### PR TITLE
Fix spree sample load data (rails 4)

### DIFF
--- a/sample/db/samples/tax_rates.rb
+++ b/sample/db/samples/tax_rates.rb
@@ -1,6 +1,6 @@
 north_america = Spree::Zone.find_by_name!("North America")
 clothing = Spree::TaxCategory.find_by_name!("Clothing")
-tax_rate = Spree::TaxRate.create!(
+tax_rate = Spree::TaxRate.create(
   :name => "North America",
   :zone => north_america, 
   :amount => 0.05,


### PR DESCRIPTION
Small fix to make `spree_sample:load` on rails4 branch. I'll write the blog post about it today. And then users may run Rails 4 with Spree following these steps https://gist.github.com/huoxito/5727240.
