### PR TITLE
Fix db:admin:create task to locate the correct users.rb file

### DIFF
--- a/auth/lib/tasks/auth.rake
+++ b/auth/lib/tasks/auth.rake
@@ -2,7 +2,7 @@ namespace :db do
   namespace :admin do
     desc "Create admin username and password"
     task :create => :environment do
-      require File.join(Rails.root, 'db', 'sample', 'users.rb')
+      require File.join(File.dirname(__FILE__), '..', '..', 'db', 'default', 'users.rb')
     end
   end
 end


### PR DESCRIPTION
Well, at the moment db:admin:create is broken due  to mis-locating the users.rb file. This patch fixes the issue.

step to re-produce:

$ rails new sandbox

edit the Gemfile to include 'spree' and then do all the bootstrap with

$ rails g spree:site
$ rake db:migrate
$ rake db:seed

Test out the db:admin:create rake:

$ rake db:admin:create
