### PR TITLE
add missing model translation.

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -189,6 +189,9 @@ en:
       spree/state:
         one: State
         other: States
+      spree/stock_movement:
+        one: Stock Movement
+        other: Stock Movements
       spree/stock_location:
         one: Stock Location
         other: Stock Locations


### PR DESCRIPTION
After installing a fresh 2.2.0 shop i came across this message:

```
NO TRANSLATION MISSING: EN.ACTIVERECORD.MODELS.SPREE/STOCK_MOVEMENT.OTHER FOUND, ADD ONE!
```
