### PR TITLE
JS and CSS assets in newly generated extensions require non-existant spree_core assets

### DIFF
--- a/cmd/lib/spree_cmd/templates/extension/app/assets/javascripts/admin/%file_name%.js
+++ b/cmd/lib/spree_cmd/templates/extension/app/assets/javascripts/admin/%file_name%.js
@@ -1,1 +1,1 @@
-//= require admin/spree_core
+//= require admin/spree_backend

--- a/cmd/lib/spree_cmd/templates/extension/app/assets/javascripts/store/%file_name%.js
+++ b/cmd/lib/spree_cmd/templates/extension/app/assets/javascripts/store/%file_name%.js
@@ -1,1 +1,1 @@
-//= require store/spree_core
+//= require store/spree_frontend

--- a/cmd/lib/spree_cmd/templates/extension/app/assets/stylesheets/admin/%file_name%.css
+++ b/cmd/lib/spree_cmd/templates/extension/app/assets/stylesheets/admin/%file_name%.css
@@ -1,3 +1,3 @@
 /*
- *= require admin/spree_core
+ *= require admin/spree_backend
 */

--- a/cmd/lib/spree_cmd/templates/extension/app/assets/stylesheets/store/%file_name%.css
+++ b/cmd/lib/spree_cmd/templates/extension/app/assets/stylesheets/store/%file_name%.css
@@ -1,3 +1,3 @@
 /*
- *= require store/spree_core
+ *= require store/spree_frontend
 */


### PR DESCRIPTION
The commit in this pull request changes the assets required in the extension templates to the new spree_frontend and spree_backend assets.
