### PR TITLE
Remove useless return in the show action from the products controller

### DIFF
--- a/frontend/app/controllers/spree/products_controller.rb
+++ b/frontend/app/controllers/spree/products_controller.rb
@@ -13,8 +13,6 @@ module Spree
     end
 
     def show
-      return unless @product
-
       @variants = @product.variants_including_master.active(current_currency).includes([:option_values, :images])
       @product_properties = @product.product_properties.includes(:property)
       @taxon = Spree::Taxon.find(params[:taxon_id]) if params[:taxon_id]


### PR DESCRIPTION
load_product method will raise an ActiveRecord::RecordNotFound exception if the product could not be find, that exception will stop the method execution, so checking for @product to be set is not necessary.
