### PR TITLE
Fix for improperly namespaced url

### DIFF
--- a/core/app/views/spree/admin/shared/_tabs.html.erb
+++ b/core/app/views/spree/admin/shared/_tabs.html.erb
@@ -2,4 +2,4 @@
 <%= tab :orders, :payments, :creditcard_payments, :shipments, :credit_cards, :return_authorizations, :icon => 'icon-shopping-cart' %>
 <%= tab :products , :option_types, :properties, :prototypes, :variants, :product_properties, :taxons, :icon => 'icon-th-large' %>
 <%= tab :reports, :icon => 'icon-file'  %>
-<%= tab :configurations, :general_settings, :mail_methods, :tax_categories, :zones, :states, :payment_methods, :inventory_settings, :taxonomies, :shipping_methods, :trackers, :label => 'configuration', :icon => 'icon-wrench', :url => edit_admin_general_settings_path %>
+<%= tab :configurations, :general_settings, :mail_methods, :tax_categories, :zones, :states, :payment_methods, :inventory_settings, :taxonomies, :shipping_methods, :trackers, :label => 'configuration', :icon => 'icon-wrench', :url => spree.edit_admin_general_settings_path %>


### PR DESCRIPTION
Without this change controllers which are:
a) outside of the Spree module namespace and
b) inherit from Spree::Admin::BaseController

will not be able to determine the url and their views will not
compile.
