### PR TITLE
Add capybara-accessible for accessibility errors in CI

### DIFF
--- a/frontend/app/views/spree/shared/_search.html.erb
+++ b/frontend/app/views/spree/shared/_search.html.erb
@@ -3,7 +3,7 @@
   <%= select_tag :taxon,
         options_for_select([[Spree.t(:all_departments), '']] +
                               @taxons.map {|t| [t.name, t.id]},
-                            @taxon ? @taxon.id : params[:taxon]) %>
+                              @taxon ? @taxon.id : params[:taxon]), 'aria-label' => 'Taxon' %>
   <%= search_field_tag :keywords, params[:keywords], :placeholder => Spree.t(:search) %>
   <%= submit_tag Spree.t(:search), :name => nil %>
 <% end %>

--- a/frontend/spec/features/address_spec.rb
+++ b/frontend/spec/features/address_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Address" do
+describe "Address", inaccessible: true do
   let!(:product) { create(:product, :name => "RoR Mug") }
   let!(:order) { create(:order_with_totals, :state => 'cart') }
 

--- a/frontend/spec/features/cart_spec.rb
+++ b/frontend/spec/features/cart_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Cart" do
+describe "Cart", inaccessible: true do
   it "shows cart icon on non-cart pages" do
     visit spree.root_path
     page.should have_selector("li#link-to-cart a", :visible => true)
@@ -52,7 +52,7 @@ describe "Cart" do
 
     before { variant.option_values.destroy_all }
 
-    it "still adds product to cart" do
+    it "still adds product to cart", inaccessible: true do
       visit spree.product_path(product)
       click_button "add-to-cart-button"
 

--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Checkout" do
+describe "Checkout", inaccessible: true do
 
   let!(:country) { create(:country, :states_required => true) }
   let!(:state) { create(:state, :country => country) }
@@ -22,7 +22,7 @@ describe "Checkout" do
         click_button "Checkout"
       end
 
-      it "should default checkbox to checked" do
+      it "should default checkbox to checked", inaccessible: true do
         find('input#order_use_billing').should be_checked
       end
 
@@ -83,7 +83,7 @@ describe "Checkout" do
       Spree::CheckoutController.any_instance.stub(:skip_state_validation? => true)
     end
 
-    it "redirects to payment page" do
+    it "redirects to payment page", inaccessible: true do
       visit spree.checkout_state_path(:delivery)
       click_button "Save and Continue"
       choose "Credit Card"

--- a/frontend/spec/features/checkout_unshippable_spec.rb
+++ b/frontend/spec/features/checkout_unshippable_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "checkout with unshippable items" do
+describe "checkout with unshippable items", inaccessible: true do
   let!(:stock_location) { create(:stock_location) }
   let(:order) { OrderWalkthrough.up_to(:address) }
 

--- a/frontend/spec/features/currency_spec.rb
+++ b/frontend/spec/features/currency_spec.rb
@@ -6,7 +6,7 @@ describe "Switching currencies in backend" do
   end
 
   # Regression test for #2340
-  it "does not cause current_order to become nil" do
+  it "does not cause current_order to become nil", inaccessible: true do
     visit spree.root_path
     click_link "RoR Mug"
     click_button "Add To Cart"

--- a/frontend/spec/features/products_spec.rb
+++ b/frontend/spec/features/products_spec.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 require 'spec_helper'
 
-describe "Visiting Products" do
+describe "Visiting Products", inaccessible: true do
   include_context "custom products"
 
   before(:each) do

--- a/frontend/spec/features/taxons_spec.rb
+++ b/frontend/spec/features/taxons_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "viewing products" do
+describe "viewing products", inaccessible: true do
   let!(:taxonomy) { create(:taxonomy, :name => "Category") }
   let!(:super_clothing) { taxonomy.root.children.create(:name => "Super Clothing") }
   let!(:t_shirts) { super_clothing.children.create(:name => "T-Shirts") }

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -39,6 +39,12 @@ require 'spree/testing_support/order_walkthrough'
 
 require 'paperclip/matchers'
 
+require 'capybara/accessible'
+
+if ENV['WEBDRIVER'] == 'accessible'
+  Capybara.javascript_driver = :accessible
+end
+
 RSpec.configure do |config|
   config.color = true
   config.mock_with :rspec
@@ -50,6 +56,10 @@ RSpec.configure do |config|
   # examples within a transaction, comment the following line or assign false
   # instead of true.
   config.use_transactional_fixtures = false
+
+  config.around(:each, :inaccessible => true) do |example|
+    Capybara::Accessible.skip_audit { example.run }
+  end
 
   config.before(:each) do
     WebMock.disable!

--- a/frontend/spree_frontend.gemspec
+++ b/frontend/spree_frontend.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'stringex', '~> 1.5.1'
 
   s.add_development_dependency 'email_spec', '~> 1.2.1'
+  s.add_development_dependency 'capybara-accessible'
 end


### PR DESCRIPTION
[capybara-accessible](https://github.com/casecommons/capybara-accessible) applies javascript accessibility assertions to pages when they load, using Google's [Accessibility Developer Tools](https://github.com/GoogleChrome/accessibility-developer-tools) tests. That way, accessibility errors in markup will trigger errors in CI.

We've fixed one of the layout errors and marked the other failing tests as inaccessible, until they can be addressed.

[Closes #3374]
