### PR TITLE
Fix cucumber in 0-70-stable

### DIFF
--- a/auth/config.ru
+++ b/auth/config.ru
@@ -1,4 +1,4 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('../spec/test_app/config/environment',  __FILE__)
-run TestApp::Application
+run Dummy::Application

--- a/config/environments/cucumber.rb
+++ b/config/environments/cucumber.rb
@@ -1,4 +1,4 @@
-TestApp::Application.configure do
+Dummy::Application.configure do
   # Settings specified here will take precedence over those in config/environment.rb
 
   # The test environment is used exclusively to run your application's


### PR DESCRIPTION
without this fix one will get uninitialized constant TestApp (NameError)
when trying to run the cucumber tests because rake test_app creates
an app that is scoped in Dummy, not TestApp
