### PR TITLE
Add validation of shipping_category_id to Product. Fixes #3188

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Spree 2.1.0 (unreleased) ##
 
+* The Products API endpoint now returns an additional key called `shipping_category_id`, and also requires `shipping_category_id` on create.
+
+    *Jeff Dutil*
+
 * The Products API endpoint now returns an additional key called `display_price`, which is the proper rendering of the price of a product.
 
     *Ryan Bigg*

--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -12,7 +12,7 @@ module Spree
       end
 
       def product_attributes
-        [:id, :name, :description, :price, :display_price, :available_on, :permalink, :meta_description, :meta_keywords, :taxon_ids]
+        [:id, :name, :description, :price, :display_price, :available_on, :permalink, :meta_description, :meta_keywords, :shipping_category_id, :taxon_ids]
       end
 
       def product_property_attributes

--- a/api/spec/controllers/spree/api/products_controller_spec.rb
+++ b/api/spec/controllers/spree/api/products_controller_spec.rb
@@ -7,7 +7,7 @@ module Spree
 
     let!(:product) { create(:product) }
     let!(:inactive_product) { create(:product, :available_on => Time.now.tomorrow, :name => "inactive") }
-    let(:attributes) { [:id, :name, :description, :price, :display_price, :available_on, :permalink, :meta_description, :meta_keywords, :taxon_ids] }
+    let(:attributes) { [:id, :name, :description, :price, :display_price, :available_on, :permalink, :meta_description, :meta_keywords, :shipping_category_id, :taxon_ids] }
 
     before do
       stub_authentication!
@@ -137,6 +137,7 @@ module Spree
         required_attributes = json_response["required_attributes"]
         required_attributes.should include("name")
         required_attributes.should include("price")
+        required_attributes.should include("shipping_category_id")
       end
 
       it_behaves_like "modifying product actions are restricted"
@@ -172,7 +173,8 @@ module Spree
 
       it "can create a new product" do
         api_post :create, :product => { :name => "The Other Product",
-                                        :price => 19.99 }
+                                        :price => 19.99,
+                                        :shipping_category_id => create(:shipping_category).id }
         json_response.should have_attributes(attributes)
         response.status.should == 201
       end
@@ -189,7 +191,8 @@ module Spree
 
         it "can still create a product" do
           api_post :create, :product => { :name => "The Other Product",
-                                          :price => 19.99 },
+                                          :price => 19.99,
+                                          :shipping_category_id => create(:shipping_category).id },
                             :token => "fake"
           json_response.should have_attributes(attributes)
           response.status.should == 201
@@ -202,7 +205,7 @@ module Spree
         json_response["error"].should == "Invalid resource. Please fix errors and try again."
         errors = json_response["errors"]
         errors.delete("permalink") # Don't care about this one.
-        errors.keys.should =~ ["name", "price"]
+        errors.keys.should =~ ["name", "price", "shipping_category_id"]
       end
 
       it "can update a product" do

--- a/backend/app/views/spree/admin/products/new.html.erb
+++ b/backend/app/views/spree/admin/products/new.html.erb
@@ -49,6 +49,16 @@
 
     </div>
 
+    <div class='row'>
+      <div class="alpha four columns">
+        <%= f.field_container :shipping_category do %>
+          <%= f.label :shipping_category_id, Spree.t(:shipping_categories) %><span class="required">*</span><br />
+          <%= f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2 fullwidth' }) %>
+          <%= f.error_message_on :shipping_category_id %>
+        <% end %>
+      </div>
+    </div>
+
     <div class="clearfix" data-hook="product-from-prototype" id="product-from-prototype">
       <%= render :file => 'spree/admin/prototypes/show' if @prototype %>
     </div>

--- a/backend/spec/features/admin/orders/shipments_spec.rb
+++ b/backend/spec/features/admin/orders/shipments_spec.rb
@@ -41,14 +41,13 @@ describe "Shipments" do
       targetted_select2 'LA', from: '#s2id_item_stock_location'
       click_icon :ok
       wait_for_ajax
