### PR TITLE
1095 - fix payment_state when emptying cart

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -477,7 +477,8 @@ module Spree
       # The +payment_state+ value helps with reporting, etc. since it provides a quick and easy way to locate Orders needing attention.
       def update_payment_state
         
-        if payment_total == 0 || round_money(payment_total) < round_money(total)
+        #line_item are empty when user empties cart
+        if self.line_items.empty? || round_money(payment_total) < round_money(total)
           self.payment_state = 'balance_due'
           self.payment_state = 'failed' if payments.present? and payments.last.state == 'failed'
         elsif round_money(payment_total) > round_money(total)

--- a/core/spec/models/order_spec.rb
+++ b/core/spec/models/order_spec.rb
@@ -346,7 +346,7 @@ describe Spree::Order do
 
   context "#update!" do
     # before { Order.should_receive :update_all }
-    let(:line_items) { [mock_model(Spree::Adjustment, :amount => 5) ]}
+    let(:line_items) { [mock_model(Spree::LineItem, :amount => 5) ]}
     
     context "when payments are sufficient" do
       it "should set payment_state to paid" do

--- a/core/spec/models/order_spec.rb
+++ b/core/spec/models/order_spec.rb
@@ -346,10 +346,12 @@ describe Spree::Order do
 
   context "#update!" do
     # before { Order.should_receive :update_all }
-
+    let(:line_items) { [mock_model(Spree::Adjustment, :amount => 5) ]}
+    
     context "when payments are sufficient" do
       it "should set payment_state to paid" do
         order.stub(:total => 100.01, :payment_total => 100.012343)
+        order.stub(:line_items => line_items)
         order.update!
         order.payment_state.should == "paid"
       end
@@ -379,6 +381,7 @@ describe Spree::Order do
     context "when payments are more than sufficient" do
       it "should set the payment_state to credit_owed" do
         order.stub(:total => 100, :payment_total => 150)
+        order.stub(:line_items => line_items)
         order.update!
         order.payment_state.should == "credit_owed"
       end
@@ -513,49 +516,12 @@ describe Spree::Order do
 
   end
 
-  context "#update_payment_state" do
-    
+  context "#update_payment_state" do    
     it "should set payment_state to balance_due if no line_item" do
       order.stub(:line_items => [])
       order.update!
       order.payment_state.should == "balance_due"
-    end
-    
-    it "should set payment_state to balance_due if payment_total < total" do      
-      line_items = [ mock_model(Spree::LineItem, :amount => 200), mock_model(Spree::LineItem, :amount => 200) ]
-      order.stub(:line_items => line_items)
-      
-      payments = [ mock_model(Spree::Payment, :amount => 100, :checkout? => false), mock_model(Spree::Payment, :amount => 100, :checkout? => false) ]
-      payments.stub(:completed => payments)
-      order.stub(:payments => payments)
-      
-      order.update!
-      order.payment_state.should == "balance_due"
-    end
-    
-    it "should set payment_state to paid if payment_total == total" do      
-      line_items = [ mock_model(Spree::LineItem, :amount => 100), mock_model(Spree::LineItem, :amount => 100) ]
-      order.stub(:line_items => line_items)
-      
-      payments = [ mock_model(Spree::Payment, :amount => 100, :checkout? => false), mock_model(Spree::Payment, :amount => 100, :checkout? => false) ]
-      payments.stub(:completed => payments)
-      order.stub(:payments => payments)
-      
-      order.update!
-      order.payment_state.should == "paid"
-    end
-    
-    it "should set payment_state to credit_owed if payment_total > total" do      
-      line_items = [ mock_model(Spree::LineItem, :amount => 50), mock_model(Spree::LineItem, :amount => 100) ]
-      order.stub(:line_items => line_items)
-      
-      payments = [ mock_model(Spree::Payment, :amount => 100, :checkout? => false), mock_model(Spree::Payment, :amount => 100, :checkout? => false) ]
-      payments.stub(:completed => payments)
-      order.stub(:payments => payments)
-      
-      order.update!
-      order.payment_state.should == "credit_owed"
-    end
+    end    
   end
 
   context "#payment_method" do


### PR DESCRIPTION
line_items are empty when user empties cart. So check this condition while updating payment_state. Fixing this issue broke two tests which checks case for sufficient and insufficient payment. Those tests are also updated and are passing now.
