### PR TITLE
check_authorization should use params token first

### DIFF
--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -74,7 +74,7 @@ module Spree
     end
 
     def check_authorization
-      session[:access_token] ||= params[:token]
+      session[:access_token] = params[:token] if params[:token]
       order = Spree::Order.find_by_number(params[:id]) || current_order
 
       if order


### PR DESCRIPTION
in check_authorization method.
The original code is:
session[:access_token] ||= params[:token]

So once session[:access_token] has been set, I can't reset it unless I close my browser to invalidate session.

The example scenario is below. 

If I had a order url with token "http://www.example.com/orders/R176458284/token/383caf1a6dd71df4"
However, I incorrectly copy and paste it to browser and open it:
"http://www.example.com/orders/R176458284/token/383caf1a6dd71"
Now I got a unauthorized 401 page, that's correct because my token is wrong.
But after that, I try the correct link again and it still won't work since session[:access_token] has already been set and won't be set again even I pass a new params[:token]

I believe the correct logic is to check params[:token] first, once params[:token] is available, session[:access_token] should always be overridden by params[:token].

Thanks.
