### PR TITLE
product.rb: Product#possible_promotions fix

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -188,7 +188,7 @@ module Spree
     end
 
     def possible_promotions
-      promotion_ids = promotion_rules.map(&:activator_id).uniq
+      promotion_ids = promotion_rules.map(&:promotion_id).uniq
       Spree::Promotion.advertised.where(id: promotion_ids).reject(&:expired?)
     end
 


### PR DESCRIPTION
Fixes #4395 an error on the product show page

Product#possible_promotions is to use `:promotion_id` instead `:activator_id` - because `activator_id` was renamed to `promotion_id`
