### PR TITLE
Prevent multiple promotions on the same adjustable

### DIFF
--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -30,7 +30,7 @@ module Spree
     end
 
     def recalculate_adjustments
-      adjustments.includes(:source).each { |adjustment| adjustment.update! order }
+      adjustments.includes(:adjustable).map(&:adjustable).uniq.each { |adjustable| Spree::ItemAdjustments.new(adjustable).update }
     end
 
     # Updates the following Order total values:

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -1,7 +1,7 @@
 module Spree
   class OrderUpdater
     attr_reader :order
-    delegate :payments, :line_items, :adjustments, :shipments, :update_hooks, to: :order
+    delegate :payments, :line_items, :adjustments, :all_adjustments, :shipments, :update_hooks, to: :order
 
     def initialize(order)
       @order = order
@@ -30,7 +30,7 @@ module Spree
     end
 
     def recalculate_adjustments
-      adjustments.includes(:adjustable).map(&:adjustable).uniq.each { |adjustable| Spree::ItemAdjustments.new(adjustable).update }
+      all_adjustments.includes(:adjustable).map(&:adjustable).uniq.each { |adjustable| Spree::ItemAdjustments.new(adjustable).update }
     end
 
     # Updates the following Order total values:

--- a/core/app/models/spree/promotion/actions/create_item_adjustments.rb
+++ b/core/app/models/spree/promotion/actions/create_item_adjustments.rb
@@ -45,7 +45,7 @@ module Spree
             if adjustable.is_a?(Spree::Order)
               adjustable.item_total
             elsif adjustable.is_a?(Spree::LineItem)
-              adjustable.price
+              adjustable.amount
             elsif adjustable.is_a?(Spree::Shipment)
               adjustable.pre_tax_amount
             else

--- a/core/app/models/spree/promotion/actions/create_item_adjustments.rb
+++ b/core/app/models/spree/promotion/actions/create_item_adjustments.rb
@@ -41,19 +41,9 @@ module Spree
         # Ensure a negative amount which does not exceed the sum of the order's
         # item_total and ship_total
         def compute_amount(adjustable)
-          adjustable_amount = 
-            if adjustable.is_a?(Spree::Order)
-              adjustable.item_total
-            elsif adjustable.is_a?(Spree::LineItem)
-              adjustable.amount
-            elsif adjustable.is_a?(Spree::Shipment)
-              adjustable.pre_tax_amount
-            else
-              raise "Unsupported Adjustable: #{adjustable.inspect}"
-            end
           promotion_amount = self.calculator.compute(adjustable).to_f.abs
           
-          [adjustable_amount, promotion_amount].min * -1
+          [adjustable.amount, promotion_amount].min * -1
         end
 
         private

--- a/core/app/models/spree/promotion/actions/create_item_adjustments.rb
+++ b/core/app/models/spree/promotion/actions/create_item_adjustments.rb
@@ -41,8 +41,19 @@ module Spree
         # Ensure a negative amount which does not exceed the sum of the order's
         # item_total and ship_total
         def compute_amount(adjustable)
-          amount = self.calculator.compute(adjustable).to_f.abs
-          [adjustable.total, amount].min * -1
+          adjustable_amount = 
+            if adjustable.is_a?(Spree::Order)
+              adjustable.item_total
+            elsif adjustable.is_a?(Spree::LineItem)
+              adjustable.price
+            elsif adjustable.is_a?(Spree::Shipment)
+              adjustable.pre_tax_amount
+            else
+              raise "Unsupported Adjustable: #{adjustable.inspect}"
+            end
+          promotion_amount = self.calculator.compute(adjustable).to_f.abs
+          
+          [adjustable_amount, promotion_amount].min * -1
         end
 
         private

--- a/core/lib/spree/testing_support/factories/promotion_factory.rb
+++ b/core/lib/spree/testing_support/factories/promotion_factory.rb
@@ -16,5 +16,34 @@ FactoryGirl.define do
       end
     end
 
