### PR TITLE
Fix error in promotion processing [Fixes 1282]

### DIFF
--- a/promo/lib/spree_promo.rb
+++ b/promo/lib/spree_promo.rb
@@ -89,7 +89,7 @@ module SpreePromo
           new_promotions = eligible_automatic_promotions - current_promotions
           new_promotions.each do |promotion|
             next if current_promotions.present? && !promotion.combine?
-            amount = credit.source.compute(self)
+            amount = promotion.compute(self)
             if amount > 0
               self.promotion_credits.create(
                   :source => promotion,


### PR DESCRIPTION
Issue https://github.com/spree/spree/issues/1282

When call OrdersController#populate got:
undefined local variable or methodcredit' for #Order:0x007fcfaa69b820`
