### PR TITLE
Fix n+1 query performance issues on TaxRate.match method

### DIFF
--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -26,9 +26,10 @@ module Spree
 
     # Gets the array of TaxRates appropriate for the specified order
     def self.match(order)
-      return [] unless order.tax_zone
-      all.select do |rate|
-        rate.zone == order.tax_zone || rate.zone.contains?(order.tax_zone) || rate.zone.default_tax
+      order_zone = order.tax_zone
+      return [] unless order_zone
+      includes(zone: { zone_members: :zoneable }).all.select do |rate|
+        rate.zone == order_zone || rate.zone.contains?(order_zone) || rate.zone.default_tax
       end
     end
 


### PR DESCRIPTION
Modified Spree::TaxRate.match method to prevent n+1 queries, which were amplified by the fact that they were repeated in a select loop (specifically, repeated calls to order.tax_zone). 
With a large # tax rates and zones defined, this made checkout transition from address to payment state run extremely slow. No functional changes result in this update; simply a performance improvement to existing code by caching the order.tax_zone result in a local variable and eager loading the tax rate relations.

I don't believe this change applies to 2-2-stable and up, but this does affect 2-0-stable and 2-1-stable. Only tested locally for 2-0-stable.
