### PR TITLE
Improve stub_authorization in controllers to fix the promotion admin spec

### DIFF
--- a/backend/app/controllers/spree/admin/promotions_controller.rb
+++ b/backend/app/controllers/spree/admin/promotions_controller.rb
@@ -15,7 +15,7 @@ module Spree
         end
 
         def collection
-          return @collection if @collection.present?
+          return @collection if defined?(@collection)
           params[:q] ||= HashWithIndifferentAccess.new
 
           @collection = super

--- a/backend/spec/controllers/spree/admin/promotions_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/promotions_controller_spec.rb
@@ -7,31 +7,30 @@ describe Spree::Admin::PromotionsController do
   let!(:promotion2) { create(:promotion, name: "name2", code: "code2", path: "path2") }
 
   context "#index" do
-
     it "succeeds" do
       spree_get :index
-      expect(assigns[:promotions].map(&:id)).to eq [promotion1.id, promotion2.id]
+      expect(assigns[:promotions]).to match_array [promotion1, promotion2]
     end
 
     context "search" do
       it "pages results" do
         spree_get :index, per_page: '1'
-        expect(assigns[:promotions].map(&:id)).to eq [promotion1.id]
+        expect(assigns[:promotions]).to eq [promotion1]
       end
 
       it "filters by name" do
         spree_get :index, q: {name_cont: promotion1.name}
-        expect(assigns[:promotions].map(&:id)).to eq [promotion1.id]
+        expect(assigns[:promotions]).to eq [promotion1]
       end
 
       it "filters by code" do
         spree_get :index, q: {code_cont: promotion1.code}
-        expect(assigns[:promotions].map(&:id)).to eq [promotion1.id]
+        expect(assigns[:promotions]).to eq [promotion1]
       end
 
       it "filters by path" do
         spree_get :index, q: {path_cont: promotion1.path}
-        expect(assigns[:promotions].map(&:id)).to eq [promotion1.id]
+        expect(assigns[:promotions]).to eq [promotion1]
       end
     end
   end

--- a/core/lib/spree/testing_support/authorization_helpers.rb
+++ b/core/lib/spree/testing_support/authorization_helpers.rb
@@ -1,45 +1,48 @@
 module Spree
   module TestingSupport
     module AuthorizationHelpers
+      module CustomAbility
+        def build_ability(&block)
+          block ||= proc{ |u| can :manage, :all }
+          Class.new do
+            include CanCan::Ability
+            define_method(:initialize, block)
+          end
+        end
+      end
+
       module Controller
-        def stub_authorization!
+        include CustomAbility
+
+        def stub_authorization!(&block)
+          ability_class = build_ability(&block)
           before do
-            controller.stub :authorize! => true
+            controller.stub(:current_ability).and_return{ ability_class.new(nil) }
           end
         end
       end
 
       module Request
-        class SuperAbility
-          include CanCan::Ability
-
-          def initialize(user)
-            # allow anyone to perform anything on anything
-            can :manage, :all
-          end
-        end
+        include CustomAbility
 
         def stub_authorization!
+          ability = build_ability
+
           after(:all) do
-            ability = Spree::TestingSupport::AuthorizationHelpers::Request::SuperAbility
             Spree::Ability.remove_ability(ability)
+          end
+
+          before(:all) do
+            Spree::Ability.register_ability(ability)
           end
 
           before do
             Api::BaseController.any_instance.stub :try_spree_current_user => Spree.user_class.new
           end
-
-          before(:all) do
-            ability = Spree::TestingSupport::AuthorizationHelpers::Request::SuperAbility
-            Spree::Ability.register_ability(ability)
-          end
         end
 
         def custom_authorization!(&block)
-          ability = Class.new do
-            include CanCan::Ability
-            define_method(:initialize, block)
-          end
+          ability = build_ability(&block)
           after(:all) do
             Spree::Ability.remove_ability(ability)
           end


### PR DESCRIPTION
The promotions_controller_spec has been failing since it was merged [:bomb:](http://ci.spree.fm/viewLog.html?buildId=49898&buildTypeId=bt76&tab=buildChangesDiv).

The existing stub_authorization for controllers stubbed out `authorize!`. This allowed any action, but made .accessible_by return an empty result set. It now behaves similarly to feature tests and returns a custom ability with all (or custom) permissions.
