### PR TITLE
Fix variant eager loading in Shipment `manifest`

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -154,7 +154,7 @@ module Spree
     end
 
     def manifest
-      inventory_units.includes(:variant).group_by(&:variant).map do |variant, units|
+      inventory_units.joins(:variant).includes(:variant).group_by(&:variant).map do |variant, units|
         states = {}
         units.group_by(&:state).each { |state, iu| states[state] = iu.count }
         OpenStruct.new(variant: variant, quantity: units.length, states: states)

--- a/core/spec/models/spree/inventory_unit_spec.rb
+++ b/core/spec/models/spree/inventory_unit_spec.rb
@@ -62,6 +62,11 @@ describe Spree::InventoryUnit do
       unit.variant.destroy
       expect(unit.reload.variant).to be_a Spree::Variant
     end
+
+    it "can still fetch variants by eager loading (remove default_scope)" do
+      unit.variant.destroy
+      expect(Spree::InventoryUnit.joins(:variant).includes(:variant).first.variant).to be_a Spree::Variant
+    end
   end
 
   context "#finalize_units!" do


### PR DESCRIPTION
Deleted variants were not being fetched due to a default scope. Adding a
`joins` seems to override the default scope and fix exceptions in
backend when trying to view orders with deleted variants

default_scope seems to be evil. It might save us from adding scope in some places but also create issues in many others.

This one should fix #3673
