### PR TITLE
Improve support for cc data encrypted on client (browsers)

### DIFF
--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -159,7 +159,8 @@ module Spree
       end
 
       def create_payment_profile
-        return unless source.is_a?(CreditCard) && source.number && !source.has_payment_profile?
+        return unless source.respond_to?(:has_payment_profile?) && !source.has_payment_profile?
+
         payment_method.create_profile(self)
       rescue ActiveMerchant::ConnectionError => e
         gateway_error e

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -69,7 +69,7 @@ module Spree
     @@source_attributes = [
       :number, :month, :year, :expiry, :verification_value,
       :first_name, :last_name, :cc_type, :gateway_customer_profile_id, 
-      :gateway_payment_profile_id, :last_digits, :name]
+      :gateway_payment_profile_id, :last_digits, :name, :encrypted_data]
 
     @@stock_item_attributes = [:variant, :stock_location, :backorderable, :variant_id]
 

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -126,6 +126,15 @@ describe Spree::CreditCard do
       credit_card.save
       credit_card.should be_valid
     end
+
+    context "encrypted data is present" do
+      it "does not validate presence of number or cvv" do
+        credit_card.encrypted_data = "$fdgsfgdgfgfdg&gfdgfdgsf-"
+        credit_card.valid?
+        expect(credit_card.errors[:number]).to be_empty
+        expect(credit_card.errors[:verification_value]).to be_empty
+      end
+    end
   end
 
   context "#save" do


### PR DESCRIPTION
Some users might choose to encrypt cc info on client side and not record
anything related to credit card at all on db. See Adyen Client-Side Encryption
for example.

I believe we could move on here and make some other attributes also not required when encrypted data is present. Motivation here is I'm working with this gateway which does not send cc number, verification value instead it send all cc info encrypted in one string. In that case the CreditCard model would hold profile ids only. And I really didn't want to create another model to handle that. CreditCard could support both scenarios imo.

Any thoughts against this? Should merge it soon in case no issues come up.
