### PR TITLE
Fix ReadOnlyError when destroying StockItem

### DIFF
--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -1,8 +1,10 @@
 module Spree
   class StockItem < ActiveRecord::Base
+    acts_as_paranoid
+
     belongs_to :stock_location, class_name: 'Spree::StockLocation'
     belongs_to :variant, class_name: 'Spree::Variant'
-    has_many :stock_movements, dependent: :destroy
+    has_many :stock_movements
 
     validates_presence_of :stock_location, :variant
     validates_uniqueness_of :variant_id, scope: :stock_location_id

--- a/core/db/migrate/20130915032339_add_deleted_at_to_spree_stock_items.rb
+++ b/core/db/migrate/20130915032339_add_deleted_at_to_spree_stock_items.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtToSpreeStockItems < ActiveRecord::Migration
+  def change
+    add_column :spree_stock_items, :deleted_at, :datetime
+  end
+end

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -142,6 +142,16 @@ describe Spree::Product do
       end
     end
 
+    context "has stock movements" do
+      let(:product) { create(:product) }
+      let(:variant) { product.master }
+      let(:stock_item) { variant.stock_items.first }
+
+      it "doesnt raise ReadOnlyRecord error" do
+        Spree::StockMovement.create!(stock_item: stock_item, quantity: 1)
+        expect { product.destroy }.not_to raise_error
+      end
+    end
   end
 
   context "permalink" do

--- a/core/spec/models/spree/stock_item_spec.rb
+++ b/core/spec/models/spree/stock_item_spec.rb
@@ -109,4 +109,12 @@ describe Spree::StockItem do
       end
     end
   end
+
+  context "with stock movements" do
+    before { Spree::StockMovement.create(stock_item: subject, quantity: 1) }
+
+    it "doesnt raise ReadOnlyRecord error" do
+      expect { subject.destroy }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
StockMovement is a read only object so we can't delete them. And by that
logic I believe we shouldn't clear stock items from the database either
otherwise we will have stock movements associated with non existing
stock items

Wdyt? This should fix the issue reported in #3723 but there's still stuff related to fix / discuss. Maybe we also need to make so that stock locations are never cleared from db as well. And we still need to unscope stock items from a stock movement perspective otherwise we will have the same trouble when trying to fetch removed items in a stock movement object.
