### PR TITLE
[backend] consistent no resource found.

### DIFF
--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -80,7 +80,7 @@
 
 <%= paginate @orders %>
 
-<% unless @orders.empty? %>
+<% if @orders.any? %>
   <table class="index responsive" id="listing_orders" data-hook>
     <colgroup>
        <col style="width: 13%;">
@@ -126,8 +126,9 @@
     </tbody>
   </table>
 <% else %>
-  <div class="no-objects-found">
-    <%= Spree.t(:no_orders_found)%>
+  <div class="alpha twelve columns no-objects-found">
+    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/order')) %>,
+    <%= link_to Spree.t(:add_one), spree.new_admin_order_path %>!
   </div>
 <% end %>
 

--- a/backend/app/views/spree/admin/payment_methods/index.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/index.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:payment_methods) %>
@@ -28,13 +28,13 @@
         <th><%= Spree.t(:display) %></th>
         <th><%= Spree.t(:active) %></th>
         <th data-hook="admin_payment_methods_index_header_actions" class="actions"></th>
-      </tr>  
+      </tr>
     </thead>
     <tbody>
       <% @payment_methods.each do |method|%>
         <tr id="<%= spree_dom_id method %>" data-hook="admin_payment_methods_index_rows" class="<%= cycle('odd', 'even')%>">
           <td class="align-center"><%= method.name %></td>
-          <td><%= method.type %></td>
+          <td class="align-center"><%= method.type %></td>
           <td class="align-center"><%= method.environment.to_s.titleize %></td>
           <td class="align-center"><%= method.display_on.blank? ? Spree.t(:both) : Spree.t(method.display_on) %></td>
           <td class="align-center"><%= method.active ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>
@@ -47,6 +47,9 @@
     </tbody>
   </table>
 <% else %>
-  <div class="alpha twelve columns no-objects-found"><%= Spree.t(:no_payment_methods_found) %></div>
+  <div class="alpha twelve columns no-objects-found">
+    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/payment_method')) %>,
+    <%= link_to Spree.t(:add_one), spree.new_admin_payment_method_path %>!
+  </div>
 <% end %>
 

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -93,10 +93,10 @@
     </tbody>
   </table>
 <% else %>
-  <div class="no-objects-found">
-    <%= Spree.t(:no_results) %>
+  <div class="alpha twelve columns no-objects-found">
+    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/product')) %>,
+    <%= link_to Spree.t(:add_one), spree.new_admin_product_path %>!
   </div>
 <% end %>
 
 <%= paginate @collection %>
-

--- a/backend/app/views/spree/admin/promotions/index.html.erb
+++ b/backend/app/views/spree/admin/promotions/index.html.erb
@@ -8,12 +8,7 @@
   </li>
 <% end %>
 
-<% unless @promotions.any? %>
-  <div class="no-objects-found">
-    <%= Spree.t(:no_promotions_found) %>.
-    <%= link_to Spree.t(:add_one), spree.new_admin_promotion_path %>!
-  </div>
-<% else %>
+<% if @promotions.any? %>
   <table class="index">
     <colgroup>
       <col style="width: 20%">
@@ -49,4 +44,9 @@
       <% end %>
     </tbody>
   </table>
+<% else %>
+  <div class="alpha twelve columns no-objects-found">
+    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/promotion')) %>,
+    <%= link_to Spree.t(:add_one), spree.new_admin_promotion_path %>!
+  </div>
 <% end %>

--- a/backend/app/views/spree/admin/shipping_categories/index.html.erb
+++ b/backend/app/views/spree/admin/shipping_categories/index.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:shipping_categories) %>
@@ -10,6 +10,7 @@
   </li>
 <% end %>
 
+<% if @shipping_categories.any? %>
 <table class="index">
   <colgroup>
     <col style="width: 85%">
@@ -24,7 +25,7 @@
   <tbody>
     <% @shipping_categories.each do |shipping_category|%>
     <tr id="<%= spree_dom_id shipping_category %>" data-hook="category_row" class="<%= cycle('odd', 'even')%>">
