### PR TITLE
Backend configurations "Mail Method Settings" link behavior when it is the active page.

### DIFF
--- a/backend/app/controllers/spree/admin/mail_methods_controller.rb
+++ b/backend/app/controllers/spree/admin/mail_methods_controller.rb
@@ -26,7 +26,7 @@ module Spree
       rescue Exception => e
         flash[:error] = t('admin.mail_methods.testmail.error') % {:e => e}
       ensure
-        redirect_to edit_admin_mail_method_url
+        redirect_to edit_admin_mail_methods_url
       end
 
       private

--- a/backend/app/views/spree/admin/mail_methods/edit.html.erb
+++ b/backend/app/views/spree/admin/mail_methods/edit.html.erb
@@ -6,14 +6,14 @@
 
 <% content_for :page_actions do %>
   <li>
-    <%= link_to_with_icon 'icon-envelope-alt', t('admin.mail_methods.send_testmail'), testmail_admin_mail_method_path,
+    <%= link_to_with_icon 'icon-envelope-alt', t('admin.mail_methods.send_testmail'), testmail_admin_mail_methods_path,
       :method => :post, :title => t('admin.mail_methods.send_testmail'), :class => 'send_mail button no-text' %>
   </li>
 <% end %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @mail_method } %>
 
-<%= form_tag admin_mail_method_path, :method => :put do |f| %>
+<%= form_tag admin_mail_methods_path, :method => :put do |f| %>
   <fieldset class="no-border-top">
     <%= render :partial => 'form', :locals => { :f => f } %>
     <div class="form-buttons filter-actions actions" data-hook="buttons"><%= button t(:update), 'icon-refresh' %></div>

--- a/backend/app/views/spree/admin/shared/_configuration_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_configuration_menu.html.erb
@@ -7,7 +7,7 @@
     <ul class="sidebar" data-hook="admin_configurations_sidebar_menu">
       <%= configurations_sidebar_menu_item t(:general_settings), edit_admin_general_settings_path %>
       <% if Spree::Config[:override_actionmailer_config] %>
-        <%= configurations_sidebar_menu_item t(:mail_method_settings), edit_admin_mail_method_path %>
+        <%= configurations_sidebar_menu_item t(:mail_method_settings), edit_admin_mail_methods_path %>
       <% end %>
       <%= configurations_sidebar_menu_item t(:image_settings), edit_admin_image_settings_path %>
       <%= configurations_sidebar_menu_item t(:tax_categories), admin_tax_categories_path %>

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -181,7 +181,7 @@ Spree::Core::Engine.routes.draw do
 
     resources :trackers
     resources :payment_methods
-    resource :mail_method, :only => [:edit, :update] do
+    resource :mail_methods, :only => [:edit, :update] do
       post :testmail, :on => :collection
     end
   end


### PR DESCRIPTION
In the backend configurations page, the "Mail Method Settings" link was
not giving the "link_to_unless_current" behavior
