### PR TITLE
Displaying per unit cost with Spree::LineItem.single_money instead of Spree::Variant.display_amount

### DIFF
--- a/core/app/views/spree/admin/orders/_line_item.html.erb
+++ b/core/app/views/spree/admin/orders/_line_item.html.erb
@@ -1,6 +1,6 @@
 <tr id="<%= spree_dom_id(f.object) %>" data-hook="admin_order_form_line_item_row" class="<%= cycle('odd', 'even')%>">
   <td><%=f.object.variant.product.name%> <%= "(#{f.object.variant.options_text})" unless f.object.variant.option_values.empty? %></td>
-  <td class="price align-center"><%= f.object.variant.display_amount %></td>
+  <td class="price align-center"><%= f.object.single_money %></td>
   <td class="qty"><%= f.number_field :quantity, :min => 0, :class => "qty" %></td>
   <td class="total align-center"><%= f.object.display_amount %></td>
   <td data-hook="admin_order_form_line_item_actions" class="actions">

--- a/core/app/views/spree/admin/shared/_order_details.html.erb
+++ b/core/app/views/spree/admin/shared/_order_details.html.erb
@@ -11,7 +11,7 @@
     <% order.line_items.each do |item| %>
       <tr data-hook="order_details_line_item_row" class="<%= cycle('odd', 'even')%>">
         <td width="300"><%= item.variant.product.name %> <%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %></td>
-        <td class="price"><%= item.variant.display_amount %></td>
+        <td class="price"><%= item.single_money %></td>
         <td class="qty"><%= item.quantity %></td>
         <td class="total"><span><%= item.display_amount %></span></td>
       </tr>

--- a/core/app/views/spree/order_mailer/cancel_email.text.erb
+++ b/core/app/views/spree/order_mailer/cancel_email.text.erb
@@ -6,7 +6,7 @@
 <%= t('order_mailer.cancel_email.order_summary_canceled') %>
 ============================================================
 <% @order.line_items.each do |item| %>
-  <%= item.variant.sku %> <%= raw(item.variant.product.name) %> <%= raw(item.variant.options_text) -%> (<%=item.quantity%>) @ <%= item.variant.display_amount %> = <%= item.display_amount %>
+  <%= item.variant.sku %> <%= raw(item.variant.product.name) %> <%= raw(item.variant.options_text) -%> (<%=item.quantity%>) @ <%= item.single_money %> = <%= item.display_amount %>
 <% end %>
 ============================================================
 <%= t('order_mailer.cancel_email.subtotal', :subtotal => @order.display_item_total) %>

--- a/core/app/views/spree/order_mailer/confirm_email.text.erb
+++ b/core/app/views/spree/order_mailer/confirm_email.text.erb
@@ -6,7 +6,7 @@
 <%= t('order_mailer.confirm_email.order_summary') %>
 ============================================================
 <% @order.line_items.each do |item| %>
-  <%= item.variant.sku %> <%= raw(item.variant.product.name) %> <%= raw(item.variant.options_text) -%> (<%=item.quantity%>) @ <%= item.variant.display_amount %> = <%= item.display_amount %>
+  <%= item.variant.sku %> <%= raw(item.variant.product.name) %> <%= raw(item.variant.options_text) -%> (<%=item.quantity%>) @ <%= item.single_money %> = <%= item.display_amount %>
 <% end %>
 ============================================================
 <%= t('order_mailer.confirm_email.subtotal', :subtotal => @order.display_item_total) %>

--- a/core/app/views/spree/shared/_order_details.html.erb
+++ b/core/app/views/spree/shared/_order_details.html.erb
@@ -67,7 +67,7 @@
           <%= truncated_product_description(item.variant.product) %>
           <%= "(" + item.variant.options_text + ")" unless item.variant.option_values.empty? %>
         </td>
-        <td data-hook="order_item_price" class="price"><span><%= item.variant.display_amount.to_html %></span></td>
+        <td data-hook="order_item_price" class="price"><span><%= item.single_money.to_html %></span></td>
         <td data-hook="order_item_qty"><%= item.quantity %></td>
         <td data-hook="order_item_total" class="total"><span><%= item.display_amount.to_html %></span></td>
       </tr>

--- a/core/spec/mailers/order_mailer_spec.rb
+++ b/core/spec/mailers/order_mailer_spec.rb
@@ -23,7 +23,6 @@ describe Spree::OrderMailer do
     )
   end
 
-
   it "doesn't aggressively escape double quotes in confirmation body" do
     confirmation_email = Spree::OrderMailer.confirm_email(order)
     confirmation_email.body.should_not include("&quot;")

--- a/core/spec/mailers/order_mailer_spec.rb
+++ b/core/spec/mailers/order_mailer_spec.rb
@@ -9,8 +9,8 @@ describe Spree::OrderMailer do
     order = stub_model(Spree::Order)
     product = stub_model(Spree::Product, :name => %Q{The "BEST" product})
     variant = stub_model(Spree::Variant, :product => product)
-    price = stub_model(Spree::Price, :variant => variant)
-    line_item = stub_model(Spree::LineItem, :variant => variant, :order => order, :quantity => 1, :price => 5)
+    price = stub_model(Spree::Price, :variant => variant, :amount => 5.00)
+    line_item = stub_model(Spree::LineItem, :variant => variant, :order => order, :quantity => 1, :price => 4.99)
     variant.stub(:default_price => price)
     order.stub(:line_items => [line_item])
     order
@@ -22,7 +22,7 @@ describe Spree::OrderMailer do
       :preferred_mails_from => "spree@example.com"
     )
   end
-  
+
 
   it "doesn't aggressively escape double quotes in confirmation body" do
     confirmation_email = Spree::OrderMailer.confirm_email(order)
@@ -49,6 +49,24 @@ describe Spree::OrderMailer do
 
     specify do
       cancel_email.body.should_not include("Ineligible Adjustment")
+    end
+  end
+
+  context "displays unit costs from line item" do
+    # Regression test for #2772
+
+    # Tests mailer view spree/order_mailer/confirm_email.text.erb
+    specify do
+      confirmation_email = Spree::OrderMailer.confirm_email(order)
+      confirmation_email.body.should include("4.99")
+      confirmation_email.body.should_not include("5.00")
+    end
+
+    # Tests mailer view spree/order_mailer/cancel_email.text.erb
+    specify do
+      cancel_email = Spree::OrderMailer.cancel_email(order)
+      cancel_email.body.should include("4.99")
+      cancel_email.body.should_not include("5.00")
     end
   end
 

--- a/core/spec/requests/order_spec.rb
+++ b/core/spec/requests/order_spec.rb
@@ -14,6 +14,20 @@ describe 'orders' do
     lambda { visit spree.order_path(order) }.should_not raise_error
   end
 
+  it "should display line item price" do
+    # Regression test for #2772
+    line_item = order.line_items.first
+    line_item.price = 19.00
+    line_item.save!
+
+    visit spree.order_path(order)
+
+    # Tests view spree/shared/_order_details
+    within 'td.price' do
+      page.should have_content "19.00"
+    end
+  end
+
   it "should have credit card info if paid with credit card" do
     create(:payment, :order => order)
     visit spree.order_path(order)


### PR DESCRIPTION
This is a pull request related to the following conversation https://groups.google.com/forum/?fromgroups=#!topic/spree-user/uxQbvvU1Ris
