### PR TITLE
use .send(Kaminari.config.page_method_name) instead of .page()

### DIFF
--- a/api/app/controllers/spree/api/countries_controller.rb
+++ b/api/app/controllers/spree/api/countries_controller.rb
@@ -7,7 +7,8 @@ module Spree
       def index
         @countries = Country.accessible_by(current_ability, :read).ransack(params[:q]).result.
                      includes(:states).order('name ASC').
-                     page(params[:page]).per(params[:per_page])
+                     send(Kaminari.config.page_method_name, params[:page]).
+                     per(params[:per_page])
         country = Country.order("updated_at ASC").last
         if stale?(country)
           respond_with(@countries)

--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -37,7 +37,7 @@ module Spree
 
       def index
         authorize! :index, Order
-        @orders = Order.ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
+        @orders = Order.ransack(params[:q]).result.send(Kaminari.config.page_method_name, params[:page]).per(params[:per_page])
         respond_with(@orders)
       end
 
@@ -70,7 +70,7 @@ module Spree
 
       def mine
         if current_api_user.persisted?
-          @orders = current_api_user.orders.ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
+          @orders = current_api_user.orders.ransack(params[:q]).result.send(Kaminari.config.page_method_name, params[:page]).per(params[:per_page])
         else
           render "spree/api/errors/unauthorized", status: :unauthorized
         end

--- a/api/app/controllers/spree/api/payments_controller.rb
+++ b/api/app/controllers/spree/api/payments_controller.rb
@@ -6,7 +6,7 @@ module Spree
       before_filter :find_payment, only: [:update, :show, :authorize, :purchase, :capture, :void, :credit]
 
       def index
-        @payments = @order.payments.ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
+        @payments = @order.payments.ransack(params[:q]).result.send(Kaminari.config.page_method_name, params[:page]).per(params[:per_page])
         respond_with(@payments)
       end
 

--- a/api/app/controllers/spree/api/product_properties_controller.rb
+++ b/api/app/controllers/spree/api/product_properties_controller.rb
@@ -8,7 +8,8 @@ module Spree
       def index
         @product_properties = @product.product_properties.accessible_by(current_ability, :read).
                               ransack(params[:q]).result.
-                              page(params[:page]).per(params[:per_page])
+                              send(Kaminari.config.page_method_name, params[:page]).
+                              per(params[:per_page])
         respond_with(@product_properties)
       end
 

--- a/api/app/controllers/spree/api/products_controller.rb
+++ b/api/app/controllers/spree/api/products_controller.rb
@@ -9,7 +9,7 @@ module Spree
           @products = product_scope.ransack(params[:q]).result
         end
 
-        @products = @products.distinct.page(params[:page]).per(params[:per_page])
+        @products = @products.distinct.send(Kaminari.config.page_method_name, params[:page]).per(params[:per_page])
         expires_in 15.minutes, :public => true
         headers['Surrogate-Control'] = "max-age=#{15.minutes}"
       end

--- a/api/app/controllers/spree/api/properties_controller.rb
+++ b/api/app/controllers/spree/api/properties_controller.rb
@@ -13,7 +13,7 @@ module Spree
           @properties = @properties.ransack(params[:q]).result
         end
 
-        @properties = @properties.page(params[:page]).per(params[:per_page])
+        @properties = @properties.send(Kaminari.config.page_method_name, params[:page]).per(params[:per_page])
         respond_with(@properties)
       end
 

--- a/api/app/controllers/spree/api/return_authorizations_controller.rb
+++ b/api/app/controllers/spree/api/return_authorizations_controller.rb
@@ -22,7 +22,8 @@ module Spree
         authorize! :admin, ReturnAuthorization
         @return_authorizations = order.return_authorizations.accessible_by(current_ability, :read).
                                  ransack(params[:q]).result.
-                                 page(params[:page]).per(params[:per_page])
+                                 send(Kaminari.config.page_method_name, params[:page]).
+                                 per(params[:per_page])
         respond_with(@return_authorizations)
       end
 

--- a/api/app/controllers/spree/api/states_controller.rb
+++ b/api/app/controllers/spree/api/states_controller.rb
@@ -10,7 +10,7 @@ module Spree
                     includes(:country).order('name ASC')
 
         if params[:page] || params[:per_page]
-          @states = @states.page(params[:page]).per(params[:per_page])
+          @states = @states.send(Kaminari.config.page_method_name, params[:page]).per(params[:per_page])
         end
 
         state = @states.last

--- a/api/app/controllers/spree/api/stock_items_controller.rb
+++ b/api/app/controllers/spree/api/stock_items_controller.rb
@@ -4,7 +4,7 @@ module Spree
       before_filter :stock_location, except: [:update, :destroy]
 
       def index