-      <td style="width:350px;"><%= shipping_category.name %></td>
+      <td class="align-center" style="width:350px;"><%= shipping_category.name %></td>
       <td class="actions">
         <%= link_to_edit shipping_category, :no_text => true %>
         <%= link_to_delete shipping_category, :no_text => true %>
@@ -33,3 +34,9 @@
     <% end %>
   </tbody>
 </table>
+<% else %>
+  <div class="alpha twelve columns no-objects-found">
+    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/shipping_category')) %>,
+    <%= link_to Spree.t(:add_one), spree.new_admin_shipping_category_path %>!
+  </div>
+<% end %>

--- a/backend/app/views/spree/admin/shipping_methods/index.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/index.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:shipping_methods) %>
@@ -9,6 +9,7 @@
     <%= button_link_to Spree.t(:new_shipping_method), new_object_url,  :icon => 'icon-plus', :id => 'admin_new_shipping_method_link' %>
   </li>
 <% end %>
+
 <% if @shipping_methods.any? %>
   <table class="index" id='listing_shipping_methods'>
     <colgroup>
@@ -30,9 +31,9 @@
     <tbody>
       <% @shipping_methods.each do |shipping_method|%>
         <tr id="<%= spree_dom_id shipping_method %>" data-hook="admin_shipping_methods_index_rows" class="<%= cycle('odd', 'even')%>">
-          <td><%= shipping_method.admin_name + ' / ' if shipping_method.admin_name.present? %><%= shipping_method.name %></td>
-          <td><%= shipping_method.zones.collect(&:name).join(", ") if shipping_method.zones %></td>
-          <td><%= shipping_method.calculator.description %></td>
+          <td class="align-center"><%= shipping_method.admin_name + ' / ' if shipping_method.admin_name.present? %><%= shipping_method.name %></td>
+          <td class="align-center"><%= shipping_method.zones.collect(&:name).join(", ") if shipping_method.zones %></td>
+          <td class="align-center"><%= shipping_method.calculator.description %></td>
           <td class="align-center"><%= shipping_method.display_on.blank? ? Spree.t(:both) : Spree.t(shipping_method.display_on) %></td>
           <td data-hook="admin_shipping_methods_index_row_actions" class="actions">
             <%= link_to_edit shipping_method, :no_text => true %>
@@ -43,6 +44,9 @@
     </tbody>
   </table>
 <% else %>
-  <div class="alpha twelve columns no-objects-found"><%= Spree.t(:no_shipping_methods_found) %></div>
+  <div class="alpha twelve columns no-objects-found">
+    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/shipping_method')) %>,
+    <%= link_to Spree.t(:add_one), spree.new_admin_shipping_method_path %>!
+  </div>
 <% end %>
 

--- a/backend/app/views/spree/admin/stock_locations/_form.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/_form.html.erb
@@ -15,15 +15,15 @@
         <label for="active"><%= Spree.t(:state) %></label>
         <ul>
           <li>
-            <%= f.label :active, Spree.t(:active) + ':' %>
+            <%= f.label :active, Spree.t(:active) %>
             <%= f.check_box :active %>
           </li>
           <li>
-            <%= f.label :active, Spree.t(:backorderable_default) + ':' %>
+            <%= f.label :active, Spree.t(:backorderable_default) %>
             <%= f.check_box :backorderable_default %>
           </li>
           <li>
-            <%= f.label :active, Spree.t(:propagate_all_variants) + ':' %>
+            <%= f.label :active, Spree.t(:propagate_all_variants) %>
             <%= f.check_box :propagate_all_variants %>
           </li>
         </ul>
@@ -34,27 +34,27 @@
   <div class="row">
     <div class="alpha four columns">
       <div class="field ">
-        <%= f.label :address1, Spree.t(:street_address) + ':' %>
+        <%= f.label :address1, Spree.t(:street_address) %>
         <%= f.text_field :address1, :class => 'fullwidth' %>
       </div>
     </div>
 
     <div class="four columns">
       <div class="field ">
-        <%= f.label :address2, Spree.t(:street_address_2) + ':' %>
+        <%= f.label :address2, Spree.t(:street_address_2) %>
         <%= f.text_field :address2, :class => 'fullwidth' %>
       </div>
     </div>
     <div class="four columns">
       <div class="field ">
