### PR TITLE
Calculators work against LineItems

### DIFF
--- a/core/app/models/spree/calculator.rb
+++ b/core/app/models/spree/calculator.rb
@@ -35,5 +35,18 @@ module Spree
     def available?(object)
       true
     end
+
+
+    private
+
+    # Given an object which might be an Order or a LineItem (amongst
+    # others), return a collection of line items.
+    def line_items_for(object)
+      if object.respond_to? :line_items
+        object.line_items
+      else
+        [object]
+      end
+    end
   end
 end

--- a/core/app/models/spree/calculator/flat_percent_item_total.rb
+++ b/core/app/models/spree/calculator/flat_percent_item_total.rb
@@ -11,8 +11,7 @@ module Spree
     end
 
     def compute(object)
-      return unless object.present? and object.line_items.present?
-      item_total = object.line_items.map(&:amount).sum
+      item_total = line_items_for(object).map(&:amount).sum
       value = item_total * BigDecimal(self.preferred_flat_percent.to_s) / 100.0
       (value * 100).round.to_f / 100
     end

--- a/core/app/models/spree/calculator/flexi_rate.rb
+++ b/core/app/models/spree/calculator/flexi_rate.rb
@@ -20,7 +20,7 @@ module Spree
     def compute(object)
       sum = 0
       max = self.preferred_max_items.to_i
-      items_count = object.line_items.map(&:quantity).sum
+      items_count = line_items_for(object).map(&:quantity).sum
       items_count.times do |i|
         # check max value to avoid divide by 0 errors
         if (max == 0 && i == 0) || (max > 0) && (i % max == 0)

--- a/core/app/models/spree/calculator/per_item.rb
+++ b/core/app/models/spree/calculator/per_item.rb
@@ -13,7 +13,7 @@ module Spree
 
     def compute(object=nil)
       return 0 if object.nil?
-      self.preferred_amount * object.line_items.reduce(0) do |sum, value|
+      self.preferred_amount * line_items_for(object).reduce(0) do |sum, value|
         if matching_products.blank? || matching_products.include?(value.product)
           value_to_add = value.quantity
         else

--- a/core/lib/spree/core/controller_helpers/respond_with.rb
+++ b/core/lib/spree/core/controller_helpers/respond_with.rb
@@ -8,7 +8,7 @@ module ActionController
         options = resources.size == 1 ? {} : resources.extract_options!
 
 
