### PR TITLE
Fix redirect loop with Spree::Config[:redirect_https_to_http]

### DIFF
--- a/core/spec/lib/spree/core/controller_helpers/ssl_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/ssl_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+describe Spree::Core::ControllerHelpers::SSL, :type => :controller do
+  controller do
+    include Spree::Core::ControllerHelpers::SSL
+    def index; render text: 'index'; end
+    def self.ssl_supported?; true; end
+  end
+  before do
+    @routes.draw do
+      get '/anonymous/index'
+    end
+  end
+
+  describe 'redirect to http' do
+    before { Spree::Config[:redirect_https_to_http] = true  }
+    after  { Spree::Config[:redirect_https_to_http] = false }
+    before { request.env['HTTPS'] = 'on' }
+
+    context 'allowed two actions' do
+      controller(described_class) do
+        ssl_allowed :index
+        ssl_allowed :foobar
+      end
+      specify{ controller.ssl_allowed_actions.should == [:index, :foobar] }
+      specify{ get(:index).should be_success }
+    end
+    context 'allowed a single action' do
+      controller(described_class){ ssl_allowed :index }
+      specify{ controller.ssl_allowed_actions.should == [:index] }
+      specify{ get(:index).should be_success }
+    end
+    context 'allowed all actions' do
+      controller(described_class){ ssl_allowed }
+      specify{ controller.ssl_allowed_actions.should == [] }
+      specify{ get(:index).should be_success }
+    end
+    context 'ssl not allowed' do
+      controller(described_class){ }
+      specify{ get(:index).should be_redirect }
+    end
+  end
+
+  describe 'redirect to https' do
+    context 'required a single action' do
+      controller(described_class){ ssl_required :index }
+      specify{ controller.ssl_allowed_actions.should == [:index] }
+      specify{ get(:index).should be_redirect }
+    end
+    context 'required all actions' do
+      controller(described_class){ ssl_required }
+      specify{ controller.ssl_allowed_actions.should == [] }
+      specify{ get(:index).should be_redirect }
+    end
+    context 'not required' do
+      controller(described_class){ }
+      specify{ get(:index).should be_success }
+    end
+  end
+end


### PR DESCRIPTION
force_non_ssl_redirect was testing if the actions was included in ssl_{required,allowed}_actions, but didn't consider the case that it was empty (which means all actions allow/require ssl). This caused an infinite redirect loop on admin and checkout pages with the option enabled.

This fixes the issue and simplifies the code by combining the lists of allowed and required ssl actions. Also added some specs.

While on the topic of the SSL helper, I believe bb43c7a30ddbf6693cb7340f3ec492be7a321cf9 from @huoxito's rails 4 work should be backported to the `2-0-stable` branch, as rails 3.2 uses `Rack::SSL` as well.
https://github.com/rails/rails/blob/3-2-stable/railties/lib/rails/application.rb#L253
