### PR TITLE
Restore ContentController under /content

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'http://rubygems.org'
 
 gem 'json'
 gem 'sqlite3'
-
 # Gems used only for assets and not required
 # in production environments by default.
 group :assets do
@@ -38,3 +37,5 @@ end
 # end
 
 gemspec
+
+

--- a/core/app/controllers/spree/content_controller.rb
+++ b/core/app/controllers/spree/content_controller.rb
@@ -1,0 +1,23 @@
+module Spree
+  class ContentController < BaseController
+    # Don't serve local files or static assets
+    before_filter { render_404 if params[:path] =~ /(\.|\\)/ }
+
+    rescue_from ActionView::MissingTemplate, :with => :render_404
+    caches_page :show, :index, :if => Proc.new { Spree::Config[:cache_static_content] }
+
+    respond_to :html
+
+    def show
+      respond_with do |format|
+        format.html { render :action => params[:path] }
+      end
+    end
+
+    def cvv
+      respond_with do |format|
+        format.html {  render 'cvv', :layout => false }
+      end
+    end
+  end
+end

--- a/core/config/routes.rb
+++ b/core/config/routes.rb
@@ -199,4 +199,5 @@ Spree::Core::Engine.routes.draw do
   match '/admin', :to => 'admin/orders#index', :as => :admin
 
   match '/content/cvv', :to => 'content#cvv'
+  match '/content/*path', :to => 'content#show', :via => :get
 end

--- a/core/spec/controllers/spree/content_controller_spec.rb
+++ b/core/spec/controllers/spree/content_controller_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe Spree::ContentController do
+
+  it "should understand routes" do
+    pending("assert_routing tests are now broken, is this relevant any more?")
+    assert_routing("/spree/content/cvv", {:controller => "content", :action => "cvv", :use_route => :spree })
+  end
+
+  it "should not display a local file" do
+    controller.stub :current_user => Factory(:user)
+    get :show, :path => "../../Gemfile"
+    response.response_code.should == 404
+  end
+
+end

--- a/promo/app/controllers/spree/content_controller_decorator.rb
+++ b/promo/app/controllers/spree/content_controller_decorator.rb
@@ -1,0 +1,9 @@
+# Keep a record ot all static page paths visited for promotions that require them
+Spree::ContentController.class_eval do
+  after_filter :store_visited_path
+
+  def store_visited_path
+    session[:visited_paths] ||= []
+    session[:visited_paths] = (session[:visited_paths]  + [params[:path]]).compact.uniq
+  end
+end


### PR DESCRIPTION
Restores static page functionality under /content/view path. Needed by Promotions that require a static landing page to be visited first.
