### PR TITLE
Set cc_type server-side in case of js failure

### DIFF
--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -16,9 +16,18 @@ module Spree
     # needed for some of the ActiveMerchant gateways (eg. SagePay)
     alias_attribute :brand, :cc_type
 
+    CARD_TYPES = {
+      visa: /^4[0-9]{12}(?:[0-9]{3})?$/,
+      master: /(^5[1-5][0-9]{14}$)|(^6759[0-9]{2}([0-9]{10})$)|(^6759[0-9]{2}([0-9]{12})$)|(^6759[0-9]{2}([0-9]{13})$)/,
+      diners_club: /^3(?:0[0-5]|[68][0-9])[0-9]{11}$/,
+      american_express: /^3[47][0-9]{13}$/,
+      discover: /^6(?:011|5[0-9]{2})[0-9]{12}$/,
+      jcb: /^(?:2131|1800|35\d{3})\d{11}$/
+    }
+
     def expiry=(expiry)
       if expiry.present?
-        self[:month], self[:year] = expiry.split(" / ")
+        self[:month], self[:year] = expiry.delete(' ').split('/')
         self[:year] = "20" + self[:year] if self[:year].length == 2
       end
     end
@@ -30,23 +39,24 @@ module Spree
     # cc_type is set by jquery.payment, which helpfully provides different
     # types from Active Merchant. Converting them is necessary.
     def cc_type=(type)
-      real_type = case type
-      when 'mastercard', 'maestro'
-        'master'
-      when 'amex'
-        'american_express'
-      when 'dinersclub'
-        'diners_club'
-      else
-        type
+      self[:cc_type] = case type
+      when 'mastercard', 'maestro' then 'master'
+      when 'amex' then 'american_express'
+      when 'dinersclub' then 'diners_club'
+      when '' then try_type_from_number
+      else type
       end
-      self[:cc_type] = real_type
     end
 
     def set_last_digits
       number.to_s.gsub!(/\s/,'')
       verification_value.to_s.gsub!(/\s/,'')
       self.last_digits ||= number.to_s.length <= 4 ? number : number.to_s.slice(-4..-1)
+    end
+
+    def try_type_from_number
+      numbers = number.delete(' ') if number
+      CARD_TYPES.find{|type, pattern| return type.to_s if numbers =~ pattern}.to_s
     end
 
     def name?

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -103,13 +103,13 @@ describe Spree::CreditCard do
       credit_card.should_not be_valid
       credit_card.errors[:base].should be_blank
     end
-    
+
     it "does not run expiration in the past validation if year and month are empty" do
       credit_card.year = ""
       credit_card.month = ""
       credit_card.should_not be_valid
       credit_card.errors[:card].should be_blank
-    end 
+    end
 
     it "should only validate on create" do
       credit_card.attributes = valid_credit_card_attributes
@@ -164,6 +164,18 @@ describe Spree::CreditCard do
       expect(credit_card.year).to eq('2014')
     end
 
+    it "can set with a 2-digit month and 4-digit year without whitespace" do
+      credit_card.expiry = '04/14'
+      expect(credit_card.month).to eq('04')
+      expect(credit_card.year).to eq('2014')
+    end
+
+    it "can set with a 2-digit month and 4-digit year without whitespace" do
+      credit_card.expiry = '04/2014'
+      expect(credit_card.month).to eq('04')
+      expect(credit_card.year).to eq('2014')
+    end
+
     it "does not blow up when passed an empty string" do
       lambda { credit_card.expiry = '' }.should_not raise_error
     end
@@ -186,6 +198,36 @@ describe Spree::CreditCard do
       credit_card.cc_type = 'some_outlandish_cc_type'
       credit_card.cc_type.should == 'some_outlandish_cc_type'
     end
+
+    it "assigns the type based on card number in the event of js failure" do
+      credit_card.number = '4242424242424242'
+      credit_card.cc_type = ''
+      credit_card.cc_type.should == 'visa'
+
+      credit_card.number = '5555555555554444'
+      credit_card.cc_type = ''
+      credit_card.cc_type.should == 'master'
+
+      credit_card.number = '378282246310005'
+      credit_card.cc_type = ''
+      credit_card.cc_type.should == 'american_express'
+
+      credit_card.number = '30569309025904'
+      credit_card.cc_type = ''
+      credit_card.cc_type.should == 'diners_club'
+
+      credit_card.number = '3530111333300000'
+      credit_card.cc_type = ''
+      credit_card.cc_type.should == 'jcb'
+
+      credit_card.number = ''
+      credit_card.cc_type = ''
+      credit_card.cc_type.should == ''
+
+      credit_card.number = nil
+      credit_card.cc_type = ''
+      credit_card.cc_type.should == ''
+    end
   end
 
   context "#associations" do
@@ -193,7 +235,7 @@ describe Spree::CreditCard do
       expect { credit_card.payments.to_a }.not_to raise_error
     end
   end
-  
+
   context "#to_active_merchant" do
     before do
       credit_card.number = "4111111111111111"


### PR DESCRIPTION
Currently, `cc_type` is set on the client-side using `jquery.payments`.  This creates a single point of failure at malfunctioning or disabled javascript given that the lack of a `cc_type` on a payment source causes some spree gateways to fail.  This pull request adds a redundant check on the server-side for cases where the javascript either fails or is disabled.
- Change `CreditCard#expiry=` to remove whitespace and split on `'/'` instead of splitting on `' / '` because when js fails, a user entry of `'04/12'` will break.
- Change `CreditCard#cc_type=` to match a type based on the card number when `cc_type` is an empty string, as is the case when js fails.
