### PR TITLE
#to_package Use symbols for state. Fixes #3326

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -224,7 +224,7 @@ module Spree
     def to_package
       package = Stock::Package.new(stock_location, order)
       inventory_units.includes(:variant).each do |inventory_unit|
-        package.add inventory_unit.variant, 1, inventory_unit.state
+        package.add inventory_unit.variant, 1, inventory_unit.state_name
       end
       package
     end

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -101,6 +101,16 @@ describe Spree::Shipment do
         shipment.stub(shipped?: true)
         shipment.refresh_rates.should == []
       end
+
+      context 'to_package' do
+        it 'should use symbols for states when adding contents to package' do
+          shipment.stub_chain(:inventory_units, includes: [ build(:inventory_unit, variant: variant, state: 'on_hand'),
+                                                            build(:inventory_unit, variant: variant, state: 'backordered') ] )
+          package = shipment.to_package
+          package.on_hand.count.should eq 1
+          package.backordered.count.should eq 1
+        end
+      end
     end
   end
 


### PR DESCRIPTION
From Original Issue: 

Calling `to_package` on a Shipment (as done in `refresh_rates`) creates a Package with invalid inventary_unit's states - i.e. it uses strings for the state of the inventary unit instead of symbols (expected).

To reproduce:

``` ruby
package = my_shipment.to_package
package.backordered # will always return an apty array []
package.on_hand # same thing, empty array
```
