### PR TITLE
Apply payments partially

### DIFF
--- a/core/spec/models/order/payment_spec.rb
+++ b/core/spec/models/order/payment_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+module Spree
+  describe Order do
+    let(:order) { stub_model(Order) }
+    let(:updater) { Spree::OrderUpdater.new(order) }
+
+    before do
+      # So that Payment#purchase! is called during processing
+      Spree::Config[:auto_capture] = true
+
+      order.stub_chain(:line_items, :empty?).and_return(false)
+      order.stub :total => 100
+    end
+
+    it 'processes all payments' do
+      payment_1 = Factory(:payment, :amount => 50)
+      payment_2 = Factory(:payment, :amount => 50)
+      order.stub(:pending_payments).and_return([payment_1, payment_2])
+
+      order.process_payments!
+      updater.update_payment_state
+      order.payment_state.should == 'paid'
+
+      payment_1.should be_completed
+      payment_2.should be_completed
+    end
+
+    it 'does not go over total for order' do
+      payment_1 = Factory(:payment, :amount => 50)
+      payment_2 = Factory(:payment, :amount => 50)
+      payment_3 = Factory(:payment, :amount => 50)
+      order.stub(:pending_payments).and_return([payment_1, payment_2, payment_3])
+
+      order.process_payments!
+      updater.update_payment_state
+      order.payment_state.should == 'paid'
+
+      payment_1.should be_completed
+      payment_2.should be_completed
+      payment_3.should be_pending
+    end
+
+    it "does not use failed payments" do
+      payment_1 = Factory(:payment, :amount => 50)
+      payment_2 = Factory(:payment, :amount => 50, :state => 'failed')
+      order.stub(:pending_payments).and_return([payment_1])
+
+      payment_2.should_not_receive(:process!)
+
+      order.process_payments!
+    end
+  end
+end


### PR DESCRIPTION
Rather than iterating through each payment for an order and attempt to apply it, only iterate through pending payments and apply them until the payment_total has been brought in line (or has crossed over) the order total.

Fixes #1954.

/cc @BDQ