-        @stock_items = scope.ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
+        @stock_items = scope.ransack(params[:q]).result.send(Kaminari.config.page_method_name, params[:page]).per(params[:per_page])
         respond_with(@stock_items)
       end
 

--- a/api/app/controllers/spree/api/stock_locations_controller.rb
+++ b/api/app/controllers/spree/api/stock_locations_controller.rb
@@ -3,7 +3,7 @@ module Spree
     class StockLocationsController < Spree::Api::BaseController
       def index
         authorize! :read, StockLocation
-        @stock_locations = StockLocation.accessible_by(current_ability, :read).order('name ASC').ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
+        @stock_locations = StockLocation.accessible_by(current_ability, :read).order('name ASC').ransack(params[:q]).result.send(Kaminari.config.page_method_name, params[:page]).per(params[:per_page])
         respond_with(@stock_locations)
       end
 

--- a/api/app/controllers/spree/api/stock_movements_controller.rb
+++ b/api/app/controllers/spree/api/stock_movements_controller.rb
@@ -5,7 +5,7 @@ module Spree
 
       def index
         authorize! :read, StockMovement
-        @stock_movements = scope.ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
+        @stock_movements = scope.ransack(params[:q]).result.send(Kaminari.config.page_method_name, params[:page]).per(params[:per_page])
         respond_with(@stock_movements)
       end
 

--- a/api/app/controllers/spree/api/taxonomies_controller.rb
+++ b/api/app/controllers/spree/api/taxonomies_controller.rb
@@ -5,7 +5,8 @@ module Spree
       def index
         @taxonomies = Taxonomy.accessible_by(current_ability, :read).order('name').includes(:root => :children).
                       ransack(params[:q]).result.
-                      page(params[:page]).per(params[:per_page])
+                      send(Kaminari.config.page_method_name, params[:page]).
+                      per(params[:per_page])
         respond_with(@taxonomies)
       end
 

--- a/api/app/controllers/spree/api/taxons_controller.rb
+++ b/api/app/controllers/spree/api/taxons_controller.rb
@@ -12,7 +12,7 @@ module Spree
           end
         end
 
-        @taxons = @taxons.page(params[:page]).per(params[:per_page])
+        @taxons = @taxons.send(Kaminari.config.page_method_name, params[:page]).per(params[:per_page])
         respond_with(@taxons)
       end
 
@@ -65,7 +65,7 @@ module Spree
         # Products#index does not do the sorting.
         taxon = Spree::Taxon.find(params[:id])
         @products = taxon.products.ransack(params[:q]).result
-        @products = @products.page(params[:page]).per(500 || params[:per_page])
+        @products = @products.send(Kaminari.config.page_method_name, params[:page]).per(500 || params[:per_page])
         render "spree/api/products/index"
       end
 

--- a/api/app/controllers/spree/api/users_controller.rb
+++ b/api/app/controllers/spree/api/users_controller.rb
@@ -3,7 +3,7 @@ module Spree
     class UsersController < Spree::Api::BaseController
 
       def index
-        @users = Spree.user_class.accessible_by(current_ability,:read).ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
+        @users = Spree.user_class.accessible_by(current_ability,:read).ransack(params[:q]).result.send(Kaminari.config.page_method_name, params[:page]).per(params[:per_page])
         respond_with(@users)
       end
 

--- a/api/app/controllers/spree/api/variants_controller.rb
+++ b/api/app/controllers/spree/api/variants_controller.rb
@@ -22,7 +22,8 @@ module Spree
 
       def index
         @variants = scope.includes(:option_values).ransack(params[:q]).result.
-          page(params[:page]).per(params[:per_page])
+          send(Kaminari.config.page_method_name, params[:page]).
+          per(params[:per_page])
         respond_with(@variants)
       end
 

--- a/api/app/controllers/spree/api/zones_controller.rb
+++ b/api/app/controllers/spree/api/zones_controller.rb
@@ -19,7 +19,7 @@ module Spree
       end
 
       def index
-        @zones = Zone.accessible_by(current_ability, :read).order('name ASC').ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
+        @zones = Zone.accessible_by(current_ability, :read).order('name ASC').ransack(params[:q]).result.send(Kaminari.config.page_method_name, params[:page]).per(params[:per_page])
         respond_with(@zones)
       end
 

--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -39,7 +39,7 @@ module Spree
         # e.g. SELECT  DISTINCT DISTINCT "spree_orders".id, "spree_orders"."created_at" AS alias_0 FROM "spree_orders"
         # see https://github.com/spree/spree/pull/3919
         @orders = @search.result(distinct: true).
-          page(params[:page]).
+          send(Kaminari.config.page_method_name, params[:page]).
           per(params[:per_page] || Spree::Config[:orders_per_page])
 
         # Restore dates

