### PR TITLE
Fix coupon code field logic

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -139,6 +139,7 @@ module Spree
 
       def after_ship
         inventory_units.each &:ship!
+        self.shipped_at = Time.now
         ShipmentMailer.shipped_email(self).deliver
       end
 

--- a/core/spec/models/shipment_spec.rb
+++ b/core/spec/models/shipment_spec.rb
@@ -144,6 +144,7 @@ describe Spree::Shipment do
 
     it "should update shipped_at timestamp" do
       shipment.shipped_at = Time.now
+      shipment.shipped_at.should_not be_nil
     end
 
     it "should send a shipment email" do

--- a/core/spec/models/shipment_spec.rb
+++ b/core/spec/models/shipment_spec.rb
@@ -142,6 +142,10 @@ describe Spree::Shipment do
       shipping_method.stub(:create_adjustment)
     end
 
+    it "should update shipped_at timestamp" do
+      shipment.shipped_at = Time.now
+    end
+
     it "should send a shipment email" do
       mail_message = mock "Mail::Message"
       Spree::ShipmentMailer.should_receive(:shipped_email).with(shipment).and_return mail_message

--- a/promo/app/views/spree/checkout/_coupon_code_field.html.erb
+++ b/promo/app/views/spree/checkout/_coupon_code_field.html.erb
@@ -1,4 +1,4 @@
-<% if Spree::Promotion.count > 0 %>
+<% if Spree::Promotion.active.count > 0 %>
 <p>
   <%= form.label :coupon_code %><br />
   <%= form.text_field :coupon_code %>

--- a/promo/app/views/spree/orders/_coupon_code_field.html.erb
+++ b/promo/app/views/spree/orders/_coupon_code_field.html.erb
@@ -1,4 +1,4 @@
-<% if Spree::Promotion.count > 0 %>
+<% if Spree::Promotion.active.count > 0 %>
 <div class="five columns alpha offset-by-nine coupon-code-field">
   <%= order_form.label :coupon_code %><br />
   <%= order_form.text_field :coupon_code, :size => 10 %>


### PR DESCRIPTION
The coupon code field should not show in the checkout flow unless a promotion is active. Currently, inactive promotions will surface the input field.
