### PR TITLE
Fix issue #1521 with api key not showing in user edit view after generation.

### DIFF
--- a/api/app/views/spree/admin/users/_api_fields.html.erb
+++ b/api/app/views/spree/admin/users/_api_fields.html.erb
@@ -1,7 +1,7 @@
 <h2><%= t('access', :scope => 'spree.api') %></h2>
 
-<% if @user.authentication_token.present? %>
-  <p><strong><%= t('key', :scope => 'spree.api') %></strong> <%= @user.authentication_token %></p>
+<% if @user.api_key.present? %>
+  <p><strong><%= t('key', :scope => 'spree.api') %></strong> <%= @user.api_key %></p>
 
   <%= form_tag spree.clear_api_key_admin_user_path(@user), :method => :put do %>
     <%= button t('clear_key', :scope => 'spree.api') %>


### PR DESCRIPTION
Updated @user.authentication_token.present? check, and print out to use @user.api_key instead in the api_fields partial.

Not sure why @user_authentication_token was being used instead.

My first spree commit!

[Fixes #1521]
