### PR TITLE
rake tasks should take into account Gemfile

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -3,3 +3,14 @@ Spree API
 Manage orders,shipments etc. with a simple REST API
 
 See [RESTful API guide](http://spreecommerce.com/documentation/rest.html) for more details.
+
+Testing
+=======
+
+Create the test site
+
+    rake test_app
+
+Run the tests
+
+    rake spec

--- a/api/Rakefile
+++ b/api/Rakefile
@@ -1,5 +1,21 @@
 require 'rake'
 require 'rake/testtask'
+
+gemfile = File.expand_path('../spec/test_app/Gemfile', __FILE__)
+if File.exists?(gemfile)
+  require 'bundler'
+  ENV['BUNDLE_GEMFILE'] = gemfile
+  Bundler.setup
+
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new
+
+  require 'cucumber/rake/task'
+  Cucumber::Rake::Task.new do |t|
+    t.cucumber_opts = %w{--format pretty}
+  end
+end
+
 require 'rake/packagetask'
 require 'rake/gempackagetask'
 
@@ -14,14 +30,6 @@ task :release => :package do
   require 'rake/gemcutter'
   Rake::Gemcutter::Tasks.new(spec).define
   Rake::Task['gem:push'].invoke
-end
-
-require 'rspec/core/rake_task'
-RSpec::Core::RakeTask.new
-
-require 'cucumber/rake/task'
-Cucumber::Rake::Task.new do |t|
-  t.cucumber_opts = %w{--format pretty}
 end
 
 desc "Regenerates a rails 3 app for testing"

--- a/auth/Rakefile
+++ b/auth/Rakefile
@@ -1,6 +1,23 @@
 require 'rubygems'
 require 'rake'
 require 'rake/testtask'
+
+gemfile = File.expand_path('../spec/test_app/Gemfile', __FILE__)
+if File.exists?(gemfile)
+  require 'bundler'
+  ENV['BUNDLE_GEMFILE'] = gemfile
+  Bundler.setup
+
+  require 'rspec'
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new
+
+  require 'cucumber/rake/task'
+  Cucumber::Rake::Task.new do |t|
+    t.cucumber_opts = %w{--format pretty}
+  end
+end
+
 require 'rake/packagetask'
 require 'rake/gempackagetask'
 
@@ -19,15 +36,6 @@ end
 
 desc "Default Task"
 task :default => [ :spec ]
-
-require 'rspec'
-require 'rspec/core/rake_task'
-RSpec::Core::RakeTask.new
-
-require 'cucumber/rake/task'
-Cucumber::Rake::Task.new do |t|
-  t.cucumber_opts = %w{--format pretty}
-end
 
 desc "Regenerates a rails 3 app for testing"
 task :test_app do

--- a/core/Rakefile
+++ b/core/Rakefile
@@ -1,5 +1,21 @@
 require 'rubygems'
 require 'rake'
+
+gemfile = File.expand_path('../spec/test_app/Gemfile', __FILE__)
+if File.exists?(gemfile)
+  require 'bundler'
+  ENV['BUNDLE_GEMFILE'] = gemfile
+  Bundler.setup
+
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new
+
+  require 'cucumber/rake/task'
+  Cucumber::Rake::Task.new do |t|
+    t.cucumber_opts = %w{--format pretty}
+  end
+end
+
 require 'rake/testtask'
 require 'rake/packagetask'
 require 'rake/gempackagetask'
@@ -20,13 +36,6 @@ end
 desc "Default Task"
 task :default => [ :spec ]
 
-require 'rspec/core/rake_task'
-RSpec::Core::RakeTask.new
-
-require 'cucumber/rake/task'
-Cucumber::Rake::Task.new do |t|
-  t.cucumber_opts = %w{--format pretty}
-end
 
 desc "Regenerates a rails 3 app for testing"
 task :test_app do

--- a/dash/README.md
+++ b/dash/README.md
@@ -1,3 +1,14 @@
 = Overview Dashboard
 
 Core extension to display basic graphs and charts on store activity. Can be deleted if you don't require the dashboard.
+
+Running Tests
+-------------
+
+You need to do a quick one-time creation of a test application and then you can use it to run the tests.
+
+    rake test_app
+
+Then run the tests
+
+    rake spec

--- a/dash/Rakefile
+++ b/dash/Rakefile
@@ -1,5 +1,21 @@
 require 'rake'
 require 'rake/testtask'
+
+gemfile = File.expand_path('../spec/test_app/Gemfile', __FILE__)
+if File.exists?(gemfile)
+  require 'bundler'
+  ENV['BUNDLE_GEMFILE'] = gemfile
+  Bundler.setup
+
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new
+
+  require 'cucumber/rake/task'
+  Cucumber::Rake::Task.new do |t|
+    t.cucumber_opts = %w{--format pretty}
+  end
+end
+
 require 'rake/packagetask'
 require 'rake/gempackagetask'
 
@@ -14,14 +30,6 @@ task :release => :package do
   require 'rake/gemcutter'
   Rake::Gemcutter::Tasks.new(spec).define
   Rake::Task['gem:push'].invoke
-end
-
-require 'rspec/core/rake_task'
-RSpec::Core::RakeTask.new
-
-require 'cucumber/rake/task'
-Cucumber::Rake::Task.new do |t|
-  t.cucumber_opts = %w{--format pretty}
 end
 
 desc "Regenerates a rails 3 app for testing"

--- a/promo/README.markdown
+++ b/promo/README.markdown
@@ -1,3 +1,14 @@
 = Promotions
 
 Description goes here
+
+Running Tests
+-------------
+
+You need to do a quick one-time creation of a test application and then you can use it to run the tests.
+
+    rake test_app
+
+Then run the tests
+
+    rake spec

--- a/promo/Rakefile
+++ b/promo/Rakefile
@@ -3,6 +3,17 @@ require 'rake/testtask'
 require 'rake/packagetask'
 require 'rake/gempackagetask'
 
+gemfile = File.expand_path('../spec/test_app/Gemfile', __FILE__)
+if File.exists?(gemfile)
+  require 'bundler'
+  ENV['BUNDLE_GEMFILE'] = gemfile
+  Bundler.setup
+
+  require 'rspec'
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new
+end
+
 spec = eval(File.read('spree_promo.gemspec'))
 
 Rake::GemPackageTask.new(spec) do |p|
@@ -18,10 +29,6 @@ end
 
 desc "Default Task"
 task :default => [ :spec ]
-
-require 'rspec'
-require 'rspec/core/rake_task'
-RSpec::Core::RakeTask.new
 
 desc "Regenerates a rails 3 app for testing"
 task :test_app do


### PR DESCRIPTION
rake tasks should only the gems mentioned in the Gemfile. It ensures that user is able to run tests even if user has other versions of gems installed.
