### PR TITLE
Make auto_capture? a per payment method configuration

### DIFF
--- a/backend/app/views/spree/admin/payment_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/_form.html.erb
@@ -23,6 +23,10 @@
         <%= label_tag nil, Spree.t(:display) %>
         <%= select(:payment_method, :display_on, Spree::PaymentMethod::DISPLAY.collect { |display| [Spree.t(display), display == :both ? nil : display.to_s] }, {}, {:class => 'select2 fullwidth'}) %>
       </div>
+      <div data-hook="auto_capture" class="field">
+        <%= label_tag nil, Spree.t(:auto_capture) %>
+        <%= select(:payment_method, :auto_capture, [["#{Spree.t(:use_app_default)} (#{Spree::Config[:auto_capture]})", ''], [Spree.t(:say_yes), true], [Spree.t(:say_no), false]], {}, {:class => 'select2 fullwidth'}) %>
+      </div>
       <div data-hook="active" class="field">
         <%= label_tag nil, Spree.t(:active) %>
         <ul>

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -54,7 +54,7 @@ module Spree
     end
 
     def auto_capture?
-      Spree::Config[:auto_capture]
+      self.auto_capture.nil? ? Spree::Config[:auto_capture] : self.auto_capture
     end
 
     def supports?(source)

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -359,6 +359,7 @@ en:
     are_you_sure_delete: Are you sure you want to delete this record?
     associated_adjustment_closed: The associated adjustment is closed, and will not be recalculated. Do you want to open it?
     authorization_failure: Authorization Failure
+    auto_capture: Auto Capture
     available_on: Available On
     avs_response: AVS Response
     back: Back
@@ -1108,6 +1109,7 @@ en:
     update: Update
     updating: Updating
     usage_limit: Usage Limit
+    use_app_default: Use App Default
     use_billing_address: Use Billing Address
     use_new_cc: Use a new card
     use_s3: Use Amazon S3 For Images

--- a/core/db/migrate/20140204192230_add_auto_capture_to_payment_methods.rb
+++ b/core/db/migrate/20140204192230_add_auto_capture_to_payment_methods.rb
@@ -1,0 +1,5 @@
+class AddAutoCaptureToPaymentMethods < ActiveRecord::Migration
+  def change
+    add_column :spree_payment_methods, :auto_capture, :boolean
+  end
+end

--- a/core/spec/models/spree/payment_method_spec.rb
+++ b/core/spec/models/spree/payment_method_spec.rb
@@ -34,4 +34,62 @@ describe Spree::PaymentMethod do
     end
   end
 
+  describe '#auto_capture?' do
+    class TestGateway < Spree::Gateway
+      def provider_class
+        Provider
+      end
+    end
+
+    let(:gateway) { TestGateway.new }
+
+    subject { gateway.auto_capture? }
+
+    context 'when auto_capture is nil' do
+      before(:each) do
+        Spree::Config.should_receive('[]').with(:auto_capture).and_return(auto_capture)
+      end
+
+      context 'and when Spree::Config[:auto_capture] is false' do
+        let(:auto_capture) { false }
+
+        it 'should be false' do
+          gateway.auto_capture.should be_nil
+          subject.should be_false
+        end
+      end
+
+      context 'and when Spree::Config[:auto_capture] is true' do
+        let(:auto_capture) { true }
+
+        it 'should be true' do
+          gateway.auto_capture.should be_nil
+          subject.should be_true
+        end
+      end
+    end
+
+    context 'when auto_capture is not nil' do
+      before(:each) do
+        gateway.auto_capture = auto_capture
+      end
+
+      context 'and is true' do
+        let(:auto_capture) { true }
+
+        it 'should be true' do
+          subject.should be_true
+        end
+      end
+
+      context 'and is false' do
+        let(:auto_capture) { false }
+
+        it 'should be true' do
+          subject.should be_false
+        end
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Allows of payment methods to have auto_capture on/off per gateway. Right now, it is a global config Spree::Config[:auto_capture] that can be set in Spree. To make it per-payment method, the recommended approach is to provide an auto_capture? method on the object you want to change.

http://guides.spreecommerce.com/developer/payments.html

This change will make it less of a developer change and more of an Admin change. When set to nil, the payment method will continue to respect the global config. But if it is set to true/false, then auto_capture will be per payment method.
