### PR TITLE
Upgrade cancan

### DIFF
--- a/auth/app/models/ability.rb
+++ b/auth/app/models/ability.rb
@@ -57,7 +57,7 @@ class Ability
     #include any abilities registered by extensions, etc.
     Ability.abilities.each do |clazz|
       ability = clazz.send(:new, user)
-      @can_definitions = can_definitions + ability.send(:can_definitions)
+      @rules = rules + ability.send(:rules)
     end
 
   end

--- a/auth/spree_auth.gemspec
+++ b/auth/spree_auth.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency('spree_core',  version)
   s.add_dependency('devise', '= 1.2.rc')
-  s.add_dependency('cancan', '= 1.3.3')
+  s.add_dependency('cancan', '= 1.5.1')
 end


### PR DESCRIPTION
In the new cancan "can_definitions" were renamed to "rules". I've only done a lightweight testing, so I might have missed some other incompatibilities. Either way it might be worth pulling into master.
