### PR TITLE
bumped skrill and usa epay gems

### DIFF
--- a/cmd/lib/spree_cmd/installer.rb
+++ b/cmd/lib/spree_cmd/installer.rb
@@ -75,10 +75,10 @@ module SpreeCmd
 
         if @install_default_gateways
           gem :spree_usa_epay, { :git => 'git://github.com/spree/spree_usa_epay.git',
-                                 :ref => '0cb57b4afbf1eef6a0ad67a4a1ea506c6418fde1' }
+                                 :ref => '6576a0ac6b998bd6efa4dd053ba57120511bee9c' }
 
           gem :spree_skrill, { :git => 'git://github.com/spree/spree_skrill.git',
-                               :ref => '37e6159aa71ec053499e2c7aa9cf799a3b3bdb39' }
+                               :ref => '93cd573addeff26fbbd8c5855d35df659cf5bf1f' }
         end
 
         run 'bundle install', :capture => true


### PR DESCRIPTION
They both depend on core now:

  s.add_dependency('spree_core', '~>1.0.0.rc3')
