### PR TITLE
allow product rule to match 'none'

### DIFF
--- a/core/app/models/spree/promotion/rules/product.rb
+++ b/core/app/models/spree/promotion/rules/product.rb
@@ -7,7 +7,7 @@ module Spree
       class Product < PromotionRule
         has_and_belongs_to_many :products, class_name: '::Spree::Product', join_table: 'spree_products_promotion_rules', foreign_key: 'promotion_rule_id'
 
-        MATCH_POLICIES = %w(any all)
+        MATCH_POLICIES = %w(any all none)
         preference :match_policy, :string, default: MATCH_POLICIES.first
 
         # scope/association that is used to test eligibility
@@ -23,8 +23,10 @@ module Spree
           return true if eligible_products.empty?
           if preferred_match_policy == 'all'
             eligible_products.all? {|p| order.products.include?(p) }
-          else
+          elsif preferred_match_policy == 'any'
             order.products.any? {|p| eligible_products.include?(p) }
+          else
+            order.products.none? {|p| eligible_products.include?(p) }
           end
         end
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -896,6 +896,7 @@ en:
       label: Order must contain %{select} of these products
       match_all: all
       match_any: at least one
+      match_none: none 
       product_source:
         group: From product group
         manual: Manually choose

--- a/core/spec/models/spree/promotion/rules/product_spec.rb
+++ b/core/spec/models/spree/promotion/rules/product_spec.rb
@@ -46,5 +46,21 @@ describe Spree::Promotion::Rules::Product do
         rule.should_not be_eligible(order)
       end
     end
+
+    context "with 'none' match policy" do
+      before { rule.preferred_match_policy = 'none' }
+
+      it "should be eligible if none of the order's products are in eligible products" do
+        order.stub(:products => [@product1])
+        rule.stub(:eligible_products => [@product2, @product3])
+        rule.should be_eligible(order)
+      end
+
+      it "should not be eligible if any of the order's products are in eligible products" do
+        order.stub(:products => [@product1, @product2])
+        rule.stub(:eligible_products => [@product2, @product3])
+        rule.should_not be_eligible(order)
+      end
+    end
   end
 end


### PR DESCRIPTION
Change the product promotion rule to have an option to exclude products from a promotion.  This can be very useful when certain products can not be purchased at a discount.
