### PR TITLE
Dependency error in install.rb

### DIFF
--- a/install.rb
+++ b/install.rb
@@ -2,7 +2,7 @@ require 'fileutils'
 
 version = ARGV.pop
 
-%w( core api backend dash frontend sample ).each do |framework|
+%w( cmd core api backend frontend dash sample ).each do |framework|
   puts "Installing #{framework}..."
 
   Dir.chdir(framework) do


### PR DESCRIPTION
On cloning the spree repo and running

```
$ ruby install.rb 2.0.0.beta
```

The installation failed with the following output:

```
Installing core...
WARNING:  description and summary are identical
Installing api...
WARNING:  licenses is empty
WARNING:  no homepage specified
WARNING:  description and summary are identical
WARNING:  prerelease dependency on spree_core (= 2.0.0.beta) is not recommended
Installing backend...
WARNING:  licenses is empty
WARNING:  prerelease dependency on spree_core (= 2.0.0.beta) is not recommended
WARNING:  prerelease dependency on spree_api (= 2.0.0.beta) is not recommended
Installing dash...
WARNING:  prerelease dependency on spree_backend (= 2.0.0.beta) is not recommended
WARNING:  prerelease dependency on spree_frontend (= 2.0.0.beta) is not recommended
ERROR:  While executing gem ... (Gem::DependencyError)
    Unable to resolve dependencies: spree_dash requires spree_frontend (= 2.0.0.beta)
Installing frontend...
WARNING:  licenses is empty
WARNING:  prerelease dependency on spree_core (= 2.0.0.beta) is not recommended
WARNING:  prerelease dependency on spree_api (= 2.0.0.beta) is not recommended
Installing sample...
WARNING:  prerelease dependency on spree_core (= 2.0.0.beta) is not recommended
Installing Spree...
WARNING:  prerelease dependency on spree_core (= 2.0.0.beta) is not recommended
WARNING:  prerelease dependency on spree_api (= 2.0.0.beta) is not recommended
WARNING:  prerelease dependency on spree_backend (= 2.0.0.beta) is not recommended
WARNING:  prerelease dependency on spree_dash (= 2.0.0.beta) is not recommended
WARNING:  prerelease dependency on spree_frontend (= 2.0.0.beta) is not recommended
WARNING:  prerelease dependency on spree_sample (= 2.0.0.beta) is not recommended
WARNING:  prerelease dependency on spree_cmd (= 2.0.0.beta) is not recommended
ERROR:  While executing gem ... (Gem::DependencyError)
    Unable to resolve dependencies: spree requires spree_dash (= 2.0.0.beta), spree_cmd (= 2.0.0.beta)
```

This commit rearranges the installation order to fix the dependency error.
