### PR TITLE
Fixed broken request/checkout_spec [Fix #1868]

### DIFF
--- a/core/app/assets/javascripts/store/cart.js.coffee
+++ b/core/app/assets/javascripts/store/cart.js.coffee
@@ -1,6 +1,6 @@
 $ ->
   if ($ 'form#update-cart').is('*')
-    ($ 'form#update-cart a.delete').show().on 'click' ->
+    ($ 'form#update-cart a.delete').show().on 'click', (e) ->
       ($ this).parents('.line-item').first().find('input.line_item_quantity').val 0
       ($ this).parents('form').first().submit()
       false


### PR DESCRIPTION
It appears to me that some javascript refactoring took out a couple of required characters.
