### PR TITLE
Raise RecordNotFound in OrderContents if line item can't be found

### DIFF
--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -6,21 +6,22 @@ module Spree
       @order = order
     end
 
+    # Get current line item for variant if exists
+    # Add variant qty to line_item
     def add(variant, quantity, currency=nil, shipment=nil)
-      #get current line item for variant if exists
       line_item = order.find_line_item_by_variant(variant)
-
-      #add variant qty to line_item
       add_to_line_item(line_item, variant, quantity, currency, shipment)
     end
 
+    # Get current line item for variant
+    # Remove variant qty from line_item
     def remove(variant, quantity, shipment=nil)
-      #get current line item for variant
       line_item = order.find_line_item_by_variant(variant)
 
-      #TODO raise exception if line_item is nil
+      unless line_item
+        raise ActiveRecord::RecordNotFound, "Line item not found for variant #{variant.sku}"
+      end
 
-      #remove variant qty from line_item
       remove_from_line_item(line_item, variant, quantity, shipment)
     end
 

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -34,6 +34,14 @@ describe Spree::OrderContents do
   context "#remove" do
     let(:variant) { create(:variant) }
 
+    context "given an invalid variant" do
+      it "raises an exception" do
+        expect {
+          subject.remove(variant, 1)
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
     it 'should reduce line_item quantity if quantity is less the line_item quantity' do
       line_item = subject.add(variant, 3)
       subject.remove(variant, 1)


### PR DESCRIPTION
Remove TODO on `remove` method and raises error when the line item can't
be found by variant
