### PR TITLE
fixed issue when content of link to cart was escaped

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -1,15 +1,19 @@
 module Spree::BaseHelper
 
-  def link_to_cart(text = t('cart'))
+  def link_to_cart(text = nil)
     return "" if current_page?(cart_path)
+
+    text = text ? h(text) : t('cart')
     css_class = nil
+
     if current_order.nil? or current_order.line_items.empty?
       text = "#{text}: (#{t('empty')})"
       css_class = 'empty'
     else
-      text = "#{text}: (#{current_order.item_count}) #{order_price(current_order)}"
+      text = "#{text}: (#{current_order.item_count}) #{order_price(current_order)}".html_safe
       css_class = 'full'
     end
+
     link_to text, cart_path, :class => css_class
   end
 

--- a/core/app/views/orders/edit.html.erb
+++ b/core/app/views/orders/edit.html.erb
@@ -19,7 +19,7 @@
         </div>
 
         <div id="subtotal" data-hook>
-          <h3><%= "#{t(:subtotal)}: #{order_price(@order)}" %></h3>
+          <h3><%= t(:subtotal) %>: <%= order_price(@order) %></h3>
           <div class="links" data-hook="cart_buttons">
             <%= button_tag :class => 'large primary', :id => 'update-button' do %>
               <%= image_tag('icons/update.png') + t(:update) %>


### PR DESCRIPTION
problem was following: link_to_cart calls order_currency
(which is properly marked as html_safe), but concatenates it
with another string, resulting to html unsafe string

fix is following: if no argument is passed to link_to_cart
use value from i18n, otherwise escape passed value
then create content of link and mark it as html safe
