### PR TITLE
capybara 2.1 requires visible: false to match elements in <head>

### DIFF
--- a/core/lib/spree/testing_support/capybara_ext.rb
+++ b/core/lib/spree/testing_support/capybara_ext.rb
@@ -104,7 +104,7 @@ end
 
 RSpec::Matchers.define :have_meta do |name, expected|
   match do |actual|
-    has_css?("meta[name='#{name}'][content='#{expected}']")
+    has_css?("meta[name='#{name}'][content='#{expected}']", visible: false)
   end
 
   failure_message_for_should do |actual|
@@ -119,7 +119,7 @@ end
 
 RSpec::Matchers.define :have_title do |expected|
   match do |actual|
-    has_css?("title", :text => expected)
+    has_css?("title", :text => expected, visible: false)
   end
 
   failure_message_for_should do |actual|


### PR DESCRIPTION
update custom matchers to do this
