### PR TITLE
Uses objects instead of symbols to define property and taxon edit forms

### DIFF
--- a/core/app/views/admin/properties/edit.html.erb
+++ b/core/app/views/admin/properties/edit.html.erb
@@ -4,7 +4,7 @@
 
 <%= render 'shared/error_messages', :target => @property %>
 
-<%= form_for(:property, :url => object_url, :html => { :method => :put }) do |f| %>
+<%= form_for(@property, :url => object_url, :html => { :method => :put }) do |f| %>
   <%= render :partial => "form", :locals => { :f => f } %>
   <%= render :partial => 'admin/shared/edit_resource_links' %>
 <% end %>

--- a/core/app/views/admin/taxons/edit.html.erb
+++ b/core/app/views/admin/taxons/edit.html.erb
@@ -2,7 +2,7 @@
 
 <h1><%= t("taxon_edit")%></h1>
 
-<%= form_for(:taxon, :url => admin_taxonomy_taxon_url(@taxonomy, @taxon), :html => { :method => :put, :multipart => true}) do |f| %>
+<%= form_for(@taxon, :url => admin_taxonomy_taxon_url(@taxonomy, @taxon), :html => { :method => :put, :multipart => true}) do |f| %>
   <%= render :partial => 'form', :locals => {:f => f} %>
 
   <p class="form-buttons">


### PR DESCRIPTION
Using symbols instead of objects is causing issues with `fields_for` which I use in my [spree-simple_product_translations](https://github.com/jeroenj/spree-simple_product_translations) extension.
