### PR TITLE
Remove cucumber from extension generators Gemfile and update Readme.

### DIFF
--- a/core/lib/generators/spree/extension/templates/Gemfile
+++ b/core/lib/generators/spree/extension/templates/Gemfile
@@ -3,17 +3,7 @@ source 'http://rubygems.org'
 gem 'sqlite3'
 
 group :test do
-  gem 'rspec-rails', '= 2.6.1'
-end
-
-group :cucumber do
-  gem 'cucumber-rails', '1.0.0'
-  gem 'database_cleaner', '= 0.6.7'
-  gem 'nokogiri'
   gem 'capybara', '1.0.1'
-end
-
-group :test, :cucumber do
   gem 'ffaker'
   gem 'factory_girl'
 end

--- a/core/lib/generators/spree/extension/templates/README.md
+++ b/core/lib/generators/spree/extension/templates/README.md
@@ -12,8 +12,9 @@ Example goes here.
 Testing
 -------
 
-Be sure to add the rspec-rails gem to your Gemfile and then create a dummy test app for the specs to run against.
+Be sure to bundle your dependencies and then create a dummy test app for the specs to run against.
 
+    $ bundle
     $ bundle exec rake test app
     $ bundle exec rspec spec
 

--- a/core/lib/generators/spree/extension/templates/extension.gemspec
+++ b/core/lib/generators/spree/extension/templates/extension.gemspec
@@ -17,6 +17,5 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency 'spree_core', '>= <%= Spree.version %>'
-  s.add_development_dependency 'rspec-rails'
+  s.add_development_dependency 'rspec-rails', '~> 2.7'
 end
-


### PR DESCRIPTION
I think only including rspec in the extension generator will do for most developers.  I don't see cucumber being used for many extensions, and the developer can easily add it if they would like.

Also rspec isn't required in the Gemfile since it's in the gemspec.  Personally I'd like to move all the dependencies to just the gemspec as well where its best practice.

Also can anyone let me know how to generate an extension from edge spree using my local repo?
