### PR TITLE
Run extension installation generator during rake test_app.

### DIFF
--- a/core/lib/spree/testing_support/common_rake.rb
+++ b/core/lib/spree/testing_support/common_rake.rb
@@ -23,5 +23,13 @@ namespace :common do
     end
 
     system(cmd)
+
+    begin
+      require "generators/#{ENV['LIB_NAME']}/install_generator"
+      puts 'Running extension installation generator...'
+      "#{ENV['LIB_NAME'].classify}::Generators::InstallGenerator".constantize.start
+    rescue LoadError
+      puts 'Skipping installation no generator to run...'
+    end
   end
 end


### PR DESCRIPTION
This will improve & simplify the process of writing extension specs by running the extensions installation generator during the rake test_app task.  That way the developer doesn't need to worry about setting up a spec that relies upon something such as a configuration file needing to be copied to the main app during installation.
