### PR TITLE
Wrap code example in CONTRIBUTING.md with backticks (`)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ Syntax:
 * Two spaces, no tabs.
 * No trailing whitespace. Blank lines should not have any space.
 * Prefer &&/|| over and/or.
-* `MyClass.my_method(my_arg)` not `my_method( my_arg )` or my_method my_arg.
+* `MyClass.my_method(my_arg)` not `my_method( my_arg )` or `my_method my_arg`.
 * `a = b` and not `a=b`.
 * `a_method { |block| ... }` and not `a_method { | block | ... }`
 * Follow the conventions you see used in the source already.


### PR DESCRIPTION
Noticed this while looking over the guidelines.
