### PR TITLE
Allow a rabl template to be specified when making an API request

### DIFF
--- a/api/app/controllers/spree/api/addresses_controller.rb
+++ b/api/app/controllers/spree/api/addresses_controller.rb
@@ -1,16 +1,19 @@
 module Spree
   module Api
     class AddressesController < Spree::Api::BaseController
+      respond_to :json
+
       def show
         @address = Address.find(params[:id])
         authorize! :read, @address
+        respond_with(@address)
       end
 
       def update
         @address = Address.find(params[:id])
         authorize! :read, @address
         @address.update_attributes(params[:address])
-        render :show, :status => 200
+        respond_with(@address, :default_template => :show)
       end
     end
   end

--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -1,7 +1,10 @@
+require 'spree/api/responders'
 module Spree
   module Api
     class BaseController < ActionController::Metal
       include Spree::Api::ControllerSetup
+
+      self.responder = Spree::Api::Responders::AppResponder
 
       attr_accessor :current_api_user
 

--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -3,6 +3,7 @@ module Spree
   module Api
     class BaseController < ActionController::Metal
       include Spree::Api::ControllerSetup
+      include ::ActionController::Head
 
       self.responder = Spree::Api::Responders::AppResponder
 

--- a/api/app/controllers/spree/api/countries_controller.rb
+++ b/api/app/controllers/spree/api/countries_controller.rb
@@ -1,13 +1,17 @@
 module Spree
   module Api
     class CountriesController < Spree::Api::BaseController
+      respond_to :json
+
       def index
         @countries = Country.ransack(params[:q]).result.includes(:states).order('name ASC')
           .page(params[:page]).per(params[:per_page])
+        respond_with(@countries)
       end
 
       def show
         @country = Country.find(params[:id])
+        respond_with(@country)
       end
     end
   end

--- a/api/app/controllers/spree/api/images_controller.rb
+++ b/api/app/controllers/spree/api/images_controller.rb
@@ -1,28 +1,31 @@
 module Spree
   module Api
     class ImagesController < Spree::Api::BaseController
+      respond_to :json
+
       def show
         @image = Image.find(params[:id])
+        respond_with(@image)
       end
 
       def create
         authorize! :create, Image
         @image = Image.create(params[:image])
-        render :show, :status => 201
+        respond_with(@image, :status => 201, :default_template => :show)
       end
 
       def update
         authorize! :update, Image
         @image = Image.find(params[:id])
         @image.update_attributes(params[:image])
-        render :show, :status => 200
+        respond_with(@image, :default_template => :show)
       end
 
       def destroy
         authorize! :delete, Image
         @image = Image.find(params[:id])
         @image.destroy
-        render :text => nil, :status => 204
+        respond_with(@image, :status => 204)
       end
     end
   end

--- a/api/app/controllers/spree/api/line_items_controller.rb
+++ b/api/app/controllers/spree/api/line_items_controller.rb
@@ -1,11 +1,13 @@
 module Spree
   module Api
     class LineItemsController < Spree::Api::BaseController
+      respond_to :json
+
       def create
         authorize! :read, order
         @line_item = order.line_items.build(params[:line_item], :as => :api)
         if @line_item.save
-          render :show, :status => 201
+          respond_with(@line_item, :status => 201, :default_template => :show)
         else
           invalid_resource!(@line_item)
         end
@@ -15,7 +17,7 @@ module Spree
         authorize! :read, order
         @line_item = order.line_items.find(params[:id])
         if @line_item.update_attributes(params[:line_item])
-          render :show
+          respond_with(@line_item, :default_template => :show)
         else
           invalid_resource!(@line_item)
         end
@@ -25,7 +27,7 @@ module Spree
         authorize! :read, order
         @line_item = order.line_items.find(params[:id])
         @line_item.destroy
-        render :text => nil, :status => 204
+        respond_with(@line_item, :status => 204)
       end
 
       private

--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -1,15 +1,19 @@
 module Spree
   module Api
     class OrdersController < Spree::Api::BaseController
+      respond_to :json
+
       before_filter :authorize_read!, :except => [:index, :search, :create]
 
       def index
         # should probably look at turning this into a CanCan step
         raise CanCan::AccessDenied unless current_api_user.has_spree_role?("admin")
         @orders = Order.ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
+        respond_with(@orders)
       end
 
       def show
+        respond_with(@order)
       end
 
       def create
@@ -21,7 +25,7 @@ module Spree
         authorize! :update, Order
         if order.update_attributes(nested_params)
           order.update!
-          render :show
+          respond_with(order, :default_template => :show)
         else
           invalid_resource!(order)
         end

