### PR TITLE
set min-height CSS for sidebar to align product listing columns correctly

### DIFF
--- a/core/public/stylesheets/screen.css
+++ b/core/public/stylesheets/screen.css
@@ -287,6 +287,7 @@ body.two-col #wrapper { background-image: url(../images/wrapper-back-2.png); }
   display: inline;
   float: left;
   width: 150px;
+  min-height: 100px;
   margin-right: 10px;
   padding-right: 24px;
   margin-right: 25px;


### PR DESCRIPTION
set min-height CSS for sidebar to align product listing columns correctly in the case of zero taxons, see screenshot:

http://dl.dropbox.com/u/19968220/Screen-shot-2011-04-08-at-12.00.jpg

thanks joneslee85 for this
