### PR TITLE
Rails 4 tweaks for Spree API component

### DIFF
--- a/api/app/controllers/spree/api/addresses_controller.rb
+++ b/api/app/controllers/spree/api/addresses_controller.rb
@@ -12,12 +12,17 @@ module Spree
         @address = Address.find(params[:id])
         authorize! :update, @address
 
-        if @address.update_attributes(params[:address])
+        if @address.update_attributes(address_params)
           respond_with(@address, :default_template => :show)
         else
           invalid_resource!(@address)
         end
       end
+
+      private
+        def address_params
+          params.require(:address).permit(permitted_address_attributes)
+        end
     end
   end
 end

--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -3,8 +3,10 @@ require_dependency 'spree/api/controller_setup'
 module Spree
   module Api
     class BaseController < ActionController::Metal
+      include ActionController::StrongParameters
       include Spree::Api::ControllerSetup
       include Spree::Core::ControllerHelpers::SSL
+      include Spree::Core::ControllerHelpers::StrongParameters
       include ::ActionController::Head
 
       self.responder = Spree::Api::Responders::AppResponder

--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -103,7 +103,7 @@ module Spree
       end
 
       def api_key
-        request.headers["X-Spree-Token"] || params[:token]
+        request.headers.env["X-Spree-Token"] || params[:token]
       end
       helper_method :api_key
 

--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -21,10 +21,7 @@ module Spree
       end
 
       def update
-        user_id = object_params.delete(:user_id)
         if @order.update_attributes(object_params)
-          # TODO: Replace with better code when we switch to strong_parameters
-          # Also remove above user_id stripping
           if current_api_user.has_spree_role?("admin") && user_id.present?
             @order.associate_user!(Spree.user_class.find(user_id))
           end
@@ -49,7 +46,16 @@ module Spree
               params[:order][:payments_attributes].first[:amount] = @order.total
             end
           end
-          params[:order] || {}
+
+          if params[:order]
+            params.require(:order).permit(permitted_checkout_attributes)
+          else
+            {}
+          end
+        end
+
+        def user_id
+          params[:order][:user_id] if params[:order]
         end
 
         def nested_params

--- a/api/app/controllers/spree/api/images_controller.rb
+++ b/api/app/controllers/spree/api/images_controller.rb
@@ -9,13 +9,13 @@ module Spree
 
       def create
         authorize! :create, Image
-        @image = Image.create(params[:image])
+        @image = Image.create(image_params)
         respond_with(@image, :status => 201, :default_template => :show)
       end
 
       def update
         @image = Image.accessible_by(current_ability, :update).find(params[:id])
-        @image.update_attributes(params[:image])
+        @image.update_attributes(image_params)
         respond_with(@image, :default_template => :show)
       end
 
@@ -24,6 +24,11 @@ module Spree
         @image.destroy
         respond_with(@image, :status => 204)
       end
+
+      private
+        def image_params
+          params.require(:image).permit(permitted_image_attributes)
+        end
     end
   end
 end

--- a/api/app/controllers/spree/api/inventory_units_controller.rb
+++ b/api/app/controllers/spree/api/inventory_units_controller.rb
@@ -11,7 +11,7 @@ module Spree
         authorize! :update, inventory_unit.order
 
         inventory_unit.transaction do
-          if inventory_unit.update_attributes(params[:inventory_unit])
+          if inventory_unit.update_attributes(inventory_unit_params)
             fire
             render :show, :status => 200
           else
@@ -42,7 +42,10 @@ module Spree
       def fire
         inventory_unit.send("#{@event}!") if @event
       end
-
+      
+      def inventory_unit_params
+        params.require(:inventory_unit).permit(permitted_inventory_unit_attributes)
+      end
     end
   end
 end

--- a/api/app/controllers/spree/api/line_items_controller.rb
+++ b/api/app/controllers/spree/api/line_items_controller.rb
@@ -4,7 +4,7 @@ module Spree
 
       def create
         authorize! :update, order
-        @line_item = order.line_items.build(params[:line_item], :as => :api)
+        @line_item = order.line_items.build(line_item_params)
         if @line_item.save
           respond_with(@line_item, :status => 201, :default_template => :show)
         else
