### PR TITLE
simpler stylesheet_tag definition (master)

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -68,13 +68,7 @@ module Spree::BaseHelper
   end
 
   def stylesheet_tags(paths=stylesheet_paths)
-    output = ''
-    if !paths.blank?
-      paths.each do |path|
-        output << stylesheet_link_tag(path)
-      end
-    end
-    return output
+    paths.blank? ? '' : stylesheet_link_tag(paths, :cache => true)
   end
 
   def stylesheet_paths


### PR DESCRIPTION
stylesheet_link_tag already accepts an array of stylesheet names, and when :cache=>true option is passed, will automatically merge them in production
