### PR TITLE
Require Shipping Calculators to Inherit from Spree::Calculator::Shipping

### DIFF
--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -20,6 +20,10 @@ module Spree
       I18n.t(:shipping)
     end
 
+    def self.calculators
+       Rails.application.config.spree.calculators.send(self.to_s.tableize.gsub('/', '_').sub('spree_', '')).select{|c| c.name.start_with?("Spree::Calculator::Shipping::")}
+    end
+
     def zone
       raise "DEPRECATION WARNING: ShippingMethod#zone is no longer correct. Multiple zones need to be supported"
       Rails.logger.error "DEPRECATION WARNING: ShippingMethod#zone is no longer correct. Multiple zones need to be supported"

--- a/core/spec/models/spree/shipping_method_spec.rb
+++ b/core/spec/models/spree/shipping_method_spec.rb
@@ -1,6 +1,17 @@
 require 'spec_helper'
 
 describe Spree::ShippingMethod do
+  context 'calculators' do
+  
+    it "Should reject calculators that don't inherit from Spree::Calculator::Shipping::" do
+      calculators = Rails.stub_chain(:application, :config, :spree, :calculators, :send).and_return [
+            Spree::Calculator::Shipping::FlatPercentItemTotal,
+            Spree::Calculator::Shipping::PriceSack,
+            Spree::Calculator::DefaultTax]
+      Spree::ShippingMethod.calculators.should == [Spree::Calculator::Shipping::FlatPercentItemTotal, Spree::Calculator::Shipping::PriceSack ]
+      Spree::ShippingMethod.calculators.should_not == [Spree::Calculator::DefaultTax]
+    end
+  end
   context 'factory' do
     let(:shipping_method){ create :shipping_method }
 


### PR DESCRIPTION
This is a required change introduced by new requirements of split_shipments
