### PR TITLE
better imagemagick check suggested by @Avdi

### DIFF
--- a/cmd/lib/spree_cmd/installer.rb
+++ b/cmd/lib/spree_cmd/installer.rb
@@ -179,15 +179,10 @@ module SpreeCmd
       end
 
       def image_magick_installed?
-        begin
-          %x(identify -version)
-        # The Errno::ENOENT exception is raised on all OSes when it cannot find a command
-        rescue Errno::ENOENT
-          return false
-        rescue # Silence any other exception
-        end
-        # If program *did* execute, check to see if it executed successfully
-        $?.success?
+        # true if command executed succesfully
+        # false for non zero exit status
+        # nil if command execution fails
+        system('identify -version')
       end
   end
 end


### PR DESCRIPTION
While pairing with Avdi Grimm he noticed the return value from `%x()` is
not used. Instead the variable `$?` is checked. A better approach is using
`system` which will return true if the command executed successfully and
then checking that value. It removes the need to check `$?` and also gets
rid of the need for rescue. Another benefit is that testing this part of
the code becomes easier.
