### PR TITLE
WIP: Adding retrieve_variants to the Searcher API

### DIFF
--- a/api/app/controllers/spree/api/variants_controller.rb
+++ b/api/app/controllers/spree/api/variants_controller.rb
@@ -1,6 +1,7 @@
 module Spree
   module Api
     class VariantsController < Spree::Api::BaseController
+      include Spree::Core::ControllerHelpers::Search
 
       before_filter :product
 
@@ -20,9 +21,15 @@ module Spree
         respond_with(@variant, status: 204)
       end
 
-      def index
-        @variants = scope.includes(:option_values).ransack(params[:q]).result.
-          page(params[:page]).per(params[:per_page])
+      def index  
+        @variants = build_searcher(
+          :Variant, {
+            scope:    scope,
+            q:        params[:q],
+            page:     params[:page],
+            per_page: params[:per_page]
+          }
+        ).search
         respond_with(@variants)
       end
 

--- a/api/spec/controllers/spree/api/variants_controller_spec.rb
+++ b/api/spec/controllers/spree/api/variants_controller_spec.rb
@@ -39,7 +39,7 @@ module Spree
 
     it 'can query the results through a paramter' do
       expected_result = create(:variant, :sku => 'FOOBAR')
-      api_get :index, :q => { :sku_cont => 'FOO' }
+      api_get :index, :q => 'FOO'
       json_response['count'].should == 1
       json_response['variants'].first['sku'].should eq expected_result.sku
     end

