### PR TITLE
Don't let mailer errors break orders

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -374,7 +374,7 @@ module Spree
       InventoryUnit.assign_opening_inventory(self)
       # lock any optional adjustments (coupon promotions, etc.)
       adjustments.optional.each { |adjustment| adjustment.update_attribute('locked', true) }
-      OrderMailer.confirm_email(self).deliver
+      deliver_order_confirmation_email
 
       self.state_changes.create({
         :previous_state => 'cart',
@@ -382,6 +382,15 @@ module Spree
         :name           => 'order' ,
         :user_id        => (User.respond_to?(:current) && User.current.try(:id)) || self.user_id
       }, :without_protection => true)
+    end
+
+    def deliver_order_confirmation_email
+      begin
+        OrderMailer.confirm_email(self).deliver
+      rescue Exception => e
+        logger.error("#{e.class.name}: #{e.message}")
+        logger.error(e.backtrace * "\n")
+      end
     end
 
     # Helper methods for checkout steps

--- a/core/spec/models/order_spec.rb
+++ b/core/spec/models/order_spec.rb
@@ -270,6 +270,11 @@ describe Spree::Order do
       order.finalize!
     end
 
+    it "should continue even if confirmation email delivery fails" do
+      Spree::OrderMailer.should_receive(:confirm_email).with(order).and_raise 'send failed!'
+      order.finalize!
+    end
+
     it "should freeze optional adjustments" do
       Spree::OrderMailer.stub_chain :confirm_email, :deliver
       adjustment = mock_model(Spree::Adjustment)


### PR DESCRIPTION
If the OrderMailer fails to deliver the email (e.g., SMTP timeout), the order gets in a state is really invalid.  This happens to us occasionally (we're using Sendgrid), and correcting the order after the fact is a real pain.  The correct behavior should be to allow the Order to complete.

I've also extracted the email sending logic to a separate method within Spree::Order, making that logic easier to override for enhancements like Delayed Job or Airbrake logging.
