### PR TITLE
Drop spree_mail_methods table

### DIFF
--- a/core/db/migrate/20130806022521_drop_spree_mail_methods.rb
+++ b/core/db/migrate/20130806022521_drop_spree_mail_methods.rb
@@ -1,0 +1,12 @@
+class DropSpreeMailMethods < ActiveRecord::Migration
+  def up
+    drop_table :spree_mail_methods
+  end
+
+  def down
+    create_table(:spree_mail_methods) do |t|
+      t.string :environment
+      t.boolean :active
+    end
+  end
+end


### PR DESCRIPTION
It's no longer used since Spree 2.0