@@ -15,7 +15,7 @@ module Spree
       def update
         authorize! :update, order
         @line_item = order.line_items.find(params[:id])
-        if @line_item.update_attributes(params[:line_item], :as => :api)
+        if @line_item.update_attributes(line_item_params)
           respond_with(@line_item, :default_template => :show)
         else
           invalid_resource!(@line_item)
@@ -34,6 +34,10 @@ module Spree
       def order
         @order ||= Order.find_by_number!(params[:order_id])
         authorize! :read, @order
+      end
+
+      def line_item_params
+        params.require(:line_item).permit(:quantity, :variant_id)
       end
     end
   end

--- a/api/app/controllers/spree/api/option_types_controller.rb
+++ b/api/app/controllers/spree/api/option_types_controller.rb
@@ -17,7 +17,7 @@ module Spree
 
       def create
         authorize! :create, Spree::OptionType
-        @option_type = Spree::OptionType.new(params[:option_type])
+        @option_type = Spree::OptionType.new(option_type_params)
         if @option_type.save
           render :show, :status => 201
         else
@@ -27,7 +27,7 @@ module Spree
 
       def update
         @option_type = Spree::OptionType.accessible_by(current_ability, :update).find(params[:id])
-        if @option_type.update_attributes(params[:option_type])
+        if @option_type.update_attributes(option_type_params)
           render :show
         else
           invalid_resource!(@option_type)
@@ -39,6 +39,11 @@ module Spree
         @option_type.destroy
         render :text => nil, :status => 204
       end
+
+      private
+        def option_type_params
+          params.require(:option_type).permit(permitted_option_type_attributes)
+        end
     end
   end
 end

--- a/api/app/controllers/spree/api/option_values_controller.rb
+++ b/api/app/controllers/spree/api/option_values_controller.rb
@@ -17,7 +17,7 @@ module Spree
 
       def create
         authorize! :create, Spree::OptionValue
-        @option_value = scope.new(params[:option_value])
+        @option_value = scope.new(option_value_params)
         if @option_value.save
           render :show, :status => 201
         else
@@ -27,7 +27,7 @@ module Spree
 
       def update
         @option_value = scope.accessible_by(current_ability, :update).find(params[:id])
-        if @option_value.update_attributes(params[:option_value])
+        if @option_value.update_attributes(option_value_params)
           render :show
         else
           invalid_resource!(@option_value)
@@ -48,6 +48,10 @@ module Spree
           else
             @scope ||= Spree::OptionValue.accessible_by(current_ability, :read).scoped
           end
+        end
+
+        def option_value_params
+          params.require(:option_value).permit(permitted_option_type_attributes)
         end
     end
   end

--- a/api/app/controllers/spree/api/payments_controller.rb
+++ b/api/app/controllers/spree/api/payments_controller.rb
@@ -16,7 +16,7 @@ module Spree
       end
 
       def create
-        @payment = @order.payments.build(params[:payment])
+        @payment = @order.payments.build(payment_params)
         if @payment.save
           respond_with(@payment, :status => 201, :default_template => :show)
         else
@@ -73,6 +73,10 @@ module Spree
           @error = e.message
           render "spree/api/errors/gateway_error", :status => 422
         end
+      end
+
+      def payment_params
+        params.require(:payment).permit(permitted_payment_attributes)
       end
     end
   end

--- a/api/app/controllers/spree/api/product_properties_controller.rb
+++ b/api/app/controllers/spree/api/product_properties_controller.rb
@@ -21,7 +21,7 @@ module Spree
 
       def create
         authorize! :create, ProductProperty
-        @product_property = @product.product_properties.new(params[:product_property])
+        @product_property = @product.product_properties.new(product_property_params)
         if @product_property.save
           respond_with(@product_property, :status => 201, :default_template => :show)
         else
@@ -32,7 +32,7 @@ module Spree
       def update
         if @product_property
           authorize! :update, @product_property
-          @product_property.update_attributes(params[:product_property])
+          @product_property.update_attributes(product_property_params)
           respond_with(@product_property, :status => 200, :default_template => :show)
         else
           invalid_resource!(@product_property)
