### PR TITLE
use the new line_item_description_text(line_item.description) method.

### DIFF
--- a/core/spec/helpers/products_helper_spec.rb
+++ b/core/spec/helpers/products_helper_spec.rb
@@ -170,7 +170,7 @@ THIS IS THE BEST PRODUCT EVER!
     end
     context "#line_item_description" do
       let(:variant) { create(:variant, :product => product, description: description) }
-      subject { line_item_description(variant) }
+      subject { line_item_description_text(variant.product.description) }
 
       it_should_behave_like "line item descriptions"
     end


### PR DESCRIPTION
Removes all the deprecation warnings.
