### PR TITLE
Fix payment processing failing in backend.

### DIFF
--- a/backend/app/controllers/spree/admin/payments_controller.rb
+++ b/backend/app/controllers/spree/admin/payments_controller.rb
@@ -71,7 +71,7 @@ module Spree
         if params[:payment] and params[:payment_source] and source_params = params.delete(:payment_source)[params[:payment][:payment_method_id]]
           params[:payment][:source_attributes] = source_params
         end
-        params.require(:payment).permit(:amount, :payment_method_id, :source_attributes)
+        params.require(:payment).permit(:amount, :payment_method_id, source_attributes: [:number, :expiry, :verification_value])
       end
 
       def load_data
@@ -86,7 +86,7 @@ module Spree
       end
 
       def can_transition_to_payment
-        unless @order.billing_address.present? 
+        unless @order.billing_address.present?
           flash[:notice] = Spree.t(:fill_in_customer_info)
           redirect_to edit_admin_order_customer_url(@order)
         end

--- a/backend/spec/controllers/spree/admin/payments_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/payments_controller_spec.rb
@@ -7,6 +7,26 @@ module Spree
 
       let(:order) { create(:order) }
 
+      context "with a valid credit card" do
+        it "should process payment correctly" do
+          order = create(:order_with_line_items, :state => "payment")
+          payment_method = create(:bogus_payment_method, :display_on => "back_end")
+          attributes = {
+            :order_id => order.number,
+            :card => "new",
+            :payment => {
+              :amount => order.total,
+              :payment_method_id => payment_method.id
+            },
+            :payment_source => {
+              "1" => {:number => Spree::Gateway::Bogus::TEST_VISA.sample}
+            }
+          }
+          spree_post :create, attributes
+          expect(response).to redirect_to spree.admin_order_payments_path(order)
+        end
+      end
+
       # Regression test for #3233
       context "with a backend payment method" do
         before do
@@ -21,7 +41,6 @@ module Spree
       end
 
       context "order has billing address" do
-
         before do
           order.bill_address = create(:address)
           order.save!
@@ -35,7 +54,6 @@ module Spree
         end
 
         context "order has payments" do
-          
           before do
             order.payments << create(:payment, amount: order.total, order: order, state: 'completed')
           end


### PR DESCRIPTION
Source attributes were being excluded by `strong_parameters` causing credit card inputs to be ignored.

The gripe I have with this is that by hardcoding what payment source parameters are allowed, what happens if users have custom attributes on their payment sources? Since this is admin panel why is `strong_parameters` required to begin with?
