### PR TITLE
fixes #1782 - add border arg to column mixins

### DIFF
--- a/vendor/extensions/theme_default/app/stylesheets/_mixins.less
+++ b/vendor/extensions/theme_default/app/stylesheets/_mixins.less
@@ -52,13 +52,14 @@
 @col_margin: 10px;
 @col_width: 30px;
 
-.column-last (@span: 1) {
+.column-last (@span: 1, @border: 0) {
   display: inline;
   float: left;
-  width: @col_width * @span + (@col_margin * (@span - 1));
+  margin-right: 0;
+  width: @col_width * @span + (@col_margin * (@span - 1)) - @border * 2;
 }
-.column (@span: 1) {
-  .column-last(@span);
+.column (@span: 1, @border: 0) {
+  .column-last(@span, @border);
   margin-right: @col_margin;
 }
 


### PR DESCRIPTION
Say I have

```
.product-listing {
  li {
    .column(6);
    .rounded_corners(3px);
  }
  li.last {
    .column-last(6);
  }
}
```

that works fine, sets 4 cols of products on my page.

now, let's say I want to add a border to each product.

```
.product-listing {
  li {
    .column(6);
    .rounded_corners(3px);
    border: 1px solid #ddd;
  }
  li.last {
    .column-last(6);
  }
}
```

suddenly, the extra 1px border bumps the width of each col up by 2 pixels, making it wrap the last entry in the row to the next row. Oops.

Proposed fix: make the .column and .column-last mixin accept a second argument with the border-width of the element you are setting the col width on.
