### PR TITLE
Do not check stock quantity twice when saving line item

### DIFF
--- a/core/app/models/spree/order_populator.rb
+++ b/core/app/models/spree/order_populator.rb
@@ -46,21 +46,11 @@ module Spree
 
       variant = Spree::Variant.find(variant_id)
       if quantity > 0
-        if check_stock_levels(variant, quantity)
-          @order.contents.add(variant, quantity, currency)
+        line_item = @order.contents.add(variant, quantity, currency)
+        unless line_item.valid?
+          errors.add(:base, line_item.errors.messages.values.join(" "))
+          return false
         end
-      end
-    end
-
-    def check_stock_levels(variant, quantity)
-      if Stock::Quantifier.new(variant).can_supply? quantity
-        true
-      else
-        display_name = %Q{#{variant.name}}
-        display_name += %Q{ (#{variant.options_text})} unless variant.options_text.blank?
-
-        errors.add(:base, Spree.t(:out_of_stock, :scope => :order_populator, :item => display_name.inspect))
-        return false
       end
     end
   end

--- a/core/app/models/spree/stock/availability_validator.rb
+++ b/core/app/models/spree/stock/availability_validator.rb
@@ -1,14 +1,16 @@
 module Spree
   module Stock
     class AvailabilityValidator < ActiveModel::Validator
-
       def validate(line_item)
         quantifier = Stock::Quantifier.new(line_item.variant_id)
 
         unless quantifier.can_supply? line_item.quantity
-          line_item.errors[:quantity] << I18n.t('validation.exceeds_available_stock')
-        end
+          variant = line_item.variant
+          display_name = %Q{#{variant.name}}
+          display_name += %Q{ (#{variant.options_text})} unless variant.options_text.blank?
 
+          line_item.errors[:quantity] << Spree.t(:out_of_stock, :scope => :order_populator, :item => display_name.inspect)
+        end
       end
     end
   end

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -60,4 +60,3 @@ describe Spree::LineItem do
     end
   end
 end
-

--- a/core/spec/models/spree/stock/availability_validator_spec.rb
+++ b/core/spec/models/spree/stock/availability_validator_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module Spree
   module Stock
     describe AvailabilityValidator do
-      let!(:line_item) { double(quantity: 5, variant_id: 1, errors: double('errors')) }
+      let!(:line_item) { double(quantity: 5, variant_id: 1, variant: double.as_null_object, errors: double('errors')) }
 
       subject { described_class.new(nil) }
 
@@ -18,8 +18,6 @@ module Spree
         line_item.errors.should_receive(:[]).with(:quantity).and_return []
         subject.validate(line_item)
       end
-
-
     end
   end
 end


### PR DESCRIPTION
Every time an user pressed the add to cart button spree was checking
stock in OrderPopulator and before saving the line item, through
Stock::AvailabilityValidator. I believe we only need to check stock on
the LineItem model
