### PR TITLE
Pass original product to duplicate_extra

### DIFF
--- a/core/app/models/product.rb
+++ b/core/app/models/product.rb
@@ -197,7 +197,7 @@ class Product < ActiveRecord::Base
     else
     end
     # allow site to do some customization
-    p.send(:duplicate_extra) if p.respond_to?(:duplicate_extra)
+    p.send(:duplicate_extra, self) if p.respond_to?(:duplicate_extra)
     p.save!
     p
   end


### PR DESCRIPTION
If there's another way of accessing original product then I've missed it. This allows me to copy some additional data in my extension.