--- a/api/app/controllers/spree/api/product_properties_controller.rb
+++ b/api/app/controllers/spree/api/product_properties_controller.rb
@@ -1,15 +1,19 @@
 module Spree
   module Api
     class ProductPropertiesController < Spree::Api::BaseController
+      respond_to :json
+
       before_filter :find_product
       before_filter :product_property, :only => [:show, :update, :destroy]
 
       def index
         @product_properties = @product.product_properties.ransack(params[:q]).result
           .page(params[:page]).per(params[:per_page])
+        respond_with(@product_properties)
       end
 
       def show
+        respond_with(@product_property)
       end
 
       def new
@@ -19,7 +23,7 @@ module Spree
         authorize! :create, ProductProperty
         @product_property = @product.product_properties.new(params[:product_property])
         if @product_property.save
-          render :show, :status => 201
+          respond_with(@product_property, :status => 201, :default_template => :show)
         else
           invalid_resource!(@product_property)
         end
@@ -28,7 +32,7 @@ module Spree
       def update
         authorize! :update, ProductProperty
         if @product_property  && @product_property.update_attributes(params[:product_property])
-          render :show, :status => 200
+          respond_with(@product_property, :status => 200, :default_template => :show)
         else
           invalid_resource!(@product_property)
         end
@@ -38,7 +42,7 @@ module Spree
         authorize! :delete, ProductProperty
         if(@product_property)
           @product_property.destroy
-          render :text => nil, :status => 204
+          respond_with(@product_property, :status => 204)
         else
           invalid_resource!(@product_property)
         end

--- a/api/app/controllers/spree/api/products_controller.rb
+++ b/api/app/controllers/spree/api/products_controller.rb
@@ -1,12 +1,16 @@
 module Spree
   module Api
     class ProductsController < Spree::Api::BaseController
+      respond_to :json
+
       def index
         @products = product_scope.ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
+        respond_with(@products)
       end
 
       def show
         @product = find_product(params[:id])
+        respond_with(@product)
       end
 
       def new
@@ -17,7 +21,7 @@ module Spree
         params[:product][:available_on] ||= Time.now
         @product = Product.new(params[:product])
         if @product.save
-          render :show, :status => 201
+          respond_with(@product, :status => 201, :default_template => :show)
         else
           invalid_resource!(@product)
         end
@@ -27,7 +31,7 @@ module Spree
         authorize! :update, Product
         @product = find_product(params[:id])
         if @product.update_attributes(params[:product])
-          render :show, :status => 200
+          respond_with(@product, :status => 200, :default_template => :show)
         else
           invalid_resource!(@product)
         end
@@ -38,7 +42,7 @@ module Spree
         @product = find_product(params[:id])
         @product.update_attribute(:deleted_at, Time.now)
         @product.variants_including_master.update_all(:deleted_at => Time.now)
-        render :text => nil, :status => 204
+        respond_with(@product, :status => 204)
       end
     end
   end

--- a/api/app/controllers/spree/api/return_authorizations_controller.rb
+++ b/api/app/controllers/spree/api/return_authorizations_controller.rb
@@ -1,21 +1,25 @@
 module Spree
   module Api
     class ReturnAuthorizationsController < Spree::Api::BaseController
+      respond_to :json
+
       before_filter :authorize_admin!
 
       def index
         @return_authorizations = order.return_authorizations.ransack(params[:q]).result
           .page(params[:page]).per(params[:per_page])
+        respond_with(@return_authorizations)
       end
 
       def show
         @return_authorization = order.return_authorizations.find(params[:id])
+        respond_with(@return_authorization)
       end
 
       def create
         @return_authorization = order.return_authorizations.build(params[:return_authorization], :as => :api)
         if @return_authorization.save
-          render :show, :status => 201
+          respond_with(@return_authorization, :status => 201, :default_template => :show)
         else
           invalid_resource!(@return_authorization)
         end
@@ -24,7 +28,7 @@ module Spree
       def update
         @return_authorization = order.return_authorizations.find(params[:id])
         if @return_authorization.update_attributes(params[:return_authorization])
-          render :show
+          respond_with(@return_authorization, :default_template => :show)
         else
           invalid_resource!(@return_authorization)
         end
@@ -33,7 +37,7 @@ module Spree
       def destroy
         @return_authorization = order.return_authorizations.find(params[:id])
         @return_authorization.destroy
-        render :text => nil, :status => 204
+        respond_with(@return_authorization, :status => 204)
       end
 
       private

--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -1,6 +1,8 @@
 module Spree
   module Api
     class ShipmentsController < Spree::Api::BaseController
