### PR TITLE
1869 property form does not indicate required attributes

### DIFF
--- a/core/app/views/admin/properties/_form.html.erb
+++ b/core/app/views/admin/properties/_form.html.erb
@@ -1,11 +1,11 @@
 <%= f.field_container :name do %>
-  <%= f.label :name, t("name") %><br />
+  <%= f.label :name, t("name") %> <span class="required">*</span><br />
   <%= f.text_field :name %>
   <%= f.error_message_on :name %>
 <% end %>
 
 <%= f.field_container :presentation do %>
-  <%= f.label :presentation, t("presentation") %><br />
+  <%= f.label :presentation, t("presentation") %> <span class="required">*</span><br />
   <%= f.text_field :presentation %>
   <%= f.error_message_on :presentation %>
 <% end %>


### PR DESCRIPTION
Both attributes of Property (name and presentation) are required. However, the required indicators aren't added in the properties form.

One could argue that if all attributes are required, it shouldn't display those indicators.

I'm not sure if you guys just forgot about it, or have the above described opinion.

[Lighthouse ticket](http://railsdog.lighthouseapp.com/projects/31096/tickets/1869-property-form-does-not-indicate-required-attributes)
