### PR TITLE
3990 payments clearing

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -261,7 +261,7 @@ module Spree
     def awaiting_returns?
       return_authorizations.any? { |return_authorization| return_authorization.authorized? }
     end
-    
+
     def add_variant(variant, quantity = 1, currency = nil)
       current_item = find_line_item_by_variant(variant)
       if current_item

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -336,6 +336,11 @@ module Spree
       shipments.each { |s| s.destroy unless s.shipping_method.available_to_order?(self) }
     end
 
+    # Clear payments when transitioning to payment step of checkout, since there could be some stale payments left. #3990
+    def clear_payments!
+      payments.destroy_all
+    end
+
     # Creates new tax charges if there are any applicable rates. If prices already
     # include taxes then price adjustments are created instead.
     def create_tax_charge!

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -338,7 +338,7 @@ module Spree
 
     # Clear payments when transitioning to payment step of checkout, since there could be some stale payments left. #3990
     def clear_payments!
-      payments.destroy_all
+      payments.with_state("checkout").destroy_all
     end
 
     # Creates new tax charges if there are any applicable rates. If prices already

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -73,6 +73,7 @@ module Spree
               end
 
               before_transition :to => :delivery, :do => :remove_invalid_shipments!
+              before_transition :to => :payment, :do => :clear_payments!
 
               after_transition :to => :complete, :do => :finalize!
               after_transition :to => :delivery, :do => :create_tax_charge!


### PR DESCRIPTION
make sure we cleanup any payments that are left behind before stepping into the payment step (again). This will prevent his from happening: Fixes #3990 

![MultiplePayments](http://monosnap.com/image/XFJjXLBtWfA2ULRov1qFDNwLl.png)
