### PR TITLE
check max value to avoid divide by 0 errors

### DIFF
--- a/core/app/models/calculator/flexi_rate.rb
+++ b/core/app/models/calculator/flexi_rate.rb
@@ -16,12 +16,14 @@ class Calculator::FlexiRate < Calculator
     max = self.preferred_max_items
     items_count = object.line_items.map(&:quantity).sum
     items_count.times do |i|
-      if (i % max == 0) && (max > 0)
+      # check max value to avoid divide by 0 errors
+      if (max == 0 && i == 0) || (max > 0) && (i % max == 0)
         sum += self.preferred_first_item
       else
         sum += self.preferred_additional_item
       end
     end
-    return(sum)
+    
+    sum
   end
 end

--- a/core/spec/models/calculator/flexi_rate_spec.rb
+++ b/core/spec/models/calculator/flexi_rate_spec.rb
@@ -1,0 +1,36 @@
+require_relative '../../spec_helper'
+
+describe Calculator::FlexiRate do
+  let(:calculator) { Calculator::FlexiRate.new }
+  let(:order) { mock_model Order, :line_items => [mock_model(LineItem, :amount => 10, :quantity => 4), mock_model(LineItem, :amount => 20, :quantity => 6)] }
+
+  context "compute" do
+    it "should compute amount correctly when all fees are 0" do
+      calculator.compute(order).round(2).should == 0.0
+    end
+
+    it "should compute amount correctly when first_item has a value" do
+      calculator.stub :preferred_first_item => 1.99
+      calculator.compute(order).round(2).should == 1.99
+    end
+    
+    it "should compute amount correctly when additional_items has a value" do
+      calculator.stub :preferred_additional_item => 0.99
+      expected = ( order.line_items.sum(&:quantity) - 1) * calculator.preferred_additional_item
+      calculator.compute(order).round(2).should == expected.round(2)
+    end
+    
+    it "should compute amount correctly when additional_items and first_item have values" do
+      calculator.stub :preferred_first_item => 1.99, :preferred_additional_item => 0.99
+      expected = (( order.line_items.sum(&:quantity) - 1) * calculator.preferred_additional_item) + calculator.preferred_first_item
+      calculator.compute(order).round(2).should == expected.round(2)
+    end
+    
+    it "should compute amount correctly when additional_items and first_item have values AND max items has value" do
+      calculator.stub :preferred_first_item => 1.99, :preferred_additional_item => 0.99, :preferred_max_items => 3
+      calculator.compute(order).round(2).should == 13.90
+    end
+    
+    
+  end
+end

--- a/core/spec/models/calculator/flexi_rate_spec.rb
+++ b/core/spec/models/calculator/flexi_rate_spec.rb
@@ -30,7 +30,5 @@ describe Calculator::FlexiRate do
       calculator.stub :preferred_first_item => 1.99, :preferred_additional_item => 0.99, :preferred_max_items => 3
       calculator.compute(order).round(2).should == 13.90
     end
-    
-    
   end
 end


### PR DESCRIPTION
In my business, we do not want max_items to play a role in our shipping costs. However, FlexiRate throws a divide by 0 error when max_items is 0. The patch addresses that error.

I've addressed this in my code through a decorator, but thought I should create this patch to see if it helped others -- or if I'm doing something silly!

Thanks for the great project!
