### PR TITLE
Set promotion rules before app initializer

### DIFF
--- a/core/app/models/spree/promotion/rules/user.rb
+++ b/core/app/models/spree/promotion/rules/user.rb
@@ -2,8 +2,13 @@ module Spree
   class Promotion
     module Rules
       class User < PromotionRule
-        belongs_to :user, class_name: Spree.user_class.to_s
-        has_and_belongs_to_many :users, class_name: Spree.user_class.to_s, join_table: 'spree_promotion_rules_users', foreign_key: 'promotion_rule_id'
+        if Spree.user_class
+          belongs_to :user, class_name: Spree.user_class.to_s
+          has_and_belongs_to_many :users, class_name: Spree.user_class.to_s, join_table: 'spree_promotion_rules_users', foreign_key: 'promotion_rule_id'
+        else
+          belongs_to :user
+          has_and_belongs_to_many :users, join_table: 'spree_promotion_rules_users', foreign_key: 'promotion_rule_id'
+        end
 
         def eligible?(order, options = {})
           users.include?(order.user)

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -86,11 +86,7 @@ module Spree
         ]
       end
 
-      # Promotion rules need to be evaluated on after initialize otherwise
-      # Spree.user_class would be nil and users might experience errors related
-      # to malformed model associations (Spree.user_class is only defined on
-      # the app initializer)
-      config.after_initialize do
+      initializer 'spree.promo.register.promotion.calculators' do
         Rails.application.config.spree.promotions.rules.concat [
           Spree::Promotion::Rules::ItemTotal,
           Spree::Promotion::Rules::Product,


### PR DESCRIPTION
And add a check in Promotion::Rules::User so associations are only
loaded once the app has set Spree.user_class. That allow users to set
their promotions rules on the spree.rb initializer again. e.g.

```
Rails.application.config.spree.promotions.rules = [Spree::Promotion::Rules::Product]
```

2-0-stable needs this one too.
