### PR TITLE
fixed strong parameters for removing from cart

### DIFF
--- a/core/lib/spree/core/controller_helpers/strong_parameters.rb
+++ b/core/lib/spree/core/controller_helpers/strong_parameters.rb
@@ -3,7 +3,7 @@ module Spree
     module ControllerHelpers
       module StrongParameters
         def permitted_order_attributes
-          [:line_items_attributes, :coupon_code]
+          [:coupon_code, :line_items_attributes => [:quantity, :id]]
         end
 
         def permitted_address_attributes

--- a/frontend/spec/requests/cart_spec.rb
+++ b/frontend/spec/requests/cart_spec.rb
@@ -43,6 +43,8 @@ describe "Cart" do
       click_link "delete_line_item_1"
     end
     page.should_not have_content("Line items quantity must be an integer")
+    page.should_not have_content("RoR Mug")
+    page.should have_content("Your cart is empty")
   end
 
   # regression for #2276


### PR DESCRIPTION
Without specifying `line_items_attributes` keys in strong parameters removing wouldn't work.
