### PR TITLE
Fix spelling in #calculator_available?

### DIFF
--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -24,7 +24,7 @@ module Spree
     end
 
     def calculator_available?(order)
-      caluclator.available?(order)
+      calculator.available?(order)
     end
 
     def within_zone?(order)


### PR DESCRIPTION
This fixes the spelling of calculator in #calculator_available in
Spree::ShippingMethod
