### PR TITLE
Multi-Currency Price support

### DIFF
--- a/core/app/controllers/spree/admin/products_controller.rb
+++ b/core/app/controllers/spree/admin/products_controller.rb
@@ -78,9 +78,9 @@ module Spree
             page(params[:page]).
             per(Spree::Config[:admin_products_per_page])
 
-          if params[:q][:s].include?("master_price")
+          if params[:q][:s].include?("master_default_price_amount")
             # PostgreSQL compatibility
-            @collection = @collection.group("spree_variants.price")
+            @collection = @collection.group("spree_prices.amount")
           end
           @collection
         end
@@ -97,7 +97,7 @@ module Spree
         end
 
         def product_includes
-         [{:variants => [:images, {:option_values => :option_type}]}, {:master => :images}]
+         [{:variants => [:images, {:option_values => :option_type}]}, {:master => [:images, :default_price]}]
         end
 
     end

--- a/core/app/controllers/spree/admin/reports_controller.rb
+++ b/core/app/controllers/spree/admin/reports_controller.rb
@@ -35,11 +35,14 @@ module Spree
 
         @search = Order.complete.ransack(params[:q])
         @orders = @search.result
-        @item_total = @orders.sum(:item_total)
-        @adjustment_total = @orders.sum(:adjustment_total)
-        @sales_total = @orders.sum(:total)
 
-        respond_with
+        @totals = {}
+        @orders.each do |order|
+          @totals[order.currency] = { :item_total => ::Money.new(0, order.currency), :adjustment_total => ::Money.new(0, order.currency), :sales_total => ::Money.new(0, order.currency) } unless @totals[order.currency]
+          @totals[order.currency][:item_total] += order.display_item_total.money
+          @totals[order.currency][:adjustment_total] += order.display_adjustment_total.money
+          @totals[order.currency][:sales_total] += order.display_total.money
+        end
       end
 
     end

--- a/core/app/controllers/spree/admin/variants_controller.rb
+++ b/core/app/controllers/spree/admin/variants_controller.rb
@@ -54,6 +54,8 @@ module Spree
         def new_before
           @object.attributes = @object.product.master.attributes.except('id', 'created_at', 'deleted_at',
                                                                         'sku', 'is_master', 'count_on_hand')
+          # Shallow Clone of the default price to populate the price field.
+          @object.default_price = @object.product.master.default_price.clone
         end
 
         def collection

--- a/core/app/controllers/spree/orders_controller.rb
+++ b/core/app/controllers/spree/orders_controller.rb
@@ -54,12 +54,12 @@ module Spree
       params[:products].each do |product_id,variant_id|
         quantity = params[:quantity].to_i if !params[:quantity].is_a?(Hash)
         quantity = params[:quantity][variant_id].to_i if params[:quantity].is_a?(Hash)
-        @order.add_variant(Variant.find(variant_id), quantity) if quantity > 0
+        @order.add_variant(Variant.find(variant_id), quantity, selected_currency) if quantity > 0
       end if params[:products]
 
       params[:variants].each do |variant_id, quantity|
         quantity = quantity.to_i
-        @order.add_variant(Variant.find(variant_id), quantity) if quantity > 0
+        @order.add_variant(Variant.find(variant_id), quantity, selected_currency) if quantity > 0
       end if params[:variants]
 
       fire_event('spree.cart.add')

--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -145,6 +145,7 @@ module Spree
     end
 
     def money(amount)
+      ActiveSupport::Deprecation.warn("[SPREE] Spree::BaseHelper#money will be deprecated.  It relies upon a single master currency.  You can instead create a Spree::Money.new(amount, { :currency => your_currency}) or see if the object you're working with returns a Spree::Money object to use.")
       Spree::Money.new(amount)
     end
 

--- a/core/app/helpers/spree/products_helper.rb
+++ b/core/app/helpers/spree/products_helper.rb
@@ -15,9 +15,9 @@ module Spree
       diff = variant.price - variant.product.price
       return nil if diff == 0
       if diff > 0
-        "(#{t(:add)}: #{Spree::Money.new(diff.abs)})"
+        "(#{t(:add)}: #{Spree::Money.new(diff.abs, { :currency => variant.currency })})"
       else
-        "(#{t(:subtract)}: #{Spree::Money.new(diff.abs)})"
+        "(#{t(:subtract)}: #{Spree::Money.new(diff.abs, { :currency => variant.currency })})"
       end
     end
 
@@ -25,7 +25,7 @@ module Spree
     def variant_full_price(variant)
       product = variant.product
       unless product.variants.active.all? { |v| v.price == product.price }
-        Spree::Money.new(variant.price).to_s
+        Spree::Money.new(variant.price, { :currency => variant.currency }).to_s
       end
     end
 

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -65,8 +65,12 @@ module Spree
       set_eligibility
     end
 
+    def currency
+      Spree::Config[:currency]
+    end
+
     def display_amount
-      Spree::Money.new(amount).to_s
+      Spree::Money.new(amount, { :currency => currency }).to_s
     end
 
     private

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -66,7 +66,7 @@ module Spree
     end
 
     def currency
-      Spree::Config[:currency]
+      adjustable.nil? ? Spree::Config[:currency] : adjustable.currency
     end
 
     def display_amount

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -53,6 +53,7 @@ module Spree
     preference :orders_per_page, :integer, :default => 15
     preference :prices_inc_tax, :boolean, :default => false
     preference :products_per_page, :integer, :default => 12
+    preference :require_master_price, :boolean, :default => true
     preference :shipment_inc_vat, :boolean, :default => false
     preference :shipping_instructions, :boolean, :default => false # Request instructions/info for shipping
     preference :show_descendents, :boolean, :default => true

--- a/core/app/models/spree/calculator/flat_rate.rb
+++ b/core/app/models/spree/calculator/flat_rate.rb
@@ -3,7 +3,9 @@ require_dependency 'spree/calculator'
 module Spree
   class Calculator::FlatRate < Calculator
     preference :amount, :decimal, :default => 0
-    attr_accessible :preferred_amount
+    preference :currency, :string, :default => Spree::Config[:currency]
+
+    attr_accessible :preferred_amount, :preferred_currency
 
     def self.description
       I18n.t(:flat_rate_per_order)

--- a/core/app/models/spree/calculator/flexi_rate.rb
+++ b/core/app/models/spree/calculator/flexi_rate.rb
@@ -5,8 +5,9 @@ module Spree
     preference :first_item,      :decimal, :default => 0.0
     preference :additional_item, :decimal, :default => 0.0
     preference :max_items,       :integer, :default => 0
+    preference :currency,        :string,  :default => Spree::Config[:currency]
 
-    attr_accessible :preferred_first_item, :preferred_additional_item, :preferred_max_items
+    attr_accessible :preferred_first_item, :preferred_additional_item, :preferred_max_items, :preferred_currency
 
     def self.description
       I18n.t(:flexible_rate)

--- a/core/app/models/spree/calculator/per_item.rb
+++ b/core/app/models/spree/calculator/per_item.rb
@@ -3,8 +3,9 @@ require_dependency 'spree/calculator'
 module Spree
   class Calculator::PerItem < Calculator
     preference :amount, :decimal, :default => 0
+    preference :currency, :string, :default => Spree::Config[:currency]
 
-    attr_accessible :preferred_amount
+    attr_accessible :preferred_amount, :preferred_currency
 
     def self.description
       I18n.t(:flat_rate_per_item)

--- a/core/app/models/spree/calculator/price_sack.rb
+++ b/core/app/models/spree/calculator/price_sack.rb
@@ -7,10 +7,12 @@ module Spree
     preference :minimal_amount, :decimal, :default => 0
     preference :normal_amount, :decimal, :default => 0
     preference :discount_amount, :decimal, :default => 0
+    preference :currency, :string, :default => Spree::Config[:currency]
 
     attr_accessible :preferred_minimal_amount,
                     :preferred_normal_amount,
-                    :preferred_discount_amount
+                    :preferred_discount_amount,
+                    :preferred_currency
 
     def self.description
       I18n.t(:price_sack)

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -24,7 +24,10 @@ module Spree
     after_destroy :update_order
 
     def copy_price
-      self.price = variant.price if variant && price.nil?
+      if variant
+        self.price = variant.price if price.nil?
+        self.currency = variant.currency if currency.nil?
+      end
     end
 
     def increment_quantity
@@ -35,19 +38,21 @@ module Spree
       self.quantity -= 1
     end
 
-    def currency
-      Spree::Config[:currency]
-    end
-
     def amount
       price * quantity
     end
     alias total amount
 
-    def display_amount
+    def single_money
+      Spree::Money.new(price, { :currency => currency })
+    end
+    alias single_display_amount single_money
+
+    def money
       Spree::Money.new(amount, { :currency => currency })
     end
-    alias display_total display_amount
+    alias display_total money
+    alias display_amount money
 
     def adjust_quantity
       self.quantity = 0 if quantity.nil? || quantity < 0

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -35,10 +35,19 @@ module Spree
       self.quantity -= 1
     end
 
+    def currency
+      Spree::Config[:currency]
+    end
+
     def amount
       price * quantity
     end
     alias total amount
+
+    def display_amount
+      Spree::Money.new(amount, { :currency => currency })
+    end
+    alias display_total display_amount
 
     def adjust_quantity
       self.quantity = 0 if quantity.nil? || quantity < 0

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -106,8 +106,24 @@ module Spree
       line_items.sum(&:amount)
     end
 
+    def currency
+      Spree::Config[:currency]
+    end
+
+    def display_outstanding_balance
+      Spree::Money.new(outstanding_balance, { :currency => currency })
+    end
+
+    def display_item_total
+      Spree::Money.new(item_total, { :currency => currency })
+    end
+
+    def display_adjustment_total
+      Spree::Money.new(adjustment_total, { :currency => currency })
+    end
+
     def display_total
-      Spree::Money.new(total)
+      Spree::Money.new(total, { :currency => currency })
     end
 
     def to_param
@@ -384,7 +400,8 @@ module Spree
         ShippingRate.new( :id => ship_method.id,
                           :shipping_method => ship_method,
                           :name => ship_method.name,
-                          :cost => cost)
+                          :cost => cost,
+                          :currency => currency)
       end.compact.sort_by { |r| r.cost }
     end
 

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -48,7 +48,7 @@ module Spree
     end
 
     def currency
-      Spree::Config[:currency]
+      order.currency
     end
 
     def display_amount

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -47,6 +47,14 @@ module Spree
       end
     end
 
