### PR TITLE
Correctly apply relevant tax rates

### DIFF
--- a/backend/app/controllers/spree/admin/shipping_methods_controller.rb
+++ b/backend/app/controllers/spree/admin/shipping_methods_controller.rb
@@ -38,6 +38,7 @@ module Spree
 
       def load_data
         @available_zones = Zone.order(:name)
+        @tax_categories = Spree::TaxCategory.order(:name)
         @calculators = ShippingMethod.calculators.sort_by(&:name)
       end
     end

--- a/backend/app/views/spree/admin/shipping_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/_form.html.erb
@@ -37,7 +37,7 @@
 <div class="alpha six columns">
   <div data-hook="admin_shipping_method_form_availability_fields" class="alpha six columns">
     <fieldset class="categories no-border-bottom">
-      <legend align="center"><%= Spree.t(:categories) %></legend>
+      <legend align="center"><%= Spree.t(:shipping_categories) %></legend>
           <%= f.field_container :categories do %>
         <% Spree::ShippingCategory.all.each do |category| %>
           <%= label_tag do %>
@@ -69,5 +69,17 @@
 
 <div data-hook="admin_shipping_method_form_calculator_fields" class="omega six columns">
   <%= render :partial => 'spree/admin/shared/calculator_fields', :locals => { :f => f } %>
+</div>
+
+<div class="alpha six columns">
+  <div class="alpha six columns">
+    <fieldset class="tax_categories no-border-bottom">
+      <legend align="center"><%= Spree.t(:tax_category) %></legend>
+        <%= f.field_container :categories do %>
+          <%= f.select :tax_category_id, @tax_categories.map { |tc| [tc.name, tc.id] }, {}, :class => "select2 fullwidth" %>
+          <%= error_message_on :shipping_method, :tax_category_id %>
+        <% end %>
+    </fieldset>
+  </div>
 </div>
 

--- a/core/app/models/spree/calculator/default_tax.rb
+++ b/core/app/models/spree/calculator/default_tax.rb
@@ -23,17 +23,17 @@ module Spree
       end
     end
 
-    def compute_shipment(shipment)
-      round_to_two_places(shipment.discounted_cost * rate.amount)
-    end
-
-    def compute_line_item(line_item)
+    # When it comes to computing shipments or line items: same same.
+    def compute_shipment_or_line_item(item)
       if rate.included_in_price
-        deduced_total_by_rate(line_item, rate)
+        deduced_total_by_rate(item.pre_tax_amount, rate)
       else
-        round_to_two_places(line_item.discounted_amount * rate.amount)
+        round_to_two_places(item.discounted_amount * rate.amount)
       end
     end
+
+    alias_method :compute_shipment, :compute_shipment_or_line_item
+    alias_method :compute_line_item, :compute_shipment_or_line_item
 
     private
 
@@ -45,8 +45,8 @@ module Spree
       BigDecimal.new(amount.to_s).round(2, BigDecimal::ROUND_HALF_UP)
     end
 
-    def deduced_total_by_rate(item, rate)
-      round_to_two_places(item.pre_tax_amount * rate.amount)
+    def deduced_total_by_rate(pre_tax_amount, rate)
+      round_to_two_places(pre_tax_amount * rate.amount)
     end
 
   end

--- a/core/app/models/spree/calculator/default_tax.rb
+++ b/core/app/models/spree/calculator/default_tax.rb
@@ -35,6 +35,16 @@ module Spree
     alias_method :compute_shipment, :compute_shipment_or_line_item
     alias_method :compute_line_item, :compute_shipment_or_line_item
 
+    def compute_shipping_rate(shipping_rate)
+      if rate.included_in_price
+        pre_tax_amount = shipping_rate.cost / (1 + rate.amount)
+        deduced_total_by_rate(pre_tax_amount, rate)
+      else
+        with_tax_amount = shipping_rate.cost * rate.amount
+        round_to_two_places(with_tax_amount)
+      end
+    end
+
     private
 
     def rate

--- a/core/app/models/spree/calculator/default_tax.rb
+++ b/core/app/models/spree/calculator/default_tax.rb
@@ -28,14 +28,10 @@ module Spree
     end
 
     def compute_line_item(line_item)
-      if line_item.tax_category == rate.tax_category
-        if rate.included_in_price
-          deduced_total_by_rate(line_item, rate)
-        else
-          round_to_two_places(line_item.discounted_amount * rate.amount)
-        end
+      if rate.included_in_price
+        deduced_total_by_rate(line_item, rate)
       else
