### PR TITLE
Fixed bad style escaping

### DIFF
--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -76,7 +76,7 @@
     </thead>
     <tbody>
       <% @collection.each do |product| %>
-          <tr <%= "style='color: red;'" if product.deleted? %> id="<%= spree_dom_id product %>" data-hook="admin_products_index_rows" class="<%= cycle('odd', 'even') %>">
+          <tr <%== "style='color: red;'" if product.deleted? %> id="<%= spree_dom_id product %>" data-hook="admin_products_index_rows" class="<%= cycle('odd', 'even') %>">
             <td class="align-center"><%= product.sku rescue '' %></td>
             <td class="align-center"><%= mini_image(product) %></td>
             <td><%= link_to product.try(:name), edit_admin_product_path(product) %></td>


### PR DESCRIPTION
Output was being escaped to produce:

```
<tr style=&#x27;color: red;&#x27;>
```
