### PR TITLE
Concurrency Issue.

### DIFF
--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -8,6 +8,7 @@ module Spree
 
     validates_presence_of :stock_location, :variant
     validates_uniqueness_of :variant_id, scope: :stock_location_id
+    validates :count_on_hand, :numericality => { :greater_than_or_equal_to => 0 }, :if => :verify_count_on_hand?
 
     delegate :weight, to: :variant
 
@@ -27,6 +28,11 @@ module Spree
         self.save!
       end
     end
+
+    def verify_count_on_hand?
+      count_on_hand_changed? && !backorderable? && (count_on_hand < count_on_hand_was) && (count_on_hand < 0)
+    end
+
 
     def set_count_on_hand(value)
       self.count_on_hand = value

--- a/core/spec/models/spree/stock_item_spec.rb
+++ b/core/spec/models/spree/stock_item_spec.rb
@@ -117,4 +117,170 @@ describe Spree::StockItem do
       expect { subject.destroy }.not_to raise_error
     end
   end
+
+  describe 'validations' do
+    describe 'count_on_hand' do
+      shared_examples_for 'valid count_on_hand' do
+        before(:each) do
+          subject.save
+        end
+
+        it { should have(:no).errors_on(:count_on_hand) }
+      end
+
+      shared_examples_for 'not valid count_on_hand' do
+        before(:each) do
+          subject.save
+        end
+        
+        it { should have(1).error_on(:count_on_hand) }
+        it { subject.errors[:count_on_hand].should include 'must be greater than or equal to 0' }
+      end
+
+      context 'when count_on_hand not changed' do
+        context 'when not backorderable' do
+          before(:each) do
+            subject.backorderable = false
+          end
+          it_should_behave_like 'valid count_on_hand'
+        end
+
+        context 'when backorderable' do
+          before(:each) do
+            subject.backorderable = true
+          end
+          it_should_behave_like 'valid count_on_hand'
+        end
+      end
+
+      context 'when count_on_hand changed' do
+        context 'when backorderable' do
+          before(:each) do
+            subject.backorderable = true
+          end
+          context 'when both count_on_hand and count_on_hand_was are positive' do
+            context 'when count_on_hand is greater than count_on_hand_was' do
+              before(:each) do
+                subject.update_column(:count_on_hand, 3)
+                subject.send(:count_on_hand=, subject.count_on_hand + 3)
+              end
+              it_should_behave_like 'valid count_on_hand'
+            end
+
+            context 'when count_on_hand is smaller than count_on_hand_was' do
+              before(:each) do
+                subject.update_column(:count_on_hand, 3)
+                subject.send(:count_on_hand=, subject.count_on_hand - 2)
+              end
+
+              it_should_behave_like 'valid count_on_hand'
+            end
+          end
+
+          context 'when both count_on_hand and count_on_hand_was are negative' do
+            context 'when count_on_hand is greater than count_on_hand_was' do
+              before(:each) do
+                subject.update_column(:count_on_hand, -3)
+                subject.send(:count_on_hand=, subject.count_on_hand + 2)
+              end
+              it_should_behave_like 'valid count_on_hand'
+            end
+
+            context 'when count_on_hand is smaller than count_on_hand_was' do
+              before(:each) do
+                subject.update_column(:count_on_hand, 3)
+                subject.send(:count_on_hand=, subject.count_on_hand - 3)
+              end
+
+              it_should_behave_like 'valid count_on_hand'
+            end
+          end
+
+          context 'when both count_on_hand is positive and count_on_hand_was is negative' do
+            context 'when count_on_hand is greater than count_on_hand_was' do
+              before(:each) do
+                subject.update_column(:count_on_hand, -3)
+                subject.send(:count_on_hand=, subject.count_on_hand + 6)
+              end
+              it_should_behave_like 'valid count_on_hand'
+            end
+          end
+
+          context 'when both count_on_hand is negative and count_on_hand_was is positive' do
+            context 'when count_on_hand is greater than count_on_hand_was' do
+              before(:each) do
+                subject.update_column(:count_on_hand, 3)
+                subject.send(:count_on_hand=, subject.count_on_hand - 6)
+              end
+              it_should_behave_like 'valid count_on_hand'
+            end
+          end
+        end
+
+        context 'when not backorderable' do
+          before(:each) do
+            subject.backorderable = false
+          end
+
+          context 'when both count_on_hand and count_on_hand_was are positive' do
+            context 'when count_on_hand is greater than count_on_hand_was' do
+              before(:each) do
+                subject.update_column(:count_on_hand, 3)
+                subject.send(:count_on_hand=, subject.count_on_hand + 3)
+              end
+              it_should_behave_like 'valid count_on_hand'
+            end
+
+            context 'when count_on_hand is smaller than count_on_hand_was' do
+              before(:each) do
+                subject.update_column(:count_on_hand, 3)
+                subject.send(:count_on_hand=, subject.count_on_hand - 2)
+              end
+
+              it_should_behave_like 'valid count_on_hand'
+            end
+          end
+
+          context 'when both count_on_hand and count_on_hand_was are negative' do
+            context 'when count_on_hand is greater than count_on_hand_was' do
+              before(:each) do
+                subject.update_column(:count_on_hand, -3)
+                subject.send(:count_on_hand=, subject.count_on_hand + 2)
+              end
+              it_should_behave_like 'valid count_on_hand'
+            end
+
+            context 'when count_on_hand is smaller than count_on_hand_was' do
+              before(:each) do
+                subject.update_column(:count_on_hand, -3)
+                subject.send(:count_on_hand=, subject.count_on_hand - 3)
+              end
+
+              it_should_behave_like 'not valid count_on_hand'
+            end
+          end
+
+          context 'when both count_on_hand is positive and count_on_hand_was is negative' do
+            context 'when count_on_hand is greater than count_on_hand_was' do
+              before(:each) do
+                subject.update_column(:count_on_hand, -3)
+                subject.send(:count_on_hand=, subject.count_on_hand + 6)
+              end
+              it_should_behave_like 'valid count_on_hand'
+            end
+          end
+
+          context 'when both count_on_hand is negative and count_on_hand_was is positive' do
+            context 'when count_on_hand is greater than count_on_hand_was' do
+              before(:each) do
+                subject.update_column(:count_on_hand, 3)
+                subject.send(:count_on_hand=, subject.count_on_hand - 6)
+              end
+              it_should_behave_like 'not valid count_on_hand'
+            end
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Steps to reproduce
1. Add a variant which has only one quantity left and is not backorderable.
2. Add this variant by different users on two different browsers.
3. Now process the order and stop at the payment step. Choose the payment method.
4. On the other browser, choose the same payment method and stop.
5. Now, click on the Pay button from both browsers. Both orders get completed.
6. Check at admin end, count on hand of the stock item of that variant is -1.

This is replicable only with an high speed internet connection. Otherwise it can simulated by creating two or more processes.
