### PR TITLE
Automatically set up jirafe when visiting admin for the first time

### DIFF
--- a/dash/app/controllers/spree/admin/analytics_controller.rb
+++ b/dash/app/controllers/spree/admin/analytics_controller.rb
@@ -1,50 +1,32 @@
 module Spree
   class Admin::AnalyticsController < Admin::BaseController
 
-    def sign_up
-      redirect_if_registered and return
-      @store = {
-        :first_name => '',
-        :last_name => '',
-        :email => try_spree_current_user.try(:email),
-        :currency => 'USD',
-        :time_zone => Time.zone,
-        :name => Spree::Config.site_name,
-        :url => format_url(Spree::Config.site_url)
-      }
-    end
-
     def register
       redirect_if_registered and return
-      @store = params[:store]
-      @store[:url] = format_url(@store[:url])
-
-      unless @store.has_key? :terms_of_service
-        flash[:error] = t(:agree_to_terms_of_service)
-        return render :sign_up
-      end
-
-      unless @store.has_key? :privacy_policy
-        flash[:error] = t(:agree_to_privacy_policy)
-        return render :sign_up
-      end
 
       begin
-        @store = Spree::Dash::Jirafe.register(@store)
-        Spree::Dash::Config.app_id = @store[:app_id]
-        Spree::Dash::Config.app_token = @store[:app_token]
-        Spree::Dash::Config.site_id = @store[:site_id]
-        Spree::Dash::Config.token = @store[:site_token]
-        flash[:notice] = t(:successfully_signed_up_for_analytics)
+        store = Spree::Dash::Jirafe.register(store_hash)
+        Spree::Dash::Config.app_id = store[:app_id]
+        Spree::Dash::Config.app_token = store[:app_token]
+        Spree::Dash::Config.site_id = store[:site_id]
+        Spree::Dash::Config.token = store[:site_token]
         redirect_to admin_path
       rescue Spree::Dash::JirafeException => e
         flash[:error] = e.message
-        render :sign_up
+        redirect_to root_path
       end
     end
 
-    def edit
-
+    def sync
+      begin
+        store = Spree::Dash::Jirafe.synchronize_resources(store_hash)
+        session[:last_jirafe_sync] = DateTime.now
+        flash[:notice] = "Updated"
+        redirect_to admin_path
+      rescue Spree::Dash::JirafeException => e
+        flash[:error] = e.message
+        redirect_to admin_path
+      end
     end
 
     def update
@@ -65,9 +47,31 @@ module Spree
       end
     end
 
+    def store_hash
+      url = Spree::Config.site_url || "http://demo.spreecommerce.com"
+      email = "junk@spreecommerce.com"
+      name = Spree::Config.site_name || "Spree Store"
+
+      store = {
+        :first_name    => 'Spree',
+        :last_name     => 'User',
+        :email         => email,
+        :name          => 'Spree Store Dos',
+        :url           => format_url(url),
+        :platform_type => 'spree-development',
+        :currency      => 'USD',
+        :time_zone     => ActiveSupport::TimeZone::MAPPING['Eastern Time (US & Canada)'],
+      }
+
+      if Spree::Dash::Config.app_id.present? && Spree::Dash::Config.app_token.present?
+        store[:app_id] = Spree::Dash::Config.app_id
+        store[:app_token] = Spree::Dash::Config.app_token
+      end
+      store
+    end
+
     def format_url(url)
       url =~ /^http/ ? url : "http://#{url}"
     end
-
   end
 end

--- a/dash/app/controllers/spree/admin/analytics_controller.rb
+++ b/dash/app/controllers/spree/admin/analytics_controller.rb
@@ -51,14 +51,15 @@ module Spree
       url = Spree::Config.site_url || "http://demo.spreecommerce.com"
       email = "junk@spreecommerce.com"
       name = Spree::Config.site_name || "Spree Store"
+      platform_type = Rails.env.production? ? "spree" : "spree-#{Rails.env}"
 
       store = {
         :first_name    => 'Spree',
         :last_name     => 'User',
         :email         => email,
-        :name          => 'Spree Store Dos',
+        :name          => 'Spree Store',
         :url           => format_url(url),
-        :platform_type => 'spree-development',
+        :platform_type => platform_type,
         :currency      => 'USD',
         :time_zone     => ActiveSupport::TimeZone::MAPPING['Eastern Time (US & Canada)'],
       }

--- a/dash/app/controllers/spree/admin/overview_controller.rb
+++ b/dash/app/controllers/spree/admin/overview_controller.rb
@@ -1,5 +1,6 @@
 module Spree
   class Admin::OverviewController < Admin::BaseController
+    before_filter :check_last_jirafe_sync_time, :only => :index
 
     JIRAFE_LOCALES = { :english => 'en_US',
                        :french => 'fr_FR',
@@ -7,10 +8,22 @@ module Spree
                        :japanese => 'ja_JA' }
 
     def index
