### PR TITLE
Small bugfix for Spree mounted at non-root

### DIFF
--- a/core/app/views/spree/checkout/edit.html.erb
+++ b/core/app/views/spree/checkout/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :head do %>
-  <%= javascript_include_tag '/states' %>
+  <%= javascript_include_tag states_path %>
 <% end %>
 <div id="checkout" data-hook>
   <h1><%= t(:checkout) %></h1>


### PR DESCRIPTION
This fixes a missing javascript file in the checkout process; instead of hard-coding the javascript_include_tag, we use a URL helper (it's invoking a resourced controller, so we can get away with it).
