### PR TITLE
Fetch active variant only in order import through api (1-3-stable)

### DIFF
--- a/api/app/models/spree/order_decorator.rb
+++ b/api/app/models/spree/order_decorator.rb
@@ -106,7 +106,7 @@ Spree::Order.class_eval do
   def self.ensure_variant_id_from_api(hash)
     begin
       unless hash[:variant_id].present?
-        hash[:variant_id] = Spree::Variant.find_by_sku!(hash[:sku]).id
+        hash[:variant_id] = Spree::Variant.active.find_by_sku!(hash[:sku]).id
         hash.delete(:sku)
       end
     rescue Exception => e

--- a/api/spec/models/spree/order_spec.rb
+++ b/api/spec/models/spree/order_spec.rb
@@ -42,6 +42,7 @@ module Spree
     it 'can build an order from API with just line items' do
       params = { :line_items_attributes => line_items }
 
+      Order.should_receive(:ensure_variant_id_from_api)
       order = Order.build_from_api(user, params)
 
       order.user.should == nil
@@ -138,6 +139,24 @@ module Spree
       }.to raise_error /XXX/
     end
 
+    context 'variant not deleted' do
+      it 'ensures variant id from api' do
+        hash = { sku: variant.sku }
+        Order.ensure_variant_id_from_api(hash)
+        expect(hash[:variant_id]).to eq variant.id
+      end
+    end
+
+    context 'variant was deleted' do
+      it 'raise error as variant shouldnt be found' do
+        variant.product.delete
+        hash = { sku: variant.sku }
+        expect {
+          Order.ensure_variant_id_from_api(hash)
+        }.to raise_error
+      end
+    end
+
     it 'ensures_country_id for country fields' do
       [:name, :iso, :iso_name, :iso3].each do |field|
         address = { :country => { field => country.send(field) }}
@@ -154,18 +173,31 @@ module Spree
       end
     end
 
-    it 'builds a shipments' do
-      params = { :shipments_attributes => [{ :tracking => '123456789',
-                                             :cost => '4.99',
-                                             :shipping_method => shipping_method.name,
-                                             :inventory_units => [{ :sku => sku }]
-                                           }] }
-      order = Order.build_from_api(user, params)
-      shipment = order.shipments.first
-      shipment.inventory_units.first.variant_id.should eq product.master.id
-      shipment.tracking.should eq '123456789'
-      shipment.adjustment.amount.should eq 4.99
-      shipment.adjustment.should be_locked
+    context "shippments" do
+      let(:params) do
+        { :shipments_attributes => [
+            { :tracking => '123456789',
+              :cost => '4.99',
+              :shipping_method => shipping_method.name,
+              :inventory_units => [{ :sku => sku }]
+            }
+        ] }
+      end
+
+      it 'ensures variant exists and is not deleted' do
+        Order.should_receive(:ensure_variant_id_from_api)
+        order = Order.build_from_api(user, params)
+      end
+
+      it 'builds them properly' do
+        order = Order.build_from_api(user, params)
+
+        shipment = order.shipments.first
+        shipment.inventory_units.first.variant_id.should eq product.master.id
+        shipment.tracking.should eq '123456789'
+        shipment.adjustment.amount.should eq 4.99
+        shipment.adjustment.should be_locked
+      end
     end
 
     it 'handles shipment building exceptions' do


### PR DESCRIPTION
I'll submit another PR to master and 2-0-stable to port the specs and ensure the behaviour is maintained there too.

cc @BDQ
