### PR TITLE
Missing I18n on 'ship' in admin area

### DIFF
--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -9,7 +9,7 @@
       <strong class="stock-location-name" data-hook="stock-location-name">'<%= shipment.stock_location.name %>'</strong>
       <% if shipment.ready? and can? :update, shipment %>
         -
-        <%= link_to 'ship', '#', :class => 'ship button icon-arrow-right', :data => {'shipment-number' => shipment.number} %>
+        <%= link_to Spree.t(:ship), '#', :class => 'ship button icon-arrow-right', :data => {'shipment-number' => shipment.number} %>
       <% end %>
     </legend>
   </fieldset>


### PR DESCRIPTION
Hi,

I noticed that in the [spree/admin/orders/_shipment.html.erb on the 2-1-stable](https://github.com/spree/spree/blob/2-1-stable/backend/app/views/spree/admin/orders/_shipment.html.erb#L12) branch, the `link_to 'ship'` is not localized, while the [2-2-stable](https://github.com/spree/spree/blob/2-2-stable/backend/app/views/spree/admin/orders/_shipment.html.erb#L12) and [master](https://github.com/spree/spree/blob/master/backend/app/views/spree/admin/orders/_shipment.html.erb#L12) branches are.
