### PR TITLE
fix for payments made via /admin

### DIFF
--- a/backend/app/controllers/spree/admin/payments_controller.rb
+++ b/backend/app/controllers/spree/admin/payments_controller.rb
@@ -29,9 +29,12 @@ module Spree
         begin
           if @payment.save
             invoke_callbacks(:create, :after)
-            # Transition order as far as it will go.
-            while @order.next; end
-            @payment.process! if @order.completed?
+            if @order.completed?
+              @payment.process!
+            else
+              # Transition order as far as it will go, which will trigger payment as well
+              while @order.next; end
+            end
             flash[:success] = flash_message_for(@payment, :successfully_created)
             redirect_to admin_order_payments_path(@order)
           else

--- a/backend/spec/controllers/spree/admin/payments_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/payments_controller_spec.rb
@@ -27,6 +27,7 @@ module Spree
           }
           spree_post :create, attributes
           order.payments.count.should == 1
+          Spree::LogEntry.where(source: order.payments.first).count.should == 1
           expect(response).to redirect_to(spree.admin_order_payments_path(order))
           expect(order.reload.state).to eq('complete')
         end


### PR DESCRIPTION
this was causing double-billing on orders placed via /admin.
in our case braintree prevented the duplicate billing but that resulted in the same payment being marked as failed when actually it succeeded the first time.
