### PR TITLE
Don't access Spree::Config[:site_url] at startup

### DIFF
--- a/frontend/app/views/spree/shared/_head.html.erb
+++ b/frontend/app/views/spree/shared/_head.html.erb
@@ -3,7 +3,7 @@
 <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
 <meta content="width=device-width, initial-scale=1.0, maximum-scale=1" name="viewport">
 <%== meta_data_tags %>
-<%= canonical_tag %>
+<%= canonical_tag(Spree::Config.site_url) %>
 <%= favicon_link_tag image_path('favicon.ico') %>
 <%= stylesheet_link_tag 'spree/frontend/all', :media => 'screen' %>
 <%= csrf_meta_tags %>

--- a/frontend/config/initializers/canonical_rails.rb
+++ b/frontend/config/initializers/canonical_rails.rb
@@ -1,9 +1,4 @@
 CanonicalRails.setup do |config|
-
-  # This is the main host, not just the TLD, omit slashes and protocol. If you have more than one, pick the one you want to rank in search results.
-
-  config.host = Spree::Config[:site_url]
-
   # http://en.wikipedia.org/wiki/URL_normalization
   # Trailing slash represents semantics of a directory, ie a collection view - implying an :index get route;
   # otherwise we have to assume semantics of an instance of a resource type, a member view - implying a :show get route

--- a/frontend/spree_frontend.gemspec
+++ b/frontend/spree_frontend.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_api', version
   s.add_dependency 'spree_core', version
 
-  s.add_dependency 'canonical-rails'
+  s.add_dependency 'canonical-rails', '~> 0.0.4'
   s.add_dependency 'jquery-rails', '~> 3.1.0'
   s.add_dependency 'stringex', '~> 1.5.1'
 


### PR DESCRIPTION
Now `Spree::Config.site_url` is passed to `canonical_tag` only when the page is rendered. This also means that changes to the `site_url` in the admin are picked up without restarting the server.

Thanks @jumph4x, for releasing a new version of canonical-rails with this feature.

All settings in #3833 now have been fixed in master or in an open PR :tada:
