### PR TITLE
Update core/app/views/spree/orders/_line_item.html.erb

### DIFF
--- a/core/app/views/spree/orders/_line_item.html.erb
+++ b/core/app/views/spree/orders/_line_item.html.erb
@@ -14,7 +14,7 @@
         <%= variant.in_stock? ? t(:insufficient_stock, :on_hand => variant.on_hand) : t(:out_of_stock) %><br />
       </span>
     <% end %>
-    <%= line_item_description(variant) %>
+    <%= line_item_description(variant).html_safe %>
   </td>
   <td class="cart-item-price" data-hook="cart_item_price">
     <%= money line_item.price %>


### PR DESCRIPTION
Add .html_safe for line_item_description(variant) in order to see letters accents in languages like French, eg :

é instead of &eacute;
