### PR TITLE
Fixes inconsistent behavior with promo that adds items to the cart

### DIFF
--- a/promo/app/models/spree/promotion/actions/create_adjustment.rb
+++ b/promo/app/models/spree/promotion/actions/create_adjustment.rb
@@ -16,6 +16,7 @@ module Spree
           order.adjustments.promotion.reload.clear
           order.update!
           create_adjustment("#{I18n.t(:promotion)} (#{promotion.name})", order, order)
+          order.update!
         end
 
         # override of CalculatedAdjustments#create_adjustment so promotional

--- a/promo/app/models/spree/promotion/actions/create_line_items.rb
+++ b/promo/app/models/spree/promotion/actions/create_line_items.rb
@@ -12,6 +12,7 @@ module Spree
             current_quantity = order.quantity_of(item.variant)
             if current_quantity < item.quantity
               order.add_variant(item.variant, item.quantity - current_quantity)
+              order.update!
             end
           end
         end

--- a/promo/spec/models/promotion/actions/create_adjustment_spec.rb
+++ b/promo/spec/models/promotion/actions/create_adjustment_spec.rb
@@ -16,9 +16,8 @@ describe Spree::Promotion::Actions::CreateAdjustment do
 
 
     it "should create a discount with correct negative amount when order is eligible" do
-      order.stub(:ship_total => 5, :item_total => 5000, :reload => nil)
+      order.stub(:ship_total => 2500, :item_total => 5000, :reload => nil)
       promotion.stub(:eligible? => true)
-      action.calculator.stub(:compute => 2500)
 
       action.perform(:order => order)
       promotion.credits_count.should == 1

--- a/promo/spec/requests/promotion_adjustments_spec.rb
+++ b/promo/spec/requests/promotion_adjustments_spec.rb
@@ -295,6 +295,59 @@ describe "Promotion Adjustments" do
 
     end
 
+    it "should allow an admin to create a promotion that adds a 'free' item to the cart" do
+      fill_in "Name", :with => "Bundle"
+      select "Coupon code added", :from => "Event"
+      fill_in "Code", :with => "5ZHED2DH"
+      click_button "Create"
+      page.should have_content("Editing Promotion")
+
+      select "Create line items", :from => "Add action of type"
+      within('#action_fields') { click_button "Add" }
+      fill_in "Name or SKU", :with => "RoR Mug"
+      find(:xpath, '//div/h4[contains(.,"RoR Mug")]').click
+      within('.add-line-item') { click_button "Add" }
+
+      within('#actions_container') { click_button "Update" }
+
+      select "Create adjustment", :from => "Add action of type"
+      within('#new_promotion_action_form') { click_button "Add" }
+      select "Flat Rate (per order)", :from => "Calculator"
+      within('#actions_container') { click_button "Update" }
+      within('.calculator-fields') { fill_in "Amount", :with => "40.00" }
+      within('#actions_container') { click_button "Update" }
+
+      visit spree.root_path
+      click_link "RoR Bag"
+      click_button "Add To Cart"
+      click_link "Checkout"
+
+      str_addr = "bill_address"
+      select "United States", :from => "order_#{str_addr}_attributes_country_id"
+      ['firstname', 'lastname', 'address1', 'city', 'zipcode', 'phone'].each do |field|
+        fill_in "order_#{str_addr}_attributes_#{field}", :with => "#{address.send(field)}"
+      end
+      select "#{address.state.name}", :from => "order_#{str_addr}_attributes_state_id"
+      check "order_use_billing"
+      click_button "Save and Continue"
+      click_button "Save and Continue"
+
+      choose('Credit Card')
+      fill_in "card_number", :with => "4111111111111111"
+      fill_in "card_code", :with => "123"
+
+      fill_in "order_coupon_code", :with => "5ZHED2DH"
+      click_button "Save and Continue"
+
+      last_order = Spree::Order.last
+      last_order.line_items.count.should == 2
+      last_order.line_items.first.price.to_f.should == 20.00
+      last_order.line_items.last.price.to_f.should == 40.00
+      last_order.item_total.to_f.should == 60.00
+      last_order.adjustments.promotion.map(&:amount).sum.to_f.should == -40.00
+      last_order.total.to_f.should == 30.00
+    end
+
     it "ceasing to be eligible for a promotion with item total rule then becoming eligible again" do
       fill_in "Name", :with => "Spend over $50 and save $5"
       select "Order contents changed", :from => "Event"


### PR DESCRIPTION
Fixes issue in #1588 by making the assumption that the create line item action should not add items for free.
