### PR TITLE
DRYer Checkout/OrdersController Promotion class_evals

### DIFF
--- a/core/app/controllers/spree/checkout_controller.rb
+++ b/core/app/controllers/spree/checkout_controller.rb
@@ -17,11 +17,15 @@ module Spree
 
     respond_to :html
 
+    class_attribute :update_hooks
+    self.update_hooks = Set.new
+
     # Updates the order and advances to the next state (when possible.)
     # Overriden by the promo gem if it exists. 
     def update
       if @order.update_attributes(object_params)
         fire_event('spree.checkout.update')
+        update_hooks.each { |h| render :edit and return unless self.send(h) }
 
         if @order.next
           state_callback(:after)

--- a/core/app/controllers/spree/orders_controller.rb
+++ b/core/app/controllers/spree/orders_controller.rb
@@ -18,9 +18,9 @@ module Spree
     def update
       @order = current_order
       if @order.update_attributes(params[:order])
-        update_hooks.each { |h| render :edit and return unless self.send(h) }
         @order.line_items = @order.line_items.select {|li| li.quantity > 0 }
         fire_event('spree.order.contents_changed')
+        update_hooks.each { |h| render :edit and return unless self.send(h) }
         respond_with(@order) do |format|
           format.html do
             if params.has_key?(:checkout)

--- a/core/app/controllers/spree/orders_controller.rb
+++ b/core/app/controllers/spree/orders_controller.rb
@@ -7,6 +7,9 @@ module Spree
 
     respond_to :html
 
+    class_attribute :update_hooks
+    self.update_hooks = Set.new
+
     def show
       @order = Order.find_by_number!(params[:id])
       respond_with(@order)
@@ -15,12 +18,13 @@ module Spree
     def update
       @order = current_order
       if @order.update_attributes(params[:order])
+        update_hooks.each { |h| render :edit and return unless self.send(h) }
         @order.line_items = @order.line_items.select {|li| li.quantity > 0 }
         fire_event('spree.order.contents_changed')
         respond_with(@order) do |format|
           format.html do
             if params.has_key?(:checkout)
-              @order.next_transition.run_callbacks
+              # @order.next_transition.run_callbacks
               redirect_to checkout_state_path(@order.checkout_steps.first)
             else
               redirect_to cart_path

--- a/promo/app/controllers/spree/checkout_controller_decorator.rb
+++ b/promo/app/controllers/spree/checkout_controller_decorator.rb
@@ -1,30 +1,3 @@
 Spree::CheckoutController.class_eval do
-
-  #TODO 90% of this method is duplicated code. DRY
-  def update
-    if @order.update_attributes(object_params)
-
-      fire_event('spree.checkout.update')
-      render :edit and return unless apply_coupon_code
-
-      if @order.next
-        state_callback(:after)
-      else
-        flash[:error] = t(:payment_processing_failed)
-        redirect_to checkout_state_path(@order.state)
-        return
-      end
-
-      if @order.state == 'complete' || @order.completed?
-        flash.notice = t(:order_processed_successfully)
-        flash[:commerce_tracking] = 'nothing special'
-        redirect_to completion_route
-      else
-        redirect_to checkout_state_path(@order.state)
-      end
-    else
-      render :edit
-    end
-  end
-
+  self.update_hooks.add(:apply_coupon_code)
 end

--- a/promo/app/controllers/spree/orders_controller_decorator.rb
+++ b/promo/app/controllers/spree/orders_controller_decorator.rb
@@ -1,24 +1,3 @@
 Spree::OrdersController.class_eval do
-
-  def update
-    @order = current_order
-    if @order.update_attributes(params[:order])
-      render :edit and return unless apply_coupon_code
-      
-      @order.line_items = @order.line_items.select {|li| li.quantity > 0 }
-      fire_event('spree.order.contents_changed')
-      respond_with(@order) do |format|
-        format.html do
-          if params.has_key?(:checkout)
-            redirect_to checkout_state_path(@order.checkout_steps.first)
-          else
-            redirect_to cart_path
-          end
-        end
-      end
-    else
-      respond_with(@order)
-    end
-  end
-
+  self.update_hooks.add(:apply_coupon_code)
 end

--- a/promo/spec/requests/promotion_adjustments_spec.rb
+++ b/promo/spec/requests/promotion_adjustments_spec.rb
@@ -74,7 +74,7 @@ describe "Promotion Adjustments" do
     it "should allow an admin to create a single user coupon promo with flat rate discount" do
       fill_in "Name", :with => "Order's total > $30"
       fill_in "Usage Limit", :with => "1"
-      select "Coupon code added", :from => "Event"
+      select2_select "Coupon code added", :from => "promotion_event_name"
       fill_in "Code", :with => "SINGLE_USE"
       click_button "Create"
       page.should have_content("Editing Promotion")
