### PR TITLE
Cleaner factories with build test.

### DIFF
--- a/core/lib/spree/testing_support/factories.rb
+++ b/core/lib/spree/testing_support/factories.rb
@@ -1,11 +1,17 @@
+require 'factory_girl'
+
 Spree::Zone.class_eval do
   def self.global
-    find_by_name("GlobalZone") || FactoryGirl.create(:global_zone)
+    find_by_name('GlobalZone') || FactoryGirl.create(:global_zone)
   end
 end
 
-require 'factory_girl'
-
 Dir["#{File.dirname(__FILE__)}/factories/**"].each do |f|
   require File.expand_path(f)
+end
+
+FactoryGirl.define do
+  sequence(:random_string)      { Faker::Lorem.sentence }
+  sequence(:random_description) { Faker::Lorem.paragraphs(1 + Kernel.rand(5)).join("\n") }
+  sequence(:random_email)       { Faker::Internet.email }
 end

--- a/core/lib/spree/testing_support/factories/activator_factory.rb
+++ b/core/lib/spree/testing_support/factories/activator_factory.rb
@@ -1,8 +1,8 @@
 FactoryGirl.define do
-  factory :activator, :class => Spree::Activator do
+  factory :activator, class: Spree::Activator do
     name 'Activator name'
     event_name 'spree.order.contents_changed'
-    starts_at 2.weeks.ago
-    expires_at 2.weeks.from_now
+    starts_at  { 2.weeks.ago }
+    expires_at { 2.weeks.from_now }
   end
 end

--- a/core/lib/spree/testing_support/factories/address_factory.rb
+++ b/core/lib/spree/testing_support/factories/address_factory.rb
@@ -1,16 +1,16 @@
 FactoryGirl.define do
-  factory :address, :class => Spree::Address do
+  factory :address, aliases: [:bill_address, :ship_address], class: Spree::Address do
     firstname 'John'
     lastname 'Doe'
     company 'Company'
     address1 '10 Lovely Street'
     address2 'Northwest'
-    city   'Herndon'
+    city 'Herndon'
     zipcode '20170'
     phone '123-456-7890'
     alternative_phone '123-456-7899'
 
-    state  { |address| address.association(:state) }
+    state { |address| address.association(:state) }
     country do |address|
       if address.state
         address.state.country

--- a/core/lib/spree/testing_support/factories/adjustment_factory.rb
+++ b/core/lib/spree/testing_support/factories/adjustment_factory.rb
@@ -1,16 +1,17 @@
 FactoryGirl.define do
-  factory :adjustment, :class => Spree::Adjustment do
-    adjustable { FactoryGirl.create(:order) }
-    amount '100.0'
+  factory :adjustment, class: Spree::Adjustment do
+    association(:adjustable, factory: :order)
+    amount 100.0
     label 'Shipping'
-    source { FactoryGirl.create(:shipment) }
+    association(:source, factory: :shipment)
     eligible true
   end
-  factory :line_item_adjustment, :class => Spree::Adjustment do
-    adjustable { FactoryGirl.create(:line_item) }
-    amount '10.0'
+
+  factory :line_item_adjustment, class: Spree::Adjustment do
+    association(:adjustable, factory: :line_item)
+    amount 10.0
     label 'VAT 5%'
-    source { FactoryGirl.create(:tax_rate) }
+    association(:source, factory: :tax_rate)
     eligible true
   end
 end

--- a/core/lib/spree/testing_support/factories/calculator_factory.rb
+++ b/core/lib/spree/testing_support/factories/calculator_factory.rb
@@ -1,9 +1,12 @@
 FactoryGirl.define do
-  factory :calculator, :class => Spree::Calculator::FlatRate do
+  factory :calculator, class: Spree::Calculator::FlatRate do
     after(:create) { |c| c.set_preference(:amount, 10.0) }
   end
 