@@ -62,6 +62,10 @@ module Spree
             @product_property ||= @product.product_properties.includes(:property).where('spree_properties.name' => params[:id]).first
             authorize! :read, @product_property
           end
+        end
+
+        def product_property_params
+          params.require(:product_property).permit(permitted_product_properties_attributes)
         end
     end
   end

--- a/api/app/controllers/spree/api/products_controller.rb
+++ b/api/app/controllers/spree/api/products_controller.rb
@@ -25,7 +25,7 @@ module Spree
       def create
         authorize! :create, Product
         params[:product][:available_on] ||= Time.now
-        @product = Product.new(params[:product])
+        @product = Product.new(product_params)
         if @product.save
           respond_with(@product, :status => 201, :default_template => :show)
         else
@@ -36,7 +36,7 @@ module Spree
       def update
         @product = find_product(params[:id])
         authorize! :update, @product
-        if @product.update_attributes(params[:product])
+        if @product.update_attributes(product_params)
           respond_with(@product, :status => 200, :default_template => :show)
         else
           invalid_resource!(@product)
@@ -50,6 +50,11 @@ module Spree
         @product.variants_including_master.update_all(:deleted_at => Time.now)
         respond_with(@product, :status => 204)
       end
+
+      private
+        def product_params
+          params.require(:product).permit(permitted_product_attributes)
+        end
     end
   end
 end

--- a/api/app/controllers/spree/api/properties_controller.rb
+++ b/api/app/controllers/spree/api/properties_controller.rb
@@ -20,7 +20,7 @@ module Spree
 
       def create
         authorize! :create, Property
-        @property = Spree::Property.new(params[:property])
+        @property = Spree::Property.new(property_params)
         if @property.save
           respond_with(@property, :status => 201, :default_template => :show)
         else
@@ -31,7 +31,7 @@ module Spree
       def update
         if @property
           authorize! :update, @property
-          @property.update_attributes(params[:property])
+          @property.update_attributes(property_params)
           respond_with(@property, :status => 200, :default_template => :show)
         else
           invalid_resource!(@property)
@@ -56,6 +56,9 @@ module Spree
         @property = Spree::Property.accessible_by(current_ability, :read).find_by_name!(params[:id])
       end
 
+      def property_params
+        params.require(:property).permit(permitted_property_attributes)
+      end
     end
   end
 end

--- a/api/app/controllers/spree/api/return_authorizations_controller.rb
+++ b/api/app/controllers/spree/api/return_authorizations_controller.rb
@@ -4,7 +4,7 @@ module Spree
 
       def create
         authorize! :create, ReturnAuthorization
-        @return_authorization = order.return_authorizations.build(params[:return_authorization], :as => :api)
+        @return_authorization = order.return_authorizations.build(return_authorization_params)
         if @return_authorization.save
           respond_with(@return_authorization, :status => 201, :default_template => :show)
         else
@@ -38,7 +38,7 @@ module Spree
 
       def update
         @return_authorization = order.return_authorizations.accessible_by(current_ability, :update).find(params[:id])
-        if @return_authorization.update_attributes(params[:return_authorization])
+        if @return_authorization.update_attributes(return_authorization_params)
           respond_with(@return_authorization, :default_template => :show)
         else
           invalid_resource!(@return_authorization)
@@ -52,6 +52,9 @@ module Spree
         authorize! :read, @order
       end
 
+      def return_authorization_params
+        params.require(:return_authorization).permit(permitted_return_authorization_attributes)
+      end
     end
   end
 end

--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -27,7 +27,7 @@ module Spree
           @shipment.adjustment.open
         end
 
-        @shipment.update_attributes(params[:shipment])
+        @shipment.update_attributes(shipment_params)
 
         if unlock == 'yes'
           @shipment.adjustment.close
@@ -82,8 +82,16 @@ module Spree
 
       def find_and_update_shipment
         @shipment = @order.shipments.accessible_by(current_ability, :update).find_by_number!(params[:id])
-        @shipment.update_attributes(params[:shipment])
+        @shipment.update_attributes(shipment_params)
         @shipment.reload
