### PR TITLE
fix missing dummy_path/spec/dummy/rails

### DIFF
--- a/core/lib/generators/spree/dummy/dummy_generator.rb
+++ b/core/lib/generators/spree/dummy/dummy_generator.rb
@@ -36,11 +36,13 @@ module Spree
     def test_dummy_config
       @lib_name = options[:lib_name]
       @database = options[:database]
-
+      
       template "rails/database.yml", "#{dummy_path}/config/database.yml", :force => true
       template "rails/boot.rb", "#{dummy_path}/config/boot.rb", :force => true
       template "rails/application.rb", "#{dummy_path}/config/application.rb", :force => true
       template "rails/routes.rb", "#{dummy_path}/config/routes.rb", :force => true
+      template "rails/database.yml", "#{dummy_path}/config/database.yml", :force => true
+      template "rails/script/rails", "#{dummy_path/spec/dummy/rails}", :force => true
     end
 
     def test_dummy_clean

--- a/core/lib/generators/spree/dummy/dummy_generator.rb
+++ b/core/lib/generators/spree/dummy/dummy_generator.rb
@@ -41,7 +41,6 @@ module Spree
       template "rails/boot.rb", "#{dummy_path}/config/boot.rb", :force => true
       template "rails/application.rb", "#{dummy_path}/config/application.rb", :force => true
       template "rails/routes.rb", "#{dummy_path}/config/routes.rb", :force => true
-      template "rails/database.yml", "#{dummy_path}/config/database.yml", :force => true
       template "rails/script/rails", "#{dummy_path/spec/dummy/rails}", :force => true
     end
 

--- a/core/lib/generators/spree/dummy/templates/rails/rails
+++ b/core/lib/generators/spree/dummy/templates/rails/rails
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+# This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
+
+APP_PATH = File.expand_path('../../config/application',  __FILE__)
+require File.expand_path('../../config/boot',  __FILE__)
+require 'rails/commands'


### PR DESCRIPTION
added /core/lib/generators/spree/dummy/templates/rails from this source: https://github.com/radar/forem/blob/master/spec/dummy/script/rails (suggested by radar)

and also updated extension generator to copy the filem to: #{dummy_path/spec/dummy/rails}
