### PR TITLE
ProductProperty Accessors on Product

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -199,6 +199,22 @@ module Spree
       end
     end
 
+    def property(property_name)
+      return nil unless prop = properties.find_by_name(property_name)
+      product_properties.find_by_property_id(prop.id).try(:value)
+    end
+
+    def set_property(property_name, property_value)
+      prop = Spree::Property.find_or_initialize_by_name(property_name) do |p|
+        p.presentation = property_name
+        p.save!
+      end
+
+      prod_prop = Spree::ProductProperty.find_or_initialize_by_product_id_and_property_id(self.id, prop.id)
+      prod_prop.value = property_value
+      prod_prop.save!
+    end
+
     private
 
       # Builds variants from a hash of option types & values

--- a/core/spec/models/product_spec.rb
+++ b/core/spec/models/product_spec.rb
@@ -179,6 +179,8 @@ describe Spree::Product do
     end
 
     it "should not create duplicate properties when set_property is called" do
+      product = FactoryGirl.create :product
+      
       lambda {
         product.set_property('the_prop', 'value2')
         product.save

--- a/core/spec/models/product_spec.rb
+++ b/core/spec/models/product_spec.rb
@@ -168,6 +168,32 @@ describe Spree::Product do
 
   end
 
+  context "properties" do
+    it "should properly assign properties" do
+      product = FactoryGirl.create :product
+      product.set_property('the_prop', 'value1')
+      product.property('the_prop').should == 'value1'
+
+      product.set_property('the_prop', 'value2')
+      product.property('the_prop').should == 'value2'      
+    end
+
+    it "should not create duplicate properties when set_property is called" do
+      lambda {
+        product.set_property('the_prop', 'value2')
+        product.save
+        product.reload
+      }.should_not change(product.properties, :length)
+
+      lambda {
+        product.set_property('the_prop_new', 'value')
+        product.save
+        product.reload
+        product.property('the_prop_new').should == 'value'
+      }.should change { product.properties.length }.by(1)
+    end
+  end
+
   context '#create' do
     before do
       @prototype = Factory(:prototype)


### PR DESCRIPTION
I've had to deal with product properties for integration with an external inventory / product list system we are using, and I found dealing with creating, settings, and retrieving product property values a bit cumbersome.

I'm a bit weak on the nuances of how ActiveRecord handles reloading associations, thus the possibly overuse of `save`.

I have some tests I can cleanup and add to the test suite if this seems like a useful feature to add.
