### PR TITLE
Rationalize admin form data-hooks

### DIFF
--- a/core/app/views/spree/admin/adjustments/_form.html.erb
+++ b/core/app/views/spree/admin/adjustments/_form.html.erb
@@ -1,12 +1,13 @@
-<%= f.field_container :amount do %>
-  <%= f.label :amount, t(:amount) %> <span class="required">*</span><br />
-  <%= text_field :adjustment, :amount, {:style => 'width:80px;'} %>
-  <%= f.error_message_on :amount %>
-<% end %>
+<div data-hook="admin_adjustment_form_fields">
+  <%= f.field_container :amount do %>
+    <%= f.label :amount, t(:amount) %> <span class="required">*</span><br />
+    <%= text_field :adjustment, :amount, {:style => 'width:80px;'} %>
+    <%= f.error_message_on :amount %>
+  <% end %>
 
-<%= f.field_container :label do %>
-  <%= f.label :label, t(:description) %> <span class="required">*</span><br />
-  <%= text_field :adjustment, :label, {:style => 'width:180px;'} %>
-  <%= f.error_message_on :label %>
-<% end %>
-
+  <%= f.field_container :label do %>
+    <%= f.label :label, t(:description) %> <span class="required">*</span><br />
+    <%= text_field :adjustment, :label, {:style => 'width:180px;'} %>
+    <%= f.error_message_on :label %>
+  <% end %>
+</div>

--- a/core/app/views/spree/admin/images/_form.html.erb
+++ b/core/app/views/spree/admin/images/_form.html.erb
@@ -1,16 +1,18 @@
-<tr data-hook="file">
-  <td><%= t(:filename) %>:</td>
-  <td><%= f.file_field :attachment %></td>
-</tr>
-<% if @product.has_variants? %>
-  <tr data-hook="variant">
-    <td><%= Spree::Variant.model_name.human %>:</td>
-    <td><%= f.select :viewable_id, @variants %></td>
+<div data-hook="admin_image_form_fields">
+  <tr data-hook="file">
+    <td><%= t(:filename) %>:</td>
+    <td><%= f.file_field :attachment %></td>
   </tr>
-<% else %>
-  <%= hidden_field_tag :product_id, @product.id %>
-<% end %>
-<tr data-hook="alt_text">
-  <td><%= t(:alt_text) %>:</td>
-  <td><%= f.text_area :alt %></td>
-</tr>
+  <% if @product.has_variants? %>
+    <tr data-hook="variant">
+      <td><%= Spree::Variant.model_name.human %>:</td>
+      <td><%= f.select :viewable_id, @variants %></td>
+    </tr>
+  <% else %>
+    <%= hidden_field_tag :product_id, @product.id %>
+  <% end %>
+  <tr data-hook="alt_text">
+    <td><%= t(:alt_text) %>:</td>
+    <td><%= f.text_area :alt %></td>
+  </tr>
+</div>

--- a/core/app/views/spree/admin/mail_methods/_form.html.erb
+++ b/core/app/views/spree/admin/mail_methods/_form.html.erb
@@ -1,90 +1,92 @@
-<div class="clearfix">
-  <div class="left" data-hook="general">
-    <fieldset>
-      <legend><%= t(:general) %></legend>
-      <p>
-        <%= f.label :environment, t(:environment) %><br />
-        <%= f.collection_select(:environment,
-                                Rails.configuration.database_configuration.keys.sort,
-                                :to_s, :titleize,
-                                {}, {:id => 'gtwy-env'}) %>
-      </p>
+<div data-hook="admin_mail_method_form_fields">
+  <div class="clearfix">
+    <div class="left" data-hook="general">
+      <fieldset>
+        <legend><%= t(:general) %></legend>
+        <p>
+          <%= f.label :environment, t(:environment) %><br />
+          <%= f.collection_select(:environment,
+                                  Rails.configuration.database_configuration.keys.sort,
+                                  :to_s, :titleize,
+                                  {}, {:id => 'gtwy-env'}) %>
+        </p>
 
-      <p>
-        <%= f.check_box :preferred_enable_mail_delivery, {:style => "vertical-align:middle;"} %>
-        <%= f.label :preferred_enable_mail_delivery, t(:enable_mail_delivery) %>
-      </p>
+        <p>
+          <%= f.check_box :preferred_enable_mail_delivery, {:style => "vertical-align:middle;"} %>
+          <%= f.label :preferred_enable_mail_delivery, t(:enable_mail_delivery) %>
+        </p>
 
-      <p>
-        <%= f.label :preferred_mails_from, t(:send_mails_as) %><br />
-        <%= f.text_field :preferred_mails_from, :size => 40, :maxlength => 256 %>
-        <br />
-        <span class="info">
-          <%= t(:smtp_send_all_emails_as_from_following_address) %>
-        </span>
-      </p>
+        <p>
+          <%= f.label :preferred_mails_from, t(:send_mails_as) %><br />
+          <%= f.text_field :preferred_mails_from, :size => 40, :maxlength => 256 %>
+          <br />
+          <span class="info">
+            <%= t(:smtp_send_all_emails_as_from_following_address) %>
+          </span>
+        </p>
 
-      <p>
-        <%= f.label :preferred_mail_bcc, t(:send_copy_of_all_mails_to) %><br />
-        <%= f.text_field :preferred_mail_bcc, :size => 40, :maxlength => 256 %>
-        <br />
-        <span class="info">
-          <%= t(:smtp_send_copy_to_this_addresses) %>
-        </span>
-      </p>
+        <p>
+          <%= f.label :preferred_mail_bcc, t(:send_copy_of_all_mails_to) %><br />
+          <%= f.text_field :preferred_mail_bcc, :size => 40, :maxlength => 256 %>
+          <br />
+          <span class="info">
+            <%= t(:smtp_send_copy_to_this_addresses) %>
+          </span>
+        </p>
 
-      <p>
-        <%= f.label :preferred_intercept_email, t(:intercept_email_address) %><br />
-        <%= f.text_field :preferred_intercept_email, :size => 40, :maxlength => 256 %>
-        <br />
-        <span class="info">
-          <%= t(:intercept_email_instructions) %>
-        </span>
-      </p>
+        <p>
+          <%= f.label :preferred_intercept_email, t(:intercept_email_address) %><br />
+          <%= f.text_field :preferred_intercept_email, :size => 40, :maxlength => 256 %>
+          <br />
+          <span class="info">
+            <%= t(:intercept_email_instructions) %>
+          </span>
+        </p>
 
-    </fieldset>
+      </fieldset>
+
+    </div>
+
+    <div class="right" data-hook="smtp">
+
+      <fieldset>
+        <legend><%= t(:smtp) %></legend>
+        <p>
+          <%= f.label :preferred_mail_domain, t(:smtp_domain) %><br />
+          <%= f.text_field :preferred_mail_domain %>
+        </p>
+        <p>
+          <%= f.label :preferred_mail_host, t(:smtp_mail_host) %><br />
+          <%= f.text_field :preferred_mail_host %>
+        </p>
+        <p>
+          <%= f.label :preferred_mail_port, t(:smtp_port) %><br />
+          <%= f.text_field :preferred_mail_port %>
+        </p>
+        <p>
+          <%= f.label :preferred_secure_connection_type, t(:secure_connection_type) %><br />
+          <%= f.collection_select(:preferred_secure_connection_type,
+                                  Spree::MailMethod::SECURE_CONNECTION_TYPES,
+                                  :to_s, :to_s,
+                                  {}, {'style' => 'width:200px'}) %>
+        <p>
+          <%= f.label :preferred_mail_auth_type, t(:smtp_authentication_type) %><br />
+          <%= f.collection_select(:preferred_mail_auth_type,
+                                  Spree::MailMethod::MAIL_AUTH,
+                                  :to_s, :to_s,
+                                  {}, {'style' => 'width:200px'}) %>
+        </p>
+        <p>
+          <%= f.label :preferred_smtp_username, t(:smtp_username) %><br />
+          <%= f.text_field :preferred_smtp_username %>
+        </p>
+        <p>
+          <%= f.label :preferred_smtp_password, t(:smtp_password) %><br />
+          <%= f.password_field :preferred_smtp_password %>
+        </p>
+      </fieldset>
+
+    </div>
 
   </div>
