### PR TITLE
persist show deleted products checkbox

### DIFF
--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -99,7 +99,7 @@ module Spree
 
           params[:q][:s] ||= "name asc"
           @collection = super
-          @collection = @collection.with_deleted if params[:q].delete(:deleted_at_null).blank?
+          @collection = @collection.with_deleted if params[:q][:deleted_at_null] == "0"
           # @search needs to be defined as this is passed to search_form_for
           @search = @collection.ransack(params[:q])
           @collection = @search.result.

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -37,7 +37,7 @@
           <div class="three columns omega">
             <div class="field checkbox">
               <label>
-                <%= f.check_box :deleted_at_null, {:checked => params[:q][:deleted_at_null].blank?}, '', '1' %>
+                <%= f.check_box :deleted_at_null, { :checked => params[:q][:deleted_at_null] == '0' }, '0', '1' %>
                 <%= Spree.t(:show_deleted) %>
               </label>
             </div>


### PR DESCRIPTION
I am not sure if there was a reason why the show deleted checkbox in the backend products index didn't carry it's state from one request to another or why it defaulted to showing deleted products..

This PR fixes both of these. Close if the current functionality is intended.
