### PR TITLE
Newer jquery returns undefined

### DIFF
--- a/core/app/assets/javascripts/admin/admin.js.erb
+++ b/core/app/assets/javascripts/admin/admin.js.erb
@@ -160,8 +160,8 @@ $(document).ready(function(){
     new_table_row.find("input").each(function () {
       var el = $(this);
       el.val("");
-      el.attr("id", el.attr("id").replace(/\d+/, new_id))
-      el.attr("name", el.attr("name").replace(/\d+/, new_id))
+      if (typeof el.attr("id") !== 'undefined') el.attr("id", el.attr("id").replace(/\d+/, new_id))
+      if (typeof el.attr("name") !== 'undefined') el.attr("name", el.attr("name").replace(/\d+/, new_id))
     })
     // When cloning a new row, set the href of all icons to be an empty "#"
     // This is so that clicking on them does not perform the actions for the

--- a/core/app/assets/javascripts/admin/admin.js.erb
+++ b/core/app/assets/javascripts/admin/admin.js.erb
@@ -157,7 +157,7 @@ $(document).ready(function(){
     var target = $(this).data("target");
     var new_table_row = $(target + ' tr:visible:last').clone();
     var new_id = new Date().getTime();
-    new_table_row.find("input").each(function () {
+    new_table_row.find("input, select").each(function () {
       var el = $(this);
       el.val("");
       if (typeof el.attr("id") !== 'undefined') el.attr("id", el.attr("id").replace(/\d+/, new_id))


### PR DESCRIPTION
These fix a couple of bugs I ran into when trying to reuse the spree table structure code.
1. d8c149c - if you don't have an ID assigned to all of your input elements, you'll get a JS error with the newest jQuery because it returns undefined when not finding elements
2. 44c3749 - if you are leveraging this code with select boxes, they won't get the correct ID set and not be POSTed
