### PR TITLE
View product link

### DIFF
--- a/backend/app/views/spree/admin/shared/_product_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_product_tabs.html.erb
@@ -24,6 +24,9 @@
       <li<%== ' class="active"' if current == 'Stock Management' %>>
         <%= link_to_with_icon 'icon-tasks', Spree.t(:stock_management), stock_admin_product_url(@product) %>
       </li>
+      <li>
+        <%= link_to_with_icon 'icon-external-link', Spree.t(:view_product), product_url(@product), target: "_blank" %>
+      </li>
     </ul>
   </nav>
 


### PR DESCRIPTION
It would be nice to be able to view a product directly from the product admin. Added a new "View Product" link to the side nav.

![0ma5](https://f.cloud.github.com/assets/4784/508981/60859992-bd97-11e2-9149-68f676e50dd4.png)
