### PR TITLE
Only run transition callbacks if order state is cart

### DIFF
--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -26,7 +26,7 @@ module Spree
         respond_with(@order) do |format|
           format.html do
             if params.has_key?(:checkout)
-              @order.next_transition.run_callbacks
+              @order.next_transition.run_callbacks if @order.cart?
               redirect_to checkout_state_path(@order.checkout_steps.first)
             else
               redirect_to cart_path


### PR DESCRIPTION
Calling order.next_transition.run_callbacks with order in payment state
might raise

  undefined method `run_callbacks' for nil:NilClass

And we only need to call that manually when changing from cart to
address, fixes #2921

Please let me know if I missed anything or it breaks the build. I've only run controllers and the checkout feature spec.
