### PR TITLE
Products.js Javascript Fixes

### DIFF
--- a/cmd/lib/spree_cmd/templates/extension/Gemfile
+++ b/cmd/lib/spree_cmd/templates/extension/Gemfile
@@ -1,3 +1,6 @@
 source 'http://rubygems.org'
 
+# Provides basic authentication functionality for testing parts of your engine
+gem 'spree_auth_devise', :git => "git://github.com/spree/spree_auth_devise"
+
 gemspec

--- a/core/app/assets/javascripts/store/product.js.coffee
+++ b/core/app/assets/javascripts/store/product.js.coffee
@@ -1,18 +1,19 @@
 add_image_handlers = ->
+  thumbnails = ($ '#product-images ul.thumbnails')
   ($ '#main-image').data 'selectedThumb', ($ '#main-image img').attr('src')
-  ($ 'ul.thumbnails li').eq(0).addClass 'selected'
-  ($ 'ul.thumbnails a').on 'click', (event) ->
+  thumbnails.find('li').eq(0).addClass 'selected'
+  thumbnails.find('a').on 'click', (event) ->
     ($ '#main-image').data 'selectedThumb', ($ event.currentTarget).attr('href')
     ($ '#main-image').data 'selectedThumbId', ($ event.currentTarget).parent().attr('id')
     ($ this).mouseout ->
-      ($ 'ul.thumbnails li').removeClass 'selected'
+      thumbnails.find('li').removeClass 'selected'
       ($ event.currentTarget).parent('li').addClass 'selected'
     false
 
-  ($ 'ul.thumbnails li').on 'mouseenter', (event) ->
+  thumbnails.find('li').on 'mouseenter', (event) ->
     ($ '#main-image img').attr 'src', ($ event.currentTarget).find('a').attr('href')
 
-  ($ 'ul.thumbnails li').on 'mouseleave', (event) ->
+  thumbnails.find('li').on 'mouseleave', (event) ->
     ($ '#main-image img').attr 'src', ($ '#main-image').data('selectedThumb')
 
 show_variant_images = (variant_id) ->
@@ -20,9 +21,9 @@ show_variant_images = (variant_id) ->
   ($ 'li.vtmb-' + variant_id).show()
   currentThumb = ($ '#' + ($ '#main-image').data('selectedThumbId'))
   if not currentThumb.hasClass('vtmb-' + variant_id) and not currentThumb.hasClass('tmb-all')
-    thumb = ($ ($ 'ul.thumbnails li:visible').eq(0))
+    thumb = $(thumbnails).find('li:visible').first()
     newImg = thumb.find('a').attr('href')
-    ($ 'ul.thumbnails li').removeClass 'selected'
+    $(thumbnails).find('li').removeClass 'selected'
     thumb.addClass 'selected'
     ($ '#main-image img').attr 'src', newImg
     ($ '#main-image').data 'selectedThumb', newImg


### PR DESCRIPTION
When viewing a product in the store that has variants with images such as:

http://localhost:3000/products/ruby-on-rails-baseball-jersey

the javascript code switches the thumbnail images displayed based on the variant that is chosen.  So in the above example, clicking on the **Size: S, Color: Red** option switches the thumbnails to show the red jersey options.

The problem is that the **Main** image for the product will only show the **main product** image if that image exists.

So, using the above example, clicking on the **Size: S, Color: Red** option continues to show the **black** (maybe navy blue) image, requiring that the user hover over, or click the red thumbnail in order to view the red shirt.

It is my opinion that the **Red** shirt should be displayed by default in the main image automatically if the **Size: S, Color: Red** option was selected.

This can be accomplished by changing the **show_variant_images** method in the product.js.coffee file that currently looks like this:

``` coffeescript
show_variant_images = (variant_id) ->
  ($ 'li.vtmb').hide()
  ($ 'li.vtmb-' + variant_id).show()
  currentThumb = ($ '#' + ($ '#main-image').data('selectedThumbId'))
  if not currentThumb.hasClass('vtmb-' + variant_id) and not currentThumb.hasClass('tmb-all')
    thumb = ($ ($ 'ul.thumbnails li:visible').eq(0))
    newImg = thumb.find('a').attr('href')
    ($ 'ul.thumbnails li').removeClass 'selected'
    thumb.addClass 'selected'
    ($ '#main-image img').attr 'src', newImg
    ($ '#main-image').data 'selectedThumb', newImg
    ($ '#main-image').data 'selectedThumbId', thumb.attr('id')
```

