### PR TITLE
[backend] Misc layout fixes for shipping and stock pages.

### DIFF
--- a/backend/app/views/spree/admin/shipping_methods/index.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/index.html.erb
@@ -30,9 +30,9 @@
     <tbody>
       <% @shipping_methods.each do |shipping_method|%>
         <tr id="<%= spree_dom_id shipping_method %>" data-hook="admin_shipping_methods_index_rows" class="<%= cycle('odd', 'even')%>">
-          <td><%= shipping_method.admin_name + ' / ' if shipping_method.admin_name.present? %><%= shipping_method.name %></td>
-          <td><%= shipping_method.zones.collect(&:name).join(", ") if shipping_method.zones %></td>
-          <td><%= shipping_method.calculator.description %></td>
+          <td class="align-center"><%= shipping_method.admin_name + ' / ' if shipping_method.admin_name.present? %><%= shipping_method.name %></td>
+          <td class="align-center"><%= shipping_method.zones.collect(&:name).join(", ") if shipping_method.zones %></td>
+          <td class="align-center"><%= shipping_method.calculator.description %></td>
           <td class="align-center"><%= shipping_method.display_on.blank? ? Spree.t(:both) : Spree.t(shipping_method.display_on) %></td>
           <td data-hook="admin_shipping_methods_index_row_actions" class="actions">
             <%= link_to_edit shipping_method, :no_text => true %>

--- a/backend/app/views/spree/admin/stock_locations/_form.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/_form.html.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="alpha twelve columns">
       <%= f.field_container :name do %>
-        <%= f.label :name, Spree.t(:name) %>
+        <%= f.label :name, Spree.t(:name) %> <span class="required">*</span><br />
         <%= f.text_field :name, :class => 'fullwidth' %>
       <% end %><br>
       <%= f.field_container :admin_name do %>
@@ -14,17 +14,17 @@
       <%= f.field_container :active do %>
         <label for="active"><%= Spree.t(:state) %></label>
         <ul>
-          <li>
-            <%= f.label :active, Spree.t(:active) + ':' %>
-            <%= f.check_box :active %>
+          <li style="padding:4px;display:block">
+            <%= f.check_box(:active) %>
+            <%= f.label :active, Spree.t(:active) %>
           </li>
-          <li>
-            <%= f.label :active, Spree.t(:backorderable_default) + ':' %>
-            <%= f.check_box :backorderable_default %>
+          <li style="padding:4px">
+            <%= f.check_box(:backorderable_default) %>
+            <%= f.label :active, Spree.t(:backorderable_default) %>
           </li>
-          <li>
-            <%= f.label :active, Spree.t(:propagate_all_variants) + ':' %>
-            <%= f.check_box :propagate_all_variants %>
+          <li style="padding:4px">
+            <%= f.check_box(:propagate_all_variants) %>
+            <%= f.label :active, Spree.t(:propagate_all_variants) %>
           </li>
         </ul>
       <% end %>
@@ -34,27 +34,27 @@
   <div class="row">
     <div class="alpha four columns">
       <div class="field ">
-        <%= f.label :address1, Spree.t(:street_address) + ':' %>
+        <%= f.label :address1, Spree.t(:street_address) %>
         <%= f.text_field :address1, :class => 'fullwidth' %>
       </div>
     </div>
 
     <div class="four columns">
       <div class="field ">
-        <%= f.label :address2, Spree.t(:street_address_2) + ':' %>
+        <%= f.label :address2, Spree.t(:street_address_2) %>
         <%= f.text_field :address2, :class => 'fullwidth' %>
       </div>
     </div>
     <div class="four columns">
       <div class="field ">
-        <%= f.label :city, Spree.t(:city) + ':' %>
+        <%= f.label :city, Spree.t(:city) %>
         <%= f.text_field :city, :class => 'fullwidth' %>
       </div>
     </div>
 
     <div class="omega four columns">
       <div class="field ">
-        <%= f.label :zipcode, Spree.t(:zip) + ':' %>
+        <%= f.label :zipcode, Spree.t(:zip) %>
         <%= f.text_field :zipcode, :class => 'fullwidth' %>
       </div>
     </div>
