### PR TITLE
Truncate long product names, and add clearfix to product list. [fixes #1...

### DIFF
--- a/core/app/assets/stylesheets/store/screen.css.scss
+++ b/core/app/assets/stylesheets/store/screen.css.scss
@@ -490,6 +490,15 @@ mark {background-color: $link_text_color; color: $layout_background_color; font-
   }
 
   ul#products {
+		&:after {
+	  	content: " ";
+    	display: block;
+	  	clear: both;
+	  	visibility: hidden;
+	  	line-height: 0;
+	  	height: 0;
+		}
+
     li {
       text-align: center;
       font-weight: bold;

--- a/core/app/views/spree/shared/_products.html.erb
+++ b/core/app/views/spree/shared/_products.html.erb
@@ -16,7 +16,7 @@
         <div class="product-image">
           <%= link_to small_image(product, :itemprop => "name"), product %>
         </div>
-        <%= link_to product.name, product, :class => 'info', :itemprop => "name" %>
+        <%= link_to truncate(product.name, :length => 50), product, :class => 'info', :itemprop => "name", :title => product.name %>
         <span class="price selling" itemprop="price"><%= number_to_currency product.price %></span>
       </li>
     <% end %>


### PR DESCRIPTION
...171]

Similar to #1174 but I think it will be nicer to also display the product name in the title attribute, as well as, implement a clearfix for the floating product list.
