### PR TITLE
Add s3_host_alias configuration option to allow CNAME hosts to be specif

### DIFF
--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -77,6 +77,7 @@ module Spree
     preference :s3_headers, :string, :default => "{\"Cache-Control\":\"max-age=31557600\"}"
     preference :use_s3, :boolean, :default => false # Use S3 for images rather than the file system
     preference :s3_protocol, :string
+    preference :s3_host_alias, :string
 
     # searcher_class allows spree extension writers to provide their own Search class
     def searcher_class


### PR DESCRIPTION
...ied for S3/Cloudfront.
