### PR TITLE
Remove `ìnverse_of` from order has_many :adjustments

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -40,7 +40,7 @@ module Spree
     has_many :line_items, -> { order('created_at ASC') }, dependent: :destroy
     has_many :payments, dependent: :destroy
     has_many :return_authorizations, dependent: :destroy
-    has_many :adjustments, -> { order('created_at ASC') }, as: :adjustable, dependent: :destroy
+    has_many :adjustments, -> { order("#{Adjustment.table_name}.created_at ASC") }, as: :adjustable, dependent: :destroy
     has_many :line_item_adjustments, through: :line_items, source: :adjustments
 
     has_many :shipments, dependent: :destroy do

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -25,7 +25,8 @@ module Spree
         update_shipment_state
       end
       
-      update_adjustments
+      update_promotion_adjustments
+      update_shipping_adjustments
       # update totals a second time in case updated adjustments have an effect on the total
       update_totals
 
@@ -124,9 +125,15 @@ module Spree
     #
     # Adjustments will check if they are still eligible. Ineligible adjustments
     # are preserved but not counted towards adjustment_total.
-    def update_adjustments
-      order.adjustments.reload.each { |adjustment| adjustment.update! }
+    def update_promotion_adjustments
+      order.adjustments.reload.promotion.each { |adjustment| adjustment.update!(order) }
       choose_best_promotion_adjustment
+    end
+
+    # Shipping adjustments don't receive order on update! because they calculated
+    # over a shipping / package object rather than an order object
+    def update_shipping_adjustments
+      order.adjustments.reload.shipping.each { |adjustment| adjustment.update! }
     end
 
     private

--- a/core/spec/models/spree/order/totals_spec.rb
+++ b/core/spec/models/spree/order/totals_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+module Spree
+  describe Order do
+    let(:order) { Order.create }
+    let!(:shirt_item) { order.contents.add(create(:variant), 1) }
+    let!(:bag_item) { order.contents.add(create(:variant), 1) }
+
+    context "promotions" do
+      let!(:promotion) { Promotion.create(name: "Huhuhu") }
+
+      let(:promo_calculator) do
+        Calculator::FlatPercentItemTotal.create(preferred_flat_percent: "10")
+      end
+
+      let!(:action) do
+        Promotion::Actions::CreateAdjustment.create(calculator: promo_calculator)
+      end
+
+      before do
+        promotion.actions << action
+        action.perform(order: order)
+      end
+
+      context "saves more than one line item at once" do
+        let(:params) do
+          { line_items_attributes: {
+              "0" => { id: shirt_item.id, quantity: 2 },
+              "1" => { id: bag_item.id, quantity: 2 }
+          } }
+        end
+
+        it "calculates descount properly" do
+          order.update_attributes(params)
+          expected_discount = - order.reload.item_total * (promo_calculator.preferred_flat_percent / 100)
+          expect(order.adjustments.promotion.first.amount).to eql expected_discount.round(2)
+        end
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -167,78 +167,87 @@ module Spree
       updater.update
     end
 
-    context "#update_adjustments" do
-      let(:originator) do
-        originator = Spree::Promotion::Actions::CreateAdjustment.create
-        calculator = Spree::Calculator::PerItem.create(:calculable => originator)
-        originator.calculator = calculator
-        originator.save
-        originator
-      end
-
-      def create_adjustment(label, amount)
-        create(:adjustment, :adjustable => order,
-                            :originator => originator,
-                            :amount     => amount,
-                            :state      => "closed",
-                            :label      => label,
-                            :mandatory  => false)
-      end
-
-      it "should make all but the most valuable promotion adjustment ineligible, leaving non promotion adjustments alone" do
-        create_adjustment("Promotion A", -100)
-        create_adjustment("Promotion B", -200)
-        create_adjustment("Promotion C", -300)
-        create(:adjustment, :adjustable => order,
-                            :originator => nil,
-                            :amount => -500,
-                            :state => "closed",
-                            :label => "Some other credit")
-        order.adjustments.each {|a| a.update_column(:eligible, true)}
-
-        updater.update_adjustments
-
-        order.adjustments.eligible.promotion.count.should == 1
-        order.adjustments.eligible.promotion.first.label.should == 'Promotion C'
-      end
-
-      context "multiple adjustments and the best one is not eligible" do
-        let!(:promo_a) { create_adjustment("Promotion A", -100) }
-        let!(:promo_c) { create_adjustment("Promotion C", -300) }
-
-        before do
-          promo_a.update_column(:eligible, true)
-          promo_c.update_column(:eligible, false)
-        end
-
-        # regression for #3274
-        it "still makes the previous best eligible adjustment valid" do
-          updater.update_adjustments
-          order.adjustments.eligible.promotion.first.label.should == 'Promotion A'
+    context "update adjustments" do
+      context "shipments" do
+        it "updates" do
+          expect(updater).to receive(:update_shipping_adjustments)
+          updater.update
         end
       end
 
