### PR TITLE
Only build ship_address if order has delivery step

### DIFF
--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -124,9 +124,14 @@ module Spree
         send(method_name) if respond_to?(method_name, true)
       end
 
+      # Skip setting ship address if order doesn't have a delivery checkout step
+      # to avoid triggering validations on shipping address
       def before_address
         @order.bill_address ||= Address.default
-        @order.ship_address ||= Address.default
+
+        if @order.checkout_steps.include? "delivery"
+          @order.ship_address ||= Address.default
+        end
       end
 
       def before_delivery

--- a/frontend/app/views/spree/shared/_order_details.html.erb
+++ b/frontend/app/views/spree/shared/_order_details.html.erb
@@ -1,10 +1,13 @@
 <div class="row steps-data">
 
   <% if order.has_step?("address") %>
-    <div class="columns alpha four" data-hook="order-ship-address">
-      <h6><%= Spree.t(:shipping_address) %> <%= link_to "(#{Spree.t(:edit)})", checkout_state_path(:address) unless @order.completed? %></h6>
-      <%= render :partial => 'spree/shared/address', :locals => { :address => order.ship_address } %>
-    </div>
+
+    <% if order.has_step?("delivery") %>
+      <div class="columns alpha four" data-hook="order-ship-address">
+        <h6><%= Spree.t(:shipping_address) %> <%= link_to "(#{Spree.t(:edit)})", checkout_state_path(:address) unless @order.completed? %></h6>
+        <%= render :partial => 'spree/shared/address', :locals => { :address => order.ship_address } %>
+      </div>
+    <% end %>
 
     <div class="columns alpha four" data-hook="order-bill-address">
       <h6><%= Spree.t(:billing_address) %> <%= link_to "(#{Spree.t(:edit)})", checkout_state_path(:address) unless @order.completed? %></h6>

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -5,6 +5,11 @@ describe Spree::CheckoutController do
   let(:user) { stub_model(Spree::LegacyUser) }
   let(:order) { FactoryGirl.create(:order_with_totals) }
 
+  let(:address_params) do
+    address = FactoryGirl.build(:address)
+    address.attributes.except("created_at", "updated_at")
+  end
+
   before do
     controller.stub :try_spree_current_user => user
     controller.stub :current_order => order
@@ -78,11 +83,6 @@ describe Spree::CheckoutController do
           order.stub :available_payment_methods => [stub_model(Spree::PaymentMethod)]
           order.stub :ensure_available_shipping_rates => true
           order.line_items << FactoryGirl.create(:line_item)
-        end
-
-        let(:address_params) do
-          address = FactoryGirl.build(:address)
-          address.attributes.except("created_at", "updated_at")
         end
 
         it "should assign order" do
@@ -275,7 +275,15 @@ describe Spree::CheckoutController do
 
   context "order doesn't have a delivery step" do
     before do
-      order.stub(:checkout_steps => ["cart", "payment"])
+      order.stub(:checkout_steps => ["cart", "address", "payment"])
+      order.stub state: "address"
+      controller.stub :check_authorization => true
+    end
+
+    it "doesn't set shipping address on the order" do
+      expect(order).to receive(:bill_address)
+      expect(order).to_not receive(:ship_address)
+      spree_post :update
     end
 
     it "doesn't remove unshippable items before payment" do


### PR DESCRIPTION
Stores which redefine the checkout workflow and remove the delivery step
usually don't care about the shipping address. This should avoid
shipping address validation errors because the order could try to save
an empty shipping address

Hopefully a fix for #2571

2-0-stable needs it too in case it looks right
