### PR TITLE
Link Country Based and State Based labels to radio control

### DIFF
--- a/core/app/views/spree/admin/zones/_form.html.erb
+++ b/core/app/views/spree/admin/zones/_form.html.erb
@@ -14,7 +14,7 @@
 
     <div data-hook="default" class="field">
       <%= zone_form.check_box :default_tax %>
-      <%= label_tag t(:default_tax_zone) %>      
+      <%= label_tag t(:default_tax_zone) %>
     </div>
 
     <div data-hook="type" class="field">
@@ -22,13 +22,13 @@
       <ul>
         <li>
           <%= zone_form.radio_button('kind', 'country', { :id => 'country_based' }) %>
-          <%= label_tag t(:country_based) %>
+          <%= label_tag :country_based, t(:country_based) %>
         </li>
         <li>
           <%= zone_form.radio_button('kind', 'state', { :id => 'state_based' }) %>
-          <%= label_tag t(:state_based) %>
+          <%= label_tag :state_based, t(:state_based) %>
         </li>
-      </ul>      
+      </ul>
     </div>
   </fieldset>
 </div>


### PR DESCRIPTION
Currently the Country Based and State Based labels have the wrong "for" reference as it's capitalized.
