### PR TITLE
fixed duplicated rows id's and name when selecting properties from proto...

### DIFF
--- a/backend/app/assets/javascripts/admin/admin.js.erb
+++ b/backend/app/assets/javascripts/admin/admin.js.erb
@@ -139,11 +139,11 @@ $(document).ready(function(){
              }
     });
   });
-
+  var uniqueId = 1;
   $('.spree_add_fields').click(function() {
     var target = $(this).data("target");
     var new_table_row = $(target + ' tr:visible:last').clone();
-    var new_id = new Date().getTime();
+    var new_id = new Date().getTime() + (uniqueId++);
     new_table_row.find("input, select").each(function () {
       var el = $(this);
       el.val("");


### PR DESCRIPTION
This fixes the issue in the Admin panel, when you try to add multiple properties via the "select prototype" button.
the problem was that the code generates duplicated id's and name attributes.

to reproduce the problem, just make a prototype with more than 10 properties, choose any product and add the properties via the "select from prototype" button and click "update".