+      end
+
+      def shipment_params
+        if params[:shipment] && !params[:shipment].empty?
+          params.require(:shipment).permit(permitted_shipment_attributes)
+        else
+          {}
+        end
       end
     end
   end

--- a/api/app/controllers/spree/api/stock_items_controller.rb
+++ b/api/app/controllers/spree/api/stock_items_controller.rb
@@ -19,10 +19,9 @@ module Spree
         count_on_hand = 0
         if params[:stock_item].has_key?(:count_on_hand)
           count_on_hand = params[:stock_item][:count_on_hand].to_i
-          params[:stock_item].delete(:count_on_hand)
         end
 
-        @stock_item = scope.new(params[:stock_item])
+        @stock_item = scope.new(stock_item_params)
         if @stock_item.save
           @stock_item.adjust_count_on_hand(count_on_hand)
           respond_with(@stock_item, status: 201, default_template: :show)
@@ -62,6 +61,10 @@ module Spree
 
       def scope
         @stock_location.stock_items.accessible_by(current_ability, :read).includes(:variant => :product)
+      end
+
+      def stock_item_params
+        params.require(:stock_item).permit(permitted_stock_item_attributes)
       end
     end
   end

--- a/api/app/controllers/spree/api/stock_locations_controller.rb
+++ b/api/app/controllers/spree/api/stock_locations_controller.rb
@@ -12,7 +12,7 @@ module Spree
 
       def create
         authorize! :create, StockLocation
-        @stock_location = StockLocation.new(params[:stock_location])
+        @stock_location = StockLocation.new(stock_location_params)
         if @stock_location.save
           respond_with(@stock_location, status: 201, default_template: :show)
         else
@@ -22,7 +22,7 @@ module Spree
 
       def update
         authorize! :update, stock_location
-        if stock_location.update_attributes(params[:stock_location])
+        if stock_location.update_attributes(stock_location_params)
           respond_with(stock_location, status: 200, default_template: :show)
         else
           invalid_resource!(stock_location)
@@ -39,6 +39,10 @@ module Spree
 
       def stock_location
         @stock_location ||= StockLocation.accessible_by(current_ability, :read).find(params[:id])
+      end
+
+      def stock_location_params
+        params.require(:stock_location).permit(permitted_stock_location_attributes)
       end
     end
   end

--- a/api/app/controllers/spree/api/stock_movements_controller.rb
+++ b/api/app/controllers/spree/api/stock_movements_controller.rb
@@ -15,7 +15,7 @@ module Spree
 
       def create
         authorize! :create, StockMovement
-        @stock_movement = scope.new(params[:stock_movement])
+        @stock_movement = scope.new(stock_movement_params)
         if @stock_movement.save
           respond_with(@stock_movement, status: 201, default_template: :show)
         else
@@ -25,7 +25,7 @@ module Spree
 
       def update
         @stock_movement = StockMovement.accessible_by(current_ability, :update).find(params[:id])
-        if @stock_movement.update_attributes(params[:stock_movement])
+        if @stock_movement.update_attributes(stock_movement_params)
           respond_with(@stock_movement, status: 200, default_template: :show)
         else
           invalid_resource!(@stock_movement)
@@ -47,6 +47,10 @@ module Spree
 
       def scope
         @stock_location.stock_movements.accessible_by(current_ability, :read)
+      end
+
+      def stock_movement_params
+        params.require(:stock_movement).permit(permitted_stock_movement_attributes)
       end
     end
   end

--- a/api/app/controllers/spree/api/taxonomies_controller.rb
+++ b/api/app/controllers/spree/api/taxonomies_controller.rb
@@ -21,7 +21,7 @@ module Spree
 
       def create
         authorize! :create, Taxonomy
-        @taxonomy = Taxonomy.new(params[:taxonomy])
+        @taxonomy = Taxonomy.new(taxonomy_params)
         if @taxonomy.save
           respond_with(@taxonomy, :status => 201, :default_template => :show)
         else
@@ -31,7 +31,7 @@ module Spree
 
       def update
         authorize! :update, taxonomy
-        if taxonomy.update_attributes(params[:taxonomy])
+        if taxonomy.update_attributes(taxonomy_params)
           respond_with(taxonomy, :status => 200, :default_template => :show)
         else
           invalid_resource!(taxonomy)