-        0
+        round_to_two_places(line_item.discounted_amount * rate.amount)
       end
     end
 
@@ -49,13 +45,8 @@ module Spree
       BigDecimal.new(amount.to_s).round(2, BigDecimal::ROUND_HALF_UP)
     end
 
-    def deduced_total_by_rate(line_item, rate)
-      combined_taxes = 0
-      line_item.product.tax_category.tax_rates.each do |tax|
-        combined_taxes += tax.amount
-      end
-      price_without_taxes = line_item.discounted_amount / (1 + combined_taxes)
-      round_to_two_places(price_without_taxes * rate.amount)
+    def deduced_total_by_rate(item, rate)
+      round_to_two_places(item.pre_tax_amount * rate.amount)
     end
 
   end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -286,7 +286,7 @@ module Spree
     # include taxes then price adjustments are created instead.
     def create_tax_charge!
       Spree::TaxRate.adjust(self, line_items)
-      Spree::TaxRate.adjust(self, shipments)
+      Spree::TaxRate.adjust(self, shipments) if shipments.any?
     end
 
     def outstanding_balance

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -111,6 +111,10 @@ module Spree
       self.save!
     end
 
+    def tax_category
+      selected_shipping_rate.try(:tax_category)
+    end
+
     def refresh_rates
       return shipping_rates if shipped?
       return [] unless can_get_rates?

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -112,7 +112,7 @@ module Spree
     end
 
     def tax_category
-      selected_shipping_rate.try(:tax_category)
+      selected_shipping_rate.try(:tax_rate).try(:tax_category)
     end
 
     def refresh_rates

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -150,6 +150,7 @@ module Spree
     def discounted_cost
       cost + promo_total
     end
+    alias discounted_amount discounted_cost
 
     # Only one of either included_tax_total or additional_tax_total is set
     # This method returns the total of the two. Saves having to check if 

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -15,6 +15,8 @@ module Spree
                                     :class_name => 'Spree::Zone',
                                     :foreign_key => 'shipping_method_id'
 
+    belongs_to :tax_category, :class_name => 'Spree::TaxCategory'
+
     validates :name, presence: true
 
     validate :at_least_one_shipping_category
@@ -38,6 +40,10 @@ module Spree
     # Some shipping methods are only meant to be set via backend
     def frontend?
       self.display_on != "back_end"
+    end
+
+    def tax_category
+      Spree::TaxCategory.unscoped { super }
     end
 
     private

--- a/core/app/models/spree/shipping_rate.rb
+++ b/core/app/models/spree/shipping_rate.rb
@@ -12,8 +12,18 @@ module Spree
     delegate :order, :currency, to: :shipment
     delegate :name, to: :shipping_method
 
+    def display_base_price
+      Spree::Money.new(cost, currency: currency)
+    end
+
+    def display_tax_amount
+      Spree::Money.new(cost * tax_rate.amount, currency: currency)
+    end
+
     def display_price
-      
+      price = display_base_price.to_s
+      price += " (+ #{display_tax_amount} tax)" if tax_rate
+      price
     end
     alias_method :display_cost, :display_price
 

--- a/core/app/models/spree/shipping_rate.rb
+++ b/core/app/models/spree/shipping_rate.rb
@@ -17,7 +17,7 @@ module Spree
     end
 
     def display_tax_amount
-      Spree::Money.new(cost * tax_rate.amount, currency: currency)
+      Spree::Money.new(tax_rate.calculator.compute_shipping_rate(self), currency: currency)
     end
 
     def display_price

--- a/core/app/models/spree/shipping_rate.rb
+++ b/core/app/models/spree/shipping_rate.rb
@@ -22,7 +22,14 @@ module Spree
 
     def display_price
       price = display_base_price.to_s
-      price += " (+ #{display_tax_amount} tax)" if tax_rate
+      if tax_rate
+        amount = "#{display_tax_amount} #{tax_rate.name}"
+        if tax_rate.included_in_price?
+          price += " (incl. #{amount})"
+        else
+          price += " (+ #{amount})"
+        end
+      end
       price
     end
     alias_method :display_cost, :display_price

