### PR TITLE
Use permitted_option_value_attributes instead of permitted_option_type_a...

### DIFF
--- a/api/app/controllers/spree/api/option_values_controller.rb
+++ b/api/app/controllers/spree/api/option_values_controller.rb
@@ -51,7 +51,7 @@ module Spree
         end
 
         def option_value_params
-          params.require(:option_value).permit(permitted_option_type_attributes)
+          params.require(:option_value).permit(permitted_option_value_attributes)
         end
     end
   end

--- a/api/spec/controllers/spree/api/option_values_controller_spec.rb
+++ b/api/spec/controllers/spree/api/option_values_controller_spec.rb
@@ -111,6 +111,13 @@ module Spree
           option_value.name.should == "Option Value"
         end
 
+        it "permits the correct attributes" do
+          controller.should_receive(:permitted_option_value_attributes)
+          api_put :update, :id => option_value.id, :option_value => {
+                            :name => ""
+                           }
+        end
+
         it "cannot update an option value with invalid attributes" do
           api_put :update, :id => option_value.id, :option_value => {
                             :name => ""


### PR DESCRIPTION
Use permitted_option_value_attributes instead of permitted_option_type_attributes inside Spree::Api:OptionValuesController
