### PR TITLE
Frontend CheckoutController #state_callbacks refactor

### DIFF
--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -1,22 +1,20 @@
 module Spree
-  # Handles checkout logic.  This is somewhat contrary to standard REST convention since there is not actually a
-  # Checkout object.  There's enough distinct logic specific to checkout which has nothing to do with updating an
-  # order that this approach is waranted.
-
-  # Much of this file, especially the update action is overriden in the promo gem.
-  # This is to allow for the promo behavior but also allow the promo gem to be 
-  # removed if the functionality is not needed. 
-
+  # This is somewhat contrary to standard REST convention since there is not
+  # actually a Checkout object. There's enough distinct logic specific to
+  # checkout which has nothing to do with updating an order that this approach
+  # is waranted.
   class CheckoutController < Spree::StoreController
     ssl_required
 
     before_filter :load_order
+    before_filter :ensure_order_not_completed
+    before_filter :ensure_checkout_allowed
+    before_filter :ensure_sufficient_stock_lines
+
     before_filter :ensure_valid_state
     before_filter :associate_user
     before_filter :check_authorization
     rescue_from Spree::Core::GatewayError, :with => :rescue_from_spree_gateway_error
-
-    helper 'spree/orders'
 
     helper 'spree/orders'
 
@@ -34,8 +32,7 @@ module Spree
           state_callback(:after)
         else
           flash[:error] = t(:payment_processing_failed)
-          redirect_to checkout_state_path(@order.state)
-          return
+          redirect_to checkout_state_path(@order.state) and return
         end
 
         if @order.state == "complete" || @order.completed?
@@ -69,11 +66,27 @@ module Spree
 
       def load_order
         @order = current_order
-        redirect_to spree.cart_path and return unless @order and @order.checkout_allowed?
-        raise_insufficient_quantity and return if @order.insufficient_stock_lines.present?
-        redirect_to spree.cart_path and return if @order.completed?
+        redirect_to spree.cart_path and return unless @order
+
         @order.state = params[:state] if params[:state]
         state_callback(:before)
+      end
+
+      def ensure_checkout_allowed
+        unless @order.checkout_allowed?
+          redirect_to spree.cart_path
+        end
+      end
+
+      def ensure_order_not_completed
+        redirect_to spree.cart_path if @order.completed?
+      end
+
+      def ensure_sufficient_stock_lines
+        if @order.insufficient_stock_lines.present?
+          flash[:error] = t(:spree_inventory_error_flash_for_insufficient_quantity)
+          redirect_to spree.cart_path
+        end
       end
 
       # Provides a route to redirect after order completion
@@ -81,22 +94,24 @@ module Spree
         spree.order_path(@order)
       end
 
+      # For payment step, filter order parameters to produce the expected nested
+      # attributes for a single payment and its source, discarding attributes
+      # for payment methods other than the one selected
       def object_params
-        # For payment step, filter order parameters to produce the expected nested attributes for a single payment and its source, discarding attributes for payment methods other than the one selected
         if @order.payment?
-          if params[:payment_source].present? && source_params = params.delete(:payment_source)[params[:order][:payments_attributes].first[:payment_method_id].underscore]
-            params[:order][:payments_attributes].first[:source_attributes] = source_params
+          if params[:payment_source].present?
+            source_params = params.delete(:payment_source)[params[:order][:payments_attributes].first[:payment_method_id].underscore]
+
+            if source_params
+              params[:order][:payments_attributes].first[:source_attributes] = source_params
+            end
           end
+
           if (params[:order][:payments_attributes])
             params[:order][:payments_attributes].first[:amount] = @order.total
           end
         end
         params[:order]
-      end
-
-      def raise_insufficient_quantity
-        flash[:error] = t(:spree_inventory_error_flash_for_insufficient_quantity)
-        redirect_to spree.cart_path
       end
 
       def state_callback(before_or_after = :before)


### PR DESCRIPTION
Hello there. This is just a suggestion for avoiding confusion among spree users such as the one described in #2488. `state_callback(:after)` doesn't make much sense and it doesn't behave as expected so I figured Spree may just be better off without it.

I also tried to clean up old invalid comments and spread `load_order` logic into more methods.

Please let me know if that looks good and I might submit patches for 1-2-stable as well.
