### PR TITLE
Product clone - optional image cloning

### DIFF
--- a/core/lib/spree/core/product_duplicator.rb
+++ b/core/lib/spree/core/product_duplicator.rb
@@ -2,8 +2,12 @@ module Spree
   class ProductDuplicator
     attr_accessor :product
 
-    def initialize(product)
+    @@clone_images_default = true
+    mattr_accessor :clone_images_default
+
+    def initialize(product, include_images = @@clone_images_default)
       @product = product
+      @include_images = include_images
     end
 
     def duplicate
@@ -39,7 +43,7 @@ module Spree
       master.dup.tap do |new_master|
         new_master.sku = "COPY OF #{master.sku}"
         new_master.deleted_at = nil
-        new_master.images = master.images.map { |image| duplicate_image image }
+        new_master.images = master.images.map { |image| duplicate_image image } if @include_images
         new_master.price = master.price
         new_master.currency = master.currency
       end

--- a/core/spec/models/spree/product_duplicator_spec.rb
+++ b/core/spec/models/spree/product_duplicator_spec.rb
@@ -18,8 +18,50 @@ module Spree
       expect{duplicator.duplicate}.to change{Spree::Product.count}.by(1)
     end
 
-    it "will duplicate the product images" do
-      expect{duplicator.duplicate}.to change{Spree::Image.count}.by(1)
+    context 'when image duplication enabled' do
+
+      it "will duplicate the product images" do
+        expect{duplicator.duplicate}.to change{Spree::Image.count}.by(1)
+      end
+
+    end
+
+    context 'when image duplication disabled' do
+
+      let!(:duplicator) { Spree::ProductDuplicator.new(product, false) }
+
+      it "will not duplicate the product images" do
+        expect{duplicator.duplicate}.to change{Spree::Image.count}.by(0)
+      end
+
+    end
+
+    context 'image duplication default' do
+
+      context 'when default is set to true' do
+
+        it 'clones images if no flag passed to initializer' do
+          expect{duplicator.duplicate}.to change{Spree::Image.count}.by(1)
+        end
+
+      end
+
+      context 'when default is set to false' do
+
+        before do
+          ProductDuplicator.clone_images_default = false
+        end
+
+        after do
+          ProductDuplicator.clone_images_default = true
+        end
+
+        it 'does not clone images if no flag passed to initializer' do
+          expect{ProductDuplicator.new(product).duplicate}.to change{Spree::Image.count}.by(0)
+        end
+
+      end
+
     end
 
     context "product attributes" do


### PR DESCRIPTION
Cloning a product currently copies the images as part of the process. This submission makes image duplication a configurable option, which is enabled by default for backward compatibility.

The impetus behind this change is that products with large # images can take a very long time to clone. Given that you won't likely want the same images for 2 products, this allows you to turn off image duplication if your business process does not require it.

This configuration flag is set to true by default, which out of the box leaves the product clone functionality identical to how it works today. 
In order to test this change, you'll need to set the configuration flag to false. 
Recommendation is to do the following in under config/initializers/spree.rb in your rails app:

```
Spree.config do |config|
  config.dup_product_images_on_clone = false
end
```
