### PR TITLE
Fix bugs with errors on update action in Return Authorizations

### DIFF
--- a/core/app/controllers/spree/admin/resource_controller.rb
+++ b/core/app/controllers/spree/admin/resource_controller.rb
@@ -34,7 +34,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
       end
     else
       invoke_callbacks(:update, :fails)
-      respond_with(@object, :location => [:admin, @object])
+      respond_with(@object)
     end
   end
 

--- a/core/app/controllers/spree/admin/return_authorizations_controller.rb
+++ b/core/app/controllers/spree/admin/return_authorizations_controller.rb
@@ -14,7 +14,7 @@ module Spree
 
       protected
         def associate_inventory_units
-          params[:return_quantity].each { |variant_id, qty| @return_authorization.add_variant(variant_id.to_i, qty.to_i) }
+          (params[:return_quantity] || []).each { |variant_id, qty| @return_authorization.add_variant(variant_id.to_i, qty.to_i) }
         end
     end
   end


### PR DESCRIPTION
NoMethodError raised when you do this steps:
1. Create return authorization for all products in order
2. Receive it
3. Click Update
3. You'll receive an error 
`undefined method`admin_return_authorization_url'`
cause of :location => [:admin, @object] gives path without nesting (order/return_authorizations)

Second error is `NoMethodError: undefined method`each' for nil:NilClass` 
It occurs when we update recieved Return Authorization because there's no fields 'return_quantity[]' in its edit form.
