### PR TITLE
Add variant_id index to spree_prices

### DIFF
--- a/core/db/migrate/20130226054936_add_variant_id_index_to_spree_prices.rb
+++ b/core/db/migrate/20130226054936_add_variant_id_index_to_spree_prices.rb
@@ -1,0 +1,5 @@
+class AddVariantIdIndexToSpreePrices < ActiveRecord::Migration
+  def change
+    add_index :spree_prices, :variant_id
+  end
+end


### PR DESCRIPTION
Necessary since we spree_prices is automatically included when
listing products (whereever the default searcher is used)
