### PR TITLE
Remove shared_contexts from core spec_helper

### DIFF
--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -40,7 +40,6 @@ RSpec.configure do |config|
 
   config.fixture_path = File.join(File.expand_path(File.dirname(__FILE__)), "fixtures")
 
-  #config.include Devise::TestHelpers, :type => :controller
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, comment the following line or assign false
   # instead of true.
@@ -55,7 +54,6 @@ RSpec.configure do |config|
   end
 
   config.before(:each) do
-    WebMock.disable!
     DatabaseCleaner.start
     reset_spree_preferences
   end
@@ -67,7 +65,6 @@ RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
 
   config.include Spree::TestingSupport::Preferences
-
   config.include Spree::TestingSupport::UrlHelpers
   config.include Spree::TestingSupport::ControllerRequests
   config.include Spree::TestingSupport::Flash
@@ -76,67 +73,3 @@ RSpec.configure do |config|
 
   config.fail_fast = ENV['FAIL_FAST'] || false
 end
-
-shared_context "custom products" do
-  before(:each) do
-
-    taxonomy = FactoryGirl.create(:taxonomy, :name => 'Categories')
-    root = taxonomy.root
-    clothing_taxon = FactoryGirl.create(:taxon, :name => 'Clothing', :parent_id => root.id)
-    bags_taxon = FactoryGirl.create(:taxon, :name => 'Bags', :parent_id => root.id)
-    mugs_taxon = FactoryGirl.create(:taxon, :name => 'Mugs', :parent_id => root.id)
-
-    taxonomy = FactoryGirl.create(:taxonomy, :name => 'Brands')
-    root = taxonomy.root
-    apache_taxon = FactoryGirl.create(:taxon, :name => 'Apache', :parent_id => root.id)
-    rails_taxon = FactoryGirl.create(:taxon, :name => 'Ruby on Rails', :parent_id => root.id)
-    ruby_taxon = FactoryGirl.create(:taxon, :name => 'Ruby', :parent_id => root.id)
-
-    FactoryGirl.create(:custom_product, :name => 'Ruby on Rails Ringer T-Shirt', :price => '19.99', :taxons => [rails_taxon, clothing_taxon])
-    FactoryGirl.create(:custom_product, :name => 'Ruby on Rails Mug', :price => '15.99', :taxons => [rails_taxon, mugs_taxon])
-    FactoryGirl.create(:custom_product, :name => 'Ruby on Rails Tote', :price => '15.99', :taxons => [rails_taxon, bags_taxon])
-    FactoryGirl.create(:custom_product, :name => 'Ruby on Rails Bag', :price => '22.99', :taxons => [rails_taxon, bags_taxon])
-    FactoryGirl.create(:custom_product, :name => 'Ruby on Rails Baseball Jersey', :price => '19.99', :taxons => [rails_taxon, clothing_taxon])
-    FactoryGirl.create(:custom_product, :name => 'Ruby on Rails Stein', :price => '16.99', :taxons => [rails_taxon, mugs_taxon])
-    FactoryGirl.create(:custom_product, :name => 'Ruby on Rails Jr. Spaghetti', :price => '19.99', :taxons => [rails_taxon, clothing_taxon])
-    FactoryGirl.create(:custom_product, :name => 'Ruby Baseball Jersey', :price => '19.99', :taxons => [ruby_taxon, clothing_taxon])
-    FactoryGirl.create(:custom_product, :name => 'Apache Baseball Jersey', :price => '19.99', :taxons => [apache_taxon, clothing_taxon])
-  end
-end
-
-
-
-shared_context "product prototype" do
-
-  def build_option_type_with_values(name, values)
-    ot = FactoryGirl.create(:option_type, :name => name)
-    values.each do |val|
-      ot.option_values.create({:name => val.downcase, :presentation => val}, :without_protection => true)
-    end
-    ot
-  end
-
-  let(:product_attributes) do
-    # FactoryGirl.attributes_for is un-deprecated!
-    #   https://github.com/thoughtbot/factory_girl/issues/274#issuecomment-3592054
-    FactoryGirl.attributes_for(:simple_product)
-  end
-
-  let(:prototype) do
-    size = build_option_type_with_values("size", %w(Small Medium Large))
-    FactoryGirl.create(:prototype, :name => "Size", :option_types => [ size ])
-  end
-
-  let(:option_values_hash) do
-    hash = {}
-    prototype.option_types.each do |i|
-      hash[i.id.to_s] = i.option_value_ids
-    end
-    hash
-  end
-
-end
-
-PAYMENT_STATES = Spree::Payment.state_machine.states.keys unless defined? PAYMENT_STATES
-SHIPMENT_STATES = Spree::Shipment.state_machine.states.keys unless defined? SHIPMENT_STATES
-ORDER_STATES = Spree::Order.state_machine.states.keys unless defined? ORDER_STATES


### PR DESCRIPTION
I think these are just leftovers from the split backend / frontend thing
