### PR TITLE
Fix incorrect permalink increments

### DIFF
--- a/core/lib/spree/core/permalinks.rb
+++ b/core/lib/spree/core/permalinks.rb
@@ -40,7 +40,7 @@ module Spree
           permalink_value = self.to_param
           field = self.class.permalink_field
           # Do other links exist with this permalink?
-          other = self.class.first(:conditions => "#{field} LIKE '#{self.send(field)}%'", :order => "#{field} DESC")
+          other = self.class.first(:conditions => "#{field} LIKE '#{permalink_value}%'", :order => "#{field} DESC")
           if other
             # Find the number of that permalink and add one.
             if /-(\d+)$/.match(other.send(field))

--- a/core/spec/models/product_spec.rb
+++ b/core/spec/models/product_spec.rb
@@ -48,6 +48,7 @@ describe Spree::Product do
 
       context "permalink should be incremented until the value is not taken" do
         before do
+          @other_product = Factory(:product, :name => 'zoo')
           @product1 = Factory(:product, :name => 'foo')
           @product2 = Factory(:product, :name => 'foo')
           @product3 = Factory(:product, :name => 'foo')


### PR DESCRIPTION
`Spree::Product.create` was executing a query with `permalink LIKE '%'` which caused incorrect permalink increment values to be assigned to products and wouldn't allow to create products with the same names.

``` sql
SELECT `spree_products`.* FROM `spree_products` WHERE (permalink LIKE '%') ORDER BY permalink DESC LIMIT 1
```
