### PR TITLE
Require 'mail' gem in Spree::Core

### DIFF
--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -7,6 +7,7 @@ require 'awesome_nested_set'
 require 'acts_as_list'
 require 'active_merchant'
 require 'ransack'
+require 'mail'
 
 module Spree
 


### PR DESCRIPTION
I was getting exceptions, and requiring this gem fixed the exceptions.
