### PR TITLE
Add .js extension to request for States controller's javascript in spree...

### DIFF
--- a/core/app/views/spree/checkout/edit.html.erb
+++ b/core/app/views/spree/checkout/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :head do %>
-  <%= javascript_include_tag states_url %>
+  <%= javascript_include_tag states_url + '.js' %>
 <% end %>
 <div id="checkout" data-hook>  
   <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @order } %>


### PR DESCRIPTION
.../checkout/edit view

Fixes issue where some clients (or proxies) can mangle or omit the Accept header, causing Rails to infer the response type from the format of the URL rather than the Accept header.  This causes a 406 error trying to load the states javascript during checkout, so checkout is broken in turn.

Since Rails is inferring response type from the URL, which is currently "/states", it defaults the response type to HTML. However, since the States controller only responds to :js, it issues a 406 Not Acceptable error rather than serving back the javascript. Checkout depends on that javascript, so checkout breaks.

Not sure of a way to reliably reproduce the issue since it's showing up in a somewhat exotic setup, but it would probably occur if a request to /states were sent with no accept header whatsoever. I don't have the know-how to mock up such a request.

Simple solution is to just add the .js extension to the request. This triggers Rails to correctly infer the response type, getting rid of the 406 error and making everyone happy.

Back when this was the case (before the commit which changed the request from /states.js to states_url), it was working fine in my environment, and it does so again since I put in a workaround in my application in the form of a deface modification to the view.

However, a general solution would serve better, in the form of the commit submitted here.
