### PR TITLE
528 fix broken create line items action promotion

### DIFF
--- a/core/app/models/product.rb
+++ b/core/app/models/product.rb
@@ -38,6 +38,7 @@ class Product < ActiveRecord::Base
   after_create :set_master_variant_defaults
   after_create :add_properties_and_option_types_from_prototype
   before_save :recalculate_count_on_hand
+  before_update :sanitize_permalink
   after_save :update_memberships if ProductGroup.table_exists?
   after_save :set_master_on_hand_to_zero_when_product_has_variants
   after_save :save_master
@@ -227,6 +228,10 @@ class Product < ActiveRecord::Base
   end
 
   private
+  
+  def sanitize_permalink
+    self.permalink = self.permalink.to_url
+  end
 
   def recalculate_count_on_hand
     product_count_on_hand = has_variants? ?

--- a/promo/app/views/admin/promotions/actions/_create_line_items.html.erb
+++ b/promo/app/views/admin/promotions/actions/_create_line_items.html.erb
@@ -11,9 +11,6 @@
         <%= item.variant.product.name %>
       </td>
       <td>
-        <%= item.variant.options_text.presence || t("master") %>
-      </td>
-      <td>
         <%= item.quantity %>
       </td>
       <td>
@@ -34,10 +31,7 @@
     <div style="float:left;width:50%;margin-right:5%;">
       <%= label_tag :add_product_name, t("name_or_sku") %>
       <%= text_field_tag :add_product_name, nil, :class => 'fullwidth' %>
-    </div>
-    <div style="float:left;width:10%;margin-right:5%;">
-      <%= label_tag :add_line_item_variant_id, t("variant") %><br />
-      <select name="add_line_item_variant_id" class="fullwidth"></select>
+      <%= hidden_field_tag :add_line_item_variant_id %>
     </div>
     <div style="float:left;width:10%;margin-right:5%;">
       <%= label_tag :add_quantity, t("qty") %>

--- a/promo/public/admin/javascripts/promotions.js
+++ b/promo/public/admin/javascripts/promotions.js
@@ -56,19 +56,16 @@ var initProductActions = function(){
       }
     }).result(function(event, data, formatted) {
       if(data){
-        // $('#add_product_id').val(data.product.id);
-        var url = "/admin/products/" + data.product.permalink + "/variants.json?authenticity_token=" + $('meta[name=csrf-token]').attr("content");
-        var $variant_select = $("select[name='add_line_item_variant_id']");
-        $variant_select.html('');
-        $.getJSON(url, {}, function(variants_data){
-          $.each(variants_data, function(){
-            $variant_select.append($("<option />").val(this.id).text(this.label));
-          });
-        });
+        if(data['variant']==undefined){
+          // product
+          $('#add_line_item_variant_id').val(data['product']['master']['id']);
+        }else{
+          // variant
+          $('#add_line_item_variant_id').val(data['variant']['id']);
+        }
       }
     }
     );
-
 
     var hideOrShowItemTables = function(){
       $('.promotion_action table').each(function(){
@@ -98,15 +95,14 @@ var initProductActions = function(){
     };
     setupRemoveLineItems();
     // Add line item to list
-    $(".promotion_action.create_line_items button.add").click(function(){
+    $(".promotion_action.create_line_items button.add").live('click',function(){
       var $container = $(this).parents('.promotion_action');
       var product_name = $container.find("input[name='add_product_name']").val();
-      var variant_id = $container.find("select[name='add_line_item_variant_id']").val();
-      var variant_name = $container.find("select[name='add_line_item_variant_id'] option:selected").text();
+      var variant_id = $container.find("input[name='add_line_item_variant_id']").val();
       var quantity = $container.find("input[name='add_quantity']").val();
       if(variant_id){
         // Add to the table
-        var newRow = "<tr><td>" + product_name + "</td><td>" + variant_name + "</td><td>" + quantity + "</td><td><img src='/admin/images/icons/cross.png' /></td></tr>";
+        var newRow = "<tr><td>" + product_name + "</td><td>" + quantity + "</td><td><img src='/admin/images/icons/cross.png' /></td></tr>";
         $container.find('table').append(newRow);
         // Add to serialized string in hidden text field
         var $hiddenField = $container.find("input[type='hidden']");


### PR DESCRIPTION
Currently the rails3-0 branch (and possibly others) has a non-working create line items action.

When you type in a product name, it just hangs, and you get a javascript error (which is related to the 'duplicate' variants dropdown I reference in issue #528).

This commit removes the drop down, and stores the selected variant in a hidden field (just like we do on the admin/orders/new product-autocomplete.
