### PR TITLE
Add inverse_of to associations between shipping methods and rates

### DIFF
--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -9,7 +9,7 @@ module Spree
     has_many :shipments
     has_many :shipping_method_categories
     has_many :shipping_categories, through: :shipping_method_categories
-    has_many :shipping_rates
+    has_many :shipping_rates, inverse_of: :shipping_method
 
     has_and_belongs_to_many :zones, :join_table => 'spree_shipping_methods_zones',
                                     :class_name => 'Spree::Zone',

--- a/core/app/models/spree/shipping_rate.rb
+++ b/core/app/models/spree/shipping_rate.rb
@@ -1,13 +1,13 @@
 module Spree
   class ShippingRate < ActiveRecord::Base
     belongs_to :shipment, class_name: 'Spree::Shipment'
-    belongs_to :shipping_method, class_name: 'Spree::ShippingMethod'
+    belongs_to :shipping_method, class_name: 'Spree::ShippingMethod', inverse_of: :shipping_rates
 
     scope :with_shipping_method,
       -> { includes(:shipping_method).
            references(:shipping_method).
            order("cost ASC") }
-    
+
     delegate :order, :currency, to: :shipment
     delegate :name, to: :shipping_method
 


### PR DESCRIPTION
This branch adds `:inverse_of` declarations to the shipping methods and rates.
