### PR TITLE
Faster cart render

### DIFF
--- a/frontend/app/views/spree/orders/_form.html.erb
+++ b/frontend/app/views/spree/orders/_form.html.erb
@@ -10,9 +10,7 @@
     </tr>
   </thead>
   <tbody id="line_items" data-hook>
-    <%= order_form.fields_for :line_items do |item_form| %>
-      <%= render :partial => 'line_item', :locals => { :variant => item_form.object.variant, :line_item => item_form.object, :item_form => item_form } %>
-    <% end %>
+    <%= render partial: 'line_item', collection: order_form.object.line_items, locals: {order_form: order_form} %>
   </tbody>
   <%= render "spree/orders/adjustments" unless @order.adjustments.eligible.blank? %>
 </table>

--- a/frontend/app/views/spree/orders/_line_item.html.erb
+++ b/frontend/app/views/spree/orders/_line_item.html.erb
@@ -1,31 +1,34 @@
-<tr class="<%= cycle('', 'alt') %> line-item">
-  <td class="cart-item-image" data-hook="cart_item_image">
-    <% if variant.images.length == 0 %>
-      <%= link_to small_image(variant.product), variant.product %>
-    <% else %>
-      <%= link_to image_tag(variant.images.first.attachment.url(:small)), variant.product %>
-    <% end %>
-  </td>
-  <td class="cart-item-description" data-hook="cart_item_description">
-    <h4><%= link_to variant.product.name, product_path(variant.product) %></h4>
-    <%= variant.options_text %>
-    <% if @order.insufficient_stock_lines.include? line_item %>
-      <span class="out-of-stock">
-        <%= Spree.t(:out_of_stock) %>&nbsp;&nbsp;<br />
-      </span>
-    <% end %>
-    <%= line_item_description(variant) %>
-  </td>
-  <td class="cart-item-price" data-hook="cart_item_price">
-    <%= line_item.single_money.to_html %>
-  </td>
-  <td class="cart-item-quantity" data-hook="cart_item_quantity">
-    <%= item_form.number_field :quantity, :min => 0, :class => "line_item_quantity", :size => 5 %>
-  </td>
-  <td class="cart-item-total" data-hook="cart_item_total">
-    <%= line_item.display_amount.to_html unless line_item.quantity.nil? %>
-  </td>
-  <td class="cart-item-delete" data-hook="cart_item_delete">
-    <%= link_to image_tag('icons/delete.png'), '#', :class => 'delete', :id => "delete_#{dom_id(line_item)}" %>
-  </td>
-</tr>
+<% variant = line_item.variant -%>
+<%= order_form.fields_for :line_items, line_item do |item_form| -%>
+  <tr class="<%= cycle('', 'alt') %> line-item">
+    <td class="cart-item-image" data-hook="cart_item_image">
+      <% if variant.images.length == 0 %>
+        <%= link_to small_image(variant.product), variant.product %>
+      <% else %>
+        <%= link_to image_tag(variant.images.first.attachment.url(:small)), variant.product %>
+      <% end %>
+    </td>
+    <td class="cart-item-description" data-hook="cart_item_description">
+      <h4><%= link_to variant.product.name, product_path(variant.product) %></h4>
+      <%= variant.options_text %>
+      <% if @order.insufficient_stock_lines.include? line_item %>
+        <span class="out-of-stock">
+          <%= Spree.t(:out_of_stock) %>&nbsp;&nbsp;<br />
+        </span>
+      <% end %>
+      <%= line_item_description(variant) %>
+    </td>
+    <td class="cart-item-price" data-hook="cart_item_price">
+      <%= line_item.single_money.to_html %>
+    </td>
+    <td class="cart-item-quantity" data-hook="cart_item_quantity">
+      <%= item_form.number_field :quantity, :min => 0, :class => "line_item_quantity", :size => 5 %>
+    </td>
+    <td class="cart-item-total" data-hook="cart_item_total">
+      <%= line_item.display_amount.to_html unless line_item.quantity.nil? %>
+    </td>
+    <td class="cart-item-delete" data-hook="cart_item_delete">
+      <%= link_to image_tag('icons/delete.png'), '#', :class => 'delete', :id => "delete_#{dom_id(line_item)}" %>
+    </td>
+  </tr>
+<% end -%>


### PR DESCRIPTION
I found that by passing the `line_items` collection directly to the `render` method in the orders#edit (cart) form we see significant performance gains because the partial is only rendered once. In our case we saw performance gains of view rendering of around 50% faster when about 10 items are in the cart. The gains are probably smaller in other apps (we have overriding the partial using Deface) but still worthwhile. 

I think this could be useful for master branch as well as 2-0-stable but I haven't tried it yet (not on rails 4 yet).
