### PR TITLE
Move available countries to base helper

### DIFF
--- a/core/app/helpers/checkout_helper.rb
+++ b/core/app/helpers/checkout_helper.rb
@@ -24,9 +24,4 @@ module CheckoutHelper
     content_tag('ol', raw(items.join("\n")), :class => 'progress-steps', :id => "checkout-step-#{@order.state}")
   end
 
-  def available_countries
-    return Country.all unless zone = Zone.find_by_name(Spree::Config[:checkout_zone])
-    zone.country_list
-  end
-
 end

--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -88,4 +88,9 @@ module Spree::BaseHelper
   def logo(image_path=Spree::Config[:logo])
     link_to image_tag(image_path), root_path
   end
+  
+  def available_countries
+    return Country.all unless zone = Zone.find_by_name(Spree::Config[:checkout_zone])
+    zone.country_list
+  end
 end


### PR DESCRIPTION
This helper is called from other locations besides within checkout.  For example was causing errors on /admin/orders/xxxx/shipments/yyyyyy/edit.
