### PR TITLE
Favoring Spree::Base for models instead of changing ActiveRecord::Base

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Address < ActiveRecord::Base
+  class Address < Spree::Base
     belongs_to :country, class_name: "Spree::Country"
     belongs_to :state, class_name: "Spree::State"
 

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -21,7 +21,7 @@
 # total. This allows an adjustment to be preserved if it becomes ineligible so
 # it might be reinstated.
 module Spree
-  class Adjustment < ActiveRecord::Base
+  class Adjustment < Spree::Base
     belongs_to :adjustable, polymorphic: true
     belongs_to :source, polymorphic: true
     belongs_to :order, :class_name => "Spree::Order"

--- a/core/app/models/spree/asset.rb
+++ b/core/app/models/spree/asset.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Asset < ActiveRecord::Base
+  class Asset < Spree::Base
     belongs_to :viewable, polymorphic: true, touch: true
     acts_as_list scope: :viewable
   end

--- a/core/app/models/spree/base.rb
+++ b/core/app/models/spree/base.rb
@@ -1,0 +1,4 @@
+class Spree::Base < ActiveRecord::Base
+  include Spree::Preferences::Preferable
+  self.abstract_class = true
+end

--- a/core/app/models/spree/calculator.rb
+++ b/core/app/models/spree/calculator.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Calculator < ActiveRecord::Base
+  class Calculator < Spree::Base
     belongs_to :calculable, polymorphic: true
 
     # This method calls a compute_<computable> method. must be overriden in concrete calculator.

--- a/core/app/models/spree/classification.rb
+++ b/core/app/models/spree/classification.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Classification < ActiveRecord::Base
+  class Classification < Spree::Base
     self.table_name = 'spree_products_taxons'
     acts_as_list
     belongs_to :product, class_name: "Spree::Product", inverse_of: :classifications

--- a/core/app/models/spree/configuration.rb
+++ b/core/app/models/spree/configuration.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Configuration < ActiveRecord::Base
+  class Configuration < Spree::Base
 
   end
 end

--- a/core/app/models/spree/country.rb
+++ b/core/app/models/spree/country.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Country < ActiveRecord::Base
+  class Country < Spree::Base
     has_many :states, -> { order('name ASC') }, dependent: :destroy
     has_many :addresses, dependent: :nullify
 

--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -1,5 +1,5 @@
 module Spree
-  class CreditCard < ActiveRecord::Base
+  class CreditCard < Spree::Base
     has_many :payments, as: :source
 
     before_save :set_last_digits

--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -1,5 +1,5 @@
 module Spree
-  class InventoryUnit < ActiveRecord::Base
+  class InventoryUnit < Spree::Base
     belongs_to :variant, class_name: "Spree::Variant", inverse_of: :inventory_units
     belongs_to :order, class_name: "Spree::Order", inverse_of: :inventory_units
     belongs_to :shipment, class_name: "Spree::Shipment", touch: true, inverse_of: :inventory_units

--- a/core/app/models/spree/legacy_user.rb
+++ b/core/app/models/spree/legacy_user.rb
@@ -1,6 +1,6 @@
 # Default implementation of User.  This class is intended to be modified by extensions (ex. spree_auth_devise)
 module Spree
-  class LegacyUser < ActiveRecord::Base
+  class LegacyUser < Spree::Base
     include Core::UserAddress
 
     self.table_name = 'spree_users'

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -1,5 +1,5 @@
 module Spree
-  class LineItem < ActiveRecord::Base
+  class LineItem < Spree::Base
     before_validation :adjust_quantity
     belongs_to :order, class_name: "Spree::Order", inverse_of: :line_items
     belongs_to :variant, class_name: "Spree::Variant", inverse_of: :line_items

--- a/core/app/models/spree/log_entry.rb
+++ b/core/app/models/spree/log_entry.rb
@@ -1,5 +1,5 @@
 module Spree
-  class LogEntry < ActiveRecord::Base
+  class LogEntry < Spree::Base
     belongs_to :source, polymorphic: true
 
     # Fix for #1767

