### PR TITLE
Fixes backend New Product button for edit page

### DIFF
--- a/backend/app/views/spree/admin/products/edit.html.erb
+++ b/backend/app/views/spree/admin/products/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_actions do %>
   <li><%= button_link_to t(:back_to_products_list), session[:return_to] || admin_products_url, :icon => 'icon-arrow-left' %></li>
   <li id="new_product_link">
-    <%= button_link_to t(:new_product), new_object_url, { :remote => true, :icon => 'icon-plus', :id => 'admin_new_product' } %>
+    <%= button_link_to t(:new_product), new_object_url, { :icon => 'icon-plus', :id => 'admin_new_product' } %>
   </li>
 <% end %>
 


### PR DESCRIPTION
Backend products edit page has too much content already. While we could
just add:

```
<div id="new_product" data-hook></div>
```

to make the form load on the same page imo it's less confusing to just
open the form for a new product in a new page.

fixes #2531
