### PR TITLE
Preferences Refactor

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,1 +1,24 @@
 ## Spree 2.3.0 (unreleased) ##
+
+### Preferences Refactoring
+
+Preferences defined on ActiveRecord objects are now stored on the same table.
+This is done by adding a preferences column which is serialized via
+ActiveRecord::Base.serialize.
+
+```
+> Spree::Calculator.first
+=> #<Spree::Calculator::Shipping::FlatRate id: 1,
+                                           type: "Spree::Calculator::Shipping::FlatRate",
+                                           calculable_id: 1,
+                                           calculable_type: "Spree::ShippingMethod",
+                                           created_at: "2014-03-13 01:38:27",
+                                           updated_at: "2014-03-13 01:38:28",
+                                           preferences: {:amount=>5.0, :currency=>"USD"}>
+```
+
+Records now need to be saved for modified preferences to be persisted.
+Assigning `calculator.preferred_amount = 10` will not update the database
+record until `calculator.save` is called.
+
+A migration will move existing preferences onto the new column.

--- a/core/app/models/spree/base.rb
+++ b/core/app/models/spree/base.rb
@@ -1,4 +1,9 @@
 class Spree::Base < ActiveRecord::Base
   include Spree::Preferences::Preferable
+  serialize :preferences, Hash
+  after_initialize do
+    self.preferences = default_preferences.merge(preferences) if has_attribute?(:preferences)
+  end
+
   self.abstract_class = true
 end

--- a/core/app/models/spree/calculator/flat_rate.rb
+++ b/core/app/models/spree/calculator/flat_rate.rb
@@ -3,7 +3,7 @@ require_dependency 'spree/calculator'
 module Spree
   class Calculator::FlatRate < Calculator
     preference :amount, :decimal, default: 0
-    preference :currency, :string, default: Spree::Config[:currency]
+    preference :currency, :string, default: ->{ Spree::Config[:currency] }
 
     def self.description
       Spree.t(:flat_rate_per_order)

--- a/core/app/models/spree/calculator/flexi_rate.rb
+++ b/core/app/models/spree/calculator/flexi_rate.rb
@@ -5,7 +5,7 @@ module Spree
     preference :first_item,      :decimal, default: 0.0
     preference :additional_item, :decimal, default: 0.0
     preference :max_items,       :integer, default: 0
-    preference :currency,        :string,  default: Spree::Config[:currency]
+    preference :currency,        :string,  default: ->{ Spree::Config[:currency] }
 
     def self.description
       Spree.t(:flexible_rate)

--- a/core/app/models/spree/calculator/price_sack.rb
+++ b/core/app/models/spree/calculator/price_sack.rb
@@ -7,7 +7,7 @@ module Spree
     preference :minimal_amount, :decimal, default: 0
     preference :normal_amount, :decimal, default: 0
     preference :discount_amount, :decimal, default: 0
-    preference :currency, :string, default: Spree::Config[:currency]
+    preference :currency, :string, default: ->{ Spree::Config[:currency] }
 
     def self.description
       Spree.t(:price_sack)

--- a/core/app/models/spree/calculator/shipping/flat_rate.rb
+++ b/core/app/models/spree/calculator/shipping/flat_rate.rb
@@ -4,7 +4,7 @@ module Spree
   module Calculator::Shipping
     class FlatRate < ShippingCalculator
       preference :amount, :decimal, default: 0
-      preference :currency, :string, default: Spree::Config[:currency]
+      preference :currency, :string, default: ->{ Spree::Config[:currency] }
 
       def self.description
         Spree.t(:shipping_flat_rate_per_order)

--- a/core/app/models/spree/calculator/shipping/flexi_rate.rb
+++ b/core/app/models/spree/calculator/shipping/flexi_rate.rb
@@ -6,7 +6,7 @@ module Spree
       preference :first_item,      :decimal, default: 0.0
       preference :additional_item, :decimal, default: 0.0
       preference :max_items,       :integer, default: 0
-      preference :currency,        :string,  default: Spree::Config[:currency]
+      preference :currency,        :string,  default: ->{ Spree::Config[:currency] }
 
       def self.description
         Spree.t(:shipping_flexible_rate)

--- a/core/app/models/spree/calculator/shipping/per_item.rb
+++ b/core/app/models/spree/calculator/shipping/per_item.rb
@@ -4,7 +4,7 @@ module Spree
   module Calculator::Shipping
     class PerItem < ShippingCalculator
       preference :amount, :decimal, default: 0
-      preference :currency, :string, default: Spree::Config[:currency]
+      preference :currency, :string, default: ->{ Spree::Config[:currency] }
 
       def self.description
         Spree.t(:shipping_flat_rate_per_item)

