### PR TITLE
add attr_accessible that is used by seed

### DIFF
--- a/core/app/models/spree/country.rb
+++ b/core/app/models/spree/country.rb
@@ -3,6 +3,8 @@ module Spree
     has_many :states, -> { order('name ASC') }
 
     validates :name, :iso_name, presence: true
+    
+    attr_accessible :name, :iso3, :iso, :iso_name, :numcode
 
     def self.states_required_by_country_id
       states_required = Hash.new(true)


### PR DESCRIPTION
Ran `spree:install` and the seed failed due to mass-assignment of fields in `Spree::Country`. Simply added the `attr_accessible` to `Spree::Country`.

---

Output from the exec:

```
bundle exec rails g spree:install
      create  config/initializers/spree.rb
      create  config/spree.yml
      remove  public/index.html
      append  public/robots.txt
      create  app/assets/javascripts/store
      create  app/assets/javascripts/admin
      create  app/assets/stylesheets/store
      create  app/assets/stylesheets/admin
      create  app/assets/images/store
      create  app/assets/images/admin
      create  app/assets/javascripts/store/all.js
      create  app/assets/stylesheets/store/all.css
      create  app/assets/javascripts/admin/all.js
      create  app/assets/stylesheets/admin/all.css
      create  app/overrides
      append  db/seeds.rb
     copying  migrations
    creating  database
     running  migrations
     loading  seed data
        rake  db:seed 
loading ruby /home/zinger/.rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/bundler/gems/spree-4059a35c41e4/core/db/default/spree/countries.rb
rake aborted!
Validation failed: Name can't be blank, ISO Name can't be blank
/home/tmp/blah/db/seeds.rb:10:in `<top (required)>'
Tasks: TOP => db:load_dir
(See full trace by running task with --trace)
     loading  sample data
      insert  config/routes.rb
**************************************************
We added the following line to your application's config/routes.rb file:

    mount Spree::Core::Engine, :at => '/'
**************************************************
Spree has been installed successfully. You're all ready to go!

Enjoy!
```
