### PR TITLE
Fix remove taxon js code

### DIFF
--- a/backend/app/assets/javascripts/admin/taxonomy.js.coffee
+++ b/backend/app/assets/javascripts/admin/taxonomy.js.coffee
@@ -51,8 +51,8 @@ handle_rename = (e, data) ->
     error: handle_ajax_error
 
 handle_delete = (e, data) ->
-  last_rollback = data.rlb
-  node = data.rslt.ob
+  last_rollback = data.rlbk
+  node = data.rslt.obj
   delete_url = base_url.clone()
   delete_url.setPath delete_url.path() + '/' + node.attr("id")
   jConfirm Spree.translations.are_you_sure_delete, Spree.translations.confirm_delete, (r) ->


### PR DESCRIPTION
The error in #3136 was created by me while running vim macros to remove semicolons, removed too much, to convert the file to coffee script. Sorry about that.

2-0-stable needs this one too
