### PR TITLE
backend: Remove missing reports#show route

### DIFF
--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -119,7 +119,7 @@ Spree::Core::Engine.add_routes do
       end
     end
 
-    resources :reports, :only => [:index, :show] do
+    resources :reports, :only => [:index] do
       collection do
         get :sales_total
         post :sales_total


### PR DESCRIPTION
The [ReportsController](https://github.com/spree/spree/blob/master/backend/app/controllers/spree/admin/reports_controller.rb) has no show action, so it should not be in the routes.
