### PR TITLE
Fix for bug which causes duplicate permalinks to be generated under some conditions

### DIFF
--- a/core/lib/spree/core/permalinks.rb
+++ b/core/lib/spree/core/permalinks.rb
@@ -46,25 +46,14 @@ module Spree
       def save_permalink
         permalink_value = self.to_param
         field = self.class.permalink_field
-        order = self.class.permalink_order
-        # Do other links exist with this permalink?
-        other = self.class.first(
-          :conditions => "#{field} LIKE '#{permalink_value}%'",
-          :order => "#{order} LENGTH(#{field}) DESC, #{field} DESC"
-        )
-        if other
-          # Find existence of that permalink or the number of that permalink and add one.
-          if ( permalink_value == other.send(field) || /-(\d+)$/.match(other.send(field)) )
-            if $1
-              number = $1.to_i + 1
-            # Otherwise default to suffixing it with a 1.
-            else
-              number = 1
-            end
-
+          # Do other links exist with this permalink?
+          other = self.class.all(:conditions => "#{field} LIKE '#{permalink_value}%'")
+          unless other.empty?
+            # Find the existing permalink with the highest number, and increment that number.
+            # (If none of the existing permalinks have a number, this will evaluate to 1.)
+            number = other.map { |o| o.send(field)[/-(\d+)$/, 1].to_i }.max + 1
             permalink_value += "-#{number.to_s}"
           end
-        end
         write_attribute(field, permalink_value)
       end
     end


### PR DESCRIPTION
To cause Spree to erroneously generate duplicate permalinks:
1. Import a product with name "ABC XYZ". The permalink will be "abc-xyz".
2. Again, import a product with name "ABC XYZ". The permalink will be "abc-xyz-1".
3. Import a product with name "ABC". The permalink will be "abc-2".
4. Again, import a product with name "ABC". The generated permalink will be "abc-2", and validation of the new record will fail with a "duplicate permalink" error.

To prevent this error from occurring, it is necessary to pull back _all_ records with matching permalinks in `save_permalink`, from `spree/core/lib/permalinks.rb`. If you just pull back one, I can't see how to guarantee that the generated permalinks will always be unique. There will always be corner cases where it may fail.
