### PR TITLE
[#00] full support for STI classes

### DIFF
--- a/backend/app/views/spree/admin/images/edit.html.erb
+++ b/backend/app/views/spree/admin/images/edit.html.erb
@@ -8,7 +8,7 @@
   <li><%= button_link_to Spree.t(:back_to_images_list), admin_product_images_url(@product), :icon => 'arrow-left' %></li>
 <% end %>
 
-<%= form_for [:admin, @product, @image], :html => { :multipart => true } do |f| %>
+<%= form_for [:admin, @product.becomes(Spree::Product), @image], :html => { :multipart => true } do |f| %>
   <fieldset data-hook="edit_image">
     <legend align="center"><%= @image.attachment_file_name%></legend>
     <div data-hook="thumbnail" class="field alpha three columns align-center">

--- a/backend/app/views/spree/admin/images/new.html.erb
+++ b/backend/app/views/spree/admin/images/new.html.erb
@@ -1,4 +1,4 @@
-<%= form_for [:admin, @product, @image], :html => { :multipart => true } do |f| %>
+<%= form_for [:admin, @product.becomes(Spree::Product), @image], :html => { :multipart => true } do |f| %>
   <fieldset data-hook="new_image">
     <legend align="center"><%= Spree.t(:new_image) %></legend>
 

--- a/backend/app/views/spree/admin/product_properties/index.html.erb
+++ b/backend/app/views/spree/admin/product_properties/index.html.erb
@@ -15,7 +15,7 @@
   </ul>
 <% end %>
 
-<%= form_for @product, :url => admin_product_url(@product), :method => :put do |f| %>
+<%= form_for @product.becomes(Spree::Product), :url => admin_product_url(@product), :method => :put do |f| %>
   <fieldset class="no-border-top">
     <div class="add_product_properties" data-hook="add_product_properties"></div>
 

--- a/backend/app/views/spree/admin/products/edit.html.erb
+++ b/backend/app/views/spree/admin/products/edit.html.erb
@@ -12,7 +12,7 @@
 <%= render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => 'Product Details' } %>
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @product } %>
 
-<%= form_for [:admin, @product], :method => :put, :html => { :multipart => true } do |f| %>
+<%= form_for [:admin, @product.becomes(Spree::Product)], :method => :put, :html => { :multipart => true } do |f| %>
   <fieldset class="no-border-top">
     <%= render :partial => 'form', :locals => { :f => f } %>
     <%= render :partial => 'spree/admin/shared/edit_resource_links' %>

--- a/backend/app/views/spree/admin/variants/edit.html.erb
+++ b/backend/app/views/spree/admin/variants/edit.html.erb
@@ -4,7 +4,7 @@
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @variant } %>
 
-<%= form_for [:admin, @product, @variant] do |f| %>
+<%= form_for [:admin, @product.becomes(Spree::Product), @variant] do |f| %>
   <fieldset class="no-border-top">
     <div data-hook="admin_variant_edit_form">
       <%= render :partial => 'form', :locals => { :f => f } %>

--- a/backend/app/views/spree/admin/variants/new.html.erb
+++ b/backend/app/views/spree/admin/variants/new.html.erb
@@ -1,6 +1,6 @@
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @variant } %>
 
-<%= form_for [:admin, @product, @variant] do |f| %>
+<%= form_for [:admin, @product.becomes(Spree::Product), @variant] do |f| %>
   <fieldset data-hook="admin_variant_new_form">
     <legend align="center"><%= Spree.t(:new_variant) %></legend>
     <%= render :partial => 'form', :locals => { :f => f } %>


### PR DESCRIPTION
STI classes are "Single Table Inheritance" classes. That is, classes
inheriting from classes inheriting ActiveRecord::Base. This is a
uncommon use case, but is more often used if you have a downstream
system populating a spree database.

In this model, it's possible to have class inheritance to define
different behaviour for different kinds of products.

i.e.: Book -> Spree::Product, Shirt -> Spree::Product, DVD ->
Spree::Product.

This will enable the usage of Spree's default views without any hassle
for the cases where replacing the default is not really needed.
