### PR TITLE
admin shipping labels maps. fix spree/spree#3298

### DIFF
--- a/backend/app/views/spree/admin/shipping_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/_form.html.erb
@@ -30,8 +30,10 @@
       <legend align="center"><%= Spree.t(:categories) %></legend>
           <%= f.field_container :categories do %>
         <% Spree::ShippingCategory.all.each do |category| %>
-          <%= f.label :shipping_category_id, category.name %>
-          <%= check_box_tag('shipping_method[shipping_categories][]', category.id, @shipping_method.shipping_categories.include?(category)) %><br>
+          <%= label_tag do %>
+            <%= category.name %>
+            <%= check_box_tag('shipping_method[shipping_categories][]', category.id, @shipping_method.shipping_categories.include?(category)) %><br>
+          <% end %>
         <% end %>
         <%= error_message_on :shipping_method, :shipping_category_id %>
       <% end %>
@@ -43,8 +45,11 @@
       <legend align="center"><%= Spree.t(:zones) %></legend>
       <%= f.field_container :zones do %>
         <% Spree::Zone.all.each do |zone| %>
-          <%= f.label :zone_id, zone.name %>
-          <%= check_box_tag('shipping_method[zones][]', zone.id, @shipping_method.zones.include?(zone)) %><br>
+          <%= label_tag do %>
+            <%= zone.name %>
+            <%= check_box_tag('shipping_method[zones][]', zone.id, @shipping_method.zones.include?(zone)) %>
+          <% end %>
+          <br>
         <% end %>
         <%= error_message_on :shipping_method, :zone_id %>
       <% end %>


### PR DESCRIPTION
there is no need for mapping directly of label to
checkbox id, decided to nest checkboxes inside
the labels instead
