### PR TITLE
Fix selective brand filter

### DIFF
--- a/core/lib/spree/product_filters.rb
+++ b/core/lib/spree/product_filters.rb
@@ -138,7 +138,7 @@ module Spree
         scope = Spree::ProductProperty.scoped(:conditions => ["property_id = ?", @@brand_property]).
                                        scoped(:joins      => {:product => :taxons},
                                               :conditions => ["#{Spree::Taxon.table_name}.id in (?)", [taxon] + taxon.descendants])
-        brands = scope.map {|p| p.value}
+        brands = scope.map {|p| p.value}.uniq
 
         { :name   => "Applicable Brands",
           :scope  => :selective_brand_any,

--- a/core/lib/spree/product_filters.rb
+++ b/core/lib/spree/product_filters.rb
@@ -135,7 +135,6 @@ module Spree
         if taxon.nil?
           taxon = Spree::Taxonomy.first.root
         end
-        all_brands = Spree::ProductProperty.where(:property_id => @@brand_property).map(&:value).uniq
         scope = Spree::ProductProperty.scoped(:conditions => ["property_id = ?", @@brand_property]).
                                        scoped(:joins      => {:product => :taxons},
                                               :conditions => ["#{Spree::Taxon.table_name}.id in (?)", [taxon] + taxon.descendants])
@@ -143,7 +142,6 @@ module Spree
 
         { :name   => "Applicable Brands",
           :scope  => :selective_brand_any,
-          :conds  => Hash[*all_brands.map {|m| [m, "p_colour.value like '%#{m}%'"]}.flatten],
           :labels => brands.sort.map {|k| [k,k]}
         }
       end

--- a/core/lib/spree/product_filters.rb
+++ b/core/lib/spree/product_filters.rb
@@ -129,7 +129,7 @@ module Spree
     #   The brand-finding code can be simplified if a few more named scopes were added to
     #   the product properties model.
     if Spree::Property.table_exists? && @@brand_property
-      Spree::Product.scope :selective_brand_any, lambda {|opts| Spree::Product.brand_any(opts) }
+      Spree::Product.scope :selective_brand_any, lambda {|*opts| Spree::Product.brand_any(*opts) }
 
       def ProductFilters.selective_brand_filter(taxon = nil)
         if taxon.nil?


### PR DESCRIPTION
This pull request fixes a few issues with the selective brand filter in core/lib/spree/product_filters.rb.
1. It raises an exception if multiple brands are selected.
2. It shows the same brand multiple times (once for each product with that brand).
3. It does a slow SQL query for selecting all brands to build a condition hash which is not used. (Btw: the conditions are broken because they use the wrong table name, so they would not work anyhow.)

These issues are fixed in individual commits so they can be cherry-picked if you do not want to apply all of them.

Because this are bugs, I created a pull request against the 1-1-stable branch, but I can rebase it against master or another branch.
