### PR TITLE
improved capybara select2 helpers

### DIFF
--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -172,7 +172,7 @@ describe "Order Details", js: true do
             fill_in "order_bill_address_attributes_zipcode", :with => "20814"
             fill_in "order_bill_address_attributes_phone", :with => "301-444-5002"
             select2 "Alabama", :from => "State"
-            select2 "United States of Foo", :from => "Country"
+            select2 "United States of America", :from => "Country"
             click_icon :refresh
 
             click_link "Order Details"

--- a/core/lib/spree/testing_support/capybara_ext.rb
+++ b/core/lib/spree/testing_support/capybara_ext.rb
@@ -36,8 +36,8 @@ module CapybaraExt
     label = find_label_by_text(options[:from])
     within label.first(:xpath,".//..") do
       options[:from] = "##{find(".select2-container")["id"]}"
-      targetted_select2_search(value, options)
     end
+    targetted_select2_search(value, options)
   end
 
   def targetted_select2_search(value, options)
@@ -51,8 +51,8 @@ module CapybaraExt
 
     within label.first(:xpath,".//..") do
       options[:from] = "##{find(".select2-container")["id"]}"
-      targetted_select2(value, options)
     end
+    targetted_select2(value, options)
   end
 
   def select2_no_label value, options={}
@@ -73,9 +73,10 @@ module CapybaraExt
   end
 
   def select_select2_result(value)
-    #p %Q{$("div.select2-result-label:contains('#{value}')").mouseup()}
-    sleep(1)
-    page.execute_script(%Q{$("div.select2-result-label:contains('#{value}')").mouseup()})
+    # results are in a div appended to the end of the document
+    within(:xpath, '//body') do
+      page.find("div.select2-result-label", text: %r{#{Regexp.escape(value)}}i).click
+    end
   end
 
   def find_label_by_text(text)


### PR DESCRIPTION
Existing `select2` used `sleep(1)` to wait for the select2 dropdown to appear and then executed some javascript to select the desired option. This replaces that with a standard capybara `page.find(...).click`.

As well with avoiding the `sleep(1)`, this will raise an exception if the desired option is missing.

The build reliably passes on my machine, hopefully CI agrees.
