### PR TITLE
Prevents admin js errors by ensuring taxons key in api response

### DIFF
--- a/api/app/views/spree/api/taxons/index.v1.rabl
+++ b/api/app/views/spree/api/taxons/index.v1.rabl
@@ -4,7 +4,7 @@ node(:total_count) { @taxons.total_count }
 node(:current_page) { params[:page] ? params[:page].to_i : 1 }
 node(:per_page) { params[:per_page] || Kaminari.config.default_per_page }
 node(:pages) { @taxons.num_pages }
-child(@taxons) do
+child @taxons => :taxons do
   attributes *taxon_attributes
   unless params[:without_children]
     extends "spree/api/taxons/taxons"

--- a/api/spec/controllers/spree/api/taxons_controller_spec.rb
+++ b/api/spec/controllers/spree/api/taxons_controller_spec.rb
@@ -47,21 +47,42 @@ module Spree
         expect(json_response["pages"]).to eql(2)
       end
 
-      it "gets all taxons" do
-        api_get :index
+      describe 'searching' do
+        context 'with a name' do
+          before do
+            api_get :index, :q => { :name_cont => name }
+          end
 
-        json_response['taxons'].first['name'].should eq taxonomy.root.name
-        children = json_response['taxons'].first['taxons']
-        children.count.should eq 1
-        children.first['name'].should eq taxon.name
-        children.first['taxons'].count.should eq 1
-      end
+          context 'with one result' do
+            let(:name) { "Ruby" }
 
-      it "can search for a single taxon" do
-        api_get :index, :q => { :name_cont => "Ruby" }
+            it "returns an array including the matching taxon" do
+              json_response['taxons'].count.should == 1
+              json_response['taxons'].first['name'].should eq "Ruby"
+            end
+          end
 
-        json_response['taxons'].count.should == 1
-        json_response['taxons'].first['name'].should eq "Ruby"
+          context 'with no results' do
+            let(:name) { "Imaginary" }
+
+            it 'returns an empty array of taxons' do
+              json_response.keys.should include('taxons')
+              json_response['taxons'].count.should == 0
+            end
+          end
+        end
+
+        context 'with no filters' do
+          it "gets all taxons" do
+            api_get :index
+
+            json_response['taxons'].first['name'].should eq taxonomy.root.name
+            children = json_response['taxons'].first['taxons']
+            children.count.should eq 1
+            children.first['name'].should eq taxon.name
+            children.first['taxons'].count.should eq 1
+          end
+        end
       end
 
       it "gets a single taxon" do


### PR DESCRIPTION
Previously, a response from /api/taxons (typically from the autocomplete in admin) would not include the 'taxons' key if the ransack query didn't yield any results.

To reproduce, simply enter a bogus taxon name in the autocomplete field for a product in the product admin, and js errors will occur for every character typed.

![screen shot 2014-01-07 at 5 47 04 pm](https://f.cloud.github.com/assets/57874/1864144/1cd75ca0-77ee-11e3-8020-e7e8ddcbb550.png)
