### PR TITLE
Generation of spree extensions is failing

### DIFF
--- a/cmd/lib/spree_cmd/templates/extension/Gemfile
+++ b/cmd/lib/spree_cmd/templates/extension/Gemfile
@@ -1,6 +1,6 @@
 source 'http://rubygems.org'
 
 # Provides basic authentication functionality for testing parts of your engine
-gem 'spree_auth_devise', :git => "git://github.com/spree/spree_auth_devise"
+gem 'spree_auth_devise', :git => "git://github.com/spree/spree_auth_devise", :branch => '1-3-stable'
 
 gemspec


### PR DESCRIPTION
This patch fixes the generation of extensions. This currently fails with the following message when 'bundle install' is run on a newly generated extension folder:

```
$ bundle install
Fetching git://github.com/spree/spree_auth_devise
remote: Counting objects: 2212, done.
remote: Compressing objects: 100% (926/926), done.
remote: Total 2212 (delta 1176), reused 2063 (delta 1053)
Receiving objects: 100% (2212/2212), 382.92 KiB | 195 KiB/s, done.
Resolving deltas: 100% (1176/1176), done.
Fetching gem metadata from http://rubygems.org/.......
Fetching gem metadata from http://rubygems.org/..
Could not find gem 'spree_core (~> 2.0.0.beta) ruby', which is required by gem 'spree_auth_devise (>= 0) ruby', in any of the sources.
```

It's failing because the template Gemfile used to generate the extension does not specify the spree_auth_devise branch to depend upon.
