### PR TITLE
Password redirect fix when updating current user's password

### DIFF
--- a/auth/app/controllers/users_controller.rb
+++ b/auth/app/controllers/users_controller.rb
@@ -27,7 +27,7 @@ class UsersController < Spree::BaseController
       if params[:user][:password].present?
         # this logic needed b/c devise wants to log us out after password changes
         user = User.reset_password_by_token(params[:user])
-        sign_in(@user, :event => :authentication)
+        sign_in(@user, :event => :authentication, :bypass => true)
       end
       flash.notice = I18n.t("account_updated")
       redirect_to account_url

--- a/auth/app/controllers/users_controller.rb
+++ b/auth/app/controllers/users_controller.rb
@@ -27,7 +27,7 @@ class UsersController < Spree::BaseController
       if params[:user][:password].present?
         # this logic needed b/c devise wants to log us out after password changes
         user = User.reset_password_by_token(params[:user])
-        sign_in(@user, :event => :authentication, :bypass => true)
+        sign_in(@user, :event => :authentication, :bypass => !Spree::Auth::Config[:signout_after_password_change])
       end
       flash.notice = I18n.t("account_updated")
       redirect_to account_url

--- a/auth/app/models/spree_auth_configuration.rb
+++ b/auth/app/models/spree_auth_configuration.rb
@@ -1,3 +1,4 @@
 class SpreeAuthConfiguration < Configuration
   preference :registration_step, :boolean, :default => true
+  preference :signout_after_password_change, :boolean, :default => true
 end


### PR DESCRIPTION
devise requires :bypass => true when using sign_in with existing user session.
