### PR TITLE
Apply coupons take two aka "The Coupon Applicator"

### DIFF
--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -89,13 +89,11 @@ module Spree
         end
 
         def after_update_attributes
-          if object_params[:coupon_code].present?
-            coupon_result = Spree::CouponApplicator.new(@order).apply
-            if !coupon_result[:coupon_applied?]
-              @coupon_message = coupon_result[:error]
-              respond_with(@order, :default_template => 'spree/api/orders/could_not_apply_coupon')
-              return true
-            end
+          coupon_result = Spree::Promo::CouponApplicator.new(@order).apply
+          if !coupon_result[:coupon_applied?]
+            @coupon_message = coupon_result[:error]
+            respond_with(@order, :default_template => 'spree/api/orders/could_not_apply_coupon')
+            return true
           end
           false
         end

--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -89,11 +89,13 @@ module Spree
         end
 
         def after_update_attributes
-          coupon_result = Spree::Promo::CouponApplicator.new(@order).apply
-          if !coupon_result[:coupon_applied?]
-            @coupon_message = coupon_result[:error]
-            respond_with(@order, :default_template => 'spree/api/orders/could_not_apply_coupon')
-            return true
+          if object_params && object_params[:coupon_code].present?
+            coupon_result = Spree::Promo::CouponApplicator.new(@order).apply
+            if !coupon_result[:coupon_applied?]
+              @coupon_message = coupon_result[:error]
+              respond_with(@order, :default_template => 'spree/api/orders/could_not_apply_coupon')
+              return true
+            end
           end
           false
         end

--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -6,6 +6,7 @@ module Spree
 
       include Spree::Core::ControllerHelpers::Auth
       include Spree::Core::ControllerHelpers::Order
+      include ActionView::Helpers::TranslationHelper
 
       respond_to :json
 
@@ -16,6 +17,7 @@ module Spree
 
       def update
         if @order.update_attributes(object_params)
+          return if after_update_attributes
           state_callback(:after) if @order.next
           respond_with(@order, :default_template => 'spree/api/orders/show')
         else
@@ -84,6 +86,18 @@ module Spree
           else
             render 'spree/api/orders/could_not_transition', :status => 422
           end
+        end
+
+        def after_update_attributes
+          if object_params[:coupon_code].present?
+            coupon_result = Spree::CouponApplicator.new(@order).apply
+            if !coupon_result[:coupon_applied?]
+              @coupon_message = coupon_result[:error]
+              respond_with(@order, :default_template => 'spree/api/orders/could_not_apply_coupon')
+              return true
+            end
+          end
+          false
         end
     end
   end

--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -6,7 +6,6 @@ module Spree
 
       include Spree::Core::ControllerHelpers::Auth
       include Spree::Core::ControllerHelpers::Order
-      include ActionView::Helpers::TranslationHelper
 
       respond_to :json
 

--- a/api/app/views/spree/api/orders/could_not_apply_coupon.v1.rabl
+++ b/api/app/views/spree/api/orders/could_not_apply_coupon.v1.rabl
@@ -1,0 +1,2 @@
+object false
+node(:error) { @coupon_message }

--- a/api/spec/controllers/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/controllers/spree/api/checkouts_controller_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spree/promo/coupon_applicator'
 
 module Spree
   describe Api::CheckoutsController do
@@ -96,6 +97,13 @@ module Spree
         api_put :update, :id => order.to_param
         json_response['number'].should == order.number
         response.status.should == 200
+      end
+
+      it "can apply a coupon code to an order" do
+        order.update_column(:state, "payment")
+        Spree::Promo::CouponApplicator.should_receive(:new).with(order).and_call_original
+        Spree::Promo::CouponApplicator.any_instance.should_receive(:apply)
+        api_put :update, :id => order.to_param, :order => { :coupon_code => "foobar" }
       end
     end
   end

--- a/core/lib/spree/promo/coupon_applicator.rb
+++ b/core/lib/spree/promo/coupon_applicator.rb
@@ -1,0 +1,53 @@
+module Spree
+  module Promo
+    class CouponApplicator
+      attr_reader :order
+
+      def initialize(order)
+        @order = order
+      end
+
+      def apply
+        if @order.coupon_code.present?
+          # check if coupon code is already applied
+          if @order.adjustments.promotion.eligible.detect { |p| p.originator.promotion.code == @order.coupon_code }.present?
+            result = { :coupon_applied? => true, :notice => I18n.t(:coupon_code_already_applied) }
+          else
+            event_name = "spree.checkout.coupon_code_added"
+
+            promotion = Spree::Promotion.find_by_code(@order.coupon_code)
+
+            if promotion.present?
+              if promotion.expired?
+                result = { :coupon_applied? => false, :error => I18n.t(:coupon_code_expired) }
+              end
+
+              if promotion.usage_limit_exceeded?
+                result = { :coupon_applied? => false, :error => I18n.t(:coupon_code_max_usage) }
+              end
+
+              previous_promo = @order.adjustments.promotion.eligible.first
+              ActiveSupport::Notifications.instrument(event_name, :coupon_code => @order.coupon_code, :order => @order)
+              promo = @order.adjustments.promotion.detect { |p| p.originator.promotion.code == @order.coupon_code }
+              if promo.present? and promo.eligible
+                result = { :coupon_applied? => true, :success => I18n.t(:coupon_code_applied) }
+              elsif previous_promo.present? and promo.present?
+                result = { :coupon_applied? => false, :error => I18n.t(:coupon_code_better_exists) }
+              elsif promo.present?
+                result = { :coupon_applied? => false, :error => I18n.t(:coupon_code_not_eligible) }
+              else
+                # if the promotion was created after the order
+                result = { :coupon_applied? => false, :error => I18n.t(:coupon_code_not_found) }
+              end
+            else
+              result = { :coupon_applied? => false, :error => I18n.t(:coupon_code_not_found) }
+            end
+          end
+        else
+          result = { :coupon_applied? => true }
+        end
+        result
+      end
+    end
+  end
+end

