### PR TITLE
Load promotion rules after app initialization

### DIFF
--- a/core/app/models/spree/promotion/rules/user.rb
+++ b/core/app/models/spree/promotion/rules/user.rb
@@ -4,10 +4,8 @@ module Spree
       class User < PromotionRule
         attr_accessible :user_ids_string
 
-        belongs_to :user, :class_name => "::#{Spree.user_class.to_s}"
-        has_and_belongs_to_many :users, :class_name => "::#{Spree.user_class.to_s}",
-          :join_table => 'spree_promotion_rules_users', :foreign_key => 'promotion_rule_id',
-          :association_foreign_key => 'user_id'
+        belongs_to :user, :class_name => Spree.user_class.to_s
+        has_and_belongs_to_many :users, :class_name => Spree.user_class.to_s, :join_table => 'spree_promotion_rules_users', :foreign_key => 'promotion_rule_id'
 
         def eligible?(order, options = {})
           users.include?(order.user)

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -66,9 +66,12 @@ module Spree
         Mail.register_interceptor(Spree::Core::MailInterceptor)
       end
 
+      # We need to define promotions rules here so extensions and existing apps
+      # can add their custom classes on their initializer files
       initializer 'spree.promo.environment' do |app|
         app.config.spree.add_class('promotions')
         app.config.spree.promotions = Spree::Promo::Environment.new
+        app.config.spree.promotions.rules = []
       end
 
       initializer 'spree.promo.register.promotion.calculators' do |app|
@@ -83,8 +86,12 @@ module Spree
         ]
       end
 
-      initializer 'spree.promo.register.promotions.rules' do |app|
-        app.config.spree.promotions.rules = [
+      # Promotion rules need to be evaluated on after initialize otherwise
+      # Spree.user_class would be nil and users might experience errors related
+      # to malformed model associations (Spree.user_class is only defined on
+      # the app initializer)
+      config.after_initialize do
+        Rails.application.config.spree.promotions.rules.concat [
           Spree::Promotion::Rules::ItemTotal,
           Spree::Promotion::Rules::Product,
           Spree::Promotion::Rules::User,


### PR DESCRIPTION
So that they can make proper use of `Spree.user_class` which is only
defined on the app spree.rb initializer

Sorry about my previous PR. It did not fix #3145. I was confused by the loading behaviour in Rails.

I believe this solution now does fix it and doesn't break any existing apps.
