### PR TITLE
Update shipping rate cost column to default to 0.

### DIFF
--- a/core/db/migrate/20130423223847_set_default_shipping_rate_cost.rb
+++ b/core/db/migrate/20130423223847_set_default_shipping_rate_cost.rb
@@ -1,0 +1,5 @@
+class SetDefaultShippingRateCost < ActiveRecord::Migration
+  def change
+    change_column :spree_shipping_rates, :cost, :decimal, default: 0, precision: 8, scale: 2
+  end
+end


### PR DESCRIPTION
This prevents an issue where a shipping rate can have a nil cost, which will cause Shipment#ensure_correct_adjustment to fail from a nil adjustment amount.

https://github.com/spree/spree/blob/master/core/app/models/spree/shipment.rb#L277-L278
