### PR TITLE
Variant options not correctly shown in autocomplete

### DIFF
--- a/core/app/views/spree/admin/variants/_autocomplete.js.erb
+++ b/core/app/views/spree/admin/variants/_autocomplete.js.erb
@@ -20,7 +20,7 @@
       {{#if variant.option_values}}
         <ul class='variant-options'>
           {{#each variant.option_values}}
-            <li><strong>{{option_value.option_type.presentation}}:</strong> {{option_value.presentation}}</li>
+            <li><strong>{{this.option_type.presentation}}:</strong> {{this.presentation}}</li>
           {{/each}}
         </ul>
       {{/if}}


### PR DESCRIPTION
Repro steps:
1. Go to admin, orders, click New
2. start typing a variant name like "jersey"

The auto-completed items shown will not show the variant options, and the values of these options for each variant.

The attached fixes the handlebar script to correctly show them.

Before:

![Screenshot_1_21_13_5_04_PM](https://f.cloud.github.com/assets/759955/84820/5ad3324e-6427-11e2-8744-c0c9b5c9bba2.png)

After:

![Screenshot_1_21_13_5_05_PM](https://f.cloud.github.com/assets/759955/84823/86eb1540-6427-11e2-9eba-2019ce274d36.png)
