### PR TITLE
Remove t() helper override

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -165,15 +165,7 @@ module Spree
       end
     end
 
-    def t(*args)
-      puts "WARNING: Spree's translations are now scoped to a 'spree' namespace. Please use the Spree.t helper."
-      puts "Called from: #{caller[0]}"
-      I18n.t(*args)
-    end
-
-
     private
-
     # Returns style of image or nil
     def image_style_from_method_name(method_name)
       if style = method_name.to_s.sub(/_image$/, '')
@@ -194,6 +186,5 @@ module Spree
         end
       end
     end
-
   end
 end


### PR DESCRIPTION
All spree core codebase now uses Spree.t() so I think we can safely
remove it. Plus I don't believe it's a good idea to throw warning every
time t() is called. Spree extensions or even other libraries can just
choose not to use Spree.t() at all. I don't think we should force then
to.

Guys do you think we still need that method?
