### PR TITLE
remove broken variant "deleted" scope

### DIFF
--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -43,9 +43,6 @@ module Spree
 
     after_touch :clear_in_stock_cache
 
-    # default variant scope only lists non-deleted variants
-    scope :deleted, lambda { where.not(deleted_at: nil) }
-
     def self.active(currency = nil)
       joins(:prices).where(deleted_at: nil).where('spree_prices.currency' => currency || Spree::Config[:currency]).where('spree_prices.amount IS NOT NULL')
     end


### PR DESCRIPTION
this "deleted" scope doesn't remove the default "deleted_at: nil" condition so it just produces a query like this:

``` sql
SELECT "spree_variants".*
FROM "spree_variants"
WHERE "spree_variants"."deleted_at" IS NULL
AND   "spree_variants"."deleted_at" IS NOT NULL
```

instead you have to use the "only_deleted" scope from the acts_as_paranoid gem
see https://github.com/goncalossilva/acts_as_paranoid/blob/ae0fe74/README.markdown#filtering

example: https://github.com/spree/spree/pull/4562
