### PR TITLE
use current released version of skrill and usa_epay

### DIFF
--- a/cmd/lib/spree_cmd/installer.rb
+++ b/cmd/lib/spree_cmd/installer.rb
@@ -74,11 +74,8 @@ module SpreeCmd
         gem :spree, @spree_gem_options
 
         if @install_default_gateways
-          gem :spree_usa_epay, { :git => 'git://github.com/spree/spree_usa_epay.git',
-                                 :ref => '6576a0ac6b998bd6efa4dd053ba57120511bee9c' }
-
-          gem :spree_skrill, { :git => 'git://github.com/spree/spree_skrill.git',
-                               :ref => '93cd573addeff26fbbd8c5855d35df659cf5bf1f' }
+          gem :spree_usa_epay
+          gem :spree_skrill
         end
 
         run 'bundle install', :capture => true


### PR DESCRIPTION
spree_skrill and spree_usa_epay have been released top rubygems. The command line installer does not specify a specific sha anymore.

I also fixed spree_skrill so you can test locally. The payment is created in a pending state until the skrill call back occurs
