### PR TITLE
Fix update of the thumbnails when selecting a variant

### DIFF
--- a/frontend/app/views/spree/products/_thumbnails.html.erb
+++ b/frontend/app/views/spree/products/_thumbnails.html.erb
@@ -10,7 +10,7 @@
     <% if @product.has_variants? %>
       <% @product.variant_images.each do |i| %>
         <% next if @product.images.include?(i) %>
-        <li class='vtmb' id='tmb-<%= i.id %>'>
+        <li class='vtmb vtmb-<%= i.viewable.id %>' id='tmb-<%= i.id %>'>
           <%= link_to(image_tag(i.attachment.url(:mini)), i.attachment.url(:product)) %>
         </li>
       <% end %>


### PR DESCRIPTION
Hi (and sorry for the duplicate PR),

in the rails4 branch I've found a problem where the thumbnails/product image was not updated when clicking on the variant.

The variantId received by the showVariantImages didn't match the attributes of the thumbnail, which didn't have the .vtmb-<variant id> class anymore.
