### PR TITLE
Removing html in product description in cart before it gets truncated

### DIFF
--- a/core/app/views/spree/orders/_line_item.html.erb
+++ b/core/app/views/spree/orders/_line_item.html.erb
@@ -14,7 +14,7 @@
         <%= variant.in_stock? ? t(:insufficient_stock, :on_hand => variant.on_hand) : t(:out_of_stock) %><br />
       </span>
     <% end %>
-    <%= truncate(variant.product.description, :length => 100, :omission => "...") %>
+    <%= truncate(variant.product.description.gsub(/<(.*?)>/,""), :length => 100, :omission => "...") %>
   </td>
   <td data-hook="cart_item_price">
     <%= number_to_currency line_item.price %>


### PR DESCRIPTION
HTML tags will display currently
