### PR TITLE
Renames csrf_meta_tag -> csrf_meta_tags

### DIFF
--- a/core/app/views/admin/orders/edit.html.erb
+++ b/core/app/views/admin/orders/edit.html.erb
@@ -1,4 +1,4 @@
-<%= csrf_meta_tag %>
+<%= csrf_meta_tags %>
 <div class='order-links' data-hook="admin_order_edit_buttons">
   <div class='toolbar'>
     <%= event_links %>

--- a/core/app/views/admin/orders/new.html.erb
+++ b/core/app/views/admin/orders/new.html.erb
@@ -1,5 +1,5 @@
 <%= render :partial => 'admin/shared/order_tabs', :locals => {:current => "Order Details"} %>
-<%= csrf_meta_tag %>
+<%= csrf_meta_tags %>
 
 <div data-hook="admin_order_new_header">
   <h2><%= t("new_order")%></h2>

--- a/core/app/views/admin/orders/user.html.erb
+++ b/core/app/views/admin/orders/user.html.erb
@@ -1,5 +1,5 @@
 <%= render :partial => 'admin/shared/order_tabs', :locals => {:current => "Customer Details"} %>
-<%= csrf_meta_tag %>
+<%= csrf_meta_tags %>
 
 <% if @order.cart? %>
   <div id="add-line-item" data-hook>

--- a/core/app/views/admin/shared/_head.html.erb
+++ b/core/app/views/admin/shared/_head.html.erb
@@ -1,5 +1,5 @@
 <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
-<%= csrf_meta_tag %>
+<%= csrf_meta_tags %>
 <title><%= "Spree #{t('administration')}: " %>
 <%= t(controller.controller_name, :default => controller.controller_name.titleize) %></title>
 

--- a/core/app/views/shared/_head.html.erb
+++ b/core/app/views/shared/_head.html.erb
@@ -2,6 +2,6 @@
 <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
 <%== meta_data_tags %>
 <%= stylesheet_link_tag "store/all", :media => "screen" %>
-<%= csrf_meta_tag %>
+<%= csrf_meta_tags %>
 <%= javascript_include_tag "store/all" %>
 <%= yield :head %>


### PR DESCRIPTION
Renames csrf_meta_tag -> csrf_meta_tags because csrf_meta_tag is only kept for backward compatability
