### PR TITLE
Fix user autocomplete for admin orders.

### DIFF
--- a/core/app/assets/javascripts/admin/checkouts/edit.js
+++ b/core/app/assets/javascripts/admin/checkouts/edit.js
@@ -49,7 +49,7 @@ $(document).ready(function(){
       source: function(request, response) {
         var params = { q: $('#customer_search').val(),
                        authenticity_token: AUTH_TOKEN }
-        $.get(Spree.routes.user_search + '&' + jQuery.param(params), function(data) {
+        $.get(Spree.routes.user_search + '?' + jQuery.param(params), function(data) {
           result = prep_user_autocomplete_data(data)
           response(result);
         });


### PR DESCRIPTION
This bug fix is for 1-2-stable and 1-1-stable.  Currently the query params are being appended incorrectly w/ & instead of ? which causes simply the first 10 records to be returned.
