### PR TITLE
Getting off of Devise RC

### DIFF
--- a/auth/spree_auth.gemspec
+++ b/auth/spree_auth.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency('spree_core',  version)
-  s.add_dependency('devise', '= 1.2.rc2')
+  s.add_dependency('devise', '= 1.3.1')
   s.add_dependency('cancan', '= 1.5.1')
 end


### PR DESCRIPTION
We should be running all currents instead of RC's anyway =)

Also helps with picking up new omniauth stuff as well in new spree_social
