### PR TITLE
small refactor for restarting the checkout flow

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -506,8 +506,12 @@ module Spree
     def ensure_updated_shipments
       if shipments.any?
         self.shipments.destroy_all
-        self.update_column(:state, "address")
+        restart_checkout_flow
       end
+    end
+
+    def restart_checkout_flow
+      self.update_column(:state, checkout_steps.first)
     end
 
     def refresh_shipment_rates

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -620,4 +620,21 @@ describe Spree::Order do
       end
     end
   end
+
+  describe ".restart_checkout_flow" do
+    it "updates the state column to the first checkout_steps value" do
+      order = create(:order, :state => "delivery")
+      expect(order.checkout_steps).to eql ["address", "delivery", "complete"]
+      expect{ order.restart_checkout_flow }.to change{order.state}.from("delivery").to("address")
+    end
+
+    context "with custom checkout_steps" do
+      it "updates the state column to the first checkout_steps value" do
+        order = create(:order, :state => "delivery")
+        order.should_receive(:checkout_steps).and_return ["custom_step", "address", "delivery", "complete"]
+        expect{ order.restart_checkout_flow }.to change{order.state}.from("delivery").to("custom_step")
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
use a better name for the method that restarts the checkout flow,also make sure we use the checkout_steps.first instead of hardcoding it to "address".

need to add some specs, do not merge this just yet. 
