### PR TITLE
Ensure avs_response == 'M' is not considered risky

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -512,7 +512,7 @@ module Spree
 
     def is_risky?
       self.payments.where(%{
-        (avs_response IS NOT NULL and avs_response != 'D') or
+        (avs_response IS NOT NULL and avs_response != 'D' and avs_response != 'M') or
         (cvv_response_code IS NOT NULL and cvv_response_code != 'M') or
         cvv_response_message IS NOT NULL or
         state = 'failed'


### PR DESCRIPTION
Addresses mistakenly considering an `avs_response` of `'M'` as risky as pointed out by @radar in https://github.com/spree/spree/pull/4021
