### PR TITLE
Associate user in Order `merge!` when possible

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -421,7 +421,7 @@ module Spree
       line_items.select &:insufficient_stock?
     end
 
-    def merge!(order)
+    def merge!(order, user = nil)
       order.line_items.each do |line_item|
         next unless line_item.currency == currency
         current_line_item = self.line_items.find_by(variant: line_item.variant)
@@ -433,6 +433,9 @@ module Spree
           line_item.save
         end
       end
+
+      self.associate_user!(user) if !self.user && !user.blank?
+
       # So that the destroy doesn't take out line items which may have been re-assigned
       order.line_items.reload
       order.destroy

--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -59,7 +59,7 @@ module Spree
             if session[:order_id].nil? && last_incomplete_order
               session[:order_id] = last_incomplete_order.id
             elsif current_order(true) && last_incomplete_order && current_order != last_incomplete_order
-              current_order.merge!(last_incomplete_order)
+              current_order.merge!(last_incomplete_order, user)
             end
           end
         end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -434,6 +434,13 @@ describe Spree::Order do
       lambda { order_2.reload }.should raise_error(ActiveRecord::RecordNotFound)
     end
 
+    context "user is provided" do
+      it "assigns user to new order" do
+        order_1.merge!(order_2, user)
+        expect(order_1.user).to eq user
+      end
+    end
+
     context "merging together two orders with line items for the same variant" do
       before do
         order_1.contents.add(variant, 1)


### PR DESCRIPTION
Users might be losing their cart changes when they come back but don't
visit either the /cart page or the /checkout
