### PR TITLE
Fetch X-Spree-Token in request.headers

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -109,7 +109,7 @@ module Spree
       end
 
       def api_key
-        request.headers.env["X-Spree-Token"] || params[:token]
+        request.headers["X-Spree-Token"] || params[:token]
       end
       helper_method :api_key
 

--- a/api/lib/spree/api/responders/rabl_template.rb
+++ b/api/lib/spree/api/responders/rabl_template.rb
@@ -14,7 +14,7 @@ module Spree
         end
 
         def template
-          request.headers.env['X-Spree-Template'] || controller.params[:template] || options[:default_template]
+          request.headers['X-Spree-Template'] || controller.params[:template] || options[:default_template]
         end
       end
     end

--- a/api/spec/controllers/spree/api/base_controller_spec.rb
+++ b/api/spec/controllers/spree/api/base_controller_spec.rb
@@ -29,7 +29,7 @@ describe Spree::Api::BaseController do
     end
 
     it "with an invalid API key" do
-      request.env["X-Spree-Token"] = "fake_key"
+      request.headers["X-Spree-Token"] = "fake_key"
       get :index, {}
       json_response.should == { "error" => "Invalid API key (fake_key) specified." }
       response.status.should == 401

--- a/api/spec/controllers/spree/api/zones_controller_spec.rb
+++ b/api/spec/controllers/spree/api/zones_controller_spec.rb
@@ -48,13 +48,13 @@ module Spree
       end
 
       it "uses the specified template" do
-        request.headers.env['X-Spree-Template'] = 'show'
+        request.headers['X-Spree-Template'] = 'show'
         api_get :custom_show, :id => @zone.id
         response.should render_template('spree/api/zones/show')
       end
 
       it "falls back to the default template if the specified template does not exist" do
-        request.headers.env['X-Spree-Template'] = 'invoice'
+        request.headers['X-Spree-Template'] = 'invoice'
         api_get :show, :id => @zone.id
         response.should render_template('spree/api/zones/show')
       end


### PR DESCRIPTION
As that is where it's available rather than in request.headers.env
