### PR TITLE
Fix and improve price adjustment total rendering

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -201,15 +201,10 @@ module Spree
     # Array of totals grouped by Adjustment#label.  Useful for displaying price adjustments on an
     # invoice.  For example, you can display tax breakout for cases where tax is included in price.
     def price_adjustment_totals
-      totals = {}
-
-      price_adjustments.each do |adjustment|
-        label = adjustment.label
-        totals[label] ||= 0
-        totals[label] = totals[label] + adjustment.amount
-      end
-
-      totals
+      Hash[price_adjustments.group_by(&:label).map do |label, adjustments|
+        total = adjustments.sum(&:amount)
+        [label, Spree::Money.new(total, { :currency => currency })]
+      end]
     end
 
     def updater

--- a/core/app/views/spree/admin/shared/_order_details.html.erb
+++ b/core/app/views/spree/admin/shared/_order_details.html.erb
@@ -40,10 +40,10 @@
   </tbody>
   <% if order.price_adjustment_totals.present? %>
     <tbody id="price-adjustments" data-hook="order_details_price_adjustments">
-      <% @order.price_adjustment_totals.keys.each do |key| %>
+      <% @order.price_adjustment_totals.each do |label, total| %>
         <tr>
-          <td colspan="3"><strong><%= key %></strong></td>
-          <td class="total"><span><%= @order.price_adjustment_totals[key].display_amount %></span></td>
+          <td colspan="3"><strong><%= label %></strong></td>
+          <td class="total"><span><%= total %></span></td>
         </tr>
       <% end %>
     </tbody>

--- a/core/app/views/spree/checkout/_summary.html.erb
+++ b/core/app/views/spree/checkout/_summary.html.erb
@@ -21,10 +21,10 @@
     </tr>
     <% if order.price_adjustment_totals.present? %>
       <tbody id="price-adjustments" data-hook="order_details_price_adjustments">
-        <% @order.price_adjustment_totals.keys.each do |key| %>
+        <% @order.price_adjustment_totals.each do |label, total| %>
           <tr class="total">
-            <td><strong><%= key %></strong></td>
-            <td><strong><span><%= @order.price_adjustment_totals[key].display_total %></span></strong></td>
+            <td><strong><%= label %></strong></td>
+            <td><strong><span><%= total %></span></strong></td>
           </tr>
         <% end %>
       </tbody>

--- a/core/app/views/spree/shared/_order_details.html.erb
+++ b/core/app/views/spree/shared/_order_details.html.erb
@@ -95,10 +95,10 @@
   </tfoot>
   <% if order.price_adjustment_totals.present? %>
     <tfoot id="price-adjustments" data-hook="order_details_price_adjustments">
-      <% @order.price_adjustment_totals.keys.each do |key| %>
+      <% @order.price_adjustment_totals.each do |key, total| %>
         <tr class="total">
           <td colspan="4"><strong><%= key %></strong></td>
-          <td class="total"><span><%= @order.price_adjustment_totals[key].display_amount %></span></td>
+          <td class="total"><span><%= total %></span></td>
         </tr>
       <% end %>
     </tfoot>

--- a/core/spec/models/order/adjustments_spec.rb
+++ b/core/spec/models/order/adjustments_spec.rb
@@ -65,8 +65,8 @@ describe Spree::Order do
       end
 
       it "should return the correct totals" do
-        @order.price_adjustment_totals["Foo"].should == 10
-        @order.price_adjustment_totals["Bar"].should == 20
+        @order.price_adjustment_totals["Foo"].should == Spree::Money.new(10)
+        @order.price_adjustment_totals["Bar"].should == Spree::Money.new(20)
       end
     end
 
@@ -83,8 +83,8 @@ describe Spree::Order do
         @order.price_adjustment_totals.size.should == 2
       end
       it "should return the correct totals" do
-        @order.price_adjustment_totals["Foo"].should == 10
-        @order.price_adjustment_totals["Bar"].should == 60
+        @order.price_adjustment_totals["Foo"].should == Spree::Money.new(10)
+        @order.price_adjustment_totals["Bar"].should == Spree::Money.new(60)
       end
     end
   end


### PR DESCRIPTION
`Order.price_adjustment_totals` returned a hash of labels to BigDecimal amounts. Views were incorrectly calling .display_amount on BigDecimal, raising an exception.

This changes price_adjustment_totals to return Money objects rather than BigDecimals, and fixes the views.

This should also be merged in to 1-3-stable.
