### PR TITLE
Add invoice number to authnet cim

### DIFF
--- a/core/app/models/gateway/authorize_net_cim.rb
+++ b/core/app/models/gateway/authorize_net_cim.rb
@@ -24,7 +24,8 @@ class Gateway::AuthorizeNetCim < Gateway
   end
 
   def authorize(amount, creditcard, gateway_options)
-    create_transaction(amount, creditcard, :auth_only)
+    t_options = { :order => {:invoice_number => gateway_options[:order_id] } }
+    create_transaction( amount, creditcard, :auth_only, t_options )
   end
 
   def purchase(amount, creditcard, gateway_options)


### PR DESCRIPTION
I apologize for not including a test. I have tested it extensively in my app against the authnet CIM sandbox. Should be applicable to 0-70-stable also. This should close 779. I have another fix for saving shipping address to gateway but can create a new issue for it. 
