### PR TITLE
Improve shipping performance, add quantity to InventoryUnit

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/shipments.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js.erb
@@ -143,16 +143,20 @@ $(document).ready(function () {
 adjustShipmentItems = function(shipment_number, variant_id, quantity){
     var shipment = _.findWhere(shipments, {number: shipment_number + ''});
     var inventory_units = _.where(shipment.inventory_units, {variant_id: variant_id});
+    var total_units = 0;
+    for(var i = 0; i < inventory_units.length; i++){
+      total_units += inventory_units[i].quantity;
+    }
 
     var url = Spree.routes.shipments_api + "/" + shipment_number;
 
     var new_quantity = 0;
-    if(inventory_units.length<quantity){
+    if(total_units<quantity){
       url += "/add"
-      new_quantity = (quantity - inventory_units.length);
-    }else if(inventory_units.length>quantity){
+      new_quantity = (quantity - total_units);
+    }else if(total_units>quantity){
       url += "/remove"
-      new_quantity = (inventory_units.length - quantity);
+      new_quantity = (total_units - quantity);
     }
     url += '.json';
 

--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -1,10 +1,10 @@
 module Spree
   class InventoryUnit < Spree::Base
     belongs_to :variant, class_name: "Spree::Variant", inverse_of: :inventory_units
-    belongs_to :order, class_name: "Spree::Order", inverse_of: :inventory_units
     belongs_to :shipment, class_name: "Spree::Shipment", touch: true, inverse_of: :inventory_units
     belongs_to :return_authorization, class_name: "Spree::ReturnAuthorization"
     belongs_to :line_item, class_name: "Spree::LineItem", inverse_of: :inventory_units
+    delegate :order, to: :shipment
 
     has_many :return_items, inverse_of: :inventory_unit
 
@@ -13,7 +13,7 @@ module Spree
     scope :shipped, -> { where state: 'shipped' }
     scope :returned, -> { where state: 'returned' }
     scope :backordered_per_variant, ->(stock_item) do
-      includes(:shipment, :order)
+      includes(shipment: :order)
         .where("spree_shipments.state != 'canceled'").references(:shipment)
         .where(variant_id: stock_item.variant_id)
         .where('spree_orders.completed_at is not null')

--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -20,6 +20,8 @@ module Spree
         .backordered.order("spree_orders.completed_at ASC")
     end
 
+    validates :quantity, numericality: { greater_than_or_equal_to: 1, only_integer: true }
+
     # state machine (see http://github.com/pluginaweek/state_machine/tree/master for details)
     state_machine initial: :on_hand do
       event :fill_backorder do

--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -64,6 +64,19 @@ module Spree
         variant_id: variant_id).first
     end
 
+    def remove(count)
+      count = quantity if count > quantity
+
+      self.quantity -= count
+      if quantity == 0
+        destroy
+      else
+        save!
+      end
+
+      count
+    end
+
     # Remove variant default_scope `deleted_at: nil`
     def variant
       Spree::Variant.unscoped { super }

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -42,7 +42,7 @@ module Spree
     has_many :adjustments, -> { order("#{Adjustment.table_name}.created_at ASC") }, as: :adjustable, dependent: :destroy
     has_many :line_item_adjustments, through: :line_items, source: :adjustments
     has_many :shipment_adjustments, through: :shipments, source: :adjustments
-    has_many :inventory_units, inverse_of: :order
+    has_many :inventory_units, through: :shipments
     has_many :products, through: :variants
     has_many :variants, through: :line_items
 

--- a/core/app/models/spree/order_inventory.rb
+++ b/core/app/models/spree/order_inventory.rb
@@ -65,10 +65,10 @@ module Spree
         if variant.should_track_inventory?
           on_hand, back_order = shipment.stock_location.fill_status(variant, quantity)
 
-          on_hand.times { shipment.set_up_inventory('on_hand', variant, order, line_item) }
-          back_order.times { shipment.set_up_inventory('backordered', variant, order, line_item) }
+          on_hand.times { shipment.set_up_inventory('on_hand', variant, line_item) }
+          back_order.times { shipment.set_up_inventory('backordered', variant, line_item) }
         else
-          quantity.times { shipment.set_up_inventory('on_hand', variant, order, line_item) }
+          quantity.times { shipment.set_up_inventory('on_hand', variant, line_item) }
         end
 
         # adding to this shipment, and removing from stock_location

--- a/core/app/models/spree/order_inventory.rb
+++ b/core/app/models/spree/order_inventory.rb
@@ -62,12 +62,11 @@ module Spree
         if variant.should_track_inventory?
           on_hand, back_order = shipment.stock_location.fill_status(variant, quantity)
 
-          on_hand.times { shipment.set_up_inventory('on_hand', variant, line_item) }
-          back_order.times { shipment.set_up_inventory('backordered', variant, line_item) }
+          shipment.set_up_inventory('on_hand',     variant, line_item, on_hand)
+          shipment.set_up_inventory('backordered', variant, line_item, back_order)
         else
-          quantity.times { shipment.set_up_inventory('on_hand', variant, line_item) }
+          shipment.set_up_inventory('on_hand',     variant, line_item, quantity)
         end
-
         # adding to this shipment, and removing from stock_location
         if order.completed?
           shipment.stock_location.unstock(variant, quantity, shipment)

--- a/core/app/models/spree/order_inventory.rb
+++ b/core/app/models/spree/order_inventory.rb
@@ -18,13 +18,12 @@ module Spree
     def verify(shipment = nil)
       if order.completed? || shipment.present?
 
-        if inventory_units.size < line_item.quantity
-          quantity = line_item.quantity - inventory_units.size
-
+        quantity = line_item.quantity - inventory_units.size
+        if quantity > 0
           shipment = determine_target_shipment unless shipment
           add_to_shipment(shipment, quantity)
-        elsif inventory_units.size > line_item.quantity
-          remove(inventory_units, shipment)
+        elsif quantity < 0
+          remove(-quantity, shipment)
         end
       end
     end
@@ -34,9 +33,7 @@ module Spree
     end
 
     private
-      def remove(item_units, shipment = nil)
-        quantity = item_units.size - line_item.quantity
-
+      def remove(quantity, shipment = nil)
         if shipment.present?
           remove_from_shipment(shipment, quantity)
         else

--- a/core/app/models/spree/order_inventory.rb
+++ b/core/app/models/spree/order_inventory.rb
@@ -18,7 +18,7 @@ module Spree
     def verify(shipment = nil)
       if order.completed? || shipment.present?
 
-        quantity = line_item.quantity - inventory_units.size
+        quantity = line_item.quantity - inventory_units.sum(:quantity)
         if quantity > 0
           shipment = determine_target_shipment unless shipment
           add_to_shipment(shipment, quantity)
@@ -87,8 +87,7 @@ module Spree
 
         shipment_units.each do |inventory_unit|
           break if removed_quantity == quantity
-          inventory_unit.destroy
-          removed_quantity += 1
+          removed_quantity += inventory_unit.remove(quantity - removed_quantity)
         end
 
         shipment.destroy if shipment.inventory_units.count == 0

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -281,12 +281,10 @@ module Spree
 
     def to_package
       package = Stock::Package.new(stock_location, order)
-      grouped_inventory_units = inventory_units.includes(:line_item).group_by do |iu|
-        [iu.line_item, iu.state_name]
-      end
-
-      grouped_inventory_units.each do |(line_item, state_name), inventory_units|
-        package.add line_item, inventory_units.count, state_name
+      manifest.each do |item|
+        item.states.each do |state, count|
+          package.add item.line_item, count, state.to_sym, item.variant
+        end
       end
       package
     end

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -251,11 +251,10 @@ module Spree
       self.save!
     end
 
-    def set_up_inventory(state, variant, order, line_item)
+    def set_up_inventory(state, variant, line_item)
       self.inventory_units.create(
         state: state,
         variant_id: variant.id,
-        order_id: order.id,
         line_item_id: line_item.id
       )
     end

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -265,12 +265,14 @@ module Spree
     end
 
     def set_up_inventory(state, variant, line_item)
-      self.inventory_units.create(
-        state: state,
-        variant_id: variant.id,
-        line_item_id: line_item.id,
-        quantity: 1
-      )
+      unless quantity == 0
+        self.inventory_units.create!(
+          state: state,
+          variant_id: variant.id,
+          line_item_id: line_item.id,
+          quantity: quantity
+        )
+      end
     end
 
     def shipped=(value)

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -268,7 +268,8 @@ module Spree
       self.inventory_units.create(
         state: state,
         variant_id: variant.id,
-        line_item_id: line_item.id
+        line_item_id: line_item.id,
+        quantity: 1
       )
     end
 

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -167,7 +167,7 @@ module Spree
     ManifestItem = Struct.new(:line_item, :variant, :quantity, :states)
 
     def manifest
-      counts = inventory_units.group(:line_item_id, :variant_id, :state).count
+      counts = inventory_units.group(:line_item_id, :variant_id, :state).sum(:quantity)
 
       # Change counts into a hash of {variant_id => {state => quantity}}
       states = Hash.new{|h,k| h[k] = {} }

--- a/core/app/models/spree/stock/availability_validator.rb
+++ b/core/app/models/spree/stock/availability_validator.rb
@@ -4,8 +4,9 @@ module Spree
       def validate(line_item)
         if shipment = line_item.target_shipment
           units = shipment.inventory_units_for(line_item.variant)
-          return if units.count > line_item.quantity
-          quantity = line_item.quantity - units.count
+          unit_quantity = units.sum(:quantity)
+          return if unit_quantity > line_item.quantity
+          quantity = line_item.quantity - unit_quantity
         else
           quantity = line_item.quantity
         end

--- a/core/app/models/spree/stock/package.rb
+++ b/core/app/models/spree/stock/package.rb
@@ -88,6 +88,7 @@ module Spree
             unit.variant = item.variant
             unit.line_item = item.line_item
             unit.state = item.state.to_s
+            unit.quantity = 1
           end
         end
 

--- a/core/app/models/spree/stock/package.rb
+++ b/core/app/models/spree/stock/package.rb
@@ -85,7 +85,6 @@ module Spree
           item.quantity.times do |n|
             unit = shipment.inventory_units.build
             unit.pending = true
-            unit.order = order
             unit.variant = item.variant
             unit.line_item = item.line_item
             unit.state = item.state.to_s

--- a/core/app/models/spree/stock/package.rb
+++ b/core/app/models/spree/stock/package.rb
@@ -82,14 +82,12 @@ module Spree
         shipment.shipping_rates = shipping_rates
 
         contents.each do |item|
-          item.quantity.times do |n|
-            unit = shipment.inventory_units.build
-            unit.pending = true
-            unit.variant = item.variant
-            unit.line_item = item.line_item
-            unit.state = item.state.to_s
-            unit.quantity = 1
-          end
+          unit = shipment.inventory_units.build
+          unit.pending = true
+          unit.variant = item.variant
+          unit.line_item = item.line_item
+          unit.state = item.state.to_s
+          unit.quantity = item.quantity
         end
 
         shipment

--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -65,8 +65,9 @@ module Spree
       # If stock was -20 but then was -25 (decrease of 5 units), do nothing.
       def process_backorders(number)
         if number > 0
-          backordered_inventory_units.first(number).each do |unit|
-            unit.fill_backorder
+          backordered_inventory_units.each do |unit|
+            break unless number > 0
+            number -= unit.fill_backorders(number)
           end
         end
       end

--- a/core/db/migrate/20140414071782_remove_order_id_from_inventory_units.rb
+++ b/core/db/migrate/20140414071782_remove_order_id_from_inventory_units.rb
@@ -1,0 +1,5 @@
+class RemoveOrderIdFromInventoryUnits < ActiveRecord::Migration
+  def up
+    remove_column :spree_inventory_units, :order_id
+  end
+end

--- a/core/db/migrate/20140506204501_add_quantity_to_inventory_units.rb
+++ b/core/db/migrate/20140506204501_add_quantity_to_inventory_units.rb
@@ -1,0 +1,6 @@
+class AddQuantityToInventoryUnits < ActiveRecord::Migration
+  def change
+    add_column :spree_inventory_units, :quantity, :integer
+    execute "UPDATE spree_inventory_units SET quantity = 1"
+  end
+end

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -47,6 +47,7 @@ module Spree
                 ensure_variant_id_from_params(iu)
 
                 unit = shipment.inventory_units.build
+                unit.line_item = order.line_items.find_by_variant_id(iu[:variant_id])
                 unit.order = order
                 unit.variant_id = iu[:variant_id]
               end

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -48,7 +48,6 @@ module Spree
 
                 unit = shipment.inventory_units.build
                 unit.line_item = order.line_items.find_by_variant_id(iu[:variant_id])
-                unit.order = order
                 unit.variant_id = iu[:variant_id]
               end
 

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -49,6 +49,7 @@ module Spree
                 unit = shipment.inventory_units.build
                 unit.line_item = order.line_items.find_by_variant_id(iu[:variant_id])
                 unit.variant_id = iu[:variant_id]
+                unit.quantity = 1
               end
 
               shipment.save!

--- a/core/lib/spree/testing_support/factories/inventory_unit_factory.rb
+++ b/core/lib/spree/testing_support/factories/inventory_unit_factory.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :inventory_unit, class: Spree::InventoryUnit do
-    variant
-    order
+    line_item
+    variant { line_item.variant }
     state 'on_hand'
     association(:shipment, factory: :shipment, state: 'pending')
     # return_authorization

--- a/core/lib/spree/testing_support/factories/inventory_unit_factory.rb
+++ b/core/lib/spree/testing_support/factories/inventory_unit_factory.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
     line_item
     variant { line_item.variant }
     state 'on_hand'
+    quantity 1
     association(:shipment, factory: :shipment, state: 'pending')
     # return_authorization
   end

--- a/core/lib/spree/testing_support/factories/shipment_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipment_factory.rb
@@ -15,7 +15,8 @@ FactoryGirl.define do
           shipment.inventory_units.create(
             order_id: shipment.order_id,
             variant_id: line_item.variant_id,
-            line_item_id: line_item.id
+            line_item_id: line_item.id,
+            quantity: 1
           )
         end
       end

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -221,7 +221,6 @@ module Spree
         end
 
         it 'ensures variant exists and is not deleted' do
-          Importer::Order.should_receive(:ensure_variant_id_from_params)
           order = Importer::Order.import(user,params)
         end
 

--- a/core/spec/models/spree/inventory_unit_spec.rb
+++ b/core/spec/models/spree/inventory_unit_spec.rb
@@ -89,11 +89,28 @@ describe Spree::InventoryUnit do
         shipment.tap(&:save!)
       end
 
+      let(:other_shipment) do
+        shipment = Spree::Shipment.new
+        shipment.stock_location = stock_location
+        shipment.shipping_methods << create(:shipping_method)
+        shipment.order = other_order
+        # We don't care about this in this test
+        shipment.stub(:ensure_correct_adjustment)
+        shipment.tap(&:save!)
+      end
+
+      let(:other_item) do
+        Spree::LineItem.create!(
+          variant: stock_item.variant,
+          order: other_order
+        )
+      end
+
       let!(:other_unit) do
         unit = other_shipment.inventory_units.build
         unit.state = 'backordered'
         unit.variant_id = stock_item.variant.id
-        unit.order_id = other_order.id
+        unit.line_item = other_item
         unit.tap(&:save!)
       end
 

--- a/core/spec/models/spree/inventory_unit_spec.rb
+++ b/core/spec/models/spree/inventory_unit_spec.rb
@@ -22,12 +22,23 @@ describe Spree::InventoryUnit do
       shipment.tap(&:save!)
     end
 
+    let(:variant) do
+      stock_item.variant
+    end
+
+    let(:line_item) do
+      Spree::LineItem.create!(
+        variant: variant,
+        order: order
+      )
+    end
+
     let!(:unit) do
-      unit = shipment.inventory_units.build
-      unit.state = 'backordered'
-      unit.variant_id = stock_item.variant.id
-      unit.order_id = order.id
-      unit.tap(&:save!)
+      shipment.inventory_units.create!(
+        state: 'backordered',
+        line_item: line_item,
+        variant: variant
+      )
     end
 
     # Regression for #3066
@@ -43,7 +54,8 @@ describe Spree::InventoryUnit do
     it "does not find inventory units that aren't backordered" do
       on_hand_unit = shipment.inventory_units.build
       on_hand_unit.state = 'on_hand'
-      on_hand_unit.variant_id = 1
+      on_hand_unit.variant = variant
+      on_hand_unit.line_item = line_item
       on_hand_unit.save!
 
       Spree::InventoryUnit.backordered_for_stock_item(stock_item).should_not include(on_hand_unit)
@@ -53,6 +65,7 @@ describe Spree::InventoryUnit do
       other_variant_unit = shipment.inventory_units.build
       other_variant_unit.state = 'backordered'
       other_variant_unit.variant = create(:variant)
+      other_variant_unit.line_item = line_item
       other_variant_unit.save!
 
       Spree::InventoryUnit.backordered_for_stock_item(stock_item).should_not include(other_variant_unit)
@@ -94,7 +107,7 @@ describe Spree::InventoryUnit do
 
   context "variants deleted" do
     let!(:unit) do
-      Spree::InventoryUnit.create(variant: stock_item.variant)
+      create :inventory_unit
     end
 
     it "can still fetch variant" do

--- a/core/spec/models/spree/inventory_unit_spec.rb
+++ b/core/spec/models/spree/inventory_unit_spec.rb
@@ -37,7 +37,8 @@ describe Spree::InventoryUnit do
       shipment.inventory_units.create!(
         state: 'backordered',
         line_item: line_item,
-        variant: variant
+        variant: variant,
+        quantity: 1
       )
     end
 
@@ -56,6 +57,7 @@ describe Spree::InventoryUnit do
       on_hand_unit.state = 'on_hand'
       on_hand_unit.variant = variant
       on_hand_unit.line_item = line_item
+      on_hand_unit.quantity = 1
       on_hand_unit.save!
 
       Spree::InventoryUnit.backordered_for_stock_item(stock_item).should_not include(on_hand_unit)
@@ -66,6 +68,7 @@ describe Spree::InventoryUnit do
       other_variant_unit.state = 'backordered'
       other_variant_unit.variant = create(:variant)
       other_variant_unit.line_item = line_item
+      other_variant_unit.quantity = 1
       other_variant_unit.save!
 
       Spree::InventoryUnit.backordered_for_stock_item(stock_item).should_not include(other_variant_unit)
@@ -111,6 +114,7 @@ describe Spree::InventoryUnit do
         unit.state = 'backordered'
         unit.variant_id = stock_item.variant.id
         unit.line_item = other_item
+        unit.quantity = 1
         unit.tap(&:save!)
       end
 

--- a/core/spec/models/spree/order_inventory_spec.rb
+++ b/core/spec/models/spree/order_inventory_spec.rb
@@ -211,7 +211,7 @@ describe Spree::OrderInventory do
         let(:different_line_item) { create(:line_item) }
 
         let!(:different_inventory) do
-          shipment.set_up_inventory("on_hand", variant, order, different_line_item)
+          shipment.set_up_inventory("on_hand", variant, different_line_item)
         end
 
         context "completed order" do

--- a/core/spec/models/spree/order_inventory_spec.rb
+++ b/core/spec/models/spree/order_inventory_spec.rb
@@ -169,9 +169,8 @@ describe Spree::OrderInventory do
           mock_model(Spree::InventoryUnit, :variant_id => variant.id, :state => 'backordered')
         ])
 
-        shipment.inventory_units_for_item[0].should_receive(:destroy)
-        shipment.inventory_units_for_item[1].should_not_receive(:destroy)
-        shipment.inventory_units_for_item[2].should_receive(:destroy)
+        shipment.inventory_units_for_item[0].should_receive(:remove).with(2).and_return(1)
+        shipment.inventory_units_for_item[2].should_receive(:remove).with(1).and_return(1)
 
         subject.send(:remove_from_shipment, shipment, 2).should == 2
       end
@@ -182,8 +181,7 @@ describe Spree::OrderInventory do
           mock_model(Spree::InventoryUnit, :variant_id => variant.id, :state => 'on_hand')
         ])
 
