### PR TITLE
Fix to invalidate previously entered payments. Fixes #2687 and #2822

### DIFF
--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -122,7 +122,7 @@ module Spree
       end
 
       def invalidate_old_payments
-        order.payments.with_state(:checkout).where("id != ?", self.id).each do |payment|
+        order.payments.with_state('checkout').where("id != ?", self.id).each do |payment|
           payment.invalidate!
         end
       end

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -14,6 +14,8 @@ module Spree
 
     # update the order totals, etc.
     after_save :update_order
+    # invalidate previously entered payments
+    after_create :invalidate_old_payments
 
     attr_accessor :source_attributes
     after_initialize :build_source
@@ -117,6 +119,12 @@ module Spree
         payment_method.create_profile(self)
       rescue ActiveMerchant::ConnectionError => e
         gateway_error e
+      end
+
+      def invalidate_old_payments
+        order.payments.with_state(:checkout).where("id != ?", self.id).each do |payment|
+          payment.invalidate!
+        end
       end
 
       def update_order


### PR DESCRIPTION
This addresses issues https://github.com/spree/spree/issues/2687 and https://github.com/spree/spree/issues/2822

This pull adds an on_create callback to Spree::Payment so that the newly created payment invalidates the previous payments. This fixes the Edit Payment functionality and no longer queues up multiple payments in the :checkout state leading to incorrect credit cards being charged and multiple payments being left in the :checkout state after order is complete.

This implementation avoids the recursion and self-invalidation issues present in pull request https://github.com/spree/spree/pull/2722
