### PR TITLE
Reintroduce no shipping methods error

### DIFF
--- a/core/app/models/order.rb
+++ b/core/app/models/order.rb
@@ -26,6 +26,7 @@ class Order < ActiveRecord::Base
   before_create :generate_order_number
 
   validates_presence_of :email, :if => :require_email
+  validate :has_available_shipment
 
   #delegate :ip_address, :to => :checkout
   def ip_address
@@ -457,6 +458,13 @@ class Order < ActiveRecord::Base
   # Determine if email is required (we don't want validation errors before we hit the checkout)
   def require_email
     return true unless new_record? or state == 'cart'
+  end
+
+  def has_available_shipment
+    return unless :address == state_name.to_sym
+    return unless ship_address && ship_address.valid?
+    errors.add :base, :no_shipping_methods_available \
+      if available_shipping_methods.empty?
   end
 
   def after_cancel

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -373,6 +373,9 @@ en:
   enter_password_to_confirm: "(we need your current password to confirm your changes)"
   environment: "Environment"
   error: error
+  errors:
+    messages:
+      no_shipping_methods_available: "No shipping methods available for selected location, please change your address and try again."
   event: Event
   existing_customer: "Existing Customer"
   expiration: "Expiration"
@@ -526,7 +529,6 @@ en:
   no_payment_methods_available: "Can't check out, no payment methods are configured for this environment"
   no_products_found: "No products found"
   no_results: "No results"
-  no_shipping_methods_available: "No shipping methods available, please change your address and try again."
   no_user_found: "No user was found with that email address"
   none: None
   none_available: "None Available"


### PR DESCRIPTION
It used to reside in delivery view until checkout process was refactored by Sean. I thought I'd add it as a validation for the address state.
