### PR TITLE
product_description helper problems

### DIFF
--- a/core/app/helpers/spree/products_helper.rb
+++ b/core/app/helpers/spree/products_helper.rb
@@ -14,7 +14,7 @@ module Spree
 
     # converts line breaks in product description into <p> tags (for html display purposes)
     def product_description(product)
-      raw(product.description.gsub(/(.*?)\n\n/m, '<p>\1</p>\n\n'))
+      raw(product.description.gsub(/(.*?)\r?\n\r?\n/m, '<p>\1</p>'))
     end
 
     def variant_images_hash(product)


### PR DESCRIPTION
fixed windows \r\n type of newlines, and \n doesn't extrapolate in '
