### PR TITLE
Fix `load_sample`

### DIFF
--- a/core/lib/spree/testing_support/common_rake.rb
+++ b/core/lib/spree/testing_support/common_rake.rb
@@ -32,4 +32,17 @@ namespace :common do
       puts 'Skipping installation no generator to run...'
     end
   end
+
+  task :seed do |t, args|
+    puts "Seeding ..."
+    cmd = "bundle exec rake db:seed RAILS_ENV=test"
+
+    if RUBY_PLATFORM =~ /mswin/ #windows
+      cmd += " >nul"
+    else
+      cmd += " >/dev/null"
+    end
+
+    system(cmd)
+  end
 end

--- a/sample/Rakefile
+++ b/sample/Rakefile
@@ -20,5 +20,5 @@ desc "Generates a dummy app for testing"
 task :test_app do
   ENV['LIB_NAME'] = 'spree/core'
   Rake::Task['common:test_app'].invoke
+  Rake::Task['common:seed'].invoke
 end
-

--- a/sample/db/samples/products.rb
+++ b/sample/db/samples/products.rb
@@ -1,6 +1,8 @@
 Spree::Sample.load_sample("tax_categories")
+Spree::Sample.load_sample("shipping_categories")
 
 clothing = Spree::TaxCategory.find_by_name!("Clothing")
+shipping_category = Spree::ShippingCategory.find_by_name!("Default Shipping")
 
 default_attrs = {
   :description => Faker::Lorem.paragraph,
@@ -11,30 +13,35 @@ products = [
   {
     :name => "Ruby on Rails Tote",
     :tax_category => clothing,
+    :shipping_category => shipping_category,
     :price => 15.99,
     :eur_price => 14,
   },
   {
     :name => "Ruby on Rails Bag",
     :tax_category => clothing,
+    :shipping_category => shipping_category,
     :price => 22.99,
     :eur_price => 19,
   },
   {
     :name => "Ruby on Rails Baseball Jersey",
     :tax_category => clothing,
+    :shipping_category => shipping_category,
     :price => 19.99,
     :eur_price => 16
   },
   {
     :name => "Ruby on Rails Jr. Spaghetti",
     :tax_category => clothing,
+    :shipping_category => shipping_category,
     :price => 19.99,
     :eur_price => 16
 
   },
   {
     :name => "Ruby on Rails Ringer T-Shirt",
+    :shipping_category => shipping_category,
     :tax_category => clothing,
     :price => 19.99,
     :eur_price => 16
@@ -42,62 +49,73 @@ products = [
   {
     :name => "Ruby Baseball Jersey",
     :tax_category => clothing,
+    :shipping_category => shipping_category,
     :price => 19.99,
     :eur_price => 16
   },
   {
     :name => "Apache Baseball Jersey",
     :tax_category => clothing,
+    :shipping_category => shipping_category,
     :price => 19.99,
     :eur_price => 16
   },
   {
     :name => "Spree Baseball Jersey",
     :tax_category => clothing,
+    :shipping_category => shipping_category,
     :price => 19.99,
     :eur_price => 16
   },
   {
     :name => "Spree Jr. Spaghetti",
     :tax_category => clothing,
+    :shipping_category => shipping_category,
     :price => 19.99,
     :eur_price => 16
   },
   {
     :name => "Spree Ringer T-Shirt",
     :tax_category => clothing,
+    :shipping_category => shipping_category,
     :price => 19.99,
     :eur_price => 16
   },
   {
     :name => "Spree Tote",
     :tax_category => clothing,
+    :shipping_category => shipping_category,
     :price => 15.99,
     :eur_price => 14,
   },
   {
     :name => "Spree Bag",
     :tax_category => clothing,
+    :shipping_category => shipping_category,
     :price => 22.99,
     :eur_price => 19
   },
   {
     :name => "Ruby on Rails Mug",
+    :shipping_category => shipping_category,
     :price => 13.99,
     :eur_price => 12
   },
   {
     :name => "Ruby on Rails Stein",
+    :shipping_category => shipping_category,
     :price => 16.99,
     :eur_price => 14
   },
   {
     :name => "Spree Stein",
+    :shipping_category => shipping_category,
     :price => 16.99,
     :eur_price => 14,
   },
   {
     :name => "Spree Mug",
+    :shipping_category => shipping_category,
     :price => 13.99,
     :eur_price => 12
   }

--- a/sample/spec/lib/load_sample_spec.rb
+++ b/sample/spec/lib/load_sample_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe "Load samples" do
+  it "doesn't raise any error" do
+    expect {
+      SpreeSample::Engine.load_samples
+    }.to_not raise_error
+  end
+end

--- a/sample/spec/spec_helper.rb
+++ b/sample/spec/spec_helper.rb
@@ -1,0 +1,19 @@
+# This file is copied to ~/spec when you run 'ruby script/generate rspec'
+# from the project root directory.
+ENV["RAILS_ENV"] ||= 'test'
+require File.expand_path("../dummy/config/environment", __FILE__)
+require 'rspec/rails'
+require 'ffaker'
+
+RSpec.configure do |config|
+  config.color = true
+  config.mock_with :rspec
+
+  # If you're not using ActiveRecord, or you'd prefer not to run each of your
+  # examples within a transaction, comment the following line or assign false
+  # instead of true.
+  config.use_transactional_fixtures = true
+
+  config.include FactoryGirl::Syntax::Methods
+  config.fail_fast = ENV['FAIL_FAST'] || false
+end


### PR DESCRIPTION
Broke after 7a5e43662c57807dafaebf8160069e4de8f1c855 which requires
product to have a shipping category

I'm trying to come up with some spec to test both `load_sample` and the spree install command.
