### PR TITLE
Products index fix

### DIFF
--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -99,7 +99,7 @@ module Spree
 
           params[:q][:s] ||= "name asc"
           @collection = super
-          @collection = @collection.with_deleted if params[:q].delete(:deleted_at_null).blank?
+          @collection = @collection.with_deleted if params[:q][:deleted_at_null] == '0'
           # @search needs to be defined as this is passed to search_form_for
           @search = @collection.ransack(params[:q])
           @collection = @search.result.

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -37,7 +37,7 @@
           <div class="three columns omega">
             <div class="field checkbox">
               <label>
-                <%= f.check_box :deleted_at_null, {:checked => params[:q][:deleted_at_null].blank?}, '', '1' %>
+                <%= f.check_box :deleted_at_null, {:checked => params[:q][:deleted_at_null] == '0'}, '0', '1' %>
                 <%= Spree.t(:show_deleted) %>
               </label>
             </div>

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -335,7 +335,8 @@ describe "Products" do
           click_icon :trash
         end
         # This will show our deleted product
-        click_button "Search"
+        check "Show Deleted"
+        click_icon :search
         click_link product.name
         find("#product_price").value.to_f.should == product.price
       end


### PR DESCRIPTION
In the "it still being visible" test in the "deleting a product" spec, the show deleted box was never checked. The first commit checks that show deleted box before searching for the newly deleted product. 

The second commit defaults show deleted box to not be checked and keeps the checkbox from losing it's state when paginating.
