### PR TITLE
flash message is coupon_code_not_found if Promotion#activate returns true and action is create line items

### DIFF
--- a/core/lib/spree/promo/coupon_applicator.rb
+++ b/core/lib/spree/promo/coupon_applicator.rb
@@ -34,7 +34,12 @@ module Spree
         event_name = "spree.checkout.coupon_code_added"
         if promotion.activate(:coupon_code => @order.coupon_code, :order => @order)
           promo = @order.adjustments.includes(:originator).promotion.detect { |p| p.originator.promotion.code == @order.coupon_code }
-          determine_promotion_application_result(promo)
+          if promo.present?
+            determine_promotion_application_result(promo)
+          else
+            # if action is create line items
+            return { :coupon_applied? => true, :success =>  Spree.t(:coupon_code_applied) }
+          end
         else
           return { :coupon_applied? => false, :error =>  Spree.t(:coupon_code_not_eligible) }
         end


### PR DESCRIPTION
If Promotion#activate returns true and action is create line items, then we are not making any entry to adjustments for that order, Then in following code promo will always nil.

``` ruby
promo = @order.adjustments.includes(:originator).promotion.detect { |p| p.originator.promotion.code == @order.coupon_code }
```

that's why it returns following message

``` ruby
return { :coupon_applied? => false, :error =>  Spree.t(:coupon_code_not_found) }
```

I check this with spreecommerce live demo as well it is reproducible
steps
1) go to => https://monster-boutique-2583.spree.mx/products/ruby-on-rails-baseball-jersey
2) click add to cart
3) go to => https://monster-boutique-2583.spree.mx/cart
4) use coupon code => "promotest"
5) click update
6) then you will see "Ruby on Rails Stein" this product in cart but flash message is "The coupon code you entered doesn't exist. Please try again."
