### PR TITLE
Introduce attr items to OrderPopulator instance

### DIFF
--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -6,21 +6,22 @@ module Spree
       @order = order
     end
 
-    def add(variant, quantity, currency=nil, shipment=nil)
-      #get current line item for variant if exists
+    # Gets current line item for variant if exists
+    # Adds variant qty to line_item
+    # Returns the line_item created or updated
+    def add(variant, quantity, currency = nil, shipment = nil)
       line_item = order.find_line_item_by_variant(variant)
-
-      #add variant qty to line_item
       add_to_line_item(line_item, variant, quantity, currency, shipment)
     end
 
-    def remove(variant, quantity, shipment=nil)
-      #get current line item for variant
+    # Gets current line item for variant
+    # Updates item quantity or destroys it if quantity is 0
+    # Returns the line_item updated or destroyed
+    def remove(variant, quantity, shipment = nil)
       line_item = order.find_line_item_by_variant(variant)
-
-      #TODO raise exception if line_item is nil
-
-      #remove variant qty from line_item
+      unless line_item
+        raise ActiveRecord::RecordNotFound, "Line item not found for variant #{variant.sku}"
+      end
       remove_from_line_item(line_item, variant, quantity, shipment)
     end
 
@@ -64,6 +65,5 @@ module Spree
       order.reload
       line_item
     end
-
   end
 end

--- a/core/app/models/spree/order_populator.rb
+++ b/core/app/models/spree/order_populator.rb
@@ -1,10 +1,10 @@
 module Spree
   class OrderPopulator
     attr_accessor :order, :currency
-    attr_reader :errors
+    attr_reader :errors, :items
 
     def initialize(order, currency)
-      @order = order
+      @order, @items = order, []
       @currency = currency
       @errors = ActiveModel::Errors.new(self)
     end
@@ -47,7 +47,7 @@ module Spree
       variant = Spree::Variant.find(variant_id)
       if quantity > 0
         if check_stock_levels(variant, quantity)
-          @order.contents.add(variant, quantity, currency)
+          items << @order.contents.add(variant, quantity, currency)
         end
       end
     end

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -34,21 +34,29 @@ describe Spree::OrderContents do
   context "#remove" do
     let(:variant) { create(:variant) }
 
-    it 'should reduce line_item quantity if quantity is less the line_item quantity' do
+    context "given an invalid variant" do
+      it "raises an exception" do
+        expect {
+          subject.remove(variant, 1)
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    it 'reduces line_item quantity if quantity is less the line_item quantity' do
       line_item = subject.add(variant, 3)
       subject.remove(variant, 1)
 
       line_item.reload.quantity.should == 2
     end
 
-    it 'should remove line_item if quantity matches line_item quantity' do
+    it 'removes line_item if quantity matches line_item quantity' do
       subject.add(variant, 1)
       subject.remove(variant, 1)
 
       order.reload.find_line_item_by_variant(variant).should be_nil
     end
 
-    it "should update order totals" do
+    it "updates order totals" do
       order.item_total.to_f.should == 0.00
       order.total.to_f.should == 0.00
 
@@ -61,7 +69,5 @@ describe Spree::OrderContents do
       order.item_total.to_f.should == 19.99
       order.total.to_f.should == 19.99
     end
-
   end
-
 end

--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -49,7 +49,7 @@ module Spree
     def populate
       populator = Spree::OrderPopulator.new(current_order(true), current_currency)
       if populator.populate(params.slice(:products, :variants, :quantity))
-        fire_event('spree.cart.add')
+        fire_event('spree.cart.add', items: populator.items)
         fire_event('spree.order.contents_changed')
         respond_with(@order) do |format|
           format.html { redirect_to cart_path }

--- a/frontend/spec/controllers/spree/orders_controller_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_spec.rb
@@ -23,6 +23,7 @@ describe Spree::OrdersController do
       let(:populator) { double('OrderPopulator') }
       before do
         Spree::OrderPopulator.should_receive(:new).and_return(populator)
+        populator.should_receive(:items)
       end
 
       it "should handle single variant/quantity pair" do


### PR DESCRIPTION
And pass it to fire_event spree.cart.add call in
OrdersController#populate. It should help extensions to make better use
of that event since they will be able to access the order and the items
populated at the time of the event call
