### PR TITLE
Checks config before setting shipment 'pending' state

### DIFF
--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -22,7 +22,7 @@ module Spree
     preference :address_requires_state, :boolean, :default => true # should state/state_name be required
     preference :admin_interface_logo, :string, :default => 'admin/bg/spree_50.png'
     preference :admin_products_per_page, :integer, :default => 10
-    preference :allow_backorder_shipping, :boolean, :default => false # should only be true if you don't need to track inventory
+    preference :allow_backorder_shipping, :boolean, :default => false
     preference :allow_backorders, :boolean, :default => true
     preference :allow_checkout_on_gateway_error, :boolean, :default => false
     preference :allow_guest_checkout, :boolean, :default => true

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -108,14 +108,19 @@ module Spree
 
     # Determines the appropriate +state+ according to the following logic:
     #
-    # pending    unless order is complete and +order.payment_state+ is +paid+
+    # pending    unless order is complete, +order.payment_state+ is +paid+ 
+    #            and allow_backorder_shipping is false
     # shipped    if already shipped (ie. does not change the state)
     # ready      all other cases
     def determine_state(order)
       return 'pending' unless order.can_ship?
-      return 'pending' if inventory_units.any? &:backordered?
-      return 'shipped' if state == 'shipped'
+      return 'pending' if self.hold_backordered?
+      return 'shipped' if self.state == 'shipped'
       order.paid? ? 'ready' : 'pending'
+    end
+
+    def hold_backordered?
+      self.inventory_units.any?(&:backordered?) && !Spree::Config[:allow_backorder_shipping]
     end
 
     private

--- a/core/spec/models/shipment_spec.rb
+++ b/core/spec/models/shipment_spec.rb
@@ -27,7 +27,6 @@ describe Spree::Shipment do
   end
 
   context "#update!" do
-
     shared_examples_for "immutable once shipped" do
       it "should remain in shipped state once shipped" do
         shipment.state = "shipped"
@@ -36,8 +35,26 @@ describe Spree::Shipment do
       end
     end
 
+    shared_context "allow_backorder_shipping true" do
+      before(:each) do
+        reset_spree_preferences do |config|
+          config.allow_backorder_shipping = true
+        end
+      end
+    end
+
+    shared_examples_for "ready if allow_backorder_shipping is true" do
+      include_context "allow_backorder_shipping true"
+
+      it "should have a state of ready even if backordered" do
+        shipment.stub(:inventory_units => [mock_model(Spree::InventoryUnit, :backordered? => true)])
+        shipment.should_receive(:update_column).with("state", "ready")
+        shipment.update!(order)
+      end
+    end
+
     shared_examples_for "pending if backordered" do
-      it "should have a state of pending if backordered" do
+      specify do
         shipment.stub(:inventory_units => [mock_model(Spree::InventoryUnit, :backordered? => true)])
         shipment.should_receive(:update_column).with("state", "pending")
         shipment.update!(order)
@@ -58,8 +75,10 @@ describe Spree::Shipment do
         shipment.should_receive(:update_column).with("state", "ready")
         shipment.update!(order)
       end
+
       it_should_behave_like "immutable once shipped"
       it_should_behave_like "pending if backordered"
+      it_should_behave_like "ready if allow_backorder_shipping is true"
     end
 
     context "when order has balance due" do
@@ -69,8 +88,14 @@ describe Spree::Shipment do
         shipment.should_receive(:update_column).with("state", "pending")
         shipment.update!(order)
       end
+
       it_should_behave_like "immutable once shipped"
       it_should_behave_like "pending if backordered"
+
+      context do
+        include_context "allow_backorder_shipping true"
+        it_should_behave_like "pending if backordered"
+      end
     end
 
     context "when order has a credit owed" do
@@ -80,8 +105,10 @@ describe Spree::Shipment do
         shipment.should_receive(:update_column).with("state", "ready")
         shipment.update!(order)
       end
+
       it_should_behave_like "immutable once shipped"
       it_should_behave_like "pending if backordered"
+      it_should_behave_like "ready if allow_backorder_shipping is true"
     end
 
     context "when shipment state changes to shipped" do


### PR DESCRIPTION
Spree should say a shipment is **ready** if `allow_backorder_shipping` is
true and the order is paid.

The following test should illustrate the issue where the admin user could not ship an order because it has some backordered items even though the config `allow_backorder_shipping` is true. (run it in the models/shipment_spec.rb)

``` ruby
context "when order is paid" do
  before { order.stub :paid? => true }

  context "allow_backorder_shipping is true" do
    before(:each) do
      reset_spree_preferences do |config|
        config.allow_backorder_shipping = true
      end
    end

    it "should have a state of ready even if backordered" do
      shipment.stub(:inventory_units => [mock_model(Spree::InventoryUnit, :backordered? => true)])
      shipment.should_receive(:update_column).with("state", "ready")
      shipment.update!(order)
    end
  end
end
```

I also tried to improve the test coverage a little bit for this config.
