### PR TITLE
Speed up admin/shipping_methods/_form with local var

### DIFF
--- a/backend/app/views/spree/admin/shipping_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/_form.html.erb
@@ -54,9 +54,10 @@
     <fieldset class="no-border-bottom">
       <legend align="center"><%= Spree.t(:zones) %></legend>
       <%= f.field_container :zones do %>
+        <% shipping_method_zones = @shipping_method.zones.to_a %>
         <% Spree::Zone.all.each do |zone| %>
           <%= label_tag do %>
-            <%= check_box_tag('shipping_method[zones][]', zone.id, @shipping_method.zones.include?(zone)) %>
+            <%= check_box_tag('shipping_method[zones][]', zone.id, shipping_method_zones.include?(zone)) %>
             <%= zone.name %>
           <% end %>
           <br>


### PR DESCRIPTION
I saw [almost 200](http://en.wikipedia.org/wiki/List_of_sovereign_states) calls to `Spree::Zone Exists (0.3ms)` when I viewed [admin/shipping_methods/_form](https://github.com/spree/spree/blob/2-0-stable/backend/app/views/spree/admin/shipping_methods/_form.html.erb) and thought: There must be a better way.

Here I suggest putting the `@shipping_method.zones` into a local variable so we can hit _that_ 200x instead of the db.

Notes:
- The `to_a` method is necessary to force Rails to evaluate the `.zones` scope. Otherwise it's not smart enough to evaluate it once-and-for-all, and we still get hundreds of db calls. (This actually seems to be undesirable Rails behavior IMHO.)
- If we want to, we could always simplify the array of `Zones` to an array of `ids` -- replacing `to_a` with `.pluck(:id)` and having the checkbox tag read `include?(zone.id)` instead of `include?(zone)`. However I'm not sure this additional change is necessary.
