### PR TITLE
Add in stock notification.

### DIFF
--- a/frontend/app/views/spree/products/_cart_form.html.erb
+++ b/frontend/app/views/spree/products/_cart_form.html.erb
@@ -28,6 +28,9 @@
         <div id="product-price">
           <h6 class="product-section-title"><%= Spree.t(:price) %></h6>
           <div><span class="price selling" itemprop="price"><%= display_price(@product) %></span></div>
+          <% if @product.master.in_stock? %>
+            <link itemprop="availability" href="http://schema.org/InStock" />
+          <% end %>
         </div>
 
         <div class="add-to-cart">


### PR DESCRIPTION
This will mark the structured data schema with "In Stock" if the item
is in stock.

This can provide more information in the Google search results.

Sample:
![in-stock](https://f.cloud.github.com/assets/764390/651826/61b493e2-d483-11e2-998f-0a21e4c0f6dd.png)
