### PR TITLE
use line_item.price instead of line_item.variant.price

### DIFF
--- a/core/app/views/spree/orders/_line_item.html.erb
+++ b/core/app/views/spree/orders/_line_item.html.erb
@@ -17,13 +17,13 @@
     <%= truncate(variant.product.description, :length => 100, :omission => "...") %>
   </td>
   <td data-hook="cart_item_price">
-    <%= number_to_currency line_item.variant.price %>
+    <%= number_to_currency line_item.price %>
   </td>
   <td data-hook="cart_item_quantity">
     <%= item_form.number_field :quantity, :min => 0, :class => "line_item_quantity", :size => 5 %>
   </td>
   <td data-hook="cart_item_total">
-    <%= number_to_currency(line_item.variant.price * line_item.quantity) unless line_item.quantity.nil? %>
+    <%= number_to_currency(line_item.price * line_item.quantity) unless line_item.quantity.nil? %>
   </td>
   <td data-hook="cart_item_delete">
     <%= link_to image_tag('icons/delete.png'), '#', :class => 'delete', :id => "delete_#{dom_id(line_item)}" %>


### PR DESCRIPTION
Resolves issues reported at https://github.com/spree/spree/issues/1028 by reading from line_item.price rather than variant.price on the cart form. This price does not change once a line item is created on an order, whereas variant.price will be updated with any sort of product price change.
