### PR TITLE
fixes saving permalinks when using joins and includes

### DIFF
--- a/core/lib/spree/core/permalinks.rb
+++ b/core/lib/spree/core/permalinks.rb
@@ -42,7 +42,7 @@ module Spree
       def save_permalink(permalink_value=self.to_param)
         field = self.class.permalink_field
           # Do other links exist with this permalink?
-          other = self.class.where("#{field} LIKE ?", "#{permalink_value}%")
+          other = self.class.where("#{self.class.table_name}.#{field} LIKE ?", "#{permalink_value}%")
           if other.any?
             # Find the existing permalink with the highest number, and increment that number.
             # (If none of the existing permalinks have a number, this will evaluate to 1.)


### PR DESCRIPTION
When using products with:

``` ruby
Spree::Product.class_eval do
  default_scope includes(:taxons)
end
```

Saving a product will throw an exception: `ambiguous column name: permalink`.
This is because in `core/lib/spree/core/permalinks.rb` the `save_permalink` method runs a where query without the table_name.

This pull request should fix that.
