### PR TITLE
fixes variant factory

### DIFF
--- a/core/lib/spree/core/testing_support/factories/product_factory.rb
+++ b/core/lib/spree/core/testing_support/factories/product_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :simple_product, :class => Spree::Product do
+  factory :base_product, :class => Spree::Product do
     sequence(:name) { |n| "Product ##{n} - #{Kernel.rand(9999)}" }
     description { Faker::Lorem.paragraphs(1 + Kernel.rand(5)).join("\n") }
     price 19.99
@@ -7,13 +7,15 @@ FactoryGirl.define do
     sku 'ABC'
     available_on 1.year.ago
     deleted_at nil
+  end
+
+  factory :simple_product, :parent => :base_product do
     on_hand 5
   end
 
   factory :product, :parent => :simple_product do
     tax_category { |r| Spree::TaxCategory.first || r.association(:tax_category) }
     shipping_category { |r| Spree::ShippingCategory.first || r.association(:shipping_category) }
-    on_hand 5
   end
 
   factory :product_with_option_types, :parent => :product do

--- a/core/lib/spree/core/testing_support/factories/variant_factory.rb
+++ b/core/lib/spree/core/testing_support/factories/variant_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :variant, :class => Spree::Variant do
+  factory :base_variant, :class => Spree::Variant do
     price 19.99
     cost_price 17.00
     sku    { Faker::Lorem.sentence }
@@ -7,10 +7,16 @@ FactoryGirl.define do
     height { BigDecimal.new("#{rand(200)}.#{rand(99)}") }
     width  { BigDecimal.new("#{rand(200)}.#{rand(99)}") }
     depth  { BigDecimal.new("#{rand(200)}.#{rand(99)}") }
-    on_hand 5
 
     # associations:
-    product { |p| p.association(:product) }
+    product { |p| p.association(:base_product) }
     option_values { [FactoryGirl.create(:option_value)] }
+  end
+
+  factory :variant, :parent => :base_variant do
+    on_hand 5
+    
+    # associations:
+    product { |p| p.association(:product) }
   end
 end

--- a/core/spec/models/variant_spec.rb
+++ b/core/spec/models/variant_spec.rb
@@ -121,6 +121,7 @@ describe Spree::Variant do
       before { Spree::Config.set :track_inventory_levels => false }
 
       it "should raise an exception" do
+        variant = create(:base_variant)
         lambda { variant.on_hand = 100 }.should raise_error
       end
 


### PR DESCRIPTION
If you set `:track_inventory_levels` to `false`, the variant factory is broken.

Since both the variant and product factory has the on_hand attribute set, calling `FactoryGirl.create(:variant)` raises `Cannot set on_hand value when Spree::Config[:track_inventory_levels] is false`.

There's a test in `core/spec/models/variant_spec.rb` but it's useless to detect the error because it swallows the exception making the test pass.

I created two new factories (`:base_variant` and `:base_product`) that don't have `on_hand` set. Probably it's better to remove on_hand altogether (which is frequently passed anyway to factory creation calls) but I couldn't make up my mind so went for the simpler route.
