### PR TITLE
Redirect to customer details page should not depend on order state.

### DIFF
--- a/backend/app/controllers/spree/admin/payments_controller.rb
+++ b/backend/app/controllers/spree/admin/payments_controller.rb
@@ -85,14 +85,8 @@ module Spree
         @previous_cards = @order.credit_cards.with_payment_profile
       end
 
-      # At this point admin should have passed through Customer Details step
-      # where order.next is called which leaves the order in payment step
-      #
-      # Orders in complete step also allows to access this controller
-      #
-      # Otherwise redirect user to that step
       def can_transition_to_payment
-        unless @order.payment? || @order.complete?
+        unless @order.billing_address.present? 
           flash[:notice] = Spree.t(:fill_in_customer_info)
           redirect_to edit_admin_order_customer_url(@order)
         end

--- a/backend/spec/controllers/spree/admin/payments_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/payments_controller_spec.rb
@@ -7,28 +7,42 @@ module Spree
 
       let(:order) { create(:order) }
 
-      before do
-        Spree::Order.stub find_by_number!: order
-        order.stub(:payment_required? => true)
-      end
+      context "order has billing address" do
 
-      context "order has no payments" do
-        context "passed through customer details step" do
-          before { order.stub(state: "payment") }
+        before do
+          order.bill_address = create(:address)
+          order.save!
+        end
 
+        context "order does not have payments" do
           it "redirect to new payments page" do
-            spree_get :index, { amount: 100 }
+            spree_get :index, { amount: 100, order_id: order.number }
             response.should redirect_to(spree.new_admin_order_payment_path(order))
           end
         end
 
-        context "try to skip customer details step" do
-          it "redirect to customer details step" do
-            spree_get :index, { amount: 100 }
-            response.should redirect_to(spree.edit_admin_order_customer_path(order))
+        context "order has payments" do
+          
+          before do
+            order.payments << create(:payment, amount: order.total, order: order, state: 'completed')
+          end
+
+          it "shows the payments page" do
+            spree_get :index, { amount: 100, order_id: order.number }
+            expect(response.code).to eq "200"
           end
         end
+
       end
+
+      context "order does not have a billing address" do
+
+        it "should redirect to the customer details page" do
+          spree_get :index, { amount: 100, order_id: order.number }
+          expect(response).to redirect_to(spree.edit_admin_order_customer_path(order))
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
The problem with the current method is twofold:
1. It does not account for any states that occur after the order has been created, specifically 'awaiting_return' and 'returned' . The latter causes a problem because it is impossible to then go to payments to refund the money if items have been returned in an RMA. Adding those 2 states to the current `unless` statement seems like a code smell.
2. It assumes the implementer has not modified the checkout steps; it essentially binds people to the checkout steps that are there by default.

In general, it seems like we should only be concerned with the presence of the billing address before we create a new payment. 
