### PR TITLE
Add ability to approve an order after it has been found to be 'risky'

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/globals/_variables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/globals/_variables.scss
@@ -120,16 +120,27 @@ $color-ste-active-bg:            $color-success !default;
 $color-ste-active-text:          $color-1 !default;
 $color-ste-inactive-bg:          $color-notice !default;
 $color-ste-inactive-text:        $color-1 !default;
+$color-ste-considered_risky-bg:  $color-error !default;
+$color-ste-considered_risky-text:$color-1 !default;
 
 // Available states
-$states:                      completed,                 complete,                 sold,                 pending,                 awaiting_return,                 returned,                 credit_owed,                 paid,                 shipped,                 balance_due,                 backorder,                 checkout,                 cart,                 address,                 delivery,                 payment,                 confirm,                 canceled,                 ready,                 void,                 active,                 inactive  !default;
-$states-bg-colors:            $color-ste-completed-bg,   $color-ste-complete-bg,   $color-ste-sold-bg,   $color-ste-pending-bg,   $color-ste-awaiting_return-bg,   $color-ste-returned-bg,   $color-ste-credit_owed-bg,   $color-ste-paid-bg,   $color-ste-shipped-bg,   $color-ste-balance_due-bg,   $color-ste-backorder-bg,   $color-ste-checkout-bg,   $color-ste-cart-bg,   $color-ste-address-bg,   $color-ste-delivery-bg,   $color-ste-payment-bg,   $color-ste-confirm-bg,   $color-ste-canceled-bg,   $color-ste-ready-bg,   $color-ste-void-bg,   $color-ste-active-bg,   $color-ste-inactive-bg  !default;
-$states-text-colors:          $color-ste-completed-text, $color-ste-complete-text, $color-ste-sold-text, $color-ste-pending-text, $color-ste-awaiting_return-text, $color-ste-returned-text, $color-ste-credit_owed-text, $color-ste-paid-text, $color-ste-shipped-text, $color-ste-balance_due-text, $color-ste-backorder-text, $color-ste-checkout-text, $color-ste-cart-text, $color-ste-address-text, $color-ste-delivery-text, $color-ste-payment-text, $color-ste-confirm-text, $color-ste-canceled-text, $color-ste-ready-text, $color-ste-void-text, $color-ste-active-text, $color-ste-inactive-text !default;
+$states: completed, complete, sold, pending, awaiting_return, returned, credit_owed, paid, shipped, balance_due, backorder, checkout, cart, address,
+delivery, payment, confirm, canceled, ready, void, active, inactive, considered_risky !default;
+
+$states-bg-colors: $color-ste-completed-bg, $color-ste-complete-bg, $color-ste-sold-bg, $color-ste-pending-bg, $color-ste-awaiting_return-bg,
+$color-ste-returned-bg, $color-ste-credit_owed-bg, $color-ste-paid-bg, $color-ste-shipped-bg, $color-ste-balance_due-bg, $color-ste-backorder-bg, 
+$color-ste-checkout-bg, $color-ste-cart-bg, $color-ste-address-bg, $color-ste-delivery-bg, $color-ste-payment-bg, $color-ste-confirm-bg, 
+$color-ste-canceled-bg, $color-ste-ready-bg, $color-ste-void-bg, $color-ste-active-bg, $color-ste-inactive-bg, $color-ste-considered_risky-bg !default;
+
+$states-text-colors: $color-ste-completed-text, $color-ste-complete-text, $color-ste-sold-text, $color-ste-pending-text, $color-ste-awaiting_return-text, 
+$color-ste-returned-text, $color-ste-credit_owed-text, $color-ste-paid-text, $color-ste-shipped-text, $color-ste-balance_due-text, $color-ste-backorder-text, 
+$color-ste-checkout-text, $color-ste-cart-text, $color-ste-address-text, $color-ste-delivery-text, $color-ste-payment-text, $color-ste-confirm-text, 
+$color-ste-canceled-text, $color-ste-ready-text, $color-ste-void-text, $color-ste-active-text, $color-ste-inactive-text, $color-ste-considered_risky-text !default;
 
 // Available actions
