### PR TITLE
Refactor payment methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ branches:
   only:
     - 1-0-stable
     - master
+    - refactor-payment-methods
 rvm:
   - 1.8.7
   - 1.9.3

--- a/api/app/controllers/spree/api/v1/payments_controller.rb
+++ b/api/app/controllers/spree/api/v1/payments_controller.rb
@@ -1,0 +1,56 @@
+module Spree
+  module Api
+    module V1
+      class PaymentsController < Spree::Api::V1::BaseController
+        before_filter :find_order
+        before_filter :find_payment, :only => [:show, :authorize, :capture]
+
+        def index
+          @payments = @order.payments
+        end
+
+        def new
+          @payment_methods = Spree::PaymentMethod.where(:environment => Rails.env)
+        end
+
+        def create
+          @payment = @order.payments.build(params[:payment])
+          if @payment.save
+            render :show, :status => 201
+          else
+            invalid_resource!(@payment)
+          end
+        end
+
+        def show
+        end
+
+        def authorize
+          authorize! :authorize, Payment
+          begin
+            @payment.authorize!
+          rescue Spree::Core::GatewayError
+            #noop, will deal with it in the response
+          end
+
+          if @payment.failed?
+            render :gateway_error, :status => 422
+          else
+            render :show, :status => 200
+          end
+        end
+
+        private
+
+        def find_order
+          @order = Order.find_by_number(params[:order_id])
+          authorize! :read, @order
+        end
+
+        def find_payment
+          @payment = @order.payments.find(params[:id])
+        end
+      end
+    end
+  end
+end

--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -39,6 +39,14 @@ module Spree
       def option_type_attributes
         [:id, :name, :presentation, :position]
       end
+
+      def payment_attributes
+        [:id, :source_type, :source_id, :amount, :payment_method_id, :response_code, :state, :avs_response, :created_at, :updated_at]
+      end
+
+      def payment_method_attributes
+        [:id, :name, :description]
+      end
     end
   end
 end

--- a/api/app/models/spree/payment_decorator.rb
+++ b/api/app/models/spree/payment_decorator.rb
@@ -1,0 +1,5 @@
+Spree::Payment.class_eval do
+  def authorize!
+    self.payment_source.authorize(self)
+  end
+end

--- a/api/app/models/spree/payment_decorator.rb
+++ b/api/app/models/spree/payment_decorator.rb
@@ -1,5 +1,0 @@
-Spree::Payment.class_eval do
-  def authorize!
-    self.payment_source.authorize(self)
-  end
-end

--- a/api/app/views/spree/api/v1/payments/index.rabl
+++ b/api/app/views/spree/api/v1/payments/index.rabl
@@ -1,0 +1,2 @@
+collection @payments
+attributes *payment_attributes

--- a/api/app/views/spree/api/v1/payments/new.rabl
+++ b/api/app/views/spree/api/v1/payments/new.rabl
@@ -1,0 +1,6 @@
+object false
+node(:attributes) { [*payment_attributes] }
+child @payment_methods => :payment_methods do
+  attributes *payment_method_attributes
+end
+

--- a/api/app/views/spree/api/v1/payments/show.rabl
+++ b/api/app/views/spree/api/v1/payments/show.rabl
@@ -1,0 +1,2 @@
+object @payment
+attributes *payment_attributes

--- a/api/spec/controllers/spree/api/v1/payments_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/payments_controller_spec.rb
@@ -1,0 +1,90 @@
+require 'spec_helper'
+
+module Spree
+  describe Spree::Api::V1::PaymentsController do
+    let!(:order) { Factory(:order) }
+    let!(:payment) { Factory(:payment, :order => order) }
+    let!(:attributes) { [:id, :source_type, :source_id, :amount,
+                         :payment_method_id, :response_code, :state, :avs_response, 
+                         :created_at, :updated_at] }
+
+    let(:resource_scoping) { { :order_id => order.to_param } }
+    before do
+      stub_authentication!
+    end
+
+    context "as a user" do
+      context "when the order belongs to the user" do
+        before do
+          Order.any_instance.stub :user => current_api_user
+        end
+
+        it "can view the payments for their order" do
+          api_get :index
+          json_response.first.should have_attributes(attributes)
+        end
+
+        it "can learn how to create a new payment" do
+          api_get :new
+          json_response["attributes"].should == attributes.map(&:to_s)
+          json_response["payment_methods"].should_not be_empty
+          json_response["payment_methods"].first.should have_attributes([:id, :name, :description])
+        end
+
+        it "can create a new payment" do
+          api_post :create, :payment => { :payment_method_id => PaymentMethod.first.id, :amount => 50 }
+          response.status.should == 201
+          json_response.should have_attributes(attributes)
+        end
+
+        it "can view a pre-existing payment's details" do
+          api_get :show, :id => payment.to_param
+          json_response.should have_attributes(attributes)
+        end
+
+        it "cannot authorize a payment" do
+          api_put :authorize, :id => payment.to_param
+          assert_unauthorized!
+        end
+      end
+
+      context "when the order does not belong to the user" do
+        before do
+          Order.any_instance.stub :user => stub_model(User)
+        end
+
+        it "cannot view payments for somebody else's order" do
+          api_get :index, :order_id => order.to_param
+          assert_unauthorized!
+        end
+      end
+    end
+
+    context "as an admin" do
+      sign_in_as_admin!
+
+      it "can view the payments on any order" do
+        api_get :index
+        response.status.should == 200
+        json_response.first.should have_attributes(attributes)
+      end
+
+      context "for a given payment" do
+
+        it "can authorize" do
+          api_put :authorize, :id => payment.to_param
+          response.status.should == 200
+        end
+
+        it "returns a 422 status when authorization fails" do
+          fake_response = stub(:success? => false, :to_s => "Could not authorize card")
+          Spree::Gateway::Bogus.any_instance.should_receive(:authorize).and_return(fake_response)
+          api_put :authorize, :id => payment.to_param
+          response.status.should == 422
+        end
+      end
+
+    end
+
+  end
+end

--- a/core/app/controllers/spree/admin/payments_controller.rb
+++ b/core/app/controllers/spree/admin/payments_controller.rb
@@ -51,7 +51,6 @@ module Spree
       end
 
       def fire
-        # TODO: consider finer-grained control for this type of action (right now anyone in admin role can perform)
         return unless event = params[:e] and @payment.payment_source
         if @payment.send("#{event}!")
           flash.notice = t(:payment_updated)

--- a/core/app/controllers/spree/admin/payments_controller.rb
+++ b/core/app/controllers/spree/admin/payments_controller.rb
@@ -53,7 +53,7 @@ module Spree
       def fire
         # TODO: consider finer-grained control for this type of action (right now anyone in admin role can perform)
         return unless event = params[:e] and @payment.payment_source
-        if @payment.payment_source.send("#{event}", @payment)
+        if @payment.send("#{event}!", @payment)
           flash.notice = t(:payment_updated)
         else
           flash[:error] = t(:cannot_perform_operation)

--- a/core/app/controllers/spree/admin/payments_controller.rb
+++ b/core/app/controllers/spree/admin/payments_controller.rb
@@ -53,7 +53,7 @@ module Spree
       def fire
         # TODO: consider finer-grained control for this type of action (right now anyone in admin role can perform)
         return unless event = params[:e] and @payment.payment_source
