### PR TITLE
Removes prepend_before_filter from ressources controller

### DIFF
--- a/core/app/controllers/spree/admin/resource_controller.rb
+++ b/core/app/controllers/spree/admin/resource_controller.rb
@@ -2,7 +2,7 @@ require 'spree/core/action_callbacks'
 
 class Spree::Admin::ResourceController < Spree::Admin::BaseController
   helper_method :new_object_url, :edit_object_url, :object_url, :collection_url
-  prepend_before_filter :load_resource
+  before_filter :load_resource
   rescue_from ActiveRecord::RecordNotFound, :with => :resource_not_found
 
   respond_to :html


### PR DESCRIPTION
And replaces it with a simple before_filter.

This fixes an issue using Authlogic as custom user authentication as discussed [here](https://github.com/spree/spree/pull/1512#issuecomment-6104052)
