### PR TITLE
Clear tax adjustments only in TaxRate#adjust

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -43,15 +43,15 @@ module Spree
     has_many :state_changes, as: :stateful
     has_many :line_items, dependent: :destroy, order: 'created_at ASC'
     has_many :payments, dependent: :destroy
+    has_many :return_authorizations, dependent: :destroy
+    has_many :adjustments, as: :adjustable, dependent: :destroy, order: 'created_at ASC'
+    has_many :line_item_adjustments, through: :line_items, source: :adjustments
 
     has_many :shipments, dependent: :destroy do
       def states
         pluck(:state).uniq
       end
     end
-
-    has_many :return_authorizations, dependent: :destroy
-    has_many :adjustments, as: :adjustable, dependent: :destroy, order: 'created_at ASC'
 
     accepts_nested_attributes_for :line_items
     accepts_nested_attributes_for :bill_address
@@ -203,24 +203,24 @@ module Spree
       return tax_zone != Zone.default_tax
     end
 
-    # Array of adjustments that are inclusive in the variant price. Useful for when
-    # prices include tax (ex. VAT) and you need to record the tax amount separately.
     def price_adjustments
-      adjustments = []
-
-      line_items.each { |line_item| adjustments.concat line_item.adjustments }
-
-      adjustments
+      ActiveSupport::Deprecation.warn("Order#price_adjustments will be deprecated in Spree 2.1, please use Order#line_item_adjustments instead.")
+      self.line_item_adjustments
     end
 
-    # Array of totals grouped by Adjustment#label. Useful for displaying price
+    # Array of totals grouped by Adjustment#label. Useful for displaying line item
     # adjustments on an invoice. For example, you can display tax breakout for
     # cases where tax is included in price.
