### PR TITLE
Kaminari 0.14.1 in 1-3-stable

### DIFF
--- a/api/lib/spree/api/testing_support/setup.rb
+++ b/api/lib/spree/api/testing_support/setup.rb
@@ -9,19 +9,6 @@ module Spree
             user
           end
         end
-
-        # Default kaminari's pagination to a certain range
-        # Means that you don't need to create 25 objects to test pagination
-        def default_per_page(count)
-          before do
-            @current_default_per_page = Kaminari.config.default_per_page
-            Kaminari.config.default_per_page = 1
-          end
-
-          after do
-            Kaminari.config.default_per_page = @current_default_per_page
-          end
-        end
       end
     end
   end

--- a/api/spec/controllers/spree/api/products_controller_spec.rb
+++ b/api/spec/controllers/spree/api/products_controller_spec.rb
@@ -28,11 +28,10 @@ module Spree
       end
 
       context "pagination" do
-        default_per_page(1)
 
         it "can select the next page of products" do
           second_product = create(:product)
-          api_get :index, :page => 2
+          api_get :index, :page => 2, :per_page => 1
           json_response["products"].first.should have_attributes(attributes)
           json_response["total_count"].should == 2
           json_response["current_page"].should == 2

--- a/api/spec/controllers/spree/api/variants_controller_spec.rb
+++ b/api/spec/controllers/spree/api/variants_controller_spec.rb
@@ -78,11 +78,9 @@ module Spree
     end
 
     context "pagination" do
-      default_per_page(1)
-
       it "can select the next page of variants" do
         second_variant = create(:variant)
-        api_get :index, :page => 2
+        api_get :index, :page => 2, :per_page => 1
         json_response["variants"].first.should have_attributes(attributes)
         json_response["total_count"].should == 3
         json_response["current_page"].should == 2

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activemerchant', '~> 1.34'
   s.add_dependency 'json', '>= 1.5.5'
   s.add_dependency 'rails', '~> 3.2.14'
-  s.add_dependency 'kaminari', '0.13.0'
+  s.add_dependency 'kaminari', '0.14.1'
   s.add_dependency 'deface', '>= 0.9.0'
   s.add_dependency 'stringex', '~> 1.3.2'
   s.add_dependency 'cancan', '1.6.8'


### PR DESCRIPTION
I found myself in need of this update in a project where is not viable to upgrade to 2-0-stable at the moment.

According to [spree/spree#2169](https://github.com/spree/spree/pull/2169), this breaks the API specs. This pull request introduces the same changes as https://github.com/spree/spree/commit/a1f3f21ef1abb1fdbdcbd7ac8fb50e0e704f3c81.

Not sure whether these changes are welcome in this branch given the spec breaking but thought this could also be useful to others.
