### PR TITLE
refactor header partial to include _main_nav_bar and _nav_bar markup at same place so that easily overriden with deface

### DIFF
--- a/core/app/views/spree/shared/_header.html.erb
+++ b/core/app/views/spree/shared/_header.html.erb
@@ -1,5 +1,17 @@
 <header id="header" class="row" data-hook>
   <figure id="logo" class="columns alpha six" data-hook><%= logo %></figure>
-  <%= render :partial => 'spree/shared/nav_bar' %>
-  <%= render :partial => 'spree/shared/main_nav_bar' if store_menu? %>
+  <nav id="top-nav-bar" class="columns omega ten">
+	  <ul id="nav-bar" class="inline" data-hook>
+	    <li id="search-bar" data-hook>
+	      <%= render :partial => 'spree/shared/search' %>
+	    </li>
+	  </ul>
+	</nav>
+	<% if store_menu? %>
+	<nav class="columns alpha omega sixteen">
+	  <ul id="main-nav-bar" class="inline" data-hook>
+	    <%= render :partial => 'spree/shared/store_menu' %>
+	  </ul>
+	</nav>
+	<% end %>
 </header>

--- a/core/app/views/spree/shared/_main_nav_bar.html.erb
+++ b/core/app/views/spree/shared/_main_nav_bar.html.erb
@@ -1,6 +1,0 @@
-<nav class="columns alpha omega sixteen">
-  <ul id="main-nav-bar" class="inline" data-hook>
-    <li id="home-link" data-hook><%= link_to t(:home), root_path %></li>
-    <li id="link-to-cart" data-hook><%= link_to_cart %></li>
-  </ul>
-</nav>

--- a/core/app/views/spree/shared/_nav_bar.html.erb
+++ b/core/app/views/spree/shared/_nav_bar.html.erb
@@ -1,7 +1,0 @@
-<nav id="top-nav-bar" class="columns omega ten">
-  <ul id="nav-bar" class="inline" data-hook>
-    <li id="search-bar" data-hook>
-      <%= render :partial => 'spree/shared/search' %>
-    </li>
-  </ul>
-</nav>

--- a/core/app/views/spree/shared/_store_menu.html.erb
+++ b/core/app/views/spree/shared/_store_menu.html.erb
@@ -1,0 +1,2 @@
+<li id="home-link" data-hook><%= link_to t(:home), root_path %></li>
+<li id="link-to-cart" data-hook><%= link_to_cart %></li>


### PR DESCRIPTION
It is common requirement where people might want to add links from/to nav_bar to/from main_nav_bar. So if they all at same place which header than easily overridden using deface.
