### PR TITLE
Bugfix/orphaned shipping rates

### DIFF
--- a/core/app/models/spree/ability.rb
+++ b/core/app/models/spree/ability.rb
@@ -41,10 +41,13 @@ module Spree
         can :create, Spree.user_class
         #############################
         can :read, Order do |order, token|
-          order.user == user || order.token && token == order.token
+          puts
+          puts "Checking order ability..."
+          puts
+          order.user == user || (order.token && token == order.token)
         end
         can :update, Order do |order, token|
-          order.user == user || order.token && token == order.token
+          order.user == user || (order.token && token == order.token)
         end
         can :create, Order
 

--- a/core/app/models/spree/ability.rb
+++ b/core/app/models/spree/ability.rb
@@ -41,13 +41,10 @@ module Spree
         can :create, Spree.user_class
         #############################
         can :read, Order do |order, token|
-          puts
-          puts "Checking order ability..."
-          puts
-          order.user == user || (order.token && token == order.token)
+          order.user == user || order.token && token == order.token
         end
         can :update, Order do |order, token|
-          order.user == user || (order.token && token == order.token)
+          order.user == user || order.token && token == order.token
         end
         can :create, Order
 

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -6,7 +6,7 @@ module Spree
     belongs_to :address, class_name: 'Spree::Address'
     belongs_to :stock_location, class_name: 'Spree::StockLocation'
 
-    has_many :shipping_rates
+    has_many :shipping_rates, dependent: :destroy
     has_many :shipping_methods, through: :shipping_rates
     has_many :state_changes, as: :stateful
     has_many :inventory_units, dependent: :destroy


### PR DESCRIPTION
Added dependent: :destroy to has_many :shipping_rates to prevent orphaned records when shipments are destroyed. (i.e. transitioning into delivery when shipments had already been created)
