### PR TITLE
Upgrade jquery-rails to ~> 3.0.0

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Spree 2.1.0 (unreleased) ##
 
+*   No longer requires all jquery ui modules. Extensions should include the
+    ones they need on their own manifest file. #3237
+
+    *Washington Luiz*
+    
 *   Symbolize attachment style keys on ImageSettingController otherwise users
     would get *undefined method `processors' for "48x48>":String>* since
     paperclip can't handle key strings. #3069 #3080

--- a/backend/app/assets/javascripts/admin/option_type_autocomplete.js.erb
+++ b/backend/app/assets/javascripts/admin/option_type_autocomplete.js.erb
@@ -20,7 +20,6 @@ $(document).ready(function() {
           }
         },
         results: function (data, page) {
-          console.log(data)
           return { results: data }
         }
       },

--- a/backend/app/assets/javascripts/admin/spree_backend.js
+++ b/backend/app/assets/javascripts/admin/spree_backend.js
@@ -1,5 +1,7 @@
 //= require jquery-migrate-1.0.0
-//= require jquery-ui
+//= require jquery.ui.datepicker
+//= require jquery.ui.sortable
+//= require jquery.ui.autocomplete
 //= require modernizr
 //= require jquery.cookie
 //= require jquery.delayedobserver

--- a/backend/app/assets/stylesheets/admin/spree_backend.css
+++ b/backend/app/assets/stylesheets/admin/spree_backend.css
@@ -8,7 +8,8 @@
  *= require responsive-tables
  *= require normalize
  *= require skeleton
- *= require jquery-ui.datepicker
+ *= require jquery.ui.datepicker
+ *= require jquery.ui.autocomplete
  *= require jquery.powertip
  *= require select2
 

--- a/backend/lib/spree/backend.rb
+++ b/backend/lib/spree/backend.rb
@@ -1,6 +1,7 @@
 require 'rails/all'
 require 'rails/generators'
 require 'jquery-rails'
+require 'jquery-ui-rails'
 require 'deface'
 require 'select2-rails'
 

--- a/backend/spree_backend.gemspec
+++ b/backend/spree_backend.gemspec
@@ -21,7 +21,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_core', version
   s.add_dependency 'spree_api', version
 
-  s.add_dependency 'jquery-rails', '~> 2.0'
+  s.add_dependency 'jquery-rails', '~> 3.0.0'
+  s.add_dependency 'jquery-ui-rails', '~> 4.0.0'
   s.add_dependency 'select2-rails', '3.2.1'
 
   s.add_dependency 'rails', '~> 3.2.8'

--- a/frontend/spree_frontend.gemspec
+++ b/frontend/spree_frontend.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_core', version
   s.add_dependency 'spree_api', version
 
-  s.add_dependency 'jquery-rails', '~> 2.2.1'
+  s.add_dependency 'jquery-rails', '~> 3.0.0'
   s.add_dependency 'select2-rails', '3.2.1'
 
   s.add_dependency 'rails', '~> 3.2.13'


### PR DESCRIPTION
Looks like this is enough to get us running Spree on jquery-rails 3.0.

I bumped the version required and went through pages on backend and frontend with the browser js console open. Everything went great. I guess we will need to upgrade select2 at some point later as well, it should help to get rid of js warnings. But that will be a bit harder because we'll probably have to update the capybara helpers to match the new select2 markup.

Please let me know if tests look good. I've got some odd failures right now locally but I'm pretty sure it's not related to this change.
