### PR TITLE
Class and tag update for sidebar filter title

### DIFF
--- a/core/app/views/spree/shared/_filters.html.erb
+++ b/core/app/views/spree/shared/_filters.html.erb
@@ -7,7 +7,7 @@
       <% labels = filter[:labels] || filter[:conds].map {|m,c| [m,m]} %>
       <% next if labels.empty? %>
       <div class="navigation" data-hook="navigation">
-        <span class="category"> <%= filter[:name] %> </span>
+        <h6 class="filter-title"> <%= filter[:name] %> </h6>
         <ul class="filter_choices">
           <% labels.each do |nm,val| %>
             <% label = "#{filter[:name]}_#{nm}".gsub(/\s+/,'_') %>


### PR DESCRIPTION
Looks like spree is using h6 as the standard header tag for taxonomies and different sidebar titles. Switching from span.category makes styling a bit easier.
