### PR TITLE
Update stringex to handle special chars in API calls

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'jquery-rails', '>= 1.0.14'
   s.add_dependency 'highline', '= 1.6.2'
-  s.add_dependency 'stringex', '= 1.0.3'
+  s.add_dependency 'stringex', '= 1.3.0'
   s.add_dependency 'state_machine', '= 1.0.1'
   s.add_dependency 'faker', '= 1.0.0'
   s.add_dependency 'paperclip', '= 2.4.1'


### PR DESCRIPTION
Stringex has been updated recently to fix an error in YAML parsing which pops up when using non-ascii characters in API requests.

Updating to stringex 1.3.0 seems to fix this.

I understand that stringex is not used in the current master branch, but this would still be good for the current stable branch.
