### PR TITLE
move available preferences to a constant and minor HTML fixes and cleanup

### DIFF
--- a/core/app/controllers/admin/general_settings_controller.rb
+++ b/core/app/controllers/admin/general_settings_controller.rb
@@ -1,4 +1,9 @@
 class Admin::GeneralSettingsController < Admin::BaseController
+  before_filter :load_data
+
+  AVAILABLE_PREFERENCES = ['site_name', 'default_seo_title', 'default_meta_keywords',
+                       'default_meta_description', 'site_url', 'allow_ssl_in_production',
+                       'allow_ssl_in_development_and_test']
 
   def update
     @config = Spree::Config.instance
@@ -7,4 +12,8 @@ class Admin::GeneralSettingsController < Admin::BaseController
     redirect_to admin_general_settings_path
   end
 
+  private
+  def load_data
+    @preferences = AVAILABLE_PREFERENCES
+  end
 end

--- a/core/app/views/admin/general_settings/edit.html.erb
+++ b/core/app/views/admin/general_settings/edit.html.erb
@@ -1,11 +1,10 @@
 <%= render :partial => 'admin/shared/configuration_menu' %>
 
-<h1><%= t('edit_general_settings') %></h1>
+<h1><%= t(:edit_general_settings) %></h1>
 
 <%= form_for(Spree::Config.instance, :url => admin_general_settings_path) do |form| %>
   <fieldset id="preferences">
-  <% ['site_name', 'default_seo_title', 'default_meta_keywords', 'default_meta_description', 
-      'site_url', 'allow_ssl_in_production', 'allow_ssl_in_development_and_test'].each do |key| 
+  <% @preferences.each do |key|
       type = AppConfiguration.preference_definitions[key].instance_eval{@type}.to_sym
       field = "preferred_#{key}" %>
      <%= form.field_container field do %>
@@ -16,7 +15,7 @@
   <% end %>
   </fieldset>
   <p class="form-buttons">
-    <%= button t('update') %>
-    <%= t("or") %> <%= link_to t("cancel"), admin_general_settings_url %>
+    <%= button t(:update) %>
+    <%= t(:or) %> <%= link_to t(:cancel), admin_general_settings_url %>
   </p>
 <% end %>

--- a/core/app/views/admin/general_settings/show.html.erb
+++ b/core/app/views/admin/general_settings/show.html.erb
@@ -1,26 +1,26 @@
 <%= render :partial => 'admin/shared/configuration_menu' %>
 
-<h1><%= t("general_settings") %></h1>
+<h1><%= t(:general_settings) %></h1>
 
 <table>
-  <% ['site_name', 'default_seo_title', 'default_meta_keywords', 'default_meta_description', 
-      'site_url'].each do |key| %>
+  <% @preferences.each do |key| %>
     <tr>
       <th scope="row"><%= t(key) %>:</th>
       <td><%= Spree::Config[key] %></td>
     </tr>
   <% end %>
-	<td colspan="2">
-	  <%= (Spree::Config[:allow_ssl_in_production] ? t("ssl_will_be_used_in_production_mode") : t("ssl_will_not_be_used_in_production_mode")) %>
-	</td>
+  <tr>
+    <td colspan="2">
+      <%= (Spree::Config[:allow_ssl_in_production] ? t(:ssl_will_be_used_in_production_mode) : t(:ssl_will_not_be_used_in_production_mode)) %>
+    </td>
   </tr>
   <tr>
-	<td colspan="2">
-	  <%= (Spree::Config[:allow_ssl_in_development_and_test] ? t("ssl_will_be_used_in_development_and_test_modes") : t("ssl_will_not_be_used_in_development_and_test_modes")) %>
-	</td>
+    <td colspan="2">
+      <%= (Spree::Config[:allow_ssl_in_development_and_test] ? t(:ssl_will_be_used_in_development_and_test_modes) : t(:ssl_will_not_be_used_in_development_and_test_modes)) %>
+    </td>
   </tr>
 </table>
 
-<p><%= link_to_with_icon 'edit', t("edit"), edit_admin_general_settings_path, :id => 'admin_general_settings_link' %></p>
+<p><%= link_to_with_icon 'edit', t(:edit), edit_admin_general_settings_path, :id => 'admin_general_settings_link' %></p>
 
 


### PR DESCRIPTION
I moved available preferences array out of the view and into a constant in Admin::GeneralSettings controller like we did with Admin::ReportsController for dynamic extension sake.
