### PR TITLE
Don't try to update the spree_adjustments.originator_type column if it does not exist

### DIFF
--- a/core/db/migrate/20130807024301_upgrade_adjustments.rb
+++ b/core/db/migrate/20130807024301_upgrade_adjustments.rb
@@ -12,6 +12,7 @@ class UpgradeAdjustments < ActiveRecord::Migration
       adjustment.destroy
     end
 
+    return unless Spree::Adjustment.column_names.include? "originator_type"
     # Tax adjustments have their sources altered
     Spree::Adjustment.where(:originator_type => "Spree::TaxRate").find_each do |adjustment|
       adjustment.source = adjustment.originator


### PR DESCRIPTION
This fixes the migration path for projects that started from version 2.1.0.beta
