### PR TITLE
Removing bad links in admin

### DIFF
--- a/core/app/views/admin/orders/show.html.erb
+++ b/core/app/views/admin/orders/show.html.erb
@@ -10,18 +10,13 @@
 <%= hook :admin_order_show_addresses do %>
   <% if @order.bill_address %>
     <div class='adr'>
-      <h4>
-        <%= link_to t("bill_address"), (@current_action=="edit" ? edit_admin_checkout_url(@order.number) : admin_orders_checkout_url(@order.number)) %>
-      </h4>
+      <h4><%= t("bill_address") %></h4>
       <%= render :partial => 'admin/shared/address', :locals => {:address => @order.bill_address} %>
     </div>
   <% end %>
   <% if @order.ship_address %>
     <div class='adr'>
-      <h4>
-        <%= link_to t("ship_address"), (@current_action=="edit" ? edit_admin_checkout_url(@order.number) : admin_orders_checkout_url(@order.number)) %>
-        <%= t("ship_address") if @order.shipments.empty? %>
-      </h4>
+      <h4><%= t("ship_address") %></h4>
       <%= render :partial => 'admin/shared/address', :locals => {:address => @order.ship_address} %>
     </div>
     <% end %>


### PR DESCRIPTION
@schof, we briefly discussed this. You mentioned that these links should point to the screen to where you can edit the shipping/billing addresses, but the more I thought about it that did not make as much sense to me as just making this text not be a hyperlink at all. If the user wishes to edit the addresses, they can just click the "Customer Details" tab on the right hand side.
