### PR TITLE
Correct card_code typo, and add coupon code hook.

### DIFF
--- a/core/app/views/spree/checkout/payment/_gateway.html.erb
+++ b/core/app/views/spree/checkout/payment/_gateway.html.erb
@@ -19,7 +19,7 @@
   <%= select_year(Date.today, :prefix => param_prefix, :field_name => 'year', :start_year => Date.today.year, :end_year => Date.today.year + 15, :class => 'required') %>
   <span class="required">*</span>
 </p>
-<p class="field" data-hook="cart_code">
+<p class="field" data-hook="card_code">
   <%= label_tag nil, t(:card_code) %><br />
   <%= text_field_tag "#{param_prefix}[verification_value]", '', options_hash.merge(:id => 'card_code', :class => 'required', :size => 5) %>
   <span class="required">*</span>

--- a/promo/app/views/spree/checkout/_coupon_code_field.html.erb
+++ b/promo/app/views/spree/checkout/_coupon_code_field.html.erb
@@ -1,6 +1,6 @@
 <% if Spree::Promotion.count > 0 %>
-<p>
-  <%= form.label :coupon_code %><br />
-  <%= form.text_field :coupon_code %>
-</p>
+  <p class='field' data-hook='coupon_code'>
+    <%= form.label :coupon_code %><br />
+    <%= form.text_field :coupon_code %>
+  </p>
 <% end %>


### PR DESCRIPTION
The #card_code fields wrapping p tag has a typo for the hook value.

I also added the field class and a data hook to the promo coupon code field to match markup for the other fields when you want to add styling to the field class or utilize deface.
