### PR TITLE
Fixes #4304 - RABL cache collision for variants

### DIFF
--- a/api/app/views/spree/api/variants/show.v1.rabl
+++ b/api/app/views/spree/api/variants/show.v1.rabl
@@ -1,4 +1,4 @@
 object @variant
-cache @variant
+cache ['show', root_object]
 extends "spree/api/variants/variant_full"
 child(:images => :images) { extends "spree/api/images/show" }

--- a/api/app/views/spree/api/variants/variant_full.v1.rabl
+++ b/api/app/views/spree/api/variants/variant_full.v1.rabl
@@ -1,5 +1,5 @@
 object @variant
-cache @variant
+cache ['variant_full', root_object]
 extends "spree/api/variants/variant"
 
 child(:images => :images) do

--- a/api/lib/spree/api/testing_support/caching.rb
+++ b/api/lib/spree/api/testing_support/caching.rb
@@ -1,0 +1,10 @@
+RSpec.configure do |config|
+  config.before(:each, :caching => true) do 
+    ActionController::Base.perform_caching = true
+  end
+  
+  config.after(:each, :caching => true) do
+    ActionController::Base.perform_caching = false
+    Rails.cache.clear
+  end
+end

--- a/api/spec/requests/rabl_cache_spec.rb
+++ b/api/spec/requests/rabl_cache_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe "Rabl Cache", :caching => true do
+  let!(:user)  { create(:admin_user) }
+
+  before do
+    create(:variant) 
+    user.generate_spree_api_key!
+    Spree::Product.count.should == 1
+  end
+  
+  it "doesn't create a cache key collision for models with different rabl templates" do
+    get "/api/variants", :token => user.spree_api_key
+    response.status.should == 200
+
+    # Make sure we get a non master variant
+    variant_a = JSON.parse(response.body)['variants'].last
+    variant_a['is_master'].should be_false
+    variant_a['stock_items'].should_not be_nil
+
+    get "/api/products/#{Spree::Product.first.id}", :token => user.spree_api_key
+    response.status.should == 200
+    variant_b = JSON.parse(response.body)['variants'].last
+    variant_b['is_master'].should be_false
+
+    variant_a['id'].should == variant_b['id']
+    variant_b['stock_items'].should be_nil
+  end
+end

--- a/api/spec/spec_helper.rb
+++ b/api/spec/spec_helper.rb
@@ -32,6 +32,7 @@ Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each {|f| require f}
 require 'spree/testing_support/factories'
 require 'spree/testing_support/preferences'
 
+require 'spree/api/testing_support/caching'
 require 'spree/api/testing_support/helpers'
 require 'spree/api/testing_support/setup'
 


### PR DESCRIPTION
This uses the template path to ensure unique cache keys and guarantees no collisions. Could have also used a string, this is a more generic solution.
