### PR TITLE
Using `find_each` instead of `all.each`

### DIFF
--- a/core/db/migrate/20130830001159_migrate_old_shipping_calculators.rb
+++ b/core/db/migrate/20130830001159_migrate_old_shipping_calculators.rb
@@ -1,6 +1,6 @@
 class MigrateOldShippingCalculators < ActiveRecord::Migration
   def up
-    Spree::ShippingMethod.all.each do |shipping_method|
+    Spree::ShippingMethod.find_each do |shipping_method|
       old_calculator = shipping_method.calculator
       next if old_calculator.class < Spree::ShippingCalculator # We don't want to mess with new shipping calculators
       new_calculator = eval("Spree::Calculator::Shipping::#{old_calculator.class.name.demodulize}").new


### PR DESCRIPTION
It's unlikely that a Spree store will have a dramatic number of ShippingMethods, but if so, a call to `find_each` rather than `all.each` will reduce the memory footprint of the migration by processing them in batches.
