### PR TITLE
On branch fix_skeleton_use_of_alpha_omega_classes

### DIFF
--- a/core/app/views/spree/layouts/spree_application.html.erb
+++ b/core/app/views/spree/layouts/spree_application.html.erb
@@ -13,7 +13,7 @@
       <div id="wrapper" class="row" data-hook>
           <%= breadcrumbs(@taxon) %>
         <%= render :partial => 'spree/shared/sidebar' if content_for? :sidebar %>
-        <div id="content" class="columns omega <%= !content_for?(:sidebar) ? "sixteen alpha" : "twelve" %>" data-hook>
+        <div id="content" class="columns <%= !content_for?(:sidebar) ? "sixteen" : "twelve" %>" data-hook>
           <%= flash_messages %>
           <%= yield %>
         </div>

--- a/core/app/views/spree/shared/_footer.html.erb
+++ b/core/app/views/spree/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer id="footer" class="alpha omega sixteen columns" data-hook>
+<footer id="footer" class="sixteen columns" data-hook>
   <div id="footer-left" class="columns alpha eight" data-hook>
     <p><%= t :powered_by  %> <%= link_to 'Spree', 'http://spreecommerce.com/' %></p>
   </div>

--- a/core/app/views/spree/shared/_header.html.erb
+++ b/core/app/views/spree/shared/_header.html.erb
@@ -1,5 +1,5 @@
 <header id="header" class="row" data-hook>
-  <figure id="logo" class="columns alpha six" data-hook><%= logo %></figure>
+  <figure id="logo" class="columns six" data-hook><%= logo %></figure>
   <%= render :partial => 'spree/shared/nav_bar' %>
   <%= render :partial => 'spree/shared/main_nav_bar' if store_menu? %>
 </header>

--- a/core/app/views/spree/shared/_main_nav_bar.html.erb
+++ b/core/app/views/spree/shared/_main_nav_bar.html.erb
@@ -1,4 +1,4 @@
-<nav class="columns alpha omega sixteen">
+<nav class="columns sixteen">
   <ul id="main-nav-bar" class="inline" data-hook>
     <li id="home-link" data-hook><%= link_to t(:home), root_path %></li>
     <li id="link-to-cart" data-hook><%= link_to_cart %></li>

--- a/core/app/views/spree/shared/_nav_bar.html.erb
+++ b/core/app/views/spree/shared/_nav_bar.html.erb
@@ -1,4 +1,4 @@
-<nav id="top-nav-bar" class="columns omega ten">
+<nav id="top-nav-bar" class="columns ten">
   <ul id="nav-bar" class="inline" data-hook>
     <li id="search-bar" data-hook>
       <%= render :partial => 'spree/shared/search' %>

--- a/core/app/views/spree/shared/_sidebar.html.erb
+++ b/core/app/views/spree/shared/_sidebar.html.erb
@@ -1,3 +1,3 @@
-<aside id="sidebar" class="columns alpha four" data-hook>
+<aside id="sidebar" class="columns four" data-hook>
   <%= yield :sidebar %>
 </aside>


### PR DESCRIPTION
Changes to be committed:

modified:   ../core/app/views/spree/layouts/spree_application.html.erb
modified:   ../core/app/views/spree/shared/_footer.html.erb
modified:   ../core/app/views/spree/shared/_header.html.erb
modified:   ../core/app/views/spree/shared/_main_nav_bar.html.erb
modified:   ../core/app/views/spree/shared/_nav_bar.html.erb
modified:   ../core/app/views/spree/shared/_sidebar.html.erb

Remove not correctly used alpha & omega classes from layout and partials.

Fixes #1921
