### PR TITLE
Fixes incorrect order.item_total when line items have multiple currencie...

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -22,6 +22,7 @@ module Spree
     validates :price, numericality: true
     validates_with Stock::AvailabilityValidator
 
+    validate :ensure_proper_currency
     before_destroy :update_inventory
 
     after_save :update_inventory
@@ -117,6 +118,12 @@ module Spree
 
       def create_tax_charge
         Spree::TaxRate.adjust(order, [self])
+      end
+
+      def ensure_proper_currency
+        unless currency == order.currency
+          errors.add(:currency, t(:must_match_order_currency))
+        end
       end
   end
 end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -68,6 +68,7 @@ module Spree
     attr_accessor :use_billing
 
     before_create :link_by_email
+    before_update :homogenize_line_item_currencies, if: :currency_changed?
 
     validates :email, presence: true, if: :require_email
     validates :email, email: true, if: :require_email, allow_blank: true
@@ -600,6 +601,37 @@ module Spree
       def set_currency
         self.currency = Spree::Config[:currency] if self[:currency].nil?
       end
+  
+      # Updates the order's prices and all line items prices
+      def homogenize_line_item_currencies
+        begin
+          update! if update_line_item_currencies!
+        rescue
+          return false # flunk the validation
+        end
+      end
+                                                    
+      # Updates prices of order's line items
+      def update_line_item_currencies!
+        line_items.where('currency != ?', currency).each do |line_item|
+          update_line_item_price!(line_item)
+        end
+      end
+  
+      # Returns the price object from given item
+      def price_from_line_item(line_item)
+        line_item.variant.prices.where(currency: currency).first
+      end
+  
+      # Updates price from given line item
+      def update_line_item_price!(line_item)
+        price = price_from_line_item(line_item)
 
+        if price
+          line_item.update_attributes!(currency: price.currency, price: price.amount)
+        else
+          raise 'no price found for line item'
+        end
+      end
   end
 end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -223,6 +223,10 @@ en:
           attributes:
             base:
               card_expired: "Card has expired"
+        spree/line_item:
+          attributes:
+            currency:
+              must_match_order_currency: "Must match order currency"
   devise:
     confirmations:
       confirmed: Your account was successfully confirmed. You are now signed in.

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -190,4 +190,17 @@ describe Spree::LineItem do
       end
     end
   end
+
+  context "saving with currency the same as order.currency" do
+    it "saves the line_item" do
+      expect { order.line_items.first.update_attributes!(currency: 'USD') }.to_not raise_error
+    end
+  end
+
+  context "saving with currency different than order.currency" do
+    it "doesn't save the line_item" do
+      expect { order.line_items.first.update_attributes!(currency: 'AUD') }.to raise_error
+    end
+  end
+
 end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -872,4 +872,31 @@ describe Spree::Order do
       order.apply_free_shipping_promotions
     end
   end
+
+  context "#multi currency" do
+    let!(:line_item) { create(:line_item) }
+    let!(:euro_price) { create(:price, variant: line_item.variant, amount: 8, currency: 'EUR') }
+
+    context "#changing order currency" do
+      it "succeeds without error" do
+        expect { line_item.order.update_attributes!(currency: 'EUR') }.to_not raise_error
+      end      
+
+      it "changes the line_item currencies" do
+        expect { line_item.order.update_attributes!(currency: 'EUR') }.to change{ line_item.reload.currency }.from('USD').to('EUR')
+      end
+
+      it "changes the line_item amounts" do
+        expect { line_item.order.update_attributes!(currency: 'EUR') }.to change{ line_item.reload.amount }.to(8)
+      end
+
+      it "fails to change the order currency when no prices are available in that currency" do
+        expect { line_item.order.update_attributes!(currency: 'GBP') }.to raise_error
+      end
+
+      it "calculates the item total in the order.currency" do
+        expect { line_item.order.update_attributes!(currency: 'EUR') }.to change{ line_item.order.item_total }.to(8)
+      end
+    end
+  end
 end


### PR DESCRIPTION
...s

Given an order having line items in multiple currencies, order.total will simply add the line item prices and claim the total is in USD, even if a line item price is in another currency.

Undoubtedly, this PR will spark some discussion regarding the right way to handle this.  I have proposed one solution: force every line item to have the current order currency.

I'm not happy about where I put this code.  I wanted to do it in a before_validation hook on 'order', but the order_updater bypasses all validations.

So I have provided a test that illustrates the issue and I'd love to have some discussion on the proper way to handle the scenario.  

thanks to @jdutil for some input.
