### PR TITLE
Fixed the call to select_month and select_year in checkout gateway partial

### DIFF
--- a/core/app/views/spree/checkout/payment/_gateway.html.erb
+++ b/core/app/views/spree/checkout/payment/_gateway.html.erb
@@ -15,8 +15,8 @@
 </p>
 <p class="field" data-hook="card_expiration">
   <%= label_tag nil, t(:expiration) %><br />
-  <%= select_month(Date.today, :prefix => param_prefix, :field_name => 'month', :use_month_numbers => true, :class => 'required') %>
-  <%= select_year(Date.today, :prefix => param_prefix, :field_name => 'year', :start_year => Date.today.year, :end_year => Date.today.year + 15, :class => 'required') %>
+  <%= select_month(Date.today, { :prefix => param_prefix, :field_name => 'month', :use_month_numbers => true }, :class => 'required') %>
+  <%= select_year(Date.today, { :prefix => param_prefix, :field_name => 'year', :start_year => Date.today.year, :end_year => Date.today.year + 15 }, :class => 'required') %>
   <span class="required">*</span>
 </p>
 <p class="field" data-hook="card_code">


### PR DESCRIPTION
A wrong use of `select_month` and `select_year`, which signatures are:

``` ruby
select_month(date, options = {}, html_options = {})
select_year(date, options = {}, html_options = {})
```

prevented the right class to be associated to the `select` tags.
This patch fixes these issues
