### PR TITLE
Added Korean translations for JQuery validate plugin

### DIFF
--- a/frontend/vendor/assets/javascripts/jquery.validate/localization/messages_ko.js
+++ b/frontend/vendor/assets/javascripts/jquery.validate/localization/messages_ko.js
@@ -1,0 +1,25 @@
+/*
+ * Translated default messages for the jQuery validation plugin.
+ * Locale: KO (Korean; 한국어)
+ */
+(function ($) {
+  $.extend($.validator.messages, {
+    required: "필수 항목입니다.",
+    remote: "항목을 수정하세요.",
+    email: "유효하지 않은 E-Mail주소입니다.",
+    url: "유효하지 않은 URL입니다.",
+    date: "올바른 날짜를 입력하세요.",
+    dateISO: "올바른 날짜(ISO)를 입력하세요.",
+    number: "유효한 숫자가 아닙니다.",
+    digits: "숫자만 입력 가능합니다.",
+    creditcard: "신용카드 번호가 바르지 않습니다.",
+    equalTo: "같은 값을 다시 입력하세요.",
+    extension: "올바른 확장자가 아닙니다.",
+    maxlength: $.validator.format("{0}자를 넘을 수 없습니다. "),
+    minlength: $.validator.format("{0}자 이상 입력하세요."),
+    rangelength: $.validator.format("문자 길이가 {0} 에서 {1} 사이의 값을 입력하세요."),
+    range: $.validator.format("{0} 에서 {1} 사이의 값을 입력하세요."),
+    max: $.validator.format("{0} 이하의 값을 입력하세요."),
+    min: $.validator.format("{0} 이상의 값을 입력하세요.")
+  });
+}(jQuery));


### PR DESCRIPTION
This is a Korean localization file for the jquery.validate plugin. We're using it for our local site, so I figured I'd share it with the community.

Not sure if I need to include tests to submit a PR for this? I didn't see any in the /spec directory for the other localizations to use as a reference, so I'm just submitting it as is. Let me know if you need anything else.
