### PR TITLE
Make it possible to translate user/password/edit

### DIFF
--- a/auth/app/views/spree/user_passwords/edit.html.erb
+++ b/auth/app/views/spree/user_passwords/edit.html.erb
@@ -3,11 +3,11 @@
 
 <%= form_for @user, :url => spree.user_password_path, :html => {:method => :put} do |f| %>
   <p>
-    <%= f.label :password %><br />
+    <%= f.label :password, t(:password) %><br />
     <%= f.password_field :password %><br />
   </p>
   <p>
-    <%= f.label :password_confirmation %><br />
+    <%= f.label :password_confirmation, t(:password_confirmation) %><br />
     <%= f.password_field :password_confirmation %><br />
   </p>
   <%= f.hidden_field :reset_password_token %>


### PR DESCRIPTION
This is patching master, but my normal fix is running on stable-0.60. bundle exec rake does not appear to work for me, so I didn't run tests.
