### PR TITLE
simple_current_order only gets incomplete orders

### DIFF
--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -13,7 +13,7 @@ module Spree
 
         # Used in the link_to_cart helper.
         def simple_current_order
-          @order ||= Spree::Order.find_by(id: session[:order_id], currency: current_currency)
+          @order ||= Spree::Order.find_by(id: session[:order_id], currency: current_currency, completed_at: nil)
         end
 
         # The current incomplete order from the session for use in cart and during checkout


### PR DESCRIPTION
This currently causes an issue with better_spree_paypal_express, and possibly
other extensions.

While Spree sets the session's order_id to nil when an order is complete,
better_spree_paypal_express does not.  Therefore, a completed order can be
retrieved as the simple_current_order.

It makes sense to replicate the logic of current_order (which does not allow
completed orders to be returned) here.
