### PR TITLE
RubyGems could not find devise 1.4.0 (rails3-1)

### DIFF
--- a/auth/spree_auth.gemspec
+++ b/auth/spree_auth.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency('spree_core',  version)
-  s.add_dependency('devise', '= 1.4.0')
+  s.add_dependency('devise', '= 1.4.2')
   s.add_dependency('cancan', '= 1.6.4')
 end


### PR DESCRIPTION
Gem could not find devise 1.4.0, it did not exists. Replaced with current version (v1.4.2) instead.
