### PR TITLE
Switch to CDN JS for html5shiv

### DIFF
--- a/core/app/views/spree/shared/_head.html.erb
+++ b/core/app/views/spree/shared/_head.html.erb
@@ -10,6 +10,6 @@
 <%= csrf_meta_tags %>
 <%= javascript_include_tag 'store/all' %>
 <!--[if lt IE 9]>
-  <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.6/html5shiv.min.js"></script>
 <![endif]-->
 <%= yield :head %>


### PR DESCRIPTION
Seems a bit more future proof compared to googlecode as html5shiv is on github.
