### PR TITLE
Fixes error when cloning a deleted product

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -140,10 +140,12 @@ module Spree
       image_dup = lambda { |i| j = i.dup; j.attachment = i.attachment.clone; j }
       p.images = self.images.map { |i| image_dup.call i }
 
-      variant = self.master.dup
-      variant.sku = 'COPY OF ' + self.master.sku
+      #variant = self.master.dup
+      master = Spree::Variant.find_by_product_id_and_is_master(self.id, true)
+      variant = master.dup
+      variant.sku = 'COPY OF ' + master.sku
       variant.deleted_at = nil
-      variant.images = self.master.images.map { |i| image_dup.call i }
+      variant.images = master.images.map { |i| image_dup.call i }
       p.master = variant
 
       if self.has_variants?

--- a/core/spec/requests/admin/products/products_spec.rb
+++ b/core/spec/requests/admin/products/products_spec.rb
@@ -86,13 +86,27 @@ describe "Products" do
     end
   end
 
-  context "cloning a product" do
+  context "cloning a product", :js => true do
     it "should allow an admin to clone a product" do
       Factory(:product, :name => 'apache baseball cap', :available_on => '2011-01-01 01:01:01', :sku => "A100")
 
       click_link "Products"
       within('table#listing_products tr:nth-child(2)') { click_link "Clone" }
       page.should have_content("Product has been cloned")
+    end
+
+    context "cloning a deleted product" do
+      it "should allow an admin to clone a deleted product" do
+        Factory(:product, :name => 'apache baseball cap', :available_on => '2011-01-01 01:01:01', :sku => "A100", :deleted_at => '2011-05-01 01:01:01')
+
+        click_link "Products"
+        check "Show Deleted"
+        click_button "Search"
+
+        page.should have_content("apache baseball cap")
+        within('table#listing_products tr:nth-child(2)') { click_link "Clone" }
+        page.should have_content("Product has been cloned")
+      end
     end
   end
 


### PR DESCRIPTION
Cloning a previously deleted product was failing due to the call to self.master in Product#duplicate. 
