### PR TITLE
standardized address attributes in api_helpers

### DIFF
--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -71,6 +71,10 @@ module Spree
         [:id, :number, :state, :amount, :order_id, :reason, :created_at, :updated_at]
       end
 
+      def address_attributes
+        [:id, :firstname, :lastname, :full_name, :address1, :address2, :city, :zipcode, :phone, :company, :alternative_phone, :country_id, :state_id, :state_name]
+      end
+
       def country_attributes
         [:id, :iso_name, :iso, :iso3, :name, :numcode]
       end

--- a/api/app/views/spree/api/addresses/show.v1.rabl
+++ b/api/app/views/spree/api/addresses/show.v1.rabl
@@ -1,8 +1,6 @@
 object @address
-attributes :id, :firstname, :lastname, :full_name, :address1, :address2,
-           :city, :zipcode, :phone,
-           :company, :alternative_phone, :country_id, :state_id,
-           :state_name
+attributes *address_attributes
+
 child(:country) do |address|
   attributes *country_attributes
 end


### PR DESCRIPTION
Added address_attributes to the api_helpers.rb file so that it would be in line with all of the other object attributes in the api.
