### PR TITLE
API - No longer 'include child root'

### DIFF
--- a/api/lib/spree/api/engine.rb
+++ b/api/lib/spree/api/engine.rb
@@ -6,6 +6,11 @@ module Spree
       isolate_namespace Spree
       engine_name 'spree_api'
 
+      Rabl.configure do |config|
+        config.include_json_root = false
+        config.include_child_root = false
+      end
+
       initializer "spree.api.environment", :before => :load_config_initializers do |app|
         Spree::Api::Config = Spree::ApiConfiguration.new
       end

--- a/api/spec/controllers/spree/api/v1/addresses_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/addresses_controller_spec.rb
@@ -16,13 +16,13 @@ module Spree
 
       it "gets an address" do
         api_get :show, :id => @address.id
-        json_response['address']['address1'].should eq @address.address1
+        json_response['address1'].should eq @address.address1
       end
 
       it "updates an address" do
         api_put :update, :id => @address.id,
                          :address => { :address1 => "123 Test Lane" }
-        json_response['address']['address1'].should eq '123 Test Lane'
+        json_response['address1'].should eq '123 Test Lane'
       end
     end
 

--- a/api/spec/controllers/spree/api/v1/countries_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/countries_controller_spec.rb
@@ -12,7 +12,7 @@ module Spree
 
     it "gets all countries" do
       api_get :index
-      json_response["countries"].first['country']['iso3'].should eq @country.iso3
+      json_response['countries'].first['iso3'].should eq @country.iso3
     end
 
     context "with two countries" do
@@ -28,7 +28,7 @@ module Spree
       it 'can query the results through a paramter' do
         api_get :index, :q => { :name_cont => 'zam' }
         json_response['count'].should == 1
-        json_response['countries'].first['country']['name'].should eq @zambia.name
+        json_response['countries'].first['name'].should eq @zambia.name
       end
 
       it 'can control the page size through a parameter' do
@@ -41,8 +41,8 @@ module Spree
 
     it "includes states" do
       api_get :show, :id => @country.id
-      states = json_response['country']['states']
-      states.first['state']['name'].should eq @state.name
+      states = json_response['states']
+      states.first['name'].should eq @state.name
     end
   end
 end

--- a/api/spec/controllers/spree/api/v1/line_items_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/line_items_controller_spec.rb
@@ -34,7 +34,7 @@ module Spree
         api_post :create, :line_item => { :variant_id => product.master.to_param, :quantity => 1 }
         response.status.should == 201
         json_response.should have_attributes(attributes)
-        json_response["line_item"]["variant"]["name"].should_not be_blank
+        json_response["variant"]["name"].should_not be_blank
       end
 
       it "can update a line item on the order" do

--- a/api/spec/controllers/spree/api/v1/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/orders_controller_spec.rb
@@ -66,14 +66,14 @@ module Spree
       order.line_items.count.should == 1
       order.line_items.first.variant.should == variant
       order.line_items.first.quantity.should == 5
-      json_response["order"]["state"].should == "address"
+      json_response["state"].should == "address"
     end
 
     it "can create an order without any parameters" do
       lambda { api_post :create }.should_not raise_error(NoMethodError)
       response.status.should == 201
       order = Order.last
-      json_response["order"]["state"].should == "address"
+      json_response["state"].should == "address"
     end
 
     context "working with an order" do
@@ -108,7 +108,7 @@ module Spree
         order.shipping_address.firstname.should == shipping_address[:firstname]
         order.billing_address.firstname.should == billing_address[:firstname]
         order.state.should == "delivery"
-        json_response["order"]["shipping_methods"].should_not be_empty
+        json_response["shipping_methods"].should_not be_empty
       end
 
       it "can add just shipping address information to an order" do
@@ -147,7 +147,7 @@ module Spree
         api_put :update, :id => order.to_param, :order => { :line_items => [{:variant_id => create(:variant).id, :quantity => 2}] }
 
         response.status.should == 200
-        json_response['order']['item_total'].to_f.should_not == order.item_total.to_f
+        json_response['item_total'].to_f.should_not == order.item_total.to_f
       end
 
       context "with a line item" do
