### PR TITLE
Fixed mass assignment error when editing taxonomy tree

### DIFF
--- a/core/app/models/spree/image.rb
+++ b/core/app/models/spree/image.rb
@@ -3,7 +3,7 @@ module Spree
     validates_attachment_presence :attachment
     validate :no_attachment_errors
 
-    attr_accessible :attachment, :alt
+    attr_accessible :attachment, :alt, :viewable_id
 
     has_attached_file :attachment,
                       :styles => { :mini => '48x48>', :small => '100x100>', :product => '240x240>', :large => '600x600>' },

--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -6,7 +6,7 @@ module Spree
     has_and_belongs_to_many :products, :join_table => 'spree_products_taxons'
     before_create :set_permalink
 
-    attr_accessible :name, :parent_id, :position
+    attr_accessible :name, :parent_id, :position, :description, :permalink
 
     validates :name, :presence => true
     has_attached_file :icon,

--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -6,7 +6,7 @@ module Spree
     has_and_belongs_to_many :products, :join_table => 'spree_products_taxons'
     before_create :set_permalink
 
-    attr_accessible :name
+    attr_accessible :name, :parent_id, :position
 
     validates :name, :presence => true
     has_attached_file :icon,


### PR DESCRIPTION
Using a 3.2.3 Rails App with spree gem from git/master.

In Admin, under 'Configuration' / 'Taxonomies' , while creating or editing a Taxonomy tree, right clicking on the tree root, editing the name of the child and pressing enter does not save.

An error dialog appears and the console reads ActiveModel::MassAssignmentSecurity::Error (Can't mass-assign protected attributes: parent_id, position) .

Due to new 3.2.3 mass assignment protection we have to set parent_id, position  under attr_accessible.
