### PR TITLE
move deliver email under completed_at touch

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -327,9 +327,10 @@ module Spree
       save
       updater.run_hooks
 
+      touch :completed_at
+
       deliver_order_confirmation_email unless confirmation_delivered?
 
-      touch :completed_at
       consider_risk
     end
 


### PR DESCRIPTION
This will avoid breaking the confirmation email, 'cause if not the completed_at date will be nil.
