### PR TITLE
Fix force_non_ssl_redirect redirect location

### DIFF
--- a/core/lib/spree/core/controller_helpers/ssl.rb
+++ b/core/lib/spree/core/controller_helpers/ssl.rb
@@ -39,11 +39,14 @@ module Spree
             def force_non_ssl_redirect(host = nil)
               return true if defined?(ssl_allowed_actions) and ssl_allowed_actions.include?(action_name.to_sym)
               if request.ssl? and (!defined?(ssl_required_actions) or !ssl_required_actions.include?(action_name.to_sym))
-                redirect_options = {:protocol => 'http://', :status => :moved_permanently}
-                redirect_options.merge!(:host => host) if host
-                redirect_options.merge!(:params => request.query_parameters)
+                redirect_options = {
+                  :protocol => 'http://',
+                  :host     => host || request.host,
+                  :path     => request.fullpath,
+                }
                 flash.keep if respond_to?(:flash)
-                redirect_to redirect_options
+                insecure_url = ActionDispatch::Http::URL.url_for(redirect_options)
+                redirect_to insecure_url, :status => :moved_permanently
               end
             end
         end

--- a/frontend/spec/controllers/spree/products_controller_spec.rb
+++ b/frontend/spec/controllers/spree/products_controller_spec.rb
@@ -67,12 +67,13 @@ describe Spree::ProductsController do
     context "receives a SSL request" do
       before do
         request.env['HTTPS'] = 'on'
+        request.path = "/products?foo=bar"
       end
 
       it "should redirect to http" do
-        controller.should_receive(:redirect_to).with(hash_including(:protocol => 'http://'))
         spree_get :index
-        request.protocol.should eql('https://')
+        response.should redirect_to("http://#{request.host}/products?foo=bar")
+        response.code.should == 301
       end
     end
   end


### PR DESCRIPTION
When visiting an https page with `Config[:force_non_ssl_redirect] = true`, the redirect from `/` was to `/orders/populate?controller=home`.

Building the new URL using the new protocol, existing host, and `request.fullpath` fixes this.
