### PR TITLE
Use 2-1-stable branch of spree_auth_devise when generating sandbox

### DIFF
--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -10,7 +10,7 @@ fi
 
 cd ./sandbox
 echo "gem 'spree', :path => '..'" >> Gemfile
-echo "gem 'spree_auth_devise', :github => 'spree/spree_auth_devise'" >> Gemfile
+echo "gem 'spree_auth_devise', :github => 'spree/spree_auth_devise', :branch => '2-1-stable'" >> Gemfile
 
 bundle install --gemfile Gemfile
 bundle exec rails g spree:install --auto-accept --user_class=Spree::User


### PR DESCRIPTION
Generating a sandbox in 2-1-stable was failing due to some dependencies declared in the master branch of spree_auth_devise. Specifying the 2-1-stable branch resolved this for me. 
