### PR TITLE
strong_params: Simpler modification of allowed params

### DIFF
--- a/core/lib/spree/core/controller_helpers/strong_parameters.rb
+++ b/core/lib/spree/core/controller_helpers/strong_parameters.rb
@@ -2,111 +2,33 @@ module Spree
   module Core
     module ControllerHelpers
       module StrongParameters
-        def permitted_order_attributes
-          [:line_items_attributes => permitted_line_item_attributes].push permitted_checkout_attributes
+        def permitted_attributes
+          Spree::PermittedAttributes
         end
 
-        def permitted_line_item_attributes
-          [:id, :variant_id, :quantity]
-        end
-
-        def permitted_address_attributes
-           [:firstname, :lastname, :address1, :address2,
-            :city, :country_id, :state_id, :zipcode, :phone,
-            :state_name, :alternative_phone, :company]
-        end
-
-        def permitted_source_attributes
-          [:number, :month, :year, :verification_value,
-           :first_name, :last_name]
-        end
+        delegate *Spree::PermittedAttributes::ATTRIBUTES,
+                 :to => :permitted_attributes,
+                 :prefix => :permitted
 
         def permitted_payment_attributes
-          [:amount, :payment_method_id, :source_attributes => permitted_source_attributes]
+          permitted_attributes.payment_attributes + [
+            :source_attributes => permitted_source_attributes
+          ]
         end
 
         def permitted_checkout_attributes
-          [:email, :use_billing, :shipping_method_id, :coupon_code,
-           :bill_address_attributes => permitted_address_attributes,
-           :ship_address_attributes => permitted_address_attributes,
-           :payments_attributes => permitted_payment_attributes,
-           :shipments_attributes => permitted_shipment_attributes]
+          permitted_attributes.checkout_attributes + [
+            :bill_address_attributes => permitted_address_attributes,
+            :ship_address_attributes => permitted_address_attributes,
+            :payments_attributes => permitted_payment_attributes,
+            :shipments_attributes => permitted_shipment_attributes
+          ]
         end
 
