### PR TITLE
Fix: tax: Only apply the tax rate once

### DIFF
--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -26,7 +26,7 @@ module Spree
     def self.match(order)
       return [] unless order.tax_zone
       all.select do |rate|
-        rate.zone == order.tax_zone || rate.zone.contains?(order.tax_zone) || rate.zone.default_tax
+        rate.zone == order.tax_zone || rate.zone.contains?(order.tax_zone)
       end
     end
 


### PR DESCRIPTION
My setup is the following. I am based in Germany and have a TaxZone for the VAT (19%), then I have a TaxZone for the rest of the European Union for the VAT (19%). I have this separation because if someone from the EU has a valid EUVAT Id I will not charge the VAT.

Somehow when placing an order for something like Italy, I ended up applying the tax rate twice. I think the TaxRate.match selector is wrong (and/or my ruby skills are weak).

I understand that this would require a testcase but I lack the time to write one and I am posting this pull request mostly as an indicator that this area of code still needs some work.
