### PR TITLE
Received return authorizations doesnt create adjustment

### DIFF
--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -67,8 +67,10 @@ module Spree
 
       def process_return
         inventory_units.each &:return!
-        credit = Adjustment.create(:source => self, :adjustable => order, :amount => amount.abs * -1, :label => I18n.t(:rma_credit))
-        order.update!
+        credit = Adjustment.new(:amount => amount.abs * -1, :label => I18n.t(:rma_credit))
+        credit.source = self
+        credit.adjustable = order
+        credit.save
       end
 
       def allow_receive?

--- a/core/spec/models/return_authorization_spec.rb
+++ b/core/spec/models/return_authorization_spec.rb
@@ -85,7 +85,11 @@ describe Spree::ReturnAuthorization do
     end
 
     it "should add credit for specified amount" do
-      Spree::Adjustment.should_receive(:create).with(:source => return_authorization, :adjustable => order, :amount => -20, :label => I18n.t(:rma_credit))
+      mock_adjustment = mock
+      mock_adjustment.should_receive(:source=).with(return_authorization)
+      mock_adjustment.should_receive(:adjustable=).with(order)
+      mock_adjustment.should_receive(:save)
+      Spree::Adjustment.should_receive(:new).with(:amount => -20, :label => I18n.t(:rma_credit)).and_return(mock_adjustment)
       return_authorization.receive!
     end
 


### PR DESCRIPTION
The `Adjustment#source` & `Adjustment#adjustable` attributes aren't `attr_accessible`, so adjustments are being created that are not attached to the order when a return authorization is received.

In addition, I removed the call to `Order#update!` in `Adjustment#process_return` because if the adjustment is created properly the `Order#update!` will be called (via `after_save :update_adjustable` in `Adjustment`).
