### PR TITLE
add table_name to fix "order created_at" excpetion error

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -41,7 +41,7 @@ module Spree
     alias_attribute :shipping_address, :ship_address
 
     has_many :state_changes, as: :stateful
-    has_many :line_items, dependent: :destroy, order: 'spree_line_items.created_at ASC'
+    has_many :line_items, dependent: :destroy, order: "#{Spree::LineItem.table_name}.created_at ASC"
     has_many :payments, dependent: :destroy
 
     has_many :shipments, dependent: :destroy do
@@ -51,7 +51,7 @@ module Spree
     end
 
     has_many :return_authorizations, dependent: :destroy
-    has_many :adjustments, as: :adjustable, dependent: :destroy, order: 'spree_adjustments.created_at ASC'
+    has_many :adjustments, as: :adjustable, dependent: :destroy, order: "#{Spree::Adjustment.table_name}.created_at ASC"
 
     accepts_nested_attributes_for :line_items
     accepts_nested_attributes_for :bill_address

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -41,7 +41,7 @@ module Spree
     alias_attribute :shipping_address, :ship_address
 
     has_many :state_changes, as: :stateful
-    has_many :line_items, dependent: :destroy, order: 'created_at ASC'
+    has_many :line_items, dependent: :destroy, order: 'spree_line_items.created_at ASC'
     has_many :payments, dependent: :destroy
 
     has_many :shipments, dependent: :destroy do
@@ -51,7 +51,7 @@ module Spree
     end
 
     has_many :return_authorizations, dependent: :destroy
-    has_many :adjustments, as: :adjustable, dependent: :destroy, order: 'created_at ASC'
+    has_many :adjustments, as: :adjustable, dependent: :destroy, order: 'spree_adjustments.created_at ASC'
 
     accepts_nested_attributes_for :line_items
     accepts_nested_attributes_for :bill_address


### PR DESCRIPTION
- fix for Issue #3305
- include a test

``` bash
localhost:core xwaynec$ bundle exec rspec spec/models/spree/order_spec.rb
Instance method "open" is already defined in Object, use generic helper instead or set StateMachine::Machine.ignore_method_conflicts = true.
......................................DEPRECATION WARNING: [SPREE] Spree::Order#remove_variant will be deprecated in Spree 2.1, please use order.contents.remove instead. (called from remove_variant at /Users/xwaynec/Project/spree/core/app/models/spree/order.rb:275)
.DEPRECATION WARNING: [SPREE] Spree::Order#remove_variant will be deprecated in Spree 2.1, please use order.contents.remove instead. (called from remove_variant at /Users/xwaynec/Project/spree/core/app/models/spree/order.rb:275)
.DEPRECATION WARNING: [SPREE] Spree::Order#remove_variant will be deprecated in Spree 2.1, please use order.contents.remove instead. (called from remove_variant at /Users/xwaynec/Project/spree/core/app/models/spree/order.rb:275)
.....................

Finished in 3.58 seconds
61 examples, 0 failures
```
