### PR TITLE
Master should be made out of stock when its variants are created.

### DIFF
--- a/core/app/models/spree/stock/availability_validator.rb
+++ b/core/app/models/spree/stock/availability_validator.rb
@@ -17,7 +17,7 @@ module Spree
           display_name = %Q{#{variant.name}}
           display_name += %Q{ (#{variant.options_text})} unless variant.options_text.blank?
 
-          line_item.errors[:quantity] << Spree.t(:out_of_stock, :scope => :order_populator, :item => display_name.inspect)
+          line_item.errors[:quantity] << Spree.t(:selected_quantity_not_available, :scope => :order_populator, :item => display_name.inspect)
         end
       end
     end

--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -44,6 +44,11 @@ module Spree
       self.in_stock? || self.backorderable?
     end
 
+    def reduce_count_on_hand_to_zero
+      self.set_count_on_hand(0) if count_on_hand > 0
+    end
+
+
     private
       def count_on_hand=(value)
         write_attribute(:count_on_hand, value)

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -751,6 +751,7 @@ en:
     order_number: Order
     order_populator:
       out_of_stock: ! '%{item} is out of stock.'
+      selected_quantity_not_available: ! 'Selected quantity of %{item} is not available.'
       please_enter_reasonable_quantity: Please enter a reasonable quantity.
     order_processed_successfully: Your order has been processed successfully
     order_state:

--- a/core/spec/models/spree/stock_item_spec.rb
+++ b/core/spec/models/spree/stock_item_spec.rb
@@ -33,6 +33,28 @@ describe Spree::StockItem do
     end
   end
 
+  describe 'reduce_count_on_hand_to_zero' do
+    context 'when count_on_hand > 0' do
+      before(:each) do
+        subject.update_column('count_on_hand', 4)
+        subject.reduce_count_on_hand_to_zero
+      end
+
+      it { subject.count_on_hand.should eq(0) }
+    end
+
+    context 'when count_on_hand > 0' do
+      before(:each) do
+        subject.update_column('count_on_hand', -4)
+        @count_on_hand = subject.count_on_hand
+        subject.reduce_count_on_hand_to_zero
+      end
+
+      it { subject.count_on_hand.should eq(@count_on_hand) }
+    end
+  end
+
+
   context "adjust count_on_hand" do
     let!(:current_on_hand) { subject.count_on_hand }
 

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -33,6 +33,21 @@ describe Spree::Variant do
         product.variants.create(:name => "Foobar")
       end
     end
+
+
+    describe 'mark_master_out_of_stock' do
+      context 'when product is created without variants' do
+        it { product.master.should be_in_stock }
+      end
+
+      context 'when a variant is created' do
+        before(:each) do
+          product.variants.create!(:name => 'any-name')
+        end
+
+        it { product.master.should_not be_in_stock }
+      end
+    end
   end
 
   context "product has other variants" do


### PR DESCRIPTION
After variants of a product is created, master is still saleable at admin end, but admin can't manage it stock information.

Also, if a user changes variant id to master id in admin end, it will get added to its cart and also he will be able to buy it.

So, master should be made out of stock when a variant is created for a product.
