### PR TITLE
1820 restore braintree support

### DIFF
--- a/core/app/models/gateway/braintree.rb
+++ b/core/app/models/gateway/braintree.rb
@@ -1,0 +1,88 @@
+class Gateway::Braintree < Gateway
+	preference :merchant_id, :string
+	preference :public_key, :string
+	preference :private_key, :string
+
+  def provider_class
+    ActiveMerchant::Billing::BraintreeGateway
+  end
+
+  def authorize(money, creditcard, options = {})
+    adjust_options_for_braintree(creditcard, options)
+    payment_method = creditcard.gateway_customer_profile_id || creditcard
+    provider.authorize(money, payment_method, options)
+  end
+
+  def capture(authorization, ignored_creditcard, ignored_options)
+    amount = (authorization.amount * 100).to_i
+    provider.capture(amount, authorization.response_code)
+  end
+
+  def create_profile(payment)
+    if payment.source.gateway_customer_profile_id.nil?
+      response = provider.store(payment.source)
+      if response.success?
+        payment.source.update_attributes!(:gateway_customer_profile_id => response.params["customer_vault_id"])
+      else
+        payment.source.gateway_error response.message
+      end
+    end
+  end
+
+  def credit(*args)
+    if args.size == 4
+      credit_with_payment_profiles(*args)
+    elsif args.size == 3
+      credit_without_payment_profiles(*args)
+    else
+      raise ArgumentError, "Expected 3 or 4 arguments, received #{args.size}"
+    end
+  end
+
+  def credit_with_payment_profiles(amount, payment, response_code, option)
+    provider.credit(amount, payment)
+  end
+
+  def credit_without_payment_profiles(amount, response_code, options)
+    transaction = ::Braintree::Transaction.find(response_code)
+    if BigDecimal.new(amount.to_s) == (transaction.amount * 100)
+      provider.refund(response_code)
+    else
+      raise NotImplementedError
+    end
+  end
+
+  def payment_profiles_supported?
+    true
+  end
+
+  def purchase(money, creditcard, options = {})
+    authorize(money, creditcard, options.merge(:submit_for_settlement => true))
+  end
+
+  def void(response_code, ignored_creditcard, ignored_options)
+    provider.void(response_code)
+  end
+
+  protected
+
+  def adjust_country_name(options)
+    [:billing_address, :shipping_address].each do |address|
+      if options[address] && options[address][:country] == "US"
+        options[address][:country] = "United States of America"
+      end
+    end
+  end
+
+  def adjust_billing_address(creditcard, options)
+    if creditcard.gateway_customer_profile_id
+      options.delete(:billing_address)
+    end
+  end
+
+  def adjust_options_for_braintree(creditcard, options)
+    adjust_country_name(options)
+    adjust_billing_address(creditcard, options)
+  end
+end
+

--- a/core/lib/spree_core/railtie.rb
+++ b/core/lib/spree_core/railtie.rb
@@ -21,6 +21,7 @@ module SpreeCore
           Gateway::PayPal,
           Gateway::SagePay,
           Gateway::Beanstream,
