### PR TITLE
use display_price helper whenever possible to allow overriding price display behavior

### DIFF
--- a/frontend/app/views/spree/products/_cart_form.html.erb
+++ b/frontend/app/views/spree/products/_cart_form.html.erb
@@ -7,7 +7,7 @@
         <ul>
           <% @product.variants_and_option_values(current_currency).each_with_index do |variant, index| %>
             <li>
-              <%= radio_button_tag "products[#{@product.id}]", variant.id, index == 0, 'data-price' => variant.price_in(current_currency).display_price %>
+              <%= radio_button_tag "products[#{@product.id}]", variant.id, index == 0, 'data-price' => display_price(variant) %>
               <label for="<%= ['products', @product.id, variant.id].join('_') %>">
                 <span class="variant-description">
                   <%= variant_options variant %>
@@ -29,7 +29,7 @@
           <h6 class="product-section-title"><%= Spree.t(:price) %></h6>
           <div>
             <span class="price selling" itemprop="price">
-              <%= display_price(@product.master) %>
+              <%= display_price(@product) %>
             </span>
             <span itemprop="priceCurrency" content="<%= @product.currency %>"></span>
           </div>


### PR DESCRIPTION
Let me know if there are more steps I need to do in submitting this. This is my first pull request and I am not all the way familiar with the procedure.

This change takes advantage of display_price to avoid writing repetitive and complex code. In the process it also now allows for easy overriding of price display behavior. In my particular application it allows me to more easily implement a price-per-unit feature.

Since display_price already works with both products and variants the @product.master is unnecessary as far as I can tell.
