### PR TITLE
Remove credit card number stripping

### DIFF
--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -14,10 +14,6 @@ module Spree
     attr_accessible :first_name, :last_name, :number, :verification_value, :year,
                     :month, :gateway_customer_profile_id, :gateway_payment_profile_id
 
-    def number=(num)
-      @number = num.gsub(/[^0-9]/, '') rescue nil
-    end
-
     def set_last_digits
       number.to_s.gsub!(/\s/,'')
       verification_value.to_s.gsub!(/\s/,'')

--- a/core/spec/models/credit_card_spec.rb
+++ b/core/spec/models/credit_card_spec.rb
@@ -191,26 +191,5 @@ describe Spree::CreditCard do
       credit_card.spree_cc_type.should == "master"
     end
   end
-
-  context "#number=" do
-    it "should strip non-numeric characters from card input" do
-      credit_card.number = "6011000990139424"
-      credit_card.number.should == "6011000990139424"
-
-      credit_card.number = "  6011-0009-9013-9424  "
-      credit_card.number.should == "6011000990139424"
-    end
-
-    it "should not raise an exception on non-string input" do
-      credit_card.number = Hash.new
-      credit_card.number.should be_nil
-    end
-  end
-
-  context "#associations" do
-    it "should be able to access its payments" do
-      lambda { credit_card.payments.all }.should_not raise_error ActiveRecord::StatementInvalid
-    end
-  end
 end
 


### PR DESCRIPTION
This breaks client side encryption for Braintree integration.  When the encrypted number come through here, this code strips out all the alpha characters.

This reverts [pull request #1881](https://github.com/spree/spree/pull/1881)
