### PR TITLE
Don't save invalid addresses

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -299,7 +299,7 @@ module Spree
 
       if persisted?
         # immediately persist the changes we just made, but don't use save since we might have an invalid address associated
-        self.class.where(id: id).update_all(email: user.email, user_id: user.id)
+        self.class.unscoped.where(id: id).update_all(email: user.email, user_id: user.id)
       end
     end
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -299,8 +299,7 @@ module Spree
 
       if persisted?
         # immediately persist the changes we just made, but don't use save since we might have an invalid address associated
-        update_column(:user_id, user.id)
-        update_column(:email, user.email)
+        self.class.where(id: id).update_all(email: user.email, user_id: user.id)
       end
     end
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -296,9 +296,12 @@ module Spree
     def associate_user!(user)
       self.user = user
       self.email = user.email
-      # disable validations since they can cause issues when associating
-      # an incomplete address during the address step
-      save(validate: false)
+
+      if persisted?
+        # immediately persist the changes we just made, but don't use save since we might have an invalid address associated
+        update_column(:user_id, user.id)
+        update_column(:email, user.email)
+      end
     end
 
     # FIXME refactor this method and implement validation using validates_* utilities

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -54,12 +54,38 @@ describe Spree::Order do
   end
 
   context "#associate_user!" do
-    it "should associate a user with this order" do
+    it "should associate a user with a persisted order" do
+      order = FactoryGirl.create(:order_with_line_items)
+      user = FactoryGirl.create(:user)
+
       order.user = nil
       order.email = nil
       order.associate_user!(user)
       order.user.should == user
       order.email.should == user.email
+
+      # verify that the changes we made were persisted
+      order.reload
+      order.user.should == user
+      order.email.should == user.email
+    end
+
+    it "should associate a user with a non-persisted order" do
+      order = Spree::Order.new
+
+      expect do
+        order.associate_user!(user)
+      end.to change { [order.user, order.email] }.from([nil, nil]).to([user, user.email])
+    end
+
+    it "should not persist an invalid address" do
+      address = Spree::Address.new
+      order.user = nil
+      order.email = nil
+      order.ship_address = address
+      expect do
+        order.associate_user!(user)
+      end.not_to change { address.persisted? }.from(false)
     end
   end
 


### PR DESCRIPTION
The code that this pull request replaces calls `save(validate: false)` for the sole purpose of persisting invalid addresses. In fact, there is even a comment that says exactly that. But having records saved in an invalid can cause problems (it is in our app) and should be avoided.

This pull request accomplishes the task of associating a user with an order and immediately persisting that association, but it does't save invalid addresses.

The replaced code originated in 62addaaba4efe6f1ada54825ec8358d63fdee864.

Thanks.
