### PR TITLE
1772 deleted products show up in admin index by default

### DIFF
--- a/core/app/views/admin/products/index.html.erb
+++ b/core/app/views/admin/products/index.html.erb
@@ -65,7 +65,7 @@
         </p>
         <p>
           <label><%= t("show_deleted") %></label><br />
-          <%= f.check_box :deleted_at_not_null, {}, "1", "" %>
+          <%= f.check_box :deleted_at_not_null, {:checked => (params[:search] and !params[:search][:deleted_at_not_null].blank?)}, "1", "" %>
         </p>
       <% end %>
 


### PR DESCRIPTION
fix for http://railsdog.lighthouseapp.com/projects/31096-spree/tickets/1772-deleted-products-show-up-in-admin-index-by-default
