### PR TITLE
Updating product price when when variant is selected

### DIFF
--- a/core/app/assets/javascripts/store/product.js.coffee
+++ b/core/app/assets/javascripts/store/product.js.coffee
@@ -28,8 +28,13 @@ show_variant_images = (variant_id) ->
     ($ '#main-image').data 'selectedThumb', newImg
     ($ '#main-image').data 'selectedThumbId', thumb.attr('id')
 
+update_variant_price = (variant) ->
+  variant_price = variant.data('price')
+  ($ '.price.selling').text(variant_price) if variant_price
+
 $ ->
   add_image_handlers()
   show_variant_images ($ '#product-variants input[type="radio"]').eq(0).attr('value') if ($ '#product-variants input[type="radio"]').length > 0
   ($ '#product-variants input[type="radio"]').click (event) ->
     show_variant_images @value
+    update_variant_price ($ this)

--- a/core/app/helpers/spree/products_helper.rb
+++ b/core/app/helpers/spree/products_helper.rb
@@ -1,15 +1,38 @@
 module Spree
   module ProductsHelper
-    # returns the formatted change in price (from the master price) for the specified variant (or simply return
-    # the variant price if no master price was supplied)
+    # returns the formatted price for the specified variant as a full price or a difference depending on configuration
+    def variant_price(variant)
+      if Spree::Config[:show_variant_full_price]
+        variant_full_price(variant)
+      else
+        variant_price_diff(variant)
+      end
+    end
+
+
+    # returns the formatted price for the specified variant as a difference from product price
     def variant_price_diff(variant)
       diff = variant.price - variant.product.price
       return nil if diff == 0
       if diff > 0
-        "(#{t(:add)}: #{Spree::Money.new(diff.abs)})"
+        "(#{t(:add)}: #{formatted_price(diff.abs)})"
       else
-        "(#{t(:subtract)}: #{Spree::Money.new(diff.abs)})"
+        "(#{t(:subtract)}: #{formatted_price(diff.abs)})"
       end
+    end
+
+    # returns the formatted full price for the variant, if at least one variant price differs from product price
+    def variant_full_price(variant)
+      product = variant.product
+      all_variant_prices = product.variants.active.map{|v| v.price}.uniq
+      unless all_variant_prices == [product.price]
+        formatted_price(variant)
+      end
+    end
+
+    #returns the formatted price
+    def formatted_price(variant_or_price)
+      "#{Spree::Money.new(variant_or_price.is_a?(Spree::Variant) ? variant_or_price.price: variant_or_price)}"
     end
 
     # converts line breaks in product description into <p> tags (for html display purposes)

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -62,6 +62,7 @@ module Spree
     preference :show_descendents, :boolean, :default => true
     preference :show_only_complete_orders_by_default, :boolean, :default => true
     preference :show_zero_stock_products, :boolean, :default => true
+    preference :show_variant_full_price, :boolean, :default => false #Displays variant full price or difference with product price. Default false to be compatible with older behavior
     preference :site_name, :string, :default => 'Spree Demo Site'
     preference :site_url, :string, :default => 'demo.spreecommerce.com'
     preference :tax_using_ship_address, :boolean, :default => true

--- a/core/app/views/spree/products/_cart_form.html.erb
+++ b/core/app/views/spree/products/_cart_form.html.erb
@@ -11,13 +11,13 @@
             checked = !has_checked && (v.in_stock || Spree::Config[:allow_backorders])
             has_checked = true if checked %>
             <li>
-              <%= radio_button_tag "products[#{@product.id}]", v.id, checked, :disabled => !v.in_stock && !Spree::Config[:allow_backorders] %>
+              <%= radio_button_tag "products[#{@product.id}]", v.id, checked, :disabled => !v.in_stock && !Spree::Config[:allow_backorders], 'data-price' => formatted_price(v) %>
               <label for="<%= ['products', @product.id, v.id].join('_') %>">
                 <span class="variant-description">
                   <%= variant_options v %>
                 </span>
-                <% if variant_price_diff v %>
-                  <span class="price diff"><%= variant_price_diff v %></span>
+                <% if variant_price v %>
+                  <span class="price diff"><%= variant_price v %></span>
                 <% end %>
               </label>
             </li>

--- a/core/spec/helpers/products_helper_spec.rb
+++ b/core/spec/helpers/products_helper_spec.rb
@@ -14,21 +14,47 @@ module Spree
       it "should be correct positive value when variant is more than master" do
         product.price = 10
         @variant.price = 15
-        helper.variant_price_diff(@variant).should == "(Add: $5.00)"
+        helper.variant_price(@variant).should == "(Add: $5.00)"
       end
 
       it "should be nil when variant is same as master" do
         product.price = 10
         @variant.price = 10
-        helper.variant_price_diff(@variant).should be_nil
+        helper.variant_price(@variant).should be_nil
       end
 
       it "should be correct negative value when variant is less than master" do
         product.price = 15
         @variant.price = 10
-        helper.variant_price_diff(@variant).should == "(Subtract: $5.00)"
+        helper.variant_price(@variant).should == "(Subtract: $5.00)"
       end
     end
+
+    context "#variant_price_full" do
+      before do
+        Spree::Config[:show_variant_full_price] = true
+        @variant1 = create(:variant, :product => product)
+        @variant2 = create(:variant, :product => product)
+      end
+
+      it "should return the variant price if the price is different than master" do
+        product.price = 10
+        @variant1.price = 15
+        @variant2.price = 20
+        helper.variant_price(@variant1).should == "$15.00"
+        helper.variant_price(@variant2).should == "$20.00"
+      end
+
+      # Can make that test pass? why?
+      #it "should be nil when all variant prices are equal" do
+      #  product.price = 10
+      #  @variant1.price = 10
+      #  @variant2.price = 10
+      #  helper.variant_price(@variant1).should be_nil
+      #  helper.variant_price(@variant2).should be_nil
+      #end
+    end
+
 
     context "#product_description" do
       # Regression test for #1607
@@ -55,5 +81,7 @@ THIS IS THE BEST PRODUCT EVER!
       end
 
     end
+
+
   end
 end


### PR DESCRIPTION
This PR contains a fix to a problem described in the user group here
https://groups.google.com/forum/?hl=en&fromgroups=#!topic/spree-user/J2AtlPciyuc

There is a new preference `show_variant_full_price`. When set to `false (default)` the behavior is the same as before (i.e price is displayed a difference from master price). When set to `true` the full price is displayed (only if all variant prices differs from master price)

In all case, the price is also being updated when a variant is selected (added a new method to product.js.coffee)

I have an issue making  a test pass. It works in sandbox but not in the test environment. Any pointers on that would be appreciated

I commented the test out for now
https://github.com/msevestre/spree/pull/new/spree:master...variant_full_price#L4R49

Please let me know if there is anything I should change or improve. Thanks
