### PR TITLE
Remove variant default_scope from Price class

### DIFF
--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -22,6 +22,11 @@ module Spree
       self[:amount] = parse_price(price)
     end
 
+    # Remove variant default_scope `deleted_at: nil`
+    def variant
+      Spree::Variant.unscoped { super }
+    end
+
     private
     def check_price
       raise "Price must belong to a variant" if variant.nil?

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -391,4 +391,12 @@ describe Spree::Variant do
       build(:variant).should_track_inventory?.should eq(true)
     end
   end
+
+  describe "deleted_at scope" do
+    before { variant.destroy && variant.reload }
+    it "should have a price if deleted" do
+      variant.price = 10
+      expect(variant.price).to eq(10)
+    end
+  end
 end


### PR DESCRIPTION
this fixes **Price must belong to a variant** when trying to fetch the price of a deleted variant
