### PR TITLE
corrected a typo in accurate_title method that was introduced in commit ...

### DIFF
--- a/core/app/controllers/spree/orders_controller.rb
+++ b/core/app/controllers/spree/orders_controller.rb
@@ -64,7 +64,7 @@ module Spree
       redirect_to spree.cart_path
     end
 
-    def accurate_titles
+    def accurate_title
       @order && @order.completed? ? "#{Order.model_name.human} #{@order.number}" : t(:shopping_cart)
     end
   end


### PR DESCRIPTION
There was a typo introduced in commit cb19a45209 that renamed the method accurate_title to accurate_titles, which is never called anywhere. I've restored it to it's original name so that the Order Number correctly appears on the checkout/confirm page. It was otherwise showing the site name.
