### PR TITLE
Update all adjustment types (2-0-stable)

### DIFF
--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -82,23 +82,17 @@ module Spree
     # delegate updating of amount to their Originator when present, but only if
     # +locked+ is false. Adjustments that are +locked+ will never change their amount.
     #
-    # Adjustments delegate updating of amount to their Originator when present,
-    # but only if when they're in "open" state, closed or finalized adjustments
-    # are not recalculated.
-    #
-    # It receives +calculable+ as the updated source here so calculations can be
-    # performed on the current values of that source. If we used +source+ it 
-    # could load the old record from db for the association. e.g. when updating
-    # more than on line items at once via accepted_nested_attributes the order
-    # object on the association would be in a old state and therefore the
-    # adjustment calculations would not performed on proper values
-    def update!(calculable = nil)
+    # order#update_adjustments passes self as the src, this is so calculations can
+    # be performed on the # current values. If we used source it would load the old
+    # record from db for the association
+    def update!(calculable=nil)
       return if immutable?
       # Fix for #3381
       # If we attempt to call 'source' before the reload, then source is currently
       # the order object. After calling a reload, the source is the Shipment.
       reload
-      originator.update_adjustment(self, calculable || source) if originator.present?
+      calculable = source unless calculable == source
+      originator.update_adjustment(self, calculable) if originator.present?
       set_eligibility
     end
 

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -25,8 +25,7 @@ module Spree
         update_shipment_state
       end
       
-      update_promotion_adjustments
-      update_shipping_adjustments
+      update_adjustments
       # update totals a second time in case updated adjustments have an effect on the total
       update_totals
 
@@ -125,15 +124,9 @@ module Spree
     #
     # Adjustments will check if they are still eligible. Ineligible adjustments
     # are preserved but not counted towards adjustment_total.
-    def update_promotion_adjustments
-      order.adjustments.reload.promotion.each { |adjustment| adjustment.update!(order) }
+    def update_adjustments
+      order.adjustments.reload.each { |adjustment| adjustment.update!(order) }
       choose_best_promotion_adjustment
-    end
-
-    # Shipping adjustments don't receive order on update! because they calculated
-    # over a shipping / package object rather than an order object
-    def update_shipping_adjustments
-      order.adjustments.reload.shipping.each { |adjustment| adjustment.update! }
     end
 
     private

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -167,87 +167,78 @@ module Spree
       updater.update
     end
 
-    context "update adjustments" do
-      context "shipments" do
-        it "updates" do
-          expect(updater).to receive(:update_shipping_adjustments)
-          updater.update
+    context "#update_adjustments" do
+      let(:originator) do
+        originator = Spree::Promotion::Actions::CreateAdjustment.create
+        calculator = Spree::Calculator::PerItem.create({:calculable => originator}, :without_protection => true)
+        originator.calculator = calculator
+        originator.save
+        originator
+      end
+
+      def create_adjustment(label, amount)
+        create(:adjustment, :adjustable => order,
+                            :originator => originator,
+                            :amount     => amount,
+                            :state      => "closed",
+                            :label      => label,
+                            :mandatory  => false)
+      end
+
+      it "should make all but the most valuable promotion adjustment ineligible, leaving non promotion adjustments alone" do
+        create_adjustment("Promotion A", -100)
+        create_adjustment("Promotion B", -200)
+        create_adjustment("Promotion C", -300)
+        create(:adjustment, :adjustable => order,
+                            :originator => nil,
+                            :amount => -500,
+                            :state => "closed",
+                            :label => "Some other credit")
+        order.adjustments.each {|a| a.update_attribute_without_callbacks(:eligible, true)}
+
+        updater.update_adjustments
+
+        order.adjustments.eligible.promotion.count.should == 1
+        order.adjustments.eligible.promotion.first.label.should == 'Promotion C'
+      end
+
+      context "multiple adjustments and the best one is not eligible" do
+        let!(:promo_a) { create_adjustment("Promotion A", -100) }
+        let!(:promo_c) { create_adjustment("Promotion C", -300) }
+
+        before do
+          promo_a.update_attribute_without_callbacks(:eligible, true)
+          promo_c.update_attribute_without_callbacks(:eligible, false)
+        end
+
+        # regression for #3274
+        it "still makes the previous best eligible adjustment valid" do
+          updater.update_adjustments
+          order.adjustments.eligible.promotion.first.label.should == 'Promotion A'
         end
       end
 