with this

``` coffeescript
show_variant_images = (variant_id) ->
  ($ 'li.vtmb').hide()
  ($ 'li.vtmb-' + variant_id).show()
  currentThumb = ($ '#' + ($ '#main-image').data('selectedThumbId'))
  if not currentThumb.hasClass('vtmb-' + variant_id)
    thumb = ($ ($ 'ul.thumbnails li:visible.vtmb').eq(0))
    thumb = ($ ($ 'ul.thumbnails li:visible').eq(0)) unless thumb.length > 0
    newImg = thumb.find('a').attr('href')
    ($ 'ul.thumbnails li').removeClass 'selected'
    thumb.addClass 'selected'
    ($ '#main-image img').attr 'src', newImg
    ($ '#main-image').data 'selectedThumb', newImg
    ($ '#main-image').data 'selectedThumbId', thumb.attr('id')
```

The pieces to notice are the removal of:

``` coffeescript
 and not currentThumb.hasClass('tmb-all')
```

and the addition/modification of:

``` coffeescript
    thumb = ($ ($ 'ul.thumbnails li:visible.vtmb').eq(0))
    thumb = ($ ($ 'ul.thumbnails li:visible').eq(0)) unless thumb.length > 0
```

Additionally, the current code for the method **add_image_handlers** in the same file causes twitter bootstrap thumbnail support to stop working.

I recognize that twitter bootstrap isn't part of the core Spree code, but a small change to this file allows them to play together without a problem.

The current **add_image_handlers** method that looks like this:

``` coffeescript
add_image_handlers = ->
  ($ '#main-image').data 'selectedThumb', ($ '#main-image img').attr('src')
  ($ 'ul.thumbnails li').eq(0).addClass 'selected'
  ($ 'ul.thumbnails a').on 'click', (event) ->
    ($ '#main-image').data 'selectedThumb', ($ event.currentTarget).attr('href')
    ($ '#main-image').data 'selectedThumbId', ($ event.currentTarget).parent().attr('id')
    ($ this).mouseout ->
      ($ 'ul.thumbnails li').removeClass 'selected'
      ($ event.currentTarget).parent('li').addClass 'selected'
    false

  ($ 'ul.thumbnails li').on 'mouseenter', (event) ->
    ($ '#main-image img').attr 'src', ($ event.currentTarget).find('a').attr('href')

  ($ 'ul.thumbnails li').on 'mouseleave', (event) ->
    ($ '#main-image img').attr 'src', ($ '#main-image').data('selectedThumb')
```

Should be changed to this:

``` coffeescript
add_image_handlers = ->
  ($ '#main-image').data 'selectedThumb', ($ '#main-image img').attr('src')
  ($ '#product-thumbnails li').eq(0).addClass 'selected'
  ($ '#product-thumbnails a').on 'click', (event) ->
    ($ '#main-image').data 'selectedThumb', ($ event.currentTarget).attr('href')
    ($ '#main-image').data 'selectedThumbId', ($ event.currentTarget).parent().attr('id')
    ($ this).mouseout ->
      ($ '#product-thumbnails li').removeClass 'selected'
      ($ event.currentTarget).parent('li').addClass 'selected'
    false

  ($ '#product-thumbnails li').on 'mouseenter', (event) ->
    ($ '#main-image img').attr 'src', ($ event.currentTarget).find('a').attr('href')

  ($ '#product-thumbnails li').on 'mouseleave', (event) ->
    ($ '#main-image img').attr 'src', ($ '#main-image').data('selectedThumb')
```

Basically every instance of:

```
ul.thumbnails
```

has been replaced with:

```
#product-thumbnails
```

The aforementioned ul.thumbnails targets **EVERY** ul that has a thumbnail class on **ANY** page that has the products.js included (which means every page since it gets compiled into all.js).  Since the **mouseenter**, **mouseleave**, and **click** handlers are all overridden here, the twitter bootstrap handlers for thumbnails gets clobbered.

I would appreciate if the **add_image_handlers** method was fixed in the Spree core so that we play nicer with other javascript.

Thanks,
Chris
