### PR TITLE
Fixes first order promotion rule

### DIFF
--- a/core/app/models/spree/promotion/rules/first_order.rb
+++ b/core/app/models/spree/promotion/rules/first_order.rb
@@ -2,20 +2,27 @@ module Spree
   class Promotion
     module Rules
       class FirstOrder < PromotionRule
+        attr_reader :user, :email
+
         def eligible?(order, options = {})
-          user = order.try(:user) || options[:user]
-          if user
-            return orders_by_email(user.email) == 0
-          elsif order.email
-            return orders_by_email(order.email) == 0
+          @user = order.try(:user) || options[:user]
+          @email = order.email
+
+          if user || email
+            completed_orders.blank? || (completed_orders.first == order)
+          else
+            false
+          end
+        end
+
+        private
+          def completed_orders
+            user ? user.orders.complete : orders_by_email
           end
 
-          return false
-        end
-
-        def orders_by_email(email)
-          Spree::Order.where(:email => email).count
-        end
+          def orders_by_email
+            Spree::Order.where(:email => email).complete
+          end
       end
     end
   end

--- a/core/spec/models/spree/promotion/rules/first_order_spec.rb
+++ b/core/spec/models/spree/promotion/rules/first_order_spec.rb
@@ -3,29 +3,47 @@ require 'spec_helper'
 describe Spree::Promotion::Rules::FirstOrder do
   let(:rule) { Spree::Promotion::Rules::FirstOrder.new }
   let(:order) { mock_model(Spree::Order, :user => nil, :email => nil) }
+  let(:user) { mock_model(Spree::LegacyUser) }
 
   it "should not be eligible without a user or email" do
     rule.should_not be_eligible(order)
   end
 
-  context "should be eligible if user does not have any other completed orders yet" do
-    let(:user) { mock_model(Spree::LegacyUser) }
+  context "first order" do
+    context "for a signed user" do
+      context "with no completed orders" do
+        before(:each) do
+          user.stub_chain(:orders, :complete => [])
+        end
 
-    before do
-      user.stub_chain(:orders, :complete, :count => 0)
+        specify do
+          order.stub(:user => user)
+          rule.should be_eligible(order)
+        end
+
+        it "should be eligible when user passed in payload data" do
+          rule.should be_eligible(order, :user => user)
+        end
+      end
+
+      context "with completed orders" do
+        before(:each) do
+          order.stub(:user => user)
+        end
+
+        it "should be eligible when checked against first completed order" do
+          user.stub_chain(:orders, :complete => [order])
+          rule.should be_eligible(order)
+        end
+
+        it "should not be eligible with another order" do
+          user.stub_chain(:orders, :complete => [mock_model(Spree::Order)])
+          rule.should_not be_eligible(order)
+        end
+      end
     end
 
-    it "for an order without a user, but with user in payload data" do
-      rule.should be_eligible(order, :user => user)
-    end
-
-    it "for an order with a user, no user in payload data" do
-      order.stub :user => user
-      rule.should be_eligible(order)
-    end
-
-    # Regression test for #2306
-    context "for an order with a 'guest' user" do
+    context "for a guest user" do
       let(:email) { 'user@spreecommerce.com' }
       before { order.stub :email => 'user@spreecommerce.com' }
 
@@ -34,14 +52,9 @@ describe Spree::Promotion::Rules::FirstOrder do
       end
 
       context "with another order" do
-        before { rule.stub(:orders_by_email => 1) }
+        before { rule.stub(:orders_by_email => [mock_model(Spree::Order)]) }
         it { rule.should_not be_eligible(order) }
       end
-    end
-
-    it "#orders_by_email" do
-      Spree::Order.create!(:email => "user@spreecommerce.com")
-      rule.orders_by_email("user@spreecommerce.com").should == 1
     end
   end
 end


### PR DESCRIPTION
I was going to submit a patch to fix a scenario which involved the `FirstOrder` but then realized that the rule was not working at all.

The scenario was:

Store has a promo with a the first order rule.
Customer places an order and the discount applies to this order, as it should
Admin updates the order some how. e.g. updates a shipment
The first order discount is removed from the order when it shouldn't.

That is in a Spree store tracked somewhere between Spree 1.2 and Spree 1.3. Spree should not remove the discount from the first order when it's completed.

This patch fixes that and also the logic involving the promotion rule. I believe this was the commit that introduced the bug c014893b7dc2560a581f62096e448d546440c9f7. Currently promotions with this rule will probably never be eligible (for signed in users) due to this logic:

``` ruby
...
if user
  return orders_by_email(user.email) == 0
elsif order.email
  return orders_by_email(order.email) == 0
end
...

def orders_by_email(email)
  Spree::Order.where(:email => email).count
end
```

Please let me know if I missed anything. Is 1-2-stable still receiving pull requests? We could apply this there and resolve #2306
