### PR TITLE
Add special_instructions to the permitted checkout attributes

### DIFF
--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -31,7 +31,7 @@ module Spree
       :city, :country_id, :state_id, :zipcode, :phone,
       :state_name, :alternative_phone, :company]
 
-    @@checkout_attributes = [:email, :use_billing, :shipping_method_id, :coupon_code]
+    @@checkout_attributes = [:email, :use_billing, :shipping_method_id, :coupon_code, :special_instructions]
 
     @@image_attributes = [:alt, :attachment, :position, :viewable_type, :viewable_id]
 


### PR DESCRIPTION
This branch fixes a bug where special_instructions were being ignored during checkout because they weren't part of the permitted attributes.
