### PR TITLE
Admin payments new minor fixes

### DIFF
--- a/core/app/views/spree/admin/payments/new.html.erb
+++ b/core/app/views/spree/admin/payments/new.html.erb
@@ -11,6 +11,7 @@
 
     <p class="form-buttons" data-hook="buttons">
       <%= button @order.cart? ? t(:continue) : t(:update) %>
+      <%= t(:or) %> <%= link_to t(:back), admin_order_payments_url(@order) %>
     </p>
 
   <% end %>

--- a/core/app/views/spree/admin/payments/new.html.erb
+++ b/core/app/views/spree/admin/payments/new.html.erb
@@ -20,5 +20,5 @@
 <% end %>
 
 <% content_for :head do %>
-  <%= javascript_include_tag '/admin/javascripts/payments/new.js' %>
+  <%= javascript_include_tag '/assets/admin/payments/new.js' %>
 <% end %>


### PR DESCRIPTION
- fixing the the path to asset admin/payments/new.js in admin/payments/new view javascript_include_tag
- adding a "back" link to the view to cancel the payment creation
