### PR TITLE
Variant api updates

### DIFF
--- a/api/app/views/spree/api/images/show.v1.rabl
+++ b/api/app/views/spree/api/images/show.v1.rabl
@@ -2,6 +2,6 @@ object @image
 attributes *image_attributes
 attributes :viewable_type, :viewable_id
 node(:attachment_url) { |i| i.attachment.to_s }
-code(:urls) do |v|
-  v.attachment.styles.keys.inject({}) { |urls, style| urls[style] = v.attachment.url(style); urls  }
+Spree::Image.attachment_definitions[:attachment][:styles].each do |k,v|
+  node("#{k}_url") { |i| i.attachment.url(k) }
 end

--- a/api/app/views/spree/api/images/show.v1.rabl
+++ b/api/app/views/spree/api/images/show.v1.rabl
@@ -2,3 +2,6 @@ object @image
 attributes *image_attributes
 attributes :viewable_type, :viewable_id
 node(:attachment_url) { |i| i.attachment.to_s }
+code(:urls) do |v|
+  v.attachment.styles.keys.inject({}) { |urls, style| urls[style] = v.attachment.url(style); urls  }
+end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -22,7 +22,7 @@ Spree::Core::Engine.routes.draw do
       end
     end
 
-    resources :variants, :only => [:index]
+    resources :variants, :only => [:index, :show]
 
     resources :option_types do
       resources :option_values

--- a/api/spec/controllers/spree/api/variants_controller_spec.rb
+++ b/api/spec/controllers/spree/api/variants_controller_spec.rb
@@ -120,8 +120,7 @@ module Spree
         images = json_response["images"]
         image = images.first
 
-        expect(image).to have_attributes [:urls]
-        expect(image['urls']).to have_attributes [:mini, :small, :product, :large]
+        expect(image).to have_attributes [:mini_url, :small_url, :product_url, :large_url]
       end
 
     end

--- a/api/spec/controllers/spree/api/variants_controller_spec.rb
+++ b/api/spec/controllers/spree/api/variants_controller_spec.rb
@@ -87,27 +87,43 @@ module Spree
       end
     end
 
-    it "can see a single variant" do
-      api_get :show, :id => variant.to_param
-      json_response.should have_attributes(attributes)
-      option_values = json_response["option_values"]
-      option_values.first.should have_attributes([:name,
-                                                 :presentation,
-                                                 :option_type_name,
-                                                 :option_type_id])
-    end
+    context "single variant" do
 
-    it "can see a single variant with images" do
-      variant.images.create!(:attachment => image("thinking-cat.jpg"))
+      it "can see a single variant" do
+        api_get :show, :id => variant.to_param
+        json_response.should have_attributes(attributes)
+        option_values = json_response["option_values"]
+        option_values.first.should have_attributes([:name,
+                                                    :presentation,
+                                                    :option_type_name,
+                                                    :option_type_id])
+      end
 
-      api_get :show, :id => variant.to_param
+      it "can see a single variant with images" do
+        variant.images.create!(:attachment => image("thinking-cat.jpg"))
 
-      json_response.should have_attributes(attributes + [:images])
-      option_values = json_response["option_values"]
-      option_values.first.should have_attributes([:name,
-                                                 :presentation,
-                                                 :option_type_name,
-                                                 :option_type_id])
+        api_get :show, :id => variant.to_param
+
+        json_response.should have_attributes(attributes + [:images])
+        option_values = json_response["option_values"]
+        option_values.first.should have_attributes([:name,
+                                                    :presentation,
+                                                    :option_type_name,
+                                                    :option_type_id])
+      end
+
+      it 'shows variant image urls' do
+        variant.images.create!(:attachment => image("thinking-cat.jpg"))
+
+        api_get :show, :id => variant.to_param
+
+        images = json_response["images"]
+        image = images.first
+
+        expect(image).to have_attributes [:urls]
+        expect(image['urls']).to have_attributes [:mini, :small, :product, :large]
+      end
+
     end
 
     it "can learn how to create a new variant" do


### PR DESCRIPTION
Add ability to view individual variant through API (currently, only index list exposed) and add image variation urls to image details
