### PR TITLE
Don't select backend only shipping rates by default

### DIFF
--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -8,6 +8,7 @@ module Spree
     has_many :shipments
     has_many :shipping_method_categories
     has_many :shipping_categories, through: :shipping_method_categories
+    has_many :shipping_rates
 
     has_and_belongs_to_many :zones, :join_table => 'spree_shipping_methods_zones',
                                     :class_name => 'Spree::Zone',
@@ -47,6 +48,11 @@ module Spree
 
     def self.calculators
       spree_calculators.send(model_name_without_spree_namespace).select{ |c| c < Spree::ShippingCalculator }
+    end
+
+    # Some shipping methods are only meant to be set via backend
+    def frontend?
+      self.display_on != "back_end"
     end
 
     private

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -57,25 +57,41 @@ module Spree
           expect(subject.shipping_rates(package).map(&:cost)).to eq %w[3.00 4.00 5.00].map(&BigDecimal.method(:new))
         end
 
-        it "selects the most affordable shipping rate" do
-          shipping_methods = 3.times.map { create(:shipping_method) }
-          shipping_methods[0].stub_chain(:calculator, :compute).and_return(5.00)
-          shipping_methods[1].stub_chain(:calculator, :compute).and_return(3.00)
-          shipping_methods[2].stub_chain(:calculator, :compute).and_return(4.00)
+        context "general shipping methods" do
+          let(:shipping_methods) { 2.times.map { create(:shipping_method) } }
 
-          subject.stub(:shipping_methods).and_return(shipping_methods)
+          it "selects the most affordable shipping rate" do
+            shipping_methods[0].stub_chain(:calculator, :compute).and_return(5.00)
+            shipping_methods[1].stub_chain(:calculator, :compute).and_return(3.00)
 
-          expect(subject.shipping_rates(package).sort_by(&:cost).map(&:selected)).to eq [true, false, false]
+            subject.stub(:shipping_methods).and_return(shipping_methods)
+
+            expect(subject.shipping_rates(package).sort_by(&:cost).map(&:selected)).to eq [true, false]
+          end
+
+          it "selects the most affordable shipping rate and doesn't raise exception over nil cost" do
+            shipping_methods[0].stub_chain(:calculator, :compute).and_return(1.00)
+            shipping_methods[1].stub_chain(:calculator, :compute).and_return(nil)
+
+            subject.stub(:shipping_methods).and_return(shipping_methods)
+
+            subject.shipping_rates(package)
+          end
         end
 
-        it "selects the most affordable shipping rate and doesn't raise exception over nil cost" do
-          shipping_methods = 2.times.map { create(:shipping_method) }
-          shipping_methods[0].stub_chain(:calculator, :compute).and_return(1.00)
-          shipping_methods[1].stub_chain(:calculator, :compute).and_return(nil)
+        context "involves backend only shipping methods" do
+          let(:backend_method) { create(:shipping_method, display_on: "back_end") }
+          let(:generic_method) { create(:shipping_method) }
 
-          subject.stub(:shipping_methods).and_return(shipping_methods)
+          # regression for #3287
+          it "doesn't select backend rates even if they're more affordable" do
+            backend_method.stub_chain(:calculator, :compute).and_return(0.00)
+            generic_method.stub_chain(:calculator, :compute).and_return(5.00)
 
-          subject.shipping_rates(package)
+            subject.stub(:shipping_methods).and_return([backend_method, generic_method])
+
+            expect(subject.shipping_rates(package).map(&:selected)).to eq [false, true]
+          end
         end
       end
     end


### PR DESCRIPTION
As frontend users shouldn't select shipping rates only meant to be used
via backend. So Estimator by default only marks frontend/generic
shipping rates as selected

Fixes #3287

While working on this fix I wondered if we really need the `display_on` field at all. Maybe a boolean backend flag on shipping methods should be enough in case there's no reason to hide any shipping method in backend. Makes sense? I could put that refactoring in the my not priority list and work on it some time later.

CI is green.
