### PR TITLE
Dont send a HTTP POST when removing non-persisted nested fields

### DIFF
--- a/core/app/assets/javascripts/admin/admin.js.erb
+++ b/core/app/assets/javascripts/admin/admin.js.erb
@@ -199,7 +199,9 @@ $(document).ready(function(){
     el = $(this);
     el.prev("input[type=hidden]").val("1");
     el.closest(".fields").hide();
-    if (el.attr("href")) {
+    if (el.attr("href") == '#') {
+      el.parents("tr").fadeOut('hide');
+    }else if (el.attr("href")) {
       $.ajax({
         type: 'POST',
         url: el.attr("href"),

--- a/core/spec/requests/admin/products/option_types_spec.rb
+++ b/core/spec/requests/admin/products/option_types_spec.rb
@@ -75,4 +75,40 @@ describe "Option Types" do
     # What *is* visible is a new option value field, with blank values
     all("tbody#option_values tr input").all? { |input| input.value.blank? }
   end
+  
+  # Regression test for #3204
+  it "can remove a non-persisted option value from an option type", :js => true do
+    create(:option_type)
+    click_link "Option Types"
+    within('table#listing_option_types') { click_icon :edit }
+    wait_until do
+      page.find("tbody#option_values", :visible => true)
+    end
+
+    all("tbody#option_values tr").select(&:visible?).count.should == 1
+
+    # Add a new option type
+    click_link "Add Option Value"
+    all("tbody#option_values tr").select(&:visible?).count.should == 2
+
+    # Remove default option type
+    within("tbody#option_values") do
+      find('.remove_fields').click
+    end
+    # Check that there was no HTTP requst
+    all("div#progress[style]").count.should == 0
+    # Assert that the field is hidden automatically
+    all("tbody#option_values tr").select(&:visible?).count.should == 1
+
+    # Remove added option type
+    within("tbody#option_values") do
+      find('.remove_fields').click
+    end
+    # Check that there was no HTTP requst
+    all("div#progress[style]").count.should == 0
+    # Assert that the field is hidden automatically
+    all("tbody#option_values tr").select(&:visible?).count.should == 0
+
+  end
+
 end


### PR DESCRIPTION
Hey I was creating a extension and noticed that if you remove a non-persisted nested field it sends a POST to the server trying to remove it.

A core example of this is in Option Values:

When you click the "Add Option Value" link
And you click the newly created "Remove" icon
Then the server sends a HTTP POST request that fails with 404 or 302

I did the patch against 1-3-stable as that's what I'm using currently, but I can change it to use master if you like.

I'm writing up a test for it now.
