### PR TITLE
Tax Categories for Product Variants

### DIFF
--- a/backend/app/controllers/spree/admin/variants_controller.rb
+++ b/backend/app/controllers/spree/admin/variants_controller.rb
@@ -3,6 +3,7 @@ module Spree
     class VariantsController < ResourceController
       belongs_to 'spree/product', :find_by => :permalink
       new_action.before :new_before
+      before_filter :load_data, :only => [:new, :create, :edit, :update]
 
       # override the destory method to set deleted_at value
       # instead of actually deleting the product.
@@ -37,6 +38,11 @@ module Spree
             @collection ||= Variant.where(:product_id => parent.id).deleted
           end
           @collection
+        end
+
+      private
+        def load_data
+          @tax_categories = TaxCategory.order(:name)
         end
     end
   end

--- a/backend/app/views/spree/admin/variants/_form.html.erb
+++ b/backend/app/views/spree/admin/variants/_form.html.erb
@@ -22,6 +22,11 @@
       <%= f.label :cost_price, Spree.t(:cost_price) %>
       <%= f.text_field :cost_price, :value => number_to_currency(@variant.cost_price, :unit => ''), :class => 'fullwidth' %>
     </div>
+
+    <div class="field" data-hook="tax_category">
+      <%= f.label :tax_category_id, Spree.t(:tax_category) %>
+      <%= f.collection_select(:tax_category_id, @tax_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2 fullwidth' }) %>
+    </div>
   </div>
 </div>
 

--- a/backend/spec/features/admin/products/variant_spec.rb
+++ b/backend/spec/features/admin/products/variant_spec.rb
@@ -23,6 +23,7 @@ describe "Variants" do
       find('input#variant_height').value.should == "3.00"
       find('input#variant_width').value.should == "1.00"
       find('input#variant_depth').value.should == "1.50"
+      expect(page).to have_select('variant[tax_category_id]')
     end
   end
 

--- a/backend/spec/features/admin/products/variant_spec.rb
+++ b/backend/spec/features/admin/products/variant_spec.rb
@@ -17,12 +17,12 @@ describe "Variants" do
       within_row(1) { click_icon :edit }
       click_link "Variants"
       click_on "New Variant"
-      find('input#variant_price').value.should == "1.99"
-      find('input#variant_cost_price').value.should == "1.00"
-      find('input#variant_weight').value.should == "2.50"
-      find('input#variant_height').value.should == "3.00"
-      find('input#variant_width').value.should == "1.00"
-      find('input#variant_depth').value.should == "1.50"
+      expect(find('input#variant_price').value).to eq("1.99")
+      expect(find('input#variant_cost_price').value).to eq("1.00")
+      expect(find('input#variant_weight').value).to eq("2.50")
+      expect(find('input#variant_height').value).to eq("3.00")
+      expect(find('input#variant_width').value).to eq("1.00")
+      expect(find('input#variant_depth').value).to eq("1.50")
       expect(page).to have_select('variant[tax_category_id]')
     end
   end

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -40,7 +40,7 @@ module Spree
 
     def copy_tax_category
       if variant
-        self.tax_category = variant.product.tax_category
+        self.tax_category = variant.tax_category
       end
     end
 

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -3,10 +3,11 @@ module Spree
     acts_as_paranoid
 
     belongs_to :product, touch: true, class_name: 'Spree::Product'
+    belongs_to :tax_category, class_name: 'Spree::TaxCategory'
 
     delegate_belongs_to :product, :name, :description, :permalink, :available_on,
-                        :tax_category_id, :shipping_category_id, :meta_description,
-                        :meta_keywords, :tax_category, :shipping_category
+                        :shipping_category_id, :meta_description, :meta_keywords,
+                        :shipping_category
 
     has_many :inventory_units
     has_many :line_items
@@ -44,6 +45,14 @@ module Spree
 
     def self.active(currency = nil)
       joins(:prices).where(deleted_at: nil).where('spree_prices.currency' => currency || Spree::Config[:currency]).where('spree_prices.amount IS NOT NULL')
+    end
+
+    def tax_category
+      if self[:tax_category_id].nil?
+        product.tax_category
+      else
+        TaxCategory.find(self[:tax_category_id])
+      end
     end
 
     def cost_price=(price)

--- a/core/db/migrate/20131107132123_add_tax_category_to_variants.rb
+++ b/core/db/migrate/20131107132123_add_tax_category_to_variants.rb
@@ -1,0 +1,6 @@
+class AddTaxCategoryToVariants < ActiveRecord::Migration
+  def change
+    add_column :spree_variants, :tax_category_id, :integer
+    add_index  :spree_variants, :tax_category_id
+  end
+end

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -95,7 +95,7 @@ describe Spree::LineItem do
     it "copies over a variant's tax category" do
       line_item.tax_category = nil
       line_item.copy_tax_category
-      line_item.tax_category.should == line_item.variant.product.tax_category
+      expect(line_item.tax_category).to eq(line_item.variant.tax_category)
     end
   end
 

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -344,4 +344,22 @@ describe Spree::Variant do
       expect(variant.total_on_hand).to eq(Spree::Stock::Quantifier.new(variant).total_on_hand)
     end
   end
+
+  describe '#tax_category' do
+    context 'when tax_category is nil' do
+      let(:product) { build(:product) }
+      let(:variant) { build(:variant, product: product, tax_category_id: nil) }
+      it 'returns the parent products tax_category' do
+        expect(variant.tax_category).to eq(product.tax_category)
+      end
+    end
+
+    context 'when tax_category is set' do
+      let(:tax_category) { create(:tax_category) }
+      let(:variant) { build(:variant, tax_category: tax_category) }
+      it 'returns the tax_category set on itself' do
+        expect(variant.tax_category).to eq(tax_category)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Currently you can only set a tax category on a product as a whole, this is largely fine but here in the UK there are a number of occasions when different variants of a product will require different VAT (tax) treatment. An example of this is as follows:

> Children's clothing in UK VAT is zero rated (0% tax) but adults clothing is standard rate (20% tax). A clothing store that sells the same t-shirt design in sizes ranging from children's to adults does not want to make two separate products for the same t-shirt as this would be duplication.

Whilst this might seem a rather specific issue I wanted to suggest this as a non-breaking change as it will fallback to the product tax category if there isn't one on the variant itself so if you do not need to set the tax at the variant level you don't have to.
