### PR TITLE
extract searcher_class instantiation into a ContollerHelper module

### DIFF
--- a/core/app/controllers/spree/base_controller.rb
+++ b/core/app/controllers/spree/base_controller.rb
@@ -5,6 +5,7 @@ class Spree::BaseController < ApplicationController
   include Spree::Core::ControllerHelpers::RespondWith
   include Spree::Core::ControllerHelpers::SSL
   include Spree::Core::ControllerHelpers::Common
+  include Spree::Core::ControllerHelpers::Search
 
   respond_to :html
 end

--- a/core/lib/spree/core/controller_helpers/search.rb
+++ b/core/lib/spree/core/controller_helpers/search.rb
@@ -1,0 +1,14 @@
+module Spree
+  module Core
+    module ControllerHelpers
+      module Search
+        def build_searcher params
+          Spree::Config.searcher_class.new(params).tap do |searcher|
+            searcher.current_user = try_spree_current_user
+            searcher.current_currency = current_currency
+          end
+        end
+      end
+    end
+  end
+end

--- a/frontend/app/controllers/spree/home_controller.rb
+++ b/frontend/app/controllers/spree/home_controller.rb
@@ -4,9 +4,7 @@ module Spree
     respond_to :html
 
     def index
-      @searcher = Spree::Config.searcher_class.new(params)
-      @searcher.current_user = try_spree_current_user
-      @searcher.current_currency = current_currency
+      @searcher = build_searcher(params)
       @products = @searcher.retrieve_products
     end
   end

--- a/frontend/app/controllers/spree/products_controller.rb
+++ b/frontend/app/controllers/spree/products_controller.rb
@@ -7,9 +7,7 @@ module Spree
     respond_to :html
 
     def index
-      @searcher = Config.searcher_class.new(params)
-      @searcher.current_user = try_spree_current_user
-      @searcher.current_currency = current_currency
+      @searcher = build_searcher(params)
       @products = @searcher.retrieve_products
     end
 

--- a/frontend/app/controllers/spree/taxons_controller.rb
+++ b/frontend/app/controllers/spree/taxons_controller.rb
@@ -9,9 +9,7 @@ module Spree
       @taxon = Taxon.find_by_permalink!(params[:id])
       return unless @taxon
 
-      @searcher = Spree::Config.searcher_class.new(params.merge(:taxon => @taxon.id))
-      @searcher.current_user = try_spree_current_user
-      @searcher.current_currency = current_currency
+      @searcher = build_searcher(params.merge(:taxon => @taxon.id))
       @products = @searcher.retrieve_products
     end
 


### PR DESCRIPTION
searcher_class was being instantiated in the same way in home_controller, products_controller, and taxons_controller. This moves that code into a new `Spree::Core::ControllerHelpers::Search` module.

I needed to modify the params used when creating `@searcher` in these 4 classes to add a value saved in the session. It would have been nice to just override once method. Added bonus of cleaning up the common code in these 3 controllers.
