### PR TITLE
moved fixtures as testing_support for extensions

### DIFF
--- a/auth/spec/spec_helper.rb
+++ b/auth/spec/spec_helper.rb
@@ -10,12 +10,9 @@ require 'spree/url_helpers'
 # in ./support/ and its subdirectories.
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
 
+require 'spree/core/testing_support/fixtures'
 require 'spree/core/testing_support/factories'
 require 'spree/core/testing_support/env'
-
-require 'active_record/fixtures'
-fixtures_dir = File.expand_path('../../../core/db/default', __FILE__)
-ActiveRecord::Fixtures.create_fixtures(fixtures_dir, ['spree/countries', 'spree/zones', 'spree/zone_members', 'spree/states', 'spree/roles'])
 
 RSpec.configure do |config|
   # == Mock Framework

--- a/core/lib/spree/core/testing_support/fixtures.rb
+++ b/core/lib/spree/core/testing_support/fixtures.rb
@@ -1,0 +1,4 @@
+require 'active_record/fixtures'
+
+fixtures_dir = File.expand_path('../../../../../db/default', __FILE__)
+ActiveRecord::Fixtures.create_fixtures(fixtures_dir, ['spree/countries', 'spree/zones', 'spree/zone_members', 'spree/states', 'spree/roles'])


### PR DESCRIPTION
to use fixtures in extensions test. add in spec_helper:

``` ruby
require 'spree/core/testing_support/fixtures'
```
