### PR TITLE
Remove ForbiddenAttributesProtection module from Order

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -4,7 +4,6 @@ require 'spree/order/checkout'
 module Spree
   class Order < ActiveRecord::Base
     include Checkout
-    include ActiveModel::ForbiddenAttributesProtection
 
     checkout_flow do
       go_to_state :address


### PR DESCRIPTION
Left over from master rebase on rails4 branch, we don't need that any
longer
