### PR TITLE
Don't update shipping addr if use billing addr is checked

### DIFF
--- a/frontend/app/assets/javascripts/store/checkout.js.coffee
+++ b/frontend/app/assets/javascripts/store/checkout.js.coffee
@@ -64,35 +64,26 @@ Spree.ready ($) ->
 
     ($ 'p#bcountry select').change ->
       updateState 'b'
-      if $('input#order_use_billing').is(':checked')
-        countryId = $('#bcountry select').val()
-        $('#scountry select').val(countryId).change()
-
-    ($ 'p#bstate input').change ->
-      if $('input#order_use_billing').is(':checked')
-        $('#sstate input').val($('#sstate input').val())
-
-    ($ 'p#bstate select').change ->
-      console.log("triggering right field")
-      if $('input#order_use_billing').is(':checked')
-        $('p#sstate select').val($('#bstate select').val())
-
 
     ($ 'p#scountry select').change ->
       updateState 's'
 
     updateState 'b'
-    updateState 's'
 
-    ($ 'input#order_use_billing').change(->
-      if ($ this).is(':checked')
+    order_use_billing = ($ 'input#order_use_billing')
+    order_use_billing.change ->
+      update_shipping_form_state order_use_billing
+
+    update_shipping_form_state = (order_use_billing) ->
+      if order_use_billing.is(':checked')
         ($ '#shipping .inner').hide()
         ($ '#shipping .inner input, #shipping .inner select').prop 'disabled', true
       else
         ($ '#shipping .inner').show()
         ($ '#shipping .inner input, #shipping .inner select').prop 'disabled', false
         updateState('s')
-    ).triggerHandler 'change'
+    
+    update_shipping_form_state order_use_billing
 
   if ($ '#checkout_form_payment').is('*')
     ($ 'input[type="radio"][name="order[payments_attributes][][payment_method_id]"]').click(->


### PR DESCRIPTION
By running updateState() on shipping address form we enable those
fields and need to propagate changes from billing address to shipping
address when we shouldn't because they're already propagated server
side. We should only run updateState() on shipping form if use billing
address is not checked

Fixes #3232

2-0-stable needs this fix as well in case it's merged
