### PR TITLE
Additions to Return Authorizations API

### DIFF
--- a/api/app/controllers/spree/api/return_authorizations_controller.rb
+++ b/api/app/controllers/spree/api/return_authorizations_controller.rb
@@ -41,6 +41,34 @@ module Spree
         respond_with(@return_authorization, :status => 204)
       end
 
+      def add
+        @return_authorization = order.return_authorizations.accessible_by(current_ability, :update).find(params[:id])
+        @return_authorization.add_variant params[:variant_id].to_i, params[:quantity].to_i
+        if @return_authorization.valid?
+          respond_with @return_authorization, default_template: :show
+        else
+          invalid_resource!(@return_authorization)
+        end
+      end
+
+      def receive
+        @return_authorization = order.return_authorizations.accessible_by(current_ability, :update).find(params[:id])
+        if @return_authorization.receive
+          respond_with @return_authorization, default_template: :show
+        else
+          invalid_resource!(@return_authorization)
+        end
+      end
+
+      def cancel
+        @return_authorization = order.return_authorizations.accessible_by(current_ability, :update).find(params[:id])
+        if @return_authorization.cancel
+          respond_with @return_authorization, default_template: :show
+        else
+          invalid_resource!(@return_authorization)
+        end
+      end
+
       private
 
       def order

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -29,7 +29,13 @@ Spree::Core::Engine.routes.draw do
     end
 
     resources :orders do
-      resources :return_authorizations
+      resources :return_authorizations do
+        member do
+          put :add
+          put :cancel
+          put :receive
+        end
+      end
       member do
         put :address
         put :delivery

--- a/api/spec/controllers/spree/api/return_authorizations_controller_spec.rb
+++ b/api/spec/controllers/spree/api/return_authorizations_controller_spec.rb
@@ -44,6 +44,21 @@ module Spree
         assert_unauthorized!
       end
 
+      it "cannot add a variant to a return authorization" do
+        api_put :add
+        assert_unauthorized!
+      end
+
+      it "cannot mark a return authorization as received" do
+        api_put :receive
+        assert_unauthorized!
+      end
+
+      it "cannot cancel a return authorization" do
+        api_put :cancel
+        assert_unauthorized!
+      end
+
       it "cannot delete a return authorization" do
         api_delete :destroy
         assert_unauthorized!
@@ -103,6 +118,53 @@ module Spree
         api_put :update, :id => return_authorization.id, :return_authorization => { :amount => 19.99 }
         response.status.should == 200
         json_response.should have_attributes(attributes)
+      end
+
+      it "can add an inventory unit to a return authorization on the order" do
+        FactoryGirl.create(:return_authorization, :order => order)
+        return_authorization = order.return_authorizations.first
+        inventory_unit = return_authorization.returnable_inventory.first
+        inventory_unit.should be
+        return_authorization.inventory_units.should be_empty
+        api_put :add, :id => return_authorization.id, variant_id: inventory_unit.variant.id, quantity: 1
+        response.status.should == 200
+        json_response.should have_attributes(attributes)
+        return_authorization.reload.inventory_units.should_not be_empty
+      end
+
+      it "can mark a return authorization as received on the order with an inventory unit" do
+        FactoryGirl.create(:new_return_authorization, :order => order)
+        return_authorization = order.return_authorizations.first
+        return_authorization.state.should == "authorized"
+
+        # prep (use a rspec context or a factory instead?)
+        inventory_unit = return_authorization.returnable_inventory.first
+        inventory_unit.should be
+        return_authorization.inventory_units.should be_empty
+        api_put :add, :id => return_authorization.id, variant_id: inventory_unit.variant.id, quantity: 1
+        # end prep
+
+        api_delete :receive, :id => return_authorization.id
+        response.status.should == 200
+        return_authorization.reload.state.should == "received"
+      end
+
+      it "cannot mark a return authorization as received on the order with no inventory units" do
+        FactoryGirl.create(:new_return_authorization, :order => order)
+        return_authorization = order.return_authorizations.first
+        return_authorization.state.should == "authorized"
+        api_delete :receive, :id => return_authorization.id
+        response.status.should == 422
+        return_authorization.reload.state.should == "authorized"
+      end
+
+      it "can cancel a return authorization on the order" do
+        FactoryGirl.create(:new_return_authorization, :order => order)
+        return_authorization = order.return_authorizations.first
+        return_authorization.state.should == "authorized"
+        api_delete :cancel, :id => return_authorization.id
+        response.status.should == 200
+        return_authorization.reload.state.should == "canceled"
       end
 
       it "can delete a return authorization on the order" do

--- a/core/lib/spree/testing_support/factories/return_authorization_factory.rb
+++ b/core/lib/spree/testing_support/factories/return_authorization_factory.rb
@@ -6,4 +6,8 @@ FactoryGirl.define do
     reason 'no particular reason'
     state 'received'
   end
+
+  factory :new_return_authorization, class: Spree::ReturnAuthorization do
+    association(:order, factory: :shipped_order)
+  end
 end


### PR DESCRIPTION
I wrote three additions (add variant, mark as received, mark as canceled) to the Return Authorizations API because it did not offer all of the functionality that the admin interface had.  I needed it so that an outside system can manage these for my Spree implementation. I tried to design them in line with similar methods on the Shipments API.

I also wrote these for the 2-0-stable branch because I'm not using 2.1 in production yet.  If you guys like these additions, pull them in. I can write them into the Spree docs if this pull request get accepted.
