### PR TITLE
Use includes(:model) for fewer queries

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -492,7 +492,7 @@ module Spree
     # Receives an adjustment +originator+ (here a PromotionAction object) and tells
     # if the order has adjustments from that already
     def promotion_credit_exists?(originator)
-      !! adjustments.promotion.reload.detect { |credit| credit.originator.id == originator.id }
+      !! adjustments.includes(:originator).promotion.reload.detect { |credit| credit.originator.id == originator.id }
     end
 
     def promo_total

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -487,7 +487,7 @@ describe Spree::Order do
     let(:originator) { double("Originator", id: 1) }
     let(:adjustment) { double("Adjustment", originator: originator) }
 
-    before { order.stub_chain(:adjustments, :promotion, reload: [adjustment]) }
+    before { order.stub_chain(:adjustments, :includes, :promotion, reload: [adjustment]) }
 
     context "order has an adjustment from given promo action" do
       it { expect(order.promotion_credit_exists? originator).to be_true }


### PR DESCRIPTION
Small change for less queries. Can we please have this in 2-0-stable as well?
