### PR TITLE
Order token in headers

### DIFF
--- a/api/app/controllers/spree/api/addresses_controller.rb
+++ b/api/app/controllers/spree/api/addresses_controller.rb
@@ -4,13 +4,13 @@ module Spree
       before_filter :find_order
 
       def show
-        authorize! :read, @order, params[:order_token]
+        authorize! :read, @order, order_token
         find_address
         respond_with(@address)
       end
 
       def update
-        authorize! :update, @order, params[:order_token]
+        authorize! :update, @order, order_token
         find_address
 
         if @address.update_attributes(address_params)
@@ -37,6 +37,10 @@ module Spree
           else
             raise CanCan::AccessDenied
           end
+        end
+
+        def order_token
+          request.headers["X-Spree-Order-Token"] || params[:order_token]
         end
     end
   end

--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -16,7 +16,7 @@ module Spree
       end
 
       def next
-        authorize! :update, @order, params[:order_token]
+        authorize! :update, @order, order_token
         @order.next!
         respond_with(@order, default_template: 'spree/api/orders/show', status: 200)
       rescue StateMachine::InvalidTransition
@@ -24,7 +24,7 @@ module Spree
       end
 
       def advance
-        authorize! :update, @order, params[:order_token]
+        authorize! :update, @order, order_token
         while @order.next; end
         respond_with(@order, default_template: 'spree/api/orders/show', status: 200)
       end
@@ -34,7 +34,7 @@ module Spree
       end
 
       def update
-        authorize! :update, @order, params[:order_token]
+        authorize! :update, @order, order_token
         order_params = object_params
         line_items = order_params.delete('line_items_attributes')
         if @order.update_attributes(order_params)
@@ -131,6 +131,10 @@ module Spree
             end
           end
           false
+        end
+
+        def order_token
+          request.headers["X-Spree-Order-Token"] || params[:order_token]
         end
     end
   end

--- a/api/app/controllers/spree/api/line_items_controller.rb
+++ b/api/app/controllers/spree/api/line_items_controller.rb
@@ -35,7 +35,7 @@ module Spree
 
         def order
           @order ||= Spree::Order.find_by!(number: params[:order_id])
-          authorize! :update, @order, params[:order_token]
+          authorize! :update, @order, order_token
         end
 
         def line_items_attributes
@@ -47,6 +47,10 @@ module Spree
 
         def line_item_params
           params.require(:line_item).permit(:quantity, :variant_id)
+        end
+
+        def order_token
+          request.headers["X-Spree-Order-Token"] || params[:order_token]
         end
     end
   end

--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -135,11 +135,15 @@ module Spree
 
         def find_order
           @order = Spree::Order.find_by!(number: params[:id])
-          authorize! :update, @order, params[:order_token]
+          authorize! :update, @order, order_token
         end
 
         def before_delivery
           @order.create_proposed_shipments
+        end
+
+        def order_token
+          request.headers["X-Spree-Order-Token"] || params[:order_token]
         end
 
     end

--- a/api/spec/controllers/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/controllers/spree/api/checkouts_controller_spec.rb
@@ -37,7 +37,7 @@ module Spree
     end
 
     context "PUT 'update'" do
-      let(:order) do 
+      let(:order) do
         order = create(:order_with_line_items)
         # Order should be in a pristine state
         # Without doing this, the order may transition from 'cart' straight to 'delivery'
@@ -55,6 +55,14 @@ module Spree
         order.state.should eq "cart"
         order.email.should_not be_nil
         api_put :update, :id => order.to_param, :order_token => order.token
+        order.reload.state.should eq "address"
+      end
+
+      it "should transition a recently created order from cart to address with order token in header" do
+        order.state.should eq "cart"
+        order.email.should_not be_nil
+        request.headers["X-Spree-Order-Token"] = order.token
+        api_put :update, :id => order.to_param
         order.reload.state.should eq "address"
       end
 

--- a/api/spec/controllers/spree/api/line_items_controller_spec.rb
+++ b/api/spec/controllers/spree/api/line_items_controller_spec.rb
@@ -28,6 +28,14 @@ module Spree
         json_response.should have_attributes(attributes)
         json_response["variant"]["name"].should_not be_blank
       end
+
+      it "can add a new line item to an existing order with token in header" do
+        request.headers["X-Spree-Order-Token"] = order.token
+        api_post :create, :line_item => { :variant_id => product.master.to_param, :quantity => 1 }
+        response.status.should == 201
+        json_response.should have_attributes(attributes)
+        json_response["variant"]["name"].should_not be_blank
+      end
     end
 
     context "as the order owner" do

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -110,6 +110,12 @@ module Spree
       response.status.should == 200
     end
 
+    it "can view an order if the token is passed in header" do
+      request.headers["X-Spree-Order-Token"] = order.token
+      api_get :show, :id => order.to_param
+      response.status.should == 200
+    end
+
     it "cannot cancel an order that doesn't belong to them" do
       order.update_attribute(:completed_at, Time.now)
       order.update_attribute(:shipment_state, "ready")
@@ -144,7 +150,7 @@ module Spree
       line_item.should_receive(:update_attributes).with("special" => true)
 
       controller.stub(permitted_line_item_attributes: [:id, :variant_id, :quantity, :special])
-      api_post :create, :order => { 
+      api_post :create, :order => {
         :line_items => {
           "0" => {
             :variant_id => variant.to_param, :quantity => 5, :special => true
@@ -182,7 +188,7 @@ module Spree
       order.stub(:associate_user!)
       order.stub_chain(:contents, :add).and_return(line_item = double('LineItem'))
       line_item.should_not_receive(:update_attributes)
-      api_post :create, :order => { 
+      api_post :create, :order => {
         :line_items => {
           "0" => {
             :variant_id => variant.to_param, :quantity => 5
@@ -367,7 +373,7 @@ module Spree
         end
 
         it "lists line item adjustments" do
-          adjustment = create(:adjustment, 
+          adjustment = create(:adjustment,
             :label => "10% off!",
             :order => order,
             :adjustable => order.line_items.first)


### PR DESCRIPTION
Added ability to pass order token in headers instead of query string. It's sometimes much more convenient.
