### PR TITLE
Always downcase promo code on promo.activate

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -44,9 +44,10 @@ module Spree
     def activate(payload)
       return unless order_activatable? payload[:order]
 
+      # make sure code is always downcased (old databases might have mixed case codes)
       if code.present?
         event_code = payload[:coupon_code]
-        return unless event_code == self.code
+        return unless event_code == self.code.downcase.strip
       end
 
       if path.present?

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -90,6 +90,17 @@ describe Spree::Promotion do
       promotion.activate(@payload)
     end
 
+    context "database has uppercase code" do
+      it "always downcase code on comparison" do
+        promotion.stub(:code => 'xxX')
+        @payload[:coupon_code] = 'xxx'
+        @action1.should_receive(:perform).with(@payload)
+        @action2.should_receive(:perform).with(@payload)
+
+        promotion.activate(@payload)
+      end
+    end
+
     it "should check path if present" do
       promotion.path = 'content/cvv'
       @payload[:path] = 'content/cvv'


### PR DESCRIPTION
Old spree databases might have promo codes with mixed cases which would
make coupon codes case sensitive

e.g. "nocode" == "noCode" ("nocode" entered by user would be invalid)

I think 2-0-stable needs this one too
