### PR TITLE
Promotion Pending Tests passing

### DIFF
--- a/auth/app/controllers/spree/user_registrations_controller.rb
+++ b/auth/app/controllers/spree/user_registrations_controller.rb
@@ -17,7 +17,8 @@ class Spree::UserRegistrationsController < Devise::RegistrationsController
     @user = build_resource(params[:user])
     if resource.save
       set_flash_message(:notice, :signed_up)
-      fire_event('spree.user.signup', :user => @user)
+      sign_in(:user, @user)
+      fire_event('spree.user.signup', :user => @user, :order => current_order(true))
       sign_in_and_redirect(:user, @user)
     else
       clean_up_passwords(resource)

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -59,12 +59,16 @@ module Spree
     # when present, but only if +locked+ is false.  Adjustments that are +locked+ will never change their amount.
     # The new adjustment amount will be set by by the +originator+ and is not automatically saved.  This makes it save
     # to use this method in an after_save hook for other models without causing an infinite recursion problem.
-    def update!
+    #
+    # order#update_adjustments passes self as the src, this is so calculations can be performed on the
+    # current values. If we used source it would load the old record from db for the association
+    def update!(src = nil)
+      src ||= source
       return if locked?
-      set_eligibility
       if originator.present?
-        originator.update_adjustment(self, source)
+        originator.update_adjustment(self, src)
       end
+      set_eligibility
     end
 
     private

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -517,7 +517,7 @@ module Spree
       # Adjustments will check if they are still eligible. Ineligible adjustments are preserved but not counted
       # towards adjustment_total.
       def update_adjustments
-        self.adjustments.reload.each(&:update!)
+        self.adjustments.reload.each { |adjustment| adjustment.update!(self) }
       end
 
       # Determine if email is required (we don't want validation errors before we hit the checkout)

--- a/core/lib/spree/core/controller_helpers.rb
+++ b/core/lib/spree/core/controller_helpers.rb
@@ -88,7 +88,8 @@ module Spree
         # add additional keys as appropriate. Override this method if you need additional data when
         # responding to a notification
         def default_notification_payload
-          {:user => (respond_to?(:current_user) && current_user), :order => current_order}
+          { :user => (respond_to?(:current_user) && current_user),
+            :order => current_order(true) }
         end
 
         private
@@ -111,7 +112,7 @@ module Spree
           ActiveSupport::Deprecation.warn "current_gateway is deprecated and will be removed in Spree > 1.0"
           @current_gateway ||= Gateway.current
         end
-        
+
         def associate_user
           return unless current_user and current_order
           current_order.associate_user!(current_user)

--- a/promo/app/controllers/spree/checkout_controller_decorator.rb
+++ b/promo/app/controllers/spree/checkout_controller_decorator.rb
@@ -1,21 +1,17 @@
 Spree::CheckoutController.class_eval do
-  before_filter :apply_pending_promotions
 
+  #TODO 90% of this method is duplicated code. DRY
   def update
     if @order.update_attributes(object_params)
 
       fire_event('spree.checkout.update')
 
       if @order.coupon_code.present?
-        # Promotion codes are stored in the preference table
-        # Therefore we need to do a lookup there and find if one exists
-        #
-        # TODO: The ActiveRecord::Base.connection.quote_column_name stuff is a bit long...
-        # TODO: Is there a better way to do that?
-        if Spree::Preference.where(:value => @order.coupon_code).where("#{ActiveRecord::Base.connection.quote_column_name("key")} LIKE 'spree/promotion/code/%'").present?
+
+        if Spree::Promotion.exists?(:code => @order.coupon_code)
           fire_event('spree.checkout.coupon_code_added', :coupon_code => @order.coupon_code)
-        # If it doesn't exist, raise an error!
-        # Giving them another chance to enter a valid coupon code
+          # If it doesn't exist, raise an error!
+          # Giving them another chance to enter a valid coupon code
         else
           flash[:error] = t(:promotion_not_found)
           render :edit and return
@@ -42,15 +38,4 @@ Spree::CheckoutController.class_eval do
     end
   end
 
-  private
-
-  def apply_pending_promotions
-    # Apply all promotions that may have been triggered before theorder had been created
-    if current_user
-      current_user.pending_promotions.each do |promotional|
-        promotional.promotion.activate(:order => @order, :user => current_user)
-        promotional.destroy
-      end
-    end
-  end
 end

--- a/promo/app/models/spree/pending_promotion.rb
+++ b/promo/app/models/spree/pending_promotion.rb
@@ -1,6 +1,0 @@
-module Spree
-  class PendingPromotion < ActiveRecord::Base
-    belongs_to :user
-    belongs_to :promotion
-  end
-end

