### PR TITLE
Fix promotion label

### DIFF
--- a/promo/app/views/spree/admin/promotions/_form.html.erb
+++ b/promo/app/views/spree/admin/promotions/_form.html.erb
@@ -2,33 +2,33 @@
 <fieldset id="general_fields">
   <legend><%= t(:general) %></legend>
   <%= f.field_container :name do %>
-    <%= f.label :name, t(:name) %><br />
+    <%= f.label :name %><br />
     <%= f.text_field :name %>
   <% end %>
 
   <%= f.field_container :event_name do %>
-    <%= f.label :event_name, t(:event) %><br />
+    <%= f.label :event_name %><br />
     <%= f.select :event_name, Spree::Activator.event_names.map{|name| [t("events.#{name}"), name] } %>
   <% end %>
 
   <%= f.field_container :code do %>
-    <%= f.label :code, t(:code) %><br />
+    <%= f.label :code %><br />
     <%= f.text_field :code %>
   <% end %>
 
   <%= f.field_container :path do %>
-    <%= f.label :path, t(:path) %><br />
+    <%= f.label :path %><br />
     <%= f.text_field :path %>
   <% end %>
 
   <%= f.field_container :description do %>
-    <%= f.label :description, t(:description) %><br />
+    <%= f.label :description %><br />
     <%= f.text_area :description, :style => 'height:50px;' %>
   <% end %>
 
   <%= f.field_container :advertise do %>
     <%= f.check_box :advertise %>
-    <%= f.label :advertise, t(:advertise) %>
+    <%= f.label :advertise %>
   <% end %>
 
 </fieldset>
@@ -36,16 +36,16 @@
 <fieldset id="expiry_fields">
   <legend><%= t(:expiry) %></legend>
   <p>
-    <%= f.label :usage_limit, t(:usage_limit) %><br />
+    <%= f.label :usage_limit %><br />
     <%= f.text_field :usage_limit %>
   </p>
 
   <p id="starts_at_field">
-    <%= f.label :starts_at, t(:starts_at) %>
+    <%= f.label :starts_at %>
     <%= f.text_field :starts_at, :class => 'datepicker' %>
   </p>
   <p id="expires_at_field">
-    <%= f.label :expires_at, t(:expires_at) %>
+    <%= f.label :expires_at %>
     <%= f.text_field :expires_at, :class => 'datepicker' %>
   </p>
 </fieldset>

--- a/promo/config/locales/en.yml
+++ b/promo/config/locales/en.yml
@@ -3,18 +3,20 @@ en:
   activerecord:
     attributes:
       spree/promotion:
+        advertise: Advertise
         name: Name
         description: Description
-        code: Code
-        usage_limit: Usage limit
-        starts_at: Starts at
         expires_at: Expires at
+        event_name: Event Name
+        code: Code
+        usage_limit: Usage Limit
+        path: Path
+        starts_at: Starts at
+        code: Code
   add_action_of_type: Add action of type
   add_rule_of_type: Add rule of type
-  advertise: Advertise
   coupon: Coupon
   coupon_code: Coupon code
-  description: Description
   editing_promotion: Editing Promotion
   events:
     spree:
@@ -22,10 +24,8 @@ en:
         coupon_code_added: Coupon code added
       content:
         visited: Visit static content page
-  expires_at: Expires at
   expiry: Expiry
   free_shipping: Free Shipping
-  name: Name
   new_promotion: New Promotion
   no_rules_added: No rules added
   promotion_not_found: The coupon code you entered doesn't exist. Please try again.
@@ -77,7 +77,6 @@ en:
   rules: Rules
   spree/order:
     coupon_code: Coupon Code
-  starts_at: Starts at
   user_rule:
     choose_users: Choose users
   item_total_rule:
@@ -88,4 +87,3 @@ en:
     path: Path
   promotion_action: Promotion Action
   promotion_rule: Promotion Rule
-  usage_limit: Usage Limit

--- a/promo/config/locales/en.yml
+++ b/promo/config/locales/en.yml
@@ -4,15 +4,14 @@ en:
     attributes:
       spree/promotion:
         advertise: Advertise
-        name: Name
+        code: Code
         description: Description
-        expires_at: Expires at
         event_name: Event Name
-        code: Code
-        usage_limit: Usage Limit
+        expires_at: Expires At
+        name: Name
         path: Path
-        starts_at: Starts at
-        code: Code
+        starts_at: Starts At
+        usage_limit: Usage Limit
   add_action_of_type: Add action of type
   add_rule_of_type: Add rule of type
   coupon: Coupon
@@ -26,17 +25,26 @@ en:
         visited: Visit static content page
   expiry: Expiry
   free_shipping: Free Shipping
+  item_total_rule:
+    operators:
+      gt: greater than
+      gte: greater than or equal to
+  landing_page_rule:
+    path: Path
   new_promotion: New Promotion
   no_rules_added: No rules added
+  product_rule:
+    choose_products: Choose products
+    label: "Order must contain %{select} of these products"
+    match_any: at least one
+    match_all: all
+    product_source:
+      group: From product group
+      manual: Manually choose
   promotion_not_found: The coupon code you entered doesn't exist. Please try again.
   promotion: Promotion
+  promotion_action: Promotion Action
   promotion_actions: Actions
-  promotions: Promotions
-  promotion_form:
-    match_policies:
-      all: Match all of these rules
-      any: Match any of these rules
-  promotions_description: Manage offers and coupons with promotions
   promotion_action_types:
     create_adjustment:
       name: Create adjustment
@@ -47,43 +55,35 @@ en:
     give_store_credit:
       name: Give store credit
       description: Gives the user store credit of the amount specified
+  promotion_form:
+    match_policies:
+      all: Match all of these rules
+      any: Match any of these rules
+  promotions: Promotions
+  promotions_description: Manage offers and coupons with promotions
+  promotion_rule: Promotion Rule
   promotion_rule_types:
-    user:
-      name: User
-      description: Available only to the specified users
-    product:
-      name: Product(s)
-      description: Order includes specified product(s)
-    item_total:
-      name: Item total
-      description: Order total meets these criteria
     first_order:
       name: First order
       description: "Must be the customer's first order"
+    item_total:
+      name: Item total
+      description: Order total meets these criteria
     landing_page:
       name: Landing Page
       description: Customer must have visited the specified page
+    product:
+      name: Product(s)
+      description: Order includes specified product(s)
+    user:
+      name: User
+      description: Available only to the specified users
     user_logged_in:
       name: User Logged In
       description: Available only to logged in users
-  product_rule:
-    choose_products: Choose products
-    label: "Order must contain %{select} of these products"
-    match_any: at least one
-    match_all: all
-    product_source:
-      group: From product group
-      manual: Manually choose
   rules: Rules
   spree/order:
     coupon_code: Coupon Code
   user_rule:
     choose_users: Choose users
-  item_total_rule:
-    operators:
-      gt: greater than
-      gte: greater than or equal to
-  landing_page_rule:
-    path: Path
-  promotion_action: Promotion Action
-  promotion_rule: Promotion Rule
+


### PR DESCRIPTION
This should finally solve the promotion translation issue. I cleaned up the promotion form in a more standard way and added missing keys. Then, in the second commit, I alphabetically sorted and removed duplicates keys from locale. 
