### PR TITLE
Fix Spree.translations corruption of I18n cache

### DIFF
--- a/core/app/views/spree/admin/shared/_translations.html.erb
+++ b/core/app/views/spree/admin/shared/_translations.html.erb
@@ -4,7 +4,7 @@
                               :scope => 'spree.date_picker',
                               :default => 'yy/mm/dd'),
     :abbr_day_names => I18n.t(:abbr_day_names, :scope => :date),
-    :month_names    => I18n.t(:month_names, :scope => :date).delete_if(&:blank?),
+    :month_names    => I18n.t(:month_names, :scope => :date).reject(&:blank?),
     :previous       => I18n.t(:previous),
     :next           => I18n.t(:next),
     :no_results     => I18n.t(:no_results),


### PR DESCRIPTION
This fixes the problem, that after working in the backen, the `date.month_names` I18n cache gets corrupted, because the backend is using `delete_if` on the hash, which modifies self.

A similar fix is already in the current master and 1-2-stable branches. See #2427 for reference.
