### PR TITLE
Fix issue with stock movement routes.

### DIFF
--- a/backend/app/views/spree/admin/stock_movements/index.html.erb
+++ b/backend/app/views/spree/admin/stock_movements/index.html.erb
@@ -42,7 +42,7 @@
 <% else %>
   <div class="alpha twelve columns no-objects-found">
     <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/stock_movement')) %>,
-    <%= link_to Spree.t(:add_one), spree.new_admin_stock_movement_path %>!
+    <%= link_to Spree.t(:add_one), spree.new_admin_stock_location_stock_movement_path(@stock_location) %>!
   </div>
 <% end %>
 

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -136,7 +136,6 @@ Spree::Core::Engine.add_routes do
       end
     end
 
-    resources :stock_movements
     resources :stock_items, :only => [:create, :update, :destroy]
     resources :tax_rates
     resource  :tax_settings


### PR DESCRIPTION
The standard stock movement route depends upon stock_location being
specified. The StockMovementsController depends on a stock_location_id
being specified, so the correct stock movement route is the one nested
under stock location.

Using the non-nested route leads to an error "Couldn't find
Spree::StockLocation without an ID".
