### PR TITLE
Fix order email assignment via api checkouts#create

### DIFF
--- a/api/app/models/spree/order_decorator.rb
+++ b/api/app/models/spree/order_decorator.rb
@@ -14,6 +14,7 @@ Spree::Order.class_eval do
 
     order = create!(params)
     order.associate_user!(user)
+    order.update_column(:email, params[:email]) if params[:email]
 
     order.create_shipments_from_api(shipments)
     order.create_line_items_from_api(line_items)

--- a/api/spec/controllers/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/controllers/spree/api/checkouts_controller_spec.rb
@@ -28,6 +28,12 @@ module Spree
         json_response['number'].should be_present
         response.status.should == 201
       end
+
+      it "assigns email when creating a new order" do
+        api_post :create, :order => { :email => "guest@spreecommerce.com" }
+        expect(json_response['email']).not_to eq controller.current_api_user
+        expect(json_response['email']).to eq "guest@spreecommerce.com"
+      end
     end
 
     context "PUT 'update'" do

--- a/api/spec/models/spree/order_spec.rb
+++ b/api/spec/models/spree/order_spec.rb
@@ -52,6 +52,12 @@ module Spree
       order.state.should eq 'complete'
     end
 
+    it "assigns order[email] over user email to order" do
+      params = { email: 'wooowww@test.com' }
+      order = Order.build_from_api(user, params)
+      expect(order.email).to eq params[:email]
+    end
+
     it 'can build an order from API with just line items' do
       params = { :line_items_attributes => line_items }
 


### PR DESCRIPTION
Before a request like this:

```
curl http://localhost:9292/api/checkouts -X POST --data "order[email]=check@spreecommerce.com"
```

would create an order with an empty email. Now it also allows to set an
order email different from the current authenticated user via that same
request.

Initially I tried to assign the email provided using

```
`order.email = params[:email]`
```

but calling `save!` wouldn't persist that email, I have not idea why
yet.
