### PR TITLE
Updated RubyGems version to 1.8.23 so that Heroku can host it.

### DIFF
--- a/spree.gemspec
+++ b/spree.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
   s.required_ruby_version     = '>= 1.9.3'
-  s.required_rubygems_version = '>= 1.8.25'
+  s.required_rubygems_version = '>= 1.8.23'
 
   s.author       = 'Sean Schofield'
   s.email        = 'sean@spreecommerce.com'


### PR DESCRIPTION
See details in this issue: https://github.com/spree/spree/issues/3076#issuecomment-18364208
