### PR TITLE
Fix SimpleBogus gateway.

### DIFF
--- a/core/app/models/spree/gateway/bogus_simple.rb
+++ b/core/app/models/spree/gateway/bogus_simple.rb
@@ -6,14 +6,6 @@ module Spree
       false
     end
 
-    def capture(money, response_code, options = {})
-      if response_code == '12345'
-        ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, :test => true, :authorization => '67890')
-      else
-        ActiveMerchant::Billing::Response.new(false, 'Bogus Gateway: Forced failure', :error => 'Bogus Gateway: Forced failure', :test => true)
-      end
-    end
-
     def authorize(money, credit_card, options = {})
       if VALID_CCS.include? credit_card.number
         ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, :test => true, :authorization => '12345', :avs_result => { :code => 'A' })

--- a/core/spec/models/spree/gateway/bogus_simple.rb
+++ b/core/spec/models/spree/gateway/bogus_simple.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe Spree::Gateway::BogusSimple do
+
+  subject { Spree::Gateway::BogusSimple.new }
+
+  # regression test for #3824
+  describe "#capture" do
+    it "returns success with the right response code" do
+      response = subject.capture(123, '12345', {})
+      response.message.should =~ /success/
+    end
+
+    it "returns failure with the wrong response code" do
+      response = subject.capture(123, 'wrong', {})
+      response.message.should =~ /failure/
+    end
+  end
+
+end

--- a/core/spec/models/spree/gateway/bogus_simple.rb
+++ b/core/spec/models/spree/gateway/bogus_simple.rb
@@ -8,12 +8,12 @@ describe Spree::Gateway::BogusSimple do
   describe "#capture" do
     it "returns success with the right response code" do
       response = subject.capture(123, '12345', {})
-      response.message.should =~ /success/
+      expect(response.message).to include("success")
     end
 
     it "returns failure with the wrong response code" do
       response = subject.capture(123, 'wrong', {})
-      response.message.should =~ /failure/
+      expect(response.message).to include("failure")
     end
   end
 

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -276,7 +276,7 @@ describe Spree::Payment do
           it "stores the uncaptured amount on the payment" do
             payment.capture!(6000)
             expect(payment.uncaptured_amount).to eq(40) # 100 - 60 = 40
-          end 
+          end
         end
 
         context "if unsuccessful" do


### PR DESCRIPTION
SimpleBogus gateway was breaking when trying to process credit card payments. Since the SimpleBogus gateway does not have payment profiles enabled, the following code runs when you process a payment:

``` ruby
# Standard ActiveMerchant capture usage
response = payment_method.capture(money.money.cents,
                                  response_code,
                                  gateway_options)
```

https://github.com/spree/spree/blob/master/core/app/models/spree/payment/processing.rb#L46-L50

SimpleBogusGateway inherits its process method from BogusGateway:

``` ruby
def capture(authorization, credit_card, gateway_options)
  if authorization.response_code == '12345'
    ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, :test => true, :authorization => '67890')
  else
    ActiveMerchant::Billing::Response.new(false, 'Bogus Gateway: Forced failure', :error => 'Bogus Gateway: Forced failure', :test => true)
  end
end
```

https://github.com/spree/spree/blob/master/core/app/models/spree/gateway/bogus.rb#L35-L42

`Payment#capture!` sends in cents instead of authorization as first param to `BogusGateway#capture`  which breaks.
