### PR TITLE
Add API token to autocomplete on Taxons Page

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/taxons.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/taxons.js.coffee
@@ -22,6 +22,7 @@ $(document).ready ->
           page: page,
           q:
             name_cont: term
+          token: Spree.api_key
         results: (data, page) ->
           more = page < data.pages;
           results: data['taxons'],


### PR DESCRIPTION
AJAX API call to autocomplete taxon failing due to no token in the Select2 setup
