### PR TITLE
Use can_supply in stead of in_stock in frontend

### DIFF
--- a/frontend/app/views/spree/products/_cart_form.html.erb
+++ b/frontend/app/views/spree/products/_cart_form.html.erb
@@ -36,7 +36,7 @@
             <span itemprop="priceCurrency" content="<%= @product.currency %>"></span>
           </div>
 
-          <% if @product.master.in_stock? %>
+          <% if @product.master.can_supply? %>
             <link itemprop="availability" href="http://schema.org/InStock" />
           <% end %> 
         </div>


### PR DESCRIPTION
Use can_supply in stead of the deprecated in_stock in the product cart form.
