### PR TITLE
Use Spree.url() to build taxonomies jstree urls

### DIFF
--- a/backend/app/assets/javascripts/admin/taxonomy.js.coffee
+++ b/backend/app/assets/javascripts/admin/taxonomy.js.coffee
@@ -70,11 +70,12 @@ handle_delete = (e, data) ->
 root = exports ? this
 root.setup_taxonomy_tree = (taxonomy_id) ->
   if taxonomy_id != undefined
+    # this is defined within admin/taxonomies/edit
+    root.base_url = Spree.url(Spree.routes.taxonomy_taxons_path)
+
     $.ajax
-      url: '/api/taxonomies/' + taxonomy_id + '/jstree', 
+      url: base_url.path().replace("/taxons", "/jstree"),
       success: (taxonomy) ->
-        # this is defined within admin/taxonomies/edit
-        root.base_url = Spree.url(Spree.routes.taxonomy_taxons_path)
         last_rollback = null
 
         conf =
@@ -82,7 +83,7 @@ root.setup_taxonomy_tree = (taxonomy_id) ->
             data: taxonomy,
             ajax:
               url: (e) ->
-                '/api/taxonomies/' + taxonomy_id + '/taxons/' + e.attr('id') + '/jstree'
+                base_url.path() + '/' + e.attr('id') + '/jstree'
           themes:
             theme: "apple",
             url: "/assets/jquery.jstree/themes/apple/style.css"


### PR DESCRIPTION
URLs were hardcoded which caused errors when users mounted Spree in a
path other then "/"

[Fixes #3070]

This one should probably go to master and 2-0-stable
