### PR TITLE
Reverting Commit 6bf3c54

### DIFF
--- a/core/app/models/spree/gateway.rb
+++ b/core/app/models/spree/gateway.rb
@@ -6,8 +6,6 @@ module Spree
 
     preference :server, :string, :default => 'test'
     preference :test_mode, :boolean, :default => true
-    
-    attr_accessible :preferred_server, :preferred_test_mode
 
     attr_accessible :preferred_server, :preferred_test_mode
 


### PR DESCRIPTION
There was no reason to commit this change, as the `attr_accessible` line is already present with the same exact attributes just two lines down from it.
