### PR TITLE
Adding Missing Google Analytics trackTrans

### DIFF
--- a/core/app/views/spree/shared/_google_analytics.html.erb
+++ b/core/app/views/spree/shared/_google_analytics.html.erb
@@ -13,9 +13,9 @@
         "<%= @order.total %>",                            <%# Order total %>
         "<%= @order.adjustments.tax.sum(:amount) %>",     <%# Tax Amount %>
         "<%= @order.adjustments.shipping.sum(:amount) %>",<%# Ship Amount %>
-        "",                                               <%# City %>
-        "",                                               <%# State %>
-        ""                                                <%# Country %>
+        "<%= @order.bill_address.city %>",                <%# City %>
+        "<%= @order.bill_address.state.name %>",          <%# State %>
+        "<%= @order.bill_address.country.name %>"         <%# Country %>
       ]);
       <% @order.line_items.each do |line_item| %>
         _gaq.push(['_addItem',
@@ -27,6 +27,7 @@
           "<%= line_item.quantity %>"             <%# quantity - required %>
         ]);
       <% end %>
+      _gaq.push(['_trackTrans']);
     <% end %>
 
     (function() {

--- a/core/app/views/spree/shared/_google_analytics.html.erb
+++ b/core/app/views/spree/shared/_google_analytics.html.erb
@@ -14,7 +14,7 @@
         "<%= @order.adjustments.tax.sum(:amount) %>",
         "<%= @order.adjustments.shipping.sum(:amount) %>",
         "<%= @order.bill_address.city %>",
-        "<%= @order.bill_address.state.try(:name) || @order.bill_address.state_name %>",
+        "<%= @order.bill_address.state_text %>",
         "<%= @order.bill_address.country.name %>"
       ]);
       <% @order.line_items.each do |line_item| %>

--- a/core/app/views/spree/shared/_google_analytics.html.erb
+++ b/core/app/views/spree/shared/_google_analytics.html.erb
@@ -6,25 +6,25 @@
     _gaq.push(['_trackPageview']);
 
     <% if flash[:commerce_tracking] %>
-     <%# report e-commerce transaction information when applicable %>
+      <%# more info: https://developers.google.com/analytics/devguides/collection/gajs/methods/gaJSApiEcommerce %>
       _gaq.push(['_addTrans',
-        "<%= @order.number %>",                           <%# Order Number %>
-        "",                                               <%# Affiliation %>
-        "<%= @order.total %>",                            <%# Order total %>
-        "<%= @order.adjustments.tax.sum(:amount) %>",     <%# Tax Amount %>
-        "<%= @order.adjustments.shipping.sum(:amount) %>",<%# Ship Amount %>
-        "<%= @order.bill_address.city %>",                <%# City %>
-        "<%= @order.bill_address.state.name %>",          <%# State %>
-        "<%= @order.bill_address.country.name %>"         <%# Country %>
+        "<%= @order.number %>",
+        "",
+        "<%= @order.total %>",
+        "<%= @order.adjustments.tax.sum(:amount) %>",
+        "<%= @order.adjustments.shipping.sum(:amount) %>",
+        "<%= @order.bill_address.city %>",
+        "<%= @order.bill_address.state.try(:name) || @order.bill_address.state_name %>",
+        "<%= @order.bill_address.country.name %>"
       ]);
       <% @order.line_items.each do |line_item| %>
         _gaq.push(['_addItem',
-          "<%= @order.number %>",                 <%# order ID - required %>
-          "<%= line_item.variant.sku %>",         <%# SKU/code - required %>
-          "<%= line_item.variant.product.name %>",<%# product name %>
-          "",                                     <%# category or variation, Product Category %>
-          "<%= line_item.price %>",               <%# unit price - required %>
-          "<%= line_item.quantity %>"             <%# quantity - required %>
+          "<%= @order.number %>",
+          "<%= line_item.variant.sku %>",
+          "<%= line_item.variant.product.name %>",
+          "",
+          "<%= line_item.price %>",
+          "<%= line_item.quantity %>"
         ]);
       <% end %>
       _gaq.push(['_trackTrans']);


### PR DESCRIPTION
I thought #1784 fixed the issue, but ecommerce tracking in GA still did not work.

I dug into the GA eCommerce documentation a bit and learned that a _trackTrans call was missing from the GA code.

Also added in address information to the transaction tracking.
