### PR TITLE
Remove order.update_totals from order.payment_required?

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -9,10 +9,7 @@ module Spree
       go_to_state :address
       go_to_state :delivery
       go_to_state :payment, if: ->(order) {
-        # Fix for #2191
-        if order.shipments
-          order.update_totals
-        end
+        order.update_totals
         order.payment_required?
       }
       go_to_state :confirm, if: ->(order) { order.confirmation_required? }
@@ -163,7 +160,6 @@ module Spree
 
     # Is this a free order in which case the payment step should be skipped
     def payment_required?
-      update_totals
       total.to_f > 0.0
     end
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -463,6 +463,19 @@ describe Spree::Order do
     end
   end
 
+  context "payment required?" do
+    let(:order) { Spree::Order.new }
+
+    context "total is zero" do
+      it { order.payment_required?.should be_false }
+    end
+
+    context "total > zero" do
+      before { order.stub(total: 1) }
+      it { order.payment_required?.should be_true }
+    end
+  end
+
   # Related to the fix for #2694
   context "#has_unprocessed_payments?" do
     let!(:persisted_order) { create(:order) }


### PR DESCRIPTION
Instead we can call `order.update_totals` on the checkout_flow block
only since that's the only place on the code base where it seems to be
necessary. Plus calling `order.update_totals` generates a whole bunch of
work users may really not need or expect when calling
`order.payment_required?`

I was looking into #3040 and found the case where `order.update_totals` was called twice consecutively. I think that was necessary to fix some issue in the past but it doesn't seem to be the case any more. I ran this change on CI and everything is still green.
