### PR TITLE
Fixing the problem with translate with relative path.

### DIFF
--- a/core/app/controllers/spree/base_controller.rb
+++ b/core/app/controllers/spree/base_controller.rb
@@ -8,3 +8,5 @@ class Spree::BaseController < ApplicationController
 
   respond_to :html
 end
+
+require 'spree/i18n/initializer'

--- a/core/lib/spree/i18n.rb
+++ b/core/lib/spree/i18n.rb
@@ -1,15 +1,36 @@
 require 'i18n'
 require 'active_support/core_ext/array/extract_options'
+require 'spree/i18n/base'
 
 module Spree
   extend ActionView::Helpers::TranslationHelper
 
-  # Add spree namespace and delegate to Rails TranslationHelper for some nice
-  # extra functionality. e.g return reasonable strings for missing translations
-  def self.t(*args)
-    options = args.extract_options!
-    options[:scope] = [*options[:scope]].unshift(:spree)
-    args << options
-    super(*args)
+  class << self
+    # Add spree namespace and delegate to Rails TranslationHelper for some nice
+    # extra functionality. e.g return reasonable strings for missing translations
+    def translate(*args)
+      @virtual_path = virtual_path
+
+      options = args.extract_options!
+      options[:scope] = [*options[:scope]].unshift(:spree)
+      args << options
+      super(*args)
+    end
+
+    alias_method :t, :translate
+
+    def context
+      Spree::ViewContext.context
+    end
+
+    def virtual_path
+      if context
+        path = context.instance_variable_get("@virtual_path")
+
+        if path
+          path.gsub(/spree/, '')
+        end
+      end
+    end
   end
 end

--- a/core/lib/spree/i18n/base.rb
+++ b/core/lib/spree/i18n/base.rb
@@ -1,0 +1,17 @@
+module Spree
+  module ViewContext
+    def self.context=(context)
+      @context = context
+    end
+
+    def self.context
+      @context
+    end
+
+    def view_context
+      super.tap do |context|
+        Spree::ViewContext.context = context
+      end
+    end
+  end
+end

--- a/core/lib/spree/i18n/initializer.rb
+++ b/core/lib/spree/i18n/initializer.rb
@@ -1,0 +1,1 @@
+Spree::BaseController.send(:include, Spree::ViewContext)

--- a/core/spec/lib/i18n_spec.rb
+++ b/core/spec/lib/i18n_spec.rb
@@ -21,6 +21,24 @@ describe "i18n" do
 
   it "translates within the spree scope" do
     Spree.normal_t(:foo).should eql("bar")
+    Spree.translate(:foo).should eql("bar")
+  end
+
+  it "translates within the spree scope using a path" do
+    Spree.stub(:virtual_path).and_return('bar')
+
+    Spree.normal_t('.legacy_translation').should eql("back in the day...")
+    Spree.translate('.legacy_translation').should eql("back in the day...")
+  end
+
+  it "raise error without any context when using a path" do
+    expect {
+      Spree.normal_t('.legacy_translation')
+    }.to raise_error
+
+    expect {
+      Spree.translate('.legacy_translation')
+    }.to raise_error
   end
 
   it "prepends a string scope" do


### PR DESCRIPTION
This commit fix #3176 and add #translate method to Spree module.

To fix this issue, was necessary adding a monkey patch to initialize
the i18n after load the spree base controller.

Also, I changed the method #t. Now this method is an alias to #translate.

In my concept, we need to follow the same convention of i18n and
translation helpers of rails.

So, the developers can use #t and #translate without any problems.
