### PR TITLE
Refactor api auth

### DIFF
--- a/api/app/controllers/spree/api/addresses_controller.rb
+++ b/api/app/controllers/spree/api/addresses_controller.rb
@@ -41,10 +41,6 @@ module Spree
           end
         end
 
-        def order_token
-          request.headers["X-Spree-Order-Token"] || params[:order_token]
-        end
-
         def load_and_authorize_address(permission)
           find_address
           if @order

--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -66,7 +66,7 @@ module Spree
 
       def check_for_user_or_api_key
         # User is already authenticated with Spree, make request this way instead.
-        return true if @current_api_user || !Spree::Api::Config[:requires_authentication]
+        return true if @current_api_user
 
         if api_key.blank? && order_token.blank?
           render "spree/api/errors/must_specify_api_key", :status => 401 and return

--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -13,6 +13,7 @@ module Spree
       attr_accessor :current_api_user
 
       before_filter :set_content_type
+      before_filter :load_user
       before_filter :check_for_user_or_api_key, :if => :requires_authentication?
       before_filter :authorize_for_order, :if => Proc.new { order_token.present? }
       before_filter :authenticate_user
@@ -65,19 +66,21 @@ module Spree
 
       def check_for_user_or_api_key
         # User is already authenticated with Spree, make request this way instead.
-        return true if @current_api_user = try_spree_current_user || !Spree::Api::Config[:requires_authentication]
+        return true if @current_api_user || !Spree::Api::Config[:requires_authentication]
 
         if api_key.blank? && order_token.blank?
           render "spree/api/errors/must_specify_api_key", :status => 401 and return
         end
       end
 
+      def load_user
+        @current_api_user = (try_spree_current_user || Spree.user_class.find_by(spree_api_key: api_key.to_s))
+      end
+
       def authenticate_user
         unless @current_api_user
           if order_token.blank? && (requires_authentication? || api_key.present?)
-            unless @current_api_user = Spree.user_class.find_by(spree_api_key: api_key.to_s)
-              render "spree/api/errors/invalid_api_key", :status => 401 and return
-            end
+            render "spree/api/errors/invalid_api_key", :status => 401 and return
           else
             # An anonymous user
             @current_api_user = Spree.user_class.new

--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -158,9 +158,7 @@ module Spree
 
       def authorize_for_order
         @order = Spree::Order.find_by(number: params[:order_id] || params[:id])
-        unless @order.token == order_token
-          unauthorized
-        end
+        authorize! :read, @order, order_token
       end
     end
   end

--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -14,7 +14,6 @@ module Spree
 
       before_filter :set_content_type
       before_filter :load_user
-      before_filter :check_for_user_or_api_key, :if => :requires_authentication?
       before_filter :authorize_for_order, :if => Proc.new { order_token.present? }
       before_filter :authenticate_user
       after_filter  :set_jsonp_format
@@ -64,22 +63,15 @@ module Spree
         headers["Content-Type"] = content_type
       end
 
-      def check_for_user_or_api_key
-        # User is already authenticated with Spree, make request this way instead.
-        return true if @current_api_user
-
-        if api_key.blank? && order_token.blank?
-          render "spree/api/errors/must_specify_api_key", :status => 401 and return
-        end
-      end
-
       def load_user
         @current_api_user = (try_spree_current_user || Spree.user_class.find_by(spree_api_key: api_key.to_s))
       end
 
       def authenticate_user
         unless @current_api_user
-          if order_token.blank? && (requires_authentication? || api_key.present?)
+          if requires_authentication? && api_key.blank? && order_token.blank?
+            render "spree/api/errors/must_specify_api_key", :status => 401 and return
+          elsif order_token.blank? && (requires_authentication? || api_key.present?)
             render "spree/api/errors/invalid_api_key", :status => 401 and return
           else
             # An anonymous user

--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -131,10 +131,6 @@ module Spree
           end
           false
         end
-
-        def order_token
-          request.headers["X-Spree-Order-Token"] || params[:order_token]
-        end
     end
   end
 end

--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -145,10 +145,6 @@ module Spree
           @order.create_proposed_shipments
         end
 
-        def order_token
-          request.headers["X-Spree-Order-Token"] || params[:order_token]
-        end
-
     end
   end
 end

--- a/api/lib/spree/api/testing_support/helpers.rb
+++ b/api/lib/spree/api/testing_support/helpers.rb
@@ -17,7 +17,6 @@ module Spree
         end
 
         def stub_authentication!
-          controller.stub :check_for_user_or_api_key
           Spree::LegacyUser.stub(:find_by).with(hash_including(:spree_api_key)) { current_api_user }
         end
 

--- a/api/spec/controllers/spree/api/base_controller_spec.rb
+++ b/api/spec/controllers/spree/api/base_controller_spec.rb
@@ -21,6 +21,24 @@ describe Spree::Api::BaseController do
     end
   end
 
+  context "when validating based on an order token" do
+    let!(:order) { create :order }
+
+    context "with a correct order token" do
+      it "succeeds" do
+        api_get :index, order_token: order.token, order_id: order.number
+        response.status.should == 200
+      end
+    end
+
+    context "with an incorrect order token" do
+      it "returns unauthorized" do
+        api_get :index, order_token: "NOT_A_TOKEN", order_id: order.number
+        response.status.should == 401
+      end
+    end
+  end
+
   context "cannot make a request to the API" do
     it "without an API key" do
       api_get :index


### PR DESCRIPTION
This cleans up some of the API authorization in the hopes that some of the internal authorization logic within the API BaseController can be moved to cancan at some point in the future.

This change is not intended to modify any functionality.  Tests path both before and after these commits.
