### PR TITLE
Warn about missing migrations

### DIFF
--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -52,6 +52,7 @@ require 'spree/core/environment_extension'
 require 'spree/core/environment/calculators'
 require 'spree/core/environment'
 require 'spree/promo/environment'
+require 'spree/migrations'
 require 'spree/core/engine'
 
 require 'spree/i18n'

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -98,6 +98,10 @@ module Spree
           :number,
           :verification_value]
       end
+
+      initializer "spree.core.checking_migrations" do |app|
+        Migrations.new(config, engine_name).check
+      end
     end
   end
 end

--- a/core/lib/spree/migrations.rb
+++ b/core/lib/spree/migrations.rb
@@ -1,0 +1,55 @@
+module Spree
+  class Migrations
+    attr_reader :config, :engine_name
+
+    # Takes the engine config block and engine name
+    def initialize(config, engine_name)
+      @config, @engine_name = config, engine_name
+    end
+
+    # Puts warning when any engine migration is not present on the Rails app
+    # db/migrate dir
+    #
+    # First split:
+    #
+    #   ["20131128203548", "update_name_fields_on_spree_credit_cards.spree.rb"]
+    #
+    # Second split should give the engine_name of the migration
+    #
+    #   ["update_name_fields_on_spree_credit_cards", "spree.rb"]
+    #
+    # Shouldn't run on test mode because migrations inside engine don't have
+    # engine name on the file name
+    def check
+      if File.exists?("config/spree.yml") && File.directory?("db/migrate")
+        engine_in_app = app_migrations.map do |file_name|
+          name, engine = file_name.split(".", 2)
+          next unless engine == "#{engine_name}.rb"
+          name
+        end.compact! || []
+
+        unless (engine_migrations.sort - engine_in_app.sort).empty?
+          puts "[#{engine_name.capitalize} WARNING] Missing migrations." \
+               "Run `bundle exec rake railties:install:migrations` to get them.\n\n"
+          true
+        end
+      end
+    end
+
+    private
+      def engine_migrations
+        Dir.entries("#{config.root}/db/migrate").map do |file_name|
+          name = file_name.split("_", 2).last.split(".", 2).first
+          name.empty? ? next : name
+        end.compact! || []
+      end
+
+      def app_migrations
+        Dir.entries("db/migrate").map do |file_name|
+          next if [".", ".."].include? file_name
+          name = file_name.split("_", 2).last
+          name.empty? ? next : name
+        end.compact! || []
+      end
+  end
+end

--- a/core/spec/lib/spree/migrations_spec.rb
+++ b/core/spec/lib/spree/migrations_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+module Spree
+  describe Migrations do
+    let(:app_migrations) { [".", "34_add_title.rb", "52_add_text.rb"] }
+    let(:engine_migrations) { [".", "334_create_orders.spree.rb", "777_create_products.spree.rb"] }
+
+    let(:config) { double("Config", root: "dir") }
+
+    subject { described_class.new(config, "spree")  }
+
+    before do
+      expect(File).to receive(:exists?).with("config/spree.yml").and_return true
+      expect(File).to receive(:directory?).with("db/migrate").and_return true
+    end
+
+    it "warns about missing migrations" do
+      expect(Dir).to receive(:entries).with("db/migrate").and_return app_migrations
+      expect(Dir).to receive(:entries).with("dir/db/migrate").and_return engine_migrations
+
+      silence_stream(STDOUT) {
+        expect(subject.check).to eq true
+      }
+    end
+
+    context "no missing migrations" do
+      it "says nothing" do
+        expect(Dir).to receive(:entries).with("dir/db/migrate").and_return engine_migrations
+        expect(Dir).to receive(:entries).with("db/migrate").and_return (app_migrations + engine_migrations)
+        expect(subject.check).to eq nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Every time users boot their apps they would see a warning like:

```
[spree] Missing migrations. Run `bundle exec rake railties:install:migrations` to get them.
```

Would you guys think this is a valid / useful idea? Or would this just bring too much overhead and won't ever work properly anyway (aka bad stupid idea)? I think it's pretty common to forget about copying migrations after upgrading spree or some extension and stop a bit yesterday to think about what we could do to remember users while they're launching their apps.

Note: this code is probably is probably broken. I opened the PR more as a way to get feedback on the idea. Maybe we could move on from here to a better implementation, put it in another gem or just forget about it.

no :beers: this weekend
