### PR TITLE
New scopes for Order class

### DIFF
--- a/core/app/models/order.rb
+++ b/core/app/models/order.rb
@@ -42,6 +42,8 @@ class Order < ActiveRecord::Base
   scope :by_state, lambda {|state| where("state = ?", state)}
   scope :complete, where("orders.completed_at IS NOT NULL")
   scope :incomplete, where("orders.completed_at IS NULL")
+  scope :by_variant, lambda {|variant| joins(:line_items).where("line_items.variant_id = ?", variant.id)}
+  scope :by_variants, lambda {|variants| joins(:line_items).where("line_items.variant_id in (?)", variants.map(&:id))}
 
   make_permalink :field => :number
 

--- a/core/spec/models/order_spec.rb
+++ b/core/spec/models/order_spec.rb
@@ -625,5 +625,24 @@ describe Order do
         order.create_tax_charge!
       end
     end
+    
+    context "scope :by_variant and :by_variants" do
+      it "should return the Orders associated with a given variant" do
+        variant1 = mock_model(Variant, :product => "product1", :id => 1)
+        variant2 = mock_model(Variant, :product => "product2", :id => 2)
+        line_items = [mock_model(LineItem, :variant => variant1), mock_model(LineItem, :variant => variant2)]
+        order.stub(:line_items => line_items)
+        Order.by_variant(variant1).count.should == 1
+      end
+      it "should return the Orders associated with a given array of variants" do
+        variant1 = mock_model(Variant, :product => "product1", :id => 1, :sku => "ABC 123")
+        variant2 = mock_model(Variant, :product => "product2", :id => 2, :sku => "ABC 1234")
+        variants = [variant1,variant2]
+        line_items = [mock_model(LineItem, :variant => variant1), mock_model(LineItem, :variant => variant2)]
+        order.stub(:line_items => line_items)
+        Order.by_variants(variants).count.should == 2
+      end
+    end
+    
   end
 end


### PR DESCRIPTION
added two scopes on the Order class that allows users to scope Orders by variant or by an array of Variants.  I feel like this will help a lot of people. Added two tests in the order_spec.rb as well.
