### PR TITLE
Compare strings to strings when transitioning to shipment states

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -35,7 +35,7 @@ module Spree
       event :ready do
         transition from: :pending, to: :ready, if: lambda { |shipment|
           # Fix for #2040
-          shipment.determine_state(shipment.order) == :ready
+          shipment.determine_state(shipment.order) == 'ready'
         }
       end
 


### PR DESCRIPTION
Currently, the determine_state method returns a string, so we should compare the string value, not a sym value.
