### PR TITLE
Rename "Bucket" -> Tier to fix conflict with aws-s3

### DIFF
--- a/core/app/models/calculator/price_tier.rb
+++ b/core/app/models/calculator/price_tier.rb
@@ -1,4 +1,4 @@
-class Calculator::PriceBucket < Calculator
+class Calculator::PriceTier < Calculator
   preference :minimal_amount, :decimal, :default => 0
   preference :normal_amount, :decimal, :default => 0
   preference :discount_amount, :decimal, :default => 0

--- a/core/lib/spree_core/railtie.rb
+++ b/core/lib/spree_core/railtie.rb
@@ -28,7 +28,7 @@ module SpreeCore
           Calculator::FlatRate,
           Calculator::FlexiRate,
           Calculator::PerItem,
-          Calculator::PriceBucket]
+          Calculator::PriceTier]
 
        app.config.spree.calculators.tax_rates = [
           Calculator::SalesTax,


### PR DESCRIPTION
Spree requires paperclip version 1.4.3. This version of paperclip depends upon aws-s3 for Amazon s3 storage.
Due to some conflict with the aws-s3 gen, loading PriceBucket errors with:
`gems/spree_core-0.70.3/app/models/calculator/price_bucket.rb:1:in `<top (required)>': superclass mismatch for class PriceBucket (TypeError)`

Here is a fix that renames PriceBucket to PriceTier. I'd be happy with any other approach that allows me to use Spree and Paperclip and S3. Another solution would be to upgrade the paperclip dependency to egde (where they use a new gem).

This issue has been discussed here: http://osdir.com/ml/spree-user/2011-10/msg00022.html