-        if @payment.send("#{event}!", @payment)
+        if @payment.send("#{event}!")
           flash.notice = t(:payment_updated)
         else
           flash[:error] = t(:cannot_perform_operation)

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -77,6 +77,12 @@ module Spree
       attributes.except('id', 'created_at', 'updated_at', 'order_id', 'country_id').all? { |_, v| v.nil? }
     end
 
+    # Generates an ActiveMerchant compatible address hash
+    def active_merchant_hash
+      { :name => full_name, :address1 => address1, :address2 => address2, :city => city,
+        :state => state_text, :zip => zipcode, :country => country.iso, :phone => phone }
+    end
+
     private
 
       def state_validate

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -80,7 +80,7 @@ module Spree
     # Generates an ActiveMerchant compatible address hash
     def active_merchant_hash
       { :name => full_name, :address1 => address1, :address2 => address2, :city => city,
-        :state => state_text, :zip => zipcode, :country => country.iso, :phone => phone }
+        :state => state_text, :zip => zipcode, :country => country.try(:iso), :phone => phone }
     end
 
     private

--- a/core/app/models/spree/creditcard.rb
+++ b/core/app/models/spree/creditcard.rb
@@ -15,8 +15,8 @@ module Spree
                     :month, :gateway_customer_profile_id
 
     def set_last_digits
-      number.to_s.gsub!(/\s/,'') unless number.nil?
-      verification_value.to_s.gsub!(/\s/,'') unless number.nil?
+      number.to_s.gsub!(/\s/,'')
+      verification_value.to_s.gsub!(/\s/,'')
       self.last_digits ||= number.to_s.length <= 4 ? number : number.to_s.slice(-4..-1)
     end
 

--- a/core/app/models/spree/creditcard.rb
+++ b/core/app/models/spree/creditcard.rb
@@ -107,7 +107,7 @@ module Spree
         payment.complete
       else
         payment.failure
-        gateway_error(response) unless response.success?
+        gateway_error(response)
       end
     rescue ActiveMerchant::ConnectionError => e
       gateway_error e

--- a/core/app/models/spree/creditcard.rb
+++ b/core/app/models/spree/creditcard.rb
@@ -23,9 +23,13 @@ module Spree
     end
 
     def set_last_digits
-      number.to_s.gsub!(/\s/,'') unless number.nil?
-      verification_value.to_s.gsub!(/\s/,'') unless number.nil?
-      self.last_digits ||= number.to_s.length <= 4 ? number : number.to_s.slice(-4..-1)
+      unless number.nil?
+        number.to_s.gsub!(/\s/,'')
+        verification_value.to_s.gsub!(/\s/,'')
+      end
+
+      # Last four digits
+      self.last_digits ||= number.to_s[-4, 4]
     end
 
     # cheap hack to get to the type? method from deep within ActiveMerchant without stomping on

--- a/core/app/models/spree/creditcard.rb
+++ b/core/app/models/spree/creditcard.rb
@@ -16,9 +16,9 @@ module Spree
 
     def process!(payment)
       if Spree::Config[:auto_capture]
-        purchase(payment.amount.to_f, payment)
+        payment.purchase!
       else
-        authorize(payment.amount.to_f, payment)
+        payment.authorize!
       end
     end
 
@@ -73,117 +73,6 @@ module Spree
 
     scope :with_payment_profile, where('gateway_customer_profile_id IS NOT NULL')
 
-    def authorize(amount, payment)
-      # ActiveMerchant is configured to use cents so we need to multiply order total by 100
-      payment_gateway = payment.payment_method
-      check_environment(payment_gateway)
-
-      response = payment_gateway.authorize((amount * 100).round, self, gateway_options(payment))
-      record_log payment, response
-
-      if response.success?
-        payment.response_code = response.authorization
-        payment.avs_response = response.avs_result['code']
-        payment.pend
-      else
-        payment.failure
-        gateway_error(response)
-      end
-    rescue ActiveMerchant::ConnectionError => e
-      gateway_error e
-    end
-
-    def purchase(amount, payment)
-      #combined Authorize and Capture that gets processed by the ActiveMerchant gateway as one single transaction.
-      payment_gateway = payment.payment_method
-      check_environment(payment_gateway)
-
-      response = payment_gateway.purchase((amount * 100).round, self, gateway_options(payment))
-      record_log payment, response
-
-      if response.success?
-        payment.response_code = response.authorization
-        payment.avs_response = response.avs_result['code']
-        payment.complete
-      else
-        payment.failure
-        gateway_error(response)
-      end
-    rescue ActiveMerchant::ConnectionError => e
-      gateway_error e
-    end
-
-    def capture(payment)
-      return unless payment.pending?
-      payment_gateway = payment.payment_method
-      check_environment(payment_gateway)
-
-      if payment_gateway.payment_profiles_supported?
-        # Gateways supporting payment profiles will need access to creditcard object because this stores the payment profile information
-        # so supply the authorization itself as well as the creditcard, rather than just the authorization code
-        response = payment_gateway.capture(payment, self, minimal_gateway_options(payment, false))
-      else
-        # Standard ActiveMerchant capture usage
-        response = payment_gateway.capture((payment.amount * 100).round, payment.response_code, minimal_gateway_options(payment, false))
-      end
-
-      record_log payment, response
-
-      if response.success?
-        payment.response_code = response.authorization
-        payment.complete
-      else
-        payment.failure
-        gateway_error(response)
-      end
-    rescue ActiveMerchant::ConnectionError => e
-      gateway_error e
-    end
-
-    def void(payment)
-      payment_gateway = payment.payment_method
-      check_environment(payment_gateway)
-
-      response = payment_gateway.void(payment.response_code, minimal_gateway_options(payment, false))
-      record_log payment, response
-
-      if response.success?
-        payment.response_code = response.authorization
-        payment.void
-      else
-        gateway_error(response)
-      end
-    rescue ActiveMerchant::ConnectionError => e
-      gateway_error e
-    end
-
-    def credit(payment)
-      payment_gateway = payment.payment_method
-      check_environment(payment_gateway)
-
-      amount = payment.credit_allowed >= payment.order.outstanding_balance.abs ? payment.order.outstanding_balance.abs : payment.credit_allowed.abs
-      if payment_gateway.payment_profiles_supported?
-        response = payment_gateway.credit((amount * 100).round, self, payment.response_code, minimal_gateway_options(payment, false))
-      else
-        response = payment_gateway.credit((amount * 100).round, payment.response_code, minimal_gateway_options(payment, false))
-      end
-
-      record_log payment, response
-
-      if response.success?
-        Payment.create({ :order => payment.order,
-                         :source => payment,
-                         :payment_method => payment.payment_method,
-                         :amount => amount.abs * -1,
-                         :response_code => response.authorization,
-                         :state => 'completed' }, :without_protection => true)
-      else
-        gateway_error(response)
-      end
-    rescue ActiveMerchant::ConnectionError => e
-      gateway_error e
-    end
-
     def actions
       %w{capture void credit}
     end
@@ -195,7 +84,7 @@ module Spree
 
     # Indicates whether its possible to void the payment.
     def can_void?(payment)
-      payment.state == 'void' ? false : true
+      payment.state != 'void'
     end
 
     # Indicates whether its possible to credit the payment.  Note that most gateways require that the
@@ -210,64 +99,9 @@ module Spree
       gateway_customer_profile_id.present?
     end
 
