### PR TITLE
Adding shipping error

### DIFF
--- a/core/lib/spree/shipping_error.rb
+++ b/core/lib/spree/shipping_error.rb
@@ -1,0 +1,3 @@
+module Spree
+  class ShippingError < RuntimeError; end
+end


### PR DESCRIPTION
This is needed because some Spree extensions (ie spree_active_shipping) 'rescue_from Spree::ShippingError'.
