### PR TITLE
Using `find_each` instead of `all.each` to improve memory

### DIFF
--- a/core/db/migrate/20130417123427_add_shipping_rates_to_shipments.rb
+++ b/core/db/migrate/20130417123427_add_shipping_rates_to_shipments.rb
@@ -1,6 +1,6 @@
 class AddShippingRatesToShipments < ActiveRecord::Migration
   def up
-    Spree::Shipment.all.each do |shipment|
+    Spree::Shipment.find_each do |shipment|
       shipment.shipping_rates.create(:shipping_method_id => shipment.shipping_method_id,
                                      :cost => shipment.cost,
                                      :selected => true)

--- a/core/db/migrate/20130509115210_add_number_to_stock_transfer.rb
+++ b/core/db/migrate/20130509115210_add_number_to_stock_transfer.rb
@@ -6,7 +6,7 @@ class AddNumberToStockTransfer < ActiveRecord::Migration
     rename_column :spree_stock_transfers, :reference_number, :reference
     add_column :spree_stock_transfers, :number, :string
 
-    Spree::StockTransfer.all.each do |transfer|
+    Spree::StockTransfer.find_each do |transfer|
       transfer.send(:generate_stock_transfer_number)
       transfer.save!
     end


### PR DESCRIPTION
This syntax will run our migration over the `Spree::StockTransfer` model in batches, which will improve performance on stores with high numbers of stock transfers.
