### PR TITLE
Replaces instances of Product.condition? with Product.respond_to?

### DIFF
--- a/core/app/models/product_group.rb
+++ b/core/app/models/product_group.rb
@@ -75,7 +75,7 @@ class ProductGroup < ActiveRecord::Base
   def from_route(attrs)
     self.order_scope = attrs.pop if attrs.length % 2 == 1
     attrs.each_slice(2) do |scope|
-      next unless Product.condition?(scope.first)
+      next unless Product.respond_to?(scope.first)
       add_scope(scope.first, scope.last.split(","))
     end
     self

--- a/core/app/models/product_scope.rb
+++ b/core/app/models/product_scope.rb
@@ -16,8 +16,8 @@ class ProductScope < ActiveRecord::Base
 
   # Get all products with this scope
   def products
-    if Product.condition?(self.name)
-      Product.send(self.name, *self.arguments)
+    if Product.respond_to?(name)
+      Product.send(name, *arguments)
     end
   end
 

--- a/core/spec/models/product_group_spec.rb
+++ b/core/spec/models/product_group_spec.rb
@@ -6,5 +6,31 @@ describe ProductGroup do
     it { should validate_presence_of(:name) }
     it { should have_valid_factory(:product_group) }
   end
-
+  
+  describe '#from_route' do
+    context "wth valid scopes" do
+      before do 
+        subject.from_route(["master_price_lte", "100", "in_name_or_keywords", "Ikea", "ascend_by_master_price"])
+      end
+      
+      it "sets one ordering scope" do
+        subject.product_scopes.select(&:is_ordering?).length.should == 1
+      end
+      
+      it "sets two non-ordering scopes" do
+        subject.product_scopes.reject(&:is_ordering?).length.should == 2
+      end
+    end
+        
+    context 'with an invalid product scope' do
+      before do 
+        subject.from_route(["master_pri_lte", "100", "in_name_or_kerds", "Ikea"])
+      end
+      
+      it 'sets no product scopes' do
+        subject.product_scopes.should be_empty
+      end
+    end
+       
+  end
 end

--- a/core/spec/models/product_scope_spec.rb
+++ b/core/spec/models/product_scope_spec.rb
@@ -17,5 +17,23 @@ describe ProductScope do
     end
 
   end
+  
+  describe "#products" do
+    context "with an existing Product scope" do
+      it "sends an eponymous message to Product" do
+        Product.should_receive(:master_price_lte).with('100')
+        subject.name = 'master_price_lte'
+        subject.arguments = ['100']
+        subject.products
+      end
+    end
+    
+    context "with a non-existent Product scope" do
+      it "should return nil" do
+        subject.name = 'dlghdskjhgsjkg'
+        subject.products.should be_nil
+      end
+    end
+  end
 
 end


### PR DESCRIPTION
Product.condition? is no longer defined and was throwing exceptions in the two instances where we saw it used.

We (danhodos and I) also added specs for the methods where Product.condition? were used.
