### PR TITLE
fix thank you message on order completion

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -68,7 +68,7 @@ module Spree
     end
 
     def flash_messages(opts = {})
-      opts[:ignore_types] = [:commerce_tracking].concat(Array(opts[:ignore_types]) || [])
+      opts[:ignore_types] = [:order_completed].concat(Array(opts[:ignore_types]) || [])
 
       flash.each do |msg_type, text|
         unless opts[:ignore_types].include?(msg_type)

--- a/core/app/helpers/spree/orders_helper.rb
+++ b/core/app/helpers/spree/orders_helper.rb
@@ -8,6 +8,10 @@ module Spree
     def truncated_product_description(product)
       truncate_html(raw(product.description))
     end
+
+    def order_just_completed?(order)
+      flash[:commerce_tracking] && order.present?
+    end
   end
 end
 

--- a/core/app/helpers/spree/orders_helper.rb
+++ b/core/app/helpers/spree/orders_helper.rb
@@ -10,7 +10,7 @@ module Spree
     end
 
     def order_just_completed?(order)
-      flash[:commerce_tracking] && order.present?
+      flash[:order_completed] && order.present?
     end
   end
 end

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -35,7 +35,7 @@ module Spree
         if @order.completed?
           session[:order_id] = nil
           flash.notice = Spree.t(:order_processed_successfully)
-          flash[:commerce_tracking] = "nothing special"
+          flash[:order_completed] = true
           redirect_to completion_route
         else
           redirect_to checkout_state_path(@order.state)
@@ -70,7 +70,7 @@ module Spree
       end
 
       def load_order_with_lock
-        @order = current_order(lock: true) 
+        @order = current_order(lock: true)
         redirect_to spree.cart_path and return unless @order
 
         if params[:state]

--- a/frontend/app/views/spree/orders/show.html.erb
+++ b/frontend/app/views/spree/orders/show.html.erb
@@ -3,7 +3,7 @@
   <h1><%= accurate_title %></h1>
 
   <div id="order" data-hook>
-    <% if params.has_key? :checkout_complete %>
+    <% if order_just_completed?(@order) %>
       <h1><%= Spree.t(:thank_you_for_your_order) %></h1>
     <% end %>
     <%= render :partial => 'spree/shared/order_details', :locals => { :order => @order } %>
@@ -12,7 +12,7 @@
 
     <p data-hook="links">
       <%= link_to Spree.t(:back_to_store), spree.root_path, :class => "button" %>
-      <% unless params.has_key? :checkout_complete %>
+      <% unless order_just_completed?(@order) %>
         <% if try_spree_current_user && respond_to?(:spree_account_path) %>
           <%= link_to Spree.t(:my_account), spree_account_path, :class => "button" %>
         <% end %>

--- a/frontend/app/views/spree/shared/_google_analytics.html.erb
+++ b/frontend/app/views/spree/shared/_google_analytics.html.erb
@@ -8,7 +8,7 @@
     ga('create', '<%= tracker.analytics_id %>','<%= Spree::Config[:site_url].sub!(/^www./,'') %>');
     ga('send', 'pageview');
 
-    <% if flash[:commerce_tracking] && @order.present? %>
+    <% if order_just_completed?(@order) %>
       <%# more info: https://developers.google.com/analytics/devguides/collection/analyticsjs/ecommerce %>
       ga('require', 'ecommerce', 'ecommerce.js');
       ga('ecommerce:addTransaction', {

--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -135,7 +135,7 @@ describe "Checkout", inaccessible: true do
 
   context "and likes to double click buttons" do
     let!(:user) { create(:user) }
-    
+
     let!(:order) do
       order = OrderWalkthrough.up_to(:delivery)
       order.stub :confirmation_required? => true
@@ -449,6 +449,38 @@ describe "Checkout", inaccessible: true do
       it 'should be displayed' do
         expect(page).to have_css("[data-hook=save_user_address]")
       end
+    end
+  end
+
+  context "when order is completed" do
+    let!(:user) { create(:user) }
+
+    let!(:order) do
+      order = OrderWalkthrough.up_to(:delivery)
+
+      order.reload
+      order.user = user
+      order.update!
+      order
+    end
+
+    before(:each) do
+      Spree::CheckoutController.any_instance.stub(:current_order => order)
+      Spree::CheckoutController.any_instance.stub(:try_spree_current_user => user)
+      Spree::OrdersController.any_instance.stub(:try_spree_current_user => user)
+
+      visit spree.checkout_state_path(:delivery)
+      click_button "Save and Continue"
+      click_button "Save and Continue"
+    end
+
+    it "displays a thank you message", js: true do
+      expect(page).to have_content(Spree.t(:thank_you_for_your_order))
+    end
+
+    it "does not display a thank you message on that order future visits", js: true do
+      visit spree.order_path(order)
+      expect(page).to_not have_content(Spree.t(:thank_you_for_your_order))
     end
   end
 


### PR DESCRIPTION
thank you message was no more displayed since it was using a wrong
params to test when order was just completed.
This solves the issue by using flash[:commerce_tracking] param
to test when to display the message. An helper method has been
added to avoid code duplication.

It follows this [mailing list thread](https://groups.google.com/forum/#!searchin/spree-user/Where$20is$20the$20checkout_complete$20key$20added$20to$20params$3F%7Csort:relevance%7Cspell:false/spree-user/GxQtP33m5-8/CtWyO1enJ34J)
