### PR TITLE
Remove duplicate attr_accessible :attachment declaration and fix broken ...

### DIFF
--- a/core/app/models/spree/image.rb
+++ b/core/app/models/spree/image.rb
@@ -3,7 +3,7 @@ module Spree
     validates_attachment_presence :attachment
     validate :no_attachment_errors
 
-    attr_accessible :attachment, :alt, :viewable_id
+    attr_accessible :alt, :attachment, :position, :viewable_id
 
     has_attached_file :attachment,
                       :styles => { :mini => '48x48>', :small => '100x100>', :product => '240x240>', :large => '600x600>' },
@@ -13,8 +13,6 @@ module Spree
     # save the w,h of the original image (from which others can be calculated)
     # we need to look at the write-queue for images which have not been saved yet
     after_post_process :find_dimensions
-
-    attr_accessible :attachment, :position
 
     # Load user defined paperclip settings
     if Spree::Config[:use_s3]

--- a/core/spec/models/product_spec.rb
+++ b/core/spec/models/product_spec.rb
@@ -297,8 +297,8 @@ describe Spree::Product do
     let(:product) { Factory(:product) }
 
     before do
-      Spree::Image.create!(:viewable => product, :alt => "position 2", :position => 2)
-      Spree::Image.create!(:viewable => product, :alt => "position 1", :position => 1)
+      Spree::Image.create!(:viewable_id => product.id, :alt => "position 2", :attachment => File.open(File.expand_path('../../../app/assets/images/noimage/product.png', __FILE__)), :position => 2)
+      Spree::Image.create!(:viewable_id => product.id, :alt => "position 1", :attachment => File.open(File.expand_path('../../../app/assets/images/noimage/product.png', __FILE__)), :position => 1)
     end
 
     it "should be sorted by position" do


### PR DESCRIPTION
...spec.

Was removing the duplicate attr_accessible :attachment declaration and noticed a broken spec, which I've also fixed.
