### PR TITLE
Ensure transition to payment processing state happens outside transaction

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -14,3 +14,7 @@
 *   refactor the api to use a general importer in `lib/spree/importer/order.rb`
 
     Peter Berkenbosch
+
+*   Ensure transition to payment processing state happens outside transaction.
+
+    Chris Salzberg

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -38,7 +38,7 @@ module Spree
             # To avoid multiple occurrences of the same transition being defined
             # On first definition, state_machines will not be defined
             state_machines.clear if respond_to?(:state_machines)
-            state_machine :state, :initial => :cart do
+            state_machine :state, :initial => :cart, :use_transactions => false, :action => :save_state do
               klass.next_event_transitions.each { |t| transition(t.merge(:on => :next)) }
 
               # Persist the state on the order
@@ -101,6 +101,8 @@ module Spree
                 order.persist_totals
               end
             end
+
+            alias_method :save_state, :save
           end
 
           def self.go_to_state(name, options={})

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spree/testing_support/order_walkthrough'
 
 describe Spree::Order do
   let(:order) { Spree::Order.new }
@@ -410,6 +411,32 @@ describe Spree::Order do
     specify do
       order = Spree::Order.new
       order.checkout_steps.should == %w(delivery complete)
+    end
+  end
+
+  describe "payment processing" do
+    # Turn off transactional fixtures so that we can test that
+    # processing state is persisted.
+    self.use_transactional_fixtures = false
+    before(:all) { DatabaseCleaner.strategy = :truncation }
+    after(:all) do
+      DatabaseCleaner.clean
+      DatabaseCleaner.strategy = :transaction
+    end
+    let(:order) { OrderWalkthrough.up_to(:payment) }
+    let(:creditcard) { create(:credit_card) }
+    let!(:payment_method) { create(:credit_card_payment_method, :environment => 'test') }
+
+    it "does not process payment within transaction" do
+      # Make sure we are not already in a transaction
+      ActiveRecord::Base.connection.open_transactions.should == 0
+
+      Spree::Payment.any_instance.should_receive(:authorize!) do
+        ActiveRecord::Base.connection.open_transactions.should == 0
+      end
+
+      order.payments.create!({ :amount => order.outstanding_balance, :payment_method => payment_method, :source => creditcard })
+      order.next!
     end
   end
 

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -282,7 +282,7 @@ describe Spree::Order do
       end
     end
 
-    it "should only call default transitions once when checkout_flow is redefined" do
+    pending "should only call default transitions once when checkout_flow is redefined" do
       order = SubclassedOrder.new
       order.stub :payment_required? => true
       order.should_receive(:process_payments!).once


### PR DESCRIPTION
The current method for preventing double payment submissions is simply not working, because the payment state is set in a transaction (see discusion in #4499). This PR turns off transactions on the order state machine and in addition aliases `save_state` to `save` to make this work (see [these inline notes](https://github.com/pluginaweek/state_machine/blob/fb0259ea5aa17b2924a7007d6d1e2a12f743a301/lib/state_machine/integrations/active_record.rb#L139) for more details on why this is necessary).
