### PR TITLE
Reload shipment after removing variant item via api

### DIFF
--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -73,7 +73,7 @@ module Spree
 
         @order.contents.remove(variant, quantity, @shipment)
 
-        respond_with(@shipment, :default_template => :show)
+        respond_with(@shipment.reload, :default_template => :show)
       end
 
       private

--- a/api/spec/controllers/spree/api/shipments_controller_spec.rb
+++ b/api/spec/controllers/spree/api/shipments_controller_spec.rb
@@ -91,28 +91,18 @@ describe Spree::Api::ShipmentsController do
 
     context 'for completed shipments' do
       let(:order) { create :completed_order_with_totals }
-
       let!(:resource_scoping) { { :order_id => order.to_param, :id => order.shipments.first.to_param } }
 
-      it 'can add a variant to a shipment' do
-        params = {
-          variant_id: variant.to_param,
-          quantity: 2
-        }
-        api_put :add, params
+      it 'adds a variant to a shipment' do
+        api_put :add, { variant_id: variant.to_param, quantity: 2 }
         response.status.should == 200
         json_response['inventory_units'].select { |h| h['variant_id'] == variant.id }.size.should == 2
       end
 
-      it 'can remove a variant from a shipment' do
+      it 'removes a variant from a shipment' do
         order.contents.add(variant, 2)
 
-        params = {
-          variant_id: variant.to_param,
-          quantity: 1
-        }
-
-        api_put :remove, params
+        api_put :remove, { variant_id: variant.to_param, quantity: 1 }
         response.status.should == 200
         json_response['inventory_units'].select { |h| h['variant_id'] == variant.id }.size.should == 1
      end

--- a/core/app/models/spree/order_inventory.rb
+++ b/core/app/models/spree/order_inventory.rb
@@ -6,36 +6,22 @@ module Spree
       @order = order
     end
 
-    def verify(line_item, shipment=nil)
-      # should only verify inventory for completed orders
-      # as carts have inventory assigned via create_proposed_shipment methh
-      #
-      # or when shipment is explicitly passed
+    # Only verify inventory for completed orders
+    # as carts have inventory assigned via create_proposed_shipment methh
+    #
+    # or when shipment is explicitly passed
+    def verify(line_item, shipment = nil)
       if order.completed? || shipment.present?
 
         variant_units = inventory_units_for(line_item.variant)
 
         if variant_units.size < line_item.quantity
-          #add
           quantity = line_item.quantity - variant_units.size
 
           shipment = determine_target_shipment(line_item.variant) unless shipment
-
           add_to_shipment(shipment, line_item.variant, quantity)
-
-        elsif  !shipment.present? && variant_units.size > line_item.quantity
-          #remove
-          quantity = variant_units.size - line_item.quantity
-
-          order.shipments.each do |shipment|
-            break if quantity == 0
-
-            quantity -= remove_from_shipment(shipment, line_item.variant, quantity)
-          end
-
-        elsif shipment.present? && variant_units.size > line_item.quantity
-          quantity = variant_units.size - line_item.quantity
-          quantity -= remove_from_shipment(shipment, line_item.variant, quantity)
+        elsif variant_units.size > line_item.quantity
+          remove(line_item, variant_units, shipment)
         end
       else
         true
@@ -48,16 +34,32 @@ module Spree
     end
 
     private
+    def remove(line_item, variant_units, shipment = nil)
+      quantity = variant_units.size - line_item.quantity
 
+      if shipment.present?
+        remove_from_shipment(shipment, line_item.variant, quantity)
+      else
+        order.shipments.each do |shipment|
+          break if quantity == 0
+          quantity -= remove_from_shipment(shipment, line_item.variant, quantity)
+        end
+      end
+    end
+
+    # Returns either one of the shipment:
+    #
+    # first unshipped that already includes this variant
+    # first unshipped that's leaving from a stock_location that stocks this variant
+    #
     def determine_target_shipment(variant)
-      # get first unshipped shipment that already includes this variant
-      shipment = order.shipments.detect { |shipment| (shipment.ready? || shipment.pending?) && shipment.include?(variant) }
+      shipment = order.shipments.detect do |shipment|
+        (shipment.ready? || shipment.pending?) && shipment.include?(variant)
+      end
 
-      # get first unshipped shipment that's leaving from the a stock_location that stocks this variant
-      shipment ||= order.shipments.detect { |shipment| (shipment.ready? || shipment.pending?) && variant.stock_location_ids.include?(shipment.stock_location_id) }
-
-      # ship it!
-      shipment
+      shipment ||= order.shipments.detect do |shipment|
+        (shipment.ready? || shipment.pending?) && variant.stock_location_ids.include?(shipment.stock_location_id)
+      end
     end
 
     def add_to_shipment(shipment, variant, quantity)
@@ -107,6 +109,5 @@ module Spree
       # return quantity removed
       removed_quantity
     end
-
   end
 end


### PR DESCRIPTION
Fix broken spec on api build. The item was being removed properly but
the controller still returned the old obj instead of the new one with
the item removed

This should green the api build for both 1.9 and 2.0