@@ -230,7 +230,7 @@ module Spree
           api_get :index, :q => { :email_cont => 'spree' }
           json_response["orders"].count.should == 1
           json_response["orders"].first.should have_attributes(attributes)
-          json_response["orders"].first["order"]["email"].should == expected_result.email
+          json_response["orders"].first["email"].should == expected_result.email
           json_response["count"].should == 1
           json_response["current_page"].should == 1
           json_response["pages"].should == 1
@@ -247,7 +247,7 @@ module Spree
 
         specify do
           api_put :cancel, :id => order.to_param
-          json_response["order"]["state"].should == "canceled"
+          json_response["state"].should == "canceled"
         end
       end
     end

--- a/api/spec/controllers/spree/api/v1/payments_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/payments_controller_spec.rb
@@ -88,7 +88,7 @@ module Spree
         it 'can query the results through a paramter' do
           api_get :index, :q => { :response_code_cont => '999' }
           json_response['count'].should == 1
-          json_response['payments'].first['payment']['response_code'].should eq @payment.response_code
+          json_response['payments'].first['response_code'].should eq @payment.response_code
         end
       end
 

--- a/api/spec/controllers/spree/api/v1/product_properties_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/product_properties_controller_spec.rb
@@ -45,7 +45,7 @@ module Spree
       property = Spree::ProductProperty.last
       api_get :index, :q => { :value_cont => 'loose' }
       json_response['count'].should == 1
-      json_response['product_properties'].first['product_property']['value'].should eq property.value
+      json_response['product_properties'].first['value'].should eq property.value
     end
 
     it "can see a single product_property" do
@@ -108,7 +108,6 @@ module Spree
 
       it "can see a single product_property by id" do
         api_get :show, :id => property_1.id
-        json_response.count.should eq 1
         json_response.should have_attributes(attributes)
       end
     end

--- a/api/spec/controllers/spree/api/v1/products_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/products_controller_spec.rb
@@ -69,18 +69,17 @@ module Spree
         product.set_property("spree", "rocks")
         api_get :show, :id => product.to_param
         json_response.should have_attributes(attributes)