--- a/core/lib/spree/promo/coupon_applicator.rb
+++ b/core/lib/spree/promo/coupon_applicator.rb
@@ -11,7 +11,7 @@ module Spree
         if @order.coupon_code.present?
           # check if coupon code is already applied
           if @order.adjustments.promotion.eligible.detect { |p| p.originator.promotion.code == @order.coupon_code }.present?
-            result = { :coupon_applied? => true, :notice => I18n.t(:coupon_code_already_applied) }
+            return { :coupon_applied? => true, :notice => I18n.t(:coupon_code_already_applied) }
           else
             event_name = "spree.checkout.coupon_code_added"
 
@@ -19,34 +19,33 @@ module Spree
 
             if promotion.present?
               if promotion.expired?
-                result = { :coupon_applied? => false, :error => I18n.t(:coupon_code_expired) }
+                return { :coupon_applied? => false, :error => I18n.t(:coupon_code_expired) }
               end
 
               if promotion.usage_limit_exceeded?
-                result = { :coupon_applied? => false, :error => I18n.t(:coupon_code_max_usage) }
+                return { :coupon_applied? => false, :error => I18n.t(:coupon_code_max_usage) }
               end
 
               previous_promo = @order.adjustments.promotion.eligible.first
               ActiveSupport::Notifications.instrument(event_name, :coupon_code => @order.coupon_code, :order => @order)
               promo = @order.adjustments.promotion.detect { |p| p.originator.promotion.code == @order.coupon_code }
               if promo.present? and promo.eligible
-                result = { :coupon_applied? => true, :success => I18n.t(:coupon_code_applied) }
+                return { :coupon_applied? => true, :success => I18n.t(:coupon_code_applied) }
               elsif previous_promo.present? and promo.present?
-                result = { :coupon_applied? => false, :error => I18n.t(:coupon_code_better_exists) }
+                return { :coupon_applied? => false, :error => I18n.t(:coupon_code_better_exists) }
               elsif promo.present?
-                result = { :coupon_applied? => false, :error => I18n.t(:coupon_code_not_eligible) }
+                return { :coupon_applied? => false, :error => I18n.t(:coupon_code_not_eligible) }
               else
                 # if the promotion was created after the order
-                result = { :coupon_applied? => false, :error => I18n.t(:coupon_code_not_found) }
+                return { :coupon_applied? => false, :error => I18n.t(:coupon_code_not_found) }
               end
             else
-              result = { :coupon_applied? => false, :error => I18n.t(:coupon_code_not_found) }
+              return { :coupon_applied? => false, :error => I18n.t(:coupon_code_not_found) }
             end
           end
         else
-          result = { :coupon_applied? => true }
+          return { :coupon_applied? => true }
         end
-        result
       end
     end
   end

--- a/core/spec/lib/spree/promo/coupon_applicator_spec.rb
+++ b/core/spec/lib/spree/promo/coupon_applicator_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe Spree::Promo::CouponApplicator do
+  subject do
+    Spree::Promo::CouponApplicator.new(order)
+  end
+
+  describe "#apply" do
+    let(:order) { create(:order, :state => "payment", :coupon_code => "tenoff") }
+
+    it "can apply a coupon code to an order" do
+      flat_percent_calc = Spree::Calculator::FlatPercentItemTotal.create(:preferred_flat_percent => "10")
+      promo = Spree::Promotion.create(:name => "Discount", :event_name => "spree.checkout.coupon_code_added", :code => "tenoff", :usage_limit => "10", :starts_at => DateTime.yesterday, :expires_at => DateTime.tomorrow)
+      promo_rule = Spree::Promotion::Rules::ItemTotal.create(:preferred_operator => "gt", :preferred_amount => "1")
+      promo_rule.update_attribute(:activator_id, promo.id)
+      promo_action = Spree::Promotion::Actions::CreateAdjustment.create(:calculator_type => "Spree::Calculator::FlatPercentItemTotal")
+      promo_action.update_attribute(:activator_id, promo.id)
+      flat_percent_calc.update_attribute(:calculable_id, promo.id)
+      Spree::Order.any_instance.stub(:payment_required? => false)
+      Spree::Adjustment.any_instance.stub(:eligible => true)
+      order.update_column(:state, "payment")
+      order.coupon_code = "tenoff"
+
+      subject.apply
+      order.adjustments.first.label.should == "Promotion (#{promo.name})"
+    end
+  end
+end

--- a/frontend/app/controllers/spree/store_controller.rb
+++ b/frontend/app/controllers/spree/store_controller.rb
@@ -7,7 +7,7 @@ module Spree
     end
 
     protected
-      # This method is placed here so that the CheckoutController 
+      # This method is placed here so that the CheckoutController
       # and OrdersController can both reference it.
       def apply_coupon_code
         if @order.coupon_code.present?


### PR DESCRIPTION
With 387650b a few weeks ago, I added a CheckoutsController to the spree API that is further explained at http://api.spreecommerce.com/v1/order/checkouts/

This is take two on this after receiving feedback last week. @radar, hoping this is more what we are looking for now that split_core is in master. I can expand on the CouponApplicator specs if that makes sense.

As always, feedback is welcome!
