### PR TITLE
adds missing translation calls and locale keys

### DIFF
--- a/promo/app/views/spree/admin/promotions/_form.html.erb
+++ b/promo/app/views/spree/admin/promotions/_form.html.erb
@@ -2,7 +2,7 @@
 <fieldset id="general_fields">
   <legend><%= t(:general) %></legend>
   <%= f.field_container :name do %>
-    <%= f.label t(:name) %><br />
+    <%= f.label :name, t(:name) %><br />
     <%= f.text_field :name %>
   <% end %>
 
@@ -22,7 +22,7 @@
   <% end %>
 
   <%= f.field_container :description do %>
-    <%= f.label t(:description) %><br />
+    <%= f.label :description, t(:description) %><br />
     <%= f.text_area :description, :style => 'height:50px;' %>
   <% end %>
 
@@ -41,11 +41,11 @@
   </p>
 
   <p id="starts_at_field">
-    <%= f.label t(:starts_at) %>
+    <%= f.label :starts_at, t(:starts_at) %>
     <%= f.text_field :starts_at, :class => 'datepicker' %>
   </p>
   <p id="expires_at_field">
-    <%= f.label t(:expires_at) %>
+    <%= f.label :expires_at, t(:expires_at) %>
     <%= f.text_field :expires_at, :class => 'datepicker' %>
   </p>
 </fieldset>

--- a/promo/app/views/spree/admin/promotions/_form.html.erb
+++ b/promo/app/views/spree/admin/promotions/_form.html.erb
@@ -2,7 +2,7 @@
 <fieldset id="general_fields">
   <legend><%= t(:general) %></legend>
   <%= f.field_container :name do %>
-    <%= f.label :name %><br />
+    <%= f.label t(:name) %><br />
     <%= f.text_field :name %>
   <% end %>
 
@@ -22,7 +22,7 @@
   <% end %>
 
   <%= f.field_container :description do %>
-    <%= f.label :description %><br />
+    <%= f.label t(:description) %><br />
     <%= f.text_area :description, :style => 'height:50px;' %>
   <% end %>
 
@@ -41,11 +41,11 @@
   </p>
 
   <p id="starts_at_field">
-    <%= f.label :starts_at %>
+    <%= f.label t(:starts_at) %>
     <%= f.text_field :starts_at, :class => 'datepicker' %>
   </p>
   <p id="expires_at_field">
-    <%= f.label :expires_at %>
+    <%= f.label t(:expires_at) %>
     <%= f.text_field :expires_at, :class => 'datepicker' %>
   </p>
 </fieldset>

--- a/promo/app/views/spree/admin/promotions/actions/_create_adjustment.html.erb
+++ b/promo/app/views/spree/admin/promotions/actions/_create_adjustment.html.erb
@@ -15,7 +15,7 @@
     <div class="settings">
       <% promotion_action.calculator.preferences.keys.map do |key| %>
         <% field_name = "#{param_prefix}[calculator_attributes][preferred_#{key}]" %>
-        <%= label_tag field_name, key.to_s.titleize %>
+        <%= label_tag field_name, t(key.to_s) %>
         <%= preference_field_tag(field_name,
                                  promotion_action.calculator.get_preference(key),
                                  :type => promotion_action.calculator.preference_type(key)) %>

--- a/promo/config/locales/en.yml
+++ b/promo/config/locales/en.yml
@@ -14,6 +14,7 @@ en:
   advertise: Advertise
   coupon: Coupon
   coupon_code: Coupon code
+  description: Description
   editing_promotion: Editing Promotion
   events:
     spree:
@@ -21,8 +22,10 @@ en:
         coupon_code_added: Coupon code added
       content:
         visited: Visit static content page
+  expires_at: Expires at
   expiry: Expiry
   free_shipping: Free Shipping
+  name: Name
   new_promotion: New Promotion
   no_rules_added: No rules added
   promotion_not_found: The coupon code you entered doesn't exist. Please try again.
@@ -74,6 +77,7 @@ en:
   rules: Rules
   spree/order:
     coupon_code: Coupon Code
+  starts_at: Starts at
   user_rule:
     choose_users: Choose users
   item_total_rule:
@@ -84,3 +88,4 @@ en:
     path: Path
   promotion_action: Promotion Action
   promotion_rule: Promotion Rule
+  usage_limit: Usage limit


### PR DESCRIPTION
There's something impossible to translate in the promotion form. This commit should fix the issue.
