### PR TITLE
For some windows OS which RUBY_PLATFORM is like i386-mingw32.

### DIFF
--- a/cmd/lib/spree_cmd/installer.rb
+++ b/cmd/lib/spree_cmd/installer.rb
@@ -192,7 +192,7 @@ module SpreeCmd
 
       def image_magick_installed?
         cmd = 'identify -version'
-        if RUBY_PLATFORM =~ /mswin/ #windows
+        if RUBY_PLATFORM =~ /mingw|mswin/ #windows
           cmd += " >nul"
         else
           cmd += " >/dev/null"


### PR DESCRIPTION
For some windows OS which RUBY_PLATFORM is like i386-mingw32.
My ruby is installed by RailsInstaller(http://railsinstaller.org/) which use mingw as the platform in windows.
So if the spree_cmd check the image_magick installed or not only use the 'mswin' format will failed in my enviroment.
