### PR TITLE
Fix product factory name sequence with Kernel.rand so it is not interpreted as a Spree::Product method

### DIFF
--- a/core/lib/spree/core/testing_support/factories/product_factory.rb
+++ b/core/lib/spree/core/testing_support/factories/product_factory.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :simple_product, :class => Spree::Product do
-    sequence(:name) { |n| "Product ##{n} - #{rand(9999)}" }
+    sequence(:name) { |n| "Product ##{n} - #{Kernel.rand(9999)}" }
     description { Faker::Lorem.paragraphs(1 + Kernel.rand(5)).join("\n") }
     price 19.99
     cost_price 17.00


### PR DESCRIPTION
c44384d3e1d57b4906c1f73cafd0a1682241ddf5 fixed this problem, but it was reintroduced in the product name sequence in f00e876a6308b1ad33bb1886c2031ce915b00ac8 . This commit fixes it.
