### PR TITLE
Add s3_host_alias configuration option and associated changes in s3_support

### DIFF
--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -77,6 +77,7 @@ module Spree
     preference :s3_headers, :string, :default => "{\"Cache-Control\":\"max-age=31557600\"}"
     preference :use_s3, :boolean, :default => false # Use S3 for images rather than the file system
     preference :s3_protocol, :string
+    preference :s3_host_alias, :string
 
     # searcher_class allows spree extension writers to provide their own Search class
     def searcher_class

--- a/core/lib/spree/core/s3_support.rb
+++ b/core/lib/spree/core/s3_support.rb
@@ -16,6 +16,7 @@ module Spree
             self.attachment_definitions[field][:s3_headers] = ActiveSupport::JSON.decode(config[:s3_headers])
             self.attachment_definitions[field][:bucket] = config[:s3_bucket]
             self.attachment_definitions[field][:s3_protocol] = config[:s3_protocol] unless config[:s3_protocol].blank?
+            self.attachment_definitions[field][:s3_host_alias] = config[:s3_host_alias] unless config[:s3_host_alias].blank?
           end
         end
       end


### PR DESCRIPTION
My apologies for the duplicate pull requests. Did not add the option to the image model and s3_support lib/core files.
