### PR TITLE
Remove 'relation' from simple scopes definition.

### DIFF
--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -23,7 +23,7 @@ module Spree
         # We should not define price scopes here, as they require something slightly different
         next if name.to_s.include?("master_price")
         parts = name.to_s.match(/(.*)_by_(.*)/)
-        self.scope(name.to_s, -> { relation.order("#{Product.quoted_table_name}.#{parts[2]} #{parts[1] == 'ascend' ?  "ASC" : "DESC"}") })
+        self.scope(name.to_s, -> { order("#{Product.quoted_table_name}.#{parts[2]} #{parts[1] == 'ascend' ?  "ASC" : "DESC"}") })
       end
     end
 

--- a/core/spec/models/spree/product/scopes_spec.rb
+++ b/core/spec/models/spree/product/scopes_spec.rb
@@ -20,4 +20,36 @@ describe "Product scopes" do
       Spree::Product.in_taxon(@parent_taxon).to_a.count.should == 1
     end
   end
+
+  context '#add_simple_scopes' do
+    let(:simple_scopes) { [:ascend_by_updated_at, :descend_by_name] }
+
+    before do
+      Spree::Product.add_simple_scopes(simple_scopes)
+    end
+
+    context 'define scope' do
+      context 'ascend_by_updated_at' do
+        context 'on class' do
+          it { Spree::Product.ascend_by_updated_at.to_sql.should eq Spree::Product.order("#{Spree::Product.quoted_table_name}.updated_at ASC").to_sql }
+        end
+
+        context 'on ActiveRecord::Relation' do
+          it { Spree::Product.limit(2).ascend_by_updated_at.to_sql.should eq Spree::Product.limit(2).order("#{Spree::Product.quoted_table_name}.updated_at ASC").to_sql }
+          it { Spree::Product.limit(2).ascend_by_updated_at.to_sql.should eq Spree::Product.ascend_by_updated_at.limit(2).to_sql }
+        end
+      end
+
+      context 'descend_by_name' do
+        context 'on class' do
+          it { Spree::Product.descend_by_name.to_sql.should eq Spree::Product.order("#{Spree::Product.quoted_table_name}.name DESC").to_sql }
+        end
+
+        context 'on ActiveRecord::Relation' do
+          it { Spree::Product.limit(2).descend_by_name.to_sql.should eq Spree::Product.limit(2).order("#{Spree::Product.quoted_table_name}.name DESC").to_sql }
+          it { Spree::Product.limit(2).descend_by_name.to_sql.should eq Spree::Product.descend_by_name.limit(2).to_sql }
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Remove 'relation' from simple scopes definition as it neglects other chain scopes and returns all products.

Steps to reproduce: (In rails console)
-> Get some ActiveRecord::Relation for Spree::Product model, say Spree::Product.limit(2).ascend_by_updated_at

Actual result: Returns all products ascend by updated at
Expected result: Returns 2 products ascend by updated at
