### PR TITLE
Fix token field data to allow ' in the product name.  

### DIFF
--- a/core/app/helpers/spree/admin/base_helper.rb
+++ b/core/app/helpers/spree/admin/base_helper.rb
@@ -181,7 +181,7 @@ module Spree
         products = Product.with_ids(value.split(','))
         product_names = products.inject({}){|memo,item| memo[item.id] = item.name; memo}
         product_rules = products.collect{ |p| { :id => p.id, :name => p.name } }
-        %(<input type="text" name="#{name}" value="#{value}" class="tokeninput products" data-names='#{product_names.to_json}' data-pre='#{product_rules.to_json}'/>).html_safe
+        %(<input type="text" name="#{name}" value="#{value}" class="tokeninput products" data-names='#{h product_names.to_json}' data-pre='#{h product_rules.to_json}'/>).html_safe
       end
 
       def link_to_add_fields(name, target)


### PR DESCRIPTION
Fails if product name is ex. "70's T-Shirt".  Displays "undefined" in the product list.
