### PR TITLE
Stock::Estimator should select the most affordable shipping rate by default

### DIFF
--- a/core/app/models/spree/stock/estimator.rb
+++ b/core/app/models/spree/stock/estimator.rb
@@ -18,7 +18,8 @@ module Spree
           shipping_rates << ShippingRate.new( :shipping_method => shipping_method,
                                               :cost => cost)
         end
-        shipping_rates.sort_by { |r| r.cost || 0 }.first.selected = true unless shipping_rates.empty?
+        shipping_rates.sort_by! { |r| r.cost || 0 }
+        shipping_rates.first.selected = true unless shipping_rates.empty?
         shipping_rates
       end
 

--- a/core/app/models/spree/stock/estimator.rb
+++ b/core/app/models/spree/stock/estimator.rb
@@ -18,7 +18,7 @@ module Spree
           shipping_rates << ShippingRate.new( :shipping_method => shipping_method,
                                               :cost => cost)
         end
-        shipping_rates.first.selected = true unless shipping_rates.empty?
+        shipping_rates.sort_by { |r| r.cost || 0 }.first.selected = true unless shipping_rates.empty?
         shipping_rates
       end
 

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -46,6 +46,17 @@ module Spree
           shipping_rates.should == []
         end
 
+        it "sorts shipping rates by cost" do
+          shipping_methods = 3.times.map { create(:shipping_method) }
+          shipping_methods[0].stub_chain(:calculator, :compute).and_return(5.00)
+          shipping_methods[1].stub_chain(:calculator, :compute).and_return(3.00)
+          shipping_methods[2].stub_chain(:calculator, :compute).and_return(4.00)
+
+          subject.stub(:shipping_methods).and_return(shipping_methods)
+
+          expect(subject.shipping_rates(package).map(&:cost)).to eq %w[3.00 4.00 5.00].map(&BigDecimal.method(:new))
+        end
+
         it "selects the most affordable shipping rate" do
           shipping_methods = 3.times.map { create(:shipping_method) }
           shipping_methods[0].stub_chain(:calculator, :compute).and_return(5.00)

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -45,6 +45,27 @@ module Spree
           shipping_rates = subject.shipping_rates(package)
           shipping_rates.should == []
         end
+
+        it "selects the most affordable shipping rate" do
+          shipping_methods = 3.times.map { create(:shipping_method) }
+          shipping_methods[0].stub_chain(:calculator, :compute).and_return(5.00)
+          shipping_methods[1].stub_chain(:calculator, :compute).and_return(3.00)
+          shipping_methods[2].stub_chain(:calculator, :compute).and_return(4.00)
+
+          subject.stub(:shipping_methods).and_return(shipping_methods)
+
+          expect(subject.shipping_rates(package).sort_by(&:cost).map(&:selected)).to eq [true, false, false]
+        end
+
+        it "selects the most affordable shipping rate and doesn't raise exception over nil cost" do
+          shipping_methods = 2.times.map { create(:shipping_method) }
+          shipping_methods[0].stub_chain(:calculator, :compute).and_return(1.00)
+          shipping_methods[1].stub_chain(:calculator, :compute).and_return(nil)
+
+          subject.stub(:shipping_methods).and_return(shipping_methods)
+
+          subject.shipping_rates(package)
+        end
       end
     end
   end


### PR DESCRIPTION
Currently, the first shipping rate is selected. Since the ordering of these rates is arbitrary, the selected rate is also arbitrary. Selecting the most affordable rate by default seems more logical to me.
