### PR TITLE
Improve variants backend form

### DIFF
--- a/backend/app/controllers/spree/admin/variants_controller.rb
+++ b/backend/app/controllers/spree/admin/variants_controller.rb
@@ -2,11 +2,7 @@ module Spree
   module Admin
     class VariantsController < ResourceController
       belongs_to 'spree/product', :find_by => :permalink
-      create.before :create_before
       new_action.before :new_before
-
-      def index
-      end
 
       # override the destory method to set deleted_at value
       # instead of actually deleting the product.
@@ -26,14 +22,6 @@ module Spree
       end
 
       protected
-
-        def create_before
-          option_values = params[:new_variant]
-          option_values.each_value {|id| @object.option_values << OptionValue.find(id)}
-          @object.save
-        end
-
-
         def new_before
           @object.attributes = @object.product.master.attributes.except('id', 'created_at', 'deleted_at',
                                                                         'sku', 'is_master')
@@ -54,4 +42,3 @@ module Spree
     end
   end
 end
-

--- a/backend/app/views/spree/admin/variants/_form.html.erb
+++ b/backend/app/views/spree/admin/variants/_form.html.erb
@@ -1,19 +1,10 @@
 <div data-hook="admin_variant_form_fields" class="label-block left six columns alpha">
-  
   <div data-hook="variants">
-    <% @product.options.each do |option| %>
+    <% @product.option_types.each do |option_type| %>
       <div class="field" data-hook="presentation">
-        <%= label :new_variant, option.option_type.presentation %>
-        <% if @variant.new_record? %>
-          <%= select(:new_variant, option.option_type.presentation,
-            option.option_type.option_values.collect {|ov| [ ov.presentation, ov.id ] },
-            {}, {:class => 'select2 fullwidth'})
-          %>
-        <% else %>
-          <% if opt = @variant.option_values.detect {|o| o.option_type == option.option_type }.try(:presentation) %>
-            <%= text_field(:new_variant,  option.option_type.presentation, :value => opt, :disabled => 'disabled', :class => 'fullwidth') %>
-          <% end %>
-        <% end %>
+        <%= label :new_variant, option_type.presentation %>
+        <%= f.collection_select 'option_value_ids', option_type.option_values, :id, :presentation,
+          { :prompt => true }, { :name => 'variant[option_value_ids][]', :class => 'select2 fullwidth' } %>
       </div>
     <% end %>
 
@@ -33,8 +24,6 @@
     </div>
   </div>
 </div>
-
-
 
 <div class="right six columns omega label-block" data-hook="admin_variant_form_additional_fields">
   <% [:weight, :height, :width, :depth].each do |field| %>

--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -25,21 +25,19 @@
     </thead>
     <tbody>
     <% @variants.each do |variant| %>
-      <!-- you can skip variant with no options: that's just the default variant that all products have -->
-      <% next if variant.option_values.empty? %>
-        <tr id="<%= spree_dom_id variant %>" <%= 'style="color:red;"' if variant.deleted? %> data-hook="variants_row" class="<%= cycle('odd', 'even')%>">
-          <td class="no-border">
-            <span class="handle"></span>
-          </td>
-          <td><%= variant.options_text %></td>
-          <td class="align-center"><%= variant.display_price.to_html %></td>
-          <td class="align-center"><%= variant.sku %></td>
-          <td class="actions">
-            <%= link_to_edit(variant, :no_text => true) unless variant.deleted? %>
-            &nbsp;
-            <%= link_to_delete(variant, :no_text => true) unless variant.deleted? %>
-          </td>
-        </tr>
+      <tr id="<%= spree_dom_id variant %>" <%= 'style="color:red;"' if variant.deleted? %> data-hook="variants_row" class="<%= cycle('odd', 'even')%>">
+        <td class="no-border">
+          <span class="handle"></span>
+        </td>
+        <td><%= variant.options_text %></td>
+        <td class="align-center"><%= variant.display_price.to_html %></td>
+        <td class="align-center"><%= variant.sku %></td>
+        <td class="actions">
+          <%= link_to_edit(variant, :no_text => true) unless variant.deleted? %>
+          &nbsp;
+          <%= link_to_delete(variant, :no_text => true) unless variant.deleted? %>
+        </td>
+      </tr>
       <% end %>
       <% unless @product.has_variants? %>
         <tr><td colspan="5"><%= t(:none) %></td></tr>

--- a/backend/spec/requests/admin/products/edit/variants_spec.rb
+++ b/backend/spec/requests/admin/products/edit/variants_spec.rb
@@ -8,9 +8,9 @@ describe "Product Variants" do
   end
 
   context "editing variant option types", :js => true do
-    it "should allow an admin to create option types for a variant" do
-      create(:product)
+    let!(:product) { create(:product) }
 
+    it "should allow an admin to create option types for a variant" do
       click_link "Products"
 
       within_row(1) { click_icon :edit }
@@ -19,7 +19,7 @@ describe "Product Variants" do
       page.should have_content("To add variants, you must first define")
     end
 
