### PR TITLE
fix for payments made via /admin

### DIFF
--- a/backend/app/controllers/spree/admin/payments_controller.rb
+++ b/backend/app/controllers/spree/admin/payments_controller.rb
@@ -31,7 +31,9 @@ module Spree
             invoke_callbacks(:create, :after)
             # Transition order as far as it will go.
             while @order.next; end
-            @payment.process! if @order.completed?
+            # If "@order.next" didn't trigger payment processing already (e.g. if the order was
+            # already complete) then trigger it manually now
+            @payment.process! if @order.completed? && @payment.checkout?
             flash[:success] = flash_message_for(@payment, :successfully_created)
             redirect_to admin_order_payments_path(@order)
           else

--- a/backend/spec/controllers/spree/admin/payments_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/payments_controller_spec.rb
@@ -27,6 +27,7 @@ module Spree
           }
           spree_post :create, attributes
           order.payments.count.should == 1
+          Spree::LogEntry.where(source: order.payments.first).count.should == 1
           expect(response).to redirect_to(spree.admin_order_payments_path(order))
           expect(order.reload.state).to eq('complete')
         end


### PR DESCRIPTION
orders placed via /admin were being charged twice.

See these two lines from Spree::Admin::PaymentsController:

```
while @order.next; end
@payment.process! if @order.completed?
```

For incomplete orders the first line will trigger callbacks that cause
the payment to be charged if the order reaches the "completed" state.
Then the second line will process the payment _again_, resulting in a
double charge.

We can't just remove the second line because orders that are already
complete won't trigger any callbacks from the first line, so these
orders need to have their payments charged manually.

The effect of the bug in our case was that Braintree rejected the second
(duplicate) billing on the payment, and this resulted in the Payment
object being marked as failed when actually it succeeded on the first
attempt. So it appeared from within Spree that a successful payment
was a failed payment.

It would be great to get this into the 2-2-stable branch as well.

This replaces https://github.com/spree/spree/pull/4765
