### PR TITLE
Added Regexp tab matching

### DIFF
--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -29,7 +29,9 @@ module Spree
           link = link_to(titleized_label, destination_url)
         end
 
-        selected = if options[:match_path]
+        selected = if options[:match_path].is_a? Regexp
+          request.fullpath =~ options[:match_path]
+        elsif options[:match_path]
           request.fullpath.starts_with?("#{admin_path}#{options[:match_path]}")
         else
           args.include?(controller.controller_name.to_sym)

--- a/backend/spec/helpers/admin/navigation_helper_spec.rb
+++ b/backend/spec/helpers/admin/navigation_helper_spec.rb
@@ -54,9 +54,21 @@ describe Spree::Admin::NavigationHelper do
           tab.should include('class="selected"')
         end
 
+        it "should be selected if the fullpath matches a regular expression" do
+          controller.stub(:controller_name).and_return("bonobos")
+          tab = helper.tab(:orders, :label => "delivered orders", :match_path => /orders$|orders\//)
+          tab.should include('class="selected"')
+        end
+
         it "should not be selected if the fullpath does not match" do
           controller.stub(:controller_name).and_return("bonobos")
           tab = helper.tab(:orders, :label => "delivered orders", :match_path => '/shady')
+          tab.should_not include('class="selected"')
+        end
+
+        it "should not be selected if the fullpath does not match a regular expression" do
+          controller.stub(:controller_name).and_return("bonobos")
+          tab = helper.tab(:orders, :label => "delivered orders", :match_path => /shady$|shady\//)
           tab.should_not include('class="selected"')
         end
       end


### PR DESCRIPTION
Using a Regexp fixes cases where a simple String comparison is not precise enough (ie: '/members' also matches '/memberships' whereas /members$/ doesn't match /memberships$/)
