### PR TITLE
Fix `on_demand' inconsistency at Product model

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -127,7 +127,7 @@ module Spree
 
     def on_demand=(new_on_demand)
       raise 'cannot set on_demand of product with variants' if has_variants? && Spree::Config[:track_inventory_levels]
-      master.on_demand = on_demand
+      master.on_demand = new_on_demand
       self[:on_demand] = new_on_demand
     end
 


### PR DESCRIPTION
Fix for possible wrong assignment of `on_demand` for a product without variants. I see no point to store _old on_demand_ flag for a master variant and the _new one_ on product's instance at the same time. It leads to the inconsistency.
