### PR TITLE
remove assign_stock_changes_to

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -85,10 +85,6 @@ module Spree
       !sufficient_stock?
     end
 
-    def assign_stock_changes_to=(shipment)
-      @preferred_shipment = shipment
-    end
-
     # Remove product default_scope `deleted_at: nil`
     def product
       variant.product


### PR DESCRIPTION
Nobody likes this function. It showed up to a party once and everyone
else left. Its parents are ashamed of it. It listens to bad music.
Removing it is doing the whole class a favour.
