### PR TITLE
Add attr_accessible for icon field of Taxon

### DIFF
--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -6,7 +6,7 @@ module Spree
     has_and_belongs_to_many :products, :join_table => 'spree_products_taxons'
     before_create :set_permalink
 
-    attr_accessible :name, :parent_id, :position, :description, :permalink
+    attr_accessible :name, :parent_id, :position, :icon, :description, :permalink
 
     validates :name, :presence => true
     has_attached_file :icon,


### PR DESCRIPTION
In 1-1-stable, updating a taxon icon results in a mass assignment error because the icon field is not accessible.
