### PR TITLE
Smarter Spree::Config cache

### DIFF
--- a/core/lib/spree/preference_access.rb
+++ b/core/lib/spree/preference_access.rb
@@ -6,7 +6,7 @@ module Spree::PreferenceAccess
         key = key.to_s if key.is_a?(Symbol)
         return nil unless config = self.instance
         # preferences will be cached under the name of the class including this module (ex. Spree::Config)
-        prefs = Rails.cache.fetch(self.to_s) { config.preferences }
+        prefs = Rails.cache.fetch("configuration_#{config.id}".to_sym) { config.preferences }
         return prefs if key.nil?
         prefs[key]
       end
@@ -18,7 +18,7 @@ module Spree::PreferenceAccess
           config.set_preference(key, value)
         end
         config.save
-        Rails.cache.delete(self.to_s) { config.preferences }
+        Rails.cache.delete("configuration_#{config.id}".to_sym)
       end
 
       alias_method :[], :get


### PR DESCRIPTION
Currently Spree::PreferenceAccess always uses rails cache with the key :"Spree::Config". If a developer decides to overwrite Spree::Config::instance method to return the AppConfig instance based on some varying criteria he will face unpredicted results when using Spree::Config[] accessor.

This commit changes the cache key to :"configuration_#{config.id}". This doesn't change anything for projects that don't monkey patch Spree::Config::instance, but fixes configuration access for those that do.

An example usage scenario is a multi site extension with different configurations per site.
