### PR TITLE
Remove unused find_by_status from inventory_units

### DIFF
--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -62,11 +62,6 @@ module Spree
       end
     end
 
-    # find the specified quantity of units with the specified status
-    def self.find_by_status(variant, quantity, status)
-      variant.inventory_units.where(:status => status).limit(quantity)
-    end
-
     private
       def allow_ship?
         Spree::Config[:allow_backorder_shipping] || self.sold?


### PR DESCRIPTION
Small cleanup. `Spree::InventoryUnit#find_by_status` is broken and not used anywhere
