### PR TITLE
Fix: Strip the tags from the order summary

### DIFF
--- a/core/app/views/spree/shared/_order_details.html.erb
+++ b/core/app/views/spree/shared/_order_details.html.erb
@@ -76,7 +76,7 @@
         </td>
         <td data-hook="order_item_description">
           <h4><%= item.variant.product.name %></h4>
-          <%= truncate(item.variant.product.description, :length => 100, :omission => "...") %>
+          <%= truncate(strip_tags(item.variant.product.description), :length => 100, :omission => "...") %>
           <%= "(" + item.variant.options_text + ")" unless item.variant.option_values.empty? %>
         </td>
         <td data-hook="order_item_price" class="price"><span><%= money item.price %></span></td>


### PR DESCRIPTION
The spree editor allows to use rich text and this would be displayed
inside the order details. Use strip_tags to remove the richtext from
this overview.
