### PR TITLE
Fixed hardcoded paths to fontawesome

### DIFF
--- a/core/app/assets/stylesheets/admin/plugins/font-awesome.scss
+++ b/core/app/assets/stylesheets/admin/plugins/font-awesome.scss
@@ -23,8 +23,8 @@
     */
 @font-face {
   font-family: "FontAwesome";
-  src: url('/assets/fontawesome-webfont.eot');
-  src: url('/assets/fontawesome-webfont.eot?#iefix') format('eot'), url('/assets/fontawesome-webfont.woff') format('woff'), url('/assets/fontawesome-webfont.ttf') format('truetype'), url('/assets/fontawesome-webfont.svg#FontAwesome') format('svg');
+  src: font-url('fontawesome-webfont.eot');
+  src: font-url('fontawesome-webfont.eot?#iefix') format('eot'),font-url('fontawesome-webfont.woff') format('woff'), font-url('fontawesome-webfont.ttf') format('truetype'), font-url('fontawesome-webfont.svg#FontAwesome') format('svg');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
Using the asset pipeline `font-url` means that it respects changes to `config.assets.prefix`, allowing the app to be mounted on any url, in my case `/store`.
