### PR TITLE
update default robots.txt with current routes

### DIFF
--- a/core/lib/generators/spree/install/install_generator.rb
+++ b/core/lib/generators/spree/install/install_generator.rb
@@ -53,14 +53,19 @@ module Spree
       return unless File.exists? 'public/robots.txt'
       append_file "public/robots.txt", <<-ROBOTS
 User-agent: *
-Disallow: /checkouts
+Disallow: /checkout
+Disallow: /cart
 Disallow: /orders
 Disallow: /countries
 Disallow: /line_items
 Disallow: /password_resets
 Disallow: /states
+Disallow: /tax_categories
 Disallow: /user_sessions
+Disallow: /user_registrations
 Disallow: /users
+Disallow: /account
+Disallow: /shipments
       ROBOTS
     end
 


### PR DESCRIPTION
It looks like the default robots.txt content hasn't been updated since 0.3 or even earlier.
