### PR TITLE
Return the proper line-item.

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -270,6 +270,7 @@ module Spree
         current_item.price   = variant.price
         self.line_items << current_item
       end
+      current_item
     end
 
     # FIXME refactor this method and implement validation using validates_* utilities


### PR DESCRIPTION
The function add_variant in order.rb returns different values depending on if the object exists in the line items already or not.

This change causes the function to return a consistent value for both cases allowing the return value to be used  in the calling method.

Note:  core/app/controllers/spree/admin/line_items_controller.rb is expecting this return value.  But if the item already exists then the return value is all line items rather than the newly added line item.
