### PR TITLE
prefix table name on scopes

### DIFF
--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -53,8 +53,8 @@ module Spree
     scope :shipping, -> { where(adjustable_type: 'Spree::Shipment') }
     scope :optional, -> { where(mandatory: false) }
     scope :eligible, -> { where(eligible: true) }
-    scope :charge, -> { where('amount >= 0') }
-    scope :credit, -> { where('amount < 0') }
+    scope :charge, -> { where("#{quoted_table_name}.amount >= 0") }
+    scope :credit, -> { where("#{quoted_table_name}.amount < 0") }
     scope :promotion, -> { where(source_type: 'Spree::PromotionAction') }
     scope :return_authorization, -> { where(source_type: "Spree::ReturnAuthorization") }
     scope :included, -> { where(included: true)  }

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -92,7 +92,7 @@ module Spree
     end
 
     def self.complete
-      where('completed_at IS NOT NULL')
+      where.not(completed_at: nil)
     end
 
     def self.incomplete

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -31,7 +31,7 @@ module Spree
     scope :completed, -> { with_state('completed') }
     scope :pending, -> { with_state('pending') }
     scope :failed, -> { with_state('failed') }
-    scope :valid, -> { where('state NOT IN (?)', %w(failed invalid)) }
+    scope :valid, -> { where.not(state: %w(failed invalid)) }
 
     after_rollback :persist_invalid
 

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -42,7 +42,7 @@ module Spree
     after_create :set_position
 
     # default variant scope only lists non-deleted variants
-    scope :deleted, lambda { where('deleted_at IS NOT NULL') }
+    scope :deleted, lambda { where.not(deleted_at: nil) }
 
     def self.active(currency = nil)
       joins(:prices).where(deleted_at: nil).where('spree_prices.currency' => currency || Spree::Config[:currency]).where('spree_prices.amount IS NOT NULL')


### PR DESCRIPTION
I think it's good to always prefix table names in scopes to avoid breaking queries with joins when using `merge()`.

For example i had a problem joining `Product` with  `merge(Variant.deleted)` (ambiguous column name: deleted_at)