-$actions:                        edit,                   clone,                   remove,                   void,                   capture,                   save,                      cancel,                   mail  !default;
-$actions-bg-colors:              $color-action-edit-bg,  $color-action-clone-bg,  $color-action-remove-bg,  $color-action-void-bg,  $color-action-capture-bg,  $color-action-save-bg,     $color-action-cancel-bg,  $color-action-mail-bg  !default;
-$actions-brd-colors:             $color-action-edit-brd, $color-action-clone-brd, $color-action-remove-brd, $color-action-void-brd, $color-action-capture-brd, $color-action-save-brd,    $color-action-cancel-brd, $color-action-mail-brd !default;
+$actions: edit, clone, remove, void, capture, save, cancel, mail !default;
+$actions-bg-colors: $color-action-edit-bg, $color-action-clone-bg, $color-action-remove-bg, $color-action-void-bg, $color-action-capture-bg, $color-action-save-bg, $color-action-cancel-bg, $color-action-mail-bg !default;
+$actions-brd-colors: $color-action-edit-brd, $color-action-clone-brd, $color-action-remove-brd, $color-action-void-brd, $color-action-capture-brd, $color-action-save-brd, $color-action-cancel-brd, $color-action-mail-brd !default;
 
 // Sizes
 //--------------------------------------------------------------

--- a/backend/app/assets/stylesheets/spree/backend/sections/_orders.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_orders.scss
@@ -56,3 +56,9 @@
 [data-hook="adjustments_new_coupon_code"] {
   margin-bottom: 18px;
 }
+
+#risk_analysis legend {
+  background-color: #c00;
+  color: #FFF;
+  font-size: 2em;
+}

--- a/backend/app/assets/stylesheets/spree/backend/shared/_icons.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_icons.scss
@@ -16,6 +16,7 @@
 
 .icon-email:before    { @extend .icon-envelope:before }
 .icon-resume:before   { @extend .icon-refresh:before  }
+.icon-approve:before  { @extend .icon-ok:before       }
 
 .icon-cancel:before,
 .icon-void:before     { @extend .icon-remove:before   }

--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -2,7 +2,7 @@ module Spree
   module Admin
     class OrdersController < Spree::Admin::BaseController
       before_filter :initialize_order_events
-      before_filter :load_order, :only => [:edit, :update, :fire, :resend, :open_adjustments, :close_adjustments]
+      before_filter :load_order, :only => [:edit, :update, :cancel, :resume, :approve, :resend, :open_adjustments, :close_adjustments]
 
       respond_to :html
 
@@ -74,18 +74,21 @@ module Spree
         render :action => :edit
       end
 
-      def fire
-        # TODO - possible security check here but right now any admin can before any transition (and the state machine
-        # itself will make sure transitions are not applied in the wrong state)
-        event = params[:e]
-        if @order.state_events.include?(event.to_sym) && @order.send("#{event}")
-          flash[:success] = Spree.t(:order_updated)
-        else
-          flash[:error] = Spree.t(:cannot_perform_operation)
-        end
-      rescue Spree::Core::GatewayError => ge
-        flash[:error] = "#{ge.message}"
-      ensure
+      def cancel
+        @order.cancel!
+        flash[:success] = Spree.t(:order_canceled)
+        redirect_to :back
+      end
+
+      def resume
+        @order.resume!
+        flash[:success] = Spree.t(:order_resumed)
+        redirect_to :back
+      end
+
+      def approve
+        @order.approved_by(try_spree_current_user)
+        flash[:success] = Spree.t(:order_approved)
         redirect_to :back
       end
 
@@ -120,7 +123,7 @@ module Spree
 
         # Used for extensions which need to provide their own custom event links on the order details view.
         def initialize_order_events
-          @order_events = %w{cancel resume}
+          @order_events = %w{approve cancel resume}
         end
 
         def model_class

--- a/backend/app/helpers/spree/admin/orders_helper.rb
+++ b/backend/app/helpers/spree/admin/orders_helper.rb
@@ -6,7 +6,7 @@ module Spree
         links = []
         @order_events.sort.each do |event|
           if @order.send("can_#{event}?")
