### PR TITLE
fix small typo in README template for extension generator

### DIFF
--- a/cmd/lib/spree_cmd/templates/extension/README.md
+++ b/cmd/lib/spree_cmd/templates/extension/README.md
@@ -15,7 +15,7 @@ Testing
 Be sure to bundle your dependencies and then create a dummy test app for the specs to run against.
 
     $ bundle
-    $ bundle exec rake test app
+    $ bundle exec rake test_app
     $ bundle exec rspec spec
 
 Copyright (c) <%= Time.now.year %> [name of extension creator], released under the New BSD License


### PR DESCRIPTION
to create a test app you need to run the test_app rake task. 
