### PR TITLE
Freeze to jquery-rails 2.1.4 as jQuery 1.9 breaks a plugin

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -22,7 +22,10 @@ Gem::Specification.new do |s|
   s.add_dependency 'acts_as_list', '= 0.1.4'
   s.add_dependency 'nested_set', '= 1.7.0'
 
-  s.add_dependency 'jquery-rails', '~> 2.0'
+  # This gem dependency is frozen ON PURPOSE to 2.1.4!!
+  # This is because 2.2.0 uses jQuery 1.9 which breaks the jquery.horizontalNav
+  # plugin that we are using in the admin backend.
+  s.add_dependency 'jquery-rails', '~> 2.1.4'
   s.add_dependency 'highline', '= 1.6.11'
   s.add_dependency 'state_machine', '= 1.1.2'
   s.add_dependency 'ffaker', '~> 1.12.0'


### PR DESCRIPTION
This is a backport of the commit spree/spree@3e476ba5a07ed0aea0e68b361814269b3b5e4109 from branch 1-2-stable.

This is a follow up from [this comment on issue #2408](https://github.com/spree/spree/pull/2408#issuecomment-13902574)
