### PR TITLE
Fix: Run update hooks when finalizing order

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -221,7 +221,7 @@ module Spree
     end
 
     def updater
-      OrderUpdater.new(self)
+      @updater ||= OrderUpdater.new(self)
     end
 
     def update!

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -382,11 +382,11 @@ module Spree
       adjustments.each { |adjustment| adjustment.update_column('locked', true) }
 
       # update payment and shipment(s) states, and save
-      updater = OrderUpdater.new(self)
       updater.update_payment_state
       shipments.each { |shipment| shipment.update!(self) }
       updater.update_shipment_state
       save
+      updater.run_hooks
 
       deliver_order_confirmation_email
 

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -34,6 +34,10 @@ module Spree
         :total => order.total
       })
 
+      run_hooks
+    end
+
+    def run_hooks
       update_hooks.each { |hook| order.send hook }
     end
 

--- a/core/spec/models/order_spec.rb
+++ b/core/spec/models/order_spec.rb
@@ -491,4 +491,28 @@ describe Spree::Order do
       end
     end
   end
+
+  context "add_update_hook" do
+    before do
+      Spree::Order.class_eval do
+        register_update_hook :add_awesome_sauce
+      end
+    end
+
+    after do
+      Spree::Order.update_hooks = Set.new
+    end
+
+    it "calls hook during update" do
+      order = create(:order)
+      order.should_receive(:add_awesome_sauce)
+      order.update!
+    end
+
+    it "calls hook during finalize" do
+      order = create(:order)
+      order.should_receive(:add_awesome_sauce)
+      order.finalize!
+    end
+  end
 end


### PR DESCRIPTION
When defining an update hook in the order model like this:

``` ruby
Spree::Order.class_eval do
  register_update_hook :do_stuff

  def do_stuff
    ...
  end
end
```

and later call `order.save` or `order.finalize`

**Expected** 

`do_stuff` should be called

**Actual**

`do_stuff` is only called during #update, but not #finalize
