### PR TITLE
pass country_id as data to jQuery.get

### DIFF
--- a/frontend/app/assets/javascripts/store/checkout.js.coffee
+++ b/frontend/app/assets/javascripts/store/checkout.js.coffee
@@ -15,7 +15,7 @@ Spree.ready ($) ->
       countryId = getCountryId(region)
       if countryId?
         unless Spree.Checkout[countryId]?
-          $.get Spree.routes.states_search + "/?country_id=#{countryId}", (data) ->
+          $.get Spree.routes.states_search, {country_id: countryId}, (data) ->
             Spree.Checkout[countryId] =
               states: data.states
               states_required: data.states_required


### PR DESCRIPTION
if your default url options happen to include ?locale=en then
the previous implementation would end up generating:
api/states?locale=en?country_id=49 instead of
api/states?locale=en&country_id=49
