### PR TITLE
Currency symbol position preference selection not showing in general settings

### DIFF
--- a/core/app/views/spree/admin/general_settings/edit.html.erb
+++ b/core/app/views/spree/admin/general_settings/edit.html.erb
@@ -52,11 +52,11 @@
               <div class="choices">
                 <ul>
                   <li>
-                    <%= radio_button_tag :currency_symbol_position, "before" %>
+                    <%= radio_button_tag :currency_symbol_position, "before", Spree::Config[:currency_symbol_position] == "before" %>
                     <%= label_tag :currency_symbol_position_before, Spree::Money.new(10, :symbol_position => "before") %>
                   </li>
                   <li class="white-space-nowrap">
-                    <%= radio_button_tag :currency_symbol_position, "after" %>
+                    <%= radio_button_tag :currency_symbol_position, "after", Spree::Config[:currency_symbol_position] == "after" %>
                     <%= label_tag :currency_symbol_position_after, Spree::Money.new(10, :symbol_position => "after") %>
                   </li>
                 </ul>


### PR DESCRIPTION
The current selection for the currency symbol position gets persisted but it's not showing up in the form. That depends on the `radio_button_tag` `checked` parameter not being provided.
