### PR TITLE
handling preferences before activerecord is saved [fixes #940 #871]

### DIFF
--- a/core/app/models/spree/preferences/preferable.rb
+++ b/core/app/models/spree/preferences/preferable.rb
@@ -1,3 +1,8 @@
+# The preference_cache_key is used to determine if the preference
+# can be set. The default behavior is to return nil if there is no
+# id value. On ActiveRecords, new objects will have their preferences
+# saved to a pending hash until it is persisted.
+#
 # class_attributes are inheritied unless you reassign them in
 # the subclass, so when you inherit a Preferable class, the
 # inherited hook will assign a new hash for the subclass definitions
@@ -8,11 +13,19 @@ module Spree::Preferences::Preferable
   def self.included(base)
     base.class_eval do
       extend Spree::Preferences::PreferableClassMethods
+
+      if respond_to?(:after_create)
+        after_create do |obj|
+          obj.save_pending_preferences
+        end
+      end
+
       if respond_to?(:after_destroy)
         after_destroy do |obj|
           obj.clear_preferences
         end
       end
+
     end
   end
 
@@ -64,7 +77,15 @@ module Spree::Preferences::Preferable
   end
 
   def preference_cache_key(name)
-    [self.class.name, name, (try(:id) || :new)].join('::').underscore
+    return unless id
+    [self.class.name, name, id].join('::').underscore
+  end
+
+  def save_pending_preferences
+    return unless @pending_preferences
+    @pending_preferences.each do |name, value|
+      set_preference(name, value)
+    end
   end
 
   def clear_preferences
@@ -72,6 +93,16 @@ module Spree::Preferences::Preferable
   end
 
   private
+
+  def add_pending_preference(name, value)
+    @pending_preferences ||= {}
+    @pending_preferences[name] = value
+  end
+
+  def get_pending_preference(name)
+    return unless @pending_preferences
+    @pending_preferences[name]
+  end
 
   def preference_store
     Spree::Preferences::Store.instance

--- a/core/app/models/spree/preferences/preferable_class_methods.rb
+++ b/core/app/models/spree/preferences/preferable_class_methods.rb
@@ -7,11 +7,17 @@ module Spree::Preferences
       default = options[:default]
       description = options[:description] || name
 
+      # cache_key will be nil for new objects, then if we check if there
+      # is a pending preference before going to default
       define_method preference_getter_method(name) do
-        if preference_store.exist? preference_cache_key(name)
+        if preference_cache_key(name) && preference_store.exist?(preference_cache_key(name))
           preference_store.get preference_cache_key(name)
         else
-          send self.class.preference_default_getter_method(name)
+          if get_pending_preference(name)
+            get_pending_preference(name)
+          else
+            send self.class.preference_default_getter_method(name)
+          end
         end
       end
       alias_method prefers_getter_method(name), preference_getter_method(name)
@@ -22,7 +28,12 @@ module Spree::Preferences
         if type == :boolean && !value.is_a?(TrueClass) && !value.is_a?(FalseClass)
           value = value.to_i == 1
         end
-        preference_store.set preference_cache_key(name), value
+
+        if preference_cache_key(name)
+          preference_store.set preference_cache_key(name), value
+        else
+          add_pending_preference(name, value)
+        end
       end
       alias_method prefers_setter_method(name), preference_setter_method(name)
 

--- a/core/spec/models/preferences/store_spec.rb
+++ b/core/spec/models/preferences/store_spec.rb
@@ -13,7 +13,7 @@ describe Spree::Preferences::Store do
 
   it "can set and get false values when cache return nil" do
     @store.set :test, false
-    @store.get(:test).should be_nil
+    @store.get(:test).should be_false
   end
 end
 


### PR DESCRIPTION
For active record models, if the object hasn't been saved, we store the preferences in a pending hash, then write them after_create

 #940 #871
