### PR TITLE
Added wrap_params to BaseController, to make API work with Backbone

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -4,6 +4,7 @@ module Spree
   module Api
     class BaseController < ActionController::Metal
       include ActionController::StrongParameters
+      include ActionController::ParamsWrapper
       include Spree::Api::ControllerSetup
       include Spree::Core::ControllerHelpers::SSL
       include Spree::Core::ControllerHelpers::StrongParameters
@@ -22,6 +23,8 @@ module Spree
       rescue_from ActiveRecord::RecordNotFound, :with => :not_found
 
       helper Spree::Api::ApiHelpers
+
+      wrap_parameters format: :json
 
       ssl_allowed
 


### PR DESCRIPTION
I am not sure about it, as you use `paramRoot` in [spree-marionette](https://github.com/radar/spree-marionette/blob/master/app/assets/javascripts/spree/models/line_items.js#L14).
But for me `wrap_params` shouldn't affect anything, and for me it's more convenient to add it.
