### PR TITLE
Removes textmate macro left over from devise down migration.

### DIFF
--- a/auth/db/migrate/20101026184950_rename_columns_for_devise.rb
+++ b/auth/db/migrate/20101026184950_rename_columns_for_devise.rb
@@ -22,7 +22,6 @@ class RenameColumnsForDevise < ActiveRecord::Migration
     remove_column :spree_users, :authentication_token
     remove_column :spree_users, :locked_at
     remove_column :spree_users, :unlock_token
-    rename_column :table_name, :new_column_name, :column_name
     rename_column :spree_users, :last_sign_in_ip, :last_login_ip
     rename_column :spree_users, :current_sign_in_ip, :current_login_ip
     rename_column :spree_users, :last_sign_in_at, :last_login_at


### PR DESCRIPTION
It removes this line: https://github.com/spree/spree/blob/master/auth/db/migrate/20101026184950_rename_columns_for_devise.rb#L25

That @jbrien added with this commit: 4a08bb35bdae9af7a703562742fa7b79125fc2fe
