### PR TITLE
Grant 'user' role to newly registered users

### DIFF
--- a/auth/app/controllers/user_registrations_controller.rb
+++ b/auth/app/controllers/user_registrations_controller.rb
@@ -14,7 +14,7 @@ class UserRegistrationsController < Devise::RegistrationsController
   # POST /resource/sign_up
   def create
     @user = build_resource(params[:user])
-    logger.debug(@user)
+    @user.roles << Role.find_or_create_by_name(:user)
     if resource.save
       set_flash_message(:notice, :signed_up)
       sign_in_and_redirect(:user, @user)


### PR DESCRIPTION
I can see that admin interface no longer forces 'user' role on every edited user, which is nice, because that was also affecting edited guests.

But since this role is still listed in core/db/default/roles.yml then I assume that people who register should be granted it.
