### PR TITLE
Require singleton in preferences store. Otherwise Rails autoload fails to load this file

### DIFF
--- a/core/app/models/spree/preferences/store.rb
+++ b/core/app/models/spree/preferences/store.rb
@@ -3,6 +3,9 @@
 # StoreInstance has a persistence flag that is on by default,
 # but we disable database persistence in testing to speed up tests
 #
+
+require 'singleton'
+
 module Spree::Preferences
 
   class StoreInstance


### PR DESCRIPTION
fixes
  Expected /Users/mikz/.rvm/gems/ree-1.8.7-2011.03@eshop/gems/spree_core-1.0.0.rc2/app/models/spree/preferences/store.rb to define Spree::Preferences::Store (LoadError)
