### PR TITLE
Add missing equal sign for admin_shipping_method_form_availability_fields

### DIFF
--- a/core/app/views/spree/admin/shipping_methods/_form.html.erb
+++ b/core/app/views/spree/admin/shipping_methods/_form.html.erb
@@ -24,7 +24,7 @@
   </div>
 </div>
 
-<div data-hook"admin_shipping_method_form_availability_fields" class="alpha six columns">
+<div data-hook="admin_shipping_method_form_availability_fields" class="alpha six columns">
   <fieldset class="categories no-border-bottom">
     <legend align="center"><%= t(:availability) %></legend>
 


### PR DESCRIPTION
Shipping methods form in admin was missing an equal sign on a data-hook which prevents deface rule from applying.
