### PR TITLE
Tweak product.hast_stock? method

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -110,8 +110,9 @@ module Spree
     end
 
     # Returns true if there are inventory units (any variant) with "on_hand" state for this product
+    # Variants take precedence over master
     def has_stock?
-      master.in_stock? || variants.any?(&:in_stock?)
+      variants.any? ? variants.any?(&:in_stock?) : master.in_stock?
     end
 
     def tax_category


### PR DESCRIPTION
This request is in response to Issue #1373. Here's the tweaked logic:

``` ruby
# Returns true if there are inventory units (any variant) with "on_hand" state for this product
# Variants take precedence over master
def has_stock?
   variants.any? ? variants.any?(&:in_stock?) : master.in_stock?
end
```
