### PR TITLE
Rails4 last build fix and warning

### DIFF
--- a/api/app/controllers/spree/api/option_types_controller.rb
+++ b/api/app/controllers/spree/api/option_types_controller.rb
@@ -5,7 +5,7 @@ module Spree
         if params[:ids]
           @option_types = Spree::OptionType.accessible_by(current_ability, :read).where(:id => params[:ids].split(','))
         else
-          @option_types = Spree::OptionType.accessible_by(current_ability, :read).scoped.ransack(params[:q]).result
+          @option_types = Spree::OptionType.accessible_by(current_ability, :read).load.ransack(params[:q]).result
         end
         respond_with(@option_types)
       end

--- a/api/app/controllers/spree/api/option_values_controller.rb
+++ b/api/app/controllers/spree/api/option_values_controller.rb
@@ -46,7 +46,7 @@ module Spree
           if params[:option_type_id]
             @scope ||= Spree::OptionType.find(params[:option_type_id]).option_values.accessible_by(current_ability, :read)
           else
-            @scope ||= Spree::OptionValue.accessible_by(current_ability, :read).scoped
+            @scope ||= Spree::OptionValue.accessible_by(current_ability, :read).load
           end
         end
 

--- a/backend/app/assets/javascripts/admin/option_type_autocomplete.js.erb
+++ b/backend/app/assets/javascripts/admin/option_type_autocomplete.js.erb
@@ -20,7 +20,6 @@ $(document).ready(function() {
           }
         },
         results: function (data, page) {
-          console.log(data)
           return { results: data }
         }
       },

--- a/backend/app/assets/javascripts/admin/spree_backend.js
+++ b/backend/app/assets/javascripts/admin/spree_backend.js
@@ -1,5 +1,7 @@
 //= require jquery-migrate-1.0.0
-//= require jquery-ui
+//= require jquery.ui.datepicker
+//= require jquery.ui.sortable
+//= require jquery.ui.autocomplete
 //= require modernizr
 //= require jquery.cookie
 //= require jquery.delayedobserver

--- a/backend/app/assets/stylesheets/admin/spree_backend.css
+++ b/backend/app/assets/stylesheets/admin/spree_backend.css
@@ -8,7 +8,8 @@
  *= require responsive-tables
  *= require normalize
  *= require skeleton
- *= require jquery-ui.datepicker
+ *= require jquery.ui.datepicker
+ *= require jquery.ui.autocomplete
  *= require jquery.powertip
  *= require select2
 

--- a/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
+++ b/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
@@ -39,7 +39,7 @@ module Spree
           end
 
           def load_order
-            @order = Order.find_by_number!(params[:order_id], :include => :adjustments)
+            @order = Order.includes(:adjustments).find_by_number!(params[:order_id])
           end
 
       end

--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -116,7 +116,7 @@ module Spree
       private
 
         def load_order
-          @order = Order.find_by_number!(params[:id], :include => :adjustments) if params[:id]
+          @order = Order.includes(:adjustments).find_by_number!(params[:id]) if params[:id]
           authorize! action, @order
         end
 

--- a/backend/lib/spree/backend.rb
+++ b/backend/lib/spree/backend.rb
@@ -1,6 +1,7 @@
 require 'rails/all'
 require 'rails/generators'
 require 'jquery-rails'
+require 'jquery-ui-rails'
 require 'select2-rails'
 
 require 'spree/core'

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -61,13 +61,13 @@ describe Spree::Admin::OrdersController do
     end
 
     it 'should grant access to users with an admin role' do
-      user.spree_roles << Spree::Role.find_or_create_by_name('admin')
+      user.spree_roles << Spree::Role.find_or_create_by(name: 'admin')
       spree_post :index
       response.should render_template :index
     end
 
     it 'should grant access to users with an bar role' do
-      user.spree_roles << Spree::Role.find_or_create_by_name('bar')
+      user.spree_roles << Spree::Role.find_or_create_by(name: 'bar')
       Spree::Ability.register_ability(BarAbility)
       spree_post :index
       response.should render_template :index
@@ -79,7 +79,7 @@ describe Spree::Admin::OrdersController do
       order.stub(:user).and_return Spree.user_class.new
       order.stub(:token).and_return nil
       user.spree_roles.clear
-      user.spree_roles << Spree::Role.find_or_create_by_name('bar')
+      user.spree_roles << Spree::Role.find_or_create_by(name: 'bar')
       Spree::Ability.register_ability(BarAbility)
       spree_put :update, { :id => 'R123' }
       response.should redirect_to('/unauthorized')

--- a/backend/spree_backend.gemspec
+++ b/backend/spree_backend.gemspec
@@ -21,7 +21,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_core', version
   s.add_dependency 'spree_api', version
 
