### PR TITLE
Removed disableSelection() call which was causing problems in Firefox.

### DIFF
--- a/core/app/assets/javascripts/admin/admin.js.erb
+++ b/core/app/assets/javascripts/admin/admin.js.erb
@@ -246,7 +246,7 @@ $(document).ready(function(){
           $("table.sortable tr:odd").removeClass("odd even").addClass("odd");
         }
 
-      }).disableSelection();
+      });
   });
 
   $('a.dismiss').click(function() {


### PR DESCRIPTION
There is a blocking UI issue in Gecko-based browsers (Firefox) which prevents focusing on any text input fields inside the node if we call .disableSelection() on it (FF has a non-standard onselectstart event), since the default action of mousedown on an input is to move the focus to that input but that default action is being prevented. 

So right now all text input fields which are inside sortable container are unclickable in Firefox.
To reproduce:
- Go to admin section.
- Go to Products.
- Go to Option Types.
- Create new option type if you don't already have one, or just edit an existing one.
- When editing option type, add option value. Observe that input fields are not clickable in Firefox.

The fix is to simply remove the call to .disableSelection() since it has been deprecated in jQuery UI partly due to this issue. 

See http://bugs.jqueryui.com/ticket/7755 (deprecation) and http://bugs.jqueryui.com/ticket/7735
