### PR TITLE
Fix product active scope

### DIFF
--- a/core/app/models/product.rb
+++ b/core/app/models/product.rb
@@ -75,7 +75,7 @@ class Product < ActiveRecord::Base
   scope :available,       lambda { |*on| where("products.available_on <= ?", on.first || Time.zone.now ) }
 
   #RAILS 3 TODO - this scope doesn't match the original 2.3.x version, needs attention (but it works)
-  scope :active,          not_deleted.available
+  scope :active,          lambda{ not_deleted.available }
 
   scope :on_hand,         where("products.count_on_hand > 0")
 


### PR DESCRIPTION
You can read more about this on rubyonrails-core, where I have used this bug as an example in a discussion:

http://groups.google.com/group/rubyonrails-core/browse_thread/thread/151882ad7f48b3dd

Notice that you won't see this bug in development environment, because the Product class is reloaded with each request. You can however run `rails c` and then in the console execute `Product.active` a few times and check the generated queries in log/development.log.
