### PR TITLE
Fixed the navigation_helper so it selects correctly tabs as it should. Related to issue #910.

### DIFF
--- a/core/app/helpers/spree/admin/navigation_helper.rb
+++ b/core/app/helpers/spree/admin/navigation_helper.rb
@@ -22,9 +22,7 @@ module Spree
         css_classes = []
 
         selected = if options[:match_path]
-          # TODO: Seems a Rails issue- revisit issue #910
-          #   shoud look like this: request.url.starts_with?(root_url + "admin#{options[:match_path]}")
-          request.url.starts_with?(root_url + "admin#{options[:match_path]}") || request.fullpath.starts_with?("//admin#{options[:match_path]}")
+          request.fullpath.match(/#{"\/admin#{options[:match_path].gsub("/","\\/")}"}/)
         else
           args.include?(controller.controller_name.to_sym)
         end

--- a/core/app/helpers/spree/admin/navigation_helper.rb
+++ b/core/app/helpers/spree/admin/navigation_helper.rb
@@ -22,8 +22,7 @@ module Spree
         css_classes = []
 
         selected = if options[:match_path]
-          # TODO: Seems a Rails issue- revisit issue #910
-          request.fullpath.starts_with?("//admin#{options[:match_path]}")
+          request.url.starts_with?(root_url + "admin#{options[:match_path]}")
         else
           args.include?(controller.controller_name.to_sym)
         end

--- a/core/app/helpers/spree/admin/navigation_helper.rb
+++ b/core/app/helpers/spree/admin/navigation_helper.rb
@@ -22,7 +22,9 @@ module Spree
         css_classes = []
 
         selected = if options[:match_path]
-          request.url.starts_with?(root_url + "admin#{options[:match_path]}")
+          # TODO: Seems a Rails issue- revisit issue #910
+          #   shoud look like this: request.url.starts_with?(root_url + "admin#{options[:match_path]}")
+          request.url.starts_with?(root_url + "admin#{options[:match_path]}") || request.fullpath.starts_with?("//admin#{options[:match_path]}")
         else
           args.include?(controller.controller_name.to_sym)
         end


### PR DESCRIPTION
Fixed the navigation_helper so it selects correctly tabs as it should, independently of the mounted path of Spree.

Related to issue #910.

https://github.com/spree/spree/issues/910#issuecomment-33420545
