### PR TITLE
Add data-hooks to admin/products/new

### DIFF
--- a/backend/app/views/spree/admin/products/new.html.erb
+++ b/backend/app/views/spree/admin/products/new.html.erb
@@ -15,7 +15,7 @@
 
     <div data-hook="new_product_attrs" class="row">
       <% unless @product.has_variants? %>
-        <div class="alpha four columns">
+        <div data-hook="new_product_sku" class="alpha four columns">
           <%= f.field_container :sku do %>
             <%= f.label :sku, Spree.t(:sku) %><br />
             <%= f.text_field :sku, :size => 16, :class => 'fullwidth' %>
@@ -24,14 +24,14 @@
         </div>
       <% end %>
 
-      <div class="four columns">
+      <div data-hook="new_product_prototype" class="four columns">
         <%= f.field_container :prototype do %>
           <%= f.label :prototype_id, Spree.t(:prototype) %><br />
           <%= f.collection_select :prototype_id, Spree::Prototype.all, :id, :name, {:include_blank => true}, {:class => 'select2 fullwidth'} %>
         <% end %>
       </div>
 
-      <div class="four columns">
+      <div data-hook="new_product_price" class="four columns">
         <%= f.field_container :price do %>
           <%= f.label :price, Spree.t(:master_price) %> <span class="required">*</span><br />
           <%= f.text_field :price, :value => number_to_currency(@product.price, :unit => ''), :class => 'fullwidth' %>
@@ -39,7 +39,7 @@
         <% end %>
       </div>
 
-      <div class="omega four columns">
+      <div data-hook="new_product_available_on" class="omega four columns">
         <%= f.field_container :available_on do %>
           <%= f.label :available_on, Spree.t(:available_on) %>
           <%= f.error_message_on :available_on %>
@@ -50,7 +50,7 @@
     </div>
 
     <div class='row'>
-      <div class="alpha four columns">
+      <div data-hook="new_product_shipping_category" class="alpha four columns">
         <%= f.field_container :shipping_category do %>
           <%= f.label :shipping_category_id, Spree.t(:shipping_categories) %><span class="required">*</span><br />
           <%= f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2 fullwidth' }) %>


### PR DESCRIPTION
Similar to https://github.com/spree/spree/pull/4521, this commit adds data-hooks that make manipulation of the admin/products/new page considerably easier, cleaner, and more succinct.
