### PR TITLE
In memory sort of variant.options_text

### DIFF
--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -68,7 +68,9 @@ module Spree
     end
 
     def options_text
-      values = self.option_values.joins(:option_type).order("#{Spree::OptionType.table_name}.position asc")
+      values = self.option_values.sort do |a, b|
+        a.option_type.position <=> b.option_type.position
+      end
 
       values.map! do |ov|
         "#{ov.option_type.presentation}: #{ov.presentation}"

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -250,16 +250,16 @@ describe Spree::Variant do
 
   # Regression test for #2432
   describe 'options_text' do
+    let!(:variant) { create(:variant, option_values: []) }
+
     before do
-      option_type = double("OptionType", :presentation => "Foo")
-      option_values = [double("OptionValue", :option_type => option_type, :presentation => "bar")]
-      variant.stub(:option_values).and_return(option_values)
+      # Order bar than foo
+      variant.option_values << create(:option_value, {name: 'Foo', presentation: 'Foo', option_type: create(:option_type, position: 2, name: 'Foo Type', presentation: 'Foo Type')})
+      variant.option_values << create(:option_value, {name: 'Bar', presentation: 'Bar', option_type: create(:option_type, position: 1, name: 'Bar Type', presentation: 'Bar Type')})
     end
 
-    it "orders options correctly" do
-      variant.option_values.should_receive(:joins).with(:option_type).and_return(scope = double)
-      scope.should_receive(:order).with('spree_option_types.position asc').and_return(variant.option_values)
-      variant.options_text
+    it 'should order by bar than foo' do
+      variant.options_text.should == 'Bar Type: Bar, Foo Type: Foo'
     end
   end
 


### PR DESCRIPTION
Assume that the option_values -> option_types have been eager loaded via joins/includes and simply sort in memory. Removing the explicit query removes N queries for products/show in the api where N = number of variants that belong to the product. This should allow us to fully take advantage of the API optimizations made here:

https://github.com/spree/spree/commit/30597b2aa7a1f47b5e636750baf7c100f0cc42b2

This is probably making things worse if things aren't eager loaded....if this is dicey, I guess I can just class_eval out options_text within our app but I would love to have an optimal API out of the box.
