### PR TITLE
Refactor Spree::Api::ApiHelpers.required_fields_for

### DIFF
--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -40,7 +40,7 @@ module Spree
         # Permalinks presence is validated, but are really automatically generated
         # Therefore we shouldn't tell API clients that they MUST send one through
         # Do not require slugs, either
-        required_fields - ['permalink', 'slug']
+        required_fields - ['slug']
       end
 
       @@product_attributes = [

--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -40,7 +40,7 @@ module Spree
         # Permalinks presence is validated, but are really automatically generated
         # Therefore we shouldn't tell API clients that they MUST send one through
         # Do not require slugs, either
-        required_fields - ['permalink', 'slugs']
+        required_fields - ['permalink', 'slug']
       end
 
       @@product_attributes = [

--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -34,15 +34,13 @@ module Spree
       mattr_reader *ATTRIBUTES
 
       def required_fields_for(model)
-        required_fields = model._validators.select do |field, validations|
-          validations.any? { |v| v.is_a?(ActiveModel::Validations::PresenceValidator) }
-        end.map(&:first) # get fields that are invalid
+        required_fields = model.validators.select do |validation|
+          validation.is_a?(ActiveModel::Validations::PresenceValidator)
+        end.map(&:attributes).map(&:first).map(&:to_s) # get fields that are invalid
         # Permalinks presence is validated, but are really automatically generated
         # Therefore we shouldn't tell API clients that they MUST send one through
-        required_fields.map!(&:to_s).delete("permalink")
         # Do not require slugs, either
-        required_fields.delete("slug")
-        required_fields
+        required_fields - ['permalink', 'slugs']
       end
 
       @@product_attributes = [


### PR DESCRIPTION
On line 36 the method is currently using '_validators'
which is a private method, so I refactored it to use
the public method 'validators' and pulled the attribute
from there.

I also simplified the deletion of two attributes into
a single line.  I was also thinking of using symbols
instead of strings but I wasn't sure if this would
break functionality somewhere else although tests
were green.
