### PR TITLE
Attemp to fix random failing specs on CI

### DIFF
--- a/backend/spec/features/admin/orders/shipments_spec.rb
+++ b/backend/spec/features/admin/orders/shipments_spec.rb
@@ -41,13 +41,13 @@ describe "Shipments" do
       targetted_select2 'LA', from: '#s2id_item_stock_location'
       click_icon :ok
       wait_for_ajax
-      page.should have_selector("#shipment_#{order.shipments.first.id}")
+      expect(page.find("#shipment_#{order.shipments.first.id}")).to be_present
 
       within_row(2) { click_icon 'resize-horizontal' }
       targetted_select2 "LA(#{order.reload.shipments.last.number})", from: '#s2id_item_stock_location'
       click_icon :ok
       wait_for_ajax
-      page.should have_selector("#shipment_#{order.reload.shipments.last.id}")
+      expect(page.find("#shipment_#{order.reload.shipments.last.id}")).to be_present
     end
   end
 end

--- a/backend/spec/features/admin/products/edit/taxons_spec.rb
+++ b/backend/spec/features/admin/products/edit/taxons_spec.rb
@@ -36,7 +36,9 @@ describe "Product Taxons" do
       selected_taxons.should =~ [taxon_1.id, taxon_2.id]
 
       # Regression test for #2139
-      all("#s2id_product_taxon_ids .select2-search-choice").count.should == 2
+      sleep(1)
+      expect(first(".select2-search-choice", text: taxon_1.name)).to be_present
+      expect(first(".select2-search-choice", text: taxon_2.name)).to be_present
     end
   end
 end


### PR DESCRIPTION
Capybara first will wait a bit for those inputs to be displayed.
Hopefully it's enough time to make it stop failing randomly in CI

I've seen these two specs fail quite frequently for a while in CI which is kind of annoying because we always have to look into the build logs to make sure none of the others failed too. Just ran four builds with this patch and it seems they no longer fail. Let me know if you've got any other idea on how to address this issue.