-  s.add_dependency 'jquery-rails', '~> 2.0'
+  s.add_dependency 'jquery-rails', '~> 3.0.0'
+  s.add_dependency 'jquery-ui-rails', '~> 4.0.0'
   s.add_dependency 'select2-rails', '3.2.1'
 
   s.add_development_dependency 'email_spec', '~> 1.2.1'

--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -13,6 +13,7 @@ gem 'coffee-rails', '~> 4.0.0.rc1'
 gem 'sass-rails', '~> 4.0.0.rc1'
 
 gem 'ransack', github: 'ernie/ransack', branch: 'rails-4'
+gem 'awesome_nested_set', github: 'huoxito/awesome_nested_set', branch: 'rails4'
 
 group :test do
   gem 'capybara', '~> 1.1'

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -363,7 +363,7 @@ module Spree
 
     def credit_cards
       credit_card_ids = payments.from_credit_card.pluck(:source_id).uniq
-      CreditCard.all(conditions: { id: credit_card_ids })
+      CreditCard.where(id: credit_card_ids)
     end
 
     # Finalizes an in progress order after checkout is complete.

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -75,7 +75,7 @@ module Spree
 
     # Products assigned to all product rules
     def products
-      @products ||= self.rules.all.inject([]) do |products, rule|
+      @products ||= self.rules.to_a.inject([]) do |products, rule|
         rule.respond_to?(:products) ? products << rule.products : products
       end.flatten.uniq
     end

--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -59,7 +59,7 @@ module Spree
     end
 
     def returnable_inventory
-      order.shipped_shipments.collect{|s| s.inventory_units.all}.flatten
+      order.shipped_shipments.collect{|s| s.inventory_units.to_a}.flatten
     end
 
     private

--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -14,7 +14,7 @@ module Spree
         def current_order(create_order_if_necessary = false)
           return @current_order if @current_order
           if session[:order_id]
-            current_order = Spree::Order.find_by_id_and_currency(session[:order_id], current_currency, :include => :adjustments)
+            current_order = Spree::Order.includes(:adjustments).find_by_id_and_currency(session[:order_id], current_currency)
             @current_order = current_order unless current_order.try(:completed?)
           end
           if create_order_if_necessary and (@current_order.nil? or @current_order.completed?)

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -156,7 +156,7 @@ describe Spree::CreditCard do
 
   context "#associations" do
     it "should be able to access its payments" do
-      expect { credit_card.payments.all }.not_to raise_error(ActiveRecord::StatementInvalid)
+      expect { credit_card.payments.to_a }.not_to raise_error(ActiveRecord::StatementInvalid)
     end
   end
 end

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -190,7 +190,7 @@ describe Spree::Promotion do
 
     context "when there's no product rule associated" do
       before(:each) do
-        promotion.stub_chain(:rules, :all).and_return([mock_model(Spree::Promotion::Rules::User)])
+        promotion.stub_chain(:rules, :to_a).and_return([mock_model(Spree::Promotion::Rules::User)])
       end
 
       it "should not have products but still return an empty array" do

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'highline', '= 1.6.18'
 
   s.add_dependency 'acts_as_list', '= 0.2.0'
-  s.add_dependency 'awesome_nested_set', '2.1.5'
+  # s.add_dependency 'awesome_nested_set', '2.1.5'
   # Frozen to 0.13.0 due to: https://github.com/amatsuda/kaminari/pull/282
   s.add_dependency 'kaminari', '0.13.0'
 

--- a/frontend/spree_frontend.gemspec
+++ b/frontend/spree_frontend.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_core', version
   s.add_dependency 'spree_api', version
 
-  s.add_dependency 'jquery-rails', '~> 2.2.1'
+  s.add_dependency 'jquery-rails', '~> 3.0.0'
   s.add_dependency 'select2-rails', '3.2.1'
 
   s.add_dependency 'stringex', '~> 1.5.1'


### PR DESCRIPTION
This PR get us a green build on rails4 branch :beers: and with very few warnings this time

I'll keep an eye on deface, ransack and awesome_nested_set for release candidates. I think ransack build was green last time I checked, deface build has an error I can't explain yet and awesome_nested_set probably needs some more help.

This is what we need to add to the Gemfile on a rails 4 app to get Spree running:

```
gem 'spree', github: 'spree/spree', branch: 'rails4'
gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: 'rails4'
gem 'deface', github: 'huoxito/deface', branch: 'rails4'
gem 'ransack', github: 'ernie/ransack', branch: 'rails-4'
gem 'awesome_nested_set', github: 'huoxito/awesome_nested_set', branch: 'rails4'
```

feedback much appreciated