-            links << button_link_to(Spree.t(event), fire_admin_order_url(@order, :e => event),
+            links << button_link_to(Spree.t(event), [event, :admin, @order],
                                     :method => :put,
                                     :icon => "icon-#{event}",
                                     :data => { :confirm => Spree.t(:order_sure_want_to, :event => Spree.t(event)) })

--- a/backend/app/views/spree/admin/orders/_form.html.erb
+++ b/backend/app/views/spree/admin/orders/_form.html.erb
@@ -31,10 +31,6 @@
     </fieldset>
   <% end %>
 
-<% if @order.payments.exists? %>
-  <%= render 'spree/admin/orders/risk_analysis', latest_payment: @order.payments.order("created_at DESC").first %>
-<% end %>
-
   <%= javascript_tag do -%>
     var order_number = '<%= @order.number %>';
     var shipments = [];

--- a/backend/app/views/spree/admin/orders/_risk_analysis.html.erb
+++ b/backend/app/views/spree/admin/orders/_risk_analysis.html.erb
@@ -1,4 +1,4 @@
-<fieldset class="no-border-bottom">
+<fieldset class="no-border-bottom" id="risk_analysis">
   <legend><%= "#{Spree.t(:risk_analysis)}: #{Spree.t(:not) unless @order.is_risky?} #{Spree.t(:risky)}" %></legend>
   <table>
     <thead>

--- a/backend/app/views/spree/admin/orders/edit.html.erb
+++ b/backend/app/views/spree/admin/orders/edit.html.erb
@@ -17,6 +17,10 @@
   <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @order } %>
 </div>
 
+<% if @order.payments.exists? && @order.considered_risky? %>
+  <%= render 'spree/admin/orders/risk_analysis', latest_payment: @order.payments.order("created_at DESC").first %>
+<% end %>
+
 <%= render :partial => 'add_product' if can?(:update, @order) %>
 
 <% if @order.line_items.empty? %>

--- a/backend/app/views/spree/admin/shared/_order_summary.html.erb
+++ b/backend/app/views/spree/admin/shared/_order_summary.html.erb
@@ -30,5 +30,12 @@
       <dt data-hook><%= Spree.t(:date_completed) %>:</dt>
       <dd id='date_complete'><%= pretty_time(@order.completed_at) %></dd>
     <% end %>
+
+    <% if @order.approved? %>
+      <dt><%= Spree.t(:approver) %></dt>
+      <dd><%= @order.approver.email %></dd>
+      <dt><%= Spree.t(:approved_at) %></dt>
+      <dd><%= pretty_time(@order.approved_at) %></dd>
+    <% end %>
   </dl>
 </header>

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -71,11 +71,12 @@ Spree::Core::Engine.add_routes do
 
     resources :orders, :except => [:show] do
       member do
-        put :fire
-        get :fire
         post :resend
         get :open_adjustments
         get :close_adjustments
+        put :approve
+        put :cancel
+        put :resume
       end
 
       resource :customer, :controller => "orders/customer_details"

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -28,47 +28,27 @@ describe Spree::Admin::OrdersController do
     let(:order) { mock_model(Spree::Order, :complete? => true, :total => 100, :number => 'R123456789') }
     before { Spree::Order.stub :find_by_number! => order }
 
-    context "#fire" do
-      before(:each) do
-        order.stub :foo => true
+    context "#approve" do
+      it "approves an order" do
+        expect(order).to receive(:approved_by).with(controller.try_spree_current_user)
+        spree_put :approve, id: order.number
+        expect(flash[:success]).to eq Spree.t(:order_approved)
       end
+    end
 
-      it "should receive state_events" do
-        order.should_receive(:state_events).and_return([:foo])
-        spree_put :fire, {:id => "R1234567", :e => "foo"}
+    context "#cancel" do
+      it "cancels an order" do
+        expect(order).to receive(:cancel!)
+        spree_put :cancel, id: order.number
+        expect(flash[:success]).to eq Spree.t(:order_canceled)
       end
+    end
 
