### PR TITLE
Fixing products cloning with rails 3.1

### DIFF
--- a/core/app/models/product.rb
+++ b/core/app/models/product.rb
@@ -188,7 +188,7 @@ class Product < ActiveRecord::Base
 
     p.product_properties = self.product_properties.map {|q| r = q.dup; r.created_at = r.updated_at = nil; r}
 
-    image_dup = lambda {|i| j = i.dup; j.attachment = i.attachment.dup; j}
+    image_dup = lambda {|i| j = i.dup; j.attachment = i.attachment.clone; j}
     p.images = self.images.map {|i| image_dup.call i}
 
     variant = self.master.dup

--- a/core/app/models/product.rb
+++ b/core/app/models/product.rb
@@ -180,25 +180,25 @@ class Product < ActiveRecord::Base
   # for adding products which are closely related to existing ones
   # define "duplicate_extra" for site-specific actions, eg for additional fields
   def duplicate
-    p = self.clone
+    p = self.dup
     p.name = 'COPY OF ' + self.name
     p.deleted_at = nil
     p.created_at = p.updated_at = nil
     p.taxons = self.taxons
 
-    p.product_properties = self.product_properties.map {|q| r = q.clone; r.created_at = r.updated_at = nil; r}
+    p.product_properties = self.product_properties.map {|q| r = q.dup; r.created_at = r.updated_at = nil; r}
 
-    image_clone = lambda {|i| j = i.clone; j.attachment = i.attachment.clone; j}
-    p.images = self.images.map {|i| image_clone.call i}
+    image_dup = lambda {|i| j = i.dup; j.attachment = i.attachment.dup; j}
+    p.images = self.images.map {|i| image_dup.call i}
 
-    variant = self.master.clone
+    variant = self.master.dup
     variant.sku = 'COPY OF ' + self.master.sku
     variant.deleted_at = nil
-    variant.images = self.master.images.map {|i| image_clone.call i}
+    variant.images = self.master.images.map {|i| image_dup.call i}
     p.master = variant
 
     if self.has_variants?
-      # don't clone the actual variants, just the characterising types
+      # don't dup the actual variants, just the characterising types
       p.option_types = self.option_types
     else
     end


### PR DESCRIPTION
Since rails 3.1, products cloning doesn't work as expected (no product ID management, etc.).

In rails 3.1, ActiveRecord::Base#dup and ActiveRecord::Base#clone semantics have changed.
See: https://gist.github.com/994614

This is a proposed fix.
