### PR TITLE
Allow CreditCard to be used autonomously from Payment. 

### DIFF
--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -1,7 +1,10 @@
 module Spree
   class CreditCard < ActiveRecord::Base
-    belongs_to :user
-    validates :user, :presence => true, :if => :has_payment_profile?
+    if Spree.user_class
+      belongs_to :user, :class_name => Spree.user_class.to_s
+    else
+      belongs_to :user
+    end
 
     belongs_to :bill_address, :foreign_key => :bill_address_id, :class_name => "Spree::Address"
     alias_attribute :billing_address, :bill_address

--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -1,5 +1,15 @@
 module Spree
   class CreditCard < ActiveRecord::Base
+    belongs_to :user
+    validates :user, :presence => true, :if => :has_payment_profile?
+
+    belongs_to :bill_address, :foreign_key => :bill_address_id, :class_name => "Spree::Address"
+    alias_attribute :billing_address, :bill_address
+
+    belongs_to :payment_method
+    alias_attribute :gateway, :payment_method
+    validates :payment_method, :presence => true, :if => :has_payment_profile?
+
     has_many :payments, :as => :source
 
     before_save :set_last_digits

--- a/core/db/migrate/20120919033104_add_user_and_payment_method_and_bill_address_to_credit_card.rb
+++ b/core/db/migrate/20120919033104_add_user_and_payment_method_and_bill_address_to_credit_card.rb
@@ -9,6 +9,9 @@ class AddUserAndPaymentMethodAndBillAddressToCreditCard < ActiveRecord::Migratio
     # if all migrations are run (as with test module)
     Spree::CreditCard.reset_table_name 
 
+    # Postgres gem does not reload column information without explicit reset
+    Spree::CreditCard.reset_column_information 
+
     Spree::CreditCard.where('gateway_customer_profile_id IS NOT NULL').find_each do |credit_card|
       next unless (payment = credit_card.payments.first) && payment.order && payment.order.user
       credit_card.user = payment.order.try(:user)

--- a/core/db/migrate/20120919033104_add_user_and_payment_method_and_bill_address_to_credit_card.rb
+++ b/core/db/migrate/20120919033104_add_user_and_payment_method_and_bill_address_to_credit_card.rb
@@ -1,0 +1,21 @@
+class AddUserAndPaymentMethodAndBillAddressToCreditCard < ActiveRecord::Migration
+  def change
+    add_column :spree_credit_cards, :user_id, :integer
+    add_column :spree_credit_cards, :payment_method_id, :integer
+    add_column :spree_credit_cards, :bill_address_id, :integer
+
+    # Name was changed in previous migration, so it still thinks it's spree_creditcard 
+    # if all migrations are run (as with test module)
+    Spree::CreditCard.reset_table_name 
+
+    Spree::CreditCard.where('gateway_customer_profile_id IS NOT NULL').find_each do |credit_card|
+      next unless payment = credit_card.payments.first
+      credit_card.user = payment.order.try(:user)
+      credit_card.payment_method = payment.payment_method
+      credit_card.bill_address = payment.order.try(:bill_address)
+      unless credit_card.save
+        puts "Unable to migrate data to credit card #{credit_card.id}: #{credit_card.errors.inspect}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Interface on PaymentMethod.create_profile was changed to create_payment_profile. This was to change from taking a Payment to taking a CreditCard (or other source) so that payment profiles can be created without a Payment.

Added user, bill_address, and payment_method to CreditCard and copy this data on successful Payments prior to creating a payment profile.

Migration includes copying data for all credit cards with a payment profile.

Please review and comment. Thanks!
