### PR TITLE
Scope eligible when choosing best adjustment

### DIFF
--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -131,7 +131,7 @@ module Spree
       # This promotion provides the most discount, and if two promotions
       # have the same amount, then it will pick the latest one.
       def choose_best_promotion_adjustment
-        if best_promotion_adjustment = order.adjustments.promotion.reorder("amount ASC, created_at DESC").first
+        if best_promotion_adjustment = order.adjustments.promotion.eligible.reorder("amount ASC, created_at DESC").first
           other_promotions = order.adjustments.promotion.where("id NOT IN (?)", best_promotion_adjustment.id)
           other_promotions.update_all(eligible: false)
         end

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -164,6 +164,22 @@ module Spree
         order.adjustments.eligible.promotion.first.label.should == 'Promotion C'
       end
 
+      context "multiple adjustments and the best one is not eligible" do
+        let!(:promo_a) { create_adjustment("Promotion A", -100) }
+        let!(:promo_c) { create_adjustment("Promotion C", -300) }
+
+        before do
+          promo_a.update_attribute_without_callbacks(:eligible, true)
+          promo_c.update_attribute_without_callbacks(:eligible, false)
+        end
+
+        # regression for #3274
+        it "still makes the previous best eligible adjustment valid" do
+          updater.update_adjustments
+          order.adjustments.eligible.promotion.first.label.should == 'Promotion A'
+        end
+      end
+
       it "should only leave one adjustment even if 2 have the same amount" do
         create_adjustment("Promotion A", -100)
         create_adjustment("Promotion B", -200)


### PR DESCRIPTION
When the order had a better but not eligible adjustment the store would
make all other adjustments not eligible. Instead it should scope
eligible adjustments when figuring out which one should make it to the
order

thanks to @sohara for pointing that out

2-0-stable needs this fix too
