### PR TITLE
Add customer_id to gateway options

### DIFF
--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -115,14 +115,15 @@ module Spree
       end
 
       def gateway_options
-        options = { :email    => order.email,
-                    :customer => order.email,
-                    :ip       => order.last_ip_address,
+        options = { :email       => order.email,
+                    :customer    => order.email,
+                    :customer_id => order.user_id,
+                    :ip          => order.last_ip_address,
                     # Need to pass in a unique identifier here to make some
                     # payment gateways happy.
                     #
                     # For more information, please see Spree::Payment#set_unique_identifier
-                    :order_id => gateway_order_id }
+                    :order_id    => gateway_order_id }
 
         options.merge!({ :shipping => order.ship_total * 100,
                          :tax      => order.additional_tax_total * 100,


### PR DESCRIPTION
:customer and :email are both "email", the customer id could be prefered 
to uniquely identifiy a customer on the gateway 
