### PR TITLE
Taxonomy menu base uri problem

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -101,9 +101,7 @@ module Spree::BaseHelper
   
   # generates nested url to product based on supplied taxon
   def seo_url(taxon, product = nil)
-    return '/t/' + taxon.permalink if product.nil?
-    warn "DEPRECATION: the /t/taxon-permalink/p/product-permalink urls are "+
-      "not used anymore. Use product_url instead. (called from #{caller[0]})"
+    return nested_taxons_path(taxon.permalink) if product.nil?
     return product_url(product)
   end
   


### PR DESCRIPTION
The seo_url method returns the taxonomy links url not considering the application base uri.
The problem appears when the application is not configured to domain root.
