### PR TITLE
Fixed and simplified product taxons select/remove javascript

### DIFF
--- a/core/app/views/admin/shared/_product_tabs.html.erb
+++ b/core/app/views/admin/shared/_product_tabs.html.erb
@@ -8,22 +8,22 @@
   <ul class="sidebar product-menu">
     <%= hook :admin_product_tabs, {:current => current} do %>
 
-      <li<%= ' class="active"' if current == "Product Details" %>>
+      <li<%= ' class=active' if current == "Product Details" %>>
         <%= link_to t("product_details"), edit_admin_product_url(@product) %>
       </li>
-      <li<%= ' class="active"' if current == "Images" %>>
+      <li<%= ' class=active' if current == "Images" %>>
         <%= link_to t("images"), admin_product_images_url(@product) %>
       </li>
-      <li<%= ' class="active"' if current == "Variants" %>>
+      <li<%= ' class=active' if current == "Variants" %>>
         <%= link_to t("variants"),  admin_product_variants_url(@product)  %>
       </li>
-      <li<%= ' class="active"' if current == "Option Types" %>>
+      <li<%= ' class=active' if current == "Option Types" %>>
         <%= link_to t("option_types"), selected_admin_product_option_types_url(@product) %>
       </li>
-      <li<%= ' class="active"' if current == "Product Properties" %>>
+      <li<%= ' class=active' if current == "Product Properties" %>>
         <%= link_to t("product_properties"), admin_product_product_properties_url(@product) %>
       </li>
-      <li<%= ' class="active"' if current == "Taxons" %>>
+      <li<%= ' class=active' if current == "Taxons" %>>
         <%= link_to t("taxons"), selected_admin_product_taxons_url(@product) %>
       </li>
 

--- a/core/app/views/admin/taxons/_taxon_table.html.erb
+++ b/core/app/views/admin/taxons/_taxon_table.html.erb
@@ -8,16 +8,12 @@
   </thead>
   <tbody>
     <% taxons.each do |taxon| %>
-      <tr id="<%= dom_id(taxon, :sel)%>">
+      <tr id="<%= dom_id(taxon, :sel) %>">
         <td><%= taxon.name %></td>
         <td><%= taxon_path taxon %></td>
   	    <td class="actions">
-          <%= image_tag "spinner.gif", :style => "display:none", :id => "#{dom_id(taxon, :rem_spinner)}" %>
-		      <%= link_to icon('delete') + ' ' + t('remove'), 
-		                         {:url => remove_admin_product_taxon_url(@product, taxon),
-		                         :loading => "jQuery('##{dom_id(taxon, :rem_spinner)}').show()",
-		                         :update => 'selected-taxons',
-		                         :complete => "jQuery('##{dom_id(taxon, :sel)}').remove(); jQuery('##{dom_id(taxon, :rem_spinner)}').hide();"}, :remote => true, :class => 'iconlink' %>
+          <%= image_tag "spinner.gif", :style => "display:none", :class => "spinner" %>
+		      <%= link_to icon('delete') + ' ' + t('remove'), '#' + t('remove').underscore, :rel => remove_admin_product_taxon_url(@product, taxon), :class => 'iconlink' %>
   	    </td>        
       </tr>
     <% end %>

--- a/core/app/views/admin/taxons/available.html.erb
+++ b/core/app/views/admin/taxons/available.html.erb
@@ -1,0 +1,32 @@
+<script type="text/javascript">
+  function displayRow(){
+    var row = document.getElementById("captionRow");
+    if (row.style.display == '') row.style.display = 'none';
+    else row.style.display = '';
+  }
+</script>
+<h4><%= t('available_taxons') %></h4>
+<table class="index">
+	<thead>
+		<tr>
+			<th><%= t("name") %></th>
+			<th><%= t("path") %></th>
+			<th><%= t("action") %></th>
+		</tr>
+	</thead>
+	<tbody>
+    <% @available_taxons.each do |taxon| %>
+      <tr id="<%= dom_id(taxon) %>">
+        <td><%= taxon.name %></td>
+        <td><%= taxon_path taxon %></td>
+		    <td class="actions">
+          <%= image_tag "spinner.gif", :style => "display:none", :class => 'spinner' %>		    
+	        <%= link_to icon('add') + ' ' + t('select'), '#' + t('select').underscore, :rel => select_admin_product_taxon_path(@product, taxon), :class => 'iconlink' %>
+		    </td>        
+      </tr>
+    <% end %>
+    <% if @available_taxons.empty? %>
+     <tr><td colspan="3"><%= t('no_match_found') %>.</td></tr>
+    <% end %>
+  </tbody>
+</table>

--- a/core/app/views/admin/taxons/selected.html.erb
+++ b/core/app/views/admin/taxons/selected.html.erb
@@ -12,6 +12,16 @@
 <% end %>
 
 <%= javascript_tag do %>
+
+  $('table tr td a.iconlink').live('click', function(evt) {
+	  evt.preventDefault();	 
+	  var tr = $(this).hide().siblings('img.spinner').show().parents('tr');
+	  $.post(this.rel, function(res) {
+  	  tr.remove();
+	    $('#selected-taxons').html(res);
+	  });
+	});
+
   function search_for_taxons(){
     jQuery.ajax({
      data: {q: jQuery("#searchtext").val() }, 


### PR DESCRIPTION
This change simply adds a jQuery click handler to the select and remove links in the product taxon table. This functionality was broken in the 0.30.0 beta release.
