### PR TITLE
Fix tax calculator with non-VAT taxes.

### DIFF
--- a/core/app/models/spree/calculator/default_tax.rb
+++ b/core/app/models/spree/calculator/default_tax.rb
@@ -33,7 +33,11 @@ module Spree
 
       def compute_line_item(line_item)
         if line_item.product.tax_category == rate.tax_category
-          deduced_total_by_rate(line_item.total, rate)
+          if rate.included_in_price
+            deduced_total_by_rate(line_item.total, rate)
+          else
+            round_to_two_places(line_item.total * rate.amount)
+          end
         else
           0
         end

--- a/core/spec/models/calculator/default_tax_spec.rb
+++ b/core/spec/models/calculator/default_tax_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe Spree::Calculator::DefaultTax do
   let!(:tax_category) { create(:tax_category, :tax_rates => []) }
-  let!(:rate) { mock_model(Spree::TaxRate, :tax_category => tax_category, :amount => 0.05) }
+  let!(:rate) { mock_model(Spree::TaxRate, :tax_category => tax_category, :amount => 0.05, :included_in_price => vat) }
+  let(:vat) { false }
   let!(:calculator) { Spree::Calculator::DefaultTax.new({:calculable => rate}, :without_protection => true) }
   let!(:order) { create(:order) }
   let!(:product_1) { create(:product) }
@@ -59,12 +60,24 @@ describe Spree::Calculator::DefaultTax do
       end
     end
 
-    context "when given a line item" do
+    context "when tax is included in price" do
+      let(:vat) { true }
       context "when the variant matches the tax category" do
         it "should be equal to the item total * rate" do
           calculator.compute(line_item_1).should == 1.43
         end
       end
+    end
+
+    context "when tax is not included in price" do
+      context "when the variant matches the tax category" do
+        it "should be equal to the item total * rate" do
+          calculator.compute(line_item_1).should == 1.50
+        end
+      end
+    end
+
+    context "when given a line item" do
 
       context "when the variant does not match the tax category" do
         before do


### PR DESCRIPTION
This is an issue with Spree line items and tax rate calculators.

The method used to subtract tax from a VAT did not play nicely
with non value added taxes.

Previously the test would show that 5% of $30 is $1.43 instead of $1.50.

$30.00 - $1.43 = $28.57
$28.57 \* 1.05 =~ $30

So the code makes sense for VAT's only.  It should now work for both types of tax.
