### PR TITLE
Fix escaped quotes in admin menu.

### DIFF
--- a/core/app/views/spree/admin/shared/_product_tabs.html.erb
+++ b/core/app/views/spree/admin/shared/_product_tabs.html.erb
@@ -1,4 +1,4 @@
-<h1><%== t(:editing_product) + " &ldquo;#{@product.name}&rdquo;" %></h1>
+<h1><%== t(:editing_product) + " &ldquo;#{h @product.name}&rdquo;".html_safe %></h1>
 
 <% content_for :sidebar do %>
 


### PR DESCRIPTION
Admin menu showed escaped quotes. This fix escapes product name and marks string as html_safe.