+      redirect_to admin_analytics_register_path unless Spree::Dash::Config.configured?
+
       if JIRAFE_LOCALES.values.include? params[:locale]
         Spree::Dash::Config.locale = params[:locale]
       end
     end
 
+    private
+
+    def check_last_jirafe_sync_time
+      if session[:last_jirafe_sync]
+        hours_since_last_sync = ((DateTime.now - session[:last_jirafe_sync]) * 24).to_i
+        redirect_to admin_analytics_sync_path if hours_since_last_sync > 24
+      else
+        redirect_to admin_analytics_sync_path
+      end
+    end
   end
 end

--- a/dash/config/routes.rb
+++ b/dash/config/routes.rb
@@ -1,8 +1,8 @@
 Spree::Core::Engine.routes.prepend do
   match '/admin' => 'admin/overview#index', :as => :admin
 
-  get '/admin/analytics/sign_up' => 'admin/analytics#sign_up', :as => :admin_analytics_sign_up
-  post '/admin/analytics/register' => 'admin/analytics#register', :as => :admin_analytics_register
+  get '/admin/analytics/register' => 'admin/analytics#register', :as => :admin_analytics_register
+  get '/admin/analytics/sync' => 'admin/analytics#sync', :as => :admin_analytics_sync
 
   get '/jirafe' => 'admin/analytics#edit', :as => :admin_analytics
   put '/jirafe' => 'admin/analytics#update', :as => :admin_analytics

--- a/dash/spec/controllers/admin/analytics_controller_spec.rb
+++ b/dash/spec/controllers/admin/analytics_controller_spec.rb
@@ -22,6 +22,8 @@ describe Spree::Admin::AnalyticsController do
     end
 
     it "redirects after registration" do
+      Spree::Dash::Jirafe.should_receive(:register).
+                          and_return({ :app_id => '1', :app_token => '2', :site_id => '3', :site_token => '4' })
       Spree::Config.site_name = "test_site"
       Spree::Config.site_url = "http://test_site.com"
       spree_get :register
@@ -33,7 +35,6 @@ describe Spree::Admin::AnalyticsController do
                           and_return({ :app_id => '1', :app_token => '2', :site_id => '3', :site_token => '4' })
       spree_get :register
       Spree::Dash::Config.configured?.should be_true
-      response.should redirect_to(spree.admin_path)
     end
   end
 end

--- a/dash/spec/controllers/admin/overview_controller_spec.rb
+++ b/dash/spec/controllers/admin/overview_controller_spec.rb
@@ -5,6 +5,8 @@ describe Spree::Admin::OverviewController do
   before :each do
     @user = create(:admin_user)
     controller.stub :spree_current_user => @user
+    Spree::Dash::Config.should_receive(:configured?).and_return(true)
+    session[:last_jirafe_sync] = DateTime.now
   end
 
   it "sets the locale preference" do

--- a/dash/spec/requests/admin/analytics_spec.rb
+++ b/dash/spec/requests/admin/analytics_spec.rb
@@ -10,21 +10,13 @@ describe "Analytics Activation" do
     Spree::Dash::Config.app_token = nil
     Spree::Dash::Config.site_id = nil
     Spree::Dash::Config.token = nil
+
+    Spree::Dash::Jirafe.should_receive(:register).
+                        and_return({ :app_id => '1', :app_token => '2', :site_id => '3', :site_token => '4' })
   end
 
-  it "user can activate spree_analytics" do
-      Spree::Dash::Jirafe.should_receive(:register).
-                          with(hash_including(:url => 'http://test.com')).
-                          and_return({ :app_id => '1', :app_token => '2', :site_id => '3', :site_token => '4' })
-
-      visit spree.admin_analytics_sign_up_path
-      check 'store[terms_of_service]'
-      check 'store[privacy_policy]'
-      fill_in 'store[first_name]', :with => "test_first_name"
-      fill_in 'store[last_name]', :with => "test_last_name"
-      fill_in 'store[url]', :with => "test.com"
-      select '(GMT+00:00) Casablanca', :from => 'store[time_zone]'
-      click_button 'Activate'
+  it "user is signed up for analytics the first time they visit the dashboard" do
+      visit spree.admin_path
 
       Spree::Dash::Config.app_id.should eq '1'
       Spree::Dash::Config.app_token.should eq '2'
@@ -32,8 +24,9 @@ describe "Analytics Activation" do
       Spree::Dash::Config.token.should eq '4'
   end
 
-  it "can edit anayltics information" do
+  it "can edit exisiting anayltics information" do
     visit spree.admin_path
+
     click_link "Configuration"
     click_link "Jirafe"
     fill_in 'app_id', :with => "1"


### PR DESCRIPTION
Includes the following changes to dash
- Automatically register with jirafe the first time an admin logs in
- Sync all admin users with jirafe at least once every 24 hours

You can still edit your jirafe configuration if you don't want to use the automatic registration
