### PR TITLE
Fix ssl_allowed NameError in Api BaseController

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -3,6 +3,7 @@ module Spree
     class BaseController < ActionController::Metal
       include Spree::Api::ControllerSetup
       include ::ActionController::Head
+      include Spree::Core::ControllerHelpers::Auth
 
       self.responder = Spree::Api::Responders::AppResponder
 


### PR DESCRIPTION
030ea7114dcc0fa572167d1ffa9085bd5a50f449 introduced a `NameError`. Without including the `Auth` module (or `SslRequirement`) `ssl_allowed` was not defined.
