### PR TITLE
group_by_products_id scope breaks count for PostgreSQL

### DIFF
--- a/core/app/models/product.rb
+++ b/core/app/models/product.rb
@@ -86,7 +86,7 @@ class Product < ActiveRecord::Base
 
   if (ActiveRecord::Base.connection.adapter_name == 'PostgreSQL')
     if ActiveRecord::Base.connection.tables.include?("products")
-      scope :group_by_products_id, { :group => "products." + Product.column_names.join(", products.") }
+      scope :group_by_products_id, { :group => Product.column_names.map{|col_name| "products.#{col_name}"} }
     end
   else
     scope :group_by_products_id, { :group => "products.id" }

--- a/core/spec/models/product_spec.rb
+++ b/core/spec/models/product_spec.rb
@@ -85,6 +85,17 @@ describe Product do
       end
     end
 
+    context ".group_by_products_id.count" do
+      let(:product) { Factory(:product) }
+      it 'produces a properly formed ordered-hash key' do
+        expected_key = (ActiveRecord::Base.connection.adapter_name == 'PostgreSQL') ?
+          Product.column_names.map{|col_name| product.send(col_name)} :
+          product.id
+        count_key = Product.group_by_products_id.count.keys.first
+        [expected_key, count_key].each{|val| val.map!{|e| e.is_a?(Time) ? e.strftime("%Y-%m-%d %H:%M:%S") : e} if val.respond_to?(:map!)}
+        count_key.should == expected_key
+      end
+    end
 
   end
 


### PR DESCRIPTION
The code used:
```  scope :group_by_products_id, { :group => "products." + Product.column_names.join(", products.") }

``````
assigns all column names to a string which is not the expected convention by ActiveRecord::Calculations

Used in this way, calling 'count' will improperly group by the value of the last column in column_names, rather than by all columns.  Pagination may break as a result of this, since it relies on total_entries to determine paging.

The code should actually pass an array like so:
```  scope :group_by_products_id, { :group => Product.column_names.map{|col_name| "products.#{col_name}" }
``````

It should also probably be passed in a lambda block to avoid hitting the database when the class is initially loaded (unless that was intended behavior?).
