### PR TITLE
remove adjustments finalize!

### DIFF
--- a/api/spec/controllers/spree/api/shipments_controller_spec.rb
+++ b/api/spec/controllers/spree/api/shipments_controller_spec.rb
@@ -92,7 +92,7 @@ describe Spree::Api::ShipmentsController do
         Spree::Order.any_instance.stub(:paid? => true, :complete? => true)
         # For the shipment notification email
         Spree::Config[:mails_from] = "spree@example.com"
-
+        shipment.adjustments << Spree::Adjustment.create!({:label => "discount", :amount => -3.99})
         shipment.update!(shipment.order)
         shipment.state.should == "ready"
         Spree::ShippingRate.any_instance.stub(:cost => 5)

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -305,7 +305,6 @@ module Spree
 
       def after_ship
         inventory_units.each &:ship!
-        adjustments.map(&:finalize!)
         send_shipped_email
         touch :shipped_at
         update_order_shipment_state


### PR DESCRIPTION
According to commit 953c960680f284a2eb97b160a4610a72494ce107. 
This commit removes the confusing "finalized" state  from Spree::Adjustment.

When I click ship button in admin, it will throw error in after_ship method since no finalize! method in adjustment any more.

```
undefined method `finalize!' for #<Spree::Adjustment:0x000001095a1180>
```
