### PR TITLE
Fix migration to support legacy stores with deleted variants and line items

### DIFF
--- a/core/db/migrate/20131118183431_add_line_item_id_to_spree_inventory_units.rb
+++ b/core/db/migrate/20131118183431_add_line_item_id_to_spree_inventory_units.rb
@@ -5,12 +5,14 @@ class AddLineItemIdToSpreeInventoryUnits < ActiveRecord::Migration
       add_column :spree_inventory_units, :line_item_id, :integer
       add_index :spree_inventory_units, :line_item_id
 
-      shipments = Spree::Shipment.includes({ :inventory_units => :variant }, :order)
+      shipments = Spree::Shipment.includes(:inventory_units, :order)
 
       shipments.find_each do |shipment|
         shipment.inventory_units.group_by(&:variant).each do |variant, units|
 
           line_item = shipment.order.find_line_item_by_variant(variant)
+          next line_item
+
           Spree::InventoryUnit.where(id: units.map(&:id)).update_all(line_item_id: line_item.id)
         end
       end

--- a/core/db/migrate/20131118183431_add_line_item_id_to_spree_inventory_units.rb
+++ b/core/db/migrate/20131118183431_add_line_item_id_to_spree_inventory_units.rb
@@ -11,7 +11,7 @@ class AddLineItemIdToSpreeInventoryUnits < ActiveRecord::Migration
         shipment.inventory_units.group_by(&:variant).each do |variant, units|
 
           line_item = shipment.order.find_line_item_by_variant(variant)
-          next line_item
+          next unless line_item
 
           Spree::InventoryUnit.where(id: units.map(&:id)).update_all(line_item_id: line_item.id)
         end


### PR DESCRIPTION
Trying to migrate my existing store and the migration for adding line item ids to inventory units fails when a variant has since been deleted or when a line item no longer exists.

Variants are not found as the Spree::Shipment includes scope will not find deleted variants. Removing the scope will find them. Here is some console output from testing locally:

**With variant include**

``` ruby
pry(main)> Spree::Shipment.includes({ :inventory_units => :variant }, :order).find(...).inventory_units.group_by(&:variant).each { |v, u| puts v.nil? }
  Spree::Shipment Load (0.4ms)  SELECT "spree_shipments".* FROM "spree_shipments" WHERE "spree_shipments"."id" = $1 LIMIT 1  [["id", 2178]]
  Spree::InventoryUnit Load (0.3ms)  SELECT "spree_inventory_units".* FROM "spree_inventory_units" WHERE "spree_inventory_units"."shipment_id" IN (2178)
  Spree::Variant Load (0.3ms)  SELECT "spree_variants".* FROM "spree_variants" WHERE "spree_variants"."id" IN (4793, 754, 4840, 1251, 378, 2719, 4739, 2340) AND ("spree_variants".deleted_at IS NULL)
  Spree::Order Load (0.2ms)  SELECT "spree_orders".* FROM "spree_orders" WHERE "spree_orders"."id" IN (5636)
false
false
false
false
false
false
true <-------- Nil variant here
false
```

**Without variant include**

``` ruby
pry(main)> Spree::Shipment.includes(:inventory_units, :order).find(...).inventory_units.group_by(&:variant).each { |v, u| puts v.nil? }
  Spree::Shipment Load (0.4ms)  SELECT "spree_shipments".* FROM "spree_shipments" WHERE "spree_shipments"."id" = $1 LIMIT 1  [["id", 2178]]
  Spree::InventoryUnit Load (0.3ms)  SELECT "spree_inventory_units".* FROM "spree_inventory_units" WHERE "spree_inventory_units"."shipment_id" IN (2178)
  Spree::Order Load (0.2ms)  SELECT "spree_orders".* FROM "spree_orders" WHERE "spree_orders"."id" IN (5636)
  Spree::Variant Load (0.7ms)  SELECT "spree_variants".* FROM "spree_variants" WHERE "spree_variants"."id" = $1 ORDER BY "spree_variants"."id" ASC LIMIT 1  [["id", 4793]]
  Spree::Variant Load (0.2ms)  SELECT "spree_variants".* FROM "spree_variants" WHERE "spree_variants"."id" = $1 ORDER BY "spree_variants"."id" ASC LIMIT 1  [["id", 754]]
  Spree::Variant Load (0.2ms)  SELECT "spree_variants".* FROM "spree_variants" WHERE "spree_variants"."id" = $1 ORDER BY "spree_variants"."id" ASC LIMIT 1  [["id", 4840]]
  Spree::Variant Load (0.2ms)  SELECT "spree_variants".* FROM "spree_variants" WHERE "spree_variants"."id" = $1 ORDER BY "spree_variants"."id" ASC LIMIT 1  [["id", 1251]]
  Spree::Variant Load (0.2ms)  SELECT "spree_variants".* FROM "spree_variants" WHERE "spree_variants"."id" = $1 ORDER BY "spree_variants"."id" ASC LIMIT 1  [["id", 1251]]
  Spree::Variant Load (0.2ms)  SELECT "spree_variants".* FROM "spree_variants" WHERE "spree_variants"."id" = $1 ORDER BY "spree_variants"."id" ASC LIMIT 1  [["id", 1251]]
  Spree::Variant Load (0.2ms)  SELECT "spree_variants".* FROM "spree_variants" WHERE "spree_variants"."id" = $1 ORDER BY "spree_variants"."id" ASC LIMIT 1  [["id", 1251]]
  Spree::Variant Load (0.1ms)  SELECT "spree_variants".* FROM "spree_variants" WHERE "spree_variants"."id" = $1 ORDER BY "spree_variants"."id" ASC LIMIT 1  [["id", 1251]]
  Spree::Variant Load (0.2ms)  SELECT "spree_variants".* FROM "spree_variants" WHERE "spree_variants"."id" = $1 ORDER BY "spree_variants"."id" ASC LIMIT 1  [["id", 1251]]
  Spree::Variant Load (0.2ms)  SELECT "spree_variants".* FROM "spree_variants" WHERE "spree_variants"."id" = $1 ORDER BY "spree_variants"."id" ASC LIMIT 1  [["id", 378]]
  Spree::Variant Load (0.2ms)  SELECT "spree_variants".* FROM "spree_variants" WHERE "spree_variants"."id" = $1 ORDER BY "spree_variants"."id" ASC LIMIT 1  [["id", 2719]]
  Spree::Variant Load (0.1ms)  SELECT "spree_variants".* FROM "spree_variants" WHERE "spree_variants"."id" = $1 ORDER BY "spree_variants"."id" ASC LIMIT 1  [["id", 4739]]
  Spree::Variant Load (0.2ms)  SELECT "spree_variants".* FROM "spree_variants" WHERE "spree_variants"."id" = $1 ORDER BY "spree_variants"."id" ASC LIMIT 1  [["id", 2340]]
false
false
false
false
false
false
false
false
```

I have not found any way other than skipping update where the corresponding line item no longer exists.
