### PR TITLE
Switch from state_machine to aasm

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -2,6 +2,7 @@ require 'spree/core/validators/email'
 
 module Spree
   class Order < ActiveRecord::Base
+    require_dependency 'spree/order/state_machine'
     token_resource
 
     attr_accessible :line_items, :bill_address_attributes, :ship_address_attributes, :payments_attributes,
@@ -54,52 +55,8 @@ module Spree
     class_attribute :update_hooks
     self.update_hooks = Set.new
 
-    # order state machine (see http://github.com/pluginaweek/state_machine/tree/master for details)
-    state_machine :initial => 'cart', :use_transactions => false do
-
-      event :next do
-        transition :from => 'cart',     :to => 'address'
-        transition :from => 'address',  :to => 'delivery'
-        transition :from => 'delivery', :to => 'payment', :if => :payment_required?
-        transition :from => 'delivery', :to => 'complete'
-        transition :from => 'confirm',  :to => 'complete'
-
-        # note: some payment methods will not support a confirm step
-        transition :from => 'payment',  :to => 'confirm',
-                                        :if => Proc.new { |order| order.payment_method && order.payment_method.payment_profiles_supported? }
-
-        transition :from => 'payment', :to => 'complete'
-      end
-
-      event :cancel do
-        transition :to => 'canceled', :if => :allow_cancel?
-      end
-      event :return do
-        transition :to => 'returned', :from => 'awaiting_return'
-      end
-      event :resume do
-        transition :to => 'resumed', :from => 'canceled', :if => :allow_resume?
-      end
-      event :authorize_return do
-        transition :to => 'awaiting_return'
-      end
-
-      before_transition :to => 'complete' do |order|
-        begin
-          order.process_payments!
-        rescue Core::GatewayError
-          !!Spree::Config[:allow_checkout_on_gateway_error]
-        end
-      end
-
-      before_transition :to => 'delivery', :do => :remove_invalid_shipments!
-
-      after_transition :to => 'complete', :do => :finalize!
-      after_transition :to => 'delivery', :do => :create_tax_charge!
-      after_transition :to => 'payment',  :do => :create_shipment!
-      after_transition :to => 'resumed',  :do => :after_resume
-      after_transition :to => 'canceled', :do => :after_cancel
-
+    def confirmation_required?
+      payment_method && payment_method.payment_profiles_supported?
     end
 
     def self.by_number(number)

--- a/core/app/models/spree/order/state_machine.rb
+++ b/core/app/models/spree/order/state_machine.rb
@@ -1,0 +1,59 @@
+Spree::Order.class_eval do
+  # checkout do
+  #   step :address
+  #   step :delivery
+  #   step :payment, :if => :payment_required?
+  #   step :confirm, :if => :confirmation_required?
+  # end
+  include AASM
+  aasm :column => :state do
+    state :cart, :initial => true
+    state :address
+    state :delivery
+    state :payment
+    state :confirm
+    state :complete
+    state :canceled
+    state :awaiting_return
+    state :returned
+    state :resumed
+
+    event :next do
+      transitions :from => :cart, :to => :address
+      transitions :from => :address, :to => :delivery
+      transitions :from => :delivery, :to => :payment, :guard => :payment_required?
+      transitions :from => :delivery, :to => :complete
+      transitions :from => :payment, :to => :confirm, :guard => :confirmation_required?
+      transitions :from => :payment, :to => :complete
+    end
+
+    event :cancel do
+      transitions :to => :canceled, :guard => :allow_cancel?
+    end
+    event :return do
+      transitions :from => :awaiting_return, :to => :returned
+    end
+    event :resume do
+      transitions :from => :canceled, :to => :resumed, :guard => :allow_resume?
+    end
+    event :authorize_return do
+      transitions :to => :awaiting_return
+    end
+
+    # before_transition :to => 'complete' do |order|
+    #   begin
+    #     order.process_payments!
+    #   rescue Core::GatewayError
+    #     !!Spree::Config[:allow_checkout_on_gateway_error]
+    #   end
+    # end
+
+    # before_transition :to => 'delivery', :do => :remove_invalid_shipments!
+
+    # after_transition :to => 'complete', :do => :finalize!
+    # after_transition :to => 'delivery', :do => :create_tax_charge!
+    # after_transition :to => 'payment',  :do => :create_shipment!
+    # after_transition :to => 'resumed',  :do => :after_resume
+    # after_transition :to => 'canceled', :do => :after_cancel
+  end
+end

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -29,6 +29,7 @@
 require 'rails/all'
 require 'rails/generators'
 require 'state_machine'
