### PR TITLE
Fix Paperclip S3 schemeless URL generation

### DIFF
--- a/core/lib/spree/core/s3_support.rb
+++ b/core/lib/spree/core/s3_support.rb
@@ -15,7 +15,7 @@ module Spree
             self.attachment_definitions[field][:s3_credentials] = s3_creds
             self.attachment_definitions[field][:s3_headers] = ActiveSupport::JSON.decode(config[:s3_headers])
             self.attachment_definitions[field][:bucket] = config[:s3_bucket]
-            self.attachment_definitions[field][:s3_protocol] = config[:s3_protocol].downcase unless config[:s3_protocol].blank?
+            self.attachment_definitions[field][:s3_protocol] = config[:s3_protocol].blank? ? '' : config[:s3_protocol].downcase
             self.attachment_definitions[field][:s3_host_alias] = config[:s3_host_alias] unless config[:s3_host_alias].blank?
           end
         end


### PR DESCRIPTION
If the config setting is blank, we need to pass paperclip an empty string not nil
