### PR TITLE
Move #invoke_callbacks to Admin::BaseController.

### DIFF
--- a/backend/app/controllers/spree/admin/base_controller.rb
+++ b/backend/app/controllers/spree/admin/base_controller.rb
@@ -11,6 +11,7 @@ module Spree
       before_filter :authorize_admin
 
       protected
+
         def action
           params[:action].to_sym
         end
@@ -85,6 +86,7 @@ module Spree
         def config_locale
           Spree::Backend::Config[:locale]
         end
+
     end
   end
 end

--- a/backend/app/controllers/spree/admin/payments_controller.rb
+++ b/backend/app/controllers/spree/admin/payments_controller.rb
@@ -1,6 +1,8 @@
 module Spree
   module Admin
     class PaymentsController < Spree::Admin::BaseController
+      include Spree::Backend::Callbacks
+
       before_filter :load_order, :only => [:create, :new, :index, :fire]
       before_filter :load_payment, :except => [:create, :new, :index]
       before_filter :load_data
@@ -18,23 +20,27 @@ module Spree
       end
 
       def create
-        @payment = @order.payments.build(object_params)
+        invoke_callbacks(:create, :before)
+        @payment ||= @order.payments.build(object_params)
         if params[:card].present? and params[:card] != 'new'
           @payment.source = @payment.payment_method.payment_source_class.find_by_id(params[:card])
         end
 
         begin
           if @payment.save
+            invoke_callbacks(:create, :after)
             # Transition order as far as it will go.
             while @order.next; end
             @payment.process! if @order.completed?
             flash[:success] = flash_message_for(@payment, :successfully_created)
             redirect_to admin_order_payments_path(@order)
           else
+            invoke_callbacks(:create, :fails)
             flash[:error] = Spree.t(:payment_could_not_be_created)
             render :new
           end
         rescue Spree::Core::GatewayError => e
+          invoke_callbacks(:create, :fails)
           flash[:error] = "#{e.message}"
           redirect_to new_admin_order_payment_path(@order)
         end

--- a/backend/lib/spree/backend.rb
+++ b/backend/lib/spree/backend.rb
@@ -7,4 +7,6 @@ require 'select2-rails'
 require 'spree/core'
 
 require 'spree/responder'
+require 'spree/backend/action_callbacks'
+require 'spree/backend/callbacks'
 require 'spree/backend/engine'

--- a/backend/lib/spree/backend/action_callbacks.rb
+++ b/backend/lib/spree/backend/action_callbacks.rb
@@ -21,6 +21,6 @@ module Spree
     def fails(method)
       @fails_methods << method
     end
-  end
 
+  end
 end

--- a/backend/lib/spree/backend/callbacks.rb
+++ b/backend/lib/spree/backend/callbacks.rb
@@ -1,0 +1,47 @@
+module Spree
+  module Backend
+    module Callbacks
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+
+        attr_accessor :callbacks
+
+        protected
+
+        def new_action
+          @callbacks ||= {}
+          @callbacks[:new_action] ||= Spree::ActionCallbacks.new
+        end
+
+        def create
+          @callbacks ||= {}
+          @callbacks[:create] ||= Spree::ActionCallbacks.new
+        end
+
+        def update
+          @callbacks ||= {}
+          @callbacks[:update] ||= Spree::ActionCallbacks.new
+        end
+
+        def destroy
+          @callbacks ||= {}
+          @callbacks[:destroy] ||= Spree::ActionCallbacks.new
+        end
+      end
+
+      protected
+
+      def invoke_callbacks(action, callback_type)
+        callbacks = self.class.callbacks || {}
+        return if callbacks[action].nil?
+        case callback_type.to_sym
+          when :before then callbacks[action].before_methods.each {|method| send method }
+          when :after  then callbacks[action].after_methods.each  {|method| send method }
+          when :fails  then callbacks[action].fails_methods.each  {|method| send method }
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Add callback hooks for Admin::PaymentsController#create.

Allows extending payment controller for new payment methods such as gift vouchers:
See https://github.com/spree-contrib/spree_vouchers/commit/def90bf508c383ffa3a56786aa570ba7b8677618#commitcomment-5709993 for the reasoning behind this.

I'm receiving a couple inconsistent payment spec failures locally, but travis is passing... I suspect it's some poltergeist voodoo that perhaps @jhawthorn can help me with.
