### PR TITLE
Add devise to fix dummy db seed/migration

### DIFF
--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -21,6 +21,7 @@ group :test do
   gem 'rspec-rails', '~> 2.9.0'
   gem 'factory_girl_rails', '~> 1.7.0'
   gem 'email_spec', '~> 1.2.1'
+  gem 'devise', '~> 2.0.4'
 
   gem 'ffaker'
   gem 'shoulda-matchers', '~> 1.0.0'


### PR DESCRIPTION
This is all-encompassing of issues such as #1544 and #1545. Devise 2.0.x should be a common dependency to prevent test_app breakage
