### PR TITLE
Fixes removing a PromotionRule from Promotion (admin panel) ActiveRecord::RecordNotFound

### DIFF
--- a/promo/app/views/admin/promotion_rules/destroy.js.erb
+++ b/promo/app/views/admin/promotion_rules/destroy.js.erb
@@ -1,1 +1,1 @@
-jQuery('#<%= dom_id object %>').fadeOut();
+jQuery('#<%= dom_id object %>').fadeOut().remove();


### PR DESCRIPTION
Removing a PromotionRule from Promotion  (after that PromotionRule has been previously been saved) resulted in ActiveRecord::RecordNotFound because jQuery's fadeOut() does not actually remove the html code for the PromotionRule. By adding remove() at the end, the behaviour is fixed...

Bye!
