### PR TITLE
Update taxonomy.js

### DIFF
--- a/backend/app/assets/javascripts/admin/taxonomy.js
+++ b/backend/app/assets/javascripts/admin/taxonomy.js
@@ -64,7 +64,7 @@ var handle_delete = function(e, data){
       $.ajax({
         type: "POST",
         dataType: "json",
-        url: base_url + node.attr("id"),
+        url: base_url + '/' + node.attr("id"),
         data: ({_method: "delete", authenticity_token: AUTH_TOKEN}),
         error: handle_ajax_error
       });


### PR DESCRIPTION
since the Delete taxon url is look like given below,
DELETE "/api/taxonomies/854451433/taxons558398399"
the delete process is not happening.
somebody missed a slash in between the 'taxon' and taxon_id
