### PR TITLE
Remove config/spree.yml from being generated.

### DIFF
--- a/core/lib/generators/spree/install/install_generator.rb
+++ b/core/lib/generators/spree/install/install_generator.rb
@@ -34,14 +34,6 @@ module Spree
       template 'config/initializers/spree.rb', 'config/initializers/spree.rb'
     end
 
-    def config_spree_yml
-      create_file "config/spree.yml" do
-        settings = { 'version' => Spree.version }
-
-        settings.to_yaml
-      end
-    end
-
     def remove_unneeded_files
       remove_file "public/index.html"
     end


### PR DESCRIPTION
I can't find anywhere this file is actually being used for anything.  I believe this is an old method for setting preferences, but we now have the config/initializers/spree.rb file for that.
