### PR TITLE
Renaming PriceBucket to PriceSack

### DIFF
--- a/core/app/models/calculator/price_sack.rb
+++ b/core/app/models/calculator/price_sack.rb
@@ -1,10 +1,10 @@
-class Calculator::PriceBucket < Calculator
+class Calculator::PriceSack < Calculator
   preference :minimal_amount, :decimal, :default => 0
   preference :normal_amount, :decimal, :default => 0
   preference :discount_amount, :decimal, :default => 0
 
   def self.description
-    I18n.t("price_bucket")
+    I18n.t("price_sack")
   end
 
   # as object we always get line items, as calculable we have Coupon, ShippingMethod

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -672,7 +672,8 @@ en:
   preview: Preview
   previous: Previous
   price: Price
-  price_bucket: Price Bucket
+  price_sack: Price Sack
+  price_range: Price Range
   price_with_vat_included: "%{price} (inc. VAT)"
   problem_authorizing_card: "Problem authorizing credit card"
   problem_capturing_card: "Problem capturing credit card"

--- a/core/lib/spree_core/railtie.rb
+++ b/core/lib/spree_core/railtie.rb
@@ -28,7 +28,7 @@ module SpreeCore
           Calculator::FlatRate,
           Calculator::FlexiRate,
           Calculator::PerItem,
-          Calculator::PriceBucket]
+          Calculator::PriceSack]
 
        app.config.spree.calculators.tax_rates = [
           Calculator::SalesTax,


### PR DESCRIPTION
Renaming PriceBucket to PriceSack as is already in 1.0 version in master, including locales
