### PR TITLE
handle credit card names with spaces

### DIFF
--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -112,8 +112,8 @@ module Spree
         :month => month,
         :year => year,
         :verification_value => verification_value,
-        :first_name => first_name || name.to_s.split.first,
-        :last_name => last_name || name.to_s.split.last
+        :first_name => first_name || name.to_s.split(/[[:space:]]/, 2)[0],
+        :last_name => last_name || name.to_s.split(/[[:space:]]/, 2)[1]
       )
     end
 

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -310,13 +310,13 @@ describe Spree::CreditCard do
     context "provides name instead of first and last" do
       before do
         credit_card.first_name = credit_card.last_name = nil
-        credit_card.name = "Bob Law"
+        credit_card.name = "Ludwig van Beethoven"
       end
 
       it "falls back to split first and last" do
         am_card = credit_card.to_active_merchant
-        expect(am_card.first_name).to eq "Bob"
-        expect(am_card.last_name).to eq "Law"
+        expect(am_card.first_name).to eq "Ludwig"
+        expect(am_card.last_name).to eq "van Beethoven"
       end
     end
   end


### PR DESCRIPTION
this addresses a change from https://github.com/spree/spree/commit/71d4deed1aa815a2727357f2c35e2f544f5f1959
