### PR TITLE
Switched Ruby 1.9-only Hash to hashrocket style for 1.8 compatibility.

### DIFF
--- a/api/app/controllers/spree/api/v1/base_controller.rb
+++ b/api/app/controllers/spree/api/v1/base_controller.rb
@@ -65,7 +65,7 @@ module Spree
         end
 
         def error_during_processing(exception)
-          render :text => { exception: exception.message }.to_json,
+          render :text => { :exception => exception.message }.to_json,
                  :status => 422 and return
         end
 


### PR DESCRIPTION
Found a hash that wasn't compatible with Ruby 1.8
