### PR TITLE
Make order-update concurrency safe

### DIFF
--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -47,7 +47,7 @@ module Spree
       end
 
       def update
-        find_order
+        find_order(true)
         # Parsing line items through as an update_attributes call in the API will result in
         # many line items for the same variant_id being created. We must be smarter about this,
         # hence the use of the update_line_items method, defined within order_decorator.rb.
@@ -136,8 +136,8 @@ module Spree
           end
         end
 
-        def find_order
-          @order = Spree::Order.find_by!(number: params[:id])
+        def find_order(lock = false)
+          @order = Spree::Order.lock(lock).find_by!(number: params[:id])
           authorize! :update, @order, order_token
         end
 

--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -11,15 +11,18 @@ module Spree
         end
 
         # The current incomplete order from the session for use in cart and during checkout
-        def current_order(create_order_if_necessary = false)
+        def current_order(options = {})
+          options[:create_order_if_necessary] ||= false
+          options[:lock] ||= false
+
           return @current_order if @current_order
 
           if session[:order_id]
-            current_order = Spree::Order.includes(:adjustments).find_by(id: session[:order_id], currency: current_currency)
+            current_order = Spree::Order.includes(:adjustments).lock(options[:lock]).find_by(id: session[:order_id], currency: current_currency)
             @current_order = current_order unless current_order.try(:completed?)
           end
 
-          if create_order_if_necessary and (@current_order.nil? or @current_order.completed?)
+          if options[:create_order_if_necessary] and (@current_order.nil? or @current_order.completed?)
             @current_order = Spree::Order.new(currency: current_currency)
             @current_order.user ||= try_spree_current_user
             # See issue #3346 for reasons why this line is here

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -6,7 +6,7 @@ module Spree
   class CheckoutController < Spree::StoreController
     ssl_required
 
-    before_filter :load_order
+    before_filter :load_order_with_lock
 
     before_filter :ensure_order_not_completed
     before_filter :ensure_checkout_allowed
@@ -69,8 +69,8 @@ module Spree
         false
       end
 
-      def load_order
-        @order = current_order
+      def load_order_with_lock
+        @order = current_order(lock: true) 
         redirect_to spree.cart_path and return unless @order
 
         if params[:state]

--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -8,7 +8,7 @@ module Spree
 
     respond_to :html
 
-    before_filter :assign_order, only: :update
+    before_filter :assign_order_with_lock, only: :update
     before_filter :apply_coupon_code, only: :update
 
     def show
@@ -40,7 +40,7 @@ module Spree
 
     # Adds a new item to the order (creating a new order if none already exists)
     def populate
-      populator = Spree::OrderPopulator.new(current_order(true), current_currency)
+      populator = Spree::OrderPopulator.new(current_order(create_order_if_necessary: true), current_currency)
       if populator.populate(params[:variant_id], params[:quantity])
         current_order.ensure_updated_shipments
 
@@ -90,8 +90,8 @@ module Spree
         end
       end
 
-      def assign_order
-        @order = current_order
+      def assign_order_with_lock
+        @order = current_order(lock: true)
         unless @order
           flash[:error] = Spree.t(:order_not_found)
           redirect_to root_path and return

--- a/frontend/spec/controllers/spree/current_order_tracking_spec.rb
+++ b/frontend/spec/controllers/spree/current_order_tracking_spec.rb
@@ -19,7 +19,7 @@ describe 'current order tracking' do
   it 'automatically tracks who the order was created by' do
     controller.stub(:try_spree_current_user => user)
     get :index
-    controller.current_order(true).created_by.should == controller.try_spree_current_user
+    controller.current_order(create_order_if_necessary: true).created_by.should == controller.try_spree_current_user
   end
 
   context "current order creation" do


### PR DESCRIPTION
When two order-updates happen at the same time, we can loose one of the
updates without this change. This locks the row on select, ensuring that
any subsequent changes don't get overwritten.

ORIGINAL COMMIT: https://github.com/bonobos/spree/commit/be9bb2a6bcfc72f186e4641516fdd00fc2b724f0
ORIGINAL AUTHOR: https://github.com/magnusvk

Additional Notes: We discovered an issue with the Order API. Trying to get our change reviewed/accepted into Spree to minimize future upgrade pain points.
