### PR TITLE
Fix for User rules on Promotions

### DIFF
--- a/core/app/models/spree/promotion/rules/user.rb
+++ b/core/app/models/spree/promotion/rules/user.rb
@@ -2,8 +2,8 @@ module Spree
   class Promotion
     module Rules
       class User < PromotionRule
-        belongs_to :user, class_name: Spree.user_class
-        has_and_belongs_to_many :users, class_name: Spree.user_class, join_table: 'spree_promotion_rules_users', foreign_key: 'promotion_rule_id'
+        belongs_to :user, class_name: "::#{Spree.user_class.to_s}"
+        has_and_belongs_to_many :users, class_name: "::#{Spree.user_class.to_s}", join_table: 'spree_promotion_rules_users', foreign_key: 'promotion_rule_id'
 
         def applicable?(promotable)
           promotable.is_a?(Spree::Order)


### PR DESCRIPTION
If your Spree.user_class is  "User", adding users to the "Limit to Users" promotion rule will break. Fixes #4234
