### PR TITLE
Fix to make Country and State controls work in IE8, IE7 and IE6

### DIFF
--- a/core/public/javascripts/checkout.js
+++ b/core/public/javascripts/checkout.js
@@ -4,7 +4,7 @@
     $('#checkout_form_address').validate();
 
     var get_states = function(region){
-      var country        = $('span#' + region + 'country :only-child').val();
+      var country        = $('p#' + region + 'country' + ' span#' + region + 'country :only-child').val();
       return state_mapper[country];
     }
     
@@ -43,8 +43,8 @@
       if(this.checked){ $('#payment_method_'+this.value).show(); }
     }).triggerHandler('click');
 
-    $('span#bcountry select').change(function() { update_state('b'); });
-    $('span#scountry select').change(function() { update_state('s'); });
+    $('p#bcountry span#bcountry select').change(function() { update_state('b'); });
+    $('p#scountry span#scountry select').change(function() { update_state('s'); });
     update_state('b');
     update_state('s');
 


### PR DESCRIPTION
This commit fixes an issue in the Address page of the checkout process.  The Country and State controls were not working as expected in IE8, IE7, or IE6.  The State control was displaying as a textbox when United States was selected as a country.  It should show as a dropdown with the States.

This fix is in the checkout.js file.  The fix makes the jQuery search expressions more specific.  With this fix jQuery can find the controls it needs to manipulate when the user selects a country.

For some unknown reason, the existing code was working in other major browsers (Chrome, Safari, Firefox).  This fix preserves the behavior in those browsers.

Discussion in spree google group:
http://groups.google.com/group/spree-user/browse_thread/thread/f79692eb80d2cf03
