### PR TITLE
Add percent per item calculator to promotions

### DIFF
--- a/promo/app/models/spree/calculator/percent_per_item.rb
+++ b/promo/app/models/spree/calculator/percent_per_item.rb
@@ -1,0 +1,48 @@
+module Spree
+
+  # A calculator for promotions that calculates a percent-off discount
+  # for all matching products in an order. This should not be used as a 
+  # shipping calculator since it would be the same thing as a flat percent
+  # off the entire order.
+  
+  class Calculator::PercentPerItem < Calculator
+    preference :percent, :decimal, :default => 0
+
+    attr_accessible :preferred_percent
+
+    def self.description
+      I18n.t(:percent_per_item)
+    end
+
+    def compute(object=nil)
+      return 0 if object.nil?
+      object.line_items.reduce(0) do |sum, line_item|
+        sum += value_for_line_item(line_item)
+      end
+    end
+
+  private
+
+    # Returns all products that match the promotion's rule. 
+    def matching_products
+      @matching_products ||= if compute_on_promotion?
+        self.calculable.promotion.rules.map(&:products).flatten
+      end
+    end
+
+    # Calculates the discount value of each line item. Returns zero 
+    # unless the product is included in the promotion rules.
+    def value_for_line_item(line_item)
+      if compute_on_promotion?
+        return 0 unless matching_products.include?(line_item.product)
+      end
+      line_item.price * line_item.quantity * preferred_percent
+    end
+
+    # Determines wether or not the calculable object is a promotion
+    def compute_on_promotion?
+      @compute_on_promotion ||= self.calculable.respond_to?(:promotion)
+    end
+
+  end
+end

--- a/promo/config/locales/en.yml
+++ b/promo/config/locales/en.yml
@@ -33,6 +33,7 @@ en:
     path: Path
   new_promotion: New Promotion
   no_rules_added: No rules added
+  percent_per_item: Percent Per Item
   product_rule:
     choose_products: Choose products
     label: "Order must contain %{select} of these products"

--- a/promo/lib/spree/promo/engine.rb
+++ b/promo/lib/spree/promo/engine.rb
@@ -32,6 +32,7 @@ module Spree
           Spree::Calculator::FlatRate,
           Spree::Calculator::FlexiRate,
           Spree::Calculator::PerItem,
+          Spree::Calculator::PercentPerItem,
           Spree::Calculator::FreeShipping
         ]
       end

--- a/promo/spec/models/calculator/percent_per_item_spec.rb
+++ b/promo/spec/models/calculator/percent_per_item_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe Spree::Calculator::PercentPerItem do
+  # Like an order object, but not quite...
+  let!(:product1) { double("Product") }
+  let!(:product2) { double("Product") }
+  let!(:line_items) { [double("LineItem", :quantity => 5, :product => product1, :price => 10), double("LineItem", :quantity => 1, :product => product2, :price => 10)] }
+  let!(:object) { double("Order", :line_items => line_items) }
+
+  let!(:promotion_calculable) { double("Calculable", :promotion => promotion) }
+
+  let!(:promotion) { double("Promotion", :rules => [double("Rule", :products => [product1])]) }
+
+  let!(:calculator) { Spree::Calculator::PercentPerItem.new(:preferred_percent => 0.25) }
+
+  it "has a translation for description" do
+    calculator.description.should_not include("translation missing")
+    calculator.description.should == I18n.t(:percent_per_item)
+  end
+
+  it "correctly calculates per item promotion" do
+    calculator.stub(:calculable => promotion_calculable)
+    calculator.compute(object).to_f.should == 12.5 # 5 x 10 x 0.25 since only product1 is included in the promotion rule
+  end
+
+  it "returns 0 when no object passed" do
+    calculator.stub(:calculable => promotion_calculable)
+    calculator.compute.should == 0
+  end
+
+  it "computes on promotion when promotion is present" do
+    calculator.send(:compute_on_promotion?).should_not be_true
+    calculator.stub(:calculable => promotion_calculable)
+    calculator.send(:compute_on_promotion?).should be_true
+  end
+
+end


### PR DESCRIPTION
This PR adds a new calculator to promotions. It calculates a percent per item discount for eligible products.
