### PR TITLE
Add endpoint to retrieve a current user's orders in the API.

### DIFF
--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -61,6 +61,15 @@ module Spree
         end
       end
 
+      def mine
+        if current_api_user.anonymous?
+          render "spree/api/errors/unauthorized", status: :unauthorized
+        else
+          @orders = current_api_user.orders
+          render :mine
+        end
+      end
+
       def apply_coupon_code
         find_order
         @order.coupon_code = params[:coupon_code]

--- a/api/app/views/spree/api/orders/mine.v1.rabl
+++ b/api/app/views/spree/api/orders/mine.v1.rabl
@@ -1,0 +1,4 @@
+object false
+child(@orders => :orders) do
+  extends "spree/api/orders/order"
+end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -28,6 +28,8 @@ Spree::Core::Engine.add_routes do
       resources :option_values
     end
 
+    get '/orders/mine', :to => 'orders#mine', :as => 'my_orders'
+
     resources :orders do
       resources :addresses, :only => [:show, :update]
 

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -41,6 +41,27 @@ module Spree
       assert_unauthorized!
     end
 
+    context "the current api user is anonymous" do
+      let(:current_api_user) { double(anonymous?: true) }
+
+      it "returns a 401" do
+        api_get :mine
+
+        response.status.should == 401
+      end
+    end
+
+    context "the current api user is authenticated" do
+      it "can view all of their own orders" do
+        current_api_user.should_receive(:orders) { [order] }
+
+        api_get :mine
+
+        json_response["orders"].length.should == 1
+        json_response["orders"].first["number"].should == order.number
+      end
+    end
+
     it "can view their own order" do
       Order.any_instance.stub :user => current_api_user
       api_get :show, :id => order.to_param


### PR DESCRIPTION
Returns 401 if the user is anonymous.
