### PR TITLE
Added --old-style-hash option for DummyGenerator to maintain backward-com

### DIFF
--- a/core/lib/generators/spree/dummy/dummy_generator.rb
+++ b/core/lib/generators/spree/dummy/dummy_generator.rb
@@ -26,6 +26,7 @@ module Spree
       opts[:database] = 'sqlite3' if opts[:database].blank?
       opts[:force] = true
       opts[:skip_bundle] = true
+      opts[:old_style_hash] = true
 
       invoke Rails::Generators::AppGenerator,
         [ File.expand_path(dummy_path, destination_root) ], opts


### PR DESCRIPTION
Added --old-style-hash option for DummyGenerator to maintain backward-compatability with Ruby 1.8
