### PR TITLE
[API] Respect CanCan.

### DIFF
--- a/api/app/controllers/spree/api/addresses_controller.rb
+++ b/api/app/controllers/spree/api/addresses_controller.rb
@@ -10,7 +10,7 @@ module Spree
 
       def update
         @address = Address.find(params[:id])
-        authorize! :read, @address
+        authorize! :update, @address
 
         if @address.update_attributes(params[:address])
           respond_with(@address, :default_template => :show)

--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -117,12 +117,12 @@ module Spree
 
       def product_scope
         if current_api_user.has_spree_role?("admin")
-          scope = Product
+          scope = Product.accessible_by(current_ability, :read)
           unless params[:show_deleted]
             scope = scope.not_deleted
           end
         else
-          scope = Product.active
+          scope = Product.accessible_by(current_ability, :read).active
         end
 
         scope.includes(:master)

--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -7,11 +7,17 @@ module Spree
       include Spree::Core::ControllerHelpers::Auth
       include Spree::Core::ControllerHelpers::Order
 
-      respond_to :json
-
       def create
+        authorize! :create, Order
         @order = Order.build_from_api(current_api_user, nested_params)
         respond_with(@order, :default_template => 'spree/api/orders/show', :status => 201)
+      end
+
+      def next
+        @order.next!
+        respond_with(@order, :default_template => 'spree/api/orders/show', :status => 200)
+      rescue StateMachine::InvalidTransition
+        respond_with(@order, :default_template => 'spree/api/orders/could_not_transition', :status => 422)
       end
 
       def update
@@ -28,13 +34,6 @@ module Spree
         else
           invalid_resource!(@order)
         end
-      end
-
-      def next
-        @order.next!
-        respond_with(@order, :default_template => 'spree/api/orders/show', :status => 200)
-        rescue StateMachine::InvalidTransition
-          respond_with(@order, :default_template => 'spree/api/orders/could_not_transition', :status => 422)
       end
 
       private

--- a/api/app/controllers/spree/api/countries_controller.rb
+++ b/api/app/controllers/spree/api/countries_controller.rb
@@ -3,7 +3,7 @@ module Spree
     class CountriesController < Spree::Api::BaseController
 
       def index
-        @countries = Country.ransack(params[:q]).result.
+        @countries = Country.accessible_by(current_ability, :read).ransack(params[:q]).result.
                      includes(:states).order('name ASC').
                      page(params[:page]).per(params[:per_page])
 
@@ -11,7 +11,7 @@ module Spree
       end
 
       def show
-        @country = Country.find(params[:id])
+        @country = Country.accessible_by(current_ability, :read).find(params[:id])
         respond_with(@country)
       end
     end

--- a/api/app/controllers/spree/api/images_controller.rb
+++ b/api/app/controllers/spree/api/images_controller.rb
@@ -1,10 +1,9 @@
 module Spree
   module Api
     class ImagesController < Spree::Api::BaseController
-      respond_to :json
 
       def show
-        @image = Image.find(params[:id])
+        @image = Image.accessible_by(current_ability, :read).find(params[:id])
         respond_with(@image)
       end
 
@@ -15,15 +14,13 @@ module Spree
       end
 
       def update
-        authorize! :update, Image
-        @image = Image.find(params[:id])
+        @image = Image.accessible_by(current_ability, :update).find(params[:id])
         @image.update_attributes(params[:image])
         respond_with(@image, :default_template => :show)
       end
 
       def destroy
-        authorize! :delete, Image
-        @image = Image.find(params[:id])
+        @image = Image.accessible_by(current_ability, :destroy).find(params[:id])
         @image.destroy
         respond_with(@image, :status => 204)
       end

--- a/api/app/controllers/spree/api/inventory_units_controller.rb
+++ b/api/app/controllers/spree/api/inventory_units_controller.rb
@@ -8,7 +8,7 @@ module Spree
       end
 
       def update
-        authorize! :update, Order
+        authorize! :update, inventory_unit.order
 
         inventory_unit.transaction do
           if inventory_unit.update_attributes(params[:inventory_unit])
@@ -23,7 +23,7 @@ module Spree
       private
 
       def inventory_unit
-        @inventory_unit ||= InventoryUnit.find(params[:id])
+        @inventory_unit ||= InventoryUnit.accessible_by(current_ability, :read).find(params[:id])
       end
 
       def prepare_event

--- a/api/app/controllers/spree/api/line_items_controller.rb
+++ b/api/app/controllers/spree/api/line_items_controller.rb
@@ -1,10 +1,9 @@
 module Spree
   module Api
     class LineItemsController < Spree::Api::BaseController
-      respond_to :json
 
       def create
-        authorize! :read, order
+        authorize! :update, order
         @line_item = order.line_items.build(params[:line_item], :as => :api)
         if @line_item.save
           respond_with(@line_item, :status => 201, :default_template => :show)
@@ -14,7 +13,7 @@ module Spree
       end
 
       def update
-        authorize! :read, order
+        authorize! :update, order
         @line_item = order.line_items.find(params[:id])
         if @line_item.update_attributes(params[:line_item], :as => :api)
           respond_with(@line_item, :default_template => :show)
@@ -24,7 +23,7 @@ module Spree
       end
 
       def destroy
-        authorize! :read, order
+        authorize! :update, order
         @line_item = order.line_items.find(params[:id])
         @line_item.destroy
         respond_with(@line_item, :status => 204)
@@ -34,6 +33,7 @@ module Spree
 
       def order
         @order ||= Order.find_by_number!(params[:order_id])
+        authorize! :read, @order
       end
     end
   end

--- a/api/app/controllers/spree/api/option_types_controller.rb
+++ b/api/app/controllers/spree/api/option_types_controller.rb
@@ -3,21 +3,21 @@ module Spree
     class OptionTypesController < Spree::Api::BaseController
       def index
         if params[:ids]