-      context "promotions" do
-        let(:originator) do
-          originator = Spree::Promotion::Actions::CreateAdjustment.create
-          calculator = Spree::Calculator::PerItem.create({:calculable => originator}, :without_protection => true)
-          originator.calculator = calculator
-          originator.save
-          originator
-        end
+      it "should only leave one adjustment even if 2 have the same amount" do
+        create_adjustment("Promotion A", -100)
+        create_adjustment("Promotion B", -200)
+        create_adjustment("Promotion C", -200)
 
-        def create_adjustment(label, amount)
-          create(:adjustment, :adjustable => order,
-                              :originator => originator,
-                              :amount     => amount,
-                              :state      => "closed",
-                              :label      => label,
-                              :mandatory  => false)
-        end
+        updater.update_adjustments
 
-        it "should make all but the most valuable promotion adjustment ineligible, leaving non promotion adjustments alone" do
-          create_adjustment("Promotion A", -100)
-          create_adjustment("Promotion B", -200)
-          create_adjustment("Promotion C", -300)
-          create(:adjustment, :adjustable => order,
-                              :originator => nil,
-                              :amount => -500,
-                              :state => "closed",
-                              :label => "Some other credit")
-          order.adjustments.each {|a| a.update_attribute_without_callbacks(:eligible, true)}
+        order.adjustments.eligible.promotion.count.should == 1
+        order.adjustments.eligible.promotion.first.amount.to_i.should == -200
+      end
 
-          updater.update_promotion_adjustments
+      it "should only include eligible adjustments in promo_total" do
+        create_adjustment("Promotion A", -100)
+        create(:adjustment, :adjustable => order,
+                            :originator => nil,
+                            :amount     => -1000,
+                            :state      => "closed",
+                            :eligible   => false,
+                            :label      => 'Bad promo')
 
-          order.adjustments.eligible.promotion.count.should == 1
-          order.adjustments.eligible.promotion.first.label.should == 'Promotion C'
-        end
-
-        context "multiple adjustments and the best one is not eligible" do
-          let!(:promo_a) { create_adjustment("Promotion A", -100) }
-          let!(:promo_c) { create_adjustment("Promotion C", -300) }
-
-          before do
-            promo_a.update_attribute_without_callbacks(:eligible, true)
-            promo_c.update_attribute_without_callbacks(:eligible, false)
-          end
-
-          # regression for #3274
-          it "still makes the previous best eligible adjustment valid" do
-            updater.update_promotion_adjustments
-            order.adjustments.eligible.promotion.first.label.should == 'Promotion A'
-          end
-        end
-
-        it "should only leave one adjustment even if 2 have the same amount" do
-          create_adjustment("Promotion A", -100)
-          create_adjustment("Promotion B", -200)
-          create_adjustment("Promotion C", -200)
-
-          updater.update_promotion_adjustments
-
-          order.adjustments.eligible.promotion.count.should == 1
-          order.adjustments.eligible.promotion.first.amount.to_i.should == -200
-        end
-
-        it "should only include eligible adjustments in promo_total" do
-          create_adjustment("Promotion A", -100)
-          create(:adjustment, :adjustable => order,
-                              :originator => nil,
-                              :amount     => -1000,
-                              :state      => "closed",
-                              :eligible   => false,
-                              :label      => 'Bad promo')
-
-          order.promo_total.to_f.should == -100.to_f
-        end
+        order.promo_total.to_f.should == -100.to_f
       end
     end
   end


### PR DESCRIPTION
In f9ed99a the order updater was changed to update only shipping adjustments and promotion adjustments. This was done so that the in-memory order was used for promotions calculations. This broke some extensions (spree_tax_cloud, spree_gift_card) which expected their custom adjustment types to receive updates.

This goes back to the previous behaviour of updating all adjustments, but uses the in memory order object if it is the adjustment's source.

This is intended for `2-0-stable` only, `2-1-stable` has the same patch in #3961.

cc @huoxito
