### PR TITLE
Fixing what seems to be a namespacing error in self.available

### DIFF
--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -185,7 +185,7 @@ module Spree
     end
 
     def self.available(available_on = nil)
-      where("#{Product.quoted_table_name}.available_on <= ?", available_on || Time.now)
+      where("#{Spree::Product.quoted_table_name}.available_on <= ?", available_on || Time.now)
     end
 
     #RAILS 3 TODO - this scope doesn't match the original 2.3.x version, needs attention (but it works)


### PR DESCRIPTION
On Spree 1.0.4, the following line in app/views/spree/shared/_products.html.erb 

```
<% if products.empty? %>
```

was generating the following error:

```
Mysql2::Error: Unknown column 'products.available_on' in 'where clause': SELECT  DISTINCT `spree_products`.id FROM `spree_products` LEFT OUTER JOIN `spree_product_taxons` ON `spree_product_taxons`.`product_id` = `spree_products`.`id` LEFT OUTER JOIN `spree_assets` ON `spree_assets`.`viewable_id` = `spree_products`.`id` AND `spree_assets`.`type` IN ('Spree::Image', 'ContentImage') AND `spree_assets`.`viewable_type` = 'Spree::Product' LEFT OUTER JOIN `spree_variants` ON `spree_variants`.`product_id` = `spree_products`.`id` AND `spree_variants`.is_master = 1 AND `spree_variants`.deleted_at IS NULL WHERE `spree_products`.`deleted_at` IS NULL AND (products.available_on <= '2012-05-29 01:12:51') AND (spree_products.id in (select product_id from spree_variants where product_id = spree_products.id group by product_id having sum(count_on_hand) > 0)) ORDER BY product_taxons.taxon_id, product_taxons.position LIMIT 20 OFFSET 0
```

The problem was that Product.quoted_table_name returned "products" instead of "spree_products".

Small fix attached.
