### PR TITLE
Fix broken page display in item transfer from one shipment to another

### DIFF
--- a/backend/app/assets/javascripts/admin/variant_autocomplete.js.erb
+++ b/backend/app/assets/javascripts/admin/variant_autocomplete.js.erb
@@ -180,8 +180,6 @@ completeItemSplit = function(event) {
       async: false,
       url: Spree.url(Spree.routes.orders_api + "/" + order_number + "/shipments/" + original_shipment_number + "/remove.json"),
       data: { variant_id: variant_id, quantity: quantity }
-    }).done(function(msg) {
-      window.location.reload();
     });
 
     if (new_shipment != undefined) {
@@ -190,6 +188,8 @@ completeItemSplit = function(event) {
         async: false,
         url: Spree.url(Spree.routes.orders_api + "/" + order_number + "/shipments.json"),
         data: { variant_id: variant_id, quantity: quantity, stock_location_id: stock_location_id }
+      }).done(function(msg) {
+        window.location.reload();
       });
     } else {
       $.ajax({
@@ -197,6 +197,8 @@ completeItemSplit = function(event) {
         async: false,
         url: Spree.url(Spree.routes.orders_api + "/" + order_number + "/shipments/" + target_shipment_number + "/add.json"),
         data: { variant_id: variant_id, quantity: quantity }
+      }).done(function(msg) {
+        window.location.reload();
       });
     }
   }

--- a/backend/spec/features/admin/orders/shipments_spec.rb
+++ b/backend/spec/features/admin/orders/shipments_spec.rb
@@ -26,7 +26,6 @@ describe "Shipments" do
   context "moving variants between shipments", js: true do
     let!(:la) { create(:stock_location, name: "LA") }
     before(:each) do
-      create(:stock_location, name: "LA")
       visit spree.admin_path
       click_link "Orders"
       within_row(1) do


### PR DESCRIPTION
When a shipment is split, and an item is transferred from one shipment to another, there are two AJAX calls.  The first removes the item from the original shipment, while the second adds the item to the target shipment (potentially creating a new shipment in the process).

Currently the page reloads after the first of these AJAX calls, not after the second.  This means that the transferred item 'disappears' from the page, and is not displayed in the target shipment.  If the target shipment is new, then the shipment doesn't appear on the page either.

Shifting the page reload to the 'done' method of the second request resolves this issue.  There was already a failing test covering this, and resolution of this issue makes this test green.

Also removed an extraneous create(:stock_location, name: "LA") from the spec, as the one in the let! was getting invoked already.
