### PR TITLE
add empty order action to the rest api

### DIFF
--- a/api/app/controllers/spree/api/v1/orders_controller.rb
+++ b/api/app/controllers/spree/api/v1/orders_controller.rb
@@ -55,6 +55,12 @@ module Spree
           render :show
         end
 
+        def empty
+          authorize! :read, order
+          order.line_items.destroy_all
+          render :text => nil, :status => 200
+        end
+
         private
 
         def map_nested_attributes
@@ -72,6 +78,9 @@ module Spree
             render :could_not_transition, :status => 422
           end
         end
+
+
+
       end
     end
   end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -31,6 +31,7 @@ Spree::Core::Engine.routes.prepend do
           put :address
           put :delivery
           put :cancel
+          put :empty
         end
 
         resources :line_items


### PR DESCRIPTION
Rest API currently doesn't have a way to empty an order/cart. This patch adds an empty action in the OrderController and adds the corresponding route in routes.rb.
