### PR TITLE
Fetch deleted variant and product in line items

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -83,6 +83,16 @@ module Spree
       @preferred_shipment = shipment
     end
 
+    # Remove product default_scope `deleted_at: nil`
+    def product
+      variant.product
+    end
+
+    # Remove variant default_scope `deleted_at: nil`
+    def variant
+      Spree::Variant.unscoped { super }
+    end
+
     private
       def update_inventory
         Spree::OrderInventory.new(self.order).verify(self, target_shipment)

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -20,6 +20,16 @@ describe Spree::LineItem do
       line_item.order.should_receive(:create_tax_charge!)
       line_item.destroy
     end
+
+    it "fetches deleted products" do
+      line_item.product.destroy
+      expect(line_item.reload.product).to be_a Spree::Product
+    end
+
+    it "fetches deleted variants" do
+      line_item.variant.destroy
+      expect(line_item.reload.variant).to be_a Spree::Variant
+    end
   end
 
   # Test for #3391


### PR DESCRIPTION
Suggested fix for both #3518 and #3534.

Any idea on how we could fetch a product from the line item using one query only? the same way `has_one :product, through: :variant` does.

ps. 2-0-stable need the fix as well
