### PR TITLE
Fix and extend Product Properties REST API to work with real IDs to

### DIFF
--- a/api/app/controllers/spree/api/v1/product_properties_controller.rb
+++ b/api/app/controllers/spree/api/v1/product_properties_controller.rb
@@ -48,10 +48,14 @@ module Spree
         private
           def product
             @product ||= Spree::Product.find_by_permalink(params[:product_id]) if params[:product_id]
+            @product ||= Spree::Product.find_by_id(params[:product_id]) if params[:product_id]
           end
           
           def product_property
-            @product_property = @product.product_properties.find(:first, :joins => :property, :conditions => {'spree_properties.name' => params['id']},:readonly => false)
+            if @product
+              @product_property ||= @product.product_properties.find(:first, :joins => :property, :conditions => {'spree_properties.name' => params[:id]},:readonly => false)
+              @product_property ||= @product.product_properties.find_by_id(params[:id])
+            end
           end
       end
     end

--- a/api/app/controllers/spree/api/v1/product_properties_controller.rb
+++ b/api/app/controllers/spree/api/v1/product_properties_controller.rb
@@ -1,0 +1,59 @@
+module Spree
+  module Api
+    module V1
+      class ProductPropertiesController < Spree::Api::V1::BaseController
+        before_filter :product
+        before_filter :product_property, :only => [:show, :update, :destroy]
+
+        def index
+          @product_properties = @product.product_properties
+        end
+        
+        def show
+        end
+        
+        def new
+        end
+        
+        def create
+          authorize! :create, ProductProperty
+          @product_property = @product.product_properties.new(params[:product_property])
+          if @product_property.save
+            render :show, :status => 201
+          else
+            invalid_resource!(@product_property)
+          end
+        end
+        
+        def update
+          authorize! :update, ProductProperty
+          if @product_property  && @product_property.update_attributes(params[:product_property])
+            render :show, :status => 200
+          else
+            invalid_resource!(@product_property)
+          end
+        end
+        
+        def destroy
+          authorize! :delete, ProductProperty
+          if(@product_property)
+            @product_property.destroy
+            render :text => nil, :status => 200
+          else
+            invalid_resource!(@product_property)
+          end
+          
+        end
+        
+        private
+          def product
+            @product ||= Spree::Product.find_by_permalink(params[:product_id]) if params[:product_id]
+          end
+          
+          def product_property
+            @product_property = @product.product_properties.find(:first, :joins => :property, :conditions => {'spree_properties.name' => params['property_name']},:readonly => false)
+          end
+      end
+    end
+  end
+end

--- a/api/app/controllers/spree/api/v1/product_properties_controller.rb
+++ b/api/app/controllers/spree/api/v1/product_properties_controller.rb
@@ -51,7 +51,7 @@ module Spree
           end
           
           def product_property
-            @product_property = @product.product_properties.find(:first, :joins => :property, :conditions => {'spree_properties.name' => params['property_name']},:readonly => false)
+            @product_property = @product.product_properties.find(:first, :joins => :property, :conditions => {'spree_properties.name' => params['id']},:readonly => false)
           end
       end
     end

--- a/api/app/views/spree/api/v1/product_properties/index.rabl
+++ b/api/app/views/spree/api/v1/product_properties/index.rabl
@@ -1,0 +1,4 @@
+collection @product_properties
+attributes *product_property_attributes 
+
+

--- a/api/app/views/spree/api/v1/product_properties/new.rabl
+++ b/api/app/views/spree/api/v1/product_properties/new.rabl
@@ -1,0 +1,2 @@
+node(:attributes) { [*product_property_attributes] }
+node(:required_attributes) { [] }

--- a/api/app/views/spree/api/v1/product_properties/show.rabl
+++ b/api/app/views/spree/api/v1/product_properties/show.rabl
@@ -1,0 +1,2 @@
+object @product_property
+attributes *product_property_attributes

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -16,13 +16,14 @@ Spree::Core::Engine.routes.prepend do
         end
 
         resources :variants
+        resources :product_properties
       end
 
       resources :images
 
       resources :variants, :only => [:index] do
       end
-
+      
       resources :orders do
         collection do
           get :search

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -20,7 +20,6 @@ Spree::Core::Engine.routes.prepend do
       end
 
       resources :images
-
       resources :variants, :only => [:index] do
       end
       

--- a/api/spec/controllers/spree/api/v1/product_properties_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/product_properties_controller_spec.rb
@@ -23,7 +23,7 @@ module Spree
     end
     
     it "can see a single product_property" do
-      api_get :show, :property_name => property_1.property_name
+      api_get :show, :id => property_1.property_name
       json_response.count.should eq 1
       json_response.should have_attributes(attributes)
     end
@@ -40,7 +40,7 @@ module Spree
     end
     
     it "cannot update a product property" do
-      api_put :update, :property_name => property_1.property_name, :product_property => { :value => "my value 456" }
+      api_put :update, :id => property_1.property_name, :product_property => { :value => "my value 456" }
       assert_unauthorized!
     end
     
@@ -62,12 +62,12 @@ module Spree
       end
 
       it "can update a product property" do
-        api_put :update, :property_name => property_1.property_name, :product_property => { :value => "my value 456" }
+        api_put :update, :id => property_1.property_name, :product_property => { :value => "my value 456" }
         response.status.should == 200
       end
 
       it "can delete a variant" do
-        api_delete :destroy, :property_name => property_1.property_name
+        api_delete :destroy, :id => property_1.property_name
         response.status.should == 200
         lambda { property_1.reload }.should raise_error(ActiveRecord::RecordNotFound)
       end

