### PR TITLE
Fix admin order form update after removing item

### DIFF
--- a/core/app/controllers/spree/admin/line_items_controller.rb
+++ b/core/app/controllers/spree/admin/line_items_controller.rb
@@ -26,7 +26,8 @@ module Spree
       def destroy
         @line_item.destroy
         respond_with(@line_item) do |format|
-          format.html { render :partial => 'spree/admin/orders/form', :locals => { :order => @order.reload } }
+          format.html { redirect_to edit_admin_order_path(@order) }
+          format.js { @order.reload }
         end
       end
 

--- a/core/spec/controllers/spree/admin/line_items_controller_spec.rb
+++ b/core/spec/controllers/spree/admin/line_items_controller_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+module Spree
+  module Admin
+    describe LineItemsController do
+      stub_authorization!
+
+      let!(:line_item) { create(:line_item) }
+      let!(:order) { line_item.order }
+
+      before { order.update_column :total, 10 }
+
+      context "destroy line item" do
+        it "reloads order total" do
+          spree_delete :destroy, { :format => :js, :order_id => order.number, :id => line_item.id }
+          expect(assigns(:order).total).to eql(order.reload.total)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We need to reload the order explicitly otherwise the same order object
would be passed to the form partial again. fixes #2972
