### PR TITLE
1885 typo in rake task spreereset taxon peramlinks

### DIFF
--- a/core/lib/tasks/taxon.rake
+++ b/core/lib/tasks/taxon.rake
@@ -1,6 +1,6 @@
 namespace :spree do
   desc "Resets all taxon permalinks"
-  task :reset_taxon_peramlinks => :environment do
+  task :reset_taxon_permalinks => :environment do
     Taxon.where(:parent_id => nil).each {|taxon| redo_permalinks(taxon) }
   end
 


### PR DESCRIPTION
Commit says enough I guess. Lighthouse [ticket here](http://railsdog.lighthouseapp.com/projects/31096-spree/tickets/1885-typo-in-rake-task-spreereset_taxon_peramlinks).
