### PR TITLE
Deprecates the Order#between method for created_between & completed_between

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -90,8 +90,12 @@ module Spree
       where(number: number)
     end
 
+    scope :created_between, ->(start_date, end_date) { where(created_at: start_date..end_date) }
+    scope :completed_between, ->(start_date, end_date) { where(completed_at: start_date..end_date) }
+
     def self.between(start_date, end_date)
-      where(created_at: start_date..end_date)
+      ActiveSupport::Deprecation.warn("Order#between will be deprecated in Spree 2.3, please use either Order#created_between or Order#completed_between instead.")
+      self.created_between(start_date, end_date)
     end
 
     def self.by_customer(customer)


### PR DESCRIPTION
Addresses the discussion in https://github.com/spree/spree/issues/4554 and https://github.com/spree/spree/pull/4577
