### PR TITLE
Make the parameters consistent across orders#create and orders#update

### DIFF
--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -80,10 +80,11 @@ module Spree
 
       private
         def deal_with_line_items
-          line_item_attributes = params[:order][:line_items].map do |id, attributes|
-            [id, attributes.slice(*permitted_line_item_attributes)]
+          line_item_attributes = params[:order][:line_items]
+          line_item_attributes.each_key do |key|
+            # need to call .to_hash to make sure Rails 4's strong parameters don't bite
+            line_item_attributes[key] = line_item_attributes[key].slice(*permitted_line_item_attributes).to_hash
           end
-          line_item_attributes = Hash[line_item_attributes].delete_if { |k,v| v.empty? }
           @order.update_line_items(line_item_attributes)
         end
 

--- a/api/app/models/spree/order_decorator.rb
+++ b/api/app/models/spree/order_decorator.rb
@@ -159,8 +159,12 @@ Spree::Order.class_eval do
 
   def update_line_items(line_item_params)
     return if line_item_params.blank?
-    line_item_params.each do |id, attributes|
-      self.line_items.find(id).update_attributes!(attributes)
+    line_item_params.each_value do |attributes|
+      if attributes[:id].present?
+        self.line_items.find(attributes[:id]).update_attributes!(attributes)
+      else
+        self.line_items.create!(attributes)
+      end
     end
     self.ensure_updated_shipments
   end

--- a/api/spec/controllers/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/controllers/spree/api/checkouts_controller_spec.rb
@@ -71,7 +71,7 @@ module Spree
       it "can take line_items_attributes as a parameter" do
         line_item = order.line_items.first
         api_put :update, :id => order.to_param, :order_token => order.token,
-                         :order => { :line_items_attributes => { line_item.id => { :quantity => 1 } } }
+                         :order => { :line_items_attributes => { 0 => { :id => line_item.id, :quantity => 1 } } }
         response.status.should == 200
         order.reload.state.should eq "address"
       end
@@ -79,7 +79,7 @@ module Spree
       it "can take line_items as a parameter" do
         line_item = order.line_items.first
         api_put :update, :id => order.to_param, :order_token => order.token,
-                         :order => { :line_items => { line_item.id => { :quantity => 1 } } }
+                         :order => { :line_items => { 0 => { :id => line_item.id, :quantity => 1 } } }
         response.status.should == 200
         order.reload.state.should eq "address"
       end

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -235,6 +235,22 @@ module Spree
         json_response['line_items'].first['quantity'].should == 10
       end
 
+      it "adds an extra line item" do
+        variant2 = create(:variant)
+        api_put :update, :id => order.to_param, :order => {
+          :line_items => {
+            0 => { :id => line_item.id, :quantity => 10 },
+            1 => { :variant_id => variant2.id, :quantity => 1}
+          }
+        }
+
+        response.status.should == 200
+        json_response['line_items'].count.should == 2
+        json_response['line_items'][0]['quantity'].should == 10
+        json_response['line_items'][1]['variant_id'].should == variant2.id
+        json_response['line_items'][1]['quantity'].should == 1
+      end
+
       it "cannot change the price of an existing line item" do
         api_put :update, :id => order.to_param, :order => {
           :line_items => {

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -226,7 +226,7 @@ module Spree
       it "updates quantities of existing line items" do
         api_put :update, :id => order.to_param, :order => {
           :line_items => {
-            line_item.id => { :quantity => 10 }
+            0 => { :id => line_item.id, :quantity => 10 }
           }
         }
 
@@ -238,7 +238,7 @@ module Spree
       it "cannot change the price of an existing line item" do
         api_put :update, :id => order.to_param, :order => {
           :line_items => {
-            line_item.id => { :price => 0 }
+            0 => { :id => line_item.id, :price => 0 }
           }
         }
 
@@ -290,7 +290,7 @@ module Spree
           previous_shipments = order.shipments
           api_put :update, :id => order.to_param, :order => {
             :line_items => {
-              line_item.id => { :quantity => 10 }
+              0 => { :id => line_item.id, :quantity => 10 }
             }
           }
           expect(order.reload.shipments).to be_empty


### PR DESCRIPTION
We had a little bit of trouble using the Spree API here at Bonobos that is addressed by this. We are using the Orders API to manage our cart from our custom front-end. However, it turns out that orders#create expects a different structure of the line-items attributes than orders#update does.

Here's what #create expects:
line_items: {
    0: { variant_id: 123, quantity: 1 },
    1: { variant_id: 234, quantity: 1 }
}

And this is what #update expects before this change:
line_items: {
    12: { id: 12, variant_id: 123, quantity: 1 },
    23: { id: 23, variant_id: 234, quantity: 1 }
}

That's pretty icky on the client, as we now have a Backbone model that has to send up different JSON depending on whether we are calling create or update. This change makes the two endpoints consistent by changing the format that #update expects. That way, we now also support adding a new line-item on an orders#update call, something that wasn't possible before.
