### PR TITLE
Change price fields to handle locale values properly

### DIFF
--- a/core/app/views/spree/admin/variants/_form.html.erb
+++ b/core/app/views/spree/admin/variants/_form.html.erb
@@ -21,10 +21,10 @@
       <%= f.text_field :sku %></p>
 
       <p data-hook="price"><%= f.label :price, t(:price) %>:<br />
-      <%= f.text_field :price, :value => number_with_precision(@variant.price, :precision => 2) %></p>
+      <%= f.text_field :price, :value => number_to_currency(@variant.price, :unit => '') %></p>
 
       <p data-hook="cost_price"><%= f.label :cost_price, t(:cost_price) %>:<br />
-      <%= f.text_field :cost_price, :value => number_with_precision(@variant.cost_price, :precision => 2) %></p>
+      <%= f.text_field :cost_price, :value => number_to_currency(@variant.cost_price, :unit => '') %></p>
 
     <% if Spree::Config[:track_inventory_levels] %>
       <p data-hook="on_hand"><%= f.label :on_hand, t(:on_hand) %>: <br />


### PR DESCRIPTION
When en-GB is selected as a locale, and the internationalisation instructions are followed, the variant price fields (price and cost_price) show the wrong value on edit.

When the price is 9.99 they are showing 999 - which means on save they become 999.00.

Have changed the text_fields to use the same number method as the product edit page.

Not sure how to write a test for this, but can reproduce on a couple of sandbox installs here.
