### PR TITLE
Display default product image when variants have none

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -186,7 +186,11 @@ module Spree
           if !product.is_a?(Spree::Variant) && !product.variant_images.empty?
             create_product_image_tag(product.variant_images.first, product, options, style)
           else
-            image_tag "noimage/#{style}.png", options
+            if product.is_a?(Variant) && !product.product.variant_images.empty?
+              create_product_image_tag(product.product.variant_images.first, product, options, style)
+            else
+              image_tag "noimage/#{style}.png", options
+            end
           end
         else
           create_product_image_tag(product.images.first, product, options, style)


### PR DESCRIPTION
Account for scenarios where a product has variants but they don't have
any images. In that case when displaying a variant we should check if
the product master variant doesn't have an image before displaying a
noimage file.

[Fixes #3172]