--- a/core/app/models/spree/calculator/shipping/price_sack.rb
+++ b/core/app/models/spree/calculator/shipping/price_sack.rb
@@ -8,7 +8,7 @@ module Spree
       preference :minimal_amount, :decimal, default: 0
       preference :normal_amount, :decimal, default: 0
       preference :discount_amount, :decimal, default: 0
-      preference :currency, :string, default: Spree::Config[:currency]
+      preference :currency, :string, default: ->{ Spree::Config[:currency] }
 
       def self.description
         Spree.t(:shipping_price_sack)

--- a/core/app/models/spree/preference.rb
+++ b/core/app/models/spree/preference.rb
@@ -2,34 +2,4 @@ class Spree::Preference < Spree::Base
   serialize :value
 
   validates :key, presence: true
-  validates :value_type, presence: true
-
-  scope :valid, -> { where(Spree::Preference.arel_table[:key].not_eq(nil)).where(Spree::Preference.arel_table[:value_type].not_eq(nil)) }
-
-  # The type conversions here should match
-  # the ones in spree::preferences::preferrable#convert_preference_value
-  def value
-    if self[:value_type].present?
-      case self[:value_type].to_sym
-      when :string, :text
-        self[:value].to_s
-      when :password
-        self[:value].to_s
-      when :decimal
-        BigDecimal.new(self[:value].to_s).round(2, BigDecimal::ROUND_HALF_UP)
-      when :integer
-        self[:value].to_i
-      when :boolean
-        (self[:value].to_s =~ /^[t|1]/i) != nil
-      else
-        self[:value].is_a?(String) ? YAML.load(self[:value]) : self[:value]
-      end
-    else
-      self[:value]
-    end
-  end
-
-  def raw_value
-    self[:value]
-  end
 end

--- a/core/app/models/spree/preferences/configuration.rb
+++ b/core/app/models/spree/preferences/configuration.rb
@@ -28,12 +28,8 @@ module Spree::Preferences
       yield(self) if block_given?
     end
 
-    def preference_cache_key(name)
-      [rails_cache_id, self.class.name, name].compact.join('::').underscore
-    end
-
-    def rails_cache_id
-      ENV['RAILS_CACHE_ID']
+    def preference_store
+      ScopedStore.new(self.class.name.underscore)
     end
 
     def reset

--- a/core/app/models/spree/preferences/configuration.rb
+++ b/core/app/models/spree/preferences/configuration.rb
@@ -28,7 +28,7 @@ module Spree::Preferences
       yield(self) if block_given?
     end
 
-    def preference_store
+    def preferences
       ScopedStore.new(self.class.name.underscore)
     end
 

--- a/core/app/models/spree/preferences/preferable.rb
+++ b/core/app/models/spree/preferences/preferable.rb
@@ -64,12 +64,18 @@ module Spree::Preferences::Preferable
     respond_to? self.class.preference_getter_method(name)
   end
 
-  def preferences
-    prefs = {}
-    methods.grep(/^prefers_.*\?$/).each do |pref_method|
-      prefs[pref_method.to_s.gsub(/prefers_|\?/, '').to_sym] = send(pref_method)
+  def defined_preferences
+    methods.grep(/\Apreferred_.*=\Z/).map do |pref_method|
+      pref_method.to_s.gsub(/\Apreferred_|=\Z/, '').to_sym
     end
-    prefs
+  end
+
+  def preferences
+    Hash[
+      defined_preferences.map do |preference|
+        [preference, get_preference(preference)]
+      end
+    ]
   end
 
   def prefers?(name)

--- a/core/app/models/spree/preferences/preferable.rb
+++ b/core/app/models/spree/preferences/preferable.rb
@@ -33,8 +33,6 @@ module Spree::Preferences::Preferable
     has_preference! name
     send self.class.preference_getter_method(name)
   end
-  alias :preferred :get_preference
-  alias :prefers? :get_preference
 
   def set_preference(name, value)
     has_preference! name
@@ -49,11 +47,6 @@ module Spree::Preferences::Preferable
   def preference_default(name)
     has_preference! name
     send self.class.preference_default_getter_method(name)
-  end
-
-  def preference_description(name)
-    has_preference! name
-    send self.class.preference_description_getter_method(name)
   end
 
   def has_preference!(name)
@@ -76,10 +69,6 @@ module Spree::Preferences::Preferable
         [preference, get_preference(preference)]
       end
     ]
-  end
-
-  def prefers?(name)
-    get_preference(name)
   end
 
   def preference_cache_key(name)

