### PR TITLE
More whitelisted attributes for mass-assignment

### DIFF
--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -22,7 +22,7 @@
 #
 module Spree
   class Adjustment < ActiveRecord::Base
-    attr_accessible :amount, :label
+    attr_accessible :source, :originator, :amount, :label, :mandatory
 
     belongs_to :adjustable, :polymorphic => true
     belongs_to :source, :polymorphic => true

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -20,7 +20,7 @@ module Spree
     calculated_adjustments
     scope :by_zone, lambda { |zone| where(:zone_id => zone) }
 
-    attr_accessible :amount, :tax_category_id, :calculator, :zone_id, :included_in_price
+    attr_accessible :amount, :tax_category_id, :calculator, :calculator_type, :zone_id, :included_in_price
 
     # Gets the array of TaxRates appropriate for the specified order
     def self.match(order)


### PR DESCRIPTION
spree-1.0-stable:

Adds more attributes to mass-assignment whitelist for adjustments.

The current whitelisted attributes in adjustment.rb are not enough.
https://github.com/spree/spree/commit/b9669fa56bee15a253cbab56528112bad9505534#commitcomment-1560552

When creating adjustments with source and originator, the related attributes will be ignored.
This breaks many things like the calculation for taxes and shipments.

Also when adding a new TaxRate, a calculator must be chosen.
The calculator_type attribute is sent via the form and needs to be whitelisted.

Thanks
