### PR TITLE
Fix edit taxon form.

### DIFF
--- a/core/app/views/spree/admin/taxons/edit.html.erb
+++ b/core/app/views/spree/admin/taxons/edit.html.erb
@@ -2,7 +2,7 @@
 
 <h1><%= t(:taxon_edit) %></h1>
 
-<%= form_for [:admin, @taxonomy, @taxon], :method => :put, :html => { :multipart => true } do |f| %>
+<%= form_for [:admin, @taxonomy, @taxon], :url => admin_taxonomy_taxon_path(@taxonomy, @taxon.id), :method => :put, :html => { :multipart => true } do |f| %>
   <%= render :partial => 'form', :locals => { :f => f } %>
 
   <p class="form-buttons" data-hook="buttons">

--- a/core/spec/requests/admin/taxons_spec.rb
+++ b/core/spec/requests/admin/taxons_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe "Taxons" do
+  stub_authorization!
+  let!(:taxonomy) { create(:taxonomy, :name => "Category") }
+  let!(:clothing) { taxonomy.root.children.create(:name => "Clothing", :taxonomy_id => taxonomy.id) }
+
+  context "edit taxon" do
+    it "will update the taxon with updated values" do
+      visit spree.edit_admin_taxonomy_taxon_path(taxonomy, clothing.id)
+      fill_in "Description", :with => "The finest clothing you can imagen!"
+      click_button "Update"
+      page.should have_content "Taxon \"Clothing\" has been successfully updated!"
+    end
+  end
+end


### PR DESCRIPTION
The taxon edit form in the admin was doing a PUT to the full to_param (seo_url) taxon path. Resulting in an exception. This PR fixes that.

Including specs. With a strange issue on the taxon creation factory. I needed to explicitly set the taxonomy_id on the taxon being created through the taxonomy.