--- a/core/app/models/spree/option_type.rb
+++ b/core/app/models/spree/option_type.rb
@@ -1,5 +1,5 @@
 module Spree
-  class OptionType < ActiveRecord::Base
+  class OptionType < Spree::Base
     has_many :option_values, -> { order(:position) }, dependent: :destroy, inverse_of: :option_type
     has_many :product_option_types, dependent: :destroy, inverse_of: :option_type
     has_many :products, through: :product_option_types

--- a/core/app/models/spree/option_value.rb
+++ b/core/app/models/spree/option_value.rb
@@ -1,5 +1,5 @@
 module Spree
-  class OptionValue < ActiveRecord::Base
+  class OptionValue < Spree::Base
     belongs_to :option_type, class_name: 'Spree::OptionType', touch: true, inverse_of: :option_values
     acts_as_list scope: :option_type
     has_and_belongs_to_many :variants, join_table: 'spree_option_values_variants', class_name: "Spree::Variant"

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -2,7 +2,7 @@ require 'spree/core/validators/email'
 require 'spree/order/checkout'
 
 module Spree
-  class Order < ActiveRecord::Base
+  class Order < Spree::Base
     include Checkout
 
     checkout_flow do

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Order < ActiveRecord::Base
+  class Order < Spree::Base
     module Checkout
       def self.included(klass)
         klass.class_eval do

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Payment < ActiveRecord::Base
+  class Payment < Spree::Base
     include Spree::Payment::Processing
 
     IDENTIFIER_CHARS = (('A'..'Z').to_a + ('0'..'9').to_a - %w(0 1 I O)).freeze

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Payment < ActiveRecord::Base
+  class Payment < Spree::Base
     module Processing
       def process!
         if payment_method && payment_method.source_required?

--- a/core/app/models/spree/payment_capture_event.rb
+++ b/core/app/models/spree/payment_capture_event.rb
@@ -1,5 +1,5 @@
 module Spree
-  class PaymentCaptureEvent < ActiveRecord::Base
+  class PaymentCaptureEvent < Spree::Base
     belongs_to :payment, class_name: 'Spree::Payment'
 
     def display_amount

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -1,5 +1,5 @@
 module Spree
-  class PaymentMethod < ActiveRecord::Base
+  class PaymentMethod < Spree::Base
     acts_as_paranoid
     DISPLAY = [:both, :front_end, :back_end]
     default_scope -> { where(deleted_at: nil) }

--- a/core/app/models/spree/preference.rb
+++ b/core/app/models/spree/preference.rb
@@ -1,4 +1,4 @@
-class Spree::Preference < ActiveRecord::Base
+class Spree::Preference < Spree::Base
   serialize :value
 
   validates :key, presence: true

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Price < ActiveRecord::Base
+  class Price < Spree::Base
     acts_as_paranoid
     belongs_to :variant, class_name: 'Spree::Variant', inverse_of: :prices
 

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -19,7 +19,7 @@
 #
 
 module Spree
-  class Product < ActiveRecord::Base
+  class Product < Spree::Base
     extend FriendlyId
     friendly_id :name, use: :slugged
 

--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Product < ActiveRecord::Base
+  class Product < Spree::Base
     cattr_accessor :search_scopes do
       []
     end

--- a/core/app/models/spree/product_option_type.rb
+++ b/core/app/models/spree/product_option_type.rb
@@ -1,5 +1,5 @@
 module Spree
-  class ProductOptionType < ActiveRecord::Base
+  class ProductOptionType < Spree::Base
     belongs_to :product, class_name: 'Spree::Product', inverse_of: :product_option_types
     belongs_to :option_type, class_name: 'Spree::OptionType', inverse_of: :product_option_types
     acts_as_list scope: :product

--- a/core/app/models/spree/product_property.rb
+++ b/core/app/models/spree/product_property.rb
@@ -1,5 +1,5 @@
 module Spree
-  class ProductProperty < ActiveRecord::Base
+  class ProductProperty < Spree::Base
     belongs_to :product, touch: true, class_name: 'Spree::Product', inverse_of: :product_properties
     belongs_to :property, class_name: 'Spree::Property', inverse_of: :product_properties
 

