### PR TITLE
1 3 stable

### DIFF
--- a/core/app/views/spree/shared/_main_nav_bar.html.erb
+++ b/core/app/views/spree/shared/_main_nav_bar.html.erb
@@ -1,6 +1,6 @@
 <nav class="columns sixteen">
   <ul id="main-nav-bar" class="inline" data-hook>
-    <li id="home-link" data-hook><%= link_to t(:home), root_path %></li>
+    <li id="home-link" data-hook><%= link_to t(:home), spree.root_path %></li>
     <li id="link-to-cart" data-hook><%= link_to_cart %></li>
   </ul>
 </nav>

--- a/core/app/views/spree/shared/_search.html.erb
+++ b/core/app/views/spree/shared/_search.html.erb
@@ -1,5 +1,5 @@
 <% @taxons = @taxon && @taxon.parent ? @taxon.parent.children : Spree::Taxon.roots %>
-<%= form_tag products_path, :method => :get do %>
+<%= form_tag spree.products_path, :method => :get do %>
   <%= select_tag :taxon,
         options_for_select([[t(:all_departments), '']] +
                               @taxons.map {|t| [t.name, t.id]},


### PR DESCRIPTION
I changed the root_path to spree.root_path and products_path to spree.products_path in order to allow the partials to be rendered within non-spree templates. I believe this counts as refactoring, but let me know if you need tests. 
