### PR TITLE
Refactors models/spree/order#after_cancel for better delayed mailer support

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -553,8 +553,12 @@ module Spree
       def after_cancel
         shipments.each { |shipment| shipment.cancel! }
 
-        OrderMailer.cancel_email(self.id).deliver
+        send_cancel_email
         self.payment_state = 'credit_owed' unless shipped?
+      end
+
+      def send_cancel_email
+        OrderMailer.cancel_email(self.id).deliver
       end
 
       def after_resume


### PR DESCRIPTION
Refactors `spree/order#after_cancel` to follow the patterns in place in `gem spree_auth_devise` and `gem devise`. Those designs allow the mailer logic to be easily configured with `gem delayed_job`.

With the patch I can do this:

``` ruby
module Spree
  Order.class_eval do

    handle_asynchronously :send_cancel_email

  end
end
```

Without the patch, I have to do something like this, which breaks forward compatibility:

``` ruby
module Spree
  Order.class_eval do

    def after_cancel
      shipments.each { |shipment| shipment.cancel! }

      send_cancel_email
      self.payment_state = 'credit_owed' unless shipped?
    end

    def send_cancel_email
      OrderMailer.cancel_email(self.id).deliver
    end

    handle_asynchronously :send_cancel_email

  end
end
```
