### PR TITLE
Fix syntax error for Ruby 1.9.2

### DIFF
--- a/core/spec/models/order_spec.rb
+++ b/core/spec/models/order_spec.rb
@@ -616,7 +616,7 @@ describe Order do
 
       it "should use default countries rate when none match address" do
         TaxRate.stub :match => []
-        rate.stub_chain :zone, :country_list => [mock_model Country, :id => Spree::Config[:default_country_id]]
+        rate.stub_chain :zone, :country_list => [mock_model(Country, :id => Spree::Config[:default_country_id])]
         rate_1.stub_chain :zone, :country_list => []
         TaxRate.stub :all => [rate, rate_1]
 


### PR DESCRIPTION
Hi there. I attempted to run the tests this morning and ran into a syntax error. I figured it out easily and fixed it with this small change.

All the spec tests pass on 1.9.2 now.
