### PR TITLE
Show current taxon products

### DIFF
--- a/core/app/views/taxons/show.html.erb
+++ b/core/app/views/taxons/show.html.erb
@@ -7,11 +7,15 @@
   <% end %>
 <% end %>
 
-<% if @taxon.children.empty? || !params[:keywords].blank? %>
+<% force_products = @taxon.children.empty? || params[:keywords].present? %>
+
+<% if @products.present? || force_products %>
   <%= hook :taxon_products do %>
     <%= render :partial => "shared/products", :locals => {:products => @products, :taxon => @taxon } %>
   <% end %>
-<% else %>
+<% end %>
+
+<% unless force_products %>
   <%= hook :taxon_children do %>
     <%= render :partial => "taxon", :collection => @taxon.children %>
   <% end %>

--- a/core/lib/spree/search/base.rb
+++ b/core/lib/spree/search/base.rb
@@ -26,7 +26,15 @@ module Spree::Search
     protected
     def get_base_scope
       base_scope = @cached_product_group ? @cached_product_group.products.active : Product.active
-      base_scope = base_scope.in_taxon(taxon) unless taxon.blank?
+      if taxon.present?
+        # select products from taxon and it's children during search
+        if keywords.present?
+          base_scope = base_scope.in_taxon(taxon)
+        # select products only from the current taxon otherwise
+        else
+          base_scope = base_scope.taxons_name_eq taxon.name
+        end
+      end
       base_scope = get_products_conditions_for(base_scope, keywords) unless keywords.blank?
 
       base_scope = base_scope.on_hand unless Spree::Config[:show_zero_stock_products]


### PR DESCRIPTION
Fixes TaxonsController#show.

This makes taxon view display products from the current taxon.

Until now current taxon's products were displayed only if the taxon didn't have
any children.

Try http://your_spree_demo/t/categories/clothing/shirts and see if it lists
"Ruby on Rails Jr. Spaghetti".
