### PR TITLE
file missing error when calling rake from spree root directory

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,8 +12,8 @@ end
 def run_all_tests(database_name)
   %w(api auth core dash promo).each do |gem_name|
     puts "########################### #{gem_name}|#{database_name} (spec) ###########################"
-    sh "cd #{gem_name} && #{$0} test_app DB_NAME='#{database_name}'"
-    sh "cd #{gem_name} && #{$0} spec"
+    sh "cd #{gem_name} && bundle exec rake test_app DB_NAME='#{database_name}'"
+    sh "cd #{gem_name} && bundle exec rake spec"
   end
 end
 


### PR DESCRIPTION
rake --trace
*\* Invoke default (first_time)
*\* Invoke all_tests (first_time)
*\* Execute all_tests
###### ##################### api|sqlite3 (spec)

cd api && /home/versi/.rvm/gems/ruby-1.9.3-p0@spree1/bin/rake test_app DB_NAME='sqlite3'
rake aborted!
cannot load such file -- spree_auth

Tasks: TOP => common:test_app
(See full trace by running task with --trace)
rake aborted!
Command failed with status (1): [cd api && /home/versi/.rvm/gems/ruby-1.9.3...]
/home/versi/.rvm/gems/ruby-1.9.3-p0@spree1/gems/rake-0.9.2.2/lib/rake/file_utils.rb:53:in `block in create_shell_runner'
/home/versi/.rvm/gems/ruby-1.9.3-p0@spree1/gems/rake-0.9.2.2/lib/rake/file_utils.rb:45:in`call'
/home/versi/.rvm/gems/ruby-1.9.3-p0@spree1/gems/rake-0.9.2.2/lib/rake/file_utils.rb:45:in `sh'
/home/versi/.rvm/gems/ruby-1.9.3-p0@spree1/gems/rake-0.9.2.2/lib/rake/file_utils_ext.rb:39:in`sh'
/home/versi/Desktop/spree/Rakefile:15:in `block in run_all_tests'
/home/versi/Desktop/spree/Rakefile:13:in`each'
/home/versi/Desktop/spree/Rakefile:13:in `run_all_tests'
/home/versi/Desktop/spree/Rakefile:33:in`block in <top (required)>'
