### PR TITLE
Reorder short circuit evaluation of Estimator#shipping_methods

### DIFF
--- a/core/app/models/spree/stock/estimator.rb
+++ b/core/app/models/spree/stock/estimator.rb
@@ -52,8 +52,8 @@ module Spree
         package.shipping_methods.select do |ship_method|
           calculator = ship_method.calculator
           begin
-            calculator.available?(package) &&
             ship_method.include?(order.ship_address) &&
+            calculator.available?(package) &&
             (calculator.preferences[:currency].nil? ||
              calculator.preferences[:currency] == currency)
           rescue Exception => exception


### PR DESCRIPTION
It makes more sense to ensure that the order has a valid shipping address before performing intensive calculator operations. 

This also helps avoid potential issues where user defined calculators expect an address to be present when calculating the availability of a package with no negative effects to spree core.

If this looks fine for 2-2 I'll send another PR that applies cleanly to master.