-          @option_types = Spree::OptionType.where(:id => params[:ids].split(','))
+          @option_types = Spree::OptionType.accessible_by(current_ability, :read).where(:id => params[:ids].split(','))
         else
-          @option_types = Spree::OptionType.scoped.ransack(params[:q]).result
+          @option_types = Spree::OptionType.accessible_by(current_ability, :read).scoped.ransack(params[:q]).result
         end
         respond_with(@option_types)
       end
 
       def show
-      	@option_type = Spree::OptionType.find(params[:id])
-      	respond_with(@option_type)
+        @option_type = Spree::OptionType.accessible_by(current_ability, :read).find(params[:id])
+        respond_with(@option_type)
       end
 
       def create
-      	authorize! :create, Spree::OptionType
-      	@option_type = Spree::OptionType.new(params[:option_type])
+        authorize! :create, Spree::OptionType
+        @option_type = Spree::OptionType.new(params[:option_type])
         if @option_type.save
           render :show, :status => 201
         else
@@ -26,8 +26,7 @@ module Spree
       end
 
       def update
-        authorize! :update, Spree::OptionType
-        @option_type = Spree::OptionType.find(params[:id])
+        @option_type = Spree::OptionType.accessible_by(current_ability, :update).find(params[:id])
         if @option_type.update_attributes(params[:option_type])
           render :show
         else
@@ -36,8 +35,7 @@ module Spree
       end
 
       def destroy
-        authorize! :destroy, Spree::OptionType
-        @option_type = Spree::OptionType.find(params[:id])
+        @option_type = Spree::OptionType.accessible_by(current_ability, :destroy).find(params[:id])
         @option_type.destroy
         render :text => nil, :status => 204
       end

--- a/api/app/controllers/spree/api/option_values_controller.rb
+++ b/api/app/controllers/spree/api/option_values_controller.rb
@@ -11,13 +11,13 @@ module Spree
       end
 
       def show
-      	@option_value = scope.find(params[:id])
-      	respond_with(@option_value)
+        @option_value = scope.find(params[:id])
+        respond_with(@option_value)
       end
 
       def create
-      	authorize! :create, Spree::OptionValue
-      	@option_value = scope.new(params[:option_value])
+        authorize! :create, Spree::OptionValue
+        @option_value = scope.new(params[:option_value])
         if @option_value.save
           render :show, :status => 201
         else
@@ -26,8 +26,7 @@ module Spree
       end
 
       def update
-        authorize! :update, Spree::OptionValue
-        @option_value = scope.find(params[:id])
+        @option_value = scope.accessible_by(current_ability, :update).find(params[:id])
         if @option_value.update_attributes(params[:option_value])
           render :show
         else
@@ -36,8 +35,7 @@ module Spree
       end
 
       def destroy
-        authorize! :destroy, Spree::OptionValue
-        @option_value = scope.find(params[:id])
+        @option_value = scope.accessible_by(current_ability, :destroy).find(params[:id])
         @option_value.destroy
         render :text => nil, :status => 204
       end
@@ -46,9 +44,9 @@ module Spree
 
         def scope
           if params[:option_type_id]
-            @scope ||= Spree::OptionType.find(params[:option_type_id]).option_values
+            @scope ||= Spree::OptionType.find(params[:option_type_id]).option_values.accessible_by(current_ability, :read)
           else
-            @scope ||= Spree::OptionValue.scoped
+            @scope ||= Spree::OptionValue.accessible_by(current_ability, :read).scoped
           end
         end
     end

--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -1,55 +1,62 @@
 module Spree
   module Api
     class OrdersController < Spree::Api::BaseController
-      respond_to :json
 
-      before_filter :authorize_read!, :except => [:index, :search, :create]
+      # Dynamically defines our stores checkout steps to ensure we check authorization on each step.
+      Order.checkout_steps.keys.each do |step|
+        define_method step do
+          authorize! :update, @order
+        end
+      end
+
+      def cancel
+        @order = Order.find_by_number!(params[:id])
+        authorize! :update, @order
+        @order.cancel!
+        render :show
+      end
+
+      def create
+        authorize! :create, Order
+        @order = Order.build_from_api(current_api_user, nested_params)
+        respond_with(@order, :default_template => :show, :status => 201)
+      end
+
+      def empty
+        @order = Order.find_by_number!(params[:id])
+        authorize! :update, @order
+        @order.line_items.destroy_all
+        @order.update!
+        render :text => nil, :status => 200
+      end
 
       def index
-        # should probably look at turning this into a CanCan step
-        raise CanCan::AccessDenied unless current_api_user.has_spree_role?("admin")
+        authorize! :index, Order
         @orders = Order.ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
         respond_with(@orders)
       end
 
       def show
+        @order = Order.find_by_number!(params[:id])
+        authorize! :read, @order
         respond_with(@order)
       end
 
-      def create
-        @order = Order.build_from_api(current_api_user, nested_params)
-        respond_with(order, :default_template => :show, :status => 201)
-      end
-
       def update
-        authorize! :update, Order
-        if order.update_attributes(nested_params)
-          order.update!
-          respond_with(order, :default_template => :show)
+        @order = Order.find_by_number!(params[:id])
+        authorize! :update, @order
+        if @order.update_attributes(nested_params)
+          @order.update!
+          respond_with(@order, :default_template => :show)
         else
-          invalid_resource!(order)
+          invalid_resource!(@order)
         end
-      end
-
-      def cancel
-        order.cancel!
-        render :show
-      end
-
-      def empty
-        order.line_items.destroy_all
-        order.update!
-        render :text => nil, :status => 200
       end
 
       private
 
       def nested_params
         map_nested_attributes_keys Order, params[:order] || {}
-      end
-
-      def order
-        @order ||= Order.find_by_number!(params[:id])
       end
 
       def next!(options={})
@@ -60,9 +67,6 @@ module Spree
         end
       end
 
