### PR TITLE
Fix spree_sample:load for stock.

### DIFF
--- a/sample/db/samples/stock.rb
+++ b/sample/db/samples/stock.rb
@@ -1,7 +1,6 @@
 Spree::Sample.load_sample("variants")
 
-location = Spree::StockLocation.first_or_create!
-location.name = 'default'
+location = Spree::StockLocation.first_or_create! name: 'default'
 location.active = true
 location.country =  Spree::Country.where(iso: 'US').first
 location.save!


### PR DESCRIPTION
Fixes:

```
JDutil@Jeffs-MacBook-Pro ~/Code/tmp_2_0$ rake spree_sample:load                                                                                                                                  ‹2.0.0-p0›
Loaded Payment Methods samples
Loaded Shipping Categories samples
Loaded Shipping Methods samples
Loaded Tax Categories samples
Loaded Tax Rates samples
Loaded Products samples
Loaded Taxonomies samples
Loaded Taxons samples
Loaded Option Types samples
Loaded Option Values samples
Loaded Product Option Types samples
Loaded Product Properties samples
Loaded Prototypes samples
Loaded Variants samples
rake aborted!
Validation failed: Name can't be blank
/Users/JDutil/Code/spree/sample/db/samples/stock.rb:3:in `<top (required)>'
/Users/JDutil/Code/spree/sample/lib/spree/sample.rb:7:in `load_sample'
/Users/JDutil/Code/spree/sample/lib/tasks/sample.rake:21:in `block (2 levels) in <top (required)>'
Tasks: TOP => spree_sample:load
(See full trace by running task with --trace)
```
