### PR TITLE
Add support for rails 2 3 12

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require(File.join(File.dirname(__FILE__), 'config', 'boot'))
 
 require 'rake'
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 
 require 'tasks/rails'
 
@@ -23,8 +23,9 @@ begin
     s.executables = ['spree']
     s.rubyforge_project = 'spree'
     s.version = Spree::Version
-    s.add_dependency 'rake', '>= 0.7.1'
-    s.add_dependency 'rails', '= 2.3.8'
+    s.add_dependency 'rake', '>= 0.9.2'
+    s.add_dependency 'rdoc', '>= 3.9.4'
+    s.add_dependency 'rails', '= 2.3.12'
     s.add_dependency 'rack', '>= 1.1.0'
     s.add_dependency 'highline', '= 1.5.1'
     s.add_dependency 'authlogic', '2.1.3'

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -55,7 +55,7 @@ module Spree
   class Boot 
     include Spree::RubyGemsLoader
     def run
-      load_rails("2.3.8")  # note: spree requires this specific version of rails (change at your own risk)
+      load_rails("2.3.12")  # note: spree requires this specific version of rails (change at your own risk)
       load_initializer
       Spree::Initializer.run(:set_load_path)
     end

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -27,7 +27,7 @@ Spree::Initializer.run do |config|
   # config.gem "aws-s3", :lib => "aws/s3"
 
   config.gem "highline", :version => '1.5.1'
-  config.gem 'authlogic', :version => '>=2.1.3'
+  config.gem 'authlogic', :version => '2.1.3'
   config.gem 'authlogic-oid', :lib => "authlogic_openid", :version => '1.0.4'
   config.gem "activemerchant", :lib => "active_merchant", :version => '1.7.0'
   config.gem 'activerecord-tableless', :lib => 'tableless', :version => '0.1.0'

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -24,4 +24,4 @@ config.action_controller.allow_forgery_protection = false
 config.gem "shoulda", :lib => "shoulda", :version => "2.10.2"
 config.gem "factory_girl", :lib => "factory_girl", :version => "1.2.3"
 config.gem 'test-unit', :lib => 'test/unit', :version => '~>2.0.9' if RUBY_VERSION.to_f >= 1.9
-config.gem "rspec", :lib => 'spec'
+config.gem "rspec", :lib => 'spec', :version => '1.3.2'

--- a/lib/generators/extension/templates/Rakefile
+++ b/lib/generators/extension/templates/Rakefile
@@ -1,6 +1,6 @@
 require 'rake'
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 
 desc 'Default: run unit tests.'
 task :default => :test

--- a/lib/plugins/option_tags_with_disable/Rakefile
+++ b/lib/plugins/option_tags_with_disable/Rakefile
@@ -1,6 +1,6 @@
 require 'rake'
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 
 desc 'Default: run unit tests.'
 task :default => :test

--- a/lib/spree/extension_loader.rb
+++ b/lib/spree/extension_loader.rb
@@ -46,7 +46,7 @@ module Spree
         
     def add_extension_paths
       extension_load_paths.reverse_each do |path|
-        configuration.load_paths.unshift path
+        configuration.autoload_paths.unshift path
         $LOAD_PATH.unshift path
       end
     end

--- a/lib/spree/initializer.rb
+++ b/lib/spree/initializer.rb
@@ -42,7 +42,7 @@ module Spree
       end
 
       # Provide the load paths for the Spree installation
-      def default_load_paths
+      def default_autoload_paths
         paths = ["#{SPREE_ROOT}/test/mocks/#{environment}"]
 
         # Add the app's controller directory
@@ -158,6 +158,7 @@ module Spree
       extension_loader.add_controller_paths
       super
     end
+    
 
     def initialize_metal
       Rails::Rack::Metal.metal_paths += ["#{SPREE_ROOT}/app/metal"]

--- a/vendor/extensions/api/Rakefile
+++ b/vendor/extensions/api/Rakefile
@@ -18,7 +18,7 @@ unless defined? SPREE_ROOT
 end
 
 require 'rake'
-require 'rake/rdoctask'
+require 'rdoc/task'
 require 'rake/testtask'
 
 rspec_base = File.expand_path(SPREE_ROOT + '/vendor/plugins/rspec/lib')

--- a/vendor/extensions/overview_dashboard/Rakefile
+++ b/vendor/extensions/overview_dashboard/Rakefile
@@ -18,7 +18,7 @@ unless defined? SPREE_ROOT
 end
 
 require 'rake'
-require 'rake/rdoctask'
+require 'rdoc/task'
 require 'rake/testtask'
 
 rspec_base = File.expand_path(SPREE_ROOT + '/vendor/plugins/rspec/lib')

--- a/vendor/extensions/payment_gateway/Rakefile
+++ b/vendor/extensions/payment_gateway/Rakefile
@@ -18,7 +18,7 @@ unless defined? SPREE_ROOT
 end
 
 require 'rake'
-require 'rake/rdoctask'
+require 'rdoc/task'
 require 'rake/testtask'
 
 rspec_base = File.expand_path(SPREE_ROOT + '/vendor/plugins/rspec/lib')

--- a/vendor/extensions/theme_default/Rakefile
+++ b/vendor/extensions/theme_default/Rakefile
@@ -18,7 +18,7 @@ unless defined? SPREE_ROOT
 end
 
 require 'rake'
