### PR TITLE
Fix /auth/ build

### DIFF
--- a/auth/spec/controllers/admin/admin_users_controller_spec.rb
+++ b/auth/spec/controllers/admin/admin_users_controller_spec.rb
@@ -46,7 +46,7 @@ describe Spree::Admin::UsersController do
   describe 'resource callbacks' do
     [:create, :update].each do |action|
       describe "##{action}" do
-        let(:user) { stub('User', has_role?: true).as_null_object }
+        let(:user) { mock_model(Spree::User).as_null_object }
 
         before do
           Spree::User.stub(new: user, find: user)

--- a/auth/spec/requests/password_reset_spec.rb
+++ b/auth/spec/requests/password_reset_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 describe "Reset Password" do
+  before do
+    Spree::MailMethod.create!(
+      environment: Rails.env,
+      preferred_mails_from: "spree@example.com"
+    )
+  end
+
   it "should allow the user to indicate they have forgotten their password" do
     visit spree.login_path
     click_link "Forgot Password?"


### PR DESCRIPTION
There are a couple failures in the `/auth/` build. It should be green after this merge. See commits for details.

Fixes:
- `A sender (Return-Path, Sender or From) required to send a message`
- `undefined method 'model_name' for RSpec::Mocks::Mock:Class`
