### PR TITLE
Fix format of price input in products/new.html.erb

### DIFF
--- a/backend/app/views/spree/admin/products/new.html.erb
+++ b/backend/app/views/spree/admin/products/new.html.erb
@@ -34,7 +34,7 @@
       <div class="four columns">
         <%= f.field_container :price do %>
           <%= f.label :price, Spree.t(:master_price) %> <span class="required">*</span><br />
-          <%= f.text_field :price, :class => 'fullwidth' %>
+          <%= f.text_field :price, :value => number_to_currency(@product.price, :unit => ''), :class => 'fullwidth' %>
           <%= f.error_message_on :price %>
         <% end %>
       </div>

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -209,6 +209,40 @@ describe "Products" do
         page.should have_content("Name can't be blank")
       end
 
+      context "using a locale with a different decimal format " do
+        before do
+          # change English locale’s separator and delimiter to match 19,99 format
+          I18n.backend.store_translations(:en,
+            :number => {
+              :currency => {
+                :format => {
+                  :separator => ",",
+                  :delimiter => "."
+                }
+              }
+            })
+        end
+
+        after do
+          # revert changes to English locale
+          I18n.backend.store_translations(:en,
+            :number => {
+              :currency => {
+                :format => {
+                  :separator => ".",
+                  :delimiter => ","
+                }
+              }
+            })
+        end
+
+        it "should show localized price value on validation errors", :js => true do
+          fill_in "product_price", :with => "19,99"
+          click_button "Create"
+          find('input#product_price').value.should == '19,99'
+        end
+      end
+
       # Regression test for #2097
       it "can set the count on hand to a null value", :js => true do
         fill_in "product_name", :with => "Baseball Cap"
@@ -220,6 +254,7 @@ describe "Products" do
         page.should have_content("successfully updated!")
       end
     end
+    
 
     context "cloning a product", :js => true do
       it "should allow an admin to clone a product" do


### PR DESCRIPTION
The new product form should format the value of the price input.

This is relevant when the users saves and the field is displayed again due to a failed validation (e.g. missing shipping category)

A locale other than english would mess up the prices otherwise.
