### PR TITLE
Fix bugs in  Spree::Admin::TaxSettingsController

### DIFF
--- a/core/app/controllers/spree/admin/tax_settings_controller.rb
+++ b/core/app/controllers/spree/admin/tax_settings_controller.rb
@@ -7,7 +7,7 @@ module Spree
 
         respond_to do |format|
           format.html {
-            redirect_to admin_tax_settings_path
+            redirect_to edit_admin_tax_settings_path
           }
         end
       end

--- a/core/app/views/spree/admin/tax_settings/edit.html.erb
+++ b/core/app/views/spree/admin/tax_settings/edit.html.erb
@@ -6,9 +6,10 @@
 
 <%= form_tag admin_tax_settings_path, :method => :put do %>
   <div data-hook="shipment_vat" class="field align-center">
+    <%= hidden_field_tag 'preferences[shipment_inc_vat]', '0' %>
     <%= check_box_tag 'preferences[shipment_inc_vat]', '1',  Spree::Config[:shipment_inc_vat] %>
     <%= label_tag nil, t(:shipment_inc_vat) %>    
-    <%= hidden_field_tag 'preferences[shipment_inc_vat]', '0' %>    
+
   </div>
 
   <div class="form-buttons" data-hook="buttons">


### PR DESCRIPTION
Hi

I'm fixing 2 small bugs, first is error The action 'show' could not be found for Spree::Admin::TaxSettingsController and second is the problem with hidden input, which overrides the value from check-box user entry.

Martin
