### PR TITLE
Capture and void emails, html formatted emails

### DIFF
--- a/auth/app/views/users/show.html.erb
+++ b/auth/app/views/users/show.html.erb
@@ -26,7 +26,7 @@
       <tbody>
       <% @orders.each do |order| %>
         <tr class="<%= cycle('even', 'odd') %>">
-          <td><%= link_to order.number, order_url(order) %></td>
+          <td><%= link_to order.number, order_path(order) %></td>
           <td><%=order.created_at.to_date%></td>
           <td><%= t(order.state).titleize %></td>
           <td><%= t("payment_states.#{order.payment_state}") if order.payment_state %></td>

--- a/core/app/controllers/admin/payments_controller.rb
+++ b/core/app/controllers/admin/payments_controller.rb
@@ -54,6 +54,11 @@ class Admin::PaymentsController < Admin::BaseController
     return unless event = params[:e] and @payment.payment_source
     if @payment.payment_source.send("#{event}", @payment)
       flash.notice = t('payment_updated')
+      if event == 'capture'
+        OrderMailer.capture_email(@order).deliver
+      elsif event == 'void'
+        OrderMailer.void_email(@order).deliver
+      end
     else
       flash[:error] = t('cannot_perform_operation')
     end

--- a/core/app/mailers/order_mailer.rb
+++ b/core/app/mailers/order_mailer.rb
@@ -6,7 +6,32 @@ class OrderMailer < ActionMailer::Base
     subject = (resend ? "[RESEND] " : "")
     subject += "#{Spree::Config[:site_name]} #{t('subject', :scope =>'order_mailer.confirm_email')} ##{order.number}"
     mail(:to => order.email,
-         :subject => subject)
+         :subject => subject) do |format|
+            format.text
+            format.html
+    end
+  end
+
+  def capture_email(order, resend=false)
+    @order = order
+    subject = (resend ? "[RESEND] " : "")
+    subject += "#{Spree::Config[:site_name]} #{t('subject', :scope =>'order_mailer.capture_email')} ##{order.number}"
+    mail(:to => order.email,
+         :subject => subject) do |format|
+            format.text
+            format.html
+    end
+  end
+
+  def void_email(order, resend=false)
+    @order = order
+    subject = (resend ? "[RESEND] " : "")
+    subject += "#{Spree::Config[:site_name]} #{t('subject', :scope =>'order_mailer.void_email')} ##{order.number}"
+    mail(:to => order.email,
+         :subject => subject) do |format|
+            format.text
+            format.html
+    end
   end
 
   def cancel_email(order, resend=false)
@@ -14,6 +39,9 @@ class OrderMailer < ActionMailer::Base
     subject = (resend ? "[RESEND] " : "")
     subject += "#{Spree::Config[:site_name]} #{t('subject', :scope => 'order_mailer.cancel_email')} ##{order.number}"
     mail(:to => order.email,
-         :subject => subject)
+         :subject => subject) do |format|
+            format.text
+            format.html
+    end
   end
 end

--- a/core/app/views/order_mailer/cancel_email.html.erb
+++ b/core/app/views/order_mailer/cancel_email.html.erb
@@ -1,0 +1,24 @@
+<html>
+<body>
+<p>Dear Customer,</p>
+
+<p>Your order has been CANCELED.  Please retain this cancellation information for your records.</p>
+
+<hr/>
+<h5>Order Summary [CANCELED]</h5>
+<hr/>
+<pre>
+<% for item in @order.line_items %>
+<%=item.variant.sku %> <%=item.variant.product.name%> <%= variant_options(item.variant) %> (<%=item.quantity%>) @ <%= number_to_currency item.price %> = <%= number_to_currency(item.price * item.quantity) %>
+<% end %>
+</pre>
+<hr/>
+<pre>
+Subtotal: <%= number_to_currency @order.item_total %>
+<% @order.adjustments.each do |adjustment| %>
+<%= "#{adjustment.label}: #{number_to_currency adjustment.amount}"%>
+<% end %>
+Order Total: <%= number_to_currency @order.total %>
+</pre>
+</body>
+</html>

