### PR TITLE
[backend] Layout promotions fix.

### DIFF
--- a/backend/app/views/spree/admin/promotions/_form.html.erb
+++ b/backend/app/views/spree/admin/promotions/_form.html.erb
@@ -32,7 +32,7 @@
       <%= f.field_container :description do %>
         <%= f.label :description %><br />
         <%= f.text_area :description, :rows => 7, :class => 'fullwidth' %>
-      <% end %>      
+      <% end %>
     </div>
   </div>
 
@@ -40,9 +40,11 @@
     <%= f.field_container :usage_limit do %>
       <%= f.label :usage_limit %><br />
       <%= f.number_field :usage_limit, :min => 0, :class => 'fullwidth' %><br>
-      <%= Spree.t(:current_promotion_usage, :count => @promotion.credits_count) %>
+      <span class="info">
+        <%= Spree.t(:current_promotion_usage, :count => @promotion.credits_count) %>
+      </span>
     <% end %>
-    
+
     <div id="starts_at_field" class="field">
       <%= f.label :starts_at %>
       <%= f.text_field :starts_at, :value => datepicker_field_value(@promotion.starts_at), :class => 'datepicker datepicker-from fullwidth' %>


### PR DESCRIPTION
- page: admin/promotions/new
- issue: Add missing span info tag around help text

![screen shot 2013-08-12 at 05 38 04](https://f.cloud.github.com/assets/66969/945283/a78535c4-0300-11e3-8284-3e1f00c2890a.png)
