### PR TITLE
Changed scope for country name translations

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -127,7 +127,7 @@ module Spree
       end
 
       countries.collect do |country|
-        country.name = I18n.t(country.iso, :scope => 'countries', :default => country.name)
+        country.name = I18n.t(country.iso, :scope => 'country_names', :default => country.name)
         country
       end.sort { |a, b| a.name <=> b.name }
     end


### PR DESCRIPTION
This is done to avoid conflict with label for Spree admin configuration menu.
See issue #2420