-        def permitted_image_attributes
-          [:alt, :attachment, :position, :viewable_type, :viewable_id]
-        end
-
-        def permitted_inventory_unit_attributes
-          [:shipment, :variant_id]
-        end
-
-        def permitted_option_type_attributes
-          [:name, :presentation, :option_values_attributes]
-        end
-
-        def permitted_option_value_attributes
-          [:name, :presentation]
-        end
-
-        def permitted_product_properties_attributes
-          [:property_name, :value, :position]
-        end
-
-        def permitted_product_attributes
-          [:name, :description, :available_on, :permalink, :meta_description,
-           :meta_keywords, :price, :sku, :deleted_at, :prototype_id,
-           :option_values_hash, :weight, :height, :width, :depth,
-           :shipping_category_id, :tax_category_id, :product_properties_attributes,
-           :variants_attributes, :taxon_ids, :option_type_ids, :cost_currency, :cost_price]
-        end
-
-        def permitted_property_attributes
-          [:name, :presentation]
-        end
-
-        def permitted_return_authorization_attributes
-          [:amount, :reason, :stock_location_id]
-        end
-
-        def permitted_shipment_attributes
-          [:order, :special_instructions, :stock_location_id, :id,
-           :tracking, :address, :inventory_units, :selected_shipping_rate_id]
-        end
-
-        def permitted_stock_item_attributes
-          [:variant, :stock_location, :backorderable, :variant_id]
-        end
-
-        def permitted_stock_location_attributes
-          [:name, :active, :address1, :address2, :city, :zipcode,
-           :backorderable_default, :state_name, :state_id, :country_id, :phone,
-           :propagate_all_variants]
-        end
-
-        def permitted_stock_movement_attributes
-          [:quantity, :stock_item, :stock_item_id, :originator, :action]
-        end
-
-        def permitted_taxonomy_attributes
-          [:name]
-        end
-
-        def permitted_taxon_attributes
-          [:name, :parent_id, :position, :icon, :description, :permalink, :taxonomy_id,
-           :meta_description, :meta_keywords, :meta_title]
-        end
-
-        # TODO Should probably use something like Spree.user_class.permitted_attributes
-        def permitted_user_attributes
-          [:email, :password, :password_confirmation]
-        end
-
-        def permitted_variant_attributes
-          [:name, :presentation, :cost_price, :lock_version,
-           :position, :option_value_ids,
-           :product_id, :option_values_attributes, :price,
-           :weight, :height, :width, :depth, :sku, :cost_currency]
+        def permitted_order_attributes
+          permitted_checkout_attributes + [
+            :line_items_attributes => permitted_line_item_attributes
+          ]
         end
       end
     end

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -1,0 +1,94 @@
+module Spree
+  module PermittedAttributes
+    ATTRIBUTES = [
+      :address_attributes,
+      :checkout_attributes,
+      :image_attributes,
+      :inventory_unit_attributes,
+      :line_item_attributes,
+      :option_type_attributes,
+      :option_value_attributes,
+      :payment_attributes,
+      :product_attributes,
+      :product_properties_attributes,
+      :property_attributes,
+      :return_authorization_attributes,
+      :shipment_attributes,
+      :source_attributes,
+      :stock_item_attributes,
+      :stock_location_attributes,
+      :stock_movement_attributes,
+      :taxon_attributes,
+      :taxonomy_attributes,
+      :user_attributes,
+      :variant_attributes
+    ]
+
+    mattr_reader *ATTRIBUTES
+
+    @@address_attributes = [
+      :firstname, :lastname, :address1, :address2,
+      :city, :country_id, :state_id, :zipcode, :phone,
+      :state_name, :alternative_phone, :company]
+
+    @@checkout_attributes = [:email, :use_billing, :shipping_method_id, :coupon_code]
+
+    @@image_attributes = [:alt, :attachment, :position, :viewable_type, :viewable_id]
+
+    @@inventory_unit_attributes = [:shipment, :variant_id]
+
+    @@line_item_attributes = [:id, :variant_id, :quantity]
+
+    @@option_type_attributes = [:name, :presentation, :option_values_attributes]
+
+    @@option_value_attributes = [:name, :presentation]
+
+    @@payment_attributes = [:amount, :payment_method_id]
+
+    @@product_properties_attributes = [:property_name, :value, :position]
+
+    @@product_attributes = [
+      :name, :description, :available_on, :permalink, :meta_description,
+      :meta_keywords, :price, :sku, :deleted_at, :prototype_id,
+      :option_values_hash, :weight, :height, :width, :depth,
+      :shipping_category_id, :tax_category_id, :product_properties_attributes,
+      :variants_attributes, :taxon_ids, :option_type_ids, :cost_currency, :cost_price]
+
+    @@property_attributes = [:name, :presentation]
+
+    @@return_authorization_attributes = [:amount, :reason, :stock_location_id]
+
+    @@shipment_attributes = [
+      :order, :special_instructions, :stock_location_id, :id,
+      :tracking, :address, :inventory_units, :selected_shipping_rate_id]
+
+    @@source_attributes = [
+      :number, :month, :year, :verification_value,
+      :first_name, :last_name]
+
+    @@stock_item_attributes = [:variant, :stock_location, :backorderable, :variant_id]
+
+    @@stock_location_attributes = [
+      :name, :active, :address1, :address2, :city, :zipcode,
+      :backorderable_default, :state_name, :state_id, :country_id, :phone,
+      :propagate_all_variants]
+
+    @@stock_movement_attributes = [
+      :quantity, :stock_item, :stock_item_id, :originator, :action]
+
+    @@taxonomy_attributes = [:name]
+
+    @@taxon_attributes = [
+      :name, :parent_id, :position, :icon, :description, :permalink, :taxonomy_id,
+      :meta_description, :meta_keywords, :meta_title]
+
+    # TODO Should probably use something like Spree.user_class.attributes
+    @@user_attributes = [:email, :password, :password_confirmation]
+
+    @@variant_attributes = [
+      :name, :presentation, :cost_price, :lock_version,
+      :position, :option_value_ids,
+      :product_id, :option_values_attributes, :price,
+      :weight, :height, :width, :depth, :sku, :cost_currency]
+  end
+end


### PR DESCRIPTION
With existing `ControllerHelpers::PermittedAttributes`, adding additional permitted attributes can only be done by overriding the method. To be done safely in extensions, this would rely on a lot of method aliasing.

This introduces `Spree::PermittedAttributes`, which has as module attributes for the the accessible attributes on the spree models. This is easily modifiable by spree applications or extensions.

```
Spree::PermittedAttributes.line_item_attributes << :my_custom_attribute
```

`ControllerHelpers::StrongParameters` contains the same methods as before but mostly delegates to `Spree::PermittedAttributes`. The controller helpers also describe the allowed nested attributes.

For more complex customization (ex. permissions depending on role), controllers can still override  `permitted_attributes` with `SimpleDelegator` (or similar) or override `permitted_*_attributes` methods themselves to modify the attributes on a per request basis.

Thanks to Hates, Radar, huoxito, and jstrong in #spree for quick discussion.
