### PR TITLE
TaxRate#zone_id is not set when created with Spree Admin UI

### DIFF
--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -20,7 +20,7 @@ module Spree
     calculated_adjustments
     scope :by_zone, lambda { |zone| where(:zone_id => zone) }
 
-    attr_accessible :amount, :tax_category_id, :calculator
+    attr_accessible :amount, :tax_category_id, :calculator, :zone_id
 
     # Gets the array of TaxRates appropriate for the specified order
     def self.match(order)


### PR DESCRIPTION
You can duplicate this by attempting to create a TaxRate using the Admin UI

Ruby: 1.9.3-p125
Spree: 1.1.0.rc1
Rails: 3.2.3

NoMethodError in Spree/admin/tax_rates#index

undefined method `name' for nil:NilClass
Extracted source (around line #24):

You can also use the Rails console to view the TaxRate created and will see that the TaxRate#zone_id is nil.
