### PR TITLE
Fixed incorrectly-escaped active tab html for products_tabs

### DIFF
--- a/core/app/views/admin/shared/_product_tabs.html.erb
+++ b/core/app/views/admin/shared/_product_tabs.html.erb
@@ -8,22 +8,22 @@
   <ul class="sidebar product-menu">
     <%= hook :admin_product_tabs, {:current => current} do %>
 
-      <li<%= ' class="active"' if current == "Product Details" %>>
+      <li<%= raw(' class="active"') if current == "Product Details" %>>
         <%= link_to t("product_details"), edit_admin_product_url(@product) %>
       </li>
-      <li<%= ' class="active"' if current == "Images" %>>
+      <li<%= raw(' class="active"') if current == "Images" %>>
         <%= link_to t("images"), admin_product_images_url(@product) %>
       </li>
-      <li<%= ' class="active"' if current == "Variants" %>>
+      <li<%= raw(' class="active"') if current == "Variants" %>>
         <%= link_to t("variants"),  admin_product_variants_url(@product)  %>
       </li>
-      <li<%= ' class="active"' if current == "Option Types" %>>
+      <li<%= raw(' class="active"') if current == "Option Types" %>>
         <%= link_to t("option_types"), selected_admin_product_option_types_url(@product) %>
       </li>
-      <li<%= ' class="active"' if current == "Product Properties" %>>
+      <li<%= raw(' class="active"') if current == "Product Properties" %>>
         <%= link_to t("product_properties"), admin_product_product_properties_url(@product) %>
       </li>
-      <li<%= ' class="active"' if current == "Taxons" %>>
+      <li<%= raw(' class="active"') if current == "Taxons" %>>
         <%= link_to t("taxons"), selected_admin_product_taxons_url(@product) %>
       </li>
 


### PR DESCRIPTION
Rails 3 escapes html by default, quick fix using raw()
