### PR TITLE
Fix for inaccurate shipment confirmation email

### DIFF
--- a/core/app/views/spree/shipment_mailer/shipped_email.text.erb
+++ b/core/app/views/spree/shipment_mailer/shipped_email.text.erb
@@ -5,7 +5,7 @@ Your order has been shipped
 ============================================================
 Shipment Summary
 ============================================================
-<% @shipment.line_items.each do |item| %>
+<% @shipment.manifest.each do |item| %>
   <%= item.variant.sku %> <%= item.variant.product.name %> <%= variant_options(item.variant, :include_style => false) %> (<%= item.quantity %>)
 <% end %>
 ============================================================


### PR DESCRIPTION
if `Spree::Config[:track_inventory_levels] = false` then all items will be included in the shipment notification regardless of if they are included in the shipment or not.

`Shipment#manifest` instead of `Shipment#line_items` seems like it should fix the issue.