+require 'aasm'
 require 'paperclip'
 require 'kaminari'
 require 'nested_set'

--- a/core/spec/models/order/state_machine_spec.rb
+++ b/core/spec/models/order/state_machine_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+describe "Order's state machine default" do
+  let!(:order) { Factory(:order) }
+  before do
+    order.stub(:has_available_shipment)
+    order.stub(:has_available_payment)
+  end
+
+  def should_transition_to(state)
+    p order.next!
+    p order.errors
+    order.state.to_s.should == state.to_s
+  end
+
+  context "from cart" do
+    before { order.state = 'cart' }
+
+    it "transitions to address" do
+      should_transition_to(:address)
+    end
+  end
+
+  context "from address" do
+    before { order.state = 'address' }
+
+    it "transitions to delivery" do
+      should_transition_to(:delivery)
+    end
+  end
+
+  context "from delivery" do
+    before { order.state = 'delivery' }
+
+    context "with payment required" do
+      before { order.stub(:payment_required? => true) }
+      it "transitions to payment" do
+        should_transition_to(:payment)
+      end
+    end
+
+    context "without payment required" do
+      before { order.stub(:payment_required? => false) }
+      it "transitions to complete" do
+        should_transition_to(:complete)
+      end
+    end
+    end
+
+    context "from payment" do
+      before { order.state = 'payment' }
+
+      context "with confirmation required" do
+        before { order.stub(:confirmation_required? => true) }
+        it "transitions to confirmation" do
+          should_transition_to(:confirm)
+        end
+      end
+
+      context "without confirmation required" do
+        before { order.stub(:confirmation_required? => false) }
+        it "transitions to complete" do
+          should_transition_to(:complete)
+        end
+      end
+
+  end
+end

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'jquery-rails', '~> 2.0.0'
   s.add_dependency 'highline', '= 1.6.11'
   s.add_dependency 'state_machine', '= 1.1.2'
+  s.add_dependency 'aasm', '3.0.8'
   s.add_dependency 'ffaker', '~> 1.12.0'
   s.add_dependency 'paperclip', '~> 2.7'
   s.add_dependency 'aws-sdk', '~> 1.3.4'


### PR DESCRIPTION
Since #1418 didn't fly with the uptops (@BDQ), I was all "challenge accepted" this morning and set about toying with other state machine gems "for a few minutes" and then I would do some writing. It's been three hours, and no writing has been done.

Nevertheless, I think I've found what we need now in the aasm gem. This gem allows you to re-define the state machine (by clearing previous states and events and defining new ones) and I think with this we could probably provide an API like this:

``` ruby
Spree::Order.class_eval do
  checkout do
    step :address
    step :delivery
    step :payment, :if => :payment_required?
    step :confirmation, :if => :confirmation_required?
  end
end
```

With of course the `cart` and `complete` states being automatically set up. The `step` method simply defines the steps that will be visible to the user.

Each `step` call would define a state transition. So by calling `step :delivery` after `step :address` you'd expect to end up with something like this in your state machine:

``` ruby
event :next do
  transitions :from => :address, :to => :delivery
end
```

In the cases where steps are optional, the following would happen:

``` ruby
event :next do
  transitions :from => :delivery, :to => :payment, :guard => :payment_required?
  transitions :from => :delivery, :to => :complete
end
```

In the case of a double guard like the delivery -> payment -> confirm -> complete flow, you'd expect this:

``` ruby
event :next do
  transitions :from => :delivery, :to => :payment, :guard => :payment_required?
  transitions :from => :delivery, :to => :confirm, :guard => :confirmation_required?
  transitions :from => :delivery, :to => :complete
  transitions :from => :confirm, :to => :complete
end
```

I'm not quite sure how to implement at the moment, but I'll have a play around later.
