### PR TITLE
Fix spec failing on quote type used in database - allow both " and ` in regexp match

### DIFF
--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -131,13 +131,13 @@ describe Spree::Product do
     describe 'Variants sorting' do
       context 'without master variant' do
         it 'sorts variants by position' do
-          product.variants.to_sql.should match(/ORDER BY \"spree_variants\".position ASC/)
+          product.variants.to_sql.should match(/ORDER BY (\`|\")spree_variants(\`|\").position ASC/)
         end
       end
 
       context 'with master variant' do
         it 'sorts variants by position' do
-          product.variants_including_master.to_sql.should match(/ORDER BY \"spree_variants\".position ASC/)
+          product.variants_including_master.to_sql.should match(/ORDER BY (\`|\")spree_variants(\`|\").position ASC/)
         end
       end
     end


### PR DESCRIPTION
SQL can use different quote types depending on the database.  MySQL uses backticks.  Change regexp in spec to recognize either double quotes or backticks as valid.

This fixes a failing spec on the MySQL core CI run.
