### PR TITLE
Add default order to the variants_including_master product association

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -45,7 +45,8 @@ module Spree
 
     has_many :variants_including_master,
       class_name: 'Spree::Variant',
-      dependent: :destroy
+      dependent: :destroy,
+      order: "#{::Spree::Variant.quoted_table_name}.position ASC"
 
     has_many :prices, through: :variants, order: 'spree_variants.position, spree_variants.id, currency'
     has_many :stock_items, through: :variants

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -127,6 +127,21 @@ describe Spree::Product do
         product.variants_and_option_values.should == [low]
       end
     end
+
+    describe 'Variants sorting' do
+      context 'without master variant' do
+        it 'sorts variants by position' do
+          product.variants.to_sql.should match(/ORDER BY \"spree_variants\".position ASC/)
+        end
+      end
+
+      context 'with master variant' do
+        it 'sorts variants by position' do
+          product.variants_including_master.to_sql.should match(/ORDER BY \"spree_variants\".position ASC/)
+        end
+      end
+    end
+
   end
 
   context "permalink" do


### PR DESCRIPTION
We are using the spree api, and we noticed the product variants aren't sorted in the show action, the show view uses the variants_including_master association, this association wasn't sorted by position.
