### PR TITLE
Edge raises when rates arent created

### DIFF
--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -72,7 +72,14 @@ module Spree
                 end
               end
 
-              before_transition :to => :delivery, :do => :create_proposed_shipments
+              before_transition :to => :delivery do |order|
+                begin
+                  order.create_proposed_shipments
+                rescue Core::ShippingRateError => error
+                  order.checkout_errors << error.message
+                  false
+                end
+              end
 
               after_transition :to => :complete, :do => :finalize!
               after_transition :to => :delivery, :do => :create_tax_charge!

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -106,8 +106,11 @@ module Spree
       return shipping_rates if shipped?
 
       shipping_method_id = shipping_method.try(:id)
-      self.shipping_rates = Stock::Estimator.new(order).shipping_rates(to_package)
-
+      begin
+        self.shipping_rates = Stock::Estimator.new(order).shipping_rates(to_package)
+      rescue Core::ShippingRateError
+        self.shipping_rates = []
+      end
 
       if shipping_method_id
         selected_rate = shipping_rates.detect { |rate|

--- a/core/app/models/spree/stock/estimator.rb
+++ b/core/app/models/spree/stock/estimator.rb
@@ -20,7 +20,9 @@ module Spree
 
         shipping_rates.sort_by! { |r| r.cost || 0 }
 
-        unless shipping_rates.empty?
+        if shipping_rates.empty?
+          raise Core::ShippingRateError.new(Spree.t(:no_shipping_rates_found))
+        else
           if frontend_only
             shipping_rates.each do |rate|
               rate.selected = true and break if rate.shipping_method.frontend?

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -667,6 +667,7 @@ en:
     no_results: No results
     no_rules_added: No rules added
     no_shipping_methods_found: No shipping methods found
+    no_shipping_rates_found: No shipping rates found
     no_trackers_found: No Trackers Found
     no_stock_locations_found: No stock locations found
     no_tracking_present: No tracking details provided.

--- a/core/lib/spree/core/shipping_rate_error.rb
+++ b/core/lib/spree/core/shipping_rate_error.rb
@@ -1,0 +1,5 @@
+module Spree
+  module Core
+    class ShippingRateError < RuntimeError; end
+  end
+end

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -168,7 +168,7 @@ describe Spree::Order do
     it "should only call default transitions once when checkout_flow is redefined" do
       order = SubclassedOrder.new
       order.stub :payment_required? => true
-      order.should_receive(:process_payments!).once
+      order.should_receive(:process_payments!).once.and_return(true)
       order.state = "payment"
       order.next!
       order.state.should == "complete"

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -224,6 +224,20 @@ describe Spree::Order do
       end
 
     end
+
+    context "raise gateway error" do
+      before do
+        payments.first.should_receive(:process!) { raise Spree::Core::GatewayError.new }
+      end
+
+      it "rescues the error" do
+        expect { order.process_payments!  }.to_not raise_error
+      end
+
+      it "returns allow_checkout_on_gateway_error config value" do
+        expect(order.process_payments!).to eql Spree::Config.allow_checkout_on_gateway_error
+      end
+    end
   end
 
   context "#outstanding_balance" do

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -227,7 +227,7 @@ describe Spree::Order do
 
     context "raise gateway error" do
       before do
-        payments.first.should_receive(:process!) { raise Spree::Core::GatewayError.new }
+        payment.should_receive(:process!) { raise Spree::Core::GatewayError.new }
       end
 
       it "rescues the error" do

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -25,14 +25,16 @@ module Spree
 
         it "does not return shipping rates from a shipping method if the order's ship address is in a different zone" do
           shipping_method.zones.each{|z| z.members.delete_all}
-          shipping_rates = subject.shipping_rates(package)
-          shipping_rates.should == []
+          expect {
+            subject.shipping_rates(package)
+          }.to raise_error(Core::ShippingRateError)
         end
 
         it "does not return shipping rates from a shipping method if the calculator is not available for that order" do
           ShippingMethod.any_instance.stub_chain(:calculator, :available?).and_return(false)
-          shipping_rates = subject.shipping_rates(package)
-          shipping_rates.should == []
+          expect {
+            subject.shipping_rates(package)
+          }.to raise_error(Core::ShippingRateError)
         end
 
         it "returns shipping rates from a shipping method if the currency matches the order's currency" do
@@ -42,8 +44,9 @@ module Spree
 
         it "does not return shipping rates from a shipping method if the currency is different than the order's currency" do
           order.currency = "GBP"
-          shipping_rates = subject.shipping_rates(package)
-          shipping_rates.should == []
+          expect {
+            subject.shipping_rates(package)
+          }.to raise_error(Core::ShippingRateError)
         end
 
         it "sorts shipping rates by cost" do

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -25,7 +25,7 @@ module Spree
         return if after_update_attributes
 
         unless @order.next
-          flash[:error] = Spree.t(:payment_processing_failed)
+          flash[:error] = @order.checkout_errors.join(" ")
           redirect_to checkout_state_path(@order.state) and return
         end
 

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -18,8 +18,6 @@ module Spree
 
     helper 'spree/orders'
 
-    rescue_from Spree::Core::GatewayError, :with => :rescue_from_spree_gateway_error
-
     # Updates the order and advances to the next state (when possible.)
     def update
       if @order.update_attributes(object_params)
@@ -138,11 +136,6 @@ module Spree
         @differentiator.missing.each do |variant, quantity|
           @order.contents.remove(variant, quantity)
         end
-      end
-
-      def rescue_from_spree_gateway_error
-        flash[:error] = Spree.t(:spree_gateway_error_flash_for_checkout)
-        render :edit
       end
 
       def check_authorization

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -25,7 +25,7 @@ module Spree
         return if after_update_attributes
 
         unless @order.next
-          flash[:error] = @order.checkout_errors.join(" ")
+          flash[:error] = @order.checkout_error
           redirect_to checkout_state_path(@order.state) and return
         end
 

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -174,20 +174,6 @@ describe Spree::CheckoutController do
         response.should redirect_to spree.cart_path
       end
     end
-
-    context "Spree::Core::GatewayError" do
-      before do
-        order.stub :user => user
-        order.stub(:update_attributes).and_raise(Spree::Core::GatewayError)
-        spree_post :update, {:state => "address"}
-      end
-
-      it "should render the edit template" do
-        response.should render_template :edit
-        flash[:error].should == Spree.t(:spree_gateway_error_flash_for_checkout)
-      end
-    end
-
   end
 
   context "When last inventory item has been purchased" do

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -76,7 +76,6 @@ describe Spree::CheckoutController do
           # Must have *a* shipping method and a payment method so updating from address works
           order.stub :available_shipping_methods => [stub_model(Spree::ShippingMethod)]
           order.stub :available_payment_methods => [stub_model(Spree::PaymentMethod)]
-          order.stub :create_proposed_shipments => []
         end
 
         let(:address_params) do
@@ -89,26 +88,26 @@ describe Spree::CheckoutController do
           assigns[:order].should_not be_nil
         end
 
-        it "should advance the state" do
-          spree_post :update, {
-            :state => "address",
-            :order => {
-              :bill_address_attributes => address_params,
-              :use_billing => true
-            }
-          }
-          order.reload.state.should == "delivery"
-        end
+        context "update address attributes" do
+          before do
+            order.stub :create_proposed_shipments => []
 
-        it "should redirect the next state" do
-          spree_post :update, {
-            :state => "address",
-            :order => {
-              :bill_address_attributes => address_params,
-              :use_billing => true
+            spree_post :update, {
+              :state => "address",
+              :order => {
+                :bill_address_attributes => address_params,
+                :use_billing => true
+              }
             }
-          }
-          response.should redirect_to spree.checkout_state_path("delivery")
+          end
+
+          it "advances the state" do
+            order.reload.state.should == "delivery"
+          end
+
+          it "redirects the next state" do
+            response.should redirect_to spree.checkout_state_path("delivery")
+          end
         end
       end
 

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -76,6 +76,7 @@ describe Spree::CheckoutController do
           # Must have *a* shipping method and a payment method so updating from address works
           order.stub :available_shipping_methods => [stub_model(Spree::ShippingMethod)]
           order.stub :available_payment_methods => [stub_model(Spree::PaymentMethod)]
+          order.stub :create_proposed_shipments => []
         end
 
         let(:address_params) do

--- a/frontend/spec/requests/checkout_spec.rb
+++ b/frontend/spec/requests/checkout_spec.rb
@@ -164,6 +164,24 @@ describe "Checkout" do
     end
   end
 
+  # regression for #2958
+  context "cant generate shipping rate for every package", js: true do
+    let!(:bag) { create(:product, :name => "RoR Bag", shipping_category: nil) }
+
+    before { Spree::ShippingMethod.destroy_all }
+
+    it "raises error and doesn't go to next step" do
+      add_mug_to_cart
+      click_on "Checkout"
+      fill_in "order_email", :with => "ryan@spreecommerce.com"
+      fill_in_address
+      click_on "Save and Continue"
+
+      expect(current_path).to eql(spree.checkout_state_path("address"))
+      page.should have_content(Spree.t(:no_shipping_rates_found))
+    end
+  end
+
   # regression for #2921
   context "goes back from payment to add another item", js: true do
     let!(:bag) { create(:product, :name => "RoR Bag") }


### PR DESCRIPTION
Hi there, started looking into #2958 and ended up changing more than I expected.

I believe there are too many rescues spread on the code base for the same `order.process_payments!` code, when that method itself already rescues the exception.  So I removed duplicated code from `Order::Checkout` regarding this. I also removed the `rescue_from GatewayError` in `CheckoutController` because that method was never being called anyway afaik. The same error was being rescued two times already on the stack.

The third commit adds a new attribute to Order so that we can better keep track of errors during checkout transitions and display a generic message when no error is specified. Currently spree assumes every transition fails because of a payment error.

The last commit resolves #2958 by raising an error when spree can't generate any shipping rate for a package. This one breaks the build, just realized after running backend and frontend. I believe it's probably because I need to treat the exception somewhere else. I'd make another PR for it but it kind of depends on the previous commits to display the message during checkout. As far as I can see it might be better to raise a custom exception than having `undefined method for nilClass` later on.

Please let me know what you think about it. I've seen the error described in #2958 many times while working on other issues and it would be great to have a solution for that. Maybe we can come up with another one for that here if this PR doesn't look right.
