### PR TITLE
Braintree seems to send an empty authorization when capturing payments. ...

### DIFF
--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -121,8 +121,10 @@ module Spree
       record_response(response)
 
       if response.success?
-        self.response_code = response.authorization
-        self.avs_response = response.avs_result['code']
+        unless response.authorization.nil?
+          self.response_code = response.authorization
+          self.avs_response = response.avs_result['code']
+        end
         self.send("#{success_state}!")
       else
         self.send(failure_state)


### PR DESCRIPTION
...We need to preserve the original response code to support partial credits (refunds). 
