### PR TITLE
Fixed json_data of products in admin

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -64,7 +64,8 @@ module Spree
       Image.joins("LEFT JOIN #{Variant.quoted_table_name} ON #{Variant.quoted_table_name}.id = #{Asset.quoted_table_name}.viewable_id").
       where("#{Variant.quoted_table_name}.product_id = #{self.id}").
       order("#{Asset.quoted_table_name}.position").
-      extend(Spree::Core::RelationSerialization)
+      extend(Spree::Core::RelationSerialization).
+      all
     end
 
     alias_method :images, :variant_images


### PR DESCRIPTION
Fixed `Spree::Product#variant_images` to return array instead of `ActiveRecord::Relation`
