### PR TITLE
Require secure connection on OrderController#show

### DIFF
--- a/core/app/controllers/spree/orders_controller.rb
+++ b/core/app/controllers/spree/orders_controller.rb
@@ -1,5 +1,7 @@
 module Spree
   class OrdersController < BaseController
+    ssl_required :show
+    
     rescue_from ActiveRecord::RecordNotFound, :with => :render_404
     helper 'spree/products'
 


### PR DESCRIPTION
In reference to #2125. SSL is required per PCI compliance specifications.

I haven't tested this change, but since it is so small, it should be fine.
