### PR TITLE
Enable mail delivery should default to true

### DIFF
--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -71,7 +71,7 @@ module Spree
     preference :track_inventory_levels, :boolean, default: true # Determines whether to track on_hand values for variants / products.
 
     # Default mail headers settings
-    preference :enable_mail_delivery, :boolean, :default => false
+    preference :enable_mail_delivery, :boolean, :default => true
     preference :send_core_emails, :boolean, :default => true
     preference :mails_from, :string, :default => 'spree@example.com'
     preference :mail_bcc, :string, :default => 'spree@example.com'


### PR DESCRIPTION
If you're overriding the default smtp configuration of a system that can deliver emails out of the box, the override should also be turned on by default. Opting out is the normal use case. 