--- a/core/app/models/spree/shipping_rate.rb
+++ b/core/app/models/spree/shipping_rate.rb
@@ -2,6 +2,7 @@ module Spree
   class ShippingRate < ActiveRecord::Base
     belongs_to :shipment, class_name: 'Spree::Shipment'
     belongs_to :shipping_method, class_name: 'Spree::ShippingMethod', inverse_of: :shipping_rates
+    belongs_to :tax_rate, class_name: 'Spree::TaxRate'
 
     scope :with_shipping_method,
       -> { includes(:shipping_method).
@@ -12,20 +13,16 @@ module Spree
     delegate :name, to: :shipping_method
 
     def display_price
-      if Spree::Config[:shipment_inc_vat]
-        price = (1 + Spree::TaxRate.default) * cost
-      else
-        price = cost
-      end
-
-      Spree::Money.new(price, { currency: currency })
+      
     end
-
     alias_method :display_cost, :display_price
 
     def shipping_method
       Spree::ShippingMethod.unscoped { super }
     end
 
+    def tax_rate
+      Spree::TaxRate.unscoped { super }
+    end
   end
 end

--- a/core/app/models/spree/stock/estimator.rb
+++ b/core/app/models/spree/stock/estimator.rb
@@ -29,7 +29,19 @@ module Spree
       def calculate_shipping_rates(package)
         shipping_methods(package).map do |shipping_method|
           cost = shipping_method.calculator.compute(package)
-          shipping_method.shipping_rates.new(cost: cost) if cost
+          tax_category = shipping_method.tax_category
+          if tax_category
+            tax_rate = tax_category.tax_rates.detect do |rate|
+              rate.zone == package.order.tax_zone
+            end
+          end
+
+          if cost
+            rate = shipping_method.shipping_rates.new(cost: cost)
+            rate.tax_rate = tax_rate if tax_rate
+          end
+
+          rate
         end.compact
       end
 

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -34,7 +34,11 @@ module Spree
 
     def self.adjust(order, items)
       self.match(order).each do |rate|
-        items.each { |item| rate.adjust(order, item) }
+        items.each do |item|
+          if item.tax_category == rate.tax_category
+            rate.adjust(order, item)
+          end
+        end
       end
     end
 

--- a/core/db/migrate/20140207085910_add_tax_category_id_to_shipping_methods.rb
+++ b/core/db/migrate/20140207085910_add_tax_category_id_to_shipping_methods.rb
@@ -1,0 +1,5 @@
+class AddTaxCategoryIdToShippingMethods < ActiveRecord::Migration
+  def change
+    add_column :spree_shipping_methods, :tax_category_id, :integer
+  end
+end

--- a/core/db/migrate/20140207093021_add_tax_rate_id_to_shipping_rates.rb
+++ b/core/db/migrate/20140207093021_add_tax_rate_id_to_shipping_rates.rb
@@ -1,0 +1,5 @@
+class AddTaxRateIdToShippingRates < ActiveRecord::Migration
+  def change
+    add_column :spree_shipping_rates, :tax_rate_id, :integer
+  end
+end

--- a/core/db/migrate/20140211040159_add_pre_tax_amount_to_line_items_and_shipments.rb
+++ b/core/db/migrate/20140211040159_add_pre_tax_amount_to_line_items_and_shipments.rb
@@ -1,0 +1,6 @@
+class AddPreTaxAmountToLineItemsAndShipments < ActiveRecord::Migration
+  def change
+    add_column :spree_line_items, :pre_tax_amount, :decimal, precision: 8, scale: 2
+    add_column :spree_shipments, :pre_tax_amount, :decimal, precision: 8, scale: 2
+  end
+end

--- a/core/spec/models/spree/calculator/default_tax_spec.rb
+++ b/core/spec/models/spree/calculator/default_tax_spec.rb
@@ -108,18 +108,6 @@ describe Spree::Calculator::DefaultTax do
       end
     end
 
-    context "when given a line item" do
-      context "when the variant does not match the tax category" do
-        before do
-          line_item.stub :tax_category => nil
-        end
-
-        it "should be 0" do
-          calculator.compute(line_item).should == 0
-        end
-      end
-    end
-
     context "when given a shipment" do
       it "should be 5% of 15" do
         calculator.compute(shipment).should == 0.75

--- a/core/spec/models/spree/calculator/default_tax_spec.rb
+++ b/core/spec/models/spree/calculator/default_tax_spec.rb
@@ -4,8 +4,8 @@ describe Spree::Calculator::DefaultTax do
   let!(:country) { create(:country) }
   let!(:zone) { create(:zone, :name => "Country Zone", :default_tax => true, :zone_members => []) }
   let!(:tax_category) { create(:tax_category, :tax_rates => []) }
-  let!(:rate) { create(:tax_rate, :tax_category => tax_category, :amount => 0.05, :included_in_price => vat) }
-  let(:vat) { false }
+  let!(:rate) { create(:tax_rate, :tax_category => tax_category, :amount => 0.05, :included_in_price => included_in_price) }
+  let(:included_in_price) { false }
   let!(:calculator) { Spree::Calculator::DefaultTax.new(:calculable => rate ) }
   let!(:order) { create(:order) }
   let!(:line_item) { create(:line_item, :price => 10, :quantity => 3, :tax_category => tax_category) }
@@ -62,7 +62,7 @@ describe Spree::Calculator::DefaultTax do
       end
 
       context "when tax is included in price" do
-        let(:vat) { true }
+        let(:included_in_price) { true }
 
         it "will return the deducted amount from the totals" do
           # total price including 5% tax = 57.14
@@ -74,7 +74,7 @@ describe Spree::Calculator::DefaultTax do
     end
 
     context "when tax is included in price" do
-      let(:vat) { true }
+      let(:included_in_price) { true }
       context "when the variant matches the tax category" do
 
         context "when line item is discounted" do

--- a/core/spec/models/spree/calculator/default_tax_spec.rb
+++ b/core/spec/models/spree/calculator/default_tax_spec.rb
@@ -78,31 +78,33 @@ describe Spree::Calculator::DefaultTax do
       context "when the variant matches the tax category" do
 
         context "when line item is discounted" do
-          before { line_item.promo_total = -1 }
+          before do
+            line_item.promo_total = -1
+            Spree::TaxRate.store_pre_tax_amount(line_item, [rate])
+          end
 
           it "should be equal to the item's discounted total * rate" do
             calculator.compute(line_item).should == 1.38
           end
         end
 
-        it "should be equal to the item total * rate" do
+        it "should be equal to the item's discounted * rate" do
           calculator.compute(line_item).should == 1.43
         end
       end
     end
 
     context "when tax is not included in price" do
-
       context "when the line item is discounted" do
         before { line_item.promo_total = -1 }
 
-        it "should be equal to the item's discounted total * rate" do
+        it "should be equal to the item's pre-tax total * rate" do
           calculator.compute(line_item).should == 1.45
         end
       end
 
       context "when the variant matches the tax category" do
-        it "should be equal to the item total * rate" do
+        it "should be equal to the item pre-tax total * rate" do
           calculator.compute(line_item).should == 1.50
         end
       end

--- a/core/spec/models/spree/order/state_machine_spec.rb
+++ b/core/spec/models/spree/order/state_machine_spec.rb
@@ -56,7 +56,15 @@ describe Spree::Order do
       end
 
       it "adjusts tax rates when transitioning to delivery" do
+        # Once for the line items
+        Spree::TaxRate.should_receive(:adjust).once
+        order.should_receive(:set_shipments_cost)
+        order.next!
+      end
+
+      it "adjusts tax rates twice if there are any shipments" do
         # Once for the line items, once for the shipments
+        order.shipments.build
         Spree::TaxRate.should_receive(:adjust).twice
         order.should_receive(:set_shipments_cost)
         order.next!

--- a/core/spec/models/spree/shipping_rate_spec.rb
+++ b/core/spec/models/spree/shipping_rate_spec.rb
@@ -8,7 +8,6 @@ describe Spree::ShippingRate do
   let(:shipping_rate) { Spree::ShippingRate.new(:shipment => shipment,
                                                 :shipping_method => shipping_method,
                                                 :cost => 10.55) }
-  before { Spree::TaxRate.stub(:default => 0.05) }
 
   context "#display_price" do
     context "when shipment includes VAT" do
@@ -47,6 +46,25 @@ describe Spree::ShippingRate do
       shipping_rate.save
       shipping_rate.reload
       expect(shipping_rate.shipping_method).to eq(shipping_method)
+    end
+  end
+
+  context "#tax_rate" do
+    let!(:tax_rate) { create(:tax_rate) }
+
+    before do
+      shipping_rate.tax_rate = tax_rate
+    end
+
+    it "can be retrieved" do
+      expect(shipping_rate.tax_rate.reload).to eq(tax_rate)
+    end
+
+    it "can be retrieved even when deleted" do
+      tax_rate.update_column(:deleted_at, Time.now)
+      shipping_rate.save
+      shipping_rate.reload
+      expect(shipping_rate.tax_rate).to eq(tax_rate)
     end
   end
 end

--- a/core/spec/models/spree/shipping_rate_spec.rb
+++ b/core/spec/models/spree/shipping_rate_spec.rb
@@ -7,20 +7,24 @@ describe Spree::ShippingRate do
   let(:shipping_method) { create(:shipping_method) }
   let(:shipping_rate) { Spree::ShippingRate.new(:shipment => shipment,
                                                 :shipping_method => shipping_method,
-                                                :cost => 10.55) }
+                                                :cost => 10) }
 
   context "#display_price" do
