### PR TITLE
Allow users to dont split packages

### DIFF
--- a/core/app/models/spree/stock/packer.rb
+++ b/core/app/models/spree/stock/packer.rb
@@ -10,7 +10,11 @@ module Spree
       end
 
       def packages
-        build_splitter.split [default_package]
+        if splitters.empty?
+          [default_package]
+        else
+          build_splitter.split [default_package]
+        end
       end
 
       def default_package

--- a/core/spec/models/spree/stock/packer_spec.rb
+++ b/core/spec/models/spree/stock/packer_spec.rb
@@ -14,6 +14,11 @@ module Spree
           packages.size.should eq 1
           packages.first.contents.size.should eq 5
         end
+
+        it 'allows users to set splitters to an empty array' do
+          packages = Packer.new(stock_location, order, []).packages
+          packages.size.should eq 1
+        end
       end
 
       context 'default_package' do


### PR DESCRIPTION
By making the Packer know how to deal with an empty splitters array we
allow users to set

```
Rails.application.config.spree.stock_splitters = []
```

in theirs apps so that packages will never be split

It would be great to have it in 2-0-stable as well it should apply cleanly
