### PR TITLE
Execute transition callbacks in promos

### DIFF
--- a/promo/app/controllers/spree/orders_controller_decorator.rb
+++ b/promo/app/controllers/spree/orders_controller_decorator.rb
@@ -15,6 +15,7 @@ Spree::OrdersController.class_eval do
       respond_with(@order) do |format|
         format.html do
           if params.has_key?(:checkout)
+            @order.next_transition.run_callbacks
             redirect_to checkout_state_path(@order.checkout_steps.first)
           else
             redirect_to cart_path


### PR DESCRIPTION
I noticed in the core copy of Spree::OrdersController#update we execute transition callbacks:
https://github.com/spree/spree/blob/1-3-stable/core/app/controllers/spree/orders_controller.rb#L29

But in the promo copy of Spree::OrdersController#update we do not:
https://github.com/spree/spree/blob/1-3-stable/promo/app/controllers/spree/orders_controller_decorator.rb#L18

This PR fixes that, although, I'm wondering why we define these methods twice at all?