-    context "when shipment includes VAT" do
-      before { Spree::Config[:shipment_inc_vat] = true }
-      it "displays the correct price" do
-        shipping_rate.display_price.to_s.should == "$11.08" # $10.55 * 1.05 == $11.08
+    context "when tax included in price" do
+      let(:tax_rate) { create(:tax_rate, :amount => 0.1, :included_in_price => true) }
+      before { shipping_rate.tax_rate = tax_rate }
+
+      it "shows correct tax amount" do
+        expect(shipping_rate.display_price.to_s).to eq("omg")
       end
     end
 
-    context "when shipment does not include VAT" do
-      before { Spree::Config[:shipment_inc_vat] = false }
-      it "displays the correct price" do
-        shipping_rate.display_price.to_s.should == "$10.55"
+    context "when tax is additional to price" do
+      let(:tax_rate) { create(:tax_rate, :amount => 0.1) }
+      before { shipping_rate.tax_rate = tax_rate }
+
+      it "shows correct tax amount" do
+        expect(shipping_rate.display_price.to_s).to eq("$10.00 (+ $1.00 tax)")
       end
     end
 

--- a/core/spec/models/spree/shipping_rate_spec.rb
+++ b/core/spec/models/spree/shipping_rate_spec.rb
@@ -17,7 +17,7 @@ describe Spree::ShippingRate do
       before { shipping_rate.tax_rate = tax_rate }
 
       it "shows correct tax amount" do
