### PR TITLE
Date format in datepicker fields

### DIFF
--- a/core/app/helpers/spree/admin/base_helper.rb
+++ b/core/app/helpers/spree/admin/base_helper.rb
@@ -22,6 +22,14 @@ module Spree
         end
       end
 
+      def datepicker_field_value(date)
+        unless date.blank?
+          l(date, :format => t('spree.date_picker.format'))
+        else
+          nil
+        end
+      end
+
       # This method demonstrates the use of the :child_index option to render a
       # form partial for, for instance, client side addition of new nested
       # records.

--- a/core/app/views/spree/admin/products/_form.html.erb
+++ b/core/app/views/spree/admin/products/_form.html.erb
@@ -47,12 +47,7 @@
     <%= f.field_container :available_on do %>
       <%= f.label :available_on, t(:available_on) %>
       <%= f.error_message_on :available_on %>
-      <% if @product.available_on? %>
-        <% available_on = l(@product.available_on, :format => t('spree.date_picker.format')) %>
-      <% else %>
-        <% available_on = nil %>
-      <% end %>
-      <%= f.text_field :available_on, :value => available_on, :class => 'datepicker' %>
+      <%= f.text_field :available_on, :value => datepicker_field_value(@product.available_on), :class => 'datepicker' %>
     <% end %>
 
     <% unless @product.has_variants? %>

--- a/core/spec/helpers/admin/base_helper_spec.rb
+++ b/core/spec/helpers/admin/base_helper_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Spree::Admin::BaseHelper do
+  include Spree::Admin::BaseHelper
+
+  context "#datepicker_field_value" do
+    it "should return nil when date is empty" do
+      date = nil
+      datepicker_field_value(date).should be_nil
+    end
+
+    it "should return a formatted date when date is present" do
+      date = Time.new(2013,8,14)
+      datepicker_field_value(date).should == "2013/08/14"
+    end
+  end
+
+end

--- a/core/spec/requests/admin/products/edit/products_spec.rb
+++ b/core/spec/requests/admin/products/edit/products_spec.rb
@@ -5,10 +5,9 @@ describe 'Product Details' do
   stub_authorization!
 
   context 'editing a product' do
-    let(:available_on) { Time.now }
     it 'should list the product details' do
       create(:product, :name => 'Bún thịt nướng', :permalink => 'bun-thit-nuong', :sku => 'A100',
-              :description => 'lorem ipsum', :available_on => available_on, :count_on_hand => 10)
+              :description => 'lorem ipsum', :available_on => '2013-08-14 01:02:03', :count_on_hand => 10)
 
       visit spree.admin_path
       click_link 'Products'
@@ -22,7 +21,7 @@ describe 'Product Details' do
       find('textarea#product_description').text.strip.should == 'lorem ipsum'
       find('input#product_price').value.should == '19.99'
       find('input#product_cost_price').value.should == '17.00'
-      find('input#product_available_on').value.should_not be_blank
+      find('input#product_available_on').value.should == "2013/08/14"
       find('input#product_sku').value.should == 'A100'
     end
 

--- a/promo/app/views/spree/admin/promotions/_form.html.erb
+++ b/promo/app/views/spree/admin/promotions/_form.html.erb
@@ -50,7 +50,7 @@
 
     <div id="expires_at_field" class="field">
       <%= f.label :expires_at %>
-      <%= f.text_field :expires_at, :value => datepicker_field_value(@promotion.expires_at), :class => 'datepicker datepicker-top fullwidth' %>
+      <%= f.text_field :expires_at, :value => datepicker_field_value(@promotion.expires_at), :class => 'datepicker datepicker-to fullwidth' %>
     </div>  
   </div>
 </div>

--- a/promo/app/views/spree/admin/promotions/_form.html.erb
+++ b/promo/app/views/spree/admin/promotions/_form.html.erb
@@ -45,12 +45,12 @@
     
     <div id="starts_at_field" class="field">
       <%= f.label :starts_at %>
-      <%= f.text_field :starts_at, :class => 'datepicker datepicker-from fullwidth' %>
+      <%= f.text_field :starts_at, :value => datepicker_field_value(@promotion.starts_at), :class => 'datepicker datepicker-from fullwidth' %>
     </div>
 
     <div id="expires_at_field" class="field">
       <%= f.label :expires_at %>
-      <%= f.text_field :expires_at, :class => 'datepicker datepicker-top fullwidth' %>
+      <%= f.text_field :expires_at, :value => datepicker_field_value(@promotion.expires_at), :class => 'datepicker datepicker-top fullwidth' %>
     </div>  
   </div>
 </div>

--- a/promo/spec/requests/promotions_spec.rb
+++ b/promo/spec/requests/promotions_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe "Promotions" do
+  stub_authorization!
+
+  context 'editing a promotion' do
+    it 'should show correct field values' do
+      create(:promotion, :name => 'Promo', :starts_at => '2013-08-14 01:02:03',
+              :expires_at => '2013-08-15 01:02:03')
+
+      visit spree.admin_path
+      click_link 'Promotions'
+      within_row(1) { click_icon :edit }
+
+      find('input#promotion_name').value.should == 'Promo'
+      find('input#promotion_starts_at').value.should == '2013/08/14'
+      find('input#promotion_expires_at').value.should == '2013/08/15'
+    end
+
+  end
+end


### PR DESCRIPTION
Introduced `datepicker_field_value(date)` helper method for datepicker fields.

Used this method in `admin/products/_form` and `admin/promotions/_form`
