### PR TITLE
Use twiddle wakka for rails dependency.

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'paperclip', '= 2.4.1'
   s.add_dependency 'meta_search', '= 1.1.1'
   s.add_dependency 'activemerchant', '= 1.17.0'
-  s.add_dependency 'rails', '>= 3.1.1', '<= 3.1.3'
+  s.add_dependency 'rails', '~> 3.1.1'
   s.add_dependency 'kaminari', '>= 0.12.4'
   s.add_dependency 'deface', '>= 0.7.1'
 end


### PR DESCRIPTION
Since your experimenting with loosening up the rails dependency I think it would be simpler to use a twiddle wakka:

```
s.add_dependency 'rails', '~>  3.1.1'
```

This would allow developers to update their rails version to to any 3.1.x release above 3.1.1 without waiting for a spree update after every release.  Should problems be found with a particular new Rails release than it would be more appropriate to go to the >= / <= versioning.

This will help developers keep up to date easier, and reduce the development Spree needs to do.

http://robots.thoughtbot.com/post/2508037841/twiddle-wakka
