### PR TITLE
use on_hand method to get on_hand for variant while populating order so ...

### DIFF
--- a/core/app/models/spree/order_populator.rb
+++ b/core/app/models/spree/order_populator.rb
@@ -51,10 +51,10 @@ module Spree
       display_name += %Q{ (#{variant.options_text})} unless variant.options_text.blank?
 
       if variant.in_stock?
-        if variant.count_on_hand >= quantity
+        if variant.on_hand >= quantity
           return true
         else
-          errors.add(:base, %Q{There are only #{variant.count_on_hand} of #{display_name.inspect} remaining.} + 
+          errors.add(:base, %Q{There are only #{variant.on_hand} of #{display_name.inspect} remaining.} + 
                             %Q{ Please select a quantity less than or equal to this value.})
           return false
         end

--- a/core/spec/models/order_populator_spec.rb
+++ b/core/spec/models/order_populator_spec.rb
@@ -30,11 +30,11 @@ describe Spree::OrderPopulator do
       end
 
       context "when :track_inventory_levels is true" do
+        before { Spree::Config.set :track_inventory_levels => true }
 
         it "should add an error if the variant does not have enough stock on hand" do
-          variant.stub :in_stock? => true
-          variant.stub :on_hand => 2
-
+          variant.should_receive(:in_stock?).and_return(true)
+          variant.should_receive(:on_hand).twice.and_return(2)
           order.should_not_receive(:add_variant)
           subject.populate(:products => { 1 => 2 }, :quantity => 3)
           subject.should_not be_valid
@@ -46,11 +46,11 @@ describe Spree::OrderPopulator do
       end
 
       context "when :track_inventory_levels is false" do
+        before { Spree::Config.set :track_inventory_levels => false }
 
-        it "should return nil" do
-          variant.stub :in_stock? => true
-          variant.stub :on_hand => (1.0/0) # Infinity when :track_inventory_levels is false
-
+        it "can add any number of products to order regardless of on_hand" do
+          variant.should_receive(:in_stock?).and_return(true)
+          variant.should_receive(:on_hand).and_return((1.0 / 0))
           order.should_receive(:add_variant)
           subject.populate(:products => { 1 => 2 }, :quantity => 3000)
           subject.should be_valid

--- a/core/spec/models/order_populator_spec.rb
+++ b/core/spec/models/order_populator_spec.rb
@@ -29,17 +29,35 @@ describe Spree::OrderPopulator do
         subject.errors.full_messages.join("").should == %Q{"T-Shirt (Size: M)" is out of stock.}
       end
 
-      it "should add an error if the variant does not have enough stock on hand" do
-        variant.stub :in_stock? => true
-        variant.stub :count_on_hand => 2
+      context "when :track_inventory_levels is true" do
 
-        order.should_not_receive(:add_variant)
-        subject.populate(:products => { 1 => 2 }, :quantity => 3)
-        subject.should_not be_valid
-        output = %Q{There are only 2 of \"T-Shirt (Size: M)\" remaining.} +
-                 %Q{ Please select a quantity less than or equal to this value.}
-        subject.errors.full_messages.join("").should == output
+        it "should add an error if the variant does not have enough stock on hand" do
+          variant.stub :in_stock? => true
+          variant.stub :on_hand => 2
+
+          order.should_not_receive(:add_variant)
+          subject.populate(:products => { 1 => 2 }, :quantity => 3)
+          subject.should_not be_valid
+          output = %Q{There are only 2 of \"T-Shirt (Size: M)\" remaining.} +
+                   %Q{ Please select a quantity less than or equal to this value.}
+          subject.errors.full_messages.join("").should == output
+        end
+
       end
+
+      context "when :track_inventory_levels is false" do
+
+        it "should return nil" do
+          variant.stub :in_stock? => true
+          variant.stub :on_hand => (1.0/0) # Infinity when :track_inventory_levels is false
+
+          order.should_receive(:add_variant)
+          subject.populate(:products => { 1 => 2 }, :quantity => 3000)
+          subject.should be_valid
+        end
+
+      end
+
     end
 
     context "with variant parameters" do


### PR DESCRIPTION
...that :track_inventory_levels is taken into consideration. [Fixes #2379]
