### PR TITLE
Fix for entering localized amounts for payments

### DIFF
--- a/backend/app/views/spree/admin/payments/_form.html.erb
+++ b/backend/app/views/spree/admin/payments/_form.html.erb
@@ -2,7 +2,7 @@
   <div class="alpha three columns">
     <div class="field">
       <%= f.label :amount, Spree.t(:amount) %>
-      <%= f.text_field :amount, :value => @order.outstanding_balance, :class => 'fullwidth' %>
+      <%= f.text_field :amount, :value => @order.display_outstanding_balance.to_html, :class => 'fullwidth' %>
     </div>
   </div>
   <div class="omega nine columns">

--- a/backend/app/views/spree/admin/payments/_form.html.erb
+++ b/backend/app/views/spree/admin/payments/_form.html.erb
@@ -2,7 +2,7 @@
   <div class="alpha three columns">
     <div class="field">
       <%= f.label :amount, Spree.t(:amount) %>
-      <%= f.text_field :amount, :value => @order.display_outstanding_balance.to_html, :class => 'fullwidth' %>
+      <%= f.text_field :amount, :value => @order.display_outstanding_balance.money, :class => 'fullwidth' %>
     </div>
   </div>
   <div class="omega nine columns">


### PR DESCRIPTION
While running Spree in Dutch locale, adding a Payment recognizes the decimal separator as thousands separator. So when using the pre filled value (e.g. 45.21) this will be converted to a much larger amount (4521.00). The fix makes sure that a localized value is filled in (45,21 instead of 45.21).

Tested on Spree 2.2.1
