### PR TITLE
Restrict factory_girl to 2.x for Ruby 1.8 support in extension generator.

### DIFF
--- a/cmd/lib/spree_cmd/templates/extension/extension.gemspec
+++ b/cmd/lib/spree_cmd/templates/extension/extension.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_core', '~> <%= spree_version %>'
 
   s.add_development_dependency 'capybara', '1.0.1'
-  s.add_development_dependency 'factory_girl'
+  s.add_development_dependency 'factory_girl', '~> 2.6.4'
   s.add_development_dependency 'ffaker'
-  s.add_development_dependency 'rspec-rails',  '~> 2.8'
+  s.add_development_dependency 'rspec-rails',  '~> 2.9'
   s.add_development_dependency 'sqlite3'
 end


### PR DESCRIPTION
Also bumped rspec-rails to latest release.
