### PR TITLE
Hide preview buttons when Spree::Dash::Config.configured?

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -386,6 +386,7 @@ en:
   enter_exactly_as_shown_on_card: Please enter exactly as shown on the card
   enter_at_least_five_letters: Enter at least five letters of customer name
   enter_password_to_confirm: "(we need your current password to confirm your changes)"
+  enter_token: Enter Token
   environment: "Environment"
   error: error
   errors:
@@ -483,6 +484,7 @@ en:
   item_total: "Item Total"
   last_name: "Last Name"
   last_name_begins_with: "Last Name Begins With"
+  learn_more: Learn More
   leave_blank_to_not_change: "(leave blank if you don't want to change it)"
   list: List
   listing_categories: "Listing Categories"

--- a/dash/app/views/spree/admin/overview/index.html.erb
+++ b/dash/app/views/spree/admin/overview/index.html.erb
@@ -30,14 +30,13 @@
     <div class="analytics_splash">
       <%= image_tag 'analytics_dashboard_preview.png', :alt => 'Spree Analytics' %>
     </div>
+    <br>
+    <div class="preview-buttons">
+      <%= link_to content_tag(:span, t(:enter_token)), admin_path(:dash_edit => true), :class => "button green" %>
+      <%= t(:or) %> &nbsp;
+      <%= link_to content_tag(:span, t(:learn_more)), "http://spreecommerce.com/blog/2012/01/31/introducing-spree-analytics/", :class => "button", :target => "_blank" %>
+    </div>
+    
   <% end %>
-  <br>
-  <div class="preview-buttons">
-    <%= link_to t(:enter_token), admin_path(:dash_edit => true), :class => "button green" %>
-    <%= t(:or) %> &nbsp;
-    <%= link_to t(:learn_more), "http://spreecommerce.com/blog/2012/01/31/introducing-spree-analytics/", :class => "button", :target => "_blank" %>
-  </div>
-  
+
 <% end %>
-
-


### PR DESCRIPTION
Fix for when the dash preferences are entered.  It should not show the buttons that overlay the preview image.  Also added the missing translations.
