### PR TITLE
Perfomance improvement and fixes return value in promotion#products

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -476,7 +476,7 @@ module Spree
     end
 
     def products
-      line_items.map { |li| li.variant.product }
+      line_items.map { |li| li.product }
     end
 
     def variants

--- a/core/spec/models/order_spec.rb
+++ b/core/spec/models/order_spec.rb
@@ -24,8 +24,8 @@ describe Spree::Order do
     before :each do
       @variant1 = mock_model(Spree::Variant, :product => "product1")
       @variant2 = mock_model(Spree::Variant, :product => "product2")
-      @line_items = [mock_model(Spree::LineItem, :variant => @variant1, :variant_id => @variant1.id, :quantity => 1),
-                     mock_model(Spree::LineItem, :variant => @variant2, :variant_id => @variant2.id, :quantity => 2)]
+      @line_items = [mock_model(Spree::LineItem, :product => "product1", :variant => @variant1, :variant_id => @variant1.id, :quantity => 1),
+                     mock_model(Spree::LineItem, :product => "product2", :variant => @variant2, :variant_id => @variant2.id, :quantity => 2)]
       order.stub(:line_items => @line_items)
     end
 

--- a/promo/app/models/spree/promotion.rb
+++ b/promo/app/models/spree/promotion.rb
@@ -79,7 +79,7 @@ module Spree
     # Products assigned to all product rules
     def products
       @products ||= self.rules.all.inject([]) do |products, rule|
-        products << rule.products if rule.respond_to?(:products)
+        rule.respond_to?(:products) ? products << rule.products : products
       end.flatten.uniq
     end
 

--- a/promo/spec/models/promotion_spec.rb
+++ b/promo/spec/models/promotion_spec.rb
@@ -39,7 +39,6 @@ describe Spree::Promotion do
       @valid_promotion.name = nil
       @valid_promotion.should_not be_valid
     end
-
   end
 
   describe ".advertised" do
@@ -69,7 +68,6 @@ describe Spree::Promotion do
 
       Spree::PromotionRule.count.should == 0
     end
-
   end
 
   describe "#activate" do
@@ -174,9 +172,9 @@ describe Spree::Promotion do
   end
 
   context "#products" do
-    context "when it has product rules with products associated" do
-      let(:promotion) { create(:promotion) }
+    let(:promotion) { create(:promotion) }
 
+    context "when it has product rules with products associated" do
       before do
         promotion_rule = Spree::Promotion::Rules::Product.new
         promotion_rule.promotion = promotion
@@ -186,6 +184,16 @@ describe Spree::Promotion do
 
       it "should have products" do
         promotion.products.size.should == 1
+      end
+    end
+
+    context "when there's no product rule associated" do
+      before(:each) do
+        promotion.stub_chain(:rules, :all).and_return([mock_model(Spree::Promotion::Rules::User)])
+      end
+
+      it "should not have products but still return an empty array" do
+        promotion.products.should be_blank
       end
     end
   end
@@ -227,7 +235,6 @@ describe Spree::Promotion do
         promotion.should be_eligible(@order)
       end
     end
-
   end
 
   context "rules" do
@@ -268,7 +275,5 @@ describe Spree::Promotion do
         @promotion.rules_are_eligible?(@order).should be_true
       end
     end
-
   end
-
 end


### PR DESCRIPTION
I changed `promotion#products` in #2363 and today I realized that there might be situations where the block would return `nil` to `flatten`.  Sorry about that. I don't think it currently breaks anything in Spree core but it may lead to issues when folks try to implement their custom promotion rules / actions.

I'm also wondering why the promo specs takes so much time to run. promotion_spec.rb takes over 3 minutes to run inside Spree repo while the same spec takes less than 10 seconds to run in our custom store. Maybe I'm missing something.