--- a/core/app/views/order_mailer/capture_email.html.erb
+++ b/core/app/views/order_mailer/capture_email.html.erb
@@ -1,0 +1,29 @@
+<html>
+<body>
+<p>Dear Customer,</p>
+
+<p>Your account has been charged for the amount shown.</p>
+
+<p>Please review and retain the following order information for your records.</p>
+
+<p>This email is informational only.  No action is required on your part.</p>
+
+<hr/>
+<h5>Order Summary</h5>
+<hr/>
+<pre>
+<% for item in @order.line_items %>
+<%=item.variant.sku %> <%=item.variant.product.name%> <%= variant_options(item.variant) %> (<%=item.quantity%>) @ <%= number_to_currency item.price %> = <%= number_to_currency(item.price * item.quantity) %>
+<% end %>
+</pre>
+<hr/>
+<pre>
+Subtotal: <%= number_to_currency @order.item_total %>
+<% @order.adjustments.each do |adjustment| %>
+<%= "#{adjustment.label}: #{number_to_currency adjustment.amount}"%>
+<% end %>
+Order Total: <%= number_to_currency @order.total %>
+</pre>
+<p>Thank you for your business.</p>
+</body>
+</html>

--- a/core/app/views/order_mailer/capture_email.text.erb
+++ b/core/app/views/order_mailer/capture_email.text.erb
@@ -1,0 +1,23 @@
+Dear Customer,
+
+Your account has been charged for the amount shown.
+
+Please review and retain the following order information for your records.
+
+This email is informational only.  No action is required on your part.
+
+============================================================
+Order Summary
+============================================================
+<% for item in @order.line_items %>
+<%=item.variant.sku %> <%=item.variant.product.name%> <%= variant_options(item.variant) %> (<%=item.quantity%>) @ <%= number_to_currency item.price %> = <%= number_to_currency(item.price * item.quantity) %>
+<% end %>
+============================================================
+Subtotal: <%= number_to_currency @order.item_total %>
+<% @order.adjustments.each do |adjustment| %>
+<%= "#{adjustment.label}: #{number_to_currency adjustment.amount}"%>
+<% end %>
+Order Total: <%= number_to_currency @order.total %>
+
+
+Thank you for your business.

--- a/core/app/views/order_mailer/confirm_email.html.erb
+++ b/core/app/views/order_mailer/confirm_email.html.erb
@@ -1,0 +1,25 @@
+<html>
+<body>
+<p>Dear Customer,</p>
+
+<p>Please review and retain the following order information for your records.</p>
+
+<hr/>
+<h5>Order Summary</h5>
+<hr/>
+<pre>
+<% for item in @order.line_items %>
+<%=item.variant.sku %> <%=item.variant.product.name%> <%= variant_options(item.variant) %> (<%=item.quantity%>) @ <%= number_to_currency item.price %> = <%= number_to_currency(item.price * item.quantity) %>
+<% end %>
+</pre>
+<hr/>
+<pre>
+Subtotal: <%= number_to_currency @order.item_total %>
+<% @order.adjustments.each do |adjustment| %>
+<%= "#{adjustment.label}: #{number_to_currency adjustment.amount}"%>
+<% end %>
+Order Total: <%= number_to_currency @order.total %>
+</pre>
+<p>Thank you for your business.</p>
+</body>
+</html>

