### PR TITLE
Fix order errors flash

### DIFF
--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -162,7 +162,7 @@ module Spree
 
       def apply_coupon_code
         if params[:order] && params[:order][:coupon_code]
-          @order.coupon_code = params[:order][:coupon_code] 
+          @order.coupon_code = params[:order][:coupon_code]
 
           coupon_result = Spree::Promo::CouponApplicator.new(@order).apply
           if coupon_result[:coupon_applied?]

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -27,7 +27,7 @@ module Spree
     def update
       if @order.update_attributes(object_params)
         unless @order.next
-          flash[:error] = @order.errors[:base].join("\n")
+          flash[:error] = @order.errors.full_messages.join("\n")
           redirect_to checkout_state_path(@order.state) and return
         end
 


### PR DESCRIPTION
This branch fixes a problem where a blank error message is displayed on the checkout process when an association in a `Spree::Order` is invalid and prevents `Spree::Order#next` from succeeding.

Here is what the actual error message looks like:

![screen shot 2013-09-11 at 11 52 22 am](https://f.cloud.github.com/assets/133/1128588/332780d4-1b6e-11e3-935f-04abbb7fb7a4.png)

In most circumstances, only the base error is displayed, but there are cases where the state of the order is made invalid due to a bug ([like one I found with spree_active_shipping](https://github.com/spree/spree_active_shipping/pull/131)) and a nicer error message would make it more obvious.
