### PR TITLE
Multiple promotions incorrectly applied

### DIFF
--- a/promo/app/models/spree/order_decorator.rb
+++ b/promo/app/models/spree/order_decorator.rb
@@ -16,9 +16,7 @@ Spree::Order.class_eval do
       most_valuable_adjustment = adjustments.promotion.eligible.max{|a,b| a.amount.abs <=> b.amount.abs}
       current_adjustments = (adjustments.promotion.eligible - [most_valuable_adjustment])
       current_adjustments.each do |adjustment|
-        if adjustment.originator.calculator.is_a?(Spree::Calculator::PerItem)
-          adjustment.update_attribute_without_callbacks(:eligible, false)
-        end
+        adjustment.update_attribute_without_callbacks(:eligible, false)
       end
     end
     alias_method_chain :update_adjustments, :promotion_limiting

--- a/promo/spec/requests/promotion_adjustments_spec.rb
+++ b/promo/spec/requests/promotion_adjustments_spec.rb
@@ -416,15 +416,15 @@ describe "Promotion Adjustments" do
       visit spree.root_path
       click_link "RoR Bag"
       click_button "Add To Cart"
-      Spree::Order.last.total.to_f.should == 13.00
+      Spree::Order.last.total.to_f.should == 15.00
 
       fill_in "order[line_items_attributes][0][quantity]", :with => "2"
       click_button "Update"
-      Spree::Order.last.total.to_f.should == 31.00
+      Spree::Order.last.total.to_f.should == 35.00
 
       fill_in "order[line_items_attributes][0][quantity]", :with => "3"
       click_button "Update"
-      Spree::Order.last.total.to_f.should == 49.00
+      Spree::Order.last.total.to_f.should == 54.00
     end
 
     def create_per_product_promotion product_name, discount_amount


### PR DESCRIPTION
In 1.2.0, if you have multiple eligible promotions, they will all be applied. For example, if I have two simple promos:

10% off orders over $100
20% off orders over $200

If I then build an order for $400, both promotions will apply for a total of 30% off.

The attached code fixes this. The change that broke looks like it was originally added by @radar in 10458f5
