### PR TITLE
go from pending to passing request spec

### DIFF
--- a/core/spec/requests/admin/orders/customer_details_spec.rb
+++ b/core/spec/requests/admin/orders/customer_details_spec.rb
@@ -16,7 +16,6 @@ describe "Customer Details" do
     end
 
     it "should be able to update customer details for an existing order" do
-      pending
       click_link "Orders"
       within(:css, 'table#listing_orders tr:nth-child(2)') { click_link "Edit" }
       click_link "Customer Details"
@@ -39,7 +38,6 @@ describe "Customer Details" do
     end
 
     it "should show validation errors" do
-      pending
       click_link "Orders"
       within(:css, 'table#listing_orders tr:nth-child(2)') { click_link "Edit" }
       click_link "Customer Details"


### PR DESCRIPTION
Simply removing the 'pending' caused the tests to pass.

It looks like the tests do what the 'it' section asks, so I'm thinking these 'pending's were just accidentally left in place?
