### PR TITLE
Lazy bcc Application in Mail Interceptor

### DIFF
--- a/core/lib/spree/core/mail_interceptor.rb
+++ b/core/lib/spree/core/mail_interceptor.rb
@@ -16,7 +16,7 @@ module Spree
         end
 
         if mail_method.preferred_mail_bcc.present?
-          message.bcc = mail_method.preferred_mail_bcc
+          message.bcc ||= mail_method.preferred_mail_bcc
         end
       end
 


### PR DESCRIPTION
It is impossible (as far I can tell) to override the `MailMethod` bcc preference in a `ActionMailer`. If someone is calling `mail(:bcc => '...')` the Spree mail interceptor should leave the bcc as is (just like Spree handles the from field).

Does this break any existing functionality? Am I missing anything here?
