### PR TITLE
fixed line_item quantity issue [Fixes #1037]

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -298,6 +298,11 @@ module Spree
       line_items.detect { |line_item| line_item.variant_id == variant.id }
     end
 
+    def quantity_of(variant)
+      line_item = line_items.find { |line_item| line_item.variant_id == variant.id }
+      line_item ? line_item.quantity : 0
+    end
+
     def ship_total
       adjustments.shipping.map(&:amount).sum
     end

--- a/core/spec/models/order_spec.rb
+++ b/core/spec/models/order_spec.rb
@@ -70,12 +70,27 @@ describe Spree::Order do
   end
 
   context "#products" do
+    before :each do
+      @variant1 = mock_model(Spree::Variant, :product => "product1")
+      @variant2 = mock_model(Spree::Variant, :product => "product2")
+      @line_items = [mock_model(Spree::LineItem, :variant => @variant1, :variant_id => @variant1.id, :quantity => 1),
+                     mock_model(Spree::LineItem, :variant => @variant2, :variant_id => @variant2.id, :quantity => 2)]
+      order.stub(:line_items => @line_items)
+    end
+
     it "should return ordered products" do
-      variant1 = mock_model(Spree::Variant, :product => "product1")
-      variant2 = mock_model(Spree::Variant, :product => "product2")
-      line_items = [mock_model(Spree::LineItem, :variant => variant1), mock_model(Spree::LineItem, :variant => variant2)]
-      order.stub(:line_items => line_items)
       order.products.should == ['product1', 'product2']
+    end
+
+    it "contains?" do
+      order.contains?(@variant1).should be_true
+    end
+
+    it "gets the quantity of a given variant" do
+      order.quantity_of(@variant1).should == 1
+
+      @variant3 = mock_model(Spree::Variant, :product => "product3")
+      order.quantity_of(@variant3).should == 0
     end
   end
 

--- a/promo/app/models/spree/promotion/actions/create_line_items.rb
+++ b/promo/app/models/spree/promotion/actions/create_line_items.rb
@@ -7,7 +7,10 @@ module Spree
     def perform(options = {})
       return unless order = options[:order]
       promotion_action_line_items.each do |item|
-        order.add_variant(item.variant, item.quantity)
+        current_quantity = order.quantity_of(item.variant)
+        if current_quantity < item.quantity
+          order.add_variant(item.variant, item.quantity - current_quantity)
+        end
       end
     end
 

--- a/promo/spec/models/promotion/actions/create_line_items_spec.rb
+++ b/promo/spec/models/promotion/actions/create_line_items_spec.rb
@@ -18,11 +18,26 @@ describe Spree::Promotion::Actions::CreateLineItems do
         :quantity => 2
       )
     end
+
     it "adds line items to order with correct variant and quantity" do
       action.perform(:order => order)
       order.line_items.count.should == 2
       order.line_items.first.variant.should == @v1
       order.line_items.first.quantity.should == 1
+    end
+
+    it "only adds the delta of quantity to an order" do
+      order.add_variant(@v2, 1)
+      action.perform(:order => order)
+      order.line_items.first.variant.should == @v2
+      order.line_items.first.quantity.should == 2
+    end
+
+    it "doesn't add if the quantity is greater" do
+      order.add_variant(@v2, 3)
+      action.perform(:order => order)
+      order.line_items.first.variant.should == @v2
+      order.line_items.first.quantity.should == 3
     end
   end
 


### PR DESCRIPTION
if a promotion is supposed to add a line item, it will add it even if the line_item already exists with the expected quantity
