### PR TITLE
Allow pagination of product search results.

### DIFF
--- a/core/app/views/spree/shared/_products.html.erb
+++ b/core/app/views/spree/shared/_products.html.erb
@@ -26,6 +26,5 @@
 <% end %>
 
 <% if paginated_products.respond_to?(:num_pages)
-      params.delete(:search)
       params.delete(:taxon)
 %><%= paginate paginated_products %><% end %>

--- a/core/spec/requests/products_spec.rb
+++ b/core/spec/requests/products_spec.rb
@@ -106,6 +106,22 @@ describe "Visiting Products" do
     tmp.sort!.should == ["Ruby on Rails Ringer T-Shirt", "Ruby on Rails Stein", "Ruby on Rails Tote"]
   end
 
+  it "should be able to display products priced between 15 and 18 dollars across multiple pages" do
+    Spree::Config.products_per_page = 2
+    within(:css, '#taxonomies') { click_link "Ruby on Rails" }
+    check "Price_Range_$15.00_-_$18.00"
+    within(:css, '#sidebar_products_search') { click_button "Search" }
+
+    page.all('ul.product-listing li').size.should == 2
+    tmp = page.all('ul.product-listing li a').map(&:text).flatten.compact
+    tmp.delete("")
+    tmp.sort!.should == ["Ruby on Rails Ringer T-Shirt", "Ruby on Rails Tote"]
+    find('nav.pagination .next a').click
+    tmp = page.all('ul.product-listing li a').map(&:text).flatten.compact
+    tmp.delete("")
+    tmp.sort!.should == ["Ruby on Rails Stein"]
+  end
+
   it "should be able to display products priced 18 dollars and above" do
     within(:css, '#taxonomies') { click_link "Ruby on Rails" }
     check "Price_Range_$18.00_-_$20.00"


### PR DESCRIPTION
Currently if you do a product search or use the product filters such as the price range the search results are lost when attempting to page through them.  This allows you to see the second, third etc.. pages of the search results.