-      def authorize_read!
-        authorize! :read, order
-      end
     end
   end
 end

--- a/api/app/controllers/spree/api/payments_controller.rb
+++ b/api/app/controllers/spree/api/payments_controller.rb
@@ -1,7 +1,6 @@
 module Spree
   module Api
     class PaymentsController < Spree::Api::BaseController
-      respond_to :json
 
       before_filter :find_order
       before_filter :find_payment, :only => [:show, :authorize, :purchase, :capture, :void, :credit]

--- a/api/app/controllers/spree/api/product_properties_controller.rb
+++ b/api/app/controllers/spree/api/product_properties_controller.rb
@@ -1,13 +1,12 @@
 module Spree
   module Api
     class ProductPropertiesController < Spree::Api::BaseController
-      respond_to :json
 
       before_filter :find_product
-      before_filter :product_property, :only => [:show, :update, :destroy]
+      before_filter :product_property, only: [:show, :update, :destroy]
 
       def index
-        @product_properties = @product.product_properties.
+        @product_properties = @product.product_properties.accessible_by(current_ability, :read).
                               ransack(params[:q]).result.
                               page(params[:page]).per(params[:per_page])
         respond_with(@product_properties)
@@ -31,8 +30,9 @@ module Spree
       end
 
       def update
-        authorize! :update, ProductProperty
-        if @product_property  && @product_property.update_attributes(params[:product_property])
+        if @product_property
+          authorize! :update, @product_property
+          @product_property.update_attributes(params[:product_property])
           respond_with(@product_property, :status => 200, :default_template => :show)
         else
           invalid_resource!(@product_property)
@@ -40,8 +40,8 @@ module Spree
       end
 
       def destroy
-        authorize! :delete, ProductProperty
-        if(@product_property)
+        if @product_property
+          authorize! :destroy, @product_property
           @product_property.destroy
           respond_with(@product_property, :status => 204)
         else
@@ -50,14 +50,17 @@ module Spree
       end
 
       private
+
         def find_product
           @product = super(params[:product_id])
+          authorize! :read, @product
         end
 
         def product_property
           if @product
             @product_property ||= @product.product_properties.find_by_id(params[:id])
-            @product_property ||= @product.product_properties.joins(:property).where('spree_properties.name' => params[:id]).readonly(false).first
+            @product_property ||= @product.product_properties.includes(:property).where('spree_properties.name' => params[:id]).first
+            authorize! :read, @product_property
           end
         end
     end

--- a/api/app/controllers/spree/api/products_controller.rb
+++ b/api/app/controllers/spree/api/products_controller.rb
@@ -1,13 +1,12 @@
 module Spree
   module Api
     class ProductsController < Spree::Api::BaseController
-      respond_to :json
 
       def index
         if params[:ids]
-          @products = product_scope.where(:id => params[:ids])
+          @products = product_scope.accessible_by(current_ability, :read).where(:id => params[:ids])
         else
-          @products = product_scope.ransack(params[:q]).result
+          @products = product_scope.accessible_by(current_ability, :read).ransack(params[:q]).result
         end
 
         @products = @products.page(params[:page]).per(params[:per_page])
@@ -35,8 +34,8 @@ module Spree
       end
 
       def update
-        authorize! :update, Product
         @product = find_product(params[:id])
+        authorize! :update, @product
         if @product.update_attributes(params[:product])
           respond_with(@product, :status => 200, :default_template => :show)
         else
@@ -45,8 +44,8 @@ module Spree
       end
 
       def destroy
-        authorize! :delete, Product
         @product = find_product(params[:id])
+        authorize! :destroy, @product
         @product.update_attribute(:deleted_at, Time.now)
         @product.variants_including_master.update_all(:deleted_at => Time.now)
         respond_with(@product, :status => 204)

--- a/api/app/controllers/spree/api/properties_controller.rb
+++ b/api/app/controllers/spree/api/properties_controller.rb
@@ -1,12 +1,11 @@
 module Spree
   module Api
     class PropertiesController < Spree::Api::BaseController
-      respond_to :json
 
       before_filter :find_property, :only => [:show, :update, :destroy]
 
       def index
-        @properties = Spree::Property.
+        @properties = Spree::Property.accessible_by(current_ability, :read).
                       ransack(params[:q]).result.
                       page(params[:page]).per(params[:per_page])
         respond_with(@properties)
@@ -30,8 +29,9 @@ module Spree
       end
 
       def update
-        authorize! :update, Property
-        if @property && @property.update_attributes(params[:property])
+        if @property
+          authorize! :update, @property
+          @property.update_attributes(params[:property])
           respond_with(@property, :status => 200, :default_template => :show)
         else
           invalid_resource!(@property)
@@ -39,8 +39,8 @@ module Spree
       end
 
       def destroy
-        authorize! :delete, Property
-        if(@property)
+        if @property
+          authorize! :destroy, @property
           @property.destroy
           respond_with(@property, :status => 204)
         else
@@ -51,9 +51,9 @@ module Spree
       private
 
       def find_property
-        @property = Spree::Property.find(params[:id])
+        @property = Spree::Property.accessible_by(current_ability, :read).find(params[:id])
       rescue ActiveRecord::RecordNotFound
-        @property = Spree::Property.find_by_name!(params[:id])
+        @property = Spree::Property.accessible_by(current_ability, :read).find_by_name!(params[:id])
       end
 
     end

--- a/api/app/controllers/spree/api/return_authorizations_controller.rb
+++ b/api/app/controllers/spree/api/return_authorizations_controller.rb
@@ -1,23 +1,9 @@
 module Spree
   module Api
     class ReturnAuthorizationsController < Spree::Api::BaseController
