### PR TITLE
Touch product when updating images positions

### DIFF
--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -59,7 +59,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
 
   def update_positions
     params[:positions].each do |id, index|
-      model_class.where(:id => id).update_all(:position => index)
+      model_class.find(id).update_attributes(:position => index)
     end
 
     respond_to do |format|

--- a/backend/spec/controllers/spree/admin/resource_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/resource_controller_spec.rb
@@ -21,5 +21,12 @@ describe Spree::Admin::ResourceController do
         variant.reload
       }.to change(variant, :position).from(1).to(2)
     end
+
+    it "touches updated_at" do
+      expect {
+        spree_post :update_positions, id: variant.id, positions: { variant.id => "2" }, format: "js"
+        variant.reload
+      }.to change(variant, :updated_at)
+    end
   end
 end


### PR DESCRIPTION
of course this is slower than the previous direct SQL UPDATE but works as expected with 2.2+ caches.
