### PR TITLE
Bump acts_as_list to 0.3.0 (rails4 compatible)

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
 
   s.add_dependency 'activemerchant', '1.42.3'
-  s.add_dependency 'acts_as_list', '= 0.2.0'
+  s.add_dependency 'acts_as_list', '= 0.3.0'
   s.add_dependency 'awesome_nested_set', '~> 3.0.0.rc.3'
   s.add_dependency 'aws-sdk', '1.27.0'
   s.add_dependency 'cancan', '~> 1.6.10'


### PR DESCRIPTION
Version 0.3.0 removes unwanted (and incompatible) `attr_accessible`'s
