### PR TITLE
Call ShippingMethod#available? as the methods parameter name suggests

### DIFF
--- a/core/app/models/spree/stock/estimator.rb
+++ b/core/app/models/spree/stock/estimator.rb
@@ -26,7 +26,7 @@ module Spree
       private
       def shipping_methods(package)
         shipping_methods = package.shipping_methods
-        shipping_methods.delete_if { |ship_method| !ship_method.calculator.available?(package.contents) }
+        shipping_methods.delete_if { |ship_method| !ship_method.calculator.available?(package) }
         shipping_methods.delete_if { |ship_method| !ship_method.include?(order.ship_address) }
         shipping_methods.delete_if { |ship_method| !(ship_method.calculator.preferences[:currency].nil? || ship_method.calculator.preferences[:currency] == currency) }
         shipping_methods


### PR DESCRIPTION
Call ShippingMethod#available? with package as parameter, like the method expects. [Fixes #3213]
