### PR TITLE
Fixed reference to unqualified reference to Taxon.

### DIFF
--- a/core/lib/spree/search/base.rb
+++ b/core/lib/spree/search/base.rb
@@ -36,7 +36,7 @@ module Spree::Search
       end
 
       def prepare(params)
-        @properties[:taxon] = params[:taxon].blank? ? nil : Taxon.find(params[:taxon])
+        @properties[:taxon] = params[:taxon].blank? ? nil : Spree::Taxon.find(params[:taxon])
         @properties[:keywords] = params[:keywords]
 
         per_page = params[:per_page].to_i


### PR DESCRIPTION
Was getting error in `Spree::Search::Base` due to using `Taxon` instead of `Spree::Taxon`.
