### PR TITLE
1 1 stable

### DIFF
--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -70,7 +70,7 @@ module Spree
       end
 
       # sets the manifests / assets to be precompiled
-      initializer "spree.assets.precompile", :group => :asset do |app|
+      initializer "spree.assets.precompile", :group => :assets do |app|
         Spree::Core::Engine.add_assets_to_precompile_list!(app)
       end
 

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -70,7 +70,7 @@ module Spree
       end
 
       # sets the manifests / assets to be precompiled
-      initializer "spree.assets.precompile" do |app|
+      initializer "spree.assets.precompile", :group => :asset do |app|
         Spree::Core::Engine.add_assets_to_precompile_list!(app)
       end
 


### PR DESCRIPTION
Assets aren't being precompiled with initialize_on_precompile=false for Heroku users.  The following change inspired from a rails_admin commit should fix:

https://github.com/sferik/rails_admin/pull/1135
