### PR TITLE
529 fix order update payment state

### DIFF
--- a/core/app/models/order.rb
+++ b/core/app/models/order.rb
@@ -419,10 +419,10 @@ class Order < ActiveRecord::Base
   #
   # The +payment_state+ value helps with reporting, etc. since it provides a quick and easy way to locate Orders needing attention.
   def update_payment_state
-    if payment_total < total
+    if round_money(payment_total) < round_money(total)
       self.payment_state = "balance_due"
       self.payment_state = "failed" if payments.present? and payments.last.state == "failed"
-    elsif payment_total > total
+    elsif round_money(payment_total) > round_money(total)
       self.payment_state = "credit_owed"
     else
       self.payment_state = "paid"
@@ -432,12 +432,16 @@ class Order < ActiveRecord::Base
       self.state_events.create({
         :previous_state => old_payment_state,
         :next_state     => self.payment_state,
-        :name           => "payment" ,
+        :name           => "payment",
         :user_id        =>  (User.respond_to?(:current) && User.current && User.current.id) || self.user_id
       })
     end
   end
 
+  def round_money(n)
+    (n*100).round / 100.0
+  end
+  
   # Updates the following Order total values:
   #
   # +payment_total+      The total value of all finalized Payments (NOTE: non-finalized Payments are excluded)

--- a/core/spec/models/order_spec.rb
+++ b/core/spec/models/order_spec.rb
@@ -291,7 +291,7 @@ describe Order do
   context "#update!" do
     context "when payments are sufficient" do
       it "should set payment_state to paid" do
-        order.stub(:total => 100, :payment_total => 100)
+        order.stub(:total => 100.01, :payment_total => 100.012343)
         order.update!
         order.payment_state.should == "paid"
       end


### PR DESCRIPTION
fixing comparison of money in order model, was setting payment_state to balance_due because of rounding issues

[Fixes #529]