-        shipment.inventory_units_for_item[0].should_not_receive(:destroy)
-        shipment.inventory_units_for_item[1].should_receive(:destroy)
+        shipment.inventory_units_for_item[1].should_receive(:remove).with(1).and_return(1)
 
         subject.send(:remove_from_shipment, shipment, 1).should == 1
       end
@@ -194,8 +192,7 @@ describe Spree::OrderInventory do
           mock_model(Spree::InventoryUnit, :variant_id => variant.id, :state => 'on_hand')
         ])
 
-        shipment.inventory_units_for_item[0].should_not_receive(:destroy)
-        shipment.inventory_units_for_item[1].should_receive(:destroy)
+        shipment.inventory_units_for_item[1].should_receive(:remove).with(1).and_return(1)
 
         subject.send(:remove_from_shipment, shipment, 1).should == 1
       end

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -200,16 +200,23 @@ describe Spree::Shipment do
       end
 
       context 'to_package' do
-        let(:inventory_units) do
-          [build(:inventory_unit, line_item: line_item, variant: variant, state: 'on_hand'),
-           build(:inventory_unit, line_item: line_item, variant: variant, state: 'backordered')]
+        let(:manifest) do
+          [
+            double(:manifest_item,
+                   line_item: line_item,
+                   variant: variant,
+                   states: {'on_hand' => 3, 'backordered' => 5}
+                  )
+          ]
         end
 
         it 'should use symbols for states when adding contents to package' do
