### PR TITLE
using namespaced jirafe jquery, support for locales in admin dashboard

### DIFF
--- a/dash/app/controllers/spree/admin/overview_controller.rb
+++ b/dash/app/controllers/spree/admin/overview_controller.rb
@@ -1,6 +1,15 @@
 module Spree
   class Admin::OverviewController < Admin::BaseController
+
+    JIRAFE_LOCALES = { :english => 'en_US',
+                       :french => 'fr_FR',
+                       :german => 'de_DE' }
+
     def index
+      if JIRAFE_LOCALES.values.include? params[:locale]
+        Spree::Dash::Config.locale = params[:locale]
+      end
     end
+
   end
 end

--- a/dash/app/helpers/spree/admin/overview_helper.rb
+++ b/dash/app/helpers/spree/admin/overview_helper.rb
@@ -1,0 +1,13 @@
+module Spree
+  module Admin
+    module OverviewHelper
+
+      def jirafe_locale_links
+        Spree::Admin::OverviewController::JIRAFE_LOCALES.collect do |langage, locale|
+          link_to t(langage), admin_path(:locale => locale)
+        end
+      end
+
+    end
+  end
+end

--- a/dash/app/models/spree/dash_configuration.rb
+++ b/dash/app/models/spree/dash_configuration.rb
@@ -4,6 +4,7 @@ module Spree
     preference :app_token, :string
     preference :site_id, :string
     preference :token, :string
+    preference :locale, :string, :default => 'en_US'
 
     def configured?
       preferred_app_id.present? and preferred_site_id.present? and preferred_token.present?

--- a/dash/app/views/spree/admin/overview/index.html.erb
+++ b/dash/app/views/spree/admin/overview/index.html.erb
@@ -1,28 +1,27 @@
 <% content_for :head do %>
   <%= stylesheet_link_tag 'https://api.jirafe.com/dashboard/css/spree_ui.css', :media => 'all' %>
-  <%= javascript_include_tag 'https://api.jirafe.com/dashboard/js/spree_ui.js' %>
+  <%= javascript_include_tag 'https://jirafe.com/dashboard/js/spree_namespaced_ui.js' %>
 <% end %>
 
 <% if Spree::Dash::Config.configured? %>
   <h1><%= t(:overview) %></h1>
   <div id="jirafe"></div>
   <%= javascript_tag :defer => 'defer' do %>
-    if (typeof jQuery != 'undefined') {
-        (function($) {
-         $('#jirafe').jirafe({
-            api_url:    'https://api.jirafe.com/v1',
-            api_token:  '<%= Spree::Dash::Config.token %>',
-            app_id:     '<%= Spree::Dash::Config.app_id %>',
-            version:    'spree-v0.1.0'
-            });
-         })(jQuery);
-    }
+    jirafe.jQuery('#jirafe').jirafe({
+       api_url: 'https://api.jirafe.com/v1',
+       api_token: '<%= Spree::Dash::Config.token %>',
+       app_id: '<%= Spree::Dash::Config.app_id %>',
+       version: 'spree-v0.1.0',
+       locale: '<%= Spree::Dash::Config.locale %>' });
     setTimeout(function() {
       if ($('mod-jirafe') == undefined) {
         $('messages').insert ("<ul class=\"messages\"><li class=\"error-msg\">We're unable to connect with the Jirafe service for the moment. Please wait a few minutes and refresh this page later.</li></ul>");
         }
     }, 10000);
   <% end %>
+  <div id="jirafe_locales">
+    <%= raw jirafe_locale_links.join(' | ') %>
+  </div>
 <% else %>
   <div class="analytics_splash">
     <%= image_tag 'analytics_dashboard_preview.png', :alt => 'Spree Analytics' %>

--- a/dash/spec/controllers/admin/overview_controller_spec.rb
+++ b/dash/spec/controllers/admin/overview_controller_spec.rb
@@ -1,4 +1,16 @@
 require 'spec_helper'
 
 describe Spree::Admin::OverviewController do
+
+  before :each do
+    @user = Factory(:admin_user)
+    controller.stub :current_user => @user
+  end
+
+  it "sets the locale preference" do
+    Spree::Dash::Config.locale = 'en_EN'
+    get :index, :locale => 'fr_FR'
+    Spree::Dash::Config.locale.should eq 'fr_FR'
+  end
+
 end


### PR DESCRIPTION
I created a preference for locale, currently supporting french, german and english. You can see links underneath the analytics report on the admin overview tab.

[fixes #1204]
