### PR TITLE
Order totals stale after add variant

### DIFF
--- a/api/spec/models/spree/order_spec.rb
+++ b/api/spec/models/spree/order_spec.rb
@@ -5,14 +5,14 @@ module Spree
     let(:user) { stub_model(User) }
 
     it 'can build an order from API parameters' do
-
-      Spree::Variant.should_receive(:find).and_return(stub_model(Variant, :id => 1))
-      order = Order.build_from_api(user, { :line_items_attributes => [{ :variant_id => 1, :quantity => 5 }]})
+      product = Spree::Product.create!(:name => 'Test', :sku => 'TEST-1', :price => 33.22)
+      variant_id = product.master.id
+      order = Order.build_from_api(user, { :line_items_attributes => [{ :variant_id => variant_id, :quantity => 5 }]})
 
       order.user.should == user
       line_item = order.line_items.first
       line_item.quantity.should == 5
-      line_item.variant_id.should == 1
+      line_item.variant_id.should == variant_id
     end
   end
 end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -296,6 +296,7 @@ module Spree
         current_item.update_attribute(field[:name].gsub(' ', '_').downcase, value)
       end
 
+      self.reload
       current_item
     end
 

--- a/core/spec/models/order_spec.rb
+++ b/core/spec/models/order_spec.rb
@@ -979,4 +979,18 @@ describe Spree::Order do
     end
   end
 
+  context "#add_variant" do
+    it "should update order totals" do
+      order = Spree::Order.create!
+
+      order.item_total.to_f.should == 0.00
+      order.total.to_f.should == 0.00
+
+      product = Spree::Product.create!(:name => 'Test', :sku => 'TEST-1', :price => 22.25)
+      order.add_variant(product.master)
+
+      order.item_total.to_f.should == 22.25
+      order.total.to_f.should == 22.25
+    end
+  end
 end

--- a/core/spec/requests/admin/orders/payments_spec.rb
+++ b/core/spec/requests/admin/orders/payments_spec.rb
@@ -36,14 +36,14 @@ describe "Payments" do
 
       click_link "Payments"
       within('#payment_status') { page.should have_content("Payment: balance due") }
-      find('table.index tbody tr:nth-child(2) td:nth-child(2)').text.should == "$39.98"
+      find('table.index tbody tr:nth-child(2) td:nth-child(2)').text.should == "$49.98"
       find('table.index tbody tr:nth-child(2) td:nth-child(3)').text.should == "Credit Card"
       find('table.index tbody tr:nth-child(2) td:nth-child(4)').text.should == "pending"
 
       click_button "Void"
       within('#payment_status') { page.should have_content("Payment: balance due") }
       page.should have_content("Payment Updated")
-      find('table.index tbody tr:nth-child(2) td:nth-child(2)').text.should == "$39.98"
+      find('table.index tbody tr:nth-child(2) td:nth-child(2)').text.should == "$49.98"
       find('table.index tbody tr:nth-child(2) td:nth-child(3)').text.should == "Credit Card"
       find('table.index tbody tr:nth-child(2) td:nth-child(4)').text.should == "void"
 


### PR DESCRIPTION
Calling `Order#add_variant` should update order totals. While the values are getting correctly updated in the database, the in-memory instance of the order is not getting updated. One solution is to call `reload` from within the `Order#add_variant` method.
