### PR TITLE
Use asset pipeline for jstree

### DIFF
--- a/backend/app/assets/javascripts/admin/taxonomy.js.coffee
+++ b/backend/app/assets/javascripts/admin/taxonomy.js.coffee
@@ -86,7 +86,7 @@ root.setup_taxonomy_tree = (taxonomy_id) ->
                 base_url.path() + '/' + e.attr('id') + '/jstree'
           themes:
             theme: "apple",
-            url: "/assets/jquery.jstree/themes/apple/style.css"
+            url: Spree.url(Spree.routes.jstree_theme_path)
           strings:
             new_node: new_taxon,
             loading: Spree.translations.loading + "..."

--- a/backend/app/assets/stylesheets/admin/plugins/_font-awesome.scss
+++ b/backend/app/assets/stylesheets/admin/plugins/_font-awesome.scss
@@ -27,8 +27,8 @@
  * -------------------------- */
 @font-face {
   font-family: 'FontAwesome';
-  src: font-url('fontawesome-webfont.eot?v=3.2.1');
-  src: font-url('fontawesome-webfont.eot?#iefix&v=3.2.1') format('embedded-opentype'), font-url('fontawesome-webfont.woff?v=3.2.1') format('woff'), font-url('fontawesome-webfont.ttf?v=3.2.1') format('truetype'), font-url('fontawesome-webfont.svg#fontawesomeregular?v=3.2.1') format('svg');
+  src: font-url('fontawesome-webfont.eot');
+  src: font-url('fontawesome-webfont.eot?#iefix') format('embedded-opentype'), font-url('fontawesome-webfont.woff') format('woff'), font-url('fontawesome-webfont.ttf') format('truetype'), font-url('fontawesome-webfont.svg#fontawesomeregular') format('svg');
   font-weight: normal;
   font-style: normal;
 }

--- a/backend/app/views/spree/admin/taxonomies/edit.erb
+++ b/backend/app/views/spree/admin/taxonomies/edit.erb
@@ -22,6 +22,7 @@
       <script>
         Spree.routes.taxonomy_taxons_path = "<%= spree.api_taxonomy_taxons_path(@taxonomy) %>";
         Spree.routes.admin_taxonomy_taxons_path = "<%= spree.admin_taxonomy_taxons_path(@taxonomy) %>";
+        Spree.routes.jstree_theme_path = "<%= stylesheet_path("jquery.jstree/themes/apple/style.css") %>";
       </script>
       <div id="taxonomy_tree" class="tree"></div>
     </div>

--- a/backend/vendor/assets/javascripts/jquery.jstree/themes/apple/style.scss
+++ b/backend/vendor/assets/javascripts/jquery.jstree/themes/apple/style.scss
@@ -4,9 +4,9 @@
  * Supported plugins: ui (hovered, clicked), checkbox, contextmenu, search
  */
 
-.jstree-apple > ul { background:url("bg.jpg") left top repeat; }
-.jstree-apple li, 
-.jstree-apple ins { background-image:url("d.png"); background-repeat:no-repeat; background-color:transparent; }
+.jstree-apple > ul { background:image-url("jquery.jstree/themes/apple/bg.jpg") left top repeat; }
+.jstree-apple li,
+.jstree-apple ins { background-image:image-url("jquery.jstree/themes/apple/d.png"); background-repeat:no-repeat; background-color:transparent; }
 .jstree-apple li { background-position:-90px 0; background-repeat:repeat-y;  }
 .jstree-apple li.jstree-last { background:transparent; }
 .jstree-apple .jstree-open > ins { background-position:-72px 0; }
