### PR TITLE
Generating test_apps for extensions doesn't work the way the developer extensions tutorial implies it should

### DIFF
--- a/cmd/lib/spree_cmd/templates/extension/Rakefile
+++ b/cmd/lib/spree_cmd/templates/extension/Rakefile
@@ -2,7 +2,7 @@ require 'bundler'
 Bundler::GemHelper.install_tasks
 
 require 'rspec/core/rake_task'
-require 'spree/testing_support/common_rake'
+require 'spree/testing_support/extension_rake'
 
 RSpec::Core::RakeTask.new
 
@@ -11,5 +11,5 @@ task :default => [:spec]
 desc 'Generates a dummy app for testing'
 task :test_app do
   ENV['LIB_NAME'] = '<%=file_name%>'
-  Rake::Task['common:test_app'].invoke
+  Rake::Task['extension:test_app'].invoke
 end

--- a/cmd/lib/spree_cmd/templates/extension/lib/generators/%file_name%/install/install_generator.rb.tt
+++ b/cmd/lib/spree_cmd/templates/extension/lib/generators/%file_name%/install/install_generator.rb.tt
@@ -2,6 +2,8 @@ module <%= class_name %>
   module Generators
     class InstallGenerator < Rails::Generators::Base
 
+      class_option :auto_run_migrations, :type => :boolean, :default => false
+
       def add_javascripts
         append_file 'app/assets/javascripts/store/all.js', "//= require store/<%= file_name %>\n"
         append_file 'app/assets/javascripts/admin/all.js', "//= require admin/<%= file_name %>\n"
@@ -17,12 +19,12 @@ module <%= class_name %>
       end
 
       def run_migrations
-         res = ask 'Would you like to run the migrations now? [Y/n]'
-         if res == '' || res.downcase == 'y'
-           run 'bundle exec rake db:migrate'
-         else
-           puts 'Skipping rake db:migrate, don\'t forget to run it!'
-         end
+        run_migrations = options[:auto_run_migrations] || ['', 'y', 'Y'].include?(ask 'Would you like to run the migrations now? [Y/n]')
+        if run_migrations
+          run 'bundle exec rake db:migrate'
+        else
+          puts 'Skipping rake db:migrate, don\'t forget to run it!'
+        end
       end
     end
   end

--- a/core/lib/generators/spree/dummy/dummy_generator.rb
+++ b/core/lib/generators/spree/dummy/dummy_generator.rb
@@ -50,6 +50,16 @@ module Spree
       template "initializers/custom_user.rb", "#{dummy_path}/config/initializers/custom_user.rb", :force => true
     end
 
+    def test_dummy_inject_extension_requirements
+      if DummyGeneratorHelper.inject_extension_requirements
+        inside dummy_path do
+          %w(spree_frontend spree_backend spree_api).each do |requirement|
+            inject_into_file 'config/application.rb', "require '#{requirement}'\n", :before => /require '#{@lib_name}'/, :verbose => true
+          end
+        end
+      end
+    end
+
     def test_dummy_clean
       inside dummy_path do
         remove_file ".gitignore"
@@ -108,6 +118,11 @@ module Spree
         '../../../../../Gemfile'
       end
     end
-
   end
 end
+
+module Spree::DummyGeneratorHelper
+  mattr_accessor :inject_extension_requirements
+  self.inject_extension_requirements = false
+end
+

--- a/core/lib/spree/testing_support/common_rake.rb
+++ b/core/lib/spree/testing_support/common_rake.rb
@@ -25,9 +25,9 @@ namespace :common do
     system(cmd)
 
     begin
-      require "generators/#{ENV['LIB_NAME']}/install_generator"
+      require "generators/#{ENV['LIB_NAME']}/install/install_generator"
       puts 'Running extension installation generator...'
-      "#{ENV['LIB_NAME'].classify}::Generators::InstallGenerator".constantize.start
+      "#{ENV['LIB_NAME'].camelize}::Generators::InstallGenerator".constantize.start
     rescue LoadError
       puts 'Skipping installation no generator to run...'
     end

--- a/core/lib/spree/testing_support/common_rake.rb
+++ b/core/lib/spree/testing_support/common_rake.rb
@@ -27,7 +27,7 @@ namespace :common do
     begin
       require "generators/#{ENV['LIB_NAME']}/install/install_generator"
       puts 'Running extension installation generator...'
-      "#{ENV['LIB_NAME'].camelize}::Generators::InstallGenerator".constantize.start
+      "#{ENV['LIB_NAME'].camelize}::Generators::InstallGenerator".constantize.start(["--auto-run-migrations"])
     rescue LoadError
       puts 'Skipping installation no generator to run...'
     end

--- a/core/lib/spree/testing_support/extension_rake.rb
+++ b/core/lib/spree/testing_support/extension_rake.rb
@@ -1,0 +1,10 @@
+require 'spree/testing_support/common_rake'
+
+desc "Generates a dummy app for testing an extension"
+namespace :extension do
+  task :test_app, [:user_class] do |t, args|
+    Spree::DummyGeneratorHelper.inject_extension_requirements = true
+    Rake::Task['common:test_app'].invoke
+  end
+end
+


### PR DESCRIPTION
This pull request fixes problems with the generation of extensions.

Before this changeset, it was not possible to generate a working dummy test_app for extensions due to the following:
- The config/application.rb file in the extensions dummy test_app did not require spree, therefore the db:migrate step failed.
- The common:test_app rake task used a faulty algorithm to discover the extension's InstallGenerator.
- When running the InstallGenerator the test_app task would prompt the user whether to run the migrations.

The changes in this PR fix these problems, while minimising changes to the DummyGenerator so that working test_apps may still be generated for spree components (e.g. spree_frontend etc)
