### PR TITLE
Store tax category on line item

### DIFF
--- a/core/app/models/spree/calculator/default_tax.rb
+++ b/core/app/models/spree/calculator/default_tax.rb
@@ -24,7 +24,7 @@ module Spree
 
       def compute_order(order)
         matched_line_items = order.line_items.select do |line_item|
-          line_item.product.tax_category == rate.tax_category
+          line_item.tax_category == rate.tax_category
         end
 
         line_items_total = matched_line_items.sum(&:total)
@@ -32,7 +32,7 @@ module Spree
       end
 
       def compute_line_item(line_item)
-        if line_item.product.tax_category == rate.tax_category
+        if line_item.tax_category == rate.tax_category
           if rate.included_in_price
             deduced_total_by_rate(line_item.total, rate)
           else

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -3,11 +3,13 @@ module Spree
     before_validation :adjust_quantity
     belongs_to :order, class_name: "Spree::Order"
     belongs_to :variant, class_name: "Spree::Variant"
+    belongs_to :tax_category, class_name: "Spree::TaxCategory"
 
     has_one :product, through: :variant
     has_many :adjustments, as: :adjustable, dependent: :destroy
 
     before_validation :copy_price
+    before_validation :copy_tax_category
 
     validates :variant, presence: true
     validates :quantity, numericality: {
@@ -32,6 +34,12 @@ module Spree
         self.price = variant.price if price.nil?
         self.cost_price = variant.cost_price if cost_price.nil?
         self.currency = variant.currency if currency.nil?
+      end
+    end
+
+    def copy_tax_category
+      if variant
+        self.tax_category = variant.product.tax_category
       end
     end
 

--- a/core/db/migrate/20130802014537_add_tax_category_id_to_spree_line_items.rb
+++ b/core/db/migrate/20130802014537_add_tax_category_id_to_spree_line_items.rb
@@ -1,0 +1,5 @@
+class AddTaxCategoryIdToSpreeLineItems < ActiveRecord::Migration
+  def change
+    add_column :spree_line_items, :tax_category_id, :integer
+  end
+end

--- a/core/spec/models/spree/calculator/default_tax_spec.rb
+++ b/core/spec/models/spree/calculator/default_tax_spec.rb
@@ -6,10 +6,8 @@ describe Spree::Calculator::DefaultTax do
   let(:vat) { false }
   let!(:calculator) { Spree::Calculator::DefaultTax.new({:calculable => rate}, :without_protection => true) }
   let!(:order) { create(:order) }
-  let!(:product_1) { create(:product, :tax_category => tax_category) }
-  let!(:product_2) { create(:product, :tax_category => tax_category) }
-  let!(:line_item_1) { create(:line_item, :product => product_1, :price => 10, :quantity => 3) }
-  let!(:line_item_2) { create(:line_item, :product => product_2, :price => 5, :quantity => 1) }
+  let!(:line_item_1) { create(:line_item, :price => 10, :quantity => 3, :tax_category => tax_category) }
+  let!(:line_item_2) { create(:line_item, :price => 5, :quantity => 1, :tax_category => tax_category) }
 
   context "#compute" do
     context "when given an order" do
@@ -19,8 +17,8 @@ describe Spree::Calculator::DefaultTax do
 
       context "when no line items match the tax category" do
         before do
-          product_1.tax_category = nil
-          product_2.tax_category = nil
+          line_item_1.tax_category = nil
+          line_item_2.tax_category = nil
         end
 
         it "should be 0" do
@@ -30,8 +28,8 @@ describe Spree::Calculator::DefaultTax do
 
       context "when one item matches the tax category" do
         before do
-          product_1.tax_category = tax_category
-          product_2.tax_category = nil
+          line_item_1.tax_category = tax_category
+          line_item_2.tax_category = nil
         end
 
         it "should be equal to the item total * rate" do
@@ -81,7 +79,7 @@ describe Spree::Calculator::DefaultTax do
 
       context "when the variant does not match the tax category" do
         before do
-          line_item_2.product.tax_category = nil
+          line_item_2.tax_category = nil
         end
 
         it "should be 0" do

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -36,6 +36,15 @@ describe Spree::LineItem do
     end
   end
 
+  # Test for #3481
+  context '#copy_tax_category' do
+    it "copies over a variant's tax category" do
+      line_item.tax_category = nil
+      line_item.copy_tax_category
+      line_item.tax_category.should == line_item.variant.product.tax_category
+    end
+  end
+
   describe '.currency' do
     it 'returns the globally configured currency' do
       line_item.currency == 'USD'


### PR DESCRIPTION
Fixes #3481, real proper like.

> Currently, to calculate a tax rate for a line item, we reach through the associated variant to the product and then the product's tax category.  [See here for what I mean](https://github.com/spree/spree/blob/e99c7b1d0649ccaf13c74760d59f092807bd8979/core/app/models/spree/calculator/default_tax.rb#L34-L35) for what I mean. It would be faster to not have to do that, and so storing tax_category on the line item would aid in this.
