### PR TITLE
Tax zone performance

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -208,7 +208,7 @@ module Spree
     # Returns the relevant zone (if any) to be used for taxation purposes.
     # Uses default tax zone unless there is a specific match
     def tax_zone
-      Zone.match(tax_address) || Zone.default_tax
+      @tax_zone ||= Zone.match(tax_address) || Zone.default_tax
     end
 
     # Indicates whether tax should be backed out of the price calcualtions in
@@ -216,7 +216,7 @@ module Spree
     # taxes in that case.
     def exclude_tax?
       return false unless Spree::Config[:prices_inc_tax]
-      return tax_zone != Zone.default_tax
+      tax_zone != Zone.default_tax
     end
 
     # Returns the address for taxation based on configuration
@@ -586,6 +586,11 @@ module Spree
       self.ensure_updated_shipments
     end
 
+    def reload
+      remove_instance_variable(:@tax_zone) if defined?(@tax_zone)
+      super
+    end
+
     private
 
       def link_by_email
@@ -594,7 +599,7 @@ module Spree
 
       # Determine if email is required (we don't want validation errors before we hit the checkout)
       def require_email
-        return true unless new_record? or ['cart', 'address'].include?(state)
+        true unless new_record? or ['cart', 'address'].include?(state)
       end
 
       def ensure_line_items_present

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -72,7 +72,7 @@ describe Spree::LineItem do
         order.bill_address = nil
         order.ship_address = nil
         order.save
-        order.tax_zone.should be_nil
+        order.reload.tax_zone.should be_nil
       end
 
       it "does not create a tax adjustment" do


### PR DESCRIPTION
In our Spree app, this change reduced the time to transition from address to payment (during checkout) from 1:15 (that's one minute 15 seconds) to 0:02, in development mode.