-  factory :no_amount_calculator, :class => Spree::Calculator::FlatRate do
+  factory :no_amount_calculator, class: Spree::Calculator::FlatRate do
     after(:create) { |c| c.set_preference(:amount, 0) }
+  end
+
+  factory :default_tax_calculator, class: Spree::Calculator::DefaultTax do
   end
 end

--- a/core/lib/spree/testing_support/factories/configuration_factory.rb
+++ b/core/lib/spree/testing_support/factories/configuration_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :configuration, :class => Spree::Configuration do
+  factory :configuration, class: Spree::Configuration do
     name 'Default Configuration'
     type 'app_configuration'
   end

--- a/core/lib/spree/testing_support/factories/country_factory.rb
+++ b/core/lib/spree/testing_support/factories/country_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :country, :class => Spree::Country do
+  factory :country, class: Spree::Country do
     iso_name 'UNITED STATES'
     name 'United States of Foo'
     iso 'US'

--- a/core/lib/spree/testing_support/factories/credit_card_factory.rb
+++ b/core/lib/spree/testing_support/factories/credit_card_factory.rb
@@ -4,7 +4,7 @@ class TestCard < Spree::CreditCard
 end
 
 FactoryGirl.define do
-  factory :credit_card, :class => TestCard do
+  factory :credit_card, class: TestCard do
     verification_value 123
     month 12
     year 2013

--- a/core/lib/spree/testing_support/factories/inventory_unit_factory.rb
+++ b/core/lib/spree/testing_support/factories/inventory_unit_factory.rb
@@ -1,9 +1,9 @@
 FactoryGirl.define do
-  factory :inventory_unit, :class => Spree::InventoryUnit do
-    variant { FactoryGirl.create(:variant) }
-    order { FactoryGirl.create(:order) }
+  factory :inventory_unit, class: Spree::InventoryUnit do
+    variant
+    order
     state 'on_hand'
-    shipment { FactoryGirl.create(:shipment, :state => 'pending') }
-    #return_authorization { FactoryGirl.create(:return_authorization) }
+    association(:shipment, factory: :shipment, state: 'pending')
+    # return_authorization
   end
 end

--- a/core/lib/spree/testing_support/factories/line_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/line_item_factory.rb
@@ -1,9 +1,7 @@
 FactoryGirl.define do
-  factory :line_item, :class => Spree::LineItem do
+  factory :line_item, class: Spree::LineItem do
     quantity 1
     price { BigDecimal.new('10.00') }
-
-    # associations:
     order
     variant
   end

--- a/core/lib/spree/testing_support/factories/mail_method_factory.rb
+++ b/core/lib/spree/testing_support/factories/mail_method_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :mail_method, :class => Spree::MailMethod do
+  factory :mail_method, class: Spree::MailMethod do
     environment { Rails.env }
     active true
   end

--- a/core/lib/spree/testing_support/factories/options_factory.rb
+++ b/core/lib/spree/testing_support/factories/options_factory.rb
@@ -1,11 +1,11 @@
 FactoryGirl.define do
-  factory :option_value, :class => Spree::OptionValue do
+  factory :option_value, class: Spree::OptionValue do
     name 'Size'
     presentation 'S'
     option_type
   end
 
-  factory :option_type, :class => Spree::OptionType do
+  factory :option_type, class: Spree::OptionType do
     name 'foo-size'
     presentation 'Size'
   end

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -1,53 +1,52 @@
 FactoryGirl.define do
-  factory :order, :class => Spree::Order do
-    # associations:
-    association(:user, :factory => :user)
-    association(:bill_address, :factory => :address)
+  factory :order, class: Spree::Order do
+    user
+    bill_address
     completed_at nil
     bill_address_id nil
     ship_address_id nil
-    email 'foo@example.com'
+    email { user.email }
 
-    factory :order_with_totals, :parent => :order do
+    factory :order_with_totals do
       after(:create) do |order|
