### PR TITLE
Make spree e-mails translatable. issue #1880

### DIFF
--- a/core/app/views/spree/order_mailer/cancel_email.text.erb
+++ b/core/app/views/spree/order_mailer/cancel_email.text.erb
@@ -1,16 +1,16 @@
-Dear Customer,
+<%= t('order_mailer.cancel_email.dear_customer') %>
 
-Your order has been CANCELED.  Please retain this cancellation information for your records.
+<%= t('order_mailer.cancel_email.instructions') %>
 
 ============================================================
-Order Summary [CANCELED]
+<%= t('order_mailer.cancel_email.order_summary_canceled') %>
 ============================================================
 <% @order.line_items.each do |item| %>
   <%= item.variant.sku %> <%= raw(item.variant.product.name) %> <%= raw(item.variant.options_text) -%> (<%=item.quantity%>) @ <%= number_to_currency item.price %> = <%= number_to_currency(item.price * item.quantity) %>
 <% end %>
 ============================================================
-Subtotal: <%= number_to_currency @order.item_total %>
+<%= t('order_mailer.cancel_email.subtotal') %> <%= number_to_currency @order.item_total %>
 <% @order.adjustments.eligible.each do |adjustment| %>
   <%= raw(adjustment.label) %> <%= number_to_currency(adjustment.amount) %>
 <% end %>
-Order Total: <%= number_to_currency(@order.total) %>
+<%= t('order_mailer.cancel_email.total') %> <%= number_to_currency(@order.total) %>

--- a/core/app/views/spree/order_mailer/confirm_email.text.erb
+++ b/core/app/views/spree/order_mailer/confirm_email.text.erb
@@ -1,19 +1,18 @@
-Dear Customer,
+<%= t('order_mailer.confirm_email.dear_customer') %>
 
-Please review and retain the following order information for your records.
+<%= t('order_mailer.confirm_email.instructions') %>
 
 ============================================================
-Order Summary
+<%= t('order_mailer.confirm_email.order_summary') %>
 ============================================================
 <% @order.line_items.each do |item| %>
   <%= item.variant.sku %> <%= raw(item.variant.product.name) %> <%= raw(item.variant.options_text) -%> (<%=item.quantity%>) @ <%= number_to_currency item.price %> = <%= number_to_currency(item.price * item.quantity) %>
 <% end %>
 ============================================================
-Subtotal: <%= number_to_currency @order.item_total %>
+<%= t('order_mailer.confirm_email.subtotal') %> <%= number_to_currency @order.item_total %>
 <% @order.adjustments.eligible.each do |adjustment| %>
   <%= raw(adjustment.label) %> <%= number_to_currency(adjustment.amount) %>
 <% end %>
-Order Total: <%= number_to_currency(@order.total) %>
+<%= t('order_mailer.confirm_email.total') %> <%= number_to_currency(@order.total) %>
 
-
-Thank you for your business.
+<%= t('order_mailer.confirm_email.thanks') %>

--- a/core/app/views/spree/shipment_mailer/shipped_email.text.erb
+++ b/core/app/views/spree/shipment_mailer/shipped_email.text.erb
@@ -1,15 +1,15 @@
-Dear Customer,
+<%= t('shipment_mailer.shipped_email.dear_customer') %>
 
-Your order has been shipped
+<%= t('shipment_mailer.shipped_email.instructions') %>
 
 ============================================================
-Shipment Summary
+<%= t('shipment_mailer.shipped_email.shipment_summary') %>
 ============================================================
 <% @shipment.manifest.each do |item| %>
   <%= item.variant.sku %> <%= item.variant.product.name %> <%= variant_options(item.variant) %> (<%= item.quantity %>)
 <% end %>
 ============================================================
 
-<%= "Tracking Information: #{@shipment.tracking}" if @shipment.tracking %>
+<%= t('shipment_mailer.shipped_email.track_information', :tracking => @shipment.tracking) if @shipment.tracking %>
 
-Thank you for your business.
+<%= t('shipment_mailer.shipped_email.thanks') %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -603,6 +603,12 @@ en:
   order_mailer:
     confirm_email:
       subject:  "Order Confirmation"
