### PR TITLE
Fixing checkout error

### DIFF
--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -40,6 +40,7 @@ require 'spree/core/engine'
 
 require 'spree/i18n'
 require 'spree/money'
+require 'spree/promo/coupon_applicator'
 
 require 'spree/core/delegate_belongs_to'
 require 'spree/core/ext/active_record'


### PR DESCRIPTION
NameError: uninitialized constant Spree::Core::CouponApplicator was thrown on checkout. Noticed coupon applicator was not being loaded in library.
