### PR TITLE
current_currency Product Searching

### DIFF
--- a/core/app/controllers/spree/home_controller.rb
+++ b/core/app/controllers/spree/home_controller.rb
@@ -6,6 +6,7 @@ module Spree
     def index
       @searcher = Spree::Config.searcher_class.new(params)
       @searcher.current_user = try_spree_current_user
+      @searcher.current_currency = current_currency
       @products = @searcher.retrieve_products
       respond_with(@products)
     end

--- a/core/app/controllers/spree/orders_controller.rb
+++ b/core/app/controllers/spree/orders_controller.rb
@@ -54,12 +54,12 @@ module Spree
       params[:products].each do |product_id,variant_id|
         quantity = params[:quantity].to_i if !params[:quantity].is_a?(Hash)
         quantity = params[:quantity][variant_id].to_i if params[:quantity].is_a?(Hash)
-        @order.add_variant(Variant.find(variant_id), quantity, selected_currency) if quantity > 0
+        @order.add_variant(Variant.find(variant_id), quantity, current_currency) if quantity > 0
       end if params[:products]
 
       params[:variants].each do |variant_id, quantity|
         quantity = quantity.to_i
-        @order.add_variant(Variant.find(variant_id), quantity, selected_currency) if quantity > 0
+        @order.add_variant(Variant.find(variant_id), quantity, current_currency) if quantity > 0
       end if params[:variants]
 
       fire_event('spree.cart.add')

--- a/core/app/controllers/spree/products_controller.rb
+++ b/core/app/controllers/spree/products_controller.rb
@@ -17,7 +17,7 @@ module Spree
     def show
       return unless @product
 
-      @variants = @product.variants_including_master.active.includes([:option_values, :images])
+      @variants = @product.variants_including_master.active(current_currency).includes([:option_values, :images])
       @product_properties = @product.product_properties.includes(:property)
 
       referer = request.env['HTTP_REFERER']
@@ -40,7 +40,7 @@ module Spree
         if try_spree_current_user.try(:has_spree_role?, "admin")
           @product = Product.find_by_permalink!(params[:id])
         else
-          @product = Product.active.find_by_permalink!(params[:id])
+          @product = Product.active(current_currency).find_by_permalink!(params[:id])
         end
       end
   end

--- a/core/app/controllers/spree/products_controller.rb
+++ b/core/app/controllers/spree/products_controller.rb
@@ -9,6 +9,7 @@ module Spree
     def index
       @searcher = Config.searcher_class.new(params)
       @searcher.current_user = try_spree_current_user
+      @searcher.current_currency = current_currency
       @products = @searcher.retrieve_products
       respond_with(@products)
     end

--- a/core/app/controllers/spree/taxons_controller.rb
+++ b/core/app/controllers/spree/taxons_controller.rb
@@ -11,6 +11,7 @@ module Spree
 
       @searcher = Spree::Config.searcher_class.new(params.merge(:taxon => @taxon.id))
       @searcher.current_user = try_spree_current_user
+      @searcher.current_currency = current_currency
       @products = @searcher.retrieve_products
 
       respond_with(@taxon)

--- a/core/app/helpers/spree/products_helper.rb
+++ b/core/app/helpers/spree/products_helper.rb
@@ -12,20 +12,20 @@ module Spree
 
     # returns the formatted price for the specified variant as a difference from product price
     def variant_price_diff(variant)
-      diff = variant.price - variant.product.price
+      diff = variant.amount_in(current_currency) - variant.product.amount_in(current_currency)
       return nil if diff == 0
       if diff > 0
-        "(#{t(:add)}: #{Spree::Money.new(diff.abs, { :currency => variant.currency })})"
+        "(#{t(:add)}: #{Spree::Money.new(diff.abs, { :currency => current_currency })})"
       else
