### PR TITLE
Limit shipping methods to certain stock locations

### DIFF
--- a/backend/app/controllers/spree/admin/shipping_methods_controller.rb
+++ b/backend/app/controllers/spree/admin/shipping_methods_controller.rb
@@ -4,6 +4,7 @@ module Spree
       before_filter :load_data, :except => [:index]
       before_filter :set_shipping_category, :only => [:create, :update]
       before_filter :set_zones, :only => [:create, :update]
+      before_filter :set_stock_locations, :only => [:create, :update]
 
       def destroy
         @object.touch :deleted_at
@@ -30,6 +31,13 @@ module Spree
         @shipping_method.zones = Spree::Zone.where(:id => params["shipping_method"][:zones])
         @shipping_method.save
         params[:shipping_method].delete(:zones)
+      end
+
+      def set_stock_locations
+        return true if params["shipping_method"][:stock_locations] == ""
+        @shipping_method.stock_locations = Spree::StockLocation.where(:id => params["shipping_method"][:stock_locations])
+        @shipping_method.save
+        params[:shipping_method].delete(:stock_locations)
       end
 
       def location_after_save

--- a/backend/app/views/spree/admin/shipping_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/_form.html.erb
@@ -55,6 +55,22 @@
       <% end %>
     </fieldset>
   </div>
+
+  <div class="omage six columns">
+    <fieldset class="no-border-bottom">
+      <legend align="center"><%=Spree.t(:stock_location) %></legend>
+      <%= f.field_container :stock_locations do %>
+        <% Spree::StockLocation.all.each do |stock_location| %>
+          <%= label_tag do %>
+            <%= check_box_tag('shipping_method[stock_locations][]', stock_location.id, @shipping_method.stock_locations.include?(stock_location)) %>
+            <%= stock_location.name %>
+          <% end %>
+          <br>
+          <%= error_message_on :shipping_method, :stock_location %>
+        <% end %>
+      <% end %>
+    </fieldset>
+  </div>
 </div>
 
 <div data-hook="admin_shipping_method_form_calculator_fields" class="omega six columns">

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -14,8 +14,13 @@ module Spree
                                     :class_name => 'Spree::Zone',
                                     :foreign_key => 'shipping_method_id'
 
+    has_and_belongs_to_many :stock_locations, :join_table => 'spree_shipping_method_stock_locations',
+                                              :class_name => 'Spree::StockLocation',
+                                              :foreign_key => 'shipping_method_id'
+
     attr_accessible :name, :zones, :display_on, :shipping_category_id,
-                    :match_none, :match_one, :match_all, :tracking_url
+                    :match_none, :match_one, :match_all, :tracking_url,
+                    :stock_locations
 
     validates :name, presence: true
 

--- a/core/app/models/spree/stock/estimator.rb
+++ b/core/app/models/spree/stock/estimator.rb
@@ -39,6 +39,7 @@ module Spree
         shipping_methods.delete_if { |ship_method| !ship_method.calculator.available?(package) }
         shipping_methods.delete_if { |ship_method| !ship_method.include?(order.ship_address) }
         shipping_methods.delete_if { |ship_method| !(ship_method.calculator.preferences[:currency].nil? || ship_method.calculator.preferences[:currency] == currency) }
+        shipping_methods.delete_if { |ship_method| !ship_method.stock_locations.include?(package.stock_location) }
         shipping_methods
       end
 

--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -12,6 +12,9 @@ module Spree
         :backorderable_default, :state_name, :state_id, :country_id, :phone,
         :country_id, :propagate_all_variants
 
+    has_and_belongs_to_many :shipping_methods, :join_table => 'spree_shipping_method_stock_locations',
+                                               :class_name => 'Spree::ShippingMethod',
+                                               :foreign_key => 'stock_location_id'
     scope :active, -> { where(active: true) }
 
     after_create :create_stock_items, :if => "self.propagate_all_variants?"

--- a/core/db/migrate/20130807182932_create_shipping_method_stock_location.rb
+++ b/core/db/migrate/20130807182932_create_shipping_method_stock_location.rb
@@ -1,0 +1,12 @@
+class CreateShippingMethodStockLocation < ActiveRecord::Migration
+  def up
+    create_table :spree_shipping_method_stock_locations, :id => false do |t|
+      t.integer :shipping_method_id
+      t.integer :stock_location_id
+    end
+  end
+
+  def down
+    drop_table :spree_shipping_method_stock_locations
+  end
+end


### PR DESCRIPTION
This is for when you have a shipping method that _could_ be technically used in multiple stock locations, but you don't want it to show up for some of them (ie, maybe 1 StockLocation can ship overnight and another cant)
