### PR TITLE
Improve message for missing shipping rates in checkout

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -592,7 +592,7 @@ en:
       operators:
         gt: greater than
         gte: greater than or equal to
-    items_cannot_be_shipped: We are unable to ship the selected items to your shipping address. Please choose another shipping address.
+    items_cannot_be_shipped: We are unable to calculate shipping rates for the selected items.
     jirafe: Jirafe
     landing_page_rule:
       path: Path


### PR DESCRIPTION
It feels pretty weird to have a default message that tells the customer
to "choose a different shipping address". I think we should just tell
explictly that the store cannot come up with any shipping rate. That
might be either because the shipping address is not covered or that the
taxes associated with products in cart are not properly associated with
any shipping method

Any ideas on how to improve the message? I believe strongly we should at least get rid of the _Please choose another shipping address_ part. this was mostly motivated by the discussion in #3521