--- a/core/app/models/spree/preferences/preferable.rb
+++ b/core/app/models/spree/preferences/preferable.rb
@@ -1,13 +1,36 @@
-# The preference_cache_key is used to determine if the preference
-# can be set. The default behavior is to return nil if there is no
-# id value. On ActiveRecords, new objects will have their preferences
-# saved to a pending hash until it is persisted.
+# Preferable allows defining preference accessor methods.
 #
-# class_attributes are inheritied unless you reassign them in
-# the subclass, so when you inherit a Preferable class, the
-# inherited hook will assign a new hash for the subclass definitions
-# and copy all the definitions allowing the subclass to add
-# additional defintions without affecting the base
+# A class including Preferable must implement #preferences which should return
+# an object responding to .fetch(key), []=(key, val), and .delete(key).
+#
+# The generated writer method performs typecasting before assignment into the
+# preferences object.
+#
+# Examples:
+#
+#   # Spree::Base includes Preferable and defines preferences as a serialized
+#   # column.
+#   class Settings < Spree::Base
+#     preference :color,       :string,  default: 'red'
+#     preference :temperature, :integer, default: 21
+#   end
+#
+#   s = Settings.new
+#   s.preferred_color # => 'red'
+#   s.preferred_temperature # => 21
+#
+#   s.preferred_color = 'blue'
+#   s.preferred_color # => 'blue'
+#
+#   # Typecasting is performed on assignment
+#   s.preferred_temperature = '24'
+#   s.preferred_color # => 24
+#
+#   # Modifications have been made to the .preferences hash
+#   s.preferences #=> {color: 'blue', temperature: 24}
+#
+#   # Save the changes. All handled by activerecord
+#   s.save!
 module Spree::Preferences::Preferable
   extend ActiveSupport::Concern
 

--- a/core/app/models/spree/preferences/preferable.rb
+++ b/core/app/models/spree/preferences/preferable.rb
@@ -71,15 +71,6 @@ module Spree::Preferences::Preferable
     ]
   end
 
-  def preference_cache_key(name)
-    return unless id
-    [rails_cache_id, self.class.name, name, id].compact.join('::').underscore
-  end
-
-  def rails_cache_id
-    ENV['RAILS_CACHE_ID']
-  end
-
   def save_pending_preferences
     return unless @pending_preferences
     @pending_preferences.each do |name, value|
@@ -88,20 +79,10 @@ module Spree::Preferences::Preferable
   end
 
   def clear_preferences
-    preferences.keys.each {|pref| preference_store.delete preference_cache_key(pref)}
+    preferences.keys.each {|pref| preference_store.delete pref}
   end
 
   private
-
-  def add_pending_preference(name, value)
-    @pending_preferences ||= {}
-    @pending_preferences[name] = value
-  end
-
-  def get_pending_preference(name)
-    return unless @pending_preferences
-    @pending_preferences[name]
-  end
 
   def convert_preference_value(value, type)
     case type
@@ -129,8 +110,11 @@ module Spree::Preferences::Preferable
   end
 
   def preference_store
-    Spree::Preferences::Store.instance
+    if id
+      Spree::Preferences::ScopedStore.new(self.class.name.underscore, id)
+    else
+      @pending_preferences ||= {}
+    end
   end
-
 end
 

--- a/core/app/models/spree/preferences/preferable_class_methods.rb
+++ b/core/app/models/spree/preferences/preferable_class_methods.rb
@@ -24,7 +24,7 @@ module Spree::Preferences
       define_method preference_setter_method(name) do |value|
         value = convert_preference_value(value, type)
         if preference_cache_key(name)
-          preference_store.set preference_cache_key(name), value, type
+          preference_store.set preference_cache_key(name), value
         else
           add_pending_preference(name, value)
         end

--- a/core/app/models/spree/preferences/preferable_class_methods.rb
+++ b/core/app/models/spree/preferences/preferable_class_methods.rb
@@ -3,9 +3,8 @@ module Spree::Preferences
 
     def preference(name, type, *args)
       options = args.extract_options!
-      options.assert_valid_keys(:default, :description)
+      options.assert_valid_keys(:default)
       default = options[:default]
-      description = options[:description] || name
 
       # cache_key will be nil for new objects, then if we check if there
       # is a pending preference before going to default
@@ -19,7 +18,6 @@ module Spree::Preferences
           get_pending_preference(name) || default
         end
       end
-      alias_method prefers_getter_method(name), preference_getter_method(name)
 
       define_method preference_setter_method(name) do |value|
         value = convert_preference_value(value, type)
@@ -29,7 +27,6 @@ module Spree::Preferences
           add_pending_preference(name, value)
         end
       end
