### PR TITLE
Extensions should include files in their own spec/support/**

### DIFF
--- a/cmd/lib/spree_cmd/templates/extension/spec/spec_helper.rb.tt
+++ b/cmd/lib/spree_cmd/templates/extension/spec/spec_helper.rb.tt
@@ -7,7 +7,8 @@ require 'rspec/rails'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
-Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
+EXTENSION_ROOT=File.join(File.dirname(__FILE__), '../')
+Dir[File.join(EXTENSION_ROOT, "spec/support/**/*.rb")].each {|f| require f }
 
 # Requires factories defined in spree_core
 require 'spree/core/testing_support/factories'

--- a/cmd/lib/spree_cmd/templates/extension/spec/spec_helper.rb.tt
+++ b/cmd/lib/spree_cmd/templates/extension/spec/spec_helper.rb.tt
@@ -7,8 +7,7 @@ require 'rspec/rails'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
-EXTENSION_ROOT=File.join(File.dirname(__FILE__), '../')
-Dir[File.join(EXTENSION_ROOT, "spec/support/**/*.rb")].each {|f| require f }
+Dir[File.join(File.dirname(__FILE__), "support/**/*.rb")].each {|f| require f }
 
 # Requires factories defined in spree_core
 require 'spree/core/testing_support/factories'


### PR DESCRIPTION
Extensions should include files in their own spec/support/**. Wasn't currently working.