--- a/core/app/models/spree/product_scope/scopes.rb
+++ b/core/app/models/spree/product_scope/scopes.rb
@@ -1,5 +1,5 @@
 module Spree
-  class ProductScope < ActiveRecord::Base
+  class ProductScope < Spree::Base
     before_validation(:on => :create) do
       # Add default empty arguments so scope validates and errors aren't caused when previewing it
       if name && args = self.class.arguments_for_scope_name(name)

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Promotion < ActiveRecord::Base
+  class Promotion < Spree::Base
     MATCH_POLICIES = %w(all any)
     UNACTIVATABLE_ORDER_STATES = ["complete", "awaiting_return", "returned"]
 

--- a/core/app/models/spree/promotion_action.rb
+++ b/core/app/models/spree/promotion_action.rb
@@ -1,7 +1,7 @@
 # Base class for all types of promotion action.
 # PromotionActions perform the necessary tasks when a promotion is activated by an event and determined to be eligible.
 module Spree
-  class PromotionAction < ActiveRecord::Base
+  class PromotionAction < Spree::Base
     belongs_to :promotion, class_name: 'Spree::Promotion'
 
     scope :of_type, ->(t) { where(type: t) }

--- a/core/app/models/spree/promotion_action_line_item.rb
+++ b/core/app/models/spree/promotion_action_line_item.rb
@@ -1,5 +1,5 @@
 module Spree
-  class PromotionActionLineItem < ActiveRecord::Base
+  class PromotionActionLineItem < Spree::Base
     belongs_to :promotion_action, class_name: 'Spree::Promotion::Actions::CreateLineItems'
     belongs_to :variant, class_name: 'Spree::Variant'
   end

--- a/core/app/models/spree/promotion_rule.rb
+++ b/core/app/models/spree/promotion_rule.rb
@@ -1,6 +1,6 @@
 # Base class for all promotion rules
 module Spree
-  class PromotionRule < ActiveRecord::Base
+  class PromotionRule < Spree::Base
     belongs_to :promotion, class_name: 'Spree::Promotion', inverse_of: :promotion_rules
 
     scope :of_type, ->(t) { where(type: t) }

--- a/core/app/models/spree/property.rb
+++ b/core/app/models/spree/property.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Property < ActiveRecord::Base
+  class Property < Spree::Base
     has_and_belongs_to_many :prototypes, join_table: 'spree_properties_prototypes'
 
     has_many :product_properties, dependent: :delete_all, inverse_of: :property

--- a/core/app/models/spree/prototype.rb
+++ b/core/app/models/spree/prototype.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Prototype < ActiveRecord::Base
+  class Prototype < Spree::Base
     has_and_belongs_to_many :properties, join_table: :spree_properties_prototypes
     has_and_belongs_to_many :option_types, join_table: :spree_option_types_prototypes
 

--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -1,5 +1,5 @@
 module Spree
-  class ReturnAuthorization < ActiveRecord::Base
+  class ReturnAuthorization < Spree::Base
     belongs_to :order, class_name: 'Spree::Order'
 
     has_many :inventory_units

--- a/core/app/models/spree/role.rb
+++ b/core/app/models/spree/role.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Role < ActiveRecord::Base
+  class Role < Spree::Base
     has_and_belongs_to_many :users, join_table: 'spree_roles_users', class_name: Spree.user_class.to_s
   end
 end

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -1,7 +1,7 @@
 require 'ostruct'
 
 module Spree
-  class Shipment < ActiveRecord::Base
+  class Shipment < Spree::Base
     belongs_to :order, class_name: 'Spree::Order', touch: true, inverse_of: :shipments
     belongs_to :address, class_name: 'Spree::Address', inverse_of: :shipments
     belongs_to :stock_location, class_name: 'Spree::StockLocation'

--- a/core/app/models/spree/shipping_category.rb
+++ b/core/app/models/spree/shipping_category.rb
@@ -1,5 +1,5 @@
 module Spree
-  class ShippingCategory < ActiveRecord::Base
+  class ShippingCategory < Spree::Base
     validates :name, presence: true
     has_many :products, inverse_of: :shipping_category
     has_many :shipping_method_categories

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -1,5 +1,5 @@
 module Spree
