### PR TITLE
Boolean Preferences return incorrect value of nil for false

### DIFF
--- a/core/app/models/spree/preference.rb
+++ b/core/app/models/spree/preference.rb
@@ -1,7 +1,7 @@
 class Spree::Preference < ActiveRecord::Base
 
   validates :key, :presence => true
-  validates :value, :presence => true
+  validates :value, :presence => true, :unless => Proc.new { |pref| pref.value_type.to_sym == :boolean && pref.value == false }
   validates :value_type, :presence => true
 
   # The type conversions here should match

--- a/core/spec/models/preference_spec.rb
+++ b/core/spec/models/preference_spec.rb
@@ -20,14 +20,27 @@ describe Spree::Preference do
 
       Spree::Preference.find_by_key(key)
     end
-
-    it ":boolean" do
-      value_type = :boolean
-      value = true
-      key = "boolean_key"
-      pref = round_trip_preference(key, value, value_type)
-      pref.value.should eq value
-      pref.value_type.should == value_type.to_s
+    
+    context ":boolean" do
+      
+      it "true" do
+        value_type = :boolean
+        value = true
+        key = "boolean_key"
+        pref = round_trip_preference(key, value, value_type)
+        pref.value.should eq value
+        pref.value_type.should == value_type.to_s
+      end
+      
+      it "false" do
+        value_type = :boolean
+        value = false
+        key = "boolean_key"
+        pref = round_trip_preference(key, value, value_type)
+        pref.value.should eq value
+        pref.value_type.should == value_type.to_s
+      end
+      
     end
 
     it ":integer" do


### PR DESCRIPTION
We noticed our Spree app had stopped sending email notifications after we upgraded from rc4 to v1.0.0.

After a little investigation we discovered an issue with preferences, its a little tangled as it behaves differently in mysql and sqlite ( didn't test further dbs at this point ).
### MySQL
#### To Reproduce
1. Create new workspace / gemset, etc
2. run `gem install spree_cmd`
3. run `rails new mystore -d mysql`
4. Set-up mysql access if required 
5. run `spree install`
6. run `rails s`
7. Visit http://localhost:3000/admin/mail_methods
8. Create a new mail method with "Enable Mail Delivery" ticked
9. Click send test mail - no message will be sent
10. Edit your mail method - Enable Mail Delivery will be unticked
11. Check spree_preferences in database, row for "spree/mail_method/enable_mail_delivery/1" will have a value of "1", true in MySQL
###### Further Steps
1. Open General Settings
2. Save without changing anything
3. Re-open, check boxes that were ticked are now unticked. They will be set as true in the database.

A little playing around in the console showed that preference rows with type 'boolean' and value 'true' return a value of nil instead.
### sqlite

If you change the database to sqlite and go through the above steps again, things will now appear to work, however, if you untick any "true" preference and then save and reopen, it will remain true. 

In the console, false values are returned as nil and aren't being persisted to the database by forms.
#### MySQL patch

I applied the following patch to our app: https://gist.github.com/1836269

This makes MySQL behave the same as sqlite for us but doesn't resolve the underlying issue.
#### Pull Request

I've attached a failing test that illustrates the issue with boolean preferences.

I'm sorry I haven't had time to investigate further to offer a fix.
