### PR TITLE
remove reference to shipment.adjustment

### DIFF
--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -22,17 +22,7 @@ module Spree
       def update
         @shipment = Spree::Shipment.accessible_by(current_ability, :update).readonly(false).find_by!(number: params[:id])
 
-        unlock = params[:shipment].delete(:unlock)
-
-        if unlock == 'yes'
-          @shipment.adjustment.open
-        end
-
         @shipment.update_attributes(shipment_params)
-
-        if unlock == 'yes'
-          @shipment.adjustment.close
-        end
 
         @shipment.reload
         respond_with(@shipment, default_template: :show)


### PR DESCRIPTION
shipment.adjustment no longer exists so we can kill this. also wasn't
tested, so no need to change test cases.

My understanding is with the adjustment refactoring we don't need to
deal with the open/close anymore anyway.
