### PR TITLE
Fix for bug #1468

### DIFF
--- a/core/app/controllers/spree/admin/orders_controller.rb
+++ b/core/app/controllers/spree/admin/orders_controller.rb
@@ -50,8 +50,10 @@ module Spree
         if @order.update_attributes(params[:order]) && @order.line_items.present?
           @order.update!
           unless @order.complete?
-
+            # Jump to next step if order is not complete.
+            return_path = admin_order_customer_path(@order)
           else
+            # Otherwise, go back to first page since all necessary information has been filled out.
             return_path = admin_order_path(@order)
           end
         else


### PR DESCRIPTION
With this code, updating an order through the admin panel will now succesfully redirect to the next step (customer details) if the order is not complete. This pull request hardcodes the return_path in OrdersController to be the next step, which is the same technique employed in CustomerDetailsController.

Maybe it would be better to define some centralized location that determines the redirect sequence in case the step order changes in some future point? I don't know.