-        expect(shipping_rate.display_price.to_s).to eq("$10.00 (incl. $1.00 #{tax_rate.name})")
+        expect(shipping_rate.display_price.to_s).to eq("$10.00 (incl. $0.91 #{tax_rate.name})")
       end
     end
 

--- a/core/spec/models/spree/shipping_rate_spec.rb
+++ b/core/spec/models/spree/shipping_rate_spec.rb
@@ -11,11 +11,13 @@ describe Spree::ShippingRate do
 
   context "#display_price" do
     context "when tax included in price" do
+      # This zone needs to exist so the inclusive tax test works
+      let!(:zone) { create(:zone, :default_tax => true) }
       let(:tax_rate) { create(:tax_rate, :amount => 0.1, :included_in_price => true) }
       before { shipping_rate.tax_rate = tax_rate }
 
       it "shows correct tax amount" do
-        expect(shipping_rate.display_price.to_s).to eq("omg")
+        expect(shipping_rate.display_price.to_s).to eq("$10.00 (incl. $1.00 #{tax_rate.name})")
       end
     end
 
@@ -24,7 +26,7 @@ describe Spree::ShippingRate do
       before { shipping_rate.tax_rate = tax_rate }
 
       it "shows correct tax amount" do
-        expect(shipping_rate.display_price.to_s).to eq("$10.00 (+ $1.00 tax)")
+        expect(shipping_rate.display_price.to_s).to eq("$10.00 (+ $1.00 #{tax_rate.name})")
       end
     end
 

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -106,6 +106,24 @@ module Spree
             expect(subject.shipping_rates(package).map(&:selected)).to eq [true]
           end
         end
+
+        context "includes tax adjustments if applicable" do
+          let!(:tax_rate) { create(:tax_rate, zone: order.tax_zone) }
+
+          before do
+            Spree::ShippingMethod.all.each do |sm|
+              sm.tax_category_id = tax_rate.tax_category_id
+              sm.save
+            end
+            package.shipping_methods.map(&:reload)
+          end
+
+
+          it "links the shipping rate and the tax rate" do
+            shipping_rates = subject.shipping_rates(package)
+            expect(shipping_rates.first.tax_rate).to eq(tax_rate)
+          end
+        end
       end
     end
   end

