### PR TITLE
Dont list anonymous users in admin

### DIFF
--- a/auth/app/models/user.rb
+++ b/auth/app/models/user.rb
@@ -15,6 +15,7 @@ class User < ActiveRecord::Base
   attr_accessible :email, :password, :password_confirmation, :remember_me, :persistence_token
 
   scope :admin, lambda { includes(:roles).where("roles.name" => "admin") }
+  scope :registered, where('users.email NOT LIKE "%@example.net"')
 
   # has_role? simply needs to return true or false whether a user has a role or not.
   def has_role?(role_in_question)

--- a/core/app/controllers/admin/users_controller.rb
+++ b/core/app/controllers/admin/users_controller.rb
@@ -33,7 +33,7 @@ class Admin::UsersController < Admin::BaseController
   def collection
     return @collection if @collection.present?
     unless request.xhr?
-      @search = User.metasearch(params[:search])
+      @search = User.registered.metasearch(params[:search])
       @collection = @search.paginate(:per_page => Spree::Config[:admin_products_per_page], :page => params[:page])
 
       #scope = scope.conditions "lower(email) = ?", @filter.email.downcase unless @filter.email.blank?


### PR DESCRIPTION
I don't think anyone cares about a long list of random generated emails.

I've left anonymous users in the xhr search that performs first and last name comparisons too. I don't know why though, because even my own addresses patch doesn't populate bill/ship address data for guests.

I was always wondering why do we even create those anonymous users.
