### PR TITLE
Using iso instead of name column for translating countries. 

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -142,7 +142,7 @@ module Spree
     def available_countries
       countries = Zone.find_by_name(Spree::Config[:checkout_zone]).try(:country_list) || Country.all
       countries.collect do |c| 
-        c.name = I18n.t(c.name, :scope => 'countries', :default => c.name)
+        c.name = I18n.t(c.iso, :scope => 'countries', :default => c.name)
         c 
       end.sort{ |a,b| a.name <=> b.name }
     end


### PR DESCRIPTION
This change ensures compatibility with localized_country_select gem, that uses the much more valid ISO value of the country, instead of the name.
