### PR TITLE
admin/taxonomies: jstree: translations and escaping

### DIFF
--- a/core/app/assets/javascripts/admin/taxonomy.js
+++ b/core/app/assets/javascripts/admin/taxonomy.js
@@ -59,7 +59,7 @@ var handle_delete = function(e, data){
   last_rollback = data.rlbk;
   var node = data.rslt.obj;
 
-  jConfirm('Are you sure you want to delete this taxon?', 'Confirm Taxon Deletion', function(r) {
+  jConfirm(Spree.translations.are_you_sure_delete, Spree.translations.confirm_delete, function(r) {
     if(r){
       $.ajax({
         type: "POST",
@@ -103,7 +103,7 @@ $(document).ready(function(){
       },
       "strings" : {
         "new_node" : new_taxon,
-        "loading" : loading + "..."
+        "loading" : Spree.translations.loading + "..."
       },
       "crrm" : {
         "move" : {
@@ -131,48 +131,48 @@ $(document).ready(function(){
             if(type_of_node == "root") {
               menu = {
                 "create" : {
-                  "label"            : "Create",
+                  "label"            : Spree.translations.add,
                   "action"           : function (obj) { this.create(obj); }
                 },
                  "paste" : {
                    "separator_before" : true,
-                   "label"            : "Paste",
+                   "label"            : Spree.translations.paste,
                    "action"           : function (obj) { is_cut = false; this.paste(obj); },
                    "_disabled"        : is_cut == false
                 },
                 "edit" : {
                   "separator_before" : true,
-                  "label"            : "Edit",
+                  "label"            : Spree.translations.edit,
                   "action"           : function (obj) { window.location = base_url + obj.attr("id") + "/edit/"; }
                 }
               }
             } else {
               menu =  {
                 "create" : {
-                  "label"            : "Create",
+                  "label"            : Spree.translations.add,
                   "action"           : function (obj) { this.create(obj); }
                 },
                 "rename" : {
-                  "label"            : "Rename",
+                  "label"            : Spree.translations.rename,
                   "action"           : function (obj) { this.rename(obj); }
                 },
                 "remove" : {
-                  "label"            : "Remove",
+                  "label"            : Spree.translations.remove,
                   "action"           : function (obj) { this.remove(obj); }
                 },
                 "cut" : {
                   "separator_before" : true,
-                  "label"            : "Cut",
+                  "label"            : Spree.translations.cut,
                   "action"           : function (obj) { is_cut = true; this.cut(obj); }
                 },
                 "paste" : {
-                  "label"            : "Paste",
+                  "label"            : Spree.translations.paste,
                   "action"           : function (obj) { is_cut = false; this.paste(obj); },
                   "_disabled"        : is_cut == false
                 },
                 "edit" : {
                   "separator_before" : true,
-                  "label"            : "Edit",
+                  "label"            : Spree.translations.edit,
                   "action"           : function (obj) { window.location = base_url + obj.attr("id") + "/edit/"; }
                 }
                     }

--- a/core/app/views/spree/admin/shared/_translations.html.erb
+++ b/core/app/views/spree/admin/shared/_translations.html.erb
@@ -11,7 +11,16 @@
     :type_to_search => I18n.t(:type_to_search),
     :searching      => I18n.t(:searching),
     :sku            => I18n.t(:sku),
-    :on_hand        => I18n.t(:on_hand)
+    :on_hand        => I18n.t(:on_hand),
+    :add            => I18n.t(:add),
+    :paste          => I18n.t(:paste),
+    :edit           => I18n.t(:edit),
+    :rename         => I18n.t(:rename),
+    :remove         => I18n.t(:remove),
+    :cut            => I18n.t(:cut),
+    :loading        => I18n.t(:loading),
+    :confirm_delete => I18n.t(:confirm_delete),
+    :are_you_sure_delete => I18n.t(:are_you_sure_delete)
   }.to_json
 %>
 </script>

--- a/core/app/views/spree/admin/taxonomies/edit.erb
+++ b/core/app/views/spree/admin/taxonomies/edit.erb
@@ -28,14 +28,14 @@
     var initial = [
       { "attr" :
       { "id" : "<%= @taxonomy.root.id %>", "rel" : "root" },
-      "data" : "<%= @taxonomy.root.name %>",
+      "data" : "<%= escape_javascript(raw(@taxonomy.root.name)) %>",
       "state" : "open",
       "children" : [
         <% @taxonomy.root.children.each_with_index do |taxon,i| %>
           {
             "attr" :
             { "id" : "<%= taxon.id %>"},
-            "data" : "<%= taxon.name %>"
+            "data" : "<%= escape_javascript(raw(taxon.name)) %>"
             <% unless taxon.children.empty? %>
               ,"state" : "closed"
             <% end %>

--- a/core/app/views/spree/admin/taxonomies/get_children.json.erb
+++ b/core/app/views/spree/admin/taxonomies/get_children.json.erb
@@ -1,7 +1,7 @@
 [<% @taxons.each_with_index do |t,i| %>
   { "attr" :
     { "id" : "<%= t.id %>" },
-    "data" : "<%= t.name %>"
+    "data" : "<%= escape_javascript(raw(t.name)) %>"
     <% unless t.children.empty? %>
       ,"state" : "closed"
     <% end %>


### PR DESCRIPTION
1) jstree now uses localized labels

2) escaped the taxonomy names passed to jstree
