### PR TITLE
Removed validator for preferences so nil or empty strings can be set

### DIFF
--- a/core/app/models/spree/preference.rb
+++ b/core/app/models/spree/preference.rb
@@ -3,12 +3,6 @@ class Spree::Preference < ActiveRecord::Base
   validates :key, :presence => true
   validates :value_type, :presence => true
 
-  validate do |preference|
-    unless preference.value.present? || preference.value.kind_of?(FalseClass)
-      preference.errors.add(:value, "Value must be present")
-    end
-  end
-
   scope :valid, where(Spree::Preference.arel_table[:key].not_eq(nil)).where(Spree::Preference.arel_table[:value_type].not_eq(nil))
 
   # The type conversions here should match

--- a/core/spec/models/preference_spec.rb
+++ b/core/spec/models/preference_spec.rb
@@ -10,24 +10,6 @@ describe Spree::Preference do
     @preference.should be_valid
   end
 
-  describe "validates value is present" do
-    it "string is valid" do
-      @preference = Spree::Preference.new
-      @preference.key = :test
-      @preference.value_type = :string
-      @preference.value = "test value"
-      @preference.should be_valid
-    end
-
-    it "nil string is invalid" do
-      @preference = Spree::Preference.new
-      @preference.key = :test
-      @preference.value_type = :string
-      @preference.value = nil
-      @preference.should_not be_valid
-    end
-  end
-
   describe "type coversion for values" do
     def round_trip_preference(key, value, value_type)
       p = Spree::Preference.new


### PR DESCRIPTION
@bdq requested this fix so he can set nil strings
