### PR TITLE
Add maximum length validation for promotion description

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -16,6 +16,7 @@ module Spree
     validates :name, presence: true
     validates :path, uniqueness: true
     validates :usage_limit, numericality: { greater_than: 0, allow_nil: true }
+    validates :description, length: { maximum: 255 }
 
     # TODO: This shouldn't be necessary with :autosave option but nested attribute updating of actions is broken without it
     after_save :save_rules_and_actions


### PR DESCRIPTION
The promotion description is stored in `activators.description` which is a text field but there was nothing enforcing the maximum length.
