### PR TITLE
Add attr_accessible to PaymentMethod and Gateway

### DIFF
--- a/core/app/models/spree/gateway.rb
+++ b/core/app/models/spree/gateway.rb
@@ -7,6 +7,8 @@ module Spree
     preference :server, :string, :default => 'test'
     preference :test_mode, :boolean, :default => true
 
+    attr_accessible :preferred_server, :preferred_test_mode
+
     def payment_source_class
       Creditcard
     end

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -5,6 +5,8 @@ module Spree
 
     scope :production, where(:environment => 'production')
 
+    attr_accessible :name, :description, :environment, :display_on, :active
+
     def self.providers
       Rails.application.config.spree.payment_methods
     end


### PR DESCRIPTION
This is necessary to work with current spree_gateway code; see https://github.com/spree/spree_gateway/pull/9 for discussion.

I believe merging this pull will break spree_usa_epay - it will need attr_accessible added to its properties.  I will add a pull request there in a minute.
