### PR TITLE
Used non gemcutter way for extension rake release

### DIFF
--- a/api/Rakefile
+++ b/api/Rakefile
@@ -18,10 +18,9 @@ Gem::PackageTask.new(spec) do |p|
 end
 
 desc "Release to gemcutter"
-task :release => :package do
-  require 'rake/gemcutter'
-  Rake::Gemcutter::Tasks.new(spec).define
-  Rake::Task['gem:push'].invoke
+task :release do
+  version = File.read(File.expand_path("../../SPREE_VERSION", __FILE__)).strip
+  cmd = "cd pkg && gem push spree_api-#{version}.gem"; puts cmd; system cmd
 end
 
 desc "Generates a dummy app for testing"

--- a/auth/Rakefile
+++ b/auth/Rakefile
@@ -19,10 +19,9 @@ Gem::PackageTask.new(spec) do |p|
 end
 
 desc "Release to gemcutter"
-task :release => :package do
-  require 'rake/gemcutter'
-  Rake::Gemcutter::Tasks.new(spec).define
-  Rake::Task['gem:push'].invoke
+task :release do
+  version = File.read(File.expand_path("../../SPREE_VERSION", __FILE__)).strip
+  cmd = "cd pkg && gem push spree_auth-#{version}.gem"; puts cmd; system cmd
 end
 
 desc "Generates a dummy app for testing"

--- a/core/Rakefile
+++ b/core/Rakefile
@@ -16,10 +16,9 @@ Gem::PackageTask.new(spec) do |p|
 end
 
 desc "Release to gemcutter"
-task :release => :package do
-  require 'rake/gemcutter'
-  Rake::Gemcutter::Tasks.new(spec).define
-  Rake::Task['gem:push'].invoke
+task :release do
+  version = File.read(File.expand_path("../../SPREE_VERSION", __FILE__)).strip
+  cmd = "cd pkg && gem push spree_core-#{version}.gem"; puts cmd; system cmd
 end
 
 task :default => [:spec, :cucumber]

--- a/dash/Rakefile
+++ b/dash/Rakefile
@@ -18,10 +18,9 @@ Gem::PackageTask.new(spec) do |p|
 end
 
 desc "Release to gemcutter"
-task :release => :package do
-  require 'rake/gemcutter'
-  Rake::Gemcutter::Tasks.new(spec).define
-  Rake::Task['gem:push'].invoke
+task :release do
+  version = File.read(File.expand_path("../../SPREE_VERSION", __FILE__)).strip
+  cmd = "cd pkg && gem push spree_dash-#{version}.gem"; puts cmd; system cmd
 end
 
 desc "Generates a dummy app for testing"

--- a/promo/Rakefile
+++ b/promo/Rakefile
@@ -18,10 +18,9 @@ Gem::PackageTask.new(spec) do |p|
 end
 
 desc "Release to gemcutter"
-task :release => :package do
-  require 'rake/gemcutter'
-  Rake::Gemcutter::Tasks.new(spec).define
-  Rake::Task['gem:push'].invoke
+task :release do
+  version = File.read(File.expand_path("../../SPREE_VERSION", __FILE__)).strip
+  cmd = "cd pkg && gem push spree_promo-#{version}.gem"; puts cmd; system cmd
 end
 
 desc "Generates a dummy app for testing"

--- a/sample/Rakefile
+++ b/sample/Rakefile
@@ -10,8 +10,7 @@ Gem::PackageTask.new(spec) do |p|
 end
 
 desc "Release to gemcutter"
-task :release => :package do
-  require 'rake/gemcutter'
-  Rake::Gemcutter::Tasks.new(spec).define
-  Rake::Task['gem:push'].invoke
+task :release do
+  version = File.read(File.expand_path("../../SPREE_VERSION", __FILE__)).strip
+  cmd = "cd pkg && gem push spree_sample-#{version}.gem"; puts cmd; system cmd
 end


### PR DESCRIPTION
Now all extensions can be separately released to rubygems w/o using <code>gemcutter</code>. The code is actually copied and adapted from the <code>rake gem:release</code>
