### PR TITLE
Fix for longer sales tax amount

### DIFF
--- a/core/db/migrate/20090823005402_spree_zero_nine_zero.rb
+++ b/core/db/migrate/20090823005402_spree_zero_nine_zero.rb
@@ -321,7 +321,7 @@ class SpreeZeroNineZero < ActiveRecord::Migration
     end
 
     create_table :tax_rates, :force => true do |t|
-      t.decimal  :amount, :precision => 8, :scale => 4
+      t.decimal  :amount, :precision => 8, :scale => 6
       t.references :zone
       t.references :tax_category
 


### PR DESCRIPTION
Upped the tax_rates amount field scale to 6 to support United States longer percentages. ie 8.5625%
