### PR TITLE
added autocomplete off HTML5 tag to mail method settings for username and password

### DIFF
--- a/backend/app/views/spree/admin/mail_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/mail_methods/_form.html.erb
@@ -64,11 +64,11 @@
         </div>
         <div class="field">
           <%= label_tag :smtp_username, Spree.t(:smtp_username) %><br />
-          <%= text_field_tag :smtp_username, Spree::Config[:smtp_username], :class => 'fullwidth' %>
+          <%= text_field_tag :smtp_username, Spree::Config[:smtp_username], :class => 'fullwidth', :autocomplete => 'off' %>
         </div>
         <div class="field">
           <%= label_tag :preferred_smtp_password, Spree.t(:smtp_password) %><br />
-          <%= password_field_tag :smtp_password, Spree::Config[:smtp_password], :class => 'fullwidth' %>
+          <%= password_field_tag :smtp_password, Spree::Config[:smtp_password], :class => 'fullwidth', :autocomplete => 'off' %>
         </div>
       </fieldset>
     </div>


### PR DESCRIPTION
When editing mail method settings, the username and password are overridden for display with browser supplied autocomplete values (in Safari). These would likely never be the user's own passwords in their keychain anyways.
