### PR TITLE
Set Postgres host when creating a test_app

### DIFF
--- a/core/lib/generators/spree/dummy/templates/rails/database.yml
+++ b/core/lib/generators/spree/dummy/templates/rails/database.yml
@@ -27,21 +27,31 @@ production:
   database: <%= database_prefix %>spree_production
   encoding: utf8
 <% when 'postgres' %>
+<% db_host = ENV['DB_HOST'] -%>
 development:
   adapter: postgresql
   database: <%= database_prefix %>spree_development
   username: postgres
   min_messages: warning
+<% unless db_host.blank? %>
+  host: <%= db_host %>
+<% end %>
 test:
   adapter: postgresql
   database: <%= database_prefix %>spree_test
   username: postgres
   min_messages: warning
+<% unless db_host.blank? %>
+  host: <%= db_host %>
+<% end %>
 production:
   adapter: postgresql
   database: <%= database_prefix %>spree_production
   username: postgres
   min_messages: warning
+<% unless db_host.blank? %>
+  host: <%= db_host %>
+<% end %>
 <% else %>
 development:
   adapter: sqlite3


### PR DESCRIPTION
Sets the host for the Postgres database config. I'm using the Postgres.app where you have to set the host to localhost.

Usage is:

```
$ DB=postgres DB_HOST=localhost bundle exec rake test_app
```
