### PR TITLE
Added back to stock locations button, removed edit and destroy button

### DIFF
--- a/backend/app/views/spree/admin/stock_movements/index.html.erb
+++ b/backend/app/views/spree/admin/stock_movements/index.html.erb
@@ -33,11 +33,6 @@
         <td class="align-center"><%= stock_movement.stock_item.variant_name %></td>
         <td class="align-center"><%= stock_movement.quantity %></td>
         <td class="align-center"><%= pretty_originator(stock_movement) %></td>
-        <td data-hook="admin_stock_movements_index_row_actions" class="actions">
-          <%= link_to_with_icon 'icon-edit', Spree.t(:edit), edit_admin_stock_location_stock_movement_path(@stock_location, stock_movement), data: { action: 'edit' }, no_text: true %>
-          <%= link_to_with_icon 'icon-trash', Spree.t(:delete), admin_stock_location_stock_movement_path(@stock_location, stock_movement), method: :delete,
-            data: { confirm: Spree.t(:are_you_sure), action: 'remove' }, no_text: true %>
-        </td>
       </tr>
     <% end %>
   </tbody>

--- a/backend/app/views/spree/admin/stock_movements/index.html.erb
+++ b/backend/app/views/spree/admin/stock_movements/index.html.erb
@@ -8,6 +8,9 @@
   <li>
     <%= button_link_to Spree.t(:new_stock_movement), new_admin_stock_location_stock_movement_path(@stock_location),  icon: 'icon-plus', id: 'admin_new_stock_movement_link' %>
   </li>
+  <li>
+    <%= link_to_with_icon 'icon-arrow-left', Spree.t(:back_to_stock_locations_list), admin_stock_locations_path, :class => 'button' %>
+  </li>
 <% end %>
 
 <table class="index" id='listing_stock_movements'>
@@ -33,7 +36,7 @@
         <td data-hook="admin_stock_movements_index_row_actions" class="actions">
           <%= link_to_with_icon 'icon-edit', Spree.t(:edit), edit_admin_stock_location_stock_movement_path(@stock_location, stock_movement), data: { action: 'edit' }, no_text: true %>
           <%= link_to_with_icon 'icon-trash', Spree.t(:delete), admin_stock_location_stock_movement_path(@stock_location, stock_movement), method: :delete,
-            data: { confirm: t(:are_you_sure), action: 'remove' }, no_text: true %>
+            data: { confirm: Spree.t(:are_you_sure), action: 'remove' }, no_text: true %>
         </td>
       </tr>
     <% end %>

--- a/core/app/models/spree/stock_movement.rb
+++ b/core/app/models/spree/stock_movement.rb
@@ -1,3 +1,7 @@
+# Spree::StockMovement
+# StockMovement is used for tracking stock item's total count_on_hand.
+# An existing StockMovement udner a StockLocation can not be updated or destroyed.
+#
 module Spree
   class StockMovement < ActiveRecord::Base
     belongs_to :stock_item, class_name: 'Spree::StockItem'
@@ -12,8 +16,16 @@ module Spree
 
     scope :recent, order('created_at DESC')
 
+    # existing StockMovement is readonly as it should not be updated.
     def readonly?
       !new_record?
+    end
+
+    # existing StockMovement can not be destroy as it is used for 
+    # tracking stock item's total count_on_hand.
+    def destroy
+      raise Spree.t(:can_not_destroy_stock_movement) if !new_record?
+      super
     end
 
     private

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -363,6 +363,7 @@ en:
     cancel: cancel
     cannot_create_payment_without_payment_methods: You cannot create a payment for an order without any payment methods defined.
     cannot_create_returns: Cannot create returns as this order has no shipped units.
+    can_not_destroy_stock_movement: Cannot destroy a stock movement as it is used for tracking stock item total quantity.
     cannot_perform_operation: Cannot perform requested operation
     cannot_set_shipping_method_without_address: Cannot set shipping method until customer details are provided.
     capture: Capture

--- a/core/spec/models/spree/stock_movement_spec.rb
+++ b/core/spec/models/spree/stock_movement_spec.rb
@@ -16,6 +16,13 @@ describe Spree::StockMovement do
     }.to raise_error(ActiveRecord::ReadOnlyRecord)
   end
 
+  it 'can not be destroyed unless new' do
+    subject.save
+    expect {
+      subject.destroy
+    }.to raise_error(RuntimeError)
+  end
+
   it 'does not update count on hand when track inventory levels is false' do
     Spree::Config[:track_inventory_levels] = false
     subject.quantity = 1


### PR DESCRIPTION
Added Navigation back to Stock Locations on Stock movements' index page.
Removed edit and destroy button from Stock movements' index page, added spec for the same.

Fixes #3280
