### PR TITLE
JS-Frontend: Added namespaces to functions and refactored to CamelCase

### DIFF
--- a/core/app/assets/javascripts/spree.js
+++ b/core/app/assets/javascripts/spree.js
@@ -1,1 +1,0 @@
-var Spree = {};

--- a/core/app/assets/javascripts/spree.js.coffee
+++ b/core/app/assets/javascripts/spree.js.coffee
@@ -1,0 +1,3 @@
+class window.Spree
+  @ready: (callback) ->
+    jQuery(document).ready(callback)

--- a/frontend/app/assets/javascripts/store/cart.js.coffee
+++ b/frontend/app/assets/javascripts/store/cart.js.coffee
@@ -1,4 +1,4 @@
-$ ->
+Spree.ready ($) ->
   if ($ 'form#update-cart').is('*')
     ($ 'form#update-cart a.delete').show().one 'click', ->
       ($ this).parents('.line-item').first().find('input.line_item_quantity').val 0

--- a/frontend/app/assets/javascripts/store/checkout.js.coffee
+++ b/frontend/app/assets/javascripts/store/checkout.js.coffee
@@ -2,64 +2,64 @@ Spree.disableSaveOnClick = ->
   ($ 'form.edit_order').submit ->
     ($ this).find(':submit, :image').attr('disabled', true).removeClass('primary').addClass 'disabled'
 
-Spree.checkout = {}
+Spree.Checkout = {}
 
 Spree.ready ($) ->
   if ($ '#checkout_form_address').is('*')
     ($ '#checkout_form_address').validate()
 
-    country_id = (region) ->
+    getCountryId = (region) ->
       $('p#' + region + 'country select').val()
 
-    update_state = (region) ->
-      c_id = country_id(region)
-      if c_id != undefined
-        if Spree.checkout[c_id] == undefined
-          $.get Spree.routes.states_search + "/?country_id=#{c_id}", (data) ->
-            Spree.checkout[c_id] = {}
-            Spree.checkout[c_id]['states'] = data.states
-            Spree.checkout[c_id]['states_required'] = data.states_required
-            fill_in_states(Spree.checkout[c_id], region)
+    updateState = (region) ->
+      countryId = getCountryId(region)
+      if countryId?
+        unless Spree.Checkout[countryId]?
+          $.get Spree.routes.states_search + "/?country_id=#{countryId}", (data) ->
+            Spree.Checkout[countryId] =
+              states: data.states
+              states_required: data.states_required
+            fillStates(Spree.Checkout[countryId], region)
         else
-          fill_in_states(Spree.checkout[c_id], region)
+          fillStates(Spree.Checkout[countryId], region)
 
-    fill_in_states = (data, region) ->
-      states_required = data.states_required
+    fillStates = (data, region) ->
+      statesRequired = data.states_required
       states = data.states
 
-      state_para = ($ 'p#' + region + 'state')
-      state_select = state_para.find('select')
-      state_input = state_para.find('input')
-      state_span_required = state_para.find('state-required')
+      statePara = ($ 'p#' + region + 'state')
+      stateSelect = statePara.find('select')
+      stateInput = statePara.find('input')
+      stateSpanRequired = statePara.find('state-required')
       if states.length > 0
-        selected = parseInt state_select.val()
-        state_select.html ''
-        states_with_blank = [{ name: '', id: ''}].concat(states)
-        $.each states_with_blank, (idx, state) ->
+        selected = parseInt stateSelect.val()
+        stateSelect.html ''
+        statesWithBlank = [{ name: '', id: ''}].concat(states)
+        $.each statesWithBlank, (idx, state) ->
           opt = ($ document.createElement('option')).attr('value', state.id).html(state.name)
           opt.prop 'selected', true if selected is state.id
-          state_select.append opt
+          stateSelect.append opt
 
-        state_select.prop('disabled', false).show()
-        state_input.hide().prop 'disabled', true
-        state_para.show()
-        state_span_required.show()
+        stateSelect.prop('disabled', false).show()
+        stateInput.hide().prop 'disabled', true
+        statePara.show()
+        stateSpanRequired.show()
       else
-        state_select.hide().prop 'disabled', true
-        state_input.show()
-        if states_required
-          state_span_required.show()
+        stateSelect.hide().prop 'disabled', true
+        stateInput.show()
+        if statesRequired
+          stateSpanRequired.show()
         else