-      alias_method prefers_setter_method(name), preference_setter_method(name)
 
       define_method preference_default_getter_method(name) do
         default
@@ -38,20 +35,6 @@ module Spree::Preferences
       define_method preference_type_getter_method(name) do
         type
       end
-
-      define_method preference_description_getter_method(name) do
-        description
-      end
-    end
-
-    def remove_preference(name)
-      remove_method preference_getter_method(name) if method_defined? preference_getter_method(name)
-      remove_method preference_setter_method(name) if method_defined? preference_setter_method(name)
-      remove_method prefers_getter_method(name) if method_defined? prefers_getter_method(name)
-      remove_method prefers_setter_method(name) if method_defined? prefers_setter_method(name)
-      remove_method preference_default_getter_method(name) if method_defined? preference_default_getter_method(name)
-      remove_method preference_type_getter_method(name) if method_defined? preference_type_getter_method(name)
-      remove_method preference_description_getter_method(name) if method_defined? preference_description_getter_method(name)
     end
 
     def preference_getter_method(name)
@@ -62,14 +45,6 @@ module Spree::Preferences
        "preferred_#{name}=".to_sym
     end
 
-    def prefers_getter_method(name)
-      "prefers_#{name}?".to_sym
-    end
-
-    def prefers_setter_method(name)
-       "prefers_#{name}=".to_sym
-    end
-
     def preference_default_getter_method(name)
       "preferred_#{name}_default".to_sym
     end
@@ -77,10 +52,5 @@ module Spree::Preferences
     def preference_type_getter_method(name)
       "preferred_#{name}_type".to_sym
     end
-
-    def preference_description_getter_method(name)
-      "preferred_#{name}_description".to_sym
-    end
-
   end
 end

--- a/core/app/models/spree/preferences/preferable_class_methods.rb
+++ b/core/app/models/spree/preferences/preferable_class_methods.rb
@@ -5,6 +5,7 @@ module Spree::Preferences
       options = args.extract_options!
       options.assert_valid_keys(:default)
       default = options[:default]
+      default = ->{ options[:default] } unless default.is_a?(Proc)
 
       # cache_key will be nil for new objects, then if we check if there
       # is a pending preference before going to default
@@ -13,9 +14,9 @@ module Spree::Preferences
         # perference_cache_key will only be nil/false for new records
         #
         if preference_cache_key(name)
-          preference_store.get(preference_cache_key(name), default)
+          preference_store.get(preference_cache_key(name), &default)
         else
-          get_pending_preference(name) || default
+          get_pending_preference(name) || default.call
         end
       end
 
@@ -28,9 +29,7 @@ module Spree::Preferences
         end
       end
 
-      define_method preference_default_getter_method(name) do
-        default
-      end
+      define_method preference_default_getter_method(name), &default
 
       define_method preference_type_getter_method(name) do
         type

--- a/core/app/models/spree/preferences/preferable_class_methods.rb
+++ b/core/app/models/spree/preferences/preferable_class_methods.rb
@@ -10,23 +10,14 @@ module Spree::Preferences
       # cache_key will be nil for new objects, then if we check if there
       # is a pending preference before going to default
       define_method preference_getter_method(name) do
-
-        # perference_cache_key will only be nil/false for new records
-        #
-        if preference_cache_key(name)
-          preference_store.get(preference_cache_key(name), &default)
-        else
-          get_pending_preference(name) || default.call
+        preference_store.fetch(name) do
+          default.call
         end
       end
 
       define_method preference_setter_method(name) do |value|
         value = convert_preference_value(value, type)
-        if preference_cache_key(name)
-          preference_store.set preference_cache_key(name), value
-        else
-          add_pending_preference(name, value)
-        end
+        preference_store[name] = value
       end
 
       define_method preference_default_getter_method(name), &default

--- a/core/app/models/spree/preferences/preferable_class_methods.rb
+++ b/core/app/models/spree/preferences/preferable_class_methods.rb
@@ -10,14 +10,19 @@ module Spree::Preferences
       # cache_key will be nil for new objects, then if we check if there
       # is a pending preference before going to default
       define_method preference_getter_method(name) do
-        preference_store.fetch(name) do
+        preferences.fetch(name) do
           default.call
         end
       end
 
       define_method preference_setter_method(name) do |value|
         value = convert_preference_value(value, type)
-        preference_store[name] = value
+        preferences[name] = value
+
+        # If this is an activerecord object, we need to inform
+        # ActiveRecord::Dirty that this value has changed, since this is an
+        # in-place update to the preferences hash.
+        preferences_will_change! if respond_to?(:preferences_will_change!)
       end
 
       define_method preference_default_getter_method(name), &default

