### PR TITLE
Updated rspec syntax and spree namespacing for readability.

### DIFF
--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -58,11 +58,11 @@ describe Spree::BaseHelper do
     end
 
     it "should not raise errors when style exists" do
-      lambda { very_strange_image(product) }.should_not raise_error
+      expect { very_strange_image(product) }.not_to raise_error
     end
 
     it "should raise NoMethodError when style is not exists" do
-      lambda { another_strange_image(product) }.should raise_error(NoMethodError)
+      expect { another_strange_image(product) }.to raise_error(NoMethodError)
     end
 
   end

--- a/core/spec/helpers/order_helper_spec.rb
+++ b/core/spec/helpers/order_helper_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Spree
-  describe OrdersHelper do
+  describe Spree::OrdersHelper do
     # Regression test for #2518 + #2323
     it "truncates HTML correctly in product description" do
       product = stub(:description => "<strong>" + ("a" * 95) + "</strong> This content is invisible.")

--- a/core/spec/helpers/products_helper_spec.rb
+++ b/core/spec/helpers/products_helper_spec.rb
@@ -3,8 +3,8 @@
 require 'spec_helper'
 
 module Spree
-  describe ProductsHelper do
-    include ProductsHelper
+  describe Spree::ProductsHelper do
+    include Spree::ProductsHelper
 
     let(:product) { create(:product) }
     let(:currency) { 'USD' }

--- a/core/spec/helpers/promotion_rules_helper_spec.rb
+++ b/core/spec/helpers/promotion_rules_helper_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 module Spree
- describe PromotionRulesHelper do 
+ describe Spree::PromotionRulesHelper do
    it "does not include existing rules in options" do
      promotion = Spree::Promotion.new
      promotion.promotion_rules << Spree::Promotion::Rules::ItemTotal.new

--- a/core/spec/models/spree/address_spec.rb
+++ b/core/spec/models/spree/address_spec.rb
@@ -62,7 +62,7 @@ describe Spree::Address do
 
     let(:country) { mock_model(Spree::Country, :states => [state], :states_required => true) }
     let(:state) { stub_model(Spree::State, :name => 'maryland', :abbr => 'md') }
-    let(:address) { FactoryGirl.build(:address, :country => country) }
+    let(:address) { build(:address, :country => country) }
 
     before do
       country.states.stub :find_all_by_name_or_abbr => [state]

--- a/core/spec/models/spree/alert_spec.rb
+++ b/core/spec/models/spree/alert_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'webmock'
 
 module Spree
-  describe Alert do
+  describe Spree::Alert do
     include WebMock::API
 
     before { WebMock.enable! }
@@ -12,15 +12,15 @@ module Spree
 
       stub_request(:get, "alerts.spreecommerce.com/alerts.json").to_return(alerts_json)
       alerts = Spree::Alert.current("localhost")
-      alerts.first.should == { 
+      alerts.first.should == {
         "created_at"=>"2012-07-13T11:47:58Z",
         "updated_at"=>"2012-07-13T11:47:58Z",
         "url"=>"http://spreecommerce.com/blog/2012/07/12/spree-1-0-6-released/",
         "id"=>24,
         "url_name"=>"Blog Post",
-        "severity"=>"Release", 
+        "severity"=>"Release",
         "message"=>"Spree 1.0.6 Released"
-      } 
+      }
     end
   end
 end

--- a/core/spec/models/spree/calculator/per_item_spec.rb
+++ b/core/spec/models/spree/calculator/per_item_spec.rb
@@ -46,7 +46,7 @@ describe Spree::Calculator::PerItem do
     before { promotion.stub :rules => [double("Rule")] }
     specify do
       calculator.stub(:calculable => promotion_calculable)
-      lambda { calculator.matching_products }.should_not raise_error
+      expect { calculator.matching_products }.not_to raise_error
     end
   end
 end

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -213,7 +213,7 @@ describe Spree::CreditCard do
 
   context "#associations" do
     it "should be able to access its payments" do
