### PR TITLE
Add explicit ordering to taxons returned by API

### DIFF
--- a/api/app/controllers/spree/api/taxons_controller.rb
+++ b/api/app/controllers/spree/api/taxons_controller.rb
@@ -8,7 +8,7 @@ module Spree
           if params[:ids]
             @taxons = Spree::Taxon.accessible_by(current_ability, :read).where(id: params[:ids].split(','))
           else
-            @taxons = Spree::Taxon.accessible_by(current_ability, :read).ransack(params[:q]).result
+            @taxons = Spree::Taxon.accessible_by(current_ability, :read).order(:taxonomy_id, :lft).ransack(params[:q]).result
           end
         end
         respond_with(@taxons)


### PR DESCRIPTION
Add an explicit ordering to the taxons rather than depending on the implicit ordering in the database.  Previously this ordering was dependent on the database, and because Postgres did not implement the expected ordering the spec was failing.

Ordering was chosen for top-down, left to right ordering of taxons in the order in which taxonomies were defined.  This fixes a failing spec in Postgres.
