### PR TITLE
1703 orderupdate should be called after a shipment is saved

### DIFF
--- a/core/app/models/shipment.rb
+++ b/core/app/models/shipment.rb
@@ -7,6 +7,7 @@ class Shipment < ActiveRecord::Base
   has_many :inventory_units
   before_create :generate_shipment_number
   after_destroy :release_inventory_units
+  after_save :update_order
 
   attr_accessor :special_instructions
   accepts_nested_attributes_for :address
@@ -144,5 +145,9 @@ class Shipment < ActiveRecord::Base
   def after_ship
     inventory_units.each &:ship!
     ShipmentMailer.shipped_email(self).deliver
+  end
+  
+  def update_order
+    order.update!
   end
 end

--- a/core/spec/models/shipment_spec.rb
+++ b/core/spec/models/shipment_spec.rb
@@ -129,6 +129,7 @@ describe Shipment do
     before do
       shipment.state = 'ready'
       shipment.stub :require_inventory => false
+      shipment.stub :update_order => true
     end
 
     it "should send a shipment email" do
@@ -139,4 +140,20 @@ describe Shipment do
     end
 
   end
+
+  context "#save" do
+    
+    before do
+      shipment.state = 'ready'
+      shipment.stub :require_inventory => false
+    end
+    
+    it "should call order#update!" do
+      order = Order.create
+      shipment = Shipment.create(:order => order)
+      order.should_receive(:update!)
+      shipment.save
+    end
+  end
+  
 end


### PR DESCRIPTION
Fix for http://railsdog.lighthouseapp.com/projects/31096-spree/tickets/1703-orderupdate-should-be-called-after-a-shipment-is-saved
