### PR TITLE
Always pass Spree::Payment's currency to gateway

### DIFF
--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -115,8 +115,8 @@ module Spree
       options.merge!({ :shipping => order.ship_total * 100,
                        :tax      => order.tax_total * 100,
                        :subtotal => order.item_total * 100 })
-      
-      options.merge!({ :currency => payment_method.preferences[:currency_code] }) if payment_method && payment_method.preferences[:currency_code]
+
+      options.merge!({ :currency => currency })
 
       options.merge!({ :billing_address  => order.bill_address.try(:active_merchant_hash),
                       :shipping_address => order.ship_address.try(:active_merchant_hash) })

--- a/core/spec/models/payment_spec.rb
+++ b/core/spec/models/payment_spec.rb
@@ -75,7 +75,7 @@ describe Spree::Payment do
       end
 
       it "should call authorize on the gateway with the currency code" do
-        gateway.stub :preferences => {:currency_code => 'GBP'}
+        payment.stub :currency => 'GBP'
         payment.payment_method.should_receive(:authorize).with(amount_in_cents,
                                                                card,
                                                                hash_including({:currency => "GBP"})).and_return(success_response)


### PR DESCRIPTION
@gmacdougall's work gave Spree::Payment a currency (same currency as order). This causes that currency always passed to the gateway as the :currency option.

This allows multiple currencies to be used with a payment method, and should save some configuration for single currency sites.
