### PR TITLE
Abstract admin product autocomplete to model method

### DIFF
--- a/core/app/assets/javascripts/admin/product_autocomplete.js.erb
+++ b/core/app/assets/javascripts/admin/product_autocomplete.js.erb
@@ -22,7 +22,7 @@ format_product_autocomplete = function(item){
   }else{
     // variant
     var variant = item.data['variant'];
-    var name = item.data.product['name'];
+    var name = variant['admin_label']
 
     if(variant['images'].length!=0){
       html = image_html(variant);
@@ -31,10 +31,6 @@ format_product_autocomplete = function(item){
         html = image_html(product);
       }
     }
-
-    name += " - " + $.map(variant['option_values'], function(option_value){
-      return option_value["option_type"]["presentation"] + ": " + option_value['presentation'];
-    }).join(", ")
 
     html += "<div><h4>" + name + "</h4>";
     html += "<span><strong>" + Spree.translations.sku + ":</strong>" + variant['sku'] + "</span>";
@@ -53,10 +49,7 @@ prep_product_autocomplete_data = function(data){
       //variants
       return $.map(product['variants'], function(variant){
 
-        var name = product['name'];
-        name += " - " + $.map(variant['option_values'], function(option_value){
-          return option_value["option_type"]["presentation"] + ": " + option_value['presentation'];
-        }).join(", ");
+        var name = variant['admin_label']
 
         return {
             data: {product: product, variant: variant},

--- a/core/app/controllers/spree/admin/products_controller.rb
+++ b/core/app/controllers/spree/admin/products_controller.rb
@@ -61,7 +61,7 @@ module Spree
             collection.map {|p| {'id' => p.id, 'name' => p.name}}.to_json
           else
             collection.to_json(:include => {:variants => {:include => {:option_values => {:include => :option_type},
-                                                          :images => {:only => [:id], :methods => :mini_url}}},
+                                                          :images => {:only => [:id], :methods => :mini_url}}, :methods => :admin_label},
                                                           :images => {:only => [:id], :methods => :mini_url}, :master => {}})
           end
         end

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -131,6 +131,9 @@ module Spree
       self.option_values.detect { |o| o.option_type.name == opt_name }.try(:presentation)
     end
 
+    def admin_label
+      self.product.name += " - " + self.option_values.map { |ov| ov.option_type.presentation + " " + ov.presentation }.join(',')
+    end
 
     private
 


### PR DESCRIPTION
I've had to perform many custom tweaks to the formatting of the admin product autocomplete dropdown label. I've abstracted this to a method on variant where the formatting can be easily overridden and tweaked as desired, and this method is included in the admin products controller json_data. This way, the hash can be easily accessed via javascript, and easily tweaked in a class_eval in ruby.
