### PR TITLE
Fix input padding on number fields

### DIFF
--- a/frontend/app/assets/stylesheets/store/screen.css.scss
+++ b/frontend/app/assets/stylesheets/store/screen.css.scss
@@ -151,7 +151,7 @@ span.required {
 fieldset {
   margin: 0;
   min-width: 100%;
-  
+
   -webkit-box-sizing: border-box;
      -moz-box-sizing: border-box;
           box-sizing: border-box;
@@ -738,7 +738,7 @@ ul#products {
 
 #billing {
   input[type="text"], input[type="email"],
-  input[type="tel"], input[type="number"], 
+  input[type="tel"], input[type="number"],
   select, textarea {
     width: 100%;
   }

--- a/frontend/app/assets/stylesheets/store/screen.css.scss
+++ b/frontend/app/assets/stylesheets/store/screen.css.scss
@@ -113,7 +113,7 @@ input[type="password"], input[type="search"], input[type="tel"],
 input[type="text"], input[type="time"], input[type="url"],
 input[type="week"] {
   border: $default_border;
-  padding: 5px 10px;
+  padding: 5px;
   font-family: $ff_base;
   font-size: $input_box_font_size;
 


### PR DESCRIPTION
This branch fixes the input padding on number fields. Without this fix the number field, in particular the quantity field is truncated:

![truncated](https://f.cloud.github.com/assets/133/1480219/507e14f4-46a2-11e3-90ba-343e90953071.png)

With this fix the number field appears as you would expect:

![normal](https://f.cloud.github.com/assets/133/1480220/5c3c19a8-46a2-11e3-99cd-c279aa9e6ee1.png)
