### PR TITLE
Remove blank username line in dummy database.yml mysql config

### DIFF
--- a/core/lib/generators/spree/dummy/templates/rails/database.yml
+++ b/core/lib/generators/spree/dummy/templates/rails/database.yml
@@ -17,17 +17,14 @@ production:
 development:
   adapter: mysql2
   database: <%= database_prefix %>spree_development
-  username:
   encoding: utf8
 test:
   adapter: mysql2
   database: <%= database_prefix %>spree_test
-  username:
   encoding: utf8
 production:
   adapter: mysql2
   database: <%= database_prefix %>spree_production
-  username:
   encoding: utf8
 <% when 'postgres' %>
 development:


### PR DESCRIPTION
For some reason activerecord-jdbcmysql-adapter hates blank usernames
and will not connect despite the fact that mysql2 works fine. Removing
these lines doesn't break mysql2 so I see no reason to keep them there.
I'm trying to test my gems on jruby in anticipation of spree working on
jruby so this fix would be helpful. Here's sample Travis output showing
what goes wrong:
https://travis-ci.org/swrobel/spree_zero_stock_products/jobs/11136157
