### PR TITLE
Pass in order params on order creation so they can be overridden

### DIFF
--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -48,9 +48,7 @@ module Spree
       end
 
       def new
-        @order = Order.create
-        @order.created_by = try_spree_current_user
-        @order.save
+        @order = Order.create(order_params)
         redirect_to edit_admin_order_url(@order)
       end
 
@@ -116,6 +114,11 @@ module Spree
       end
 
       private
+        def order_params
+          params[:created_by_id] = try_spree_current_user.try(:id)
+          params.permit(:created_by_id)
+        end
+
         def load_order
           @order = Order.includes(:adjustments).find_by_number!(params[:id])
           authorize! action, @order

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -63,8 +63,10 @@ describe Spree::Admin::OrdersController do
     # Test for #3346
     context "#new" do
       it "a new order has the current user assigned as a creator" do
-        spree_get :new
-        assigns[:order].created_by.should == controller.try_spree_current_user
+        Spree::Order.should_receive(:create)
+          .with('created_by_id' => controller.try_spree_current_user.id)
+          .and_return(order)
+        spree_get :new        
       end
     end
 


### PR DESCRIPTION
This is necessary in the case that in your application you have added required attributes to the Order model. There is similar code in the api order controller.
