### PR TITLE
strip tags from product description before truncating

### DIFF
--- a/core/app/views/spree/shared/_order_details.html.erb
+++ b/core/app/views/spree/shared/_order_details.html.erb
@@ -78,7 +78,7 @@
         </td>
         <td data-hook="order_item_description">
           <h4><%= item.variant.product.name %></h4>
-          <%= truncate(item.variant.product.description, :length => 100, :omission => "...") %>
+          <%= truncate(strip_tags(item.variant.product.description), :length => 100, :omission => "...") %>
           <%= "(" + item.variant.options_text + ")" unless item.variant.option_values.empty? %>
         </td>
         <td data-hook="order_item_price" class="price"><span><%= item.variant.display_amount %></span></td>


### PR DESCRIPTION
needed if the product description contains html tags from the richt text editor(spree_editor gem)
