### PR TITLE
Update core/app/views/spree/shared/_google_analytics.html.erb

### DIFF
--- a/core/app/views/spree/shared/_google_analytics.html.erb
+++ b/core/app/views/spree/shared/_google_analytics.html.erb
@@ -5,7 +5,7 @@
     _gaq.push(['_setAccount', '<%= tracker.analytics_id %>']);
     _gaq.push(['_trackPageview']);
 
-    <% if flash[:commerce_tracking] %>
+    <% if flash[:commerce_tracking] && @order.present? %>
       <%# more info: https://developers.google.com/analytics/devguides/collection/gajs/methods/gaJSApiEcommerce %>
       _gaq.push(['_addTrans',
         "<%= @order.number %>",


### PR DESCRIPTION
If an error occurs during the final page of the checkout  - order_path(@order), this leaves the flash[:commerce_tracking] set. So when the user goes back to the home page or any subsequent page, the pages will throw an nil exception on <%= @order.number %> because the framework sees that the flash[:commerce_tracking] hasn't been cleared.

The fix is to also check that @order is present.
