### PR TITLE
Only use Spree::Responder if needed for the current controller.

### DIFF
--- a/core/lib/spree/core/respond_with.rb
+++ b/core/lib/spree/core/respond_with.rb
@@ -7,7 +7,7 @@ module ActionController
       if collector = retrieve_collector_from_mimes(&block)
         options = resources.size == 1 ? {} : resources.extract_options!
 
-        if defined_response = collector.response and Spree::BaseController.spree_responders.empty?
+        if defined_response = collector.response and !Spree::BaseController.spree_responders.keys.include?(self.class.to_s.to_sym)
           if action = options.delete(:action)
             render :action => action
           else

--- a/core/spec/controllers/spree/orders_controller_extension_spec.rb
+++ b/core/spec/controllers/spree/orders_controller_extension_spec.rb
@@ -81,6 +81,22 @@ describe Spree::OrdersController do
         end
       end
 
+      context 'A different controllers respond_override. Regression test for #1301' do
+        before do
+          @order = create(:order)
+          Spree::Admin::OrdersController.instance_eval do
+            respond_override({:update => {:html => {:success => lambda { render(:text => 'success!!!') }}}})
+          end
+        end
+        describe "POST" do
+          it "should not effect the wrong controller" do
+            Spree::Responder.should_not_receive(:call)
+            put :update, {}, {:order_id => @order.id}
+            response.should redirect_to(spree.cart_path)
+          end
+        end
+      end
+
     end
   end
 


### PR DESCRIPTION
Stops preventing defined_response.call when any spree_responders are
defined. [fixes #1301]
