### PR TITLE
Fixes problem when trying to migrate with PostgreSQL

### DIFF
--- a/core/config/initializers/old_tables.rb
+++ b/core/config/initializers/old_tables.rb
@@ -1,6 +1,4 @@
-namespace_migration_version = 20111023201514
-
-#  NOTE: It is safe to remove this initializer once the database has been migrated above the version noted above.
+#  NOTE: It is safe to remove this initializer once the database has been migrated above the namespace_top_level_models migration.
 #
 #  This is a hack needed when running under PostgreSQL.  It's needed because certain ActiveRecord::Base
 #  calls (table_exists?, etc) will trigger a query such as this:
@@ -19,11 +17,9 @@ namespace_migration_version = 20111023201514
 #  by the time you call Spree::Product.table_name = 'products', it's too late.  Setting the table names explicitly
 #  below was the only way I could get the migrations to run properly.
 #
-current_version = ActiveRecord::Base.connection.tables.include?("schema_migrations") ?
-  ActiveRecord::Base.connection.execute("select version from schema_migrations order by version desc limit 1")[0]['version'].to_i
-  : 0
+tables = ActiveRecord::Base.connection.tables
 
-if current_version < namespace_migration_version
+if !tables.include?("schema_migrations") or !tables.include?("spree_products")
   Spree::Variant.class_eval do
     set_table_name 'variants'
   end
@@ -46,6 +42,14 @@ if current_version < namespace_migration_version
 
   Spree::Order.class_eval do
     set_table_name 'orders'
+  end
+
+  Spree::Adjustment.class_eval do
+    set_table_name 'adjustments'
+  end
+
+  Spree::Creditcard.class_eval do
+    set_table_name 'creditcards'
   end
 else
   puts "NOTE: Initializer #{__FILE__} is no longer needed and can be removed"

--- a/core/config/initializers/old_tables.rb
+++ b/core/config/initializers/old_tables.rb
@@ -1,0 +1,52 @@
+namespace_migration_version = 20111023201514
+
+#  NOTE: It is safe to remove this initializer once the database has been migrated above the version noted above.
+#
+#  This is a hack needed when running under PostgreSQL.  It's needed because certain ActiveRecord::Base
+#  calls (table_exists?, etc) will trigger a query such as this:
+#
+#    PGError: ERROR:  relation "spree_products" does not exist
+#    LINE 4:              WHERE a.attrelid = '"spree_products"'::regclass
+#                                            ^
+#    :             SELECT a.attname, format_type(a.atttypid, a.atttypmod), d.adsrc, a.attnotnull
+#                  FROM pg_attribute a LEFT JOIN pg_attrdef d
+#                    ON a.attrelid = d.adrelid AND a.attnum = d.adnum
+#                 WHERE a.attrelid = '"spree_products"'::regclass
+#                   AND a.attnum > 0 AND NOT a.attisdropped
+#                 ORDER BY a.attnum
+#
+#  Some of these calls happen when the model classes are loaded (Spree::Product).  When in the migrations,
+#  by the time you call Spree::Product.table_name = 'products', it's too late.  Setting the table names explicitly
+#  below was the only way I could get the migrations to run properly.
+#
+current_version = ActiveRecord::Base.connection.tables.include?("schema_migrations") ?
+  ActiveRecord::Base.connection.execute("select version from schema_migrations order by version desc limit 1")[0]['version'].to_i
+  : 0
+
+if current_version < namespace_migration_version
+  Spree::Variant.class_eval do
+    set_table_name 'variants'
+  end
+
+  Spree::Product.class_eval do
+    set_table_name 'products'
+  end
+
+  Spree::InventoryUnit.class_eval do
+    set_table_name 'inventory_units'
+  end
+
+  Spree::Taxon.class_eval do
+    set_table_name 'taxons'
+  end
+
+  Spree::Shipment.class_eval do
+    set_table_name 'shipments'
+  end
+
+  Spree::Order.class_eval do
+    set_table_name 'orders'
+  end
+else
+  puts "NOTE: Initializer #{__FILE__} is no longer needed and can be removed"
+end

--- a/core/db/migrate/20090923100315_add_count_on_hand_to_variants_and_products.rb
+++ b/core/db/migrate/20090923100315_add_count_on_hand_to_variants_and_products.rb
@@ -3,13 +3,6 @@ class AddCountOnHandToVariantsAndProducts < ActiveRecord::Migration
     add_column :variants, :count_on_hand, :integer, :default => 0, :null => false
     add_column :products, :count_on_hand, :integer, :default => 0, :null => false
 
