### PR TITLE
explained tests dependency how to set up environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,9 +292,22 @@ If you want to run the simplecov code coverage report
 COVERAGE=true bundle exec rspec spec
 ```
 
-If you're working on multiple facets of Spree, you may want
-to run this command at the root of the Spree project to
-generate test applications and run specs for all the facets:
+If you're working on multiple facets of Spree to test,
+please ensure that you have a postgres user:
+
+```shell
+createuser -s -r postgres
+```
+
+And also ensure that you have [PhantomJS](http://phantomjs.org/) installed as well:
+
+```shell
+brew update && brew install phantomjs
+```
+
+To execute all the tests, you may want to run this command at the
+root of the Spree project to generate test applications and run
+specs for all the facets:
 ```shell
 bash build.sh
 ```


### PR DESCRIPTION
When I went to run `bash build.sh`, I was getting this error:

```
Couldn't create database for {"adapter"=>"postgresql", "database"=>"spree/frontend_spree_development", "username"=>"postgres", "min_messages"=>"warning"}
FATAL:  role "postgres" does not exist
```

This [SO QA](http://stackoverflow.com/questions/7863770/rails-and-postgresql-role-postgres-does-not-exist) did the trick and I ran:

```
createuser -s -r postgres
```

My rails dummy applications were now set up. Updated [Readme](https://github.com/spree/spree/blob/master/README.md) to contain this knowledge.

There was also an issue where I did not have PhantomJS in my path. I also specify that the tests require PhantomJS and how they can install it.

Hope this helps makes spree friendlier for people.
