### PR TITLE
Fix two more issues in top_grossing_products

### DIFF
--- a/dash/app/controllers/admin/overview_controller.rb
+++ b/dash/app/controllers/admin/overview_controller.rb
@@ -108,7 +108,7 @@ class Admin::OverviewController < Admin::BaseController
   end
 
   def top_grossing_variants
-    prices = LineItem.includes(:order).where("orders.state = 'complete'").sum("price * quantity", :group => :variant_id, :order => 'sum(price) desc', :limit => 5)
+    prices = LineItem.includes(:order).where("orders.state = 'complete'").sum("price * quantity", :group => :variant_id, :order => 'sum(price * quantity) desc', :limit => 5)
     variants = prices.map do |v|
       variant = Variant.find(v[0])
       [variant.name, v[1]]


### PR DESCRIPTION
Hi,

first my previous patch was not complete and I messed up when moving around the patch, the intention was to to get rid of the multiplication and simply use the summed price (v[1]). But even this fix is not complete and we can ask the database to sum up "quantity \* price" of each line item.
