### PR TITLE
Protocol relative URL for Google font.

### DIFF
--- a/core/app/views/spree/admin/shared/_head.html.erb
+++ b/core/app/views/spree/admin/shared/_head.html.erb
@@ -8,7 +8,7 @@
 </title>
 
 <!-- Get "Open Sans" font from Google -->
-<link href='http://fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,400,600&subset=latin,cyrillic,greek,vietnamese' rel='stylesheet' type='text/css'>
+<link href='//fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,400,600&subset=latin,cyrillic,greek,vietnamese' rel='stylesheet' type='text/css'>
 
 <%= stylesheet_link_tag 'admin/all' %>
 


### PR DESCRIPTION
This fixes an insecure content from a secure context issue when the
admin interface is loaded through HTTPS.

The protocol specific URL will request this element thorough HTTPS
if the current page is being served over HTTPS.

This should also be merged in to 1-3-stable.
