### PR TITLE
Promotion#save method should returns false if object is invalid

### DIFF
--- a/promo/app/models/promotion.rb
+++ b/promo/app/models/promotion.rb
@@ -12,8 +12,9 @@ class Promotion < ActiveRecord::Base
   # TODO: Remove that after fix for https://rails.lighthouseapp.com/projects/8994/tickets/4329-has_many-through-association-does-not-link-models-on-association-save
   # is provided
   def save(*)
-    super
-    promotion_rules.each { |p| p.save }
+    if super
+      promotion_rules.each { |p| p.save }
+    end
   end
 
   MATCH_POLICIES = %w(all any)

--- a/promo/spec/models/promotion_spec.rb
+++ b/promo/spec/models/promotion_spec.rb
@@ -3,6 +3,18 @@ require File.dirname(__FILE__) + '/../spec_helper'
 describe Promotion do
   let(:promotion) { Promotion.new }
 
+  describe "#save" do
+    let(:promotion_valid) { Promotion.new :name => "A promotion", :code => "XXXX" }
+
+    context "when is invalid" do
+      it { promotion.save.should be_false }
+    end
+
+    context "when is valid" do
+      it { promotion_valid.save.should be_true }
+    end
+  end
+
   context "creating discounts" do
     let(:order) { Order.new }
 


### PR DESCRIPTION
If you try to create a new promotion, in Promotions Page, and dont fill all required fields an "route error" occurs.
Previous code never returns false when saves an invalid promotion object and resource_controller tries to redirect to edit action.
