### PR TITLE
Tracking IP addresses for order

### DIFF
--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -110,7 +110,7 @@ module Spree
     def gateway_options
       options = { :email    => order.email,
                   :customer => order.email,
-                  :ip       => '192.168.1.100', # TODO: Use an actual IP
+                  :ip       => order.last_ip_address,
                   :order_id => order.number }
 
       options.merge!({ :shipping => order.ship_total * 100,

--- a/core/db/migrate/20121126040517_add_last_ip_to_spree_orders.rb
+++ b/core/db/migrate/20121126040517_add_last_ip_to_spree_orders.rb
@@ -1,0 +1,5 @@
+class AddLastIpToSpreeOrders < ActiveRecord::Migration
+  def change
+    add_column :spree_orders, :last_ip_address, :string
+  end
+end

--- a/core/lib/spree/core/controller_helpers/common.rb
+++ b/core/lib/spree/core/controller_helpers/common.rb
@@ -66,6 +66,11 @@ module Spree
             type.all  { render :status => :not_found, :nothing => true }
           end
         end
+
+        def ip_address
+          request.env['HTTP_X_REAL_IP'] || request.env['REMOTE_ADDR']
+        end
+
         private
 
         def set_user_language

--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -24,6 +24,7 @@ module Spree
           return @current_order if @current_order
           if session[:order_id]
             current_order = Spree::Order.find_by_id_and_currency(session[:order_id], current_currency, :include => :adjustments)
+            current_order.last_ip_address = ip_address
             @current_order = current_order unless current_order.try(:completed?)
           end
           if create_order_if_necessary and (@current_order.nil? or @current_order.completed?)

--- a/core/spec/controllers/spree/current_order_ip_tracking_spec.rb
+++ b/core/spec/controllers/spree/current_order_ip_tracking_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'tracking current IP address for orders' do
+  controller(Spree::StoreController) do
+    def index
+      render :nothing => true
+    end
+  end
+
+  let(:order) { FactoryGirl.create(:order) }
+
+  it 'is done automatically when current_order is called' do
+    get :index, {}, { :order_id => order.id }
+    controller.current_order.last_ip_address.should == "0.0.0.0"
+  end
+end

--- a/core/spec/models/payment_spec.rb
+++ b/core/spec/models/payment_spec.rb
@@ -554,4 +554,13 @@ describe Spree::Payment do
       payment.display_amount.should == Spree::Money.new(payment.amount)
     end
   end
+
+  # Regression test for #2216
+  context "#gateway_options" do
+    before { order.stub(:last_ip_address => "192.168.1.1") }
+
+    it "contains an IP" do
+      payment.gateway_options[:ip].should == order.last_ip_address
+    end
+  end
 end


### PR DESCRIPTION
This is a partial fix for #2216.

When a user works with an order in Spree, we will now track their IP address on the `spree_orders` table. This will be passed through in the gateway options whenever a payment is processed.

Now, I say partial because it doesn't account for two other situations.

The first is payments through the admin backend.

The second is payments through the API.

I don't know if we should implement those for now. 

Ping @BDQ.
