### PR TITLE
Better Default Product Meta Description

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -65,12 +65,19 @@ module Spree
 
     def meta_data_tags
       object = instance_variable_get('@'+controller_name.singularize)
-      meta = { :keywords => Spree::Config[:default_meta_keywords], :description => Spree::Config[:default_meta_description] }
+      meta = {}
 
-      if object.kind_of?(ActiveRecord::Base)
+      if object.kind_of? ActiveRecord::Base
         meta[:keywords] = object.meta_keywords if object[:meta_keywords].present?
         meta[:description] = object.meta_description if object[:meta_description].present?
       end
+
+      meta[:description] = strip_tags(object.description) if meta[:description].blank? and object.kind_of? Spree::Product
+
+      meta = {
+        :keywords => Spree::Config[:default_meta_keywords],
+        :description => Spree::Config[:default_meta_description]
+      }.merge(meta)
 
       meta.map do |name, content|
         tag('meta', :name => name, :content => content)


### PR DESCRIPTION
This is partially in reference to [this discussion](https://groups.google.com/forum/?fromgroups#!searchin/spree-user/proposal$20description/spree-user/ELyj6twgF6A/oT1eXp0wlF0J).

Assigning a meta description for each product is a tedious process, and in most cases won't happen. Falling back to a HTML-stripped `Spree::Product.description` seems like a better solution to me.
