### PR TITLE
Removes useless call to order#update!

### DIFF
--- a/promo/app/models/spree/promotion/actions/create_adjustment.rb
+++ b/promo/app/models/spree/promotion/actions/create_adjustment.rb
@@ -1,27 +1,36 @@
 module Spree
   class Promotion
     module Actions
+      # Responsible for the creation and management of an adjustment since an
+      # an adjustment uses its originator to also update its eligiblity and amount
       class CreateAdjustment < PromotionAction
         calculated_adjustments
+
+        has_many :adjustments, :as => :originator, :dependent => :destroy
 
         delegate :eligible?, :to => :promotion
 
         before_validation :ensure_action_has_calculator
 
+        # Creates the adjustment related to a promotion for the order passed
+        # through options hash
         def perform(options = {})
-          return unless order = options[:order]
-          # Nothing to do if the promotion is already associated with the order
-          return if order.promotion_credit_exists?(promotion)
+          order = options[:order]
+          return if order.promotion_credit_exists?(self.promotion)
 
-          order.adjustments.promotion.reload.clear
-          order.update!
-          create_adjustment("#{I18n.t(:promotion)} (#{promotion.name})", order, order)
-          order.update!
+          self.create_adjustment("#{I18n.t(:promotion)} (#{promotion.name})", order, order)
         end
 
-        # override of CalculatedAdjustments#create_adjustment so promotional
-        # adjustments are added all the time. They will get their eligability
-        # set to false if the amount is 0
+        # Override of CalculatedAdjustments#create_adjustment so promotional
+        # adjustments are added all the time. They will get their eligibility
+        # set to false if the amount is 0.
+        #
+        # Currently an adjustment is created even when its promotion is not eligible.
+        # This helps to figure out later which adjustments should be eligible
+        # as the order is being updated
+        #
+        # BTW The order is updated (through order#update) every time an adjustment
+        # is saved
         def create_adjustment(label, target, calculable, mandatory=false)
           amount = compute_amount(calculable)
           params = { :amount => amount,
@@ -32,7 +41,8 @@ module Spree
           target.adjustments.create(params, :without_protection => true)
         end
 
-        # Ensure a negative amount which does not exceed the sum of the order's item_total and ship_total
+        # Ensure a negative amount which does not exceed the sum of the order's
+        # item_total and ship_total
         def compute_amount(calculable)
           [(calculable.item_total + calculable.ship_total), super.to_f.abs].min * -1
         end

--- a/promo/spec/models/promotion/actions/create_adjustment_spec.rb
+++ b/promo/spec/models/promotion/actions/create_adjustment_spec.rb
@@ -7,17 +7,15 @@ describe Spree::Promotion::Actions::CreateAdjustment do
 
   # From promotion spec:
   context "#perform" do
-
     before do
       action.calculator = Spree::Calculator::FreeShipping.new
       promotion.promotion_actions = [action]
       action.stub(:promotion => promotion)
     end
 
-
-    it "should create a discount with correct negative amount when order is eligible" do
-      order.stub(:ship_total => 2500, :item_total => 5000, :reload => nil)
-      promotion.stub(:eligible? => true)
+    it "should create a discount with correct negative amount" do
+      order = create(:line_item, price: 5000).order
+      order.stub(:ship_total => 2500)
 
       action.perform(:order => order)
       promotion.credits_count.should == 1
@@ -34,7 +32,6 @@ describe Spree::Promotion::Actions::CreateAdjustment do
       action.perform(:order => order)
       promotion.credits_count.should == 1
     end
-
   end
 
   context "#compute_amount" do


### PR DESCRIPTION
The only reason I could see for those to be there is to make a test
pass. But the problem was on the test itself due to the way stubs work.
Also add some doc blocks to CreateAdjustment class.

By the time update_totals is called the order item_total would be 0 again because the order in that test has no line items. I hope that helps understanding why that test failed when the order#update! calls were removed. This was really confusing to figure out. After 20 min running the promo tests I got a green build so we should be still good after this.

Every time an adjustment is saved the order#update! is called so there's no need to call it before and after a promo adjustment is created.

I also added a missing association to make it clear that this class is associated with adjustments through an originator.

If I missed any reason for having two calls for order#update! around `create_adjustment` please let me know.