@@ -50,6 +50,13 @@ module Spree
         @taxonomy ||= Taxonomy.accessible_by(current_ability, :read).find(params[:id])
       end
 
+      def taxonomy_params
+        if params[:taxonomy] && !params[:taxonomy].empty?
+          params.require(:taxonomy).permit(permitted_taxonomy_attributes)
+        else
+          {}
+        end
+      end
     end
   end
 end

--- a/api/app/controllers/spree/api/taxons_controller.rb
+++ b/api/app/controllers/spree/api/taxons_controller.rb
@@ -26,7 +26,7 @@ module Spree
 
       def create
         authorize! :create, Taxon
-        @taxon = Taxon.new(params[:taxon])
+        @taxon = Taxon.new(taxon_params)
         @taxon.taxonomy_id = params[:taxonomy_id]
         taxonomy = Taxonomy.find_by_id(params[:taxonomy_id])
 
@@ -46,7 +46,7 @@ module Spree
 
       def update
         authorize! :update, taxon
-        if taxon.update_attributes(params[:taxon])
+        if taxon.update_attributes(taxon_params)
           respond_with(taxon, :status => 200, :default_template => :show)
         else
           invalid_resource!(taxon)
@@ -71,6 +71,13 @@ module Spree
         @taxon ||= taxonomy.taxons.accessible_by(current_ability, :read).find(params[:id])
       end
 
+      def taxon_params
+        if params[:taxon] && !params[:taxon].empty?
+          params.require(:taxon).permit(permitted_taxon_attributes)
+        else
+          {}
+        end
+      end
     end
   end
 end

--- a/api/app/controllers/spree/api/users_controller.rb
+++ b/api/app/controllers/spree/api/users_controller.rb
@@ -16,7 +16,7 @@ module Spree
 
       def create
         authorize! :create, Spree.user_class
-        @user = Spree.user_class.new(params[:user])
+        @user = Spree.user_class.new(user_params)
         if @user.save
           respond_with(@user, :status => 201, :default_template => :show)
         else
@@ -26,7 +26,7 @@ module Spree
 
       def update
         authorize! :update, user
-        if user.update_attributes(params[:user])
+        if user.update_attributes(user_params)
           respond_with(user, :status => 200, :default_template => :show)
         else
           invalid_resource!(user)
@@ -43,6 +43,10 @@ module Spree
 
       def user
         @user ||= Spree.user_class.accessible_by(current_ability, :read).find(params[:id])
+      end
+
+      def user_params
+        params.require(:user).permit(permitted_user_attributes)
       end
     end
   end

--- a/api/app/controllers/spree/api/variants_controller.rb
+++ b/api/app/controllers/spree/api/variants_controller.rb
@@ -6,7 +6,7 @@ module Spree
 
       def create
         authorize! :create, Variant
-        @variant = scope.new(params[:variant])
+        @variant = scope.new(variant_params)
         if @variant.save
           respond_with(@variant, :status => 201, :default_template => :show)
         else
@@ -36,7 +36,7 @@ module Spree
 
       def update
         @variant = scope.accessible_by(current_ability, :update).find(params[:id])
-        if @variant.update_attributes(params[:variant])
+        if @variant.update_attributes(variant_params)
           respond_with(@variant, :status => 200, :default_template => :show)
         else
           invalid_resource!(@product)
@@ -66,6 +66,10 @@ module Spree
             end
           end
           variants
+        end
+
+        def variant_params
+          params.require(:variant).permit(permitted_variant_attributes)
         end
     end
   end

--- a/api/lib/spree/api/responders/rabl_template.rb
+++ b/api/lib/spree/api/responders/rabl_template.rb
@@ -14,7 +14,7 @@ module Spree
         end
 
         def template
-          request.headers['X-Spree-Template'] || controller.params[:template] || options[:default_template]
+          request.headers.env['X-Spree-Template'] || controller.params[:template] || options[:default_template]
         end
       end
     end

--- a/api/spec/controllers/spree/api/return_authorizations_controller_spec.rb
+++ b/api/spec/controllers/spree/api/return_authorizations_controller_spec.rb
@@ -114,7 +114,7 @@ module Spree
       end
 
       it "can add a new return authorization to an existing order" do
