### PR TITLE
current_store on spree frontend (+ fixes some frontend specs)

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -46,8 +46,8 @@ module Spree
       end
 
       meta.reverse_merge!({
-        keywords: Spree::Config[:default_meta_keywords],
-        description: Spree::Config[:default_meta_description]
+        keywords: current_store.meta_keywords,
+        description: current_store.meta_description,
       })
       meta
     end

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -19,9 +19,6 @@ require "spree/core/search/base"
 
 module Spree
   class AppConfiguration < Preferences::Configuration
-
-    attr_accessor :store
-
     # Alphabetized to more easily lookup particular preferences
     preference :address_requires_state, :boolean, default: true # should state/state_name be required
     preference :admin_interface_logo, :string, default: 'logo/spree_50.png'
@@ -91,18 +88,11 @@ module Spree
       default_seo_title: :seo_title,
     }
 
-    def default_store
-      # hack to access preferences on stores if spun up before the database exists
-      # safe to kill when all the Spree::Config access is gone
-      return OpenStruct.new if @store.nil? && !ActiveRecord::Base.connection.table_exists?(Spree::Store.table_name)
-      self.store ||= Spree::Store.first || Spree::Store.new
-    end
-
     DEPRECATED_STORE_PREFERENCES.each do |old_preference_name, store_method|
       # support all the old preference methods with a warning
       define_method "preferred_#{old_preference_name}" do
         ActiveSupport::Deprecation.warn("#{old_preference_name} is no longer supported on Spree::Config, please access it through #{store_method} on Spree::Store")
-        default_store.send(store_method)
+        Store.default.send(store_method)
       end
     end
   end

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -1,5 +1,9 @@
 module Spree
   class Store < ActiveRecord::Base
     validates :name, :url, :mail_from_address, presence: true
+
+    def self.default
+      first || new
+    end
   end
 end

--- a/core/lib/spree/core/controller_helpers/common.rb
+++ b/core/lib/spree/core/controller_helpers/common.rb
@@ -39,12 +39,12 @@ module Spree
           end
 
           def default_title
-            Spree::Config[:site_name]
+            current_store.name
           end
 
           # this is a hook for subclasses to provide title
           def accurate_title
-            Spree::Config[:default_seo_title]
+            current_store.seo_title
           end
 
           def render_404(exception = nil)

--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 describe Spree::BaseHelper do
   include Spree::BaseHelper
 
+  let(:current_store){ create :store }
+
   context "available_countries" do
     let(:country) { create(:country) }
 

--- a/frontend/app/controllers/spree/store_controller.rb
+++ b/frontend/app/controllers/spree/store_controller.rb
@@ -11,6 +11,11 @@ module Spree
       fresh_when(simple_current_order)
     end
 
+    def current_store
+      @current_store ||= Spree::Store.default
+    end
+    helper_method :current_store
+
     protected
       # This method is placed here so that the CheckoutController
       # and OrdersController can both reference it (or any other controller

--- a/frontend/app/views/spree/shared/_google_analytics.html.erb
+++ b/frontend/app/views/spree/shared/_google_analytics.html.erb
@@ -13,7 +13,7 @@
       ga('require', 'ecommerce', 'ecommerce.js');
       ga('ecommerce:addTransaction', {
         'id': '<%= j @order.number %>',                                     // Transaction ID. Required.
-        'affiliation': '<%= Spree::Config[:site_name] %>',                 // Affiliation or store name.
+        'affiliation': '<%= current_store.name %>',                 // Affiliation or store name.
         'revenue': '<%= @order.total %>',                                 // Grand Total.
         'shipping': '<%= @order.shipments.sum("cost + promo_total") %>', // Shipping.
         'tax': '<%= @order.all_adjustments.tax.sum(:amount) %>',        // Tax.

--- a/frontend/app/views/spree/shared/_head.html.erb
+++ b/frontend/app/views/spree/shared/_head.html.erb
@@ -3,7 +3,7 @@
 <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
 <meta content="width=device-width, initial-scale=1.0, maximum-scale=1" name="viewport">
 <%== meta_data_tags %>
-<%= canonical_tag(Spree::Config.site_url) %>
+<%= canonical_tag(current_store.url) %>
 <%= favicon_link_tag image_path('favicon.ico') %>
 <%= stylesheet_link_tag 'spree/frontend/all', :media => 'screen' %>
 <%= csrf_meta_tags %>

--- a/frontend/spec/features/template_rendering_spec.rb
+++ b/frontend/spec/features/template_rendering_spec.rb
@@ -11,7 +11,9 @@ describe "Template rendering" do
   end
 
   it 'layout should have canonical tag referencing site url' do
+    Spree::Store.create!(name: 'My Spree Store', url: 'spreestore.example.com', mail_from_address: 'test@example.com')
+
     visit spree.root_path
-    find('link[rel=canonical]')[:href].should eql('http://demo.spreecommerce.com/')
+    find('link[rel=canonical]')[:href].should eql('http://spreestore.example.com/')
   end
 end


### PR DESCRIPTION
Another baby step towards multitenancy.

This fixes [two failing frontend specs](http://ci.spree.fm/viewLog.html?buildId=50240&buildTypeId=bt78&tab=buildLog#_focus=1655) due to storing the "default site" across test cases. Also greatly reduces deprecation warnings in frontend specs.

This adds `current_store` to `Spree::StoreController` and exposes it as a helper method.
