### PR TITLE
Allow mail settings changes to apply without server restart

### DIFF
--- a/backend/app/controllers/spree/admin/mail_methods_controller.rb
+++ b/backend/app/controllers/spree/admin/mail_methods_controller.rb
@@ -1,8 +1,6 @@
 module Spree
   module Admin
     class MailMethodsController < Spree::Admin::BaseController
-      after_filter :initialize_mail_settings
-
       def update
         if params[:smtp_password].blank?
           params.delete(:smtp_password)
@@ -14,7 +12,7 @@ module Spree
         end
 
         flash[:success] = Spree.t(:successfully_updated, :resource => Spree.t(:mail_methods))
-        render :edit
+        redirect_to edit_admin_mail_method_url
       end
 
       def testmail
@@ -28,11 +26,6 @@ module Spree
       ensure
         redirect_to edit_admin_mail_method_url
       end
-
-      private
-        def initialize_mail_settings
-          Spree::Core::MailSettings.init
-        end
     end
   end
 end

--- a/backend/spec/controllers/spree/admin/mail_methods_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/mail_methods_controller_spec.rb
@@ -5,17 +5,15 @@ describe Spree::Admin::MailMethodsController do
 
   context "#update" do
     it "should reinitialize the mail settings" do
-      Spree::Core::MailSettings.should_receive(:init)
       spree_put :update, { :enable_mail_delivery => "1", :mails_from => "spree@example.com" }
+      response.should be_redirect
     end
   end
 
   it "can trigger testmail" do
-    request.env["HTTP_REFERER"] = "/"
     user = create(:user, email: 'user@spree.com')
     controller.stub(:try_spree_current_user => user)
     Spree::Config[:enable_mail_delivery] = "1"
