### PR TITLE
Re-add missing update_positions_admin_product_product_properties_url

### DIFF
--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -62,7 +62,11 @@ Spree::Core::Engine.routes.append do
     resources :tax_categories
 
     resources :products do
-      resources :product_properties
+      resources :product_properties do
+        collection do
+          post :update_positions
+        end
+      end
       resources :images do
         collection do
           post :update_positions

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -99,6 +99,8 @@ Spree::Core::Engine.routes.append do
       end
     end
 
+    delete '/product_properties/:id', :to => "product_properties#destroy", :as => :product_property
+
     resources :prototypes do
       member do
         get :select

--- a/backend/spec/requests/admin/products/properties_spec.rb
+++ b/backend/spec/requests/admin/products/properties_spec.rb
@@ -59,4 +59,22 @@ describe "Properties" do
       page.should have_content("Name can't be blank")
     end
   end
+
+  context "linking a property to a product", :js => true do
+    before do
+      create(:product)
+      visit spree.admin_products_path
+      click_icon :edit
+      click_link "Product Properties"
+    end
+
+    # Regression test for #2279
+    specify do
+      fill_in "product_product_properties_attributes_0_property_name", :with => "A Property"
+      fill_in "product_product_properties_attributes_0_value", :with => "A Value"
+      click_button "Update"
+      click_link "Product Properties"
+      all("tbody#product_properties tr").count.should == 2
+    end
+  end
 end


### PR DESCRIPTION
Somehow this method got lost in one of the more recent commits
