### PR TITLE
Use last used order address

### DIFF
--- a/core/app/controllers/spree/checkout_controller.rb
+++ b/core/app/controllers/spree/checkout_controller.rb
@@ -74,9 +74,9 @@ module Spree
       end
 
       def before_address
-        past = Spree::Order.order("id desc").where(:user_id => @order.user.id).complete.limit(1)
-        if order = past.detect(&:bill_address)
-          @order.bill_address = order.bill_address.clone if order.bill_address
+        past_order = @order.user.orders.complete.order("id desc").first
+        if past_order
+          @order.bill_address = past_order.bill_address.clone if past_order.bill_address
         end
         @order.bill_address ||= current_user.bill_address if current_user
         @order.bill_address ||= Address.default

--- a/core/app/controllers/spree/checkout_controller.rb
+++ b/core/app/controllers/spree/checkout_controller.rb
@@ -74,6 +74,11 @@ module Spree
       end
 
       def before_address
+        past = Spree::Order.order("id desc").where(:user_id => @order.user.id).complete.limit(1)
+        if order = past.detect(&:bill_address)
+          @order.bill_address = order.bill_address.clone if order.bill_address
+        end
+        @order.bill_address ||= current_user.bill_address if current_user
         @order.bill_address ||= Address.default
         @order.ship_address ||= Address.default
       end

--- a/core/lib/spree/core/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/core/testing_support/factories/order_factory.rb
@@ -20,7 +20,7 @@ FactoryGirl.define do
     end
   end
   
-  factory :order_complete, :parent => :order_with_totals do
+  factory :complete_order, :parent => :order_with_totals do
     state "confirm"
     association(:bill_address, :factory => :address)
     association(:ship_address, :factory => :address)

--- a/core/lib/spree/core/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/core/testing_support/factories/order_factory.rb
@@ -19,4 +19,15 @@ FactoryGirl.define do
       Factory(:inventory_unit, :order => order, :state => 'shipped')
     end
   end
+  
+  factory :order_complete, :parent => :order_with_totals do
+    state "confirm"
+    association(:bill_address, :factory => :address)
+    association(:ship_address, :factory => :address)
+    association(:shipping_method, :factory => :shipping_method)
+    after_create do |order|
+      order.next!
+    end
+  end
+  
 end

--- a/core/spec/controllers/spree/checkout_controller_spec.rb
+++ b/core/spec/controllers/spree/checkout_controller_spec.rb
@@ -2,13 +2,7 @@ require 'spec_helper'
 
 describe Spree::CheckoutController do
   let(:order) { mock_model(Spree::Order, :checkout_allowed? => true, :completed? => false, :update_attributes => true, :payment? => false, :insufficient_stock_lines => [], :coupon_code => nil).as_null_object }
-  before { controller.stub :current_order => order, :current_user => Factory(:user) }
-
-  it "should understand checkout routes" do
-    pending("assert_routing tests are now broken, is this relevant any more?")
-    assert_routing("/checkout/delivery", {:controller => "spree/checkout", :action => "edit", :state => "delivery"})
-    assert_routing("/checkout/update/delivery", {:controller => "spree/checkout", :action => "update", :state => "delivery"})
-  end
+  before { controller.stub :current_order => order }
 
   context "#edit" do
 

--- a/core/spec/controllers/spree/checkout_controller_spec.rb
+++ b/core/spec/controllers/spree/checkout_controller_spec.rb
@@ -2,7 +2,13 @@ require 'spec_helper'
 
 describe Spree::CheckoutController do
   let(:order) { mock_model(Spree::Order, :checkout_allowed? => true, :completed? => false, :update_attributes => true, :payment? => false, :insufficient_stock_lines => [], :coupon_code => nil).as_null_object }
-  before { controller.stub :current_order => order }
+  before { controller.stub :current_order => order, :current_user => Factory(:user) }
+
+  it "should understand checkout routes" do
+    pending("assert_routing tests are now broken, is this relevant any more?")
+    assert_routing("/checkout/delivery", {:controller => "spree/checkout", :action => "edit", :state => "delivery"})
+    assert_routing("/checkout/update/delivery", {:controller => "spree/checkout", :action => "update", :state => "delivery"})
+  end
 
   context "#edit" do
 

--- a/core/spec/requests/checkout_spec.rb
+++ b/core/spec/requests/checkout_spec.rb
@@ -55,7 +55,7 @@ describe "Checkout" do
   
   context "visitor makes checkout as logged in user" do
     before(:each) do
-      @last_order = Factory(:order_complete)
+      @last_order = Factory(:complete_order)
       Factory(:product, :name => "RoR Mug")
     end
     

--- a/core/spec/requests/checkout_spec.rb
+++ b/core/spec/requests/checkout_spec.rb
@@ -31,8 +31,6 @@ describe "Checkout" do
     end
     
     it "should not autofill the billing address" do
-
-      Spree::Product.delete_all
       product = Factory(:product, :name => "RoR Mug")
       visit spree.root_path
       click_link "RoR Mug"
@@ -57,7 +55,6 @@ describe "Checkout" do
   
   context "visitor makes checkout as logged in user" do
     before(:each) do
-      Spree::Product.delete_all
       @last_order = Factory(:order_complete)
       Factory(:product, :name => "RoR Mug")
     end

--- a/core/spec/requests/checkout_spec.rb
+++ b/core/spec/requests/checkout_spec.rb
@@ -29,4 +29,29 @@ describe "Checkout" do
       end
     end
   end
+  
+  context "visitor makes checkout again" do
+    it "should auto fill the billing address with the previous used one" do
+      Spree::Product.delete_all
+      last_order = Factory(:order_complete)
+      Factory(:product, :name => "RoR Mug")
+      
+      sign_in_as!(last_order.user)
+      visit spree.root_path
+      click_link "RoR Mug"
+      click_button "add-to-cart-button"
+      click_link "Checkout"
+      
+      find_field("order_bill_address_attributes_firstname").value.should == last_order.bill_address.firstname
+      find_field("order_bill_address_attributes_lastname").value.should == last_order.bill_address.lastname
+      find_field("order_bill_address_attributes_address1").value.should == last_order.bill_address.address1
+      find_field("order_bill_address_attributes_address2").value.should == last_order.bill_address.address2
+      find_field("order_bill_address_attributes_city").value.should == last_order.bill_address.city
+      find_field("order_bill_address_attributes_zipcode").value.should == last_order.bill_address.zipcode
+      find_field("order_bill_address_attributes_country_id").find('option[selected]').text.should == last_order.bill_address.country.name
+      find_field("order_bill_address_attributes_phone").value.should == last_order.bill_address.phone
+      
+    end
+  end
+
 end

--- a/core/spec/requests/checkout_spec.rb
+++ b/core/spec/requests/checkout_spec.rb
@@ -55,28 +55,49 @@ describe "Checkout" do
     
   end
   
-  context "visitor makes checkout again" do
-    it "should auto fill the billing address with the previous used one" do
+  context "visitor makes checkout as logged in user" do
+    before(:each) do
       Spree::Product.delete_all
-      last_order = Factory(:order_complete)
+      @last_order = Factory(:order_complete)
       Factory(:product, :name => "RoR Mug")
-      
-      sign_in_as!(last_order.user)
+    end
+    
+    it "should auto fill the billing address with the previous used one" do
+      sign_in_as!(@last_order.user)
       visit spree.root_path
       click_link "RoR Mug"
       click_button "add-to-cart-button"
       click_link "Checkout"
       
