### PR TITLE
Restore TestMailer

### DIFF
--- a/backend/app/controllers/spree/admin/mail_methods_controller.rb
+++ b/backend/app/controllers/spree/admin/mail_methods_controller.rb
@@ -18,7 +18,7 @@ module Spree
       end
 
       def testmail
-        if TestMailer.test_email(try_spree_current_user.try(:id)).deliver
+        if TestMailer.test_email(try_spree_current_user.id).deliver
           flash[:success] = Spree.t('admin.mail_methods.testmail.delivery_success')
         else
           flash[:error] = Spree.t('admin.mail_methods.testmail.delivery_error')

--- a/backend/app/controllers/spree/admin/mail_methods_controller.rb
+++ b/backend/app/controllers/spree/admin/mail_methods_controller.rb
@@ -18,7 +18,7 @@ module Spree
       end
 
       def testmail
-        if TestMailer.test_email(try_spree_current_user).deliver
+        if TestMailer.test_email(try_spree_current_user.try(:id)).deliver
           flash[:success] = Spree.t('admin.mail_methods.testmail.delivery_success')
         else
           flash[:error] = Spree.t('admin.mail_methods.testmail.delivery_error')

--- a/backend/spec/controllers/spree/admin/mail_methods_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/mail_methods_controller_spec.rb
@@ -12,7 +12,7 @@ describe Spree::Admin::MailMethodsController do
 
   it "can trigger testmail" do
     request.env["HTTP_REFERER"] = "/"
-    user = double('User', email: 'user@spree.com', spree_api_key: 'fake')
+    user = create(:user, email: 'user@spree.com')
     controller.stub(:try_spree_current_user => user)
     Spree::Config[:enable_mail_delivery] = "1"
     ActionMailer::Base.perform_deliveries = true

--- a/core/app/mailers/spree/test_mailer.rb
+++ b/core/app/mailers/spree/test_mailer.rb
@@ -1,8 +1,9 @@
 module Spree
   class TestMailer < BaseMailer
     def test_email(user)
+      recipient = user.respond_to?(:id) ? user : Spree.user_class.find(user)
       subject = "#{Spree::Config[:site_name]} #{Spree.t('test_mailer.test_email.subject')}"
-      mail(to: user.email, from: from_address, subject: subject)
+      mail(to: recipient.email, from: from_address, subject: subject)
     end
   end
 end

--- a/core/app/views/spree/test_mailer/test_email.text.erb
+++ b/core/app/views/spree/test_mailer/test_email.text.erb
@@ -1,0 +1,4 @@
+<%= t('test_mailer.test_email.greeting') %>
+================
+
+<%= t('test_mailer.test_email.message') %>

--- a/core/spec/mailers/test_mailer_spec.rb
+++ b/core/spec/mailers/test_mailer_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+require 'email_spec'
+
+describe Spree::TestMailer do
+  include EmailSpec::Helpers
+  include EmailSpec::Matchers
+
+  let(:user) { create(:user) }
+
+  context ":from not set explicitly" do
+    it "falls back to spree config" do
+      message = Spree::TestMailer.test_email(user)
+      message.from.should == [Spree::Config[:mails_from]]
+    end
+  end
+
+  it "confirm_email accepts a user id as an alternative to a User object" do
+    Spree.user_class.should_receive(:find).with(user.id).and_return(user)
+    lambda {
+      test_email = Spree::TestMailer.test_email(user.id)
+    }.should_not raise_error
+  end
+end


### PR DESCRIPTION
The testmail function on the admin controller is broken because the view for the TestMailer was deleted.  Restored the functionality and made some compatibility changes.  Specifically:
1. Re-added test_mailer view so that TestMailer functions. 
2. Changed TestMailer to take an id, so it can support Resque/Sidekiq.
3. Updated controller to pass an id rather than the user object itself.  
4. Updated controller spec to use persisted user.
5. Added a spec for the TestMailer itself, to prevent regression.
