### PR TITLE
Update payment state not only when order is completed

### DIFF
--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -16,15 +16,15 @@ module Spree
     # associations try to save and then in turn try to call +update!+ again.)
     def update
       update_totals
+      update_payment_state
 
       if order.completed?
-        update_payment_state
 
         # give each of the shipments a chance to update themselves
         shipments.each { |shipment| shipment.update!(order) }
         update_shipment_state
       end
-      
+
       update_adjustments
       # update totals a second time in case updated adjustments have an effect on the total
       update_totals


### PR DESCRIPTION
Sometime between version 1.3 and 2.1, the order_updater model was changed such that the payment_status field was no longer updated automatically on any order change, but instead only after the order had been completed.

I can't say why this change was made, but it breaks the correct behavior for those stores (like mine) which separate the order submission from the capture step.  In particular, when the order is entered, we manually capture the order after a review period.  Since we accept a lot of international orders, this cuts down on credit card fraud and chargebacks, as well as incorrect order details (we sell complicated products which people sometimes configure incorrectly).

When you separate the capture step from order submission, the order gets entered into the store but not as a completed order.  Since the updater does not update the payment_state in this case, the payment_state is nil and shows up as blank in the order admin interface.  Since that field is a link which takes you to the capture interface, the effect of this issue is to make it more difficult to get to the order capture step in the admin interface.

My pull request simply moves the update_payment_state back outside the order completion conditional, as it was prior to 2.1 (or 2.0, wherever the change was made).  I have not run the test suite to verify that it does not break any other specs.
