### PR TITLE
Stops spreecat joining and parting the channel by sending a notice to the channel instead.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,11 @@ script:
 notifications:
   email:
     - ryan@spreecommerce.com
-  irc: "irc.freenode.org#spree"
+  irc:
+    use_notice: true
+    skip_join: true
+    channels:
+      - "irc.freenode.org#spree"
 branches:
   only:
     - 1-0-stable


### PR DESCRIPTION
Changes from this:

![Spree Travis CI](https://img.skitch.com/20120518-dbn4rntintbbifuj5g59t4ku4c.png)

To this style which is non interruptive and takes up less space:

![Refinery Travis CI](https://img.skitch.com/20120518-jnmk1s59qfudrynu6aef4n1kji.png)
