### PR TITLE
Force select2-rails to 3.2.1

### DIFF
--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -72,8 +72,8 @@ module Spree
         quantity = params[:quantity].to_i
 
         @order.contents.remove(variant, quantity, @shipment)
-
-        respond_with(@shipment.reload, :default_template => :show)
+        @shipment.reload if @shipment.persisted?
+        respond_with(@shipment, :default_template => :show)
       end
 
       private

--- a/backend/spec/requests/admin/configuration/shipping_methods_spec.rb
+++ b/backend/spec/requests/admin/configuration/shipping_methods_spec.rb
@@ -49,7 +49,7 @@ describe "Shipping Methods" do
       end
 
       find(:css, ".calculator-settings-warning").should_not be_visible
-      select('Flexible Rate', :from => 'calc_type')
+      select2_search('Flexible Rate', :from => 'Calculator')
       find(:css, ".calculator-settings-warning").should be_visible
 
       click_button "Update"

--- a/backend/spree_backend.gemspec
+++ b/backend/spree_backend.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_api', version
 
   s.add_dependency 'jquery-rails', '~> 2.0'
-  s.add_dependency 'select2-rails', '~> 3.2'
+  s.add_dependency 'select2-rails', '3.2.1'
 
   s.add_dependency 'rails', '~> 3.2.8'
   s.add_dependency 'deface', '>= 0.9.0'

--- a/frontend/spree_frontend.gemspec
+++ b/frontend/spree_frontend.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_api', version
 
   s.add_dependency 'jquery-rails', '~> 2.2.1'
-  s.add_dependency 'select2-rails', '~> 3.2'
+  s.add_dependency 'select2-rails', '3.2.1'
 
   s.add_dependency 'rails', '~> 3.2.13'
   s.add_dependency 'deface', '>= 0.9.0'


### PR DESCRIPTION
select2-rails 3.2.2 breaks all capybara helpers in Spree that depends on
the label tag for attribute. e.g.

```
<%= label_tag :add_variant_id, Spree.t(:name_or_sku) %>

Instead of:

<label for="s2id_add_variant_id">some text</label>

will generate:

<label for="s2id_autogen1">some text</label>
```

see https://github.com/ivaynberg/select2/commit/519070b11da9347cf1542d26fc59a83b0c3fd934

wtf select2 ..

Most of backend request specs were failing due to this
