### PR TITLE
Fix flash_messages method in base_helper

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -79,7 +79,7 @@ module Spree
     end
 
     def flash_messages(opts = {})
-      opts[:ignore_types] = [:commerce_tracking].concat(opts[:ignore_types] || [])
+      opts[:ignore_types] = [:commerce_tracking].concat([opts[:ignore_types]] || [])
 
       flash.each do |msg_type, text|
         unless opts[:ignore_types].include?(msg_type)


### PR DESCRIPTION
Currently the flash_messages method fails if options are passed in. This pull request wraps the opts[:ignore_types] hash in an array to properly concatenate. I assume concat was chosen incase the hash value includes an array of objects, so this should get everything working.
