### PR TITLE
avoid blank fields on stock management when variant has no SKU

### DIFF
--- a/backend/app/controllers/spree/admin/images_controller.rb
+++ b/backend/app/controllers/spree/admin/images_controller.rb
@@ -19,7 +19,7 @@ module Spree
         def load_data
           @product = Product.find_by_permalink(params[:product_id])
           @variants = @product.variants.collect do |variant|
-            [variant.options_text, variant.id]
+            [variant.sku_and_options_text, variant.id]
           end
           @variants.insert(0, [Spree.t(:all), @product.master.id])
         end

--- a/backend/app/helpers/spree/admin/images_helper.rb
+++ b/backend/app/helpers/spree/admin/images_helper.rb
@@ -6,7 +6,7 @@ module Spree
           if image.viewable.is_master?
             Spree.t(:all)
           else
-            image.viewable.options_text
+            image.viewable.sku_and_options_text
           end
         else
           Spree.t(:all)

--- a/backend/app/views/spree/admin/products/_add_stock_form.html.erb
+++ b/backend/app/views/spree/admin/products/_add_stock_form.html.erb
@@ -20,7 +20,7 @@
       <div class="five columns omega">
         <%= f.field_container :variant_id do %>
           <%= label_tag 'variant_id', Spree.t(:variant) %>
-          <%= select_tag 'variant_id', options_from_collection_for_select(@variants, :id, :sku),
+          <%= select_tag 'variant_id', options_from_collection_for_select(@variants, :id, :sku_and_options_text),
             class: 'select2 fullwidth' %>
         <% end %>
       </div>

--- a/backend/app/views/spree/admin/products/stock.html.erb
+++ b/backend/app/views/spree/admin/products/stock.html.erb
@@ -28,7 +28,7 @@
       <% if variant.stock_items.present? %>
         <tr id="<%= spree_dom_id variant %>" data-hook="admin_product_stock_management_index_rows" class="<%= cycle('odd', 'even') %>">
           <td class="align-center">
-            <%= variant.sku %>
+            <%= variant.sku_and_options_text %>
             <br>
             <% if variant.images.present? %>
               <%= image_tag variant.images.first.attachment.url(:mini) %>

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -23,7 +23,7 @@ module Spree
       class_name: 'Spree::Price',
       dependent: :destroy
 
-    delegate_belongs_to :default_price, :display_price, :display_amount, :price, :price=, :currency 
+    delegate_belongs_to :default_price, :display_price, :display_amount, :price, :price=, :currency
 
     has_many :prices,
       class_name: 'Spree::Price',
@@ -127,13 +127,17 @@ module Spree
       "#{name} - #{sku}"
     end
 
+    def sku_and_options_text
+      "#{sku} #{options_text}".strip
+    end
+
     # Product may be created with deleted_at already set,
     # which would make AR's default finder return nil.
     # This is a stopgap for that little problem.
     def product
       Spree::Product.unscoped { super }
     end
-    
+
     def in_stock?(quantity=1)
       Spree::Stock::Quantifier.new(self).can_supply?(quantity)
     end


### PR DESCRIPTION
Following the discussion on https://github.com/spree/spree/pull/3650 this is a way to make product's stock management page usable when variant SKUs are not in use.
