### PR TITLE
Adds tab highlight when on admin/products/images

### DIFF
--- a/core/app/views/admin/shared/_tabs.html.erb
+++ b/core/app/views/admin/shared/_tabs.html.erb
@@ -1,6 +1,6 @@
 <%= tab :overview, :route => :admin %>
 <%= tab :orders, :payments, :creditcard_payments, :shipments, :creditcards, :return_authorizations %>
-<%= tab :products , :option_types, :properties, :prototypes, :variants, :product_properties, :taxons %>
+<%= tab :products, :option_types, :properties, :prototypes, :images, :variants, :product_properties, :taxons %>
 <%= tab :reports %>
 <%= tab :configurations, :general_settings, :mail_methods, :tax_categories, :zones, :states, :payment_methods, :inventory_settings, :taxonomies, :shipping_methods, :trackers, :label => 'configuration' %>
 <%= tab :users %>


### PR DESCRIPTION
When on the images page inside admin/products, the products tab isn't highlighted as active. With this patch it is.
