### PR TITLE
Use raw for the line item description text

### DIFF
--- a/core/app/helpers/spree/products_helper.rb
+++ b/core/app/helpers/spree/products_helper.rb
@@ -47,7 +47,7 @@ module Spree
 
     def line_item_description_text description_text
       if description_text.present?
-        truncate(strip_tags(description_text.gsub('&nbsp;', ' ')), length: 100)
+        raw(truncate(strip_tags(description_text.gsub('&nbsp;', ' ')), length: 100))
       else
         Spree.t(:product_has_no_description)
       end


### PR DESCRIPTION
Use raw for the line item description text, otherwise special chars like éàè... in french are not displayed well
