### PR TITLE
Improves Api::ProductsController#create

### DIFF
--- a/api/app/controllers/spree/api/products_controller.rb
+++ b/api/app/controllers/spree/api/products_controller.rb
@@ -28,6 +28,7 @@ module Spree
         params[:product][:available_on] ||= Time.now
 
         variants_attributes = params[:product].delete(:variants_attributes) || []
+        option_type_attributes = params[:product].delete(:option_types) || []
 
         @product = Product.new(params[:product])
         begin
@@ -37,13 +38,13 @@ module Spree
               variant.update_attributes(variant_attribute)
             end
 
-            params[:product].fetch(:option_types, []).each do |name|
+            option_type_attributes.each do |name|
               option_type = OptionType.where(name: name).first_or_initialize do |option_type|
                 option_type.presentation = name
                 option_type.save!
               end
 
-              @product.option_types << option_type
+              @product.option_types << option_type unless @product.option_types.include?(option_type)
             end
 
             respond_with(@product, :status => 201, :default_template => :show)

--- a/api/spec/controllers/spree/api/products_controller_spec.rb
+++ b/api/spec/controllers/spree/api/products_controller_spec.rb
@@ -205,6 +205,8 @@ module Spree
           attributes.merge!({
             shipping_category_id: 1,
 
+            option_types: ['size', 'color'],
+
             variants_attributes: [
               attributes_for_variant,
               attributes_for_variant
@@ -238,7 +240,7 @@ module Spree
           expect(json_response['product_properties'][0]['value']).to eq('cotton')
         end
 
-        it "can create a new product with option_types" do
+        it "can create a new product with option_types even if without variants" do
           attributes = attributes_for(:product)
 
           attributes.merge!({

--- a/api/spec/controllers/spree/api/products_controller_spec.rb
+++ b/api/spec/controllers/spree/api/products_controller_spec.rb
@@ -179,12 +179,78 @@ module Spree
         end
       end
 
-      it "can create a new product" do
-        api_post :create, :product => { :name => "The Other Product",
-                                        :price => 19.99,
-                                        :shipping_category_id => create(:shipping_category).id }
-        json_response.should have_attributes(attributes)
-        response.status.should == 201
+      describe "creating products" do
+        it "can create a new product" do
+          api_post :create, :product => { :name => "The Other Product",
+                                          :price => 19.99,
+                                          :shipping_category_id => create(:shipping_category).id }
+          json_response.should have_attributes(attributes)
+          response.status.should == 201
+        end
+
+        it "can create a new product with embedded variants" do
+          def attributes_for_variant
+            h = attributes_for(:variant)
+            h.delete(:option_values)
+            h.merge({
+              options: [
+                { name: "size", value: "small" },
+                { name: "color", value: "black" }
+              ]
+            })
+          end
+
+          attributes = attributes_for(:product)
+
+          attributes.merge!({
+            shipping_category_id: 1,
+
+            variants_attributes: [
+              attributes_for_variant,
+              attributes_for_variant
+            ]
+          })
+
+          api_post :create, :product => attributes
+
+          expect(json_response['variants'].count).to eq(3) # 1 master + 2 variants
+          expect(json_response['variants'][1]['option_values'][0]['name']).to eq('small')
+          expect(json_response['variants'][1]['option_values'][0]['option_type_name']).to eq('size')
+
+          expect(json_response['option_types'].count).to eq(2) # size, color
+        end
+
+        it "can create a new product with embedded product_properties" do
+          attributes = attributes_for(:product)
+
+          attributes.merge!({
+            shipping_category_id: 1,
+
+            product_properties_attributes: [{
+              property_name: "fabric",
+              value: "cotton"
+            }]
+          })
+
+          api_post :create, :product => attributes
+
+          expect(json_response['product_properties'][0]['property_name']).to eq('fabric')
+          expect(json_response['product_properties'][0]['value']).to eq('cotton')
+        end
+
+        it "can create a new product with option_types" do
+          attributes = attributes_for(:product)
+
+          attributes.merge!({
+            shipping_category_id: 1,
+
+            option_types: ['size', 'color']
+          })
+
+          api_post :create, :product => attributes
+
+          expect(json_response['option_types'].count).to eq(2)
+        end
       end
 
       # Regression test for #2140

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -11,7 +11,8 @@ module Spree
     attr_accessible :name, :presentation, :cost_price, :lock_version,
                     :position, :option_value_ids,
                     :product_id, :option_values_attributes, :price,
-                    :weight, :height, :width, :depth, :sku, :cost_currency, :track_inventory
+                    :weight, :height, :width, :depth, :sku, :cost_currency,
+                    :track_inventory, :options
 
     has_many :inventory_units
     has_many :line_items
@@ -78,6 +79,12 @@ module Spree
     # their own definition.
     def deleted?
       deleted_at
+    end
+
+    def options=(options = {})
+      options.each do |option|
+        set_option_value(option[:name], option[:value])
+      end
     end
 
     def set_option_value(opt_name, opt_value)


### PR DESCRIPTION
See #4172.

Adds support to:
- Create product's variants (including variant's option_types)
- Create product's product_properties
- Create product's option_type
