### PR TITLE
Allow users to not override default mailer configs (1-3-stable)

### DIFF
--- a/core/app/mailers/spree/base_mailer.rb
+++ b/core/app/mailers/spree/base_mailer.rb
@@ -1,0 +1,16 @@
+module Spree
+  class BaseMailer < ActionMailer::Base
+    def from_address
+      if MailMethod.current
+        MailMethod.current.preferred_mails_from
+      else
+        Spree::Config.emails_sent_from
+      end
+    end
+
+    def money(amount)
+      Spree::Money.new(amount).to_s
+    end
+    helper_method :money
+  end
+end

--- a/core/app/mailers/spree/order_mailer.rb
+++ b/core/app/mailers/spree/order_mailer.rb
@@ -1,31 +1,22 @@
 module Spree
-  class OrderMailer < ActionMailer::Base
-    helper 'spree/base'
-
-    def from_address
-      MailMethod.current.preferred_mails_from
-    end
-
+  class OrderMailer < BaseMailer
     def confirm_email(order, resend = false)
       find_order(order)
       subject = (resend ? "[#{t(:resend).upcase}] " : '')
       subject += "#{Spree::Config[:site_name]} #{t('order_mailer.confirm_email.subject')} ##{@order.number}"
-      mail(:to => @order.email,
-           :from => from_address,
-           :subject => subject)
+      mail(to: @order.email, from: from_address, subject: subject)
     end
 
     def cancel_email(order, resend = false)
       find_order(order)
       subject = (resend ? "[#{t(:resend).upcase}] " : '')
       subject += "#{Spree::Config[:site_name]} #{t('order_mailer.cancel_email.subject')} ##{@order.number}"
-      mail(:to => @order.email,
-           :from => from_address,
-           :subject => subject)
+      mail(to: @order.email, from: from_address, subject: subject)
     end
 
-    def find_order(order)
-      @order = order.is_a?(Spree::Order) ? order : Spree::Order.find(order)
-    end
+    private
+      def find_order(order)
+        @order = order.is_a?(Spree::Order) ? order : Spree::Order.find(order)
+      end
   end
 end

--- a/core/app/mailers/spree/shipment_mailer.rb
+++ b/core/app/mailers/spree/shipment_mailer.rb
@@ -1,18 +1,10 @@
 module Spree
-  class ShipmentMailer < ActionMailer::Base
-    helper 'spree/base'
-
-    def from_address
-      MailMethod.current.preferred_mails_from
-    end
-
+  class ShipmentMailer < BaseMailer
     def shipped_email(shipment, resend = false)
       @shipment = shipment.is_a?(Spree::Shipment) ? shipment : Spree::Shipment.find(shipment)
       subject = (resend ? "[#{t(:resend).upcase}] " : '')
       subject += "#{Spree::Config[:site_name]} #{t('shipment_mailer.shipped_email.subject')} ##{@shipment.order.number}"
-      mail(:to => @shipment.order.email,
-           :from => from_address,
-           :subject => subject)
+      mail(to: @shipment.order.email, from: from_address, subject: subject)
     end
   end
 end

--- a/core/app/mailers/spree/test_mailer.rb
+++ b/core/app/mailers/spree/test_mailer.rb
@@ -1,15 +1,9 @@
 module Spree
-  class TestMailer < ActionMailer::Base
-    def from_address
-      MailMethod.current.preferred_mails_from
-    end
-
+  class TestMailer < BaseMailer
     def test_email(mail_method, user)
       @mail_method = mail_method
       subject = "#{Spree::Config[:site_name]} #{t('test_mailer.test_email.subject')}"
-      mail(:to => user.email,
-           :from => from_address,
-           :subject => subject)
+      mail(to: user.email, from: from_address, subject: subject)
     end
   end
 end

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -57,6 +57,7 @@ module Spree
     preference :logo, :string, :default => 'admin/bg/spree_50.png'
     preference :max_level_in_taxons_menu, :integer, :default => 1 # maximum nesting level in taxons menu
     preference :max_quantity, :integer, :default => 1000 # Maximum allowable quantity when checking out
+    preference :override_actionmailer_config, :boolean, :default => true
     preference :orders_per_page, :integer, :default => 15
     preference :prices_inc_tax, :boolean, :default => false
     preference :products_per_page, :integer, :default => 12
