### PR TITLE
Google analytics fix for IE8 SSL warning

### DIFF
--- a/frontend/app/views/spree/shared/_google_analytics.html.erb
+++ b/frontend/app/views/spree/shared/_google_analytics.html.erb
@@ -32,7 +32,7 @@
 
     (function() {
       var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-      ga.src = '//google-analytics.com/ga.js';
+      ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
       var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
     })();
   <% end %>


### PR DESCRIPTION
Undoes #2977 which while cleaner in principle breaks IE8 SSL support.  I have verified this in my production app with a local override of `_google_analytics.html.erb`.

I will completely understand if no one wants this patch.

Thanks!

Edit:  By 'breaks IE8 SSL support' I meant "introduces a mixed content page is insecure" sort of warning on all storefront page loads from IE8 that will scare away customers.
