### PR TITLE
Provide the Spree current user to the searcher class

### DIFF
--- a/core/app/controllers/spree/home_controller.rb
+++ b/core/app/controllers/spree/home_controller.rb
@@ -5,6 +5,7 @@ module Spree
 
     def index
       @searcher = Spree::Config.searcher_class.new(params)
+      @searcher.current_user = try_spree_current_user
       @products = @searcher.retrieve_products
       respond_with(@products)
     end

--- a/core/app/controllers/spree/products_controller.rb
+++ b/core/app/controllers/spree/products_controller.rb
@@ -8,6 +8,7 @@ module Spree
 
     def index
       @searcher = Config.searcher_class.new(params)
+      @searcher.current_user = try_spree_current_user
       @products = @searcher.retrieve_products
       respond_with(@products)
     end

--- a/core/app/controllers/spree/taxons_controller.rb
+++ b/core/app/controllers/spree/taxons_controller.rb
@@ -10,6 +10,7 @@ module Spree
       return unless @taxon
 
       @searcher = Spree::Config.searcher_class.new(params.merge(:taxon => @taxon.id))
+      @searcher.current_user = try_spree_current_user
       @products = @searcher.retrieve_products
 
       respond_with(@taxon)

--- a/core/lib/spree/core/search/base.rb
+++ b/core/lib/spree/core/search/base.rb
@@ -3,6 +3,7 @@ module Spree
     module Search
       class Base
         attr_accessor :properties
+        attr_accessor :current_user
 
         def initialize(params)
           @properties = {}

--- a/core/spec/controllers/spree/home_controller_spec.rb
+++ b/core/spec/controllers/spree/home_controller_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe Spree::HomeController do
+  it "should provide the current user to the searcher class" do
+    user = stub(:last_incomplete_spree_order => nil)
+    controller.stub :spree_current_user => user
+    Spree::Config.searcher_class.any_instance.should_receive(:current_user=).with(user)
+    spree_get :index
+    response.status.should == 200
+  end
+end

--- a/core/spec/controllers/spree/products_controller_spec.rb
+++ b/core/spec/controllers/spree/products_controller_spec.rb
@@ -14,4 +14,12 @@ describe Spree::ProductsController do
     spree_get :show, :id => product.to_param
     response.status.should == 404
   end
+
+  it "should provide the current user to the searcher class" do
+    user = stub(:last_incomplete_spree_order => nil)
+    controller.stub :spree_current_user => user
+    Spree::Config.searcher_class.any_instance.should_receive(:current_user=).with(user)
+    spree_get :index
+    response.status.should == 200
+  end
 end

--- a/core/spec/controllers/spree/taxons_controller_spec.rb
+++ b/core/spec/controllers/spree/taxons_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe Spree::TaxonsController do
+  it "should provide the current user to the searcher class" do
+    taxon = create(:taxon, :permalink => "test")
+    user = stub(:last_incomplete_spree_order => nil)
+    controller.stub :spree_current_user => user
+    Spree::Config.searcher_class.any_instance.should_receive(:current_user=).with(user)
+    spree_get :show, :id => taxon.permalink
+    response.status.should == 200
+  end
+end

--- a/core/spec/lib/search/base_spec.rb
+++ b/core/spec/lib/search/base_spec.rb
@@ -50,4 +50,11 @@ describe Spree::Core::Search::Base do
     searcher.retrieve_products.count.should == 1
   end
 
+  it "accepts a current user" do
+    user = stub
+    searcher = Spree::Core::Search::Base.new({})
+    searcher.current_user = user
+    searcher.current_user.should eql(user)
+  end
+
 end


### PR DESCRIPTION
I needed to provide the current user from my application to Spree, in order to hide results that were not relevant for that users location.

I figured this might be a common use case so I've attached a patch to do just that.

By default, it will do nothing at all with this information, the idea is this could be hooked in by extending the searcher class.
