### PR TITLE
Include fontawesome on the list of assets to precompile

### DIFF
--- a/backend/lib/spree/backend/engine.rb
+++ b/backend/lib/spree/backend/engine.rb
@@ -21,6 +21,7 @@ module Spree
           jqPlot/excanvas.min.js
           spree/backend/images/new.js
           jquery.jstree/themes/apple/*
+          fontawesome-webfont*
         ]
       end
     end


### PR DESCRIPTION
When you deploy to a production environment, using rake assets:precompile does not include the fontawesome files and backend icons on the admin side are not showing up.

I've only recently started using spree, so there might be a legitimate reason behind why it was left behind.

In any case, this fixed the problem for me.
