### PR TITLE
use twelve-hour clock in pretty_time

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -155,7 +155,7 @@ module Spree
 
     def pretty_time(time)
       [I18n.l(time.to_date, :format => :long),
-        time.strftime("%H:%m %p")].join(" ")
+        time.strftime("%l:%m %p")].join(" ")
     end
 
     def method_missing(method_name, *args, &block)


### PR DESCRIPTION
if we're going to use the AM/PM field `%p` then we should use the 12-hour representation, rather than the 24-hour representation
