### PR TITLE
Add product.has_variants and variant.in_stock to products#show api

### DIFF
--- a/api/app/views/spree/api/products/show.v1.rabl
+++ b/api/app/views/spree/api/products/show.v1.rabl
@@ -2,6 +2,7 @@ object @product
 cache @product
 attributes *product_attributes
 node(:display_price) { |p| p.display_price.to_s }
+node(:has_variants) { |p| p.has_variants? }
 child :master => :master do
   extends "spree/api/variants/show"
 end

--- a/api/app/views/spree/api/variants/variant.v1.rabl
+++ b/api/app/views/spree/api/variants/variant.v1.rabl
@@ -1,5 +1,6 @@
 attributes *variant_attributes
 node(:options_text) { |v| v.options_text }
+node(:in_stock) { |v| v.in_stock? }
 child :option_values => :option_values do
   attributes *option_value_attributes
 end

--- a/api/spec/controllers/spree/api/variants_controller_spec.rb
+++ b/api/spec/controllers/spree/api/variants_controller_spec.rb
@@ -10,9 +10,9 @@ module Spree
       variant.option_values << create(:option_value)
       variant
     end
-    let!(:attributes) { [:id, :name, :sku, :price, :weight, :height,
-                         :width, :depth, :is_master, :cost_price,
-                         :permalink, :description] }
+    let!(:base_attributes) { [:id, :name, :sku, :price, :weight, :height, :width, :depth, :is_master, :cost_price, :permalink, :description] }
+    let!(:show_attributes) { base_attributes.dup.push(:in_stock) }
+    let!(:new_attributes) { base_attributes }
 
     before do
       stub_authentication!
@@ -20,7 +20,7 @@ module Spree
 
     it "can see a paginated list of variants" do
       api_get :index
-      json_response["variants"].first.should have_attributes(attributes)
+      json_response["variants"].first.should have_attributes(show_attributes)
       json_response["count"].should == 1
       json_response["current_page"].should == 1
       json_response["pages"].should == 1
@@ -79,7 +79,7 @@ module Spree
       it "can select the next page of variants" do
         second_variant = create(:variant)
         api_get :index, :page => 2, :per_page => 1
-        json_response["variants"].first.should have_attributes(attributes)
+        json_response["variants"].first.should have_attributes(show_attributes)
         json_response["total_count"].should == 3
         json_response["current_page"].should == 2
         json_response["pages"].should == 3
@@ -88,7 +88,7 @@ module Spree
 
     it "can see a single variant" do
       api_get :show, :id => variant.to_param
-      json_response.should have_attributes(attributes)
+      json_response.should have_attributes(show_attributes)
       option_values = json_response["option_values"]
       option_values.first.should have_attributes([:name,
                                                  :presentation,
@@ -101,7 +101,7 @@ module Spree
 
       api_get :show, :id => variant.to_param
 
-      json_response.should have_attributes(attributes + [:images])
+      json_response.should have_attributes(show_attributes + [:images])
       option_values = json_response["option_values"]
       option_values.first.should have_attributes([:name,
                                                  :presentation,
@@ -111,7 +111,7 @@ module Spree
 
     it "can learn how to create a new variant" do
       api_get :new
-      json_response["attributes"].should == attributes.map(&:to_s)
+      json_response["attributes"].should == new_attributes.map(&:to_s)
       json_response["required_attributes"].should be_empty
     end
 
@@ -149,7 +149,7 @@ module Spree
 
       it "can create a new variant" do
         api_post :create, :variant => { :sku => "12345" }
-        json_response.should have_attributes(attributes)
+        json_response.should have_attributes(new_attributes)
         response.status.should == 201
         json_response["sku"].should == "12345"
 


### PR DESCRIPTION
These two pieces of imformation are important for the API to allow clients to deliver ui/ux friendly product variant picker to users.

The product.has_variants? allows clients to determine if the product is_master variant can be selected as a purchase-able option. This is the current functionality in Spree-Frontend:

https://github.com/spree/spree/blob/master/frontend/app/views/spree/products/_cart_form.html.erb#L26

The second change is an enhancement to the API that prevents users from picking variants that are not in stock. We can X it out or shade it out to indicate that it's a possible option but not available. The urrent Spree-Frontend doesn't even check for this, and instead warns of inventory on add-to-cart. This is less than ideal if we want to prevent people from getting into this dead-end and block the selection to begin with.
- changes to product show rabl and variant base template
- tests for product and variant API specs

remove white space added

change tests per richard feedback
