### PR TITLE
spree namespace missing here 

### DIFF
--- a/backend/app/views/spree/admin/shared/_alert.html.erb
+++ b/backend/app/views/spree/admin/shared/_alert.html.erb
@@ -1,5 +1,5 @@
 <div class="alert <%= alert.severity.downcase %>">
   <%= alert.message %> <%= link_to alert.url_name, alert.url if alert.url %>
-  <%= link_to 'X', dismiss_alert_admin_general_settings_path(:alert_id => alert.id),
+  <%= link_to 'X', spree.dismiss_alert_admin_general_settings_path(:alert_id => alert.id),
               :remote => true, :method => :post, :class => 'dismiss' %>
 </div>


### PR DESCRIPTION
Causes errors in custom admin sections.
Should be merged in spree-1.3-stable.