-          shipment.stub_chain(:inventory_units, includes: inventory_units)
+          expect(shipment).to receive(:manifest).and_return(manifest)
           package = shipment.to_package
-          package.on_hand.count.should eq 1
-          package.backordered.count.should eq 1
+          expect(package.on_hand.count).to eq 1
+          expect(package.on_hand.first.quantity).to eq 3
+          expect(package.backordered.count).to eq 1
+          expect(package.backordered.first.quantity).to eq 5
         end
       end
     end

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -613,7 +613,7 @@ describe Spree::Shipment do
     let(:inventory_units) { double }
 
     let(:params) do
-      { variant_id: variant.id, state: 'on_hand', line_item_id: line_item.id }
+      { variant_id: variant.id, state: 'on_hand', line_item_id: line_item.id, quantity: 1 }
     end
 
     before { shipment.stub inventory_units: inventory_units }

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -619,8 +619,8 @@ describe Spree::Shipment do
     before { shipment.stub inventory_units: inventory_units }
 
     it "associates variant and order" do
-      expect(inventory_units).to receive(:create).with(params)
-      unit = shipment.set_up_inventory('on_hand', variant, line_item)
+      expect(inventory_units).to receive(:create!).with(params)
+      unit = shipment.set_up_inventory('on_hand', variant, line_item, 1)
     end
   end
 

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -344,9 +344,9 @@ describe Spree::Shipment do
     end
 
     it 'restocks the items' do