-    def record_log(payment, response)
-      payment.log_entries.create({:details => response.to_yaml}, :without_protection => true)
-    end
-
-    def gateway_error(error)
-      if error.is_a? ActiveMerchant::Billing::Response
-        text = error.params['message'] || error.params['response_reason_text'] || error.message
-      elsif error.is_a? ActiveMerchant::ConnectionError
-        text = I18n.t(:unable_to_connect_to_gateway)
-      else
-        text = error.to_s
-      end
-      logger.error(I18n.t(:gateway_error))
-      logger.error("  #{error.to_yaml}")
-      raise Core::GatewayError.new(text)
-    end
-
-    def gateway_options(payment)
-      options = { :billing_address  => generate_address_hash(payment.order.bill_address),
-                  :shipping_address => generate_address_hash(payment.order.ship_address) }
-      options.merge minimal_gateway_options(payment)
-    end
-
-    # Generates an ActiveMerchant compatible address hash from one of Spree's address objects
-    def generate_address_hash(address)
-      return {} if address.nil?
-      { :name => address.full_name, :address1 => address.address1, :address2 => address.address2, :city => address.city,
-        :state => address.state_text, :zip => address.zipcode, :country => address.country.iso, :phone => address.phone }
-    end
-
-    # Generates a minimal set of gateway options.  There appears to be some issues with passing in
-    # a billing address when authorizing/voiding a previously captured transaction.  So omits these
-    # options in this case since they aren't necessary.
-    def minimal_gateway_options(payment, totals = true)
-
-      options = { :email    => payment.order.email,
-                  :customer => payment.order.email,
-                  :ip       => payment.order.ip_address,
-                  :order_id => payment.order.number }
-      if totals
-        options.merge!({ :shipping => payment.order.ship_total * 100,
-                         :tax      => payment.order.tax_total * 100,
-                         :subtotal => payment.order.item_total * 100 })
-      end
-      options
-    end
-
     def spree_cc_type
       return 'visa' if Rails.env.development?
       cc_type
-    end
-
-    # Saftey check to make sure we're not accidentally performing operations on a live gateway.
-    # Ex. When testing in staging environment with a copy of production data.
-    def check_environment(gateway)
-      return if gateway.environment == Rails.env
-      message = I18n.t(:gateway_config_unavailable) + " - #{Rails.env}"
-      raise Core::GatewayError.new(message)
     end
   end
 end

--- a/core/app/models/spree/creditcard.rb
+++ b/core/app/models/spree/creditcard.rb
@@ -14,14 +14,6 @@ module Spree
     attr_accessible :first_name, :last_name, :number, :verification_value, :year,
                     :month, :gateway_customer_profile_id
 
-    def process!(payment)
-      if Spree::Config[:auto_capture]
-        payment.purchase!
-      else
-        payment.authorize!
-      end
-    end
-
     def set_last_digits
       number.to_s.gsub!(/\s/,'') unless number.nil?
       verification_value.to_s.gsub!(/\s/,'') unless number.nil?

--- a/core/app/models/spree/creditcard.rb
+++ b/core/app/models/spree/creditcard.rb
@@ -23,11 +23,9 @@ module Spree
     end
 
     def set_last_digits
-      # Last four digits
-      self.last_digits ||= number.to_s[-4, 4]
-
-      self.number = nil
-      self.verification_value = nil
+      number.to_s.gsub!(/\s/,'') unless number.nil?
+      verification_value.to_s.gsub!(/\s/,'') unless number.nil?
+      self.last_digits ||= number.to_s.length <= 4 ? number : number.to_s.slice(-4..-1)
     end
 
     # cheap hack to get to the type? method from deep within ActiveMerchant without stomping on

--- a/core/app/models/spree/creditcard.rb
+++ b/core/app/models/spree/creditcard.rb
@@ -23,13 +23,11 @@ module Spree
     end
 
     def set_last_digits
-      unless number.nil?
-        number.to_s.gsub!(/\s/,'')
-        verification_value.to_s.gsub!(/\s/,'')
-      end
-
       # Last four digits
       self.last_digits ||= number.to_s[-4, 4]
+
+      self.number = nil
+      self.verification_value = nil
     end
 
     # cheap hack to get to the type? method from deep within ActiveMerchant without stomping on

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -1,5 +1,6 @@
 module Spree
   class Payment < ActiveRecord::Base
+    include Spree::Payment::Processing
     belongs_to :order
     belongs_to :source, :polymorphic => true, :validate => true
     belongs_to :payment_method

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -1,0 +1,150 @@
+module Spree
+  class Payment < ActiveRecord::Base
+    module Processing
+      def authorize!(credit_card)
+        gateway_action(credit_card, :authorize, :pend)
+      end
+
+      def purchase!(credit_card)
+        gateway_action(credit_card, :purchase, :success)
+      end
+
+      def capture!(credit_card)
+        return unless pending?
+        protect_from_connection_error do
+          check_environment(payment_method)
+
+          if payment_method.payment_profiles_supported?
+            # Gateways supporting payment profiles will need access to creditcard object because this stores the payment profile information
+            # so supply the authorization itself as well as the creditcard, rather than just the authorization code
+            response = payment_method.capture(payment, credit_card, options)
+          else
+            # Standard ActiveMerchant capture usage
+            response = payment_method.capture((amount * 100).round,
+                                              response_code,
+                                              options)
+          end
+
+          handle_response(response, :complete, :failure)
+        end
+      end
+
+      def void!
+        protect_from_connection_error do
+          check_environment(payment_method)
+
+          response = payment_method.void(self.response_code, gateway_options)
+          record_log payment, response
+
+          if response.success?
+            self.response_code = response.authorization
+            self.void
+          else
+            gateway_error(response)
+          end
+        end
+      end
+    end
+
+    def credit!
+      protect_from_connection_error do
+        check_environment(payment_method)
+
+        amount = credit_allowed >= order.outstanding_balance.abs ? order.outstanding_balance.abs : credit_allowed.abs
+        if payment_method.payment_profiles_supported?
+          response = payment_method.credit((amount * 100).round, self, response_code, minimal_gateway_options(payment, false))
+        else
+          response = payment_method.credit((amount * 100).round, response_code, minimal_gateway_options(payment, false))
+        end
+
+        record_response(response)
+
+        if response.success?
+          self.class.create({ :order => order,
+                              :source => self,
+                              :payment_method => payment_method,
+                              :amount => amount.abs * -1,
+                              :response_code => response.authorization,
+                              :state => 'completed' }, :without_protection => true)
+        else
+          gateway_error(response)
+        end
+      end
+    end
+
+    private
+
+    def gateway_action(credit_card, action, success_state)
+      protect_from_connection_error do
+        check_environment(payment_method)
+
+        response = payment_method.send(action, (amount * 100).round,
+                                       credit_card,
+                                       gateway_options)
+        handle_response(response, success_state, :failure)
+      end
+    end
+
+    def handle_response(response, success_state, failure_state)
+      record_response(response)
+
+      if response.success?
+        self.response_code = response.authorization
+        self.send(success_state)
+      else
+        self.send(failure_state)
+        gateway_error(response)
+      end
+    end
+
+    def gateway_options
+      options = { :email    => order.email,
+        :customer => order.email,
+        :ip       => order.ip_address,
+        :order_id => order.number }
+
+      if totals
+        options.merge!({ :shipping => order.ship_total * 100,
+                       :tax      => order.tax_total * 100,
+                       :subtotal => order.item_total * 100 })
+      end
+
+      options.merge({ :billing_address  => order.bill_address.try(:active_merchant_hash),
+                    :shipping_address => order.ship_address.try(:active_merchant_hash) })
+    end
+
+    def protect_from_connection_error
+      begin
+        yield
+      rescue ActiveMerchant::ConnectionError => e
+        gateway_error(e)
+      end
+    end
+
+    def record_log(response)
+      log_entries.create({:details => response.to_yaml}, :without_protection => true)
+    end
+
+    def gateway_error(error)
+      if error.is_a? ActiveMerchant::Billing::Response
+        text = error.params['message'] || error.params['response_reason_text'] || error.message
+      elsif error.is_a? ActiveMerchant::ConnectionError
+        text = I18n.t(:unable_to_connect_to_gateway)
+      else
+        text = error.to_s
+      end
+      logger.error(I18n.t(:gateway_error))
+      logger.error("  #{error.to_yaml}")
+      raise Core::GatewayError.new(text)
+    end
+
+    # Saftey check to make sure we're not accidentally performing operations on a live gateway.
+    # Ex. When testing in staging environment with a copy of production data.
+    def check_environment(gateway)
+      return if gateway.environment == Rails.env
+      message = I18n.t(:gateway_config_unavailable) + " - #{Rails.env}"
+      raise Core::GatewayError.new(message)
+    end
+
+  end
+end

