### PR TITLE
Allow per_page param for admin orders pagination.

### DIFF
--- a/core/app/controllers/spree/admin/orders_controller.rb
+++ b/core/app/controllers/spree/admin/orders_controller.rb
@@ -36,7 +36,7 @@ module Spree
         end
 
         @search = Order.ransack(params[:q])
-        @orders = @search.result(:distinct => true).includes([:user, :shipments, :payments]).page(params[:page]).per(Spree::Config[:orders_per_page])
+        @orders = @search.result(:distinct => true).includes([:user, :shipments, :payments]).page(params[:page]).per(params[:per_page] || Spree::Config[:orders_per_page])
 
         # Restore dates
         params[:q][:created_at_gt] = created_at_gt

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -63,7 +63,6 @@ module Spree
     before_create :link_by_email
     after_create :create_tax_charge!
 
-    # TODO: validate the format of the email as well (but we can't rely on authlogic anymore to help with validation)
     validates :email, :presence => true, :email => true, :if => :require_email
     validate :has_available_shipment
     validate :has_available_payment


### PR DESCRIPTION
Also removed the TODO comment as it's already done.

I can add a spec as well for this, but not sure it's worth the added overhead.

in core/specs/requests/admin/orders/listing_spec.rb

``` ruby
  context "listing orders with per_page param" do
    before(:each) do
      visit spree.admin_orders_path(:per_page => 1)
    end

    it "should list existing orders limited to per_page param" do
      find('table#listing_orders tbody tr:nth-child(1) td:nth-child(2)').text.should == "R100"
      page.should_not have_selector('table#listing_orders tbody tr:nth-child(2) td:nth-child(2)')
    end
  end
```
