### PR TITLE
Fix display in the dash

### DIFF
--- a/dash/app/controllers/admin/overview_controller.rb
+++ b/dash/app/controllers/admin/overview_controller.rb
@@ -108,9 +108,8 @@ class Admin::OverviewController < Admin::BaseController
   end
 
   def top_grossing_variants
-    quantity = LineItem.includes(:order).where("orders.state = 'complete'").sum(:quantity, :group => :variant_id, :order => 'sum(quantity) desc', :limit => 5)
     prices = LineItem.includes(:order).where("orders.state = 'complete'").sum(:price, :group => :variant_id, :order => 'sum(price) desc', :limit => 5)
-    variants = quantity.map do |v|
+    variants = prices.map do |v|
       variant = Variant.find(v[0])
       [variant.name, v[1] * prices[v[0]]]
     end

--- a/dash/app/controllers/admin/overview_controller.rb
+++ b/dash/app/controllers/admin/overview_controller.rb
@@ -99,7 +99,7 @@ class Admin::OverviewController < Admin::BaseController
   end
 
   def best_selling_variants
-    li = LineItem.includes(:order).where("orders.state = 'complete'").sum(:quantity, :group => :variant_id, :limit => 5)
+    li = LineItem.includes(:order).where("orders.state = 'complete'").sum(:quantity, :group => :variant_id, :order => 'sum(quantity) desc', :limit => 5)
     variants = li.map do |v|
       variant = Variant.find(v[0])
       [variant.name, v[1] ]
@@ -108,8 +108,8 @@ class Admin::OverviewController < Admin::BaseController
   end
 
   def top_grossing_variants
-    quantity = LineItem.includes(:order).where("orders.state = 'complete'").sum(:quantity, :group => :variant_id, :limit => 5)
-    prices = LineItem.includes(:order).where("orders.state = 'complete'").sum(:price, :group => :variant_id, :limit => 5)
+    quantity = LineItem.includes(:order).where("orders.state = 'complete'").sum(:quantity, :group => :variant_id, :order => 'sum(quantity) desc', :limit => 5)
+    prices = LineItem.includes(:order).where("orders.state = 'complete'").sum(:price, :group => :variant_id, :order => 'sum(price) desc', :limit => 5)
     variants = quantity.map do |v|
       variant = Variant.find(v[0])
       [variant.name, v[1] * prices[v[0]]]


### PR DESCRIPTION
master has killed the dash but it still applies to 0.60 and 0.70.
- Do not show canceled orders
- Fix calculation of best selling products
- Do not SUM(all_sold_products_in_group)*SUM(sold_products_in_group)..
