### PR TITLE
use ruby 1.8 hashrocket syntax in controller_helpers/order.rb

### DIFF
--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -28,7 +28,7 @@ module Spree
             @current_order = current_order unless current_order.try(:completed?)
           end
           if create_order_if_necessary and (@current_order.nil? or @current_order.completed?)
-            @current_order = Spree::Order.new(currency: current_currency)
+            @current_order = Spree::Order.new(:currency => current_currency)
             before_save_new_order
             @current_order.save!
             after_save_new_order


### PR DESCRIPTION
whoops. A 1.9 hash snuck in here.
