### PR TITLE
Ruby 1.9 method defined check fix

### DIFF
--- a/promo/app/models/spree/order_decorator.rb
+++ b/promo/app/models/spree/order_decorator.rb
@@ -10,7 +10,7 @@ Spree::Order.class_eval do
     line_items.map {|li| li.variant.product}
   end
 
-  unless self.instance_methods.include?('update_adjustments_with_promotion_limiting')
+  unless self.method_defined?('update_adjustments_with_promotion_limiting')
     def update_adjustments_with_promotion_limiting
       update_adjustments_without_promotion_limiting
       return if adjustments.promotion.eligible.none?


### PR DESCRIPTION
Module#instance_methods returns Strings on 1.8 and Symbols on 1.9, sidestep the issue by using Module#method_defined?.
