### PR TITLE
Fixed Product.in_taxon to not return duplicates

### DIFF
--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -51,7 +51,7 @@ module Spree
     #
     #   Spree::Product.taxons_id_eq(x)
     add_search_scope :in_taxon do |taxon|
-      joins(:taxons).where(Taxon.table_name => { :id => taxon.self_and_descendants.map(&:id) })
+      joins(:taxons).where(Taxon.table_name => { :id => taxon.self_and_descendants.map(&:id) }).uniq
     end
 
     # This scope selects products in all taxons AND all its descendants

--- a/core/spec/models/product/scopes_spec.rb
+++ b/core/spec/models/product/scopes_spec.rb
@@ -8,18 +8,16 @@ describe "Product scopes" do
       @taxonomy = create(:taxonomy)
       @root_taxon = @taxonomy.root
       
-      @taxon = create(:taxon, :name => 'A1', :taxonomy_id => @taxonomy.id)
-      @taxon2 = create(:taxon, :name => 'A2', :taxonomy_id => @taxonomy.id)
+      @parent_taxon = create(:taxon, name: 'Parent', :taxonomy_id => @taxonomy.id, :parent => @root_taxon)
+      @child_taxon = create(:taxon, name: 'Child 1', :taxonomy_id => @taxonomy.id, :parent => @parent_taxon)
+      @parent_taxon.reload # Need to reload for descendents to show up
       
-      @taxon.move_to_child_of(@root_taxon)
-      @taxon2.move_to_child_of(@taxon)
-      
-      product.taxons << @taxon
-      product.taxons << @taxon2
+      product.taxons << @parent_taxon
+      product.taxons << @child_taxon
     end
     
     it "calling Product.in_taxon should not return duplicate records" do
-      Spree::Product.in_taxon(@taxon).length.should == 1
+      Spree::Product.in_taxon(@parent_taxon).length.should == 1
     end
   end
 end

--- a/core/spec/models/product/scopes_spec.rb
+++ b/core/spec/models/product/scopes_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe "Product scopes" do
+  let!(:product) { create(:product) }
+  
+  context "A product assigned to parent and child taxons" do
+    before do
+      @taxonomy = create(:taxonomy)
+      @root_taxon = @taxonomy.root
+      
+      @taxon = create(:taxon, :name => 'A1', :taxonomy_id => @taxonomy.id)
+      @taxon2 = create(:taxon, :name => 'A2', :taxonomy_id => @taxonomy.id)
+      
+      @taxon.move_to_child_of(@root_taxon)
+      @taxon2.move_to_child_of(@taxon)
+      
+      product.taxons << @taxon
+      product.taxons << @taxon2
+    end
+    
+    it "calling Product.in_taxon should not return duplicate records" do
+      Spree::Product.in_taxon(@taxon).length.should == 1
+    end
+  end
+end


### PR DESCRIPTION
When a product is assigned to a parent taxon and that parent’s child taxon, `Product.in_taxon(taxon)`should not return duplicate records.
