### PR TITLE
Fix product_properties autocomplete (raw output in js)

### DIFF
--- a/core/app/views/spree/admin/product_properties/index.html.erb
+++ b/core/app/views/spree/admin/product_properties/index.html.erb
@@ -39,7 +39,7 @@
 <% end %>
 
 <%= javascript_tag do -%>
-  var properties = [<%= @properties.map{|id| "'#{id}'"}.join(', ') %>];
+  var properties = [<%= raw @properties.map{|id| "'#{id}'"}.join(', ') %>];
 
   $("#product_properties input.autocomplete").live("keydown", function(){
     already_auto_completed = $(this).is('ac_input');


### PR DESCRIPTION
The Product Properties admin UI is currently broken, because there's a syntax error in the autocomplete JS caused by escaped output. Fixed by raw output.
