### PR TITLE
Make product variants thumbnails selection more specific in product.js.coffee

### DIFF
--- a/frontend/app/assets/javascripts/store/product.js.coffee
+++ b/frontend/app/assets/javascripts/store/product.js.coffee
@@ -22,10 +22,10 @@ $ ->
     ($ 'li.tmb-' + variantId).show()
     currentThumb = ($ '#' + ($ '#main-image').data('selectedThumbId'))
     if not currentThumb.hasClass('vtmb-' + variantId)
-      thumb = ($ ($ 'ul.thumbnails li:visible.vtmb').eq(0))
-      thumb = ($ ($ 'ul.thumbnails li:visible').eq(0)) unless thumb.length > 0
+      thumb = ($ ($ '#product-images ul.thumbnails li:visible.vtmb').eq(0))
+      thumb = ($ ($ '#product-images ul.thumbnails li:visible').eq(0)) unless thumb.length > 0
       newImg = thumb.find('a').attr('href')
-      ($ 'ul.thumbnails li').removeClass 'selected'
+      ($ '#product-images ul.thumbnails li').removeClass 'selected'
       thumb.addClass 'selected'
       ($ '#main-image img').attr 'src', newImg
       ($ '#main-image').data 'selectedThumb', newImg


### PR DESCRIPTION
Just ran into this issue today.

In my `products#show` view I display the similar/related products using thumbnails and added the `.thumbnails` class for styling consistency. So my view has two `ul.thumbnails` elements, but when a product has variants and the variants don't have thumbnails (i.e. the `#product-images ul.thumbnails` element doesn't exist) the `Spree.showVariantImages` function is applied to the similar products `ul.thumbnails` element and doesn't work as expected. Does that make sense?

Making the JS selector specific to the `#product-images` section resolves that.

I believe the `#product-images ul.thumbnails` selector in `Spree.showVariantImages` could also be moved to a variable like in `addImageHandlers`.
