### PR TITLE
The checkout Address form should default to the default_country_id

### DIFF
--- a/core/app/helpers/checkout_helper.rb
+++ b/core/app/helpers/checkout_helper.rb
@@ -34,23 +34,25 @@ module CheckoutHelper
 
   module FormBuilder
     
-    def address_country_select(available_countries, options = {}, html_options = {})
-      options[:selected] = Spree::Config[:default_country_id]
-      html_options[:class] = 'required'
+    def address_country_select(available_countries, options = {:selected => Spree::Config[:default_country_id]}, html_options = {:class => 'required'})
       collection_select :country_id, available_countries, :id, :name, options, html_options
     end
     
-    def address_state_select(order_part, options = {}, html_options = {})
-      have_states = !order_part.country.states.empty?
+    def address_state_select(states, options = {:include_blank => true}, html_options = {:class => 'required'})
+      have_states = !states.empty?
+      
+      select_html_options = html_options
+      text_field_html_options = html_options
+      
+      select_html_options[:class] = 'hidden' if !have_states
+      select_html_options[:disabled] = !have_states
+      
+      text_field_html_options[:class] = 'hidden' if have_states
+      text_field_html_options[:disabled] = have_states
 
       state_elements =
-        collection_select(:state_id, order_part.country.states,
-                  :id, :name,
-                  {:include_blank => true},
-                  {:class => have_states ? "required" : "hidden", :disabled => !have_states}) +
-        text_field(:state_name,
-                  :class => !have_states ? "required" : "hidden",
-                  :disabled => have_states)
+        collection_select(:state_id, states, :id, :name, options, select_html_options) +
+        text_field(:state_name, text_field_html_options)
       
       @template.javascript_tag('document.write("' + state_elements.gsub('"', "'").gsub("\n", "") + '");') +
       @template.content_tag(:noscript, text_field(:state_name), :class => 'required')

--- a/core/app/helpers/checkout_helper.rb
+++ b/core/app/helpers/checkout_helper.rb
@@ -32,4 +32,31 @@ module CheckoutHelper
     content_tag('ol', raw(items.join("\n")), :class => 'progress-steps', :id => "checkout-step-#{@order.state}")
   end
 
+  module FormBuilder
+    
+    def address_country_select(available_countries, options = {}, html_options = {})
+      options[:selected] = Spree::Config[:default_country_id]
+      html_options[:class] = 'required'
+      collection_select :country_id, available_countries, :id, :name, options, html_options
+    end
+    
+    def address_state_select(order_part, options = {}, html_options = {})
+      have_states = !order_part.country.states.empty?
+
+      state_elements =
+        collection_select(:state_id, order_part.country.states,
+                  :id, :name,
+                  {:include_blank => true},
+                  {:class => have_states ? "required" : "hidden", :disabled => !have_states}) +
+        text_field(:state_name,
+                  :class => !have_states ? "required" : "hidden",
+                  :disabled => have_states)
+      
+      @template.javascript_tag('document.write("' + state_elements.gsub('"', "'").gsub("\n", "") + '");') +
+      @template.content_tag(:noscript, text_field(:state_name), :class => 'required')
+    end
+    
+  end
 end
+
+ActionView::Helpers::FormBuilder.send(:include, CheckoutHelper::FormBuilder)

--- a/core/app/views/checkout/_address.html.erb
+++ b/core/app/views/checkout/_address.html.erb
@@ -30,27 +30,8 @@ div.inner input[type=text], div.inner select { width: 80%; }
       <% if Spree::Config[:address_requires_state] %>
         <p class="field">
           <span id="bstate">
-            <% have_states = !@order.bill_address.country.states.empty? %>
             <%= bill_form.label :state, t(:state) %>
