### PR TITLE
2 Migrations to ease in the upgrade from 1.3 -> 2.0

### DIFF
--- a/core/db/migrate/20130830001033_add_shipping_category_to_shipping_methods_and_products.rb
+++ b/core/db/migrate/20130830001033_add_shipping_category_to_shipping_methods_and_products.rb
@@ -1,0 +1,15 @@
+class AddShippingCategoryToShippingMethodsAndProducts < ActiveRecord::Migration
+  def up
+    default_category = Spree::ShippingCategory.first
+    default_category ||= Spree::ShippingCategory.create!(:name => "Default")
+
+    Spree::ShippingMethod.all.each do |method|
+      method.shipping_categories << default_category if method.shipping_categories.blank?
+    end
+
+    Spree::Product.where(shipping_category_id: nil).update_all(shipping_category_id: default_category.id)
+  end
+
+  def down
+  end
+end

--- a/core/db/migrate/20130830001159_migrate_old_shipping_calculators.rb
+++ b/core/db/migrate/20130830001159_migrate_old_shipping_calculators.rb
@@ -1,0 +1,19 @@
+class MigrateOldShippingCalculators < ActiveRecord::Migration
+  def up
+    Spree::ShippingMethod.all.each do |shipping_method|
+      old_calculator = shipping_method.calculator
+      next if old_calculator.class < Spree::ShippingCalculator # We don't want to mess with new shipping calculators
+      new_calculator = eval("Spree::Calculator::Shipping::#{old_calculator.class.name.demodulize}").new
+      new_calculator.preferences.keys.each do |pref|
+        # Preferences can't be read/set by name, you have to prefix preferred_
+        pref_method = "preferred_#{pref}"
+        new_calculator.send("#{pref_method}=", old_calculator.send(pref_method))
+      end
+      new_calculator.save
+      shipping_method.calculator = new_calculator
+    end
+  end
+
+  def down
+  end
+end


### PR DESCRIPTION
- Assign a shipping category to existing products & shipping methods if they don't have one
- Migrate old shipping calculators to the new ones and preserve their preferences

Fixes #3605

Should probably be merged into master as well
