### PR TITLE
Make default tax not apply to non-matching zones.

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -174,8 +174,7 @@ module Spree
     # Returns the relevant zone (if any) to be used for taxation purposes.
     # Uses default tax zone unless there is a specific match
     def tax_zone
-      zone_address = Spree::Config[:tax_using_ship_address] ? ship_address : bill_address
-      Zone.match(zone_address) || Zone.default_tax
+      Zone.match(tax_address) || Zone.default_tax
     end
 
     # Indicates whether tax should be backed out of the price calcualtions in
@@ -186,6 +185,13 @@ module Spree
       return tax_zone != Zone.default_tax
     end
 
+    # Returns the address for taxation based on configuration
+    def tax_address
+      Spree::Config[:tax_using_ship_address] ? ship_address : bill_address
+    end
+
+    # Array of adjustments that are inclusive in the variant price.  Useful for when prices
+    # include tax (ex. VAT) and you need to record the tax amount separately.
     def price_adjustments
       ActiveSupport::Deprecation.warn("Order#price_adjustments will be deprecated in Spree 2.1, please use Order#line_item_adjustments instead.")
       self.line_item_adjustments

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -25,7 +25,7 @@ module Spree
     def self.match(order)
       return [] unless order.tax_zone
       all.select do |rate|
-        rate.zone == order.tax_zone || rate.zone.contains?(order.tax_zone) || rate.zone.default_tax
+        rate.zone == order.tax_zone || rate.zone.contains?(order.tax_zone) || (order.tax_address.nil? && rate.zone.default_tax)
       end
     end
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -571,4 +571,25 @@ describe Spree::Order do
       expect(order.state).to eql "address"
     end
   end
+
+  describe ".tax_address" do
+    before { Spree::Config[:tax_using_ship_address] = tax_using_ship_address }
+    subject { order.tax_address }
+
+    context "when tax_using_ship_address is true" do
+      let(:tax_using_ship_address) { true }
+
+      it 'returns ship_address' do
+        subject.should == order.ship_address
+      end
+    end
+
+    context "when tax_using_ship_address is not true" do
+      let(:tax_using_ship_address) { false }
+
+      it "returns bill_address" do
+        subject.should == order.bill_address
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/tax_rate_spec.rb
+++ b/core/spec/models/spree/tax_rate_spec.rb
@@ -90,17 +90,34 @@ describe Spree::TaxRate do
         end
 
         context "when there order has a different tax zone" do
-          before { order.stub :tax_zone => create(:zone, :name => "Other Zone") }
+          before do
+            order.stub :tax_zone => create(:zone, :name => "Other Zone")
+            order.stub :tax_address => tax_address
+          end
 
-          it "should return the rates associated with the default tax zone" do
-            rate = Spree::TaxRate.create(
-              :amount => 1,
-              :zone => @zone,
-              :tax_category => tax_category,
-              :calculator => calculator
-            )
+          let!(:rate) do
+            Spree::TaxRate.create(:amount => 1,
+                                  :zone => @zone,
+                                  :tax_category => tax_category,
+                                  :calculator => calculator)
+          end
 
-            Spree::TaxRate.match(order).should == [rate]
+          subject { Spree::TaxRate.match(order) }
+
+          context "when the order has a tax_address" do
+            let(:tax_address) { stub_model(Spree::Address) }
+
+            it "returns no tax rate" do
+              subject.should be_empty
+            end
+          end
+
+          context "when the order does not have a tax_address" do
+            let(:tax_address) { nil}
+
+            it "should return the rates associated with the default tax zone" do
+              subject.should == [rate]
+            end
           end
         end
       end


### PR DESCRIPTION
Tax Rates can be flagged as a default tax rate, and it will apply to
all orders if there is no information to base a tax rate off of.

However, once we have enough information to determine the appropriate
tax rate for a user (i.e. a tax_address, which is the billing address
or shipping address) we should use that to determine the tax rate
which will apply.

Previously, the default tax rate would match for all orders regardless
of the zone specified in the order.

Fixes #2335.
