### PR TITLE
Don't allow line items for a completed order to be created, updated or d...

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -22,6 +22,9 @@ module Spree
     validates :price, numericality: true
     validates_with Stock::AvailabilityValidator
 
+    validate :order_cannot_be_completed
+    before_destroy :order_cannot_be_completed
+
     validate :ensure_proper_currency
     before_destroy :update_inventory
 
@@ -123,6 +126,15 @@ module Spree
       def ensure_proper_currency
         unless currency == order.currency
           errors.add(:currency, t(:must_match_order_currency))
+        end
+      end
+
+      def order_cannot_be_completed
+        if order.completed?
+          errors.add(:base, :line_items_frozen_for_completed_orders)
+          false
+        else
+          true
         end
       end
   end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -231,6 +231,8 @@ en:
               card_expired: "Card has expired"
         spree/line_item:
           attributes:
+            base:
+              line_items_frozen_for_completed_orders: "Line items are frozen for completed orders"
             currency:
               must_match_order_currency: "Must match order currency"
   devise:


### PR DESCRIPTION
...estroyed

This is an attempt to fix a problem discussed in IRC where a line item can be added or removed from a completed order via the api, causing the order to change from completed to an address state, and causing all shipments to be removed from the order.

This appears to create multiple other test failures, however, I will be offline for a few days so I figured I'd provide this to the community as an initial pass.
