### PR TITLE
Mass assignment exception when creating a promo code that creates a line item

### DIFF
--- a/promo/app/models/spree/promotion_action.rb
+++ b/promo/app/models/spree/promotion_action.rb
@@ -6,6 +6,8 @@ module Spree
 
     scope :of_type, lambda {|t| {:conditions => {:type => t}}}
 
+    attr_accessible :line_items_string
+
     # This method should be overriden in subclass
     # Updates the state of the order or performs some other action depending on the subclass
     # options will contain the payload from the event that activated the promotion. This will include

--- a/promo/spec/requests/promotion_adjustments_spec.rb
+++ b/promo/spec/requests/promotion_adjustments_spec.rb
@@ -295,6 +295,21 @@ describe "Promotion Adjustments" do
 
     end
 
+    it "should allow an admin to create a promotion that adds an item to the cart" do
+      fill_in "Name", :with => "Bundle"
+      select "Coupon code added", :from => "Event"
+      fill_in "Code", :with => "5ZHED2DH"
+      click_button "Create"
+      page.should have_content("Editing Promotion")
+
+      select "Create line items", :from => "Add action of type"
+      within('#action_fields') do
+        click_button "Add"
+        click_button "Update"
+      end
+      page.should_not have_content("Can't mass-assign protected attributes: line_items_string")
+    end
+
     it "ceasing to be eligible for a promotion with item total rule then becoming eligible again" do
       fill_in "Name", :with => "Spend over $50 and save $5"
       select "Order contents changed", :from => "Event"


### PR DESCRIPTION
A mass assignment exception is raised while attempting to create a promo code that adds a line item to the cart.
