### PR TITLE
Add request spec to cover backend new order process

### DIFF
--- a/backend/app/views/spree/admin/payments/_list.html.erb
+++ b/backend/app/views/spree/admin/payments/_list.html.erb
@@ -2,7 +2,7 @@
   <thead>
     <tr data-hook="payments_header">
       <th><%= "#{Spree.t('date')}/#{Spree.t('time')}" %></th>
-      <th><%= Spree.t(:amount, :scope => 'activerecord.attributes.spree/payment') %></th>
+      <th><%= Spree.t(:amount) %></th>
       <th><%= Spree.t(:payment_method) %></th>
       <th><%= Spree.t(:payment_state) %></th>
       <th class="actions"></th>

--- a/backend/spec/requests/admin/configuration/shipping_methods_spec.rb
+++ b/backend/spec/requests/admin/configuration/shipping_methods_spec.rb
@@ -12,13 +12,11 @@ describe "Shipping Methods" do
 
     visit spree.admin_path
     click_link "Configuration"
+    click_link "Shipping Methods"
   end
 
-
   context "show" do
-    it "should display exisiting shipping methods" do
-      click_link "Shipping Methods"
-
+    it "should display existing shipping methods" do
       within_row(1) do
         column_text(1).should == shipping_method.name 
         column_text(2).should == zone.name
@@ -30,20 +28,22 @@ describe "Shipping Methods" do
 
   context "create" do
     it "should be able to create a new shipping method" do
-      click_link "Shipping Methods"
-      click_link "admin_new_shipping_method_link"
-      page.should have_content("New Shipping Method")
+      click_link "New Shipping Method"
+
       fill_in "shipping_method_name", :with => "bullock cart"
-      click_button "Create"
-      page.should have_content("successfully created!")
-      page.should have_content("Editing Shipping Method")
+
+      within("#shipping_method_categories_field") do
+        check first("input[type='checkbox']")["name"]
+      end
+
+      click_on "Create"
+      expect(current_path).to eql(spree.edit_admin_shipping_method_path(Spree::ShippingMethod.last))
     end
   end
 
   # Regression test for #1331
   context "update" do
     it "can change the calculator", :js => true do
-      click_link "Shipping Methods"
       within("#listing_shipping_methods") do
         click_icon :edit
       end
@@ -56,5 +56,4 @@ describe "Shipping Methods" do
       page.should_not have_content("Shipping method is not found")
     end
   end
-
 end

--- a/backend/spec/requests/admin/orders/new_order_spec.rb
+++ b/backend/spec/requests/admin/orders/new_order_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+describe "New Order" do
+  let!(:stock_location) { create(:stock_location_with_items) }
+  let!(:product) { create(:product) }
+  let!(:state) { create(:state) }
+  let!(:user) { create(:user) }
+  let!(:payment_method) { create(:payment_method) }
+  let!(:shipping_method) { create(:shipping_method) }
+  let!(:stock_item) { product.master.stock_items.first.adjust_count_on_hand(10) }
+
+  stub_authorization!
+
+  before do
+    visit spree.admin_path
+    click_on "Orders"
+    click_on "New Order"
+  end
+
+  it "completes new order succesfully", js: true do
+    select2_search product.name, :from => Spree.t(:name_or_sku)
+    click_icon :plus
+    click_on "Customer Details"
+
+    within "#select-customer" do
+      targetted_select2_search user.email, :from => "#s2id_customer_search"
+    end
+
+    check "order_use_billing"
+    fill_in_address
+    click_on "Update"
+
+    click_on "Payments"
+    click_on "Update"
+
+    expect(current_path).to eql(spree.edit_admin_order_path(Spree::Order.last))
+
+    click_on "Payments"
+    click_icon "capture"
+
+    click_on "Order Details"
+    click_on "ship"
+
+    page.should have_content("shipped")
+    sleep(1) # Otherwise it runs into locked db errors on DabataseCleaner.clean
+  end
+
+  def fill_in_address(kind = "bill")
+    fill_in "First Name",              :with => "John 99"
+    fill_in "Last Name",               :with => "Doe"
+    fill_in "Street Address",          :with => "100 first lane"
+    fill_in "Street Address (cont'd)", :with => "#101"
+    fill_in "City",                    :with => "Bethesda"
+    fill_in "Zip",                     :with => "20170"
+    targetted_select2_search state.name, :from => "#s2id_order_#{kind}_address_attributes_state_id"
+    fill_in "Phone",                   :with => "123-456-7890"
+  end
+end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -355,6 +355,7 @@ en:
     cannot_create_returns: Cannot create returns as this order has no shipped units.
     cannot_perform_operation: Cannot perform requested operation
     cannot_set_shipping_method_without_address: Cannot set shipping method until customer details are provided.
+    capture: Capture
     card_code: Card Code
     card_number: Card Number
     card_type_is: Card type is
@@ -420,6 +421,7 @@ en:
     current_promotion_usage: ! 'Current Usage: %{count}'
     customer: Customer
     customer_details: Customer Details
+    customer_details_updated: Customer Details Updated
     customer_search: Customer Search
     cut: Cut
     dash:


### PR DESCRIPTION
[Fixes #3000]

I had to add `sleep(1)` to the end of the new order request spec because I was getting odd errors about database locked. I'd appreciate if someone could check if the spec passes without that line. This is the error I ran into (or something very similar):

```
 Failure/Error: Unable to find matching line from backtrace
 ActiveRecord::StatementInvalid:
   SQLite3::BusyException: database is locked: DELETE FROM "shipping_methods_zones";
```

Also the current order details request spec takes about 9 min to run on my machine. I think some of them may not be necessary. It tests an action with one stock location then it tests the same action when there's two stock locations. Any special reason to keep these on the request spec context? please advise cc @LBRapid
