### PR TITLE
Escape spaces in generated shipment tracking URLs

### DIFF
--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -27,7 +27,7 @@ module Spree
     end
 
     def build_tracking_url(tracking)
-      tracking_url.gsub(/:tracking/, tracking) unless tracking.blank? || tracking_url.blank?
+      tracking_url.gsub(/:tracking/, URI.escape(tracking)) unless tracking.blank? || tracking_url.blank?
     end
 
     def self.calculators


### PR DESCRIPTION
# What

Tracking numbers returned by remote shipment labeling APIs (i.e. USPS/Endicia) sometimes include spaces.  Passing these straight through to a URL results in unexpected behavior when the tracking URL makes its way to the edges of the app (e.g. [the shipment mailer template](https://github.com/spree/spree/blob/dcce1c3b7c4f57fcb21ed0ac3b1982de53b56c70/core/app/views/spree/shipment_mailer/shipped_email.text.erb#L14)).  Why not `URI#escape` the tracking number before passing it on as a link?
## Before

Tracking Information: 1111 2222 3333
Tracking Link: https://tools.usps.com/go/TrackConfirmAction?qtc_tLabels1=1111 2222 3333
## After

Tracking Information: 1111 2222 3333
Tracking Link: https://tools.usps.com/go/TrackConfirmAction?qtc_tLabels1=1111%202222%203333
