### PR TITLE
More robust namespace adjusting

### DIFF
--- a/core/db/migrate/20130830001159_migrate_old_shipping_calculators.rb
+++ b/core/db/migrate/20130830001159_migrate_old_shipping_calculators.rb
@@ -3,7 +3,7 @@ class MigrateOldShippingCalculators < ActiveRecord::Migration
     Spree::ShippingMethod.all.each do |shipping_method|
       old_calculator = shipping_method.calculator
       next if old_calculator.class < Spree::ShippingCalculator # We don't want to mess with new shipping calculators
-      new_calculator = eval("Spree::Calculator::Shipping::#{old_calculator.class.name.demodulize}").new
+      new_calculator = eval(old_calculator.class.name.sub("::Calculator::", "::Calculator::Shipping::")).new
       new_calculator.preferences.keys.each do |pref|
         # Preferences can't be read/set by name, you have to prefix preferred_
         pref_method = "preferred_#{pref}"


### PR DESCRIPTION
As discussed in https://github.com/spree/spree/issues/4479, the existing migration would generate inaccurate class names due to the fact that `demodularize` will only select the very last part of the class name.

So, for instance,

`Spree::Calculator::Fedex::Ground`
would be changed to
`Spree::Calculator::Shipping::Ground`
which would trigger an `uninitialized constant` exception.
The desired new class name is
`Spree::Calculator::Shipping::Fedex::Ground`
and this suggested PR will handle those class name changes more appropriately.
