### PR TITLE
Addition of the kaminari locale.

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1134,3 +1134,10 @@ en:
   zone_based: "Zone Based"
   zone_setting_description: "Collections of countries, states or other zones to be used in various calculations."
   zones: Zones
+  views:
+    pagination:
+      first: "&laquo; First"
+      last: "Last &raquo;"
+      previous: "&lsaquo; Prev"
+      next: "Next &rsaquo;"
+      truncate: "&hellip;"


### PR DESCRIPTION
I think that this addition is necessary.

Because it's overwritten by a command to "rake spree_i18n:update_default" in spree_i18n default files.
