### PR TITLE
Reversing order in which adjustments and line_items are destroyed when c...

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -497,8 +497,8 @@ module Spree
     end
 
     def empty!
-      line_items.destroy_all
       adjustments.destroy_all
+      line_items.destroy_all
     end
 
     # destroy any previous adjustments.


### PR DESCRIPTION
...art is emptied

See, e.g., https://github.com/spree/spree/issues/3787#issuecomment-25417823

Occasionally deleting the line_items before the adjustment will cause strange things to happen, like trying to recalculate the shipping and getting `nil` shipping amounts for shipments of no line items. Deleting the adjustments first and the line_items second seems a little cleaner in this way.

Also, philosophically it seems to make sense to empty a cart in the reverse order of how it was populated. So the cart begins with line items, to which handling and tax and shipping are added... Seems reasonable to "roll back" to a fresh cart by reversing the order and taking away the adjustments then the line_items.

If for some reason, the state gets stuck mid-emptying-of-cart, then you might be left with a user who's got their items but no shipping or tax charges. I'm not clear on whether `empty!` also rolls back the order state machine (which would prevent that bug), but I'm also not sure how concerned we should be about this possibility -- as opposed to the known issues that can sometimes happen when you delete the line_items first, rather than second.

I can see an argument both ways, but my opinion would be that this proposed order makes the most sense overall.
