### PR TITLE
Making the last step in breadcrumbs a link.

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -105,7 +105,7 @@ module Spree
       if taxon
         crumbs << content_tag(:li, link_to(t(:products) , products_path) + separator)
         crumbs << taxon.ancestors.collect { |ancestor| content_tag(:li, link_to(ancestor.name , seo_url(ancestor)) + separator) } unless taxon.ancestors.empty?
-        crumbs << content_tag(:li, content_tag(:span, taxon.name))
+        crumbs << content_tag(:li, content_tag(:span, link_to(taxon.name , seo_url(taxon))))
       else
         crumbs << content_tag(:li, content_tag(:span, t(:products)))
       end


### PR DESCRIPTION
The taxon you are currently in doesn't appear as a link on the products page, meaning you can't easily click back there. 
