### PR TITLE
Adjust payment capture amount

### DIFF
--- a/api/app/controllers/spree/api/payments_controller.rb
+++ b/api/app/controllers/spree/api/payments_controller.rb
@@ -3,7 +3,7 @@ module Spree
     class PaymentsController < Spree::Api::BaseController
 
       before_filter :find_order
-      before_filter :find_payment, only: [:show, :authorize, :purchase, :capture, :void, :credit]
+      before_filter :find_payment, only: [:update, :show, :authorize, :purchase, :capture, :void, :credit]
 
       def index
         @payments = @order.payments.ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
@@ -19,6 +19,17 @@ module Spree
         @payment = @order.payments.build(payment_params)
         if @payment.save
           respond_with(@payment, status: 201, default_template: :show)
+        else
+          invalid_resource!(@payment)
+        end
+      end
+
+      def update
+        authorize! params[:action], @payment
+        if ! @payment.pending?
+          render 'update_forbidden', status: 403
+        elsif @payment.update_attributes(payment_params)
+          respond_with(@payment, default_template: :show)
         else
           invalid_resource!(@payment)
         end

--- a/api/app/controllers/spree/api/payments_controller.rb
+++ b/api/app/controllers/spree/api/payments_controller.rb
@@ -46,7 +46,7 @@ module Spree
 
       def credit
         if params[:amount].to_f > @payment.credit_allowed
-          render 'spree/api/payments/credit_over_limit', status: 422
+          render 'credit_over_limit', status: 422
         else
           perform_payment_action(:credit, params[:amount])
         end

--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -44,7 +44,7 @@ module Spree
       end
 
       def payment_attributes
-        [:id, :source_type, :source_id, :amount, :payment_method_id, :response_code, :state, :avs_response, :created_at, :updated_at]
+        [:id, :source_type, :source_id, :amount, :display_amount, :payment_method_id, :response_code, :state, :avs_response, :created_at, :updated_at]
       end
 
       def payment_method_attributes
@@ -113,4 +113,3 @@ module Spree
     end
   end
 end
-

--- a/api/app/views/spree/api/payments/credit_over_limit.v1.rabl
+++ b/api/app/views/spree/api/payments/credit_over_limit.v1.rabl
@@ -1,2 +1,2 @@
 object false
-node(:error) { I18n.t(:credit_over_limit, :limit => @payment.credit_allowed, :scope => 'spree.api') }
+node(:error) { I18n.t(:credit_over_limit, :limit => @payment.credit_allowed, :scope => 'spree.api.payment') }

--- a/api/app/views/spree/api/payments/index.v1.rabl
+++ b/api/app/views/spree/api/payments/index.v1.rabl
@@ -1,7 +1,6 @@
 object false
 child(@payments => :payments) do
   attributes *payment_attributes
-  node(:display_amount) { |payment| payment.display_amount.to_s }
 end
 node(:count) { @payments.count }
 node(:current_page) { params[:page] || 1 }

--- a/api/app/views/spree/api/payments/index.v1.rabl
+++ b/api/app/views/spree/api/payments/index.v1.rabl
@@ -1,6 +1,7 @@
 object false
 child(@payments => :payments) do
   attributes *payment_attributes
+  node(:display_amount) { |payment| payment.display_amount.to_s }
 end
 node(:count) { @payments.count }
 node(:current_page) { params[:page] || 1 }

--- a/api/app/views/spree/api/payments/new.v1.rabl
+++ b/api/app/views/spree/api/payments/new.v1.rabl
@@ -3,4 +3,3 @@ node(:attributes) { [*payment_attributes] }
 child @payment_methods => :payment_methods do
   attributes *payment_method_attributes
 end
-

--- a/api/app/views/spree/api/payments/show.v1.rabl
+++ b/api/app/views/spree/api/payments/show.v1.rabl
@@ -1,3 +1,2 @@
 object @payment
 attributes *payment_attributes
-node(:display_amount) { @payment.display_amount.to_s }

--- a/api/app/views/spree/api/payments/show.v1.rabl
+++ b/api/app/views/spree/api/payments/show.v1.rabl
@@ -1,2 +1,3 @@
 object @payment
 attributes *payment_attributes
+node(:display_amount) { @payment.display_amount.to_s }

--- a/api/app/views/spree/api/payments/update_forbidden.v1.rabl
+++ b/api/app/views/spree/api/payments/update_forbidden.v1.rabl
@@ -1,0 +1,2 @@
+object false
+node(:error) { I18n.t(:update_forbidden, :state => @payment.state, :scope => 'spree.api.payment') }

--- a/api/config/locales/en.yml
+++ b/api/config/locales/en.yml
@@ -7,7 +7,6 @@ en:
       invalid_resource: "Invalid resource. Please fix errors and try again."
       resource_not_found: "The resource you were looking for could not be found."
       gateway_error: "There was a problem with the payment gateway: %{text}"
-      credit_over_limit: "This payment can only be credited up to %{limit}. Please specify an amount less than or equal to this number."
       access: "API Access"
       key: "Key"
       clear_key: "Clear key"
@@ -19,6 +18,8 @@ en:
       order:
         could_not_transition: "The order could not be transitioned. Please fix the errors and try again."
         invalid_shipping_method: "Invalid shipping method specified."
+      payment:
+        credit_over_limit: "This payment can only be credited up to %{limit}. Please specify an amount less than or equal to this number."
       shipment:
         cannot_ready: "Cannot ready shipment."
       stock_location_required: "A stock_location_id parameter must be provided in order to retrieve stock movements."