-        "(#{t(:subtract)}: #{Spree::Money.new(diff.abs, { :currency => variant.currency })})"
+        "(#{t(:subtract)}: #{Spree::Money.new(diff.abs, { :currency => current_currency })})"
       end
     end
 
     # returns the formatted full price for the variant, if at least one variant price differs from product price
     def variant_full_price(variant)
       product = variant.product
-      unless product.variants.active.all? { |v| v.price == product.price }
-        Spree::Money.new(variant.price, { :currency => variant.currency }).to_s
+      unless product.variants.active(current_currency).all? { |v| v.price == product.price }
+        Spree::Money.new(variant.price, { :currency => current_currency }).to_s
       end
     end
 

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -22,25 +22,15 @@ module Spree
     end
 
     def price=(price)
-      self[:amount] = parse_price(price) if price.present?
+      self[:amount] = parse_price(price)
     end
 
     private
     def check_price
       raise "Price must belong to a variant" if variant.nil?
-      if amount.nil?
-        if variant.is_master? || variant.product.master.nil? || variant.product.master.default_price.nil?
-          self.amount = nil
-        else
-          self.amount = variant.product.master.default_price.amount
-        end
-      end
+
       if currency.nil?
-        if variant.product.master.default_price.nil?
-          self.currency = Spree::Config[:currency]
-        else
-          self.currency = variant.product.master.default_price.currency
-        end
+        self.currency = Spree::Config[:currency]
       end
     end
 

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -48,7 +48,7 @@ module Spree
 
     has_many :prices, :through => :variants, :order => 'spree_variants.position, spree_variants.id, currency'
 
-    delegate_belongs_to :master, :sku, :price, :currency, :display_amount, :display_price, :weight, :height, :width, :depth, :is_master, :has_default_price?, :cost_currency, :price_in
+    delegate_belongs_to :master, :sku, :price, :currency, :display_amount, :display_price, :weight, :height, :width, :depth, :is_master, :has_default_price?, :cost_currency, :price_in, :amount_in
     delegate_belongs_to :master, :cost_price if Variant.table_exists? && Variant.column_names.include?('cost_price')
 
     after_create :set_master_variant_defaults

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -46,7 +46,9 @@ module Spree
 
     has_many :variants_including_master_and_deleted, :class_name => 'Spree::Variant'
 
-    delegate_belongs_to :master, :sku, :price, :currency, :display_amount, :display_price, :weight, :height, :width, :depth, :is_master, :has_default_price?, :cost_currency
+    has_many :prices, :through => :variants, :order => 'spree_variants.position, spree_variants.id, currency'
+
+    delegate_belongs_to :master, :sku, :price, :currency, :display_amount, :display_price, :weight, :height, :width, :depth, :is_master, :has_default_price?, :cost_currency, :price_in
     delegate_belongs_to :master, :cost_price if Variant.table_exists? && Variant.column_names.include?('cost_price')
 
     after_create :set_master_variant_defaults

--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -188,14 +188,15 @@ module Spree
     end
 
     # Can't use add_search_scope for this as it needs a default argument
-    def self.available(available_on = nil)
-      joins(:master).where("#{Product.quoted_table_name}.available_on <= ?", available_on || Time.now)
+    def self.available(available_on = nil, currency = nil)
+      joins(:master => :prices).where("#{Product.quoted_table_name}.available_on <= ?", available_on || Time.now).where('spree_prices.currency' => currency || Spree::Config[:currency]).where('spree_prices.amount IS NOT NULL')
     end
     search_scopes << :available
 
-    add_search_scope :active do
-      not_deleted.available
+    def self.active(currency = nil)
+      not_deleted.available(nil, currency)
     end
+    search_scopes << :active
 
     add_search_scope :on_hand do
       variants_table = Variant.table_name

--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -189,7 +189,7 @@ module Spree
 
     # Can't use add_search_scope for this as it needs a default argument
     def self.available(available_on = nil)
-      joins(:master => :default_price).where("#{Spree::Price.quoted_table_name}.amount IS NOT NULL").where("#{Product.quoted_table_name}.available_on <= ?", available_on || Time.now)
+      joins(:master).where("#{Product.quoted_table_name}.available_on <= ?", available_on || Time.now)
     end
     search_scopes << :available
 

