### PR TITLE
wrong constant name Spree::Frontend when creating a test app

### DIFF
--- a/core/lib/generators/spree/dummy/dummy_generator.rb
+++ b/core/lib/generators/spree/dummy/dummy_generator.rb
@@ -53,9 +53,9 @@ module Spree
     def test_dummy_inject_extension_requirements
       if DummyGeneratorHelper.inject_extension_requirements
         inside dummy_path do
-          inject_require_for('spree_frontend') if Object.const_defined?("Spree::Frontend")
-          inject_require_for('spree_backend') if Object.const_defined?("Spree::Backend")
-          inject_require_for('spree_api') if Object.const_defined?("Spree::Api")
+          inject_require_for('spree_frontend') if defined?(Spree::Frontend)
+          inject_require_for('spree_backend') if defined?(Spree::Backend)
+          inject_require_for('spree_api') if defined?(Spree::Api)
         end
       end
     end


### PR DESCRIPTION
When creating a new test_app (`rake test_app`) I get this error:

`wrong constant name Spree::Frontend`

Full stack trace:

```
/Users/willian/src/spree/core/lib/generators/spree/dummy/dummy_generator.rb:56:in `const_defined?'
/Users/willian/src/spree/core/lib/generators/spree/dummy/dummy_generator.rb:56:in `block in test_dummy_inject_extension_requirements'
/Users/willian/.rvm/gems/ruby-2.0.0-p0@global/gems/bundler-1.3.4/lib/bundler/vendor/thor/actions.rb:182:in `block in inside'
/Users/willian/.rvm/gems/ruby-2.0.0-p0@global/gems/bundler-1.3.4/lib/bundler/vendor/thor/actions.rb:182:in `inside'
/Users/willian/src/spree/core/lib/generators/spree/dummy/dummy_generator.rb:55:in `test_dummy_inject_extension_requirements'
/Users/willian/.rvm/gems/ruby-2.0.0-p0@global/gems/bundler-1.3.4/lib/bundler/vendor/thor/task.rb:27:in `run'
/Users/willian/.rvm/gems/ruby-2.0.0-p0@global/gems/bundler-1.3.4/lib/bundler/vendor/thor/invocation.rb:120:in `invoke_task'
/Users/willian/.rvm/gems/ruby-2.0.0-p0@global/gems/bundler-1.3.4/lib/bundler/vendor/thor/invocation.rb:126:in `block in invoke_all'
/Users/willian/.rvm/gems/ruby-2.0.0-p0@global/gems/bundler-1.3.4/lib/bundler/vendor/thor/invocation.rb:126:in `each'
/Users/willian/.rvm/gems/ruby-2.0.0-p0@global/gems/bundler-1.3.4/lib/bundler/vendor/thor/invocation.rb:126:in `map'
/Users/willian/.rvm/gems/ruby-2.0.0-p0@global/gems/bundler-1.3.4/lib/bundler/vendor/thor/invocation.rb:126:in `invoke_all'
/Users/willian/.rvm/gems/ruby-2.0.0-p0@global/gems/bundler-1.3.4/lib/bundler/vendor/thor/group.rb:238:in `dispatch'
/Users/willian/.rvm/gems/ruby-2.0.0-p0@global/gems/bundler-1.3.4/lib/bundler/vendor/thor/base.rb:434:in `start'
/Users/willian/src/spree/core/lib/spree/testing_support/common_rake.rb:13:in `block (2 levels) in <top (required)>'
/Users/willian/src/spree/core/lib/spree/testing_support/extension_rake.rb:7:in `block (2 levels) in <top (required)>'
/Users/willian/src/spree_hstore/Rakefile:14:in `block in <top (required)>'
/Users/willian/.rvm/gems/ruby-2.0.0-p0/bin/ruby_noexec_wrapper:14:in `eval'
/Users/willian/.rvm/gems/ruby-2.0.0-p0/bin/ruby_noexec_wrapper:14:in `<main>'
```

On `dummy_generator.rb` line 56:

```
inject_require_for('spree_frontend') if Object.const_defined?("Spree::Frontend")
```

I fixed this by doing:

```
inject_require_for('spree_frontend') if defined?(Spree::Frontend)
```

`Object.const_defined?("Spree::Frontend")` was introduced 5 days ago in this fdfd348fe4301d15c71a980d60fc0aa3c41df283 commit.

@radar I'm not sure if this will result in the expected behaviour! Could you verify this for me?
