### PR TITLE
Upgrading acts_as_nested_set to awesome_nested_set

### DIFF
--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -31,7 +31,7 @@ require 'rails/generators'
 require 'state_machine'
 require 'paperclip'
 require 'kaminari'
-require 'nested_set'
+require 'awesome_nested_set'
 require 'acts_as_list'
 require 'active_merchant'
 require 'ransack'
@@ -104,7 +104,7 @@ ActiveRecord::Base.class_eval do
 end
 
 if defined?(ActionView)
-  require 'nested_set/helper'
+  require 'awesome_nested_set/helper'
   ActionView::Base.class_eval do
     include CollectiveIdea::Acts::NestedSet::Helper
   end

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency 'acts_as_list', '= 0.1.4'
-  s.add_dependency 'nested_set', '= 1.7.0'
+  s.add_dependency 'awesome_nested_set', '2.1.4'
 
   s.add_dependency 'jquery-rails', '~> 2.0'
   s.add_dependency 'select2-rails', '0.0.9'


### PR DESCRIPTION
I am working on creating an application that uses both Spree and RefineryCMS. At the moment this requires a few small tweaks but otherwise works well. The only major conflict is that RefineryCMS uses awesome_nested_set whereas Spree uses acts_as_nested_set. They are namespaced and named the same so in some admin pages of refinery it causes it to use the wrong gem. Upgrading awesome_nested_set allows both apps to work nicely together and both test suites pass.
