### PR TITLE
Bugfix: Taxons could not be ordered

### DIFF
--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -20,6 +20,8 @@ module Spree
       path: ':rails_root/public/spree/taxons/:id/:style/:basename.:extension',
       default_url: '/assets/default_taxon.png'
 
+    default_scope order: "#{self.table_name}.position"
+
     include Spree::Core::S3Support
     supports_s3 :icon
 


### PR DESCRIPTION
If you reorder the taxons in the admin interface, it does not have any effect, because the ordering of the taxons is not used. Setting a default scope with this ordering fixes that.
