### PR TITLE
Replaced Taxon :position refs with :child_index= [Fixes #3390]

### DIFF
--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -60,7 +60,7 @@ module Spree
       end
 
       def taxon_attributes
-        [:id, :name, :pretty_name, :permalink, :position, :parent_id, :taxonomy_id]
+        [:id, :name, :pretty_name, :permalink, :parent_id, :taxonomy_id]
       end
 
       def inventory_unit_attributes

--- a/api/spec/controllers/spree/api/taxons_controller_spec.rb
+++ b/api/spec/controllers/spree/api/taxons_controller_spec.rb
@@ -7,7 +7,7 @@ module Spree
     let(:taxonomy) { create(:taxonomy) }
     let(:taxon) { create(:taxon, :name => "Ruby", :taxonomy => taxonomy) }
     let(:taxon2) { create(:taxon, :name => "Rails", :taxonomy => taxonomy) }
-    let(:attributes) { ["id", "name", "pretty_name", "permalink", "position", "parent_id", "taxonomy_id"] }
+    let(:attributes) { ["id", "name", "pretty_name", "permalink", "parent_id", "taxonomy_id"] }
 
     before do
       stub_authentication!

--- a/backend/app/assets/javascripts/admin/taxonomy.js.coffee
+++ b/backend/app/assets/javascripts/admin/taxonomy.js.coffee
@@ -30,7 +30,7 @@ handle_create = (e, data) ->
     type: "POST",
     dataType: "json",
     url: base_url.toString(),
-    data: ({"taxon[name]": name, "taxon[parent_id]": new_parent.attr("id"), "taxon[child_index]": position }),
+    data: ({"taxon[name]": name, "taxon[parent_id]": new_parent.attr("id")}),
     error: handle_ajax_error,
     success: (data,result) ->
       node.attr('id', data.id)

--- a/backend/app/assets/javascripts/admin/taxonomy.js.coffee
+++ b/backend/app/assets/javascripts/admin/taxonomy.js.coffee
@@ -14,7 +14,7 @@ handle_move = (e, data) ->
     type: "POST",
     dataType: "json",
     url: url.toString(),
-    data: ({_method: "put", "taxon[parent_id]": new_parent.attr("id"), "taxon[position]": position }),
+    data: ({_method: "put", "taxon[parent_id]": new_parent.attr("id"), "taxon[child_index]": position }),
     error: handle_ajax_error
 
   true
@@ -30,7 +30,7 @@ handle_create = (e, data) ->
     type: "POST",
     dataType: "json",
     url: base_url.toString(),
-    data: ({"taxon[name]": name, "taxon[parent_id]": new_parent.attr("id"), "taxon[position]": position }),
+    data: ({"taxon[name]": name, "taxon[parent_id]": new_parent.attr("id"), "taxon[child_index]": position }),
     error: handle_ajax_error,
     success: (data,result) ->
       node.attr('id', data.id)

--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -8,8 +8,8 @@ module Spree
 
     before_create :set_permalink
 
-    attr_accessible :name, :parent_id, :position, :icon, :description, :permalink, :taxonomy_id,
-                    :meta_description, :meta_keywords, :meta_title
+    attr_accessible :name, :parent_id, :icon, :description, :permalink, :taxonomy_id,
+                    :meta_description, :meta_keywords, :meta_title, :child_index
 
     validates :name, presence: true
 
@@ -19,8 +19,6 @@ module Spree
       url: '/spree/taxons/:id/:style/:basename.:extension',
       path: ':rails_root/public/spree/taxons/:id/:style/:basename.:extension',
       default_url: '/assets/default_taxon.png'
-
-    default_scope order: "#{self.table_name}.position"
 
     include Spree::Core::S3Support
     supports_s3 :icon
@@ -74,5 +72,14 @@ module Spree
       ancestor_chain + "#{name}"
     end
 
+    # awesome_nested_set sorts by :lft and :rgt. This call re-inserts the child
+    # node so that its resulting position matches the observable 0-indexed position.
+    # ** Note ** no :position column needed - a_n_s doesn't handle the reordering if
+    #  you bring your own :order_column.
+    #
+    #  See #3390 for background.
+    def child_index=(idx)
+      move_to_child_with_index(parent, idx.to_i)
+    end
   end
 end

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activemerchant', '1.41.0'
   s.add_dependency 'acts_as_list', '= 0.2.0'
-  s.add_dependency 'awesome_nested_set', '2.1.5'
+  s.add_dependency 'awesome_nested_set', '2.1.6'
   s.add_dependency 'aws-sdk', '1.11.1' # temporarily locked down due to https://github.com/aws/aws-sdk-ruby/issues/273
   s.add_dependency 'cancan', '~> 1.6.10'
   s.add_dependency 'deface', '= 0.9.1'


### PR DESCRIPTION
Taxon position unnecessarily fights against the awesome_nested_set
API. By using a_n_s's :move_to_child_with_index method we can more
fully leverage acts_as_nested_set.

@radar - replaces PR 3955 with a single commit.
