### PR TITLE
Defaulting variant weight to 0 at the schema level

### DIFF
--- a/core/db/migrate/20140205181631_default_variant_weight_to_zero.rb
+++ b/core/db/migrate/20140205181631_default_variant_weight_to_zero.rb
@@ -1,0 +1,11 @@
+class DefaultVariantWeightToZero < ActiveRecord::Migration
+  def up
+    Spree::Variant.unscoped.where(weight: nil).update_all("weight = 0.0")
+
+    change_column :spree_variants, :weight, :decimal, precision: 8, scale: 2, default: 0.0
+  end
+
+  def down
+    change_column :spree_variants, :weight, :decimal, precision: 8, scale: 2
+  end
+end


### PR DESCRIPTION
Fixes #4300