--- a/api/config/locales/en.yml
+++ b/api/config/locales/en.yml
@@ -20,6 +20,7 @@ en:
         invalid_shipping_method: "Invalid shipping method specified."
       payment:
         credit_over_limit: "This payment can only be credited up to %{limit}. Please specify an amount less than or equal to this number."
+        update_forbidden: "This payment cannot be updated because it is %{state}."
       shipment:
         cannot_ready: "Cannot ready shipment."
       stock_location_required: "A stock_location_id parameter must be provided in order to retrieve stock movements."

--- a/api/spec/controllers/spree/api/payments_controller_spec.rb
+++ b/api/spec/controllers/spree/api/payments_controller_spec.rb
@@ -41,7 +41,7 @@ module Spree
 
         it "can view a pre-existing payment's details" do
           api_get :show, :id => payment.to_param
-          json_response.should have_attributes(attributes)
+          json_response.should have_attributes(attributes << :display_amount)
         end
 
         it "cannot authorize a payment" do

--- a/api/spec/controllers/spree/api/payments_controller_spec.rb
+++ b/api/spec/controllers/spree/api/payments_controller_spec.rb
@@ -5,7 +5,7 @@ module Spree
     render_views
     let!(:order) { create(:order) }
     let!(:payment) { create(:payment, :order => order) }
-    let!(:attributes) { [:id, :source_type, :source_id, :amount,
+    let!(:attributes) { [:id, :source_type, :source_id, :amount, :display_amount,
                          :payment_method_id, :response_code, :state, :avs_response,
                          :created_at, :updated_at] }
 
@@ -41,7 +41,7 @@ module Spree
 
         it "can view a pre-existing payment's details" do
           api_get :show, :id => payment.to_param
-          json_response.should have_attributes(attributes << :display_amount)
+          json_response.should have_attributes(attributes)
         end
 
         it "cannot update a payment" do

--- a/api/spec/controllers/spree/api/payments_controller_spec.rb
+++ b/api/spec/controllers/spree/api/payments_controller_spec.rb
@@ -10,6 +10,7 @@ module Spree
                          :created_at, :updated_at] }
 
     let(:resource_scoping) { { :order_id => order.to_param } }
+
     before do
       stub_authentication!
     end
@@ -93,84 +94,95 @@ module Spree
       end
 
       context "for a given payment" do
-
-        it "can authorize" do
-          api_put :authorize, :id => payment.to_param
-          response.status.should == 200
-          payment.reload
-          payment.state.should == "pending"
-        end
-
-        context "authorization fails" do
-          before do
-            fake_response = double(:success? => false, :to_s => "Could not authorize card")
-            Spree::Gateway::Bogus.any_instance.should_receive(:authorize).and_return(fake_response)
+        context "authorizing" do
+          it "can authorize" do
             api_put :authorize, :id => payment.to_param
-          end 
-
-          it "returns a 422 status" do
-            response.status.should == 422
-            json_response["error"].should == "There was a problem with the payment gateway: Could not authorize card"
+            response.status.should == 200
+            payment.reload.state.should == "pending"
           end
 
-          it "returns a 422 status" do
-            pending "Investigate why a payment.reload after the request raises 'stack level too deep'" 
-            payment.reload
-            payment.state.should == "failed"
+          context "authorization fails" do
+            before do
+              fake_response = double(:success? => false, :to_s => "Could not authorize card")
+              Spree::Gateway::Bogus.any_instance.should_receive(:authorize).and_return(fake_response)
+              api_put :authorize, :id => payment.to_param
+            end
+
+            it "returns a 422 status" do
+              response.status.should == 422
+              json_response["error"].should == "There was a problem with the payment gateway: Could not authorize card"
+            end
+
+            it "does not raise a stack level error" do
+              pending "Investigate why a payment.reload after the request raises 'stack level too deep'"
+              payment.reload.state.should == "failed"
+            end
           end
         end
 
-        it "can capture" do
-          api_put :capture, :id => payment.to_param
-          response.status.should == 200
-          payment.reload
-          payment.state.should == "completed"
-        end
-
-        it "returns a 422 status when purchasing fails" do
-          fake_response = double(:success? => false, :to_s => "Insufficient funds")
-          Spree::Gateway::Bogus.any_instance.should_receive(:capture).and_return(fake_response)
-          api_put :capture, :id => payment.to_param
-          response.status.should == 422
-          json_response["error"].should == "There was a problem with the payment gateway: Insufficient funds"
-        end
-
-        it "can purchase" do
-          api_put :purchase, :id => payment.to_param
-          response.status.should == 200
-          payment.reload
-          payment.state.should == "completed"
-        end
-
-        context "purchasing fails" do
-          before do
-            fake_response = double(:success? => false, :to_s => "Insufficient funds")
-            Spree::Gateway::Bogus.any_instance.should_receive(:purchase).and_return(fake_response)
+        context "capturing" do
+          it "can capture" do
+            api_put :capture, :id => payment.to_param
+            response.status.should == 200
+            payment.reload.state.should == "completed"
           end
 
-          it "returns a 422" do
+          context "capturing fails" do
+            before do
+              fake_response = double(:success? => false, :to_s => "Insufficient funds")
+              Spree::Gateway::Bogus.any_instance.should_receive(:capture).and_return(fake_response)
+            end
+
+            it "returns a 422 status" do
+              api_put :capture, :id => payment.to_param
+              response.status.should == 422
+              json_response["error"].should == "There was a problem with the payment gateway: Insufficient funds"
+            end
+          end
+        end
+
+        context "purchasing" do
+          it "can purchase" do
             api_put :purchase, :id => payment.to_param
