### PR TITLE
Fix assert valid keys in nav helper link to delete

### DIFF
--- a/core/app/helpers/spree/admin/navigation_helper.rb
+++ b/core/app/helpers/spree/admin/navigation_helper.rb
@@ -57,7 +57,7 @@ module Spree
       end
 
       def link_to_delete(resource, options = {}, html_options={})
-        options.assert_valid_keys(:url, :caption, :title, :dataType, :success, :name)
+        options.assert_valid_keys(:url, :caption, :title, :dataType, :success, :error, :name)
 
         options.reverse_merge! :url => object_url(resource) unless options.key? :url
         options.reverse_merge! :caption => t(:are_you_sure)


### PR DESCRIPTION
This same fix should be added to master as well.  I'm not sure if I'm supposed to create a separate pull request for that.
