### PR TITLE
Use correlated subquery in Product.on_hand scope to increase performance

### DIFF
--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -199,7 +199,8 @@ module Spree
     end
 
     def self.on_hand
-      where("spree_products.id in (select product_id from spree_variants group by product_id having sum(count_on_hand) > 0)")
+      variants_table = Variant.table_name
+      where("#{table_name}.id in (select product_id from #{variants_table} where product_id = #{table_name}.id group by product_id having sum(count_on_hand) > 0)")
     end
 
     def self.taxons_name_eq(name)


### PR DESCRIPTION
We're deploying a store on 1.0 with 15K product variants.  The current version of the _Product.on_hand_ scope wasn't performing well in MySQL with a "large" table.

This change uses a correlated subquery improved query performance for us by more than 2 orders of magnitude.  It was the best performing option we tried on MySQL.  

Current specs for product scopes are passing with this change, but it's not clear how other databases will optimize new query. 

We would welcome any feedback on getting something similar into master and 1-0-stable
