### PR TITLE
Fix edit payment

### DIFF
--- a/core/app/controllers/spree/checkout_controller.rb
+++ b/core/app/controllers/spree/checkout_controller.rb
@@ -14,6 +14,8 @@ module Spree
     before_filter :ensure_valid_state
     before_filter :associate_user
     before_filter :check_authorization
+    before_filter :clear_existing_payments, :only => :update
+
     rescue_from Spree::Core::GatewayError, :with => :rescue_from_spree_gateway_error
 
     respond_to :html
@@ -122,5 +124,12 @@ module Spree
       def check_authorization
         authorize!(:edit, current_order, session[:access_token])
       end
+
+      # if there is already a payment on this order, we want to update it
+      # rather than creating a new one
+      def clear_existing_payments
+        @order.payments.destroy_all if params[:order][:payments_attributes].any?
+      end
+
   end
 end

--- a/core/app/controllers/spree/checkout_controller.rb
+++ b/core/app/controllers/spree/checkout_controller.rb
@@ -127,7 +127,7 @@ module Spree
 
       # "PUT Update" will create a new payment/source through update_attributes, so we delete existing payments first
       def clear_existing_payments
-        @order.payments.destroy_all if @order.payment
+        @order.payments.destroy_all if params[:order] && params[:order][:payments_attributes]
       end
 
   end

--- a/core/app/controllers/spree/checkout_controller.rb
+++ b/core/app/controllers/spree/checkout_controller.rb
@@ -125,10 +125,9 @@ module Spree
         authorize!(:edit, current_order, session[:access_token])
       end
 
-      # if there is already a payment on this order, we want to update it
-      # rather than creating a new one
+      # "PUT Update" will create a new payment/source through update_attributes, so we delete existing payments first
       def clear_existing_payments
-        @order.payments.destroy_all if params[:order][:payments_attributes].any?
+        @order.payments.destroy_all if @order.payment
       end
 
   end

--- a/core/spec/requests/checkout_spec.rb
+++ b/core/spec/requests/checkout_spec.rb
@@ -72,11 +72,12 @@ describe "Checkout" do
       end
     end
 
-    context "and likes to double click buttons" do
-      before(:each) do
-        user = create(:user)
+    context "order requires confirmation" do
 
-        order = OrderWalkthrough.up_to(:delivery)
+      let(:order) { OrderWalkthrough.up_to(:delivery) }
+      let(:user) { create(:user) }
+      before(:each) do
+
         order.stub :confirmation_required? => true
 
         order.reload
@@ -88,26 +89,29 @@ describe "Checkout" do
         Spree::CheckoutController.any_instance.stub(:skip_state_validation? => true)
       end
 
-      it "prevents double clicking the payment button on checkout", :js => true do
-        visit spree.checkout_state_path(:payment)
+      describe "likes to double click buttons" do
 
-        # prevent form submit to verify button is disabled
-        page.execute_script("$('#checkout_form_payment').submit(function(){return false;})")
+        it "prevents double clicking the payment button on checkout", :js => true do
+          visit spree.checkout_state_path(:payment)
 
-        page.should_not have_selector('input.button[disabled]')
-        click_button "Save and Continue"
-        page.should have_selector('input.button[disabled]')
-      end
+          # prevent form submit to verify button is disabled
+          page.execute_script("$('#checkout_form_payment').submit(function(){return false;})")
 
-      it "prevents double clicking the confirm button on checkout", :js => true do
-        visit spree.checkout_state_path(:confirm)
+          page.should_not have_selector('input.button[disabled]')
+          click_button "Save and Continue"
+          page.should have_selector('input.button[disabled]')
+        end
 
-        # prevent form submit to verify button is disabled
-        page.execute_script("$('#checkout_form_confirm').submit(function(){return false;})")
+        it "prevents double clicking the confirm button on checkout", :js => true do
+          visit spree.checkout_state_path(:confirm)
 
-        page.should_not have_selector('input.button[disabled]')
-        click_button "Place Order"
-        page.should have_selector('input.button[disabled]')
+          # prevent form submit to verify button is disabled
+          page.execute_script("$('#checkout_form_confirm').submit(function(){return false;})")
+
+          page.should_not have_selector('input.button[disabled]')
+          click_button "Place Order"
+          page.should have_selector('input.button[disabled]')
+        end
       end
 
       # Regression test for #1596

--- a/core/spec/requests/checkout_spec.rb
+++ b/core/spec/requests/checkout_spec.rb
@@ -114,6 +114,20 @@ describe "Checkout" do
         end
       end
 
+      context 'payment already exists on order' do
+        before(:each) do
+          payment = order.payments.new
+          payment.payment_method = Spree::PaymentMethod.first
+          payment.save!
+        end
+
+        it 'updates the existing payment' do
+          visit spree.checkout_state_path(:payment)
+          expect { click_button "Save and Continue" }.to_not change{ order.payments.count }
+        end
+      end
+
+
       # Regression test for #1596
       context "full checkout" do
         before do


### PR DESCRIPTION
As discussed in IRC, this isn't pretty but its the best I've got at the moment.

I tried updating existing payments using the nested attributes, but can't effectively get build_source called on a payment when @order.update_attributes is called, so I elected to delete all the payments when update is hit with payment information. 
