### PR TITLE
Fix path inclusion in case gems were not yet installed

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -90,7 +90,7 @@ end
 
 desc "Creates a sandbox application for simulating the Spree code in a deployed Rails app"
 task :sandbox do
-  require 'spree_core'
+  require File.expand_path("../core/lib/spree_core", __FILE__)
 
   SpreeCore::Generators::SandboxGenerator.start ["--lib_name=spree", "--database=#{ENV['DB_NAME']}"]
   SpreeCore::Generators::SiteGenerator.start

--- a/api/Rakefile
+++ b/api/Rakefile
@@ -4,7 +4,7 @@ require 'rake/packagetask'
 require 'rubygems/package_task'
 require 'rspec/core/rake_task'
 require 'cucumber/rake/task'
-require 'spree_core/testing_support/common_rake'
+require File.expand_path("../../core/lib/spree_core/testing_support/common_rake", __FILE__)
 
 RSpec::Core::RakeTask.new
 Cucumber::Rake::Task.new

--- a/api/lib/spree_api.rb
+++ b/api/lib/spree_api.rb
@@ -1,6 +1,6 @@
-require 'spree_core'
-require 'spree_auth'
-require 'spree_api_hooks'
+require File.expand_path("../../../core/lib/spree_core", __FILE__)
+require File.expand_path("../../../auth/lib/spree_auth", __FILE__)
+require File.expand_path("../spree_api_hooks", __FILE__)
 
 module SpreeApi
   class Engine < Rails::Engine

--- a/auth/Rakefile
+++ b/auth/Rakefile
@@ -5,7 +5,7 @@ require 'rake/packagetask'
 require 'rubygems/package_task'
 require 'rspec/core/rake_task'
 require 'cucumber/rake/task'
-require 'spree_core/testing_support/common_rake'
+require File.expand_path("../../core/lib/spree_core/testing_support/common_rake", __FILE__)
 
 RSpec::Core::RakeTask.new
 Cucumber::Rake::Task.new

--- a/auth/lib/spree_auth.rb
+++ b/auth/lib/spree_auth.rb
@@ -1,10 +1,10 @@
-require 'spree_core'
+require File.expand_path("../../../core/lib/spree_core", __FILE__)
 require 'devise'
 require 'cancan'
 
-require 'spree/auth/config'
-require 'spree/token_resource'
-require 'spree_auth_hooks'
+require File.expand_path("../spree/auth/config", __FILE__)
+require File.expand_path("../spree/token_resource", __FILE__)
+require File.expand_path("../spree_auth_hooks", __FILE__)
 
 module SpreeAuth
   class Engine < Rails::Engine

--- a/core/lib/spree_core.rb
+++ b/core/lib/spree_core.rb
@@ -41,45 +41,42 @@ require 'meta_search'
 require 'find_by_param'
 require 'jquery-rails'
 
-require 'spree_core/ext/active_record'
-require 'spree_core/ext/hash'
-
-require 'spree_core/delegate_belongs_to'
+require File.expand_path("../spree_core/ext/active_record", __FILE__)
+require File.expand_path("../spree_core/ext/hash", __FILE__)
+require File.expand_path("../spree_core/delegate_belongs_to", __FILE__)
 ActiveRecord::Base.send :include, DelegateBelongsTo
 
-require 'spree_core/theme_support'
-require 'spree_core/enumerable_constants'
+require File.expand_path("../spree_core/theme_support", __FILE__)
+require File.expand_path("../spree_core/enumerable_constants", __FILE__)
+require File.expand_path("../spree_core/spree_custom_responder", __FILE__)
+require File.expand_path("../spree_core/spree_respond_with", __FILE__)
 
-require 'spree_core/spree_custom_responder'
-require 'spree_core/spree_respond_with'
+require File.expand_path("../spree_core/ssl_requirement", __FILE__)
+require File.expand_path("../spree_core/preferences/model_hooks", __FILE__)
+require File.expand_path("../spree_core/preferences/preference_definition", __FILE__)
+require File.expand_path("../store_helpers", __FILE__)
+require File.expand_path("../spree/file_utilz", __FILE__)
+require File.expand_path("../spree/calculated_adjustments", __FILE__)
+require File.expand_path("../spree/current_order", __FILE__)
+require File.expand_path("../spree/preference_access", __FILE__)
+require File.expand_path("../spree/config", __FILE__)
+require File.expand_path("../spree/mail_settings", __FILE__)
+require File.expand_path("../spree/mail_interceptor", __FILE__)
+require File.expand_path("../redirect_legacy_product_url", __FILE__)
+require File.expand_path("../middleware/seo_assist", __FILE__)
 
