### PR TITLE
Fixed lookup of Scopes because it generated a lookup error when using spree_sphinx_search

### DIFF
--- a/core/app/helpers/admin/product_groups_helper.rb
+++ b/core/app/helpers/admin/product_groups_helper.rb
@@ -4,7 +4,7 @@ module Admin::ProductGroupsHelper
   def product_scope_field(product_scope, i)
     value = (product_scope.arguments || [])[i]
     name = "product_group[product_scopes_attributes][][arguments][]"
-    helper_method_for_scope = Scopes::Product::ATTRIBUTE_HELPER_METHODS[product_scope.name.to_sym] || :text_field_tag
+    helper_method_for_scope = ::Scopes::Product::ATTRIBUTE_HELPER_METHODS[product_scope.name.to_sym] || :text_field_tag
     send(helper_method_for_scope, name, value)
   end
 

--- a/core/app/models/product_scope.rb
+++ b/core/app/models/product_scope.rb
@@ -41,7 +41,7 @@ class ProductScope < ActiveRecord::Base
 
   before_validation(:on => :create) {
     # Add default empty arguments so scope validates and errors aren't caused when previewing it
-     if name && args = Scopes::Product.arguments_for_scope_name(name)
+     if name && args = ::Scopes::Product.arguments_for_scope_name(name)
       self.arguments ||= ['']*args.length
     end
   }

--- a/core/app/views/admin/product_groups/_product_scope.html.erb
+++ b/core/app/views/admin/product_groups/_product_scope.html.erb
@@ -6,7 +6,7 @@
     <% end %>
   </td>
   <td data-hook="arguments">
-    <% if arguments = Scopes::Product.arguments_for_scope_name(product_scope.name.strip) %>
+    <% if arguments = ::Scopes::Product.arguments_for_scope_name(product_scope.name.strip) %>
       <table><tr>
       <% arguments.each_with_index do |argument, i| %>
         <td>

--- a/core/app/views/admin/product_groups/edit.html.erb
+++ b/core/app/views/admin/product_groups/edit.html.erb
@@ -14,7 +14,7 @@
 
       <%= f.field_container :order_scope do %>
         <%= f.label :order_scope, t(:sort_ordering) %><br />
-        <%= f.select(:order_scope, Scopes::Product::ORDERING.collect{|p| [ t(:name, :scope =>[:product_scopes, :scopes, p]), p.to_s ] }) %>
+        <%= f.select(:order_scope, ::Scopes::Product::ORDERING.collect{|p| [ t(:name, :scope =>[:product_scopes, :scopes, p]), p.to_s ] }) %>
       <% end %>
 
       <table id="product_scopes" data-hook>
@@ -29,7 +29,7 @@
     <%
     options =
     grouped_options_for_select(
-    Scopes::Product::SCOPES.map do |group_name, scopes|
+    ::Scopes::Product::SCOPES.map do |group_name, scopes|
       [
         t(:name, :scope => [:product_scopes, :groups, group_name]),
         scopes.keys.map do |scope_name|

--- a/core/lib/scopes.rb
+++ b/core/lib/scopes.rb
@@ -56,7 +56,7 @@ module Scopes
   def generate_translations
     require 'ya2yaml'
     {
-      'product_scopes' => generate_translation(Scopes::Product::SCOPES)
+      'product_scopes' => generate_translation(::Scopes::Product::SCOPES)
     }.ya2yaml
   end
 end

--- a/core/lib/scopes/product.rb
+++ b/core/lib/scopes/product.rb
@@ -239,7 +239,7 @@ SQL
   end
 
   def self.arguments_for_scope_name(name)
-    if group = Scopes::Product::SCOPES.detect{|k,v| v[name.to_sym]}
+    if group = ::Scopes::Product::SCOPES.detect{|k,v| v[name.to_sym]}
       group[1][name.to_sym]
     end
   end


### PR DESCRIPTION
When using the `spree_sphinx_search`-extension, a lookup error regarding the Scopes module occurs when creating a ProductScope in a ProductGroup. The error message is as follows:

```
NameError: uninitialized constant ThinkingSphinx::ActiveRecord::Scopes::Product
```

This pull request fixes this error. It changes all occurrences of `Scopes` to `::Scopes`.