-  class ShippingMethod < ActiveRecord::Base
+  class ShippingMethod < Spree::Base
     include Spree::Core::CalculatedAdjustments
     DISPLAY = [:both, :front_end, :back_end]
 

--- a/core/app/models/spree/shipping_method_category.rb
+++ b/core/app/models/spree/shipping_method_category.rb
@@ -1,5 +1,5 @@
 module Spree
-  class ShippingMethodCategory < ActiveRecord::Base
+  class ShippingMethodCategory < Spree::Base
     belongs_to :shipping_method, class_name: 'Spree::ShippingMethod'
     belongs_to :shipping_category, class_name: 'Spree::ShippingCategory'
   end

--- a/core/app/models/spree/shipping_rate.rb
+++ b/core/app/models/spree/shipping_rate.rb
@@ -1,5 +1,5 @@
 module Spree
-  class ShippingRate < ActiveRecord::Base
+  class ShippingRate < Spree::Base
     belongs_to :shipment, class_name: 'Spree::Shipment'
     belongs_to :shipping_method, class_name: 'Spree::ShippingMethod', inverse_of: :shipping_rates
 

--- a/core/app/models/spree/state.rb
+++ b/core/app/models/spree/state.rb
@@ -1,5 +1,5 @@
 module Spree
-  class State < ActiveRecord::Base
+  class State < Spree::Base
     belongs_to :country, class_name: 'Spree::Country'
     has_many :addresses, dependent: :nullify
 

--- a/core/app/models/spree/state_change.rb
+++ b/core/app/models/spree/state_change.rb
@@ -1,5 +1,5 @@
 module Spree
-  class StateChange < ActiveRecord::Base
+  class StateChange < Spree::Base
     belongs_to :user
     belongs_to :stateful, polymorphic: true
     before_create :assign_user

--- a/core/app/models/spree/stock/splitter/backordered.rb
+++ b/core/app/models/spree/stock/splitter/backordered.rb
@@ -1,7 +1,7 @@
 module Spree
   module Stock
     module Splitter
-      class Backordered < Base
+      class Backordered < Spree::Stock::Splitter::Base
 
         def split(packages)
           split_packages = []

--- a/core/app/models/spree/stock/splitter/shipping_category.rb
+++ b/core/app/models/spree/stock/splitter/shipping_category.rb
@@ -1,7 +1,7 @@
 module Spree
   module Stock
     module Splitter
-      class ShippingCategory < Base
+      class ShippingCategory < Spree::Stock::Splitter::Base
         def split(packages)
           split_packages = []
           packages.each do |package|

--- a/core/app/models/spree/stock/splitter/weight.rb
+++ b/core/app/models/spree/stock/splitter/weight.rb
@@ -1,7 +1,7 @@
 module Spree
   module Stock
     module Splitter
-      class Weight < Base
+      class Weight < Spree::Stock::Splitter::Base
         attr_reader :packer, :next_splitter
 
         cattr_accessor :threshold do

--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -1,5 +1,5 @@
 module Spree
-  class StockItem < ActiveRecord::Base
+  class StockItem < Spree::Base
     acts_as_paranoid
 
     belongs_to :stock_location, class_name: 'Spree::StockLocation'

--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -1,5 +1,5 @@
 module Spree
-  class StockLocation < ActiveRecord::Base
+  class StockLocation < Spree::Base
     has_many :stock_items, dependent: :delete_all
     has_many :stock_movements, through: :stock_items
 

--- a/core/app/models/spree/stock_movement.rb
+++ b/core/app/models/spree/stock_movement.rb
@@ -1,5 +1,5 @@
 module Spree
-  class StockMovement < ActiveRecord::Base
+  class StockMovement < Spree::Base
     belongs_to :stock_item, class_name: 'Spree::StockItem', inverse_of: :stock_movements
     belongs_to :originator, polymorphic: true
 

--- a/core/app/models/spree/stock_transfer.rb
+++ b/core/app/models/spree/stock_transfer.rb
@@ -1,5 +1,5 @@
 module Spree
