### PR TITLE
Clear order checkout controller

### DIFF
--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -8,12 +8,6 @@ module Spree
       # This before_filter comes from Spree::Core::ControllerHelpers::Order
       skip_before_filter :set_current_order
 
-      def create
-        authorize! :create, Order
-        @order = Spree::Core::Importer::Order.import(current_api_user, nested_params)
-        respond_with(@order, default_template: 'spree/api/orders/show', status: 201)
-      end
-
       def next
         load_order(true)
         authorize! :update, @order, order_token
@@ -28,10 +22,6 @@ module Spree
         authorize! :update, @order, order_token
         while @order.next; end
         respond_with(@order, default_template: 'spree/api/orders/show', status: 200)
-      end
-
-      def show
-        redirect_to(api_order_path(params[:id]), status: 301)
       end
 
       def update

--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -28,11 +28,7 @@ module Spree
         load_order(true)
         authorize! :update, @order, order_token
 
-        line_items = nested_params.delete('line_items_attributes')
-
         if @order.update_from_params(params, permitted_checkout_attributes)
-
-          @order.update_line_items(line_items)
           if current_api_user.has_spree_role?('admin') && user_id.present?
             @order.associate_user!(Spree.user_class.find(user_id))
           end
@@ -82,14 +78,6 @@ module Spree
 
         def before_payment
           @order.payments.destroy_all if request.put?
-        end
-
-        def next!(options={})
-          if @order.valid? && @order.next
-            render 'spree/api/orders/show', status: options[:status] || 200
-          else
-            render 'spree/api/orders/could_not_transition', status: 422
-          end
         end
 
         def after_update_attributes

--- a/api/app/controllers/spree/api/line_items_controller.rb
+++ b/api/app/controllers/spree/api/line_items_controller.rb
@@ -16,7 +16,6 @@ module Spree
       def update
         @line_item = find_line_item
         if @order.contents.update_cart(line_items_attributes)
-          @order.ensure_updated_shipments
           @line_item.reload
           respond_with(@line_item, default_template: :show)
         else

--- a/api/app/controllers/spree/api/line_items_controller.rb
+++ b/api/app/controllers/spree/api/line_items_controller.rb
@@ -1,11 +1,11 @@
 module Spree
   module Api
     class LineItemsController < Spree::Api::BaseController
-
       def create
         variant = Spree::Variant.find(params[:line_item][:variant_id])
         @line_item = order.contents.add(variant, params[:line_item][:quantity])
-        if @line_item.save
+
+        if @line_item.errors.empty?
           @order.ensure_updated_shipments
           respond_with(@line_item, status: 201, default_template: :show)
         else
@@ -33,7 +33,6 @@ module Spree
       end
 
       private
-
         def order
           @order ||= Spree::Order.includes(:line_items).find_by!(number: order_id)
           authorize! :update, @order, order_token

--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -29,8 +29,6 @@ module Spree
       def empty
         authorize! :update, @order, order_token
         @order.empty!
-        @order.update!
-
         render text: nil, status: 200
       end
 

--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -112,14 +112,6 @@ module Spree
           [:import, :number, :completed_at, :locked_at, :channel]
         end
 
-        def next!(options={})
-          if @order.valid? && @order.next
-            render :show, status: options[:status] || 200
-          else
-            render :could_not_transition, status: 422
-          end
-        end
-
         def find_order(lock = false)
           @order = Spree::Order.lock(lock).find_by!(number: params[:id])
         end

--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -1,9 +1,10 @@
 module Spree
   module Api
     class OrdersController < Spree::Api::BaseController
-
       skip_before_filter :check_for_user_or_api_key, only: :apply_coupon_code
       skip_before_filter :authenticate_user, only: :apply_coupon_code
+
+      before_filter :find_order, except: [:create, :mine, :index, :update]
 
       # Dynamically defines our stores checkout steps to ensure we check authorization on each step.
       Order.checkout_steps.keys.each do |step|
@@ -14,7 +15,6 @@ module Spree
       end
 
       def cancel
-        find_order
         authorize! :update, @order, params[:token]
         @order.cancel!
         render :show
@@ -27,10 +27,10 @@ module Spree
       end
 
       def empty
-        find_order
         authorize! :update, @order, order_token
         @order.empty!
         @order.update!
+
         render text: nil, status: 200
       end
 
@@ -41,7 +41,6 @@ module Spree
       end
 
       def show
-        find_order
         authorize! :show, @order, order_token
         method = "before_#{@order.state}"
         send(method) if respond_to?(method, true)
