### PR TITLE
Recreate shipments in frontend when necessary

### DIFF
--- a/frontend/spec/controllers/spree/orders_controller_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_spec.rb
@@ -2,7 +2,19 @@ require 'spec_helper'
 
 describe Spree::OrdersController do
   let(:user) { create(:user) }
-  let(:order) { mock_model(Spree::Order, :number => "R123", :reload => nil, :save! => true, :coupon_code => nil, :user => user, :completed? => false, :currency => "USD", :token => 'a1b2c3d4')}
+
+  let(:order) do
+    mock_model(Spree::Order, :number => "R123",
+                             :reload => nil,
+                             :save! => true,
+                             :coupon_code => nil,
+                             :user => user,
+                             :completed? => false,
+                             :currency => "USD",
+                             :token => 'a1b2c3d4',
+                             :shipments => [])
+  end
+
   before do
     # Don't care about IP address being set here
     order.stub(:last_ip_address=)

--- a/frontend/spec/requests/checkout_spec.rb
+++ b/frontend/spec/requests/checkout_spec.rb
@@ -190,6 +190,48 @@ describe "Checkout" do
     end
   end
 
+  context "from payment step customer goes back to cart", js: true do
+    before do
+      add_mug_to_cart
+      click_on "Checkout"
+      fill_in "order_email", :with => "ryan@spreecommerce.com"
+      fill_in_address
+      click_on "Save and Continue"
+      click_on "Save and Continue"
+      expect(current_path).to eql(spree.checkout_state_path("payment"))
+    end
+
+    context "and updates line item quantity" do
+      it "uptades shipments properly" do
+        visit spree.cart_path
+        within ".cart-item-quantity" do
+          fill_in first("input")["name"], with: 3
+        end
+
+        click_on "Update"
+        visit spree.checkout_state_path("payment")
+        click_on "Save and Continue"
+
+        expect(Spree::InventoryUnit.count).to eq 3
+      end
+    end
+
+    context "and adds new product to cart" do
+      let!(:bag) { create(:product, :name => "RoR Bag") }
+
+      it "updates shipments properly" do
+        visit spree.root_path
+        click_link bag.name
+        click_button "add-to-cart-button"
+
+        visit spree.checkout_state_path("payment")
+        click_on "Save and Continue"
+
+        expect(Spree::InventoryUnit.count).to eq 2
+      end
+    end
+  end
+
   def fill_in_address
     address = "order_bill_address_attributes"
     fill_in "#{address}_firstname", :with => "Ryan"


### PR DESCRIPTION
Every time a customer gets to the point where shipments were created,
delivery step, and then decides to go back and change some item quantity
or add a new product we need to recreate the shipments so they properly
reflect the current order state.

I initially tried to apply these changes on the spree_core level but it
turns out to be really difficult because while both backend and frontend
use the same API in backend inventory units are created as soon as items
are included on the order. On the other hand in frontend inventory units
are only created when customers reaches the delivery step

I think it fixes the issue described in #3244, at least on the frontend component. I'm not sure where exactly I should add the code in the spree api component to fix it there as well but I can investigate it next.

Also I thought about redirecting users to the delivery step after running `create_proposed_shipments` so that we can be sure they would view the shipments updated. But I believe that could get pretty annoying and I think most users would still follow the usual checkout flow instead of going right back to payment or confirm checkout steps.

In case it looks right 2-0-stable needs this fix as well.
