### PR TITLE
Load all line_items for an order

### DIFF
--- a/api/spec/controllers/spree/api/line_items_controller_spec.rb
+++ b/api/spec/controllers/spree/api/line_items_controller_spec.rb
@@ -106,7 +106,7 @@ module Spree
         context "order is completed" do
           before do
             order.stub completed?: true
-            Order.stub find_by!: order
+            Order.stub_chain :includes, find_by!: order
           end
 
           it "doesn't destroy shipments or restart checkout flow" do


### PR DESCRIPTION
Instead of loading a single line_item, then loading the rest of the
line_items when updating the order, load all of the line_items and pick
out the one being updated / destroyed.