-    # Due to our namespacing changes, this migration (from earlier Spree versions) is broken
-    # To fix it, temporarily set table name on each of the models involved
-    # And then...
-    Spree::Variant.table_name = 'variants'
-    Spree::Product.table_name = 'products'
-    Spree::InventoryUnit.table_name = 'inventory_units'
-
     # In some cases needed to reflect changes in table structure
     Spree::Variant.reset_column_information
     Spree::Product.reset_column_information
@@ -29,11 +22,6 @@ class AddCountOnHandToVariantsAndProducts < ActiveRecord::Migration
         p.update_attribute(:count_on_hand, product_count_on_hand)
       end
     end
-
-    # ... Switch things back at the end of the migration
-    Spree::Variant.table_name = 'spree_variants'
-    Spree::Product.table_name = 'spree_products'
-    Spree::InventoryUnit.table_name = 'spree_inventory_units'
   end
 
   def self.down

--- a/core/db/migrate/20091007134354_change_taxons_to_nested_set.rb
+++ b/core/db/migrate/20091007134354_change_taxons_to_nested_set.rb
@@ -5,9 +5,6 @@ class ChangeTaxonsToNestedSet < ActiveRecord::Migration
 
     Spree::Taxon.reset_column_information # So the new root ids get saved
 
-    # Temporarily set the table back to taxons
-    Spree::Taxon.table_name = 'taxons'
-
     Spree::Taxon.class_eval do
       # adapted from awesome nested set to use 'position' information
       indices = {}
@@ -34,9 +31,6 @@ class ChangeTaxonsToNestedSet < ActiveRecord::Migration
         set_left_and_rights.call(root_node)
       end
     end
-
-    # Set it back after the migration
-    Spree::Taxon.table_name = 'spree_taxons'
   end
 
   def self.down

--- a/core/db/migrate/20091015153048_add_openid_field_to_users.rb
+++ b/core/db/migrate/20091015153048_add_openid_field_to_users.rb
@@ -11,14 +11,9 @@ class AddOpenidFieldToUsers < ActiveRecord::Migration
   def self.down
     remove_column :users, :openid_identifier
 
-    # Due to namespacing change, temporarily set the table back to users
-    Spree::User.table_name = 'users'
-
     [:login, :crypted_password, :salt].each do |field|
       Spree::User.where(field => nil).each { |user| user.update_attribute(field, '') if user.send(field).nil? }
       change_column :users, field, :string, :default => '', :null => false
     end
-
-    Spree::User.table_name = 'spree_users'
   end
 end

--- a/core/db/migrate/20091021133257_charge_refactoring.rb
+++ b/core/db/migrate/20091021133257_charge_refactoring.rb
@@ -7,9 +7,6 @@ end
 
 class ChargeRefactoring < ActiveRecord::Migration
   def self.up
-    # Temporarily set table name for legacy support
-    Spree::Adjustment.table_name = "adjustments"
-
     add_column :orders, :completed_at, :timestamp
     Order.reset_column_information
     Order.all.each {|o| o.update_attribute(:completed_at, o.checkout && o.checkout.read_attribute(:completed_at)) }
@@ -19,9 +16,6 @@ class ChargeRefactoring < ActiveRecord::Migration
     Spree::Adjustment.update_all "type = secondary_type"
     Spree::Adjustment.update_all "type = 'CouponCredit'", "type = 'Credit'"
     remove_column :adjustments, :secondary_type
-
-    # Reset table name
-    Spree::Adjustment.table_name = "spree_adjustments"
   end
 
   def self.down

--- a/core/db/migrate/20100105132138_shipment_id_for_inventory_units.rb
+++ b/core/db/migrate/20100105132138_shipment_id_for_inventory_units.rb
@@ -3,9 +3,6 @@ class ShipmentIdForInventoryUnits < ActiveRecord::Migration
     add_column :inventory_units, :shipment_id, :integer
     add_index :inventory_units, :shipment_id
 
-    # migrate legacy shipments
-    Spree::Shipment.table_name = 'shipments'
-
     Spree::Shipment.all.each do |shipment|
       unless shipment.order
         puts "Warning: shipment has invalid order - #{shipment.id}"
@@ -15,8 +12,6 @@ class ShipmentIdForInventoryUnits < ActiveRecord::Migration
         unit.update_attribute('shipment_id', shipment.id)
       end
     end
-
-    Spree::Shipment.table_name = 'spree_shipments'
   end
 
   def self.down

--- a/core/db/migrate/20100209144531_polymorphic_payments.rb
+++ b/core/db/migrate/20100209144531_polymorphic_payments.rb
@@ -12,8 +12,6 @@ class PolymorphicPayments < ActiveRecord::Migration
     end
     execute "UPDATE payments SET payable_type = 'Order'"
 