-    def price_adjustment_totals
-      Hash[price_adjustments.group_by(&:label).map do |label, adjustments|
+    def line_item_adjustment_totals
+      Hash[self.line_item_adjustments.eligible.group_by(&:label).map do |label, adjustments|
         total = adjustments.sum(&:amount)
         [label, Spree::Money.new(total, { currency: currency })]
       end]
+    end
+
+    def price_adjustment_totals
+      ActiveSupport::Deprecation.warn("Order#price_adjustment_totals will be deprecated in Spree 2.1, please use Order#line_item_adjustment_totals instead.")
+      self.line_item_adjustment_totals
     end
 
     def updater
@@ -472,11 +472,9 @@ module Spree
       adjustments.destroy_all
     end
 
-    # destroy any previous adjustments.
-    # Adjustments will be recalculated during order update.
     def clear_adjustments!
-      adjustments.tax.each(&:destroy)
-      price_adjustments.each(&:destroy)
+      self.adjustments.destroy_all
+      self.line_item_adjustments.destroy_all
     end
 
     def has_step?(step)

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -32,7 +32,9 @@ module Spree
     end
 
     def self.adjust(order)
-      order.clear_adjustments!
+      order.adjustments.tax.destroy_all
+      order.line_item_adjustments.where(originator_type: 'Spree::TaxRate').destroy_all
+
       self.match(order).each do |rate|
         rate.adjust(order)
       end

--- a/core/spec/models/spree/order/adjustments_spec.rb
+++ b/core/spec/models/spree/order/adjustments_spec.rb
@@ -3,19 +3,17 @@ describe Spree::Order do
   let(:order) { Spree::Order.new }
 
   context "clear_adjustments" do
-    it "should destroy all previous tax adjustments" do
-      adjustment = stub
-      adjustment.should_receive :destroy
+    let(:adjustment) { double("Adjustment") }
 
-      order.stub_chain :adjustments, :tax => [adjustment]
+    it "destroys all order adjustments" do
+      order.stub(:adjustments => adjustment)
+      adjustment.should_receive(:destroy_all)
       order.clear_adjustments!
     end
 
-    it "should destroy all price adjustments" do
-      adjustment = stub
-      adjustment.should_receive :destroy
-
-      order.stub :price_adjustments => [adjustment]
+    it "destroy all line item adjustments" do
+      order.stub(:line_item_adjustments => adjustment)
+      adjustment.should_receive(:destroy_all)
       order.clear_adjustments!
     end
   end
@@ -40,15 +38,15 @@ describe Spree::Order do
   end
   
 
-  context "#price_adjustment_totals" do
+  context "line item adjustment totals" do
     before { @order = Spree::Order.create! }
 
 
-    context "when there are no price adjustments" do
-      before { @order.stub :price_adjustments => [] }
+    context "when there are no line item adjustments" do
+      before { @order.stub_chain(:line_item_adjustments, :eligible => []) }
 
       it "should return an empty hash" do
-        @order.price_adjustment_totals.should == {}
+        @order.line_item_adjustment_totals.should == {}
       end
     end
 
@@ -57,16 +55,16 @@ describe Spree::Order do
       let(:adj2) { mock_model Spree::Adjustment, :amount => 20, :label => "Bar" }
 
       before do
-        @order.stub :price_adjustments => [adj1, adj2]
+        @order.stub_chain(:line_item_adjustments, :eligible => [adj1, adj2])
       end
 
       it "should return exactly two totals" do
-        @order.price_adjustment_totals.size.should == 2
+        @order.line_item_adjustment_totals.size.should == 2
       end
 
       it "should return the correct totals" do
-        @order.price_adjustment_totals["Foo"].should == Spree::Money.new(10)
-        @order.price_adjustment_totals["Bar"].should == Spree::Money.new(20)
+        @order.line_item_adjustment_totals["Foo"].should == Spree::Money.new(10)
+        @order.line_item_adjustment_totals["Bar"].should == Spree::Money.new(20)
       end
     end
 
@@ -76,20 +74,20 @@ describe Spree::Order do
       let(:adj3) { mock_model Spree::Adjustment, :amount => 40, :label => "Bar" }
 
       before do
-        @order.stub :price_adjustments => [adj1, adj2, adj3]
+        @order.stub_chain(:line_item_adjustments, :eligible => [adj1, adj2, adj3])
       end
 
       it "should return exactly two totals" do
-        @order.price_adjustment_totals.size.should == 2
+        @order.line_item_adjustment_totals.size.should == 2
       end
       it "should return the correct totals" do
-        @order.price_adjustment_totals["Foo"].should == Spree::Money.new(10)
-        @order.price_adjustment_totals["Bar"].should == Spree::Money.new(60)
+        @order.line_item_adjustment_totals["Foo"].should == Spree::Money.new(10)
+        @order.line_item_adjustment_totals["Bar"].should == Spree::Money.new(60)
       end
     end
   end
 
-  context "#price_adjustments" do
+  context "line item adjustments" do
     before do
       @order = Spree::Order.create!
       @order.stub :line_items => [line_item1, line_item2]
@@ -100,7 +98,7 @@ describe Spree::Order do
 
     context "when there are no line item adjustments" do
       it "should return nothing if line items have no adjustments" do
-        @order.price_adjustments.should be_empty
+        @order.line_item_adjustments.should be_empty
       end
     end
 
@@ -111,7 +109,7 @@ describe Spree::Order do
       end
 
       it "should return the adjustments for that line item" do
-         @order.price_adjustments.should =~ [@adj1, @adj2]
+         @order.line_item_adjustments.should =~ [@adj1, @adj2]
       end
     end
 
@@ -122,7 +120,7 @@ describe Spree::Order do
       end
 
       it "should return the adjustments for each line item" do
-        @order.price_adjustments.should == [@adj1, @adj2]
+        @order.line_item_adjustments.should == [@adj1, @adj2]
       end
     end
   end

--- a/core/spec/models/spree/tax_rate_spec.rb
+++ b/core/spec/models/spree/tax_rate_spec.rb
@@ -155,9 +155,9 @@ describe Spree::TaxRate do
         @order.adjustments.tax.charge.count.should == 0
       end
 
-      it "should not create a price adjustment" do
+      it "should not create a line item adjustment" do
         @rate.adjust(@order)
-        @order.price_adjustments.count.should == 0
+        @order.line_item_adjustments.count.should == 0
       end
 
       it "should not create a refund" do
@@ -177,7 +177,7 @@ describe Spree::TaxRate do
 
           it "should create one price adjustment" do
             @rate.adjust(@order)
-            @order.price_adjustments.count.should == 1
+            @order.line_item_adjustments.count.should == 1
           end
 
           it "should not create a tax refund" do
@@ -194,9 +194,9 @@ describe Spree::TaxRate do
         context "when zone is not contained by default tax zone" do
           before { Spree::Zone.stub_chain :default_tax, :contains? => false }
 
-          it "should not create a price adjustment" do
+          it "should not create a line item adjustment" do
             @rate.adjust(@order)
-            @order.price_adjustments.count.should == 0
+            @order.line_item_adjustments.count.should == 0
           end
 
           it "should create a tax refund" do
@@ -215,9 +215,9 @@ describe Spree::TaxRate do
       context "when price does not include tax" do
         before { @rate.included_in_price = false }
 
-        it "should not create price adjustment" do
+        it "should not create line item adjustment" do
           @rate.adjust(@order)
-          @order.price_adjustments.count.should == 0
+          @order.line_item_adjustments.count.should == 0
         end
 
         it "should not create a tax refund" do
@@ -240,7 +240,7 @@ describe Spree::TaxRate do
         @order.contents.add(@taxable2.master, 1)
       end
 
-      context "when price includes tax" do
+      context "when line item includes tax" do
         before { @rate.included_in_price = true }
 
         context "when zone is contained by default tax zone" do
@@ -248,7 +248,7 @@ describe Spree::TaxRate do
 
           it "should create multiple price adjustments" do
             @rate.adjust(@order)
-            @order.price_adjustments.count.should == 2
+            @order.line_item_adjustments.count.should == 2
           end
 
           it "should not create a tax refund" do
@@ -267,7 +267,7 @@ describe Spree::TaxRate do
 
           it "should not create a price adjustment" do
             @rate.adjust(@order)
-            @order.price_adjustments.count.should == 0
+            @order.line_item_adjustments.count.should == 0
           end
 
           it "should create a single tax refund" do
@@ -288,7 +288,7 @@ describe Spree::TaxRate do
 
         it "should not create a price adjustment" do
           @rate.adjust(@order)
-          @order.price_adjustments.count.should == 0
+          @order.line_item_adjustments.count.should == 0
         end
 
         it "should not create a tax refund" do


### PR DESCRIPTION
> It doesn't make sense to remove all line item adjustments from
> TaxRate#adjust. I'm not sure it makes sense to remove any adjustments at
> all. Spree calls order#create_tax_charge!, which in turn destroy all
> item adjustments, when:
> - creating orders
> - saving line items
> - after transition to order delivery state

Guys yesterday I finally started working on a promo line item adjustment extension. Most of the code I'm extracting from a highly customized Spree app. This is one of the points I've noticed while trying to make the code work on Spree edge. Please let me know your thoughts.

I believe we should definitely get rid of the agressive `order#clear_adjustments` in `TaxRate#adjust`. Maybe this could be the first step of a bigger refactoring. It doesn't sound right that a `order#create_tax_charge!` removes all tax charges before it create new ones. Looks confusing to me.
