### PR TITLE
Added missing index for variant_id and currency on spree_prices

### DIFF
--- a/core/db/migrate/20140120160805_add_index_to_variant_id_and_currency_on_prices.rb
+++ b/core/db/migrate/20140120160805_add_index_to_variant_id_and_currency_on_prices.rb
@@ -1,0 +1,5 @@
+class AddIndexToVariantIdAndCurrencyOnPrices < ActiveRecord::Migration
+  def change
+    add_index :spree_prices, [:variant_id, :currency]
+  end
+end


### PR DESCRIPTION
Query to get products from a taxon

```
SELECT COUNT(*) FROM "spree_products" INNER JOIN "spree_variants" ON "spree_variants"."product_id" = "spree_products"."id" AND "spree_variants"."is_master" = 't' AND "spree_variants"."deleted_at" IS NULL INNER JOIN "spree_prices" ON "spree_prices"."variant_id" = "spree_variants"."id" WHERE "spree_products"."deleted_at" IS NULL AND ("spree_products".deleted_at IS NULL or "spree_products".deleted_at >= '2014-01-20 15:33:58.341590') AND ("spree_products".available_on <= '2014-01-20 15:33:58.341879') AND "spree_products"."id" IN (SELECT spree_products_taxons.product_id FROM "spree_products_taxons" INNER JOIN "spree_taxons" ON "spree_taxons"."id" = "spree_products_taxons"."taxon_id" WHERE "spree_taxons"."id" IN (8970)) AND (spree_prices.amount IS NOT NULL) AND "spree_prices"."currency" = 'EUR';
```

Before:

```
Time: 43.675 ms
```

After adding indexes:

```
Time: 2.752 ms
```
