### PR TITLE
Add Date Completed Display to orders#show

### DIFF
--- a/core/app/views/spree/admin/shared/_order_tabs.html.erb
+++ b/core/app/views/spree/admin/shared/_order_tabs.html.erb
@@ -8,6 +8,7 @@
     <% if @order.completed? %>
       <h5 id="shipment_status"><%= t(:shipment) %>: <%= t(@order.shipment_state, :scope => :shipment_state, :default => [:missing, "none"]) %></h5>
       <h5 id="payment_status"><%= t(:payment) %>: <%= t(@order.payment_state, :scope => :payment_states, :default => [:missing, "none"]) %></h5>
+      <h5 id="date_completed" style="width:100%; float:none;" data-hook><%= t(:date_completed) %>: <%= (@order.completed? ? @order.completed_at : @order.created_at).to_datetime.to_s(:db) %></h5>
     <% end %>
     <br class="clear" />
   </div>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -339,6 +339,7 @@ en:
   customer_details_updated: "The customer's details have been updated."
   customer_search: "Customer Search"
   date_created: Date created
+  date_completed: Date Completed
   date_range: "Date Range"
   debit: Debit
   default: Default


### PR DESCRIPTION
This helps in backend order administration + customer support. Without this the admin has to go to the order history, or search for the order and look at the time in the table view. 
