### PR TITLE
Bump aws-sdk

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activemerchant', '~> 1.34'
   s.add_dependency 'acts_as_list', '= 0.2.0'
   s.add_dependency 'awesome_nested_set', '2.1.5'
-  s.add_dependency 'aws-sdk', '~> 1.3.4'
+  s.add_dependency 'aws-sdk', '~> 1.11.1'
   s.add_dependency 'cancan', '~> 1.6.10'
   s.add_dependency 'deface', '>= 1.0.0.rc2'
   s.add_dependency 'ffaker', '~> 1.16'


### PR DESCRIPTION
Should be pretty safe, and this allows use of newer AWS services.
