### PR TITLE
change message to selected_quantity_not_available when selected quantity...

### DIFF
--- a/core/app/models/spree/stock/availability_validator.rb
+++ b/core/app/models/spree/stock/availability_validator.rb
@@ -17,7 +17,7 @@ module Spree
           display_name = %Q{#{variant.name}}
           display_name += %Q{ (#{variant.options_text})} unless variant.options_text.blank?
 
-          line_item.errors[:quantity] << Spree.t(:out_of_stock, :scope => :order_populator, :item => display_name.inspect)
+          line_item.errors[:quantity] << Spree.t(:selected_quantity_not_available, :scope => :order_populator, :item => display_name.inspect)
         end
       end
     end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -751,6 +751,7 @@ en:
     order_number: Order
     order_populator:
       out_of_stock: ! '%{item} is out of stock.'
+      selected_quantity_not_available: ! 'Selected quantity of %{item} is not available.'
       please_enter_reasonable_quantity: Please enter a reasonable quantity.
     order_processed_successfully: Your order has been processed successfully
     order_state:


### PR DESCRIPTION
When a user adds a certain quantity of a variant in its cart, and if the selected quantity is not available - it shows a message %{item} is out of stock, but the item is still in stock. So, the error message should be changed. 
