### PR TITLE
implement re-ordering of option values in admin UI

### DIFF
--- a/core/app/controllers/spree/admin/option_types_controller.rb
+++ b/core/app/controllers/spree/admin/option_types_controller.rb
@@ -31,6 +31,17 @@ module Spree
         end
       end
 
+      def update_values_positions
+        params[:positions].each do |id, index|
+          OptionValue.where(:id => id).update_all(:position => index)
+        end
+
+        respond_to do |format|
+          format.html { redirect_to admin_product_variants_url(params[:product_id]) }
+          format.js  { render :text => 'Ok' }
+        end
+      end
+
       # AJAX method for selecting an existing option type and associating with the current product
       def select
         @product.option_types << OptionType.find(params[:id])

--- a/core/app/views/spree/admin/option_types/_option_value_fields.html.erb
+++ b/core/app/views/spree/admin/option_types/_option_value_fields.html.erb
@@ -1,5 +1,5 @@
 <tr class="option_value fields" id="spree_<%= dom_id(f.object) %>"  data-hook="option_value">
-  <td class="name"><%= f.text_field :name %></td>
+  <td class="name"><span class="handle"></span> </span><%= f.text_field :name %></td>
   <td class="presentation"><%= f.text_field :presentation %></td>
   <td class="actions"><%= link_to_remove_fields t(:remove), f %></td>
 </tr>

--- a/core/app/views/spree/admin/option_types/_option_value_fields.html.erb
+++ b/core/app/views/spree/admin/option_types/_option_value_fields.html.erb
@@ -1,5 +1,5 @@
 <tr class="option_value fields" id="spree_<%= dom_id(f.object) %>"  data-hook="option_value">
-  <td class="name"><span class="handle"></span> </span><%= f.text_field :name %></td>
+  <td class="name"><span class="handle"></span> <%= f.text_field :name %></td>
   <td class="presentation"><%= f.text_field :presentation %></td>
   <td class="actions"><%= link_to_remove_fields t(:remove), f %></td>
 </tr>

--- a/core/app/views/spree/admin/option_types/edit.html.erb
+++ b/core/app/views/spree/admin/option_types/edit.html.erb
@@ -6,7 +6,7 @@
   <legend><%= t(:editing_option_type) %></legend>
   <%= render :partial => 'form', :locals => { :f => f } %>
   <h3><%= t(:option_values) %></h3>
-  <table class="index">
+  <table class="index sortable" data-hook data-sortable-link="<%= update_values_positions_admin_option_types_url %>">
     <thead data-hook="option_header">
       <tr>
         <th><%= t(:name) %></th>

--- a/core/config/routes.rb
+++ b/core/config/routes.rb
@@ -104,6 +104,7 @@ Spree::Core::Engine.routes.draw do
     resources :option_types do
       collection do
         post :update_positions
+        post :update_values_positions
       end
     end
 


### PR DESCRIPTION
fixes #1700

this uses a new ajax method called `update_values_positions` on Admin/OptionTypesController. Technically this should be on a OptionValuesController, but since that doesn't exist (and it would have only the one method, everything else dealing with OptionValue is managed as nested attributes on OptionType), I didn't want to be so aggressive as to create a new controller and refactor. But, it's not maybe ideal.

RE testing, I made a stab but it seems testing sortable lists of this nature is a known problem. Even @jnicklas has given up on it, and if he can't do it my chances are slim https://groups.google.com/forum/?fromgroups#!topic/ruby-capybara/ZGLA1FAW30A

thirdly, this is against 1-1-stable because I'm unable to get master to run due to auth issues at the moment, so could not sanity check. But this should install cleanly on master at any rate. 
