### PR TITLE
Spree_Auth_take_two related commits

### DIFF
--- a/api/db/migrate/20120411123334_resize_api_key_field.rb
+++ b/api/db/migrate/20120411123334_resize_api_key_field.rb
@@ -1,5 +1,7 @@
 class ResizeApiKeyField < ActiveRecord::Migration
   def change
-    change_column :spree_users, :api_key, :string, :limit => 48
+    unless defined?(User)    
+      change_column :spree_users, :api_key, :string, :limit => 48
+    end
   end
 end

--- a/core/lib/generators/spree/custom_user/custom_user_generator.rb
+++ b/core/lib/generators/spree/custom_user/custom_user_generator.rb
@@ -22,7 +22,7 @@ module Spree
     end
 
     def generate
-      migration_template 'migration.rb.tt', "db/migrate/add_spree_auth_fields_to_#{table_name}_table.rb"
+      migration_template 'migration.rb.tt', "db/migrate/add_spree_fields_to_custom_user_table.rb"
       template 'authentication_helpers.rb.tt', "lib/spree/authentication_helpers.rb"
 
       file_action = File.exist?('config/initializers/spree.rb') ? :append_file : :create_file


### PR DESCRIPTION
One API migration was missing the user check, the custom_user generator's migration file was not matching the name properly, reverted to previous.
