### PR TITLE
Allow inventory tracking control (enable/disable) at the variant level.

### DIFF
--- a/backend/app/assets/javascripts/admin/variant_management.js.coffee
+++ b/backend/app/assets/javascripts/admin/variant_management.js.coffee
@@ -1,0 +1,10 @@
+jQuery ->
+  $('.track_inventory_checkbox').on 'click', ->
+    $(@).siblings('.variant_track_inventory').val($(@).is(':checked'))
+    $(@).parent('form').submit()
+  $('.toggle_variant_track_inventory').on 'submit', ->
+    $.ajax
+      type: @method
+      url: @action
+      data: $(@).serialize()
+    false

--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -121,6 +121,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
     end
 
     def model_class
+      return "Spree::#{self.class.superclass.controller_name.classify}".constantize unless Spree.const_defined?(controller_name.classify)
       "Spree::#{controller_name.classify}".constantize
     end
 
@@ -129,7 +130,8 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
     end
 
     def object_name
-      controller_name.singularize
+      return controller_name.singularize if Spree.const_defined?(controller_name.classify)
+      self.class.superclass.controller_name.singularize
     end
 
     def load_resource

--- a/backend/app/controllers/spree/admin/variants_including_master_controller.rb
+++ b/backend/app/controllers/spree/admin/variants_including_master_controller.rb
@@ -1,0 +1,6 @@
+module Spree
+  module Admin
+    class VariantsIncludingMasterController < VariantsController
+    end
+  end
+end

--- a/backend/app/views/spree/admin/products/stock.html.erb
+++ b/backend/app/views/spree/admin/products/stock.html.erb
@@ -33,6 +33,15 @@
             <% if variant.images.present? %>
               <%= image_tag variant.images.first.attachment.url(:mini) %>
             <% end %>
+            <br/>
+            <%= form_tag admin_product_variants_including_master_path(@product, variant, format: :js), method: :put, class: 'toggle_variant_track_inventory' do %>
+                <%= check_box_tag 'track_inventory', 1, variant.track_inventory?,
+                                  class: 'track_inventory_checkbox' %>
+                <%= Spree.t(:track_inventory) %>
+                <%= hidden_field_tag 'variant[track_inventory]', variant.track_inventory?,
+                    class: 'variant_track_inventory',
+                    id: "variant_track_inventory_#{variant.id}" %>
+            <% end %>
           </td>
           <td colspan="4" class="stock_location_info">
             <table>

--- a/backend/app/views/spree/admin/variants/update.js.erb
+++ b/backend/app/views/spree/admin/variants/update.js.erb
@@ -1,0 +1,1 @@
+<%= @object.as_json %>

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -42,6 +42,7 @@ Spree::Core::Engine.routes.draw do
           post :update_positions
         end
       end
+      resources :variants_including_master, :only => [:update]
     end
 
     get '/variants/search', :to => "variants#search", :as => :search_variants

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -27,7 +27,7 @@ module Spree
     after_save :update_order
     after_destroy :update_order
 
-    delegate :name, :description, to: :variant
+    delegate :name, :description, :should_track_inventory?, to: :variant
 
     attr_accessor :target_shipment
 

--- a/core/app/models/spree/order_inventory.rb
+++ b/core/app/models/spree/order_inventory.rb
@@ -65,7 +65,7 @@ module Spree
     end
 
     def add_to_shipment(shipment, variant, quantity)
-      if Config.track_inventory_levels
+      if variant.should_track_inventory?
         on_hand, back_order = shipment.stock_location.fill_status(variant, quantity)
 
         on_hand.times { shipment.set_up_inventory('on_hand', variant, order) }

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -220,10 +220,10 @@ module Spree
     end
 
     def total_on_hand
-      if Spree::Config.track_inventory_levels
-        self.stock_items.sum(&:count_on_hand)
-      else
+      if self.variants_including_master.any? { |v| !v.should_track_inventory? }
         Float::INFINITY
+      else
+        self.stock_items.sum(&:count_on_hand)
       end
     end
 

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -166,8 +166,8 @@ module Spree
     end
 
     def line_items
-      if order.complete? and Spree::Config[:track_inventory_levels]
-        order.line_items.select { |li| inventory_units.pluck(:variant_id).include?(li.variant_id) }
+      if order.complete? and Spree::Config.track_inventory_levels
+        order.line_items.select { |li| !li.should_track_inventory? || inventory_units.pluck(:variant_id).include?(li.variant_id) }
       else
         order.line_items
       end

--- a/core/app/models/spree/stock/packer.rb
+++ b/core/app/models/spree/stock/packer.rb
@@ -20,7 +20,7 @@ module Spree
       def default_package
         package = Package.new(stock_location, order)
         order.line_items.each do |line_item|
