### PR TITLE
When removing defunct zone members use classify instead of capitalize

### DIFF
--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -128,7 +128,7 @@ module Spree
 
       def remove_defunct_members
         if zone_members.any?
-          zone_members.where('zoneable_id IS NULL OR zoneable_type != ?', "Spree::#{kind.capitalize}").destroy_all
+          zone_members.where('zoneable_id IS NULL OR zoneable_type != ?', "Spree::#{kind.classify}").destroy_all
         end
       end
 


### PR DESCRIPTION
When creating a custom zone member type like zip_code for example using capitalize removes all models with zonable type != Spree::Zip_code instead of Spree::ZipCode
