### PR TITLE
Fix variant factory when Spree::Config[:track_inventory_levels] = false

### DIFF
--- a/core/lib/spree/core/testing_support/factories/product_factory.rb
+++ b/core/lib/spree/core/testing_support/factories/product_factory.rb
@@ -10,7 +10,9 @@ FactoryGirl.define do
   end
 
   factory :simple_product, :parent => :base_product do
-    on_hand 5
+    if Spree::Config[:track_inventory_levels]
+      on_hand 5
+    end
   end
 
   factory :product, :parent => :simple_product do
@@ -26,7 +28,10 @@ FactoryGirl.define do
     name "Custom Product"
     price "17.99"
     description { Faker::Lorem.paragraphs(1 + Kernel.rand(5)).join("\n") }
-    on_hand 5
+
+    if Spree::Config[:track_inventory_levels]
+      on_hand 5
+    end
 
     # associations:
     tax_category { |r| Spree::TaxCategory.first || r.association(:tax_category) }

--- a/core/lib/spree/core/testing_support/factories/variant_factory.rb
+++ b/core/lib/spree/core/testing_support/factories/variant_factory.rb
@@ -14,8 +14,10 @@ FactoryGirl.define do
   end
 
   factory :variant, :parent => :base_variant do
-    on_hand 5
-    
+    if Spree::Config[:track_inventory_levels]
+      on_hand 5
+    end
+
     # associations:
     product { |p| p.association(:product) }
   end


### PR DESCRIPTION
If `Spree::Config[:track_inventory_levels] = false` and you call `FactoryGirl.create(:variant)`, then [this line](https://github.com/spree/spree/blob/4e4085d99051c36a559b95f7864c7987168194bd/core/app/models/spree/variant.rb#L60) raises an exception. The solution is to only call `on_hand=` if `Spree::Config[:track_inventory_levels]` is `true`.
