### PR TITLE
Fix Spree::TaxonsHelper#taxon_preview not to show duplicate products

### DIFF
--- a/core/app/helpers/spree/taxons_helper.rb
+++ b/core/app/helpers/spree/taxons_helper.rb
@@ -4,12 +4,12 @@ module Spree
     # that we can use configurations as well as make it easier for end users to override this determination.  One idea is
     # to show the most popular products for a particular taxon (that is an exercise left to the developer.)
     def taxon_preview(taxon, max=4)
-      products = taxon.active_products.limit(max)
+      products = taxon.active_products.limit(max).uniq
       if (products.size < max)
+        products_arel = Spree::Product.arel_table
         taxon.descendants.each do |taxon|
           to_get = max - products.length
-          products += taxon.active_products.limit(to_get)
-          products = products.uniq
+          products += taxon.active_products.where(products_arel[:id].not_in(products.map(&:id))).limit(to_get).uniq
           break if products.size >= max
         end
       end


### PR DESCRIPTION
If a product belongs to nested taxons(e.g, category->sub category->sub-sub category), there's a possibility #taxon_preview returns duplicate products.

This error is caused by wrong way of use uniq method.
Here's an example to explain rails behavior.

``` ruby
products = Spree::Product.limit 1
products.class
# ActiveRecord::Relation::ActiveRecord_Relation_Spree_Product
products += products
products.class
# Array
```

When activerecord's collection is merged by "+=", it returns an Array object.
So "products.uniq" doesn't work out as expected.