-      respond_to :json
-
-      before_filter :authorize_admin!
-
-      def index
-        @return_authorizations = order.return_authorizations.
-                                 ransack(params[:q]).result.
-                                 page(params[:page]).per(params[:per_page])
-        respond_with(@return_authorizations)
-      end
-
-      def show
-        @return_authorization = order.return_authorizations.find(params[:id])
-        respond_with(@return_authorization)
-      end
 
       def create
+        authorize! :create, ReturnAuthorization
         @return_authorization = order.return_authorizations.build(params[:return_authorization], :as => :api)
         if @return_authorization.save
           respond_with(@return_authorization, :status => 201, :default_template => :show)
@@ -26,8 +12,32 @@ module Spree
         end
       end
 
+      def destroy
+        @return_authorization = order.return_authorizations.accessible_by(current_ability, :destroy).find(params[:id])
+        @return_authorization.destroy
+        respond_with(@return_authorization, :status => 204)
+      end
+
+      def index
+        authorize! :admin, ReturnAuthorization
+        @return_authorizations = order.return_authorizations.accessible_by(current_ability, :read).
+                                 ransack(params[:q]).result.
+                                 page(params[:page]).per(params[:per_page])
+        respond_with(@return_authorizations)
+      end
+
+      def new
+        authorize! :admin, ReturnAuthorization
+      end
+
+      def show
+        authorize! :admin, ReturnAuthorization
+        @return_authorization = order.return_authorizations.accessible_by(current_ability, :read).find(params[:id])
+        respond_with(@return_authorization)
+      end
+
       def update
-        @return_authorization = order.return_authorizations.find(params[:id])
+        @return_authorization = order.return_authorizations.accessible_by(current_ability, :update).find(params[:id])
         if @return_authorization.update_attributes(params[:return_authorization])
           respond_with(@return_authorization, :default_template => :show)
         else
@@ -35,21 +45,13 @@ module Spree
         end
       end
 
-      def destroy
-        @return_authorization = order.return_authorizations.find(params[:id])
-        @return_authorization.destroy
-        respond_with(@return_authorization, :status => 204)
-      end
-
       private
 
       def order
         @order ||= Order.find_by_number!(params[:order_id])
+        authorize! :read, @order
       end
 
-      def authorize_admin!
-        authorize! :manage, Spree::ReturnAuthorization
-      end
     end
   end
 end

--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -1,12 +1,12 @@
 module Spree
   module Api
     class ShipmentsController < Spree::Api::BaseController
-      respond_to :json
 
       before_filter :find_order
       before_filter :find_and_update_shipment, :only => [:ship, :ready, :add, :remove]
 
       def create
+        authorize! :create, Shipment
         variant = Spree::Variant.find(params[:variant_id])
         quantity = params[:quantity].to_i
         @shipment = @order.shipments.create(:stock_location_id => params[:stock_location_id])
@@ -19,8 +19,7 @@ module Spree
       end
 
       def update
-        authorize! :read, Shipment
-        @shipment = @order.shipments.find_by_number!(params[:id])
+        @shipment = @order.shipments.accessible_by(current_ability, :update).find_by_number!(params[:id])
 
         unlock = params[:shipment].delete(:unlock)
 
@@ -39,7 +38,6 @@ module Spree
       end
 
       def ready
-        authorize! :read, Shipment
         unless @shipment.ready?
           if @shipment.can_ready?
             @shipment.ready!
@@ -51,7 +49,6 @@ module Spree
       end
 
       def ship
-        authorize! :read, Shipment
         unless @shipment.shipped?
           @shipment.ship!
         end
@@ -84,7 +81,7 @@ module Spree
       end
 
       def find_and_update_shipment
-        @shipment = @order.shipments.find_by_number!(params[:id])
+        @shipment = @order.shipments.accessible_by(current_ability, :update).find_by_number!(params[:id])
         @shipment.update_attributes(params[:shipment])
         @shipment.reload
       end

--- a/api/app/controllers/spree/api/states_controller.rb
+++ b/api/app/controllers/spree/api/states_controller.rb
@@ -21,10 +21,10 @@ module Spree
       private
         def scope
           if params[:country_id]
-            @country = Country.find(params[:country_id])
-            return @country.states
+            @country = Country.accessible_by(current_ability, :read).find(params[:country_id])
+            return @country.states.accessible_by(current_ability, :read)
           else
-            return State.scoped
+            return State.accessible_by(current_ability, :read)
           end
         end
     end

--- a/api/app/controllers/spree/api/stock_items_controller.rb
+++ b/api/app/controllers/spree/api/stock_items_controller.rb
@@ -32,8 +32,7 @@ module Spree
       end
 
       def update
-        authorize! :update, StockItem
-        @stock_item = StockItem.find(params[:id])
+        @stock_item = StockItem.accessible_by(current_ability, :update).find(params[:id])
 
         count_on_hand = 0
         if params[:stock_item].has_key?(:count_on_hand)
@@ -49,8 +48,7 @@ module Spree
       end
 
       def destroy
-        authorize! :delete, StockItem
-        @stock_item = StockItem.find(params[:id])
+        @stock_item = StockItem.accessible_by(current_ability, :destroy).find(params[:id])
         @stock_item.destroy
         respond_with(@stock_item, status: 204)
       end
@@ -59,11 +57,11 @@ module Spree
 
       def stock_location
         render 'spree/api/shared/stock_location_required', status: 422 and return unless params[:stock_location_id]
-        @stock_location ||= StockLocation.find(params[:stock_location_id])
+        @stock_location ||= StockLocation.accessible_by(current_ability, :read).find(params[:stock_location_id])
       end
 
       def scope
-        @stock_location.stock_items.includes(:variant => :product)
+        @stock_location.stock_items.accessible_by(current_ability, :read).includes(:variant => :product)
       end
     end
   end

--- a/api/app/controllers/spree/api/stock_locations_controller.rb
+++ b/api/app/controllers/spree/api/stock_locations_controller.rb
@@ -2,7 +2,7 @@ module Spree
   module Api
     class StockLocationsController < Spree::Api::BaseController
       def index