--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -105,7 +105,7 @@ module Spree
           @collection = @search.result.
                 distinct_by_product_ids(params[:q][:s]).
                 includes(product_includes).
-                page(params[:page]).
+                send(Kaminari.config.page_method_name, params[:page]).
                 per(Spree::Config[:admin_products_per_page])
 
           @collection

--- a/backend/app/controllers/spree/admin/promotions_controller.rb
+++ b/backend/app/controllers/spree/admin/promotions_controller.rb
@@ -23,7 +23,7 @@ module Spree
           @search = @collection.ransack(params[:q])
           @collection = @search.result(distinct: true).
             includes(promotion_includes).
-            page(params[:page]).
+            send(Kaminari.config.page_method_name, params[:page]).
             per(params[:per_page] || Spree::Config[:promotions_per_page])
 
           @collection

--- a/backend/app/controllers/spree/admin/stock_movements_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_movements_controller.rb
@@ -7,7 +7,7 @@ module Spree
       def index
         @stock_movements = stock_location.stock_movements.recent.
           includes(:stock_item => { :variant => :product }).
-          page(params[:page])
+          send(Kaminari.config.page_method_name, params[:page])
       end
 
       def new

--- a/backend/app/controllers/spree/admin/stock_transfers_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_transfers_controller.rb
@@ -9,7 +9,7 @@ module Spree
         @stock_transfers = @q.result
                              .includes(:stock_movements => { :stock_item => :stock_location })
                              .order('created_at DESC')
-                             .page(params[:page])
+                             .send(Kaminari.config.page_method_name, params[:page])
       end
 
       def show

--- a/backend/app/controllers/spree/admin/users_controller.rb
+++ b/backend/app/controllers/spree/admin/users_controller.rb
@@ -67,7 +67,7 @@ module Spree
       def orders
         params[:q] ||= {}
         @search = Spree::Order.ransack(params[:q].merge(user_id_eq: @user.id))
-        @orders = @search.result.page(params[:page]).per(Spree::Config[:admin_products_per_page])
+        @orders = @search.result.send(Kaminari.config.page_method_name, params[:page]).per(Spree::Config[:admin_products_per_page])
       end
 
       def items
@@ -76,7 +76,7 @@ module Spree
           line_items: {
             variant: [:product, { option_values: :option_type }]
           }).ransack(params[:q].merge(user_id_eq: @user.id))
-        @orders = @search.result.page(params[:page]).per(Spree::Config[:admin_products_per_page])
+        @orders = @search.result.send(Kaminari.config.page_method_name, params[:page]).per(Spree::Config[:admin_products_per_page])
       end
 
       def generate_api_key
@@ -112,7 +112,7 @@ module Spree
                               .limit(params[:limit] || 100)
           else
             @search = Spree.user_class.ransack(params[:q])
-            @collection = @search.result.page(params[:page]).per(Spree::Config[:admin_products_per_page])
+            @collection = @search.result.send(Kaminari.config.page_method_name, params[:page]).per(Spree::Config[:admin_products_per_page])
           end
         end
 

--- a/backend/app/controllers/spree/admin/zones_controller.rb
+++ b/backend/app/controllers/spree/admin/zones_controller.rb
@@ -13,7 +13,7 @@ module Spree
           params[:q] ||= {}
           params[:q][:s] ||= "ascend_by_name"
           @search = super.ransack(params[:q])
-          @zones = @search.result.page(params[:page]).per(params[:per_page])
+          @zones = @search.result.send(Kaminari.config.page_method_name, params[:page]).per(params[:per_page])
         end
 
         def load_data

--- a/core/lib/spree/core/search/base.rb
+++ b/core/lib/spree/core/search/base.rb
@@ -20,7 +20,7 @@ module Spree
           unless Spree::Config.show_products_without_price
             @products = @products.where("spree_prices.amount IS NOT NULL").where("spree_prices.currency" => current_currency)
           end
-          @products = @products.page(curr_page).per(per_page)
+          @products = @products.send(Kaminari.config.page_method_name, curr_page).per(per_page)
         end
 
         def method_missing(name)


### PR DESCRIPTION
will_paginate and kaminari fight each other. the following makes them tolerate each other

``` ruby
if defined?(WillPaginate)
  module WillPaginate
    module ActiveRecord
      module RelationMethods
        alias_method :per, :per_page
        alias_method :num_pages, :total_pages
      end
    end
  end
  ::ActiveRecord::Relation.send :include, Kaminari::ActiveRecordRelationMethods
  ::ActiveRecord::Relation.send :include, Kaminari::PageScopeMethods
end
```

but `build_searcher()` causes kaminaris `rel_next_prev_link_tags()` to fail

with this patch it is possible to use kaminaris `config.page_method_name = :kaminari_page` which allows them to play nice
