### PR TITLE
Add apply_promo_code endpoint to 2-1-stable

### DIFF
--- a/api/app/views/spree/api/orders/apply_coupon_code.v1.rabl
+++ b/api/app/views/spree/api/orders/apply_coupon_code.v1.rabl
@@ -1,0 +1,7 @@
+object @coupon_result
+
+# Mimic of eventual payload in Spree Core to keep contract the same when we upgrade.
+# https://github.com/spree/spree/blob/master/api/app/views/spree/api/promotions/handler.v1.rabl
+node(:success) { @coupon_result.success }
+node(:error) { @coupon_result.error }
+node(:successful) { @coupon_result.coupon_applied? }

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -31,6 +31,10 @@ Spree::Core::Engine.add_routes do
     get '/orders/mine', :to => 'orders#mine', :as => 'my_orders'
 
     resources :orders do
+      member do
+        put :apply_coupon_code
+      end
+
       resources :addresses, :only => [:show, :update]
 
       resources :return_authorizations do

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -546,6 +546,64 @@ module Spree
         end
       end
     end
+
+    describe 'apply_promo_code' do
+      # Borrowed from:
+      # https://github.com/spree/spree/blob/master/api/spec/controllers/spree/api/promotion_application_spec.rb
+
+      let(:order) { create(:order, state: 'payment', user: current_api_user) }
+
+      subject do
+        api_put :apply_coupon_code, id: order.to_param, coupon_code: coupon_code
+      end
+
+      context 'when valid promo code' do
+        let(:coupon_code) { 'some_code' }
+
+        # Create a promotion for testing.
+        # https://github.com/spree/spree/blob/2-1-stable/core/spec/lib/spree/promo/coupon_applicator_spec.rb
+        before(:each) do
+          flat_percent_calc = Spree::Calculator::FlatPercentItemTotal.create(:preferred_flat_percent => "10")
+          promo = Spree::Promotion.create(:name => "Discount", :event_name => "spree.checkout.coupon_code_added", :code => coupon_code, :usage_limit => "10", :starts_at => DateTime.yesterday, :expires_at => DateTime.tomorrow)
+          promo_rule = Spree::Promotion::Rules::ItemTotal.create(:preferred_operator => "gt", :preferred_amount => "1")
+          promo_rule.update_attribute(:activator_id, promo.id)
+          promo_action = Spree::Promotion::Actions::CreateAdjustment.create(:calculator_type => "Spree::Calculator::FlatPercentItemTotal")
+          promo_action.update_attribute(:activator_id, promo.id)
+          flat_percent_calc.update_attribute(:calculable_id, promo.id)
+          Spree::Order.any_instance.stub(:payment_required? => false)
+          Spree::Adjustment.any_instance.stub(:eligible => true)
+        end
+
+        it 'should should be_ok ' do
+          subject
+          response.should be_ok 
+        end
+
+        it 'should have success JSON' do
+          subject
+          result = JSON.parse(response.body)
+          result['successful'].should be_true
+          result['success'].should == "The coupon code was successfully applied to your order."
+          result['error'].should be_nil
+        end
+      end
+
+      context 'when invalid promo code' do
+        let(:coupon_code) { 'xxxxx' }
+        it 'should should be_ok ' do
+          subject
+          response.code.to_i.should == 422
+        end
+
+        it 'should have error JSON' do
+          subject
+          result = JSON.parse(response.body)
+          result['successful'].should be_false
+          result['error'].should == "The coupon code you entered doesn't exist. Please try again."
+          result['success'].should be_nil
+        end
+      end
+    end
   end
 end
 


### PR DESCRIPTION
This commit adds the necessary logic to apply a promo code to an order against the API. The RESTful contract was structured in a way to be identical with the eventual API endpoint in Spree master, as implemented in this commit. This should allow people to code against this apply_promo_code and not have to change their client code when the real API endpoint is available.

https://github.com/spree/spree/commit/72a5b74c47af975fc3492580415a4cdc2dc02c0c
