### PR TITLE
Error when generating a new controller

### DIFF
--- a/core/config/initializers/workarounds_for_ruby19.rb
+++ b/core/config/initializers/workarounds_for_ruby19.rb
@@ -8,7 +8,7 @@ if RUBY_VERSION.to_f >= 1.9
 
     alias_method(:orig_concat, :concat)
     def concat(value)
-      orig_concat value.force_encoding(Encoding::UTF_8)
+      orig_concat value.frozen? ? value : value.force_encoding(Encoding::UTF_8)
     end
   end
 


### PR DESCRIPTION
Pull request fixes the following issue:

~/htdocs/ringstore[master*]$ rails g controller pages index
/Users/josh/.rvm/gems/ruby-1.9.2-p136/bundler/gems/spree-219d1fbbeb4c/core/config/initializers/workarounds_for_ruby19.rb:11:in `force_encoding': can't modify frozen string (RuntimeError)
    from /Users/josh/.rvm/gems/ruby-1.9.2-p136/bundler/gems/spree-219d1fbbeb4c/core/config/initializers/workarounds_for_ruby19.rb:11:in`concat'
    from (erb):3:in `block in template'
    from (erb):2:in`each'
    from (erb):2:in `template'
    from /Users/josh/.rvm/rubies/ruby-1.9.2-p136/lib/ruby/1.9.1/erb.rb:753:in`eval'
    from /Users/josh/.rvm/rubies/ruby-1.9.2-p136/lib/ruby/1.9.1/erb.rb:753:in `result'
    from /Users/josh/.rvm/gems/ruby-1.9.2-p136/gems/thor-0.14.6/lib/thor/actions/file_manipulation.rb:111:in`block in template'
    from /Users/josh/.rvm/gems/ruby-1.9.2-p136/gems/thor-0.14.6/lib/thor/actions/create_file.rb:54:in `call'
    from /Users/josh/.rvm/gems/ruby-1.9.2-p136/gems/thor-0.14.6/lib/thor/actions/create_file.rb:54:in`render'
    from /Users/josh/.rvm/gems/ruby-1.9.2-p136/gems/thor-0.14.6/lib/thor/actions/create_file.rb:47:in `identical?'
    from /Users/josh/.rvm/gems/ruby-1.9.2-p136/gems/thor-0.14.6/lib/thor/actions/create_file.rb:73:in`on_conflict_behavior'
    from /Users/josh/.rvm/gems/ruby-1.9.2-p136/gems/thor-0.14.6/lib/thor/actions/empty_directory.rb:111:in `invoke_with_conflict_check'
    from /Users/josh/.rvm/gems/ruby-1.9.2-p136/gems/thor-0.14.6/lib/thor/actions/create_file.rb:61:in`invoke!'
    from /Users/josh/.rvm/gems/ruby-1.9.2-p136/gems/thor-0.14.6/lib/thor/actions.rb:95:in `action'
    from /Users/josh/.rvm/gems/ruby-1.9.2-p136/gems/thor-0.14.6/lib/thor/actions/create_file.rb:26:in`create_file'
    from /Users/josh/.rvm/gems/ruby-1.9.2-p136/gems/thor-0.14.6/lib/thor/actions/file_manipulation.rb:110:in `template'
    from /Users/josh/.rvm/gems/ruby-1.9.2-p136/gems/railties-3.0.3/lib/rails/generators/rails/controller/controller_generator.rb:8:in`create_controller_files'
    from /Users/josh/.rvm/gems/ruby-1.9.2-p136/gems/thor-0.14.6/lib/thor/task.rb:22:in `run'
    from /Users/josh/.rvm/gems/ruby-1.9.2-p136/gems/thor-0.14.6/lib/thor/invocation.rb:118:in`invoke_task'
    from /Users/josh/.rvm/gems/ruby-1.9.2-p136/gems/thor-0.14.6/lib/thor/invocation.rb:124:in `block in invoke_all'
    from /Users/josh/.rvm/gems/ruby-1.9.2-p136/gems/thor-0.14.6/lib/thor/invocation.rb:124:in`each'
    from /Users/josh/.rvm/gems/ruby-1.9.2-p136/gems/thor-0.14.6/lib/thor/invocation.rb:124:in `map'
    from /Users/josh/.rvm/gems/ruby-1.9.2-p136/gems/thor-0.14.6/lib/thor/invocation.rb:124:in`invoke_all'
    from /Users/josh/.rvm/gems/ruby-1.9.2-p136/gems/thor-0.14.6/lib/thor/group.rb:226:in `dispatch'
    from /Users/josh/.rvm/gems/ruby-1.9.2-p136/gems/thor-0.14.6/lib/thor/base.rb:389:in`start'
    from /Users/josh/.rvm/gems/ruby-1.9.2-p136/gems/railties-3.0.3/lib/rails/generators.rb:163:in `invoke'
    from /Users/josh/.rvm/gems/ruby-1.9.2-p136/gems/railties-3.0.3/lib/rails/commands/generate.rb:10:in`<top (required)>'
    from /Users/josh/.rvm/gems/ruby-1.9.2-p136/gems/activesupport-3.0.3/lib/active_support/dependencies.rb:239:in `require'
    from /Users/josh/.rvm/gems/ruby-1.9.2-p136/gems/activesupport-3.0.3/lib/active_support/dependencies.rb:239:in`block in require'
    from /Users/josh/.rvm/gems/ruby-1.9.2-p136/gems/activesupport-3.0.3/lib/active_support/dependencies.rb:225:in `block in load_dependency'
    from /Users/josh/.rvm/gems/ruby-1.9.2-p136/gems/activesupport-3.0.3/lib/active_support/dependencies.rb:596:in`new_constants_in'
    from /Users/josh/.rvm/gems/ruby-1.9.2-p136/gems/activesupport-3.0.3/lib/active_support/dependencies.rb:225:in `load_dependency'
    from /Users/josh/.rvm/gems/ruby-1.9.2-p136/gems/activesupport-3.0.3/lib/active_support/dependencies.rb:239:in`require'
    from /Users/josh/.rvm/gems/ruby-1.9.2-p136/gems/railties-3.0.3/lib/rails/commands.rb:17:in `<top (required)>'
    from script/rails:6:in`require'
    from script/rails:6:in `<main>'
