### PR TITLE
Prototype properties ordering behavior and select fix.

### DIFF
--- a/core/app/models/spree/property.rb
+++ b/core/app/models/spree/property.rb
@@ -9,8 +9,6 @@ module Spree
 
     validates :name, :presentation, :presence => true
 
-    scope :sorted
-
     def self.find_all_by_prototype(prototype)
       id = prototype
       if prototype.class == Prototype

--- a/core/app/models/spree/property.rb
+++ b/core/app/models/spree/property.rb
@@ -9,7 +9,7 @@ module Spree
 
     validates :name, :presentation, :presence => true
 
-    scope :sorted, lambda { order(:name) }
+    scope :sorted
 
     def self.find_all_by_prototype(prototype)
       id = prototype

--- a/core/app/views/spree/admin/prototypes/_form.html.erb
+++ b/core/app/views/spree/admin/prototypes/_form.html.erb
@@ -11,7 +11,7 @@
     <div id='properties' data-hook>
       <%= f.field_container :property_ids do %>
         <%= f.label :property_ids, t(:properties) %><br>
-        <%= f.select :property_ids, Spree::Property.sorted.map { |p| [p.presentation, p.id] }, {}, { :multiple => true, :class => "select2 fullwidth" } %>
+        <%= f.select :property_ids, Spree::Property.all.map { |p| [p.presentation, p.id] }, {}, { :multiple => true, :class => "select2 fullwidth" } %>
       <% end %>
     </div>
   </div>

--- a/core/app/views/spree/admin/prototypes/select.js.erb
+++ b/core/app/views/spree/admin/prototypes/select.js.erb
@@ -1,4 +1,4 @@
-<% @prototype_properties.each do |prop| %>
+<% @prototype_properties.sort_by{|id| -id[:id]}.each do |prop| %>
   $("a.add_fields").click();
-  $(".product_property.fields:last input:first").val("<%= prop.name %>");
+  $(".product_property.fields:first input:first").val("<%= prop.name %>");
 <% end %>

--- a/core/app/views/spree/admin/prototypes/select.js.erb
+++ b/core/app/views/spree/admin/prototypes/select.js.erb
@@ -1,4 +1,4 @@
-<% @prototype_properties.sort_by{|id| -id[:id]}.each do |prop| %>
+<% @prototype_properties.sort_by{ |prop| -prop[:id] }.each do |prop| %>
   $("a.add_fields").click();
   $(".product_property.fields:first input:first").val("<%= prop.name %>");
 <% end %>


### PR DESCRIPTION
Hi all,

This is more or less two issues (behavior+fix) in one which I believe are related.

Firstly, there is a bug in product properties when selecting a prototype. It will only populate the last field and the rest of the fields will be blank. We just needed to change :last to :first selector.

Secondly, when creating a new prototype and populating them with properties, then updating (saving), the order in which they were added will be lost and they will be ordered by name. IMHO, this defeats the purpose of prototype properties, as most people will want to have them in a particular order as they were added, especially if there are many of them. So I removed the name order for properties, and also added some sorting logic to select.js.erb so that they are properly populated in the correct order.

I am not sure if this is an elegant fix, but it has been working perfectly for me, and I believe makes it more consistent in behavior.

Looking forward to feedback on this.

Thanks!
