### PR TITLE
moves checkout steps javascript into specific methods

### DIFF
--- a/frontend/app/assets/javascripts/store/checkout/address.js.coffee
+++ b/frontend/app/assets/javascripts/store/checkout/address.js.coffee
@@ -1,4 +1,4 @@
-Spree.ready ($) ->
+Spree.onAddress = () ->
   if ($ '#checkout_form_address').is('*')
     ($ '#checkout_form_address').validate()
 
@@ -76,5 +76,8 @@ Spree.ready ($) ->
         ($ '#shipping .inner').show()
         ($ '#shipping .inner input, #shipping .inner select').prop 'disabled', false
         Spree.updateState('s')
-    
+
     update_shipping_form_state order_use_billing
+
+Spree.ready ($) ->
+  Spree.onAddress()

--- a/frontend/app/assets/javascripts/store/checkout/payment.js.coffee
+++ b/frontend/app/assets/javascripts/store/checkout/payment.js.coffee
@@ -1,6 +1,6 @@
-Spree.ready ($) ->
+Spree.onPayment = () ->
   if ($ '#checkout_form_payment').is('*')
-  
+
     $(".cardNumber").payment('formatCardNumber')
     $(".cardExpiry").payment('formatCardExpiry')
     $(".cardCode").payment('formatCardCVC')
@@ -38,7 +38,7 @@ Spree.ready ($) ->
           coupon_status = $("#coupon_status")
 
         url = Spree.url(Spree.routes.apply_coupon_code(Spree.current_order_id),
-          { 
+          {
             order_token: Spree.current_order_token,
             coupon_code: coupon_code
           }
@@ -59,5 +59,6 @@ Spree.ready ($) ->
             $('.continue').attr('disabled', false)
             return false
         })
-        
 
+Spree.ready ($) ->
+  Spree.onPayment()


### PR DESCRIPTION
I'm trying to implement one step checkout with Spree. Everything is quite smooth but when I update with Ajax some steps I should need to call specific javascript methods on newly rendered DOM elements. With this PR it's possible to directly call Spree.onAddress() and Spree.onPayment() when needed.
