### PR TITLE
Allow precompile assets without opening db connection

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -20,7 +20,10 @@
 
 module Spree
   class Product < ActiveRecord::Base
+    LIKE = self.connection.adapter_name == 'PostgreSQL' ? 'ILIKE' : 'LIKE'
+
     acts_as_paranoid
+
     has_many :product_option_types, dependent: :destroy
     has_many :option_types, through: :product_option_types
     has_many :product_properties, dependent: :destroy

--- a/core/config/initializers/spree.rb
+++ b/core/config/initializers/spree.rb
@@ -1,0 +1,5 @@
+module Spree
+  if ActiveRecord::Base.connected?
+    LIKE = ActiveRecord::Base.connection.adapter_name == 'PostgreSQL' ? 'ILIKE' : 'LIKE'
+  end
+end

--- a/core/config/initializers/spree.rb
+++ b/core/config/initializers/spree.rb
@@ -1,5 +1,0 @@
-module Spree
-  if ActiveRecord::Base.connected?
-    LIKE = ActiveRecord::Base.connection.adapter_name == 'PostgreSQL' ? 'ILIKE' : 'LIKE'
-  end
-end

--- a/core/lib/spree/core/permalinks.rb
+++ b/core/lib/spree/core/permalinks.rb
@@ -14,8 +14,10 @@ module Spree
           options[:field] ||= :permalink
           self.permalink_options = options
 
-          if self.table_exists? && self.column_names.include?(permalink_options[:field].to_s)
-            before_validation(:on => :create) { save_permalink }
+          if self.connected?
+            if self.table_exists? && self.column_names.include?(permalink_options[:field].to_s)
+              before_validation(:on => :create) { save_permalink }
+            end
           end
         end
 

--- a/frontend/config/initializers/spree.rb
+++ b/frontend/config/initializers/spree.rb
@@ -2,5 +2,3 @@ require 'mail'
 
 # Spree Configuration
 SESSION_KEY = '_spree_session_id'
-
-LIKE = ActiveRecord::Base.connection.adapter_name == 'PostgreSQL' ? 'ILIKE' : 'LIKE'


### PR DESCRIPTION
Related to #3688 hopefully fix it

I think that `LIKE` constant in frontend is legacy code, it's not used anywhere now. But in case it is we could add a `self.connected?` there too to check if a db connection was opened.
