### PR TITLE
Allows old orders to get promo adjustments

### DIFF
--- a/promo/app/models/spree/promotion.rb
+++ b/promo/app/models/spree/promotion.rb
@@ -71,9 +71,7 @@ module Spree
     end
 
     def order_activatable?(order)
-      order &&
-      created_at.to_i < order.created_at.to_i &&
-      !UNACTIVATABLE_ORDER_STATES.include?(order.state)
+      order && !UNACTIVATABLE_ORDER_STATES.include?(order.state)
     end
 
     # Products assigned to all product rules

--- a/promo/spec/models/promotion_spec.rb
+++ b/promo/spec/models/promotion_spec.rb
@@ -111,8 +111,8 @@ describe Spree::Promotion do
       promotion.activate(@payload)
     end
 
-    it "does not activate if newer then order" do
-      @action1.should_not_receive(:perform).with(@payload)
+    it "does activate if newer then order" do
+      @action1.should_receive(:perform).with(@payload)
       promotion.created_at = DateTime.now + 2
       promotion.activate(@payload)
     end
@@ -211,13 +211,11 @@ describe Spree::Promotion do
 
     context "when it is expired" do
       before { promotion.stub(:expired? => true) }
-
       specify { promotion.should_not be_eligible(@order) }
     end
 
     context "when it is not expired" do
       before { promotion.expires_at = Time.now + 1.day }
-
       specify { promotion.should be_eligible(@order) }
     end
 


### PR DESCRIPTION
UNACTIVATABLE_ORDER_STATES already covers scenarios where a promo should
not be applied to an order

Fixes #2388

Made the change and updated a test case. I didn't run the all tests locally because the promo test suite is unbelievable slow in my machine. Let's see if all goes fine.
