### PR TITLE
Add more schema changes that would use in configuration

### DIFF
--- a/core/db/migrate/20140227112348_add_preference_store_to_everything.rb
+++ b/core/db/migrate/20140227112348_add_preference_store_to_everything.rb
@@ -4,5 +4,17 @@ class AddPreferenceStoreToEverything < ActiveRecord::Migration
     add_column :spree_gateways, :preferences, :text
     add_column :spree_payment_methods, :preferences, :text
     add_column :spree_promotion_rules, :preferences, :text
+    add_column :spree_option_types, :preferences, :text
+    add_column :spree_option_values, :preferences, :text
+    add_column :spree_properties, :preferences, :text
+    add_column :spree_prototypes, :preferences, :text
+    add_column :spree_shipping_categories, :preferences, :text
+    add_column :spree_shipping_methods, :preferences, :text
+    add_column :spree_shipping_method_categories, :preferences, :text
+    add_column :spree_stock_locations, :preferences, :text
+    add_column :spree_tax_categories, :preferences, :text
+    add_column :spree_taxons, :preferences, :text
+    add_column :spree_taxonomies, :preferences, :text
+    add_column :spree_variants, :preferences, :text    
   end
 end


### PR DESCRIPTION
Since Spree preference refactoring: https://github.com/spree/spree/pull/4373, all models that implement preferable need to add preferences column respectively. I add more models here.
However, I think it's quite bother if we has to add preference column all by ourself.
Is there any thing we can do to make it better? For example: a rake task that can add preferences column to those models inherit from Spree::Base would be great.
