### PR TITLE
working route tests for spree

### DIFF
--- a/api/spec/routing/spree/api/orders_controller_spec.rb
+++ b/api/spec/routing/spree/api/orders_controller_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe Spree::Api::OrdersController do
+
+  routes { Spree::Core::Engine.routes }
+
+  describe "PUT /api/orders/:id/apply_coupon" do
+    it "should route" do
+      expect(:put => "/api/orders/123/apply_coupon_code?coupon_code=X").to route_to(
+        controller:   'spree/api/orders',
+        action:       'apply_coupon_code',
+        id:           '123',
+        coupon_code:  'X',
+        format:       'json'
+      )
+    end
+  end
+
+  describe "GET /api/orders/mine" do
+    it "should route" do
+      expect(:get => "/api/orders/mine").to route_to(
+        controller: 'spree/api/orders',
+        action:     'mine',
+        format:     'json'
+      )
+    end
+  end
+end
+


### PR DESCRIPTION
- working route tests for 2 API order endpoints, /mine and /apply_coupon_code
- hopefully useful to others wanting to write route tests and improves coverage of spree api

Been having a really hard time writing route tests for Spree...spent a lot of time Googling/Stack-Overflowing and finally found something that works that lets me test routes. The original cause was having /api/orders/mine end up in the orders#show?id=mine incorrectly. The issue was in our app, not API, but not having a test made things really hard to diagnose.

Sending this commit to Spree as a future template for letting other's write route tests. If not accepted, I'll just blog about it.