-      shipment.stub_chain(inventory_units: [mock_model(Spree::InventoryUnit, state: "on_hand", line_item: line_item, variant: variant)])
+      shipment.stub(manifest: [double(:manifest_item, variant: variant, states: {"on_hand" => 2})])
       shipment.stock_location = mock_model(Spree::StockLocation)
-      shipment.stock_location.should_receive(:restock).with(variant, 1, shipment)
+      shipment.stock_location.should_receive(:restock).with(variant, 2, shipment)
       shipment.after_cancel
     end
 
@@ -391,9 +391,9 @@ describe Spree::Shipment do
     end
 
     it 'unstocks them items' do
-      shipment.stub_chain(inventory_units: [mock_model(Spree::InventoryUnit, line_item: line_item, variant: variant)])
+      shipment.stub(manifest: [double(:manifest_item, variant: variant, quantity: 2)])
       shipment.stock_location = mock_model(Spree::StockLocation)
-      shipment.stock_location.should_receive(:unstock).with(variant, 1, shipment)
+      shipment.stock_location.should_receive(:unstock).with(variant, 2, shipment)
       shipment.after_resume
     end
 

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -606,14 +606,14 @@ describe Spree::Shipment do
     let(:inventory_units) { double }
 
     let(:params) do
-      { variant_id: variant.id, state: 'on_hand', order_id: order.id, line_item_id: line_item.id }
+      { variant_id: variant.id, state: 'on_hand', line_item_id: line_item.id }
     end
 
     before { shipment.stub inventory_units: inventory_units }
 
     it "associates variant and order" do
       expect(inventory_units).to receive(:create).with(params)