-
-  <div class="right" data-hook="smtp">
-
-    <fieldset>
-      <legend><%= t(:smtp) %></legend>
-      <p>
-        <%= f.label :preferred_mail_domain, t(:smtp_domain) %><br />
-        <%= f.text_field :preferred_mail_domain %>
-      </p>
-      <p>
-        <%= f.label :preferred_mail_host, t(:smtp_mail_host) %><br />
-        <%= f.text_field :preferred_mail_host %>
-      </p>
-      <p>
-        <%= f.label :preferred_mail_port, t(:smtp_port) %><br />
-        <%= f.text_field :preferred_mail_port %>
-      </p>
-      <p>
-        <%= f.label :preferred_secure_connection_type, t(:secure_connection_type) %><br />
-        <%= f.collection_select(:preferred_secure_connection_type,
-                                Spree::MailMethod::SECURE_CONNECTION_TYPES,
-                                :to_s, :to_s,
-                                {}, {'style' => 'width:200px'}) %>
-      <p>
-        <%= f.label :preferred_mail_auth_type, t(:smtp_authentication_type) %><br />
-        <%= f.collection_select(:preferred_mail_auth_type,
-                                Spree::MailMethod::MAIL_AUTH,
-                                :to_s, :to_s,
-                                {}, {'style' => 'width:200px'}) %>
-      </p>
-      <p>
-        <%= f.label :preferred_smtp_username, t(:smtp_username) %><br />
-        <%= f.text_field :preferred_smtp_username %>
-      </p>
-      <p>
-        <%= f.label :preferred_smtp_password, t(:smtp_password) %><br />
-        <%= f.password_field :preferred_smtp_password %>
-      </p>
-    </fieldset>
-
-  </div>
-
 </div>

--- a/core/app/views/spree/admin/option_types/_form.html.erb
+++ b/core/app/views/spree/admin/option_types/_form.html.erb
@@ -1,11 +1,13 @@
-<%= f.field_container :name do %>
-  <%= f.label :name, t(:name) %> <span class="required">*</span><br />
-  <%= f.text_field :name %>
-  <%= f.error_message_on :name %>
-<% end %>
+<div data-hook="admin_option_type_form_fields">
+  <%= f.field_container :name do %>
+    <%= f.label :name, t(:name) %> <span class="required">*</span><br />
+    <%= f.text_field :name %>
+    <%= f.error_message_on :name %>
+  <% end %>
 
-<%= f.field_container :presentation do %>
-  <%= f.label :presentation, t(:presentation) %> <span class="required">*</span><br />
-  <%= f.text_field :presentation %>
-  <%= f.error_message_on :presentation %>
-<% end %>
+  <%= f.field_container :presentation do %>
+    <%= f.label :presentation, t(:presentation) %> <span class="required">*</span><br />
+    <%= f.text_field :presentation %>
+    <%= f.error_message_on :presentation %>
+  <% end %>
+</div>

--- a/core/app/views/spree/admin/orders/_form.html.erb
+++ b/core/app/views/spree/admin/orders/_form.html.erb
@@ -1,54 +1,56 @@
-<% if @line_item.try(:errors).present? %>
-  <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @line_item } %>
-<% end %>
+ <div data-hook="admin_order_form_fields">
+  <% if @line_item.try(:errors).present? %>
+    <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @line_item } %>
+  <% end %>
 
-<%= form_for @order, :url => admin_order_url(@order), :method => :put do |f| %>
-  <%= f.hidden_field :number %>
-  <table class="index">
-    <tbody id="line-items">
-      <tr data-hook="admin_order_form_line_items_headers">
-        <th><%= t(:item_description) %></th>
-        <th class="price"><%= t(:price) %></th>
-        <th class="qty"><%= t(:qty) %></th>
-        <th class="total"><span><%= t(:total) %></span></th>
-        <th class="orders-actions" data-hook="admin_order_form_line_items_header_actions"></th>
-      </tr>
-      <%= f.fields_for :line_items do |li_form| %>
-        <%= render :partial => 'spree/admin/orders/line_item', :locals => { :f => li_form } %>
-      <% end %>
-    </tbody>
-    <tbody id="subtotal" data-hook="admin_order_form_subtotal">
-      <tr id="subtotal-row">
-        <td colspan="3"><b><%= t(:subtotal) %>:</b></td>
-        <td class="total"><span><%= number_to_currency @order.item_total %></span></td>
-        <td></td>
-      </tr>
-    </tbody>
-    <tbody id="order-charges" data-hook="admin_order_form_adjustments">
-      <% @order.adjustments.each do |adjustment| %>
-        <tr>
-          <td colspan="3"><strong><%= adjustment.label %></strong></td>
-          <td class="total"><span><%= number_to_currency adjustment.amount %></span></td>
+  <%= form_for @order, :url => admin_order_url(@order), :method => :put do |f| %>
+    <%= f.hidden_field :number %>
+    <table class="index">
+      <tbody id="line-items">
+        <tr data-hook="admin_order_form_line_items_headers">
+          <th><%= t(:item_description) %></th>
+          <th class="price"><%= t(:price) %></th>
+          <th class="qty"><%= t(:qty) %></th>
+          <th class="total"><span><%= t(:total) %></span></th>
+          <th class="orders-actions" data-hook="admin_order_form_line_items_header_actions"></th>
+        </tr>
+        <%= f.fields_for :line_items do |li_form| %>
+          <%= render :partial => 'spree/admin/orders/line_item', :locals => { :f => li_form } %>
+        <% end %>
+      </tbody>
+      <tbody id="subtotal" data-hook="admin_order_form_subtotal">
+        <tr id="subtotal-row">
+          <td colspan="3"><b><%= t(:subtotal) %>:</b></td>
+          <td class="total"><span><%= number_to_currency @order.item_total %></span></td>
           <td></td>
         </tr>
-      <% end %>
-    </tbody>
-    <tbody id="order-total" data-hook="admin_order_form_total">
-      <tr>
-        <td colspan="3"><b><%= t(:order_total) %>:</b></td>
-        <td class="total"><span id="order_total"><%= number_to_currency @order.total %></span></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
+      </tbody>
+      <tbody id="order-charges" data-hook="admin_order_form_adjustments">
+        <% @order.adjustments.each do |adjustment| %>
+          <tr>
+            <td colspan="3"><strong><%= adjustment.label %></strong></td>
+            <td class="total"><span><%= number_to_currency adjustment.amount %></span></td>
+            <td></td>
+          </tr>
+        <% end %>
+      </tbody>
+      <tbody id="order-total" data-hook="admin_order_form_total">
+        <tr>
+          <td colspan="3"><b><%= t(:order_total) %>:</b></td>
+          <td class="total"><span id="order_total"><%= number_to_currency @order.total %></span></td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
 
-  <p class="form-buttons" data-hook="admin_order_form_buttons">
-    <%= button t(:update) %>
-    <%= t(:or) %> <%= link_to t(:back), admin_orders_url %>
-  </p>
+    <p class="form-buttons" data-hook="admin_order_form_buttons">
+      <%= button t(:update) %>
+      <%= t(:or) %> <%= link_to t(:back), admin_orders_url %>
+    </p>
 
-<% end %>
+  <% end %>
 
-<%= javascript_tag do -%>
-  <%= render :partial => 'spree/admin/shared/update_order_state', :handlers => [:js] %>
-<% end -%>
+  <%= javascript_tag do -%>
+    <%= render :partial => 'spree/admin/shared/update_order_state', :handlers => [:js] %>
+  <% end -%>
+</div>

