### PR TITLE
fix font-awesome icons for admin taxons tree

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/plugins/_jstree.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_jstree.scss
@@ -2,15 +2,16 @@
   > ul, .jstree-icon {
     background-image: none;
   }
-  
+
   .jstree-icon {
     @extend [class^="icon-"]:before;
+    @extend .fa;
   }
 
-  .jstree-open > .jstree-icon {    
+  .jstree-open > .jstree-icon {
     @extend .fa-caret-down;
   }
-  .jstree-closed > .jstree-icon {    
+  .jstree-closed > .jstree-icon {
     @extend .fa-caret-right;
   }
 
@@ -31,24 +32,27 @@
 
       .jstree-icon {
         padding-left: 0px;
-        @extend .fa-arrows;   
+        @extend .fa;
+        @extend .fa-arrows;
       }
     }
   }
 }
 
-#vakata-dragged.jstree-apple .jstree-invalid, 
+#vakata-dragged.jstree-apple .jstree-invalid,
 #vakata-dragged.jstree-apple .jstree-ok,
 #jstree-marker {
   background-image: none !important;
   background-color: transparent !important;
-  @extend [class^="icon-"]:before;   
+  @extend [class^="icon-"]:before;
 }
 #vakata-dragged.jstree-apple .jstree-invalid {
-  @extend .fa-bars;  
+  @extend .fa;
+  @extend .fa-bars;
   color: $color-5;
 }
 #vakata-dragged.jstree-apple .jstree-ok {
+  @extend .fa;
   @extend .fa-ok;
   color: $color-2;
 }
@@ -71,7 +75,7 @@
   -webkit-box-shadow: none !important;
      -moz-box-shadow: none !important;
           box-shadow: none !important;
-  
+
 }
 
 #vakata-contextmenu {
@@ -109,7 +113,7 @@
       -webkit-box-shadow: none !important;
       line-height: inherit !important;
       padding: 5px 10px !important;
-      margin: 0 !important;      
+      margin: 0 !important;
     }
   }
 

--- a/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
@@ -105,6 +105,7 @@ table {
 
     .handle {
       @extend [class^="icon-"]:before;
+      @extend .fa;
       @extend .fa-bars;
       cursor: move;
     }


### PR DESCRIPTION
Looks like taxons tree icons are broken in my Spree 2.2.2, probably after https://github.com/spree/spree/commit/246c06619daaddc3fc106847e6b156637ade3885.
Adding some `@extend .fa;` seems to fix, because `.fa` class [is now required for all icons](https://github.com/FortAwesome/Font-Awesome/wiki/Upgrading-from-3.2.1-to-4#new-default-syntax).
Clean trailing spaces as bonus.
