### PR TITLE
Make AvailabilityValidator aware of inventory units

### DIFF
--- a/core/app/models/spree/stock/availability_validator.rb
+++ b/core/app/models/spree/stock/availability_validator.rb
@@ -2,9 +2,17 @@ module Spree
   module Stock
     class AvailabilityValidator < ActiveModel::Validator
       def validate(line_item)
+        if shipment = line_item.target_shipment
+          units = shipment.inventory_units_for(line_item.variant)
+          return if units.count > line_item.quantity
+          quantity = line_item.quantity - units.count
+        else
+          quantity = line_item.quantity
+        end
+
         quantifier = Stock::Quantifier.new(line_item.variant_id)
 
-        unless quantifier.can_supply? line_item.quantity
+        unless quantifier.can_supply? quantity
           variant = line_item.variant
           display_name = %Q{#{variant.name}}
           display_name += %Q{ (#{variant.options_text})} unless variant.options_text.blank?

--- a/core/spec/models/spree/stock/availability_validator_spec.rb
+++ b/core/spec/models/spree/stock/availability_validator_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module Spree
   module Stock
     describe AvailabilityValidator do
-      let!(:line_item) { double(quantity: 5, variant_id: 1, variant: double.as_null_object, errors: double('errors')) }
+      let!(:line_item) { double(quantity: 5, target_shipment: nil, variant_id: 1, variant: double.as_null_object, errors: double('errors')) }
 
       subject { described_class.new(nil) }
 


### PR DESCRIPTION
When checking stock from line items related to shipments and inventory
units we need to check stock according to the inventory units count and
not only to the line item quantity. e.g. typical case

```
Store has 5 of item A in stock
Customer purchases 5 of item A
Store creates 5 inventory units once order is completed
At this point item A is out of stock

Store admin wants to ship only 4 of Item A
Spree should be able to decrease that quantity and restock the item
```

The store don't need to check stock for Item A in that scenario because
it's actually decreasing the item quantity. In fact we need to restock 1
item back to the stock location

Possible fix for #3575 (2-0-stable also needs it). I think this still doesn't cover all cases. Users might still get unexpected results when a variant is spread into multiple shipments (via inventory units). It seems to me the best way to fix it 100% is to associate inventory units directly with line items. I'll investigate it further and try that approach later on.
