### PR TITLE
Fix core order/adjustment spec

### DIFF
--- a/core/spec/models/spree/order/adjustments_spec.rb
+++ b/core/spec/models/spree/order/adjustments_spec.rb
@@ -121,7 +121,8 @@ describe Spree::Order do
       end
 
       it "should return the adjustments for each line item" do
-        @order.line_item_adjustments.should == [@adj1, @adj2]
+        expect(@order.line_item_adjustments).to include @adj1
+        expect(@order.line_item_adjustments).to include @adj2
       end
     end
   end


### PR DESCRIPTION
It was failing most likely to the default ordering in postgres. I
changed it so that it doesn't depend on the order to be valid anymore

cc @jdutil
