### PR TITLE
cancan: Hide unauthorized links in admin

### DIFF
--- a/backend/app/views/spree/admin/orders/edit.html.erb
+++ b/backend/app/views/spree/admin/orders/edit.html.erb
@@ -1,8 +1,14 @@
 <%= csrf_meta_tags %>
 <% content_for :page_actions do %>
-  <li><%= event_links %></li>
-  <li><%= button_link_to Spree.t(:resend), resend_admin_order_url(@order), :method => :post, :icon => 'icon-email' %></li>
-  <li><%= button_link_to Spree.t(:back_to_orders_list), admin_orders_path, :icon => 'icon-arrow-left' %></li>
+  <% if can?(:fire, @order) %>
+    <li><%= event_links %></li>
+  <% end %>
+  <% if can?(:resend, @order) %>
+    <li><%= button_link_to Spree.t(:resend), resend_admin_order_url(@order), :method => :post, :icon => 'icon-email' %></li>
+  <% end %>
+  <% if can?(:admin, Spree::Order) %>
+    <li><%= button_link_to Spree.t(:back_to_orders_list), admin_orders_path, :icon => 'icon-arrow-left' %></li>
+  <% end %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Order Details' } %>
@@ -11,7 +17,7 @@
   <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @order } %>
 </div>
 
-<%= render :partial => 'add_product' %>
+<%= render :partial => 'add_product' if can?(:update, @order) %>
 
 <% if @order.line_items.empty? %>
   <div class="no-objects-found">

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -6,7 +6,7 @@
   <li>
     <%= button_link_to Spree.t(:new_order), new_admin_order_url, :icon => 'icon-plus', :id => 'admin_new_order' %>
   </li>
-<% end %>
+<% end if can? :edit, Spree::Order.new %>
 
 <% content_for :table_filter_title do %>
   <%= Spree.t(:search) %>

--- a/backend/app/views/spree/admin/products/edit.html.erb
+++ b/backend/app/views/spree/admin/products/edit.html.erb
@@ -1,8 +1,10 @@
 <% content_for :page_actions do %>
   <li><%= button_link_to Spree.t(:back_to_products_list), session[:return_to] || admin_products_url, :icon => 'icon-arrow-left' %></li>
-  <li id="new_product_link">
-    <%= button_link_to Spree.t(:new_product), new_object_url, { :icon => 'icon-plus', :id => 'admin_new_product' } %>
-  </li>
+  <% if can?(:create, Spree::Product) %>
+    <li id="new_product_link">
+      <%= button_link_to Spree.t(:new_product), new_object_url, { :icon => 'icon-plus', :id => 'admin_new_product' } %>
+    </li>
+  <% end %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/product_sub_menu' %>

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -6,7 +6,7 @@
   <li id="new_product_link">
     <%= button_link_to Spree.t(:new_product), new_object_url, { :remote => true, :icon => 'icon-plus', :id => 'admin_new_product' } %>
   </li>
-<% end %>
+<% end if can?(:create, Spree::Product) %>
 
 <%= render :partial => 'spree/admin/shared/product_sub_menu' %>
 
@@ -82,11 +82,11 @@
             <td><%= link_to product.try(:name), edit_admin_product_path(product) %></td>
             <td class="align-center"><%= product.display_price.to_html rescue '' %></td>
             <td class="actions" data-hook="admin_products_index_row_actions">
-              <%= link_to_edit product, :no_text => true, :class => 'edit' unless product.deleted? %>
+              <%= link_to_edit product, :no_text => true, :class => 'edit' if can?(:edit, product) && !product.deleted? %>
               &nbsp;
-              <%= link_to_clone product, :no_text => true, :class => 'clone' %>
+              <%= link_to_clone product, :no_text => true, :class => 'clone' if can?(:clone, product) %>
               &nbsp;
-              <%= link_to_delete product, :no_text => true unless product.deleted? %>
+              <%= link_to_delete product, :no_text => true if can?(:delete, product) && !product.deleted? %>
             </td>
           </tr>
       <% end %>

