### PR TITLE
Assign params in ResourceController#create instead of ResourceController#build_resource

### DIFF
--- a/core/app/controllers/spree/admin/resource_controller.rb
+++ b/core/app/controllers/spree/admin/resource_controller.rb
@@ -40,6 +40,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
 
   def create
     invoke_callbacks(:create, :before)
+    @object.attributes = params[object_name]
     if @object.save
       invoke_callbacks(:create, :after)
       flash[:success] = flash_message_for(@object, :successfully_created)
@@ -172,9 +173,9 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
 
     def build_resource
       if parent_data.present?
-        parent.send(controller_name).build(params[object_name])
+        parent.send(controller_name).build
       else
-        model_class.new(params[object_name])
+        model_class.new
       end
     end
 


### PR DESCRIPTION
ResourceController’s `#create` and `#update` methods differ in the way attributes are assigned to objects:

With `#update`, params are not assigned until `update_attributes(params[object_name])`is called. Before that the `update.before`callback is executed.

`#create` is different. Due to the way the `build_resource` method is defined, parameters are already assigned before the `#create` method is called. This also means, that attributes are already assigned when the `create.before` callback is executed.
This prevents users from filtering the `params`hash using controller callbacks.

Both `#create` and `#update` should be built the same way.
