### PR TITLE
Corrected an issue with Add To Cart button not working on IE7

### DIFF
--- a/core/app/views/spree/products/_cart_form.html.erb
+++ b/core/app/views/spree/products/_cart_form.html.erb
@@ -38,7 +38,7 @@
           <% if @product.has_stock? || Spree::Config[:allow_backorders] %>      
             <%= number_field_tag (@product.has_variants? ? :quantity : "variants[#{@product.master.id}]"),
               1, :class => 'title', :in => 1..@product.on_hand %>
-            <%= button_tag :class => 'large primary', :id => 'add-to-cart-button' do %>
+            <%= button_tag :class => 'large primary', :id => 'add-to-cart-button', :type => :submit do %>
               <%= t(:add_to_cart) %>
             <% end %>
           <% else %>


### PR DESCRIPTION
The Add to Cart button doesn't work under IE7. I think this was a recent problem because it doesn't appear in the RailsDog demo (which lead me to the solution). Under IE7, the button needs a type='submit' attribute to work correctly.

I also tested this with IE6 and IE8 and both work correctly.
