### PR TITLE
Make sure the sum of capturable payments is equal to the order total

### DIFF
--- a/api/spec/controllers/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/controllers/spree/api/checkouts_controller_spec.rb
@@ -267,7 +267,7 @@ module Spree
       it "returns a sensible error when no payment method is specified" do
         order.update_column(:state, "payment")
         api_put :next, :id => order.to_param, :order_token => order.token, :order => {}
-        json_response["errors"]["base"].should include(Spree.t(:no_pending_payments))
+        json_response["errors"]["base"].should include(Spree.t(:collected_payment_does_not_match_order_total))
       end
     end
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -591,6 +591,12 @@ module Spree
       super
     end
 
+    def ensure_capturable_payment_amount_matches_total
+      payment_matches_total = payments.valid.to_a.sum(&:amount) == total
+      errors.add(:base, Spree.t(:collected_payment_does_not_match_order_total)) unless payment_matches_total
+      payment_matches_total
+    end
+
     private
 
       def link_by_email

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -71,7 +71,10 @@ module Spree
 
               if states[:payment]
                 before_transition :to => :complete do |order|
-                  order.process_payments! if order.payment_required?
+                  if order.payment_required?
+                    order.ensure_capturable_payment_amount_matches_total &&
+                      order.process_payments!
+                  end
                 end
               end
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1125,6 +1125,7 @@ en:
     thank_you_for_your_order: Thank you for your business.  Please print out a copy of this confirmation page for your records.
     there_are_no_items_for_this_order: There are no items for this order. Please add an item to the order to continue.
     there_were_problems_with_the_following_fields: There were problems with the following fields
+    collected_payment_does_not_match_order_total: Collected payment does not match order total
     thumbnail: Thumbnail
     time: Time
     to_add_variants_you_must_first_define: To add variants, you must first define

--- a/core/spec/models/spree/order/state_machine_spec.rb
+++ b/core/spec/models/spree/order/state_machine_spec.rb
@@ -19,6 +19,15 @@ describe Spree::Order do
         order.stub :has_available_shipment
       end
 
+      context "when payment capturable total does not match order total" do
+        before { order.stub :ensure_capturable_payment_amount_matches_total => false }
+
+        it "should not complete the order" do
+           order.next
+           order.state.should == "confirm"
+         end
+      end
+
       context "when payment processing succeeds" do
         before { order.stub :process_payments! => true }
 

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -143,6 +143,8 @@ describe Spree::CheckoutController do
           order.stub :confirmation_required? => true
           order.update_column(:state, "confirm")
           order.stub :user => user
+          order.update_totals
+          order.persist_totals
           # An order requires a payment to reach the complete state
           # This is because payment_required? is true on the order
           create(:payment, :amount => order.total, :order => order)
@@ -282,6 +284,7 @@ describe Spree::CheckoutController do
       end
 
       it "when GatewayError is raised" do
+        order.stub(:ensure_capturable_payment_amount_matches_total).and_return(true)
         order.payments.any_instance.stub(:process!).and_raise(Spree::Core::GatewayError.new(Spree.t(:payment_processing_failed)))
         spree_put :update, :order => {}
         flash[:error].should == Spree.t(:payment_processing_failed)


### PR DESCRIPTION
This check is meant to prevent not being able to capture enough funds to pay for the order or ever capturing more than the order total.
