### PR TITLE
fixes jstree ordering problem with jquery 1.9

### DIFF
--- a/core/vendor/assets/javascripts/jquery.jstree/jquery.jstree.js
+++ b/core/vendor/assets/javascripts/jquery.jstree/jquery.jstree.js
@@ -1787,12 +1787,13 @@
 					obj.data("jstree-children", d);
 				}
 				if($.isArray(js)) {
-					d = $();
+					d = $('<ul>');
 					if(!js.length) { return false; }
 					for(i = 0, j = js.length; i < j; i++) {
 						tmp = this._parse_json(js[i], obj, true);
-						if(tmp.length) { d = d.add(tmp); }
+						if(tmp.length) { d = d.append(tmp); }
 					}
+					d = d.children();
 				}
 				else {
 					if(typeof js == "string") { js = { data : js }; }


### PR DESCRIPTION
Using Chrome browser i see a wrong taxons ordering on the taxon edit tree, using spree 1.3.2/1-3-stable (jquery-rails 2.2.x). No problems with spree 1.3.1 (jquery 2.1.x).
No problems with Firefox.

The jstree problem with jquery 1.9 was reported here: vakata/jstree#334 and the patch works.
