### PR TITLE
Rails4 bundle

### DIFF
--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -14,7 +14,7 @@ gem 'sass-rails', '~> 4.0.0.rc1'
 
 group :test do
   gem 'capybara', '~> 1.1'
-  gem 'database_cleaner', '0.7.1'
+  gem 'database_cleaner', '~> 1.0.1'
   gem 'email_spec', '1.4.0'
   gem 'factory_girl_rails', '~> 4.2.1'
   gem 'ffaker'

--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -9,12 +9,8 @@ gem 'mysql2'
 gem 'pg'
 gem 'sqlite3'
 
-# Gems used only for assets and not required
-# in production environments by default.
-group :assets do
-  gem 'coffee-rails', '~> 3.2'
-  gem 'sass-rails', '~> 3.2'
-end
+gem 'coffee-rails', '~> 4.0.0.rc1'
+gem 'sass-rails', '~> 4.0.0.rc1'
 
 group :test do
   gem 'capybara', '~> 1.1'
@@ -29,7 +25,5 @@ group :test do
   gem 'simplecov'
   gem 'webmock', '1.8.11'
 end
-
-gem 'strong_parameters'
 
 gemspec

--- a/core/Gemfile
+++ b/core/Gemfile
@@ -1,3 +1,5 @@
 eval(File.read(File.dirname(__FILE__) + '/../common_spree_dependencies.rb'))
 
+gem 'ransack', github: 'ernie/ransack', branch: 'rails-4'
+
 gemspec

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -9,7 +9,7 @@ module Spree
     has_many :shipping_method_categories
     has_many :shipping_categories, through: :shipping_method_categories
 
-    has_and_belongs_to_many :zones
+    has_and_belongs_to_many :zones, join_table: "shipping_methods_zones"
 
     validates :name, presence: true
 

--- a/core/app/models/spree/stock_transfer.rb
+++ b/core/app/models/spree/stock_transfer.rb
@@ -7,8 +7,6 @@ module Spree
 
     make_permalink field: :number, prefix: 'T'
 
-    attr_accessible :reference
-
     def to_param
       number
     end

--- a/core/lib/generators/spree/dummy/templates/rails/test.rb
+++ b/core/lib/generators/spree/dummy/templates/rails/test.rb
@@ -11,9 +11,6 @@ Dummy::Application.configure do
   config.serve_static_assets = true
   config.static_cache_control = "public, max-age=3600"
 
-  # Log error messages when you accidentally call methods on nil
-  config.whiny_nils = true
-
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
@@ -30,10 +27,6 @@ Dummy::Application.configure do
   config.action_mailer.delivery_method = :test
   ActionMailer::Base.default :from => "spree@example.com"
 
-  # Raise exception on mass assignment protection for Active Record models
-  config.active_record.mass_assignment_sanitizer = :strict
-
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
 end
-

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -6,15 +6,7 @@ require 'kaminari'
 require 'awesome_nested_set'
 require 'acts_as_list'
 require 'active_merchant'
-require 'ransack'
-begin
-  require 'strong_parameters'
-rescue LoadError
-  puts "Couldn't find strong_parameters. Please add this line to your Gemfile:
-
-  gem 'strong_parameters', :github => 'rails/strong_parameters'"
-  exit
-end
+# require 'ransack'
 
 module Spree
 

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -6,7 +6,7 @@ require 'kaminari'
 require 'awesome_nested_set'
 require 'acts_as_list'
 require 'active_merchant'
-# require 'ransack'
+require 'ransack'
 
 module Spree
 

--- a/core/spec/lib/mail_interceptor_spec.rb
+++ b/core/spec/lib/mail_interceptor_spec.rb
@@ -27,10 +27,12 @@ describe Spree::OrderMailer do
 
     it "should use the provided from address" do
       Spree::Config[:mails_from] = "preference@foobar.com"
-      message = ActionMailer::Base.mail(:from => "override@foobar.com", :to => "test@test.com")
+      message.from = "override@foobar.com"
+      message.to = "test@test.com"
       message.deliver
-      @email = ActionMailer::Base.deliveries.first
-      @email.from.should == ["override@foobar.com"]
+      email = ActionMailer::Base.deliveries.first
+      email.from.should == ["override@foobar.com"]
+      email.to.should == ["test@test.com"]
     end
 
     it "should add the bcc email when provided" do

--- a/core/spec/models/spree/order/callbacks_spec.rb
+++ b/core/spec/models/spree/order/callbacks_spec.rb
@@ -12,7 +12,7 @@ describe Spree::Order do
       it "o'brien@gmail.com is a valid email address" do
         order.state = 'address'
         order.email = "o'brien@gmail.com"
-        order.should be_valid
+        order.should have(:no).error_on(:email)
       end
     end
   end
@@ -36,7 +36,7 @@ describe Spree::Order do
     it "should not validate email address" do
       order.state = "cart"
       order.email = nil
-      order.should be_valid
+      order.should have(:no).error_on(:email)
     end
   end
 end

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -387,7 +387,7 @@ describe Spree::Shipment do
     it "should run correct callbacks" do
       shipment.should_receive(:ensure_correct_adjustment)
       shipment.should_receive(:update_order)
-      shipment.run_callbacks(:save, :after)
+      shipment.run_callbacks(:save)
     end
   end
 

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |s|
   s.files        = Dir['LICENSE', 'README.md', 'app/**/*', 'config/**/*', 'lib/**/*', 'db/**/*', 'vendor/**/*']
   s.require_path = 'lib'
 
+  s.add_dependency 'rails', '~> 4.0.0.rc1'
+
   # Necessary for the install generator
   s.add_dependency 'highline', '= 1.6.18'
 
@@ -29,11 +31,9 @@ Gem::Specification.new do |s|
   s.add_dependency 'ffaker', '~> 1.16.1'
   s.add_dependency 'paperclip', '~> 3.4.1'
   s.add_dependency 'aws-sdk', '~> 1.3.4'
-  s.add_dependency 'ransack', '0.7.2'
+  # s.add_dependency 'ransack', '0.7.2'
   s.add_dependency 'activemerchant', '~> 1.31'
-  s.add_dependency 'json', '>= 1.7.7'
-  s.add_dependency 'rails', '~> 3.2.13'
-  s.add_dependency 'deface', '>= 0.9.0'
+  # s.add_dependency 'deface', '>= 0.9.0'
   s.add_dependency 'stringex', '~> 1.5.1'
   s.add_dependency 'cancan', '1.6.8'
   s.add_dependency 'truncate_html', '0.9.2'


### PR DESCRIPTION
This requires rails 4.0.0.rc1 and adds a few fixes to make tests actually run on the core gem. Next I should look into get rid of some of the zillions warnings I see. Some of them come from other dependencies.

I think we should focus on getting the core gem green with as few warnings as possible and then move to the other components.
