### PR TITLE
Mail interceptor

### DIFF
--- a/core/lib/spree/mail_interceptor.rb
+++ b/core/lib/spree/mail_interceptor.rb
@@ -8,7 +8,7 @@ module Spree
     def self.delivering_email(message)
       return unless mail_method = MailMethod.current
       message.from ||= mail_method.preferred_mails_from
-      if mail_method.preferred_intercept_email
+      if mail_method.preferred_intercept_email && mail_method.preferred_intercept_email!=""
         message.subject = "[#{message.to}] #{message.subject}"
         message.to = mail_method.preferred_intercept_email
       end

--- a/core/lib/spree/mail_interceptor.rb
+++ b/core/lib/spree/mail_interceptor.rb
@@ -8,7 +8,7 @@ module Spree
     def self.delivering_email(message)
       return unless mail_method = MailMethod.current
       message.from ||= mail_method.preferred_mails_from
-      if mail_method.preferred_intercept_email && mail_method.preferred_intercept_email!=""
+      if mail_method.preferred_intercept_email.present?
         message.subject = "[#{message.to}] #{message.subject}"
         message.to = mail_method.preferred_intercept_email
       end


### PR DESCRIPTION
My mails were intercepted even if I had not set intercept_email_address in administration>>editing_mail_method.
Indeed a click on update mail method creates a preference (intercept_email) with a value="".

If we do not check if intercept_email preference is not an empty string, the interceptor will try to intercept the mail... and will replace the :to recipient by an empty string "".
