### PR TITLE
Adds tracking_url field to shipping methods

### DIFF
--- a/backend/app/views/spree/admin/shipments/index.html.erb
+++ b/backend/app/views/spree/admin/shipments/index.html.erb
@@ -29,7 +29,7 @@
         <td><%= shipment.number %></td>
         <td><%= shipment.shipping_method.name if shipment.shipping_method %></td>
         <td><%= shipment.display_cost %></td>
-        <td><%= shipment.tracking %></td>
+        <td><%= link_to_tracking shipment, :target => '_blank' %></td>
         <td><%= t(shipment.state.to_sym, :scope => :state_names, :default => shipment.state.to_s.humanize) %></td>
         <td><%= shipment.shipped_at.to_s(:date_time24) if shipment.shipped_at %></td>
         <td class="actions" data-hook="admin_shipments_index_row_actions">

--- a/backend/app/views/spree/admin/shipping_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/_form.html.erb
@@ -22,6 +22,14 @@
       <%= error_message_on :shipping_method, :display_on %>
     <% end %>
   </div>
+
+  <div class="alpha twelve columns">
+    <%= f.field_container :tracking_url do %>
+      <%= f.label :tracking_url, t(:tracking_url) %><br />
+      <%= f.text_field :tracking_url, :class => 'fullwidth', :placeholder => t(:tracking_url_placeholder) %>
+      <%= error_message_on :shipping_method, :tracking_url %>
+    <% end %>
+  </div>
 </div>
 
 <div data-hook="admin_shipping_method_form_availability_fields" class="alpha six columns">

--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -163,11 +163,11 @@ module Spree
       end
     end
 
-    def link_to_tracking(shipment)
+    def link_to_tracking(shipment, options = {})
       return unless shipment.tracking
 
       if shipment.tracking_url
-        link_to(shipment.tracking, shipment.tracking_url)
+        link_to(shipment.tracking, shipment.tracking_url, options)
       else
         content_tag(:span, shipment.tracking)
       end

--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -163,6 +163,16 @@ module Spree
       end
     end
 
+    def link_to_tracking(shipment)
+      return unless shipment.tracking
+
+      if shipment.tracking_url
+        link_to(shipment.tracking, shipment.tracking_url)
+      else
+        content_tag(:span, shipment.tracking)
+      end
+    end
+
     private
 
     # Returns style of image or nil

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -556,6 +556,10 @@ module Spree
       adjustments.eligible.promotion.map(&:amount).sum
     end
 
+    def shipped?
+      %w(partial shipped).include?(shipment_state)
+    end
+
     private
       def link_by_email
         self.email = user.email if self.user
@@ -583,9 +587,7 @@ module Spree
 
         #TODO: make_shipments_pending
         OrderMailer.cancel_email(self).deliver
-        unless %w(partial shipped).include?(shipment_state)
-          self.payment_state = 'credit_owed'
-        end
+        self.payment_state = 'credit_owed' unless shipped?
       end
 
       def restock_items!

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -119,6 +119,10 @@ module Spree
       order.paid? ? 'ready' : 'pending'
     end
 
+    def tracking_url
+      shipping_method.build_tracking_url(tracking)
+    end
+
     private
       def generate_shipment_number
         return number unless number.blank?

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -30,6 +30,8 @@ module Spree
     scope :shipped, with_state('shipped')
     scope :ready, with_state('ready')
     scope :pending, with_state('pending')
