### PR TITLE
index spree_orders#completed_at

### DIFF
--- a/core/db/migrate/20130729214043_index_completed_at_on_spree_orders.rb
+++ b/core/db/migrate/20130729214043_index_completed_at_on_spree_orders.rb
@@ -1,0 +1,5 @@
+class IndexCompletedAtOnSpreeOrders < ActiveRecord::Migration
+  def change
+    add_index :spree_orders, :completed_at
+  end
+end


### PR DESCRIPTION
An index on this column is probably a good idea. First, the `Order.complete` and `Order.incomplete` scopes query on this column. Also, by default in the admin orders index the orders are both filtered and sorted by this column.
