### PR TITLE
Fixed ProductFilters.brand_filter

### DIFF
--- a/core/lib/spree/product_filters.rb
+++ b/core/lib/spree/product_filters.rb
@@ -108,7 +108,7 @@ module Spree
       def ProductFilters.brand_filter
         brands = Spree::ProductProperty.where(:property_id => @@brand_property).map(&:value).compact.uniq
         pp = Spree::ProductProperty.arel_table
-        conds  = Hash[*brands.map {|b| [b, pp.value.eq(b)]}.flatten]
+        conds  = Hash[*brands.map {|b| [b, pp[:value].eq(b)]}.flatten]
         { :name   => "Brands",
           :scope  => :brand_any,
           :conds  => conds,


### PR DESCRIPTION
which was calling an undefined 'value' method on arel_table.

Now using [:value] to access the attribute.
