### PR TITLE
jstree assets now going through asset pipeline

### DIFF
--- a/auth/spree_auth.gemspec
+++ b/auth/spree_auth.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency('spree_core',  version)
-  s.add_dependency('devise', '= 1.4.6')
+  s.add_dependency('devise', '= 1.4.7')
   s.add_dependency('cancan', '= 1.6.5')
 end

--- a/core/app/assets/stylesheets/admin/spree_core.css
+++ b/core/app/assets/stylesheets/admin/spree_core.css
@@ -12,4 +12,5 @@
  *= require admin/edit_checkouts.css
  *= require admin/token-input.css
  *= require jquery-ui.datepicker
+ *= require jquery.jstree/themes/apple/style.css
 */

--- a/core/app/views/admin/images/new.html.erb
+++ b/core/app/views/admin/images/new.html.erb
@@ -9,4 +9,10 @@
   </p>
 <% end %>
 
-<%= javascript_include_tag 'admin/images/new.js' %>
+<%= javascript_tag do %>
+  $('#cancel_link').click(function (event) {
+    event.preventDefault();
+    $('#new_image_link').show();
+    $('#images').html('');
+  });
+<% end %>

--- a/core/vendor/assets/javascripts/jquery.jstree/themes/apple/style.scss
+++ b/core/vendor/assets/javascripts/jquery.jstree/themes/apple/style.scss
@@ -4,9 +4,9 @@
  * Supported plugins: ui (hovered, clicked), checkbox, contextmenu, search
  */
 
-.jstree-apple > ul { background:url("bg.jpg") left top repeat; }
+.jstree-apple > ul { background:image-url("jquery.jstree/themes/apple/bg.jpg") left top repeat; }
 .jstree-apple li, 
-.jstree-apple ins { background-image:url("d.png"); background-repeat:no-repeat; background-color:transparent; }
+.jstree-apple ins { background-image:image-url("jquery.jstree/themes/apple/d.png"); background-repeat:no-repeat; background-color:transparent; }
 .jstree-apple li { background-position:-90px 0; background-repeat:repeat-y;  }
 .jstree-apple li.jstree-last { background:transparent; }
 .jstree-apple .jstree-open > ins { background-position:-72px 0; }
@@ -17,7 +17,7 @@
 .jstree-apple .jstree-hovered { background:#e7f4f9; border:1px solid #d8f0fa; padding:0 3px 0 1px; text-shadow:1px 1px 1px silver; }
 .jstree-apple .jstree-clicked { background:#beebff; border:1px solid #99defd; padding:0 3px 0 1px; }
 .jstree-apple a .jstree-icon { background-position:-56px -20px; }
-.jstree-apple a.jstree-loading .jstree-icon { background:url("throbber.gif") center center no-repeat !important; }
+.jstree-apple a.jstree-loading .jstree-icon { background:image-url("jquery.jstree/themes/apple/throbber.gif") center center no-repeat !important; }
 
 .jstree-apple.jstree-focused { background:white; }
 
@@ -40,9 +40,9 @@
 .jstree-apple .jstree-undetermined > a > .jstree-checkbox:hover { background-position:-20px -37px; }
 
 #vakata-dragged.jstree-apple ins { background:transparent !important; }
-#vakata-dragged.jstree-apple .jstree-ok { background:url("d.png") -2px -53px no-repeat !important; }
-#vakata-dragged.jstree-apple .jstree-invalid { background:url("d.png") -18px -53px no-repeat !important; }
-#jstree-marker.jstree-apple { background:url("d.png") -41px -57px no-repeat !important; text-indent:-100px; }
+#vakata-dragged.jstree-apple .jstree-ok { background:image-url("jquery.jstree/themes/apple/d.png") -2px -53px no-repeat !important; }
+#vakata-dragged.jstree-apple .jstree-invalid { background:image-url("jquery.jstree/themes/apple/d.png") -18px -53px no-repeat !important; }
+#jstree-marker.jstree-apple { background:image-url("jquery.jstree/themes/apple/d.png") -41px -57px no-repeat !important; text-indent:-100px; }
 
 .jstree-apple a.jstree-search { color:aqua; }
 .jstree-apple .jstree-locked a { color:silver; cursor:default; }


### PR DESCRIPTION
Unfortunately the jstree javascript itself still inserts a style tag pointing to its css file into the page, which will 404. jsTree provides no public way to stop it doing this, and I didn't want to hack the source itself.

At least now the assets are loaded in production though.
