### PR TITLE
Backend - Fix failing spec.

### DIFF
--- a/backend/spec/controllers/spree/admin/resource_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/resource_controller_spec.rb
@@ -9,14 +9,18 @@ describe Spree::Admin::ResourceController do
       Spree::Admin::ResourceController.any_instance.stub(:model_class).and_return Spree::Variant
     end
 
+    let(:variant) { create(:variant) }
+
+    it 'has 1 as initial position when created' do
+      variant.position.should == 1
+    end
+
     it 'returns Ok on json' do
-      variant = create(:variant)
       variant2 = create(:variant)
       expect {
 				spree_post :update_positions, :id => variant.id, :positions => { variant.id => '2', variant2.id => '1' }, :format => "js"
         variant.reload
-      }.to change(variant, :position).from(nil).to(2)
+      }.to change(variant, :position).from(1).to(2)
     end
-
   end
 end


### PR DESCRIPTION
The update_positions spec failed due to it expected initial position to be nil when created but its actually 1.
