### PR TITLE
Add inverse_of to product variant associations

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -35,15 +35,18 @@ module Spree
 
     has_one :master,
       -> { where is_master: true },
+      inverse_of: :product,
       class_name: 'Spree::Variant',
       dependent: :destroy
 
     has_many :variants,
       -> { where(is_master: false).order("#{::Spree::Variant.quoted_table_name}.position ASC") },
+      inverse_of: :product,
       class_name: 'Spree::Variant'
 
     has_many :variants_including_master,
       -> { order("#{::Spree::Variant.quoted_table_name}.position ASC") },
+      inverse_of: :product,
       class_name: 'Spree::Variant',
       dependent: :destroy
 


### PR DESCRIPTION
This should help reduce calls to the database when referencing back to a parent product or any of it's delegated attributes from variant. Change was recommended by @cbrunsdon.