-      sleep(1)
-      page.should have_selector("#shipment_#{order.shipments.last.id}")
+      page.should have_selector("#shipment_#{order.shipments.first.id}")
 
       within_row(2) { click_icon 'resize-horizontal' }
       targetted_select2 "LA(#{order.reload.shipments.last.number})", from: '#s2id_item_stock_location'
       click_icon :ok
       wait_for_ajax
-      page.should have_selector("#shipment_#{order.shipments.last.id}")
+      page.should have_selector("#shipment_#{order.reload.shipments.last.id}")
     end
   end
 end

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -2,6 +2,7 @@
 require 'spec_helper'
 
 describe "Products" do
+
   stub_authorization!
 
   context "as admin user" do
@@ -140,6 +141,7 @@ describe "Products" do
       before(:each) do
         @option_type_prototype = prototype
         @property_prototype = create(:prototype, :name => "Random")
+        @shipping_category = create(:shipping_category)
         click_link "Products"
         click_link "admin_new_product"
         within('#new_product') do
@@ -154,6 +156,7 @@ describe "Products" do
         fill_in "product_available_on", :with => "2012/01/24"
         select "Size", :from => "Prototype"
         check "Large"
+        select @shipping_category.name, from: "product_shipping_category_id"
         click_button "Create"
         page.should have_content("successfully created!")
         Spree::Product.last.variants.length.should == 1
@@ -180,6 +183,7 @@ describe "Products" do
 
     context "creating a new product" do
       before(:each) do
+        @shipping_category = create(:shipping_category)
         click_link "Products"
         click_link "admin_new_product"
         within('#new_product') do
@@ -192,6 +196,7 @@ describe "Products" do
         fill_in "product_sku", :with => "B100"
         fill_in "product_price", :with => "100"
         fill_in "product_available_on", :with => "2012/01/24"
+        select @shipping_category.name, from: "product_shipping_category_id"
         click_button "Create"
         page.should have_content("successfully created!")
         click_button "Update"
@@ -207,6 +212,7 @@ describe "Products" do
       it "can set the count on hand to a null value", :js => true do
         fill_in "product_name", :with => "Baseball Cap"
         fill_in "product_price", :with => "100"
+        select @shipping_category.name, from: "product_shipping_category_id"
         click_button "Create"
         page.should have_content("successfully created!")
         click_button "Update"
@@ -274,10 +280,10 @@ describe "Products" do
 
         within(:css, "#prototypes tr#row_1") do
           click_link 'Select'
+          wait_for_ajax
         end
 
         page.all('tr.product_property').size > 1
-
         within(:css, "tr.product_property:first-child") do
           first('input[type=text]')[:value].should eq('baseball_cap_color')
         end

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Spree 2.1.0 (unreleased) ##
 
+* Product requires `shipping_category_id` on create #3188.
+
+    *Jeff Dutil*
+
 *   No longer set ActiveRecord::Base.include_root_in_json = true during install.
     Originally set to false back in 2011 according to convention. After
     https://groups.google.com/forum/#!topic/spree-user/D9dZQayC4z, it

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -66,16 +66,35 @@ module Spree
 
     accepts_nested_attributes_for :variants, allow_destroy: true
 
-    validates :name, :permalink, presence: true
+    validates :name, presence: true
+    validates :permalink, presence: true
     validates :price, presence: true, if: proc { Spree::Config[:require_master_price] }
+    validates :shipping_category_id, presence: true
 
     attr_accessor :option_values_hash
 
