### PR TITLE
 "1 234.00 " cost_price validation failure coming from admin product controller

### DIFF
--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -63,6 +63,12 @@ module Spree
       end
     end
 
+    # and cost_price
+    def cost_price=(price)
+      if price.present?
+        self[:cost_price] = price.to_s.gsub(/[^0-9\.-]/, '').to_f
+      end
+    end
 
     # returns number of units currently on backorder for this variant.
     def on_backorder


### PR DESCRIPTION
Please notice the difference of _before_type_cast (String vs Float)

1.9.3p125 :090 > m.class
 => Spree::Variant(id: integer, sku: string, price: decimal, weight: decimal, height: decimal, width: decimal, depth: decimal, deleted_at: datetime, is_master: boolean, product_id: integer, count_on_hand: integer, cost_price: decimal, position: integer) 
1.9.3p125 :091 > m
 => #<Spree::Variant id: 1073482949, sku: "COPY OF SWK2000/10", price: #<BigDecimal:7140eb8,'0.817E4',9(18)>, weight: nil, height: nil, width: nil, depth: nil, deleted_at: nil, is_master: true, product_id: 1073605631, count_on_hand: 15, cost_price: #<BigDecimal:7140648,'0.6115E4',9(18)>, position: nil> 
1.9.3p125 :092 > m.cost_price = "6 115.00 "
 => "6 115.00 " 
1.9.3p125 :093 > m.price = "8 700.00 "
 => "8 700.00 " 
1.9.3p125 :094 > m.save
   (0.4ms)  BEGIN
   (0.3ms)  ROLLBACK
 => false 
1.9.3p125 :095 > m.errors
 => #<ActiveModel::Errors:0x0000000705fdf0 @base=#<Spree::Variant id: 1073482949, sku: "COPY OF SWK2000/10", price: #<BigDecimal:6fe9b50,'0.87E4',9(45)>, weight: nil, height: nil, width: nil, depth: nil, deleted_at: nil, is_master: true, product_id: 1073605631, count_on_hand: 15, cost_price: #<BigDecimal:6fe9448,'0.6E1',9(18)>, position: nil>, @messages={:cost_price=>["is not a number"]}> 
1.9.3p125 :096 > m.cost_price_before_type_cast
 => "6 115.00 " 
1.9.3p125 :097 > m.price_before_type_cast
 => 8700.0

Please backport to 1-1-stable also
