### PR TITLE
Test instructions update

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,11 +131,6 @@ If you want to remove precompiled assets (recommended before you commit to Git a
 Running Tests
 -------------
 
-If you want to run all the tests across all the gems then
-
-    $ cd spree
-    $ bundle exec rake
-
 Each gem contains its own series of tests, and for each directory, you need to do a quick one-time
 creation of a test application and then you can use it to run the tests.  For example, to run the
 tests for the core project.
@@ -162,6 +157,15 @@ If you want to run specs for only a single spec file
 If you want to run a particular line of spec
 
     $ bundle exec rspec spec/models/state_spec.rb:7
+
+Travis, the continuous integration service, runs the test suite for each gem one at a time.
+
+    $ bundle exec rake test_app
+    $ cd api; bundle install; bundle exec rspec spec
+    $ cd ../auth; bundle install; bundle exec rspec spec
+    $ cd ../core; bundle install; bundle exec rspec spec
+    $ cd ../dash; bundle install; bundle exec rspec spec
+    $ cd ../promo; bundle install; bundle exec rspec spec
 
 
 Contributing

--- a/Rakefile
+++ b/Rakefile
@@ -18,8 +18,6 @@ task :test_app do
   end
 end
 
-task :default => :all_tests
-
 desc "Run all tests for all supported databases"
 task :ci do
   cmd = "bundle update"; puts cmd; system cmd;


### PR DESCRIPTION
Updates the README and Rakefile to reflect that the `all_tests` task is now gone.
