### PR TITLE
Using valid credit card brand in development mode

### DIFF
--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -64,7 +64,7 @@ module Spree
 
     # needed for some of the ActiveMerchant gateways (eg. SagePay)
     def brand
-      cc_type
+      spree_cc_type
     end
 
     scope :with_payment_profile, lambda { where('gateway_customer_profile_id IS NOT NULL') }


### PR DESCRIPTION
When using a gateway which doesnt use valid card numbers as test card numbers for their test server (for example data cash use visa numbers that start with a 1: https://testserver.datacash.com/software/download.cgi?show=magicnumbers) CreditCard#brand will always return nil. To solve this I have replace the brand lookup with spree_cc_type which always returns 'visa' in development mode.
