### PR TITLE
Permalink creation failure for similar names - 1254

### DIFF
--- a/core/lib/spree/core/permalinks.rb
+++ b/core/lib/spree/core/permalinks.rb
@@ -40,7 +40,7 @@ module Spree
         field = self.class.permalink_field
         # Do other links exist with this permalink?
         other = self.class.first(
-          :conditions => "#{field} LIKE '#{permalink_value}%'",
+          :conditions => "#{field} LIKE '#{permalink_value}%' AND #{field} NOT LIKE '#{permalink_value}-%-%'",
           :order => "LENGTH(#{field}) DESC, #{field} DESC"
         )
         if other

--- a/core/spec/models/product_spec.rb
+++ b/core/spec/models/product_spec.rb
@@ -91,6 +91,21 @@ describe Spree::Product do
         end
       end
 
+      context "permalink should be incremented until the value is not taken for similar names" do
+        before do
+          @other_product = Factory(:product, :name => 'foo bar')
+          @product1 = Factory(:product, :name => 'foo')
+          @product2 = Factory(:product, :name => 'foo')
+          @product3 = Factory(:product, :name => 'foo')
+          end
+        end
+        it "should have valid permalink" do
+          @product1.permalink.should == 'foo'
+          @product2.permalink.should == 'foo-1'
+          @product3.permalink.should == 'foo-2'
+        end
+      end
+
       context "make_permalink should declare validates_uniqueness_of" do
         before do
           @product1 = Factory(:product, :name => 'foo')


### PR DESCRIPTION
Solution for this Issue https://github.com/spree/spree/issues/1254

Just need to add a condition on the filter :

```
    # Do other links exist with this permalink?
    other = self.class.first(
      :conditions => "#{field} LIKE '#{permalink_value}%' AND #{field} NOT LIKE '#{permalink_value}-%-%'",
      :order => "LENGTH(#{field}) DESC, #{field} DESC"
    )
```

Have a nice day