--- a/core/app/models/spree/preferences/scoped_store.rb
+++ b/core/app/models/spree/preferences/scoped_store.rb
@@ -1,0 +1,33 @@
+module Spree::Preferences
+  class ScopedStore
+    def initialize prefix, suffix=nil
+      @prefix = prefix
+      @suffix = suffix
+    end
+
+    def store
+      Spree::Preferences::Store.instance
+    end
+
+    def fetch key, &block
+      store.fetch(key_for(key), &block)
+    end
+
+    def []= key, value
+      store[key_for(key)] = value
+    end
+
+    def delete key
+      store.delete(key_for(key))
+    end
+
+    private
+    def key_for key
+      [rails_cache_id, @prefix, key, @suffix].compact.join('/')
+    end
+
+    def rails_cache_id
+      ENV['RAILS_CACHE_ID']
+    end
+  end
+end

--- a/core/app/models/spree/preferences/store.rb
+++ b/core/app/models/spree/preferences/store.rb
@@ -16,9 +16,9 @@ module Spree::Preferences
       @persistence = true
     end
 
-    def set(key, value, type)
+    def set(key, value)
       @cache.write(key, value)
-      persist(key, value, type)
+      persist(key, value)
     end
 
     def exist?(key)
@@ -68,12 +68,11 @@ module Spree::Preferences
 
     private
 
-    def persist(cache_key, value, type)
+    def persist(cache_key, value)
       return unless should_persist?
 
       preference = Spree::Preference.where(:key => cache_key).first_or_initialize
       preference.value = value
-      preference.value_type = type
       preference.save
     end
 

--- a/core/app/models/spree/preferences/store.rb
+++ b/core/app/models/spree/preferences/store.rb
@@ -20,13 +20,14 @@ module Spree::Preferences
       @cache.write(key, value)
       persist(key, value)
     end
+    alias_method :[]=, :set
 
     def exist?(key)
       @cache.exist?(key) ||
       should_persist? && Spree::Preference.where(:key => key).exists?
     end
 
-    def get(key,fallback=nil)
+    def get(key)
       # return the retrieved value, if it's in the cache
       # use unless nil? incase the value is actually boolean false
       #
@@ -44,7 +45,7 @@ module Spree::Preferences
           val = preference.value
         else
           # use the fallback value
-          val = fallback
+          val = yield
         end
 
         # Cache either the value from the db or the fallback value.
@@ -53,9 +54,10 @@ module Spree::Preferences
 
         return val
       else
-        return fallback
+        yield
       end
     end
+    alias_method :fetch, :get
 
     def delete(key)
       @cache.delete(key)

--- a/core/db/migrate/20140106065820_remove_value_type_from_spree_preferences.rb
+++ b/core/db/migrate/20140106065820_remove_value_type_from_spree_preferences.rb
@@ -1,0 +1,8 @@
+class RemoveValueTypeFromSpreePreferences < ActiveRecord::Migration
+  def up
+    remove_column :spree_preferences, :value_type
+  end
+  def down
+    raise ActiveRecord::IrreversableMigration
+  end
+end

--- a/core/db/migrate/20140227112348_add_preference_store_to_everything.rb
+++ b/core/db/migrate/20140227112348_add_preference_store_to_everything.rb
@@ -1,0 +1,8 @@
+class AddPreferenceStoreToEverything < ActiveRecord::Migration
+  def change
+    add_column :spree_calculators, :preferences, :text
+    add_column :spree_gateways, :preferences, :text
+    add_column :spree_payment_methods, :preferences, :text
+    add_column :spree_promotion_rules, :preferences, :text
+  end
+end

--- a/core/db/migrate/20140309023735_migrate_old_preferences.rb
+++ b/core/db/migrate/20140309023735_migrate_old_preferences.rb
@@ -1,0 +1,23 @@
+class MigrateOldPreferences < ActiveRecord::Migration
+  def up
+    migrate_preferences(Spree::Calculator)
+    migrate_preferences(Spree::PaymentMethod)
+    migrate_preferences(Spree::PromotionRule)
+  end
+
+  def down
+  end
+
+  private
+  def migrate_preferences klass
+    klass.reset_column_information
+    klass.find_each do |record|
+      store = Spree::Preferences::ScopedStore.new(record.class.name.underscore, record.id)
+      record.defined_preferences.each do |key|
+        value = store.fetch(key){}
+        record.preferences[key] = value unless value.nil?
+      end
+      record.save!
+    end
+  end
+end

