### PR TITLE
0.70 fix for on_hand scope including products with 0 on hand

### DIFF
--- a/core/app/models/product.rb
+++ b/core/app/models/product.rb
@@ -90,7 +90,7 @@ class Product < ActiveRecord::Base
     end
 
     def on_hand
-      where(Product.arel_table[:count_on_hand].gteq(0))
+      where(Product.arel_table[:count_on_hand].gt(0))
     end
 
     def id_equals(input_id)


### PR DESCRIPTION
The product on_hand scope was querying "count_on_hand >= 0" instead of "count_on_hand > 0".

I know 1.0 is getting most of the attention these days but since 0.70 is still the stable branch, and this seems like a significant bug, I thought it would be worth fixing.
