### PR TITLE
fixing multi_json version

### DIFF
--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -7,7 +7,7 @@ gem 'json'
 gem 'sqlite3'
 gem 'mysql2'
 gem 'pg'
-
+gem 'multi_json', "1.2.0"
 # Gems used only for assets and not required
 # in production environments by default.
 group :assets do


### PR DESCRIPTION
multi_json 1.3 had a lot of deprecation warnings. Locking in at 1.2