-            response.status.should == 422
-            json_response["error"].should == "There was a problem with the payment gateway: Insufficient funds"
+            response.status.should == 200
+            payment.reload.state.should == "completed"
+          end
+
+          context "purchasing fails" do
+            before do
+              fake_response = double(:success? => false, :to_s => "Insufficient funds")
+              Spree::Gateway::Bogus.any_instance.should_receive(:purchase).and_return(fake_response)
+            end
+
+            it "returns a 422 status" do
+              api_put :purchase, :id => payment.to_param
+              response.status.should == 422
+              json_response["error"].should == "There was a problem with the payment gateway: Insufficient funds"
+            end
           end
         end
 
-        it "can void" do
-          api_put :void, :id => payment.to_param
-          response.status.should == 200
-          payment.reload
-          payment.state.should == "void"
-        end
+        context "voiding" do
+          it "can void" do
+            api_put :void, :id => payment.to_param
+            response.status.should == 200
+            payment.reload.state.should == "void"
+          end
 
-        it "returns a 422 status when voiding fails" do
-          fake_response = double(:success? => false, :to_s => "NO REFUNDS")
-          Spree::Gateway::Bogus.any_instance.should_receive(:void).and_return(fake_response)
-          api_put :void, :id => payment.to_param
-          response.status.should == 422
-          json_response["error"].should == "There was a problem with the payment gateway: NO REFUNDS"
+          context "voiding fails" do
+            before do
+              fake_response = double(:success? => false, :to_s => "NO REFUNDS")
+              Spree::Gateway::Bogus.any_instance.should_receive(:void).and_return(fake_response)
+            end
 
-          payment.reload
-          payment.state.should == "checkout"
+            it "returns a 422 status" do
+              api_put :void, :id => payment.to_param
+              response.status.should == 422
+              json_response["error"].should == "There was a problem with the payment gateway: NO REFUNDS"
+
+              payment.reload.state.should == "checkout"
+            end
+          end
         end
 
         context "crediting" do
@@ -181,31 +193,30 @@ module Spree
           it "can credit" do
             api_put :credit, :id => payment.to_param
             response.status.should == 200
-            payment.reload
-            payment.state.should == "completed"
+            payment.reload.state.should == "completed"
 
-            # Ensur that a credit payment was created, and it has correct credit amount
+            # Ensure that a credit payment was created, and it has correct credit amount
             credit_payment = Payment.where(:source_type => 'Spree::Payment', :source_id => payment.id).last
             credit_payment.amount.to_f.should == -45.75
           end
 
-          it "returns a 422 status when crediting fails" do
-            fake_response = double(:success? => false, :to_s => "NO CREDIT FOR YOU")
-            Spree::Gateway::Bogus.any_instance.should_receive(:credit).and_return(fake_response)
-            api_put :credit, :id => payment.to_param
-            response.status.should == 422
-            json_response["error"].should == "There was a problem with the payment gateway: NO CREDIT FOR YOU"
-          end
+          context "crediting fails" do
+            it "returns a 422 status" do
+              fake_response = double(:success? => false, :to_s => "NO CREDIT FOR YOU")
+              Spree::Gateway::Bogus.any_instance.should_receive(:credit).and_return(fake_response)
+              api_put :credit, :id => payment.to_param
+              response.status.should == 422
+              json_response["error"].should == "There was a problem with the payment gateway: NO CREDIT FOR YOU"
+            end
 
-          it "cannot credit over credit_allowed limit" do
-            api_put :credit, :id => payment.to_param, :amount => 1000000
-            response.status.should == 422
-            json_response["error"].should == "This payment can only be credited up to 45.75. Please specify an amount less than or equal to this number."
+            it "cannot credit over credit_allowed limit" do
+              api_put :credit, :id => payment.to_param, :amount => 1000000
+              response.status.should == 422
+              json_response["error"].should == "This payment can only be credited up to 45.75. Please specify an amount less than or equal to this number."
+            end
           end
         end
       end
-
     end
-
   end
 end

--- a/backend/app/assets/javascripts/admin/admin.js.erb
+++ b/backend/app/assets/javascripts/admin/admin.js.erb
@@ -33,15 +33,14 @@ jQuery(function($) {
     fadeOutTime: 50,
   });
 
-  $('.with-tip').on({
-    powerTipPreRender: function(){
-      $('#powerTip').addClass($(this).attr("data-action"));
-      $('#powerTip').addClass($(this).attr("data-tip-color"));
-    },
-    powerTipClose: function(){
-      $('#powerTip').removeClass($(this).attr("data-action"))
-    }
-  });
+  $('body')
+    .on('powerTipPreRender', '.with-tip', function() {
+      $('#powerTip').addClass($(this).data('action'));
+      $('#powerTip').addClass($(this).data('tip-color'));
+    })
+    .on('powerTipClose', '.with-tip', function() {
+      $('#powerTip').removeClass($(this).data('action'));
+    })
 
   // Make flash messages dissapear
   setTimeout('$(".flash").fadeOut()', 5000);

