### PR TITLE
1792 fix tasks running twice

### DIFF
--- a/lib/generators/templates/spree_site.rb
+++ b/lib/generators/templates/spree_site.rb
@@ -3,6 +3,10 @@ module SpreeSite
     def self.activate
       # Add your custom site logic here
     end
+    
+    def load_tasks
+    end
+    
     config.to_prepare &method(:activate).to_proc
   end
 end


### PR DESCRIPTION
Prevent tasks from being loaded a second time from the rails engine by overriding the load_tasks method.
