### PR TITLE
fix inline javascript for address state elements

### DIFF
--- a/core/app/views/spree/address/_form.html.erb
+++ b/core/app/views/spree/address/_form.html.erb
@@ -50,7 +50,7 @@
          ].join.gsub('"', "'").gsub("\n", "")
       %>
       <%= javascript_tag do -%>
-        document.write("<%== state_elements %>");
+        $('#<%="#{address_id}state" %>').append("<%== state_elements %>");
       <% end %>
     </p>
       <noscript>


### PR DESCRIPTION
I'm trying to changing spree checkout steps to one page checkout using ajax calls to move from a step to another. 

Everything seems feasible but there's a problem with actual code trying to call address/_form partial via ajax call. The problem is with `document.write` that can be only used when DOM is not fully loaded or it will replace all body content. Some references to this issue: [1](http://stackoverflow.com/questions/2360076/javascript-document-write-replaces-all-body-content-when-using-ajax), [2](http://stackoverflow.com/questions/7509341/document-write-and-ajax-doesnt-work-looking-for-an-alternative), [3](https://groups.google.com/forum/?fromgroups=#!topic/jquery-en/tzu5n5k8Jp4)

This commit should solve the problem since it's now working for me.
