### PR TITLE
Account for purchased units in stock availability validation

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -45,7 +45,12 @@ module Spree
     end
 
     def sufficient_stock?
-      Spree::Config[:allow_backorders] ? true : (variant.on_hand >= quantity)
+      return true if Spree::Config[:allow_backorders]
+      if new_record? || !order.completed?
+        variant.on_hand >= quantity
+      else
+        variant.on_hand >= (quantity - self.changed_attributes['quantity'].to_i)
+      end
     end
 
     def insufficient_stock?

--- a/core/spec/models/line_item_spec.rb
+++ b/core/spec/models/line_item_spec.rb
@@ -145,6 +145,31 @@ describe Spree::LineItem do
         line_item.insufficient_stock?.should be_false
         line_item.sufficient_stock?.should be_true
       end
+
+      context 'when line item has been saved' do
+        before { line_item.stub(:new_record? => false) }
+
+        it 'should report sufficient stock when reducing purchased quantity' do
+          line_item.stub(:changed_attributes => {'quantity' => 6}, :quantity => 5)
+          line_item.stub_chain :variant, :on_hand => 0
+          line_item.insufficient_stock?.should be_false
+          line_item.sufficient_stock?.should be_true
+        end
+
+        it 'should report sufficient stock when increasing purchased quantity and variant has enough on_hand' do
+          line_item.stub(:changed_attributes => {'quantity' => 5}, :quantity => 6)
+          line_item.stub_chain :variant, :on_hand => 1
+          line_item.insufficient_stock?.should be_false
+          line_item.sufficient_stock?.should be_true
+        end
+
+        it 'should report insufficient stock when increasing purchased quantity and new units is more than variant on_hand' do
+          line_item.stub(:changed_attributes => {'quantity' => 5}, :quantity => 7)
+          line_item.stub_chain :variant, :on_hand => 1
+          line_item.insufficient_stock?.should be_true
+          line_item.sufficient_stock?.should be_false
+        end
+      end
     end
 
     context 'when backordering is enabled' do


### PR DESCRIPTION
The `LineItem#stock_availability` validation breaks admin when you try to increase/decrease the `LineItem#quantity` because the validation isn't account for units already purchased.  So for example, reducing a purchased quantity from 5 to 4 when `Variant#on_hand` is 3 will result in a validation error, as well as increasing quantity on a purchased line item from 4 to 5 (buying one additional unit) under the same scenario.
