### PR TITLE
Spree Preference Fixes

### DIFF
--- a/core/app/controllers/spree/admin/general_settings_controller.rb
+++ b/core/app/controllers/spree/admin/general_settings_controller.rb
@@ -9,18 +9,13 @@ module Spree
       def edit
         @preferences = [:site_name, :default_seo_title, :default_meta_keywords,
                         :default_meta_description, :site_url, :allow_ssl_in_production,
-                        :allow_ssl_in_development_and_test]
+                        :allow_ssl_in_development_and_test, :check_for_spree_alerts]
       end
 
       def update
         params.each do |name, value|
           next unless Spree::Config.has_preference? name
-
-          if Spree::Config.preference_type(name) == :boolean
-            Spree::Config[name] = (value == "1")
-          else
-            Spree::Config[name] = value
-          end
+          Spree::Config[name] = value
         end
 
         redirect_to admin_general_settings_path

--- a/core/app/models/spree/preference.rb
+++ b/core/app/models/spree/preference.rb
@@ -16,7 +16,7 @@ class Spree::Preference < ActiveRecord::Base
     when Fixnum.to_s
       self[:value].to_i
     when Bignum.to_s
-      self[:value].to_i
+      self[:value].to_f.to_i
     when Float.to_s
       self[:value].to_f
     when TrueClass.to_s

--- a/core/app/models/spree/preferences/preferable.rb
+++ b/core/app/models/spree/preferences/preferable.rb
@@ -15,6 +15,8 @@ module Spree::Preferences::Preferable
     raise NoMethodError.new "#{name} preference not defined" unless has_preference? name
     send self.class.preference_getter_method(name)
   end
+  alias :preferred :get_preference
+  alias :prefers? :get_preference
 
   def set_preference(name, value)
     raise NoMethodError.new "#{name} preference not defined" unless has_preference? name

--- a/core/app/models/spree/preferences/preferable_class_methods.rb
+++ b/core/app/models/spree/preferences/preferable_class_methods.rb
@@ -4,8 +4,6 @@ module Spree::Preferences
     def preference(name, type, *args)
       options = args.extract_options!
       options.assert_valid_keys(:default)
-
-      value_type = args.first
       default = options[:default]
 
       define_method preference_getter_method(name) do
@@ -32,7 +30,7 @@ module Spree::Preferences
       end
 
       define_method preference_type_getter_method(name) do
-        value_type
+        type
       end
 
     end

--- a/core/app/views/spree/admin/general_settings/show.html.erb
+++ b/core/app/views/spree/admin/general_settings/show.html.erb
@@ -24,6 +24,11 @@
       <%= Spree::Config[:allow_ssl_in_development_and_test] ? t(:ssl_will_be_used_in_development_and_test_modes) : t(:ssl_will_not_be_used_in_development_and_test_modes) %>
     </td>
   </tr>
+  <tr>
+    <td colspan="2">
+      <%= (Spree::Config[:check_for_spree_alerts] ? t("spree_alert_checking") : t("spree_alert_not_checking")) %>
+    </td>
+  </tr>
 </table>
 
 <p><%= link_to_with_icon 'edit', t(:edit), edit_admin_general_settings_path, :id => 'admin_general_settings_link' %></p>

--- a/core/app/views/spree/admin/payment_methods/edit.html.erb
+++ b/core/app/views/spree/admin/payment_methods/edit.html.erb
@@ -2,7 +2,7 @@
 
 <h1><%= t(:editing_payment_method) %></h1>
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @payment_method } %>
-<%= form_for [:spree, @payment_method], :url => admin_payment_method_path(@payment_method), :html => { :method => :put } do |f| %>
+<%= form_for @payment_method, :url => admin_payment_method_path(@payment_method), :html => { :method => :put } do |f| %>
   <%= render :partial => 'form', :locals => { :f => f } %>
   <p data-hook="buttons">
     <%= submit_tag t(:update) %>

--- a/core/db/migrate/20111128153359_new_preferences.rb
+++ b/core/db/migrate/20111128153359_new_preferences.rb
@@ -10,9 +10,16 @@ class NewPreferences < ActiveRecord::Migration
     add_column :spree_preferences, :value_type, :string
     add_index :spree_preferences, :key, :unique => true
 
+    # remove old constraints for migration
+    change_column :spree_preferences, :name, :string, :null => true
+    change_column :spree_preferences, :owner_id, :integer, :null => true
+    change_column :spree_preferences, :owner_type, :string, :null => true
+    change_column :spree_preferences, :group_id, :integer, :null => true
+    change_column :spree_preferences, :group_type, :string, :null => true
+
     OldPrefs.all.each do |old_pref|
       next unless old_pref.owner
