### PR TITLE
Use correct spree auth devise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ branches:
   only:
     - 1-0-stable
     - 1-1-stable
+    - 1-2-stable
     - master
 rvm:
   - 1.8.7

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Installation
 The fastest way to get started is by using the spree command line tool
 available in the spree gem which will add Spree to an existing Rails application.
 
-    $ gem install rails -v 3.2.7
+    $ gem install rails -v 3.2.8
     $ gem install spree
-    $ rails _3.2.7_ new my_store
+    $ rails _3.2.8_ new my_store
     $ spree install my_store
 
 This will add the Spree gem to your Gemfile, create initializers, copy migrations and

--- a/cmd/lib/spree_cmd.rb
+++ b/cmd/lib/spree_cmd.rb
@@ -4,16 +4,17 @@ require 'thor/group'
 module SpreeCmd
   class Command
 
-    if ARGV.first == 'version'
-      puts Gem.loaded_specs['spree_cmd'].version
-    elsif ARGV.first == 'extension'
-      ARGV.shift
-      require 'spree_cmd/extension'
-      SpreeCmd::Extension.start
-    else
-      ARGV.shift
-      require 'spree_cmd/installer'
-      SpreeCmd::Installer.start
+    case ARGV.first
+      when 'version' || '-v' || '--version'
+        puts Gem.loaded_specs['spree_cmd'].version
+      when 'extension'
+        ARGV.shift
+        require 'spree_cmd/extension'
+        SpreeCmd::Extension.start
+      else
+        ARGV.shift
+        require 'spree_cmd/installer'
+        SpreeCmd::Installer.start
     end
   end
 end

--- a/cmd/lib/spree_cmd/installer.rb
+++ b/cmd/lib/spree_cmd/installer.rb
@@ -1,4 +1,5 @@
 require 'rbconfig'
+require 'active_support/core_ext/string'
 
 module SpreeCmd
 
@@ -64,6 +65,12 @@ module SpreeCmd
     def ask_questions
       @install_default_gateways = ask_with_default('Would you like to install the default gateways?')
       @install_default_auth = ask_with_default('Would you like to install the default authentication system?')
+      unless @install_default_auth
+        @user_class = ask("What is the name of the class representing users within your application? [User]")
+        if @user_class.blank?
+          @user_class = "User"
+        end
+      end
 
       if options[:skip_install_data]
         @run_migrations = false
@@ -106,6 +113,7 @@ module SpreeCmd
       spree_options << "--migrate=#{@run_migrations}"
       spree_options << "--seed=#{@load_seed_data}"
       spree_options << "--sample=#{@load_sample_data}"
+      spree_options << "--user_class=#{@user_class}"
       spree_options << "--auto_accept" if options[:auto_accept]
 
       inside @app_path do

--- a/cmd/lib/spree_cmd/installer.rb
+++ b/cmd/lib/spree_cmd/installer.rb
@@ -181,10 +181,16 @@ module SpreeCmd
       end
 
       def image_magick_installed?
+        cmd = 'identify -version'
+        if RUBY_PLATFORM =~ /mswin/ #windows
+          cmd += " >nul"
+        else
+          cmd += " >/dev/null"
+        end
         # true if command executed succesfully
         # false for non zero exit status
         # nil if command execution fails
-        system('identify -version')
+        system(cmd)
       end
   end
 end

--- a/cmd/lib/spree_cmd/installer.rb
+++ b/cmd/lib/spree_cmd/installer.rb
@@ -101,7 +101,7 @@ module SpreeCmd
         end
 
         if @install_default_auth
-          gem :spree_auth_devise, :git => "git://github.com/radar/spree_auth_devise"
+          gem :spree_auth_devise, :git => "git://github.com/spree/spree_auth_devise"
         end
 
         run 'bundle install', :capture => true

--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -95,7 +95,11 @@ module Spree
       link_to image_tag(image_path), root_path
     end
 
-    def flash_messages
+    def flash_messages(opts = {})
+      flash.reject do |msg_type, text|
+        opts[:ignore_types] && opts[:ignore_types].include?(msg_type)
+      end
+
       flash.each do |msg_type, text|
         concat(content_tag :div, text, :class => "flash #{msg_type}") unless msg_type == :commerce_tracking
       end

--- a/core/lib/generators/spree/install/install_generator.rb
+++ b/core/lib/generators/spree/install/install_generator.rb
@@ -9,6 +9,7 @@ module Spree
     class_option :seed, :type => :boolean, :default => true, :banner => 'load seed data (migrations must be run)'
     class_option :sample, :type => :boolean, :default => true, :banner => 'load sample data (migrations must be run)'
     class_option :auto_accept, :type => :boolean
+    class_option :user_class, :type => :string
     class_option :admin_email, :type => :string
     class_option :admin_password, :type => :string
     class_option :lib_name, :type => :string, :default => 'spree'

--- a/core/lib/generators/spree/install/templates/config/initializers/spree.rb
+++ b/core/lib/generators/spree/install/templates/config/initializers/spree.rb
@@ -11,4 +11,4 @@ Spree.config do |config|
   # config.site_name = "Spree Demo Site"
 end
 
-Spree.user_class = "Spree::LegacyUser"
+Spree.user_class = <%= (options[:user_class] || "Spree::LegacyUser").inspect %>

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'aws-sdk', '~> 1.3.4'
   s.add_dependency 'ransack', '~> 0.6.0'
   s.add_dependency 'activemerchant', '= 1.20.4'
-  s.add_dependency 'rails', '~> 3.2.7'
+  s.add_dependency 'rails', '~> 3.2.8'
   s.add_dependency 'kaminari', '>= 0.13.0'
   s.add_dependency 'deface', '>= 0.9.0'
   s.add_dependency 'stringex', '~> 1.3.2'

--- a/sample/db/sample/spree/users.yml
+++ b/sample/db/sample/spree/users.yml
@@ -1,8 +1,0 @@
-<%
-1.upto(100) do |i|
-%>
-user_<%= i %>:
-  email: <%= Faker::Internet.email %>
-  ship_address: ship_address_<%= i %>
-  bill_address: bill_address_<%= i %>
-<% end %>


### PR DESCRIPTION
running the spree 1.2.0.rc1, the spree installer still uses the older @radar repository instead of the more up-to-date and official spree repo.
