### PR TITLE
Delegate t() to Rails t() instead of i18n.t()

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -165,13 +165,6 @@ module Spree
       end
     end
 
-    def t(*args)
-      puts "WARNING: Spree's translations are now scoped to a 'spree' namespace. Please use the Spree.t helper."
-      puts "Called from: #{caller[0]}"
-      I18n.t(*args)
-    end
-
-
     private
 
     # Returns style of image or nil


### PR DESCRIPTION
Rails t() offers a couple more nice features before calling I18n.t()
see http://api.rubyonrails.org/classes/ActionView/Helpers/TranslationHelper.html#method-i-translate

about #3176

Unless we make Spree.t() behave the same way as Rails t() I think we should also remove the warnings telling users to stop using t() in favor of Spree.t(). What do you think?
