### PR TITLE
Don't allow customer to choose shipping methods reserved for backend

### DIFF
--- a/frontend/app/views/spree/checkout/_delivery.html.erb
+++ b/frontend/app/views/spree/checkout/_delivery.html.erb
@@ -37,7 +37,7 @@
 
           <h5 class="stock-shipping-method-title"><%= Spree.t(:shipping_method) %></h5>
           <ul class="field radios shipping-methods">
-            <% ship_form.object.shipping_rates.each do |rate| %>
+            <% ship_form.object.shipping_rates.select{|sr| sr.shipping_method.display_on != 'back_end'}.each do |rate| %>
               <li class="shipping-method">
                 <label>
                   <%= ship_form.radio_button :selected_shipping_rate_id, rate.id %>


### PR DESCRIPTION
It seems that by default all shipping methods can be selected by a customer even if they are meant to be reserved for backend use only (meaning the display_on property is set to back_end). This patch corrects that. However, I am unsure if the template is the correct place to narrow the collection of shipping methods. 

Also, this change seems quite straightforward and probably not deserving of a feature spec... but let me know if you'd like me to create on anyway.
