### PR TITLE
Negative order total promotion bug

### DIFF
--- a/promo/app/models/promotion.rb
+++ b/promo/app/models/promotion.rb
@@ -47,8 +47,7 @@ class Promotion < ActiveRecord::Base
 
   def create_discount(order)
     return if order.promotion_credit_exists?(self)
-    if eligible?(order) and amount = calculator.compute(order)
-      amount = order.item_total if amount > order.item_total
+    if eligible?(order) and amount = compute(order)
       order.promotion_credits.reload.clear unless combine? and order.promotion_credits.all? { |credit| credit.source.combine? }
       order.update!
       PromotionCredit.create!({
@@ -60,7 +59,11 @@ class Promotion < ActiveRecord::Base
     end
   end
 
-
+  def compute(order)
+    amount = calculator.compute(order)
+    amount = order.item_total if amount > order.item_total
+    -amount
+  end
 
   # Products assigned to all product rules
   def products

--- a/promo/app/models/promotion_credit.rb
+++ b/promo/app/models/promotion_credit.rb
@@ -1,29 +1,9 @@
 class PromotionCredit < ::Adjustment
   scope :with_order, :conditions => "order_id IS NOT NULL"
 
-  def calculate_adjustment
-    adjustment_source && calculate_coupon_credit
-  end
-
   # Checks if credit is still applicable to order
   # If source of adjustment is credit, it checks if it's still valid
   def applicable?
-    adjustment_source && adjustment_source.eligible?(order) && super
-  end
-
-  # Calculates credit for the coupon.
-  #
-  # If coupon amount exceeds the order item_total, credit is adjusted.
-  #
-  # Always returns negative non positive.
-  def calculate_coupon_credit
-    return 0 if order.line_items.empty?
-    amount = adjustment_source.calculator.compute(order.line_items).abs
-    amount = order.item_total if amount > order.item_total
-    -1 * amount
-  end
-
-  def total
-    map(&:amount).sum
+    source && source.eligible?(order) && super
   end
 end

--- a/promo/lib/spree_promo.rb
+++ b/promo/lib/spree_promo.rb
@@ -64,7 +64,7 @@ module SpreePromo
           # recalculate amount
           self.promotion_credits.each do |credit|
             if credit.source.eligible?(self)
-              amount = -credit.source.calculator.compute(self).abs
+              amount = credit.source.compute(self)
               if credit.amount != amount
                 # avoid infinite callbacks
                 PromotionCredit.update_all("amount = #{amount}", { :id => credit.id })
@@ -81,12 +81,11 @@ module SpreePromo
           new_promotions = eligible_automatic_promotions - current_promotions
           new_promotions.each do |promotion|
             next if current_promotions.present? && !promotion.combine?
-            amount = promotion.calculator.compute(self).abs
-            amount = item_total if amount > item_total
+            amount = credit.source.compute(self)
             if amount > 0
               self.promotion_credits.create(
                   :source => promotion,
-                  :amount => -amount,
+                  :amount => amount,
                   :label  => promotion.name
                 )
             end

--- a/promo/spec/models/order_spec.rb
+++ b/promo/spec/models/order_spec.rb
@@ -1,0 +1,28 @@
+require File.dirname(__FILE__) + '/../spec_helper'
+
+describe Order do
+
+  describe "process_automatic_promotions" do
+    
+    describe "if eligible and promo amount exceeds order line item total" do
+      let(:calculator) { Calculator::FlatPercentItemTotal.new }
+      let(:promotion) { Promotion.new(:usage_limit => 1, :calculator => calculator) }
+      let(:promotion_credit) { PromotionCredit.new(:source => promotion) }
+      let(:order) { Order.new }
+      let(:item_total) { 20 }
+      before {
+        order.stub(:item_total => item_total)
+        promotion.stub(:eligible? => true)
+        calculator.stub(:compute => 100)
+        order.promotion_credits = [promotion_credit]
+      }
+      after {
+        order.process_automatic_promotions
+      }
+
+      it "it should provide a promotion amount equal to line item total" do
+        PromotionCredit.should_receive(:update_all).with("amount = #{-item_total}", { :id => promotion_credit.id })
+      end
+    end
+  end
+end


### PR DESCRIPTION
if eligible and promo amount exceeds order line item total process_automatic_promotions should provide a promotion amount equal to line item total
