### PR TITLE
Fix use billing address

### DIFF
--- a/core/app/controllers/checkout_controller.rb
+++ b/core/app/controllers/checkout_controller.rb
@@ -64,8 +64,8 @@ class CheckoutController < Spree::BaseController
   end
 
   def before_address
-    @order.bill_address ||= Address.new(:country => default_country)
-    @order.ship_address ||= Address.new(:country => default_country)
+    @order.bill_address ||= Address.new(:country_id => default_country_id)
+    @order.ship_address ||= Address.new(:country_id => default_country_id)
   end
 
   def before_delivery
@@ -81,8 +81,8 @@ class CheckoutController < Spree::BaseController
     session[:order_id] = nil
   end
 
-  def default_country
-    Country.find Spree::Config[:default_country_id]
+  def default_country_id
+    Spree::Config[:default_country_id]
   end
 
   def rescue_from_spree_gateway_error


### PR DESCRIPTION
When creating a new order and changing billing address country selecting "Use billing address" for shipment would leave shipment country on the default.

Steps to reproduce in Spree:
1. Start new order
2. Fill in billing address and change country from the default
3. For shipping select "Use billing address"
4. Continue

Now the database will have shipping address with all values from billing, except the country which will be set to default. If you use spree_sample and have choosen Canada for billing the shipment will still be for United States.

Reason:
`CheckoutController` loads country association in `before_address`:
    @order.bill_address ||= Address.new(:country => default_country)
    @order.ship_address ||= Address.new(:country => default_country)

That sets `ship_address.country` attribute and changing `ship_address.country_id` doesn't reload the association. When later `order.save` is called the `country` will take precedence over `country_id`.

See how this works in console:

```
$rails c
Loading development environment (Rails 3.0.4)
irb(main):002:0> c = Country.find(214)
=> #<Country id: 214, iso_name: "UNITED STATES", iso: "US", name: "United States", iso3: "USA", numcode: 840, subdomain_account_id: 1>
irb(main):003:0> a = Address.new(:country => c)
=> #<Address id: nil, firstname: nil, lastname: nil, address1: nil, address2: nil, city: nil, state_id: nil, zipcode: nil, country_id: 214, phone: nil, created_at: nil, updated_at: nil, state_name: nil, alternative_phone: nil>
irb(main):004:0> a.country_id = 35
=> 35
irb(main):005:0> a
=> #<Address id: nil, firstname: nil, lastname: nil, address1: nil, address2: nil, city: nil, state_id: nil, zipcode: nil, country_id: 35, phone: nil, created_at: nil, updated_at: nil, state_name: nil, alternative_phone: nil>
irb(main):006:0> a.country
=> #<Country id: 214, iso_name: "UNITED STATES", iso: "US", name: "United States", iso3: "USA", numcode: 840, subdomain_account_id: 1>
irb(main):007:0> a.save(:validate => false)
=> true
irb(main):008:0> a
=> #<Address id: 1072978432, firstname: nil, lastname: nil, address1: nil, address2: nil, city: nil, state_id: nil, zipcode: nil, country_id: 214, phone: nil, created_at: "2011-02-18 13:14:21", updated_at: "2011-02-18 13:14:21", state_name: nil, alternative_phone: nil>
```

The other fix would be to call implicit association reload in `clone_billing_address` like this

```
self.ship_address.country(true)
self.ship_address.state(true)
```

But those are all unnecessary queries. There's really no reason for setting actual country model instead of just id in `before_address`.
