### PR TITLE
Delegate Spree.t to Rails TranslationHelper

### DIFF
--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -57,7 +57,7 @@
               <%= link_to '', '#', :class => 'save-item icon_link icon-ok no-text with-tip', :data => {'shipment-number' => shipment.number, 'variant-id' => item.variant.id, :action => 'save'}, :title => Spree.t('actions.save'), :style => 'display: none' %>
               <%= link_to '', '#', :class => 'cancel-item icon_link icon-cancel no-text with-tip', :data => {:action => 'cancel'}, :title => Spree.t('actions.cancel'), :style => 'display: none' %>
               <%= link_to '', '#', :class => 'edit-item icon_link icon-edit no-text with-tip', :data => {:action => 'edit'}, :title => Spree.t('edit') %>
-              <%= link_to '', '#', :class => 'delete-item icon-trash no-text with-tip', :data => {'shipment-number' => shipment.number, 'variant-id' => item.variant.id, :action => 'remove'}, :title => Spree.t('actions.delete') %>
+              <%= link_to '', '#', :class => 'delete-item icon-trash no-text with-tip', :data => {'shipment-number' => shipment.number, 'variant-id' => item.variant.id, :action => 'remove'}, :title => Spree.t(:delete) %>
             <% end %>
           </td>
         <% end %>

--- a/core/lib/spree/i18n.rb
+++ b/core/lib/spree/i18n.rb
@@ -2,11 +2,14 @@ require 'i18n'
 require 'active_support/core_ext/array/extract_options'
 
 module Spree
+  extend ActionView::Helpers::TranslationHelper
+
+  # Add spree namespace and delegate to Rails TranslationHelper for some nice
+  # extra functionality. e.g return reasonable strings for missing translations
   def self.t(*args)
     options = args.extract_options!
     options[:scope] = [*options[:scope]].unshift(:spree)
     args << options
-    I18n.t(*args)
+    super(*args)
   end
 end
-

--- a/core/spec/lib/i18n_spec.rb
+++ b/core/spec/lib/i18n_spec.rb
@@ -35,6 +35,10 @@ describe "i18n" do
     Spree.normal_t([:foo, 'bar.foo']).should eql(["bar", "bar within bar scope"])
   end
 
+  it "returns reasonable string for missing translations" do
+    Spree.t(:missing_entry).should include("<span")
+  end
+
   context "missed + unused translations" do
     def key_with_locale(key)
       "#{key} (#{I18n.locale})"

--- a/core/spec/mailers/order_mailer_spec.rb
+++ b/core/spec/mailers/order_mailer_spec.rb
@@ -84,34 +84,10 @@ describe Spree::OrderMailer do
   end
 
   context "emails must be translatable" do
-    context "en locale" do
-      before do
-        en_confirm_mail = { :order_mailer => { :confirm_email => { :dear_customer => 'Dear Customer,' } } }
-        en_cancel_mail = { :order_mailer => { :cancel_email => { :order_summary_canceled => 'Order Summary [CANCELED]' } } }
-        I18n.backend.store_translations :en, en_confirm_mail
-        I18n.backend.store_translations :en, en_cancel_mail
-        I18n.locale = :en
-      end
-
-      context "confirm_email" do
-        specify do
-          confirmation_email = Spree::OrderMailer.confirm_email(order)
-          confirmation_email.body.should include("Dear Customer,")
-        end
-      end
-
-      context "cancel_email" do
-        specify do
-          cancel_email = Spree::OrderMailer.cancel_email(order)
-          cancel_email.body.should include("Order Summary [CANCELED]")
-        end
-      end
-    end
-
     context "pt-BR locale" do
       before do
-        pt_br_confirm_mail = { :order_mailer => { :confirm_email => { :dear_customer => 'Caro Cliente,' } } }
-        pt_br_cancel_mail = { :order_mailer => { :cancel_email => { :order_summary_canceled => 'Resumo da Pedido [CANCELADA]' } } }
+        pt_br_confirm_mail = { :spree => { :order_mailer => { :confirm_email => { :dear_customer => 'Caro Cliente,' } } } }
+        pt_br_cancel_mail = { :spree => { :order_mailer => { :cancel_email => { :order_summary_canceled => 'Resumo da Pedido [CANCELADA]' } } } }
         I18n.backend.store_translations :'pt-BR', pt_br_confirm_mail
         I18n.backend.store_translations :'pt-BR', pt_br_cancel_mail
         I18n.locale = :'pt-BR'

--- a/core/spec/mailers/shipment_mailer_spec.rb
+++ b/core/spec/mailers/shipment_mailer_spec.rb
@@ -38,21 +38,9 @@ describe Spree::ShipmentMailer do
 
   context "emails must be translatable" do
     context "shipped_email" do
-      context "en locale" do
-        before do
-          en_shipped_email = { :shipment_mailer => { :shipped_email => { :dear_customer => 'Dear Customer,' } } }
-          I18n.backend.store_translations :en, en_shipped_email
-          I18n.locale = :en
-        end
-
-        specify do
-          shipped_email = Spree::ShipmentMailer.shipped_email(shipment)
-          shipped_email.body.should include("Dear Customer,")
-        end
-      end
       context "pt-BR locale" do
         before do
-          pt_br_shipped_email = { :shipment_mailer => { :shipped_email => { :dear_customer => 'Caro Cliente,' } } }
+          pt_br_shipped_email = { :spree => { :shipment_mailer => { :shipped_email => { :dear_customer => 'Caro Cliente,' } } } }
           I18n.backend.store_translations :'pt-BR', pt_br_shipped_email
           I18n.locale = :'pt-BR'
         end


### PR DESCRIPTION
This way we get all the nice features Rails t() helper offers, mainly
displaying reasonable strings for missing translations.

At this point core test suite should be all green. I've remove a couple
i18n specs which were translating to :en locale. I don't think that make
sense since :en is the default locale. Other translations specs pass now

As noticed in https://github.com/spree/spree/pull/2988#issuecomment-17526800 cc @radar looks good?
