### PR TITLE
Centralized Coupon Application Logic

### DIFF
--- a/core/app/controllers/spree/store_controller.rb
+++ b/core/app/controllers/spree/store_controller.rb
@@ -19,6 +19,7 @@ module Spree
     def default_notification_payload
       {:user => try_spree_current_user, :order => current_order}
     end
+
   end
 end
 

--- a/promo/app/controllers/spree/checkout_controller_decorator.rb
+++ b/promo/app/controllers/spree/checkout_controller_decorator.rb
@@ -5,18 +5,7 @@ Spree::CheckoutController.class_eval do
     if @order.update_attributes(object_params)
 
       fire_event('spree.checkout.update')
-
-      if @order.coupon_code.present?
-        event_name = "spree.checkout.coupon_code_added"
-        if promo = Spree::Promotion.with_coupon_code(@order.coupon_code).where(:event_name => event_name).first
-          fire_event(event_name, :coupon_code => @order.coupon_code)
-          # If it doesn't exist, raise an error!
-          # Giving them another chance to enter a valid coupon code
-        else
-          flash[:error] = t(:promotion_not_found)
-          render :edit and return
-        end
-      end
+      render :edit and return unless apply_coupon_code
 
       if @order.next
         state_callback(:after)

--- a/promo/app/controllers/spree/orders_controller_decorator.rb
+++ b/promo/app/controllers/spree/orders_controller_decorator.rb
@@ -3,14 +3,8 @@ Spree::OrdersController.class_eval do
   def update
     @order = current_order
     if @order.update_attributes(params[:order])
-      if @order.coupon_code.present?
-        if apply_coupon_code
-          flash[:notice] = t(:coupon_code_applied)
-        else
-          flash[:error] = t(:promotion_not_found)
-          render :edit and return
-        end
-      end
+      render :edit and return unless apply_coupon_code
+      
       @order.line_items = @order.line_items.select {|li| li.quantity > 0 }
       fire_event('spree.order.contents_changed')
       respond_with(@order) do |format|
@@ -24,16 +18,6 @@ Spree::OrdersController.class_eval do
       end
     else
       respond_with(@order)
-    end
-  end
-
-  def apply_coupon_code
-    return if @order.coupon_code.blank?
-    if promo = Spree::Promotion.with_coupon_code(@order.coupon_code).first
-      if promo.order_activatable?(@order)
-        fire_event('spree.checkout.coupon_code_added', :coupon_code => @order.coupon_code)
-        true
-      end
     end
   end
 

--- a/promo/app/controllers/spree/store_controller_decorator.rb
+++ b/promo/app/controllers/spree/store_controller_decorator.rb
@@ -1,0 +1,56 @@
+Spree::StoreController.class_eval do
+
+  protected
+    def apply_coupon_code
+      if @order.coupon_code.present?
+        # check if coupon code is already applied
+        if @order.adjustments.promotion.eligible.detect { |p| p.originator.promotion.code == @order.coupon_code }.present?
+          flash[:notice] = t(:coupon_code_already_applied)
+          true
+        else
+          event_name = "spree.checkout.coupon_code_added"
+
+          # TODO should restrict to payload's event name?
+          # case insensitive coupon name
+          promotion = Spree::Promotion.find(:first, :conditions => [ "lower(code) = ?", @order.coupon_code ])
+
+          if promotion.present?
+            if promotion.expired?
+              flash[:error] = t(:coupon_code_expired)
+              return false
+            end
+
+            if promotion.usage_limit_exceeded?
+              flash[:error] = t(:coupon_code_max_usage)
+              return false
+            end
+
+            previous_promo = @order.adjustments.promotion.eligible.first
+            fire_event(event_name, :coupon_code => @order.coupon_code)
+            promo = @order.adjustments.promotion.detect { |p| p.originator.promotion.code == @order.coupon_code }
+
+            if promo.present? and promo.eligible
+              flash[:success] = t(:coupon_code_applied)
+              true
+            elsif promo.present?
+              flash[:error] = t(:coupon_code_not_eligible)
+              false
+            elsif previous_promo.present?
+              flash[:error] = t(:coupon_code_better_exists)
+              false
+            else
+              # if the promotion was created after the order
+              flash[:error] = t(:coupon_code_not_found)
+              false
+            end
+          else
+            flash[:error] = t(:coupon_code_not_found)
+            false
+          end
+        end
+      else
+        true
+      end
+    end
+
+end

