### PR TITLE
adding order association with shipping_method.

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -42,6 +42,8 @@ module Spree
     has_many :line_items, dependent: :destroy, order: "#{Spree::LineItem.table_name}.created_at ASC"
     has_many :payments, dependent: :destroy, :class_name => "Spree::Payment"
 
+    belongs_to :shipping_method
+    
     has_many :shipments, dependent: :destroy do
       def states
         pluck(:state).uniq


### PR DESCRIPTION
I am facing error for paypal express undefined method or variable shipping_method for Spree::Order, so I just check it there is missing association with order and shipping method
