### PR TITLE
Promo rule error on selecting products instead of product_group

### DIFF
--- a/promo/app/views/spree/admin/promotions/rules/_product.html.erb
+++ b/promo/app/views/spree/admin/promotions/rules/_product.html.erb
@@ -5,6 +5,6 @@
 </p>
 <p>
   <label>
-    <%= t('product_rule.label', :select => select_tag("#{param_prefix}[preferred_match_policy]", options_for_select(Spree::Promotion::Rules::Product::MATCH_POLICIES.map{|s| [t("product_rule.match_#{s}"),s] }, promotion_rule.preferred_match_policy))).html_safe %>
+      <%= t('product_rule.label', :select => select_tag("#{param_prefix}[preferred_match_policy]", options_for_select(Spree::Promotion::Rules::Product::MATCH_POLICIES.map{|s| [t("product_rule.match_#{s}"),s] }, promotion_rule.preferred_match_policy)), :include_blank => true).html_safe %>
   </label>
 </p>


### PR DESCRIPTION
This error is valid on 0.70.X and master but master its a little easy to get. 

**0.7.X**

   When creating a products rule and just selecting the manual choose of products will go fine, but if for any chance click on the product_group (just clicking and after go back to manual choose), it will save the group and the manual choose.

  That will make next load of the Promotion it will show product_group instead of manual choose

**Master**
  Just creating a Promotion with the Product rule type will put a product_group id

**Why?**

The problem cames mainly because there's not `:include_blank`  on the selection so when it loads always auto selects the first option.

In the model are a function to clean `product_group_id` which is 

```
  def products_source=(source)
    if source.to_s == 'manual'
      self.product_group_id = nil
    end
  end
```

But at least in my case my data came in this way

```
"promotion"=>{
     "preferred_match_policy"=>"any", 
     "promotion_rules_attributes"=>{ 
             "26"=>{ "id"=>"26", 
                         "products_source"=>"manual", 
                         "product_group_id"=>"1",
                         "product_ids_string"=>"14,441,460", 
                         "preferred_match_policy"=>"any" 
                       }
     }
}
```

So its executing `products_source` before the assignment of product_group_id

I send the same patch on the 0.70.X in the #1249
