### PR TITLE
Fix for failing authorization when modifying the taxonomy tree

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -66,8 +66,8 @@ module Spree
             render "spree/api/errors/invalid_api_key", :status => 401 and return
           end
         else
-          # Effectively, an anonymous user
-          @current_api_user = Spree.user_class.new
+          # An authenticated user or an anonymous user
+          @current_api_user = try_spree_current_user || Spree.user_class.new
         end
       end
 


### PR DESCRIPTION
Issue: when modifying the taxonomy tree (create, update, destroy), authorization
is required but fails when Spree::Api::Config[:requires_authentication] is false
