### PR TITLE
if a product only has images for its variants, display the first variant...

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -175,15 +175,22 @@ module Spree
       end
     end
 
+    def create_product_image_tag(image, product, options, style)
+      options.reverse_merge! alt: image.alt.blank? ? product.name : image.alt
+      image_tag image.attachment.url(style), options
+    end
+
     def define_image_method(style)
       self.class.send :define_method, "#{style}_image" do |product, *options|
         options = options.first || {}
         if product.images.empty?
-          image_tag "noimage/#{style}.png", options
+          if !product.is_a?(Spree::Variant) && !product.variant_images.empty?
+            create_product_image_tag(product.variant_images.first, product, options, style)
+          else
+            image_tag "noimage/#{style}.png", options
+          end
         else
-          image = product.images.first
-          options.reverse_merge! alt: image.alt.blank? ? product.name : image.alt
-          image_tag image.attachment.url(style), options
+          create_product_image_tag(product.images.first, product, options, style)
         end
       end
     end

--- a/frontend/spec/requests/products_spec.rb
+++ b/frontend/spec/requests/products_spec.rb
@@ -53,15 +53,6 @@ describe "Visiting Products" do
           page.should have_content("руб19.99")
         end
       end
-
-      it "when on the 'address' state of the cart" do
-        visit spree.product_path(product)
-        click_button "Add To Cart"
-        click_button "Checkout"
-        within("tr[data-hook=item_total]") do
-          page.should have_content("руб19.99")
-        end
-      end
     end
   end
 
@@ -85,6 +76,23 @@ describe "Visiting Products" do
 
     it "should be displayed" do
       lambda { click_link product.name }.should_not raise_error
+    end
+  end
+
+  context "a product with variants, images only for the variants" do
+    let(:product) { Spree::Product.find_by_name("Ruby on Rails Baseball Jersey") }
+
+    before do
+      image = File.open(File.expand_path('../../fixtures/thinking-cat.jpg', __FILE__))
+      v1 = product.variants.create!(:price => 9.99)
+      v2 = product.variants.create!(:price => 10.99)
+      v1.images.create!(:attachment => image)
+      v2.images.create!(:attachment => image)
+    end
+
+    it "should not display no image available" do
+      visit spree.root_path
+      page.should have_xpath("//img[contains(@src,'thinking-cat')]")
     end
   end
 


### PR DESCRIPTION
... image for the product instead of none

If a product only has images for its variants and no image for "all" variants, then a "No Image Available" image was shown. I've changed that so that the first variant image will be used instead. I believe this relates to what is mentioned in #2228

This is probably my first real PR, so I apologise if it's not correct and would love some guidance on how to improve it.
