### PR TITLE
Fix duplicate result if name contains SKU

### DIFF
--- a/core/app/controllers/spree/admin/products_controller.rb
+++ b/core/app/controllers/spree/admin/products_controller.rb
@@ -108,7 +108,7 @@ module Spree
 
             tmp = super.where(["#{Variant.table_name}.sku #{LIKE} ?", "%#{params[:q]}%"])
             tmp = tmp.includes(:variants_including_master).limit(params[:limit] || 10)
-            @collection.concat(tmp)
+            @collection.concat(tmp).uniq!
           end
           @collection
         end

--- a/core/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/core/spec/controllers/spree/admin/products_controller_spec.rb
@@ -51,6 +51,13 @@ describe Spree::Admin::ProductsController do
       assigns[:collection].should_not be_empty
       assigns[:collection].should include(product)
     end
+
+    it "should not return duplicate results if name contains SKU" do
+      product = create(:product, :sku => "ABC123", :name => "ABC product")
+      spree_xhr_get :index, { :q => "ABC", :format => :json }
+      assigns[:collection].should_not be_empty
+      assigns[:collection].length.should == 1
+    end
   end
 
   context "creating a product" do


### PR DESCRIPTION
My Spree app happens to have product names that includes part of the SKUs. When I create an order in the admin, the products autocomplete then return duplicated results (because both the SKU and the name matches)

**Step to reproduce:** in the Spree admin, create a product named _"ABC test"_ with a SKU _"ABC123"_. Go to the _Orders_ tab and create a _New Order_. Search for _"ABC"_ in the product field. When the autocomplete results appears you should see a duplicate entry for _"ABC test"_.

**Expected behavior:** no duplicate entries :)

**Broken behavior:** duplicate entries! 

**Fix:** the fix is trivial. In the product controller, I added a call to `#uniq` at the end of the `#collection` method. Also added a test to verify the behavior.

Cheers!
