### PR TITLE
Move noscript blocks out of paragraph - deface breaks such invalid html

### DIFF
--- a/core/app/views/spree/checkout/_address.html.erb
+++ b/core/app/views/spree/checkout/_address.html.erb
@@ -48,9 +48,6 @@
         <p class="field" id="bstate">
           <% have_states = !@order.bill_address.country.states.empty? %>
           <%= bill_form.label :state, t(:state) %><span class="required">*</span><br />
-          <noscript>
-            <%= bill_form.text_field :state_name, :class => 'required' %>
-          </noscript>
           <% state_elements = [
              bill_form.collection_select(:state_id, @order.bill_address.country.states,
                                 :id, :name,
@@ -66,6 +63,9 @@
             document.write("<%== state_elements %>");
           <% end -%>
         </p>
+          <noscript>
+            <%= bill_form.text_field :state_name, :class => 'required' %>
+          </noscript>
       <% end %>
 
       <p class="field" id="bzipcode">
@@ -135,9 +135,6 @@
         <p class="field" id="sstate">
           <% have_states = !@order.ship_address.country.states.empty? %>
           <%= ship_form.label :state, t(:state) %><span class="required">*</span><br />
-          <noscript>
-            <%= ship_form.text_field :state_name, :class => 'required' %>
-          </noscript>
           <% state_elements = [
              ship_form.collection_select(:state_id, @order.ship_address.country.states,
                                 :id, :name,
@@ -153,6 +150,9 @@
             document.write("<%== state_elements %>");
           <% end %>
         </p>
+          <noscript>
+            <%= ship_form.text_field :state_name, :class => 'required' %>
+          </noscript>
       <% end %>
 
       <p class="field" id="szipcode">


### PR DESCRIPTION
I ran across this issue when I added an override to the spree/checkout/_address view.

Simply by virtue of adding a deface override to that view (irrespective of what you're overriding), the resulting html renders in such a way that it breaks checkout.js, which is responsible for showing/hiding the state field of  the billing and shipping addresses based on whether or not a country has states configured.

This results in the state picker not properly converting to a text input when the user's chosen country does not have states configured for it.

I tracked down the cause to invalid html in the view itself.  Evidently, deface's processing "corrects" the invalid html, causing the output to no longer have the structure that the selector in checkout.js expect, so the functions defined there never get called.

The offending tag is the noscript block that lies in the paragraph that houses the state select/input field.  According to the [html4 dtd](http://www.w3.org/TR/html4/sgml/dtd.html#block), noscript is a block-level element (unlike `<script>`) which cannot be placed inside a paragraph because paragraphs can only contain inline elements.

Because of this, the deface processing adds a closing `</p>`, moving the paragraph contents outside of the paragraph and the checkout.js selector's p#bstate/sstate.

The simplest fix is to move the noscript block outside and below the paragraph.  I've tested this and it works  both when the browser supports javascript as well as when javascript is turned off.
