### PR TITLE
Rename duplicate hook that breaks recently viewed products extension.

### DIFF
--- a/core/app/views/spree/products/show.html.erb
+++ b/core/app/views/spree/products/show.html.erb
@@ -27,7 +27,7 @@
 
         <h1 class="product-title" itemprop="name"><%= accurate_title %></h1>
 
-        <div itemprop="description" data-hook="product_description">
+        <div itemprop="description" data-hook="description">
           <%= product_description(@product) rescue t(:product_has_no_description) %>
         </div>
 
@@ -36,7 +36,7 @@
         </div>
 
       </div>
-    
+
       <%= render :partial => 'taxons' %>
 
     </div>


### PR DESCRIPTION
There is another data-hook already with the name product_description on div#product-description.  When this duplicate hook was added it caused recently viewed products extension to begin rendering it's override twice.
