### PR TITLE
Normalize promo codes

### DIFF
--- a/promo/app/controllers/spree/store_controller_decorator.rb
+++ b/promo/app/controllers/spree/store_controller_decorator.rb
@@ -4,37 +4,37 @@ Spree::StoreController.class_eval do
     def apply_coupon_code
       if @order.coupon_code.present?
         # check if coupon code is already applied
-        if @order.adjustments.promotion.eligible.detect { |p| p.originator.promotion.code == @order.coupon_code }.present?
+        if @order.coupon_code_applied?
           flash[:notice] = t(:coupon_code_already_applied)
           true
         else
           event_name = "spree.checkout.coupon_code_added"
 
           # TODO should restrict to payload's event name?
-          promotion = Spree::Promotion.find_by_code(@order.coupon_code)
+          current_promotion = @order.find_promo_for_coupon_code
 
-          if promotion.present?
-            if promotion.expired?
+          if current_promotion.present?
+            if current_promotion.expired?
               flash[:error] = t(:coupon_code_expired)
               return false
             end
 
-            if promotion.usage_limit_exceeded?
+            if current_promotion.usage_limit_exceeded?
               flash[:error] = t(:coupon_code_max_usage)
               return false
             end
 
             previous_promo = @order.adjustments.promotion.eligible.first
-            promotion.activate(:order => @order, :coupon_code => @order.coupon_code)
-            promo = @order.adjustments.promotion.detect { |p| p.originator.promotion.code == @order.coupon_code }
+            current_promotion.activate(:order => @order, :coupon_code => @order.coupon_code)
+            promo_adjustment = @order.find_adjustment_for_coupon_code
 
-            if promo.present? and promo.eligible
+            if promo_adjustment.present? and promo_adjustment.eligible
               flash[:success] = t(:coupon_code_applied)
               true
-            elsif previous_promo.present? and promo.present?
+            elsif previous_promo.present? and promo_adjustment.present?
               flash[:error] = t(:coupon_code_better_exists)
               false
-            elsif promo.present?
+            elsif promo_adjustment.present?
               flash[:error] = t(:coupon_code_not_eligible)
               false
             else

--- a/promo/app/models/spree/order_decorator.rb
+++ b/promo/app/models/spree/order_decorator.rb
@@ -1,10 +1,7 @@
 Spree::Order.class_eval do
-  attr_accessible :coupon_code
-  attr_reader :coupon_code
 
-  def coupon_code=(code)
-    @coupon_code = code.strip.downcase rescue nil
-  end
+  attr_accessible :coupon_code
+  attr_accessor   :coupon_code
 
   # Tells us if there if the specified promotion is already associated with the order
   # regardless of whether or not its currently eligible.  Useful because generally
@@ -15,5 +12,25 @@ Spree::Order.class_eval do
 
   def promo_total
     adjustments.eligible.promotion.pluck(:amount).sum
+  end
+
+  def coupon_code_applied?
+    adjustments.promotion.eligible.detect do |p|
+      Spree::Promotion.normalize_coupon_code(p.originator.promotion.code) == normalized_coupon_code
+    end.present?
+  end
+
+  def find_adjustment_for_coupon_code
+    adjustments.promotion.detect do |p|
+      Spree::Promotion.normalize_coupon_code(p.originator.promotion.code) == normalized_coupon_code
+    end
+  end
+
+  def find_promo_for_coupon_code
+    Spree::Promotion.where("LOWER(code) = '#{normalized_coupon_code}'").first
+  end
+
+  def normalized_coupon_code
+    Spree::Promotion.normalize_coupon_code(coupon_code)
   end
 end

--- a/promo/app/models/spree/promotion.rb
+++ b/promo/app/models/spree/promotion.rb
@@ -45,8 +45,9 @@ module Spree
       return unless order_activatable? payload[:order]
 
       if code.present?
-        event_code = payload[:coupon_code]
-        return unless event_code == self.code
+        normalized_submitted_code = Spree::Promotion.normalize_coupon_code(payload[:coupon_code])
+        normalized_expected_code = Spree::Promotion.normalize_coupon_code(self.code)
+        return unless normalized_submitted_code == normalized_expected_code
       end
 
       if path.present?
@@ -102,8 +103,10 @@ module Spree
       credits.count
     end
 
-    def code=(coupon_code)
-      write_attribute(:code, (coupon_code.downcase.strip rescue nil))
+    private
+
+    def self.normalize_coupon_code(code)
+      code.to_s.strip.downcase rescue ""
     end
   end
 end

--- a/promo/config/locales/en.yml
+++ b/promo/config/locales/en.yml
@@ -16,12 +16,12 @@ en:
   add_rule_of_type: Add rule of type
   back_to_promotions_list: "Back To Promotions List"
   coupon: Coupon
-  coupon_code: Coupon code
+  coupon_code: Coupon code (NOT case sensitive)
   coupon_code_applied: The coupon code was successfully applied to your order.
   coupon_code_expired: The coupon code is expired
   coupon_code_already_applied: The coupon code has already been applied to this order
   coupon_code_better_exists: The previously applied coupon code results in a better deal
-  coupon_code_not_found: The coupon code you entered doesn't exist. Please try again.
+  coupon_code_not_found: The coupon code you entered doesn't exist. Please try again. Coupon codes are not case sensitive.
   coupon_code_max_usage: Coupon code usage limit exceeded
   coupon_code_not_eligible: This coupon code is not eligible for this order
   editing_promotion: Editing Promotion


### PR DESCRIPTION
Previously we were forcing the case of promo codes in a user-facing
way. For example, if you entered a capitalize promo code in checkout
it would be returned in lower case.

While this is helpful for making coupon codes case insensitive
it is confusing to users and administrators. This change normalizes
the coupon code only when it is evaulated for applicability.
