### PR TITLE
Seperate checkout process from Order

### DIFF
--- a/core/app/controllers/spree/checkout_controller.rb
+++ b/core/app/controllers/spree/checkout_controller.rb
@@ -94,7 +94,7 @@ module Spree
 
       def before_address
         @order.bill_address ||= Address.default
-        if @order.deliverable?
+        if @order.needs_delivery?
           @order.ship_address ||= Address.default
         end
       end

--- a/core/app/controllers/spree/checkout_controller.rb
+++ b/core/app/controllers/spree/checkout_controller.rb
@@ -94,7 +94,9 @@ module Spree
 
       def before_address
         @order.bill_address ||= Address.default
-        @order.ship_address ||= Address.default
+        if @order.deliverable?
+          @order.ship_address ||= Address.default
+        end
       end
 
       def before_delivery

--- a/core/app/controllers/spree/checkout_controller.rb
+++ b/core/app/controllers/spree/checkout_controller.rb
@@ -94,7 +94,7 @@ module Spree
 
       def before_address
         @order.bill_address ||= Address.default
-        if @order.needs_delivery?
+        if @order.delivery_required?
           @order.ship_address ||= Address.default
         end
       end

--- a/core/app/helpers/spree/checkout_helper.rb
+++ b/core/app/helpers/spree/checkout_helper.rb
@@ -1,15 +1,7 @@
 module Spree
   module CheckoutHelper
-    def checkout_states
-      if @order.payment and @order.payment.payment_method.payment_profiles_supported?
-        %w(address delivery payment confirm complete)
-      else
-        %w(address delivery payment complete)
-      end
-    end
-
     def checkout_progress
-      states = checkout_states
+      states = @order.steps
       items = states.map do |state|
         text = t("order_state.#{state}").titleize
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -2,6 +2,7 @@ require 'spree/core/validators/email'
 
 module Spree
   class Order < ActiveRecord::Base
+    require_dependency 'spree/order/state_machine'
     token_resource
 
     attr_accessible :line_items, :bill_address_attributes, :ship_address_attributes, :payments_attributes,
@@ -54,54 +55,6 @@ module Spree
     class_attribute :update_hooks
     self.update_hooks = Set.new
 
-    # order state machine (see http://github.com/pluginaweek/state_machine/tree/master for details)
-    state_machine :initial => 'cart', :use_transactions => false do
-
-      event :next do
-        transition :from => 'cart',     :to => 'address'
-        transition :from => 'address',  :to => 'delivery'
-        transition :from => 'delivery', :to => 'payment', :if => :payment_required?
-        transition :from => 'delivery', :to => 'complete'
-        transition :from => 'confirm',  :to => 'complete'
-
-        # note: some payment methods will not support a confirm step
-        transition :from => 'payment',  :to => 'confirm',
-                                        :if => Proc.new { |order| order.payment_method && order.payment_method.payment_profiles_supported? }
-
-        transition :from => 'payment', :to => 'complete'
-      end
-
-      event :cancel do
-        transition :to => 'canceled', :if => :allow_cancel?
-      end
-      event :return do
-        transition :to => 'returned', :from => 'awaiting_return'
-      end
-      event :resume do
-        transition :to => 'resumed', :from => 'canceled', :if => :allow_resume?
-      end
-      event :authorize_return do
-        transition :to => 'awaiting_return'
-      end
-
-      before_transition :to => 'complete' do |order|
-        begin
-          order.process_payments!
-        rescue Core::GatewayError
-          !!Spree::Config[:allow_checkout_on_gateway_error]
-        end
-      end
-
-      before_transition :to => 'delivery', :do => :remove_invalid_shipments!
-
-      after_transition :to => 'complete', :do => :finalize!
-      after_transition :to => 'delivery', :do => :create_tax_charge!
-      after_transition :to => 'payment',  :do => :create_shipment!
-      after_transition :to => 'resumed',  :do => :after_resume
-      after_transition :to => 'canceled', :do => :after_cancel
-
-    end
-
     def self.by_number(number)
       where(:number => number)
     end
@@ -149,6 +102,10 @@ module Spree
     # in your own application if you require additional steps before allowing a checkout.
     def checkout_allowed?
       line_items.count > 0
+    end
+
+    def deliverable?
+      true
     end
 
     # Is this a free order in which case the payment step should be skipped
@@ -384,7 +341,11 @@ module Spree
     end
 
     def process_payments!
-      ret = payments.each(&:process!)
+      begin
+        ret = payments.each(&:process!)
+      rescue Core::GatewayError
+        !!Spree::Config[:allow_checkout_on_gateway_error]
+      end
     end
 
     # Finalizes an in progress order after checkout is complete.

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -164,7 +164,7 @@ module Spree
       update_payment_state
 
       # give each of the shipments a chance to update themselves
-      if needs_delivery?
+      if delivery_required?
         shipments.each { |shipment| shipment.update!(self) }#(&:update!)
         update_shipment_state
       end
@@ -180,7 +180,7 @@ module Spree
         :total => total
       }
 
-      if needs_delivery?
+      if delivery_required?
         new_attributes.merge!(:shipment_state => shipment_state)
       end
 
@@ -535,7 +535,7 @@ module Spree
       end
 
       def has_available_shipment
-        return unless needs_delivery?
+        return unless delivery_required?
         return unless :address == state_name.to_sym
         return unless ship_address && ship_address.valid?
         errors.add(:base, :no_shipping_methods_available) if available_shipping_methods.empty?

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -46,7 +46,7 @@ module Spree
     after_create :create_tax_charge!
 
     # TODO: validate the format of the email as well (but we can't rely on authlogic anymore to help with validation)
-    validates :email, :presence => true, :email => true, :if => :require_email
+    validates :email, :presence => true, :email => true, :if => :require_email?
     validate :has_available_shipment, :unless => :delivery_required?
     validate :has_available_payment, :unless => :payment_required?
 
