### PR TITLE
Adding classes to cart td and th for easier css styling

### DIFF
--- a/core/app/views/spree/orders/_form.html.erb
+++ b/core/app/views/spree/orders/_form.html.erb
@@ -2,11 +2,11 @@
 <table id="cart-detail" data-hook>
   <thead>
     <tr data-hook="cart_items_headers">
-      <th colspan="2"><%= t(:item) %></th>
-      <th><%= t(:price) %></th>
-      <th><%= t(:qty) %></th>
-      <th><%= t(:total) %></th>
-      <th></th>
+      <th class="cart-item-description-header" colspan="2"><%= t(:item) %></th>
+      <th class="cart-item-price-header"><%= t(:price) %></th>
+      <th class="cart-item-quantity-header"><%= t(:qty) %></th>
+      <th class="cart-item-total-header"><%= t(:total) %></th>
+      <th class="cart-item-delete-header"></th>
     </tr>
   </thead>
   <tbody id="line_items" data-hook>

--- a/core/app/views/spree/orders/_line_item.html.erb
+++ b/core/app/views/spree/orders/_line_item.html.erb
@@ -1,12 +1,12 @@
 <tr class="<%= cycle('', 'alt') %> line-item">
-  <td data-hook="cart_item_image">
+  <td class="cart-item-image" data-hook="cart_item_image">
     <% if variant.images.length == 0 %>
       <%= link_to small_image(variant.product), variant.product %>
     <% else %>
       <%= link_to image_tag(variant.images.first.attachment.url(:small)), variant.product %>
     <% end %>
   </td>
-  <td data-hook="cart_item_description">
+  <td class="cart-item-description" data-hook="cart_item_description">
     <h4><%= link_to variant.product.name, product_path(variant.product) %></h4>
     <%= variant.options_text %>
     <% if @order.insufficient_stock_lines.include? line_item %>
@@ -16,16 +16,16 @@
     <% end %>
     <%= truncate(variant.product.description, :length => 100, :omission => "...") %>
   </td>
-  <td data-hook="cart_item_price">
+  <td class="cart-item-price" data-hook="cart_item_price">
     <%= number_to_currency line_item.price %>
   </td>
-  <td data-hook="cart_item_quantity">
+  <td class="cart-item-quantity" data-hook="cart_item_quantity">
     <%= item_form.number_field :quantity, :min => 0, :class => "line_item_quantity", :size => 5 %>
   </td>
-  <td data-hook="cart_item_total">
+  <td class="cart-item-total" data-hook="cart_item_total">
     <%= number_to_currency(line_item.price * line_item.quantity) unless line_item.quantity.nil? %>
   </td>
-  <td data-hook="cart_item_delete">
+  <td class="cart-item-delete" data-hook="cart_item_delete">
     <%= link_to image_tag('icons/delete.png'), '#', :class => 'delete', :id => "delete_#{dom_id(line_item)}" %>
   </td>
 </tr>


### PR DESCRIPTION
Styling using `td[data-hook="..."]` is going to break older browsers. Aside from polyfills, this is the best cross-browser solution that I'm aware of. Thoughts?
