### PR TITLE
use the official spree git repo for spree_auth_devise

### DIFF
--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -4,7 +4,7 @@ rm -rf sandbox
 rails new sandbox --skip-bundle
 cd sandbox
 echo "gem 'spree', :path => '..'\n" >> Gemfile
-echo "gem 'spree_auth_devise', :git => 'git://github.com/devilcoders/spree_auth_devise'\n" >> Gemfile
+echo "gem 'spree_auth_devise', :git => 'git://github.com/spree/spree_auth_devise.git'\n" >> Gemfile
 bundle install --gemfile Gemfile
 rails g spree:install --auto-accept --user_class=Spree::User
 bundle exec rake spree_auth:admin:create


### PR DESCRIPTION
The script that generates the sandbox app does not use the spree/spree_auth_devise gem. Fixed in this commit.
