### PR TITLE
Let to specify the separator and delimiter based on the current locale c...

### DIFF
--- a/core/lib/spree/money.rb
+++ b/core/lib/spree/money.rb
@@ -10,6 +10,12 @@ module Spree
       @options[:with_currency] = true if Spree::Config[:display_currency]
       @options[:symbol_position] = Spree::Config[:currency_symbol_position].to_sym
       @options[:no_cents] = true if Spree::Config[:hide_cents]
+      
+      # This three lines will let other 'locale' configurations to use their specific separator and delimiter
+      separator, delimiter = I18n.t([:'number.currency.format.separator', :'number.currency.format.delimiter'])
+      @options[:separator] = separator
+      @options[:delimiter] = delimiter
+
       @options.merge!(options)
       # Must be a symbol because the Money gem doesn't do the conversion
       @options[:symbol_position] = @options[:symbol_position].to_sym


### PR DESCRIPTION
...onfiguration

Looking for the proper way to change the delimiter and separator, I've
found a place that the locale was been used to decide which delimiter and
separator to use. So I changed it as follow.
