### PR TITLE
Remove object_params in favor of a callback system

### DIFF
--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -359,4 +359,37 @@ describe Spree::Order do
       order.checkout_steps.should == %w(delivery complete)
     end
   end
+
+  describe 'update_from_params' do
+    let(:permitted_params) { {} }
+    let(:params) { {} }
+    it 'calls update_atributes without order params' do
+      order.should_receive(:update_attributes).with({})
+      order.update_from_params( params, permitted_params)
+    end
+
+    it 'runs the callbacks' do
+      order.should_receive(:run_callbacks).with(:updating_from_params)
+      order.update_from_params( params, permitted_params)
+    end
+
+    context 'has params' do
+      let(:permitted_params) { [ :good_param ] }
+      let(:params) { ActionController::Parameters.new(order: {  bad_param: 'okay' } ) }
+      it 'does not let through unpermitted attributes' do
+        order.should_receive(:update_attributes).with({})
+        order.update_from_params(params, permitted_params)
+      end
+      context 'has allowed params' do
+        let(:params) { ActionController::Parameters.new(order: {  good_param: 'okay' } ) }
+
+        it 'accepts permitted attributes' do
+          order.should_receive(:update_attributes).with({"good_param" => 'okay'})
+          order.update_from_params(params, permitted_params)
+        end
+      end
+    end
+
+
+  end
 end


### PR DESCRIPTION
object_params is one of the uglier areas of the code that is also
frequently in need of expanding upon (who remembers the promo
controller implementation?).

rather than continually expanding and class_evaling over top of
object_params, I have switched it to a callback based system that
extensions can subscribe to and do whatever action is required. While
all this changes is core is deprecates object_params for a single
callback, in our "live" site, this fixes the integration of 3 separate
extensions that deal with different payment types.

The ugliest part to this commit by far is the @updating_params instance
variable as a place to change the parameters, but I am very open to
suggestions or alternate sub/pub methods than ActiveSupport::Callbacks

From here, the next thing to do to clean it up farther is create a
CheckoutRequest object to start wrapping the functionality of the params
into cleaner portions.
