### PR TITLE
need to specifiy the source attribute when doing autocomplete.

### DIFF
--- a/core/app/views/spree/admin/product_properties/index.html.erb
+++ b/core/app/views/spree/admin/product_properties/index.html.erb
@@ -47,7 +47,7 @@
   $("#product_properties input.autocomplete").live("keydown", function(){
     already_auto_completed = $(this).is('ac_input');
     if (!already_auto_completed) {
-      $(this).autocomplete(properties);
+      $(this).autocomplete({source: properties});
       $(this).focus();
     }
   });


### PR DESCRIPTION
The autocomplete in admin when adding product properties to a product was failing. 
