### PR TITLE
Only allow one promo

### DIFF
--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -63,6 +63,11 @@ module Spree
       source.class < Spree::PromotionAction
     end
 
+    def already_marked_ineligible?
+      # by default eligible is true
+      eligible == false
+    end
+
     # Recalculate amount given a target e.g. Order, Shipment, LineItem
     #
     # Passing a target here would always be recommended as it would avoid
@@ -77,13 +82,9 @@ module Spree
       return amount if closed?
       if source.present?
         amount = source.compute_amount(target || adjustable)
-        self.update_columns(
-          amount: amount,
-          updated_at: Time.now,
-        )
-        if promotion?
-          self.update_column(:eligible, source.promotion.eligible?(adjustable))
-        end
+        self.amount = amount
+        self.eligible = source.promotion.eligible?(adjustable) if promotion? && !already_marked_ineligible?
+        self.save if changed?
       end
       amount
     end

--- a/core/app/models/spree/promotion_handler/coupon.rb
+++ b/core/app/models/spree/promotion_handler/coupon.rb
@@ -67,10 +67,15 @@ module Spree
         discount ||= order.shipment_adjustments.promotion.detect(&detector)
         discount ||= order.adjustments.promotion.detect(&detector)
 
+        best_promo = order.adjustments.promotion.eligible.first
         if result and discount.eligible
           order.update_totals
           order.persist_totals
           self.success = Spree.t(:coupon_code_applied)
+        elsif best_promo.present? && best_promo != discount
+          self.error = Spree.t(:coupon_code_better_exists)
+        elsif not discount.eligible
+          self.error = Spree.t(:coupon_code_not_eligible)
         else
           # if the promotion was created after the order
           self.error = Spree.t(:coupon_code_not_found)


### PR DESCRIPTION
This is a fix for #4675
Please compare to #4775 and discuss the best implementation

Also restores the coupon error messages that provide additional information to the user why a coupon was declined.

Note: haven't run the complete specs yet
