### PR TITLE
Make sure empty string values for code and path are saved as nil value

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -20,6 +20,7 @@ module Spree
 
     # TODO: This shouldn't be necessary with :autosave option but nested attribute updating of actions is broken without it
     after_save :save_rules_and_actions
+    before_save :normalize_blank_values
 
     def save_rules_and_actions
       (rules + actions).each &:save
@@ -67,7 +68,7 @@ module Spree
       eligible = lambda { |r| r.eligible?(promotable, options) }
       specific_rules = rules.for(promotable)
       if match_policy == 'all'
-        # If there are rules for this promotion, but no rules for this 
+        # If there are rules for this promotion, but no rules for this
         # particular promotable, then the promotion is ineligible by default.
         specific_rules.any? && specific_rules.all?(&eligible)
       else
@@ -102,6 +103,13 @@ module Spree
 
     def credits_count
       credits.count
+    end
+
+    private
+    def normalize_blank_values
+      [:code, :path].each do |column|
+        self[column] = nil if self[column].blank?
+      end
     end
   end
 end

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -243,4 +243,14 @@ describe Spree::Promotion do
       end
     end
   end
+
+  # regression for #4059
+  # admin form posts the code and path as empty string
+  describe "normalize blank values for code & path" do
+    it "will save blank value as nil value instead" do
+      promotion = Spree::Promotion.create(:name => "A promotion", :code => "", :path => "")
+      expect(promotion.code).to be_nil
+      expect(promotion.path).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
since the cart promotion handler expects code and path to be nil.
Other solution could be to change the where clauses to search for empty strings,
but that would mean updating all specs and factories to set an empty string
and I like the nil value better.

[Fixes #4059]
