### PR TITLE
Improve Order#products and Order#variants methods

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -48,6 +48,8 @@ module Spree
     has_many :line_item_adjustments, through: :line_items, source: :adjustments
     has_many :shipment_adjustments, through: :shipments, source: :adjustments
     has_many :inventory_units, inverse_of: :order
+    has_many :products, through: :variants
+    has_many :variants, through: :line_items
 
     has_and_belongs_to_many :promotions, join_table: 'spree_orders_promotions'
 
@@ -391,14 +393,6 @@ module Spree
 
     def billing_lastname
       bill_address.try(:lastname)
-    end
-
-    def products
-      line_items.map(&:product)
-    end
-
-    def variants
-      line_items.map(&:variant)
     end
 
     def insufficient_stock_lines

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -447,10 +447,6 @@ describe Spree::Order do
       order.stub(:line_items => @line_items)
     end
 
-    it "should return ordered products" do
-      order.products.should == ['product1', 'product2']
-    end
-
     it "contains?" do
       order.contains?(@variant1).should be_true
     end


### PR DESCRIPTION
- Now they are an active record relations instead of an array (so much flexible).
- All the hard job is done by the database engine now.
