### PR TITLE
Uses originator_type instead of label for Adjustment tax and Shipping scopes.

### DIFF
--- a/core/app/models/adjustment.rb
+++ b/core/app/models/adjustment.rb
@@ -28,8 +28,8 @@ class Adjustment < ActiveRecord::Base
   validates :label, :presence => true
   validates :amount, :numericality => true
 
-  scope :tax, lambda { where(:label => I18n.t(:tax)) }
-  scope :shipping, lambda { where(:label => I18n.t(:shipping)) }
+  scope :tax, lambda { where(:originator_type => 'TaxRate') }
+  scope :shipping, lambda { where(:originator_type => 'ShippingMethod') }
   scope :optional, where(:mandatory => false)
   scope :eligible, where(:eligible => true)
 


### PR DESCRIPTION
Currently adjustments have a label which is an I18n translation. There is however one issue with that: if I create an adjustment coming from an English locale, a tax rate will be saved with the "Tax" label. If I then change the locale to something else (let's say Dutch in this example), and I perform a lookup of adjustments with the `tax` scope, I won't see those adjustments since it's trying to find adjustments with the Dutch label of `:tax` (which is "BTW" in this example).

An example of this in console:

```
ruby-1.8.7-p334 :002 > I18n.locale
 => :en
ruby-1.8.7-p334 :003 > order.adjustments
+-----+----------+--------+------------+...+-----------------+
| id  | order_id | amount | label      |...| originator_type |
+-----+----------+--------+------------+...+-----------------+
| 552 | 109      | 10.0   | verzending |...| ShippingMethod  |
| 556 | 109      | -6.0   | korting    |...| Discount        |
| 557 | 109      | 44.93  | BTW        |...| TaxRate         |
| 558 | 109      | 0.0    | BTW        |...| TaxRate         |
| 559 | 109      | 2.1    | BTW        |...| TaxRate         |
+-----+----------+--------+------------+...+-----------------+
5 rows in set
ruby-1.8.7-p334 :004 > order.adjustments.tax
# => Adjustment Load (2.8ms)  SELECT `adjustments`.* FROM `adjustments` WHERE `adjustments`.`label` = 'Tax' AND (`adjustments`.order_id = 109)
=> []
ruby-1.8.7-p334 :005 > I18n.locale = :nl
=> :nl
ruby-1.8.7-p334 :006 > order.adjustments.tax
# => Adjustment Load (3.8ms)  SELECT `adjustments`.* FROM `adjustments` WHERE `adjustments`.`label` = 'BTW' AND (`adjustments`.order_id = 109)
+-----+----------+--------+-------+...+-----------------+
| id  | order_id | amount | label |...| originator_type |
+-----+----------+--------+-------+...+-----------------+
| 557 | 109      | 44.93  | BTW   |...| TaxRate         |
| 558 | 109      | 0.0    | BTW   |...| TaxRate         |
| 559 | 109      | 2.1    | BTW   |...| TaxRate         |
+-----+----------+--------+-------+...+-----------------+
3 rows in set
```

In my opinion these labels shouldn't be stored in the database. You can go through the originator relationship to fetch which type of adjustment it is, and define the label in there (with I18n).

In this pull request I have already updated the scopes for adjustments that do the type filtering. Instead of using the label it's using the originator_type to filter. This already fixed a part of the problem for me. Displaying the label however is still in the locale it got saved into the database.
