### PR TITLE
Dont set preference on assets:precompile

### DIFF
--- a/core/app/models/spree/preferences/store.rb
+++ b/core/app/models/spree/preferences/store.rb
@@ -86,7 +86,7 @@ module Spree::Preferences
     end
 
     def should_persist?
-      @persistence and Spree::Preference.table_exists?
+      @persistence && Spree::Preference.connected? && Spree::Preference.table_exists?
     end
 
   end


### PR DESCRIPTION
Avoid opening a db connection when running assets:precompile to help
users to deploy their apps to heroku

Another attempt to fix #3688, core build looks green and the preferences in spree.rb initializer still get persisted when you start the console or the boots the app.
