### PR TITLE
Making bugfix in commit 07b2c6316a3cf623ca4ea4be8d680e46b6b8f9d4 to spree promo order decorator as well

### DIFF
--- a/promo/app/controllers/spree/orders_controller_decorator.rb
+++ b/promo/app/controllers/spree/orders_controller_decorator.rb
@@ -15,7 +15,7 @@ Spree::OrdersController.class_eval do
       respond_with(@order) do |format|
         format.html do
           if params.has_key?(:checkout)
-            @order.next_transition.run_callbacks
+            @order.next_transition.run_callbacks if @order.cart?
             redirect_to checkout_state_path(@order.checkout_steps.first)
           else
             redirect_to cart_path


### PR DESCRIPTION
https://github.com/spree/spree/issues/3612 and https://github.com/spree/spree/issues/3613 are being addressed by changes to the `orders_controller`. However, we need to also modify the `promo/app/controllers/spree/orders_controller_decorator.rb` to also include the `if @order.cart?` line, otherwise the older broken code in this decorator will override the fixed code in the core `orders_controller`.
