### PR TITLE
avoid calling available_to_order? on nil

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -320,7 +320,7 @@ module Spree
     # Clear shipment when transitioning to delivery step of checkout if the
     # current shipping address is not eligible for the existing shipping method
     def remove_invalid_shipments!
-      shipments.each { |s| s.destroy unless s.shipping_method.available_to_order?(self) }
+      shipments.each { |s| s.destroy unless s.shipping_method.try(:available_to_order?, self) }
     end
 
     # Creates new tax charges if there are any applicable rates. If prices already


### PR DESCRIPTION
This is a fix for the following exception.

```
NoMethodError: undefined method `available_to_order?' for nil:NilClass

vendor/bundle/ruby/1.9.1/gems/spree_core-1.3.2/app/models/spree/order.rb:323:in `block in remove_invalid_shipments!'
vendor/bundle/ruby/1.9.1/gems/activerecord-3.2.13/lib/active_record/associations/collection_proxy.rb:89:in `each'
vendor/bundle/ruby/1.9.1/gems/activerecord-3.2.13/lib/active_record/associations/collection_proxy.rb:89:in `method_missing'
vendor/bundle/ruby/1.9.1/gems/spree_core-1.3.2/app/models/spree/order.rb:323:in `remove_invalid_shipments!'
vendor/bundle/ruby/1.9.1/gems/state_machine-1.1.2/lib/state_machine/eval_helpers.rb:56:in `evaluate_method'
vendor/bundle/ruby/1.9.1/gems/state_machine-1.1.2/lib/state_machine/callback.rb:191:in `block in run_methods'
vendor/bundle/ruby/1.9.1/gems/state_machine-1.1.2/lib/state_machine/callback.rb:190:in `each'
vendor/bundle/ruby/1.9.1/gems/state_machine-1.1.2/lib/state_machine/callback.rb:190:in `run_methods'
vendor/bundle/ruby/1.9.1/gems/state_machine-1.1.2/lib/state_machine/callback.rb:159:in `call'
vendor/bundle/ruby/1.9.1/gems/state_machine-1.1.2/lib/state_machine/transition.rb:413:in `before'
vendor/bundle/ruby/1.9.1/gems/state_machine-1.1.2/lib/state_machine/transition.rb:239:in `block in run_callbacks'
vendor/bundle/ruby/1.9.1/gems/state_machine-1.1.2/lib/state_machine/transition.rb:341:in `block in pausable'
vendor/bundle/ruby/1.9.1/gems/state_machine-1.1.2/lib/state_machine/transition.rb:341:in `catch'
vendor/bundle/ruby/1.9.1/gems/state_machine-1.1.2/lib/state_machine/transition.rb:341:in `pausable'
vendor/bundle/ruby/1.9.1/gems/state_machine-1.1.2/lib/state_machine/transition.rb:239:in `run_callbacks'
vendor/bundle/ruby/1.9.1/gems/state_machine-1.1.2/lib/state_machine/transition_collection.rb:126:in `run_callbacks'
vendor/bundle/ruby/1.9.1/gems/state_machine-1.1.2/lib/state_machine/transition_collection.rb:211:in `run_callbacks'
vendor/bundle/ruby/1.9.1/gems/state_machine-1.1.2/lib/state_machine/transition_collection.rb:63:in `block (2 levels) in perform'
vendor/bundle/ruby/1.9.1/gems/state_machine-1.1.2/lib/state_machine/transition_collection.rb:63:in `catch'
vendor/bundle/ruby/1.9.1/gems/state_machine-1.1.2/lib/state_machine/transition_collection.rb:63:in `block in perform'
vendor/bundle/ruby/1.9.1/gems/state_machine-1.1.2/lib/state_machine/transition_collection.rb:185:in `within_transaction'
vendor/bundle/ruby/1.9.1/gems/state_machine-1.1.2/lib/state_machine/transition_collection.rb:62:in `perform'
vendor/bundle/ruby/1.9.1/gems/state_machine-1.1.2/lib/state_machine/integrations/active_model.rb:520:in `around_validation'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:310:in `_callback_around_303'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:214:in `_conditional_callback_around_1773'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:403:in `_run__967965461883881956__validation__4125425114172882812__callbacks'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:405:in `__run_callback'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:385:in `_run_validation_callbacks'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:81:in `run_callbacks'
vendor/bundle/ruby/1.9.1/gems/activemodel-3.2.13/lib/active_model/validations/callbacks.rb:53:in `run_validations!'
vendor/bundle/ruby/1.9.1/gems/activemodel-3.2.13/lib/active_model/validations.rb:195:in `valid?'
vendor/bundle/ruby/1.9.1/gems/activerecord-3.2.13/lib/active_record/validations.rb:69:in `valid?'
vendor/bundle/ruby/1.9.1/gems/activerecord-3.2.13/lib/active_record/validations.rb:77:in `perform_validations'
vendor/bundle/ruby/1.9.1/gems/activerecord-3.2.13/lib/active_record/validations.rb:50:in `save'
vendor/bundle/ruby/1.9.1/gems/activerecord-3.2.13/lib/active_record/attribute_methods/dirty.rb:22:in `save'
vendor/bundle/ruby/1.9.1/gems/activerecord-3.2.13/lib/active_record/transactions.rb:259:in `block (2 levels) in save'
vendor/bundle/ruby/1.9.1/gems/activerecord-3.2.13/lib/active_record/transactions.rb:313:in `block in with_transaction_returning_status'
vendor/bundle/ruby/1.9.1/gems/activerecord-3.2.13/lib/active_record/connection_adapters/abstract/database_statements.rb:192:in `transaction'
vendor/bundle/ruby/1.9.1/gems/activerecord-3.2.13/lib/active_record/transactions.rb:208:in `transaction'
vendor/bundle/ruby/1.9.1/gems/activerecord-3.2.13/lib/active_record/transactions.rb:311:in `with_transaction_returning_status'
vendor/bundle/ruby/1.9.1/gems/activerecord-3.2.13/lib/active_record/transactions.rb:259:in `block in save'
vendor/bundle/ruby/1.9.1/gems/activerecord-3.2.13/lib/active_record/transactions.rb:270:in `rollback_active_record_state!'
vendor/bundle/ruby/1.9.1/gems/activerecord-3.2.13/lib/active_record/transactions.rb:258:in `save'
vendor/bundle/ruby/1.9.1/gems/state_machine-1.1.2/lib/state_machine/transition_collection.rb:153:in `block (2 levels) in run_actions'
vendor/bundle/ruby/1.9.1/gems/state_machine-1.1.2/lib/state_machine/transition_collection.rb:153:in `each'
vendor/bundle/ruby/1.9.1/gems/state_machine-1.1.2/lib/state_machine/transition_collection.rb:153:in `block in run_actions'
vendor/bundle/ruby/1.9.1/gems/state_machine-1.1.2/lib/state_machine/transition_collection.rb:169:in `catch_exceptions'
vendor/bundle/ruby/1.9.1/gems/state_machine-1.1.2/lib/state_machine/transition_collection.rb:147:in `run_actions'
vendor/bundle/ruby/1.9.1/gems/state_machine-1.1.2/lib/state_machine/transition_collection.rb:60:in `perform'
vendor/bundle/ruby/1.9.1/gems/state_machine-1.1.2/lib/state_machine/transition.rb:212:in `perform'
vendor/bundle/ruby/1.9.1/gems/state_machine-1.1.2/lib/state_machine/event.rb:167:in `fire'
vendor/bundle/ruby/1.9.1/gems/state_machine-1.1.2/lib/state_machine/event.rb:236:in `block in add_actions'
vendor/bundle/ruby/1.9.1/gems/state_machine-1.1.2/lib/state_machine/machine.rb:753:in `call'
vendor/bundle/ruby/1.9.1/gems/state_machine-1.1.2/lib/state_machine/machine.rb:753:in `block (2 levels) in define_helper'
vendor/bundle/ruby/1.9.1/gems/spree_promo-1.3.2/app/controllers/spree/checkout_controller_decorator.rb:13:in `update'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.2.13/lib/action_controller/metal/implicit_render.rb:4:in `send_action'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.2.13/lib/abstract_controller/base.rb:167:in `process_action'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.2.13/lib/action_controller/metal/rendering.rb:10:in `process_action'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.2.13/lib/abstract_controller/callbacks.rb:18:in `block in process_action'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:524:in `_run__3741170520503152946__process_action__544618109417896398__callbacks'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:405:in `__run_callback'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:385:in `_run_process_action_callbacks'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:81:in `run_callbacks'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.2.13/lib/abstract_controller/callbacks.rb:17:in `process_action'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.2.13/lib/action_controller/metal/rescue.rb:29:in `process_action'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.2.13/lib/action_controller/metal/instrumentation.rb:30:in `block in process_action'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.13/lib/active_support/notifications.rb:123:in `block in instrument'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.13/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.13/lib/active_support/notifications.rb:123:in `instrument'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.2.13/lib/action_controller/metal/instrumentation.rb:29:in `process_action'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.2.13/lib/action_controller/metal/params_wrapper.rb:207:in `process_action'
vendor/bundle/ruby/1.9.1/gems/activerecord-3.2.13/lib/active_record/railties/controller_runtime.rb:18:in `process_action'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.2.13/lib/abstract_controller/base.rb:121:in `process'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.2.13/lib/abstract_controller/rendering.rb:45:in `process'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.2.13/lib/action_controller/metal.rb:203:in `dispatch'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.2.13/lib/action_controller/metal/rack_delegation.rb:14:in `dispatch'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.2.13/lib/action_controller/metal.rb:246:in `block in action'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.2.13/lib/action_dispatch/routing/route_set.rb:73:in `call'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.2.13/lib/action_dispatch/routing/route_set.rb:73:in `dispatch'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.2.13/lib/action_dispatch/routing/route_set.rb:36:in `call'
vendor/bundle/ruby/1.9.1/gems/journey-1.0.4/lib/journey/router.rb:68:in `block in call'
vendor/bundle/ruby/1.9.1/gems/journey-1.0.4/lib/journey/router.rb:56:in `each'
vendor/bundle/ruby/1.9.1/gems/journey-1.0.4/lib/journey/router.rb:56:in `call'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.2.13/lib/action_dispatch/routing/route_set.rb:612:in `call'
vendor/bundle/ruby/1.9.1/gems/spree_core-1.3.2/lib/spree/core/middleware/redirect_legacy_product_url.rb:13:in `call'
vendor/bundle/ruby/1.9.1/gems/spree_core-1.3.2/lib/spree/core/middleware/seo_assist.rb:27:in `call'
vendor/bundle/ruby/1.9.1/gems/railties-3.2.13/lib/rails/engine.rb:479:in `call'
vendor/bundle/ruby/1.9.1/gems/railties-3.2.13/lib/rails/railtie/configurable.rb:30:in `method_missing'
vendor/bundle/ruby/1.9.1/gems/journey-1.0.4/lib/journey/router.rb:68:in `block in call'
vendor/bundle/ruby/1.9.1/gems/journey-1.0.4/lib/journey/router.rb:56:in `each'
vendor/bundle/ruby/1.9.1/gems/journey-1.0.4/lib/journey/router.rb:56:in `call'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.2.13/lib/action_dispatch/routing/route_set.rb:612:in `call'
vendor/bundle/ruby/1.9.1/gems/warden-1.2.1/lib/warden/manager.rb:35:in `block in call'
vendor/bundle/ruby/1.9.1/gems/warden-1.2.1/lib/warden/manager.rb:34:in `catch'
vendor/bundle/ruby/1.9.1/gems/warden-1.2.1/lib/warden/manager.rb:34:in `call'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.2.13/lib/action_dispatch/middleware/best_standards_support.rb:17:in `call'
vendor/bundle/ruby/1.9.1/gems/rack-1.4.5/lib/rack/etag.rb:23:in `call'
vendor/bundle/ruby/1.9.1/gems/rack-1.4.5/lib/rack/conditionalget.rb:35:in `call'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.2.13/lib/action_dispatch/middleware/head.rb:14:in `call'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.2.13/lib/action_dispatch/middleware/params_parser.rb:21:in `call'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.2.13/lib/action_dispatch/middleware/flash.rb:242:in `call'
vendor/bundle/ruby/1.9.1/gems/rack-1.4.5/lib/rack/session/abstract/id.rb:210:in `context'
vendor/bundle/ruby/1.9.1/gems/rack-1.4.5/lib/rack/session/abstract/id.rb:205:in `call'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.2.13/lib/action_dispatch/middleware/cookies.rb:341:in `call'
vendor/bundle/ruby/1.9.1/gems/activerecord-3.2.13/lib/active_record/query_cache.rb:64:in `call'
vendor/bundle/ruby/1.9.1/gems/activerecord-3.2.13/lib/active_record/connection_adapters/abstract/connection_pool.rb:479:in `call'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.2.13/lib/action_dispatch/middleware/callbacks.rb:28:in `block in call'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:405:in `_run__2951894977106098935__call__4125425114172882812__callbacks'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:405:in `__run_callback'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:385:in `_run_call_callbacks'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:81:in `run_callbacks'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.2.13/lib/action_dispatch/middleware/callbacks.rb:27:in `call'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.2.13/lib/action_dispatch/middleware/remote_ip.rb:31:in `call'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.2.13/lib/action_dispatch/middleware/debug_exceptions.rb:16:in `call'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.2.13/lib/action_dispatch/middleware/show_exceptions.rb:56:in `call'
vendor/bundle/ruby/1.9.1/gems/railties-3.2.13/lib/rails/rack/logger.rb:32:in `call_app'
vendor/bundle/ruby/1.9.1/gems/railties-3.2.13/lib/rails/rack/logger.rb:16:in `block in call'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.13/lib/active_support/tagged_logging.rb:22:in `tagged'
vendor/bundle/ruby/1.9.1/gems/railties-3.2.13/lib/rails/rack/logger.rb:16:in `call'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.2.13/lib/action_dispatch/middleware/request_id.rb:22:in `call'
vendor/bundle/ruby/1.9.1/gems/rack-1.4.5/lib/rack/methodoverride.rb:21:in `call'
vendor/bundle/ruby/1.9.1/gems/rack-1.4.5/lib/rack/runtime.rb:17:in `call'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.13/lib/active_support/cache/strategy/local_cache.rb:72:in `call'
vendor/bundle/ruby/1.9.1/gems/rack-1.4.5/lib/rack/lock.rb:15:in `call'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.2.13/lib/action_dispatch/middleware/static.rb:63:in `call'
vendor/bundle/ruby/1.9.1/gems/rack-cache-1.2/lib/rack/cache/context.rb:136:in `forward'
vendor/bundle/ruby/1.9.1/gems/rack-cache-1.2/lib/rack/cache/context.rb:143:in `pass'
vendor/bundle/ruby/1.9.1/gems/rack-cache-1.2/lib/rack/cache/context.rb:155:in `invalidate'
vendor/bundle/ruby/1.9.1/gems/rack-cache-1.2/lib/rack/cache/context.rb:71:in `call!'
vendor/bundle/ruby/1.9.1/gems/rack-cache-1.2/lib/rack/cache/context.rb:51:in `call'
vendor/bundle/ruby/1.9.1/gems/railties-3.2.13/lib/rails/engine.rb:479:in `call'
vendor/bundle/ruby/1.9.1/gems/railties-3.2.13/lib/rails/application.rb:223:in `call'
vendor/bundle/ruby/1.9.1/gems/railties-3.2.13/lib/rails/railtie/configurable.rb:30:in `method_missing'
vendor/bundle/ruby/1.9.1/gems/unicorn-4.6.2/lib/unicorn/http_server.rb:552:in `process_client'
vendor/bundle/ruby/1.9.1/gems/unicorn-4.6.2/lib/unicorn/http_server.rb:632:in `worker_loop'
vendor/bundle/ruby/1.9.1/gems/unicorn-4.6.2/lib/unicorn/http_server.rb:500:in `spawn_missing_workers'
vendor/bundle/ruby/1.9.1/gems/unicorn-4.6.2/lib/unicorn/http_server.rb:142:in `start'
vendor/bundle/ruby/1.9.1/gems/unicorn-4.6.2/bin/unicorn:126:in `<top (required)>'
vendor/bundle/ruby/1.9.1/bin/unicorn:19:in `load'
vendor/bundle/ruby/1.9.1/bin/unicorn:19:in `<main>'
```

The action is `PUT /checkout/update/address` (during the checkout process). The sequence of events that led to this was I deleted shipping methods in the admin interface while a user was in the checkout process. Now this user is stuck in a state where he gets this every time he tries to checkout.

I didn't include any tests since `remove_invalid_shipments!` was already untested and this change is very simple.
