### PR TITLE
1871 optiontype form does not indicate required attributes and has a typo

### DIFF
--- a/core/app/views/admin/option_types/_form.html.erb
+++ b/core/app/views/admin/option_types/_form.html.erb
@@ -1,11 +1,11 @@
 <%= f.field_container :name do %>
-  <%= f.label :name, t("name") %><br />
+  <%= f.label :name, t("name") %> <span class="required">*</span><br />
   <%= f.text_field :name %>
   <%= f.error_message_on :name %>
 <% end %>
 
-<%= f.field_container :name do %>
-  <%= f.label :presentation, t("presentation") %><br />
+<%= f.field_container :presentation do %>
+  <%= f.label :presentation, t("presentation") %> <span class="required">*</span><br />
   <%= f.text_field :presentation %>
   <%= f.error_message_on :presentation %>
 <% end %>


### PR DESCRIPTION
Just like [this](https://github.com/spree/spree/pull/231) the OptionType form is missing the required attributes indicators.

It also lists twice a field_container for `:name`, while it should have one for `:presentation`.

[Lighthouse ticket](http://railsdog.lighthouseapp.com/projects/31096/tickets/1871-optiontype-form-does-not-indicate-required-attributes-and-has-a-typo)
