### PR TITLE
Update order before redirecting to checkout

### DIFF
--- a/core/app/views/spree/orders/edit.html.erb
+++ b/core/app/views/spree/orders/edit.html.erb
@@ -26,7 +26,9 @@
           <%= button_tag :class => 'primary', :id => 'update-button' do %>
             <%= t(:update) %>
           <% end %>
-         <%= link_to t(:checkout), checkout_state_path(@order.checkout_steps.first), :class => 'button checkout primary', :id => 'checkout-link' %>
+          <%= button_tag :class => 'button checkout primary', :id => 'checkout-link', :name => 'checkout' do %>
+            <%= t(:checkout) %>
+          <% end %>
         </div>
 
       </div>

--- a/core/spec/requests/admin/configuration/shipping_methods_spec.rb
+++ b/core/spec/requests/admin/configuration/shipping_methods_spec.rb
@@ -81,7 +81,7 @@ describe "Shipping Methods" do
           visit spree.root_path
           click_link "Mug"
           click_button "Add To Cart"
-          click_link "Checkout"
+          click_button "Checkout"
 
           str_addr = "bill_address"
           select "United States", :from => "order_#{str_addr}_attributes_country_id"
@@ -108,7 +108,7 @@ describe "Shipping Methods" do
           visit spree.root_path
           click_link "Mug"
           click_button "Add To Cart"
-          click_link "Checkout"
+          click_button "Checkout"
 
           str_addr = "bill_address"
           select "United States", :from => "order_#{str_addr}_attributes_country_id"
@@ -137,7 +137,7 @@ describe "Shipping Methods" do
           visit spree.root_path
           click_link "Mug"
           click_button "Add To Cart"
-          click_link "Checkout"
+          click_button "Checkout"
 
           str_addr = "bill_address"
           select "United States", :from => "order_#{str_addr}_attributes_country_id"
@@ -162,7 +162,7 @@ describe "Shipping Methods" do
           visit spree.root_path
           click_link "Mug"
           click_button "Add To Cart"
-          click_link "Checkout"
+          click_button "Checkout"
 
           str_addr = "bill_address"
           select "United States", :from => "order_#{str_addr}_attributes_country_id"
@@ -198,7 +198,7 @@ describe "Shipping Methods" do
           click_link "Home"
           click_link "Shirt"
           click_button "Add To Cart"
-          click_link "Checkout"
+          click_button "Checkout"
 
           str_addr = "bill_address"
           select "United States", :from => "order_#{str_addr}_attributes_country_id"
@@ -226,7 +226,7 @@ describe "Shipping Methods" do
           click_link "Home"
           click_link "Shirt"
           click_button "Add To Cart"
-          click_link "Checkout"
+          click_button "Checkout"
 
           str_addr = "bill_address"
           select "United States", :from => "order_#{str_addr}_attributes_country_id"

--- a/core/spec/requests/checkout_spec.rb
+++ b/core/spec/requests/checkout_spec.rb
@@ -91,7 +91,7 @@ describe "Checkout" do
           visit spree.root_path
           click_link "RoR Mug"
           click_button "add-to-cart-button"
-          click_link "Checkout"
+          click_button "Checkout"
           Spree::Order.last.update_column(:email, "ryan@spreecommerce.com")
 
           address = "order_bill_address_attributes"

--- a/promo/app/controllers/spree/orders_controller_decorator.rb
+++ b/promo/app/controllers/spree/orders_controller_decorator.rb
@@ -13,7 +13,11 @@ Spree::OrdersController.class_eval do
       end
       @order.line_items = @order.line_items.select {|li| li.quantity > 0 }
       fire_event('spree.order.contents_changed')
-      respond_with(@order) { |format| format.html { redirect_to cart_path } }
+      if params.has_key?(:checkout)
+        respond_with(@order) { |format| format.html { redirect_to checkout_state_path(@order.checkout_steps.first) } }
+      else
+        respond_with(@order) { |format| format.html { redirect_to cart_path } }
+      end
     else
       respond_with(@order)
     end


### PR DESCRIPTION
When clicking 'Checkout' on the cart page, any changes made to the order will not e saved unless 'Update' is clicked first, updating the order. 

I propose we update the 'Checkout' button to also update the order. This way, any last minute changes will be preserved while a user is attempting to checkout.

I am putting this up for discussion at the moment. You will notice I added this code to promo rather than core. This is because promo overrides the update action on Spree::OrdersController. I think this is something that could use some clean up as well.

Thanks
