### PR TITLE
Make PercentPerItem also check if rule responds to #products

### DIFF
--- a/core/app/models/spree/calculator/percent_per_item.rb
+++ b/core/app/models/spree/calculator/percent_per_item.rb
@@ -23,10 +23,14 @@ module Spree
 
   private
 
-    # Returns all products that match the promotion's rule. 
+    # Returns all products that match this calculator, but only if the calculator
+    # is attached to a promotion. If attached to a ShippingMethod, nil is returned.
+    # Copied from per_item.rb
     def matching_products
-      @matching_products ||= if compute_on_promotion?
-        self.calculable.promotion.rules.map(&:products).flatten
+      if self.calculable.respond_to?(:promotion)
+        self.calculable.promotion.rules.map do |rule|
+          rule.respond_to?(:products) ? rule.products : []
+        end.flatten
       end
     end
 

--- a/core/spec/models/spree/calculator/percent_per_item_spec.rb
+++ b/core/spec/models/spree/calculator/percent_per_item_spec.rb
@@ -40,4 +40,13 @@ describe Spree::Calculator::PercentPerItem do
     calculator.send(:compute_on_promotion?).should be_true
   end
 
+  # test that we do not fail when one promorule does not respond to products
+  context "does not fail if a promotion rule does not respond to products" do
+    before { promotion.stub :rules => [double("Rule", :products => [product1]), double("Rule")] }
+    specify do
+      calculator.stub(:calculable => promotion_calculable)
+      expect { calculator.matching_products }.not_to raise_error
+    end
+  end
+
 end


### PR DESCRIPTION
Copied #matching_products from PerItem to allow for promotions that are a combination of product and non product rules.
