### PR TITLE
Added deleted_at to Tax Categories

### DIFF
--- a/core/app/controllers/spree/admin/tax_categories_controller.rb
+++ b/core/app/controllers/spree/admin/tax_categories_controller.rb
@@ -1,6 +1,19 @@
 module Spree
   module Admin
     class TaxCategoriesController < ResourceController
+      def destroy
+        if @object.mark_deleted!
+          flash.notice = flash_message_for(@object, :successfully_removed)
+          respond_with(@object) do |format|
+            format.html { redirect_to collection_url }
+            format.js   { render :partial => "spree/admin/shared/destroy" }
+          end
+        else
+          respond_with(@object) do |format|
+            format.html { redirect_to collection_url }
+          end
+        end
+      end
     end
   end
 end

--- a/core/app/models/spree/tax_category.rb
+++ b/core/app/models/spree/tax_category.rb
@@ -1,10 +1,12 @@
 module Spree
   class TaxCategory < ActiveRecord::Base
-    validates :name, :presence => true, :uniqueness => true
+    validates :name, :presence => true, :uniqueness => { :scope => :deleted_at }
 
     has_many :tax_rates, :dependent => :destroy
 
     before_save :set_default_category
+
+    default_scope where(:deleted_at => nil)
 
     def set_default_category
       #set existing default tax category to false if this one has been marked as default
@@ -14,5 +16,9 @@ module Spree
       end
     end
 
+    def mark_deleted!
+      self.deleted_at = Time.now
+      self.save
+    end
   end
 end

--- a/core/db/migrate/20120203153759_add_deleted_at_to_tax_category.rb
+++ b/core/db/migrate/20120203153759_add_deleted_at_to_tax_category.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtToTaxCategory < ActiveRecord::Migration
+  def change
+    add_column :spree_tax_categories, :deleted_at, :datetime
+  end
+end

--- a/core/spec/models/tax_category_spec.rb
+++ b/core/spec/models/tax_category_spec.rb
@@ -12,6 +12,15 @@ describe Spree::TaxCategory do
       end
       it { should validate_uniqueness_of(:name) }
     end
+
+    context '#mark_deleted!' do
+      let(:tax_category) { Factory(:tax_category) }
+
+      it "should set the deleted at column to the current time" do
+        tax_category.mark_deleted!
+        tax_category.deleted_at.should_not be_nil
+      end
+    end
   end
 
 end


### PR DESCRIPTION
When tax categories are deleted they are no longer destroyed. Instead they are marked as deleted.
