### PR TITLE
fixes Handlebars error

### DIFF
--- a/backend/app/assets/javascripts/admin/checkouts/edit.js
+++ b/backend/app/assets/javascripts/admin/checkouts/edit.js
@@ -1,5 +1,7 @@
 $(document).ready(function() {
-  window.customerTemplate = Handlebars.compile($('#customer_autocomplete_template').text());
+  if ($('#customer_autocomplete_template').length > 0) {
+    window.customerTemplate = Handlebars.compile($('#customer_autocomplete_template').text());
+  }
 
   formatCustomerResult = function(customer) {
     return customerTemplate({

--- a/backend/app/assets/javascripts/admin/variant_autocomplete.js.erb
+++ b/backend/app/assets/javascripts/admin/variant_autocomplete.js.erb
@@ -2,7 +2,9 @@
 // variant autocompletion
 
 $(document).ready(function() {
-  window.variantTemplate = Handlebars.compile($('#variant_autocomplete_template').text());
+  if ($('#variant_autocomplete_template').length > 0) {
+    window.variantTemplate = Handlebars.compile($('#variant_autocomplete_template').text());
+  }
 })
 
 formatVariantResult = function(variant) {


### PR DESCRIPTION
Currently a js error is raised by Handlebars whenever an empty string is passed to its `compile()` function.

```
You must pass a string or Handlebars AST to Handlebars.compile. You passed 
```

This prevents further js code to be run on the admin backend.

The problem is also in `1-3-stable`.
