### PR TITLE
Adding :original to spree_api_key_layout override

### DIFF
--- a/api/app/overrides/api_key_spree_layout.rb
+++ b/api/app/overrides/api_key_spree_layout.rb
@@ -2,5 +2,6 @@ Deface::Override.new(:virtual_path => "spree/layouts/spree_application",
                      :name => "api_key_spree_layout",
                      :insert_bottom => "body",
                      :partial => "spree/api/key",
-                     :disabled => false)
+                     :disabled => false,
+                     :original => "eb4b04993e8e4d1c20a7c3d974dfed20b59aec4c")
 


### PR DESCRIPTION
Resolves warning:

```
Deface: [WARNING][0m No :original defined for 'api_key_spree_layout', you should change its definition to include:
 :original => 'eb4b04993e8e4d1c20a7c3d974dfed20b59aec4c'
```
