### PR TITLE
fix escaping issues on order details page in admin menu

### DIFF
--- a/core/app/views/spree/admin/shared/_order_tabs.html.erb
+++ b/core/app/views/spree/admin/shared/_order_tabs.html.erb
@@ -1,13 +1,13 @@
-<h1><%= t(:order) + " #{@order.number}" %></h1>
+<h1><%= t(:order) %> <%= @order.number %></h1>
 
 <% content_for :sidebar do %>
   <div id="order_tab_summary" data-hook>
-    <h3 id="order_number" data-hook><%= "#{t(:order)} ##{@order.number} " %></h3>
-    <h5 id="order_status" data-hook><%= "#{t(:status)}: #{t("order_state.#{@order.state}")}" %></h5>
-    <h5 id="order_total" data-hook><%= "#{t(:total)}: #{number_to_currency @order.total}" %></h5>
+    <h3 id="order_number" data-hook><%= t(:order) %> #<%= @order.number%></h3>
+    <h5 id="order_status" data-hook><%= t(:status) %>: <%= t(@order.state, :scope => :order_state) %></h5>
+    <h5 id="order_total" data-hook><%= t(:total) %>: <%= number_to_currency @order.total %></h5>
     <% if @order.completed? %>
-      <h5 id="shipment_status"><%= "#{t(:shipment)}: #{t("shipment_states.#{@order.shipment_state}")}" %></h5>
-      <h5 id="payment_status"><%= "#{t(:payment)}: #{t("payment_states.#{@order.payment_state}")}" %></h5>
+      <h5 id="shipment_status"><%= t(:shipment) %>: <%= t(@order.shipment_state, :scope => :shipment_state, :default => [:missing, "none"]) %></h5>
+      <h5 id="payment_status"><%= t(:payment) %>: <%= t(@order.payment_state, :scope => :payment_states, :default => [:missing, "none"]) %></h5>
     <% end %>
     <br class="clear" />
   </div>

--- a/core/app/views/spree/admin/shared/_update_order_state.js
+++ b/core/app/views/spree/admin/shared/_update_order_state.js
@@ -1,6 +1,6 @@
-$('#order_tab_summary h5#order_status').html('<%= "#{t(:status)}: #{t("order_state.#{@order.state}")}" %>');
-$('#order_tab_summary h5#order_total').html('<%= "#{t(:total)}: #{number_to_currency @order.total}" %>');
+$('#order_tab_summary h5#order_status').html('<%= j t(:status) %>: <%= j t(@order.state, :scope => :order_state) %>');
+$('#order_tab_summary h5#order_total').html('<%= j t(:total) %>: <%= j number_to_currency @order.total %>');
 <% if @order.completed? %>
-$('#order_tab_summary h5#payment_status').html('<%= "#{t(:payment)}: #{t("payment_states.#{@order.payment_state}")}" %>');
-$('#order_tab_summary h5#shipment_status').html('<%= "#{t(:shipment)}: #{t("shipment_states.#{@order.shipment_state}")}" %>');
+$('#order_tab_summary h5#payment_status').html('<%= j t(:payment) %>: <%= j t(@order.payment_state, :scope => :payment_states, :default => [:missing, "none"]) %>');
+$('#order_tab_summary h5#shipment_status').html('<%= j t(:shipment) %>: <%= j t(@order.shipment_state, :scope => :shipment_state, :default => [:missing, "none"]) %>');
 <% end %>

--- a/core/spec/requests/admin/orders/order_details_spec.rb
+++ b/core/spec/requests/admin/orders/order_details_spec.rb
@@ -1,14 +1,19 @@
+# coding: utf-8
 require 'spec_helper'
 
 describe "Order Details" do
   context "edit order page" do
-    it "should allow me to edit order details", :js => true do
+
+    before do
       reset_spree_preferences do |config|
         config.allow_backorders = true
       end
+    end
 
-      order = Factory(:order, :completed_at => "2011-02-01 12:36:15", :number => "R100")
-      product = Factory(:product, :name => 'spree t-shirt', :on_hand => 5)
+    let(:product) { Factory(:product, :name => 'spree t-shirt', :on_hand => 5, :price => 19.99) }
+    let(:order) { Factory(:order, :completed_at => "2011-02-01 12:36:15", :number => "R100", :state => :complete) }
+
+    it "should allow me to edit order details", :js => true do
       order.add_variant(product.master, 2)
       order.inventory_units.each do |iu|
         iu.update_attribute_without_callbacks('state', 'sold')
@@ -24,6 +29,37 @@ describe "Order Details" do
       click_link "Edit"
       fill_in "order_line_items_attributes_0_quantity", :with => "1"
       page.should have_content("Total: $19.99")
+    end
+
+    it "should render details properly" do
+      sign_in_as!(Factory(:admin_user))
+
+      visit spree.edit_admin_order_path(order)
+
+      within "#sidebar" do
+        find("#order_number").text.should == "Order #R100"
+        find("#order_status").text.should == "Status: complete"
+        find("#shipment_status").text.should == "Shipment: none"
+        find("#payment_status").text.should == "Payment: none"
+      end
+
+      I18n.backend.store_translations I18n.locale,
+        :shipment_state => { :missing => 'some text' },
+        :payment_states => { :missing => 'other text' },
+        :number => { :currency => { :format => {
+          :format => "%n&mdash;%u",
+          :unit => "&pound;"
+        }}}
+
+      visit spree.edit_admin_order_path(order)
+
+      within "#sidebar" do
+        # beware - the dash before pound is really em dash character '—'
+        find("#order_total").text.should == "#{I18n.t(:total)}: 0.00—£"
+        find("#shipment_status").text.should == "#{I18n.t(:shipment)}: some text"
+        find("#payment_status").text.should == "#{I18n.t(:payment)}: other text"
+      end
+
     end
   end
 end


### PR DESCRIPTION
fixed problems:
- when there is no shipment or payment state it will print all states to template
- when using currency format with html characters, like `"%n&nbsp;%u"` it is escaped
- properly escape strings in javascript template (`j` is alias to `escape_javascript`)

would be nice to have some decorator to DRY these state lookups

relevant spec (`spec/requests/admin/orders/order_details_spec.rb`) is green
