### PR TITLE
1744 show and edit actions result in error if user is not logged in

### DIFF
--- a/auth/app/controllers/users_controller.rb
+++ b/auth/app/controllers/users_controller.rb
@@ -1,5 +1,7 @@
 class UsersController < Spree::BaseController
   resource_controller
+  
+  before_filter :authorize_user, :only => [:edit, :show]
 
   ssl_required :new, :create, :edit, :update, :show
 
@@ -48,6 +50,10 @@ class UsersController < Spree::BaseController
     session_params = params[:user]
     session_params[:login] = session_params[:email]
     UserSession.create session_params
+  end
+  
+  def authorize_user
+    authorize!(:show, @user)
   end
 
 end

--- a/auth/spec/controllers/users_controller_spec.rb
+++ b/auth/spec/controllers/users_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe UsersController do
+  
+  let(:user) { mock_model(User, :email => "spree@example.com") }
 
   context "#create" do
 
@@ -26,7 +28,6 @@ describe UsersController do
   end
 
   context "#update" do
-    let(:user) { mock_model(User, :email => "spree@example.com") }
 
     before do
       controller.stub :current_user => user
@@ -38,5 +39,61 @@ describe UsersController do
       UserSession.should_receive :create
       put :update, {:user => {:password => "newpw", :password_confirmation => "newpw", :email => user.email}}
     end
+  end
+  
+  context "#show" do
+    context "user logged in" do
+
+      before do
+        controller.stub :current_user => user
+        user.stub(:has_role?).with('admin').and_return(false)
+      end
+      
+      it "should not redirect to login_path when logged in" do
+         get :show, {:id => "blah"}
+         response.should_not redirect_to login_path
+       end
+    end
+    
+    context "user not logged in" do
+     
+       before do
+         controller.stub :current_user => nil  
+       end
+     
+       it "should redirect to login_path when not logged in" do
+         get :show, {:id => "blah"}
+         response.should redirect_to login_path
+       end
+     
+     end
+  end
+  
+  context "#edit" do
+    context "user logged in" do
+
+      before do
+        controller.stub :current_user => user
+        user.stub(:has_role?).with('admin').and_return(false)
+      end
+      
+      it "should not redirect to login_path when logged in" do
+         get :edit, {:id => "blah"}
+         response.should_not redirect_to login_path
+       end
+    end
+    
+    context "user not logged in" do
+     
+       before do
+         controller.stub :current_user => nil  
+       end
+     
+       it "should redirect to login_path when not logged in" do
+         get :edit, {:id => "blah"}
+         response.should redirect_to login_path
+       end
+     
+     end
   end
 end


### PR DESCRIPTION
fix for http://railsdog.lighthouseapp.com/projects/31096-spree/tickets/1744-show-and-edit-actions-result-in-error-if-user-is-not-logged-in