-        api_post :create, :return_autorization => { :order_id => order.number, :amount => 14.22, :reason => "Defective" }
+        api_post :create, :order_id => order.number, :return_authorization => { :amount => 14.22, :reason => "Defective" }
         response.status.should == 201
         json_response.should have_attributes(attributes)
         json_response["state"].should_not be_blank

--- a/api/spec/controllers/spree/api/zones_controller_spec.rb
+++ b/api/spec/controllers/spree/api/zones_controller_spec.rb
@@ -48,13 +48,13 @@ module Spree
       end
 
       it "uses the specified template" do
-        request.env['X-Spree-Template'] = 'show'
+        request.headers.env['X-Spree-Template'] = 'show'
         api_get :custom_show, :id => @zone.id
         response.should render_template('spree/api/zones/show')
       end
 
       it "falls back to the default template if the specified template does not exist" do
-        request.env['X-Spree-Template'] = 'invoice'
+        request.headers.env['X-Spree-Template'] = 'invoice'
         api_get :show, :id => @zone.id
         response.should render_template('spree/api/zones/show')
       end

--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -6,7 +6,13 @@ module Spree
     belongs_to :return_authorization, class_name: "Spree::ReturnAuthorization"
 
     scope :backordered, -> { where state: 'backordered' }
-    scope :shipped,     -> { where state: 'shipped' }
+    scope :shipped, -> { where state: 'shipped' }
+    scope :backordered_per_variant, ->(stock_item) do
+      includes(:shipment)
+        .where("spree_shipments.state != 'canceled'").references(:shipment)
+        .where(variant_id: stock_item.variant_id)
+        .backordered.order("#{self.table_name}.created_at ASC")
+    end
 
     # state machine (see http://github.com/pluginaweek/state_machine/tree/master for details)
     state_machine initial: :on_hand do
@@ -24,14 +30,16 @@ module Spree
       end
     end
 
+    # This was refactored from a simpler query because the previous implementation
+    # lead to issues once users tried to modify the objects returned. That's due
+    # to ActiveRecord `joins(shipment: :stock_location)` only return readonly
+    # objects
+    # 
+    # Returns an array of backordered inventory units as per a given stock item
     def self.backordered_for_stock_item(stock_item)
-      stock_locations_table = Spree::StockLocation.table_name
-      shipments_table = Spree::Shipment.table_name
-      joins(shipment: :stock_location).
-      where("#{stock_locations_table}.id = ?", stock_item.stock_location_id).
-      where(variant_id: stock_item.variant_id).
-      where("#{shipments_table}.state != 'canceled'").
-      backordered.order('created_at ASC')
+      backordered_per_variant(stock_item).select do |unit|
+        unit.shipment.stock_location == stock_item.stock_location
+      end
     end
 
     def self.finalize_units!(inventory_units)

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -363,7 +363,7 @@ module Spree
 
     def credit_cards
       credit_card_ids = payments.from_credit_card.pluck(:source_id).uniq
-      CreditCard.scoped(conditions: { id: credit_card_ids })
+      CreditCard.all(conditions: { id: credit_card_ids })
     end
 
     # Finalizes an in progress order after checkout is complete.

--- a/core/app/models/spree/order_inventory.rb
+++ b/core/app/models/spree/order_inventory.rb
@@ -29,7 +29,7 @@ module Spree
     end
 
     def inventory_units_for(variant)
-      units = order.shipments.collect{|s| s.inventory_units.all}.flatten
+      units = order.shipments.collect{|s| s.inventory_units.to_a}.flatten
       units.group_by(&:variant_id)[variant.id] || []
     end
 

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -17,8 +17,8 @@ module Spree
     has_many :images, -> { order(:position) }, as: :viewable, dependent: :destroy, class_name: "Spree::Image"
 
     has_one :default_price,
+      -> { where currency: Spree::Config[:currency] },
       class_name: 'Spree::Price',
-      conditions: proc { { currency: Spree::Config[:currency] } },
       dependent: :destroy
 
     delegate_belongs_to :default_price, :display_price, :display_amount, :price, :price=, :currency if Spree::Price.table_exists?