-        FactoryGirl.create(:line_item, :order => order)
+        create(:line_item, order: order)
         order.line_items.reload # to ensure order.line_items is accessible after
       end
     end
 
     factory :order_with_line_items do
+      bill_address
+      ship_address
+
       ignore do
         line_items_count 5
       end
-      bill_address { FactoryGirl.create(:address) }
-      ship_address { FactoryGirl.create(:address) }
 
       after(:create) do |order, evaluator|
-        FactoryGirl.create(:shipment, :order => order)
+        create(:shipment, order: order)
         order.shipments.reload
 
-        FactoryGirl.create_list(:line_item, evaluator.line_items_count, :order => order)
+        create_list(:line_item, evaluator.line_items_count, order: order)
         order.line_items.reload
         order.update!
       end
-    end
 
-    factory :completed_order_with_totals, :parent => :order_with_line_items do
-      bill_address { FactoryGirl.create(:address) }
-      ship_address { FactoryGirl.create(:address) }
-      state 'complete'
-      completed_at Time.now
+      factory :completed_order_with_totals do
+        # bill_address
+        # ship_address
+        state 'complete'
+        completed_at { Time.now }
 
-      factory :shipped_order do
-        after(:create) do |order|
-          order.shipments.each do |shipment|
-            shipment.inventory_units.each { |u| u.update_attribute('state', 'shipped') }
-            shipment.update_attribute('state', 'shipped')
+        factory :shipped_order do
+          after(:create) do |order|
+            order.shipments.each do |shipment|
+              shipment.inventory_units.each { |u| u.update_attribute('state', 'shipped') }
+              shipment.update_attribute('state', 'shipped')
+            end
+            order.reload
           end
-          order.reload
         end
       end
     end
   end
-
 end

--- a/core/lib/spree/testing_support/factories/payment_factory.rb
+++ b/core/lib/spree/testing_support/factories/payment_factory.rb
@@ -1,17 +1,16 @@
 FactoryGirl.define do
-  factory :payment, :class => Spree::Payment do
+  factory :payment, class: Spree::Payment do
     amount 45.75
-    payment_method { FactoryGirl.create(:bogus_payment_method) }
-    source { FactoryGirl.build(:credit_card) }
-    order { FactoryGirl.create(:order) }
+    association(:payment_method, factory: :bogus_payment_method)
+    association(:source, factory: :credit_card)
+    order
     state 'checkout'
     response_code '12345'
-
   end
 
-  factory :check_payment, :class => Spree::Payment do
+  factory :check_payment, class: Spree::Payment do
     amount 45.75
-    payment_method { FactoryGirl.create(:payment_method) }
-    order { FactoryGirl.create(:order) }
+    payment_method
+    order
   end
 end

--- a/core/lib/spree/testing_support/factories/payment_method_factory.rb
+++ b/core/lib/spree/testing_support/factories/payment_method_factory.rb
@@ -1,17 +1,17 @@
 FactoryGirl.define do
-  factory :payment_method, :class => Spree::PaymentMethod::Check do
+  factory :payment_method, class: Spree::PaymentMethod::Check do
     name 'Check'
     environment 'test'
   end
 
-  factory :bogus_payment_method, :class => Spree::Gateway::Bogus do
+  factory :bogus_payment_method, class: Spree::Gateway::Bogus do
     name 'Credit Card'
     environment 'test'
   end
 
-  # authorize.net was moved to spree_gateway. Leaving this factory
-  # in place with bogus in case anyone is using it
-  factory :authorize_net_payment_method, :class => Spree::Gateway::BogusSimple do
+  # authorize.net was moved to spree_gateway.
+  # Leaving this factory in place with bogus in case anyone is using it.
+  factory :authorize_net_payment_method, class: Spree::Gateway::BogusSimple do
     name 'Credit Card'
     environment 'test'
   end