--- a/core/app/views/spree/admin/orders/customer_details/_form.html.erb
+++ b/core/app/views/spree/admin/orders/customer_details/_form.html.erb
@@ -1,48 +1,48 @@
+<div data-hook="admin_customer_detail_fields">
+  <h3><%= t(:customer_details) %></h3>
+  <table class="index" data-hook="customer_guest">
+    <thead>
+      <th colspan="8"><%= t(:account) %></th>
+    </thead>
+    <tbody>
+      <tr data-hook="customer_fields">
+        <td class="lbl-col"><%= f.label :email, t(:email) + ':' %></td>
+        <td class="val-col" colspan="3"><%= f.email_field :email, :class => 'fullwidth' %></td>
+        <td class="lbl-col"><%= label_tag nil, t(:guest_checkout) %>:</td>
+        <td class="val-col" colspan="3">
+          <% if @order.completed? %>
+            <%= @order.user.nil? ? t(:yes) : t(:no) %>
+          <% else %>
+            <% guest = @order.user.nil? || @order.user.anonymous? %>
+            <label class="sub">
+              <%= radio_button_tag :guest_checkout, true, guest %>
+              <%= t(:yes) %>
+            </label> &nbsp;
+            <label class="sub">
+              <%= radio_button_tag :guest_checkout, false, !guest, :disabled => @order.cart? %>
+              <%= t(:no) %>
+            </label>
+            <%= hidden_field_tag :user_id, @order.user_id %>
+          <% end %>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 
-<h3><%= t(:customer_details) %></h3>
-<table class="index" data-hook="customer_guest">
-  <thead>
-    <th colspan="8"><%= t(:account) %></th>
-  </thead>
-  <tbody>
-    <tr data-hook="customer_fields">
-      <td class="lbl-col"><%= f.label :email, t(:email) + ':' %></td>
-      <td class="val-col" colspan="3"><%= f.email_field :email, :class => 'fullwidth' %></td>
-      <td class="lbl-col"><%= label_tag nil, t(:guest_checkout) %>:</td>
-      <td class="val-col" colspan="3">
-        <% if @order.completed? %>
-          <%= @order.user.nil? ? t(:yes) : t(:no) %>
-        <% else %>
-          <% guest = @order.user.nil? || @order.user.anonymous? %>
-          <label class="sub">
-            <%= radio_button_tag :guest_checkout, true, guest %>
-            <%= t(:yes) %>
-          </label> &nbsp;
-          <label class="sub">
-            <%= radio_button_tag :guest_checkout, false, !guest, :disabled => @order.cart? %>
-            <%= t(:no) %>
-          </label>
-          <%= hidden_field_tag :user_id, @order.user_id %>
-        <% end %>
-      </td>
-    </tr>
-  </tbody>
-</table>
+  <h3><%= Spree::Address.model_name.human(:count => 2) %></h3>
+  <%= f.fields_for :bill_address do |ba_form| %>
+    <%= render :partial => 'spree/admin/shared/address_form', :locals => { :f => ba_form, :name => t(:billing_address), :use_billing => false } %>
+  <% end %>
 
-<h3><%= Spree::Address.model_name.human(:count => 2) %></h3>
-<%= f.fields_for :bill_address do |ba_form| %>
-  <%= render :partial => 'spree/admin/shared/address_form', :locals => { :f => ba_form, :name => t(:billing_address), :use_billing => false } %>
-<% end %>
+  <%= f.fields_for :ship_address do |sa_form| %>
+    <%= render :partial => 'spree/admin/shared/address_form', :locals => { :f => sa_form, :name => t(:shipping_address), :use_billing => true } %>
+  <% end %>
 
-<%= f.fields_for :ship_address do |sa_form| %>
-  <%= render :partial => 'spree/admin/shared/address_form', :locals => { :f => sa_form, :name => t(:shipping_address), :use_billing => true } %>
-<% end %>
+  <p class="form-buttons" data-hook="buttons">
+    <%= button @order.cart? ? t(:continue) : t(:update) %>
+  </p>
 
-<p class="form-buttons" data-hook="buttons">
-  <%= button @order.cart? ? t(:continue) : t(:update) %>
-</p>
-
-<% content_for :head do %>
-  <%= javascript_include_tag states_url, 'admin/address_states.js' %>
-<% end %>
-
+  <% content_for :head do %>
+    <%= javascript_include_tag states_url, 'admin/address_states.js' %>
+  <% end %>
+</div>

--- a/core/app/views/spree/admin/payment_methods/_form.html.erb
+++ b/core/app/views/spree/admin/payment_methods/_form.html.erb
@@ -1,50 +1,52 @@
-<table data-hook="payment_method">
-  <tr data-hook="name">
-    <td><%= label_tag nil, t(:name) %></td>
-    <td><%= text_field :payment_method, :name, {'style' => 'width:200px;'} %></td>
-  </tr>
-  <tr data-hook="description">
-    <td><%= label_tag nil, t(:description) %></td>
-    <td><%= text_area :payment_method, :description, {:cols => 60, :rows => 4} %></td>
-  </tr>
-  <tr data-hook="environment">
-    <td><%= label_tag nil, t(:environment) %></td>
-    <td>
-      <%= collection_select(:payment_method, :environment, Rails.configuration.database_configuration.keys.sort, :to_s, :titleize, {}, {:id => 'gtwy-env'}) %>
-    </td>
-  </tr>
-  <tr data-hook="display">
-    <td><%= label_tag nil, t(:display) %></td>
-    <td>
-      <%= select(:payment_method, :display_on, Spree::PaymentMethod::DISPLAY.collect { |display| [t(display), display == :both ? nil : display.to_s] }) %>
-    </td>
-  </tr>
-  <tr data-hook="active">
-    <td><%= label_tag nil, t(:active) %></td>
-    <td>
-      <label class="sub">
-        <%= radio_button :payment_method, :active, true %>
-        <%= t(:yes) %>
-      </label> &nbsp;
-      <label class="sub">
-        <%= radio_button :payment_method, :active, false %>
-        <%= t(:no) %>
-      </label>
-    </td>
-  </tr>
-</table>
+<div data-hook="admin_payment_method_form_fields">
+  <table data-hook="payment_method">
+    <tr data-hook="name">
+      <td><%= label_tag nil, t(:name) %></td>
+      <td><%= text_field :payment_method, :name, {'style' => 'width:200px;'} %></td>
+    </tr>
+    <tr data-hook="description">
+      <td><%= label_tag nil, t(:description) %></td>
+      <td><%= text_area :payment_method, :description, {:cols => 60, :rows => 4} %></td>
+    </tr>
+    <tr data-hook="environment">
+      <td><%= label_tag nil, t(:environment) %></td>
+      <td>
+        <%= collection_select(:payment_method, :environment, Rails.configuration.database_configuration.keys.sort, :to_s, :titleize, {}, {:id => 'gtwy-env'}) %>
+      </td>
+    </tr>
+    <tr data-hook="display">
+      <td><%= label_tag nil, t(:display) %></td>
+      <td>
+        <%= select(:payment_method, :display_on, Spree::PaymentMethod::DISPLAY.collect { |display| [t(display), display == :both ? nil : display.to_s] }) %>
+      </td>
+    </tr>
+    <tr data-hook="active">
+      <td><%= label_tag nil, t(:active) %></td>
+      <td>
+        <label class="sub">
+          <%= radio_button :payment_method, :active, true %>
+          <%= t(:yes) %>
+        </label> &nbsp;
+        <label class="sub">
+          <%= radio_button :payment_method, :active, false %>
+          <%= t(:no) %>
+        </label>
+      </td>
+    </tr>
+  </table>
 
-<h2><%= t(:settings) %></h2>
+  <h2><%= t(:settings) %></h2>
 
-<div id="preference-settings" data-hook>
-  <%= f.label :type, t(:provider) %>
-  <%= collection_select(:payment_method, :type, @providers, :to_s, :name, {}, {:id => 'gtwy-type'}) %>
+  <div id="preference-settings" data-hook>
+    <%= f.label :type, t(:provider) %>
+    <%= collection_select(:payment_method, :type, @providers, :to_s, :name, {}, {:id => 'gtwy-type'}) %>
 
-  <% unless @object.new_record? %>
-    <%= preference_fields(@object, f) %>
+    <% unless @object.new_record? %>
+      <%= preference_fields(@object, f) %>
 
-    <% if @object.respond_to?(:preferences) %>
-      <div id="gateway-settings-warning" style="color:#FF0000;"><%= t(:provider_settings_warning) %></div>
+      <% if @object.respond_to?(:preferences) %>
+        <div id="gateway-settings-warning" style="color:#FF0000;"><%= t(:provider_settings_warning) %></div>
+      <% end %>
     <% end %>
-  <% end %>
+  </div>
 </div>

--- a/core/app/views/spree/admin/payments/_form.html.erb
+++ b/core/app/views/spree/admin/payments/_form.html.erb
@@ -1,15 +1,17 @@
-<p>
-  <%= f.label :amount, t(:amount) %>
-  <%= f.text_field :amount, :size => 8, :value => @order.outstanding_balance %>
-</p>
+<div data-hook="admin_payment_form_fields">
+  <p>
+    <%= f.label :amount, t(:amount) %>
+    <%= f.text_field :amount, :size => 8, :value => @order.outstanding_balance %>
+  </p>
 
