### PR TITLE
Eager load all things for api/product/:id

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -131,19 +131,21 @@ module Spree
       end
 
       def product_scope
+        variants_associations = [{ option_values: :option_type }, :default_price, :prices, :images]
         if current_api_user.has_spree_role?("admin")
           scope = Product.with_deleted.accessible_by(current_ability, :read)
+            .includes(:product_properties, :option_types, variants_including_master: variants_associations)
+
           unless params[:show_deleted]
             scope = scope.not_deleted
           end
         else
           scope = Product.accessible_by(current_ability, :read).active
+            .includes(:product_properties, :option_types, variants_including_master: variants_associations)
         end
 
-        scope.includes(:master)
+        scope
       end
-
     end
   end
 end
-

--- a/api/app/controllers/spree/api/products_controller.rb
+++ b/api/app/controllers/spree/api/products_controller.rb
@@ -107,7 +107,7 @@ module Spree
             @product.option_types << option_type unless @product.option_types.include?(option_type)
           end
 
-          respond_with(@product, :status => 200, :default_template => :show)
+          respond_with(@product.reload, :status => 200, :default_template => :show)
         else
           invalid_resource!(@product)
         end

--- a/api/app/views/spree/api/products/show.v1.rabl
+++ b/api/app/views/spree/api/products/show.v1.rabl
@@ -15,7 +15,7 @@ child :variants_including_master => :variants do
 end
 
 child :option_types => :option_types do
-  extends "spree/api/option_types/show"
+  attributes *option_type_attributes
 end
 
 child :product_properties => :product_properties do

--- a/api/spec/controllers/spree/api/products_controller_spec.rb
+++ b/api/spec/controllers/spree/api/products_controller_spec.rb
@@ -336,7 +336,15 @@ module Spree
           }
           variant_id = product.variants.create!({ product: product }.merge(variant_hash)).id
 
-          api_put :update, :id => product.to_param, :product => { :variants => [variant_hash.merge(:id => variant_id.to_s, :sku => '456', :options => [{:name => "size", :value => "large" }])] }
+          api_put :update, :id => product.to_param, :product => {
+            :variants => [
+              variant_hash.merge(
+                :id => variant_id.to_s,
+                :sku => '456',
+                :options => [{:name => "size", :value => "large" }]
+              )
+            ]
+          }
 
           expect(json_response['variants'].count).to eq(2) # 1 master + 1 variants
           variants = json_response['variants'].select { |v| !v['is_master'] }


### PR DESCRIPTION
Need to call `reload` on @product at update action so that it loads new
variants and show them properly on the template

@HoyaBoya could you please try this out and let us know if you see significant improvements?

I think it could improve performance for both _api/products_ and _api/products/:id_

related to #4285
