### PR TITLE
best_selling_variants and top_grossing_variants are now calculated properly

### DIFF
--- a/dash/app/controllers/spree/admin/overview_controller.rb
+++ b/dash/app/controllers/spree/admin/overview_controller.rb
@@ -98,7 +98,7 @@ class Spree::Admin::OverviewController < Spree::Admin::BaseController
     end
 
     def best_selling_variants
-      li = LineItem.includes(:order).where("#{Spree::Order.table_name}.state = 'complete'").order("SUM(#{Spree::LineItem.table_name}.quantity) DESC").sum(:quantity, :group => :variant_id, :limit => 5)	
+      li = Spree::LineItem.includes(:order).where("#{Spree::Order.table_name}.state = 'complete'").order("SUM(#{Spree::LineItem.table_name}.quantity) DESC").sum(:quantity, :group => :variant_id, :limit => 5)	
       variants = li.map do |v|
         variant = Spree::Variant.find(v[0])
         [variant.name, v[1] ]
@@ -107,7 +107,7 @@ class Spree::Admin::OverviewController < Spree::Admin::BaseController
     end
 
     def top_grossing_variants
-      total_sold_prices = LineItem.includes(:order).where("#{Spree::Order.table_name}.state = 'complete'").order("SUM(#{Spree::LineItem.table_name}.quantity * #{Spree::LineItem.table_name}.price) DESC").sum("price * quantity", :group => :variant_id, :limit => 5)	
+      total_sold_prices = Spree::LineItem.includes(:order).where("#{Spree::Order.table_name}.state = 'complete'").order("SUM(#{Spree::LineItem.table_name}.quantity * #{Spree::LineItem.table_name}.price) DESC").sum("price * quantity", :group => :variant_id, :limit => 5)	
       variants = total_sold_prices.map do |v|
         variant = Spree::Variant.find(v[0])
         [variant.name, v[1]]

--- a/dash/app/controllers/spree/admin/overview_controller.rb
+++ b/dash/app/controllers/spree/admin/overview_controller.rb
@@ -98,7 +98,7 @@ class Spree::Admin::OverviewController < Spree::Admin::BaseController
     end
 
     def best_selling_variants
-      li = Spree::LineItem.includes(:order).where("#{Spree::Order.table_name}.state = 'complete'").sum(:quantity, :group => :variant_id, :limit => 5)
+      li = LineItem.includes(:order).where("#{Spree::Order.table_name}.state = 'complete'").order("SUM(#{Spree::LineItem.table_name}.quantity) DESC").sum(:quantity, :group => :variant_id, :limit => 5)	
       variants = li.map do |v|
         variant = Spree::Variant.find(v[0])
         [variant.name, v[1] ]
@@ -107,11 +107,10 @@ class Spree::Admin::OverviewController < Spree::Admin::BaseController
     end
 
     def top_grossing_variants
-      quantity = Spree::LineItem.includes(:order).where("#{Spree::Order.table_name}.state = 'complete'").sum(:quantity, :group => :variant_id, :limit => 5)
-      prices = Spree::LineItem.includes(:order).where("#{Spree::Order.table_name}.state = 'complete'").sum(:price, :group => :variant_id, :limit => 5)
-      variants = quantity.map do |v|
+      total_sold_prices = LineItem.includes(:order).where("#{Spree::Order.table_name}.state = 'complete'").order("SUM(#{Spree::LineItem.table_name}.quantity * #{Spree::LineItem.table_name}.price) DESC").sum("price * quantity", :group => :variant_id, :limit => 5)	
+      variants = total_sold_prices.map do |v|
         variant = Spree::Variant.find(v[0])
-        [variant.name, v[1] * prices[v[0]]]
+        [variant.name, v[1]]
       end
 
       variants.sort { |x,y| y[1] <=> x[1] }


### PR DESCRIPTION
adjusted to use namespacing.
#718 reworked according to master (file path, namespace).
