### PR TITLE
DRY up Paperclip configuration.

### DIFF
--- a/core/app/models/image.rb
+++ b/core/app/models/image.rb
@@ -1,10 +1,7 @@
 class Image < Asset
   validate :no_attachement_errors
   has_attached_file :attachment,
-                    :styles => { :mini => '48x48>', :small => '100x100>', :product => '240x240>', :large => '600x600>' },
-                    :default_style => :product,
-                    :url => "/assets/products/:id/:style/:basename.:extension",
-                    :path => ":rails_root/public/assets/products/:id/:style/:basename.:extension"
+                    Spree::Paperclip::Config.to_h
 
   # save the w,h of the original image (from which others can be calculated)
   # we need to look at the write-queue for images which have not been saved yet

--- a/core/app/models/paperclip_configuration.rb
+++ b/core/app/models/paperclip_configuration.rb
@@ -1,0 +1,13 @@
+class PaperclipConfiguration < Configuration
+
+  preference :url,           :string,  :default => '/:class/:attachment/:id/:style_:filename'
+  preference :path,          :string,  :default => ':rails_root/public/assets/:class/:id/:style/:basename.:extension'
+  preference :default_url,   :string,  :default => '/images/noimage/:style.png'
+  preference :whiny,         :boolean, :default => false
+  preference :storage,       :string,  :default => :filesystem
+  preference :default_style, :symbol,  :default => :product
+  preference :styles,        :hash,    :default => { :mini => '48x48>', :small => '100x100>', :product => '240x240>', :large => '600x600>' }
+
+  validates :name, :presence => true, :uniqueness => true
+
+end

--- a/core/app/models/taxon.rb
+++ b/core/app/models/taxon.rb
@@ -7,11 +7,11 @@ class Taxon < ActiveRecord::Base
 
   validates :name, :presence => true
   has_attached_file :icon,
-                :styles => { :mini => '32x32>', :normal => '128x128>' },
-                :default_style => :mini,
-                :url => "/assets/taxons/:id/:style/:basename.:extension",
-                :path => ":rails_root/public/assets/taxons/:id/:style/:basename.:extension",
-                :default_url => "/assets/default_taxon.png"
+                Spree::Paperclip::Config.merge(
+                  :styles => { :mini => '32x32>', :normal => '128x128>' },
+                  :default_style => :mini,
+                  :default_url => "/images/default_taxon.png"
+                )
 
 
   include ::ProductFilters  # for detailed defs of filters

--- a/core/lib/spree/paperclip_config.rb
+++ b/core/lib/spree/paperclip_config.rb
@@ -1,0 +1,36 @@
+module Spree
+  module Paperclip
+    # Singleton class to access the Paperclip configuration object (PaperclipConfiguration.first by default) and it's preferecnes.
+    #
+    # Usage:
+    #   Spree::Paperclip::Config[:foo]                  # Returns the foo preference
+    #   Spree::Paperclip::Config[]                      # Returns a Hash with all the tax preferences
+    #   Spree::Paperclip::Config.instance               # Returns the configuration object (Paperclip.first)
+    #   Spree::Paperclip::Config.set(preferences_hash)  # Set the tax preferences as especified in 
+    class Config
+      include Singleton
+      include PreferenceAccess
+      class << self
+        def instance
+          return nil unless ActiveRecord::Base.connection.tables.include? 'configurations'
+          PaperclipConfiguration.find_or_create_by_name('Default Paperclip configuration.')
+        end
+
+        # Return the configuration as a hash, ready to be passed into has_attached_file
+        def to_h
+          {}.tap do |hash|
+            instance.preferences.each do |index,value|
+              hash[index.to_sym] = value
+            end
+          end
+        end
+
+        # Merge in the arguments to the defaults.
+        def merge opts={}
+          to_h.merge(opts)
+        end
+
+      end
+    end
+  end
+end

--- a/core/lib/spree_core.rb
+++ b/core/lib/spree_core.rb
@@ -67,6 +67,7 @@ require 'spree/mail_settings'
 require 'spree/mail_interceptor'
 require 'redirect_legacy_product_url'
 require 'middleware/seo_assist'
+require 'spree/paperclip_config'
 
 require 'spree_base' # added 11-3 JBD
 


### PR DESCRIPTION
I've just been through the difficultly of deploying using Rackspace CloudFiles as the storage engine for Paperclip.  I wound up ripping out most of the paperclip config and moving it into a preference model.
