### PR TITLE
Move extension dependencies to gemspec.

### DIFF
--- a/core/lib/generators/spree/extension/templates/Gemfile
+++ b/core/lib/generators/spree/extension/templates/Gemfile
@@ -1,11 +1,7 @@
 source 'http://rubygems.org'
 
-gem 'sqlite3'
-
 group :test do
-  gem 'capybara', '1.0.1'
   gem 'ffaker'
-  gem 'factory_girl'
 end
 
 if RUBY_VERSION < "1.9"

--- a/core/lib/generators/spree/extension/templates/extension.gemspec
+++ b/core/lib/generators/spree/extension/templates/extension.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'capybara', '1.0.1'
   s.add_development_dependency 'factory_girl'
+  s.add_devleopment_dependency 'ffaker'
   s.add_development_dependency 'rspec-rails',  '~> 2.7'
   s.add_development_dependency 'sqlite3'
 end

--- a/core/lib/generators/spree/extension/templates/extension.gemspec
+++ b/core/lib/generators/spree/extension/templates/extension.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'capybara', '1.0.1'
   s.add_development_dependency 'factory_girl'
-  s.add_devleopment_dependency 'ffaker'
+  s.add_development_dependency 'ffaker'
   s.add_development_dependency 'rspec-rails',  '~> 2.7'
   s.add_development_dependency 'sqlite3'
 end

--- a/core/lib/generators/spree/extension/templates/extension.gemspec
+++ b/core/lib/generators/spree/extension/templates/extension.gemspec
@@ -17,5 +17,9 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency 'spree_core', '>= <%= Spree.version %>'
-  s.add_development_dependency 'rspec-rails', '~> 2.7'
+
+  s.add_development_dependency 'capybara', '1.0.1'
+  s.add_development_dependency 'factory_girl'
+  s.add_development_dependency 'rspec-rails',  '~> 2.7'
+  s.add_development_dependency 'sqlite3'
 end


### PR DESCRIPTION
ffaker is the only gem not initializing itself from the gemspec.
