### PR TITLE
Tidied code inside preferences/store.rb

### DIFF
--- a/core/app/models/spree/preferences/store.rb
+++ b/core/app/models/spree/preferences/store.rb
@@ -27,30 +27,23 @@ module Spree::Preferences
     end
 
     def get(key)
-      # look first in our cache
-      val = @cache.read(key)
-
       # return the retrieved value, if it's in the cache
-      return val if val.present?
+      if (val = @cache.read(key)).present?
+        return val
+      end
 
       return nil unless should_persist?
 
-      # if it's not in the cache, maybe it's in the database, but
+      # If it's not in the cache, maybe it's in the database, but
       # has been cleared from the cache
 
       # does it exist in the database?
-      preference = Spree::Preference.find_by_key(key)
-
-      if preference.present?
-
+      if preference = Spree::Preference.find_by_key(key)
         # it does exist, so let's put it back into the cache
         @cache.write(preference.key, preference.value)
 
         # and return the value
-        return preference.value
-      else
-        # it never existed and our initial cache miss was correct
-        return nil
+        preference.value
       end
     end
 


### PR DESCRIPTION
- Methods always return nil in the absence of an explicit return.
- In-lined Preference retrieval and presence check.
- In-lined cache read presence check.
