### PR TITLE
Bumped acts_as_list to 0.1.4

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency('acts_as_list', '= 0.1.3')
+  s.add_dependency('acts_as_list', '= 0.1.4')
   s.add_dependency('nested_set', '= 1.6.7')
   s.add_dependency('rd_unobtrusive_date_picker', '= 0.1.0')
   s.add_dependency('rd_find_by_param', '= 0.1.1')


### PR DESCRIPTION
this gem is now dependent on sqlite3 gem instead of sqlite3-ruby gem which is more consistent with spree_core gem spec.
