### PR TITLE
add request spec for remove from cart link, refers to #1934

### DIFF
--- a/core/spec/requests/cart_spec.rb
+++ b/core/spec/requests/cart_spec.rb
@@ -10,4 +10,21 @@ describe "Cart" do
     visit spree.cart_path
     lambda { find("li#link-to-cart a") }.should raise_error(Capybara::ElementNotFound)
   end
+
+  it "prevents double clicking the remove button on cart", :js => true do
+    @product = create(:product, :name => "RoR Mug")
+    @product.on_hand = 1
+    @product.save
+
+    visit spree.root_path
+    click_link "RoR Mug"
+    click_button "add-to-cart-button"
+
+    # prevent form submit to verify button is disabled
+    page.execute_script("$('#update-cart').submit(function(){return false;})")
+
+    page.should_not have_selector('button#update-button[disabled]')
+    page.find(:css, '.delete img').click
+    page.should have_selector('button#update-button[disabled]')
+  end
 end


### PR DESCRIPTION
After seeing @cmar 8f3ff66e9139fd6725d72a7bed996bd36de87a5c commit I realized how to test the single click  on the remove line items from cart link. This is the resulting regression test for my previous commit (#1934).
