### PR TITLE
Fix migration for postgresql.

### DIFF
--- a/core/db/migrate/20130306195650_add_backorderable_to_stock_item.rb
+++ b/core/db/migrate/20130306195650_add_backorderable_to_stock_item.rb
@@ -1,5 +1,5 @@
 class AddBackorderableToStockItem < ActiveRecord::Migration
   def change
-    add_column :spree_stock_items, :backorderable, :boolean, :default => 1
+    add_column :spree_stock_items, :backorderable, :boolean, :default => true
   end
 end


### PR DESCRIPTION
Fixes:

```
JDutil@Jeffs-MacBook-Pro ~/Code/tmp_2_0$ bundle exec rake db:migrate                                                                                                                             ‹2.0.0-p0›
==  AddBackorderableToStockItem: migrating ====================================
-- add_column(:spree_stock_items, :backorderable, :boolean, {:default=>1})
rake aborted!
An error has occurred, this and all later migrations canceled:

PG::Error: ERROR:  column "backorderable" is of type boolean but default expression is of type integer
HINT:  You will need to rewrite or cast the expression.
: ALTER TABLE "spree_stock_items" ADD COLUMN "backorderable" boolean DEFAULT 1
/Users/JDutil/Code/tmp_2_0/db/migrate/20130308085437_add_backorderable_to_stock_item.spree.rb:4:in `change'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)
```
