### PR TITLE
Remember user address in checkout

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -14,9 +14,17 @@ module Spree
     alias_attribute :first_name, :firstname
     alias_attribute :last_name, :lastname
 
-    def self.default
+    def self.build_default
       country = Spree::Country.find(Spree::Config[:default_country_id]) rescue Spree::Country.first
       new(country: country)
+    end
+
+    def self.default(user = nil, kind = "bill")
+      if user
+        user.send(:"#{kind}_address") || build_default
+      else
+        build_default
+      end
     end
 
     # Can modify an address if it's not been used in an order (but checkouts controller has finer control)

--- a/core/app/models/spree/legacy_user.rb
+++ b/core/app/models/spree/legacy_user.rb
@@ -1,10 +1,11 @@
 # Default implementation of User.  This class is intended to be modified by extensions (ex. spree_auth_devise)
 module Spree
   class LegacyUser < ActiveRecord::Base
+    include Core::UserAddress
+
     self.table_name = 'spree_users'
+
     has_many :orders, foreign_key: :user_id
-    belongs_to :ship_address, class_name: 'Spree::Address'
-    belongs_to :bill_address, class_name: 'Spree::Address'
 
     before_destroy :check_completed_orders
 

--- a/core/lib/spree/core/user_address.rb
+++ b/core/lib/spree/core/user_address.rb
@@ -11,11 +11,13 @@ module Spree
         alias_attribute :shipping_address, :ship_address
 
         def persist_order_address(order)
-          unless self.bill_address || self.ship_address
-            self.bill_address = order.bill_address.clone
-            self.ship_address = order.ship_address.clone
-            self.save
-          end
+          address = self.bill_address || self.build_bill_address
+          address.attributes = order.bill_address.attributes.except('id', 'updated_at', 'created_at')
+          address.save
+
+          address = self.ship_address || self.build_ship_address
+          address.attributes = order.ship_address.attributes.except('id', 'updated_at', 'created_at')
+          address.save
         end
       end
     end

--- a/core/lib/spree/core/user_address.rb
+++ b/core/lib/spree/core/user_address.rb
@@ -1,0 +1,23 @@
+module Spree
+  module Core
+    module UserAddress
+      extend ActiveSupport::Concern
+
+      included do
+        belongs_to :bill_address, foreign_key: :bill_address_id, class_name: 'Spree::Address'
+        alias_attribute :billing_address, :bill_address
+
+        belongs_to :ship_address, foreign_key: :ship_address_id, class_name: 'Spree::Address'
+        alias_attribute :shipping_address, :ship_address
+
+        def persist_order_address(order)
+          unless self.bill_address || self.ship_address
+            self.bill_address = order.bill_address.clone
+            self.ship_address = order.ship_address.clone
+            self.save
+          end
+        end
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/user_spec.rb
+++ b/core/spec/models/spree/user_spec.rb
@@ -4,12 +4,35 @@ describe Spree::LegacyUser do
   # Regression test for #2844 + #3346
   context "#last_incomplete_order" do
     let!(:user) { create(:user) }
+    let!(:order) { create(:order, bill_address: create(:address), ship_address: create(:address)) }
+
     let!(:order_1) { create(:order, :created_at => 1.day.ago, :user => user, :created_by => user) }
     let!(:order_2) { create(:order, :user => user, :created_by => user) }
     let!(:order_3) { create(:order, :user => user, :created_by => create(:user)) }
 
     it "returns correct order" do
       user.last_incomplete_spree_order.should == order_2
+    end
+
+    context "persists order address" do
+      it "copies over order addresses" do
+        expect {
+          user.persist_order_address(order)
+        }.to change { Spree::Address.count }.by(2)
+
+        expect(user.bill_address).to eq order.bill_address
+        expect(user.ship_address).to eq order.ship_address
+      end
+
+      it "doesnt create new addresses if user has already" do
+        user.update_column(:bill_address_id, create(:address))
+        user.update_column(:ship_address_id, create(:address))
+        user.reload
+
+        expect {
+          user.persist_order_address(order)
+        }.not_to change { Spree::Address.count }
+      end
     end
   end
 end

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -165,7 +165,7 @@ module Spree
 
       def persist_user_address
         if @order.address? && spree_current_user.respond_to?(:persist_order_address)
