### PR TITLE
add :ignore_types option to flash_messages

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -95,8 +95,10 @@ module Spree
       link_to image_tag(image_path), root_path
     end
 
-    def flash_messages
-      flash.each do |msg_type, text|
+    def flash_messages(opts = {})
+      flash.reject{|msg_type, text|
+        opts[:ignore_types] && opts[:ignore_types].include?(msg_type)
+      }.each do |msg_type, text|
         concat(content_tag :div, text, :class => "flash #{msg_type}") unless msg_type == :commerce_tracking
       end
       nil


### PR DESCRIPTION
From 1.1, `flash_messages` displays all flash entries.
At 1.0, `flash_messages` displays only `:notice` and `:error`.
When I update to 1.1.3, it displays unwanted flash entries that defined by me for another access tracking code(like for mixpanel).

This pull request provides `:ignore_types` option to `flash_messages`.

I found issues about `flash_message` (#1368, #1428).
It seems to be good to display all flash entries.
So this patch is not "accept types" but "ignore types".
