### PR TITLE
Better errors on coupon code failing

### DIFF
--- a/core/app/models/spree/promotion_handler/coupon.rb
+++ b/core/app/models/spree/promotion_handler/coupon.rb
@@ -36,6 +36,7 @@ module Spree
 
       def handle_present_promotion(promotion)
         return promotion_usage_limit_exceeded if promotion.usage_limit_exceeded?(order)
+        return promotion_applied if promotion_exists_on_order?(order, promotion)
         return ineligible_for_this_order unless promotion.eligible?(order)
 
         # If any of the actions for the promotion return `true`,
@@ -44,7 +45,7 @@ module Spree
         if result
           determine_promotion_application_result(result)
         else
-          self.error = Spree.t(:coupon_code_already_applied)
+          self.error = Spree.t(:coupon_code_unknown_error)
         end
       end
 
@@ -54,6 +55,14 @@ module Spree
 
       def ineligible_for_this_order
         self.error = Spree.t(:coupon_code_not_eligible)
+      end
+
+      def promotion_applied
+        self.error = Spree.t(:coupon_code_already_applied)
+      end
+
+      def promotion_exists_on_order?(order, promotion)
+        order.promotions.include? promotion
       end
 
       def determine_promotion_application_result(result)

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -485,6 +485,7 @@ en:
     coupon_code_max_usage: Coupon code usage limit exceeded
     coupon_code_not_eligible: This coupon code is not eligible for this order
     coupon_code_not_found: The coupon code you entered doesn't exist. Please try again.
+    coupon_code_unknown_error: This coupon code could not be applied to the cart at this time.
     create: Create
     create_a_new_account: Create a new account
     created_at: Created At

--- a/core/spec/models/spree/promotion_handler/coupon_spec.rb
+++ b/core/spec/models/spree/promotion_handler/coupon_spec.rb
@@ -152,6 +152,13 @@ module Spree
               expect(subject.error).to eq Spree.t(:coupon_code_already_applied)
             end
 
+            it "coupon fails to activate" do
+              Spree::Promotion.any_instance.stub(:activate).and_return false
+              subject.apply
+              expect(subject.error).to eq Spree.t(:coupon_code_unknown_error)
+            end
+
+
             it "coupon code hit max usage" do
               promotion.update_column(:usage_limit, 1)
               coupon = Coupon.new(order)


### PR DESCRIPTION
Assuming everything that wouldn't activate properly was "already
applied" doesn't work since anything that fails to activate but wasn't
"already applied" shows up to an end-user as "already applied". By
explicitly checking for coupons already applied we can put a more
generic error if activate fails.

(this should probably also be applied to 2-2-stable)