--- a/promo/app/controllers/spree/store_controller_decorator.rb
+++ b/promo/app/controllers/spree/store_controller_decorator.rb
@@ -11,8 +11,7 @@ Spree::StoreController.class_eval do
           event_name = "spree.checkout.coupon_code_added"
 
           # TODO should restrict to payload's event name?
-          # case insensitive coupon name
-          promotion = Spree::Promotion.find(:first, :conditions => [ "lower(code) = ?", @order.coupon_code ])
+          promotion = Spree::Promotion.find_by_code(@order.coupon_code)
 
           if promotion.present?
             if promotion.expired?

--- a/promo/app/controllers/spree/store_controller_decorator.rb
+++ b/promo/app/controllers/spree/store_controller_decorator.rb
@@ -32,11 +32,11 @@ Spree::StoreController.class_eval do
             if promo.present? and promo.eligible
               flash[:success] = t(:coupon_code_applied)
               true
+            elsif previous_promo.present? and promo.present?
+              flash[:error] = t(:coupon_code_better_exists)
+              false
             elsif promo.present?
               flash[:error] = t(:coupon_code_not_eligible)
-              false
-            elsif previous_promo.present?
-              flash[:error] = t(:coupon_code_better_exists)
               false
             else
               # if the promotion was created after the order

--- a/promo/app/models/spree/order_decorator.rb
+++ b/promo/app/models/spree/order_decorator.rb
@@ -1,6 +1,10 @@
 Spree::Order.class_eval do
   attr_accessible :coupon_code
-  attr_accessor :coupon_code
+  attr_reader :coupon_code
+
+  def coupon_code=(code)
+    @coupon_code = code.strip.downcase rescue nil
+  end
 
   # Tells us if there if the specified promotion is already associated with the order
   # regardless of whether or not its currently eligible.  Useful because generally

--- a/promo/app/models/spree/promotion.rb
+++ b/promo/app/models/spree/promotion.rb
@@ -36,16 +36,12 @@ module Spree
       where(:advertise => true)
     end
 
-    def self.with_coupon_code(coupon_code)
-      search(:code_cont => coupon_code).result
-    end
-
     def activate(payload)
       return unless order_activatable? payload[:order]
 
       if code.present?
-        event_code = payload[:coupon_code].to_s.strip.downcase
-        return unless event_code == self.code.to_s.strip.downcase
+        event_code = payload[:coupon_code]
+        return unless event_code == self.code
       end
 
       if path.present?
@@ -99,6 +95,10 @@ module Spree
 
     def credits_count
       credits.count
+    end
+
+    def code=(coupon_code)
+      write_attribute(:code, (coupon_code.downcase.strip rescue nil))
     end
 
   end

--- a/promo/config/locales/en.yml
+++ b/promo/config/locales/en.yml
@@ -18,6 +18,11 @@ en:
   coupon: Coupon
   coupon_code: Coupon code
   coupon_code_applied: The coupon code was successfully applied to your order.
+  coupon_code_expired: The coupon code is expired
+  coupon_code_already_applied: The coupon code has already been applied to this order
+  coupon_code_better_exists: The previously applied coupon code results in a better deal
+  coupon_code_not_found: The coupon code you entered doesn't exist. Please try again.
+  coupon_code_max_usage: Coupon code usage limit exceeded
   editing_promotion: Editing Promotion
   events:
     spree:
@@ -44,7 +49,6 @@ en:
     product_source:
       group: From product group
       manual: Manually choose
-  promotion_not_found: The coupon code you entered doesn't exist. Please try again.
   promotion: Promotion
   promotion_action: Promotion Action
   promotion_actions: Actions

--- a/promo/config/locales/en.yml
+++ b/promo/config/locales/en.yml
@@ -23,6 +23,7 @@ en:
   coupon_code_better_exists: The previously applied coupon code results in a better deal
   coupon_code_not_found: The coupon code you entered doesn't exist. Please try again.
   coupon_code_max_usage: Coupon code usage limit exceeded
+  coupon_code_not_eligible: This coupon code is not eligible for this order
   editing_promotion: Editing Promotion
   events:
     spree:

--- a/promo/spec/controllers/spree/orders_controller_spec.rb
+++ b/promo/spec/controllers/spree/orders_controller_spec.rb
@@ -24,18 +24,6 @@ describe Spree::OrdersController do
   end
 
   describe "#update" do
