### PR TITLE
1872 adddescriptiontotaxons has issues with existence validation

### DIFF
--- a/core/db/migrate/20100506185838_add_description_to_taxons.rb
+++ b/core/db/migrate/20100506185838_add_description_to_taxons.rb
@@ -1,11 +1,10 @@
 class AddDescriptionToTaxons < ActiveRecord::Migration
-    def self.up
-      # skip this migration if the attribute already exists because of advanced taxon extension
-      return if Taxon.new.respond_to? :description
-      add_column :taxons, :description, :text
-    end
+  def self.up
+    # skip this migration if the attribute already exists because of advanced taxon extension
+    add_column :taxons, :description, :text unless column_exists?(:taxons, :description)
+  end
 
-    def self.down
-      remove_column :taxons, :description
-    end
+  def self.down
+    remove_column :taxons, :description
+  end
 end


### PR DESCRIPTION
The `AddDescriptionToTaxons` migration has an issue with the check if the description column already exists.

Currently it does this:
    def self.up
      # skip this migration if the attribute already exists because of advanced taxon extension
      return if Taxon.new.respond_to? :description
      add_column :taxons, :description, :text
    end

This works fine since if the attribute is there, the column _should_ be there too.

But there is one case where it acts different. I've built a [Product Translations](http://spreecommerce.com/extensions/133-product-translations) extension earlier this week which translates some product details. One of this is `description` in `Taxon`. Because of the `translates :description` method, `Taxon.new.respond_to? :description` will return `true`. It will also do this even before all migrations have ran which results in it returning `true` at the moment this migration will be ran (when you start from a clean db for example).

A better way to have this migration is to use the `column_exists?` helper:
    def self.up
      # skip this migration if the attribute already exists because of advanced taxon extension
      add_column :taxons, :description, :text unless column_exists?(:taxons, :description)
    end

This one also has a [Lighthouse ticket](http://railsdog.lighthouseapp.com/projects/31096/tickets/1872-adddescriptiontotaxons-has-issues-with-existence-validation)
