### PR TITLE
Allow voiding of transactions on gateways supporting profiles

### DIFF
--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -50,7 +50,14 @@ module Spree
         protect_from_connection_error do
           check_environment
 
-          response = payment_method.void(self.response_code, gateway_options)
+          if payment_method.payment_profiles_supported?
+            # Gateways supporting payment profiles will need access to creditcard object because this stores the payment profile information
+            # so supply the authorization itself as well as the creditcard, rather than just the authorization code
+            response = payment_method.void(self.response_code, source, gateway_options)
+          else
+            # Standard ActiveMerchant capture usage
+            response = payment_method.void(self.response_code, gateway_options)
+          end
           record_response(response)
 
           if response.success?

--- a/core/spec/models/payment_spec.rb
+++ b/core/spec/models/payment_spec.rb
@@ -221,9 +221,20 @@ describe Spree::Payment do
         payment.state = 'pending'
       end
 
-      it "should call payment_gateway.void with the payment's response_code" do
-        gateway.should_receive(:void).with('123', anything).and_return(success_response)
-        payment.void_transaction!
+      context "when profiles are supported" do
+        it "should call payment_gateway.void with the payment's response_code" do
+          gateway.stub :payment_profiles_supported? => true
+          gateway.should_receive(:void).with('123', card, anything).and_return(success_response)
+          payment.void_transaction!
+        end
+      end
+
+      context "when profiles are not supported" do
+        it "should call payment_gateway.void with the payment's response_code" do
+          gateway.stub :payment_profiles_supported? => false
+          gateway.should_receive(:void).with('123', anything).and_return(success_response)
+          payment.void_transaction!
+        end
       end
 
       it "should log the response" do


### PR DESCRIPTION
Due to changes in deb438e470ee5823c769ab6a70f27fec19d59c1b voiding transactions on gateways gateways supporting payment profiles like AuthorizeNetCim have been raising an argument error.
