### PR TITLE
add attr_accessible :name that is used by seed for Spree::SotckLocation

### DIFF
--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -9,6 +9,8 @@ module Spree
     validates_presence_of :name
 
     scope :active, -> { where(active: true) }
+    
+    attr_accessible :name
 
     after_create :create_stock_items, :if => "self.propagate_all_variants?"
 


### PR DESCRIPTION
Using a fresh set of migrations off of the master branch from `bundle exec rake railties:install:migrations` I got an error `Can't mass-assign protected attributes for Spree::StockLocation`. I simply added the `attr_accessible :name` and the migrations work succesfully.

---

Output from rake db:migrate using jruby 1.7,3

```
==  CreateDefaultStock: migrating =============================================
rake aborted!
An error has occurred, all later migrations canceled:

Can't mass-assign protected attributes for Spree::StockLocation: name
path/db/migrate/20130814023858_create_default_stock.spree.rb:6:in `up'
org/jruby/RubyBasicObject.java:1677:in `__send__'
org/jruby/RubyKernel.java:2103:in `send'
org/jruby/RubyArray.java:1613:in `each'
org/jruby/RubyProc.java:249:in `call'
org/jruby/RubyArray.java:1613:in `each'
org/jruby/RubyArray.java:1613:in `each'
org/jruby/RubyKernel.java:1046:in `load'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)
```