--- a/core/spec/models/creditcard_spec.rb
+++ b/core/spec/models/creditcard_spec.rb
@@ -36,12 +36,12 @@ describe Spree::Creditcard do
 
   context "#process!" do
     it "should purchase if with auto_capture" do
-      Spree::Config.stub("[]").and_return(true)
+      Spree::Config[:auto_capture] = true
       @creditcard.should_receive(:purchase)
       @creditcard.process!(@payment)
     end
     it "should authorize without auto_capture" do
-      Spree::Config.stub("[]").and_return(false)
+      Spree::Config[:auto_capture] = false
       @creditcard.should_receive(:authorize)
       @creditcard.process!(@payment)
     end

--- a/core/spec/models/creditcard_spec.rb
+++ b/core/spec/models/creditcard_spec.rb
@@ -12,10 +12,11 @@ describe Spree::Creditcard do
     Rails.stub(:env => ActiveSupport::StringInquirer.new(environment))
   end
 
+  let(:creditcard) { Spree::Creditcard.new }
+
   before(:each) do
 
     @order = Factory(:order)
-    @creditcard = Spree::Creditcard.new
     @payment = Spree::Payment.create({:amount => 100, :order => @order}, :without_protection => true)
 
     @success_response = mock('gateway_response', :success? => true, :authorization => '123', :avs_result => {'code' => 'avs-code'})
@@ -33,330 +34,6 @@ describe Spree::Creditcard do
 
     @payment.stub :payment_method => @payment_gateway
   end