-        if defined_response = collector.response and !(Spree::BaseController.spree_responders[self.class.to_s.to_sym].try(:[], action_name.to_sym)
+        if defined_response = collector.response and !(Spree::BaseController.spree_responders[self.class.to_s.to_sym].try(:[], action_name.to_sym))
           if action = options.delete(:action)
             render :action => action
           else

--- a/core/lib/spree/core/controller_helpers/respond_with.rb
+++ b/core/lib/spree/core/controller_helpers/respond_with.rb
@@ -7,7 +7,8 @@ module ActionController
       if collector = retrieve_collector_from_mimes(&block)
         options = resources.size == 1 ? {} : resources.extract_options!
 
-        if defined_response = collector.response and !Spree::BaseController.spree_responders.keys.include?(self.class.to_s.to_sym)
+
+        if defined_response = collector.response and !(Spree::BaseController.spree_responders[self.class.to_s.to_sym].try(:[], action_name.to_sym)
           if action = options.delete(:action)
             render :action => action
           else

--- a/core/spec/models/calculator/flat_percent_item_total_spec.rb
+++ b/core/spec/models/calculator/flat_percent_item_total_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe Spree::Calculator::FlatPercentItemTotal do
   let(:calculator) { Spree::Calculator::FlatPercentItemTotal.new }
-  let(:order) { mock_model Spree::Order, :line_items => [mock_model(Spree::LineItem, :amount => 10), mock_model(Spree::LineItem, :amount => 20)] }
+  let(:line_item1) { mock_model(Spree::LineItem, :amount => 10) }
+  let(:line_item2) { mock_model(Spree::LineItem, :amount => 20) }
+  let(:order) { mock_model Spree::Order, :line_items => [line_item1, line_item2] }
 
   before { calculator.stub :preferred_flat_percent => 10 }
 
@@ -17,6 +19,10 @@ describe Spree::Calculator::FlatPercentItemTotal do
 
       order.stub :line_items => [mock_model(Spree::LineItem, :amount => 10.56), mock_model(Spree::LineItem, :amount => 20.48)]
       calculator.compute(order).should == 3.10
+    end
+
+    it "should compute amount correctly for a single line item" do
+      calculator.compute(line_item1).should == 1.0
     end
   end
 end

--- a/core/spec/models/calculator/flexi_rate_spec.rb
+++ b/core/spec/models/calculator/flexi_rate_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe Spree::Calculator::FlexiRate do
   let(:calculator) { Spree::Calculator::FlexiRate.new }
-  let(:order) { mock_model Spree::Order, :line_items => [mock_model(Spree::LineItem, :amount => 10, :quantity => 4), mock_model(Spree::LineItem, :amount => 20, :quantity => 6)] }
+  let(:line_item1) { mock_model(Spree::LineItem, :amount => 10, :quantity => 4) }
+  let(:line_item2) { mock_model(Spree::LineItem, :amount => 20, :quantity => 6) }
+  let(:order) { mock_model Spree::Order, :line_items => [line_item1, line_item2] }
 
   context "compute" do
     it "should compute amount correctly when all fees are 0" do
@@ -29,8 +31,15 @@ describe Spree::Calculator::FlexiRate do
       calculator.compute(order).round(2).should == 26.0
     end
 
-    it "should allow creation of new object with all the attributes" do
-      Spree::Calculator::FlexiRate.new(:preferred_first_item => 1, :preferred_additional_item => 1, :preferred_max_items => 1)
+    context "computing for a single line item" do
+      it "should return the first item rate" do
+        calculator.stub :preferred_first_item => 1.0
+        calculator.compute(line_item1).round(2).should == 1.0
+      end
     end
+  end
+
+  it "should allow creation of new object with all the attributes" do
+    Spree::Calculator::FlexiRate.new(:preferred_first_item => 1, :preferred_additional_item => 1, :preferred_max_items => 1)
   end
 end

--- a/core/spec/models/calculator/per_item_spec.rb
+++ b/core/spec/models/calculator/per_item_spec.rb
@@ -26,9 +26,14 @@ describe Spree::Calculator::PerItem do
     calculator.compute(object).to_f.should == 50 # 5 x 10
   end
 
-  it 'correctly calculates per item promotion with no rules i.e. no product restrictions' do
+  it "correctly calculates per item promotion with no rules i.e. no product restrictions" do
     calculator.stub(:calculable => double("Calculable", :promotion => promotion_without_rules))
     calculator.compute(object).to_f.should == 80 # 5 x 10 + 3 x 10
+  end
+
+  it "correctly calculates on a single line item object" do
+    calculator.stub(:calculable => shipping_calculable)
+    calculator.compute(line_items.first).to_f.should == 50 # 5 x 10
   end
 
   it "returns 0 when no object passed" do

--- a/core/spec/models/calculator/price_sack_spec.rb
+++ b/core/spec/models/calculator/price_sack_spec.rb
@@ -11,6 +11,7 @@ describe Spree::Calculator::PriceSack do
 
   let(:order) { stub_model(Spree::Order) }
   let(:shipment) { stub_model(Spree::Shipment) }
+  let(:line_item) { stub_model(Spree::LineItem, price: 1, quantity: 2) }
 
   # Regression test for #714 and #739
   it "computes with an order object" do
@@ -20,6 +21,10 @@ describe Spree::Calculator::PriceSack do
   # Regression test for #1156
   it "computes with a shipment object" do
     calculator.compute(shipment)
+  end
+
+  it "computes with a line item object" do
+    calculator.compute(line_item)
   end
 
   # Regression test for #2055


### PR DESCRIPTION
Presently, if you try to make adjustments that are calculated against individual line items, the calculators provided by Spree fail because they are designed to be run against Orders (with the exception of DefaultTax). This pull request makes them more flexible so that they can run against either Orders or LineItems.

Known issues:

The FlatRate calculator is labelled "Flat Rate (per order)". In this pull request, I've made the FlatRate calculator compatible with a line item input, but it seems to me like an unnatural pairing, and there is some unintuitive behaviour that results. Perhaps it'd be less confusing to not allow the calculator to work with line items in the first place.
