### PR TITLE
Active Merchant amount fix

### DIFF
--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -68,9 +68,10 @@ module Spree
       order.currency
     end
 
-    def display_amount
+    def money
       Spree::Money.new(amount, { currency: currency })
     end
+    alias display_amount money
 
     def offsets_total
       offsets.pluck(:amount).sum

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -44,7 +44,7 @@ module Spree
             response = payment_method.capture(self, source, gateway_options)
           else
             # Standard ActiveMerchant capture usage
-            response = payment_method.capture((amount * 100).round,
+            response = payment_method.capture(money.money.cents,
                                               response_code,
                                               gateway_options)
           end

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -22,10 +22,13 @@ describe Spree::Payment do
     payment.source = card
     payment.order = order
     payment.payment_method = gateway
+    payment.amount = 100
     payment
   end
 
   let(:amount_in_cents) { payment.amount.to_f * 100 }
+
+  let(:currency) { 'USD' }
 
   let!(:success_response) do
     mock('success_response', :success? => true,
@@ -38,6 +41,7 @@ describe Spree::Payment do
   before(:each) do
     # So it doesn't create log entries every time a processing method is called
     payment.log_entries.stub(:create)
+    order.stub(:currency) { currency }
   end
 
   # Regression test for https://github.com/spree/spree/pull/2224
@@ -214,19 +218,47 @@ describe Spree::Payment do
         end
 
         context "if successful" do
-          before do
-            payment.payment_method.should_receive(:capture).with(payment, card, anything).and_return(success_response)
+          context "when profiles are supported" do
+            before do
+              payment.payment_method.should_receive(:capture).with(payment, card, anything).and_return(success_response)
+            end
+
+            it "should make payment complete" do
+              payment.should_receive(:complete)
+              payment.capture!
+            end
+
+            it "should store the response_code" do
+              gateway.stub :capture => success_response
+              payment.capture!
+              payment.response_code.should == '123'
+            end
           end
 
-          it "should make payment complete" do
-            payment.should_receive(:complete)
-            payment.capture!
-          end
+          context "when profiles are not supported" do
+            before do
+              gateway.stub(:payment_profiles_supported?) { false }
+              gateway.should_receive(:capture).with(expected_amount, nil, anything).and_return(success_response)
+            end
 
-          it "should store the response_code" do
-            gateway.stub :capture => success_response
-            payment.capture!
-            payment.response_code.should == '123'
+            context "when currency has decimal places" do
+              let(:expected_amount) { 10000 }
+
+              it "should make payment complete" do
+                payment.should_receive(:complete)
+                payment.capture!
+              end
+            end
+
+            context "when currency does not have decimal places" do
+              let(:expected_amount) { 100 }
+              let(:currency) { 'JPY' }
+
+              it "should make payment complete" do
+                payment.should_receive(:complete)
+                payment.capture!
+              end
+            end
           end
         end
 


### PR DESCRIPTION
The payment processing code currently multiplies all amounts by 100 when passing the results in to active merchant.  This does not play nicely with currency which do not have cents (or other forms of subunits of a currency).

RubyMoney tracks this sort of stuff nicely, so I modified this code to use the RubyMoney cents function:

```
Money.new(100, 'USD').cents   #=> 100
Money.new(100, 'USD').to_s    #=> "1.00"

Money.new(100, 'JPY').cents   #=> 100
Money.new(100, 'JPY').to_s    #=> "100"
```

This means that items which cost 100 yen, will have 100 passed to ActiveMerchant rather than 10,000.

This has the potential to cause issues for people who have written gateways which relied upon this behaviour, but I believe this code correctly represents what should be happening.
