### PR TITLE
Prompt for creation of a new admin during `rake db:admin:create`

### DIFF
--- a/auth/db/default/users.rb
+++ b/auth/db/default/users.rb
@@ -51,5 +51,16 @@ def create_admin_user
 end
 
 if Rails.env.development?
-  create_admin_user if User.where("roles.name" => 'admin').includes(:roles).empty?
+  if User.where("roles.name" => 'admin').includes(:roles).empty?
+    create_admin_user
+  else
+    puts "Admin user has already been previsouly created."
+    puts "Would you like to create a new admin user?"
+    res = STDIN.gets.chomp
+    if res =~ /y[es]*/
+      create_admin_user
+    else
+      puts "No admin user created."
+    end
+  end
 end


### PR DESCRIPTION
This should resolve issues reported at https://github.com/spree/spree/issues/686 by prompting the user to create a new admin if one already exists while running `rake db:admin:create`
