### PR TITLE
Allow authenticated users to access api without key

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -63,13 +63,15 @@ module Spree
       end
 
       def authenticate_user
-        if requires_authentication? || api_key.present?
-          unless @current_api_user = Spree.user_class.find_by_spree_api_key(api_key.to_s)
-            render "spree/api/errors/invalid_api_key", :status => 401 and return
+        unless @current_api_user
+          if requires_authentication? || api_key.present?
+            unless @current_api_user = Spree.user_class.find_by_spree_api_key(api_key.to_s)
+              render "spree/api/errors/invalid_api_key", :status => 401 and return
+            end
+          else
+            # An anonymous user
+            @current_api_user = Spree.user_class.new
           end
-        else
-          # An authenticated user or an anonymous user
-          @current_api_user = try_spree_current_user || Spree.user_class.new
         end
       end
 

--- a/api/spec/controllers/spree/api/base_controller_spec.rb
+++ b/api/spec/controllers/spree/api/base_controller_spec.rb
@@ -11,7 +11,7 @@ describe Spree::Api::BaseController do
   context "signed in as a user using an authentication extension" do
     before do
       controller.stub :try_spree_current_user => stub(:email => "spree@example.com")
-      Spree::Api::Config[:requires_authentication] = false
+      Spree::Api::Config[:requires_authentication] = true
     end
 
     it "can make a request" do


### PR DESCRIPTION
I ran into an issue where one of the backend views was trying to access the API's states_controller in json request. It was getting rejected with a invalid_api_key error. 

Looking at the base_controller, it seems the spec was not properly configured since it was setting `Spree::Api::Config[:requires_authentication] = false`. Unless I'm missing something, shouldn't that spec be verifying the user when authentication is in fact required (as opposed to when it is not)?

In any case, it probably doesn't make sense to authenticated logged in users twice, i.e. in two different before_filters. It was happening in both `check_for_user_or_api_key` and `authenticate_user`.

Please let me know if I'm missing something, but this fixed my use case and (I believe) a spec that was previously passing for the wrong reason.
