### PR TITLE
raise ShippingError when rate_hash empty fix #3267

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -428,6 +428,8 @@ module Spree
                           :cost => cost,
                           :currency => currency)
       end.compact.sort_by { |r| r.cost }
+      raise Spree::ShippingError.new("#{I8n.t(:shipping_error)}: #{I18n.t(:no_shipping_services)}") if @rate_hash.empty?
+      @rate_hash
     end
 
     def paid?

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -605,6 +605,7 @@ en:
   no_results: "No results"
   no_shipments_for_this_order: "There are no shipments for this order"
   no_shipping_methods_found: "No shipping methods found"
+  no_shipping_services: "There are no valid services available for the shipping destination."
   no_trackers_found: "No Trackers Found"
   no_user_found: "No user was found with that email address"
   none: None


### PR DESCRIPTION
raises a ShippingError if no services could return rates for the
desireddestionation, also added its locale
