### PR TITLE
Associate a user’s shipping and billing addresses with their order when checking out

### DIFF
--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -29,6 +29,7 @@ module Spree
         authorize! :update, @order, order_token
 
         if @order.update_from_params(params, permitted_checkout_attributes, request.headers.env)
+          persist_user_address(@order) 
           if current_api_user.has_spree_role?('admin') && user_id.present?
             @order.associate_user!(Spree.user_class.find(user_id))
           end

--- a/api/spec/controllers/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/controllers/spree/api/checkouts_controller_spec.rb
@@ -22,6 +22,7 @@ module Spree
     end
 
     context "PUT 'update'" do
+      let(:user) { create(:user) }
       let(:order) do
         order = create(:order_with_line_items)
         # Order should be in a pristine state
@@ -33,6 +34,7 @@ module Spree
       before(:each) do
         Order.any_instance.stub(:confirmation_required? => true)
         Order.any_instance.stub(:payment_required? => true)
+        controller.stub :try_spree_current_user => user
       end
 
       it "should transition a recently created order from cart to address" do
@@ -235,6 +237,19 @@ module Spree
         PromotionHandler::Coupon.should_receive(:new).with(order).and_call_original
         PromotionHandler::Coupon.any_instance.should_receive(:apply).and_return({:coupon_applied? => true})
         api_put :update, :id => order.to_param, :order_token => order.guest_token, :order => { :coupon_code => "foobar" }
+      end
+
+      context "current_user responds to save address method" do
+        it "calls persist order address on user" do
+          expect(user).to receive(:persist_order_address)
+          api_put :update, :id => order.to_param, :order_token => order.token
+        end
+      end
+
+      context "current_user doesn't respond to persist_order_address" do
+        it "doesnt raise an error" do
+          expect{ api_put :update, :id => order.to_param, :order_token => order.token }.to_not raise_error
+        end
       end
     end
 

--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -48,7 +48,8 @@ module Spree
       end
 
       def new
-        @order = Order.create(order_params)
+        user = Spree.user_class.find_by_id(params[:user_id])
+        @order = Spree::Core::Importer::Order.import(user, order_params)
         redirect_to edit_admin_order_url(@order)
       end
 

--- a/backend/app/views/spree/admin/users/_user_page_actions.html.erb
+++ b/backend/app/views/spree/admin/users/_user_page_actions.html.erb
@@ -2,4 +2,7 @@
   <li>
     <%= button_link_to Spree.t(:back_to_users_list), spree.admin_users_path, :icon => 'arrow-left' %>
   </li>
+  <li>
+    <%= button_link_to Spree.t(:create_new_order), spree.new_admin_order_path(user_id: @user.id), :icon => 'plus' %>
+  </li>
 <% end %>

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -62,9 +62,23 @@ describe Spree::Admin::OrdersController do
 
     # Test for #3346
     context "#new" do
-      it "a new order has the current user assigned as a creator" do
+      it "imports a new order and sets the current user as a creator" do
+        Spree::Core::Importer::Order.should_receive(:import)
+          .with(nil, {'created_by_id' => controller.try_spree_current_user.id})
+          .and_return(order)
         spree_get :new
-        assigns[:order].created_by.should == controller.try_spree_current_user
+      end
+
+      context "when a user_id is passed as a parameter" do
+        let(:user)  { mock_model(Spree.user_class) }
+        before { Spree.user_class.stub :find_by_id => user }
+
+        it "imports a new order and assigns the user to the order" do
+          Spree::Core::Importer::Order.should_receive(:import)
+            .with(user, {'created_by_id' => controller.try_spree_current_user.id})
+            .and_return(order)
+          spree_get :new, { user_id: user.id }
+        end
       end
     end
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -247,18 +247,21 @@ module Spree
       @contents ||= Spree::OrderContents.new(self)
     end
 
-    # Associates the specified user with the order.
+    # Associates the specified user and user addresses with the order.
     def associate_user!(user, override_email = true)
       self.user = user
-      attrs_to_set = { user_id: user.id }
-      attrs_to_set[:email] = user.email if override_email
-      attrs_to_set[:created_by_id] = user.id if self.created_by.blank?
-      assign_attributes(attrs_to_set)
+      attrs_to_set = { user_id: user.try(:id) }
+      attrs_to_set[:email] = user.try(:email) if override_email
+      attrs_to_set[:created_by_id] = user.try(:id) if self.created_by.blank?
 
       if persisted?
         # immediately persist the changes we just made, but don't use save since we might have an invalid address associated
         self.class.unscoped.where(id: id).update_all(attrs_to_set)
       end
+
+      attrs_to_set[:ship_address_attributes] = user.ship_address.attributes.except('id', 'updated_at', 'created_at') if user.try(:ship_address)
+      attrs_to_set[:bill_address_attributes] = user.bill_address.attributes.except('id', 'updated_at', 'created_at') if user.try(:bill_address)
+      assign_attributes(attrs_to_set)
     end
 
     # FIXME refactor this method and implement validation using validates_* utilities

--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -66,6 +66,12 @@ module Spree
         def ip_address
           request.remote_ip
         end