@@ -96,7 +97,5 @@ module Spree
     def searcher_class=(sclass)
       @searcher_class = sclass
     end
-
   end
-
 end

--- a/core/app/views/spree/admin/shared/_configuration_menu.html.erb
+++ b/core/app/views/spree/admin/shared/_configuration_menu.html.erb
@@ -6,7 +6,9 @@
   <nav class="menu">
     <ul class="sidebar" data-hook="admin_configurations_sidebar_menu">
       <%= configurations_sidebar_menu_item t(:general_settings), edit_admin_general_settings_path %>
-      <%= configurations_sidebar_menu_item t(:mail_methods), admin_mail_methods_path %>
+      <% if Spree::Config[:override_actionmailer_config] %>
+        <%= configurations_sidebar_menu_item t(:mail_methods), admin_mail_methods_path %>
+      <% end %>
       <%= configurations_sidebar_menu_item t(:image_settings), edit_admin_image_settings_path %>
       <%= configurations_sidebar_menu_item t(:tax_categories), admin_tax_categories_path %>
       <%= configurations_sidebar_menu_item t(:tax_rates), admin_tax_rates_path %>

--- a/core/lib/spree/core/mail_interceptor.rb
+++ b/core/lib/spree/core/mail_interceptor.rb
@@ -1,14 +1,13 @@
-# Allows us to intercept any outbound mail message and make last minute changes (such as specifying a "from" address or
-# sending to a test email account.)
+# Allows us to intercept any outbound mail message and make last minute changes
+# (such as specifying a "from" address or # sending to a test email account.)
 #
 # See http://railscasts.com/episodes/206-action-mailer-in-rails-3 for more details.
 module Spree
   module Core
     class MailInterceptor
-
       def self.delivering_email(message)
+        return unless Spree::Config.override_actionmailer_config
         return unless mail_method = Spree::MailMethod.current
-        message.from ||= mail_method.preferred_mails_from
 
         if mail_method.preferred_intercept_email.present?
           message.subject = "#{message.to} #{message.subject}"
@@ -19,7 +18,6 @@ module Spree
           message.bcc ||= mail_method.preferred_mail_bcc
         end
       end
-
     end
   end
 end

--- a/core/lib/spree/core/mail_settings.rb
+++ b/core/lib/spree/core/mail_settings.rb
@@ -1,39 +1,66 @@
 module Spree
   module Core
-    module MailSettings
-
-      # Override the Rails application mail settings based on preference.
-      # This makes it possible to configure the mail settings
-      # through an admin interface instead of requiring changes to the Rails envrionment file.
+    class MailSettings
+      # Override the Rails application mail settings based on preferences
+      # This makes it possible to configure the mail settings through an admin
+      # interface instead of requiring changes to the Rails envrionment file
       def self.init
-        return unless mail_method = Spree::MailMethod.current
-        # Email settings were configured in an initializer
-        return if ActionMailer::Base.smtp_settings[:user_name]
-        ActionMailer::Base.default_url_options[:host] ||= Spree::Config[:site_url]
+        instance = new
+        instance.override! if instance.override?
+      end
+
+      def override!
         if mail_method.prefers_enable_mail_delivery?
-          mail_server_settings = {
-            :address => mail_method.preferred_mail_host,
-            :domain => mail_method.preferred_mail_domain,
-            :port => mail_method.preferred_mail_port,
-            :authentication => mail_method.preferred_mail_auth_type
-          }
-
-          if mail_method.preferred_mail_auth_type != 'none'
-            mail_server_settings[:user_name] = mail_method.preferred_smtp_username
-            mail_server_settings[:password] = mail_method.preferred_smtp_password
-          end
-
-          tls = mail_method.preferred_secure_connection_type == 'TLS'
-          mail_server_settings[:enable_starttls_auto] = tls
-
+          ActionMailer::Base.default_url_options[:host] ||= Spree::Config[:site_url]
           ActionMailer::Base.smtp_settings = mail_server_settings
           ActionMailer::Base.perform_deliveries = true
         else
-          #logger.warn "NOTICE: Mail not enabled"
           ActionMailer::Base.perform_deliveries = false
         end
       end
 
+      def override?
+        override_actionmailer_config? && mail_method
+      end
+
+      private
+        def mail_server_settings
+          settings = if need_authentication?
+            basic_settings.merge(user_credentials)
+          else
+            basic_settings
+          end
+
+          settings.merge :enable_starttls_auto => secure_connection?
+        end
+
+        def user_credentials
+          { :user_name => mail_method.preferred_smtp_username,
+            :password => mail_method.preferred_smtp_password }
+        end
+
+        def basic_settings
+          { :address => mail_method.preferred_mail_host,
+            :domain => mail_method.preferred_mail_domain,
+            :port => mail_method.preferred_mail_port,
+            :authentication => mail_method.preferred_mail_auth_type }
+        end
+
+        def need_authentication?
+          mail_method.preferred_mail_auth_type != 'none'
+        end
+
+        def secure_connection?
+          mail_method.preferred_secure_connection_type == 'TLS'
+        end
+
+        def mail_method
+          Spree::MailMethod.current
+        end
+
+        def override_actionmailer_config?
+          Spree::Config.override_actionmailer_config
+        end
     end
   end
 end

--- a/core/spec/lib/mail_interceptor_spec.rb
+++ b/core/spec/lib/mail_interceptor_spec.rb
@@ -1,76 +1,44 @@
 require 'spec_helper'
 
-# We'll use the OrderMailer as a quick and easy way to test.  IF it works here - it works for all email (in theory.)
-describe Spree::OrderMailer do
-  let(:mail_method) { mock("mail_method", :preferred_mails_from => "spree@example.com", :preferred_intercept_email => nil, :preferred_mail_bcc => nil) }
-  let(:order) { Spree::Order.new(:email => "customer@example.com") }
-  let(:message) { Spree::OrderMailer.confirm_email(order) }
-  #let(:email) { mock "email" }
+# We'll use the OrderMailer as a quick and easy way to test.
+# If it works here - it works for all email (in theory)
+module Spree
+  describe OrderMailer do
+    let(:mail_method) { double('MailMethod') }
+    let(:order) { Order.new(:email => "customer@example.com") }
+    let(:message) { OrderMailer.confirm_email(order) }
 
-  before(:all) do
-    ActionMailer::Base.perform_deliveries = true
-    ActionMailer::Base.deliveries.clear
-  end
+    before { MailMethod.stub(:current => mail_method) }
 
-  context "#deliver" do
-    before do
-      ActionMailer::Base.delivery_method = :test
-      Spree::MailMethod.stub :current => mail_method
-    end
-    after { ActionMailer::Base.deliveries.clear }
-
-    it "should use the from address specified in the preference" do
-      mail_method.stub :preferred_mails_from => "no-reply@foobar.com"
-      message.deliver
-      @email = ActionMailer::Base.deliveries.first
-      @email.from.should == ["no-reply@foobar.com"]
-    end
-
-    it "should use the provided from address" do
-      mail_method.stub :preferred_mails_from => "preference@foobar.com"
-      message = ActionMailer::Base.mail(:from => "override@foobar.com", :to => "test@test.com")
-      message.deliver
-      @email = ActionMailer::Base.deliveries.first
-      @email.from.should == ["override@foobar.com"]
-    end
-
-    it "should add the bcc email when provided" do
-      mail_method.stub :preferred_mail_bcc => "bcc-foo@foobar.com"
-      message.deliver
-      @email = ActionMailer::Base.deliveries.first
-      @email.bcc.should == ["bcc-foo@foobar.com"]
-    end
-
-    context "when intercept_email is provided" do
-      it "should strip the bcc recipients" do
-        message.bcc.should be_blank
-      end
-
-      it "should strip the cc recipients" do
-        message.cc.should be_blank
-      end
-
-      it "should replace the receipient with the specified address" do
+    context "mail method preferences set" do
+      before do
+        mail_method.stub :preferred_mails_from => "no-reply@foobar.com"
+        mail_method.stub :preferred_mail_bcc => "bcc-foo@foobar.com"
         mail_method.stub :preferred_intercept_email => "intercept@foobar.com"
-        message.deliver
-        @email = ActionMailer::Base.deliveries.first
-        @email.to.should == ["intercept@foobar.com"]
       end
-      it "should modify the subject to include the original email" do
-        mail_method.stub :preferred_intercept_email => "intercept@foobar.com"
-        message.deliver
-        @email = ActionMailer::Base.deliveries.first
-        @email.subject.match(/customer@example\.com/).should be_true
+
+      it { message.deliver.from.should == ["no-reply@foobar.com"] }
+      it { message.deliver.bcc.should == ["bcc-foo@foobar.com"] }
+      it { message.deliver.to.should == ["intercept@foobar.com"] }
+
+      it "modifies the subject to include the original email" do
+        message.deliver.subject.should include(order.email)
       end
