### PR TITLE
allow overriding of phone validation

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -5,7 +5,8 @@ module Spree
 
     has_many :shipments
 
-    validates :firstname, :lastname, :address1, :city, :zipcode, :country, :phone, :presence => true
+    validates :firstname, :lastname, :address1, :city, :zipcode, :country, :presence => true
+    validates :phone, :presence => true, :if => :require_phone?
     validate :state_validate
 
     attr_accessible :firstname, :lastname, :address1, :address2,
@@ -85,6 +86,10 @@ module Spree
     end
 
     private
+
+      def require_phone?
+        true
+      end
 
       def state_validate
         # Skip state validation without country (also required)

--- a/core/spec/models/address_spec.rb
+++ b/core/spec/models/address_spec.rb
@@ -137,6 +137,13 @@ describe Spree::Address do
       address.errors["phone"].should == ["can't be blank"]
     end
 
+    it "require_phone? returns false and phone is blank" do
+      Spree::Config.set :address_requires_state => false
+      address.instance_eval{ self.stub :require_phone? => false }
+      address.phone = ""
+      address.should be_valid
+    end
+
   end
 
   context ".default" do

--- a/core/spec/models/address_spec.rb
+++ b/core/spec/models/address_spec.rb
@@ -125,6 +125,18 @@ describe Spree::Address do
       address.should be_valid
     end
 
+    it "phone is set" do
+      Spree::Config.set :address_requires_state => false
+      address.phone = "123"
+      address.should be_valid
+    end
+
+    it "phone is blank" do
+      address.phone = ""
+      address.valid?
+      address.errors["phone"].should == ["can't be blank"]
+    end
+
   end
 
   context ".default" do
@@ -188,6 +200,10 @@ describe Spree::Address do
       let(:address) { stub_model(Spree::Address, :state => state) }
       specify { address.state_text.should == 'virginia' }
     end
+  end
 
+  context "defines require_phone? helper method" do
+    let(:address) { stub_model(Spree::Address) }
+    specify { address.instance_eval{ require_phone? }.should be_true}
   end
 end


### PR DESCRIPTION
Validate presence of `phone` attribute only if `require_phone?` returns true.

This allows for disabling phone validation in a decorator. 

In my case I use it to only validate `bill_address.phone`.

I’ve seen the issue of overriding phone validation around in the mailing list a few times, so I think this would be useful for others as well and should be integrated intro spree/core.
