### PR TITLE
Not requiring a state should not mean the same as hiding the field

### DIFF
--- a/core/app/helpers/spree/checkout_helper.rb
+++ b/core/app/helpers/spree/checkout_helper.rb
@@ -4,6 +4,16 @@ module Spree
       @order.checkout_steps
     end
 
+    def state_required_class
+      'required' if state_required?
+    end
+
+    def state_required_label
+      if state_required?
+        content_tag :span, '*', :class => state_required_class
+      end
+    end
+
     def checkout_progress
       states = checkout_states
       items = states.map do |state|
@@ -26,6 +36,11 @@ module Spree
         content_tag('li', content_tag('span', text), :class => css_classes.join('-'))
       end
       content_tag('ol', raw(items.join("\n")), :class => 'progress-steps', :id => "checkout-step-#{@order.state}")
+    end
+
+    private
+    def state_required?
+      Spree::Config[:address_requires_state]
     end
   end
 end

--- a/core/app/views/spree/checkout/_address.html.erb
+++ b/core/app/views/spree/checkout/_address.html.erb
@@ -38,29 +38,30 @@
         </span>
       </p>
 
-      <% if Spree::Config[:address_requires_state] %>
-        <p class="field" id="bstate">
-          <% have_states = !@order.bill_address.country.states.empty? %>
-          <%= bill_form.label :state, t(:state) %><span class="required">*</span><br />
-          <% state_elements = [
-             bill_form.collection_select(:state_id, @order.bill_address.country.states,
-                                :id, :name,
-                                {:include_blank => true},
-                                {:class => have_states ? 'required' : 'hidden',
-                                :disabled => !have_states}) +
-             bill_form.text_field(:state_name,
-                                :class => !have_states ? 'required' : 'hidden',
-                                :disabled => have_states)
-             ].join.gsub('"', "'").gsub("\n", "")
-          %>
-          <%= javascript_tag do -%>
-            document.write("<%== state_elements %>");
-          <% end -%>
-        </p>
-          <noscript>
-            <%= bill_form.text_field :state_name, :class => 'required' %>
-          </noscript>
-      <% end %>
+      <p class="field" id="bstate">
+        <% have_states = !@order.bill_address.country.states.empty? %>
+
+        <%= bill_form.label :state, t(:state) %><%= state_required_label %><br />
+
+        <% state_elements = [
+           bill_form.collection_select(:state_id, @order.bill_address.country.states,
+                              :id, :name,
+                              {:include_blank => true},
+                              {:class => have_states ? state_required_class : 'hidden',
+                              :disabled => !have_states}) +
+           bill_form.text_field(:state_name,
+                              :class => !have_states ? state_required_class : 'hidden',
+                              :disabled => have_states)
+           ].join.gsub('"', "'").gsub("\n", "")
+        %>
+        <%= javascript_tag do -%>
+          document.write("<%== state_elements %>");
+        <% end -%>
+      </p>
+
+      <noscript>
+        <%= bill_form.text_field :state_name, :class => state_required_class %>
+      </noscript>
 
       <p class="field" id="bzipcode">
         <%= bill_form.label :zipcode, t(:zip) %><span class="required">*</span><br />
@@ -86,7 +87,7 @@
   <%= form.fields_for :ship_address do |ship_form| %>
     <legend><%= t(:shipping_address) %></legend>
     <p class="field checkbox" data-hook="use_billing">
-      <%= check_box_tag 'order[use_billing]', '1', (!(@order.bill_address.empty? && @order.ship_address.empty?) && @order.bill_address.same_as?(@order.ship_address)) %> 
+      <%= check_box_tag 'order[use_billing]', '1', (!(@order.bill_address.empty? && @order.ship_address.empty?) && @order.bill_address.same_as?(@order.ship_address)) %>
       <%= label_tag :order_use_billing, t(:use_billing_address), :id => 'use_billing' %>
     </p>
     <div class="inner" data-hook="shipping_inner">
@@ -125,29 +126,28 @@
         </span>
       </p>
 
-      <% if Spree::Config[:address_requires_state] %>
-        <p class="field" id="sstate">
-          <% have_states = !@order.ship_address.country.states.empty? %>
-          <%= ship_form.label :state, t(:state) %><span class="required">*</span><br />
-          <% state_elements = [
-             ship_form.collection_select(:state_id, @order.ship_address.country.states,
-                                :id, :name,
-                                {:include_blank => true},
-                                {:class => have_states ? 'required' : 'hidden',
-                                :disabled => !have_states}) +
-             ship_form.text_field(:state_name,
-                                :class => !have_states ? 'required' : 'hidden',
-                                :disabled => have_states)
-             ].join.gsub('"', "'").gsub("\n", "")
-          %>
-          <%= javascript_tag do -%>
-            document.write("<%== state_elements %>");
-          <% end %>
-        </p>
-          <noscript>
-            <%= ship_form.text_field :state_name, :class => 'required' %>
-          </noscript>
-      <% end %>
+      <p class="field" id="sstate">
+        <% have_states = !@order.ship_address.country.states.empty? %>
+        <%= ship_form.label :state, t(:state) %><%= state_required_label %><br />
+        <% state_elements = [
+           ship_form.collection_select(:state_id, @order.ship_address.country.states,
+                              :id, :name,
+                              {:include_blank => true},
+                              {:class => have_states ? state_required_class : 'hidden',
+                              :disabled => !have_states}) +
+           ship_form.text_field(:state_name,
+                              :class => !have_states ? state_required_class : 'hidden',
+                              :disabled => have_states)
+           ].join.gsub('"', "'").gsub("\n", "")
+        %>
+        <%= javascript_tag do -%>
+          document.write("<%== state_elements %>");
+        <% end %>
+      </p>
+
+      <noscript>
+        <%= ship_form.text_field :state_name, :class => state_required_class %>
+      </noscript>
 
       <p class="field" id="szipcode">
         <%= ship_form.label :zipcode, t(:zip) %><span class="required">*</span><br />


### PR DESCRIPTION
There was a PR (cannot for the life of me find it to reference now) where the :address_requires_state config option is used to completely hide the State field in the checkout/address form.

In our opinion, this is incorrect. The option is named "address_requires_state" not "show_state" or "hide_state". We want an Optional Field named State so that countries that have a state can fill it in, and those who do not, can ignore it.

This change makes it so the config option is used to toggle the visual distinctions in the UI on whether the field is required. This logic is already in place in the model for validation, so it makes sense that the UI should line up: it's an optional field now.

If people want to remove the field completely we think that should be a different config with a better name.
