### PR TITLE
only loading valid preferences to populate cache

### DIFF
--- a/core/app/models/spree/preference.rb
+++ b/core/app/models/spree/preference.rb
@@ -4,6 +4,8 @@ class Spree::Preference < ActiveRecord::Base
   validates :value, :presence => true
   validates :value_type, :presence => true
 
+  scope :valid, where("key IS NOT NULL").where("value_type IS NOT NULL")
+
   # The type conversions here should match
   # the ones in spree::preferences::preferrable#convert_preference_value
   def value
@@ -19,6 +21,10 @@ class Spree::Preference < ActiveRecord::Base
     when :boolean
       (self[:value].to_s =~ /^t/i) != nil
     end
+  end
+
+  def raw_value
+    self[:value]
   end
 
   # For the rc releases of 1.0, we stored the object class names, this converts

--- a/core/app/models/spree/preferences/store.rb
+++ b/core/app/models/spree/preferences/store.rb
@@ -56,7 +56,7 @@ module Spree::Preferences
     def load_preferences
       return unless should_persist?
 
-      Spree::Preference.all.each do |p|
+      Spree::Preference.valid.each do |p|
         Spree::Preference.convert_old_value_types(p) # see comment
         @cache.write(p.key, p.value)
       end

--- a/promo/db/migrate/20120119024707_namespace_promo_tables.rb
+++ b/promo/db/migrate/20120119024707_namespace_promo_tables.rb
@@ -48,22 +48,16 @@ class NamespacePromoTables < ActiveRecord::Migration
     add_column :spree_activators, :code, :string
     add_column :spree_activators, :advertise, :boolean, :default => false
 
+    Spree::Activator.reset_column_information
+
     Spree::Preference.where(:owner_type => 'Spree::Activator').each do |preference|
       unless Spree::Activator.exists? preference.owner_id
         preference.destroy
         next
       end
 
-      preference.value_type = case preference.name
-                              when 'usage_limit'
-                                :integer
-                              when 'advertise'
-                                :boolean
-                              else
-                                :string
-                              end
       @activator = Spree::Activator.find(preference.owner_id)
-      @activator.update_attribute(preference.name, preference.value)
+      @activator.update_attribute(preference.name, preference.raw_value)
       preference.destroy
     end
 


### PR DESCRIPTION
using raw values to set the new activator data, so 0 or nil will migrate correctly