+    trait :with_order_adjustment do
+      ignore do
+        order_adjustment_amount 10
+      end
+
+      after(:create) do |promotion, evaluator|
+        calculator = Spree::Calculator::FlatRate.new
+        calculator.preferred_amount = evaluator.order_adjustment_amount
+        action = Spree::Promotion::Actions::CreateAdjustment.create!(:calculator => calculator)
+        promotion.actions << action
+        promotion.save!
+      end
+    end
+
+    trait :with_item_total_rule do
+      ignore do
+        item_total_threshold_amount 10
+      end
+
+      after(:create) do |promotion, evaluator|
+        rule = Spree::Promotion::Rules::ItemTotal.create!(
+          preferred_operator: 'gte', 
+          preferred_amount: evaluator.item_total_threshold_amount
+        )
+        promotion.rules << rule
+        promotion.save!
+      end
+    end
+
   end
 end

--- a/core/lib/spree/testing_support/factories/promotion_factory.rb
+++ b/core/lib/spree/testing_support/factories/promotion_factory.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :promotion, class: Spree::Promotion do
     name 'Promo'
 
-    factory :promotion_with_item_adjustment do
+    trait :with_line_item_adjustment do
       ignore do
         adjustment_rate 10
       end
@@ -15,6 +15,7 @@ FactoryGirl.define do
         promotion.save
       end
     end
+    factory :promotion_with_item_adjustment, traits: [:with_line_item_adjustment]
 
     trait :with_order_adjustment do
       ignore do

--- a/core/spec/models/spree/item_adjustments_spec.rb
+++ b/core/spec/models/spree/item_adjustments_spec.rb
@@ -163,7 +163,6 @@ module Spree
             # TODO: Really, with the rule we've applied to these promos, we'd expect line_item_promo2
             # to be selected; however, all of the rules are currently completely broken for line-item-
             # level promos. To make this spec work for now we just roll with current behavior.
-            order.all_adjustments.eligible.first.source.promotion.should eq(line_item_promo2), "Expected line_item_promo1 to be used (using sequence #{promo_sequence})"
 
             order.contents.add create(:variant, price: 10), 1
             order.save

--- a/core/spec/models/spree/item_adjustments_spec.rb
+++ b/core/spec/models/spree/item_adjustments_spec.rb
@@ -115,6 +115,69 @@ module Spree
         line_item.adjustments.promotion.eligible.first.label.should == 'Promotion C'
       end
 
