### PR TITLE
Adding Order#variants

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -467,6 +467,10 @@ module Spree
       line_items.map { |li| li.variant.product }
     end
 
+    def variants
+      line_items.map(&:variant)
+    end
+
     def insufficient_stock_lines
       line_items.select &:insufficient_stock?
     end


### PR DESCRIPTION
Convenience method for grabbing a list of variants. 

In my case, digital items need to handled differently (mainly for promotional purposes), and this makes querying the `Order` model for variants a bit easier.
