### PR TITLE
Stock::Quantifier must take a variant, not an id

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -78,7 +78,7 @@ module Spree
     end
 
     def sufficient_stock?
-      Stock::Quantifier.new(variant_id).can_supply? quantity
+      Stock::Quantifier.new(variant).can_supply? quantity
     end
 
     def insufficient_stock?

--- a/core/app/models/spree/stock/availability_validator.rb
+++ b/core/app/models/spree/stock/availability_validator.rb
@@ -10,7 +10,7 @@ module Spree
           quantity = line_item.quantity
         end
 
-        quantifier = Stock::Quantifier.new(line_item.variant_id)
+        quantifier = Stock::Quantifier.new(line_item.variant)
 
         unless quantifier.can_supply? quantity
           variant = line_item.variant

--- a/core/app/models/spree/stock/quantifier.rb
+++ b/core/app/models/spree/stock/quantifier.rb
@@ -4,7 +4,7 @@ module Spree
       attr_reader :stock_items
 
       def initialize(variant)
-        @variant = resolve_variant_id(variant)
+        @variant = variant
         @stock_items = Spree::StockItem.joins(:stock_location).where(:variant_id => @variant, Spree::StockLocation.table_name =>{ :active => true})
       end
 
@@ -22,14 +22,6 @@ module Spree
 
       def can_supply?(required)
         total_on_hand >= required || backorderable?
-      end
-
-      private
-
-      # return variant when passed either variant object or variant id
-      def resolve_variant_id(variant)
-        variant = Spree::Variant.find_by_id(variant) unless variant.respond_to?(:should_track_inventory?)
-        variant
       end
 
     end


### PR DESCRIPTION
This is an alternative to #4658

@brchristian pointed out that the previous resolve_variant_id logic was broken
when a variant had been deleted.

This removes the resolve_variant_id private method from Quantifier, and 
reuqires that a variant object be passed in. Finding associated variants 
should be the resposibility of the caller, and the code to load a variant
unscoped need not be here.