-      unit = shipment.set_up_inventory('on_hand', variant, order, line_item)
+      unit = shipment.set_up_inventory('on_hand', variant, line_item)
     end
   end
 

--- a/core/spec/models/spree/stock/package_spec.rb
+++ b/core/spec/models/spree/stock/package_spec.rb
@@ -4,7 +4,7 @@ module Spree
   module Stock
     describe Package do
       let(:variant) { build(:variant, weight: 25.0) }
-      let(:line_item) { build(:line_item, variant: variant) }
+      let(:line_item) { build(:line_item, variant: variant, order: order) }
       let(:stock_location) { build(:stock_location) }
       let(:order) { build(:order) }
 

--- a/core/spec/models/spree/stock/package_spec.rb
+++ b/core/spec/models/spree/stock/package_spec.rb
@@ -80,7 +80,9 @@ module Spree
         expect(shipment.address).to eq subject.order.ship_address
         expect(shipment.order).to eq subject.order
         expect(shipment.stock_location).to eq subject.stock_location
-        expect(shipment.inventory_units.size).to eq 3
+        expect(shipment.inventory_units.size).to eq 2
+        expect(shipment.inventory_units[0].quantity).to eq 2
+        expect(shipment.inventory_units[1].quantity).to eq 1
 
         first_unit = shipment.inventory_units.first
         expect(first_unit.variant).to eq variant

