### PR TITLE
Fix promotion eligibility rules

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -83,7 +83,7 @@ module Spree
 
     def adjusted_credits_count(order)
       return credits_count if order.nil?
-      credits_count - (order.promotion_credit_exists?(self) ? 1 : 0)
+      credits_count - (exists_on_order?(order) ? 1 : 0)
     end
 
     def credits
@@ -96,6 +96,10 @@ module Spree
 
     def code=(coupon_code)
       write_attribute(:code, (coupon_code.downcase.strip rescue nil))
+    end
+    
+    def exists_on_order?(order)
+      actions.any? { |a| a.credit_exists_on_order?(order) }
     end
   end
 end

--- a/core/app/models/spree/promotion/actions/create_adjustment.rb
+++ b/core/app/models/spree/promotion/actions/create_adjustment.rb
@@ -17,7 +17,7 @@ module Spree
         # through options hash
         def perform(options = {})
           order = options[:order]
-          return if order.promotion_credit_exists?(self)
+          return if credit_exists_on_order?(order)
 
           self.create_adjustment("#{Spree.t(:promotion)} (#{promotion.name})", order, order)
         end

--- a/core/app/models/spree/promotion_action.rb
+++ b/core/app/models/spree/promotion_action.rb
@@ -13,5 +13,9 @@ module Spree
     def perform(options = {})
       raise 'perform should be implemented in a sub-class of PromotionAction'
     end
+
+    def credit_exists_on_order?(order)
+      !!order.promotion_credit_exists?(self)
+    end
   end
 end

--- a/core/spec/models/spree/promotion/actions/create_adjustment_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_adjustment_spec.rb
@@ -13,6 +13,11 @@ describe Spree::Promotion::Actions::CreateAdjustment do
       action.stub(:promotion => promotion)
     end
 
+    it 'should call credit_exist_on_order?' do
+      action.should_receive(:credit_exists_on_order?).with(order).and_return(true) 
+      action.perform(:order => order)
+    end
+
     it "should create a discount with correct negative amount" do
       order = create(:line_item, :price => 5000).order
 

--- a/core/spec/models/spree/promotion_action_spec.rb
+++ b/core/spec/models/spree/promotion_action_spec.rb
@@ -6,5 +6,35 @@ describe Spree::PromotionAction do
     expect { MyAction.new.perform }.to raise_error
   end
 
+  describe '#credit_exists_on_order?' do
+    let(:order) { create(:order_with_line_items, :state => "payment", :coupon_code => "tenoff") }
+    let(:promo_action) { Spree::Promotion::Actions::CreateAdjustment.create(:calculator_type => "Spree::Calculator::FlatPercentItemTotal") }
+    
+    context 'when promo is applied' do
+      before do
+        flat_percent_calc = Spree::Calculator::FlatPercentItemTotal.create(:preferred_flat_percent => "10")
+        promo = Spree::Promotion.create(:name => "Discount", :event_name => "spree.checkout.coupon_code_added", :code => "tenoff", :usage_limit => "10", :starts_at => DateTime.yesterday, :expires_at => DateTime.tomorrow)
+        promo_rule = Spree::Promotion::Rules::ItemTotal.create(:preferred_operator => "gt", :preferred_amount => "1")
+        promo_rule.update_attribute(:activator_id, promo.id)
+        promo_action.update_attribute(:activator_id, promo.id)
+        flat_percent_calc.update_attribute(:calculable_id, promo.id)
+        Spree::Order.any_instance.stub(:payment_required? => false)
+        Spree::Adjustment.any_instance.stub(:eligible => true)
+        order.update_column(:state, "payment")
+        order.coupon_code = "tenoff"
+        Spree::Promo::CouponApplicator.new(order).apply
+      end
+
+      it 'should return true' do
+        promo_action.credit_exists_on_order?(order).should be_true
+      end 
+    end
+
+    context 'when promo is not applied' do
+      it 'should return false' do
+        promo_action.credit_exists_on_order?(order).should be_false
+      end
+    end
+  end
 end
 

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -41,6 +41,37 @@ describe Spree::Promotion do
     end
   end
 
+  describe '#exists_on_order?' do
+    let(:promotion) { create :promotion } 
+    let(:order) { create :order }
+    let(:action_1) { Spree::Promotion::Actions::CreateAdjustment.new }
+    let(:action_2) { Spree::Promotion::Actions::CreateAdjustment.new }
+
+    before do
+      promotion.actions << action_1
+      promotion.actions << action_2
+
+      action_1.should_receive(:credit_exists_on_order?).with(order).and_return(false)
+      action_2.should_receive(:credit_exists_on_order?).with(order).and_return(action_2_status)
+    end
+
+    context 'when one returns true' do
+      let(:action_2_status) { true }
+
+      it 'should be true' do
+        promotion.exists_on_order?(order).should be_true
+      end    
+    end
+
+    context 'when none returns true' do
+      let(:action_2_status) { false }
+
+      it 'should be false' do
+        promotion.exists_on_order?(order).should be_false
+      end 
+    end
+  end
+
   describe ".advertised" do
     let(:promotion) { create(:promotion) }
     let(:advertised_promotion) { create(:promotion, :advertise => true) }


### PR DESCRIPTION
In 2.1, prior to this change, a promotion's determination as to whether it has been applied to an order would always fail, since the order's calculation of whether a promotion credit exists compares against a promotion action, not a promotion. This change makes a promotion check whether its promotion actions have been applied to the order to see if it is on the order.

Colloboration with @pdamer, @athal7
