### PR TITLE
Fix limiting the availability of aShippingMethod to front end or back en...

### DIFF
--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -13,10 +13,10 @@ module Spree
     calculated_adjustments
 
     def available?(order, display_on = nil)
-      displayable? && calculator.available?(order)
+      displayable?(display_on) && calculator.available?(order)
     end
 
-    def displayable?
+    def displayable?(display_on)
       (self.display_on == display_on.to_s || self.display_on.blank?)
     end
 

--- a/core/spec/models/shipping_method_spec.rb
+++ b/core/spec/models/shipping_method_spec.rb
@@ -31,6 +31,34 @@ describe Spree::ShippingMethod do
         @shipping_method.available?(@order).should be_true
       end
     end
+
+    context "whe the calculator is front_end" do
+      before { @shipping_method.display_on = 'front_end' }
+
+      context "and the order is processed through the front_end" do
+        it "should be true" do
+          @shipping_method.available?(@order, :front_end).should be_true
+        end
+
+        it "should be false" do
+          @shipping_method.available?(@order, :back_end).should be_false
+        end
+      end
+    end
+
+    context "whe the calculator is back_end" do
+      before { @shipping_method.display_on = 'back_end' }
+
+      context "and the order is processed through the back_end" do
+        it "should be false" do
+          @shipping_method.available?(@order, :front_end).should be_false
+        end
+
+        it "should be true" do
+          @shipping_method.available?(@order, :back_end).should be_true
+        end
+      end
+    end
   end
 
   context 'available_to_order?' do


### PR DESCRIPTION
In ShippingMethod#displayable? the attribute display_on was being checked against itself and not the intended instance variable. This bug is also present in 1-2-stable.
