### PR TITLE
Add dependency status to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ however, to use only the pieces you are interested in.  So for example, you coul
 and perhaps combine it with your own custom authorization scheme instead of using spree_auth.
 
 [![Build Status](https://secure.travis-ci.org/spree/spree.png)](http://travis-ci.org/spree/spree)
+[![Dependency Status](https://gemnasium.com/spree/spree.png)](https://gemnasium.com/spree/spree)
 
 Using the Gem
 -------------


### PR DESCRIPTION
The dependency status is an indication of how up-to-date your gem dependency requirements are with the gems' latest versions.
