### PR TITLE
Normalizes copy product navigation_helper#link_to_clone

### DIFF
--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -6,6 +6,7 @@ module Spree
       before_filter :load_data, :except => :index
       create.before :create_before
       update.before :update_before
+      helper_method :clone_object_url
 
       def show
         session[:return_to] ||= request.referer
@@ -110,6 +111,9 @@ module Spree
          [{:variants => [:images, {:option_values => :option_type}]}, {:master => [:images, :default_price]}]
         end
 
+        def clone_object_url resource
+          clone_admin_product_url resource
+        end
     end
   end
 end

--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -60,7 +60,7 @@ module Spree
 
       def link_to_clone(resource, options={})
         options[:data] = {:action => 'clone'}
-        link_to_with_icon('icon-copy', Spree.t(:clone), clone_admin_product_url(resource), options)
+        link_to_with_icon('icon-copy', Spree.t(:clone), clone_object_url(resource), options)
       end
 
       def link_to_new(resource)


### PR DESCRIPTION
I had to use `link_to_clone` for another resource, not a product. Since the `clone_admin_product_url` was fixed in the method, I had to duplicate it.

I would like to suggest to normalize this method to work similar to `:new_object_url, :edit_object_url, :object_url, :collection_url`.

I added the `helper_method` directly in the ProductController instead of ResourceController, because I don't know how frequently it will be used by others resources. If it makes sense to add it in the ResourceController I can change the PR.

**Usage:**

``` ruby
module Spree::Admin
  class MyResourceController  < ResourceController
    helper_method :clone_object_url

    protected

    def clone_object_url resource
      clone_admin_my_resource_url resource
    end
  end
end
```
## 

``` erb
<%= link_to_clone my_resource, no_text: true %>
```