--- a/core/spec/models/spree/stock_item_spec.rb
+++ b/core/spec/models/spree/stock_item_spec.rb
@@ -79,16 +79,13 @@ describe Spree::StockItem do
 
       # Regression test for #3755
       it "processes existing backorders, even with negative stock" do
-        inventory_unit.should_receive(:fill_backorder)
-        inventory_unit_2.should_not_receive(:fill_backorder)
+        expect(inventory_unit).to receive(:fill_backorders).with(1).and_return(1)
         subject.adjust_count_on_hand(1)
-        subject.count_on_hand.should == -1
+        expect(subject.count_on_hand).to eq -1
       end
 
       # Test for #3755
       it "does not process backorders when stock is adjusted negatively" do
-        inventory_unit.should_not_receive(:fill_backorder)
-        inventory_unit_2.should_not_receive(:fill_backorder)
         subject.adjust_count_on_hand(-1)
         subject.count_on_hand.should == -3
       end
@@ -97,11 +94,11 @@ describe Spree::StockItem do
         before { subject.stub(:backordered_inventory_units => [inventory_unit, inventory_unit_2]) }
 
         it "fills existing backorders" do
-          inventory_unit.should_receive(:fill_backorder)
-          inventory_unit_2.should_receive(:fill_backorder)
+          expect(inventory_unit).to   receive(:fill_backorders).with(3).and_return(2)
+          expect(inventory_unit_2).to receive(:fill_backorders).with(1).and_return(1)
 
           subject.adjust_count_on_hand(3)