+    def currency
+      Spree::Config[:currency]
+    end
+
+    def display_amount
+      Spree::Money.new(amount, { :currency => currency })
+    end
+
     def offsets_total
       offsets.map(&:amount).sum
     end

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -1,0 +1,61 @@
+module Spree
+  class Price < ActiveRecord::Base
+    belongs_to :variant, :class_name => 'Spree::Variant'
+
+    validate :check_price
+    validates :amount, :numericality => { :greater_than_or_equal_to => 0 }, :allow_nil => true
+
+    attr_accessible :variant_id, :currency, :amount
+
+    def display_amount
+      return nil if amount.nil?
+      money.to_s
+    end
+    alias :display_price :display_amount
+
+    def money
+      Spree::Money.new(amount, { :currency => currency })
+    end
+
+    def price
+      amount
+    end
+
+    def price=(price)
+      self[:amount] = parse_price(price) if price.present?
+    end
+
+    private
+    def check_price
+      raise "Price must belong to a variant" if variant.nil?
+      if amount.nil?
+        if variant.is_master? || variant.product.master.nil? || variant.product.master.default_price.nil?
+          self.amount = nil
+        else
+          self.amount = variant.product.master.default_price.amount
+        end
+      end
+      if currency.nil?
+        if variant.product.master.default_price.nil?
+          self.currency = Spree::Config[:currency]
+        else
+          self.currency = variant.product.master.default_price.currency
+        end
+      end
+    end
+
+    # strips all non-price-like characters from the price, taking into account locale settings
+    def parse_price(price)
+      return price unless price.is_a?(String)
+
+      separator, delimiter = I18n.t([:'number.currency.format.separator', :'number.currency.format.delimiter'])
+      non_price_characters = /[^0-9\-#{separator}]/
+      price.gsub!(non_price_characters, '') # strip everything else first
+      price.gsub!(separator, '.') unless separator == '.' # then replace the locale-specific decimal separator with the standard separator if necessary
+
+      price.to_d
+    end
+
+  end
+end
+

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -46,13 +46,14 @@ module Spree
 
     has_many :variants_including_master_and_deleted, :class_name => 'Spree::Variant'
 
-    delegate_belongs_to :master, :sku, :price, :currency, :display_amount, :display_price, :weight, :height, :width, :depth, :is_master
+    delegate_belongs_to :master, :sku, :price, :currency, :display_amount, :display_price, :weight, :height, :width, :depth, :is_master, :has_default_price?, :cost_currency
     delegate_belongs_to :master, :cost_price if Variant.table_exists? && Variant.column_names.include?('cost_price')
 
     after_create :set_master_variant_defaults
     after_create :add_properties_and_option_types_from_prototype
     after_create :build_variants_from_option_values_hash, :if => :option_values_hash
     before_save :recalculate_count_on_hand
+
     after_save :save_master
     after_save :set_master_on_hand_to_zero_when_product_has_variants
 
@@ -63,7 +64,8 @@ module Spree
 
     accepts_nested_attributes_for :variants, :allow_destroy => true
 
-    validates :name, :price, :permalink, :presence => true
+    validates :name, :permalink, :presence => true
+    validates :price, :presence => true, :if => proc { Spree::Config[:require_master_price] }
 
     attr_accessor :option_values_hash
 
@@ -71,10 +73,9 @@ module Spree
                     :meta_keywords, :price, :sku, :deleted_at, :prototype_id,
                     :option_values_hash, :on_demand, :on_hand, :weight, :height, :width, :depth,
                     :shipping_category_id, :tax_category_id, :product_properties_attributes,
-                    :variants_attributes, :taxon_ids, :option_type_ids
+                    :variants_attributes, :taxon_ids, :option_type_ids, :cost_currency
 
     attr_accessible :cost_price if Variant.table_exists? && Variant.column_names.include?('cost_price')
-
 
     accepts_nested_attributes_for :product_properties, :allow_destroy => true, :reject_if => lambda { |pp| pp[:property_name].blank? }
 
@@ -180,6 +181,8 @@ module Spree
       variant.sku = 'COPY OF ' + master.sku
       variant.deleted_at = nil
       variant.images = master.images.map { |i| image_dup.call i }
+      variant.price = master.price
+      variant.currency = master.currency
       p.master = variant
 
       # don't dup the actual variants, just the characterising types
@@ -237,10 +240,6 @@ module Spree
       end
     end
 
-    def display_price
-      Spree::Money.new(price, { :currency => currency }).to_s
-    end
-
     private
 
       # Builds variants from a hash of option types & values
@@ -284,7 +283,7 @@ module Spree
       # there's a weird quirk with the delegate stuff that does not automatically save the delegate object
       # when saving so we force a save using a hook.
       def save_master
-        master.save if master && (master.changed? || master.new_record?)
+        master.save if master && (master.changed? || master.new_record? || (master.default_price && (master.default_price.changed || master.default_price.new_record)))
       end
 
       def ensure_master

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -46,7 +46,7 @@ module Spree
 
     has_many :variants_including_master_and_deleted, :class_name => 'Spree::Variant'
 
-    delegate_belongs_to :master, :sku, :price, :weight, :height, :width, :depth, :is_master
+    delegate_belongs_to :master, :sku, :price, :currency, :display_amount, :display_price, :weight, :height, :width, :depth, :is_master
     delegate_belongs_to :master, :cost_price if Variant.table_exists? && Variant.column_names.include?('cost_price')
 
     after_create :set_master_variant_defaults
@@ -238,7 +238,7 @@ module Spree
     end
 
     def display_price
-      Spree::Money.new(price).to_s
+      Spree::Money.new(price, { :currency => currency }).to_s
     end
 
     private

--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -27,23 +27,23 @@ module Spree
     end
 
     add_search_scope :ascend_by_master_price do
-      joins(:master).order("#{variant_table_name}.price ASC")
+      joins(:master => :default_price).order("#{price_table_name}.amount ASC")
     end
 
     add_search_scope :descend_by_master_price do
-      joins(:master).order("#{variant_table_name}.price DESC")
+      joins(:master => :default_price).order("#{price_table_name}.amount DESC")
     end
 
     add_search_scope :price_between do |low, high|
-      joins(:master).where(Variant.table_name => { :price => low..high })
+      joins(:master => :default_price).where(Price.table_name => { :amount => low..high })
     end
 
     add_search_scope :master_price_lte do |price|
-      joins(:master).where("#{variant_table_name}.price <= ?", price)
+      joins(:master => :default_price).where("#{price_table_name}.amount <= ?", price)
     end
 
     add_search_scope :master_price_gte do |price|
-      joins(:master).where("#{variant_table_name}.price >= ?", price)
+      joins(:master => :default_price).where("#{price_table_name}.amount >= ?", price)
     end
 
     # This scope selects products in taxon AND all its descendants
@@ -189,7 +189,7 @@ module Spree
 
     # Can't use add_search_scope for this as it needs a default argument
     def self.available(available_on = nil)
-      where("#{Product.quoted_table_name}.available_on <= ?", available_on || Time.now)
+      joins(:master => :default_price).where("#{Spree::Price.quoted_table_name}.amount IS NOT NULL").where("#{Product.quoted_table_name}.available_on <= ?", available_on || Time.now)
     end
     search_scopes << :available
 
@@ -217,8 +217,8 @@ module Spree
 
     private
 
-      def self.variant_table_name
-        Variant.quoted_table_name
+      def self.price_table_name
+        Price.quoted_table_name
       end
 
       # specifically avoid having an order for taxon search (conflicts with main order)

--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -23,6 +23,14 @@ module Spree
       end
     end
 
+    def currency
+      Spree::Config[:currency]
+    end
+
+    def display_amount
+      Spree::Money.new(amount, { :currency => currency })
+    end
+
     def add_variant(variant_id, quantity)
       order_units = order.inventory_units.group_by(&:variant_id)
       returned_units = inventory_units.group_by(&:variant_id)

--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -24,7 +24,7 @@ module Spree
     end
 
     def currency
-      Spree::Config[:currency]
+      order.nil? ? Spree::Config[:currency] : order.currency
     end
 
     def display_amount

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -43,7 +43,7 @@ module Spree
     end
 
     def currency
-      Spree::Config[:currency]
+      order.nil? ? Spree::Config[:currency] : order.currency
     end
 
     # The adjustment amount associated with this shipment (if any.)  Returns only the first adjustment to match

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -42,12 +42,21 @@ module Spree
       self.shipped_at = Time.now
     end
 
+    def currency
+      Spree::Config[:currency]
+    end
+
     # The adjustment amount associated with this shipment (if any.)  Returns only the first adjustment to match
     # the shipment but there should never really be more than one.
     def cost
       adjustment ? adjustment.amount : 0
     end
     alias_method :amount, :cost
+
+    def display_cost
+      Spree::Money.new(cost, { :currency => currency })
+    end
+    alias_method :display_amount, :display_cost
 
     # shipment state machine (see http://github.com/pluginaweek/state_machine/tree/master for details)
     state_machine :initial => 'pending', :use_transactions => false do

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -30,7 +30,8 @@ module Spree
     def available_to_order?(order, display_on= nil)
       available?(order, display_on) &&
       within_zone?(order) &&
-      category_match?(order)
+      category_match?(order) &&
+      currency_match?(order)
     end
 
     # Indicates whether or not the category rules for this shipping method
@@ -45,6 +46,14 @@ module Spree
       elsif match_none
         order.products.all? { |p| p.shipping_category != shipping_category }
       end
+    end
+
+    def currency_match?(order)
+      calculator_currency.nil? || calculator_currency == order.currency
+    end
+
+    def calculator_currency
+      calculator.preferences[:currency]
     end
 
     def self.all_available(order, display_on = nil)

--- a/core/app/models/spree/shipping_rate.rb
+++ b/core/app/models/spree/shipping_rate.rb
@@ -1,5 +1,5 @@
 module Spree
-  class ShippingRate < Struct.new(:id, :shipping_method, :name, :cost)
+  class ShippingRate < Struct.new(:id, :shipping_method, :name, :cost, :currency)
     def initialize(attributes = {})
       attributes.each do |k, v|
         self.send("#{k}=", v)
@@ -13,7 +13,7 @@ module Spree
         price = cost
       end
 
-      Spree::Money.new(price)
+      Spree::Money.new(price, { :currency => currency })
     end
   end
 end

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -46,6 +46,15 @@ module Spree
       end
     end
 
+    def currency
+      Spree::Config[:currency]
+    end
+
+    def display_amount
+      Spree::Money.new(price, { :currency => currency })
+    end
+    alias :display_price :display_amount
+
     def price=(price)
       self[:price] = parse_price(price) if price.present?
     end

--- a/core/app/views/spree/admin/orders/_form.html.erb
+++ b/core/app/views/spree/admin/orders/_form.html.erb
@@ -31,7 +31,7 @@
         <tbody id="subtotal" data-hook="admin_order_form_subtotal" class="no-border-top">
           <tr id="subtotal-row">
             <td colspan="3"><b><%= t(:subtotal) %>:</b></td>
-            <td class="total align-center"><span><%= money(@order.item_total) %></span></td>
+            <td class="total align-center"><span><%= @order.display_item_total %></span></td>
             <td class="actions"></td>
           </tr>
         </tbody>

--- a/core/app/views/spree/admin/orders/_line_item.html.erb
+++ b/core/app/views/spree/admin/orders/_line_item.html.erb
@@ -1,8 +1,8 @@
 <tr id="<%= spree_dom_id(f.object) %>" data-hook="admin_order_form_line_item_row" class="<%= cycle('odd', 'even')%>">
   <td><%=f.object.variant.product.name%> <%= "(#{f.object.variant.options_text})" unless f.object.variant.option_values.empty? %></td>
-  <td class="price align-center"><%= money(f.object.price) %></td>
+  <td class="price align-center"><%= f.object.variant.display_amount %></td>
   <td class="qty"><%= f.number_field :quantity, :min => 0, :class => "qty" %></td>
-  <td class="total align-center"><%= money(f.object.price * f.object.quantity) %></td>
+  <td class="total align-center"><%= f.object.display_amount %></td>
   <td data-hook="admin_order_form_line_item_actions" class="actions">
     <%= link_to_delete f.object, {:url => admin_order_line_item_url(@order.number, f.object), :no_text => true} %>
   </td>

--- a/core/app/views/spree/admin/payments/_list.html.erb
+++ b/core/app/views/spree/admin/payments/_list.html.erb
@@ -12,7 +12,7 @@
     <% payments.each do |payment| %>
       <tr data-hook="payments_row" class="<%= cycle('odd', 'even')%>">
         <td><%= pretty_time(payment.created_at) %></td>
-        <td class='align-center'><%= money(payment.amount) %></td>
+        <td class='align-center'><%= payment.display_amount %></td>
         <td class="align-center"><%= link_to payment_method_name(payment), spree.admin_order_payment_path(@order, payment) %></td>
         <td class="align-center"> <span class="state <%= payment.state %>"><%= t(payment.state, :scope => :payment_states, :default => payment.state.capitalize) %></span></td>
         <td class="actions">

--- a/core/app/views/spree/admin/payments/index.html.erb
+++ b/core/app/views/spree/admin/payments/index.html.erb
@@ -14,7 +14,7 @@
 <% end %>
 
 <% if @order.outstanding_balance? %>
-  <h5 class="outstanding-balance"><%= @order.outstanding_balance < 0 ? t(:credit_owed) : t(:balance_due) %>: <strong><%= money(@order.outstanding_balance) %></strong></h5>
+  <h5 class="outstanding-balance"><%= @order.outstanding_balance < 0 ? t(:credit_owed) : t(:balance_due) %>: <strong><%= @order.display_outstanding_balance %></strong></h5>
 <% end %>
 
 <%= render :partial => 'list', :locals => { :payments => @payments } %>

--- a/core/app/views/spree/admin/products/_form.html.erb
+++ b/core/app/views/spree/admin/products/_form.html.erb
@@ -21,18 +21,24 @@
   </div>
 
   <div class="right four columns omega" data-hook="admin_product_form_right">
+    <%= f.field_container :price do %>
+      <%= f.label :price, raw(t(:master_price) + content_tag(:span, ' *', :class => "required")) %>
+      <%= f.text_field :price, :value => number_to_currency(@product.price, :unit => '') %>
+      <%= f.error_message_on :price %>
+    <% end %>
+
     <div class="alpha two columns">
-      <%= f.field_container :price do %>
-        <%= f.label :price, raw(t(:master_price) + content_tag(:span, ' *', :class => "required")) %>
-        <%= f.text_field :price, :value => number_to_currency(@product.price, :unit => '') %>
-        <%= f.error_message_on :price %>
-      <% end %>
-    </div>
-    <div class="omega two columns">
       <%= f.field_container :cost_price do %>
         <%= f.label :cost_price, t(:cost_price) %>
         <%= f.text_field :cost_price, :value => number_to_currency(@product.cost_price, :unit => '') %>
         <%= f.error_message_on :cost_price %>
+      <% end %>
+    </div>
+    <div class="omega two columns">
+      <%= f.field_container :cost_currency do %>
+        <%= f.label :cost_currency, t(:cost_currency) %>
+        <%= f.text_field :cost_currency %>
+        <%= f.error_message_on :cost_currency %>
       <% end %>
     </div>
 

--- a/core/app/views/spree/admin/products/index.html.erb
+++ b/core/app/views/spree/admin/products/index.html.erb
@@ -72,7 +72,7 @@
       <tr data-hook="admin_products_index_headers">
         <th><%= t(:sku) %></th>
         <th colspan="2"><%= sort_link @search,:name, t(:name), { :default_order => "desc" }, {:title => 'admin_products_listing_name_title'} %></th>
-        <th><%= sort_link @search,:master_price, t(:master_price), {}, {:title => 'admin_products_listing_price_title'} %></th>
+        <th><%= sort_link @search,:master_default_price_amount, t(:master_price), {}, {:title => 'admin_products_listing_price_title'} %></th>
         <th data-hook="admin_products_index_header_actions" class="actions"></th>
       </tr>  
     </thead>  

--- a/core/app/views/spree/admin/products/index.html.erb
+++ b/core/app/views/spree/admin/products/index.html.erb
@@ -82,7 +82,7 @@
             <td class="align-center"><%= product.sku rescue '' %></td>
             <td class="align-center"><%= mini_image(product) %></td>
             <td><%= link_to product.try(:name), edit_admin_product_path(product) %></td>
-            <td class="align-center"><%= money(product.price) rescue '' %></td>
+            <td class="align-center"><%= product.display_price rescue '' %></td>
             <td class="actions" data-hook="admin_products_index_row_actions">
               <%= link_to_edit product, :no_text => true, :class => 'edit' unless product.deleted? %>
               &nbsp;

--- a/core/app/views/spree/admin/reports/sales_total.html.erb
+++ b/core/app/views/spree/admin/reports/sales_total.html.erb
@@ -18,16 +18,20 @@
 <table class="admin-report" data-hook="sales_total">
   <thead>
     <tr>
+      <th><%= t(:currency) %></th>
       <th><%= t(:item_total) %></th>
       <th><%= t(:adjustment_total) %></th>
       <th><%= t(:sales_total) %></th>
     </tr>
   </thead>
   <tbody>
-    <tr class="align-center">
-      <td><%= money @item_total %></td>    
-      <td><%= money @adjustment_total %></td>
-      <td><%= money @sales_total %></td>
-    </tr>
+    <% @totals.each do |key, row| %>
+      <tr class="align-center">
+        <td><%= key %></td>
+        <td><%= row[:item_total].format %></td>
+        <td><%= row[:adjustment_total].format %></td>
+        <td><%= row[:sales_total].format %></td>
+      </tr>
+    <% end %>
   </tbody>
 </table>

--- a/core/app/views/spree/admin/return_authorizations/_form.html.erb
+++ b/core/app/views/spree/admin/return_authorizations/_form.html.erb
@@ -35,7 +35,7 @@
   <%= f.field_container :amount do %>
     <%= f.label :amount, t(:amount) %> <span class="required">*</span><br />
     <% if @return_authorization.received? %>
-      <%= money @return_authorization.amount %>
+      <%= @return_authorization.display_amount %>
     <% else %>
       <%= f.text_field :amount, {:style => 'width:80px;'} %> <%= t(:rma_value) %>: <span id="rma_value">0.00</span>
       <%= f.error_message_on :amount %>

--- a/core/app/views/spree/admin/return_authorizations/index.html.erb
+++ b/core/app/views/spree/admin/return_authorizations/index.html.erb
@@ -29,7 +29,7 @@
         <tr id="<%= spree_dom_id(return_authorization) %>" data-hook="rma_row" class="<%= cycle('odd', 'even')%>">
           <td><%= return_authorization.number %></td>
           <td><%= t(return_authorization.state.downcase) %></td>
-          <td><%= money return_authorization.amount %></td>
+          <td><%= return_authorization.display_amount %></td>
           <td><%= pretty_time(return_authorization.created_at) %></td>
           <td class="actions">
             <%= link_to_edit return_authorization %>

--- a/core/app/views/spree/admin/shared/_order_details.html.erb
+++ b/core/app/views/spree/admin/shared/_order_details.html.erb
@@ -11,16 +11,16 @@
     <% @order.line_items.each do |item| %>
       <tr data-hook="order_details_line_item_row" class="<%= cycle('odd', 'even')%>">
         <td width="300"><%= item.variant.product.name %> <%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %></td>
-        <td class="price"><%= money item.price %></td>
+        <td class="price"><%= item.variant.display_amount %></td>
         <td class="qty"><%= item.quantity %></td>
-        <td class="total"><span><%= money(item.price * item.quantity) %></span></td>
+        <td class="total"><span><%= item.display_amount %></span></td>
       </tr>
     <% end %>
   </tbody>
   <tbody id="subtotal" data-hook="order_details_subtotal"  class="with-border">
     <tr class="total" id="subtotal-row">
       <td colspan="3"><b><%= t(:subtotal) %>:</b></td>
-      <td class="total"><span><%= money @order.item_total %></span></td>
+      <td class="total"><span><%= @order.display_total %></span></td>
     </tr>
   </tbody>
   <tbody id="order-charges" data-hook="order_details_adjustments"  class="with-border">
@@ -28,14 +28,14 @@
     <% next if (adjustment.originator_type == 'Spree::TaxRate') and (adjustment.amount == 0) %>
       <tr class="total">
         <td colspan="3"><strong><%= adjustment.label %>:</strong></td>
-        <td class="total"><span><%= money adjustment.amount %></span></td>
+        <td class="total"><span><%= adjustment.display_amount %></span></td>
       </tr>
     <% end %>
   </tbody>
   <tbody id="order-total" data-hook="order_details_total" class="with-border grand-total">
     <tr>
       <td colspan="3" ><%= t(:order_total) %>:</td>
-      <td class="total" id="order-total"><span id="order_total"><%= money @order.total %></span></td>
+      <td class="total" id="order-total"><span id="order_total"><%= @order.display_total %></span></td>
     </tr>
   </tbody>
   <% if order.price_adjustment_totals.present? %>
@@ -43,7 +43,7 @@
       <% @order.price_adjustment_totals.keys.each do |key| %>
         <tr>
           <td colspan="3"><strong><%= key %></strong></td>
-          <td class="total"><span><%= money @order.price_adjustment_totals[key] %></span></td>
+          <td class="total"><span><%= @order.price_adjustment_totals[key].display_amount %></span></td>
         </tr>
       <% end %>
     </tbody>

--- a/core/app/views/spree/admin/shared/_order_tabs.html.erb
+++ b/core/app/views/spree/admin/shared/_order_tabs.html.erb
@@ -12,7 +12,7 @@
       <dt id="order_status" data-hook><%= t(:status) %>:</dt>
       <dd><span class="state <%= @order.state %>"><%= t(@order.state, :scope => :order_state) %></span></dd>
       <dt data-hook><%= t(:total) %>:</dt>
-      <dd id='order_total'><%= money @order.total %></dd>
+      <dd id='order_total'><%= @order.display_total %></dd>
     
       <% if @order.completed? %>
         <dt><%= t(:shipment) %>: </dt>

--- a/core/app/views/spree/admin/shipments/edit.html.erb
+++ b/core/app/views/spree/admin/shipments/edit.html.erb
@@ -16,7 +16,7 @@
 <div data-hook="admin_shipment_edit_header">
   
   <% if @shipment.cost %>
-    <h5 class="outstanding-balance"><%= t(:charges) %> <span class="green"><%= money @shipment.cost %></span></h5>
+    <h5 class="outstanding-balance"><%= t(:charges) %> <span class="green"><%= @shipment.display_cost %></span></h5>
   <% end %>
 
   <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @shipment } %>

