### PR TITLE
Modify the look of the coupon code.

### DIFF
--- a/promo/app/overrides/promo_cart_coupon_code_field.rb
+++ b/promo/app/overrides/promo_cart_coupon_code_field.rb
@@ -1,6 +1,6 @@
 Deface::Override.new(:virtual_path => "spree/orders/edit",
                      :name => "promo_cart_coupon_code_field",
-                     :insert_after => "[data-hook='cart_buttons']",
+                     :insert_top => "[data-hook='cart_buttons']",
                      :partial => "spree/orders/coupon_code_field",
                      :disabled => false,
                      :original => "c11d9a1996fb86e992aba19035074cf5f688dea2")

--- a/promo/app/views/spree/orders/_coupon_code_field.html.erb
+++ b/promo/app/views/spree/orders/_coupon_code_field.html.erb
@@ -1,7 +1,4 @@
 <% if Spree::Promotion.count > 0 %>
-<div class="five columns alpha offset-by-nine coupon-code-field">
-  <%= order_form.label :coupon_code %><br />
-  <%= order_form.text_field :coupon_code, :size => 10 %>
+  <%= order_form.text_field :coupon_code, :size => 10, :placeholder => I18n.t(:coupon_code) %>
   <%= order_form.submit I18n.t(:apply) %>
-</div>
 <% end %>


### PR DESCRIPTION
This moves coupon code to be better aligned with the cart buttons.
This significantly improves the way things look in alternate
localizations.

It used to look like this:
![coupon-code-bad](https://f.cloud.github.com/assets/764390/276916/e38e4854-90b8-11e2-8839-af0934e69867.png)

And now it looks like this:
![coupon_code_good](https://f.cloud.github.com/assets/764390/276917/e3a3dffc-90b8-11e2-9bd1-8e7d46b13d48.png)

If you're a fan, this change should also be applied similarly to master.
