### PR TITLE
Display 'Capture events' table in the Payment show page

### DIFF
--- a/backend/app/views/spree/admin/payments/_capture_events.html.erb
+++ b/backend/app/views/spree/admin/payments/_capture_events.html.erb
@@ -1,0 +1,19 @@
+<% if @payment.capture_events.exists? %>
+  <h3><%= Spree.t(:capture_events) %></h3>
+  <table class="index" id="capture_events">
+    <thead>
+      <tr data-hook="payments_header">
+        <th><%= "#{Spree.t('date')}/#{Spree.t('time')}" %></th>
+        <th><%= Spree.t(:amount) %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @payment.capture_events.each do |capture_event| %>
+        <tr id="<%= dom_id(capture_event) %>" data-hook="capture_events_row" class="<%= cycle('odd', 'even')%>">
+          <td><%= pretty_time(capture_event.created_at) %></td>
+          <td><%= capture_event.display_amount %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/backend/app/views/spree/admin/payments/show.html.erb
+++ b/backend/app/views/spree/admin/payments/show.html.erb
@@ -21,3 +21,5 @@
 <div data-hook="amount" class="align-center">
   <h5><%= label_tag nil, Spree.t(:amount) %>: <span class="green"><%= @payment.display_amount.to_html %></span> </h5>
 </div>
+
+<%= render 'spree/admin/payments/capture_events' %>

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -53,6 +53,19 @@ describe 'Payments' do
       end
     end
 
+    it 'should list all captures for a payment' do
+      capture_amount = order.outstanding_balance/2 * 100
+      payment.capture!(capture_amount)
+
+      visit spree.admin_order_payment_path(order, payment)
+      expect(page).to have_content 'Capture events'
+      # within '#capture_events' do
+        within_row(1) do
+          expect(page).to have_content(capture_amount / 100)
+        end
+      # end
+    end
+
     it 'should be able to list and create payment methods for an order', js: true do
       find('#payment_status').text.should == 'PENDING'
       within_row(1) do

--- a/core/app/models/spree/payment_capture_event.rb
+++ b/core/app/models/spree/payment_capture_event.rb
@@ -1,5 +1,9 @@
 module Spree
   class PaymentCaptureEvent < ActiveRecord::Base
     belongs_to :payment, class_name: 'Spree::Payment'
+
+    def display_amount
+      Spree::Money.new(amount, { currency: payment.currency })
+    end
   end
 end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -403,6 +403,7 @@ en:
     cannot_perform_operation: Cannot perform requested operation
     cannot_set_shipping_method_without_address: Cannot set shipping method until customer details are provided.
     capture: Capture
+    capture_events: Capture events
     card_code: Card Code
     card_number: Card Number
     card_type: Brand


### PR DESCRIPTION
The payment show pages should be able to display all the capture events for that payment. For that purpose we created a new partial that displays a table for all of the payments' capture events. The table will not be displayed if there are no captures for that specific payment.

The payment capture events are represented by the model `Spree::PaymentCaptureEvent`. In order to display a properly formatted amount for the event captures, we added the method `#display_amount` (using `Spree::Money`) to that model.

Francisco Orvalho and Ryan Bigg
