### PR TITLE
Remove append_view_path from api ControllerSetup

### DIFF
--- a/api/lib/spree/api/controller_setup.rb
+++ b/api/lib/spree/api/controller_setup.rb
@@ -21,9 +21,6 @@ module Spree
           include CanCan::ControllerAdditions
           include Spree::Core::ControllerHelpers::Auth
 
-          prepend_view_path Rails.root + "app/views"
-          append_view_path File.expand_path("../../../app/views", File.dirname(__FILE__))
-
           self.responder = Spree::Api::Responders::AppResponder
           respond_to :json
         end


### PR DESCRIPTION
That line was preventing us from overriding templates within other
application or extensions

Noticed it while trying to override an api rabl template from within another gem/extension. Also I'm still able to override templates from within the rails application removing these lines.

It would be great to have a spec to cover this but I'm not sure how we can do that. Any ideas? In case I didn't miss anything we need to apply it to 2-0-stable, 1-3-stable and 1-2-stable as well. Please let me know if yo want me to submit a PR for each branch