-        product_json = json_response["product"]
-        product_json["variants"].first.should have_attributes([:name,
+        json_response['variants'].first.should have_attributes([:name,
                                                               :is_master,
                                                               :count_on_hand,
                                                               :price])
 
-        product_json["images"].first.should have_attributes([:attachment_file_name,
+        json_response["images"].first.should have_attributes([:attachment_file_name,
                                                             :attachment_width,
                                                             :attachment_height,
                                                             :attachment_content_type])
 
-        product_json["product_properties"].first.should have_attributes([:value,
+        json_response["product_properties"].first.should have_attributes([:value,
                                                                          :product_id,
                                                                          :property_name])
       end
@@ -95,11 +94,11 @@ module Spree
 
         specify do
           api_get :show, :id => product.to_param
-          json_response["product"]["permalink"].should =~ /and-1-ways/
+          json_response["permalink"].should =~ /and-1-ways/
           product.destroy
 
           api_get :show, :id => other_product.id
-          json_response["product"]["permalink"].should =~ /droids/
+          json_response["permalink"].should =~ /droids/
         end
       end
 

--- a/api/spec/controllers/spree/api/v1/return_authorizations_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/return_authorizations_controller_spec.rb
@@ -67,7 +67,7 @@ module Spree
         api_get :show, :order_id => order.id, :id => return_authorization.id
         response.status.should == 200
         json_response.should have_attributes(attributes)
-        json_response["return_authorization"]["state"].should_not be_blank
+        json_response["state"].should_not be_blank
       end
 
       it "can get a list of return authorizations" do
@@ -95,7 +95,7 @@ module Spree
         order.return_authorizations << expected_result
         api_get :index, :q => { :reason_cont => 'damage' }
         json_response['count'].should == 1
-        json_response['return_authorizations'].first['return_authorization']['reason'].should eq expected_result.reason
+        json_response['return_authorizations'].first['reason'].should eq expected_result.reason
       end
 
       it "can learn how to create a new return authorization" do
@@ -125,7 +125,7 @@ module Spree
         api_post :create, :return_autorization => { :order_id => order.id, :amount => 14.22, :reason => "Defective" }
         response.status.should == 201
         json_response.should have_attributes(attributes)
-        json_response["return_authorization"]["state"].should_not be_blank
+        json_response["state"].should_not be_blank
       end
     end
 

--- a/api/spec/controllers/spree/api/v1/shipments_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/shipments_controller_spec.rb
@@ -30,7 +30,7 @@ describe Spree::Api::V1::ShipmentsController do
     it "can make a shipment ready" do
       api_put :ready
       json_response.should have_attributes(attributes)
-      json_response["shipment"]["state"].should == "ready"
+      json_response["state"].should == "ready"
       shipment.reload.state.should == "ready"
     end
 
@@ -44,7 +44,7 @@ describe Spree::Api::V1::ShipmentsController do
         shipment.reload
         api_put :ship, :order_id => shipment.order.to_param, :id => shipment.to_param, :shipment => { :tracking => "123123" }
         json_response.should have_attributes(attributes)
-        json_response["shipment"]["state"].should == "shipped"
+        json_response["state"].should == "shipped"
       end
     end
   end

--- a/api/spec/controllers/spree/api/v1/taxonomies_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/taxonomies_controller_spec.rb
@@ -20,8 +20,8 @@ module Spree
       it "gets all taxonomies" do
         api_get :index
 
-        json_response["taxonomies"].first['taxonomy']['name'].should eq taxonomy.name
-        json_response["taxonomies"].first['taxonomy']['root']['taxons'].count.should eq 1
+        json_response["taxonomies"].first['name'].should eq taxonomy.name
+        json_response["taxonomies"].first['root']['taxons'].count.should eq 1
       end
 
       it 'can control the page size through a parameter' do
@@ -36,27 +36,27 @@ module Spree
         expected_result = create(:taxonomy, :name => 'Style')
         api_get :index, :q => { :name_cont => 'style' }
         json_response['count'].should == 1
-        json_response['taxonomies'].first['taxonomy']['name'].should eq expected_result.name
+        json_response['taxonomies'].first['name'].should eq expected_result.name
       end
 
       it "gets a single taxonomy" do
         api_get :show, :id => taxonomy.id
 
-        json_response['taxonomy']['name'].should eq taxonomy.name
+        json_response['name'].should eq taxonomy.name
 
-        children = json_response['taxonomy']['root']['taxons']
+        children = json_response['root']['taxons']
         children.count.should eq 1
-        children.first['taxon']['name'].should eq taxon.name
-        children.first['taxon'].key?('taxons').should be_false
+        children.first['name'].should eq taxon.name
+        children.first.key?('taxons').should be_false
       end
 
       it "gets a single taxonomy with set=nested" do
         api_get :show, :id => taxonomy.id, :set => 'nested'
 
-        json_response['taxonomy']['name'].should eq taxonomy.name
+        json_response['name'].should eq taxonomy.name
 
-        children = json_response['taxonomy']['root']['taxons']
-        children.first['taxon'].key?('taxons').should be_true
+        children = json_response['root']['taxons']
+        children.first.key?('taxons').should be_true
       end
 
       it "can learn how to create a new taxonomy" do

--- a/api/spec/controllers/spree/api/v1/taxons_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/taxons_controller_spec.rb
@@ -20,18 +20,18 @@ module Spree
       it "gets all taxons" do
         api_get :index, :taxonomy_id => taxonomy.id
 
-        json_response.first['taxon']['name'].should eq taxon.name
-        children = json_response.first['taxon']['taxons']
+        json_response.first['name'].should eq taxon.name
+        children = json_response.first['taxons']
         children.count.should eq 1
-        children.first['taxon']['name'].should eq taxon2.name
-        children.first['taxon']['taxons'].count.should eq 1
+        children.first['name'].should eq taxon2.name
+        children.first['taxons'].count.should eq 1
       end
 
       it "gets a single taxon" do
         api_get :show, :id => taxon.id, :taxonomy_id => taxonomy.id
 
-        json_response['taxon']['name'].should eq taxon.name
-        json_response['taxon']['taxons'].count.should eq 1
+        json_response['name'].should eq taxon.name
+        json_response['taxons'].count.should eq 1
       end
 
       it "can learn how to create a new taxon" do

--- a/api/spec/controllers/spree/api/v1/variants_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/variants_controller_spec.rb
@@ -40,12 +40,12 @@ module Spree
       expected_result = create(:variant, :sku => 'FOOBAR')
       api_get :index, :q => { :sku_cont => 'FOO' }
       json_response['count'].should == 1
-      json_response['variants'].first['variant']['sku'].should eq expected_result.sku
+      json_response['variants'].first['sku'].should eq expected_result.sku
     end
 
     it "variants returned contain option values data" do
       api_get :index
-      option_values = json_response["variants"].last["variant"]["option_values"]
+      option_values = json_response["variants"].last["option_values"]
       option_values.first.should have_attributes([:name,
                                                  :presentation,
                                                  :option_type_name,
@@ -85,7 +85,7 @@ module Spree
     it "can see a single variant" do
       api_get :show, :id => variant.to_param
       json_response.should have_attributes(attributes)
-      option_values = json_response["variant"]["option_values"]
+      option_values = json_response["option_values"]
       option_values.first.should have_attributes([:name,
                                                  :presentation,
                                                  :option_type_name,

--- a/api/spec/controllers/spree/api/v1/zones_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/zones_controller_spec.rb
@@ -28,14 +28,14 @@ module Spree
       expected_result = create(:zone, :name => 'South America')
       api_get :index, :q => { :name_cont => 'south' }
       json_response['count'].should == 1
-      json_response['zones'].first['zone']['name'].should eq expected_result.name
+      json_response['zones'].first['name'].should eq expected_result.name
     end
 
     it "gets a zone" do
       api_get :show, :id => @zone.id
       json_response.should have_attributes(attributes)
-      json_response['zone']['name'].should eq @zone.name
-      json_response['zone']['zone_members'].size.should eq @zone.zone_members.count
+      json_response['name'].should eq @zone.name
+      json_response['zone_members'].size.should eq @zone.zone_members.count
     end
 
     context "as an admin" do
@@ -57,7 +57,7 @@ module Spree
         api_post :create, params
         response.status.should == 201
         json_response.should have_attributes(attributes)
-        json_response["zone"]["zone_members"].should_not be_empty
+        json_response["zone_members"].should_not be_empty
       end
 
       it "updates a zone" do
@@ -75,8 +75,8 @@ module Spree
 
         api_put :update, params
         response.status.should == 200
-        json_response['zone']['name'].should eq 'North Pole'
-        json_response['zone']['zone_members'].should_not be_blank
+        json_response['name'].should eq 'North Pole'
+        json_response['zone_members'].should_not be_blank
       end
 
       it "can delete a zone" do

--- a/api/spec/support/have_attributes_matcher.rb
+++ b/api/spec/support/have_attributes_matcher.rb
@@ -5,8 +5,8 @@
 RSpec::Matchers.define :have_attributes do |expected_attributes|
   match do |actual|
     # actual is a Hash object representing an object, like this:
-    # { "product" => { "name" => "Product #1" } }
-    actual_attributes = actual.values.first.keys.map(&:to_sym)
+    # { "name" => "Product #1" }
+    actual_attributes = actual.keys.map(&:to_sym)
     expected_attributes.map(&:to_sym).all? { |attr| actual_attributes.include?(attr) }
   end
 end


### PR DESCRIPTION
For example:

A request to orders index used to return json that looked similar to

``` json
orders: [ order: { number: 'R123', ..}, order: { number: 'R456'} ]
```

Now it returns json that looks like

``` json
orders: [ { number: 'R123', ..}, { number: 'R456'} ]
```
