### PR TITLE
Add index to spree_orders for user_id & created_by_id

### DIFF
--- a/core/db/migrate/20140415041315_add_user_id_created_by_id_index_to_order.rb
+++ b/core/db/migrate/20140415041315_add_user_id_created_by_id_index_to_order.rb
@@ -3,4 +3,3 @@ class AddUserIdCreatedByIdIndexToOrder < ActiveRecord::Migration
     add_index :spree_orders, [:user_id, :created_by_id]
   end
 end
-https://github.com/spree/spree/issues/4582

--- a/core/db/migrate/20140415041315_add_user_id_created_by_id_index_to_order.rb
+++ b/core/db/migrate/20140415041315_add_user_id_created_by_id_index_to_order.rb
@@ -1,0 +1,6 @@
+class AddUserIdCreatedByIdIndexToOrder < ActiveRecord::Migration
+  def change
+    add_index :spree_orders, [:user_id, :created_by_id]
+  end
+end
+https://github.com/spree/spree/issues/4582


### PR DESCRIPTION
Addresses potential performance regressions discussed at https://github.com/spree/spree/issues/4582 in the last_incomplete_spree_order method arising after that method changed in https://github.com/spree/spree/commit/c455e1a7d675837e577e229fd1b479ae924fe020
