### PR TITLE
Spree::ProductsController can now look up taxon by param.

### DIFF
--- a/core/app/controllers/spree/products_controller.rb
+++ b/core/app/controllers/spree/products_controller.rb
@@ -24,6 +24,8 @@ module Spree
 
       if referer && referer.match(HTTP_REFERER_REGEXP)
         @taxon = Taxon.find_by_permalink($1)
+      elsif params[:taxon].present?
+        @taxon = Taxon.find(params[:taxon])
       end
 
       respond_with(@product)

--- a/core/spec/controllers/spree/products_controller_spec.rb
+++ b/core/spec/controllers/spree/products_controller_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+module Spree
+  describe ProductsController do
+
+    describe "#show" do
+      before do
+        Product.stub(:find_by_permalink!).and_return(Factory(:product))
+      end
+
+      context "when the :taxon param is present" do
+        let(:taxon_id) { '123' }
+
+        it "retrieves the Taxon by ID" do
+          Taxon.should_receive(:find).with(taxon_id)
+          get :show, :taxon => taxon_id
+        end
+      end
+
+      context "when the :taxon param is not present" do
+        it "doesn't retrieve the Taxon by ID" do
+          Taxon.should_not_receive(:find)
+          get :show
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a feature request, I guess.  I'm not using the SEO stuff on my project, so looking up the `Spree::Taxon` in the `Spree::ProductsController` didn't work for me.  Also, I don't think using the referer is a good way pull the current taxon information anyway, and probably needs to be re-thought.  If the user bookmarks the project show view, the referer won't be there, right?