-          state_input.val ''
-          state_span_required.hide()
-        state_para.toggle(!!states_required)
-        state_input.prop('disabled', !states_required)
+          stateInput.val ''
+          stateSpanRequired.hide()
+        statePara.toggle(!!statesRequired)
+        stateInput.prop('disabled', !statesRequired)
 
     ($ 'p#bcountry select').change ->
-      update_state 'b'
+      updateState 'b'
       if $('input#order_use_billing').is(':checked')
-        c_id = $('#bcountry select').val()
-        $('#scountry select').val(c_id).change()
+        countryId = $('#bcountry select').val()
+        $('#scountry select').val(countryId).change()
 
     ($ 'p#bstate input').change ->
       if $('input#order_use_billing').is(':checked')
@@ -72,10 +72,10 @@ Spree.ready ($) ->
 
 
     ($ 'p#scountry select').change ->
-      update_state 's'
+      updateState 's'
 
-    update_state 'b'
-    update_state 's'
+    updateState 'b'
+    updateState 's'
 
     ($ 'input#order_use_billing').click(->
       if ($ this).is(':checked')
@@ -84,7 +84,7 @@ Spree.ready ($) ->
       else
         ($ '#shipping .inner').show()
         ($ '#shipping .inner input, #shipping .inner select').prop 'disabled', false
-        update_state('s')
+        updateState('s')
     ).triggerHandler 'click'
 
   if ($ '#checkout_form_payment').is('*')
@@ -94,9 +94,9 @@ Spree.ready ($) ->
     )
 
     ($ document).on('click', '#cvv_link', (event) ->
-      window_name = 'cvv_info'
-      window_options = 'left=20,top=20,width=500,height=500,toolbar=0,resizable=0,scrollbars=1'
-      window.open(($ this).attr('href'), window_name, window_options)
+      windowName = 'cvv_info'
+      windowOptions = 'left=20,top=20,width=500,height=500,toolbar=0,resizable=0,scrollbars=1'
+      window.open(($ this).attr('href'), windowName, windowOptions)
       event.preventDefault()
     )
 

--- a/frontend/app/assets/javascripts/store/checkout.js.coffee
+++ b/frontend/app/assets/javascripts/store/checkout.js.coffee
@@ -1,10 +1,10 @@
-@disableSaveOnClick = ->
+Spree.disableSaveOnClick = ->
   ($ 'form.edit_order').submit ->
     ($ this).find(':submit, :image').attr('disabled', true).removeClass('primary').addClass 'disabled'
 
 Spree.checkout = {}
 
-$ ->
+Spree.ready ($) ->
   if ($ '#checkout_form_address').is('*')
     ($ '#checkout_form_address').validate()
 

--- a/frontend/app/assets/javascripts/store/product.js.coffee
+++ b/frontend/app/assets/javascripts/store/product.js.coffee
@@ -1,4 +1,4 @@
-add_image_handlers = ->
+Spree.add_image_handlers = ->
   thumbnails = ($ '#product-images ul.thumbnails')
   ($ '#main-image').data 'selectedThumb', ($ '#main-image img').attr('src')
   thumbnails.find('li').eq(0).addClass 'selected'
@@ -16,7 +16,7 @@ add_image_handlers = ->
   thumbnails.find('li').on 'mouseleave', (event) ->
     ($ '#main-image img').attr 'src', ($ '#main-image').data('selectedThumb')
 
-show_variant_images = (variant_id) ->
+Spree.show_variant_images = (variant_id) ->
   ($ 'li.vtmb').hide()
   ($ 'li.vtmb-' + variant_id).show()
   currentThumb = ($ '#' + ($ '#main-image').data('selectedThumbId'))
@@ -30,13 +30,13 @@ show_variant_images = (variant_id) ->
     ($ '#main-image').data 'selectedThumb', newImg
     ($ '#main-image').data 'selectedThumbId', thumb.attr('id')
 
-update_variant_price = (variant) ->
+Spree.update_variant_price = (variant) ->
   variant_price = variant.data('price')
   ($ '.price.selling').text(variant_price) if variant_price
 
 $ ->