-        <%= f.label :city, Spree.t(:city) + ':' %>
+        <%= f.label :city, Spree.t(:city) %>
         <%= f.text_field :city, :class => 'fullwidth' %>
       </div>
     </div>
 
     <div class="omega four columns">
       <div class="field ">
-        <%= f.label :zipcode, Spree.t(:zip) + ':' %>
+        <%= f.label :zipcode, Spree.t(:zip) %>
         <%= f.text_field :zipcode, :class => 'fullwidth' %>
       </div>
     </div>
@@ -63,7 +63,7 @@
   <div class="row">
     <div class="alpha eight columns">
       <div class="field ">
-        <%= f.label :country_id, Spree.t(:country) + ':' %>
+        <%= f.label :country_id, Spree.t(:country) %>
         <span id="country"><%= f.collection_select :country_id, available_countries, :id, :name, {}, {:class => 'select2 fullwidth'} %></span>
       </div>
     </div>
@@ -71,7 +71,7 @@
     <div class="four columns">
       <div class="field ">
         <% if f.object.country %>
-          <%= f.label :state_id, Spree.t(:state) + ':' %>
+          <%= f.label :state_id, Spree.t(:state) %>
           <span id="state" class="region">
             <%= f.text_field :state_name, :style => "display: #{f.object.country.states.empty? ? 'block' : 'none' };", :disabled => !f.object.country.states.empty?, :class => 'fullwidth state_name' %>
             <%= f.collection_select :state_id, f.object.country.states.sort, :id, :name, {:include_blank => true}, {:class => 'select2 fullwidth', :style => "display: #{f.object.country.states.empty? ? 'none' : 'block' };", :disabled => f.object.country.states.empty?} %>
@@ -82,7 +82,7 @@
 
     <div class="omega four columns">
       <div class="field ">
-        <%= f.label :phone, Spree.t(:phone) + ':' %>
+        <%= f.label :phone, Spree.t(:phone) %>
         <%= f.phone_field :phone, :class => 'fullwidth' %>
       </div>
     </div>

--- a/backend/app/views/spree/admin/stock_locations/index.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/index.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:stock_locations) %>
@@ -37,9 +37,9 @@
            @delete_url = admin_stock_location_path(stock_location)
       %>
         <tr id="<%= spree_dom_id stock_location %>" data-hook="stock_location_row" class="<%= cycle('odd', 'even')%>">
-          <td><%= display_name(stock_location) %></td>
-          <td><span class="state <%= state(stock_location) %>"><%= state(stock_location) %></span></td>
-          <td><%= link_to Spree.t(:stock_movements), admin_stock_location_stock_movements_path(stock_location.id) %> </td>
+          <td class="align-center"><%= display_name(stock_location) %></td>
+          <td class="align-center"><span class="state <%= state(stock_location) %>"><%= state(stock_location) %></span></td>
+          <td class="align-center"><%= link_to Spree.t(:stock_movements), admin_stock_location_stock_movements_path(stock_location.id) %></td>
           <td class="actions">
             <%= link_to_edit stock_location, :no_text => true %>
             <%= link_to_delete stock_location, :no_text => true %>
@@ -49,5 +49,8 @@
     </tbody>
   </table>
 <% else %>
-  <div class="alpha twelve columns no-objects-found"><%= Spree.t(:no_stock_locations_found) %></div>
+  <div class="alpha twelve columns no-objects-found">
+    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/stock_location')) %>,
+    <%= link_to Spree.t(:add_one), spree.new_admin_stock_location_path %>!
+  </div>
 <% end %>

--- a/backend/app/views/spree/admin/stock_movements/index.html.erb
+++ b/backend/app/views/spree/admin/stock_movements/index.html.erb
@@ -13,6 +13,7 @@
   </li>
 <% end %>
 
+<% if @stock_movements.any? %>
 <table class="index" id='listing_stock_movements'>
   <colgroup>
     <col style="width: 35%">
@@ -36,5 +37,11 @@
     <% end %>
   </tbody>
 </table>
+<% else %>
+  <div class="alpha twelve columns no-objects-found">
+    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/stock_movement')) %>,
+    <%= link_to Spree.t(:add_one), spree.new_admin_stock_movement_path %>!
+  </div>
+<% end %>
 
 <%= paginate @stock_movements %>

