### PR TITLE
Add internal shipping_method name

### DIFF
--- a/backend/app/views/spree/admin/shipping_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/_form.html.erb
@@ -15,6 +15,16 @@
     <% end %>
   </div>
 
+  <div class="alpha omega twelve columns">
+    <div class="alpha six columns">
+      <%= f.field_container :admin_name do %>
+        <%= f.label :admin_name, Spree.t(:internal_name) %><br />
+        <%= f.text_field :admin_name, :class => 'fullwidth', :label => false  %>
+        <%= error_message_on :shipping_method, :admin_name %>
+      <% end %>
+    </div>
+  </div>
+
   <div class="alpha twelve columns">
     <%= f.field_container :tracking_url do %>
       <%= f.label :tracking_url, Spree.t(:tracking_url) %><br />

--- a/backend/app/views/spree/admin/shipping_methods/index.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/index.html.erb
@@ -30,7 +30,7 @@
     <tbody>
       <% @shipping_methods.each do |shipping_method|%>
         <tr id="<%= spree_dom_id shipping_method %>" data-hook="admin_shipping_methods_index_rows" class="<%= cycle('odd', 'even')%>">
-          <td><%= shipping_method.name %></td>
+          <td><%= shipping_method.admin_name + ' / ' if shipping_method.admin_name.present? %><%= shipping_method.name %></td>
           <td><%= shipping_method.zones.collect(&:name).join(", ") if shipping_method.zones %></td>
           <td><%= shipping_method.calculator.description %></td>
           <td class="align-center"><%= shipping_method.display_on.blank? ? Spree.t(:both) : Spree.t(shipping_method.display_on) %></td>

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -14,7 +14,7 @@ module Spree
                                     :class_name => 'Spree::Zone',
                                     :foreign_key => 'shipping_method_id'
 
-    attr_accessible :name, :zones, :display_on, :shipping_category_id,
+    attr_accessible :name, :admin_name, :zones, :display_on, :shipping_category_id,
                     :match_none, :match_one, :match_all, :tracking_url
 
     validates :name, presence: true

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -575,6 +575,7 @@ en:
     insufficient_stock: Insufficient stock available, only %{on_hand} remaining
     intercept_email_address: Intercept Email Address
     intercept_email_instructions: Override email recipient and replace with this address.
+    internal_name: Internal Name
     invalid_payment_provider: Invalid payment provider.
     invalid_promotion_action: Invalid promotion action.
     invalid_promotion_rule: Invalid promotion rule.

--- a/core/db/migrate/20130809164245_add_admin_name_column_to_spree_shipping_methods.rb
+++ b/core/db/migrate/20130809164245_add_admin_name_column_to_spree_shipping_methods.rb
@@ -1,0 +1,5 @@
+class AddAdminNameColumnToSpreeShippingMethods < ActiveRecord::Migration
+  def change
+    add_column :spree_shipping_methods, :admin_name, :string
+  end
+end


### PR DESCRIPTION
Allows a place to store an internal name for a shipping method that helps associate the method to some backend context while still displaying a sensible name to shoppers
