### PR TITLE
Using Spree::Variant.quoted_table_name and Spree::Asset.quoted_table_name

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -18,9 +18,6 @@
 # Sum of on_hand each variant's inventory level determine "on_hand" level for the product.
 #
 class Spree::Product < ActiveRecord::Base
-  variants_table_name = Spree::Variant.table_name
-  assets_table_name = Spree::Asset.table_name
-
   has_many :product_option_types, :dependent => :destroy
   has_many :option_types, :through => :product_option_types
   has_many :product_properties, :dependent => :destroy
@@ -33,7 +30,7 @@ class Spree::Product < ActiveRecord::Base
 
   has_one :master,
     :class_name => 'Spree::Variant',
-    :conditions => ["#{variants_table_name}.is_master = ? AND #{variants_table_name}.deleted_at IS NULL", true]
+    :conditions => ["#{Spree::Variant.quoted_table_name}.is_master = ? AND #{Spree::Variant.quoted_table_name}.deleted_at IS NULL", true]
 
   delegate_belongs_to :master, :sku, :price, :weight, :height, :width, :depth, :is_master
   delegate_belongs_to :master, :cost_price if Spree::Variant.table_exists? && Spree::Variant.column_names.include?('cost_price')
@@ -48,21 +45,21 @@ class Spree::Product < ActiveRecord::Base
 
   has_many :variants,
     :class_name => 'Spree::Variant',
-    :conditions => ["#{variants_table_name}.is_master = ? AND #{variants_table_name}.deleted_at IS NULL", false],
-    :order => "#{variants_table_name}.position ASC"
+    :conditions => ["#{::Spree::Variant.quoted_table_name}.is_master = ? AND #{::Spree::Variant.quoted_table_name}.deleted_at IS NULL", false],
+    :order => "#{::Spree::Variant.quoted_table_name}.position ASC"
 
   has_many :variants_including_master,
     :class_name => 'Spree::Variant',
-    :conditions => ["#{variants_table_name}.deleted_at IS NULL"],
+    :conditions => ["#{::Spree::Variant.quoted_table_name}.deleted_at IS NULL"],
     :dependent => :destroy
 
   has_many :variants_with_only_master,
     :class_name => 'Spree::Variant',
-    :conditions => ["#{variants_table_name}.deleted_at IS NULL AND #{variants_table_name}.is_master = ?", true],
+    :conditions => ["#{::Spree::Variant.quoted_table_name}.deleted_at IS NULL AND #{::Spree::Variant.quoted_table_name}.is_master = ?", true],
     :dependent => :destroy
 
   def variant_images
-    Spree::Image.find_by_sql("SELECT #{assets_table_name}.* FROM #{assets_table_name} LEFT JOIN #{variants_table_name} ON (#{variants_table_name}.id = #{assets_table_name}.viewable_id) WHERE (#{variants_table_name}.product_id = #{self.id})")
+    Spree::Image.find_by_sql("SELECT #{Spree::Asset.quoted_table_name}.* FROM #{Spree::Asset.quoted_table_name} LEFT JOIN #{Spree::Variant.quoted_table_name} ON (#{Spree::Variant.quoted_table_name}.id = #{Spree::Asset.quoted_table_name}.viewable_id) WHERE (#{Spree::Variant.table_name}.product_id = #{self.id})")
   end
 
   validates :name, :price, :permalink, :presence => true


### PR DESCRIPTION
Using Spree::Variant.quoted_table_name and Spree::Asset.quoted_table_name in place of hardcoded variables that don't always work.

cc @joneslee85 @radar
