### PR TITLE
Reset classes cycle

### DIFF
--- a/core/app/views/spree/shared/_products.html.erb
+++ b/core/app/views/spree/shared/_products.html.erb
@@ -13,7 +13,7 @@
   <% reset_cycle('default') %>
   <% products.each do |product| %>
     <% if Spree::Config[:show_zero_stock_products] || product.has_stock? %>
-      <li id="product_<%= product.id %>" class="columns three <%= cycle("alpha", "secondary", "", "omega secondary") %>" data-hook="products_list_item" itemscope itemtype="http://schema.org/Product">
+      <li id="product_<%= product.id %>" class="columns three <%= cycle("alpha", "secondary", "", "omega secondary", :name => "classes") %>" data-hook="products_list_item" itemscope itemtype="http://schema.org/Product">
         <div class="product-image">
           <%= link_to small_image(product, :itemprop => "image"), product, :itemprop => 'url' %>
         </div>
@@ -22,6 +22,7 @@
       </li>
     <% end %>
   <% end %>
+  <% reset_cycle("classes") %>
 </ul>
 <% end %>
 


### PR DESCRIPTION
Resets cycle as shown here: 
http://api.rubyonrails.org/classes/ActionView/Helpers/TextHelper.html#method-i-reset_cycle.

In taxon previews it introduces css classes problems if a taxons contains less then four products.
