### PR TITLE
Don't ignore promo action beyond the first created

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Spree 2.1.0 (unreleased) ##
 
+*   Change `order.promotion_credit_exists?` api. Now it receives an adjustment
+    originator (PromotionAction instance) instead of a promotion. Allowing
+    multiple adjustments being created for the same promotion as the current
+    PromotionAction / Promotion api suggests #3262
+
 *   Remove after_save callback for stock items backorders processing and
     fixes count on hand updates when there are backordered units #3066
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -502,10 +502,13 @@ module Spree
     end
 
     # Tells us if there if the specified promotion is already associated with the order
-    # regardless of whether or not its currently eligible.  Useful because generally
-    # you would only want a promotion to apply to order no more than once.
-    def promotion_credit_exists?(promotion)
-      !! adjustments.promotion.reload.detect { |credit| credit.originator.promotion.id == promotion.id }
+    # regardless of whether or not its currently eligible. Useful because generally
+    # you would only want a promotion action to apply to order no more than once.
+    #
+    # Receives an adjustment +originator+ (here a PromotionAction object) and tells
+    # if the order has adjustments from that already
+    def promotion_credit_exists?(originator)
+      !! adjustments.promotion.reload.detect { |credit| credit.originator.id == originator.id }
     end
 
     def promo_total

--- a/core/app/models/spree/promotion/actions/create_adjustment.rb
+++ b/core/app/models/spree/promotion/actions/create_adjustment.rb
@@ -17,7 +17,7 @@ module Spree
         # through options hash
         def perform(options = {})
           order = options[:order]
-          return if order.promotion_credit_exists?(self.promotion)
+          return if order.promotion_credit_exists?(self)
 
           self.create_adjustment("#{Spree.t(:promotion)} (#{promotion.name})", order, order)
         end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -489,6 +489,22 @@ describe Spree::Order do
     end
   end
 
+  context "promotion adjustments" do
+    let(:originator) { double("Originator", id: 1) }
+    let(:adjustment) { double("Adjustment", originator: originator) }
+
+    before { order.stub_chain(:adjustments, :promotion, reload: [adjustment]) }
+
+    context "order has an adjustment from given promo action" do
+      it { expect(order.promotion_credit_exists? originator).to be_true }
+    end
+
+    context "order has no adjustment from given promo action" do
+      before { originator.stub(id: 12) }
+      it { expect(order.promotion_credit_exists? originator).to be_true }
+    end
+  end
+
   context "payment required?" do
     let(:order) { Spree::Order.new }
 


### PR DESCRIPTION
Currently Spree allow users to associate multiple actions, e.g
CreateAdjustment, to a promotion however it doesn't allow a promotion to
have multiple adjustments in the same other as the backend UI suggests.

It changes the `order.promotion_credit_exists?` api so that multiple
adjustments can be created for the same promotion even though only one
of them, the one with best amount, will be eligible.

Fixes #3262
