### PR TITLE
use the official spree repository.

### DIFF
--- a/cmd/lib/spree_cmd/installer.rb
+++ b/cmd/lib/spree_cmd/installer.rb
@@ -101,7 +101,7 @@ module SpreeCmd
         end
 
         if @install_default_auth
-          gem :spree_auth_devise, :git => "git://github.com/radar/spree_auth_devise"
+          gem :spree_auth_devise, :git => "git://github.com/spree/spree_auth_devise"
         end
 
         run 'bundle install', :capture => true


### PR DESCRIPTION
forked from the 1-2-stable.. so this pull request has to go there as well.. Is this wanted behaviour? Let me know..if not.. I will branch from master then and send the pull again..

This is a small fix to make sure the spree_auth_devise gem is the official spree one and not pointing to the older radar version.
