### PR TITLE
Make assets:precompile not open db connection

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -52,7 +52,8 @@ module Spree
     has_many :stock_items, through: :variants_including_master
 
     delegate_belongs_to :master, :sku, :price, :currency, :display_amount, :display_price, :weight, :height, :width, :depth, :is_master, :has_default_price?, :cost_currency, :price_in, :amount_in
-    delegate_belongs_to :master, :cost_price if Variant.table_exists? && Variant.column_names.include?('cost_price')
+
+    delegate_belongs_to :master, :cost_price
 
     after_create :set_master_variant_defaults
     after_create :add_properties_and_option_types_from_prototype

--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -23,8 +23,7 @@ module Spree
         # We should not define price scopes here, as they require something slightly different
         next if name.to_s.include?("master_price")
         parts = name.to_s.match(/(.*)_by_(.*)/)
-        order_text = "#{Product.quoted_table_name}.#{parts[2]} #{parts[1] == 'ascend' ?  "ASC" : "DESC"}"
-        self.scope(name.to_s, -> { relation.order(order_text) })
+        self.scope(name.to_s, -> { relation.order("#{Product.quoted_table_name}.#{parts[2]} #{parts[1] == 'ascend' ?  "ASC" : "DESC"}") })
       end
     end
 
@@ -212,10 +211,7 @@ module Spree
     # problem shown in #1247.
     def self.group_by_products_id
       if (ActiveRecord::Base.connection.adapter_name == 'PostgreSQL')
-        # Need to check, otherwise `column_names` will fail
-        if table_exists?
-          group(column_names.map { |col_name| "#{table_name}.#{col_name}"})
-        end
+        group(column_names.map { |col_name| "#{table_name}.#{col_name}"})
       else
         group("#{self.quoted_table_name}.id")
       end

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -23,7 +23,7 @@ module Spree
       class_name: 'Spree::Price',
       dependent: :destroy
 
-    delegate_belongs_to :default_price, :display_price, :display_amount, :price, :price=, :currency if Spree::Price.table_exists?
+    delegate_belongs_to :default_price, :display_price, :display_amount, :price, :price=, :currency 
 
     has_many :prices,
       class_name: 'Spree::Price',
@@ -31,7 +31,8 @@ module Spree
 
     validate :check_price
     validates :price, numericality: { greater_than_or_equal_to: 0 }, presence: true, if: proc { Spree::Config[:require_master_price] }
-    validates :cost_price, numericality: { greater_than_or_equal_to: 0, allow_nil: true } if self.table_exists? && self.column_names.include?('cost_price')
+
+    validates :cost_price, numericality: { greater_than_or_equal_to: 0, allow_nil: true }
 
     before_validation :set_cost_currency
     after_save :save_default_price

--- a/core/lib/spree/core/permalinks.rb
+++ b/core/lib/spree/core/permalinks.rb
@@ -14,11 +14,7 @@ module Spree
           options[:field] ||= :permalink
           self.permalink_options = options
 
-          if self.connected?
-            if self.table_exists? && self.column_names.include?(permalink_options[:field].to_s)
-              before_validation(:on => :create) { save_permalink }
-            end
-          end
+          before_validation(:on => :create) { save_permalink }
         end
 
         def find_by_param(value, *args)

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activemerchant', '1.39.2'
   s.add_dependency 'acts_as_list', '= 0.2.0'
-  s.add_dependency 'awesome_nested_set', '~> 3.0.0.rc.1'
+  s.add_dependency 'awesome_nested_set', '~> 3.0.0.rc.2'
   s.add_dependency 'aws-sdk', '1.11.1' # temporarily locked down due to https://github.com/aws/aws-sdk-ruby/issues/273
   s.add_dependency 'cancan', '~> 1.6.10'
   s.add_dependency 'deface', '>= 1.0.0.rc3'
@@ -36,5 +36,4 @@ Gem::Specification.new do |s|
   s.add_dependency 'state_machine', '1.2.0'
   s.add_dependency 'stringex', '~> 1.5.1'
   s.add_dependency 'truncate_html', '0.9.2'
-
 end


### PR DESCRIPTION
Took a further look at #3688 to make assets:precompile also run without a db connection in production (eager loading all the spree code).

I had to copy the awesome_nested_set module over into spree_core because we don't have a release for that gem yet that fixes the same issue we're having here and I couldn't find another way to fix it. We can remove the overridden module once we have a new awesome_nested_set release, see https://github.com/collectiveidea/awesome_nested_set/issues/208

The build looks ok but I might need to do a bit of more testing or look up to see if we can safely remove the `table_exists?` or `column_names` methods that were opening a db connection. Anyone can tell in what cases we need those checks?
