### PR TITLE
spree_extension_installed? for #1241

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -1,5 +1,9 @@
 module Spree
   module BaseHelper
+    def spree_extension_installed?(ext)
+      Rails.application.railties.all.map(&:railtie_name).include? ext  
+    end
+    
     def link_to_cart(text = nil)
       return "" if current_page?(cart_path)
 


### PR DESCRIPTION
This seems like the most simple (albeit not the most efficient) solution.

Caching the name array would speed up subsequent hits on the helper, what would be the best place in the Spree architecture to throw the cached name array?
