### PR TITLE
using completed_at rather than created_at for more accurate sales total report

### DIFF
--- a/core/app/controllers/spree/admin/reports_controller.rb
+++ b/core/app/controllers/spree/admin/reports_controller.rb
@@ -15,23 +15,17 @@ module Spree
       def sales_total
         params[:q] = {} unless params[:q]
 
-        if params[:q][:created_at_gt].blank?
-          params[:q][:created_at_gt] = Time.zone.now.beginning_of_month
+        if params[:q][:completed_at_gt].blank?
+          params[:q][:completed_at_gt] = Time.zone.now.beginning_of_month
         else
-          params[:q][:created_at_gt] = Time.zone.parse(params[:q][:created_at_gt]).beginning_of_day rescue Time.zone.now.beginning_of_month
+          params[:q][:completed_at_gt] = Time.zone.parse(params[:q][:completed_at_gt]).beginning_of_day rescue Time.zone.now.beginning_of_month
         end
 
-        if params[:q] && !params[:q][:created_at_lt].blank?
-          params[:q][:created_at_lt] = Time.zone.parse(params[:q][:created_at_lt]).end_of_day rescue ""
+        if params[:q] && !params[:q][:completed_at_lt].blank?
+          params[:q][:completed_at_lt] = Time.zone.parse(params[:q][:completed_at_lt]).end_of_day rescue ""
         end
 
-        if params[:q].delete(:completed_at_not_null) == "1"
-          params[:q][:completed_at_not_null] = true
-        else
-          params[:q][:completed_at_not_null] = false
-        end
-
-        params[:q][:s] ||= "created_at desc"
+        params[:q][:s] ||= "completed_at desc"
 
         @search = Order.complete.ransack(params[:q])
         @orders = @search.result

--- a/core/app/views/spree/admin/reports/sales_total.html.erb
+++ b/core/app/views/spree/admin/reports/sales_total.html.erb
@@ -12,7 +12,7 @@
 <% end %>
 
 <% content_for :table_filter do %>
-  <%= render :partial => 'spree/admin/shared/report_criteria', :locals => {} %>
+  <%= render :partial => 'spree/admin/shared/report_order_criteria', :locals => {} %>
 <% end %>
 
 <table class="admin-report" data-hook="sales_total">

--- a/core/app/views/spree/admin/shared/_report_order_criteria.html.erb
+++ b/core/app/views/spree/admin/shared/_report_order_criteria.html.erb
@@ -1,0 +1,17 @@
+<%= search_form_for @search, :url => spree.sales_total_admin_reports_path  do |s| %>
+    <div class="date-range-filter field align-center">
+        <%= label_tag nil, t(:start), :class => 'inline' %>
+        <%= s.text_field :completed_at_gt, :class => 'datepicker datepicker-from', :value => datepicker_field_value(params[:q][:completed_at_gt]) %>
+        
+        <span class="range-divider">
+          <i class="icon-arrow-right"></i>
+        </span>
+
+        <%= s.text_field :completed_at_lt, :class => 'datepicker datepicker-to', :value => datepicker_field_value(params[:q][:completed_at_lt]) %>
+        <%= label_tag nil, t(:end), :class => 'inline' %>
+    </div>
+
+    <div class="actions filter-actions">
+      <%= button t(:search), 'icon-search'  %>
+    </div>
+<% end %>


### PR DESCRIPTION
As per the conversation with @peterberkenbosch in https://github.com/spree/spree/issues/4198
