### PR TITLE
Allow stock items to only touch their variant after save if their in_sto...

### DIFF
--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -35,6 +35,7 @@ module Spree
     preference :always_include_confirm_step, :boolean, default: false # Ensures confirmation step is always in checkout_progress bar, but does not force a confirm step if your payment methods do not support it.
     preference :always_put_site_name_in_title, :boolean, default: true
     preference :auto_capture, :boolean, default: false # automatically capture the credit card (as opposed to just authorize and capture later)
+    preference :binary_inventory_cache, :boolean, default: false # only invalidate product cache when a stock item changes whether it is in_stock
     preference :check_for_spree_alerts, :boolean, default: true
     preference :checkout_zone, :string, default: nil # replace with the name of a zone if you would like to limit the countries
     preference :company, :boolean, default: false # Request company field for billing and shipping addr

--- a/core/spec/models/spree/stock_item_spec.rb
+++ b/core/spec/models/spree/stock_item_spec.rb
@@ -149,4 +149,51 @@ describe Spree::StockItem do
       }.to raise_error
     end
   end
+
+  describe "#after_save" do
+    context "binary_inventory_cache is set to false (default)" do
+      context "in_stock? changes" do
+        it "touches its variant" do
+          expect do
+            subject.adjust_count_on_hand(subject.count_on_hand * -1)
+          end.to change { subject.variant.reload.updated_at }
+        end
+      end
+
+      context "in_stock? does not change" do
+        it "touches its variant" do
+          expect do
+            subject.adjust_count_on_hand((subject.count_on_hand * -1) + 1)
+          end.to change { subject.variant.reload.updated_at }
+        end
+      end
+    end
+
+    context "binary_inventory_cache is set to true" do
+      before { Spree::Config.binary_inventory_cache = true }
+      context "in_stock? changes" do
+        it "touches its variant" do
+          expect do
+            subject.adjust_count_on_hand(subject.count_on_hand * -1)
+          end.to change { subject.variant.reload.updated_at }
+        end
+      end
+
+      context "in_stock? does not change" do
+        it "does not touch its variant" do
+          expect do
+            subject.adjust_count_on_hand((subject.count_on_hand * -1) + 1)
+          end.not_to change { subject.variant.reload.updated_at }
+        end
+      end
+    end
+  end
+
+  describe "#after_touch" do
+    it "touches its variant" do
+      expect do
+        subject.touch
+      end.to change { subject.variant.updated_at }
+    end
+  end
 end


### PR DESCRIPTION
...ck state changes

Currently when a stock item changes its count on hand (e.g. an order is placed), it touches the related variant, which touches its related product (thus invalidating product cache). For users that do not show inventory counts on their product page, this code enables the ability to keep product page cache warm until a stock item changes its in_stock state, rather than on every purchase of that stock item.