+          Gateway::Braintree,
           PaymentMethod::Check
         ].each{|gw|
           begin

--- a/core/spec/factories/creditcard_factory.rb
+++ b/core/spec/factories/creditcard_factory.rb
@@ -1,0 +1,11 @@
+# allows creditcard info to be saved to the datbase which is needed for factories to work properly
+class TestCard < Creditcard
+  def remove_readonly_attributes(attributes) attributes; end
+end
+
+Factory.define(:creditcard, :class => TestCard) do |f|
+  f.verification_value 123
+  f.month 12
+  f.year 2013
+  f.number "4111111111111111"
+end

--- a/core/spec/factories/line_item_factory.rb
+++ b/core/spec/factories/line_item_factory.rb
@@ -1,0 +1,8 @@
+Factory.define(:line_item) do |record|
+  record.quantity { 2 + rand(10) }
+  record.price { BigDecimal.new("#{rand(200)}.#{rand(99)}") }
+
+  # associations:
+  record.association(:order, :factory => :order)
+  record.association(:variant, :factory => :variant)
+end

--- a/core/spec/factories/options_factory.rb
+++ b/core/spec/factories/options_factory.rb
@@ -1,0 +1,10 @@
+Factory.define :option_value do |f|
+  f.name "Size"
+  f.presentation "S"
+  f.association :option_type
+end
+
+Factory.define :option_type do |f|
+  f.name "foo-size"
+  f.presentation "Size"
+end

--- a/core/spec/factories/order_factory.rb
+++ b/core/spec/factories/order_factory.rb
@@ -1,0 +1,9 @@
+Factory.define(:order) do |record|
+  # associations:
+  record.association(:user, :factory => :user)
+  record.association(:bill_address, :factory => :address)
+end
+
+Factory.define :order_with_totals, :parent => :order do |f|
+  f.line_items { [Factory(:line_item)] }
+end

--- a/core/spec/factories/payment_factory.rb
+++ b/core/spec/factories/payment_factory.rb
@@ -1,0 +1,24 @@
+Factory.define :payment do |f|
+  f.amount 45.75
+  f.payment_method { Gateway.current }
+  f.source { Factory.build(:creditcard) }
+  f.order { Factory(:order) }
+
+  # limit the payment amount to order's remaining balance, to avoid over-pay exceptions
+  f.after_create do |pmt| 
+      pmt.update_attribute(:amount, [pmt.amount, pmt.order.outstanding_balance].min) 
+  end
+end
+
+# Factory.define :creditcard_txn do |f|
+#   f.association :payment
+#   f.amount 45.75
+#   f.response_code 12345
+#   f.txn_type CreditcardTxn::TxnType::AUTHORIZE
+# 
+#   # match the payment amount to the payment's value
+#   f.after_create do |txn| 
+#     # txn.update_attribute(:amount, [txn.amount, txn.payment.payment].min)
+#     txn.update_attribute(:amount, txn.payment.amount)
+#   end
+# end

--- a/core/spec/factories/product_factory.rb
+++ b/core/spec/factories/product_factory.rb
@@ -1,0 +1,14 @@
+Factory.sequence(:product_sequence) {|n| "Product ##{n} - #{rand(9999)}"}
+
+Factory.define :product do |f|
+  f.name { Factory.next(:product_sequence) }
+  f.description { Faker::Lorem.paragraphs(rand(5)+1).join("\n") }
+
+  # associations:
+  f.tax_category {|r| TaxCategory.find(:first) || r.association(:tax_category)}
+  f.shipping_category {|r| ShippingCategory.find(:first) || r.association(:shipping_category)}
+
+  f.price 19.99
+  f.cost_price 17.00
+  f.sku "ABC"
+end

--- a/core/spec/factories/role_factory.rb
+++ b/core/spec/factories/role_factory.rb
@@ -1,0 +1,9 @@
+Factory.sequence(:role_sequence) {|n| "Role ##{n}"}
+
+Factory.define(:role) do |record|
+  record.name { Factory.next(:role_sequence) }
+end
+
+Factory.define(:admin_role, :parent => :role) do |r|
+  r.name "admin"
+end

--- a/core/spec/factories/shipping_category_factory.rb
+++ b/core/spec/factories/shipping_category_factory.rb
@@ -1,0 +1,5 @@
+Factory.sequence(:shipping_category_sequence) {|n| "ShippingCategory ##{n}"}
+
+Factory.define(:shipping_category) do |record|
+  record.name { Factory.next(:shipping_category_sequence) } 
+end

--- a/core/spec/factories/tax_category_factory.rb
+++ b/core/spec/factories/tax_category_factory.rb
@@ -1,0 +1,8 @@
+Factory.sequence(:tax_category_sequence) {|n| "TaxCategory ##{n}"}
+
+Factory.define(:tax_category) do |record|
+  record.name { "TaxCategory - #{rand(999999)}" }
+  record.description { Faker::Lorem.sentence }
+
+  record.tax_rates {[TaxRate.new(:amount => 0.05, :calculator => Calculator::Vat.new, :zone => Zone.global)]}
+end

--- a/core/spec/factories/user_factory.rb
+++ b/core/spec/factories/user_factory.rb
@@ -1,0 +1,19 @@
+Factory.define(:user) do |record|
+  record.email { Faker::Internet.email }
+  record.login { Factory.next(:login) }
+  # record.password "spree"
+  # record.password_confirmation "spree"
+
+  #record.bill_address { Factory(:address) }
+  #record.ship_address { Factory(:address) }
+end
+
+Factory.sequence :login do |n|
+  Faker::Internet.user_name + n.to_s
+end
+
+###### ADD YOUR CODE BELOW THIS LINE #####
+
+Factory.define(:admin_user, :parent => :user) do |u|
+  u.roles { [Role.find_by_name("admin") || Factory(:admin_role)]}
+end

--- a/core/spec/factories/variant_factory.rb
+++ b/core/spec/factories/variant_factory.rb
@@ -1,0 +1,14 @@
+Factory.define(:variant) do |f|
+  f.price 19.99
+  f.cost_price 17.00
+  f.sku    { Faker::Lorem.sentence }
+  f.weight { BigDecimal.new("#{rand(200)}.#{rand(99)}") }
+  f.height { BigDecimal.new("#{rand(200)}.#{rand(99)}") }
+  f.width  { BigDecimal.new("#{rand(200)}.#{rand(99)}") }
+  f.depth  { BigDecimal.new("#{rand(200)}.#{rand(99)}") }
+
+  # associations:
+  f.association(:product, :factory => :product)
+  f.option_values { [Factory(:option_value)] }
+end
+

--- a/core/spec/factories/zone_factory.rb
+++ b/core/spec/factories/zone_factory.rb
@@ -1,0 +1,18 @@
+Factory.sequence(:zone_sequence) {|n| "Zone ##{n}"}
+
+Factory.define(:global_zone, :class => Zone) do |record|
+  record.name "GlobalZone"
+  record.description { Faker::Lorem.sentence }
+  record.zone_members {|proxy|
+    zone = proxy.instance_eval{@instance}
+    Country.find(:all).map{|c| ZoneMember.create({:zoneable => c, :zone => zone})}
+  }
+end 
+
+Factory.define(:zone) do |f|
+  f.name { Faker::Lorem.words }
+  f.description { Faker::Lorem.sentence }     
+  f.zone_members do |member|
+    [ZoneMember.create(:zoneable => Factory(:country))]   
+  end
+end

--- a/core/spec/models/gateway/braintree_spec.rb
+++ b/core/spec/models/gateway/braintree_spec.rb
@@ -1,0 +1,191 @@
+ $:.unshift File.dirname(__FILE__) + '/../../'
+ require 'spec_helper'
+
+describe Gateway::Braintree do
+  
+  before(:each) do
+    Gateway.update_all(:active => false)
+    @gateway = Gateway::Braintree.create!(:name => "Braintree Gateway", :environment => "test", :active => true)
+    
+    @gateway.set_preference(:merchant_id, "zbn5yzq9t7wmwx42" )
+    @gateway.set_preference(:public_key, "ym9djwqpkxbv3xzt")
+    @gateway.set_preference(:private_key, "4ghghkyp2yy6yqc8")
+    @gateway.save!
+    
+    with_payment_profiles_off do
+      @country = Factory(:country, :name => "United States", :iso_name => "UNITED STATES", :iso3 => "USA", :iso => "US", :numcode => 840)
+      @address = Factory(:address,
+        :firstname => 'John',
+        :lastname => 'Doe',
+        :address1 => '1234 My Street',
+        :address2 => 'Apt 1',
+        :city =>  'Washington DC',
+        :zipcode => '20123',
+        :phone => '(555)555-5555',
+        :state_name => 'MD',
+        :country => @country
+      )
+      @order = Factory(:order_with_totals, :bill_address => @address, :ship_address => @address)
+      @order.update!
+      @creditcard = Factory(:creditcard, :verification_value => '123', :number => '5105105105105100', :month => 9, :year => Time.now.year + 1, :first_name => 'John', :last_name => 'Doe')
+      @payment = Factory(:payment, :source => @creditcard, :order => @order, :amount => @order.total)
+    end
+    
+  end
+  
+  it "should be braintree gateway" do
+    @gateway.provider_class.should == ::ActiveMerchant::Billing::BraintreeGateway
+  end
+  
+  describe "authorize" do
+    it "should return a success response with an authorization code" do
+      result = @gateway.authorize(500, @creditcard,      {:server=>"test", 
+                                                        :test =>true, 
+                                                        :merchant_id=>"zbn5yzq9t7wmwx42", 
+                                                        :public_key=> "ym9djwqpkxbv3xzt", 
+                                                        :private_key=> "4ghghkyp2yy6yqc8"})
+
+      result.success?.should be_true
+      result.authorization.should match(/\A\w{6}\z/)
+      Braintree::Transaction::Status::Authorized.should == Braintree::Transaction.find(result.authorization).status
+   end
+   
+   it 'should work through the spree payment interface' do
+      Spree::Config.set :auto_capture => false
+      @payment.log_entries.size.should == 0
+      @payment.process!
+      @payment.log_entries.size.should == 1
+      @payment.response_code.should match /\A\w{6}\z/
+      @payment.state.should == 'pending'
+      transaction = ::Braintree::Transaction.find(@payment.response_code)
+      transaction.status.should == Braintree::Transaction::Status::Authorized
+      transaction.credit_card_details.masked_number.should == "510510******5100"
+      transaction.credit_card_details.expiration_date.should == "09/#{Time.now.year + 1}"
+      transaction.customer_details.first_name.should == 'John'
+      transaction.customer_details.last_name.should == 'Doe'
+   end
+    
+  end
+  
+  describe "capture" do
+    
+    it " should capture a previous authorization" do
+      @payment.process!
+      assert_equal 1, @payment.log_entries.size
+      assert_match /\A\w{6}\z/, @payment.response_code
+      transaction = ::Braintree::Transaction.find(@payment.response_code)
+      transaction.status.should == Braintree::Transaction::Status::Authorized
+      capture_result = @gateway.capture(@payment,:ignored_arg_creditcard, :ignored_arg_options)
+      capture_result.success?.should be_true
+      transaction = ::Braintree::Transaction.find(@payment.response_code)
+      transaction.status.should == Braintree::Transaction::Status::SubmittedForSettlement
+    end
+    
+    it "raise an error if capture fails using spree interface" do
+      Spree::Config.set :auto_capture => false
+      @payment.log_entries.size.should == 0
+      @payment.process!
+      @payment.log_entries.size.should == 1
+      transaction = ::Braintree::Transaction.find(@payment.response_code)
+      transaction.status.should == Braintree::Transaction::Status::Authorized
+      @payment.payment_source.capture(@payment) # as done in PaymentsController#fire
+      # transaction = ::Braintree::Transaction.find(@payment.response_code)
+      # transaction.status.should == Braintree::Transaction::Status::SubmittedForSettlement
+      # lambda do
+      #   @payment.payment_source.capture(@payment)
+      # end.should raise_error(Spree::GatewayError, "Cannot submit for settlement unless status is authorized. (91507)")
+    end
+  end
+  
+  describe 'purchase' do
+    it 'should return a success response with an authorization code' do
+      result =  @gateway.purchase(500, @creditcard)
+      result.success?.should be_true
+      result.authorization.should match(/\A\w{6}\z/)
+      Braintree::Transaction::Status::SubmittedForSettlement.should == Braintree::Transaction.find(result.authorization).status
+    end
+    
+    it 'should work through the spree payment interface with payment profiles' do
+      purchase_using_spree_interface
+      transaction = ::Braintree::Transaction.find(@payment.response_code)
+      transaction.credit_card_details.token.should match(/\A\w{4}\z/)
+    end
+    
+    it 'should work through the spree payment interface without payment profiles' do
+        with_payment_profiles_off do
+          purchase_using_spree_interface
+          transaction = ::Braintree::Transaction.find(@payment.response_code)
+          transaction.credit_card_details.token.should be_nil
+        end      
+    end
+  end
+    
+  describe "credit" do
+    it "should work through the spree interface" do
+      @payment.amount += 100.00
+      purchase_using_spree_interface
+      credit_using_spree_interface
+    end
+  end
+  
+  describe "void" do
+    it "should work through the spree creditcard / payment interface" do
+      assert_equal 0, @payment.log_entries.size
+      @payment.process!
+      assert_equal 1, @payment.log_entries.size
+      @payment.response_code.should match(/\A\w{6}\z/)
+      transaction = Braintree::Transaction.find(@payment.response_code)
+      transaction.status.should == Braintree::Transaction::Status::SubmittedForSettlement
+      @creditcard.void(@payment)
+      transaction = Braintree::Transaction.find(transaction.id)
+      transaction.status.should == Braintree::Transaction::Status::Voided
+    end
+  end
+  def credit_using_spree_interface
+    @payment.log_entries.size.should == 1
+    @payment.source.credit(@payment) # as done in PaymentsController#fire
+    @payment.log_entries.size.should == 2
+    #Let's get the payment record associated with the credit
+    @payment = @order.payments.last
+    @payment.response_code.should match(/\A\w{6}\z/)
+    transaction = ::Braintree::Transaction.find(@payment.response_code)
+    transaction.type.should == Braintree::Transaction::Type::Credit
+    transaction.status.should == Braintree::Transaction::Status::SubmittedForSettlement
+    transaction.credit_card_details.masked_number.should == "510510******5100"
+    transaction.credit_card_details.expiration_date.should == "09/#{Time.now.year + 1}"
+    transaction.customer_details.first_name.should == "John"
+    transaction.customer_details.last_name.should == "Doe"
+  end
+  
+  def purchase_using_spree_interface
+    Spree::Config.set :auto_capture => true
+    @payment.send(:create_payment_profile)
+    @payment.log_entries.size == 0
+    @payment.process! # as done in PaymentsController#create
+    @payment.log_entries.size == 1
+    @payment.response_code.should match /\A\w{6}\z/
+    @payment.state.should == 'completed'
+    transaction = ::Braintree::Transaction.find(@payment.response_code)
+    Braintree::Transaction::Status::SubmittedForSettlement.should == transaction.status
+    transaction.credit_card_details.masked_number.should == "510510******5100"
+    transaction.credit_card_details.expiration_date.should == "09/#{Time.now.year + 1}"
+    transaction.customer_details.first_name.should == 'John'
+    transaction.customer_details.last_name.should == 'Doe'
+  end
+  
+  def with_payment_profiles_off(&block)
+    Gateway::Braintree.class_eval do
+      def payment_profiles_supported?
+        false
+      end
+    end
+    yield
+  ensure
+    Gateway::Braintree.class_eval do
+      def payment_profiles_supported?
+        true
+      end
+    end
+  end
+  
+end

--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -10,6 +10,9 @@ require 'factories'
 # in ./support/ and its subdirectories.
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
 
+# #require factories
+Dir["#{File.dirname(__FILE__)}/factories/**/*.rb"].each {|f| require f}
+
 RSpec.configure do |config|
   # == Mock Framework
   #
@@ -27,6 +30,12 @@ RSpec.configure do |config|
   # examples within a transaction, comment the following line or assign false
   # instead of true.
   config.use_transactional_fixtures = true
+end
+
+Zone.class_eval do
+  def self.global
+    find_by_name("GlobalZone") || Factory(:global_zone)
+  end
 end
 
 @configuration ||= AppConfiguration.find_or_create_by_name("Default configuration")


### PR DESCRIPTION
This commit restores support for Braintree, most of the files in this commit relate to the specs for the braintree gateway, I ported over factories that were need to get the specs to run.  I noticed when I based railsdog that someone had added a require 'factories' line in spec helper.  I tried removing the factories that I added but then the spec started failing due to missing factories so I added them back in.