--- a/core/lib/spree/testing_support/factories/price_factory.rb
+++ b/core/lib/spree/testing_support/factories/price_factory.rb
@@ -1,8 +1,7 @@
 FactoryGirl.define do
-  factory :price, :class => Spree::Price do
-    variant :variant
+  factory :price, class: Spree::Price do
+    variant
     amount 19.99
     currency 'USD'
   end
 end
-

--- a/core/lib/spree/testing_support/factories/product_factory.rb
+++ b/core/lib/spree/testing_support/factories/product_factory.rb
@@ -1,40 +1,38 @@
 FactoryGirl.define do
-  factory :base_product, :class => Spree::Product do
+  factory :base_product, class: Spree::Product do
     sequence(:name) { |n| "Product ##{n} - #{Kernel.rand(9999)}" }
-    description { Faker::Lorem.paragraphs(1 + Kernel.rand(5)).join("\n") }
+    description { generate(:random_description) }
     price 19.99
     cost_price 17.00
     sku 'ABC'
-    available_on 1.year.ago
+    available_on { 1.year.ago }
     deleted_at nil
 
     # ensure stock item will be created for this products master
     before(:create) { create(:stock_location) if Spree::StockLocation.count == 0 }
+
+    factory :product do
+      tax_category { |r| Spree::TaxCategory.first || r.association(:tax_category) }
+      shipping_category { |r| Spree::ShippingCategory.first || r.association(:shipping_category) }
+
+      factory :product_with_option_types do
+        after(:create) { |product| create(:product_option_type, product: product) }
+      end
+    end
   end
 
-  factory :product, :parent => :base_product do
-    tax_category { |r| Spree::TaxCategory.first || r.association(:tax_category) }
-    shipping_category { |r| Spree::ShippingCategory.first || r.association(:shipping_category) }
-  end
-
-  factory :product_with_option_types, :parent => :product do
-    after(:create) { |product| FactoryGirl.create(:product_option_type, :product => product) }
-  end
-
-  factory :custom_product, :class => Spree::Product do
-    name "Custom Product"
-    price "17.99"
-    description { Faker::Lorem.paragraphs(1 + Kernel.rand(5)).join("\n") }
-
-    # associations:
-    tax_category { |r| Spree::TaxCategory.first || r.association(:tax_category) }
-    shipping_category { |r| Spree::ShippingCategory.first || r.association(:shipping_category) }
-
+  factory :custom_product, class: Spree::Product do
+    name 'Custom Product'
+    description { generate(:random_description) }
+    price 17.99
     sku 'ABC'
-    available_on 1.year.ago
+    available_on { 1.year.ago }
     deleted_at nil
 
-    association :taxons
+    tax_category { |r| Spree::TaxCategory.first || r.association(:tax_category) }
+    shipping_category { |r| Spree::ShippingCategory.first || r.association(:shipping_category) }
+
+    # association :taxons
 
     # ensure stock item will be created for this products master
     before(:create) { create(:stock_location) if Spree::StockLocation.count == 0 }

--- a/core/lib/spree/testing_support/factories/product_option_type_factory.rb
+++ b/core/lib/spree/testing_support/factories/product_option_type_factory.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
-  factory :product_option_type, :class => Spree::ProductOptionType do
-    product { FactoryGirl.create(:product) }
-    option_type { FactoryGirl.create(:option_type) }
+  factory :product_option_type, class: Spree::ProductOptionType do
+    product
+    option_type
   end
 end

--- a/core/lib/spree/testing_support/factories/product_property_factory.rb
+++ b/core/lib/spree/testing_support/factories/product_property_factory.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
-  factory :product_property, :class => Spree::ProductProperty do
-    product { FactoryGirl.create(:product) }
-    property { FactoryGirl.create(:property) }
+  factory :product_property, class: Spree::ProductProperty do
+    product
+    property
   end
 end

