### PR TITLE
Fix specs

### DIFF
--- a/auth/app/overrides/auth_user_login_form.rb
+++ b/auth/app/overrides/auth_user_login_form.rb
@@ -1,5 +1,0 @@
-Deface::Override.new(:virtual_path => "spree/checkout/registration",
-                     :name => "auth_user_login_form",
-                     :replace_contents => "[data-hook='registration'] #account, #registration[data-hook] #account",
-                     :template => "spree/user_sessions/new",
-                     :disabled => false)

--- a/auth/app/views/spree/checkout/registration.html.erb
+++ b/auth/app/views/spree/checkout/registration.html.erb
@@ -1,14 +1,14 @@
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @user } %>
 <h2><%= t(:registration) %></h2>
-<div id="registration" data-hook class="columns alpha eight">
-  <div id="account">
-    <!-- TODO: add partial with registration form -->
+<div id="registration">
+  <div id="account" class="columns alpha eight">
+    <%= render :file => 'spree/user_sessions/new' %>
   </div>
   <% if Spree::Config[:allow_guest_checkout] %>
-    <div id="guest_checkout" data-hook class="columns omega eight">
+    <div id="guest_checkout" class="columns omega eight">
       <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @order } %>
-      <h2><%= t(:guest_user_account) %></h2>
-      <%= form_for @order, :url => update_checkout_registration_path, :method => :put, :html => { :id => 'checkout_form_registration' } do |f| %>
+      <h6><%= t(:guest_user_account) %></h6>
+      <%= form_for @order, :url => spree.update_checkout_registration_path, :method => :put, :html => { :id => 'checkout_form_registration' } do |f| %>
         <p>
           <%= f.label :email, t(:email) %><br />
           <%= f.email_field :email, :class => 'title' %>

--- a/auth/spec/requests/checkout_spec.rb
+++ b/auth/spec/requests/checkout_spec.rb
@@ -10,6 +10,7 @@ describe "Checkout", :js => true do
 
     Factory(:payment_method, :environment => 'test')
     Factory(:product, :name => "RoR Mug")
+    visit spree.login_path
     visit spree.root_path
   end
 


### PR DESCRIPTION
For some reason when deface tries to get the source of:

:template => "spree/user_sessions/new"

it returns nil.

I've tried digging into this more, but I can't figure out why calling source in Deface on the filepath returns nil.  It is properly locating the template path, and all html/erb appears to be well formed.
