### PR TITLE
API variants images fix for issue #2529

### DIFF
--- a/api/app/views/spree/api/line_items/show.v1.rabl
+++ b/api/app/views/spree/api/line_items/show.v1.rabl
@@ -2,4 +2,5 @@ object @line_item
 attributes *line_item_attributes
 child :variant do
   extends "spree/api/variants/variant"
+  child(:images => :images) { extends "spree/api/images/show" }
 end

--- a/api/app/views/spree/api/products/show.v1.rabl
+++ b/api/app/views/spree/api/products/show.v1.rabl
@@ -6,10 +6,10 @@ child :variants_including_master => :variants do
   child :option_values => :option_values do
     attributes *option_value_attributes
   end
-end
-
-child :images => :images do
-  extends "spree/api/images/show"
+  
+  child :images => :images do
+    extends "spree/api/images/show"
+  end
 end
 
 child :option_types => :option_types do

--- a/api/app/views/spree/api/variants/index.v1.rabl
+++ b/api/app/views/spree/api/variants/index.v1.rabl
@@ -7,4 +7,5 @@ node(:pages) { @variants.num_pages }
 child(@variants => :variants) do
   attributes *variant_attributes
   child(:option_values => :option_values) { attributes *option_value_attributes }
+  child(:images => :images) { extends "spree/api/images/show" }
 end

--- a/api/app/views/spree/api/variants/show.v1.rabl
+++ b/api/app/views/spree/api/variants/show.v1.rabl
@@ -1,3 +1,4 @@
 object @variant
 extends "spree/api/variants/variant"
 child(:option_values => :option_values) { attributes *option_value_attributes }
+child(:images => :images) { extends "spree/api/images/show" }

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -109,6 +109,14 @@ module Spree
           response.status.should == 200
           order.reload.line_items.should be_empty
         end
+        
+        it "can list its line items with images" do
+          order.line_items.first.variant.images.create!(:attachment => image("thinking-cat.jpg"))
+          
+          api_get :show, :id => order.to_param
+          
+          json_response['line_items'].first['variant'].should have_attributes([:images])
+        end
       end
     end
 

--- a/api/spec/controllers/spree/api/products_controller_spec.rb
+++ b/api/spec/controllers/spree/api/products_controller_spec.rb
@@ -66,18 +66,22 @@ module Spree
 
       it "gets a single product" do
         product.master.images.create!(:attachment => image("thinking-cat.jpg"))
+        product.variants.create!
+        product.variants.first.images.create!(:attachment => image("thinking-cat.jpg"))
         product.set_property("spree", "rocks")
         api_get :show, :id => product.to_param
         json_response.should have_attributes(attributes)
         json_response['variants'].first.should have_attributes([:name,
                                                               :is_master,
                                                               :count_on_hand,
-                                                              :price])
+                                                              :price,
+                                                              :images])
 
-        json_response["images"].first.should have_attributes([:attachment_file_name,
-                                                            :attachment_width,
-                                                            :attachment_height,
-                                                            :attachment_content_type])
+        json_response['variants'].first['images'].first.should have_attributes([:attachment_file_name,
+                                                                                :attachment_width,
+                                                                                :attachment_height,
+                                                                                :attachment_content_type,
+                                                                                :attachment_url])
 
         json_response["product_properties"].first.should have_attributes([:value,
                                                                          :product_id,

--- a/api/spec/controllers/spree/api/variants_controller_spec.rb
+++ b/api/spec/controllers/spree/api/variants_controller_spec.rb
@@ -51,6 +51,14 @@ module Spree
                                                  :option_type_name,
                                                  :option_type_id])
     end
+    
+    it "variants returned contain images data" do
+      variant.images.create!(:attachment => image("thinking-cat.jpg"))
+
+      api_get :index
+
+      json_response["variants"].last.should have_attributes([:images])
+    end
 
     # Regression test for #2141
     context "a deleted variant" do
@@ -85,6 +93,19 @@ module Spree
     it "can see a single variant" do
       api_get :show, :id => variant.to_param
       json_response.should have_attributes(attributes)
+      option_values = json_response["option_values"]
+      option_values.first.should have_attributes([:name,
+                                                 :presentation,
+                                                 :option_type_name,
+                                                 :option_type_id])
+    end
+    
+    it "can see a single variant with images" do
+      variant.images.create!(:attachment => image("thinking-cat.jpg"))
+      
+      api_get :show, :id => variant.to_param
+      
+      json_response.should have_attributes(attributes + [:images])      
       option_values = json_response["option_values"]
       option_values.first.should have_attributes([:name,
                                                  :presentation,


### PR DESCRIPTION
Hi!

This pull request is to put variants' images attributes in more places than before, so that we can show images in every page where we need them, based on which information we have in each page (products and its variants, orders and its line_items, variants itself etc).

Hope you accept it soon, so that we can change our Gemfiles!

Regards!
Tiago.
