### PR TITLE
Add dependent destroy to category mapping table

### DIFF
--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -6,7 +6,7 @@ module Spree
     default_scope -> { where(deleted_at: nil) }
 
     has_many :shipments
-    has_many :shipping_method_categories
+    has_many :shipping_method_categories, :dependent => :destroy
     has_many :shipping_categories, through: :shipping_method_categories
     has_many :shipping_rates, inverse_of: :shipping_method
 


### PR DESCRIPTION
Should clear the mapping table if a method is destroyed.
