### PR TITLE
Updates Order Import API

### DIFF
--- a/api/app/models/spree/order_decorator.rb
+++ b/api/app/models/spree/order_decorator.rb
@@ -151,4 +151,11 @@ Spree::Order.class_eval do
       raise "#{e.message} #{search}"
     end
   end
+
+  def update_line_items(line_item_params)
+    return if line_item_params.blank?
+    line_item_params.each do |id, attributes|
+      self.line_items.find(id).update_attributes!(attributes)
+    end
+  end
 end

--- a/api/app/models/spree/order_decorator.rb
+++ b/api/app/models/spree/order_decorator.rb
@@ -1,26 +1,154 @@
 Spree::Order.class_eval do
   def self.build_from_api(user, params)
-    line_items = params.delete(:line_items_attributes) || []
+    completed_at = params.delete(:completed_at)
+    line_items = params.delete(:line_items_attributes) || {}
+    shipments = params.delete(:shipments_attributes) || []
+    payments = params.delete(:payments_attributes) || []
+    adjustments = params.delete(:adjustments_attributes) || []
 
-    order = create(params)
+    ensure_country_id_from_api params[:ship_address_attributes]
+    ensure_state_id_from_api params[:ship_address_attributes]
+
+    ensure_country_id_from_api params[:bill_address_attributes]
+    ensure_state_id_from_api params[:bill_address_attributes]
+
+    order = create!(params)
     order.associate_user!(user)
 
-    unless line_items.empty?
-      line_items.each_key do |k|
-        line_item = line_items[k]
-        extra_params = line_item.except(:variant_id, :quantity)
-        line_item = order.contents.add(Spree::Variant.find(line_item[:variant_id]), line_item[:quantity])
-        line_item.update_attributes(extra_params) unless extra_params.empty?
-      end
-    end
+    order.create_shipments_from_api(shipments)
+    order.create_line_items_from_api(line_items)
+    order.create_adjustments_from_api(adjustments)
+    order.create_payments_from_api(payments)
+    order.complete_from_api(completed_at)
 
+    order.save!
     order
   end
 
-  def update_line_items(line_item_params)
-    return if line_item_params.blank?
-    line_item_params.each do |id, attributes|
-      self.line_items.find(id).update_attributes!(attributes)
+  def complete_from_api(completed_at)
+    if completed_at
+      self.completed_at = completed_at
+      self.state = 'complete'
+    end
+  end
+
+  def create_shipments_from_api(shipments_hash)
+    shipments_hash.each do |s|
+      begin
+        shipment = shipments.build
+        shipment.tracking = s[:tracking]
+
+        inventory_units = s[:inventory_units] || []
+        inventory_units.each do |iu|
+          self.class.ensure_variant_id_from_api(iu)
+
+          unit = shipment.inventory_units.build
+          unit.order = self
+          unit.variant_id = iu[:variant_id]
+        end
+
+        shipment.save!
+
+        shipping_method = Spree::ShippingMethod.find_by_name!(s[:shipping_method])
+        shipment.shipping_rates.create!(:shipping_method => shipping_method,
+                                        :cost => s[:cost])
+      rescue Exception => e
+        raise "#{e.message} #{s}"
+      end
+    end
+  end
+
+  def create_payments_from_api(payments_hash)
+    payments_hash.each do |p|
+      begin
+        payment = payments.build
+        payment.amount = p[:amount].to_f
+        payment.state = p.fetch(:state, 'completed')
+        payment.payment_method = Spree::PaymentMethod.find_by_name!(p[:payment_method])
+        payment.save!
+      rescue Exception => e
+        raise "#{e.message} #{p}"
+      end
+    end
+  end
+
+  def create_line_items_from_api(line_items_hash)
+    line_items_hash.each_key do |k|
+      begin
+        line_item = line_items_hash[k]
+        self.class.ensure_variant_id_from_api(line_item)
+
+        extra_params = line_item.except(:variant_id, :quantity)
+        line_item = self.contents.add(Spree::Variant.find(line_item[:variant_id]), line_item[:quantity])
+        line_item.update_attributes(extra_params) unless extra_params.empty?
+      rescue Exception => e
+        raise "#{e.message} #{line_item}"
+      end
+    end
+  end
+
+  def create_adjustments_from_api(adjustments)
+    adjustments.each do |a|
+      begin
+        adjustment = self.adjustments.build(:amount => a['amount'].to_f,
+                                            :label => a['label'])
+        adjustment.save!
+        adjustment.finalize!
+      rescue Exception => e
+        raise "#{e.message} #{a}"
+      end
+    end
+  end
+
+  def self.ensure_variant_id_from_api(hash)
+    begin
+      unless hash[:variant_id].present?
+        hash[:variant_id] = Spree::Variant.find_by_sku!(hash[:sku]).id
+        hash.delete(:sku)
+      end
+    rescue Exception => e
+      raise "#{e.message} #{hash}"
+    end
+  end
+
+  def self.ensure_country_id_from_api(address)
+    return if address.nil? or address[:country_id].present? or address[:country].nil?
+
+    begin
+      search = {}
+      if name = address[:country]['name']
+        search[:name] = name
+      elsif iso_name = address[:country]['iso_name']
+        search[:iso_name] = iso_name.upcase
+      elsif iso = address[:country]['iso']
+        search[:iso] = iso.upcase
+      elsif iso3 = address[:country]['iso3']
+        search[:iso3] = iso3.upcase
+      end
+
+      address.delete(:country)
+      address[:country_id] = Spree::Country.where(search).first!.id
+
+    rescue Exception => e
+      raise "#{e.message} #{search}"
+    end
+  end
+
+  def self.ensure_state_id_from_api(address)
+    return if address.nil? or address[:state_id].present? or address[:state].nil?
+
+    begin
+      search = {}
+      if name = address[:state]['name']
+        search[:name] = name
+      elsif abbr = address[:state]['abbr']
+        search[:abbr] = abbr.upcase
+      end
+
+      address.delete(:state)
+      address[:state_id] = Spree::State.where(search).first!.id
+    rescue Exception => e
+      raise "#{e.message} #{search}"
     end
   end
 end

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -79,7 +79,7 @@ module Spree
       # Regression test for #3404
       it "can specify additional parameters for a line item" do
         variant = create(:variant)
