### PR TITLE
Editing a user unnecessarily sets it's role to "user"

### DIFF
--- a/core/app/controllers/admin/users_controller.rb
+++ b/core/app/controllers/admin/users_controller.rb
@@ -55,7 +55,6 @@ class Admin::UsersController < Admin::BaseController
     return unless params[:user]
     @user.roles.delete_all
     params[:user][:role] ||= {}
-    params[:user][:role][:user] = 1     # all new accounts have user role
     Role.all.each { |role|
       @user.roles << role unless params[:user][:role][role.name].blank?
     }


### PR DESCRIPTION
This is not required. Sean has confirmed that this is a holdover from the old days.

This is my first pull request so please forgive is I did not put it in correctly.

-Ewen
