### PR TITLE
Fetch active variant only in order import through api

### DIFF
--- a/api/app/models/spree/order_decorator.rb
+++ b/api/app/models/spree/order_decorator.rb
@@ -103,7 +103,7 @@ Spree::Order.class_eval do
   def self.ensure_variant_id_from_api(hash)
     begin
       unless hash[:variant_id].present?
-        hash[:variant_id] = Spree::Variant.find_by_sku!(hash[:sku]).id
+        hash[:variant_id] = Spree::Variant.active.find_by_sku!(hash[:sku]).id
         hash.delete(:sku)
       end
     rescue Exception => e


### PR DESCRIPTION
This is so that we ensure the same behaviour applied in #3642 is also verified in master and 2-0-stable (it should apply cleanly to 2-0-stable)
