### PR TITLE
Updated HOWTO docstring in testing_support/controller_requests to match current paths

### DIFF
--- a/core/lib/spree/testing_support/controller_requests.rb
+++ b/core/lib/spree/testing_support/controller_requests.rb
@@ -11,7 +11,7 @@
 #
 # Then, in your controller tests, you can access spree routes like this:
 #
-#   require 'spec_helperr'
+#   require 'spec_helper'
 #
 #   describe Spree::ProductsController do
 #     it "can see all the products" do

--- a/core/lib/spree/testing_support/controller_requests.rb
+++ b/core/lib/spree/testing_support/controller_requests.rb
@@ -4,14 +4,14 @@
 # Inside your spec_helper.rb, include this module inside the RSpec.configure
 # block by doing this:
 #
-#   require 'spree/core/testing_support/controller_requests'
+#   require 'spree/testing_support/controller_requests'
 #   RSpec.configure do |c|
-#     c.include Spree::Core::TestingSupport::ControllerRequests, :type => :controller
+#     c.include Spree::TestingSupport::ControllerRequests, :type => :controller
 #   end
 #
 # Then, in your controller tests, you can access spree routes like this:
 #
-#   require 'spec_helper'
+#   require 'spec_helperr'
 #
 #   describe Spree::ProductsController do
 #     it "can see all the products" do


### PR DESCRIPTION
Previously referred to `spree/core/testing_support` which does not load under 2.0.5.  Since the last update to these lines was from 2012 I assumed this was a casualty of the refactoring into multiple Spree gems.
