### PR TITLE
Ransack gem dependency updated to version 1.0.0.

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'paperclip', '~> 3.4.1'
   s.add_dependency 'paranoia', '~> 1.3'
   s.add_dependency 'rails', '~> 3.2.14'
-  s.add_dependency 'ransack', '0.7.2'
+  s.add_dependency 'ransack', '~> 1.0.0'
   s.add_dependency 'state_machine', '1.2.0'
   s.add_dependency 'stringex', '~> 1.5.1'
   s.add_dependency 'truncate_html', '0.9.2'


### PR DESCRIPTION
Updated Ransack dependency to version 1.0.0 instead of 0.7.2.