-    it "should allow an admin to create a variant if there are option types" do
+    it "allows admin to create a variant if there are option types" do
       click_link "Products"
       click_link "Option Types"
       click_link "new_option_type_link"
@@ -34,8 +34,6 @@ describe "Product Variants" do
       click_button "Update"
       page.should have_content("successfully updated!")
 
-      create(:product)
-
       visit spree.admin_path
       click_link "Products"
       within('table.index tbody tr:nth-child(1)') do
@@ -48,11 +46,15 @@ describe "Product Variants" do
 
       within('#sidebar') { click_link "Variants" }
       click_link "New Variant"
+
+      targetted_select2 "black", :from => "#s2id_variant_option_value_ids"
       fill_in "variant_sku", :with => "A100"
       click_button "Create"
       page.should have_content("successfully created!")
+
       within(".index") do
         page.should have_content("19.99")
+        page.should have_content("black")
         page.should have_content("A100")
       end
     end

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -110,6 +110,17 @@ describe Spree::Product do
         product.should_not be_available
       end
     end
+
+    context "variants_and_option_values" do
+      let!(:high) { create(:variant, product: product) }
+      let!(:low) { create(:variant, product: product) }
+
+      before { high.option_values.destroy_all }
+
+      it "returns only variants with option values" do
+        product.variants_and_option_values.should == [low]
+      end
+    end
   end
 
   context "validations" do
@@ -383,5 +394,4 @@ describe Spree::Product do
       reflection.options[:dependent] = :delete_all
     end
   end
-
 end

--- a/frontend/app/views/spree/products/_cart_form.html.erb
+++ b/frontend/app/views/spree/products/_cart_form.html.erb
@@ -1,22 +1,19 @@
 <%= form_for :order, :url => populate_orders_path do |f| %>
   <div id="inside-product-cart-form" data-hook="inside_product_cart_form" itemprop="offers" itemscope itemtype="http://schema.org/Offer">
 
-    <% if @product.has_variants? %>
+    <% if @product.variants_and_option_values(current_currency).any? %>
       <div id="product-variants" class="columns five alpha">
         <h6 class="product-section-title"><%= t(:variants) %></h6>
         <ul>
-          <% has_checked = false
-          @product.variants.active(current_currency).each_with_index do |v,index|
-            checked = !has_checked
-            has_checked = true if checked %>
+          <% @product.variants_and_option_values(current_currency).each_with_index do |variant, index| %>
             <li>
-              <%= radio_button_tag "products[#{@product.id}]", v.id, checked, 'data-price' => v.price_in(current_currency).display_price %>
-              <label for="<%= ['products', @product.id, v.id].join('_') %>">
+              <%= radio_button_tag "products[#{@product.id}]", variant.id, index == 0, 'data-price' => variant.price_in(current_currency).display_price %>
+              <label for="<%= ['products', @product.id, variant.id].join('_') %>">
                 <span class="variant-description">
-                  <%= variant_options v %>
+                  <%= variant_options variant %>
                 </span>
-                <% if variant_price v %>
-                  <span class="price diff"><%= variant_price v %></span>
+                <% if variant_price variant %>
+                  <span class="price diff"><%= variant_price variant %></span>
                 <% end %>
               </label>
             </li>
@@ -34,7 +31,7 @@
         </div>
 
         <div class="add-to-cart">
-          <%= number_field_tag (@product.has_variants? ? :quantity : "variants[#{@product.master.id}]"),
+          <%= number_field_tag (@product.variants_and_option_values.any? ? :quantity : "variants[#{@product.master.id}]"),
             1, :class => 'title', :min => 1 %>
           <%= button_tag :class => 'large primary', :id => 'add-to-cart-button', :type => :submit do %>
             <%= t(:add_to_cart) %>
@@ -47,6 +44,5 @@
           <div><span class="price selling" itemprop="price"><%= t('product_not_available_in_this_currency') %></span></div>
         </div>
     <% end %>    
-
   </div>
 <% end %>

--- a/frontend/spec/requests/cart_spec.rb
+++ b/frontend/spec/requests/cart_spec.rb
@@ -44,4 +44,20 @@ describe "Cart" do
     end
     page.should_not have_content("Line items quantity must be an integer")
   end
+
+  # regression for #2276
+  context "product contains variants but no option values" do
+    let(:variant) { create(:variant) }
+    let(:product) { variant.product }
+
+    before { variant.option_values.destroy_all }
+
+    it "still adds product to cart" do
+      visit spree.product_path(product)
+      click_button "add-to-cart-button"
+
+      visit spree.cart_path
+      page.should have_content(product.name)
+    end
+  end
 end


### PR DESCRIPTION
Variants are not removed along with its options values. Example:

When admin deletes an option type all variants associated with that
record are not removed. However they are not displayed in admin
anymore due to a condition which did not allow to display variants with
no option values. Even though variants are still displayed, their radio
buttons, on the front end.

This patch aims to allow admin to associate variants with new option
values and edit option values associated with a variant. I coulnd't see
any reason why admin couldn't to that. It also tries to make better use
of both Spree and Rails FormHelper API.

fixes #2276

Should Spree frontend display variants that have no option values? Maybe I should change that on this PR as well.
