### PR TITLE
Fix install.rb and lists of gems files

### DIFF
--- a/api/spree_api.gemspec
+++ b/api/spree_api.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://spreecommerce.com'
   s.rubyforge_project = 'spree_api'
 
-  s.files        = Dir['LICENSE', 'README.md', 'app/**/*', 'config/**/*', 'lib/**/*']
+  s.files        = Dir['LICENSE', 'README.md', 'app/**/*', 'config/**/*', 'lib/**/*', 'db/**/*']
   s.require_path = 'lib'
   s.requirements << 'none'
 

--- a/auth/spree_auth.gemspec
+++ b/auth/spree_auth.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://spreecommerce.com'
   s.rubyforge_project = 'spree_auth'
 
-  s.files        = Dir['LICENSE', 'README.md', 'app/**/*', 'config/**/*', 'lib/**/*']
+  s.files        = Dir['LICENSE', 'README.md', 'app/**/*', 'config/**/*', 'lib/**/*', 'db/**/*']
   s.require_path = 'lib'
   s.requirements << 'none'
 

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://spreecommerce.com'
   s.rubyforge_project = 'spree_core'
 
-  s.files        = Dir['LICENSE', 'README.md', 'app/**/*', 'config/**/*', 'lib/**/*']
+  s.files        = Dir['LICENSE', 'README.md', 'app/**/*', 'config/**/*', 'lib/**/*', 'db/**/*', 'public/**/*']
   s.require_path = 'lib'
   s.requirements << 'none'
 

--- a/dash/spree_dash.gemspec
+++ b/dash/spree_dash.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://spreecommerce.com'
   s.rubyforge_project = 'spree_dash'
 
-  s.files        = Dir['LICENSE', 'README.md', 'app/**/*', 'config/**/*', 'lib/**/*']
+  s.files        = Dir['LICENSE', 'README.md', 'app/**/*', 'config/**/*', 'lib/**/*', 'db/**/*', 'public/**/*']
   s.require_path = 'lib'
   s.requirements << 'none'
 

--- a/install.rb
+++ b/install.rb
@@ -1,6 +1,6 @@
 version = ARGV.pop
 
-%w( core api auth dash promotions sample ).each do |framework|
+%w( core api auth dash promo sample ).each do |framework|
   puts "Installing #{framework}..."
   `cd #{framework} && gem build spree_#{framework}.gemspec && gem install spree_#{framework}-#{version}.gem --no-ri --no-rdoc && rm spree_#{framework}-#{version}.gem`
 end

--- a/promo/spree_promo.gemspec
+++ b/promo/spree_promo.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://spreecommerce.com'
   s.rubyforge_project = 'spree_promotions'
 
-  s.files        = Dir['CHANGELOG', 'README', 'MIT-LICENSE', 'lib/**/*']
+  s.files        = Dir['CHANGELOG', 'README', 'MIT-LICENSE', 'app/**/*', 'config/**/*', 'lib/**/*', 'db/**/*', 'public/**/*']
   s.require_path = 'lib'
   s.requirements << 'none'
 

--- a/sample/spree_sample.gemspec
+++ b/sample/spree_sample.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://spreecommerce.com'
   s.rubyforge_project = 'spree_sample'
 
-  s.files        = Dir['LICENSE', 'README.md', 'lib/**/*']
+  s.files        = Dir['LICENSE', 'README.md', 'lib/**/*', 'db/**/*']
   s.require_path = 'lib'
   s.requirements << 'none'
 


### PR DESCRIPTION
Hello,

When I tried generating gems on my system I encountered a couple of problems. First was that install.rb uses the old "spree_promotions" gem name instead of spree_promo. `cd` and other commands fail for this gem.

Second was that created gems were missing important files. Some were missing app/**/\* files, other were missing public/**/\* or db/*.

The included commit fixes those two issues.

Thanks for your work on spree. Cheers!
Adam
