### PR TITLE
Fix update of the thumbnails when selecting a variant

### DIFF
--- a/frontend/app/assets/javascripts/store/product.js.coffee
+++ b/frontend/app/assets/javascripts/store/product.js.coffee
@@ -18,7 +18,7 @@ Spree.addImageHandlers = ->
 
 Spree.showVariantImages = (variantId) ->
   ($ 'li.vtmb').hide()
-  ($ 'li.vtmb-' + variantId).show()
+  ($ '#tmb-' + variantId).show()
   currentThumb = ($ '#' + ($ '#main-image').data('selectedThumbId'))
   if not currentThumb.hasClass('vtmb-' + variantId)
     thumb = ($ ($ 'ul.thumbnails li:visible.vtmb').eq(0))

--- a/frontend/app/views/spree/products/_thumbnails.html.erb
+++ b/frontend/app/views/spree/products/_thumbnails.html.erb
@@ -10,7 +10,7 @@
     <% if @product.has_variants? %>
       <% @product.variant_images.each do |i| %>
         <% next if @product.images.include?(i) %>
-        <li class='vtmb' id='tmb-<%= i.id %>'>
+        <li class='vtmb' id='tmb-<%= i.viewable.id %>'>
           <%= link_to(image_tag(i.attachment.url(:mini)), i.attachment.url(:product)) %>
         </li>
       <% end %>


### PR DESCRIPTION
Hi,

in the rails4 branch I've found a problem where the thumbnails/product image was not updated when clicking on the variant.

I found it was due to two problems:
- the variantId received by the showVariantImages didn't match the attributes of the thumbnail.
- in the javascript, the thumbnail to display was selected using its class attribute, but in the markup the id attribute is the one to include the ID of the variant.
