### PR TITLE
Verify insufficient_stock_lines while resuming an order.

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -421,6 +421,12 @@ module Spree
       line_items.select &:insufficient_stock?
     end
 
+    def ensure_line_items_are_in_stock
+      if insufficient_stock_lines.present?
+        errors.add(:base, Spree.t(:insufficient_stock_lines_present)) and return false
+      end
+    end
+
     def merge!(order)
       order.line_items.each do |line_item|
         next unless line_item.currency == currency

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -73,6 +73,8 @@ module Spree
 
               before_transition :to => :delivery, :do => :create_proposed_shipments
               before_transition :to => :delivery, :do => :ensure_available_shipping_rates
+              
+              before_transition :to => :resumed, :do => :ensure_line_items_are_in_stock
 
               after_transition :to => :complete, :do => :finalize!
               after_transition :to => :delivery, :do => :create_tax_charge!

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -613,6 +613,7 @@ en:
         gt: greater than
         gte: greater than or equal to
     items_cannot_be_shipped: We are unable to calculate shipping rates for the selected items.
+    insufficient_stock_lines_present: Some line items in this order have insufficient quantity.
     jirafe: Jirafe
     landing_page_rule:
       path: Path


### PR DESCRIPTION
Steps to Reproduce
1. Create an order.
2. Add a product in it and complete it.
3. Cancel the order from admin end.
4. Now, go to the stock management of the product and made it out of stock.
5. Come back to the canceled order and resume it.

Expectation - it shouldn't be resumed as product doesn't have sufficient quantity.
Actual - It is resumed. And when you see the stock items of the product, its in negative.
