### PR TITLE
silence Variant#in_stock? warning for correct usage

### DIFF
--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -149,9 +149,13 @@ module Spree
       "#{sku} #{options_text}".strip
     end
 
-    def in_stock?(quantity=1)
-      puts %q{[DEPRECATION] In Spree 2.2, Variant#in_stock? will no longer take a quantity. Use Variant#can_supply? instead.}
-      can_stock?(quantity)
+    def in_stock?(quantity=:argument_here_is_deprecated)
+      if quantity == :argument_here_is_deprecated
+        can_stock?(1)
+      else
+        puts %q{[DEPRECATION] In Spree 2.2, Variant#in_stock? will no longer take a quantity. Use Variant#can_supply? instead.}
+        can_stock?(quantity)
+      end
     end
 
     def can_stock?(quantity=1)


### PR DESCRIPTION
See comment here: https://github.com/spree/spree/commit/a7e6bc1#diff-f61dbf6358707ede7a8f24c85692baa5R147

It looks like it's still OK to call in_stock? without any arguments. If that's true then let's not print a deprecation notice when the method is called without arguments.

Or is the idea to get people to stop calling `in_stock?` completely?
