### PR TITLE
Remove transaction around Spree::Payment state transitions.

### DIFF
--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -38,7 +38,7 @@ module Spree
     end
 
     # order state machine (see http://github.com/pluginaweek/state_machine/tree/master for details)
-    state_machine :initial => 'checkout' do
+    state_machine :initial => 'checkout', :use_transactions => false, :action => :save_state do
       # With card payments, happens before purchase or authorization happens
       event :started_processing do
         transition :from => ['checkout', 'pending', 'completed', 'processing'], :to => 'processing'
@@ -149,5 +149,7 @@ module Spree
           self.identifier = identifier
         end
       end
+
+      alias_method :save_state, :save
   end
 end


### PR DESCRIPTION
Similar to #4542 and #4499.

Payment state transitions are wrapped in transactions. In the case we are working with, we have a payment observer that runs an `after_transition` callback which triggers an electronic shipment, which can occasionally fail. When it fails it rolls back the entire transaction, including the payment.

This means that although the payment has been successfully processed, we see it as pending.

Stripping the transaction does not seem to cause any problems, and allows for this type of case (i.e. where a payment has succeeded, but an `after_callback` has failed) to persist the payment to the db. 

I'm submitting this to `1-3-stable` since that's what we're working with, but it should apply to master as well. I can add a test too, just let me know.

I think in general that no state transitions on spree models really need to be wrapped in transactions, they are just set that way by default by `state_machine`.
