### PR TITLE
Symbol vs string keys in Spree::Order.build_from_api

### DIFF
--- a/api/app/models/spree/order_decorator.rb
+++ b/api/app/models/spree/order_decorator.rb
@@ -97,8 +97,8 @@ Spree::Order.class_eval do
   def create_adjustments_from_api(adjustments)
     adjustments.each do |a|
       begin
-        adjustment = self.adjustments.build(:amount => a['amount'].to_f,
-                                            :label => a['label'])
+        adjustment = self.adjustments.build(:amount => a[:amount].to_f,
+                                            :label => a[:label])
         adjustment.save!
         adjustment.finalize!
       rescue Exception => e

--- a/api/spec/models/spree/order_spec.rb
+++ b/api/spec/models/spree/order_spec.rb
@@ -254,8 +254,8 @@ module Spree
 
     it 'adds adjustments' do
       params = { :adjustments_attributes => [
-          { "label" => "Shipping Discount", "amount" => "-4.99" },
-          { "label" => "Promotion Discount", "amount" => "-3.00" }] }
+          { label: 'Shipping Discount', amount: -4.99 },
+          { label: 'Promotion Discount', amount: -3.00 }] }
 
       order = Order.build_from_api(user, params)
       order.adjustments.all?(&:finalized?).should be_true
@@ -265,8 +265,8 @@ module Spree
 
     it 'handles adjustment building exceptions' do
       params = { :adjustments_attributes => [
-          { "amount" => "XXX" },
-          { "label" => "Promotion Discount", "amount" => "-3.00" }] }
+          { amount: 'XXX' },
+          { label: 'Promotion Discount', amount: '-3.00' }] }
 
       expect {
         order = Order.build_from_api(user, params)


### PR DESCRIPTION
I noticed in this file https://github.com/spree/spree/blob/2-1-stable/api/app/models/spree/order_decorator.rb#L100

String keys are used on the adjustments hash but just a few lines above for other hashes symbols are used.  This bit me using the new hash syntax and invoking this method.  Would it be worthwhile to throw a `symbolize_keys` in there or something else to make these methods consistent?
