### PR TITLE
Can't delete zone members in admin site

### DIFF
--- a/core/app/helpers/spree/admin/base_helper.rb
+++ b/core/app/helpers/spree/admin/base_helper.rb
@@ -62,7 +62,7 @@ module Spree
       def remove_nested(fields)
         out = ''
         out << fields.hidden_field(:_destroy) unless fields.object.new_record?
-        out << (link_to icon('delete'), "#", :class => 'remove')
+        out << (link_to icon('icon-remove'), "#", :class => 'remove')
         out.html_safe
       end
 


### PR DESCRIPTION
The delete button for zone members doesn't show up.  Repro steps:
1. Go to admin, configurations, zones
2. Create a new zone
3. select states, save
4. edit new zone, add two states, save
5. edit new zone, note that you can't delete the states

This fix will display the delete button for each member.  Formatting isn't great (perhaps someone else could fix that), but this fix at least restores the functionality.
