### PR TITLE
rename per_item to flat_percent_item_total

### DIFF
--- a/core/db/migrate/20140210195232_rename_per_item_to_flat_percent_item_total.rb
+++ b/core/db/migrate/20140210195232_rename_per_item_to_flat_percent_item_total.rb
@@ -1,0 +1,9 @@
+class RenamePerItemToFlatPercentItemTotal < ActiveRecord::Migration
+  def change
+	Spree::Calculator.where("type='Spree::Calculator::PerItem'").update_all("type='Spree::Calculator::FlatPercentItemTotal'")
+	Spree::Preference.where("`key` like 'spree/calculator/per_item/%'").each do |p|
+		p.key = p.key.gsub(/per_item/, 'flat_percent_item_total')
+		p.save!
+	end
+  end
+end

--- a/core/db/migrate/20140210195232_rename_per_item_to_flat_percent_item_total.rb
+++ b/core/db/migrate/20140210195232_rename_per_item_to_flat_percent_item_total.rb
@@ -5,5 +5,10 @@ class RenamePerItemToFlatPercentItemTotal < ActiveRecord::Migration
 		p.key = p.key.gsub(/per_item/, 'flat_percent_item_total')
 		p.save!
 	end
+	Spree::Calculator.where("type='Spree::Calculator::FreeShipping'").each do |c|
+		pa = Spree::Promotion::Actions::CreateAdjustment.where(:promotion_id => c.calculable_id).first
+		pa.type = "Spree::Promotion::Actions::FreeShipping"
+		pa.save!
+	end	
   end
 end


### PR DESCRIPTION
rename per_item to flat_percent_item_total since Spree::Calculator::PerItem has been removed.
