### PR TITLE
0 60 stable - Creditcard#spree_cc_type

### DIFF
--- a/core/app/models/creditcard.rb
+++ b/core/app/models/creditcard.rb
@@ -2,6 +2,7 @@ class Creditcard < ActiveRecord::Base
   has_many :payments, :as => :source
 
   before_save :set_last_digits
+  after_validation :set_card_type
 
   attr_accessor :number, :verification_value
 
@@ -22,7 +23,20 @@ class Creditcard < ActiveRecord::Base
     verification_value.to_s.gsub!(/\s/,'') unless number.nil?
     self.last_digits ||= number.to_s.length <= 4 ? number : number.to_s.slice(-4..-1)
   end
-
+  
+  # cheap hack to get to the type? method from deep within ActiveMerchant without stomping on
+  # potentially existing methods in CreditCard
+  class CardDetector
+    class << self
+      include ActiveMerchant::Billing::CreditCardMethods::ClassMethods
+    end
+  end
+  
+  # sets self.cc_type while we still have the card number
+  def set_card_type
+    self.cc_type = CardDetector.type?(number)
+  end
+  
   def name?
     first_name? && last_name?
   end
@@ -239,8 +253,8 @@ class Creditcard < ActiveRecord::Base
   end
 
   def spree_cc_type
-    return "visa" if ENV['RAILS_ENV'] == "development"
-    self.class.type?(number)
+    return "visa" if ::Rails.env == "development"
+    self.cc_type
   end
 
   # Saftey check to make sure we're not accidentally performing operations on a live gateway.

--- a/core/app/models/creditcard.rb
+++ b/core/app/models/creditcard.rb
@@ -34,7 +34,7 @@ class Creditcard < ActiveRecord::Base
   
   # sets self.cc_type while we still have the card number
   def set_card_type
-    self.cc_type = CardDetector.type?(number)
+    self.cc_type ||= CardDetector.type?(self.number)
   end
   
   def name?

--- a/core/spec/models/creditcard_spec.rb
+++ b/core/spec/models/creditcard_spec.rb
@@ -76,7 +76,7 @@ describe Creditcard do
         @creditcard.authorize(100, @payment)
       end
     end
-    context "if unsucessfull" do
+    context "if unsuccessful" do
       it "should make payment failed" do
         @payment_gateway.stub(:authorize).and_return(@fail_response)
         @payment.should_receive(:fail)
@@ -103,7 +103,7 @@ describe Creditcard do
         lambda {@creditcard.purchase(100, @payment)}.should raise_error(Spree::GatewayError)
       end
     end
-    context "if sucessfull" do
+    context "if successful" do
       before do
         @payment_gateway.stub(:purchase).and_return(@success_response)
       end
@@ -117,7 +117,7 @@ describe Creditcard do
         @creditcard.purchase(100, @payment)
       end
     end
-    context "if unsucessfull" do
+    context "if unsuccessful" do
       it "should make payment failed" do
         @payment_gateway.stub(:purchase).and_return(@fail_response)
         @payment.should_receive(:fail)
@@ -151,7 +151,7 @@ describe Creditcard do
           lambda {@creditcard.capture(@payment)}.should raise_error(Spree::GatewayError)
         end
       end
-      context "if sucessfull" do
+      context "if successful" do
         it "should make payment complete" do
           @payment.should_receive(:complete)
           @creditcard.capture(@payment)
@@ -161,7 +161,7 @@ describe Creditcard do
           @payment.response_code.should == '123'
         end
       end
-      context "if unsucessfull" do
+      context "if unsuccessful" do
         it "should not make payment complete" do
           @payment_gateway.stub(:capture).and_return(@fail_response)
           @payment.should_receive(:fail)
@@ -202,7 +202,7 @@ describe Creditcard do
         lambda {@creditcard.void(@payment)}.should raise_error(Spree::GatewayError)
       end
     end
-    context "if sucessfull" do
+    context "if successful" do
       it "should update the response_code with the authorization from the gateway" do
         @payment.response_code = 'abc'
         @creditcard.void(@payment)
