### PR TITLE
[backend] Various layout fixes.

### DIFF
--- a/backend/app/assets/javascripts/admin/stock_management.js.coffee
+++ b/backend/app/assets/javascripts/admin/stock_management.js.coffee
@@ -1,7 +1,7 @@
 jQuery ->
-  $('.stock_item_backorderable').live 'click', ->
+  $('.stock_item_backorderable').on 'click', ->
     $(@).parent('form').submit()
-  $('.toggle_stock_item_backorderable').submit ->
+  $('.toggle_stock_item_backorderable').on 'submit', ->
     $.ajax
       type: @method
       url: @action

--- a/backend/app/views/spree/admin/general_settings/edit.html.erb
+++ b/backend/app/views/spree/admin/general_settings/edit.html.erb
@@ -11,7 +11,7 @@
       <% @preferences_general.each do |key|
           type = Spree::Config.preference_type(key) %>
           <div class="field">
-            <%= label_tag(key, Spree.t(key) + ': ') + tag(:br) if type != :boolean %>
+            <%= label_tag(key, Spree.t(key)) + tag(:br) if type != :boolean %>
             <%= preference_field_tag(key, Spree::Config[key], :type => type) %>
             <%= label_tag(key, Spree.t(key)) + tag(:br) if type == :boolean %>
           </div>
@@ -25,7 +25,7 @@
             <% @preferences_security.each do |key|
                 type = Spree::Config.preference_type(key) %>
                 <div class="field">
-                  <%= label_tag(key, Spree.t(key) + ': ') + tag(:br) if type != :boolean %>
+                  <%= label_tag(key, Spree.t(key)) + tag(:br) if type != :boolean %>
                   <%= preference_field_tag(key, Spree::Config[key], :type => type) %>
                   <%= label_tag(key, Spree.t(key)) + tag(:br) if type == :boolean %>
                 </div>
@@ -38,7 +38,7 @@
             <% @preferences_currency.each do |key|
                 type = Spree::Config.preference_type(key) %>
                 <div class="field">
-                  <%= label_tag(key, Spree.t(key) + ': ') + tag(:br) if type != :boolean %>
+                  <%= label_tag(key, Spree.t(key)) + tag(:br) if type != :boolean %>
                   <%= preference_field_tag(key, Spree::Config[key], :type => type) %>
                   <%= label_tag(key, Spree.t(key)) + tag(:br) if type == :boolean %>
                 </div>

--- a/backend/app/views/spree/admin/option_types/index.html.erb
+++ b/backend/app/views/spree/admin/option_types/index.html.erb
@@ -14,12 +14,14 @@
 
 <table class="index sortable" id="listing_option_types" data-hook data-sortable-link="<%= update_positions_admin_option_types_url %>">
   <colgroup>
-    <col style="width: 44%">
-    <col style="width: 44%">
-    <col style="width: 12%">
+    <col style="width: 10%">
+    <col style="width: 35%">
+    <col style="width: 40%">
+    <col style="width: 15%">
   </colgroup>
   <thead>
     <tr data-hook="option_header">
+      <th class="no-border"></th>
       <th><%= Spree.t(:name) %></th>
       <th><%= Spree.t(:presentation) %></th>
       <th class="actions"></th>
@@ -28,8 +30,9 @@
   <tbody>
     <% @option_types.each do |option_type| %>
       <tr class="spree_option_type <%= cycle('odd', 'even')%>" id="<%= spree_dom_id option_type %>" data-hook="option_row">
-        <td><span class="handle"></span> <%= option_type.name %></td>
-        <td class="presentation"><%= option_type.presentation %></td>
+        <td class="no-border"><span class="handle"></span></td>
+        <td class="align-center"><%= option_type.name %></td>
+        <td class="align-center presentation"><%= option_type.presentation %></td>
         <td class="actions">
           <%= link_to_edit(option_type, :class => 'admin_edit_option_type', :no_text => true) %>
           <%= link_to_delete(option_type, :no_text => true) %>

--- a/backend/app/views/spree/admin/orders/customer_details/_form.html.erb
+++ b/backend/app/views/spree/admin/orders/customer_details/_form.html.erb
@@ -1,18 +1,18 @@
 <fieldset data-hook="admin_customer_detail_form_fields" class="no-border-top">
