### PR TITLE
Rename SalesTax calculator to DefaultTax in 1.0

### DIFF
--- a/core/db/migrate/20120523061241_convert_sales_tax_to_default_tax.rb
+++ b/core/db/migrate/20120523061241_convert_sales_tax_to_default_tax.rb
@@ -1,0 +1,9 @@
+class ConvertSalesTaxToDefaultTax < ActiveRecord::Migration
+  def up
+    execute "UPDATE spree_calculators SET type='Spree::Calculator::DefaultTax' WHERE type='Spree::Calculator::SalesTax'"
+  end
+
+  def down
+    execute "UPDATE spree_calculators SET type='Spree::Calculator::SalesTax' WHERE type='Spree::Calculator::DefaultTax'"
+ end
+end


### PR DESCRIPTION
This fixes issue #1581 per your request.

Thanks.
