### PR TITLE
Remember customer credit cards on checkout

### DIFF
--- a/backend/app/controllers/spree/admin/payments_controller.rb
+++ b/backend/app/controllers/spree/admin/payments_controller.rb
@@ -19,8 +19,8 @@ module Spree
 
       def create
         @payment = @order.payments.build(object_params)
-        if @payment.payment_method.is_a?(Spree::Gateway) && @payment.payment_method.payment_profiles_supported? && params[:card].present? and params[:card] != 'new'
-          @payment.source = CreditCard.find_by_id(params[:card])
+        if params[:card].present? and params[:card] != 'new'
+          @payment.source = @payment.payment_method.payment_source_class.find_by_id(params[:card])
         end
 
         begin

--- a/backend/app/views/spree/admin/payments/_form.html.erb
+++ b/backend/app/views/spree/admin/payments/_form.html.erb
@@ -26,7 +26,7 @@
             <% if method.source_required? %>
               <br />
               <%= render :partial => "spree/admin/payments/source_forms/#{method.method_type}",
-                         :locals => { :payment_method => method, previous_cards: method.sources_by_order(@order) } %>
+                         :locals => { :payment_method => method, previous_cards: method.sources_with_profile(@order) } %>
             <% end %>
           </div>
         <% end %>

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -169,10 +169,10 @@ describe 'Payments' do
 
   context "with no prior payments" do
     let(:order) { create(:order_with_line_items, :line_items_count => 1) }
+    let!(:payment_method) { create(:credit_card_payment_method)}
 
     # Regression tests for #4129
     context "with a credit card payment method" do
-      let!(:payment_method) { create(:credit_card_payment_method)}
       before do
         visit spree.admin_order_payments_path(order)
       end
@@ -197,6 +197,20 @@ describe 'Payments' do
         page.should have_content("Verification Value can't be blank")
         page.should have_content("Month is not a number")
         page.should have_content("Year is not a number")
+      end
+    end
+
+    context "user existing card" do
+      let!(:cc) do
+        create(:credit_card, user_id: order.user_id, payment_method: payment_method, gateway_customer_profile_id: "BGS-RFRE")
+      end
+
+      before { visit spree.admin_order_payments_path(order) }
+
+      it "is able to reuse customer payment source" do
+        expect(find("#card_#{cc.id}")).to be_checked
+        click_button "Continue"
+        page.should have_content("Payment has been successfully created!")
       end
     end
   end

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Spree 2.3.0 (unreleased) ##
 
-### Preferences Refactoring
+### Major
+
+#### Preferences Refactoring
 
 Preferences defined on ActiveRecord objects are now stored on the same table.
 This is done by adding a preferences column which is serialized via
@@ -22,3 +24,13 @@ Assigning `calculator.preferred_amount = 10` will not update the database
 record until `calculator.save` is called.
 
 A migration will move existing preferences onto the new column.
+
+### Minor
+
+*   A user_id and payment_method_id column were added to CreditCard. By default
+    both are set when initializing the payment source (via Payment object). That
+    should help improving payment profiles control for both customers and store
+    owners. A Core::UserPaymentSource module was added to exemplify what should
+    be added to the user class to make better use of that feature.
+
+    Washington Luiz

--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -1,5 +1,6 @@
 module Spree
   class CreditCard < Spree::Base
+    belongs_to :payment_method
     has_many :payments, as: :source
 
     before_save :set_last_digits

--- a/core/app/models/spree/gateway.rb
+++ b/core/app/models/spree/gateway.rb
@@ -51,6 +51,14 @@ module Spree
       provider_class.supports?(source.brand)
     end
 
+    def disable_customer_profile(source)
+      if source.is_a? CreditCard
+        source.update_column :gateway_customer_profile_id, nil
+      else
+        raise 'You must implement disable_customer_profile method for this gateway.'
+      end
+    end
+
     def sources_by_order(order)
       source_ids = order.payments.where(source_type: payment_source_class.to_s, payment_method_id: self.id).pluck(:source_id).uniq
       payment_source_class.where(id: source_ids)

