### PR TITLE
Don't access :allow_ssl_in_* during initialization

### DIFF
--- a/core/lib/spree/core/controller_helpers/ssl.rb
+++ b/core/lib/spree/core/controller_helpers/ssl.rb
@@ -15,16 +15,14 @@ module Spree
 
           def self.ssl_required(*actions)
             ssl_allowed *actions
-            if ssl_supported?
-              if actions.empty? or Rails.application.config.force_ssl
-                force_ssl
-              else
-                force_ssl :only => actions
-              end
+            if actions.empty? or Rails.application.config.force_ssl
+              force_ssl :if => :ssl_supported?
+            else
+              force_ssl :if => :ssl_supported?, :only => actions
             end
           end
 
-          def self.ssl_supported?
+          def ssl_supported?
             return Spree::Config[:allow_ssl_in_production] if Rails.env.production?
             return Spree::Config[:allow_ssl_in_staging] if Rails.env.staging?
             return Spree::Config[:allow_ssl_in_development_and_test] if (Rails.env.development? or Rails.env.test?)

--- a/core/spec/lib/spree/core/controller_helpers/ssl_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/ssl_spec.rb
@@ -5,7 +5,7 @@ describe Spree::Core::ControllerHelpers::SSL, :type => :controller do
     include Spree::Core::ControllerHelpers::SSL
     def index; render text: 'index'; end
     def create; end
-    def self.ssl_supported?; true; end
+    def ssl_supported?; true; end
   end
 
   describe 'redirect to http' do


### PR DESCRIPTION
This causes changes to `Spree::Config.allow_ssl_in_*` (see) to be used at runtime without a server restart.

The `:if` parameter of `force_ssl` is only available in rails >= 4. (So this should work for spree >= 2.1)
