### PR TITLE
Added missing 'taxonomy' translation and fix notice flash view

### DIFF
--- a/core/app/views/layouts/admin.html.erb
+++ b/core/app/views/layouts/admin.html.erb
@@ -35,10 +35,10 @@
 
 
     <% if flash[:error] %>
-    <div class="flash error"><%= flash[:error] %></div>
+    <div class="flash error"><%== flash[:error] %></div>
     <% end %>
     <% if self.notice %>
-    <div class="flash notice"><%= self.notice %></div>
+    <div class="flash notice"><%== self.notice %></div>
     <% end %>
 
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -950,6 +950,7 @@ en:
   tax_type: "Tax Type"
   taxon: Taxon
   taxon_edit: Edit Taxon
+  taxonomy: Taxonomy
   taxonomies: Taxonomies
   taxonomies_setting_description: "Create and manage taxonomies."
   taxonomy_edit: "Edit taxonomy"


### PR DESCRIPTION
When Update one Taxonomy, the flash message is not fully translated, missing 'taxonomy' string and the string quote symbol is not escaped too.

Step to reproduce:
1. Login into Admin
2. Go to Configuration > Taxonomy
3. Edit one Taxonomy
4. Press Update
