### PR TITLE
Truncate product description when used as meta description

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -56,7 +56,7 @@ module Spree
       end
 
       if meta[:description].blank? && object.kind_of?(Spree::Product)
-        meta[:description] = strip_tags(object.description)
+        meta[:description] = strip_tags(truncate(object.description, :length => 160, :separator => ' '))
       end
 
       meta.reverse_merge!({


### PR DESCRIPTION
I ran into some nastiness on a product with a very verbose description, which was being used as the content of the meta description in the header. I googled this up for a reasonable limit:
http://www.seomoz.org/learn-seo/meta-description

It says 155, so this truncates at 160 with `separator => ' '` so we don't truncate mid-word and truncations should end up with a max of _approximately_ 155.
