### PR TITLE
Added 'on demand' option for products/variants

### DIFF
--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -50,7 +50,7 @@ module Spree
       sold = quantity - back_order
 
       #set on_hand if configured
-      if Spree::Config[:track_inventory_levels]&&!variant.on_demand
+      if self.track_level?
         variant.decrement!(:count_on_hand, quantity)
       end
 
@@ -61,7 +61,7 @@ module Spree
     end
 
     def self.decrease(order, variant, quantity)
-      if Spree::Config[:track_inventory_levels]&&!variant.on_demand
+      if self.track_level?
         variant.increment!(:count_on_hand, quantity)
       end
 
@@ -113,10 +113,14 @@ module Spree
       end
 
       def restock_variant
-        if Spree::Config[:track_inventory_levels]&&!variant.on_demand
+        if self.track_level?
           variant.on_hand += 1
           variant.save
         end
+      end
+
+      def track_level?
+        Spree::Config[:track_inventory_levels] && !variant.on_demand
       end
   end
 end

--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -50,7 +50,7 @@ module Spree
       sold = quantity - back_order
 
       #set on_hand if configured
-      if Spree::Config[:track_inventory_levels]
+      if Spree::Config[:track_inventory_levels]&&!variant.on_demand
         variant.decrement!(:count_on_hand, quantity)
       end
 
@@ -61,7 +61,7 @@ module Spree
     end
 
     def self.decrease(order, variant, quantity)
-      if Spree::Config[:track_inventory_levels]
+      if Spree::Config[:track_inventory_levels]&&!variant.on_demand
         variant.increment!(:count_on_hand, quantity)
       end
 
@@ -113,7 +113,7 @@ module Spree
       end
 
       def restock_variant
-        if Spree::Config[:track_inventory_levels]
+        if Spree::Config[:track_inventory_levels]&&!variant.on_demand
           variant.on_hand += 1
           variant.save
         end

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -110,9 +110,9 @@ module Spree
     end
 
     def on_demand=(new_on_demand)
-      raise 'cannot set on_demand of product with variants'if has_variants? && Spree::Config[:track_inventory_levels]
-      master.on_demand=on_demand
-      self[:on_demand]=new_on_demand
+      raise 'cannot set on_demand of product with variants' if has_variants? && Spree::Config[:track_inventory_levels]
+      master.on_demand = on_demand
+      self[:on_demand] = new_on_demand
     end
 
     # Returns true if there are inventory units (any variant) with "on_hand" state for this product

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -131,7 +131,7 @@ module Spree
     end
 
     def on_demand=(on_demand)
-      self[:on_demand]=on_demand
+      self[:on_demand] = on_demand
       if on_demand
         inventory_units.with_state('backordered').each(&:fill_backorder)
       end

--- a/core/app/views/spree/admin/products/_form.html.erb
+++ b/core/app/views/spree/admin/products/_form.html.erb
@@ -49,6 +49,10 @@
       <% end %>
 
       <% if Spree::Config[:track_inventory_levels] %>
+        <%= f.field_container :on_demand do %>
+          <%= f.label :on_demand, t(:on_demand) %>
+          <%= f.check_box :on_demand %>
+        <% end %>
         <%= f.field_container :on_hand do %>
           <%= f.label :on_hand, t(:on_hand) %>
           <%= f.number_field :on_hand, :min => 0 %>

--- a/core/app/views/spree/admin/variants/_form.html.erb
+++ b/core/app/views/spree/admin/variants/_form.html.erb
@@ -34,6 +34,10 @@
 
     <% if Spree::Config[:track_inventory_levels] %>
       <div class="field" data-hook="on_hand">
+        <%= f.label :on_demand, t(:on_demand) %>
+        <%= f.check_box :on_demand, :class => 'fullwidth' %>
+      </div>
+      <div class="field" data-hook="on_hand">
         <%= f.label :on_hand, t(:on_hand) %>
         <%= f.text_field :on_hand, :class => 'fullwidth' %>
       </div>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -88,6 +88,7 @@ en:
         master_price: "Master Price"
         name: Name
         on_hand: "On Hand"
+        on_demand: "On Demand"
         shipping_category: "Shipping Category"
         tax_category: "Tax Category"
       spree/property:

--- a/core/db/migrate/20121012071449_add_on_demand_to_product_and_variant.rb
+++ b/core/db/migrate/20121012071449_add_on_demand_to_product_and_variant.rb
@@ -1,0 +1,6 @@
+class AddOnDemandToProductAndVariant < ActiveRecord::Migration
+  def change
+  	add_column :spree_products, :on_demand, :boolean, :default => false
+  	add_column :spree_variants, :on_demand, :boolean, :default => false
+  end
+end

--- a/core/spec/models/inventory_unit_spec.rb
+++ b/core/spec/models/inventory_unit_spec.rb
@@ -5,7 +5,7 @@ describe Spree::InventoryUnit do
     reset_spree_preferences
   end
 
-  let(:variant) { mock_model(Spree::Variant, :on_hand => 95) }
+  let(:variant) { mock_model(Spree::Variant, :on_hand => 95, :on_demand => false) }
   let(:line_item) { mock_model(Spree::LineItem, :variant => variant, :quantity => 5) }
   let(:order) { mock_model(Spree::Order, :line_items => [line_item], :inventory_units => [], :shipments => mock('shipments'), :completed? => true) }
 
@@ -47,6 +47,19 @@ describe Spree::InventoryUnit do
     context "when :track_inventory_levels is false" do
       before do
         Spree::Config.set :track_inventory_levels => false
+        Spree::InventoryUnit.stub(:create_units)
+      end
+
+      it "should decrement count_on_hand" do
+        variant.should_not_receive(:decrement!)
+        Spree::InventoryUnit.increase(order, variant, 5)
+      end
+
+    end
+    
+    context "when on_demand is true" do
+      before do
+        variant.stub(:on_demand).and_return(true)
         Spree::InventoryUnit.stub(:create_units)
       end
 
@@ -102,6 +115,19 @@ describe Spree::InventoryUnit do
     context "when :track_inventory_levels is false" do
       before do
         Spree::Config.set :track_inventory_levels => false
+        Spree::InventoryUnit.stub(:destroy_units)
+      end
+
+      it "should decrement count_on_hand" do
+        variant.should_not_receive(:increment!)
+        Spree::InventoryUnit.decrease(order, variant, 5)
+      end
+
+    end
+
+    context "when on_demand is true" do
+      before do
+        variant.stub(:on_demand).and_return(true)
         Spree::InventoryUnit.stub(:destroy_units)
       end
 
@@ -184,6 +210,15 @@ describe Spree::InventoryUnit do
       end
     end
 
+    context "when :on_demand is true" do
+      before { variant.stub(:on_demand).and_return(true) }
+
+      it "should return zero back orders" do
+        variant.stub(:on_hand).and_return(nil)
+        Spree::InventoryUnit.determine_backorder(order, variant, 5).should == 0
+      end
+    end
+
   end
 
   context "#create_units" do
@@ -247,7 +282,7 @@ describe Spree::InventoryUnit do
   end
 
   context "return!" do
-    let(:inventory_unit) { Spree::InventoryUnit.create({:state => "shipped", :variant => mock_model(Spree::Variant, :on_hand => 95)}, :without_protection => true) }
+    let(:inventory_unit) { Spree::InventoryUnit.create({:state => "shipped", :variant => mock_model(Spree::Variant, :on_hand => 95, :on_demand => false)}, :without_protection => true) }
 
     it "should update on_hand for variant" do
       inventory_unit.variant.should_receive(:on_hand=).with(96)
@@ -265,6 +300,16 @@ describe Spree::InventoryUnit do
         inventory_unit.return!
       end
     end
+    context "when on_demand is true" do
+      before { inventory_unit.variant.stub(:on_demand).and_return(true) }
+
+      it "does not update on_hand for variant" do
+        inventory_unit.variant.should_not_receive(:on_hand=).with(96)
+        inventory_unit.variant.should_not_receive(:save)
+        inventory_unit.return!
+      end
+    end
+
   end
 end
 


### PR DESCRIPTION
Added an on demand option for products and variants whose inventory should not be tracked as they are produced on demand or shipped by a third party.

It's my serious pull request so:
1. Pull with caution.
2. Any feedback appreciated.

[fixes #1940]
