### PR TITLE
Dont touch stock items when order not completed

### DIFF
--- a/core/app/models/spree/order_inventory.rb
+++ b/core/app/models/spree/order_inventory.rb
@@ -54,7 +54,6 @@ module Spree
     #
     # first unshipped that already includes this variant
     # first unshipped that's leaving from a stock_location that stocks this variant
-    #
     def determine_target_shipment(variant)
       shipment = order.shipments.detect do |shipment|
         (shipment.ready? || shipment.pending?) && shipment.include?(variant)
@@ -101,9 +100,7 @@ module Spree
         removed_quantity += 1
       end
 
-      if shipment.inventory_units.count == 0
-        shipment.destroy
-      end
+      shipment.destroy if shipment.inventory_units.count == 0
 
       # removing this from shipment, and adding to stock_location
       if order.completed?

--- a/core/spec/models/spree/order_inventory_spec.rb
+++ b/core/spec/models/spree/order_inventory_spec.rb
@@ -30,6 +30,15 @@ describe Spree::OrderInventory do
       let(:shipment) { order.shipments.first }
       let(:variant) { create :variant }
 
+      context "order is not completed" do
+        before { order.stub completed?: false }
+
+        it "doesn't unstock items" do
+          shipment.stock_location.should_not_receive(:unstock)
+          subject.send(:add_to_shipment, shipment, variant, 5).should == 5
+        end
+      end
+
       it 'should create inventory_units in the necessary states' do
         shipment.stock_location.should_receive(:fill_status).with(variant, 5).and_return([3, 2])
 
@@ -103,6 +112,15 @@ describe Spree::OrderInventory do
     context '#remove_from_shipment' do
       let(:shipment) { order.shipments.first }
       let(:variant) { order.line_items.first.variant }
+
+      context "order is not completed" do
+        before { order.stub completed?: false }
+
+        it "doesn't restock items" do
+          shipment.stock_location.should_not_receive(:restock)
+          subject.send(:remove_from_shipment, shipment, variant, 1).should == 1
+        end
+      end
 
       it 'should create stock_movement' do
         subject.send(:remove_from_shipment, shipment, variant, 1).should == 1

--- a/core/spec/models/spree/order_inventory_spec.rb
+++ b/core/spec/models/spree/order_inventory_spec.rb
@@ -10,8 +10,7 @@ describe Spree::OrderInventory do
     units.map(&:variant_id).should == [line_item.variant.id]
   end
 
-  context 'when order is missing inventory units' do
-
+  context "when order is missing inventory units" do
     before do
       line_item.update_attribute_without_callbacks(:quantity, 2)
     end
@@ -25,59 +24,61 @@ describe Spree::OrderInventory do
       subject.verify(line_item)
       order.reload.shipments.first.inventory_units_for(line_item.variant).size.should == 2
     end
+  end
 
-    context "#add_to_shipment" do
-      let(:shipment) { order.shipments.first }
-      let(:variant) { create :variant }
+  context "#add_to_shipment" do
+    let(:shipment) { order.shipments.first }
+    let(:variant) { create :variant }
 
-      context "order is not completed" do
-        before { order.stub completed?: false }
+    context "order is not completed" do
+      before { order.stub completed?: false }
 
-        it "doesn't unstock items" do
-          shipment.stock_location.should_not_receive(:unstock)
-          subject.send(:add_to_shipment, shipment, variant, 5).should == 5
-        end
-      end
-
-      it 'should create inventory_units in the necessary states' do
-        shipment.stock_location.should_receive(:fill_status).with(variant, 5).and_return([3, 2])
-
+      it "doesn't unstock items" do
+        shipment.stock_location.should_not_receive(:unstock)
         subject.send(:add_to_shipment, shipment, variant, 5).should == 5
-
-        units = shipment.inventory_units.group_by &:variant_id
-        units = units[variant.id].group_by &:state
-        units['backordered'].size.should == 2
-        units['on_hand'].size.should == 3
-      end
-
-      it 'should create stock_movement' do
-        subject.send(:add_to_shipment, shipment, variant, 5).should == 5
-
-        stock_item = shipment.stock_location.stock_item(variant)
-        movement = stock_item.stock_movements.last
-        # movement.originator.should == shipment
-        movement.quantity.should == -5
       end
     end
 
-    context "#determine_target_shipment" do
-      let(:stock_location) { create :stock_location }
-      let(:variant) { line_item.variant }
+    it 'should create inventory_units in the necessary states' do
+      shipment.stock_location.should_receive(:fill_status).with(variant, 5).and_return([3, 2])
 
-      before do
-        order.shipments.create(:stock_location_id => stock_location.id)
-        shipped = order.shipments.create(:stock_location_id => order.shipments.first.stock_location.id)
-        shipped.update_attribute_without_callbacks(:state, 'shipped')
-      end
+      subject.send(:add_to_shipment, shipment, variant, 5).should == 5
 
