### PR TITLE
Fix for issue #503

### DIFF
--- a/auth/app/controllers/user_registrations_controller.rb
+++ b/auth/app/controllers/user_registrations_controller.rb
@@ -18,7 +18,6 @@ class UserRegistrationsController < Devise::RegistrationsController
     logger.debug(@user)
     if resource.save
       set_flash_message(:notice, :signed_up)
-      ActiveSupport::Notifications.instrument('spree.user.signup', default_notification_payload.merge(:user => @user))
       fire_event('spree.user.signup', :user => @user)
       sign_in_and_redirect(:user, @user)
     else

--- a/auth/spec/controllers/user_registrations_controller_spec.rb
+++ b/auth/spec/controllers/user_registrations_controller_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe UserRegistrationsController do
+
+  context "#create" do
+    it "should fire exactly one spree.user.signup notification" do
+      activator = Activator.create!(:event_name => 'spree.user.signup')
+
+      ActiveSupport::Notifications.subscribe(/spree.user.signup/) { |*args| activator.activate }
+
+      activator.should_receive(:activate).once
+
+      new_user = Factory.build(:user)
+      post user_registration_path, {"commit"=>"Create", "user"=> {"password" => new_user.password, "password_confirmation" => new_user.password, "email" => new_user.email }}
+    end
+  end
+end

--- a/promo/app/models/promotion.rb
+++ b/promo/app/models/promotion.rb
@@ -64,7 +64,7 @@ class Promotion < Activator
   end
 
   def coupon_is_eligible?(order, code = nil)
-    return true if order.promotion_credit_exists?(self)
+    return true if order && order.promotion_credit_exists?(self)
     return true if event_name != 'spree.checkout.coupon_code_added'
     code.to_s.strip.downcase == preferred_code.to_s.strip.downcase
   end

--- a/promo/spec/models/promotion_spec.rb
+++ b/promo/spec/models/promotion_spec.rb
@@ -24,6 +24,12 @@ describe Promotion do
       promotion.promotion_actions = [@action1, @action2]
     end
 
+    context "when checking coupon_is_eligible?" do
+      it "should accommodate promotions that are not attached to orders" do
+        lambda {promotion.activate(:order => nil, :user => nil)}.should_not raise_error
+      end
+    end
+
     context "when eligible?" do
       before do
         promotion.stub(:eligible? => true)


### PR DESCRIPTION
We currently have two notification calls.  One is explicit, followed immediately by a call to fire_event, which does it again.

Test is attached.

Also, have a fix for promotions.  coupon_is_eligible? will crash if the promotion is not attached to an order.

A use case of "vouchers for store credit" will not be attached to an order.  
