### PR TITLE
Fixes autocomplete urls. Fixes #1666

### DIFF
--- a/core/app/assets/javascripts/admin/admin.js.erb
+++ b/core/app/assets/javascripts/admin/admin.js.erb
@@ -120,7 +120,7 @@ $.fn.product_autocomplete = function(){
   return this.each(function() {
     $(this).autocomplete({
       source: function(request, response) {
-        $.get("/admin/products.json?q=" + $('#add_product_name').val() + "&authenticity_token=" + encodeURIComponent($('meta[name=csrf-token]').attr("content")), function(data) {
+        $.get(Spree.routes.admin_products_path({format: 'json'}) + "?q=" + $('#add_product_name').val() + "&authenticity_token=" + encodeURIComponent($('meta[name=csrf-token]').attr("content")), function(data) {
           result = prep_product_autocomplete_data(data)
           response(result);
         });

--- a/core/app/assets/javascripts/admin/checkouts/edit.js
+++ b/core/app/assets/javascripts/admin/checkouts/edit.js
@@ -46,7 +46,7 @@ $(document).ready(function(){
       minChars: 5,
       delay: 1500,
       source: function(request, response) {
-        $.get("/admin/users.json?q=" + $("#customer_search").val() + "&authenticity_token=" + encodeURIComponent($('meta[name=csrf-token]').attr("content")), function(data) {
+        $.get(Spree.routes.admin_users_path({format: 'json'}) + "?q=" + $("#customer_search").val() + "&authenticity_token=" + encodeURIComponent($('meta[name=csrf-token]').attr("content")), function(data) {
           result = prep_user_autocomplete_data(data)
           response(result);
         });

--- a/core/app/assets/javascripts/admin/spree.routes.js.erb
+++ b/core/app/assets/javascripts/admin/spree.routes.js.erb
@@ -1,0 +1,30 @@
+// This object provides dynamically generated Rails routes in Javascript.
+// Since Rails does not provide url_helpers in js.erb files, we have to use this little neat hack.
+// Found via https://github.com/magiclabs/alchemy_cms
+
+<% self.class.instance_eval { include Spree::Core::Engine.routes.url_helpers } %>
+
+if (typeof(Spree) === 'undefined') {
+  var Spree = {};
+}
+
+(function($) {
+
+  var routes = {};
+  $.extend(Spree, routes);
+
+  Spree.routes = {
+
+    admin_users_path: function(options) {
+      if (typeof(options) === 'undefined') options = {format: 'html'};
+      return '<%= admin_users_path %>' + '.' + options.format;
+    },
+
+    admin_products_path: function(options) {
+      if (typeof(options) === 'undefined') options = {format: 'html'};
+      return '<%= admin_products_path %>' + '.' + options.format;
+    }
+
+  }
+
+})(jQuery);


### PR DESCRIPTION
This fixes an issue with wrong urls in autocomplete textfields, if Spree is mounted at anything other then `/`.

Could please someone port this into 1-1-stable and master after merging it in?

Thanks <3
