### PR TITLE
Fixes PercentPerItem calculator equation

### DIFF
--- a/promo/app/models/spree/calculator/percent_per_item.rb
+++ b/promo/app/models/spree/calculator/percent_per_item.rb
@@ -30,19 +30,16 @@ module Spree
       end
     end
 
-    # Calculates the discount value of each line item. Returns zero 
-    # unless the product is included in the promotion rules.
     def value_for_line_item(line_item)
       if compute_on_promotion?
         return 0 unless matching_products.include?(line_item.product)
       end
-      line_item.price * line_item.quantity * preferred_percent
+      ((line_item.price * line_item.quantity) * preferred_percent) / 100
     end
 
     # Determines wether or not the calculable object is a promotion
     def compute_on_promotion?
       @compute_on_promotion ||= self.calculable.respond_to?(:promotion)
     end
-
   end
 end

--- a/promo/spec/models/calculator/percent_per_item_spec.rb
+++ b/promo/spec/models/calculator/percent_per_item_spec.rb
@@ -11,7 +11,7 @@ describe Spree::Calculator::PercentPerItem do
 
   let!(:promotion) { double("Promotion", :rules => [double("Rule", :products => [product1])]) }
 
-  let!(:calculator) { Spree::Calculator::PercentPerItem.new(:preferred_percent => 0.25) }
+  let!(:calculator) { Spree::Calculator::PercentPerItem.new(:preferred_percent => 25) }
 
   it "has a translation for description" do
     calculator.description.should_not include("translation missing")
@@ -20,7 +20,7 @@ describe Spree::Calculator::PercentPerItem do
 
   it "correctly calculates per item promotion" do
     calculator.stub(:calculable => promotion_calculable)
-    calculator.compute(object).to_f.should == 12.5 # 5 x 10 x 0.25 since only product1 is included in the promotion rule
+    calculator.compute(object).to_f.should == 12.5
   end
 
   it "returns 0 when no object passed" do

--- a/promo/spec/requests/promotion_adjustments_spec.rb
+++ b/promo/spec/requests/promotion_adjustments_spec.rb
@@ -169,6 +169,36 @@ describe "Promotion Adjustments" do
       Spree::Order.last.total.to_f.should == 54.00
     end
 
+    it "should allow an admin to create an product promo with percent per item discount" do
+      visit spree.admin_path
+      click_link "Promotions"
+      click_link "New Promotion"
+
+      fill_in "Name", :with => "Percent Per Item"
+      select2 "Add to cart", :from => "Event Name"
+      click_button "Create"
+      page.should have_content("Editing Promotion")
+
+      select2 "Product(s)", :from => "Add rule of type"
+      within("#rule_fields") { click_button "Add" }
+      select2_search "RoR Mug", :from => "Choose products"
+      within('#rule_fields') { click_button "Update" }
+
+      select2 "Create adjustment", :from => "Add action of type"
+      within('#action_fields') { click_button "Add" }
+      select2 "Percent Per Item", :from => "Calculator"
+      within('#actions_container') { click_button "Update" }
+      within('.calculator-fields') { fill_in "Percent", :with => "10" }
+      within('#actions_container') { click_button "Update" }
+
+      visit spree.root_path
+      click_link "RoR Mug"
+      click_button "Add To Cart"
+
+      # A $40,00 product should get a $4,00 discount
+      Spree::Order.last.total.to_f.should == 36.00
+    end
+
     it "should allow an admin to create an automatic promotion with free shipping (no code)" do
       fill_in "Name", :with => "Free Shipping"
       click_button "Create"


### PR DESCRIPTION
There's a bug when using the PercentPerItem calculator.

To reproduce:

Create a promotion with Add to Cart event. Save
Set a product rule and choose one product. Update
Set a create adjustment action. Update. Choose Percent Per Item calculator. Update
Enter **10** in the percent input. Update

Add the same product above to the cart
You should see the order total is 0.00

It happens because when creating the adjustment Spree tries to doesn't allow the discount to exceed the sum of  order total.

``` ruby
def compute_amount(calculable)
  [(calculable.item_total + calculable.ship_total), super.to_f.abs].min * -1
end
```

The compute_amount in PercentPerItem is broken because it expects input like "0.10" if you want to give 10% on every product. But I believe, as it is expected in every other calculator, input should be "10" not "0.10".

This test case can reproduce the issue. I ran it on current 1-3-stable (promo/spec/requests/promotions_adjustments_spec.rb)

``` ruby
it "should allow an admin to create an product promo with percent per item discount" do
  visit spree.admin_path
  click_link "Promotions"
  click_link "New Promotion"

  fill_in "Name", :with => "Percent Per Item"
  select2 "Add to cart", :from => "Event Name"
  click_button "Create"
  page.should have_content("Editing Promotion")

  select2 "Product(s)", :from => "Add rule of type"
  within("#rule_fields") { click_button "Add" }
  select2_search "RoR Mug", :from => "Choose products"
  within('#rule_fields') { click_button "Update" }

  select2 "Create adjustment", :from => "Add action of type"
  within('#action_fields') { click_button "Add" }
  select2 "Percent Per Item", :from => "Calculator"
  within('#actions_container') { click_button "Update" }
  within('.calculator-fields') { fill_in "Percent", :with => "10" }
  within('#actions_container') { click_button "Update" }

  visit spree.root_path
  click_link "RoR Mug"
  click_button "Add To Cart"

  Spree::Order.last.total.to_f.should == 0.00
end
```

It passes when it shouldn't. The order total should be 36.00
