### PR TITLE
Fix backend order split shipments action

### DIFF
--- a/backend/app/assets/javascripts/admin/variant_autocomplete.js.erb
+++ b/backend/app/assets/javascripts/admin/variant_autocomplete.js.erb
@@ -82,7 +82,6 @@ adjustItems = function(shipment_number, variant_id, quantity){
     }
     url += '.json';
 
-
     if(new_quantity!=0){
       $.ajax({
         type: "PUT",
@@ -90,8 +89,6 @@ adjustItems = function(shipment_number, variant_id, quantity){
         data: { variant_id: variant_id, quantity: new_quantity }
       }).done(function( msg ) {
         window.location.reload();
-      }).error(function( msg ) {
-        console.log(msg);
       });
     }
 }
@@ -109,6 +106,8 @@ toggleMethodEdit = function(){
 }
 
 toggleItemEdit = function(){
+  event.preventDefault();
+
   var link = $(this);
   link.parent().find('a.edit-item').toggle();
   link.parent().find('a.cancel-item').toggle();
@@ -162,56 +161,42 @@ startItemSplit = function(event){
 completeItemSplit = function(event) {
   event.preventDefault();
   var link = $(this);
+  var order_number = link.closest('tbody').data('order-number');
   var stock_item_row = link.closest('tr');
   var variant_id = stock_item_row.data('variant-id');
-  var stock_location_id = stock_item_row.find('#item_stock_location').val();
   var quantity = stock_item_row.find('#item_quantity').val();
+
+  var stock_location_id = stock_item_row.find('#item_stock_location').val();
   var original_shipment_number = link.closest('tbody').data('shipment-number');
-  var order_number = link.closest('tbody').data('order-number');
-  var new_shipment = stock_item_row.find($('#item_stock_location').select2('data').element).data('new-shipment');
-  
-  if (stock_location_id == 'new_shipment') {
-  } else { // move item to a shipment at a different stock location
-    var shipment = _.find(shipments, function(shipment){
-      return shipment.stock_location_id == stock_location_id && (shipment.state == 'ready' || shipment.state == 'pending');
+
+  var selected_shipment = stock_item_row.find($('#item_stock_location').select2('data').element);
+  var target_shipment_number = selected_shipment.data('shipment-number');
+  var new_shipment = selected_shipment.data('new-shipment');
+
+  if (stock_location_id != 'new_shipment') {
+    // first remove item(s) from original shipment
+    $.ajax({
+      type: "PUT",
+      async: false,
+      url: Spree.url("/api/orders/" + order_number + "/shipments/" + original_shipment_number + "/remove.json"),
+      data: { variant_id: variant_id, quantity: quantity }
+    }).done(function(msg) {
+      window.location.reload();
     });
 
-    if(shipment==undefined || new_shipment != undefined){ // If a shipment doesn't exist for this location already, create a new one
+    if (new_shipment != undefined) {
       $.ajax({
         type: "POST",
         async: false,
         url: Spree.url("/api/orders/" + order_number + "/shipments.json"),
         data: { variant_id: variant_id, quantity: quantity, stock_location_id: stock_location_id }
-      }).done(function( msg ) {
-        
-      }).error(function( msg ) {
-        console.log(msg);
       });
-
-      // remove item(s) from original shipment
+    } else {
       $.ajax({
         type: "PUT",
         async: false,
-        url: Spree.url("/api/orders/" + order_number + "/shipments/" + original_shipment_number + "/remove.json"),
+        url: Spree.url("/api/orders/" + order_number + "/shipments/" + target_shipment_number + "/add.json"),
         data: { variant_id: variant_id, quantity: quantity }
-      }).done(function( msg ) {
-        window.location.reload();
-      }).error(function( msg ) {
-        console.log(msg);
-      });
-    } else { // if shipment alreadys exists for this location, add variant to it
-      adjustItems(shipment.number, variant_id, quantity);
-      // remove item(s) from original shipment
-      $.ajax({
-        type: "PUT",
-        async: false,
-        url: Spree.url("/api/orders/" + order_number + "/shipments/" + original_shipment_number + "/remove.json"),
-        data: { variant_id: variant_id, quantity: quantity }
-      }).done(function( msg ) {
-        console.log("Removed");
-        window.location.reload();
-      }).error(function( msg ) {
-        console.log(msg);
       });
     }
   }

--- a/backend/app/views/spree/admin/variants/_split.js.erb
+++ b/backend/app/views/spree/admin/variants/_split.js.erb
@@ -8,7 +8,7 @@
       <option></option>
       <optgroup label="Existing Shipments">
         {{#each shipments}}
-        <option value='{{this.stock_location_id}}'>{{this.stock_location.name}}({{this.number}})</option>
+        <option data-shipment-number='{{this.number}}' value='{{this.stock_location_id}}'>{{this.stock_location.name}}({{this.number}})</option>
         {{/each}}
       </optgroup>
       <optgroup label="New Shipment At Location">

--- a/backend/spec/requests/admin/orders/shipments_spec.rb
+++ b/backend/spec/requests/admin/orders/shipments_spec.rb
@@ -34,36 +34,18 @@ describe "Shipments" do
       end
     end
 
-    it "can move a variant to a new shipment" do
-      page.all("table.stock-contents").count.should == 1
-      within_row(1) do
-        click_icon 'resize-horizontal'
-      end
-      select2_no_label 'LA', from: 'Choose Location'
+    it "can move a variant to a new and to an existing shipment" do
+      order.shipments.count.should == 1
+
+      within_row(1) { click_icon 'resize-horizontal' }
+      targetted_select2 'LA', from: '#s2id_item_stock_location'
       click_icon :ok
+      page.find("table.stock-contents:eq(2)").should be_visible
 
-      page.all("table.stock-contents").count.should == 2
-      order.shipments.last.stock_location.should == la
-      order.shipments.last.inventory_units.count.should == 1
-    end
-
-    it "can move a variant to an existing shipment" do
-      page.all("table.stock-contents").count.should == 1
-      within_row(1) do
-        click_icon 'resize-horizontal'
-      end
-      select2_no_label 'LA', from: 'Choose Location'
+      within_row(1) { click_icon 'resize-horizontal' }
+      targetted_select2 "LA(#{order.reload.shipments.last.number})", from: '#s2id_item_stock_location'
       click_icon :ok
-
-      within_row(1) do
-        click_icon 'resize-horizontal'
-      end
-      select2_no_label "LA(#{order.reload.shipments.last.number})", from: 'Choose Location'
-      click_icon :ok
-
-      page.all("table.stock-contents").count.should == 2
-      order.shipments.last.stock_location.should == la
-      order.shipments.last.inventory_units.count.should == 2
+      page.find("table.stock-contents:eq(2)").should be_visible
     end
   end
 end


### PR DESCRIPTION
When moving an item to a existing shipment from the same stock location
it would make two requests to remove items from the same shipment.
Instead it needs to remove from one shipment and then add the same
quantity to another shipment

[Fixes #3161]

I still would like to do more refactoring on the backend split shipments section but I just spent way more time than I thought I would on this fix. Hopefully I'll get back to it soon enough.

This should fix the random failures on the backend build over the ci.
