### PR TITLE
Fix previous pull request 1775

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -140,7 +140,7 @@ module Spree
       def after_ship
         send_shipped_email
         inventory_units.each &:ship!
-        self.shipped_at = Time.now
+        touch :shipped_at
       end
 
       def send_shipped_email


### PR DESCRIPTION
Sorry I didn't catch this earlier, but the shipment "shipped_at" timestamp is not being saved to the database. I've tweaked the code to ensure the record is saved.
