### PR TITLE
Enables: Coupon code entering within cart screen

### DIFF
--- a/promo/app/controllers/spree/checkout_controller_decorator.rb
+++ b/promo/app/controllers/spree/checkout_controller_decorator.rb
@@ -18,6 +18,16 @@ Spree::CheckoutController.class_eval do
         end
       end
 
+      # In an instance the coupon code is entered from the cart, if the adjustment is higher than
+      # the order total before shipping (e.g: order total: 10 and adjustment is 10.01), order gets
+      # completed without shipping cost calculations, thus skipping the payment screen. Checks for
+      # such instances and updates the adjustment totals after creating shipment. May not be the
+      # best solution and might need a different approach. Yet, this takes care of the issue.
+      if params[:order][:shipping_method_id] && @order.payment_state == 'paid' && @order.state == 'delivery'
+        @order.create_shipment!
+        @order.update!
+      end
+
       if @order.next
         state_callback(:after)
       else

--- a/promo/app/controllers/spree/orders_controller_decorator.rb
+++ b/promo/app/controllers/spree/orders_controller_decorator.rb
@@ -1,0 +1,25 @@
+Spree::OrdersController.class_eval do
+  def update
+    @order = current_order
+    if @order.update_attributes(params[:order])
+
+      if @order.coupon_code.present?
+        if Spree::Promotion.exists?(:code => @order.coupon_code)
+          fire_event('spree.checkout.coupon_code_added', :coupon_code => @order.coupon_code)
+          flash[:notice] = t(:coupon_code_added)
+          # If it doesn't exist, raise an error!
+          # Giving them another chance to enter a valid coupon code
+        else
+          flash[:error] = t(:promotion_not_found)
+          render :edit and return
+        end
+      end
+
+      @order.line_items = @order.line_items.select {|li| li.quantity > 0 }
+      fire_event('spree.order.contents_changed')
+      respond_with(@order) { |format| format.html { redirect_to cart_path } }
+    else
+      respond_with(@order)
+    end
+  end
+end

--- a/promo/config/locales/en.yml
+++ b/promo/config/locales/en.yml
@@ -14,6 +14,7 @@ en:
   advertise: Advertise
   coupon: Coupon
   coupon_code: Coupon code
+  coupon_code_added: Coupon code added
   editing_promotion: Editing Promotion
   events:
     spree:


### PR DESCRIPTION
- Coupon code entering within cart screen: (probably use an override for that: https://gist.github.com/1813651)
- Coupon code success message.
- Fix: order completion without shipping costs
