### PR TITLE
Promotion Item Total Rule to include Upper limit also

### DIFF
--- a/backend/app/views/spree/admin/promotions/rules/_item_total.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_item_total.html.erb
@@ -1,6 +1,8 @@
 <div class="field alpha four columns">
   <%= select_tag "#{param_prefix}[preferred_operator]", options_for_select(Spree::Promotion::Rules::ItemTotal::OPERATORS.map{|o| [Spree.t("item_total_rule.operators.#{o}"),o]}, promotion_rule.preferred_operator), {:class => 'select2 select_item_total fullwidth'} %>
+  <%= select_tag "#{param_prefix}[preferred_operator_max]", options_for_select(Spree::Promotion::Rules::ItemTotal::OPERATORS_MAX.map{|o| [Spree.t("item_total_rule.operators.#{o}"),o]}, promotion_rule.preferred_operator_max), {:class => 'select2 select_item_total fullwidth'} %>
 </div>
 <div class="field omega four columns">
   <%= text_field_tag "#{param_prefix}[preferred_amount]", promotion_rule.preferred_amount, :class => 'fullwidth' %>
+  <%= text_field_tag "#{param_prefix}[preferred_amount_max]", promotion_rule.preferred_amount_max, :class => 'fullwidth' %>
 </div>

--- a/core/app/models/spree/promotion/rules/item_total.rb
+++ b/core/app/models/spree/promotion/rules/item_total.rb
@@ -6,8 +6,12 @@ module Spree
       class ItemTotal < PromotionRule
         preference :amount, :decimal, default: 100.00
         preference :operator, :string, default: '>'
+        preference :amount_max, :decimal, default: 1000.00
+        preference :operator_max, :string, default: '<'
+
 
         OPERATORS = ['gt', 'gte']
+        OPERATORS_MAX = ['lt','lte']
 
         def applicable?(promotable)
           promotable.is_a?(Spree::Order)
@@ -15,7 +19,10 @@ module Spree
 
         def eligible?(order, options = {})
           item_total = order.item_total
-          item_total.send(preferred_operator == 'gte' ? :>= : :>, BigDecimal.new(preferred_amount.to_s))
+          lower_limit_condition = item_total.send(preferred_operator == 'gte' ? :>= : :>, BigDecimal.new(preferred_amount.to_s))
+          upper_limit_condition = item_total.send(preferred_operator_max == 'lte' ? :<= : :<, BigDecimal.new(preferred_amount_max.to_s))
+          lower_limit_condition and upper_limit_condition
+
         end
       end
     end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -653,6 +653,8 @@ en:
       operators:
         gt: greater than
         gte: greater than or equal to
+        lt: less than
+        lte: less than or equal to
     items_cannot_be_shipped: We are unable to calculate shipping rates for the selected items.
     jirafe: Jirafe
     landing_page_rule:

--- a/core/spec/models/spree/promotion/rules/item_total_spec.rb
+++ b/core/spec/models/spree/promotion/rules/item_total_spec.rb
@@ -5,41 +5,133 @@ describe Spree::Promotion::Rules::ItemTotal do
   let(:order) { double(:order) }
 
   before { rule.preferred_amount = 50 }
+  before { rule.preferred_amount_max = 60 }
 
-  context "preferred operator set to gt" do
-    before { rule.preferred_operator = 'gt' }
+  context "preferred operator set to gt and preferred operator_max set to lt" do
+    before do
+      rule.preferred_operator = 'gt'
+      rule.preferred_operator_max = 'lt'
+    end
 
-    it "should be eligible when item total is greater than preferred amount" do
+    it "should be eligible when item total is greater than preferred amount and lower than preferred amount_max" do
       order.stub :item_total => 51
       rule.should be_eligible(order)
     end
 
-    it "should not be eligible when item total is equal to preferred amount" do
+    it "should not be eligible when item total is equal to preferred amount and lower than preferred amount_max" do
       order.stub :item_total => 50
       rule.should_not be_eligible(order)
     end
 
-    it "should not be eligible when item total is lower than to preferred amount" do
+    it "should not be eligible when item total is lower than preferred amount and lower than preferred amount_max" do
       order.stub :item_total => 49
