### PR TITLE
Add an internal name field to stock_locations

### DIFF
--- a/backend/app/views/spree/admin/stock_locations/_form.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/_form.html.erb
@@ -4,6 +4,10 @@
       <%= f.field_container :name do %>
         <%= f.label :name, Spree.t(:name) %>
         <%= f.text_field :name, :class => 'fullwidth' %>
+      <% end %><br>
+      <%= f.field_container :admin_name do %>
+        <%= f.label :admin_name, Spree.t(:internal_name) %>
+        <%= f.text_field :admin_name, :class => 'fullwidth', :label => false %>
       <% end %>
     </div>
     <div class="omega four columns">

--- a/backend/app/views/spree/admin/stock_locations/index.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/index.html.erb
@@ -37,7 +37,7 @@
            @delete_url = admin_stock_location_path(stock_location)
       %>
         <tr id="<%= spree_dom_id stock_location %>" data-hook="stock_location_row" class="<%= cycle('odd', 'even')%>">
-          <td><%= stock_location.name %></td>
+          <td><%= stock_location.admin_name + ' / ' if stock_location.admin_name.present? %><%= stock_location.name %></td>
           <td><span class="state <%= stock_location.active? ? 'active' : 'inactive' %>"><%= stock_location.active? ? 'active' : 'inactive' %></span></td>
           <td><%= link_to Spree.t(:stock_movements), admin_stock_location_stock_movements_path(stock_location.id) %> </td>
           <td class="actions">

--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -8,7 +8,7 @@ module Spree
 
     validates_presence_of :name
 
-    attr_accessible :name, :active, :address1, :address2, :city, :zipcode,
+    attr_accessible :name, :admin_name, :active, :address1, :address2, :city, :zipcode,
         :backorderable_default, :state_name, :state_id, :country_id, :phone,
         :country_id, :propagate_all_variants
 

--- a/core/db/migrate/20130809164330_add_admin_name_column_to_spree_stock_locations.rb
+++ b/core/db/migrate/20130809164330_add_admin_name_column_to_spree_stock_locations.rb
@@ -1,0 +1,5 @@
+class AddAdminNameColumnToSpreeStockLocations < ActiveRecord::Migration
+  def change
+    add_column :spree_stock_locations, :admin_name, :string
+  end
+end


### PR DESCRIPTION
Name displayed on frontend is not always very intuitive when managing stock_locations on the backend, or in other internal scripts. Add this field to allow setting an internal name.
