### PR TITLE
cleanup Product.like_any with some arel

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -146,10 +146,11 @@ module Spree
     end
 
     def self.like_any(fields, values)
-      # PostgreSQL is case sensitive, so we need to use ILIKE to work around that.
-      like = ActiveRecord::Base.connection.adapter_name == 'PostgreSQL' ? 'ILIKE' : 'LIKE'
-      where_str = fields.map { |field| Array.new(values.size, "#{self.quoted_table_name}.#{field} #{like} ?").join(' OR ') }.join(' OR ')
-      self.where([where_str, values.map { |value| "%#{value}%" } * fields.size].flatten)
+      where fields.map { |field|
+        values.map { |value|
+          arel_table[field].matches("%#{value}%")
+        }.inject(:or)
+      }.inject(:or)
     end
 
     # Suitable for displaying only variants that has at least one option value.


### PR DESCRIPTION
Inspired by radar's cleanup in fe77e9cc095b1fb41040270ef697391cb8a5daef, this relies more heavily on arel for query generation.

`.matches` in arel generates `ILIKE` in postgresql and `LIKE` in mysql and sqlite.