@@ -531,7 +531,7 @@ module Spree
       end
 
       # Determine if email is required (we don't want validation errors before we hit the checkout)
-      def require_email
+      def require_email?
         return true unless new_record? or state == 'cart'
       end
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -104,6 +104,9 @@ module Spree
       line_items.count > 0
     end
 
+    # This method should be overriden to be false if some of your orders have items
+    # that are "undeliverable", i.e. there is no shipping address. This is for things
+    # such as online-only goods, and the like.
     def deliverable?
       true
     end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -104,13 +104,6 @@ module Spree
       line_items.count > 0
     end
 
-    # This method should be overriden to be false if some of your orders have items
-    # that are "undeliverable", i.e. there is no shipping address. This is for things
-    # such as online-only goods, and the like.
-    def deliverable?
-      true
-    end
-
     # Is this a free order in which case the payment step should be skipped
     def payment_required?
       total.to_f > 0.0
@@ -176,7 +169,7 @@ module Spree
       update_payment_state
 
       # give each of the shipments a chance to update themselves
-      if deliverable?
+      if needs_delivery?
         shipments.each { |shipment| shipment.update!(self) }#(&:update!)
         update_shipment_state
       end
@@ -192,7 +185,7 @@ module Spree
         :total => total
       }
 
-      if deliverable?
+      if needs_delivery?
         new_attributes.merge!(:shipment_state => shipment_state)
       end
 
@@ -547,7 +540,7 @@ module Spree
       end
 
       def has_available_shipment
-        return unless deliverable?
+        return unless needs_delivery?
         return unless :address == state_name.to_sym
         return unless ship_address && ship_address.valid?
         errors.add(:base, :no_shipping_methods_available) if available_shipping_methods.empty?

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -339,14 +339,6 @@ module Spree
       CreditCard.scoped(:conditions => { :id => credit_card_ids })
     end
 
-    def process_payments!
-      begin
-        ret = payments.each(&:process!)
-      rescue Core::GatewayError
-        !!Spree::Config[:allow_checkout_on_gateway_error]
-      end
-    end
-
     # Finalizes an in progress order after checkout is complete.
     # Called after transition to complete state when payments will have been processed
     def finalize!

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -104,11 +104,6 @@ module Spree
       line_items.count > 0
     end
 
-    # Is this a free order in which case the payment step should be skipped
-    def payment_required?
-      total.to_f > 0.0
-    end
-
     # Indicates the number of items in the order
     def item_count
       line_items.sum(:quantity)

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -46,7 +46,7 @@ module Spree
     after_create :create_tax_charge!
 
     # TODO: validate the format of the email as well (but we can't rely on authlogic anymore to help with validation)
-    validates :email, :presence => true, :email => true, :if => :require_email?
+    validates :email, :presence => true, :email => true, :if => :email_required?
     validate :has_available_shipment, :unless => :delivery_required?
     validate :has_available_payment, :unless => :payment_required?
 
@@ -531,7 +531,7 @@ module Spree
       end
 
       # Determine if email is required (we don't want validation errors before we hit the checkout)
-      def require_email?
+      def email_required?
         return true unless new_record? or state == 'cart'
       end
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -433,6 +433,11 @@ module Spree
       order.destroy
     end
 
+    # Determine if email is required (we don't want validation errors before we hit the checkout)
+    def email_required?
+      return true unless new_record? or state == 'cart'
+    end
+
     private
       def link_by_email
         self.email = user.email if self.user and not user.anonymous?
@@ -528,11 +533,6 @@ module Spree
       # towards adjustment_total.
       def update_adjustments
         self.adjustments.reload.each { |adjustment| adjustment.update!(self) }
-      end
-
-      # Determine if email is required (we don't want validation errors before we hit the checkout)
-      def email_required?
-        return true unless new_record? or state == 'cart'
       end
 
       def has_available_shipment

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -47,8 +47,8 @@ module Spree
 
     # TODO: validate the format of the email as well (but we can't rely on authlogic anymore to help with validation)
     validates :email, :presence => true, :email => true, :if => :email_required?
-    validate :has_available_shipment, :unless => :delivery_required?
-    validate :has_available_payment, :unless => :payment_required?
+    validate :has_available_shipment
+    validate :has_available_payment
 
     make_permalink :field => :number
 
@@ -536,12 +536,14 @@ module Spree
       end
 
       def has_available_shipment
+        return true unless delivery_required?
         return unless :address == state_name.to_sym
         return unless ship_address && ship_address.valid?
         errors.add(:base, :no_shipping_methods_available) if available_shipping_methods.empty?
       end
 
       def has_available_payment
+        return true unless payment_required?
         return unless :delivery == state_name.to_sym
         errors.add(:base, :no_payment_methods_available) if available_payment_methods.empty?
       end

--- a/core/app/models/spree/order/state_machine.rb
+++ b/core/app/models/spree/order/state_machine.rb
@@ -1,30 +1,40 @@
 Spree::Order.class_eval do
   # order state machine (see http://github.com/pluginaweek/state_machine/tree/master for details)
   state_machine :initial => 'cart', :use_transactions => false do
-
     event :next do
-      transition :from => 'cart',     :to => 'address'
-      transition :from => 'address',  :to => 'delivery'
+      transition :from => 'cart',     :to => 'address', :if => :address_required?
+      transition :from => 'cart',     :to => 'delivery', :if => :delivery_required?
+      transition :from => 'cart',     :to => 'payment', :if => :payment_required?
+      transition :from => 'cart',     :to => 'confirm', :if => :confirmation_required?
+      transition :from => 'cart',     :to => 'complete'
+
+      transition :from => 'address',  :to => 'delivery', :if => :delivery_required?
+      transition :from => 'address',  :to => 'payment', :if => :payment_required?
+      transition :from => 'address',  :to => 'confirm', :if => :confirmation_required?
+      transition :from => 'address',  :to => 'complete'
+
       transition :from => 'delivery', :to => 'payment', :if => :payment_required?
