### PR TITLE
Fix admin select2 dropdown input and outline positioning

### DIFF
--- a/backend/app/assets/stylesheets/admin/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/admin/plugins/_select2.scss
@@ -68,7 +68,7 @@
   input {
     @extend input[type="text"];
     margin-top: 5px;
-    margin-left: -6px;
+    margin-left: 4px;
     padding-left: 25px;
     padding-top: 6px;
     padding-bottom: 6px;
@@ -99,7 +99,7 @@
   }
 }
 
-.select2-results { 
+.select2-results {
   padding-left: 0 !important;
 
   li {


### PR DESCRIPTION
Previously the outline and input field protruded outside of the area the dropdown occupied when it was open.

See here:

![](https://s3.amazonaws.com/uploads.hipchat.com/15480/366900/9xlcvd2w96230f5/Screen+Shot+2013-09-06+at+5.00.47+PM.png)
