### PR TITLE
Fix broken split prices migration.

### DIFF
--- a/core/db/migrate/20121031162139_split_prices_from_variants.rb
+++ b/core/db/migrate/20121031162139_split_prices_from_variants.rb
@@ -9,7 +9,7 @@ class SplitPricesFromVariants < ActiveRecord::Migration
     Spree::Variant.all.each do |variant|
       Spree::Price.create!(
         :variant_id => variant.id,
-        :amount => variant.price,
+        :amount => variant[:price],
         :currency => Spree::Config[:currency]
       )
     end


### PR DESCRIPTION
The migration will attempt to populated spree_prices with
the variant price.  Unfortunately, since variant price is
now delegated to spree_prices, it will come back as 0.

Instead of reading from the variant price method, it's
going to set the price based upon the actual column value.
