### PR TITLE
Different behaviour between `Spree::Api::LineItemsController#create` and `#update`

### DIFF
--- a/api/app/controllers/spree/api/line_items_controller.rb
+++ b/api/app/controllers/spree/api/line_items_controller.rb
@@ -16,7 +16,7 @@ module Spree
       def update
         authorize! :read, order
         @line_item = order.line_items.find(params[:id])
-        if @line_item.update_attributes(params[:line_item])
+        if @line_item.update_attributes(params[:line_item], :as => :api)
           respond_with(@line_item, :default_template => :show)
         else
           invalid_resource!(@line_item)

--- a/api/spec/controllers/spree/api/line_items_controller_spec.rb
+++ b/api/spec/controllers/spree/api/line_items_controller_spec.rb
@@ -34,6 +34,9 @@ module Spree
       end
 
       it "can update a line item on the order" do
+        stub = Spree::LineItem.any_instance.should_receive(:update_attributes)
+        stub.with(anything, :as => :api).and_call_original
+
         line_item = order.line_items.first
         api_put :update, :id => line_item.id, :line_item => { :quantity => 1000 }
         response.status.should == 200


### PR DESCRIPTION
The create method uses `:as => :api` but the `update` does not in [`Spree::Api::LineItemsController`](https://github.com/spree/spree/blob/master/api/app/controllers/spree/api/line_items_controller.rb#L19)

Is this intended? It looks weird to me, but there may be some reason I don't see. If that's unintended, I'd gladly file a pull request.

Cheers and thanks for Spree!
