### PR TITLE
present? check for shipping_method on edit orders

### DIFF
--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -68,7 +68,7 @@
 
       <tr class="show-method total">
         <td colspan="4">
-          <% if shipment.adjustment.present? %>
+          <% if shipment.adjustment.present? && shipment.shipping_method.present? %>
             <strong><%= shipment.adjustment.label %>: <%= shipment.shipping_method.name %></strong>
           <% else %>
             <%= Spree.t(:cannot_set_shipping_method_without_address) %>


### PR DESCRIPTION
Somehow, I ended up with a cancelled order without a shipping method that was causing an error in production.  This extra check prevents the exception.  Looks like this view has changed in master, so it is unnecessary there.
