### PR TITLE
Fix wrong discount calculation with flat percent promotions

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -62,7 +62,7 @@ module Spree
     end
 
     has_many :return_authorizations, dependent: :destroy
-    has_many :adjustments, as: :adjustable, dependent: :destroy, order: 'created_at ASC'
+    has_many :adjustments, as: :adjustable, dependent: :destroy, order: 'created_at ASC', inverse_of: :source
 
     accepts_nested_attributes_for :line_items
     accepts_nested_attributes_for :bill_address

--- a/frontend/spec/requests/promotion_adjustments_spec.rb
+++ b/frontend/spec/requests/promotion_adjustments_spec.rb
@@ -6,7 +6,7 @@ describe "Promotion adjustments", :js => true do
   let!(:zone) { create(:zone) }
   let!(:shipping_method) { create(:shipping_method) }
   let!(:payment_method) { create(:payment_method) }
-  let!(:product) { create(:product, :name => "RoR Mug") }
+  let!(:product) { create(:product, :name => "RoR Mug", :price => 20) }
 
   context "visitor makes checkout as guest without registration" do
     def create_basic_coupon_promotion(code)
@@ -144,6 +144,38 @@ describe "Promotion adjustments", :js => true do
         fill_in "order_coupon_code", :with => "onetwo"
         click_button "Update"
         page.should have_content(Spree.t(:coupon_code_expired))
+      end
+
+      context "calculates the correct amount of money saved with flat percent promotions" do
+        before do
+          calculator = Spree::Calculator::FlatPercentItemTotal.new
+          calculator.preferred_flat_percent = 20
+          promotion.actions.first.calculator = calculator
+          promotion.save
+
+          create(:product, :name => "Spree Mug", :price => 10)
+        end
+
+        specify do
+          visit spree.root_path
+          click_link "Spree Mug"
+          click_button "add-to-cart-button"
+
+          visit spree.cart_path
+          fill_in "order_coupon_code", :with => "onetwo"
+          click_button "Update"
+
+          fill_in "order_line_items_attributes_0_quantity", :with => 2
+          fill_in "order_line_items_attributes_1_quantity", :with => 2
+          click_button "Update"
+
+          within '#cart_adjustments' do
+            page.should have_content("Promotion (Onetwo) $-12.00")
+          end
+          within '.order-total' do
+            page.should have_content("$48.00")
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Fix wrong discount calculation with flat percent promotions when there are more than one line item in the order.

This error happened because the order instance here:
https://github.com/spree/spree/blob/master/core/app/models/spree/order_updater.rb#L24

is not always the same instance in memory here:
https://github.com/spree/spree/blob/master/core/app/models/spree/calculator/flat_percent_item_total.rb#L15

Adding the inverse option to the relationship makes sure you have the same object instance in both places.
