### PR TITLE
Fix backend Add Product to Cart UI

### DIFF
--- a/api/app/controllers/spree/api/variants_controller.rb
+++ b/api/app/controllers/spree/api/variants_controller.rb
@@ -6,7 +6,7 @@ module Spree
       before_filter :product
 
       def index
-        @variants = scope.includes(:option_values).ransack(params[:q]).result.
+        @variants = scope.includes(:product, :option_values).ransack(params[:q]).result.
           page(params[:page]).per(params[:per_page])
         respond_with(@variants)
       end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -21,8 +21,7 @@ Spree::Core::Engine.routes.prepend do
       end
     end
 
-    resources :variants, :only => [:index] do
-    end
+    resources :variants, :only => [:index]
 
     resources :option_types do
       resources :option_values

--- a/api/spec/controllers/spree/api/variants_controller_spec.rb
+++ b/api/spec/controllers/spree/api/variants_controller_spec.rb
@@ -4,7 +4,6 @@ module Spree
   describe Api::VariantsController do
     render_views
 
-
     let!(:product) { create(:product) }
     let!(:variant) do
       variant = product.master
@@ -35,11 +34,20 @@ module Spree
       json_response['pages'].should == 3
     end
 
-    it 'can query the results through a paramter' do
-      expected_result = create(:variant, :sku => 'FOOBAR')
-      api_get :index, :q => { :sku_cont => 'FOO' }
-      json_response['count'].should == 1
-      json_response['variants'].first['sku'].should eq expected_result.sku
+    context "query results through parameters" do
+      it "should search by sku" do
+        api_get :index, :q => { :sku_cont => product.master.sku }
+
+        json_response['count'].should == 1
+        json_response['variants'].first['sku'].should eq product.master.sku
+      end
+
+      it "should search by sku or product name at the same time" do
+        api_get :index, :q => { :product_name_or_sku_cont => product.name }
+
+        json_response['count'].should == 1
+        json_response['variants'].first['name'].should eq product.name
+      end
     end
 
     it "variants returned contain option values data" do
@@ -170,7 +178,5 @@ module Spree
         lambda { variant.reload }.should raise_error(ActiveRecord::RecordNotFound)
       end
     end
-
-
   end
 end

--- a/backend/app/controllers/spree/admin/line_items_controller.rb
+++ b/backend/app/controllers/spree/admin/line_items_controller.rb
@@ -11,14 +11,7 @@ module Spree
       def create
         variant = Variant.find(params[:line_item][:variant_id])
         @line_item = @order.contents.add(variant, params[:line_item][:quantity].to_i)
-
-        if @order.save
-          render_order_form
-        else
-          respond_with(@line_item) do |format|
-            format.js { render :action => 'create', :locals => { :order => @order.reload } }
-          end
-        end
+        @order.save
       end
 
       def destroy
@@ -33,7 +26,8 @@ module Spree
 
       private
         def render_order_form
-          render :partial => 'spree/admin/orders/form', :locals => { :order => @order.reload }
+          @order.reload
+          respond_with(@line_item) { |format| format.js { render :create } }
         end
 
         def load_order

--- a/backend/app/views/spree/admin/orders/_add_product.html.erb
+++ b/backend/app/views/spree/admin/orders/_add_product.html.erb
@@ -8,7 +8,6 @@
       <%= label_tag :add_variant_id, t(:name_or_sku) %>
       <%= hidden_field_tag :add_variant_id, "", :class => "variant_autocomplete fullwidth" %>
     </div>
-
   </fieldset>
 
   <div id="stock_details"></div>

--- a/backend/app/views/spree/admin/shared/_update_order_state.js
+++ b/backend/app/views/spree/admin/shared/_update_order_state.js
@@ -1,7 +1,7 @@
-$('#order_tab_summary h5#order_status').html('<%= j t(:status) %>: <%= j t(@order.state, :scope => :order_state) %>');
-$('#order_tab_summary h5#order_total').html('<%= j t(:total) %>: <%= j @order.display_total.to_html %>');
+$('#order_tab_summary #order_status').html('<%= j t(@order.state, :scope => :order_state) %>');
+$('#order_tab_summary #order_total').html('<%= j @order.display_total.to_html %>');
 
 <% if @order.completed? %>
-  $('#order_tab_summary h5#payment_status').html('<%= j t(:payment) %>: <%= j t(@order.payment_state, :scope => :payment_states, :default => [:missing, "none"]) %>');
-  $('#order_tab_summary h5#shipment_status').html('<%= j t(:shipment) %>: <%= j t(@order.shipment_state, :scope => :shipment_state, :default => [:missing, "none"]) %>');
+  $('#order_tab_summary #payment_status').html('<%= j t(@order.payment_state, :scope => :payment_states, :default => [:missing, "none"]) %>');
+  $('#order_tab_summary #shipment_status').html('<%= j t(@order.shipment_state, :scope => :shipment_state, :default => [:missing, "none"]) %>');
 <% end %>

--- a/backend/spec/requests/admin/orders/line_items_spec.rb
+++ b/backend/spec/requests/admin/orders/line_items_spec.rb
@@ -17,7 +17,7 @@ describe "Add items to cart" do
       click_link "Orders"
       click_link "New Order"
       
-      select2_search "t-shirt", :from => "Name or SKU (enter at least first 4 characters of product name)"
+      select2_search product.name, :from => "Name or SKU (enter at least first 4 characters of product name)"
       within('#add-line-item') { click_on "Add" }
       page.should have_content(product.price)
     end

--- a/backend/spec/requests/admin/orders/line_items_spec.rb
+++ b/backend/spec/requests/admin/orders/line_items_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe "Add items to cart" do
+  stub_authorization!
+
+  context "edit order page" do
+    let!(:product) { create(:product, :name => 't-shirt', :price => 19.99) }
+
+    before(:each) do
+      configure_spree_preferences do |config|
+        config.allow_backorders = true
+      end
+    end
+
+    it "should search product and add it", :js => true do
+      visit spree.admin_path
+      click_link "Orders"
+      click_link "New Order"
+      
+      select2_search "t-shirt", :from => "Name or SKU (enter at least first 4 characters of product name)"
+      within('#add-line-item') { click_on "Add" }
+      page.should have_content(product.price)
+    end
+  end
+end


### PR DESCRIPTION
The request was sent but the view was not being updated properly.

I started to notice it after reading #2666. When adding a product to cart through backend the form and order_summary are not updated properly.

I'm aware that the spec added do not pass so I don't expect it to be merge instantly. Just wanted to suggest a fix. I should take a closer look to fix that spec later today though. I'm not 100% sure but I think that are no integration specs to reproduce the whole checkout workflow through backend.

While working on it I also notice that the search itself is broken. e.g. Try searching for "T-Shirt" on a clean Spree install (current master edge at 11c9ce913531d19fd4ab19d7f95c8475c1a63cb1). It just returns all products, no filter at all. Or am I missing something? Hopefully I can take a look at this later too.

cheers
