### PR TITLE
Fix inconsistent required classes and style red.

### DIFF
--- a/core/app/assets/stylesheets/store/screen.css.scss
+++ b/core/app/assets/stylesheets/store/screen.css.scss
@@ -190,6 +190,12 @@ mark {background-color: $link_text_color; color: $layout_background_color; font-
     margin-top: 3px;
   }
 
+  span.required {
+    color: $c_red;
+    font-weight: bold;
+    font-size: 1.2em;
+  }
+
   input[type="submit"], input[type="button"],
   input[type= "reset"], button, a.button {
     background-color: $link_text_color;;

--- a/core/app/views/spree/admin/payments/source_forms/_gateway.html.erb
+++ b/core/app/views/spree/admin/payments/source_forms/_gateway.html.erb
@@ -12,7 +12,7 @@
     <div data-hook="card_number">
       <%= label_tag nil, t(:card_number) %><br />
       <%= text_field_tag "#{param_prefix}[number]", '', :class => 'required', :size => 19, :maxlength => 19 %>
-      <span class="req">*</span>
+      <span class="required">*</span>
       &nbsp;
       <span id="card_type" style="display:none;">
         ( <span id="looks_like" ><%= t(:card_type_is) %> <span id="type"></span></span>
@@ -24,12 +24,12 @@
       <%= label_tag nil, t(:expiration) %><br />
       <%= select_month(Date.today, :prefix => param_prefix, :field_name => 'month', :use_month_numbers => true, :class => 'required') %>
       <%= select_year(Date.today, :prefix => param_prefix, :field_name => 'year', :start_year => Date.today.year, :end_year => Date.today.year + 15, :class => 'required') %>
-      <span class="req">*</span>
+      <span class="required">*</span>
     </div>
     <div data-hook="card_code">
       <%= label_tag nil, t(:card_code) %><br />
       <%= text_field_tag "#{param_prefix}[verification_value]", '', :class => 'required', :size => 5 %>
-      <span class="req">*</span>
+      <span class="required">*</span>
       <a href="/content/cvv" target="_blank" onclick="window.open(this.href,'cvv_info','left=20,top=20,width=500,height=500,toolbar=0,resizable=0,scrollbars=1');return false">
         (<%= t(:whats_this) %>)
       </a>

--- a/core/app/views/spree/checkout/_address.html.erb
+++ b/core/app/views/spree/checkout/_address.html.erb
@@ -4,11 +4,11 @@
     <legend><%= t(:billing_address) %></legend>
     <div class="inner" data-hook="billing_inner">
       <p class="field" id="bfirstname">
-        <%= bill_form.label :firstname, t(:first_name) %><span class="req">*</span><br />
+        <%= bill_form.label :firstname, t(:first_name) %><span class="required">*</span><br />
         <%= bill_form.text_field :firstname, :class => 'required' %>
       </p>
       <p class="field" id="blastname">
-        <%= bill_form.label :lastname, t(:last_name) %><span class="req">*</span><br />
+        <%= bill_form.label :lastname, t(:last_name) %><span class="required">*</span><br />
         <%= bill_form.text_field :lastname, :class => 'required' %>
       </p>
       <% if Spree::Config[:company] %>
@@ -18,7 +18,7 @@
         </p>
       <% end %>
       <p class="field" id="baddress1">
-        <%= bill_form.label :address1, t(:street_address) %><span class="req">*</span><br />
+        <%= bill_form.label :address1, t(:street_address) %><span class="required">*</span><br />
         <%= bill_form.text_field :address1, :class => 'required' %>
       </p>
       <p class="field" id="baddress2">
@@ -27,12 +27,12 @@
       </p>
 
       <p class="field" id="bcity">
-        <%= bill_form.label :city, t(:city) %><span class="req">*</span><br />
+        <%= bill_form.label :city, t(:city) %><span class="required">*</span><br />
         <%= bill_form.text_field :city, :class => 'required' %>
       </p>
 
       <p class="field" id="bcountry">
-        <%= bill_form.label :country_id, t(:country) %><span class="req">*</span><br />
+        <%= bill_form.label :country_id, t(:country) %><span class="required">*</span><br />
         <span id="bcountry">
           <%= bill_form.collection_select :country_id, available_countries, :id, :name, {}, {:class => 'required'} %>
         </span>
@@ -41,7 +41,7 @@
       <% if Spree::Config[:address_requires_state] %>
         <p class="field" id="bstate">
           <% have_states = !@order.bill_address.country.states.empty? %>
-          <%= bill_form.label :state, t(:state) %><span class="req">*</span><br />
+          <%= bill_form.label :state, t(:state) %><span class="required">*</span><br />
           <noscript>
             <%= bill_form.text_field :state_name, :class => 'required' %>
           </noscript>
@@ -63,11 +63,11 @@
       <% end %>
 
       <p class="field" id="bzipcode">
-        <%= bill_form.label :zipcode, t(:zip) %><span class="req">*</span><br />
+        <%= bill_form.label :zipcode, t(:zip) %><span class="required">*</span><br />
         <%= bill_form.text_field :zipcode, :class => 'required' %>
       </p>
       <p class="field" id="bphone">
-        <%= bill_form.label :phone, t(:phone) %><span class="req">*</span><br />
+        <%= bill_form.label :phone, t(:phone) %><span class="required">*</span><br />
         <%= bill_form.text_field :phone, :class => 'required' %>
       </p>
       <% if Spree::Config[:alternative_billing_phone] %>
@@ -91,11 +91,11 @@
     </p>
     <div class="inner" data-hook="shipping_inner">
       <p class="field" id="sfirstname">
-        <%= ship_form.label :firstname, t(:first_name) %><span class="req">*</span><br />
+        <%= ship_form.label :firstname, t(:first_name) %><span class="required">*</span><br />
         <%= ship_form.text_field :firstname, :class => 'required' %>
       </p>
       <p class="field" id="slastname">
-        <%= ship_form.label :lastname, t(:last_name) %><span class="req">*</span><br />
+        <%= ship_form.label :lastname, t(:last_name) %><span class="required">*</span><br />
         <%= ship_form.text_field :lastname, :class => 'required' %>
       </p>
       <% if Spree::Config[:company] %>
@@ -105,7 +105,7 @@
         </p>
       <% end %>
       <p class="field" id="saddress1">
-        <%= ship_form.label :address1, t(:street_address) %><span class="req">*</span><br />
+        <%= ship_form.label :address1, t(:street_address) %><span class="required">*</span><br />
         <%= ship_form.text_field :address1, :class => 'required' %>
       </p>
       <p class="field" id="saddress2">
@@ -114,12 +114,12 @@
       </p>
 
       <p class="field" id="scity">
-        <%= ship_form.label :city, t(:city) %><span class="req">*</span><br />
+        <%= ship_form.label :city, t(:city) %><span class="required">*</span><br />
         <%= ship_form.text_field :city, :class => 'required' %>
       </p>
 
       <p class="field" id="scountry">
-        <%= ship_form.label :country_id, t(:country) %><span class="req">*</span><br />
+        <%= ship_form.label :country_id, t(:country) %><span class="required">*</span><br />
         <span id="scountry">
           <%= ship_form.collection_select :country_id, available_countries, :id, :name, {}, {:class => 'required'} %>
         </span>
@@ -128,7 +128,7 @@
       <% if Spree::Config[:address_requires_state] %>
         <p class="field" id="sstate">
           <% have_states = !@order.ship_address.country.states.empty? %>
-          <%= ship_form.label :state, t(:state) %><span class="req">*</span><br />
+          <%= ship_form.label :state, t(:state) %><span class="required">*</span><br />
           <noscript>
             <%= ship_form.text_field :state_name, :class => 'required' %>
           </noscript>
@@ -150,11 +150,11 @@
       <% end %>
 
       <p class="field" id="szipcode">
-        <%= ship_form.label :zipcode, t(:zip) %><span class="req">*</span><br />
+        <%= ship_form.label :zipcode, t(:zip) %><span class="required">*</span><br />
         <%= ship_form.text_field :zipcode, :class => 'required' %>
       </p>
       <p class="field" id="sphone">
-        <%= ship_form.label :phone, t(:phone) %><span class="req">*</span><br />
+        <%= ship_form.label :phone, t(:phone) %><span class="required">*</span><br />
         <%= ship_form.text_field :phone, :class => 'required' %>
       </p>
       <% if Spree::Config[:alternative_shipping_phone] %>

--- a/core/app/views/spree/checkout/payment/_gateway.html.erb
+++ b/core/app/views/spree/checkout/payment/_gateway.html.erb
@@ -5,7 +5,7 @@
   <%= label_tag nil, t(:card_number) %><br />
   <% options_hash = Rails.env.production? ? {:autocomplete => 'off'} : {} %>
   <%= text_field_tag "#{param_prefix}[number]", '', options_hash.merge(:id => 'card_number', :class => 'required', :size => 19, :maxlength => 19) %>
-  <span class="req">*</span>
+  <span class="required">*</span>
   &nbsp;
   <span id="card_type" style="display:none;">
     ( <span id="looks_like" ><%= t(:card_type_is) %> <span id="type"></span></span>
@@ -17,12 +17,12 @@
   <%= label_tag nil, t(:expiration) %><br />
   <%= select_month(Date.today, :prefix => param_prefix, :field_name => 'month', :use_month_numbers => true, :class => 'required') %>
   <%= select_year(Date.today, :prefix => param_prefix, :field_name => 'year', :start_year => Date.today.year, :end_year => Date.today.year + 15, :class => 'required') %>
-  <span class="req">*</span>
+  <span class="required">*</span>
 </p>
 <p class="field" data-hook="cart_code">
   <%= label_tag nil, t(:card_code) %><br />
   <%= text_field_tag "#{param_prefix}[verification_value]", '', options_hash.merge(:id => 'card_code', :class => 'required', :size => 5) %>
-  <span class="req">*</span>
+  <span class="required">*</span>
   <%= link_to "(#{t(:whats_this)})", spree.content_path('cvv'), :target => '_blank', :onclick => "window.open(this.href,'cvv_info','left=20,top=20,width=500,height=500,toolbar=0,resizable=0,scrollbars=1');return false", "data-hook" => "cvv_link" %>
 </p>
 <%= hidden_field param_prefix, 'first_name', :value => @order.billing_firstname %>


### PR DESCRIPTION
I've noticed some asterisk spans use the class 'req' and others use the class 'required'.  I've made them all 'required' for consistency, and I added a red style to the asterisk to stand out better.