+      transition :from => 'delivery', :to => 'confirm', :if => :confirmation_required?
       transition :from => 'delivery', :to => 'complete'
-      transition :from => 'confirm',  :to => 'complete'
 
-      # note: some payment methods will not support a confirm step
-      transition :from => 'payment',  :to => 'confirm',
-        :if => Proc.new { |order| order.payment_method && order.payment_method.payment_profiles_supported? }
+      transition :from => 'payment',  :to => 'confirm', :if => :confirmation_required?
+      transition :from => 'payment',  :to => 'complete'
 
-      transition :from => 'payment', :to => 'complete'
+      transition :from => 'confirm', :to => 'complete'
     end
 
     event :cancel do
       transition :to => 'canceled', :if => :allow_cancel?
     end
+
     event :return do
       transition :to => 'returned', :from => 'awaiting_return'
     end
+
     event :resume do
       transition :to => 'resumed', :from => 'canceled', :if => :allow_resume?
     end
+
     event :authorize_return do
       transition :to => 'awaiting_return'
     end
@@ -45,35 +55,35 @@ Spree::Order.class_eval do
 
   def steps
     steps = []
-    steps << "address" if needs_address?
-    steps << "delivery" if needs_delivery?
-    steps << "payment" if needs_payment?
-    steps << "confirm" if needs_confirmation?
+    steps << "address" if address_required?
+    steps << "delivery" if delivery_required?
+    steps << "payment" if payment_required?
+    steps << "confirm" if confirmation_required?
     steps << "complete"
     steps
   end
 
   # Override this method if some of your orders do not
   # need either a billing or a shipping address.
-  def needs_address?
+  def address_required?
     true
   end
 
   # This method should be overriden to be false if some of your orders have items
   # that are all "undeliverable", i.e. there is no need for a shipping address
   # This is for things such as online-only goods, and the like.
-  def needs_delivery?
+  def delivery_required?
     true
   end
 
   # Override this method if your orders do not need to be paid for.
-  def needs_payment?
-    true
+  def payment_required?
+    total.to_f > 0.0
   end
 
   # Override this method if you do not wish for orders to be confirmed
   # before order is completed.
-  def needs_confirmation?
-    true
+  def confirmation_required?
+    order.payment_method && order.payment_method.payment_profiles_supported?
   end
 end

--- a/core/app/models/spree/order/state_machine.rb
+++ b/core/app/models/spree/order/state_machine.rb
@@ -43,10 +43,37 @@ Spree::Order.class_eval do
 
   end
 
+  def steps
+    steps = []
+    steps << "address" if needs_address?
+    steps << "delivery" if needs_delivery?
+    steps << "payment" if needs_payment?
+    steps << "confirm" if needs_confirmation?
+    steps << "complete"
+    steps
+  end
+
+  # Override this method if some of your orders do not
+  # need either a billing or a shipping address.
+  def needs_address?
+    true
+  end
+
   # This method should be overriden to be false if some of your orders have items
   # that are all "undeliverable", i.e. there is no need for a shipping address
   # This is for things such as online-only goods, and the like.
   def needs_delivery?
+    true
+  end
+
+  # Override this method if your orders do not need to be paid for.
+  def needs_payment?
+    true
+  end
+
+  # Override this method if you do not wish for orders to be confirmed
+  # before order is completed.
+  def needs_confirmation?
     true
   end
 end

--- a/core/app/models/spree/order/state_machine.rb
+++ b/core/app/models/spree/order/state_machine.rb
@@ -39,13 +39,7 @@ Spree::Order.class_eval do
       transition :to => 'awaiting_return'
     end
 
-    before_transition :to => 'complete' do |order|
-      begin
-        order.payments.each(&:process)
-      rescue Spree::Core::GatewayError
-        !!Spree::Config[:allow_checkout_on_gateway_error]
-      end
-    end
+    before_transition :to => 'complete', :do => :before_complete
 
     before_transition :to => 'delivery', :do => :remove_invalid_shipments!
 
@@ -55,6 +49,14 @@ Spree::Order.class_eval do
     after_transition :to => 'resumed',  :do => :after_resume
     after_transition :to => 'canceled', :do => :after_cancel
 
+  end
+
+  def before_complete
+    begin
+      payments.each(&:process)
+    rescue Spree::Core::GatewayError
+      !!Spree::Config[:allow_checkout_on_gateway_error]
+    end
   end
 
   def steps

--- a/core/app/models/spree/order/state_machine.rb
+++ b/core/app/models/spree/order/state_machine.rb
@@ -30,11 +30,7 @@ Spree::Order.class_eval do
     end
 
     before_transition :to => 'complete' do |order|
-      begin
-        order.process_payments!
-      rescue Spree::Core::GatewayError
-        !!Spree::Config[:allow_checkout_on_gateway_error]
-      end
+      order.process_payments!
     end
 
     before_transition :to => 'delivery', :do => :remove_invalid_shipments!

