### PR TITLE
Skip :after callbacks and use private send in CreateDefaultStock migration so it can run

### DIFF
--- a/core/db/migrate/20130213191427_create_default_stock.rb
+++ b/core/db/migrate/20130213191427_create_default_stock.rb
@@ -1,8 +1,12 @@
 class CreateDefaultStock < ActiveRecord::Migration
   def up
+    Spree::StockLocation.skip_callback(:create, :after, :create_stock_items)
+    Spree::StockItem.skip_callback(:save, :after, :process_backorders)
     location = Spree::StockLocation.create(name: 'default')
     Spree::Variant.all.each do |variant|
-      location.stock_items.create(variant: variant, count_on_hand: variant.count_on_hand)
+      stock_item = location.stock_items.build(variant: variant)
+      stock_item.send(:count_on_hand=, variant.count_on_hand)
+      stock_item.save!
     end
 
     remove_column :spree_variants, :count_on_hand


### PR DESCRIPTION
Skip :after callbacks on StockLocation and StockItem when creating
intitial instances. Use private send to set StockItem.count_on_hand
because :count_on_hand= is now private.

These changes are necessary because of changes to the models that I presume were made after the migrations were coded. 

The private send is necessary because of [this commit](https://github.com/spree/spree/commit/9acf57f6baf55993ca0f4f032e9b7ad684712c9b).

Skipping :after callbacks on StockLocation is required due to [this commit](https://github.com/spree/spree/commit/0ba60a08f934af9d6a7f17f6e9c90a1749547e9b).

Skipping :after callbacks on StockItem is required due to [this commit](https://github.com/spree/spree/commit/630afbb7f2549556fb1bc914e16a2e3802cc8f15).

I'm not sure if the changes I've made are the best way to work around these issues, but the migration now runs without raising any errors.