--- a/promo/app/models/spree/promotion.rb
+++ b/promo/app/models/spree/promotion.rb
@@ -2,16 +2,6 @@ module Spree
   class Promotion < Spree::Activator
     MATCH_POLICIES = %w(all any)
 
-    preference :usage_limit, :integer
-    preference :match_policy, :string, :default => MATCH_POLICIES.first
-    preference :code, :string
-    preference :advertise, :boolean, :default => false
-
-    [:usage_limit, :match_policy, :code, :advertise].each do |field|
-      alias_method field, "preferred_#{field}"
-      alias_method "#{field}=", "preferred_#{field}="
-    end
-
     has_many :promotion_rules, :foreign_key => 'activator_id', :autosave => true, :dependent => :destroy
     alias_method :rules, :promotion_rules
     accepts_nested_attributes_for :promotion_rules
@@ -20,8 +10,6 @@ module Spree
     alias_method :actions, :promotion_actions
     accepts_nested_attributes_for :promotion_actions
 
-    after_create :update_preferences
-
     # TODO: This shouldn't be necessary with :autosave option but nested attribute updating of actions is broken without it
     after_save :save_rules_and_actions
     def save_rules_and_actions
@@ -29,24 +17,8 @@ module Spree
     end
 
     validates :name, :presence => true
-    #validates :preferred_code, :presence => true, :if => lambda{|r| r.event_name == 'spree.checkout.coupon_code_added' }
-
-    %w(usage_limit match_policy code advertise).each do |pref|
-      method_name = pref.to_sym
-      define_method method_name do
-        get_preference(pref.to_sym)
-      end
-
-      method_name = "#{pref}=".to_sym
-      define_method method_name do |value|
-        unless new_record?
-          pref = value
-        else
-          @preferences_hash ||= {}
-          @preferences_hash[pref.to_sym] = value
-        end
-      end
-    end
+    validates :code, :presence => true, :if => lambda{|r| r.event_name == 'spree.checkout.coupon_code_added' }
+    validates :usage_limit, :numericality => { :greater_than => 0, :allow_nil => true }
 
     class << self
       def advertised
@@ -67,25 +39,20 @@ module Spree
     end
 
     def activate(payload)
-      # Since multiple promotions could be listening we need to make sure the
-      # event applies to this one.
-      if eligible?(payload[:order], payload)
-        actions.each do |action|
-          action.perform(payload)
-        end
+      if code.present?
+        event_code = payload[:coupon_code].to_s.strip.downcase
+        return unless event_code == self.code.to_s.strip.downcase
+      end
+
+      actions.each do |action|
+        action.perform(payload)
       end
     end
 
-    # Whether the promotion is eligible for this particular order.
-    def eligible?(order, options = {})
+    # called anytime order.update! happens
+    def eligible?(order)
       return false if expired? || usage_limit_exceeded?(order)
-
-      if preferred_code
-        event_code = options[:coupon_code].to_s.strip.downcase
-        return event_code == self.code.to_s.strip.downcase
-      else
-        return rules_are_eligible?(order, options)
-      end
+      rules_are_eligible?(order, {})
     end
 
     def rules_are_eligible?(order, options = {})
@@ -104,7 +71,7 @@ module Spree
     end
 
     def usage_limit_exceeded?(order = nil)
-      preferred_usage_limit.present? && preferred_usage_limit.to_i > 0 && adjusted_credits_count(order) >= preferred_usage_limit.to_i
+      usage_limit.present? && usage_limit > 0 && adjusted_credits_count(order) >= usage_limit
     end
 
     def adjusted_credits_count(order)
@@ -120,16 +87,5 @@ module Spree
       credits.count
     end
 
-
-    private
-
-    def update_preferences
-      if @preferences_hash.present? && !@preferences_hash.empty?
-        @preferences_hash.each do |key, value|
-          pref_key = "spree/promotion/#{key}/#{self.id}"
-          Spree::Preference.create(:value => value, :key => pref_key)
-        end
-      end
-    end
   end
 end

--- a/promo/app/models/spree/promotion/actions/create_adjustment.rb
+++ b/promo/app/models/spree/promotion/actions/create_adjustment.rb
@@ -10,13 +10,22 @@ module Spree
       return unless order = options[:order]
       # Nothing to do if the promotion is already associated with the order
       return if order.promotion_credit_exists?(promotion)
