### PR TITLE
Allow unshippable items on the order

### DIFF
--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -133,10 +133,12 @@ module Spree
       end
 
       def before_payment
-        packages = @order.shipments.map { |s| s.to_package }
-        @differentiator = Spree::Stock::Differentiator.new(@order, packages)
-        @differentiator.missing.each do |variant, quantity|
-          @order.contents.remove(variant, quantity)
+        if @order.checkout_steps.include? "delivery"
+          packages = @order.shipments.map { |s| s.to_package }
+          @differentiator = Spree::Stock::Differentiator.new(@order, packages)
+          @differentiator.missing.each do |variant, quantity|
+            @order.contents.remove(variant, quantity)
+          end
         end
       end
 

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -274,4 +274,22 @@ describe Spree::CheckoutController do
       end
     end
   end
+
+  context "order doesn't have a delivery step" do
+    before do
+      order.stub(:checkout_steps => ["cart", "payment"])
+    end
+
+    it "doesn't remove unshippable items before payment" do
+      expect {
+        spree_post :update, { :state => "payment" }
+      }.to_not change { order.line_items }
+    end
+  end
+
+  it "does remove unshippable items before payment" do
+    expect {
+      spree_post :update, { :state => "payment" }
+    }.to change { order.line_items }
+  end
 end


### PR DESCRIPTION
Not every line item must be shipped on the order. I believe Spree should
be ok with that. Removing line items between delivery and payment steps
seems unexpected behaviour in that scenario

This was reported on #2966 and today I looked further and found that the reason for the remove line items before payment code was related to not allowing unshippable items on the final order.

@cmar could you please take a look?
