### PR TITLE
fix hardcoded paths for fontawesome

### DIFF
--- a/backend/app/assets/stylesheets/admin/plugins/font-awesome.scss
+++ b/backend/app/assets/stylesheets/admin/plugins/font-awesome.scss
@@ -23,8 +23,8 @@
     */
 @font-face {
   font-family: "FontAwesome";
-  src: url('/assets/fontawesome-webfont.eot');
-  src: url('/assets/fontawesome-webfont.eot?#iefix') format('eot'), url('/assets/fontawesome-webfont.woff') format('woff'), url('/assets/fontawesome-webfont.ttf') format('truetype'), url('/assets/fontawesome-webfont.svg#FontAwesome') format('svg');
+  src: font-url('fontawesome-webfont.eot');
+  src: font-url('fontawesome-webfont.eot?#iefix') format('eot'), font-url('fontawesome-webfont.woff') format('woff'), font-url('fontawesome-webfont.ttf') format('truetype'), font-url('fontawesome-webfont.svg#FontAwesome') format('svg');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
Hi,
when spree is deployed under a sub-url (e.g. example.org/store) the urls to fontawesome do not work, because they are hardcoded.
This fix uses `font-url` instead of `url`, so that the urls to fontawesome are generated correctly, when spree is deployed under a sub-url.

There was a pull request with the same issue a few months back, but somehow the fix isn't in the current stable-2-0 (https://github.com/spree/spree/pull/2424).
