### PR TITLE
Fix last_incomplete_spree_order to return 'last' order

### DIFF
--- a/core/config/initializers/user_class_extensions.rb
+++ b/core/config/initializers/user_class_extensions.rb
@@ -18,7 +18,7 @@ Spree::Core::Engine.config.to_prepare do
       end
 
       def last_incomplete_spree_order
-        spree_orders.incomplete.order('created_at DESC').last
+        spree_orders.incomplete.order('created_at DESC').first
       end
     end
   end


### PR DESCRIPTION
`order('created_at DESC').last` equals `order('created_at ASC').first`.
So, this method returns "earliest" order.

This PR fixes it with `order('created_at DESC').first`.
