### PR TITLE
Adjustment creation fails when 'receiving' return authorizations

### DIFF
--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -65,7 +65,7 @@ module Spree
 
       def process_return
         inventory_units.each &:return!
-        credit = Adjustment.create(:source => self, :order_id => self.order.id, :amount => self.amount.abs * -1, :label => I18n.t(:rma_credit))
+        credit = Adjustment.create(:source => self, :adjustable => self.order, :amount => self.amount.abs * -1, :label => I18n.t(:rma_credit))
         self.order.update!
       end
 


### PR DESCRIPTION
Return authorization fails when 'receive' event is fired. The adjustment attribute that is getting updated is now polymorphic. Changed code to reflect that.
