### PR TITLE
html_safe for return value on meta_data_tags helper

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -75,7 +75,7 @@ module Spree::BaseHelper
 
     meta.map do |name, content|
       tag('meta', :name => name, :content => content)
-    end.join("\n")
+    end.join("\n").html_safe
   end
 
   def body_class


### PR DESCRIPTION
html_safe for return value on meta_data_tags helper. Fixes bug introduced by commit 84ccd9f8372305db162553b0592852181c80de33
