### PR TITLE
Switch backend specs to use poltergeist

### DIFF
--- a/backend/app/views/spree/admin/shared/_destroy.js.erb
+++ b/backend/app/views/spree/admin/shared/_destroy.js.erb
@@ -1,6 +1,5 @@
 <% success = flash.discard(:success)
 if success %>
-  console.log(show_flash)
   show_flash('success', "<%= success %>")
 <% end %>
 

--- a/backend/spec/features/admin/configuration/countries_spec.rb
+++ b/backend/spec/features/admin/configuration/countries_spec.rb
@@ -12,8 +12,9 @@ module Spree
       fill_in "Iso Name", with: "BRL"
       click_button "Create"
 
-      click_icon :trash
-      page.driver.browser.switch_to.alert.accept
+      accept_alert do
+        click_icon :trash
+      end
       wait_for_ajax
 
       expect { Country.find(country.id) }.to raise_error

--- a/backend/spec/features/admin/configuration/stock_locations_spec.rb
+++ b/backend/spec/features/admin/configuration/stock_locations_spec.rb
@@ -25,8 +25,9 @@ describe "Stock Locations" do
     visit current_path
 
     find('#listing_stock_locations').should have_content("NY Warehouse")
-    click_icon :trash
-    page.driver.browser.switch_to.alert.accept
+    accept_alert do
+      click_icon :trash
+    end
     # Wait for API request to complete.
     wait_for_ajax
     visit current_path 

--- a/backend/spec/features/admin/orders/adjustments_promotions_spec.rb
+++ b/backend/spec/features/admin/orders/adjustments_promotions_spec.rb
@@ -40,10 +40,12 @@ describe "Adjustments Promotions" do
 
     context "for already applied promotion" do
       it "should show an error message", :js => true do
-        2.times {
-          fill_in "coupon_code", :with => "10_off"
-          click_button "Add Coupon Code"
-        }
+        fill_in "coupon_code", :with => "10_off"
+        click_button "Add Coupon Code"
+        page.should have_content('-$10.00')
+
+        fill_in "coupon_code", :with => "10_off"
+        click_button "Add Coupon Code"
         page.should have_content("already been applied")
       end
     end

--- a/backend/spec/features/admin/orders/adjustments_spec.rb
+++ b/backend/spec/features/admin/orders/adjustments_spec.rb
@@ -118,7 +118,7 @@ describe "Adjustments" do
         end
       end
 
-      page.should have_content("TOTAL: $170.00")
+      page.should have_content(/TOTAL: ?\$170\.00/)
     end
   end
 end

--- a/backend/spec/features/admin/orders/adjustments_spec.rb
+++ b/backend/spec/features/admin/orders/adjustments_spec.rb
@@ -112,9 +112,10 @@ describe "Adjustments" do
     end
 
     it "should update the total", :js => true do
-      within_row(2) do
-        click_icon(:trash)
-        page.driver.browser.switch_to.alert.accept
+      accept_alert do
+        within_row(2) do
+          click_icon(:trash)
+        end
       end
 
       page.should have_content("TOTAL: $170.00")

--- a/backend/spec/features/admin/orders/line_items_spec.rb
+++ b/backend/spec/features/admin/orders/line_items_spec.rb
@@ -23,8 +23,12 @@ describe "Order Line Items", js: true do
         find(".edit-line-item").click
         fill_in "quantity", :with => 10
         find(".save-line-item").click
-        page.should have_content("10", :css => ".line-item-qty-show")
-        page.should have_content("$100.00", :css => ".line-item-total")
+        within '.line-item-qty-show' do
+          page.should have_content("10")
+        end
+        within '.line-item-total' do
+          page.should have_content("$100.00")
+        end
       end
     end
   end

--- a/backend/spec/features/admin/orders/line_items_spec.rb
+++ b/backend/spec/features/admin/orders/line_items_spec.rb
@@ -36,8 +36,9 @@ describe "Order Line Items", js: true do
 
     within(".line-items") do
       within_row(1) do
-        find(".delete-line-item").click
-        page.driver.browser.switch_to.alert.accept
+        accept_alert do
+          find(".delete-line-item").click
+        end
       end
     end
 

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -52,11 +52,12 @@ describe "Order Details", js: true do
         page.should have_content("spree t-shirt")
 
         within_row(1) do
