### PR TITLE
Admin table CSS fix

### DIFF
--- a/backend/app/assets/stylesheets/admin/shared/_tables.scss
+++ b/backend/app/assets/stylesheets/admin/shared/_tables.scss
@@ -126,6 +126,7 @@ table {
 
   tbody {
     tr {
+      &:first-child th,
       &:first-child td {
         border-top: 1px solid $color-border;
       }


### PR DESCRIPTION
Fixes admin tables that have a `<th>` tag in the `<tbody>` so that they have a top border:

**Before**

![iika](https://f.cloud.github.com/assets/4784/814855/badadb70-ef1d-11e2-9f15-8a283de0fb1d.png)

**After**

![b2jx](https://f.cloud.github.com/assets/4784/814857/c51bcfe0-ef1d-11e2-9fd4-e7bdf186f16a.png)
