### PR TITLE
add user_id index to spree_orders

### DIFF
--- a/core/db/migrate/20130611185927_add_user_id_index_to_spree_orders.rb
+++ b/core/db/migrate/20130611185927_add_user_id_index_to_spree_orders.rb
@@ -1,0 +1,5 @@
+class AddUserIdIndexToSpreeOrders < ActiveRecord::Migration
+  def change
+    add_index :spree_orders, :user_id
+  end
+end


### PR DESCRIPTION
If you update a cart (for example, change the quantity of a line item and click "update") while a user is logged in, the following query is executed:

``` sql
SELECT "spree_orders".* FROM "spree_orders" WHERE "spree_orders"."user_id" = 2 AND "spree_orders"."completed_at" IS NULL ORDER BY created_at DESC LIMIT 1
```

This results in a table scan without the index that is created by this patch. Also, it's just good practice to index a foreign key that you know will be queried against.