--- a/core/app/views/spree/admin/shipments/index.html.erb
+++ b/core/app/views/spree/admin/shipments/index.html.erb
@@ -28,7 +28,7 @@
       <tr id="<%= spree_dom_id shipment %>" data-hook="admin_shipments_index_rows" class="<%= cycle('odd', 'even') %>">
         <td><%= shipment.number %></td>
         <td><%= shipment.shipping_method.name if shipment.shipping_method %></td>
-        <td><%= money shipment.cost %></td>
+        <td><%= shipment.display_cost %></td>
         <td><%= shipment.tracking %></td>
         <td><%= t(shipment.state.to_sym, :scope => :state_names, :default => shipment.state.to_s.humanize) %></td>
         <td><%= shipment.shipped_at.to_s(:date_time24) if shipment.shipped_at %></td>

--- a/core/app/views/spree/admin/variants/index.html.erb
+++ b/core/app/views/spree/admin/variants/index.html.erb
@@ -33,7 +33,7 @@
             <span class="handle"></span>
           </td>
           <td><%= variant.options_text %></td>
-          <td class="align-center"><%= money variant.price %></td>
+          <td class="align-center"><%= variant.display_price %></td>
           <td class="align-center"><%= variant.sku %></td>
           <td class="align-center"><%= variant.on_hand %></td>
           <td class="actions">