--- a/core/lib/spree/core/calculated_adjustments.rb
+++ b/core/lib/spree/core/calculated_adjustments.rb
@@ -3,7 +3,7 @@ module Spree
     module CalculatedAdjustments
       def self.included(klass)
         klass.class_eval do
-          has_one   :calculator, :class_name => "Spree::Calculator", :as => :calculable, :dependent => :destroy
+          has_one   :calculator, class_name: "Spree::Calculator", as: :calculable, inverse_of: :calculable, dependent: :destroy, autosave: true
           accepts_nested_attributes_for :calculator
           validates :calculator, :presence => true
 

--- a/core/lib/spree/testing_support/factories/promotion_factory.rb
+++ b/core/lib/spree/testing_support/factories/promotion_factory.rb
@@ -10,9 +10,7 @@ FactoryGirl.define do
       after(:create) do |promotion, evaluator|
         calculator = Spree::Calculator::FlatRate.new
         calculator.preferred_amount = evaluator.adjustment_rate
-        action = Spree::Promotion::Actions::CreateItemAdjustments.create(:calculator => calculator)
-        promotion.actions << action
-        promotion.save
+        Spree::Promotion::Actions::CreateItemAdjustments.create!(calculator: calculator, promotion: promotion)
       end
     end
 

--- a/core/spec/models/spree/preference_spec.rb
+++ b/core/spec/models/spree/preference_spec.rb
@@ -5,16 +5,14 @@ describe Spree::Preference do
   it "should require a key" do
     @preference = Spree::Preference.new
     @preference.key = :test
-    @preference.value_type = :boolean
     @preference.value = true
     @preference.should be_valid
   end
 
   describe "type coversion for values" do
-    def round_trip_preference(key, value, value_type)
+    def round_trip_preference(key, value)
       p = Spree::Preference.new
       p.value = value
-      p.value_type = value_type
       p.key = key
       p.save
 
@@ -22,75 +20,59 @@ describe Spree::Preference do
     end
 
     it ":boolean" do
-      value_type = :boolean
       value = true
       key = "boolean_key"
-      pref = round_trip_preference(key, value, value_type)
+      pref = round_trip_preference(key, value)
       pref.value.should eq value
-      pref.value_type.should == value_type.to_s
     end
 
     it "false :boolean" do
-      value_type = :boolean
       value = false
       key = "boolean_key"
-      pref = round_trip_preference(key, value, value_type)
+      pref = round_trip_preference(key, value)
       pref.value.should eq value
-      pref.value_type.should == value_type.to_s
     end
 
     it ":integer" do
-      value_type = :integer
       value = 10
       key = "integer_key"
-      pref = round_trip_preference(key, value, value_type)
+      pref = round_trip_preference(key, value)
       pref.value.should eq value
-      pref.value_type.should == value_type.to_s
     end
 
     it ":decimal" do
-      value_type = :decimal
       value = 1.5
       key = "decimal_key"
-      pref = round_trip_preference(key, value, value_type)
+      pref = round_trip_preference(key, value)
       pref.value.should eq value
-      pref.value_type.should == value_type.to_s
     end
 
     it ":string" do
-      value_type = :string
       value = "This is a string"
       key = "string_key"
-      pref = round_trip_preference(key, value, value_type)
+      pref = round_trip_preference(key, value)
       pref.value.should eq value
-      pref.value_type.should == value_type.to_s
     end
 
     it ":text" do
-      value_type = :text
       value = "This is a string stored as text"
       key = "text_key"
-      pref = round_trip_preference(key, value, value_type)
+      pref = round_trip_preference(key, value)
       pref.value.should eq value
-      pref.value_type.should == value_type.to_s
     end
 
     it ":password" do
-      value_type = :password
       value = "This is a password"
       key = "password_key"
-      pref = round_trip_preference(key, value, value_type)
+      pref = round_trip_preference(key, value)
       pref.value.should eq value
-      pref.value_type.should == value_type.to_s
     end
 
     it ":any" do
-      value_type = :any
       value = [1, 2]
       key = "any_key"
-      pref = round_trip_preference(key, value, value_type)
+      pref = round_trip_preference(key, value)
       pref.value.should eq value
-      pref.value_type.should == value_type.to_s
     end
 
   end

--- a/core/spec/models/spree/preferences/configuration_spec.rb
+++ b/core/spec/models/spree/preferences/configuration_spec.rb
@@ -9,23 +9,6 @@ describe Spree::Preferences::Configuration do
     @config = AppConfig.new
   end
 
