### PR TITLE
Generate sensibly lengthed SKUs

### DIFF
--- a/core/lib/spree/core/testing_support/factories/variant_factory.rb
+++ b/core/lib/spree/core/testing_support/factories/variant_factory.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :base_variant, :class => Spree::Variant do
     price 19.99
     cost_price 17.00
-    sku    { Faker::Lorem.sentence }
+    sku    { SecureRandom.hex }
     weight { BigDecimal.new("#{rand(200)}.#{rand(99)}") }
     height { BigDecimal.new("#{rand(200)}.#{rand(99)}") }
     width  { BigDecimal.new("#{rand(200)}.#{rand(99)}") }


### PR DESCRIPTION
IMHO it doesn't make sense to use a full sentence as a SKU. I think SecureRandom provides a better representation of a SKU. Also, I found that some third party libraries have a problem with the length of the SKU being generated by the sentence. This is obviously not Spree's problem, but I think this is a more sane default.