--- a/backend/app/views/spree/admin/shared/_product_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_product_tabs.html.erb
@@ -9,20 +9,21 @@
 <% content_for :sidebar do %>
   <nav class="menu">
     <ul data-hook="admin_product_tabs">
-      <li<%== ' class="active"' if current == 'Product Details' %>>
+      <%= content_tag :li, :class => ('active' if current == 'Product Details') do %>
         <%= link_to_with_icon 'icon-edit', Spree.t(:product_details), edit_admin_product_url(@product) %>
-      </li>
-      <li<%== ' class="active"' if current == 'Images' %>>
+      <% end if can?(:admin, Spree::Product) %>
+      <%= content_tag :li, :class => ('active' if current == 'Images') do %>
         <%= link_to_with_icon 'icon-picture', Spree.t(:images), admin_product_images_url(@product) %>
-      </li>
-      <li<%== ' class="active"' if current == 'Variants' %>>
+      <% end if can?(:admin, Spree::Image) %>
+      <%= content_tag :li, :class => ('active' if current == 'Variants') do %>
         <%= link_to_with_icon 'icon-th-large', Spree.t(:variants),  admin_product_variants_url(@product) %>
-      </li>
-      <li<%== ' class="active"' if current == 'Product Properties' %>>
+      <% end if can?(:admin, Spree::Variant) %>
+      <%= content_tag :li, :class => ('active' if current == 'Product Properties') do %>
         <%= link_to_with_icon 'icon-tasks', Spree.t(:product_properties), admin_product_product_properties_url(@product) %>
-      </li>
-      <li<%== ' class="active"' if current == 'Stock Management' %>>
+      <% end if can?(:admin, Spree::ProductProperty) %>
+      <%= content_tag :li, :class => ('active' if current == 'Stock Management') do %>
         <%= link_to_with_icon 'icon-tasks', Spree.t(:stock_management), stock_admin_product_url(@product) %>
+      <% end if can?(:stock, Spree::Product) %>
       </li>
     </ul>
   </nav>

--- a/backend/spec/features/admin/homepage_spec.rb
+++ b/backend/spec/features/admin/homepage_spec.rb
@@ -59,7 +59,9 @@ describe "Homepage" do
   end
 
   context 'as fakedispatch user' do
-    stub_bar_authorization!
+    custom_authorization! do |user|
+      can [:admin, :edit, :index, :read], Spree::Order
+    end
 
     it 'should only display tabs fakedispatch has access to' do
       visit spree.admin_path

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -176,6 +176,32 @@ describe "Order Details", js: true do
     end
   end
 
+  context 'with only read permissions' do
+    custom_authorization! do |user|
+      can [:admin, :index, :read, :edit], Spree::Order
+    end
+    it "should not display forbidden links" do
+      visit spree.edit_admin_order_path(order)
+      page.should_not have_button('cancel')
+      page.should_not have_button('Resend')
+
+      # Order Tabs
+      page.should_not have_link('Order Details')
+      page.should_not have_link('Customer Details')
+      page.should_not have_link('Adjustments')
+      page.should_not have_link('Payments')
+      page.should_not have_link('Return Authorizations')
+
+      # Order item actions
+      page.should_not have_css('.delete-item')
+      page.should_not have_css('.split-item')
+      page.should_not have_css('.edit-item')
+      page.should_not have_css('.edit-tracking')
+
+      page.should_not have_css('#add-line-item')
+    end
+  end
+
   context 'as Fakedispatch' do
     custom_authorization! do |user|
       # allow dispatch to :admin, :index, and :edit on Spree::Order

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -177,7 +177,12 @@ describe "Order Details", js: true do
   end
 
   context 'as Fakedispatch' do
