### PR TITLE
1258 redeeming an invalid coupons does not show error message

### DIFF
--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -53,6 +53,13 @@ class CheckoutsController < Spree::BaseController
       flash.now[:error] = t("unable_to_authorize_credit_card") + ": #{ge.message}"
     end
 
+    if params[:checkout] and params[:checkout][:coupon_code]     # 1258 - Set error flash if coupon code was provided but invalid
+        given_coupon = Coupon.find_by_code( params[:checkout][:coupon_code].upcase )
+        unless given_coupon and @checkout.order.coupon_credits.collect(&:adjustment_source).include? given_coupon
+            flash.now[:error] = t("invalid_coupon_code")
+        end
+    end 
+
     render 'edit'
   end
 

--- a/config/locales/en_spree.yml
+++ b/config/locales/en_spree.yml
@@ -427,6 +427,7 @@ en:
   included_in_this_shipment: Included in this Shipment
   instructions_to_reset_password: "Fill out the form below and instructions to reset your password will be emailed to you:"
   integration_settings_warning: "If you are changing the billing integration, you must save first before you can edit the integration settings"
+  invalid_coupon_code: Invalid coupon code.
   invalid_search: "Invalid search criteria."
   inventory: Inventory
   inventory_adjustment: "Inventory Adjustment"


### PR DESCRIPTION
if coupon code param exists in update, checks given coupon code is now associated with the order. If not, error
