### PR TITLE
Fix labels i18n

### DIFF
--- a/core/config/initializers/form_builder.rb
+++ b/core/config/initializers/form_builder.rb
@@ -2,10 +2,6 @@
 # Allow some application_helper methods to be used in the scoped form_for manner
 #
 class ActionView::Helpers::FormBuilder
-  def label(method, text = nil, options={})
-    @template.label(@object_name,method,text,options)
-  end
-
   def field_container(method, options = {}, &block)
     @template.field_container(@object_name,method,options,&block)
   end


### PR DESCRIPTION
I don't know why this was reimplemented, but it wasn't calling objectify_options and thus failed to internationalize model attributes.

InstanceTag::to_label_tag requires object to call human_attribute_name on it's class.
