### PR TITLE
Fix for #3371 Manual order entry from admin interface does not work correctly when spree is not at root url

### DIFF
--- a/backend/app/assets/javascripts/admin/shipments.js.erb
+++ b/backend/app/assets/javascripts/admin/shipments.js.erb
@@ -7,7 +7,7 @@ $(document).ready(function() {
   $('[data-hook=admin_order_edit_form] a.ship').click(function(){
     var link = $(this);
     var shipment_number = link.data('shipment-number');
-    var url = Spree.url("/api/orders/" + order_number + "/shipments/" + shipment_number + "/ship.json");
+    var url = Spree.url( Spree.routes.orders_api + order_number + "/shipments/" + shipment_number + "/ship.json");
     $.ajax({
       type: "PUT",
       url: url
@@ -28,7 +28,7 @@ $(document).ready(function() {
     var shipment_number = link.data('shipment-number');
     var selected_shipping_rate_id = link.parents('tbody').find("select#selected_shipping_rate_id[data-shipment-number='" + shipment_number + "']").val();
     var unlock = link.parents('tbody').find("input[name='open_adjustment'][data-shipment-number='" + shipment_number + "']:checked").val();
-    var url = Spree.url("/api/orders/" + order_number + "/shipments/" + shipment_number + ".json");
+    var url = Spree.url( Spree.routes.orders_api + order_number + "/shipments/" + shipment_number + ".json");
 
     $.ajax({
       type: "PUT",
@@ -50,7 +50,7 @@ $(document).ready(function() {
     var link = $(this);
     var shipment_number = link.data('shipment-number');
     var tracking = link.parents('tbody').find('input#tracking').val();
-    var url = Spree.url("/api/orders/" + order_number + "/shipments/" + shipment_number + ".json");
+    var url = Spree.url( Spree.routes.orders_api + order_number + "/shipments/" + shipment_number + ".json");
 
     $.ajax({
       type: "PUT",

--- a/backend/app/assets/javascripts/admin/variant_autocomplete.js.erb
+++ b/backend/app/assets/javascripts/admin/variant_autocomplete.js.erb
@@ -70,7 +70,7 @@ adjustItems = function(shipment_number, variant_id, quantity){
     var shipment = _.findWhere(shipments, {number: shipment_number + ''});
     var inventory_units = _.where(shipment.inventory_units, {variant_id: variant_id});
 
-    var url = "/api/orders/" + order_number + "/shipments/" + shipment_number;
+    var url = Spree.routes.orders_api + order_number + "/shipments/" + shipment_number;
 
     var new_quantity = 0;
     if(inventory_units.length<quantity){
@@ -178,7 +178,7 @@ completeItemSplit = function(event) {
     $.ajax({
       type: "PUT",
       async: false,
-      url: Spree.url("/api/orders/" + order_number + "/shipments/" + original_shipment_number + "/remove.json"),
+      url: Spree.url(Spree.routes.orders_api + order_number + "/shipments/" + original_shipment_number + "/remove.json"),
       data: { variant_id: variant_id, quantity: quantity }
     }).done(function(msg) {
       window.location.reload();
@@ -188,14 +188,14 @@ completeItemSplit = function(event) {
       $.ajax({
         type: "POST",
         async: false,
-        url: Spree.url("/api/orders/" + order_number + "/shipments.json"),
+        url: Spree.url(Spree.routes.orders_api + order_number + "/shipments.json"),
         data: { variant_id: variant_id, quantity: quantity, stock_location_id: stock_location_id }
       });
     } else {
       $.ajax({
         type: "PUT",
         async: false,
-        url: Spree.url("/api/orders/" + order_number + "/shipments/" + target_shipment_number + "/add.json"),
+        url: Spree.url(Spree.routes.orders_api + order_number + "/shipments/" + target_shipment_number + "/add.json"),
         data: { variant_id: variant_id, quantity: quantity }
       });
     }
@@ -226,7 +226,7 @@ addVariantFromStockLocation = function() {
   if(shipment==undefined){
     $.ajax({
       type: "POST",
-      url: Spree.url("/api/orders/" + order_number + "/shipments.json"),
+      url: Spree.url(Spree.routes.orders_api + order_number + "/shipments.json"),
       data: { variant_id: variant_id, quantity: quantity, stock_location_id: stock_location_id }
     }).done(function( msg ) {
       window.location.reload();

--- a/backend/app/views/spree/admin/shared/_routes.html.erb
+++ b/backend/app/views/spree/admin/shared/_routes.html.erb
@@ -5,4 +5,6 @@
   Spree.routes.user_search = "<%= spree.admin_search_users_url(:format => 'json') %>";
   Spree.routes.product_search = "<%= spree.api_products_url(:format => 'json') %>";
   Spree.routes.option_type_search = "<%= spree.api_option_types_url(:format => 'json') %>";
+  Spree.routes.orders_api = "<%= spree.api_orders_url(:format => 'json') %>";
+
 </script>


### PR DESCRIPTION
Fix for #3371 - Manual order entry from admin interface does not work correctly when spree is not at root url

Use spree.api_orders_url to determine the orders api url rather than hard coding it. 