@@ -142,7 +142,7 @@ describe "Promotion Adjustments" do
 
     it "should allow an admin to create an automatic promo with flat percent discount" do
       fill_in "Name", :with => "Order's total > $30"
-      select "Order contents changed", :from => "Event"
+      select2_select "Order contents changed", :from => "promotion_event_name"
       click_button "Create"
       page.should have_content("Editing Promotion")
 
@@ -232,7 +232,7 @@ describe "Promotion Adjustments" do
 
     it "should allow an admin to create an automatic promo requiring a landing page to be visited" do
       fill_in "Name", :with => "Deal"
-      select "Visit static content page", :from => "Event"
+      select2_select "Visit static content page", :from => "promotion_event_name"
       fill_in "Path", :with => "content/cvv"
       click_button "Create"
       page.should have_content("Editing Promotion")
@@ -288,12 +288,11 @@ describe "Promotion Adjustments" do
 
     it "should allow an admin to create a promotion that adds a 'free' item to the cart" do
       fill_in "Name", :with => "Bundle"
-      select "Coupon code added", :from => "Event"
+      select2_select "Coupon code added", :from => "promotion_event_name"
       fill_in "Code", :with => "5ZHED2DH"
       click_button "Create"
       page.should have_content("Editing Promotion")
-
-      select "Create line items", :from => "Add action of type"
+      select2_select "Create line items", :from => "action_type"
       within('#action_fields') { click_button "Add" }
       # Forced narcolepsy, thanks to JavaScript
       sleep(1)
@@ -334,7 +333,6 @@ describe "Promotion Adjustments" do
 
       fill_in "order_coupon_code", :with => "5ZHED2DH"
       click_button "Save and Continue"
-
       last_order = Spree::Order.last
       last_order.line_items.count.should == 2
       last_order.line_items.map(&:price).should =~ [20.00, 40.00]
@@ -345,7 +343,7 @@ describe "Promotion Adjustments" do
 
     it "ceasing to be eligible for a promotion with item total rule then becoming eligible again" do
       fill_in "Name", :with => "Spend over $50 and save $5"
-      select "Order contents changed", :from => "Event"
+      select2_select "Order contents changed", :from => "promotion_event_name"
       click_button "Create"
       page.should have_content("Editing Promotion")
 
@@ -388,7 +386,7 @@ describe "Promotion Adjustments" do
 
     it "only counting the most valuable promotion adjustment in an order" do
       fill_in "Name", :with => "$5 off"
-      select "Order contents changed", :from => "Event"
+      select2_select "Order contents changed", :from => "promotion_event_name"
       click_button "Create"
       page.should have_content("Editing Promotion")
       select "Create adjustment", :from => "Add action of type"
@@ -401,7 +399,7 @@ describe "Promotion Adjustments" do
       visit spree.admin_promotions_path
       click_link "New Promotion"
       fill_in "Name", :with => "10% off"
-      select "Order contents changed", :from => "Event"
+      select2_select "Order contents changed", :from => "promotion_event_name"
       click_button "Create"
       page.should have_content("Editing Promotion")
       select "Create adjustment", :from => "Add action of type"

--- a/promo/spec/support/promotion_creation.rb
+++ b/promo/spec/support/promotion_creation.rb
@@ -1,4 +1,14 @@
 module PromotionCreation
+  def select2_select(text, options)
+    page.find("#s2id_#{options[:from]} a").click
+    page.all("ul.select2-results li").each do |e|
+      if e.text == text
+        e.click
+        return
+      end
+    end
+  end
+
   def create_per_product_promotion product_name, discount_amount, event = "Add to cart"
     promotion_name = "Bundle d#{discount_amount}"
 
@@ -7,7 +17,7 @@ module PromotionCreation
     click_link "New Promotion"
 
     fill_in "Name", :with => promotion_name
-    select event, :from => "Event"
+    select2_select event, :from => "promotion_event_name"
     click_button "Create"
     page.should have_content("Editing Promotion")
 
@@ -41,7 +51,7 @@ module PromotionCreation
     promotion_name = "Order's total > $#{order_min}, Discount #{order_discount}"
     fill_in "Name", :with => promotion_name
     fill_in "Usage Limit", :with => "100"
-    select "Coupon code added", :from => "Event"
+    select2_select "Coupon code added", :from => "promotion_event_name"
     fill_in "Code", :with => coupon_code
     click_button "Create"
     page.should have_content("Editing Promotion")


### PR DESCRIPTION
This is an attempt to make the `class_eval`s a bit DRYer. Instead of copying the whole method I used the hook method utilized in the order model.

Although this cleans up the code a bit, I believe this will allow for improvements to the promotional system (specifically #1984) that would now be very cumbersome.

I've also fixed the breaking promo specs related to the use of select2.
