### PR TITLE
Bump ActiveMerchant to version 1.27.0

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'paperclip', '~> 2.7'
   s.add_dependency 'aws-sdk', '~> 1.3.4'
   s.add_dependency 'ransack', '~> 0.7.0'
-  s.add_dependency 'activemerchant', '= 1.20.4'
+  s.add_dependency 'activemerchant', '= 1.27.0'
   s.add_dependency 'rails', '~> 3.2.8'
   s.add_dependency 'kaminari', '>= 0.13.0'
   s.add_dependency 'deface', '>= 0.9.0'


### PR DESCRIPTION
Using latest ActiveMerchant version to encompass a change for Elavon gateway:
https://github.com/Shopify/active_merchant/pull/320

PS - First pull request, so please let me know if I should be doing things a certain way.