-    Spree::Creditcard.table_name = 'creditcards'
-
     Spree::Creditcard.all.each do |creditcard|
       if checkout = Checkout.find_by_id(creditcard.checkout_id) and checkout.order
         if payment = checkout.order.payments.first
@@ -21,8 +19,6 @@ class PolymorphicPayments < ActiveRecord::Migration
         end
       end
     end
-
-    Spree::Creditcard.table_name = 'spree_creditcards'
 
     remove_column :creditcards, :checkout_id
   end

--- a/core/db/migrate/20100214212536_assign_creditcard_txns_to_payment.rb
+++ b/core/db/migrate/20100214212536_assign_creditcard_txns_to_payment.rb
@@ -2,16 +2,11 @@ class AssignCreditcardTxnsToPayment < ActiveRecord::Migration
   def self.up
     add_column :creditcard_txns, :payment_id, :integer
 
-    # Temporarily set back to creditcards
-    Spree::Creditcard.table_name = 'creditcards'
-
     ActiveRecord::Base.connection.select_all('SELECT * FROM creditcard_txns').each do |txn_attrs|
       if creditcard = Spree::Creditcard.find_by_id(txn_attrs['creditcard_id']) and creditcard.payments.first
         execute "UPDATE creditcard_txns SET payment_id = #{creditcard.payments.first.id} WHERE id = #{txn_attrs['id']}"
       end
     end
-
-    Spree::Creditcard.table_name = 'spree_creditcards'
 
     remove_column :creditcard_txns, :creditcard_payment_id
   end

--- a/core/db/migrate/20100506180619_add_icon_to_taxons.rb
+++ b/core/db/migrate/20100506180619_add_icon_to_taxons.rb
@@ -1,15 +1,11 @@
 class AddIconToTaxons < ActiveRecord::Migration
     def self.up
-      # legacy table support
-      Spree::Taxon.table_name = 'taxons'
       # skip this migration if the attribute already exists because of advanced taxon extension
       return if Spree::Taxon.new.respond_to? :icon_file_name
       add_column :taxons, :icon_file_name,    :string
       add_column :taxons, :icon_content_type, :string
       add_column :taxons, :icon_file_size,    :integer
       add_column :taxons, :icon_updated_at,   :datetime
-
-      Spree::Taxon.table_name = 'spree_taxons'
     end
 
     def self.down

--- a/core/db/migrate/20101026184714_migrate_transactions_to_payment_state.rb
+++ b/core/db/migrate/20101026184714_migrate_transactions_to_payment_state.rb
@@ -12,9 +12,6 @@ class MigrateTransactionsToPaymentState < ActiveRecord::Migration
   PAYMENT_COMPLETE = 'completed'
   PAYMENT_VOID = 'void'
   PAYMENT_PENDING = 'pending'
-  
-  # Temporarily set the table back to payments
-  Spree::Payment.table_name = 'payments'
 
   def self.up
     migrate_authorized_only_transactions
@@ -22,8 +19,6 @@ class MigrateTransactionsToPaymentState < ActiveRecord::Migration
     migrate_completed_transactions
     migrate_purchased_transactions
     migrate_credited_transactions
-
-    Spree::Payment.table_name = 'spree_payments'
   end
 
   def self.migrate_credited_transactions

--- a/core/db/migrate/20101026184959_generate_anonymous_users.rb
+++ b/core/db/migrate/20101026184959_generate_anonymous_users.rb
@@ -1,8 +1,5 @@
 class GenerateAnonymousUsers < ActiveRecord::Migration
   def self.up
-    Spree::User.table_name = 'users'
-    Spree::Order.table_name = 'orders'
-
     Spree::User.reset_column_information
     Spree::Order.where(:user_id => nil).each do |order|
       user = Spree::User.anonymous!
@@ -10,9 +7,6 @@ class GenerateAnonymousUsers < ActiveRecord::Migration
       order.user = user
       order.save!
     end
-
-    Spree::User.table_name = 'spree_users'
-    Spree::Order.table_name = 'spree_orders'
   end
 
   def self.down

--- a/core/db/migrate/20101026185022_update_order_state.rb
+++ b/core/db/migrate/20101026185022_update_order_state.rb
@@ -1,10 +1,6 @@
 class UpdateOrderState < ActiveRecord::Migration
   def self.up
-    Spree::Order.table_name = 'orders'
-
     Spree::Order.all.map(&:update!)
-
-    Spree::Order.table_name = 'spree_orders'
   end
 
   def self.down


### PR DESCRIPTION
You can read the comments in `core/config/initializers/old_tables.rb` to get the details of the issue this commit fixes.  Basically, when running under PostgreSQL, the migrations would fail when the table names were temporarily set using `.table_name = 'blah'`.  This is the cleanest way I could find to fix it.  Let me know if you have any questions.
