### PR TITLE
Update return_authorization.rb

### DIFF
--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -3,7 +3,7 @@ module Spree
     belongs_to :order, class_name: 'Spree::Order'
 
     has_many :inventory_units
-    has_one :stock_location
+    belongs_to :stock_location
     before_create :generate_number
     before_save :force_positive_amount
 


### PR DESCRIPTION
This should be a belongs_to since the stock_location_id is on the spree_return_authorizations table. Currently it throws an error

```
     Failure/Error: trial.purchase!({trial_item.id => :return})
     ActiveRecord::StatementInvalid:
       PG::UndefinedColumn: ERROR:  column spree_stock_locations.return_authorization_id does not exist
       LINE 1: ..._locations".* FROM "spree_stock_locations"  WHERE "spree_sto...
                                                                    ^
       : SELECT  "spree_stock_locations".* FROM "spree_stock_locations"  WHERE "spree_stock_locations"."return_authorization_id" = $1 LIMIT 1
```
