### PR TITLE
Remove .select(field) from permalinks.rb; 

### DIFF
--- a/core/lib/spree/core/permalinks.rb
+++ b/core/lib/spree/core/permalinks.rb
@@ -51,7 +51,7 @@ module Spree
 
           field = self.class.permalink_field
             # Do other links exist with this permalink?
-            other = self.class.select(field).where("#{self.class.table_name}.#{field} LIKE ?", "#{permalink_value}%")
+            other = self.class.where("#{self.class.table_name}.#{field} LIKE ?", "#{permalink_value}%")
             if other.any?
               # Find the existing permalink with the highest number, and increment that number.
               # (If none of the existing permalinks have a number, this will evaluate to 1.)


### PR DESCRIPTION
gloabalize3 modifies the statement for the models and causes blow up; the select statement restricts them unecessarily, causing the errors

https://github.com/spree/spree/issues/3329
