### PR TITLE
Add missing end keyword removed by 63755d

### DIFF
--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -70,6 +70,7 @@ module Spree
           :password_confirmation,
           :number,
           :verification_value]
+      end
 
       # sets the manifests / assets to be precompiled, even when initialize_on_precompile is false
       initializer "spree.assets.precompile", :group => :all do |app|


### PR DESCRIPTION
Reported error
core/lib/spree/core/engine.rb:95: syntax error, unexpected $end, expecting keyword_end
 (SyntaxError)
