### PR TITLE
Fix issue where payments can get their credit cards disassociated from t...

### DIFF
--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -113,8 +113,8 @@ module Spree
 
     # see https://github.com/spree/spree/issues/981
     def build_source
-      return if source_attributes.nil?
-      if payment_method and payment_method.payment_source_class
+      return unless new_record?
+      if source_attributes.present? && source.blank? && payment_method.try(:payment_source_class)
         self.source = payment_method.payment_source_class.new(source_attributes)
         self.source.payment_method_id = payment_method.id
         self.source.user_id = self.order.user_id if self.order

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -645,6 +645,12 @@ describe Spree::Payment do
       payment.source.should have(1).error_on(:number)
       payment.source.should have(1).error_on(:verification_value)
     end
+
+    it "does not build a new source when duplicating the model with source_attributes set" do
+      payment = create(:payment)
+      payment.source_attributes = params[:source_attributes]
+      expect { payment.dup }.to_not change { payment.source }
+    end
   end
 
   describe "#currency" do


### PR DESCRIPTION
...hem.

This was initially discovered when integrating with the paper_trail gem, which
calls dup in an after_update to try to capture the changed state of the
object, however, this could happen elsewhere and it is good to be
defensive here.