@@ -151,7 +150,6 @@ module Spree
         def order_id
           super || params[:id]
         end
-
     end
   end
 end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -44,7 +44,7 @@ Spree::Core::Engine.add_routes do
       end
     end
 
-    resources :checkouts, concerns: :order_routes do
+    resources :checkouts, only: [:update], concerns: :order_routes do
       member do
         put :next
         put :advance

--- a/api/spec/controllers/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/controllers/spree/api/checkouts_controller_spec.rb
@@ -21,31 +21,6 @@ module Spree
       Spree::Config[:track_inventory_levels] = true
     end
 
-    context "GET 'show'" do
-      let(:order) { create(:order) }
-
-      it "redirects to Orders#show" do
-        api_get :show, :id => order.number
-        response.status.should == 301
-        response.should redirect_to("/api/orders/#{order.number}")
-      end
-    end
-
-    context "POST 'create'" do
-      it "creates a new order when no parameters are passed" do
-        api_post :create
-
-        json_response['number'].should be_present
-        response.status.should == 201
-      end
-
-      it "assigns email when creating a new order" do
-        api_post :create, :order => { :email => "guest@spreecommerce.com" }
-        expect(json_response['email']).not_to eq controller.current_api_user
-        expect(json_response['email']).to eq "guest@spreecommerce.com"
-      end
-    end
-
     context "PUT 'update'" do
       let(:order) do
         order = create(:order_with_line_items)
@@ -54,7 +29,6 @@ module Spree
         order.shipments.delete_all
         order
       end
-
 
       before(:each) do
         Order.any_instance.stub(:confirmation_required? => true)

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -143,15 +143,24 @@ module Spree
     it "can create an order" do
       api_post :create, :order => { :line_items => { "0" => { :variant_id => variant.to_param, :quantity => 5 } } }
       response.status.should == 201
+
       order = Order.last
       order.line_items.count.should == 1
       order.line_items.first.variant.should == variant
       order.line_items.first.quantity.should == 5
+
+      json_response['number'].should be_present
       json_response["token"].should_not be_blank
       json_response["state"].should == "cart"
       order.user.should == current_api_user
       order.email.should == current_api_user.email
       json_response["user_id"].should == current_api_user.id
+    end
+
+    it "assigns email when creating a new order" do
+      api_post :create, :order => { :email => "guest@spreecommerce.com" }
+      expect(json_response['email']).not_to eq controller.current_api_user
+      expect(json_response['email']).to eq "guest@spreecommerce.com"
     end
 
     # Regression test for #3404

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -267,7 +267,7 @@ module Spree
       it "updates quantities of existing line items" do
         api_put :update, :id => order.to_param, :order => {
           :line_items => {
-            0 => { :id => line_item.id, :quantity => 10 }
+            "0" => { :id => line_item.id, :quantity => 10 }
           }
         }
 
@@ -280,8 +280,8 @@ module Spree
         variant2 = create(:variant)
         api_put :update, :id => order.to_param, :order => {
           :line_items => {
-            0 => { :id => line_item.id, :quantity => 10 },
-            1 => { :variant_id => variant2.id, :quantity => 1}
+            "0" => { :id => line_item.id, :quantity => 10 },
+            "1" => { :variant_id => variant2.id, :quantity => 1}
           }
         }
 


### PR DESCRIPTION
Hey @radar here's a first part of a work motivated by quick twitter chat. Reviewing the contents of api orders, checkouts and line items controller. There's a couple breaking changes here and I want to write some changelogs before it reaches master. Some of the commits below might also be cherry-picked to stable branches as they're more like performance improvements.

Here are a few assumptions I suggest we make so the order / checkout api gets more clear:
- CheckoutController does stuff related to checkout only. Much like what happens in frontend. It moves the order through its different states and deals with parameters related to those things.
- LineItemController is the way to add an item to cart or update a single item on cart. Let's take that responsability out ot CheckoutController. 
- Creating an Order is OrderController duty only. So is showing an order as well as any other after completed order action, e.g. cancel.

I guess I never really looked at those three controllers in a roll until an hour ago. The main reason I believe CheckoutController should still live with OrderController is that the later already does way too much and looking at frontend checkout controller there's also a lot of other stuff (e.g. filter callbacks) only related to checkout.

Next I want to build this common interface in spree_core that both frontend and api checkout controllers could use. Doing everything via nested attributes always felt confusing for me.  

If you have strong opinions about any of the changes let me know otherwise I should merge it soon. Also I'd love to know if you guys have any other ideas on how spree api checkout calls should look like.
