### PR TITLE
CreateAdjustment promotion action now associates adjustments through both order_id and adjustable_id

### DIFF
--- a/core/app/models/spree/promotion/actions/create_adjustment.rb
+++ b/core/app/models/spree/promotion/actions/create_adjustment.rb
@@ -21,11 +21,12 @@ module Spree
           return if promotion_credit_exists?(order)
 
           amount = compute_amount(order)
-          order.adjustments.create!(
+          Spree::Adjustment.create!(
             amount: amount,
+            order: order,
             adjustable: order,
             source: self,
-            label: "#{Spree.t(:promotion)} (#{promotion.name})",
+            label: "#{Spree.t(:promotion)} (#{promotion.name})"
           )
           true
         end

--- a/core/spec/models/spree/promotion/actions/create_adjustment_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_adjustment_spec.rb
@@ -22,6 +22,12 @@ describe Spree::Promotion::Actions::CreateAdjustment do
       order.adjustments.first.amount.to_i.should == -10
     end
 
+    it "should create a discount accessible through both order_id and adjustable_id" do
+      action.perform(:order => order)
+      order.adjustments.count.should == 1
+      order.all_adjustments.count.should == 1
+    end
+
     it "should not create a discount when order already has one from this promotion" do
       order.shipments.create!(:cost => 10)
 
@@ -47,7 +53,7 @@ describe Spree::Promotion::Actions::CreateAdjustment do
 
     context "when order is complete" do
       let(:order) do
-        create(:order_with_line_items, 
+        create(:order_with_line_items,
                :state => "complete",
                :completed_at => Time.now,
                :line_items_count => 1)


### PR DESCRIPTION
`Spree::Promotion::Actions::CreateAdjustment` is not associating its created adjustment record to the relevant order through `order_id`. Without the `order_id` relationship set on adjustment this promotion action creates, `order.all_adjustments` does not return the newly created promotion.
