### PR TITLE
1682 newline sandbox gemfile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -30,7 +30,7 @@ task :sandbox do
     def append_gemfile
       inside "sandbox" do
         append_file "Gemfile" do
-          "gem 'spree', :path => '../' "
+          "gem 'spree', :path => '../' \n"
         end
       end
     end


### PR DESCRIPTION
after
$ rake sandbox
$ cd sandbox
$ rails g spree:extension dummy

The last line of sandbox/Gemfile became (in one line):
gem 'spree', :path => '../' gem "dummy", :require => "dummy", :path => "dummy"

The correct content should be:
gem 'spree', :path => '../' 
gem "dummy", :require => "dummy", :path => "dummy"