--- a/core/spec/models/spree/tax_rate_spec.rb
+++ b/core/spec/models/spree/tax_rate_spec.rb
@@ -153,18 +153,37 @@ describe Spree::TaxRate do
 
   context "adjust" do
     let(:order) { stub_model(Spree::Order) }
-    let(:rate_1) { stub_model(Spree::TaxRate) }
-    let(:rate_2) { stub_model(Spree::TaxRate) }
-    let(:line_items) { [stub_model(Spree::LineItem)] }
+    let(:tax_category_1) { stub_model(Spree::TaxCategory) }
+    let(:tax_category_2) { stub_model(Spree::TaxCategory) }
+    let(:rate_1) { stub_model(Spree::TaxRate, :tax_category => tax_category_1) }
+    let(:rate_2) { stub_model(Spree::TaxRate, :tax_category => tax_category_2) }
 
-    before do
-      Spree::TaxRate.stub :match => [rate_1, rate_2]
+    context "with line items" do
+      let(:line_items) { [stub_model(Spree::LineItem, :tax_category => tax_category_1)] }
+
+      before do
+        Spree::TaxRate.stub :match => [rate_1, rate_2]
+      end
+
+      it "should apply adjustments for two tax rates to the order" do
+        rate_1.should_receive(:adjust)
+        rate_2.should_not_receive(:adjust)
+        Spree::TaxRate.adjust(order, line_items)
+      end
     end
 
-    it "should apply adjustments for two tax rates to the order" do
-      rate_1.should_receive(:adjust)
-      rate_2.should_receive(:adjust)
-      Spree::TaxRate.adjust(order, line_items)
+    context "with shipments" do
+      let(:shipments) { [stub_model(Spree::Shipment, :tax_category => tax_category_1)] }
+
+      before do
+        Spree::TaxRate.stub :match => [rate_1, rate_2]
+      end
+
+      it "should apply adjustments for two tax rates to the order" do
+        rate_1.should_receive(:adjust)
+        rate_2.should_not_receive(:adjust)
+        Spree::TaxRate.adjust(order, shipments)
+      end
     end
   end
 

--- a/core/spec/models/spree/tax_rate_spec.rb
+++ b/core/spec/models/spree/tax_rate_spec.rb
@@ -259,12 +259,12 @@ describe Spree::TaxRate do
       let!(:line_item) { @order.contents.add(@nontaxable.master, 1) }
 
       it "should not create a tax adjustment" do
-        @rate1.adjust(@order, line_item)
+        Spree::TaxRate.adjust(@order, @order.line_items)
         line_item.adjustments.tax.charge.count.should == 0
       end
 
       it "should not create a refund" do
-        @rate1.adjust(@order, line_item)
+        Spree::TaxRate.adjust(@order, @order.line_items)
         line_item.adjustments.credit.count.should == 0
       end
     end
@@ -273,21 +273,22 @@ describe Spree::TaxRate do
       let!(:line_item) { @order.contents.add(@taxable.master, 1) }
 
       context "when price includes tax" do
-        before {
+        before do
           @rate1.update_column(:included_in_price, true)
           @rate2.update_column(:included_in_price, true)
-        }
+          Spree::TaxRate.store_pre_tax_amount(line_item, [@rate1, @rate2])
+        end
 
         context "when zone is contained by default tax zone" do
           before { Spree::Zone.stub_chain :default_tax, :contains? => true }
 
-          it "should create one adjustment" do
-            @rate1.adjust(@order, line_item)
-            line_item.adjustments.count.should == 1
+          it "should create two adjustments, one for each tax rate" do
+            Spree::TaxRate.adjust(@order, @order.line_items)
+            line_item.adjustments.count.should == 2
           end
 
           it "should not create a tax refund" do
-            @rate1.adjust(@order, line_item)
+            Spree::TaxRate.adjust(@order, @order.line_items)
             line_item.adjustments.credit.count.should == 0
           end
         end
@@ -295,13 +296,36 @@ describe Spree::TaxRate do
         context "when zone is not contained by default tax zone" do
           before { Spree::Zone.stub_chain :default_tax, :contains? => false }
           it "should not create an adjustment" do
-            @rate1.adjust(@order, line_item)
+            Spree::TaxRate.adjust(@order, @order.line_items)
             line_item.adjustments.charge.count.should == 0
           end
 
