### PR TITLE
Corrected an issue with ensuring there is only one default tax category

### DIFF
--- a/core/app/models/spree/tax_category.rb
+++ b/core/app/models/spree/tax_category.rb
@@ -14,7 +14,7 @@ module Spree
       #set existing default tax category to false if this one has been marked as default
 
       if is_default && tax_category = self.class.where(:is_default => true).first
-        tax_category.update_attribute(:is_default, false)
+        tax_category.update_attribute(:is_default, false) unless tax_category==self
       end
     end
 

--- a/core/spec/models/tax_category_spec.rb
+++ b/core/spec/models/tax_category_spec.rb
@@ -22,5 +22,27 @@ describe Spree::TaxCategory do
       end
     end
   end
+  context 'default tax category' do
+    let(:tax_category) { Factory(:tax_category) }
+    let(:new_tax_category) { Factory(:tax_category) }
 
+    before do
+      tax_category.update_attribute(:is_default, true)
+    end
+    
+    it "should undefault the previous default tax category" do
+      new_tax_category.update_attribute(:is_default, true)
+      new_tax_category.is_default.should be_true
+
+      tax_category.reload
+      tax_category.is_default.should be_false
+    end
+    
+    it "should undefault the previous default tax category except when updating the existing default tax category" do
+      tax_category.update_attribute(:description, "Updated description")
+      
+      tax_category.reload
+      tax_category.is_default.should be_true      
+    end    
+  end
 end


### PR DESCRIPTION
There is a callback after updating a TaxCategory that attempts to ensure that there is only a single default in the database. The issue is that if you happen to be updating the current default tax category, you will stomp it's default status (try the second test that I added to see it fails on master).

We noticed this when one of our guys updated the description on a tax category using the admin control panel and we suddenly started receiving orders without taxes applied because there was no longer a default tax category (pretty nasty!).
