### PR TITLE
Add `touch: true` option to `Spree::Asset#viewable` association

### DIFF
--- a/core/app/models/spree/asset.rb
+++ b/core/app/models/spree/asset.rb
@@ -1,6 +1,6 @@
 module Spree
   class Asset < ActiveRecord::Base
-    belongs_to :viewable, polymorphic: true
+    belongs_to :viewable, polymorphic: true, touch: true
     acts_as_list scope: :viewable
   end
 end

--- a/core/spec/models/spree/asset_spec.rb
+++ b/core/spec/models/spree/asset_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe Spree::Asset do
+
+  describe "#viewable" do
+
+    it "touches association" do
+      product = create(:custom_product)
+      asset = Spree::Asset.create! { |a| a.viewable = product.master }
+
+      old_updated_at = 100.years.ago
+      product.update_column(:updated_at, old_updated_at)
+
+      expect do
+        asset.touch
+      end.to change { product.reload.updated_at }.from(old_updated_at)
+    end
+
+  end
+
+end

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -2,6 +2,13 @@
 
 require 'spec_helper'
 
+module ThirdParty
+  class Extension < ActiveRecord::Base
+    # nasty hack so we don't have to create a table to back this fake model
+    set_table_name :spree_products
+  end
+end
+
 describe Spree::Product do
   context 'product instance' do
     let(:product) { create(:product) }


### PR DESCRIPTION
We're using a fragment cache like:

``` erb
<% cache product do %>
  ...
<% end %>
```

But when a product images is created/updated/destroyed then `product.updated_at` does not get updated and the cache does not get invalidated. This pull request fixes that.

This is a common caching paradigm in Rails. If you are unfamiliar with it, then check out this [Railscast](http://railscasts.com/episodes/90-fragment-caching-revised). Also, `Spree::Variant` [already does this](https://github.com/spree/spree/blob/7abd266f50d8c7bbb609c086df78a164f1cf200b/core/app/models/spree/variant.rb#L3).
