### PR TITLE
Add propagate variants config to StockLocation

### DIFF
--- a/backend/app/views/spree/admin/stock_locations/_form.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/_form.html.erb
@@ -18,6 +18,10 @@
             <%= f.label :active, Spree.t(:backorderable_default) + ':' %>
             <%= f.check_box :backorderable_default %>
           </li>
+          <li>
+            <%= f.label :active, Spree.t(:propagate_all_variants) + ':' %>
+            <%= f.check_box :propagate_all_variants %>
+          </li>
         </ul>
       <% end %>
     </div>

--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -10,11 +10,15 @@ module Spree
 
     attr_accessible :name, :active, :address1, :address2, :city, :zipcode,
         :backorderable_default, :state_name, :state_id, :country_id, :phone,
-        :country_id
+        :country_id, :propagate_all_variants
 
     scope :active, -> { where(active: true) }
 
-    after_create :create_stock_items
+    after_create :create_stock_items, :if => "self.propagate_all_variants?"
+
+    def propagate_variant(variant)
+      self.stock_items.create!(variant: variant, backorderable: self.backorderable_default)
+    end
 
     def stock_item(variant)
       stock_items.where(variant_id: variant).order(:id).first
@@ -57,9 +61,7 @@ module Spree
 
     private
       def create_stock_items
-        Spree::Variant.find_each do |v|
-          self.stock_items.create!(variant: v, backorderable: self.backorderable_default)
-        end
+        Variant.find_each { |variant| self.propagate_variant(variant) }
       end
   end
 end

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -172,8 +172,8 @@ module Spree
       end
 
       def create_stock_items
-        Spree::StockLocation.all.each do |stock_location|
-          stock_location.stock_items.create!(variant: self, backorderable: stock_location.backorderable_default)
+        StockLocation.all.each do |stock_location|
+          stock_location.propagate_variant(self) if stock_location.propagate_all_variants?
         end
       end
 

--- a/core/db/migrate/20130516151222_add_propage_all_variants_to_spree_stock_location.rb
+++ b/core/db/migrate/20130516151222_add_propage_all_variants_to_spree_stock_location.rb
@@ -1,0 +1,5 @@
+class AddPropageAllVariantsToSpreeStockLocation < ActiveRecord::Migration
+  def change
+    add_column :spree_stock_locations, :propagate_all_variants, :boolean, default: true
+  end
+end

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -18,23 +18,11 @@ describe Spree::Variant do
   end
 
   context "after create" do
-    context "stock items" do
-      let!(:product) { create(:product) }
+    let!(:product) { create(:product) }
 
-      it "creates a new record" do
-        lambda {
-          product.variants.create(:name => "Foobar")
-        }.should change(Spree::StockItem, :count).by(1)
-      end
-
-      context "backorderable" do
-        let!(:stock_location) { Spree::StockLocation.create(:name => "Default", backorderable_default: false) }
-        let(:variant) { product.variants.create(:name => "Foobar") }
-
-        it "sets backorderable based on the stock location config" do
-          stock_location.backorderable?(variant).should be_false
-        end
-      end
+    it "propagate to stock items" do
+      Spree::StockLocation.any_instance.should_receive(:propagate_variant)
+      product.variants.create(:name => "Foobar")
     end
   end
 


### PR DESCRIPTION
Every time either a new stock location or new variant is created the
stock_location##propagate_all_variants value will be checked to decide
whether new stock items should be created for the new stock location or
variant

I think we still need to either improve the Stock Location form UI to inform users how that config works or update the guides about this change.
