### PR TITLE
Distinct Order.created_between and completed_between methods

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -87,9 +87,8 @@ module Spree
       where(number: number)
     end
 
-    def self.between(start_date, end_date)
-      where(created_at: start_date..end_date)
-    end
+    scope :created_between, ->(start_date, end_date) { where(created_at: start_date..end_date) }
+    scope :completed_between, ->(start_date, end_date) { where(completed_at: start_date..end_date) }
 
     def self.by_customer(customer)
       joins(:user).where("#{Spree.user_class.table_name}.email" => customer)


### PR DESCRIPTION
Addresses the discussion in https://github.com/spree/spree/issues/4554
