### PR TITLE
Fix promotion.products method.

### DIFF
--- a/promo/app/models/spree/promotion.rb
+++ b/promo/app/models/spree/promotion.rb
@@ -78,7 +78,7 @@ module Spree
 
     # Products assigned to all product rules
     def products
-      @products ||= rules.of_type('Promotion::Rules::Product').map(&:products).flatten.uniq
+      @products ||= rules.of_type('Spree::Promotion::Rules::Product').map(&:products).flatten.uniq
     end
 
     def usage_limit_exceeded?(order = nil)

--- a/promo/spec/models/promotion_spec.rb
+++ b/promo/spec/models/promotion_spec.rb
@@ -173,6 +173,23 @@ describe Spree::Promotion do
     end
   end
 
+  context "#products" do
+    context "when it has product rules with products associated" do
+      let(:p) { Factory.create(:promotion) }
+
+      before do
+        pr = Spree::Promotion::Rules::Product.new
+        pr.promotion = p
+        pr.products << Factory.create(:product)
+        pr.save
+      end
+
+      it "should have products" do
+        p.products.size.should eq 1
+      end
+    end
+  end
+
   context "#eligible?" do
     before do
       @order = Factory(:order)

--- a/promo/spec/spec_helper.rb
+++ b/promo/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require File.expand_path("../dummy/config/environment", __FILE__)
 require 'rspec/rails'
 require 'database_cleaner'
 require 'spree/url_helpers'
+require 'ffaker'
 
 # Requires supporting files with custom matchers and macros, etc,
 # in ./support/ and its subdirectories.


### PR DESCRIPTION
products was incorrectly specifying the class for PromotionRule leaving off Spree namespace. 
