### PR TITLE
fix _taxonomies.html.erb cache key

### DIFF
--- a/frontend/app/views/spree/shared/_taxonomies.html.erb
+++ b/frontend/app/views/spree/shared/_taxonomies.html.erb
@@ -1,8 +1,9 @@
+<% max_level = Spree::Config[:max_level_in_taxons_menu] || 1 %>
 <nav id="taxonomies" class="sidebar-item" data-hook>
   <% @taxonomies.each do |taxonomy| %>
-    <% cache taxonomy do %>
+    <% cache [taxonomy, max_level] do %>
       <h6 class='taxonomy-root'><%= Spree.t(:shop_by_taxonomy, :taxonomy => taxonomy.name) %></h6>
-      <%= taxons_tree(taxonomy.root, @taxon, Spree::Config[:max_level_in_taxons_menu] || 1) %>
+      <%= taxons_tree(taxonomy.root, @taxon, max_level) %>
     <% end %>
   <% end %>
 </nav>

--- a/frontend/spec/features/caching/taxons_spec.rb
+++ b/frontend/spec/features/caching/taxons_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe 'taxons', :caching => true do
+  let!(:taxonomy) { create(:taxonomy) }
+  let!(:taxon) { create(:taxon, :taxonomy => taxonomy) }
+
+  before do
+    # warm up the cache
+    visit spree.root_path
+    assert_written_to_cache("views/spree/taxonomies/#{taxonomy.id}")
+    assert_written_to_cache("views/taxons/#{taxon.updated_at.utc.to_i}")
+
+    clear_cache_events
+  end
+
+  it "busts the cache when max_level_in_taxons_menu conf changes" do
+    Spree::Config[:max_level_in_taxons_menu] = 5
+    visit spree.root_path
+    assert_written_to_cache("views/spree/taxonomies/#{taxonomy.id}")
+    expect(cache_writes.count).to eq(1)
+  end
+end


### PR DESCRIPTION
by adding in the cache key a config value used inside the cache block
ref https://github.com/spree/spree/commit/b2b476df66e17fe24b2bb56e3e05cae78879369d#commitcomment-5550037
