### PR TITLE
Call ensure_updated_shipments on line items destroy

### DIFF
--- a/api/app/controllers/spree/api/line_items_controller.rb
+++ b/api/app/controllers/spree/api/line_items_controller.rb
@@ -28,6 +28,7 @@ module Spree
         @line_item = order.line_items.find(params[:id])
         variant = Spree::Variant.find(@line_item.variant_id)
         @order.contents.remove(variant, @line_item.quantity)
+        @order.ensure_updated_shipments
         respond_with(@line_item, status: 204)
       end
 

--- a/api/spec/controllers/spree/api/line_items_controller_spec.rb
+++ b/api/spec/controllers/spree/api/line_items_controller_spec.rb
@@ -96,6 +96,12 @@ module Spree
           api_put :update, :id => line_item.id, :line_item => { :quantity => 1000 }
           expect(order.reload.shipments).to be_empty
         end
+
+        it "clear out shipments on delete" do
+          expect(order.reload.shipments).not_to be_empty
+          api_delete :destroy, :id => line_item.id
+          expect(order.reload.shipments).to be_empty
+        end
       end
     end
 


### PR DESCRIPTION
I think we also need to call ensure_updated_shipments when a line item is destroyed.
