### PR TITLE
#874 adding company to address with a preference to have it show in the form

### DIFF
--- a/core/app/assets/javascripts/admin/checkouts/edit.js
+++ b/core/app/assets/javascripts/admin/checkouts/edit.js
@@ -63,6 +63,7 @@ $(document).ready(function(){
           if(addr!=undefined){
             $('#order_' + addr_name + '_address_attributes_firstname').val(addr['firstname']);
             $('#order_' + addr_name + '_address_attributes_lastname').val(addr['lastname']);
+            $('#order_' + addr_name + '_address_attributes_company').val(addr['company']);
             $('#order_' + addr_name + '_address_attributes_address1').val(addr['address1']);
             $('#order_' + addr_name + '_address_attributes_address2').val(addr['address2']);
             $('#order_' + addr_name + '_address_attributes_city').val(addr['city']);
@@ -110,6 +111,7 @@ $(document).ready(function(){
 
     $('#order_bill_address_attributes_firstname').val("");
     $('#order_bill_address_attributes_lastname').val("");
+    $('#order_bill_address_attributes_company').val("");
     $('#order_bill_address_attributes_address1').val("");
     $('#order_bill_address_attributes_address2').val("");
     $('#order_bill_address_attributes_city').val("");
@@ -120,6 +122,7 @@ $(document).ready(function(){
 
     $('#order_ship_address_attributes_firstname').val("");
     $('#order_ship_address_attributes_lastname').val("");
+    $('#order_bill_address_attributes_company').val("");
     $('#order_ship_address_attributes_address1').val("");
     $('#order_ship_address_attributes_address2').val("");
     $('#order_ship_address_attributes_city').val("");

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -46,6 +46,7 @@ module Spree
     preference :allow_guest_checkout, :boolean, :default => true
     preference :alternative_billing_phone, :boolean, :default => false # Request extra phone for bill addr
     preference :alternative_shipping_phone, :boolean, :default => false # Request extra phone for ship addr
+    preference :company, :boolean, :default => false # Request company field for billing and shipping addr
     preference :shipping_instructions, :boolean, :default => false # Request instructions/info for shipping
     preference :show_price_inc_vat, :boolean, :default => false
     preference :shipment_inc_vat, :boolean, :default => false

--- a/core/app/views/spree/admin/shared/_address.html.erb
+++ b/core/app/views/spree/admin/shared/_address.html.erb
@@ -1,5 +1,6 @@
 <p data-hook="address">
-  <%="#{address.firstname} #{address.lastname} (#{address.phone}" %><%= address.alternative_phone unless address.alternative_phone.blank? %>)<br />
+  <%="#{address.firstname} #{address.lastname} "%><%= address.company unless address.company.blank? %>
+  <%="(#{address.phone}" %><%= address.alternative_phone unless address.alternative_phone.blank? %>)<br />
   <%= address.address1 %> <%= ", #{address.address2}" unless address.address2.blank? %>
   <%= ", #{address.city}, #{address.state_text}, #{address.zipcode}, #{address.country.name}" %>
 </p>

--- a/core/app/views/spree/admin/shared/_address_form.html.erb
+++ b/core/app/views/spree/admin/shared/_address_form.html.erb
@@ -22,6 +22,12 @@
       </td>
       <td class="val-col" colspan="3"><%= f.text_field :lastname %></td>
     </tr>
+    <% if Spree::Config[:company] %>
+    <tr class="<%= name == t(:company) ? 'shipping-row' : 'billing-row' %>">
+	    <td class="lbl-col">  <%= f.label :company, t(:company) + ':' %> </td>
+	    <td class=colspan="7"> <%= f.text_field :company %> </td>
+	  </tr>
+    <% end %>
     <tr class="<%= name == t(:shipping_address) ? 'shipping-row' : 'billing-row' %>">
       <td class="lbl-col">
         <%= f.label :address1, t(:street_address) + ':' %>

--- a/core/app/views/spree/checkout/_address.html.erb
+++ b/core/app/views/spree/checkout/_address.html.erb
@@ -10,6 +10,12 @@
         <%= bill_form.label :lastname, t(:last_name) %><span class="req">*</span><br />
         <%= bill_form.text_field :lastname, :class => 'required' %>
       </p>
+      <% if Spree::Config[:company] %>
+        <p class="field" id="bcompany">
+          <%= bill_form.label :company, t(:company) %><br />
+          <%= bill_form.text_field :company %>
+        </p>
+      <% end %>
       <p class="field" id="baddress1">
         <%= bill_form.label :address1, t(:street_address) %><span class="req">*</span><br />
         <%= bill_form.text_field :address1, :class => 'required' %>
@@ -89,6 +95,12 @@
         <%= ship_form.label :lastname, t(:last_name) %><span class="req">*</span><br />
         <%= ship_form.text_field :lastname, :class => 'required' %>
       </p>
+      <% if Spree::Config[:company] %>
+        <p class="field" id="scompany">
+          <%= ship_form.label :company, t(:company) %><br />
+          <%= ship_form.text_field :company %>
+        </p>
+      <% end %>
       <p class="field" id="saddress1">
         <%= ship_form.label :address1, t(:street_address) %><span class="req">*</span><br />
         <%= ship_form.text_field :address1, :class => 'required' %>

--- a/core/db/migrate/20111215032408_add_company_to_addresses.rb
+++ b/core/db/migrate/20111215032408_add_company_to_addresses.rb
@@ -1,0 +1,5 @@
+class AddCompanyToAddresses < ActiveRecord::Migration
+  def change
+    add_column :spree_addresses, :company, :string
+  end
+end

--- a/core/lib/spree/core/testing_support/factories/address_factory.rb
+++ b/core/lib/spree/core/testing_support/factories/address_factory.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :address, :class => Spree::Address do
     firstname 'John'
     lastname 'Doe'
+    company 'Company'
     address1 '10 Lovely Street'
     address2 'Northwest'
     city   'Herndon'

--- a/core/spec/models/address_spec.rb
+++ b/core/spec/models/address_spec.rb
@@ -25,6 +25,7 @@ describe Spree::Address do
                          :country_id => 1,
                          :firstname => 'firstname',
                          :lastname => 'lastname',
+                         :company => 'company',
                          :phone => 'phone',
                          :state_id => state.id,
                          :state_name => state.name,
@@ -39,6 +40,7 @@ describe Spree::Address do
       cloned.country_id.should == original.country_id
       cloned.firstname.should == original.firstname
       cloned.lastname.should == original.lastname
+      cloned.company.should == original.company
       cloned.phone.should == original.phone
       cloned.state_id.should == original.state_id
       cloned.state_name.should == original.state_name

--- a/core/spec/requests/admin/orders/customer_details_spec.rb
+++ b/core/spec/requests/admin/orders/customer_details_spec.rb
@@ -31,6 +31,7 @@ describe "Customer Details" do
       ["ship_address", "bill_address"].each do |address|
         find_field("order_#{address}_attributes_firstname").value.should == "John"
         find_field("order_#{address}_attributes_lastname").value.should == "Doe"
+        find_field("order_#{address}_attributes_company").value.should == "Company"
         find_field("order_#{address}_attributes_address1").value.should == "10 Lovely Street"
         find_field("order_#{address}_attributes_address2").value.should == "Northwest"
         find_field("order_#{address}_attributes_city").value.should == "Herndon"
@@ -48,6 +49,7 @@ describe "Customer Details" do
       click_link "Customer Details"
       fill_in "order_ship_address_attributes_firstname",  :with => "John 99"
       fill_in "order_ship_address_attributes_lastname",   :with => "Doe"
+      fill_in "order_ship_address_attributes_lastname",   :with => "Company"
       fill_in "order_ship_address_attributes_address1",   :with => "100 first lane"
       fill_in "order_ship_address_attributes_address2",   :with => "#101"
       fill_in "order_ship_address_attributes_city",       :with => "Bethesda"
@@ -55,7 +57,7 @@ describe "Customer Details" do
       fill_in "order_ship_address_attributes_state_name", :with => "Alabama"
       fill_in "order_ship_address_attributes_phone",     :with => "123-456-7890"
       click_button "Continue"
-
+      
       visit spree.admin_path
       click_link "Orders"
       within(:css, 'table#listing_orders') { click_link "Edit" }


### PR DESCRIPTION
This is a pull request to add company field to address.  I saw a recent thread where someone brought up the topic again and I'd been meaning to do this for a while.  I've done this myself on a few spree sites.  I read back through the mailing list thread that talked about implementing this feature before and saw some notes about implementing it with a preference to show/hide.  I added a config to hide it similar to the alternate phone number.

I didn't write a test.  If you have some suggestions on what to write i.e. request/controller/view spec I'd be happy to resubmit it w/ one.
