### PR TITLE
Add manual adjustments to discount

### DIFF
--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -56,6 +56,7 @@ module Spree
     scope :charge, -> { where('amount >= 0') }
     scope :credit, -> { where('amount < 0') }
     scope :promotion, -> { where(originator_type: 'Spree::PromotionAction') }
+    scope :manual, -> { where(originator_type: nil) }
     scope :return_authorization, -> { where(source_type: "Spree::ReturnAuthorization") }
 
     def promotion?

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -85,7 +85,7 @@ module Spree
     # are not recalculated.
     #
     # It receives +calculable+ as the updated source here so calculations can be
-    # performed on the current values of that source. If we used +source+ it 
+    # performed on the current values of that source. If we used +source+ it
     # could load the old record from db for the association. e.g. when updating
     # more than on line items at once via accepted_nested_attributes the order
     # object on the association would be in a old state and therefore the

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -491,6 +491,10 @@ module Spree
       adjustments.eligible.manual.sum(:amount)
     end
 
+    def discount_total
+      promo_total + manual_adjustment_total
+    end
+
     def shipped?
       %w(partial shipped).include?(shipment_state)
     end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -487,6 +487,10 @@ module Spree
       adjustments.eligible.promotion.sum(:amount)
     end
 
+    def manual_adjustment_total
+      adjustments.eligible.manual.sum(:amount)
+    end
+
     def shipped?
       %w(partial shipped).include?(shipment_state)
     end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -507,7 +507,7 @@ module Spree
     #
     # At some point the might need to force the order to transition from address
     # to delivery again so that proper updated shipments are created.
-    # e.g. customer goes back from payment step and changes order items 
+    # e.g. customer goes back from payment step and changes order items
     def ensure_updated_shipments
       if shipments.any?
         self.shipments.destroy_all

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -283,11 +283,11 @@ module Spree
     end
 
     def ship_total
-      adjustments.shipping.map(&:amount).sum
+      adjustments.shipping.sum(:amount)
     end
 
     def tax_total
-      adjustments.tax.map(&:amount).sum
+      adjustments.tax.sum(:amount)
     end
 
     # Creates new tax charges if there are any applicable rates. If prices already
@@ -484,7 +484,7 @@ module Spree
     end
 
     def promo_total