@@ -17,11 +17,11 @@
 .jstree-apple .jstree-hovered { background:#e7f4f9; border:1px solid #d8f0fa; padding:0 3px 0 1px; text-shadow:1px 1px 1px silver; }
 .jstree-apple .jstree-clicked { background:#beebff; border:1px solid #99defd; padding:0 3px 0 1px; }
 .jstree-apple a .jstree-icon { background-position:-56px -20px; }
-.jstree-apple a.jstree-loading .jstree-icon { background:url("throbber.gif") center center no-repeat !important; }
+.jstree-apple a.jstree-loading .jstree-icon { background:image-url("jquery.jstree/themes/apple/throbber.gif") center center no-repeat !important; }
 
 .jstree-apple.jstree-focused { background:white; }
 
-.jstree-apple .jstree-no-dots li, 
+.jstree-apple .jstree-no-dots li,
 .jstree-apple .jstree-no-dots .jstree-leaf > ins { background:transparent; }
 .jstree-apple .jstree-no-dots .jstree-open > ins { background-position:-18px 0; }
 .jstree-apple .jstree-no-dots .jstree-closed > ins { background-position:0 0; }
@@ -40,20 +40,20 @@
 .jstree-apple .jstree-undetermined > a > .jstree-checkbox:hover { background-position:-20px -37px; }
 
 #vakata-dragged.jstree-apple ins { background:transparent !important; }
-/*#vakata-dragged.jstree-apple .jstree-ok { background:url("d.png") -2px -53px no-repeat !important; }*/
-/*#vakata-dragged.jstree-apple .jstree-invalid { background:url("d.png") -18px -53px no-repeat !important; }*/
-/*#jstree-marker.jstree-apple { background:url("d.png") -41px -57px no-repeat !important; text-indent:-100px; }*/
+/*#vakata-dragged.jstree-apple .jstree-ok { background:image-url("jquery.jstree/themes/apple/d.png") -2px -53px no-repeat !important; }*/
+/*#vakata-dragged.jstree-apple .jstree-invalid { background:image-url("jquery.jstree/themes/apple/d.png") -18px -53px no-repeat !important; }*/
+/*#jstree-marker.jstree-apple { background:image-url("jquery.jstree/themes/apple/d.png") -41px -57px no-repeat !important; text-indent:-100px; }*/
 
 .jstree-apple a.jstree-search { color:aqua; }
 .jstree-apple .jstree-locked a { color:silver; cursor:default; }
 
-#vakata-contextmenu.jstree-apple-context, 
+#vakata-contextmenu.jstree-apple-context,
 #vakata-contextmenu.jstree-apple-context li ul { background:#f0f0f0; border:1px solid #979797; -moz-box-shadow: 1px 1px 2px #999; -webkit-box-shadow: 1px 1px 2px #999; box-shadow: 1px 1px 2px #999; }
 #vakata-contextmenu.jstree-apple-context li { }
 #vakata-contextmenu.jstree-apple-context a { color:black; }
-#vakata-contextmenu.jstree-apple-context a:hover, 
+#vakata-contextmenu.jstree-apple-context a:hover,
 #vakata-contextmenu.jstree-apple-context .vakata-hover > a { padding:0 5px; background:#e8eff7; border:1px solid #aecff7; color:black; -webkit-border-radius:2px; border-radius:2px; }
-#vakata-contextmenu.jstree-apple-context li.jstree-contextmenu-disabled a, 
+#vakata-contextmenu.jstree-apple-context li.jstree-contextmenu-disabled a,
 #vakata-contextmenu.jstree-apple-context li.jstree-contextmenu-disabled a:hover { color:silver; background:transparent; border:0; padding:1px 4px; }
 #vakata-contextmenu.jstree-apple-context li.vakata-separator { background:white; border-top:1px solid #e0e0e0; margin:0; }
 #vakata-contextmenu.jstree-apple-context li ul { margin-left:-4px; }


### PR DESCRIPTION
These fixes are required for styles to load correctly on the taxonomy edit page in production mode in Rails 4.

I see the contributing guidelines say that tests are required, but I'm not sure how I might go about testing this. Will give it a go if you have any ideas.
- Hard-coding links to /assets/ without fingerprints does not work on Rails 4
- The version number in the query string is not necessary for fingerprinted assets.
