### PR TITLE
Minor grammar correction in Core Gemspec 

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -5,8 +5,8 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_core'
   s.version     = version
-  s.summary     = 'The barebones necessary for Spree.'
-  s.description = 'The barebones necessary for Spree.'
+  s.summary     = 'The bare bones necessary for Spree.'
+  s.description = 'The bare bones necessary for Spree.'
 
   s.required_ruby_version = '>= 1.9.3'
   s.author      = 'Sean Schofield'


### PR DESCRIPTION
'Barebones' without a space functions as an adjective. In this case, we're referring to the gem, so using 'bones' as a noun is correct.

... this is _totally_ not bikeshedding.