-    attr_accessible :name, :description, :available_on, :permalink, :meta_description,
-                    :meta_keywords, :price, :sku, :deleted_at, :prototype_id,
-                    :option_values_hash, :weight, :height, :width, :depth,
-                    :shipping_category_id, :tax_category_id, :product_properties_attributes,
-                    :variants_attributes, :taxon_ids, :option_type_ids, :cost_currency
+    attr_accessible :available_on,
+                    :cost_currency,
+                    :deleted_at,
+                    :depth,
+                    :description,
+                    :height,
+                    :meta_description,
+                    :meta_keywords,
+                    :name,
+                    :option_type_ids,
+                    :option_values_hash,
+                    :permalink,
+                    :price,
+                    :product_properties_attributes,
+                    :prototype_id,
+                    :shipping_category_id,
+                    :sku,
+                    :tax_category_id,
+                    :taxon_ids,
+                    :weight,
+                    :width,
+                    :variants_attributes
 
     attr_accessible :cost_price if Variant.table_exists? && Variant.column_names.include?('cost_price')
 

--- a/core/lib/spree/testing_support/factories/product_factory.rb
+++ b/core/lib/spree/testing_support/factories/product_factory.rb
@@ -7,34 +7,24 @@ FactoryGirl.define do
     sku 'ABC'
     available_on { 1.year.ago }
     deleted_at nil
+    shipping_category { |r| Spree::ShippingCategory.first || r.association(:shipping_category) }
 
     # ensure stock item will be created for this products master
     before(:create) { create(:stock_location) if Spree::StockLocation.count == 0 }
 
+    factory :custom_product do
+      name 'Custom Product'
+      price 17.99
+
+      tax_category { |r| Spree::TaxCategory.first || r.association(:tax_category) }
+    end
+
     factory :product do
       tax_category { |r| Spree::TaxCategory.first || r.association(:tax_category) }
-      shipping_category { |r| Spree::ShippingCategory.first || r.association(:shipping_category) }
 
       factory :product_with_option_types do
         after(:create) { |product| create(:product_option_type, product: product) }
       end
     end
-  end
-
-  factory :custom_product, class: Spree::Product do
-    name 'Custom Product'
-    description { generate(:random_description) }
-    price 17.99
-    sku 'ABC'
-    available_on { 1.year.ago }
-    deleted_at nil
-
-    tax_category { |r| Spree::TaxCategory.first || r.association(:tax_category) }
-    shipping_category { |r| Spree::ShippingCategory.first || r.association(:shipping_category) }
-
-    # association :taxons
-
-    # ensure stock item will be created for this products master
-    before(:create) { create(:stock_location) if Spree::StockLocation.count == 0 }
   end
 end

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -177,7 +177,7 @@ describe Spree::CreditCard do
 
   context "#associations" do
     it "should be able to access its payments" do
-      expect { credit_card.payments.all }.not_to raise_error(ActiveRecord::StatementInvalid)
+      expect { credit_card.payments.all }.not_to raise_error
     end
   end
   

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -444,7 +444,7 @@ describe Spree::Payment do
       end
 
       specify do
-        expect { payment.process! }.not_to raise_error(Spree::Core::GatewayError)
+        expect { payment.process! }.not_to raise_error
       end
     end
   end

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -232,7 +232,7 @@ describe Spree::Product do
 
   context '#create' do
     let!(:prototype) { create(:prototype) }
-    let!(:product) { Spree::Product.new(:name => "Foo", :price => 1.99) }
+    let!(:product) { Spree::Product.new(name: "Foo", price: 1.99, shipping_category_id: create(:shipping_category).id) }
 
     before { product.prototype_id = prototype.id }
 

--- a/frontend/spec/support/shared_contexts/custom_products.rb
+++ b/frontend/spec/support/shared_contexts/custom_products.rb
@@ -23,5 +23,3 @@ shared_context "custom products" do
     FactoryGirl.create(:custom_product, :name => 'Apache Baseball Jersey', :price => '19.99', :taxons => [apache_taxon, clothing_taxon])
   end
 end
-
-


### PR DESCRIPTION
Not sure if we want to include this on 2-0-stable or not as it's an api change.

The issues this resolves are marked for 2.0.4 milestone though:
https://github.com/spree/spree/issues/3188
https://github.com/spree/spree/issues/3347

Also need to update guides, which I started although not sure if other pages need updates:
https://github.com/spree/spree-guides/pull/147
