### PR TITLE
Use states_url instead of states_path for javascript_include_tag.

### DIFF
--- a/core/app/views/spree/admin/orders/customer_details/_form.html.erb
+++ b/core/app/views/spree/admin/orders/customer_details/_form.html.erb
@@ -43,6 +43,6 @@
 </p>
 
 <% content_for :head do %>
-  <%= javascript_include_tag states_path, 'admin/address_states.js' %>
+  <%= javascript_include_tag states_url, 'admin/address_states.js' %>
 <% end %>
 

--- a/core/app/views/spree/checkout/edit.html.erb
+++ b/core/app/views/spree/checkout/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :head do %>
-  <%= javascript_include_tag states_path %>
+  <%= javascript_include_tag states_url %>
 <% end %>
 <div id="checkout" data-hook>  
   <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @order } %>


### PR DESCRIPTION
If you specify an `assets_host` in your app the `javascript_include_tag` will use that host in the url for `states_path`, and will end up rendering something like this:

```
<script src="http://assets.yourapp.com/states" type="text/javascript"></script>
```

This of course won't work, as the request to `states` is meant to hit the `StatesController` to render the javascript dynamically.  Using `states_url` instead will override the assets host and cause the request to properly be routed to the controller and not the assets host.
