### PR TITLE
add validates_attachment to Spree::Taxon icon

### DIFF
--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -18,6 +18,7 @@ module Spree
       url: '/spree/taxons/:id/:style/:basename.:extension',
       path: ':rails_root/public/spree/taxons/:id/:style/:basename.:extension',
       default_url: '/assets/default_taxon.png'
+    validates_attachment :icon, content_type: { content_type: ["image/jpg", "image/jpeg", "image/png"] }
 
     include Spree::Core::ProductFilters  # for detailed defs of filters
 


### PR DESCRIPTION
Bump Paperclip to 4.1.1
https://github.com/spree/spree/commit/1922ad5f1765dfcc04442c848c967aa4b8912461#commitcomment-6159392
