### PR TITLE
Strip all non-numeric characters from credit card input

### DIFF
--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -14,6 +14,10 @@ module Spree
     attr_accessible :first_name, :last_name, :number, :verification_value, :year,
                     :month, :gateway_customer_profile_id, :gateway_payment_profile_id
 
+    def number=(num)
+      @number = num.gsub(/[^0-9]/, '') rescue nil
+    end
+    
     def set_last_digits
       number.to_s.gsub!(/\s/,'')
       verification_value.to_s.gsub!(/\s/,'')

--- a/core/spec/models/credit_card_spec.rb
+++ b/core/spec/models/credit_card_spec.rb
@@ -191,5 +191,20 @@ describe Spree::CreditCard do
       credit_card.spree_cc_type.should == "master"
     end
   end
+
+  context "#number=" do
+    it "should strip non-numeric characters from card input" do
+      credit_card.number = "6011000990139424"
+      credit_card.number.should == "6011000990139424"
+
+      credit_card.number = "  6011-0009-9013-9424  "
+      credit_card.number.should == "6011000990139424"
+    end
+
+    it "should not raise an exception on non-string input" do
+      credit_card.number = Hash.new
+      credit_card.number.should be_nil
+    end
+  end
 end
 


### PR DESCRIPTION
There is no instructions on the payment form indicating that the credit card number must be entered without any additional characters (e.g. hyphens). 

From a UX POV I think it makes sense to eliminate all non-numeric characters from credit card input. 