--- a/backend/app/views/spree/admin/stock_transfers/index.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/index.html.erb
@@ -1,18 +1,18 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t('stock_transfers') %>
+  <%= Spree.t(:stock_transfers) %>
 <% end %>
 
 <% content_for :page_actions do %>
   <li>
-    <%= button_link_to Spree.t('new_stock_transfer'), new_admin_stock_transfer_path, { :icon => 'icon-forward' } %>
+    <%= button_link_to Spree.t(:new_stock_transfer), new_admin_stock_transfer_path, { :icon => 'icon-forward' } %>
   </li>
 <% end %>
 
 <div data-hook="admin_orders_index_search">
   <fieldset>
-    <legend align="center"><%= Spree.t('search') %></legend>
+    <legend align="center"><%= Spree.t(:search) %></legend>
     <%= search_form_for @q, :url => admin_stock_transfers_path do |f| %>
 
       <div class="field-block alpha four columns">
@@ -24,7 +24,7 @@
 
       <div class="four columns">
         <div class="field">
-          <%= f.label :source_location, Spree.t('source') %>
+          <%= f.label :source_location, Spree.t(:source) %>
           <%= f.select :source_location_id_eq,
                options_from_collection_for_select(@stock_locations, :id, :name, @q.source_location_id_eq),
                { include_blank: true }, class: 'select2 fullwidth' %>
@@ -33,7 +33,7 @@
 
       <div class="omega four columns">
         <div class="field">
-          <%= f.label :destination_location, Spree.t('destination') %>
+          <%= f.label :destination_location, Spree.t(:destination) %>
           <%= f.select :destination_location_id_eq,
                options_from_collection_for_select(@stock_locations, :id, :name, @q.destination_location_id_eq),
                { include_blank: true }, class: 'select2 fullwidth' %>
@@ -44,14 +44,14 @@
 
       <div class="actions filter-actions">
         <div data-hook="admin_stock_transfers_index_search_buttons">
-          <%= button Spree.t('filter_results'), 'icon-search' %>
+          <%= button Spree.t(:filter_results), 'icon-search' %>
         </div>
       </div>
     <% end %>
   </fieldset>
 </div>
 
-<% if !@stock_transfers.empty? %>
+<% if @stock_transfers.any? %>
   <table class='index' id='listing_stock_transfers' data-hook>
     <colgroup>
       <col style='width: 25%' />
@@ -62,20 +62,20 @@
     </colgroup>
     <thead>
       <tr data-hook='stock_transfers_header'>
-        <th><%= Spree.t('created_at') %></th>
-        <th><%= Spree.t('reference') %></th>
-        <th><%= Spree.t('source') %></th>
-        <th><%= Spree.t('destination') %></th>
+        <th><%= Spree.t(:created_at) %></th>
+        <th><%= Spree.t(:reference) %></th>
+        <th><%= Spree.t(:source) %></th>
+        <th><%= Spree.t(:destination) %></th>
         <th class='actions'></th>
       </tr>
     </thead>
     <tbody>
       <% @stock_transfers.each do |stock_transfer| %>
         <tr id="<%= spree_dom_id stock_transfer %>" data-hook="stock_transfer_row" class="<%= cycle('odd', 'even')%>">
-          <td><%= stock_transfer.created_at %></td>
-          <td class='align-center'><%= stock_transfer.reference %></td>
-          <td><%= stock_transfer.source_location.try(:name) %></td>
-          <td><%= stock_transfer.destination_location.try(:name) %></td>
+          <td class="align-center"><%= stock_transfer.created_at %></td>
+          <td class="align-center"><%= stock_transfer.reference %></td>
+          <td class="align-center"><%= stock_transfer.source_location.try(:name) %></td>
+          <td class="align-center"><%= stock_transfer.destination_location.try(:name) %></td>
           <td class='actions'>
             <%= link_to '', admin_stock_transfer_path(stock_transfer),
             title: 'view', class: 'view icon_link with-tip icon-eye-open no-text',
@@ -86,8 +86,9 @@
     </tbody>
   </table>
 <% else %>
