### PR TITLE
Improved promotion adjustment scope. Fixes #1993

### DIFF
--- a/promo/app/models/spree/adjustment_decorator.rb
+++ b/promo/app/models/spree/adjustment_decorator.rb
@@ -1,3 +1,7 @@
 Spree::Adjustment.class_eval do
-  scope :promotion, lambda { where('label LIKE ?', "#{I18n.t(:promotion)}%") }
+  class << self
+    def promotion
+      where(:originator_type => 'Spree::PromotionAction')
+    end
+  end
 end

--- a/promo/spec/models/order_spec.rb
+++ b/promo/spec/models/order_spec.rb
@@ -25,9 +25,13 @@ describe Spree::Order do
       create_adjustment("Promotion A", -100)
       create_adjustment("Promotion B", -200)
       create_adjustment("Promotion C", -300)
-      create_adjustment("Some other credit", -500)
-      order.adjustments.each {|a| a.update_attribute_without_callbacks(:eligible, true)}
+      create(:adjustment, :adjustable => order,
+                          :originator => nil,
+                          :amount => -500,
+                          :locked => true,
+                          :label => "Some other credit")
 
+      order.adjustments.each {|a| a.update_attribute_without_callbacks(:eligible, true)}
       order.send(:update_adjustments)
       order.adjustments.eligible.promotion.count.should == 1
       order.adjustments.eligible.promotion.first.label.should == 'Promotion C'


### PR DESCRIPTION
The scope now matches on the `originator_type` and checks for `Spree::Promotion`. Described in detail in #1993
