### PR TITLE
Fixed order total and shipment cost not updating after changing shipping rate

### DIFF
--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -44,6 +44,7 @@ module Spree
           end
           return if after_update_attributes
           state_callback(:after) if @order.next
+          OrderUpdater.new(@order).update
           respond_with(@order, default_template: 'spree/api/orders/show')
         else
           invalid_resource!(@order)

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -108,6 +108,7 @@ module Spree
     def selected_shipping_rate_id=(id)
       shipping_rates.update_all(selected: false)
       shipping_rates.update(id, selected: true)
+      persist_cost
       self.save!
     end
 


### PR DESCRIPTION
After changing shipping rate in checkouts controller, the order total and shipment cost remained the same. This commit fixes this problem.

**Steps to reproduce**
1. Create a checkout and progress it to delivery state
2. Switch between shipping rates with different cost

Expecting order total to change, but nothing happens.

I got no regression test as there is some problem with shipment methods in checkouts controller test. After refreshing rates [in this line](https://github.com/spree/spree/blob/master/api/spec/controllers/spree/api/checkouts_controller_spec.rb#L111), the shipment has three shipping rates, and every one's cost is 0. Any ideas for this?
