### PR TITLE
Fix adding variants to RMAs

### DIFF
--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -46,7 +46,7 @@ module Spree
           next unless inventory_unit.return_authorization.nil? && count < quantity
 
           inventory_unit.return_authorization = self
-          inventory_unit.return!
+          inventory_unit.save!
 
           count += 1
         end

--- a/core/spec/models/spree/return_authorization_spec.rb
+++ b/core/spec/models/spree/return_authorization_spec.rb
@@ -27,6 +27,11 @@ describe Spree::ReturnAuthorization do
         return_authorization.inventory_units.size.should == 1
       end
 
+      it "should associate inventory units as shipped" do
+        return_authorization.add_variant(variant.id, 1)
+        expect(return_authorization.inventory_units.where(state: 'shipped').size).to eq 1
+      end
+
       it "should update order state" do
         order.should_receive(:authorize_return!)
         return_authorization.add_variant(variant.id, 1)
@@ -34,16 +39,17 @@ describe Spree::ReturnAuthorization do
     end
 
     context "on rma that already has inventory_units" do
-      before { order.stub(:awaiting_return? => true) }
+      before do 
+        return_authorization.add_variant(variant.id, 1)
+      end
 
-      xit "should associate inventory unit" do
-        order.stub(:authorize_return!)
-        return_authorization.add_variant(variant.id, 2)
-        return_authorization.inventory_units.size.should == 2
+      it "should not associate more inventory units than there are on the order" do
+        return_authorization.add_variant(variant.id, 1)
+        expect(return_authorization.inventory_units.size).to eq 1
       end
 
       it "should not update order state" do
-        return_authorization.add_variant(variant.id, 1)
+        expect{return_authorization.add_variant(variant.id, 1)}.to_not change{order.state}
       end
 
     end


### PR DESCRIPTION
When adding a variant to an RMA, it should not be marked as received until the RMA itself has been marked as received.

Fixes https://github.com/spree/spree/issues/3121
