### PR TITLE
Add FAIL_FAST env variable to enable fail fast

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,11 @@ If you want to run a particular line of spec
 bundle exec rspec spec/models/state_spec.rb:7
 ```
 
+You can also enable fail fast in order to stop tests at the first failure
+```shell
+FAIL_FAST=true bundle exec rspec spec/models/state_spec.rb
+```
+
 Contributing
 ------------
 

--- a/api/spec/spec_helper.rb
+++ b/api/spec/spec_helper.rb
@@ -25,4 +25,6 @@ RSpec.configure do |config|
   config.before do
     Spree::Api::Config[:requires_authentication] = true
   end
+
+  config.fail_fast = ENV['FAIL_FAST'] || false
 end

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -58,4 +58,6 @@ RSpec.configure do |config|
   config.include Spree::TestingSupport::Flash
 
   config.include Paperclip::Shoulda::Matchers
+
+  config.fail_fast = ENV['FAIL_FAST'] || false
 end

--- a/cmd/lib/spree_cmd/templates/extension/spec/spec_helper.rb.tt
+++ b/cmd/lib/spree_cmd/templates/extension/spec/spec_helper.rb.tt
@@ -43,4 +43,6 @@ RSpec.configure do |config|
   # examples within a transaction, remove the following line or assign false
   # instead of true.
   config.use_transactional_fixtures = true
+
+  config.fail_fast = ENV['FAIL_FAST'] || false
 end

--- a/cmd/spec/spec_helper.rb
+++ b/cmd/spec/spec_helper.rb
@@ -9,4 +9,5 @@ RSpec.configure do |config|
 
   config.use_transactional_fixtures = false
 
+  config.fail_fast = ENV['FAIL_FAST'] || false
 end

--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -59,6 +59,8 @@ RSpec.configure do |config|
   config.include Spree::TestingSupport::Flash
 
   config.include Paperclip::Shoulda::Matchers
+
+  config.fail_fast = ENV['FAIL_FAST'] || false
 end
 
 shared_context "custom products" do

--- a/dash/spec/spec_helper.rb
+++ b/dash/spec/spec_helper.rb
@@ -40,4 +40,6 @@ RSpec.configure do |config|
   config.include Spree::TestingSupport::ControllerRequests, :type => :controller
 
   config.include Rack::Test::Methods, :type => :requests
+
+  config.fail_fast = ENV['FAIL_FAST'] || false
 end

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -57,4 +57,6 @@ RSpec.configure do |config|
   config.include Spree::TestingSupport::Flash
 
   config.include Paperclip::Shoulda::Matchers
+
+  config.fail_fast = ENV['FAIL_FAST'] || false
 end

--- a/sample/spec/spec_helper.rb
+++ b/sample/spec/spec_helper.rb
@@ -28,4 +28,6 @@ RSpec.configure do |config|
   config.after(:each) do
     DatabaseCleaner.clean
   end
+
+  config.fail_fast = ENV['FAIL_FAST'] || false
 end


### PR DESCRIPTION
I think that quite often it's useful to be able to stop tests at first failure.