-      find_field("order_bill_address_attributes_firstname").value.should == last_order.bill_address.firstname
-      find_field("order_bill_address_attributes_lastname").value.should == last_order.bill_address.lastname
-      find_field("order_bill_address_attributes_address1").value.should == last_order.bill_address.address1
-      find_field("order_bill_address_attributes_address2").value.should == last_order.bill_address.address2
-      find_field("order_bill_address_attributes_city").value.should == last_order.bill_address.city
-      find_field("order_bill_address_attributes_zipcode").value.should == last_order.bill_address.zipcode
-      find_field("order_bill_address_attributes_country_id").find('option[selected]').text.should == last_order.bill_address.country.name
-      find_field("order_bill_address_attributes_phone").value.should == last_order.bill_address.phone
+      find_field("order_bill_address_attributes_firstname").value.should == @last_order.bill_address.firstname
+      find_field("order_bill_address_attributes_lastname").value.should == @last_order.bill_address.lastname
+      find_field("order_bill_address_attributes_address1").value.should == @last_order.bill_address.address1
+      find_field("order_bill_address_attributes_address2").value.should == @last_order.bill_address.address2
+      find_field("order_bill_address_attributes_city").value.should == @last_order.bill_address.city
+      find_field("order_bill_address_attributes_zipcode").value.should == @last_order.bill_address.zipcode
+      find_field("order_bill_address_attributes_country_id").find('option[selected]').text.should == @last_order.bill_address.country.name
+      find_field("order_bill_address_attributes_phone").value.should == @last_order.bill_address.phone
       
     end
+    
+    it "should not auto fill the billing address when there is no previous order" do
+      sign_in_as!(Factory(:user))
+      visit spree.root_path
+      click_link "RoR Mug"
+      click_button "add-to-cart-button"
+      click_link "Checkout"
+      
+      find_field("order_bill_address_attributes_firstname").value.should be_nil
+      find_field("order_bill_address_attributes_lastname").value.should be_nil
+      find_field("order_bill_address_attributes_address1").value.should be_nil
+      find_field("order_bill_address_attributes_address2").value.should be_nil
+      find_field("order_bill_address_attributes_city").value.should be_nil
+      find_field("order_bill_address_attributes_zipcode").value.should be_nil
+      find_field("order_bill_address_attributes_country_id").find('option[selected]').text.should == Spree::Address.default.country.name
+      find_field("order_bill_address_attributes_phone").value.should be_nil
+      
+    end
+    
   end
 
 end

--- a/core/spec/requests/checkout_spec.rb
+++ b/core/spec/requests/checkout_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe "Checkout" do
   context "visitor makes checkout as guest without registration" do
+    
     context "when backordering is disabled" do
       before(:each) do
         reset_spree_preferences do |config|
@@ -28,6 +29,30 @@ describe "Checkout" do
         within(:css, "span.out-of-stock") { page.should have_content("Out of Stock") }
       end
     end
+    
+    it "should not autofill the billing address" do
+
+      Spree::Product.delete_all
+      product = Factory(:product, :name => "RoR Mug")
+      visit spree.root_path
+      click_link "RoR Mug"
+      click_button "add-to-cart-button"
+      click_link "Checkout"
+      
+      fill_in "order_email",  :with => "john.doe@example.com"
+      click_button "Continue"
+      
+      find_field("order_bill_address_attributes_firstname").value.should be_nil
+      find_field("order_bill_address_attributes_lastname").value.should be_nil
+      find_field("order_bill_address_attributes_address1").value.should be_nil
+      find_field("order_bill_address_attributes_address2").value.should be_nil
+      find_field("order_bill_address_attributes_city").value.should be_nil
+      find_field("order_bill_address_attributes_zipcode").value.should be_nil
+      find_field("order_bill_address_attributes_country_id").find('option[selected]').text.should == Spree::Address.default.country.name
+      find_field("order_bill_address_attributes_phone").value.should be_nil
+    
+    end
+    
   end
   
   context "visitor makes checkout again" do


### PR DESCRIPTION
Added functionality that autofills the billing address with the last billing address used if present. 
