### PR TITLE
Fix postgres orphaned preferences SQL

### DIFF
--- a/core/config/initializers/check_for_orphaned_preferences.rb
+++ b/core/config/initializers/check_for_orphaned_preferences.rb
@@ -1,5 +1,5 @@
 begin
-  ActiveRecord::Base.connection.execute("select owner_id, owner_type, name, value from spree_preferences where `key` is null").each do |pref|
+  ActiveRecord::Base.connection.execute("select owner_id, owner_type, name, value from spree_preferences where 'key' is null").each do |pref|
     warn "[WARNING] Orphaned preference `#{pref[2]}` with value `#{pref[3]}` for #{pref[1]} with id of: #{pref[0]}, you should reset the preference value manually."
   end
 rescue


### PR DESCRIPTION
Quoting fields/reserved keywords with backticks is only allowed in MySQL, while single quotes are supported by both Postgres and MySQL.

It probably would be wisest to remove this initializer completely and use the ORM instead.
