### PR TITLE
Show add to cart if price in selected currency.

### DIFF
--- a/core/app/views/spree/products/_cart_form.html.erb
+++ b/core/app/views/spree/products/_cart_form.html.erb
@@ -26,7 +26,7 @@
       </div>
     <% end%>
 
-    <% if @product.price %>
+    <% if @product.price_in(current_currency) %>
       <div data-hook="product_price" class="columns five <% if !@product.has_variants? %> alpha <% else %> omega <% end %>">
         
         <div id="product-price">


### PR DESCRIPTION
This is a bug with the cart form.  It would show the add to cart button
if there was a valid price in the master currency rather than the
current currency.  This causes the add to cart button to not display if
the product is not available in the master currency but available in a
different currency.
