### PR TITLE
Pass args to method with send

### DIFF
--- a/core/app/models/spree/gateway.rb
+++ b/core/app/models/spree/gateway.rb
@@ -33,7 +33,7 @@ module Spree
       if @provider.nil? || !@provider.respond_to?(method)
         super
       else
-        provider.send(method)
+        provider.send(method, *args)
       end
     end
 


### PR DESCRIPTION
Pretty sure this was meant to be send with *args, since it doesn't make a ton of sense to do a lookup of responds_to? on method_missing but not send along any args we got. 