-
-require 'spree_core/ssl_requirement'
-require 'spree_core/preferences/model_hooks'
-require 'spree_core/preferences/preference_definition'
-require 'store_helpers'
-require 'spree/file_utilz'
-require 'spree/calculated_adjustments'
-require 'spree/current_order'
-require 'spree/preference_access'
-require 'spree/config'
-require 'spree/mail_settings'
-require 'spree/mail_interceptor'
-require 'redirect_legacy_product_url'
-require 'middleware/seo_assist'
-
-require 'spree_base' # added 11-3 JBD
+require File.expand_path("../spree_base", __FILE__) # added 11-3 JBD
 
 silence_warnings do
-  require 'spree_core/authorize_net_cim_hack'
+  require File.expand_path("../spree_core/authorize_net_cim_hack", __FILE__)
 end
 
-require 'spree_core/version'
+require File.expand_path("../spree_core/version", __FILE__)
 
-require 'spree_core/railtie'
-require 'generators/spree_core/site/site_generator'
-require 'generators/spree_core/dummy/dummy_generator'
-require 'generators/spree_core/sandbox/sandbox_generator'
+require File.expand_path("../spree_core/railtie", __FILE__)
+require File.expand_path("../generators/spree_core/site/site_generator", __FILE__)
+require File.expand_path("../generators/spree_core/dummy/dummy_generator", __FILE__)
+require File.expand_path("../generators/spree_core/sandbox/sandbox_generator", __FILE__)
 
 ActiveRecord::Base.class_eval do
   include Spree::CalculatedAdjustments

--- a/core/lib/spree_core/theme_support.rb
+++ b/core/lib/spree_core/theme_support.rb
@@ -1,1 +1,1 @@
-require 'spree_core/theme_support/hook_listener'
+require File.expand_path("../theme_support/hook_listener", __FILE__)

--- a/dash/Rakefile
+++ b/dash/Rakefile
@@ -4,7 +4,7 @@ require 'rake/packagetask'
 require 'rubygems/package_task'
 require 'rspec/core/rake_task'
 require 'cucumber/rake/task'
-require 'spree_core/testing_support/common_rake'
+require File.expand_path("../../core/lib/spree_core/testing_support/common_rake", __FILE__)
 
 RSpec::Core::RakeTask.new
 Cucumber::Rake::Task.new

--- a/dash/lib/spree_dash.rb
+++ b/dash/lib/spree_dash.rb
@@ -1,4 +1,4 @@
-require 'spree_core'
+require File.expand_path("../../../core/lib/spree_core", __FILE__)
 
 module SpreeDash
   class Engine < Rails::Engine

--- a/promo/Rakefile
+++ b/promo/Rakefile
@@ -4,7 +4,7 @@ require 'rake/packagetask'
 require 'rubygems/package_task'
 require 'rspec/core/rake_task'
 require 'cucumber/rake/task'
-require 'spree_core/testing_support/common_rake'
+require File.expand_path("../../core/lib/spree_core/testing_support/common_rake", __FILE__)
 
 RSpec::Core::RakeTask.new
 Cucumber::Rake::Task.new

--- a/promo/lib/spree_promo.rb
+++ b/promo/lib/spree_promo.rb
@@ -1,6 +1,6 @@
-require 'spree_core'
-require 'spree_auth'
-require 'spree_promo_hooks'
+require File.expand_path("../../../core/lib/spree_core", __FILE__)
+require File.expand_path("../../../auth/lib/spree_auth", __FILE__)
+require File.expand_path("../spree_promo_hooks", __FILE__)
 
 module SpreePromo
   class Engine < Rails::Engine


### PR DESCRIPTION
If none of spree_\* gems are installed, all rake tasks or related-code will fail to locate spree_\* library. Wondering if using relative path would be a more ideal solution?
