### PR TITLE
Skip stock status when track_inventory_levels false

### DIFF
--- a/core/app/models/spree/stock/packer.rb
+++ b/core/app/models/spree/stock/packer.rb
@@ -16,11 +16,15 @@ module Spree
       def default_package
         package = Package.new(stock_location, order)
         order.line_items.each do |line_item|
-          next unless stock_location.stock_item(line_item.variant)
+          if Config.track_inventory_levels
+            next unless stock_location.stock_item(line_item.variant)
 
-          on_hand, backordered = stock_location.fill_status(line_item.variant, line_item.quantity)
-          package.add line_item.variant, on_hand, :on_hand if on_hand > 0
-          package.add line_item.variant, backordered, :backordered if backordered > 0
+            on_hand, backordered = stock_location.fill_status(line_item.variant, line_item.quantity)
+            package.add line_item.variant, on_hand, :on_hand if on_hand > 0
+            package.add line_item.variant, backordered, :backordered if backordered > 0
+          else
+            package.add line_item.variant, line_item.quantity, :on_hand
+          end
         end
         package
       end

--- a/core/spec/models/spree/stock/packer_spec.rb
+++ b/core/spec/models/spree/stock/packer_spec.rb
@@ -39,6 +39,22 @@ module Spree
             packer.default_package.contents.should be_empty
           end
         end
+
+        context "doesn't track inventory levels" do
+          let(:order) { Order.create }
+          let!(:line_item) { order.contents.add(create(:variant), 30) }
+
+          before { Config.track_inventory_levels = false }
+
+          it "doesn't bother stock items status in stock location" do
+            expect(subject.stock_location).not_to receive(:fill_status)
+            subject.default_package
+          end
+
+          it "still creates package with proper quantity" do
+            expect(subject.default_package.quantity).to eql 30
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
No need to check stock status for any item on the order if the store
doesn't care about inventory levels. Noticed after reading #3438

CI says all green :+1: 2-0-stable needs the fix as well
