### PR TITLE
MySQL error when keyword key isn't escaped

### DIFF
--- a/promo/app/controllers/spree/checkout_controller_decorator.rb
+++ b/promo/app/controllers/spree/checkout_controller_decorator.rb
@@ -7,7 +7,7 @@ Spree::CheckoutController.class_eval do
       if @order.coupon_code.present?
         # Promotion codes are stored in the preference table
         # Therefore we need to do a lookup there and find if one exists
-        if Spree::Preference.where(:value => @order.coupon_code).where("key LIKE 'spree/promotion/code/%'").present?
+        if Spree::Preference.where(:value => @order.coupon_code).where("`key` LIKE 'spree/promotion/code/%'").present?
           fire_event('spree.checkout.coupon_code_added', :coupon_code => @order.coupon_code)
         # If it doesn't exist, raise an error!
         # Giving them another chance to enter a valid coupon code


### PR DESCRIPTION
MySQL throws an error when the the keyword key isn't escaped with back tick character (`) in line 10. Not sure if it's only happening with me.. May be somebody can verify.

I found the solution here: http://goo.gl/S2mHq