+      dear_customer: "Dear Customer,"
+      instructions: "Please review and retain the following order information for your records."
+      order_summary: "Order Summary"
+      subtotal: "Subtotal:"
+      total: "Order Total:"
+      thanks: "Thank you for your business."
     cancel_email:
       subject: "Cancellation of Order"
   order_not_in_system: That order number is not valid on this site.

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -903,6 +903,11 @@ en:
   shipment_mailer:
     shipped_email:
       subject: "Shipment Notification"
+      dear_customer: "Dear Customer,"
+      instructions: "Your order has been shipped"
+      shipment_summary: "Shipment Summary"
+      track_information: "Tracking Information: %{tracking}"
+      thanks: "Thank you for your business."
   shipment_number: "Shipment #"
   shipment_state: Shipment State
   shipment_states:

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -611,6 +611,11 @@ en:
       thanks: "Thank you for your business."
     cancel_email:
       subject: "Cancellation of Order"
+      dear_customer: "Dear Customer,"
+      instructions: "Your order has been CANCELED.  Please retain this cancellation information for your records."
+      order_summary_canceled: "Order Summary [CANCELED]"
+      subtotal: "Subtotal:"
+      total: "Order Total:"
   order_not_in_system: That order number is not valid on this site.
   order_number: Order
   order_operation_authorize: Authorize

--- a/core/spec/mailers/order_mailer_spec.rb
+++ b/core/spec/mailers/order_mailer_spec.rb
@@ -31,7 +31,7 @@ describe Spree::OrderMailer do
     end
 
     let!(:confirmation_email) { Spree::OrderMailer.confirm_email(order) }
-    let!(:cancel_email) { Spree::OrderMailer.confirm_email(order) }
+    let!(:cancel_email) { Spree::OrderMailer.cancel_email(order) }
 
     specify do
       confirmation_email.body.should_not include("Ineligible Adjustment")

--- a/core/spec/mailers/order_mailer_spec.rb
+++ b/core/spec/mailers/order_mailer_spec.rb
@@ -42,30 +42,52 @@ describe Spree::OrderMailer do
     end
   end
 
-  context "emails must be translatable by locale" do
-    context "en" do
+  context "emails must be translatable" do
+    context "en locale" do
       before do
-        en = { :order_mailer => { :confirm_email => { :dear_customer => 'Dear Customer,' } } }
-        I18n.backend.store_translations :en, en
+        en_confirm_mail = { :order_mailer => { :confirm_email => { :dear_customer => 'Dear Customer,' } } }
+        en_cancel_mail = { :order_mailer => { :cancel_email => { :order_summary_canceled => 'Order Summary [CANCELED]' } } }
+        I18n.backend.store_translations :en, en_confirm_mail
+        I18n.backend.store_translations :en, en_cancel_mail
         I18n.locale = :en
       end
 
-      specify do
-        confirmation_email = Spree::OrderMailer.confirm_email(order)
-        confirmation_email.body.should include("Dear Customer,")
+      context "confirm_email" do
+        specify do
+          confirmation_email = Spree::OrderMailer.confirm_email(order)
+          confirmation_email.body.should include("Dear Customer,")
+        end
+      end
+
+      context "cancel_email" do
+        specify do
+          cancel_email = Spree::OrderMailer.cancel_email(order)
+          cancel_email.body.should include("Order Summary [CANCELED]")
+        end
       end
     end
 
-    context "pt-BR" do
+    context "pt-BR locale" do
       before do
-        pt_br = { :order_mailer => { :confirm_email => { :dear_customer => 'Caro Cliente,' } } }
-        I18n.backend.store_translations :'pt-BR', pt_br
+        pt_br_confirm_mail = { :order_mailer => { :confirm_email => { :dear_customer => 'Caro Cliente,' } } }
+        pt_br_cancel_mail = { :order_mailer => { :cancel_email => { :order_summary_canceled => 'Resumo da Pedido [CANCELADA]' } } }
+        I18n.backend.store_translations :'pt-BR', pt_br_confirm_mail
+        I18n.backend.store_translations :'pt-BR', pt_br_cancel_mail
         I18n.locale = :'pt-BR'
       end
 
