### PR TITLE
Move ul style from view code into css

### DIFF
--- a/core/app/assets/stylesheets/store/screen.css
+++ b/core/app/assets/stylesheets/store/screen.css
@@ -90,6 +90,11 @@ div#product-images { width: 50%; }
 div#product-images, div#main-image, div#cart-form { float: left; }
 div#product-description { float: none; clear: both; }
 
+ul.filter_choices {
+  list-style-type:none;
+  padding-left:0px;
+}
+
 ul.thumbnails, #breadcrumbs ul {
   margin: 0;
   padding: 0;

--- a/core/app/views/spree/shared/_filters.html.erb
+++ b/core/app/views/spree/shared/_filters.html.erb
@@ -7,7 +7,7 @@
     <% next if labels.empty? %>
     <div class="navigation" data-hook="navigation">
       <span class="category"> <%= filter[:name] %> </span>
-      <ul style="list-style-type:none; padding-left:0px;" class="filter_choices">
+      <ul class="filter_choices">
         <% labels.each do |nm,val| %>
           <% label = "#{filter[:name]}_#{nm}".gsub(/\s+/,'_') %>
           <li class="nowrap">


### PR DESCRIPTION
Hello Spree Guru's!
Thanks for sharing your work on Spree.  This is the first time I've ever asked for a pull, so if I've got something wrong please let me know so I learn and get it right next time

This is a small fix, I found in shared/_filters.html.erb, there's a style coded into the view.  This tiny patch moves that style into the CSS, applying only to the UL class.  I also used grep to check elsewhere in the code and I believe the class is only used once in the _filters.html.erb
