### PR TITLE
rescue error_message_on helper method

### DIFF
--- a/backend/app/helpers/spree/admin/base_helper.rb
+++ b/backend/app/helpers/spree/admin/base_helper.rb
@@ -11,13 +11,17 @@ module Spree
       end
 
       def error_message_on(object, method, options = {})
-        object = convert_to_model(object)
-        obj = object.respond_to?(:errors) ? object : instance_variable_get("@#{object}")
+        begin
+          object = convert_to_model(object)
+          obj = object.respond_to?(:errors) ? object : instance_variable_get("@#{object}")
 
-        if obj && obj.errors[method].present?
-          errors = obj.errors[method].map { |err| h(err) }.join('<br />').html_safe
-          content_tag(:span, errors, :class => 'formError')
-        else
+          if obj && obj.errors[method].present?
+            errors = obj.errors[method].map { |err| h(err) }.join('<br />').html_safe
+            content_tag(:span, errors, :class => 'formError')
+          else
+            ''
+          end
+        rescue
           ''
         end
       end


### PR DESCRIPTION
I create a new child model of Spree::Product. When new a product, I would like to use accepts_nested_attributes_for and form builder fields_for method to create child data as well.

However, It always give me this error:

```
ActionView::Template::Error (`@product[bidding_attributes]' is not allowed as an instance variable name):
    1: $("#new_product_wrapper").html('<%= escape_javascript(render :template => "spree/admin/products/new", :formats => [:html], :handlers => [:erb]) %>');
    2: handle_date_picker_fields();
    3: <% unless Rails.env.test? %>
    4:   $('.select2').select2();
  /Users/wuboy/.rvm/gems/ruby-2.1.1/bundler/gems/spree-da169e034db3/backend/app/helpers/spree/admin/base_helper.rb:15:in `instance_variable_get'
  /Users/wuboy/.rvm/gems/ruby-2.1.1/bundler/gems/spree-da169e034db3/backend/app/helpers/spree/admin/base_helper.rb:15:in `error_message_on'
  /Users/wuboy/.rvm/gems/ruby-2.1.1/bundler/gems/spree-da169e034db3/backend/app/helpers/spree/admin/base_helper.rb:7:in `field_container'
  /Users/wuboy/.rvm/gems/ruby-2.1.1/bundler/gems/spree-da169e034db3/backend/config/initializers/form_builder.rb:6:in `field_container'
  /Users/wuboy/.rvm/gems/ruby-2.1.1/bundler/gems/spree-da169e034db3/backend/app/views/spree/admin/products/new.html.erb:65:in `block (2 levels) in _d49ffa0e1f0bdbd8b85052a9b613726f'
```

error_message_on method tries to use instance_variable_get to get "@product[bidding_attributes]" which is not available.

If I remove field_container, everything is fine.
Maybe we should just rescue it to avoid further error.
