### PR TITLE
Introduce better approach for regenerating shipments

### DIFF
--- a/api/app/models/spree/order_decorator.rb
+++ b/api/app/models/spree/order_decorator.rb
@@ -105,5 +105,6 @@ Spree::Order.class_eval do
     line_item_params.each do |id, attributes|
       self.line_items.find(id).update_attributes!(attributes)
     end
+    self.ensure_updated_shipments
   end
 end

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -168,7 +168,7 @@ module Spree
         address
       end
 
-      it "can update quantities of existing line items" do
+      it "updates quantities of existing line items" do
         api_put :update, :id => order.to_param, :order => {
           :line_items => {
             line_item.id => { :quantity => 10 }
@@ -213,6 +213,20 @@ module Spree
         json_response['error'].should_not be_nil
         json_response['errors'].should_not be_nil
         json_response['errors']['ship_address.firstname'].first.should eq "can't be blank"
+      end
+
+      context "order has shipments" do
+        before { order.create_proposed_shipments }
+
+        it "clears out all existing shipments on line item udpate" do
+          previous_shipments = order.shipments
+          api_put :update, :id => order.to_param, :order => {
+            :line_items => {
+              line_item.id => { :quantity => 10 }
+            }
+          }
+          expect(order.reload.shipments).to be_empty
+        end
       end
 
       context "with a line item" do

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -506,6 +506,18 @@ module Spree
       shipments
     end
 
+    # Clean shipments and make order back to address state
+    #
+    # At some point the might need to force the order to transition from address
+    # to delivery again so that proper updated shipments are created.
+    # e.g. customer goes back from payment step and changes order items 
+    def ensure_updated_shipments
+      if shipments.any?
+        self.shipments.destroy_all
+        self.update_column(:state, "address")
+      end
+    end
+
     private
 
       def link_by_email

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -535,5 +535,18 @@ describe Spree::Order do
       order.finalize!
     end
   end
-end
 
+  context "ensure shipments will be updated" do
+    before { Spree::Shipment.create!(order: order) }
+
+    it "destroys current shipments" do
+      order.ensure_updated_shipments
+      expect(order.shipments).to be_empty
+    end
+
+    it "puts order back in address state" do
+      order.ensure_updated_shipments
+      expect(order.state).to eql "address"
+    end
+  end
+end

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -17,6 +17,8 @@ module Spree
     before_filter :check_authorization
     before_filter :apply_coupon_code
 
+    before_filter :setup_for_current_state
+
     helper 'spree/orders'
 
     rescue_from Spree::Core::GatewayError, :with => :rescue_from_spree_gateway_error
@@ -69,7 +71,6 @@ module Spree
           redirect_to checkout_state_path(@order.state) if @order.can_go_to_state?(params[:state]) && !skip_state_validation?
           @order.state = params[:state]
         end
-        setup_for_current_state
       end
 
       def ensure_checkout_allowed

--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -21,7 +21,7 @@ module Spree
 
       if @order.update_attributes(order_params)
         @order.line_items = @order.line_items.select {|li| li.quantity > 0 }
-        @order.create_proposed_shipments if @order.shipments.any?
+        @order.ensure_updated_shipments
         return if after_update_attributes
 
         fire_event('spree.order.contents_changed')
@@ -51,7 +51,7 @@ module Spree
     def populate
       populator = Spree::OrderPopulator.new(current_order(true), current_currency)
       if populator.populate(params.slice(:products, :variants, :quantity))
-        current_order.create_proposed_shipments if current_order.shipments.any?
+        current_order.ensure_updated_shipments
 
         fire_event('spree.cart.add')
         fire_event('spree.order.contents_changed')

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -256,12 +256,10 @@ describe Spree::CheckoutController do
       configure_spree_preferences do |config|
         config.track_inventory_levels = true
       end
-
     end
 
     context "and back orders are not allowed" do
       before do
-        controller.should_receive(:before_payment)
         spree_post :update, { :state => "payment" }
       end
 
@@ -288,6 +286,8 @@ describe Spree::CheckoutController do
   end
 
   it "does remove unshippable items before payment" do
+    controller.stub :check_authorization => true
+
     expect {
       spree_post :update, { :state => "payment" }
     }.to change { order.line_items }

--- a/frontend/spec/controllers/spree/orders_controller_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_spec.rb
@@ -21,6 +21,8 @@ describe Spree::OrdersController do
       # Don't care about IP address or created_by being set here
       order.stub(:last_ip_address=)
       order.stub(:created_by=)
+      # Don't care about shipments either as feature specs will cover it
+      order.stub :ensure_updated_shipments
       Spree::Order.stub(:find).with(1).and_return(order)
       controller.stub(:try_spree_current_user => user)
     end

--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -206,30 +206,47 @@ describe "Checkout" do
       expect(current_path).to eql(spree.checkout_state_path("payment"))
     end
 
-    context "and updates line item quantity" do
-      it "uptades shipments properly" do
+    context "and updates line item quantity and try to reach payment page" do
+      before do
         visit spree.cart_path
         within ".cart-item-quantity" do
           fill_in first("input")["name"], with: 3
         end
 
         click_on "Update"
+      end
+
+      it "redirects user back to address step" do
         visit spree.checkout_state_path("payment")
+        expect(current_path).to eql(spree.checkout_state_path("address"))
+      end
+
+      it "updates shipments properly through step address -> delivery transitions" do
+        visit spree.checkout_state_path("payment")
+        click_on "Save and Continue"
         click_on "Save and Continue"
 
         expect(Spree::InventoryUnit.count).to eq 3
       end
     end
 
-    context "and adds new product to cart" do
+    context "and adds new product to cart and try to reach payment page" do
       let!(:bag) { create(:product, :name => "RoR Bag") }
 
-      it "updates shipments properly" do
+      before do
         visit spree.root_path
         click_link bag.name
         click_button "add-to-cart-button"
+      end
 
+      it "redirects user back to address step" do
         visit spree.checkout_state_path("payment")
+        expect(current_path).to eql(spree.checkout_state_path("address"))
+      end
+
+      it "updates shipments properly through step address -> delivery transitions" do
+        visit spree.checkout_state_path("payment")
+        click_on "Save and Continue"
         click_on "Save and Continue"
 
         expect(Spree::InventoryUnit.count).to eq 2


### PR DESCRIPTION
Instead of recreating shipments every time customers change order items
it only destroy shipments, if any exists, and put order state back into
address so users are forced to transition the order again from address
to delivery and so still recreate shipments properly

Another minor change on CheckoutController was necessary. We need to run
`setup_for_current_state` only after all other check are done. e.g.
authentication, valid order state. This is so that customer don't get
their items removed by the Differentiator. Current specs should cover
all possible scnearios I could think of.

I believe this is a better approach than what my previous suggestion in #3339 and it should help experience for customers going back from delivery step and changing order items, see #3405. It basically force users to go through delivery step again when shipments need to be recreated as suggested by @BDQ. By that we'd actually create shipments in one single place.

This is a rather critical change imo so I'd appreciate feedback from everyone. CI looks good and it should apply cleanly in 2-0-stable.