-
-    it "applies a promotion to an order" do
-      controller.should_receive(:fire_event).
-                 with('spree.order.contents_changed')
-      controller.should_receive(:fire_event).
-                 with('spree.checkout.coupon_code_added', hash_including(:coupon_code => coupon_code))
-      spree_put :update, :order => { :coupon_code => coupon_code }
-      order.coupon_code.should == coupon_code
-      flash[:notice].should == I18n.t(:coupon_code_applied)
-      response.should redirect_to(spree.cart_path)
-    end
-
     it "renders orders#edit when coupon code is invalid" do
       controller.should_not_receive(:fire_event).
                  with('spree.checkout.coupon_code_added', hash_including(:coupon_code => invalid_coupon_code))

--- a/promo/spec/controllers/spree/orders_controller_spec.rb
+++ b/promo/spec/controllers/spree/orders_controller_spec.rb
@@ -40,7 +40,7 @@ describe Spree::OrdersController do
       controller.should_not_receive(:fire_event).
                  with('spree.checkout.coupon_code_added', hash_including(:coupon_code => invalid_coupon_code))
       spree_put :update, :order => { :coupon_code => invalid_coupon_code }
-      flash[:error].should == I18n.t(:promotion_not_found)
+      flash[:error].should == I18n.t(:coupon_code_not_found)
       response.should render_template :edit
     end
 

--- a/promo/spec/models/promotion_spec.rb
+++ b/promo/spec/models/promotion_spec.rb
@@ -85,8 +85,8 @@ describe Spree::Promotion do
     end
 
     it "should check code if present" do
-      promotion.code = 'XXX'
-      @payload[:coupon_code] = 'XXX'
+      promotion.code = 'xxx'
+      @payload[:coupon_code] = 'xxx'
       @action1.should_receive(:perform).with(@payload)
       @action2.should_receive(:perform).with(@payload)
       promotion.activate(@payload)

--- a/promo/spec/requests/checkout_spec.rb
+++ b/promo/spec/requests/checkout_spec.rb
@@ -1,64 +1,79 @@
 require 'spec_helper'
 
 describe "Checkout" do
-  context "visitor makes checkout as guest without registration" do
+  stub_authorization!
+
+  context "visitor makes checkout as guest without registration", :js => true do
     before do
       @product = create(:product, :name => "RoR Mug")
       create(:zone)
       create(:shipping_method)
       create(:payment_method)
-    end
 
-    let!(:promotion) { create(:promotion, :code => "onetwo") }
+      @promotion = create_per_order_coupon_promotion 1, 2, 'onetwo'
 
-    it "informs about an invalid coupon code", :js => true do
       visit spree.root_path
       click_link "RoR Mug"
       click_button "add-to-cart-button"
+    end
 
-      click_button "Checkout"
-      fill_in "order_email", :with => "spree@example.com"
-      click_button "Continue"
+    # let!(:promotion) { create(:promotion, :code => "onetwo") }
+    let(:promotion) { @promotion }
 
-      fill_in "First Name", :with => "John"
-      fill_in "Last Name", :with => "Smith"
-      fill_in "Street Address", :with => "1 John Street"
-      fill_in "City", :with => "City of John"
-      fill_in "Zip", :with => "01337"
-      select "United States", :from => "Country"
-      select "Alaska", :from => "order[bill_address_attributes][state_id]"
-      fill_in "Phone", :with => "555-555-5555"
-      check "Use Billing Address"
+    context "on the payment page" do
+      it "informs about an invalid coupon code" do
+        click_button "Checkout"
+        fill_in "order_email", :with => "spree@example.com"
+        click_button "Continue"
 
-      # To shipping method screen
-      click_button "Save and Continue"
-      # To payment screen
-      click_button "Save and Continue"
+        fill_in "First Name", :with => "John"
+        fill_in "Last Name", :with => "Smith"
+        fill_in "Street Address", :with => "1 John Street"
+        fill_in "City", :with => "City of John"
+        fill_in "Zip", :with => "01337"
+        select "United States", :from => "Country"
+        select "Alaska", :from => "order[bill_address_attributes][state_id]"
+        fill_in "Phone", :with => "555-555-5555"
+        check "Use Billing Address"
 
