### PR TITLE
Sugestion to remove :rails_root from attachment_path

### DIFF
--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -67,7 +67,7 @@ module Spree
 
     # Preferences related to image settings
     preference :attachment_default_url, :string, :default => '/spree/products/:id/:style/:basename.:extension'
-    preference :attachment_path, :string, :default => ':rails_root/public/spree/products/:id/:style/:basename.:extension'
+    preference :attachment_path, :string, :default => '/public/spree/products/:id/:style/:basename.:extension'
     preference :attachment_url, :string, :default => '/spree/products/:id/:style/:basename.:extension'
     preference :attachment_styles, :string, :default => "{\"mini\":\"48x48>\",\"small\":\"100x100>\",\"product\":\"240x240>\",\"large\":\"600x600>\"}"
     preference :attachment_default_style, :string, :default => 'product'


### PR DESCRIPTION
I believe we don't want to store any images with with a path like this one:

/Users/Davidslv/projects/teresa-alecrim/public/spree ...

So I removed the :rails_root because it doesn't make sense for s3.

---

I'm thinking if this could be a problem for people that are not using AWS.

What are your opinions about this?
