### PR TITLE
Product find by permalink

### DIFF
--- a/core/app/controllers/spree/admin/images_controller.rb
+++ b/core/app/controllers/spree/admin/images_controller.rb
@@ -14,7 +14,7 @@ module Spree
         end
 
         def load_data
-          @product = Product.where(:permalink => params[:product_id]).first
+          @product = Product.find_by_permalink(params[:product_id])
           @variants = @product.variants.collect do |variant|
             [variant.options_text, variant.id]
           end

--- a/core/app/controllers/spree/admin/products_controller.rb
+++ b/core/app/controllers/spree/admin/products_controller.rb
@@ -32,7 +32,7 @@ module Spree
       end
 
       def destroy
-        @product = Product.where(:permalink => params[:id]).first!
+        @product = Product.find_by_permalink!(params[:id])
         @product.delete
 
         flash.notice = I18n.t('notice_messages.product_deleted')

--- a/core/app/controllers/spree/admin/resource_controller.rb
+++ b/core/app/controllers/spree/admin/resource_controller.rb
@@ -155,7 +155,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
 
     def parent
       if parent_data.present?
-        @parent ||= parent_data[:model_class].where(parent_data[:find_by] => params["#{model_name}_id"]).first
+        @parent ||= parent_data[:model_class].send("find_by_#{parent_data[:find_by]}", params["#{model_name}_id"])
         instance_variable_set("@#{model_name}", @parent)
       else
         nil


### PR DESCRIPTION
Replaced queries in the form of `Product.where(:permalink => id).first`with the cleaner syntax of `Product.find_by_permalink(id)`.

The motivation behind this was using Spree together with Globalize3. Globalize3 hooks into the dynamic finder methods but not into the `where()` queries. (I use Globalize3 for translating the permalinks.)

Apart from that, at least the first commit 85e9644 introduces stylistic improvements using the cleaner `find_by_x` syntax (not sure about the second commit 98b7b07) 

This should be fine to be merged into 1-2-stable as well.
