### PR TITLE
Remove redundant arrow glyph from select2 dropdown.

### DIFF
--- a/backend/app/assets/stylesheets/admin/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/admin/plugins/_select2.scss
@@ -89,7 +89,7 @@
     display: block;
     width: 100%;
     height: 100%;
-    background: none;
+    background: none !important;
     font-family: FontAwesome;
     font-weight: 200 !important;
 
@@ -99,7 +99,7 @@
   }
 }
 
-.select2-results { 
+.select2-results {
   padding-left: 0 !important;
 
   li {


### PR DESCRIPTION
Removes the default dropdown glyph from select2 since we're using FontAwesome (the two currently display side by side).

Please excuse the use of !important (select2 did it first!). It looks like this file is full of overrides ontop of the default styling.

See here: 
![screen shot 2013-09-06 at 7 09 10 pm](https://f.cloud.github.com/assets/755844/1100081/abaf300c-1749-11e3-91c2-a7626121e723.png)
