### PR TITLE
TaxRate needs on more attribute whitelisted for mass-assignment

### DIFF
--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -7,7 +7,7 @@ module Spree
     belongs_to :shipping_category
 
     attr_accessible :name, :zone_id, :display_on, :shipping_category_id,
-                    :match_none, :match_one, :match_all, :calculator_type
+                    :match_none, :match_one, :match_all, :calculator_type, :calculator_attributes
 
     calculated_adjustments
 

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -20,7 +20,7 @@ module Spree
     calculated_adjustments
     scope :by_zone, lambda { |zone| where(:zone_id => zone) }
 
-    attr_accessible :amount, :tax_category_id, :calculator, :zone_id, :included_in_price
+    attr_accessible :amount, :tax_category_id, :calculator, :calculator_type, :zone_id, :included_in_price
 
     # Gets the array of TaxRates appropriate for the specified order
     def self.match(order)


### PR DESCRIPTION
When creating a new tax rate in the admin backend, the :calculator_type attribute is sent within the params and needs to be whitelisted. Else, it can not be created because the calculator is being validated to be present.
