### PR TITLE
Refactored Core Order Checkout and added more tests.

### DIFF
--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -125,9 +125,7 @@ module Spree
 
           def self.remove_transition(options={})
             self.removed_transitions << options
-            if transition = find_transition(options)
-              self.next_event_transitions.delete(transition)
-            end
+            self.next_event_transitions.delete(find_transition(options))
           end
 
           def self.find_transition(options={})
@@ -149,15 +147,10 @@ module Spree
           end
 
           def checkout_steps
-            checkout_steps = []
-            # TODO: replace this with each_with_object once Ruby 1.9 is standard
-            self.class.checkout_steps.each do |step, options|
-              if options[:if]
-                next unless options[:if].call(self)
-              end
+            steps = self.class.checkout_steps.each_with_object([]) { |(step, options), checkout_steps|
+              next if options.include?(:if) && !options[:if].call(self)
               checkout_steps << step
-            end
-            steps = checkout_steps.map(&:to_s)
+            }.map(&:to_s)
             # Ensure there is always a complete step
             steps << "complete" unless steps.include?("complete")
             steps

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -129,6 +129,7 @@ module Spree
           end
 
           def self.find_transition(options={})
+            return nil if options.nil? || !options.include?(:from) || !options.include?(:to)
             self.next_event_transitions.detect do |transition|
               transition[options[:from].to_sym] == options[:to].to_sym
             end


### PR DESCRIPTION
Guys,
To get started into Spree codebase, I did a small refactoring in the Order Checkout code. I removed some temp variables from methods and tried to make things more readable.

On block chaining, I didn't find any example to follow, so I followed this [Ruby Style Guide: Blocks](http://xaviershay.com/ruby-style-guide#blocks-and%20procs) - let me know if it fits or has a better way to do.

I've added tests for `remove_transition` and more one to `find_transition`. There is no broken test

I hope this would be a good way to start :)
