### PR TITLE
Adjust admin product tab selected (1-3-stable)

### DIFF
--- a/core/app/views/spree/admin/shared/_tabs.html.erb
+++ b/core/app/views/spree/admin/shared/_tabs.html.erb
@@ -1,5 +1,5 @@
 <%= tab :overview, :route => :admin, :icon => 'icon-dashboard' %>
 <%= tab :orders, :payments, :creditcard_payments, :shipments, :credit_cards, :return_authorizations, :icon => 'icon-shopping-cart' %>
-<%= tab :products , :option_types, :properties, :prototypes, :variants, :product_properties, :taxons, :icon => 'icon-th-large' %>
+<%= tab :products , :option_types, :properties, :prototypes, :variants, :product_properties, :icon => 'icon-th-large' %>
 <%= tab :reports, :icon => 'icon-file'  %>
 <%= tab :configurations, :general_settings, :mail_methods, :tax_categories, :zones, :states, :payment_methods, :inventory_settings, :taxonomies, :shipping_methods, :trackers, :label => 'configuration', :icon => 'icon-wrench', :url => edit_admin_general_settings_path %>


### PR DESCRIPTION
removing taxon from the list of controllers which make it selected.

Same as #2579 but for 1-3-stable
