### PR TITLE
Order emails include ineligible adjustments

### DIFF
--- a/core/app/views/spree/order_mailer/cancel_email.text.erb
+++ b/core/app/views/spree/order_mailer/cancel_email.text.erb
@@ -10,7 +10,7 @@ Order Summary [CANCELED]
 <% end %>
 ============================================================
 Subtotal: <%= number_to_currency @order.item_total %>
-<% @order.adjustments.each do |adjustment| %>
+<% @order.adjustments.eligible.each do |adjustment| %>
 <%= "#{adjustment.label}: #{number_to_currency adjustment.amount}"%>
 <% end %>
 Order Total: <%= number_to_currency @order.total %>

--- a/core/app/views/spree/order_mailer/confirm_email.text.erb
+++ b/core/app/views/spree/order_mailer/confirm_email.text.erb
@@ -10,7 +10,7 @@ Order Summary
 <% end %>
 ============================================================
 Subtotal: <%= number_to_currency @order.item_total %>
-<% @order.adjustments.each do |adjustment| %>
+<% @order.adjustments.eligible.each do |adjustment| %>
   <%= raw(adjustment.label) %> <%= number_to_currency(adjustment.amount) %>
 <% end %>
 Order Total: <%= number_to_currency(@order.total) %>


### PR DESCRIPTION
Currently, if you have say 2 promotions:
- 5% off orders over $100
- 10% off orders over $200

If you have an order for $240, you'll have a 10% discount.  But the order confirmation email will show:

```
Subtotal: $240.00
  Promotion (5 percent off) -$12.00
  Promotion (10 percent over 200) -$24.00
  Shipping $0.00
Order Total: $216.00
```

The total is correct, but it lists a promotion that's not actually applied.

The attached fix changes things to only show the eligible promotions:

```
Subtotal: $270.00
  Promotion (10 percent over 200) -$27.00
  Shipping $0.00
Order Total: $243.00
```

Targeted at 1-1-stable, but master has the same issue as well.