--- a/core/app/models/spree/order/state_machine.rb
+++ b/core/app/models/spree/order/state_machine.rb
@@ -1,0 +1,49 @@
+Spree::Order.class_eval do
+  # order state machine (see http://github.com/pluginaweek/state_machine/tree/master for details)
+  state_machine :initial => 'cart', :use_transactions => false do
+
+    event :next do
+      transition :from => 'cart',     :to => 'address'
+      transition :from => 'address',  :to => 'delivery'
+      transition :from => 'delivery', :to => 'payment', :if => :payment_required?
+      transition :from => 'delivery', :to => 'complete'
+      transition :from => 'confirm',  :to => 'complete'
+
+      # note: some payment methods will not support a confirm step
+      transition :from => 'payment',  :to => 'confirm',
+        :if => Proc.new { |order| order.payment_method && order.payment_method.payment_profiles_supported? }
+
+      transition :from => 'payment', :to => 'complete'
+    end
+
+    event :cancel do
+      transition :to => 'canceled', :if => :allow_cancel?
+    end
+    event :return do
+      transition :to => 'returned', :from => 'awaiting_return'
+    end
+    event :resume do
+      transition :to => 'resumed', :from => 'canceled', :if => :allow_resume?
+    end
+    event :authorize_return do
+      transition :to => 'awaiting_return'
+    end
+
+    before_transition :to => 'complete' do |order|
+      begin
+        order.process_payments!
+      rescue Core::GatewayError
+        !!Spree::Config[:allow_checkout_on_gateway_error]
+      end
+    end
+
+    before_transition :to => 'delivery', :do => :remove_invalid_shipments!
+
+    after_transition :to => 'complete', :do => :finalize!
+    after_transition :to => 'delivery', :do => :create_tax_charge!
+    after_transition :to => 'payment',  :do => :create_shipment!
+    after_transition :to => 'resumed',  :do => :after_resume
+    after_transition :to => 'canceled', :do => :after_cancel
+
+  end
+end

--- a/core/app/models/spree/order/state_machine.rb
+++ b/core/app/models/spree/order/state_machine.rb
@@ -79,7 +79,7 @@ Spree::Order.class_eval do
   # that are all "undeliverable", i.e. there is no need for a shipping address
   # This is for things such as online-only goods, and the like.
   def delivery_required?
-    true
+    address_required? && true
   end
 
   # Override this method if your orders do not need to be paid for.

--- a/core/app/models/spree/order/state_machine.rb
+++ b/core/app/models/spree/order/state_machine.rb
@@ -42,4 +42,11 @@ Spree::Order.class_eval do
     after_transition :to => 'canceled', :do => :after_cancel
 
   end
+
+  # This method should be overriden to be false if some of your orders have items
+  # that are all "undeliverable", i.e. there is no need for a shipping address
+  # This is for things such as online-only goods, and the like.
+  def needs_delivery?
+    true
+  end
 end

--- a/core/app/models/spree/order/state_machine.rb
+++ b/core/app/models/spree/order/state_machine.rb
@@ -84,6 +84,6 @@ Spree::Order.class_eval do
   # Override this method if you do not wish for orders to be confirmed
   # before order is completed.
   def confirmation_required?
-    order.payment_method && order.payment_method.payment_profiles_supported?
+    payment_method && payment_method.payment_profiles_supported?
   end
 end

--- a/core/app/models/spree/order/state_machine.rb
+++ b/core/app/models/spree/order/state_machine.rb
@@ -40,7 +40,11 @@ Spree::Order.class_eval do
     end
 
     before_transition :to => 'complete' do |order|
-      order.process_payments!
+      begin
+        order.payments.each(&:process)
+      rescue Spree::Core::GatewayError
+        !!Spree::Config[:allow_checkout_on_gateway_error]
+      end
     end
 
     before_transition :to => 'delivery', :do => :remove_invalid_shipments!

--- a/core/app/models/spree/order/state_machine.rb
+++ b/core/app/models/spree/order/state_machine.rb
@@ -32,7 +32,7 @@ Spree::Order.class_eval do
     before_transition :to => 'complete' do |order|
       begin
         order.process_payments!
-      rescue Core::GatewayError
+      rescue Spree::Core::GatewayError
         !!Spree::Config[:allow_checkout_on_gateway_error]
       end
     end

--- a/core/app/models/spree/order/state_machine.rb
+++ b/core/app/models/spree/order/state_machine.rb
@@ -53,7 +53,7 @@ Spree::Order.class_eval do
 
   def before_complete
     begin
-      payments.each(&:process)
+      payments.each(&:process!)
     rescue Spree::Core::GatewayError
       !!Spree::Config[:allow_checkout_on_gateway_error]
     end

--- a/core/app/views/spree/checkout/_address.html.erb
+++ b/core/app/views/spree/checkout/_address.html.erb
@@ -86,7 +86,7 @@
   <% end %>
 </fieldset>
 </div>
-<% if @order.deliverable? %>
+<% if @order.needs_delivery? %>
   <div class="columns omega six" data-hook="shipping_fieldset_wrapper">
   <fieldset id="shipping" data-hook>
     <%= form.fields_for :ship_address do |ship_form| %>

--- a/core/app/views/spree/checkout/_address.html.erb
+++ b/core/app/views/spree/checkout/_address.html.erb
@@ -86,7 +86,7 @@
   <% end %>
 </fieldset>
 </div>
-<% if @order.needs_delivery? %>
+<% if @order.delivery_required? %>
   <div class="columns omega six" data-hook="shipping_fieldset_wrapper">
   <fieldset id="shipping" data-hook>
     <%= form.fields_for :ship_address do |ship_form| %>

--- a/core/app/views/spree/checkout/_address.html.erb
+++ b/core/app/views/spree/checkout/_address.html.erb
@@ -1,5 +1,5 @@
 <div class="columns alpha six" data-hook="billing_fieldset_wrapper">
-<% unless @order.email? %>
+<% if @order.require_email? && @order.email.blank? %>
   <p class="field" style='clear: both'>
     <%= form.label :email %><br />
     <%= form.text_field :email %>

--- a/core/app/views/spree/checkout/_address.html.erb
+++ b/core/app/views/spree/checkout/_address.html.erb
@@ -1,5 +1,5 @@
 <div class="columns alpha six" data-hook="billing_fieldset_wrapper">
-<% if @order.require_email? && @order.email.blank? %>
+<% if @order.email_required? && @order.email.blank? %>
   <p class="field" style='clear: both'>
     <%= form.label :email %><br />
     <%= form.text_field :email %>

--- a/core/app/views/spree/checkout/_address.html.erb
+++ b/core/app/views/spree/checkout/_address.html.erb
@@ -86,93 +86,94 @@
   <% end %>
 </fieldset>
 </div>
