### PR TITLE
images, variants and option_types dragged and dropped TRs do not go above table THs

### DIFF
--- a/core/app/views/spree/admin/images/index.html.erb
+++ b/core/app/views/spree/admin/images/index.html.erb
@@ -12,6 +12,7 @@
     <th><%= t(:action) %></th>
   </tr>
 
+  <tbody>
   <% @product.images.each do |image| %>
     <tr id="<%= spree_dom_id image %>" data-hook="images_row">
       <td>
@@ -46,6 +47,7 @@
       </tr>
     <% end %>
   <% end %>
+  </tbody>
 </table>
 
 <div id="images" data-hook></div>

--- a/core/app/views/spree/admin/option_types/index.html.erb
+++ b/core/app/views/spree/admin/option_types/index.html.erb
@@ -19,6 +19,7 @@
     <th><%= t(:presentation) %></th>
     <th></th>
   </tr>
+  <tbody>
   <% @option_types.each do |option_type| %>
     <tr class="spree_option_type" id="<%= spree_dom_id option_type %>" data-hook="option_row">
       <td><span class="handle"></span> <%= option_type.name %></td>
@@ -30,4 +31,5 @@
       </td>
     </tr>
   <% end %>
+  </tbody>
 </table>

--- a/core/app/views/spree/admin/variants/index.html.erb
+++ b/core/app/views/spree/admin/variants/index.html.erb
@@ -13,6 +13,7 @@
     <th><%= t(:on_hand) %></th>
     <th><%= t(:action) %></th>
   </tr>
+  <tbody>
   <% @variants.each do |variant| %>
     <!-- you can skip variant with no options: that's just the default variant that all products have -->
     <% next if variant.option_values.empty? %>
@@ -34,6 +35,7 @@
   <% unless @product.has_variants? %>
     <tr><td colspan="9"><%= t(:none) %></td></tr>
   <% end %>
+  </tbody>
 </table>
 
 <% if @product.empty_option_values? %>


### PR DESCRIPTION
Index tables using js 'drag and drop sortable functionality' (i.e. images, variants and option_types) must define tbody, if not TRs can be dropped above th

[fixes #1455]