-      context 'params[:e] includes in state_events' do
-        before(:each) do
-          order.stub(:state_events).and_return([:foo])
-        end
-
-        it "should fire the requested event on the payment" do
-          order.should_receive(:foo).and_return true
-          spree_put :fire, {:id => "R1234567", :e => "foo"}
-        end
-
-        it "should respond with a flash message if the event cannot be fired" do
-          order.stub :foo => false
-          spree_put :fire, {:id => "R1234567", :e => "foo"}
-          flash[:error].should_not be_nil
-        end
-      end
-
-      context 'params[:e] not includes in state_events' do
-        before(:each) do
-          order.stub(:state_events).and_return([:bar])
-        end
-
-        it "should not fire the requested event on the payment" do
-          order.should_not_receive(:foo)
-          spree_put :fire, {:id => "R1234567", :e => "foo"}
-        end
-
-        it "should respond with a flash message if the event cannot be fired" do
-          spree_put :fire, {:id => "R1234567", :e => "foo"}
-          flash[:error].should_not be_nil
-        end
+    context "#resume" do
+      it "resumes an order" do
+        expect(order).to receive(:resume!)
+        spree_put :resume, id: order.number
+        expect(flash[:success]).to eq Spree.t(:order_resumed)
       end
     end
 

--- a/backend/spec/features/admin/orders/risk_analysis_spec.rb
+++ b/backend/spec/features/admin/orders/risk_analysis_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe 'Order Risk Analysis' do
+  stub_authorization!
+
+  let!(:order) do
+    create(:completed_order_with_pending_payment)
+  end
+
+  def visit_order
+    visit spree.admin_path
+    click_link 'Orders'
+    within_row(1) do
+      click_link order.number
+    end
+  end
+
+  context "the order is considered risky" do
+    
+    before do
+      order.payments.first.update_column(:avs_response, 'X')
+      order.considered_risky!
+      visit_order
+    end
+
+    it "displays 'Risk Analysis' box" do
+      expect(page).to have_content 'Risk Analysis'
+    end
+
+    it "can be approved" do
+      click_button('approve')
+      expect(page).to have_content 'Approver'
+      expect(page).to have_content 'Approved at'
+      expect(page).to have_content 'Status: complete'
+    end
+
+    it "can be canceled and resumed" do
+      click_button('cancel')
+      expect(page).to have_content 'Status: canceled'
+      click_button('resume')
+      expect(page).to have_content 'Status: considered risky'
+    end
+  end
+  
+  context "the order is not considered risky" do
+
+    before do
+      visit_order      
+    end
+
+    it "does not display 'Risk Analysis' box" do
+      expect(page).to_not have_content 'Risk Analysis'
+    end
+
+  end
+
+end

--- a/core/app/models/spree/gateway/bogus.rb
+++ b/core/app/models/spree/gateway/bogus.rb
@@ -26,7 +26,7 @@ module Spree
     def authorize(money, credit_card, options = {})
       profile_id = credit_card.gateway_customer_profile_id
       if VALID_CCS.include? credit_card.number or (profile_id and profile_id.starts_with? 'BGS-')
-        ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, :test => true, :authorization => '12345', :avs_result => { :code => 'A' })
+        ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, :test => true, :authorization => '12345', :avs_result => { :code => 'D' })
       else
         ActiveMerchant::Billing::Response.new(false, 'Bogus Gateway: Forced failure', { :message => 'Bogus Gateway: Forced failure' }, :test => true)
       end
@@ -35,7 +35,7 @@ module Spree
     def purchase(money, credit_card, options = {})
       profile_id = credit_card.gateway_customer_profile_id
       if VALID_CCS.include? credit_card.number  or (profile_id and profile_id.starts_with? 'BGS-')
-        ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, :test => true, :authorization => '12345', :avs_result => { :code => 'A' })
+        ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, :test => true, :authorization => '12345', :avs_result => { :code => 'M' })
       else
         ActiveMerchant::Billing::Response.new(false, 'Bogus Gateway: Forced failure', :message => 'Bogus Gateway: Forced failure', :test => true)
       end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -343,12 +343,7 @@ module Spree
     end
 
     def deliver_order_confirmation_email