-
-<div class="columns omega six" data-hook="shipping_fieldset_wrapper">
-<fieldset id="shipping" data-hook>
-  <%= form.fields_for :ship_address do |ship_form| %>
-    <legend><%= t(:shipping_address) %></legend>
-    <p class="field checkbox" data-hook="use_billing">
-      <%= check_box_tag 'order[use_billing]', '1', (!(@order.bill_address.empty? && @order.ship_address.empty?) && @order.bill_address.same_as?(@order.ship_address)) %> 
-      <%= label_tag :order_use_billing, t(:use_billing_address), :id => 'use_billing' %>
-    </p>
-    <div class="inner" data-hook="shipping_inner">
-      <p class="field" id="sfirstname">
-        <%= ship_form.label :firstname, t(:first_name) %><span class="required">*</span><br />
-        <%= ship_form.text_field :firstname, :class => 'required' %>
+<% if @order.deliverable? %>
+  <div class="columns omega six" data-hook="shipping_fieldset_wrapper">
+  <fieldset id="shipping" data-hook>
+    <%= form.fields_for :ship_address do |ship_form| %>
+      <legend><%= t(:shipping_address) %></legend>
+      <p class="field checkbox" data-hook="use_billing">
+        <%= check_box_tag 'order[use_billing]', '1', (!(@order.bill_address.empty? && @order.ship_address.empty?) && @order.bill_address.same_as?(@order.ship_address)) %> 
+        <%= label_tag :order_use_billing, t(:use_billing_address), :id => 'use_billing' %>
       </p>
-      <p class="field" id="slastname">
-        <%= ship_form.label :lastname, t(:last_name) %><span class="required">*</span><br />
-        <%= ship_form.text_field :lastname, :class => 'required' %>
-      </p>
-      <% if Spree::Config[:company] %>
-        <p class="field" id="scompany">
-          <%= ship_form.label :company, t(:company) %><br />
-          <%= ship_form.text_field :company %>
+      <div class="inner" data-hook="shipping_inner">
+        <p class="field" id="sfirstname">
+          <%= ship_form.label :firstname, t(:first_name) %><span class="required">*</span><br />
+          <%= ship_form.text_field :firstname, :class => 'required' %>
         </p>
-      <% end %>
-      <p class="field" id="saddress1">
-        <%= ship_form.label :address1, t(:street_address) %><span class="required">*</span><br />
-        <%= ship_form.text_field :address1, :class => 'required' %>
-      </p>
-      <p class="field" id="saddress2">
-        <%= ship_form.label :address2, t(:street_address_2) %><br />
-        <%= ship_form.text_field :address2 %>
-      </p>
-
-      <p class="field" id="scity">
-        <%= ship_form.label :city, t(:city) %><span class="required">*</span><br />
-        <%= ship_form.text_field :city, :class => 'required' %>
-      </p>
-
-      <p class="field" id="scountry">
-        <%= ship_form.label :country_id, t(:country) %><span class="required">*</span><br />
-        <span id="scountry">
-          <%= ship_form.collection_select :country_id, available_countries, :id, :name, {}, {:class => 'required'} %>
-        </span>
-      </p>
-
-      <% if Spree::Config[:address_requires_state] %>
-        <p class="field" id="sstate">
-          <% have_states = !@order.ship_address.country.states.empty? %>
-          <%= ship_form.label :state, t(:state) %><span class="required">*</span><br />
-          <noscript>
-            <%= ship_form.text_field :state_name, :class => 'required' %>
-          </noscript>
-          <% state_elements = [
-             ship_form.collection_select(:state_id, @order.ship_address.country.states,
-                                :id, :name,
-                                {:include_blank => true},
-                                {:class => have_states ? 'required' : 'hidden',
-                                :disabled => !have_states}) +
-             ship_form.text_field(:state_name,
-                                :class => !have_states ? 'required' : 'hidden',
-                                :disabled => have_states)
-             ].join.gsub('"', "'").gsub("\n", "")
-          %>
-          <%= javascript_tag do -%>
-            document.write("<%== state_elements %>");
-          <% end %>
+        <p class="field" id="slastname">
+          <%= ship_form.label :lastname, t(:last_name) %><span class="required">*</span><br />
+          <%= ship_form.text_field :lastname, :class => 'required' %>
         </p>
-      <% end %>
-
-      <p class="field" id="szipcode">
-        <%= ship_form.label :zipcode, t(:zip) %><span class="required">*</span><br />
-        <%= ship_form.text_field :zipcode, :class => 'required' %>
-      </p>
-      <p class="field" id="sphone">
-        <%= ship_form.label :phone, t(:phone) %><span class="required">*</span><br />
-        <%= ship_form.phone_field :phone, :class => 'required' %>
-      </p>
-      <% if Spree::Config[:alternative_shipping_phone] %>
-        <p class="field" id="saltphone">
-          <%= ship_form.label :alternative_phone, t(:alternative_phone) %><br />
-          <%= ship_form.phone_field :alternative_phone %>
+        <% if Spree::Config[:company] %>
+          <p class="field" id="scompany">
+            <%= ship_form.label :company, t(:company) %><br />
+            <%= ship_form.text_field :company %>
+          </p>
+        <% end %>
+        <p class="field" id="saddress1">
+          <%= ship_form.label :address1, t(:street_address) %><span class="required">*</span><br />
+          <%= ship_form.text_field :address1, :class => 'required' %>
         </p>
