### PR TITLE
Only create promo items if order is eligible

### DIFF
--- a/core/app/models/spree/promotion/actions/create_line_items.rb
+++ b/core/app/models/spree/promotion/actions/create_line_items.rb
@@ -6,14 +6,44 @@ module Spree
         accepts_nested_attributes_for :promotion_action_line_items
         attr_accessible :promotion_action_line_items_attributes
 
+        delegate :eligible?, :to => :promotion
 
+        # Adds a line item to the Order if the promotion is eligible
+        #
+        # This doesn't play right with Add to Cart events because at the moment
+        # the item was added to cart the promo may not be eligible. However it
+        # might become eligible as the order gets updated.
+        #
+        # e.g.
+        #   - A promo adds a line item to cart if order total greater then $30
+        #   - Customer add 1 item of $10 to cart
+        #   - This action shouldn't perform because the order is not eligible
+        #   - Customer increases item quantity to 5 (order total goes to $50)
+        #   - Now the order is eligible for the promo and the action should perform
+        #
+        # Another complication is when the same line item created by the promo
+        # is also added to cart on a separate action.
+        #
+        # e.g.
+        #   - Promo adds 1 item A to cart if order total greater then $30
+        #   - Customer add 2 items B to cart, current order total is $40
+        #   - This action performs adding item A to cart since order is eligible
+        #   - Customer changes his mind and updates item B quantity to 1
+        #   - At this point order is no longer eligible and one might expect
+        #     that item A should be removed
+        #
+        # It doesn't remove items from the order here because there's no way
+        # it can know whether that item was added via this promo action or if
+        # it was manually populated somewhere else. In that case the item
+        # needs to be manually removed from the order by the customer
         def perform(options = {})
-          return unless order = options[:order]
+          order = options[:order]
+          return unless self.eligible? order
+
           promotion_action_line_items.each do |item|
             current_quantity = order.quantity_of(item.variant)
             if current_quantity < item.quantity
               order.contents.add(item.variant, item.quantity - current_quantity)
-              order.update!
             end
           end
         end

--- a/core/spec/models/spree/promotion/actions/create_line_items_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_line_items_spec.rb
@@ -2,46 +2,60 @@ require 'spec_helper'
 
 describe Spree::Promotion::Actions::CreateLineItems do
   let(:order) { create(:order) }
-  let(:promotion) { Spree::Promotion.new }
   let(:action) { Spree::Promotion::Actions::CreateLineItems.create }
 
   context "#perform" do
-    before do
-      @v1 = create(:variant)
-      @v2 = create(:variant)
-      action.promotion_action_line_items.create!({
-        :variant => @v1,
-        :quantity => 1}, :without_protection => true
-      )
-      action.promotion_action_line_items.create!({
-        :variant => @v2,
-        :quantity => 2}, :without_protection => true
-      )
+    context "order is not eligible" do
+      before { action.stub(eligible?: false) }
+
+      it "doesn't create line items" do
+        expect(order.line_items.count).to eql 0
+
+        action.perform(:order => order)
+        expect(order.line_items.count).to eql 0
+      end
     end
 
-    it "adds line items to order with correct variant and quantity" do
-      action.perform(:order => order)
-      order.line_items.count.should == 2
-      line_item = order.line_items.find_by_variant_id(@v1.id)
-      line_item.should_not be_nil
-      line_item.quantity.should == 1
-    end
+    context "order is eligible" do
+      let(:mug) { create(:variant) }
+      let(:shirt) { create(:variant) }
 
-    it "only adds the delta of quantity to an order" do
-      order.contents.add(@v2, 1)
-      action.perform(:order => order)
-      line_item = order.line_items.find_by_variant_id(@v2.id)
-      line_item.should_not be_nil
-      line_item.quantity.should == 2
-    end
+      before do
+        action.stub(eligible?: true)
 
-    it "doesn't add if the quantity is greater" do
-      order.contents.add(@v2, 3)
-      action.perform(:order => order)
-      line_item = order.line_items.find_by_variant_id(@v2.id)
-      line_item.should_not be_nil
-      line_item.quantity.should == 3
+        action.promotion_action_line_items.create!({
+          :variant => mug,
+          :quantity => 1}, :without_protection => true
+        )
+        action.promotion_action_line_items.create!({
+          :variant => shirt,
+          :quantity => 2}, :without_protection => true
+        )
+      end
+
+      it "adds line items to order with correct variant and quantity" do
+        action.perform(:order => order)
+        order.line_items.count.should == 2
+        line_item = order.line_items.find_by_variant_id(mug.id)
+        line_item.should_not be_nil
+        line_item.quantity.should == 1
+      end
+
+      it "only adds the delta of quantity to an order" do
+        order.contents.add(shirt, 1)
+        action.perform(:order => order)
+        line_item = order.line_items.find_by_variant_id(shirt.id)
+        line_item.should_not be_nil
+        line_item.quantity.should == 2
+      end
+
+      it "doesn't add if the quantity is greater" do
+        order.contents.add(shirt, 3)
+        action.perform(:order => order)
+        line_item = order.line_items.find_by_variant_id(shirt.id)
+        line_item.should_not be_nil
+        line_item.quantity.should == 3
+      end
     end
   end
 end
-


### PR DESCRIPTION
Add a doc block to CreateLineItem.perform block to explain why it's not
suitable for Add to Cart events and explained another possible caveat

Stores running with this action set need to make sure the promo event is Order Contents Changed instead of Add to Cart. Otherwise they might not get the expected result. Will look into an update on spree-guides about this.

ci is green on master. Will run it on 2-0-stable now as I believe we need it there too.