-      adjustments.eligible.promotion.map(&:amount).sum
+      adjustments.eligible.promotion.sum(:amount)
     end
 
     def shipped?

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -126,7 +126,7 @@ module Spree
         options.merge!({ :shipping => order.ship_total * 100,
                          :tax      => order.tax_total * 100,
                          :subtotal => order.item_total * 100,
-                         :discount => order.promo_total * 100,
+                         :discount => order.discount_total * 100,
                          :currency => currency })
 
         options.merge!({ :billing_address  => order.bill_address.try(:active_merchant_hash),

--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -6,14 +6,13 @@ require 'spec_helper'
 describe Spree::Adjustment do
 
   let(:order) { mock_model(Spree::Order, update!: nil) }
-  let(:adjustment) { Spree::Adjustment.create(:label => "Adjustment", :amount => 5) }
+  let!(:adjustment) { Spree::Adjustment.create!(:label => "Adjustment", :amount => 5) }
 
-  describe "scopes" do
-    let!(:arbitrary_adjustment) { create(:adjustment, source: nil, label: "Arbitrary") }
+  describe ".return_authorization" do
     let!(:return_authorization_adjustment) { create(:adjustment, source: create(:return_authorization)) }
 
     it "returns return_authorization adjustments" do
-      expect(Spree::Adjustment.return_authorization.to_a).to eq [return_authorization_adjustment]
+      expect(Spree::Adjustment.return_authorization).to eq([return_authorization_adjustment])
     end
   end
 

--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -8,6 +8,12 @@ describe Spree::Adjustment do
   let(:order) { mock_model(Spree::Order, update!: nil) }
   let!(:adjustment) { Spree::Adjustment.create!(:label => "Adjustment", :amount => 5) }
 
+  describe ".manual" do
+    it "returns manual adjustments" do
+      expect(Spree::Adjustment.manual).to eq([adjustment])
+    end
+  end
+
   describe ".return_authorization" do
     let!(:return_authorization_adjustment) { create(:adjustment, source: create(:return_authorization)) }
 

--- a/core/spec/models/spree/order/adjustments_spec.rb
+++ b/core/spec/models/spree/order/adjustments_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
+
 describe Spree::Order do
   let(:order) { Spree::Order.new }
 
   context "clear_adjustments" do
-
     let(:adjustment) { double("Adjustment") }
 
     it "destroys all order adjustments" do
@@ -41,7 +41,6 @@ describe Spree::Order do
 
   context "line item adjustment totals" do
     before { @order = Spree::Order.create! }
-
 
     context "when there are no line item adjustments" do
       before { @order.stub_chain(:line_item_adjustments, :eligible => []) }
@@ -146,4 +145,3 @@ describe Spree::Order do
     end
   end
 end
-

--- a/core/spec/models/spree/order/adjustments_spec.rb
+++ b/core/spec/models/spree/order/adjustments_spec.rb
@@ -20,24 +20,27 @@ describe Spree::Order do
   end
 
   context "totaling adjustments" do
-    let(:adjustment1) { mock_model(Spree::Adjustment, :amount => 5) }
-    let(:adjustment2) { mock_model(Spree::Adjustment, :amount => 10) }
-
     context "#ship_total" do
       it "should return the correct amount" do
-        order.stub_chain :adjustments, :shipping => [adjustment1, adjustment2]
+        order.stub_chain :adjustments, :shipping, :sum => 15
         order.ship_total.should == 15
       end
     end
 
     context "#tax_total" do
       it "should return the correct amount" do
-        order.stub_chain :adjustments, :tax => [adjustment1, adjustment2]
+        order.stub_chain :adjustments, :tax, :sum => 15
         order.tax_total.should == 15
       end
     end
+
+    context "#promo_total" do
+      it "should return the correct amount" do
+        order.stub_chain :adjustments, :eligible, :promotion, :sum => 15
+        order.promo_total.should == 15
+      end
+    end
   end
-  
 
   context "line item adjustment totals" do
     before { @order = Spree::Order.create! }

--- a/core/spec/models/spree/order/adjustments_spec.rb
+++ b/core/spec/models/spree/order/adjustments_spec.rb
@@ -47,6 +47,14 @@ describe Spree::Order do
         order.manual_adjustment_total.should == 15
       end
     end
+
+    describe "#discount_total" do
+      it "should return the correct amount" do
+        order.should_receive(:promo_total).and_return(5)
+        order.should_receive(:manual_adjustment_total).and_return(10)
+        order.discount_total.should == 15
+      end
+    end
   end
 
   context "line item adjustment totals" do

--- a/core/spec/models/spree/order/adjustments_spec.rb
+++ b/core/spec/models/spree/order/adjustments_spec.rb
@@ -20,24 +20,31 @@ describe Spree::Order do
   end
 
   context "totaling adjustments" do
-    context "#ship_total" do
+    describe "#ship_total" do
       it "should return the correct amount" do
         order.stub_chain :adjustments, :shipping, :sum => 15
         order.ship_total.should == 15
       end
     end
 
-    context "#tax_total" do
+    describe "#tax_total" do
       it "should return the correct amount" do
         order.stub_chain :adjustments, :tax, :sum => 15
         order.tax_total.should == 15
       end
     end
 
-    context "#promo_total" do
+    describe "#promo_total" do
       it "should return the correct amount" do
         order.stub_chain :adjustments, :eligible, :promotion, :sum => 15
         order.promo_total.should == 15
+      end
+    end
+
+    describe "#manual_adjustment_total" do
+      it "should return the correct amount" do
+        order.stub_chain :adjustments, :eligible, :manual, :sum => 15
+        order.manual_adjustment_total.should == 15
       end
     end
   end


### PR DESCRIPTION
This branch changes the payment processor to factor in manual adjustments to the discount amount passed to the gateway.
## 

The previous code would work with promo codes adjustments, but not with "manual" adjustments where the originator is nil. This adds a Spree::Order#discount_total which is used by the payment processor to set the discount option.
## 

Also this branch refactors some of the sum operations to use aggregate functions instead of pulling back the full result-set and performing the sum on in-memory objects.
