### PR TITLE
Don't override accessor if method has attr as column

### DIFF
--- a/core/lib/spree/core/delegate_belongs_to.rb
+++ b/core/lib/spree/core/delegate_belongs_to.rb
@@ -37,6 +37,8 @@ module DelegateBelongsTo
       attrs = get_association_column_names(association) if attrs.empty?
       attrs.concat get_association_column_names(association) if attrs.delete :defaults
       attrs.each do |attr|
+        next if table_exists? && column_names.include?(attr.to_s)
+
         class_def attr do |*args|
           if args.empty?
             send(:delegator_for, association).send(attr)

--- a/core/spec/lib/spree/core/delegate_belongs_to_spec.rb
+++ b/core/spec/lib/spree/core/delegate_belongs_to_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+# This is a bit of a insane spec I have to admit
+# Chosed the spree_payment_methods table because it has a `name` column
+# already. Stubs wouldn't work here (the delegation runs before this spec is
+# loaded) and adding a column here might make the test even crazy so here we go
+module Spree
+  class DelegateBelongsToStubModel < ActiveRecord::Base
+    self.table_name = "spree_payment_methods"
+    belongs_to :product
+    delegate_belongs_to :product, :name
+  end
+
+  describe DelegateBelongsToStubModel do
+    context "model has column attr delegated to associated object" do
+      it "doesnt touch the associated object" do
+        expect(subject).not_to receive(:product)
+        subject.name
+      end
+    end
+  end 
+end


### PR DESCRIPTION
Say users want to add a `name` column in spree_variants. They can't make
use of that attr on a variant instance because Spree would always
delegate that method to a product.

Now it would only delegate if the model doesn't have that column. That
would be all cases in a default scenario.

Possible bad side effects: we're touching the database one more time
when booting the spree engine. That's another issue for heroku users
right now.

Opening this one as a possible suggestion / fix for that use case. Wanted to hear if there's any other better idea or maybe if the use case itself is a bad idea and we shouldn't allow it at all in Spree core. Not really sure what I think about it yet.
