### PR TITLE
Labels for boolean preference fields are not clickable

### DIFF
--- a/backend/app/helpers/spree/admin/base_helper.rb
+++ b/backend/app/helpers/spree/admin/base_helper.rb
@@ -71,7 +71,7 @@ module Spree
         when :integer
           text_field_tag(name, value, preference_field_options(options))
         when :boolean
-          hidden_field_tag(name, 0) +
+          hidden_field_tag(name, 0, id: "#{name}_hidden") +
           check_box_tag(name, 1, value, preference_field_options(options))
         when :string
           text_field_tag(name, value, preference_field_options(options))


### PR DESCRIPTION
The `preference_field_tag` helper creates 2 inputs with the same id for boolean preferences, which breaks associated labels. Making the ids different fixes this.
