### PR TITLE
show full address in order detail/confirmation, use hCard markup

### DIFF
--- a/core/app/views/spree/admin/orders/show.html.erb
+++ b/core/app/views/spree/admin/orders/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_actions do %>
   <li>
-    <%= button_link_to t(:cancel), fire_admin_order_url(@order.number, { :e => 'cancel' }), :icon => 'icon-trash', :data => { :confirm => t(:are_you_sure) } if @order.can_cancel? %>  
+    <%= button_link_to t(:cancel), fire_admin_order_url(@order.number, { :e => 'cancel' }), :icon => 'icon-trash', :data => { :confirm => t(:are_you_sure) } if @order.can_cancel? %>
   </li>
   <li>
     <%= button_link_to t(:edit), edit_admin_order_url(@order.number), :icon => 'icon-edit' %>
@@ -15,17 +15,13 @@
   <% if @order.bill_address %>
     <fieldset class="alpha six columns no-border-bottom">
       <legend align="center"><%= t(:bill_address) %></legend>
-      <div class="align-center">
-        <%= render :partial => 'spree/admin/shared/address', :locals => { :address => @order.bill_address } %>  
-      </div>
+      <%= render :partial => 'spree/shared/address', :locals => { :address => @order.bill_address } %>
     </fieldset>
   <% end %>
   <% if @order.ship_address %>
     <fieldset class="omega six columns no-border-bottom">
       <legend align="center"><%= t(:ship_address) %></legend>
-      <div class="align-center">
-        <%= render :partial => 'spree/admin/shared/address', :locals => { :address => @order.ship_address } %>
-      </div>
+      <%= render :partial => 'spree/shared/address', :locals => { :address => @order.ship_address } %>
     </fieldset>
     <% end %>
 </div>

--- a/core/app/views/spree/admin/shared/_address.html.erb
+++ b/core/app/views/spree/admin/shared/_address.html.erb
@@ -1,6 +1,0 @@
-<div data-hook="address">
-  <%="#{address.firstname} #{address.lastname} "%><%= address.company unless address.company.blank? %>
-  <%="(#{address.phone}" %><%= address.alternative_phone unless address.alternative_phone.blank? %>)<br />
-  <%= address.address1 %> <%= ", #{address.address2}" unless address.address2.blank? %>
-  <%= ", #{address.city}, #{address.state_text}, #{address.zipcode}, #{address.country.name}" %>
-</div>

--- a/core/app/views/spree/shared/_address.html.erb
+++ b/core/app/views/spree/shared/_address.html.erb
@@ -1,0 +1,38 @@
+<div class="address vcard">
+  <div class="fn"><%= address.full_name %></div>
+  <% unless address.company.blank? %>
+    <div class="org">
+      <%= address.company %>
+    </div>
+  <% end %>
+  <div class="adr">
+    <div class="street-address">
+      <div class="street-address-line">
+        <%= address.address1 %>
+      </div>
+      <% unless address.address2.blank? %>
+        <div class="street-address-line">
+          <%= address.address2 %>
+        </div>
+      <% end %>
+    </div>
+    <div class="local">
+      <span class="locality"><%= address.city %></span>
+      <span class="region"><%= address.state_text %></span>
+      <span class="postal-code"><%= address.zipcode %></span>
+      <div class="country-name"><%= address.country.try(:name) %></div>
+    </div>
+  </div>
+  <% unless address.phone.blank? %>
+    <div class="tel">
+      <span class="type"><%= t(:phone) %></span>
+      <%= address.phone %>
+    </div>
+  <% end %>
+  <% unless address.alternative_phone.blank? %>
+    <div class="alternative-phone tel">
+      <span class="type"><%= t(:alternative_phone) %></span>
+      <%= address.alternative_phone %>
+    </div>
+  <% end %>
+</div>

--- a/core/app/views/spree/shared/_order_details.html.erb
+++ b/core/app/views/spree/shared/_order_details.html.erb
@@ -1,18 +1,14 @@
 <div class="row steps-data">
 
   <% if order.has_step?("address") %>
-    <div class="columns alpha four">
+    <div class="columns alpha four" data-hook="order-ship-address">
       <h6><%= t(:shipping_address) %> <%= link_to "(#{t(:edit)})", checkout_state_path(:address) unless @order.completed? %></h6>
-      <div class="address">
-        <%= order.ship_address %>
-      </div>
+      <%= render :partial => 'spree/shared/address', :locals => { :address => order.ship_address } %>
     </div>
 
-    <div class="columns alpha four">
+    <div class="columns alpha four" data-hook="order-bill-address">
       <h6><%= t(:billing_address) %> <%= link_to "(#{t(:edit)})", checkout_state_path(:address) unless @order.completed? %></h6>
-      <div class="address">
-        <%= order.bill_address %>
-      </div>
+      <%= render :partial => 'spree/shared/address', :locals => { :address => order.bill_address } %>
     </div>
 
     <% if @order.has_step?("delivery") %>


### PR DESCRIPTION
this does not address the problem of i18n (lol puns) but does provide a more style-able markup that follows the [hCard microformat](http://microformats.org/wiki/hcard) which is probably better than a plain comma-separated string as before.
- addresses #2136
