### PR TITLE
Create Store model

### DIFF
--- a/backend/app/controllers/spree/admin/general_settings_controller.rb
+++ b/backend/app/controllers/spree/admin/general_settings_controller.rb
@@ -1,10 +1,9 @@
 module Spree
   module Admin
     class GeneralSettingsController < Spree::Admin::BaseController
+      before_filter :set_store
 
       def edit
-        @preferences_general = [:site_name, :default_seo_title, :default_meta_keywords,
-                        :default_meta_description, :site_url]
         @preferences_security = [:allow_ssl_in_production,
                         :allow_ssl_in_staging, :allow_ssl_in_development_and_test,
                         :check_for_spree_alerts]
@@ -16,6 +15,9 @@ module Spree
           next unless Spree::Config.has_preference? name
           Spree::Config[name] = value
         end
+
+        @store.update_attributes store_params
+
         flash[:success] = Spree.t(:successfully_updated, :resource => Spree.t(:general_settings))
 
         redirect_to edit_admin_general_settings_path
@@ -28,6 +30,19 @@ module Spree
           filter_dismissed_alerts
           render :nothing => true
         end
+      end
+
+      private
+      def store_params
+        params.require(:store).permit(permitted_params)
+      end
+
+      def permitted_params
+        Spree::PermittedAttributes.store_attributes
+      end
+
+      def set_store
+        @store = Spree::Store.first
       end
     end
   end

--- a/backend/app/views/spree/admin/general_settings/edit.html.erb
+++ b/backend/app/views/spree/admin/general_settings/edit.html.erb
@@ -8,15 +8,38 @@
   <div id="preferences" data-hook>
 
     <fieldset class="general no-border-top">
-      <% @preferences_general.each do |key|
-          type = Spree::Config.preference_type(key) %>
-          <div class="field">
-            <%= label_tag(key, Spree.t(key)) + tag(:br) if type != :boolean %>
-            <%= preference_field_tag(key, Spree::Config[key], :type => type) %>
-            <%= label_tag(key, Spree.t(key)) + tag(:br) if type == :boolean %>
-          </div>
-      <% end %>
 
+      <%= fields_for :store do |f| %>
+        <div class="field">
+          <%= f.label :name %>
+          <br />
+          <%= f.text_field :name, class: 'fullwidth' %>
+        </div>
+
+        <div class="field">
+          <%= f.label :seo_title %>
+          <br />
+          <%= f.text_field :seo_title, class: 'fullwidth'  %>
+        </div>
+
+        <div class="field">
+          <%= f.label :meta_keywords %>
+          <br />
+          <%= f.text_field :meta_keywords, class: 'fullwidth'  %>
+        </div>
+
+        <div class="field">
+          <%= f.label :meta_description %>
+          <br />
+          <%= f.text_field :meta_description, class: 'fullwidth'  %>
+        </div>
+
+        <div class="field">
+          <%= f.label :url %>
+          <br />
+          <%= f.text_field :url, class: 'fullwidth'  %>
+        </div>
+      <% end %>
 
       <div class="row">
         <div class="alpha six columns">
@@ -88,5 +111,6 @@
 <% end %>
 
 <script>
+  $('#store_default_currency').select2();
   $('#currency').select2();
 </script>

--- a/backend/spec/features/admin/configuration/general_settings_spec.rb
+++ b/backend/spec/features/admin/configuration/general_settings_spec.rb
@@ -4,6 +4,7 @@ describe "General Settings" do
   stub_authorization!
 
   before(:each) do
+    store = create(:store, name: 'Test Store', url: 'test.example.org')
     visit spree.admin_path
     click_link "Configuration"
     click_link "General Settings"
@@ -12,18 +13,18 @@ describe "General Settings" do
   context "visiting general settings (admin)" do
     it "should have the right content" do
       page.should have_content("General Settings")
-      find("#site_name").value.should == "Spree Demo Site"
-      find("#site_url").value.should == "demo.spreecommerce.com"
+      find("#store_name").value.should == "Test Store"
+      find("#store_url").value.should == "test.example.org"
     end
   end
 
   context "editing general settings (admin)" do
     it "should be able to update the site name" do
-      fill_in "site_name", :with => "Spree Demo Site99"
+      fill_in "store_name", :with => "Spree Demo Site99"
       click_button "Update"
 
       assert_successful_update_message(:general_settings)
-      find("#site_name").value.should == "Spree Demo Site99"
+      find("#store_name").value.should == "Spree Demo Site99"
     end
   end
 end

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -100,7 +100,7 @@ module Spree
       site_name: :name,
       site_url: :url,
       default_meta_description: :meta_description,
-      default_meta_keywords: :meta_description,
+      default_meta_keywords: :meta_keywords,
       default_seo_title: :seo_title,
     }
 

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -94,19 +94,6 @@ module Spree
       @searcher_class = sclass
     end
 
