### PR TITLE
Fix for admin changing own password from admin/users

### DIFF
--- a/core/app/controllers/spree/admin/users_controller.rb
+++ b/core/app/controllers/spree/admin/users_controller.rb
@@ -7,6 +7,7 @@ module Spree
 
       create.after :save_user_roles
       update.before :save_user_roles
+      update.after :sign_in_if_change_own_password
 
       def index
         respond_with(@collection) do |format|
@@ -64,6 +65,12 @@ module Spree
 
         def load_roles
           @roles = Role.all
+        end
+
+        def sign_in_if_change_own_password
+          if current_user == @user && @user.password.present?
+            sign_in(@user, :event => :authentication, :bypass => true)
+          end
         end
     end
   end

--- a/core/spec/requests/admin/users_spec.rb
+++ b/core/spec/requests/admin/users_spec.rb
@@ -64,4 +64,19 @@ describe "Users" do
       page.should have_content("successfully updated!")
     end
   end
+
+  context "editing own user" do
+    before(:each) do
+      click_link("c@example.com")
+      click_link("Edit")
+    end
+
+    it "should let me edit own password" do
+      fill_in "user_password", :with => "welcome"
+      fill_in "user_password_confirmation", :with => "welcome"
+      click_button "Update"
+
+      page.should have_content("successfully updated!")
+    end
+  end
 end


### PR DESCRIPTION
If admin change own password from admin/users devise signs user out, also after updates redirect "CanCan::AccessDenied: You are not authorized to access this page" exception is rised.

So we should sign_in user again after own users password change.