-          if Config.track_inventory_levels
+          if line_item.should_track_inventory?
             next unless stock_location.stock_item(line_item.variant)
 
             on_hand, backordered = stock_location.fill_status(line_item.variant, line_item.quantity)

--- a/core/app/models/spree/stock/quantifier.rb
+++ b/core/app/models/spree/stock/quantifier.rb
@@ -4,12 +4,12 @@ module Spree
       attr_reader :stock_items
 
       def initialize(variant)
-        @variant = variant
+        @variant = resolve_variant_id(variant)
         @stock_items = Spree::StockItem.joins(:stock_location).where(:variant_id => @variant, Spree::StockLocation.table_name =>{ :active => true})
       end
 
       def total_on_hand
-        if Spree::Config.track_inventory_levels
+        if @variant.should_track_inventory?
           stock_items.sum(:count_on_hand)
         else
           Float::INFINITY
@@ -23,6 +23,15 @@ module Spree
       def can_supply?(required)
         total_on_hand >= required || backorderable?
       end
+
+      private
+
+      # return variant when passed either variant object or variant id
+      def resolve_variant_id(variant)
+        variant = Spree::Variant.find_by_id(variant) unless variant.respond_to?(:should_track_inventory?)
+        variant
+      end
+
     end
   end
 end

--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -11,7 +11,7 @@ module Spree
 
     attr_accessible :count_on_hand, :variant, :stock_location, :backorderable, :variant_id
 
-    delegate :weight, to: :variant
+    delegate :weight, :should_track_inventory?, to: :variant
 
     def backordered_inventory_units
       Spree::InventoryUnit.backordered_for_stock_item(self)

--- a/core/app/models/spree/stock_movement.rb
+++ b/core/app/models/spree/stock_movement.rb
@@ -17,10 +17,12 @@ module Spree
     end
 
     private
+
     def update_stock_item_quantity
-      return unless Spree::Config[:track_inventory_levels]
+      return unless self.stock_item.should_track_inventory?
       stock_item.adjust_count_on_hand quantity
     end
+
   end
 end
 

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -11,7 +11,7 @@ module Spree
     attr_accessible :name, :presentation, :cost_price, :lock_version,
                     :position, :option_value_ids,
                     :product_id, :option_values_attributes, :price,
-                    :weight, :height, :width, :depth, :sku, :cost_currency
+                    :weight, :height, :width, :depth, :sku, :cost_currency, :track_inventory
 
     has_many :inventory_units
     has_many :line_items
@@ -144,6 +144,12 @@ module Spree
     # This is a stopgap for that little problem.
     def product
       Spree::Product.unscoped { super }
+    end
+
+    # Shortcut method to determine if inventory tracking is enabled for this variant
+    # This considers both variant tracking flag and site-wide inventory tracking settings
+    def should_track_inventory?
+      self.track_inventory? && Spree::Config.track_inventory_levels
     end
 
     private

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1052,6 +1052,7 @@ en:
     time: Time
     to_add_variants_you_must_first_define: To add variants, you must first define
     total: Total
+    track_inventory: Track Inventory
     tracking: Tracking
     tracking_number: Tracking Number
     tracking_url: Tracking URL

--- a/core/db/migrate/20131026154747_add_track_inventory_to_variant.rb
+++ b/core/db/migrate/20131026154747_add_track_inventory_to_variant.rb
@@ -1,0 +1,5 @@
+class AddTrackInventoryToVariant < ActiveRecord::Migration
+  def change
+    add_column :spree_variants, :track_inventory, :boolean, :default => true
+  end
+end

--- a/core/lib/spree/testing_support/factories/product_factory.rb
+++ b/core/lib/spree/testing_support/factories/product_factory.rb
@@ -12,6 +12,10 @@ FactoryGirl.define do
     # ensure stock item will be created for this products master
     before(:create) { create(:stock_location) if Spree::StockLocation.count == 0 }
 
+    after(:create) do |p|
+      p.variants_including_master.each { |v| v.save! }
+    end
+
     factory :custom_product do
       name 'Custom Product'
       price 17.99

--- a/core/lib/spree/testing_support/factories/variant_factory.rb
+++ b/core/lib/spree/testing_support/factories/variant_factory.rb
@@ -9,6 +9,8 @@ FactoryGirl.define do
     height { generate(:random_float) }
     width  { generate(:random_float) }
     depth  { generate(:random_float) }
+    is_master 0
+    track_inventory true
 
     product { |p| p.association(:base_product) }
     option_values { [create(:option_value)] }
@@ -20,5 +22,18 @@ FactoryGirl.define do
       # on_hand 5
       product { |p| p.association(:product) }
     end
