### PR TITLE
Fix 500 when updating order email to something inconsistent with the associated user's email

### DIFF
--- a/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
+++ b/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
@@ -21,7 +21,7 @@ module Spree
         def update
           if @order.update_attributes(order_params)
             if params[:guest_checkout] == "false"
-              @order.associate_user!(Spree.user_class.find_by_email(@order.email))
+              @order.associate_user!(Spree.user_class.find(params[:user_id]), @order.email.blank?)
             end
             while @order.next; end
 

--- a/backend/spec/features/admin/orders/customer_details_spec.rb
+++ b/backend/spec/features/admin/orders/customer_details_spec.rb
@@ -76,7 +76,7 @@ describe "Customer Details" do
       end
     end
 
-    it "can update user email for an existing order with a user" do
+    it "updates order email for an existing order with a user" do
       order.update_columns(ship_address_id: ship_address.id, bill_address_id: bill_address.id, state: "confirm", completed_at: nil)
       previous_user = order.user
       click_link "Customer Details"

--- a/backend/spec/features/admin/orders/customer_details_spec.rb
+++ b/backend/spec/features/admin/orders/customer_details_spec.rb
@@ -75,6 +75,16 @@ describe "Customer Details" do
         find(".state").text.should == "COMPLETE"
       end
     end
+
+    it "can update user email for an existing order with a user" do
+      order.update_columns(ship_address_id: ship_address.id, bill_address_id: bill_address.id, state: "confirm", completed_at: nil)
+      previous_user = order.user
+      click_link "Customer Details"
+      fill_in "order_email", with: "newemail@example.com"
+      expect { click_button "Update" }.to change { order.reload.email }.to "newemail@example.com"
+      expect(order.user_id).to eq previous_user.id
+      expect(order.user.email).to eq previous_user.email
+    end
   end
 
   context "country associated was removed" do

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -239,14 +239,16 @@ module Spree
     end
 
     # Associates the specified user with the order.
-    def associate_user!(user)
+    def associate_user!(user, override_email = true)
       self.user = user
-      self.email = user.email
-      self.created_by = user if self.created_by.blank?
+      attrs_to_set = { user_id: user.id }
+      attrs_to_set[:email] = user.email if override_email
+      attrs_to_set[:created_by_id] = user.id if self.created_by.blank?
+      assign_attributes(attrs_to_set)
 
       if persisted?
         # immediately persist the changes we just made, but don't use save since we might have an invalid address associated
-        self.class.unscoped.where(id: id).update_all(email: user.email, user_id: user.id, created_by_id: self.created_by_id)
+        self.class.unscoped.where(id: id).update_all(attrs_to_set)
       end
     end
 


### PR DESCRIPTION
Fixes #4614
