### PR TITLE
'test_app' task failing without dev dependencies

### DIFF
--- a/cmd/lib/spree_cmd/templates/extension/extension.gemspec
+++ b/cmd/lib/spree_cmd/templates/extension/extension.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'spree_core', '~> <%= spree_version %>'
 
+  s.add_development_dependency 'spree_frontend', '~> <%= spree_version %>'
+  s.add_development_dependency 'spree_backend', '~> <%= spree_version %>'
   s.add_development_dependency 'capybara', '~> 2.1'
   s.add_development_dependency 'coffee-rails'
   s.add_development_dependency 'database_cleaner'


### PR DESCRIPTION
bundle exec rake test_app was complaining about missing gems
spree_frontend and spree_backend when running inside extension.

Additionally couldn't open a rails console inside engines spec/dummy

Added developement dependencies to 'extension.gemspec' template so that
generated extensions include these dependencies
