### PR TITLE
added tax rate label

### DIFF
--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -20,7 +20,7 @@ module Spree
     calculated_adjustments
     scope :by_zone, lambda { |zone| where(:zone_id => zone) }
 
-    attr_accessible :amount, :tax_category_id, :calculator, :zone_id, :included_in_price
+    attr_accessible :amount, :tax_category_id, :calculator, :zone_id, :included_in_price, :name
 
     # Gets the array of TaxRates appropriate for the specified order
     def self.match(order)
@@ -73,7 +73,7 @@ module Spree
     private
 
       def create_label
-        "#{tax_category.name} #{amount * 100}%"
+        name ? name : tax_category.name
       end
   end
 end

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -20,7 +20,7 @@ module Spree
     calculated_adjustments
     scope :by_zone, lambda { |zone| where(:zone_id => zone) }
 
-    attr_accessible :amount, :tax_category_id, :calculator, :zone_id, :included_in_price, :name
+    attr_accessible :amount, :tax_category_id, :calculator, :zone_id, :included_in_price, :name, :show_rate_in_label
 
     # Gets the array of TaxRates appropriate for the specified order
     def self.match(order)
@@ -73,7 +73,7 @@ module Spree
     private
 
       def create_label
-        "#{name ? name : tax_category.name} #{amount * 100}%"
+        "#{name ? name : tax_category.name} " + (show_rate_in_label ? "#{amount * 100}%" : "")
       end
   end
 end

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -73,7 +73,7 @@ module Spree
     private
 
       def create_label
-        name ? name : tax_category.name
+        "#{name ? name : tax_category.name} #{amount * 100}%"
       end
   end
 end

--- a/core/app/views/spree/admin/tax_rates/_form.html.erb
+++ b/core/app/views/spree/admin/tax_rates/_form.html.erb
@@ -4,6 +4,10 @@
       <td><%= f.label :zone, t(:zone) %></td>
       <td><%= f.collection_select(:zone_id, @available_zones, :id, :name) %></td>
     </tr>
+    <tr data-hook="name">
+      <td><%= f.label :name, t(:name) %></td>
+      <td><%= f.text_field :name %></td>
+    </tr>
     <tr data-hook="category">
       <td><%= f.label :tax_category_id, t(:tax_category) %></td>
       <td><%= f.collection_select(:tax_category_id, @available_categories,:id, :name) %></td>

--- a/core/app/views/spree/admin/tax_rates/_form.html.erb
+++ b/core/app/views/spree/admin/tax_rates/_form.html.erb
@@ -20,6 +20,10 @@
       <td><%= f.label :amount, t(:rate) %></td>
       <td><%= f.text_field :amount %></td>
     </tr>
+    <tr data-hook="show_rate">
+      <td><%= f.label :show_rate_in_label, t(:show_rate_in_label) %></td>
+      <td><%= f.check_box :show_rate_in_label %></td>
+    </tr>
   </table>
 
   <%= render :partial => 'spree/admin/shared/calculator_fields', :locals => { :f => f } %>

--- a/core/app/views/spree/admin/tax_rates/index.html.erb
+++ b/core/app/views/spree/admin/tax_rates/index.html.erb
@@ -15,6 +15,7 @@
       <th><%= t(:category) %></th>
       <th><%= t(:amount) %></th>
       <th><%= t(:included_in_price) %></th>
+      <th><%= t(:show_rate_in_label) %></th>
       <th><%= t(:calculator) %></th>
       <th><%= t(:action) %></th>
     </tr>
@@ -27,6 +28,7 @@
       <td><%=tax_rate.tax_category.try(:name) || t(:not_available) %></td>
       <td><%=tax_rate.amount %></td>
       <td><%=tax_rate.included_in_price %></td>
+      <td><%=tax_rate.show_rate_in_label %></td>
       <td><%=tax_rate.calculator.to_s %></td>
       <td>
         <%= link_to_edit tax_rate %> &nbsp;

--- a/core/app/views/spree/admin/tax_rates/index.html.erb
+++ b/core/app/views/spree/admin/tax_rates/index.html.erb
@@ -11,6 +11,7 @@
   <thead>
     <tr data-hook="rate_header">
       <th><%= t(:zone) %></th>
+      <th><%= t(:name) %></th>
       <th><%= t(:category) %></th>
       <th><%= t(:amount) %></th>
       <th><%= t(:included_in_price) %></th>
@@ -22,6 +23,7 @@
     <% @tax_rates.each do |tax_rate|%>
     <tr id="<%= spree_dom_id tax_rate %>" data-hook="rate_row">
       <td><%=tax_rate.zone.name %></td>
+      <td><%=tax_rate.name %></td>
       <td><%=tax_rate.tax_category.try(:name) || t(:not_available) %></td>
       <td><%=tax_rate.amount %></td>
       <td><%=tax_rate.included_in_price %></td>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -108,6 +108,7 @@ en:
       spree/tax_rate:
         amount: Rate
         included_in_price: Included in Price
+        show_rate_in_label: Show rate in label
       spree/taxon:
         name: Name
         permalink: Permalink

--- a/core/db/migrate/20120905145253_add_tax_rate_label.rb
+++ b/core/db/migrate/20120905145253_add_tax_rate_label.rb
@@ -1,0 +1,5 @@
+class AddTaxRateLabel < ActiveRecord::Migration
+  def change
+    add_column :spree_tax_rates, :name, :string
+  end
+end

--- a/core/db/migrate/20120905151823_add_toggle_tax_rate_display.rb
+++ b/core/db/migrate/20120905151823_add_toggle_tax_rate_display.rb
@@ -1,0 +1,5 @@
+class AddToggleTaxRateDisplay < ActiveRecord::Migration
+  def change
+    add_column :spree_tax_rates, :show_rate_in_label, :boolean, :default => true
+  end
+end

--- a/core/spec/requests/admin/configuration/tax_rates_spec.rb
+++ b/core/spec/requests/admin/configuration/tax_rates_spec.rb
@@ -14,7 +14,7 @@ describe "Tax Rates" do
   it "can see a tax rate in the list if the tax category has been deleted" do
     tax_rate.tax_category.mark_deleted!
     lambda { click_link "Tax Rates" }.should_not raise_error
-    within("table tbody td:nth-child(2)") do
+    within("table tbody td:nth-child(3)") do
       page.should have_content("N/A")
     end
   end


### PR DESCRIPTION
The tax rate did not have any label and it's important for Quebec as there are two tax rate which legally must be labeled : TPS and TVQ. I believe it would be interesting enough for other places in the world too.

I changed the label to display either the tax rate name if there is one or else the tax category name.

I also removed the tax rate percentage from the display. Again, it is a legal requirement from the tax agency in Quebec. One could easily add it in the tax rate label or override the tax_rate model.

It is my first pull request ever so please be kind if I missed some information !
