### PR TITLE
Update to support new Universal Analytics

### DIFF
--- a/frontend/app/views/spree/shared/_google_analytics.html.erb
+++ b/frontend/app/views/spree/shared/_google_analytics.html.erb
@@ -5,7 +5,7 @@
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-    ga('create', '<%= tracker.analytics_id %>');
+    ga('create', '<%= tracker.analytics_id %>','<%= Spree::Config[:site_url].sub!(/^www./,'') %>');
     ga('send', 'pageview');
 
     <% if flash[:commerce_tracking] && @order.present? %>


### PR DESCRIPTION
This change is backwards compatible and supports the new ga universal analytics site property id. GA sets this to the base domain name minus www. https://developers.google.com/analytics/devguides/collection/upgrade/?hl=en_US
