### PR TITLE
Change confirm step label to uniform it with other steps

### DIFF
--- a/frontend/app/views/spree/checkout/_confirm.html.erb
+++ b/frontend/app/views/spree/checkout/_confirm.html.erb
@@ -1,6 +1,6 @@
 <fieldset id="order_details" data-hook>
   <div class="clear"></div>
-  <legend align="center"><%= Spree.t(@order.state, :scope => :order_state).titleize %></legend>
+  <legend align="center"><%= Spree.t(:confirm) %></legend>
   <%= render :partial => 'spree/shared/order_details', :locals => { :order => @order } %>
 </fieldset>
 


### PR DESCRIPTION
It's a little one but I think it's better to uniform the way we call steps name label between each checkout steps.

Into other steps it's used a separate label, for example into [delivery](https://github.com/spree/spree/blob/master/frontend/app/views/spree/checkout/_delivery.html.erb#L2) and [payment](https://github.com/spree/spree/blob/master/frontend/app/views/spree/checkout/_payment.html.erb#L2).

Also we have a proper [I18n label](https://github.com/spree/spree/blob/master/core/config/locales/en.yml#L431) for this, so why do not use it?
