### PR TITLE
Prevent adding items without stock via admin UI

### DIFF
--- a/api/app/views/spree/api/variants/index.v1.rabl
+++ b/api/app/views/spree/api/variants/index.v1.rabl
@@ -16,6 +16,7 @@ child(@variants => :variants) do
 
   child(:stock_items) do
     attributes :id, :count_on_hand, :stock_location_id, :backorderable
+    attribute :available? => :available
 
     glue(:stock_location) do
       attribute :name => :stock_location_name

--- a/backend/app/views/spree/admin/variants/_autocomplete.js.erb
+++ b/backend/app/views/spree/admin/variants/_autocomplete.js.erb
@@ -48,18 +48,21 @@
           {{#each variant.stock_items}}
             <tr>
               <td>{{this.stock_location_name}}</td>
-              <td>
-                {{this.count_on_hand}}
-                {{#if this.backorderable}}
-                  (backorders allowed)
-                {{/if}}
-              </td>
-              <td>
-                <input class="quantity" id="stock_item_quantity" data-stock-location-id="{{this.stock_location_id}}" type="number" min="1" value="1">
-              </td>
-              <td class="actions">
-                <button class="add_variant no-text icon-plus icon_link with-tip" data-stock-location-id="{{this.stock_location_id}}" title="Add" data-action="add"></button>
-              </td>
+              {{#if this.available}}
+                <td>
+                  {{this.count_on_hand}}
+                  {{#if this.backorderable}} (backorders allowed) {{/if}}
+                </td>
+                <td>
+                  <input class="quantity" id="stock_item_quantity" data-stock-location-id="{{this.stock_location_id}}" type="number" min="1" value="1">
+                </td>
+                <td class="actions">
+                  <button class="add_variant no-text icon-plus icon_link with-tip" data-stock-location-id="{{this.stock_location_id}}" title="Add" data-action="add"></button>
+                </td>
+              {{else}}
+                <td><%= Spree.t(:out_of_stock) %></td>
+                <td>0</td>
+              {{/if}}
             </tr>
           {{/each}}
         </tbody>

--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -33,6 +33,11 @@ module Spree
       self.count_on_hand > 0
     end
 
+    # Tells whether it's available to be included in a shipment
+    def available?
+      self.in_stock? || self.backorderable?
+    end
+
     private
     def count_on_hand=(value)
       write_attribute(:count_on_hand, value)

--- a/core/spec/models/spree/stock_item_spec.rb
+++ b/core/spec/models/spree/stock_item_spec.rb
@@ -2,9 +2,10 @@ require 'spec_helper'
 
 describe Spree::StockItem do
   let(:stock_location) { create(:stock_location_with_items) }
+
   subject { stock_location.stock_items.order(:id).first }
 
-  it 'maintains the count on hand for a varaint' do
+  it 'maintains the count on hand for a variant' do
     subject.count_on_hand.should eq 10
   end
 
@@ -21,6 +22,26 @@ describe Spree::StockItem do
 
   it "can return the stock item's variant's name" do
     subject.variant_name.should == subject.variant.name
+  end
+
+  context "available to be included in shipment" do
+    context "has stock" do
+      it { subject.should be_available }
+    end
+
+    context "backorderable" do
+      before { subject.backorderable = true }
+      it { subject.should be_available }
+    end
+
+    context "no stock and not backorderable" do
+      before do
+        subject.backorderable = false
+        subject.stub(count_on_hand: 0)
+      end
+
+      it { subject.should_not be_available }
+    end
   end
 
   context "count_on_hand=" do
@@ -57,4 +78,3 @@ describe Spree::StockItem do
     end
   end
 end
-


### PR DESCRIPTION
If stock item on hand is 0 and it doesn't allow backordering admin
shouldn't be able to add the product

[Fixes #2998]
