### PR TITLE
Fixes #3293 - Change default endpoint behavior to reflect CRUD style.

### DIFF
--- a/api/app/controllers/spree/api/stock_items_controller.rb
+++ b/api/app/controllers/spree/api/stock_items_controller.rb
@@ -39,7 +39,10 @@ module Spree
           params[:stock_item].delete(:count_on_hand)
         end
 
-        if @stock_item.adjust_count_on_hand(count_on_hand)
+        updated = params[:stock_item][:append] ? @stock_item.adjust_count_on_hand(count_on_hand)
+                                               : @stock_item.set_count_on_hand(count_on_hand)
+
+        if updated
           respond_with(@stock_item, status: 200, default_template: :show)
         else
           invalid_resource!(@stock_item)

--- a/api/app/controllers/spree/api/stock_items_controller.rb
+++ b/api/app/controllers/spree/api/stock_items_controller.rb
@@ -39,8 +39,8 @@ module Spree
           params[:stock_item].delete(:count_on_hand)
         end
 
-        updated = params[:stock_item][:append] ? @stock_item.adjust_count_on_hand(count_on_hand)
-                                               : @stock_item.set_count_on_hand(count_on_hand)
+        updated = params[:stock_item][:force] ? @stock_item.adjust_count_on_hand(count_on_hand)
+                                              : @stock_item.set_count_on_hand(count_on_hand)
 
         if updated
           respond_with(@stock_item, status: 200, default_template: :show)

--- a/api/app/controllers/spree/api/stock_items_controller.rb
+++ b/api/app/controllers/spree/api/stock_items_controller.rb
@@ -39,8 +39,8 @@ module Spree
           params[:stock_item].delete(:count_on_hand)
         end
 
-        updated = params[:stock_item][:force] ? @stock_item.adjust_count_on_hand(count_on_hand)
-                                              : @stock_item.set_count_on_hand(count_on_hand)
+        updated = params[:stock_item][:force] ? @stock_item.set_count_on_hand(count_on_hand)
+                                              : @stock_item.adjust_count_on_hand(count_on_hand)
 
         if updated
           respond_with(@stock_item, status: 200, default_template: :show)

--- a/api/spec/controllers/spree/api/stock_items_controller_spec.rb
+++ b/api/spec/controllers/spree/api/stock_items_controller_spec.rb
@@ -69,7 +69,6 @@ module Spree
           id: stock_item.to_param,
           stock_item: {
             count_on_hand: 40,
-            force: true,
           }
         }
 
@@ -85,6 +84,7 @@ module Spree
           id: stock_item.to_param,
           stock_item: {
             count_on_hand: 40,
+            force: true,
           }
         }
 

--- a/api/spec/controllers/spree/api/stock_items_controller_spec.rb
+++ b/api/spec/controllers/spree/api/stock_items_controller_spec.rb
@@ -69,7 +69,7 @@ module Spree
           id: stock_item.to_param,
           stock_item: {
             count_on_hand: 40,
-            append: true,
+            force: true,
           }
         }
 

--- a/api/spec/controllers/spree/api/stock_items_controller_spec.rb
+++ b/api/spec/controllers/spree/api/stock_items_controller_spec.rb
@@ -69,12 +69,28 @@ module Spree
           id: stock_item.to_param,
           stock_item: {
             count_on_hand: 40,
+            append: true,
           }
         }
 
         api_put :update, params
         response.status.should == 200
         json_response['count_on_hand'].should eq 50
+      end
+
+      it 'can set a stock item to modify the current inventory' do
+        stock_item.count_on_hand.should == 10
+
+        params = {
+          id: stock_item.to_param,
+          stock_item: {
+            count_on_hand: 40,
+          }
+        }
+
+        api_put :update, params
+        response.status.should == 200
+        json_response['count_on_hand'].should eq 40
       end
 
       it 'can delete a stock item' do

--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -17,13 +17,17 @@ module Spree
       variant.name
     end
 
-    def adjust_count_on_hand(value)
+    def adjust_count_on_hand(value, forced = false)
       self.with_lock do
-        self.count_on_hand = self.count_on_hand + value
+        self.count_on_hand = forced ? value : self.count_on_hand + value
         process_backorders if in_stock?
 
         self.save!
       end
+    end
+
+    def set_count_on_hand(value)
+      adjust_count_on_hand(value, true)
     end
 
     def in_stock?

--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -17,9 +17,9 @@ module Spree
       variant.name
     end
 
-    def adjust_count_on_hand(value, forced = false)
+    def adjust_count_on_hand(value)
       self.with_lock do
-        self.count_on_hand = forced ? value : self.count_on_hand + value
+        self.count_on_hand = self.count_on_hand + value
         process_backorders if in_stock?
 
         self.save!
@@ -27,7 +27,10 @@ module Spree
     end
 
     def set_count_on_hand(value)
-      adjust_count_on_hand(value, true)
+      self.count_on_hand = value
+      process_backorders if in_stock?
+
+      self.save!
     end
 
     def in_stock?

--- a/core/spec/models/spree/stock_item_spec.rb
+++ b/core/spec/models/spree/stock_item_spec.rb
@@ -83,7 +83,7 @@ describe Spree::StockItem do
 
       copy.count_on_hand.should eq(current_on_hand)
       copy.set_count_on_hand(10)
-      copy.count_on_hand.should eq(10)
+      copy.count_on_hand.should eq(current_on_hand)
     end
 
     context "item out of stock (by two items)" do


### PR DESCRIPTION
This patch changes the default endpoint of the API's StockItemController to follow CRUD conventions for updating the resource. Per conversation in IRC it was discussed that the upate action on this controller would externally be inferred to "Update" the resource. Instead this action appends the inventory to the current count in the database which isn't explicitly stated to the end user.

I approached this issue as described in this PR and am open to feedback. Other thoughts of approaching it was to change the name of the param from count_on_hand to something more indicative to represent the fact that it is additive inventory, not declarative. 

Creating a separate endpoint and action just to allow users to set the resource.

Implement as described, but create a separate endpoint and action to allow for the addition of inventory to prevent possible errors related to forgetting the append param.

This made sense because from a store owners perspective they would be in one of two scenarios:

1) A store holds inventory locally, and whenever it is notified of a shipment en route that third party can add that inventory to their inventory as it is on arrival e.g. additive inventory

2) A store holds inventory externally, e.g. in a shared warehouse, the operator of that warehouse would then have complete control of the "inventory on hand" and it would make sense to be able to control the "count on hand"

If case #1 was the most predominantly used, the fact remains that keeping the ability to add on a bare update function doesn't seem very CRUDy. The third parties that would update this information also fit into a niche. Usually the store wouldn't update their inventory until they receive it from their provider, at this point the inventory would unlikely be additive via an API and instead would be on the actual application by the receiver.

This is my first ever open source contribution, so if I'm blatantly off course please let me know and how I should improve in the future.
