### PR TITLE
[1-0-stable] Devise Security Upgrade ( 1.4.8 > 1.5.3 )

### DIFF
--- a/auth/spree_auth.gemspec
+++ b/auth/spree_auth.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency 'spree_core', version
-  s.add_dependency 'devise', '= 1.4.8'
+  s.add_dependency 'devise', '= 1.5.3'
   s.add_dependency 'cancan', '= 1.6.7'
 end


### PR DESCRIPTION
Upgrading Devise in the 1.0.x branch in regard to the 28th Jan security notice
##### Background

Due to heavy customisation, we are locked in on v1.0.x for one app and have been using the 1-0-stable branch for recent Rails security updates, this patch is in keeping with the last few commits.
##### Note on tests

Tests are **failing** in this commit, however the failing tests exist prior. The auth gem is green and our own testsuite for an application using this ref is green and currently undergoing QA.
