### PR TITLE
0-70 - Fixing the broken Creditcard#spree_cc_type method.

### DIFF
--- a/core/app/models/creditcard.rb
+++ b/core/app/models/creditcard.rb
@@ -2,6 +2,7 @@ class Creditcard < ActiveRecord::Base
   has_many :payments, :as => :source
 
   before_save :set_last_digits
+  after_validation :set_card_type
 
   attr_accessor :number, :verification_value
 
@@ -21,6 +22,19 @@ class Creditcard < ActiveRecord::Base
     number.to_s.gsub!(/\s/,'') unless number.nil?
     verification_value.to_s.gsub!(/\s/,'') unless number.nil?
     self.last_digits ||= number.to_s.length <= 4 ? number : number.to_s.slice(-4..-1)
+  end
+
+  # cheap hack to get to the type? method from deep within ActiveMerchant without stomping on
+  # potentially existing methods in CreditCard
+  class CardDetector
+    class << self
+      include ActiveMerchant::Billing::CreditCardMethods::ClassMethods
+    end
+  end
+
+  # sets self.cc_type while we still have the card number
+  def set_card_type
+    self.cc_type ||= CardDetector.type?(self.number)
   end
 
   def name?
@@ -243,7 +257,7 @@ class Creditcard < ActiveRecord::Base
 
   def spree_cc_type
     return "visa" if ENV['RAILS_ENV'] == "development"
-    self.class.type?(number)
+    self.cc_type
   end
 
   # Saftey check to make sure we're not accidentally performing operations on a live gateway.

--- a/core/spec/models/creditcard_spec.rb
+++ b/core/spec/models/creditcard_spec.rb
@@ -470,5 +470,66 @@ describe Creditcard do
     end
   end
 
+  context "#spree_cc_type" do
+    before do
+      @creditcard.attributes = valid_creditcard_attributes
+    end
+
+    context "in development mode" do
+      before do
+        Rails.env = "development"
+      end
+
+      it "should return visa" do
+        @creditcard.save
+        @creditcard.spree_cc_type.should == "visa"
+      end
+
+      after do 
+        Rails.env = "test"
+      end
+    end
+
+    context "in production mode" do
+      before do
+        Rails.env = "production"
+      end
+
+      it "should return the actual cc_type for a valid number" do
+        @creditcard.number = "378282246310005"
+        @creditcard.save
+        @creditcard.spree_cc_type.should == "american_express"
+      end
+
+      after do
+        Rails.env = "test"
+      end
+    end
+  end
+
+  context "#set_card_type" do
+    before :each do
+      Rails.env = "production"
+      @creditcard.attributes = valid_creditcard_attributes
+    end
+
+    it "stores the creditcard type after validation" do
+      @creditcard.number = "6011000990139424"
+      @creditcard.save
+      @creditcard.spree_cc_type.should == "discover"
+    end
+
+    it "does not overwrite the creditcard type when loaded and saved" do
+      @creditcard.number = "5105105105105100"
+      @creditcard.save
+      @creditcard.number = "XXXXXXXXXXXX5100"
+      @creditcard.save
+      @creditcard.spree_cc_type.should == "master"
+    end
+
+    after do
+      Rails.env = "test"
+    end
+  end
 end
 


### PR DESCRIPTION
Fixing the broken Creditcard#spree_cc_type method. Creditcard needs to store this info before we ditch the number. Specs included.
