### PR TITLE
No need to pass option on spree.promo initializer

### DIFF
--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -66,7 +66,7 @@ module Spree
         Mail.register_interceptor(Spree::Core::MailInterceptor)
       end
 
-      initializer 'spree.promo.environment', :after => 'spree.environment' do |app|
+      initializer 'spree.promo.environment' do |app|
         app.config.spree.add_class('promotions')
         app.config.spree.promotions = Spree::Promo::Environment.new
       end


### PR DESCRIPTION
For some reason this was making the calculator.shipping_methods nil in
the spree app initializer. It prevented users from adding their own
calculators with code like:

  Rails.application.config.spree.calculators.shipping_methods << CustomUserClass

Fixes #3118

I wish I could write a better commit message for that but I just can't, need to do some research. Can someone please tell better?
