### PR TITLE
Fix available package shipping methods (for master)

### DIFF
--- a/core/app/models/spree/stock/package.rb
+++ b/core/app/models/spree/stock/package.rb
@@ -85,7 +85,7 @@ module Spree
       end
 
       def shipping_methods
-        shipping_categories.map { |sc| sc.shipping_methods }.flatten.uniq
+        shipping_categories.map(&:shipping_methods).reduce(:&).to_a
       end
 
       def inspect

--- a/core/db/migrate/20131211192741_unique_shipping_method_categories.rb
+++ b/core/db/migrate/20131211192741_unique_shipping_method_categories.rb
@@ -1,0 +1,24 @@
+class UniqueShippingMethodCategories < ActiveRecord::Migration
+  def change
+    klass   = Spree::ShippingMethodCategory
+    columns = %w[shipping_category_id shipping_method_id]
+
+    say "Find duplicate #{klass} records"
+    duplicates = klass.
+      select((columns + %w[COUNT(*)]).join(',')).
+      group(columns.join(',')).
+      having('COUNT(*) > 1').
+      map { |row| row.attributes.slice(*columns) }
+
+    say "Delete all but the oldest duplicate #{klass} record"
+    duplicates.each do |conditions|
+      klass.where(conditions).order(:created_at).drop(1).each(&:destroy)
+    end
+
+    say "Add unique index to #{klass.table_name} for #{columns.inspect}"
+    add_index klass.table_name, columns, unique: true, name: 'unique_spree_shipping_method_categories'
+
+    say "Remove redundant simple index on #{klass.table_name}"
+    remove_index klass.table_name, name: 'index_spree_shipping_method_categories_on_shipping_category_id'
+  end
+end

--- a/core/spec/models/spree/stock/package_spec.rb
+++ b/core/spec/models/spree/stock/package_spec.rb
@@ -74,10 +74,10 @@ module Spree
         variant1 = mock_model(Variant, shipping_category: category1)
         variant2 = mock_model(Variant, shipping_category: category2)
         variant3 = mock_model(Variant, shipping_category: nil)
-        contents = [Package::ContentItem.new(line_item, variant, 1),
-                    Package::ContentItem.new(line_item, variant, 1),
-                    Package::ContentItem.new(line_item, variant, 1),
-                    Package::ContentItem.new(line_item, variant, 1)]
+        contents = [Package::ContentItem.new(line_item, variant1, 1),
+                    Package::ContentItem.new(line_item, variant1, 1),
+                    Package::ContentItem.new(line_item, variant2, 1),
+                    Package::ContentItem.new(line_item, variant3, 1)]
 
         package = Package.new(stock_location, order, contents)
         package.shipping_methods.should == [method1]
@@ -85,7 +85,7 @@ module Spree
 
       it 'builds an empty list of shipping methods when no categories' do
         variant  = mock_model(Variant, shipping_category: nil)
-        contents = [Package::ContentItem.new(variant, 1)]
+        contents = [Package::ContentItem.new(line_item, variant, 1)]
         package  = Package.new(stock_location, order, contents)
         package.shipping_methods.should be_empty
       end

--- a/sample/db/samples/shipping_methods.rb
+++ b/sample/db/samples/shipping_methods.rb
@@ -56,7 +56,6 @@ end
   shipping_method = Spree::ShippingMethod.find_by_name!(shipping_method_name)
   shipping_method.calculator.preferred_amount = price
   shipping_method.calculator.preferred_currency = currency
-  shipping_method.shipping_categories << Spree::ShippingCategory.first
   shipping_method.save!
 end
 

--- a/sample/db/samples/shipping_methods.rb
+++ b/sample/db/samples/shipping_methods.rb
@@ -9,7 +9,7 @@ end
 europe_vat = Spree::Zone.find_by_name!("EU_VAT")
 shipping_category = Spree::ShippingCategory.find_or_create_by!(name: 'Default')
 
-shipping_methods = [
+Spree::ShippingMethod.create!([
   {
     :name => "UPS Ground (USD)",
     :zones => [north_america],
@@ -40,11 +40,7 @@ shipping_methods = [
     :calculator => Spree::Calculator::Shipping::FlatRate.create!,
     :shipping_categories => [shipping_category]
   }
-]
-
-shipping_methods.each do |shipping_method_attrs|
-  Spree::ShippingMethod.create!(shipping_method_attrs)
-end
+])
 
 {
   "UPS Ground (USD)" => [5, "USD"],


### PR DESCRIPTION
(NOTE: This is related to #4102)

This branch fixes the package shipping methods to only return the shipping methods that are _common_ to all the shipping categories. The current code returns _all_ the shipping methods, even those that may not apply to a product.

Typically this isn't noticeable since `Spree::Stock::Splitter::ShippingCategory` is enabled by default, and splits up the package into separate packages grouped by the shipping category. However, when this is not used then the package can potentially return invalid shipping methods.

This also adds a unique constraint to the table used by `Spree::ShippingMethodCategory` that ensures the join record is only recorded once. The migration will also remove any duplicate records before applying the uniqueness constraint.
