### PR TITLE
Fix preferences being reset to defaults when app initialized with empty cache

### DIFF
--- a/core/app/models/spree/preferences/store.rb
+++ b/core/app/models/spree/preferences/store.rb
@@ -86,7 +86,7 @@ module Spree::Preferences
     end
 
     def should_persist?
-      @persistence && Spree::Preference.connected? && Spree::Preference.table_exists?
+      @persistence and Spree::Preference.table_exists?
     end
 
   end

--- a/core/app/models/spree/preferences/store.rb
+++ b/core/app/models/spree/preferences/store.rb
@@ -39,23 +39,22 @@ module Spree::Preferences
         # has been cleared from the cache
 
         # does it exist in the database?
-        if Spree::Preference.table_exists? && preference = Spree::Preference.find_by_key(key)
-          # it does exist, so let's put it back into the cache
-          @cache.write(preference.key, preference.value)
-
-          # and return the value
-          return preference.value
+        if preference = Spree::Preference.find_by_key(key)
+          # it does exist
+          val = preference.value
+        else
+          # use the fallback value
+          val = fallback
         end
-      end
 
-      unless fallback.nil?
-        # cache fallback so we won't hit the db above on
-        # subsequent queries for the same key
-        #
-        @cache.write(key, fallback)
-      end
+        # Cache either the value from the db or the fallback value.
+        # This avoids hitting the db with subsequent queries.
+        @cache.write(key, val)
 
-      return fallback
+        return val
+      else
+        return fallback
+      end
     end
 
     def delete(key)

--- a/core/spec/models/spree/preferences/store_spec.rb
+++ b/core/spec/models/spree/preferences/store_spec.rb
@@ -33,11 +33,11 @@ describe Spree::Preferences::Store do
     Rails.cache.read(:test).should be_false
   end
 
-  it "should return and cache fallback value when persistence is disabled (i.e. during bootstrap)" do
+  it "should return but not cache fallback value when persistence is disabled" do
     Rails.cache.clear
     @store.stub(:should_persist? => false)
     @store.get(:test, true).should be_true
-    Rails.cache.read(:test).should be_true
+    Rails.cache.exist?(:test).should be_false
   end
 
   it "should return nil when key can't be found and fallback value is not supplied" do


### PR DESCRIPTION
When starting an application with an empty cache, preferences which are accessed at startup have incorrect (default) values.

I added some good old fashioned printf debugging at freerunningtech/spree@b9a705f4b9b442bae6d733f29cce0ef9970c39cf. With this and an empty cache I get the following when running rake environment in sandbox: ([Full output](https://gist.github.com/jhawthorn/6849082))

```
get("/spree/app_configuration/currency")
  should_persist? false
  = USD (fallback+saved)
get("/spree/app_configuration/override_actionmailer_config")
  should_persist? false
  = true (fallback+saved)
get("/spree/app_configuration/enable_mail_delivery")
  should_persist? false
  = false (fallback+saved)
```

`should_persist?` is always `false` at startup because `Spree::Preference.connected?` is `false` until an attempt is made at accessing the database. This causes the default values for settings to be used even if they were set preferences. Those values were then written to cache, resulting in the incorrect settings continuing to be used which is _extremely_ bad.

My first commit (9fb53da) reverts 9ca8ef9, which is incorrect as it uses the default values for all startup settings. This commit alone fixes the issue. This may break asset compilation on heroku in rails 4, but IMO this was not the correct fix and it's much more important to load the correct settings.

The second commit (deafc0d) prevents writing the fallback values to cache if persistence is disabled. Which was exacerbating the other issue.

(Related #3785)
