### PR TITLE
add the ability to override or decorate a sample file.

### DIFF
--- a/sample/lib/spree/sample.rb
+++ b/sample/lib/spree/sample.rb
@@ -1,10 +1,23 @@
 module Spree
   module Sample
     def self.load_sample(file)
-      path = File.expand_path(samples_path + "#{file}.rb")
+
+      local_path = nil
+      decorator_paths = []
+      $LOAD_PATH.each do |p|
+        lp = File.expand_path(Pathname.new(File.join(p, '..', 'db', 'samples')) + "#{file}.rb")
+        lpd = File.expand_path(Pathname.new(File.join(p, '..', 'db', 'samples')) + "#{file}_decorator.rb")
+        local_path = lp if File.exists?(lp) && !lp.to_s.include?("sample/")
+        decorator_paths << lpd if File.exists?(lpd)
+      end
+
+      path = local_path || File.expand_path(samples_path + "#{file}.rb")
       # Check to see if the specified file has been loaded before
       if !$LOADED_FEATURES.include?(path)
         require path
+        decorator_paths.each do |dpath|
+          require dpath
+        end
         puts "Loaded #{file.titleize} samples"
       end
     end


### PR DESCRIPTION
When doing "rake spree_sample:load", It will only load products in EUR and USD currency. However, if you are using different currency (for me, it's TWD). Sample data won't list in products page. I would like to add the ability to override or decorate original sample loading data in spree_sample/db/samples/

The fix will search in $LOAD_PATH and find last override #{samples}.rb and all decorate file #{samples}_decorator.rb in db/samples (which is the same path as origin)

I don't know how to add test for this since it need to install a fresh spree app and put overridden data.
However, I test in my local environment with these files:

override products to add TWD currency to products
<a href="https://gist.github.com/wuboy0307/5846113">my_app/db/samples/products.rb</a>
decorate taxons.rb to add a new taxon
<a href="https://gist.github.com/wuboy0307/5846158">my_app/db/samples/taxons_decorator.rb</a>

overridden data has beed loaded and I can see those record in db now.
