### PR TITLE
No duplicate option values when a variant is duplicated

### DIFF
--- a/core/lib/spree/core/product_duplicator.rb
+++ b/core/lib/spree/core/product_duplicator.rb
@@ -49,7 +49,7 @@ module Spree
       new_variant = variant.dup
       new_variant.sku = "COPY OF #{new_variant.sku}"
       new_variant.deleted_at = nil
-      new_variant.option_values = variant.option_values.map { |option_value| option_value.dup}
+      new_variant.option_values = variant.option_values.map { |option_value| option_value}
       new_variant
     end
 

--- a/core/spec/models/spree/product_duplicator_spec.rb
+++ b/core/spec/models/spree/product_duplicator_spec.rb
@@ -43,13 +43,22 @@ module Spree
     end
 
     context "with variants" do
-      let!(:variant1) { create(:variant, product: product) }
-      let!(:variant2) { create(:variant, product: product) }
+      let(:option_type) { create(:option_type, name: "MyOptionType")}
+      let(:option_value1) { create(:option_value, name: "OptionValue1", option_type: option_type)}
+      let(:option_value2) { create(:option_value, name: "OptionValue2", option_type: option_type)}
+
+      let!(:variant1) { create(:variant, product: product, option_values: [option_value1]) }
+      let!(:variant2) { create(:variant, product: product, option_values: [option_value2]) }
       
       it  "will duplciate the variants" do
         # will change the count by 3, since there will be a master variant as well
         expect{duplicator.duplicate}.to change{Spree::Variant.count}.by(3)
       end
+
+      it "will not duplicate the option values" do
+        expect{duplicator.duplicate}.to change{Spree::OptionValue.count}.by(0)
+      end
+
     end
   end
 end


### PR DESCRIPTION
Fixes #4417
