### PR TITLE
Build against multiple rubies for better coverage.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,8 @@ notifications:
 branches:
   only:
     - master
+rvm:
+  - 1.8.7
+  - 1.9.2
+  - 1.9.3
+  - ree


### PR DESCRIPTION
Travis-CI should build against any supported versions of ruby.  I'm not sure which are actually fully supported, but that can be adjusted easily enough.