-            <noscript>
-              <%= bill_form.text_field :state_name, :class => 'required' %>
-            </noscript>
-            <% state_elements = [
-               bill_form.collection_select(:state_id, @order.bill_address.country.states,
-                                  :id, :name,
-                                  {:include_blank => true},
-                                  {:class => have_states ? "required" : "hidden",
-                                  :disabled => !have_states}) +
-                bill_form.text_field(:state_name,
-                                  :class => !have_states ? "required" : "hidden",
-                                  :disabled => have_states)
-                ].join.gsub('"', "'").gsub("\n", "")
-            %>
-            <script type="text/javascript" language="javascript" charset="utf-8">
-            // <![CDATA[
-            document.write("<%== state_elements %>");
-            // ]]>
-            </script>
+            <%= bill_form.address_state_select @order.bill_address %>
           </span>
           <span class="req">*</span>
         </p>
@@ -61,7 +42,7 @@ div.inner input[type=text], div.inner select { width: 80%; }
       </p>
       <p id="bcountry" class="field">
         <%= bill_form.label :country_id, t(:country) %>
-        <span id="bcountry"><%= bill_form.collection_select :country_id, available_countries, :id, :name, {}, {:class => 'required'} %></span>
+        <span id="bcountry"><%= bill_form.address_country_select available_countries %></span>
         <span class="req">*</span>
       </p>
       <p id="bphone" class="field">
@@ -109,27 +90,8 @@ div.inner input[type=text], div.inner select { width: 80%; }
       <% if Spree::Config[:address_requires_state] %>
         <p class="field">
           <span id="sstate">
-            <% have_states = !@order.ship_address.country.states.empty? %>
             <%= ship_form.label :state, t(:state) %>
-            <noscript>
-              <%= ship_form.text_field :state_name, :class => 'required' %>
-            </noscript>
-            <% state_elements = [
-                  ship_form.collection_select(:state_id, @order.bill_address.country.states,
-                                    :id, :name,
-                                    {:include_blank => true},
-                                    {:class => have_states ? "required" : "hidden",
-                                    :disabled => !have_states}) +
-                  ship_form.text_field(:state_name,
-                                    :class => !have_states ? "required" : "hidden",
-                                    :disabled => have_states)
-                ].join.gsub('"', "'").gsub("\n", "")
-            %>
-            <script type="text/javascript" language="javascript" charset="utf-8">
-            // <![CDATA[
-            document.write("<%== state_elements %>");
-            // ]]>
-            </script>
+            <%= ship_form.address_state_select @order.ship_address %>
           </span>
           <span class="req">*</span>
         </p>
@@ -140,7 +102,7 @@ div.inner input[type=text], div.inner select { width: 80%; }
       </p>
       <p id="scountry" class="field">
         <%= ship_form.label :country_id, t(:country) %>
-        <span id="scountry"><%= ship_form.collection_select :country_id, available_countries, :id, :name, {}, {:class => 'required'} %></span>
+        <span id="scountry"><%= ship_form.address_country_select available_countries %></span>
         <span class="req">*</span>
       </p>
       <p id="sphone" class="field">

--- a/core/app/views/checkout/_address.html.erb
+++ b/core/app/views/checkout/_address.html.erb
@@ -31,7 +31,7 @@ div.inner input[type=text], div.inner select { width: 80%; }
         <p class="field">
           <span id="bstate">
             <%= bill_form.label :state, t(:state) %>
-            <%= bill_form.address_state_select @order.bill_address %>
+            <%= bill_form.address_state_select @order.bill_address.country.states %>
           </span>
           <span class="req">*</span>
         </p>
@@ -91,7 +91,7 @@ div.inner input[type=text], div.inner select { width: 80%; }
         <p class="field">
           <span id="sstate">
             <%= ship_form.label :state, t(:state) %>
-            <%= ship_form.address_state_select @order.ship_address %>
+            <%= ship_form.address_state_select @order.ship_address.country.states %>
           </span>
           <span class="req">*</span>
         </p>


### PR DESCRIPTION
Hi Guys,

I have moved country and state selects out of the _address to a form builder... making them more DRY and override-able.

And set the selected :country_id to Spree::Config[:default_country_id] as the browser default doesn't work so well for users outside the US.