+
+    factory :master_variant do
+      is_master 1
+    end
+
+    factory :on_demand_variant do
+      track_inventory false
+
+      factory :on_demand_master_variant do
+        is_master 1
+      end
+    end
+
   end
 end

--- a/core/spec/models/spree/order_inventory_spec.rb
+++ b/core/spec/models/spree/order_inventory_spec.rb
@@ -65,6 +65,21 @@ describe Spree::OrderInventory do
       end
     end
 
+    context "variant doesnt track inventory" do
+      before { variant.track_inventory = false }
+
+      it "creates only on hand inventory units" do
+        variant.stock_items.destroy_all
+
+        line_item = order.contents.add variant, 1
+        subject.verify(line_item, shipment)
+
+        units = shipment.inventory_units_for(line_item.variant)
+        expect(units.count).to eq 1
+        expect(units.first).to be_on_hand
+      end
+    end
+
     it 'should create stock_movement' do
       subject.send(:add_to_shipment, shipment, variant, 5).should == 5
 

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -505,7 +505,12 @@ describe Spree::Product do
   describe '#total_on_hand' do
     it 'should be infinite if track_inventory_levels is false' do
       Spree::Config[:track_inventory_levels] = false
-      build(:product).total_on_hand.should eql(Float::INFINITY)
+      build(:product, :variants_including_master => [build(:master_variant)]).total_on_hand.should eql(Float::INFINITY)
+    end
+
+    it 'should be infinite if variant is on demand' do
+      Spree::Config[:track_inventory_levels] = true
+      build(:product, :variants_including_master => [build(:on_demand_master_variant)]).total_on_hand.should eql(Float::INFINITY)
     end
 
     it 'should return master variants quantity' do

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -225,6 +225,26 @@ describe Spree::Shipment do
     end
   end
 
+  context "when variant inventory tracking is false" do
+    it "should include line items without inventory if variant inventory tracking is off" do
+      line_items = [mock_model(Spree::LineItem)]
+      line_items.each { |li| li.stub should_track_inventory?: false }
+      order.stub complete?: true
+      order.stub line_items: line_items
+      shipment.line_items.should == line_items
+    end
+
+    it "should not include line items without inventory if variant inventory tracking is on" do
+      line_items = [mock_model(Spree::LineItem)]
+      line_items.each { |li| li.stub should_track_inventory?: true }
+      order.stub complete?: true
+      order.stub line_items: line_items
+      shipment.line_items.should == []
+    end
+  end
+
+
+
   context "when order is completed" do
     after { Spree::Config.set track_inventory_levels: true }
 

--- a/core/spec/models/spree/stock/quantifier_spec.rb
+++ b/core/spec/models/spree/stock/quantifier_spec.rb
@@ -35,6 +35,14 @@ module Spree
           it_should_behave_like 'unlimited supply'
         end
 
+        context 'when variant inventory tracking is off' do
+          before { stock_item.variant.track_inventory = false }
+
+          specify { subject.total_on_hand.should == Float::INFINITY }
+
+          it_should_behave_like 'unlimited supply'
+        end
+
         context 'when stock item allows backordering' do
 
           specify { subject.backorderable?.should be_true }

--- a/core/spec/models/spree/stock_movement_spec.rb
+++ b/core/spec/models/spree/stock_movement_spec.rb
@@ -24,6 +24,14 @@ describe Spree::StockMovement do
     stock_item.count_on_hand.should == 10
   end
 
+  it 'does not update count on hand when variant inventory tracking is off' do
+    stock_item.variant.track_inventory = false
+    subject.quantity = 1
+    subject.save
+    stock_item.reload
+    stock_item.count_on_hand.should == 10
+  end
+
   context "when quantity is negative" do
     context "after save" do
       it "should decrement the stock item count on hand" do

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -344,4 +344,27 @@ describe Spree::Variant do
       expect(variant.total_on_hand).to eq(Spree::Stock::Quantifier.new(variant).total_on_hand)
     end
   end
+
+  describe "#should_track_inventory?" do
+
+    it 'should not track inventory when global setting is off' do
+      Spree::Config[:track_inventory_levels] = false
+
+      build(:variant).should_track_inventory?.should eq(false)
+    end
+
+    it 'should not track inventory when variant is turned off' do
+      Spree::Config[:track_inventory_levels] = true
+
+      build(:on_demand_variant).should_track_inventory?.should eq(false)
+    end
+
+    it 'should track inventory when global and variant are on' do
+      Spree::Config[:track_inventory_levels] = true
+
+      build(:variant).should_track_inventory?.should eq(true)
+    end
+
+  end
+
 end


### PR DESCRIPTION
This retains the site-wide inventory tracking flag, but also allows this type of control down at the variant level.
