### PR TITLE
payment_method_spec: avoid INSERT in before(:all)

### DIFF
--- a/core/spec/models/spree/payment_method_spec.rb
+++ b/core/spec/models/spree/payment_method_spec.rb
@@ -2,9 +2,7 @@ require 'spec_helper'
 
 describe Spree::PaymentMethod do
   describe "#available" do
-    before(:all) do
-      Spree::PaymentMethod.delete_all
-
+    before do
       [nil, 'both', 'front_end', 'back_end'].each do |display_on|
         Spree::Gateway::Test.create(
           :name => 'Display Both',
@@ -14,6 +12,9 @@ describe Spree::PaymentMethod do
           :description => 'foofah'
         )
       end
+    end
+
+    it "should have 4 total methods" do
       Spree::PaymentMethod.all.size.should == 4
     end
 


### PR DESCRIPTION
This before(:all) block (which is outside of the database transaction that specs are run in) was creating four payment methods which caused order_spec to fail occasionally (to reproduce: run rspec in core a few times).

```
Failures:

  1) Spree::Order#available_payment_methods does not include a payment method twice if display_on is blank
     Failure/Error: expect(order.available_payment_methods.count).to eq(1)

       expected: 1
            got: 4

       (compared using ==)
     # ./spec/models/spree/order_spec.rb:855:in `block (3 levels) in <top (required)>'
```

This changes it to a normal before block.
