### PR TITLE
Allow admin to view product pages

### DIFF
--- a/auth/app/controllers/spree/products_controller_decorator.rb
+++ b/auth/app/controllers/spree/products_controller_decorator.rb
@@ -1,0 +1,13 @@
+Spree::ProductsController.class_eval do
+  rescue_from CanCan::AccessDenied, :with => :render_404
+
+  private
+    def load_product
+      @product = Spree::Product.find_by_permalink!(params[:id])
+      if !@product.deleted? && (@product.available_on.nil? || @product.available_on.future?)
+        # Allow admins to view any yet to be available products
+        authorize! :update, Spree::Product, @product
+      end
+    end
+end
+

--- a/auth/app/controllers/spree/products_controller_decorator.rb
+++ b/auth/app/controllers/spree/products_controller_decorator.rb
@@ -6,7 +6,7 @@ Spree::ProductsController.class_eval do
       @product = Spree::Product.find_by_permalink!(params[:id])
       if !@product.deleted? && (@product.available_on.nil? || @product.available_on.future?)
         # Allow admins to view any yet to be available products
-        authorize! :update, Spree::Product, @product
+        authorize! :update, Spree::Product
       end
     end
 end

--- a/auth/spec/controllers/products_controller_spec.rb
+++ b/auth/spec/controllers/products_controller_spec.rb
@@ -4,7 +4,7 @@ describe Spree::ProductsController do
   let!(:product) { Factory(:product, :available_on => 1.year.from_now) }
 
   it "allows admins to view non-active products" do
-    controller.should_receive(:authorize!).with(:update, Spree::Product, product)
+    controller.should_receive(:authorize!).with(:update, Spree::Product)
     get :show, :id => product.to_param
     response.status.should == 200
   end

--- a/auth/spec/controllers/products_controller_spec.rb
+++ b/auth/spec/controllers/products_controller_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe Spree::ProductsController do
+  let!(:product) { Factory(:product, :available_on => 1.year.from_now) }
+
+  it "allows admins to view non-active products" do
+    controller.should_receive(:authorize!).with(:update, Spree::Product, product)
+    get :show, :id => product.to_param
+    response.status.should == 200
+  end
+
+  it "cannot view non-active products" do
+    get :show, :id => product.to_param
+    response.status.should == 404
+  end
+end

--- a/core/app/controllers/spree/products_controller.rb
+++ b/core/app/controllers/spree/products_controller.rb
@@ -1,6 +1,7 @@
 module Spree
   class ProductsController < BaseController
     HTTP_REFERER_REGEXP = /^https?:\/\/[^\/]+\/t\/([a-z0-9\-\/]+)$/
+    before_filter :load_product, :only => :show
     rescue_from ActiveRecord::RecordNotFound, :with => :render_404
     helper 'spree/taxons'
 
@@ -13,7 +14,6 @@ module Spree
     end
 
     def show
-      @product = Product.active.find_by_permalink!(params[:id])
       return unless @product
 
       @variants = Variant.active.includes([:option_values, :images]).where(:product_id => @product.id)
@@ -31,6 +31,10 @@ module Spree
     private
       def accurate_title
         @product ? @product.name : super
+      end
+
+      def load_product
+        @product = Product.active.find_by_permalink!(params[:id])
       end
   end
 end


### PR DESCRIPTION
It was fixed recently to prevent non-active products from being displayed, but it is useful for our admins to be able to preview what the Product page would look like before it becomes available.
