### PR TITLE
remove csrf-meta from partial bodies

### DIFF
--- a/backend/app/views/spree/admin/orders/customer_details/edit.html.erb
+++ b/backend/app/views/spree/admin/orders/customer_details/edit.html.erb
@@ -1,7 +1,5 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Customer Details' } %>
 
-<%= csrf_meta_tags %>
-
 <% content_for :page_title do %>
   <i class="icon-arrow-right"></i> <%= Spree.t(:customer_details) %>
 <% end %>

--- a/backend/app/views/spree/admin/orders/edit.html.erb
+++ b/backend/app/views/spree/admin/orders/edit.html.erb
@@ -1,4 +1,3 @@
-<%= csrf_meta_tags %>
 <% content_for :page_actions do %>
   <% if can?(:fire, @order) %>
     <li><%= event_links %></li>


### PR DESCRIPTION
I might be mistaken with this removal, however I couldn't find a reason for the csrf_meta tags to be included in these two partials as they are specified in the head.
