### PR TITLE
It is not ideal to turn off assets debug mode in development, the best wa

### DIFF
--- a/core/lib/spree_core/railtie.rb
+++ b/core/lib/spree_core/railtie.rb
@@ -70,8 +70,7 @@ module SpreeCore
 
     # sets the manifests / assets to be precompiled
     initializer "spree.assets.precompile" do |app|
-      app.config.assets.precompile += ['store/all.*', 'admin/all.*', 'admin/spree_dash.*', 'admin/orders/edit_form.js', '*.png', '*.jpg', '*.jpeg', '*.gif']
-      app.config.assets.debug = false
+      app.config.assets.precompile += ['*.js', '*.css', '*.png', '*.jpg', '*.jpeg', '*.gif']
     end
 
 


### PR DESCRIPTION
It is not ideal to turn off assets debug mode in development, the best way is to use wildmask for all js and css files
