### PR TITLE
drop credit_cards first_name and last_name fields

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Spree 2.3.0 (unreleased) ##
 
+*   Drop first_name and last_name fields from spree_credit_cards.  Add
+    first_name & last_name methods for now to keep ActiveMerchant happy.
+
+    Jordan Brough
+
 *   Replaced session[:order_id] usage with cookies.signed[:order_id].
 
     Now we are using a signed cookie to store the order id on a guests

--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -106,12 +106,13 @@ module Spree
       gateway_customer_profile_id.present? || gateway_payment_profile_id.present?
     end
 
-    # ActiveMerchant expects an object that responds to #first_name and #last_name.
-    # Even better would be to have spree_gateway always call #to_active_merchant before passing
+    # ActiveMerchant needs first_name/last_name because we pass it a Spree::CreditCard and it calls those methods on it.
+    # Looking at the ActiveMerchant source code we should probably be calling #to_active_merchant before passing
     # the object to ActiveMerchant but this should do for now.
     def first_name
       name.to_s.split(/[[:space:]]/, 2)[0]
     end
+
     def last_name
       name.to_s.split(/[[:space:]]/, 2)[1]
     end

--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -106,14 +106,24 @@ module Spree
       gateway_customer_profile_id.present? || gateway_payment_profile_id.present?
     end
 
+    # ActiveMerchant expects an object that responds to #first_name and #last_name.
+    # Even better would be to have spree_gateway always call #to_active_merchant before passing
+    # the object to ActiveMerchant but this should do for now.
+    def first_name
+      name.to_s.split(/[[:space:]]/, 2)[0]
+    end
+    def last_name
+      name.to_s.split(/[[:space:]]/, 2)[1]
+    end
+
     def to_active_merchant
       ActiveMerchant::Billing::CreditCard.new(
         :number => number,
         :month => month,
         :year => year,
         :verification_value => verification_value,
-        :first_name => first_name || name.to_s.split(/[[:space:]]/, 2)[0],
-        :last_name => last_name || name.to_s.split(/[[:space:]]/, 2)[1]
+        :first_name => first_name,
+        :last_name => last_name,
       )
     end
 

--- a/core/db/migrate/20140604135309_drop_credit_card_first_name_and_last_name.rb
+++ b/core/db/migrate/20140604135309_drop_credit_card_first_name_and_last_name.rb
@@ -1,0 +1,6 @@
+class DropCreditCardFirstNameAndLastName < ActiveRecord::Migration
+  def change
+    remove_column :spree_credit_cards, :first_name, :string
+    remove_column :spree_credit_cards, :last_name, :string
+  end
+end

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -287,13 +287,32 @@ describe Spree::CreditCard do
     end
   end
 
+  context "#first_name" do
+    before do
+      credit_card.name = "Ludwig van Beethoven"
+    end
+
+    it "extracts the first name" do
+      expect(credit_card.first_name).to eq "Ludwig"
+    end
+  end
+
+  context "#last_name" do
+    before do
+      credit_card.name = "Ludwig van Beethoven"
+    end
+
+    it "extracts the last name" do
+      expect(credit_card.last_name).to eq "van Beethoven"
+    end
+  end
+
   context "#to_active_merchant" do
     before do
       credit_card.number = "4111111111111111"
       credit_card.year = Time.now.year
       credit_card.month = Time.now.month
-      credit_card.first_name = "Bob"
-      credit_card.last_name = "Boblaw"
+      credit_card.name = "Ludwig van Beethoven"
       credit_card.verification_value = 123
     end
 
@@ -302,22 +321,9 @@ describe Spree::CreditCard do
       am_card.number.should == "4111111111111111"
       am_card.year.should == Time.now.year
       am_card.month.should == Time.now.month
-      am_card.first_name.should == "Bob"
-      am_card.last_name.should == "Boblaw"
+      am_card.first_name.should == "Ludwig"
+      am_card.last_name.should == "van Beethoven"
       am_card.verification_value.should == 123
-    end
-
-    context "provides name instead of first and last" do
-      before do
-        credit_card.first_name = credit_card.last_name = nil
-        credit_card.name = "Ludwig van Beethoven"
-      end
-
-      it "falls back to split first and last" do
-        am_card = credit_card.to_active_merchant
-        expect(am_card.first_name).to eq "Ludwig"
-        expect(am_card.last_name).to eq "van Beethoven"
-      end
     end
   end
 end


### PR DESCRIPTION
It was intended for this to happen eventually: https://github.com/spree/spree/pull/2807#issuecomment-16345435
It's been causing confusion for us and some others in a couple ways so it seems like a good time to drop them.
