### PR TITLE
Localize datepicker date format

### DIFF
--- a/core/app/views/spree/admin/products/_form.html.erb
+++ b/core/app/views/spree/admin/products/_form.html.erb
@@ -41,7 +41,7 @@
     <%= f.field_container :available_on do %>
       <%= f.label :available_on, t(:available_on) %>
       <%= f.error_message_on :available_on %>
-      <%= f.text_field :available_on, :value => (@product.available_on.blank? ? '' : @product.available_on.strftime('%Y/%m/%d')), :class => 'datepicker' %>
+      <%= f.text_field :available_on, :value => l(@product.available_on, :format => t('spree.date_picker.format')), :class => 'datepicker' %>
     <% end %>
 
     <% unless @product.has_variants? %>

--- a/core/app/views/spree/admin/products/_form.html.erb
+++ b/core/app/views/spree/admin/products/_form.html.erb
@@ -41,7 +41,7 @@
     <%= f.field_container :available_on do %>
       <%= f.label :available_on, t(:available_on) %>
       <%= f.error_message_on :available_on %>
-      <%= f.text_field :available_on, :value => l(@product.available_on, :format => t('spree.date_picker.format')), :class => 'datepicker' %>
+      <%= f.text_field :available_on, :value => l(@product.available_on, :format => t('spree.date_picker')), :class => 'datepicker' %>
     <% end %>
 
     <% unless @product.has_variants? %>

--- a/core/app/views/spree/admin/products/_form.html.erb
+++ b/core/app/views/spree/admin/products/_form.html.erb
@@ -41,7 +41,7 @@
     <%= f.field_container :available_on do %>
       <%= f.label :available_on, t(:available_on) %>
       <%= f.error_message_on :available_on %>
-      <%= f.text_field :available_on, :value => l(@product.available_on, :format => t('spree.date_picker')), :class => 'datepicker' %>
+      <%= f.text_field :available_on, :value => l(@product.available_on, :format => t('spree.date_picker.format')), :class => 'datepicker' %>
     <% end %>
 
     <% unless @product.has_variants? %>

--- a/core/app/views/spree/admin/shared/_translations.html.erb
+++ b/core/app/views/spree/admin/shared/_translations.html.erb
@@ -1,6 +1,6 @@
 <script>
   Spree.translations = <%==
-  { :date_picker    => I18n.t(:format, 
+  { :date_picker    => I18n.t(:js_format,
                               :scope => 'spree.date_picker',
                               :default => 'yy/mm/dd'),
     :abbr_day_names      => I18n.t(:abbr_day_names, :scope => :date),

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -999,7 +999,8 @@ en:
   spree:
     date: Date
     date_picker:
-      format: 'yy/mm/dd'
+      format: ! '%Y/%m/%d'
+      js_format: 'yy/mm/dd'
     time: Time
   spree_gateway_error_flash_for_checkout: "There was a problem with your payment information. Please check your information and try again."
   spree_inventory_error_flash_for_insufficient_quantity: "An item in your cart has become unavailable."


### PR DESCRIPTION
Replaced `…available_on.strftime('%Y/%m/%d')`with localized date

Introduced a new i18n key for that:

`spree.date_picker.format` date format to be used with date picker
`spree.date_picker.js_format` contains the same format for use with javascript
