### PR TITLE
require 'spree/core' is needed to isolate the Spree namespace. fixes #1554

### DIFF
--- a/cmd/lib/spree_cmd/templates/extension/lib/%file_name%/engine.rb.tt
+++ b/cmd/lib/spree_cmd/templates/extension/lib/%file_name%/engine.rb.tt
@@ -1,5 +1,6 @@
 module <%= class_name %>
   class Engine < Rails::Engine
+    require 'spree/core'
     engine_name '<%= file_name %>'
     isolate_namespace Spree
 

--- a/cmd/lib/spree_cmd/templates/extension/lib/%file_name%/engine.rb.tt
+++ b/cmd/lib/spree_cmd/templates/extension/lib/%file_name%/engine.rb.tt
@@ -1,5 +1,6 @@
 module <%= class_name %>
   class Engine < Rails::Engine
+    module Spree; end
     require 'spree/core'
     engine_name '<%= file_name %>'
     isolate_namespace Spree


### PR DESCRIPTION
Adding the require in the extension template
