### PR TITLE
Bug 2-2-stable fix: issue with cart_link not displaying in https

### DIFF
--- a/frontend/app/controllers/spree/store_controller.rb
+++ b/frontend/app/controllers/spree/store_controller.rb
@@ -2,6 +2,8 @@ module Spree
   class StoreController < Spree::BaseController
     include Spree::Core::ControllerHelpers::Order
 
+    ssl_allowed :cart_link
+    
     def unauthorized
       render 'spree/shared/unauthorized', :layout => Spree::Config[:layout], :status => 401
     end

--- a/frontend/spec/controllers/spree/store_controller_spec.rb
+++ b/frontend/spec/controllers/spree/store_controller_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe Spree::StoreController do
+  context "redirect_https_to_http enabled" do
+    before do
+      reset_spree_preferences do |config|
+        config.allow_ssl_in_development_and_test = true
+        config.redirect_https_to_http = true
+      end
+    end
+
+    context "receives a non SSL request" do
+      it "should not redirect" do
+        controller.should_not_receive(:redirect_to)
+        spree_get :cart_link
+        request.protocol.should eql('http://')
+      end
+    end
+
+    context "receives a SSL request" do
+      before do
+        request.env['HTTPS'] = 'on'
+      end
+
+      it "should not redirect" do
+        controller.should_not_receive(:redirect_to)
+        spree_get :cart_link
+        request.protocol.should eql('https://')
+      end
+    end
+  end
+end


### PR DESCRIPTION
(I guess due to mixed-mode ssl)

fixes issue with cart_link not displaying (I guess due to mixed-mode ssl)

This is due to https calls to /cart-link redirecting to http
I expect if I'm in https mode any calls should also be in https.

Using 2-2-stable and Rails 4.0.3

This occurs when there are products in the cart, and when in https mode within the Checkout process the following occurs:

I, [2014-03-30T14:03:31.852561 #1867]  INFO -- : Started GET "/cart_link" for 200.200.200.200 at 2014-03-30 14:03:31 +1100
I, [2014-03-30T14:03:31.858300 #1867]  INFO -- : Processing by Spree::StoreController#cart_link as _/_
I, [2014-03-30T14:03:31.859980 #1867]  INFO -- : Redirected to http://url.com/cart_link
I, [2014-03-30T14:03:31.860096 #1867]  INFO -- : Filter chain halted as :force_non_ssl_redirect rendered or redirected
I, [2014-03-30T14:03:31.860236 #1867]  INFO -- : Completed 301 Moved Permanently in 2ms (ActiveRecord: 0.0ms)
