### PR TITLE
centering search field on select2 plugin in admin area

### DIFF
--- a/backend/app/assets/stylesheets/admin/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/admin/plugins/_select2.scss
@@ -70,7 +70,7 @@
   input {
     @extend input[type="text"];
     margin-top: 5px;
-    margin-left: -6px;
+    margin-left: 4px;
     padding-left: 25px;
     padding-top: 6px;
     padding-bottom: 6px;


### PR DESCRIPTION
I'm current working on `2-1-stable branch` in a project, and I noticed the search field on select2 plugin on admin area was not aligned, like here:

![before](https://f.cloud.github.com/assets/1538066/1303457/254e98da-3158-11e3-90cb-52bb61cbc055.png)

I pulled master branch to and ran the `spec/features/admin/products/stock_management_spec.rb` spec, and also noticed that was not aligned.

I made this little change on the css, and now it looks like this:

![after](https://f.cloud.github.com/assets/1538066/1303458/25596d46-3158-11e3-8591-05cb420ef51c.png)

I noticed this on a Chrome on Mac, and did this change using Firefox on Ubuntu.
