### PR TITLE
Fix unexpected end of file error in adjustment decorator model.

### DIFF
--- a/promo/app/models/spree/adjustment_decorator.rb
+++ b/promo/app/models/spree/adjustment_decorator.rb
@@ -1,3 +1,3 @@
-class Adjustment.class_eval do
+Spree::Adjustment.class_eval do
   scope :promotion, lambda { where('label LIKE ?', "#{I18n.t(:promotion)}%") }
 end


### PR DESCRIPTION
Fix to get specs running again, which currently fail trying to parse this file.

/Users/JD/spree/promo/app/models/spree/adjustment_decorator.rb:4: syntax error, unexpected '\n', expecting tCOLON2 or '[' or '.'
