### PR TITLE
disable product filtering by default

### DIFF
--- a/core/app/models/taxon.rb
+++ b/core/app/models/taxon.rb
@@ -16,14 +16,16 @@ class Taxon < ActiveRecord::Base
 
   # indicate which filters should be used for a taxon
   # this method should be customized to your own site
+  # if you want filtering in your site, override this method
+  # and take a look at core/lib/product_filters.rb module
   include ::ProductFilters  # for detailed defs of filters
   def applicable_filters
     fs  = []
     # fs << ProductFilters.taxons_below(self)
     ## unless it's a root taxon? left open for demo purposes
     fs += [
-      ProductFilters.price_filter,
-      ProductFilters.brand_filter,
+      #ProductFilters.price_filter,
+      #ProductFilters.brand_filter,
       #ProductFilters.selective_brand_filter(self) 
       ]
   end


### PR DESCRIPTION
I don't know where to edit docs for this one, so there's just commit at the moment.

also see
http://railsdog.lighthouseapp.com/projects/31096-spree/tickets/1797-do-not-make-product-filters-obligatory-in-clean-site
and
http://groups.google.com/group/spree-user/browse_thread/thread/48a4f9401b069deb/2c4d09a96af1b297
