### PR TITLE
type conversions for preferences [Fixes #1117]

### DIFF
--- a/core/app/models/spree/preference.rb
+++ b/core/app/models/spree/preference.rb
@@ -1,31 +1,52 @@
 class Spree::Preference < ActiveRecord::Base
 
   validates :key, :presence => true
+  validates :value, :presence => true
+  validates :value_type, :presence => true
 
-  def value=(value)
-    self[:value] = value
-    self[:value_type] = value.class.name
+  # The type conversions here should match
+  # the ones in spree::preferences::preferrable#convert_preference_value
+  def value
+    case self[:value_type].to_sym
+    when :string
+      self[:value].to_s
+    when :password
+      self[:value].to_s
+    when :decimal
+      BigDecimal.new(self[:value].to_s).round(2, BigDecimal::ROUND_HALF_UP)
+    when :integer
+      self[:value].to_i
+    when :boolean
+      (self[:value].to_s =~ /^t/i) != nil
+    end
   end
 
-  def value
-    return unless self[:value]
+  # For the rc releases of 1.0, we stored the object class names, this converts
+  # to preferences definition types. This code should eventually be removed.
+  # it is called during the load_preferences of the Preferences::Store
+  def self.convert_old_value_types(preference)
+    return unless [Symbol.to_s, Fixnum.to_s, Bignum.to_s,
+                   Float.to_s, TrueClass.to_s, FalseClass.to_s].include? preference.value_type
 
-    case self[:value_type]
+    case preference.value_type
     when Symbol.to_s
-      self[:value].to_sym
+      preference.value_type = 'string'
     when Fixnum.to_s
-      self[:value].to_i
+      preference.value_type = 'integer'
     when Bignum.to_s
-      self[:value].to_f.to_i
+      preference.value_type = 'integer'
+      preference.value = preference.value.to_f.to_i
     when Float.to_s
-      self[:value].to_f
+      preference.value_type = 'decimal'
     when TrueClass.to_s
-      true
+      preference.value_type = 'boolean'
+      preference.value = "true"
     when FalseClass.to_s
-      false
-    else
-      self[:value]
+      preference.value_type = 'boolean'
+      preference.value = "false"
     end
+
+    preference.save
   end
 
 end

--- a/core/app/models/spree/preferences/preferable.rb
+++ b/core/app/models/spree/preferences/preferable.rb
@@ -104,6 +104,31 @@ module Spree::Preferences::Preferable
     @pending_preferences[name]
   end
 
+  def convert_preference_value(value, type)
+    case type
+    when :string
+      value.to_s
+    when :password
+      value.to_s
+    when :decimal
+      BigDecimal.new(value.to_s).round(2, BigDecimal::ROUND_HALF_UP)
+    when :integer
+      value.to_i
+    when :boolean
+      if value.is_a?(FalseClass) ||
+         value.nil? ||
+         value == 0 ||
+         value =~ /^(f|false|0)$/i ||
+         (value.respond_to? :empty? and value.empty?)
+         false
+      else
+         true
+      end
+    else
+      value
+    end
+  end
+
   def preference_store
     Spree::Preferences::Store.instance
   end

--- a/core/app/models/spree/preferences/preferable_class_methods.rb
+++ b/core/app/models/spree/preferences/preferable_class_methods.rb
@@ -23,20 +23,9 @@ module Spree::Preferences
       alias_method prefers_getter_method(name), preference_getter_method(name)
 
       define_method preference_setter_method(name) do |value|
-        # Boolean attributes can come back from forms as '0' or '1'
-        # Convert them to their correct values here
-        if type == :boolean && !value.is_a?(TrueClass) && !value.is_a?(FalseClass)
-          value = value.downcase if value.respond_to? :downcase
-          case value
-          when 0, '0', 'false', 'f', "", []
-            value = false
-          else
-            value = true
-          end
-        end
-
+        value = convert_preference_value(value, type)
         if preference_cache_key(name)
-          preference_store.set preference_cache_key(name), value
+          preference_store.set preference_cache_key(name), value, type
         else
           add_pending_preference(name, value)
         end

--- a/core/app/models/spree/preferences/store.rb
+++ b/core/app/models/spree/preferences/store.rb
@@ -17,16 +17,16 @@ module Spree::Preferences
       load_preferences
     end
 
-    def set(key, value)
+    def set(key, value, type)
       @cache.write(key, value)
-      persist(key, value)
+      persist(key, value, type)
     end
 
     def exist?(key)
       @cache.exist? key
     end
 
-    def get(key, default_key=nil)
+    def get(key)
       @cache.read(key)
     end
 
@@ -37,11 +37,12 @@ module Spree::Preferences
 
     private
 
-    def persist(cache_key, value)
+    def persist(cache_key, value, type)
       return unless should_persist?
 
       preference = Spree::Preference.find_or_initialize_by_key(cache_key)
       preference.value = value
+      preference.value_type = type
       preference.save
     end
 
@@ -56,7 +57,8 @@ module Spree::Preferences
       return unless should_persist?
 
       Spree::Preference.all.each do |p|
-         @cache.write(p.key, p.value)
+        Spree::Preference.convert_old_value_types(p) # see comment
+        @cache.write(p.key, p.value)
       end
     end
 

--- a/core/lib/spree/core/user_banners.rb
+++ b/core/lib/spree/core/user_banners.rb
@@ -5,7 +5,7 @@ module Spree
   module Core
     module UserBanners
       def self.included(base)
-        base.preference :dismissed_banners, :text, :default => ''
+        base.preference :dismissed_banners, :string, :default => ''
       end
 
       def dismissed_banner_ids

--- a/core/spec/lib/mail_settings_spec.rb
+++ b/core/spec/lib/mail_settings_spec.rb
@@ -46,9 +46,9 @@ describe Spree::Core::MailSettings do
 
         context "mail_port preference" do
           it "should override the application defaults" do
-            mail_method.set_preference(:mail_port, "123")
+            mail_method.set_preference(:mail_port, 123)
             Spree::Core::MailSettings.init
-            ActionMailer::Base.smtp_settings[:port].should == "123"
+            ActionMailer::Base.smtp_settings[:port].should == 123
           end
         end
 

--- a/core/spec/models/preference_spec.rb
+++ b/core/spec/models/preference_spec.rb
@@ -5,75 +5,87 @@ describe Spree::Preference do
   it "should require a key" do
     @preference = Spree::Preference.new
     @preference.key = :test
+    @preference.value_type = :boolean
+    @preference.value = true
     @preference.should be_valid
   end
 
-  it "sets the value type with value" do
-    @preference = Spree::Preference.new
-
-    @preference.value = true
-    @preference.value_type.should eq TrueClass.to_s
-
-    @preference.value = "test"
-    @preference.value_type.should eq String.to_s
-  end
-
   describe "type coversion for values" do
-    def round_trip_preference(key, value)
+    def round_trip_preference(key, value, value_type)
       p = Spree::Preference.new
       p.value = value
+      p.value_type = value_type
       p.key = key
       p.save
 
       Spree::Preference.find_by_key(key)
     end
 
-    it "Symbol" do
-      value = :fbi
-      key = "fox/mulder"
-      pref = round_trip_preference(key, value)
-      pref.value.should eq value
-      pref.value.class.should eq value.class
-    end
-
-    it "Fixnum" do
-      value = 1234
-      key = "hipster"
-      pref = round_trip_preference(key, value)
-      pref.value.should eq value
-      pref.value.class.should eq value.class
-    end
-
-    it "Bignum" do
-      value = 2342341234123409981440 #in db as "2.34234123412341e+21"
-      key = "notorious/b/i/g"
-      pref = round_trip_preference(key, value)
-      pref.value.should eq value
-      pref.value.class.should eq value.class
-    end
-
-    it "Float" do
-      value = 3.14
-      key = "apple/pie"
-      pref = round_trip_preference(key, value)
-      pref.value.should eq value
-      pref.value.class.should eq value.class
-    end
-
-    it "TrueClass" do
+    it ":boolean" do
+      value_type = :boolean
       value = true
-      key = "you/cant/handle"
-      pref = round_trip_preference(key, value)
+      key = "boolean_key"
+      pref = round_trip_preference(key, value, value_type)
       pref.value.should eq value
-      pref.value.class.should eq value.class
+      pref.value_type.should == value_type.to_s
     end
 
-    it "FalseClass" do
-      value = false
-      key = "ll/cool/j"
-      pref = round_trip_preference(key, value)
+    it ":integer" do
+      value_type = :integer
+      value = 10
+      key = "integer_key"
+      pref = round_trip_preference(key, value, value_type)
       pref.value.should eq value
-      pref.value.class.should eq value.class
+      pref.value_type.should == value_type.to_s
+    end
+
+    it ":decimal" do
+      value_type = :decimal
+      value = 1.5
+      key = "decimal_key"
+      pref = round_trip_preference(key, value, value_type)
+      pref.value.should eq value
+      pref.value_type.should == value_type.to_s
+    end
+
+    it ":string" do
+      value_type = :string
+      value = "This is a string"
+      key = "string_key"
+      pref = round_trip_preference(key, value, value_type)
+      pref.value.should eq value
+      pref.value_type.should == value_type.to_s
+    end
+
+    it ":password" do
+      value_type = :password
+      value = "This is a password"
+      key = "password_key"
+      pref = round_trip_preference(key, value, value_type)
+      pref.value.should eq value
+      pref.value_type.should == value_type.to_s
+    end
+
+  end
+
+  describe "converting old values" do
+
+    it "converts true" do
+      p = Spree::Preference.new
+      p.value = 't'
+      p.value_type = TrueClass.to_s
+      Spree::Preference.convert_old_value_types(p)
+      p.value_type.should == 'boolean'
+      p.value.should == true
+    end
+
+    it "converts false" do
+      p = Spree::Preference.new
+      p.value = 'f'
+      p.value_type = FalseClass.to_s
+      Spree::Preference.convert_old_value_types(p)
+      p.value_type.should == 'boolean'
+      p.value.should == false
     end
 
   end

--- a/core/spec/models/preferences/configuration_spec.rb
+++ b/core/spec/models/preferences/configuration_spec.rb
@@ -10,18 +10,18 @@ describe Spree::Preferences::Configuration do
   end
 
   it "has named methods to access preferences" do
-    @config.color = :orange
-    @config.color.should eq :orange
+    @config.color = 'orange'
+    @config.color.should eq 'orange'
   end
 
   it "uses [ ] to access preferences" do
-    @config[:color] = :red
-    @config[:color].should eq :red
+    @config[:color] = 'red'
+    @config[:color].should eq 'red'
   end
 
   it "uses set/get to access preferences" do
-    @config.set :color, :green
-    @config.get(:color).should eq :green
+    @config.set :color, 'green'
+    @config.get(:color).should eq 'green'
   end
 
 end

--- a/core/spec/models/preferences/preferable_spec.rb
+++ b/core/spec/models/preferences/preferable_spec.rb
@@ -11,7 +11,7 @@ describe Spree::Preferences::Preferable do
         @id = rand(999)
       end
 
-      preference :color, :string, :default => :green, :description => "My Favorite Color"
+      preference :color, :string, :default => 'green', :description => "My Favorite Color"
     end
 
     class B < A
@@ -38,8 +38,8 @@ describe Spree::Preferences::Preferable do
     end
 
     it "instances have defaults" do
-      @a.preferred_color.should eq :green
-      @b.preferred_color.should eq :green
+      @a.preferred_color.should eq 'green'
+      @b.preferred_color.should eq 'green'
       @b.preferred_flavor.should be_nil
     end
 
@@ -60,8 +60,8 @@ describe Spree::Preferences::Preferable do
     end
 
     it "has a default" do
-      @a.preferred_color_default.should eq :green
-      @a.preference_default(:color).should eq :green
+      @a.preferred_color_default.should eq 'green'
+      @a.preference_default(:color).should eq 'green'
     end
 
     it "has a description" do
@@ -80,25 +80,25 @@ describe Spree::Preferences::Preferable do
   describe "preference access" do
     it "handles ghost methods for preferences" do
       #pending("TODO: cmar to look at this test to figure out why it's failing on 1.9")
-      @a.preferred_color = :blue
-      @a.preferred_color.should eq :blue
+      @a.preferred_color = 'blue'
+      @a.preferred_color.should eq 'blue'
 
-      @a.prefers_color = :green
-      @a.prefers_color?.should eq :green
+      @a.prefers_color = 'green'
+      @a.prefers_color?.should eq 'green'
     end
 
     it "has genric readers" do
-      @a.preferred_color = :red
-      @a.prefers?(:color).should eq :red
-      @a.preferred(:color).should eq :red
+      @a.preferred_color = 'red'
+      @a.prefers?(:color).should eq 'red'
+      @a.preferred(:color).should eq 'red'
     end
 
     it "parent and child instances have their own prefs" do
-      @a.preferred_color = :red
-      @b.preferred_color = :blue
+      @a.preferred_color = 'red'
+      @b.preferred_color = 'blue'
 
-      @a.preferred_color.should eq :red
-      @b.preferred_color.should eq :blue
+      @a.preferred_color.should eq 'red'
+      @b.preferred_color.should eq 'blue'
     end
 
     it "raises when preference not defined" do
@@ -109,8 +109,42 @@ describe Spree::Preferences::Preferable do
 
     it "builds a hash of preferences" do
       @b.preferred_flavor = :strawberry
-      @b.preferences[:flavor].should eq :strawberry
-      @b.preferences[:color].should eq :green #default from A
+      @b.preferences[:flavor].should eq 'strawberry'
+      @b.preferences[:color].should eq 'green' #default from A
+    end
+
+    context "converts integer preferences to integer values" do
+      before do
+        A.preference :is_integer, :integer
+      end
+
+      it "with strings" do
+        @a.set_preference(:is_integer, '3')
+        @a.preferences[:is_integer].should == 3
+
+        @a.set_preference(:is_integer, '')
+        @a.preferences[:is_integer].should == 0
+      end
+
+    end
+
+    context "converts decimal preferences to BigDecimal values" do
+      before do
+        A.preference :if_decimal, :decimal
+      end
+
+      it "returns a BigDecimal" do
+        @a.set_preference(:if_decimal, 3.3)
+        @a.preferences[:if_decimal].class.should == BigDecimal
+      end
+
+      it "with strings" do
+        @a.set_preference(:if_decimal, '3.3')
+        @a.preferences[:if_decimal].should == 3.3
+
+        @a.set_preference(:if_decimal, '')
+        @a.preferences[:if_decimal].should == 0.0
+      end
     end
 
     context "converts boolean preferences to boolean values" do

--- a/core/spec/models/preferences/store_spec.rb
+++ b/core/spec/models/preferences/store_spec.rb
@@ -6,16 +6,13 @@ describe Spree::Preferences::Store do
   end
 
   it "sets and gets a key" do
-    @store.set :test, :value
+    @store.set :test, 1, :integer
     @store.exist?(:test).should be_true
-    @store.get(:test).should eq :value
+    @store.get(:test).should eq 1
   end
 
   it "can set and get false values when cache return nil" do
-    @store.set :test, false
+    @store.set :test, false, :boolean
     @store.get(:test).should be_false
   end
 end
-
-
-


### PR DESCRIPTION
type conversions for preferences. changed the value_types stored
in the database. temporary conversion for preferences created during
1.0 release candidates.

 [Fixes #1117]