-      <% end %>
-    </div>
-  <% end %>
-</fieldset>
-</div>
+        <p class="field" id="saddress2">
+          <%= ship_form.label :address2, t(:street_address_2) %><br />
+          <%= ship_form.text_field :address2 %>
+        </p>
+
+        <p class="field" id="scity">
+          <%= ship_form.label :city, t(:city) %><span class="required">*</span><br />
+          <%= ship_form.text_field :city, :class => 'required' %>
+        </p>
+
+        <p class="field" id="scountry">
+          <%= ship_form.label :country_id, t(:country) %><span class="required">*</span><br />
+          <span id="scountry">
+            <%= ship_form.collection_select :country_id, available_countries, :id, :name, {}, {:class => 'required'} %>
+          </span>
+        </p>
+
+        <% if Spree::Config[:address_requires_state] %>
+          <p class="field" id="sstate">
+            <% have_states = !@order.ship_address.country.states.empty? %>
+            <%= ship_form.label :state, t(:state) %><span class="required">*</span><br />
+            <noscript>
+              <%= ship_form.text_field :state_name, :class => 'required' %>
+            </noscript>
+            <% state_elements = [
+               ship_form.collection_select(:state_id, @order.ship_address.country.states,
+                                  :id, :name,
+                                  {:include_blank => true},
+                                  {:class => have_states ? 'required' : 'hidden',
+                                  :disabled => !have_states}) +
+               ship_form.text_field(:state_name,
+                                  :class => !have_states ? 'required' : 'hidden',
+                                  :disabled => have_states)
+               ].join.gsub('"', "'").gsub("\n", "")
+            %>
+            <%= javascript_tag do -%>
+              document.write("<%== state_elements %>");
+            <% end %>
+          </p>
+        <% end %>
+
+        <p class="field" id="szipcode">
+          <%= ship_form.label :zipcode, t(:zip) %><span class="required">*</span><br />
+          <%= ship_form.text_field :zipcode, :class => 'required' %>
+        </p>
+        <p class="field" id="sphone">
+          <%= ship_form.label :phone, t(:phone) %><span class="required">*</span><br />
+          <%= ship_form.phone_field :phone, :class => 'required' %>
+        </p>
+        <% if Spree::Config[:alternative_shipping_phone] %>
+          <p class="field" id="saltphone">
+            <%= ship_form.label :alternative_phone, t(:alternative_phone) %><br />
+            <%= ship_form.phone_field :alternative_phone %>
+          </p>
+        <% end %>
+      </div>
+    <% end %>
+  </fieldset>
+  </div>
+<% end %>
 <hr class="clear" />
 <div class="form-buttons" data-hook="buttons">
   <%= submit_tag t(:save_and_continue), :class => 'continue button primary' %>

--- a/core/app/views/spree/shared/_order_details.html.erb
+++ b/core/app/views/spree/shared/_order_details.html.erb
@@ -1,19 +1,21 @@
 <div class="row steps-data">
-  <% if order.needs_delivery? %>
+  <% if order.needs_address? %>
+    <% if order.needs_delivery? %>
+      <div class="columns alpha four">
+        <h6><%= t(:shipping_address) %> <%= link_to "(#{t(:edit)})", checkout_state_path(:address) unless @order.completed? %></h6>
+        <div class="address">
+          <%= order.ship_address %>
+        </div>
+      </div>
+    <% end %>
+
     <div class="columns alpha four">
-      <h6><%= t(:shipping_address) %> <%= link_to "(#{t(:edit)})", checkout_state_path(:address) unless @order.completed? %></h6>
+      <h6><%= t(:billing_address) %> <%= link_to "(#{t(:edit)})", checkout_state_path(:address) unless @order.completed? %></h6>
       <div class="address">
-        <%= order.ship_address %>
+        <%= order.bill_address %>
       </div>
     </div>
   <% end %>
-
-  <div class="columns alpha four">
-    <h6><%= t(:billing_address) %> <%= link_to "(#{t(:edit)})", checkout_state_path(:address) unless @order.completed? %></h6>
-    <div class="address">
-      <%= order.bill_address %>
-    </div>
-  </div>
 
   <% if order.needs_delivery? %>
     <div class="columns alpha four">
@@ -24,22 +26,24 @@
     </div>
   <% end %>
 
-  <div class="columns omega four">
-    <h6><%= t(:payment_information) %> <%= link_to "(#{t(:edit)})", checkout_state_path(:payment) unless @order.completed? %></h6>
-    <div class="payment-info">
-      <% unless order.credit_cards.empty? %>
-        <span class="cc-type">
-          <%= image_tag "credit_cards/icons/#{order.credit_cards.first.cc_type}.png" %>
-          <%= t(:ending_in)%> <%= order.credit_cards.first.last_digits %>
-        </span>
-        <br />
-        <span class="full-name">
-          <%= order.credit_cards.first.first_name %>
-          <%= order.credit_cards.first.last_name %>
-        </span>
-      <% end %>
+  <% if order.needs_payment? %>
+    <div class="columns omega four">
+      <h6><%= t(:payment_information) %> <%= link_to "(#{t(:edit)})", checkout_state_path(:payment) unless @order.completed? %></h6>
+      <div class="payment-info">
+        <% unless order.credit_cards.empty? %>
+          <span class="cc-type">
+            <%= image_tag "credit_cards/icons/#{order.credit_cards.first.cc_type}.png" %>
+            <%= t(:ending_in)%> <%= order.credit_cards.first.last_digits %>
+          </span>
+          <br />
+          <span class="full-name">
+            <%= order.credit_cards.first.first_name %>
+            <%= order.credit_cards.first.last_name %>
+          </span>
+        <% end %>
+      </div>
     </div>
-  </div>
+  <% end %>
 
 </div>
 

--- a/core/app/views/spree/shared/_order_details.html.erb
+++ b/core/app/views/spree/shared/_order_details.html.erb
@@ -1,6 +1,6 @@
 <div class="row steps-data">
-  <% if order.needs_address? %>
-    <% if order.needs_delivery? %>
+  <% if order.delivery_required? %>
+    <% if order.delivery_required? %>
       <div class="columns alpha four">
         <h6><%= t(:shipping_address) %> <%= link_to "(#{t(:edit)})", checkout_state_path(:address) unless @order.completed? %></h6>
         <div class="address">
