### PR TITLE
API - Fix missed translation.

### DIFF
--- a/api/app/controllers/spree/api/taxons_controller.rb
+++ b/api/app/controllers/spree/api/taxons_controller.rb
@@ -32,8 +32,8 @@ module Spree
         taxonomy = Taxonomy.find_by_id(params[:taxonomy_id])
 
         if taxonomy.nil?
-          @taxon.errors[:taxonomy_id] = "Invalid taxonomy_id."
-          invalid_resource!(@taxon) and return 
+          @taxon.errors[:taxonomy_id] = I18n.t(:invalid_taxonomy_id, :scope => 'spree.api')
+          invalid_resource!(@taxon) and return
         end
 
         @taxon.parent_id = taxonomy.root.id unless params[:taxon][:parent_id]

--- a/api/config/locales/en.yml
+++ b/api/config/locales/en.yml
@@ -22,3 +22,4 @@ en:
       shipment:
         cannot_ready: "Cannot ready shipment."
       stock_location_required: "A stock_location_id parameter must be provided in order to retrieve stock movements."
+      invalid_taxonomy_id: "Invalid taxonomy id."

--- a/api/spec/controllers/spree/api/taxons_controller_spec.rb
+++ b/api/spec/controllers/spree/api/taxons_controller_spec.rb
@@ -93,7 +93,7 @@ module Spree
         response.status.should == 201
 
         taxonomy.reload.root.children.count.should eq 2
-        
+
         Spree::Taxon.last.parent_id.should eq taxonomy.root.id
         Spree::Taxon.last.taxonomy_id.should eq taxonomy.id
       end
@@ -106,15 +106,15 @@ module Spree
 
         taxonomy.reload.root.children.count.should eq 1
       end
-      
+
       it "cannot create a new taxon with invalid taxonomy_id" do
         api_post :create, :taxonomy_id => 1000, :taxon => { :name => "Colors" }
         response.status.should == 422
         json_response["error"].should == "Invalid resource. Please fix errors and try again."
-        
+
         errors = json_response["errors"]
         errors["taxonomy_id"].should_not be_nil
-        errors["taxonomy_id"].first.should eq "Invalid taxonomy_id."
+        errors["taxonomy_id"].first.should eq "Invalid taxonomy id."
 
         taxonomy.reload.root.children.count.should eq 1
       end


### PR DESCRIPTION
"Invalid taxonomy_id." was not translated. Changed it to "Invalid taxonomy id." and updated the spec that tested it.