--- a/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js.erb
@@ -26,9 +26,7 @@ $.fn.variantAutocomplete = function() {
       datatype: 'json',
       data: function(term, page) {
         return {
-          q: {
-            "product_name_or_sku_cont": term
-          }
+          q: term
         }
       },
       results: function (data, page) {

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -15,7 +15,7 @@
 # a.get :color
 # a.preferred_color
 #
-require "spree/core/search/base"
+require "spree/core/search"
 
 module Spree
   class AppConfiguration < Preferences::Configuration
@@ -91,7 +91,7 @@ module Spree
 
     # searcher_class allows spree extension writers to provide their own Search class
     def searcher_class
-      @searcher_class ||= Spree::Core::Search::Base
+      @searcher_class ||= Spree::Core::Search
     end
 
     def searcher_class=(sclass)

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -79,10 +79,6 @@ module Spree
       values.to_sentence({ words_connector: ", ", two_words_connector: ", " })
     end
 
-    def gross_profit
-      cost_price.nil? ? 0 : (price - cost_price)
-    end
-
     # use deleted? rather than checking the attribute directly. this
     # allows extensions to override deleted? if they want to provide
     # their own definition.

--- a/core/lib/spree/core/controller_helpers/search.rb
+++ b/core/lib/spree/core/controller_helpers/search.rb
@@ -2,8 +2,8 @@ module Spree
   module Core
     module ControllerHelpers
       module Search
-        def build_searcher params
-          Spree::Config.searcher_class.new(params).tap do |searcher|
+        def build_searcher(klass, params)
+          Spree::Config.searcher_class.const_get(klass).new(params).tap do |searcher|
             searcher.current_user = try_spree_current_user
             searcher.current_currency = current_currency
           end

--- a/core/lib/spree/core/search.rb
+++ b/core/lib/spree/core/search.rb
@@ -1,0 +1,3 @@
+require 'spree/core/search/base'
+require 'spree/core/search/product'
+require 'spree/core/search/variant'

--- a/core/lib/spree/core/search/base.rb
+++ b/core/lib/spree/core/search/base.rb
@@ -5,70 +5,13 @@ module Spree
         attr_accessor :properties
         attr_accessor :current_user
         attr_accessor :current_currency
+        attr_accessor :params
 
         def initialize(params)
+          @params = params
           self.current_currency = Spree::Config[:currency]
-          @properties = {}
-          prepare(params)
         end
-
-        def retrieve_products
-          @products_scope = get_base_scope
-          curr_page = page || 1
-
-          @products = @products_scope.includes([:master => :prices])
-          unless Spree::Config.show_products_without_price
-            @products = @products.where("spree_prices.amount IS NOT NULL").where("spree_prices.currency" => current_currency)
-          end
-          @products = @products.page(curr_page).per(per_page)
-        end
-
-        def method_missing(name)
-          if @properties.has_key? name
-            @properties[name]
-          else
-            super
-          end
-        end
-
-        protected
-          def get_base_scope
-            base_scope = Spree::Product.active
-            base_scope = base_scope.in_taxon(taxon) unless taxon.blank?
-            base_scope = get_products_conditions_for(base_scope, keywords)
-            base_scope = add_search_scopes(base_scope)
-            base_scope
-          end
-
-          def add_search_scopes(base_scope)
-            search.each do |name, scope_attribute|
-              scope_name = name.to_sym
-              if base_scope.respond_to?(:search_scopes) && base_scope.search_scopes.include?(scope_name.to_sym)
-                base_scope = base_scope.send(scope_name, *scope_attribute)
-              else
-                base_scope = base_scope.merge(Spree::Product.ransack({scope_name => scope_attribute}).result)
-              end
-            end if search
-            base_scope
-          end
-
-          # method should return new scope based on base_scope
-          def get_products_conditions_for(base_scope, query)
-            unless query.blank?
-              base_scope = base_scope.like_any([:name, :description], query.split)
-            end
-            base_scope
-          end
-
-          def prepare(params)
-            @properties[:taxon] = params[:taxon].blank? ? nil : Spree::Taxon.find(params[:taxon])
-            @properties[:keywords] = params[:keywords]
-            @properties[:search] = params[:search]
-
-            per_page = params[:per_page].to_i
-            @properties[:per_page] = per_page > 0 ? per_page : Spree::Config[:products_per_page]
-            @properties[:page] = (params[:page].to_i <= 0) ? 1 : params[:page].to_i
-          end
+        
       end
     end
   end

--- a/core/lib/spree/core/search/product.rb
+++ b/core/lib/spree/core/search/product.rb
@@ -5,48 +5,39 @@ module Spree
 
         def initialize(params)
           super
-          @properties = {}
           prepare(params)
         end
 
         def search
           @products_scope = get_base_scope
-          curr_page = page || 1
+          curr_page = params[:page] || 1
 
           @products = @products_scope.includes([:master => :prices])
           unless Spree::Config.show_products_without_price
             @products = @products.where("spree_prices.amount IS NOT NULL").where("spree_prices.currency" => current_currency)
           end
-          @products = @products.page(curr_page).per(per_page)
-        end
-
-        def method_missing(name)
-          if @properties.has_key? name
-            @properties[name]
-          else
-            super
-          end
+          @products = @products.page(curr_page).per(params[:per_page])
         end
 
         protected
 
         def get_base_scope
           base_scope = Spree::Product.active
-          base_scope = base_scope.in_taxon(taxon) unless taxon.blank?
-          base_scope = get_products_conditions_for(base_scope, keywords)
+          base_scope = base_scope.in_taxon(params[:taxon]) if params[:taxon].present?
+          base_scope = get_products_conditions_for(base_scope, params[:keywords])
           base_scope = add_search_scopes(base_scope)
           base_scope
         end
 
         def add_search_scopes(base_scope)
-          search.each do |name, scope_attribute|
+          params[:search].each do |name, scope_attribute|
             scope_name = name.to_sym
             if base_scope.respond_to?(:search_scopes) && base_scope.search_scopes.include?(scope_name.to_sym)
               base_scope = base_scope.send(scope_name, *scope_attribute)
             else
               base_scope = base_scope.merge(Spree::Product.ransack({scope_name => scope_attribute}).result)
             end
-          end if search
+          end if params[:search]
           base_scope
         end
 
@@ -59,13 +50,11 @@ module Spree
         end
 
         def prepare(params)
-          @properties[:taxon] = params[:taxon].blank? ? nil : Spree::Taxon.find(params[:taxon])
-          @properties[:keywords] = params[:keywords]
-          @properties[:search] = params[:search]
+          @params[:taxon] = params[:taxon].blank? ? nil : Spree::Taxon.find(params[:taxon])
 
           per_page = params[:per_page].to_i
-          @properties[:per_page] = per_page > 0 ? per_page : Spree::Config[:products_per_page]
-          @properties[:page] = (params[:page].to_i <= 0) ? 1 : params[:page].to_i
+          @params[:per_page] = per_page > 0 ? per_page : Spree::Config[:products_per_page]
+          @params[:page] = (params[:page].to_i <= 0) ? 1 : params[:page].to_i
         end
       end
     end

--- a/core/lib/spree/core/search/product.rb
+++ b/core/lib/spree/core/search/product.rb
@@ -1,0 +1,73 @@
+module Spree
+  module Core
+    module Search
+      class Product < Base
+
+        def initialize(params)
+          super
+          @properties = {}
+          prepare(params)
+        end
+
+        def search
+          @products_scope = get_base_scope
+          curr_page = page || 1
+
+          @products = @products_scope.includes([:master => :prices])
+          unless Spree::Config.show_products_without_price
+            @products = @products.where("spree_prices.amount IS NOT NULL").where("spree_prices.currency" => current_currency)
+          end
+          @products = @products.page(curr_page).per(per_page)
+        end
+
+        def method_missing(name)
+          if @properties.has_key? name
+            @properties[name]
+          else
+            super
+          end
+        end
+
+        protected
+
+        def get_base_scope
+          base_scope = Spree::Product.active
+          base_scope = base_scope.in_taxon(taxon) unless taxon.blank?
+          base_scope = get_products_conditions_for(base_scope, keywords)
+          base_scope = add_search_scopes(base_scope)
+          base_scope
+        end
+
+        def add_search_scopes(base_scope)
+          search.each do |name, scope_attribute|
+            scope_name = name.to_sym
+            if base_scope.respond_to?(:search_scopes) && base_scope.search_scopes.include?(scope_name.to_sym)
+              base_scope = base_scope.send(scope_name, *scope_attribute)
+            else
+              base_scope = base_scope.merge(Spree::Product.ransack({scope_name => scope_attribute}).result)
+            end
+          end if search
+          base_scope
+        end
+
+        # method should return new scope based on base_scope
+        def get_products_conditions_for(base_scope, query)
+          unless query.blank?
+            base_scope = base_scope.like_any([:name, :description], query.split)
+          end
+          base_scope
+        end
+
+        def prepare(params)
+          @properties[:taxon] = params[:taxon].blank? ? nil : Spree::Taxon.find(params[:taxon])
+          @properties[:keywords] = params[:keywords]
+          @properties[:search] = params[:search]
+
+          per_page = params[:per_page].to_i
+          @properties[:per_page] = per_page > 0 ? per_page : Spree::Config[:products_per_page]
+          @properties[:page] = (params[:page].to_i <= 0) ? 1 : params[:page].to_i
+        end
+      end
+    end
+  end
+end

--- a/core/lib/spree/core/search/variant.rb
+++ b/core/lib/spree/core/search/variant.rb
@@ -1,0 +1,42 @@
+module Spree
+  module Core
+    module Search
+      class Variant < Base
+        def initialize(params)
+          super
+          params[:scope] ||= Spree::Variant.scoped
+        end
+
+        def search
+          # Syntax inferred from http://ransack-demo.herokuapp.com/users/advanced_search
+          query = { g: {} }
+          grouping_count = 0
+          fields = ['option_values_name', 'product_name', 'sku']
+          params[:q].split(' ').each do |part|
+            query[:g][grouping_count.to_s] = {
+              m: 'or',
+              c: {}
+            }
+            condition_count = 0
+            fields.each do |field|
+              query[:g][grouping_count.to_s][:c][condition_count.to_s] = {
+                a: { '0' => { name: field } },
+                p: 'cont',
+                v: { '0' => { value: part } }
+              }
+              condition_count += 1
+            end
+            grouping_count += 1
+          end
+
+          result = params[:scope]
+            .ransack(query)
+            .result
+            .page(params[:page])
+            .per(params[:per_page])
+        end
+      end
+    end
+  end
+end
+

--- a/core/spec/lib/search/product_spec.rb
+++ b/core/spec/lib/search/product_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Spree::Core::Search::Base do
+describe Spree::Core::Search::Product do
 
   before do
     include Spree::Core::ProductFilters
@@ -12,58 +12,58 @@ describe Spree::Core::Search::Base do
 
   it "returns all products by default" do
     params = { :per_page => "" }
-    searcher = Spree::Core::Search::Base.new(params)
-    searcher.retrieve_products.count.should == 2
+    searcher = Spree::Core::Search::Product.new(params)
+    searcher.search.count.should == 2
   end
 
   it "switches to next page according to the page parameter" do
     @product3 = create(:product, :name => "RoR Pants", :price => 14.00)
 
     params = { :per_page => "2" }
-    searcher = Spree::Core::Search::Base.new(params)
-    searcher.retrieve_products.count.should == 2
+    searcher = Spree::Core::Search::Product.new(params)
+    searcher.search.count.should == 2
 
     params.merge! :page => "2"
-    searcher = Spree::Core::Search::Base.new(params)
-    searcher.retrieve_products.count.should == 1
+    searcher = Spree::Core::Search::Product.new(params)
+    searcher.search.count.should == 1
   end
 
   it "maps search params to named scopes" do
     params = { :per_page => "",
                :search => { "price_range_any" => ["Under $10.00"] }}
-    searcher = Spree::Core::Search::Base.new(params)
+    searcher = Spree::Core::Search::Product.new(params)
     searcher.send(:get_base_scope).to_sql.should match /<= 10/
-    searcher.retrieve_products.count.should == 1
+    searcher.search.count.should == 1
   end
 
   it "maps multiple price_range_any filters" do
     params = { :per_page => "",
                :search => { "price_range_any" => ["Under $10.00", "$10.00 - $15.00"] }}
-    searcher = Spree::Core::Search::Base.new(params)
+    searcher = Spree::Core::Search::Product.new(params)
     searcher.send(:get_base_scope).to_sql.should match /<= 10/
     searcher.send(:get_base_scope).to_sql.should match /between 10 and 15/i
-    searcher.retrieve_products.count.should == 2
+    searcher.search.count.should == 2
   end
 
   it "uses ransack if scope not found" do
     params = { :per_page => "",
                :search => { "name_not_cont" => "Shirt" }}
-    searcher = Spree::Core::Search::Base.new(params)
-    searcher.retrieve_products.count.should == 1
+    searcher = Spree::Core::Search::Product.new(params)
+    searcher.search.count.should == 1
   end
 
   it "accepts a current user" do
     user = double
-    searcher = Spree::Core::Search::Base.new({})
+    searcher = Spree::Core::Search::Product.new({})
     searcher.current_user = user
     searcher.current_user.should eql(user)
   end
 
   it "finds products in alternate currencies" do
     price = create(:price, :currency => 'EUR', :variant => @product1.master)
-    searcher = Spree::Core::Search::Base.new({})
+    searcher = Spree::Core::Search::Product.new({})
     searcher.current_currency = 'EUR'
-    searcher.retrieve_products.should == [@product1]
+    searcher.search.should == [@product1]
   end
 
 end

--- a/core/spec/lib/search/variant_spec.rb
+++ b/core/spec/lib/search/variant_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+
+describe Spree::Core::Search::Variant do
+
+  before do
+    @variant = create(:variant, :sku => "ROR-0001")
+    @variant_2 = create(:variant, :sku => "ROR-0002")
+  end
+
+  it "can find the variant by its SKU" do
+    params = {
+      q: "ROR-0001"
+    }
+
+    searcher = Spree::Core::Search::Variant.new(params)
+    searcher.search.should include(@variant)
+    searcher.search.should_not include(@variant_2)
+  end
+
+  context "searching based on product name" do
+    before do
+      @variant.product.update_column(:name, 'Find this')
+    end
+
+    it "finds the right variant" do
+      params = {
+        q: 'Find this'
+      }
+
+      searcher = Spree::Core::Search::Variant.new(params)
+      searcher.search.should include(@variant)
+      searcher.search.should_not include(@variant_2)
+    end
+  end
+
+  context "searching based on option value name" do
+    before do
+      @variant.option_values.delete_all
+      @variant.option_values.create!(
+        option_type: @variant.product.option_types.first,
+        name: 'Find this',
+        presentation: 'FIND THIS'
+      )
+    end
+
+    it "finds the right variant" do
+      params = {
+        q: @variant.option_values.first.name
+      }
+
+      searcher = Spree::Core::Search::Variant.new(params)
+      searcher.search.should include(@variant)
+      searcher.search.should_not include(@variant_2)
+    end
+  end
+
+  context "searching based on a combination" do
+    before do
+      @variant.product.update_column(:name, 'Big Car')
+        @variant.option_values.delete_all
+        @variant.option_values.create!(
+          option_type: @variant.product.option_types.first,
+          name: 'Red',
+          presentation: 'Red'
+        )
+    end
+
+    it "finds the right variant" do
+      params = {
+        q: 'Big Red Car'
+      }
+
+      searcher = Spree::Core::Search::Variant.new(params)
+      searcher.search.should include(@variant)
+      searcher.search.should_not include(@variant_2)
+    end
+  end
+end

--- a/frontend/app/controllers/spree/home_controller.rb
+++ b/frontend/app/controllers/spree/home_controller.rb
@@ -4,8 +4,7 @@ module Spree
     respond_to :html
 
     def index
-      @searcher = build_searcher(params)
-      @products = @searcher.retrieve_products
+      @products = build_searcher(:Product, params).search
       @taxonomies = Spree::Taxonomy.includes(root: :children)
     end
   end

--- a/frontend/app/controllers/spree/products_controller.rb
+++ b/frontend/app/controllers/spree/products_controller.rb
@@ -1,6 +1,8 @@
 module Spree
   class ProductsController < Spree::StoreController
     before_filter :load_product, :only => :show
+    before_filter :load_taxon, :only => :index
+
     rescue_from ActiveRecord::RecordNotFound, :with => :render_404
     helper 'spree/taxons'
 
@@ -31,6 +33,10 @@ module Spree
           @products = Product.active(current_currency)
         end
         @product = @products.friendly.find(params[:id])
+      end
+
+      def load_taxon
+        @taxon = Spree::Taxon.find(params[:taxon]) if params[:taxon].present?
       end
   end
 end

--- a/frontend/app/controllers/spree/products_controller.rb
+++ b/frontend/app/controllers/spree/products_controller.rb
@@ -7,8 +7,7 @@ module Spree
     respond_to :html
 
     def index
-      @searcher = build_searcher(params)
-      @products = @searcher.retrieve_products
+      @products = build_searcher(:Product, params).search
       @taxonomies = Spree::Taxonomy.includes(root: :children)
     end
 

--- a/frontend/app/controllers/spree/taxons_controller.rb
+++ b/frontend/app/controllers/spree/taxons_controller.rb
@@ -9,8 +9,7 @@ module Spree
       @taxon = Taxon.find_by_permalink!(params[:id])
       return unless @taxon
 
-      @searcher = build_searcher(params.merge(:taxon => @taxon.id))
-      @products = @searcher.retrieve_products
+      @products = build_searcher(:Product, params.merge(:taxon => @taxon.id)).search
       @taxonomies = Spree::Taxonomy.includes(root: :children)
     end
 

--- a/frontend/app/views/spree/shared/_products.html.erb
+++ b/frontend/app/views/spree/shared/_products.html.erb
@@ -1,5 +1,5 @@
 <%
-  paginated_products = @searcher.retrieve_products if params.key?(:keywords)
+  paginated_products = @products if params.key?(:keywords)
   paginated_products ||= products
 %>
 


### PR DESCRIPTION
Based on some feedback from some of our clients and my own personal experience, the search features provided by `/api/variants` are a bit lacking. They very often don't return the results you want. This is the endpoint used on the product picker in the admin backend, btw (but you probably knew that already). Ideally, you'd be able to hook into this and set your own searching logic to the task (like in products), but there's no way to do this for variants.

I propose that the `Spree::Core::Search::Base` class needs to define an API for variant searching, and this patch hints at the kind of API I would expect. The caveat is that this API differs from `retrieve_products` in that it doesn't build the scope inside the method, but rather the scope is provided to it and then it can do searching based on whatever `params[:q]` is.

I'm on the fence about adding a `retrieve_variants` method to `Spree::Core::Search::Base` which has a different API and different functionality to that of the `retrieve_products` method there. It _feels_ like I'm trying to squish too much into that one class.

---

So here's what I was thinking: let's keep `Spree::Core::Search::Base` but move all the product searching logic into another class, called `Spree::Core::Search::Product`. Then we could have another class called `Spree::Core::Search::Variant` and I'd be able to define my `retrieve_variants` method in there if I so pleased.

How does this sound?
