### PR TITLE
Show variants as sold out if they're out of stock

### DIFF
--- a/frontend/app/views/spree/products/_cart_form.html.erb
+++ b/frontend/app/views/spree/products/_cart_form.html.erb
@@ -15,6 +15,9 @@
                 <% if variant_price variant %>
                   <span class="price diff"><%= variant_price variant %></span>
                 <% end %>
+                <% if ! variant.can_supply? %>
+                  <span class="out-of-stock">SOLD OUT</span>
+                <% end %>
               <% end %>
             </li>
           <% end%>


### PR DESCRIPTION
When visiting a product page, sold out variants are displayed exactly the same as available ones, so customers can't tell that a given variant is actually unavailable. This adds the text "SOLD OUT" in the case that a variant's "can_supply" is false.
