### PR TITLE
to suppress the error from the log, check for column names before executing SQL

### DIFF
--- a/core/config/initializers/check_for_orphaned_preferences.rb
+++ b/core/config/initializers/check_for_orphaned_preferences.rb
@@ -1,6 +1,9 @@
 begin
-  ActiveRecord::Base.connection.execute("SELECT owner_id, owner_type, name, value FROM spree_preferences WHERE 'key' IS NULL").each do |pref|
-    warn "[WARNING] Orphaned preference `#{pref[2]}` with value `#{pref[3]}` for #{pref[1]} with id of: #{pref[0]}, you should reset the preference value manually."
+  required_column_names = ["owner_id", "owner_type", "name"]     
+  if (Spree::Preference.column_names & required_column_names) == required_column_names
+     ActiveRecord::Base.connection.execute("SELECT owner_id, owner_type, name, value FROM spree_preferences WHERE 'key' IS NULL").each do |pref|
+       warn "[WARNING] Orphaned preference `#{pref[2]}` with value `#{pref[3]}` for #{pref[1]} with id of: #{pref[0]}, you should reset the preference value manually."
+     end
   end
 rescue
 end


### PR DESCRIPTION
This addresses issue https://github.com/spree/spree/issues/2592

The initializer looks like it was created to remind users to run a migration on older version preferences.  
The initializer is gone from master but I presume it is still required for 1.3.x releases.
This patch is a slight refactor to check the schema first to verify the columns exist.

I realize this may not be necessary or desirable - feedback appreciated either way.