-  # Regression test for #3831
-  context "with a rails cache id set" do
-    before do
-      @config.stub :rails_cache_id => "cache"
-    end
-
-    it "can access the preference cache key" do
-      expect(@config.preference_cache_key("foo")).to eql("cache/app_config/foo")
-    end
-  end
-
-  context "with no rails cache id set" do
-    it "does not prefix the preference cache key with a slash" do
-      expect(@config.preference_cache_key("foo")).to eql("app_config/foo")
-    end
-  end
-
   it "has named methods to access preferences" do
     @config.color = 'orange'
     @config.color.should eq 'orange'

--- a/core/spec/models/spree/preferences/preferable_spec.rb
+++ b/core/spec/models/spree/preferences/preferable_spec.rb
@@ -11,6 +11,10 @@ describe Spree::Preferences::Preferable do
         @id = rand(999)
       end
 
+      def preferences
+        @preferences ||= default_preferences
+      end
+
       preference :color, :string, :default => 'green'
     end
 
@@ -101,6 +105,13 @@ describe Spree::Preferences::Preferable do
       @b.preferred_flavor = :strawberry
       @b.preferences[:flavor].should eq 'strawberry'
       @b.preferences[:color].should eq 'green' #default from A
+    end
+
+    it "builds a hash of preference defaults" do
+      @b.default_preferences.should eq({
+        flavor: nil,
+        color: 'green'
+      })
     end
 
     context "converts integer preferences to integer values" do
@@ -196,6 +207,7 @@ describe Spree::Preferences::Preferable do
         def self.up
           create_table :pref_tests do |t|
             t.string :col
+            t.text :preferences
           end
         end
 

--- a/core/spec/models/spree/preferences/preferable_spec.rb
+++ b/core/spec/models/spree/preferences/preferable_spec.rb
@@ -11,7 +11,7 @@ describe Spree::Preferences::Preferable do
         @id = rand(999)
       end
 
-      preference :color, :string, :default => 'green', :description => "My Favorite Color"
+      preference :color, :string, :default => 'green'
     end
 
     class B < A
@@ -89,11 +89,6 @@ describe Spree::Preferences::Preferable do
       @a.preference_default(:color).should eq 'green'
     end
 
