### PR TITLE
made shipped_at accessible in shipment model

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -17,7 +17,8 @@ module Spree
 
     attr_accessor :special_instructions
     attr_accessible :order, :special_instructions, :stock_location_id, :number,
-                    :tracking, :address, :inventory_units, :selected_shipping_rate_id
+                    :tracking, :address, :inventory_units, :selected_shipping_rate_id,
+                    :shipped_at
 
     accepts_nested_attributes_for :address
     accepts_nested_attributes_for :inventory_units


### PR DESCRIPTION
added shipped_at to attr_accessible in shipment model. Imports of shipments were failing in spree_endpoint because of a mass assignment error.