-      specify do
-        confirmation_email = Spree::OrderMailer.confirm_email(order)
-        confirmation_email.body.should include("Caro Cliente,")
+      context "confirm_email" do
+        specify do
+          confirmation_email = Spree::OrderMailer.confirm_email(order)
+          confirmation_email.body.should include("Caro Cliente,")
+        end
+      end
+
+      context "cancel_email" do
+        specify do
+          cancel_email = Spree::OrderMailer.cancel_email(order)
+          cancel_email.body.should include("Resumo da Pedido [CANCELADA]")
+        end
       end
     end
   end

--- a/core/spec/mailers/order_mailer_spec.rb
+++ b/core/spec/mailers/order_mailer_spec.rb
@@ -42,4 +42,31 @@ describe Spree::OrderMailer do
     end
   end
 
+  context "emails must be translatable by locale" do
+    context "en" do
+      before do
+        en = { :order_mailer => { :confirm_email => { :dear_customer => 'Dear Customer,' } } }
+        I18n.backend.store_translations :en, en
+        I18n.locale = :en
+      end
+
+      specify do
+        confirmation_email = Spree::OrderMailer.confirm_email(order)
+        confirmation_email.body.should include("Dear Customer,")
+      end
+    end
+
+    context "pt-BR" do
+      before do
+        pt_br = { :order_mailer => { :confirm_email => { :dear_customer => 'Caro Cliente,' } } }
+        I18n.backend.store_translations :'pt-BR', pt_br
+        I18n.locale = :'pt-BR'
+      end
+
+      specify do
+        confirmation_email = Spree::OrderMailer.confirm_email(order)
+        confirmation_email.body.should include("Caro Cliente,")
+      end
+    end
+  end
 end

--- a/core/spec/mailers/shipment_mailer_spec.rb
+++ b/core/spec/mailers/shipment_mailer_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+require 'email_spec'
+
+describe Spree::ShipmentMailer do
+  include EmailSpec::Helpers
+  include EmailSpec::Matchers
+
+  let!(:order) do
+    order = stub_model(Spree::Order, :backordered? => false)
+    product = stub_model(Spree::Product, :name => %Q{The "BEST" product})
+    variant = stub_model(Spree::Variant, :product => product)
+    line_item = stub_model(Spree::LineItem, :variant => variant, :order => order, :quantity => 1, :price => 5)
+    order.stub(:line_items => [line_item])
+    order
+  end
+  let(:shipping_method) { mock_model Spree::ShippingMethod, :calculator => mock('calculator') }
+  let(:shipment) do
+    shipment = Spree::Shipment.new :order => order, :shipping_method => shipping_method
+    shipment.state = 'pending'
+    shipment
+  end
+
+  context "emails must be translatable" do
+    context "shipped_email" do
+      context "en locale" do
+        before do
+          en_shipped_email = { :shipment_mailer => { :shipped_email => { :dear_customer => 'Dear Customer,' } } }
+          I18n.backend.store_translations :en, en_shipped_email
+          I18n.locale = :en
+        end
+
+        specify do
+          shipped_email = Spree::ShipmentMailer.shipped_email(shipment)
+          shipped_email.body.should include("Dear Customer,")
+        end
+      end
+      context "pt-BR locale" do
+        before do
+          pt_br_shipped_email = { :shipment_mailer => { :shipped_email => { :dear_customer => 'Caro Cliente,' } } }
+          I18n.backend.store_translations :'pt-BR', pt_br_shipped_email
+          I18n.locale = :'pt-BR'
+        end
+
+        specify do
+          shipped_email = Spree::ShipmentMailer.shipped_email(shipment)
+          shipped_email.body.should include("Caro Cliente,")
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
Added support to current e-mails, to use I18n file to translate them.

ps: I've worked on 1.1-stable branch because I am using spree 1.1.2 version, and I did not cherry-pick to master branch.
