### PR TITLE
Adding instructions about how to override the product_filters.rb file.

### DIFF
--- a/core/lib/product_filters.rb
+++ b/core/lib/product_filters.rb
@@ -2,6 +2,14 @@
 #   the exact code probably won't be useful, though you're welcome to modify and reuse
 #   the current contents are mainly for testing and documentation
 
+# To override this file...
+#   1) Make a copy of it in your sites local /lib folder
+#   2) Add it to the config load path, or require it in an initializer, e.g...
+#      
+#      # config/initializers/spree.rb
+#      require 'product_filters'
+#
+
 # set up some basic filters for use with products
 #
 # Each filter has two parts


### PR DESCRIPTION
Updating help text in product_filters.rb to include information on how to override and initialize the file. 
The lib directory is no longer auto loaded in Rails3 so manual initialization is required.
The commit just adds this information in to the file.