-  
+
   <fieldset class="index no-border-bottom" data-hook="customer_guest">
     <legend align="center"><%= Spree.t(:account) %></legend>
-      
+
     <div data-hook="customer_fields" class="row">
       <div class="alpha eight columns">
         <div class="field">
-          <%= f.label :email, Spree.t(:email) + ':' %>
+          <%= f.label :email, Spree.t(:email) %>
           <%= f.email_field :email, :class => 'fullwidth' %>
         </div>
       </div>
       <div class="omega four columns">
         <div class="field">
-          <%= label_tag nil, Spree.t(:guest_checkout) %>:
+          <%= label_tag nil, Spree.t(:guest_checkout) %>
           <ul>
             <% if @order.completed? %>
               <li>
@@ -26,8 +26,8 @@
               </li>
               <li>
                 <%= radio_button_tag :guest_checkout, false, !guest, :disabled => @order.cart? %>
-                <%= Spree.t(:say_no) %>  
-              </li>              
+                <%= Spree.t(:say_no) %>
+              </li>
               <%= hidden_field_tag :user_id, @order.user_id %>
             <% end %>
           </ul>
@@ -44,13 +44,13 @@
       <% end %>
     </fieldset>
   </div>
-  
+
   <div class="omega six columns" data-hook="ship_address_wrapper">
     <fieldset class="no-border-bottom">
       <legend align="center"><%= Spree.t(:shipping_address) %></legend>
       <%= f.fields_for :ship_address do |sa_form| %>
         <%= render :partial => 'spree/admin/shared/address_form', :locals => { :f => sa_form, :name => Spree.t(:shipping_address), :use_billing => true } %>
-      <% end %>    
+      <% end %>
     </fieldset>
   </div>
 

--- a/backend/app/views/spree/admin/product_properties/index.html.erb
+++ b/backend/app/views/spree/admin/product_properties/index.html.erb
@@ -1,8 +1,6 @@
-<%= render :partial => 'spree/admin/shared/product_sub_menu' %>
-
-<%= render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => 'Product Properties' } %>
-
-<%= render :partial => 'spree/shared/error_messages', :locals => { :target => @product } %>
+<%= render 'spree/admin/shared/product_sub_menu' %>
+<%= render 'spree/admin/shared/product_tabs', :current => 'Product Properties' %>
+<%= render 'spree/shared/error_messages', :target => @product %>
 
 <% content_for :page_actions do %>
   <ul class="tollbar inline-menu">
@@ -12,7 +10,7 @@
     <li>
       <span id="new_ptype_link">
         <%= link_to Spree.t(:select_from_prototype), available_admin_prototypes_url, :remote => true, 'data-update' => 'prototypes', :class => 'button icon-copy' %>
-      </span>  
+      </span>
     </li>
   </ul>
 <% end %>
@@ -20,10 +18,10 @@
 <%= form_for @product, :url => admin_product_url(@product), :method => :put do |f| %>
   <fieldset class="no-border-top">
     <div class="add_product_properties" data-hook="add_product_properties"></div>
-    
+
     <div id="prototypes" data-hook></div>
     <%= image_tag 'select2-spinner.gif', :plugin => 'spree', :style => 'display:none;', :id => 'busy_indicator' %>
-    
+
     <table class="index sortable" data-hook data-sortable-link="<%= update_positions_admin_product_product_properties_url %>">
       <thead>
         <tr data-hook="product_properties_header">
@@ -34,12 +32,12 @@
       </thead>
       <tbody id="product_properties" data-hook>
         <%= f.fields_for :product_properties do |pp_form| %>
-          <%= render :partial => 'product_property_fields', :locals => { :f => pp_form } %>
+          <%= render 'product_property_fields', :f => pp_form %>
         <% end %>
       </tbody>
     </table>
 
-    <%= render :partial => 'spree/admin/shared/edit_resource_links' %>
+    <%= render 'spree/admin/shared/edit_resource_links' %>
 
     <%= hidden_field_tag 'clear_product_properties', 'true' %>
   </fieldset>
@@ -47,8 +45,7 @@
 
 <%= javascript_tag do -%>
   var properties = <%= raw(@properties.to_json) %>;
