### PR TITLE
Use evaluate_script instead of execute_script

### DIFF
--- a/core/lib/spree/testing_support/capybara_ext.rb
+++ b/core/lib/spree/testing_support/capybara_ext.rb
@@ -94,7 +94,7 @@ module CapybaraExt
 
   def wait_for_ajax
     counter = 0
-    while page.execute_script("return $.active").to_i > 0
+    while page.evaluate_script("$.active").to_i > 0
       counter += 1
       sleep(0.1)
       raise "AJAX request took longer than 5 seconds." if counter >= 50


### PR DESCRIPTION
evaluate_script was meant to be used for these kinds of situations.
