### PR TITLE
Fix credit card show for credit type payment

### DIFF
--- a/core/app/views/admin/payments/show.html.erb
+++ b/core/app/views/admin/payments/show.html.erb
@@ -7,4 +7,4 @@
   <%= object.amount %>
 </p>
 
-<%= render "admin/payments/source_views/#{@payment.payment_method.method_type}", :payment => object %>
+<%= render "admin/payments/source_views/#{@payment.payment_method.method_type}", :payment => object.source.is_a?(Payment) ? object.source : object %>


### PR DESCRIPTION
for credit type payment, we could not see Credit Card details (show action) because the payment.source is not CreditCard class, in fact payment.source.source would be the CreditCard class.
