### PR TITLE
Fix dynamic classes adding for #content div on spree_application layout

### DIFF
--- a/core/app/views/spree/layouts/spree_application.html.erb
+++ b/core/app/views/spree/layouts/spree_application.html.erb
@@ -13,7 +13,7 @@
       <div id="wrapper" class="row" data-hook>
           <%= breadcrumbs(@taxon) %>
         <%= render :partial => 'spree/shared/sidebar' if content_for? :sidebar %>
-        <div id="content" class="columns omega <%= !content_for(:sidebar) ? "sixteen alpha" : "twelve" %>" data-hook>
+        <div id="content" class="columns omega <%= !content_for?(:sidebar) ? "sixteen alpha" : "twelve" %>" data-hook>
           <%= flash_messages %>
           <%= yield %>
         </div>


### PR DESCRIPTION
This -> https://github.com/spree/spree/commit/02a5d68e834b4c2429c94425f1826ca8c276df6d#L0R16 <- commit breaks dynamic class adding to #content div and product show page get wrong class. This pull requirest fixing it. The only thing that was missing is "?" in content_for. 
