### PR TITLE
Adds the possibility to translate routes and checkout slugs in spree_i18n

### DIFF
--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -73,6 +73,12 @@ module Spree
         @order = current_order(lock: true) 
         redirect_to spree.cart_path and return unless @order
 
+        keys = @order.checkout_steps
+        vals = @order.checkout_steps.map{ |t| Spree.t("checkout_steps.slugs.#{t}", default: '') }
+        checkout_steps = Hash[keys.zip vals]
+        state = checkout_steps.key(params[:state])
+        params[:state] = state if state
+        
         if params[:state]
           redirect_to checkout_state_path(@order.state) if @order.can_go_to_state?(params[:state]) && !skip_state_validation?
           @order.state = params[:state]

--- a/frontend/app/controllers/spree/store_controller.rb
+++ b/frontend/app/controllers/spree/store_controller.rb
@@ -1,6 +1,7 @@
 module Spree
   class StoreController < Spree::BaseController
     include Spree::Core::ControllerHelpers::Order
+    skip_around_filter :set_locale_from_url
 
     def unauthorized
       render 'spree/shared/unauthorized', :layout => Spree::Config[:layout], :status => 401

--- a/frontend/config/initializers/route_translator.rb
+++ b/frontend/config/initializers/route_translator.rb
@@ -1,0 +1,5 @@
+require 'route_translator'
+
+RouteTranslator.config do |config|
+  config.hide_locale = true
+end

--- a/frontend/config/routes.rb
+++ b/frontend/config/routes.rb
@@ -1,37 +1,41 @@
+require 'route_translator'
+
 Spree::Core::Engine.add_routes do
 
   root :to => 'home#index'
-
-  resources :products, :only => [:index, :show]
-
-  get '/locale/set', :to => 'locale#set'
-
-  # non-restful checkout stuff
-  patch '/checkout/update/:state', :to => 'checkout#update', :as => :update_checkout
-  get '/checkout/:state', :to => 'checkout#edit', :as => :checkout_state
-  get '/checkout', :to => 'checkout#edit' , :as => :checkout
 
   populate_redirect = redirect do |params, request|
     request.flash[:error] = Spree.t(:populate_get_error)
     request.referer || '/cart'
   end
 
-  get '/orders/populate', :to => populate_redirect
-  get '/orders/:id/token/:token' => 'orders#show', :as => :token_order
+  localized do
+    resources :products, :only => [:index, :show]
 
-  resources :orders, :except => [:new, :create, :destroy] do
-    post :populate, :on => :collection
+    get '/locale/set', :to => 'locale#set'
+  
+    # non-restful checkout stuff
+    patch '/checkout/update/:state', :to => 'checkout#update', :as => :update_checkout
+    get '/checkout/:state', :to => 'checkout#edit', :as => :checkout_state
+    get '/checkout', :to => 'checkout#edit' , :as => :checkout
+
+    get '/orders/populate', :to => populate_redirect
+    get '/orders/:id/token/:token' => 'orders#show', :as => :token_order
+
+    resources :orders, :except => [:new, :create, :destroy] do
+      post :populate, :on => :collection
+    end
+
+    get '/cart', :to => 'orders#edit', :as => :cart
+    patch '/cart', :to => 'orders#update', :as => :update_cart
+    put '/cart/empty', :to => 'orders#empty', :as => :empty_cart
+
+    # route globbing for pretty nested taxon and product paths
+    get '/t/*id', :to => 'taxons#show', :as => :nested_taxons
+
+    get '/unauthorized', :to => 'home#unauthorized', :as => :unauthorized
+    get '/content/cvv', :to => 'content#cvv', :as => :cvv
+    get '/content/*path', :to => 'content#show', :as => :content
+    get '/cart_link', :to => 'store#cart_link', :as => :cart_link
   end
-
-  get '/cart', :to => 'orders#edit', :as => :cart
-  patch '/cart', :to => 'orders#update', :as => :update_cart
-  put '/cart/empty', :to => 'orders#empty', :as => :empty_cart
-
-  # route globbing for pretty nested taxon and product paths
-  get '/t/*id', :to => 'taxons#show', :as => :nested_taxons
-
-  get '/unauthorized', :to => 'home#unauthorized', :as => :unauthorized
-  get '/content/cvv', :to => 'content#cvv', :as => :cvv
-  get '/content/*path', :to => 'content#show', :as => :content
-  get '/cart_link', :to => 'store#cart_link', :as => :cart_link
 end

--- a/frontend/spree_frontend.gemspec
+++ b/frontend/spree_frontend.gemspec
@@ -24,7 +24,9 @@ Gem::Specification.new do |s|
   s.add_dependency 'canonical-rails', '~> 0.0.4'
   s.add_dependency 'jquery-rails', '~> 3.1.0'
   s.add_dependency 'stringex', '~> 1.5.1'
-
+  
+  s.add_dependency 'route_translator', '~> 3.2.0'
+  
   s.add_development_dependency 'email_spec', '~> 1.2.1'
   s.add_development_dependency 'capybara-accessible'
 end


### PR DESCRIPTION
This is tied to https://github.com/spree/spree_i18n/pull/385 and https://github.com/spree/spree_auth_devise/pull/172
