### PR TITLE
Set payment to processing state when capturing.

### DIFF
--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -32,7 +32,7 @@ module Spree
       end
       # When processing during checkout fails
       event :failure do
-        transition :from => 'processing', :to => 'failed'
+        transition :from => ['pending', 'processing'], :to => 'failed'
       end
       # With card payments this represents authorizing the payment
       event :pend do

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -29,6 +29,7 @@ module Spree
 
       def capture!
         return true if completed?
+        started_processing!
         protect_from_connection_error do
           check_environment
 


### PR DESCRIPTION
Without setting payment to the processing state when calling capture the payment wont get set to failed state on failure.
