### PR TITLE
Fixed issue with duplicate thumbnails on ProductController#show

### DIFF
--- a/core/app/views/spree/products/_thumbnails.html.erb
+++ b/core/app/views/spree/products/_thumbnails.html.erb
@@ -1,16 +1,16 @@
-<!-- no need for thumnails unless there is more then one image -->
-<% if product.images.size > 1 || product.variant_images.size > 0 %>
+<%# no need for thumnails unless there is more then one image %>
+<% if (@product.images + @product.variant_images).uniq.size > 1 %>
   <ul id="product-thumbnails" class="thumbnails inline" data-hook>
-    <% product.images.each do |i| %>
-      <li class="tmb-all" id="tmb-<%= i.id.to_s %>"><%= link_to image_tag(i.attachment.url(:mini)), i.attachment.url(:product) %></li>
-    <% end %>
-    <% if @product.has_variants?
-      @variants.each do |v|
-        if v.available?
-          v.images.each do |i| %>
-            <li class="vtmb-<%= v.id.to_s %> vtmb" id="tmb-<%= i.id.to_s %>"><%= link_to image_tag(i.attachment.url(:mini)), i.attachment.url(:product) %></li>
-          <%
-          end
+    <%
+    @product.images.each do |i|
+      concat(content_tag(:li, link_to(image_tag(i.attachment.url(:mini)), i.attachment.url(:product)), :class => 'tmb-all', :id => "tmb-#{i.id}"))
+    end
+
+    if @product.has_variants?
+      @variants.select(&:available?).each do |v|
+        v.images.each do |i|
+          next if @product.images.include? i
+          concat(content_tag(:li, link_to(image_tag(i.attachment.url(:mini)), i.attachment.url(:product)), :class => "vtmb-#{v.id} vtmb", :id => "tmb-#{i.id}"))
         end
       end
     end

--- a/core/app/views/spree/products/show.html.erb
+++ b/core/app/views/spree/products/show.html.erb
@@ -9,7 +9,7 @@
           <%= render :partial => 'image' %>
         </div>
         <div id="thumbnails" data-hook>
-          <%= render :partial => 'thumbnails', :locals => { :product => @product } %>
+          <%= render :partial => 'thumbnails' %>
         </div>
       </div>
 


### PR DESCRIPTION
Spree 1.1.4 changes the way thumbnails were displayed. I didn't look into what exactly changed, but I think `Product#images` and `Product#variant_images` both returned the master variant image. This makes sense, but the thumbnail's partial was not updated to reflect this – in my case I was getting duplicate thumbnail display. This PR fixed the duplicate thumbnail display issue and cleans up the thumbnails partial.

Also, there were references to both `@product` and `product`, I switched to using the instance variable for consistency's sake.

This applies to master, 1-2-stable, and 1-1-stable.
