### PR TITLE
API Resolves #4100 Addresses API

### DIFF
--- a/api/app/controllers/spree/api/addresses_controller.rb
+++ b/api/app/controllers/spree/api/addresses_controller.rb
@@ -4,14 +4,23 @@ module Spree
       before_filter :find_order
 
       def show
-        authorize! :read, @order, params[:order_token]
-        find_address
+        if @order
+          authorize! :read, @order, order_token
+          find_address
+        else
+          find_address
+        end
         respond_with(@address)
       end
 
       def update
-        authorize! :update, @order, params[:order_token]
-        find_address
+        if @order
+          authorize! :update, @order, order_token
+          find_address
+        else
+          authorize! :update, @address
+          find_address
+        end
 
         if @address.update_attributes(address_params)
           respond_with(@address, :default_template => :show)
@@ -26,17 +35,25 @@ module Spree
         end
 
         def find_order
-          @order = Spree::Order.find_by!(number: params[:order_id])
+          @order = Spree::Order.find_by!(number: params[:order_id]) if params[:order_id]
         end
 
         def find_address
-          @address = if @order.bill_address_id == params[:id].to_i
-            @order.bill_address
-          elsif @order.ship_address_id == params[:id].to_i
-            @order.ship_address
+          if @order
+            @address = if @order.bill_address_id == params[:id].to_i
+              @order.bill_address
+            elsif @order.ship_address_id == params[:id].to_i
+              @order.ship_address
+            else
+              raise CanCan::AccessDenied
+            end
           else
-            raise CanCan::AccessDenied
+            @address = Spree::Address.find(params[:id])
           end
+        end
+
+        def order_token
+          request.headers["X-Spree-Order-Token"] || params[:order_token]
         end
     end
   end

--- a/api/spec/controllers/spree/api/addresses_controller_spec.rb
+++ b/api/spec/controllers/spree/api/addresses_controller_spec.rb
@@ -7,49 +7,75 @@ module Spree
     before do
       stub_authentication!
       @address = create(:address)
-      @order = create(:order, :bill_address => @address)
     end
-
-    context "with their own address" do
+    
+    context "with order" do
       before do
-        Order.any_instance.stub :user => current_api_user
+        @order = create(:order, :bill_address => @address)
+      end
+      
+      context "with their own address" do
+        before do
+          Order.any_instance.stub :user => current_api_user
+        end
+
+        it "gets an address" do
+          api_get :show, :id => @address.id, :order_id => @order.number
+          json_response['address1'].should eq @address.address1
+        end
+
+        it "updates an address" do
+          api_put :update, :id => @address.id, :order_id => @order.number,
+                           :address => { :address1 => "123 Test Lane" }
+          json_response['address1'].should eq '123 Test Lane'
+        end
+
+        it "receives the errors object if address is invalid" do
+          api_put :update, :id => @address.id, :order_id => @order.number,
+                           :address => { :address1 => "" }
+
+          json_response['error'].should_not be_nil
+          json_response['errors'].should_not be_nil
+          json_response['errors']['address1'].first.should eq "can't be blank"
+        end
       end
 
-      it "gets an address" do
-        api_get :show, :id => @address.id, :order_id => @order.number
-        json_response['address1'].should eq @address.address1
-      end
+      context "on an address that does not belong to this order" do
+        before do
+          @order.bill_address_id = nil
+          @order.ship_address = nil
+        end
 
-      it "updates an address" do
-        api_put :update, :id => @address.id, :order_id => @order.number,
-                         :address => { :address1 => "123 Test Lane" }
-        json_response['address1'].should eq '123 Test Lane'
-      end
+        it "cannot retreive address information" do
+          api_get :show, :id => @address.id, :order_id => @order.number
+          assert_unauthorized!
+        end
 
-      it "receives the errors object if address is invalid" do
-        api_put :update, :id => @address.id, :order_id => @order.number,
-                         :address => { :address1 => "" }
-
-        json_response['error'].should_not be_nil
-        json_response['errors'].should_not be_nil
-        json_response['errors']['address1'].first.should eq "can't be blank"
+        it "cannot update address information" do
+          api_get :update, :id => @address.id, :order_id => @order.number
+          assert_unauthorized!
+        end
       end
     end
+    
+    context "without order" do
+      context "with their own address" do
+        before do
+          Order.any_instance.stub :user => current_api_user
+        end
 
-    context "on an address that does not belong to this order" do
-      before do
-        @order.bill_address_id = nil
-        @order.ship_address = nil
+        it "gets an address" do
+          api_get :show, :id => @address.id
+          json_response['address1'].should eq @address.address1
+        end
       end
 
-      it "cannot retreive address information" do
-        api_get :show, :id => @address.id, :order_id => @order.number
-        assert_unauthorized!
-      end
-
-      it "cannot update address information" do
-        api_get :update, :id => @address.id, :order_id => @order.number
-        assert_unauthorized!
+      context "on an address that does not belong to this user" do
+        it "cannot update address information" do
+          api_put :update, :id => @address.id, :address => { :address1 => "123 Test Lane" }
+          json_response['address1'].should be_nil
+          assert_unauthorized!
+        end
       end
     end
   end

--- a/core/app/models/spree/ability.rb
+++ b/core/app/models/spree/ability.rb
@@ -47,6 +47,10 @@ module Spree
         can :update, Order do |order, token|
           order.user == user || order.token && token == order.token
         end
+        can [:create, :read], Address
+        can :update, Address do |address|
+          user.bill_address == address || user.ship_address == address
+        end
         can [:index, :read], Product
         can [:index, :read], ProductProperty
         can [:index, :read], Property


### PR DESCRIPTION
Initial commit for Issue #4100. Added back missing routes and resource, where an Order isn't exclusively needed in order to access an Address. Documentation likely needs to be updated and this could use some minor refactoring.