@@ -17,7 +17,7 @@
     </div>
   <% end %>
 
-  <% if order.needs_delivery? %>
+  <% if order.delivery_required? %>
     <div class="columns alpha four">
       <h6><%= t(:shipping_method) %> <%= link_to "(#{t(:edit)})", checkout_state_path(:delivery) unless @order.completed? %></h6>
       <div class="delivery">
@@ -26,7 +26,7 @@
     </div>
   <% end %>
 
-  <% if order.needs_payment? %>
+  <% if order.payment_required? %>
     <div class="columns omega four">
       <h6><%= t(:payment_information) %> <%= link_to "(#{t(:edit)})", checkout_state_path(:payment) unless @order.completed? %></h6>
       <div class="payment-info">

--- a/core/app/views/spree/shared/_order_details.html.erb
+++ b/core/app/views/spree/shared/_order_details.html.erb
@@ -1,5 +1,5 @@
 <div class="row steps-data">
-  <% if order.deliverable? %>
+  <% if order.needs_delivery? %>
     <div class="columns alpha four">
       <h6><%= t(:shipping_address) %> <%= link_to "(#{t(:edit)})", checkout_state_path(:address) unless @order.completed? %></h6>
       <div class="address">
@@ -15,7 +15,7 @@
     </div>
   </div>
 
-  <% if order.deliverable? %>
+  <% if order.needs_delivery? %>
     <div class="columns alpha four">
       <h6><%= t(:shipping_method) %> <%= link_to "(#{t(:edit)})", checkout_state_path(:delivery) unless @order.completed? %></h6>
       <div class="delivery">

--- a/core/app/views/spree/shared/_order_details.html.erb
+++ b/core/app/views/spree/shared/_order_details.html.erb
@@ -1,11 +1,12 @@
 <div class="row steps-data">
-  
-  <div class="columns alpha four">
-    <h6><%= t(:shipping_address) %> <%= link_to "(#{t(:edit)})", checkout_state_path(:address) unless @order.completed? %></h6>
-    <div class="address">
-      <%= order.ship_address %>
+  <% if order.deliverable? %>
+    <div class="columns alpha four">
+      <h6><%= t(:shipping_address) %> <%= link_to "(#{t(:edit)})", checkout_state_path(:address) unless @order.completed? %></h6>
+      <div class="address">
+        <%= order.ship_address %>
+      </div>
     </div>
-  </div>
+  <% end %>
 
   <div class="columns alpha four">
     <h6><%= t(:billing_address) %> <%= link_to "(#{t(:edit)})", checkout_state_path(:address) unless @order.completed? %></h6>
@@ -14,12 +15,14 @@
     </div>
   </div>
 
-  <div class="columns alpha four">
-    <h6><%= t(:shipping_method) %> <%= link_to "(#{t(:edit)})", checkout_state_path(:delivery) unless @order.completed? %></h6>
-    <div class="delivery">
-      <%= order.shipping_method.name %>
+  <% if order.deliverable? %>
+    <div class="columns alpha four">
+      <h6><%= t(:shipping_method) %> <%= link_to "(#{t(:edit)})", checkout_state_path(:delivery) unless @order.completed? %></h6>
+      <div class="delivery">
+        <%= order.shipping_method.name %>
+      </div>
     </div>
-  </div>
+  <% end %>
 
   <div class="columns omega four">
     <h6><%= t(:payment_information) %> <%= link_to "(#{t(:edit)})", checkout_state_path(:payment) unless @order.completed? %></h6>

--- a/core/app/views/spree/shared/_order_details.html.erb
+++ b/core/app/views/spree/shared/_order_details.html.erb
@@ -1,5 +1,5 @@
 <div class="row steps-data">
-  <% if order.delivery_required? %>
+  <% if order.address_required? %>
     <% if order.delivery_required? %>
       <div class="columns alpha four">
         <h6><%= t(:shipping_address) %> <%= link_to "(#{t(:edit)})", checkout_state_path(:address) unless @order.completed? %></h6>

--- a/core/lib/generators/spree/state_machine/state_machine_generator.rb
+++ b/core/lib/generators/spree/state_machine/state_machine_generator.rb
@@ -1,0 +1,22 @@
+module Spree
+  class StateMachineGenerator < Rails::Generators::Base
+    def self.source_paths
+      paths = self.superclass.source_paths
+      paths << Spree::Core::Engine.paths["app/models"].expanded[0]
+      paths.flatten
+    end
+
+    def copy
+      destination = "app/models/spree/order/state_machine.rb"
+      copy_file "spree/order/state_machine.rb", destination
+      inject_into_file destination, :before => "Spree::Order.class_eval do\n" do
+%Q{
+# This file overrides the default state machine for Spree's Order model.
+# For information about customizing the checkout process, please read
+# the Checkout guide: http://guides.spreecommerce.com/checkout.html
+}.gsub(/^\n/, '')
+      end
+    end
+  end
+end
+

