### PR TITLE
Order submenu broken for custom roles

### DIFF
--- a/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
+++ b/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
@@ -48,6 +48,10 @@ module Spree
             @order = Order.includes(:adjustments).find_by_number!(params[:order_id])
           end
 
+          def model_class
+            Spree::Order
+          end
+
       end
     end
   end

--- a/backend/app/controllers/spree/admin/payments_controller.rb
+++ b/backend/app/controllers/spree/admin/payments_controller.rb
@@ -101,6 +101,10 @@ module Spree
       def load_payment
         @payment = Payment.find(params[:id])
       end
+
+      def model_class
+        Spree::Payment
+      end
     end
   end
 end

--- a/backend/app/views/spree/admin/shared/_order_submenu.html.erb
+++ b/backend/app/views/spree/admin/shared/_order_submenu.html.erb
@@ -6,7 +6,7 @@
       </li>
     <% end %>
 
-    <% if can? :update, @order && checkout_steps.include?("address") %>
+    <% if can?(:update, @order) && checkout_steps.include?("address") %>
       <li<%== ' class="active"' if current == 'Customer Details' %>>
         <%= link_to_with_icon 'icon-user', Spree.t(:customer_details), admin_order_customer_url(@order) %>
       </li>
@@ -18,7 +18,7 @@
       </li>
     <% end %>
 
-    <% if can? :index, @order.payments && @payment_required %>
+    <% if can?(:index, @order.payments) && @payment_required %>
       <li<%== ' class="active"' if current == 'Payments' %>>
         <%= link_to_with_icon 'icon-credit-card', Spree.t(:payments), admin_order_payments_url(@order) %>
       </li>

--- a/backend/app/views/spree/admin/shared/_order_submenu.html.erb
+++ b/backend/app/views/spree/admin/shared/_order_submenu.html.erb
@@ -12,19 +12,19 @@
       </li>
     <% end %>
 
-    <% if can? :index, @order.adjustments.new %>
+    <% if can? :index, Spree::Adjustment %>
       <li<%== ' class="active"' if current == 'Adjustments' %>>
         <%= link_to_with_icon 'icon-cogs', Spree.t(:adjustments), admin_order_adjustments_url(@order) %>
       </li>
     <% end %>
 
-    <% if can?(:index, @order.payments.new) && @payment_required %>
+    <% if can?(:index, Spree::Payment) && @payment_required %>
       <li<%== ' class="active"' if current == 'Payments' %>>
         <%= link_to_with_icon 'icon-credit-card', Spree.t(:payments), admin_order_payments_url(@order) %>
       </li>
     <% end %>
 
-    <% if can? :index, @order.return_authorizations.new %>
+    <% if can? :index, Spree::ReturnAuthorization %>
       <% if @order.completed? %>
         <li<%== ' class="active"' if current == 'Return Authorizations' %>>
           <%= link_to_with_icon 'icon-share-alt', Spree.t(:return_authorizations), admin_order_return_authorizations_url(@order) %>

--- a/backend/app/views/spree/admin/shared/_order_submenu.html.erb
+++ b/backend/app/views/spree/admin/shared/_order_submenu.html.erb
@@ -12,19 +12,19 @@
       </li>
     <% end %>
 
-    <% if can? :index, @order.adjustments %>
+    <% if can? :index, @order.adjustments.new %>
       <li<%== ' class="active"' if current == 'Adjustments' %>>
         <%= link_to_with_icon 'icon-cogs', Spree.t(:adjustments), admin_order_adjustments_url(@order) %>
       </li>
     <% end %>
 
-    <% if can?(:index, @order.payments) && @payment_required %>
+    <% if can?(:index, @order.payments.new) && @payment_required %>
       <li<%== ' class="active"' if current == 'Payments' %>>
         <%= link_to_with_icon 'icon-credit-card', Spree.t(:payments), admin_order_payments_url(@order) %>
       </li>
     <% end %>
 
-    <% if can? :index, @order.return_authorizations %>
+    <% if can? :index, @order.return_authorizations.new %>
       <% if @order.completed? %>
         <li<%== ' class="active"' if current == 'Return Authorizations' %>>
           <%= link_to_with_icon 'icon-share-alt', Spree.t(:return_authorizations), admin_order_return_authorizations_url(@order) %>


### PR DESCRIPTION
There are 2 issues with the ability checks on the order submenu when using custom roles:
- Conditions using `&&` are not working as expected (`&&` operator takes precedence over `can?` method call)
- `can?` calls are not following cancan conventions of passing a model instance or class.

These fixes allow a custom ability class like the following to work as expected:

``` ruby
module Spree
  class ShopkeeperAbility
    include CanCan::Ability

    def initialize(user)
      user ||= Spree.user_class.new

      if user.respond_to?(:has_spree_role?) && user.has_spree_role?('shopkeeper')
        can :manage, Spree::Order
        can :manage, Spree::Adjustment
        can :manage, Spree::Payment
        can :manage, Spree::ReturnAuthorization
      end

    end
  end
end
```
