### PR TITLE
Add :s3_host_name to Spree configuration options and update S3Support to...

### DIFF
--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -83,6 +83,7 @@ module Spree
     preference :use_s3, :boolean, default: false # Use S3 for images rather than the file system
     preference :s3_protocol, :string
     preference :s3_host_alias, :string
+    preference :s3_host_name, :string
 
     # Default mail headers settings
     preference :enable_mail_delivery, :boolean, :default => false

--- a/core/app/models/spree/image.rb
+++ b/core/app/models/spree/image.rb
@@ -17,11 +17,11 @@ module Spree
     include Spree::Core::S3Support
     supports_s3 :attachment
 
-    Spree::Image.attachment_definitions[:attachment][:styles] = ActiveSupport::JSON.decode(Spree::Config[:attachment_styles]).symbolize_keys!
-    Spree::Image.attachment_definitions[:attachment][:path] = Spree::Config[:attachment_path]
-    Spree::Image.attachment_definitions[:attachment][:url] = Spree::Config[:attachment_url]
-    Spree::Image.attachment_definitions[:attachment][:default_url] = Spree::Config[:attachment_default_url]
-    Spree::Image.attachment_definitions[:attachment][:default_style] = Spree::Config[:attachment_default_style]
+    self.attachment_definitions[:attachment][:styles] = ActiveSupport::JSON.decode(Spree::Config[:attachment_styles]).symbolize_keys!
+    self.attachment_definitions[:attachment][:path] = Spree::Config[:attachment_path]
+    self.attachment_definitions[:attachment][:url] = Spree::Config[:attachment_url]
+    self.attachment_definitions[:attachment][:default_url] = Spree::Config[:attachment_default_url]
+    self.attachment_definitions[:attachment][:default_style] = Spree::Config[:attachment_default_style]
 
     #used by admin products autocomplete
     def mini_url

--- a/core/lib/spree/core/s3_support.rb
+++ b/core/lib/spree/core/s3_support.rb
@@ -17,6 +17,7 @@ module Spree
             self.attachment_definitions[field][:bucket] = config[:s3_bucket]
             self.attachment_definitions[field][:s3_protocol] = config[:s3_protocol].downcase unless config[:s3_protocol].blank?
             self.attachment_definitions[field][:s3_host_alias] = config[:s3_host_alias] unless config[:s3_host_alias].blank?
+            self.attachment_definitions[field][:s3_host_name] = config[:s3_host_name] unless config[:s3_host_name].blank?
           end
         end
       end

--- a/core/lib/spree/testing_support/factories/image_factory.rb
+++ b/core/lib/spree/testing_support/factories/image_factory.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :image, class: Spree::Image do
+    attachment { File.open File.expand_path('../../../../spec/fixtures/thinking-cat.jpg', File.dirname(__FILE__)) }
+  end
+end

--- a/core/spec/models/spree/image_spec.rb
+++ b/core/spec/models/spree/image_spec.rb
@@ -1,5 +1,16 @@
 require 'spec_helper'
 
 describe Spree::Image do
+  let(:image) { build :image }
+  subject { image }
 
+  it 'should have valid factory' do
+    should be_valid
+  end
+
+  describe '#attachment' do
+    subject { image.attachment }
+
+    it { should be_a Paperclip::Attachment }
+  end
 end


### PR DESCRIPTION
In my project I'm using `AmazonS3`, but images accessible only through region specific subdomain `s3-eu-west-1`. Paperclip allows to setup such kind of domain using `s3_host_name`, so I've added this key to `Spree::Config` to be configurable and updated `Spree::Core::S3Support` to use it.

P.S. I've tried to add tests for that, but looks like this changes could no be tested simply, because `Spree::Config` assing it's values on class loading.
