### PR TITLE
Translation order_state skrill

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -617,6 +617,7 @@ en:
     payment: payment
     resumed: resumed
     returned: returned
+    skrill: skrill
   order_summary: Order Summary
   order_sure_want_to: "Are you sure you want to %{event} this order?"
   order_total: "Order Total"


### PR DESCRIPTION
When you are here http://localhost:3000/admin/orders

You a message about missing translation of skrill, and generate a <span> in a markup <option>

I add the translation and now it's ok

Best regards.
