### PR TITLE
Add missing colon on adjustment line of admin order form

### DIFF
--- a/core/app/views/spree/admin/orders/_form.html.erb
+++ b/core/app/views/spree/admin/orders/_form.html.erb
@@ -28,7 +28,7 @@
       <tbody id="order-charges" data-hook="admin_order_form_adjustments">
         <% @order.adjustments.eligible.each do |adjustment| %>
           <tr>
-            <td colspan="3"><strong><%= adjustment.label %></strong></td>
+            <td colspan="3"><strong><%= adjustment.label %>:</strong></td>
             <td class="total"><span><%= adjustment.display_amount %></span></td>
             <td></td>
           </tr>


### PR DESCRIPTION
I noticed the adjustment line of the admin order form is missing a trailing `:` which is present for order total and subtotal.

![missing-colon](https://f.cloud.github.com/assets/100218/92665/8ae38534-65e8-11e2-8437-1086d0128720.png)

The issue only affects the form. The admin order details view is fine.
