### PR TITLE
Only displaying distinct orders on admin/orders

### DIFF
--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -35,7 +35,7 @@ module Spree
         end
 
         @search = Order.accessible_by(current_ability, :index).ransack(params[:q])
-        @orders = @search.result.includes([:user, :shipments, :payments]).
+        @orders = @search.result(distinct: true).includes([:user, :shipments, :payments]).
           page(params[:page]).
           per(params[:per_page] || Spree::Config[:orders_per_page])
 


### PR DESCRIPTION
On `admin/orders` we've added some more fields to filter results on billing country / countries (`bill_address_country_id_in`) and ordered variant(s) (`line_items_variant_id_in`). Thanks to the help of Ransack this is working out of the box, however, multiple results for a single order show up. This is due to the way SQL-joins are made.

Searching in the Ransack docs, I found out that adding a simple `distinct: true` to the `results` call in `Spree::Admin::OrdersController` `index` method would be sufficient to fix this issue.

_Source_: https://github.com/ernie/ransack#simple-mode (item no. 3)

Though we could easily fix this for ourselves by overriding the `index` method, I can imagine more developers could encounter this issue and fixing it by overriding a whole method isn't a great way to go.

_The code_ (https://github.com/spree/spree/blob/master/backend/app/controllers/spree/admin/orders_controller.rb#L38):

_Before_:

``` ruby
@orders = @search.result.includes([:user, :shipments, :payments]).page(params[:page]).per(params[:per_page] || Spree::Config[:orders_per_page])
```

_After_:

``` ruby
@orders = @search.result(distinct: true).includes([:user, :shipments, :payments]).page(params[:page]).per(params[:per_page] || Spree::Config[:orders_per_page])
```

_Env_:
- Rails 3.2.14
- Currently running 2-0 stable, but the code in master is unchanged