--- a/core/lib/spree/testing_support/factories/promotion_factory.rb
+++ b/core/lib/spree/testing_support/factories/promotion_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :promotion, :class => Spree::Promotion, :parent => :activator do
+  factory :promotion, class: Spree::Promotion, parent: :activator do
     name 'Promo'
   end
 end

--- a/core/lib/spree/testing_support/factories/property_factory.rb
+++ b/core/lib/spree/testing_support/factories/property_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :property, :class => Spree::Property do
+  factory :property, class: Spree::Property do
     name 'baseball_cap_color'
     presentation 'cap color'
   end

--- a/core/lib/spree/testing_support/factories/prototype_factory.rb
+++ b/core/lib/spree/testing_support/factories/prototype_factory.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
-  factory :prototype, :class => Spree::Prototype do
+  factory :prototype, class: Spree::Prototype do
     name 'Baseball Cap'
-    properties { [FactoryGirl.create(:property)] }
+    properties { [create(:property)] }
   end
 end

--- a/core/lib/spree/testing_support/factories/return_authorization_factory.rb
+++ b/core/lib/spree/testing_support/factories/return_authorization_factory.rb
@@ -1,8 +1,8 @@
 FactoryGirl.define do
-  factory :return_authorization, :class => Spree::ReturnAuthorization do
+  factory :return_authorization, class: Spree::ReturnAuthorization do
     number '100'
     amount 100.00
-    order { FactoryGirl.create(:shipped_order) }
+    association(:order, factory: :shipped_order)
     reason 'no particular reason'
     state 'received'
   end

--- a/core/lib/spree/testing_support/factories/role_factory.rb
+++ b/core/lib/spree/testing_support/factories/role_factory.rb
@@ -1,11 +1,9 @@
 FactoryGirl.define do
-  sequence(:role_sequence) { |n| "Role ##{n}" }
+  factory :role, class: Spree::Role do
+    sequence(:name) { |n| "Role ##{n}" }
 
-  factory :role, :class => Spree::Role do
-    name { FactoryGirl.generate :role_sequence }
-  end
-
-  factory :admin_role, :parent => :role do
-    name 'admin'
+    factory :admin_role do
+      name 'admin'
+    end
   end
 end

--- a/core/lib/spree/testing_support/factories/shipment_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipment_factory.rb
@@ -1,19 +1,19 @@
 FactoryGirl.define do
-  factory :shipment, :class => Spree::Shipment do
-    order { FactoryGirl.create(:order) }
+  factory :shipment, class: Spree::Shipment do
     tracking 'U10000'
     number '100'
     cost 100.00
-    address { FactoryGirl.create(:address) }
     state 'pending'
-    stock_location {FactoryGirl.create(:stock_location)}
-    stock_location_id {stock_location.id}
+    order
+    address
+    stock_location
+    # stock_location_id { stock_location.id }
 
     after(:create) do |shipment, evalulator|
       shipment.add_shipping_method(create(:shipping_method), true)
 
       shipment.order.line_items.each do |line_item|
-        line_item.quantity.times { shipment.inventory_units.create(:variant_id => line_item.variant) }
+        line_item.quantity.times { shipment.inventory_units.create(variant_id: line_item.variant) }
       end
     end
   end

--- a/core/lib/spree/testing_support/factories/shipping_category_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipping_category_factory.rb
@@ -1,7 +1,5 @@
 FactoryGirl.define do
-  sequence(:shipping_category_sequence) { |n| "ShippingCategory ##{n}" }
-
-  factory :shipping_category, :class => Spree::ShippingCategory do
-    name { FactoryGirl.generate :shipping_category_sequence }
+  factory :shipping_category, class: Spree::ShippingCategory do
+    sequence(:name) { |n| "ShippingCategory ##{n}" }
   end
 end

--- a/core/lib/spree/testing_support/factories/shipping_method_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipping_method_factory.rb
@@ -1,18 +1,18 @@
 FactoryGirl.define do
