### PR TITLE
Send core emails

### DIFF
--- a/core/app/mailers/spree/base_mailer.rb
+++ b/core/app/mailers/spree/base_mailer.rb
@@ -8,5 +8,14 @@ module Spree
       Spree::Money.new(amount).to_s
     end
     helper_method :money
+
+    alias_method :orig_mail, :mail
+
+    def mail(headers={}, &block)
+      if Spree::Config[:send_core_emails]
+        orig_mail
+      end
+    end
+
   end
 end

--- a/core/app/mailers/spree/base_mailer.rb
+++ b/core/app/mailers/spree/base_mailer.rb
@@ -9,12 +9,8 @@ module Spree
     end
     helper_method :money
 
-    alias_method :orig_mail, :mail
-
     def mail(headers={}, &block)
-      if Spree::Config[:send_core_emails]
-        orig_mail
-      end
+      super if Spree::Config[:send_core_emails]
     end
 
   end

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -87,6 +87,7 @@ module Spree
 
     # Default mail headers settings
     preference :enable_mail_delivery, :boolean, :default => false
+    preference :send_core_emails, :boolean, :default => true
     preference :mails_from, :string, :default => 'spree@example.com'
     preference :mail_bcc, :string, :default => 'spree@example.com'
     preference :intercept_email, :string, :default => nil

--- a/core/spec/mailers/order_mailer_spec.rb
+++ b/core/spec/mailers/order_mailer_spec.rb
@@ -113,4 +113,13 @@ describe Spree::OrderMailer do
       end
     end
   end
+
+  context "with preference :send_core_emails set to false" do
+    it "sends no email" do
+      Spree::Config.set(:send_core_emails, false)
+      message = Spree::OrderMailer.confirm_email(order)
+      message.body.should be_blank
+    end
+  end
+
 end


### PR DESCRIPTION
Allow developers to use standard rails mail configuration (in config files) by setting `:override_actionmailer_config` to false without sending spree core emails (e.g. order confirmation). This is useful e.g. in the    case where devs have opted to use an external mail API such as Mandrill    for store-related emails but still want to use ActionMailer in other    parts of their app.

I named the config preference `send_core_emails`. I'm open to other naming if preferred. Also, I put a small spec for this in `order_mailer_spec.rb`, not sure if that's the best location for such a spec.

Finally, I'm aliasing the `#mail` action in `Spree::BaseMailer`, a subclass of `ActionMailer::Base` from which all other spree mailers inherit. Not sure if this might be considered dangerous/harmful.
