### PR TITLE
added redirect for admin/products#show

### DIFF
--- a/core/app/controllers/spree/admin/products_controller.rb
+++ b/core/app/controllers/spree/admin/products_controller.rb
@@ -8,6 +8,10 @@ module Spree
       create.before :create_before
       update.before :update_before
 
+      def show
+        redirect_to( :action => :edit )
+      end
+
       def index
         respond_with(@collection) do |format|
           format.html

--- a/core/app/views/spree/admin/products/show.html.erb
+++ b/core/app/views/spree/admin/products/show.html.erb
@@ -1,4 +1,0 @@
-<%= render :partial => 'shared/product_sub_menu' %>
-TODO - show product details here <br /><br />
-
-<%= render :partial => 'shared/show_resource_links' %>


### PR DESCRIPTION
I don't think admin/products#show is linked to from anywhere, but it is handy to look up the admin URL from the store by just adding /admin at the beginning.

The show template was broken so I removed it and replaced it with a redirect to the edit action.
