### PR TITLE
Symbolize attachment styles keys on controller

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -1,3 +1,7 @@
 ## Spree 2.1.0 (unreleased) ##
 
-* No changes.
+*   Symbolize attachment style keys on ImageSettingController otherwise users
+    would get *undefined method `processors' for "48x48>":String>* since
+    paperclip can't handle key strings.
+
+    *Washington Luiz*

--- a/backend/app/controllers/spree/admin/image_settings_controller.rb
+++ b/backend/app/controllers/spree/admin/image_settings_controller.rb
@@ -21,7 +21,6 @@ module Spree
         end
       end
 
-
       private
 
       def update_styles(params)
@@ -55,7 +54,7 @@ module Spree
           Spree::Image.attachment_definitions[:attachment].delete :storage
         end
 
-        Spree::Image.attachment_definitions[:attachment][:styles] = ActiveSupport::JSON.decode(Spree::Config[:attachment_styles])
+        Spree::Image.attachment_definitions[:attachment][:styles] = ActiveSupport::JSON.decode(Spree::Config[:attachment_styles]).symbolize_keys!
         Spree::Image.attachment_definitions[:attachment][:path] = Spree::Config[:attachment_path]
         Spree::Image.attachment_definitions[:attachment][:default_url] = Spree::Config[:attachment_default_url]
         Spree::Image.attachment_definitions[:attachment][:default_style] = Spree::Config[:attachment_default_style]
@@ -63,4 +62,3 @@ module Spree
     end
   end
 end
-

--- a/backend/spec/requests/admin/configuration/image_settings_spec.rb
+++ b/backend/spec/requests/admin/configuration/image_settings_spec.rb
@@ -21,5 +21,19 @@ describe "image settings" do
     Spree::Config[:attachment_path].should == "spec/dummy/tmp/bfaoro"
   end
 
-end
+  # Regression test for #3069
+  context "updates style configs and uploads products" do
+    let!(:product) { create(:product) }
+    let(:file_path) { Rails.root + "../../spec/support/ror_ringer.jpeg" }
 
+    it "still uploads image gracefully" do
+      click_button "Update"
+
+      visit spree.new_admin_product_image_path(product)
+      attach_file('image_attachment', file_path)
+      expect {
+        click_on "Update"
+      }.to_not raise_error(NoMethodError)
+    end
+  end
+end


### PR DESCRIPTION
[Fixes #3069]

This is also broken in 2-0-stable so please merge it there too in case it sounds right.

@sfielder could you apply this patch and confirm that it fixes your issue?
