### PR TITLE
Fix gsub bug when using i18n gems.

### DIFF
--- a/core/app/helpers/admin/navigation_helper.rb
+++ b/core/app/helpers/admin/navigation_helper.rb
@@ -15,7 +15,7 @@ module Admin::NavigationHelper
     destination_url = send("#{options[:route]}_path")
 
     ## if more than one form, it'll capitalize all words
-    label_with_first_letters_capitalized = t(options[:label], :default => options[:label]).gsub(/\b\w/){$&.upcase}
+    label_with_first_letters_capitalized = t(options[:label], :default => options[:label]).gsub(/\b\w/){|c| c.upcase}
 
     link = link_to(label_with_first_letters_capitalized, destination_url)
 


### PR DESCRIPTION
As discussed with BBQ, this is a weird bug that manifests itself when gems interfere with i18n features. Apparently also only for certain ruby interpreters.

This issue popped up for me when using CopyCopter, and this solved it.

This probably also solves spree/spree_static_content#16
