### PR TITLE
Changed remove_defunct_members zone model's method in case of compound name class

### DIFF
--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -128,7 +128,7 @@ module Spree
 
       def remove_defunct_members
         if zone_members.any?
-          zone_members.where('zoneable_id IS NULL OR zoneable_type != ?', "Spree::#{kind.capitalize}").destroy_all
+          zone_members.where('zoneable_id IS NULL OR zoneable_type != ?', "Spree::#{kind.camelize}").destroy_all
         end
       end
 


### PR DESCRIPTION
Since there is an underscore method call inside Zone model's kind method, compound class names are welcome as ZoneMembers.

``` ruby
def kind
  if members.any? && !members.any? { |member| member.try(:zoneable_type).nil? }
    members.last.zoneable_type.demodulize.underscore
  end
end
```

Therefore Zone model's callback `after_save: remove_defunct_members` will destroy the ones that are supposed to and the newly saved zoneable compound class name types as well. So `"Spree::#{kind.capitalize}"` needs to be camelized instead of capitalized.
