### PR TITLE
make sure we only assign the order when the promotion is activated. 

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -21,7 +21,7 @@ module Spree
     validates :description, length: { maximum: 255 }
 
     before_save :normalize_blank_values
-    
+
     def self.advertised
       where(advertise: true)
     end
@@ -47,11 +47,6 @@ module Spree
       order = payload[:order]
       return unless self.class.order_activatable?(order)
 
-      # connect to the order
-      #create the join_table entry.
-      self.orders << order
-      self.save
-
       # Track results from actions to see if any action has been taken.
       # Actions should return nil/false if no action has been taken.
       # If an action returns true, then an action has been taken.
@@ -59,7 +54,16 @@ module Spree
         action.perform(payload)
       end
       # If an action has been taken, report back to whatever activated this promotion.
-      return results.include?(true)
+      action_taken = results.include?(true)
+
+      if action_taken
+      # connect to the order
+      # create the join_table entry.
+        self.orders << order
+        self.save
+      end
+
+      return action_taken
     end
 
     # called anytime order.update! happens

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -94,11 +94,25 @@ describe Spree::Promotion do
       expect(promotion.activate(@payload)).to be_true
     end
 
-    it "keeps track of the order" do
-      expect(promotion.orders).to be_empty
-      expect(promotion.activate(@payload)).to be_true
-      expect(promotion.orders.first).to eql @order
+    context "keeps track of the orders" do
+      context "when activated" do
+        it "assigns the order" do
+          expect(promotion.orders).to be_empty
+          expect(promotion.activate(@payload)).to be_true
+          expect(promotion.orders.first).to eql @order
+        end
+      end
+      context "when not activated" do
+        it "will not assign the order" do
+          @order.state = 'complete'
+          expect(promotion.orders).to be_empty
+          expect(promotion.activate(@payload)).to be_false
+          expect(promotion.orders).to be_empty
+        end
+      end
+
     end
+
   end
 
   context "#usage_limit_exceeded" do


### PR DESCRIPTION
Fixes #4213
