### PR TITLE
Bugfix: the product page was not displaying properly the variants check ...

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -133,7 +133,7 @@ module Spree
     end
 
     def display_price(product_or_variant)
-      product_or_variant.price_in(current_currency).display_price.to_html
+      product_or_variant.price_in(current_currency).display_price
     end
 
     def pretty_time(time)


### PR DESCRIPTION
The product page was not displaying properly the variants check boxes because the call to the display_price method (inside views/spree/products/_cart_form.html.erb ) was producing broken html code.

What's the sense of calling to_html to create the <span> attribute when it's created internally for the purpose of defining the value of <data-price> ?
