### PR TITLE
Support bundle dependency the new money 6.0.0 gem 

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'httparty', '~> 0.11' # For checking alerts.
   s.add_dependency 'json', '~> 1.7'
   s.add_dependency 'kaminari', '~> 0.14.1'
-  s.add_dependency 'money', '>= 5.1.1' # Allows anyone to use money from master. See #2737.
+  s.add_dependency 'money', '~> 5.1.1' # Move this dependency forward
   s.add_dependency 'paperclip', '~> 3.4.1'
   s.add_dependency 'paranoia', '~> 1.3'
   s.add_dependency 'rails', '~> 3.2.14'


### PR DESCRIPTION
Unable to bundle install, this fixes that
