### PR TITLE
Tax Category removal causes issue if there are Tax Rates children

### DIFF
--- a/core/app/models/spree/tax_category.rb
+++ b/core/app/models/spree/tax_category.rb
@@ -2,7 +2,7 @@ module Spree
   class TaxCategory < ActiveRecord::Base
     validates :name, :presence => true, :uniqueness => true
 
-    has_many :tax_rates
+    has_many :tax_rates, :dependent => :restrict
 
     before_save :set_default_category
 

--- a/core/spec/models/tax_category_spec.rb
+++ b/core/spec/models/tax_category_spec.rb
@@ -51,5 +51,15 @@ describe Spree::TaxCategory do
 
   end
 
+  context 'delete' do
+    let!(:tax_category) {Factory(:tax_category)}
+    let!(:tax_rate) {Factory(:tax_rate, :tax_category => tax_category)}
+    it "should not allow deletion when tax rates are assigned" do
+      p tax_category.inspect
+      lambda {tax_category.destroy}.should raise_error ActiveRecord::DeleteRestrictionError
+      p tax_category.inspect
+    end
+  end
+
 
 end


### PR DESCRIPTION
When removing a tax category, if there are tax rate children, when going to the tax rate index page, an error is raised.
