### PR TITLE
Deleting preferables should clear associated preferences

### DIFF
--- a/core/app/models/spree/preferences/preferable.rb
+++ b/core/app/models/spree/preferences/preferable.rb
@@ -8,6 +8,11 @@ module Spree::Preferences::Preferable
   def self.included(base)
     base.class_eval do
       extend Spree::Preferences::PreferableClassMethods
+      if respond_to?(:after_destroy)
+        after_destroy do |obj|
+          obj.clear_preferences
+        end
+      end
     end
   end
 
@@ -60,6 +65,10 @@ module Spree::Preferences::Preferable
 
   def preference_cache_key(name)
     [self.class.name, name, (try(:id) || :new)].join('::').underscore
+  end
+
+  def clear_preferences
+    preferences.keys.each {|pref| preference_store.delete preference_cache_key(pref)}
   end
 
   private


### PR DESCRIPTION
When deleting active record objects, the associated preferences should get cleared. They are not getting cleared and this is causing problems in tests as the following scenario takes place:
- Object is created for an ActiveRecord class which has an associated preference
- Test is run
- Object is destroyed
- Object is created again (this is created with same id as the db is reset)
- Object returns the preference values of the previous object.
