### PR TITLE
adding original to deface override

### DIFF
--- a/dash/app/overrides/analytics_header.rb
+++ b/dash/app/overrides/analytics_header.rb
@@ -1,4 +1,5 @@
 Deface::Override.new(:virtual_path => "spree/layouts/spree_application",
                      :name => "add_analytics_header",
                      :insert_bottom => "[data-hook='inside_head']",
-                     :partial => "spree/analytics/header")
+                     :partial => "spree/analytics/header"),
+                     :original => '6f23c8af6e863d0499835c00b3f2763cb98e1d75'

--- a/dash/app/overrides/analytics_header.rb
+++ b/dash/app/overrides/analytics_header.rb
@@ -1,5 +1,5 @@
 Deface::Override.new(:virtual_path => "spree/layouts/spree_application",
                      :name => "add_analytics_header",
                      :insert_bottom => "[data-hook='inside_head']",
-                     :partial => "spree/analytics/header"),
-                     :original => '6f23c8af6e863d0499835c00b3f2763cb98e1d75'
+                     :partial => "spree/analytics/header",
+                     :original => '6f23c8af6e863d0499835c00b3f2763cb98e1d75')


### PR DESCRIPTION
Deface: [WARNING] No :original defined for 'add_analytics_header', you should change its definition to include:
 :original => '6f23c8af6e863d0499835c00b3f2763cb98e1d75' 
