### PR TITLE
User Promotion should only apply to Users added to the promotion

### DIFF
--- a/core/app/models/spree/promotion/rules/user.rb
+++ b/core/app/models/spree/promotion/rules/user.rb
@@ -8,7 +8,7 @@ module Spree
         has_and_belongs_to_many :users, :class_name => Spree.user_class.to_s, :join_table => 'spree_promotion_rules_users', :foreign_key => 'promotion_rule_id'
 
         def eligible?(order, options = {})
-          users.none? or users.include?(order.user)
+          users.include?(order.user)
         end
 
         def user_ids_string

--- a/core/spec/models/spree/promotion/rules/user_spec.rb
+++ b/core/spec/models/spree/promotion/rules/user_spec.rb
@@ -6,17 +6,13 @@ describe Spree::Promotion::Rules::User do
   context "#eligible?(order)" do
     let(:order) { Spree::Order.new }
 
-    it "should be eligible if users are not provided" do
-      users = mock("users", :none? => true)
-      rule.stub(:users => users)
-
-      rule.should be_eligible(order)
+    it "should not be eligible if users are not provided" do
+      rule.should_not be_eligible(order)
     end
 
     it "should be eligible if users include user placing the order" do
       user = mock_model(Spree::LegacyUser)
       users = [user, mock_model(Spree::LegacyUser)]
-      users.stub(:none? => false)
       rule.stub(:users => users)
       order.stub(:user => user)
 
@@ -26,7 +22,6 @@ describe Spree::Promotion::Rules::User do
     it "should not be eligible if user placing the order is not listed" do
       order.stub(:user => mock_model(Spree::LegacyUser))
       users = [mock_model(Spree::LegacyUser), mock_model(Spree::LegacyUser)]
-      users.stub(:none? => false)
       rule.stub(:users => users)
 
       rule.should_not be_eligible(order)


### PR DESCRIPTION
We noticed that when we removed the last user from a User promotion that the promotion was then applied to every user in the system. This was surprising.

I think it's more intuitive for a User-based promotion to apply to nobody when empty. We have other methods for creating site-wide promotions, so it's not a feature that needs to be here.
