### PR TITLE
Update orders.promo_total in OrderUpdater

### DIFF
--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -38,6 +38,7 @@ module Spree
     # +payment_total+      The total value of all finalized Payments (NOTE: non-finalized Payments are excluded)
     # +item_total+         The total value of all LineItems
     # +adjustment_total+   The total value of all adjustments (promotions, credits, etc.)
+    # +promo_total+        The total value of all promotion adjustments
     # +total+              The so-called "order total."  This is equivalent to +item_total+ plus +adjustment_total+.
     def update_totals
       order.payment_total = payments.completed.sum(:amount)
@@ -69,6 +70,10 @@ module Spree
       order.included_tax_total = line_items.sum(:included_tax_total) + shipments.sum(:included_tax_total)
       order.additional_tax_total = line_items.sum(:additional_tax_total) + shipments.sum(:additional_tax_total)
 
+      order.promo_total = line_items.sum(:promo_total) +
+                          shipments.sum(:promo_total) +
+                          adjustments.promotion.eligible.sum(:amount)
+
       update_order_total
     end
 
@@ -92,6 +97,7 @@ module Spree
         additional_tax_total: order.additional_tax_total,
         payment_total: order.payment_total,
         shipment_total: order.shipment_total,
+        promo_total: order.promo_total,
         total: order.total,
         updated_at: Time.now,
       )


### PR DESCRIPTION
orders.promo_total field wasn't getting updated in certain cases, like when you add the promo first and then a line item afterward.
the _adjustment_ got updated and the correct number was displayed in the cart, but the orders.promo_total value was incorrect.