-        @stock_locations = StockLocation.order('name ASC').ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
+        @stock_locations = StockLocation.accessible_by(current_ability, :read).order('name ASC').ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
         respond_with(@stock_locations)
       end
 
@@ -21,7 +21,7 @@ module Spree
       end
 
       def update
-        authorize! :update, StockLocation
+        authorize! :update, stock_location
         if stock_location.update_attributes(params[:stock_location])
           respond_with(stock_location, status: 200, default_template: :show)
         else
@@ -30,7 +30,7 @@ module Spree
       end
 
       def destroy
-        authorize! :delete, StockLocation
+        authorize! :destroy, stock_location
         stock_location.destroy
         respond_with(stock_location, :status => 204)
       end
@@ -38,7 +38,7 @@ module Spree
       private
 
       def stock_location
-        @stock_location ||= StockLocation.find(params[:id])
+        @stock_location ||= StockLocation.accessible_by(current_ability, :read).find(params[:id])
       end
     end
   end

--- a/api/app/controllers/spree/api/stock_movements_controller.rb
+++ b/api/app/controllers/spree/api/stock_movements_controller.rb
@@ -24,8 +24,7 @@ module Spree
       end
 
       def update
-        authorize! :update, StockMovement
-        @stock_movement = StockMovement.find(params[:id])
+        @stock_movement = StockMovement.accessible_by(current_ability, :update).find(params[:id])
         if @stock_movement.update_attributes(params[:stock_movement])
           respond_with(@stock_movement, status: 200, default_template: :show)
         else
@@ -34,8 +33,7 @@ module Spree
       end
 
       def destroy
-        authorize! :delete, StockMovement
-        @stock_movement = StockMovement.find(params[:id])
+        @stock_movement = StockMovement.accessible_by(current_ability, :destroy).find(params[:id])
         @stock_movement.destroy
         respond_with(@stock_movement, status: 204)
       end
@@ -44,11 +42,11 @@ module Spree
 
       def stock_location
         render 'spree/api/shared/stock_location_required', status: 422 and return unless params[:stock_location_id]
-        @stock_location ||= StockLocation.find(params[:stock_location_id])
+        @stock_location ||= StockLocation.accessible_by(current_ability, :read).find(params[:stock_location_id])
       end
 
       def scope
-        @stock_location.stock_movements
+        @stock_location.stock_movements.accessible_by(current_ability, :read)
       end
     end
   end

--- a/api/app/controllers/spree/api/taxonomies_controller.rb
+++ b/api/app/controllers/spree/api/taxonomies_controller.rb
@@ -1,17 +1,16 @@
 module Spree
   module Api
     class TaxonomiesController < Spree::Api::BaseController
-      respond_to :json
 
       def index
-        @taxonomies = Taxonomy.order('name').includes(:root => :children).
+        @taxonomies = Taxonomy.accessible_by(current_ability, :read).order('name').includes(:root => :children).
                       ransack(params[:q]).result.
                       page(params[:page]).per(params[:per_page])
         respond_with(@taxonomies)
       end
 
       def show
-        @taxonomy = Taxonomy.find(params[:id])
+        @taxonomy = Taxonomy.accessible_by(current_ability, :read).find(params[:id])
         respond_with(@taxonomy)
       end
 
@@ -31,7 +30,7 @@ module Spree
       end
 
       def update
-        authorize! :update, Taxonomy
+        authorize! :update, taxonomy
         if taxonomy.update_attributes(params[:taxonomy])
           respond_with(taxonomy, :status => 200, :default_template => :show)
         else
@@ -40,7 +39,7 @@ module Spree
       end
 
       def destroy
-        authorize! :delete, Taxonomy
+        authorize! :destroy, taxonomy
         taxonomy.destroy
         respond_with(taxonomy, :status => 204)
       end
@@ -48,7 +47,7 @@ module Spree
       private
 
       def taxonomy
-        @taxonomy ||= Taxonomy.find(params[:id])
+        @taxonomy ||= Taxonomy.accessible_by(current_ability, :read).find(params[:id])
       end
 
     end

--- a/api/app/controllers/spree/api/taxons_controller.rb
+++ b/api/app/controllers/spree/api/taxons_controller.rb
@@ -1,16 +1,15 @@
 module Spree
   module Api
     class TaxonsController < Spree::Api::BaseController
-      respond_to :json
 
       def index
         if taxonomy
           @taxons = taxonomy.root.children
         else
           if params[:ids]
-            @taxons = Taxon.where(:id => params[:ids].split(","))
+            @taxons = Taxon.accessible_by(current_ability, :read).where(:id => params[:ids].split(","))
           else
-            @taxons = Taxon.ransack(params[:q]).result
+            @taxons = Taxon.accessible_by(current_ability, :read).ransack(params[:q]).result
           end
         end
         respond_with(@taxons)
@@ -46,7 +45,7 @@ module Spree
       end
 
       def update
-        authorize! :update, Taxon
+        authorize! :update, taxon
         if taxon.update_attributes(params[:taxon])
           respond_with(taxon, :status => 200, :default_template => :show)
         else
@@ -55,7 +54,7 @@ module Spree
       end
 
       def destroy
-        authorize! :delete, Taxon
+        authorize! :destroy, taxon
         taxon.destroy
         respond_with(taxon, :status => 204)
       end
@@ -64,12 +63,12 @@ module Spree
 
       def taxonomy
         if params[:taxonomy_id].present?
-          @taxonomy ||= Taxonomy.find(params[:taxonomy_id])
+          @taxonomy ||= Taxonomy.accessible_by(current_ability, :read).find(params[:taxonomy_id])
         end
       end
 
       def taxon
-        @taxon ||= taxonomy.taxons.find(params[:id])
+        @taxon ||= taxonomy.taxons.accessible_by(current_ability, :read).find(params[:id])
       end
 
     end

