### PR TITLE
Add preference option to hide cents in price display 

### DIFF
--- a/core/app/controllers/spree/admin/general_settings_controller.rb
+++ b/core/app/controllers/spree/admin/general_settings_controller.rb
@@ -8,7 +8,7 @@ module Spree
         @preferences_security = [:allow_ssl_in_production,
                         :allow_ssl_in_staging, :allow_ssl_in_development_and_test,
                         :check_for_spree_alerts]
-        @preferences_currency = [:display_currency]
+        @preferences_currency = [:display_currency, :hide_cents]
       end
 
       def update

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -46,6 +46,7 @@ module Spree
     preference :default_meta_keywords, :string, :default => 'spree, demo'
     preference :default_seo_title, :string, :default => ''
     preference :dismissed_spree_alerts, :string, :default => ''
+    preference :hide_cents, :boolean, :default => false
     preference :last_check_for_spree_alerts, :string, :default => nil
     preference :layout, :string, :default => 'spree/layouts/spree_application'
     preference :logo, :string, :default => 'admin/bg/spree_50.png'

--- a/core/app/views/spree/admin/general_settings/edit.html.erb
+++ b/core/app/views/spree/admin/general_settings/edit.html.erb
@@ -6,7 +6,7 @@
 
 <%= form_tag admin_general_settings_path, :method => :put do %>
   <div id="preferences" data-hook>
-    
+
     <fieldset class="general no-border-top">
       <% @preferences_general.each do |key|
           type = Spree::Config.preference_type(key) %>
@@ -16,7 +16,7 @@
             <%= label_tag(key, t(key)) + tag(:br) if type == :boolean %>
           </div>
       <% end %>
-    
+
 
       <div class="row">
         <div class="alpha six columns">
@@ -30,7 +30,7 @@
                   <%= label_tag(key, t(key)) + tag(:br) if type == :boolean %>
                 </div>
             <% end %>
-          </fieldset>    
+          </fieldset>
         </div>
         <div class="omega six columns">
           <fieldset class="currency no-border-bottom">
@@ -62,7 +62,7 @@
                 </ul>
               </div>
             </div>
-          </fieldset>    
+          </fieldset>
         </div>
       </div>
 
@@ -73,10 +73,10 @@
       </div>
 
     </fieldset>
-     
+
   </div>
 
-  
+
 <% end %>
 
 <script>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -282,13 +282,13 @@ en:
   back_to_prototypes_list: "Back To Prototypes List"
   back_to_reports_list: "Back To Reports List"
   back_to_shipping_categories: "Back To Shipping Categories"
-  back_to_shipping_methods_list: "Back To Shipping Methods List"  
+  back_to_shipping_methods_list: "Back To Shipping Methods List"
   back_to_states_list: "Back To States List"
   back_to_store: "Go Back To Store"
   back_to_tax_categories_list: "Back To Tax Categories List"
   back_to_taxonomies_list: "Back To Taxonomies List"
   back_to_trackers_list: "Back To Trackers List"
-  back_to_zones_list: "Back To Zones List"  
+  back_to_zones_list: "Back To Zones List"
   backordered: Backordered
   backordering_is_allowed: "Backordering %{not} allowed"
   balance_due: "Balance Due"
@@ -484,6 +484,7 @@ en:
   has_no_shipped_units: has no shipped units
   height: Height
   hello_user: "Hello User"
+  hide_cents: "Hide cents"
   history: History
   home: "Home"
   icon: "Icon"

--- a/core/lib/spree/money.rb
+++ b/core/lib/spree/money.rb
@@ -9,9 +9,11 @@ module Spree
       @options = {}
       @options[:with_currency] = true if Spree::Config[:display_currency]
       @options[:symbol_position] = Spree::Config[:currency_symbol_position].to_sym
+      @options[:no_cents] = true if Spree::Config[:hide_cents]
       @options.merge!(options)
       # Must be a symbol because the Money gem doesn't do the conversion
       @options[:symbol_position] = @options[:symbol_position].to_sym
+
     end
 
     def to_s

--- a/core/spec/lib/money_spec.rb
+++ b/core/spec/lib/money_spec.rb
@@ -29,6 +29,14 @@ module Spree
       end
     end
 
+    context "hide cents" do
+      it "config option" do
+        Spree::Config[:hide_cents] = true
+        money = Spree::Money.new(10)
+        money.to_s.should == "$10"
+      end
+    end
+
     context "currency parameter" do
       context "when currency is specified in Canadian Dollars" do
         it "uses the currency param over the global configuration" do


### PR DESCRIPTION
Add an option in general settings for currency to hide cents for price display.

More information what I did :
- Add configuration option to hide cents in price display
- Wrote test for it
