### PR TITLE
Adding non sellable category to products on Spree.

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -68,7 +68,7 @@ module Spree
     attr_accessible :name, :description, :available_on, :permalink, :meta_description,
                     :meta_keywords, :price, :sku, :deleted_at, :prototype_id,
                     :option_values_hash, :on_hand, :weight, :height, :width, :depth,
-                    :shipping_category_id, :tax_category_id, :product_properties_attributes,
+                    :shipping_category_id, :sellable, :tax_category_id, :product_properties_attributes,
                     :variants_attributes, :taxon_ids, :option_type_ids
 
     attr_accessible :cost_price if Variant.table_exists? && Variant.column_names.include?('cost_price')

--- a/core/app/views/spree/admin/products/_form.html.erb
+++ b/core/app/views/spree/admin/products/_form.html.erb
@@ -71,6 +71,11 @@
         </ul>
       <% end %>
 
+      <%= f.field_container :sellable do %>
+        <%= f.label :sellable, t(:sellable) %><br />
+        <%= f.check_box :sellable %> 
+      <% end %>
+
       <%= f.field_container :shipping_categories do %>
         <%= f.label :shipping_category_id, t(:shipping_categories) %><br />
         <%= f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { :include_blank => true }, { 'style' => 'width:200px' }) %>

--- a/core/app/views/spree/products/_cart_form.html.erb
+++ b/core/app/views/spree/products/_cart_form.html.erb
@@ -35,15 +35,17 @@
         </div>
 
         <div class="add-to-cart">
-          <% if @product.has_stock? || Spree::Config[:allow_backorders] %>      
-            <%= number_field_tag (@product.has_variants? ? :quantity : "variants[#{@product.master.id}]"),
-              1, :class => 'title', :in => 1..@product.on_hand %>
-            <%= button_tag :class => 'large primary', :id => 'add-to-cart-button', :type => :submit do %>
-              <%= t(:add_to_cart) %>
-            <% end %>
-          <% else %>
-            <%= content_tag('strong', t(:out_of_stock)) %>
-          <% end %>
+          <% if @product.sellable %>
+             <% if @product.has_stock? || Spree::Config[:allow_backorders] %>      
+               <%= number_field_tag (@product.has_variants? ? :quantity : "variants[#{@product.master.id}]"),
+               1, :class => 'title', :in => 1..@product.on_hand %>
+               <%= button_tag :class => 'large primary', :id => 'add-to-cart-button', :type => :submit do %>
+               <%= t(:add_to_cart) %>
+             <% end %>
+             <% else %>
+               <%= content_tag('strong', t(:out_of_stock)) %>
+             <% end %>
+          <% end %>    
         </div>
 
       </div>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -897,6 +897,7 @@ en:
   select: Select
   select_from_prototype: "Select From Prototype"
   select_preferred_shipping_option: "Select preferred shipping option"
+  sellable: "Sellable Product"
   send_copy_of_all_mails_to: Send Copy of All Mails To
   send_copy_of_orders_mails_to: Send Copy of Order Mails To
   send_mails_as: Send Mails As

--- a/core/db/migrate/20120925125406_add_sellable_field.rb
+++ b/core/db/migrate/20120925125406_add_sellable_field.rb
@@ -1,0 +1,5 @@
+class AddSellableField < ActiveRecord::Migration
+  def change
+    add_column :spree_products, :sellable, :boolean, :default => true
+  end
+end


### PR DESCRIPTION
A new column has been introduced in the products table that makes it configurable at a product level whether it can be retailed on the site or not.
