### PR TITLE
On branch remove_formalize

### DIFF
--- a/core/app/assets/javascripts/store/spree_core.js
+++ b/core/app/assets/javascripts/store/spree_core.js
@@ -1,5 +1,4 @@
 //= require jquery.validate/jquery.validate.min
-//= require jquery.formalize.min
 //= require store/checkout
 //= require store/product
 //= require store/cart

--- a/core/app/assets/stylesheets/store/screen.css.scss
+++ b/core/app/assets/stylesheets/store/screen.css.scss
@@ -5,15 +5,21 @@
 /*--------------------------------------*/
 body {
   font-family: $ff_base;
-  color: $body_text_color;
-  line-height: 18px;
   font-size: $base_font_size;
+  font-weight: 400;
+  color: $body_text_color;
+  line-height: 18px;  
   background-color: $layout_background_color;
+  -webkit-font-smoothing: antialiased;
 }
 
 /* Line style */
 hr {
-  border-color: $border_color;
+  height: 0;
+  background-color: transparent;
+  color: transparent;
+  border: none;
+  border-bottom: 1px solid $border_color;
 }
 
 /* Custom text-selection colors (remove any text shadows: twitter.com/miketaylr/status/12228805301) */
@@ -42,6 +48,11 @@ mark {background-color: $link_text_color; color: $layout_background_color; font-
   /* Lists
   /*--------------------------------------*/
   ul, ol {
+    margin-left: 0;
+    margin-top: 0;
+    -webkit-padding-start: 0px;
+    list-style-position: inside;
+
     &.inline {
       li {
         display: inline-block;
@@ -79,8 +90,10 @@ mark {background-color: $link_text_color; color: $layout_background_color; font-
   h6 { font-size: $sub_heading_font_size - 2; line-height: $sub_heading_font_size - 2 + 10; }
 
   h1, h2, h3, h4, h5, h6 {    
-    font-weight: bold;
+    font-weight: 700;
     color: $title_text_color;
+    -webkit-margin-before: 0;
+    -webkit-margin-after: 0;
   }
 
   /*--------------------------------------*/
@@ -93,7 +106,7 @@ mark {background-color: $link_text_color; color: $layout_background_color; font-
   input[type="text"], input[type="time"], input[type="url"], 
   input[type="week"] {
     border: $default_border;
-    padding: 2px 5px;    
+    padding: 5px 10px;    
     font-family: $ff_base;
     font-size: $input_box_font_size;
 
@@ -111,18 +124,6 @@ mark {background-color: $link_text_color; color: $layout_background_color; font-
     }
   }
 
-  select {
-    border: $default_border;
-    font-family: $ff_base;
-    background-image: url('select_arrow.gif');
-    background-repeat: no-repeat;
-    background-position: right center;
-
-    &:active, &:focus {
-      @extend input[type="text"]:focus  
-    }
-  }
-
   label.error {
     display: block;
     font-size: $base_font_size - 1;
@@ -136,6 +137,10 @@ mark {background-color: $link_text_color; color: $layout_background_color; font-
     font-size: 1.2em;
   }
 
+  fieldset {
+    margin: 0;
+  }
+
   input[type="submit"], input[type="button"],
   input[type= "reset"], button, a.button {
     background-color: $link_text_color;
@@ -146,6 +151,11 @@ mark {background-color: $link_text_color; color: $layout_background_color; font-
     font-size: $button_font_size;
     font-family: $ff_base;
     border: 1px solid $button_border_color;
+    padding: 6px 10px 5px;
+    vertical-align:  top;
+
+    -webkit-font-smoothing: antialiased;
+
     -webkit-box-shadow: inset 0 1px 0 rgba(255,255,255,0.4);
      -khtml-box-shadow: inset 0 1px 0 rgba(255,255,255,0.4);
        -moz-box-shadow: inset 0 1px 0 rgba(255,255,255,0.4);
@@ -157,7 +167,6 @@ mark {background-color: $link_text_color; color: $layout_background_color; font-
         -ms-border-radius: 0px;
          -o-border-radius: 0px;
             border-radius: 0px;
-    vertical-align:  text-top;
 
     &.large {
       padding: 7px 10px;
@@ -183,9 +192,7 @@ mark {background-color: $link_text_color; color: $layout_background_color; font-
     }
   } 
 
-  input[type="checkbox"], input[type="button"],
-  input[type="submit"], input[type="reset"], 
-  button, label {
+  input[type="checkbox"], label {
     vertical-align: middle;
   }
 
@@ -416,8 +423,7 @@ mark {background-color: $link_text_color; color: $layout_background_color; font-
       margin-right: 3px;
       width: 60px;
       vertical-align: middle;
-      padding: 5px;
-      height: 35px;
+      padding: 8px 10px;
     }
   }
 
@@ -638,6 +644,17 @@ mark {background-color: $link_text_color; color: $layout_background_color; font-
             }
           }
         }
+      }
+    }
+  }
+
+  #payment-methods {
+    list-style: none;
+
+    li {
+      fieldset {
+        border: none;
+        padding: 0;
       }
     }
   }

--- a/core/app/assets/stylesheets/store/screen.css.scss
+++ b/core/app/assets/stylesheets/store/screen.css.scss
@@ -42,6 +42,10 @@ mark {background-color: $link_text_color; color: $layout_background_color; font-
     &:hover {
       color: darken($link_text_color, 10) !important;
     }
+
+    &:active, &:focus {
+      outline: none;
+    }
   }
 
   /*--------------------------------------*/
@@ -51,6 +55,7 @@ mark {background-color: $link_text_color; color: $layout_background_color; font-
     margin-left: 0;
     margin-top: 0;
     -webkit-padding-start: 0px;
+    padding-left: 0;
     list-style-position: inside;
 
     &.inline {
@@ -94,6 +99,8 @@ mark {background-color: $link_text_color; color: $layout_background_color; font-
     color: $title_text_color;
     -webkit-margin-before: 0;
     -webkit-margin-after: 0;
+    margin-top: 0;
+    margin-bottom: 0;
   }
 
   /*--------------------------------------*/
@@ -329,10 +336,6 @@ mark {background-color: $link_text_color; color: $layout_background_color; font-
     }
 
     .taxons-list {
-      padding-left: 20px;
-      margin-bottom: 20px;
-      list-style: disc outside;
-
       li {
         a {
           font-size: $main_navigation_font_size

--- a/core/app/assets/stylesheets/store/spree_core.css
+++ b/core/app/assets/stylesheets/store/spree_core.css
@@ -1,7 +1,6 @@
 /*
 * This is a manifest file that includes stylesheets for spree_core  
- *= require html5reset
+ *= require normalize
  *= require skeleton
- *= require jquery.formalize
  *= require store/screen 
 */

--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -101,7 +101,7 @@ module Spree
         crumbs << content_tag(:li, content_tag(:span, t(:products)))
       end
       crumb_list = content_tag(:ul, raw(crumbs.flatten.map{|li| li.mb_chars}.join), :class => 'inline')
-      content_tag(:nav, crumb_list, :id => 'breadcrumbs')
+      content_tag(:nav, crumb_list, :id => 'breadcrumbs', :class => 'sixteen columns')
     end
 
     def taxons_tree(root_taxon, current_taxon, max_level = 1)


### PR DESCRIPTION
Changes to be committed:

modified:   ../core/app/assets/javascripts/store/spree_core.js
modified:   ../core/app/assets/stylesheets/store/screen.css.scss
modified:   ../core/app/assets/stylesheets/store/spree_core.css
modified:   ../core/app/helpers/spree/base_helper.rb

Remove jquery.formalize and html5reset. Now both admin and frontend will use normalize.css

Fixes #1742
