### PR TITLE
Bypass assets host for states JS

### DIFF
--- a/core/app/views/spree/checkout/edit.html.erb
+++ b/core/app/views/spree/checkout/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :head do %>
-  <%= javascript_include_tag states_path(:format => :js) %>
+  <%= javascript_include_tag states_url(:format => :js) %>
 <% end %>
 <div id="checkout" data-hook>  
   <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @order } %>


### PR DESCRIPTION
If you push to a production environment that uses `assets_host` and go through the checkout process, you'll get an error about states.js missing because Rails is trying to use the `assets_host` to build the URL.

This patch just uses the `_url` helper to bypass the `assets_host` config. It seems a little hacky, but I couldn't find another way to tell Rails not to insert the `assets_host` value.