--- a/core/app/views/spree/checkout/_summary.html.erb
+++ b/core/app/views/spree/checkout/_summary.html.erb
@@ -4,27 +4,27 @@
   <tbody>
     <tr data-hook="item_total">
       <td><strong><%= t(:item_total) %>:</strong></td>
-      <td><strong><%= money order.item_total %></strong></td>
+      <td><strong><%= order.display_item_total %></strong></td>
     </tr>
     <tbody id="summary-order-charges" data-hook>
       <% order.adjustments.eligible.each do |adjustment| %>
       <% next if (adjustment.originator_type == 'Spree::TaxRate') and (adjustment.amount == 0) %>
         <tr>
           <td><%= adjustment.label %>: </td>
-          <td><%= money adjustment.amount %></td>
+          <td><%= adjustment.display_amount %></td>
         </tr>
       <% end %>
     </tbody>
     <tr data-hook="order_total">
       <td><strong><%= t(:order_total) %>:</strong></td>
-      <td><strong><span id='summary-order-total'><%= money @order.total %></span></strong></td>
+      <td><strong><span id='summary-order-total'><%= @order.display_total %></span></strong></td>
     </tr>
     <% if order.price_adjustment_totals.present? %>
       <tbody id="price-adjustments" data-hook="order_details_price_adjustments">
         <% @order.price_adjustment_totals.keys.each do |key| %>
           <tr class="total">
             <td><strong><%= key %></strong></td>
-            <td><strong><span><%= money @order.price_adjustment_totals[key] %></span></strong></td>
+            <td><strong><span><%= @order.price_adjustment_totals[key].display_total %></span></strong></td>
           </tr>
         <% end %>
       </tbody>

--- a/core/app/views/spree/order_mailer/cancel_email.text.erb
+++ b/core/app/views/spree/order_mailer/cancel_email.text.erb
@@ -6,11 +6,11 @@
 <%= t('order_mailer.cancel_email.order_summary_canceled') %>
 ============================================================
 <% @order.line_items.each do |item| %>
-  <%= item.variant.sku %> <%= raw(item.variant.product.name) %> <%= raw(item.variant.options_text) -%> (<%=item.quantity%>) @ <%= money item.price %> = <%= money(item.price * item.quantity) %>
+  <%= item.variant.sku %> <%= raw(item.variant.product.name) %> <%= raw(item.variant.options_text) -%> (<%=item.quantity%>) @ <%= item.variant.display_amount %> = <%= item.display_amount %>
 <% end %>
 ============================================================
-<%= t('order_mailer.cancel_email.subtotal') %> <%= money @order.item_total %>
+<%= t('order_mailer.cancel_email.subtotal') %> <%= @order.display_item_total %>
 <% @order.adjustments.eligible.each do |adjustment| %>
-  <%= raw(adjustment.label) %> <%= money(adjustment.amount) %>
+  <%= raw(adjustment.label) %> <%= adjustment.display_amount %>
 <% end %>
-<%= t('order_mailer.cancel_email.total') %> <%= money(@order.total) %>
+<%= t('order_mailer.cancel_email.total') %> <%= @order.display_total %>

--- a/core/app/views/spree/order_mailer/confirm_email.text.erb
+++ b/core/app/views/spree/order_mailer/confirm_email.text.erb
@@ -6,15 +6,15 @@
 <%= t('order_mailer.confirm_email.order_summary') %>
 ============================================================
 <% @order.line_items.each do |item| %>
-  <%= item.variant.sku %> <%= raw(item.variant.product.name) %> <%= raw(item.variant.options_text) -%> (<%=item.quantity%>) @ <%= money item.price %> = <%= money(item.price * item.quantity) %>
+  <%= item.variant.sku %> <%= raw(item.variant.product.name) %> <%= raw(item.variant.options_text) -%> (<%=item.quantity%>) @ <%= item.variant.display_amount %> = <%= item.display_amount %>
 <% end %>
 ============================================================
-<%= t('order_mailer.confirm_email.subtotal') %>: <%= money @order.item_total %>
+<%= t('order_mailer.confirm_email.subtotal') %>: <%= @order.display_item_total %>
 
 <% @order.adjustments.eligible.each do |adjustment| %>
-  <%= raw(adjustment.label) %> <%= money(adjustment.amount) %>
+  <%= raw(adjustment.label) %> <%= adjustment.display_amount %>
 <% end %>
 
-<%= t('order_mailer.confirm_email.total') %>: <%= money(@order.total) %>
+<%= t('order_mailer.confirm_email.total') %>: <%= @order.display_total %>
 
 <%= t('order_mailer.confirm_email.thanks') %>

--- a/core/app/views/spree/orders/_adjustments.html.erb
+++ b/core/app/views/spree/orders/_adjustments.html.erb
@@ -7,7 +7,7 @@
   <% @order.adjustments.eligible.each do |adjustment| %>
     <tr>
       <td colspan="4"><%= adjustment.label %></td>
-      <td><%= money(adjustment.amount) %></td>
+      <td><%= adjustment.display_amount %></td>
       <td></td>
     </tr>
   <% end %>

--- a/core/app/views/spree/orders/_line_item.html.erb
+++ b/core/app/views/spree/orders/_line_item.html.erb
@@ -17,13 +17,13 @@
     <%= line_item_description(variant) %>
   </td>
   <td class="cart-item-price" data-hook="cart_item_price">
-    <%= money line_item.price %>
+    <%= line_item.variant.display_amount %>
   </td>
   <td class="cart-item-quantity" data-hook="cart_item_quantity">
     <%= item_form.number_field :quantity, :min => 0, :class => "line_item_quantity", :size => 5 %>
   </td>
   <td class="cart-item-total" data-hook="cart_item_total">
-    <%= money(line_item.price * line_item.quantity) unless line_item.quantity.nil? %>
+    <%= line_item.display_amount unless line_item.quantity.nil? %>
   </td>
   <td class="cart-item-delete" data-hook="cart_item_delete">
     <%= link_to image_tag('icons/delete.png'), '#', :class => 'delete', :id => "delete_#{dom_id(line_item)}" %>

--- a/core/app/views/spree/orders/_line_item.html.erb
+++ b/core/app/views/spree/orders/_line_item.html.erb
@@ -17,7 +17,7 @@
     <%= line_item_description(variant) %>
   </td>
   <td class="cart-item-price" data-hook="cart_item_price">
-    <%= line_item.variant.display_amount %>
+    <%= line_item.single_money %>
   </td>
   <td class="cart-item-quantity" data-hook="cart_item_quantity">
     <%= item_form.number_field :quantity, :min => 0, :class => "line_item_quantity", :size => 5 %>

--- a/core/app/views/spree/products/_cart_form.html.erb
+++ b/core/app/views/spree/products/_cart_form.html.erb
@@ -11,7 +11,7 @@
             checked = !has_checked && (v.in_stock || Spree::Config[:allow_backorders])
             has_checked = true if checked %>
             <li>
-              <%= radio_button_tag "products[#{@product.id}]", v.id, checked, :disabled => !v.in_stock && !Spree::Config[:allow_backorders], 'data-price' => money(v.price) %>
+              <%= radio_button_tag "products[#{@product.id}]", v.id, checked, :disabled => !v.in_stock && !Spree::Config[:allow_backorders], 'data-price' => v.display_price %>
               <label for="<%= ['products', @product.id, v.id].join('_') %>">
                 <span class="variant-description">
                   <%= variant_options v %>
@@ -31,7 +31,7 @@
         
         <div id="product-price">
           <h6 class="product-section-title"><%= t(:price) %></h6>
-          <div><span class="price selling" itemprop="price"><%= money @product.price %></span></div>
+          <div><span class="price selling" itemprop="price"><%= @product.display_price %></span></div>
         </div>
 
         <div class="add-to-cart">

--- a/core/app/views/spree/shared/_order_details.html.erb
+++ b/core/app/views/spree/shared/_order_details.html.erb
@@ -79,16 +79,16 @@
           <%= truncate(item.variant.product.description, :length => 100, :omission => "...") %>
           <%= "(" + item.variant.options_text + ")" unless item.variant.option_values.empty? %>
         </td>
-        <td data-hook="order_item_price" class="price"><span><%= money item.price %></span></td>
+        <td data-hook="order_item_price" class="price"><span><%= item.variant.display_amount %></span></td>
         <td data-hook="order_item_qty"><%= item.quantity %></td>
-        <td data-hook="order_item_total" class="total"><span><%= money(item.price * item.quantity) %></span></td>
+        <td data-hook="order_item_total" class="total"><span><%= item.display_amount %></span></td>
       </tr>
     <% end %>
   </tbody>
   <tfoot id="order-total" data-hook="order_details_total">
     <tr class="total">
       <td colspan="4"><b><%= t(:order_total) %>:</b></td>
-      <td class="total"><span id="order_total"><%= money @order.total %></span></td>
+      <td class="total"><span id="order_total"><%= @order.display_total %></span></td>
     </tr>
   </tfoot>
   <% if order.price_adjustment_totals.present? %>
@@ -96,7 +96,7 @@
       <% @order.price_adjustment_totals.keys.each do |key| %>
         <tr class="total">
           <td colspan="4"><strong><%= key %></strong></td>
-          <td class="total"><span><%= money @order.price_adjustment_totals[key] %></span></td>
+          <td class="total"><span><%= @order.price_adjustment_totals[key].display_amount %></span></td>
         </tr>
       <% end %>
     </tfoot>
@@ -104,7 +104,7 @@
   <tfoot id="subtotal" data-hook="order_details_subtotal">
     <tr class="total" id="subtotal-row">
       <td colspan="4"><b><%= t(:subtotal) %>:</b></td>
-      <td class="total"><span><%= money @order.item_total %></span></td>
+      <td class="total"><span><%= @order.display_item_total %></span></td>
     </tr>
   </tfoot>
   <tfoot id="order-charges" data-hook="order_details_adjustments">
@@ -112,7 +112,7 @@
     <% next if (adjustment.originator_type == 'Spree::TaxRate') and (adjustment.amount == 0) %>
       <tr class="total">
         <td colspan="4"><strong><%= adjustment.label %></strong></td>
-        <td class="total"><span><%= money adjustment.amount %></span></td>
+        <td class="total"><span><%= adjustment.display_amount %></span></td>
       </tr>
     <% end %>
   </tfoot>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -83,6 +83,7 @@ en:
         name: Name
       spree/product:
         available_on: "Available On"
+        cost_currency: "Cost Currency"
         cost_price: "Cost Price"
         description: Description
         master_price: "Master Price"
@@ -121,6 +122,7 @@ en:
         password: "Password"
         password_confirmation: "Password Confirmation"
       spree/variant:
+        cost_currency: "Cost Currency"
         cost_price: "Cost Price"
         depth: Depth
         height: Height
@@ -336,6 +338,7 @@ en:
   continue: Continue
   continue_shopping: "Continue shopping"
   copy_all_mails_to: Copy All Mails To