-      begin
-        OrderMailer.confirm_email(self.id).deliver
-      rescue Exception => e
-        logger.error("#{e.class.name}: #{e.message}")
-        logger.error(e.backtrace * "\n")
-      end
+      OrderMailer.confirm_email(self.id).deliver
     end
 
     # Helper methods for checkout steps

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -315,8 +315,6 @@ module Spree
     # Finalizes an in progress order after checkout is complete.
     # Called after transition to complete state when payments will have been processed
     def finalize!
-      touch :completed_at
-
       # lock all adjustments (coupon promotions, etc.)
       all_adjustments.update_all state: 'closed'
 
@@ -332,6 +330,16 @@ module Spree
       updater.run_hooks
 
       deliver_order_confirmation_email
+
+      consider_risk
+    end
+
+    def consider_risk
+      if is_risky?
+        self.considered_risky!
+      else
+        touch :completed_at
+      end
     end
 
     def deliver_order_confirmation_email

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -23,9 +23,11 @@ module Spree
     if Spree.user_class
       belongs_to :user, class_name: Spree.user_class.to_s
       belongs_to :created_by, class_name: Spree.user_class.to_s
+      belongs_to :approver, class_name: Spree.user_class.to_s
     else
       belongs_to :user
       belongs_to :created_by
+      belongs_to :approver
     end
 
     belongs_to :bill_address, foreign_key: :bill_address_id, class_name: 'Spree::Address'
@@ -329,13 +331,13 @@ module Spree
       save
       updater.run_hooks
 
-      deliver_order_confirmation_email
+      deliver_order_confirmation_email unless confirmation_delivered?
 
       consider_risk
     end
 
     def consider_risk
-      if is_risky?
+      if is_risky? && !approved?
         self.considered_risky!
       else
         touch :completed_at
@@ -344,6 +346,7 @@ module Spree
 
     def deliver_order_confirmation_email
       OrderMailer.confirm_email(self.id).deliver
+      update_column(:confirmation_delivered, true)
     end
 
     # Helper methods for checkout steps
@@ -356,7 +359,7 @@ module Spree
     end
 
     def pending_payments
-      payments.select(&:checkout?)
+      payments.select { |payment| payment.checkout? || payment.pending? }
     end
 
     # processes any pending payments and must return a boolean as it's
@@ -533,6 +536,20 @@ module Spree
       }.squish!).uniq.count > 0
     end
 
+    def approved_by(user)
+      self.transaction do
+        self.update_columns(
+          approver_id: user.id,
+          approved_at: Time.now,
+        )
+        self.approve!
+      end
+    end
+
+    def approved?
+      !!self.approved_at
+    end
+
     private
 
       def link_by_email
@@ -577,6 +594,7 @@ module Spree
 
       def after_resume
         shipments.each { |shipment| shipment.resume! }
+        consider_risk
       end
 
       def use_billing?
@@ -586,5 +604,6 @@ module Spree
       def set_currency
         self.currency = Spree::Config[:currency] if self[:currency].nil?
       end
+
   end
 end

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -73,6 +73,10 @@ module Spree
                 transition :to => :considered_risky
               end
 
+              event :approve do
+                transition :to => :complete, :from => :considered_risky
+              end
+
               if states[:payment]
                 before_transition :to => :complete do |order|
                   order.process_payments! if order.payment_required?

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -69,6 +69,10 @@ module Spree
                 transition :to => :awaiting_return
               end
 
+              event :considered_risky do
+                transition :to => :considered_risky
+              end
+
               if states[:payment]
                 before_transition :to => :complete do |order|
                   order.process_payments! if order.payment_required?

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -355,6 +355,9 @@ en:
     analytics_desc_list_4: It's completely free!
     analytics_trackers: Analytics Trackers
     and: and
+    approve: approve
+    approver: Approver
+    approved_at: Approved at
     are_you_sure: Are you sure?
     are_you_sure_delete: Are you sure you want to delete this record?
     associated_adjustment_closed: The associated adjustment is closed, and will not be recalculated. Do you want to open it?