--- a/backend/app/assets/javascripts/admin/admin.js.erb
+++ b/backend/app/assets/javascripts/admin/admin.js.erb
@@ -31,7 +31,6 @@ jQuery(function($) {
     smartPlacement: true,
     fadeInTime: 50,
     fadeOutTime: 50,
-    intentPollInterval: 300
   });
 
   $('.with-tip').on({

--- a/backend/app/assets/javascripts/admin/admin.js.erb
+++ b/backend/app/assets/javascripts/admin/admin.js.erb
@@ -80,17 +80,12 @@ jQuery(function($) {
 $.fn.visible = function(cond) { this[cond ? 'show' : 'hide' ]() };
 
 show_flash_error = function(message) {
-  error_div = $('.flash.error');
-  if (error_div.length > 0) {
-    error_div.html(message);
-    error_div.show();
-  } else {
-    if ($("#content .toolbar").length > 0) {
-      $("#content .toolbar").before('<div class="flash error">' + message + '</div>');
-    } else {
-      $("#content h1").before('<div class="flash error">' + message + '</div>');
-    }
+  var error_div = $('.flash.error');
+  if (error_div.length == 0) {
+    error_div = $('<div class="flash error" />');
+    $('#wrapper').prepend(error_div);
   }
+  error_div.html(message).show().fadeOut(5000);
 }
 
 // Apply to individual radio button that makes another element visible when checked

--- a/backend/app/assets/javascripts/admin/payments/edit.js.coffee
+++ b/backend/app/assets/javascripts/admin/payments/edit.js.coffee
@@ -1,0 +1,148 @@
+jQuery ($) ->
+  # Payment model
+  class Payment
+    constructor: (id) ->
+      @url  = Spree.url("#{Spree.routes.payments_api}/#{id}.json")
+      @json = $.getJSON @url.toString(), (data) =>
+        @data = data
+
+    if_pending: (callback) ->
+      @json.done (data) ->
+        callback() if data.state is 'pending'
+
+    update: (attributes, success) ->
+      jqXHR = $.ajax
+        type: 'PUT'
+        url:  @url.toString()
+        data: { payment: attributes }
+      jqXHR.done (data) =>
+        @data = data
+      jqXHR.fail ->
+        response = $.parseJSON(jqXHR.responseText)
+        show_flash_error(response.error)
+
+    amount:         -> @data.amount
+    display_amount: -> @data.display_amount
+
+  # Payment base view
+  class PaymentView
+    constructor: (@$el, @payment) ->
+      @render()
+
+    render: ->
+      @add_action_button()
+
+    show: ->
+      @remove_buttons()
+      new ShowPaymentView(@$el, @payment)
+
+    edit: ->
+      @remove_buttons()
+      new EditPaymentView(@$el, @payment)
+
+    add_action_button: ->
+      @$actions().prepend @$new_button(@action)
+
+    remove_buttons: ->
+      @$buttons().remove()
+
+    $new_button: (action) ->
+      $('<a />')
+        .attr
+          class: "icon-#{action} icon_link no-text with-tip"
+          title: Spree.translations[action]
+        .data
+          action: action
+        .one
+          click: (event) ->
+            event.preventDefault()
+          mousedown: ->
+            $(@).data('clicked', true)
+          mouseup: =>
+            @[action]()
+        .powerTip
+          smartPlacement: true
+          fadeInTime:     50
+          fadeOutTime:    50
+
+    $buttons: ->
+      @$actions().find(".icon-#{@action}, .icon-cancel")
+
+    $actions: ->
+      @$el.find('.actions')
+
+    $amount: ->
+      @$el.find('td.amount')
+
+  # Payment show view
+  class ShowPaymentView extends PaymentView
+    action: 'edit'
+
+    render: ->
+      super
+      @set_actions_display()
+      @show_actions()
+      @show_amount()
+
+    set_actions_display: ->
+      width = @$actions().width()
+      @$actions().width(width).css('text-align', 'left')
+
+    show_actions: ->
+      @$actions().find('a').show()
+
+    show_amount: ->
+      amount = $('<span />')
+        .html(@payment.display_amount())
+        .one('click', => @edit().$input().focus())
+      @$amount().html(amount)
+
+  # Payment edit view
+  class EditPaymentView extends PaymentView
+    action: 'save'
+
+    render: ->
+      super
+      @hide_actions()
+      @edit_amount()
+      @add_cancel_button()
+
+    add_cancel_button: ->
+      @$actions().append @$new_button('cancel')
+
+    hide_actions: ->
+      @$actions().find('a').not(@$buttons()).hide()
+
+    edit_amount: ->
+      amount = @$amount()
+      amount.html(@$new_input(amount.find('span').width()))
+
+    save: (event) ->
+      @payment.update(amount: @$input().val())
+        .done(=> @show())
+
+    cancel: @::show
+
+    $new_input: (width) ->
+      amount = @constructor.normalize_amount(@payment.display_amount())
+      $('<input />')
+        .attr(id: 'amount', value: amount)
+        .width(width)
+        .one
+          blur: =>
+            clicked = (@$buttons().filter -> $(@).data('clicked')).length
+            @save() unless clicked
+        .css('text-align': 'right')
+
+    $input: ->
+      @$amount().find('input')
+
+    @normalize_amount: (amount) ->
+      separator = Spree.translations.currency_separator
+      amount.replace(///[^\d#{separator}]///g, '')
+
+  # Attach ShowPaymentView to each pending payment in the table
+  $('.admin tr[data-hook=payments_row]').each ->
+    $el = $(@)
+    payment = new Payment($el.attr('id').match(/\d+$/))
+    payment.if_pending -> new ShowPaymentView($el, payment)

--- a/backend/app/assets/javascripts/admin/progress.coffee
+++ b/backend/app/assets/javascripts/admin/progress.coffee
@@ -16,12 +16,12 @@ $(document).ready ->
     top: 'auto'
     left: 'auto'
 
-  target = document.getElementById("spinner")  
+  target = document.getElementById("spinner")
 
   $(document).ajaxStart ->
-    $("#progress").fadeIn()
-    spinner = new Spinner(opts).spin(target)    
+    $("#progress").stop(true, true).fadeIn()
+    spinner = new Spinner(opts).spin(target)
 
   $(document).ajaxStop ->
-    $("#progress").fadeOut()    
+    $("#progress").fadeOut()
 

--- a/backend/app/assets/stylesheets/admin/shared/_tables.scss
+++ b/backend/app/assets/stylesheets/admin/shared/_tables.scss
@@ -84,7 +84,7 @@ table {
         background-color: $color-notice;
         color: $color-1;
       }
-      .icon-edit:hover, .icon-capture:hover, .icon-ok:hover, .icon-plus:hover {
+      .icon-edit:hover, .icon-capture:hover, .icon-ok:hover, .icon-plus:hover, .icon-save:hover {
         background-color: $color-success;
         color: $color-1;
       }

--- a/backend/app/views/spree/admin/payments/_list.html.erb
+++ b/backend/app/views/spree/admin/payments/_list.html.erb
@@ -10,9 +10,9 @@
   </thead>
   <tbody>
     <% payments.each do |payment| %>
-      <tr data-hook="payments_row" class="<%= cycle('odd', 'even')%>">
+      <tr id="<%= dom_id(payment) %>" data-hook="payments_row" class="<%= cycle('odd', 'even')%>">
         <td><%= pretty_time(payment.created_at) %></td>
-        <td class='align-center'><%= payment.display_amount.to_html %></td>
+        <td class="align-center amount"><%= payment.display_amount.to_html %></td>
         <td class="align-center"><%= link_to payment_method_name(payment), spree.admin_order_payment_path(@order, payment) %></td>
         <td class="align-center"> <span class="state <%= payment.state %>"><%= Spree.t(payment.state, :scope => :payment_states, :default => payment.state.capitalize) %></span></td>
         <td class="actions">

--- a/backend/app/views/spree/admin/shared/_routes.html.erb
+++ b/backend/app/views/spree/admin/shared/_routes.html.erb
@@ -9,5 +9,5 @@
   Spree.routes.checkouts_api = "<%= spree.api_checkouts_url(:format => 'json') %>";
   Spree.routes.stock_locations_api = "<%= spree.api_stock_locations_url(:format => 'json') %>";
   Spree.routes.variants_api = "<%= spree.api_variants_url(:format => 'json') %>";
-
+  Spree.routes.payments_api = "<%= spree.api_order_payments_url(:format => 'json') if params[:order_id] %>";
 </script>

--- a/backend/app/views/spree/admin/shared/_translations.html.erb
+++ b/backend/app/views/spree/admin/shared/_translations.html.erb
@@ -10,8 +10,10 @@
     :choose_a_customer        => Spree.t(:choose_a_customer),
     :confirm_delete           => Spree.t(:confirm_delete),
     :cut                      => Spree.t(:cut),
-    :destroy                  => Spree.t(:destroy),
-    :edit                     => Spree.t(:edit),
+    :destroy                  => Spree.t(:destroy, :scope => :actions),
+    :edit                     => Spree.t(:edit,    :scope => :actions),
+    :save                     => Spree.t(:save,    :scope => :actions),
+    :cancel                   => Spree.t(:cancel,  :scope => :actions),
     :first_day                => Spree.t(:first_day,
                                          :scope => 'date_picker',
                                          :default => 0).to_i,
@@ -31,7 +33,8 @@
     :type_to_search           => Spree.t(:type_to_search),
     :taxon_placeholder        => Spree.t(:taxon_placeholder),
     :variant_placeholder      => Spree.t(:variant_placeholder),
-    :value                    => Spree.t(:value)
+    :value                    => Spree.t(:value),
+    :currency_separator       => I18n.t('number.currency.format.separator'),
   }.to_json
 %>
 </script>

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -1,85 +1,91 @@
 require 'spec_helper'
 
-describe "Payments" do
+describe 'Payments' do
   stub_authorization!
 
-  let(:order) { create(:completed_order_with_totals, :number => "R100") }
+  let!(:payment) do
+    create(:payment,
+      order:          order,
+      amount:         order.outstanding_balance,
+      payment_method: create(:bogus_payment_method),  # Credit Card
+      state:          state
+    )
+  end
 
-  context "payment methods" do
+  let(:order) { create(:completed_order_with_totals, number: 'R100') }
+  let(:state) { 'checkout' }
 
-    before(:each) do
-      create(:payment, :order => order, :amount => order.outstanding_balance, :payment_method => create(:bogus_payment_method, :environment => 'test'))
-      visit spree.admin_path
-      click_link "Orders"
-      within_row(1) do
-        click_link "R100"
-      end
+  before do
+    visit spree.admin_path
+    click_link 'Orders'
+    within_row(1) do
+      click_link order.number
+    end
+    click_link 'Payments'
+  end
+
+  def refresh_page
+    visit current_path
+  end
+
+  it 'should be able to list and create payment methods for an order', js: true do
+    find('#payment_status').text.should == 'BALANCE DUE'
+    within_row(1) do
+      column_text(2).should == '$50.00'
+      column_text(3).should == 'Credit Card'
+      column_text(4).should == 'CHECKOUT'
     end
 
-    it "should be able to list and create payment methods for an order", :js => true do
+    click_icon :void
+    find('#payment_status').text.should == 'BALANCE DUE'
+    page.should have_content('Payment Updated')
 
-      click_link "Payments"
-      find("#payment_status").text.should == "BALANCE DUE"
-      within_row(1) do
-        column_text(2).should == "$50.00"
-        column_text(3).should == "Credit Card"
-        column_text(4).should == "CHECKOUT"
-      end
+    within_row(1) do
+      column_text(2).should == '$50.00'
+      column_text(3).should == 'Credit Card'
+      column_text(4).should == 'VOID'
+    end
 
-      click_icon :void
-      find("#payment_status").text.should == "BALANCE DUE"
-      page.should have_content("Payment Updated")
+    click_on 'New Payment'
+    page.should have_content('New Payment')
+    click_button 'Update'
+    page.should have_content('successfully created!')
 
-      within_row(1) do
-        column_text(2).should == "$50.00"
-        column_text(3).should == "Credit Card"
-        column_text(4).should == "VOID"
-      end
+    click_icon(:capture)
+    find('#payment_status').text.should == 'PAID'
 
-      click_on "New Payment"
-      page.should have_content("New Payment")
-      click_button "Update"
-      page.should have_content("successfully created!")
+    page.should_not have_selector('#new_payment_section')
+  end
 
+  # Regression test for #1269
+  it 'cannot create a payment for an order with no payment methods' do
+    Spree::PaymentMethod.delete_all
+    order.payments.delete_all
+
+    click_on 'New Payment'
+    page.should have_content('You cannot create a payment for an order without any payment methods defined.')
+    page.should have_content('Please define some payment methods first.')
+  end
+
+  # Regression tests for #1453
+  context 'with a check payment' do
+    let!(:payment) do
+      create(:payment,
+        order:          order,
+        amount:         order.outstanding_balance,
+        payment_method: create(:payment_method)  # Check
+      )
+    end
+
+    it 'capturing a check payment from a new order' do
       click_icon(:capture)
-      find("#payment_status").text.should == "PAID"
-
-      page.should_not have_css('#new_payment_section')
+      page.should_not have_content('Cannot perform requested operation')
+      page.should have_content('Payment Updated')
     end
 
-    # Regression test for #1269
-    it "cannot create a payment for an order with no payment methods" do
-      Spree::PaymentMethod.delete_all
-      order.payments.delete_all
-
-      visit spree.new_admin_order_payment_path(order)
-      page.should have_content("You cannot create a payment for an order without any payment methods defined.")
-      page.should have_content("Please define some payment methods first.")
+    it 'voids a check payment from a new order' do
+      click_icon(:void)
+      page.should have_content('Payment Updated')
     end
-
-    # Regression tests for #1453
-    context "with a check payment" do
-      before do
-        order.payments.delete_all
-        create(:payment, :order => order,
-                        :state => "checkout",
-                        :amount => order.outstanding_balance,
-                        :payment_method => create(:bogus_payment_method, :environment => 'test'))
-      end
-
-      it "capturing a check payment from a new order" do
-        visit spree.admin_order_payments_path(order)
-        click_icon(:capture)
-        page.should_not have_content("Cannot perform requested operation")
-        page.should have_content("Payment Updated")
-      end
-
-      it "voids a check payment from a new order" do
-        visit spree.admin_order_payments_path(order)
-        click_icon(:void)
-        page.should have_content("Payment Updated")
-      end
-    end
-
   end
 end

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,5 @@
+set -e
+
 # Switching Gemfile
 function set_gemfile(){
   echo "Switching Gemfile..."

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -34,6 +34,8 @@ module Spree
 
     after_rollback :persist_invalid
 
+    validates :amount, numericality: true
+
     def persist_invalid
       return unless ['failed', 'invalid'].include?(state)
       state_will_change!

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -78,6 +78,16 @@ module Spree
     end
     alias display_amount money
 
+    def amount=(amount)
+      self[:amount] =
+        case amount
+        when String
+          separator = I18n.t('number.currency.format.separator')
+          number    = amount.delete("^0-9-#{separator}").tr(separator, '.')
+          number.to_d if number.present?
+        end || amount
+    end
+
     def offsets_total
       offsets.pluck(:amount).sum
     end

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -37,7 +37,7 @@ module Spree
     def persist_invalid
       return unless ['failed', 'invalid'].include?(state)
       state_will_change!
-      save 
+      save
     end
 
     # order state machine (see http://github.com/pluginaweek/state_machine/tree/master for details)

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -93,7 +93,7 @@ module Spree
           record_response(response)
 
           if response.success?
-            self.class.create(
+            self.class.create!(
               :order => order,
               :source => self,
               :payment_method => payment_method,
@@ -169,7 +169,7 @@ module Spree
       end
 
       def record_response(response)
-        log_entries.create(:details => response.to_yaml)
+        log_entries.create!(:details => response.to_yaml)
       end
 
       def protect_from_connection_error

--- a/core/lib/spree/money.rb
+++ b/core/lib/spree/money.rb
@@ -33,6 +33,10 @@ module Spree
       output
     end
 
+    def as_json(*)
+      to_s
+    end
+
     def ==(obj)
       @money == obj.money
     end

--- a/core/spec/lib/spree/money_spec.rb
+++ b/core/spec/lib/spree/money_spec.rb
@@ -131,4 +131,13 @@ describe Spree::Money do
       money.to_html.should == "10.00&nbsp;&#x20AC;"
     end
   end
+
+  describe "#as_json" do
+    let(:options) { double('options') }
+
+    it "returns the expected string" do
+      money = Spree::Money.new(10)
+      money.as_json(options).should == "$10.00"
+    end
+  end
 end

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -336,7 +336,7 @@ describe Spree::Payment do
 
     context "#credit" do
       before do
-        payment.state = 'complete'
+        payment.state = 'completed'
         payment.response_code = '123'
       end
 

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -640,4 +640,67 @@ describe Spree::Payment do
       end
     end
   end
+
+  describe "#amount=" do
+    before do
+      subject.amount = amount
+    end
+
+    context "when the amount is a string" do
+      context "amount is a decimal" do
+        let(:amount) { '2.99' }
+
+        its(:amount) { should eql(BigDecimal('2.99')) }
+      end
+
+      context "amount is an integer" do
+        let(:amount) { '2' }
+
+        its(:amount) { should eql(BigDecimal('2.0')) }
+      end
+
+      context "amount contains a dollar sign" do
+        let(:amount) { '$2.99' }
+
+        its(:amount) { should eql(BigDecimal('2.99')) }
+      end
+
+      context "amount contains a comma" do
+        let(:amount) { '$2,999.99' }
+
+        its(:amount) { should eql(BigDecimal('2999.99')) }
+      end
+
+      context "amount contains a negative sign" do
+        let(:amount) { '-2.99' }
+
+        its(:amount) { should eql(BigDecimal('-2.99')) }
+      end
+
+      context "amount is invalid" do
+        let(:amount) { 'invalid' }
+
+        # this is a strange default for ActiveRecord
+        its(:amount) { should eql(BigDecimal('0')) }
+      end
+
+      context "amount is an empty string" do
+        let(:amount) { '' }
+
+        its(:amount) { should be_nil }
+      end
+    end
+
+    context "when the amount is a number" do
+      let(:amount) { 1.55 }
+
+      its(:amount) { should eql(BigDecimal('1.55')) }
+    end
+
+    context "when the amount is nil" do
+      let(:amount) { nil }
+
+      its(:amount) { should be_nil }
+    end
+  end
 end

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -38,7 +38,7 @@ describe Spree::Payment do
 
   before(:each) do
     # So it doesn't create log entries every time a processing method is called
-    payment.log_entries.stub(:create)
+    payment.log_entries.stub(:create!)
   end
 
   context 'validations' do
@@ -126,7 +126,7 @@ describe Spree::Payment do
       end
 
       it "should log the response" do
-        payment.log_entries.should_receive(:create).with(:details => anything)
+        payment.log_entries.should_receive(:create!).with(:details => anything)
         payment.authorize!
       end
 
@@ -177,7 +177,7 @@ describe Spree::Payment do
       end
 
       it "should log the response" do
-        payment.log_entries.should_receive(:create).with(:details => anything)
+        payment.log_entries.should_receive(:create!).with(:details => anything)
         payment.purchase!
       end
 
@@ -263,7 +263,7 @@ describe Spree::Payment do
         it "should do nothing" do
           payment.should_not_receive(:complete)
           payment.payment_method.should_not_receive(:capture)
-          payment.log_entries.should_not_receive(:create)
+          payment.log_entries.should_not_receive(:create!)
           payment.capture!
         end
       end
@@ -292,7 +292,7 @@ describe Spree::Payment do
       end
 
       it "should log the response" do
-        payment.log_entries.should_receive(:create).with(:details => anything)
+        payment.log_entries.should_receive(:create!).with(:details => anything)
         payment.void_transaction!
       end
 
@@ -374,7 +374,7 @@ describe Spree::Payment do
       end
 
       it "should log the response" do
-        payment.log_entries.should_receive(:create).with(:details => anything)
+        payment.log_entries.should_receive(:create!).with(:details => anything)
         payment.credit!
       end
 
@@ -387,7 +387,7 @@ describe Spree::Payment do
 
       context "when response is successful" do
         it "should create an offsetting payment" do
-          Spree::Payment.should_receive(:create)
+          Spree::Payment.should_receive(:create!)
           payment.credit!
         end
 

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -25,7 +25,7 @@ describe Spree::Payment do
     payment
   end
 
-  let(:amount_in_cents) { payment.amount.to_f * 100 }
+  let(:amount_in_cents) { (payment.amount * 100).round }
 
   let!(:success_response) do
     double('success_response', :success? => true,
@@ -55,7 +55,6 @@ describe Spree::Payment do
 
   # Regression test for https://github.com/spree/spree/pull/2224
   context 'failure' do
-
     it 'should transition to failed from pending state' do
       payment.state = 'pending'
       payment.failure
@@ -84,7 +83,7 @@ describe Spree::Payment do
       payment.stub(:create_payment_profile)
     end
 
-    context "#process!" do
+    describe "#process!" do
       it "should purchase if with auto_capture" do
         payment.payment_method.should_receive(:auto_capture?).and_return(true)
         payment.should_receive(:purchase!)
@@ -110,7 +109,7 @@ describe Spree::Payment do
 
     end
 
-    context "#authorize" do
+    describe "#authorize!" do
       it "should call authorize on the gateway with the payment amount" do
         payment.payment_method.should_receive(:authorize).with(amount_in_cents,
                                                                card,
@@ -171,7 +170,7 @@ describe Spree::Payment do
       end
     end
 
-    context "purchase" do
+    describe "#purchase!" do
       it "should call purchase on the gateway with the payment amount" do
         gateway.should_receive(:purchase).with(amount_in_cents, card, anything).and_return(success_response)
         payment.purchase!
@@ -218,7 +217,7 @@ describe Spree::Payment do
       end
     end
 
-    context "#capture" do
+    describe "#capture!" do
       before do
         payment.stub(:complete).and_return(true)
       end
@@ -270,7 +269,7 @@ describe Spree::Payment do
       end
     end
 
-    context "#void" do
+    describe "#void_transaction!" do
       before do
         payment.response_code = '123'
         payment.state = 'pending'
@@ -334,7 +333,7 @@ describe Spree::Payment do
       end
     end
 
-    context "#credit" do
+    describe "#credit!" do
       before do
         payment.state = 'completed'
         payment.response_code = '123'
@@ -449,7 +448,7 @@ describe Spree::Payment do
     end
   end
 
-  context "#credit_allowed" do
+  describe "#credit_allowed" do
     it "is the difference between offsets total and payment amount" do
       payment.amount = 100
       payment.stub(:offsets_total).and_return(0)
@@ -459,18 +458,19 @@ describe Spree::Payment do
     end
   end
 
-  context "#can_credit?" do
+  describe "#can_credit?" do
     it "is true if credit_allowed > 0" do
       payment.stub(:credit_allowed).and_return(100)
       payment.can_credit?.should be_true
     end
+
     it "is false if credit_allowed is 0" do
       payment.stub(:credit_allowed).and_return(0)
       payment.can_credit?.should be_false
     end
   end
 
-  context "#credit" do
+  describe "#credit!" do
     context "when amount <= credit_allowed" do
       it "makes the state processing" do
         payment.state = 'completed'
@@ -478,6 +478,7 @@ describe Spree::Payment do
         payment.partial_credit(10)
         payment.should be_processing
       end
+
       it "calls credit on the source with the payment and amount" do
         payment.state = 'completed'
         payment.stub(:credit_allowed).and_return(10)
@@ -485,6 +486,7 @@ describe Spree::Payment do
         payment.partial_credit(10)
       end
     end
+
     context "when amount > credit_allowed" do
       it "should not call credit on the source" do
         payment.state = 'completed'
@@ -495,7 +497,7 @@ describe Spree::Payment do
     end
   end
 
-  context "#save" do
+  describe "#save" do
     it "should call order#update!" do
       payment = Spree::Payment.create(:amount => 100, :order => order)
       order.should_receive(:update!)
@@ -507,7 +509,6 @@ describe Spree::Payment do
         gateway.stub :payment_profiles_supported? => true
         payment.source.stub :has_payment_profile? => false
       end
-
 
       context "when there is an error connecting to the gateway" do
         it "should call gateway_error " do
@@ -534,8 +535,6 @@ describe Spree::Payment do
           )
         end
       end
-
-
     end
 
     context "when profiles are not supported" do
@@ -553,7 +552,7 @@ describe Spree::Payment do
     end
   end
 
-  context "#build_source" do
+  describe "#build_source" do
     it "should build the payment's source" do
       params = { :amount => 100, :payment_method => gateway,
         :source_attributes => {
@@ -580,21 +579,21 @@ describe Spree::Payment do
     end
   end
 
-  context "#currency" do
+  describe "#currency" do
     before { order.stub(:currency) { "ABC" } }
     it "returns the order currency" do
       payment.currency.should == "ABC"
     end
   end
 
-  context "#display_amount" do
+  describe "#display_amount" do
     it "returns a Spree::Money for this amount" do
       payment.display_amount.should == Spree::Money.new(payment.amount)
     end
   end
 
   # Regression test for #2216
-  context "#gateway_options" do
+  describe "#gateway_options" do
     before { order.stub(:last_ip_address => "192.168.1.1") }
 
     it "contains an IP" do
@@ -602,7 +601,7 @@ describe Spree::Payment do
     end
   end
 
-  context "#set_unique_identifier" do
+  describe "#set_unique_identifier" do
     # Regression test for #1998
     it "sets a unique identifier on create" do
       payment.run_callbacks(:create)
@@ -618,7 +617,6 @@ describe Spree::Payment do
       payment.save
       payment.identifier.should == old_identifier
     end
-
 
     context "other payment exists" do
       let(:other_payment) {


### PR DESCRIPTION
This branch adds the ability for an admin user to edit a pending payment amount so that a different amount can be captured than the original authorization. In my specific use case we are applying adjustments to an order manually based on the customer's standing, whether they are known students (for student discount), employees and various other criteria that is difficult to automate. We want to be able to capture an amount equal to or less than the authorized amount, which this feature allows.

Fix #3738
## 

Last commit description:

This adds a coffeescript file with classes to manage the payment object, as well as two classes to manage the show and edit view states for a payment.

The show view is the starting state and is added to each pending payment in the table. It will add the edit icon as well as make the amount clickable; clicking on either will change to the edit view.

The edit view will hide the capture and pending icons, as well as change the edit icon to save. It will also change the amount to a text field, which can be edited. Moving focus from the text field or clicking on the save icon will save the payment using an ajax request. The edit view may be cancelled and reverted back to the show view by clicking on the cancel button.

If the ajax request is successful, then the show view will return. If there is an error, a flash message will display at the top of the page and fade away after 5 seconds.
## 

This branch also includes small fixes and refactorings to code that I had to modify in order to add this feature. I tried to follow conventions in the newer code, but if you disagree with anything please note it in the PR and I will fix it.
