### PR TITLE
Log API errors in Rails log

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -82,6 +82,9 @@ module Spree
       end
 
       def error_during_processing(exception)
+        Rails.logger.error exception.message
+        Rails.logger.error exception.backtrace.join("\n")
+
         render :text => { :exception => exception.message }.to_json,
           :status => 422 and return
       end


### PR DESCRIPTION
Currently the exception message is returned in the JSON error response, but the backtrace is lost.

This patch adds logging of the exception's message & backtrace to the rails log