-
-  context "#process!" do
-    it "should purchase if with auto_capture" do
-      Spree::Config[:auto_capture] = true
-      @creditcard.should_receive(:purchase)
-      @creditcard.process!(@payment)
-    end
-    it "should authorize without auto_capture" do
-      Spree::Config[:auto_capture] = false
-      @creditcard.should_receive(:authorize)
-      @creditcard.process!(@payment)
-    end
-  end
-
-  context "#authorize" do
-    it "should call authorize on the gateway with the payment amount" do
-      @payment_gateway.should_receive(:authorize).with(10000, @creditcard, anything)
-      @creditcard.authorize(100, @payment)
-    end
-
-    it "should log the response" do
-      @payment.log_entries.should_receive(:create).with({:details => anything}, {:without_protection => true})
-      @creditcard.authorize(100, @payment)
-    end
-
-    context "when gateway does not match the environment" do
-      it "should raise an exception" do
-        @payment_gateway.stub :environment => "foo"
-        lambda {@creditcard.authorize(100, @payment)}.should raise_error(Spree::Core::GatewayError)
-      end
-    end
-
-    context "if sucesssful" do
-      it "should store the response_code and avs_response" do
-        @creditcard.authorize(100, @payment)
-        @payment.response_code.should == '123'
-        @payment.avs_response.should == 'avs-code'
-      end
-      it "should make payment pending" do
-        @payment.should_receive(:pend)
-        @creditcard.authorize(100, @payment)
-      end
-    end
-    context "if unsucessfull" do
-      it "should make payment failed" do
-        @payment_gateway.stub(:authorize).and_return(@fail_response)
-        @payment.should_receive(:failure)
-        @payment.should_not_receive(:pend)
-        lambda{
-          @creditcard.authorize(100, @payment)
-        }.should raise_error(Spree::Core::GatewayError)
-      end
-    end
-  end
-
-  context "#purchase" do
-    it "should call purchase on the gateway with the payment amount" do
-     @payment_gateway.should_receive(:purchase).with(10000, @creditcard, anything)
-     @creditcard.purchase(100, @payment)
-    end
-    it "should log the response" do
-     @payment.log_entries.should_receive(:create).with({:details => anything}, {:without_protection => true})
-     @creditcard.purchase(100, @payment)
-    end
-    context "when gateway does not match the environment" do
-     it "should raise an exception" do
-       @payment_gateway.stub :environment => "foo"
-       lambda {@creditcard.purchase(100, @payment)}.should raise_error(Spree::Core::GatewayError)
-     end
-    end
-    context "if sucessfull" do
-     before do
-       @payment_gateway.stub(:purchase).and_return(@success_response)
-     end
-     it "should store the response_code and avs_response" do
-       @creditcard.purchase(100, @payment)
-       @payment.response_code.should == '123'
-       @payment.avs_response.should == 'avs-code'
-     end
-     it "should make payment complete" do
-       @payment.should_receive(:complete)
-       @creditcard.purchase(100, @payment)
-     end
-    end
-    context "if unsucessfull" do
-     it "should make payment failed" do
-       @payment_gateway.stub(:purchase).and_return(@fail_response)
-       @payment.should_receive(:failure)
-       @payment.should_not_receive(:pend)
-       lambda{
-         @creditcard.purchase(100, @payment)
-       }.should raise_error(Spree::Core::GatewayError)
-     end
-    end
-  end
-
-  context "#capture" do
-    before do
-     @payment.stub(:complete).and_return(true)
-    end
-    context "when payment is pending" do
-      before do
-        @payment.state = 'pending'
-      end
-      it "should call capture on the gateway with the self as the authorization" do
-        @payment_gateway.should_receive(:capture).with(@payment, @creditcard, anything)
-        @creditcard.capture(@payment)
-      end
-      it "should not pass subtotal" do
-        @order.stub :item_total => 90
-        @payment_gateway.should_not_receive(:capture).with(@payment, @creditcard,
-                                                           hash_including(:subtotal => 9000))
-        @creditcard.capture(@payment)
-      end
-      it "should not pass shipping" do
-        @order.stub :ship_total => 5
-        @payment_gateway.should_not_receive(:capture).with(@payment, @creditcard,
-                                                           hash_including(:shipping => 500))
-        @creditcard.capture(@payment)
-      end
-      it "should not pass tax" do
-        @order.stub :tax_total => 5
-        @payment_gateway.should_not_receive(:capture).with(@payment, @creditcard,
-                                                           hash_including(:tax=> 500))
-        @creditcard.capture(@payment)
-      end
-      it "should log the response" do
-        @payment.log_entries.should_receive(:create).with({:details => anything}, {:without_protection => true})
-        @creditcard.capture(@payment)
-      end
-      context "when gateway does not match the environment" do
-       it "should raise an exception" do
-         @payment_gateway.stub :environment => "foo"
-         lambda {@creditcard.capture(@payment)}.should raise_error(Spree::Core::GatewayError)
-       end
-      end
-      context "if sucessfull" do
-       it "should make payment complete" do
-         @payment.should_receive(:complete)
-         @creditcard.capture(@payment)
-       end
-       it "should store the response_code" do
-         @creditcard.capture(@payment)
-         @payment.response_code.should == '123'
-       end
-      end
-      context "if unsucessfull" do
-       it "should not make payment complete" do
-         @payment_gateway.stub(:capture).and_return(@fail_response)
-         @payment.should_receive(:failure)
-         @payment.should_not_receive(:complete)
-         lambda{
-           @creditcard.capture(@payment)
-         }.should raise_error(Spree::Core::GatewayError)
-       end
-      end
-    end
-    context "when payment is not pending" do
-      before do
-        @payment.state = 'checkout'
-      end
-      it "should not call capture on the gateway" do
-        @payment_gateway.should_not_receive(:capture).with(@payment, @creditcard, anything)
-        @creditcard.capture(@payment)
-      end
-    end
-  end
-
-  context "#void" do
-    before do
-      @payment.response_code = '123'
-      @payment.state = 'pending'
-    end
-    it "should call payment_gateway.void with the payment's response_code" do
-      @payment_gateway.should_receive(:void).with('123', anything)
-      @creditcard.void(@payment)
-    end
-    it "should not pass subtotal" do
-      @order.stub :item_total => 90
-      @payment_gateway.should_not_receive(:void).with('123', hash_including(:subtotal => 9000))
-      @creditcard.void(@payment)
-    end
-    it "should not pass shipping" do
-      @order.stub :ship_total => 5
-      @payment_gateway.should_not_receive(:void).with('123', hash_including(:shipping => 500))
-      @creditcard.void(@payment)
-    end
-    it "should not pass tax" do
-      @order.stub :tax_total => 5
-      @payment_gateway.should_not_receive(:void).with('123', hash_including(:tax=> 500))
-      @creditcard.void(@payment)
-    end
-    it "should log the response" do
-      @payment.log_entries.should_receive(:create).with({:details => anything}, {:without_protection => true})
-      @creditcard.void(@payment)
-    end
-    context "when gateway does not match the environment" do
-      it "should raise an exception" do
-        @payment_gateway.stub :environment => "foo"
-        lambda {@creditcard.void(@payment)}.should raise_error(Spree::Core::GatewayError)
-      end
-    end
-    context "if sucessfull" do
-      it "should update the response_code with the authorization from the gateway" do
-        @payment.response_code = 'abc'
-        @creditcard.void(@payment)
-        @payment.response_code.should == '123'
-      end
-      it "should void the payment" do
-        @creditcard.should_receive(:void)
-        @creditcard.void(@payment)
-      end
-    end
-    context "if unsucesfull" do
-      it "should not void the payment" do
-        @payment_gateway.stub(:void).and_return(@fail_response)
-        @payment.should_not_receive(:void)
-        lambda {
-          @creditcard.void(@payment)
-        }.should raise_error(Spree::Core::GatewayError)
-      end
-    end
-  end
-
-  context "#credit" do
-    before do
-      @payment.state = 'complete'
-      @payment.response_code = '123'
-      @payment.stub(:order).and_return(@order)
-    end
-
-    context "when outstanding_balance is less than payment amount" do
-      before {  @order.stub :outstanding_balance => 10 }
-
-      it "should call credit on the gateway with the credit amount and response_code" do
-        @payment_gateway.should_receive(:credit).with(1000, @creditcard, '123', anything)
-        @creditcard.credit(@payment)
-      end
-      it "should not pass subtotal" do
-        @order.stub :item_total => 90
-        @payment_gateway.should_not_receive(:credit).with(1000, @creditcard, '123',
-                                                          hash_including(:subtotal => 9000))
-        @creditcard.credit(@payment)
-      end
-      it "should not pass shipping" do
-        @order.stub :ship_total => 5
-        @payment_gateway.should_not_receive(:credit).with(1000, @creditcard, '123',
-                                                          hash_including(:shipping => 500))
-        @creditcard.credit(@payment)
-      end
-      it "should not pass tax" do
-        @order.stub :tax_total => 5
-        @payment_gateway.should_not_receive(:credit).with(1000, @creditcard, '123',
-                                                          hash_including(:tax => 500))
-        @creditcard.credit(@payment)
-      end
-    end
-
-    context "when outstanding_balance is equal to payment amount" do
-      before { @order.stub :outstanding_balance => 100 }
-
-      it "should call credit on the gateway with the credit amount and response_code" do
-        @payment_gateway.should_receive(:credit).with(10000, @creditcard, '123', anything)
-        @creditcard.credit(@payment)
-      end
-    end
-
-    context "when outstanding_balance is greater than payment amount" do
-      before {  @order.stub :outstanding_balance => 101 }
-
-      it "should call credit on the gateway with the original payment amount and response_code" do
-        @payment_gateway.should_receive(:credit).with(10000, @creditcard, '123', anything)
-        @creditcard.credit(@payment)
-      end
-    end
-
-    it "should log the response" do
-      @payment.log_entries.should_receive(:create).with({:details => anything}, {:without_protection => true})
-      @creditcard.credit(@payment)
-    end
-
-    context "when gateway does not match the environment" do
-      it "should raise an exception" do
-        @payment_gateway.stub :environment => "foo"
-        lambda {@creditcard.credit(@payment)}.should raise_error(Spree::Core::GatewayError)
-      end
-    end
-
-    context "when response is sucesssful" do
-      it "should create an offsetting payment" do
-        Spree::Payment.should_receive(:create)
-        @creditcard.credit(@payment)
-      end
-      context "resulting payment" do
-        before do
-          @order.stub :outstanding_balance => 10
-          @offsetting_payment = @creditcard.credit(@payment)
-        end
-        it "should be the supplied amount" do
-          @offsetting_payment.amount.should == -10
-        end
-        it "should be in the complete state" do
-          @offsetting_payment.should be_completed
-        end
-        it "has response_code from the transaction" do
-          @offsetting_payment.response_code.should == '123'
-        end
-        it "has original payment as its source" do
-          @offsetting_payment.source.should == @payment
-        end
-      end
-    end
-    context "when response is unsucessfull" do
-      it "should not create a payment" do
-        @payment_gateway.stub(:credit).and_return(@fail_response)
-        Spree::Payment.should_not_receive(:create)
-        lambda {
-          @creditcard.credit(@payment)
-        }.should raise_error(Spree::Core::GatewayError)
-      end
-    end
-  end
-
-  let(:creditcard) { Spree::Creditcard.new }
 
   context "#can_capture?" do
     it "should be true if payment state is pending" do
@@ -441,44 +118,42 @@ describe Spree::Creditcard do
 
   context "#valid?" do
     it "should validate presence of number" do
-      @creditcard.attributes = valid_creditcard_attributes.except(:number)
-      @creditcard.should_not be_valid
-      @creditcard.errors[:number].should == ["can't be blank"]
+      creditcard.attributes = valid_creditcard_attributes.except(:number)
+      creditcard.should_not be_valid
+      creditcard.errors[:number].should == ["can't be blank"]
     end
 
     it "should validate presence of security code" do