-    # This and the two aliases are only required while store prefs are beind deprecated
-    def get_preference name
-      name_sym = name.to_sym
-      if DEPRECATED_STORE_PREFERENCES.include? name_sym
-        ActiveSupport::Deprecation.warn("#{name} is no longer supported on Spree::Config, please access it through #{DEPRECATED_STORE_PREFERENCES[name_sym]} on Spree::Store")
-        default_store.send(DEPRECATED_STORE_PREFERENCES[name_sym])
-      else
-        super(name)
-      end
-    end
-    alias :get :get_preference
-    alias :[] :get_preference
-
     private
     # all the following can be deprecated when store prefs are no longer supported
     DEPRECATED_STORE_PREFERENCES = {
@@ -125,10 +112,11 @@ module Spree
     end
 
     DEPRECATED_STORE_PREFERENCES.each do |old_preference_name, store_method|
-      # support all the old preference methods through get_preference
-      define_method old_preference_name, proc { self.get_preference old_preference_name }
-      # this makes them still look like preferences
-      define_method "preferred_#{old_preference_name.to_s}", proc {}
+      # support all the old preference methods with a warning
+      define_method "preferred_#{old_preference_name}" do
+        ActiveSupport::Deprecation.warn("#{old_preference_name} is no longer supported on Spree::Config, please access it through #{store_method} on Spree::Store")
+        default_store.send(store_method)
+      end
     end
   end
 end

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -1,0 +1,5 @@
+module Spree
+  class Store < ActiveRecord::Base
+    validates :name, :url, :mail_from_address, presence: true
+  end
+end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -99,6 +99,12 @@ en:
       spree/state:
         abbr: Abbreviation
         name: Name
+      spree/store:
+        url: Site URL
+        meta_description: Meta Description
+        meta_keywords: Meta Keywords
+        seo_title: Seo Title
+        name: Site Name
       spree/tax_category:
         description: Description
         name: Name
@@ -522,9 +528,6 @@ en:
       js_format: yy/mm/dd
     date_range: Date Range
     default: Default
-    default_meta_description: Default Meta Description
-    default_meta_keywords: Default Meta Keywords
-    default_seo_title: Default Seo Title
     default_tax: Default Tax
     default_tax_zone: Default Tax Zone
     delete: Delete
@@ -1048,8 +1051,6 @@ en:
     show_deleted: Show Deleted
     show_only_complete_orders: Only show complete orders
     show_rate_in_label: Show rate in label
-    site_name: Site Name
-    site_url: Site URL
     sku: SKU
     slug: Slug
     smtp: SMTP

--- a/core/db/default/spree/stores.rb
+++ b/core/db/default/spree/stores.rb
@@ -1,0 +1,5 @@
+Spree::Store.new do |s|
+  s.name              = 'Spree Demo Site'
+  s.url               = 'demo.spreecommerce.com'
+  s.mail_from_address = 'spree@example.com'
+end.save!

--- a/core/db/migrate/20140309024355_create_spree_stores.rb
+++ b/core/db/migrate/20140309024355_create_spree_stores.rb
@@ -1,0 +1,15 @@
+class CreateSpreeStores < ActiveRecord::Migration
+  def change
+    create_table :spree_stores do |t|
+      t.string :name
+      t.string :url
+      t.text :meta_description
+      t.text :meta_keywords
+      t.string :seo_title
+      t.string :mail_from_address
+      t.string :default_currency
+
+      t.timestamps
+    end
+  end
+end

--- a/core/db/migrate/20140309033438_create_store_from_preferences.rb
+++ b/core/db/migrate/20140309033438_create_store_from_preferences.rb
@@ -1,0 +1,17 @@
+class CreateStoreFromPreferences < ActiveRecord::Migration
+  def change
+    preference_store = Spree::Preferences::Store.instance
+
+    # we set defaults for the things we now require
+    Spree::Store.new do |s|
+      s.name              = preference_store.get('spree/app_configuration/site_name') || 'Spree Demo Site'
+      s.url               = preference_store.get('spree/app_configuration/site_url') || 'demo.spreecommerce.com'
+      s.mail_from_address = preference_store.get('spree/app_configuration/mails_from') || 'spree@example.com'
+
+      s.meta_description = preference_store.get 'spree/app_configuration/default_meta_description'
+      s.meta_keywords    = preference_store.get 'spree/app_configuration/default_meta_keywords'
+      s.seo_title        = preference_store.get 'spree/app_configuration/default_seo_title'
+      s.default_currency = preference_store.get 'spree/app_configuration/currency'
+    end.save!
+  end
+end

--- a/core/db/migrate/20140309033438_create_store_from_preferences.rb
+++ b/core/db/migrate/20140309033438_create_store_from_preferences.rb
@@ -4,14 +4,21 @@ class CreateStoreFromPreferences < ActiveRecord::Migration
 
     # we set defaults for the things we now require
     Spree::Store.new do |s|
-      s.name              = preference_store.get('spree/app_configuration/site_name') || 'Spree Demo Site'
-      s.url               = preference_store.get('spree/app_configuration/site_url') || 'demo.spreecommerce.com'
-      s.mail_from_address = preference_store.get('spree/app_configuration/mails_from') || 'spree@example.com'
+      s.name              = preference_store.get 'spree/app_configuration/site_name' do
+        'Spree Demo Site'
+      end
+      s.url               = preference_store.get 'spree/app_configuration/site_url' do
+        'demo.spreecommerce.com'
+      end
+      s.mail_from_address = preference_store.get 'spree/app_configuration/mails_from' do
+        'spree@example.com'
+      end
 
-      s.meta_description = preference_store.get 'spree/app_configuration/default_meta_description'
-      s.meta_keywords    = preference_store.get 'spree/app_configuration/default_meta_keywords'
-      s.seo_title        = preference_store.get 'spree/app_configuration/default_seo_title'
-      s.default_currency = preference_store.get 'spree/app_configuration/currency'
+      s.meta_description = preference_store.get('spree/app_configuration/default_meta_description') {}
+      s.meta_keywords    = preference_store.get('spree/app_configuration/default_meta_keywords') {}
+      s.seo_title        = preference_store.get('spree/app_configuration/default_seo_title') {}
+      s.default_currency = preference_store.get('spree/app_configuration/currency') {}
+
     end.save!
   end
 end

--- a/core/lib/generators/spree/install/templates/config/initializers/spree.rb
+++ b/core/lib/generators/spree/install/templates/config/initializers/spree.rb
@@ -7,8 +7,8 @@
 # config.setting_name = 'new value'
 Spree.config do |config|
   # Example:
-  # Uncomment to override the default site name.
-  # config.site_name = "Spree Demo Site"
+  # Uncomment to stop tracking inventory levels in the application
+  # config.track_inventory_levels = false
 end
 
 Spree.user_class = <%= (options[:user_class].blank? ? "Spree::LegacyUser" : options[:user_class]).inspect %>

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -28,7 +28,7 @@ module Spree
   # Example:
   #
   #   Spree.config do |config|
-  #     config.site_name = "An awesome Spree site"
+  #     config.track_inventory_levels = false
   #   end
   #
   # This method is defined within the core gem on purpose.

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -18,6 +18,7 @@ module Spree
       :stock_item_attributes,
       :stock_location_attributes,
       :stock_movement_attributes,
+      :store_attributes,
       :taxon_attributes,
       :taxonomy_attributes,
       :user_attributes,
@@ -80,6 +81,9 @@ module Spree
 
     @@stock_movement_attributes = [
       :quantity, :stock_item, :stock_item_id, :originator, :action]
+
+    @@store_attributes = [:name, :url, :seo_title, :meta_keywords,
+                         :meta_description, :default_currency]
 
     @@taxonomy_attributes = [:name]
 

--- a/core/lib/spree/testing_support/factories/store_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_factory.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :store, class: Spree::Store do
+    name 'Spree Test STore'
+    url 'localhost:3000'
+    mail_from_address 'spree@example.org'
+  end
+end

--- a/core/lib/spree/testing_support/preferences.rb
+++ b/core/lib/spree/testing_support/preferences.rb
@@ -5,7 +5,7 @@ module Spree
       # pass a block to override the defaults with a block
       #
       # reset_spree_preferences do |config|
-      #   config.site_name = "my fancy pants store"
+      #   config.track_inventory_levels = false
       # end
       #
       def reset_spree_preferences(&config_block)

--- a/core/spec/models/spree/app_configuration_spec.rb
+++ b/core/spec/models/spree/app_configuration_spec.rb
@@ -5,13 +5,13 @@ describe Spree::AppConfiguration do
   let (:prefs) { Rails.application.config.spree.preferences }
 
   it "should be available from the environment" do
-    prefs.site_name = "TEST SITE NAME"
-    prefs.site_name.should eq "TEST SITE NAME"
+    prefs.layout = "my/layout"
+    prefs.layout.should eq "my/layout"
   end
 
   it "should be available as Spree::Config for legacy access" do
-    Spree::Config.site_name = "Spree::Config TEST SITE NAME"
-    Spree::Config.site_name.should eq "Spree::Config TEST SITE NAME"
+    Spree::Config.layout = "my/layout"
+    Spree::Config.layout.should eq "my/layout"
   end
 
   it "uses base searcher class by default" do

--- a/core/spec/models/spree/store_spec.rb
+++ b/core/spec/models/spree/store_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe Spree::Store do
+
+end


### PR DESCRIPTION
As discussed at railsconf, this is an model I think we need in spree for multiple reasons:
1. It provides a common point for different multi-tenant solutions to extend 
2. It gives us a more coherent place to put configuration variables than throwing them on Spree::Config (and makes them work in mutli-tennant solutions)
3. Existing almost as reproduced in many stores and extensions already

Keep in mind as of right now this does not cover:
1. Domains, or anything related. It is not opinionated on what store should be used at any given time
2. Currencies. I attempted to start overriding Spree::Config[:currency] to return the first store's currency and ran into countless problems. I will continue to work on this, but I think its still a good start point even though it does not deprecate Spree::Config[:currency]. I left the attribute on the model as I do think thats what people should be extending.
3. Remove of all references to old-style configuration. Right now I just throw deprecation warnings, but will work on removing more and more of them in future commits.

Anyway, still needs some work but I wanted to get something up so everyone has a chance to see where this is. The ugliest stuff is in providing the compatibility with Spree::Config preferences, so suggestions are more than welcome there.
