### PR TITLE
Tax category fix

### DIFF
--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -35,7 +35,10 @@ module Spree
       category = TaxCategory.includes(:tax_rates).where(:is_default => true).first
       return 0 unless category
 
-      category.effective_amount || 0
+      address ||= Address.new(:country_id => Spree::Config[:default_country_id])
+      rate = category.tax_rates.detect { |rate| rate.zone.include? address }.try(:amount)
+
+      rate || 0
     end
 
     # Creates necessary tax adjustments for the order.


### PR DESCRIPTION
TaxRate.default was trying a call a method that no longer exists. Now we determine the rate to use through TaxCategory.
