### PR TITLE
Improved tracking URL generation to handle spaces in tracking numbers

### DIFF
--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -43,7 +43,8 @@ module Spree
     end
 
     def build_tracking_url(tracking)
-      tracking_url.gsub(/:tracking/, tracking) unless tracking.blank? || tracking_url.blank?
+      return if tracking.blank? || tracking_url.blank?
+      tracking_url.gsub(/:tracking/, ERB::Util.url_encode(tracking)) # :url_encode exists in 1.8.7 through 2.1.0
     end
 
     def self.calculators

--- a/core/spec/models/spree/shipping_method_spec.rb
+++ b/core/spec/models/spree/shipping_method_spec.rb
@@ -40,4 +40,22 @@ describe Spree::ShippingMethod do
       shipping_method.calculator.calculable.should == shipping_method
     end
   end
+
+  context "generating tracking URLs" do
+    context "shipping method has a tracking URL mask on file" do
+      let(:tracking_url) { "https://track-o-matic.com/:tracking" }
+      before { subject.stub(:tracking_url) { tracking_url } }
+
+      context 'tracking number has spaces' do
+        let(:tracking_numbers) { ["1234 5678 9012 3456", "a bcdef"] }
+        let(:expectations) { %w[https://track-o-matic.com/1234%205678%209012%203456 https://track-o-matic.com/a%20bcdef] }
+
+        it "should return a single URL with '%20' in lieu of spaces" do
+          tracking_numbers.each_with_index do |num, i|
+            subject.build_tracking_url(num).should == expectations[i]
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes #4149. Unfortunately 4149 is so old that I lost access to the `dpritchett/patch-1` branch (deleted it to do something else via the Github web UI no doubt) and so I'm having to resubmit it as a second PR.
# What

Tracking numbers returned by remote shipment labeling APIs (i.e. USPS/Endicia) sometimes include spaces.  Passing these straight through to a URL results in unexpected behavior when the tracking URL makes its way to the edges of the app (e.g. [the shipment mailer template](https://github.com/spree/spree/blob/dcce1c3b7c4f57fcb21ed0ac3b1982de53b56c70/core/app/views/spree/shipment_mailer/shipped_email.text.erb#L14)).  Why not `URI#escape` the tracking number before passing it on as a link?
## Before

Tracking Information: 1111 2222 3333
Tracking Link: https://tools.usps.com/go/TrackConfirmAction?qtc_tLabels1=1111 2222 3333
## After

Tracking Information: 1111 2222 3333
Tracking Link: https://tools.usps.com/go/TrackConfirmAction?qtc_tLabels1=1111%202222%203333
