### PR TITLE
Adds a version option to Spree installer.

### DIFF
--- a/cmd/lib/spree_cmd/extension.rb
+++ b/cmd/lib/spree_cmd/extension.rb
@@ -36,7 +36,7 @@ module SpreeCmd
 
         Your extension has been generated with a gemspec dependency on Spree #{spree_version}.
 
-        Please update the Versionfile to designate compatibilty with different versions of Spree.
+        Please update the Versionfile to designate compatibility with different versions of Spree.
         See http://spreecommerce.com/documentation/extensions.html#versionfile
 
         Consider listing your extension in the official extension registry http://spreecommerce.com/extensions"

--- a/cmd/lib/spree_cmd/installer.rb
+++ b/cmd/lib/spree_cmd/installer.rb
@@ -12,8 +12,7 @@ module SpreeCmd
     class_option :skip_install_data, :type => :boolean, :default => false,
                  :desc => 'Skip running migrations and loading seed and sample data'
 
-    class_option :version, :type => :string, :default => 'current',
-                 :desc => 'Spree Version to use (current, edge, local)'
+    class_option :version, :type => :string, :desc => 'Spree Version to use'
 
     class_option :edge, :type => :boolean
 
@@ -42,6 +41,8 @@ module SpreeCmd
         @spree_gem_options[:ref] = options[:ref] if options[:ref]
         @spree_gem_options[:branch] = options[:branch] if options[:branch]
         @spree_gem_options[:tag] = options[:tag] if options[:tag]
+      elsif options[:version]
+        @spree_gem_options[:version] = options[:version]
       end
     end
 
@@ -106,10 +107,11 @@ module SpreeCmd
 
     private
 
-      def gem(name, options={})
+      def gem(name, gem_options={})
         say_status :gemfile, name
         parts = ["'#{name}'"]
-        options.each { |key, value| parts << ":#{key} => '#{value}'" }
+        parts << ["'#{gem_options.delete(:version)}'"] if gem_options[:version]
+        gem_options.each { |key, value| parts << ":#{key} => '#{value}'" }
         append_file 'Gemfile', "gem #{parts.join(', ')}\n", :verbose => false
       end
 


### PR DESCRIPTION
Added an option to choose which version of Spree to be used by the
installer (passing in the version is optional).

The goal is to facilitate the testing of extensions with published
versions of the Spree gem, instead of using either git branches or tags.
