### PR TITLE
api/orders_controller#empty: now uses empty!

### DIFF
--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -25,7 +25,7 @@ module Spree
 
       def empty
         find_order
-        @order.line_items.destroy_all
+        @order.empty!
         @order.update!
         render text: nil, status: 200
       end

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -216,15 +216,19 @@ module Spree
       end
 
       context "with a line item" do
-        before do
-          create(:line_item, :order => order)
-          order.reload
+        let(:order_with_line_items) do
+          order = create(:order_with_line_items)
+          create(:adjustment, :adjustable => order)
+          order
         end
 
         it "can empty an order" do
-          api_put :empty, :id => order.to_param
+          order_with_line_items.adjustments.count.should be == 1
+          api_put :empty, :id => order_with_line_items.to_param
           response.status.should == 200
-          order.reload.line_items.should be_empty
+          order_with_line_items.reload
+          order_with_line_items.line_items.should be_empty
+          order_with_line_items.adjustments.should be_empty
         end
 
         it "can list its line items with images" do


### PR DESCRIPTION
this is consistent with frontend/orders_controller

[Closes #3611]