-<% @payment_methods.each do |method| %>
+  <% @payment_methods.each do |method| %>
 
-  <label data-hook="payment_method">
-    <%= radio_button_tag 'payment[payment_method_id]', method.id, method == @payment_method %>
-    <%= t(method.name, :scope => :payment_methods, :default => method.name) %>
-  </label>
+    <label data-hook="payment_method">
+      <%= radio_button_tag 'payment[payment_method_id]', method.id, method == @payment_method %>
+      <%= t(method.name, :scope => :payment_methods, :default => method.name) %>
+    </label>
 
-  <%= render :partial => "spree/admin/payments/source_forms/#{method.method_type}", :locals => { :payment_method => method } %>
+    <%= render :partial => "spree/admin/payments/source_forms/#{method.method_type}", :locals => { :payment_method => method } %>
 
-<% end %>
+  <% end %>
+</div>

--- a/core/app/views/spree/admin/products/_form.html.erb
+++ b/core/app/views/spree/admin/products/_form.html.erb
@@ -1,104 +1,106 @@
-<div class="clearfix">
-  <div class="left" data-hook="admin_product_form_left">
-    <%= f.field_container :name do %>
-      <%= f.label :name, t(:name) %> <span class="required">*</span><br />
-      <%= f.text_field :name, :class => 'fullwidth title' %>
-      <%= f.error_message_on :name %>
-    <% end %>
-
-    <%= f.field_container :permalink do %>
-      <%= f.label :permalink, t(:permalink) %> <span class="required">*</span><br />
-      <%= f.text_field :permalink, :class => 'fullwidth title' %>
-      <%= f.error_message_on :permalink %>
-    <% end %>
-
-    <%= f.field_container :description do %>
-      <%= f.label :description, t(:description) %><br />
-      <%= f.text_area :description, {:cols => 60, :rows => 4, :class => 'fullwidth'} %>
-      <%= f.error_message_on :description %>
-    <% end %>
-  </div>
-  <div class="right" data-hook="admin_product_form_right">
-      <%= f.field_container :price do %>
-        <%= f.label :price, t(:master_price) %> <span class="required">*</span><br />
-        <%= f.text_field :price, :value => number_to_currency(@product.price, :unit => '') %>
-        <%= f.error_message_on :price %>
+<div data-hook="admin_product_form_fields">
+  <div class="clearfix">
+    <div class="left" data-hook="admin_product_form_left">
+      <%= f.field_container :name do %>
+        <%= f.label :name, t(:name) %> <span class="required">*</span><br />
+        <%= f.text_field :name, :class => 'fullwidth title' %>
+        <%= f.error_message_on :name %>
       <% end %>
 
-      <%= f.field_container :cost_price do %>
-        <%= f.label :cost_price, t(:cost_price) %><br />
-        <%= f.text_field :cost_price, :value => number_to_currency(@product.cost_price, :unit => '') %>
-      <%= f.error_message_on :cost_price %>
-    <% end %>
-
-    <%= f.field_container :available_on do %>
-      <%= f.label :available_on, t(:available_on) %><br />
-      <%= f.error_message_on :available_on %>
-      <%= f.text_field :available_on, :class => 'datepicker' %>
-    <% end %>
-
-    <% unless @product.has_variants? %>
-      <%= f.field_container :sku do %>
-        <%= f.label :sku, t(:sku) %><br />
-        <%= f.text_field :sku, :size => 16 %>
+      <%= f.field_container :permalink do %>
+        <%= f.label :permalink, t(:permalink) %> <span class="required">*</span><br />
+        <%= f.text_field :permalink, :class => 'fullwidth title' %>
+        <%= f.error_message_on :permalink %>
       <% end %>
 
-      <% if Spree::Config[:track_inventory_levels] %>
-        <%= f.field_container :on_hand do %>
-          <%= f.label :on_hand, t(:on_hand) %><br />
-          <%= f.number_field :on_hand, :min => 0 %>
+      <%= f.field_container :description do %>
+        <%= f.label :description, t(:description) %><br />
+        <%= f.text_area :description, {:cols => 60, :rows => 4, :class => 'fullwidth'} %>
+        <%= f.error_message_on :description %>
+      <% end %>
+    </div>
+    <div class="right" data-hook="admin_product_form_right">
+        <%= f.field_container :price do %>
+          <%= f.label :price, t(:master_price) %> <span class="required">*</span><br />
+          <%= f.text_field :price, :value => number_to_currency(@product.price, :unit => '') %>
+          <%= f.error_message_on :price %>
         <% end %>
+
+        <%= f.field_container :cost_price do %>
+          <%= f.label :cost_price, t(:cost_price) %><br />
+          <%= f.text_field :cost_price, :value => number_to_currency(@product.cost_price, :unit => '') %>
+        <%= f.error_message_on :cost_price %>
       <% end %>
 
-      <ul id="shipping_specs">
-        <li id="shipping_specs_weight_field">
-          <%= f.label :weight, t(:weight) %>
-          <%= f.text_field :weight, :size => 4 %>
-        </li>
-        <li id="shipping_specs_height_field">
-          <%= f.label :height, t(:height) %>
-          <%= f.text_field :height, :size => 4 %>
-        </li>
-        <li id="shipping_specs_width_field">
-          <%= f.label :width, t(:width) %>
-          <%= f.text_field :width, :size => 4 %>
-        </li>
-        <li id="shipping_specs_depth_field">
-          <%= f.label :depth, t(:depth) %>
-          <%= f.text_field :depth, :size => 4 %>
-        </li>
-      </ul>
+      <%= f.field_container :available_on do %>
+        <%= f.label :available_on, t(:available_on) %><br />
+        <%= f.error_message_on :available_on %>
+        <%= f.text_field :available_on, :class => 'datepicker' %>
+      <% end %>
+
+      <% unless @product.has_variants? %>
+        <%= f.field_container :sku do %>
+          <%= f.label :sku, t(:sku) %><br />
+          <%= f.text_field :sku, :size => 16 %>
+        <% end %>
+
+        <% if Spree::Config[:track_inventory_levels] %>
+          <%= f.field_container :on_hand do %>
+            <%= f.label :on_hand, t(:on_hand) %><br />
+            <%= f.number_field :on_hand, :min => 0 %>
+          <% end %>
+        <% end %>
+
+        <ul id="shipping_specs">
+          <li id="shipping_specs_weight_field">
+            <%= f.label :weight, t(:weight) %>
+            <%= f.text_field :weight, :size => 4 %>
+          </li>
+          <li id="shipping_specs_height_field">
+            <%= f.label :height, t(:height) %>
+            <%= f.text_field :height, :size => 4 %>
+          </li>
+          <li id="shipping_specs_width_field">
+            <%= f.label :width, t(:width) %>
+            <%= f.text_field :width, :size => 4 %>
+          </li>
+          <li id="shipping_specs_depth_field">
+            <%= f.label :depth, t(:depth) %>
+            <%= f.text_field :depth, :size => 4 %>
+          </li>
+        </ul>
+      <% end %>
+
+      <%= f.field_container :shipping_categories do %>
+        <%= f.label :shipping_category_id, t(:shipping_categories) %><br />
+        <%= f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { :include_blank => true }, { 'style' => 'width:200px' }) %>
+        <%= f.error_message_on :shipping_category %>
+      <% end %>
+
+      <%= f.field_container :tax_category do %>
+        <%= f.label :tax_category_id, t(:tax_category) %><br />
+        <%= f.collection_select(:tax_category_id, @tax_categories, :id, :name, { :include_blank => true }, { 'style' => 'width:200px' }) %>
+        <%= f.error_message_on :tax_category %>
+      <% end %>
+    </div>
+  </div>
+
+  <h2><%= t(:metadata) %></h2>
+  <div data-hook="admin_product_form_meta">
+    <%= f.field_container :meta_keywords do %>
+      <%= f.label :meta_keywords, t(:meta_keywords) %><br />
+      <%= f.text_field :meta_keywords, :class => 'fullwidth' %>
     <% end %>
 
