### PR TITLE
spree_users should have unique index on email

### DIFF
--- a/core/config/routes.rb
+++ b/core/config/routes.rb
@@ -11,9 +11,9 @@ Spree::Core::Engine.routes.draw do
   resources :states, :only => :index
 
   # non-restful checkout stuff
-  match '/checkout/update/:state', :to => 'checkout#update', :as => :update_checkout
-  match '/checkout/:state', :to => 'checkout#edit', :as => :checkout_state
-  match '/checkout', :to => 'checkout#edit', :state => 'address', :as => :checkout
+  match '/checkout/update/:state', :to => 'checkout#update', :as => :update_checkout, :via => :put
+  match '/checkout/:state', :to => 'checkout#edit', :as => :checkout_state, :via => :get
+  match '/checkout', :to => 'checkout#edit', :state => 'address', :as => :checkout, :via => :get
 
   resources :orders do
     post :populate, :on => :collection

--- a/core/db/migrate/20120605211305_make_users_email_index_unique.rb
+++ b/core/db/migrate/20120605211305_make_users_email_index_unique.rb
@@ -1,0 +1,11 @@
+class MakeUsersEmailIndexUnique < ActiveRecord::Migration
+  def up
+    remove_index "spree_users", :name => "email_idx"
+    add_index "spree_users", ["email"], :name => "email_idx", :unique => true
+  end
+
+  def down
+    remove_index "spree_users", :name => "email_idx"
+    add_index "spree_users", ["email"], :name => "email_idx"
+  end
+end


### PR DESCRIPTION
We've found we're getting a number of duplicate user records, not due to failure in the validation but some database anomaly, they have identical timestamps but sequential ids. The application is still validating users correctly. I don't know the exact cause but changing the existing index on email to unique seems like a good precaution.  
