### PR TITLE
Admin::Orders should test order.completed? instead of complete?

### DIFF
--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -55,7 +55,7 @@ module Spree
       end
 
       def edit
-        unless @order.complete?
+        unless @order.completed?
           @order.refresh_shipment_rates
         end
       end
@@ -63,8 +63,8 @@ module Spree
       def update
         if @order.update_attributes(params[:order]) && @order.line_items.present?
           @order.update!
-          unless @order.complete?
-            # Jump to next step if order is not complete.
+          unless @order.completed?
+            # Jump to next step if order is not completed.
             redirect_to admin_order_customer_path(@order) and return
           end
         else

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -25,7 +25,7 @@ describe Spree::Admin::OrdersController do
       end
     end
 
-    let(:order) { mock_model(Spree::Order, :complete? => true, :total => 100, :number => 'R123456789') }
+    let(:order) { mock_model(Spree::Order, :completed? => true, :total => 100, :number => 'R123456789') }
     before { Spree::Order.stub :find_by_number! => order }
 
     context "#approve" do
@@ -70,14 +70,14 @@ describe Spree::Admin::OrdersController do
 
     # Regression test for #3684
     context "#edit" do
-      it "does not refresh rates if the order is complete" do
-        order.stub :complete? => true
+      it "does not refresh rates if the order is completed" do
+        order.stub :completed? => true
         order.should_not_receive :refresh_shipment_rates
         spree_get :edit, :id => order.number
       end
 
       it "does refresh the rates if the order is incomplete" do
-        order.stub :complete? => false
+        order.stub :completed? => false
         order.should_receive :refresh_shipment_rates
         spree_get :edit, :id => order.number
       end


### PR DESCRIPTION
Checkout steps are customizable, 'complete' may not be the only state in which an order is considered completed.