-    <%= f.field_container :shipping_categories do %>
-      <%= f.label :shipping_category_id, t(:shipping_categories) %><br />
-      <%= f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { :include_blank => true }, { 'style' => 'width:200px' }) %>
-      <%= f.error_message_on :shipping_category %>
-    <% end %>
-
-    <%= f.field_container :tax_category do %>
-      <%= f.label :tax_category_id, t(:tax_category) %><br />
-      <%= f.collection_select(:tax_category_id, @tax_categories, :id, :name, { :include_blank => true }, { 'style' => 'width:200px' }) %>
-      <%= f.error_message_on :tax_category %>
+    <%= f.field_container :meta_description do %>
+      <%= f.label :meta_description, t(:meta_description) %><br />
+      <%= f.text_field :meta_description, :class => 'fullwidth' %>
     <% end %>
   </div>
-</div>
 
-<h2><%= t(:metadata) %></h2>
-<div data-hook="admin_product_form_meta">
-  <%= f.field_container :meta_keywords do %>
-    <%= f.label :meta_keywords, t(:meta_keywords) %><br />
-    <%= f.text_field :meta_keywords, :class => 'fullwidth' %>
-  <% end %>
-
-  <%= f.field_container :meta_description do %>
-    <%= f.label :meta_description, t(:meta_description) %><br />
-    <%= f.text_field :meta_description, :class => 'fullwidth' %>
-  <% end %>
-</div>
-
-<div data-hook="admin_product_form_additional_fields">
-  <% Spree::Variant.additional_fields.select { |af| af[:only].nil? || af[:only].include?(:product) }.each do |field| %>
-    <%= render :partial => 'spree/admin/shared/additional_field', :locals => { :field => field, :f => f } %>
-  <% end %>
+  <div data-hook="admin_product_form_additional_fields">
+    <% Spree::Variant.additional_fields.select { |af| af[:only].nil? || af[:only].include?(:product) }.each do |field| %>
+      <%= render :partial => 'spree/admin/shared/additional_field', :locals => { :field => field, :f => f } %>
+    <% end %>
+  </div>
 </div>

--- a/core/app/views/spree/admin/properties/_form.html.erb
+++ b/core/app/views/spree/admin/properties/_form.html.erb
@@ -1,5 +1,4 @@
-<div data-hook="admin_property_form">
-
+<div data-hook="admin_property_form_fields">
   <%= f.field_container :name do %>
     <%= f.label :name, t(:name) %> <span class="required">*</span><br />
     <%= f.text_field :name %>
@@ -11,5 +10,4 @@
     <%= f.text_field :presentation %>
     <%= f.error_message_on :presentation %>
   <% end %>
-
 </div>

--- a/core/app/views/spree/admin/prototypes/_form.html.erb
+++ b/core/app/views/spree/admin/prototypes/_form.html.erb
@@ -1,44 +1,46 @@
-<%= f.field_container :name do %>
-  <%= f.label :name, t(:name) %><br />
-  <%= f.text_field :name %>
-  <%= f.error_message_on :name %>
-<% end %>
+<div data-hook="admin_prototype_form_fields">
+  <%= f.field_container :name do %>
+    <%= f.label :name, t(:name) %><br />
+    <%= f.text_field :name %>
+    <%= f.error_message_on :name %>
+  <% end %>
 
-<h3><%= t(:properties) %></h3>
+  <h3><%= t(:properties) %></h3>
 
-<ul class='checkbox-list' id='properties' data-hook>
-<% Spree::Property.sorted.each do |property| %>
-  <% selected = if @prototype.new_record?
-    (params[:property] and params[:property][:id] and params[:property][:id].include?(property.id.to_s))
-  else
-    @prototype.properties.include?(property)
-  end %>
-  <li>
-    <label>
-      <%= check_box_tag 'property[id][]', "#{property.id}", selected %>
-      <%= property.name %>
-    </label>
-  </li>
-<% end %>
-</ul>
+  <ul class='checkbox-list' id='properties' data-hook>
+  <% Spree::Property.sorted.each do |property| %>
+    <% selected = if @prototype.new_record?
+      (params[:property] and params[:property][:id] and params[:property][:id].include?(property.id.to_s))
+    else
+      @prototype.properties.include?(property)
+    end %>
+    <li>
+      <label>
+        <%= check_box_tag 'property[id][]', "#{property.id}", selected %>
+        <%= property.name %>
+      </label>
+    </li>
+  <% end %>
+  </ul>
 
-<hr />
+  <hr />
 
-<h3><%= t(:option_types) %></h3>
+  <h3><%= t(:option_types) %></h3>
 
-<ul class="checkbox-list" id="option_types" data-hook>
-<% Spree::OptionType.all.each do |option_type| %>
-  <% selected = if @prototype.new_record?
-    (params[:option_type] and params[:option_type][:id] and params[:option_type][:id].include?(option_type.id.to_s))
-  else
-    @prototype.option_types.include?(option_type)
-  end %>
-  <li>
-    <label>
-      <%= check_box_tag 'option_type[id][]', "#{option_type.id}", selected %>
-      <%= option_type.name %>
-    </label>
-  </li>
-<% end %>
-</ul>
-<hr />
+  <ul class="checkbox-list" id="option_types" data-hook>
+  <% Spree::OptionType.all.each do |option_type| %>
+    <% selected = if @prototype.new_record?
+      (params[:option_type] and params[:option_type][:id] and params[:option_type][:id].include?(option_type.id.to_s))
+    else
+      @prototype.option_types.include?(option_type)
+    end %>
+    <li>
+      <label>
+        <%= check_box_tag 'option_type[id][]', "#{option_type.id}", selected %>
+        <%= option_type.name %>
+      </label>
+    </li>
+  <% end %>
+  </ul>
+  <hr />
+</div>

--- a/core/app/views/spree/admin/return_authorizations/_form.html.erb
+++ b/core/app/views/spree/admin/return_authorizations/_form.html.erb
@@ -1,77 +1,79 @@
-<table class="index">
-  <tr data-hook="rma_header">
-    <th><%= t(:product) %></th>
-    <th><%= t(:quantity_shipped) %></th>
-    <th><%= t(:quantity_returned) %></th>
-    <th><%= t(:return_quantity) %></th>
-  </tr>
-  <% @return_authorization.order.inventory_units.group_by(&:variant).each do | variant, units| %>
-    <tr id="<%= dom_id(variant) %>" data-hook="rma_row">
-      <td>
-        <h4 style="margin-bottom:0px;"><%= variant.name %></h4>
-        <%= variant.options_text %>
-      </td>
-      <td><%= units.select(&:shipped?).size %></td>
-      <td><%= units.select(&:returned?).size %></td>
-      <td class="return_quantity">
-        <% if @return_authorization.received? %>
-          <%= @return_authorization.inventory_units.group_by(&:variant)[variant].try(:size) || 0 %>
-        <% elsif units.select(&:shipped?).empty? %>
-          0
-        <% else %>
-          <%= text_field_tag "return_quantity[#{variant.id}]",
-              @return_authorization.inventory_units.group_by(&:variant)[variant].try(:size) || 0, {:style => 'width:30px;'} %>
-        <% end %>
-      </td>
+<div data-hook="admin_return_authorization_form_fields">
+  <table class="index">
+    <tr data-hook="rma_header">
+      <th><%= t(:product) %></th>
+      <th><%= t(:quantity_shipped) %></th>
+      <th><%= t(:quantity_returned) %></th>
+      <th><%= t(:return_quantity) %></th>
     </tr>
-  <% end %>
-</table>
-
-<%= f.field_container :amount do %>
-  <%= f.label :amount, t(:amount) %> <span class="required">*</span><br />
-  <% if @return_authorization.received? %>
-    <%= number_to_currency @return_authorization.amount %>
-  <% else %>
-    <%= f.text_field :amount, {:style => 'width:80px;'} %> <%= t(:rma_value) %>: <span id="rma_value"></span>
-    <%= f.error_message_on :amount %>
-  <% end %>
-<% end %>
-
-<%= f.field_container :reason do %>
-  <%= f.label :reason, t(:reason) %>
-  <%= f.text_area :reason, {:style => 'height:100px;', :class => 'fullwidth'} %>
-  <%= f.error_message_on :reason %>
-<% end %>
-
-
-<% content_for :head do %>
-  <%= javascript_tag do -%>
-    var variant_prices = new Array();
     <% @return_authorization.order.inventory_units.group_by(&:variant).each do | variant, units| %>