-          it "should create a tax refund" do
-            @rate1.adjust(@order, line_item)
-            line_item.adjustments.credit.count.should == 1
+          it "should create a tax refund for each tax rate" do
+            Spree::TaxRate.adjust(@order, @order.line_items)
+            line_item.adjustments.credit.count.should == 2
+          end
+        end
+
+        context "when price does not include tax" do
+          before do             
+            @zone = create(:zone, :name => "Country Zone", :default_tax => false, :zone_members => [])
+            @order.stub :tax_zone => @zone
+
+            [@rate1, @rate2].each do |rate|
+              rate.included_in_price = false
+              rate.zone = @zone
+              rate.save
+            end
+          end
+
+          it "should create an adjustment" do
+            Spree::TaxRate.adjust(@order, @order.line_items)
+            line_item.adjustments.count.should == 2
+          end
+
+          it "should not create a tax refund" do
+            Spree::TaxRate.adjust(@order, @order.line_items)
+            line_item.adjustments.credit.count.should == 0
           end
         end
 
@@ -325,20 +349,6 @@ describe Spree::TaxRate do
             included_tax = @order.line_item_adjustments.sum(:amount)
             expect(@price_before_taxes + included_tax).to eq(line_item.price)
           end
-        end
-      end
-
-      context "when price does not include tax" do
-        before { @rate.update_column(:included_in_price, false) }
-
-        it "should create an adjustment" do
-          @rate.adjust(@order, line_item)
-          line_item.adjustments.count.should == 1
-        end
-
-        it "should not create a tax refund" do
-          @rate.adjust(@order, line_item)
-          line_item.adjustments.credit.count.should == 0
         end
       end
     end

--- a/frontend/app/views/spree/checkout/_summary.html.erb
+++ b/frontend/app/views/spree/checkout/_summary.html.erb
@@ -18,16 +18,14 @@
       </tbody>
     <% end %>
 
-    <% order.all_adjustments.tax.eligible.group_by(&:label).each do |label, adjustments| %>
-      <tbody data-hook="order_details_tax_adjustments">
-        <% order.all_adjustments.tax.eligible.group_by(&:label).each do |label, adjustments| %>
-          <tr class="total">
-            <td><%= label %></td>
-            <td><%= Spree::Money.new(adjustments.sum(&:amount)).to_html %></td>
-          </tr>
-        <% end %>
-      </tbody>
-    <% end %>
+    <tbody data-hook="order_details_tax_adjustments">
+      <% order.all_adjustments.tax.eligible.group_by(&:label).each do |label, adjustments| %>
+        <tr class="total">
+          <td><%= label %></td>
+          <td><%= Spree::Money.new(adjustments.sum(&:amount)).to_html %></td>
+        </tr>
+      <% end %>
+    </tbody>
 
     <% if order.checkout_steps.include?("delivery") %>
       <tr data-hook="shipping_total">


### PR DESCRIPTION
This is a medium size PR which addresses a couple of things:
### 1. Shipments were not being taxed correctly if the rate was an inclusive tax.

This is now fixed by shipping methods linking to tax categories, and then when shipping rates are generated the relevant tax rate (if any) is linked to the shipment. As a "side-effect" of this, shipping rates are able to display the amount of tax they will incur. 
### 2. Fixes #4318

I've personally witnessed a case where tax rates from the same tax category were being applied to an item in the order. See my example in #4318. There is now a fix for this within this PR. 
### 3. Altered the Spree::TaxRate specs to call class-level adjust, not instance-level

This means that the fix for point number 2 here is tested. A small difference, but an important one.
### 4. Pre-tax amounts are now being stored

Previously, if you wanted to gain access to the pre-tax amount for an item you would need to re-calculate that based off the tax for that item. Now it's stored and you don't need to do the calculation. This amount is then used to calculate the amount of tax that should be applied to an item. For instance, a $10 item with 10% inclusive tax should have a tax amount of $0.91, not $1.00. Sales tax of 10% would cause the tax rate to be an additional one of 10%, which _would_ be $1.00 and NOT $0.91.

(Have I mentioned how much fun tax is yet?)
### 5. Fixed some silly double looping in checkout's sidebar

It was seriously dumb and I think it was my fault. It was causing tax rates to appear not once but twice. Fix was simple.

Build is green on CI.

/cc @cduv @jdurand
