### PR TITLE
Update all legacy FactoryGirl references to avoid deprecations.

### DIFF
--- a/api/spec/controllers/spree/api/v1/addresses_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/addresses_controller_spec.rb
@@ -6,7 +6,7 @@ module Spree
 
     before do
       stub_authentication!
-      @address = Factory(:address)
+      @address = create(:address)
     end
 
     it "gets an address" do

--- a/api/spec/controllers/spree/api/v1/countries_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/countries_controller_spec.rb
@@ -6,7 +6,7 @@ module Spree
 
     before do
       stub_authentication!
-      @state = Factory(:state)
+      @state = create(:state)
       @country = @state.country
     end
 

--- a/api/spec/controllers/spree/api/v1/images_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/images_controller_spec.rb
@@ -4,7 +4,7 @@ module Spree
   describe Spree::Api::V1::ImagesController do
     render_views
 
-    let!(:product) { Factory(:product) }
+    let!(:product) { create(:product) }
     let!(:attributes) { [:id, :position, :attachment_content_type, 
                          :attachment_file_name, :type, :attachment_updated_at, :attachment_width, 
                          :attachment_height, :alt] }

--- a/api/spec/controllers/spree/api/v1/line_items_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/line_items_controller_spec.rb
@@ -5,12 +5,12 @@ module Spree
     render_views
 
     let!(:order) do
-     order = Factory(:order)
-     order.line_items << Factory(:line_item)
+     order = create(:order)
+     order.line_items << create(:line_item)
      order
     end
 
-    let(:product) { Factory(:product) }
+    let(:product) { create(:product) }
     let(:attributes) { [:id, :quantity, :price, :variant] }
     let(:resource_scoping) { { :order_id => order.to_param } }
 

--- a/api/spec/controllers/spree/api/v1/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/orders_controller_spec.rb
@@ -4,7 +4,7 @@ module Spree
   describe Api::V1::OrdersController do
     render_views
 