-        Order.should_receive(:create).and_return(order = Spree::Order.new)
+        Order.should_receive(:create!).and_return(order = Spree::Order.new)
         order.stub(:associate_user!)
         order.stub_chain(:contents, :add).and_return(line_item = double('LineItem'))
         line_item.should_receive(:update_attributes).with("special" => true)
@@ -96,7 +96,7 @@ module Spree
       # Regression test for #3404
       it "does not update line item needlessly" do
         variant = create(:variant)
-        Order.should_receive(:create).and_return(order = Spree::Order.new)
+        Order.should_receive(:create!).and_return(order = Spree::Order.new)
         order.stub(:associate_user!)
         order.stub_chain(:contents, :add).and_return(line_item = double('LineItem'))
         line_item.should_not_receive(:update_attributes)

--- a/api/spec/models/spree/order_spec.rb
+++ b/api/spec/models/spree/order_spec.rb
@@ -2,17 +2,216 @@ require 'spec_helper'
 
 module Spree
   describe Order do
-    let(:user) { stub_model(LegacyUser) }
-    let(:product) { create :product }
+    let!(:country) { FactoryGirl.create(:country) }
+    let!(:state) { country.states.first || FactoryGirl.create(:state, :country => country) }
+    let!(:stock_location) { FactoryGirl.create(:stock_location) }
 
-    it 'can build an order from API parameters' do
-      variant_id = product.master.id
-      order = Order.build_from_api(user, { :line_items_attributes => { "0" => { :variant_id => variant_id, :quantity => 5 }}})
+    let(:user) { stub_model(LegacyUser, :email => 'fox@mudler.com') }
+    let(:shipping_method) { create(:shipping_method) }
+    let(:payment_method) { create(:payment_method) }
+    let(:product) { product = Spree::Product.create(:name => 'Test',
+                                           :sku => 'TEST-1',
+                                           :price => 33.22)
+                    product.shipping_category = FactoryGirl.create(:shipping_category)
+                    product.save
+                    product }
+    let(:variant) { variant = product.master
+                    variant.stock_items.each { |si| si.update_attribute(:count_on_hand, 10) }
+                    variant }
+    let(:sku) { variant.sku }
+    let(:variant_id) { variant.id }
 
+    let(:line_items) {{ "0" => { :variant_id => variant.id, :quantity => 5 }}}
+    let(:ship_address) {{
+       :address1 => '123 Testable Way',
+       :firstname => 'Fox',
+       :lastname => 'Mulder',
+       :city => 'Washington',
+       :country_id => country.id,
+       :state_id => state.id,
+       :zipcode => '666',
+       :phone => '666-666-6666'
+    }}
+
+    it 'can import an order number' do
+      params = { number: '123-456-789' }
+      order = Order.build_from_api(user, params)
+      order.number.should eq '123-456-789'
+    end
+
+    it 'optionally add completed at' do
+      params = { email: 'test@test.com',
+                 completed_at: Time.now,
+                 line_items_attributes: line_items }
+
+      order = Order.build_from_api(user, params)
+      order.should be_completed
+      order.state.should eq 'complete'
+    end
+
+    it 'can build an order from API with just line items' do
+      params = { :line_items_attributes => line_items }
+
+      order = Order.build_from_api(user, params)
       order.user.should == nil
       line_item = order.line_items.first
       line_item.quantity.should == 5
       line_item.variant_id.should == variant_id
