### PR TITLE
Using "spree_" prefix in extension generator

### DIFF
--- a/core/lib/generators/spree/extension/extension_generator.rb
+++ b/core/lib/generators/spree/extension/extension_generator.rb
@@ -4,6 +4,8 @@ module Spree
     source_root File.expand_path('../templates', __FILE__)
 
     def generate
+      use_prefix "spree_"
+
       directory "app", "#{file_name}/app"
       directory "lib", "#{file_name}/lib"
       directory "script", "#{file_name}/script"
@@ -19,7 +21,13 @@ module Spree
       template "rspec", "#{file_name}/.rspec"
       template "spec/spec_helper.rb.tt", "#{file_name}/spec/spec_helper.rb"
       template "Versionfile", "#{file_name}/Versionfile"
+    end
 
+    def use_prefix(prefix)
+      unless file_name =~ /^#{prefix}/
+        @file_name = prefix + file_name
+        @singular_name = prefix + singular_name
+      end
     end
   end
 end


### PR DESCRIPTION
As discussed on IRC earlier today, doing some changes to add the "spree_" prefix to file names etc when using extension generator, as according to the edge documentation. See output at section "5.1 Getting Started" in the [Extension Tutorial](http://edgeguides.spreecommerce.com/creating_extensions.html).

Didn't really want to touch the inherited file_name and singular_name read-only attributes of [the generator](http://api.rubyonrails.org/classes/Rails/Generators/NamedBase.html) but if we define new methods/instance variables, we'd need to edit many of the template files as well. So this makes it a lot simpler, isolating the change to a single file.

Later, guys!
