### PR TITLE
admin menu  spans all width and centers items

### DIFF
--- a/backend/app/assets/stylesheets/admin/components/_navigation.scss
+++ b/backend/app/assets/stylesheets/admin/components/_navigation.scss
@@ -63,12 +63,18 @@ nav.menu {
 #admin-menu {
   background-color: $color-3;
 
+  ul{
+    display: table;
+    table-layout: fixed;
+    width: 100%;
+  }
+
   li {
-    min-width: 90px;
+    display: table-cell;
 
     a {
       display: block;
-      padding: 25px 20px;
+      padding: 25px 15px;
       color: $color-1 !important;
       text-transform: uppercase;
       position: relative;

--- a/backend/app/views/spree/admin/shared/_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_menu.html.erb
@@ -1,7 +1,7 @@
 <nav id="admin-menu" data-hook>
   <div class="container">
     <div class="sixteen columns main-menu-wrapper">
-      <ul data-hook="admin_tabs" class="inline-menu fullwidth-menu">
+      <ul data-hook="admin_tabs" class="fullwidth-menu">
         <%= render :partial => 'spree/admin/shared/tabs' %>
       </ul>
     </div>


### PR DESCRIPTION
since we removed horizontalNav.js from the backend
we need a way to replicate the previous behavior
display: table; on the parent <ul> and using
display: table-cell; on chil <li> ensures we
always use the whole width of the parent container
and we span the children <li> accordingly using
the same width across the given space

Conflicts:
    backend/app/views/spree/layouts/admin.html.erb

Same as #3725 fixes #3720 on master
