### PR TITLE
Upgraded estimator rescue log level to Error

### DIFF
--- a/core/app/models/spree/stock/estimator.rb
+++ b/core/app/models/spree/stock/estimator.rb
@@ -48,9 +48,9 @@ module Spree
       end
 
       def log_calculator_exception(ship_method, exception)
-        Rails.logger.info("Something went wrong calculating rates with the #{ship_method.name} (ID=#{ship_method.id}) shipping method.")
-        Rails.logger.info("*" * 50)
-        Rails.logger.info(exception.backtrace.join("\n"))
+        Rails.logger.error("Something went wrong calculating rates with the #{ship_method.name} (ID=#{ship_method.id}) shipping method.")
+        Rails.logger.error("*" * 50)
+        Rails.logger.error(exception.backtrace.join("\n"))
       end
     end
   end


### PR DESCRIPTION
Per a discussion in #spree I feel that the `.error` log level is more appropriate here - something bad's happening and while we definitely want to recover and not return a `500` we still need to give the admin a heads up ASAP.  In the absence of a critical error detection meta-framework the `error` loglevel seems like the way to go.  I can set up an email alert on this loglevel in Papertrail for instance.