-          click_icon :trash
+          accept_alert do
+            click_icon :trash
+          end
         end
 
         # Click "ok" on confirmation dialog
-        page.driver.browser.switch_to.alert.accept
         page.should_not have_content("spree t-shirt")
       end
 
@@ -65,11 +66,12 @@ describe "Order Details", js: true do
         page.should have_content("spree t-shirt")
 
         within_row(1) do
-          click_icon :trash
+          # Click "cancel" on confirmation dialog
+          dismiss_alert do
+            click_icon :trash
+          end
         end
 
-        # Click "cancel" on confirmation dialog
-        page.driver.browser.switch_to.alert.dismiss
         page.should have_content("spree t-shirt")
       end
 

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -62,7 +62,7 @@ describe "Order Details", js: true do
       end
 
       # Regression test for #3862
-      it "can remove an item from a shipment" do
+      it "can cancel removing an item from a shipment" do
         page.should have_content("spree t-shirt")
 
         within_row(1) do

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -151,8 +151,8 @@ describe "Order Details", js: true do
               click_icon :ok
             end
 
-            wait_for_ajax
-            page.should have_content("TOTAL: $100.00")
+            # poltergeist and selenium disagree on the existance of this space
+            page.should have_content(/TOTAL: ?\$100\.00/)
           end
 
           it "can add tracking information for the second shipment" do

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -131,7 +131,12 @@ describe 'Payments' do
       it 'allows the amount change to be cancelled by clicking on the cancel button' do
         within_row(1) do
           click_icon(:edit)
-          fill_in('amount', with: '$1')
+
+          # Can't use fill_in here, as under poltergeist that will unfocus (and
+          # thus submit) the field under poltergeist
+          find('td.amount input').click
+          page.execute_script("$('td.amount input').val('$1')")
+
           click_icon(:cancel)
           page.should have_selector('td.amount span', text: '$150.00')
           payment.reload.amount.should == 150.00

--- a/backend/spec/features/admin/products/edit/images_spec.rb
+++ b/backend/spec/features/admin/products/edit/images_spec.rb
@@ -33,8 +33,9 @@ describe "Product Images" do
       page.should have_content("successfully updated!")
       page.should have_content("ruby on rails t-shirt")
 
-      click_icon :trash
-      page.driver.browser.switch_to.alert.accept
+      accept_alert do
+        click_icon :trash
+      end
       page.should_not have_content("ruby on rails t-shirt")
     end
   end

--- a/backend/spec/features/admin/products/edit/products_spec.rb
+++ b/backend/spec/features/admin/products/edit/products_spec.rb
@@ -55,8 +55,11 @@ describe 'Product Details' do
       create(:product)
 
       visit spree.admin_products_path
-      within_row(1) { click_icon :trash }
-      page.driver.browser.switch_to.alert.accept
+      within_row(1) do
+        accept_alert do
+          click_icon :trash
+        end
+      end
       wait_for_ajax
     end
   end

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -321,7 +321,7 @@ describe "Products" do
 
         page.all('tr.product_property').size > 1
         within(:css, "tr.product_property:first-child") do
-          first('input[type=text]')[:value].should eq('baseball_cap_color')
+          first('input[type=text]').value.should eq('baseball_cap_color')
         end
       end
     end

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -331,8 +331,9 @@ describe "Products" do
 
       it "is still viewable" do
         visit spree.admin_products_path
-        click_icon :trash
-        page.driver.browser.switch_to.alert.accept
+        accept_alert do
+          click_icon :trash
+        end
         # This will show our deleted product
         click_button "Search"
         click_link product.name

--- a/backend/spec/features/admin/products/properties_spec.rb
+++ b/backend/spec/features/admin/products/properties_spec.rb
@@ -73,7 +73,7 @@ describe "Properties" do
       fill_in_property
       # Sometimes the page doesn't load before the all check is done
       # lazily finding the element gives the page 10 seconds
-      page.should have_css("tbody#product_properties")
+      page.should have_css("tbody#product_properties tr:nth-child(2)")
       all("tbody#product_properties tr").count.should == 2
 
       page.evaluate_script('window.confirm = function() { return true; }')

