### PR TITLE
[Dash] Set model class to allow abilities to define access.

### DIFF
--- a/core/lib/spree/core/controller_helpers/common.rb
+++ b/core/lib/spree/core/controller_helpers/common.rb
@@ -2,83 +2,83 @@ module Spree
   module Core
     module ControllerHelpers
       module Common
-        def self.included(base)
-          base.class_eval do
-            helper_method :title
-            helper_method :title=
-            helper_method :accurate_title
+        extend ActiveSupport::Concern
+        included do
+          helper_method :title
+          helper_method :title=
+          helper_method :accurate_title
 
-            layout :get_layout
+          layout :get_layout
 
-            before_filter :set_user_language
+          before_filter :set_user_language
+
+          protected
+
+          # Convenience method for firing instrumentation events with the default payload hash
+          def fire_event(name, extra_payload = {})
+            ActiveSupport::Notifications.instrument(name, default_notification_payload.merge(extra_payload))
           end
-        end
 
-        protected
+          # Creates the hash that is sent as the payload for all notifications. Specific notifications will
+          # add additional keys as appropriate. Override this method if you need additional data when
+          # responding to a notification
+          def default_notification_payload
+            {:user => try_spree_current_user, :order => current_order}
+          end
 
-        # Convenience method for firing instrumentation events with the default payload hash
-        def fire_event(name, extra_payload = {})
-          ActiveSupport::Notifications.instrument(name, default_notification_payload.merge(extra_payload))
-        end
+          # can be used in views as well as controllers.
+          # e.g. <% title = 'This is a custom title for this view' %>
+          attr_writer :title
 
-        # Creates the hash that is sent as the payload for all notifications. Specific notifications will
-        # add additional keys as appropriate. Override this method if you need additional data when
-        # responding to a notification
-        def default_notification_payload
-          {:user => try_spree_current_user, :order => current_order}
-        end
-
-        # can be used in views as well as controllers.
-        # e.g. <% title = 'This is a custom title for this view' %>
-        attr_writer :title
-
-        def title
-          title_string = @title.present? ? @title : accurate_title
-          if title_string.present?
-            if Spree::Config[:always_put_site_name_in_title]
-              [title_string, default_title].join(' - ')
+          def title
+            title_string = @title.present? ? @title : accurate_title
+            if title_string.present?
+              if Spree::Config[:always_put_site_name_in_title]
+                [title_string, default_title].join(' - ')
+              else
+                title_string
+              end
             else
-              title_string
+              default_title
             end
-          else
-            default_title
           end
-        end
 
-        def default_title
-          Spree::Config[:site_name]
-        end
-
-        # this is a hook for subclasses to provide title
-        def accurate_title
-          Spree::Config[:default_seo_title]
-        end
-
-        def render_404(exception = nil)
-          respond_to do |type|
-            type.html { render :status => :not_found, :file    => "#{::Rails.root}/public/404", :formats => [:html], :layout => nil}
-            type.all  { render :status => :not_found, :nothing => true }
+          def default_title
+            Spree::Config[:site_name]
           end
-        end
 
-        private
+          # this is a hook for subclasses to provide title
+          def accurate_title
+            Spree::Config[:default_seo_title]
+          end
 
-        def set_user_language
-          locale = session[:locale]
-          locale ||= config_locale if respond_to?(:config_locale)
-          locale ||= Rails.application.config.i18n.default_locale
-          locale ||= I18n.default_locale unless I18n.available_locales.map(&:to_s).include?(locale)
-          I18n.locale = locale
-        end
+          def render_404(exception = nil)
+            respond_to do |type|
+              type.html { render :status => :not_found, :file    => "#{::Rails.root}/public/404", :formats => [:html], :layout => nil}
+              type.all  { render :status => :not_found, :nothing => true }
+            end
+          end
 
-        # Returns which layout to render.
-        # 
-        # You can set the layout you want to render inside your Spree configuration with the +:layout+ option.
-        # 
-        # Default layout is: +app/views/spree/layouts/spree_application+
-        # 
-        def get_layout
-          layout ||= Spree::Config[:layout]
+          private
+
+          def set_user_language
+            locale = session[:locale]
+            locale ||= config_locale if defined?(:config_locale)
+            locale ||= Rails.application.config.i18n.default_locale
+            locale ||= I18n.default_locale unless I18n.available_locales.map(&:to_s).include?(locale)
+            I18n.locale = locale
+          end
+
+          # Returns which layout to render.
+          # 
+          # You can set the layout you want to render inside your Spree configuration with the +:layout+ option.
+          # 
+          # Default layout is: +app/views/spree/layouts/spree_application+
+          # 
+          def get_layout
+            layout ||= Spree::Config[:layout]
+          end
+
         end
       end
     end

--- a/core/lib/spree/core/controller_helpers/common.rb
+++ b/core/lib/spree/core/controller_helpers/common.rb
@@ -63,7 +63,7 @@ module Spree
 
           def set_user_language
             locale = session[:locale]
-            locale ||= config_locale if defined?(:config_locale)
+            locale ||= config_locale if respond_to?(:config_locale, true)
             locale ||= Rails.application.config.i18n.default_locale
             locale ||= I18n.default_locale unless I18n.available_locales.map(&:to_s).include?(locale)
             I18n.locale = locale

--- a/dash/app/controllers/spree/admin/overview_controller.rb
+++ b/dash/app/controllers/spree/admin/overview_controller.rb
@@ -27,5 +27,9 @@ module Spree
         end
       end
     end
+
+    def model_class
+      Spree::Dash
+    end
   end
 end

--- a/dash/spec/controllers/admin/overview_controller_spec.rb
+++ b/dash/spec/controllers/admin/overview_controller_spec.rb
@@ -2,17 +2,20 @@ require 'spec_helper'
 
 describe Spree::Admin::OverviewController do
 
-  before :each do
+  it "sets the locale preference" do
     @user = create(:admin_user)
     controller.stub :spree_current_user => @user
     Spree::Dash::Config.should_receive(:configured?).at_least(1).times.and_return(true)
     session[:last_jirafe_sync] = DateTime.now
-  end
 
-  it "sets the locale preference" do
     Spree::Dash::Config.locale = 'en_EN'
     spree_get :index, :locale => 'fr_FR'
     Spree::Dash::Config.locale.should eq 'fr_FR'
+  end
+
+  # Regression test for https://github.com/spree/spree/pull/2859
+  it 'should respond to model_class as Spree::Dash' do
+    controller.send(:model_class).should eql(Spree::Dash)
   end
 
 end


### PR DESCRIPTION
This allows an ability to set access to the overview page like so:

```
can [:admin, :index, :sync], Spree::Dash
```
