### PR TITLE
Add a default locale file to extension generator.

### DIFF
--- a/core/lib/generators/spree/extension/extension_generator.rb
+++ b/core/lib/generators/spree/extension/extension_generator.rb
@@ -15,6 +15,7 @@ module Spree
       template "Rakefile", "#{file_name}/Rakefile"
       template "README.md", "#{file_name}/README.md"
       template "config/routes.rb", "#{file_name}/config/routes.rb"
+      template "config/locales/en.yml", "#{file_name}/config/locales/en.yml"
       template "rspec", "#{file_name}/.rspec"
       template "spec/spec_helper.rb.tt", "#{file_name}/spec/spec_helper.rb"
       template "Versionfile", "#{file_name}/Versionfile"

--- a/core/lib/generators/spree/extension/templates/config/locales/en.yml
+++ b/core/lib/generators/spree/extension/templates/config/locales/en.yml
@@ -1,0 +1,5 @@
+# Sample localization file for English. Add more files in this directory for other locales.
+# See https://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
+
+en:
+  hello: "Hello world"

--- a/core/spec/lib/ext_spec.rb
+++ b/core/spec/lib/ext_spec.rb
@@ -26,7 +26,7 @@ describe 'Core extensions' do
 
     end
 
-    context "updte_attributes_without_callbacks" do
+    context "update_attributes_without_callbacks" do
 
       it "sets the attributes" do
         order.update_attributes_without_callbacks :state => 'address', :email => 'spree@example.com'

--- a/lib/spree/extension.rb
+++ b/lib/spree/extension.rb
@@ -25,6 +25,7 @@ module Spree
       empty_directory "#{file_name}/app/views"
       empty_directory "#{file_name}/app/overrides"
       empty_directory "#{file_name}/config"
+      empty_directory "#{file_name}/config/locales"
       empty_directory "#{file_name}/db"
 
       directory "lib", "#{file_name}/lib"
@@ -39,6 +40,7 @@ module Spree
       template "extension.gemspec", "#{file_name}/#{file_name}.gemspec"
       template "Versionfile", "#{file_name}/Versionfile"
       template "routes.rb", "#{file_name}/config/routes.rb"
+      template "en.yml", "#{file_name}/config/locales/en.yml"
       template "Gemfile", "#{file_name}/Gemfile" unless integrated
       template "spec_helper.rb.tt", "#{file_name}/spec/spec_helper.rb"
       template "rspec", "#{file_name}/.rspec"


### PR DESCRIPTION
Opening this now to discuss a couple questions I have.

1)  What's the proper way to generate an extension from edge on my local machine?

2)  There appears to be two separate extension generator files.  Is one an old copy left behind?  The `lib/spree/extension.rb` file is the one I see run, but it points to a source_root template directory that I don't see existing.  The `core/lib/generators/spree/extension/extension_generator.rb` file doesn't appear to be used, but that file is pointing to the proper template path.

Unless I'm missing something I think these files should be combined / remove the unused one.

Note: This hasn't been tested yet.
