### PR TITLE
Having this route always on makes it hard to integrate another CMS

### DIFF
--- a/core/config/routes.rb
+++ b/core/config/routes.rb
@@ -204,7 +204,7 @@ Rails.application.routes.draw do
   #match '/:controller(/:action(/:id(.:format)))'
 
   # a catchall route for "static" content (except paths with explicit extensions: .html, .ico, etc)
-  #if Spree::Config.instance && Spree::Config.get(:use_content_controller)
+  if Spree::Config.instance && Spree::Config.get(:use_content_controller)
     match '/*path' => 'content#show'
-  #end
+  end
 end


### PR DESCRIPTION
Revert "Comment out problematic preference check during routes.  It was failing during migration of legacy site."

This reverts commit 9a18fb4d9c08df9ebdc0d158fed39ca3af65dc8f.

Conflicts:

```
core/config/routes.rb
```
