### PR TITLE
Assign location to shipment when importing orders (api)

### DIFF
--- a/api/app/models/spree/order_decorator.rb
+++ b/api/app/models/spree/order_decorator.rb
@@ -37,6 +37,7 @@ Spree::Order.class_eval do
       begin
         shipment = shipments.build
         shipment.tracking = s[:tracking]
+        shipment.stock_location = Spree::StockLocation.find_by_name!(s[:stock_location])
 
         inventory_units = s[:inventory_units] || []
         inventory_units.each do |iu|


### PR DESCRIPTION
Spree assumes a shipment always have a stock location
