### PR TITLE
Fix specs for mail interceptor

### DIFF
--- a/frontend/spec/lib/mail_interceptor_spec.rb
+++ b/frontend/spec/lib/mail_interceptor_spec.rb
@@ -5,6 +5,7 @@ describe Spree::OrderMailer do
   let(:mail_method) { mock("mail_method", :preferred_mails_from => nil, :preferred_intercept_email => nil, :preferred_mail_bcc => nil) }
   let(:order) { Spree::Order.new(:email => "customer@example.com") }
   let(:message) { Spree::OrderMailer.confirm_email(order) }
+  let(:mail_method) { create(:mail_method) }
   #let(:email) { mock "email" }
 
   before(:all) do


### PR DESCRIPTION
It solves this kind of errors running specs:

```
Spree::OrderMailer#deliver when intercept_mode is not provided should not modify the recipient
     Failure/Error: message.deliver
     ArgumentError:
       A sender (Return-Path, Sender or From) required to send a message
     # ./spec/lib/mail_interceptor_spec.rb:72:in `block (4 levels) in <top (required)>'
```

thanks to @mtylty for the original solution.
