### PR TITLE
fix invalid method call on gateway connection error

### DIFF
--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -112,7 +112,7 @@ module Spree
         return unless source.is_a?(Creditcard) && source.number && !source.has_payment_profile?
         payment_method.create_profile(self)
       rescue ActiveMerchant::ConnectionError => e
-        gateway_error e
+        source.gateway_error e
       end
 
       def update_order

--- a/core/spec/models/payment_spec.rb
+++ b/core/spec/models/payment_spec.rb
@@ -128,11 +128,23 @@ describe Spree::Payment do
 
     context "when profiles are supported" do
       before { gateway.stub :payment_profiles_supported? => true }
-
-      it "should create a payment profile" do
-        gateway.should_receive :create_profile
-        payment = Spree::Payment.create({:amount => 100, :order => order, :source => card, :payment_method => gateway}, :without_protection => true)
+      
+      context "when there is an error connecting to the gateway" do
+        it "should call source.gateway_error " do
+          gateway.should_receive(:create_profile).and_raise(ActiveMerchant::ConnectionError)
+          card.should_receive(:gateway_error)
+          payment = Spree::Payment.create({:amount => 100, :order => order, :source => card, :payment_method => gateway}, :without_protection => true)
+        end
       end
+      
+      context "when successfully connecting to the gateway" do
+        it "should create a payment profile" do
+          gateway.should_receive :create_profile
+          payment = Spree::Payment.create({:amount => 100, :order => order, :source => card, :payment_method => gateway}, :without_protection => true)
+        end
+      end
+      
+      
     end
 
     context "when profiles are not supported" do


### PR DESCRIPTION
when a gateway connection error occurs during the create_payment_profile call one currently receives undefined method `gateway_error'.  
