### PR TITLE
Allow overriding of shipping method’s adjustment label

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -146,9 +146,10 @@ module Spree
       def ensure_correct_adjustment
         if adjustment
           adjustment.originator = shipping_method
+          adjustment.label = shipping_method.adjustment_label
           adjustment.save
         else
-          shipping_method.create_adjustment(I18n.t(:shipping), order, self, true)
+          shipping_method.create_adjustment(shipping_method.adjustment_label, order, self, true)
           reload #ensure adjustment is present on later saves
         end
       end

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -15,6 +15,10 @@ module Spree
 
     calculated_adjustments
 
+    def adjustment_label
+      I18n.t(:shipping)
+    end
+
     def available?(order, display_on = nil)
       displayable?(display_on) && calculator.available?(order)
     end


### PR DESCRIPTION
Allow overriding of a shipping method’s adjustment label.

Useful in cases where the name of the adjustment is not necessarily the same as the shipping method’s name.

In my case I override `def adjustment_label` in order to read the label value from the database.
