### PR TITLE
Check for option types and values existence when creating a new variant

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -185,6 +185,17 @@ module Spree
       self.where([where_str, values.map { |value| "%#{value}%" } * fields.size].flatten)
     end
 
+    def empty_option_values?
+      return true if options.empty?
+
+      options.each do |opt|
+        if opt.option_type.option_values.empty?
+          return true
+        end
+      end
+      false
+    end
+
     private
       def recalculate_count_on_hand
         product_count_on_hand = has_variants? ?

--- a/core/app/views/spree/admin/variants/index.html.erb
+++ b/core/app/views/spree/admin/variants/index.html.erb
@@ -36,11 +36,13 @@
   <% end %>
 </table>
 
-<% if @product.options.empty? %>
+<% if @product.empty_option_values? %>
 
   <p class='first_add_option_types' data-hook="first_add_option_types">
     <%= t(:to_add_variants_you_must_first_define) %>
     <%= link_to t(:option_types), selected_admin_product_option_types_url(@product) %>
+    <%= t(:and) %>
+    <%= link_to t(:option_values), admin_option_types_url %>
   </p>
 
 <% else %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -252,6 +252,7 @@ en:
   alternative_phone: Alternative Phone
   amount: Amount
   analytics_trackers: Analytics Trackers
+  and: And
   apply: "Apply"
   are_you_sure: "Are you sure?"
   are_you_sure_category: "Are you sure you want to delete this category?"


### PR DESCRIPTION
Resolves a reported issue where an error was being thrown while trying to create a new product variant when option types existed without option values.
