### PR TITLE
Spree::Payment.class.undescore will always convert spree/payment

### DIFF
--- a/backend/app/views/spree/admin/payments/show.html.erb
+++ b/backend/app/views/spree/admin/payments/show.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :page_title do %>
   <i class="icon-arrow-right"></i>
-  <%= Spree.t("activerecord.models.#{@payment.class.to_s.underscore}.one") %>
+  <%= I18n.t(:one, scope: "activerecord.models.spree/payment") %>
   <i class="icon-arrow-right"></i>
   <%= payment_method_name(@payment) %>
 <% end %>


### PR DESCRIPTION
Hi,

When I was translating Spree to portuguese, I noticed that the payment breadcrumb was still in English. I found that strange, and checked the yml key used on that line, and found out this: 

``` ruby
<%= Spree.t("activerecord.models.#{@payment.class.to_s.underscore}.one") %>
```

, in this file: https://github.com/spree/spree/blob/2-1-stable/backend/app/views/spree/admin/payments/show.html.erb#L5

I thought this line was strange because the default `en.yml` file does not have a `spree.activerecord` key.

Besides that, the `@payment` variable will always return a `Spree::Payment`, that'll be undescored to "spree/payment".

Also, I noticed there's a difference between `2-0-stable` branch and `2-1-stable` in this line, where the `2-0-stable` branch keeps the I18n function.

Sorry if I misunderstood something, I'm still battling my way to understanding Spree internals :)
