### PR TITLE
Don't set count_on_hand to zero when not all backorders filled

### DIFF
--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -39,10 +39,7 @@ module Spree
         if new_level > on_hand
           # fill backordered orders before creating new units
           backordered_units = inventory_units.with_state('backordered')
-          backordered_units.slice(0, new_level).each do
-            backordered_units.shift.fill_backorder
-            new_level -= 1
-          end
+          backordered_units.slice(0, new_level).each &:fill_backorder
           new_level -= backordered_units.count
         end
 

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -40,7 +40,7 @@ module Spree
           # fill backordered orders before creating new units
           backordered_units = inventory_units.with_state('backordered')
           backordered_units.slice(0, new_level).each &:fill_backorder
-          new_level -= backordered_units.count
+          new_level -= backordered_units.length
         end
 
         self.count_on_hand = new_level

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -38,10 +38,12 @@ module Spree
         # increase Inventory when
         if new_level > on_hand
           # fill backordered orders before creating new units
-          inventory_units.with_state('backordered').slice(0, new_level).each do |iu|
-            iu.fill_backorder
+          backordered_units = inventory_units.with_state('backordered')
+          backordered_units.slice(0, new_level).each do
+            backordered_units.shift.fill_backorder
             new_level -= 1
           end
+          new_level -= backordered_units.count
         end
 
         self.count_on_hand = new_level

--- a/core/spec/models/variant_spec.rb
+++ b/core/spec/models/variant_spec.rb
@@ -63,6 +63,16 @@ describe Spree::Variant do
           variant.count_on_hand.should == 95
         end
 
+        it "should keep count_on_hand negative when count is not enough to fill backorders" do
+          variant.count_on_hand = -10
+          variant.save!
+          variant.inventory_units.stub(:with_state).and_return(Array.new(10, inventory_unit))
+          inventory_unit.should_receive(:fill_backorder).exactly(5).times
+          variant.on_hand = 5
+          variant.save!
+          variant.count_on_hand.should == -5
+        end
+
       end
 
       context "and count is decreased" do


### PR DESCRIPTION
A little strange Spree behavior with track_inventory_levels == true.

count_on_hand = -10

on_hand = 15 -> count_on_hand becomes 5. Good.
But: on_hand = 5 -> count_on_hand becomes 0. Not -5

Seems it should keep count_on_hand negative when new count is not enough to fill backorders
