### PR TITLE
Order Show Line Items

### DIFF
--- a/backend/app/assets/javascripts/admin/variant_autocomplete.js.erb
+++ b/backend/app/assets/javascripts/admin/variant_autocomplete.js.erb
@@ -43,12 +43,16 @@ $(document).ready(function() {
       var save = $(this);
       var shipment_number = save.data('shipment-number');
       var variant_id = save.data('variant-id');
+      var line_item_id = save.data('line-item-id');
 
       var quantity = parseInt(save.parents('tr').find('input.line_item_quantity').val());
 
       toggleItemEdit();
-
-      adjustItems(shipment_number, variant_id, quantity);
+      if (shipment_number) {
+        adjustShipmentItems(shipment_number, variant_id, quantity);
+      } else {
+        adjustLineItem(line_item_id, quantity);
+      }
       return false;
     });
 
@@ -60,14 +64,17 @@ $(document).ready(function() {
         var variant_id = del.data('variant-id');
 
         toggleItemEdit();
-
-        adjustItems(shipment_number, variant_id, 0);
+        if (shipment_number) {
+          adjustShipmentItems(shipment_number, variant_id, 0);
+        } else {
+          adjustLineItem(line_item_id, 0);
+        }
       }
     });
   }
 });
 
-adjustItems = function(shipment_number, variant_id, quantity){
+adjustShipmentItems = function(shipment_number, variant_id, quantity){
     var shipment = _.findWhere(shipments, {number: shipment_number + ''});
     var inventory_units = _.where(shipment.inventory_units, {variant_id: variant_id});
 
@@ -93,6 +100,32 @@ adjustItems = function(shipment_number, variant_id, quantity){
       });
     }
 }
+
+adjustLineItem = function(line_item_id, quantity){
+  var url = Spree.routes.orders_api + "/" + order_number + "/line_items/" + line_item_id;
+
+  if(quantity > 0){
+    $.ajax({
+      type: "PUT",
+      url: Spree.url(url),
+      data: { 
+        line_item: {
+          quantity: quantity
+        }
+      }
+    }).done(function( msg ) {
+      advanceOrder();
+    });
+  } else {
+    $.ajax({
+      type: "DELETE",
+      url: Spree.url(url)
+    }).done(function( msg ) {
+      advanceOrder();
+    });
+  }
+}
+
 
 toggleTrackingEdit = function(){
   var link = $(this);

--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -60,7 +60,7 @@ module Spree
 
       def link_to_clone(resource, options={})
         options[:data] = {:action => 'clone'}
-        link_to_with_icon('icon-copy', Spree.t(:clone), clone_admin_product_url(resource), options)
+        link_to_with_icon('icon-copy', Spree.t(:clone), clone_object_url(resource), options)
       end
 
       def link_to_new(resource)
@@ -69,8 +69,9 @@ module Spree
       end
 
       def link_to_edit(resource, options={})
+        url = options[:url] || edit_object_url(resource)
         options[:data] = {:action => 'edit'}
-        link_to_with_icon('icon-edit', Spree.t(:edit), edit_object_url(resource), options)
+        link_to_with_icon('icon-edit', Spree.t(:edit), url, options)
       end
 
       def link_to_edit_url(url, options={})

--- a/backend/app/views/spree/admin/orders/_form.html.erb
+++ b/backend/app/views/spree/admin/orders/_form.html.erb
@@ -3,7 +3,11 @@
     <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @line_item } %>
   <% end %>
 
-  <%= render :partial => "spree/admin/orders/shipment", :collection => @order.shipments, :locals => { :order => order } %>
+  <% if Spree::Order.checkout_step_names.include?(:shipment) %>
+    <%= render :partial => "spree/admin/orders/shipment", :collection => @order.shipments, :locals => { :order => order } %>
+  <% else %>
+    <%= render :partial => "spree/admin/orders/line_items", :locals => { :order => order } %>
+  <% end %>
   <% if order.adjustments.eligible.exists? %>
     <fieldset class="no-border-bottom">
       <legend><%= Spree.t('adjustments') %></legend>

