### PR TITLE
Fix removal of polymorphic associations

### DIFF
--- a/core/db/migrate/20130319190507_drop_source_and_destination_from_stock_movement.rb
+++ b/core/db/migrate/20130319190507_drop_source_and_destination_from_stock_movement.rb
@@ -1,7 +1,9 @@
 class DropSourceAndDestinationFromStockMovement < ActiveRecord::Migration
   def up
-    remove_column :spree_stock_movements, :source, polymorphic: true
-    remove_column :spree_stock_movements, :destination, polymorphic: true
+    change_table :spree_stock_movements do |t|
+      t.remove_references :source, :polymorphic => true
+      t.remove_references :destination, :polymorphic => true
+    end
   end
 
   def down


### PR DESCRIPTION
Fixes following error when running this migration:

PG::Error: ERROR:  column "source" of relation "spree_stock_movements" does not exist