-  factory :base_shipping_method, :class => Spree::ShippingMethod do
+  factory :base_shipping_method, class: Spree::ShippingMethod do
     zones { |a| [Spree::Zone.global] }
     name 'UPS Ground'
+
     after(:create) do |shipping_method, evaluator|
-      shipping_method.shipping_categories << ( Spree::ShippingCategory.first || create(:shipping_category))
+      shipping_method.shipping_categories << (Spree::ShippingCategory.first || create(:shipping_category))
     end
 
-    factory :shipping_method, :class => Spree::ShippingMethod do
-      calculator { FactoryGirl.build(:calculator) }
+    factory :shipping_method, class: Spree::ShippingMethod do
+      association(:calculator, factory: :calculator, strategy: :build)
     end
 
-    factory :free_shipping_method, :class => Spree::ShippingMethod do
-      calculator { FactoryGirl.build(:no_amount_calculator) }
+    factory :free_shipping_method, class: Spree::ShippingMethod do
+      association(:calculator, factory: :no_amount_calculator, strategy: :build)
     end
-
   end
 end

--- a/core/lib/spree/testing_support/factories/state_factory.rb
+++ b/core/lib/spree/testing_support/factories/state_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :state, :class => Spree::State do
+  factory :state, class: Spree::State do
     name 'Alabama'
     abbr 'AL'
     country do |country|

--- a/core/lib/spree/testing_support/factories/stock_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_factory.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   # must use build()
-  factory :stock_packer, :class => Spree::Stock::Packer do
+  factory :stock_packer, class: Spree::Stock::Packer do
     ignore do
       stock_location { build(:stock_location) }
       contents []
@@ -9,7 +9,7 @@ FactoryGirl.define do
     initialize_with { new(stock_location, contents) }
   end
 
-  factory :stock_package, :class => Spree::Stock::Package do
+  factory :stock_package, class: Spree::Stock::Package do
     ignore do
       stock_location { build(:stock_location) }
       order { create(:order_with_line_items, line_items_count: 2) }

--- a/core/lib/spree/testing_support/factories/stock_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_item_factory.rb
@@ -1,9 +1,8 @@
 FactoryGirl.define do
-  factory :stock_item, :class => Spree::StockItem do
-    # associations:
+  factory :stock_item, class: Spree::StockItem do
     variant
     stock_location
 
-    after(:create) {|object| object.adjust_count_on_hand(10) }
+    after(:create) { |object| object.adjust_count_on_hand(10) }
   end
 end

--- a/core/lib/spree/testing_support/factories/stock_location_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_location_factory.rb
@@ -1,12 +1,11 @@
 FactoryGirl.define do
-  factory :stock_location, :class => Spree::StockLocation do
+  factory :stock_location, class: Spree::StockLocation do
     name 'NY Warehouse'
-    active true
-
     address1 '1600 Pennsylvania Ave NW'
     city 'Washington'
     zipcode '20500'
     phone '(202) 456-1111'
+    active true
 
     state  { |stock_location| stock_location.association(:state) }
     country  { |stock_location| stock_location.association(:country) }

--- a/core/lib/spree/testing_support/factories/stock_movement_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_movement_factory.rb
@@ -1,9 +1,7 @@
 FactoryGirl.define do
-  factory :stock_movement, :class => Spree::StockMovement do
+  factory :stock_movement, class: Spree::StockMovement do
     quantity 1
     action 'sold'
-
-    # associations:
     stock_item
   end
 

--- a/core/lib/spree/testing_support/factories/tax_category_factory.rb
+++ b/core/lib/spree/testing_support/factories/tax_category_factory.rb
@@ -1,16 +1,6 @@
 FactoryGirl.define do
-  factory :tax_category, :class => Spree::TaxCategory do
+  factory :tax_category, class: Spree::TaxCategory do
     name { "TaxCategory - #{rand(999999)}" }
