### PR TITLE
Decorator files are not loaded in Engines created with the new extension template.

### DIFF
--- a/lib/spree/templates/extension/lib/%file_name%/engine.rb.tt
+++ b/lib/spree/templates/extension/lib/%file_name%/engine.rb.tt
@@ -10,15 +10,15 @@ module <%= class_name %>
     end
 
     def self.activate
-      Dir.glob(File.join(File.dirname(__FILE__), "../app/**/*_decorator*.rb")) do |c|
+      Dir.glob(File.join(File.dirname(__FILE__), "../../app/**/*_decorator*.rb")) do |c|
         Rails.application.config.cache_classes ? require(c) : load(c)
       end
 
-      Dir.glob(File.join(File.dirname(__FILE__), "../app/overrides/*.rb")) do |c|
+      Dir.glob(File.join(File.dirname(__FILE__), "../../app/overrides/*.rb")) do |c|
         Rails.application.config.cache_classes ? require(c) : load(c)
       end
 
-      Dir.glob(File.join(File.dirname(__FILE__), "../app/overrides/*.rb")) do |c|
+      Dir.glob(File.join(File.dirname(__FILE__), "../../app/overrides/*.rb")) do |c|
         Rails.env.production? ? require(c) : load(c)
       end
     end


### PR DESCRIPTION
The `*_decorator*.rb` files are not being auto loaded from Engines created with the new extension template in the `spree --pre` gem.

This is due to the Rails::Engine now being defined in the new `%file_name%/engine.rb` file.

I have changed these to go up the extra directory so it can find the app folder correctly.
