### PR TITLE
Base CC expiry on the rails configured timezone

### DIFF
--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -28,4 +28,5 @@ group :test do
   gem 'simplecov'
   gem 'webmock', '1.8.11'
   gem 'poltergeist', '1.5.0'
+  gem 'timecop'
 end

--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -114,7 +114,7 @@ module Spree
 
     def expiry_not_in_the_past
       if year.present? && month.present?
-        time = "#{year}-#{month}-1".to_time
+        time = Time.zone.parse("#{year}-#{month}-1")
         if time < Time.zone.now.to_time.beginning_of_month
           errors.add(:base, :card_expired)
         end

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -100,6 +100,20 @@ describe Spree::CreditCard do
       credit_card.errors[:base].should == ["Card has expired"]
     end
 
+    it "should handle TZ correctly" do
+      # The card is valid according to the system clock's local time
+      # (Time.now).
+      # However it has expired in rails's configured time zone (Time.current),
+      # which is the value we should be respecting.
+      time = Time.new(2014, 04, 30, 23, 0, 0, "-07:00")
+      Timecop.freeze(time) do
+        credit_card.month = 1.month.ago.month
+        credit_card.year = 1.month.ago.year
+        credit_card.should_not be_valid
+        credit_card.errors[:base].should == ["Card has expired"]
+      end
+    end
+
     it "does not run expiration in the past validation if month is not set" do
       credit_card.month = nil
       credit_card.year = Time.now.year


### PR DESCRIPTION
I'd rather `rm -Rf` all timezones worldwide, but the UN isn't accepting pull requests.
