### PR TITLE
Edge for backend only install

### DIFF
--- a/core/lib/generators/spree/install/install_generator.rb
+++ b/core/lib/generators/spree/install/install_generator.rb
@@ -70,14 +70,19 @@ Disallow: /account
     def setup_assets
       @lib_name = 'spree'
       %w{javascripts stylesheets images}.each do |path|
-        empty_directory "app/assets/#{path}/store"
+        empty_directory "app/assets/#{path}/store" if defined? Spree::Frontend
         empty_directory "app/assets/#{path}/admin"
       end
 
-      template "app/assets/javascripts/store/all.js"
-      template "app/assets/javascripts/admin/all.js"
-      template "app/assets/stylesheets/store/all.css"
-      template "app/assets/stylesheets/admin/all.css"
+      if defined? Spree::Frontend
+        template "app/assets/javascripts/store/all.js"
+        template "app/assets/stylesheets/store/all.css"
+      end
+
+      if defined? Spree::Backend
+        template "app/assets/javascripts/admin/all.js"
+        template "app/assets/stylesheets/admin/all.css"
+      end
     end
 
     def create_overrides_directory

--- a/core/lib/spree/core/controller_helpers/auth.rb
+++ b/core/lib/spree/core/controller_helpers/auth.rb
@@ -27,8 +27,7 @@ module Spree
             redirect_to '/unauthorized'
           else
             store_location
-            url = spree.respond_to?(:login_path) ? spree.login_path : spree.root_path
-            redirect_to url
+            redirect_to respond_to?(:spree_login_path) ? spree_login_path : spree.root_path
           end
         end
 


### PR DESCRIPTION
Add a few tweaks to make it easier for users to run a backend only install. Maybe we could turn this https://gist.github.com/huoxito/5977700 into a small guide / tutorial on spree-guides?

This possibility of isolating breaking components and authentication into separate pieces is one of the things that amazes me most about Spree :beers:
