### PR TITLE
Improves Api::ProductsController#create

### DIFF
--- a/api/spec/controllers/spree/api/products_controller_spec.rb
+++ b/api/spec/controllers/spree/api/products_controller_spec.rb
@@ -8,6 +8,11 @@ module Spree
     let!(:product) { create(:product) }
     let!(:inactive_product) { create(:product, :available_on => Time.now.tomorrow, :name => "inactive") }
     let(:attributes) { [:id, :name, :description, :price, :display_price, :available_on, :permalink, :meta_description, :meta_keywords, :shipping_category_id, :taxon_ids] }
+    let(:product_data) do
+      { name: "The Other Product",
+        price: 19.99,
+        shipping_category_id: create(:shipping_category).id }
+    end
 
     before do
       stub_authentication!
@@ -185,11 +190,79 @@ module Spree
         end
       end
 
-      context 'creating a product' do
-        let(:product_data) do
-          { name: "The Other Product",
-            price: 19.99,
-            shipping_category_id: create(:shipping_category).id }
+      describe "creating a product" do
+        it "can create a new product" do
+          api_post :create, :product => { :name => "The Other Product",
+                                          :price => 19.99,
+                                          :shipping_category_id => create(:shipping_category).id }
+          json_response.should have_attributes(attributes)
+          response.status.should == 201
+        end
+
+        it "can create a new product with embedded variants" do
+          def attributes_for_variant
+            h = attributes_for(:variant)
+            h.delete(:option_values)
+            h.merge({
+              options: [
+                { name: "size", value: "small" },
+                { name: "color", value: "black" }
+              ]
+            })
+          end
+
+          attributes = product_data
+
+          attributes.merge!({
+            shipping_category_id: 1,
+
+            option_types: ['size', 'color'],
+
+            variants_attributes: [
+              attributes_for_variant,
+              attributes_for_variant
+            ]
+          })
+
+          api_post :create, :product => attributes
+
+          expect(json_response['variants'].count).to eq(3) # 1 master + 2 variants
+          expect(json_response['variants'][1]['option_values'][0]['name']).to eq('small')
+          expect(json_response['variants'][1]['option_values'][0]['option_type_name']).to eq('size')
+
+          expect(json_response['option_types'].count).to eq(2) # size, color
+        end
+
+        it "can create a new product with embedded product_properties" do
+          attributes = product_data
+
+          attributes.merge!({
+            shipping_category_id: 1,
+
+            product_properties_attributes: [{
+              property_name: "fabric",
+              value: "cotton"
+            }]
+          })
+
+          api_post :create, :product => attributes
+
+          expect(json_response['product_properties'][0]['property_name']).to eq('fabric')
+          expect(json_response['product_properties'][0]['value']).to eq('cotton')
+        end
+
+        it "can create a new product with option_types" do
+          attributes = product_data
+
+          attributes.merge!({
+            shipping_category_id: 1,
+
+            option_types: ['size', 'color']
+          })
+
+          api_post :create, :product => attributes
+
+          expect(json_response['option_types'].count).to eq(2)
         end
 
         it "can create a new product" do

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -68,8 +68,6 @@ module Spree
 
     has_many :variant_images, -> { order(:position) }, source: :images, through: :variants_including_master
 
-    accepts_nested_attributes_for :variants, allow_destroy: true
-
     validates :name, presence: true
     validates :permalink, presence: true
     validates :price, presence: true, if: proc { Spree::Config[:require_master_price] }

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -76,6 +76,12 @@ module Spree
       deleted_at
     end
 
+    def options=(options = {})
+      options.each do |option|
+        set_option_value(option[:name], option[:value])
+      end
+    end
+
     def set_option_value(opt_name, opt_value)
       # no option values on master
       return if self.is_master

--- a/core/lib/spree/core/controller_helpers/strong_parameters.rb
+++ b/core/lib/spree/core/controller_helpers/strong_parameters.rb
@@ -30,6 +30,13 @@ module Spree
             :line_items_attributes => permitted_line_item_attributes
           ]
         end
+
+        def permitted_product_attributes
+          permitted_attributes.product_attributes + [
+            :product_properties_attributes => permitted_product_properties_attributes,
+            :variants_attributes => permitted_variant_attributes
+          ]
+        end
       end
     end
   end

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -54,8 +54,8 @@ module Spree
       :name, :description, :available_on, :permalink, :meta_description,
       :meta_keywords, :price, :sku, :deleted_at, :prototype_id,
       :option_values_hash, :weight, :height, :width, :depth,
-      :shipping_category_id, :tax_category_id, :product_properties_attributes,
-      :variants_attributes, :taxon_ids, :option_type_ids, :cost_currency, :cost_price]
+      :shipping_category_id, :tax_category_id,
+      :taxon_ids, :option_type_ids, :cost_currency, :cost_price, option_types: []]
 
     @@property_attributes = [:name, :presentation]
 
@@ -93,7 +93,7 @@ module Spree
     @@variant_attributes = [
       :name, :presentation, :cost_price, :lock_version,
       :position, :option_value_ids,
-      :product_id, :option_values_attributes, :price,
-      :weight, :height, :width, :depth, :sku, :cost_currency]
+      :product_id, :product, :option_values_attributes, :price,
+      :weight, :height, :width, :depth, :sku, :cost_currency, options: [ :name, :value ]]
   end
 end


### PR DESCRIPTION
Adds support to:
- Create product's variants (including variant's option_types)
- Create product's product_properties
- Create product's option_type
