### PR TITLE
Refactor available_to_order? in shipping method.

### DIFF
--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -26,11 +26,21 @@ module Spree
       zone && zone.include?(order.ship_address)
     end
 
+    # available_to_order_if can be used to declare which conditions must be met in order
+    # to be available to an order
+    #
+    # available_to_order_if :method_name?
+    #
+    # Your method must take in a single parameter which is a Spree::Order
+    def self.available_to_order_if(*args)
+      @@available_to_order_methods ||= []
+      @@available_to_order_methods.concat args
+    end
+
+    available_to_order_if :available?, :within_zone?, :category_match?, :currency_match?
+
     def available_to_order?(order)
-      available?(order) &&
-      within_zone?(order) &&
-      category_match?(order) &&
-      currency_match?(order)
+      @@available_to_order_methods.all? { |m| self.send(m, order)}
     end
 
     # Indicates whether or not the category rules for this shipping method


### PR DESCRIPTION
This is designed to make methods like this easier to manage through
extensions.  In order to extend this, I can do the following:

``` Ruby
Spree::ShippingMethod.class_eval do
  available_to_order_if :my_special_condition?

  def my_special_condition?(order)
    # logic goes here
  end
end
```

Previously I would have to override available_to_order? as well.

This makes it difficult to keep my extension up to date with Spree
revisions and makes it difficult to have multiple extensions modify
the behaviour of available_to_order? by adding additional restrictions.

I'm curious to get some input from the Spree team to see what you think about this.  I feel that a change like this would make it much easier for extension writers to modify the functionality of Spree.

I'm currently looking at having two different extensions modify this bit of code (also, available payment methods) in order to support custom logic.  Currently we have to manage some of that logic in our application rather than in the spree extensions.
