### PR TITLE
use the name of the option type instead of the presentation. That way di...

### DIFF
--- a/core/app/helpers/spree/admin/products_helper.rb
+++ b/core/app/helpers/spree/admin/products_helper.rb
@@ -18,7 +18,7 @@ module Spree
           content_tag(:option,
                       :value    => option_type.id,
                       :selected => ('selected' if selected)) do
-            option_type.presentation
+            option_type.name
           end
         end.join("").html_safe
       end


### PR DESCRIPTION
...fferent option types with the same presentation are easily spotted.

I have some issues when there are different Colors for example.

name : colors_prod1
presentation : Color

name : colors_prod2
presentation : Color

When adding option types in product edit, I can't see the difference anymore.
