### PR TITLE
Add nil object check for StockLocation#fill_status

### DIFF
--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -40,18 +40,21 @@ module Spree
     end
 
     def fill_status(variant, quantity)
-      item = stock_item(variant)
+      if item = stock_item(variant)
 
-      if item.count_on_hand >= quantity
-        on_hand = quantity
-        backordered = 0
+        if item.count_on_hand >= quantity
+          on_hand = quantity
+          backordered = 0
+        else
+          on_hand = item.count_on_hand
+          on_hand = 0 if on_hand < 0
+          backordered = item.backorderable? ? (quantity - on_hand) : 0
+        end
+
+        [on_hand, backordered]
       else
-        on_hand = item.count_on_hand
-        on_hand = 0 if on_hand < 0
-        backordered = item.backorderable? ? (quantity - on_hand) : 0
+        [0, 0]
       end
-
-      [on_hand, backordered]
     end
 
     private

--- a/core/spec/models/spree/stock_location_spec.rb
+++ b/core/spec/models/spree/stock_location_spec.rb
@@ -110,6 +110,19 @@ module Spree
           backordered.should eq 0
         end
       end
+
+      context 'without stock_items' do
+        subject { create(:stock_location) }
+        let(:variant) { create(:base_variant) }
+
+        it 'zero on_hand and backordered', focus: true do
+          subject
+          variant.stock_items.destroy_all
+          on_hand, backordered = subject.fill_status(variant, 1)
+          on_hand.should eq 0
+          backordered.should eq 0
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
The StockLocation#fill_status assumes that each StockLocation has a StockItem for every Variant. However, in our app, after db migration to Spree 2, we have stock locations that have no stock items. I am uncertain if this is due to a missing (not yet written) migration, or whether the assumption is unreliable. 

This [after create method](https://github.com/spree/spree/blob/master/core/app/models/spree/variant.rb#L174) seems to imply that in fact there should be a stock_item in each stock_location for each variant and there is a corresponding after_create method in StockLocation.

I wonder if it will be difficult to track all legacy and newly created variants, as well as newly created StockLocations, to ensure that the assumption holds.

If we don't want to depend on that we could use this nil object check. Otherwise we should revisit the spree 2 migrations and see what is missing.

cc @cmar
