### PR TITLE
Nil safety to tax_rate index view.

### DIFF
--- a/core/app/views/admin/tax_rates/index.html.erb
+++ b/core/app/views/admin/tax_rates/index.html.erb
@@ -21,7 +21,7 @@
     <% @tax_rates.each do |tax_rate|%>
     <tr id="<%= dom_id tax_rate %>" data-hook="rate_row">
       <td><%=tax_rate.zone.name %></td>
-      <td><%=tax_rate.tax_category.name %></td>
+      <td><%=tax_rate.tax_category.try(:name) %></td>
       <td><%=tax_rate.amount %></td>
       <td><%=tax_rate.calculator.to_s %></td>
       <td>


### PR DESCRIPTION
If TaxRate is created before any TaxCategory records exists. TaxRate index view crashes, because tax_rate.tax_category is nil.
