### PR TITLE
Edge fix readonly inventory units

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Spree 2.1.0 (unreleased) ##
 
+*   Remove after_save callback for stock items backorders processing and
+    fixes count on hand updates when there are backordered units #3066
+
+    *Washington Luiz*
+
 *   InventoryUnit#backordered_for_stock_item no longer returns readonly objects
     neither return an ActiveRecored::Association. It returns only an array of
     writable backordered units for a given stock item #3066

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Spree 2.1.0 (unreleased) ##
 
+*   InventoryUnit#backordered_for_stock_item no longer returns readonly objects
+    neither return an ActiveRecored::Association. It returns only an array of
+    writable backordered units for a given stock item #3066
+
+    *Washington Luiz*
+
 *   Scope shipping rates as per shipping method display_on #3119
     e.g. Shipping methods set to back_end only should not be displayed on frontend too
 

--- a/core/spec/models/spree/inventory_unit_spec.rb
+++ b/core/spec/models/spree/inventory_unit_spec.rb
@@ -20,7 +20,7 @@ describe Spree::InventoryUnit do
     let!(:unit) do
       unit = shipment.inventory_units.build
       unit.state = 'backordered'
-      unit.variant_id = 1
+      unit.variant_id = stock_item.variant.id
       unit.tap(&:save!)
     end
 
@@ -31,14 +31,12 @@ describe Spree::InventoryUnit do
     end
 
     it "finds inventory units from its stock location when the unit's variant matches the stock item's variant" do
-      stock_item.variant_id = 1
       Spree::InventoryUnit.backordered_for_stock_item(stock_item).should =~ [unit]
     end
 
     it "does not find inventory units that aren't backordered" do
       on_hand_unit = shipment.inventory_units.build
       on_hand_unit.state = 'on_hand'
-      on_hand_unit.variant_id = 1
       on_hand_unit.save!
 
       Spree::InventoryUnit.backordered_for_stock_item(stock_item).should_not include(on_hand_unit)


### PR DESCRIPTION
Two commits with different fixes but both related to the same action _update stock items quantity with existing backorders_ described in #3066. This should fix that issue however it creates another one, after a purchase the stock items quantity is not updated properly, probably because I removed the after_save callback from StockItem.

I intend to look into that tomorrow and hopefull should push one more commit to this PR. Another issue is core test suite is still green. I could only notice that issue because I manually did some purchases and watched the results.

Please read the commits messages for details on both changes and let mw know if I'm missing anything.
