### PR TITLE
Locked devise at version 2.0.x, as 2.1 just launched and breaks auth

### DIFF
--- a/auth/spree_auth.gemspec
+++ b/auth/spree_auth.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency 'spree_core', version
-  s.add_dependency 'devise', '~> 2.0'
+  s.add_dependency 'devise', '~> 2.0.0'
   s.add_dependency 'cancan', '= 1.6.7'
 end


### PR DESCRIPTION
Devise just launched 2.1, running bundle update breaks Spree Auth; locking devise to 2.0.x.
Will update to Spree to use Devise 2.1 as 2.1 clears RC process and docs are released, etc.
