### PR TITLE
Patch core initializer and user model to enable custom users with orders

### DIFF
--- a/core/app/models/spree/user.rb
+++ b/core/app/models/spree/user.rb
@@ -1,12 +1,17 @@
 # Default implementation of User.  This class is intended to be modified by extensions (ex. spree_auth_devise)
 module Spree
-  class User < ActiveRecord::Base
-    attr_accessible :email, :password, :password_confirmation
+  klass = SPREE_USER_CLASS == "Spree::User" ? ActiveRecord::Base : SPREE_USER_CLASS.constantize
+  class User < klass
+    if SPREE_USER_CLASS == "Spree::User"
+      attr_accessible :email, :password, :password_confirmation 
+      scope :registered
+      attr_accessor :password
+      attr_accessor :password_confirmation
+    end
 
     belongs_to :ship_address, :class_name => 'Spree::Address'
     belongs_to :bill_address, :class_name => 'Spree::Address'
 
-    scope :registered
 
     def anonymous?
       false
@@ -21,7 +26,5 @@ module Spree
       true
     end
 
-    attr_accessor :password
-    attr_accessor :password_confirmation
   end
 end

--- a/core/lib/generators/spree/custom_user/templates/initializer.rb.tt
+++ b/core/lib/generators/spree/custom_user/templates/initializer.rb.tt
@@ -1,2 +1,21 @@
 Spree.user_class = "<%= class_name %>"
 Spree.current_user_method = "current_<%= class_name.downcase %>"
+
+unless Spree.user_class == Spree::User
+  module Spree
+    class User < Spree.user_class
+      belongs_to :ship_address, :class_name => 'Spree::Address'
+      belongs_to :bill_address, :class_name => 'Spree::Address'
+
+      # Creates an anonymous user
+      def self.anonymous!
+        create
+      end
+
+      def has_spree_role?(role)
+        true
+      end
+    end
+  end
+end
+

--- a/core/lib/generators/spree/custom_user/templates/initializer.rb.tt
+++ b/core/lib/generators/spree/custom_user/templates/initializer.rb.tt
@@ -1,21 +1,2 @@
 Spree.user_class = "<%= class_name %>"
 Spree.current_user_method = "current_<%= class_name.downcase %>"
-
-unless Spree.user_class == Spree::User
-  module Spree
-    class User < Spree.user_class
-      belongs_to :ship_address, :class_name => 'Spree::Address'
-      belongs_to :bill_address, :class_name => 'Spree::Address'
-
-      # Creates an anonymous user
-      def self.anonymous!
-        create
-      end
-
-      def has_spree_role?(role)
-        true
-      end
-    end
-  end
-end
-

--- a/core/lib/generators/spree/install/templates/config/initializers/spree.rb
+++ b/core/lib/generators/spree/install/templates/config/initializers/spree.rb
@@ -11,4 +11,5 @@ Spree.config do |config|
   # config.site_name = "Spree Demo Site"
 end
 
-Spree.user_class = "Spree::User"
+SPREE_USER_CLASS = "Spree::User"
+Spree.user_class = SPREE_USER_CLASS


### PR DESCRIPTION
There's probably a much better way to do this, but this patch works and passes core tests.

If merged, this PR would require a slight tweak to the custom authentication instructions on http://ryanbigg.com/spree-guides/authentication.html

I.e., instead of directly setting Spree.user_class = "User" (or whatever the developer wants their custom user model to be), this PR would require a developer to set an environment var SPREE_USER_CLASS (in the same initializers/spree.rb file).

Net effect is that Spree::User becomes a sub-class of User (or whatever custom user model a developer specifies in initializers/spree.rb).  All the associations between Spree::Order and Spree::User are not touched at all -- because Spree::User is a subclass of User, the desired associations between Spree::Order and custom User are automatically applied by ActiveRecord. 
