### PR TITLE
Specification#default_executable has been deprecated since RubyGems 1.7.0

### DIFF
--- a/spree.gemspec
+++ b/spree.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
 
   #s.bindir             = 'bin'
   #s.executables        = ['spree']
-  #s.default_executable = 'spree'
 
   s.add_dependency('spree_core',  version)
   s.add_dependency('spree_auth', version)


### PR DESCRIPTION
Specification#default_executable has been deprecated since RubyGems 1.7.0
