### PR TITLE
Fix zero dollar checkout

### DIFF
--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -64,7 +64,7 @@ module Spree
 
               before_transition :to => :complete do |order|
                 begin
-                  order.process_payments!
+                  order.process_payments! if order.payemnt_required?
                 rescue Spree::Core::GatewayError
                   !!Spree::Config[:allow_checkout_on_gateway_error]
                 end


### PR DESCRIPTION
This is a bug related to promo. If you have a promo that makes the purchase $0, some gateways (usaepay) will reject the authorization and causing checkout to fail. 
