### PR TITLE
Bump rails version to 3.1.11

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rd_resource_controller'
   s.add_dependency 'meta_search', '= 1.1.1'
   s.add_dependency 'activemerchant', '= 1.17.0'
-  s.add_dependency 'rails', '3.1.6'
+  s.add_dependency 'rails', '3.1.11'
   s.add_dependency 'kaminari', '>= 0.12.4'
   s.add_dependency 'deface', '>= 0.7.0'
 end


### PR DESCRIPTION
Updates Rails version to 3.1.11 which fixes important security vulnerabilities
