### PR TITLE
Locking Devise to 2.0.x to fix build

### DIFF
--- a/auth/spree_auth.gemspec
+++ b/auth/spree_auth.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency 'spree_core', version
-  s.add_dependency 'devise', '~> 2.0'
+  s.add_dependency 'devise', '~> 2.0.4'
   s.add_dependency 'cancan', '= 1.6.7'
 end


### PR DESCRIPTION
Build Error: 
[DEVISE] You're trying to include :encryptable in your model but it is not bundled with the Devise gem anymore. Please add `devise-encryptable` to your Gemfile to proceed.

Devise 2.1 was released today.
