### PR TITLE
Fixed ". is not a rails project." error on run generators/spree installer

### DIFF
--- a/cmd/lib/spree_cmd/installer.rb
+++ b/cmd/lib/spree_cmd/installer.rb
@@ -161,7 +161,7 @@ module SpreeCmd
       end
 
       def rails_project?
-        File.exists? File.join(@app_path, 'script', 'rails')
+        File.exists? File.join(@app_path, 'bin', 'rails')
       end
 
       def linux?


### PR DESCRIPTION
Fixed ". is not a rails project." error on all running of a rails generator or spree installer

In rails 4 folde /script moved to /bin