-  <div class="no-objects-found">
-    <%= Spree.t('empty') %>
+  <div class="alpha twelve columns no-objects-found">
+    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/stock_transfer')) %>,
+    <%= link_to Spree.t(:add_one), spree.new_admin_stock_transfer_path %>!
   </div>
 <% end %>
 

--- a/backend/app/views/spree/admin/tax_categories/index.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/index.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:listing_tax_categories) %>
@@ -12,6 +12,7 @@
   </ul>
 <% end %>
 
+<% if @tax_categories.any? %>
 <table class="index" id='listing_tax_categories' data-hook>
   <colgroup>
     <col style="width: 30%" />
@@ -33,16 +34,19 @@
          @delete_url = admin_tax_category_path(tax_category)
     %>
       <tr id="<%= spree_dom_id tax_category %>" data-hook="tax_row" class="<%= cycle('odd', 'even')%>">
-        <td><%= tax_category.name %></td>
-        <td><%= tax_category.description %></td>
-        <td class="align-center"><%= tax_category.is_default.to_s.titleize %></td>
+        <td class="align-center"><%= tax_category.name %></td>
+        <td class="align-center"><%= tax_category.description %></td>
+        <td class="align-center"><%= tax_category.is_default? ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>
         <td class="actions">
           <%= link_to_edit tax_category, :no_text => true %>
           <%= link_to_delete tax_category, :no_text => true %>
       </tr>
     <% end %>
-    <% if @tax_categories.empty? %>
-      <tr data-hook="tax_none"><td colspan="4"><%= Spree.t(:none) %></td></tr>
-    <% end %>
   </tbody>
 </table>
+<% else %>
+  <div class="alpha twelve columns no-objects-found">
+    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/tax_category')) %>,
+    <%= link_to Spree.t(:add_one), spree.new_admin_tax_category_path %>!
+  </div>
+<% end %>

--- a/backend/app/views/spree/admin/tax_rates/_form.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/_form.html.erb
@@ -2,7 +2,7 @@
   <div class="alpha twelve columns">
     <fieldset data-hook="tax_rates" class=" no-border-bottom">
       <legend align="center"><%= Spree.t(:general_settings) %></legend>
-      
+
       <div class="alpha six columns">
         <div data-hook="name" class="field">
           <%= f.label :name, Spree.t(:name) %>
@@ -11,11 +11,11 @@
         <div data-hook="rate" class="field">
           <%= f.label :amount, Spree.t(:rate) %>
           <%= f.text_field :amount, :class => 'fullwidth' %>
-          <p><em><%= Spree.t(:tax_rate_amount_explanation) %></em></p>
+          <br/><span class="info"><%= Spree.t(:tax_rate_amount_explanation) %></span>
         </div>
         <div data-hook="included" class="field">
           <%= f.check_box :included_in_price %>
-          <%= f.label :included_in_price, Spree.t(:included_in_price) %>      
+          <%= f.label :included_in_price, Spree.t(:included_in_price) %>
         </div>
       </div>
 
@@ -23,20 +23,20 @@
         <div data-hook="zone" class="field">
           <%= f.label :zone, Spree.t(:zone) %>
           <%= f.collection_select(:zone_id, @available_zones, :id, :name, {}, {:class => 'select2 fullwidth'}) %>
-        </div>      
+        </div>
         <div data-hook="category" class="field">
           <%= f.label :tax_category_id, Spree.t(:tax_category) %>
           <%= f.collection_select(:tax_category_id, @available_categories,:id, :name, {}, {:class => 'select2 fullwidth'}) %>
         </div>
         <div data-hook="show_rate" class="field">
           <%= f.check_box :show_rate_in_label %>
-          <%= f.label :show_rate_in_label, Spree.t(:show_rate_in_label) %>      
-        </div>  
+          <%= f.label :show_rate_in_label, Spree.t(:show_rate_in_label) %>
+        </div>
       </div>
     </fieldset>
   </div>
-  
+
   <div class="clear"></div>
 
-  <%= render :partial => 'spree/admin/shared/calculator_fields', :locals => { :f => f } %>
+  <%= render 'spree/admin/shared/calculator_fields', :f => f %>
 </div>

