### PR TITLE
Fix order_id assignment in OrderInventory

### DIFF
--- a/core/app/models/spree/order_inventory.rb
+++ b/core/app/models/spree/order_inventory.rb
@@ -67,13 +67,8 @@ module Spree
     def add_to_shipment(shipment, variant, quantity)
       on_hand, back_order = shipment.stock_location.fill_status(variant, quantity)
 
-      on_hand.times do
-        shipment.inventory_units.create(variant_id: variant.id, state: 'on_hand')
-      end
-
-      back_order.times do
-        shipment.inventory_units.create(variant_id: variant.id, state: 'backordered')
-      end
+      on_hand.times { shipment.set_up_inventory('on_hand', variant, order) }
+      back_order.times { shipment.set_up_inventory('backordered', variant, order) }
 
       # adding to this shipment, and removing from stock_location
       if order.completed?

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -225,6 +225,10 @@ module Spree
       package
     end
 
+    def set_up_inventory(state, variant, order)
+      self.inventory_units.create(variant_id: variant.id, state: state, order_id: order.id)
+    end
+
     private
 
       def manifest_unstock(item)

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -412,6 +412,21 @@ describe Spree::Shipment do
     end
   end
 
+  context "set up new inventory units" do
+    let(:variant) { double("Variant", id: 9) }
+    let(:inventory_units) { double }
+    let(:params) do
+      { variant_id: variant.id, state: 'on_hand', order_id: order.id }
+    end
+
+    before { shipment.stub inventory_units: inventory_units }
+
+    it "associates variant and order" do
+      expect(inventory_units).to receive(:create).with(params)
+      unit = shipment.set_up_inventory('on_hand', variant, order)
+    end
+  end
+
   # Regression test for #3349
   context "#destroy" do
     it "destroys linked shipping_rates" do


### PR DESCRIPTION
We missed the order param when creating inventory units through
shipments in OrderInventory. That will cause exception later on because
a InventoryUnit expect to always be associated with an order (which is
something I believe we should probably remove completely in the next
major release)
