### PR TITLE
Ensure correct classes on stateSelect, stateInput elements in checkout.js

### DIFF
--- a/frontend/app/assets/javascripts/store/checkout.js.coffee
+++ b/frontend/app/assets/javascripts/store/checkout.js.coffee
@@ -44,16 +44,22 @@ Spree.ready ($) ->
         stateInput.hide().prop 'disabled', true
         statePara.show()
         stateSpanRequired.show()
+        stateSelect.addClass('required') if statesRequired
+        stateInput.removeClass('required')
       else
         stateSelect.hide().prop 'disabled', true
         stateInput.show()
         if statesRequired
           stateSpanRequired.show()
+          stateInput.addClass('required')
         else
           stateInput.val ''
           stateSpanRequired.hide()
+          stateInput.removeClass('required')
         statePara.toggle(!!statesRequired)
         stateInput.prop('disabled', !statesRequired)
+        stateInput.removeClass('hidden')
+        stateSelect.removeClass('required')
 
     ($ 'p#bcountry select').change ->
       updateState 'b'

--- a/frontend/spec/requests/address_spec.rb
+++ b/frontend/spec/requests/address_spec.rb
@@ -18,7 +18,7 @@ describe "Address" do
     @state_name_css = "##{address}_state_name"
   end
 
-  context "country requires state", :js => true do
+  context "country requires state", :js => true, :focus => true do
     let!(:canada) { create(:country, :name => "Canada", :states_required => true, :iso => "CA") }
 
     context "but has no state" do
@@ -28,6 +28,9 @@ describe "Address" do
         select canada.name, :from => @country_css
         page.should have_selector(@state_select_css, visible: false)
         page.should have_selector(@state_name_css, visible: true)
+        find(@state_name_css)['class'].should_not =~ /hidden/
+        find(@state_name_css)['class'].should =~ /required/
+        find(@state_select_css)['class'].should_not =~ /required/
         page.should_not have_selector("input#{@state_name_css}[disabled]")
       end
     end
@@ -41,6 +44,8 @@ describe "Address" do
         select canada.name, :from => @country_css
         page.should have_selector(@state_select_css, visible: true)
         page.should have_selector(@state_name_css, visible: false)
+        find(@state_select_css)['class'].should =~ /required/
+        find(@state_name_css)['class'].should_not =~ /required/
       end
     end
 
@@ -54,6 +59,9 @@ describe "Address" do
 
         select france.name, :from => @country_css
         page.find(@state_name_css).should have_content('')
+        find(@state_name_css)['class'].should_not =~ /hidden/
+        find(@state_name_css)['class'].should_not =~ /required/
+        find(@state_select_css)['class'].should_not =~ /required/
       end
     end
   end


### PR DESCRIPTION
On the frontend we have js that toggles visibility of the state text inputs and selects depending on whether the selected country has associated states. By default the state text input has the class 'hidden' assigned to it. Currently there is no 'hidden' class in the frontend css but many sites use a '.hidden' selector to apply display:none. Therefore when the stateInput visibility is toggled the presence of the 'hidden' class should be as well.

Additionally the validate.js plugin uses the .required class to determine whether that form element should be validated. I've also toggled the presence of the 'required' class as necessary.
