### PR TITLE
Fixed problem with entitlements check

### DIFF
--- a/backend/app/views/spree/admin/shared/_order_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_order_tabs.html.erb
@@ -47,7 +47,7 @@
           <%= link_to_with_icon 'icon-edit', Spree.t(:order_details), edit_admin_order_url(@order) %>
         </li>
       <% end %>
-      <% if can? :update, @order && checkout_steps.include?("address") %>
+      <% if can?(:update, @order) && checkout_steps.include?("address") %>
         <li<%== ' class="active"' if current == 'Customer Details' %>>
           <%= link_to_with_icon 'icon-user', Spree.t(:customer_details), admin_order_customer_url(@order) %>
         </li>
@@ -57,7 +57,7 @@
           <%= link_to_with_icon 'icon-cogs', Spree.t(:adjustments), admin_order_adjustments_url(@order) %>
         </li>
       <% end %>
-      <% if can? :index, Spree::Payment && @payment_required %>
+      <% if can?(:index, Spree::Payment) && @payment_required %>
         <li<%== ' class="active"' if current == 'Payments' %>>
           <%= link_to_with_icon 'icon-credit-card', Spree.t(:payments), admin_order_payments_url(@order) %>
         </li>


### PR DESCRIPTION
This pull requests fixes the problem with entitlements check while editing order from admin interface. The problem is that the wrong object is passed to can-can ability verifier.

I can see that this problem is already fixed in the latest code, but branch 2-0-stable still has this bug and would be good to have this feature fixed.