-    end
 
-    context "when intercept_mode is not provided" do
-      before { mail_method.stub :preferred_intercept_email => "" }
+      context "except intercept mail" do
+        before { mail_method.stub :preferred_intercept_email => "" }
 
-      it "should not modify the recipient" do
-        message.deliver
-        @email = ActionMailer::Base.deliveries.first
-        @email.to.should == ["customer@example.com"]
+        it "does not modify the recipient" do
+          message.deliver.to.should == ["customer@example.com"]
+        end
+      end
+
+      context "override actionmailer config set false" do
+        before { Config.override_actionmailer_config = false }
+
+        it "does not run spree interceptor" do
+          message.deliver.to.should == ["customer@example.com"]
+        end
       end
     end
   end

--- a/core/spec/lib/mail_settings_spec.rb
+++ b/core/spec/lib/mail_settings_spec.rb
@@ -2,84 +2,88 @@ require 'spec_helper'
 
 describe Spree::Core::MailSettings do
   let(:mail_method) { Spree::MailMethod.new(:environment => "test") }
+  let!(:subject) { Spree::Core::MailSettings.new }
 
-  context "init" do
-    before do
-      Spree::MailMethod.stub :current => mail_method
-      ActionMailer::Base.smtp_settings = {}
-    end
+  before { Spree::MailMethod.stub :current => mail_method }
 
-    context "perform_delivery preference" do
-      it "should override the application defaults" do
-        mail_method.set_preference(:enable_mail_delivery, false)
+  context "override option is true" do
+    before { Spree::Config.override_actionmailer_config = true }
+
+    context "init" do
+      it "calls override!" do
+        Spree::Core::MailSettings.should_receive(:new).and_return(subject)
+        subject.should_receive(:override!)
         Spree::Core::MailSettings.init
-        ActionMailer::Base.perform_deliveries.should be_false
-        mail_method.set_preference(:enable_mail_delivery, true)
       end
     end
 
-    context "when delivery is true" do
+    context "enable delivery" do
       before { mail_method.set_preference(:enable_mail_delivery, true) }
 
-      context "when mail_auth_type is other than none" do
-        before { mail_method.set_preference(:mail_auth_type, "login") }
+      context "overrides appplication defaults" do
 
-        context "mail_auth_type preference" do
-          it "should override the application defaults" do
-            Spree::Core::MailSettings.init
-            ActionMailer::Base.smtp_settings[:authentication].should == "login"
-          end
-        end
-
-        context "mail_host preference" do
-          it "should override the application defaults" do
+        context "authentication method is none" do
+          before do
             mail_method.set_preference(:mail_host, "smtp.example.com")
-            Spree::Core::MailSettings.init
-            ActionMailer::Base.smtp_settings[:address].should == "smtp.example.com"
-          end
-        end
-
-        context "mail_domain preference" do
-          it "should override the application defaults" do
             mail_method.set_preference(:mail_domain, "example.com")
-            Spree::Core::MailSettings.init
-            ActionMailer::Base.smtp_settings[:domain].should == "example.com"
-          end
-        end
-
-        context "mail_port preference" do
-          it "should override the application defaults" do
             mail_method.set_preference(:mail_port, 123)
-            Spree::Core::MailSettings.init
-            ActionMailer::Base.smtp_settings[:port].should == 123
-          end
-        end
-
-        context "smtp_username preference" do
-          it "should override the application defaults" do
+            mail_method.set_preference(:mail_auth_type, "none")
             mail_method.set_preference(:smtp_username, "schof")
-            Spree::Core::MailSettings.init
-            ActionMailer::Base.smtp_settings[:user_name].should == "schof"
-          end
-        end
-
-        context "smtp_password preference" do
-          it "should override the application defaults" do
             mail_method.set_preference(:smtp_password, "hellospree!")