--- a/core/spec/models/order/state_machine_spec.rb
+++ b/core/spec/models/order/state_machine_spec.rb
@@ -1,0 +1,167 @@
+require 'spec_helper'
+
+describe Spree::Order do
+  let(:order) { stub_model(Spree::Order) }
+  def disable(*steps)
+    steps.each do |step|
+      order.stub("#{step}_required?" => false)
+    end
+  end
+
+  def enable(*steps)
+    steps.each do |step|
+      order.stub("#{step}_required?" => true)
+    end
+  end
+
+  def should_transition_to(step)
+    order.next!
+    order.state.should == step.to_s
+  end
+
+  context "state transitions" do
+    before do
+      order.stub(:email_required? => false)
+    end
+
+    context "from cart" do
+      before do
+        order.state = 'cart'
+      end
+
+      it 'transitions to address' do
+        should_transition_to(:address)
+      end
+
+      it "transitions to delivery if address not required" do
+        disable(:address)
+        should_transition_to(:delivery)
+      end
+
+      it "transitions to payment if address and delivery not required, but payment is" do
+        disable(:address, :delivery)
+        enable(:payment)
+        should_transition_to(:payment)
+      end
+
+      it "transitions to confirm if address, delivery and payment not required, but confirmation is" do
+        disable(:address, :delivery, :payment)
+        enable(:confirmation)
+        should_transition_to(:confirm)
+      end
+
+      it "transitions to complete if address, delivery, payment and confirmation not required" do
+        disable(:address, :delivery, :payment, :confirmation)
+        should_transition_to(:complete)
+      end
+    end
+
+    context "from address" do
+      before do
+        order.state = 'address'
+      end
+
+      it "transitions to delivery" do
+        should_transition_to(:delivery)
+      end
+
+      it "transitions to payment if delivery not required" do
+        disable(:delivery)
+        enable(:payment)
+        should_transition_to(:payment)
+      end
+
+      it "transitions to confirm if delivery and payment not required, but confirmation is" do
+        disable(:delivery, :payment)
+        enable(:confirmation)
+        should_transition_to(:confirm)
+      end
+
+      it "transitions to complete if delivery, payment and confirm are not required" do
+        disable(:delivery, :payment, :confirmation)
+        should_transition_to(:complete)
+      end
+    end
+
+    context "from delivery" do
+      before do
+        order.state = 'delivery'
+        order.stub(:has_available_payment)
+        order.stub(:has_available_shipment)
+        order.stub(:create_shipment!)
+      end
+
+      it "transitions to payment" do
+        enable(:payment)
+        should_transition_to(:payment)
+      end
+
+      it "transitions to confirm if payment not required, but confirmation is" do
+        disable(:payment)
+        enable(:confirmation)
+        should_transition_to(:confirm)
+      end
+
+      it "transitions to complete if payment and confirmation not required" do
+        disable(:payment, :confirmation)
+        should_transition_to(:complete)
+      end
+    end
+
+    context "from payment" do
+      before do
+        order.state = 'payment'
+      end
+
+      it "transitions to confirmation if confirmation is required" do
+        enable(:confirmation)
+        should_transition_to(:confirm)
+      end
+
+      it "transitions to ocmplete if confirmation is not required" do
+        disable(:confirmation)
+        should_transition_to(:complete)
+      end
+    end
+
+    context "from confirm" do
+      before do
+        order.state = 'confirm'
+      end
+
+      it "transitions to complete" do
+        should_transition_to(:complete)
+      end
+    end
+  end
+
+  context "steps" do
+    before do
+      enable(:address, :delivery, :payment, :confirmation, :complete)
+    end
+
+    it "requires address, delivery, payment, confirm and complete" do
+      order.steps.should == %w(address delivery payment confirm complete)
+    end
+
+    it "does not require an address" do
+      disable(:address)
+      order.steps.should == %w(delivery payment confirm complete)
+    end
+
+    it "does not require a delivery" do
+      disable(:delivery)
+      order.steps.should == %w(address payment confirm complete)
+    end
+
+    it "does not require a payment" do
+      disable(:payment)
+      order.steps.should == %w(address delivery confirm complete)
+    end
+
+    it "does not require confirmation" do
+      disable(:confirmation)
+      order.steps.should == %w(address delivery payment complete)
+    end
+  end
+end

--- a/core/spec/models/order_spec.rb
+++ b/core/spec/models/order_spec.rb
@@ -144,7 +144,7 @@ describe Spree::Order do
 
        context "when credit card payment fails" do
          before do
-           order.stub(:process_payments!).and_raise(Spree::Core::GatewayError)
+           Spree::Payment.any_instance.stub(:process).and_raise(Spree::Core::GatewayError)
          end
 
          context "when not configured to allow failed payments" do
@@ -299,14 +299,6 @@ describe Spree::Order do
     it "should log state event" do
       order.state_changes.should_receive(:create)
       order.finalize!
-    end
-  end
-
-  context "#process_payments!" do
-    it "should process the payments" do
-      order.stub!(:payments).and_return([mock(Spree::Payment)])
-      order.payment.should_receive(:process!)
-      order.process_payments!
     end
   end
 

--- a/core/spec/requests/admin/configuration/shipping_methods_spec.rb
+++ b/core/spec/requests/admin/configuration/shipping_methods_spec.rb
@@ -11,7 +11,7 @@ describe "Shipping Methods" do
 
   before(:each) do
     # HACK: To work around no email prompting on check out
-    Spree::Order.any_instance.stub(:require_email => false)
+    Spree::Order.any_instance.stub(:email_required? => false)
     PAYMENT_STATES = Spree::Payment.state_machine.states.keys unless defined? PAYMENT_STATES
     SHIPMENT_STATES = Spree::Shipment.state_machine.states.keys unless defined? SHIPMENT_STATES
     ORDER_STATES = Spree::Order.state_machine.states.keys unless defined? ORDER_STATES


### PR DESCRIPTION
One of main problems I have had with customising spree is the checkout process. In order to change the entire process for sites I have to override the state machine contained in Order which really doesn't feel like a clean way of doing it.

The way I have currently overridden the process (which I think is the way defined in the documentation) is like this

```
Spree::Order.state_machine[:state] = StateMachine::Machine.new(Spree::Order, :initial => "cart") do
  event :next do
    transition :from => 'cart', :to => 'summary'
    transition :from => 'summary', :to => 'complete'
  end
end
```

This causes serval methods to be redefined within the class which state machine doesn't always seem happy about. It is possible to use a different event name but this causes me to completely overide the checkout controller and creates more work rather than less.

A better solution in my opinion would be to set the checkout process in the same why as the ProductSearcher is set within spree and pass the Order into this to manage the checkout process. This could also allow to use multiple checkout processes for a site (something I am currently trying to deal with) in a far more separate maner than having a large state machine with a guard at the start to push it down the correct path.
