### PR TITLE
Exclude dummy app from SimpleCov

### DIFF
--- a/cmd/lib/spree_cmd/templates/extension/spec/spec_helper.rb.tt
+++ b/cmd/lib/spree_cmd/templates/extension/spec/spec_helper.rb.tt
@@ -1,6 +1,7 @@
 # Run Coverage report
 require 'simplecov'
 SimpleCov.start do
+  add_filter 'spec/dummy'
   add_group 'Controllers', 'app/controllers'
   add_group 'Helpers', 'app/helpers'
   add_group 'Mailers', 'app/mailers'


### PR DESCRIPTION
SimpleCov seems to want to include the dummy app
when calculating coverage, which causes extension
coverage to appear lower than it is. This excludes
it when initializing SimpleCov in spec_helper.rb
