### PR TITLE
Enable to show products without available_on.

### DIFF
--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -198,7 +198,7 @@ module Spree
 
     # Can't use add_search_scope for this as it needs a default argument
     def self.available(available_on = nil, currency = nil)
-      scope = joins(:master => :prices).where("#{Product.quoted_table_name}.available_on <= ?", available_on || Time.now)
+      scope = joins(:master => :prices).where("#{Product.quoted_table_name}.available_on <= ? OR #{Product.quoted_table_name}.available_on IS NULL", available_on || Time.now)
       unless Spree::Config.show_products_without_price
         scope = scope.where('spree_prices.currency' => currency || Spree::Config[:currency]).where('spree_prices.amount IS NOT NULL')
       end


### PR DESCRIPTION
Hi,

The products without 'available_on' attribute are not shown in store now.
I think 'available_on' attribute is more useful if it's a optional attribute.
