### PR TITLE
Backorder shipping in admin system not working

### DIFF
--- a/backend/spec/features/admin/orders/new_order_spec.rb
+++ b/backend/spec/features/admin/orders/new_order_spec.rb
@@ -73,4 +73,50 @@ describe "New Order" do
     targetted_select2_search state.name, :from => "#s2id_order_#{kind}_address_attributes_state_id"
     fill_in "Phone",                   :with => "123-456-7890"
   end
+
+  describe "with inventory tracking off" do
+    before(:each) do
+      Spree::Config[:track_inventory_levels] = false
+    end
+
+    after do
+      Spree::Config[:track_inventory_levels] = true
+    end
+
+    let!(:stock_item) { product.master.stock_items.first.adjust_count_on_hand(-10) }
+
+    # I think this spec should fail - we want the product to be backordered, but
+    # it shows up in the order as "on hand"...so we're not really testing what we want
+    # here.
+    it "should complete a new order successfully", js: true do
+
+      select2_search product.name, :from => Spree.t(:name_or_sku)
+      click_icon :plus
+      click_on "Customer Details"
+
+      within "#select-customer" do
+        targetted_select2_search user.email, :from => "#s2id_customer_search"
+      end
+
+      check "order_use_billing"
+      fill_in_address
+      click_on "Update"
+
+      click_on "Payments"
+      click_on "Update"
+
+      expect(current_path).to eql(spree.edit_admin_order_path(Spree::Order.last))
+
+      click_on "Payments"
+      click_icon "capture"
+
+      click_on "Order Details"
+      click_on "ship"
+      wait_for_ajax
+
+      page.should have_content("shipped")
+    end
+
+  end
+
 end

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -204,7 +204,7 @@ module Spree
     def determine_state(order)
       return 'canceled' if order.canceled?
       return 'pending' unless order.can_ship?
-      return 'pending' if inventory_units.any? &:backordered?
+      return 'pending' if (!Spree::Config[:allow_backorder_shipping] && inventory_units.any?(&:backordered?))
       return 'shipped' if state == 'shipped'
       order.paid? ? 'ready' : 'pending'
     end


### PR DESCRIPTION
For a store that doesn't track inventory at all, we set the following in our initialization:

```
config.track_inventory_levels = false
config.allow_backorder_shipping = true
```

Now, in this scenario:
1. Make an order through the regular end-user checkout process
2. In admin, add an item to the order.  This item shows up as backordered.
3. Add a payment so the revised order is paid, and should be ready to ship
4. Can't ship the order - there's no "ship" button.

This PR edits the way the shipment state is calculated, by not leaving it in "pending" state because of backordered inventory units if we allow backordered orders to ship.

That said - I'm sure there's a better way to do this.  Ideally, adding an item in the admin system would always show it as "on-hand" if we're not tracking inventory.  After a little checking, though, it wasn't obvious to me how to accomplish that...
