### PR TITLE
#1066 fix cart empty after logout and login again

### DIFF
--- a/auth/spec/controllers/user_sessions_controller_spec.rb
+++ b/auth/spec/controllers/user_sessions_controller_spec.rb
@@ -7,23 +7,49 @@ describe Spree::UserSessionsController do
 
   context '#create' do
     context 'when current_order is associated with a guest user' do
+      let(:guest_user) { mock Spree::User }
       let(:user) { mock Spree::User }
-      let(:order) { mock_model Spree::Order }
+      let(:order) { mock_model Spree::Order, :user => guest_user}
 
       before do
         controller.stub :current_user => user
         controller.stub :current_order => order
       end
 
-      it 'should associate the order with the newly authenticated user' do
-        order.should_receive(:associate_user!).with(user)
-        post :create, {}, { :order_id => 1 }
+      context "when current_user has incompleted order" do
+        let(:user_order) { mock_model Spree::Order, :user => user}
+
+        before do
+          user.stub(:orders).with(:order => "updated_at").and_return([user_order])
+        end
+
+        it 'should merge the order' do
+          user_order.should_receive(:merge!).with(order)
+          post :create
+        end
+
+        it 'should destroy the session token for guest_user' do
+          user_order.stub(:merge!)
+          post :create, {}, { :order_id => 1, :guest_token => 'foo' }
+          session[:guest_token].should be_nil
+        end
       end
 
-      it 'should destroy the session token for guest_user' do
-        order.stub(:associate_user!)
-        post :create, {}, { :order_id => 1, :guest_token => 'foo' }
-        session[:guest_token].should be_nil
+      context "when current_user has no incompleted order" do
+        before do
+          user.stub(:orders).with(:order => "updated_at").and_return([])
+        end
+
+        it 'should associate the order with the newly authenticated user' do
+          order.should_receive(:associate_user!).with(user)
+          post :create, {}, { :order_id => 1 }
+        end
+
+        it 'should destroy the session token for guest_user' do
+          order.stub(:associate_user!)
+          post :create, {}, { :order_id => 1, :guest_token => 'foo' }
+          session[:guest_token].should be_nil
+        end
       end
     end
   end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -429,6 +429,13 @@ module Spree
       line_items.select &:insufficient_stock?
     end
 
+    # Copies the +line_items+ from passed order
+    def merge!(order)
+      order.line_items.each do |li|
+        self.add_variant(li.variant, li.quantity)
+      end
+    end
+
     private
       def create_user
         self.email = user.email if self.user and not user.anonymous?

--- a/core/lib/spree/core/controller_helpers.rb
+++ b/core/lib/spree/core/controller_helpers.rb
@@ -92,7 +92,7 @@ module Spree
         def associate_user
           return unless current_user and current_order and not current_user == current_order.user
           # get the last incompleted order
-          order = current_user.orders(:order => "updated_at").select { |item| item.completed_at.nil? }.last
+          order = current_user.orders.where("completed_at IS NULL").order("updated_at").last
           if order
             order.merge!(current_order)
             session[:order_id] = order.id

--- a/core/lib/spree/core/current_order.rb
+++ b/core/lib/spree/core/current_order.rb
@@ -19,7 +19,7 @@ module Spree
           @current_order = Spree::Order.find_by_id(session[:order_id], :include => :adjustments)
         elsif current_user
           # get the last incompleted order
-          @current_order = current_user.orders(:order => "updated_at").select { |item| item.completed_at.nil? }.last
+          @current_order = current_user.orders.where("completed_at IS NULL").order("updated_at").last
         end
         if create_order_if_necessary and (@current_order.nil? or @current_order.completed?)
           @current_order = Spree::Order.new

--- a/core/lib/spree/core/current_order.rb
+++ b/core/lib/spree/core/current_order.rb
@@ -17,6 +17,9 @@ module Spree
         return @current_order if @current_order
         if session[:order_id]
           @current_order = Spree::Order.find_by_id(session[:order_id], :include => :adjustments)
+        elsif current_user
+          # get the last incompleted order
+          @current_order = current_user.orders(:order => "updated_at").select { |item| item.completed_at.nil? }.last
         end
         if create_order_if_necessary and (@current_order.nil? or @current_order.completed?)
           @current_order = Spree::Order.new

--- a/core/spec/models/order_spec.rb
+++ b/core/spec/models/order_spec.rb
@@ -516,12 +516,12 @@ describe Spree::Order do
 
   end
 
-  context "#update_payment_state" do    
+  context "#update_payment_state" do
     it "should set payment_state to balance_due if no line_item" do
       order.stub(:line_items => [])
       order.update!
       order.payment_state.should == "balance_due"
-    end    
+    end
   end
 
   context "#payment_method" do

--- a/core/spec/models/order_spec.rb
+++ b/core/spec/models/order_spec.rb
@@ -631,6 +631,22 @@ describe Spree::Order do
     it "should change shipment status (unless shipped)"
   end
 
+  context "#merge!" do
+    let(:guest_user) { stub_model(Spree::User, :email => "guest@example.com") }
+    let!(:variant) { stub_model(Spree::Variant, :on_hand => 3) }
+    let!(:variant1) { stub_model(Spree::Variant, :on_hand => 3) }
+    let(:session_order) { stub_model(Spree::Order, :user => guest_user) }
+
+    before(:each) do
+      order.stub :line_items => [stub_model(Spree::LineItem, :variant => variant, :quantity => 1)]
+      session_order.stub :line_items => [stub_model(Spree::LineItem, :variant => variant1, :quantity => 1)]
+    end
+
+    it "should merge line_items" do
+      order.merge!(session_order)
+      order.line_items.length.should == 2
+    end
+  end
 
   # Another regression test for #729
   context "#resume" do


### PR DESCRIPTION
Cart goes empty when user logout and login again. This fix resolve this issue. 

It does by copying line_items to logged in user's last incomplete order from session order. Because when user log in we should concern with line_items in session order as other details (addresses, shipping method etc) will be chosen by user during checkout. This will also not override user defaults if any (like saved addresses). 

It basically populate the line_items by calling add_variant method. And when user do checkout adjustments will be calculated as done for normal checkout flow. Another advantage of this is that for logged in order there will be only one incomplete order in database. unless he completes the order he will be working with incomplete order only. 

When there is no incomplete order than session order will be associated with current_user (which is current situation for all scenario).
