### PR TITLE
Don't load all promos to apply a coupon code

### DIFF
--- a/core/lib/spree/promo/coupon_applicator.rb
+++ b/core/lib/spree/promo/coupon_applicator.rb
@@ -32,8 +32,8 @@ module Spree
         return promotion_usage_limit_exceeded if promotion.usage_limit_exceeded?
 
         event_name = "spree.checkout.coupon_code_added"
-        ActiveSupport::Notifications.instrument(event_name, :coupon_code => @order.coupon_code, :order => @order)
-        promo = @order.adjustments.promotion.detect { |p| p.originator.promotion.code == @order.coupon_code }
+        promotion.activate(:coupon_code => @order.coupon_code, :order => @order)
+        promo = @order.adjustments.includes(:originator).promotion.detect { |p| p.originator.promotion.code == @order.coupon_code }
         determine_promotion_application_result(promo)
       end
 


### PR DESCRIPTION
As suggested by @balexand in #3156. The build still looks fine with this patch and it should help stores running with too many promo codes.

@balexand I'd appreciate if you could give more feedback here, like did you run into any trouble after monkey patching your app with this code? do you think we'd have to make any other change? thanks.

ps. 2-0-stable needs the patch as well.
