### PR TITLE
Add attr_accessible for `user_ids_string` in user promotion rule

### DIFF
--- a/promo/app/models/spree/promotion/rules/user.rb
+++ b/promo/app/models/spree/promotion/rules/user.rb
@@ -1,5 +1,8 @@
 module Spree
   class Promotion::Rules::User < PromotionRule
+
+    attr_accessible :user_ids_string
+
     belongs_to :user
     has_and_belongs_to_many :users, :class_name => '::Spree::User', :join_table => 'spree_promotion_rules_users', :foreign_key => 'promotion_rule_id'
 


### PR DESCRIPTION
I was seeing the following error when creating a promotion with a user rule. 

```
Started PUT "/admin/promotions/6" for 127.0.0.1 at 2012-05-17 07:40:36 -0700
Processing by Spree::Admin::PromotionsController#update as HTML
  Parameters: {"utf8"=>"✓", "authenticity_token"=>"AHyBoCvVjpcZLKYukI+jpDiW1laJYaUcryjJHH2V7K4=", "promotion"=>{"match_policy"=>"all", "promotion_rules_attributes"=>{"14"=>{"id"=>"14", "user_ids_string"=>"1"}}}, "button"=>"", "id"=>"6"}
  Spree::Promotion Load (0.7ms)  SELECT "spree_activators".* FROM "spree_activators" WHERE "spree_activators"."type" IN ('Spree::Promotion') AND "spree_activators"."id" = $1 LIMIT 1  [["id", "6"]]
  Spree::User Load (0.4ms)  SELECT "spree_users".* FROM "spree_users" WHERE "spree_users"."id" = 1 LIMIT 1
  Spree::Role Load (0.3ms)  SELECT "spree_roles".* FROM "spree_roles" INNER JOIN "spree_roles_users" ON "spree_roles"."id" = "spree_roles_users"."role_id" WHERE "spree_roles_users"."user_id" = 1
   (0.1ms)  BEGIN
  Spree::PromotionRule Load (0.3ms)  SELECT "spree_promotion_rules".* FROM "spree_promotion_rules" WHERE "spree_promotion_rules"."activator_id" = 6 AND "spree_promotion_rules"."id" IN (14)

WARNING: Can't mass-assign protected attributes: user_ids_string

  Spree::PromotionRule Load (0.3ms)  SELECT "spree_promotion_rules".* FROM "spree_promotion_rules" WHERE "spree_promotion_rules"."activator_id" = 6
  Spree::PromotionAction Load (0.2ms)  SELECT "spree_promotion_actions".* FROM "spree_promotion_actions" WHERE "spree_promotion_actions"."activator_id" = 6
  Spree::Promotion Load (0.3ms)  SELECT "spree_activators".* FROM "spree_activators" WHERE "spree_activators"."type" IN ('Spree::Promotion') AND "spree_activators"."id" = 6 LIMIT 1
   (0.1ms)  COMMIT
Redirected to http://localhost:3000/admin/promotions/6/edit
Completed 302 Found in 17ms (ActiveRecord: 2.8ms)
```

This PR adds `attr_accessible :user_ids_string` to the user promotion rule.

Thanks!

-Spencer