-  class StockTransfer < ActiveRecord::Base
+  class StockTransfer < Spree::Base
     has_many :stock_movements, :as => :originator
 
     belongs_to :source_location, :class_name => 'StockLocation'

--- a/core/app/models/spree/tax_category.rb
+++ b/core/app/models/spree/tax_category.rb
@@ -1,5 +1,5 @@
 module Spree
-  class TaxCategory < ActiveRecord::Base
+  class TaxCategory < Spree::Base
     acts_as_paranoid
     validates :name, presence: true, uniqueness: { scope: :deleted_at }
 

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -9,7 +9,7 @@ module Spree
 end
 
 module Spree
-  class TaxRate < ActiveRecord::Base
+  class TaxRate < Spree::Base
     acts_as_paranoid
     include Spree::Core::CalculatedAdjustments
     belongs_to :zone, class_name: "Spree::Zone"

--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Taxon < ActiveRecord::Base
+  class Taxon < Spree::Base
     acts_as_nested_set dependent: :destroy
 
     belongs_to :taxonomy, class_name: 'Spree::Taxonomy', touch: true, inverse_of: :taxons

--- a/core/app/models/spree/taxonomy.rb
+++ b/core/app/models/spree/taxonomy.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Taxonomy < ActiveRecord::Base
+  class Taxonomy < Spree::Base
     validates :name, presence: true
 
     has_many :taxons, inverse_of: :taxonomy

--- a/core/app/models/spree/tokenized_permission.rb
+++ b/core/app/models/spree/tokenized_permission.rb
@@ -1,5 +1,5 @@
 module Spree
-  class TokenizedPermission < ActiveRecord::Base
+  class TokenizedPermission < Spree::Base
     belongs_to :permissable, polymorphic: true
   end
 end

--- a/core/app/models/spree/tracker.rb
+++ b/core/app/models/spree/tracker.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Tracker < ActiveRecord::Base
+  class Tracker < Spree::Base
     def self.current
       tracker = where(active: true, environment: Rails.env).first
       tracker.analytics_id.present? ? tracker : nil if tracker

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Variant < ActiveRecord::Base
+  class Variant < Spree::Base
     acts_as_paranoid
 
     belongs_to :product, touch: true, class_name: 'Spree::Product', inverse_of: :variants

--- a/core/app/models/spree/variant/scopes.rb
+++ b/core/app/models/spree/variant/scopes.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Variant < ActiveRecord::Base
+  class Variant < Spree::Base
     #FIXME WARNING tested only under sqlite and postgresql
     scope :descend_by_popularity, -> { order("COALESCE((SELECT COUNT(*) FROM  #{LineItem.quoted_table_name} GROUP BY #{LineItem.quoted_table_name}.variant_id HAVING #{LineItem.quoted_table_name}.variant_id = #{Variant.quoted_table_name}.id), 0) DESC") }
 

--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Zone < ActiveRecord::Base
+  class Zone < Spree::Base
     has_many :zone_members, dependent: :destroy, class_name: "Spree::ZoneMember"
     has_many :tax_rates, dependent: :destroy
     has_and_belongs_to_many :shipping_methods, :join_table => 'spree_shipping_methods_zones'

--- a/core/app/models/spree/zone_member.rb
+++ b/core/app/models/spree/zone_member.rb
@@ -1,5 +1,5 @@
 module Spree
-  class ZoneMember < ActiveRecord::Base
+  class ZoneMember < Spree::Base
     belongs_to :zone, class_name: 'Spree::Zone', counter_cache: true
     belongs_to :zoneable, polymorphic: true
 

--- a/core/lib/spree/core/delegate_belongs_to.rb
+++ b/core/lib/spree/core/delegate_belongs_to.rb
@@ -4,8 +4,8 @@
 #
 # Todo - integrate with ActiveRecord::Dirty to make sure changes to delegate object are noticed
 # Should do
