### PR TITLE
Ensure that spree/states#index returns javascript response

### DIFF
--- a/core/app/controllers/spree/states_controller.rb
+++ b/core/app/controllers/spree/states_controller.rb
@@ -2,6 +2,8 @@ module Spree
   class StatesController < BaseController
     ssl_allowed :index
 
+    respond_to :js
+
     def index
       # table of {country.id => [ state.id , state.name ]}, arrays sorted by name
       # blank is added elsewhere, if needed
@@ -11,6 +13,8 @@ module Spree
       Spree::State.order('name ASC').each { |state|
         @state_info[state.country_id.to_s].push [state.id, state.name]
       }
+
+      respond_with(@state_info)
     end
   end
 end


### PR DESCRIPTION
Updated the controller to always return the states#index as javascript.

I can't reproduce this error myself, but I've seen a few errors in Airbrake about it.  Looks like it happens in IE9.  
