### PR TITLE
Specification#has_rdoc is deprecated in RubyGems 1.7.0

### DIFF
--- a/lib/generators/templates/extension.gemspec.tt
+++ b/lib/generators/templates/extension.gemspec.tt
@@ -16,7 +16,5 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.has_rdoc = true
-
   s.add_dependency('spree_core', '>= <%= Spree.version %>')
 end

--- a/sample/spree_sample.gemspec
+++ b/sample/spree_sample.gemspec
@@ -17,7 +17,5 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.has_rdoc = true
-
   s.add_dependency('spree_core', version)
 end


### PR DESCRIPTION
as title
