### PR TITLE
Add preference to allow product_description to be rendered raw.

### DIFF
--- a/core/app/helpers/spree/products_helper.rb
+++ b/core/app/helpers/spree/products_helper.rb
@@ -31,7 +31,11 @@ module Spree
 
     # converts line breaks in product description into <p> tags (for html display purposes)
     def product_description(product)
-      raw(product.description.gsub(/(.*?)\r?\n\r?\n/m, '<p>\1</p>'))
+      if Spree::Config[:show_raw_product_description]
+        raw(product.description)
+      else
+        raw(product.description.gsub(/(.*?)\r?\n\r?\n/m, '<p>\1</p>'))
+      end
     end
 
     def line_item_description(variant)

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -65,7 +65,7 @@ module Spree
     preference :shipping_instructions, :boolean, :default => false # Request instructions/info for shipping
     preference :show_descendents, :boolean, :default => true
     preference :show_only_complete_orders_by_default, :boolean, :default => true
-    preference :show_product_raw_description, :boolean, :default => false
+    preference :show_raw_product_description, :boolean, :default => false
     preference :show_zero_stock_products, :boolean, :default => true
     preference :show_variant_full_price, :boolean, :default => false #Displays variant full price or difference with product price. Default false to be compatible with older behavior
     preference :show_products_without_price, :boolean, :default => false

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -65,6 +65,7 @@ module Spree
     preference :shipping_instructions, :boolean, :default => false # Request instructions/info for shipping
     preference :show_descendents, :boolean, :default => true
     preference :show_only_complete_orders_by_default, :boolean, :default => true
+    preference :show_product_raw_description, :boolean, :default => false
     preference :show_zero_stock_products, :boolean, :default => true
     preference :show_variant_full_price, :boolean, :default => false #Displays variant full price or difference with product price. Default false to be compatible with older behavior
     preference :show_products_without_price, :boolean, :default => false

--- a/core/spec/helpers/products_helper_spec.rb
+++ b/core/spec/helpers/products_helper_spec.rb
@@ -134,6 +134,23 @@ THIS IS THE BEST PRODUCT EVER!
         description.strip.should == %Q{<p>\nTHIS IS THE BEST PRODUCT EVER!</p>"IT CHANGED MY LIFE" - Sue, MD}
       end
 
+      it "renders a product description without any formatting based on configuration" do
+        initialDescription = %Q{
+            <p>hello world</p>
+
+            <p>tihs is completely awesome and it works</p>
+
+            <p>why so many spaces in the code. and why some more formatting afterwards?</p>
+        }
+
+        product.description = initialDescription
+
+        Spree::Config[:show_raw_product_description] = true
+        description = product_description(product)
+        description.should == initialDescription
+        Spree::Config[:show_raw_product_description] = false
+      end
+
     end
   end
 end

--- a/core/spec/helpers/products_helper_spec.rb
+++ b/core/spec/helpers/products_helper_spec.rb
@@ -148,7 +148,6 @@ THIS IS THE BEST PRODUCT EVER!
         Spree::Config[:show_raw_product_description] = true
         description = product_description(product)
         description.should == initialDescription
-        Spree::Config[:show_raw_product_description] = false
       end
 
     end


### PR DESCRIPTION
There was a [bug in the spree editor](https://github.com/spree/spree_editor/issues/39) whereby if the WYSIWYG editor that we used output something that met the regex that the current product description code was checking for that we would get some bad output. Read the issue for more details.

I thought that the correct way to solve this problem would be to add a Spree preference and then we could make use of it in the spree_editor code as [you can see in this branch here](https://github.com/robertmassaioli/spree_editor/tree/raw-product-description) which will soon be a pull request.

I would like to see this pull request merged into both master and 1-3-stable if at all possible. I made this change off 1-3-stable so I raised the PR against it.

I have also followed the "guidelines for contributing" and have written a single test case for this relatively small change.

Thankyou very much for you time in reviewing this pull request I really do appreciate it and Spree and am hoping to help by continuing to commit bug fixes and other changes that I find along the way. Please let me know if I have done it wrong and I'll fix it up.