--- a/core/app/models/spree/gateway.rb
+++ b/core/app/models/spree/gateway.rb
@@ -61,7 +61,19 @@ module Spree
 
     def sources_by_order(order)
       source_ids = order.payments.where(source_type: payment_source_class.to_s, payment_method_id: self.id).pluck(:source_id).uniq
-      payment_source_class.where(id: source_ids)
+      payment_source_class.where(id: source_ids).with_payment_profile
+    end
+
+    def sources_with_profile(order)
+      if order.completed?
+        sources_by_order order
+      else
+        if order.user_id
+          self.credit_cards.where(user_id: order.user_id).with_payment_profile
+        else
+          []
+        end
+      end
     end
   end
 end

--- a/core/app/models/spree/legacy_user.rb
+++ b/core/app/models/spree/legacy_user.rb
@@ -2,6 +2,7 @@
 module Spree
   class LegacyUser < Spree::Base
     include Core::UserAddress
+    include Core::UserPaymentSource
 
     self.table_name = 'spree_users'
 

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -116,6 +116,8 @@ module Spree
       return if source_attributes.nil?
       if payment_method and payment_method.payment_source_class
         self.source = payment_method.payment_source_class.new(source_attributes)
+        self.source.payment_method_id = payment_method.id
+        self.source.user_id = self.order.user_id if self.order
       end
     end
 

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -9,6 +9,7 @@ module Spree
     validates :name, presence: true
 
     has_many :payments, class_name: "Spree::Payment"
+    has_many :credit_cards, class_name: "Spree::CreditCard"
 
     def self.providers
       Rails.application.config.spree.payment_methods

--- a/core/db/migrate/20140307235515_add_user_id_to_spree_credit_cards.rb
+++ b/core/db/migrate/20140307235515_add_user_id_to_spree_credit_cards.rb
@@ -1,0 +1,13 @@
+class AddUserIdToSpreeCreditCards < ActiveRecord::Migration
+  def change
+    unless Spree::CreditCard.column_names.include? "user_id"
+      add_column :spree_credit_cards, :user_id, :integer
+      add_index :spree_credit_cards, :user_id
+    end
+
+    unless Spree::CreditCard.column_names.include? "payment_method_id"
+      add_column :spree_credit_cards, :payment_method_id, :integer
+      add_index :spree_credit_cards, :payment_method_id
+    end
+  end
+end

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -61,6 +61,7 @@ require 'spree/money'
 
 require 'spree/permitted_attributes'
 require 'spree/core/user_address'
+require 'spree/core/user_payment_source'
 require 'spree/core/delegate_belongs_to'
 require 'spree/core/permalinks'
 require 'spree/core/token_resource'

--- a/core/lib/spree/core/user_payment_source.rb
+++ b/core/lib/spree/core/user_payment_source.rb
@@ -1,0 +1,20 @@
+module Spree
+  module Core
+    module UserPaymentSource
+      extend ActiveSupport::Concern
+
+      included do
+        has_many :credit_cards, class_name: "Spree::CreditCard", foreign_key: :user_id
+
+        def payment_sources
+          credit_cards.with_payment_profile
+        end
+
+        def drop_payment_source(source)
+          gateway = source.payment_method
+          gateway.disable_customer_profile(source)
+        end
+      end
+    end
+  end
+end

--- a/core/lib/spree/testing_support/factories/credit_card_factory.rb
+++ b/core/lib/spree/testing_support/factories/credit_card_factory.rb
@@ -1,10 +1,5 @@
-# allows credit card info to be saved to the database which is needed for factories to work properly
-class TestCard < Spree::CreditCard
-  def remove_readonly_attributes(attributes) attributes; end
-end
-
 FactoryGirl.define do
-  factory :credit_card, class: TestCard do
+  factory :credit_card, class: Spree::CreditCard do
     verification_value 123
     month 12
     year { Time.now.year }

