### PR TITLE
Fixing locked orders due to invalid card details for a payment

### DIFF
--- a/core/app/models/spree/gateway.rb
+++ b/core/app/models/spree/gateway.rb
@@ -44,5 +44,11 @@ module Spree
     def method_type
       'gateway'
     end
+
+    def supports?(source)
+      return true unless provider_class.respond_to? :supports?
+      return false unless source.brand
+      provider_class.supports?(source.brand)
+    end
   end
 end

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -29,8 +29,10 @@ module Spree
     after_rollback :persist_invalid
 
     def persist_invalid
-      state_will_change!
-      save 
+      if state == 'invalid'
+        state_will_change!
+        save 
+      end
     end
 
     # order state machine (see http://github.com/pluginaweek/state_machine/tree/master for details)

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -26,6 +26,13 @@ module Spree
     scope :pending, with_state('pending')
     scope :failed, with_state('failed')
 
+    after_rollback :persist_invalid
+
+    def persist_invalid
+      state_will_change!
+      save 
+    end
+
     # order state machine (see http://github.com/pluginaweek/state_machine/tree/master for details)
     state_machine :initial => 'checkout' do
       # With card payments, happens before purchase or authorization happens
@@ -46,6 +53,10 @@ module Spree
       end
       event :void do
         transition :from => ['pending', 'completed', 'checkout'], :to => 'void'
+      end
+      # when the card brand isnt supported
+      event :invalidate! do
+        transition :from => ['checkout'], :to => 'invalid'
       end
     end
 

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -29,10 +29,8 @@ module Spree
     after_rollback :persist_invalid
 
     def persist_invalid
-      if state == 'invalid'
-        state_will_change!
-        save 
-      end
+      state_will_change!
+      save 
     end
 
     # order state machine (see http://github.com/pluginaweek/state_machine/tree/master for details)

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -29,6 +29,7 @@ module Spree
     after_rollback :persist_invalid
 
     def persist_invalid
+      return unless ['failed', 'invalid'].include?(state)
       state_will_change!
       save 
     end
@@ -55,7 +56,7 @@ module Spree
         transition :from => ['pending', 'completed', 'checkout'], :to => 'void'
       end
       # when the card brand isnt supported
-      event :invalidate! do
+      event :invalidate do
         transition :from => ['checkout'], :to => 'invalid'
       end
     end

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -5,10 +5,15 @@ module Spree
         if payment_method && payment_method.source_required?
           if source
             if !processing?
-              if payment_method.auto_capture?
-                purchase!
+              if payment_method.supports?(source)
+                if payment_method.auto_capture?
+                  purchase!
+                else
+                  authorize!
+                end
               else
-                authorize!
+                invalidate!
+                raise Core::GatewayError.new(I18n.t(:payment_method_not_supported))
               end
             end
           else

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -58,5 +58,9 @@ module Spree
     def auto_capture?
       Spree::Config[:auto_capture]
     end
+
+    def supports?(source)
+      true
+    end
   end
 end


### PR DESCRIPTION
This fixes the locked order issue described in previous issue https://github.com/spree/spree/issues/1767

A brief review of the issue:
If a user tries to place an order, but their credit card details are invalid the payment will change its state to failed, however due to database transaction being owned by the order for that payment, the transaction is rolled back because the code raises an exception during the state transition for the order.

To reproduce:
1) Configure a payment method which uses a BogusSimple Gatway.
2) Populate a Basket in the store
3) Checkout the basket, during the payment step, enter an incorrect credit card number e.g. 1234123412341234
If you follow the process_payments! method through using the ruby debugger, you will see the state of the payment will move from checkout -> processing -> failed, however, when process_payments! returns false due to the payment being failed, the transition (Spree::Order::Checkout before_transition :to => :complete) will rollback the Order transaction, causing the child payments state to be rolled back to checkout as well.
4) The payment view will re render, with a blank credit card form, this time enter a valid credit card number e.g. 
4111111111111111
At this point you would expect the order to complete, however the order attempts to process the initial payment, that is in the 'checkout' state due to the rollback, and once again this initial payment fails, therefore causing the whole Order transition to fail again.

To fix this I added an after_rollback hook to payment class which forces a save on the object if its state is failed.

Along side this fix, I have included some code to add a new 'invalid' state to the payment object. Payment#process! will invoke the invalidate! event if the payment_method does not support the payment source. I have implemented Gateway#supports? to check if the card brand is supported by the chosen gateway. I have done this because using an incorrect card with some gateways (for my case Worldpay) causes an exception to be thrown due to the card having no brand (due to an incorrectly formatted card number), I added the new state as I wasnt sure if setting the state to failed would imply a greater error / enables additional functionality elsewhere in the codebase.

Please note that although I have added some specs, and fixed any which I have broken, there were already some failing which I haven't been able to fix for you...

rspec ./spec/controllers/spree/orders_controller_extension_spec.rb:27 # Spree::OrdersController extension testing update specify symbol for handler instead of Proc POST has value success
rspec ./spec/controllers/spree/orders_controller_extension_spec.rb:44 # Spree::OrdersController extension testing update render POST has value success
rspec ./spec/controllers/spree/orders_controller_extension_spec.rb:61 # Spree::OrdersController extension testing update redirect POST has value success
rspec ./spec/controllers/spree/orders_controller_extension_spec.rb:78 # Spree::OrdersController extension testing update validation error POST has value success
rspec ./spec/controllers/spree/orders_controller_extension_spec.rb:94 # Spree::OrdersController extension testing update A different controllers respond_override. Regression test for #1301 POST should not effect the wrong controller
rspec ./spec/requests/admin/products/edit/taxons_spec.rb:11 # Product Taxons managing taxons should allow an admin to manage taxons
