### PR TITLE
Don't use hard coded assets prefix

### DIFF
--- a/frontend/app/views/spree/checkout/edit.html.erb
+++ b/frontend/app/views/spree/checkout/edit.html.erb
@@ -32,5 +32,5 @@ Spree.current_order_token = "<%= @order.token %>"
 </script>
 
 <% if I18n.locale != :en %>
-  <script src="#{assets_prefix}/jquery.validate/localization/messages_#{I18n.locale}.js"></script>
+  <script src="<%= assets_prefix %>/jquery.validate/localization/messages_<%= I18n.locale %>.js"></script>
 <% end %>

--- a/frontend/app/views/spree/checkout/edit.html.erb
+++ b/frontend/app/views/spree/checkout/edit.html.erb
@@ -32,5 +32,5 @@ Spree.current_order_token = "<%= @order.token %>"
 </script>
 
 <% if I18n.locale != :en %>
-  <script src='/assets/jquery.validate/localization/messages_<%= I18n.locale %>.js'></script>
+  <script src="#{assets_prefix}/jquery.validate/localization/messages_#{I18n.locale}.js"></script>
 <% end %>


### PR DESCRIPTION
People don't serve the assets always from the `/assets`. This path shouldn't break on current users, but for example  it allows using `/dev-assets` in development environment:
http://guides.rubyonrails.org/asset_pipeline.html#local-precompilation
