### PR TITLE
Fix issue #2341

### DIFF
--- a/core/app/views/spree/products/_cart_form.html.erb
+++ b/core/app/views/spree/products/_cart_form.html.erb
@@ -37,7 +37,7 @@
         <div class="add-to-cart">
           <% if @product.on_sale? %>      
             <%= number_field_tag (@product.has_variants? ? :quantity : "variants[#{@product.master.id}]"),
-              1, :class => 'title', :in => 1..@product.on_hand, :min => 1 %>
+              1, :class => 'title' %>
             <%= button_tag :class => 'large primary', :id => 'add-to-cart-button', :type => :submit do %>
               <%= t(:add_to_cart) %>
             <% end %>


### PR DESCRIPTION
Remove HTML5 style input number validation because it is not yet supported by IE and Firefox.

Spree should behave consistent in major browsers. (#2341)

Html5 input validation support reference:
http://www.w3schools.com/html/html5_form_input_types.asp
