### PR TITLE
Do not localize product and variant price fields.

### DIFF
--- a/core/app/views/spree/admin/products/_form.html.erb
+++ b/core/app/views/spree/admin/products/_form.html.erb
@@ -21,13 +21,13 @@
   <div class="right" data-hook="admin_product_form_right">
       <%= f.field_container :price do %>
         <%= f.label :price, t(:master_price) %> <span class="required">*</span><br />
-        <%= f.text_field :price, :value => number_with_precision(@product.price, :precision => 2) %>
+        <%= f.text_field :price %>
         <%= f.error_message_on :price %>
       <% end %>
 
       <%= f.field_container :cost_price do %>
         <%= f.label :cost_price, t(:cost_price) %><br />
-        <%= f.text_field :cost_price, :value => number_with_precision(@product.cost_price, :precision => 2) %>
+        <%= f.text_field :cost_price %>
       <%= f.error_message_on :cost_price %>
     <% end %>
 

--- a/core/app/views/spree/admin/variants/_form.html.erb
+++ b/core/app/views/spree/admin/variants/_form.html.erb
@@ -20,10 +20,10 @@
     <%= f.text_field :sku %></p>
 
     <p data-hook="price"><%= f.label :price, t(:price) %>:<br />
-    <%= f.text_field :price, :value => number_with_precision(@variant.price, :precision => 2) %></p>
+    <%= f.text_field :price %></p>
 
     <p data-hook="cost_price"><%= f.label :cost_price, t(:cost_price) %>:<br />
-    <%= f.text_field :cost_price, :value => number_with_precision(@variant.cost_price, :precision => 2) %></p>
+    <%= f.text_field :cost_price %></p>
 
     <% if Spree::Config[:track_inventory_levels] %>
       <p data-hook="on_hand"><%= f.label :on_hand, t(:on_hand) %>: <br />


### PR DESCRIPTION
Since they do not get converted correctly as decimal on save.

This removes the validation errors if saving a product or variant with localized price values.

Please see #468 for further discussion details.
