### PR TITLE
Don't include HTML tags in shipment emails

### DIFF
--- a/core/app/views/spree/shipment_mailer/shipped_email.text.erb
+++ b/core/app/views/spree/shipment_mailer/shipped_email.text.erb
@@ -6,7 +6,7 @@ Your order has been shipped
 Shipment Summary
 ============================================================
 <% @shipment.line_items.each do |item| %>
-<%= item.variant.sku %> <%= item.variant.product.name %> <%= variant_options(item.variant) %> (<%= item.quantity %>)
+  <%= item.variant.sku %> <%= item.variant.product.name %> <%= variant_options(item.variant, :include_style => false) %> (<%= item.quantity %>)
 <% end %>
 ============================================================
 

--- a/core/spec/mailers/shipment_mailer_spec.rb
+++ b/core/spec/mailers/shipment_mailer_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+require 'email_spec'
+
+describe Spree::ShipmentMailer do
+  include EmailSpec::Helpers
+  include EmailSpec::Matchers
+
+  let(:shipment) do
+    shipment = stub_model(Spree::Shipment)
+    order = stub_model(Spree::Order)
+    product = stub_model(Spree::Product, :name => %Q{The "BEST" product})
+    variant = stub_model(Spree::Variant, :product => product)
+    variant.stub(:in_stock? => false)
+    line_item = stub_model(Spree::LineItem, :variant => variant, :order => order, :quantity => 1, :price => 5)
+    shipment.stub(:line_items => [line_item], :order => order)
+    shipment
+  end
+
+  it "doesn't include out of stock html span in the email body" do
+    Spree::Config.allow_backorders = false
+    shipment_email = Spree::ShipmentMailer.shipped_email(shipment)
+    shipment_email.body.should_not include(%Q{span class="out-of-stock"})
+  end
+end


### PR DESCRIPTION
HTML tags were being included in shipment emails so that you sometimes ended up with emails that looked like 

```
Dear Customer,

Your order has been shipped

============================================================
Shipment Summary
============================================================
74439833 Spree Bag <span class="out-of-stock">(Out of Stock) </span> (1)
============================================================

Tracking Information: 9499907123456123456781

Thank you for your business.
```

When calling variant_options in the shipped_email mail template, we should pass it :include_style => false to ensure that unwanted html doesn't end up in the text email template.
