### PR TITLE
Do not destroy associated adjustments when tax rate or promotion is deleted

### DIFF
--- a/core/app/models/spree/promotion/actions/create_adjustment.rb
+++ b/core/app/models/spree/promotion/actions/create_adjustment.rb
@@ -56,14 +56,14 @@ module Spree
           end
 
           def deals_with_adjustments
-            adjustment_scope = self.adjustments.joins("LEFT OUTER JOIN spree_orders ON spree_orders.id = spree_adjustments.adjustable_id")
-            # For incomplete orders, remove the adjustment completely.
-            adjustment_scope.where("spree_orders.completed_at IS NULL").readonly(false).destroy_all
-
-            # For complete orders, the source will be invalid.
-            # Therefore we nullify the source_id, leaving the adjustment in place.
+            # We nullify the source_id, leaving the adjustment in place.
             # This would mean that the order's total is not altered at all.
-            adjustment_scope.where("spree_orders.completed_at IS NOT NULL").update_all("source_id = NULL")
+            self.adjustments.each do |adjustment|
+              adjustment.update_columns(
+                source_id: nil,
+                updated_at: Time.now,
+              )
+            end
           end
       end
     end

--- a/core/app/models/spree/promotion/actions/create_item_adjustments.rb
+++ b/core/app/models/spree/promotion/actions/create_item_adjustments.rb
@@ -62,17 +62,9 @@ module Spree
           end
 
           def deals_with_adjustments
-            adjustment_scope = self.adjustments.includes(:order).references(:spree_orders)
-
-            # For incomplete orders, remove the adjustment completely.
-            adjustment_scope.where("spree_orders.completed_at IS NULL").each do |adjustment|
-              adjustment.destroy
-            end
-
-            # For complete orders, the source will be invalid.
-            # Therefore we nullify the source_id, leaving the adjustment in place.
+            # We nullify the source_id, leaving the adjustment in place.
             # This would mean that the order's total is not altered at all.
-            adjustment_scope.where("spree_orders.completed_at IS NOT NULL").each do |adjustment|
+            self.adjustments.each do |adjustment|
               adjustment.update_columns(
                 source_id: nil,
                 updated_at: Time.now,

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -15,11 +15,13 @@ module Spree
     belongs_to :zone, class_name: "Spree::Zone"
     belongs_to :tax_category, class_name: "Spree::TaxCategory"
 
-    has_many :adjustments, as: :source, dependent: :destroy
+    has_many :adjustments, as: :source
 
     validates :amount, presence: true, numericality: true
     validates :tax_category_id, presence: true
     validates_with DefaultTaxZoneValidator
+
+    before_destroy :deals_with_adjustments
 
     scope :by_zone, ->(zone) { where(zone_id: zone) }
 
@@ -191,6 +193,17 @@ module Spree
         label = ""
         label << (name.present? ? name : tax_category.name) + " "
         label << (show_rate_in_label? ? "#{amount * 100}%" : "")
+      end
+
+      def deals_with_adjustments
+        # We nullify the source_id, leaving the adjustment in place.
+        # This would mean that the order's total is not altered at all.
+        self.adjustments.each do |adjustment|
+          adjustment.update_columns(
+            source_id: nil,
+            updated_at: Time.now,
+          )
+        end
       end
   end
 end

--- a/core/spec/models/spree/promotion/actions/create_adjustment_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_adjustment_spec.rb
@@ -52,10 +52,10 @@ describe Spree::Promotion::Actions::CreateAdjustment do
     end
 
     context "when order is not complete" do
-      it "should not keep the adjustment" do
+      it "should still keep the adjustment" do
         action.perform(:order => order)
         action.destroy
-        order.adjustments.count.should == 0
+        order.adjustments.count.should == 1
       end
     end
 

--- a/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
@@ -86,13 +86,13 @@ module Spree
           let!(:action) { CreateItemAdjustments.create! }
           let(:other_action) { CreateItemAdjustments.create! }
 
-          it "destroys adjustments for incompleted orders" do
+          it "doesn't destroy adjustments for incompleted orders" do
             order = Order.create
             action.adjustments.create!(label: "Check", amount: 0, order: order)
 
             expect {
               action.destroy
-            }.to change { Adjustment.count }.by(-1)
+            }.to change { Adjustment.count }.by(0)
           end
 
           it "nullifies adjustments for completed orders" do


### PR DESCRIPTION
This is an attempt to fix https://github.com/spree/spree/issues/4771

Currently when a tax rate is deleted the associated tax adjustments are destroyed no matter the order is open or closed. When a promotion is deleted the associated promotion adjustments are destroyed too if the order is still open. On top of that when the adjustments are destroyed the total cost doesn't get updated, which results in discrepancy in sum of the total cost.

One way to address this is to make sure total cost gets updated when adjustments are destroyed. But I think for better user experience we'd better keep those adjustments even for open order. Adjustments are created at the time a tax rate or coupon code is applied. It's like taking a snapshot. Later the deletion of the tax rate or promotion should not affect the adjustments that were created already. Unless we communicate that well to user, which we're not doing anything currently. It's a bad user experience when you see the discount and click "place order" and only find out later that you didn't get the discount. If I was the user I would feel cheated.

The fix in this PR is to keep the adjustments when a tax rate or promotion is deleted. It only nullifies the source_id in this case. So far I don't find any side effect of doing that. Anybody who is familiar with adjustments code are welcome to provide feedback.
