### PR TITLE
Don't change Property's presentation name if it's already set

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -232,10 +232,7 @@ module Spree
 
     def set_property(property_name, property_value)
       ActiveRecord::Base.transaction do
-        property = Property.where(:name => property_name).first_or_initialize
-        property.presentation = property_name
-        property.save!
-
+        property = Property.where(:name => property_name).first_or_create!(:presentation => property_name)
         product_property = ProductProperty.where(:product_id => id, :property_id => property.id).first_or_initialize
         product_property.value = property_value
         product_property.save!

--- a/core/spec/models/product_spec.rb
+++ b/core/spec/models/product_spec.rb
@@ -301,6 +301,15 @@ describe Spree::Product do
         product.property('the_prop_new').should == 'value'
       }.should change { product.properties.length }.by(1)
     end
+
+    it "should not overwrite properties' presentation names" do
+      product = FactoryGirl.create :product
+      Spree::Property.where(:name => 'foo').first_or_create!(:presentation => "Foo's Presentation Name")
+      product.set_property('foo', 'value1')
+      product.set_property('bar', 'value2')
+      Spree::Property.where(:name => 'foo').first.presentation.should == "Foo's Presentation Name"
+      Spree::Property.where(:name => 'bar').first.presentation.should == "bar"
+    end
   end
 
   context '#create' do


### PR DESCRIPTION
`Product.set_property(propname, value)` currently sets the Property's presentation name to `propname` even if the Property already exists and has a property name set. This pull request fixes this bug and adds a test.
