### PR TITLE
Load promotion rules after app initialization

### DIFF
--- a/promo/lib/spree/promo/engine.rb
+++ b/promo/lib/spree/promo/engine.rb
@@ -20,9 +20,12 @@ module Spree
       config.autoload_paths += %W(#{config.root}/lib)
       config.to_prepare &method(:activate).to_proc
 
+      # We need to define promotions rules here so extensions and existing apps
+      # can add their custom classes on their initializer files
       initializer 'spree.promo.environment', :after => 'spree.environment' do |app|
         app.config.spree.add_class('promotions')
         app.config.spree.promotions = Spree::Promo::Environment.new
+        app.config.spree.promotions.rules = []
       end
 
       initializer 'spree.promo.register.promotion.calculators' do |app|
@@ -37,8 +40,12 @@ module Spree
         ]
       end
 
-      initializer 'spree.promo.register.promotions.rules' do |app|
-        app.config.spree.promotions.rules = [
+      # Promotion rules need to be evaluated on after initialize otherwise
+      # Spree.user_class would be nil and users might experience errors related
+      # to malformed model associations (Spree.user_class is only defined on
+      # the app initializer)
+      config.after_initialize do
+        Rails.application.config.spree.promotions.rules.concat [
           Spree::Promotion::Rules::ItemTotal,
           Spree::Promotion::Rules::Product,
           Spree::Promotion::Rules::User,


### PR DESCRIPTION
So that they can make proper use of `Spree.user_class` which is only
defined on the app spree.rb initializer

[Fixes #3152]

This fix is already applied to spree 2.0 and 2.1 
