### PR TITLE
Change big variant rabl template to have consistent image structure with small variant rabl template. Fix potentially colliding cache keys.

### DIFF
--- a/api/app/views/spree/api/variants/big.v1.rabl
+++ b/api/app/views/spree/api/variants/big.v1.rabl
@@ -3,20 +3,7 @@ attributes *variant_attributes
 
 cache ['big_variant', root_object]
 
-node(:display_price) { |p| p.display_price.to_s }
-node(:options_text) { |v| v.options_text }
-node(:in_stock) { |v| v.in_stock? }
-
-child :option_values => :option_values do
-  attributes *option_value_attributes
-end
-
-child(:images => :images) do
-  attributes *image_attributes
-  code(:urls) do |v|
-    v.attachment.styles.keys.inject({}) { |urls, style| urls[style] = v.attachment.url(style); urls  }
-  end
-end
+extends "spree/api/variants/small"
 
 child(:stock_items => :stock_items) do
   attributes :id, :count_on_hand, :stock_location_id, :backorderable

--- a/api/app/views/spree/api/variants/small.v1.rabl
+++ b/api/app/views/spree/api/variants/small.v1.rabl
@@ -1,5 +1,5 @@
 attributes *variant_attributes
-cache ['show', root_object]
+cache ['small_variant', root_object]
 
 node(:display_price) { |p| p.display_price.to_s }
 node(:options_text) { |v| v.options_text }

--- a/api/spec/controllers/spree/api/variants_controller_spec.rb
+++ b/api/spec/controllers/spree/api/variants_controller_spec.rb
@@ -59,6 +59,15 @@ module Spree
       api_get :index
 
       json_response["variants"].last.should have_attributes([:images])
+      json_response['variants'].first['images'].first.should have_attributes([:attachment_file_name,
+                                                                               :attachment_width,
+                                                                               :attachment_height,
+                                                                               :attachment_content_type,
+                                                                               :mini_url,
+                                                                               :small_url,
+                                                                               :product_url,
+                                                                               :large_url])
+
     end
 
     # Regression test for #2141


### PR DESCRIPTION
Collab with @jordan-brough