+    end
+
+    it 'handles line_item building exceptions' do
+      line_items['0'][:variant_id] = 'XXX'
+      params = { :line_items_attributes => line_items }
+
+      expect {
+        order = Order.build_from_api(user, params)
+      }.to raise_error /XXX/
+    end
+
+    it 'can build an order from API with variant sku' do
+      params = { :line_items_attributes => {
+                   "0" => { :sku => sku, :quantity => 5 } }}
+
+      order = Order.build_from_api(user, params)
+
+      line_item = order.line_items.first
+      line_item.variant_id.should == variant_id
+      line_item.quantity.should == 5
+    end
+
+    it 'handles exceptions when sku is not found' do
+      params = { :line_items_attributes => {
+                   "0" => { :sku => 'XXX', :quantity => 5 } }}
+      expect {
+        order = Order.build_from_api(user, params)
+      }.to raise_error /XXX/
+    end
+
+    it 'can build an order from API shipping address' do
+      params = { :ship_address_attributes => ship_address,
+                 :line_items_attributes => line_items }
+
+      order = Order.build_from_api(user, params)
+      order.ship_address.address1.should eq '123 Testable Way'
+    end
+
+    it 'can build an order from API with country attributes' do
+      ship_address.delete(:country_id)
+      ship_address[:country] = { 'iso' => 'US' }
+      params = { :ship_address_attributes => ship_address,
+                 :line_items_attributes => line_items }
+
+      order = Order.build_from_api(user, params)
+      order.ship_address.country.iso.should eq 'US'
+    end
+
+    it 'handles country lookup exceptions' do
+      ship_address.delete(:country_id)
+      ship_address[:country] = { 'iso' => 'XXX' }
+      params = { :ship_address_attributes => ship_address,
+                 :line_items_attributes => line_items }
+
+      expect {
+        order = Order.build_from_api(user, params)
+      }.to raise_error /XXX/
+    end
+
+    it 'can build an order from API with state attributes' do
+      ship_address.delete(:state_id)
+      ship_address[:state] = { 'name' => 'Alabama' }
+      params = { :ship_address_attributes => ship_address,
+                 :line_items_attributes => line_items }
+
+      order = Order.build_from_api(user, params)
+      order.ship_address.state.name.should eq 'Alabama'
+    end
+
+    it 'handles state lookup exceptions' do
+      ship_address.delete(:state_id)
+      ship_address[:state] = { 'name' => 'XXX' }
+      params = { :ship_address_attributes => ship_address,
+                 :line_items_attributes => line_items }
+
+      expect {
+        order = Order.build_from_api(user, params)
+      }.to raise_error /XXX/
+    end
+
+    it 'ensures_country_id for country fields' do
+      [:name, :iso, :iso_name, :iso3].each do |field|
+        address = { :country => { field => country.send(field) }}
+        Order.ensure_country_id_from_api(address)
+        address[:country_id].should eq country.id
+      end
+    end
+
+    it 'ensures_state_id for state fields' do
+      [:name, :abbr].each do |field|
+        address = { :state => { field => state.send(field) }}
+        Order.ensure_state_id_from_api(address)
+        address[:state_id].should eq state.id
+      end
+    end
+
+    it 'builds a shipments' do
+      params = { :shipments_attributes => [{ tracking: '123456789',
+                                             cost: '4.99',
+                                             shipping_method: shipping_method.name,
+                                             inventory_units: [{ sku: sku }]
+                                           }] }
+      order = Order.build_from_api(user, params)
+
+      shipment = order.shipments.first
+      shipment.inventory_units.first.variant_id.should eq product.master.id
+      shipment.tracking.should eq '123456789'
+      shipment.shipping_rates.first.cost.should eq 4.99
+    end
+
+    it 'handles shipment building exceptions' do
+      params = { :shipments_attributes => [{ tracking: '123456789',
+                                             cost: '4.99',
+                                             shipping_method: 'XXX',
+                                             inventory_units: [{ sku: sku }]
+                                           }] }
+      expect {
+        order = Order.build_from_api(user, params)
+      }.to raise_error /XXX/
+    end
+
+    it 'adds adjustments' do
+      params = { :adjustments_attributes => [
+          { "label" => "Shipping Discount", "amount" => "-4.99" },
+          { "label" => "Promotion Discount", "amount" => "-3.00" }] }
+
+      order = Order.build_from_api(user, params)
+      order.adjustments.all?(&:finalized?).should be_true
+      order.adjustments.first.label.should eq 'Shipping Discount'
+      order.adjustments.first.amount.should eq -4.99
+    end
+
+    it 'handles adjustment building exceptions' do
+      params = { :adjustments_attributes => [
+          { "amount" => "XXX" },
+          { "label" => "Promotion Discount", "amount" => "-3.00" }] }
+
+      expect {
+        order = Order.build_from_api(user, params)
+      }.to raise_error /XXX/
+    end
+
+    it 'builds a payment' do
+      params = { :payments_attributes => [{ amount: '4.99',
+                                            payment_method: payment_method.name }] }
+      order = Order.build_from_api(user, params)
+      order.payments.first.amount.should eq 4.99
+    end
+
+    it 'handles payment building exceptions' do
+      params = { :payments_attributes => [{ amount: '4.99',
+                                            payment_method: 'XXX' }] }
+      expect {
+        order = Order.build_from_api(user, params)
+      }.to raise_error /XXX/
     end
   end
 end


### PR DESCRIPTION
This PR Updates Order Import API/2-0-stable to work as [Order Import API/1-3-stable](https://github.com/spree/spree/blob/1-3-stable/api/app/models/spree/order_decorator.rb).
