### PR TITLE
Update readme for new CI location

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Running Tests
 
 We use [TeamCity](http://www.jetbrains.com/teamcity/) to run the tests for Spree.
 
-You can see the build statuses at [http://ci.spreecommerce.com](http://ci.spreecommerce.com/guestLogin.html?guest=1).
+You can see the build statuses at [http://ci.spree.fm](http://ci.spree.fm/guestLogin.html?guest=1).
 
 ---
 


### PR DESCRIPTION
The move of domain is permanent, according to the spreefolk in IRC
