### PR TITLE
Select2 fix #3854 to center the search in admin area in ie, firefox and chrome

### DIFF
--- a/backend/app/assets/stylesheets/admin/hacks/_ie.scss
+++ b/backend/app/assets/stylesheets/admin/hacks/_ie.scss
@@ -18,7 +18,6 @@ html.ie {
   }
   .select2-search {
     &:before {
-      position: relative;
       z-index: 10000;
       content: '\f002' !important;
     }

--- a/backend/app/assets/stylesheets/admin/hacks/_mozilla.scss
+++ b/backend/app/assets/stylesheets/admin/hacks/_mozilla.scss
@@ -22,6 +22,7 @@ html.firefox {
 
   // Fix select2 search input left padding to not overlap search icon
   .select2-search input.select2-input {
+    padding-bottom: 12px !important;
     padding-left: 25px !important;
   }
 

--- a/backend/app/assets/stylesheets/admin/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/admin/plugins/_select2.scss
@@ -63,7 +63,7 @@
     @extend [class^="icon-"]:before;
 
     position: absolute;
-    top: 13px;
+    top: 16px;
     left: 13px;
   }
 


### PR DESCRIPTION
I did some more fixes to center the search box in different browsers:

Was in Chrome:
![chrome-current](https://f.cloud.github.com/assets/493547/1319906/cd62d376-3322-11e3-9447-018e424cc672.png)

Was in IE9:
![ie9-current](https://f.cloud.github.com/assets/493547/1319910/2aed0066-3323-11e3-8189-7ba328882d56.png)

After fixes it is:
Chrome:
![chrome-fixed](https://f.cloud.github.com/assets/493547/1319911/39e08a7a-3323-11e3-9498-86b50b2afb80.png)

Firefox:
![firefox-fixed](https://f.cloud.github.com/assets/493547/1319912/3f87e4aa-3323-11e3-833b-f3397cf266db.png)

IE9:
![ie9-fixed](https://f.cloud.github.com/assets/493547/1319915/6efee2ce-3323-11e3-83c3-e50627c47af7.png)
