### PR TITLE
Product#save_master callback makes the master always saved

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -290,7 +290,7 @@ module Spree
       # there's a weird quirk with the delegate stuff that does not automatically save the delegate object
       # when saving so we force a save using a hook.
       def save_master
-        master.save if master && (master.changed? || master.new_record? || (master.default_price && (master.default_price.changed || master.default_price.new_record)))
+        master.save if master && (master.changed? || master.new_record? || (master.default_price && (master.default_price.changed? || master.default_price.new_record?)))
       end
 
       def ensure_master

--- a/core/spec/models/product_spec.rb
+++ b/core/spec/models/product_spec.rb
@@ -1,5 +1,4 @@
 # coding: UTF-8
-
 require 'spec_helper'
 
 describe Spree::Product do
@@ -37,6 +36,64 @@ describe Spree::Product do
         clone.master.sku.should == 'COPY OF ' + product.master.sku
         clone.taxons.should == product.taxons
         clone.images.size.should == product.images.size
+      end
+    end
+
+    context "master variant" do
+      context "when master variant changed" do
+        before do
+          product.master.sku = "Something changed"
+        end
+
+        it "saves the master" do
+          product.master.should_receive(:save)
+          product.save
+        end
+      end
+
+      context "when master default price is a new record" do
+        before do
+          @price = product.master.build_default_price
+          @price.price = 12
+        end
+
+        it "saves the master" do
+          product.master.should_receive(:save)
+          product.save
+        end
+
+        it "saves the default price" do
+          proc do
+            product.save
+          end.should change{ @price.new_record? }.from(true).to(false)
+        end
+
+      end
+
+      context "when master default price changed" do
+        before do
+          master = product.master
+          master.default_price = create(:price, :variant => master)
+          master.save!
+          product.master.default_price.price = 12
+        end
+
+        it "saves the master" do
+          product.master.should_receive(:save)
+          product.save
+        end
+
+        it "saves the default price" do
+          product.master.default_price.should_receive(:save)
+          product.save
+        end
+      end
+
+      context "when master variant and price haven't changed" do
+        it "does not save the master" do
+          product.master.should_not_receive(:save)
+          product.save
+        end
       end
     end
 


### PR DESCRIPTION
The bug makes the master variant of a product saved each time a product is saved.

A nasty side effect is that the master variant is saved every time an object associates a variant or a product.
For example it saves the variant (and by side effect the product) every time the cart is updated.
