### PR TITLE
Disable inactive payment method fields

### DIFF
--- a/core/app/assets/javascripts/store/checkout.js.coffee
+++ b/core/app/assets/javascripts/store/checkout.js.coffee
@@ -71,8 +71,8 @@ $ ->
 
   if ($ '#checkout_form_payment').is('*')
     ($ 'input[type="radio"][name="order[payments_attributes][][payment_method_id]"]').click(->
-      ($ '#payment-methods li').hide()
-      ($ '#payment_method_' + @value).show() if @checked
+      ($ '#payment-methods li').hide().find('input,select,textarea').attr('disabled', 'disabled')
+      ($ '#payment_method_' + @value).find('input,select,textarea').removeAttr('disabled').show() if @checked
     )
 
     ($ '#cvv_link').live('click', (event) ->


### PR DESCRIPTION
Failed validations from inactive and hidden payment method fields
will prevent the checkout form from being submitted.  Disabling
these fields will instruct the validation plugin to skip them
during validation.
