### PR TITLE
Add default date display format if one is not defined in the locale file

### DIFF
--- a/backend/app/helpers/spree/admin/base_helper.rb
+++ b/backend/app/helpers/spree/admin/base_helper.rb
@@ -24,7 +24,7 @@ module Spree
 
       def datepicker_field_value(date)
         unless date.blank?
-          l(date, :format => Spree.t('date_picker.format'))
+          l(date, :format => Spree.t('date_picker.format', default: '%Y/%m/%d'))
         else
           nil
         end


### PR DESCRIPTION
Add a default format if no format is defined in the locale file.  Use the same default format as the datepicker gets in the translations partial.  This prevents display errors when using a number of the locales in spree_i18n that lack this value.
