### PR TITLE
Only run `create_shipment!` when we really need it (1-3-stable)

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -17,7 +17,7 @@ module Spree
       go_to_state :delivery
       go_to_state :payment, :if => lambda { |order|
         # Fix for #2191
-        if order.shipping_method
+        if order.total.to_f <= 0 && order.shipping_method
           order.create_shipment!
           order.update_totals
         end


### PR DESCRIPTION
In checkout_flow that would be only when order.total is zero and the
order has a shipping method
