### PR TITLE
Define source_required? method in PaymentMethod::Check

### DIFF
--- a/core/app/models/payment_method/check.rb
+++ b/core/app/models/payment_method/check.rb
@@ -24,4 +24,8 @@ class PaymentMethod::Check < PaymentMethod
     payment.void
     true
   end
+  
+  def source_required?
+    false
+  end
 end


### PR DESCRIPTION
Fix for issue #1221.