--- a/api/app/controllers/spree/api/users_controller.rb
+++ b/api/app/controllers/spree/api/users_controller.rb
@@ -1,7 +1,6 @@
 module Spree
   module Api
     class UsersController < Spree::Api::BaseController
-      respond_to :json
 
       def index
         @users = Spree.user_class.accessible_by(current_ability,:read).ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
@@ -9,7 +8,6 @@ module Spree
       end
 
       def show
-        authorize! :show, user
         respond_with(user)
       end
 
@@ -44,7 +42,7 @@ module Spree
       private
 
       def user
-        @user ||= Spree.user_class.find(params[:id])
+        @user ||= Spree.user_class.accessible_by(current_ability, :read).find(params[:id])
       end
     end
   end

--- a/api/app/controllers/spree/api/zones_controller.rb
+++ b/api/app/controllers/spree/api/zones_controller.rb
@@ -2,15 +2,6 @@ module Spree
   module Api
     class ZonesController < Spree::Api::BaseController
 
-      def index
-        @zones = Zone.order('name ASC').ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
-        respond_with(@zones)
-      end
-
-      def show
-        respond_with(zone)
-      end
-
       def create
         authorize! :create, Zone
         @zone = Zone.new(map_nested_attributes_keys(Spree::Zone, params[:zone]))
@@ -21,8 +12,23 @@ module Spree
         end
       end
 
+      def destroy
+        authorize! :destroy, zone
+        zone.destroy
+        respond_with(zone, :status => 204)
+      end
+
+      def index
+        @zones = Zone.accessible_by(current_ability, :read).order('name ASC').ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
+        respond_with(@zones)
+      end
+
+      def show
+        respond_with(zone)
+      end
+
       def update
-        authorize! :update, Zone
+        authorize! :update, zone
         if zone.update_attributes(map_nested_attributes_keys(Spree::Zone, params[:zone]))
           respond_with(zone, :status => 200, :default_template => :show)
         else
@@ -30,15 +36,10 @@ module Spree
         end
       end
 
-      def destroy
-        authorize! :delete, Zone
-        zone.destroy
-        respond_with(zone, :status => 204)
-      end
-
       private
+
       def zone
-        @zone ||= Spree::Zone.find(params[:id])
+        @zone ||= Spree::Zone.accessible_by(current_ability, :read).find(params[:id])
       end
     end
   end

--- a/api/lib/spree/api/testing_support/helpers.rb
+++ b/api/lib/spree/api/testing_support/helpers.rb
@@ -6,6 +6,11 @@ module Spree
           JSON.parse(response.body)
         end
 
+        def assert_not_found!
+          json_response.should == { "error" => "The resource you were looking for could not be found." }
+          response.status.should == 404
+        end
+
         def assert_unauthorized!
           json_response.should == { "error" => "You are not authorized to perform that action." }
           response.status.should == 401

--- a/api/spec/controllers/spree/api/addresses_controller_spec.rb
+++ b/api/spec/controllers/spree/api/addresses_controller_spec.rb
@@ -24,11 +24,11 @@ module Spree
                          :address => { :address1 => "123 Test Lane" }
         json_response['address1'].should eq '123 Test Lane'
       end
-      
+
       it "receives the errors object if address is invalid" do
         api_put :update, :id => @address.id,
                          :address => { :address1 => "" }
-                         
+
         json_response['error'].should_not be_nil
         json_response['errors'].should_not be_nil
         json_response['errors']['address1'].first.should eq "can't be blank"

--- a/api/spec/controllers/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/controllers/spree/api/checkouts_controller_spec.rb
@@ -73,6 +73,7 @@ module Spree
       it "will return an error if the order cannot transition" do
         order.update_column(:state, "address")
         api_put :update, :id => order.to_param
+        # Order has not transitioned
         response.status.should == 422
       end
 

--- a/api/spec/controllers/spree/api/images_controller_spec.rb
+++ b/api/spec/controllers/spree/api/images_controller_spec.rb
@@ -54,12 +54,12 @@ module Spree
 
       it "cannot update an image" do
         api_put :update, :id => 1
-        assert_unauthorized!
+        assert_not_found!
       end
 
       it "cannot delete an image" do
         api_delete :destroy, :id => 1
-        assert_unauthorized!
+        assert_not_found!
       end
     end
   end

--- a/api/spec/controllers/spree/api/inventory_units_controller_spec.rb
+++ b/api/spec/controllers/spree/api/inventory_units_controller_spec.rb
@@ -9,36 +9,40 @@ module Spree
       @inventory_unit = create(:inventory_unit)
     end
 
-    it "gets an inventory unit" do
-      api_get :show, :id => @inventory_unit.id
-      json_response['state'].should eq @inventory_unit.state
-    end
+    context "as an admin" do
+      sign_in_as_admin!
 
-    it "updates an inventory unit (only shipment is accessable by default)" do
-      api_put :update, :id => @inventory_unit.id,
-                       :inventory_unit => { :shipment => nil }
-      json_response['shipment_id'].should be_nil
-    end
+      it "gets an inventory unit" do
+        api_get :show, :id => @inventory_unit.id
+        json_response['state'].should eq @inventory_unit.state
+      end
 
-    context 'fires state event' do
-      it 'if supplied with :fire param' do
+      it "updates an inventory unit (only shipment is accessable by default)" do
         api_put :update, :id => @inventory_unit.id,
-                         :fire => 'ship',
                          :inventory_unit => { :shipment => nil }
-
-        json_response['state'].should eq 'shipped'
+        json_response['shipment_id'].should be_nil
       end
 
-      it 'and returns exception if cannot fire' do
-        api_put :update, :id => @inventory_unit.id,
-                         :fire => 'return'
-        json_response['exception'].should match /cannot transition to return/
-      end
+      context 'fires state event' do
+        it 'if supplied with :fire param' do
+          api_put :update, :id => @inventory_unit.id,
+                           :fire => 'ship',
+                           :inventory_unit => { :shipment => nil }
 