-
-  $("#product_properties input.autocomplete").live("keydown", function(){
+  $('#product_properties').on('keydown', 'input.autocomplete', function() {
     already_auto_completed = $(this).is('ac_input');
     if (!already_auto_completed) {
       $(this).autocomplete({source: properties});
@@ -56,4 +53,3 @@
     }
   });
 <% end -%>
-

--- a/backend/app/views/spree/admin/products/stock.html.erb
+++ b/backend/app/views/spree/admin/products/stock.html.erb
@@ -20,7 +20,7 @@
   <thead>
     <tr data-hook="admin_product_stock_management_index_headers">
       <th><%= Spree.t(:variant) %></th>
-      <th colspan="3"><%= Spree.t(:stock_location_info) %></th>
+      <th colspan="4"><%= Spree.t(:stock_location_info) %></th>
     </tr>
   </thead>
   <tbody>
@@ -37,23 +37,23 @@
           <td colspan="4" class="stock_location_info">
             <table>
               <colgroup>
-                <col style="width: 40%" />
+                <col style="width: 45%" />
                 <col style="width: 20%" />
                 <col style="width: 20%" />
-                <col style="width: 20%" />
+                <col style="width: 15%" />
               </colgroup>
               <thead>
                 <th><%= Spree.t(:stock_location) %></th>
                 <th><%= Spree.t(:count_on_hand) %></th>
                 <th><%= Spree.t(:backorderable) %></th>
-                <th></th>
+                <th class="actions"></th>
               </thead>
               <tbody>
                 <% variant.stock_items.each do |item| %>
                   <% next unless @stock_locations.include?(item.stock_location) %>
 
                   <tr id="stock-item-<%= item.id %>" class="<%= cycle('odd', 'even', :name => 'stock_locations')%>">
-                    <td><%= item.stock_location.name %></td>
+                    <td class="align-center"><%= item.stock_location.name %></td>
                     <td class="align-center"><%= item.count_on_hand %></td>
                     <td class="align-center">
                       <%= form_tag admin_stock_item_path(item), method: :put, class: 'toggle_stock_item_backorderable' do %>
@@ -62,9 +62,11 @@
                               id: "stock_item_backorderable_#{item.stock_location.id}" %>
                       <% end %>
                     </td>
-                    <td class="align-center">
-                      <%= link_to "", [:admin, item], method: :delete, remote: true,
-                        confirm: Spree.t(:are_you_sure), class: "icon_link with-tip icon-trash" %>
+                    <td class="actions">
+                      <%= link_to(icon('delete'), [:admin, item],
+                            method: :delete, remote: true, confirm: Spree.t(:are_you_sure),
+                            class: 'icon_link with-tip icon-trash no-text',
+                            title: Spree.t(:remove), data: { action: :remove }) %>
                     </td>
                   </tr>
                 <% end %>

--- a/backend/app/views/spree/admin/properties/index.html.erb
+++ b/backend/app/views/spree/admin/properties/index.html.erb
@@ -8,15 +8,15 @@
   </li>
 <% end %>
 
-<%= render :partial => 'spree/admin/shared/product_sub_menu' %>
+<%= render 'spree/admin/shared/product_sub_menu' %>
 
 <div id="new_property"></div>
 
 <table class="index" id='listing_properties' data-hook>
   <colgroup>
+    <col style="width: 40%">
     <col style="width: 45%">
-    <col style="width: 45%">
-    <col style="width: 10%">
+    <col style="width: 15%">
   </colgroup>
   <thead>
     <tr data-hook="listing_properties_header">
@@ -28,8 +28,8 @@
   <tbody>
     <% @properties.each do |property| %>
       <tr id="<%= spree_dom_id property %>" data-hook="listing_properties_row" class="<%= cycle('odd', 'even')%>">
-        <td><%= property.name %></td>
-        <td><%= property.presentation %></td>
+        <td style="padding-left:1em"><%= property.name %></td>
+        <td style="padding-left:1em"><%= property.presentation %></td>
         <td class="actions">
           <%= link_to_edit(property, :no_text => true) %>
           <%= link_to_delete(property, :no_text => true) %>

--- a/backend/app/views/spree/admin/prototypes/_form.html.erb
+++ b/backend/app/views/spree/admin/prototypes/_form.html.erb
@@ -1,7 +1,7 @@
 <div data-hook="admin_prototype_form_fields" class="row">
   <div class="alpha four columns">
     <%= f.field_container :name do %>
-      <%= f.label :name, Spree.t(:name) %>
+      <%= f.label :name, Spree.t(:name) %> <span class="required">*</span><br />
       <%= f.text_field :name, :class => 'fullwidth' %>
       <%= f.error_message_on :name %>
     <% end %>

--- a/backend/app/views/spree/admin/prototypes/index.html.erb
+++ b/backend/app/views/spree/admin/prototypes/index.html.erb
@@ -8,7 +8,7 @@
   </li>
 <% end %>
 
-<%= render :partial => 'spree/admin/shared/product_sub_menu' %>
+<%= render 'spree/admin/shared/product_sub_menu' %>
 
 <%= image_tag 'select2-spinner.gif', :plugin => 'spree', :style => 'display: none', :id => 'busy_indicator' %>
 
@@ -29,7 +29,7 @@
   <tbody>
     <% @prototypes.each do |prototype| %>
       <tr id="<%= spree_dom_id prototype %>" data-hook="prototypes_row" class="<%= cycle('odd', 'even')%>">
-        <td><%= prototype.name %></td>
+        <td style="padding-left:1em"><%= prototype.name %></td>
         <td class="actions">
           <%= link_to_edit(prototype, :no_text => true, :class => 'admin_edit_prototype') %>
           <%= link_to_delete(prototype, :no_text => true) %>

--- a/backend/app/views/spree/admin/reports/index.html.erb
+++ b/backend/app/views/spree/admin/reports/index.html.erb
@@ -12,10 +12,9 @@
   <tbody>
     <% @reports.each do |key, value| %>
     <tr data-hook="reports_row">
-      <td><%= link_to value[:name], send("#{key}_admin_reports_url".to_sym) %></td>
-      <td><%= value[:description] %></td>
+      <td class="align-center"><%= link_to value[:name], send("#{key}_admin_reports_url".to_sym) %></td>
+      <td style="padding-left:1em"><%= value[:description] %></td>
     </tr>
     <% end %>
   </tbody>
 </table>
-

--- a/backend/app/views/spree/admin/shared/_address_form.html.erb
+++ b/backend/app/views/spree/admin/shared/_address_form.html.erb
@@ -13,52 +13,52 @@
 
 <div id="<%= is_shipping_address ? 'shipping' : 'billing' %>" style="display: <%= (use_billing && (!(@order.bill_address.empty? && @order.ship_address.empty?) && @order.bill_address.eql?(@order.ship_address))) ? 'none' : 'block' %>" data-hook="address_fields">
   <div class="field <%= "#{shipping_or_billing}-row" %>">
-    <%= f.label :firstname, Spree.t(:first_name) + ':' %>
+    <%= f.label :firstname, Spree.t(:first_name) %>
     <%= f.text_field :firstname, :class => 'fullwidth' %>
   </div>
   <div class="field <%= "#{shipping_or_billing}-row" %>">
-    <%= f.label :lastname, Spree.t(:last_name) + ':' %>
+    <%= f.label :lastname, Spree.t(:last_name) %>
     <%= f.text_field :lastname, :class => 'fullwidth' %>
   </div>
   <% if Spree::Config[:company] %>
     <div class="field <%= "#{shipping_or_billing}-row" %>">
-      <%= f.label :company, Spree.t(:company) + ':' %>
+      <%= f.label :company, Spree.t(:company) %>
       <%= f.text_field :company, :class => 'fullwidth' %>
     </div>
   <% end %>
   <div class="field <%= "#{shipping_or_billing}-row" %>">
-    <%= f.label :address1, Spree.t(:street_address) + ':' %>
+    <%= f.label :address1, Spree.t(:street_address) %>
     <%= f.text_field :address1, :class => 'fullwidth' %>
   </div>
   <div class="field <%= "#{shipping_or_billing}-row" %>">
-    <%= f.label :address2, Spree.t(:street_address_2) + ':' %>
+    <%= f.label :address2, Spree.t(:street_address_2) %>
     <%= f.text_field :address2, :class => 'fullwidth' %>
   </div>
   <div class="field <%= "#{shipping_or_billing}-row" %>">
-    <%= f.label :city, Spree.t(:city) + ':' %>
+    <%= f.label :city, Spree.t(:city) %>
     <%= f.text_field :city, :class => 'fullwidth' %>
   </div>
   <div class="field <%= "#{shipping_or_billing}-row" %>">
-    <%= f.label :zipcode, Spree.t(:zip) + ':' %>
+    <%= f.label :zipcode, Spree.t(:zip) %>
     <%= f.text_field :zipcode, :class => 'fullwidth' %>
   </div>
   <div class="field <%= "#{shipping_or_billing}-row" %>">
-    <%= f.label :country_id, Spree.t(:country) + ':' %>
+    <%= f.label :country_id, Spree.t(:country) %>
     <span id="<%= s_or_b %>country">
       <%= f.collection_select :country_id, available_countries, :id, :name, {}, {:class => 'select2 fullwidth'} %>
     </span>
   </div>
   <div class="field <%= "#{shipping_or_billing}-row" %>">
-    <%= f.label :state_id, Spree.t(:state) + ':' %>
+    <%= f.label :state_id, Spree.t(:state) %>
     <span id="<%= s_or_b %>state">
-      <%= f.text_field :state_name, 
+      <%= f.text_field :state_name,
             :style => "display: #{f.object.country.states.empty? ? 'block' : 'none' };",
            :disabled => !f.object.country.states.empty?, :class => 'fullwidth state_name' %>
       <%= f.collection_select :state_id, f.object.country.states.sort, :id, :name, {:include_blank => true}, {:class => 'select2 fullwidth', :style => "display: #{f.object.country.states.empty? ? 'none' : 'block' };", :disabled => f.object.country.states.empty?} %>
     </span>
   </div>
   <div class="field <%= "#{shipping_or_billing}-row" %>">
-    <%= f.label :phone, Spree.t(:phone) + ':' %>
+    <%= f.label :phone, Spree.t(:phone) %>
     <%= f.phone_field :phone, :class => 'fullwidth' %>
   </div>
 </div>

--- a/backend/app/views/spree/admin/taxonomies/_list.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/_list.html.erb
@@ -1,10 +1,12 @@
 <table class="index sortable" id='listing_taxonomies' data-hook data-sortable-link="<%= update_positions_admin_taxonomies_url %>">
   <colgroup>
-    <col style="width: 85%">
+    <col style="width: 10%">
+    <col style="width: 75%">
     <col style="width: 15%">
   </colgroup>
   <thead>
     <tr data-hook="taxonomies_header">
+      <th class="no-border"></th>
       <th><%= Spree.t(:name) %></th>
       <th class="actions"></th>
     </tr>
@@ -12,10 +14,8 @@
   <tbody>
     <% @taxonomies.each do |taxonomy| %>
       <tr id="<%= spree_dom_id taxonomy %>" data-hook="taxonomies_row" class="<%= cycle('odd', 'even')%>">
-        <td>
-          <span class="handle"></span>
-          <%= taxonomy.name %>
-        </td>
+        <td class="no-border"><span class="handle"></span></td>
+        <td class="align-center"><%= taxonomy.name %></td>
         <td class="actions">
           <%= link_to_edit taxonomy.id, :no_text => true %>
           <%= link_to_delete taxonomy, :no_text => true %>

--- a/backend/app/views/spree/admin/taxonomies/index.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/index.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:taxonomies) %>
@@ -6,10 +6,10 @@
 
 <% content_for :page_actions do %>
   <li>
-    <%= button_link_to Spree.t(:new_taxonomy), spree.new_admin_taxonomy_url, :icon => 'icon-plus', :id => 'admin_new_taxonomy_link' %></p>
+    <%= button_link_to Spree.t(:new_taxonomy), spree.new_admin_taxonomy_url, :icon => 'icon-plus', :id => 'admin_new_taxonomy_link' %>
   </li>
 <% end %>
 
-<div id='list-taxonomies' data-hook>
-  <%= render :partial => 'list' %>
+<div id="list-taxonomies" data-hook>
+  <%= render 'list' %>
 </div>

--- a/backend/app/views/spree/admin/taxons/_form.html.erb
+++ b/backend/app/views/spree/admin/taxons/_form.html.erb
@@ -2,14 +2,16 @@
   <div class="alpha five columns">
     <%= f.field_container :name do %>
       <%= f.label :name, Spree.t(:name) %> <span class="required">*</span><br />
-      <%= error_message_on :taxon, :name, :class => 'fullwidth title' %>
       <%= text_field :taxon, :name, :class => 'fullwidth' %>
+      <%= error_message_on :taxon, :name, :class => 'fullwidth title' %>
     <% end %>
 
     <%= f.field_container :permalink_part do %>
-      <%= f.label :permalink_part, Spree.t(:permalink) %><span class="required">*</span><br />
-      <%= @taxon.permalink.split("/")[0...-1].join("/") + "/" %>
-      <%= text_field_tag :permalink_part, @permalink_part %>
+      <%= f.label :permalink_part, Spree.t(:permalink) %> <span class="required">*</span><br />
+      <%= text_field_tag :permalink_part, @permalink_part, :class => 'fullwidth' %><br />
+      <span class="info" id="permalink_part_display">
+        <%= @taxon.permalink.split('/')[0...-1].join('/') + '/' %>
+      </span>
     <% end %>
 
     <%= f.field_container :icon do %>
@@ -41,5 +43,4 @@
       <%= f.text_field :meta_keywords, :class => 'fullwidth', :rows => 6 %>
     <% end %>
   </div>
-
 </div>

--- a/backend/app/views/spree/admin/taxons/edit.html.erb
+++ b/backend/app/views/spree/admin/taxons/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:taxon_edit) %>
@@ -13,11 +13,26 @@
 <% # Because otherwise the form would attempt to use to_param of @taxon %>
 <% form_url = admin_taxonomy_taxon_path(@taxonomy.id, @taxon.id) %>
 <%= form_for [:admin, @taxonomy, @taxon], :method => :put, :url => form_url, :html => { :multipart => true } do |f| %>
