### PR TITLE
Authorize instance

### DIFF
--- a/auth/app/controllers/spree/admin/admin_controller_decorator.rb
+++ b/auth/app/controllers/spree/admin/admin_controller_decorator.rb
@@ -4,12 +4,12 @@ Spree::Admin::BaseController.class_eval do
 
   def authorize_admin
     begin
-      model = model_class
+      record = model_class.new
     rescue
-      model = Object
+      record = Object.new
     end
-    authorize! :admin, model
-    authorize! params[:action].to_sym, model
+    authorize! :admin, record
+    authorize! params[:action].to_sym, record
   end
 
   protected

--- a/auth/app/controllers/spree/admin/admin_orders_controller_decorator.rb
+++ b/auth/app/controllers/spree/admin/admin_orders_controller_decorator.rb
@@ -6,7 +6,7 @@ Spree::Admin::OrdersController.class_eval do
       load_order
       session[:access_token] ||= params[:token]
 
-      resource = @order || Spree::Order
+      resource = @order || Spree::Order.new
       action = params[:action].to_sym
 
       authorize! action, resource, session[:access_token]

--- a/auth/app/controllers/spree/orders_controller_decorator.rb
+++ b/auth/app/controllers/spree/orders_controller_decorator.rb
@@ -9,7 +9,7 @@ Spree::OrdersController.class_eval do
       if order
         authorize! :edit, order, session[:access_token]
       else
-        authorize! :create, Spree::Order
+        authorize! :create, Spree::Order.new
       end
     end
 end

--- a/auth/app/controllers/spree/users_controller.rb
+++ b/auth/app/controllers/spree/users_controller.rb
@@ -42,7 +42,7 @@ class Spree::UsersController < Spree::BaseController
     end
 
     def authorize_actions
-      authorize! params[:action].to_sym, Spree::User
+      authorize! params[:action].to_sym, Spree::User.new
     end
 
     def accurate_title


### PR DESCRIPTION
Per https://github.com/ryanb/cancan/wiki/Checking-Abilities :

```
Important: If a block or hash of conditions exist they will be ignored when checking on a class, and it will return true
```

I don't think this a security hole in default Spree installations, as the only times classes are used instead of objects is for new orders and new users, which (by default) can be created by anyone.

I only ran into this when I tried denying anonymous users the ability to create orders.
