### PR TITLE
fix error message css for checkout for guest

### DIFF
--- a/core/public/stylesheets/screen.css
+++ b/core/public/stylesheets/screen.css
@@ -509,6 +509,7 @@ ul#nav-bar li.cart-indicator a.full { background-image: url(../images/cart-full_
   background: #f4b4b4 url(../images/shadow_top.png) 0px -50px repeat-x;
   color: #000000;
   border: 1px solid #000000;
+  float: left;
 }
 .errorExplanation p { margin: 0px; }
 .errorExplanation ul { margin-bottom: 0px; }


### PR DESCRIPTION
Flash error message overlap the 'Login as Exisiting customer' heading.

How to produce the bug:
1. Add item, checkout
2. At /checkout/registration, leave email field of Checkout as Guest empty and hit Continue button

Fix:
Simply float the errorExplanation box
