### PR TITLE
enable spree_frontend variables_override

### DIFF
--- a/frontend/app/assets/stylesheets/store/_variables_override.css.scss
+++ b/frontend/app/assets/stylesheets/store/_variables_override.css.scss
@@ -1,0 +1,7 @@
+/*--------------------------------------------------------- 
+  Empty file to override variables in user applications.
+
+  To set your own colors, sizes or fonts just override this 
+  file in your application and set variables according to
+  globals/_variables.scss file.
+  --------------------------------------------------------- */

--- a/frontend/app/assets/stylesheets/store/screen.css.scss
+++ b/frontend/app/assets/stylesheets/store/screen.css.scss
@@ -1,3 +1,4 @@
+@import 'variables_override';
 @import 'variables';
 
 /*--------------------------------------*/


### PR DESCRIPTION
Allow spree frontend CSS variables to be overridden the way spree backend allows them to be overridden
