### PR TITLE
allow more detailed ActiveMerchant exception messages to be logged

### DIFF
--- a/core/app/models/creditcard.rb
+++ b/core/app/models/creditcard.rb
@@ -89,8 +89,8 @@ class Creditcard < ActiveRecord::Base
       payment.failure
       gateway_error(response)
     end
-  rescue ActiveMerchant::ConnectionError
-    gateway_error I18n.t(:unable_to_connect_to_gateway)
+  rescue ActiveMerchant::ConnectionError => e
+    gateway_error e
   end
 
   def purchase(amount, payment)
@@ -109,8 +109,8 @@ class Creditcard < ActiveRecord::Base
       payment.failure
       gateway_error(response) unless response.success?
     end
-  rescue ActiveMerchant::ConnectionError
-    gateway_error I18n.t(:unable_to_connect_to_gateway)
+  rescue ActiveMerchant::ConnectionError => e
+    gateway_error e
   end
 
   def capture(payment)
@@ -136,8 +136,8 @@ class Creditcard < ActiveRecord::Base
       payment.failure
       gateway_error(response)
     end
-  rescue ActiveMerchant::ConnectionError
-    gateway_error I18n.t(:unable_to_connect_to_gateway)
+  rescue ActiveMerchant::ConnectionError => e
+    gateway_error e
   end
 
   def void(payment)
@@ -153,8 +153,8 @@ class Creditcard < ActiveRecord::Base
     else
       gateway_error(response)
     end
-  rescue ActiveMerchant::ConnectionError
-    gateway_error I18n.t(:unable_to_connect_to_gateway)
+  rescue ActiveMerchant::ConnectionError => e
+    gateway_error e
   end
 
   def credit(payment)
@@ -180,8 +180,8 @@ class Creditcard < ActiveRecord::Base
     else
       gateway_error(response)
     end
-  rescue ActiveMerchant::ConnectionError
-    gateway_error I18n.t(:unable_to_connect_to_gateway)
+  rescue ActiveMerchant::ConnectionError => e
+    gateway_error e
   end
 
   def actions
@@ -217,6 +217,8 @@ class Creditcard < ActiveRecord::Base
   def gateway_error(error)
     if error.is_a? ActiveMerchant::Billing::Response
       text = error.params['message'] || error.params['response_reason_text'] || error.message
+    elsif error.is_a? ActiveMerchant::ConnectionError
+      text = I18n.t(:unable_to_connect_to_gateway)  
     else
       text = error.to_s
     end

--- a/core/app/models/payment.rb
+++ b/core/app/models/payment.rb
@@ -102,7 +102,7 @@ class Payment < ActiveRecord::Base
       return unless source.is_a?(Creditcard) && source.number && !source.has_payment_profile?
       payment_method.create_profile(self)
     rescue ActiveMerchant::ConnectionError => e
-      gateway_error I18n.t(:unable_to_connect_to_gateway)
+      gateway_error e
     end
 
     def update_order


### PR DESCRIPTION
When ActiveMerchant raises the ConnectionError exception it passes along one of 4 useful error message, such as "The remote server reset the connection", which Spree currently ignores. This commit allows that text message to be logged while not changing what is shown through the web interface.
