### PR TITLE
Check for column_name in migration instead

### DIFF
--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -1,7 +1,6 @@
 module Spree
   class StockItem < ActiveRecord::Base
-    # Column name check here for #3805
-    acts_as_paranoid if column_names.include?("deleted_at")
+    acts_as_paranoid
 
     belongs_to :stock_location, class_name: 'Spree::StockLocation'
     belongs_to :variant, class_name: 'Spree::Variant'

--- a/core/db/migrate/20130213191427_create_default_stock.rb
+++ b/core/db/migrate/20130213191427_create_default_stock.rb
@@ -4,6 +4,14 @@ class CreateDefaultStock < ActiveRecord::Migration
     Spree::StockItem.skip_callback(:save, :after, :process_backorders)
     location = Spree::StockLocation.new(name: 'default')
     location.save(validate: false)
+
+    Spree::StockItem.class_eval do
+      # Column name check here for #3805
+      unless column_names.include?("deleted_at")
+        def self.acts_as_paranoid; end
+      end
+    end
+
     Spree::Variant.all.each do |variant|
       stock_item = location.stock_items.build(variant: variant)
       stock_item.send(:count_on_hand=, variant.count_on_hand)


### PR DESCRIPTION
Avoid a db connection when loading all Spree code right away

should apply cleanly to both 2-1-stable and 2-0-stable
