### PR TITLE
No need to call `order.create_proposed_shipments` twice

### DIFF
--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -91,11 +91,6 @@ module Spree
           @order.ship_address ||= Address.default
         end
 
-        def before_delivery
-          return if params[:order].present?
-          @order.create_proposed_shipments
-        end
-
         def before_payment
           @order.payments.destroy_all if request.put?
         end

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -128,8 +128,6 @@ module Spree
       def before_delivery
         return if params[:order].present?
 
-        @order.create_proposed_shipments
-
         packages = @order.shipments.map { |s| s.to_package }
         @differentiator = Spree::Stock::Differentiator.new(@order, packages)
       end


### PR DESCRIPTION
Shipments are already destroyed and created every time order moves from
address to delivery

As reported in #3169. But I'm not sure how exactly it causes that error. Either way calling `create_proposed_shipments` twice seems like a bad use of current Spree API.
