### PR TITLE
Fix shipping instructions style.

### DIFF
--- a/core/app/assets/stylesheets/store/screen.css.scss
+++ b/core/app/assets/stylesheets/store/screen.css.scss
@@ -788,6 +788,14 @@ mark {background-color: $link_text_color; color: $layout_background_color; font-
 
   #shipping_method {
     p {
+      &#minstrs {
+        clear: both;
+
+        label {
+          width: 100%;
+        }
+      }
+
       label {
         float: left;
         font-weight: bold;


### PR DESCRIPTION
Shipping instructions doesn't look very good due to the way floating is handled.

![shipping-instructions-before](https://f.cloud.github.com/assets/764390/340299/6e3eafbc-9d4c-11e2-987c-8e279e15115a.png)

now looks like:

![shipping-instructions-after](https://f.cloud.github.com/assets/764390/340297/5b8eaea8-9d4c-11e2-956e-9bd53fee7f11.png)
