### PR TITLE
State dropdown does not update correctly

### DIFF
--- a/core/app/assets/javascripts/admin/address_states.js
+++ b/core/app/assets/javascripts/admin/address_states.js
@@ -2,7 +2,7 @@ var update_state = function(region) {
   var country        = $('span#' + region + 'country .select2').select2('val');
   var states         = state_mapper[country];
 
-  var state_select   = $('span#' + region + 'state .select2');
+  var state_select   = $('span#' + region + 'state select.select2');
   var state_input    = $('span#' + region + 'state input');
 
   if(states) {


### PR DESCRIPTION
In the address step, when creating an order manually through the admin:

When the user changes the address's billing or shipping country from a country that has states to another country that also has states. the state dropdown is not displayed, because a JS error occurs.

For example: If I have states defined for both USA and Canada, but not Greenland. The javascript wont work when switching between USA -> Canada or Canada -> USA. It only worked when switching from a non-state country to a country with states. i.e. Greenland -> USA and USA -> Greenland both worked.  

Updating the jquery selector for finding the select, corrected the issue.
