### PR TITLE
Risk Analysis Order#is_risky? and Payment#is_cvv_risky? bugs

### DIFF
--- a/backend/app/views/spree/admin/orders/_risk_analysis.html.erb
+++ b/backend/app/views/spree/admin/orders/_risk_analysis.html.erb
@@ -11,7 +11,7 @@
           <%= Spree.t(:failed_payment_attempts) %>:
         </strong></td>
           <td class="align-center">
-            <span class="<%= @order.is_risky? ? 'state void' : 'state complete' %>">
+            <span class="<%= @order.payments.failed.count > 0 ? 'state void' : 'state complete' %>">
               <%= link_to "#{pluralize(@order.payments.failed.count, Spree.t(:payment))}", spree.admin_order_payments_path(@order) %>
             </span>
         </td>

--- a/backend/app/views/spree/admin/orders/_risk_analysis.html.erb
+++ b/backend/app/views/spree/admin/orders/_risk_analysis.html.erb
@@ -1,5 +1,5 @@
 <fieldset class="no-border-bottom">
-  <legend><%= Spree.t(:risk_analysis) %></legend>
+  <legend><%= "#{Spree.t(:risk_analysis)}: #{Spree.t(:not) unless @order.is_risky?} #{Spree.t(:risky)}" %></legend>
   <table>
     <thead>
       <th><%= Spree.t('risk')%></th>

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -528,9 +528,9 @@ module Spree
 
     def is_risky?
       self.payments.where(%{
-        (avs_response IS NOT NULL and and avs_response != '' and avs_response != 'D' and avs_response != 'M') or
-        (cvv_response_code IS NOT NULL and cvv_response_code != '' and cvv_response_code != 'M') or
-        cvv_response_message IS NOT NULL and cvv_response_message IS NOT '' or
+        (avs_response IS NOT NULL and avs_response != '' and avs_response != 'D' and avs_response != 'M') or
+        (cvv_response_code IS NOT NULL and cvv_response_code != 'M') or
+        cvv_response_message IS NOT NULL and cvv_response_message != '' or
         state = 'failed'
       }.squish!).uniq.count > 0
     end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -528,9 +528,9 @@ module Spree
 
     def is_risky?
       self.payments.where(%{
-        (avs_response IS NOT NULL and avs_response != 'D' and avs_response != 'M') or
-        (cvv_response_code IS NOT NULL and cvv_response_code != 'M') or
-        cvv_response_message IS NOT NULL or
+        (avs_response IS NOT NULL and and avs_response != '' and avs_response != 'D' and avs_response != 'M') or
+        (cvv_response_code IS NOT NULL and cvv_response_code != '' and cvv_response_code != 'M') or
+        cvv_response_message IS NOT NULL and cvv_response_message IS NOT '' or
         state = 'failed'
       }.squish!).uniq.count > 0
     end

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -119,11 +119,11 @@ module Spree
     end
 
     def is_avs_risky?
-      !(avs_response == "D" || avs_response.nil?)
+      !(avs_response == "D" || avs_response.blank?)
     end
 
     def is_cvv_risky?
-      !(cvv_response_code == "M" || cvv_response_code.nil?)
+      !(cvv_response_code == "M" || cvv_response_code.blank?)
     end
 
     private

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -119,12 +119,16 @@ module Spree
     end
 
     def is_avs_risky?
-      !(avs_response == "D" || avs_response.blank?)
+      return false if avs_response == "D"
+      return false if avs_response.blank?
+      return true
     end
 
     def is_cvv_risky?
-      !(cvv_response_code == "M" || cvv_response_code.blank?) ||
-       (cvv_response_message.blank?)
+      return false if cvv_response_code == "M"
+      return false if cvv_response_code.nil?
+      return false if cvv_response_message.present?
+      return true
     end
 
     private

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -123,7 +123,8 @@ module Spree
     end
 
     def is_cvv_risky?
-      !(cvv_response_code == "M" || cvv_response_code.blank?)
+      !(cvv_response_code == "M" || cvv_response_code.blank?) ||
+       (cvv_response_message.blank?)
     end
 
     private

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -926,6 +926,7 @@ en:
     review: Review
     risk: Risk
     risk_analysis: Risk Analysis
+    risky: Risky
     rma_credit: RMA Credit
     rma_number: RMA Number
     rma_value: RMA Value

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -688,33 +688,63 @@ describe Spree::Order do
           order.is_risky?.should == false
         end
       end
-    end
 
-    context "AVS response message" do
-      let(:order) { FactoryGirl.create(:order, payments: [FactoryGirl.create(:payment, avs_response: "A")]) }
-      it "returns true if the order has an avs_response" do
-        order.is_risky?.should == true
+      context "with avs_response == ''" do
+        it "is not considered risky" do
+          payment.update_attribute(:avs_response, '')
+          order.is_risky?.should == false
+        end
+      end
+
+      context "with cvv_response_code == M" do
+        let(:payment) { FactoryGirl.create(:payment, cvv_response_code: "M") }
+        it "is not considered risky" do
+          order.is_risky?.should == false
+        end
+      end
+
+      context "with cvv_response_code == ''" do
+        it "is not considered risky" do
+          payment.update_attribute(:cvv_response_code, '')
+          order.is_risky?.should == false
+        end
+      end
+
+      context "with cvv_response_message == ''" do
+        it "is not considered risky" do
+          payment.update_attribute(:cvv_response_message, '')
+          order.is_risky?.should == false
+        end
       end
     end
 