-      lambda { credit_card.payments.all }.should_not raise_error ActiveRecord::StatementInvalid
+      expect { credit_card.payments.all }.not_to raise_error(ActiveRecord::StatementInvalid)
     end
   end
 end

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -232,7 +232,7 @@ describe Spree::LineItem do
       line_item = create(:line_item)
       adjustment = line_item.adjustments.create(:amount => 10, :label => "test")
       line_item.destroy
-      lambda { adjustment.reload }.should raise_error(ActiveRecord::RecordNotFound)
+      expect { adjustment.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 

--- a/core/spec/models/spree/order/order/validations_spec.rb
+++ b/core/spec/models/spree/order/order/validations_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
 module Spree
-  describe Order do
+  describe Spree::Order do
     context "validations" do
       # Regression test for #2214
       it "does not return two error messages when email is blank" do
-        order = Order.new
+        order = Spree::Order.new
         order.stub(:require_email => true)
         order.valid?
         order.errors[:email].should == ["can't be blank"]

--- a/core/spec/models/spree/order/payment_spec.rb
+++ b/core/spec/models/spree/order/payment_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 module Spree
-  describe Order do
-    let(:order) { stub_model(Order) }
+  describe Spree::Order do
+    let(:order) { stub_model(Spree::Order) }
     let(:updater) { Spree::OrderUpdater.new(order) }
 
     before do

--- a/core/spec/models/spree/order/tax_spec.rb
+++ b/core/spec/models/spree/order/tax_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Spree
-  describe Order do
+  describe Spree::Order do
     let(:order) { stub_model(Spree::Order) }
 
     context "#tax_zone" do

--- a/core/spec/models/spree/order_populator_spec.rb
+++ b/core/spec/models/spree/order_populator_spec.rb
@@ -24,7 +24,7 @@ describe Spree::OrderPopulator do
         variant.stub :available? => false
 
         order.should_not_receive(:add_variant)
-        subject.populate(:products => { 1 => 2 }, :quantity => 1) 
+        subject.populate(:products => { 1 => 2 }, :quantity => 1)
         subject.should_not be_valid
         subject.errors.full_messages.join("").should == %Q{"T-Shirt (Size: M)" is out of stock.}
       end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -415,7 +415,7 @@ describe Spree::Order do
 
     it "destroys the other order" do
       order_1.merge!(order_2)
-      lambda { order_2.reload }.should raise_error(ActiveRecord::RecordNotFound)
+      expect { order_2.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     context "merging together two orders with line items for the same variant" do

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Spree
-  describe OrderUpdater do
+  describe Spree::OrderUpdater do
     let(:order) { stub_model(Spree::Order) }
     let(:updater) { Spree::OrderUpdater.new(order) }
 
@@ -110,7 +110,7 @@ module Spree
     end
 
     it "updates each shipment" do
-      shipment = stub_model(Shipment)
+      shipment = stub_model(Spree::Shipment)
       shipments = [shipment]
       order.stub :shipments => shipments
       shipments.stub :states => []

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -91,7 +91,7 @@ describe Spree::Payment do
 
       it "should invalidate if payment method doesnt support source" do
         payment.payment_method.should_receive(:supports?).with(payment.source).and_return(false)
-        lambda { payment.process!}.should raise_error(Spree::Core::GatewayError)
+        expect { payment.process!}.to raise_error(Spree::Core::GatewayError)
         payment.state.should eq('invalid')
       end
 
@@ -121,7 +121,7 @@ describe Spree::Payment do
       context "when gateway does not match the environment" do
         it "should raise an exception" do
           gateway.stub :environment => "foo"
-          lambda { payment.authorize! }.should raise_error(Spree::Core::GatewayError)
+          expect { payment.authorize! }.to raise_error(Spree::Core::GatewayError)
         end
       end
 
@@ -170,7 +170,7 @@ describe Spree::Payment do
       context "when gateway does not match the environment" do
         it "should raise an exception" do
           gateway.stub :environment => "foo"
-          lambda { payment.purchase!  }.should raise_error(Spree::Core::GatewayError)
+          expect { payment.purchase!  }.to raise_error(Spree::Core::GatewayError)
         end
       end
 
@@ -198,7 +198,7 @@ describe Spree::Payment do
           gateway.stub(:purchase).and_return(failed_response)
           payment.should_receive(:failure)
           payment.should_not_receive(:pend)
-          lambda { payment.purchase! }.should raise_error(Spree::Core::GatewayError)
+          expect { payment.purchase! }.to raise_error(Spree::Core::GatewayError)
         end
       end
     end
@@ -235,7 +235,7 @@ describe Spree::Payment do
             gateway.stub :capture => failed_response
             payment.should_receive(:failure)
             payment.should_not_receive(:complete)
-            lambda { payment.capture! }.should raise_error(Spree::Core::GatewayError)
+            expect { payment.capture! }.to raise_error(Spree::Core::GatewayError)
           end
         end
       end
@@ -285,7 +285,7 @@ describe Spree::Payment do
       context "when gateway does not match the environment" do
         it "should raise an exception" do
           gateway.stub :environment => "foo"
-          lambda { payment.void_transaction! }.should raise_error(Spree::Core::GatewayError)
+          expect { payment.void_transaction! }.to raise_error(Spree::Core::GatewayError)
         end
       end
 
@@ -302,7 +302,7 @@ describe Spree::Payment do
         it "should not void the payment" do
           gateway.stub :void => failed_response
           payment.should_not_receive(:void)
-          lambda { payment.void_transaction! }.should raise_error(Spree::Core::GatewayError)
+          expect { payment.void_transaction! }.to raise_error(Spree::Core::GatewayError)
         end
       end
 
@@ -395,7 +395,7 @@ describe Spree::Payment do
     it "should not create a payment" do
       gateway.stub :credit => failed_response
       Spree::Payment.should_not_receive(:create)
-      lambda { payment.credit! }.should raise_error(Spree::Core::GatewayError)
+      expect { payment.credit! }.to raise_error(Spree::Core::GatewayError)
     end
   end
 
@@ -405,7 +405,7 @@ describe Spree::Payment do
 
       payment.should_not_receive(:authorize!)
       payment.should_not_receive(:purchase!)
-      payment.process!.should == nil
+      payment.process!.should be_nil
     end
   end
 
@@ -416,7 +416,7 @@ describe Spree::Payment do
       end
 
       specify do
-        lambda { payment.process! }.should raise_error(Spree::Core::GatewayError, I18n.t(:payment_processing_failed))
+        expect { payment.process! }.to raise_error(Spree::Core::GatewayError, I18n.t(:payment_processing_failed))
       end
     end
   end
@@ -429,7 +429,7 @@ describe Spree::Payment do
       end
 
       specify do
-        lambda { payment.process! }.should_not raise_error(Spree::Core::GatewayError)
+        expect { payment.process! }.not_to raise_error(Spree::Core::GatewayError)
       end
     end
   end

--- a/core/spec/models/spree/preferences/preferable_spec.rb
+++ b/core/spec/models/spree/preferences/preferable_spec.rb
@@ -54,9 +54,9 @@ describe Spree::Preferences::Preferable do
     end
 
     it "can be asked and raises" do
-      lambda {
+      expect {
         @a.has_preference! :flavor
-      }.should raise_error(NoMethodError, "flavor preference not defined")
+      }.to raise_error(NoMethodError, "flavor preference not defined")
     end
 
     it "has a type" do
@@ -75,9 +75,9 @@ describe Spree::Preferences::Preferable do
     end
 
     it "raises if not defined" do
-      lambda {
+      expect {
         @a.get_preference :flavor
-      }.should raise_error(NoMethodError, "flavor preference not defined")
+      }.to raise_error(NoMethodError, "flavor preference not defined")
     end
 
   end
@@ -106,9 +106,9 @@ describe Spree::Preferences::Preferable do
     end
 
     it "raises when preference not defined" do
-      lambda {
+      expect {
         @a.set_preference(:bad, :bone)
-      }.should raise_exception(NoMethodError, "bad preference not defined")
+      }.to raise_exception(NoMethodError, "bad preference not defined")
     end
 
     it "builds a hash of preferences" do

--- a/core/spec/models/spree/product_duplicator_spec.rb
+++ b/core/spec/models/spree/product_duplicator_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 module Spree
-  describe ProductDuplicator do
-    let(:product) do 
+  describe Spree::ProductDuplicator do
+    let(:product) do
       double 'Product',
         :name => "foo",
         :taxons => [],

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -13,8 +13,7 @@ describe Spree::Product do
   context "#count_on_hand=" do
     it "cannot be set manually" do
       product = Spree::Product.new
-      setter = lambda { product.count_on_hand = 5 }
-      setter.should raise_error(I18n.t('exceptions.count_on_hand_setter'))
+      expect { product.count_on_hand = 5 }.to raise_error(I18n.t('exceptions.count_on_hand_setter'))
     end
   end
 
@@ -292,7 +291,7 @@ describe Spree::Product do
 
   context "properties" do
     it "should properly assign properties" do
-      product = FactoryGirl.create :product
+      product = create(:product)
       product.set_property('the_prop', 'value1')
       product.property('the_prop').should == 'value1'
 
@@ -301,25 +300,25 @@ describe Spree::Product do
     end
 
     it "should not create duplicate properties when set_property is called" do
-      product = FactoryGirl.create :product
+      product = create(:product)
 
-      lambda {
+      expect {
         product.set_property('the_prop', 'value2')
         product.save
         product.reload
-      }.should_not change(product.properties, :length)
+      }.not_to change(product.properties, :length)
 
-      lambda {
+      expect {
         product.set_property('the_prop_new', 'value')
         product.save
         product.reload
         product.property('the_prop_new').should == 'value'
-      }.should change { product.properties.length }.by(1)
+      }.to change { product.properties.length }.by(1)
     end
 
     # Regression test for #2455
     it "should not overwrite properties' presentation names" do
-      product = FactoryGirl.create :product
+      product = create(:product)
       Spree::Property.where(:name => 'foo').first_or_create!(:presentation => "Foo's Presentation Name")
       product.set_property('foo', 'value1')
       product.set_property('bar', 'value2')
@@ -346,7 +345,7 @@ describe Spree::Product do
 
     context "when prototype with option types is supplied" do
       def build_option_type_with_values(name, values)
-        ot = FactoryGirl.create(:option_type, :name => name)
+        ot = create(:option_type, :name => name)
         values.each do |val|
           ot.option_values.create({:name => val.downcase, :presentation => val}, :without_protection => true)
         end
@@ -355,7 +354,7 @@ describe Spree::Product do
 
       let(:prototype) do
         size = build_option_type_with_values("size", %w(Small Medium Large))
-        FactoryGirl.create(:prototype, :name => "Size", :option_types => [ size ])
+        create(:prototype, :name => "Size", :option_types => [ size ])
       end
 
       let(:option_values_hash) do

--- a/core/spec/models/spree/promotion_action_spec.rb
+++ b/core/spec/models/spree/promotion_action_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Spree::PromotionAction do
 
   it "should force developer to implement 'perform' method" do
-    lambda { MyAction.new.perform }.should raise_error
+    expect { MyAction.new.perform }.to raise_error
   end
 
 end

--- a/core/spec/models/spree/promotion_rule_spec.rb
+++ b/core/spec/models/spree/promotion_rule_spec.rb
@@ -1,18 +1,18 @@
 require 'spec_helper'
 
 module Spree
-  describe PromotionRule do
-    
-    class BadTestRule < PromotionRule; end
+  describe Spree::PromotionRule do
 
-    class TestRule < PromotionRule
+    class BadTestRule < Spree::PromotionRule; end
+
+    class TestRule < Spree::PromotionRule
       def eligible?
         true
       end
     end
 
     it "should force developer to implement eligible? method" do
-      lambda { BadTestRule.new.eligible? }.should raise_error
+      expect { BadTestRule.new.eligible? }.to raise_error
     end
 
     it "validates unique rules for a promotion" do

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -126,10 +126,10 @@ describe Spree::Promotion do
      it "should have its usage limit exceeded" do
        promotion.usage_limit = 2
        promotion.stub(:credits_count => 2)
-       promotion.usage_limit_exceeded?.should == true
+       promotion.usage_limit_exceeded?.should be_true
 
        promotion.stub(:credits_count => 3)
-       promotion.usage_limit_exceeded?.should == true
+       promotion.usage_limit_exceeded?.should be_true
      end
    end
 

--- a/core/spec/models/spree/taxon_spec.rb
+++ b/core/spec/models/spree/taxon_spec.rb
@@ -45,11 +45,10 @@ describe Spree::Taxon do
 
   # Regression test for #2620
   context "creating a child node using first_or_create" do
-    let(:taxonomy) { FactoryGirl.create(:taxonomy) }
+    let(:taxonomy) { create(:taxonomy) }
 
     it "does not error out" do
-      action = lambda { taxonomy.root.children.where(:name => "Some name").first_or_create }
-      action.should_not raise_error
+      expect { taxonomy.root.children.where(:name => "Some name").first_or_create }.not_to raise_error
     end
   end
 

--- a/core/spec/models/spree/tracker_spec.rb
+++ b/core/spec/models/spree/tracker_spec.rb
@@ -10,12 +10,12 @@ describe Spree::Tracker do
 
     it "does not return a tracker with a blank analytics_id" do
       @tracker.update_attribute(:analytics_id, '')
-      Spree::Tracker.current.should == nil
+      Spree::Tracker.current.should be_nil
     end
 
     it "does not return an inactive tracker" do
       @tracker.update_attribute(:active, false)
-      Spree::Tracker.current.should == nil
+      Spree::Tracker.current.should be_nil
     end
   end
 end

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -33,7 +33,7 @@ describe Spree::Variant do
     copy.save!
 
     variant.count_on_hand = 100
-    expect { variant.save }.to raise_error ActiveRecord::StaleObjectError
+    expect { variant.save }.to raise_error(ActiveRecord::StaleObjectError)
 
     variant.reload.count_on_hand.should == 200
     variant.count_on_hand = 100
@@ -118,7 +118,7 @@ describe Spree::Variant do
 
       it "should raise an exception" do
         variant = create(:base_variant)
-        lambda { variant.on_hand = 100 }.should raise_error
+        expect { variant.on_hand = 100 }.to raise_error
       end
 
     end
@@ -176,7 +176,7 @@ describe Spree::Variant do
     context "product has other variants" do
       describe "option value accessors" do
         before {
-          @multi_variant = FactoryGirl.create :variant, :product => variant.product
+          @multi_variant = create(:variant, :product => variant.product)
           variant.product.reload
         }
 

--- a/core/spec/models/spree/zone_spec.rb
+++ b/core/spec/models/spree/zone_spec.rb
@@ -264,7 +264,7 @@ describe Spree::Zone do
       it "should clear previous default tax zone" do
         zone1 = create(:zone, :name => "foo", :default_tax => true)
         zone = create(:zone, :name => "bar", :default_tax => true)
-        zone1.reload.default_tax.should == false
+        zone1.reload.default_tax.should be_false
       end
     end
 


### PR DESCRIPTION
Did this in #2770 that I closed due to that I went rampage with code formatting on that one :)
- Rspec expect syntax instead of lambda and other rspec syntax changes for nil and boolean comparison.
- Added Spree namespace to models without removing nested `module` due to that `git` mark all code as modified, so I leave that to the core team to clean up when desired.
- Removed forgotten FactoryGirl cleanups that was done earlier in an already merged commit.
