### PR TITLE
Set created_by for orders when associating a user if created_by is blank

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -252,10 +252,11 @@ module Spree
     def associate_user!(user)
       self.user = user
       self.email = user.email
+      self.created_by = user if self.created_by.blank?
 
       if persisted?
         # immediately persist the changes we just made, but don't use save since we might have an invalid address associated
-        self.class.unscoped.where(id: id).update_all(email: user.email, user_id: user.id)
+        self.class.unscoped.where(id: id).update_all(email: user.email, user_id: user.id, created_by_id: self.created_by_id)
       end
     end
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -55,7 +55,7 @@ describe Spree::Order do
 
   context "#associate_user!" do
     it "should associate a user with a persisted order" do
-      order = FactoryGirl.create(:order_with_line_items)
+      order = FactoryGirl.create(:order_with_line_items, created_by: nil)
       user = FactoryGirl.create(:user)
 
       order.user = nil
@@ -63,12 +63,34 @@ describe Spree::Order do
       order.associate_user!(user)
       order.user.should == user
       order.email.should == user.email
+      order.created_by.should == user
 
       # verify that the changes we made were persisted
       order.reload
       order.user.should == user
       order.email.should == user.email
+      order.created_by.should == user
     end
+
+    it "should not overwrite the created_by if it already is set" do
+      creator = create(:user)
+      order = FactoryGirl.create(:order_with_line_items, created_by: creator)
+      user = FactoryGirl.create(:user)
+
+      order.user = nil
+      order.email = nil
+      order.associate_user!(user)
+      order.user.should == user
+      order.email.should == user.email
+      order.created_by.should == creator
+
+      # verify that the changes we made were persisted
+      order.reload
+      order.user.should == user
+      order.email.should == user.email
+      order.created_by.should == creator
+    end
+
 
     it "should associate a user with a non-persisted order" do
       order = Spree::Order.new


### PR DESCRIPTION
Fixes an issue introduced by the addition of created_by (and associated logic) to Order.  If an Order is created by a visitor, and that visitor is subsequently authenticated as a user, then the created_by for the Order should be set to the authenticated user.   Specific changes:
1. Sets created_by for orders when associating with a user IF the created_by value is blank.  
2. Adds specs for both cases - created_by blank and created_by set to another user.

Fixes spree/spree_auth_devise issue - https://github.com/spree/spree_auth_devise/issues/120
