### PR TITLE
Default Order adjustments to be ordered by created_at

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -24,7 +24,7 @@ module Spree
     has_many :payments, :dependent => :destroy
     has_many :shipments, :dependent => :destroy
     has_many :return_authorizations, :dependent => :destroy
-    has_many :adjustments, :as => :adjustable, :dependent => :destroy
+    has_many :adjustments, :as => :adjustable, :dependent => :destroy, :order => "created_at ASC"
 
     accepts_nested_attributes_for :line_items
     accepts_nested_attributes_for :bill_address


### PR DESCRIPTION
I was noticing that the order adjustments seemed to be in a random sort-order in the mail views. This PR will sort adjustments by their `created_at` timestamp.

Thanks!

Examples:

_Email 1:_

```
Subtotal:   $280.00
Shipping:   $24.00
Promotion (10% off 12 or more):     -$28.00
Sales Tax 7.75%:    $21.70
```

_Email 2:_

```
Subtotal:   $260.00
Promotion (10% off 12 or more):     -$26.00
Sales Tax 7.75%:    $20.15
Shipping:   $24.00
```
