### PR TITLE
Define import variables scss explicitly to allow extensions to run JS re...

### DIFF
--- a/core/app/assets/stylesheets/store/screen.css.scss
+++ b/core/app/assets/stylesheets/store/screen.css.scss
@@ -1,4 +1,4 @@
-@import "store/variables";
+@import "./variables.css.scss";
 
 /*--------------------------------------*/
 /* Basic styles 


### PR DESCRIPTION
...quest specs.

When attempting to run request specs w/Javascript drivers during extension development  you receive the following error: File to import not found or unreadable: store/variables

Even though running the dummy app with rails s works fine, which is odd.  I found to fix the issue you must change the import call, and both the leading ./ and .css.scss extension must be present to resolve the issue.

This fix should resolve issue #1824 I believe.

The issues also similar to #1874 & #1649 which were closed already after getting the sandbox to run.

@radar if you could please also pull this into 1-1-stable that would be great.  Thanks!
