### PR TITLE
Fix page-actions buttons line wrap in admin

### DIFF
--- a/backend/app/assets/stylesheets/admin/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/admin/shared/_forms.scss
@@ -62,6 +62,7 @@ button, .button {
   color: $color-btn-text;
   text-transform: uppercase;
   font-weight: 600 !important;
+  white-space: nowrap;
 
   &:before {
     font-weight: normal !important;

--- a/backend/app/assets/stylesheets/admin/shared/_layout.scss
+++ b/backend/app/assets/stylesheets/admin/shared/_layout.scss
@@ -75,6 +75,7 @@
   }
   .page-actions {
     text-align: right;
+    line-height: 38px;
     form {
       display: inline-block;
     }


### PR DESCRIPTION
We had a problem in the admin where the page action buttons would overlap each other if there was a long product title. Thanks to @forkata for the original fix.

![before](http://i.hawth.ca/s/1s3Zqj7D.png)

This can be fixed by giving these buttons a line height.

![after](http://i.hawth.ca/s/pamxp2UD.png)

All buttons are also given `white-space: nowrap;`, as the buttons do not look correct split across multiple lines.

![broken buttons](http://i.hawth.ca/s/QQcGl1Z3.png)

I tested this on chrome, FF, IE9, and IE10. I believe this cleanly applies to master, 2-1-stable, and 2-0-stable.
