### PR TITLE
Having a spree_api_key field on the user model is optional

### DIFF
--- a/api/app/overrides/api_admin_user_edit_form.rb
+++ b/api/app/overrides/api_admin_user_edit_form.rb
@@ -1,4 +1,4 @@
-if defined?(Deface)
+if defined?(Deface) && @user.respond_to?(:spree_api_key)
   Deface::Override.new(:virtual_path => "spree/admin/users/edit",
                        :name => "api_admin_user_edit_form",
                        :insert_after => "[data-hook='admin_user_edit_general_settings']",

--- a/backend/app/views/spree/layouts/admin.html.erb
+++ b/backend/app/views/spree/layouts/admin.html.erb
@@ -52,8 +52,10 @@
 
     <div data-hook="admin_footer_scripts"></div>
 
-    <script>
-      Spree.api_key = <%= raw(try_spree_current_user.try(:spree_api_key).to_s.inspect) %>;
-    </script>
+    <% if try_spree_current_user.try(:respond_to?, :spree_api_key) %>
+      <script>
+        Spree.api_key = <%= raw(try_spree_current_user.try(:spree_api_key).to_s.inspect) %>;
+      </script>
+    <% end %>
   </body>
 </html>

--- a/frontend/app/views/spree/layouts/spree_application.html.erb
+++ b/frontend/app/views/spree/layouts/spree_application.html.erb
@@ -33,8 +33,10 @@
     </div>
 
     <%= render :partial => 'spree/shared/google_analytics' %>
-    <script>
-      Spree.api_key = <%= raw(try_spree_current_user.try(:spree_api_key).to_s.inspect) %>;
-    </script>
+    <% if try_spree_current_user.try(:respond_to?, :spree_api_key) %>
+      <script>
+        Spree.api_key = <%= raw(try_spree_current_user.try(:spree_api_key).to_s.inspect) %>;
+      </script>
+    <% end %>
   </body>
 </html>


### PR DESCRIPTION
This removes failure cases when the spree_api_key is not available on
the spree user model. As the spree_api_key is optional, its absence should
never lead to a failure.
