### PR TITLE
Fix issue changing between payment methods in admin

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/select_payments.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/select_payments.js.coffee
@@ -1,0 +1,7 @@
+$ ->
+  if $('.new_payment').is('*')
+    $('.payment-method-settings fieldset').addClass('hidden').first().removeClass('hidden')
+    $('input[name="payment[payment_method_id]"]').click ()->
+      $('.payment-method-settings fieldset').addClass('hidden')
+      id = $(this).parents('li').data('id')
+      $("fieldset##{id}").removeClass('hidden')

--- a/backend/app/views/spree/admin/payments/_form.html.erb
+++ b/backend/app/views/spree/admin/payments/_form.html.erb
@@ -8,9 +8,9 @@
   <div class="omega nine columns">
     <div class="field">
       <label><%= Spree.t(:payment_method) %></label>
-      <ul>
+      <ul id='payment-methods'>
         <% @payment_methods.each do |method| %>
-          <li>
+          <li data-id="<%= Spree.t(method.name, :scope => :payment_methods, :default => method.name).parameterize %>">
             <label data-hook="payment_method_field">
               <%= radio_button_tag 'payment[payment_method_id]', method.id, method == @payment_method %>
               <%= Spree.t(method.name, :scope => :payment_methods, :default => method.name) %>


### PR DESCRIPTION
If you have more than one payment method completing an order via admin, when you select the checkbox to use another payment method instead credit card, it doesn't show nothing
