### PR TITLE
Remove items with quantity 0 on cart page

### DIFF
--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -20,6 +20,7 @@ module Spree
       end
 
       if @order.update_attributes(params[:order])
+        @order.line_items = @order.line_items.select {|li| li.quantity > 0 }
         @order.create_proposed_shipments if @order.shipments.any?
         return if after_update_attributes
 

--- a/frontend/spec/controllers/spree/orders_controller_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_spec.rb
@@ -3,102 +3,121 @@ require 'spec_helper'
 describe Spree::OrdersController do
   let(:user) { create(:user) }
 
-  let(:order) do
-    mock_model(Spree::Order, :number => "R123",
-                             :reload => nil,
-                             :save! => true,
-                             :coupon_code => nil,
-                             :user => user,
-                             :completed? => false,
-                             :currency => "USD",
-                             :token => 'a1b2c3d4',
-                             :shipments => [])
-  end
-
-  before do
-    # Don't care about IP address being set here
-    order.stub(:last_ip_address=)
-    Spree::Order.stub(:find).with(1).and_return(order)
-    controller.stub(:try_spree_current_user => user)
-  end
-
-  context "#populate" do
-    before { Spree::Order.stub(:new).and_return(order) }
-
-    it "should create a new order when none specified" do
-      Spree::Order.should_receive(:new).and_return order
-      spree_post :populate, {}, {}
-      session[:order_id].should == order.id
+  context "Order model mock" do
+    let(:order) do
+      mock_model(Spree::Order, :number => "R123",
+                               :reload => nil,
+                               :save! => true,
+                               :coupon_code => nil,
+                               :user => user,
+                               :completed? => false,
+                               :currency => "USD",
+                               :token => 'a1b2c3d4',
+                               :shipments => [])
     end
 
-    context "with Variant" do
-      let(:populator) { double('OrderPopulator') }
-      before do
-        Spree::OrderPopulator.should_receive(:new).and_return(populator)
-      end
-
-      it "should handle single variant/quantity pair" do
-        populator.should_receive(:populate).with("variants" => { 1 => "2" }).and_return(true)
-        spree_post :populate, { :order_id => 1, :variants => { 1 => 2 } }
-        response.should redirect_to spree.cart_path
-      end
-
-      it "should handle multiple variant/quantity pairs with shared quantity" do
-        populator.should_receive(:populate).with("products" => { 1 => "2" }, "quantity" => "1").and_return(true)
-        spree_post :populate, { :order_id => 1, :products => { 1 => 2 }, :quantity => 1 }
-        response.should redirect_to spree.cart_path
-      end
-    end
-  end
-
-  context "#update" do
     before do
-      order.stub(:update_attributes).and_return true
-      order.stub(:line_items).and_return([])
-      order.stub(:line_items=).with([])
+      # Don't care about IP address being set here
       order.stub(:last_ip_address=)
-      Spree::Order.stub(:find_by_id_and_currency).and_return(order)
+      Spree::Order.stub(:find).with(1).and_return(order)
+      controller.stub(:try_spree_current_user => user)
     end
 
-    it "should not result in a flash success" do
-      spree_put :update, {}, {:order_id => 1}
-      flash[:success].should be_nil
+    context "#populate" do
+      before { Spree::Order.stub(:new).and_return(order) }
+
+      it "should create a new order when none specified" do
+        Spree::Order.should_receive(:new).and_return order
+        spree_post :populate, {}, {}
+        session[:order_id].should == order.id
+      end
+
+      context "with Variant" do
+        let(:populator) { double('OrderPopulator') }
+        before do
+          Spree::OrderPopulator.should_receive(:new).and_return(populator)
+        end
+
+        it "should handle single variant/quantity pair" do
+          populator.should_receive(:populate).with("variants" => { 1 => "2" }).and_return(true)
+          spree_post :populate, { :order_id => 1, :variants => { 1 => 2 } }
+          response.should redirect_to spree.cart_path
+        end
+
+        it "should handle multiple variant/quantity pairs with shared quantity" do
+          populator.should_receive(:populate).with("products" => { 1 => "2" }, "quantity" => "1").and_return(true)
+          spree_post :populate, { :order_id => 1, :products => { 1 => 2 }, :quantity => 1 }
+          response.should redirect_to spree.cart_path
+        end
+      end
     end
 
