### PR TITLE
Fix eWay test mode so it looks for the :test_mode and not :test

### DIFF
--- a/core/app/models/gateway/eway.rb
+++ b/core/app/models/gateway/eway.rb
@@ -3,9 +3,21 @@ class Gateway::Eway < Gateway
 
   # Note: EWay supports purchase method only (no authorize method).
   # Ensure Spree::Config[:auto_capture] is set to true
+  # There is now ActiveMerchant::Billing::EwayManagedGateway if you need token payments.
 
   def provider_class
     ActiveMerchant::Billing::EwayGateway
+  end
+  
+  def options
+    # add :test key in the options hash, as that is what the ActiveMerchant::Billing::EwayGateway expects
+    if self.prefers? :test_mode
+      self.class.default_preferences[:test] = true
+    else
+      self.class.default_preferences.delete(:test)
+    end
+
+    super
   end
 
 end

--- a/core/spec/models/gateway/eway_spec.rb
+++ b/core/spec/models/gateway/eway_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe Gateway::Eway do
+  let (:gateway) { Gateway::Eway.new }
+
+  describe "options" do
+    it "should include :test => true in  when :test_mode is true" do
+      gateway.prefers_test_mode = true
+      gateway.options[:test].should == true
+    end
+
+    it "should not include :test when test_mode is false" do
+      gateway.prefers_test_mode = false
+      gateway.options[:test].should be_nil
+    end
+  end
+end


### PR DESCRIPTION
Fixes the eWay test mode so it looks for the :test_mode and not :test preference for ActiveMerchant.

Fixes #554, This is the same issue as #100