+  cost_currency: "Cost Currency"
   cost_price: "Cost Price"
   count_of_reduced_by: "count of '%{name}' reduced by %{count}"
   country: Country

--- a/core/db/migrate/20121031162139_split_prices_from_variants.rb
+++ b/core/db/migrate/20121031162139_split_prices_from_variants.rb
@@ -1,0 +1,30 @@
+class SplitPricesFromVariants < ActiveRecord::Migration
+  def up
+    create_table :spree_prices do |t|
+      t.integer :variant_id, :null => false
+      t.decimal :amount, :precision => 8, :scale => 2, :null => false
+      t.string :currency
+    end
+
+    Spree::Variant.all.each do |variant|
+      Spree::Price.create!(
+        :variant_id => variant.id,
+        :amount => variant.price,
+        :currency => Spree::Config[:currency]
+      )
+    end
+
+    remove_column :spree_variants, :price
+  end
+
+  def down
+    add_column :spree_variants, :price, :decimal, :after => :sku, :scale => 8, :precision => 2
+
+    Spree::Variant.all.each do |variant|
+      variant.price = variant.default_price.amount
+      variant.save!
+    end
+
+    drop_table :spree_prices
+  end
+end

--- a/core/db/migrate/20121107003422_remove_not_null_from_spree_prices_amount.rb
+++ b/core/db/migrate/20121107003422_remove_not_null_from_spree_prices_amount.rb
@@ -1,0 +1,9 @@
+class RemoveNotNullFromSpreePricesAmount < ActiveRecord::Migration
+  def up
+    change_column :spree_prices, :amount, :decimal, :precision => 8, :scale => 2, :null => true
+  end
+
+  def down
+    change_column :spree_prices, :amount, :decimal, :precision => 8, :scale => 2, :null => false
+  end
+end

--- a/core/db/migrate/20121107184631_add_currency_to_line_items.rb
+++ b/core/db/migrate/20121107184631_add_currency_to_line_items.rb
@@ -1,0 +1,5 @@
+class AddCurrencyToLineItems < ActiveRecord::Migration
+  def change
+    add_column :spree_line_items, :currency, :string
+  end
+end

--- a/core/db/migrate/20121107194006_add_currency_to_orders.rb
+++ b/core/db/migrate/20121107194006_add_currency_to_orders.rb
@@ -1,0 +1,5 @@
+class AddCurrencyToOrders < ActiveRecord::Migration
+  def change
+    add_column :spree_orders, :currency, :string
+  end
+end

--- a/core/db/migrate/20121109173623_add_cost_currency_to_variants.rb
+++ b/core/db/migrate/20121109173623_add_cost_currency_to_variants.rb
@@ -1,0 +1,5 @@
+class AddCostCurrencyToVariants < ActiveRecord::Migration
+  def change
+    add_column :spree_variants, :cost_currency, :string, :after => :cost_price
+  end
+end

--- a/core/lib/spree/core/controller_helpers/common.rb
+++ b/core/lib/spree/core/controller_helpers/common.rb
@@ -55,6 +55,14 @@ module Spree
           Spree::Config[:default_seo_title]
         end
 
+        def supported_currencies
+          Spree::Money.supported_currencies
+        end
+
+        def selected_currency
+          session[:currency] || Spree::Config[:currency]
+        end
+
         def render_404(exception = nil)
           respond_to do |type|
             type.html { render :status => :not_found, :file    => "#{::Rails.root}/public/404", :formats => [:html], :layout => nil}

--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -23,11 +23,11 @@ module Spree
         def current_order(create_order_if_necessary = false)
           return @current_order if @current_order
           if session[:order_id]
-            current_order = Spree::Order.find_by_id(session[:order_id], :include => :adjustments)
+            current_order = Spree::Order.find_by_id_and_currency(session[:order_id], selected_currency, :include => :adjustments)
             @current_order = current_order unless current_order.try(:completed?)
           end
           if create_order_if_necessary and (@current_order.nil? or @current_order.completed?)
-            @current_order = Spree::Order.new
+            @current_order = Spree::Order.new(currency: selected_currency)
             before_save_new_order
             @current_order.save!
             after_save_new_order

--- a/core/lib/spree/core/search/base.rb
+++ b/core/lib/spree/core/search/base.rb
@@ -14,7 +14,7 @@ module Spree
           @products_scope = get_base_scope
           curr_page = page || 1
 
-          @products = @products_scope.includes([:master]).page(curr_page).per(per_page)
+          @products = @products_scope.includes([:master => :default_price]).where("spree_prices.amount IS NOT NULL").page(curr_page).per(per_page)
         end
 
         def method_missing(name)

--- a/core/lib/spree/core/testing_support/factories/price_factory.rb
+++ b/core/lib/spree/core/testing_support/factories/price_factory.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :price, :class => Spree::Price do
+    variant :variant
+    amount 19.99
+    currency 'USD'
+  end
+end
+

--- a/core/lib/spree/money.rb
+++ b/core/lib/spree/money.rb
@@ -2,8 +2,10 @@ require 'money'
 
 module Spree
   class Money
+    attr_reader :money
+
     def initialize(amount, options={})
-      @money = ::Money.parse([amount, Spree::Config[:currency]].join)
+      @money = ::Money.parse([amount, (options[:currency] || Spree::Config[:currency])].join)
       @options = {}
       @options[:with_currency] = true if Spree::Config[:display_currency]
       @options[:symbol_position] = Spree::Config[:currency_symbol_position].to_sym
@@ -14,6 +16,10 @@ module Spree
 
     def to_s
       @money.format(@options)
+    end
+
+    def ==(obj)
+      @money == obj.money
     end
   end
 end

--- a/core/lib/spree/product_filters.rb
+++ b/core/lib/spree/product_filters.rb
@@ -61,7 +61,7 @@ module Spree
       conds.each do |new_scope|
         scope = scope.or(new_scope)
       end
-      Spree::Product.joins(:master).where(scope)
+      Spree::Product.joins(:master => :default_price).where(scope)
     end
 
     def ProductFilters.format_price(amount)
@@ -69,12 +69,12 @@ module Spree
     end
 
     def ProductFilters.price_filter
