### PR TITLE
Add backorderable default config to StockLocation

### DIFF
--- a/backend/app/views/spree/admin/stock_locations/_form.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/_form.html.erb
@@ -14,6 +14,10 @@
             <%= f.label :active, Spree.t(:active) + ':' %>
             <%= f.check_box :active %>
           </li>
+          <li>
+            <%= f.label :active, Spree.t(:backorderable_default) + ':' %>
+            <%= f.check_box :backorderable_default %>
+          </li>
         </ul>
       <% end %>
     </div>

--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -9,7 +9,8 @@ module Spree
     validates_presence_of :name
 
     attr_accessible :name, :active, :address1, :address2, :city, :zipcode,
-                    :state_name, :state_id, :country_id, :phone, :country_id
+        :backorderable_default, :state_name, :state_id, :country_id, :phone,
+        :country_id
 
     scope :active, -> { where(active: true) }
 
@@ -55,10 +56,9 @@ module Spree
     end
 
     private
-
       def create_stock_items
         Spree::Variant.find_each do |v|
-          self.stock_items.create!(variant: v)
+          self.stock_items.create!(variant: v, backorderable: self.backorderable_default)
         end
       end
   end

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -173,7 +173,7 @@ module Spree
 
       def create_stock_items
         Spree::StockLocation.all.each do |stock_location|
-          stock_location.stock_items.create!(variant: self)
+          stock_location.stock_items.create!(variant: self, backorderable: stock_location.backorderable_default)
         end
       end
 

--- a/core/db/migrate/20130515180736_add_backorderable_default_to_spree_stock_location.rb
+++ b/core/db/migrate/20130515180736_add_backorderable_default_to_spree_stock_location.rb
@@ -1,0 +1,5 @@
+class AddBackorderableDefaultToSpreeStockLocation < ActiveRecord::Migration
+  def change
+    add_column :spree_stock_locations, :backorderable_default, :boolean, default: true
+  end
+end

--- a/core/spec/models/spree/stock_location_spec.rb
+++ b/core/spec/models/spree/stock_location_spec.rb
@@ -2,16 +2,31 @@ require 'spec_helper'
 
 module Spree
   describe StockLocation do
-    subject { create(:stock_location_with_items) }
+    subject { create(:stock_location_with_items, backorderable_default: true) }
     let(:stock_item) { subject.stock_items.order(:id).first }
     let(:variant) { stock_item.variant }
 
-    before(:each) do
-      Spree::StockLocation.delete_all
-    end
-
     it 'creates stock_items for all variants' do
       subject.stock_items.count.should eq Variant.count
+    end
+
+    context "backorderable default" do
+      let(:stock_items) { subject.stock_items }
+
+      context "true" do
+        it 'sets stock items backorderable true as well' do
+          stock_items.map(&:backorderable).first.should be_true
+        end
+      end
+
+      context "false" do
+        let(:stock_location) { StockLocation.create(name: "testing", backorderable_default: false) }
+        let(:stock_items) { stock_location.stock_items }
+
+        it 'sets stock items backorderable false' do
+          stock_items.map(&:backorderable).first.should be_false
+        end
+      end
     end
 
     it 'finds a stock_item for a variant' do
@@ -113,4 +128,3 @@ module Spree
     end
   end
 end
-

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -18,13 +18,23 @@ describe Spree::Variant do
   end
 
   context "after create" do
-    it "should create a stock item for the variant for each stock location" do
-      Spree::StockLocation.delete_all # FIXME leaky database
-      Spree::StockLocation.create(:name => "Default")
-      product = create(:product)
-      lambda {
-        product.variants.create(:name => "Foobar")
-      }.should change(Spree::StockItem, :count).by(1)
+    context "stock items" do
+      let!(:product) { create(:product) }
+
+      it "creates a new record" do
+        lambda {
+          product.variants.create(:name => "Foobar")
+        }.should change(Spree::StockItem, :count).by(1)
+      end
+
+      context "backorderable" do
+        let!(:stock_location) { Spree::StockLocation.create(:name => "Default", backorderable_default: false) }
+        let(:variant) { product.variants.create(:name => "Foobar") }
+
+        it "sets backorderable based on the stock location config" do
+          stock_location.backorderable?(variant).should be_false
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Stock items backorderable values will be set according to this config
every time either a variant or a stock location is created
