### PR TITLE
[1.1] Fix email validation error I18n symbol lookup

### DIFF
--- a/core/lib/spree/core/validators/email.rb
+++ b/core/lib/spree/core/validators/email.rb
@@ -18,6 +18,6 @@ class EmailValidator < ActiveModel::EachValidator
     rescue Exception => e
       r = false
     end
-    record.errors[attribute] << (options[:message] || "is invalid") unless r
+    record.errors.add(attribute, :invalid, {:value => value}.merge!(options)) unless r
   end
 end


### PR DESCRIPTION
And include %{value} for interpolation in validation messages.
If not specifying a custom validation message or symbol this
will now use the same error message as rails' format validator.

This is the proper fix for the issue mentioned in PR #2364.

I'll create a separate PR to fix this in master (which should also apply to 1.2+).