-      v = Spree::Variant.arel_table
-      conds = [ [ I18n.t(:under_price, :price => format_price(10))   , v[:price].lteq(10)],
-                [ "#{format_price(10)} - #{format_price(15)}"        , v[:price].in(10..15)],
-                [ "#{format_price(15)} - #{format_price(18)}"        , v[:price].in(15..18)],
-                [ "#{format_price(18)} - #{format_price(20)}"        , v[:price].in(18..20)],
-                [ I18n.t(:or_over_price, :price => format_price(20)) , v[:price].gteq(20)]]
+      v = Spree::Price.arel_table
+      conds = [ [ I18n.t(:under_price, :price => format_price(10))   , v[:amount].lteq(10)],
+                [ "#{format_price(10)} - #{format_price(15)}"        , v[:amount].in(10..15)],
+                [ "#{format_price(15)} - #{format_price(18)}"        , v[:amount].in(15..18)],
+                [ "#{format_price(18)} - #{format_price(20)}"        , v[:amount].in(18..20)],
+                [ I18n.t(:or_over_price, :price => format_price(20)) , v[:amount].gteq(20)]]
       { :name   => I18n.t(:price_range),
         :scope  => :price_range_any,
         :conds  => Hash[*conds.flatten],

--- a/core/spec/controllers/spree/orders_controller_spec.rb
+++ b/core/spec/controllers/spree/orders_controller_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Spree::OrdersController do
   let(:user) { create(:user) }
-  let(:order) { mock_model(Spree::Order, :number => "R123", :reload => nil, :save! => true, :coupon_code => nil, :user => user, :completed? => false)}
+  let(:order) { mock_model(Spree::Order, :number => "R123", :reload => nil, :save! => true, :coupon_code => nil, :user => user, :completed? => false, :currency => "USD")}
   before do
     Spree::Order.stub(:find).with(1).and_return(order)
     #ensure no respond_overrides are in effect
@@ -27,17 +27,17 @@ describe Spree::OrdersController do
       end
 
       it "should handle single variant/quantity pair" do
-        order.should_receive(:add_variant).with(@variant, 2)
+        order.should_receive(:add_variant).with(@variant, 2, order.currency)
         spree_post :populate, {:order_id => 1, :variants => {@variant.id => 2}}
       end
       it "should handle multiple variant/quantity pairs with shared quantity" do
         @variant.stub(:product_id).and_return(10)
-        order.should_receive(:add_variant).with(@variant, 1)
+        order.should_receive(:add_variant).with(@variant, 1, order.currency)
         spree_post :populate, {:order_id => 1, :products => {@variant.product_id => @variant.id}, :quantity => 1}
       end
       it "should handle multiple variant/quantity pairs with specific quantity" do
         @variant.stub(:product_id).and_return(10)
-        order.should_receive(:add_variant).with(@variant, 3)
+        order.should_receive(:add_variant).with(@variant, 3, order.currency)
         spree_post :populate, {:order_id => 1, :products => {@variant.product_id => @variant.id}, :quantity => {@variant.id.to_s => 3}}
       end
     end
@@ -48,7 +48,7 @@ describe Spree::OrdersController do
       order.stub(:update_attributes).and_return true
       order.stub(:line_items).and_return([])
       order.stub(:line_items=).with([])
-      Spree::Order.stub(:find_by_id).and_return(order)
+      Spree::Order.stub(:find_by_id_and_currency).and_return(order)
     end
 
     it "should not result in a flash success" do

--- a/core/spec/helpers/products_helper_spec.rb
+++ b/core/spec/helpers/products_helper_spec.rb
@@ -81,8 +81,8 @@ module Spree
 
       it "should be nil when all variant prices are equal" do
         product.price = 10
-        @variant1.update_column(:price, 10)
-        @variant2.update_column(:price, 10)
+        @variant1.default_price.update_column(:amount, 10)
+        @variant2.default_price.update_column(:amount, 10)
         helper.variant_price(@variant1).should be_nil
         helper.variant_price(@variant2).should be_nil
       end

--- a/core/spec/helpers/products_helper_spec.rb
+++ b/core/spec/helpers/products_helper_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'spec_helper'
 
 module Spree
@@ -11,22 +13,42 @@ module Spree
         @variant = create(:variant, :product => product)
       end
 
-      it "should be correct positive value when variant is more than master" do
-        product.price = 10
-        @variant.price = 15
-        helper.variant_price(@variant).should == "(Add: $5.00)"
-      end
-
       it "should be nil when variant is same as master" do
         product.price = 10
         @variant.price = 10
         helper.variant_price(@variant).should be_nil
       end
 
-      it "should be correct negative value when variant is less than master" do
-        product.price = 15
-        @variant.price = 10
-        helper.variant_price(@variant).should == "(Subtract: $5.00)"
+      context "when currency is default" do
+        it "should be correct positive value when variant is more than master" do
+          product.price = 10
+          @variant.price = 15
+          helper.variant_price(@variant).should == "(Add: $5.00)"
+        end
+
+        it "should be correct negative value when variant is less than master" do
+          product.price = 15
+          @variant.price = 10
+          helper.variant_price(@variant).should == "(Subtract: $5.00)"
+        end
+      end
+
+      context "when currency is JPY" do
+        before do
+          @variant.stub(:currency) { 'JPY' }
+        end
+
+        it "should be correct positive value when variant is more than master" do
+          product.price = 100
+          @variant.price = 150
+          helper.variant_price(@variant).should == "(Add: ¥50)"
+        end
+
+        it "should be correct negative value when variant is less than master" do
+          product.price = 150
+          @variant.price = 100
+          helper.variant_price(@variant).should == "(Subtract: ¥50)"
+        end
       end
     end
 
@@ -37,12 +59,24 @@ module Spree
         @variant2 = create(:variant, :product => product)
       end
 
-      it "should return the variant price if the price is different than master" do
-        product.price = 10
-        @variant1.price = 15
-        @variant2.price = 20
-        helper.variant_price(@variant1).should == "$15.00"
-        helper.variant_price(@variant2).should == "$20.00"
+      context "when currency is default" do
+        it "should return the variant price if the price is different than master" do
+          product.price = 10
+          @variant1.price = 15
+          @variant2.price = 20
+          helper.variant_price(@variant1).should == "$15.00"
+          helper.variant_price(@variant2).should == "$20.00"
+        end
+      end
+
+      context "when currency is JPY" do
+        it "should return the variant price if the price is different than master" do
+          product.price = 100
+          @variant1.price = 150
+          @variant1.stub(:currency) { 'JPY' }
+
+          helper.variant_price(@variant1).should == "¥150"
+        end
       end
 
       it "should be nil when all variant prices are equal" do

--- a/core/spec/lib/money_spec.rb
+++ b/core/spec/lib/money_spec.rb
@@ -29,6 +29,22 @@ module Spree
       end
     end
 
+    context "currency parameter" do
+      context "when currency is specified in Canadian Dollars" do
+        it "uses the currency param over the global configuration" do
+          money = Spree::Money.new(10, :currency => 'CAD', :with_currency => true)
+          money.to_s.should == "$10.00 CAD"
+        end
+      end
+
+      context "when currency is specified in Japanese Yen" do
+        it "uses the currency param over the global configuration" do
+          money = Spree::Money.new(100, :currency => 'JPY')
+          money.to_s.should == "¥100"
+        end
+      end
+    end
+
     context "symbol positioning" do
       it "passed in option" do
         money = Spree::Money.new(10, :symbol_position => :after)

--- a/core/spec/mailers/order_mailer_spec.rb
+++ b/core/spec/mailers/order_mailer_spec.rb
@@ -9,7 +9,9 @@ describe Spree::OrderMailer do
     order = stub_model(Spree::Order)
     product = stub_model(Spree::Product, :name => %Q{The "BEST" product})
     variant = stub_model(Spree::Variant, :product => product)
+    price = stub_model(Spree::Price, :variant => variant)
     line_item = stub_model(Spree::LineItem, :variant => variant, :order => order, :quantity => 1, :price => 5)
+    variant.stub(:default_price => price)
     order.stub(:line_items => [line_item])
     order
   end

--- a/core/spec/models/adjustment_spec.rb
+++ b/core/spec/models/adjustment_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+#
 
 require 'spec_helper'
 
@@ -122,10 +123,21 @@ describe Spree::Adjustment do
     end
 
     context "with currency set to JPY" do
-      before { adjustment.stub(:currency) { 'JPY' } }
+      context "when adjustable is set to an order" do
+        before do
+          order.stub(:currency) { 'JPY' }
+          adjustment.adjustable = order
+        end
 
-      it "displays in JPY" do
-        adjustment.display_amount.should == "¥11"
+        it "displays in JPY" do
+          adjustment.display_amount.should == "¥11"
+        end
+      end
+
+      context "when adjustable is nil" do
+        it "displays in the default currency" do
+          adjustment.display_amount.should == "$10.55"
+        end
       end
     end
   end

--- a/core/spec/models/adjustment_spec.rb
+++ b/core/spec/models/adjustment_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'spec_helper'
 
 describe Spree::Adjustment do
@@ -117,6 +119,20 @@ describe Spree::Adjustment do
       it "does not include the currency" do
         adjustment.display_amount.should == "$10.55"
       end
+    end
+
+    context "with currency set to JPY" do
+      before { adjustment.stub(:currency) { 'JPY' } }
+
+      it "displays in JPY" do
+        adjustment.display_amount.should == "¥11"
+      end
+    end
+  end
+
+  context '#currency' do
+    it 'returns the globally configured currency' do
+      adjustment.currency.should == 'USD'
     end
   end
 end

--- a/core/spec/models/line_item_spec.rb
+++ b/core/spec/models/line_item_spec.rb
@@ -18,6 +18,7 @@ describe Spree::LineItem do
 
   before do
     line_item.stub(:order => order, :variant => variant, :new_record? => false)
+    variant.stub(:currency => "USD")
     Spree::Config.set :allow_backorders => true
   end
 
@@ -245,10 +246,17 @@ describe Spree::LineItem do
     end
   end
 
-  describe ".display_amount" do
+  describe ".money" do
     before { line_item.price = 3.50 }
     it "returns a Spree::Money representing the total for this line item" do
-      line_item.display_amount.to_s.should == "$17.50"
+      line_item.money.to_s.should == "$17.50"
+    end
+  end
+
+  describe '.single_money' do
+    before { line_item.price = 3.50 }
+    it "returns a Spree::Money representing the price for one variant" do
+      line_item.single_money.to_s.should == "$3.50"
     end
   end
 end

--- a/core/spec/models/line_item_spec.rb
+++ b/core/spec/models/line_item_spec.rb
@@ -238,4 +238,17 @@ describe Spree::LineItem do
       lambda { adjustment.reload }.should raise_error(ActiveRecord::RecordNotFound)
     end
   end
+
+  describe '.currency' do
+    it 'returns the globally configured currency' do
+      line_item.currency == 'USD'
+    end
+  end
+
+  describe ".display_amount" do
+    before { line_item.price = 3.50 }
+    it "returns a Spree::Money representing the total for this line item" do
+      line_item.display_amount.to_s.should == "$17.50"
+    end
+  end
 end

--- a/core/spec/models/order_spec.rb
+++ b/core/spec/models/order_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'spec_helper'
 
 class FakeCalculator < Spree::Calculator
@@ -338,23 +340,37 @@ describe Spree::Order do
     end
   end
 
-  context "#display_total" do
-    before { order.total = 10.55 }
-
-    context "with display_currency set to true" do
-      before { Spree::Config[:display_currency] = true }
-
-      it "shows the currency" do
-        order.display_total.to_s.should == "$10.55 USD"
-      end
+  context "#display_outstanding_balance" do
+    it "returns the value as a spree money" do
+      order.stub(:outstanding_balance) { 10.55 }
+      order.display_outstanding_balance.should == Spree::Money.new(10.55)
     end
+  end
 
-    context "with display_currency set to false" do
-      before { Spree::Config[:display_currency] = false }
+  context "#display_item_total" do
+    it "returns the value as a spree money" do
+      order.stub(:item_total) { 10.55 }
+      order.display_item_total.should == Spree::Money.new(10.55)
+    end
+  end
 
-      it "does not include the currency" do
-        order.display_total.to_s.should == "$10.55"
-      end
+  context "#display_adjustment_total" do
+    it "returns the value as a spree money" do
+      order.adjustment_total = 10.55
+      order.display_adjustment_total.should == Spree::Money.new(10.55)
+    end
+  end
+
+  context "#display_total" do
+    it "returns the value as a spree money" do
+      order.total = 10.55
+      order.display_total.should == Spree::Money.new(10.55)
+    end
+  end
+
+  context "#currency" do
+    it "returns the globally configured currency" do
+      order.currency.should == "USD"
     end
   end
 

--- a/core/spec/models/order_spec.rb
+++ b/core/spec/models/order_spec.rb
@@ -369,8 +369,20 @@ describe Spree::Order do
   end
 
   context "#currency" do
-    it "returns the globally configured currency" do
-      order.currency.should == "USD"
+    context "when object currency is ABC" do
+      before { order.currency = "ABC" }
+
+      it "returns the currency from the object" do
+        order.currency.should == "ABC"
+      end
+    end
+
+    context "when object currency is nil" do
+      before { order.currency = nil }
+
+      it "returns the globally configured currency" do
+        order.currency.should == "USD"
+      end
     end
   end
 

--- a/core/spec/models/payment_spec.rb
+++ b/core/spec/models/payment_spec.rb
@@ -526,8 +526,9 @@ describe Spree::Payment do
   end
 
   context "#currency" do
-    it "returns the globally configured currency" do
-      payment.currency.should == "USD"
+    before { order.stub(:currency) { "ABC" } }
+    it "returns the order currency" do
+      payment.currency.should == "ABC"
     end
   end
 

--- a/core/spec/models/payment_spec.rb
+++ b/core/spec/models/payment_spec.rb
@@ -524,4 +524,16 @@ describe Spree::Payment do
       payment.source.should have(1).error_on(:verification_value)
     end
   end
+
+  context "#currency" do
+    it "returns the globally configured currency" do
+      payment.currency.should == "USD"
+    end
+  end
+
+  context "#display_amount" do
+    it "returns a Spree::Money for this amount" do
+      payment.display_amount.should == Spree::Money.new(payment.amount)
+    end
+  end
 end

--- a/core/spec/models/product/scopes_spec.rb
+++ b/core/spec/models/product/scopes_spec.rb
@@ -25,7 +25,7 @@ describe "Product scopes" do
     # Regression test for #2111
     context "A product with a deleted variant" do
       before do
-        variant = product.variants.create({:count_on_hand => 300}, :without_protection => true)
+        variant = product.variants.create!({:price => 10, :count_on_hand => 300}, :without_protection => true)
         variant.update_column(:deleted_at, Time.now)
       end
 

--- a/core/spec/models/product_spec.rb
+++ b/core/spec/models/product_spec.rb
@@ -124,6 +124,14 @@ describe Spree::Product do
           product.display_price.should == "$10.55"
         end
       end
+
+      context "with currency set to JPY" do
+        before { product.master.stub(:currency) { 'JPY' } }
+
+        it "displays the currency in yen" do
+          product.display_price.to_s.should == "¥11"
+        end
+      end
     end
 
     context "#available?" do

--- a/core/spec/models/product_spec.rb
+++ b/core/spec/models/product_spec.rb
@@ -126,7 +126,11 @@ describe Spree::Product do
       end
 
       context "with currency set to JPY" do
-        before { product.master.stub(:currency) { 'JPY' } }
+        before do
+          product.master.default_price.currency = 'JPY'
+          product.master.default_price.save!
+          Spree::Config[:currency] = 'JPY'
+        end
 
         it "displays the currency in yen" do
           product.display_price.to_s.should == "¥11"

--- a/core/spec/models/return_authorization_spec.rb
+++ b/core/spec/models/return_authorization_spec.rb
@@ -109,4 +109,16 @@ describe Spree::ReturnAuthorization do
     end
   end
 
+  context "currency" do
+    it "returns the globally configured currency" do
+      return_authorization.currency.should == "USD"
+    end
+  end
+
+  context "display_amount" do
+    it "retuns a Spree::Money" do
+      return_authorization.amount = 21.22
+      return_authorization.display_amount.should == Spree::Money.new(21.22)
+    end
+  end
 end

--- a/core/spec/models/return_authorization_spec.rb
+++ b/core/spec/models/return_authorization_spec.rb
@@ -110,8 +110,9 @@ describe Spree::ReturnAuthorization do
   end
 
   context "currency" do
-    it "returns the globally configured currency" do
-      return_authorization.currency.should == "USD"
+    before { order.stub(:currency) { "ABC" } }
+    it "returns the order currency" do
+      return_authorization.currency.should == "ABC"
     end
   end
 

--- a/core/spec/models/shipment_spec.rb
+++ b/core/spec/models/shipment_spec.rb
@@ -197,4 +197,17 @@ describe Spree::Shipment do
       shipment.run_callbacks(:save, :after)
     end
   end
+
+  context "currency" do
+    it "returns the globally configured currency" do
+      shipment.currency.should == "USD"
+    end
+  end
+
+  context "display_cost" do
+    it "retuns a Spree::Money" do
+      shipment.stub(:cost) { 21.22 }
+      shipment.display_cost.should == Spree::Money.new(21.22)
+    end
+  end
 end

--- a/core/spec/models/shipment_spec.rb
+++ b/core/spec/models/shipment_spec.rb
@@ -5,7 +5,7 @@ describe Spree::Shipment do
     reset_spree_preferences
   end
 
-  let(:order) { mock_model Spree::Order, :backordered? => false, :complete? => true }
+  let(:order) { mock_model Spree::Order, :backordered? => false, :complete? => true, :currency => "USD" }
   let(:shipping_method) { mock_model Spree::ShippingMethod, :calculator => mock('calculator') }
   let(:shipment) do
     shipment = Spree::Shipment.new :order => order, :shipping_method => shipping_method
@@ -199,8 +199,8 @@ describe Spree::Shipment do
   end
 
   context "currency" do
-    it "returns the globally configured currency" do
-      shipment.currency.should == "USD"
+    it "returns the order currency" do
+      shipment.currency.should == order.currency
     end
   end
 

--- a/core/spec/models/shipping_method_spec.rb
+++ b/core/spec/models/shipping_method_spec.rb
@@ -94,6 +94,14 @@ describe Spree::ShippingMethod do
       end
     end
 
+    context "when currency_check is false" do
+      before { @shipping_method.stub(:currency_match? => false) }
+
+      it "should be false" do
+        @shipping_method.available_to_order?(@order).should be_false
+      end
+    end
+
     context "when all checks are true" do
       it "should be true" do
         @shipping_method.available_to_order?(@order).should be_true

--- a/core/spec/models/shipping_rate_spec.rb
+++ b/core/spec/models/shipping_rate_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'spec_helper'
 
 describe Spree::ShippingRate do
@@ -16,6 +18,14 @@ describe Spree::ShippingRate do
       before { Spree::Config[:shipment_inc_vat] = false }
       it "displays the correct price" do
         shipping_rate.display_price.to_s.should == "$10.55"
+      end
+    end
+
+    context "when the currency is JPY" do
+      let(:shipping_rate) { Spree::ShippingRate.new(:cost => 205, :currency => "JPY") }
+
+      it "displays the price in yen" do
+        shipping_rate.display_price.to_s.should == "¥205"
       end
     end
   end

--- a/core/spec/models/variant_spec.rb
+++ b/core/spec/models/variant_spec.rb
@@ -269,4 +269,17 @@ describe Spree::Variant do
       end
     end
   end
+
+  context "#currency" do
+    it "returns the globally configured currency" do
+      variant.currency.should == "USD"
+    end
+  end
+
+  context "#display_amount" do
+    it "retuns a Spree::Money" do
+      variant.price = 21.22
+      variant.display_amount.should == Spree::Money.new(21.22)
+    end
+  end
 end

--- a/core/spec/models/variant_spec.rb
+++ b/core/spec/models/variant_spec.rb
@@ -279,7 +279,17 @@ describe Spree::Variant do
   context "#display_amount" do
     it "retuns a Spree::Money" do
       variant.price = 21.22
-      variant.display_amount.should == Spree::Money.new(21.22)
+      variant.display_amount.should == "$21.22"
+    end
+  end
+
+  context "#cost_currency" do
+    context "when cost currency is nil" do
+      before { variant.cost_currency = nil }
+      it "populates cost currency with the default value on save" do
+        variant.save!
+        variant.cost_currency.should == "USD"
+      end
     end
   end
 end

--- a/core/spec/requests/admin/orders/order_details_spec.rb
+++ b/core/spec/requests/admin/orders/order_details_spec.rb
@@ -41,6 +41,7 @@ describe "Order Details" do
 
     it "should render details properly" do
       order.state = :complete
+      order.currency = 'GBP'
       order.save!
 
       visit spree.edit_admin_order_path(order)
@@ -56,8 +57,6 @@ describe "Order Details" do
       I18n.backend.store_translations I18n.locale,
         :shipment_state => { :missing => 'some text' },
         :payment_states => { :missing => 'other text' }
-
-      Spree::Config[:currency] = "GBP"
 
       visit spree.edit_admin_order_path(order)
 

--- a/core/spec/requests/admin/products/products_spec.rb
+++ b/core/spec/requests/admin/products/products_spec.rb
@@ -149,7 +149,6 @@ describe "Products" do
       it "should show validation errors", :js => true do
         click_button "Create"
         page.should have_content("Name can't be blank")
-        page.should have_content("Price can't be blank")
       end
 
       # Regression test for #2097

--- a/sample/db/sample/spree/adjustments.yml
+++ b/sample/db/sample/spree/adjustments.yml
@@ -18,7 +18,7 @@ ship_<%= i %>:
   amount: 5
   source: shipment_<%= i %>
   source_type: Spree::Shipment
-  originator: ups_ground
+  originator: ups_ground_usd
   originator_type: Spree::ShippingMethod
   label: Shipping
   locked: true

--- a/sample/db/sample/spree/calculators.yml
+++ b/sample/db/sample/spree/calculators.yml
@@ -1,13 +1,17 @@
-ups_ground:
-  calculable: ups_ground
+ups_ground_usd:
+  calculable: ups_ground_usd
   calculable_type: Spree::ShippingMethod
   type: Spree::Calculator::FlatRate
-ups_two_day:
-  calculable: ups_two_day
+ups_two_day_usd:
+  calculable: ups_two_day_usd
   calculable_type: Spree::ShippingMethod
   type: Spree::Calculator::FlatRate
-ups_one_day:
-  calculable: ups_one_day
+ups_one_day_usd:
+  calculable: ups_one_day_usd
+  calculable_type: Spree::ShippingMethod
+  type: Spree::Calculator::FlatRate
+ups_ground_eur:
+  calculable: ups_ground_eur
   calculable_type: Spree::ShippingMethod
   type: Spree::Calculator::FlatRate
 flat_rate_coupon_calculator:

--- a/sample/db/sample/spree/preferences.rb
+++ b/sample/db/sample/spree/preferences.rb
@@ -1,11 +1,18 @@
-shipping_method = Spree::ShippingMethod.find_by_name("UPS Ground")
+shipping_method = Spree::ShippingMethod.find_by_name("UPS Ground (USD)")
 shipping_method.calculator.preferred_amount = 5
+shipping_method.calculator.preferred_currency = 'USD'
 
-shipping_method = Spree::ShippingMethod.find_by_name("UPS One Day")
+shipping_method = Spree::ShippingMethod.find_by_name("UPS Ground (EUR)")
+shipping_method.calculator.preferred_amount = 5
+shipping_method.calculator.preferred_currency = 'EUR'
+
+shipping_method = Spree::ShippingMethod.find_by_name("UPS One Day (USD)")
 shipping_method.calculator.preferred_amount = 15
+shipping_method.calculator.preferred_currency = 'USD'
 
-shipping_method = Spree::ShippingMethod.find_by_name("UPS Two Day")
+shipping_method = Spree::ShippingMethod.find_by_name("UPS Two Day (USD)")
 shipping_method.calculator.preferred_amount = 10
+shipping_method.calculator.preferred_currency = 'USD'
 
 # flat_rate_five_dollars:
 #   name: amount

--- a/sample/db/sample/spree/prices.yml
+++ b/sample/db/sample/spree/prices.yml
@@ -1,0 +1,224 @@
+small-red-baseball-price-usd:
+  variant: small-red-baseball
+  amount: 19.99
+  currency: USD
+small-blue-baseball-price-eur:
+  variant: small-blue-baseball
+  amount: 16.00
+  currency: EUR
+small-green-baseball-price-usd:
+  variant: small-green-baseball
+  amount: 19.99
+  currency: USD
+small-green-baseball-price-eur:
+  variant: small-green-baseball
+  amount: 16.00
+  currency: EUR
+med-red-baseball-price-usd:
+  variant: med-red-baseball
+  amount: 19.99
+  currency: USD
+med-red-baseball-price-eur:
+  variant: med-red-baseball
+  amount: 16.00
+  currency: EUR
+med-blue-baseball-price-usd:
+  variant: med-blue-baseball
+  amount: 19.99
+  currency: USD
+med-blue-baseball-price-eur:
+  variant: med-blue-baseball
+  amount: 16.00
+  currency: EUR
+med-green-baseball-price-usd:
+  variant: med-green-baseball
+  amount: 19.99
+  currency: USD
+med-green-baseball-price-eur:
+  variant: med-green-baseball
+  amount: 16.00
+  currency: EUR
+large-red-baseball-price-usd:
+  variant: large-red-baseball
+  amount: 19.99
+  currency: USD
+large-red-baseball-price-eur:
+  variant: large-red-baseball
+  amount: 16.00
+  currency: EUR
+large-blue-baseball-price-usd:
+  variant: large-blue-baseball
+  amount: 19.99
+  currency: USD
+large-blue-baseball-price-eur:
+  variant: large-blue-baseball
+  amount: 16.00
+  currency: EUR
+large-green-baseball-price-usd:
+  variant: large-green-baseball
+  amount: 19.99
+  currency: USD
+large-green-baseball-price-eur:
+  variant: large-green-baseball
+  amount: 16.00
+  currency: EUR
+xlarge-green-baseball-price-usd:
+  variant: xlarge-green-baseball
+  amount: 21.99
+  currency: USD
+xlarge-green-baseball-price-eur:
+  variant: xlarge-green-baseball
+  amount: 18.50
+  currency: EUR
+ror_baseball_jersey_v-price-usd:
+  variant: ror_baseball_jersey_v
+  amount: 19.99
+  currency: USD
+ror_baseball_jersey_v-price-eur:
+  variant: ror_baseball_jersey_v
+  amount: 16.00
+  currency: EUR
+ror_tote_v-price-usd:
+  variant: ror_tote_v
+  amount: 15.99
+  currency: USD
+ror_tote_v-price-eur:
+  variant: ror_tote_v
+  amount: 14.00
+  currency: EUR
+ror_bag_v-price-usd:
+  variant: ror_bag_v
+  amount: 22.99
+  currency: USD
+ror_bag_v-price-eur:
+  variant: ror_bag_v
+  amount: 19.00
+  currency: EUR
+ror_jr_spaghetti_v-price-usd:
+  variant: ror_jr_spaghetti_v
+  amount: 19.99
+  currency: USD
+ror_jr_spaghetti_v-price-eur:
+  variant: ror_jr_spaghetti_v
+  amount: 16.00
+  currency: EUR
+ror_mug_v-price-usd:
+  variant: ror_mug_v
+  amount: 13.99
+  currency: USD
+ror_mug_v-price-eur:
+  variant: ror_mug_v
+  amount: 12.00
+  currency: EUR
+ror_ringer_v-price-usd:
+  variant: ror_ringer_v
+  amount: 19.99
+  currency: USD
+ror_ringer_v-price-eur:
+  variant: ror_ringer_v
+  amount: 16.50
+  currency: EUR
+ror_stein_v-price-usd:
+  variant: ror_stein_v
+  amount: 16.99
+  currency: USD
+ror_stein_v-price-eur:
+  variant: ror_stein_v
+  amount: 14.00
+  currency: EUR
+apache_baseball_jersey_v-price-usd:
+  variant: apache_baseball_jersey_v
+  amount: 19.99
+  currency: USD
+apache_baseball_jersey_v-price-eur:
+  variant: apache_baseball_jersey_v
+  amount: 16.00
+  currency: EUR
+ruby_baseball_jersey_v-price-usd:
+  variant: ruby_baseball_jersey_v
+  amount: 19.99
+  currency: USD
+ruby_baseball_jersey_v-price-eur:
+  variant: ruby_baseball_jersey_v
+  amount: 16.00
+  currency: EUR
+spree_baseball_jersey_v-price-usd:
+  variant: spree_baseball_jersey_v
+  amount: 19.99
+  currency: USD
+spree_baseball_jersey_v-price-eur:
+  variant: spree_baseball_jersey_v
+  amount: 16.00
+  currency: EUR
+spree_stein_v-price-usd:
+  variant: spree_stein_v
+  amount: 16.99
+  currency: USD
+spree_stein_v-price-eur:
+  variant: spree_stein_v
+  amount: 14.00
+  currency: EUR
+spree_jr_spaghetti_v-price-usd:
+  variant: spree_jr_spaghetti_v
+  amount: 19.99
+  currency: USD
+spree_jr_spaghetti_v-price-eur:
+  variant: spree_jr_spaghetti_v
+  amount: 16.00
+  currency: EUR
+spree_mug_v-price-usd:
+  variant: spree_mug_v
+  amount: 13.99
+  currency: USD
+spree_mug_v-price-eur:
+  variant: spree_mug_v
+  amount: 12.00
+  currency: EUR
+spree_ringer_v-price-usd:
+  variant: spree_ringer_v
+  amount: 17.99
+  currency: USD
+spree_ringer_v-price-eur:
+  variant: spree_ringer_v
+  amount: 15.00
+  currency: EUR
+spree_tote_v-price-usd:
+  variant: spree_tote_v
+  amount: 15.99
+  currency: USD
+spree_tote_v-price-eur:
+  variant: spree_tote_v
+  amount: 14.00
+  currency: EUR
+spree_bag_v-price-usd:
+  variant: spree_bag_v
+  amount: 22.99
+  currency: USD
+spree_bag_v-price-eur:
+  variant: spree_bag_v
+  amount: 19.00
+  currency: EUR
+small-spree-baseball-price-usd:
+  variant: small-spree-baseball
+  amount: 19.99
+  currency: USD
+small-spree-baseball-price-eur:
+  variant: small-spree-baseball
+  amount: 16.00
+  currency: EUR
+med-spree-baseball-price-usd:
+  variant: med-spree-baseball
+  amount: 19.99
+  currency: USD
+med-spree-baseball-price-eur:
+  variant: med-spree-baseball
+  amount: 16.00
+  currency: EUR
+large-spree-baseball-price-usd:
+  variant: large-spree-baseball
+  amount: 19.99
+  currency: USD
+large-spree-baseball-price-eur:
+  variant: large-spree-baseball
+  amount: 16.00
+  currency: EUR

--- a/sample/db/sample/spree/shipments.yml
+++ b/sample/db/sample/spree/shipments.yml
@@ -2,7 +2,7 @@
 shipment_<%= i %>:
   number: H<%= Array.new(11){rand(11)}.join %>
   order: order_<%= i %>
-  shipping_method: ups_ground
+  shipping_method: ups_ground_usd
   address: ship_address_<%= i %>
   state: pending
 <% end %>

--- a/sample/db/sample/spree/shipping_methods.yml
+++ b/sample/db/sample/spree/shipping_methods.yml
@@ -1,9 +1,12 @@
-ups_ground:
-  name: UPS Ground
+ups_ground_usd:
+  name: UPS Ground (USD)
   zone_id: 2
-ups_two_day:
-  name: UPS Two Day
+ups_two_day_usd:
+  name: UPS Two Day (USD)
   zone_id: 2
-ups_one_day:
-  name: UPS One Day
+ups_one_day_usd:
+  name: UPS One Day (USD)
+  zone_id: 2
+ups_ground_eur:
+  name: UPS Ground (EUR)
   zone_id: 2

--- a/sample/db/sample/spree/variants.yml
+++ b/sample/db/sample/spree/variants.yml
@@ -2,181 +2,155 @@ small-red-baseball:
   product: ror_baseball_jersey
   option_values: s, red
   sku: ROR-00001
-  price: 19.99
   cost_price: 17.00
   count_on_hand: 10
 small-blue-baseball:
   product: ror_baseball_jersey
   option_values: s, blue
   sku: ROR-00002
-  price: 19.99
   cost_price: 17.00
   count_on_hand: 10
 small-green-baseball:
   product: ror_baseball_jersey
   option_values: s, green
   sku: ROR-00003
-  price: 19.99
   cost_price: 17.00
   count_on_hand: 10
 med-red-baseball:
   product: ror_baseball_jersey
   option_values: m, red
   sku: ROR-00004
-  price: 19.99
   cost_price: 17.00
   count_on_hand: 3
 med-blue-baseball:
   product: ror_baseball_jersey
   option_values: m, blue
   sku: ROR-00005
-  price: 19.99
   cost_price: 17.00
   count_on_hand: 10
 med-green-baseball:
   product: ror_baseball_jersey
   option_values: m, green
   sku: ROR-00006
-  price: 19.99
   cost_price: 17.00
   count_on_hand: 14
 large-red-baseball:
   product: ror_baseball_jersey
   option_values: l, red
   sku: ROR-00007
-  price: 19.99
   cost_price: 17.00
   count_on_hand: 1
 large-blue-baseball:
   product: ror_baseball_jersey
   option_values: l, blue
   sku: ROR-00008
-  price: 19.99
   cost_price: 17.00
   count_on_hand: 10
 large-green-baseball:
   product: ror_baseball_jersey
   option_values: l, green
   sku: ROR-00009
-  price: 19.99
   cost_price: 17.00
   count_on_hand: 10
 xlarge-green-baseball:
   product: ror_baseball_jersey
   option_values: xl, red
   sku: ROR-00010
-  price: 21.99
   cost_price: 20.00
   count_on_hand: 10
 ror_baseball_jersey_v:
   product: ror_baseball_jersey
   sku: ROR-001
-  price: 19.99
   cost_price: 17.00
   is_master: true
   count_on_hand: 10
 ror_tote_v:
   product: ror_tote
   sku: ROR-00011
-  price: 15.99
   cost_price: 13.00
   is_master: true
   count_on_hand: 10
 ror_bag_v:
   product: ror_bag
   sku: ROR-00012
-  price: 22.99
   cost_price: 21.00
   is_master: true
   count_on_hand: 10
 ror_jr_spaghetti_v:
   product: ror_jr_spaghetti
   sku: ROR-00013
-  price: 19.99
   cost_price: 17.00
   is_master: true
   count_on_hand: 10
 ror_mug_v:
   product: ror_mug
   sku: ROR-00014
-  price: 13.99
   cost_price: 11.00
   is_master: true
   count_on_hand: 10
 ror_ringer_v:
   product: ror_ringer
   sku: ROR-00015
-  price: 17.99
   cost_price: 17.00
   is_master: true
   count_on_hand: 10
 ror_stein_v:
   product: ror_stein
   sku: ROR-00016
-  price: 16.99
   cost_price: 15.00
   is_master: true
   count_on_hand: 10
 apache_baseball_jersey_v:
   product: apache_baseball_jersey
   sku: APC-00001
-  price: 19.99
   cost_price: 17.00
   is_master: true
   count_on_hand: 10
 ruby_baseball_jersey_v:
   product: ruby_baseball_jersey
   sku: RUB-00001
-  price: 19.99
   cost_price: 17.00
   is_master: true
   count_on_hand: 10
 spree_baseball_jersey_v:
   product: spree_baseball_jersey
   sku: SPR-00001
-  price: 19.99
   cost_price: 17.00
   is_master: true
   count_on_hand: 10
 spree_stein_v:
   product: spree_stein
   sku: SPR-00016
-  price: 16.99
   cost_price: 15.00
   is_master: true
   count_on_hand: 10
 spree_jr_spaghetti_v:
   product: spree_jr_spaghetti
   sku: SPR-00013
-  price: 19.99
   cost_price: 17.00
   is_master: true
   count_on_hand: 10
 spree_mug_v:
   product: spree_mug
   sku: SPR-00014
-  price: 13.99
   cost_price: 11.00
   is_master: true
   count_on_hand: 10
 spree_ringer_v:
   product: spree_ringer
   sku: SPR-00015
-  price: 17.99
   cost_price: 17.00
   is_master: true
   count_on_hand: 10
 spree_tote_v:
   product: spree_tote
   sku: SPR-00011
-  price: 15.99
   cost_price: 13.00
   is_master: true
   count_on_hand: 10
 spree_bag_v:
   product: spree_bag
   sku: SPR-00012
-  price: 22.99
   cost_price: 21.00
   is_master: true
   count_on_hand: 10
@@ -184,20 +158,17 @@ small-spree-baseball:
   product: spree_baseball_jersey
   option_values: s
   sku: SPR-00002
-  price: 19.99
   cost_price: 17.00
   count_on_hand: 10
 med-spree-baseball:
   product: spree_baseball_jersey
   option_values: m
   sku: SPR-00005
-  price: 19.99
   cost_price: 17.00
   count_on_hand: 10
 large-spree-baseball:
   product: spree_baseball_jersey
   option_values: l
   sku: SPR-00008
-  price: 19.99
   cost_price: 17.00
   count_on_hand: 10


### PR DESCRIPTION
This allows variants to be offered at different currencies on the same
store through all steps of the spree checkout prices.

A quick guide to what you can currently do:
- Start up a new sandbox
- Switch currency in admin area from USD to Euro (or vice-versa)

Products are shown in either USD or Euro, and you can follow the purchase process through to complete the order phase.

Future orders and line items are save the currency as they are created, but old line items and currency will have a nil currency.  In cases of nil currency, the currency value will be the globally configured Spree::Config[:currency].  You can note that as you change the currency back and forth, the sandbox loaded orders will switch their currency symbol (mirroring current spree master functionality), but orders made using this codebase will reflect the currency they were made in.  It may make sense to populate the currency as part of a migration in order to correctly reflect the state of everything.

All line items in a single order must be from the same currency.  Since an order is currency specific, if you change the global currency setting while an in progress order has items in their cart, a new (empty) cart will be created for them on their next page view.

A variant must have a price in the globally configured currency in order to be displayed in the store.  For example, if you change the global currency to AUD, and attempt to browse items, no products will be displayed (unless those items have an AUD price)

Things I still plan to do:
- Provide a way to list supported currencies for our store.  For example, my store supports EUR and USD, but not the other 100+ currencies.
- Add a way for users to select which currency they wish to browse items in from the list of supported currencies.  Currently, the global currency selector is still the only way to change which currency items are browsable in.
- Provide an administration interface to set the prices in the various currencies.  Currently, this can only be done through the rails console, or by changing the global admin currency.
- Add currency support to variant cost_price.

I'm looking for feedback at this stage.  It is a somewhat invasive change to make to Spree, so please let me know if there's anything that you'd like to see improved.
