### PR TITLE
Use permalink rather than slug in 2-1 and 2-0

### DIFF
--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -9,11 +9,11 @@
       <% end %>
     </div>
 
-    <div data-hook="admin_product_form_slug">
-      <%= f.field_container :slug do %>
-        <%= f.label :slug, raw(Spree.t(:slug) + content_tag(:span, ' *',  :class => "required")) %>
-        <%= f.text_field :slug, :class => 'fullwidth title' %>
-        <%= f.error_message_on :slug %>
+    <div data-hook="admin_product_form_permalink">
+      <%= f.field_container :permalink do %>
+        <%= f.label :permalink, raw(Spree.t(:permalink) + content_tag(:span, ' *',  :class => "required")) %>
+        <%= f.text_field :permalink, :class => 'fullwidth title' %>
+        <%= f.error_message_on :permalink %>
       <% end %>
     </div>
 


### PR DESCRIPTION
My PR https://github.com/spree/spree/pull/4683 to `master` and `2-2-stable` turned out not to be backwards compatible with `2-1-stable` and `2-0-stable` due to the shift in nomenclature from `:permalink` to `:slug` that happened between 2.1 and 2.2.

This PR patches this and restores functionality to `2-1-stable` and `2-0-stable`.
