### PR TITLE
Fix dropdown for selecting a calculator for a Shipping Method.

### DIFF
--- a/core/app/views/spree/admin/shared/_calculator_fields.html.erb
+++ b/core/app/views/spree/admin/shared/_calculator_fields.html.erb
@@ -3,7 +3,7 @@
   <div id="preference-settings" data-hook>
     <p>
       <%= f.label(:calc_type, t(:calculator), :for => 'calc-type') %>
-      <%= f.collection_select(:calculator_type, @calculators, :to_s, :description, {}, {:id => 'calc-type'}) %>
+      <%= f.select(:calculator_type, @calculators.map { |c| [c.description, c.name] }, {:id => 'calc-type'}) %>
     </p>
     <% if !@object.new_record? %>
       <div class="calculator-settings">


### PR DESCRIPTION
`description` was resulting in invalid class names and exceptions
when trying to update the calculator for a Shipping Method.