-          subject.count_on_hand.should == 1
+          expect(subject.count_on_hand).to eq 1
         end
       end
     end
@@ -135,8 +132,8 @@ describe Spree::StockItem do
         before { subject.stub(:backordered_inventory_units => [inventory_unit, inventory_unit_2]) }
 
         it "fills existing backorders" do
-          inventory_unit.should_receive(:fill_backorder)
-          inventory_unit_2.should_receive(:fill_backorder)
+          expect(inventory_unit).to receive(:fill_backorders).with(3).and_return(1)
+          expect(inventory_unit_2).to receive(:fill_backorders).with(2).and_return(1)
 
           subject.set_count_on_hand(1)
           subject.count_on_hand.should == 1

--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -313,7 +313,8 @@ describe "Checkout", inaccessible: true do
         click_on "Save and Continue"
         click_on "Save and Continue"
 
-        expect(Spree::InventoryUnit.count).to eq 3
+        expect(Spree::InventoryUnit.count).to eq 1
+        expect(Spree::InventoryUnit.first.quantity).to eq 3
       end
     end
 


### PR DESCRIPTION
~~Marked WIP because this breaks `ReturnAuthorization`s (which are somewhat broken anyways, but going away soon)~~ Now fixed. :shipit:.

This work was done with the goal of having a speedy checkout with an order having 50_000 of an item. Under the current master that results in 50_000 `InventoryUnit`s being inserted and then afterwards selected multiple times per request. This takes over a minute for some requests.

Existing InventoryUnits are migrated by setting quantity=1.
## Major Changes

`InventoryUnit` now has a `quantity`, which makes checking out any quantity of a line_item the same speed. This has resulted in a small amount of additional complexity, in the form of new `#remove` and `#fill_backorders` methods which each take a quantity.

`Shipment#to_package` now relies on `Shipment#manifest`, which fixes two issues with the previous implementation:
- It now correctly handles variant not matching line_item (which can be the case when using spree-product-assembly)
- It will now re-assemble the package with correct quantities. The existing implementation would have 

Optimized `Shipment#manifest`. It now performs counting of inventory quantities in SQL without loading or instantiating InventoryUnits. Variants and line_items are then loaded as two `SELECT FROM ... WHERE id IN (?)` queries. Previously it loaded all inventory units and then performed n+1 queries in order to select variants and line items.

Removed the `order` association on `InventoryUnit` and removed the `order_id` column. Order can always be determined from shipment, and it now delegates order to shipment.

As always, any feedback is appreciated.
