### PR TITLE
Use ActiveSupport::Multibyte::Chars#titleize instead of custom method

### DIFF
--- a/core/app/helpers/admin/navigation_helper.rb
+++ b/core/app/helpers/admin/navigation_helper.rb
@@ -15,7 +15,7 @@ module Admin::NavigationHelper
     destination_url = send("#{options[:route]}_path")
 
     ## if more than one form, it'll capitalize all words
-    label_with_first_letters_capitalized = t(options[:label], :default => options[:label]).gsub(/\b\w/){|c| c.upcase}
+    label_with_first_letters_capitalized = t(options[:label], :default => options[:label]).titleize
 
     link = link_to(label_with_first_letters_capitalized, destination_url)
 

--- a/core/spec/helpers/navigation_helper_spec.rb
+++ b/core/spec/helpers/navigation_helper_spec.rb
@@ -1,3 +1,4 @@
+# coding: UTF-8
 require 'spec_helper'
 
 describe Admin::NavigationHelper do
@@ -6,6 +7,16 @@ describe Admin::NavigationHelper do
       it "should capitalize the first letter of each word in the tab's label" do
         admin_tab = tab(:orders)
         admin_tab.should include("Orders")
+      end
+
+      it "should accept options with label and capitalize each word of it" do
+        admin_tab = tab(:orders, :label => "delivered orders")
+        admin_tab.should include("Delivered Orders")
+      end
+
+      it "should capitalize words with unicode characters" do
+        admin_tab = tab(:orders, :label => "přehled") # overview
+        admin_tab.should include("Přehled")
       end
     end
   end


### PR DESCRIPTION
Works with Unicode words like "Přehled"

BTW there is missing spec for unicode words "přehled" and also for multiple words with spaces "delivered orders"
# titleize doc - http://api.rubyonrails.org/classes/ActiveSupport/Multibyte/Chars.html#method-i-titleize

It would be great to pick this to 0.70.x stable branch.