-    description { Faker::Lorem.sentence }
-  end
-
-  factory :tax_category_with_rates, :parent => :tax_category do
-    after(:create) do |tax_category|
-      tax_category.tax_rates.create!({
-        :amount => 0.05,
-        :calculator => Spree::Calculator::DefaultTax.new,
-        :zone => Spree::Zone.find_by_name('GlobalZone') || FactoryGirl.create(:global_zone)
-      }, :without_protection => true)
-    end
+    description { generate(:random_string) }
   end
 end

--- a/core/lib/spree/testing_support/factories/tax_rate_factory.rb
+++ b/core/lib/spree/testing_support/factories/tax_rate_factory.rb
@@ -1,7 +1,8 @@
 FactoryGirl.define do
-  factory :tax_rate, :class => Spree::TaxRate do
-    zone { FactoryGirl.create(:zone) }
+  factory :tax_rate, class: Spree::TaxRate do
+    zone
     amount 100.00
-    tax_category { FactoryGirl.create(:tax_category) }
+    tax_category
+    # association(:calculator, factory: :default_tax_calculator, strategy: :build)
   end
 end

--- a/core/lib/spree/testing_support/factories/taxon_factory.rb
+++ b/core/lib/spree/testing_support/factories/taxon_factory.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
-  factory :taxon, :class => Spree::Taxon do
+  factory :taxon, class: Spree::Taxon do
     name 'Ruby on Rails'
-    taxonomy { FactoryGirl.create(:taxonomy) }
+    taxonomy
     parent_id nil
   end
 end

--- a/core/lib/spree/testing_support/factories/taxonomy_factory.rb
+++ b/core/lib/spree/testing_support/factories/taxonomy_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :taxonomy, :class => Spree::Taxonomy do
+  factory :taxonomy, class: Spree::Taxonomy do
     name 'Brand'
   end
 end

--- a/core/lib/spree/testing_support/factories/tracker_factory.rb
+++ b/core/lib/spree/testing_support/factories/tracker_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :tracker, :class => Spree::Tracker do
+  factory :tracker, class: Spree::Tracker do
     environment { Rails.env }
     analytics_id 'A100'
     active true

--- a/core/lib/spree/testing_support/factories/user_factory.rb
+++ b/core/lib/spree/testing_support/factories/user_factory.rb
@@ -3,15 +3,15 @@ FactoryGirl.define do
     "xxxx#{Time.now.to_i}#{rand(1000)}#{n}xxxxxxxxxxxxx"
   end
 
-  factory :user, :class => Spree.user_class do
-    email { Faker::Internet.email }
+  factory :user, class: Spree.user_class do
+    email { generate(:random_email) }
     login { email }
     password 'secret'
-    password_confirmation 'secret'
-    authentication_token { FactoryGirl.generate(:user_authentication_token) } if Spree.user_class.attribute_method? :authentication_token
-  end
+    password_confirmation { password }
+    authentication_token { generate(:user_authentication_token) } if Spree.user_class.attribute_method? :authentication_token
 
-  factory :admin_user, :parent => :user do
-    spree_roles { [Spree::Role.find_by_name('admin') || FactoryGirl.create(:role, :name => 'admin')] }
+    factory :admin_user do
+      spree_roles { [Spree::Role.find_by_name('admin') || create(:role, name: 'admin')] }
+    end
   end
 end

--- a/core/lib/spree/testing_support/factories/variant_factory.rb
+++ b/core/lib/spree/testing_support/factories/variant_factory.rb
@@ -1,25 +1,24 @@
 FactoryGirl.define do
-  factory :base_variant, :class => Spree::Variant do
+  sequence(:random_float) { BigDecimal.new("#{rand(200)}.#{rand(99)}") }
+
+  factory :base_variant, class: Spree::Variant do
     price 19.99
     cost_price 17.00
