### PR TITLE
2 2 stable money version

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'highline', '~> 1.6.18' # Necessary for the install generator
   s.add_dependency 'httparty', '~> 0.11' # For checking alerts.
   s.add_dependency 'json', '~> 1.7'
+  s.add_dependency 'money', '< 6.1.0'
   s.add_dependency 'kaminari', '~> 0.15.0'
   s.add_dependency 'paperclip', '~> 3.4.1'
   s.add_dependency 'paranoia', '~> 2.0'


### PR DESCRIPTION
Specifies a dependency for money.

I wasn't the only person that came up with this issue: http://blog.endpoint.com/2014/04/spree-security-update-2xx-error.html

Just the only person cool enough to send a pull request.
