### PR TITLE
acts_as_paranoid for Spree::Country (requested in #3571)

### DIFF
--- a/core/app/models/spree/country.rb
+++ b/core/app/models/spree/country.rb
@@ -1,5 +1,8 @@
 module Spree
   class Country < Spree::Base
+
+    acts_as_paranoid
+
     has_many :states, -> { order('name ASC') }, dependent: :destroy
     has_many :addresses, dependent: :nullify
 

--- a/core/db/migrate/20130306181701_add_address_fields_to_stock_location.rb
+++ b/core/db/migrate/20130306181701_add_address_fields_to_stock_location.rb
@@ -12,10 +12,10 @@ class AddAddressFieldsToStockLocation < ActiveRecord::Migration
     add_column :spree_stock_locations, :phone, :string
 
 
-    usa = Spree::Country.where(:iso => 'US').first
+    usa = Spree::Country.find_by_sql("SELECT * FROM spree_countries WHERE iso = 'US';").first
     # In case USA isn't found.
     # See #3115
-    country = usa || Spree::Country.first
+    country = usa || Spree::Country.find_by_sql("SELECT * FROM spree_countries;").first
     Spree::Country.reset_column_information
     Spree::StockLocation.update_all(:country_id => country)
   end

--- a/core/db/migrate/20140519023526_add_deleted_at_to_spree_countries.rb
+++ b/core/db/migrate/20140519023526_add_deleted_at_to_spree_countries.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtToSpreeCountries < ActiveRecord::Migration
+  def change
+    add_column :spree_countries, :deleted_at, :datetime
+  end
+end

--- a/core/spec/models/spree/country_spec.rb
+++ b/core/spec/models/spree/country_spec.rb
@@ -12,4 +12,33 @@ describe Spree::Country do
   it "returns that the states are required for an invalid country" do
     Spree::Country.states_required_by_country_id['i do not exit'].should be_true
   end
+
+  context 'country instance' do
+    let(:country) { create(:country) }
+
+    context "country has no orders" do
+      context "#destroy" do
+        it "should set deleted_at value" do
+          country.destroy
+          country.deleted_at.should_not be_nil
+        end
+      end
+    end
+
+    context "country has orders" do
+      before do
+        address = create(:address, :country => country)
+        @order = create(:order, :shipping_address => address)
+      end
+
+      context "#destroy" do
+        it "should set deleted_at value" do
+          country.destroy
+          country.deleted_at.should_not be_nil
+          @order.shipping_address.country.should_not be_nil
+        end
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Requested in issue #3571
- added acts_as_paranoid to Spree::Country
- modified migration AddAddressFieldsToStockLocation to use direct SQL queries, as it needs to look up Countries before the deleted_at field is available for acts_as_paranoid
- spec
