### PR TITLE
Theoretically improve speed of get_taxonomies and converted conditions to a hash

### DIFF
--- a/core/app/models/taxonomy.rb
+++ b/core/app/models/taxonomy.rb
@@ -3,7 +3,7 @@ class Taxonomy < ActiveRecord::Base
   validates :name, :presence => true
 
   has_many :taxons, :dependent => :destroy
-  has_one :root, :class_name => 'Taxon', :conditions => "parent_id is null"
+  has_one :root, :class_name => 'Taxon', :conditions => {:parent_id => nil}
 
   after_save :set_name
 

--- a/core/lib/spree_base.rb
+++ b/core/lib/spree_base.rb
@@ -83,8 +83,7 @@ module SpreeBase
     end
 
     def get_taxonomies
-      @taxonomies ||= Taxonomy.includes(:root => :children)
-      @taxonomies.reject { |t| t.root.nil? }
+      @taxonomies ||= Taxonomy.includes(:root => :children).joins(:root)
     end
 
     def current_gateway


### PR DESCRIPTION
Is there a reason this was happening in memory before? Using a simple join automatically rejects where root is nil and retains the `@taxonomies` variable's status as `ActiveRecord::Relation` rather than `Array`.
