### PR TITLE
adding spec and fixing user_logged_in promo rule

### DIFF
--- a/core/app/models/spree/promotion/rules/user_logged_in.rb
+++ b/core/app/models/spree/promotion/rules/user_logged_in.rb
@@ -11,7 +11,7 @@ module Spree
           # we should be in before firing events,
           # so the controller will have to set this field.
 
-          return options && options[:user_signed_in]
+          return options && options[:user]
         end
 
       end

--- a/core/app/models/spree/promotion/rules/user_logged_in.rb
+++ b/core/app/models/spree/promotion/rules/user_logged_in.rb
@@ -11,7 +11,7 @@ module Spree
           # we should be in before firing events,
           # so the controller will have to set this field.
 
-          return options && options[:user]
+          return order.try(:user).try(:anonymous?) == false
         end
 
       end

--- a/core/app/models/spree/promotion/rules/user_logged_in.rb
+++ b/core/app/models/spree/promotion/rules/user_logged_in.rb
@@ -4,13 +4,6 @@ module Spree
       class UserLoggedIn < PromotionRule
 
         def eligible?(order, options = {})
-          # this is tricky.  We couldn't use any of the devise methods since we aren't in the controller.
-          # we need to rely on the controller already having done this for us.
-
-          # The thinking is that the controller should have some sense of what state
-          # we should be in before firing events,
-          # so the controller will have to set this field.
-
           return order.try(:user).try(:anonymous?) == false
         end
 

--- a/core/spec/models/spree/promotion/rules/user_logged_in_spec.rb
+++ b/core/spec/models/spree/promotion/rules/user_logged_in_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe Spree::Promotion::Rules::UserLoggedIn do
+  let(:rule) { Spree::Promotion::Rules::UserLoggedIn.new }
+
+  context "#eligible?(order)" do
+    let(:order) { Spree::Order.new }
+
+    it "should be eligible if user is logged in" do
+      user = mock_model(Spree::LegacyUser)
+      order.stub(:user => user)
+
+      rule.should be_eligible(order, {:user => user, :order => order})
+    end
+
+    it "should not be eligible if user is not logged in" do
+      rule.should_not be_eligible(order)
+    end
+  end
+end
+

--- a/core/spec/models/spree/promotion/rules/user_logged_in_spec.rb
+++ b/core/spec/models/spree/promotion/rules/user_logged_in_spec.rb
@@ -7,10 +7,10 @@ describe Spree::Promotion::Rules::UserLoggedIn do
     let(:order) { Spree::Order.new }
 
     it "should be eligible if user is logged in" do
-      user = mock_model(Spree::LegacyUser)
+      user = mock_model(Spree::LegacyUser, :anonymous? => false)
       order.stub(:user => user)
 
-      rule.should be_eligible(order, {:user => user, :order => order})
+      rule.should be_eligible(order)
     end
 
     it "should not be eligible if user is not logged in" do


### PR DESCRIPTION
This rule didn't seem to be working and was missing a spec.
