### PR TITLE
Fix typo in shared/_head template.

### DIFF
--- a/core/app/views/shared/_head.html.erb
+++ b/core/app/views/shared/_head.html.erb
@@ -1,6 +1,6 @@
 <title><%= title %></title>
 <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
-<%== meta_data_tags %>
+<%= meta_data_tags %>
 <%= stylesheet_link_tag 'store/all', :media => 'screen' %>
 <%= csrf_meta_tags %>
 <%= javascript_include_tag 'store/all' %>


### PR DESCRIPTION
There is an extra = sign when calling meta_data_tags.
