### PR TITLE
Use encodeURIComponent to encode a URL parameter.

### DIFF
--- a/core/app/assets/javascripts/admin/admin.js.erb
+++ b/core/app/assets/javascripts/admin/admin.js.erb
@@ -106,7 +106,7 @@ prep_product_autocomplete_data = function(data){
 }
 
 $.fn.product_autocomplete = function(){
-  $(this).autocomplete("/admin/products.json?authenticity_token=" + escape($('meta[name=csrf-token]').attr("content")), {
+  $(this).autocomplete("/admin/products.json?authenticity_token=" + encodeURIComponent($('meta[name=csrf-token]').attr("content")), {
       parse: prep_product_autocomplete_data,
       formatItem: function(item) {
         return format_product_autocomplete(item);


### PR DESCRIPTION
 `<meta content="XbuC4d7+HO0Fg5yYd1kccSMEHn5/vy3Agm8I5I8s2YE=" name="csrf-token" />`

escape => "XbuC4d7+HO0Fg5yYd1kccSMEHn5/vy3Agm8I5I8s2YE%3D"

use encodeURIComponent

encodeURIComponent => "XbuC4d7%2BHO0Fg5yYd1kccSMEHn5%2Fvy3Agm8I5I8s2YE%3D"