+      respond_to :json
+
       before_filter :find_order
       before_filter :find_and_update_shipment, :only => [:ship, :ready]
 
@@ -13,7 +15,7 @@ module Spree
             render "spree/api/shipments/cannot_ready_shipment", :status => 422 and return
           end
         end
-        render :show
+        respond_with(@shipment, :default_template => :show)
       end
 
       def ship
@@ -21,7 +23,7 @@ module Spree
         unless @shipment.shipped?
           @shipment.ship!
         end
-        render :show
+        respond_with(@shipment, :default_template => :show)
       end
 
       private

--- a/api/app/controllers/spree/api/taxonomies_controller.rb
+++ b/api/app/controllers/spree/api/taxonomies_controller.rb
@@ -1,20 +1,24 @@
 module Spree
   module Api
     class TaxonomiesController < Spree::Api::BaseController
+      respond_to :json
+
       def index
         @taxonomies = Taxonomy.order('name').includes(:root => :children).ransack(params[:q]).result
           .page(params[:page]).per(params[:per_page])
+        respond_with(@taxonomies)
       end
 
       def show
         @taxonomy = Taxonomy.find(params[:id])
+        respond_with(@taxonomy)
       end
 
       def create
         authorize! :create, Taxonomy
         @taxonomy = Taxonomy.new(params[:taxonomy])
         if @taxonomy.save
-          render :show, :status => 201
+          respond_with(@taxonomy, :status => 201, :default_template => :show)
         else
           invalid_resource!(@taxonomy)
         end
@@ -23,7 +27,7 @@ module Spree
       def update
         authorize! :update, Taxonomy
         if taxonomy.update_attributes(params[:taxonomy])
-          render :show, :status => 200
+          respond_with(taxonomy, :status => 200, :default_template => :show)
         else
           invalid_resource!(taxonomy)
         end
@@ -32,7 +36,7 @@ module Spree
       def destroy
         authorize! :delete, Taxonomy
         taxonomy.destroy
-        render :text => nil, :status => 204
+        respond_with(taxonomy, :status => 204)
       end
 
       private

--- a/api/app/controllers/spree/api/taxons_controller.rb
+++ b/api/app/controllers/spree/api/taxons_controller.rb
@@ -1,19 +1,23 @@
 module Spree
   module Api
     class TaxonsController < Spree::Api::BaseController
+      respond_to :json
+
       def index
         @taxons = taxonomy.root.children
+        respond_with(@taxons)
       end
 
       def show
         @taxon = taxon
+        respond_with(@taxon)
       end
 
       def create
         authorize! :create, Taxon
         @taxon = Taxon.new(params[:taxon])
         if @taxon.save
-          render :show, :status => 201
+          respond_with(@taxon, :status => 201, :default_template => :show)
         else
           invalid_resource!(@taxon)
         end
@@ -22,7 +26,7 @@ module Spree
       def update
         authorize! :update, Taxon
         if taxon.update_attributes(params[:taxon])
-          render :show, :status => 200
+          respond_with(taxon, :status => 200, :default_template => :show)
         else
           invalid_resource!(taxon)
         end
@@ -31,7 +35,7 @@ module Spree
       def destroy
         authorize! :delete, Taxon
         taxon.destroy
-        render :text => nil, :status => 204
+        respond_with(taxon, :status => 204)
       end
 
       private

--- a/api/app/controllers/spree/api/variants_controller.rb
+++ b/api/app/controllers/spree/api/variants_controller.rb
@@ -1,15 +1,19 @@
 module Spree
   module Api
     class VariantsController < Spree::Api::BaseController
+      respond_to :json
+
       before_filter :product
 
       def index
         @variants = scope.includes(:option_values).ransack(params[:q]).result.
           page(params[:page]).per(params[:per_page])
+        respond_with(@variants)
       end
 
       def show
         @variant = scope.includes(:option_values).find(params[:id])
+        respond_with(@variant)
       end
 
       def new
@@ -19,7 +23,7 @@ module Spree
         authorize! :create, Variant
         @variant = scope.new(params[:product])
         if @variant.save
-          render :show, :status => 201
+          respond_with(@variant, :status => 201, :default_template => :show)
         else
           invalid_resource!(@variant)
         end
@@ -29,7 +33,7 @@ module Spree
         authorize! :update, Variant
         @variant = scope.find(params[:id])
         if @variant.update_attributes(params[:variant])
-          render :show, :status => 200
+          respond_with(@variant, :status => 200, :default_template => :show)
         else
           invalid_resource!(@product)
         end
