### PR TITLE
Support .name and .description on line items

### DIFF
--- a/core/app/helpers/spree/products_helper.rb
+++ b/core/app/helpers/spree/products_helper.rb
@@ -40,9 +40,14 @@ module Spree
     end
 
     def line_item_description(variant)
-      description = variant.product.description
-      if description.present?
-        truncate(strip_tags(description.gsub('&nbsp;', ' ')), length: 100)
+      ActiveSupport::Deprecation.warn "line_item_description(variant) is deprecated and may be removed from future releases, use line_item_description_text(line_item.description) instead.", caller
+
+      line_item_description_text(variant.product.description)
+    end
+
+    def line_item_description_text description_text
+      if description_text.present?
+        truncate(strip_tags(description_text.gsub('&nbsp;', ' ')), length: 100)
       else
         Spree.t(:product_has_no_description)
       end

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -25,6 +25,8 @@ module Spree
     after_save :update_order
     after_destroy :update_order
 
+    delegate :name, :description, to: :variant
+
     attr_accessor :target_shipment
 
     def copy_price

--- a/core/spec/helpers/products_helper_spec.rb
+++ b/core/spec/helpers/products_helper_spec.rb
@@ -153,5 +153,32 @@ THIS IS THE BEST PRODUCT EVER!
       end
 
     end
+
+    shared_examples_for "line item descriptions" do
+      context 'variant has a blank description' do
+        let(:description) { nil }
+        it { should == Spree.t(:product_has_no_description) }
+      end
+      context 'variant has a description' do
+        let(:description) { 'test_desc' }
+        it { should == description }
+      end
+      context 'description has nonbreaking spaces' do
+        let(:description) { 'test&nbsp;desc' }
+        it { should == 'test desc' }
+      end
+    end
+    context "#line_item_description" do
+      let(:variant) { create(:variant, :product => product, description: description) }
+      subject { line_item_description(variant) }
+
+      it_should_behave_like "line item descriptions"
+    end
+    context '#line_item_description_text' do
+      subject { line_item_description_text description }
+
+      it_should_behave_like "line item descriptions"
+    end
+
   end
 end

--- a/frontend/app/views/spree/orders/_line_item.html.erb
+++ b/frontend/app/views/spree/orders/_line_item.html.erb
@@ -9,7 +9,7 @@
       <% end %>
     </td>
     <td class="cart-item-description" data-hook="cart_item_description">
-      <h4><%= link_to variant.product.name, product_path(variant.product) %></h4>
+      <h4><%= link_to line_item.name, product_path(variant.product) %></h4>
       <%= variant.options_text %>
       <% if @order.insufficient_stock_lines.include? line_item %>
         <span class="out-of-stock">
@@ -17,7 +17,7 @@
         </span>
       <% end %>
       <span class="line-item-description" data-hook="line_item_description">
-        <%= line_item_description(variant) %>
+        <%= line_item_description_text(line_item.description) %>
       </span>
     </td>
     <td class="cart-item-price" data-hook="cart_item_price">


### PR DESCRIPTION
This allows line_items to override and control what should be used for
description and name sanely.

The extra helper isn't ideal, but we do maintain the old interface for
extensions.
