### PR TITLE
Simplify get_layout implementation

### DIFF
--- a/core/lib/spree/core/controller_helpers/common.rb
+++ b/core/lib/spree/core/controller_helpers/common.rb
@@ -76,9 +76,8 @@ module Spree
           # Default layout is: +app/views/spree/layouts/spree_application+
           # 
           def get_layout
-            layout ||= Spree::Config[:layout]
+            Spree::Config[:layout]
           end
-
         end
       end
     end


### PR DESCRIPTION
Isn't this implementation wrong?

``` ruby
def get_layout
  layout ||= Spree::Config[:layout]
end
```

Why not just return `Spree::Config[:layout]`?