-    stub_bar_authorization!
+    custom_authorization! do |user|
+      # allow dispatch to :admin, :index, and :edit on Spree::Order
+      can [:admin, :edit, :index, :read], Spree::Order
+      # allow dispatch to :index, :show, :create and :update shipments on the admin
+      can [:admin, :manage, :read, :ship], Spree::Shipment
+    end
 
     it 'should not display order tabs or edit buttons without ability' do
       visit spree.edit_admin_order_path(order)

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -2,10 +2,9 @@
 require 'spec_helper'
 
 describe "Products" do
-
-  stub_authorization!
-
   context "as admin user" do
+    stub_authorization!
+
     before(:each) do
       visit spree.admin_path
     end
@@ -145,7 +144,7 @@ describe "Products" do
         click_link "Products"
         click_link "admin_new_product"
         within('#new_product') do
-         page.should have_content("SKU")
+          page.should have_content("SKU")
         end
       end
 
@@ -187,7 +186,7 @@ describe "Products" do
         click_link "Products"
         click_link "admin_new_product"
         within('#new_product') do
-         page.should have_content("SKU")
+          page.should have_content("SKU")
         end
       end
 
@@ -260,8 +259,8 @@ describe "Products" do
       end
 
       before(:each) do
-         @option_type_prototype = prototype
-         @property_prototype = create(:prototype, :name => "Random")
+        @option_type_prototype = prototype
+        @property_prototype = create(:prototype, :name => "Random")
       end
 
       it 'should parse correctly available_on' do
@@ -289,6 +288,37 @@ describe "Products" do
         end
       end
     end
+  end
+  context 'with only product permissions' do
+    custom_authorization! do |user|
+      can [:admin, :update, :index, :read], Spree::Product
+    end
+    let!(:product) { create(:product) }
 
+    it "should only display accessible links on index" do
+      visit spree.admin_products_path
+      page.should have_link('Products')
+      page.should_not have_link('Option Types')
+      page.should_not have_link('Properties')
+      page.should_not have_link('Prototypes')
+
+      page.should_not have_link('New Product')
+      page.should_not have_css('a.clone')
+      page.should have_css('a.edit')
+      page.should_not have_css('a.delete-resource')
+    end
+    it "should only display accessible links on edit" do
+      visit spree.admin_product_path(product)
+
+      # product tabs should be hidden
+      page.should have_link('Product Details')
+      page.should_not have_link('Images')
+      page.should_not have_link('Variants')
+      page.should_not have_link('Product Properties')
+      page.should_not have_link('Stock Management')
+
+      # no create permission
+      page.should_not have_link('New Product')
+    end
   end
 end

--- a/core/lib/spree/testing_support/authorization_helpers.rb
+++ b/core/lib/spree/testing_support/authorization_helpers.rb
@@ -10,17 +10,6 @@ module Spree
       end
 
       module Request
-        class BarAbility
-          include CanCan::Ability
-
-          def initialize(user)
-            # allow dispatch to :admin, :index, and :edit on Spree::Order
-            can [:admin, :edit, :index, :read], Spree::Order
-            # allow dispatch to :index, :show, :create and :update shipments on the admin
-            can [:admin, :manage, :read, :ship], Spree::Shipment
-          end
-        end
-
         class SuperAbility
           include CanCan::Ability
 
@@ -41,13 +30,15 @@ module Spree
           end
         end
 
-        def stub_bar_authorization!
+        def custom_authorization!(&block)
+          ability = Class.new do
+            include CanCan::Ability
+            define_method(:initialize, block)
+          end
           after(:all) do
-            ability = Spree::TestingSupport::AuthorizationHelpers::Request::BarAbility
             Spree::Ability.remove_ability(ability)
           end
           before(:all) do
-            ability = Spree::TestingSupport::AuthorizationHelpers::Request::BarAbility
             Spree::Ability.register_ability(ability)
           end
         end


### PR DESCRIPTION
We have a store which will has a user class which can view, but not update orders and products in the admin. This worked fairly well due to judicious use of `authorize!` in controllers, but left dead links to the unauthorized pages.

This adds more `can?` tests in the admin to hide these links.
