### PR TITLE
Remove leftover reference to testing_support/env

### DIFF
--- a/cmd/lib/spree_cmd/templates/extension/spec/spec_helper.rb.tt
+++ b/cmd/lib/spree_cmd/templates/extension/spec/spec_helper.rb.tt
@@ -12,7 +12,6 @@ Dir[File.join(File.dirname(__FILE__), 'support/**/*.rb')].each { |f| require f }
 
 # Requires factories defined in spree_core
 require 'spree/core/testing_support/factories'
-require 'spree/core/testing_support/env'
 require 'spree/core/testing_support/controller_requests'
 require 'spree/core/testing_support/authorization_helpers'
 require 'spree/core/url_helpers'


### PR DESCRIPTION
Commit a5fab651fc8e29c0d7d67d76b8a5cea69042a9ac left a reference to testing_support/env causing rspec to fail on newly created extensions. This pull request removes the reference so things  (almost) work properly out of the box.