--- a/backend/app/views/spree/admin/orders/_line_items.html.erb
+++ b/backend/app/views/spree/admin/orders/_line_items.html.erb
@@ -1,0 +1,45 @@
+  <table class="stock-contents index" data-hook="stock-contents">
+    <colgroup>
+      <col style="width: 10%;" />
+      <col style="width: 20%;" />
+      <col style="width: 20%;" />
+      <col style="width: 15%;" />
+    </colgroup>
+
+    <thead>
+      <th colspan="2"><%= Spree.t(:name) %></th>
+      <th><%= Spree.t(:price) %></th>
+      <th><%= Spree.t(:quantity) %></th>
+      <th><%= Spree.t(:total_price) %></th>
+      <th class="orders-actions actions" data-hook="admin_order_form_line_items_header_actions">&nbsp;</th>
+    </thead>
+
+    <tbody>
+      <% order.line_items.each do |item| %>
+        
+        <tr class="line-item">
+          <td class="item-image"><%= mini_image(item.variant) %></td>
+          <td class="item-name">
+            <%= item.variant.product.name %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>
+          </td>
+          <td class="item-price align-center"><%= item.single_money.to_html %></td>
+          <td class="item-qty-show align-center">
+            <%= item.quantity %>
+          </td>
+          <td class="item-qty-edit hidden">
+            <%= number_field_tag :quantity, item.quantity, :min => 0, :class => "line_item_quantity", :size => 5 %>
+          </td>
+          <td class="item-total align-center"><%= line_item_shipment_price(item, item.quantity) %></td>
+          <td class="cart-item-delete actions" data-hook="cart_item_delete">
+            <% if can? :update, item %>
+              <%= link_to '', '#', :class => 'save-item icon_link icon-ok no-text with-tip', :data => { 'line-item-id' => item.id, :action => 'save'}, :title => Spree.t('actions.save'), :style => 'display: none' %>
+              <%= link_to '', '#', :class => 'cancel-item icon_link icon-cancel no-text with-tip', :data => {:action => 'cancel'}, :title => Spree.t('actions.cancel'), :style => 'display: none' %>
+              <%= link_to '', '#', :class => 'edit-item icon_link icon-edit no-text with-tip', :data => {:action => 'edit'}, :title => Spree.t('edit') %>
+              <%= link_to '', '#', :class => 'delete-item icon-trash no-text with-tip', :data => { 'line-item-id' => item.id, :action => 'remove'}, :title => Spree.t('delete') %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -60,7 +60,7 @@
       <div class="omega four columns">
         <div class="field checkbox">
           <label>
-            <%= f.check_box :completed_at_not_null, {:checked => @show_only_completed}, '1', '0' %>
+            <%= f.check_box :completed_at_not_null, {:checked => @show_only_completed}, '1', '' %>
             <%= Spree.t(:show_only_complete_orders) %>
           </label>
         </div>
@@ -87,7 +87,9 @@
        <col style="width: 10%;">
        <col style="width: 10%;">
        <col style="width: 12%;">
-       <col style="width: 12%;">
+       <% if Spree::Order.checkout_step_names.include?(:shipment) %>
+         <col style="width: 12%;">
+       <% end %>
        <col style="width: 25%;">
        <col style="width: 10%;">
        <col style="width: 8%;">
@@ -102,7 +104,9 @@
         <th><%= sort_link @search, :number,         I18n.t(:number, :scope => 'activerecord.attributes.spree/order') %></th>
         <th><%= sort_link @search, :state,          I18n.t(:state, :scope => 'activerecord.attributes.spree/order') %></th>
         <th><%= sort_link @search, :payment_state,  I18n.t(:payment_state, :scope => 'activerecord.attributes.spree/order') %></th>
-        <th><%= sort_link @search, :shipment_state, I18n.t(:shipment_state, :scope => 'activerecord.attributes.spree/order') %></th>
+         <% if Spree::Order.checkout_step_names.include?(:shipment) %>
+          <th><%= sort_link @search, :shipment_state, I18n.t(:shipment_state, :scope => 'activerecord.attributes.spree/order') %></th>
+         <% end %>
         <th><%= sort_link @search, :email,          I18n.t(:email, :scope => 'activerecord.attributes.spree/order') %></th>
         <th><%= sort_link @search, :total,          I18n.t(:total, :scope => 'activerecord.attributes.spree/order') %></th>
         <th data-hook="admin_orders_index_header_actions" class="actions"></th>
@@ -115,7 +119,9 @@
         <td class="align-center"><%= link_to order.number, edit_admin_order_path(order) %></td>
         <td class="align-center"><span class="state <%= order.state.downcase %>"><%= Spree.t("order_state.#{order.state.downcase}") %></span></td>
         <td class="align-center"><span class="state <%= order.payment_state %>"><%= link_to Spree.t("payment_states.#{order.payment_state}"), admin_order_payments_path(order) if order.payment_state %></span></td>
-        <td class="align-center"><span class="state <%= order.shipment_state %>"><%= Spree.t("shipment_states.#{order.shipment_state}") if order.shipment_state %></span></td>
+          <% if Spree::Order.checkout_step_names.include?(:shipment) %>
+            <td class="align-center"><span class="state <%= order.shipment_state %>"><%= Spree.t("shipment_states.#{order.shipment_state}") if order.shipment_state %></span></td>
+          <% end %>
         <td><%= mail_to order.email %></td>
         <td class="align-center"><%= order.display_total.to_html %></td>
         <td class='actions align-center' data-hook="admin_orders_index_row_actions">


### PR DESCRIPTION
This pull request references #3959 

Order line items are not shown in the backend when the delivery step is removed from the checkout flow, this pull request fixes this.

It draws code from the branch @radar mentions in #3958 and inserts it into 2-0-stable.