-      it 'and returns exception bad state' do
-        api_put :update, :id => @inventory_unit.id,
-                         :fire => 'bad'
-        json_response['exception'].should match /cannot transition to bad/
+          json_response['state'].should eq 'shipped'
+        end
+
+        it 'and returns exception if cannot fire' do
+          api_put :update, :id => @inventory_unit.id,
+                           :fire => 'return'
+          json_response['exception'].should match /cannot transition to return/
+        end
+
+        it 'and returns exception bad state' do
+          api_put :update, :id => @inventory_unit.id,
+                           :fire => 'bad'
+          json_response['exception'].should match /cannot transition to bad/
+        end
       end
     end
   end

--- a/api/spec/controllers/spree/api/option_types_controller_spec.rb
+++ b/api/spec/controllers/spree/api/option_types_controller_spec.rb
@@ -62,13 +62,13 @@ module Spree
                         :option_type => {
                           :name => "Option Type"
                         }
-      assert_unauthorized!
+      assert_not_found!
       option_type.reload.name.should == original_name
     end
 
     it "cannot delete an option type" do
       api_delete :destroy, :id => option_type.id
-      assert_unauthorized!
+      assert_not_found!
       lambda { option_type.reload }.should_not raise_error(ActiveRecord::RecordNotFound)
     end
 

--- a/api/spec/controllers/spree/api/option_values_controller_spec.rb
+++ b/api/spec/controllers/spree/api/option_values_controller_spec.rb
@@ -73,13 +73,13 @@ module Spree
                           :option_value => {
                             :name => "Option Value"
                           }
-        assert_unauthorized!
+        assert_not_found!
         option_type.reload.name.should == original_name
       end
 
       it "cannot delete an option value" do
         api_delete :destroy, :id => option_type.id
-        assert_unauthorized!
+        assert_not_found!
         lambda { option_type.reload }.should_not raise_error(ActiveRecord::RecordNotFound)
       end
 

--- a/api/spec/controllers/spree/api/products_controller_spec.rb
+++ b/api/spec/controllers/spree/api/products_controller_spec.rb
@@ -120,14 +120,12 @@ module Spree
 
       it "cannot see inactive products" do
         api_get :show, :id => inactive_product.to_param
-        json_response["error"].should == "The resource you were looking for could not be found."
-        response.status.should == 404
+        assert_not_found!
       end
 
       it "returns a 404 error when it cannot find a product" do
         api_get :show, :id => "non-existant"
-        json_response["error"].should == "The resource you were looking for could not be found."
-        response.status.should == 404
+        assert_not_found!
       end
 
       it "can learn how to create a new product" do

--- a/api/spec/controllers/spree/api/return_authorizations_controller_spec.rb
+++ b/api/spec/controllers/spree/api/return_authorizations_controller_spec.rb
@@ -41,12 +41,12 @@ module Spree
 
       it "cannot update a return authorization" do
         api_put :update
-        assert_unauthorized!
+        assert_not_found!
       end
 
       it "cannot delete a return authorization" do
         api_delete :destroy
-        assert_unauthorized!
+        assert_not_found!
       end
     end
 

--- a/api/spec/controllers/spree/api/states_controller_spec.rb
+++ b/api/spec/controllers/spree/api/states_controller_spec.rb
@@ -19,7 +19,7 @@ module Spree
 
     context "pagination" do
       before do
-        State.should_receive(:scoped).and_return(@scope = stub)
+        State.should_receive(:accessible_by).and_return(@scope = stub)
         @scope.stub_chain(:ransack, :result, :includes, :order).and_return(@scope)
       end
 

--- a/api/spec/controllers/spree/api/users_controller_spec.rb
+++ b/api/spec/controllers/spree/api/users_controller_spec.rb
@@ -22,7 +22,7 @@ module Spree
       it "cannot get other users details" do
         api_get :show, :id => stranger.id
 
-        assert_unauthorized!
+        assert_not_found!
       end
 
       it "can learn how to create a new user" do
@@ -50,7 +50,7 @@ module Spree
 
       it "cannot update other users details" do
         api_put :update, :id => stranger.id, :user => { :email => "mine@example.com" }
-        assert_unauthorized!
+        assert_not_found!
       end
 
       it "can delete itself" do
@@ -60,7 +60,7 @@ module Spree
 
       it "cannot delete other user" do
         api_delete :destroy, :id => stranger.id
-        assert_unauthorized!
+        assert_not_found!
       end
 
       it "should only get own details on index" do

--- a/api/spec/controllers/spree/api/variants_controller_spec.rb
+++ b/api/spec/controllers/spree/api/variants_controller_spec.rb
@@ -4,7 +4,6 @@ module Spree
   describe Api::VariantsController do
     render_views
 
-
     let!(:product) { create(:product) }
     let!(:variant) do
       variant = product.master
@@ -125,12 +124,12 @@ module Spree
 
     it "cannot update a variant" do
       api_put :update, :id => variant.to_param, :variant => { :sku => "12345" }
-      assert_unauthorized!
+      assert_not_found!
     end
 
     it "cannot delete a variant" do
       api_delete :destroy, :id => variant.to_param
-      assert_unauthorized!
+      assert_not_found!
       lambda { variant.reload }.should_not raise_error
     end
 
@@ -170,7 +169,6 @@ module Spree
         lambda { variant.reload }.should raise_error(ActiveRecord::RecordNotFound)
       end
     end
-
 
   end
 end

--- a/core/spec/models/spree/ability_spec.rb
+++ b/core/spec/models/spree/ability_spec.rb
@@ -122,57 +122,166 @@ describe Spree::Ability do
     end
   end
 
