### PR TITLE
Remove useless modules from core spec_helper

### DIFF
--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -116,7 +116,7 @@ describe Spree::BaseHelper do
     end
 
     def link_to_tracking_html(options = {})
-      node = link_to_tracking(stub(:shipment, options))
+      node = link_to_tracking(double(:shipment, options))
       Nokogiri::HTML(node.to_s)
     end
   end

--- a/core/spec/helpers/order_helper_spec.rb
+++ b/core/spec/helpers/order_helper_spec.rb
@@ -4,7 +4,7 @@ module Spree
   describe Spree::OrdersHelper do
     # Regression test for #2518 + #2323
     it "truncates HTML correctly in product description" do
-      product = stub(:description => "<strong>" + ("a" * 95) + "</strong> This content is invisible.")
+      product = double(:description => "<strong>" + ("a" * 95) + "</strong> This content is invisible.")
       expected = "<strong>" + ("a" * 95) + "</strong>..."
       truncated_product_description(product).should == expected
     end

--- a/core/spec/lib/search/base_spec.rb
+++ b/core/spec/lib/search/base_spec.rb
@@ -53,7 +53,7 @@ describe Spree::Core::Search::Base do
   end
 
   it "accepts a current user" do
-    user = stub
+    user = double
     searcher = Spree::Core::Search::Base.new({})
     searcher.current_user = user
     searcher.current_user.should eql(user)

--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -27,13 +27,7 @@ end
 
 require 'spree/testing_support/factories'
 require 'spree/testing_support/preferences'
-
-require 'spree/testing_support/controller_requests'
-require 'spree/testing_support/authorization_helpers'
-require 'spree/testing_support/flash'
-require 'spree/testing_support/url_helpers'
 require 'spree/testing_support/capybara_ext'
-
 require 'paperclip/matchers'
 
 RSpec.configure do |config|
@@ -62,12 +56,7 @@ RSpec.configure do |config|
   end
 
   config.include FactoryGirl::Syntax::Methods
-
   config.include Spree::TestingSupport::Preferences
-  config.include Spree::TestingSupport::UrlHelpers
-  config.include Spree::TestingSupport::ControllerRequests
-  config.include Spree::TestingSupport::Flash
-
   config.include Paperclip::Shoulda::Matchers
 
   config.fail_fast = ENV['FAIL_FAST'] || false


### PR DESCRIPTION
just noticed it while working on other stuff
