### PR TITLE
Allow halting of callbacks by returning false

### DIFF
--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -201,7 +201,7 @@ module Spree
             checkout_step_index(state) > checkout_step_index(self.state)
           end
 
-          define_callbacks :updating_from_params
+          define_callbacks :updating_from_params, terminator: 'result == false'
 
           set_callback :updating_from_params, :before, :update_params_payment_source
 

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -388,8 +388,17 @@ describe Spree::Order do
           order.update_from_params(params, permitted_params)
         end
       end
-    end
 
+      context 'callbacks halt' do
+        before do
+          order.should_receive(:update_params_payment_source).and_return false
+        end
+        it 'does not let through unpermitted attributes' do
+          order.should_not_receive(:update_attributes).with({})
+          order.update_from_params(params, permitted_params)
+        end
+      end
+    end
 
   end
 end


### PR DESCRIPTION
Without specifying a :terminator to define_callbacks, its impossible to
halt the event from happening.

And yes, that is a string that is eval'd, as per:

  http://api.rubyonrails.org/classes/ActiveSupport/Callbacks/ClassMethods.html#method-i-define_callbacks
