### PR TITLE
fix shipping rates refresh losing current rate

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -103,13 +103,16 @@ module Spree
     def refresh_rates
       return shipping_rates if shipped?
 
+      # StockEstimator.new assigment below will replace the current shipping_method
+      original_shipping_method_id = shipping_method.try(:id)
+
       self.shipping_rates = Stock::Estimator.new(order).shipping_rates(to_package)
 
       if shipping_method
         selected_rate = shipping_rates.detect { |rate|
-          rate.shipping_method_id == shipping_method.id
+          rate.shipping_method_id == original_shipping_method_id
         }
-        self.selected_shipping_rate_id = selected_rate.id if selected_rate
+        self.selected_shipping_rate_id = selected_rate.id if !selected_rate.nil?
       end
 
       shipping_rates


### PR DESCRIPTION
The admin order creating seems to replace all the shipping rates and loses the current selected rate.
Seems to be affected be the change made here:
https://github.com/spree/spree/commit/8f3c82c04b7c3735e9e6d523b366ea3c2dea34a7
So this brings back the 'store and check' of shipping_method.id

To reproduce:
- Log in as admin
- Go to orders, create order
- add item
- change shipping rate => changes don't stick, always resets to default

Affects 2-0-stable as well as 2-1-stable and master
