### PR TITLE
Make shell scripts POSIX compliant

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,9 @@
+#!/bin/sh
+
 set -e
 
 # Switching Gemfile
-function set_gemfile(){
+set_gemfile(){
   echo "Switching Gemfile..."
   export BUNDLE_GEMFILE="`pwd`/Gemfile"
 }

--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -1,5 +1,5 @@
+#!/bin/sh
 # Used in the sandbox rake task in Rakefile
-#!/bin/bash
 
 rm -rf ./sandbox
 bundle exec rails new sandbox --skip-bundle


### PR DESCRIPTION
:neckbeard:

In ubuntu `sh` is `dash`, not `bash`. This small fix makes `sh build.sh` work.
