### PR TITLE
only show payment source form if source required

### DIFF
--- a/core/app/views/spree/admin/payments/_form.html.erb
+++ b/core/app/views/spree/admin/payments/_form.html.erb
@@ -20,7 +20,9 @@
       </ul>
       <div class="payment-method-settings">
         <% @payment_methods.each do |method| %>
-          <%= render :partial => "spree/admin/payments/source_forms/#{method.method_type}", :locals => { :payment_method => method } %>
+          <% if method.source_required? %>
+            <%= render :partial => "spree/admin/payments/source_forms/#{method.method_type}", :locals => { :payment_method => method } %>
+          <% end %>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
Otherwise, you'll get an error if you don't have a payment source form template.
