### PR TITLE
Stock item inventory fix (issue #4651)

### DIFF
--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -11,7 +11,11 @@ module Spree
 
     attr_accessible :count_on_hand, :variant, :stock_location, :backorderable, :variant_id
 
-    delegate :weight, :should_track_inventory?, to: :variant
+    delegate :weight, to: :variant
+
+    def should_track_inventory?
+      variant.nil? ? false : variant.should_track_inventory?
+    end
 
     def backordered_inventory_units
       Spree::InventoryUnit.backordered_for_stock_item(self)

--- a/core/spec/models/spree/stock_item_spec.rb
+++ b/core/spec/models/spree/stock_item_spec.rb
@@ -149,4 +149,28 @@ describe Spree::StockItem do
       }.to raise_error
     end
   end
+
+  context "inventory tracking" do
+
+    before do
+      subject.variant.track_inventory = true
+    end
+
+    it "tracks inventory by variant setting" do
+      expect(subject.should_track_inventory?).to eq true
+    end
+
+    context "deleted variant" do
+      before do
+        subject.variant.destroy
+        subject.reload
+      end
+
+      it "does not track inventory" do
+        expect(subject.should_track_inventory?).to eq false
+      end
+    end
+
+  end
+
 end


### PR DESCRIPTION
Fixes https://github.com/spree/spree/issues/4651 by checking for active variant and returning false if associated variant has been deleted. This seems like the most reasonable approach in this case, because there's no reason to track inventory for a deleted variant, regardless of its original settings.
