### PR TITLE
Remove duplicated api update shipments controller method

### DIFF
--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -38,26 +38,6 @@ module Spree
         respond_with(@shipment, :default_template => :show)
       end
 
-      def update
-        authorize! :read, Shipment
-        @shipment = @order.shipments.find_by_number!(params[:id])
-
-        unlock = params[:shipment].delete(:unlock)
-
-        if unlock == 'yes'
-          @shipment.adjustment.open
-        end
-
-        @shipment.update_attributes(params[:shipment])
-
-        if unlock == 'yes'
-          @shipment.adjustment.close
-        end
-
-        @shipment.reload
-        respond_with(@shipment, :default_template => :show)
-      end
-
       def ready
         authorize! :read, Shipment
         unless @shipment.ready?


### PR DESCRIPTION
In case no one have noticed or updated it yet. I realized this while looking into #2668. I believe the duplicated method was introduced accidentally in https://github.com/spree/spree/commit/1594fc9
