### PR TITLE
Comparison of String with nil failed in ProductFilters.brand_filter

### DIFF
--- a/core/lib/spree/core/product_filters.rb
+++ b/core/lib/spree/core/product_filters.rb
@@ -108,7 +108,7 @@ module Spree
 
         def ProductFilters.brand_filter
           brand_property = Spree::Property.find_by_name("brand")
-          brands = Spree::ProductProperty.where(:property_id => brand_property).pluck(:value).uniq
+          brands = Spree::ProductProperty.where(:property_id => brand_property).pluck(:value).uniq.map(&:to_s)
           pp = Spree::ProductProperty.arel_table
           conds = Hash[*brands.map { |b| [b, pp[:value].eq(b)] }.flatten]
           { :name   => "Brands",

--- a/core/spec/models/spree/product_filter_spec.rb
+++ b/core/spec/models/spree/product_filter_spec.rb
@@ -17,5 +17,10 @@ describe 'product filters' do
     it "can find products in the 'Nike' brand" do
       Spree::Product.brand_any("Nike").should include(product)
     end
+    it "sorts products without brand specified" do
+      product.set_property("brand", "Nike")
+      create(:product).set_property("brand", nil)
+      lambda { Spree::Core::ProductFilters.brand_filter[:labels] }.should_not raise_error(ArgumentError)
+    end
   end
 end


### PR DESCRIPTION
Encountered an error on my spree 1.3.0 instance. 
 ActionView::Template::Error (comparison of String with nil failed):
3:   <%= form_tag '', :method => :get, :id => 'sidebar_products_search' do %>
1: <% filters = @taxon ? @taxon.applicable_filters : [Spree::ProductFilters.all_taxons] %>
2: <% unless filters.empty? %>
4:     <% params[:search] ||= {} %>

Tried to update to 1.3.2 didn't help. After some investigation found that if brand is set to nil product_filter fails with the exception. 
Test and fix attached.
