### PR TITLE
Assert payment has source during processing

### DIFF
--- a/core/app/models/gateway.rb
+++ b/core/app/models/gateway.rb
@@ -10,6 +10,10 @@ class Gateway < PaymentMethod
     Creditcard
   end
 
+  def requires_source?
+    true
+  end
+
   # instantiates the selected gateway and configures with the options stored in the database
   def self.current
     super

--- a/core/app/models/payment.rb
+++ b/core/app/models/payment.rb
@@ -69,7 +69,15 @@ class Payment < ActiveRecord::Base
   end
 
   def process!
-    if !processing? and source and source.respond_to?(:process!)
+    return if processing?
+
+    if !source
+      raise "payment source is missing" if payment_method.requires_source?
+      return
+    end
+
+    raise "bad source type" unless source.kind_of? payment_method.payment_source_class
+    if source.respond_to?(:process!)
       started_processing!
       source.process!(self) # source is responsible for updating the payment state when it's done processing
     end

--- a/core/app/models/payment_method.rb
+++ b/core/app/models/payment_method.rb
@@ -23,6 +23,10 @@ class PaymentMethod < ActiveRecord::Base
     raise "You must implement payment_source_class method for this gateway."
   end
 
+  def requires_source?
+    false
+  end
+
   def self.available(display_on='both')
     PaymentMethod.all.select { |p| p.active && (p.display_on == display_on.to_s || p.display_on.blank?) &&  (p.environment == Rails.env || p.environment.blank?) }
   end


### PR DESCRIPTION
This security fix prevents users from completing an order without processing credit card data by gateway. It was  possible by tinkering with the payment form and removing the source_attributes fieldsets. An easy task on modern browsers that provide DOM inspectors.

It's not critical. All the user is able to do without this patch is completing an order similarly to if the store provided "Check" payment method. The order will appear in completed orders list in admin panel with "Credit Card" payment method and "checkout" payment state. An exception would be thrown if store owner tried editing the payment.
