### PR TITLE
Add missing equal sign for admin_shipping_method_form_availability_field...

### DIFF
--- a/core/app/views/spree/admin/shipping_methods/_form.html.erb
+++ b/core/app/views/spree/admin/shipping_methods/_form.html.erb
@@ -18,7 +18,7 @@
   <% end %>
 </div>
 
-<div data-hook"admin_shipping_method_form_availability_fields">
+<div data-hook="admin_shipping_method_form_availability_fields">
   <fieldset class="categories">
     <legend><%= t(:availability) %></legend>
     <%= f.field_container :shipping_category do %>


### PR DESCRIPTION
Shipping methods form in admin was missing an equal sign on a data-hook which prevents deface rule from applying.
