### PR TITLE
Add spree initializer for setting preferences.

### DIFF
--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -45,7 +45,7 @@ module Spree
   #
   # Example:
   #
-  #   Spree::Config do |config|
+  #   Spree.config do |config|
   #     config.site_name = "An awesome Spree site"
   #   end
   #

--- a/lib/generators/spree/install/install_generator.rb
+++ b/lib/generators/spree/install/install_generator.rb
@@ -21,6 +21,10 @@ module Spree
       paths.flatten
     end
 
+    def add_files
+      template 'config/initializers/spree.rb', 'config/initializers/spree.rb'
+    end
+
     def config_spree_yml
       create_file "config/spree.yml" do
         settings = { 'version' => Spree.version }

--- a/lib/generators/spree/install/templates/config/initializers/spree.rb
+++ b/lib/generators/spree/install/templates/config/initializers/spree.rb
@@ -1,0 +1,9 @@
+# Used to configure Spree Preferences
+# 
+# In order to override a default setting set: config.setting_name = 'new value'
+#
+Spree.config do |config|
+  # Example:
+  # Uncomment to override the default site name.
+  # config.site_name = "Spree Demo Site"
+end


### PR DESCRIPTION
See discussion here: https://github.com/spree/spree/commit/a4a57db941eeb6329ac9a5de64f2175e33a56f95#commitcomment-770778

I also noticed when setting this up that the javascript / stylesheet assets aren't being copied over during install.  Is this broken or has the Spree been updated so that the assets are automatically loaded into asset pipeline?  I can submit a patch if they should still be being copied over or removed from the templates.
