### PR TITLE
Shipping rate now uses display price on checkout

### DIFF
--- a/frontend/app/views/spree/checkout/_delivery.html.erb
+++ b/frontend/app/views/spree/checkout/_delivery.html.erb
@@ -42,7 +42,7 @@
                 <label>
                   <%= ship_form.radio_button :selected_shipping_rate_id, rate.id %>
                   <span class="rate-name"><%= rate.name %></span>
-                  <span class="rate-cost"><%= number_to_currency rate.cost %></span>
+                  <span class="rate-cost"><%= rate.display_price %></span>
                 </label>
               </li>
             <% end %>


### PR DESCRIPTION
On checkout shipping rates are only being displayed in the locale currency independent of the store/rate setting. The view now uses the existing `display_price` method.
