### PR TITLE
Stop Patment#identifier overwriting on each save

### DIFF
--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -109,15 +109,16 @@ module Spree
       # and this is it. Related to #1998.
       # See https://github.com/spree/spree/issues/1998#issuecomment-12869105
       def set_unique_identifier
+        return true if self.identifier.present?
+
         chars = [('A'..'Z').to_a, ('0'..'9').to_a].flatten - %w(0 1 I O)
-        identifier = ''
-        8.times { identifier << chars[rand(chars.length)] }
-        if Spree::Payment.exists?(:identifier => identifier)
-          # Call it again, we've got a duplicate ID.
-          set_unique_identifier
-        else
-          self.identifier = identifier
+        new_identifier = ''
+
+        while new_identifier.empty? or Spree::Payment.exists?(:identifier => new_identifier)
+          new_identifier = 8.times.map{ chars[rand(chars.length)] }.join
         end
+
+        self.identifier = new_identifier
       end
   end
 end


### PR DESCRIPTION
After the fix for #1998 went into the codebase, the gateway and the app invoice #'s have gotten out of sync. This happens because each time after sending the purchase/authorization to the gateway, the app calls `#save` on the payment, thereby overwriting its identifier. So the invoice # sent tothe gateway is impossible to recreate.

Makes looking up transactions really hard for the sales staff :)

This commit refactor the method to only run once with a while loop, thereby letting us simply check for identifier presence as an early return guard condition. 

Awkward case for a regression spec, but LMK if that's desired. 
