### PR TITLE
Dont update shipments and payment in order cart

### DIFF
--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -16,11 +16,15 @@ module Spree
     # associations try to save and then in turn try to call +update!+ again.)
     def update
       update_totals
-      update_payment_state
 
-      # give each of the shipments a chance to update themselves
-      shipments.each { |shipment| shipment.update!(order) }
-      update_shipment_state
+      if order.completed?
+        update_payment_state
+
+        # give each of the shipments a chance to update themselves
+        shipments.each { |shipment| shipment.update!(order) }
+        update_shipment_state
+      end
+
       update_adjustments
       # update totals a second time in case updated adjustments have an effect on the total
       update_totals

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -108,23 +108,62 @@ module Spree
       order.state_changed('shipment')
     end
 
-    it "updates each shipment" do
-      shipment = stub_model(Spree::Shipment)
-      shipments = [shipment]
-      order.stub :shipments => shipments
-      shipments.stub :states => []
-      shipments.stub :ready => []
-      shipments.stub :pending => []
-      shipments.stub :shipped => []
+    context "completed order" do
+      before { order.stub completed?: true }
 
-      shipment.should_receive(:update!).with(order)
+      it "updates payment state" do
+        expect(updater).to receive(:update_payment_state)
+        updater.update
+      end
 
-      updater.update
+      it "updates shipment state" do
+        expect(updater).to receive(:update_shipment_state)
+        updater.update
+      end
+
+      it "updates each shipment" do
+        shipment = stub_model(Spree::Shipment)
+        shipments = [shipment]
+        order.stub :shipments => shipments
+        shipments.stub :states => []
+        shipments.stub :ready => []
+        shipments.stub :pending => []
+        shipments.stub :shipped => []
+
+        shipment.should_receive(:update!).with(order)
+        updater.update
+      end
+    end
+
+    context "incompleted order" do
+      before { order.stub completed?: false }
+
+      it "doesnt update payment state" do
+        expect(updater).not_to receive(:update_payment_state)
+        updater.update
+      end
+
+      it "doesnt update shipment state" do
+        expect(updater).not_to receive(:update_shipment_state)
+        updater.update
+      end
+
+      it "doesnt update each shipment" do
+        shipment = stub_model(Spree::Shipment)
+        shipments = [shipment]
+        order.stub :shipments => shipments
+        shipments.stub :states => []
+        shipments.stub :ready => []
+        shipments.stub :pending => []
+        shipments.stub :shipped => []
+
+        expect(shipment).not_to receive(:update!).with(order)
+        updater.update
+      end
     end
 
     it "updates totals twice" do
       updater.should_receive(:update_totals).twice
-
       updater.update
     end
 


### PR DESCRIPTION
Adding a product to cart on a fresh spree install currently runs 41 SQL
queries. This change makes the POST orders/populate request run 34 SQL
queries.

So each time the store needs to run `order.update!` and the order is not
completed yet we run 7 less queries. That could make a big difference
when lots of promotions are involved.

Guys does the store really needs to care about shipment and payment state before it's not completed? I couldn't think of a use case for that. At first I added an `if order.cart?` statement to run that code but then realized we might not need that at all if the order is not completed. Build is still fine.

let me know your thoughts please
