### PR TITLE
added overrides directory loader to extention template

### DIFF
--- a/cmd/lib/spree_cmd/templates/extension/lib/%file_name%/engine.rb.tt
+++ b/cmd/lib/spree_cmd/templates/extension/lib/%file_name%/engine.rb.tt
@@ -15,6 +15,9 @@ module <%= class_name %>
       Dir.glob(File.join(File.dirname(__FILE__), '../../app/**/*_decorator*.rb')) do |c|
         Rails.configuration.cache_classes ? require(c) : load(c)
       end
+      Dir.glob(File.join(File.dirname(__FILE__), "../../app/overrides/*.rb")) do |c|
+        Rails.application.config.cache_classes ? require(c) : load(c)
+      end
     end
 
     config.to_prepare &method(:activate).to_proc


### PR DESCRIPTION
I added overrides directory loader to extention template.
In the case of extension using gem Deface, I can unify it in app/overrides directory.
