### PR TITLE
API BaseController inherits ActionController::Base

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -2,13 +2,10 @@ require_dependency 'spree/api/controller_setup'
 
 module Spree
   module Api
-    class BaseController < ActionController::Metal
-      include ActionController::StrongParameters
+    class BaseController < ActionController::Base
       include Spree::Api::ControllerSetup
       include Spree::Core::ControllerHelpers::SSL
       include Spree::Core::ControllerHelpers::StrongParameters
-      include ::ActionController::Head
-      include ::ActionController::ConditionalGet
 
       attr_accessor :current_api_user
 

--- a/api/lib/spree/api/controller_setup.rb
+++ b/api/lib/spree/api/controller_setup.rb
@@ -5,18 +5,6 @@ module Spree
     module ControllerSetup
       def self.included(klass)
         klass.class_eval do
-          include AbstractController::ViewPaths
-          include AbstractController::Callbacks
-          include AbstractController::Helpers
-
-          include ActiveSupport::Rescuable
-
-          include ActionController::Rendering
-          include ActionController::ImplicitRender
-          include ActionController::Rescue
-          include ActionController::MimeResponds
-          include ActionController::Head
-
           include CanCan::ControllerAdditions
           include Spree::Core::ControllerHelpers::Auth
 

--- a/core/lib/spree/core/controller_helpers/respond_with.rb
+++ b/core/lib/spree/core/controller_helpers/respond_with.rb
@@ -1,29 +1,3 @@
-module ActionController
-  class Base
-    def respond_with(*resources, &block)
-      raise "In order to use respond_with, first you need to declare the formats your " <<
-            "controller responds to in the class level" if self.class.mimes_for_respond_to.empty?
-
-      if collector = retrieve_collector_from_mimes(&block)
-        options = resources.size == 1 ? {} : resources.extract_options!
-
-        if defined_response = collector.response and !Spree::BaseController.spree_responders.keys.include?(self.class.to_s.to_sym)
-          if action = options.delete(:action)
-            render :action => action
-          else
-            defined_response.call
-          end
-        else
-          # The action name is needed for processing
-          options.merge!(:action_name => action_name.to_sym)
-          # If responder is not specified then pass in Spree::Responder
-          (options.delete(:responder) || Spree::Responder).call(self, resources, options)
-        end
-      end
-    end
-  end
-end
-
 module Spree
   module Core
     module ControllerHelpers


### PR DESCRIPTION
Spree::Api::BaseController now inherits from ActionController::Base.
Removed respond_with override, to fix being unable to pass
default_template to options. Removed unnecessary includes.
