### PR TITLE
use only completed promotion usages when checking usage limit

### DIFF
--- a/api/spec/controllers/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/controllers/spree/api/checkouts_controller_spec.rb
@@ -225,6 +225,14 @@ module Spree
         response.status.should == 200
       end
 
+      it "can recieve notice of ineligible coupons" do
+        Order.any_instance.stub(:eligible_promotions).and_return([double('expired promotion', expired?: true)])
+        api_put :update, :id => order.to_param, :order_token => order.token,
+          :order => { }
+        json_response['error'].should == "The coupon code is expired"
+        response.status.should == 200
+      end
+
       it "can apply a coupon code to an order" do
         pending "ensure that the order totals are properly updated, see frontend orders_controller or checkout_controller as example"
 

--- a/backend/app/views/spree/admin/promotions/_form.html.erb
+++ b/backend/app/views/spree/admin/promotions/_form.html.erb
@@ -36,7 +36,7 @@
       <%= f.label :usage_limit %><br />
       <%= f.number_field :usage_limit, :min => 0, :class => 'fullwidth' %><br>
       <span class="info">
-        <%= Spree.t(:current_promotion_usage, :count => @promotion.credits_count) %>
+        <%= link_to Spree.t(:current_promotion_usage, :count => @promotion.completed_orders_count), admin_orders_path(q: {promotions_id_in: @promotion.id}) %>
       </span>
     <% end %>
 

--- a/backend/app/views/spree/admin/promotions/index.html.erb
+++ b/backend/app/views/spree/admin/promotions/index.html.erb
@@ -79,7 +79,7 @@
           <td class="align-center"><%= promotion.code %></td>
           <td><%= promotion.description %></td>
           <td class="align-center"><%= promotion.usage_limit.nil? ? "∞" : promotion.usage_limit  %></td>
-          <td class="align-center"><%= Spree.t(:current_promotion_usage, :count => promotion.credits_count) %></td>
+          <td class="align-center"><%= link_to Spree.t(:current_promotion_usage, :count => promotion.completed_orders_count), admin_orders_path(q: {promotions_id_in: promotion.id}) %></td>
           <td class="align-center"><%= promotion.expires_at.to_date.to_s(:short_date) if promotion.expires_at %></td>
           <td class="actions">
             <%= link_to_edit promotion, :no_text => true %>

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -506,6 +506,28 @@ module Spree
       persist_totals
     end
 
+    def eligible_promotions 
+      all_adjustments.eligible.promotion.collect(&:source).compact.collect(&:promotion).compact.uniq
+    end
+
+    def remove_expired_coupons
+      eligible_promotions.each do |promotion|
+        if promotion.expired?
+          errors.add(:base, Spree.t(:coupon_code_expired))
+          break
+        elsif promotion.usage_limit_exceeded?
+          errors.add(:base, Spree.t(:coupon_code_max_usage)) 
+          break
+        end
+      end
+      if errors.present?
+        updater.recalculate_adjustments
+        return true
+      else
+        return false
+      end
+    end  
+
     # Clean shipments and make order back to address state
     #
     # At some point the might need to force the order to transition from address

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -506,7 +506,7 @@ module Spree
       persist_totals
     end
 
-    def eligible_promotions 
+    def eligible_promotions
       all_adjustments.eligible.promotion.collect(&:source).compact.collect(&:promotion).compact.uniq
     end
 
@@ -516,7 +516,7 @@ module Spree
           errors.add(:base, Spree.t(:coupon_code_expired))
           break
         elsif promotion.usage_limit_exceeded?
-          errors.add(:base, Spree.t(:coupon_code_max_usage)) 
+          errors.add(:base, Spree.t(:coupon_code_max_usage))
           break
         end
       end
@@ -526,7 +526,7 @@ module Spree
       else
         return false
       end
-    end  
+    end
 
     # Clean shipments and make order back to address state
     #

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -68,7 +68,7 @@ module Spree
 
     # called anytime order.update! happens
     def eligible?(promotable)
