### PR TITLE
Hides shipping form if use billing is checked [backend]

### DIFF
--- a/core/app/assets/javascripts/admin/checkouts/edit.js
+++ b/core/app/assets/javascripts/admin/checkouts/edit.js
@@ -61,18 +61,21 @@ $(document).ready(function() {
     })
   }
 
+  var order_use_billing_input = $('input#order_use_billing');
 
-  $('input#order_use_billing').click(function() {
-    if(!$(this).is(':checked')) {
+  var order_use_billing = function () {
+    if (!order_use_billing_input.is(':checked')) {
       $('#shipping').show();
-      $('#shipping input').prop("disabled", false);
-      $('#shipping select').prop("disabled", false);
     } else {
       $('#shipping').hide();
-      $('#shipping input').prop("disabled", true);
-      $('#shipping select').prop("disabled", true);
     }
+  };
+
+  order_use_billing_input.click(function() {
+    order_use_billing();
   });
+
+  order_use_billing();
 
   $('#guest_checkout_true').change(function() {
     $('#customer_search').val("");
@@ -87,5 +90,3 @@ $(document).ready(function() {
     })
   });
 });
-
-


### PR DESCRIPTION
When page loads shipping form was being displayed even though 'use
billing address' is checked

To reproduce.

Click on order in admin.
Click on customer details
(in case use billing address is checked) Shipping form is still displayed. It should be hidden.

Sorry I didn't add any test for it. js specs are still a pain and I just figured it might not be worth it.
