### PR TITLE
Simplify tabs for incomplete order.

### DIFF
--- a/backend/app/views/spree/admin/shared/_order_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_order_tabs.html.erb
@@ -27,44 +27,27 @@
 
   <nav class="menu">
     <ul data-hook="admin_order_tabs">
-      <% unless @order.completed? %>
-        <li<%== ' class="active"' if current == 'Order Details' %>>
-          <%= link_to_with_icon 'icon-edit', t(:order_details), edit_admin_order_url(@order) %>
-        </li>
-        <li<%== ' class="active"' if current == 'Customer Details' %>>
-          <%= link_to_with_icon 'icon-user', t(:customer_details), admin_order_customer_url(@order) %>
-        </li>
-        <li<%== ' class="active"' if current == 'Shipments' %>>
-          <%=link_to_with_icon 'icon-road', t(:shipments), @order.line_items.empty? || !@order.completed? ? 'javascript:$("form").submit();' : edit_admin_order_shipment_url(@order, @order.shipment) %>
-        </li>
-        <li<%== ' class="active"' if current == 'Adjustments' %>>
-           <%= link_to_with_icon 'icon-cogs', t(:adjustments), @order.line_items.empty? || !@order.completed? ? 'javascript:$("form").submit();' : admin_order_adjustments_url(@order) %>
-        </li>
-        <li<%== ' class="active"' if current == 'Payments' %>>
-           <%= link_to_with_icon 'icon-credit-card', t(:payments), @order.line_items.empty? || !@order.completed? ? 'javascript:$("form").submit();' : new_admin_order_payment_url(@order) %>
-        </li>
-
-      <% else %>
-        <li<%== ' class="active"' if current == 'Order Details' %>>
-          <%= link_to_with_icon 'icon-edit', t(:order_details), edit_admin_order_url(@order) %>
-        </li>
-        <li<%== ' class="active"' if current == 'Customer Details' %>>
-          <%= link_to_with_icon 'icon-user', t(:customer_details), admin_order_customer_url(@order) %>
-        </li>
-        <li<%== ' class="active"' if current == 'Adjustments' %>>
-          <%= link_to_with_icon 'icon-cogs', t(:adjustments), admin_order_adjustments_url(@order) %>
-        </li>
-        <li<%== ' class="active"' if current == 'Payments' %>>
-          <%= link_to_with_icon 'icon-credit-card', t(:payments), admin_order_payments_url(@order) %>
-        </li>
-        <li<%== ' class="active"' if current == 'Shipments' %>>          
-          <%= link_to_with_icon 'icon-road', t(:shipments), admin_order_shipments_url(@order) %>
-        </li>
-        <li<%== ' class="active"' if current == 'Return Authorizations' %>>          
+      <li<%== ' class="active"' if current == 'Order Details' %>>
+        <%= link_to_with_icon 'icon-edit', t(:order_details), edit_admin_order_url(@order) %>
+      </li>
+      <li<%== ' class="active"' if current == 'Customer Details' %>>
+        <%= link_to_with_icon 'icon-user', t(:customer_details), admin_order_customer_url(@order) %>
+      </li>
+      <li<%== ' class="active"' if current == 'Adjustments' %>>
+        <%= link_to_with_icon 'icon-cogs', t(:adjustments), admin_order_adjustments_url(@order) %>
+      </li>
+      <li<%== ' class="active"' if current == 'Payments' %>>
+        <%= link_to_with_icon 'icon-credit-card', t(:payments), admin_order_payments_url(@order) %>
+      </li>
+      <li<%== ' class="active"' if current == 'Shipments' %>>
+        <%= link_to_with_icon 'icon-road', t(:shipments), admin_order_shipments_url(@order) %>
+      </li>
+      <% if @order.completed? %>
+        <li<%== ' class="active"' if current == 'Return Authorizations' %>>
           <%= link_to_with_icon 'icon-share-alt', t(:return_authorizations), admin_order_return_authorizations_url(@order) %>
         </li>
       <% end %>
-    </ul>  
+    </ul>
   </nav>
   
 


### PR DESCRIPTION
The tabs which did something different for an incomplete order vs. a
complete order led to a lot of confusion.

The javascript form submit would also cause some confusion in
functionality.  If for example, I was on "Order Details" and clicked on
the "Payments" link, the "Order Details" form would be submitted, and I
would be taken to the "Customer Details" page, when I actually wanted
to go to the "Payments" page.
