### PR TITLE
Always create assets in test env `rake test_app`

### DIFF
--- a/core/lib/generators/spree/install/install_generator.rb
+++ b/core/lib/generators/spree/install/install_generator.rb
@@ -70,16 +70,16 @@ Disallow: /account
     def setup_assets
       @lib_name = 'spree'
       %w{javascripts stylesheets images}.each do |path|
-        empty_directory "app/assets/#{path}/store" if defined? Spree::Frontend
-        empty_directory "app/assets/#{path}/admin"
+        empty_directory "app/assets/#{path}/store" if defined? Spree::Frontend || Rails.env.test?
+        empty_directory "app/assets/#{path}/admin" if defined? Spree::Backend || Rails.env.test?
       end
 
-      if defined? Spree::Frontend
+      if defined? Spree::Frontend || Rails.env.test?
         template "app/assets/javascripts/store/all.js"
         template "app/assets/stylesheets/store/all.css"
       end
 
-      if defined? Spree::Backend
+      if defined? Spree::Backend || Rails.env.test?
         template "app/assets/javascripts/admin/all.js"
         template "app/assets/stylesheets/admin/all.css"
       end


### PR DESCRIPTION
Build in extensions broke because Spree::Frontend and Spree::Backend are
not defined when running `rake test_app` within extension gem context
