### PR TITLE
Change code to invoke mailers with ids

### DIFF
--- a/core/app/controllers/spree/admin/orders_controller.rb
+++ b/core/app/controllers/spree/admin/orders_controller.rb
@@ -102,7 +102,7 @@ module Spree
       end
 
       def resend
-        OrderMailer.confirm_email(@order, true).deliver
+        OrderMailer.confirm_email(@order.id, true).deliver
         flash.notice = t(:order_email_resent)
 
         respond_with(@order) { |format| format.html { redirect_to :back } }

--- a/core/app/mailers/spree/order_mailer.rb
+++ b/core/app/mailers/spree/order_mailer.rb
@@ -7,19 +7,19 @@ module Spree
     end
 
     def confirm_email(order, resend = false)
-      @order = order
+      @order = order.respond_to?(:id) ? order : Spree::Order.find!(order)
       subject = (resend ? "[#{t(:resend).upcase}] " : '')
-      subject += "#{Spree::Config[:site_name]} #{t('order_mailer.confirm_email.subject')} ##{order.number}"
-      mail(:to => order.email,
+      subject += "#{Spree::Config[:site_name]} #{t('order_mailer.confirm_email.subject')} ##{@order.number}"
+      mail(:to => @order.email,
            :from => from_address,
            :subject => subject)
     end
 
     def cancel_email(order, resend = false)
-      @order = order
+      @order = order.respond_to?(:id) ? order : Spree::Order.find!(order)
       subject = (resend ? "[#{t(:resend).upcase}] " : '')
-      subject += "#{Spree::Config[:site_name]} #{t('order_mailer.cancel_email.subject')} ##{order.number}"
-      mail(:to => order.email,
+      subject += "#{Spree::Config[:site_name]} #{t('order_mailer.cancel_email.subject')} ##{@order.number}"
+      mail(:to => @order.email,
            :from => from_address,
            :subject => subject)
     end

--- a/core/app/mailers/spree/order_mailer.rb
+++ b/core/app/mailers/spree/order_mailer.rb
@@ -7,7 +7,7 @@ module Spree
     end
 
     def confirm_email(order, resend = false)
-      @order = order.respond_to?(:id) ? order : Spree::Order.find!(order)
+      @order = order.respond_to?(:id) ? order : Spree::Order.find(order)
       subject = (resend ? "[#{t(:resend).upcase}] " : '')
       subject += "#{Spree::Config[:site_name]} #{t('order_mailer.confirm_email.subject')} ##{@order.number}"
       mail(:to => @order.email,
@@ -16,7 +16,7 @@ module Spree
     end
 
     def cancel_email(order, resend = false)
-      @order = order.respond_to?(:id) ? order : Spree::Order.find!(order)
+      @order = order.respond_to?(:id) ? order : Spree::Order.find(order)
       subject = (resend ? "[#{t(:resend).upcase}] " : '')
       subject += "#{Spree::Config[:site_name]} #{t('order_mailer.cancel_email.subject')} ##{@order.number}"
       mail(:to => @order.email,

--- a/core/app/mailers/spree/shipment_mailer.rb
+++ b/core/app/mailers/spree/shipment_mailer.rb
@@ -7,10 +7,10 @@ module Spree
     end
 
     def shipped_email(shipment, resend = false)
-      @shipment = shipment
+      @shipment = shipment.respond_to?(:id) ? shipment : Spree::Shipment.find!(shipment)
       subject = (resend ? "[#{t(:resend).upcase}] " : '')
-      subject += "#{Spree::Config[:site_name]} #{t('shipment_mailer.shipped_email.subject')} ##{shipment.order.number}"
-      mail(:to => shipment.order.email,
+      subject += "#{Spree::Config[:site_name]} #{t('shipment_mailer.shipped_email.subject')} ##{@shipment.order.number}"
+      mail(:to => @shipment.order.email,
            :from => from_address,
            :subject => subject)
     end

--- a/core/app/mailers/spree/shipment_mailer.rb
+++ b/core/app/mailers/spree/shipment_mailer.rb
@@ -7,7 +7,7 @@ module Spree
     end
 
     def shipped_email(shipment, resend = false)
-      @shipment = shipment.respond_to?(:id) ? shipment : Spree::Shipment.find!(shipment)
+      @shipment = shipment.respond_to?(:id) ? shipment : Spree::Shipment.find(shipment)
       subject = (resend ? "[#{t(:resend).upcase}] " : '')
       subject += "#{Spree::Config[:site_name]} #{t('shipment_mailer.shipped_email.subject')} ##{@shipment.order.number}"
       mail(:to => @shipment.order.email,

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -388,7 +388,7 @@ module Spree
 
     def deliver_order_confirmation_email
       begin
-        OrderMailer.confirm_email(self).deliver
+        OrderMailer.confirm_email(self.id).deliver
       rescue Exception => e
         logger.error("#{e.class.name}: #{e.message}")
         logger.error(e.backtrace * "\n")
@@ -637,7 +637,7 @@ module Spree
         restock_items!
 
         #TODO: make_shipments_pending
-        OrderMailer.cancel_email(self).deliver
+        OrderMailer.cancel_email(self.id).deliver
         unless %w(partial shipped).include?(shipment_state)
           self.payment_state = 'credit_owed'
         end

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -144,7 +144,7 @@ module Spree
       end
 
       def send_shipped_email
-        ShipmentMailer.shipped_email(self).deliver
+        ShipmentMailer.shipped_email(self.id).deliver
       end
 
       def ensure_correct_adjustment

--- a/core/spec/mailers/order_mailer_spec.rb
+++ b/core/spec/mailers/order_mailer_spec.rb
@@ -28,6 +28,20 @@ describe Spree::OrderMailer do
     confirmation_email.body.should_not include("&quot;")
   end
 
+  it "confirm_email accepts an order id as an alternative to an Order object" do
+    Spree::Order.should_receive(:find!).with(order.id).and_return(order)
+    lambda {
+      confirmation_email = Spree::OrderMailer.confirm_email(order.id)
+    }.should_not raise_error
+  end
+
+  it "cancel_email accepts an order id as an alternative to an Order object" do
+    Spree::Order.should_receive(:find!).with(order.id).and_return(order)
+    lambda {
+      cancel_email = Spree::OrderMailer.cancel_email(order.id)
+    }.should_not raise_error
+  end
+
   context "only shows eligible adjustments in emails" do
     before do
       order.adjustments.create({:label    => "Eligible Adjustment",

--- a/core/spec/mailers/shipment_mailer_spec.rb
+++ b/core/spec/mailers/shipment_mailer_spec.rb
@@ -29,6 +29,13 @@ describe Spree::ShipmentMailer do
     shipment_email.body.should_not include(%Q{Out of Stock})
   end
 
+  it "shipment_email accepts an shipment id as an alternative to an Shipment object" do
+    Spree::Shipment.should_receive(:find!).with(shipment.id).and_return(shipment)
+    lambda {
+      shipped_email = Spree::ShipmentMailer.shipped_email(shipment.id)
+    }.should_not raise_error
+  end
+
   context "emails must be translatable" do
     context "shipped_email" do
       context "en locale" do

--- a/core/spec/models/order/state_machine_spec.rb
+++ b/core/spec/models/order/state_machine_spec.rb
@@ -132,9 +132,14 @@ describe Spree::Order do
       order.stub :has_available_shipment
       order.stub :restock_items!
       mail_message = mock "Mail::Message"
-      Spree::OrderMailer.should_receive(:cancel_email).with(order).and_return mail_message
+      order_id = nil
+      Spree::OrderMailer.should_receive(:cancel_email) { |*args|
+        order_id = args[0]
+        mail_message
+      }
       mail_message.should_receive :deliver
       order.cancel!
+      order_id.should == order.id
     end
 
     context "restocking inventory" do

--- a/core/spec/models/order_spec.rb
+++ b/core/spec/models/order_spec.rb
@@ -122,13 +122,13 @@ describe Spree::Order do
 
     it "should send an order confirmation email" do
       mail_message = mock "Mail::Message"
-      Spree::OrderMailer.should_receive(:confirm_email).with(order).and_return mail_message
+      Spree::OrderMailer.should_receive(:confirm_email).with(order.id).and_return mail_message
       mail_message.should_receive :deliver
       order.finalize!
     end
 
     it "should continue even if confirmation email delivery fails" do
-      Spree::OrderMailer.should_receive(:confirm_email).with(order).and_raise 'send failed!'
+      Spree::OrderMailer.should_receive(:confirm_email).with(order.id).and_raise 'send failed!'
       order.finalize!
     end
 

--- a/core/spec/models/shipment_spec.rb
+++ b/core/spec/models/shipment_spec.rb
@@ -158,9 +158,14 @@ describe Spree::Shipment do
 
     it "should send a shipment email" do
       mail_message = mock "Mail::Message"
-      Spree::ShipmentMailer.should_receive(:shipped_email).with(shipment).and_return mail_message
+      shipment_id = nil
+      Spree::ShipmentMailer.should_receive(:shipped_email) { |*args|
+        shipment_id = args[0]
+        mail_message
+      }
       mail_message.should_receive :deliver
       shipment.ship!
+      shipment_id.should == shipment.id
     end
   end
 


### PR DESCRIPTION
It's generally preferable to invoke mailers using ids.  Using ids as opposed to full-blown model objects makes it easier to swap in asynchronous mailers, as only the ids need to be persisted in the back end store supporting the asynchronous mailers.

This PR includes the following changes:
1. Spree::OrderMailer and Spree::ShipmentMailer can be invoked using either models or their ids.
2. Methods that call methods on Spree::OrderMailer or Spree::ShipmentMailer now pass model ids as opposed to model objects
3. Changes to the specs to validate this behavior.
