### PR TITLE
Remove Order#exclude_tax? as it is not used anywhere.

### DIFF
--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -52,7 +52,6 @@ module Spree
     preference :logo, :string, default: 'logo/spree_50.png'
     preference :max_level_in_taxons_menu, :integer, default: 1 # maximum nesting level in taxons menu
     preference :orders_per_page, :integer, default: 15
-    preference :prices_inc_tax, :boolean, default: false
     preference :products_per_page, :integer, default: 12
     preference :promotions_per_page, :integer, default: 15
     preference :redirect_https_to_http, :boolean, :default => false

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -204,14 +204,6 @@ module Spree
       Zone.match(tax_address) || Zone.default_tax
     end
 
-    # Indicates whether tax should be backed out of the price calcualtions in
-    # cases where prices include tax but the customer is not required to pay
-    # taxes in that case.
-    def exclude_tax?
-      return false unless Spree::Config[:prices_inc_tax]
-      return tax_zone != Zone.default_tax
-    end
-
     # Returns the address for taxation based on configuration
     def tax_address
       Spree::Config[:tax_using_ship_address] ? ship_address : bill_address

--- a/core/spec/models/spree/order/tax_spec.rb
+++ b/core/spec/models/spree/order/tax_spec.rb
@@ -82,37 +82,5 @@ module Spree
       end
     end
 
-
-    context "#exclude_tax?" do
-      before do
-        @order = create(:order)
-        @default_zone = create(:zone)
-        Spree::Zone.stub :default_tax => @default_zone
-      end
-
-      context "when prices include tax" do
-        before { Spree::Config.set(:prices_inc_tax => true) }
-
-        it "should be true when tax_zone is not the same as the default" do
-          @order.stub :tax_zone => create(:zone, :name => "other_zone")
-          @order.exclude_tax?.should be_true
-        end
-
-        it "should be false when tax_zone is the same as the default" do
-          @order.stub :tax_zone => @default_zone
-          @order.exclude_tax?.should be_false
-        end
-      end
-
-      context "when prices do not include tax" do
-        before { Spree::Config.set(:prices_inc_tax => false) }
-
-        it "should be false" do
-          @order.exclude_tax?.should be_false
-        end
-      end
-    end
   end
 end
-
-


### PR DESCRIPTION
I'm working through VAT tax setup issues, and have noticed this method doesn't appear to be being used anywhere after all the tax work you've been doing @radar.  I think it is due to tax calculated on line item level instead of the order level now.

I didn't want to push right away in case you have any insight into it.  Once I have my head wrapped around all the tax included in price changes that happened in issues like https://github.com/spree/spree/pull/4327 I'll merge this if you don't first.

Also I believe https://github.com/spree/spree/pull/4327 can be closed as it's merged unless your leaving it open for people to provide feedback.