--- a/api/spec/controllers/spree/api/v1/product_properties_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/product_properties_controller_spec.rb
@@ -8,54 +8,54 @@ module Spree
     let!(:product) { create(:product) }
     let!(:property_1) {product.product_properties.create(:property_name => "My Property 1", :value => "my value 1")}
     let!(:property_2) {product.product_properties.create(:property_name => "My Property 2", :value => "my value 2")}
-    
+
     let(:attributes) { [:id, :product_id, :property_id, :value, :property_name] }
     let(:resource_scoping) { { :product_id => product.to_param } }
 
     before do
       stub_authentication!
     end
-    
+
     it "can see a list of all product properties" do
       api_get :index
       json_response.count.should eq 2
       json_response.first.should have_attributes(attributes)
     end
-    
+
     it "can see a single product_property" do
       api_get :show, :id => property_1.property_name
       json_response.count.should eq 1
       json_response.should have_attributes(attributes)
     end
-    
+
     it "can learn how to create a new product property" do
       api_get :new
       json_response["attributes"].should == attributes.map(&:to_s)
       json_response["required_attributes"].should be_empty
     end
-    
+
     it "cannot create a new product property if not an admin" do
       api_post :create, :product_property => { :property_name => "My Property 3" }
       assert_unauthorized!
     end
-    
+
     it "cannot update a product property" do
       api_put :update, :id => property_1.property_name, :product_property => { :value => "my value 456" }
       assert_unauthorized!
     end
-    
+
     it "cannot delete a product property" do
       api_delete :destroy, :property_name => property_1.property_name
       assert_unauthorized!
       lambda { property_1.reload }.should_not raise_error
     end
-    
+
     context "as an admin" do
       sign_in_as_admin!
 
       it "can create a new product property" do
         expect do
-          api_post :create, :product_property => { :property_name => "My Property 3", :value => "my value 3" }  
+          api_post :create, :product_property => { :property_name => "My Property 3", :value => "my value 3" }
         end.to change(product.product_properties, :count).by(1)
         json_response.should have_attributes(attributes)
         response.status.should == 201
@@ -72,6 +72,21 @@ module Spree
         lambda { property_1.reload }.should raise_error(ActiveRecord::RecordNotFound)
       end
     end
-    
+
+    context "with product identified by id" do
+      let(:resource_scoping) { { :product_id => product.id } }
+      it "can see a list of all product properties" do
+        api_get :index
+        json_response.count.should eq 2
+        json_response.first.should have_attributes(attributes)
+      end
+      it "can see a single product_property by id" do
+        api_get :show, :id => property_1.id
+        json_response.count.should eq 1
+        puts "Response: #{json_response}"
+        json_response.should have_attributes(attributes)
+      end
+    end
+
   end
 end

--- a/api/spec/controllers/spree/api/v1/product_properties_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/product_properties_controller_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+require 'shared_examples/protect_product_actions'
+
+module Spree
+  describe Spree::Api::V1::ProductPropertiesController do
+    render_views
+
+    let!(:product) { create(:product) }
+    let!(:property_1) {product.product_properties.create(:property_name => "My Property 1", :value => "my value 1")}
+    let!(:property_2) {product.product_properties.create(:property_name => "My Property 2", :value => "my value 2")}
+    
+    let(:attributes) { [:id, :product_id, :property_id, :value, :property_name] }
+    let(:resource_scoping) { { :product_id => product.to_param } }
+
+    before do
+      stub_authentication!
+    end
+    
+    it "can see a list of all product properties" do
+      api_get :index
+      json_response.count.should eq 2
+      json_response.first.should have_attributes(attributes)
+    end
+    
+    it "can see a single product_property" do
+      api_get :show, :property_name => property_1.property_name
+      json_response.count.should eq 1
+      json_response.should have_attributes(attributes)
+    end
+    
+    it "can learn how to create a new product property" do
+      api_get :new
+      json_response["attributes"].should == attributes.map(&:to_s)
+      json_response["required_attributes"].should be_empty
+    end
+    
+    it "cannot create a new product property if not an admin" do
+      api_post :create, :product_property => { :property_name => "My Property 3" }
+      assert_unauthorized!
+    end
+    
+    it "cannot update a product property" do
+      api_put :update, :property_name => property_1.property_name, :product_property => { :value => "my value 456" }
+      assert_unauthorized!
+    end
+    
+    it "cannot delete a product property" do
+      api_delete :destroy, :property_name => property_1.property_name
+      assert_unauthorized!
+      lambda { property_1.reload }.should_not raise_error
+    end
+    
+    context "as an admin" do
+      sign_in_as_admin!
+
+      it "can create a new product property" do
+        expect do
+          api_post :create, :product_property => { :property_name => "My Property 3", :value => "my value 3" }  
+        end.to change(product.product_properties, :count).by(1)
+        json_response.should have_attributes(attributes)
+        response.status.should == 201
+      end
+
+      it "can update a product property" do
+        api_put :update, :property_name => property_1.property_name, :product_property => { :value => "my value 456" }
+        response.status.should == 200
+      end
+
+      it "can delete a variant" do
+        api_delete :destroy, :property_name => property_1.property_name
+        response.status.should == 200
+        lambda { property_1.reload }.should raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+    
+  end
+end


### PR DESCRIPTION
Fix naming of field for expected product_property [name|id].
Add support for working with real product and/or product property IDs
