### PR TITLE
Manage currency whose subunit is not 100 (like JPY)

### DIFF
--- a/core/lib/spree/money.rb
+++ b/core/lib/spree/money.rb
@@ -3,7 +3,7 @@ require 'money'
 module Spree
   class Money
     def initialize(amount, options={})
-      @money = ::Money.new(amount * 100, Spree::Config[:currency])
+      @money = ::Money.parse([amount, Spree::Config[:currency]].join)
       @options = {}
       @options[:with_currency] = true if Spree::Config[:display_currency]
       @options[:symbol_position] = Spree::Config[:currency_symbol_position].to_sym

--- a/core/spec/lib/money_spec.rb
+++ b/core/spec/lib/money_spec.rb
@@ -1,3 +1,4 @@
+#encoding: UTF-8
 require 'spec_helper'
 
 module Spree
@@ -43,6 +44,21 @@ module Spree
         Spree::Config[:currency_symbol_position] = :after
         money = Spree::Money.new(10)
         money.to_s.should == "10.00 $"
+      end
+    end
+
+    context "JPY" do
+      before do
+        reset_spree_preferences do |config|
+          config.currency = "JPY"
+          config.currency_symbol_position = :before
+          config.display_currency = false
+        end
+      end
+
+      it "formats correctly" do
+        money = Spree::Money.new(1000)
+        money.to_s.should == "¥1,000"
       end
     end
   end


### PR DESCRIPTION
With Money.gem,

``` ruby
Money.new(1000, "JPY").format #=> "¥1,000"
```

But with Spree::Money,

``` ruby
Spree::Config[:currency] #=> "JPY"
Spree::Money.new(1000).to_s #=> "¥100,000"
```

I fixed it to provide same result as Money.gem.
