### PR TITLE
Fix variant thumbnails not showing on frontend

### DIFF
--- a/frontend/app/assets/javascripts/store/product.js.coffee
+++ b/frontend/app/assets/javascripts/store/product.js.coffee
@@ -18,7 +18,7 @@ Spree.addImageHandlers = ->
 
 Spree.showVariantImages = (variantId) ->
   ($ 'li.vtmb').hide()
-  ($ 'li#tmb-' + variantId).show()
+  ($ 'li.tmb-' + variantId).show()
   currentThumb = ($ '#' + ($ '#main-image').data('selectedThumbId'))
   if not currentThumb.hasClass('vtmb-' + variantId)
     thumb = ($ ($ 'ul.thumbnails li:visible.vtmb').eq(0))

--- a/frontend/app/assets/javascripts/store/product.js.coffee
+++ b/frontend/app/assets/javascripts/store/product.js.coffee
@@ -18,7 +18,7 @@ Spree.addImageHandlers = ->
 
 Spree.showVariantImages = (variantId) ->
   ($ 'li.vtmb').hide()
-  ($ 'li.vtmb-' + variantId).show()
+  ($ 'li#tmb-' + variantId).show()
   currentThumb = ($ '#' + ($ '#main-image').data('selectedThumbId'))
   if not currentThumb.hasClass('vtmb-' + variantId)
     thumb = ($ ($ 'ul.thumbnails li:visible.vtmb').eq(0))

--- a/frontend/app/views/spree/products/_thumbnails.html.erb
+++ b/frontend/app/views/spree/products/_thumbnails.html.erb
@@ -2,15 +2,15 @@
 <% if (@product.images + @product.variant_images).uniq.size > 1 %>
   <ul id="product-thumbnails" class="thumbnails inline" data-hook>
     <% @product.images.each do |i| %>
-      <li class='tmb-all' id='tmb-<%= i.id %>'>
-        <%= link_to(image_tag(i.attachment.url(:mini)), i.attachment.url(:product), :class => 'tmb-all', :id => "tmb-#{i.id}") %>
+      <li class='tmb-all' id='tmb-<%= i.viewable.id %>'>
+        <%= link_to(image_tag(i.attachment.url(:mini)), i.attachment.url(:product)) %>
       </li>
     <% end %>
 
     <% if @product.has_variants? %>
       <% @product.variant_images.each do |i| %>
         <% next if @product.images.include?(i) %>
-        <li class='vtmb' id='tmb-<%= i.id %>'>
+        <li class='vtmb' id='tmb-<%= i.viewable.id %>'>
           <%= link_to(image_tag(i.attachment.url(:mini)), i.attachment.url(:product)) %>
         </li>
       <% end %>

--- a/frontend/app/views/spree/products/_thumbnails.html.erb
+++ b/frontend/app/views/spree/products/_thumbnails.html.erb
@@ -2,7 +2,7 @@
 <% if (@product.images + @product.variant_images).uniq.size > 1 %>
   <ul id="product-thumbnails" class="thumbnails inline" data-hook>
     <% @product.images.each do |i| %>
-      <li class='tmb-all' id='tmb-<%= i.viewable.id %>'>
+      <li class='tmb-all tmb-<%= i.viewable.id %>'>
         <%= link_to(image_tag(i.attachment.url(:mini)), i.attachment.url(:product)) %>
       </li>
     <% end %>
@@ -10,7 +10,7 @@
     <% if @product.has_variants? %>
       <% @product.variant_images.each do |i| %>
         <% next if @product.images.include?(i) %>
-        <li class='vtmb' id='tmb-<%= i.viewable.id %>'>
+        <li class='vtmb tmb-<%= i.viewable.id %>'>
           <%= link_to(image_tag(i.attachment.url(:mini)), i.attachment.url(:product)) %>
         </li>
       <% end %>


### PR DESCRIPTION
The thumbnails for variants would not show up on a different variant click, and the
product page opened without any visible thumbnails. They all stayed hidden.

This is on Spree 2.0 branch. 
It occurred when a product had 2 variants and added an image to each variant.

I changed the thumbnails ID to use the variant ID since is the one used on the variant checkboxs.

Hope the PR is ok. 
Regards!
