### PR TITLE
fix #2347 fluid images for product

### DIFF
--- a/core/app/assets/stylesheets/store/screen.css.scss
+++ b/core/app/assets/stylesheets/store/screen.css.scss
@@ -488,6 +488,10 @@ mark {background-color: $link_text_color; color: $layout_background_color; font-
           border-color: $link_text_color;
         }
 
+        img {
+          max-width: 100%; /* Fluid images for product */
+        }
+
       }
 
       .price {
@@ -542,6 +546,7 @@ mark {background-color: $link_text_color; color: $layout_background_color; font-
 
       img {
         min-height: 240px;
+        max-width: 100%; /* Fluid images for product */
       }
     }
     #product-thumbnails {


### PR DESCRIPTION
set max-width for product image on products page and on detail page. this will fit the image according to its container.
