### PR TITLE
Allowed for client side validation of phone number and zip code to be turned off

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -82,15 +82,15 @@ module Spree
       }
     end
 
+    def require_phone?
+      true
+    end
+
+    def require_zipcode?
+      true
+    end
+
     private
-      def require_phone?
-        true
-      end
-
-      def require_zipcode?
-        true
-      end
-
       def state_validate
         # Skip state validation without country (also required)
         # or when disabled by preference

--- a/frontend/app/views/spree/address/_form.html.erb
+++ b/frontend/app/views/spree/address/_form.html.erb
@@ -59,12 +59,12 @@
   <% end %>
 
   <p class="field" id=<%="#{address_id}zipcode" %>>
-    <%= form.label :zipcode, Spree.t(:zip) %><span class="required">*</span><br />
-    <%= form.text_field :zipcode, :class => 'required' %>
+    <%= form.label :zipcode, Spree.t(:zip) %><% if address.require_zipcode? %><span class="required">*</span><br /><% end %>
+    <%= form.text_field :zipcode, :class => "#{'required' if address.require_zipcode?}" %>
   </p>
   <p class="field" id=<%="#{address_id}phone" %>>
-    <%= form.label :phone, Spree.t(:phone) %><span class="required">*</span><br />
-    <%= form.phone_field :phone, :class => 'required' %>
+    <%= form.label :phone, Spree.t(:phone) %><% if address.require_phone? %><span class="required">*</span><br /><% end %>
+    <%= form.phone_field :phone, :class => "#{'required' if address.require_phone?}" %>
   </p>
   <% if Spree::Config[:alternative_shipping_phone] %>
     <p class="field" id=<%="#{address_id}altphone" %>>


### PR DESCRIPTION
Although the validation for phone number and zip code could be turned off in the address class by changing the require_phone? and require_zipcode? methods, these methods didn't affect the client side validation. This meant that even with validation turned off, there was no way to make these fields optional if the visitor had javascript turned on.

I haven't included a test because I couldn't find any other tests for client side validation. I'd be happy to supply one if someone could point me in the right direction.
