### PR TITLE
Returns should go to correct stock location

### DIFF
--- a/api/spec/controllers/spree/api/return_authorizations_controller_spec.rb
+++ b/api/spec/controllers/spree/api/return_authorizations_controller_spec.rb
@@ -118,7 +118,7 @@ module Spree
       end
 
       it "can mark a return authorization as received on the order with an inventory unit" do
-        FactoryGirl.create(:new_return_authorization, :order => order)
+        FactoryGirl.create(:new_return_authorization, :order => order, :stock_location_id => order.shipments.first.stock_location.id)
         return_authorization = order.return_authorizations.first
         return_authorization.state.should == "authorized"
 

--- a/backend/spec/features/admin/orders/return_authorizations_spec.rb
+++ b/backend/spec/features/admin/orders/return_authorizations_spec.rb
@@ -9,7 +9,8 @@ describe "return authorizations" do
     create(:return_authorization,
             :order => order,
             :state => 'authorized',
-            :inventory_units => order.shipments.first.inventory_units)
+            :inventory_units => order.shipments.first.inventory_units,
+            :stock_location_id => order.shipments.first.stock_location_id)
   end
 
   # Regression test for #1107

--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -83,7 +83,8 @@ module Spree
       def process_return
         inventory_units.each do |iu|
           iu.return!
-          Spree::StockMovement.create!(stock_item_id: iu.find_stock_item.id, quantity: 1)
+          stock_item = Spree::StockItem.where(variant_id: iu.variant.id, stock_location_id: stock_location_id).first
+          Spree::StockMovement.create!(stock_item_id: stock_item.id, quantity: 1)
         end
 
         credit = Adjustment.new(amount: compute_amount, label: Spree.t(:rma_credit))

--- a/core/spec/models/spree/return_authorization_spec.rb
+++ b/core/spec/models/spree/return_authorization_spec.rb
@@ -86,30 +86,59 @@ describe Spree::ReturnAuthorization do
   context "receive!" do
     let(:inventory_unit) { order.shipments.first.inventory_units.first }
 
-    before  do
-      return_authorization.stub(:inventory_units => [inventory_unit], :amount => -20)
-      Spree::Adjustment.stub(:create)
-      order.stub(:update!)
+    context "to the initial stock location" do
+      before do
+        return_authorization.stub(:inventory_units => [inventory_unit], :amount => -20)
+        return_authorization.stub(:stock_location_id => inventory_unit.shipment.stock_location.id)
+        Spree::Adjustment.stub(:create)
+        order.stub(:update!)
+      end
+
+      it "should mark all inventory units are returned" do
+        inventory_unit.should_receive(:return!)
+        return_authorization.receive!
+      end
+
+      it "should add credit for specified amount" do
+        return_authorization.amount = 20
+        mock_adjustment = double
+        mock_adjustment.should_receive(:source=).with(return_authorization)
+        mock_adjustment.should_receive(:adjustable=).with(order)
+        mock_adjustment.should_receive(:save)
+        Spree::Adjustment.should_receive(:new).with(:amount => -20, :label => Spree.t(:rma_credit)).and_return(mock_adjustment)
+        return_authorization.receive!
+      end
+
+      it "should update order state" do
+        order.should_receive :update!
+        return_authorization.receive!
+      end
+
+      it "should update the stock item counts in the stock location" do
+        count_on_hand = inventory_unit.find_stock_item.count_on_hand
+        return_authorization.receive!
+        inventory_unit.find_stock_item.count_on_hand.should == count_on_hand + 1
+      end
     end
 
-    it "should mark all inventory units are returned" do
-      inventory_unit.should_receive(:return!)
-      return_authorization.receive!
-    end
+    context "to a different stock location" do
+      let(:new_stock_location) { FactoryGirl.create(:stock_location, :name => "other") }
+      before do
+        return_authorization.stub(:stock_location_id => new_stock_location.id)
+        return_authorization.stub(:inventory_units => [inventory_unit], :amount => -20)
+      end
 
-    it "should add credit for specified amount" do
-      return_authorization.amount = 20
-      mock_adjustment = double
-      mock_adjustment.should_receive(:source=).with(return_authorization)
-      mock_adjustment.should_receive(:adjustable=).with(order)
-      mock_adjustment.should_receive(:save)
-      Spree::Adjustment.should_receive(:new).with(:amount => -20, :label => Spree.t(:rma_credit)).and_return(mock_adjustment)
-      return_authorization.receive!
-    end
+      it "should update the stock item counts in new stock location" do
+        count_on_hand = Spree::StockItem.where(variant_id: inventory_unit.variant_id, stock_location_id: new_stock_location.id).first.count_on_hand
+        return_authorization.receive!
+        Spree::StockItem.where(variant_id: inventory_unit.variant_id, stock_location_id: new_stock_location.id).first.count_on_hand.should == count_on_hand + 1
+      end
 
-    it "should update order state" do
-      order.should_receive :update!
-      return_authorization.receive!
+      it "should not update the stock item counts in the original stock location" do
+        count_on_hand = inventory_unit.find_stock_item.count_on_hand
+        return_authorization.receive!
+        inventory_unit.find_stock_item.count_on_hand.should == count_on_hand
+      end
     end
   end
 


### PR DESCRIPTION
This PR fixes a bug in how returns are re-stocked. When a return is received, the inventory is always returned to the StockLocation used when creating the original order (this can be seen in line 86 of core/app/models/spree/return_authorization.rb). This overrides the ability to return the inventory to a stock location defined by the admin.

_Contents of this PR:_
- Implements tests in core/spec/models/spree/return_authorization_spec.rb that expose this bug  
- Refactors other ReturnAuthorization tests to consider ReturnAuthorization#stock_location_id  
- Implements the fix by selecting creating stock movements based on the admin selected stock location

_The Bug's Repro Steps_  
- Make sure you have a demo store with multiple stock locations (let’s call them LocationA and LocationB)  
- Create and order and ship it from items in LocationA  
- Observe the quantities of items in each stock location  
- Create a return authorization and set LocationB as the place that the item should be returned  
- Receive the return  

_Expected Results_  
- Quantities are increased at LocationB

_Actual Results_  
- Quantities as increased in LocationA