--- a/core/app/views/order_mailer/void_email.html.erb
+++ b/core/app/views/order_mailer/void_email.html.erb
@@ -1,0 +1,28 @@
+<html>
+<body>
+<p>Dear Customer,</p>
+
+<p>The pending transaction on your account has been voided.</p>
+
+<p>Please review and retain the following order information for your records.</p>
+
+<p>This email is informational only.  No action is required on your part.</p>
+
+<hr/>
+<h5>Order Summary [VOIDED]</h5>
+<hr/>
+<pre>
+<% for item in @order.line_items %>
+<%=item.variant.sku %> <%=item.variant.product.name%> <%= variant_options(item.variant) %> (<%=item.quantity%>) @ <%= number_to_currency item.price %> = <%= number_to_currency(item.price * item.quantity) %>
+<% end %>
+</pre>
+<hr/>
+<pre>
+Subtotal: <%= number_to_currency @order.item_total %>
+<% @order.adjustments.each do |adjustment| %>
+<%= "#{adjustment.label}: #{number_to_currency adjustment.amount}"%>
+<% end %>
+Order Total: <%= number_to_currency @order.total %>
+</pre>
+</body>
+</html>

--- a/core/app/views/order_mailer/void_email.text.erb
+++ b/core/app/views/order_mailer/void_email.text.erb
@@ -1,0 +1,20 @@
+Dear Customer,
+
+The pending transaction on your account has been voided.
+
+Please review and retain the following order information for your records.
+
+This email is informational only.  No action is required on your part.
+
+============================================================
+Order Summary [VOIDED]
+============================================================
+<% for item in @order.line_items %>
+<%=item.variant.sku %> <%=item.variant.product.name%> <%= variant_options(item.variant) %> (<%=item.quantity%>) @ <%= number_to_currency item.price %> = <%= number_to_currency(item.price * item.quantity) %>
+<% end %>
+============================================================
+Subtotal: <%= number_to_currency @order.item_total %>
+<% @order.adjustments.each do |adjustment| %>
+<%= "#{adjustment.label}: #{number_to_currency adjustment.amount}"%>
+<% end %>
+Order Total: <%= number_to_currency @order.total %>

--- a/core/app/views/products/_cart_form.html.erb
+++ b/core/app/views/products/_cart_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for :order, :url => populate_orders_url do |f| %>
+<%= form_for :order, :url => populate_orders_path do |f| %>
   <div data-hook="inside_product_cart_form">
 
     <% if @product.price %>

--- a/core/app/views/shared/_search.html.erb
+++ b/core/app/views/shared/_search.html.erb
@@ -1,5 +1,5 @@
 <% @taxons = @taxon && @taxon.parent ? @taxon.parent.children : Taxon.roots  %> 
-<%= form_tag products_url, :method => :get do %>
+<%= form_tag products_path, :method => :get do %>
   <%= select_tag :taxon, 
         options_for_select([[t(:all_departments), '']] + 
                               @taxons.map {|t| [t.name, t.id]}, 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -591,6 +591,10 @@ en:
       subject:  "Order Confirmation"
     cancel_email:
       subject: "Cancellation of Order"
+    capture_email:
+      subject: "Transaction Processing Complete"
+    void_email:
+      subject: "Transaction Voided"
   order_not_in_system: That order number is not valid on this site.
   order_number: Order
   order_operation_authorize: Authorize


### PR DESCRIPTION
For your consideration.  My team wanted email notifications for the capture and void actions, available through the order administration interface.  These are now available as "capture_email" and "void_email".

Perhaps it would be nice to have them as optional from the mail configuration interface.  I could certainly see different organizations having different requirements about what automated communications are received by the customer.  I'm not savvy enough to make such a modification yet.

Also, we wanted email that supports both text as well as html in the same mail.  If you look at one of the text emails in Outlook, the last horizontal rule of '='s gets moved up to the line above since it is a single linebreak  and Outlook tries to reflow the text-based emails much like markdown would.  Don't ask me why it doesn't do that to the individual line items as well.

In any case, see if there's anything you would consider bringing on board here.

I apologize for the lack of user info (I'm listed as unknows) on the commit, it's my first push to github from my box and I apparently didn't get my user info configured.
