### PR TITLE
Test clicking logo in admin returns to /admin

### DIFF
--- a/core/spec/requests/admin/homepage_spec.rb
+++ b/core/spec/requests/admin/homepage_spec.rb
@@ -12,6 +12,10 @@ describe "Homepage" do
       within('h1') { page.should have_content("Listing Orders") }
     end
 
+    it "should have a link to overview" do
+      within(:xpath, ".//figure[@data-hook='logo-wrapper']") { page.find(:xpath, "a[@href='/admin']") }
+    end
+
     it "should have a link to orders" do
       page.find_link("Orders")['/admin/orders']
     end


### PR DESCRIPTION
@radar, I know you just removed this in c8bf05a5325ae3a334d4bfdba67336e2d8511d07 but it was such an easy fix, I thought it worthwhile to add back.
