### PR TITLE
Update deface gem dependency to version >= 0.9.0

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -31,6 +31,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'activemerchant', '= 1.20.4'
   s.add_dependency 'rails', '~> 3.2.5'
   s.add_dependency 'kaminari', '>= 0.13.0'
-  s.add_dependency 'deface', '>= 0.8.0'
+  s.add_dependency 'deface', '>= 0.9.0'
   s.add_dependency 'stringex', '~> 1.3.2'
 end


### PR DESCRIPTION
deface 0.9 adds/fixes automatic reloading of overrides in development mode – without restarting the server
