### PR TITLE
fix for report locale names when extending via class_eval

### DIFF
--- a/backend/app/controllers/spree/admin/reports_controller.rb
+++ b/backend/app/controllers/spree/admin/reports_controller.rb
@@ -3,12 +3,26 @@ module Spree
     class ReportsController < Spree::Admin::BaseController
       respond_to :html
 
-      AVAILABLE_REPORTS = {
-        :sales_total => { :name => Spree.t(:sales_total), :description => Spree.t(:sales_total_description) }
-      }
+      class << self
+        def available_reports
+          @@available_reports
+        end
+
+        def add_available_report!(report_key, report_description_key = nil)
+          if report_description_key.nil?
+            report_description_key = "#{report_key}_description"
+          end
+          @@available_reports[report_key] = {name: Spree.t(report_key), description: Spree.t(report_description_key)}
+        end
+      end
+
+      def initialize
+        super 
+        ReportsController.add_available_report!(:sales_total)
+      end
 
       def index
-        @reports = AVAILABLE_REPORTS
+        @reports = ReportsController.available_reports
       end
 
       def sales_total
@@ -49,6 +63,8 @@ module Spree
       def model_class
         Spree::Admin::ReportsController
       end
+
+      @@available_reports = {}
 
     end
   end

--- a/backend/spec/controllers/spree/admin/reports_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/reports_controller_spec.rb
@@ -1,9 +1,42 @@
 require 'spec_helper'
 
 describe Spree::Admin::ReportsController do
+  stub_authorization!
+
+  describe 'ReportsController.available_reports' do
+    it 'should contain sales_total' do
+      Spree::Admin::ReportsController.available_reports.keys.include?(:sales_total).should be_true
+    end
+
+    it 'should have the proper sales total report description' do
+      Spree::Admin::ReportsController.available_reports[:sales_total][:description].should eql('Sales Total For All Orders')
+    end
+
+  end
+
+  describe 'ReportsController.add_available_report!' do
+    context 'when adding the report name' do
+      it 'should contain the report' do
+        Spree::Admin::ReportsController.add_available_report!(:some_report)
+        Spree::Admin::ReportsController.available_reports.keys.include?(:some_report).should be_true
+      end
+    end
+  end
+
+  describe 'GET index' do
+    it 'should be ok' do
+      spree_get :index
+      response.should be_ok
+    end
+  end
 
   it 'should respond to model_class as Spree::AdminReportsController' do
     controller.send(:model_class).should eql(Spree::Admin::ReportsController)
   end
 
+  after(:each) do
+    Spree::Admin::ReportsController.available_reports.delete_if do |key, value|
+      key != :sales_total
+    end
+  end
 end


### PR DESCRIPTION
- source issue: https://github.com/spree/spree/issues/4086
- try to maintain the reports not in a constant
- make it easier to add new reports over current merging of hash of hashes way

Example decorator now becomes:

https://gist.github.com/HoyaBoya/7890846

As opposed to what people are doing here for example:

https://github.com/jenius/spree_advanced_reporting/blob/master/app/controllers/spree/admin/reports_controller_decorator.rb#L5-L11
