### PR TITLE
adds div data-hook='cart_container' as a containing element to the cart

### DIFF
--- a/frontend/app/views/spree/orders/edit.html.erb
+++ b/frontend/app/views/spree/orders/edit.html.erb
@@ -1,44 +1,45 @@
 <% @body_id = 'cart' %>
+<div data-hook="cart_container">
+  <h1><%= Spree.t(:shopping_cart) %></h1>
 
-<h1><%= Spree.t(:shopping_cart) %></h1>
+  <% if @order.line_items.empty? %>
 
-<% if @order.line_items.empty? %>
+    <div data-hook="empty_cart">
+      <p><%= Spree.t(:your_cart_is_empty) %></p>
+      <p><%= link_to Spree.t(:continue_shopping), products_path, :class => 'button continue' %></p>
+    </div>
 
-  <div data-hook="empty_cart">
-    <p><%= Spree.t(:your_cart_is_empty) %></p>
-    <p><%= link_to Spree.t(:continue_shopping), products_path, :class => 'button continue' %></p>
-  </div>
-
-<% else %>
-  <div data-hook="outside_cart_form">
+  <% else %>
+    <div data-hook="outside_cart_form">
     <%= form_for @order, :url => update_cart_path, :html => {:id => 'update-cart'} do |order_form| %>
       <div data-hook="inside_cart_form">
 
-        <div data-hook="cart_items">
-          <%= render :partial => 'form', :locals => { :order_form => order_form } %>
-        </div>
-
-        <div class="links columns sixteen alpha omega" data-hook="cart_buttons">
-          <%= order_form.text_field :coupon_code, :size => 10, :placeholder => Spree.t(:coupon_code) %>
-          <%= button_tag :class => 'primary', :id => 'update-button' do %>
-            <%= Spree.t(:update) %>
-          <% end %>
-          <%= button_tag :class => 'button checkout primary', :id => 'checkout-link', :name => 'checkout' do %>
-            <%= Spree.t(:checkout) %>
-          <% end %>
-        </div>
+      <div data-hook="cart_items">
+        <%= render :partial => 'form', :locals => { :order_form => order_form } %>
       </div>
-    <% end %>
+
+      <div class="links columns sixteen alpha omega" data-hook="cart_buttons">
+        <%= order_form.text_field :coupon_code, :size => 10, :placeholder => Spree.t(:coupon_code) %>
+        <%= button_tag :class => 'primary', :id => 'update-button' do %>
+          <%= Spree.t(:update) %>
+      <% end %>
+        <%= button_tag :class => 'button checkout primary', :id => 'checkout-link', :name => 'checkout' do %>
+          <%= Spree.t(:checkout) %>
+      <% end %>
+      </div>
+    </div>
+  <% end %>
   </div>
 
   <div id="empty-cart" data-hook>
     <%= form_tag empty_cart_path, :method => :put do %>
       <p id="clear_cart_link" data-hook>
-        <%= submit_tag Spree.t(:empty_cart), :class => 'button gray' %>
-        <%= Spree.t(:or) %>
-        <%= link_to Spree.t(:continue_shopping), products_path, :class => 'continue button gray' %>
-      </p>
-    <% end %>
+    <%= submit_tag Spree.t(:empty_cart), :class => 'button gray' %>
+    <%= Spree.t(:or) %>
+    <%= link_to Spree.t(:continue_shopping), products_path, :class => 'continue button gray' %>
+    </p>
+  <% end %>
   </div>
 
-<% end %>
+  <% end %>
+</div>

--- a/frontend/spec/features/cart_spec.rb
+++ b/frontend/spec/features/cart_spec.rb
@@ -62,4 +62,8 @@ describe "Cart", inaccessible: true do
       page.should have_content(product.name)
     end
   end
+  it "should have a surrounding element with data-hook='cart_container'" do
+    visit spree.cart_path
+    page.should have_selector("div[data-hook='cart_container']")
+  end
 end


### PR DESCRIPTION
This change allows deface to interact with the entire cart contents for purpose of formatting. Previously the h1 containing the headline was excluded from the containing div and was only accessible by using very broad scopes.