--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -2,7 +2,7 @@ module Spree
   class Zone < ActiveRecord::Base
     has_many :zone_members, dependent: :destroy, class_name: "Spree::ZoneMember"
     has_many :tax_rates, dependent: :destroy
-    has_and_belongs_to_many :shipping_methods
+    has_and_belongs_to_many :shipping_methods, join_table: "shipping_methods_zones"
 
     validates :name, presence: true, uniqueness: true
     after_save :remove_defunct_members

--- a/core/lib/spree/core/controller_helpers/strong_parameters.rb
+++ b/core/lib/spree/core/controller_helpers/strong_parameters.rb
@@ -20,6 +20,93 @@ module Spree
         def permitted_payment_attributes
           [:payment_method_id, :source_attributes => permitted_source_attributes]
         end
+
+        def permitted_checkout_attributes
+          [:email, :use_billing, :shipping_method_id, :coupon_code,
+           :bill_address_attributes => permitted_address_attributes,
+           :ship_address_attributes => permitted_address_attributes,
+           :payments_attributes => permitted_payment_attributes]
+        end
+
+        def permitted_image_attributes
+          [:alt, :attachment, :position, :viewable_type, :viewable_id]
+        end
+
+        def permitted_inventory_unit_attributes
+          [:shipment, :variant_id]
+        end
+
+        def permitted_option_type_attributes
+          [:name, :presentation, :option_values_attributes]
+        end
+
+        def permitted_option_value_attributes
+          [:name, :presentation]
+        end
+
+        def permitted_payment_attributes
+          [:amount, :payment_method_id, :source_attributes]
+        end
+
+        def permitted_product_properties_attributes
+          [:property_name, :value, :position]
+        end
+
+        def permitted_product_attributes
+          [:name, :description, :available_on, :permalink, :meta_description,
+           :meta_keywords, :price, :sku, :deleted_at, :prototype_id,
+           :option_values_hash, :weight, :height, :width, :depth,
+           :shipping_category_id, :tax_category_id, :product_properties_attributes,
+           :variants_attributes, :taxon_ids, :option_type_ids, :cost_currency, :cost_price]
+        end
+
+        def permitted_property_attributes
+          [:name, :presentation]
+        end
+
+        def permitted_return_authorization_attributes
+          [:amount, :reason, :stock_location_id]
+        end
+
+        def permitted_shipment_attributes
+          [:order, :special_instructions, :stock_location_id,
+           :tracking, :address, :inventory_units, :selected_shipping_rate_id]
+        end
+
+        def permitted_stock_item_attributes
+          [:variant, :stock_location, :backorderable, :variant_id]
+        end
+
+        def permitted_stock_location_attributes
+          [:name, :active, :address1, :address2, :city, :zipcode,
+           :backorderable_default, :state_name, :state_id, :country_id, :phone,
+           :propagate_all_variants]
+        end
+
+        def permitted_stock_movement_attributes
+          [:quantity, :stock_item, :stock_item_id, :originator, :action]
+        end
+
+        def permitted_taxonomy_attributes
+          [:name]
+        end
+
+        def permitted_taxon_attributes
+          [:name, :parent_id, :position, :icon, :description, :permalink, :taxonomy_id,
+           :meta_description, :meta_keywords, :meta_title]
+        end
+
+        # TODO Should probably use something like Spree.user_class.permitted_attributes
+        def permitted_user_attributes
+          [:email, :password, :password_confirmation]
+        end
+
+        def permitted_variant_attributes
+          [:name, :presentation, :cost_price, :lock_version,
+           :position, :option_value_ids,
+           :product_id, :option_values_attributes, :price,
+           :weight, :height, :width, :depth, :sku, :cost_currency]
+        end
       end
     end
   end


### PR DESCRIPTION
Core build still looks all green on Rails 4 rc2. API component is down to 1 failing spec. Frontend should be all green too in rc2 but I haven't run it yet. We've got some more backend specs failing but I believe that's related to some spec environment tweak only. Users should be able to use backend just fine in general.

I'm excited with the possibility that we may have Spree just ready for Rails 4 as soon as it's released :)
