### PR TITLE
in order.finalize! method use close method for adjustmens

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -314,7 +314,7 @@ module Spree
     # Called after transition to complete state when payments will have been processed
     def finalize!
       # lock all adjustments (coupon promotions, etc.)
-      all_adjustments.update_all state: 'closed'
+      all_adjustments.each{|a| a.close}
 
       # update payment and shipment(s) states, and save
       updater.update_payment_state

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -269,9 +269,11 @@ describe Spree::Order do
       # and it's irrelevant to this test
       order.stub :has_available_shipment
       Spree::OrderMailer.stub_chain :confirm_email, :deliver
-      adjustments = double
+      adjustments = [double]
       order.should_receive(:all_adjustments).and_return(adjustments)
-      expect(adjustments).to receive(:update_all).with(state: 'closed')
+      adjustments.each do |adj|
+	expect(adj).to receive(:close)
+      end
       order.finalize!
     end
 


### PR DESCRIPTION
If in extension we use Adjustment state machine in this way

```
Spree::Adjustment.class_eval do
  state_machine do
    after_transition :to => :closed, :do => :method_sample
  end
end
```

method is not called when user complete order. Works only when administrator close adjustment in order management. This little fix makes it works in both ways. It makes update query for every adjustment, but in checkout page I thinks this is not big problem.
