### PR TITLE
Removing shipping error references

### DIFF
--- a/core/app/models/order.rb
+++ b/core/app/models/order.rb
@@ -315,18 +315,13 @@ class Order < ActiveRecord::Base
   end
 
   def rate_hash
-    begin
-      @rate_hash ||= available_shipping_methods(:front_end).collect do |ship_method|
-        { :id => ship_method.id,
-          :shipping_method => ship_method,
-          :name => ship_method.name,
-          :cost => ship_method.calculator.compute(self)
-        }
-      end.sort_by{|r| r[:cost]}
-    rescue Spree::ShippingError => ship_error
-      flash[:error] = ship_error.to_s
-      []
-    end
+    @rate_hash ||= available_shipping_methods(:front_end).collect do |ship_method|
+      { :id => ship_method.id,
+        :shipping_method => ship_method,
+        :name => ship_method.name,
+        :cost => ship_method.calculator.compute(self)
+      }
+    end.sort_by{|r| r[:cost]}
   end
 
   def payment


### PR DESCRIPTION
Since Spree::ShippingError has been removed, it only makes sense that any rescues from Spree::ShippingError should be removed.
