### PR TITLE
Fix mass assignment error when updating payment method

### DIFF
--- a/core/app/models/spree/gateway.rb
+++ b/core/app/models/spree/gateway.rb
@@ -6,6 +6,8 @@ module Spree
 
     preference :server, :string, :default => 'test'
     preference :test_mode, :boolean, :default => true
+    
+    attr_accessible :preferred_server, :preferred_test_mode
 
     def payment_source_class
       Creditcard


### PR DESCRIPTION
Due to mass assignment changes in rails 3.2.3 we need to add any preferences to attr_accessible otherwise we get a mass assignment error when trying to update payment methods.

This should fix Issue #1386 when used in conjunction with my [pull request in spree_gateway](https://github.com/spree/spree_gateway/pull/9)
