### PR TITLE
Allowing a shipment to be ready for resumed orders

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -355,6 +355,10 @@ module Spree
       end
     end
 
+    def can_ship?
+      self.complete? || self.resumed?
+    end
+
     def credit_cards
       credit_card_ids = payments.from_credit_card.map(&:source_id).uniq
       CreditCard.scoped(:conditions => { :id => credit_card_ids })

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -110,7 +110,7 @@ module Spree
     # shipped    if already shipped (ie. does not change the state)
     # ready      all other cases
     def determine_state(order)
-      return 'pending' unless order.complete?
+      return 'pending' unless order.complete? || order.resumed?
       return 'pending' if inventory_units.any? &:backordered?
       return 'shipped' if state == 'shipped'
       order.paid? ? 'ready' : 'pending'

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -28,7 +28,7 @@ module Spree
 
     scope :with_state, lambda { |s| where(:state => s) }
     scope :shipped, with_state('shipped')
-    scope :ready,   with_state('ready')
+    scope :ready, with_state('ready')
     scope :pending, with_state('pending')
 
     def to_param
@@ -51,11 +51,13 @@ module Spree
     def cost
       adjustment ? adjustment.amount : 0
     end
+
     alias_method :amount, :cost
 
     def display_cost
       Spree::Money.new(cost, { :currency => currency })
     end
+
     alias_method :display_amount, :display_cost
 
     # shipment state machine (see http://github.com/pluginaweek/state_machine/tree/master for details)
@@ -110,7 +112,7 @@ module Spree
     # shipped    if already shipped (ie. does not change the state)
     # ready      all other cases
     def determine_state(order)
-      return 'pending' unless order.complete? || order.resumed?
+      return 'pending' unless order.can_ship?
       return 'pending' if inventory_units.any? &:backordered?
       return 'shipped' if state == 'shipped'
       order.paid? ? 'ready' : 'pending'
@@ -121,7 +123,7 @@ module Spree
         return number unless number.blank?
         record = true
         while record
-          random = "H#{Array.new(11){rand(9)}.join}"
+          random = "H#{Array.new(11) { rand(9) }.join}"
           record = self.class.where(:number => random).first
         end
         self.number = random

--- a/core/spec/models/order_spec.rb
+++ b/core/spec/models/order_spec.rb
@@ -74,6 +74,25 @@ describe Spree::Order do
     end
   end
 
+  context "#can_ship?" do
+    let(:order) { Spree::Order.create }
+
+    it "should be true for order in the 'complete' state" do
+      order.stub(:complete? => true)
+      order.can_ship?.should be_true
+    end
+
+    it "should be true for order in the 'resumed' state" do
+      order.stub(:resumed? => true)
+      order.can_ship?.should be_true
+    end
+
+    it "should be false if the order is neither in the 'complete' nor 'resumed' state" do
+      order.stub(:resumed? => false, :complete? => false)
+      order.can_ship?.should be_false
+    end
+  end
+
   context "#finalize!" do
     let(:order) { Spree::Order.create }
     it "should set completed_at" do
@@ -178,10 +197,10 @@ describe Spree::Order do
     end
   end
 
-  context "#complete?" do
-    it "should indicate if order is complete" do
+  context "#completed?" do
+    it "should indicate if order is completed" do
       order.completed_at = nil
-      order.complete?.should be_false
+      order.completed?.should be_false
 
       order.completed_at = Time.now
       order.completed?.should be_true
@@ -306,7 +325,7 @@ describe Spree::Order do
 
     before { order.stub(:line_items => [line_item]) }
 
-    it "should return line_item that has insufficent stock on hand" do
+    it "should return line_item that has insufficient stock on hand" do
       order.insufficient_stock_lines.size.should == 1
       order.insufficient_stock_lines.include?(line_item).should be_true
     end
@@ -427,7 +446,7 @@ describe Spree::Order do
         line_items.count.should == 2
 
         # No guarantee on ordering of line items, so we do this:
-        line_items.map(&:quantity).should =~ [1,1]
+        line_items.map(&:quantity).should =~ [1, 1]
         line_items.map(&:variant_id).should =~ [variant.id, variant_2.id]
       end
     end

--- a/core/spec/models/shipment_spec.rb
+++ b/core/spec/models/shipment_spec.rb
@@ -45,7 +45,11 @@ describe Spree::Shipment do
     end
 
     context "when order is incomplete" do
-      before { order.stub :complete? => false }
+      before do
+         order.stub :complete? => false
+         order.stub :resumed? => false
+      end
+
       it "should result in a 'pending' state" do
         shipment.should_receive(:update_column).with("state", "pending")
         shipment.update!(order)
@@ -71,6 +75,19 @@ describe Spree::Shipment do
       end
       it_should_behave_like "immutable once shipped"
       it_should_behave_like "pending if backordered"
+    end
+
+    context "when a paid order has been resumed" do
+      before do
+        order.stub :complete? => false
+        order.stub :resumed? => true
+        order.stub :paid? =>true
+      end
+
+      it "should result in 'ready' state" do
+        shipment.should_receive(:update_column).with("state", "ready")
+        shipment.update!(order)
+      end
     end
 
     context "when order has a credit owed" do


### PR DESCRIPTION
@radar: To respect the `tell don't ask` principle, I would like to replace
`return 'pending' unless order.complete? || order.resumed?`
with something like
`return 'pending' unless order.can_ship?` 

but  that might lead to some confusion elsewhere. Let me know what you think and I can adjust it accordingly
