### PR TITLE
Update _delivery.html.erb to enforce space between shipping method name ...

### DIFF
--- a/core/app/views/spree/checkout/_delivery.html.erb
+++ b/core/app/views/spree/checkout/_delivery.html.erb
@@ -6,7 +6,7 @@
         <% @order.rate_hash.each do |shipping_method| %>
           <label>
             <%= radio_button(:order, :shipping_method_id, shipping_method[:id]) %>
-            <%= shipping_method.name %> <%= shipping_method.display_price.to_html %>
+            <%= shipping_method.name %>&nbsp;<%= shipping_method.display_price.to_html %>
           </label>
         <% end %>
       </p>


### PR DESCRIPTION
...and price

My `1-3-stable` site was showing the Shipping Method name and price running together - for some reason the space here wasn't registering. Converting it to a non-breaking space seemed to work, and so just to be certain about the desired behavior, I'd propose making it `&nbsp;` in Spree itself, in case there are other people encountering the same issue.
