### PR TITLE
All JSON requests fail forgery protection in test environment

### DIFF
--- a/core/app/controllers/admin/base_controller.rb
+++ b/core/app/controllers/admin/base_controller.rb
@@ -20,6 +20,7 @@ class Admin::BaseController < Spree::BaseController
   # Index request for JSON needs to pass a CSRF token in order to prevent JSON Hijacking
   def check_json_authenticity
     return unless request.format.js? or request.format.json?
+    return unless protect_against_forgery?
     auth_token = params[request_forgery_protection_token]
     unless (auth_token and form_authenticity_token == auth_token.gsub(' ', '+'))
       raise(ActionController::InvalidAuthenticityToken)

--- a/core/spec/controllers/admin/products_controller_spec.rb
+++ b/core/spec/controllers/admin/products_controller_spec.rb
@@ -3,11 +3,26 @@ require File.dirname(__FILE__) + '/../../spec_helper'
 describe Admin::ProductsController do
   context "#index" do
     it "should not allow JSON request without a valid token" do
+      controller.should_receive(:protect_against_forgery?).at_least(:once).and_return(true)
       expect {
         get :index, {:format => :json}
       }.to raise_error ActionController::InvalidAuthenticityToken
     end
+
+    it "should allow JSON request with missing token if forgery protection is disabled" do
+      controller.should_receive(:protect_against_forgery?).at_least(:once).and_return(false)
+      get :index, {:format => :json}
+      response.should be_success
+    end
+
+    it "should allow JSON request with invalid token if forgery protection is disabled" do
+      controller.should_receive(:protect_against_forgery?).at_least(:once).and_return(false)
+      get :index, {:authenticity_token => "XYZZY", :format => :json}
+      response.should be_success
+    end
+
     it "should allow JSON request with a valid token" do
+      controller.should_receive(:protect_against_forgery?).at_least(:once).and_return(true)
       controller.stub :form_authenticity_token => "123456"
       get :index, {:authenticity_token => "123456", :format => :json}
       response.should be_success

--- a/core/spec/controllers/admin/users_controller_spec.rb
+++ b/core/spec/controllers/admin/users_controller_spec.rb
@@ -3,11 +3,26 @@ require File.dirname(__FILE__) + '/../../spec_helper'
 describe Admin::UsersController do
   context "#index" do
     it "should not allow JSON request without a valid token" do
+      controller.should_receive(:protect_against_forgery?).at_least(:once).and_return(true)
       expect {
         get :index, {:format => :json}
       }.to raise_error ActionController::InvalidAuthenticityToken
     end
+
+    it "should allow JSON request with missing token if forgery protection is disabled" do
+      controller.should_receive(:protect_against_forgery?).at_least(:once).and_return(false)
+      get :index, {:format => :json}
+      response.should be_success
+    end
+
+    it "should allow JSON request with invalid token if forgery protection is disabled" do
+      controller.should_receive(:protect_against_forgery?).at_least(:once).and_return(false)
+      get :index, {:authenticity_token => "XYZZY", :format => :json}
+      response.should be_success
+    end
+
     it "should allow JSON request with a valid token" do
+      controller.should_receive(:protect_against_forgery?).at_least(:once).and_return(true)
       controller.stub :form_authenticity_token => "123456"
       get :index, {:authenticity_token => "123456", :format => :json}
       response.should be_success

--- a/dash/spec/controllers/admin/overview_controller_spec.rb
+++ b/dash/spec/controllers/admin/overview_controller_spec.rb
@@ -3,11 +3,26 @@ require 'spec_helper'
 describe Admin::OverviewController do
   context "#get_report_data" do
     it "should not allow JSON request without a valid token" do
+      controller.should_receive(:protect_against_forgery?).at_least(:once).and_return(true)
       expect {
         get :get_report_data, {:report => 'orders_totals', :name => "7_days", :format => :js}
       }.to raise_error ActionController::InvalidAuthenticityToken
     end
+
+    it "should allow JSON request with missing token if forgery protection is disabled" do
+      controller.should_receive(:protect_against_forgery?).at_least(:once).and_return(false)
+      get :get_report_data, {:report => 'orders_totals', :name => "7_days", :format => :js}
+      response.should be_success
+    end
+
+    it "should allow JSON request with invalid token if forgery protection is disabled" do
+      controller.should_receive(:protect_against_forgery?).at_least(:once).and_return(false)
+      get :get_report_data, {:report => 'orders_totals', :name => "7_days", :format => :js}
+      response.should be_success
+    end
+
     it "should allow JSON request with a valid token" do
+      controller.should_receive(:protect_against_forgery?).at_least(:once).and_return(true)
       controller.stub :form_authenticity_token => "123456"
       get :get_report_data, {:report => 'orders_totals', :name => "7_days", :authenticity_token => "123456", :format => :js}
       response.should be_success


### PR DESCRIPTION
This patch is for the 0-60-stable branch, but also also applies cleanly to master (3c3aa823693068521949f604a1adb47af199de40), where it should also be applied.

Previously, the Admin::BaseController#check_json_authenticity method was rejecting JSON requests in the test environment because the authenticity token was not provided (or was "undefined").

This change ensures that check_json_authenticity passes if forgery protection is turned off, allowing these requests to work in the test environment.