-    it "has a description" do
-      @a.preferred_color_description.should eq "My Favorite Color"
-      @a.preference_description(:color).should eq "My Favorite Color"
-    end
-
     it "raises if not defined" do
       expect {
         @a.get_preference :flavor
@@ -106,15 +101,6 @@ describe Spree::Preferences::Preferable do
     it "handles ghost methods for preferences" do
       @a.preferred_color = 'blue'
       @a.preferred_color.should eq 'blue'
-
-      @a.prefers_color = 'green'
-      @a.prefers_color?.should eq 'green'
-    end
-
-    it "has genric readers" do
-      @a.preferred_color = 'red'
-      @a.prefers?(:color).should eq 'red'
-      @a.preferred(:color).should eq 'red'
     end
 
     it "parent and child instances have their own prefs" do
@@ -336,14 +322,6 @@ describe Spree::Preferences::Preferable do
 
   it "builds cache keys" do
     @a.preference_cache_key(:color).should match /a\/color\/\d+/
-  end
-
-  it "can add and remove preferences" do
-    A.preference :test_temp, :boolean, :default => true
-    @a.preferred_test_temp.should be_true
-    A.remove_preference :test_temp
-    @a.has_preference?(:test_temp).should be_false
-    @a.respond_to?(:preferred_test_temp).should be_false
   end
 
 end

--- a/core/spec/models/spree/preferences/scoped_store_spec.rb
+++ b/core/spec/models/spree/preferences/scoped_store_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+describe Spree::Preferences::ScopedStore do
+  let(:scoped_store){ described_class.new(prefix, suffix) }
+  subject{ scoped_store }
+  let(:prefix){ nil }
+  let(:suffix){ nil }
+
+  describe '#store' do
+    subject{ scoped_store.store }
+    it{ should be Spree::Preferences::Store.instance }
+  end
+
+  context 'stubbed store' do
+    let(:store){ double(:store) }
+    before do
+      scoped_store.stub(:store).and_return(store)
+    end
+
+    context "with a prefix" do
+      let(:prefix){ 'my_class' }
+
+      it "can fetch" do
+        expect(store).to receive(:fetch).with('my_class/attr')
+        scoped_store.fetch('attr'){ 'default' }
+      end
+
+      it "can assign" do
+        expect(store).to receive(:[]=).with('my_class/attr', 'val')
+        scoped_store['attr'] = 'val'
+      end
+
+      it "can delete" do
+        expect(store).to receive(:delete).with('my_class/attr')
+        scoped_store.delete('attr')
+      end
+
+      context "and suffix" do
+        let(:suffix){ 123 }
+
+        it "can fetch" do
+          expect(store).to receive(:fetch).with('my_class/attr/123')
+          scoped_store.fetch('attr'){ 'default' }
+        end
+
+        it "can assign" do
+          expect(store).to receive(:[]=).with('my_class/attr/123', 'val')
+          scoped_store['attr'] = 'val'
+        end
+
+        it "can delete" do
+          expect(store).to receive(:delete).with('my_class/attr/123')
+          scoped_store.delete('attr')
+        end
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/preferences/store_spec.rb
+++ b/core/spec/models/spree/preferences/store_spec.rb
@@ -6,20 +6,19 @@ describe Spree::Preferences::Store do
   end
 
   it "sets and gets a key" do
-    @store.set :test, 1, :integer
+    @store.set :test, 1
     @store.exist?(:test).should be_true
     @store.get(:test).should eq 1
   end
 
   it "can set and get false values when cache return nil" do
-    @store.set :test, false, :boolean
+    @store.set :test, false
     @store.get(:test).should be_false
   end
 
   it "will return db value when cache is emtpy and cache the db value" do
     preference = Spree::Preference.where(:key => 'test').first_or_initialize
     preference.value = '123'
-    preference.value_type = 'string'
     preference.save
 
     Rails.cache.clear

--- a/core/spec/models/spree/preferences/store_spec.rb
+++ b/core/spec/models/spree/preferences/store_spec.rb
@@ -40,7 +40,7 @@ describe Spree::Preferences::Store do
   end
 
   it "should return nil when key can't be found and fallback value is not supplied" do
-    @store.get(:random_key).should be_nil
+    @store.get(:random_key){ nil }.should be_nil
   end
 
 end

--- a/core/spec/models/spree/preferences/store_spec.rb
+++ b/core/spec/models/spree/preferences/store_spec.rb
@@ -28,14 +28,14 @@ describe Spree::Preferences::Store do
 
   it "should return and cache fallback value when supplied" do
     Rails.cache.clear
-    @store.get(:test, false).should be_false
+    @store.get(:test){ false }.should be_false
     Rails.cache.read(:test).should be_false
   end
 
   it "should return but not cache fallback value when persistence is disabled" do
     Rails.cache.clear
     @store.stub(:should_persist? => false)
-    @store.get(:test, true).should be_true
+    @store.get(:test){ true }.should be_true
     Rails.cache.exist?(:test).should be_false
   end
 

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -37,12 +37,13 @@ describe Spree::Promotion do
     end
   end
 
-  describe "#delete" do
+  describe "#destroy" do
     let(:promotion) { Spree::Promotion.create(:name => "delete me") }
 
     before(:each) do
       promotion.actions << Spree::Promotion::Actions::CreateAdjustment.new
       promotion.rules << Spree::Promotion::Rules::FirstOrder.new
+      promotion.save!
       promotion.destroy
     end
 
@@ -52,6 +53,22 @@ describe Spree::Promotion do
 
     it "should delete rules" do
       Spree::PromotionRule.count.should == 0
+    end
+  end
+
+  describe "#save" do
+    let(:promotion) { Spree::Promotion.create(:name => "delete me") }
+
+    before(:each) do
+      promotion.actions << Spree::Promotion::Actions::CreateAdjustment.new
+      promotion.rules << Spree::Promotion::Rules::FirstOrder.new
+      promotion.save!
+    end
+
+    it "should deeply autosave records and preferences" do
+      promotion.actions[0].calculator.preferred_flat_percent = 10
+      promotion.save!
+      Spree::Calculator.first.preferred_flat_percent.should == 10
     end
   end
 

--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -48,7 +48,7 @@ describe "Checkout", inaccessible: true do
     # Regression test for #1596
     context "full checkout" do
       before do
-        shipping_method.calculator.preferred_amount = 10
+        shipping_method.calculator.update!(preferred_amount: 10)
         mug.shipping_category = shipping_method.shipping_categories.first
         mug.save!
       end


### PR DESCRIPTION
Hijacking the previous PR into a larger preferences refactor. This will depend on two other pull-requests, #4383 and #4337.
### Contains the following changes
- Moves preferences defined on a record (as opposed to `Spree::Config`) to a serialized `preferences` column.
- allows preferences' defaults to be defined as a proc
- remove a bunch of unused preference methods
- removes the value_type column. Performing a typecast as values are loaded from the table is unnecessary, as they are already being deserialized into the correct type.
### Still TODO
- [x] Migrate existing settings onto the serialized columns
- [x] Document the changes in the CHANGELOG and release notes
- [x] A few weird corner cases need better specs (caught in specs outside core) and an apparent rails bug needs investigation (which has a workaround in place for now)
