### PR TITLE
Fix admin auto complete css

### DIFF
--- a/core/app/assets/stylesheets/admin/admin.css.erb
+++ b/core/app/assets/stylesheets/admin/admin.css.erb
@@ -675,3 +675,8 @@ span.handle{
 select.select2 {
   width: 30em;
 }
+
+.ui-widget-content .ui-menu-item .ui-state-focus {
+  color: #476D9B;
+  border: none;
+}


### PR DESCRIPTION
See before/after screenshots. Currently, autocomplete results are returned as white text making them invisible.
![screenshot from 2013-05-28 10 00 45](https://f.cloud.github.com/assets/540762/573267/0f2a884e-c7ad-11e2-8bae-66b0a140d874.png)
![screenshot from 2013-05-28 11 38 58](https://f.cloud.github.com/assets/540762/573269/11845192-c7ad-11e2-9a41-811b2336feb3.png)
