### PR TITLE
LineItemsController uses OrderContents to update and destroy line items

### DIFF
--- a/api/app/controllers/spree/api/line_items_controller.rb
+++ b/api/app/controllers/spree/api/line_items_controller.rb
@@ -15,8 +15,9 @@ module Spree
 
       def update
         @line_item = order.line_items.find(params[:id])
-        if @line_item.update_attributes(line_item_params)
+        if @order.contents.update_cart(line_items_attributes)
           @order.ensure_updated_shipments
+          @line_item.reload
           respond_with(@line_item, default_template: :show)
         else
           invalid_resource!(@line_item)
@@ -25,7 +26,8 @@ module Spree
 
       def destroy
         @line_item = order.line_items.find(params[:id])
-        @line_item.destroy
+        variant = Spree::Variant.find(@line_item.variant_id)
+        @order.contents.remove(variant, @line_item.quantity)
         respond_with(@line_item, status: 204)
       end
 
@@ -34,6 +36,13 @@ module Spree
         def order
           @order ||= Spree::Order.find_by!(number: params[:order_id])
           authorize! :update, @order, params[:order_token]
+        end
+
+        def line_items_attributes
+          { line_items_attributes: {
+            id: params[:id],
+            quantity: params[:line_item][:quantity]
+          } }
         end
 
         def line_item_params

--- a/api/spec/controllers/spree/api/line_items_controller_spec.rb
+++ b/api/spec/controllers/spree/api/line_items_controller_spec.rb
@@ -54,15 +54,20 @@ module Spree
 
       it "can update a line item on the order" do
         line_item = order.line_items.first
-        api_put :update, :id => line_item.id, :line_item => { :quantity => 1000 }
+        api_put :update, :id => line_item.id, :line_item => { :quantity => 101 }
         response.status.should == 200
+        order.reload
+        order.total.should == 1050 # 50 original due to factory, + 1000 in this test
         json_response.should have_attributes(attributes)
+        json_response["quantity"].should == 101
       end
 
       it "can delete a line item on the order" do
         line_item = order.line_items.first
         api_delete :destroy, :id => line_item.id
         response.status.should == 204
+        order.reload
+        order.line_items.count.should == 4 # 5 original due to factory, - 1 in this test
         lambda { line_item.reload }.should raise_error(ActiveRecord::RecordNotFound)
       end
 

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -8,7 +8,7 @@ module Spree
 
     def add(variant, quantity = 1, currency = nil, shipment = nil)
       line_item = add_to_line_item(variant, quantity, currency, shipment)
-      order_updater.update_item_total
+      reload_totals
       PromotionHandler::Cart.new(order, line_item).activate
       ItemAdjustments.new(line_item).update
       reload_totals
@@ -17,6 +17,8 @@ module Spree
 
     def remove(variant, quantity = 1, shipment = nil)
       line_item = remove_from_line_item(variant, quantity, shipment)
+      reload_totals
+      PromotionHandler::Cart.new(order, line_item).activate
       ItemAdjustments.new(line_item).update
       reload_totals
       line_item
@@ -27,7 +29,7 @@ module Spree
         order.line_items = order.line_items.select {|li| li.quantity > 0 }
         # Update totals, then check if the order is eligible for any cart promotions.
         # If we do not update first, then the item total will be wrong and ItemTotal
-        # promotion rules would not be triggered. 
+        # promotion rules would not be triggered.
         reload_totals
         PromotionHandler::Cart.new(order).activate
         order.ensure_updated_shipments

--- a/core/app/models/spree/promotion_handler/cart.rb
+++ b/core/app/models/spree/promotion_handler/cart.rb
@@ -22,7 +22,7 @@ module Spree
 
       def activate
         promotions.each do |promotion|
-          if promotion.eligible?(line_item) || promotion.eligible?(order)
+          if (line_item && promotion.eligible?(line_item)) || promotion.eligible?(order)
             promotion.activate(line_item: line_item, order: order)
           end
         end


### PR DESCRIPTION
If the line item was updated or deleted before, the order total and adjustments remained the same.
This change fixes the problem as the controller uses `OrderContents` in `update` and `#destroy` now, same as `create`.
