### PR TITLE
Fix shipping methods sample data

### DIFF
--- a/sample/db/samples/shipping_methods.rb
+++ b/sample/db/samples/shipping_methods.rb
@@ -13,25 +13,25 @@ shipping_methods = [
   {
     :name => "UPS Ground (USD)",
     :zones => [north_america],
-    :calculator => Spree::Calculator::FlatRate.create!,
+    :calculator => Spree::Calculator::Shipping::FlatRate.create!,
     :shipping_categories => [shipping_category]
   },
   {
     :name => "UPS Two Day (USD)",
     :zones => [north_america],
-    :calculator => Spree::Calculator::FlatRate.create!,
+    :calculator => Spree::Calculator::Shipping::FlatRate.create!,
     :shipping_categories => [shipping_category]
   },
   {
     :name => "UPS One Day (USD)",
     :zones => [north_america],
-    :calculator => Spree::Calculator::FlatRate.create!,
+    :calculator => Spree::Calculator::Shipping::FlatRate.create!,
     :shipping_categories => [shipping_category]
   },
   {
     :name => "UPS Ground (EUR)",
     :zones => [europe_vat],
-    :calculator => Spree::Calculator::FlatRate.create!,
+    :calculator => Spree::Calculator::Shipping::FlatRate.create!,
     :shipping_categories => [shipping_category]
   }
 ]


### PR DESCRIPTION
We were association a not shipping calculator to the shipping method.
Users trying to edit the samples shipping method would get a Shipping
Method not found because it was associated with a calculator not
available.

This should apply cleanly to 2-1-stable and 2-0-stable
