### PR TITLE
Allows you to easily overwrite the translation of object_name in resource_controller by adding a method called translated_object_name.

### DIFF
--- a/core/app/controllers/admin/resource_controller.rb
+++ b/core/app/controllers/admin/resource_controller.rb
@@ -24,7 +24,7 @@ class Admin::ResourceController < Admin::BaseController
     invoke_callbacks(:update, :before)
     if @object.update_attributes(params[object_name])
       invoke_callbacks(:update, :after)
-      resource_desc = I18n.t(object_name)
+      resource_desc = translated_object_name
       resource_desc += " \"#{@object.name}\"" if @object.respond_to?(:name)
       flash[:notice] = I18n.t(:successfully_updated, :resource => resource_desc)
       respond_with(@object) do |format|
@@ -41,7 +41,7 @@ class Admin::ResourceController < Admin::BaseController
     invoke_callbacks(:create, :before)
     if @object.save
       invoke_callbacks(:create, :after)
-      resource_desc = I18n.t(object_name)
+      resource_desc = translated_object_name
       resource_desc += " \"#{@object.name}\"" if @object.respond_to?(:name)
       flash[:notice] = I18n.t(:successfully_created, :resource => resource_desc)
       respond_with(@object) do |format|
@@ -58,7 +58,7 @@ class Admin::ResourceController < Admin::BaseController
     invoke_callbacks(:destroy, :before)
     if @object.destroy
       invoke_callbacks(:destroy, :after)
-      resource_desc = I18n.t(object_name)
+      resource_desc = translated_object_name
       resource_desc += " \"#{@object.name}\"" if @object.respond_to?(:name)
       flash[:notice] = I18n.t(:successfully_removed, :resource => resource_desc)
       respond_with(@object) do |format|
@@ -104,6 +104,10 @@ class Admin::ResourceController < Admin::BaseController
 
   def model_class
     controller_name.classify.constantize
+  end
+
+  def translated_object_name
+    I18n.t(object_name)
   end
 
   def object_name


### PR DESCRIPTION
By adding the `translated_object_name` method, users and extension developers can easily avoid errors that would otherwise be caused by resource_controller looking up the `object_name` in a translation file.

For example, If I store my models attributes in my en.yml like so: (and I often do)

```
en: 
  post:
    title: Title
    posted_at: Posted At
    body: Body
    ...
```

Then resource controller would try to make the flash message out of a hash in any of the actions:

```
def update
  invoke_callbacks(:update, :before)
  if @object.update_attributes(params[object_name])
    invoke_callbacks(:update, :after)

    # object_name in this case is 'post'
    resource_desc = I18n.t(object_name)

    resource_desc += " \"#{@object.name}\"" if @object.respond_to?(:name)
    flash[:notice] = I18n.t(:successfully_updated, :resource => resource_desc)
    respond_with(@object) do |format|
      format.html { redirect_to location_after_save }
      format.js   { render :layout => false }
    end
  else
    invoke_callbacks(:update, :fails)
    respond_with(@object)
  end
end
```

This raises a NoMethod error:
### NoMethodError in Admin::Blog::PostsController#update
#### undefined method `+' for #Hash:0x000001067aac40

After this patch, I could easily avoid this error by adding this method and the appropriate translation to my en.yml:

```
def translated_object_name
  I18n.t("post.model_name")
end
```

Thanks!
