### PR TITLE
always_include_confirm_step preference seems broken

### DIFF
--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -53,6 +53,28 @@ describe "Checkout", inaccessible: true do
         page.should have_content("Shipping total $10.00")
       end
     end
+
+    #regression test for #3945
+    context "when Spree::Config[:always_include_confirm_step] is true" do
+      before do
+        Spree::Config[:always_include_confirm_step] = true
+        # Spree::Order.any_instance.stub :confirmation_required? => true
+      end
+
+      it "displays confirmation step", :js => true do
+        add_mug_to_cart
+        click_button "Checkout"
+
+        fill_in "order_email", :with => "ryan@spreecommerce.com"
+        fill_in_address
+
+        click_button "Save and Continue"
+        click_button "Save and Continue"
+        click_button "Save and Continue"
+
+        page.should have_content("Place Order")
+      end
+    end
   end
 
   #regression test for #2694


### PR DESCRIPTION
On a clean Spree 2.1.2 store I'm not able to have `always_include_confirm_step` preference working. 

Despite if I call `confirmation_required?` on the order it returns true, the confirmation step is not shown. 

I wrote a small failing test (on master branch) into spec/features/frontend/checkout_spec.rb which reproduces the issue:

``` ruby
context "when Spree::Config[:always_include_confirm_step] is true" do
  before do
    Spree::Config[:always_include_confirm_step] = true
    # The following line doesn't help neither
    # Spree::Order.any_instance.stub :confirmation_required? => true
  end

  it "displays confirmation step", :js => true do
    add_mug_to_cart
    click_button "Checkout"

    fill_in "order_email", :with => "test@spreecommerce.com"
    fill_in_address

    click_button "Save and Continue" # delivery
    click_button "Save and Continue" # payment
    page.should have_content("Place Order") # fails here
  end
```
