### PR TITLE
Add exceptions for nil records in tax categories migration

### DIFF
--- a/core/db/migrate/20130802022321_migrate_tax_categories_to_line_items.rb
+++ b/core/db/migrate/20130802022321_migrate_tax_categories_to_line_items.rb
@@ -1,7 +1,10 @@
 class MigrateTaxCategoriesToLineItems < ActiveRecord::Migration
   def change
-  	Spree::LineItem.includes(:variant => { :product => :tax_category }).find_in_batches do |line_items|
-  	  line_items.each do |line_item|
+    Spree::LineItem.includes(:variant => { :product => :tax_category }).find_in_batches do |line_items|
+      line_items.each do |line_item|
+        next if line_item.variant.nil?
+        next if line_item.variant.product.nil?
+        next if line_item.product.nil?
         line_item.update_column(:tax_category_id, line_item.product.tax_category_id)
       end
     end


### PR DESCRIPTION
A number of people have experienced migration failures upgrading on this migration.

See #3534 and #3604.

While those issues have been closed by commits, some such as myself still experience this failure.

The patch below is cribbed from https://gist.github.com/Lordnibbler/6255113.  This fix works for me and for anyone with nil line_items and associated properties.

The fix expands the number of people who will successfully be able to migrate, introduces no compatibility issues for those not experiencing the problem, and will not harm those who have already successfully run this migration (they aren't missing out on anything here).  Therefore I suggest it be accepted so as to ensure greater adoption of Spree 2.1.

Thanks.
