### PR TITLE
Fixed bug with squared variant on_hand after cancel/resume order

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -553,11 +553,8 @@ module Spree
       end
 
       def restock_items!
-        shipments.each do |shipment|
-          shipment.inventory_units.each do |inventory_unit|
-            line_item = line_items.find_by_variant_id(inventory_unit.variant_id)
-            InventoryUnit.decrease(self, inventory_unit.variant, line_item.quantity)
-          end
+        line_items.each do |line_item|
+          InventoryUnit.decrease(self, line_item.variant, line_item.quantity)
         end
       end
 
@@ -566,11 +563,8 @@ module Spree
       end
 
       def unstock_items!
-        shipments.each do |shipment|
-          shipment.inventory_units.each do |inventory_unit|
-            line_item = line_items.find_by_variant_id(inventory_unit.variant_id)
-            InventoryUnit.increase(self, inventory_unit.variant, line_item.quantity)
-          end
+        line_items.each do |line_item|
+          InventoryUnit.increase(self, line_item.variant, line_item.quantity)
         end
       end
 

--- a/core/spec/models/order_spec.rb
+++ b/core/spec/models/order_spec.rb
@@ -596,17 +596,18 @@ describe Spree::Order do
 
   context "#cancel" do
     let!(:variant) { stub_model(Spree::Variant, :on_hand => 0) }
-    let!(:inventory_unit) { stub_model(Spree::InventoryUnit, :variant => variant) }
+    let!(:inventory_units) { [stub_model(Spree::InventoryUnit, :variant => variant),
+                              stub_model(Spree::InventoryUnit, :variant => variant) ]}
     let!(:shipment) do
       shipment = stub_model(Spree::Shipment)
-      shipment.stub :inventory_units => [inventory_unit]
+      shipment.stub :inventory_units => inventory_units
       order.stub :shipments => [shipment]
       shipment
     end
 
     before do
       order.email = user.email
-      order.stub :line_items => [stub_model(Spree::LineItem, :variant => variant, :quantity => 1)]
+      order.stub :line_items => [stub_model(Spree::LineItem, :variant => variant, :quantity => 2)]
       order.line_items.stub :find_by_variant_id => order.line_items.first
 
       order.stub :completed? => true
@@ -631,7 +632,7 @@ describe Spree::Order do
 
       # Regression fix for #729
       specify do
-        Spree::InventoryUnit.should_receive(:decrease).with(order, variant, 1)
+        Spree::InventoryUnit.should_receive(:decrease).with(order, variant, 2).once
         order.cancel!
       end
 
@@ -660,16 +661,17 @@ describe Spree::Order do
 
       before do
         shipment = stub_model(Spree::Shipment)
-        line_item = stub_model(Spree::LineItem, :variant => variant, :quantity => 1)
+        line_item = stub_model(Spree::LineItem, :variant => variant, :quantity => 2)
         order.stub :line_items => [line_item]
         order.line_items.stub :find_by_variant_id => line_item
 
         order.stub :shipments => [shipment]
-        shipment.stub :inventory_units => [stub_model(Spree::InventoryUnit, :variant => variant)]
+        shipment.stub :inventory_units => [stub_model(Spree::InventoryUnit, :variant => variant),
+                                           stub_model(Spree::InventoryUnit, :variant => variant) ]
       end
 
       specify do
-        Spree::InventoryUnit.should_receive(:increase).with(order, variant, 1)
+        Spree::InventoryUnit.should_receive(:increase).with(order, variant, 2).once
         order.resume!
       end
     end


### PR DESCRIPTION
InventoryUnit.decrease calls per each inventory_unit when you cancel an order. As result, we get squared Variant count_on_hand (e.g., 25 instead 5) when track_inventory_levels and create_inventory_units are true.
The same thing occurs with Order#resume.

Why are you iterate through shipments in Order#restock_items! ?
