### PR TITLE
Fix email validation error I18n symbol lookup

### DIFF
--- a/core/lib/spree/core/validators/email.rb
+++ b/core/lib/spree/core/validators/email.rb
@@ -18,6 +18,6 @@ class EmailValidator < ActiveModel::EachValidator
     rescue Exception => e
       r = false
     end
-    record.errors[attribute] << (options[:message] || I18n.t("errors.messages.invalid")) unless r
+    record.errors.add(attribute, :invalid, {:value => value}.merge!(options)) unless r
   end
 end


### PR DESCRIPTION
And include `%{value}` for interpolation in validation messages.

The current code hardcodes the I18n key and improperly assigns the error
which leads to several problems:
- You cannot override the translation message for models/attributes
- You cannot pass your own I18n key as a symbol (eg. `:invalid_email`)
- You cannot use symbol interpolation

This fixes the above problems and is the proper solution for issue #2346.

This fix also applies to 1-2-stable and 1-3-stable.
For a fix against 1-1-stable see PR #2729.
