### PR TITLE
Support spree_roles method that's been modified outside of spree

### DIFF
--- a/core/config/initializers/user_class_extensions.rb
+++ b/core/config/initializers/user_class_extensions.rb
@@ -14,7 +14,7 @@ Spree::Core::Engine.config.to_prepare do
 
       # has_spree_role? simply needs to return true or false whether a user has a role or not.
       def has_spree_role?(role_in_question)
-        spree_roles.where(:name => role_in_question.to_s).any?
+        spree_roles.any?{ |r| r.name == role_in_question.to_s.camelize || r.name == role_in_question.to_s }
       end
 
       def last_incomplete_spree_order


### PR DESCRIPTION
If the `spree_roles` method gets modified outside of spree and if it's not an activerecord object, the `where` method doesn't work.

i.e: http://git.io/NSuJNA

Since the auth is decoupled, will a generic method be more meaningful? Or this has to be shipped along with 3rd party `spree_roles` code?