-      return false if expired? || usage_limit_exceeded?(promotable)
+      return false if expired? || usage_limit_exceeded?
       rules_are_eligible?(promotable, {})
     end
 
@@ -100,16 +100,13 @@ module Spree
       products.map(&:id)
     end
 
-    def usage_limit_exceeded?(promotable)
-      usage_limit.present? && usage_limit > 0 && completed_credits_count >= usage_limit
+    def usage_limit_exceeded?
+      usage_limit.present? && usage_limit > 0 && completed_orders_count >= usage_limit
     end
 
-    def completed_credits
-      credits.joins(:order).where.not(orders: {completed_at: nil})
-    end
-
-    def completed_credits_count
-      completed_credits.count
+    #can't just rely on orders relation because an order with an ineligible adjustment stays on that list.
+    def completed_orders_count
+      credits.joins(:order).where.not(spree_orders: {completed_at: nil}).select('order_id').references(:spree_orders).distinct.count
     end
 
     def credits

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -101,11 +101,15 @@ module Spree
     end
 
     def usage_limit_exceeded?(promotable)
-      usage_limit.present? && usage_limit > 0 && adjusted_credits_count(promotable) >= usage_limit
+      usage_limit.present? && usage_limit > 0 && completed_credits_count >= usage_limit
     end
 
-    def adjusted_credits_count(promotable)
-      credits_count - promotable.adjustments.promotion.where(:source_id => actions.pluck(:id)).count
+    def completed_credits
+      credits.joins(:order).where.not(orders: {completed_at: nil})
+    end
+
+    def completed_credits_count
+      completed_credits.count
     end
 
     def credits

--- a/core/app/models/spree/promotion_handler/coupon.rb
+++ b/core/app/models/spree/promotion_handler/coupon.rb
@@ -35,7 +35,7 @@ module Spree
       private
 
       def handle_present_promotion(promotion)
-        return promotion_usage_limit_exceeded if promotion.usage_limit_exceeded?(order)
+        return promotion_usage_limit_exceeded if promotion.usage_limit_exceeded?
         return promotion_applied if promotion_exists_on_order?(order, promotion)
         return ineligible_for_this_order unless promotion.eligible?(order)
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -320,12 +320,13 @@ describe Spree::Order do
       promotion.should_receive(:expired?).and_return(false)
       order.remove_expired_coupons.should be_false
     end
-    
+
     it "should recalculate expired promotions" do
       promotion.should_receive(:expired?).and_return(true)
       order.should_receive(:updater).and_return(updater)
       updater.should_receive(:recalculate_adjustments)
       order.remove_expired_coupons.should be_true
+      order.errors.should_not be_empty
     end
 
     it "should recalculate overused promotions" do

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -308,6 +308,36 @@ describe Spree::Order do
     end
   end
 
+  context "#remove_expired_coupons" do
+    let(:promotion) { double('promotion') }
+    let(:updater) { double('order_updater') }
+    before do
+      order.stub(:eligible_promotions).and_return([promotion])
+    end
+
+    it "should check expiry of promotions" do
+      promotion.should_receive(:usage_limit_exceeded?).and_return(false)
+      promotion.should_receive(:expired?).and_return(false)
+      order.remove_expired_coupons.should be_false
+    end
+    
+    it "should recalculate expired promotions" do
+      promotion.should_receive(:expired?).and_return(true)
+      order.should_receive(:updater).and_return(updater)
+      updater.should_receive(:recalculate_adjustments)
+      order.remove_expired_coupons.should be_true
+    end
+
+    it "should recalculate overused promotions" do
+      promotion.should_receive(:usage_limit_exceeded?).and_return(true)
+      promotion.should_receive(:expired?).and_return(false)
+      order.should_receive(:updater).and_return(updater)
+      updater.should_receive(:recalculate_adjustments)
+      order.remove_expired_coupons.should be_true
+    end
+
+  end
+
   context "#process_payments!" do
     let(:payment) { stub_model(Spree::Payment) }
     before { order.stub :pending_payments => [payment], :total => 10 }

