### PR TITLE
Add hide_curreny_symbol option

### DIFF
--- a/backend/app/controllers/spree/admin/general_settings_controller.rb
+++ b/backend/app/controllers/spree/admin/general_settings_controller.rb
@@ -8,7 +8,7 @@ module Spree
         @preferences_security = [:allow_ssl_in_production,
                         :allow_ssl_in_staging, :allow_ssl_in_development_and_test,
                         :check_for_spree_alerts]
-        @preferences_currency = [:display_currency, :hide_cents]
+        @preferences_currency = [:display_currency, :hide_cents, :hide_currency_symbol]
       end
 
       def update

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -44,6 +44,7 @@ module Spree
     preference :currency_symbol_position, :string, default: "before"
     preference :currency_thousands_separator, :string, default: ","
     preference :display_currency, :boolean, default: false
+    preference :hide_currency_symbol, :boolean, default: false
     preference :default_country_id, :integer
     preference :default_meta_description, :string, default: 'Spree demo site'
     preference :default_meta_keywords, :string, default: 'spree, demo'

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -535,6 +535,7 @@ en:
     has_no_shipped_units: has no shipped units
     height: Height
     hide_cents: Hide cents
+    hide_currency_symobl: Hide currency symbol
     home: Home
     i18n:
       available_locales: Available Locales

--- a/core/lib/spree/money.rb
+++ b/core/lib/spree/money.rb
@@ -12,6 +12,7 @@ module Spree
       @options[:no_cents] = Spree::Config[:hide_cents]
       @options[:decimal_mark] = Spree::Config[:currency_decimal_mark]
       @options[:thousands_separator] = Spree::Config[:currency_thousands_separator]
+      @options[:symbol] = false if Spree::Config[:hide_currency_symbol]
       @options.merge!(options)
       # Must be a symbol because the Money gem doesn't do the conversion
       @options[:symbol_position] = @options[:symbol_position].to_sym

--- a/core/spec/lib/spree/money_spec.rb
+++ b/core/spec/lib/spree/money_spec.rb
@@ -76,6 +76,21 @@ describe Spree::Money do
     end
   end
 
+  context "hide currency symbol" do
+    it "hides currency symbol" do
+      Spree::Config[:hide_currency_symbol] = true
+      money = Spree::Money.new(10)
+      money.to_s.should == "10.00"
+    end
+
+    it "shows currency symbol" do
+      Spree::Config[:hide_currency_symbol] = false
+      money = Spree::Money.new(10)
+      money.to_s.should == "$10.00"
+    end
+  end
+
+
   context "JPY" do
     before do
       configure_spree_preferences do |config|


### PR DESCRIPTION
There are cases when the symbol is not really helpful. For instance, in my
case, when using Romanian Leu (RON) currency, formatting with the L symbol
is not correct. The correct form would be 10 lei/Lei/LEI and not 10 L. In most
cases we just use the currency name (RON). I think it's easier to just set this
option to true rather than adding an extra decorator to do the job.