-      say "Migrating prefence #{old_pref.name}..."
+      say "Migrating preference #{old_pref.name}..."
       old_pref.owner.set_preference old_pref.name, old_pref.value
     end
 
@@ -35,3 +42,4 @@ class NewPreferences < ActiveRecord::Migration
   end
 
 end
+

--- a/core/spec/models/preference_spec.rb
+++ b/core/spec/models/preference_spec.rb
@@ -1,16 +1,16 @@
 require 'spec_helper'
 
 describe Spree::Preference do
-  before :each do
-    @preference = Spree::Preference.new
-  end
 
   it "should require a key" do
+    @preference = Spree::Preference.new
     @preference.key = :test
     @preference.should be_valid
   end
 
   it "sets the value type with value" do
+    @preference = Spree::Preference.new
+
     @preference.value = true
     @preference.value_type.should eq TrueClass.to_s
 
@@ -18,11 +18,66 @@ describe Spree::Preference do
     @preference.value_type.should eq String.to_s
   end
 
-  it "converts the value to the value_type" do
-    @preference.value = "1"
-    @preference.value_type = Fixnum.to_s
-    @preference.value.should be_instance_of Fixnum
+  describe "type coversion for values" do
+    def round_trip_preference(key, value)
+      p = Spree::Preference.new
+      p.value = value
+      p.key = key
+      p.save
+
+      Spree::Preference.find_by_key(key)
+    end
+
+    it "Symbol" do
+      value = :fbi
+      key = "fox/mulder"
+      pref = round_trip_preference(key, value)
+      pref.value.should eq value
+      pref.value.class.should eq value.class
+    end
+
+    it "Fixnum" do
+      value = 1234
+      key = "hipster"
+      pref = round_trip_preference(key, value)
+      pref.value.should eq value
+      pref.value.class.should eq value.class
+    end
+
+    it "Bignum" do
+      value = 2342341234123409981440 #in db as "2.34234123412341e+21"
+      key = "notorious/b/i/g"
+      pref = round_trip_preference(key, value)
+      pref.value.should eq value
+      pref.value.class.should eq value.class
+    end
+
+    it "Float" do
+      value = 3.14
+      key = "apple/pie"
+      pref = round_trip_preference(key, value)
+      pref.value.should eq value
+      pref.value.class.should eq value.class
+    end
+
+    it "TrueClass" do
+      value = true
+      key = "you/cant/handle"
+      pref = round_trip_preference(key, value)
+      pref.value.should eq value
+      pref.value.class.should eq value.class
+    end
+
+    it "FalseClass" do
+      value = false
+      key = "ll/cool/j"
+      pref = round_trip_preference(key, value)
+      pref.value.should eq value
+      pref.value.class.should eq value.class
+    end
+
   end
+
 end
 
 

--- a/core/spec/models/preferences/preferable_spec.rb
+++ b/core/spec/models/preferences/preferable_spec.rb
@@ -49,12 +49,18 @@ describe Spree::Preferences::Preferable do
 
   describe "preference access" do
     it "handles ghost methods for preferences" do
-      pending("TODO: cmar to look at this test to figure out why it's failing on 1.9")
+      #pending("TODO: cmar to look at this test to figure out why it's failing on 1.9")
       @a.preferred_color = :blue
       @a.preferred_color.should eq :blue
 
       @a.prefers_color = :green
-      @a.prefers_color?(:green).should be_true
+      @a.prefers_color?.should eq :green
+    end
+
+    it "has genric readers" do
+      @a.preferred_color = :red
+      @a.prefers?(:color).should eq :red
+      @a.preferred(:color).should eq :red
     end
 
     it "parent and child instances have their own prefs" do

--- a/core/spec/support/preferences.rb
+++ b/core/spec/support/preferences.rb
@@ -1,6 +1,14 @@
-  def reset_spree_preferences
-    config = Rails.application.config.spree.preferences
-    config.reset
-    yield(config) if block_given?
-  end
+# Resets all preferences to default values, you can 
+# pass a block to override the defaults with a block
+#
+# reset_spree_preferences do |config|
+#   config.site_name = "my fancy pants store"
+# end
+#
+def reset_spree_preferences
+  Spree::Preferences::Store.instance.persistence = false
+  config = Rails.application.config.spree.preferences
+  config.reset
+  yield(config) if block_given?
+end
 


### PR DESCRIPTION
- Remove constraints on old preferences so the data can be migrated
- Turned off persistence for testing (core spec's improved from 246 sec to 130 sec)
- fixed spec reporting wrong number of arguments
- properly handling bignum preferences, better test coverage
- added back preferred(:color) and prefers?(:color) to align with documentation in case anyone is using them
- removed unneeded namespace scope on form definintion
- cleaned up general settings since Radar fixed the boolean setter
