### PR TITLE
1860 invalid taxon permalink

### DIFF
--- a/core/app/controllers/taxons_controller.rb
+++ b/core/app/controllers/taxons_controller.rb
@@ -1,9 +1,10 @@
 class TaxonsController < Spree::BaseController
 
   helper :products
+  rescue_from ActiveRecord::RecordNotFound, :with => :render_404
 
   def show
-    @taxon = Taxon.find_by_permalink(params[:id])
+    raise ActiveRecord::RecordNotFound unless @taxon = Taxon.find_by_permalink(params[:id])
     params[:taxon] = @taxon.id
     @searcher = Spree::Config.searcher_class.new(params)
     @products = @searcher.retrieve_products

--- a/core/features/products.feature
+++ b/core/features/products.feature
@@ -71,3 +71,8 @@ Feature: Visiting products
     When I check "Price_Range_$20_or_over"
     When I press "Search" within "#sidebar_products_search"
     Then verify products listing for price range search 18 and above
+
+  @allow_rescue
+  Scenario: invalid taxon permalink
+    When I go to an invalid taxon page
+    Then I should get a "404 Not Found" response

--- a/core/features/step_definitions/product.rb
+++ b/core/features/step_definitions/product.rb
@@ -127,4 +127,8 @@ Then /^verify products listing for price range search 18 and above$/ do
 end
 
 
+Then /^I should get a "(\d+) ([^"]+)" response$/ do |http_status, message|
+  #response.status.should == "#{http_status} #{message}"    # webrat
+  page.driver.status_code.should == http_status.to_i        # capybara
+end
 

--- a/core/features/support/paths.rb
+++ b/core/features/support/paths.rb
@@ -16,6 +16,9 @@ module NavigationHelpers
       new_user_session_path
     when /the sign up page/
       new_user_registration_path
+    when /an invalid taxon page/
+        "/t/totally_bogus_taxon"
+        
 
     # Add more mappings here.
     # Here is an example that pulls values out of the Regexp:


### PR DESCRIPTION
http://railsdog.lighthouseapp.com/projects/31096-spree/tickets/1860

let me know what you think of this approach. Maybe the 
    rescue_from ActiveRecord::RecordNotFound, :with => :render_404
should go in Spree::BaseController? I saw some discussion around refactoring permalink generation, but I don't think this would affect that.
