### PR TITLE
Update extension development dependencies. [Fixes #1649]

### DIFF
--- a/cmd/lib/spree_cmd/templates/extension/extension.gemspec
+++ b/cmd/lib/spree_cmd/templates/extension/extension.gemspec
@@ -18,10 +18,12 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'spree_core', '~> <%= spree_version %>'
 
-  s.add_development_dependency 'capybara', '1.0.1'
+  s.add_development_dependency 'capybara', '~> 1.1.2'
+  s.add_development_dependency 'coffee-rails'
   s.add_development_dependency 'factory_girl', '~> 2.6.4'
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'rspec-rails',  '~> 2.9'
+  s.add_development_dependency 'sass-rails'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'sass-rails'
 end

--- a/cmd/lib/spree_cmd/templates/extension/extension.gemspec
+++ b/cmd/lib/spree_cmd/templates/extension/extension.gemspec
@@ -25,5 +25,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec-rails',  '~> 2.9'
   s.add_development_dependency 'sass-rails'
   s.add_development_dependency 'sqlite3'
-  s.add_development_dependency 'sass-rails'
 end


### PR DESCRIPTION
When doing extension development I wanted to run a sandbox app, and would run into the error described in #1649.  The issue is due to the gems required for the asset compilation not being required. 
