### PR TITLE
make new product button always visible on edit product page on admin sid...

### DIFF
--- a/core/app/views/spree/admin/products/edit.html.erb
+++ b/core/app/views/spree/admin/products/edit.html.erb
@@ -1,5 +1,8 @@
 <% content_for :page_actions do %>
   <li><%= button_link_to t(:back_to_products_list), admin_products_url, :icon => 'icon-arrow-left' %></li>
+  <li id="new_product_link">
+    <%= button_link_to t(:new_product), new_object_url, { :remote => true, :icon => 'icon-plus', :id => 'admin_new_product' } %>
+  </li>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/product_sub_menu' %>


### PR DESCRIPTION
...e. found that it will be very useful when entering products through admin side. this will allow use to quickly navigate to new product page after adding new one without going back to product list
