### PR TITLE
BOGO-like Promotion Calculator

### DIFF
--- a/core/app/models/spree/calculator/n_to_y_products_x_off.rb
+++ b/core/app/models/spree/calculator/n_to_y_products_x_off.rb
@@ -1,0 +1,64 @@
+require_dependency 'spree/calculator'
+
+module Spree
+  class Calculator::NToYProductsXOff < Calculator
+    preference :n_items, :integer, default: 1
+    preference :y_items, :integer, default: 2
+    preference :percent, :decimal, default: 50.0
+
+    def self.description
+      Spree.t(:n_to_y_products_off)
+    end
+
+    def compute(object = nil)
+      return 0 if object.nil?
+
+      # assumes that the products/variants in the rule are the variants targeted for the promotion
+
+      more_count = 1
+      discount = 0
+
+      self.matching_line_items(object).each do |line_item|
+        break if more_count > self.preferred_y_items
+
+        line_item.quantity.times do
+          break if more_count > self.preferred_y_items
+
+          if more_count > self.preferred_n_items
+            discount += line_item.price * self.preferred_percent / 100.0
+          end
+
+          more_count += 1
+        end
+      end
+
+      discount
+    end
+
+    protected
+
+      def matching_line_items(object = nil)
+        @matching_line_items ||= object.line_items.select { |l| matching_variants.include?(l.variant) }.sort_by! { |l| l.variant.price }
+      end
+
+      def matching_variants
+        @matching_variants ||= if compute_on_promotion?
+          self.calculable.promotion.rules.map do |rule|
+            if rule.respond_to?(:products)
+              rule.products.map(&:variants_including_master)
+            elsif rule.respond_to?(:variants)
+              rule.variants
+            else
+              []
+            end
+          end.flatten
+        end
+      end
+
+      # Determines wether or not the calculable object is a promotion
+      def compute_on_promotion?
+        @compute_on_promotion ||= self.calculable.respond_to?(:promotion)
+      end
+      
+  end
+end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -737,6 +737,7 @@ en:
     new_variant: New Variant
     new_zone: New Zone
     next: Next
+    n_to_y_products_x_off: N to Y Products x% off
     no_actions_added: No actions added
     no_orders_found: No orders found
     no_payment_methods_found: No payment methods found

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -48,7 +48,8 @@ module Spree
         app.config.spree.calculators.promotion_actions_create_adjustments = [
           Spree::Calculator::FlatPercentItemTotal,
           Spree::Calculator::FlatRate,
-          Spree::Calculator::FlexiRate
+          Spree::Calculator::FlexiRate,
+          Spree::Calculator::NToYProductsXOff
         ]
 
         app.config.spree.calculators.add_class('promotion_actions_create_item_adjustments')


### PR DESCRIPTION
Based off the conversation in #4516 there seems to be some interest in additional promotion calculators.

Here is a "N to Y for X percent off" calculator that enables BOGO and BOGO-like promotions. Some examples:
- Buy one get one free
- Buy one, get up to five 50% off
- Buy 5, get another 5 free
- Buy 2, get up to 30 10%

I wrote this for a 1.2.x store front. It needs some general cleanup and specs written. Before putting any additional effort in I wanted to see if this is something that would be merged into core.