-    sku    { Faker::Lorem.sentence }
-    weight { BigDecimal.new("#{rand(200)}.#{rand(99)}") }
-    height { BigDecimal.new("#{rand(200)}.#{rand(99)}") }
-    width  { BigDecimal.new("#{rand(200)}.#{rand(99)}") }
-    depth  { BigDecimal.new("#{rand(200)}.#{rand(99)}") }
+    sku    { generate(:random_string) }
+    weight { generate(:random_float) }
+    height { generate(:random_float) }
+    width  { generate(:random_float) }
+    depth  { generate(:random_float) }
 
-    # associations:
     product { |p| p.association(:base_product) }
-    option_values { [FactoryGirl.create(:option_value)] }
+    option_values { [create(:option_value)] }
 
     # ensure stock item will be created for this variant
     before(:create) { create(:stock_location) if Spree::StockLocation.count == 0 }
-  end
 
-  factory :variant, :parent => :base_variant do
-    #on_hand 5
-
-    # associations:
-    product { |p| p.association(:product) }
+    factory :variant do
+      # on_hand 5
+      product { |p| p.association(:product) }
+    end
   end
 end

--- a/core/lib/spree/testing_support/factories/zone_factory.rb
+++ b/core/lib/spree/testing_support/factories/zone_factory.rb
@@ -1,17 +1,17 @@
 FactoryGirl.define do
-  factory :global_zone, :class => Spree::Zone do
+  factory :global_zone, class: Spree::Zone do
     name 'GlobalZone'
-    description { Faker::Lorem.sentence }
+    description { generate(:random_string) }
     zone_members do |proxy|
       zone = proxy.instance_eval { @instance }
       Spree::Country.all.map do |c|
-        zone_member = Spree::ZoneMember.create(:zoneable => c, :zone => zone)
+        zone_member = Spree::ZoneMember.create(zoneable: c, zone: zone)
       end
     end
   end
 
-  factory :zone, :class => Spree::Zone do
-    name { Faker::Lorem.sentence }
-    description { Faker::Lorem.sentence }
+  factory :zone, class: Spree::Zone do
+    name { generate(:random_string) }
+    description { generate(:random_string) }
   end
 end


### PR DESCRIPTION
**Simplification/refactor of the FactoryGirl factories:**
- Major clean up of all factories to more readable format.
- `:address` now has aliases `:bill_address` and `:ship_address` mostly intended for internal associations but can be used to improve readability for new specs.
- Added a simple test _(placed it in spec/models/ together with ability_spec.rb)_ for factories build that revealed following before any changes was made:

```
  1) FactoryGirl factories with factory for :line_item_adjustment
     Failure/Error: subject { build(factory.name) }
     ActiveRecord::RecordInvalid:
       Validation failed: Calculator can't be blank
     # ./spec/models/factory_spec.rb:6:in `block (4 levels) in <top (required)>'

  2) FactoryGirl factories with factory for :tax_rate
     Failure/Error: is_valid.should be_true, subject.errors.full_messages.join(',')
       Calculator can't be blank
     # ./spec/models/factory_spec.rb:10:in `block (4 levels) in <top (required)>'
```
- Fixed above by adding valid calculator build association based on `Spree::Calculator::DefaultTax`
- Factory `:custom_product` had `association :taxons` with error: `Factory not registered: taxons`. _I just commented it out instead of removing it_.
- Removed factory `:tax_category_with_rates` because it was not used in **any** tests and also triggered validation failure.
- Extracted all use of `Faker` to `factories.rb` as a common library, `Faker` its actually only used very few times now except from within `sample/db/samples`.

**Notes:**
- I tested with `bash ./build.sh` to make sure my changes pass all tests.
- The calculators builds needs further investigation -they pass now -but failed before.
- `match_none match_one match_all` are set to `nil` in the factory but they `boolean` in the model?. _But I didn't change this because it might be a reason for it._