--- a/backend/app/views/spree/admin/tax_rates/index.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/index.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:tax_rates) %>
@@ -10,11 +10,7 @@
   </li>
 <% end %>
 
-<% unless @tax_rates.any? %>
-  <div class="no-objects-found">
-    <%= Spree.t(:no_results) %>
-  </div>
-<% else %>
+<% if @tax_rates.any? %>
   <table class="index">
     <colgroup>
       <col style="width: 15%">
@@ -41,12 +37,12 @@
     <tbody>
       <% @tax_rates.each do |tax_rate|%>
       <tr id="<%= spree_dom_id tax_rate %>" data-hook="rate_row" class="<%= cycle('odd', 'even')%>">
-        <td><%=tax_rate.zone.try(:name) || Spree.t(:not_available) %></td>
-        <td><%=tax_rate.name %></td>
-        <td><%=tax_rate.tax_category.try(:name) || Spree.t(:not_available) %></td>
+        <td class="align-center"><%=tax_rate.zone.try(:name) || Spree.t(:not_available) %></td>
+        <td class="align-center"><%=tax_rate.name %></td>
+        <td class="align-center"><%=tax_rate.tax_category.try(:name) || Spree.t(:not_available) %></td>
         <td class="align-center"><%=tax_rate.amount %></td>
-        <td class="align-center"><%=tax_rate.included_in_price %></td>
-        <td class="align-center"><%=tax_rate.show_rate_in_label %></td>
+        <td class="align-center"><%=tax_rate.included_in_price? ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>
+        <td class="align-center"><%=tax_rate.show_rate_in_label? ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>
         <td class="align-center"><%=tax_rate.calculator.to_s %></td>
         <td class="actions">
           <%= link_to_edit tax_rate, :no_text => true %>
@@ -56,4 +52,9 @@
       <% end %>
     </tbody>
   </table>
+<% else %>
+  <div class="alpha twelve columns no-objects-found">
+    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/tax_rate')) %>,
+    <%= link_to Spree.t(:add_one), spree.new_admin_tax_rate_path %>!
+  </div>
 <% end %>

--- a/backend/app/views/spree/admin/trackers/index.html.erb
+++ b/backend/app/views/spree/admin/trackers/index.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:analytics_trackers) %>
@@ -10,12 +10,7 @@
   </li>
 <% end %>
 
-<% unless @trackers.any? %>
-  <div class="no-objects-found">
-    <%= Spree.t(:no_trackers_found)%>,
-    <%= link_to Spree.t(:add_one), new_object_url %>!
-  </div>
-<% else %>
+<% if @trackers.any? %>
   <table class="index">
     <colgroup>
       <col style="width: 30%">
@@ -34,8 +29,8 @@
     <tbody>
       <% @trackers.each do |tracker|%>
         <tr id="<%= spree_dom_id tracker %>" data-hook="admin_trackers_index_rows" class="<%= cycle('odd', 'even')%>">
-          <td><%= tracker.analytics_id %></td>
-          <td><%= tracker.environment.to_s.titleize %></td>
+          <td class="align-center"><%= tracker.analytics_id %></td>
+          <td class="align-center"><%= tracker.environment.to_s.titleize %></td>
           <td class="align-center"><%= tracker.active ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>
           <td class="actions">
             <%= link_to_edit tracker, :no_text => true %>
@@ -45,4 +40,9 @@
       <% end %>
     </tbody>
   </table>
-<% end%>
+<% else %>
+  <div class="no-objects-found">
+    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/tracker')) %>,
+    <%= link_to Spree.t(:add_one), new_object_url %>!
+  </div>
+<% end %>

--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -45,7 +45,10 @@
     </tbody>
   </table>
 <% else %>
-  <div class="alpha twelve columns no-objects-found"><%= Spree.t(:no_results)%>.</div>
+  <div class="alpha twelve columns no-objects-found">
+    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/variant')) %>,
+    <%= link_to Spree.t(:add_one), spree.new_admin_product_variant_path(@product) %>!
+  </div>
 <% end %>
 
 <% if @product.empty_option_values? %>
