### PR TITLE
Deprecate Gateway.current

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -91,7 +91,7 @@ class Spree::Order < ActiveRecord::Base
 
       # note: some payment methods will not support a confirm step
       transition :from => 'payment',  :to => 'confirm',
-                                      :if => Proc.new { Spree::Gateway.current && Spree::Gateway.current.payment_profiles_supported? }
+                                      :if => Proc.new { |order| order.payment_method && order.payment_method.payment_profiles_supported? }
 
       transition :from => 'payment', :to => 'complete'
     end

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -25,7 +25,9 @@ class Spree::PaymentMethod < ActiveRecord::Base
     self.count(:conditions => { :type => self.to_s, :environment => Rails.env, :active => true }) > 0
   end
 
+  # TODO: Remove this method by 0.90.x
   def self.current
+    ActiveSupport::Deprecation.warn "Gateway.current is deprecated and will be removed in Spree 0.90.x. Use current_order.payment_method instead."
     first(:conditions => { :active => true, :environment => Rails.env })
   end
 

--- a/core/lib/spree/core/controller_helpers.rb
+++ b/core/lib/spree/core/controller_helpers.rb
@@ -108,6 +108,7 @@ module Spree
         end
 
         def current_gateway
+          ActiveSupport::Deprecation.warn "current_gateway is deprecated and will be removed in Spree 0.90.x"
           @current_gateway ||= Gateway.current
         end
 

--- a/core/spec/models/order_spec.rb
+++ b/core/spec/models/order_spec.rb
@@ -121,7 +121,7 @@ describe Spree::Order do
     context "when current state is address" do
       let(:sales_tax) { mock_model Spree::Calculator::SalesTax, :description => "Sales Tax" }
       let(:rate) { mock_model Spree::TaxRate, :amount => 10, :calculator => sales_tax }
-      let(:rate_1) { mock_model Spree::TaxRate, :amount => 15, :calculator => sales_tax } 
+      let(:rate_1) { mock_model Spree::TaxRate, :amount => 15, :calculator => sales_tax }
 
       before do
         order.state = "address"
@@ -462,6 +462,20 @@ describe Spree::Order do
 
   end
 
+  context "#payment_method" do
+    it "should return payment.payment_method if payment is present" do
+      payments = [Factory(:payment)]
+      payments.stub(:completed => payments)
+      order.stub(:payments => payments)
+      order.payment_method.should == order.payments.first.payment_method
+    end
+
+    it "should return the first payment method from available_payment_methods if payment is not present" do
+      Factory(:payment_method, :environment => 'test')
+      order.payment_method.should == order.available_payment_methods.first
+    end
+  end
+
   context "#allow_checkout?" do
     it "should be true if there are line_items in the order" do
       order.stub_chain(:line_items, :count => 1)
@@ -575,7 +589,7 @@ describe Spree::Order do
   end
 
   context "insufficient_stock_lines" do
-    let(:line_item) { mock_model Spree::LineItem, :insufficient_stock? => true } 
+    let(:line_item) { mock_model Spree::LineItem, :insufficient_stock? => true }
 
     before { order.stub(:line_items => [line_item]) }
 
@@ -589,10 +603,10 @@ describe Spree::Order do
   context "create_tax_charge!" do
     let(:sales_tax) { mock_model Spree::Calculator::SalesTax, :compute => 3, :[]= => nil, :description => "Money for the man" }
     let(:rate) { Spree::TaxRate.create(:amount => 0.05) }
-    let(:rate_1) { Spree::TaxRate.create(:amount => 0.15) } 
+    let(:rate_1) { Spree::TaxRate.create(:amount => 0.15) }
 
     it "should destory all existing tax adjustments" do
-      adjustment = mock_model(Spree::Adjustment, :amount => 5, :calculator => :sales_tax) 
+      adjustment = mock_model(Spree::Adjustment, :amount => 5, :calculator => :sales_tax)
       adjustment.should_receive :destroy
 
       order.stub_chain :adjustments, :tax => [adjustment]
@@ -605,7 +619,7 @@ describe Spree::Order do
 
       order.create_tax_charge!
       order.adjustments.tax.size.should == 2
- 
+
       ["Money for the man 5.0%", "Money for the man 15.0%"].each do |label|
         order.adjustments.tax.map(&:label).include?(label).should be_true
       end


### PR DESCRIPTION
Use order's payment method rather than Gateway.current. Also added specs for Order#payment_method
