### PR TITLE
Remove Ruby 1.8 Specific Code

### DIFF
--- a/core/app/models/spree/calculator/price_sack.rb
+++ b/core/app/models/spree/calculator/price_sack.rb
@@ -1,6 +1,4 @@
 require_dependency 'spree/calculator'
-# For #to_d method on Ruby 1.8
-require 'bigdecimal/util'
 
 module Spree
   class Calculator::PriceSack < Calculator

--- a/core/app/models/spree/calculator/shipping/price_sack.rb
+++ b/core/app/models/spree/calculator/shipping/price_sack.rb
@@ -1,6 +1,4 @@
 require_dependency 'spree/shipping_calculator'
-# For #to_d method on Ruby 1.8
-require 'bigdecimal/util'
 
 module Spree
   module Calculator::Shipping


### PR DESCRIPTION
Master is > 1.9. Removing some code that is ruby 1.8 specific.
