### PR TITLE
Variable misnamed, causing "spree extension" to break.

### DIFF
--- a/cmd/lib/spree_cmd/templates/extension/script/rails.tt
+++ b/cmd/lib/spree_cmd/templates/extension/script/rails.tt
@@ -1,7 +1,7 @@
 # This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
 
 ENGINE_ROOT = File.expand_path('../..', __FILE__)
-ENGINE_PATH = File.expand_path('../../lib/<%= name -%>/engine', __FILE__)
+ENGINE_PATH = File.expand_path('../../lib/<%= file_name -%>/engine', __FILE__)
 
 require 'rails/all'
 require 'rails/engine/commands'


### PR DESCRIPTION
- Changed "name" to "file_name", which is the correct variable.

```
Error was "(erb):4:in `template': undefined local variable or method `name' for 
#<SpreeCmd::Extension:0xb70665a0> (NameError)"
```
