### PR TITLE
[promo] Removes adjustments only if order is not complete

### DIFF
--- a/promo/spec/models/promotion_spec.rb
+++ b/promo/spec/models/promotion_spec.rb
@@ -53,19 +53,19 @@ describe Spree::Promotion do
   end
 
   describe "#delete" do
-    it "deletes actions" do
-      p = Spree::Promotion.create(:name => "delete me")
-      p.actions << Spree::Promotion::Actions::CreateAdjustment.new
-      p.destroy
+    let(:promotion) { Spree::Promotion.create(:name => "delete me") }
 
+    before(:each) do
+      promotion.actions << Spree::Promotion::Actions::CreateAdjustment.new
+      promotion.rules << Spree::Promotion::Rules::FirstOrder.new
+      promotion.destroy
+    end
+
+    it "should delete actions" do
       Spree::PromotionAction.count.should == 0
     end
 
-    it "deletes rules" do
-      p = Spree::Promotion.create(:name => "delete me")
-      p.rules << Spree::Promotion::Rules::FirstOrder.new
-      p.destroy
-
+    it "should delete rules" do
       Spree::PromotionRule.count.should == 0
     end
   end


### PR DESCRIPTION
This should help to fix #1046. Still missing some specs and also removes
adjustments in case its promotion becomes inactive

ps. This is a work in progress. I just wanted to report that currently every time a promotion is removed its adjustments are removed as well, no matter what. Due to this line in `Promotion::Actions::CreateAdjustment`

```
has_many :adjustments, :as => :originator, :dependent => :destroy
```

Hopefully I'll get this done and resolve #1046 before the weekend.