+    scope :trackable, where("spree_shipments.tracking is not null
+                             and spree_shipments.tracking != ''")
 
     def to_param
       number if number

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -120,7 +120,7 @@ module Spree
     end
 
     def tracking_url
-      shipping_method.build_tracking_url(tracking)
+      @tracking_url ||= shipping_method.build_tracking_url(tracking)
     end
 
     private

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -58,5 +58,9 @@ module Spree
     def self.all_available(order)
       all.select { |method| method.available_to_order?(order) }
     end
+
+    def build_tracking_url(tracking)
+      tracking_url.gsub(/:tracking/, tracking) unless tracking.blank? || tracking_url.blank?
+    end
   end
 end

--- a/core/app/views/spree/shipment_mailer/shipped_email.text.erb
+++ b/core/app/views/spree/shipment_mailer/shipped_email.text.erb
@@ -10,6 +10,7 @@
 <% end %>
 ============================================================
 
-<%= t('shipment_mailer.shipped_email.track_information', :tracking => @shipment.tracking) if @shipment.tracking %>
+<%= t('shipment_mailer.shipped_email.track_information', :tracking => @shipment.tracking)     if @shipment.tracking %>
+<%= t('shipment_mailer.shipped_email.track_link',        :url      => @shipment.tracking_url) if @shipment.tracking_url %>
 
 <%= t('shipment_mailer.shipped_email.thanks') %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -985,6 +985,7 @@ en:
       subject: "Shipment Notification"
       thanks: "Thank you for your business."
       track_information: "Tracking Information: %{tracking}"
+      track_link: "Tracking Link: %{url}"
   shipment_number: "Shipment #"
   shipment_state: "Shipment State"
   shipment_states:

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1105,6 +1105,8 @@ en:
   to_state: "To State"
   total: Total
   tracking: Tracking
+  tracking_url: Tracking URL
+  tracking_url_placeholder: "e.g. http://quickship.com/package?num=:tracking"
   transaction: Transaction
   transactions: Transactions
   tree: Tree

--- a/core/db/migrate/20130301205200_add_tracking_url_to_spree_shipping_methods.rb
+++ b/core/db/migrate/20130301205200_add_tracking_url_to_spree_shipping_methods.rb
@@ -1,0 +1,5 @@
+class AddTrackingUrlToSpreeShippingMethods < ActiveRecord::Migration
+  def change
+    add_column :spree_shipping_methods, :tracking_url, :string
+  end
+end

--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -96,4 +96,28 @@ describe Spree::BaseHelper do
       helper.output_buffer.should == "<div class=\"flash notice\">ok</div>"
     end
   end
+
+  context "link_to_tracking" do
+    it "returns tracking link if available" do
+      a = link_to_tracking_html(tracking: '123', tracking_url: 'http://g.c/?t=123').css('a')
+
+      a.text.should == '123'
+      a.attr('href').value.should == 'http://g.c/?t=123'
+    end
+
+    it "returns tracking without link if link unavailable" do
+      html = link_to_tracking_html(tracking: '123', tracking_url: nil)
+      html.css('span').text.should == '123'
+    end
+
+    it "returns nothing when no tracking" do
+      html = link_to_tracking_html(tracking: nil)
+      html.css('span').text.should == ''
+    end
+
+    def link_to_tracking_html(options = {})
+      node = link_to_tracking(stub(:shipment, options))
+      Nokogiri::HTML(node.to_s)
+    end
+  end
 end

--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -99,19 +99,19 @@ describe Spree::BaseHelper do
 
   context "link_to_tracking" do
     it "returns tracking link if available" do
-      a = link_to_tracking_html(tracking: '123', tracking_url: 'http://g.c/?t=123').css('a')
+      a = link_to_tracking_html(:tracking => '123', :tracking_url => 'http://g.c/?t=123').css('a')
 
       a.text.should == '123'
       a.attr('href').value.should == 'http://g.c/?t=123'
     end
 
     it "returns tracking without link if link unavailable" do
-      html = link_to_tracking_html(tracking: '123', tracking_url: nil)
+      html = link_to_tracking_html(:tracking => '123', :tracking_url => nil)
       html.css('span').text.should == '123'
     end
 
     it "returns nothing when no tracking" do
-      html = link_to_tracking_html(tracking: nil)
+      html = link_to_tracking_html(:tracking => nil)
       html.css('span').text.should == ''
     end
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -289,6 +289,16 @@ describe Spree::Order do
     end
   end
 
+  context "#shipped?" do
+    specify { order_with_shipment_state("partial").should   be_shipped }
+    specify { order_with_shipment_state("shipped").should   be_shipped }
+    specify { order_with_shipment_state("ready").should_not be_shipped }
+
+    def order_with_shipment_state(state)
+      order.tap {|o| o.shipment_state = state }
+    end
+  end
+
   context "rate_hash" do
     let(:shipping_method_1) { mock_model Spree::ShippingMethod, :name => 'Air Shipping', :id => 1, :calculator => mock('calculator') }
     let(:shipping_method_2) { mock_model Spree::ShippingMethod, :name => 'Ground Shipping', :id => 2, :calculator => mock('calculator') }

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -223,4 +223,13 @@ describe Spree::Shipment do
       shipment.display_cost.should == Spree::Money.new(21.22)
     end
   end
+
+  context "#tracking_url" do
+    it "uses shipping method to determine url" do
+      shipping_method.should_receive(:build_tracking_url).with("1Z12345").and_return(:some_url)
+      shipment.tracking = "1Z12345"
+
+      shipment.tracking_url.should == :some_url
+    end
+  end
 end

--- a/core/spec/models/spree/shipping_method_spec.rb
+++ b/core/spec/models/spree/shipping_method_spec.rb
@@ -196,4 +196,20 @@ describe Spree::ShippingMethod do
       end
     end
   end
+
+  context "#build_tracking_url" do
+    context "when a tracking_url is specified" do
+      let(:shipping_method) { create(:shipping_method, tracking_url: "http://www.ups.com?tracking?n=:tracking") }
+
+      specify { shipping_method.build_tracking_url("1Z12345").should == "http://www.ups.com?tracking?n=1Z12345" }
+      specify { shipping_method.build_tracking_url("").should  be_nil }
+      specify { shipping_method.build_tracking_url(nil).should be_nil }
+    end
+
+    context "when a tracking_url is not specified" do
+      let(:shipping_method) { create(:shipping_method, tracking_url: nil) }
+
+      specify { shipping_method.build_tracking_url("1Z12345").should be_nil }
+    end
+  end
 end

--- a/core/spec/models/spree/shipping_method_spec.rb
+++ b/core/spec/models/spree/shipping_method_spec.rb
@@ -199,7 +199,7 @@ describe Spree::ShippingMethod do
 
   context "#build_tracking_url" do
     context "when a tracking_url is specified" do
-      let(:shipping_method) { create(:shipping_method, tracking_url: "http://www.ups.com?tracking?n=:tracking") }
+      let(:shipping_method) { create(:shipping_method, :tracking_url => "http://www.ups.com?tracking?n=:tracking") }
 
       specify { shipping_method.build_tracking_url("1Z12345").should == "http://www.ups.com?tracking?n=1Z12345" }
       specify { shipping_method.build_tracking_url("").should  be_nil }
@@ -207,7 +207,7 @@ describe Spree::ShippingMethod do
     end
 
     context "when a tracking_url is not specified" do
-      let(:shipping_method) { create(:shipping_method, tracking_url: nil) }
+      let(:shipping_method) { create(:shipping_method, :tracking_url => nil) }
 
       specify { shipping_method.build_tracking_url("1Z12345").should be_nil }
     end

--- a/frontend/app/views/spree/shared/_order_details.html.erb
+++ b/frontend/app/views/spree/shared/_order_details.html.erb
@@ -17,7 +17,7 @@
         <div class="delivery">
           <%= order.shipping_method.name %>
         </div>
-        <%= render(:partial => 'spree/shared/shipment_tracking', :locals => {:order => @order}) if @order.shipped_units? %>
+        <%= render(:partial => 'spree/shared/shipment_tracking', :locals => {:order => @order}) if @order.shipped? %>
       </div>
     <% end %>
   <% end %>

--- a/frontend/app/views/spree/shared/_order_details.html.erb
+++ b/frontend/app/views/spree/shared/_order_details.html.erb
@@ -17,6 +17,7 @@
         <div class="delivery">
           <%= order.shipping_method.name %>
         </div>
+        <%= render(:partial => 'spree/shared/shipment_tracking', :locals => {:order => @order}) if @order.shipped_units? %>
       </div>
     <% end %>
   <% end %>

--- a/frontend/app/views/spree/shared/_shipment_tracking.html.erb
+++ b/frontend/app/views/spree/shared/_shipment_tracking.html.erb
@@ -1,0 +1,9 @@
+<% shipments = order.shipments.trackable %>
+<% if shipments.any? %>
+  <h6><%= t(:tracking) %></h6>
+  <div class="tracking">
+    <% shipments.each do |shipment| %>
+      <%= link_to_tracking(shipment) %>
+    <% end %>
+  </div>
+<% end %>

--- a/sample/db/samples/shipping_methods.rb
+++ b/sample/db/samples/shipping_methods.rb
@@ -12,22 +12,26 @@ shipping_methods = [
   {
     :name => "UPS Ground (USD)",
     :zone => north_america,
-    :calculator => Spree::Calculator::FlatRate.create!
+    :calculator => Spree::Calculator::FlatRate.create!,
+    :tracking_url => "http://wwwapps.ups.com/WebTracking/track?track=yes&trackNums=:tracking"
   },
   {
     :name => "UPS Two Day (USD)",
     :zone => north_america,
-    :calculator => Spree::Calculator::FlatRate.create!
+    :calculator => Spree::Calculator::FlatRate.create!,
+    :tracking_url => "http://wwwapps.ups.com/WebTracking/track?track=yes&trackNums=:tracking"
   },
   {
     :name => "UPS One Day (USD)",
     :zone => north_america,
-    :calculator => Spree::Calculator::FlatRate.create!
+    :calculator => Spree::Calculator::FlatRate.create!,
+    :tracking_url => "http://wwwapps.ups.com/WebTracking/track?track=yes&trackNums=:tracking"
   },
   {
     :name => "UPS Ground (EUR)",
     :zone => europe_vat,
-    :calculator => Spree::Calculator::FlatRate.create!
+    :calculator => Spree::Calculator::FlatRate.create!,
+    :tracking_url => "http://wwwapps.ups.com/WebTracking/track?track=yes&trackNums=:tracking"
   }
 ]
 


### PR DESCRIPTION
This feature adds the ability for tracking numbers to be clickable throughout the system. 

Without it, the customer needs to locate the tracking website themselves and copy and paste the tracking number (except gmail users).  It also effects admins who are trying to investigate the history of a shipment, it would be helpful if they could just click on the tracking and open up the tracking site.

A new column `tracking_url` was added to `ShippingMethod` model. The `tracking_url`  stores an example tracking link with the token `:tracking` in place of the actual number. e.g. **http://quickship.com/tracking?n=:tracking**. The `:tracking` part is interpolated with the actual tracking number at runtime. 

This new field is totally optional, when left empty everything reverts to unlinked tracking numbers 

The link is displayed in the following templates:
- shared/order_details
- admin/shipments/index
- shipment_mailer/shipped_email

We may want to add the tracking to the order listing on the account page too, since many users are going into the account page to check on the status of their orders. 

![Edit Shipping Method](https://f.cloud.github.com/assets/4437/213653/866e01ae-839e-11e2-8199-07067e333e79.png)

![Empty Tracking Placeholder Text](https://f.cloud.github.com/assets/4437/213654/8e7ce036-839e-11e2-8212-e94d4a160c79.png)

![Order Screen Tracking Link](https://f.cloud.github.com/assets/4437/213656/cf2ddc52-839e-11e2-922a-12bfc2aa8fd6.png)
