### PR TITLE
Add #total_on_hand method to Variant model

### DIFF
--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -135,6 +135,10 @@ module Spree
       Spree::Stock::Quantifier.new(self).can_supply?(quantity)
     end
 
+    def total_on_hand
+      Spree::Stock::Quantifier.new(self).total_on_hand
+    end
+
     # Product may be created with deleted_at already set,
     # which would make AR's default finder return nil.
     # This is a stopgap for that little problem.

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -332,4 +332,16 @@ describe Spree::Variant do
       end
     end
   end
+
+  describe '#total_on_hand' do
+    it 'should be infinite if track_inventory_levels is false' do
+      Spree::Config[:track_inventory_levels] = false
+      build(:variant).total_on_hand.should eql(Float::INFINITY)
+    end
+
+    it 'should match quantifier total_on_hand' do
+      variant = build(:variant)
+      expect(variant.total_on_hand).to eq(Spree::Stock::Quantifier.new(variant).total_on_hand)
+    end
+  end
 end


### PR DESCRIPTION
We already have that for Product, but there's no way of getting the total_on_hand for a given variant. This commit fixes that.

cc @radar
