### PR TITLE
Remove defunct extension links code

### DIFF
--- a/core/app/controllers/admin/configurations_controller.rb
+++ b/core/app/controllers/admin/configurations_controller.rb
@@ -1,26 +1,2 @@
 class Admin::ConfigurationsController < Admin::BaseController
-  before_filter :initialize_extension_links, :only => :index
-
-  class << self
-    def add_link(text, path, description)
-      unless @@extension_links.any?{|link| link[:link_text] == text}
-        @@extension_links << {
-          :link => path,
-          :link_text => text,
-          :description => description,
-        }
-      end
-    end
-  end
-
-  protected
-
-  def initialize_extension_links
-    @extension_links = [
-      {:link => admin_shipping_methods_path, :link_text => t("shipping_methods"), :description => t("shipping_methods_description")},
-      {:link => admin_shipping_categories_path, :link_text => t("shipping_categories"), :description => t("shipping_categories_description")},
-    ] + @@extension_links
-  end
-
-  @@extension_links = []
 end


### PR DESCRIPTION
Hi everyone

This is my first GH pull request for spree. I've been observing the project for a while and now thinking I could do something useful for the community. So I just tackle defunct and try to clean up the code.

joneslee85 told me that Admin::ConfigurationsController's extension_links seems to be defunct and after looking into this carefully, I could verify that the index view has never mentioned about @extension_links since 0.11 to prefer the view hook way.
