### PR TITLE
Font awesome compile fix

### DIFF
--- a/backend/vendor/assets/stylesheets/font-awesome.css.erb
+++ b/backend/vendor/assets/stylesheets/font-awesome.css.erb
@@ -29,7 +29,7 @@
   font-style: normal;
 }
 
-* FONT AWESOME CORE
+/* FONT AWESOME CORE
  * -------------------------- */
 [class^="icon-"],
 [class*=" icon-"] {


### PR DESCRIPTION
Asset compilation was failing due to the missing `/`

This fixes https://github.com/spree/spree/issues/3370
