### PR TITLE
Clear shipment during checkout when transitioning to 'delivery' step

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -128,6 +128,10 @@ module Spree
         end
       end
 
+      before_transition :to => ['delivery'] do |order|
+        order.shipments.each { |s| s.destroy unless s.shipping_method.available_to_order?(order) }
+      end
+
       after_transition :to => 'complete', :do => :finalize!
       after_transition :to => 'delivery', :do => :create_tax_charge!
       after_transition :to => 'payment',  :do => :create_shipment!


### PR DESCRIPTION
Clear shipment during checkout if the current shipping address is not eligible for the
existing shipping method
