### PR TITLE
ThinkingSphinx conflicts with ransack in admin controllers

### DIFF
--- a/api/app/controllers/spree/api/v1/orders_controller.rb
+++ b/api/app/controllers/spree/api/v1/orders_controller.rb
@@ -15,7 +15,7 @@ module Spree
         end
 
         def search
-          @orders = Order.search(params[:q]).result.page(params[:page])
+          @orders = Order.ransack(params[:q]).result.page(params[:page])
           render :index
         end
 

--- a/api/app/controllers/spree/api/v1/products_controller.rb
+++ b/api/app/controllers/spree/api/v1/products_controller.rb
@@ -7,7 +7,7 @@ module Spree
         end
 
         def search
-          @products = product_scope.search(params[:q]).result.page(params[:page])
+          @products = product_scope.ransack(params[:q]).result.page(params[:page])
           render :index
         end
 

--- a/core/app/controllers/spree/admin/orders_controller.rb
+++ b/core/app/controllers/spree/admin/orders_controller.rb
@@ -27,7 +27,7 @@ module Spree
           params[:q][:completed_at_lt] = params[:q].delete(:created_at_lt)
         end
 
-        @search = Order.search(params[:q])
+        @search = Order.ransack(params[:q])
         @orders = @search.result.includes([:user, :shipments, :payments]).page(params[:page]).per(Spree::Config[:orders_per_page])
         respond_with(@orders)
       end

--- a/core/app/controllers/spree/admin/products_controller.rb
+++ b/core/app/controllers/spree/admin/products_controller.rb
@@ -64,8 +64,8 @@ module Spree
           when 'basic'
             collection.map {|p| {'id' => p.id, 'name' => p.name}}.to_json
           else
-            collection.to_json(:include => {:variants => {:include => {:option_values => {:include => :option_type}, 
-                                                          :images => {:only => [:id], :methods => :mini_url}}}, 
+            collection.to_json(:include => {:variants => {:include => {:option_values => {:include => :option_type},
+                                                          :images => {:only => [:id], :methods => :mini_url}}},
                                                           :images => {:only => [:id], :methods => :mini_url}, :master => {}})
           end
         end
@@ -84,7 +84,7 @@ module Spree
 
             params[:q][:s] ||= "name asc"
 
-            @search = super.search(params[:q])
+            @search = super.ransack(params[:q])
             @collection = @search.result.
               group_by_products_id.
               includes([:master, {:variants => [:images, :option_values]}]).

--- a/core/app/controllers/spree/admin/reports_controller.rb
+++ b/core/app/controllers/spree/admin/reports_controller.rb
@@ -34,7 +34,7 @@ module Spree
 
         params[:q][:meta_sort] ||= "created_at.desc"
 
-        @search = Order.complete.search(params[:q])
+        @search = Order.complete.ransack(params[:q])
         @orders = @search.result
         @item_total = @orders.sum(:item_total)
         @adjustment_total = @orders.sum(:adjustment_total)

--- a/core/app/controllers/spree/admin/users_controller.rb
+++ b/core/app/controllers/spree/admin/users_controller.rb
@@ -24,7 +24,7 @@ module Spree
         def collection
           return @collection if @collection.present?
           unless request.xhr?
-            @search = Spree::User.registered.search(params[:q])
+            @search = Spree::User.registered.ransack(params[:q])
             @collection = @search.result.page(params[:page]).per(Spree::Config[:admin_products_per_page])
           else
             #disabling proper nested include here due to rails 3.1 bug

--- a/core/app/controllers/spree/admin/zones_controller.rb
+++ b/core/app/controllers/spree/admin/zones_controller.rb
@@ -13,7 +13,7 @@ module Spree
         def collection
           params[:q] ||= {}
           params[:q][:meta_sort] ||= "ascend_by_name"
-          @search = super.search(params[:q])
+          @search = super.ransack(params[:q])
           @zones = @search.result.page(params[:page]).per(Spree::Config[:orders_per_page])
         end
 


### PR DESCRIPTION
I use ThinkingSphinx in my project and after the upgrade to 1.1 the problem occurred -  Admin::ProductsController stopped working due to the use of the method .search already defined by TS (ransack does not define its own method .search in conflict situations).

As `.search` is just an alias for `.ransack`, I replaced it at all controllers for consistency.
