### PR TITLE
use small_image for thumbnails in product listing

### DIFF
--- a/core/app/views/spree/shared/_products.html.erb
+++ b/core/app/views/spree/shared/_products.html.erb
@@ -14,7 +14,7 @@
     <% if Spree::Config[:show_zero_stock_products] || product.has_stock? %>
       <li id="product_<%= product.id %>" class="columns three" data-hook="products_list_item" itemscope itemtype="http://schema.org/Product">
         <div class="product-image">
-          <%= link_to product_image(product, :itemprop => "name"), product %>
+          <%= link_to small_image(product, :itemprop => "name"), product %>
         </div>
         <%= link_to product.name, product, :class => 'info', :itemprop => "name" %>
         <span class="price selling" itemprop="price"><%= number_to_currency product.price %></span>


### PR DESCRIPTION
minor fix to new theme: not sure if there was a reason to use the `product_image` helper, instead of `small_image` as it used to be. But on my app the default size is 495x495, so the images look bad when scaled by the browser down to 100x100.
