### PR TITLE
Failure when deleting a taxonomy with associated taxons

### DIFF
--- a/core/app/models/spree/taxonomy.rb
+++ b/core/app/models/spree/taxonomy.rb
@@ -2,10 +2,11 @@ module Spree
   class Taxonomy < ActiveRecord::Base
     validates :name, :presence => true
 
-    has_many :taxons, :dependent => :destroy
+    has_many :taxons
     has_one :root, :conditions => { :parent_id => nil }, :class_name => 'Spree::Taxon'
 
     after_save :set_name
+    after_destroy :destroy_root_taxon
 
     private
       def set_name
@@ -14,6 +15,10 @@ module Spree
         else
           self.root = Taxon.create!({ :taxonomy_id => self.id, :name => self.name })
         end
+      end
+
+      def destroy_root_taxon
+        self.root.destroy
       end
   end
 end

--- a/core/spec/models/taxonomy_spec.rb
+++ b/core/spec/models/taxonomy_spec.rb
@@ -10,5 +10,18 @@ describe Spree::Taxonomy do
     it {should validate_presence_of(:name) }
   end
 
+  context "#destroy" do
+    before do
+       @taxonomy = Factory(:taxonomy)
+       @root_taxon = @taxonomy.root
+       @child_taxon = Factory(:taxon, :taxonomy_id => @taxonomy.id, :parent => @root_taxon)
+    end
+
+    it "should destroy all associated taxons" do
+      @taxonomy.destroy
+      expect{ Spree::Taxon.find(@root_taxon.id) }.to raise_error(ActiveRecord::RecordNotFound)
+      expect{ Spree::Taxon.find(@child_taxon.id) }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
 end
 


### PR DESCRIPTION
When we delete a taxonomy, activerecord deletes all associated taxons, but the nested_set gem tries to use theses deleted records (to recalculate the set). 
So we delete the root taxon and let to nested_set gem the responsibility of deleted all children taxons.
