### PR TITLE
Set overflow to hidden for long product titles.

### DIFF
--- a/core/app/assets/stylesheets/store/screen.css.scss
+++ b/core/app/assets/stylesheets/store/screen.css.scss
@@ -513,6 +513,7 @@ mark {background-color: $link_text_color; color: $layout_background_color; font-
           font-size: $product_list_name_font_size;
           color: $product_link_text_color;
           border-bottom: 1px solid lighten($body_text_color, 60);
+          overflow: hidden;
         }
       }
 


### PR DESCRIPTION
Even though we are truncating the titles now depending on how long certain words are the word wrap can still cause the titles to flow into 3 lines behind the price.  The current truncation length is good for a majority of titles, but some edge cases need to be hidden.