-require 'rake/rdoctask'
+require 'rdoc/task'
 require 'rake/testtask'
 
 rspec_base = File.expand_path(SPREE_ROOT + '/vendor/plugins/rspec/lib')

--- a/vendor/plugins/acts_as_tree/Rakefile
+++ b/vendor/plugins/acts_as_tree/Rakefile
@@ -1,6 +1,6 @@
 require 'rake'
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 
 desc 'Default: run unit tests.'
 task :default => :test

--- a/vendor/plugins/attribute_fu/Rakefile
+++ b/vendor/plugins/attribute_fu/Rakefile
@@ -1,7 +1,7 @@
 require 'rake'
 require "load_multi_rails_rake_tasks" 
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 
 desc 'Default: run unit tests.'
 task :default => :test

--- a/vendor/plugins/auto_complete/Rakefile
+++ b/vendor/plugins/auto_complete/Rakefile
@@ -1,6 +1,6 @@
 require 'rake' 
 require 'rake/testtask' 
-require 'rake/rdoctask' 
+require 'rdoc/task' 
  
 desc 'Default: run unit tests.' 
 task :default => :test 

--- a/vendor/plugins/awesome_nested_set/Rakefile
+++ b/vendor/plugins/awesome_nested_set/Rakefile
@@ -5,7 +5,7 @@ rescue LoadError
   exit 1
 end
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 require 'rcov/rcovtask'
 require "load_multi_rails_rake_tasks" 
 

--- a/vendor/plugins/delegate_belongs_to/Rakefile
+++ b/vendor/plugins/delegate_belongs_to/Rakefile
@@ -1,6 +1,6 @@
 require 'rake'
 require 'spec/rake/spectask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 
 desc 'Default: run specs.'
 task :default => :spec

--- a/vendor/plugins/enumerable_constants/Rakefile
+++ b/vendor/plugins/enumerable_constants/Rakefile
@@ -1,6 +1,6 @@
 require 'rake'
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 
 desc 'Default: run unit tests.'
 task :default => :test

--- a/vendor/plugins/find_by_param/Rakefile
+++ b/vendor/plugins/find_by_param/Rakefile
@@ -1,6 +1,6 @@
 require 'rake'
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 
 desc 'Default: run unit tests.'
 task :default => :test

--- a/vendor/plugins/in_place_editing/Rakefile
+++ b/vendor/plugins/in_place_editing/Rakefile
@@ -1,6 +1,6 @@
 require 'rake'
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 
 desc 'Default: run unit tests.'
 task :default => :test

--- a/vendor/plugins/jrails_auto_complete/Rakefile
+++ b/vendor/plugins/jrails_auto_complete/Rakefile
@@ -1,6 +1,6 @@
 require 'rake'
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 
 desc 'Default: run unit tests.'
 task :default => :test

--- a/vendor/plugins/mail_queue/Rakefile
+++ b/vendor/plugins/mail_queue/Rakefile
@@ -1,6 +1,6 @@
 require 'rake'
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 
 desc 'Default: run unit tests.'
 task :default => :test

--- a/vendor/plugins/open_id_authentication/Rakefile
+++ b/vendor/plugins/open_id_authentication/Rakefile
@@ -1,6 +1,6 @@
 require 'rake'
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 
 desc 'Default: run unit tests.'
 task :default => :test

--- a/vendor/plugins/resource_controller/test/Rakefile
+++ b/vendor/plugins/resource_controller/test/Rakefile
@@ -5,6 +5,6 @@ require(File.join(File.dirname(__FILE__), 'config', 'boot'))
 
 require 'rake'
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 
 require 'tasks/rails'

--- a/vendor/plugins/resource_controller/test/config/environment.rb
+++ b/vendor/plugins/resource_controller/test/config/environment.rb
@@ -20,7 +20,7 @@ Rails::Initializer.run do |config|
   # config.plugins = %W( exception_notification ssl_requirement )
 
   # Add additional load paths for your own custom dirs
-  config.load_paths += %W( #{RAILS_ROOT}/../lib )
+  config.autoload_paths += %W( #{RAILS_ROOT}/../lib )
 
   # Force all environments to use the same logger level 
   # (by default production uses :info, the others :debug)

--- a/vendor/plugins/resource_controller/test/vendor/plugins/shoulda/Rakefile
+++ b/vendor/plugins/resource_controller/test/vendor/plugins/shoulda/Rakefile
@@ -1,6 +1,6 @@
 require 'rake'
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 
 # Test::Unit::UI::VERBOSE
 

--- a/vendor/plugins/unobtrusive_date_picker/Rakefile
+++ b/vendor/plugins/unobtrusive_date_picker/Rakefile
@@ -1,5 +1,5 @@
 require 'rake'
-require 'rake/rdoctask'
+require 'rdoc/task'
 require 'rubygems'
 require 'spec/rake/spectask'
 


### PR DESCRIPTION
the unit tests all pass and so do the integration tests. A small subset of the functional tests fail but those same tests also fail on current 0-11-stable. 

One important thing to note is that rake 0.9.2 is needed as 0.8.7 doesn't play nice with rails 2.3.12. And rdoc also needs to be added as well in order to make rake happy.
