### PR TITLE
Assign position of variant at creation to the end of list

### DIFF
--- a/core/app/controllers/spree/admin/variants_controller.rb
+++ b/core/app/controllers/spree/admin/variants_controller.rb
@@ -36,6 +36,7 @@ module Spree
         def create_before
           option_values = params[:new_variant]
           option_values.each_value {|id| @object.option_values << OptionValue.find(id)}
+          @object.position = Spree::Variant.where(:product_id => @object.product_id).count - 1 # Add that variant to the end of variant position list
           @object.save
         end
 


### PR DESCRIPTION
Spree do not assign default position to variant after creation - so, after creation there is some random order of variants in admin variants page (all variants have position to nil, position filled only after drag'n'drop of variants), but on product show view order can be different - little bit confusing. Patch assign position of newly created variant to the end of variants list - so order always be the same.
