### PR TITLE
Change default tax calc. to compensate for promo and shipping

### DIFF
--- a/core/app/models/spree/calculator/default_tax.rb
+++ b/core/app/models/spree/calculator/default_tax.rb
@@ -29,9 +29,7 @@ module Spree
 
 	 line_items_total = matched_line_items.sum(&:total)
 	 adjusted_total = line_items_total + order.promo_total + order.ship_total 
-	 if adjusted_total
-	    round_to_two_places(adjusted_total * rate.amount) 
-	 end
+	 round_to_two_places(adjusted_total * rate.amount) 
       end
 
       def compute_line_item(line_item)

--- a/core/app/models/spree/calculator/default_tax.rb
+++ b/core/app/models/spree/calculator/default_tax.rb
@@ -1,56 +1,58 @@
 require_dependency 'spree/calculator'
 
 module Spree
-  class Calculator::DefaultTax < Calculator
-    def self.description
-      Spree.t(:default_tax)
-    end
-
-    def compute(computable)
-      case computable
-        when Spree::Order
-          compute_order(computable)
-        when Spree::LineItem
-          compute_line_item(computable)
+   class Calculator::DefaultTax < Calculator
+      def self.description
+	 Spree.t(:default_tax)
       end
-    end
+
+      def compute(computable)
+	 case computable
+	 when Spree::Order
+	    compute_order(computable)
+	 when Spree::LineItem
+	    compute_line_item(computable)
+	 end
+      end
 
 
-    private
+      private
 
       def rate
-        self.calculable
+	 self.calculable
       end
 
       def compute_order(order)
-        matched_line_items = order.line_items.select do |line_item|
-          line_item.product.tax_category == rate.tax_category
-        end
+	 matched_line_items = order.line_items.select do |line_item|
+	    line_item.product.tax_category == rate.tax_category
+	 end
 
-        line_items_total = matched_line_items.sum(&:total)
-        round_to_two_places(line_items_total * rate.amount)
+	 line_items_total = matched_line_items.sum(&:total)
+	 adjusted_total = line_items_total + order.promo_total + order.ship_total 
+	 if adjusted_total
+	    round_to_two_places(adjusted_total * rate.amount) 
+	 end
       end
 
       def compute_line_item(line_item)
-        if line_item.product.tax_category == rate.tax_category
-          if rate.included_in_price
-            deduced_total_by_rate(line_item.total, rate)
-          else
-	    adjusted_total = line_items_total + order.promo_total + order.ship_total
-	    round_to_two_places(adjusted_total * rate.amount) 
-          end
-        else
-          0
-        end
+	 if line_item.product.tax_category == rate.tax_category
+	    if rate.included_in_price
+	       deduced_total_by_rate(line_item.total, rate)
+	    else
+	       round_to_two_places(line_item.total * rate.amount) 
+	    end
+	 else
+	    0
+	 end
       end
 
       def round_to_two_places(amount)
-        BigDecimal.new(amount.to_s).round(2, BigDecimal::ROUND_HALF_UP)
+	 BigDecimal.new(amount.to_s).round(2, BigDecimal::ROUND_HALF_UP)
       end
 
       def deduced_total_by_rate(total, rate)
-        round_to_two_places(total - ( total / (1 + rate.amount) ) )
+	 round_to_two_places(total - ( total / (1 + rate.amount) ) )
       end
 
-  end
+   end
 end

--- a/core/app/models/spree/calculator/default_tax.rb
+++ b/core/app/models/spree/calculator/default_tax.rb
@@ -37,6 +37,7 @@ module Spree
             deduced_total_by_rate(line_item.total, rate)
           else
 	    adjusted_total = line_items_total + order.promo_total + order.ship_total
+	    round_to_two_places(adjusted_total * rate.amount) 
           end
         else
           0

--- a/core/app/models/spree/calculator/default_tax.rb
+++ b/core/app/models/spree/calculator/default_tax.rb
@@ -36,7 +36,8 @@ module Spree
           if rate.included_in_price
             deduced_total_by_rate(line_item.total, rate)
           else
-            round_to_two_places(line_item.total * rate.amount)
+	    adjusted_total = line_items_total + order.promo_total + order.ship_total
+            round_to_two_places(adjusted_total * rate.amount)
           end
         else
           0

--- a/core/app/models/spree/calculator/default_tax.rb
+++ b/core/app/models/spree/calculator/default_tax.rb
@@ -37,7 +37,6 @@ module Spree
             deduced_total_by_rate(line_item.total, rate)
           else
 	    adjusted_total = line_items_total + order.promo_total + order.ship_total
-            round_to_two_places(adjusted_total * rate.amount)
           end
         else
           0


### PR DESCRIPTION
Fix for deducting tax from promotion value, should work now that spree_promo is now part of core.