-    ActionMailer::Base.perform_deliveries = true
 
     expect {
       spree_post :testmail

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -45,8 +45,9 @@ end
 
 require 'spree/core/version'
 
-require 'spree/core/mail_settings'
 require 'spree/core/mail_interceptor'
+require 'spree/core/mail_method'
+require 'spree/core/mail_settings'
 require 'spree/core/environment_extension'
 require 'spree/core/environment/calculators'
 require 'spree/core/environment'

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -40,6 +40,7 @@ module Spree
       end
 
       initializer "spree.mail.settings" do |app|
+        ActionMailer::Base.add_delivery_method :spree, Spree::Core::MailMethod
         Spree::Core::MailSettings.init
         Mail.register_interceptor(Spree::Core::MailInterceptor)
       end

--- a/core/lib/spree/core/mail_method.rb
+++ b/core/lib/spree/core/mail_method.rb
@@ -1,0 +1,27 @@
+module Spree
+  module Core
+    class MailMethod
+      def initialize(options={})
+      end
+
+      def deliver!(mail)
+        if Config.enable_mail_delivery
+          mailer.deliver!(mail)
+        end
+      end
+
+      def mailer
+        mailer_class.new(mail_server_settings)
+      end
+
+      private
+      def mailer_class
+        Rails.env.test?? Mail::TestMailer : Mail::SMTP
+      end
+
+      def mail_server_settings
+        MailSettings.new.mail_server_settings
+      end
+    end
+  end
+end

--- a/core/lib/spree/core/mail_settings.rb
+++ b/core/lib/spree/core/mail_settings.rb
@@ -8,53 +8,48 @@ module Spree
       # This makes it possible to configure the mail settings through an admin
       # interface instead of requiring changes to the Rails envrionment file
       def self.init
-        self.new.override! if override?
+        override! if override?
       end
 
       def self.override?
         Config.override_actionmailer_config
       end
 
-      def override!
-        if Config.enable_mail_delivery
-          ActionMailer::Base.default_url_options[:host] ||= Config.site_url
-          ActionMailer::Base.smtp_settings = mail_server_settings
-          ActionMailer::Base.perform_deliveries = true
-        else
-          ActionMailer::Base.perform_deliveries = false
-        end
+      def self.override!
+        ActionMailer::Base.delivery_method = :spree
+        ActionMailer::Base.default_url_options[:host] ||= Config.site_url
+      end
+
+      def mail_server_settings
+        settings = if need_authentication?
+                     basic_settings.merge(user_credentials)
+                   else
+                     basic_settings
+                   end
+
+        settings.merge :enable_starttls_auto => secure_connection?
       end
 
       private
-        def mail_server_settings
-          settings = if need_authentication?
-            basic_settings.merge(user_credentials)
-          else
-            basic_settings
-          end
+      def user_credentials
+        { :user_name => Config.smtp_username,
+          :password => Config.smtp_password }
+      end
 
-          settings.merge :enable_starttls_auto => secure_connection?
-        end
+      def basic_settings
+        { :address => Config.mail_host,
+          :domain => Config.mail_domain,
+          :port => Config.mail_port,
+          :authentication => Config.mail_auth_type }
+      end
 
-        def user_credentials
-          { :user_name => Config.smtp_username,
-            :password => Config.smtp_password }
-        end
+      def need_authentication?
+        Config.mail_auth_type != 'None'
+      end
 
-        def basic_settings
-          { :address => Config.mail_host,
-            :domain => Config.mail_domain,
-            :port => Config.mail_port,
-            :authentication => Config.mail_auth_type }
-        end
-
-        def need_authentication?
-          Config.mail_auth_type != 'None'
-        end
-
-        def secure_connection?
-          Config.secure_connection_type == 'TLS'
-        end
+      def secure_connection?
+        Config.secure_connection_type == 'TLS'
+      end
     end
   end
 end

--- a/core/spec/lib/mail_settings_spec.rb
+++ b/core/spec/lib/mail_settings_spec.rb
@@ -3,84 +3,56 @@ require 'spec_helper'
 module Spree
   module Core
     describe MailSettings do
-      let!(:subject) { MailSettings.new }
-
       context "override option is true" do
         before { Config.override_actionmailer_config = true }
 
-        context "init" do
-          it "calls override!" do
-            MailSettings.should_receive(:new).and_return(subject)
-            subject.should_receive(:override!)
-            MailSettings.init
-          end
-        end
-
-        context "enable delivery" do
-          before { Config.enable_mail_delivery = true }
-
-          context "overrides appplication defaults" do
-
-            context "authentication method is none" do
-              before do
-                Config.mail_host = "smtp.example.com"
-                Config.mail_domain = "example.com"
-                Config.mail_port = 123
-                Config.mail_auth_type = MailSettings::SECURE_CONNECTION_TYPES[0]
-                Config.smtp_username = "schof"
-                Config.smtp_password = "hellospree!"
-                Config.secure_connection_type = "TLS"
-                subject.override!
-              end
-
-              it { ActionMailer::Base.smtp_settings[:address].should == "smtp.example.com" }
-              it { ActionMailer::Base.smtp_settings[:domain].should == "example.com" }
-              it { ActionMailer::Base.smtp_settings[:port].should == 123 }
-              it { ActionMailer::Base.smtp_settings[:authentication].should == "None" }
-              it { ActionMailer::Base.smtp_settings[:enable_starttls_auto].should be_true }
-
-              it "doesnt touch user name config" do
-                ActionMailer::Base.smtp_settings[:user_name].should == nil
-              end
-
-              it "doesnt touch password config" do
-                ActionMailer::Base.smtp_settings[:password].should == nil
-              end
-            end
-          end
-
-          context "when mail_auth_type is other than none" do
-            before do
-              Config.mail_auth_type = "login"
-              Config.smtp_username = "schof"
-              Config.smtp_password = "hellospree!"
-              subject.override!
-            end
-
-            context "overrides user credentials" do
-              it { ActionMailer::Base.smtp_settings[:user_name].should == "schof" }
-              it { ActionMailer::Base.smtp_settings[:password].should == "hellospree!" }
-            end
-          end
-        end
-
-        context "do not enable delivery" do
-          before do
-            Config.enable_mail_delivery = false
-            subject.override!
-          end
-
-          it { ActionMailer::Base.perform_deliveries.should be_false }
+        it "calls override!" do
+          ActionMailer::Base.should_receive(:delivery_method=).with(:spree)
+          MailSettings.init
         end
       end
 
       context "override option is false" do
         before { Config.override_actionmailer_config = false }
 
-        context "init" do
-          it "doesnt calls override!" do
-            subject.should_not_receive(:override!)
-            MailSettings.init
+        it "doesnt calls override!" do
+          MailSettings.should_not_receive(:override!)
+          MailSettings.init
+        end
+      end
+
+      describe "mail_server_settings" do
+        subject{ described_class.new.mail_server_settings }
+        context "authentication method is none" do
+          before do
+            Config.mail_host = "smtp.example.com"
+            Config.mail_domain = "example.com"
+            Config.mail_port = 123
+            Config.mail_auth_type = MailSettings::SECURE_CONNECTION_TYPES[0]
+            Config.smtp_username = "schof"
+            Config.smtp_password = "hellospree!"
+            Config.secure_connection_type = "TLS"
+          end
+
+          it { subject[:address].should == "smtp.example.com" }
+          it { subject[:domain].should == "example.com" }
+          it { subject[:port].should == 123 }
+          it { subject[:authentication].should == "None" }
+          it { subject[:enable_starttls_auto].should be_true }
+          it { should_not have_key(:user_name) }
+          it { should_not have_key(:password) }
+        end
+
+        context "when mail_auth_type is other than none" do
+          before do
+            Config.mail_auth_type = "login"
+            Config.smtp_username = "schof"
+            Config.smtp_password = "hellospree!"
+          end
+
+          context "overrides user credentials" do
+            it { subject[:user_name].should == "schof" }
+            it { subject[:password].should == "hellospree!" }
           end
         end
       end

--- a/core/spec/lib/spree/core/mail_method_spec.rb
+++ b/core/spec/lib/spree/core/mail_method_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+module Spree
+  module Core
+    describe MailMethod do
+      let(:mail_method){ described_class.new }
+      let(:mail) do
+        Mail.new do
+          from 'spree@example.com'
+          to 'customer@example.com'
+        end
+      end
+      context "mail delivery enabled" do
+        before { Config.enable_mail_delivery = true }
+        it "should deliver mail" do
+          expect {
+            mail_method.deliver!(mail)
+          }.to change { ActionMailer::Base.deliveries.size }.by(1)
+        end
+      end
+      context "mail delivery disabled" do
+        before { Config.enable_mail_delivery = false }
+        it "shouldn't deliver mail" do
+          expect {
+            mail_method.deliver!(mail)
+          }.not_to change { ActionMailer::Base.deliveries.size }
+        end
+      end
+      describe "mailer uses custom settings" do
+        subject { mail_method.mailer.settings }
+        it { should == MailSettings.new.mail_server_settings }
+      end
+    end
+  end
+end


### PR DESCRIPTION
mail settings need a server restart to be applied (it's an offender of #3833).

This creates a new mail delivery_method (`Spree::Core::MailMethod`) which checks spree's settings for each delivery. This also opens up the possibility to configure spree to use different underlying methods (like sendmail) in the future.
