### PR TITLE
Bumped jquery-rails to 1.0.13

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency('rd_unobtrusive_date_picker', '= 0.1.0')
   s.add_dependency('rd_find_by_param', '= 0.1.1')
 
-  s.add_dependency('jquery-rails', '>= 1.0.12')
+  s.add_dependency('jquery-rails', '>= 1.0.13')
   s.add_dependency('highline', '= 1.5.1')
   s.add_dependency('stringex', '= 1.0.3')
   s.add_dependency('state_machine', '= 1.0.1')


### PR DESCRIPTION
This is an important bump for its support of new jquery-ujs, novalidate form support.
