### PR TITLE
A fix to order create_shipment!

### DIFF
--- a/core/app/models/order.rb
+++ b/core/app/models/order.rb
@@ -263,7 +263,7 @@ class Order < ActiveRecord::Base
 
   # Creates a new shipment (adjustment is created by shipment model)
   def create_shipment!
-    shipping_method.reload
+    shipping_method(true)
     if shipment.present?
       shipment.update_attributes(:shipping_method => shipping_method)
     else


### PR DESCRIPTION
It doesn't behave wrong, it's just something I've noticed in the code. However it could go wrong if shipping_method was loaded before shipping_method_id was changed. I think that's why that check was put there in the first place.

`shipping_method.reload` makes the loaded &lt;ShippingMethod id:XXX&gt; reload it's properties. `shipping_method(true)` makes Order load a new object based on current `shipping_method_id`.
