### PR TITLE
mysql2 gem version conflict with rails 3.0.x

### DIFF
--- a/lib/generators/spree/test_app_generator.rb
+++ b/lib/generators/spree/test_app_generator.rb
@@ -82,9 +82,9 @@ module Spree
         silence_stream(STDOUT) {
           case database_name
           when "mysql"
-            gem "mysql2"
+            gem "mysql2", "0.2.7"
             append_file '../../Gemfile' do
-              "gem 'mysql2'"
+              "gem 'mysql2', '0.2.7'"
             end
           else
             gem "sqlite3-ruby"


### PR DESCRIPTION
The mysql2 gem version 0.3 requires Rails 3.1 or an adapter.  We can avoid requiring the adapter (which doesn't seem to exist) to be installed by locking the mysql2 version to 0.2.7.