-    let!(:order) { Factory(:order) }
+    let!(:order) { create(:order) }
     let(:attributes) { [:number, :item_total, :total,
                         :state, :adjustment_total, :credit_total,
                         :user_id, :created_at, :updated_at,
@@ -35,7 +35,7 @@ module Spree
     end
 
     it "can create an order" do
-      variant = Factory(:variant)
+      variant = create(:variant)
       api_post :create, :order => { :line_items => [{ :variant_id => variant.to_param, :quantity => 5 }] }
       response.status.should == 200
       order = Order.last
@@ -47,7 +47,7 @@ module Spree
 
     context "working with an order" do
       before do
-        Factory(:payment_method)
+        create(:payment_method)
         order.next # Switch from cart to address
         order.ship_address.should be_nil
         order.state.should == "address"
@@ -60,10 +60,10 @@ module Spree
       end
 
       let(:address_params) { { :country_id => Country.first.id, :state_id => State.first.id } }
-      let(:shipping_address) { clean_address(Factory.attributes_for(:address).merge!(address_params)) }
-      let(:billing_address) { clean_address(Factory.attributes_for(:address).merge!(address_params)) }
-      let!(:shipping_method) { Factory(:shipping_method) }
-      let!(:payment_method) { Factory(:payment_method) }
+      let(:shipping_address) { clean_address(attributes_for(:address).merge!(address_params)) }
+      let(:billing_address) { clean_address(attributes_for(:address).merge!(address_params)) }
+      let!(:shipping_method) { create(:shipping_method) }
+      let!(:payment_method) { create(:payment_method) }
 
       it "can add address information to an order" do
         api_put :address, :id => order.to_param, :shipping_address => shipping_address, :billing_address => billing_address
@@ -104,7 +104,7 @@ module Spree
 
       context "with a line item" do
         before do
-          order.line_items << Factory(:line_item)
+          order.line_items << create(:line_item)
         end
 
         context "for delivery" do

--- a/api/spec/controllers/spree/api/v1/payments_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/payments_controller_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 module Spree
   describe Spree::Api::V1::PaymentsController do
-    let!(:order) { Factory(:order) }
-    let!(:payment) { Factory(:payment, :order => order) }
+    let!(:order) { create(:order) }
+    let!(:payment) { create(:payment, :order => order) }
     let!(:attributes) { [:id, :source_type, :source_id, :amount,
                          :payment_method_id, :response_code, :state, :avs_response, 
                          :created_at, :updated_at] }

--- a/api/spec/controllers/spree/api/v1/products_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/products_controller_spec.rb
@@ -4,8 +4,8 @@ module Spree
   describe Spree::Api::V1::ProductsController do
     render_views
 
-    let!(:product) { Factory(:product) }
-    let!(:inactive_product) { Factory(:product, :available_on => Time.now.tomorrow, :name => "inactive") }
+    let!(:product) { create(:product) }
+    let!(:inactive_product) { create(:product, :available_on => Time.now.tomorrow, :name => "inactive") }
     let(:attributes) { [:id, :name, :description, :price, :available_on, :permalink, :count_on_hand, :meta_description, :meta_keywords, :taxon_ids] }
 
     before do
@@ -30,7 +30,7 @@ module Spree
         default_per_page(1)
 
         it "can select the next page of products" do
-          second_product = Factory(:product)
+          second_product = create(:product)
           api_get :index, :page => 2
           json_response["products"].first.should have_attributes(attributes)
           json_response["count"].should == 2
@@ -40,7 +40,7 @@ module Spree
       end
 
       it "can search for products" do
-        Factory(:product, :name => "The best product in the world")
+        create(:product, :name => "The best product in the world")
         api_get :search, :q => { :name_cont => "best" }
         json_response["products"].first.should have_attributes(attributes)
         json_response["count"].should == 1
@@ -64,7 +64,7 @@ module Spree
 
 
       context "finds a product by permalink first then by id" do
-        let!(:other_product) { Factory(:product, :permalink => "these-are-not-the-droids-you-are-looking-for") }
+        let!(:other_product) { create(:product, :permalink => "these-are-not-the-droids-you-are-looking-for") }
 
         before do
           product.update_attribute(:permalink, "#{other_product.id}-and-1-ways")

--- a/api/spec/controllers/spree/api/v1/shipments_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/shipments_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Spree::Api::V1::ShipmentsController do
-  let!(:shipment) { Factory(:shipment) }
+  let!(:shipment) { create(:shipment) }
   let!(:attributes) { [:id, :tracking, :number, :cost, :shipped_at] }
 
   before do

--- a/api/spec/controllers/spree/api/v1/taxonomies_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/taxonomies_controller_spec.rb
@@ -4,14 +4,14 @@ module Spree
   describe Api::V1::TaxonomiesController do
     render_views
 
-    let(:taxonomy) { Factory(:taxonomy) }
-    let(:taxon) { Factory(:taxon, :name => "Ruby", :taxonomy => taxonomy) }
-    let(:taxon2) { Factory(:taxon, :name => "Rails", :taxonomy => taxonomy) }
+    let(:taxonomy) { create(:taxonomy) }
+    let(:taxon) { create(:taxon, :name => "Ruby", :taxonomy => taxonomy) }
+    let(:taxon2) { create(:taxon, :name => "Rails", :taxonomy => taxonomy) }
     let(:attributes) { [:id, :name] }
 
     before do
       stub_authentication!
-      taxon2.children << Factory(:taxon, :name => "3.2.2", :taxonomy => taxonomy)
+      taxon2.children << create(:taxon, :name => "3.2.2", :taxonomy => taxonomy)
       taxon.children << taxon2
       taxonomy.root.children << taxon
     end

--- a/api/spec/controllers/spree/api/v1/taxons_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/taxons_controller_spec.rb
@@ -4,14 +4,14 @@ module Spree
   describe Api::V1::TaxonsController do
     render_views
 
-    let(:taxonomy) { Factory(:taxonomy) }
-    let(:taxon) { Factory(:taxon, :name => "Ruby", :taxonomy => taxonomy) }
-    let(:taxon2) { Factory(:taxon, :name => "Rails", :taxonomy => taxonomy) }
+    let(:taxonomy) { create(:taxonomy) }
+    let(:taxon) { create(:taxon, :name => "Ruby", :taxonomy => taxonomy) }
+    let(:taxon2) { create(:taxon, :name => "Rails", :taxonomy => taxonomy) }
     let(:attributes) { ["id", "name", "permalink", "position", "parent_id"] }
 
     before do
       stub_authentication!
-      taxon2.children << Factory(:taxon, :name => "3.2.2", :taxonomy => taxonomy)
+      taxon2.children << create(:taxon, :name => "3.2.2", :taxonomy => taxonomy)
       taxon.children << taxon2
       taxonomy.root.children << taxon
     end

--- a/api/spec/controllers/spree/api/v1/variants_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/variants_controller_spec.rb
@@ -5,10 +5,10 @@ module Spree
     render_views
 
 
-    let!(:product) { Factory(:product) }
+    let!(:product) { create(:product) }
     let!(:variant) do
       variant = product.master
-      variant.option_values << Factory(:option_value)
+      variant.option_values << create(:option_value)
       variant
     end
     let!(:attributes) { [:id, :name, :count_on_hand,

--- a/api/spec/spec_helper.rb
+++ b/api/spec/spec_helper.rb
@@ -16,6 +16,7 @@ require 'spree/api/testing_support/setup'
 RSpec.configure do |config|
   config.backtrace_clean_patterns = [/gems\/activesupport/, /gems\/actionpack/, /gems\/rspec/]
 
+  config.include FactoryGirl::Syntax::Methods
   config.include Spree::Api::TestingSupport::Helpers, :type => :controller
   config.extend Spree::Api::TestingSupport::Setup, :type => :controller
 end

--- a/auth/spec/controllers/orders_controller_spec.rb
+++ b/auth/spec/controllers/orders_controller_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe Spree::OrdersController do
   ORDER_TOKEN = 'ORDER_TOKEN'
 
-  let(:user) { Factory(:user) }
-  let(:guest_user) { Factory(:user) }
+  let(:user) { create(:user) }
+  let(:guest_user) { create(:user) }
   let(:order) { Spree::Order.new }
 
   it 'should understand order routes with token' do
@@ -72,7 +72,7 @@ describe Spree::OrdersController do
 
   context 'when an order exists in the session' do
     let(:token) { 'some_token' }
-    let(:specified_order) { Factory(:order) }
+    let(:specified_order) { create(:order) }
 
     before do
       controller.stub :current_order => order
@@ -134,7 +134,7 @@ describe Spree::OrdersController do
   end
 
   context 'when no authenticated user' do
-    let(:order) { Factory(:order, :number => 'R123') }
+    let(:order) { create(:order, :number => 'R123') }
 
     context '#show' do
       context 'when token parameter present' do

--- a/auth/spec/controllers/products_controller_spec.rb
+++ b/auth/spec/controllers/products_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Spree::ProductsController do
-  let!(:product) { Factory(:product, :available_on => 1.year.from_now) }
+  let!(:product) { create(:product, :available_on => 1.year.from_now) }
 
   it "allows admins to view non-active products" do
     controller.stub :current_user => stub(:admin? => true)

--- a/auth/spec/controllers/user_registrations_controller_spec.rb
+++ b/auth/spec/controllers/user_registrations_controller_spec.rb
@@ -6,9 +6,9 @@ describe Spree::UserRegistrationsController do
       activator = Spree::Activator.create!({:event_name => 'spree.user.signup'}, :without_protection => true)
       ActiveSupport::Notifications.subscribe(/spree.user.signup/) { |*args| activator.activate(args) }
       activator.should_receive(:activate).once
-      new_user = Factory.build(:user)
+      new_user = build(:user)
 
-      @request.env['devise.mapping'] = Devise.mappings[:user]
+      request.env['devise.mapping'] = Devise.mappings[:user]
 
       post :create, { :commit=>'Create', :user => { 'password' => new_user.password, 'password_confirmation' => new_user.password, 'email' => new_user.email } }
     end

--- a/auth/spec/controllers/users_controller_spec.rb
+++ b/auth/spec/controllers/users_controller_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe Spree::UsersController do
-  let(:admin_user) { Factory(:user) }
-  let(:user) { Factory(:user) }
+  let(:admin_user) { create(:user) }
+  let(:user) { create(:user) }
 
   before do
     sign_in user
@@ -36,7 +36,7 @@ describe Spree::UsersController do
 
     context 'when attempting to update other account' do
       it 'should not allow update' do
-        put :update, { :user => Factory(:user) }, { :user => { :email => 'mynew@email-address.com' } }
+        put :update, { :user => create(:user) }, { :user => { :email => 'mynew@email-address.com' } }
         response.should redirect_to(spree.login_url(:only_path => true))
       end
     end

--- a/auth/spec/models/user_spec.rb
+++ b/auth/spec/models/user_spec.rb
@@ -4,14 +4,14 @@ describe Spree::User do
   before(:all) { Spree::Role.create :name => 'admin' }
 
   it 'should generate the reset password token' do
-    user = Factory.build(:user)
+    user = build(:user)
     Spree::UserMailer.should_receive(:reset_password_instructions).with(user).and_return(double(:deliver => true))
     user.send_reset_password_instructions
     user.reset_password_token.should_not be_nil
   end
 
   context '#create' do
-    let(:user) { Factory.build(:user) }
+    let(:user) { build(:user) }
 
     it 'should not be anonymous' do
       user.should_not be_anonymous
@@ -20,7 +20,7 @@ describe Spree::User do
 
   context '#destroy' do
     it 'can not delete if it has completed orders' do
-      order = Factory.build(:order, :completed_at => Time.now)
+      order = build(:order, :completed_at => Time.now)
       order.save
       user = order.user
 
@@ -45,7 +45,7 @@ describe Spree::User do
   end
 
   context '#save' do
-    let(:user) { Factory.build(:user) }
+    let(:user) { build(:user) }
 
     context 'when there are no admin users' do
       it 'should assign the user an admin role' do
@@ -55,7 +55,7 @@ describe Spree::User do
     end
 
     context 'when there are existing admin users' do
-      before { Factory(:admin_user) }
+      before { create(:admin_user) }
 
       it 'should not assign the user an admin role' do
         user.save

--- a/auth/spec/requests/account_spec.rb
+++ b/auth/spec/requests/account_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe "Accounts" do
   context "editing" do
     it "should be able to edit an admin user" do
-      user = Factory(:admin_user, :email => "admin@person.com", :password => "password", :password_confirmation => "password")
+      user = create(:admin_user, :email => "admin@person.com", :password => "password", :password_confirmation => "password")
       visit spree.login_path
       fill_in "user_email", :with => user.email
       fill_in "user_password", :with => user.password
@@ -33,7 +33,7 @@ describe "Accounts" do
 
     it "should be able to edit an existing user account" do
       Spree::Auth::Config.set(:signout_after_password_change => false)
-      user = Factory(:user, :email => "email@person.com", :password => "secret", :password_confirmation => "secret")
+      user = create(:user, :email => "email@person.com", :password => "secret", :password_confirmation => "secret")
       visit spree.login_path
       fill_in "user_email", :with => user.email
       fill_in "user_password", :with => user.password

--- a/auth/spec/requests/admin/users_spec.rb
+++ b/auth/spec/requests/admin/users_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'Users' do
   before do
-    user = Factory(:admin_user, :email => "c@example.com")
+    user = create(:admin_user, :email => "c@example.com")
     sign_in_as!(user)
     visit spree.admin_users_path
   end

--- a/auth/spec/requests/admin_permissions_spec.rb
+++ b/auth/spec/requests/admin_permissions_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe "Admin Permissions" do
   context "admin is restricted from accessing orders" do
     before(:each) do
-      user = Factory(:admin_user, :email => "admin@person.com", :password => "password", :password_confirmation => "password")
+      user = create(:admin_user, :email => "admin@person.com", :password => "password", :password_confirmation => "password")
       Spree::Ability.register_ability(AbilityDecorator)
       visit spree.login_path
       fill_in "user_email", :with => user.email
@@ -17,13 +17,13 @@ describe "Admin Permissions" do
     end
 
     it "should not be able to edit orders" do
-      Factory(:order, :number => "R123")
+      create(:order, :number => "R123")
       visit spree.edit_admin_order_path("R123")
       page.should have_content("Authorization Failure")
     end
 
     it "should not be able to view an order" do
-      Factory(:order, :number => "R123")
+      create(:order, :number => "R123")
       visit spree.admin_order_path("R123")
       page.should have_content("Authorization Failure")
     end

--- a/auth/spec/requests/checkout_spec.rb
+++ b/auth/spec/requests/checkout_spec.rb
@@ -5,15 +5,15 @@ describe "Checkout", :js => true do
     PAYMENT_STATES = Spree::Payment.state_machine.states.keys unless defined? PAYMENT_STATES
     SHIPMENT_STATES = Spree::Shipment.state_machine.states.keys unless defined? SHIPMENT_STATES
     ORDER_STATES = Spree::Order.state_machine.states.keys unless defined? ORDER_STATES
-    sm =Factory(:shipping_method, :zone => Spree::Zone.find_by_name('North America'))
+    sm = create(:shipping_method, :zone => Spree::Zone.find_by_name('North America'))
     sm.calculator.set_preference(:amount, 10)
 
-    Factory(:payment_method, :environment => 'test')
-    Factory(:product, :name => "RoR Mug")
+    create(:payment_method, :environment => 'test')
+    create(:product, :name => "RoR Mug")
     visit spree.root_path
   end
 
-  let!(:address) { Factory(:address, :state => Spree::State.first) }
+  let!(:address) { create(:address, :state => Spree::State.first) }
 
   it "should allow a visitor to checkout as guest, without registration" do
     Spree::Auth::Config.set(:registration_step => true)
@@ -42,7 +42,7 @@ describe "Checkout", :js => true do
   end
 
   it "should associate an uncompleted guest order with user after logging in" do
-    user = Factory(:user, :email => "email@person.com", :password => "password", :password_confirmation => "password")
+    user = create(:user, :email => "email@person.com", :password => "password", :password_confirmation => "password")
     click_link "RoR Mug"
     click_button "Add To Cart"
     Spree::User.count.should == 2
@@ -73,7 +73,7 @@ describe "Checkout", :js => true do
 
   # Regression test for #890
   it "should associate an incomplete guest order with user after successful password reset" do
-    user = Factory(:user, :email => "email@person.com", :password => "password", :password_confirmation => "password")
+    user = create(:user, :email => "email@person.com", :password => "password", :password_confirmation => "password")
     click_link "RoR Mug"
     click_button "Add To Cart"
 
@@ -130,7 +130,7 @@ describe "Checkout", :js => true do
   end
 
   it "the current payment method does not support profiles" do
-    Factory(:authorize_net_payment_method, :environment => 'test')
+    create(:authorize_net_payment_method, :environment => 'test')
     click_link "RoR Mug"
     click_button "Add To Cart"
     click_link "Checkout"
@@ -195,7 +195,7 @@ describe "Checkout", :js => true do
   end
 
   it "user submits an invalid credit card number" do
-    Factory(:bogus_payment_method, :environment => 'test')
+    create(:bogus_payment_method, :environment => 'test')
     click_link "RoR Mug"
     click_button "Add To Cart"
     click_link "Checkout"
@@ -220,8 +220,8 @@ describe "Checkout", :js => true do
   end
 
   it "completing checkout for a free order, skipping payment step" do
-    Factory(:free_shipping_method, :zone => Spree::Zone.find_by_name('North America'))
-    Factory(:payment_method, :environment => 'test')
+    create(:free_shipping_method, :zone => Spree::Zone.find_by_name('North America'))
+    create(:payment_method, :environment => 'test')
     click_link "RoR Mug"
     click_button "Add To Cart"
     click_link "Checkout"
@@ -242,7 +242,7 @@ describe "Checkout", :js => true do
   end
 
   it "completing checkout with an invalid address input initially" do
-    Factory(:bogus_payment_method, :environment => 'test')
+    create(:bogus_payment_method, :environment => 'test')
     click_link "RoR Mug"
     click_button "Add To Cart"
     click_link "Checkout"
@@ -269,12 +269,12 @@ describe "Checkout", :js => true do
 
   it "changing country to different zone during checkout should reset shipments" do
     eu_vat_zone = Spree::Zone.find_by_name("EU_VAT")
-    italy = Factory(:country, :iso_name => "ITALY", :iso => "IT", :iso3 => "ITA", :name => "Italy", :zone => eu_vat_zone)
-    ita_address = Factory(:address, :country => italy, :state_name => "Roma")
-    eu_shipping = Factory(:shipping_method, :name => "EU", :zone => eu_vat_zone)
+    italy = create(:country, :iso_name => "ITALY", :iso => "IT", :iso3 => "ITA", :name => "Italy", :zone => eu_vat_zone)
+    ita_address = create(:address, :country => italy, :state_name => "Roma")
+    eu_shipping = create(:shipping_method, :name => "EU", :zone => eu_vat_zone)
     # TODO: Figure why calculator after_create is not firing to set this
     eu_shipping.calculator.set_preference(:amount, 20)
-    user = Factory(:user, :email => "email@person.com", :password => "password", :password_confirmation => "password")
+    user = create(:user, :email => "email@person.com", :password => "password", :password_confirmation => "password")
     visit spree.login_path
     fill_in "user_email", :with => user.email
     fill_in "user_password", :with => user.password

--- a/auth/spec/requests/password_reset_spec.rb
+++ b/auth/spec/requests/password_reset_spec.rb
@@ -8,7 +8,7 @@ describe "Reset Password" do
   end
 
   it "should allow a user to supply an email for the password reset" do
-    user = Factory(:user, :email => "foobar@example.com", :password => "secret", :password_confirmation => "secret")
+    user = create(:user, :email => "foobar@example.com", :password => "secret", :password_confirmation => "secret")
     visit spree.login_path
     click_link "Forgot Password?"
     fill_in "user_email", :with => "foobar@example.com"

--- a/auth/spec/requests/sign_in_spec.rb
+++ b/auth/spec/requests/sign_in_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe "Sign In" do
   before(:each) do
-    @user = Factory(:user, :email => "email@person.com", :password => "secret", :password_confirmation => "secret")
+    @user = create(:user, :email => "email@person.com", :password => "secret", :password_confirmation => "secret")
     visit spree.login_path
   end
 
@@ -30,7 +30,7 @@ describe "Sign In" do
   end
 
   it "should allow a user to access a restricted page after logging in" do
-    user = Factory(:admin_user, :email => "admin@person.com", :password => "password", :password_confirmation => "password")
+    user = create(:admin_user, :email => "admin@person.com", :password => "password", :password_confirmation => "password")
     visit spree.admin_path
     fill_in "user_email", :with => user.email
     fill_in "user_password", :with => user.password

--- a/auth/spec/requests/sign_out_spec.rb
+++ b/auth/spec/requests/sign_out_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe "Sign Out" do
   let!(:user) do
-   Factory(:user,
+   create(:user,
           :email => "email@person.com",
           :password => "secret",
           :password_confirmation => "secret")

--- a/auth/spec/requests/user_spec.rb
+++ b/auth/spec/requests/user_spec.rb
@@ -1,35 +1,35 @@
 require 'spec_helper'
 
 describe "Users" do
- before(:each) do
-   user = Factory(:admin_user, :email => "admin@person.com", :password => "password", :password_confirmation => "password")
-   visit spree.admin_path
-   fill_in "user_email", :with => user.email
-   fill_in "user_password", :with => user.password
-   click_button "Login"
-   click_link "Users"
-   within('table#listing_users td.user_email') { click_link "admin@person.com" }
-   click_link "Edit"
-   page.should have_content("Editing User")
- end
+  before(:each) do
+    user = create(:admin_user, :email => "admin@person.com", :password => "password", :password_confirmation => "password")
+    visit spree.admin_path
+    fill_in "user_email", :with => user.email
+    fill_in "user_password", :with => user.password
+    click_button "Login"
+    click_link "Users"
+    within('table#listing_users td.user_email') { click_link "admin@person.com" }
+    click_link "Edit"
+    page.should have_content("Editing User")
+  end
 
- it "admin editing email with validation error" do
-   fill_in "user_email", :with => "a"
-   click_button "Update"
-   page.should have_content("Email is invalid")
- end
+  it "admin editing email with validation error" do
+    fill_in "user_email", :with => "a"
+    click_button "Update"
+    page.should have_content("Email is invalid")
+  end
 
- it "admin editing roles" do
-   check "user_role_user"
-   click_button "Update"
-   page.should have_content("User has been successfully updated!")
-   within('table#listing_users') { click_link "Edit" }
-   find_field('user_role_user')['checked'].should be_true
- end
+  it "admin editing roles" do
+    check "user_role_user"
+    click_button "Update"
+    page.should have_content("User has been successfully updated!")
+    within('table#listing_users') { click_link "Edit" }
+    find_field('user_role_user')['checked'].should be_true
+  end
 
- it "listing users when anonymous users are present" do
+  it "listing users when anonymous users are present" do
     Spree::User.anonymous!
     click_link "Users"
     page.should_not have_content("@example.net")
- end
+  end
 end

--- a/auth/spec/spec_helper.rb
+++ b/auth/spec/spec_helper.rb
@@ -48,6 +48,7 @@ RSpec.configure do |config|
     Spree::Ability.abilities.delete(AbilityDecorator) if Spree::Ability.abilities.include?(AbilityDecorator)
   end
 
+  config.include FactoryGirl::Syntax::Methods
   config.include Spree::Core::UrlHelpers
   config.include Spree::Core::TestingSupport::ControllerRequests, :type => :controller
   config.include Devise::TestHelpers, :type => :controller

--- a/cmd/lib/spree_cmd/templates/extension/spec/spec_helper.rb.tt
+++ b/cmd/lib/spree_cmd/templates/extension/spec/spec_helper.rb.tt
@@ -15,6 +15,7 @@ require 'spree/core/testing_support/factories'
 require 'spree/core/url_helpers'
 
 RSpec.configure do |config|
+  config.include FactoryGirl::Syntax::Methods
 
   # == URL Helpers
   #

--- a/core/lib/spree/core/testing_support/factories.rb
+++ b/core/lib/spree/core/testing_support/factories.rb
@@ -5,7 +5,6 @@ Spree::Zone.class_eval do
 end
 
 require 'factory_girl'
-# include FactoryGirl::Syntax::Methods # TODO: This can be removed when using FactoryGirl 3.2.x
 
 Dir["#{File.dirname(__FILE__)}/factories/**"].each do |f|
   require File.expand_path(f)

--- a/core/lib/spree/core/testing_support/factories.rb
+++ b/core/lib/spree/core/testing_support/factories.rb
@@ -1,12 +1,12 @@
 Spree::Zone.class_eval do
   def self.global
-    find_by_name("GlobalZone") || Factory(:global_zone)
+    find_by_name("GlobalZone") || create(:global_zone)
   end
 end
 
 require 'factory_girl'
+# include FactoryGirl::Syntax::Methods # TODO: This can be removed when using FactoryGirl 3.2.x
 
 Dir["#{File.dirname(__FILE__)}/factories/**"].each do |f|
   require File.expand_path(f)
 end
-

--- a/core/lib/spree/core/testing_support/factories/adjustment_factory.rb
+++ b/core/lib/spree/core/testing_support/factories/adjustment_factory.rb
@@ -1,16 +1,16 @@
 FactoryGirl.define do
   factory :adjustment, :class => Spree::Adjustment do
-    adjustable { Factory(:order) }
+    adjustable { FactoryGirl.create(:order) }
     amount '100.0'
     label 'Shipping'
-    source { Factory(:shipment) }
+    source { FactoryGirl.create(:shipment) }
     eligible true
   end
   factory :line_item_adjustment, :class => Spree::Adjustment do
-    adjustable { Factory(:line_item) }
+    adjustable { FactoryGirl.create(:line_item) }
     amount '10.0'
     label 'VAT 5%'
-    source { Factory(:tax_rate) }
+    source { FactoryGirl.create(:tax_rate) }
     eligible true
   end
 end

--- a/core/lib/spree/core/testing_support/factories/inventory_unit_factory.rb
+++ b/core/lib/spree/core/testing_support/factories/inventory_unit_factory.rb
@@ -1,9 +1,9 @@
 FactoryGirl.define do
   factory :inventory_unit, :class => Spree::InventoryUnit do
-    variant { Factory(:variant) }
-    order { Factory(:order) }
+    variant { FactoryGirl.create(:variant) }
+    order { FactoryGirl.create(:order) }
     state 'sold'
-    shipment { Factory(:shipment, :state => 'pending') }
-    #return_authorization { Factory(:return_authorization) }
+    shipment { FactoryGirl.create(:shipment, :state => 'pending') }
+    #return_authorization { FactoryGirl.create(:return_authorization) }
   end
 end

--- a/core/lib/spree/core/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/core/testing_support/factories/order_factory.rb
@@ -10,21 +10,21 @@ FactoryGirl.define do
   end
 
   factory :order_with_totals, :parent => :order do
-    after_create { |order| Factory(:line_item, :order => order) }
+    after_create { |order| FactoryGirl.create(:line_item, :order => order) }
   end
 
   factory :order_with_inventory_unit_shipped, :parent => :order do
     after_create do |order|
-      Factory(:line_item, :order => order)
-      Factory(:inventory_unit, :order => order, :state => 'shipped')
+      FactoryGirl.create(:line_item, :order => order)
+      FactoryGirl.create(:inventory_unit, :order => order, :state => 'shipped')
     end
   end
 
   factory :completed_order_with_totals, :parent => :order_with_totals do
-    bill_address { Factory(:address) }
-    ship_address { Factory(:address) }
+    bill_address { FactoryGirl.create(:address) }
+    ship_address { FactoryGirl.create(:address) }
     after_create do |order|
-      Factory(:inventory_unit, :order => order, :state => 'shipped')
+      FactoryGirl.create(:inventory_unit, :order => order, :state => 'shipped')
     end
     state 'complete'
     completed_at Time.now

--- a/core/lib/spree/core/testing_support/factories/payment_factory.rb
+++ b/core/lib/spree/core/testing_support/factories/payment_factory.rb
@@ -1,9 +1,9 @@
 FactoryGirl.define do
   factory :payment, :class => Spree::Payment do
     amount 45.75
-    payment_method { Factory(:bogus_payment_method) }
-    source { Factory.build(:creditcard) }
-    order { Factory(:order) }
+    payment_method { FactoryGirl.create(:bogus_payment_method) }
+    source { FactoryGirl.build(:creditcard) }
+    order { FactoryGirl.create(:order) }
     state 'pending'
     response_code '12345'
 

--- a/core/lib/spree/core/testing_support/factories/product_factory.rb
+++ b/core/lib/spree/core/testing_support/factories/product_factory.rb
@@ -17,7 +17,7 @@ FactoryGirl.define do
   end
 
   factory :product_with_option_types, :parent => :product do
-    after_create { |product| Factory(:product_option_type, :product => product) }
+    after_create { |product| FactoryGirl.create(:product_option_type, :product => product) }
   end
 
   factory :custom_product, :class => Spree::Product do

--- a/core/lib/spree/core/testing_support/factories/product_option_type_factory.rb
+++ b/core/lib/spree/core/testing_support/factories/product_option_type_factory.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :product_option_type, :class => Spree::ProductOptionType do
-    product { Factory(:product) }
-    option_type { Factory(:option_type) }
+    product { FactoryGirl.create(:product) }
+    option_type { FactoryGirl.create(:option_type) }
   end
 end

--- a/core/lib/spree/core/testing_support/factories/product_property_factory.rb
+++ b/core/lib/spree/core/testing_support/factories/product_property_factory.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :product_property, :class => Spree::ProductProperty do
-    product { Factory(:product) }
-    property { Factory(:property) }
+    product { FactoryGirl.create(:product) }
+    property { FactoryGirl.create(:property) }
   end
 end

--- a/core/lib/spree/core/testing_support/factories/prototype_factory.rb
+++ b/core/lib/spree/core/testing_support/factories/prototype_factory.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :prototype, :class => Spree::Prototype do
     name 'Baseball Cap'
-    properties { [Factory(:property)] }
+    properties { [FactoryGirl.create(:property)] }
   end
 end

--- a/core/lib/spree/core/testing_support/factories/return_authorization_factory.rb
+++ b/core/lib/spree/core/testing_support/factories/return_authorization_factory.rb
@@ -2,8 +2,8 @@ FactoryGirl.define do
   factory :return_authorization, :class => Spree::ReturnAuthorization do
     number '100'
     amount 100.00
-    #order { Factory(:order) }
-    order { Factory(:order_with_inventory_unit_shipped) }
+    #order { FactoryGirl.create(:order) }
+    order { FactoryGirl.create(:order_with_inventory_unit_shipped) }
     reason 'no particular reason'
     state 'received'
   end

--- a/core/lib/spree/core/testing_support/factories/shipment_factory.rb
+++ b/core/lib/spree/core/testing_support/factories/shipment_factory.rb
@@ -1,11 +1,11 @@
 FactoryGirl.define do
   factory :shipment, :class => Spree::Shipment do
-    order { Factory(:order) }
-    shipping_method { Factory(:shipping_method) }
+    order { FactoryGirl.create(:order) }
+    shipping_method { FactoryGirl.create(:shipping_method) }
     tracking 'U10000'
     number '100'
     cost 100.00
-    address { Factory(:address) }
+    address { FactoryGirl.create(:address) }
     state 'pending'
   end
 end

--- a/core/lib/spree/core/testing_support/factories/shipping_method_factory.rb
+++ b/core/lib/spree/core/testing_support/factories/shipping_method_factory.rb
@@ -2,13 +2,13 @@ FactoryGirl.define do
   factory :shipping_method, :class => Spree::ShippingMethod do
     zone { |a| Spree::Zone.find_by_name('GlobalZone') || a.association(:global_zone) }
     name 'UPS Ground'
-    calculator { Factory.build(:calculator) }
+    calculator { FactoryGirl.build(:calculator) }
   end
 
   factory :free_shipping_method, :class => Spree::ShippingMethod do
     zone { |a| Spree::Zone.find_by_name('GlobalZone') || a.association(:global_zone) }
     name 'UPS Ground'
-    calculator { Factory.build(:no_amount_calculator) }
+    calculator { FactoryGirl.build(:no_amount_calculator) }
   end
 
   factory :shipping_method_with_category, :class => Spree::ShippingMethod do
@@ -18,6 +18,6 @@ FactoryGirl.define do
     match_one nil
     match_all nil
     association(:shipping_category, :factory => :shipping_category)
-    calculator { Factory.build(:calculator) }
+    calculator { FactoryGirl.build(:calculator) }
   end
 end

--- a/core/lib/spree/core/testing_support/factories/tax_rate_factory.rb
+++ b/core/lib/spree/core/testing_support/factories/tax_rate_factory.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :tax_rate, :class => Spree::TaxRate do
-    zone { Factory(:zone) }
+    zone { FactoryGirl.create(:zone) }
     amount 100.00
-    tax_category { Factory(:tax_category) }
+    tax_category { FactoryGirl.create(:tax_category) }
   end
 end

--- a/core/lib/spree/core/testing_support/factories/taxon_factory.rb
+++ b/core/lib/spree/core/testing_support/factories/taxon_factory.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :taxon, :class => Spree::Taxon do
     name 'Ruby on Rails'
-    taxonomy { Factory(:taxonomy) }
+    taxonomy { FactoryGirl.create(:taxonomy) }
     parent_id nil
   end
 end

--- a/core/lib/spree/core/testing_support/factories/user_factory.rb
+++ b/core/lib/spree/core/testing_support/factories/user_factory.rb
@@ -12,6 +12,6 @@ FactoryGirl.define do
   end
 
   factory :admin_user, :parent => :user do
-    roles { [Spree::Role.find_by_name('admin') || Factory(:role, :name => 'admin')]}
+    roles { [Spree::Role.find_by_name('admin') || FactoryGirl.create(:role, :name => 'admin')]}
   end
 end

--- a/core/lib/spree/core/testing_support/factories/variant_factory.rb
+++ b/core/lib/spree/core/testing_support/factories/variant_factory.rb
@@ -11,6 +11,6 @@ FactoryGirl.define do
 
     # associations:
     product { |p| p.association(:product) }
-    option_values { [Factory(:option_value)] }
+    option_values { [FactoryGirl.create(:option_value)] }
   end
 end

--- a/core/spec/controllers/spree/admin/mail_methods_controller_spec.rb
+++ b/core/spec/controllers/spree/admin/mail_methods_controller_spec.rb
@@ -25,7 +25,7 @@ describe Spree::Admin::MailMethodsController do
   end
 
   it "can trigger testmail without current_user" do
-    post :testmail, :id => Factory(:mail_method).id
+    post :testmail, :id => create(:mail_method).id
     flash[:error].should_not include("undefined local variable or method `current_user'")
   end
 end

--- a/core/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/core/spec/controllers/spree/admin/products_controller_spec.rb
@@ -44,7 +44,7 @@ describe Spree::Admin::ProductsController do
 
     # Regression test for #1259
     it "can find a product by SKU" do
-      product = Factory(:product, :sku => "ABC123")
+      product = create(:product, :sku => "ABC123")
       spree_get :index, :q => { :sku_start => "ABC123" }
       assigns[:collection].should_not be_empty
       assigns[:collection].should include(product)
@@ -87,7 +87,7 @@ describe Spree::Admin::ProductsController do
 
   # regression test for #1370
   context "adding properties to a product" do
-    let!(:product) { Factory(:product) }
+    let!(:product) { create(:product) }
     specify do
       spree_put :update, :id => product.to_param, :product => { :product_properties_attributes => { "1" => { :property_name => "Foo", :value => "bar" } } }
       response.should be_success
@@ -99,8 +99,8 @@ describe Spree::Admin::ProductsController do
   # regression test for #801
   context "destroying a product" do
     let(:product) do
-      product = Factory(:product)
-      Factory(:variant, :product => product)
+      product = create(:product)
+      create(:variant, :product => product)
       product
     end
 

--- a/core/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
+++ b/core/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Spree::Admin::ReturnAuthorizationsController do
   # Regression test for #1370 #3
-  let!(:order) { Factory(:order) }
+  let!(:order) { create(:order) }
   it "can create a return authorization" do
     post :create, :order_id => order.to_param, :return_authorization => { :amount => 0.0, :reason => "" }
     response.should be_success

--- a/core/spec/controllers/spree/checkout_controller_spec.rb
+++ b/core/spec/controllers/spree/checkout_controller_spec.rb
@@ -144,7 +144,7 @@ describe Spree::CheckoutController do
     let(:product) { mock_model(Spree::Product, :name => "Amazing Object") }
     let(:variant) { mock_model(Spree::Variant, :on_hand => 0) }
     let(:line_item) { mock_model Spree::LineItem, :insufficient_stock? => true }
-    let(:order) { Factory(:order) }
+    let(:order) { create(:order) }
 
     before do
       order.stub(:line_items => [line_item])

--- a/core/spec/controllers/spree/orders_controller_extension_spec.rb
+++ b/core/spec/controllers/spree/orders_controller_extension_spec.rb
@@ -10,7 +10,7 @@ describe Spree::OrdersController do
 
       context "specify symbol for handler instead of Proc" do
         before do
-          @order = Factory(:order)
+          @order = create(:order)
           Spree::OrdersController.class_eval do
             respond_override({:update => {:html => {:success => :success_method}}})
 
@@ -32,7 +32,7 @@ describe Spree::OrdersController do
 
       context "render" do
         before do
-          @order = Factory(:order)
+          @order = create(:order)
           Spree::OrdersController.instance_eval do
             respond_override({:update => {:html => {:success => lambda { render(:text => 'success!!!') }}}})
             respond_override({:update => {:html => {:failure => lambda { render(:text => 'failure!!!') }}}})
@@ -49,7 +49,7 @@ describe Spree::OrdersController do
 
       context "redirect" do
         before do
-          @order = Factory(:order)
+          @order = create(:order)
           Spree::OrdersController.instance_eval do
             respond_override({:update => {:html => {:success => lambda { redirect_to(Spree::Order.first) }}}})
             respond_override({:update => {:html => {:failure => lambda { render(:text => 'failure!!!') }}}})
@@ -65,7 +65,7 @@ describe Spree::OrdersController do
 
       context "validation error" do
         before do
-          @order = Factory(:order)
+          @order = create(:order)
           Spree::Order.update_all :state => 'address'
           Spree::OrdersController.instance_eval do
             respond_override({:update => {:html => {:success => lambda { render(:text => 'success!!!') }}}})

--- a/core/spec/controllers/spree/orders_controller_spec.rb
+++ b/core/spec/controllers/spree/orders_controller_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Spree::OrdersController do
 
-  let(:user) { Factory(:user) }
+  let(:user) { create(:user) }
   let(:order) { mock_model(Spree::Order, :number => "R123", :reload => nil, :save! => true, :coupon_code => nil, :user => user)}
   before do
     Spree::Order.stub(:find).with(1).and_return(order)

--- a/core/spec/controllers/spree/products_controller_spec.rb
+++ b/core/spec/controllers/spree/products_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Spree::ProductsController do
-  let!(:product) { Factory(:product, :available_on => 1.year.from_now) }
+  let!(:product) { create(:product, :available_on => 1.year.from_now) }
 
   # Regression test for #1390
   it "cannot view non-active products" do

--- a/core/spec/controllers/spree/states_controller_spec.rb
+++ b/core/spec/controllers/spree/states_controller_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Spree::StatesController do
   before(:each) do
-    state = Factory(:state)
+    state = create(:state)
   end
 
   it 'should display state mapper' do

--- a/core/spec/helpers/products_helper_spec.rb
+++ b/core/spec/helpers/products_helper_spec.rb
@@ -6,8 +6,8 @@ module Spree
 
     context "#variant_price_diff" do
       before do
-        @product = Factory(:product)
-        @variant = Factory(:variant, :product => @product)
+        @product = create(:product)
+        @variant = create(:variant, :product => @product)
       end
 
       it "should be correct positive value when variant is more than master" do

--- a/core/spec/lib/search/base_spec.rb
+++ b/core/spec/lib/search/base_spec.rb
@@ -4,8 +4,8 @@ describe Spree::Core::Search::Base do
 
   before do
     include ::Spree::ProductFilters
-    @product1 = Factory(:product, :name => "RoR Mug", :price => 9.00, :on_hand => 1)
-    @product2 = Factory(:product, :name => "RoR Shirt", :price => 11.00, :on_hand => 1)
+    @product1 = create(:product, :name => "RoR Mug", :price => 9.00, :on_hand => 1)
+    @product2 = create(:product, :name => "RoR Shirt", :price => 11.00, :on_hand => 1)
   end
 
   it "returns all products by default" do
@@ -15,7 +15,7 @@ describe Spree::Core::Search::Base do
   end
 
   it "switches to next page according to the page parameter" do
-    @product3 = Factory(:product, :name => "RoR Pants", :price => 14.00, :on_hand => 1)
+    @product3 = create(:product, :name => "RoR Pants", :price => 14.00, :on_hand => 1)
 
     params = { :per_page => "2" }
     searcher = Spree::Core::Search::Base.new(params)

--- a/core/spec/models/address_spec.rb
+++ b/core/spec/models/address_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe Spree::Address do
   describe "clone" do
     it "creates a copy of the address with the exception of the id, updated_at and created_at attributes" do
-      state = Factory(:state)
-      original = Factory(:address,
+      state = create(:state)
+      original = create(:address,
                          :address1 => 'address1',
                          :address2 => 'address2',
                          :alternative_phone => 'alternative_phone',
@@ -117,7 +117,7 @@ describe Spree::Address do
   context ".default" do
     before do
       @default_country_id = Spree::Config[:default_country_id]
-      new_country = Factory(:country)
+      new_country = create(:country)
       Spree::Config[:default_country_id] = new_country.id
     end
 

--- a/core/spec/models/calculator/default_tax_spec.rb
+++ b/core/spec/models/calculator/default_tax_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 
 describe Spree::Calculator::DefaultTax do
-  let!(:tax_category) { Factory(:tax_category, :tax_rates => []) }
+  let!(:tax_category) { create(:tax_category, :tax_rates => []) }
   let!(:rate) { mock_model(Spree::TaxRate, :tax_category => tax_category, :amount => 0.05) }
   let!(:calculator) { Spree::Calculator::DefaultTax.new({:calculable => rate}, :without_protection => true) }
-  let!(:order) { Factory(:order) }
-  let!(:product_1) { Factory(:product) }
-  let!(:product_2) { Factory(:product) }
-  let!(:line_item_1) { Factory(:line_item, :product => product_1, :price => 10, :quantity => 3) }
-  let!(:line_item_2) { Factory(:line_item, :product => product_2, :price => 5, :quantity => 1) }
+  let!(:order) { create(:order) }
+  let!(:product_1) { create(:product) }
+  let!(:product_2) { create(:product) }
+  let!(:line_item_1) { create(:line_item, :product => product_1, :price => 10, :quantity => 3) }
+  let!(:line_item_2) { create(:line_item, :product => product_2, :price => 5, :quantity => 1) }
 
   context "#compute" do
     context "when given an order" do

--- a/core/spec/models/creditcard_spec.rb
+++ b/core/spec/models/creditcard_spec.rb
@@ -12,7 +12,7 @@ describe Spree::Creditcard do
 
   before(:each) do
 
-    @order = Factory(:order)
+    @order = create(:order)
     @payment = Spree::Payment.create({:amount => 100, :order => @order}, :without_protection => true)
 
     @success_response = mock('gateway_response', :success? => true, :authorization => '123', :avs_result => {'code' => 'avs-code'})

--- a/core/spec/models/order_spec.rb
+++ b/core/spec/models/order_spec.rb
@@ -24,7 +24,7 @@ describe Spree::Order do
   context 'validation' do
     context "when @use_billing is populated" do
       before do
-        order.bill_address = Factory(:address)
+        order.bill_address = create(:address)
         order.ship_address = nil
       end
 
@@ -219,8 +219,8 @@ describe Spree::Order do
 
       context "when transitioning to payment state" do
         before do
-          order.inventory_units << Factory(:inventory_unit)
-          order.shipping_method = Factory(:shipping_method)
+          order.inventory_units << create(:inventory_unit)
+          order.shipping_method = create(:shipping_method)
         end
 
         it "should create a shipment" do
@@ -476,7 +476,7 @@ describe Spree::Order do
 
     it "should call adjustment#update on every adjustment}" do
       # adjustment = mock_model(Adjustment, :amount => 5, :applicable? => true, :update! => true)
-      adjustment = Factory(:adjustment, :adjustable => order, :amount => 5)
+      adjustment = create(:adjustment, :adjustable => order, :amount => 5)
       # TODO: Restore this example. Stubbing adjustments doesn't work, need a proper collection
       # so we can use adjustments.eligible
       # order.stub(:adjustments => [adjustment])
@@ -512,9 +512,9 @@ describe Spree::Order do
 
     context "with adjustments" do
       before do
-        Factory(:adjustment, :adjustable => order, :amount => 10)
-        Factory(:adjustment, :adjustable => order, :amount => 5)
-        a = Factory(:adjustment, :adjustable => order, :amount => -2, :eligible => false)
+        create(:adjustment, :adjustable => order, :amount => 10)
+        create(:adjustment, :adjustable => order, :amount => 5)
+        a = create(:adjustment, :adjustable => order, :amount => -2, :eligible => false)
         a.update_attribute_without_callbacks(:eligible, false)
         order.stub(:update_adjustments, nil) # So the last adjustment remains ineligible
         order.adjustments.reload
@@ -543,14 +543,14 @@ describe Spree::Order do
 
   context "#payment_method" do
     it "should return payment.payment_method if payment is present" do
-      payments = [Factory(:payment)]
+      payments = [create(:payment)]
       payments.stub(:completed => payments)
       order.stub(:payments => payments)
       order.payment_method.should == order.payments.first.payment_method
     end
 
     it "should return the first payment method from available_payment_methods if payment is not present" do
-      Factory(:payment_method, :environment => 'test')
+      create(:payment_method, :environment => 'test')
       order.payment_method.should == order.available_payment_methods.first
     end
   end
@@ -823,7 +823,7 @@ describe Spree::Order do
 
     context "when there is a default tax zone" do
       before do
-        @default_zone = Factory(:zone, :name => "foo_zone")
+        @default_zone = create(:zone, :name => "foo_zone")
         Spree::Zone.stub :default_tax => @default_zone
       end
 
@@ -871,8 +871,8 @@ describe Spree::Order do
       @order.stub :line_items => [line_item1, line_item2]
     end
 
-    let(:line_item1) { Factory(:line_item, :order => @order) }
-    let(:line_item2) { Factory(:line_item, :order => @order) }
+    let(:line_item1) { create(:line_item, :order => @order) }
+    let(:line_item2) { create(:line_item, :order => @order) }
 
     context "when there are no line item adjustments" do
       it "should return nothing if line items have no adjustments" do
@@ -954,8 +954,8 @@ describe Spree::Order do
 
   context "#exclude_tax?" do
     before do
-      @order = Factory(:order)
-      @default_zone = Factory(:zone)
+      @order = create(:order)
+      @default_zone = create(:zone)
       Spree::Zone.stub :default_tax => @default_zone
     end
 
@@ -963,7 +963,7 @@ describe Spree::Order do
       before { Spree::Config.set(:prices_inc_tax => true) }
 
       it "should be true when tax_zone is not the same as the default" do
-        @order.stub :tax_zone => Factory(:zone, :name => "other_zone")
+        @order.stub :tax_zone => create(:zone, :name => "other_zone")
         @order.exclude_tax?.should be_true
       end
 

--- a/core/spec/models/product_property_spec.rb
+++ b/core/spec/models/product_property_spec.rb
@@ -4,7 +4,7 @@ describe Spree::ProductProperty do
 
   context "validations" do
     it "should validate length of value" do
-      pp = Factory(:product_property)
+      pp = create(:product_property)
       pp.value = "x" * 256
       pp.should_not be_valid
     end

--- a/core/spec/models/product_spec.rb
+++ b/core/spec/models/product_spec.rb
@@ -20,11 +20,11 @@ describe Spree::Product do
   end
 
   context 'product instance' do
-    let(:product) { Factory(:product) }
+    let(:product) { create(:product) }
 
     context '#duplicate' do
       before do
-        product.stub :taxons => [Factory(:taxon)]
+        product.stub :taxons => [create(:taxon)]
       end
 
       it 'duplicates product' do
@@ -61,10 +61,10 @@ describe Spree::Product do
 
       context "permalink should be incremented until the value is not taken" do
         before do
-          @other_product = Factory(:product, :name => 'zoo')
-          @product1 = Factory(:product, :name => 'foo')
-          @product2 = Factory(:product, :name => 'foo')
-          @product3 = Factory(:product, :name => 'foo')
+          @other_product = create(:product, :name => 'zoo')
+          @product1 = create(:product, :name => 'foo')
+          @product2 = create(:product, :name => 'foo')
+          @product3 = create(:product, :name => 'foo')
         end
         it "should have valid permalink" do
           @product1.permalink.should == 'foo'
@@ -76,7 +76,7 @@ describe Spree::Product do
       context "permalink should be incremented until the value is not taken when there are more than 10 products" do
         before do
           @products = 0.upto(11).map do
-            Factory(:product, :name => 'foo')
+            create(:product, :name => 'foo')
           end
         end
         it "should have valid permalink" do
@@ -86,10 +86,10 @@ describe Spree::Product do
 
       context "permalink should be incremented until the value is not taken for similar names" do
         before do
-          @other_product = Factory(:product, :name => 'foo bar')
-          @product1 = Factory(:product, :name => 'foo')
-          @product2 = Factory(:product, :name => 'foo')
-          @product3 = Factory(:product, :name => 'foo')
+          @other_product = create(:product, :name => 'foo bar')
+          @product1 = create(:product, :name => 'foo')
+          @product2 = create(:product, :name => 'foo')
+          @product3 = create(:product, :name => 'foo')
         end
         it "should have valid permalink" do
           @product1.permalink.should == 'foo'
@@ -100,9 +100,9 @@ describe Spree::Product do
 
       context "permalink should be incremented until the value is not taken for similar names when there are more than 10 products" do
         before do
-          @other_product = Factory(:product, :name => 'foo a')
+          @other_product = create(:product, :name => 'foo a')
           @products = 0.upto(11).map do
-            Factory(:product, :name => 'foo')
+            create(:product, :name => 'foo')
           end
         end
         it "should have valid permalink" do
@@ -112,8 +112,8 @@ describe Spree::Product do
 
       context "make_permalink should declare validates_uniqueness_of" do
         before do
-          @product1 = Factory(:product, :name => 'foo')
-          @product2 = Factory(:product, :name => 'foo')
+          @product1 = create(:product, :name => 'foo')
+          @product2 = create(:product, :name => 'foo')
           @product2.update_attributes(:permalink => 'foo')
         end
 
@@ -131,14 +131,14 @@ describe Spree::Product do
 
   context "permalink generation" do
     it "supports Chinese" do
-      @product = Factory(:product, :name => "你好")
+      @product = create(:product, :name => "你好")
       @product.permalink.should == "ni-hao"
     end
   end
 
   context "scopes" do
     context ".group_by_products_id.count" do
-      let(:product) { Factory(:product) }
+      let(:product) { create(:product) }
       it 'produces a properly formed ordered-hash key' do
         expected_key = (ActiveRecord::Base.connection.adapter_name == 'PostgreSQL') ?
           Spree::Product.column_names.map{|col_name| product.send(col_name)} :
@@ -181,7 +181,7 @@ describe Spree::Product do
 
   context '#create' do
     before do
-      @prototype = Factory(:prototype)
+      @prototype = create(:prototype)
       @product = Spree::Product.new(:name => "Foo", :price => 1.99)
     end
 
@@ -294,7 +294,7 @@ describe Spree::Product do
   end
 
   context "#images" do
-    let(:product) { Factory(:product) }
+    let(:product) { create(:product) }
 
     before do
       pending "This is more trouble than it's worth. Expects bucket_name for some stupid reason."

--- a/core/spec/models/shipment_spec.rb
+++ b/core/spec/models/shipment_spec.rb
@@ -114,7 +114,7 @@ describe Spree::Shipment do
       end
 
       it "should validate with inventory" do
-        shipment.inventory_units = [Factory(:inventory_unit)]
+        shipment.inventory_units = [create(:inventory_unit)]
         shipment.valid?.should be_true
       end
 

--- a/core/spec/models/shipping_method_spec.rb
+++ b/core/spec/models/shipping_method_spec.rb
@@ -11,9 +11,9 @@ describe Spree::ShippingMethod do
 
   context 'available?' do
     before(:each) do
-      @shipping_method = Factory(:shipping_method)
-      variant = Factory(:variant, :product => Factory(:product))
-      @order = Factory(:order, :line_items => [Factory(:line_item, :variant => variant)])
+      @shipping_method = create(:shipping_method)
+      variant = create(:variant, :product => create(:product))
+      @order = create(:order, :line_items => [create(:line_item, :variant => variant)])
     end
 
     context "when the calculator is not available" do
@@ -35,11 +35,11 @@ describe Spree::ShippingMethod do
 
   context 'available_to_order?' do
     before(:each) do
-      @shipping_method = Factory(:shipping_method)
+      @shipping_method = create(:shipping_method)
       @shipping_method.zone.stub(:include? => true)
       @shipping_method.stub(:available? => true)
-      variant = Factory(:variant, :product => Factory(:product))
-      @order = Factory(:order, :line_items => [Factory(:line_item, :variant => variant)])
+      variant = create(:variant, :product => create(:product))
+      @order = create(:order, :line_items => [create(:line_item, :variant => variant)])
     end
 
     context "when availability_check is false" do
@@ -76,21 +76,21 @@ describe Spree::ShippingMethod do
   context "#category_match?" do
     context "when no category is specified" do
       before(:each) do
-        @shipping_method = Factory(:shipping_method)
+        @shipping_method = create(:shipping_method)
       end
 
       it "should return true" do
-        @shipping_method.category_match?(Factory(:order)).should be_true
+        @shipping_method.category_match?(create(:order)).should be_true
       end
     end
 
     context "when a category is specified" do
-      before { @shipping_method = Factory(:shipping_method_with_category) }
+      before { @shipping_method = create(:shipping_method_with_category) }
 
       context "when all products match" do
         before(:each) do
-          variant = Factory(:variant, :product => Factory(:product, :shipping_category => @shipping_method.shipping_category))
-          @order = Factory(:order, :line_items => [Factory(:line_item, :variant => variant)])
+          variant = create(:variant, :product => create(:product, :shipping_category => @shipping_method.shipping_category))
+          @order = create(:order, :line_items => [create(:line_item, :variant => variant)])
         end
 
         context "when rule is every match" do
@@ -120,8 +120,8 @@ describe Spree::ShippingMethod do
 
       context "when no products match" do
         before(:each) do
-          variant = Factory(:variant, :product => Factory(:product, :shipping_category => Factory(:shipping_category)))
-          @order = Factory(:order, :line_items => [Factory(:line_item, :variant => variant)])
+          variant = create(:variant, :product => create(:product, :shipping_category => create(:shipping_category)))
+          @order = create(:order, :line_items => [create(:line_item, :variant => variant)])
         end
 
         context "when rule is every match" do
@@ -151,9 +151,9 @@ describe Spree::ShippingMethod do
 
       context "when some products match" do
         before(:each) do
-          variant1 = Factory(:variant, :product => Factory(:product, :shipping_category => @shipping_method.shipping_category))
-          variant2 = Factory(:variant, :product => Factory(:product, :shipping_category => Factory(:shipping_category)))
-          @order = Factory(:order, :line_items => [Factory(:line_item, :variant => variant1), Factory(:line_item, :variant => variant2)])
+          variant1 = create(:variant, :product => create(:product, :shipping_category => @shipping_method.shipping_category))
+          variant2 = create(:variant, :product => create(:product, :shipping_category => create(:shipping_category)))
+          @order = create(:order, :line_items => [create(:line_item, :variant => variant1), create(:line_item, :variant => variant2)])
         end
 
         context "when rule is every match" do

--- a/core/spec/models/state_spec.rb
+++ b/core/spec/models/state_spec.rb
@@ -6,13 +6,13 @@ describe Spree::State do
   end
 
   it "can find a state by name or abbr" do
-    state = Factory(:state, :name => "California", :abbr => "CA")
+    state = create(:state, :name => "California", :abbr => "CA")
     Spree::State.find_all_by_name_or_abbr("California").should include(state)
     Spree::State.find_all_by_name_or_abbr("CA").should include(state)
   end
 
   it "can find all states group by country id" do
-    state = Factory(:state)
+    state = create(:state)
     Spree::State.states_group_by_country_id.should == { state.country_id.to_s => [[state.id, state.name]] }
   end
 end

--- a/core/spec/models/tax_category_spec.rb
+++ b/core/spec/models/tax_category_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Spree::TaxCategory do
   context '#mark_deleted!' do
-    let(:tax_category) { Factory(:tax_category) }
+    let(:tax_category) { create(:tax_category) }
 
     it "should set the deleted at column to the current time" do
       tax_category.mark_deleted!
@@ -11,8 +11,8 @@ describe Spree::TaxCategory do
   end
 
   context 'default tax category' do
-    let(:tax_category) { Factory(:tax_category) }
-    let(:new_tax_category) { Factory(:tax_category) }
+    let(:tax_category) { create(:tax_category) }
+    let(:new_tax_category) { create(:tax_category) }
 
     before do
       tax_category.update_attribute(:is_default, true)

--- a/core/spec/models/tax_rate_spec.rb
+++ b/core/spec/models/tax_rate_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 
 describe Spree::TaxRate do
   context "match" do
-    let(:order) { Factory(:order) }
-    let(:country) { Factory(:country) }
-    let(:tax_category) { Factory(:tax_category) }
+    let(:order) { create(:order) }
+    let(:country) { create(:country) }
+    let(:tax_category) { create(:tax_category) }
     let(:calculator) { Spree::Calculator::FlatRate.new }
 
 
@@ -15,12 +15,12 @@ describe Spree::TaxRate do
 
     context "when no rate zones match the tax zone" do
       before do
-        Spree::TaxRate.create({:amount => 1, :zone => Factory(:zone, :name => 'other_zone')}, :without_protection => true)
+        Spree::TaxRate.create({:amount => 1, :zone => create(:zone, :name => 'other_zone')}, :without_protection => true)
       end
 
       context "when there is no default tax zone" do
         before do
-          @zone = Factory(:zone, :name => "Country Zone", :default_tax => false)
+          @zone = create(:zone, :name => "Country Zone", :default_tax => false)
           @zone.zone_members.create(:zoneable => country)
         end
 
@@ -49,8 +49,8 @@ describe Spree::TaxRate do
 
         context "when the tax_zone is contained within a rate zone" do
           before do
-            sub_zone = Factory(:zone, :name => "State Zone")
-            sub_zone.zone_members.create(:zoneable => Factory(:state, :country => country))
+            sub_zone = create(:zone, :name => "State Zone")
+            sub_zone.zone_members.create(:zoneable => create(:state, :country => country))
             order.stub :tax_zone => sub_zone
             @rate = Spree::TaxRate.create({:amount => 1, :zone => @zone, :tax_category => tax_category,
                                           :calculator => calculator}, :without_protection => true)
@@ -65,12 +65,12 @@ describe Spree::TaxRate do
 
       context "when there is a default tax zone" do
         before do
-          @zone = Factory(:zone, :name => "Country Zone", :default_tax => true)
+          @zone = create(:zone, :name => "Country Zone", :default_tax => true)
           @zone.zone_members.create(:zoneable => country)
         end
 
         context "when there order has a different tax zone" do
-          before { order.stub :tax_zone => Factory(:zone, :name => "Other Zone") }
+          before { order.stub :tax_zone => create(:zone, :name => "Other Zone") }
 
           it "should return the rates associated with the default tax zone" do
             rate = Spree::TaxRate.create({:amount => 1, :zone => @zone, :tax_category => tax_category,
@@ -87,8 +87,8 @@ describe Spree::TaxRate do
   end
 
   context "default" do
-    let(:tax_category) { Factory(:tax_category) }
-    let(:country) { Factory(:country) }
+    let(:tax_category) { create(:tax_category) }
+    let(:country) { create(:country) }
     let(:calculator) { Spree::Calculator::FlatRate.new }
 
     context "when there is no default tax_category" do
@@ -105,7 +105,7 @@ describe Spree::TaxRate do
       context "when the default category has tax rates in the default tax zone" do
         before(:each) do
           Spree::Config[:default_country_id] = country.id
-          @zone = Factory(:zone, :name => "Country Zone", :default_tax => true)
+          @zone = create(:zone, :name => "Country Zone", :default_tax => true)
           @zone.zone_members.create(:zoneable => country)
           rate = Spree::TaxRate.create({:amount => 1, :zone => @zone, :tax_category => tax_category, :calculator => calculator}, :without_protection => true)
         end
@@ -130,8 +130,8 @@ describe Spree::TaxRate do
       @calculator  = Spree::Calculator::DefaultTax.new
       @rate        = Spree::TaxRate.create({:amount => 0.10, :calculator => @calculator, :tax_category => @category}, :without_protection => true)
       @order       = Spree::Order.create!
-      @taxable     = Factory(:product, :tax_category => @category)
-      @nontaxable  = Factory(:product, :tax_category => @category2)
+      @taxable     = create(:product, :tax_category => @category)
+      @nontaxable  = create(:product, :tax_category => @category2)
     end
 
     context "when order has no taxable line items" do
@@ -222,7 +222,7 @@ describe Spree::TaxRate do
 
     context "when order has multiple taxable line items" do
       before do
-        @taxable2 = Factory(:product, :tax_category => @category)
+        @taxable2 = create(:product, :tax_category => @category)
         @order.add_variant @taxable.master
         @order.add_variant @taxable2.master
       end

--- a/core/spec/models/taxonomy_spec.rb
+++ b/core/spec/models/taxonomy_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe Spree::Taxonomy do
   context "#destroy" do
     before do
-       @taxonomy = Factory(:taxonomy)
+       @taxonomy = create(:taxonomy)
        @root_taxon = @taxonomy.root
-       @child_taxon = Factory(:taxon, :taxonomy_id => @taxonomy.id, :parent => @root_taxon)
+       @child_taxon = create(:taxon, :taxonomy_id => @taxonomy.id, :parent => @root_taxon)
     end
 
     it "should destroy all associated taxons" do

--- a/core/spec/models/user_spec.rb
+++ b/core/spec/models/user_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Spree::User do
   context "Core::UserBanners" do
     it "save dismissed banners" do
-      user = Factory(:user)
+      user = create(:user)
       user.dismiss_banner(:test_banner)
       user.dismissed_banner?(:test_banner).should be_true
     end

--- a/core/spec/models/variant/scopes_spec.rb
+++ b/core/spec/models/variant/scopes_spec.rb
@@ -1,26 +1,26 @@
 require 'spec_helper'
 
 describe "Variant scopes" do
-  let!(:product) { Factory(:product) }
-  let!(:variant_1) { Factory(:variant, :product => product) }
-  let!(:variant_2) { Factory(:variant, :product => product) }
+  let!(:product) { create(:product) }
+  let!(:variant_1) { create(:variant, :product => product) }
+  let!(:variant_2) { create(:variant, :product => product) }
 
   it ".descend_by_popularity" do
     # Requires a product with at least two variants, where one has a higher number of orders than the other
-    Factory(:line_item, :variant => variant_1)
+    create(:line_item, :variant => variant_1)
     Spree::Variant.descend_by_popularity.first.should == variant_1
   end
 
   context "finding by option values" do
-    let!(:option_type) { Factory(:option_type, :name => "bar") }
+    let!(:option_type) { create(:option_type, :name => "bar") }
     let!(:option_value_1) do
-      option_value = Factory(:option_value, :name => "foo", :option_type => option_type)
+      option_value = create(:option_value, :name => "foo", :option_type => option_type)
       variant_1.option_values << option_value
       option_value
     end
 
     let!(:option_value_2) do
-      option_value = Factory(:option_value, :name => "fizz", :option_type => option_type)
+      option_value = create(:option_value, :name => "fizz", :option_type => option_type)
       variant_1.option_values << option_value
       option_value
     end

--- a/core/spec/models/variant_spec.rb
+++ b/core/spec/models/variant_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Spree::Variant do
-  let!(:variant) { Factory(:variant, :count_on_hand => 95) }
+  let!(:variant) { create(:variant, :count_on_hand => 95) }
 
   before(:each) do
     reset_spree_preferences

--- a/core/spec/models/zone_spec.rb
+++ b/core/spec/models/zone_spec.rb
@@ -2,18 +2,18 @@ require 'spec_helper'
 
 describe Spree::Zone do
   context "#match" do
-    let(:country_zone) { Factory(:zone, :name => "CountryZone") }
+    let(:country_zone) { create(:zone, :name => "CountryZone") }
     let(:country) do
-      country = Factory(:country)
+      country = create(:country)
       # Create at least one state for this country
-      state = Factory(:state, :country => country)
+      state = create(:state, :country => country)
       country
     end
 
     before { country_zone.members.create(:zoneable => country) }
 
     context "when there is only one qualifying zone" do
-      let(:address) { Factory(:address, :country => country, :state => country.states.first) }
+      let(:address) { create(:address, :country => country, :state => country.states.first) }
 
       it "should return the qualifying zone" do
         Spree::Zone.match(address).should == country_zone
@@ -21,8 +21,8 @@ describe Spree::Zone do
     end
 
     context "when there are two qualified zones with same member type" do
-      let(:address) { Factory(:address, :country => country, :state => country.states.first) }
-      let(:second_zone) { Factory(:zone, :name => "SecondZone") }
+      let(:address) { create(:address, :country => country, :state => country.states.first) }
+      let(:second_zone) { create(:zone, :name => "SecondZone") }
 
       before { second_zone.members.create(:zoneable => country) }
       it "should return the zone that was created first" do
@@ -31,8 +31,8 @@ describe Spree::Zone do
     end
 
     context "when there are two qualified zones with different member types" do
-      let(:state_zone) { Factory(:zone, :name => "StateZone") }
-      let(:address) { Factory(:address, :country => country, :state => country.states.first) }
+      let(:state_zone) { create(:zone, :name => "StateZone") }
+      let(:address) { create(:address, :country => country, :state => country.states.first) }
 
       before { state_zone.members.create(:zoneable => country.states.first) }
 
@@ -50,10 +50,10 @@ describe Spree::Zone do
 
   context "default_tax" do
     context "when there is a default tax zone specified" do
-      before { @foo_zone = Factory(:zone, :name => "whatever", :default_tax => true) }
+      before { @foo_zone = create(:zone, :name => "whatever", :default_tax => true) }
 
       it "should be the correct zone" do
-        foo_zone = Factory(:zone, :name => "foo")
+        foo_zone = create(:zone, :name => "foo")
         Spree::Zone.default_tax.should == @foo_zone
       end
     end
@@ -66,13 +66,13 @@ describe Spree::Zone do
   end
 
   context "#contains?" do
-    let(:country1) { Factory(:country) }
-    let(:country2) { Factory(:country) }
-    let(:country3) { Factory(:country) }
+    let(:country1) { create(:country) }
+    let(:country2) { create(:country) }
+    let(:country3) { create(:country) }
 
     before do
-      @source = Factory(:zone, :name => "source")
-      @target = Factory(:zone, :name => "target")
+      @source = create(:zone, :name => "source")
+      @target = create(:zone, :name => "target")
     end
 
     context "when the target has no members" do
@@ -123,7 +123,7 @@ describe Spree::Zone do
         before do
           @target.members.create(:zoneable => country1)
           @target.members.create(:zoneable => country2)
-          @target.members.create(:zoneable => Factory(:country))
+          @target.members.create(:zoneable => create(:country))
         end
 
         it "should be false" do
@@ -133,8 +133,8 @@ describe Spree::Zone do
 
       context "when none of the members are included in the zone we check against" do
         before do
-          @target.members.create(:zoneable => Factory(:country))
-          @target.members.create(:zoneable => Factory(:country))
+          @target.members.create(:zoneable => create(:country))
+          @target.members.create(:zoneable => create(:country))
         end
 
         it "should be false" do
@@ -145,7 +145,7 @@ describe Spree::Zone do
 
     context "when checking country against state" do
       before do
-        @source.members.create(:zoneable => Factory(:state))
+        @source.members.create(:zoneable => create(:state))
         @target.members.create(:zoneable => country1)
       end
 
@@ -160,7 +160,7 @@ describe Spree::Zone do
       context "when all states contained in one of the countries we check against" do
 
         before do
-          state1 = Factory(:state, :country => country1)
+          state1 = create(:state, :country => country1)
           @target.members.create(:zoneable => state1)
         end
 
@@ -172,9 +172,9 @@ describe Spree::Zone do
       context "when some states contained in one of the countries we check against" do
 
         before do
-          state1 = Factory(:state, :country => country1)
+          state1 = create(:state, :country => country1)
           @target.members.create(:zoneable => state1)
-          @target.members.create(:zoneable => Factory(:state, :country => country2))
+          @target.members.create(:zoneable => create(:state, :country => country2))
         end
 
         it "should be false" do
@@ -185,8 +185,8 @@ describe Spree::Zone do
       context "when none of the states contained in any of the countries we check against" do
 
         before do
-          @target.members.create(:zoneable => Factory(:state, :country => country2))
-          @target.members.create(:zoneable => Factory(:state, :country => country2))
+          @target.members.create(:zoneable => create(:state, :country => country2))
+          @target.members.create(:zoneable => create(:state, :country => country2))
         end
 
         it "should be false" do
@@ -200,17 +200,17 @@ describe Spree::Zone do
   context "#save" do
     context "when default_tax is true" do
       it "should clear previous default tax zone" do
-        zone1 = Factory(:zone, :name => "foo", :default_tax => true)
-        zone = Factory(:zone, :name => "bar", :default_tax => true)
+        zone1 = create(:zone, :name => "foo", :default_tax => true)
+        zone = create(:zone, :name => "bar", :default_tax => true)
         zone1.reload.default_tax.should == false
       end
     end
 
     context "when a zone member country is added to an existing zone consisting of state members" do
       it "should remove existing state members" do
-        zone = Factory(:zone, :name => "foo")
-        state = Factory(:state)
-        country = Factory(:country)
+        zone = create(:zone, :name => "foo")
+        state = create(:state)
+        country = create(:country)
         zone.members.create(:zoneable => state)
         country_member = zone.members.create(:zoneable => country)
         zone.save

--- a/core/spec/requests/admin/configuration/analytics_tracker_spec.rb
+++ b/core/spec/requests/admin/configuration/analytics_tracker_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe "Analytics Tracker" do
   context "index" do
     before(:each) do
-      2.times { Factory(:tracker, :environment => "test") }
+      2.times { create(:tracker, :environment => "test") }
       visit spree.admin_path
       click_link "Configuration"
       click_link "Analytics Tracker"

--- a/core/spec/requests/admin/configuration/mail_methods_spec.rb
+++ b/core/spec/requests/admin/configuration/mail_methods_spec.rb
@@ -8,7 +8,7 @@ describe "Mail Methods" do
 
   context "index" do
     before(:each) do
-      Factory(:mail_method)
+      create(:mail_method)
       click_link "Mail Methods"
     end
 
@@ -30,7 +30,7 @@ describe "Mail Methods" do
 
   context "edit" do
     before(:each) do
-      Factory(:mail_method)
+      create(:mail_method)
       click_link "Mail Methods"
     end
 

--- a/core/spec/requests/admin/configuration/payment_methods_spec.rb
+++ b/core/spec/requests/admin/configuration/payment_methods_spec.rb
@@ -8,7 +8,7 @@ describe "Payment Methods" do
 
   context "admin visiting payment methods listing page" do
     it "should display existing payment methods" do
-      2.times { Factory(:payment_method) }
+      2.times { create(:payment_method) }
       click_link "Payment Methods"
 
       find('table#listing_payment_methods th:nth-child(1)').text.should == "Name"
@@ -39,7 +39,7 @@ describe "Payment Methods" do
 
   context "admin editing a payment method" do
     before(:each) do
-      2.times { Factory(:payment_method) }
+      2.times { create(:payment_method) }
       click_link "Payment Methods"
       within(:css, 'table#listing_payment_methods tbody:nth-child(2) tr:nth-child(1)') { click_link "Edit" }
     end

--- a/core/spec/requests/admin/configuration/shipping_methods_spec.rb
+++ b/core/spec/requests/admin/configuration/shipping_methods_spec.rb
@@ -13,19 +13,19 @@ describe "Shipping Methods" do
     PAYMENT_STATES = Spree::Payment.state_machine.states.keys unless defined? PAYMENT_STATES
     SHIPMENT_STATES = Spree::Shipment.state_machine.states.keys unless defined? SHIPMENT_STATES
     ORDER_STATES = Spree::Order.state_machine.states.keys unless defined? ORDER_STATES
-    Factory(:payment_method, :environment => 'test')
-    Factory(:shipping_method, :zone => Spree::Zone.find_by_name('North America'))
-    @product = Factory(:product, :name => "Mug")
+    create(:payment_method, :environment => 'test')
+    create(:shipping_method, :zone => Spree::Zone.find_by_name('North America'))
+    @product = create(:product, :name => "Mug")
 
     visit spree.admin_path
     click_link "Configuration"
   end
 
-  let!(:address) { Factory(:address, :state => Spree::State.first) }
+  let!(:address) { create(:address, :state => Spree::State.first) }
 
   context "show" do
     it "should display exisiting shipping methods" do
-      2.times { Factory(:shipping_method) }
+      2.times { create(:shipping_method) }
       click_link "Shipping Methods"
 
       find('table#listing_shipping_methods tbody tr:nth-child(1) td:nth-child(1)').text.should == "UPS Ground"
@@ -62,7 +62,7 @@ describe "Shipping Methods" do
 
   context "availability", :js => true do
     before(:each) do
-      @shipping_category = Factory(:shipping_category, :name => "Default")
+      @shipping_category = create(:shipping_category, :name => "Default")
       click_link "Shipping Methods"
       click_link "admin_new_shipping_method_link"
     end
@@ -177,7 +177,7 @@ describe "Shipping Methods" do
 
     context "when rule is at least one products match" do
       before(:each) do
-        Factory(:product, :name => "Shirt")
+        create(:product, :name => "Shirt")
       end
 
       context "when match rules are satisfied" do

--- a/core/spec/requests/admin/configuration/states_spec.rb
+++ b/core/spec/requests/admin/configuration/states_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe "States" do
-  let!(:country) { Factory.create(:country) }
+  let!(:country) { create(:country) }
 
   before(:each) do
     Spree::Config[:default_country_id] = country.id
@@ -11,7 +11,7 @@ describe "States" do
   end
 
   context "admin visiting states listing" do
-    let!(:state) { Factory.create(:state, :country => country) }
+    let!(:state) { create(:state, :country => country) }
 
     it "should correctly display the states" do
       click_link "States"

--- a/core/spec/requests/admin/configuration/tax_categories_spec.rb
+++ b/core/spec/requests/admin/configuration/tax_categories_spec.rb
@@ -8,7 +8,7 @@ describe "Tax Categories" do
 
   context "admin visiting tax categories list" do
     it "should display the existing tax categories" do
-      Factory(:tax_category, :name => "Clothing", :description => "For Clothing")
+      create(:tax_category, :name => "Clothing", :description => "For Clothing")
       click_link "Tax Categories"
       page.should have_content("Listing Tax Categories")
       find('table#listing_tax_categories tbody tr td:nth-child(1)').text.should == "Clothing"
@@ -39,7 +39,7 @@ describe "Tax Categories" do
 
   context "admin editing a tax category" do
     it "should be able to update an existing tax category" do
-      Factory(:tax_category)
+      create(:tax_category)
       click_link "Tax Categories"
       within(:css, 'table#listing_tax_categories tbody tr:nth-child(1)') { click_link "Edit" }
       fill_in "tax_category_description", :with => "desc 99"

--- a/core/spec/requests/admin/configuration/tax_rates_spec.rb
+++ b/core/spec/requests/admin/configuration/tax_rates_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe "Tax Rates" do
-  let!(:tax_rate) { Factory(:tax_rate, :calculator => stub_model(Spree::Calculator)) }
+  let!(:tax_rate) { create(:tax_rate, :calculator => stub_model(Spree::Calculator)) }
 
   before do
     visit spree.admin_path

--- a/core/spec/requests/admin/configuration/taxonomies_spec.rb
+++ b/core/spec/requests/admin/configuration/taxonomies_spec.rb
@@ -8,8 +8,8 @@ describe "Taxonomies" do
 
   context "show" do
     it "should display existing taxonomies" do
-      Factory(:taxonomy, :name => 'Brand')
-      Factory(:taxonomy, :name => 'Categories')
+      create(:taxonomy, :name => 'Brand')
+      create(:taxonomy, :name => 'Categories')
       click_link "Taxonomies"
       find('table#listing_taxonomies tr:nth-child(2) td:nth-child(1)').text.should include("Brand")
       find('table#listing_taxonomies tr:nth-child(3) td:nth-child(1)').text.should include("Categories")
@@ -38,7 +38,7 @@ describe "Taxonomies" do
 
   context "edit" do
     it "should allow an admin to update an existing taxonomy" do
-      Factory(:taxonomy)
+      create(:taxonomy)
       click_link "Taxonomies"
       within(:css, 'table#listing_taxonomies tr:nth-child(2)') { click_link "Edit" }
       page.should have_content("Edit taxonomy")

--- a/core/spec/requests/admin/configuration/zones_spec.rb
+++ b/core/spec/requests/admin/configuration/zones_spec.rb
@@ -9,8 +9,8 @@ describe "Zones" do
 
   context "show" do
     it "should display existing zones" do
-      Factory(:zone, :name => "eastern", :description => "zone is eastern")
-      Factory(:zone, :name => "western", :description => "cool san fran")
+      create(:zone, :name => "eastern", :description => "zone is eastern")
+      create(:zone, :name => "western", :description => "cool san fran")
       click_link "Zones"
 
       find('table#listing_zones tbody tr:nth-child(1) td:nth-child(1)').text.should == "eastern"

--- a/core/spec/requests/admin/orders/adjustments_spec.rb
+++ b/core/spec/requests/admin/orders/adjustments_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe "Adjustments" do
   before(:each) do
     visit spree.admin_path
-    order = Factory(:order, :completed_at => "2011-02-01 12:36:15", :number => "R100")
-    Factory(:adjustment, :adjustable => order)
+    order = create(:order, :completed_at => "2011-02-01 12:36:15", :number => "R100")
+    create(:adjustment, :adjustable => order)
     click_link "Orders"
     within(:css, 'table#listing_orders tbody tr:nth-child(1)') { click_link "Edit" }
     click_link "Adjustments"

--- a/core/spec/requests/admin/orders/customer_details_spec.rb
+++ b/core/spec/requests/admin/orders/customer_details_spec.rb
@@ -1,17 +1,17 @@
 require 'spec_helper'
 
 describe "Customer Details" do
-  let(:shipping_method) { Factory(:shipping_method, :display_on => "front_end") }
-  let(:order) { Factory(:order_with_inventory_unit_shipped, :completed_at => 1.year.ago, :shipping_method => shipping_method) }
+  let(:shipping_method) { create(:shipping_method, :display_on => "front_end") }
+  let(:order) { create(:order_with_inventory_unit_shipped, :completed_at => 1.year.ago, :shipping_method => shipping_method) }
 
   before do
     reset_spree_preferences do |config|
-      config.default_country_id = Factory(:country).id
+      config.default_country_id = create(:country).id
     end
 
-    Factory(:shipping_method, :display_on => "front_end")
-    Factory(:order_with_inventory_unit_shipped, :completed_at => "2011-02-01 12:36:15")
-    Factory(:user, :email => 'foobar@example.com', :ship_address => Factory(:address), :bill_address => Factory(:address))
+    create(:shipping_method, :display_on => "front_end")
+    create(:order_with_inventory_unit_shipped, :completed_at => "2011-02-01 12:36:15")
+    create(:user, :email => 'foobar@example.com', :ship_address => create(:address), :bill_address => create(:address))
 
     visit spree.admin_path
     click_link "Orders"
@@ -43,7 +43,7 @@ describe "Customer Details" do
 
     it "should be able to update customer details for an existing order" do
       pending "Hanging at line 60"
-      order.ship_address = Factory(:address)
+      order.ship_address = create(:address)
       order.save!
 
       click_link "Customer Details"

--- a/core/spec/requests/admin/orders/history_spec.rb
+++ b/core/spec/requests/admin/orders/history_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe "Admin visiting history" do
   it "should display order history", :js => true do
-    order = Factory(:order)
+    order = create(:order)
     order.finalize!
 
     visit spree.admin_path

--- a/core/spec/requests/admin/orders/listing_spec.rb
+++ b/core/spec/requests/admin/orders/listing_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 describe "Orders Listing" do
   before(:each) do
-    Factory(:order, :created_at => Time.now + 1.day, :completed_at => Time.now + 1.day, :number => "R100")
-    Factory(:order, :created_at => Time.now - 1.day, :completed_at => Time.now - 1.day, :number => "R200")
+    create(:order, :created_at => Time.now + 1.day, :completed_at => Time.now + 1.day, :number => "R100")
+    create(:order, :created_at => Time.now - 1.day, :completed_at => Time.now - 1.day, :number => "R200")
     visit spree.admin_path
   end
 

--- a/core/spec/requests/admin/orders/order_details_spec.rb
+++ b/core/spec/requests/admin/orders/order_details_spec.rb
@@ -12,8 +12,8 @@ describe "Order Details" do
 
     after(:each) { I18n.reload! }
 
-    let(:product) { Factory(:product, :name => 'spree t-shirt', :on_hand => 5, :price => 19.99) }
-    let(:order) { Factory(:order, :completed_at => "2011-02-01 12:36:15", :number => "R100") }
+    let(:product) { create(:product, :name => 'spree t-shirt', :on_hand => 5, :price => 19.99) }
+    let(:order) { create(:order, :completed_at => "2011-02-01 12:36:15", :number => "R100") }
 
     it "should allow me to edit order details", :js => true do
       order.add_variant(product.master, 2)

--- a/core/spec/requests/admin/orders/payments_spec.rb
+++ b/core/spec/requests/admin/orders/payments_spec.rb
@@ -8,9 +8,9 @@ describe "Payments" do
     end
 
     Spree::Zone.delete_all
-    shipping_method = Factory(:shipping_method, :zone => Factory(:zone, :name => 'North America')) 
-    @order = Factory(:completed_order_with_totals, :number => "R100", :state => "complete",  :shipping_method => shipping_method) 
-    product = Factory(:product, :name => 'spree t-shirt', :on_hand => 5)
+    shipping_method = create(:shipping_method, :zone => create(:zone, :name => 'North America')) 
+    @order = create(:completed_order_with_totals, :number => "R100", :state => "complete",  :shipping_method => shipping_method) 
+    product = create(:product, :name => 'spree t-shirt', :on_hand => 5)
     product.master.count_on_hand = 5
     product.master.save
     @order.add_variant(product.master, 2)
@@ -26,7 +26,7 @@ describe "Payments" do
   context "payment methods" do
 
     before(:each) do
-      Factory(:payment, :order => @order, :amount => @order.outstanding_balance, :payment_method => Factory(:bogus_payment_method, :environment => 'test'))
+      create(:payment, :order => @order, :amount => @order.outstanding_balance, :payment_method => create(:bogus_payment_method, :environment => 'test'))
       visit spree.admin_path
       click_link "Orders"
       within('table#listing_orders tbody tr:nth-child(1)') { click_link "R100" }
@@ -71,10 +71,10 @@ describe "Payments" do
     context "with a check payment" do
       before do
         @order.payments.delete_all
-        Factory(:payment, :order => @order,
+        create(:payment, :order => @order,
                         :state => "checkout",
                         :amount => @order.outstanding_balance,
-                        :payment_method => Factory(:bogus_payment_method, :environment => 'test'))
+                        :payment_method => create(:bogus_payment_method, :environment => 'test'))
       end
 
       it "capturing a check payment from a new order" do

--- a/core/spec/requests/admin/orders/return_authorizations_spec.rb
+++ b/core/spec/requests/admin/orders/return_authorizations_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
 describe "return authorizations" do
-  let!(:order) { Factory(:completed_order_with_totals) }
+  let!(:order) { create(:completed_order_with_totals) }
 
   before do
     order.inventory_units.update_all("state = 'shipped'")
-    Factory(:return_authorization,
+    create(:return_authorization,
             :order => order,
             :state => 'authorized',
             :inventory_units => order.inventory_units)

--- a/core/spec/requests/admin/orders/shipments_spec.rb
+++ b/core/spec/requests/admin/orders/shipments_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe "Shipments" do
   
   Spree::Zone.delete_all
-  let(:shipping_method) { Factory(:shipping_method, :zone => Spree::Zone.find_by_name('North America') || Factory(:zone, :name => 'North America')) }
-  let(:order) { Factory(:completed_order_with_totals, :number => "R100", :state => "complete",  :shipping_method => shipping_method) }
+  let(:shipping_method) { create(:shipping_method, :zone => Spree::Zone.find_by_name('North America') || create(:zone, :name => 'North America')) }
+  let(:order) { create(:completed_order_with_totals, :number => "R100", :state => "complete",  :shipping_method => shipping_method) }
 
   before(:each) do
     reset_spree_preferences do |config|

--- a/core/spec/requests/admin/products/edit/images_spec.rb
+++ b/core/spec/requests/admin/products/edit/images_spec.rb
@@ -5,7 +5,7 @@ describe "Product Images" do
     it "should allow an admin to upload and edit an image for a product" do
       Spree::Image.attachment_definitions[:attachment].delete :storage
 
-      Factory(:product, :name => 'apache baseball cap', :sku => 'A100', :available_on => "2011-01-01 01:01:01", :count_on_hand => 10)
+      create(:product, :name => 'apache baseball cap', :sku => 'A100', :available_on => "2011-01-01 01:01:01", :count_on_hand => 10)
 
       visit spree.admin_path
       click_link "Products"

--- a/core/spec/requests/admin/products/edit/products_spec.rb
+++ b/core/spec/requests/admin/products/edit/products_spec.rb
@@ -5,7 +5,7 @@ describe 'Product Details' do
   context 'editing a product' do
     let(:available_on) { Time.now }
     it 'should list the product details' do
-      Factory(:product, :name => 'Bún thịt nướng', :permalink => 'bun-thit-nuong', :sku => 'A100',
+      create(:product, :name => 'Bún thịt nướng', :permalink => 'bun-thit-nuong', :sku => 'A100',
               :description => 'lorem ipsum', :available_on => available_on, :count_on_hand => 10)
 
       visit spree.admin_path
@@ -27,7 +27,7 @@ describe 'Product Details' do
     end
 
     it "should handle permalink changes" do
-      Factory(:product, :name => 'Bún thịt nướng', :permalink => 'bun-thit-nuong', :sku => 'A100',
+      create(:product, :name => 'Bún thịt nướng', :permalink => 'bun-thit-nuong', :sku => 'A100',
               :description => 'lorem ipsum', :available_on => '2011-01-01 01:01:01', :count_on_hand => 10)
 
       visit spree.admin_path

--- a/core/spec/requests/admin/products/edit/taxons_spec.rb
+++ b/core/spec/requests/admin/products/edit/taxons_spec.rb
@@ -3,11 +3,11 @@ require 'spec_helper'
 describe "Product Taxons" do
   context "managing taxons" do
     it "should allow an admin to manage taxons", :js => true do
-      taxon = Factory(:taxon, :name => 'Brands')
-      taxon2 = Factory(:taxon, :taxonomy => taxon.taxonomy, :parent_id => taxon.id, :name => 'Apache')
-      Factory(:product, :name => 'apache baseball cap', :sku => 'A100', :available_on => "2011-01-01 01:01:01")
-      Factory(:product, :name => 'apache baseball cap2', :sku => 'B100', :available_on => "2011-01-01 01:01:01")
-      Factory(:product, :name => 'zomg shirt', :sku => 'Z100', :available_on => "2011-01-01 01:01:01")
+      taxon = create(:taxon, :name => 'Brands')
+      taxon2 = create(:taxon, :taxonomy => taxon.taxonomy, :parent_id => taxon.id, :name => 'Apache')
+      create(:product, :name => 'apache baseball cap', :sku => 'A100', :available_on => "2011-01-01 01:01:01")
+      create(:product, :name => 'apache baseball cap2', :sku => 'B100', :available_on => "2011-01-01 01:01:01")
+      create(:product, :name => 'zomg shirt', :sku => 'Z100', :available_on => "2011-01-01 01:01:01")
       Spree::Product.update_all :count_on_hand => 10
 
       visit spree.admin_path

--- a/core/spec/requests/admin/products/edit/variants_spec.rb
+++ b/core/spec/requests/admin/products/edit/variants_spec.rb
@@ -7,9 +7,9 @@ describe "Product Variants" do
 
   context "editing variant option types", :js => true do
     it "should allow an admin to create option types for a variant" do
-      Factory(:product, :name => 'apache baseball cap', :sku => 'A100', :available_on => "2011-01-01 01:01:01")
-      Factory(:product, :name => 'apache baseball cap2', :sku => 'B100', :available_on => "2011-01-01 01:01:01")
-      Factory(:product, :name => 'zomg shirt', :sku => 'Z100', :available_on => "2011-01-01 01:01:01")
+      create(:product, :name => 'apache baseball cap', :sku => 'A100', :available_on => "2011-01-01 01:01:01")
+      create(:product, :name => 'apache baseball cap2', :sku => 'B100', :available_on => "2011-01-01 01:01:01")
+      create(:product, :name => 'zomg shirt', :sku => 'Z100', :available_on => "2011-01-01 01:01:01")
       Spree::Product.update_all :count_on_hand => 10
 
       click_link "Products"
@@ -37,9 +37,9 @@ describe "Product Variants" do
       click_button "Update"
       page.should have_content("successfully updated!")
 
-      Factory(:product, :name => 'apache baseball cap', :sku => 'A100', :available_on => "2011-01-01 01:01:01")
-      Factory(:product, :name => 'apache baseball cap2', :sku => 'B100', :available_on => "2011-01-01 01:01:01")
-      Factory(:product, :name => 'zomg shirt', :sku => 'Z100', :available_on => "2011-01-01 01:01:01")
+      create(:product, :name => 'apache baseball cap', :sku => 'A100', :available_on => "2011-01-01 01:01:01")
+      create(:product, :name => 'apache baseball cap2', :sku => 'B100', :available_on => "2011-01-01 01:01:01")
+      create(:product, :name => 'zomg shirt', :sku => 'Z100', :available_on => "2011-01-01 01:01:01")
       Spree::Product.update_all :count_on_hand => 10
 
       visit spree.admin_path

--- a/core/spec/requests/admin/products/option_types_spec.rb
+++ b/core/spec/requests/admin/products/option_types_spec.rb
@@ -8,8 +8,8 @@ describe "Option Types" do
 
   context "listing option types" do
     it "should list existing option types" do
-      Factory(:option_type, :name => "tshirt-color", :presentation => "Color")
-      Factory(:option_type, :name => "tshirt-size", :presentation => "Size")
+      create(:option_type, :name => "tshirt-color", :presentation => "Color")
+      create(:option_type, :name => "tshirt-size", :presentation => "Size")
 
       click_link "Option Types"
       find('table#listing_option_types tr:nth-child(2) td:nth-child(1)').text.should == " tshirt-color"
@@ -39,8 +39,8 @@ describe "Option Types" do
 
   context "editing an existing option type" do
     it "should allow an admin to update an existing option type" do
-      Factory(:option_type, :name => "tshirt-color", :presentation => "Color")
-      Factory(:option_type, :name => "tshirt-size", :presentation => "Size")
+      create(:option_type, :name => "tshirt-color", :presentation => "Color")
+      create(:option_type, :name => "tshirt-size", :presentation => "Size")
       click_link "Option Types"
       within('table#listing_option_types tr:nth-child(2)') { click_link "Edit" }
       fill_in "option_type_name", :with => "foo-size 99"

--- a/core/spec/requests/admin/products/products_spec.rb
+++ b/core/spec/requests/admin/products/products_spec.rb
@@ -9,8 +9,8 @@ describe "Products" do
     context "listing products" do
       context "sorting" do
         before do
-          Factory(:product, :name => 'apache baseball cap', :available_on => '2011-01-06 18:21:13:', :count_on_hand => '0', :price => 10)
-          Factory(:product, :name => 'zomg shirt', :available_on => '2125-01-06 18:21:13', :count_on_hand => '5', :price => 5)
+          create(:product, :name => 'apache baseball cap', :available_on => '2011-01-06 18:21:13:', :count_on_hand => '0', :price => 10)
+          create(:product, :name => 'zomg shirt', :available_on => '2125-01-06 18:21:13', :count_on_hand => '5', :price => 5)
         end
 
         it "should list existing products with correct sorting by name" do
@@ -38,8 +38,8 @@ describe "Products" do
 
     context "searching products" do
       it "should be able to search deleted products", :js => true do
-        Factory(:product, :name => 'apache baseball cap', :available_on => '2011-01-06 18:21:13:', :deleted_at => "2011-01-06 18:21:13")
-        Factory(:product, :name => 'zomg shirt', :available_on => '2125-01-06 18:21:13')
+        create(:product, :name => 'apache baseball cap', :available_on => '2011-01-06 18:21:13:', :deleted_at => "2011-01-06 18:21:13")
+        create(:product, :name => 'zomg shirt', :available_on => '2125-01-06 18:21:13')
 
         click_link "Products"
         page.should have_content("zomg shirt")
@@ -55,9 +55,9 @@ describe "Products" do
       end
 
       it "should be able to search products by their properties" do
-        Factory(:product, :name => 'apache baseball cap', :available_on => '2011-01-01 01:01:01', :sku => "A100")
-        Factory(:product, :name => 'apache baseball cap2', :available_on => '2011-01-01 01:01:01', :sku => "B100")
-        Factory(:product, :name => 'zomg shirt', :available_on => '2011-01-01 01:01:01', :sku => "Z100")
+        create(:product, :name => 'apache baseball cap', :available_on => '2011-01-01 01:01:01', :sku => "A100")
+        create(:product, :name => 'apache baseball cap2', :available_on => '2011-01-01 01:01:01', :sku => "B100")
+        create(:product, :name => 'zomg shirt', :available_on => '2011-01-01 01:01:01', :sku => "Z100")
         Spree::Product.update_all :count_on_hand => 10
 
         click_link "Products"
@@ -80,7 +80,7 @@ describe "Products" do
 
       before(:each) do
         @option_type_prototype = prototype
-        @property_prototype = Factory(:prototype, :name => "Random") 
+        @property_prototype = create(:prototype, :name => "Random") 
         click_link "Products"
         click_link "admin_new_product"
         within('#new_product') { page.should have_content("SKU") }
@@ -146,7 +146,7 @@ describe "Products" do
 
     context "cloning a product", :js => true do
       it "should allow an admin to clone a product" do
-        Factory(:product, :name => 'apache baseball cap', :available_on => '2011-01-01 01:01:01', :sku => "A100")
+        create(:product, :name => 'apache baseball cap', :available_on => '2011-01-01 01:01:01', :sku => "A100")
 
         click_link "Products"
         within('table#listing_products tr:nth-child(2)') { click_link "Clone" }
@@ -155,7 +155,7 @@ describe "Products" do
 
       context "cloning a deleted product" do
         it "should allow an admin to clone a deleted product" do
-          Factory(:product, :name => 'apache baseball cap', :available_on => '2011-01-01 01:01:01', :sku => "A100", :deleted_at => '2011-05-01 01:01:01')
+          create(:product, :name => 'apache baseball cap', :available_on => '2011-01-01 01:01:01', :sku => "A100", :deleted_at => '2011-05-01 01:01:01')
 
           click_link "Products"
           check "Show Deleted"
@@ -171,9 +171,9 @@ describe "Products" do
     context "uploading a product image" do
       it "should allow an admin to upload an image and edit it for a product" do
         Spree::Image.attachment_definitions[:attachment].delete :storage
-        Factory(:product, :name => 'apache baseball cap', :available_on => '2011-01-01 01:01:01', :sku => "A100")
-        Factory(:product, :name => 'apache baseball cap2', :available_on => '2011-01-01 01:01:01', :sku => "B100")
-        Factory(:product, :name => 'zomg shirt', :available_on => '2011-01-01 01:01:01', :sku => "Z100")
+        create(:product, :name => 'apache baseball cap', :available_on => '2011-01-01 01:01:01', :sku => "A100")
+        create(:product, :name => 'apache baseball cap2', :available_on => '2011-01-01 01:01:01', :sku => "B100")
+        create(:product, :name => 'zomg shirt', :available_on => '2011-01-01 01:01:01', :sku => "Z100")
         Spree::Product.update_all :count_on_hand => 10
 
         click_link "Products"
@@ -194,9 +194,9 @@ describe "Products" do
 
     context "uploading a product image" do
       it "should allow an admin to upload an image and edit it for a product" do
-        Factory(:product, :name => 'apache baseball cap', :available_on => '2011-01-01 01:01:01', :sku => "A100")
-        Factory(:product, :name => 'apache baseball cap2', :available_on => '2011-01-01 01:01:01', :sku => "B100")
-        Factory(:product, :name => 'zomg shirt', :available_on => '2011-01-01 01:01:01', :sku => "Z100")
+        create(:product, :name => 'apache baseball cap', :available_on => '2011-01-01 01:01:01', :sku => "A100")
+        create(:product, :name => 'apache baseball cap2', :available_on => '2011-01-01 01:01:01', :sku => "B100")
+        create(:product, :name => 'zomg shirt', :available_on => '2011-01-01 01:01:01', :sku => "Z100")
         Spree::Product.update_all :count_on_hand => 10
 
         click_link "Products"

--- a/core/spec/requests/admin/products/properties_spec.rb
+++ b/core/spec/requests/admin/products/properties_spec.rb
@@ -8,8 +8,8 @@ describe "Properties" do
 
   context "listing product properties" do
     it "should list the existing product properties" do
-      Factory(:property, :name => 'shirt size', :presentation => 'size')
-      Factory(:property, :name => 'shirt fit', :presentation => 'fit')
+      create(:property, :name => 'shirt size', :presentation => 'size')
+      create(:property, :name => 'shirt fit', :presentation => 'fit')
 
       click_link "Properties"
       find('table#listing_properties tbody tr:nth-child(1) td:nth-child(1)').text.should == "shirt size"
@@ -34,7 +34,7 @@ describe "Properties" do
 
   context "editing a property" do
     before(:each) do
-      Factory(:property)
+      create(:property)
       click_link "Properties"
       within('table#listing_properties tbody tr:nth-child(1)') { click_link "Edit" }
     end

--- a/core/spec/requests/admin/products/prototypes_spec.rb
+++ b/core/spec/requests/admin/products/prototypes_spec.rb
@@ -3,28 +3,28 @@ require 'spec_helper'
 describe "Prototypes" do
   context "listing prototypes" do
     it "should be able to list existing prototypes" do
-      Factory(:property, :name => "model", :presentation => "Model")
-      Factory(:property, :name => "brand", :presentation => "Brand")
-      Factory(:property, :name => "shirt_fabric", :presentation => "Fabric")
-      Factory(:property, :name => "shirt_sleeve_length", :presentation => "Sleeve")
-      Factory(:property, :name => "mug_type", :presentation => "Type")
-      Factory(:property, :name => "bag_type", :presentation => "Type")
-      Factory(:property, :name => "manufacturer", :presentation => "Manufacturer")
-      Factory(:property, :name => "bag_size", :presentation => "Size")
-      Factory(:property, :name => "mug_size", :presentation => "Size")
-      Factory(:property, :name => "gender", :presentation => "Gender")
-      Factory(:property, :name => "shirt_fit", :presentation => "Fit")
-      Factory(:property, :name => "bag_material", :presentation => "Material")
-      Factory(:property, :name => "shirt_type", :presentation => "Type")
-      p = Factory(:prototype, :name => "Shirt")
+      create(:property, :name => "model", :presentation => "Model")
+      create(:property, :name => "brand", :presentation => "Brand")
+      create(:property, :name => "shirt_fabric", :presentation => "Fabric")
+      create(:property, :name => "shirt_sleeve_length", :presentation => "Sleeve")
+      create(:property, :name => "mug_type", :presentation => "Type")
+      create(:property, :name => "bag_type", :presentation => "Type")
+      create(:property, :name => "manufacturer", :presentation => "Manufacturer")
+      create(:property, :name => "bag_size", :presentation => "Size")
+      create(:property, :name => "mug_size", :presentation => "Size")
+      create(:property, :name => "gender", :presentation => "Gender")
+      create(:property, :name => "shirt_fit", :presentation => "Fit")
+      create(:property, :name => "bag_material", :presentation => "Material")
+      create(:property, :name => "shirt_type", :presentation => "Type")
+      p = create(:prototype, :name => "Shirt")
       %w( brand gender manufacturer model shirt_fabric shirt_fit shirt_sleeve_length shirt_type ).each do |prop|
         p.properties << Spree::Property.find_by_name(prop)
       end
-      p = Factory(:prototype, :name => "Mug")
+      p = create(:prototype, :name => "Mug")
       %w( mug_size mug_type ).each do |prop|
         p.properties << Spree::Property.find_by_name(prop)
       end
-      p = Factory(:prototype, :name => "Bag")
+      p = create(:prototype, :name => "Bag")
       %w( bag_type bag_material ).each do |prop|
         p.properties << Spree::Property.find_by_name(prop)
       end

--- a/core/spec/requests/admin/products/variant_spec.rb
+++ b/core/spec/requests/admin/products/variant_spec.rb
@@ -3,10 +3,10 @@ require 'spec_helper'
 describe "Variants" do
   context "creating a new variant" do
     it "should allow an admin to create a new variant" do
-      product = Factory(:product_with_option_types, :price => "1.99", :cost_price => "1.00", :weight => "2.5", :height => "3.0", :width => "1.0", :depth => "1.5")
+      product = create(:product_with_option_types, :price => "1.99", :cost_price => "1.00", :weight => "2.5", :height => "3.0", :width => "1.0", :depth => "1.5")
 
       product.options.each do |option|
-        Factory(:option_value, :option_type => option.option_type)
+        create(:option_value, :option_type => option.option_type)
       end
 
       visit spree.admin_path

--- a/core/spec/requests/admin/reports_spec.rb
+++ b/core/spec/requests/admin/reports_spec.rb
@@ -16,28 +16,28 @@ describe "Reports" do
 
   context "searching the admin reports page" do
     before do
-      order = Factory(:order)
+      order = create(:order)
       order.update_attributes_without_callbacks({:adjustment_total => 100})
       order.completed_at = Time.now
       order.save!
 
-      order = Factory(:order)
+      order = create(:order)
       order.update_attributes_without_callbacks({:adjustment_total => 200})
       order.completed_at = Time.now
       order.save!
 
       #incomplete order
-      order = Factory(:order)
+      order = create(:order)
       order.update_attributes_without_callbacks({:adjustment_total => 50})
       order.save!
 
-      order = Factory(:order)
+      order = create(:order)
       order.update_attributes_without_callbacks({:adjustment_total => 200})
       order.completed_at = 3.years.ago
       order.created_at = 3.years.ago
       order.save!
 
-      order = Factory(:order)
+      order = create(:order)
       order.update_attributes_without_callbacks({:adjustment_total => 200})
       order.completed_at = 3.years.from_now
       order.created_at = 3.years.from_now

--- a/core/spec/requests/admin/users_spec.rb
+++ b/core/spec/requests/admin/users_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 describe "Users" do
   before(:each) do
-    Factory(:user, :email => "a@example.com")
-    Factory(:user, :email => "b@example.com")
+    create(:user, :email => "a@example.com")
+    create(:user, :email => "b@example.com")
     visit spree.admin_path
     click_link "Users"
   end

--- a/core/spec/requests/checkout_spec.rb
+++ b/core/spec/requests/checkout_spec.rb
@@ -8,10 +8,10 @@ describe "Checkout" do
           config.allow_backorders = false
         end
         Spree::Product.delete_all
-        @product = Factory(:product, :name => "RoR Mug")
+        @product = create(:product, :name => "RoR Mug")
         @product.on_hand = 1
         @product.save
-        Factory(:zone)
+        create(:zone)
       end
 
       it "should warn the user about out of stock items" do

--- a/core/spec/requests/order_spec.rb
+++ b/core/spec/requests/order_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'orders' do
-  let(:order) { Factory(:order, :shipping_method => Factory(:shipping_method)) }
+  let(:order) { create(:order, :shipping_method => create(:shipping_method)) }
 
   it "can visit an order" do
     # Regression test for current_user call on orders/show

--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -50,9 +50,9 @@ RSpec.configure do |config|
     DatabaseCleaner.clean
   end
 
+  config.include FactoryGirl::Syntax::Methods
   config.include Spree::Core::UrlHelpers
   config.include Spree::Core::TestingSupport::ControllerRequests
-
 
   config.include Paperclip::Shoulda::Matchers
 end
@@ -63,27 +63,27 @@ shared_context "custom products" do
       config.allow_backorders = true
     end
 
-    taxonomy = Factory(:taxonomy, :name => 'Categories')
+    taxonomy = FactoryGirl.create(:taxonomy, :name => 'Categories')
     root = taxonomy.root
-    clothing_taxon = Factory(:taxon, :name => 'Clothing', :parent_id => root.id)
-    bags_taxon = Factory(:taxon, :name => 'Bags', :parent_id => root.id)
-    mugs_taxon = Factory(:taxon, :name => 'Mugs', :parent_id => root.id)
+    clothing_taxon = FactoryGirl.create(:taxon, :name => 'Clothing', :parent_id => root.id)
+    bags_taxon = FactoryGirl.create(:taxon, :name => 'Bags', :parent_id => root.id)
+    mugs_taxon = FactoryGirl.create(:taxon, :name => 'Mugs', :parent_id => root.id)
 
-    taxonomy = Factory(:taxonomy, :name => 'Brands')
+    taxonomy = FactoryGirl.create(:taxonomy, :name => 'Brands')
     root = taxonomy.root
-    apache_taxon = Factory(:taxon, :name => 'Apache', :parent_id => root.id)
-    rails_taxon = Factory(:taxon, :name => 'Ruby on Rails', :parent_id => root.id)
-    ruby_taxon = Factory(:taxon, :name => 'Ruby', :parent_id => root.id)
+    apache_taxon = FactoryGirl.create(:taxon, :name => 'Apache', :parent_id => root.id)
+    rails_taxon = FactoryGirl.create(:taxon, :name => 'Ruby on Rails', :parent_id => root.id)
+    ruby_taxon = FactoryGirl.create(:taxon, :name => 'Ruby', :parent_id => root.id)
 
-    Factory(:custom_product, :name => 'Ruby on Rails Ringer T-Shirt', :price => '17.99', :taxons => [rails_taxon, clothing_taxon])
-    Factory(:custom_product, :name => 'Ruby on Rails Mug', :price => '13.99', :taxons => [rails_taxon, mugs_taxon])
-    Factory(:custom_product, :name => 'Ruby on Rails Tote', :price => '15.99', :taxons => [rails_taxon, bags_taxon])
-    Factory(:custom_product, :name => 'Ruby on Rails Bag', :price => '22.99', :taxons => [rails_taxon, bags_taxon])
-    Factory(:custom_product, :name => 'Ruby on Rails Baseball Jersey', :price => '19.99', :taxons => [rails_taxon, clothing_taxon])
-    Factory(:custom_product, :name => 'Ruby on Rails Stein', :price => '16.99', :taxons => [rails_taxon, mugs_taxon])
-    Factory(:custom_product, :name => 'Ruby on Rails Jr. Spaghetti', :price => '19.99', :taxons => [rails_taxon, clothing_taxon])
-    Factory(:custom_product, :name => 'Ruby Baseball Jersey', :price => '19.99', :taxons => [ruby_taxon, clothing_taxon])
-    Factory(:custom_product, :name => 'Apache Baseball Jersey', :price => '19.99', :taxons => [apache_taxon, clothing_taxon])
+    FactoryGirl.create(:custom_product, :name => 'Ruby on Rails Ringer T-Shirt', :price => '17.99', :taxons => [rails_taxon, clothing_taxon])
+    FactoryGirl.create(:custom_product, :name => 'Ruby on Rails Mug', :price => '13.99', :taxons => [rails_taxon, mugs_taxon])
+    FactoryGirl.create(:custom_product, :name => 'Ruby on Rails Tote', :price => '15.99', :taxons => [rails_taxon, bags_taxon])
+    FactoryGirl.create(:custom_product, :name => 'Ruby on Rails Bag', :price => '22.99', :taxons => [rails_taxon, bags_taxon])
+    FactoryGirl.create(:custom_product, :name => 'Ruby on Rails Baseball Jersey', :price => '19.99', :taxons => [rails_taxon, clothing_taxon])
+    FactoryGirl.create(:custom_product, :name => 'Ruby on Rails Stein', :price => '16.99', :taxons => [rails_taxon, mugs_taxon])
+    FactoryGirl.create(:custom_product, :name => 'Ruby on Rails Jr. Spaghetti', :price => '19.99', :taxons => [rails_taxon, clothing_taxon])
+    FactoryGirl.create(:custom_product, :name => 'Ruby Baseball Jersey', :price => '19.99', :taxons => [ruby_taxon, clothing_taxon])
+    FactoryGirl.create(:custom_product, :name => 'Apache Baseball Jersey', :price => '19.99', :taxons => [apache_taxon, clothing_taxon])
   end
 end
 
@@ -92,7 +92,7 @@ end
 shared_context "product prototype" do
 
   def build_option_type_with_values(name, values)
-    ot = Factory(:option_type, :name => name)
+    ot = FactoryGirl.create(:option_type, :name => name)
     values.each do |val|
       ot.option_values.create({:name => val.downcase, :presentation => val}, :without_protection => true)
     end
@@ -100,14 +100,14 @@ shared_context "product prototype" do
   end
 
   let(:product_attributes) do
-    # Factory.attributes_for is un-deprecated!
+    # FactoryGirl.attributes_for is un-deprecated!
     #   https://github.com/thoughtbot/factory_girl/issues/274#issuecomment-3592054
-    Factory.attributes_for(:simple_product)
+    FactoryGirl.attributes_for(:simple_product)
   end
 
   let(:prototype) do
     size = build_option_type_with_values("size", %w(Small Medium Large))
-    Factory(:prototype, :name => "Size", :option_types => [ size ])
+    FactoryGirl.create(:prototype, :name => "Size", :option_types => [ size ])
   end
 
   let(:option_values_hash) do

--- a/dash/spec/controllers/admin/analytics_controller_spec.rb
+++ b/dash/spec/controllers/admin/analytics_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 describe Spree::Admin::AnalyticsController do
   before :each do
-    @user = Factory(:admin_user)
+    @user = create(:admin_user)
     controller.stub :current_user => @user
   end
 

--- a/dash/spec/controllers/admin/overview_controller_spec.rb
+++ b/dash/spec/controllers/admin/overview_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Spree::Admin::OverviewController do
 
   before :each do
-    @user = Factory(:admin_user)
+    @user = create(:admin_user)
     controller.stub :current_user => @user
   end
 

--- a/dash/spec/requests/admin/analytics_spec.rb
+++ b/dash/spec/requests/admin/analytics_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe "Analytics Activation" do
   before(:each) do
-    @user = Factory(:admin_user)
+    @user = create(:admin_user)
     sign_in_as!(@user)
 
     Spree::Dash::Config.app_id = nil

--- a/dash/spec/requests/header_tags_spec.rb
+++ b/dash/spec/requests/header_tags_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe "Header Tags" do
   before do
-    @product = Factory(:product, :name => "RoR Mug")
+    @product = create(:product, :name => "RoR Mug")
 
     Spree::DashConfiguration.new.app_id = 1111
     Spree::DashConfiguration.new.site_id = 2222

--- a/dash/spec/spec_helper.rb
+++ b/dash/spec/spec_helper.rb
@@ -38,6 +38,7 @@ RSpec.configure do |config|
     DatabaseCleaner.clean
   end
 
+  config.include FactoryGirl::Syntax::Methods
   config.include Spree::Core::UrlHelpers
   config.include Spree::Core::TestingSupport::ControllerRequests, :type => :controller
 

--- a/promo/spec/controllers/spree/content_controller_spec.rb
+++ b/promo/spec/controllers/spree/content_controller_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Spree::ContentController do
   before :each do
-    controller.stub :current_user => Factory(:user)
+    controller.stub :current_user => create(:user)
   end
 
   it "fires event for #show" do

--- a/promo/spec/models/order_spec.rb
+++ b/promo/spec/models/order_spec.rb
@@ -2,15 +2,15 @@ require 'spec_helper'
 
 describe Spree::Order do
 
-  let(:order) { Factory(:order) }
+  let(:order) { create(:order) }
 
   context "#update_adjustments" do
 
     it "should make all but the most valuable promotion adjustment ineligible, leaving non promotion adjustments alone" do
-      Factory(:adjustment, :adjustable => order, :label => 'Promotion A', :amount => -100)
-      Factory(:adjustment, :adjustable => order, :label => 'Promotion B', :amount => -200)
-      Factory(:adjustment, :adjustable => order, :label => 'Promotion C', :amount => -300)
-      Factory(:adjustment, :adjustable => order, :label => 'Some other credit', :amount => -500)
+      create(:adjustment, :adjustable => order, :label => 'Promotion A', :amount => -100)
+      create(:adjustment, :adjustable => order, :label => 'Promotion B', :amount => -200)
+      create(:adjustment, :adjustable => order, :label => 'Promotion C', :amount => -300)
+      create(:adjustment, :adjustable => order, :label => 'Some other credit', :amount => -500)
       order.adjustments.each {|a| a.update_attribute_without_callbacks(:eligible, true)}
 
       order.send(:update_adjustments)
@@ -19,9 +19,9 @@ describe Spree::Order do
     end
 
     it "should only leave one adjustment even if 2 have the same amount" do
-      Factory(:adjustment, :adjustable => order, :label => 'Promotion A', :amount => -100)
-      Factory(:adjustment, :adjustable => order, :label => 'Promotion B', :amount => -200)
-      Factory(:adjustment, :adjustable => order, :label => 'Promotion C', :amount => -200)
+      create(:adjustment, :adjustable => order, :label => 'Promotion A', :amount => -100)
+      create(:adjustment, :adjustable => order, :label => 'Promotion B', :amount => -200)
+      create(:adjustment, :adjustable => order, :label => 'Promotion C', :amount => -200)
 
       order.send(:update_adjustments)
       order.adjustments.eligible.promotion.count.should == 1

--- a/promo/spec/models/promotion/actions/create_adjustment_spec.rb
+++ b/promo/spec/models/promotion/actions/create_adjustment_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe Spree::Promotion::Actions::CreateAdjustment do
-  let(:order) { Factory(:order) }
-  let(:promotion) { Factory(:promotion) }
+  let(:order) { create(:order) }
+  let(:promotion) { create(:promotion) }
   let(:action) { Spree::Promotion::Actions::CreateAdjustment.new }
 
   # From promotion spec:

--- a/promo/spec/models/promotion/actions/create_line_items_spec.rb
+++ b/promo/spec/models/promotion/actions/create_line_items_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 
 describe Spree::Promotion::Actions::CreateLineItems do
-  let(:order) { Factory(:order) }
+  let(:order) { create(:order) }
   let(:promotion) { Spree::Promotion.new }
   let(:action) { Spree::Promotion::Actions::CreateLineItems.create }
 
   context "#perform" do
     before do
-      @v1 = Factory(:variant)
-      @v2 = Factory(:variant)
+      @v1 = create(:variant)
+      @v2 = create(:variant)
       action.promotion_action_line_items.create!({
         :variant => @v1,
         :quantity => 1}, :without_protection => true
@@ -60,8 +60,8 @@ describe Spree::Promotion::Actions::CreateLineItems do
   context "#line_items_string=" do
 
     before do
-      @v1 = Factory(:variant)
-      @v2 = Factory(:variant)
+      @v1 = create(:variant)
+      @v2 = create(:variant)
     end
 
     it "creates promotion_action_line_items with matching variant and quantity for each pair in the string" do

--- a/promo/spec/models/promotion_spec.rb
+++ b/promo/spec/models/promotion_spec.rb
@@ -43,8 +43,8 @@ describe Spree::Promotion do
   end
 
   describe ".advertised" do
-    let(:promotion) { Factory(:promotion) }
-    let(:advertised_promotion) { Factory(:promotion, :advertise => true) }
+    let(:promotion) { create(:promotion) }
+    let(:advertised_promotion) { create(:promotion, :advertise => true) }
 
     it "only shows advertised promotions" do
       advertised = Spree::Promotion.advertised
@@ -175,12 +175,12 @@ describe Spree::Promotion do
 
   context "#products" do
     context "when it has product rules with products associated" do
-      let(:promotion) { Factory.create(:promotion) }
+      let(:promotion) { create(:promotion) }
 
       before do
         promotion_rule = Spree::Promotion::Rules::Product.new
         promotion_rule.promotion = promotion
-        promotion_rule.products << Factory.create(:product)
+        promotion_rule.products << create(:product)
         promotion_rule.save
       end
 
@@ -192,7 +192,7 @@ describe Spree::Promotion do
 
   context "#eligible?" do
     before do
-      @order = Factory(:order)
+      @order = create(:order)
       promotion.event_name = 'spree.checkout.coupon_code_added'
       promotion.name = "Foo"
       promotion.code = "XXX"

--- a/promo/spec/requests/checkout_spec.rb
+++ b/promo/spec/requests/checkout_spec.rb
@@ -3,11 +3,11 @@ require 'spec_helper'
 describe "Checkout" do
   context "visitor makes checkout as guest without registration" do
     before do
-      @product = Factory(:product, :name => "RoR Mug")
-      Factory(:zone)
-      Factory(:shipping_method)
-      Factory(:payment_method)
-      Factory(:promotion)
+      @product = create(:product, :name => "RoR Mug")
+      create(:zone)
+      create(:shipping_method)
+      create(:payment_method)
+      create(:promotion)
     end
 
     it "informs about an invalid coupon code", :js => true do

--- a/promo/spec/requests/promotion_adjustments_spec.rb
+++ b/promo/spec/requests/promotion_adjustments_spec.rb
@@ -7,16 +7,16 @@ describe "Promotion Adjustments" do
       SHIPMENT_STATES = Spree::Shipment.state_machine.states.keys unless defined? SHIPMENT_STATES
       ORDER_STATES = Spree::Order.state_machine.states.keys unless defined? ORDER_STATES
       # creates a default shipping method which is required for checkout
-      Factory(:bogus_payment_method, :environment => 'test')
+      create(:bogus_payment_method, :environment => 'test')
       # creates a check payment method so we don't need to worry about cc details
-      Factory(:payment_method)
+      create(:payment_method)
 
-      sm = Factory(:shipping_method, :zone => Spree::Zone.find_by_name('North America'))
+      sm = create(:shipping_method, :zone => Spree::Zone.find_by_name('North America'))
       sm.calculator.set_preference(:amount, 10)
 
-      user = Factory(:admin_user)
-      Factory(:product, :name => "RoR Mug", :price => "40")
-      Factory(:product, :name => "RoR Bag", :price => "20")
+      user = create(:admin_user)
+      create(:product, :name => "RoR Mug", :price => "40")
+      create(:product, :name => "RoR Bag", :price => "20")
 
       sign_in_as!(user)
       visit spree.admin_path
@@ -24,7 +24,7 @@ describe "Promotion Adjustments" do
       click_link "New Promotion"
     end
 
-    let!(:address) { Factory(:address, :state => Spree::State.first) }
+    let!(:address) { create(:address, :state => Spree::State.first) }
 
     it "should allow an admin to create a flat rate discount coupon promo" do
       fill_in "Name", :with => "Order's total > $30"
@@ -117,7 +117,7 @@ describe "Promotion Adjustments" do
 
       click_button "Place Order"
 
-      user = Factory(:user, :email => "john@test.com", :password => "secret", :password_confirmation => "secret")
+      user = create(:user, :email => "john@test.com", :password => "secret", :password_confirmation => "secret")
       click_link "Logout"
       click_link "Login"
       fill_in "user_email", :with => user.email

--- a/promo/spec/spec_helper.rb
+++ b/promo/spec/spec_helper.rb
@@ -38,6 +38,7 @@ RSpec.configure do |config|
     DatabaseCleaner.clean
   end
 
+  config.include FactoryGirl::Syntax::Methods
   config.include Spree::Core::UrlHelpers
   config.include Spree::Core::TestingSupport::ControllerRequests, :type => :controller
   config.include Rack::Test::Methods, :type => :requests


### PR DESCRIPTION
This will avoid all the deprecations when Ruby 1.8 is dropped, and we move on to FactoryGirl 3.