--- a/backend/spec/features/admin/products/properties_spec.rb
+++ b/backend/spec/features/admin/products/properties_spec.rb
@@ -78,6 +78,7 @@ describe "Properties" do
 
       page.evaluate_script('window.confirm = function() { return true; }')
       click_icon :trash
+      wait_for_ajax # delete action must finish before reloading
       click_link "Product Properties"
       page.should have_css("tbody#product_properties")
       all("tbody#product_properties tr").count.should == 1

--- a/backend/spec/features/admin/products/stock_management_spec.rb
+++ b/backend/spec/features/admin/products/stock_management_spec.rb
@@ -26,6 +26,7 @@ describe "Stock Management" do
       before do
         backorderable.should be_checked
         backorderable.set(false)
+        wait_for_ajax
       end
 
       it "persists the value when page reload", js: true do

--- a/backend/spec/features/admin/promotion_adjustments_spec.rb
+++ b/backend/spec/features/admin/promotion_adjustments_spec.rb
@@ -196,13 +196,10 @@ describe "Promotion Adjustments" do
       select2 "Create line items", :from => "Add action of type"
 
       within('#action_fields') { click_button "Add" }
-      # Forced narcolepsy, thanks to JavaScript
-      sleep(1)
-      page.execute_script "$('.create_line_items .select2-choice').mousedown();"
-      sleep(1)
-      page.execute_script "$('.select2-input:visible').val('RoR Mug').trigger('keyup-change');"
-      sleep(1)
-      page.execute_script "$('.select2-highlighted').mouseup();"
+
+      page.find('.create_line_items .select2-choice').click
+      page.find('.select2-input').set('RoR Mug')
+      page.find('.select2-highlighted').click
 
       within('#actions_container') { click_button "Update" }
 

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -74,6 +74,9 @@ RSpec.configure do |config|
   end
 
   config.after(:each) do
+    # Ensure js requests finish processing before advancing to the next test
+    wait_for_ajax if example.metadata[:js]
+
     DatabaseCleaner.clean
   end
 

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -42,6 +42,9 @@ require 'spree/testing_support/capybara_ext'
 
 require 'paperclip/matchers'
 
+require 'capybara/poltergeist'
+Capybara.javascript_driver = :poltergeist
+
 RSpec.configure do |config|
   config.color = true
   config.mock_with :rspec

--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -28,5 +28,5 @@ group :test do
   gem 'selenium-webdriver', '~> 2.35'
   gem 'simplecov'
   gem 'webmock', '1.8.11'
-  gem 'poltergeist', '1.4.1'
+  gem 'poltergeist', '1.5.0'
 end

--- a/core/lib/spree/testing_support/capybara_ext.rb
+++ b/core/lib/spree/testing_support/capybara_ext.rb
@@ -103,7 +103,7 @@ module CapybaraExt
 
   def wait_for_ajax
     counter = 0
-    while page.evaluate_script("$.active").to_i > 0
+    while page.evaluate_script("typeof($) === 'undefined' || $.active > 0")
       counter += 1
       sleep(0.1)
       raise "AJAX request took longer than 5 seconds." if counter >= 50

--- a/core/lib/spree/testing_support/capybara_ext.rb
+++ b/core/lib/spree/testing_support/capybara_ext.rb
@@ -109,6 +109,28 @@ module CapybaraExt
       raise "AJAX request took longer than 5 seconds." if counter >= 50
     end
   end
+
+  def accept_alert
+    if page.driver === Capybara::Selenium::Driver
+      yield
+      page.driver.browser.switch_to.alert.accept
+    else
+      page.evaluate_script('window.confirm = function() { return true; }')
+      yield
+    end
+  end
+  def dismiss_alert
+    if page.driver === Capybara::Selenium::Driver
+      yield
+      page.driver.browser.switch_to.alert.dismiss
+    else
+      page.evaluate_script('window.confirm = function() { return false; }')
+      yield
+
+      # Restore existing default
+      page.evaluate_script('window.confirm = function() { return true; }')
+    end
+  end
 end
 
 Capybara.configure do |config|


### PR DESCRIPTION
:ghost:

Using poltergeist should (hopefully) be faster, more consistent, and more convenient for developers (no need for Xvfb).

For the most part, the changes needed were minimal and made the specs better. specs should all still run properly under selenium.

In a (unscientific) test on my work desktop, this speed up `rspec` in backend from ~4m30s to ~3m30s
