### PR TITLE
Fixed typo in order detail sidebar. Shipment was always 'none'

### DIFF
--- a/core/app/views/spree/admin/products/_form.html.erb
+++ b/core/app/views/spree/admin/products/_form.html.erb
@@ -36,7 +36,7 @@
         <%= f.label :available_on, t(:available_on) %><br />
         <%= f.error_message_on :available_on %>
         <% if @product.available_on? %>
-          <% available_on = l(@product.available_on, :format => t('spree.date_picker.format')) %>
+          <% available_on = l(@product.available_on, :format => t('date_picker.format')) %>
         <% else %>
           <% available_on = nil %>
         <% end %>

--- a/core/app/views/spree/admin/shared/_order_tabs.html.erb
+++ b/core/app/views/spree/admin/shared/_order_tabs.html.erb
@@ -6,7 +6,7 @@
     <h5 id="order_status" data-hook><%= t(:status) %>: <%= t(@order.state, :scope => :order_state) %></h5>
     <h5 id="order_total" data-hook><%= t(:total) %>: <%= money @order.total %></h5>
     <% if @order.completed? %>
-      <h5 id="shipment_status"><%= t(:shipment) %>: <%= t(@order.shipment_state, :scope => :shipment_state, :default => [:missing, "none"]) %></h5>
+      <h5 id="shipment_status"><%= t(:shipment) %>: <%= t(@order.shipment_state, :scope => :shipment_states, :default => [:missing, "none"]) %></h5>
       <h5 id="payment_status"><%= t(:payment) %>: <%= t(@order.payment_state, :scope => :payment_states, :default => [:missing, "none"]) %></h5>
       <h5 id="date_completed" style="width:100%; float:none;" data-hook><%= t(:date_completed) %>: <%= I18n.l(@order.completed? ? @order.completed_at : @order.created_at) %></h5>
     <% end %>


### PR DESCRIPTION
Fixed typo in order detail sidebar. Shipment was always 'none'
