### PR TITLE
fixes Spree::CreditCard.expiry_not_in_the_past to not run validation if year or month are empty

### DIFF
--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -105,7 +105,7 @@ module Spree
     private
 
     def expiry_not_in_the_past
-      if year && month
+      if year.present? && month.present?
         time = "#{year}-#{month}-1".to_time
         if time < Time.zone.now.beginning_of_month
           errors.add(:base, :card_expired)

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -104,6 +104,13 @@ describe Spree::CreditCard do
       credit_card.should_not be_valid
       credit_card.errors[:card].should be_blank
     end
+    
+    it "does not run expiration in the past validation if year and month are empty" do
+      credit_card.year = ""
+      credit_card.month = ""
+      credit_card.should_not be_valid
+      credit_card.errors[:card].should be_blank
+    end 
 
     it "should only validate on create" do
       credit_card.attributes = valid_credit_card_attributes


### PR DESCRIPTION
adds spec to demonstrate that Spree::CreditCard.expriy_not_in_the_past is incorrect.  fixes validation bug inside Spree::CreditCard.expiry_not_in_the_past. #3454
