### PR TITLE
Capturing in the Check payment method does update the order (e.g. shipment_state does not move to ready)

### DIFF
--- a/core/app/models/payment_method/check.rb
+++ b/core/app/models/payment_method/check.rb
@@ -16,12 +16,18 @@ class PaymentMethod::Check < PaymentMethod
   def capture(payment)
     payment.update_attribute(:state, 'pending') if payment.state == 'checkout'
     payment.complete
+    payment.save!
+    payment.order.payments.reload
+    payment.order.update!
     true
   end
   
   def void(payment)
     payment.update_attribute(:state, 'pending') if payment.state == 'checkout'
     payment.void
+    payment.save!
+    payment.order.payments.reload
+    payment.order.update!
     true
   end
 end


### PR DESCRIPTION
For some reason payment.order.update! is not called and the payment_state does not move to 'paid' and the shipment_state does not move 'ready'. 
