### PR TITLE
Replace Spree::Config[:site_name] with Spree::Store.current.name.

### DIFF
--- a/core/app/mailers/spree/order_mailer.rb
+++ b/core/app/mailers/spree/order_mailer.rb
@@ -3,14 +3,14 @@ module Spree
     def confirm_email(order, resend = false)
       @order = order.respond_to?(:id) ? order : Spree::Order.find(order)
       subject = (resend ? "[#{Spree.t(:resend).upcase}] " : '')
-      subject += "#{Spree::Config[:site_name]} #{Spree.t('order_mailer.confirm_email.subject')} ##{@order.number}"
+      subject += "#{Spree::Store.current.name} #{Spree.t('order_mailer.confirm_email.subject')} ##{@order.number}"
       mail(to: @order.email, from: from_address, subject: subject)
     end
 
     def cancel_email(order, resend = false)
       @order = order.respond_to?(:id) ? order : Spree::Order.find(order)
       subject = (resend ? "[#{Spree.t(:resend).upcase}] " : '')
-      subject += "#{Spree::Config[:site_name]} #{Spree.t('order_mailer.cancel_email.subject')} ##{@order.number}"
+      subject += "#{Spree::Store.current.name} #{Spree.t('order_mailer.cancel_email.subject')} ##{@order.number}"
       mail(to: @order.email, from: from_address, subject: subject)
     end
   end

--- a/core/app/mailers/spree/shipment_mailer.rb
+++ b/core/app/mailers/spree/shipment_mailer.rb
@@ -3,7 +3,7 @@ module Spree
     def shipped_email(shipment, resend = false)
       @shipment = shipment.respond_to?(:id) ? shipment : Spree::Shipment.find(shipment)
       subject = (resend ? "[#{Spree.t(:resend).upcase}] " : '')
-      subject += "#{Spree::Config[:site_name]} #{Spree.t('shipment_mailer.shipped_email.subject')} ##{@shipment.order.number}"
+      subject += "#{Spree::Store.current.name} #{Spree.t('shipment_mailer.shipped_email.subject')} ##{@shipment.order.number}"
       mail(to: @shipment.order.email, from: from_address, subject: subject)
     end
   end

--- a/core/app/mailers/spree/test_mailer.rb
+++ b/core/app/mailers/spree/test_mailer.rb
@@ -2,7 +2,7 @@ module Spree
   class TestMailer < BaseMailer
     def test_email(user)
       recipient = user.respond_to?(:id) ? user : Spree.user_class.find(user)
-      subject = "#{Spree::Config[:site_name]} #{Spree.t('test_mailer.test_email.subject')}"
+      subject = "#{Spree::Store.current.name} #{Spree.t('test_mailer.test_email.subject')}"
       mail(to: recipient.email, from: from_address, subject: subject)
     end
   end

--- a/core/app/models/spree/alert.rb
+++ b/core/app/models/spree/alert.rb
@@ -5,7 +5,7 @@ module Spree
     def self.current(host)
       params = {
         version: Spree.version,
-        name: Spree::Config[:site_name],
+        name: Spree::Store.current.name,
         host: host,
         rails_env: Rails.env,
         rails_version: Rails.version

--- a/core/spec/models/spree/alert_spec.rb
+++ b/core/spec/models/spree/alert_spec.rb
@@ -13,7 +13,7 @@ module Spree
       stub_request(:get, "alerts.spreecommerce.com/alerts.json").
         with(:query => {
           version: Spree.version,
-          name: Spree::Config[:site_name],
+          name: Spree::Store.current.name,
           host: "localhost",
           rails_env: Rails.env,
           rails_version: Rails.version


### PR DESCRIPTION
This gets rid of the millions of deprecation warnings in the rspec output.
