### PR TITLE
Fixed Spree::Api::ProductsController#index to accept multiple ids

### DIFF
--- a/api/app/controllers/spree/api/products_controller.rb
+++ b/api/app/controllers/spree/api/products_controller.rb
@@ -4,7 +4,7 @@ module Spree
 
       def index
         if params[:ids]
-          @products = product_scope.where(:id => params[:ids])
+          @products = product_scope.where(:id => params[:ids].split(","))
         else
           @products = product_scope.ransack(params[:q]).result
         end
@@ -35,7 +35,7 @@ module Spree
           @product.permalink = nil
           retry
         end
-      end 
+      end
 
       def update
         @product = find_product(params[:id])

--- a/api/spec/controllers/spree/api/products_controller_spec.rb
+++ b/api/spec/controllers/spree/api/products_controller_spec.rb
@@ -32,6 +32,17 @@ module Spree
         json_response["per_page"].should == Kaminari.config.default_per_page
       end
 
+      it "retrieves a list of products by ids string" do
+        second_product = create(:product)
+        api_get :index, :ids => [product.id, second_product.id].join(",")
+        json_response["products"].first.should have_attributes(attributes)
+        json_response["products"][1].should have_attributes(attributes)
+        json_response["total_count"].should == 2
+        json_response["current_page"].should == 1
+        json_response["pages"].should == 1
+        json_response["per_page"].should == Kaminari.config.default_per_page
+      end
+
       it "does not return inactive products when queried by ids" do
         api_get :index, :ids => [inactive_product.id]
         json_response["count"].should == 0


### PR DESCRIPTION
Spree::Api::ProductsController#index doesn't actually work, when multiple ids are specified.
Specifically, calling "http://foo.com/api/products?ids=1,2&token=your_token" will return only product with id 1.

I fixed this issue, by spliting params[:ids] to pass ids array as arguments.
