### PR TITLE
Optional CVV response

### DIFF
--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -155,8 +155,11 @@ module Spree
         unless response.authorization.nil?
           self.response_code = response.authorization
           self.avs_response = response.avs_result['code']
-          self.cvv_response_code = response.cvv_result['code']
-          self.cvv_response_message = response.cvv_result['message']
+
+          if response.cvv_result
+            self.cvv_response_code = response.cvv_result['code']
+            self.cvv_response_message = response.cvv_result['message']
+          end
         end
         self.send("#{success_state}!")
       else

--- a/core/spec/models/payment_spec.rb
+++ b/core/spec/models/payment_spec.rb
@@ -30,11 +30,13 @@ describe Spree::Payment do
 
   let(:currency) { 'USD' }
 
-  let!(:success_response) do
-    mock('success_response', :success? => true,
-                             :authorization => '123',
-                             :avs_result => { 'code' => 'avs-code' },
-                             :cvv_result => { 'code' => 'cvv-code', 'message' => "CVV Result"})
+  def success_response(options = {})
+    default = {:success? => true,
+               :authorization => '123',
+               :avs_result => { 'code' => 'avs-code' },
+               :cvv_result => { 'code' => 'cvv-code', 'message' => "CVV Result"}}
+
+    mock('success_response', default.merge(options))
   end
 
   let(:failed_response) { mock('gateway_response', :success? => false) }


### PR DESCRIPTION
Currently Spree requires that a successful gateway response include a cvv_result.
But that breaks the bogus gateway which isnt sending a cvv_result 

This PR makes cvv_result optional. The specs were slightly refactored to reflect that a default success response is without cvv_result.
