### PR TITLE
fix js for activated payment method in checkout

### DIFF
--- a/core/app/assets/javascripts/store/checkout.js.coffee
+++ b/core/app/assets/javascripts/store/checkout.js.coffee
@@ -69,11 +69,11 @@ $ ->
     ).triggerHandler 'click'
 
   if ($ '#checkout_form_payment').is('*')
-    # Activate already checked payment method if form is re-rendered
-    # i.e. if user enters invalid data
-    ($ 'input[type="radio"]:checked').click()
-
     ($ 'input[type="radio"][name="order[payments_attributes][][payment_method_id]"]').click(->
       ($ '#payment-methods li').hide()
       ($ '#payment_method_' + @value).show() if @checked
     )
+
+    # Activate already checked payment method if form is re-rendered
+    # i.e. if user enters invalid data
+    ($ 'input[type="radio"]:checked').click()


### PR DESCRIPTION
.click() was being called before the method was bound to the input.
