### PR TITLE
Remove commented out HTML from Admin

### DIFF
--- a/core/app/views/spree/layouts/admin.html.erb
+++ b/core/app/views/spree/layouts/admin.html.erb
@@ -121,17 +121,6 @@
           </div>
         </div>
 
-        <!-- <div class="row">
-          <div id="footer" data-hook>
-            <div class="copyright align-center">
-              Powered by <%= link_to "Spree Commerce", "http://spreecommerce.com", :target => "_blank"%>
-            </div>
-            <div class="footer-content">
-              <%= yield :footer %>
-            </div>
-          </div>
-        </div> -->
-
       </div>
 
     </div>


### PR DESCRIPTION
I think this was supposed to be removed but overlooked, removed it.
