### PR TITLE
Require SSL for user account page and updating passwords.

### DIFF
--- a/auth/app/controllers/spree/user_passwords_controller.rb
+++ b/auth/app/controllers/spree/user_passwords_controller.rb
@@ -1,4 +1,5 @@
 class Spree::UserPasswordsController < Devise::PasswordsController
+  ssl_required
   include Spree::Core::ControllerHelpers
   helper 'spree/users', 'spree/base'
 

--- a/auth/app/controllers/spree/users_controller.rb
+++ b/auth/app/controllers/spree/users_controller.rb
@@ -1,4 +1,5 @@
 class Spree::UsersController < Spree::BaseController
+  ssl_required
   prepend_before_filter :load_object, :only => [:show, :edit, :update]
   prepend_before_filter :authorize_actions, :only => :new
 


### PR DESCRIPTION
SSL Should be used for the account and password update pages otherwise the users personal information isn't being encrypted.
