### PR TITLE
Add payment method name in order details page

### DIFF
--- a/core/app/views/spree/shared/_order_details.html.erb
+++ b/core/app/views/spree/shared/_order_details.html.erb
@@ -28,7 +28,9 @@
   <div class="columns omega four">
     <h6><%= t(:payment_information) %> <%= link_to "(#{t(:edit)})", checkout_state_path(:payment) unless @order.completed? %></h6>
     <div class="payment-info">
-      <% unless order.credit_cards.empty? %>
+      <% if order.credit_cards.empty? %>
+        <%= content_tag(:span, order.payment.payment_method.name) if order.payment %>
+      <% else %>
         <span class="cc-type">
           <%= image_tag "credit_cards/icons/#{order.credit_cards.first.cc_type}.png" %>
           <%= t(:ending_in)%> <%= order.credit_cards.first.last_digits %>

--- a/core/lib/spree/core/testing_support/factories/payment_factory.rb
+++ b/core/lib/spree/core/testing_support/factories/payment_factory.rb
@@ -25,4 +25,10 @@ FactoryGirl.define do
   #     txn.update_attribute(:amount, txn.payment.amount)
   #   end
   # end
+
+  factory :check_payment, :class => Spree::Payment do
+    amount 45.75
+    payment_method { FactoryGirl.create(:payment_method) }
+    order { FactoryGirl.create(:order) }
+  end
 end

--- a/core/spec/requests/order_spec.rb
+++ b/core/spec/requests/order_spec.rb
@@ -2,9 +2,22 @@ require 'spec_helper'
 
 describe 'orders' do
   let(:order) { create(:order, :shipping_method => create(:shipping_method)) }
+  let(:completed_order) { create(:completed_order_with_totals, :shipping_method => create(:shipping_method)) }
 
   it "can visit an order" do
     # Regression test for current_user call on orders/show
     lambda { visit spree.order_path(order) }.should_not raise_error
+  end
+
+  it "should have credit card info if paid with credit card" do
+    create(:payment, :order => completed_order)
+    visit spree.order_path(completed_order)
+    page.should have_content "Ending in 1111"
+  end
+
+  it "should have payment method name visible if not paid with credit card" do
+    create(:check_payment, :order => completed_order)
+    visit spree.order_path(completed_order)
+    page.should have_content "Check"
   end
 end

--- a/core/spec/requests/order_spec.rb
+++ b/core/spec/requests/order_spec.rb
@@ -12,12 +12,12 @@ describe 'orders' do
   it "should have credit card info if paid with credit card" do
     create(:payment, :order => completed_order)
     visit spree.order_path(completed_order)
-    page.should have_content "Ending in 1111"
+    within(:css, '.payment-info') { page.should have_content "Ending in 1111" }
   end
 
   it "should have payment method name visible if not paid with credit card" do
     create(:check_payment, :order => completed_order)
     visit spree.order_path(completed_order)
-    page.should have_content "Check"
+    within(:css, '.payment-info') { page.should have_content "Check" }
   end
 end


### PR DESCRIPTION
if not paid with credit card.

Currently nothing is displayed there if a user uses a different payment method to credit card.
