### PR TITLE
Fix respond_with.

### DIFF
--- a/core/lib/spree/core/respond_with.rb
+++ b/core/lib/spree/core/respond_with.rb
@@ -4,20 +4,25 @@ module ActionController
       raise "In order to use respond_with, first you need to declare the formats your " <<
             "controller responds to in the class level" if self.class.mimes_for_respond_to.empty?
 
-      if response = retrieve_collector_from_mimes(&block)
+      if collector = retrieve_collector_from_mimes(&block)
         options = resources.size == 1 ? {} : resources.extract_options!
-        options.merge!(:default_response => response)
 
-        # following statement is not present in rails code. The action name is needed for processing
-        options.merge!(:action_name => action_name.to_sym)
-
-        # if responder is not specified then pass in Spree::Responder
-        (options.delete(:responder) || Spree::Responder).call(self, resources, options)
+        if defined_response = collector.response and Spree::BaseController.spree_responders.empty?
+          if action = options.delete(:action)
+            render :action => action
+          else
+            defined_response.call
+          end
+        else
+          # The action name is needed for processing
+          options.merge!(:action_name => action_name.to_sym)
+          # If responder is not specified then pass in Spree::Responder
+          (options.delete(:responder) || Spree::Responder).call(self, resources, options)
+        end
       end
     end
   end
 end
-
 
 module Spree
   module Core

--- a/core/lib/spree/core/responder.rb
+++ b/core/lib/spree/core/responder.rb
@@ -9,8 +9,7 @@ module Spree
       class_name = controller.class.name.to_sym
       action_name = options.delete(:action_name)
 
-      if result = Spree::BaseController.spree_responders[class_name].try(:[],action_name).try(:[], self.format.to_sym)
-
+      if result = Spree::BaseController.spree_responders[class_name].try(:[], action_name).try(:[], self.format.to_sym)
         self.on_success = handler(controller, result, :success)
         self.on_failure = handler(controller, result, :failure)
       end


### PR DESCRIPTION
Fixes most specs for Rails 3.2.2

Also wanted to discuss removing this respond_with override altogether.  I'm not familiar enough with the Spree codebase to know everywhere it's being used though.

What I propose is setting the Spree::Responder on the Spree::BaseController directly.  Or just on the necessary controllers.

I think that could simplify the Spree codebase some and help prevent Rails breaking Spree in future updates.  This is under my assumption that the current implementation was done awhile ago as a workaround before Rails implemented the ability to easily override the responder.  

It could possibly allow Spree 1.1 to be backwards compatible with Rails 3.1 still also.  I'm going to look into this a bit more, but wanted to get peoples thoughts on it.
