### PR TITLE
Allow payment method to control auto_capture?

### DIFF
--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -5,7 +5,7 @@ module Spree
         if payment_method && payment_method.source_required?
           if source
             if !processing?
-              if Spree::Config[:auto_capture]
+              if payment_method.auto_capture?
                 purchase!
               else
                 authorize!

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -51,5 +51,9 @@ module Spree
     def source_required?
       true
     end
+
+    def auto_capture?
+      Spree::Config[:auto_capture]
+    end
   end
 end

--- a/core/spec/models/payment_spec.rb
+++ b/core/spec/models/payment_spec.rb
@@ -65,13 +65,13 @@ describe Spree::Payment do
 
     context "#process!" do
       it "should purchase if with auto_capture" do
-        Spree::Config[:auto_capture] = true
+        payment.payment_method.should_receive(:auto_capture?).and_return(true)
         payment.should_receive(:purchase!)
         payment.process!
       end
 
       it "should authorize without auto_capture" do
-        Spree::Config[:auto_capture] = false
+        payment.payment_method.should_receive(:auto_capture?).and_return(false)
         payment.should_receive(:authorize!)
         payment.process!
       end


### PR DESCRIPTION
Some gateways (ex. samurai, eway, stripe) only support purchase, not
auth/capture.

This allows those gateways to override auto_capture? and coexist with other payment methods not using auto_capture. Also eliminates the required configuration for those payment methods.
