### PR TITLE
Empty cart flash message missing, nomethoderror on completed order

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -32,11 +32,10 @@ class OrdersController < Spree::BaseController
 
   #override r_c default b/c we don't want to actually destroy, we just want to clear line items
   def destroy
-    self.notice = I18n.t(:basket_successfully_cleared)
     @order.line_items.clear
     @order.update_totals!
     after :destroy
-    set_flash :destroy
+    self.notice = I18n.t(:basket_successfully_cleared)
     response_for :destroy
   end
 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,6 +1,6 @@
 class OrdersController < Spree::BaseController
   prepend_before_filter :reject_unknown_object,  :only => [:show, :edit, :update, :checkout]
-  before_filter :prevent_editing_complete_order, :only => [:edit, :update, :checkout]
+  before_filter :prevent_editing_complete_order, :only => [:edit, :update, :checkout, :destroy]
   before_filter :set_user
 
   ssl_required :show

--- a/config/locales/en_spree.yml
+++ b/config/locales/en_spree.yml
@@ -254,6 +254,7 @@ en:
   back_to_store: "Go Back To Store"
   backordered: Backordered
   backordering_is_allowed: "Backordering %{not} allowed"
+  basket_successfully_cleared: Your cart has been emptied.
   balance_due: "Balance Due"
   best_selling_products: "Best Selling Products"
   best_selling_taxons: "Best Selling Taxons"


### PR DESCRIPTION
sorry about that last pull request (101) I fkd up and put based it against master

fixes #1536
http://railsdog.lighthouseapp.com/projects/31096/tickets/1536-empty-cart-button-causes-a-nomethoderror