-            Spree::Core::MailSettings.init
-            ActionMailer::Base.smtp_settings[:password].should == "hellospree!"
+            mail_method.set_preference(:secure_connection_type, "TLS")
+            subject.override!
+          end
+
+          it { ActionMailer::Base.smtp_settings[:address].should == "smtp.example.com" }
+          it { ActionMailer::Base.smtp_settings[:domain].should == "example.com" }
+          it { ActionMailer::Base.smtp_settings[:port].should == 123 }
+          it { ActionMailer::Base.smtp_settings[:authentication].should == "none" }
+          it { ActionMailer::Base.smtp_settings[:enable_starttls_auto].should be_true }
+
+          it "doesnt touch user name config" do
+            ActionMailer::Base.smtp_settings[:user_name].should == nil
+          end
+
+          it "doesnt touch password config" do
+            ActionMailer::Base.smtp_settings[:password].should == nil
           end
         end
+      end
 
-        context "secure_connection_type preference" do
-          it "should override the application defaults" do
-            mail_method.set_preference(:secure_connection_type, "TLS")
-            Spree::Core::MailSettings.init
-            ActionMailer::Base.smtp_settings[:enable_starttls_auto].should be_true
-          end
+      context "when mail_auth_type is other than none" do
+        before do
+          mail_method.set_preference(:mail_auth_type, "login")
+          mail_method.set_preference(:smtp_username, "schof")
+          mail_method.set_preference(:smtp_password, "hellospree!")
+          subject.override!
+        end
+
+        context "overrides user credentials" do
+          it { ActionMailer::Base.smtp_settings[:user_name].should == "schof" }
+          it { ActionMailer::Base.smtp_settings[:password].should == "hellospree!" }
         end
       end
     end
 
+    context "do not enable delivery" do
+      before do
+        mail_method.set_preference(:enable_mail_delivery, false)
+        subject.override!
+      end
+
+      it { ActionMailer::Base.perform_deliveries.should be_false }
+    end
+  end
+
+  context "override option is false" do
+    before { Spree::Config.override_actionmailer_config = false }
+
+    context "init" do
+      it "doesnt calls override!" do
+        Spree::Core::MailSettings.should_receive(:new).and_return(subject)
+        subject.should_not_receive(:override!)
+        Spree::Core::MailSettings.init
+      end
+    end
   end
 end

--- a/core/spec/mailers/order_mailer_spec.rb
+++ b/core/spec/mailers/order_mailer_spec.rb
@@ -16,11 +16,11 @@ describe Spree::OrderMailer do
     order
   end
 
-  before do
-    Spree::MailMethod.create!(
-      :environment => Rails.env,
-      :preferred_mails_from => "spree@example.com"
-    )
+  context ":from not set explicitly" do
+    it "falls back to spree config" do
+      message = Spree::OrderMailer.confirm_email(order)
+      message.from.should == [Spree::Config.emails_sent_from]
+    end
   end
 
   it "doesn't aggressively escape double quotes in confirmation body" do

--- a/core/spec/mailers/shipment_mailer_spec.rb
+++ b/core/spec/mailers/shipment_mailer_spec.rb
@@ -17,11 +17,11 @@ describe Spree::ShipmentMailer do
     shipment
   end
 
-  before do
-    Spree::MailMethod.create!(
-      :environment => Rails.env,
-      :preferred_mails_from => "spree@example.com"
-    )
+  context ":from not set explicitly" do
+    it "falls back to spree config" do
+      message = Spree::ShipmentMailer.shipped_email(shipment)
+      message.from.should == [Spree::Config.emails_sent_from]
+    end
   end
 
   # Regression test for #2196


### PR DESCRIPTION
Here goes my suggestion for the issue reported in #2855. It adds an explicit configuration option which allow users to skip any mailing setting defined in Spree. I believe there must be cases where Spree would be just one part of a bigger application where `Spree::Core::MailSettings` may not fit. In that case users would have to set `override_actionmailer_config = false`.

This should also fix the `from_address` method in mailers, it broke when there were no mail_method record on the database.

I haven't changed the `Spree::Core::MailInterceptor` yet to check the new config option. But I think we definitely should. Please let me know your thoughts about it. I have experienced situations where that interceptor would override others completely, e.g. the notification_exception gem which would then also send errors messages to clients instead of only to the dev team.

Once that's done it would make sense imo to hide the Mail Method tab from admin. Also I don't think it makes sense to change `override_actionmailer_config` via UI because turning that to `false` will likely require changes on the app code anyway.

I've opened this for 1-3-stable because the patch will need slightly different tweaks once #2643 gets merged. I may open another PR to master in case this one gets accepted.

please let me know your thoughts about it
