### PR TITLE
[backend] Layout customer page fix.

### DIFF
--- a/backend/app/views/spree/admin/orders/customer_details/_form.html.erb
+++ b/backend/app/views/spree/admin/orders/customer_details/_form.html.erb
@@ -1,8 +1,8 @@
 <fieldset data-hook="admin_customer_detail_form_fields" class="no-border-top">
-  
+
   <fieldset class="index no-border-bottom" data-hook="customer_guest">
     <legend align="center"><%= Spree.t(:account) %></legend>
-      
+
     <div data-hook="customer_fields" class="row">
       <div class="alpha eight columns">
         <div class="field">
@@ -12,7 +12,7 @@
       </div>
       <div class="omega four columns">
         <div class="field">
-          <%= label_tag nil, Spree.t(:guest_checkout) %>:
+          <%= label_tag nil, "#{Spree.t(:guest_checkout)}:" %>
           <ul>
             <% if @order.completed? %>
               <li>
@@ -22,12 +22,12 @@
               <% guest = @order.user.nil? || @order.user.anonymous? %>
               <li>
                 <%= radio_button_tag :guest_checkout, true, guest %>
-                <%= Spree.t(:say_yes) %>
+                <%= label_tag :guest_checkout_true, Spree.t(:say_yes) %>
               </li>
               <li>
                 <%= radio_button_tag :guest_checkout, false, !guest, :disabled => @order.cart? %>
-                <%= Spree.t(:say_no) %>  
-              </li>              
+                <%= label_tag :guest_checkout_false, Spree.t(:say_no) %>
+              </li>
               <%= hidden_field_tag :user_id, @order.user_id %>
             <% end %>
           </ul>
@@ -44,13 +44,13 @@
       <% end %>
     </fieldset>
   </div>
-  
+
   <div class="omega six columns" data-hook="ship_address_wrapper">
     <fieldset class="no-border-bottom">
       <legend align="center"><%= Spree.t(:shipping_address) %></legend>
       <%= f.fields_for :ship_address do |sa_form| %>
         <%= render :partial => 'spree/admin/shared/address_form', :locals => { :f => sa_form, :name => Spree.t(:shipping_address), :use_billing => true } %>
-      <% end %>    
+      <% end %>
     </fieldset>
   </div>
 


### PR DESCRIPTION
- page: admin/orders/{order.number}/customer
- issue: colon was left out of styling and 'Yes' and 'No' had no
  styling nor label.

It need this css also for extra tweak but no clue where to place it, i use it in my admin override style.

``` css
.field ul li label {
    text-transform: uppercase;
    font-weight: 600;
}
```

![screen shot 2013-08-12 at 05 27 32](https://f.cloud.github.com/assets/66969/945257/306ecae6-02ff-11e3-8425-31bb994b3719.png)
