### PR TITLE
A possible solution to fix autocomplete for postgres users

### DIFF
--- a/core/app/controllers/admin/products_controller.rb
+++ b/core/app/controllers/admin/products_controller.rb
@@ -92,10 +92,10 @@ class Admin::ProductsController < Admin::ResourceController
     else
       includes = [{:variants => [:images,  {:option_values => :option_type}]}, :master, :images]
 
-      @collection = super.where(["name LIKE ?", "%#{params[:q]}%"])
+      @collection = super.where(["upper(name) LIKE ?", "%#{params[:q].upcase}%"])
       @collection = @collection.includes(includes).limit(params[:limit] || 10)
 
-      tmp = super.where(["variants.sku LIKE ?", "%#{params[:q]}%"])
+      tmp = super.where(["upper(variants.sku) LIKE ?", "%#{params[:q].upcase}%"])
       tmp = tmp.includes(:variants_including_master).limit(params[:limit] || 10)
       @collection.concat(tmp)
 

--- a/core/app/controllers/admin/users_controller.rb
+++ b/core/app/controllers/admin/users_controller.rb
@@ -22,12 +22,12 @@ class Admin::UsersController < Admin::ResourceController
       @collection = @search.paginate(:per_page => Spree::Config[:admin_products_per_page], :page => params[:page])
     else
       @collection = User.includes(:bill_address => [:state, :country], :ship_address => [:state, :country]).
-                        where("users.email like :search
-                               OR addresses.firstname like :search
-                               OR addresses.lastname like :search
-                               OR ship_addresses_users.firstname like :search
-                               OR ship_addresses_users.lastname like :search",
-                               {:search => "#{params[:q].strip}%"}).
+                        where("upper(users.email) like :search
+                               OR upper(addresses.firstname) like :search
+                               OR upper(addresses.lastname) like :search
+                               OR upper(ship_addresses_users.firstname) like :search
+                               OR upper(ship_addresses_users.lastname) like :search",
+                               {:search => "#{params[:q].strip.upcase}%"}).
                         limit(params[:limit] || 100)
     end
   end  


### PR DESCRIPTION
Not sure if this is the best solution.  Wrapping upper() around fields and adding upcase to search parameter
