### PR TITLE
Add currency to itemprop.

### DIFF
--- a/frontend/app/views/spree/products/_cart_form.html.erb
+++ b/frontend/app/views/spree/products/_cart_form.html.erb
@@ -27,7 +27,7 @@
         
         <div id="product-price">
           <h6 class="product-section-title"><%= Spree.t(:price) %></h6>
-          <div><span class="price selling" itemprop="price"><%= display_price(@product) %></span></div>
+          <div><span class="price selling" itemprop="price"><%= display_price(@product) %></span><span itemprop="priceCurrency" content="<%= @product.currency %>"></span></div>
         </div>
 
         <div class="add-to-cart">


### PR DESCRIPTION
This will provide a more detailed price to users in search engine
results.

As an example.  In Canadian Dollars, it will display: CA$22.50 in the
Google search rankings instead of simply $22.50.