-      @creditcard.attributes = valid_creditcard_attributes.except(:verification_value)
-      @creditcard.should_not be_valid
-      @creditcard.errors[:verification_value].should == ["can't be blank"]
+      creditcard.attributes = valid_creditcard_attributes.except(:verification_value)
+      creditcard.should_not be_valid
+      creditcard.errors[:verification_value].should == ["can't be blank"]
     end
 
     it "should only validate on create" do
-      @creditcard.attributes = valid_creditcard_attributes
-      @creditcard.save
-      @creditcard = Spree::Creditcard.find(@creditcard.id)
-      @creditcard.should be_valid
+      creditcard.attributes = valid_creditcard_attributes
+      creditcard.save
+      creditcard.should be_valid
     end
   end
 
   context "#save" do
     before do
-      @creditcard.attributes = valid_creditcard_attributes
-      @creditcard.save
-      @creditcard = Spree::Creditcard.find(@creditcard.id)
+      creditcard.attributes = valid_creditcard_attributes
+      creditcard.save
     end
 
     it "should not actually store the number" do
-      @creditcard.number.should be_blank
+      creditcard.number.should be_blank
     end
 
-    it "should not actually store the security code"  do
-      @creditcard.verification_value.should be_blank
+    it "should not actually store the security code" do
+      creditcard.verification_value.should be_blank
     end
   end
 
   context "#spree_cc_type" do
     before do
-      @creditcard.attributes = valid_creditcard_attributes
+      creditcard.attributes = valid_creditcard_attributes
     end
 
     context "in development mode" do
@@ -487,8 +162,8 @@ describe Spree::Creditcard do
       end
 
       it "should return visa" do
-        @creditcard.save
-        @creditcard.spree_cc_type.should == "visa"
+        creditcard.save
+        creditcard.spree_cc_type.should == "visa"
       end
     end
 
@@ -498,9 +173,9 @@ describe Spree::Creditcard do
       end
 
       it "should return the actual cc_type for a valid number" do
-        @creditcard.number = "378282246310005"
-        @creditcard.save
-        @creditcard.spree_cc_type.should == "american_express"
+        creditcard.number = "378282246310005"
+        creditcard.save
+        creditcard.spree_cc_type.should == "american_express"
       end
     end
   end
@@ -508,21 +183,21 @@ describe Spree::Creditcard do
   context "#set_card_type" do
     before :each do
       stub_rails_env("production")
-      @creditcard.attributes = valid_creditcard_attributes
+      creditcard.attributes = valid_creditcard_attributes
     end
 
     it "stores the creditcard type after validation" do
-      @creditcard.number = "6011000990139424"
-      @creditcard.save
-      @creditcard.spree_cc_type.should == "discover"
+      creditcard.number = "6011000990139424"
+      creditcard.save
+      creditcard.spree_cc_type.should == "discover"
     end
 
     it "does not overwrite the creditcard type when loaded and saved" do
-      @creditcard.number = "5105105105105100"
-      @creditcard.save
-      @creditcard.number = "XXXXXXXXXXXX5100"
-      @creditcard.save
-      @creditcard.spree_cc_type.should == "master"
+      creditcard.number = "5105105105105100"
+      creditcard.save
+      creditcard.number = "XXXXXXXXXXXX5100"
+      creditcard.save
+      creditcard.spree_cc_type.should == "master"
     end
   end
 end

--- a/core/spec/models/creditcard_spec.rb
+++ b/core/spec/models/creditcard_spec.rb
@@ -65,7 +65,7 @@ describe Spree::Creditcard do
       end
     end
 
-    context "if sucesssfull" do
+    context "if sucesssful" do
       it "should store the response_code and avs_response" do
         @creditcard.authorize(100, @payment)
         @payment.response_code.should == '123'

--- a/core/spec/models/creditcard_spec.rb
+++ b/core/spec/models/creditcard_spec.rb
@@ -140,6 +140,7 @@ describe Spree::Creditcard do
     before do
       creditcard.attributes = valid_creditcard_attributes
       creditcard.save
+      creditcard.reload
     end
 
     it "should not actually store the number" do

--- a/core/spec/models/payment_spec.rb
+++ b/core/spec/models/payment_spec.rb
@@ -6,115 +6,421 @@ describe Spree::Payment do
     it { should have_valid_factory(:payment) }
   end
 
-  let(:order) { mock_model(Spree::Order, :update! => nil, :payments => []) }
-  let(:gateway) { Spree::Gateway::Bogus.new({:environment => 'test', :active => true}, :without_protection => true) }
-  let(:card) { Factory(:creditcard) }
-
-  before(:each) do
-    @payment = Spree::Payment.new({:order => order}, :without_protection => true)
-    @payment.payment_method = stub_model(Spree::PaymentMethod)
-    @payment.payment_method.stub(:source_required? => true)
-    @payment.source = mock_model(Spree::Creditcard, :save => true, :payment_gateway => nil, :process => nil, :credit => nil, :changed_for_autosave? => false)
-    @payment.stub!(:valid?).and_return(true)
-    @payment.stub!(:check_payments).and_return(nil)
-
-    order.payments.stub!(:reload).and_return([@payment])
+  let(:order) do
+    order = Spree::Order.new(:bill_address => Spree::Address.new,
+                             :ship_address => Spree::Address.new)
   end
 
-  context "#process!" do
+  let(:gateway) do
+    gateway = Spree::Gateway::Bogus.new({:environment => 'test', :active => true}, :without_protection => true)
+    gateway.stub :source_required => true
+    gateway
+  end
 
-    context "when state is checkout" do
-      before(:each) do
-        @payment.source.stub!(:process!).and_return(nil)
+  let(:card) do
+    mock_model(Spree::Creditcard, :number => "4111111111111111",
+                                  :has_payment_profile? => true)
+  end
+
+  let(:payment) do
+    payment = Spree::Payment.new
+    payment.source = card
+    payment.order = order
+    payment.payment_method = gateway
+    payment
+  end
+
+  let(:amount_in_cents) { payment.amount.to_f * 100 }
+
+  let!(:success_response) do
+    mock('success_response', :success? => true,
+                             :authorization => '123',
+                             :avs_result => { 'code' => 'avs-code' })
+  end
+
+  let(:failed_response) { mock('gateway_response', :success? => false) }
+
+  before(:each) do
+    # So it doesn't create log entries every time a processing method is called
+    payment.log_entries.stub(:create)
+  end
+
+  context "processing" do
+    before do
+      payment.stub(:update_order)
+      payment.stub(:create_payment_profile)
+    end
+
+    context "#process!" do
+      it "should purchase if with auto_capture" do
+        Spree::Config[:auto_capture] = true
+        payment.should_receive(:purchase!)
+        payment.process!
       end
-      it "should process the source" do
-        @payment.source.should_receive(:process!)
-        @payment.process!
+
+      it "should authorize without auto_capture" do
+        Spree::Config[:auto_capture] = false
+        payment.should_receive(:authorize!)
+        payment.process!
       end
+
       it "should make the state 'processing'" do
-        @payment.process!
-        @payment.should be_processing
+        payment.should_receive(:started_processing!)
+        payment.process!
       end
+
     end
 
