### PR TITLE
Shipments need to check if they can get rates

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -297,8 +297,7 @@ module Spree
       end
 
       def can_get_rates?
-        return false unless order.ship_address && order.ship_address.valid?
-        true
+        order.ship_address && order.ship_address.valid?
       end
   end
 end

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -104,6 +104,7 @@ module Spree
 
     def refresh_rates
       return shipping_rates if shipped?
+      return [] unless can_get_rates?
 
       # StockEstimator.new assigment below will replace the current shipping_method
       original_shipping_method_id = shipping_method.try(:id)
@@ -293,6 +294,11 @@ module Spree
 
       def recalculate_adjustments
         Spree::ItemAdjustments.new(self).update
+      end
+
+      def can_get_rates?
+        return false unless order.ship_address && order.ship_address.valid?
+        true
       end
   end
 end

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -88,6 +88,7 @@ describe Spree::Shipment do
 
     context 'refresh_rates' do
       let(:mock_estimator) { double('estimator', shipping_rates: shipping_rates) }
+      before { shipment.stub(:can_get_rates?){ true } }
 
       it 'should request new rates, and maintain shipping_method selection' do
         Spree::Stock::Estimator.should_receive(:new).with(shipment.order).and_return(mock_estimator)
@@ -109,6 +110,11 @@ describe Spree::Shipment do
         shipment.shipping_rates.delete_all
         shipment.stub(shipped?: true)
         shipment.refresh_rates.should == []
+      end
+
+      it "can't get rates without a shipping address" do
+        shipment.order(ship_address: nil)
+        expect(shipment.refresh_rates).to eq([])
       end
 
       context 'to_package' do


### PR DESCRIPTION
before trying to get them, a private method
has been added to check if the shipment is ready
to get rates, currently it only checks if the order
has set a shipping_address, if theres custom business
logic for a specific store this is what they should
be customising instead of the refresh_rates call
which is already getting too complicated by itself.

Added tests for this and had to include a before call
to stub this same call in order for the other tests to pass.

fixes #3848
