### PR TITLE
[API] Free shipment promotions are not applying

### DIFF
--- a/core/app/models/spree/promotion/rules/item_total.rb
+++ b/core/app/models/spree/promotion/rules/item_total.rb
@@ -10,10 +10,15 @@ module Spree
         OPERATORS = ['gt', 'gte']
 
         def applicable?(promotable)
-          promotable.is_a?(Spree::Order)
+          promotable.is_a?(Spree::Order) || promotable.is_a?(Spree::Shipment)
         end
 
-        def eligible?(order, options = {})
+        def eligible?(promotable, options = {})
+          if order.is_a?(Spree::Shipment)
+            order = promotable.order
+          else
+            order = promotable
+          end
           item_total = order.item_total
           item_total.send(preferred_operator == 'gte' ? :>= : :>, BigDecimal.new(preferred_amount.to_s))
         end

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -318,6 +318,7 @@ module Spree
 
 
       def update_adjustments
+        PromotionHandler::Cart.new(order).activate
         if cost_changed? && state != 'shipped'
           recalculate_adjustments
         end


### PR DESCRIPTION
**Steps to reproduce**
1. Create a promotion which adds free shipment with `item_total` rule
2. Add to cart items which reaches this rule
3. Go through API checkout until delivery step is reached

**Expecting** shipments to be free.

**What happens** - shipments have unchanged value.

Using Spree from master branch.

So, I've done research and found a bug, but way which I fixed it is not great. Two things acutally are not working. Everything was tested on API.
- First of all, the adjustments are not created for shipment. Currently, they are activated after order contents was changed. It's not enough, as in `cart` step, the order has no shipment available, because the address is empty and it cannot determine them. We need to run the PromotionHandler::Cart (or other) after creating shipments. 
- Secondly, even when I run the handler and adjustments are created, they are not eligible. The `item_total` rule is applicable only for `Spree::Order`, but adjustments which happen to be created by PromotionHandler::Cart have `adjustable` set to `Spree::Shipment`. Fixed it by adding few lines to the rule, but it's not great way, too.

So, we need to find better way to handle this type of promotions. Not sure how it works for frontend though.
This is pull request but contains very rough fix.
