### PR TITLE
Fix product factory.

### DIFF
--- a/core/lib/spree/core/testing_support/factories/product_factory.rb
+++ b/core/lib/spree/core/testing_support/factories/product_factory.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
 
   factory :product, :class => Spree::Product do
     name { Factory.next :product_sequence }
-    description { Faker::Lorem.paragraphs(rand(5)+1).join("\n") }
+    description { Faker::Lorem.paragraphs(rand(5) || 1).join("\n") }
 
     # associations:
     tax_category { |r| Spree::TaxCategory.find(:first) || r.association(:tax_category) }
@@ -23,7 +23,7 @@ FactoryGirl.define do
   factory :custom_product, :class => Spree::Product do
     name "Custom Product"
     price "17.99"
-    description { Faker::Lorem.paragraphs(rand(5)+1).join("\n") }
+    description { Faker::Lorem.paragraphs(rand(5) || 1).join("\n") }
 
     # associations:
     tax_category { |r| Spree::TaxCategory.find(:first) || r.association(:tax_category) }

--- a/core/lib/spree/core/testing_support/factories/product_factory.rb
+++ b/core/lib/spree/core/testing_support/factories/product_factory.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
 
   factory :product, :class => Spree::Product do
     name { Factory.next :product_sequence }
-    description { Faker::Lorem.paragraphs(rand(5) || 1).join("\n") }
+    description { Faker::Lorem.paragraphs(1+Kernel.rand(5)).join("\n") }
 
     # associations:
     tax_category { |r| Spree::TaxCategory.find(:first) || r.association(:tax_category) }
@@ -23,7 +23,7 @@ FactoryGirl.define do
   factory :custom_product, :class => Spree::Product do
     name "Custom Product"
     price "17.99"
-    description { Faker::Lorem.paragraphs(rand(5) || 1).join("\n") }
+    description { Faker::Lorem.paragraphs(1+Kernel.rand(5)).join("\n") }
 
     # associations:
     tax_category { |r| Spree::TaxCategory.find(:first) || r.association(:tax_category) }


### PR DESCRIPTION
Not quite sure why but after the update to factory girl I started receiving in Ruby 1.9.3 issues with rand returning nil:

```
Failures:

  1) Spree::Admin::ProductsController creating a product should create product
     Failure/Error: post :create, :product => product_attributes
     NoMethodError:
       undefined method `+' for nil:NilClass
     # ./lib/spree/core/testing_support/factories/product_factory.rb:6:in `block (3 levels) in <top (required)>'
     # ./spec/controllers/spree/admin/products_controller_spec.rb:62:in `block (3 levels) in <top (required)>'

  2) Spree::Admin::ProductsController creating a product should create product from prototype
     Failure/Error: post :create, :product => product_attributes.merge(:prototype_id => prototype.id)
     NoMethodError:
       undefined method `+' for nil:NilClass
     # ./lib/spree/core/testing_support/factories/product_factory.rb:6:in `block (3 levels) in <top (required)>'
     # ./spec/controllers/spree/admin/products_controller_spec.rb:67:in `block (3 levels) in <top (required)>'

  3) Spree::Admin::ProductsController creating a product should create product from prototype with option values hash
     Failure/Error: post :create, :product => product_attributes.merge(:prototype_id => prototype.id, :option_values_hash => option_values_hash)
     NoMethodError:
       undefined method `+' for nil:NilClass
     # ./lib/spree/core/testing_support/factories/product_factory.rb:6:in `block (3 levels) in <top (required)>'
     # ./spec/controllers/spree/admin/products_controller_spec.rb:80:in `block (3 levels) in <top (required)>'

Finished in 636.29 seconds
829 examples, 3 failures, 35 pending
```