--- a/core/spec/models/spree/promotion_handler/coupon_spec.rb
+++ b/core/spec/models/spree/promotion_handler/coupon_spec.rb
@@ -164,9 +164,10 @@ module Spree
               coupon = Coupon.new(order)
               coupon.apply
               expect(coupon.successful?).to be_true
+              order.update_column(:completed_at, Time.now)
 
               order_2 = create(:order)
-              order_2.stub :coupon_code => "10off"
+              order_2.stub :coupon_code => "10off",  :item_total => 50, :ship_total => 10 
               coupon = Coupon.new(order_2)
               coupon.apply
               expect(coupon.successful?).to be_false

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -124,16 +124,19 @@ describe Spree::Promotion do
 
     it "should have its usage limit exceeded" do
       promotion.usage_limit = 2
-      promotion.stub(:adjusted_credits_count => 2)
+      promotion.stub(:completed_credits_count => 2)
       promotion.usage_limit_exceeded?(promotable).should be_true
 
-      promotion.stub(:adjusted_credits_count => 3)
+      promotion.stub(:completed_credits_count => 3)
       promotion.usage_limit_exceeded?(promotable).should be_true
+
+      promotion.stub(:completed_credits_count => 1)
+      promotion.usage_limit_exceeded?(promotable).should be_false
     end
   end
 
   context "#expired" do
-    it "should not be exipired" do
+    it "should not be expired" do
       promotion.should_not be_expired
     end
 

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -116,22 +116,24 @@ describe Spree::Promotion do
   end
 
   context "#usage_limit_exceeded" do
-    let(:promotable) { double('Promotable') }
     it "should not have its usage limit exceeded with no usage limit" do
       promotion.usage_limit = 0
-      promotion.usage_limit_exceeded?(promotable).should be_false
+      promotion.usage_limit_exceeded?.should be_false
     end
 
     it "should have its usage limit exceeded" do
       promotion.usage_limit = 2
-      promotion.stub(:completed_credits_count => 2)
-      promotion.usage_limit_exceeded?(promotable).should be_true
+      promotion.stub(:completed_orders_count => 2)
+      promotion.usage_limit_exceeded?.should be_true
 
-      promotion.stub(:completed_credits_count => 3)
-      promotion.usage_limit_exceeded?(promotable).should be_true
+      promotion.stub(:completed_orders_count => 3)
+      promotion.usage_limit_exceeded?.should be_true
+    end
 
-      promotion.stub(:completed_credits_count => 1)
-      promotion.usage_limit_exceeded?(promotable).should be_false
+    it "should be within its usage limit" do
+      promotion.usage_limit = 2
+      promotion.stub(:completed_orders_count => 1)
+      promotion.usage_limit_exceeded?.should be_false
     end
   end
 

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -11,6 +11,7 @@ module Spree
     before_filter :ensure_order_not_completed
     before_filter :ensure_checkout_allowed
     before_filter :ensure_sufficient_stock_lines
+    before_filter :ensure_coupons_eligible
     before_filter :ensure_valid_state
 
     before_filter :associate_user
@@ -92,6 +93,13 @@ module Spree
       def ensure_sufficient_stock_lines
         if @order.insufficient_stock_lines.present?
           flash[:error] = Spree.t(:inventory_error_flash_for_insufficient_quantity)
+          redirect_to spree.cart_path
+        end
+      end
+
+      def ensure_coupons_eligible
+        if @order.remove_expired_coupons
+          flash[:error] = @order.errors.full_messages.first
           redirect_to spree.cart_path
         end
       end


### PR DESCRIPTION
It should only count completed orders against the usage_limit.  Counting incomplete orders as using a coupon doesn't make sense.  We could also probably take the promotable argument off of the usage_limit_exceeded? method signature but I wasn't sure that was a good idea.
