### PR TITLE
set the requires_authentication preference to false for running the backend specs

### DIFF
--- a/backend/spec/controllers/spree/admin/alerts_spec.rb
+++ b/backend/spec/controllers/spree/admin/alerts_spec.rb
@@ -13,10 +13,6 @@ describe 'alerts' do
     end
   end
 
-  before do
-    # Spree::Alert.should_receive(:current).and_return("string")
-  end
-
   # Regression test for #3716
   it "alerts returned wrong data type" do
     get :index, {}

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -35,6 +35,7 @@ require 'spree/testing_support/capybara_ext'
 
 require 'paperclip/matchers'
 
+
 RSpec.configure do |config|
   config.color = true
   config.mock_with :rspec
@@ -89,4 +90,8 @@ RSpec.configure do |config|
   config.include Paperclip::Shoulda::Matchers
 
   config.fail_fast = ENV['FAIL_FAST'] || false
+
+  config.before do
+    Spree::Api::Config[:requires_authentication] = false
+  end
 end

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -103,4 +103,8 @@ RSpec.configure do |config|
   config.include Paperclip::Shoulda::Matchers
 
   config.fail_fast = ENV['FAIL_FAST'] || false
+
+  config.before do
+    Spree::Api::Config[:requires_authentication] = false
+  end
 end


### PR DESCRIPTION
it's safe to do this since the requires_authentication is tested correctly
in the api specs.
