### PR TITLE
Use Rails.groups when doing Bundler.require

### DIFF
--- a/core/lib/generators/spree/dummy/templates/rails/application.rb
+++ b/core/lib/generators/spree/dummy/templates/rails/application.rb
@@ -2,7 +2,7 @@ require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'
 
-Bundler.require(Rails.env)
+Bundler.require(*Rails.groups)
 
 require '<%= lib_name %>'
 


### PR DESCRIPTION
Bundler doesn't require any of the non group associated gems unless it is passed the `:default` group in the `Bundler.require *groups` call.

This means for example that all the gems in the main [`Gemfile`](https://github.com/spree/spree/blob/73bae75e642f2a1a397b43c726ee93095131c48d/Gemfile) not-included in any of the `group :something do` blocks are _not_ required by Bundler.
