### PR TITLE
Use change method to trigger use_billing_address

### DIFF
--- a/frontend/app/assets/javascripts/store/checkout.js.coffee
+++ b/frontend/app/assets/javascripts/store/checkout.js.coffee
@@ -77,7 +77,7 @@ Spree.ready ($) ->
     updateState 'b'
     updateState 's'
 
-    ($ 'input#order_use_billing').click(->
+    ($ 'input#order_use_billing').change(->
       if ($ this).is(':checked')
         ($ '#shipping .inner').hide()
         ($ '#shipping .inner input, #shipping .inner select').prop 'disabled', true
@@ -85,7 +85,7 @@ Spree.ready ($) ->
         ($ '#shipping .inner').show()
         ($ '#shipping .inner input, #shipping .inner select').prop 'disabled', false
         updateState('s')
-    ).triggerHandler 'click'
+    ).triggerHandler 'change'
 
   if ($ '#checkout_form_payment').is('*')
     ($ 'input[type="radio"][name="order[payments_attributes][][payment_method_id]"]').click(->


### PR DESCRIPTION
That should prevent the shipping address form being hidden when the
browser autocompletes the form.

[Fixes 3068]

So I was just able to reproduce that issue using the `change` event to trigger show/hide logic fix it.
