### PR TITLE
Rails 4 bump paranoia

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -39,11 +39,10 @@ module Spree
       dependent: :destroy
 
     has_many :variants,
-      -> { where(is_master: false, deleted_at: nil).order("#{::Spree::Variant.quoted_table_name}.position ASC") },
+      -> { where(is_master: false).order("#{::Spree::Variant.quoted_table_name}.position ASC") },
       class_name: 'Spree::Variant'
 
     has_many :variants_including_master,
-      -> { where(deleted_at: nil) },
       class_name: 'Spree::Variant',
       dependent: :destroy
 

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'cancan', '1.6.8'
   s.add_dependency 'truncate_html', '0.9.2'
   s.add_dependency 'money', '5.1.1'
-  s.add_dependency 'paranoia', '~> 1.3'
+  s.add_dependency 'paranoia', '~> 2.0'
 
   # For checking for alerts
   s.add_dependency 'httparty', '~> 0.11'


### PR DESCRIPTION
Turns out that paranoia 1.3 won't even let us bundle due to activerecord dependency conflicts.
