### PR TITLE
api config require_authentication default true (with fixed specs)

### DIFF
--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -2,6 +2,9 @@ module Spree
   module Api
     class OrdersController < Spree::Api::BaseController
 
+      skip_before_filter :check_for_user_or_api_key, only: :apply_coupon_code
+      skip_before_filter :authenticate_user, only: :apply_coupon_code
+
       # Dynamically defines our stores checkout steps to ensure we check authorization on each step.
       Order.checkout_steps.keys.each do |step|
         define_method step do

--- a/api/app/models/spree/api_configuration.rb
+++ b/api/app/models/spree/api_configuration.rb
@@ -1,5 +1,5 @@
 module Spree
   class ApiConfiguration < Preferences::Configuration
-    preference :requires_authentication, :boolean, :default => false
+    preference :requires_authentication, :boolean, :default => true
   end
 end

--- a/backend/app/assets/javascripts/spree/backend/option_type_autocomplete.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/option_type_autocomplete.js.erb
@@ -18,7 +18,8 @@ $(document).ready(function () {
           return {
             q: {
               name_cont: term
-            }
+            },
+            token: Spree.api_key
           };
         },
         results: function (data) {

--- a/backend/app/assets/javascripts/spree/backend/product_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/product_picker.js
@@ -20,7 +20,8 @@ $.fn.productAutocomplete = function () {
             name_cont: term,
             sku_cont: term
           },
-          m: 'OR'
+          m: 'OR',
+          token: Spree.api_key
         };
       },
       results: function (data, page) {

--- a/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js.erb
@@ -22,7 +22,8 @@ $(document).ready(function () {
             page: page,
             q: {
               name_cont: term
-            }
+            },
+            token: Spree.api_key
           };
         },
         results: function (data, page) {

--- a/backend/spec/features/admin/homepage_spec.rb
+++ b/backend/spec/features/admin/homepage_spec.rb
@@ -59,6 +59,11 @@ describe "Homepage" do
   end
 
   context 'as fakedispatch user' do
+
+    before do 
+      Spree::Admin::BaseController.any_instance.stub(:spree_current_user).and_return(nil)
+    end
+    
     custom_authorization! do |user|
       can [:admin, :edit, :index, :read], Spree::Order
     end

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -210,6 +210,11 @@ describe "Order Details", js: true do
   end
 
   context 'with only read permissions' do
+    
+    before do 
+      Spree::Admin::BaseController.any_instance.stub(:spree_current_user).and_return(nil)
+    end
+
     custom_authorization! do |user|
       can [:admin, :index, :read, :edit], Spree::Order
     end
@@ -244,6 +249,7 @@ describe "Order Details", js: true do
     end
 
     it 'should not display order tabs or edit buttons without ability' do
+      Spree::Admin::BaseController.any_instance.stub(:spree_current_user).and_return(nil)
       visit spree.edit_admin_order_path(order)
       # Order Form
       page.should_not have_css('.edit-item')

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -326,7 +326,13 @@ describe "Products" do
       end
     end
   end
+
   context 'with only product permissions' do
+  
+    before do 
+      Spree::Admin::BaseController.any_instance.stub(:spree_current_user).and_return(nil)
+    end
+
     custom_authorization! do |user|
       can [:admin, :update, :index, :read], Spree::Product
     end
@@ -344,6 +350,7 @@ describe "Products" do
       page.should have_css('a.edit')
       page.should_not have_css('a.delete-resource')
     end
+  
     it "should only display accessible links on edit" do
       visit spree.admin_product_path(product)
 

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -95,4 +95,10 @@ RSpec.configure do |config|
   config.include Paperclip::Shoulda::Matchers
 
   config.fail_fast = ENV['FAIL_FAST'] || false
+
+  config.before(:each) do
+    current_user = create(:admin_user, :spree_api_key => SecureRandom.hex(24))
+    Spree::Admin::BaseController.any_instance.stub(:spree_current_user).and_return(current_user)
+  end
+  
 end

--- a/core/lib/spree/core/controller_helpers/auth.rb
+++ b/core/lib/spree/core/controller_helpers/auth.rb
@@ -5,7 +5,6 @@ module Spree
         extend ActiveSupport::Concern
 
         included do
-          before_filter :ensure_api_key
           helper_method :try_spree_current_user
 
           rescue_from CanCan::AccessDenied do |exception|
@@ -56,16 +55,6 @@ module Spree
         def redirect_back_or_default(default)
           redirect_to(session["spree_user_return_to"] || default)
           session["spree_user_return_to"] = nil
-        end
-
-        # Need to generate an API key for a user due to some actions potentially
-        # requiring authentication to the Spree API
-        def ensure_api_key
-          if user = try_spree_current_user
-            if user.respond_to?(:spree_api_key) && user.spree_api_key.blank?
-              user.generate_spree_api_key!
-            end
-          end
         end
       end
     end


### PR DESCRIPTION
setting the require_authentication back to be default true, while still have green builds.
