### PR TITLE
When a calculator is using a preference of type :text, a textarea is sho...

### DIFF
--- a/core/app/assets/javascripts/admin/calculator.js
+++ b/core/app/assets/javascripts/admin/calculator.js
@@ -6,11 +6,11 @@ $(function() {
     if (calculator_select.attr('value') == original_calc_type) {
       $('div.calculator-settings').show();
       $('div#calculator-settings-warning').hide();
-      $('.calculator-settings input').prop("disabled", false);
+      $('.calculator-settings').find('input,textarea').prop("disabled", false);
     } else {
       $('div.calculator-settings').hide();
       $('div#calculator-settings-warning').show();
-      $('.calculator-settings input').prop("disabled", true);
+      $('.calculator-settings').find('input,textarea').prop("disabled", true);
     }
   });
 })


### PR DESCRIPTION
...wn. The calculator.js should disable/enable this textarea the same as the input from a preference of any other type.
