### PR TITLE
Spree::Credit Card Expiry Method Fix

### DIFF
--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -17,8 +17,10 @@ module Spree
     alias_attribute :brand, :cc_type
 
     def expiry=(expiry)
-      self[:month], self[:year] = expiry.split(" / ")
-      self[:year] = "20" + self[:year]
+      if year.present? && month.present?
+        self[:month], self[:year] = expiry.split(" / ")
+        self[:year] = "20" + self[:year]
+      end
     end
 
     def number=(num)


### PR DESCRIPTION
The expiry method needs to check for presence before parsing. An empty card expiration field will raise the error "no implicit conversion of nil into String" on submission.
