### PR TITLE
Remove leftovers allow_backorders references

### DIFF
--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -25,7 +25,6 @@ module Spree
     preference :admin_interface_logo, :string, default: 'admin/bg/spree_50.png'
     preference :admin_products_per_page, :integer, default: 10
     preference :allow_backorder_shipping, :boolean, default: false # should only be true if you don't need to track inventory
-    preference :allow_backorders, :boolean, default: true
     preference :allow_checkout_on_gateway_error, :boolean, default: false
     preference :allow_guest_checkout, :boolean, default: true
     preference :allow_ssl_in_development_and_test, :boolean, default: false

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -3,9 +3,6 @@ require 'spec_helper'
 describe Spree::LineItem do
   let(:order) { create :order_with_line_items, line_items_count: 1 }
   let(:line_item) { order.line_items.first }
-  before do
-    Spree::Config.set :allow_backorders => true
-  end
 
   context '#save' do
     it 'should update inventory, totals, and tax' do

--- a/core/spec/models/spree/order_populator_spec.rb
+++ b/core/spec/models/spree/order_populator_spec.rb
@@ -32,10 +32,8 @@ describe Spree::OrderPopulator do
       end
 
       # Regression test for #2430
-      context "respects allow_backorders setting" do
+      context "respects backorderable setting" do
         before do
-          Spree::Config[:allow_backorders] = true
-          # Variant is available due to allow_backorders
           Spree::Stock::Quantifier.any_instance.stub(can_supply?: true)
         end
 


### PR DESCRIPTION
Backorders can be configured now as per stock location or stock item