-      fill_in "Coupon code", :with => "coupon_codes_rule_man"
-      click_button "Save and Continue"
-      page.should have_content("The coupon code you entered doesn't exist. Please try again.")
+        # To shipping method screen
+        click_button "Save and Continue"
+        # To payment screen
+        click_button "Save and Continue"
+
+        fill_in "Coupon code", :with => "coupon_codes_rule_man"
+        click_button "Save and Continue"
+        page.should have_content("The coupon code you entered doesn't exist. Please try again.")
+      end
     end
 
     context "on the cart page" do
-      before do
-        visit spree.root_path
-        click_link "RoR Mug"
-        click_button "add-to-cart-button"
+      it "can enter a coupon code and receives success notification" do
+        fill_in "Coupon code", :with => "onetwo"
+        click_button "Apply"
+        page.should have_content(I18n.t(:coupon_code_applied))
+      end
+
+      it "can enter a promotion code with both upper and lower case letters" do
+        fill_in "Coupon code", :with => "ONETwO"
+        click_button "Apply"
+        page.should have_content(I18n.t(:coupon_code_applied))
       end
 
       it "cannot enter a promotion code that was created after the order" do
         promotion.update_column(:created_at, 1.day.from_now)
         fill_in "Coupon code", :with => "onetwo"
         click_button "Apply"
-        page.should have_content("The coupon code you entered doesn't exist. Please try again.")
+        page.should have_content(I18n.t(:coupon_code_not_found))
       end
 
-      it "can enter a promotion code with both upper and lower case letters" do
-        promotion.update_column(:created_at, 1.minute.ago)
-        fill_in "Coupon code", :with => "ONETWO"
+      it "informs the user about a coupon code which has exceeded its usage" do
+        promotion.update_column(:usage_limit, 5)
+        promotion.class.any_instance.stub(:credits_count => 10)
+
+        fill_in "Coupon code", :with => "onetwo"
         click_button "Apply"
-        page.should have_content("The coupon code was successfully applied to your order.")
+        page.should have_content(I18n.t(:coupon_code_max_usage))
       end
     end
   end

--- a/promo/spec/requests/promotion_adjustments_spec.rb
+++ b/promo/spec/requests/promotion_adjustments_spec.rb
@@ -422,62 +422,6 @@ describe "Promotion Adjustments" do
       Spree::Order.last.total.to_f.should == 54.00
     end
 
-    def create_per_product_promotion product_name, discount_amount, event = "Add to cart"
-      promotion_name = "Bundle d#{discount_amount}"
-
-      visit spree.admin_path
-      click_link "Promotions"
-      click_link "New Promotion"
-
-      fill_in "Name", :with => promotion_name
-      select event, :from => "Event"
-      click_button "Create"
-      page.should have_content("Editing Promotion")
-
-      # add product_name to last promotion
-      promotion = Spree::Promotion.last
-      promotion.rules << Spree::Promotion::Rules::Product.new()
-      product = Spree::Product.find_by_name(product_name)
-      rule = promotion.rules.last
-      rule.products << product
-      if rule.save
-        puts "Created promotion: new price for #{product_name} is #{product.price - discount_amount} (was #{product.price})"
-      else
-        puts "Failed to create promotion: price for #{product_name} is still #{product.price}"
-      end
-
-      select "Create adjustment", :from => "Add action of type"
-      within('#action_fields') { click_button "Add" }
-      select "Flat Rate (per item)", :from => "Calculator"
-      within('#actions_container') { click_button "Update" }
-      within('.calculator-fields') { fill_in "Amount", :with => discount_amount.to_s }
-      within('#actions_container') { click_button "Update" }
-
-      Spree::Promotion.find_by_name promotion_name
-    end
-
-    def create_per_order_coupon_promotion order_min, order_discount, coupon_code
-      fill_in "Name", :with => "Order's total > $#{order_min}, Discount #{order_discount}"
-      fill_in "Usage Limit", :with => "100"
-      select "Coupon code added", :from => "Event"
-      fill_in "Code", :with => coupon_code
-      click_button "Create"
-      page.should have_content("Editing Promotion")
-
-      select "Item total", :from => "Add rule of type"
-      within('#rule_fields') { click_button "Add" }
-      eventually_fill_in "promotion_promotion_rules_attributes_1_preferred_amount", :with => order_min
-      within('#rule_fields') { click_button "Update" }
-
-      select "Create adjustment", :from => "Add action of type"
-      within('#action_fields') { click_button "Add" }
-      select "Flat Rate (per order)", :from => "Calculator"
-      within('#actions_container') { click_button "Update" }
-
-      within('.calculator-fields') { fill_in "Amount", :with => order_discount }
-      within('#actions_container') { click_button "Update" }
-    end
-
     def add_to_cart product_name
       visit spree.root_path
       click_link product_name

