### PR TITLE
Checking self.root for existence when destroy_root_taxon is called.

### DIFF
--- a/core/app/models/spree/taxonomy.rb
+++ b/core/app/models/spree/taxonomy.rb
@@ -18,7 +18,7 @@ module Spree
       end
 
       def destroy_root_taxon
-        self.root.destroy
+        self.root.destroy if self.root
       end
   end
 end


### PR DESCRIPTION
If this is the top Taxonomy in the tree then root would be nil and the Taxonomy would not get deleted.
