### PR TITLE
Make sure that the images aren't CMYK.

### DIFF
--- a/core/app/models/spree/image.rb
+++ b/core/app/models/spree/image.rb
@@ -10,7 +10,7 @@ module Spree
                       default_style: :product,
                       url: '/spree/products/:id/:style/:basename.:extension',
                       path: ':rails_root/public/spree/products/:id/:style/:basename.:extension',
-                      convert_options: { all: '-strip -auto-orient' }
+                      convert_options: { all: '-strip -auto-orient -colorspace RGB' }
 
     # save the w,h of the original image (from which others can be calculated)
     # we need to look at the write-queue for images which have not been saved yet


### PR DESCRIPTION
Make sure that images that are uploaded are in the RGB colorspace. 
