### PR TITLE
Order.process_payment refactor

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -414,8 +414,23 @@ module Spree
       payments.select(&:checkout?)
     end
 
+    # processes any pending payments and must return a boolean as it's
+    # return value is used by the checkout state_machine to determine
+    # success or failure of the 'complete' event for the order
+    #
+    # Returns:
+    # - true if all pending_payments processed successfully
+    # - true if a payment failed, ie. raised a GatewayError
+    #   which gets rescued and converted to TRUE when
+    #   :allow_checkout_gateway_error is set to true
+    # - false if a payment failed, ie. raised a GatewayError
+    #   which gets rescued and converted to FALSE when
+    #   :allow_checkout_on_gateway_error is set to false
+    #
     def process_payments!
-      begin
+      if pending_payments.empty?
+        raise Core::GatewayError.new Spree.t(:no_pending_payments)
+      else
         pending_payments.each do |payment|
           break if payment_total >= total
 
@@ -425,9 +440,9 @@ module Spree
             self.payment_total += payment.amount
           end
         end
-      rescue Core::GatewayError
-        !!Spree::Config[:allow_checkout_on_gateway_error]
       end
+    rescue Core::GatewayError
+      !!Spree::Config[:allow_checkout_on_gateway_error]
     end
 
     def billing_firstname

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -13,9 +13,7 @@ module Spree
         order.payment_required?
       }
       go_to_state :confirm, if: ->(order) { order.confirmation_required? }
-      go_to_state :complete, if: ->(order) {
-        (order.payment_required? && order.has_unprocessed_payments?) || !order.payment_required?
-      }
+      go_to_state :complete
       remove_transition from: :delivery, to: :confirm
     end
 
@@ -165,18 +163,6 @@ module Spree
     # If true, causes the confirmation step to happen during the checkout process
     def confirmation_required?
       payments.map(&:payment_method).compact.any?(&:payment_profiles_supported?)
-    end
-
-    # Used by the checkout state machine to check for unprocessed payments
-    # The Order should be only be able to proceed to complete if there are unprocessed
-    # payments and there is payment required.
-    #
-    # The reason for this is directly before an order transitions to complete, all
-    # of the order's payments have `process!` called on it (look in order/checkout.rb).
-    # If payment *is* required and there's no payments which haven't already been tried,
-    # then the order cannot be paid for and therefore should not be able to become complete.
-    def has_unprocessed_payments?
-      payments.with_state('checkout').reload.exists?
     end
 
     # Indicates the number of items in the order

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -64,11 +64,7 @@ module Spree
               end
 
               before_transition :to => :complete do |order|
-                begin
-                  order.process_payments! if order.payment_required?
-                rescue Spree::Core::GatewayError
-                  !!Spree::Config[:allow_checkout_on_gateway_error]
-                end
+                order.process_payments! if order.payment_required?
               end
 
               before_transition :to => :delivery, :do => :create_proposed_shipments

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -131,11 +131,10 @@ describe Spree::Order do
         before do
           order.stub :confirmation_required? => false
           order.stub :payment_required? => true
-          order.stub_chain(:has_unprocessed_payments?).and_return(true)
         end
 
         it "transitions to complete" do
-          order.should_receive(:process_payments!).once
+          order.should_receive(:process_payments!).once.and_return true
           order.next!
           order.state.should == "complete"
         end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -537,27 +537,6 @@ describe Spree::Order do
     end
   end
 
-  # Related to the fix for #2694
-  context "#has_unprocessed_payments?" do
-    let!(:persisted_order) { create(:order) }
-
-    context "with payments in the 'checkout' state" do
-      before do
-        create(:payment, :order => persisted_order, :state => 'checkout')
-      end
-
-      it "returns true" do
-        assert persisted_order.has_unprocessed_payments?
-      end
-    end
-
-    context "with no payments in the 'checkout' state" do
-      it "returns false" do
-        assert !persisted_order.has_unprocessed_payments?
-      end
-    end
-  end
-
   context "add_update_hook" do
     before do
       Spree::Order.class_eval do

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -213,12 +213,12 @@ describe Spree::Order do
     context "when a payment raises a GatewayError" do
       before { payment.should_receive(:process!).and_raise(Spree::Core::GatewayError) }
 
-      it "should return true when :allow_checkout_on_gateway_error if true" do
+      it "should return true when configured to allow checkout on gateway failures" do
         Spree::Config.set :allow_checkout_on_gateway_error => true
         order.process_payments!.should be_true
       end
 
-      it "should return false when :allow_checkout_on_gateway_error is false" do
+      it "should return false when not configured to allow checkout on gateway failures" do
         Spree::Config.set :allow_checkout_on_gateway_error => false
         order.process_payments!.should be_false
       end

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -20,12 +20,6 @@ module Spree
 
     rescue_from Spree::Core::GatewayError, :with => :rescue_from_spree_gateway_error
 
-    def edit
-      if stale_order?
-        respond_with(@order)
-      end
-    end
-
     # Updates the order and advances to the next state (when possible.)
     def update
       if @order.update_attributes(object_params)
@@ -67,10 +61,6 @@ module Spree
         false
       end
 
-      def stale_order?
-        stale?(:etag => @order, :last_modified => @order.updated_at)
-      end
-
       def load_order
         @order = current_order
         redirect_to spree.cart_path and return unless @order
@@ -79,10 +69,7 @@ module Spree
           redirect_to checkout_state_path(@order.state) if @order.can_go_to_state?(params[:state]) && !skip_state_validation?
           @order.state = params[:state]
         end
-
-        if stale_order?
-          setup_for_current_state
-        end
+        setup_for_current_state
       end
 
       def ensure_checkout_allowed

--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -10,9 +10,6 @@ module Spree
 
     def show
       @order = Order.find_by_number!(params[:id])
-      if stale?(:etag => @order, :last_modified => @order.updated_at)
-        respond_with(@order)
-      end
     end
 
     def update


### PR DESCRIPTION
@radar can you take a quick sanity check on this and merge it to master + 2-0-stable when you get a chance please?

It fixes a condition encountered on a production spree store where "failed" payments (i.e. declined, etc) were allowing an order to get into a "complete" incorrectly.

While I was fixing it I decided I could drop the conditions from the `:go_to_state :complete` , as the refactored process_payments method provides the same protection in a slight simpler way. I just want to make I fully got all the edge cases those conditions where intended to protect against. 

Also, if reverts + fixes the issues noted in #3282 

Thanks.
