### PR TITLE
Spree::Variant.deleted? returns Boolean

### DIFF
--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -87,7 +87,7 @@ module Spree
     # allows extensions to override deleted? if they want to provide
     # their own definition.
     def deleted?
-      deleted_at
+      !!deleted_at
     end
 
     # Product may be created with deleted_at already set,


### PR DESCRIPTION
This change brings the `Variant` behavior in line with the `Product` behavior:

https://github.com/spree/spree/blob/master/core/app/models/spree/product.rb#L134
