### PR TITLE
Move routes definition into a view to parallel translation settings. Rem...

### DIFF
--- a/core/app/views/spree/admin/shared/_head.html.erb
+++ b/core/app/views/spree/admin/shared/_head.html.erb
@@ -5,16 +5,9 @@
 
 <%= stylesheet_link_tag 'admin/all' %>
 <%= javascript_include_tag 'admin/all' %>
+
 <%= render "spree/admin/shared/translations" %>
-<%= javascript_tag do %>
-  var Spree = {
-    routes: <%== {
-    :product_search       => spree.admin_products_path(:format => 'json'),
-    :product_search_basic => spree.admin_products_path(:format => 'json', :json_format => 'basic', :limit => 10),
-    :user_search          => spree.admin_users_path(:format => 'json', :limit => 10)
-  }.to_json %>
-  }
-<% end %>
+<%= render "spree/admin/shared/routes" %>
 
 <%= javascript_tag do -%>
   jQuery.alerts.dialogClass = 'spree';

--- a/core/app/views/spree/admin/shared/_routes.html.erb
+++ b/core/app/views/spree/admin/shared/_routes.html.erb
@@ -1,0 +1,8 @@
+<script>
+  Spree.routes = <%== {
+    :product_search       => spree.admin_products_path(:format => 'json'),
+    :product_search_basic => spree.admin_products_path(:format => 'json', :json_format => 'basic', :limit => 10),
+    :user_search          => spree.admin_users_path(:format => 'json', :limit => 10)
+  }.to_json 
+%>
+</script>


### PR DESCRIPTION
...oving the javascript_tag setting in _head fixes the overwritten Spree javascript variable in _head (for admin) that caused plugins that relied on translations to break

This is reference to [issue 2025](https://github.com/spree/spree/issues/2025).
