### PR TITLE
Mass-assignment Issue with AuthorizeNetCIM

### DIFF
--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -12,7 +12,7 @@ module Spree
     validates :verification_value, :presence => true, :unless => :has_payment_profile?, :on => :create
 
     attr_accessible :first_name, :last_name, :number, :verification_value, :year,
-                    :month, :gateway_customer_profile_id
+                    :month, :gateway_customer_profile_id, :gateway_payment_profile_id
 
     def set_last_digits
       number.to_s.gsub!(/\s/,'')


### PR DESCRIPTION
I was testing out authorize.net's CIM gateway and got some mass-assignment errors resulting from `gateway_payment_profile_id`. This fixes the issue.