--- a/core/spec/models/spree/gateway/bogus_spec.rb
+++ b/core/spec/models/spree/gateway/bogus_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+module Spree
+  describe Gateway::Bogus do
+    let(:bogus) { create(:credit_card_payment_method) }
+    let!(:cc) { create(:credit_card, payment_method: bogus, gateway_customer_profile_id: "BGS-RERTERT") }
+
+    it "disable recurring contract by destroying payment source" do
+      bogus.disable_customer_profile(cc)
+      expect(cc.gateway_customer_profile_id).to be_nil
+    end
+  end
+end

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -607,8 +607,10 @@ describe Spree::Payment do
   end
 
   describe "#build_source" do
-    it "should build the payment's source" do
-      params = { :amount => 100, :payment_method => gateway,
+    let(:params) do
+      {
+        :amount => 100,
+        :payment_method => gateway,
         :source_attributes => {
           :expiry =>"1 / 99",
           :number => '1234567890123',
@@ -616,10 +618,20 @@ describe Spree::Payment do
           :name => 'Spree Commerce'
         }
       }
+    end
 
+    it "should build the payment's source" do
       payment = Spree::Payment.new(params)
       payment.should be_valid
       payment.source.should_not be_nil
+    end
+
+    it "assigns user and gateway to payment source" do
+      order = create(:order)
+      source = order.payments.new(params).source
+
+      expect(source.user_id).to eq order.user_id
+      expect(source.payment_method_id).to eq gateway.id
     end
 
     it "errors when payment source not valid" do

--- a/core/spec/models/spree/user_spec.rb
+++ b/core/spec/models/spree/user_spec.rb
@@ -41,5 +41,21 @@ describe Spree::LegacyUser do
         expect(user.ship_address_id).not_to be_blank
       end
     end
+
+    context "payment source" do
+      let(:payment_method) { create(:credit_card_payment_method) }
+      let!(:cc) do
+        create(:credit_card, user_id: user.id, payment_method: payment_method, gateway_customer_profile_id: "2342343")
+      end
+
+      it "has payment sources" do
+        expect(user.payment_sources.first.gateway_customer_profile_id).not_to be_empty
+      end
+
+      it "drops payment source" do
+        user.drop_payment_source cc
+        expect(cc.gateway_customer_profile_id).to be_nil
+      end
+    end
   end
 end

--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -1,1 +1,8 @@
 ## Spree 2.3.0 (unreleased) ##
+
+*   Mostly inspired by Jeff Squires extension spree_reuse_credit card, checkout
+    now can remember user credit card info. Make sure your user model responds
+    to a `payment_sources` method and customers will be able to reuse their
+    credit card info.
+
+    Washington Luiz

--- a/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js.coffee
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js.coffee
@@ -1,6 +1,21 @@
 Spree.onPayment = () ->
   if ($ '#checkout_form_payment').is('*')
 
+    if ($ '#existing_cards').is('*')
+      ($ '#payment-method-fields').hide()
+      ($ '#payment-methods').hide()
+
+      ($ '#use_existing_card_yes').click ->
+        ($ '#payment-method-fields').hide()
+        ($ '#payment-methods').hide()
+        ($ '.existing-cc-radio').prop("disabled", false)
+
+      ($ '#use_existing_card_no').click ->
+        ($ '#payment-method-fields').show()
+        ($ '#payment-methods').show()
+        ($ '.existing-cc-radio').prop("disabled", true)
+
+
     $(".cardNumber").payment('formatCardNumber')
     $(".cardExpiry").payment('formatCardExpiry')
     $(".cardCode").payment('formatCardCVC')

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -131,6 +131,10 @@ module Spree
             @order.contents.remove(variant, quantity)
           end
         end
+
+        if try_spree_current_user && try_spree_current_user.respond_to?(:credit_cards)
+          @cards = try_spree_current_user.credit_cards
+        end
       end
 
       def rescue_from_spree_gateway_error(exception)

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -132,8 +132,8 @@ module Spree
           end
         end
 
-        if try_spree_current_user && try_spree_current_user.respond_to?(:credit_cards)
-          @cards = try_spree_current_user.credit_cards
+        if try_spree_current_user && try_spree_current_user.respond_to?(:payment_sources)
+          @payment_sources = try_spree_current_user.payment_sources
         end
       end
 

--- a/frontend/app/views/spree/checkout/_payment.html.erb
+++ b/frontend/app/views/spree/checkout/_payment.html.erb
@@ -2,7 +2,7 @@
   <legend align="center"><%= Spree.t(:payment_information) %></legend>
   <div data-hook="checkout_payment_step">
 
-    <% if @cards.present? %>
+    <% if @payment_sources.present? %>
       <div class="card_options">
         <%= radio_button_tag 'use_existing_card', 'yes', true %>
         <label for="use_existing_card_yes">Use an existing card on file</label>
@@ -15,14 +15,14 @@
         <p class="field" data-hook="existing_cards">
           <table class="existing-credit-card-list">
             <tbody>
-              <% @cards.each do |card| %>
+              <% @payment_sources.each do |card| %>
                 <tr id="<%= dom_id(card,'spree')%>" class="<%= cycle('even', 'odd') %>">
                   <td><%= card.name %></td>
                   <td><%= card.display_number %></td>
                   <td><%= card.month %></td>
                   <td><%= card.year %></td>
                   <td>
-                    <%= radio_button_tag "existing_card", card.id, (card == @cards.first), { class: "existing-cc-radio" }  %>
+                    <%= radio_button_tag "existing_card", card.id, (card == @payment_sources.first), { class: "existing-cc-radio" }  %>
                   </td>
                 </tr>
               <% end %>

--- a/frontend/app/views/spree/checkout/_payment.html.erb
+++ b/frontend/app/views/spree/checkout/_payment.html.erb
@@ -1,6 +1,37 @@
 <fieldset id="payment" data-hook>
   <legend align="center"><%= Spree.t(:payment_information) %></legend>
   <div data-hook="checkout_payment_step">
+
+    <% if @cards.present? %>
+      <div class="card_options">
+        <%= radio_button_tag 'use_existing_card', 'yes', true %>
+        <label for="use_existing_card_yes">Use an existing card on file</label>
+        <br/>
+        <%= radio_button_tag 'use_existing_card', 'no' %>
+        <label for="use_existing_card_no">Use a new card / payment method</label>
+      </div>
+
+      <div id="existing_cards">
+        <p class="field" data-hook="existing_cards">
+          <table class="existing-credit-card-list">
+            <tbody>
+              <% @cards.each do |card| %>
+                <tr id="<%= dom_id(card,'spree')%>" class="<%= cycle('even', 'odd') %>">
+                  <td><%= card.name %></td>
+                  <td><%= card.display_number %></td>
+                  <td><%= card.month %></td>
+                  <td><%= card.year %></td>
+                  <td>
+                    <%= radio_button_tag "existing_card", card.id, (card == @cards.first), { class: "existing-cc-radio" }  %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </p>
+      </div>
+    <% end %>
+
     <div id="payment-method-fields" data-hook>
       <% @order.available_payment_methods.each do |method| %>
       <p>


### PR DESCRIPTION
Mostly inspired by Jeff Squires, @jsqu99, spree_reuse_credit_card extension, see
https://github.com/jsqu99/spree_reuse_credit_card

Once customers enter their cc info and recurring tokens are saved for
those credit cards the store can remember that info and display the
cards back to the customers so they don't have to enter cc info again

![screen shot 2014-03-08 at 1 31 49 am](https://f.cloud.github.com/assets/245662/2364535/5447fdc8-a67b-11e3-92ca-4006dff3337d.png)

This is a work in progress still want to add a couple more tweaks here and of course get some much appreciated feedback.
- [   ] feature specs for reusing cards / not reusing them even then they're present on the page
- [   ] display only cards with a reference token (otherwise I believe the gateway won't know how to reuse them)
- [   ] provide common interface for destroying card info from a customer perspective

My idea here is merge it in both master and 2-2-stable. Please try it out when you have chance. :) All you need is run spree on this branch and add this code somewhere in your rails app (assuming you user class is Spree::User):

``` ruby
Spree::User.has_many :credit_cards
```

Spree backend already offers a very similar feature except that it only remembers credit cards attach to the specific current order.
