### PR TITLE
Calulator changes

### DIFF
--- a/core/app/models/spree/calculator.rb
+++ b/core/app/models/spree/calculator.rb
@@ -21,7 +21,7 @@ module Spree
 
     # Returns all calculators applicable for kind of work
     def self.calculators
-      Rails.application.config.spree.calculators.all
+      Rails.application.config.spree.calculators
     end
 
     def to_s

--- a/core/app/models/spree/calculator.rb
+++ b/core/app/models/spree/calculator.rb
@@ -3,7 +3,6 @@ module Spree
     belongs_to :calculable, polymorphic: true
 
     # This method must be overriden in concrete calculator.
-    #
     # It should return amount computed based on #calculable and/or optional parameter
     def compute(something = nil)
       raise NotImplementedError, 'please use concrete calculator'

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -42,6 +42,8 @@ module Spree
     has_many :line_items, dependent: :destroy, order: "#{Spree::LineItem.table_name}.created_at ASC"
     has_many :payments, dependent: :destroy, :class_name => "Spree::Payment"
 
+    belongs_to :shipping_method
+    
     has_many :shipments, dependent: :destroy do
       def states
         pluck(:state).uniq


### PR DESCRIPTION
I just trying to see all calculators from console but for this method I get the following error, so I just make change in Calculator Model and again check it works which result is at last..

1.9.3p125 :102 > Spree::Calculator.calculators
NoMethodError: undefined method `all' for #<Spree::Core::Environment::Calculators:0x007fe71453ce30>
    from /Users/lebin/.rvm/gems/ruby-1.9.3-p125/bundler/gems/spree-9e4cfd575319/core/app/models/spree/calculator.rb:24:in`calculators'
    from (irb):102
    from /Users/lebin/.rvm/gems/ruby-1.9.3-p125/gems/railties-3.2.13/lib/rails/commands/console.rb:47:in `start'
    from /Users/lebin/.rvm/gems/ruby-1.9.3-p125/gems/railties-3.2.13/lib/rails/commands/console.rb:8:in`start'
    from /Users/lebin/.rvm/gems/ruby-1.9.3-p125/gems/railties-3.2.13/lib/rails/commands.rb:41:in `<top (required)>'
    from script/rails:6:in`require'
    from script/rails:6:in `<main>'
1.9.3p125 :103 > 

After making changes in def self.calculators method result is .. 

1.9.3p125 :106 > Spree::Calculator.calculators
 => #<Spree::Core::Environment::Calculators:0x007fe71453ce30 @shipping_methods=[Spree::Calculator::Shipping::FlatPercentItemTotal(id: integer, type: string, calculable_id: integer, calculable_type: string, created_at: datetime, updated_at: datetime), Spree::Calculator::Shipping::FlatRate(id: integer, type: string, calculable_id: integer, calculable_type: string, created_at: datetime, updated_at: datetime), Spree::Calculator::Shipping::FlexiRate(id: integer, type: string, calculable_id: integer, calculable_type: string, created_at: datetime, updated_at: datetime), Spree::Calculator::Shipping::PerItem(id: integer, type: string, calculable_id: integer, calculable_type: string, created_at: datetime, updated_at: datetime), Spree::Calculator::Shipping::PriceSack(id: integer, type: string, calculable_id: integer, calculable_type: string, created_at: datetime, updated_at: datetime)], @tax_rates=[Spree::Calculator::DefaultTax(id: integer, type: string, calculable_id: integer, calculable_type: string, created_at: datetime, updated_at: datetime)], @promotion_actions_create_adjustments=[Spree::Calculator::FlatPercentItemTotal(id: integer, type: string, calculable_id: integer, calculable_type: string, created_at: datetime, updated_at: datetime), Spree::Calculator::FlatRate(id: integer, type: string, calculable_id: integer, calculable_type: string, created_at: datetime, updated_at: datetime), Spree::Calculator::FlexiRate(id: integer, type: string, calculable_id: integer, calculable_type: string, created_at: datetime, updated_at: datetime), Spree::Calculator::PerItem(id: integer, type: string, calculable_id: integer, calculable_type: string, created_at: datetime, updated_at: datetime), Spree::Calculator::PercentPerItem(id: integer, type: string, calculable_id: integer, calculable_type: string, created_at: datetime, updated_at: datetime), Spree::Calculator::FreeShipping(id: integer, type: string, calculable_id: integer, calculable_type: string, created_at: datetime, updated_at: datetime)]> 
1.9.3p125 :107 > 