@@ -59,16 +62,15 @@
   <% content_for :page_actions do %>
     <ul class="inline-menu" data-hook="toolbar">
       <li id="new_var_link" data-hook>
-        <%= link_to_with_icon('icon-plus', 
-                              Spree.t(:new_variant), 
-                              new_admin_product_variant_url(@product), 
-                              :remote => :true, 
-                              :'data-update' => 'new_variant', 
+        <%= link_to_with_icon('icon-plus',
+                              Spree.t(:new_variant),
+                              new_admin_product_variant_url(@product),
+                              :remote => :true,
+                              :'data-update' => 'new_variant',
                               :class => 'button'
                              ) %>
       </li>
       <li><%= link_to_with_icon('icon-filter', @deleted.blank? ? Spree.t(:show_deleted) : Spree.t(:show_active), admin_product_variants_url(@product, :deleted => @deleted.blank? ? "on" : "off"), :class => 'button') %></li>
     </ul>
   <% end %>
-
 <% end %>

--- a/backend/app/views/spree/admin/zones/index.html.erb
+++ b/backend/app/views/spree/admin/zones/index.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:zones) %>
@@ -12,11 +12,7 @@
 
 <%= paginate @zones %>
 
-<% if @zones.empty? %>
-  <div class="no-objects-found">
-    <%= Spree.t(:none) %>
-  </div>
-<% else %>
+<% if @zones.any? %>
   <table class="index" id='listing_zones' data-hook>
     <colgroup>
       <col style="width: 30%" />
@@ -37,9 +33,9 @@
     <tbody>
       <% @zones.each do |zone| %>
         <tr id="<%= spree_dom_id zone %>" data-hook="zones_row" class="<%= cycle('odd', 'even')%>">
-          <td><%=zone.name %></td>
-          <td><%=zone.description %></td>
-          <td class="align-center"><%=zone.default_tax %></td>
+          <td class="align-center"><%= zone.name %></td>
+          <td><%= zone.description %></td>
+          <td class="align-center"><%= zone.default_tax? ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>
           <td class="actions">
             <%=link_to_edit zone, :no_text => true %>
             <%=link_to_delete zone, :no_text => true %>
@@ -48,6 +44,11 @@
       <% end %>
     </tbody>
   </table>
-<% end%>
+<% else %>
+  <div class="alpha twelve columns no-objects-found">
+    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/zone')) %>,
+    <%= link_to Spree.t(:add_one), spree.new_admin_zone_path %>!
+  </div>
+<% end %>
 
 <%= paginate @zones %>

--- a/backend/spec/features/admin/configuration/tax_categories_spec.rb
+++ b/backend/spec/features/admin/configuration/tax_categories_spec.rb
@@ -16,7 +16,7 @@ describe "Tax Categories" do
       within_row(1) do
         column_text(1).should == "Clothing"
         column_text(2).should == "For Clothing"
-        column_text(3).should == "False"
+        column_text(3).should == "No"
       end
     end
   end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -152,6 +152,9 @@ en:
       spree/product:
         one: Product
         other: Products
+      spree/promotion:
+        one: Promotion
+        other: Promotions
       spree/property:
         one: Property
         other: Properties
@@ -173,6 +176,9 @@ en:
       spree/state:
         one: State
         other: States
+      spree/stock_location:
+        one: Stock Location
+        other: Stock Locations
       spree/tax_category:
         one: Tax Category
         other: Tax Categories
@@ -678,6 +684,7 @@ en:
     no_promotions_found: No promotions found
     no_results: No results
     no_rules_added: No rules added
+    no_resource_found: ! 'No %{resource} found'
     no_shipping_methods_found: No shipping methods found
     no_trackers_found: No Trackers Found
     no_stock_locations_found: No stock locations found


### PR DESCRIPTION
- Use common layout pattern when no resource found, today it only show empty table headers in many parts.
- Add shared translation key for above, more DRY (did not remove old keys for safe keeping).
- Table headers have center position, no padding exists so I add class "align-center" to some tables so this also looks more consistent.
- Removed colon from labels in stock_location form because it not used elsewhere.
- Add missing active record model translations for stock_location and promotion.
- Fixed missing boolean translations for zone and stock_location tables.