-      it 'should select first non-shipped shipment that already contains given variant' do
-        shipment = subject.send(:determine_target_shipment, variant)
-        shipment.shipped?.should be_false
-        shipment.inventory_units_for(variant).should_not be_empty
-        variant.stock_location_ids.include?(shipment.stock_location_id).should be_true
-      end
+      units = shipment.inventory_units.group_by &:variant_id
+      units = units[variant.id].group_by &:state
+      units['backordered'].size.should == 2
+      units['on_hand'].size.should == 3
+    end
 
-      it 'should select first non-shipped shipment that leaves from same stock_location when no shipments already contain this varint' do
+    it 'should create stock_movement' do
+      subject.send(:add_to_shipment, shipment, variant, 5).should == 5
+
+      stock_item = shipment.stock_location.stock_item(variant)
+      movement = stock_item.stock_movements.last
+      # movement.originator.should == shipment
+      movement.quantity.should == -5
+    end
+  end
+
+  context "#determine_target_shipment" do
+    let(:stock_location) { create :stock_location }
+    let(:variant) { line_item.variant }
+
+    before do
+      order.shipments.create(:stock_location_id => stock_location.id)
+      shipped = order.shipments.create(:stock_location_id => order.shipments.first.stock_location.id)
+      shipped.update_attribute_without_callbacks(:state, 'shipped')
+    end
+
+    it 'should select first non-shipped shipment that already contains given variant' do
+      shipment = subject.send(:determine_target_shipment, variant)
+      shipment.shipped?.should be_false
+      shipment.inventory_units_for(variant).should_not be_empty
+      variant.stock_location_ids.include?(shipment.stock_location_id).should be_true
+    end
+
+    context "when no shipments already contain this varint" do
+      it 'selects first non-shipped shipment that leaves from same stock_location' do
         subject.send(:remove_from_shipment, order.shipments.first, variant, line_item.quantity)
 
         shipment = subject.send(:determine_target_shipment, variant)
@@ -86,7 +87,6 @@ describe Spree::OrderInventory do
         shipment.inventory_units_for(variant).should be_empty
         variant.stock_location_ids.include?(shipment.stock_location_id).should be_true
       end
-
     end
   end
 
@@ -153,36 +153,14 @@ describe Spree::OrderInventory do
         subject.send(:remove_from_shipment, shipment, variant, 1).should == 1
       end
 
-      it 'should only attempt to destroy as many units as are eligible, and return amount destroyed' do
+      it 'only attempts to destroy as many units as are eligible, and return amount destroyed' do
         shipment.stub(:inventory_units_for => [ mock_model(Spree::InventoryUnit, :variant_id => variant.id, :state => 'shipped'),
                                                 mock_model(Spree::InventoryUnit, :variant_id => variant.id, :state => 'on_hand') ] )
 
         shipment.inventory_units_for[0].should_not_receive(:destroy)
         shipment.inventory_units_for[1].should_receive(:destroy)
 
-        subject.send(:remove_from_shipment, shipment, variant, 3).should == 1
-      end
-
-      xit 'should raise exception if not enough deletable units are present' do
-        expect {
-          order.contents.add(variant, 2)
-          shipment.stub(:inventory_units => [ mock_model(Spree::InventoryUnit, :variant_id => variant.id, :state => 'shipped'),
-                                              mock_model(Spree::InventoryUnit, :variant_id => variant.id, :state => 'shipped') ] )
-
-          subject.send(:remove_from_shipment, shipment, variant, 1).should == 1
-
-        }.to raise_error(/Shipment does not contain enough deletable inventory_units/)
-      end
-
-      xit 'should raise exception if variant does not belong to shipment' do
-        expect {
-          order.contents.add(variant, 2)
-          shipment.stub(:inventory_units => [ mock_model(Spree::InventoryUnit, :variant_id => variant.id, :state => 'shipped'),
-                                              mock_model(Spree::InventoryUnit, :variant_id => variant.id, :state => 'shipped') ] )
-
-          subject.send(:remove_from_shipment, shipment, variant, 1).should == 1
-
-        }.to raise_error(/Variant does not belong to this shipment/)
+        subject.send(:remove_from_shipment, shipment, variant, 1).should == 1
       end
 
       it 'should destroy self if not inventory units remain' do
@@ -192,6 +170,5 @@ describe Spree::OrderInventory do
         subject.send(:remove_from_shipment, shipment, variant, 1).should == 1
       end
     end
-
   end
 end


### PR DESCRIPTION
I believe it fixes the issue described in #3324. When creating orders via backend Spree unstocks items twice. First when items are added to the order and later when order is completed.

2-0-stable needs this fix too.
