### PR TITLE
Do not build packages for missing items

### DIFF
--- a/core/app/models/spree/stock/packer.rb
+++ b/core/app/models/spree/stock/packer.rb
@@ -16,6 +16,8 @@ module Spree
       def default_package
         package = Package.new(stock_location, order)
         order.line_items.each do |line_item|
+          next unless stock_location.stock_item(line_item.variant)
+
           on_hand, backordered = stock_location.fill_status(line_item.variant, line_item.quantity)
           package.add line_item.variant, on_hand, :on_hand if on_hand > 0
           package.add line_item.variant, backordered, :backordered if backordered > 0
@@ -34,4 +36,3 @@ module Spree
     end
   end
 end
-

--- a/core/spec/models/spree/stock/coordinator_spec.rb
+++ b/core/spec/models/spree/stock/coordinator_spec.rb
@@ -3,26 +3,31 @@ require 'spec_helper'
 module Spree
   module Stock
     describe Coordinator do
-      let(:package) { build(:stock_package_fulfilled) }
-      let(:order) { package.order }
-      let(:stock_location) { package.stock_location }
+      let!(:order) { create(:order_with_line_items) }
 
       subject { Coordinator.new(order) }
 
-      before :all do
-        Rails.application.config.spree.stock_splitters = [
-         Spree::Stock::Splitter::Backordered,
-         Spree::Stock::Splitter::ShippingCategory
-        ]
+      context "packages" do
+        it "builds, prioritizes and estimates" do
+          subject.should_receive(:build_packages).ordered
+          subject.should_receive(:prioritize_packages).ordered
+          subject.should_receive(:estimate_packages).ordered
+          subject.packages
+        end
       end
 
-      it 'builds a list of packages for an order' do
-        StockLocation.should_receive(:active).and_return([stock_location])
-        subject.should_receive(:build_packer).and_return(double(:packages => [package]))
-        Estimator.any_instance.should_receive(:shipping_rates).and_return([])
+      context "build packages" do
+        it "builds a package for every stock location" do
+          subject.packages.count == StockLocation.count
+        end
 
-        packages = subject.packages
-        packages.count.should == 1
+        context "missing stock items in stock location" do
+          let!(:another_location) { create(:stock_location, propagate_all_variants: false) }
+
+          it "builds packages only for valid stock locations" do
+            subject.build_packages.count.should == (StockLocation.count - 1)
+          end
+        end
       end
     end
   end

--- a/core/spec/models/spree/stock/packer_spec.rb
+++ b/core/spec/models/spree/stock/packer_spec.rb
@@ -4,7 +4,7 @@ module Spree
   module Stock
     describe Packer do
       let(:order) { create(:order_with_line_items, line_items_count: 5) }
-      let(:stock_location) { mock_model(StockLocation, fill_status: [20, 0]) }
+      let(:stock_location) { create(:stock_location) }
 
       subject { Packer.new(stock_location, order) }
 
@@ -25,12 +25,21 @@ module Spree
 
         it 'variants are added as backordered without enough on_hand' do
           stock_location.should_receive(:fill_status).exactly(5).times.and_return([2,3])
+
           package = subject.default_package
           package.on_hand.size.should eq 5
           package.backordered.size.should eq 5
+        end
+
+        context "location doesn't have order items in stock" do
+          let(:stock_location) { create(:stock_location, propagate_all_variants: false) }
+          let(:packer) { Packer.new(stock_location, order) }
+
+          it "builds an empty package" do
+            packer.default_package.contents.should be_empty
+          end
         end
       end
     end
   end
 end
-


### PR DESCRIPTION
When building shipment packages Spree assumed that every order item had
an existing stock item in all stock locations. But that may not always
be the case since the `propagate_all_variants` config was added to
StockLocation in #3050

I think we should move forward with this. Spree should be smart enough
to figure out which order items exist in which stock locations.
Honestly I don't like the implementation of this fix but it was the only
one I could come up with for now.

This issue was brought in #3051. So we need to figure out it first to
only then merge that PR.

Another possible fix for this would be to add a `stock_location.build_packages(order)` method. That may be a lot cleaner and easier to understand imo. I just didn't go for that _yet_ because I'm still confused by the current implementation and I think many pieces would have to move.
