### PR TITLE
Replace stub! with stub in specs.

### DIFF
--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -23,7 +23,7 @@ describe Spree::CheckoutController do
     end
 
     it "should redirect to the cart path if current_order is nil" do
-      controller.stub!(:current_order).and_return(nil)
+      controller.stub(:current_order).and_return(nil)
       spree_get :edit, { :state => "delivery" }
       response.should redirect_to(spree.cart_path)
     end
@@ -162,7 +162,7 @@ describe Spree::CheckoutController do
     end
 
     context "when current_order is nil" do
-      before { controller.stub! :current_order => nil }
+      before { controller.stub :current_order => nil }
 
       it "should not change the state if order is completed" do
         order.should_not_receive(:update_attribute)

--- a/frontend/spec/controllers/spree/orders_controller_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_spec.rb
@@ -69,7 +69,7 @@ describe Spree::OrdersController do
 
   context "#empty" do
     it "should destroy line items in the current order" do
-      controller.stub!(:current_order).and_return(order)
+      controller.stub(:current_order).and_return(order)
       order.should_receive(:empty!)
       spree_put :empty
       response.should redirect_to(spree.cart_path)


### PR DESCRIPTION
`stub!()` and `stub()` have essentially the same meaning, and as [explained](http://www.mail-archive.com/rspec-users@rubyforge.org/msg13270.html) by David Chelimsky, `stub()` should be used over `stub!()`.
