### PR TITLE
Removing .includes() call from MigrateTaxCategoriesToLineItems

### DIFF
--- a/core/db/migrate/20130802022321_migrate_tax_categories_to_line_items.rb
+++ b/core/db/migrate/20130802022321_migrate_tax_categories_to_line_items.rb
@@ -1,7 +1,6 @@
 class MigrateTaxCategoriesToLineItems < ActiveRecord::Migration
   def change
-    Spree::LineItem.includes(:variant => { :product => :tax_category }).find_in_batches do |line_items|
-      line_items.each do |line_item|
+    Spree::LineItem.find_each do |line_item|
         next if line_item.variant.nil?
         next if line_item.variant.product.nil?
         next if line_item.product.nil?


### PR DESCRIPTION
Addresses the bug discussed in https://github.com/spree/spree/issues/4460

Note that this will make the migration slower, but less buggy in the case that LineItems refer to deleted Variants or Products.

If the `acts_as_paranoid` gem can be modified to allow "unscoped" `includes()` calls, then we can reinstate the performance improvement.
