### PR TITLE
Refactor taxonomy js tree

### DIFF
--- a/backend/app/assets/javascripts/admin/taxonomy.js
+++ b/backend/app/assets/javascripts/admin/taxonomy.js
@@ -76,9 +76,8 @@ var handle_delete = function(e, data){
 
 };
 
-var taxonomy_id; 
 
-$(document).ready(function(){
+var setup_taxonomy_tree = function(taxonomy_id) {
   if(taxonomy_id!=undefined){
     $.ajax({
       url: '/api/taxonomies/' + taxonomy_id + '/jstree', 
@@ -210,4 +209,4 @@ $(document).ready(function(){
       }
     });
   }
-});
+};

--- a/backend/app/views/spree/admin/taxonomies/_js_head.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/_js_head.html.erb
@@ -3,6 +3,11 @@
     var loading = '#{escape_javascript t(:loading)}';
     var new_taxon = '#{escape_javascript t(:new_taxon)}';
     var server_error = '#{escape_javascript t(:server_error)}';
-    var taxonomy_tree_error = '#{escape_javascript t(:taxonomy_tree_error)}';"
+    var taxonomy_tree_error = '#{escape_javascript t(:taxonomy_tree_error)}';
+
+    $(document).ready(function(){
+      setup_taxonomy_tree(taxonomy_id);
+    });
+    "
   %>
 <% end %>


### PR DESCRIPTION
As we discussed in #2192, I re-did my changes on the split_core branch.

You've been doing a lot of great work! 

I only needed to change a couple of lines on this branch to get the desired functionality: I wanted to be able to re-use the taxonomy tree editor elsewhere, which basically just required turning it into a function which accepts `taxonomy_id`, instead of having it load automatically based on the global `taxonomy_id` variable.

(On my original PR, I made a lot more changes, but looks like the Spree::API stuff takes care of all that now).

One last note: has the procedure for running the tests changed? I'm confident this change doesn't break anything in admin/taxonomies/edit, but I don't know if there were other places that used the code, because I couldn't get the tests to run.

I generated the sample app and ran `bundle exec rake spec` (and tried `bundle exec rspec` too), with no results. Also, the generated sample app doesn't seem to be there, even though it said it was generating and took a while to run.
