### PR TITLE
Finishing update begun in https://github.com/spree/spree/issues/3671

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ available in the spree gem which will add Spree to an existing Rails application
     $ gem install rails -v 3.2.14
     $ gem install spree -v 1.3.3
     $ rails _3.2.14_ new my_store
-    $ spree install my_store
+    $ spree _1.3.3_ install my_store
 
 This will add the Spree gem to your Gemfile, create initializers, copy migrations and
 optionally generate sample products and orders.


### PR DESCRIPTION
The change in https://github.com/spree/spree/issues/3671 helps ensure that spree 1.3.3 gets installed, but it appears that when multiple versions are installed, the `spree` command defaults to the most recent version. This way we'll make sure it's the 1.3.3 spree that's running the initialization for the new rails app.
