### PR TITLE
Remove nonsense js code on backend customer details

### DIFF
--- a/backend/app/assets/javascripts/admin/checkouts/edit.js
+++ b/backend/app/assets/javascripts/admin/checkouts/edit.js
@@ -27,31 +27,6 @@ $(document).ready(function() {
       dropdownCssClass: 'customer_search',
       formatResult: formatCustomerResult,
       formatSelection: function (customer) {
-        _.each(['bill_address', 'ship_address'], function(address) {
-          var data = customer[address];
-          address_parts = ['firstname', 'lastname',
-                           'company', 'address1',
-                           'address2', 'city',
-                           'zipcode', 'phone']
-          var attribute_wrapper = '#order_' + address + '_attributes_'
-          if(data != undefined) {
-            _.each(address_parts, function(part) {
-              $(attribute_wrapper + part).val(data[part]);
-            })
-
-            $(attribute_wrapper + 'state_id').select2("val", data['state_id']);
-            $(attribute_wrapper + 'country_id').select2("val", data['country_id']);
-          }
-          else {
-            _.each(address_parts, function(part) {
-              $(attribute_wrapper + part).val("");
-            })
-
-            $(attribute_wrapper + 'state_id').select2("val", '');
-            $(attribute_wrapper + 'country_id').select2("val", '');
-          }
-        });
-
         $('#order_email').val(customer.email);
         $('#user_id').val(customer.id);
         $('#guest_checkout_true').prop("checked", false);


### PR DESCRIPTION
When picking up a user at the backend customer details order step that
code would empty all address fields, including the previously set
default country

This should fix the backend build

2-0-stable needs this one too in case it looks right.
