### PR TITLE
Add product properties to api

### DIFF
--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -16,6 +16,10 @@ module Spree
          :available_on, :permalink, :count_on_hand, :meta_description, :meta_keywords]
       end
 
+      def product_property_attributes
+        [:id, :product_id, :property_id, :value]
+      end
+
       def variant_attributes
         [:id, :name, :count_on_hand, :sku, :price, :weight, :height, :width, :depth, :is_master, :cost_price]
       end

--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -17,7 +17,7 @@ module Spree
       end
 
       def product_property_attributes
-        [:id, :product_id, :property_id, :value]
+        [:id, :product_id, :property_id, :value, :property_name]
       end
 
       def variant_attributes

--- a/api/app/views/spree/api/v1/products/show.rabl
+++ b/api/app/views/spree/api/v1/products/show.rabl
@@ -19,3 +19,7 @@ child :option_types => :option_types do
     attributes *option_value_attributes
   end
 end
+
+child :product_properties => :product_properties do
+  attributes *product_property_attributes
+end

--- a/api/spec/controllers/spree/api/v1/products_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/products_controller_spec.rb
@@ -41,11 +41,7 @@ module Spree
 
       it "gets a single product" do
         product.master.images.create!(:attachment => image("thinking-cat.jpg"))
-
-        # ProductProperty requires a property_id for association; cannot mass-assign this attribute
-        # This stub is currently failing due to mass-assignment error. I'll defer to you guys for proper procedure...
-        product.property.create!(:name => 'rocks!', :presentation => 'rocks!')
-        product.product_property.create!(:property_name => 'spree', :value => 'rocks!', :property_id => product.property.id)
+        product.properties << Factory(:product_property)
         api_get :show, :id => product.to_param
         json_response.should have_attributes(attributes)
         product_json = json_response["product"]
@@ -59,8 +55,7 @@ module Spree
                                                             :attachment_height,
                                                             :attachment_content_type])
 
-        product_json["product_property"].first.should have_attributes([:value,
-                                                                      :product_id,
+        product_json["product_properties"].first.should have_attributes([:value,
                                                                       :property_name])
       end
 

--- a/api/spec/controllers/spree/api/v1/products_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/products_controller_spec.rb
@@ -53,6 +53,10 @@ module Spree
                                                             :attachment_width,
                                                             :attachment_height,
                                                             :attachment_content_type])
+
+        product_json["product_property"].first.should have_attributes([:value,
+                                                                      :property_id
+                                                                          ])
       end
 
 

--- a/api/spec/controllers/spree/api/v1/products_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/products_controller_spec.rb
@@ -41,6 +41,11 @@ module Spree
 
       it "gets a single product" do
         product.master.images.create!(:attachment => image("thinking-cat.jpg"))
+
+        # ProductProperty requires a property_id for association; cannot mass-assign this attribute
+        # This stub is currently failing due to mass-assignment error. I'll defer to you guys for proper procedure...
+        product.property.create!(:name => 'rocks!', :presentation => 'rocks!')
+        product.product_property.create!(:property_name => 'spree', :value => 'rocks!', :property_id => product.property.id)
         api_get :show, :id => product.to_param
         json_response.should have_attributes(attributes)
         product_json = json_response["product"]
@@ -55,8 +60,8 @@ module Spree
                                                             :attachment_content_type])
 
         product_json["product_property"].first.should have_attributes([:value,
-                                                                      :property_id
-                                                                          ])
+                                                                      :product_id,
+                                                                      :property_name])
       end
 
 

--- a/core/lib/spree/core/testing_support/factories/product_property_factory.rb
+++ b/core/lib/spree/core/testing_support/factories/product_property_factory.rb
@@ -2,5 +2,6 @@ FactoryGirl.define do
   factory :product_property, :class => Spree::ProductProperty do
     product { Factory(:product) }
     property { Factory(:property) }
+    value 'blue'
   end
 end


### PR DESCRIPTION
We had a need to add Product Properties to the Spree API. I have implemented the model object as a child of Product. I also plan to add further access by including support for the Property model object. 
