### PR TITLE
Move require ffaker to appropriate location in rake task file rather tha...

### DIFF
--- a/sample/db/sample/spree/addresses.yml
+++ b/sample/db/sample/spree/addresses.yml
@@ -1,5 +1,4 @@
 <%
-require 'ffaker'
 I18n.reload!
 1.upto(100) do |i|
 %>

--- a/sample/lib/tasks/sample.rake
+++ b/sample/lib/tasks/sample.rake
@@ -1,3 +1,5 @@
+require 'ffaker'
+
 namespace :spree_sample do
   desc "Loads sample data"
   task :load do


### PR DESCRIPTION
...n first fixture file.

Multiple fixtures require ffaker not just the first, but it remains loaded after the first.  Requiring from the task loading all the fixtures is more appropriate, and can help avoid the confusion I had when thinking it could be removed altogether.
