### PR TITLE
Make zones more robust by allowing types with 2 words (i.e. zip code).

### DIFF
--- a/backend/app/views/spree/admin/zones/_member_type.html.erb
+++ b/backend/app/views/spree/admin/zones/_member_type.html.erb
@@ -5,15 +5,15 @@
   <fieldset class="no-border-bottom">
     <legend align="center"><%= Spree.t(type) %></legend>
 
-    <ul id="ul-nested-<%= type %>" class="member-list fields">
-      <% members_of_type = zone_form.object.zone_members.select { |member| member.zoneable_type && member.zoneable_type == "Spree::#{type.capitalize}" } %>
+    <ul id="ul-nested-<%= type.dasherize %>" class="member-list fields">
+      <% members_of_type = zone_form.object.zone_members.select { |member| member.zoneable_type && member.zoneable_type == "Spree::#{type.camelize}" } %>
       <%= zone_form.fields_for :zone_members, members_of_type do |member_form| %>
         <%= render :partial => "#{type}_member", :locals => { :f => member_form } %>
       <% end %>
     </ul>
 
     <div data-hook="buttons" class="field align-center">
-      <%= button_link_to Spree.t("add_#{type}"), "##{type}_member", { :icon => 'icon-plus', :id => "nested-#{type}" } %>
+      <%= button_link_to Spree.t("add_#{type}"), "##{type}_member", { :icon => 'icon-plus', :id => "nested-#{type.dasherize}" } %>
     </div>
   </fieldset>
 </div>

--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -18,7 +18,7 @@ module Spree
 
     def kind
       if members.any? && !members.any? { |member| member.try(:zoneable_type).nil? }
-        members.last.zoneable_type.demodulize.downcase
+        members.last.zoneable_type.demodulize.underscore
       end
     end
 


### PR DESCRIPTION
I'm updating the zip code zones extension for spree >= 2.0 and ran into issues. This will allow for 2 name zoneable types.
