### PR TITLE
Admin::Order#edit -> toggleTrackingEdit() fails on 2-0-master with jquery 1.10

### DIFF
--- a/backend/app/assets/javascripts/admin/variant_autocomplete.js.erb
+++ b/backend/app/assets/javascripts/admin/variant_autocomplete.js.erb
@@ -96,8 +96,8 @@ adjustItems = function(shipment_number, variant_id, quantity){
 
 toggleTrackingEdit = function(){
   var link = $(this);
-  link.parents('tbody').find('tr.edit-tracking').toggle();
-  link.parents('tbody').find('tr.show-tracking').toggle();
+  link.parents('tbody').find('tr.edit-tracking').toggleClass('hidden');
+  link.parents('tbody').find('tr.show-tracking').toggleClass('hidden');
 }
 
 toggleMethodEdit = function(){


### PR DESCRIPTION
Hi there!  There seem to be mutually incompatible toggle methods happening here.  Clicking the "edit tracking number" button causes that button to disappear and the expected input never shows up.
### What is supposed to happen

There are two sibling `tr`s with class `hidden`.  Presumably .toggle() is going to toggle that from hidden to not hidden and vice versa.
### What actually happens

Both rows get "style=display:none" applied rather than having their hidden class toggled.  This means no tracking edits.

``` javascript
$(".edit-tracking")
[
<tr class=​"edit-tracking total hidden">​…​</tr>​
, 
<a href=​"#" class=​"edit-tracking icon_link icon-edit no-text with-tip" data-action=​"edit">​…​</a>​
]
$(".edit-tracking").toggle()
[
<tr class=​"edit-tracking total hidden" style=​"display:​ table-row;​">​…​</tr>​
, 
<a href=​"#" class=​"edit-tracking icon_link icon-edit no-text with-tip" data-action=​"edit" style=​"display:​ none;​">​</a>​
]
```
### Further concerns beyond this PR

It looks like there are other `.hidden` elements on this page and I can see plenty of `.toggle()` calls in the associated `variant_autocomplete` file.  This problem likely exists beyond the scope of my single report.

FWIW the jQuery toggle source I'm seeing on my page is here:

``` javascript
$().toggle
function ( option ) {
            if ( standardAnimationOption( option ) || typeof option === "boolean" ) {
                return orig.apply( this, arguments );
            } else {
                var args = _normalizeArguments.apply( this, arguments );
                args.mode = "toggle";
                return this.effect.call( this, args );
            }
        } 

jQuery.fn.jquery
"1.10.2"
```
