### PR TITLE
fix comment to refer to checkout_step?

### DIFF
--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -97,7 +97,7 @@ module Spree
       # attributes for a single payment and its source, discarding attributes
       # for payment methods other than the one selected
       def object_params
-        # respond_to check is necessary due to issue described in #2910
+        # has_checkout_step? check is necessary due to issue described in #2910
         if @order.has_checkout_step?("payment") && @order.payment?
           if params[:payment_source].present?
             source_params = params.delete(:payment_source)[params[:order][:payments_attributes].first[:payment_method_id].underscore]


### PR DESCRIPTION
respond_to? isn't used on master any more and refers to older code