+
+        def persist_user_address(order)
+          if order.checkout_steps.include?("address") && try_spree_current_user.respond_to?(:persist_order_address)
+            try_spree_current_user.persist_order_address(order)
+          end
+        end
       end
     end
   end

--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -68,7 +68,7 @@ module Spree
         end
 
         def persist_user_address(order)
-          if order.checkout_steps.include?("address") && try_spree_current_user.respond_to?(:persist_order_address)
+          if order.checkout_steps.include?("address") && @order.address? && try_spree_current_user.respond_to?(:persist_order_address)
             try_spree_current_user.persist_order_address(order)
           end
         end

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -24,10 +24,7 @@ module Spree
               order.state = 'complete'
             end
 
-            user_id = params.delete(:user_id)
-            if user && user.has_spree_role?("admin")
-              order.user_id = user_id
-            end
+            params.delete(:user_id) unless user.try(:has_spree_role?, "admin") && params.key?(:user_id)
 
             order.update_attributes!(params)
             # Really ensure that the order totals are correct

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -12,6 +12,7 @@ module Spree
 
             order = Spree::Order.create!
             order.associate_user!(user)
+            order.save!
 
             create_shipments_from_params(params.delete(:shipments_attributes), order)
             create_line_items_from_params(params.delete(:line_items_attributes),order)
@@ -21,6 +22,11 @@ module Spree
             if(completed_at = params.delete(:completed_at))
               order.completed_at = completed_at
               order.state = 'complete'
+            end
+
+            user_id = params.delete(:user_id)
+            if user && user.has_spree_role?("admin")
+              order.user_id = user_id
             end
 
             order.update_attributes!(params)

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -60,6 +60,49 @@ module Spree
         expect(order.email).to eq params[:email]
       end
 
+      context "assigning a user to an order" do
+        let(:other_user) { stub_model(LegacyUser, :email => 'dana@scully.com') }
+
+        context "as an admin" do
+          before { user.stub :has_spree_role? => true }
+
+          context "a user's id is not provided" do
+            context "nil user id is provided" do
+              it "unassociates the admin user from the order" do
+                params = { user_id: nil }
+                order = Importer::Order.import(user, params)
+                expect(order.user_id).to be_nil
+              end
+            end
+
+            context "another user's id is provided" do
+              it "permits the user to be assigned" do
+                params = { user_id: other_user.id }
+                order = Importer::Order.import(user, params)
+                expect(order.user_id).to eq(other_user.id)
+              end
+            end
+          end
+
+          context "a user's id is not provided" do
+            it "doesn't unassociate the admin from the order" do
+              params = { }
+              order = Importer::Order.import(user, params)
+              expect(order.user_id).to eq(user.id)
+            end
+          end
+        end
+
+        context "as a user" do
+          before { user.stub :has_spree_role? => false }
+          it "does not assign the order to the other user" do
+            params = { user_id: other_user.id }
+            order = Importer::Order.import(user, params)
+            expect(order.user_id).to eq(user.id)
+          end
+        end
+      end
+
       it 'can build an order from API with just line items' do
         params = { :line_items_attributes => line_items }
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -534,6 +534,21 @@ describe Spree::Order do
         order.associate_user!(user)
       end.not_to change { address.persisted? }.from(false)
     end
+
+    it "should duplicate a user's ship and bill addresses and associate them with a persisted order" do
+      order = FactoryGirl.create(:order_with_line_items, ship_address: nil, bill_address: nil)
+      ship_address = FactoryGirl.create(:address)
+      bill_address = FactoryGirl.create(:address)
+      user = FactoryGirl.create(:user, ship_address: ship_address, bill_address: bill_address)
+
+      order.associate_user!(user)
+      order.ship_address.attributes.except('id', 'updated_at', 'created_at').should == ship_address.attributes.except('id', 'updated_at', 'created_at')
+      order.bill_address.attributes.except('id', 'updated_at', 'created_at').should == bill_address.attributes.except('id', 'updated_at', 'created_at')
+
+      # verify we generated new address models
+      order.ship_address_id.should_not == ship_address.id
+      order.bill_address_id.should_not == bill_address.id
+    end
   end
 
   context "#can_ship?" do

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -26,7 +26,7 @@ module Spree
     # Updates the order and advances to the next state (when possible.)
     def update
       if @order.update_from_params(params, permitted_checkout_attributes, request.headers.env)
-        persist_user_address
+        persist_user_address(@order) if params[:save_user_address]
         unless @order.next
           flash[:error] = @order.errors.full_messages.join("\n")
           redirect_to checkout_state_path(@order.state) and return
@@ -145,14 +145,6 @@ module Spree
 
       def check_authorization
         authorize!(:edit, current_order, cookies.signed[:guest_token])
-      end
-
-      def persist_user_address
-        if @order.checkout_steps.include? "address"
-          if @order.address? && try_spree_current_user.respond_to?(:persist_order_address)
-            try_spree_current_user.persist_order_address(@order) if params[:save_user_address]
-          end
-        end
       end
   end
 end


### PR DESCRIPTION
This pull request allows persisting user addresses from an order in both frontend and api.  The persist_user_address method previously in frontend was moved to a core controller helper so that we can leverage this same functionality from the api.  In addition, we enable auto-applying a user's shipping and billing addresses to a new order through the api to prevent users from having to re-enter this information every time they checkout.
