### PR TITLE
add spree api_key to taxon search

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/taxons.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/taxons.js.coffee
@@ -18,6 +18,7 @@ $(document).ready ->
         url: Spree.routes.taxons_search,
         datatype: 'json',
         data: (term, page) ->
+          token: Spree.api_key || "",
           per_page: 50,
           page: page,
           q:


### PR DESCRIPTION
this fixes issue #4439 so /admin/taxons works corectly

at the moment is not possible to use the /admin/taxons page

(this should also be implemented on master branch!)
