### PR TITLE
Adding data-hook for line_item_description

### DIFF
--- a/frontend/app/views/spree/orders/_line_item.html.erb
+++ b/frontend/app/views/spree/orders/_line_item.html.erb
@@ -16,7 +16,9 @@
           <%= Spree.t(:out_of_stock) %>&nbsp;&nbsp;<br />
         </span>
       <% end %>
-      <%= line_item_description(variant) %>
+      <span class="line-item-description" data-hook="line_item_description">
+        <%= line_item_description(variant) %>
+      </span>
     </td>
     <td class="cart-item-price" data-hook="cart_item_price">
       <%= line_item.single_money.to_html %>


### PR DESCRIPTION
Same change as in https://github.com/spree/spree/commit/a4de83cd2376ba9666ec9fc63f68f7fadf236f73 on the 1-3-stable branch, but for the master branch.
