### PR TITLE
Fix last_incomplete_spree_order to return 'last' order

### DIFF
--- a/core/config/initializers/user_class_extensions.rb
+++ b/core/config/initializers/user_class_extensions.rb
@@ -18,7 +18,7 @@ Spree::Core::Engine.config.to_prepare do
       end
 
       def last_incomplete_spree_order
-        spree_orders.incomplete.order('created_at DESC').last
+        spree_orders.incomplete.order('created_at DESC').first
       end
     end
   end

--- a/core/spec/models/spree/user_spec.rb
+++ b/core/spec/models/spree/user_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe Spree::LegacyUser do
+  # Regression test for #2844
+  context "#last_incomplete_order" do
+    let!(:user) { create(:user) }
+    let!(:order_1) { create(:order, :created_at => 1.day.ago, :user => user) }
+    let!(:order_2) { create(:order, :user => user) }
+
+    it "returns correct order" do
+      user.last_incomplete_spree_order.should == order_2
+    end
+  end
+end


### PR DESCRIPTION
Backporting patch from v2.

(cherry picked from commit 8c970aac82a0a16ba19eaa6b81c8ae393b435325)