-    context "CVV response message" do
-      let(:order) { FactoryGirl.create(:order, payments: [FactoryGirl.create(:payment, cvv_response_message: "foobar'd")]) }
-      it "returns true if the order has an cvv_response_message" do
-        order.is_risky?.should == true
+    context "Risky order" do
+      context "AVS response message" do
+        let(:order) { FactoryGirl.create(:order, payments: [FactoryGirl.create(:payment, avs_response: "A")]) }
+        it "returns true if the order has an avs_response" do
+          order.is_risky?.should == true
+        end
       end
-    end
 
-    context "CVV response code" do
-      let(:order) { FactoryGirl.create(:order, payments: [FactoryGirl.create(:payment, cvv_response_code: "N")]) }
-      it "returns true if the order has an cvv_response_code" do
-        order.is_risky?.should == true
+      context "CVV response message" do
+        let(:order) { FactoryGirl.create(:order, payments: [FactoryGirl.create(:payment, cvv_response_message: "foobar'd")]) }
+        it "returns true if the order has an cvv_response_message" do
+          order.is_risky?.should == true
+        end
       end
-    end
 
-    context "state == 'failed'" do
-      let(:order) { FactoryGirl.create(:order, payments: [FactoryGirl.create(:payment, state: 'failed')]) }
-      it "returns true if the order has state == 'failed'" do
-        order.is_risky?.should == true
+      context "CVV response code" do
+        let(:order) { FactoryGirl.create(:order, payments: [FactoryGirl.create(:payment, cvv_response_code: "N")]) }
+        it "returns true if the order has an cvv_response_code" do
+          order.is_risky?.should == true
+        end
+      end
+
+      context "state == 'failed'" do
+        let(:order) { FactoryGirl.create(:order, payments: [FactoryGirl.create(:payment, state: 'failed')]) }
+        it "returns true if the order has state == 'failed'" do
+          order.is_risky?.should == true
+        end
       end
     end
   end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -690,8 +690,8 @@ describe Spree::Order do
       end
 
       context "with avs_response == ''" do
+        let(:payment) { FactoryGirl.create(:payment, avs_response: "") }
         it "is not considered risky" do
-          payment.update_attribute(:avs_response, '')
           order.is_risky?.should == false
         end
       end
@@ -703,16 +703,9 @@ describe Spree::Order do
         end
       end
 
-      context "with cvv_response_code == ''" do
-        it "is not considered risky" do
-          payment.update_attribute(:cvv_response_code, '')
-          order.is_risky?.should == false
-        end
-      end
-
       context "with cvv_response_message == ''" do
+        let(:payment) { FactoryGirl.create(:payment, cvv_response_message: "") }
         it "is not considered risky" do
-          payment.update_attribute(:cvv_response_message, '')
           order.is_risky?.should == false
         end
       end

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -702,17 +702,17 @@ describe Spree::Payment do
   end
 
   describe "is_avs_risky?" do
-    it "should return false if avs_response == 'D'" do
+    it "returns false if avs_response == 'D'" do
       payment.update_attribute(:avs_response, "D")
       payment.is_avs_risky?.should == false
     end
 
-    it "should return false if avs_response == nil" do
+    it "returns false if avs_response == nil" do
       payment.update_attribute(:avs_response, nil)
       payment.is_avs_risky?.should == false
     end
 
-    it "should return true if avs_response == A-Z, omitting D" do
+    it "returns true if avs_response == A-Z, omitting D" do
       # should use avs_response_code helper
       ('A'..'Z').reject{ |x| x == 'D' }.to_a.each do |char|
         payment.update_attribute(:avs_response, char)
@@ -722,19 +722,24 @@ describe Spree::Payment do
   end
 
   describe "is_cvv_risky?" do
-    it "should return false if cvv_response_code == 'M'" do
+    it "returns false if cvv_response_code == 'M'" do
       payment.update_attribute(:cvv_response_code, "M")
       payment.is_cvv_risky?.should == false
     end
 
-    it "should return false if cvv_response_code == nil" do
+    it "returns false if cvv_response_code == nil" do
       payment.update_attribute(:cvv_response_code, nil)
       payment.is_cvv_risky?.should == false
     end
 
-    it "should return true if cvv_response_code == A-Z, omitting D" do
+    it "returns false if cvv_response_message == ''" do
+      payment.update_attribute(:cvv_response_message, '')
+      payment.is_cvv_risky?.should == false
+    end
+
+    it "returns true if cvv_response_code == [A-Z], omitting D" do
       # should use cvv_response_code helper
-      (%w{N P S U} << '').each do |char|
+      (%w{N P S U} << "").each do |char|
         payment.update_attribute(:cvv_response_code, char)
         payment.is_cvv_risky?.should == true
       end


### PR DESCRIPTION
Addresses issues from https://github.com/spree/spree/issues/4260
- [x] `Order#is_risky?` is used in `app/views/spree/admin/orders/_risk_analysis.html.erb` partial, when it really should be checking if  `Order.payments.failed.count > 0`. As a result, when orders have 1 or more payments that have not been accepted, `Failed Payment Attempts` uses css class `.void` (a red circle) instead of CSS class `.complete` (a green circle).
- [x] `Order#is_risky?` doesn't take into account if its payments `avs_response` or `cvv_response_message` are the empty string. 
- [x] Add updated unit tests for `Order#is_risky?` method
- [x] Add logic and translations for the `_risk_analysis.html.erb` `legend` element to show whether order is risky or not.
- [x] `Payment#is_cvv_risky?` returns true if `cvv_response == ""`.
- [x] Add updated unit tests for `Payment#is_cvv_risky?` method

![screen shot 2014-01-27 at 10 03 11 pm](https://f.cloud.github.com/assets/199422/2016630/e30d2f96-87e1-11e3-8a9a-e7edfba1e6b8.png)
