### PR TITLE
fix slug uniqueness error when clone product

### DIFF
--- a/core/lib/spree/core/product_duplicator.rb
+++ b/core/lib/spree/core/product_duplicator.rb
@@ -23,6 +23,7 @@ module Spree
     def duplicate_product
       product.dup.tap do |new_product|
         new_product.name = "COPY OF #{product.name}"
+        new_product.slug = "#{DateTime.now.to_i}_#{product.slug}"
         new_product.taxons = product.taxons
         new_product.created_at = nil
         new_product.deleted_at = nil


### PR DESCRIPTION
slug must be unique, or db will throw ActiveRecord::RecordNotUnique error
Please refer to this issue: https://github.com/spree/spree/issues/4617
