### PR TITLE
Use variant name instead of sku for select

### DIFF
--- a/backend/app/views/spree/admin/products/_add_stock_form.html.erb
+++ b/backend/app/views/spree/admin/products/_add_stock_form.html.erb
@@ -20,7 +20,7 @@
       <div class="five columns omega">
         <%= f.field_container :variant_id do %>
           <%= label_tag 'variant_id', Spree.t(:variant) %>
-          <%= select_tag 'variant_id', options_from_collection_for_select(@variants, :id, :sku),
+          <%= select_tag 'variant_id', options_from_collection_for_select(@variants, :id, :name),
             class: 'select2 fullwidth' %>
         <% end %>
       </div>


### PR DESCRIPTION
Sku is not a required attribute for variants or products. Using it can leave the select input with blank values, making it difficult to choose the correct variant.
