### PR TITLE
stock_movements helper fix for stock_transfer

### DIFF
--- a/backend/app/helpers/spree/admin/stock_movements_helper.rb
+++ b/backend/app/helpers/spree/admin/stock_movements_helper.rb
@@ -3,7 +3,11 @@ module Spree
     module StockMovementsHelper
       def pretty_originator(stock_movement)
         if stock_movement.originator.respond_to?(:number)
-          link_to stock_movement.originator.number, [:edit, :admin, stock_movement.originator.order]
+          if stock_movement.originator.respond_to?(:order)
+            link_to stock_movement.originator.number, [:edit, :admin, stock_movement.originator.order]
+          else
+            stock_movement.originator.number
+          end
         else
           ""
         end

--- a/backend/spec/helpers/admin/stock_movements_helper_spec.rb
+++ b/backend/spec/helpers/admin/stock_movements_helper_spec.rb
@@ -1,0 +1,30 @@
+# coding: UTF-8
+require 'spec_helper'
+
+describe Spree::Admin::StockMovementsHelper do
+
+  describe "#pretty_originator" do
+
+    context "transfering between two locations" do
+      let(:destination_location) { create(:stock_location_with_items) }
+      let(:source_location) { create(:stock_location_with_items) }
+      let(:stock_item) { source_location.stock_items.order(:id).first }
+      let(:variant) { stock_item.variant }
+
+      before do
+        @stock_transfer = Spree::StockTransfer.create(reference: 'PO123')
+        variants = { variant => 5 }
+        @stock_transfer.transfer(source_location,
+                       destination_location,
+                       variants)
+        helper.pretty_originator(@stock_transfer.stock_movements.last)
+      end
+
+
+      it "returns link to stock transfer" do
+        helper.pretty_originator(@stock_transfer.stock_movements.last).should eq @stock_transfer.number
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Fixes pretty_originator exception for stock movement created by stock transfer between 2 locations.

Versions: rails: 4.0.*, spree: 2.1.4beta (2.1.3beta)

Steps to reproduce:

1) admin/stock_transfers/new
  create a new transfer between two locations

2) admin/stock_locations

3) admin/stock_locations/{location_id}/stock_movements
 raises "undefined method order" exception

Fix:

  return originator.number as in previous version
