### PR TITLE
set ActiveRecord::Base.include_root_in_json = false on core install

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Spree 2.1.0 (unreleased) ##
 
+*   Set ActiveRecord::Base.include_root_in_json = false during install.
+    Originally set to false back in 2011 according to convention. After
+    https://groups.google.com/forum/#!topic/spree-user/D9dZQayC4z, it
+    was changed.
+
+    *Weston Platter*
+    
 *   Change `order.promotion_credit_exists?` api. Now it receives an adjustment
     originator (PromotionAction instance) instead of a promotion. Allowing
     multiple adjustments being created for the same promotion as the current

--- a/core/lib/generators/spree/install/install_generator.rb
+++ b/core/lib/generators/spree/install/install_generator.rb
@@ -100,7 +100,7 @@ Disallow: /account
     end
       APP
 
-      append_file "config/environment.rb", "\nActiveRecord::Base.include_root_in_json = true\n"
+      append_file "config/environment.rb", "\nActiveRecord::Base.include_root_in_json = false\n"
     end
 
     def include_seed_data


### PR DESCRIPTION
11 Backend tests failed when I ran tests locally (Capybara could not find stuff in the DOM). Happy to investigate issues if CI confirms they're real. :)
