### PR TITLE
check to make sure image magick is installed (Mac only)

### DIFF
--- a/cmd/lib/spree_cmd/installer.rb
+++ b/cmd/lib/spree_cmd/installer.rb
@@ -32,6 +32,13 @@ module SpreeCmd
       end
     end
 
+    def verify_image_magick
+      unless image_magick_installed?
+        say "Image magick must be installed."
+        exit(1)
+      end
+    end
+
     def prepare_options
       @spree_gem_options = {}
 
@@ -159,6 +166,24 @@ module SpreeCmd
 
       def is_rails_project?
         File.exists? File.join(@app_path, 'script', 'rails')
+      end
+
+      def is_mac?
+        Object::RUBY_PLATFORM =~ /(darwin)/i ? true: false
+      end
+
+      def image_magick_installed?
+        if is_mac?
+          begin
+            %x(identify -version)
+          rescue
+          end
+
+          $?.success?
+        else
+          # not sure how to check on windows so assume installed
+          true
+        end
       end
   end
 end


### PR DESCRIPTION
references [#1511]

Sorry @radar but I couldn't figure out how to test this on my system. When I run rspec it can't find the spree files that I am trying to require. Rather than continue struggling with it I figured I'd send the code I have. It's complete, just not fully tested.

For what it's worth, my code snippets were tested in isolation (outside the context of a spree installation)

The check is only performed on Macs because I don't know how to do it on windows.

If you can give me some pointers on how to get my test working (specifically for SpreeCmd::Installer) I'll gladly work on it.
