### PR TITLE
Add data-hooks to admin/products/form

### DIFF
--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -1,40 +1,48 @@
 <div data-hook="admin_product_form_fields">
   
-  <div class="left eight columns alpha" data-hook="admin_product_form_left">    
-    <%= f.field_container :name do %>
-      <%= f.label :name, raw(Spree.t(:name) + content_tag(:span, ' *', :class => 'required')) %>
-      <%= f.text_field :name, :class => 'fullwidth title' %>
-      <%= f.error_message_on :name %>
-    <% end %>
+  <div class="left eight columns alpha" data-hook="admin_product_form_left">
+    <div data-hook="admin_product_form_name">
+      <%= f.field_container :name do %>
+        <%= f.label :name, raw(Spree.t(:name) + content_tag(:span, ' *', :class => 'required')) %>
+        <%= f.text_field :name, :class => 'fullwidth title' %>
+        <%= f.error_message_on :name %>
+      <% end %>
+    </div>
 
-    <%= f.field_container :slug do %>
-      <%= f.label :slug, raw(Spree.t(:slug) + content_tag(:span, ' *',  :class => "required")) %>
-      <%= f.text_field :slug, :class => 'fullwidth title' %>
-      <%= f.error_message_on :slug %>
-    <% end %>
+    <div data-hook="admin_product_form_slug">
+      <%= f.field_container :slug do %>
+        <%= f.label :slug, raw(Spree.t(:slug) + content_tag(:span, ' *',  :class => "required")) %>
+        <%= f.text_field :slug, :class => 'fullwidth title' %>
+        <%= f.error_message_on :slug %>
+      <% end %>
+    </div>
 
-    <%= f.field_container :description do %>
-      <%= f.label :description, Spree.t(:description) %>
-      <%= f.text_area :description, {:rows => "#{unless @product.has_variants? then '20' else '13' end}", :class => 'fullwidth'} %>
-      <%= f.error_message_on :description %>
-    <% end %>
+    <div data-hook="admin_product_form_description">
+      <%= f.field_container :description do %>
+        <%= f.label :description, Spree.t(:description) %>
+        <%= f.text_area :description, {:rows => "#{unless @product.has_variants? then '20' else '13' end}", :class => 'fullwidth'} %>
+        <%= f.error_message_on :description %>
+      <% end %>
+    </div>
   </div>
 
   <div class="right four columns omega" data-hook="admin_product_form_right">
+    <div data-hook="admin_product_form_price">
     <%= f.field_container :price do %>
       <%= f.label :price, raw(Spree.t(:master_price) + content_tag(:span, ' *', :class => "required")) %>
       <%= f.text_field :price, :value => number_to_currency(@product.price, :unit => '') %>
       <%= f.error_message_on :price %>
     <% end %>
+    </div>
 
-    <div class="alpha two columns">
+    <div data-hook="admin_product_form_cost_price" class="alpha two columns">
       <%= f.field_container :cost_price do %>
         <%= f.label :cost_price, Spree.t(:cost_price) %>
         <%= f.text_field :cost_price, :value => number_to_currency(@product.cost_price, :unit => '') %>
         <%= f.error_message_on :cost_price %>
       <% end %>
     </div>
-    <div class="omega two columns">
+    <div data-hook="admin_product_form_cost_currency" class="omega two columns">
       <%= f.field_container :cost_currency do %>
         <%= f.label :cost_currency, Spree.t(:cost_currency) %>
         <%= f.text_field :cost_currency %>
@@ -44,73 +52,89 @@
 
     <div class="clear"></div>
 
-    <%= f.field_container :available_on do %>
-      <%= f.label :available_on, Spree.t(:available_on) %>
-      <%= f.error_message_on :available_on %>
-      <%= f.text_field :available_on, :value => datepicker_field_value(@product.available_on), :class => 'datepicker' %>
-    <% end %>
+    <div data-hook="admin_product_form_available_on">
+      <%= f.field_container :available_on do %>
+        <%= f.label :available_on, Spree.t(:available_on) %>
+        <%= f.error_message_on :available_on %>
+        <%= f.text_field :available_on, :value => datepicker_field_value(@product.available_on), :class => 'datepicker' %>
+      <% end %>
+    </div>
 
     <% unless @product.has_variants? %>
-      <%= f.field_container :sku do %>
-        <%= f.label :sku, Spree.t(:sku) %>
-        <%= f.text_field :sku, :size => 16 %>
-      <% end %>
+      <div data-hook="admin_product_form_sku">
+        <%= f.field_container :sku do %>
+          <%= f.label :sku, Spree.t(:sku) %>
+          <%= f.text_field :sku, :size => 16 %>
+        <% end %>
+      </div>
 
       <ul id="shipping_specs">