-# class User < ActiveRecord::Base; delegate_belongs_to :contact, :firstname; end
-# class Contact < ActiveRecord::Base; end
+# class User < Spree::Base; delegate_belongs_to :contact, :firstname; end
+# class Contact < Spree::Base; end
 # u = User.first
 # u.changed? # => false
 # u.firstname = 'Bobby'

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -9,10 +9,6 @@ module Spree
         Spree::Config = app.config.spree.preferences #legacy access
       end
 
-      initializer "spree.load_preferences", :before => "spree.environment" do
-        ::ActiveRecord::Base.send :include, Spree::Preferences::Preferable
-      end
-
       initializer "spree.register.calculators" do |app|
         app.config.spree.calculators.shipping_methods = [
             Spree::Calculator::Shipping::FlatPercentItemTotal,

--- a/core/spec/lib/spree/core/delegate_belongs_to_spec.rb
+++ b/core/spec/lib/spree/core/delegate_belongs_to_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 # already. Stubs wouldn't work here (the delegation runs before this spec is
 # loaded) and adding a column here might make the test even crazy so here we go
 module Spree
-  class DelegateBelongsToStubModel < ActiveRecord::Base
+  class DelegateBelongsToStubModel < Spree::Base
     self.table_name = "spree_payment_methods"
     belongs_to :product
     delegate_belongs_to :product, :name

--- a/core/spec/models/spree/preferences/preferable_spec.rb
+++ b/core/spec/models/spree/preferences/preferable_spec.rb
@@ -260,7 +260,7 @@ describe Spree::Preferences::Preferable do
       ActiveRecord::Migration.verbose = false
       CreatePrefTest.migrate(:up)
 
-      class PrefTest < ActiveRecord::Base
+      class PrefTest < Spree::Base
         preference :pref_test_pref, :string, :default => 'abc'
         preference :pref_test_any, :any, :default => []
       end

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 module ThirdParty
-  class Extension < ActiveRecord::Base
+  class Extension < Spree::Base
     # nasty hack so we don't have to create a table to back this fake model
     self.table_name = 'spree_products'
   end

--- a/lib/spree.rb
+++ b/lib/spree.rb
@@ -4,12 +4,15 @@ require 'spree_backend'
 require 'spree_frontend'
 require 'spree_sample'
 
-begin
-  require 'protected_attributes'
-  puts "*" * 75
-  puts "[FATAL] Spree does not work with the protected_attributes gem installed!"
-  puts "You MUST remove this gem from your Gemfile. It is incompatible with Spree."
-  puts "*" * 75
-  exit
-rescue LoadError
-end
+
+# Buying some time for us to remove protected_attributes from PYR...
+
+# begin
+#   require 'protected_attributes'
+#   puts "*" * 75
+#   puts "[FATAL] Spree does not work with the protected_attributes gem installed!"
+#   puts "You MUST remove this gem from your Gemfile. It is incompatible with Spree."
+#   puts "*" * 75
+#   exit
+# rescue LoadError
+# end

--- a/lib/spree.rb
+++ b/lib/spree.rb
@@ -4,15 +4,12 @@ require 'spree_backend'
 require 'spree_frontend'
 require 'spree_sample'
 
-
-# Buying some time for us to remove protected_attributes from PYR...
-
-# begin
-#   require 'protected_attributes'
-#   puts "*" * 75
-#   puts "[FATAL] Spree does not work with the protected_attributes gem installed!"
-#   puts "You MUST remove this gem from your Gemfile. It is incompatible with Spree."
-#   puts "*" * 75
-#   exit
-# rescue LoadError
-# end
+begin
+  require 'protected_attributes'
+  puts "*" * 75
+  puts "[FATAL] Spree does not work with the protected_attributes gem installed!"
+  puts "You MUST remove this gem from your Gemfile. It is incompatible with Spree."
+  puts "*" * 75
+  exit
+rescue LoadError
+end


### PR DESCRIPTION
Moving inclusion of Spree::Preferences::Preferable away from an engine-base inclusion to ActiveRecord::Base, and instead making it a Spree-specific Spree::Base inclusion.  This is to prevent the Prefereble module from bleeding outward and causing conflicts in other Engines which may have attributes called, at the least, 'preferred' on their models already.

All core test cases pass with this merge.
