### PR TITLE
Use correct namespace for 'payment_method_not_supported' translation in ...

### DIFF
--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -13,7 +13,7 @@ module Spree
                 end
               else
                 invalidate!
-                raise Core::GatewayError.new(I18n.t(:payment_method_not_supported))
+                raise Core::GatewayError.new(Spree.t(:payment_method_not_supported))
               end
             end
           else


### PR DESCRIPTION
...payment/processing.rb

Couldn't find the original PR so I'm re-submitting this to 2-0-stable

fixes #3934 
