### PR TITLE
Fix `ProductFilters.brand_filter` example (green frontend build again)

### DIFF
--- a/core/lib/spree/core/product_filters.rb
+++ b/core/lib/spree/core/product_filters.rb
@@ -109,7 +109,7 @@ module Spree
 
         def ProductFilters.brand_filter
           brand_property = Spree::Property.find_by(name: 'brand')
-          brands = Spree::ProductProperty.where(property: brand_property).pluck(:value).uniq.map(&:to_s)
+          brands = Spree::ProductProperty.where(property_id: brand_property.try(:id)).pluck(:value).uniq.map(&:to_s)
           pp = Spree::ProductProperty.arel_table
           conds = Hash[*brands.map { |b| [b, pp[:value].eq(b)] }.flatten]
           {

--- a/frontend/spec/controllers/spree/orders_controller_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_spec.rb
@@ -60,7 +60,7 @@ describe Spree::OrdersController do
         order.stub(:line_items).and_return([])
         order.stub(:line_items=).with([])
         order.stub(:last_ip_address=)
-        Spree::Order.stub(:find_by_id_and_currency).and_return(order)
+        Spree::Order.stub_chain(:includes, find_by: order)
       end
 
       it "should not result in a flash success" do


### PR DESCRIPTION
frontend build broke after f02d25566d42f06d2ceea596ff9823d5ad06da67
which highlighted the issue here (we can't pass an object as a value to
a `property_id` key (or we shouldn't)
