### PR TITLE
Fix pre-populate of rules in promotion admin form

### DIFF
--- a/core/app/helpers/spree/admin/base_helper.rb
+++ b/core/app/helpers/spree/admin/base_helper.rb
@@ -178,9 +178,10 @@ module Spree
        end
 
       def product_picker_field(name, value)
-        products = Product.with_ids(value)
+        products = Product.with_ids(value.split(',').collect{|id|id.to_i})
         product_names_hash = products.inject({}){|memo,item| memo[item.id] = item.name; memo}
-        %(<input type="text" name="#{name}" value="#{value}" class="tokeninput products" data-names='#{product_names_hash.to_json}' />).html_safe
+        product_rules = products.collect{|p|{:id=>p.id,:name=>p.name}}
+        %(<input type="text" name="#{name}" value="#{value}" class="tokeninput products" data-names='#{product_names_hash.to_json}' data-pre='#{product_rules.to_json}'/>).html_safe
       end
 
       # renders set of hidden fields and button to add new record using nested_attributes

--- a/promo/app/views/spree/admin/promotions/rules/_user.html.erb
+++ b/promo/app/views/spree/admin/promotions/rules/_user.html.erb
@@ -2,6 +2,7 @@
   <label>
     <%= t('user_rule.choose_users') %><br />
     <% user_names_hash = promotion_rule.users.inject({}){|memo,item| memo[item.id] = item.email; memo} %>
-    <input type="text" name="<%= param_prefix %>[user_ids_string]" value="<%= promotion_rule.user_ids_string %>" class="tokeninput users" data-names='<%= user_names_hash.to_json %>' />
+		<% user_rules = promotion_rule.users.collect{|u|{:id=>u.id,:name=>u.email}} %>
+    <input type="text" name="<%= param_prefix %>[user_ids_string]" value="<%= promotion_rule.user_ids_string %>" class="tokeninput users" data-names='<%= user_names_hash.to_json %>' data-pre='<%= user_rules.to_json %>'/>
   </label>
 </p>


### PR DESCRIPTION
This patch fix the bugs described in the issue #903. With this patch the rules for user and products are correctly pre-populate in the promotions admin form.
