### PR TITLE
Migration no longer runs because of Spree::StockLocation validation

### DIFF
--- a/core/db/migrate/20130213191427_create_default_stock.rb
+++ b/core/db/migrate/20130213191427_create_default_stock.rb
@@ -2,7 +2,8 @@ class CreateDefaultStock < ActiveRecord::Migration
   def up
     Spree::StockLocation.skip_callback(:create, :after, :create_stock_items)
     Spree::StockItem.skip_callback(:save, :after, :process_backorders)
-    location = Spree::StockLocation.create(name: 'default')
+    location = Spree::StockLocation.new(name: 'default')
+    location.save(validate: false)
     Spree::Variant.all.each do |variant|
       stock_item = location.stock_items.build(variant: variant)
       stock_item.send(:count_on_hand=, variant.count_on_hand)


### PR DESCRIPTION
At some point after this migration was created, a number of additional columns (address1, etc.) were added to Spree::StockLocation.  And then validations were added on those new columns.

While this is certainly not a problem in general, it presents a problem when classes are created in migrations, as in this one.  When the Spree::StockLocation is created in this migration, the address1 column does not yet exist on this table (it's added in a later migration).  So the validation on this attribute fails, killing the migration.

This is causing failure when running specs on fresh checkouts of some extensions (spree_active_shipping, for one) and hence failing CI, etc.

While the best solution is probably to not create the object in the migration, we can ameliorate this particular case by simply skipping validation on the Spree::StockLocation instance.  This allows the migrations to run through.

So this change just skips validation on the 'default' Spree::StockLocation creation.
