### PR TITLE
Display a Name on card input on checkout payment step

### DIFF
--- a/backend/app/views/spree/admin/payments/source_forms/_gateway.html.erb
+++ b/backend/app/views/spree/admin/payments/source_forms/_gateway.html.erb
@@ -27,6 +27,14 @@
         </div>
       </div>
     </div>
+    <div class="alpha four columns">
+      <div data-hook="card_name">
+        <div class="field">
+          <%= label_tag 'card_name', raw(t(:name) + content_tag(:span, ' *', :class => 'required')) %>
+          <%= text_field_tag "#{param_prefix}[name]", '', :class => 'required fullwidth', :id => 'card_name', :maxlength => 19 %>
+        </div>
+      </div>
+    </div>
     <div class="three columns">
       <div data-hook="card_expiration" class="field">
         <%= label_tag 'card_month', raw(t(:expiration) + content_tag(:span, ' *', :class => 'required')) %><br>

--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -28,14 +28,6 @@ module Spree
       self.last_digits ||= number.to_s.length <= 4 ? number : number.to_s.slice(-4..-1)
     end
 
-    def name?
-      first_name? && last_name?
-    end
-
-    def name
-      "#{first_name} #{last_name}"
-    end
-
     def verification_value?
       verification_value.present?
     end

--- a/core/db/migrate/20130413230529_add_name_to_spree_credit_cards.rb
+++ b/core/db/migrate/20130413230529_add_name_to_spree_credit_cards.rb
@@ -1,0 +1,5 @@
+class AddNameToSpreeCreditCards < ActiveRecord::Migration
+  def change
+    add_column :spree_credit_cards, :name, :string
+  end
+end

--- a/core/db/migrate/20130414000512_update_name_fields_on_spree_credit_cards.rb
+++ b/core/db/migrate/20130414000512_update_name_fields_on_spree_credit_cards.rb
@@ -1,0 +1,13 @@
+class UpdateNameFieldsOnSpreeCreditCards < ActiveRecord::Migration
+  def up
+    if ActiveRecord::Base.connection.adapter_name.downcase.include? "mysql"
+      execute "UPDATE spree_credit_cards SET name = CONCAT(first_name, ' ', last_name)"
+    else
+      execute "UPDATE spree_credit_cards SET name = first_name || ' ' || last_name"
+    end
+  end
+
+  def down
+    execute "UPDATE spree_credit_cards SET name = NULL"
+  end
+end

--- a/frontend/app/views/spree/checkout/payment/_gateway.html.erb
+++ b/frontend/app/views/spree/checkout/payment/_gateway.html.erb
@@ -1,6 +1,11 @@
 <%= image_tag 'credit_cards/credit_card.gif', :id => 'credit-card-image' %>
 <% param_prefix = "payment_source[#{payment_method.id}]" %>
 
+<p class="field">
+  <%= label_tag "name_on_card", t(:name_on_card) %><span class="required">*</span><br />
+  <%= text_field_tag "#{param_prefix}[name]", "#{@order.billing_firstname} #{@order.billing_lastname}" %>
+</p>
+
 <p class="field" data-hook="card_number">
   <%= label_tag "card_number", Spree.t(:card_number) %><span class="required">*</span><br />
   <% options_hash = Rails.env.production? ? {:autocomplete => 'off'} : {} %>
@@ -12,10 +17,12 @@
     )
   </span>
 </p>
+
 <p class="field" data-hook="card_expiration">
   <%= label_tag "card_month", Spree.t(:expiration) %><span class="required">*</span><br />
   <%= text_field_tag "#{param_prefix}[expiry]", '', :id => 'card_expiry', :class => "required", :placeholder => "MM / YY" %>
 </p>
+
 <p class="field" data-hook="card_code">
   <%= label_tag "card_code", Spree.t(:card_code) %><span class="required">*</span><br />
   <%= text_field_tag "#{param_prefix}[verification_value]", '', options_hash.merge(:id => 'card_code', :class => 'required', :size => 5) %>
@@ -23,6 +30,3 @@
 </p>
 
 <%= hidden_field_tag "#{param_prefix}[cc_type]", '', :id => "cc_type" %>
-
-<%= hidden_field param_prefix, 'first_name', :value => @order.billing_firstname %>
-<%= hidden_field param_prefix, 'last_name', :value => @order.billing_lastname %>

--- a/frontend/app/views/spree/payments/_payment.html.erb
+++ b/frontend/app/views/spree/payments/_payment.html.erb
@@ -7,10 +7,7 @@
     <%= Spree.t(:ending_in) %> <%= source.last_digits %>
   </span>
   <br />
-  <span class="full-name">
-    <%= source.first_name %>
-    <%= source.last_name %>
-  </span>
+  <span class="full-name"><%= source.name %></span>
 <% else %>
   <%= content_tag(:span, payment.payment_method.name) %>
 <% end %>


### PR DESCRIPTION
This is my proposal to fix #2486

I replaced the first_name / last_name hidden inputs for a `name_on_card` text input. I find it odd that the `Spree::CreditCard` has first and last name when I believe only `credit_card#name` is actually used. I think those two columns could be removed in favor of just one `name` column. So far I didn't touch migrations. I'd like to get an approval of the idea before moving any further with this. cc @GeekOnCoffee @radar