--- a/core/app/views/spree/products/_cart_form.html.erb
+++ b/core/app/views/spree/products/_cart_form.html.erb
@@ -6,7 +6,7 @@
         <h6 class="product-section-title"><%= t(:variants) %></h6>
         <ul>
           <% has_checked = false
-          @product.variants.active.each_with_index do |v,index|
+          @product.variants.active(current_currency).each_with_index do |v,index|
             next if v.option_values.empty? || (!v.in_stock && !Spree::Config[:show_zero_stock_products])
             checked = !has_checked && (v.in_stock || Spree::Config[:allow_backorders])
             has_checked = true if checked %>

--- a/core/app/views/spree/products/_cart_form.html.erb
+++ b/core/app/views/spree/products/_cart_form.html.erb
@@ -11,7 +11,7 @@
             checked = !has_checked && (v.in_stock || Spree::Config[:allow_backorders])
             has_checked = true if checked %>
             <li>
-              <%= radio_button_tag "products[#{@product.id}]", v.id, checked, :disabled => !v.in_stock && !Spree::Config[:allow_backorders], 'data-price' => v.display_price %>
+              <%= radio_button_tag "products[#{@product.id}]", v.id, checked, :disabled => !v.in_stock && !Spree::Config[:allow_backorders], 'data-price' => v.price_in(current_currency).display_price %>
               <label for="<%= ['products', @product.id, v.id].join('_') %>">
                 <span class="variant-description">
                   <%= variant_options v %>
@@ -31,7 +31,7 @@
         
         <div id="product-price">
           <h6 class="product-section-title"><%= t(:price) %></h6>
-          <div><span class="price selling" itemprop="price"><%= @product.display_price %></span></div>
+          <div><span class="price selling" itemprop="price"><%= @product.price_in(current_currency).display_price %></span></div>
         </div>
 
         <div class="add-to-cart">

--- a/core/app/views/spree/shared/_products.html.erb
+++ b/core/app/views/spree/shared/_products.html.erb
@@ -17,7 +17,7 @@
           <%= link_to small_image(product, :itemprop => "image"), product, :itemprop => 'url' %>
         </div>
         <%= link_to truncate(product.name, :length => 50), product, :class => 'info', :itemprop => "name", :title => product.name %>
-        <span class="price selling" itemprop="price"><%= product.display_price %></span>
+        <span class="price selling" itemprop="price"><%= product.price_in(current_currency).display_price %></span>
       </li>
     <% end %>
   <% end %>

--- a/core/lib/spree/core/controller_helpers/common.rb
+++ b/core/lib/spree/core/controller_helpers/common.rb
@@ -8,6 +8,7 @@ module Spree
             helper_method :title=
             helper_method :accurate_title
             helper_method :current_order
+            helper_method :current_currency
 
             layout :get_layout
 
@@ -55,12 +56,8 @@ module Spree
           Spree::Config[:default_seo_title]
         end
 
-        def supported_currencies
-          Spree::Money.supported_currencies
-        end
-
-        def selected_currency
-          session[:currency] || Spree::Config[:currency]
+        def current_currency
+          Spree::Config[:currency]
         end
 
         def render_404(exception = nil)

--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -23,11 +23,11 @@ module Spree
         def current_order(create_order_if_necessary = false)
           return @current_order if @current_order
           if session[:order_id]
-            current_order = Spree::Order.find_by_id_and_currency(session[:order_id], selected_currency, :include => :adjustments)
+            current_order = Spree::Order.find_by_id_and_currency(session[:order_id], current_currency, :include => :adjustments)
             @current_order = current_order unless current_order.try(:completed?)
           end
           if create_order_if_necessary and (@current_order.nil? or @current_order.completed?)
-            @current_order = Spree::Order.new(currency: selected_currency)
+            @current_order = Spree::Order.new(currency: current_currency)
             before_save_new_order
             @current_order.save!
             after_save_new_order

