### PR TITLE
Don't fill backorders on incomplete orders (e.g. in abandoned in payment state)

### DIFF
--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -8,10 +8,11 @@ module Spree
     scope :backordered, -> { where state: 'backordered' }
     scope :shipped, -> { where state: 'shipped' }
     scope :backordered_per_variant, ->(stock_item) do
-      includes(:shipment)
+      includes(:shipment, :order)
         .where("spree_shipments.state != 'canceled'")
         .where(variant_id: stock_item.variant_id)
-        .backordered.order("#{self.table_name}.created_at ASC")
+        .where('spree_orders.completed_at is not null')
+        .backordered.order("spree_orders.completed_at ASC")
     end
 
     attr_accessible :shipment, :variant_id
@@ -36,7 +37,7 @@ module Spree
     # lead to issues once users tried to modify the objects returned. That's due
     # to ActiveRecord `joins(shipment: :stock_location)` only return readonly
     # objects
-    # 
+    #
     # Returns an array of backordered inventory units as per a given stock item
     def self.backordered_for_stock_item(stock_item)
       backordered_per_variant(stock_item).select do |unit|


### PR DESCRIPTION
Currently the scope used to find inventory doesn't scope to those belonging to orders that are actually completed, so abandoned carts can have the inventory_units filled prior to real orders.

Also, I've changed the ordering to use the order's completed_at timestamp rather that the inventory unit's created_at timestamp. I believe the former is preferable in order to ensure that backorders are filled on a first come, first served basis. Otherwise people who had the item in their cart but didn't complete the order until much later could have their backorders filled prior to those who completed their orders earlier.

This should probably be applied to master and 2-1-stable as well but doesn't yet merge cleanly.
