### PR TITLE
Fixes promotions with product rule and manually selected product.

### DIFF
--- a/promo/app/views/spree/admin/promotions/rules/_product.html.erb
+++ b/promo/app/views/spree/admin/promotions/rules/_product.html.erb
@@ -4,7 +4,7 @@
 </p>
 <p class="field products_rule_product_group">
   <label><%= t(:product_group) %><br />
-    <%= select_tag "#{param_prefix}[product_group_id]", options_from_collection_for_select(Spree::ProductGroup.all, :id, :name, promotion_rule.product_group_id) %></label>
+    <%= select_tag "#{param_prefix}[product_group_id]", options_from_collection_for_select(Spree::ProductGroup.all, :id, :name, promotion_rule.product_group_id), { :include_blank => true } %></label>
 </p>
 <p class="field products_rule_products">
   <label>

--- a/promo/app/views/spree/admin/promotions/rules/_product.html.erb
+++ b/promo/app/views/spree/admin/promotions/rules/_product.html.erb
@@ -10,6 +10,7 @@
   <label>
     <%= t('product_rule.choose_products') %><br />
     <%= product_picker_field "#{param_prefix}[product_ids_string]", promotion_rule.product_ids_string %>
+  </label>
 </p>
 <p>
   <label>


### PR DESCRIPTION
This fixes promotions that use a product rule and where a manually selected product was never taken, because the product groups select had no blank option and therefore a product_group_id was always set.
