### PR TITLE
product_picker.js: error on retrieving products in admin area from API

### DIFF
--- a/backend/app/assets/javascripts/admin/product_picker.js
+++ b/backend/app/assets/javascripts/admin/product_picker.js
@@ -24,8 +24,9 @@ $.fn.productAutocomplete = function () {
         };
       },
       results: function (data, page) {
+        var products = data.products ? data.products : [];
         return {
-          results: data.products
+          results: products
         };
       }
     },


### PR DESCRIPTION
In the following scenario:

In Spree admin area (2-1-stable), when I'm creating a product promotion, the `product_picker.js` is called and select2 autocomplete comes in.

If the ajax search returns one ore more products, it is ok, and I can continue searching.

If the ajax search returns zero products, it gives the following JS error:

``` javascript
Uncaught TypeError: Cannot read property 'length' of undefined
```

And after this error, the spinner does not disappear until the page is refreshed. Here a screenshot of this problem:

![image](https://f.cloud.github.com/assets/1538066/1605315/be256896-53d5-11e3-8cfa-f5d90948d4ac.png)

Solution 1: The [products API rabl result](https://github.com/spree/spree/blob/2-1-stable/api/app/views/spree/api/products/index.v1.rabl#L7) could return an empty array, always having the **products** node.

The only problem in this solution, is that the rabl configuration for Spree is [set to never include the child node](https://github.com/spree/spree/blob/2-1-stable/api/lib/spree/api/engine.rb#L11)

Solution 2: The [product_picker.js](https://github.com/spree/spree/blob/2-1-stable/backend/app/assets/javascripts/admin/product_picker.js#L26:L30) could verify if the **products** node exists.
