### PR TITLE
Fix users rule promo association

### DIFF
--- a/core/app/models/spree/promotion/rules/user.rb
+++ b/core/app/models/spree/promotion/rules/user.rb
@@ -4,8 +4,10 @@ module Spree
       class User < PromotionRule
         attr_accessible :user_ids_string
 
-        belongs_to :user, :class_name => Spree.user_class.to_s
-        has_and_belongs_to_many :users, :class_name => Spree.user_class.to_s, :join_table => 'spree_promotion_rules_users', :foreign_key => 'promotion_rule_id'
+        belongs_to :user, :class_name => "::#{Spree.user_class.to_s}"
+        has_and_belongs_to_many :users, :class_name => "::#{Spree.user_class.to_s}",
+          :join_table => 'spree_promotion_rules_users', :foreign_key => 'promotion_rule_id',
+          :association_foreign_key => 'user_id'
 
         def eligible?(order, options = {})
           users.include?(order.user)


### PR DESCRIPTION
Also add an association_foreign_key config because it assumed that every
Spree.user_class would return User which might not be always the case.

[Fixes #3145]]

I couldn't find a simple way to reproduce the issue on the spree_core build

2-0-stable needs the fix as well