-      it "should only leave one adjustment even if 2 have the same amount" do
-        create_adjustment("Promotion A", -100)
-        create_adjustment("Promotion B", -200)
-        create_adjustment("Promotion C", -200)
+      context "promotions" do
+        let(:originator) do
+          originator = Spree::Promotion::Actions::CreateAdjustment.create
+          calculator = Spree::Calculator::PerItem.create(:calculable => originator)
+          originator.calculator = calculator
+          originator.save
+          originator
+        end
 
-        updater.update_adjustments
+        def create_adjustment(label, amount)
+          create(:adjustment, :adjustable => order,
+                              :originator => originator,
+                              :amount     => amount,
+                              :state      => "closed",
+                              :label      => label,
+                              :mandatory  => false)
+        end
 
-        order.adjustments.eligible.promotion.count.should == 1
-        order.adjustments.eligible.promotion.first.amount.to_i.should == -200
-      end
+        it "should make all but the most valuable promotion adjustment ineligible, leaving non promotion adjustments alone" do
+          create_adjustment("Promotion A", -100)
+          create_adjustment("Promotion B", -200)
+          create_adjustment("Promotion C", -300)
+          create(:adjustment, :adjustable => order,
+                              :originator => nil,
+                              :amount => -500,
+                              :state => "closed",
+                              :label => "Some other credit")
+          order.adjustments.each {|a| a.update_column(:eligible, true)}
 
-      it "should only include eligible adjustments in promo_total" do
-        create_adjustment("Promotion A", -100)
-        create(:adjustment, :adjustable => order,
-                            :originator => nil,
-                            :amount     => -1000,
-                            :state      => "closed",
-                            :eligible   => false,
-                            :label      => 'Bad promo')
+          updater.update_promotion_adjustments
 
-        order.promo_total.to_f.should == -100.to_f
+          order.adjustments.eligible.promotion.count.should == 1
+          order.adjustments.eligible.promotion.first.label.should == 'Promotion C'
+        end
+
+        context "multiple adjustments and the best one is not eligible" do
+          let!(:promo_a) { create_adjustment("Promotion A", -100) }
+          let!(:promo_c) { create_adjustment("Promotion C", -300) }
+
+          before do
+            promo_a.update_column(:eligible, true)
+            promo_c.update_column(:eligible, false)
+          end
+
+          # regression for #3274
+          it "still makes the previous best eligible adjustment valid" do
+            updater.update_promotion_adjustments
+            order.adjustments.eligible.promotion.first.label.should == 'Promotion A'
+          end
+        end
+
+        it "should only leave one adjustment even if 2 have the same amount" do
+          create_adjustment("Promotion A", -100)
+          create_adjustment("Promotion B", -200)
+          create_adjustment("Promotion C", -200)
+
+          updater.update_promotion_adjustments
+
+          order.adjustments.eligible.promotion.count.should == 1
+          order.adjustments.eligible.promotion.first.amount.to_i.should == -200
+        end
+
+        it "should only include eligible adjustments in promo_total" do
+          create_adjustment("Promotion A", -100)
+          create(:adjustment, :adjustable => order,
+                              :originator => nil,
+                              :amount     => -1000,
+                              :state      => "closed",
+                              :eligible   => false,
+                              :label      => 'Bad promo')
+
+          order.promo_total.to_f.should == -100.to_f
+        end
       end
     end
   end

--- a/frontend/spec/features/promotion_adjustments_spec.rb
+++ b/frontend/spec/features/promotion_adjustments_spec.rb
@@ -170,10 +170,11 @@ describe "Promotion adjustments", :js => true do
           click_button "Update"
 
           within '#cart_adjustments' do
-            page.should have_content("Promotion (Onetwo) $-10.00")
+            # 20% off $60 item_total (2x $10 + 2x $20)
+            page.should have_content("Promotion (Onetwo) $-12.00")
           end
           within '.order-total' do
-            page.should have_content("$50.00")
+            page.should have_content("$48.00")
           end
         end
       end


### PR DESCRIPTION
That option will cause trouble once Spree upgrades to Rails v4.0.0 as
the store will not create proper shipment adjustments. It appears that
`inverse_of: source` will confuse activerecord because an adjustment
source is not always an order. It might be either an Order or a
Shipment for example.

This is the confusing behaviour on rails 4 console session:

```
[9] pry(Spree):1> order
=> #<Spree::Order id: 13, number: "R085433244" ... >
[10] pry(Spree):1> shipment
=> #<Spree::Shipment id: 16, tracking: nil, number: "H33417384040" ... >
[11] pry(Spree):1> order.adjustments.create(source: shipment, label: "ha", amount: 0)
=> #<Spree::Adjustment id: 41, source_id: 13, source_type: "Spree::Shipment", adjustable_id: 13, adjustable_type: "Spree::Order" ... >
```

While it also seems like an activerecord bug as well I still believe we
shouldn't rely on `inverse_of` where possible

The `inverse_of` option was introduced in #3054. This PR that same issue using other approach. Please note that the behaviour described above do not exist neither in current master nor in rails4 branch. But it will once the rebase thing happens between master and rails4. I noticed it today while tryign to get the current edge build green on rails 4 and thought I should open this PR so we can remember the issue later on.