@@ -758,6 +761,8 @@ en:
     or_over_price: ! '%{price} or over'
     order: Order
     order_adjustments: Order adjustments
+    order_approved: Order approved
+    order_canceled: Order canceled
     order_details: Order Details
     order_email_resent: Order Email Resent
     order_information: Order Information
@@ -784,11 +789,13 @@ en:
       selected_quantity_not_available: ! 'Selected quantity of %{item} is not available.'
       please_enter_reasonable_quantity: Please enter a reasonable quantity.
     order_processed_successfully: Your order has been processed successfully
+    order_resumed: Order resumed
     order_state:
       address: address
       awaiting_return: awaiting return
       canceled: canceled
       cart: cart
+      considered_risky: considered risky
       complete: complete
       confirm: confirm
       delivery: delivery

--- a/core/db/migrate/20140203161722_add_approver_id_and_approved_at_to_orders.rb
+++ b/core/db/migrate/20140203161722_add_approver_id_and_approved_at_to_orders.rb
@@ -1,0 +1,6 @@
+class AddApproverIdAndApprovedAtToOrders < ActiveRecord::Migration
+  def change
+    add_column :spree_orders, :approver_id, :integer
+    add_column :spree_orders, :approved_at, :datetime
+  end
+end

--- a/core/db/migrate/20140204115338_add_confirmation_delivered_to_spree_orders.rb
+++ b/core/db/migrate/20140204115338_add_confirmation_delivered_to_spree_orders.rb
@@ -1,0 +1,5 @@
+class AddConfirmationDeliveredToSpreeOrders < ActiveRecord::Migration
+  def change
+    add_column :spree_orders, :confirmation_delivered, :boolean, default: false
+  end
+end

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -38,6 +38,12 @@ FactoryGirl.define do
           order.update_column(:completed_at, Time.now)
         end
 
+        factory :completed_order_with_pending_payment do
+          after(:create) do |order|
+            create(:payment, amount: order.total, order: order)
+          end
+        end
+
         factory :order_ready_to_ship do
           payment_state 'paid'
           shipment_state 'ready'

--- a/core/spec/models/spree/order/state_machine_spec.rb
+++ b/core/spec/models/spree/order/state_machine_spec.rb
@@ -184,4 +184,16 @@ describe Spree::Order do
       order.stub :has_available_shipment
     end
   end
+
+  context "considered risky" do
+    before do
+      order.state = 'complete'
+    end
+
+    it "sets the state" do
+      order.considered_risky!
+      expect(order.state).to eq 'considered_risky'
+    end
+  end
+
 end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -252,11 +252,6 @@ describe Spree::Order do
       order.finalize!
     end
 
-    it "should continue even if confirmation email delivery fails" do
-      Spree::OrderMailer.should_receive(:confirm_email).with(order.id).and_raise 'send failed!'
-      order.finalize!
-    end
-
     it "should freeze all adjustments" do
       # Stub this method as it's called due to a callback
       # and it's irrelevant to this test


### PR DESCRIPTION
When an order has been found to be risky, we needed to have it go into an intermediate state, which we have called "considered risky". The order will transition into this state if the `Order#is_risky?` method returns true. This happens after the order is finalized. If the `is_risky?` method returns false, then the order will remain in the complete state.

In this state, we can choose to "Approve" or "Cancel" the order. Approving transitions the order from the "considered risky" to "complete" directly, and also sets some data on the order so that we can know the order has been reviewed by somebody.

We also fixed a bug where duplicate confirmation emails were being sent out, due to the order transitioning back to "complete" once it has been approved. We've added a `confirmation_delivered?` attribute to the Order model which is used to determine if the confirmation email has already been sent out. 

Additionally, we cleaned up the `OrdersController`'s `fire` action into three separate actions which is cleaner and provides a better message when the actions are undertaken for approving, cancelling or resuming an order. We have also moved the risk analysis partial from the bottom of the order edit page to the top, and have only made it display if the order is considered risky AND the order is not approved. The partial is not displayed otherwise.

Francisco Orvalho and Ryan Bigg