-        <li id="shipping_specs_weight_field" class="field alpha two columns">
+        <li id="shipping_specs_weight_field" data-hook="admin_product_form_weight" class="field alpha two columns">
           <%= f.label :weight, Spree.t(:weight) %>
           <%= f.text_field :weight, :size => 4 %>
         </li>
-        <li id="shipping_specs_height_field" class="field omega two columns">
+        <li id="shipping_specs_height_field" data-hook="admin_product_form_height" class="field omega two columns">
           <%= f.label :height, Spree.t(:height) %>
           <%= f.text_field :height, :size => 4 %>
         </li>
-        <li id="shipping_specs_width_field" class="field alpha two columns">
+        <li id="shipping_specs_width_field" data-hook="admin_product_form_width" class="field alpha two columns">
           <%= f.label :width, Spree.t(:width) %>
           <%= f.text_field :width, :size => 4 %>
         </li>
-        <li id="shipping_specs_depth_field" class="field omega two columns">
+        <li id="shipping_specs_depth_field" data-hook="admin_product_form_depth" class="field omega two columns">
           <%= f.label :depth, Spree.t(:depth) %>
           <%= f.text_field :depth, :size => 4 %>
         </li>
       </ul>
     <% end %>
 
-    <%= f.field_container :shipping_categories do %>
-      <%= f.label :shipping_category_id, Spree.t(:shipping_categories) %>
-      <%= f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2' }) %>
-      <%= f.error_message_on :shipping_category %>
-    <% end %>
+    <div data-hook="admin_product_form_shipping_categories">
+      <%= f.field_container :shipping_categories do %>
+        <%= f.label :shipping_category_id, Spree.t(:shipping_categories) %>
+        <%= f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2' }) %>
+        <%= f.error_message_on :shipping_category %>
+      <% end %>
+    </div>
 
-    <%= f.field_container :tax_category do %>
-      <%= f.label :tax_category_id, Spree.t(:tax_category) %>
-      <%= f.collection_select(:tax_category_id, @tax_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2' }) %>
-      <%= f.error_message_on :tax_category %>
-    <% end %>
+    <div data-hook="admin_product_form_tax_category">
+      <%= f.field_container :tax_category do %>
+        <%= f.label :tax_category_id, Spree.t(:tax_category) %>
+        <%= f.collection_select(:tax_category_id, @tax_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2' }) %>
+        <%= f.error_message_on :tax_category %>
+      <% end %>
+    </div>
   </div>
 
   <div class="twelve columns alpha omega">
-    <%= f.field_container :taxons do %>
-      <%= f.label :taxon_ids, Spree.t(:taxons) %><br />
-      <%= f.hidden_field :taxon_ids, :value => @product.taxon_ids.join(',') %>
-    <% end %>
+    <div data-hook="admin_product_form_taxons">
+      <%= f.field_container :taxons do %>
+        <%= f.label :taxon_ids, Spree.t(:taxons) %><br />
+        <%= f.hidden_field :taxon_ids, :value => @product.taxon_ids.join(',') %>
+      <% end %>
+    </div>
 
-    <%= f.field_container :option_types do %>
-      <%= f.label :option_type_ids, Spree.t(:option_types) %>
-      <%= f.hidden_field :option_type_ids, :value => @product.option_type_ids.join(',') %>
-    <% end %>
+    <div data-hook="admin_product_form_option_types">
+      <%= f.field_container :option_types do %>
+        <%= f.label :option_type_ids, Spree.t(:option_types) %>
+        <%= f.hidden_field :option_type_ids, :value => @product.option_type_ids.join(',') %>
+      <% end %>
+    </div>
   </div>
 
   <div data-hook="admin_product_form_meta" class="alpha omega twelve columns">
-    <%= f.field_container :meta_keywords do %>
-      <%= f.label :meta_keywords, Spree.t(:meta_keywords) %>
-      <%= f.text_field :meta_keywords, :class => 'fullwidth' %>
-    <% end %>
+    <div data-hook="admin_product_form_meta_keywords">
+      <%= f.field_container :meta_keywords do %>
+        <%= f.label :meta_keywords, Spree.t(:meta_keywords) %>
+        <%= f.text_field :meta_keywords, :class => 'fullwidth' %>
+      <% end %>
+    </div>
 
-    <%= f.field_container :meta_description do %>
-      <%= f.label :meta_description, Spree.t(:meta_description) %>
-      <%= f.text_field :meta_description, :class => 'fullwidth' %>
-    <% end %>
+    <div data-hook="admin_product_form_meta_description">
+      <%= f.field_container :meta_description do %>
+        <%= f.label :meta_description, Spree.t(:meta_description) %>
+        <%= f.text_field :meta_description, :class => 'fullwidth' %>
+      <% end %>
+    </div>
   </div>
 
   <div class="clear"></div>


### PR DESCRIPTION
Similar to #4521 and #4682, this commit adds data-hooks that make manipulation of the admin/products/_form page considerably easier, cleaner, and more succinct.
