### PR TITLE
Makes taxonomies API more extensible

### DIFF
--- a/api/app/controllers/spree/api/taxonomies_controller.rb
+++ b/api/app/controllers/spree/api/taxonomies_controller.rb
@@ -10,8 +10,7 @@ module Spree
       end
 
       def show
-        @taxonomy = Taxonomy.accessible_by(current_ability, :read).find(params[:id])
-        respond_with(@taxonomy)
+        respond_with(taxonomy)
       end
 
       # Because JSTree wants parameters in a *slightly* different format

--- a/api/app/controllers/spree/api/taxonomies_controller.rb
+++ b/api/app/controllers/spree/api/taxonomies_controller.rb
@@ -3,10 +3,7 @@ module Spree
     class TaxonomiesController < Spree::Api::BaseController
 
       def index
-        @taxonomies = Taxonomy.accessible_by(current_ability, :read).order('name').includes(:root => :children).
-                      ransack(params[:q]).result.
-                      page(params[:page]).per(params[:per_page])
-        respond_with(@taxonomies)
+        respond_with(taxonomies)
       end
 
       def show
@@ -44,6 +41,12 @@ module Spree
       end
 
       private
+
+      def taxonomies
+        @taxonomies = Taxonomy.accessible_by(current_ability, :read).order('name').includes(:root => :children).
+                      ransack(params[:q]).result.
+                      page(params[:page]).per(params[:per_page])
+      end
 
       def taxonomy
         @taxonomy ||= Taxonomy.accessible_by(current_ability, :read).find(params[:id])


### PR DESCRIPTION
Makes small changes to the taxonomies API controller so it is easier to extend it via a decorator.

For example, consider the case where someone wants to restrict the taxonomies with a scope. Before this change, the only way to do it was to overwrite the index action and duplicate the internal spree code (note the call to `my_scope` in the end of the chain):

``` ruby
Spree::Api::TaxonomiesController.class_eval do
  def index
    @taxonomies = Taxonomy.accessible_by(current_ability, :read).order('name').includes(:root => :children).
                  ransack(params[:q]).result.
                  page(params[:page]).per(params[:per_page]).my_scope
    respond_with(@taxonomies)
  end
end
```

But after the change, we can just append the scope and avoid duplication:

``` ruby
Spree::Api::TaxonomiesController.class_eval do
  private

  alias_method :original_taxonomies, :taxonomies
  def taxonomies
    original_taxonomies.my_scope
  end
end
```

A similar argument holds for the show action.

Since no new functionality was introduced, I didn't added tests.
