### PR TITLE
remove unused credit card fields

### DIFF
--- a/backend/app/views/spree/admin/payments/source_views/_gateway.html.erb
+++ b/backend/app/views/spree/admin/payments/source_views/_gateway.html.erb
@@ -2,28 +2,18 @@
   <legend align="center"><%= Spree.t(:credit_card) %></legend>
 
   <div class="row">
-    <div class="alpha six columns">      
+    <div class="alpha six columns">
       <dl>
+        <dt><%= Spree.t(:card_type) %>:</dt>
+        <dd><%= payment.source.cc_type %></dd>
+
         <dt><%= Spree.t(:card_number) %>:</dt>
         <dd><%= payment.source.display_number %></dd>
 
         <dt><%= Spree.t(:expiration) %>:</dt>
         <dd><%= payment.source.month %>/<%= payment.source.year %></dd>
-
-        <dt><%= Spree.t(:card_code) %>:</dt>
-        <dd><%= payment.source.verification_value %></dd>
       </dl>
     </div>
-
-    <div class="omega six columns">
-      <dl>
-        <dt><%= Spree.t(:maestro_or_solo_cards) %>:</dt>
-        <dd><%= payment.source.issue_number %></dd>
-
-        <dt><%= Spree.t(:start_date) %>:</dt>
-        <dd><%= payment.source.start_month %>/<%= payment.source.start_year %></dd>
-      </dl>
-    </div>    
   </div>
 
 </fieldset>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -395,6 +395,7 @@ en:
     capture: Capture
     card_code: Card Code
     card_number: Card Number
+    card_type: Brand
     card_type_is: Card type is
     cart: Cart
     categories: Categories
@@ -640,7 +641,6 @@ en:
     login_name: Login
     logout: Logout
     look_for_similar_items: Look for similar items
-    maestro_or_solo_cards: Maestro/Solo cards
     mail_method_settings: Mail Method Settings
     mail_methods: Mail Methods
     make_refund: Make refund
@@ -996,7 +996,6 @@ en:
     split: Split
     spree_gateway_error_flash_for_checkout: There was a problem with your payment information. Please check your information and try again.
     start: Start
-    start_date: Valid from
     state: State
     state_based: State Based
     states: States

--- a/core/db/migrate/20131001013410_remove_unused_credit_card_fields.rb
+++ b/core/db/migrate/20131001013410_remove_unused_credit_card_fields.rb
@@ -1,0 +1,12 @@
+class RemoveUnusedCreditCardFields < ActiveRecord::Migration
+  def up
+    remove_column :spree_credit_cards, :start_month
+    remove_column :spree_credit_cards, :start_year
+    remove_column :spree_credit_cards, :issue_number
+  end
+  def down
+    add_column :spree_credit_cards, :start_month,  :string
+    add_column :spree_credit_cards, :start_year,   :string
+    add_column :spree_credit_cards, :issue_number, :string
+  end
+end


### PR DESCRIPTION
Removes verification_value, issue_number, and start date from the payment admin, as they aren't used anywhere within spree and were always blank. Adds card_type, as that may be helpful.

Before:
![](http://i.hawth.ca/s/maJU9I70.png)

After:
![](http://i.hawth.ca/s/6yfh4tXt.png)
