### PR TITLE
Fix set expiry js response, update checkout.js

### DIFF
--- a/api/app/controllers/spree/api/states_controller.rb
+++ b/api/app/controllers/spree/api/states_controller.rb
@@ -1,6 +1,7 @@
 module Spree
   module Api
     class StatesController < Spree::Api::BaseController
+      skip_before_filter :set_expiry
 
       def index
         @states = scope.ransack(params[:q]).result.

--- a/frontend/app/assets/javascripts/store/checkout.js.coffee
+++ b/frontend/app/assets/javascripts/store/checkout.js.coffee
@@ -45,6 +45,7 @@ Spree.ready ($) ->
         statePara.show()
         stateSpanRequired.show()
         stateSelect.addClass('required') if statesRequired
+        stateSelect.removeClass('hidden')
         stateInput.removeClass('required')
       else
         stateSelect.hide().prop 'disabled', true

--- a/frontend/spec/requests/address_spec.rb
+++ b/frontend/spec/requests/address_spec.rb
@@ -20,6 +20,9 @@ describe "Address" do
 
   context "country requires state", :js => true, :focus => true do
     let!(:canada) { create(:country, :name => "Canada", :states_required => true, :iso => "CA") }
+    let!(:uk) { create(:country, :name => "United Kingdom", :states_required => true, :iso => "UK") }
+
+    before { Spree::Config[:default_country_id] = uk.id }
 
     context "but has no state" do
       it "shows the state input field" do
@@ -45,6 +48,7 @@ describe "Address" do
         page.should have_selector(@state_select_css, visible: true)
         page.should have_selector(@state_name_css, visible: false)
         find(@state_select_css)['class'].should =~ /required/
+        find(@state_select_css)['class'].should_not =~ /hidden/
         find(@state_name_css)['class'].should_not =~ /required/
       end
     end


### PR DESCRIPTION
It seems that somehow c3db7b7ff628b481403b9be8372257f14cd39d73 broke the checkout.js script on the frontend (the js that controls switching between state text input and state select). I am not 100% clear why this is the case but perhaps it has something to do with the way jQuery handles cache control headers? 

I am unsure why this is the case but it does seem that `frontend/spec/requests/address_spec.rb` fails as of this commit, and passes if one rolls back to its parent.

I also found an edge case where having no default_country_id, or one without associated states in the db, would leave the 'hidden' class on the state_select.
