### PR TITLE
refactor some checkout module methods

### DIFF
--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -181,7 +181,7 @@ module Spree
           end
 
           def has_checkout_step?(step)
-            step.present? ? self.checkout_steps.include?(step) : false
+            step.present? && self.checkout_steps.include?(step)
           end
 
           def checkout_step_index(step)
@@ -193,7 +193,7 @@ module Spree
           end
 
           def can_go_to_state?(state)
-            return false unless self.state.present? && has_checkout_step?(state) && has_checkout_step?(self.state)
+            return false unless has_checkout_step?(self.state) && has_checkout_step?(state)
             checkout_step_index(state) > checkout_step_index(self.state)
           end
         end


### PR DESCRIPTION
I noticed those methods (written by me some time ago) can be refactored. The first one is a simple improvement, the second one does an extra check since `self.state.present?` is already checked into `has_checkout_step?(self.state)` method called immediately after.
