### PR TITLE
taxon.ancestor[...].name can be nil

### DIFF
--- a/core/app/helpers/taxons_helper.rb
+++ b/core/app/helpers/taxons_helper.rb
@@ -5,7 +5,7 @@ module TaxonsHelper
     crumbs = [content_tag(:li, breadcrumb(t(:home) , root_path, linked) + separator)]
     if taxon
       crumbs << content_tag(:li, breadcrumb(t('products') , products_path, linked) + separator)
-      crumbs << taxon.ancestors.collect { |ancestor| content_tag(:li, breadcrumb(ancestor.name , seo_url(ancestor), linked) + separator) } unless taxon.ancestors.empty?
+      crumbs << taxon.ancestors.collect { |ancestor| content_tag(:li, breadcrumb(ancestor.name || name, seo_url(ancestor), linked) + separator) } unless taxon.ancestors.empty?
       crumbs << content_tag(:li, content_tag(:span, taxon.name))
     else
       crumbs << content_tag(:li, content_tag(:span, t('products')))

--- a/core/app/helpers/taxons_helper.rb
+++ b/core/app/helpers/taxons_helper.rb
@@ -1,11 +1,11 @@
 module TaxonsHelper
-  def breadcrumbs(taxon, separator="&nbsp;&raquo;&nbsp;")
+  def breadcrumbs(taxon, separator="&nbsp;&raquo;&nbsp;", linked = true)
     return "" if current_page?("/")
     separator = raw(separator)
-    crumbs = [content_tag(:li, link_to(t(:home) , root_path) + separator)]
+    crumbs = [content_tag(:li, breadcrumb(t(:home) , root_path, linked) + separator)]
     if taxon
-      crumbs << content_tag(:li, link_to(t('products') , products_path) + separator)
-      crumbs << taxon.ancestors.collect { |ancestor| content_tag(:li, link_to(ancestor.name , seo_url(ancestor)) + separator) } unless taxon.ancestors.empty?
+      crumbs << content_tag(:li, breadcrumb(t('products') , products_path, linked) + separator)
+      crumbs << taxon.ancestors.collect { |ancestor| content_tag(:li, breadcrumb(ancestor.name , seo_url(ancestor), linked) + separator) } unless taxon.ancestors.empty?
       crumbs << content_tag(:li, content_tag(:span, taxon.name))
     else
       crumbs << content_tag(:li, content_tag(:span, t('products')))
@@ -28,5 +28,10 @@ module TaxonsHelper
       end
     end
     products
+  end
+
+  private
+  def breadcrumb( text, link_path, linked = true )
+    linked  ? link_to(text, link_path)  : text
   end
 end


### PR DESCRIPTION
please adapt commit 8c16c4e8c8b983fd69c9 to the current spree tree. My tree includes a new feature [1] that you possibly don't want so I'm only pointing you to the fix, but you will not have to pull.

The current spree tree should have the same problem as mine, namely that taxon.ancestor.name can be nil. This happens f.ex. when you configure taxons and have multiple languages and forget to translate the taxon into the other language but access it through the interface.

Possibly a better fix would be to have taxon.name fall back on the default language?
*t

[1] http://github.com/railsdog/spree/pull/2#issuecomment-417888