@@ -63,7 +63,7 @@
   <div class="row">
     <div class="alpha eight columns">
       <div class="field ">
-        <%= f.label :country_id, Spree.t(:country) + ':' %>
+        <%= f.label :country_id, Spree.t(:country) %>
         <span id="country"><%= f.collection_select :country_id, available_countries, :id, :name, {}, {:class => 'select2 fullwidth'} %></span>
       </div>
     </div>
@@ -71,7 +71,7 @@
     <div class="four columns">
       <div class="field ">
         <% if f.object.country %>
-          <%= f.label :state_id, Spree.t(:state) + ':' %>
+          <%= f.label :state_id, Spree.t(:state) %>
           <span id="state" class="region">
             <%= f.text_field :state_name, :style => "display: #{f.object.country.states.empty? ? 'block' : 'none' };", :disabled => !f.object.country.states.empty?, :class => 'fullwidth state_name' %>
             <%= f.collection_select :state_id, f.object.country.states.sort, :id, :name, {:include_blank => true}, {:class => 'select2 fullwidth', :style => "display: #{f.object.country.states.empty? ? 'none' : 'block' };", :disabled => f.object.country.states.empty?} %>
@@ -82,7 +82,7 @@
 
     <div class="omega four columns">
       <div class="field ">
-        <%= f.label :phone, Spree.t(:phone) + ':' %>
+        <%= f.label :phone, Spree.t(:phone) %>
         <%= f.phone_field :phone, :class => 'fullwidth' %>
       </div>
     </div>

--- a/backend/app/views/spree/admin/stock_locations/index.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/index.html.erb
@@ -18,9 +18,9 @@
 <% if @stock_locations.any? %>
   <table class="index" id='listing_stock_locations' data-hook>
     <colgroup>
-      <col style="width: 50%" />
+      <col style="width: 40%" />
       <col style="width: 15%" />
-      <col style="width: 20%" />
+      <col style="width: 30%" />
       <col style="width: 15%" />
     </colgroup>
     <thead>
@@ -37,9 +37,9 @@
            @delete_url = admin_stock_location_path(stock_location)
       %>
         <tr id="<%= spree_dom_id stock_location %>" data-hook="stock_location_row" class="<%= cycle('odd', 'even')%>">
-          <td><%= display_name(stock_location) %></td>
-          <td><span class="state <%= state(stock_location) %>"><%= state(stock_location) %></span></td>
-          <td><%= link_to Spree.t(:stock_movements), admin_stock_location_stock_movements_path(stock_location.id) %> </td>
+          <td class="align-center"><%= display_name(stock_location) %></td>
+          <td class="align-center"><span class="state <%= state(stock_location) %>"><%= state(stock_location) %></span></td>
+          <td class="align-center"><%= link_to Spree.t(:stock_movements), admin_stock_location_stock_movements_path(stock_location.id) %> </td>
           <td class="actions">
             <%= link_to_edit stock_location, :no_text => true %>
             <%= link_to_delete stock_location, :no_text => true %>

--- a/backend/app/views/spree/admin/stock_transfers/new.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/new.html.erb
@@ -1,12 +1,12 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t('new_stock_transfer') %>
+  <%= Spree.t(:new_stock_transfer) %>
 <% end %>
 
 <% content_for :page_actions do %>
   <li>
-    <%= button_link_to Spree.t('back_to_stock_transfers_list'), admin_stock_transfers_path, :icon => 'icon-arrow-left' %>
+    <%= button_link_to Spree.t(:back_to_stock_transfers_list), admin_stock_transfers_path, :icon => 'icon-arrow-left' %>
   </li>
 <% end %>
 
