### PR TITLE
Add a promotion rule base on selected taxons [Fixes #4433]

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js.erb
@@ -1,3 +1,5 @@
+'use strict';
+
 set_taxon_select = function(){
   if ($('#product_taxon_ids').length > 0) {
     $('#product_taxon_ids').select2({
@@ -43,7 +45,5 @@ set_taxon_select = function(){
 }
 
 $(document).ready(function () {
-  'use strict';
-
   set_taxon_select()
 });

--- a/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js.erb
@@ -1,6 +1,4 @@
-$(document).ready(function () {
-  'use strict';
-
+set_taxon_select = function(){
   if ($('#product_taxon_ids').length > 0) {
     $('#product_taxon_ids').select2({
       placeholder: Spree.translations.taxon_placeholder,
@@ -42,4 +40,10 @@ $(document).ready(function () {
       }
     });
   }
+}
+
+$(document).ready(function () {
+  'use strict';
+
+  set_taxon_select()
 });

--- a/backend/app/views/spree/admin/promotion_rules/create.js.erb
+++ b/backend/app/views/spree/admin/promotion_rules/create.js.erb
@@ -6,3 +6,5 @@ $('.user_picker').userAutocomplete();
 
 $('#promotion_rule_type').html('<%= escape_javascript options_for_promotion_rule_types(@promotion) %>');
 $('#promotion_rule_type').select2();
+
+set_taxon_select()

--- a/backend/app/views/spree/admin/promotions/rules/_taxon.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_taxon.html.erb
@@ -1,0 +1,9 @@
+<div class="field alpha omega eight columns taxons_rule_taxons">
+  <%= label_tag "#{param_prefix}_taxon_ids_string", Spree.t('taxon_rule.choose_taxons') %>
+  <%= hidden_field_tag "#{param_prefix}[taxon_ids_string]", promotion_rule.taxon_ids.join(","), :class => "taxon_picker fullwidth", id: 'product_taxon_ids' %>
+</div>
+<div class="field alpha omega eight columns">
+  <label>
+    <%= Spree.t('product_rule.label', :select => select_tag("#{param_prefix}[preferred_match_policy]", options_for_select(Spree::Promotion::Rules::Taxon::MATCH_POLICIES.map{|s| [Spree.t("taxon_rule.match_#{s}"),s] }, promotion_rule.preferred_match_policy), {:class => 'select_taxon select2'})).html_safe %>
+  </label>
+</div>

--- a/backend/app/views/spree/admin/promotions/rules/_taxon.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_taxon.html.erb
@@ -4,6 +4,6 @@
 </div>
 <div class="field alpha omega eight columns">
   <label>
-    <%= Spree.t('product_rule.label', :select => select_tag("#{param_prefix}[preferred_match_policy]", options_for_select(Spree::Promotion::Rules::Taxon::MATCH_POLICIES.map{|s| [Spree.t("taxon_rule.match_#{s}"),s] }, promotion_rule.preferred_match_policy), {:class => 'select_taxon select2'})).html_safe %>
+    <%= Spree.t('taxon_rule.label', :select => select_tag("#{param_prefix}[preferred_match_policy]", options_for_select(Spree::Promotion::Rules::Taxon::MATCH_POLICIES.map{|s| [Spree.t("taxon_rule.match_#{s}"),s] }, promotion_rule.preferred_match_policy), {:class => 'select_taxon select2'})).html_safe %>
   </label>
 </div>

--- a/core/app/models/spree/promotion/rules/taxon.rb
+++ b/core/app/models/spree/promotion/rules/taxon.rb
@@ -19,6 +19,15 @@ module Spree
           end
         end
 
+        def taxon_ids_string
+          taxons.pluck(:id).join(',')
+        end
+
+        def taxon_ids_string=(s)
+          ids = s.to_s.split(',').map(&:strip)
+          taxons << Spree::Taxon.find(ids)
+        end
+
         private
         def order_taxons(order)
           Spree::Taxon.joins(products: {variants: :line_items}).where(spree_line_items: {order_id: order.id})

--- a/core/app/models/spree/promotion/rules/taxon.rb
+++ b/core/app/models/spree/promotion/rules/taxon.rb
@@ -1,0 +1,29 @@
+module Spree
+  class Promotion
+    module Rules
+      class Taxon < PromotionRule
+        has_and_belongs_to_many :taxons, class_name: '::Spree::Taxon', join_table: 'spree_taxons_promotion_rules', foreign_key: 'promotion_rule_id'
+
+        MATCH_POLICIES = %w(any all)
+        preference :match_policy, default: MATCH_POLICIES.first
+
+        def applicable?(promotable)
+          promotable.is_a?(Spree::Order)
+        end
+
+        def eligible?(order, options = {})
+          if preferred_match_policy == 'all'
+            order_taxons(order).where(id: taxons).count == taxons.count
+          else
+            order_taxons(order).where(id: taxons).count > 0
+          end
+        end
+
+        private
+        def order_taxons(order)
+          Spree::Taxon.joins(products: {variants: :line_items}).where(spree_line_items: {order_id: order.id})
+        end
+      end
+    end
+  end
+end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1014,6 +1014,9 @@ en:
       user_logged_in:
         description: Available only to logged in users
         name: User Logged In
+      taxon:
+        description: Ordes includes products with specified taxon(s)
+        name: Taxon(s)
     promotions: Promotions
     promotion_uses: Promotion uses
     properties: Properties

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1194,6 +1194,11 @@ en:
     taxon: Taxon
     taxon_edit: Edit Taxon
     taxon_placeholder: Add a Taxon
+    taxon_rule:
+      choose_products: Choose taxon
+      label: Order must contain %{select} of these taxons
+      match_all: all
+      match_any: at least one
     taxonomies: Taxonomies
     taxonomy: Taxonomy
     taxonomy_edit: Edit taxonomy

--- a/core/db/migrate/20140318191500_create_spree_taxons_promotion_rules.rb
+++ b/core/db/migrate/20140318191500_create_spree_taxons_promotion_rules.rb
@@ -1,0 +1,8 @@
+class CreateSpreeTaxonsPromotionRules < ActiveRecord::Migration
+  def change
+    create_table :spree_taxons_promotion_rules do |t|
+      t.references :taxon, index: true
+      t.references :promotion_rule, index: true
+    end
+  end
+end

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -70,7 +70,10 @@ module Spree
           Spree::Promotion::Rules::User,
           Spree::Promotion::Rules::FirstOrder,
           Spree::Promotion::Rules::UserLoggedIn,
-          Spree::Promotion::Rules::OneUsePerUser]
+          Spree::Promotion::Rules::OneUsePerUser,
+          Spree::Promotion::Rules::UserLoggedIn,
+          Spree::Promotion::Rules::Taxon,
+        ]
       end
 
       initializer 'spree.promo.register.promotions.actions' do |app|

--- a/core/spec/models/spree/promotion/rules/taxon_spec.rb
+++ b/core/spec/models/spree/promotion/rules/taxon_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+describe Spree::Promotion::Rules::Taxon do
+  let(:rule){ subject }
+
+  context '#elegible?(order)' do
+    let(:taxon){ create :taxon, name: 'first' }
+    let(:taxon2){ create :taxon, name: 'second'}
+    let(:order){ create :order_with_line_items }
+
+    before do
+      rule.save
+    end
+
+    context 'with any match policy' do
+      before do
+        order.line_items << create(:line_item, product: create(:product, taxons: [create(:taxon)]))
+        rule.preferred_match_policy = 'any'
+      end
+
+      it 'is eligible if order does not has any prefered taxon' do
+        order.products.first.taxons << taxon
+        rule.taxons << taxon
+        expect(rule).to be_eligible(order)
+      end
+
+      it 'is not eligile if order does not has any prefered taxon' do
+        rule.taxons << taxon2
+        expect(rule).not_to be_eligible(order)
+      end
+    end
+
+    context 'with any match policy' do
+      before do
+        rule.preferred_match_policy = 'all'
+      end
+
+      it 'is eligible order has all prefered taxons' do
+        order.products.first.taxons << taxon2
+        order.products.last.taxons << taxon
+
+        rule.taxons = [taxon, taxon2]
+
+        expect(rule).to be_eligible(order)
+      end
+
+      it 'is not eligile if order does not has all prefered taxons' do
+        rule.taxons << taxon
+        expect(rule).not_to be_eligible(order)
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/promotion/rules/taxon_spec.rb
+++ b/core/spec/models/spree/promotion/rules/taxon_spec.rb
@@ -18,7 +18,7 @@ describe Spree::Promotion::Rules::Taxon do
         rule.preferred_match_policy = 'any'
       end
 
-      it 'is eligible if order does not has any prefered taxon' do
+      it 'is eligible if order does has any prefered taxon' do
         order.products.first.taxons << taxon
         rule.taxons << taxon
         expect(rule).to be_eligible(order)
@@ -27,6 +27,16 @@ describe Spree::Promotion::Rules::Taxon do
       it 'is not eligile if order does not has any prefered taxon' do
         rule.taxons << taxon2
         expect(rule).not_to be_eligible(order)
+      end
+
+      context 'when a product has a taxon child of a taxon rule' do
+        before do
+          taxon.children << taxon2
+          order.products.first.taxons << taxon2
+          rule.taxons << taxon2
+        end
+
+        it{ expect(rule).to be_eligible(order) }
       end
     end
 
@@ -47,6 +57,20 @@ describe Spree::Promotion::Rules::Taxon do
       it 'is not eligile if order does not has all prefered taxons' do
         rule.taxons << taxon
         expect(rule).not_to be_eligible(order)
+      end
+
+      context 'when a product has a taxon child of a taxon rule' do
+        let(:taxon3){ create :taxon }
+
+        before do
+          taxon.children << taxon2
+          order.products.first.taxons << taxon2
+          order.products.last.taxons << taxon3
+          rule.taxons << taxon2
+          rule.taxons << taxon3
+        end
+
+        it{ expect(rule).to be_eligible(order) }
       end
     end
   end


### PR DESCRIPTION
You're able to select a promotion rule based in taxons.

A promotion is eligible if the products of the order contains all or any of the selected taxon of one of the selected taxon children.
