### PR TITLE
1901 a user gets signed out after updating his password

### DIFF
--- a/auth/app/controllers/users_controller.rb
+++ b/auth/app/controllers/users_controller.rb
@@ -27,7 +27,7 @@ class UsersController < Spree::BaseController
       if params[:user][:password].present?
         # this logic needed b/c devise wants to log us out after password changes
         user = User.reset_password_by_token(params[:user])
-        sign_in(@user, :event => :authentication, :bypass => true)
+        sign_in(@user, :event => :authentication, :bypass => !Spree::Config[:signout_after_password_change])
       end
       flash.notice = I18n.t("account_updated")
       redirect_to account_url

--- a/auth/app/controllers/users_controller.rb
+++ b/auth/app/controllers/users_controller.rb
@@ -27,7 +27,7 @@ class UsersController < Spree::BaseController
       if params[:user][:password].present?
         # this logic needed b/c devise wants to log us out after password changes
         user = User.reset_password_by_token(params[:user])
-        sign_in(@user, :event => :authentication)
+        sign_in(@user, :event => :authentication, :bypass => true)
       end
       flash.notice = I18n.t("account_updated")
       redirect_to account_url

--- a/auth/features/account.feature
+++ b/auth/features/account.feature
@@ -27,11 +27,3 @@ Feature: Account
     When I sign in as "email@person.com/secret"
     And I follow "My Account"
     Then I should see "email@person.com"
-
-
-
-
-
-
-
-

--- a/auth/features/account.feature
+++ b/auth/features/account.feature
@@ -27,3 +27,17 @@ Feature: Account
     When I sign in as "email@person.com/secret"
     And I follow "My Account"
     Then I should see "email@person.com"
+
+  Scenario: existing user account editing
+    Given the following user exists:
+      | email            | password | password_confirmation |
+      | email@person.com | secret   | secret                |
+    And I go to the sign in page
+    When I sign in as "email@person.com/secret"
+    And I follow "My Account"
+    And I follow "Edit"
+    And I fill in "Password" with "foobar"
+    And I fill in "Password Confirmation" with "foobar"
+    And I press "Update"
+    Then I should see "email@person.com"
+    And I should see "Account updated!"

--- a/core/app/models/app_configuration.rb
+++ b/core/app/models/app_configuration.rb
@@ -33,6 +33,7 @@ class AppConfiguration < Configuration
   preference :cache_static_content, :boolean, :default => true
   preference :use_content_controller, :boolean, :default => true
   preference :allow_checkout_on_gateway_error, :boolean, :default => false
+  preference :signout_after_password_change, :boolean, :default => true
 
   validates :name, :presence => true, :uniqueness => true
 


### PR DESCRIPTION
As described in [this lighthouse ticket](http://railsdog.lighthouseapp.com/projects/31096-spree/tickets/1901-a-user-gets-signed-out-after-updating-his-password).

It fixes an issue where the user would be signed out after updating his password.
