### PR TITLE
Need to capture real client IP for credit card payments

### DIFF
--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -110,7 +110,7 @@ module Spree
     def gateway_options
       options = { :email    => order.email,
                   :customer => order.email,
-                  :ip       => '192.168.1.100', # TODO: Use an actual IP
+                  :ip       => order.last_ip_address,
                   :order_id => order.number }
 
       options.merge!({ :shipping => order.ship_total * 100,

--- a/core/db/migrate/20121126040517_add_last_ip_to_spree_orders.rb
+++ b/core/db/migrate/20121126040517_add_last_ip_to_spree_orders.rb
@@ -1,0 +1,5 @@
+class AddLastIpToSpreeOrders < ActiveRecord::Migration
+  def change
+    add_column :spree_orders, :last_ip_address, :string
+  end
+end

--- a/core/lib/spree/core/controller_helpers/common.rb
+++ b/core/lib/spree/core/controller_helpers/common.rb
@@ -66,6 +66,11 @@ module Spree
             type.all  { render :status => :not_found, :nothing => true }
           end
         end
+
+        def ip_address
+          request.env['HTTP_X_REAL_IP'] || request.env['REMOTE_ADDR']
+        end
+
         private
 
         def set_user_language

--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -24,6 +24,7 @@ module Spree
           return @current_order if @current_order
           if session[:order_id]
             current_order = Spree::Order.find_by_id_and_currency(session[:order_id], current_currency, :include => :adjustments)
+            current_order.last_ip_address = ip_address
             @current_order = current_order unless current_order.try(:completed?)
           end
           if create_order_if_necessary and (@current_order.nil? or @current_order.completed?)

--- a/core/spec/controllers/spree/current_order_ip_tracking_spec.rb
+++ b/core/spec/controllers/spree/current_order_ip_tracking_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'tracking current IP address for orders' do
+  controller(Spree::StoreController) do
+    def index
+      render :nothing => true
+    end
+  end
+
+  let(:order) { FactoryGirl.create(:order) }
+
+  it 'is done automatically when current_order is called' do
+    get :index, {}, { :order_id => order.id }
+    controller.current_order.last_ip_address.should == "0.0.0.0"
+  end
+end

--- a/core/spec/models/payment_spec.rb
+++ b/core/spec/models/payment_spec.rb
@@ -554,4 +554,13 @@ describe Spree::Payment do
       payment.display_amount.should == Spree::Money.new(payment.amount)
     end
   end
+
+  # Regression test for #2216
+  context "#gateway_options" do
+    before { order.stub(:last_ip_address => "192.168.1.1") }
+
+    it "contains an IP" do
+      payment.gateway_options[:ip].should == order.last_ip_address
+    end
+  end
 end


### PR DESCRIPTION
A long, long time ago we hardcoded the ip_address that's passed in the gateway_options hash here:

https://github.com/spree/spree/blob/master/core/app/models/spree/payment/processing.rb#L112

It was to work around a problem with HAProxy not being able to pass the real client ip during an SSL session, which I'm sure has long been fixed (and doesn't seem to be an issue with a sane nginx config anyway).

So we need to populate the Spree::CreditCard ip_address attribute during the payment step of the checkout, and we need to ensure it's passed to the gateway_options as well.

WHY NOW? Well it turns out certain payment processors will start blocking authorizations if you get a lot of orders in a short period of time (and they all use the same client ip_address), as a fraud protection against people testing stolen CC numbers.

This needs to be fixed on master, and back ported to at least 1-2-stable.