-  add_image_handlers()
-  show_variant_images ($ '#product-variants input[type="radio"]').eq(0).attr('value') if ($ '#product-variants input[type="radio"]').length > 0
+  Spree.add_image_handlers()
+  Spree.show_variant_images ($ '#product-variants input[type="radio"]').eq(0).attr('value') if ($ '#product-variants input[type="radio"]').length > 0
   ($ '#product-variants input[type="radio"]').click (event) ->
-    show_variant_images @value
-    update_variant_price ($ this)
+    Spree.show_variant_images @value
+    Spree.update_variant_price ($ this)

--- a/frontend/app/assets/javascripts/store/product.js.coffee
+++ b/frontend/app/assets/javascripts/store/product.js.coffee
@@ -1,4 +1,4 @@
-Spree.add_image_handlers = ->
+Spree.addImageHandlers = ->
   thumbnails = ($ '#product-images ul.thumbnails')
   ($ '#main-image').data 'selectedThumb', ($ '#main-image img').attr('src')
   thumbnails.find('li').eq(0).addClass 'selected'
@@ -16,11 +16,11 @@ Spree.add_image_handlers = ->
   thumbnails.find('li').on 'mouseleave', (event) ->
     ($ '#main-image img').attr 'src', ($ '#main-image').data('selectedThumb')
 
-Spree.show_variant_images = (variant_id) ->
+Spree.showVariantImages = (variantId) ->
   ($ 'li.vtmb').hide()
-  ($ 'li.vtmb-' + variant_id).show()
+  ($ 'li.vtmb-' + variantId).show()
   currentThumb = ($ '#' + ($ '#main-image').data('selectedThumbId'))
-  if not currentThumb.hasClass('vtmb-' + variant_id)
+  if not currentThumb.hasClass('vtmb-' + variantId)
     thumb = ($ ($ 'ul.thumbnails li:visible.vtmb').eq(0))
     thumb = ($ ($ 'ul.thumbnails li:visible').eq(0)) unless thumb.length > 0
     newImg = thumb.find('a').attr('href')
@@ -30,13 +30,13 @@ Spree.show_variant_images = (variant_id) ->
     ($ '#main-image').data 'selectedThumb', newImg
     ($ '#main-image').data 'selectedThumbId', thumb.attr('id')
 
-Spree.update_variant_price = (variant) ->
-  variant_price = variant.data('price')
-  ($ '.price.selling').text(variant_price) if variant_price
+Spree.updateVariantPrice = (variant) ->
+  variantPrice = variant.data('price')
+  ($ '.price.selling').text(variantPrice) if variantPrice
 
 $ ->
-  Spree.add_image_handlers()
-  Spree.show_variant_images ($ '#product-variants input[type="radio"]').eq(0).attr('value') if ($ '#product-variants input[type="radio"]').length > 0
+  Spree.addImageHandlers()
+  Spree.showVariantImages ($ '#product-variants input[type="radio"]').eq(0).attr('value') if ($ '#product-variants input[type="radio"]').length > 0
   ($ '#product-variants input[type="radio"]').click (event) ->
-    Spree.show_variant_images @value
-    Spree.update_variant_price ($ this)
+    Spree.showVariantImages @value
+    Spree.updateVariantPrice ($ this)

--- a/frontend/app/views/spree/checkout/_confirm.html.erb
+++ b/frontend/app/views/spree/checkout/_confirm.html.erb
@@ -8,5 +8,5 @@
 
 <div class="form-buttons" data-hook="buttons">
   <%= submit_tag t(:place_order), :class => 'continue button primary' %>
-  <script>disableSaveOnClick();</script>
+  <script>Spree.disableSaveOnClick();</script>
 </div>

--- a/frontend/app/views/spree/checkout/_payment.html.erb
+++ b/frontend/app/views/spree/checkout/_payment.html.erb
@@ -33,5 +33,5 @@
 
 <div class="form-buttons" data-hook="buttons">
   <%= submit_tag t(:save_and_continue), :class => 'continue button primary' %>
-  <script>disableSaveOnClick();</script>
+  <script>Spree.disableSaveOnClick();</script>
 </div>


### PR DESCRIPTION
Ported patch #2158 to master including namespaces for frontend JS and CamelCasing. This time I separated the CamelCase patch as I don't know wether that follows your style guidelines.
