### PR TITLE
Avoid nil object errors when querying a country's state in stock location form

### DIFF
--- a/backend/app/views/spree/admin/stock_locations/_form.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/_form.html.erb
@@ -59,9 +59,11 @@
     <div class="four columns">
       <div class="field ">
         <%= f.label :state_id, t(:state) + ':' %>
+        <% states_present = (f.object.country && f.object.country.states.any?) -%>
+        <% states = states_present ? f.object.country.states : [] -%>
         <span id="state" class="region">
-          <%= f.text_field :state_name, :style => "display: #{f.object.country.states.empty? ? 'block' : 'none' };", :disabled => !f.object.country.states.empty?, :class => 'fullwidth state_name' %>
-          <%= f.collection_select :state_id, f.object.country.states.sort, :id, :name, {:include_blank => true}, {:class => 'select2 fullwidth', :style => "display: #{f.object.country.states.empty? ? 'none' : 'block' };", :disabled => f.object.country.states.empty?} %>
+          <%= f.text_field :state_name, :style => "display: #{states_present ? 'none' : 'block'};", :disabled => states_present, :class => 'fullwidth state_name' %>
+          <%= f.collection_select :state_id, states.sort, :id, :name, {:include_blank => true}, {:class => 'select2 fullwidth', :style => "display: #{states_present ? 'none' : 'block'};", :disabled => !states_present} %>
         </span>
       </div>
     </div>

--- a/backend/app/views/spree/admin/stock_locations/index.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/index.html.erb
@@ -7,7 +7,7 @@
 <% content_for :page_actions do %>
   <ul class="actions inline-menu">
     <li>
-      <%= button_link_to t(:new_stock_location), new_object_url, { :icon => 'icon-plus', :id => 'admin_new_stock_location' } %> 
+      <%= button_link_to t(:new_stock_location), new_object_url, { :icon => 'icon-plus', :id => 'admin_new_stock_location' } %>
     </li>
   </ul>
 <% end %>
@@ -35,7 +35,7 @@
       <tr id="<%= spree_dom_id stock_location %>" data-hook="stock_location_row" class="<%= cycle('odd', 'even')%>">
         <td><%= stock_location.name %></td>
         <td><span class="state <%= stock_location.active? ? 'active' : 'inactive' %>"><%= stock_location.active? ? 'active' : 'inactive' %></span></td>
-        <td><%= link_to t(:stock_movements), admin_stock_location_stock_movements_path(stock_location.id) %> </td>
+        <td><%= link_to t(:stock_movements), admin_stock_location_stock_movements_path(stock_location.id) %></td>
         <td class="actions">
           <%= link_to_edit stock_location, :no_text => true %>
           <%= link_to_delete stock_location, :no_text => true %>

--- a/backend/spec/requests/admin/configuration/stock_locations_spec.rb
+++ b/backend/spec/requests/admin/configuration/stock_locations_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe "Stock Locations" do
+  stub_authorization!
+  let!(:stock_location) { create(:stock_location, :country => nil) }
+
+  before(:each) do
+    # HACK: To work around no email prompting on check out
+    Spree::Order.any_instance.stub(:require_email => false)
+    create(:payment_method, :environment => 'test')
+
+    visit spree.admin_path
+    click_link "Configuration"
+  end
+
+
+  context "show" do
+    it "should display exisiting stock locations" do
+      click_link "Stock Locations"
+
+      within_row(1) do
+        column_text(1).should == stock_location.name
+        column_text(2).should == "active"
+        column_text(3).should == "Stock Movements"
+      end
+    end
+  end
+
+  context "create" do
+    it "should be able to create a new stock location" do
+      click_link "Stock Locations"
+      click_link "admin_new_stock_location"
+      page.should have_content("New Stock Location")
+      fill_in "stock_location_name", :with => "bullock stock location"
+      click_button "Create"
+      page.should have_content("successfully created!")
+      page.should have_content("Editing Shipping Method")
+    end
+  end
+
+  # Regression test for #2818
+  context "update" do
+    it "can change a stock location with no associated country" do
+      click_link "Stock Locations"
+      within("#listing_stock_locations") do
+        click_icon :edit
+      end
+
+      select('United States', :from => 'Country')
+
+      click_button "Update"
+      page.should have_content("successfully updated!")
+    end
+  end
+
+end


### PR DESCRIPTION
The edit form for stock locations in the backend facet assumes that an editable stock location already has a country assigned. However [this migration](https://github.com/spree/spree/blob/master/core/db/migrate/20130213191427_create_default_stock.rb#L5) creates a default stock location that doesn't have any country or address assigned. This results in your typical `undefined method states for nil` error when attempting to edit the stock location.

There was also some repetitive use of the `f.object.country.states.empty?` expression. My solution involves assigning the value of this expression to a variable while first ensuring that the country relation exists. I don't like the idea of assigning vars in a template, but I wasn't sure how far we should go in refactor this into e.g. a helper class. I'd be happy to take that on if it's considered preferable by the maintainers.
