### PR TITLE
Fix deprecation warnings

### DIFF
--- a/lib/spree/checkout/action_options.rb
+++ b/lib/spree/checkout/action_options.rb
@@ -4,7 +4,7 @@ module Spree::Checkout
     block_accessor :edit_hook, :update_hook
     
     def dup
-      returning self.class.new do |duplicate|
+      self.class.new.tap do |duplicate|
         duplicate.instance_variable_set(:@collector, wants.dup)
         duplicate.instance_variable_set(:@before, before.dup)             unless before.nil?
         duplicate.instance_variable_set(:@after, after.dup)               unless after.nil?

--- a/lib/spree/initializer.rb
+++ b/lib/spree/initializer.rb
@@ -129,7 +129,7 @@ module Spree
 
 
     def initialize_framework_views
-      view_paths = returning [] do |arr|
+      view_paths = [].tap do |arr|
         # Add the singular view path if it's not in the list
         arr << configuration.view_path if !configuration.view_paths.include?(configuration.view_path)
         # Add the default view paths

--- a/lib/validation_group.rb
+++ b/lib/validation_group.rb
@@ -14,7 +14,7 @@ module ValidationGroup
           def self.validation_groups(all_classes = false)
             return (self.validation_group_classes[self] || {}) unless all_classes
             klasses = ValidationGroup::Util.current_and_ancestors(self).reverse
-            returning Hash.new do |hash|
+            Hash.new.tap do |hash|
               klasses.each do |klass|
                 hash.merge! self.validation_group_classes[klass]
               end
@@ -129,7 +129,7 @@ end
     # Return array consisting of current and its superclasses down to and
     # including base_class.
     def self.current_and_ancestors(current)
-      returning [] do |klasses|
+      [].tap do |klasses|
         klasses << current
         root = current.base_class
         until current == root

--- a/vendor/plugins/awesome_nested_set/lib/awesome_nested_set.rb
+++ b/vendor/plugins/awesome_nested_set/lib/awesome_nested_set.rb
@@ -60,9 +60,9 @@ module CollectiveIdea #:nodoc:
             extend Columns
             extend ClassMethods
             
-            belongs_to :parent, :class_name => self.base_class.class_name,
+            belongs_to :parent, :class_name => self.base_class.model_name,
               :foreign_key => parent_column_name
-            has_many :children, :class_name => self.base_class.class_name,
+            has_many :children, :class_name => self.base_class.model_name,
               :foreign_key => parent_column_name, :order => quoted_left_column_name
 
             attr_accessor :skip_before_destroy
@@ -149,7 +149,7 @@ module CollectiveIdea #:nodoc:
         def each_root_valid?(roots_to_validate)
           left = right = 0
           roots_to_validate.all? do |root|
-            returning(root.left > left && root.right > right) do
+            (root.left > left && root.right > right).tap do
               left = root.left
               right = root.right
             end

--- a/vendor/plugins/resource_controller/lib/resource_controller/action_options.rb
+++ b/vendor/plugins/resource_controller/lib/resource_controller/action_options.rb
@@ -28,7 +28,7 @@ module ResourceController
     end
     
     def dup
-      returning self.class.new do |duplicate|
+      self.class.new.tap do |duplicate|
         duplicate.instance_variable_set(:@collector, wants.dup)
         duplicate.instance_variable_set(:@before, before.dup)       unless before.nil?
         duplicate.instance_variable_set(:@after, after.dup)         unless after.nil?

--- a/vendor/plugins/resource_controller/lib/resource_controller/failable_action_options.rb
+++ b/vendor/plugins/resource_controller/lib/resource_controller/failable_action_options.rb
@@ -15,7 +15,7 @@ module ResourceController
     delegate :flash, :flash_now, :after, :response, :wants, :to => :success
     
     def dup
-      returning self.class.new do |duplicate|
+      self.class.new.tap do |duplicate|
         duplicate.instance_variable_set(:@success, success.dup)
         duplicate.instance_variable_set(:@fails,   fails.dup)
         duplicate.instance_variable_set(:@before,  before.dup) unless before.nil?

--- a/vendor/plugins/resource_controller/test/vendor/plugins/shoulda/lib/shoulda/controller_tests/controller_tests.rb
+++ b/vendor/plugins/resource_controller/test/vendor/plugins/shoulda/lib/shoulda/controller_tests/controller_tests.rb
@@ -446,7 +446,7 @@ module ThoughtBot # :nodoc:
         end
 
         def get_existing_record(res) # :nodoc:
-          returning(instance_variable_get("@#{res.object}")) do |record|
+            (instance_variable_get("@#{res.object}")).tap do |record|
             assert(record, "This test requires you to set @#{res.object} in your setup block")    
           end
         end


### PR DESCRIPTION
change all occurrences of returning method with tap and all occurrences of class_name with model_name in order to get rid of deprecation warnings.
