### PR TITLE
Fallback string if the product have no description

### DIFF
--- a/core/app/views/spree/orders/_line_item.html.erb
+++ b/core/app/views/spree/orders/_line_item.html.erb
@@ -14,7 +14,7 @@
         <%= variant.in_stock? ? t(:insufficient_stock, :on_hand => variant.on_hand) : t(:out_of_stock) %><br />
       </span>
     <% end %>
-    <%= truncate(variant.product.description.gsub(/<(.*?)>/,""), :length => 100, :omission => "...") %>
+    <%= truncate(variant.product.description.gsub(/<(.*?)>/,""), :length => 100, :omission => "...") rescue t(:product_has_no_description) %>
   </td>
   <td class="cart-item-price" data-hook="cart_item_price">
     <%= number_to_currency line_item.price %>

--- a/core/spec/requests/products_spec.rb
+++ b/core/spec/requests/products_spec.rb
@@ -135,4 +135,12 @@ describe "Visiting Products" do
                          "Ruby on Rails Jr. Spaghetti",
                          "Ruby on Rails Ringer T-Shirt"]
   end
+
+  it "should be able to put a product without a description in the cart" do
+    product = FactoryGirl.create(:simple_product, :description => nil, :name => 'Sample', :price => '19.99')
+    visit spree.product_path(product)
+    page.should have_content "This product has no description"
+    click_button 'add-to-cart-button'
+    page.should have_content "This product has no description"
+  end
 end


### PR DESCRIPTION
if the product has no description, it will throw exception which is very bad. This patch provide a failsafe net for that case.
