### PR TITLE
Fixes broken brand and categories search

### DIFF
--- a/core/app/controllers/spree/products_controller.rb
+++ b/core/app/controllers/spree/products_controller.rb
@@ -7,7 +7,7 @@ module Spree
     respond_to :html
 
     def index
-      @searcher = Spree::Config.searcher_class.new(params)
+      @searcher = Config.searcher_class.new(params)
       @products = @searcher.retrieve_products
       respond_with(@products)
     end

--- a/core/lib/spree/core/middleware/seo_assist.rb
+++ b/core/lib/spree/core/middleware/seo_assist.rb
@@ -17,7 +17,7 @@ module Spree
           if !taxon_id.blank? && !taxon_id.is_a?(Hash) && taxon = Taxon.find(taxon_id)
             params.delete('taxon')
 
-            return build_response(params, "#{request.script_name}/t/#{taxon.permalink}" )
+            return build_response(params, "#{request.script_name}t/#{taxon.permalink}" )
           elsif env["PATH_INFO"] =~ /^\/(t|products)(\/\S+)?\/$/
             #ensures no trailing / for taxon and product urls
 


### PR DESCRIPTION
An issue with our SeoAssist middleware was causing brand and categories search to not work. This resolves that issue.
