### PR TITLE
Fix checkout to order migration

### DIFF
--- a/core/db/migrate/20101026184808_migrate_checkout_to_orders.rb
+++ b/core/db/migrate/20101026184808_migrate_checkout_to_orders.rb
@@ -1,4 +1,8 @@
 class MigrateCheckoutToOrders < ActiveRecord::Migration
+  
+  class Checkout < ActiveRecord::Base
+  end
+  
   def self.up
     Order.find_each do |order|
       checkout = update_order(order)


### PR DESCRIPTION
The checkout_to_orders migration needs to have a Checkout model to run.  

It was removed here:
http://github.com/railsdog/spree/commit/fcee52e78b7c7dc95a6b86871015f50a0119728b
So it just needs to be in the migration.
