### PR TITLE
Fix product sample in sqlite3 (2-0-stable)

### DIFF
--- a/sample/db/samples/products.rb
+++ b/sample/db/samples/products.rb
@@ -125,12 +125,10 @@ products.each do |product_attrs|
   eur_price = product_attrs.delete(:eur_price)
   Spree::Config[:currency] = "USD"
 
-  default_shipping_category = Spree::ShippingCategory.find_by_name!("Default Shipping")
   product = Spree::Product.create!(default_attrs.merge(product_attrs), :without_protection => true)
   Spree::Config[:currency] = "EUR"
   product.reload
   product.price = eur_price
-  product.shipping_category = default_shipping_category
   product.save!
 end
 

--- a/sample/db/samples/shipping_methods.rb
+++ b/sample/db/samples/shipping_methods.rb
@@ -7,7 +7,7 @@ rescue ActiveRecord::RecordNotFound
 end
 
 europe_vat = Spree::Zone.find_by_name!("EU_VAT")
-shipping_category = Spree::ShippingCategory.find_or_create_by_name!('Default')
+shipping_category = Spree::ShippingCategory.find_by_name!("Default Shipping")
 
 shipping_methods = [
   {


### PR DESCRIPTION
Users running Spree on sqlite3 (default sandbox) gets an odd "cant calculate shipping rates" in checkout. Removing the reassign of shipping category fixes the issue.
