### PR TITLE
Month Formatting Bug

### DIFF
--- a/core/app/views/spree/admin/shared/_translations.html.erb
+++ b/core/app/views/spree/admin/shared/_translations.html.erb
@@ -4,7 +4,7 @@
                               :scope => 'spree.date_picker',
                               :default => 'yy/mm/dd'),
     :abbr_day_names => I18n.t(:abbr_day_names, :scope => :date),
-    :month_names    => I18n.t(:month_names, :scope => :date).delete_if(&:blank?),
+    :month_names    => I18n.t(:month_names, :scope => :date).reject(&:blank?),
     :previous       => I18n.t(:previous),
     :next           => I18n.t(:next),
     :no_results     => I18n.t(:no_results),


### PR DESCRIPTION
The %B date formatting operator relies on nil for the first month in the month_names array. Deleting it from I18n will cause month shifting.

To reproduce the issue:

``` ruby
I18n.l(Time.now, :format => "%B %d, %Y")
I18n.t(:month_names, :scope => :date).delete_if(&:blank?)
I18n.l(Time.now, :format => "%B %d, %Y")
```
