### PR TITLE
fix wrapping opts[:ignore_types] for single variable or array

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -79,7 +79,7 @@ module Spree
     end
 
     def flash_messages(opts = {})
-      opts[:ignore_types] = [:commerce_tracking].concat([opts[:ignore_types]] || [])
+      opts[:ignore_types] = [:commerce_tracking].concat(Array(opts[:ignore_types]) || [])
 
       flash.each do |msg_type, text|
         unless opts[:ignore_types].include?(msg_type)

--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -74,4 +74,24 @@ describe Spree::BaseHelper do
     end
 
   end
+
+  # Regression test for #2034
+  context "flash_message" do
+    let(:flash) { {:notice => "ok", :foo => "foo", :bar => "bar"} }
+
+    it "should output all flash content" do
+      flash_messages
+      helper.output_buffer.should == "<div class=\"flash notice\">ok</div><div class=\"flash foo\">foo</div><div class=\"flash bar\">bar</div>"
+    end
+
+    it "should output flash content except one key" do
+      flash_messages(:ignore_types => :bar)
+      helper.output_buffer.should == "<div class=\"flash notice\">ok</div><div class=\"flash foo\">foo</div>"
+    end
+
+    it "should output flash content except some keys" do
+      flash_messages(:ignore_types => [:foo, :bar])
+      helper.output_buffer.should == "<div class=\"flash notice\">ok</div>"
+    end
+  end
 end


### PR DESCRIPTION
@3db4474

Fix for opts[:ignore_types] can receive string, symbol or array.
