### PR TITLE
[1.1.0.rc2] admin/products controller sets on_hand to negative values

### DIFF
--- a/core/app/controllers/spree/admin/products_controller.rb
+++ b/core/app/controllers/spree/admin/products_controller.rb
@@ -7,6 +7,7 @@ module Spree
       before_filter :load_data, :except => :index
       create.before :create_before
       update.before :update_before
+      before_filter :remove_negative_on_hand_from_params, :only => :update
 
       def show
         redirect_to( :action => :edit )
@@ -120,6 +121,13 @@ module Spree
           return unless params[:clear_product_properties]
           params[:product] ||= {}
         end
+
+        def remove_negative_on_hand_from_params
+          if params[:product] && params[:product][:on_hand] && params[:product][:on_hand].to_i < 0
+            params[:product].delete :on_hand
+          end
+        end
+
     end
   end
 end

--- a/core/app/views/spree/admin/products/_form.html.erb
+++ b/core/app/views/spree/admin/products/_form.html.erb
@@ -102,3 +102,18 @@
     <%= render :partial => 'spree/admin/shared/additional_field', :locals => { :field => field, :f => f } %>
   <% end %>
 </div>
+
+<% content_for :head do %>
+  <%= javascript_tag do -%>
+  $(document).ready(
+    function() {
+	$('#product_on_hand').focus(function() {
+            var oldValue = $(this).val();
+            $(this).data('oldValue', oldValue);
+        });
+	$('#product_on_hand').change(function() {
+            if ($(this).val() < 0) $(this).val($(this).data('oldValue'));
+        });
+    });
+  <% end %>
+<% end %>

--- a/core/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/core/spec/controllers/spree/admin/products_controller_spec.rb
@@ -112,4 +112,18 @@ describe Spree::Admin::ProductsController do
       end
     end
   end
+
+  # regression test for #1447
+  context "update" do
+    let(:product) { Factory(:product, :on_hand => 5, :name => "old name") }
+
+    it "should remove negative on hand values from params" do
+      put :update, :id => product, :product => { :on_hand => -5, :name => "have changed" }, :use_route => :spree
+      product.reload
+
+      product.name.should    eq("have changed")
+      product.on_hand.should eq(5)
+    end
+  end
+
 end


### PR DESCRIPTION
1. admin/products/_form partial uses 'input type=number' which renders as a text input in some browsers (e.g. FireFox 11.0 on ubuntu), thus admins can submit negative on_hand values
2. admin/products_controller#update passes negative on_hand values down to the model, resulting in products with on_hand set to negative

this PR fixes both

[Fixes #1447]
