### PR TITLE
"invalid byte sequence in US-ASCII" in *.js.erb files

### DIFF
--- a/core/app/assets/javascripts/admin/admin.js.erb
+++ b/core/app/assets/javascripts/admin/admin.js.erb
@@ -1,4 +1,4 @@
-<%# @encoding:UTF-8 %>
+<%# encoding: UTF-8 %>
 
 //= require_self
 //= require admin/product_autocomplete

--- a/core/app/assets/javascripts/admin/admin.js.erb
+++ b/core/app/assets/javascripts/admin/admin.js.erb
@@ -1,5 +1,4 @@
-<%# encoding: UTF-8 %>
-
+//<%#encoding: UTF-8%>
 //= require_self
 //= require admin/product_autocomplete
 //= require select2

--- a/core/app/assets/javascripts/admin/admin.js.erb
+++ b/core/app/assets/javascripts/admin/admin.js.erb
@@ -1,3 +1,5 @@
+<%# @encoding:UTF-8 %>
+
 //= require_self
 //= require admin/product_autocomplete
 //= require select2

--- a/core/app/assets/javascripts/admin/product_autocomplete.js.erb
+++ b/core/app/assets/javascripts/admin/product_autocomplete.js.erb
@@ -1,5 +1,4 @@
-<%# encoding: UTF-8 %>
-
+//<%#encoding: UTF-8%>
 // Product autocompletion
 image_html = function(item){
   return "<img src='" + item['images'][0]["mini_url"] + "'/>";

--- a/core/app/assets/javascripts/admin/product_autocomplete.js.erb
+++ b/core/app/assets/javascripts/admin/product_autocomplete.js.erb
@@ -1,3 +1,5 @@
+<%# @encoding:UTF-8 %>
+
 // Product autocompletion
 image_html = function(item){
   return "<img src='" + item['images'][0]["mini_url"] + "'/>";

--- a/core/app/assets/javascripts/admin/product_autocomplete.js.erb
+++ b/core/app/assets/javascripts/admin/product_autocomplete.js.erb
@@ -1,4 +1,4 @@
-<%# @encoding:UTF-8 %>
+<%# encoding: UTF-8 %>
 
 // Product autocompletion
 image_html = function(item){


### PR DESCRIPTION
``` log
ActionView::Template::Error (invalid byte sequence in US-ASCII
  (in bundler/gems/spree-1cea3feb8999/core/app/assets/javascripts/admin/admin.js.erb)):
    4: <%= t(controller.controller_name, :default => controller.controller_name.titleize) %></title>
    5: 
    6: <%= stylesheet_link_tag 'admin/all' %>
    7: <%= javascript_include_tag 'admin/all' %>
    8: 
    9: <%= javascript_tag do %>
    10:   Spree.routes = <%== {
  sprockets (2.1.3) lib/sprockets/safety_colons.rb:20:in `evaluate'
  tilt (1.3.3) lib/tilt/template.rb:76:in `render'
  sprockets (2.1.3) lib/sprockets/context.rb:177:in `block in evaluate'
  sprockets (2.1.3) lib/sprockets/context.rb:174:in `each'
  sprockets (2.1.3) lib/sprockets/context.rb:174:in `evaluate'
  sprockets (2.1.3) lib/sprockets/processed_asset.rb:12:in `initialize'
  sprockets (2.1.3) lib/sprockets/base.rb:241:in `new'
  sprockets (2.1.3) lib/sprockets/base.rb:241:in `block in build_asset'
  sprockets (2.1.3) lib/sprockets/base.rb:262:in `circular_call_protection'
  sprockets (2.1.3) lib/sprockets/base.rb:240:in `build_asset'
  sprockets (2.1.3) lib/sprockets/index.rb:89:in `block in build_asset'
  sprockets (2.1.3) lib/sprockets/caching.rb:19:in `cache_asset'
  sprockets (2.1.3) lib/sprockets/index.rb:88:in `build_asset'
  sprockets (2.1.3) lib/sprockets/base.rb:163:in `find_asset'
  sprockets (2.1.3) lib/sprockets/index.rb:56:in `find_asset'
  sprockets (2.1.3) lib/sprockets/processed_asset.rb:106:in `block in build_required_assets'
  sprockets (2.1.3) lib/sprockets/processed_asset.rb:100:in `each'
  sprockets (2.1.3) lib/sprockets/processed_asset.rb:100:in `build_required_assets'
  sprockets (2.1.3) lib/sprockets/processed_asset.rb:16:in `initialize'
  sprockets (2.1.3) lib/sprockets/base.rb:241:in `new'
  sprockets (2.1.3) lib/sprockets/base.rb:241:in `block in build_asset'
  sprockets (2.1.3) lib/sprockets/base.rb:262:in `circular_call_protection'
  sprockets (2.1.3) lib/sprockets/base.rb:240:in `build_asset'
  sprockets (2.1.3) lib/sprockets/index.rb:89:in `block in build_asset'
  sprockets (2.1.3) lib/sprockets/caching.rb:19:in `cache_asset'
  sprockets (2.1.3) lib/sprockets/index.rb:88:in `build_asset'
  sprockets (2.1.3) lib/sprockets/base.rb:163:in `find_asset'
  sprockets (2.1.3) lib/sprockets/index.rb:56:in `find_asset'
  sprockets (2.1.3) lib/sprockets/processed_asset.rb:106:in `block in build_required_assets'
  sprockets (2.1.3) lib/sprockets/processed_asset.rb:100:in `each'
  sprockets (2.1.3) lib/sprockets/processed_asset.rb:100:in `build_required_assets'
  sprockets (2.1.3) lib/sprockets/processed_asset.rb:16:in `initialize'
  sprockets (2.1.3) lib/sprockets/base.rb:241:in `new'
  sprockets (2.1.3) lib/sprockets/base.rb:241:in `block in build_asset'
  sprockets (2.1.3) lib/sprockets/base.rb:262:in `circular_call_protection'
  sprockets (2.1.3) lib/sprockets/base.rb:240:in `build_asset'
  sprockets (2.1.3) lib/sprockets/index.rb:89:in `block in build_asset'
  sprockets (2.1.3) lib/sprockets/caching.rb:19:in `cache_asset'
  sprockets (2.1.3) lib/sprockets/index.rb:88:in `build_asset'
  sprockets (2.1.3) lib/sprockets/base.rb:163:in `find_asset'
  sprockets (2.1.3) lib/sprockets/index.rb:56:in `find_asset'
  sprockets (2.1.3) lib/sprockets/bundled_asset.rb:38:in `init_with'
  sprockets (2.1.3) lib/sprockets/asset.rb:24:in `from_hash'
  sprockets (2.1.3) lib/sprockets/caching.rb:15:in `cache_asset'
  sprockets (2.1.3) lib/sprockets/index.rb:88:in `build_asset'
  sprockets (2.1.3) lib/sprockets/base.rb:163:in `find_asset'
  sprockets (2.1.3) lib/sprockets/index.rb:56:in `find_asset'
  sprockets (2.1.3) lib/sprockets/environment.rb:74:in `find_asset'
  sprockets (2.1.3) lib/sprockets/base.rb:171:in `[]'
  actionpack (3.2.8) lib/sprockets/helpers/rails_helper.rb:126:in `asset_for'
  actionpack (3.2.8) lib/sprockets/helpers/rails_helper.rb:27:in `block in javascript_include_tag'
  actionpack (3.2.8) lib/sprockets/helpers/rails_helper.rb:26:in `collect'
  actionpack (3.2.8) lib/sprockets/helpers/rails_helper.rb:26:in `javascript_include_tag'
  /home/ss/.rvm/gems/ruby-1.9.3-p0-falcon/bundler/gems/spree-1cea3feb8999/core/app/views/spree/admin/shared/_head.html.erb:7:in `_8bda54766daf8e8cd7d85351c1875a0c'
  actionpack (3.2.8) lib/action_view/template.rb:145:in `block in render'
  activesupport (3.2.8) lib/active_support/notifications.rb:125:in `instrument'
  actionpack (3.2.8) lib/action_view/template.rb:143:in `render'
  /home/ss/.rvm/gems/ruby-1.9.3-p0-falcon/bundler/gems/deface-a1214adb5650/lib/deface/action_view_extensions.rb:37:in `render'
  actionpack (3.2.8) lib/action_view/renderer/partial_renderer.rb:265:in `render_partial'
  actionpack (3.2.8) lib/action_view/renderer/partial_renderer.rb:238:in `block in render'
  actionpack (3.2.8) lib/action_view/renderer/abstract_renderer.rb:38:in `block in instrument'
  activesupport (3.2.8) lib/active_support/notifications.rb:123:in `block in instrument'
  activesupport (3.2.8) lib/active_support/notifications/instrumenter.rb:20:in `instrument'
  activesupport (3.2.8) lib/active_support/notifications.rb:123:in `instrument'
  actionpack (3.2.8) lib/action_view/renderer/abstract_renderer.rb:38:in `instrument'
  actionpack (3.2.8) lib/action_view/renderer/partial_renderer.rb:237:in `render'
  actionpack (3.2.8) lib/action_view/renderer/renderer.rb:41:in `render_partial'
  actionpack (3.2.8) lib/action_view/renderer/renderer.rb:15:in `render'
  actionpack (3.2.8) lib/action_view/helpers/rendering_helper.rb:24:in `render'
  haml (3.1.7) lib/haml/helpers/action_view_mods.rb:13:in `render_with_haml'
  /home/ss/.rvm/gems/ruby-1.9.3-p0-falcon/bundler/gems/spree-1cea3feb8999/core/app/views/spree/layouts/admin.html.erb:5:in `_3e7f25ea7bfb05156b43f64a183d1e13'
  actionpack (3.2.8) lib/action_view/template.rb:145:in `block in render'
  activesupport (3.2.8) lib/active_support/notifications.rb:125:in `instrument'
  actionpack (3.2.8) lib/action_view/template.rb:143:in `render'
  /home/ss/.rvm/gems/ruby-1.9.3-p0-falcon/bundler/gems/deface-a1214adb5650/lib/deface/action_view_extensions.rb:37:in `render'
  actionpack (3.2.8) lib/action_view/renderer/template_renderer.rb:59:in `render_with_layout'
  actionpack (3.2.8) lib/action_view/renderer/template_renderer.rb:45:in `render_template'
  actionpack (3.2.8) lib/action_view/renderer/template_renderer.rb:18:in `render'
  actionpack (3.2.8) lib/action_view/renderer/renderer.rb:36:in `render_template'
  actionpack (3.2.8) lib/action_view/renderer/renderer.rb:17:in `render'
  actionpack (3.2.8) lib/abstract_controller/rendering.rb:110:in `_render_template'
  actionpack (3.2.8) lib/action_controller/metal/streaming.rb:225:in `_render_template'
  actionpack (3.2.8) lib/abstract_controller/rendering.rb:103:in `render_to_body'
  actionpack (3.2.8) lib/action_controller/metal/renderers.rb:28:in `render_to_body'
  actionpack (3.2.8) lib/action_controller/metal/compatibility.rb:50:in `render_to_body'
  actionpack (3.2.8) lib/abstract_controller/rendering.rb:88:in `render'
  actionpack (3.2.8) lib/action_controller/metal/rendering.rb:16:in `render'
  actionpack (3.2.8) lib/action_controller/metal/instrumentation.rb:40:in `block (2 levels) in render'
  activesupport (3.2.8) lib/active_support/core_ext/benchmark.rb:5:in `block in ms'
  /home/ss/.rvm/rubies/ruby-1.9.3-p0-falcon/lib/ruby/1.9.1/benchmark.rb:295:in `realtime'
  activesupport (3.2.8) lib/active_support/core_ext/benchmark.rb:5:in `ms'
  actionpack (3.2.8) lib/action_controller/metal/instrumentation.rb:40:in `block in render'
  actionpack (3.2.8) lib/action_controller/metal/instrumentation.rb:83:in `cleanup_view_runtime'
  activerecord (3.2.8) lib/active_record/railties/controller_runtime.rb:24:in `cleanup_view_runtime'
  actionpack (3.2.8) lib/action_controller/metal/instrumentation.rb:39:in `render'
  actionpack (3.2.8) lib/action_controller/metal/implicit_render.rb:10:in `default_render'
  actionpack (3.2.8) lib/action_controller/metal/implicit_render.rb:5:in `send_action'
  actionpack (3.2.8) lib/abstract_controller/base.rb:167:in `process_action'
  actionpack (3.2.8) lib/action_controller/metal/rendering.rb:10:in `process_action'
  actionpack (3.2.8) lib/abstract_controller/callbacks.rb:18:in `block in process_action'
  activesupport (3.2.8) lib/active_support/callbacks.rb:469:in `_run__776013593__process_action__510233007__callbacks'
  activesupport (3.2.8) lib/active_support/callbacks.rb:405:in `__run_callback'
  activesupport (3.2.8) lib/active_support/callbacks.rb:385:in `_run_process_action_callbacks'
  activesupport (3.2.8) lib/active_support/callbacks.rb:81:in `run_callbacks'
  actionpack (3.2.8) lib/abstract_controller/callbacks.rb:17:in `process_action'
  actionpack (3.2.8) lib/action_controller/metal/rescue.rb:29:in `process_action'
  actionpack (3.2.8) lib/action_controller/metal/instrumentation.rb:30:in `block in process_action'
  activesupport (3.2.8) lib/active_support/notifications.rb:123:in `block in instrument'
  activesupport (3.2.8) lib/active_support/notifications/instrumenter.rb:20:in `instrument'
  activesupport (3.2.8) lib/active_support/notifications.rb:123:in `instrument'
  actionpack (3.2.8) lib/action_controller/metal/instrumentation.rb:29:in `process_action'
  actionpack (3.2.8) lib/action_controller/metal/params_wrapper.rb:207:in `process_action'
  activerecord (3.2.8) lib/active_record/railties/controller_runtime.rb:18:in `process_action'
  actionpack (3.2.8) lib/abstract_controller/base.rb:121:in `process'
  actionpack (3.2.8) lib/abstract_controller/rendering.rb:45:in `process'
  actionpack (3.2.8) lib/action_controller/metal.rb:203:in `dispatch'
  actionpack (3.2.8) lib/action_controller/metal/rack_delegation.rb:14:in `dispatch'
  actionpack (3.2.8) lib/action_controller/metal.rb:246:in `block in action'
  actionpack (3.2.8) lib/action_dispatch/routing/route_set.rb:73:in `call'
  actionpack (3.2.8) lib/action_dispatch/routing/route_set.rb:73:in `dispatch'
  actionpack (3.2.8) lib/action_dispatch/routing/route_set.rb:36:in `call'
  journey (1.0.4) lib/journey/router.rb:68:in `block in call'
  journey (1.0.4) lib/journey/router.rb:56:in `each'
  journey (1.0.4) lib/journey/router.rb:56:in `call'
  actionpack (3.2.8) lib/action_dispatch/routing/route_set.rb:600:in `call'
  /home/ss/.rvm/gems/ruby-1.9.3-p0-falcon/bundler/gems/spree-1cea3feb8999/core/lib/spree/core/middleware/redirect_legacy_product_url.rb:13:in `call'
  /home/ss/.rvm/gems/ruby-1.9.3-p0-falcon/bundler/gems/spree-1cea3feb8999/core/lib/spree/core/middleware/seo_assist.rb:27:in `call'
  railties (3.2.8) lib/rails/engine.rb:479:in `call'
  railties (3.2.8) lib/rails/railtie/configurable.rb:30:in `method_missing'
  journey (1.0.4) lib/journey/router.rb:68:in `block in call'
  journey (1.0.4) lib/journey/router.rb:56:in `each'
  journey (1.0.4) lib/journey/router.rb:56:in `call'
  actionpack (3.2.8) lib/action_dispatch/routing/route_set.rb:600:in `call'
  warden (1.1.1) lib/warden/manager.rb:35:in `block in call'
  warden (1.1.1) lib/warden/manager.rb:34:in `catch'
  warden (1.1.1) lib/warden/manager.rb:34:in `call'
  actionpack (3.2.8) lib/action_dispatch/middleware/best_standards_support.rb:17:in `call'
  rack (1.4.1) lib/rack/etag.rb:23:in `call'
  rack (1.4.1) lib/rack/conditionalget.rb:25:in `call'
  actionpack (3.2.8) lib/action_dispatch/middleware/head.rb:14:in `call'
  actionpack (3.2.8) lib/action_dispatch/middleware/params_parser.rb:21:in `call'
  actionpack (3.2.8) lib/action_dispatch/middleware/flash.rb:242:in `call'
  rack (1.4.1) lib/rack/session/abstract/id.rb:205:in `context'
  rack (1.4.1) lib/rack/session/abstract/id.rb:200:in `call'
  actionpack (3.2.8) lib/action_dispatch/middleware/cookies.rb:339:in `call'
  activerecord (3.2.8) lib/active_record/query_cache.rb:64:in `call'
  activerecord (3.2.8) lib/active_record/connection_adapters/abstract/connection_pool.rb:473:in `call'
  actionpack (3.2.8) lib/action_dispatch/middleware/callbacks.rb:28:in `block in call'
  activesupport (3.2.8) lib/active_support/callbacks.rb:405:in `_run__579880326__call__657129871__callbacks'
  activesupport (3.2.8) lib/active_support/callbacks.rb:405:in `__run_callback'
  activesupport (3.2.8) lib/active_support/callbacks.rb:385:in `_run_call_callbacks'
  activesupport (3.2.8) lib/active_support/callbacks.rb:81:in `run_callbacks'
  actionpack (3.2.8) lib/action_dispatch/middleware/callbacks.rb:27:in `call'
  actionpack (3.2.8) lib/action_dispatch/middleware/reloader.rb:65:in `call'
  actionpack (3.2.8) lib/action_dispatch/middleware/remote_ip.rb:31:in `call'
  actionpack (3.2.8) lib/action_dispatch/middleware/debug_exceptions.rb:16:in `call'
  actionpack (3.2.8) lib/action_dispatch/middleware/show_exceptions.rb:56:in `call'
  railties (3.2.8) lib/rails/rack/logger.rb:26:in `call_app'
  railties (3.2.8) lib/rails/rack/logger.rb:16:in `call'
  actionpack (3.2.8) lib/action_dispatch/middleware/request_id.rb:22:in `call'
  rack (1.4.1) lib/rack/methodoverride.rb:21:in `call'
  rack (1.4.1) lib/rack/runtime.rb:17:in `call'
  activesupport (3.2.8) lib/active_support/cache/strategy/local_cache.rb:72:in `call'
  rack (1.4.1) lib/rack/lock.rb:15:in `call'
  actionpack (3.2.8) lib/action_dispatch/middleware/static.rb:62:in `call'
  railties (3.2.8) lib/rails/engine.rb:479:in `call'
  railties (3.2.8) lib/rails/application.rb:223:in `call'
  railties (3.2.8) lib/rails/railtie/configurable.rb:30:in `method_missing'
  passenger (3.0.11) lib/phusion_passenger/rack/request_handler.rb:96:in `process_request'
  passenger (3.0.11) lib/phusion_passenger/abstract_request_handler.rb:513:in `accept_and_process_next_request'
  passenger (3.0.11) lib/phusion_passenger/abstract_request_handler.rb:274:in `main_loop'
  passenger (3.0.11) lib/phusion_passenger/rack/application_spawner.rb:206:in `start_request_handler'
  passenger (3.0.11) lib/phusion_passenger/rack/application_spawner.rb:171:in `block in handle_spawn_application'
  passenger (3.0.11) lib/phusion_passenger/utils.rb:479:in `safe_fork'
  passenger (3.0.11) lib/phusion_passenger/rack/application_spawner.rb:166:in `handle_spawn_application'
  passenger (3.0.11) lib/phusion_passenger/abstract_server.rb:357:in `server_main_loop'
  passenger (3.0.11) lib/phusion_passenger/abstract_server.rb:206:in `start_synchronously'
  passenger (3.0.11) lib/phusion_passenger/abstract_server.rb:180:in `start'
  passenger (3.0.11) lib/phusion_passenger/rack/application_spawner.rb:129:in `start'
  passenger (3.0.11) lib/phusion_passenger/spawn_manager.rb:253:in `block (2 levels) in spawn_rack_application'
  passenger (3.0.11) lib/phusion_passenger/abstract_server_collection.rb:132:in `lookup_or_add'
  passenger (3.0.11) lib/phusion_passenger/spawn_manager.rb:246:in `block in spawn_rack_application'
  passenger (3.0.11) lib/phusion_passenger/abstract_server_collection.rb:82:in `block in synchronize'
  <internal:prelude>:10:in `synchronize'
  passenger (3.0.11) lib/phusion_passenger/abstract_server_collection.rb:79:in `synchronize'
  passenger (3.0.11) lib/phusion_passenger/spawn_manager.rb:244:in `spawn_rack_application'
  passenger (3.0.11) lib/phusion_passenger/spawn_manager.rb:137:in `spawn_application'
  passenger (3.0.11) lib/phusion_passenger/spawn_manager.rb:275:in `handle_spawn_application'
  passenger (3.0.11) lib/phusion_passenger/abstract_server.rb:357:in `server_main_loop'
  passenger (3.0.11) lib/phusion_passenger/abstract_server.rb:206:in `start_synchronously'
  passenger (3.0.11) helper-scripts/passenger-spawn-server:99:in `<main>'


  Rendered /home/ss/.rvm/gems/ruby-1.9.3-p0-falcon/gems/actionpack-3.2.8/lib/action_dispatch/middleware/templates/rescues/_trace.erb (1.5ms)
  Rendered /home/ss/.rvm/gems/ruby-1.9.3-p0-falcon/gems/actionpack-3.2.8/lib/action_dispatch/middleware/templates/rescues/_request_and_response.erb (0.9ms)
  Rendered /home/ss/.rvm/gems/ruby-1.9.3-p0-falcon/gems/actionpack-3.2.8/lib/action_dispatch/middleware/templates/rescues/template_error.erb within rescues/layout (10.0ms)
```
# application.rb

``` ruby
require File.expand_path('../boot', __FILE__)

require 'rails/all'

if defined?(Bundler)
  # If you precompile assets before deploying to production, use this line
  Bundler.require(*Rails.groups(:assets => %w(development test)))
  # If you want your assets lazily compiled in production, use this line
  # Bundler.require(:default, :assets, Rails.env)
end

module SvetotechnicRu
  class Application < Rails::Application
    config.sass.preferred_syntax = :sass    
    config.to_prepare do
      # Load application's model / class decorators
      Dir.glob(File.join(File.dirname(__FILE__), "../app/**/*_decorator*.rb")) do |c|
        Rails.configuration.cache_classes ? require(c) : load(c)
      end

      # Load application's view overrides
      Dir.glob(File.join(File.dirname(__FILE__), "../app/overrides/*.rb")) do |c|
        Rails.configuration.cache_classes ? require(c) : load(c)
      end
    end

    # Settings in config/environments/* take precedence over those specified here.
    # Application configuration should go into files in config/initializers
    # -- all .rb files in that directory are automatically loaded.

    # Custom directories with classes and modules you want to be autoloadable.
    # config.autoload_paths += %W(#{config.root}/extras)

    # Only load the plugins named here, in the order given (default is alphabetical).
    # :all can be used as a placeholder for all plugins not explicitly named.
    # config.plugins = [ :exception_notification, :ssl_requirement, :all ]

    # Activate observers that should always be running.
    # config.active_record.observers = :cacher, :garbage_collector, :forum_observer

    # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
    # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
    # config.time_zone = 'Central Time (US & Canada)'

    # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
    # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
    config.i18n.default_locale = :ru

    # Configure the default encoding used in templates for Ruby 1.9.
    config.encoding = "utf-8"

    # Configure sensitive parameters which will be filtered from the log file.
    config.filter_parameters += [:password]

    # Enable escaping HTML in JSON.
    config.active_support.escape_html_entities_in_json = true

    # Use SQL instead of Active Record's schema dumper when creating the database.
    # This is necessary if your schema can't be completely dumped by the schema dumper,
    # like if you have constraints or database-specific column types
    # config.active_record.schema_format = :sql

    # Enforce whitelist mode for mass assignment.
    # This will create an empty whitelist of attributes available for mass-assignment for all models
    # in your app. As such, your models will need to explicitly whitelist or blacklist accessible
    # parameters by using an attr_accessible or attr_protected declaration.
    config.active_record.whitelist_attributes = true

    # Enable the asset pipeline
    config.assets.enabled = true

    # Version of your assets, change this if you want to expire all your assets
    config.assets.version = '1.0'
  end
end
```
