### PR TITLE
Allow users to easily override zipcode validation

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -5,7 +5,8 @@ module Spree
 
     has_many :shipments
 
-    validates :firstname, :lastname, :address1, :city, :zipcode, :country, presence: true
+    validates :firstname, :lastname, :address1, :city, :country, presence: true
+    validates :zipcode, presence: true, if: :require_zipcode?
     validates :phone, presence: true, if: :require_phone?
 
     validate :state_validate
@@ -87,8 +88,11 @@ module Spree
     end
 
     private
-
       def require_phone?
+        true
+      end
+
+      def require_zipcode?
         true
       end
 
@@ -128,6 +132,5 @@ module Spree
         # ensure at least one state field is populated
         errors.add :state, :blank if state.blank? && state_name.blank?
       end
-
   end
 end

--- a/core/spec/models/spree/address_spec.rb
+++ b/core/spec/models/spree/address_spec.rb
@@ -125,23 +125,37 @@ describe Spree::Address do
       address.should be_valid
     end
 
-    it "phone is set" do
-      address.phone = "123"
-      address.should have(:no).errors_on(:phone)
-    end
-
-    it "phone is blank" do
+    it "requires phone" do
       address.phone = ""
       address.valid?
       address.errors["phone"].should == ["can't be blank"]
     end
 
-    it "require_phone? returns false and phone is blank" do
-      address.instance_eval{ self.stub :require_phone? => false }
-      address.phone = ""
-      address.should have(:no).errors_on(:phone)
+    it "requires zipcode" do
+      address.zipcode = ""
+      address.valid?
+      address.should have(1).error_on(:zipcode)
     end
 
+    context "phone not required" do
+      before { address.instance_eval{ self.stub :require_phone? => false } }
+
+      it "shows no errors when phone is blank" do
+        address.phone = ""
+        address.valid?
+        address.should have(:no).errors_on(:phone)
+      end
+    end
+
+    context "zipcode not required" do
+      before { address.instance_eval{ self.stub :require_zipcode? => false } }
+
+      it "shows no errors when phone is blank" do
+        address.zipcode = ""
+        address.valid?
+        address.should have(:no).errors_on(:zipcode)
+      end
+    end
   end
 
   context ".default" do


### PR DESCRIPTION
Just like it's already done with the phone field

[Fixes #3065]
