### PR TITLE
Fix for Spree::Money's default currency when currency can't be detected,...

### DIFF
--- a/core/lib/spree/money.rb
+++ b/core/lib/spree/money.rb
@@ -43,7 +43,7 @@ module Spree
       # check that currency passed and embedded currency are the same,
       # and negotiate the final currency
       if currency.nil? and c.nil?
-        currency = Money.default_currency
+        currency = ::Money.default_currency
       elsif currency.nil?
         currency = c
       elsif c.nil?

--- a/core/spec/lib/spree/money_spec.rb
+++ b/core/spec/lib/spree/money_spec.rb
@@ -158,4 +158,19 @@ describe Spree::Money do
       money.as_json(options).should == "$10.00"
     end
   end
+
+  describe ".parse" do
+    subject { Spree::Money.parse input, currency  }
+
+    context "when currency nil" do
+      let(:currency) { nil }
+
+      context "when input value is a number" do
+        let(:input) { 42 }
+
+        it { should be_a ::Money }
+        its(:currency) { should == ::Money.default_currency }
+      end
+    end
+  end
 end


### PR DESCRIPTION
If currency not provided and amount does not contain currency then `Spree::Money.parse` raises an exception. It's because in context of `Spree::Money` class `Money` is a link to `self`.