@@ -213,7 +213,7 @@ describe Creditcard do
         @creditcard.void(@payment)
       end
     end
-    context "if unsucesfull" do
+    context "if unsuccessful" do
       it "should not void the payment" do
         @payment_gateway.stub(:void).and_return(@fail_response)
         @payment.should_not_receive(:void)
@@ -295,7 +295,7 @@ describe Creditcard do
         end
       end
     end
-    context "when response is unsucessfull" do
+    context "when response is unsuccessful" do
       it "should not create a payment" do
         @payment_gateway.stub(:credit).and_return(@fail_response)
         Payment.should_not_receive(:create)
@@ -436,6 +436,10 @@ describe Creditcard do
         @creditcard.save
         @creditcard.spree_cc_type.should == "visa"
       end
+      
+      after do 
+        Rails.env = "test"
+      end
     end
 
     context "in production mode" do
@@ -447,6 +451,10 @@ describe Creditcard do
         @creditcard.number = "378282246310005"
         @creditcard.save
         @creditcard.spree_cc_type.should == "american_express"
+      end
+      
+      after do
+        Rails.env = "test"
       end
     end
   end
@@ -469,6 +477,10 @@ describe Creditcard do
       @creditcard.number = "XXXXXXXXXXXX5100"
       @creditcard.save
       @creditcard.spree_cc_type.should == "master"
+    end
+    
+    after do
+      Rails.env = "test"
     end
   end
 end

--- a/core/spec/models/creditcard_spec.rb
+++ b/core/spec/models/creditcard_spec.rb
@@ -422,5 +422,33 @@ describe Creditcard do
     end
   end
 
+  context "#spree_cc_type" do
+    before do
+      @creditcard.attributes = valid_creditcard_attributes
+      @creditcard.save
+      @creditcard = Creditcard.find(@creditcard.id)
+    end
+    
+    context "in development mode" do
+      before do
+        Rails.env = "development"
+      end
+      
+      it "should return visa" do
+        @creditcard.spree_cc_type.should == "visa"
+      end
+    end
+    context "in production mode" do
+      before do
+        Rails.env = "production"
+      end
+      
+      it "should return the actual cc_type for a valid number" do
+        @creditcard.number = "378282246310005"
+        @creditcard.save
+        @creditcard.spree_cc_type.should == "american_express"
+      end
+    end
+  end
 end
 

--- a/core/spec/models/creditcard_spec.rb
+++ b/core/spec/models/creditcard_spec.rb
@@ -425,19 +425,19 @@ describe Creditcard do
   context "#spree_cc_type" do
     before do
       @creditcard.attributes = valid_creditcard_attributes
-      @creditcard.save
-      @creditcard = Creditcard.find(@creditcard.id)
     end
-    
+
     context "in development mode" do
       before do
         Rails.env = "development"
       end
       
       it "should return visa" do
+        @creditcard.save
         @creditcard.spree_cc_type.should == "visa"
       end
     end
+
     context "in production mode" do
       before do
         Rails.env = "production"
@@ -448,6 +448,27 @@ describe Creditcard do
         @creditcard.save
         @creditcard.spree_cc_type.should == "american_express"
       end
+    end
+  end
+  
+  context "#set_card_type" do
+    before :each do
+      Rails.env = "production"
+      @creditcard.attributes = valid_creditcard_attributes
+    end
+    
+    it "stores the creditcard type after validation" do
+      @creditcard.number = "6011000990139424"
+      @creditcard.save
+      @creditcard.spree_cc_type.should == "discover"
+    end
+    
+    it "does not overwrite the creditcard type when loaded and saved" do
+      @creditcard.number = "5105105105105100"
+      @creditcard.save
+      @creditcard.number = "XXXXXXXXXXXX5100"
+      @creditcard.save
+      @creditcard.spree_cc_type.should == "master"
     end
   end
 end


### PR DESCRIPTION
Fixing the broken Creditcard#spree_cc_type method. Creditcard needs to store this info before we ditch the number. Specs included.
