### PR TITLE
Changing currency variable according to google analytics docs

### DIFF
--- a/frontend/app/views/spree/shared/_google_analytics.html.erb
+++ b/frontend/app/views/spree/shared/_google_analytics.html.erb
@@ -17,7 +17,7 @@
         'revenue': '<%= @order.total %>',                                // Grand Total.
         'shipping': '<%= @order.adjustments.shipping.sum(:amount) %>',  // Shipping.
         'tax': '<%= @order.adjustments.tax.sum(:amount) %>',           // Tax.
-        'currencyCode': '<%= current_currency %>'                     // local currency code.
+        'currency': '<%= current_currency %>'                        // local currency code.
       });
       <% @order.line_items.each do |line_item| %>
         ga('ecommerce:addItem', {


### PR DESCRIPTION
Hi,

I'm using a store in BRL currency and tracking its sales with Google Analytics. I noticed that I was getting all revenue values in dollar, except the product price revenue.

I revisited the recommended analytics docs, and found that the `currencyCode` is actually `currency`. Here is the Google Analytics docs link: https://developers.google.com/analytics/devguides/collection/analyticsjs/ecommerce#multicurrency
