### PR TITLE
Fix to not allow trailing slash on script name when matching

### DIFF
--- a/core/lib/spree/core/ssl_requirement.rb
+++ b/core/lib/spree/core/ssl_requirement.rb
@@ -102,10 +102,10 @@ module SslRequirement
     def ensure_proper_protocol
       return true if ssl_allowed?
       if ssl_required? && !request.ssl? && ssl_supported?
-        redirect_to "https://" + request.host + request.fullpath
+        redirect_to "https://" + request.host + request.fullpath.sub("//", "/")
         flash.keep
       elsif request.ssl? && !ssl_required?
-        redirect_to "http://" + request.host + request.fullpath
+        redirect_to "http://" + request.host + request.fullpath.sub("//", "/")
         flash.keep
       end
 


### PR DESCRIPTION
This appears to be a [known issue](https://github.com/rails/journey/pull/24) with mounted engines on the root path. An additional slash is added to the request.fullpath and the https redirect will contain the second slash.

It will look like this:
https://example.com//login

While the issue appears to be resolved in Journey, it does not look like 1.0.3 release included with Rails 3.2.3 includes this patch (or in 3.2.4).

This small fix is not ideal (IMO) but it is working for my install and it might help others as well.
