### PR TITLE
Fix for adjustment shipping

### DIFF
--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -31,7 +31,7 @@ module Spree
 
     scope :tax, lambda { where(:originator_type => 'Spree::TaxRate', :adjustable_type => 'Spree::Order') }
     scope :price, lambda { where(:adjustable_type => 'Spree::LineItem') }
-    scope :shipping, lambda { where(:label => I18n.t(:shipping)) }
+    scope :shipping, lambda { where(:originator_type => 'Spree::ShippingMethod') }
     scope :optional, where(:mandatory => false)
     scope :eligible, where(:eligible => true)
     scope :charge, where("amount >= 0")


### PR DESCRIPTION
The Adjustment.shipping scope was using a translated field to identify shipping adjustments. This caused shipping costs to be displayed differently depending on the chosen locale.
