### PR TITLE
Sales total report should exclude incomplete orders 

### DIFF
--- a/core/app/controllers/spree/admin/reports_controller.rb
+++ b/core/app/controllers/spree/admin/reports_controller.rb
@@ -35,7 +35,7 @@ module Spree
 
         params[:search][:meta_sort] ||= "created_at.desc"
 
-        @search = Order.metasearch(params[:search])
+        @search = Order.complete.metasearch(params[:search])
         @orders = @search
         @item_total = @search.sum(:item_total)
         @adjustment_total = @search.sum(:adjustment_total)

--- a/core/spec/requests/admin/reports_spec.rb
+++ b/core/spec/requests/admin/reports_spec.rb
@@ -26,6 +26,11 @@ describe "Reports" do
       order.completed_at = Time.now
       order.save!
 
+      #incomplete order
+      order = Factory(:order)
+      order.update_attributes_without_callbacks({:adjustment_total => 50})
+      order.save!
+
       order = Factory(:order)
       order.update_attributes_without_callbacks({:adjustment_total => 200})
       order.completed_at = 3.years.ago
@@ -44,8 +49,8 @@ describe "Reports" do
       click_link "Reports"
       click_link "Sales Total"
 
-      fill_in "search_created_at_greater_than", :with => "2012/01/01"
-      fill_in "search_created_at_less_than", :with => "2012/12/31"
+      fill_in "search_created_at_greater_than", :with => 1.week.ago
+      fill_in "search_created_at_less_than", :with => 1.week.from_now
       click_button "Search"
 
       page.should have_content("$300.00")


### PR DESCRIPTION
and updated test to be less brittle

The current test is going to break at the end of the year due to hardcoded dates.