--- a/promo/spec/support/promotion_creation.rb
+++ b/promo/spec/support/promotion_creation.rb
@@ -1,0 +1,69 @@
+module PromotionCreation
+  def create_per_product_promotion product_name, discount_amount, event = "Add to cart"
+    promotion_name = "Bundle d#{discount_amount}"
+
+    visit spree.admin_path
+    click_link "Promotions"
+    click_link "New Promotion"
+
+    fill_in "Name", :with => promotion_name
+    select event, :from => "Event"
+    click_button "Create"
+    page.should have_content("Editing Promotion")
+
+    # add product_name to last promotion
+    promotion = Spree::Promotion.last
+    promotion.rules << Spree::Promotion::Rules::Product.new()
+    product = Spree::Product.find_by_name(product_name)
+    rule = promotion.rules.last
+    rule.products << product
+    if rule.save
+      puts "Created promotion: new price for #{product_name} is #{product.price - discount_amount} (was #{product.price})"
+    else
+      puts "Failed to create promotion: price for #{product_name} is still #{product.price}"
+    end
+
+    select "Create adjustment", :from => "Add action of type"
+    within('#action_fields') { click_button "Add" }
+    select "Flat Rate (per item)", :from => "Calculator"
+    within('#actions_container') { click_button "Update" }
+    within('.calculator-fields') { fill_in "Amount", :with => discount_amount.to_s }
+    within('#actions_container') { click_button "Update" }
+
+    Spree::Promotion.find_by_name promotion_name
+  end
+
+  def create_per_order_coupon_promotion order_min, order_discount, coupon_code
+    visit spree.admin_path
+    click_link "Promotions"
+    click_link "New Promotion"
+
+    promotion_name = "Order's total > $#{order_min}, Discount #{order_discount}"
+    fill_in "Name", :with => promotion_name
+    fill_in "Usage Limit", :with => "100"
+    select "Coupon code added", :from => "Event"
+    fill_in "Code", :with => coupon_code
+    click_button "Create"
+    page.should have_content("Editing Promotion")
+
+    select "Item total", :from => "Add rule of type"
+    within('#rule_fields') { click_button "Add" }
+    eventually_fill_in "promotion_promotion_rules_attributes_1_preferred_amount", :with => order_min
+    within('#rule_fields') { click_button "Update" }
+
+    select "Create adjustment", :from => "Add action of type"
+    within('#action_fields') { click_button "Add" }
+    select "Flat Rate (per order)", :from => "Calculator"
+    within('#actions_container') { click_button "Update" }
+
+    within('.calculator-fields') { fill_in "Amount", :with => order_discount }
+    within('#actions_container') { click_button "Update" }
+
+    Spree::Promotion.find_by_name promotion_name
+  end
+end
+
+
+RSpec.configure do |c|
+  c.include PromotionCreation
+end

--- a/promo/spec/support/promotion_creation.rb
+++ b/promo/spec/support/promotion_creation.rb
@@ -48,7 +48,8 @@ module PromotionCreation
 
     select "Item total", :from => "Add rule of type"
     within('#rule_fields') { click_button "Add" }
-    eventually_fill_in "promotion_promotion_rules_attributes_1_preferred_amount", :with => order_min
+
+    eventually_fill_in "promotion_promotion_rules_attributes_#{Spree::Promotion.count}_preferred_amount", :with => order_min
     within('#rule_fields') { click_button "Update" }
 
     select "Create adjustment", :from => "Add action of type"


### PR DESCRIPTION
Fixes #2013. This is an expansion of the improvements in #1636.

All logic for applying coupon codes from the `OrdersController` and `CheckoutController` is centralized under one method in the recently added `StoreController`. 

Some notes:
- The changes in #2012 are not sufficient to handle detailed customer notifications. I moved the case insensitive coupon code stuff to the model level.
- I threw the coupon login in the `StoreController` helper; could throw it in its module if needed (I don't like creating modules with only method).
- Removed spec from orders controller and moved it to the checkout request spec. Since the promotion didn't have a rule/action attached the test was breaking.
- It would be great if we could DRY up the `OrdersController` and `CheckoutController` `class_eval`s; I couldn't think of a clean way to do this though
