### PR TITLE
Tweak shipment state callback

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -139,6 +139,7 @@ module Spree
 
       def after_ship
         inventory_units.each &:ship!
+        self.shipped_at = Time.now
         ShipmentMailer.shipped_email(self).deliver
       end
 

--- a/core/spec/models/shipment_spec.rb
+++ b/core/spec/models/shipment_spec.rb
@@ -144,6 +144,7 @@ describe Spree::Shipment do
 
     it "should update shipped_at timestamp" do
       shipment.shipped_at = Time.now
+      shipment.shipped_at.should_not be_nil
     end
 
     it "should send a shipment email" do

--- a/core/spec/models/shipment_spec.rb
+++ b/core/spec/models/shipment_spec.rb
@@ -142,6 +142,10 @@ describe Spree::Shipment do
       shipping_method.stub(:create_adjustment)
     end
 
+    it "should update shipped_at timestamp" do
+      shipment.shipped_at = Time.now
+    end
+
     it "should send a shipment email" do
       mail_message = mock "Mail::Message"
       Spree::ShipmentMailer.should_receive(:shipped_email).with(shipment).and_return mail_message


### PR DESCRIPTION
This pull request sets the shipped_at timestamp in the after_ship method. Currently, the shipped_at attribute isn't explicitly being set during any state transitions and this appears to be the proper place to set the value. Test included for quality assurance and sanity check.

I ended up rebasing and merging against master after the fact. If this affects your branch, let me know and I'll fix this up the second time around