-      variant_prices[<%= variant.id.to_s %>] = <%= variant.price %>;
+      <tr id="<%= dom_id(variant) %>" data-hook="rma_row">
+        <td>
+          <h4 style="margin-bottom:0px;"><%= variant.name %></h4>
+          <%= variant.options_text %>
+        </td>
+        <td><%= units.select(&:shipped?).size %></td>
+        <td><%= units.select(&:returned?).size %></td>
+        <td class="return_quantity">
+          <% if @return_authorization.received? %>
+            <%= @return_authorization.inventory_units.group_by(&:variant)[variant].try(:size) || 0 %>
+          <% elsif units.select(&:shipped?).empty? %>
+            0
+          <% else %>
+            <%= text_field_tag "return_quantity[#{variant.id}]",
+                @return_authorization.inventory_units.group_by(&:variant)[variant].try(:size) || 0, {:style => 'width:30px;'} %>
+          <% end %>
+        </td>
+      </tr>
     <% end %>
+  </table>
 
-    function calculate_rma_price(object, value){
-      var rma_amount = 0;
+  <%= f.field_container :amount do %>
+    <%= f.label :amount, t(:amount) %> <span class="required">*</span><br />
+    <% if @return_authorization.received? %>
+      <%= number_to_currency @return_authorization.amount %>
+    <% else %>
+      <%= f.text_field :amount, {:style => 'width:80px;'} %> <%= t(:rma_value) %>: <span id="rma_value"></span>
+      <%= f.error_message_on :amount %>
+    <% end %>
+  <% end %>
 
-      $.each($("td.return_quantity input"), function(i, inpt){
-        var variant_id = $(inpt).attr('id').replace("return_quantity_", "");
-         rma_amount += variant_prices[variant_id] * $(inpt).val()
-      });
+  <%= f.field_container :reason do %>
+    <%= f.label :reason, t(:reason) %>
+    <%= f.text_area :reason, {:style => 'height:100px;', :class => 'fullwidth'} %>
+    <%= f.error_message_on :reason %>
+  <% end %>
 
-      if(!isNaN(rma_amount)){
-        $("span#rma_value").html(rma_amount.toFixed(2));
+
+  <% content_for :head do %>
+    <%= javascript_tag do -%>
+      var variant_prices = new Array();
+      <% @return_authorization.order.inventory_units.group_by(&:variant).each do | variant, units| %>
+        variant_prices[<%= variant.id.to_s %>] = <%= variant.price %>;
+      <% end %>
+
+      function calculate_rma_price(object, value){
+        var rma_amount = 0;
+
+        $.each($("td.return_quantity input"), function(i, inpt){
+          var variant_id = $(inpt).attr('id').replace("return_quantity_", "");
+           rma_amount += variant_prices[variant_id] * $(inpt).val()
+        });
+
+        if(!isNaN(rma_amount)){
+          $("span#rma_value").html(rma_amount.toFixed(2));
+        }
       }
-    }
 
-    $(document).ready(function(){
-      $.each($("td.return_quantity input"), function(i, inpt){
-        $(inpt).delayedObserver(function() {
-          calculate_rma_price();
-        }, 0.5);
+      $(document).ready(function(){
+        $.each($("td.return_quantity input"), function(i, inpt){
+          $(inpt).delayedObserver(function() {
+            calculate_rma_price();
+          }, 0.5);
+        });
+
+        calculate_rma_price();
       });
-
-      calculate_rma_price();
-    });
-  <% end -%>
-<% end %>
+    <% end -%>
+  <% end %>
+</div>

--- a/core/app/views/spree/admin/shipments/_form.html.erb
+++ b/core/app/views/spree/admin/shipments/_form.html.erb
@@ -1,73 +1,75 @@
-<% unless @shipment.order.cart? %>
-  <table class="index" style="width:100%;" data-hook="admin_shipment_form_inventory_units">
-    <tr data-hook="shipments_header">
-      <th style="width:130px;"><%= t(:include_in_shipment) %></th>
-      <th><%= t(:sku) %></th>
-      <th><%= t(:item_description) %></th>
-      <th><%= t(:status) %></th>
-      <th><%= t(:note) %></th>
-    </tr>
-
-    <% @shipment.order.inventory_units.each do |inventory_unit| %>
-      <tr data-hook="shipments_row">
-        <td style="text-align:center;">
-          <%= check_box_tag "inventory_units[#{inventory_unit.id}]",
-                            :true,
-                            (inventory_unit.shipment == @shipment),
-                            { :disabled => %w(shipped backordered returned).include?(inventory_unit.state),
-                              :class => 'inventory_unit'} %>
-        </td>
-        <td style="vertical-align:top; width:120px;"><%= inventory_unit.variant.sku %></td>
-        <td style="width:300px;">
-          <%=inventory_unit.variant.product.name %>
-          <%= '(' + variant_options(inventory_unit.variant) + ')' unless inventory_unit.variant.option_values.empty? %>
-        </td>
-        <td><%= t(inventory_unit.state) %></td>
-        <td>
-          <% if inventory_unit.shipment == @shipment %>
-            <%= t(:included_in_this_shipment) %>
-          <% elsif !inventory_unit.shipment.nil? %>
-            <%= t(:included_in_other_shipment) %> - <%= link_to inventory_unit.shipment.number, edit_admin_order_shipment_url(inventory_unit.order, inventory_unit.shipment) %>
-          <% end %>
-        </td>
+<div data-hook="admin_shipment_form_fields">
+  <% unless @shipment.order.cart? %>
+    <table class="index" style="width:100%;" data-hook="admin_shipment_form_inventory_units">
+      <tr data-hook="shipments_header">
+        <th style="width:130px;"><%= t(:include_in_shipment) %></th>
+        <th><%= t(:sku) %></th>
+        <th><%= t(:item_description) %></th>
+        <th><%= t(:status) %></th>
+        <th><%= t(:note) %></th>
       </tr>
-    <% end %>
-  </table>
-<% end %>
 
-<div data-hook="admin_shipment_form_address">
-  <% shipment_form.fields_for 'address' do |sa_form| %>
-    <%= render :partial => 'spree/admin/shared/address_form', :locals => { :f => sa_form, :name => t(:shipping_address), :use_billing => false } %>
+      <% @shipment.order.inventory_units.each do |inventory_unit| %>
+        <tr data-hook="shipments_row">
+          <td style="text-align:center;">
+            <%= check_box_tag "inventory_units[#{inventory_unit.id}]",
+                              :true,
+                              (inventory_unit.shipment == @shipment),
+                              { :disabled => %w(shipped backordered returned).include?(inventory_unit.state),
+                                :class => 'inventory_unit'} %>
+          </td>
+          <td style="vertical-align:top; width:120px;"><%= inventory_unit.variant.sku %></td>
+          <td style="width:300px;">
+            <%=inventory_unit.variant.product.name %>
+            <%= '(' + variant_options(inventory_unit.variant) + ')' unless inventory_unit.variant.option_values.empty? %>
+          </td>
+          <td><%= t(inventory_unit.state) %></td>
+          <td>
+            <% if inventory_unit.shipment == @shipment %>
+              <%= t(:included_in_this_shipment) %>
+            <% elsif !inventory_unit.shipment.nil? %>
+              <%= t(:included_in_other_shipment) %> - <%= link_to inventory_unit.shipment.number, edit_admin_order_shipment_url(inventory_unit.order, inventory_unit.shipment) %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </table>
   <% end %>
-</div>
 
-<div data-hook="admin_shipment_form_details">
-  <table class="index">
-    <tr>
-      <th colspan="8"><%= t(:shipment_details) %></th>
-    </tr>
-    <tr>
-      <td>
-        <%= shipment_form.label :shipping_method_id, t(:shipping_method) + ':' %>
-      </td>
-      <td>
-        <%= shipment_form.select :shipping_method_id,
-                                        @shipping_methods.map {|sm| ["#{sm.name} - #{sm.zone.name}", sm.id] } %>
-      </td>
-      <td>
-        <%= shipment_form.label :tracking, t(:tracking) + ':' %>
-      </td>
-      <td><%= shipment_form.text_field :tracking %></td>
-    </tr>
-    <% if Spree::Config[:shipping_instructions] %>
+  <div data-hook="admin_shipment_form_address">
+    <% shipment_form.fields_for 'address' do |sa_form| %>
+      <%= render :partial => 'spree/admin/shared/address_form', :locals => { :f => sa_form, :name => t(:shipping_address), :use_billing => false } %>
+    <% end %>
+  </div>
+
+  <div data-hook="admin_shipment_form_details">
+    <table class="index">
+      <tr>
+        <th colspan="8"><%= t(:shipment_details) %></th>
+      </tr>
       <tr>
         <td>
-          <%= shipment_form.label :special_instructions, t(:special_instructions) + ':' %>
+          <%= shipment_form.label :shipping_method_id, t(:shipping_method) + ':' %>
         </td>
-        <td colspan="3">
-            <%= shipment_form.text_area :special_instructions %>
+        <td>
+          <%= shipment_form.select :shipping_method_id,
+                                          @shipping_methods.map {|sm| ["#{sm.name} - #{sm.zone.name}", sm.id] } %>
         </td>
+        <td>
+          <%= shipment_form.label :tracking, t(:tracking) + ':' %>
+        </td>
+        <td><%= shipment_form.text_field :tracking %></td>
       </tr>
-    <% end %>
-  </table>
+      <% if Spree::Config[:shipping_instructions] %>
+        <tr>
+          <td>
+            <%= shipment_form.label :special_instructions, t(:special_instructions) + ':' %>
+          </td>
+          <td colspan="3">
+              <%= shipment_form.text_area :special_instructions %>
+          </td>
+        </tr>
+      <% end %>
+    </table>
+  </div>
 </div>

--- a/core/app/views/spree/admin/shipping_categories/_form.html.erb
+++ b/core/app/views/spree/admin/shipping_categories/_form.html.erb
@@ -1,6 +1,8 @@
-<table data-hook="name">
-  <tr>
-    <td><%= t(:name) %>:</td>
-    <td><%= f.text_field :name, {'style' => 'width:200px'} %></td>
-  </tr>
-</table>
+<div data-hook="admin_shipping_category_form_fields">
+  <table data-hook="name">
+    <tr>
+      <td><%= t(:name) %>:</td>
+      <td><%= f.text_field :name, {'style' => 'width:200px'} %></td>
+    </tr>
+  </table>
+</div>

--- a/core/app/views/spree/admin/states/_form.html.erb
+++ b/core/app/views/spree/admin/states/_form.html.erb
@@ -1,9 +1,11 @@
-<%= f.field_container :name do %>
-  <%= f.label :name, t(:name) %><br />
-  <%= f.text_field :name %>
-<% end %>
+<div data-hook="admin_state_form_fields">
+  <%= f.field_container :name do %>
+    <%= f.label :name, t(:name) %><br />
+    <%= f.text_field :name %>
+  <% end %>
 
-<%= f.field_container :abbr do %>
-  <%= f.label :abbr, t(:abbreviation) %><br />
-  <%= f.text_field :abbr %>
-<% end %>
+  <%= f.field_container :abbr do %>
+    <%= f.label :abbr, t(:abbreviation) %><br />
+    <%= f.text_field :abbr %>
+  <% end %>
+</div>

--- a/core/app/views/spree/admin/tax_categories/_form.html.erb
+++ b/core/app/views/spree/admin/tax_categories/_form.html.erb
@@ -1,12 +1,16 @@
-<%= f.field_container :name do %>
-  <%= f.label :name, t(:name) %><br />
-  <%= f.text_field :name %>
-<% end %>
-<%= f.field_container :description do %>
-  <%= f.label :description, t(:description) %><br />
-  <%= f.text_field :description %>
-<% end %>
-<%= f.field_container :is_default do %>
-  <%= f.label :is_default, t(:default) %><br />
-  <%= f.check_box :is_default %>
-<% end %>
+<div data-hook="admin_tax_category_form_fields">
+  <%= f.field_container :name do %>
+    <%= f.label :name, t(:name) %><br />
+    <%= f.text_field :name %>
+  <% end %>
+
+  <%= f.field_container :description do %>
+    <%= f.label :description, t(:description) %><br />
+    <%= f.text_field :description %>
+  <% end %>
+
+  <%= f.field_container :is_default do %>
+    <%= f.label :is_default, t(:default) %><br />
+    <%= f.check_box :is_default %>
+  <% end %>
+</div>

--- a/core/app/views/spree/admin/tax_rates/_form.html.erb
+++ b/core/app/views/spree/admin/tax_rates/_form.html.erb
@@ -1,20 +1,22 @@
-<table data-hook="tax_rates">
-  <tr data-hook="zone">
-    <td><%= f.label :zone, t(:zone) %></td>
-    <td><%= f.collection_select(:zone_id, @available_zones, :id, :name) %></td>
-  </tr>
-  <tr data-hook="category">
-    <td><%= f.label :tax_category_id, t(:tax_category) %></td>
-    <td><%= f.collection_select(:tax_category_id, @available_categories,:id, :name) %></td>
-  </tr>
-  <tr data-hook="included">
-    <td><%= f.label :included_in_price, t(:included_in_price) %></td>
-    <td><%= f.check_box :included_in_price %></td>
-  </tr>
-  <tr data-hook="rate">
-    <td><%= f.label :amount, t(:rate) %></td>
-    <td><%= f.text_field :amount %></td>
-  </tr>
-</table>
+<div data-hook="admin_tax_rate_form_fields">
+  <table data-hook="tax_rates">
+    <tr data-hook="zone">
+      <td><%= f.label :zone, t(:zone) %></td>
+      <td><%= f.collection_select(:zone_id, @available_zones, :id, :name) %></td>
+    </tr>
+    <tr data-hook="category">
+      <td><%= f.label :tax_category_id, t(:tax_category) %></td>
+      <td><%= f.collection_select(:tax_category_id, @available_categories,:id, :name) %></td>
+    </tr>
+    <tr data-hook="included">
+      <td><%= f.label :included_in_price, t(:included_in_price) %></td>
+      <td><%= f.check_box :included_in_price %></td>
+    </tr>
+    <tr data-hook="rate">
+      <td><%= f.label :amount, t(:rate) %></td>
+      <td><%= f.text_field :amount %></td>
+    </tr>
+  </table>
 
-<%= render :partial => 'spree/admin/shared/calculator_fields', :locals => { :f => f } %>
+  <%= render :partial => 'spree/admin/shared/calculator_fields', :locals => { :f => f } %>
+</div>

--- a/core/app/views/spree/admin/taxonomies/_form.html.erb
+++ b/core/app/views/spree/admin/taxonomies/_form.html.erb
@@ -1,4 +1,4 @@
-<div data-hook="admin_inside_taxonomy_form">
+<div data-hook="admin_taxonomy_form_fields">
   <%= f.field_container :name do %>
     <%= f.label :name, t(:name) %> <span class="required">*</span><br />
     <%= error_message_on :taxonomy, :name, :class => 'fullwidth title' %>

--- a/core/app/views/spree/admin/taxons/_form.html.erb
+++ b/core/app/views/spree/admin/taxons/_form.html.erb
@@ -1,4 +1,4 @@
-<div data-hook="admin_inside_taxon_form">
+<div data-hook="admin_taxon_form_fields">
   <%= f.field_container :name do %>
     <%= f.label :name, t(:name) %> <span class="required">*</span><br />
     <%= error_message_on :taxon, :name, :class => 'fullwidth title' %>
@@ -19,5 +19,4 @@
     <%= f.label :description, t(:description) %><br />
     <%= f.text_area :description %>
   <% end %>
-
 </div>

--- a/core/app/views/spree/admin/trackers/_form.html.erb
+++ b/core/app/views/spree/admin/trackers/_form.html.erb
@@ -1,27 +1,29 @@
-<table>
-  <tr data-hook="analytics_id">
-    <td><%= label_tag nil, t(:google_analytics_id) %></td>
-    <td><%= text_field :tracker, :analytics_id, {'style' => 'width:200px;'} %></td>
-  </tr>
-  <tr data-hook="environment">
-    <td><%= label_tag nil, t(:environment) %></td>
-    <td>
-      <%= collection_select(:tracker, :environment, Rails.configuration.database_configuration.keys.sort, :to_s, :titleize, {}, {:id => 'tracker-env'}) %>
-    </td>
-  </tr>
-  <tr data-hook="active">
-    <td><%= label_tag nil, t(:active) %></td>
-    <td>
-      <label class="sub">
-        <%= radio_button(:tracker, :active, true) %>
-        <%= t(:yes) %>
-      </label> &nbsp;
-      <label class="sub">
-        <%= radio_button(:tracker, :active, false) %>
-        <%= t(:no) %>
-      </label>
-    </td>
-  </tr>
-  <tbody data-hook="additional_tracker_fields">
-  </tbody>
-</table>
+<div data-hook="admin_tracker_form_fields">
+  <table>
+    <tr data-hook="analytics_id">
+      <td><%= label_tag nil, t(:google_analytics_id) %></td>
+      <td><%= text_field :tracker, :analytics_id, {'style' => 'width:200px;'} %></td>
+    </tr>
+    <tr data-hook="environment">
+      <td><%= label_tag nil, t(:environment) %></td>
+      <td>
+        <%= collection_select(:tracker, :environment, Rails.configuration.database_configuration.keys.sort, :to_s, :titleize, {}, {:id => 'tracker-env'}) %>
+      </td>
+    </tr>
+    <tr data-hook="active">
+      <td><%= label_tag nil, t(:active) %></td>
+      <td>
+        <label class="sub">
+          <%= radio_button(:tracker, :active, true) %>
+          <%= t(:yes) %>
+        </label> &nbsp;
+        <label class="sub">
+          <%= radio_button(:tracker, :active, false) %>
+          <%= t(:no) %>
+        </label>
+      </td>
+    </tr>
+    <tbody data-hook="additional_tracker_fields">
+    </tbody>
+  </table>
+</div>

--- a/core/app/views/spree/admin/variants/_form.html.erb
+++ b/core/app/views/spree/admin/variants/_form.html.erb
@@ -1,40 +1,42 @@
-<div class="clearfix">
-  <div class="left" data-hook="variants">
+<div data-hook="admin_variant_form_fields">
+  <div class="clearfix">
+    <div class="left" data-hook="variants">
 
-    <% @product.options.each do |option| %>
-      <p data-hook="presentation">
-        <%= label :new_variant, option.option_type.presentation %><br />
-        <% if @variant.new_record? %>
-          <%= select(:new_variant, option.option_type.presentation,
-            option.option_type.option_values.collect {|ov| [ ov.presentation, ov.id ] },
-            {})
-          %>
-        <% else %>
-          <% opt = @variant.option_values.detect {|o| o.option_type == option.option_type }.presentation %>
-          <%= text_field(:new_variant,  option.option_type.presentation, :value => opt, :disabled => 'disabled') %>
-        <% end %>
-      </p>
-    <% end %>
+      <% @product.options.each do |option| %>
+        <p data-hook="presentation">
+          <%= label :new_variant, option.option_type.presentation %><br />
+          <% if @variant.new_record? %>
+            <%= select(:new_variant, option.option_type.presentation,
+              option.option_type.option_values.collect {|ov| [ ov.presentation, ov.id ] },
+              {})
+            %>
+          <% else %>
+            <% opt = @variant.option_values.detect {|o| o.option_type == option.option_type }.presentation %>
+            <%= text_field(:new_variant,  option.option_type.presentation, :value => opt, :disabled => 'disabled') %>
+          <% end %>
+        </p>
+      <% end %>
 
-    <p data-hook="sku"><%= f.label :sku, t(:sku) %><br />
-    <%= f.text_field :sku %></p>
+      <p data-hook="sku"><%= f.label :sku, t(:sku) %><br />
+      <%= f.text_field :sku %></p>
 
-    <p data-hook="price"><%= f.label :price, t(:price) %>:<br />
-    <%= f.text_field :price, :value => number_with_precision(@variant.price, :precision => 2) %></p>
+      <p data-hook="price"><%= f.label :price, t(:price) %>:<br />
+      <%= f.text_field :price, :value => number_with_precision(@variant.price, :precision => 2) %></p>
 
-    <p data-hook="cost_price"><%= f.label :cost_price, t(:cost_price) %>:<br />
-    <%= f.text_field :cost_price, :value => number_with_precision(@variant.cost_price, :precision => 2) %></p>
+      <p data-hook="cost_price"><%= f.label :cost_price, t(:cost_price) %>:<br />
+      <%= f.text_field :cost_price, :value => number_with_precision(@variant.cost_price, :precision => 2) %></p>
 
-    <% if Spree::Config[:track_inventory_levels] %>
-      <p data-hook="on_hand"><%= f.label :on_hand, t(:on_hand) %>: <br />
-      <%= f.text_field :on_hand %></p>
-    <% end %>
-  </div>
-  <div class="right">
+      <% if Spree::Config[:track_inventory_levels] %>
+        <p data-hook="on_hand"><%= f.label :on_hand, t(:on_hand) %>: <br />
+        <%= f.text_field :on_hand %></p>
+      <% end %>
+    </div>
+    <div class="right">
 
-    <% Spree::Variant.additional_fields.select{|af| af[:only].nil? || af[:only].include?(:variant) }.each do |field| %>
-      <%= render :partial => 'spree/admin/shared/additional_field', :locals => { :field => field, :f => f } %>
-    <% end %>
+      <% Spree::Variant.additional_fields.select{|af| af[:only].nil? || af[:only].include?(:variant) }.each do |field| %>
+        <%= render :partial => 'spree/admin/shared/additional_field', :locals => { :field => field, :f => f } %>
+      <% end %>
 
+    </div>
   </div>
 </div>

--- a/core/app/views/spree/admin/zones/_form.html.erb
+++ b/core/app/views/spree/admin/zones/_form.html.erb
@@ -1,29 +1,31 @@
-<%= zone_form.field_container :name do %>
-  <%= zone_form.label :name, t(:name) %><br />
-  <%= zone_form.text_field :name %>
-<% end %>
+<div data-hook="admin_zone_form_fields">
+  <%= zone_form.field_container :name do %>
+    <%= zone_form.label :name, t(:name) %><br />
+    <%= zone_form.text_field :name %>
+  <% end %>
 
-<%= zone_form.field_container :description do %>
-  <%= zone_form.label :description, t(:description) %><br />
-  <%= zone_form.text_field :description %>
-<% end %>
+  <%= zone_form.field_container :description do %>
+    <%= zone_form.label :description, t(:description) %><br />
+    <%= zone_form.text_field :description %>
+  <% end %>
 
-<p data-hook="default">
-  <td><%= t(:default_tax_zone) %></td>
-  <td><%= zone_form.check_box :default_tax %></td>
-</p>
+  <p data-hook="default">
+    <td><%= t(:default_tax_zone) %></td>
+    <td><%= zone_form.check_box :default_tax %></td>
+  </p>
 
-<p data-hook="type">
-  <%= label_tag nil, t(:type) %><br />
-  <label class="sub">
-    <%= zone_form.radio_button('kind', 'country', { :id => 'country_based' }) %>
-    <%= t(:country_based) %>
-  </label> &nbsp;
-  <label class="sub">
-    <%= zone_form.radio_button('kind', 'state', { :id => 'state_based' }) %>
-    <%= t(:state_based) %>
-  </label> &nbsp;
-</p>
+  <p data-hook="type">
+    <%= label_tag nil, t(:type) %><br />
+    <label class="sub">
+      <%= zone_form.radio_button('kind', 'country', { :id => 'country_based' }) %>
+      <%= t(:country_based) %>
+    </label> &nbsp;
+    <label class="sub">
+      <%= zone_form.radio_button('kind', 'state', { :id => 'state_based' }) %>
+      <%= t(:state_based) %>
+    </label> &nbsp;
+  </p>
 
-<%= render :partial => 'member_type', :locals => { :type => 'country', :zone_form => zone_form }%>
-<%= render :partial => 'member_type', :locals => { :type => 'state', :zone_form => zone_form } %>
+  <%= render :partial => 'member_type', :locals => { :type => 'country', :zone_form => zone_form }%>
+  <%= render :partial => 'member_type', :locals => { :type => 'state', :zone_form => zone_form } %>
+</div>


### PR DESCRIPTION
This PR is more to illustrate an issue and start a discussion than something I expect to be merged as-is.

Currently, a minority of the admin forms have suitable data-hooks to insert new fields, and those that do are not consistently named.

There is admin_mail_method_form_fields (which I standardized on arbitrarily), but also things like admin_shipment_form_details and admin_inside_taxon_form and admin_product_form_additional_fields.

This pain point initially came about when I tried to add a new field to the OptionType form (in both edit and new views), and couldn't find a hook that was clear.

This diff makes more sense if you ignore whitespace as most of it is changing indentation. `git diff 1-1-stable -w`
