### PR TITLE
Order#show Template Tweak

### DIFF
--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -37,7 +37,7 @@
       
       <div class="four columns">
         <div class="field">
-          <%= label_tag nil, t(:order_number) %>
+          <%= label_tag nil, t(:order_number, :number => '') %>
           <%= f.text_field :number_cont %>
         </div>
         <div class="field">

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -682,7 +682,7 @@ en:
       thanks: "Thank you for your business."
       total: "Order Total: %{total}"
   order_not_in_system: "That order number is not valid on this site."
-  order_number: Order
+  order_number: "Order #%{number}"
   order_operation_authorize: Authorize
   order_processed_but_following_items_are_out_of_stock: "Your order has been processed, but following items are out of stock:"
   order_processed_successfully: "Your order has been processed successfully"

--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -64,7 +64,7 @@ module Spree
     end
 
     def accurate_title
-      @order && @order.completed? ? "#{Order.model_name.human} #{@order.number}" : t(:shopping_cart)
+      @order && @order.completed? ? t(:order_number, :number => @order.number) : t(:shopping_cart)
     end
 
     def check_authorization

--- a/frontend/app/views/spree/orders/show.html.erb
+++ b/frontend/app/views/spree/orders/show.html.erb
@@ -1,5 +1,5 @@
 <fieldset id="order_summary" data-hook>
-  <legend align="center"><%= t(:order) + " #" + @order.number %></legend>
+  <legend><%= t(:order) + " #" + @order.number %></legend>
   <h1><%= accurate_title %></h1>
 
   <div id="order" data-hook>

--- a/frontend/app/views/spree/orders/show.html.erb
+++ b/frontend/app/views/spree/orders/show.html.erb
@@ -1,5 +1,5 @@
 <fieldset id="order_summary" data-hook>
-  <legend><%= t(:order) + " #" + @order.number %></legend>
+  <legend><%= t(:order_number, :number => @order.number) %></legend>
   <h1><%= accurate_title %></h1>
 
   <div id="order" data-hook>


### PR DESCRIPTION
- `align="center"` on the `legend` should either be removed or moved to CSS
- I moved the 'Order #' display to the yml file – makes some code more readible
