### PR TITLE
Tax rate label adjust

### DIFF
--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -45,7 +45,7 @@ module Spree
 
     # Creates necessary tax adjustments for the order.
     def adjust(order)
-      label = "#{tax_category.name} #{amount * 100}%"
+      label = create_label
       if included_in_price
         if Zone.default_tax.contains? order.tax_zone
           order.line_items.each { |line_item| create_adjustment(label, line_item, line_item) }
@@ -63,6 +63,10 @@ module Spree
       end
     end
 
+    private
+      def create_label
+        "#{tax_category.name} #{amount * 100}%"
+      end
   end
 
 end


### PR DESCRIPTION
This PR allows to easily customize the label display in an tax line item. Right now it is always set to the name of the tax category. In Canada however, and certainly in other countries, a product can be subject to more than one tax (PST and GST for instance) and we need 2 lines with two tax-rates. For legal reasons (and also traceability for the buyer) the label displayed cannot be the same on both lines.

A Canadian shop could easily create a decorator for the TaxRate model  and simply override with a class_eval the `create_label` method instead of overriding the whole `adjust(order)` method.

Let me know if it needs more clarification

Michael