-    context "when already processing" do
-      before(:each) { @payment.state = 'processing' }
-      it "should return nil without trying to process the source" do
-        @payment.source.should_not_receive(:process!)
-        @payment.process!.should == nil
+    context "#authorize" do
+      it "should call authorize on the gateway with the payment amount" do
+        payment.payment_method.should_receive(:authorize).with(amount_in_cents,
+                                                               card,
+                                                               anything).and_return(success_response)
+        payment.authorize!
       end
-    end
 
+      it "should log the response" do
+        payment.log_entries.should_receive(:create).with({:details => anything}, {:without_protection => true})
+        payment.authorize!
+      end
 
-    context "with source required" do
-      context "raises an error if no source is specified" do
+      context "when gateway does not match the environment" do
+        it "should raise an exception" do
+          gateway.stub :environment => "foo"
+          lambda { payment.authorize! }.should raise_error(Spree::Core::GatewayError)
+        end
+      end
+
+      context "if sucesssful" do
         before do
-          @payment.source = nil
+          payment.payment_method.should_receive(:authorize).with(amount_in_cents,
+                                                                 card,
+                                                                 anything).and_return(success_response)
         end
 
-        specify do
-          lambda { @payment.process! }.should raise_error(Spree::Core::GatewayError, I18n.t(:payment_processing_failed))
+        it "should store the response_code and avs_response" do
+          payment.authorize!
+          payment.response_code.should == '123'
+          payment.avs_response.should == 'avs-code'
+        end
+
+        it "should make payment pending" do
+          payment.should_receive(:pend)
+          payment.authorize!
+        end
+      end
+
+      context "if unsucessful" do
+        it "should mark payment as failed" do
+          gateway.stub(:authorize).and_return(failed_response)
+          payment.should_receive(:failure)
+          payment.should_not_receive(:pend)
+          lambda {
+            payment.authorize!
+          }.should raise_error(Spree::Core::GatewayError)
         end
       end
     end
 
-    context "with source optional" do
-      context "raises no error if source is not specified" do
+    context "purchase" do
+      it "should call purchase on the gateway with the payment amount" do
+        gateway.should_receive(:purchase).with(amount_in_cents, card, anything).and_return(success_response)
+        payment.purchase!
+      end
+
+      it "should log the response" do
+        payment.log_entries.should_receive(:create).with({:details => anything}, {:without_protection => true})
+        payment.purchase!
+      end
+
+      context "when gateway does not match the environment" do
+        it "should raise an exception" do
+          gateway.stub :environment => "foo"
+          lambda { payment.purchase!  }.should raise_error(Spree::Core::GatewayError)
+        end
+      end
+
+      context "if sucessfull" do
         before do
-          @payment.source = nil
-          @payment.payment_method.stub(:source_required? => false)
+          payment.payment_method.should_receive(:purchase).with(amount_in_cents,
+                                                                card,
+                                                               anything).and_return(success_response)
         end
 
-        specify do
-          lambda { @payment.process! }.should_not raise_error(Spree::Core::GatewayError)
+        it "should store the response_code and avs_response" do
+          payment.purchase!
+          payment.response_code.should == '123'
+          payment.avs_response.should == 'avs-code'
+        end
+
+        it "should make payment complete" do
+          payment.should_receive(:complete)
+          payment.purchase!
+        end
+      end
+
+      context "if unsucessfull" do
+        it "should make payment failed" do
+          gateway.stub(:purchase).and_return(failed_response)
+          payment.should_receive(:failure)
+          payment.should_not_receive(:pend)
+          lambda { payment.purchase! }.should raise_error(Spree::Core::GatewayError)
         end
       end
     end
 
+    context "#capture" do
+      before do
+        payment.stub(:complete).and_return(true)
+      end
+
+      context "when payment is pending" do
+        before do
+          payment.state = 'pending'
+        end
+
+        it "should not do anything" do
+          payment.payment_method.should_not_receive(:capture)
+          payment.log_entries.should_not_receive(:create)
+        end
+
+        context "if sucessful" do
+          before do
+            payment.payment_method.should_receive(:capture).with(payment, card, anything).and_return(success_response)
+          end
+
+          it "should make payment complete" do
+            payment.should_receive(:complete)
+            payment.capture!
+          end
+
+          it "should store the response_code" do
+            gateway.stub :capture => success_response
+            payment.capture!
+            payment.response_code.should == '123'
+          end
+        end
+
+        context "if unsucessful" do
+          it "should not make payment complete" do
+            gateway.stub :capture => failed_response
+            payment.should_receive(:failure)
+            payment.should_not_receive(:complete)
+            lambda { payment.capture! }.should raise_error(Spree::Core::GatewayError)
+          end
+        end
+      end
+
+      context "when payment is not pending" do
+        before do
+          payment.state = 'checkout'
+        end
+
+        it "should not call capture on the gateway" do
+          gateway.should_not_receive(:capture).with(payment, card, anything)
+          payment.capture!
+        end
+      end
+    end
+
+    context "#void" do
+      before do
+        payment.response_code = '123'
+        payment.state = 'pending'
+      end
+
+      it "should call payment_gateway.void with the payment's response_code" do
+        gateway.should_receive(:void).with('123', anything).and_return(success_response)
+        payment.void_transaction!
+      end
+
+      it "should log the response" do
+        payment.log_entries.should_receive(:create).with({:details => anything}, {:without_protection => true})
+        payment.void_transaction!
+      end
+
+      context "when gateway does not match the environment" do
+        it "should raise an exception" do
+          gateway.stub :environment => "foo"
+          lambda { payment.void_transaction! }.should raise_error(Spree::Core::GatewayError)
+        end
+      end
+
+      context "if sucessfull" do
+        it "should update the response_code with the authorization from the gateway" do
+          # Change it to something different
+          payment.response_code = 'abc'
+          payment.void_transaction!
+          payment.response_code.should == '12345'
+        end
+      end
+
+      context "if unsucesful" do
+        it "should not void the payment" do
+          gateway.stub :void => failed_response
+          payment.should_not_receive(:void)
+          lambda { payment.void_transaction! }.should raise_error(Spree::Core::GatewayError)
+        end
+      end
+    end
+
+    context "#credit" do
+      before do
+        payment.state = 'complete'
+        payment.response_code = '123'
+      end
+
+      context "when outstanding_balance is less than payment amount" do
+        before do
+          payment.order.stub :outstanding_balance => 10
+          payment.stub :credit_allowed => 1000
+        end
+
+        it "should call credit on the gateway with the credit amount and response_code" do
+          gateway.should_receive(:credit).with(1000, card, '123', anything).and_return(success_response)
+          payment.credit!
+        end
+      end
+
+      context "when outstanding_balance is equal to payment amount" do
+        before do
+          payment.order.stub :outstanding_balance => payment.amount
+        end
+
+        it "should call credit on the gateway with the credit amount and response_code" do
+          gateway.should_receive(:credit).with(amount_in_cents, card, '123', anything).and_return(success_response)
+          payment.credit!
+        end
+      end
+
+      context "when outstanding_balance is greater than payment amount" do
+        before do
+          payment.order.stub :outstanding_balance => 101
+        end
+
+        it "should call credit on the gateway with the original payment amount and response_code" do
+          gateway.should_receive(:credit).with(amount_in_cents.to_f, card, '123', anything).and_return(success_response)
+          payment.credit!
+        end
+      end
+
+      it "should log the response" do
+        payment.log_entries.should_receive(:create).with({:details => anything}, {:without_protection => true})
+        payment.credit!
+      end
+
+      context "when gateway does not match the environment" do
+        it "should raise an exception" do
+          gateway.stub :environment => "foo"
+          lambda { payment.credit! }.should raise_error(Spree::Core::GatewayError)
+        end
+      end
+
+      context "when response is sucesssful" do
+        it "should create an offsetting payment" do
+          Spree::Payment.should_receive(:create)
+          payment.credit!
+        end
+
+        it "resulting payment should have correct values" do
+          payment.order.stub :outstanding_balance => 100
+          payment.stub :credit_allowed => 10
+
+          offsetting_payment = payment.credit!
+          offsetting_payment.amount.to_f.should == -10
+          offsetting_payment.should be_completed
+          offsetting_payment.response_code.should == '12345'
+          offsetting_payment.source.should == payment
+        end
+      end
+    end
+  end
+
+  context "when response is unsucessful" do
+    it "should not create a payment" do
+      gateway.stub :credit => failed_response
+      Spree::Payment.should_not_receive(:create)
+      lambda { payment.credit! }.should raise_error(Spree::Core::GatewayError)
+    end
+  end
+
+  context "when already processing" do
+    it "should return nil without trying to process the source" do
+      payment.state = 'processing'
+
+      payment.should_not_receive(:authorize!)
+      payment.should_not_receive(:purchase!)
+      payment.process!.should == nil
+    end
+  end
+
+  context "with source required" do
+    context "raises an error if no source is specified" do
+      before do
+        payment.source = nil
+      end
+
+      specify do
+        lambda { payment.process! }.should raise_error(Spree::Core::GatewayError, I18n.t(:payment_processing_failed))
+      end
+    end
+  end
+
+  context "with source optional" do
+    context "raises no error if source is not specified" do
+      before do
+        payment.source = nil
+        payment.payment_method.stub(:source_required? => false)
+      end
+
+      specify do
+        lambda { payment.process! }.should_not raise_error(Spree::Core::GatewayError)
+      end
+    end
   end
 
   context "#credit_allowed" do
     it "is the difference between offsets total and payment amount" do
