### PR TITLE
Fixed duplicate address records being created during the checkout process

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -20,8 +20,8 @@ module Spree
     end
 
     def self.default(user = nil, kind = "bill")
-      if user
-        user.send(:"#{kind}_address") || build_default
+      if user && user_address = user.send(:"#{kind}_address")
+        user_address.clone
       else
         build_default
       end

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -28,7 +28,7 @@ module Spree
     mattr_reader *ATTRIBUTES
 
     @@address_attributes = [
-      :firstname, :lastname, :address1, :address2,
+      :id, :firstname, :lastname, :address1, :address2,
       :city, :country_id, :state_id, :zipcode, :phone,
       :state_name, :alternative_phone, :company,
       :country => [:iso, :name, :iso3, :iso_name],

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -140,6 +140,41 @@ describe Spree::CheckoutController do
         end
       end
 
+      context "with the order in the address state" do
+        before do
+          order.update_column(:state, "address")
+          order.stub :user => user
+        end
+
+        context "with a billing and shipping address" do
+          before do
+            order.ship_address = FactoryGirl.create(:address)
+
+            @expected_bill_address_id = order.bill_address.id
+            @expected_ship_address_id = order.ship_address.id
+
+            spree_post :update, {
+                :state => "address",
+                :order => {
+                    :bill_address_attributes => order.bill_address.attributes.except("created_at", "updated_at"),
+                    :ship_address_attributes => order.ship_address.attributes.except("created_at", "updated_at"),
+                    :use_billing => false
+                }
+            }
+
+            order.reload
+          end
+
+          it "should update the same billing address" do
+            expect(order.bill_address.id).to eq(@expected_bill_address_id)
+          end
+
+          it "should update the same shipping address" do
+            expect(order.ship_address.id).to eq(@expected_ship_address_id)
+          end
+        end
+      end
+
       context "when in the confirm state" do
         before do
           order.stub :confirmation_required? => true


### PR DESCRIPTION
The bug occurred when a user filled out their address details in the address step, continued to the delivery step, and then stepped back to address. When the user continued the checkout process again the addresses already entered would be recreated as new records in the database. This occurred because the id field wasn't permitted by the controller. Without the id the existing records could not be updated, resulting in new records being created.

This pull request includes a test that breaks without the supplied fix.
