### PR TITLE
Tiny fixes to product_properties autocomplete

### DIFF
--- a/core/app/assets/stylesheets/admin/edit_checkouts.css
+++ b/core/app/assets/stylesheets/admin/edit_checkouts.css
@@ -63,7 +63,7 @@
   background-color: #fff;
 }
 .ac_over {
-  background-color: #41A6F0;
+  background-color: #41A6F0!important;
   color: #fff!important;
 }
 .ac_over h4{

--- a/core/app/views/admin/product_properties/index.html.erb
+++ b/core/app/views/admin/product_properties/index.html.erb
@@ -44,7 +44,7 @@
 <%= javascript_tag do %>
   var properties = [<%= @properties.map{|id| "'#{id}'"}.join(', ') %>];
 
-  $("#product_properties input.autocomplete").live("keydown", function(){
+  $("#product_properties td.property_name input.autocomplete").live("keydown", function(){
     already_auto_completed = $(this).is('ac_input');
     if (!already_auto_completed) {
       $(this).autocomplete(properties);


### PR DESCRIPTION
There's no need to autocomplete product property values with property names, of course (I'm working on an extension to autocomplete values instead). A tiny css glitch has also been fixed. 

Also, I wonder why the jquery.autocomplete.js being used is still the old (deprecated) version from bassistance.de, not the one from jQuery UI. These versions will conflict if used together.
