### PR TITLE
Orders unfulfilled filter

### DIFF
--- a/core/app/controllers/spree/admin/orders_controller.rb
+++ b/core/app/controllers/spree/admin/orders_controller.rb
@@ -20,6 +20,8 @@ module Spree
         created_at_gt = params[:q][:created_at_gt]
         created_at_lt = params[:q][:created_at_lt]
 
+        params[:q].delete(:inventory_units_shipment_id_null) if params[:q][:inventory_units_shipment_id_null] == "0"
+
         if !params[:q][:created_at_gt].blank?
           params[:q][:created_at_gt] = Time.zone.parse(params[:q][:created_at_gt]).beginning_of_day rescue ""
         end
@@ -34,7 +36,7 @@ module Spree
         end
 
         @search = Order.ransack(params[:q])
-        @orders = @search.result.includes([:user, :shipments, :payments]).page(params[:page]).per(Spree::Config[:orders_per_page])
+        @orders = @search.result(:distinct => true).includes([:user, :shipments, :payments]).page(params[:page]).per(Spree::Config[:orders_per_page])
 
         # Restore dates
         params[:q][:created_at_gt] = created_at_gt

--- a/core/app/views/spree/admin/orders/index.html.erb
+++ b/core/app/views/spree/admin/orders/index.html.erb
@@ -82,6 +82,10 @@
         <%= f.check_box :completed_at_not_null, {:checked => @show_only_completed}, '1', '' %>
         <%= label_tag nil, t(:show_only_complete_orders) %>
       </p>
+      <p>
+        <%= f.check_box :inventory_units_shipment_id_null, { }, '1', '0' %>
+        <%= label_tag nil, t(:show_only_unfulfilled_orders) %>
+      </p>
       <div data-hook="admin_orders_index_search_buttons">
         <p><%= button t(:search) %></p>
       </div>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -929,6 +929,7 @@ en:
   show_incomplete_orders: "Show Incomplete Orders"
   show_only_complete_orders: "Only show complete orders"
   show_out_of_stock_products: "Show out-of-stock products"
+  show_only_unfulfilled_orders: "Show only unfulfilled orders"
   showing_first_n: "Showing first %{n}"
   sign_up: "Sign up"
   site_name: "Site Name"


### PR DESCRIPTION
In my situation:  
- we have accepted pre-orders for a product
- orders have come in for that product, but customers have ordered other in-stock products alongside the pre-order product
- the pre-order product comes in, but there is no easy way of finding orders that haven't been completely fufilled

This adds a filter to the orders admin to easily locate orders with unshipped inventory items. I delete the filter if false to eliminate unneeded SQL query additions. 

I'm new to ransack, but I _think_ `:distinct => true` shouldn't mess with any existing queries since all results should have distinct order ids to begin with.
