### PR TITLE
Revert "Locking arel to 2.1.4 for now"

### DIFF
--- a/core/lib/generators/spree_core/shared/templates/Gemfile
+++ b/core/lib/generators/spree_core/shared/templates/Gemfile
@@ -1,0 +1,39 @@
+source 'http://rubygems.org'
+
+gem 'rails', '3.1.0.rc6'
+
+gem 'json'
+
+# Gems used only for assets and not required
+# in production environments by default.
+group :assets do
+  gem 'sass-rails', "~> 3.1.0.rc"
+  gem 'coffee-rails', "~> 3.1.0.rc"
+  gem 'uglifier'
+end
+
+group :test do
+  gem 'rspec-rails', '= 2.6.1'
+  gem 'factory_girl', '= 1.3.3'
+  gem 'factory_girl_rails', '= 1.0.1'
+  gem 'rcov'
+  gem 'shoulda'
+  gem 'faker'
+end
+
+group :cucumber do
+  gem 'cucumber-rails', '1.0.0'
+  gem 'database_cleaner', '= 0.6.7'
+  gem 'nokogiri'
+  gem 'capybara', '1.0.0'
+  gem 'factory_girl', '= 1.3.3'
+  gem 'factory_girl_rails', '= 1.0.1'
+  gem 'faker'
+  gem 'launchy'
+end
+
+if RUBY_VERSION < "1.9"
+  gem "ruby-debug"
+else
+  gem "ruby-debug19"
+end


### PR DESCRIPTION
This reverts commit 39a9bda10d180122dc2b2f1f07a3b97a49ea4a26.

Conflicts:

```
Gemfile
core/lib/generators/spree_core/shared/templates/Gemfile
```

Because rails 3.1.0.rc6 is now locked to arel 2.2.1 which has resolved the issue of 2.1.5
