### PR TITLE
Reference Spree::Order to prevent migration error

### DIFF
--- a/core/db/migrate/20130807024302_rename_adjustment_fields.rb
+++ b/core/db/migrate/20130807024302_rename_adjustment_fields.rb
@@ -8,7 +8,7 @@ class RenameAdjustmentFields < ActiveRecord::Migration
     # This enables the Spree::Order#all_adjustments association to work correctly
     Spree::Adjustment.reset_column_information
     Spree::Adjustment.find_each do |adjustment|
-      if adjustment.adjustable.is_a?(Order)
+      if adjustment.adjustable.is_a?(Spree::Order)
         adjustment.order = adjustment.adjustable
         adjustment.save
       end


### PR DESCRIPTION
Fixes error that occurs during migrating an existing application.

```
uninitialized constant RenameAdjustmentFields::Order
```
