### PR TITLE
Use css as spacing between qty and add to cart button.

### DIFF
--- a/core/app/assets/stylesheets/store/screen.css.scss
+++ b/core/app/assets/stylesheets/store/screen.css.scss
@@ -462,6 +462,7 @@ mark {background-color: $link_text_color; color: $layout_background_color; font-
     margin-top: 15px;
 
     input[type="number"] {
+      margin-right: 3px;
       width: 60px;
       vertical-align: middle;
       padding: 5px;

--- a/core/app/views/spree/products/_cart_form.html.erb
+++ b/core/app/views/spree/products/_cart_form.html.erb
@@ -38,7 +38,6 @@
           <% if @product.has_stock? || Spree::Config[:allow_backorders] %>      
             <%= number_field_tag (@product.has_variants? ? :quantity : "variants[#{@product.master.id}]"),
               1, :class => 'title', :in => 1..@product.on_hand %>
-            &nbsp;
             <%= button_tag :class => 'large primary', :id => 'add-to-cart-button' do %>
               <%= t(:add_to_cart) %>
             <% end %>


### PR DESCRIPTION
Should use css rather than html space for easier theme styling and deface overrides.