-      if amount = calculator.compute(order)
-        amount = BigDecimal.new(amount.to_s)
-        amount = order.item_total if amount > order.item_total
-        order.adjustments.promotion.reload.clear
-        order.update!
-        create_adjustment("#{I18n.t(:promotion)} (#{promotion.name})", order, order)
-      end
+
+      order.adjustments.promotion.reload.clear
+      order.update!
+      create_adjustment("#{I18n.t(:promotion)} (#{promotion.name})", order, order)
+    end
+
+    # override of CalculatedAdjustments#create_adjustment so promotional
+    # adjustments are added all the time. They will get their eligability
+    # set to false if the amount is 0
+    def create_adjustment(label, target, calculable, mandatory=false)
+      amount = compute_amount(calculable)
+      target.adjustments.create(:amount => amount,
+                                :source => calculable,
+                                :originator => self,
+                                :label => label,
+                                :mandatory => mandatory)
     end
 
     # Ensure a negative amount which does not exceed the sum of the order's item_total and ship_total

--- a/promo/app/models/spree/user_decorator.rb
+++ b/promo/app/models/spree/user_decorator.rb
@@ -1,4 +1,0 @@
-Spree::User.class_eval do
-  has_many :pending_promotions
-  has_many :promotions, :through => :pending_promotions
-end

--- a/promo/app/views/spree/admin/promotions/_rules.html.erb
+++ b/promo/app/views/spree/admin/promotions/_rules.html.erb
@@ -4,7 +4,7 @@
   <%= form_for @promotion, :url => object_url, :method => :put do |f| %>
     <p>
       <% Spree::Promotion::MATCH_POLICIES.each do |policy| %>
-        <label><%= f.radio_button :preferred_match_policy, policy %> <%= t "promotion_form.match_policies.#{policy}" %></label> &nbsp;
+        <label><%= f.radio_button :match_policy, policy %> <%= t "promotion_form.match_policies.#{policy}" %></label> &nbsp;
       <% end %>
     </p>
     <div id="rules" class="filter_list">

--- a/promo/db/migrate/20120119024710_promotion_prefs_to_fields.rb
+++ b/promo/db/migrate/20120119024710_promotion_prefs_to_fields.rb
@@ -1,0 +1,35 @@
+# Up until this point Promotions stored usage_limit, match_policy, code
+# and advertise in preferences. This migration creates columns for those
+# values. Temporarly adds the preferences back, and migrates the data
+class PromotionPrefsToFields < ActiveRecord::Migration
+  def up
+    drop_table :spree_pending_promotions
+
+    add_column :spree_activators, :usage_limit, :integer
+    add_column :spree_activators, :match_policy, :string, :default => 'all'
+    add_column :spree_activators, :code, :string
+    add_column :spree_activators, :advertise, :boolean, :default => false
+
+    Spree::Promotion.class_eval do
+      preference :usage_limit, :integer
+      preference :match_policy, :string, :default => 'all'
+      preference :code, :string
+      preference :advertise, :boolean, :default => false
+    end
+
+    Spree::Promotion.all.each do |promotion|
+      promotion.usage_limit = promotion.preferred_usage_limit
+      promotion.match_policy = promotion.preferred_match_policy
+      promotion.code = promotion.preferred_code
+      promotion.advertise = promotion.preferred_advertise
+      promotion.save
+    end
+  end
+
+  def down
+    remove_column :spree_activators, :usage_limit
+    remove_column :spree_activators, :match_policy
+    remove_column :spree_activators, :code
+    remove_column :spree_activators, :advertise
+  end
+end

--- a/promo/lib/spree/promo/engine.rb
+++ b/promo/lib/spree/promo/engine.rb
@@ -55,19 +55,6 @@ module Spree
           Spree::Promotion::Actions::CreateLineItems]
       end
 
-      config.after_initialize do
-        ActiveSupport::Notifications.subscribe('spree.user.signup') do |*args|
-          event_name, start_time, end_time, id, payload = args
-
-          # Used for storing promotions before order has been created
-          # Fixes #836
-          Promotion.active.event_name_starts_with('spree.user.signup').each do |activator|
-            if activator.eligible?(nil, payload)
-              payload[:user].promotions << activator
-            end
-          end
-        end
-      end
     end
   end
 end

--- a/promo/spec/requests/checkout_spec.rb
+++ b/promo/spec/requests/checkout_spec.rb
@@ -11,7 +11,6 @@ describe "Checkout" do
     end
 
     it "informs about an invalid coupon code", :js => true do
-      pending("TODO: cmar to look at this test as part of #831")
       visit spree.root_path
       click_link "RoR Mug"
       click_button "add-to-cart-button"


### PR DESCRIPTION
Update promotion activate() and eligible() logic. Promotions will always
be added to the order if the event triggers. It will only show once it
has become eligible. When the order#update! is called, it calls all
adjustments#update!. This gives promotion adjustments to recalculate
their amount and eligibility.

This also removes the pending_promotions table since the new promotions
logic handles the case of an empty order being created for user sign up.

[Alternate fix for #836]
