### PR TITLE
Removed unused variable @selected_variant

### DIFF
--- a/core/app/controllers/admin/tax_categories_controller.rb
+++ b/core/app/controllers/admin/tax_categories_controller.rb
@@ -2,7 +2,7 @@ class Admin::TaxCategoriesController < Admin::ResourceController
 
   def index
     if Spree::Config[:show_price_inc_vat] and (TaxCategory.where(:is_default => true).count != 1)
-      flash.notice = "You should configure exactly one default category with your countries default tax rate"
+      flash.notice = I18n.t("tax_category_error")
     end
   end
 end

--- a/core/app/controllers/products_controller.rb
+++ b/core/app/controllers/products_controller.rb
@@ -17,7 +17,6 @@ class ProductsController < Spree::BaseController
 
     @variants = Variant.active.includes([:option_values, :images]).where(:product_id => @product.id)
     @product_properties = ProductProperty.includes(:property).where(:product_id => @product.id)
-    @selected_variant = @variants.detect { |v| v.available? }
 
     referer = request.env['HTTP_REFERER']
 

--- a/core/app/models/line_item.rb
+++ b/core/app/models/line_item.rb
@@ -88,7 +88,7 @@ class LineItem < ActiveRecord::Base
 
     def stock_availability
       return if sufficient_stock?
-      errors.add(:quantity, "can't be greater than available stock.")
+      errors.add(:quantity, I18n.t("validation.cannot_be_greater_than_available_stock"))
     end
 
     def quantity_no_less_than_shipped

--- a/core/app/models/payment.rb
+++ b/core/app/models/payment.rb
@@ -90,7 +90,7 @@ class Payment < ActiveRecord::Base
     def amount_is_valid_for_outstanding_balance_or_credit
       return unless order
       if amount != order.outstanding_balance
-        errors.add(:amount, "does not match outstanding balance (#{order.outstanding_balance})")
+        errors.add(:amount, I18n.t("validation.does_not_match_outstanding_balance")+" (#{order.outstanding_balance})")
       end
     end
 

--- a/core/app/models/tax_rate.rb
+++ b/core/app/models/tax_rate.rb
@@ -3,6 +3,7 @@ class TaxRate < ActiveRecord::Base
   belongs_to :tax_category
 
   validates :amount, :presence => true, :numericality => true
+  validates :zone,   :presence => true
 
   calculated_adjustments :default => Calculator::SalesTax
   scope :by_zone, lambda { |zone| where("zone_id = ?", zone)}

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -958,6 +958,7 @@ en:
   tax_categories: "Tax Categories"
   tax_categories_setting_description: "Set up tax categories to identify which products should be taxable."
   tax_category: "Tax Category"
+  tax_category_error: "You should configure exactly one default category with your countries default tax rate"
   tax_rates: "Tax Rates"
   tax_rates_description: Tax rates setup and configuration.
   tax_settings: "Tax Settings"
@@ -1025,6 +1026,8 @@ en:
     is_too_large: "is too large -- stock on hand cannot cover requested quantity!"
     must_be_int: "must be an integer"
     must_be_non_negative: "must be a non-negative value"
+    cannot_be_greater_than_available_stock: "can't be greater than available stock."
+    does_not_match_outstanding_balance: "does not match outstanding balance"
   value: Value
   variant: Variant
   variants: Variants

--- a/core/spec/models/tax_rate_spec.rb
+++ b/core/spec/models/tax_rate_spec.rb
@@ -8,13 +8,19 @@ describe TaxRate do
     it { should have_valid_factory(:tax_rate) }
 
     it "should validate presence of amount" do
-      rate = TaxRate.new :zone => zone, :amount => nil
-      rate.save.should be_false
+      TaxRate.new(:zone => zone, :amount => nil).save.should be_false
+    end
+
+    it "should validate numericality of amount" do
+      TaxRate.new(:zone => zone, :amount => "hubbly bubbly").save.should be_false
     end
 
     it "should validate presence of zone" do
-      rate = TaxRate.new :zone => nil, :amount => 1
-      rate.save.should be_false
+      TaxRate.new(:zone => nil, :amount => 1).save.should be_false
+    end
+
+    it "should allow rates with valid amount and zone to be saved" do
+      TaxRate.new(:zone => zone, :amount => 1).save.should be_true
     end
   end
 

--- a/core/spec/models/tax_rate_spec.rb
+++ b/core/spec/models/tax_rate_spec.rb
@@ -3,7 +3,19 @@ require 'spec_helper'
 describe TaxRate do
 
   context 'validation' do
+    let(:zone) { Zone.new }
+
     it { should have_valid_factory(:tax_rate) }
+
+    it "should validate presence of amount" do
+      rate = TaxRate.new :zone => zone, :amount => nil
+      rate.save.should be_false
+    end
+
+    it "should validate presence of zone" do
+      rate = TaxRate.new :zone => nil, :amount => 1
+      rate.save.should be_false
+    end
   end
 
   context "match" do


### PR DESCRIPTION
In issue #410, someone complained about an error in a template caused by @selected_variant being nil. The product templates have already been changed, and @selected_variant is no longer used.

I recommend #410 should be closed.
