### PR TITLE
Flush out association between payment and its method.

### DIFF
--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -8,6 +8,8 @@ module Spree
 
     validates :name, presence: true
 
+    has_many :payments, class_name: "Spree::Payment"
+
     def self.providers
       Rails.application.config.spree.payment_methods
     end


### PR DESCRIPTION
A payment belongs to a payment method, so a payment method should have many payments.