+      rule.should_not be_eligible(order)
+    end
+
+    it "should not be eligible when item total is greater than preferred amount and equal to preferred amount_max" do
+      order.stub :item_total => 60
+      rule.should_not be_eligible(order)
+    end
+
+    it "should not be eligible when item total is greater than preferred amount and greater than preferred amount_max" do
+      order.stub :item_total => 61
+      rule.should_not be_eligible(order)
+    end
+
+  end
+
+  context "preferred operator set to gt and preferred operator_max set to lte" do
+    before do
+      rule.preferred_operator = 'gt'
+      rule.preferred_operator_max = 'lte'
+    end
+
+    it "should be eligible when item total is greater than preferred amount and lower than preferred amount_max" do
+      order.stub :item_total => 51
+      rule.should be_eligible(order)
+    end
+
+    it "should not be eligible when item total is equal to preferred amount and lower than preferred amount_max" do
+      order.stub :item_total => 50
+      rule.should_not be_eligible(order)
+    end
+
+    it "should not be eligible when item total is lower than preferred amount and lower than preferred amount_max" do
+      order.stub :item_total => 49
+      rule.should_not be_eligible(order)
+    end
+
+    it "should be eligible when item total is greater than preferred amount and equal to preferred amount_max" do
+      order.stub :item_total => 60
+      rule.should be_eligible(order)
+    end
+
+    it "should not be eligible when item total is greater than preferred amount and greater than preferred amount_max" do
+      order.stub :item_total => 61
       rule.should_not be_eligible(order)
     end
   end
 
-  context "preferred operator set to gte" do
-    before { rule.preferred_operator = 'gte' }
+  context "preferred operator set to gte and preferred operator_max set to lt" do
+    before do
+      rule.preferred_operator = 'gte'
+      rule.preferred_operator_max = 'lt'
+    end
 
-    it "should be eligible when item total is greater than preferred amount" do
+    it "should be eligible when item total is greater than preferred amount and less than preferred amount_max" do
       order.stub :item_total => 51
       rule.should be_eligible(order)
     end
 
-    it "should be eligible when item total is equal to preferred amount" do
+    it "should be eligible when item total is equal to preferred amount and lower than preferred amount_max" do
       order.stub :item_total => 50
       rule.should be_eligible(order)
     end
 
-    it "should not be eligible when item total is lower than to preferred amount" do
+    it "should not be eligible when item total is lower than preferred amount and lower than preferred amount_max" do
       order.stub :item_total => 49
+      rule.should_not be_eligible(order)
+    end
+
+    it "should not be eligible when item total is greater than preferred amount and equal to preferred amount_max" do
+      order.stub :item_total => 60
+      rule.should_not be_eligible(order)
+    end
+
+    it "should not be eligible when item total is greater than preferred amount and greater than preferred amount_max" do
+      order.stub :item_total => 61
+      rule.should_not be_eligible(order)
+    end
+  end
+
+  context "preferred operator set to gte and preferred operator_max set to lte" do
+    before do
+      rule.preferred_operator = 'gte'
+      rule.preferred_operator_max = 'lte'
+    end
+
+    it "should be eligible when item total is greater than preferred amount and lower than preferred amount_max" do
+      order.stub :item_total => 51
+      rule.should be_eligible(order)
+    end
+
+    it "should be eligible when item total is equal to preferred amount and lower than preferred amount_max" do
+      order.stub :item_total => 50
+      rule.should be_eligible(order)
+    end
+
+    it "should not be eligible when item total is lower than preferred amount and lower than preferred amount_max" do
+      order.stub :item_total => 49
+      rule.should_not be_eligible(order)
+    end
+
+    it "should be eligible when item total is greater than preferred amount and equal to preferred amount_max" do
+      order.stub :item_total => 60
+      rule.should be_eligible(order)
+    end
+
+    it "should not be eligible when item total is greater than preferred amount and greater than preferred amount_max" do
+      order.stub :item_total => 61
       rule.should_not be_eligible(order)
     end
   end


### PR DESCRIPTION
Add 'less than' and 'less than or equal to' to ItemTotal Rule in promotions.

This is required in the following scenario:

There are multiple promotions from which only one is applicable at a time based on the cart amount(Item Total).

Small Cart Promotion : 5% discount if ItemTotal is between 100 and 200 
Medium Cart Promotion : 10% discount if ItemTotal is  between 200 and 400
Large Cart Promotion : 15% discount if ItemTotal is  greater than 400

![item_total](https://f.cloud.github.com/assets/1397023/2501863/d3b0046e-b370-11e3-9c53-a8d0abdd7f46.png)
