### PR TITLE
Fix state dropdown ie

### DIFF
--- a/core/public/javascripts/checkout.js
+++ b/core/public/javascripts/checkout.js
@@ -4,7 +4,7 @@
     $('#checkout_form_address').validate();
 
     var get_states = function(region){
-      var country        = $('span#' + region + 'country :only-child').val();
+      var country        = $('span#' + region + 'country :first-child').val();
       return state_mapper[country];
     }
     


### PR DESCRIPTION
Had a state dropdown problem on the _address page in Internet Explorer. Fixed by updating the checkout.js file to use :first-child instead of :only-child to select country. Original issue here:

http://groups.google.com/group/spree-user/browse_thread/thread/f79692eb80d2cf03/9ac999b87ec39cac?lnk=gst&q=javascript+ie#9ac999b87ec39cac
