### PR TITLE
Remove promo adjustments from complete orders only

### DIFF
--- a/core/app/models/spree/promotion/actions/create_adjustment.rb
+++ b/core/app/models/spree/promotion/actions/create_adjustment.rb
@@ -6,11 +6,12 @@ module Spree
       class CreateAdjustment < PromotionAction
         include Spree::Core::CalculatedAdjustments
 
-        has_many :adjustments, :as => :originator, :dependent => :destroy
+        has_many :adjustments, :as => :originator
 
         delegate :eligible?, :to => :promotion
 
         before_validation :ensure_action_has_calculator
+        before_destroy :deals_with_adjustments
 
         # Creates the adjustment related to a promotion for the order passed
         # through options hash
@@ -49,10 +50,21 @@ module Spree
         end
 
         private
-        def ensure_action_has_calculator
-          return if self.calculator
-          self.calculator = Calculator::FlatPercentItemTotal.new
-        end
+          def ensure_action_has_calculator
+            return if self.calculator
+            self.calculator = Calculator::FlatPercentItemTotal.new
+          end
+
+          def deals_with_adjustments
+            self.adjustments.each do |adjustment|
+              if adjustment.adjustable.complete?
+                adjustment.originator = nil
+                adjustment.save
+              else
+                adjustment.destroy
+              end
+            end
+          end
       end
     end
   end

--- a/core/spec/models/spree/promotion/actions/create_adjustment_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_adjustment_spec.rb
@@ -35,6 +35,37 @@ describe Spree::Promotion::Actions::CreateAdjustment do
     end
   end
 
+  context "#destroy" do
+    before(:each) do
+      promotion.promotion_actions = [action]
+    end
+
+    context "when order is not complete" do
+      it "should not keep the adjustment" do
+        action.perform(:order => order)
+        action.destroy
+        order.adjustments.count.should == 0
+      end
+    end
+
+    context "when order is complete" do
+      let(:order) { create(:order, :state => "complete") }
+
+      before(:each) do
+        action.perform(:order => order)
+        action.destroy
+      end
+
+      it "should keep the adjustment" do
+        order.adjustments.count.should == 1
+      end
+
+      it "should nullify the adjustment originator" do
+        order.adjustments.first.originator.should be_nil
+      end
+    end
+  end
+
   context "#compute_amount" do
     before do
       action.calculator = Spree::Calculator::FreeShipping.new

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -53,19 +53,19 @@ describe Spree::Promotion do
   end
 
   describe "#delete" do
-    it "deletes actions" do
-      p = Spree::Promotion.create(:name => "delete me")
-      p.actions << Spree::Promotion::Actions::CreateAdjustment.new
-      p.destroy
+    let(:promotion) { Spree::Promotion.create(:name => "delete me") }
 
+    before(:each) do
+      promotion.actions << Spree::Promotion::Actions::CreateAdjustment.new
+      promotion.rules << Spree::Promotion::Rules::FirstOrder.new
+      promotion.destroy
+    end
+
+    it "should delete actions" do
       Spree::PromotionAction.count.should == 0
     end
 
-    it "deletes rules" do
-      p = Spree::Promotion.create(:name => "delete me")
-      p.rules << Spree::Promotion::Rules::FirstOrder.new
-      p.destroy
-
+    it "should delete rules" do
       Spree::PromotionRule.count.should == 0
     end
   end


### PR DESCRIPTION
This was merged in both master and 1-3-stable a while ago. I noticed it's not in master anymore and I guess it may bring issues since in current master every time a promo is removed all of its adjustments are removed along, users might one to keep the adjustments from complete orders. Any special reason for not having this code in master @radar?

I think it was lost when the promo gem was merged into core.  I guess that merge generated tons of conflicts.
