### PR TITLE
Promotion Usage Count in Admin

### DIFF
--- a/promo/app/views/spree/admin/promotions/_form.html.erb
+++ b/promo/app/views/spree/admin/promotions/_form.html.erb
@@ -37,7 +37,8 @@
   <legend><%= t(:expiry) %></legend>
   <p>
     <%= f.label :usage_limit %><br />
-    <%= f.text_field :usage_limit %>
+    <%= f.text_field :usage_limit %><br/>
+    <%= t(:current_promotion_usage) %> <%= @promotion.credits_count %>
   </p>
 
   <p id="starts_at_field">

--- a/promo/config/locales/en.yml
+++ b/promo/config/locales/en.yml
@@ -18,6 +18,7 @@ en:
   coupon_code: Coupon code
   coupon_code_applied: The coupon code was successfully applied to your order.
   editing_promotion: Editing Promotion
+  current_promotion_usage: 'Current Usage: '
   events:
     spree:
       checkout:


### PR DESCRIPTION
Currently there is no way for a admin (non-tech) to know what the current usage count of a promotion is, this makes it impossible for them to know if the promotional will still work for a new customer.

This PR adds a simple 'Current Usage: x' display on the promo admin.