-          spree_current_user.persist_order_address(@order)
+          spree_current_user.persist_order_address(@order) if params[:save_user_address]
         end
       end
   end

--- a/frontend/app/views/spree/checkout/_address.html.erb
+++ b/frontend/app/views/spree/checkout/_address.html.erb
@@ -20,6 +20,13 @@
   </fieldset>
 </div>
 <hr class="clear" />
+
 <div class="form-buttons" data-hook="buttons">
   <%= submit_tag Spree.t(:save_and_continue), :class => 'continue button primary' %>
+
+  <span data-hook="save_user_address">
+    &nbsp; &nbsp;
+    <%= check_box_tag 'save_user_address', '1', spree_current_user.respond_to?(:persist_order_address) %>
+    <%= label_tag :save_user_address, Spree.t(:save_my_address) %>
+  </span>
 </div>

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -12,6 +12,7 @@ describe Spree::CheckoutController do
 
   before do
     controller.stub :try_spree_current_user => user
+    controller.stub :spree_current_user => user
     controller.stub :current_order => order
   end
 
@@ -68,16 +69,28 @@ describe Spree::CheckoutController do
     end
 
     context "save successful" do
+      def spree_post_address
+        spree_post :update, {
+          :state => "address",
+          :order => {
+            :bill_address_attributes => address_params,
+            :use_billing => true
+          }
+        }
+      end
+
+      before do
+        # Must have *a* shipping method and a payment method so updating from address works
+        order.stub :available_shipping_methods => [stub_model(Spree::ShippingMethod)]
+        order.stub :available_payment_methods => [stub_model(Spree::PaymentMethod)]
+        order.stub :ensure_available_shipping_rates => true
+        order.line_items << FactoryGirl.create(:line_item)
+      end
+
       context "with the order in the cart state" do
         before do
           order.update_column(:state, "cart")
           order.stub :user => user
-
-          # Must have *a* shipping method and a payment method so updating from address works
-          order.stub :available_shipping_methods => [stub_model(Spree::ShippingMethod)]
-          order.stub :available_payment_methods => [stub_model(Spree::PaymentMethod)]
-          order.stub :ensure_available_shipping_rates => true
-          order.line_items << FactoryGirl.create(:line_item)
         end
 
         it "should assign order" do
@@ -86,25 +99,42 @@ describe Spree::CheckoutController do
         end
 
         it "should advance the state" do
-          spree_post :update, {
-            :state => "address",
-            :order => {
-              :bill_address_attributes => address_params,
-              :use_billing => true
-            }
-          }
+          spree_post_address
           order.reload.state.should == "delivery"
         end
 
         it "should redirect the next state" do
-          spree_post :update, {
-            :state => "address",
-            :order => {
-              :bill_address_attributes => address_params,
-              :use_billing => true
-            }
-          }
+          spree_post_address
           response.should redirect_to spree.checkout_state_path("delivery")
+        end
+
+        context "current_user respond to save address method" do
+          it "calls persist order address on user" do
+            expect(user).to receive(:persist_order_address)
+            spree_post :update, {
+              :state => "address",
+              :order => {
+                :bill_address_attributes => address_params,
+                :use_billing => true
+              },
+              :save_user_address => "1"
+            }
+          end
+        end
+
+        context "current_user doesnt respond to persist_order_address" do
+          it "doesnt raise any error" do
+            expect {
+              spree_post :update, {
+                :state => "address",
+                :order => {
+                  :bill_address_attributes => address_params,
+                  :use_billing => true
+                },
+                :save_user_address => "1"
+              }
+            }.to_not raise_error
+          end
         end
       end
 


### PR DESCRIPTION
First draft for my suggestion on remembering user addresses on checkout. I believe the general idea would be to save the user address the first time it's entered and on the next checkout remember that address.

With this patch merged and the `Spree::Core::User::Address` included on your `Spree.user_class` that is now possible. I'm not sure if making the `persist_order_address` is better inside the controller or tied to some other model  method (e.g. as we do with the `use_billing` flag for shipping addresses). For now I went to the controller approach.

Thoughts? Depending on how this goes I might go on with more specs and maybe letting users choose whether or not they want the address associated with their account (something like a checkbox saying "associate address with my account")

any feedback much appreciated 
