### PR TITLE
fix inline comment that can cause deface errors

### DIFF
--- a/core/app/views/spree/admin/payment_methods/_form.html.erb
+++ b/core/app/views/spree/admin/payment_methods/_form.html.erb
@@ -1,5 +1,6 @@
 <% # Usage of old-style form helpers in this file is INTENTIONAL
-   # For reasons, see commit 3e981c7. %>
+   # For reasons, see commit 3e981c7. 
+   %>
 <div data-hook="admin_payment_method_form_fields">
 
   <div data-hook="payment_method">


### PR DESCRIPTION
see https://github.com/spree/deface/issues/113 for more info

when using deface to make changes to app/views/spree/admin/payment_methods/_form.html.erb I encounter the following error:

``` text
syntax error, unexpected '<', expecting keyword_end
```

I tracked it down to the inline comment issue discussed in https://github.com/spree/deface/issues/113 
