### PR TITLE
Validate format of email only if present

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -63,7 +63,8 @@ module Spree
     before_create :link_by_email
     after_create :create_tax_charge!
 
-    validates :email, :presence => true, :email => true, :if => :require_email
+    validates :email, :presence => true, :if => :require_email
+    validates :email, :email => true, :if => :require_email, :allow_blank => true
     validate :has_available_shipment
     validate :has_available_payment
 


### PR DESCRIPTION
When no email address is given, Spree shows both an error about the missing value and an error about wrong format of the email address.

When no email address is given, only the error about the presence should be shown.
