### PR TITLE
Grab deleted variants from a inventory unit

### DIFF
--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -51,6 +51,11 @@ module Spree
         variant_id: variant_id).first
     end
 
+    # Remove variant default_scope `deleted_at: nil`
+    def variant
+      Spree::Variant.unscoped { super }
+    end
+
     private
 
       def allow_ship?

--- a/core/spec/models/spree/inventory_unit_spec.rb
+++ b/core/spec/models/spree/inventory_unit_spec.rb
@@ -53,6 +53,17 @@ describe Spree::InventoryUnit do
     end
   end
 
+  context "variants deleted" do
+    let!(:unit) do
+      Spree::InventoryUnit.create(variant: stock_item.variant)
+    end
+
+    it "can still fetch variant" do
+      unit.variant.destroy
+      expect(unit.reload.variant).to be_a Spree::Variant
+    end
+  end
+
   context "#finalize_units!" do
     let!(:stock_location) { create(:stock_location) }
     let(:variant) { create(:variant) }


### PR DESCRIPTION
Needed after paranoia gem introduced a default_scope in variant model. This fixes the issue right now but I guess we need to come up with something better than spreading that variant override across models, maybe at least create a module or something. any ideas?

ps. this is broken in 2-0-stable as well.