-  context 'for User' do
-    context 'requested by same user' do
-      let(:resource) { user }
-      it_should_behave_like 'access granted'
-      it_should_behave_like 'no index allowed'
+  context 'as Guest User' do
+
+    context 'for Address' do
+      context 'requested by any user' do
+        let(:resource) {
+          address = Spree::Address.new
+          address.stub user: create(:user)
+          address
+        }
+        it_should_behave_like 'access denied'
+      end
+
+      context 'requested by user' do
+        let(:resource) {
+          address = Spree::Address.new
+          address.stub user: user
+          address
+        }
+        it_should_behave_like 'access granted'
+      end
     end
-    context 'requested by other user' do
-      let(:resource) { Spree.user_class.new }
-      it_should_behave_like 'create only'
+
+    context 'for Country' do
+      let(:resource) { Spree::Country.new }
+      context 'requested by any user' do
+        it_should_behave_like 'read only'
+      end
     end
+
+    context 'for OptionType' do
+      let(:resource) { Spree::OptionType.new }
+      context 'requested by any user' do
+        it_should_behave_like 'read only'
+      end
+    end
+
+    context 'for OptionValue' do
+      let(:resource) { Spree::OptionType.new }
+      context 'requested by any user' do
+        it_should_behave_like 'read only'
+      end
+    end
+
+    context 'for Order' do
+      let(:resource) { Spree::Order.new }
+
+      context 'requested by same user' do
+        before(:each) { resource.user = user }
+        it_should_behave_like 'access granted'
+        it_should_behave_like 'no index allowed'
+      end
+
+      context 'requested by other user' do
+        before(:each) { resource.user = Spree.user_class.new }
+        it_should_behave_like 'create only'
+      end
+
+      context 'requested with proper token' do
+        let(:token) { 'TOKEN123' }
+        before(:each) { resource.stub :token => 'TOKEN123' }
+        it_should_behave_like 'access granted'
+        it_should_behave_like 'no index allowed'
+      end
+
+      context 'requested with inproper token' do
+        let(:token) { 'FAIL' }
+        before(:each) { resource.stub :token => 'TOKEN123' }
+        it_should_behave_like 'create only'
+      end
+    end
+
+    context 'for Product' do
+      let(:resource) { Spree::Product.new }
+      context 'requested by any user' do
+        it_should_behave_like 'read only'
+      end
+    end
+
+    context 'for ProductProperty' do
+      let(:resource) { Spree::Product.new }
+      context 'requested by any user' do
+        it_should_behave_like 'read only'
+      end
+    end
+
+    context 'for Property' do
+      let(:resource) { Spree::Product.new }
+      context 'requested by any user' do
+        it_should_behave_like 'read only'
+      end
+    end
+
+    context 'for State' do
+      let(:resource) { Spree::State.new }
+      context 'requested by any user' do
+        it_should_behave_like 'read only'
+      end
+    end
+
+    context 'for StockItem' do
+      let(:resource) { Spree::StockItem.new }
+      context 'requested by any user' do
+        it_should_behave_like 'read only'
+      end
+    end
+
+    context 'for StockLocation' do
+      let(:resource) { Spree::StockLocation.new }
+      context 'requested by any user' do
+        it_should_behave_like 'read only'
+      end
+    end
+
+    context 'for StockMovement' do
+      let(:resource) { Spree::StockMovement.new }
+      context 'requested by any user' do
+        it_should_behave_like 'read only'
+      end
+    end
+
+    context 'for Taxons' do
+      let(:resource) { Spree::Taxon.new }
+      context 'requested by any user' do
+        it_should_behave_like 'read only'
+      end
+    end
+
+    context 'for Taxonomy' do
+      let(:resource) { Spree::Taxonomy.new }
+      context 'requested by any user' do
+        it_should_behave_like 'read only'
+      end
+    end
+
+    context 'for User' do
+      context 'requested by same user' do
+        let(:resource) { user }
+        it_should_behave_like 'access granted'
+        it_should_behave_like 'no index allowed'
+      end
+      context 'requested by other user' do
+        let(:resource) { Spree.user_class.new }
+        it_should_behave_like 'create only'
+      end
+    end
+
+    context 'for Variant' do
+      let(:resource) { Spree::Variant.new }
+      context 'requested by any user' do
+        it_should_behave_like 'read only'
+      end
+    end
+
+    context 'for Zone' do
+      let(:resource) { Spree::Zone.new }
+      context 'requested by any user' do
+        it_should_behave_like 'read only'
+      end
+    end
+
   end
 
-  context 'for Order' do
-    let(:resource) { Spree::Order.new }
-
-    context 'requested by same user' do
-      before(:each) { resource.user = user }
-      it_should_behave_like 'access granted'
-      it_should_behave_like 'no index allowed'
-    end
-
-    context 'requested by other user' do
-      before(:each) { resource.user = Spree.user_class.new }
-      it_should_behave_like 'create only'
-    end
-
-    context 'requested with proper token' do
-      let(:token) { 'TOKEN123' }
-      before(:each) { resource.stub :token => 'TOKEN123' }
-      it_should_behave_like 'access granted'
-      it_should_behave_like 'no index allowed'
-    end
-
-    context 'requested with inproper token' do
-      let(:token) { 'FAIL' }
-      before(:each) { resource.stub :token => 'TOKEN123' }
-      it_should_behave_like 'create only'
-    end
-  end
-
-  context 'for Product' do
-    let(:resource) { Spree::Product.new }
-    context 'requested by any user' do
-      it_should_behave_like 'read only'
-    end
-  end
-
-  context 'for Taxons' do
-    let(:resource) { Spree::Taxon.new }
-    context 'requested by any user' do
-      it_should_behave_like 'read only'
-    end
-  end
 end


### PR DESCRIPTION
Currently the API is mainly only useful for admin access to it.  This cleans up the CanCan usage in the API controllers so that you can provide more fine grained access to the API to users without an admin role.  This is particularly useful for drop ship suppliers who should be able to update their shipments, but not the order itself.
