### PR TITLE
provide consistent sort order for promotions

### DIFF
--- a/backend/app/controllers/spree/admin/promotions_controller.rb
+++ b/backend/app/controllers/spree/admin/promotions_controller.rb
@@ -17,6 +17,7 @@ module Spree
         def collection
           return @collection if defined?(@collection)
           params[:q] ||= HashWithIndifferentAccess.new
+          params[:q][:s] ||= 'id desc'
 
           @collection = super
           @search = @collection.ransack(params[:q])

--- a/backend/spec/controllers/spree/admin/promotions_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/promotions_controller_spec.rb
@@ -9,13 +9,13 @@ describe Spree::Admin::PromotionsController do
   context "#index" do
     it "succeeds" do
       spree_get :index
-      expect(assigns[:promotions]).to match_array [promotion1, promotion2]
+      expect(assigns[:promotions]).to match_array [promotion2, promotion1]
     end
 
     context "search" do
       it "pages results" do
         spree_get :index, per_page: '1'
-        expect(assigns[:promotions]).to eq [promotion1]
+        expect(assigns[:promotions]).to eq [promotion2]
       end
 
       it "filters by name" do


### PR DESCRIPTION
make pagination sane for promotions.

especially true for postgres which seems to do more to keep its promise that "If sorting is not chosen, the rows will be returned in an unspecified order".

since there are no indexes on this table we just use the primary key with most recent first.
