### PR TITLE
typo on spec_helper template for extensions

### DIFF
--- a/cmd/lib/spree_cmd/templates/extension/spec/spec_helper.rb.tt
+++ b/cmd/lib/spree_cmd/templates/extension/spec/spec_helper.rb.tt
@@ -58,7 +58,7 @@ RSpec.configure do |config|
 
   # Capybara javascript drivers require transactional fixtures set to false, and we use DatabaseCleaner
   # to cleanup after each test instead.  Without transactional fixtures set to false the records created
-  # to setup a test will be unavailable to the browser, which runs under a seperate server instance.
+  # to setup a test will be unavailable to the browser, which runs under a separate server instance.
   config.use_transactional_fixtures = false
 
   # Ensure Suite is set to use transactions for speed.


### PR DESCRIPTION
Just a small typo on the comment about `database_cleaner`
