### PR TITLE
Added attachment_url to support AWS S3 in EU

### DIFF
--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -68,6 +68,7 @@ module Spree
     # Preferences related to image settings
     preference :attachment_default_url, :string, :default => '/spree/products/:id/:style/:basename.:extension'
     preference :attachment_path, :string, :default => ':rails_root/public/spree/products/:id/:style/:basename.:extension'
+    preference :attachment_url, :string, :default => '/spree/products/:id/:style/:basename.:extension'
     preference :attachment_styles, :string, :default => "{\"mini\":\"48x48>\",\"small\":\"100x100>\",\"product\":\"240x240>\",\"large\":\"600x600>\"}"
     preference :attachment_default_style, :string, :default => 'product'
     preference :s3_access_key, :string

--- a/core/app/models/spree/image.rb
+++ b/core/app/models/spree/image.rb
@@ -25,6 +25,7 @@ module Spree
 
     Spree::Image.attachment_definitions[:attachment][:styles] = ActiveSupport::JSON.decode(Spree::Config[:attachment_styles])
     Spree::Image.attachment_definitions[:attachment][:path] = Spree::Config[:attachment_path]
+    Spree::Image.attachment_definitions[:attachment][:url] = Spree::Config[:attachment_url]
     Spree::Image.attachment_definitions[:attachment][:default_url] = Spree::Config[:attachment_default_url]
     Spree::Image.attachment_definitions[:attachment][:default_style] = Spree::Config[:attachment_default_style]
 


### PR DESCRIPTION
When using a EU bucket on S3, the url format changes to http://bucketname.s3.amazonaws.com.
This pull request makes it possible to use S3 EU with the following configuration:

``` ruby
Spree.config do |config|
  config.site_name = "Spree Title"
  config.use_s3 = true
  config.s3_access_key = "YOUR_ACCESS_KEY"
  config.s3_secret = "YOUR_SECRET"
  config.s3_bucket = "YOUR_EU_BUCKET"
  config.attachment_url = ":s3_domain_url"
end
```
