### PR TITLE
Added :user at :tab was missing in I18N

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -302,6 +302,7 @@ en:
         reports: "Reports"
         configuration: "Configuration"
         promotions: "Promotions"
+        users: "Users"
     administration: Administration
     agree_to_privacy_policy: Agree to Privacy Policy
     agree_to_terms_of_service: Agree to Terms of Service


### PR DESCRIPTION
Added key to enable translation of the users link in the main menu of the admin panel
