### PR TITLE
Force select2-rails to 3.2.1

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'awesome_nested_set', '2.1.5'
 
   s.add_dependency 'jquery-rails', '~> 2.2.0'
-  s.add_dependency 'select2-rails', '~> 3.2'
+  s.add_dependency 'select2-rails', '3.2.1'
 
   s.add_dependency 'highline', '= 1.6.18'
   s.add_dependency 'state_machine', '= 1.1.2'


### PR DESCRIPTION
select2-rails 3.2.2 breaks all capybara helpers in Spree that depends on
the label tag for attribute. e.g.

```
<%= label_tag :add_variant_id, Spree.t(:name_or_sku) %>

Instead of:

<label for="s2id_add_variant_id">some text</label>

will generate:

<label for="s2id_autogen1">some text</label>
```

see https://github.com/ivaynberg/select2/commit/519070b11da9347cf1542d26fc59a83b0c3fd934

wtf select2 ..

Fix request specs