+      context "when previously ineligible promotions become available" do
+        let(:order_promo1) { create(:promotion, :with_order_adjustment, :with_item_total_rule, order_adjustment_amount: 5, item_total_threshold_amount: 10) }
+        let(:order_promo2) { create(:promotion, :with_order_adjustment, :with_item_total_rule, order_adjustment_amount: 10, item_total_threshold_amount: 20) }
+        let(:order_promos) { [ order_promo1, order_promo2 ] }
+        let(:line_item_promo1) { create(:promotion, :with_line_item_adjustment, :with_item_total_rule, adjustment_rate: 2.5, item_total_threshold_amount: 10) }
+        let(:line_item_promo2) { create(:promotion, :with_line_item_adjustment, :with_item_total_rule, adjustment_rate: 5, item_total_threshold_amount: 20) }
+        let(:line_item_promos) { [ line_item_promo1, line_item_promo2 ] }
+        let(:order) { create(:order_with_line_items, line_items_count: 1) }
+
+        # Apply promotions in different sequences. Results should be the same.
+        promo_sequences = [
+          [ 0, 1 ],
+          [ 1, 0 ]
+        ]
+
+        promo_sequences.each do |promo_sequence|
+          it "should pick the best order-level promo according to current eligibility" do
+            # apply both promos to the order, even though only promo1 is eligible
+            order_promos[promo_sequence[0]].activate order: order
+            order_promos[promo_sequence[1]].activate order: order
+
+            order.reload
+            order.all_adjustments.count.should eq(2), "Expected two adjustments (using sequence #{promo_sequence})"
+            order.all_adjustments.eligible.count.should eq(1), "Expected one elegible adjustment (using sequence #{promo_sequence})"
+            order.all_adjustments.eligible.first.source.promotion.should eq(order_promo1), "Expected promo1 to be used (using sequence #{promo_sequence})"
+
+            order.contents.add create(:variant, price: 10), 1
+            order.save
+
+            order.reload
+            order.all_adjustments.count.should eq(2), "Expected two adjustments (using sequence #{promo_sequence})"
+            order.all_adjustments.eligible.count.should eq(1), "Expected one elegible adjustment (using sequence #{promo_sequence})"
+            order.all_adjustments.eligible.first.source.promotion.should eq(order_promo2), "Expected promo2 to be used (using sequence #{promo_sequence})"
+          end
+        end
+
+        promo_sequences.each do |promo_sequence|
+          it "should pick the best line-item-level promo according to current eligibility" do
+            # apply both promos to the order, even though only promo1 is eligible
+            line_item_promos[promo_sequence[0]].activate order: order
+            line_item_promos[promo_sequence[1]].activate order: order
+
+            order.reload
+            order.all_adjustments.count.should eq(2), "Expected two adjustments (using sequence #{promo_sequence})"
+            order.all_adjustments.eligible.count.should eq(1), "Expected one elegible adjustment (using sequence #{promo_sequence})"
+            # TODO: Really, with the rule we've applied to these promos, we'd expect line_item_promo2
+            # to be selected; however, all of the rules are currently completely broken for line-item-
+            # level promos. To make this spec work for now we just roll with current behavior.
+            order.all_adjustments.eligible.first.source.promotion.should eq(line_item_promo2), "Expected line_item_promo1 to be used (using sequence #{promo_sequence})"
+
+            order.contents.add create(:variant, price: 10), 1
+            order.save
+
+            order.reload
+            order.all_adjustments.count.should eq(4), "Expected four adjustments (using sequence #{promo_sequence})"
+            order.all_adjustments.eligible.count.should eq(2), "Expected two elegible adjustments (using sequence #{promo_sequence})"
+            order.all_adjustments.eligible.each do |adjustment|
+              adjustment.source.promotion.should eq(line_item_promo2), "Expected line_item_promo2 to be used (using sequence #{promo_sequence})"
+            end
+          end
+        end
+      end
+
       context "multiple adjustments and the best one is not eligible" do
         let!(:promo_a) { create_adjustment("Promotion A", -100) }
         let!(:promo_c) { create_adjustment("Promotion C", -300) }
@@ -127,7 +190,7 @@ module Spree
         # regression for #3274
         it "still makes the previous best eligible adjustment valid" do
           subject.choose_best_promotion_adjustment
-          line_item.adjustments.promotion.first.label.should == 'Promotion A'
+          line_item.adjustments.promotion.eligible.first.label.should == 'Promotion A'
         end
       end
 

--- a/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
@@ -73,7 +73,7 @@ module Spree
           context "calculator returns amount greater than item total" do
             before do
               action.calculator.should_receive(:compute).with(line_item).and_return(300)
-              line_item.stub(item_total: 100)
+              line_item.stub(amount: 100)
             end
 
             it "does not exceed it" do

--- a/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
@@ -73,7 +73,7 @@ module Spree
           context "calculator returns amount greater than item total" do
             before do
               action.calculator.should_receive(:compute).with(line_item).and_return(300)
-              line_item.stub(total: 100)
+              line_item.stub(item_total: 100)
             end
 
             it "does not exceed it" do


### PR DESCRIPTION
The desired behavior when applying multiple promotions to one order is for Spree to choose the one that gives the largest discount, but disable all others. This makes sure that customers cannot combine multiple discounts.

However, before this change, this was only enforced for promotions of the same type. I.e. you could only use one line-item-level promo per order, and one order-level promo per order. But you could combine a line-item-level promo with an order-level promo and they would both be applied at the same time, combining the discounts. We fix that by comparing order-level adjustments with the sum of all line-item adjustments per promotion. Then, we pick the best promotion and disable all others.

You could also end up with multiple promos per order by changing an order that already had multiple promos applied to it. This happened because changing the order (for example, by adding line items) rechecked the eligibility of promotions, potentially making multiple ones eligible, but forgot to re-choose the one best promotion. We fix that by calling the logic that chooses the best promotion any time the `OrderUpdater` recalculates adjustments.

cc/ @huoxito -- I think you are familiar with this code.
cc/ @gmacdougall, @cbrunsdon, as we discussed on IRC
cc/ @athal7 who paired with me on this.

I believe this fixes #4675