@@ -39,7 +43,7 @@ module Spree
         authorize! :delete, Variant
         @variant = scope.find(params[:id])
         @variant.destroy
-        render :text => nil, :status => 204
+        respond_with(@variant, :status => 204)
       end
 
       private

--- a/api/app/controllers/spree/api/zones_controller.rb
+++ b/api/app/controllers/spree/api/zones_controller.rb
@@ -1,19 +1,22 @@
 module Spree
   module Api
     class ZonesController < Spree::Api::BaseController
+      respond_to :json
+
       def index
         @zones = Zone.order('name ASC').ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
+        respond_with(@zones)
       end
 
       def show
-        zone
+        respond_with(zone)
       end
 
       def create
         authorize! :create, Zone
         @zone = Zone.new(map_nested_attributes_keys(Spree::Zone, params[:zone]))
         if @zone.save
-          render :show, :status => 201
+          respond_with(@zone, :status => 201, :default_template => :show)
         else
           invalid_resource!(@zone)
         end
@@ -22,7 +25,7 @@ module Spree
       def update
         authorize! :update, Zone
         if zone.update_attributes(map_nested_attributes_keys(Spree::Zone, params[:zone]))
-          render :show, :status => 200
+          respond_with(zone, :status => 200)
         else
           invalid_resource!(@zone)
         end

--- a/api/app/controllers/spree/api/zones_controller.rb
+++ b/api/app/controllers/spree/api/zones_controller.rb
@@ -25,16 +25,16 @@ module Spree
       def update
         authorize! :update, Zone
         if zone.update_attributes(map_nested_attributes_keys(Spree::Zone, params[:zone]))
-          respond_with(zone, :status => 200)
+          respond_with(zone, :status => 200, :default_template => :show)
         else
-          invalid_resource!(@zone)
+          invalid_resource!(zone)
         end
       end
 
       def destroy
         authorize! :delete, Zone
         zone.destroy
-        render :text => nil, :status => 204
+        respond_with(zone, :status => 204)
       end
 
       private

--- a/api/lib/spree/api/responders.rb
+++ b/api/lib/spree/api/responders.rb
@@ -1,0 +1,11 @@
+require 'spree/api/responders/rabl_template'
+
+module Spree
+  module Api
+    module Responders
+      class AppResponder < ActionController::Responder
+        include RablTemplate
+      end
+    end
+  end
+end

--- a/api/lib/spree/api/responders/rabl_template.rb
+++ b/api/lib/spree/api/responders/rabl_template.rb
@@ -1,0 +1,18 @@
+module Spree
+  module Api
+    module Responders
+      module RablTemplate
+        def to_format
+          if template = controller.params[:template] || options[:default_template]
+            render template.to_sym, :status => options[:status] || 200
+          else
+            super
+          end
+
+        rescue ActionView::MissingTemplate => e
+          api_behavior(e)
+        end
+      end
+    end
+  end
+end

--- a/api/lib/spree/api/responders/rabl_template.rb
+++ b/api/lib/spree/api/responders/rabl_template.rb
@@ -3,7 +3,7 @@ module Spree
     module Responders
       module RablTemplate
         def to_format
-          if template = controller.params[:template] || options[:default_template]
+          if template
             render template.to_sym, :status => options[:status] || 200
           else
             super
@@ -11,6 +11,10 @@ module Spree
 
         rescue ActionView::MissingTemplate => e
           api_behavior(e)
+        end
+
+        def template
+          request.headers['X-Spree-Template'] || controller.params[:template] || options[:default_template]
         end
       end
     end

--- a/api/spec/controllers/spree/api/zones_controller_spec.rb
+++ b/api/spec/controllers/spree/api/zones_controller_spec.rb
@@ -38,6 +38,28 @@ module Spree
       json_response['zone_members'].size.should eq @zone.zone_members.count
     end
 
+    context "specifying a rabl template to use" do
+      before do
+        Spree::Api::ZonesController.class_eval do
+          def custom_show
+            respond_with(zone)
+          end
+        end
+      end
+
+      it "uses the specified template" do
+        request.env['X-Spree-Template'] = 'show'
+        api_get :custom_show, :id => @zone.id
+        response.should render_template('spree/api/zones/show')
+      end
+
+      it "falls back to the default template if the specified template does not exist" do
+        request.env['X-Spree-Template'] = 'invoice'
+        api_get :show, :id => @zone.id
+        response.should render_template('spree/api/zones/show')
+      end
+    end
+
     context "as an admin" do
       sign_in_as_admin!
 


### PR DESCRIPTION
Adds the option to pass a 'X-Spree-Template' header along with an api request in order to specify a rabl template to use for the response.
