### PR TITLE
Rails3 1

### DIFF
--- a/core/app/models/gateway.rb
+++ b/core/app/models/gateway.rb
@@ -17,6 +17,7 @@ class Gateway < PaymentMethod
 
   def provider
     gateway_options = options
+    gateway_options.delete :login if gateway_options.has_key?(:login) and gateway_options[:login].nil?
     ActiveMerchant::Billing::Base.gateway_mode = gateway_options[:server].to_sym
     @provider ||= provider_class.new(gateway_options)
   end

--- a/core/spec/models/gateway/braintree_spec.rb
+++ b/core/spec/models/gateway/braintree_spec.rb
@@ -36,6 +36,10 @@ describe Gateway::Braintree do
   it "should be braintree gateway" do
     @gateway.provider_class.should == ::ActiveMerchant::Billing::BraintreeGateway
   end
+  
+  it "should be the Blue Braintree" do
+    @gateway.provider.class.should == ::ActiveMerchant::Billing::BraintreeBlueGateway
+  end
 
   describe "authorize" do
     it "should return a success response with an authorization code" do
@@ -45,8 +49,12 @@ describe Gateway::Braintree do
                                                         :public_key=> "ym9djwqpkxbv3xzt",
                                                         :private_key=> "4ghghkyp2yy6yqc8"})
 
+      
+      
       result.success?.should be_true
       result.authorization.should match(/\A\w{6}\z/)
+      
+      
       Braintree::Transaction::Status::Authorized.should == Braintree::Transaction.find(result.authorization).status
    end
 


### PR DESCRIPTION
remove :login from option hash when this is nil since braintree initializer only looks at this key being present.
