### PR TITLE
(backend) in order details, line items states could not be translated

### DIFF
--- a/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
@@ -9,7 +9,7 @@
     <td class="item-price align-center"><%= line_item.single_money.to_html %></td>
     <td class="item-qty-show align-center">
         <% item.states.each do |state,count| %>
-          <%= count %> x <%= state.humanize.downcase %>
+          <%= count %> x <%= Spree.t(state) %>
         <% end %>
     </td>
     <% unless shipment.shipped? %>

--- a/backend/spec/features/admin/orders/new_order_spec.rb
+++ b/backend/spec/features/admin/orders/new_order_spec.rb
@@ -42,7 +42,7 @@ describe "New Order" do
     click_on "ship"
     wait_for_ajax
 
-    page.should have_content("shipped")
+    page.should have_content("Shipped")
   end
 
   # Regression test for #3336


### PR DESCRIPTION
The `_shipment_manifest` partial was rendering the shipment states symbols on its template. Because of it, translating the shipment states on it was not possible.

After this update, I needed to fix one broken test that searched the page for "shipped" and not "Shipped" as `Spree.t` method provides.