-    it "should render the edit view (on failure)" do
-      order.stub(:update_attributes).and_return false
-      order.stub(:errors).and_return({:number => "has some error"})
-      spree_put :update, {}, {:order_id => 1}
-      response.should render_template :edit
+    context "#update" do
+      before do
+        order.stub(:update_attributes).and_return true
+        order.stub(:line_items).and_return([])
+        order.stub(:line_items=).with([])
+        order.stub(:last_ip_address=)
+        Spree::Order.stub(:find_by_id_and_currency).and_return(order)
+      end
+
+      it "should not result in a flash success" do
+        spree_put :update, {}, {:order_id => 1}
+        flash[:success].should be_nil
+      end
+
+      it "should render the edit view (on failure)" do
+        order.stub(:update_attributes).and_return false
+        order.stub(:errors).and_return({:number => "has some error"})
+        spree_put :update, {}, {:order_id => 1}
+        response.should render_template :edit
+      end
+
+      it "should redirect to cart path (on success)" do
+        order.stub(:update_attributes).and_return true
+        spree_put :update, {}, {:order_id => 1}
+        response.should redirect_to(spree.cart_path)
+      end
     end
 
-    it "should redirect to cart path (on success)" do
-      order.stub(:update_attributes).and_return true
-      spree_put :update, {}, {:order_id => 1}
-      response.should redirect_to(spree.cart_path)
+    context "#empty" do
+      it "should destroy line items in the current order" do
+        controller.stub(:current_order).and_return(order)
+        order.should_receive(:empty!)
+        spree_put :empty
+        response.should redirect_to(spree.cart_path)
+      end
+    end
+
+    # Regression test for #2750
+    context "#update" do
+      before do
+        user.stub :last_incomplete_spree_order
+        controller.stub :set_current_order
+      end
+
+      it "cannot update a blank order" do
+        spree_put :update, :order => { :email => "foo" }
+        flash[:error].should == Spree.t(:order_not_found)
+        response.should redirect_to(spree.root_path)
+      end
     end
   end
 
-  context "#empty" do
-    it "should destroy line items in the current order" do
-      controller.stub(:current_order).and_return(order)
-      order.should_receive(:empty!)
-      spree_put :empty
-      response.should redirect_to(spree.cart_path)
-    end
-  end
+  context "line items quantity is 0" do
+    let(:order) { Spree::Order.create }
+    let(:variant) { create(:variant) }
+    let!(:line_item) { order.contents.add(variant, 1) }
 
-  # Regression test for #2750
-  context "#update" do
     before do
-      user.stub :last_incomplete_spree_order
-      controller.stub :set_current_order
+      controller.stub(:check_authorization)
+      controller.stub(:current_order => order)
     end
 
-    it "cannot update a blank order" do
-      spree_put :update, :order => { :email => "foo" }
-      flash[:error].should == Spree.t(:order_not_found)
-      response.should redirect_to(spree.root_path)
+    it "removes line items on update" do
+      expect(order.line_items.count).to eq 1
+      spree_put :update, :order => { line_items_attributes: { "0" => { id: line_item.id, quantity: 0 } } }
+      expect(order.reload.line_items.count).to eq 0
     end
   end
 end


### PR DESCRIPTION
Readd line removed in e07f4569f2dd63f411d81b6cf380140a73ac1de1 and add
spec to prove why it needs to be there for now

2-0-stable needs the fix as well. Currently the cart page display items with quantity 0 as they're not removed

ps. see the discussion in https://github.com/spree/spree/pull/3339#discussion_r5078990 for more details
