### PR TITLE
Fix ambiguous column name in UpdateShipmentStateForCanceledOrders

### DIFF
--- a/core/db/migrate/20130328130308_update_shipment_state_for_canceled_orders.rb
+++ b/core/db/migrate/20130328130308_update_shipment_state_for_canceled_orders.rb
@@ -1,6 +1,6 @@
 class UpdateShipmentStateForCanceledOrders < ActiveRecord::Migration
   def up
-    Spree::Shipment.joins(:order).where("spree_orders.state = 'canceled'").update_all(state: 'canceled')
+    Spree::Shipment.joins(:order).where("spree_orders.state = 'canceled'").update_all("spree_shipments.state = 'canceled'")
   end
 
   def down


### PR DESCRIPTION
Fixes ambiguous column error:

`Mysql2::Error: Column 'state' in field list is ambiguous: UPDATE`spree_shipments`INNER JOIN`spree_orders`ON`spree_orders`.`id`=`spree_shipments`.`order_id`SET`state`= 'canceled' WHERE (spree_orders.state = 'canceled')`
