### PR TITLE
Added :number to attr_accessible for Spree::Shipments.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ end
 desc "Generates a dummy app for testing for every Spree engine"
 task :test_app do
   require File.expand_path('../core/lib/generators/spree/install/install_generator', __FILE__)
-  %w(api backend core dash frontend).each do |engine|
+  %w(api backend core frontend).each do |engine|
     ENV['LIB_NAME'] = File.join('spree', engine)
     ENV['DUMMY_PATH'] = File.expand_path("../#{engine}/spec/dummy", __FILE__)
     Rake::Task['common:test_app'].execute

--- a/api/app/controllers/spree/api/return_authorizations_controller.rb
+++ b/api/app/controllers/spree/api/return_authorizations_controller.rb
@@ -1,23 +1,9 @@
 module Spree
   module Api
     class ReturnAuthorizationsController < Spree::Api::BaseController
-      respond_to :json
-
-      before_filter :authorize_admin!
-
-      def index
-        @return_authorizations = order.return_authorizations.
-                                 ransack(params[:q]).result.
-                                 page(params[:page]).per(params[:per_page])
-        respond_with(@return_authorizations)
-      end
-
-      def show
-        @return_authorization = order.return_authorizations.find(params[:id])
-        respond_with(@return_authorization)
-      end
 
       def create
+        authorize! :create, ReturnAuthorization
         @return_authorization = order.return_authorizations.build(params[:return_authorization], :as => :api)
         if @return_authorization.save
           respond_with(@return_authorization, :status => 201, :default_template => :show)
@@ -26,8 +12,32 @@ module Spree
         end
       end
 
+      def destroy
+        @return_authorization = order.return_authorizations.accessible_by(current_ability, :destroy).find(params[:id])
+        @return_authorization.destroy
+        respond_with(@return_authorization, :status => 204)
+      end
+
+      def index
+        authorize! :admin, ReturnAuthorization
+        @return_authorizations = order.return_authorizations.accessible_by(current_ability, :read).
+                                 ransack(params[:q]).result.
+                                 page(params[:page]).per(params[:per_page])
+        respond_with(@return_authorizations)
+      end
+
+      def new
+        authorize! :admin, ReturnAuthorization
+      end
+
+      def show
+        authorize! :admin, ReturnAuthorization
+        @return_authorization = order.return_authorizations.accessible_by(current_ability, :read).find(params[:id])
+        respond_with(@return_authorization)
+      end
+
       def update
-        @return_authorization = order.return_authorizations.find(params[:id])
+        @return_authorization = order.return_authorizations.accessible_by(current_ability, :update).find(params[:id])
         if @return_authorization.update_attributes(params[:return_authorization])
           respond_with(@return_authorization, :default_template => :show)
         else
@@ -35,21 +45,36 @@ module Spree
         end
       end
 
-      def destroy
-        @return_authorization = order.return_authorizations.find(params[:id])
-        @return_authorization.destroy
-        respond_with(@return_authorization, :status => 204)
+      def add
+        return_authorization.add_variant params[:variant_id].to_i, params[:quantity].to_i
+        if return_authorization.valid?
+          respond_with return_authorization, default_template: :show
+        else
+          invalid_resource!(return_authorization)
+        end
+      end
+
+      def receive
+        return_authorization.send("receive!")
+        respond_with(return_authorization)
+      end
+
+      def cancel
+        return_authorization.send("cancel!")
+        respond_with(return_authorization)
       end
 
       private
 
       def order
         @order ||= Order.find_by_number!(params[:order_id])
+        authorize! :read, @order
       end
 
-      def authorize_admin!
-        authorize! :manage, Spree::ReturnAuthorization
+      def return_authorization
+        @return_authorization ||= order.return_authorizations.accessible_by(current_ability, :update).find(params[:id])
       end
+
     end
   end
 end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -29,7 +29,13 @@ Spree::Core::Engine.routes.draw do
     end
 
     resources :orders do
-      resources :return_authorizations
+      resources :return_authorizations do
+        member do
+          put :add
+          put :cancel
+          put :receive
+        end
+      end
       member do
         put :address
         put :delivery

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -16,7 +16,7 @@ module Spree
     after_save :ensure_correct_adjustment, :update_order
 
     attr_accessor :special_instructions
-    attr_accessible :order, :special_instructions, :stock_location_id,
+    attr_accessible :order, :special_instructions, :stock_location_id, :number,
                     :tracking, :address, :inventory_units, :selected_shipping_rate_id
 
     accepts_nested_attributes_for :address


### PR DESCRIPTION
Documentation says you can pass in "number" and change the shipment number. Can't actually do that because "number" wasn't added to attr_accessible in Spree::Shipment and the API is using "update_attributes" method.

http://guides.spreecommerce.com/api/shipments.html
