### PR TITLE
Fix preference lookup to use key not deprecated name column.

### DIFF
--- a/core/app/models/spree/preference.rb
+++ b/core/app/models/spree/preference.rb
@@ -1,5 +1,5 @@
 class Spree::Preference < ActiveRecord::Base
-  attr_accessible :name, :key, :value_type, :value
+  attr_accessible :key, :value_type, :value
 
   validates :key, :presence => true
   validates :value_type, :presence => true

--- a/core/app/models/spree/preferences/preferable_class_methods.rb
+++ b/core/app/models/spree/preferences/preferable_class_methods.rb
@@ -15,7 +15,7 @@ module Spree::Preferences
         else
           if get_pending_preference(name)
             get_pending_preference(name)
-          elsif Spree::Preference.table_exists? && preference = Spree::Preference.find_by_name(name)
+          elsif Spree::Preference.table_exists? && preference = Spree::Preference.find_by_key(name)
             preference.value
           else
             send self.class.preference_default_getter_method(name)

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -87,7 +87,6 @@ module Spree
       master
     end
 
-
     def to_param
       permalink.present? ? permalink : (permalink_was || name.to_s.to_url)
     end

--- a/core/db/migrate/20120929093553_remove_unused_preference_columns.rb
+++ b/core/db/migrate/20120929093553_remove_unused_preference_columns.rb
@@ -1,0 +1,8 @@
+class RemoveUnusedPreferenceColumns < ActiveRecord::Migration
+  def change
+    # Columns have already been removed if the application was upgraded from an older version, but must be removed from new apps.
+    remove_column :spree_preferences, :name       if ActiveRecord::Base.connection.column_exists?(:spree_preferences, :name)
+    remove_column :spree_preferences, :owner_id   if ActiveRecord::Base.connection.column_exists?(:spree_preferences, :owner_id)
+    remove_column :spree_preferences, :owner_type if ActiveRecord::Base.connection.column_exists?(:spree_preferences, :owner_type)
+  end
+end

--- a/core/spec/models/preference_spec.rb
+++ b/core/spec/models/preference_spec.rb
@@ -118,7 +118,3 @@ describe Spree::Preference do
   end
 
 end
-
-
-
-

--- a/core/spec/models/preferences/preferable_spec.rb
+++ b/core/spec/models/preferences/preferable_spec.rb
@@ -119,12 +119,12 @@ describe Spree::Preferences::Preferable do
 
       it "retrieves a preference from the database before falling back to default" do
         preference = mock(:value => "chatreuse")
-        Spree::Preference.should_receive(:find_by_name).with(:color).and_return(preference)
+        Spree::Preference.should_receive(:find_by_key).with(:color).and_return(preference)
         @a.preferred_color.should == 'chatreuse'
       end
 
       it "defaults if no database key exists" do
-        Spree::Preference.should_receive(:find_by_name).and_return(nil)
+        Spree::Preference.should_receive(:find_by_key).and_return(nil)
         @a.preferred_color.should == 'green'
       end
     end


### PR DESCRIPTION
I ran into an issue upgrading an app from spree 1.1.x to 1.2.x due to preference lookup, and heres a breakdown of what I found.

During the refactoring of preferences by @cmar the name column was deprecated in favor of key, which can be seen in this migration:  https://github.com/spree/spree/blob/1-1-stable/core/db/migrate/20120119024710_new_preferences.rb

When my app was upgraded to use the new preferences I had run one of the older versions of the migration that removed the name column and looked like this: https://github.com/spree/spree/blob/8e6222b8cb1f994e6f6bc0d34d5d188a395eff20/core/db/migrate/20111128153359_new_preferences.rb

So I ran into errors during initialization with the name column not existing, which it does not need to since the data does get properly migrated.  The database fallback should actually be looking for the key column.

So I've updated the database fallback to properly use the key column, and added a migration to handle removing of the unused columns for new and upgraded apps.
