### PR TITLE
Fix build specs and split shipment edit button

### DIFF
--- a/backend/app/assets/javascripts/admin/variant_autocomplete.js.erb
+++ b/backend/app/assets/javascripts/admin/variant_autocomplete.js.erb
@@ -49,7 +49,7 @@ $(document).ready(function() {
       toggleItemEdit();
 
       adjustItems(shipment_number, variant_id, quantity);
-
+      return false;
     });
 
     //handle delete click
@@ -106,8 +106,6 @@ toggleMethodEdit = function(){
 }
 
 toggleItemEdit = function(){
-  event.preventDefault();
-
   var link = $(this);
   link.parent().find('a.edit-item').toggle();
   link.parent().find('a.cancel-item').toggle();
@@ -116,6 +114,8 @@ toggleItemEdit = function(){
   link.parent().find('a.delete-item').toggle();
   link.parents('tr').find('td.item-qty-show').toggle();
   link.parents('tr').find('td.item-qty-edit').toggle();
+
+  return false;
 }
 
 startItemSplit = function(event){

--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -100,7 +100,7 @@
     <tr class="show-method total">
       <td colspan="4">
         <% if shipment.adjustment.present? %>
-          <strong><%= shipment.adjustment.label %>:</strong>
+          <strong><%= shipment.adjustment.label %>: <%= shipment.shipping_method.name %></strong>
         <% else %>
           <%= Spree.t(:cannot_set_shipping_method_without_address) %>
         <% end %>

--- a/backend/spec/requests/admin/orders/order_details_spec.rb
+++ b/backend/spec/requests/admin/orders/order_details_spec.rb
@@ -73,7 +73,7 @@ describe "Order Details", js: true do
         select2 "Default", :from => "Shipping Method"
         click_icon :ok
 
-        page.should have_content("Default:")
+        page.should have_content("Default")
       end
 
       context "variant out of stock and not backorderable" do
@@ -163,7 +163,7 @@ describe "Order Details", js: true do
             # database_cleaner attempts to clean it
             sleep(1)
 
-            page.should have_content("Default:")
+            page.should have_content("Default")
           end
         end
       end
@@ -205,7 +205,7 @@ describe "Order Details", js: true do
       select2 "Default", :from => "Shipping Method"
       click_icon :ok
 
-      page.should have_content("Default:")
+      page.should have_content("Default")
     end
 
     it 'can ship' do

--- a/backend/spec/requests/admin/orders/shipments_spec.rb
+++ b/backend/spec/requests/admin/orders/shipments_spec.rb
@@ -40,12 +40,12 @@ describe "Shipments" do
       within_row(1) { click_icon 'resize-horizontal' }
       targetted_select2 'LA', from: '#s2id_item_stock_location'
       click_icon :ok
-      page.find("table.stock-contents:eq(2)").should be_visible
+      page.should have_selector("table.stock-contents:eq(2)")
 
-      within_row(1) { click_icon 'resize-horizontal' }
+      within_row(2) { click_icon 'resize-horizontal' }
       targetted_select2 "LA(#{order.reload.shipments.last.number})", from: '#s2id_item_stock_location'
       click_icon :ok
-      page.find("table.stock-contents:eq(2)").should be_visible
+      page.should have_selector("table.stock-contents:eq(2)")
     end
   end
 end

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -349,7 +349,7 @@ describe Spree::Shipment do
 
     it "should create adjustment when not present" do
       shipment.stub(:selected_shipping_rate_id => 1)
-      shipping_method.should_receive(:create_adjustment).with("UPS", order, shipment, true, "open")
+      shipping_method.should_receive(:create_adjustment).with(shipping_method.adjustment_label, order, shipment, true, "open")
       shipment.send(:ensure_correct_adjustment)
     end
 
@@ -365,7 +365,7 @@ describe Spree::Shipment do
       shipment.stub(selected_shipping_rate: mock_model(Spree::ShippingRate, cost: 10.00))
       shipment.stub(adjustment: mock_model(Spree::Adjustment, open?: true))
       shipment.adjustment.should_receive(:originator=).with(shipping_method)
-      shipment.adjustment.should_receive(:label=).with(shipping_method.name)
+      shipment.adjustment.should_receive(:label=).with(shipping_method.adjustment_label)
       shipment.adjustment.should_receive(:amount=).with(10.00)
       shipment.adjustment.should_receive(:save!)
       shipment.adjustment.should_receive(:reload)
@@ -376,7 +376,7 @@ describe Spree::Shipment do
       shipment.stub(selected_shipping_rate: mock_model(Spree::ShippingRate, cost: 10.00))
       shipment.stub(adjustment: mock_model(Spree::Adjustment, open?: false))
       shipment.adjustment.should_receive(:originator=).with(shipping_method)
-      shipment.adjustment.should_receive(:label=).with(shipping_method.name)
+      shipment.adjustment.should_receive(:label=).with(shipping_method.adjustment_label)
       shipment.adjustment.should_not_receive(:amount=).with(10.00)
       shipment.adjustment.should_receive(:save!)
       shipment.adjustment.should_receive(:reload)

--- a/frontend/spec/requests/checkout_spec.rb
+++ b/frontend/spec/requests/checkout_spec.rb
@@ -49,7 +49,7 @@ describe "Checkout" do
         page.should_not have_content("undefined method `promotion'")
 
         click_button "Save and Continue"
-        page.should have_content(shipping_method.name)
+        page.should have_content(shipping_method.adjustment_label)
       end
 
       # Regression test, no issue number


### PR DESCRIPTION
They were mostly failing due to a js error and shiping labels

This time I run at a few times on my ci project to make sure it's all green and now it's, both master and 2-0-stable.