--- a/core/lib/spree/core/search/base.rb
+++ b/core/lib/spree/core/search/base.rb
@@ -4,8 +4,10 @@ module Spree
       class Base
         attr_accessor :properties
         attr_accessor :current_user
+        attr_accessor :current_currency
 
         def initialize(params)
+          self.current_currency = Spree::Config[:currency]
           @properties = {}
           prepare(params)
         end
@@ -14,7 +16,7 @@ module Spree
           @products_scope = get_base_scope
           curr_page = page || 1
 
-          @products = @products_scope.includes([:master => :default_price]).where("spree_prices.amount IS NOT NULL").page(curr_page).per(per_page)
+          @products = @products_scope.includes([:master => :prices]).where("spree_prices.amount IS NOT NULL").where("spree_prices.currency" => current_currency).page(curr_page).per(per_page)
         end
 
         def method_missing(name)

--- a/core/spec/lib/search/base_spec.rb
+++ b/core/spec/lib/search/base_spec.rb
@@ -57,4 +57,11 @@ describe Spree::Core::Search::Base do
     searcher.current_user.should eql(user)
   end
 
+  it "finds products in alternate currencies" do
+    price = create(:price, :currency => 'EUR', :variant => @product1.master)
+    searcher = Spree::Core::Search::Base.new({})
+    searcher.current_currency = 'EUR'
+    searcher.retrieve_products.should == [@product1]
+  end
+
 end

--- a/core/spec/models/variant_spec.rb
+++ b/core/spec/models/variant_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'spec_helper'
 
 describe Spree::Variant do
@@ -289,6 +291,70 @@ describe Spree::Variant do
       it "populates cost currency with the default value on save" do
         variant.save!
         variant.cost_currency.should == "USD"
+      end
+    end
+  end
+
+  describe '.price_in' do
+    before do
+      variant.prices << create(:price, :variant => variant, :currency => "EUR", :amount => 33.33)
+    end
+
+    subject { variant.price_in(currency).display_amount }
+
+    context "when currency is not specified" do
+      let(:currency) { nil }
+
+      it "returns nil" do
+        subject.should be_nil
+      end
+    end
+
+    context "when currency is EUR" do
+      let(:currency) { 'EUR' }
+
+      it "returns the value in the EUR" do
+        subject.should == "€33.33"
+      end
+    end
+
+    context "when currency is USD" do
+      let(:currency) { 'USD' }
+
+      it "returns the value in the USD" do
+        subject.should == "$19.99"
+      end
+    end
+  end
+
+  describe '.amount_in' do
+    before do
+      variant.prices << create(:price, :variant => variant, :currency => "EUR", :amount => 33.33)
+    end
+
+    subject { variant.amount_in(currency) }
+
+    context "when currency is not specified" do
+      let(:currency) { nil }
+
+      it "returns nil" do
+        subject.should be_nil
+      end
+    end
+
+    context "when currency is EUR" do
+      let(:currency) { 'EUR' }
+
+      it "returns the value in the EUR" do
+        subject.should == 33.33
+      end
+    end
+
+    context "when currency is USD" do
+      let(:currency) { 'USD' }
+
+      it "returns the value in the USD" do
+        subject.should == 19.99
       end
     end
   end


### PR DESCRIPTION
This change defines a controller helper method called current_currency (which in this case is simply the value of Spree::Config[:currency]).  This change will allow a extension writer to override current_currency in order to return a value based on different information (session values, request domain, locale, etc.).

The value of current_currency is passed in to the searcher retrieve_products, so that products will only be found if they have a matching currency entry.

Partials which display the price for a product also explicitly look for a price listed in current_currency.

The default for current_currency is Spree::Config[:currency], and the searcher class will use Spree::Config[:currency] if a value for current_currency is not passed in via an accessor.  This should maintain the current functionality, but provide benefits to extension writers wishing to make currency based decisions.