-      @payment.amount = 100
-      @payment.stub(:offsets_total).and_return(0)
-      @payment.credit_allowed.should == 100
-      @payment.stub(:offsets_total).and_return(80)
-      @payment.credit_allowed.should == 20
+      payment.amount = 100
+      payment.stub(:offsets_total).and_return(0)
+      payment.credit_allowed.should == 100
+      payment.stub(:offsets_total).and_return(80)
+      payment.credit_allowed.should == 20
     end
   end
 
   context "#can_credit?" do
     it "is true if credit_allowed > 0" do
-      @payment.stub(:credit_allowed).and_return(100)
-      @payment.can_credit?.should be_true
+      payment.stub(:credit_allowed).and_return(100)
+      payment.can_credit?.should be_true
     end
     it "is false if credit_allowed is 0" do
-      @payment.stub(:credit_allowed).and_return(0)
-      @payment.can_credit?.should be_false
+      payment.stub(:credit_allowed).and_return(0)
+      payment.can_credit?.should be_false
     end
   end
 
   context "#credit" do
     context "when amount <= credit_allowed" do
       it "makes the state processing" do
-        @payment.state = 'completed'
-        @payment.stub(:credit_allowed).and_return(10)
-        @payment.credit(10)
-        @payment.should be_processing
+        payment.state = 'completed'
+        payment.stub(:credit_allowed).and_return(10)
+        payment.partial_credit(10)
+        payment.should be_processing
       end
       it "calls credit on the source with the payment and amount" do
-        @payment.state = 'completed'
-        @payment.stub(:credit_allowed).and_return(10)
-        @payment.source.should_receive(:credit).with(@payment, 10)
-        @payment.credit(10)
+        payment.state = 'completed'
+        payment.stub(:credit_allowed).and_return(10)
+        payment.should_receive(:credit!).with(10)
+        payment.partial_credit(10)
       end
     end
     context "when amount > credit_allowed" do
       it "should not call credit on the source" do
-        @payment.state = 'completed'
-        @payment.stub(:credit_allowed).and_return(10)
-        @payment.credit(20)
-        @payment.should be_completed
+        payment.state = 'completed'
+        payment.stub(:credit_allowed).and_return(10)
+        payment.partial_credit(20)
+        payment.should be_completed
       end
     end
   end
@@ -127,24 +433,27 @@ describe Spree::Payment do
     end
 
     context "when profiles are supported" do
-      before { gateway.stub :payment_profiles_supported? => true }
-      
+      before do
+        gateway.stub :payment_profiles_supported? => true
+        payment.source.stub :has_payment_profile? => false
+      end
+
+
       context "when there is an error connecting to the gateway" do
-        it "should call source.gateway_error " do
+        it "should call gateway_error " do
           gateway.should_receive(:create_profile).and_raise(ActiveMerchant::ConnectionError)
-          card.should_receive(:gateway_error)
-          payment = Spree::Payment.create({:amount => 100, :order => order, :source => card, :payment_method => gateway}, :without_protection => true)
+          lambda { Spree::Payment.create({:amount => 100, :order => order, :source => card, :payment_method => gateway}, :without_protection => true) }.should raise_error(Spree::Core::GatewayError)
         end
       end
-      
+
       context "when successfully connecting to the gateway" do
         it "should create a payment profile" do
-          gateway.should_receive :create_profile
+          payment.payment_method.should_receive :create_profile
           payment = Spree::Payment.create({:amount => 100, :order => order, :source => card, :payment_method => gateway}, :without_protection => true)
         end
       end
-      
-      
+
+
     end
 
     context "when profiles are not supported" do
@@ -158,10 +467,8 @@ describe Spree::Payment do
   end
 
   context "#build_source" do
-    let(:payment_method) { Factory(:bogus_payment_method) }
-
     it "should build the payment's source" do
-      params = { :amount => 100, :payment_method_id => payment_method.id,
+      params = { :amount => 100, :payment_method => gateway,
         :source_attributes => {:year=>"2012", :month =>"1", :number => '1234567890123',:verification_value => '123'}}
 
       payment = Spree::Payment.new(params, :without_protection => true)
@@ -173,7 +480,7 @@ describe Spree::Payment do
       it "should build the payment's source" do
         params = {
           :source_attributes => {:year=>"2012", :month =>"1", :number => '1234567890123',:verification_value => '123'},
-          :amount => 100, :payment_method_id => payment_method.id
+          :amount => 100, :payment_method => gateway
         }
 
         payment = Spree::Payment.new(params, :without_protection => true)
@@ -183,8 +490,8 @@ describe Spree::Payment do
     end
 
     it "errors when payment source not valid" do
-      params = { :amount => 100, :payment_method_id => payment_method.id,
-                 :source_attributes => {:year=>"2012", :month =>"1" }}
+      params = { :amount => 100, :payment_method => gateway,
+        :source_attributes => {:year=>"2012", :month =>"1" }}
 
       payment = Spree::Payment.new(params, :without_protection => true)
       payment.should_not be_valid
@@ -193,5 +500,4 @@ describe Spree::Payment do
       payment.source.should have(1).error_on(:verification_value)
     end
   end
-
 end


### PR DESCRIPTION
This commit refactors the payment methods. Mostly involves moving them out of the `Creditcard` model and into their rightful place inside the `Payment` model, via a module called `Spree::Payment::Processing`.
