### PR TITLE
make sure payments have required attributes on controller

### DIFF
--- a/backend/app/controllers/spree/admin/payments_controller.rb
+++ b/backend/app/controllers/spree/admin/payments_controller.rb
@@ -71,7 +71,7 @@ module Spree
         if params[:payment] and params[:payment_source] and source_params = params.delete(:payment_source)[params[:payment][:payment_method_id]]
           params[:payment][:source_attributes] = source_params
         end
-        params.require(:payment).permit(:amount, :payment_method_id, source_attributes: [:number, :expiry, :verification_value])
+        params.require(:payment).permit(permitted_payment_attributes)
       end
 
       def load_data

--- a/backend/app/views/spree/admin/payments/source_forms/_gateway.html.erb
+++ b/backend/app/views/spree/admin/payments/source_forms/_gateway.html.erb
@@ -17,6 +17,7 @@
     <div class="alpha four columns">
       <div data-hook="card_number">
         <div class="field">
+          <%= hidden_field_tag "#{param_prefix}[cc_type]", '', {:id => 'cc_type'} %>
           <%= label_tag 'card_number', raw(Spree.t(:card_number) + content_tag(:span, ' *', :class => 'required')) %>
           <%= text_field_tag "#{param_prefix}[number]", '', :class => 'required fullwidth', :id => 'card_number', :maxlength => 19 %>
           <span id="card_type" style="display:none;">

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -55,6 +55,8 @@ describe 'Payments' do
     fill_in 'card_expiry', :with => "01/#{Time.now.year+1}"
     fill_in 'card_code', :with => '123'
 
+    find('#cc_type', :visible => false).value.should == 'visa'
+
     click_button 'Update'
     page.should have_content('successfully created!')
 


### PR DESCRIPTION
`cc_type` was missing from the new payment form and it from the permitted attributes on the controller, I added the `permitted_paymen_attributes` that is being used on the checkouts controller of the frontend, please correct me if that's wrong.

this fixes #4276
