### PR TITLE
Fix permalink increments when number is more than one digit long.

### DIFF
--- a/core/lib/spree/core/permalinks.rb
+++ b/core/lib/spree/core/permalinks.rb
@@ -40,7 +40,10 @@ module Spree
           permalink_value = self.to_param
           field = self.class.permalink_field
           # Do other links exist with this permalink?
-          other = self.class.first(:conditions => "#{field} LIKE '#{permalink_value}%'", :order => "#{field} DESC")
+          other = self.class.first(
+            :conditions => "#{field} LIKE '#{permalink_value}%'",
+            :order => "LENGTH(#{field}) DESC, #{field} DESC"
+          )
           if other
             # Find the number of that permalink and add one.
             if /-(\d+)$/.match(other.send(field))

--- a/core/spec/models/product_spec.rb
+++ b/core/spec/models/product_spec.rb
@@ -60,6 +60,17 @@ describe Spree::Product do
         end
       end
 
+      context "permalink should be incremented until the value is not taken when there are more than 10 products" do
+        before do
+          @products = 0.upto(11).map do
+            Factory(:product, :name => 'foo')
+          end
+        end
+        it "should have valid permalink" do
+          @products[11].permalink.should == 'foo-11'
+        end
+      end
+
       context "make_permalink should declare validates_uniqueness_of" do
         before do
           @product1 = Factory(:product, :name => 'foo')


### PR DESCRIPTION
This sorts the permalinks first by `LENGTH(permalink) DESC`.
The same approach is used in `friendly_id` gem.