@@ -14,10 +14,10 @@
   {{#each variants}}
     <tr>
       <td>{{name}}</td>
-      <td class="align-center">{{quantity}}</td>
-      <td class="align-center">
-        <button class='icon-trash transfer_remove_variant button'
-                data-variant-id='{{id}}'>remove</button>
+      <td class='align-center'>{{quantity}}</td>
+      <td class='actions'>
+        <button class='icon_link icon-trash no-text transfer_remove_variant'
+                data-variant-id='{{id}}' data-action'remove'></button>
       </td>
       <input type='hidden' id='variant[]' name='variant[]' value='{{id}}'>
       <input type='hidden' id='quantity[]' name='quantity[]' value='{{quantity}}'>
@@ -27,12 +27,12 @@
 
 <%= form_tag admin_stock_transfers_path, :method => :post do %>
   <fieldset class="twelve columns alpha">
-    <legend align="center"><%= Spree.t('transfer_stock')%></legend>
+    <legend align="center"><%= Spree.t(:transfer_stock) %></legend>
 
     <div class="row" data-hook="admin_stock_movements_form_fields">
       <div class="alpha six columns">
         <div class="field" id="stock_movement_reference_field">
-          <%= label_tag 'reference', raw("#{Spree.t('reference')} (#{Spree.t('optional')})") %>
+          <%= label_tag 'reference', raw("#{Spree.t(:reference)} (#{Spree.t(:optional)})") %>
           <%= text_field_tag :reference, '', class: 'fullwidth' %>
         </div>
       </div>
@@ -46,54 +46,57 @@
       </div>
       <div class="alpha six columns">
         <div class="field" id="transfer_source_location_id_field">
-          <%= label_tag :transfer_source_location_id, Spree.t('source') %>
+          <%= label_tag :transfer_source_location_id, Spree.t(:source) %>
           <%= select_tag :transfer_source_location_id, {}, class: 'select2 fullwidth' %>
         </div>
       </div>
       <div class="six columns omega">
         <div class="field" id="transfer_destination_location_id_field">
-          <%= label_tag :transfer_destination_location_id, Spree.t('destination') %>
+          <%= label_tag :transfer_destination_location_id, Spree.t(:destination) %>
           <%= select_tag :transfer_destination_location_id, {}, class: 'select2 fullwidth' %>
         </div>
       </div>
     </div>
 
     <fieldset class="no-border-bottom" id="add-variant-to-transfer">
-      <legend><%= Spree.t('add_variant') %></legend>
+      <legend><%= Spree.t(:add_variant) %></legend>
 
       <div class="alpha eight columns">
         <div class="field" id="stock_movement_variant_id_field">
-          <%= label_tag 'variant_id', Spree.t('variant') %>
+          <%= label_tag 'variant_id', Spree.t(:variant) %>
           <%= select_tag 'transfer_variant', {}, class: 'fullwidth' %>
         </div>
       </div>
       <div class="two columns">
         <div class="field" id="stock_movement_quantity_field">
-          <%= label_tag 'quantity', Spree.t('quantity') %>
+          <%= label_tag 'quantity', Spree.t(:quantity) %>
           <%= number_field_tag 'transfer_variant_quantity', 1, class: 'fullwidth', min: 0 %>
         </div>
       </div>
       <div class="two columns omega">
-        <div class="field">
-          <%= button Spree.t('add'), 'icon-plus button transfer_add_variant' %>
+        <div class="field" style="padding: 25px 0 0 0 !important">
+          <%= button Spree.t(:add), 'icon-plus button transfer_add_variant' %>
         </div>
       </div>
 
     </fieldset>
 
-    <div class="no-objects-found">No variants added for transfer. Please, add one.</div>
+    <div class="alpha twelve columns no-objects-found">
+      <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/stock_transfer')) %>,
+      <%= link_to Spree.t(:add_one), spree.new_admin_tax_rate_path %>!
+    </div>
 
     <div id="transfer-variants-table" class="twelve columns alpha" style="display:none">
       <table class="index sortable">
         <colgroup>
-          <col style="width: 60%" />
+          <col style="width: 70%" />
           <col style="width: 20%" />
-          <col style="width: 20%" />
+          <col style="width: 10%" />
         </colgroup>
         <thead data-hook="transfer_variants_header">
           <th><%= Spree.t(:name) %></th>
           <th><%= Spree.t(:quantity) %></th>
-          <th><%= Spree.t(:remove) %></th>
+          <th class="actions"></th>
         </thead>
         <tbody id="transfer_variants_tbody">
 
@@ -102,7 +105,7 @@
     </div>
 
     <div class="filter-actions actions" data-hook="buttons">
-      <%= button Spree.t('transfer_stock'), 'icon-plus transfer_transfer' %>
+      <%= button Spree.t(:transfer_stock), 'icon-plus transfer_transfer' %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/stock_transfers/show.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/show.html.erb
@@ -1,45 +1,49 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t('stock_transfer') %>
+  <%= Spree.t(:stock_transfer) %>
 <% end %>
 
 <% content_for :page_actions do %>
   <li>
-    <%= button_link_to Spree.t('back_to_stock_transfers_list'), admin_stock_transfers_path, :icon => 'icon-arrow-left' %>
+    <%= button_link_to Spree.t(:back_to_stock_transfers_list), admin_stock_transfers_path, :icon => 'icon-arrow-left' %>
   </li>
   <li>
-    <%= button_link_to Spree.t('new_stock_transfer'), new_admin_stock_transfer_path, { :icon => 'icon-forward' } %>
+    <%= button_link_to Spree.t(:new_stock_transfer), new_admin_stock_transfer_path, { :icon => 'icon-forward' } %>
   </li>
 <% end %>
 
 <fieldset class="no-border-bottom">
-  <legend align="center"><%= Spree.t('stock_transfer') %></legend>
+  <legend align="center"><%= Spree.t(:stock_transfer) %></legend>
 
   <div class="alpha six columns">
     <div class="field">
-      <label><%= Spree.t('reference') %>:</label>
+      <label><%= Spree.t(:reference) %></label>
       <div class="value"><%= @stock_transfer.reference %></div>
     </div>
   </div>
 
   <div class="omega six columns">
     <div class="field">
-      <label><%= Spree.t('created_at') %>:</label>
+      <label><%= Spree.t(:created_at) %></label>
       <div class="value"><%= @stock_transfer.created_at %></div>
     </div>
   </div>
 
   <% if @stock_transfer.source_movements.present? %>
     <fieldset class="no-border-bottom">
-      <legend id='stock-location-source'><%= Spree.t('source') %> <i class="icon-arrow-right"></i> <%= @stock_transfer.source_location.name %></legend>
+      <legend id="stock-location-source">
+        <%= Spree.t(:source) %> <i class="icon-arrow-right"></i> <%= @stock_transfer.source_location.name %>
+      </legend>
       <%= render :partial => 'stock_movements', :object => @stock_transfer.source_movements %>
     </fieldset>
   <% end %>
 
   <% if @stock_transfer.destination_movements.present? %>
     <fieldset class="no-border-bottom">
-      <legend id='stock-location-destination'><%= Spree.t('destination') %> <i class="icon-arrow-right"></i> <%= @stock_transfer.destination_location.name %></legend>
+      <legend id="stock-location-destination">
+        <%= Spree.t(:destination) %> <i class="icon-arrow-right"></i> <%= @stock_transfer.destination_location.name %>
+      </legend>
       <%= render :partial => 'stock_movements', :object => @stock_transfer.destination_movements %>
     </fieldset>
   <% end %>

--- a/backend/spec/features/admin/stock_transfer_spec.rb
+++ b/backend/spec/features/admin/stock_transfer_spec.rb
@@ -14,7 +14,7 @@ describe 'Stock Transfers', :js => true do
     click_button 'Add'
     click_button 'Transfer Stock'
 
-    page.should have_content('STOCK TRANSFER REFERENCE: PO 666')
+    page.should have_content('STOCK TRANSFER REFERENCE PO 666')
     page.should have_content('NY')
     page.should have_content('SF')
 
@@ -24,7 +24,7 @@ describe 'Stock Transfers', :js => true do
 
   describe 'received stock transfer' do
     def it_is_received_stock_transfer(page)
-      page.should have_content('STOCK TRANSFER REFERENCE: PO 666')
+      page.should have_content('STOCK TRANSFER REFERENCE PO 666')
       page.should_not have_selector("#stock-location-source")
       page.should have_selector("#stock-location-destination")
 


### PR DESCRIPTION
- Remove colons in stock locations form label tags for consistency.
- Center table items so it looks correct.
- Add missing "required" tag for stock location name.
- Change stock transfer "remove" button to standard round version (without tooltip and table css fx due to it do not get invoked thru Ajax).
- Fix alignment of stock locations "add" button. 
- Fix untranslated "No variants added for transfer.."
- Change table column width's to respect other locales (that might have longer words, normally German and Finnish).
