### PR TITLE
Optimize touch_taxons on product.

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -258,10 +258,10 @@ module Spree
       # Iterate through this products taxons and taxonomies and touch their timestamps in a batch
       def touch_taxons
         taxons_to_touch = taxons.map(&:self_and_ancestors).flatten.uniq
-        Spree::Taxon.where(id: taxons_to_touch.map(&:id)).update_all(updated_at: Time.now)
+        Spree::Taxon.where(id: taxons_to_touch.map(&:id)).update_all(updated_at: Time.current)
 
         taxonomy_ids_to_touch = taxons_to_touch.map(&:taxonomy_id).flatten.uniq
-        Spree::Taxonomy.where(id: taxonomy_ids_to_touch).update_all(updated_at: Time.now)
+        Spree::Taxonomy.where(id: taxonomy_ids_to_touch).update_all(updated_at: Time.current)
       end
   end
 end

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -255,8 +255,13 @@ module Spree
         self.master ||= Variant.new
       end
 
+      # Iterate through this products taxons and taxonomies and touch their timestamps in a batch
       def touch_taxons
-        self.taxons.each(&:touch)
+        taxons_to_touch = taxons.map(&:self_and_ancestors).flatten.uniq
+        Spree::Taxon.where(id: taxons_to_touch.map(&:id)).update_all(updated_at: Time.now)
+
+        taxonomy_ids_to_touch = taxons_to_touch.map(&:taxonomy_id).flatten.uniq
+        Spree::Taxonomy.where(id: taxonomy_ids_to_touch).update_all(updated_at: Time.now)
       end
   end
 end


### PR DESCRIPTION
This will touch all of the taxons and taxon ancestors for  a product
using a constant number of updates (2, one for taxons, one for
taxonomies).

Previously the number of updates would be 2 \* the number of taxons &
taxon ancestors, as it would update the taxonmy for each taxon on each
update.

Example Case:

I encountered this issue when adding a new stock location to a store which has 890 products, and 265 taxons.  With propagate all variants on, it needs to insert a new stock item for each variant.

Therefore it needs to:
- Insert a stock item
- Touch the variants timestamp
- Touch the products timestamp
- Touch the timestamp of the products taxons, and all ancestor taxons
- Touch the timestamp of the taxonomy for each of these taxons

Here is a comparison of creating a new stock location before and after on this sample data set:

| Metric | Before | After |
| --- | --- | --- |
| Log | [Gist](https://gist.github.com/gmacdougall/b8c789d5dadda74bb745) | [Gist](https://gist.github.com/gmacdougall/b51af2f6912ccdd8f53f) |
| Total Queries | 96,787 | 14,624 |
| Total Updates | 50,358 | 3,560 |
