### PR TITLE
Reload rules select2 box after picking a PromotionRule

### DIFF
--- a/backend/app/views/spree/admin/promotion_rules/create.js.erb
+++ b/backend/app/views/spree/admin/promotion_rules/create.js.erb
@@ -5,3 +5,4 @@ $('.product_picker').productAutocomplete();
 $('.user_picker').userAutocomplete();
 
 $('#promotion_rule_type').html('<%= escape_javascript options_for_promotion_rule_types(@promotion) %>');
+$('#promotion_rule_type').select2();


### PR DESCRIPTION
So that the chosen rule no longer is displayed on the select2 box, users
can associate each rule only once with the promotion

Fixes #3572

This should apply cleanly to 2-1-stable and 2-0-stable