-  <%= render :partial => 'form', :locals => { :f => f } %>
+  <%= render 'form', :f => f %>
 
   <div class="form-buttons" data-hook="buttons">
     <%= button Spree.t('actions.update'), 'icon-refresh' %>
     <%= Spree.t(:or) %>
     <%= button_link_to Spree.t('actions.cancel'), edit_admin_taxonomy_url(@taxonomy), :icon => "icon-remove" %>
   </div>
+<% end %>
+
+<% content_for :head do %>
+  <%= javascript_tag do -%>
+    $(document).ready(function() {
+      var field  = $('#permalink_part'),
+          target = $('#permalink_part_display'),
+          permalink_part_default = target.text().trim();
+
+      target.text(permalink_part_default + field.val());
+      field.on('keyup blur', function () {
+        target.text(permalink_part_default + $(this).val());
+      });
+    });
+  <% end -%>
 <% end %>


### PR DESCRIPTION
I keep them separated until you guys have valuated them, then I can squash them.
- Fixes outdate jQuery live.
- Remove colons for label tags for consistency in layout.
- Add missing required for field in prototypes form.
- Fixes taxon form layout issues + js permalink helper.
- Remove loose p-tag in taxonomies index page.
- Nicer products stock delete icons.
- Fixes wild placed sorting icons.
- Misc table layout styling + cleanup in those files touched.

Also the jQuery UI autocomplete on product properties page is wild and un-styled, the quick CSS fix I use in my admin overrride:

``` scss

.ui-widget {
  font-family: $base-font-family;
  font-size: 90%;
  font-weight: 400;
}

.ui-widget-content {
  background-image: none;
  border: 1px solid $color-border;
  -webkit-border-radius: 3px;
  -moz-border-radius: 3px;
  border-radius: 3px;
  color: $color-4;
  font-size: 90%;
}

.ui-autocomplete {
  width: 300px; /* fix width for product properties table */
  list-style-type: none;

  li {
    padding: 8px;

    .ui-corner-all {
      padding: 4px;
    }

    .ui-state-focus {
      background-image: none;
      background-color: transparent;
      color: $color-2;
      border: none;
      cursor: pointer;
    }
  }
}
```

...but no clue where it should go in the scss files so you welcome to copy and paste it where it belongs or give me directions where to put it.
