### PR TITLE
Edge recreate shipments on api component

### DIFF
--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -53,6 +53,7 @@ module Spree
         if @order.update_attributes(order_params)
           @order.update_line_items(line_items)
           @order.line_items.reload
+
           @order.update!
           respond_with(@order, :default_template => :show)
         else

--- a/api/app/models/spree/order_decorator.rb
+++ b/api/app/models/spree/order_decorator.rb
@@ -105,5 +105,6 @@ Spree::Order.class_eval do
     line_item_params.each do |id, attributes|
       self.line_items.find(id).update_attributes!(attributes)
     end
+    self.ensure_updated_shipments
   end
 end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -512,6 +512,10 @@ module Spree
       shipments
     end
 
+    def ensure_updated_shipments
+      self.create_proposed_shipments if self.shipments.any?
+    end
+
     private
 
       def link_by_email

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -177,7 +177,7 @@ describe Spree::Order do
     end
 
     it "should send an order confirmation email" do
-      mail_message = mock "Mail::Message"
+      mail_message = double("Mail::Message")
       Spree::OrderMailer.should_receive(:confirm_email).with(order.id).and_return mail_message
       mail_message.should_receive :deliver
       order.finalize!
@@ -515,6 +515,15 @@ describe Spree::Order do
     end
   end
 
+  context "ensure updated shipments" do
+    before { order.stub(shipments: [double("Shipment")]) }
+
+    it "recreate shipments if order has any" do
+      expect(order).to receive(:create_proposed_shipments)
+      order.ensure_updated_shipments
+    end
+  end
+
   context "add_update_hook" do
     before do
       Spree::Order.class_eval do
@@ -539,4 +548,3 @@ describe Spree::Order do
     end
   end
 end
-

--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -21,7 +21,7 @@ module Spree
 
       if @order.update_attributes(params[:order])
         @order.line_items = @order.line_items.select {|li| li.quantity > 0 }
-        @order.create_proposed_shipments if @order.shipments.any?
+        @order.ensure_updated_shipments
         return if after_update_attributes
 
         fire_event('spree.order.contents_changed')
@@ -51,7 +51,7 @@ module Spree
     def populate
       populator = Spree::OrderPopulator.new(current_order(true), current_currency)
       if populator.populate(params.slice(:products, :variants, :quantity))
-        current_order.create_proposed_shipments if current_order.shipments.any?
+        current_order.ensure_updated_shipments
 
         fire_event('spree.cart.add')
         fire_event('spree.order.contents_changed')

--- a/frontend/spec/controllers/spree/orders_controller_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_spec.rb
@@ -13,7 +13,7 @@ describe Spree::OrdersController do
                                :completed? => false,
                                :currency => "USD",
                                :token => 'a1b2c3d4',
-                               :shipments => [])
+                               :ensure_updated_shipments => [])
     end
 
     before do


### PR DESCRIPTION
Same as #3244 for api component. This should be easy to reproduce using spree-marionette. Once order hits delivery step shipments are never rebuild when they should. Then the inventory units created don't reflect the line items on the order.

I've added a method to Order model to abstract it a little bit, ci says all green
