### PR TITLE
Remove deprecated method in Rails 4

### DIFF
--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 module ThirdParty
   class Extension < ActiveRecord::Base
     # nasty hack so we don't have to create a table to back this fake model
-    set_table_name :spree_products
+    self.table_name = 'spree_products'
   end
 end
 


### PR DESCRIPTION
This would break the core build once rails4 branch is merged into master
