### PR TITLE
Fix extension.gemspec template to include factory_girl 

### DIFF
--- a/core/lib/generators/spree/extension/templates/extension.gemspec
+++ b/core/lib/generators/spree/extension/templates/extension.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency 'spree_core', '>= <%= Spree.version %>'
-  s.add_development_dependency 'rspec-rails'
+  s.add_development_dependency 'factory_girl', '~> 2.3'
+  s.add_development_dependency 'rspec-rails', '~> 2.7'
 end
-


### PR DESCRIPTION
Otherwise the spec_helper fails requiring the Spree::Core factories.

Also added restraint to rspec-rails since the spec_helper would probably need to be changed if it goes to 3.0.
