### PR TITLE
Never allow multiple promos per order

### DIFF
--- a/core/app/models/spree/item_adjustments.rb
+++ b/core/app/models/spree/item_adjustments.rb
@@ -1,11 +1,11 @@
 module Spree
-  # Manage (recalculate) item (LineItem or Shipment) adjustments
+  # Manage (recalculate) adjustments on LineItem, Shipment and Order
   class ItemAdjustments
     include ActiveSupport::Callbacks
     define_callbacks :promo_adjustments, :tax_adjustments
     attr_reader :item
 
-    delegate :adjustments, :order, to: :item
+    delegate :adjustments, to: :item
 
     def initialize(item)
       @item = item
@@ -72,6 +72,9 @@ module Spree
 
     def best_promotion_adjustment
       @best_promotion_adjustment ||= adjustments.promotion.eligible.reorder("amount ASC, created_at DESC").first
+
+    def order
+      item.is_a?(Spree::Order) ? item : item.order
     end
   end
 end

--- a/core/app/models/spree/item_adjustments.rb
+++ b/core/app/models/spree/item_adjustments.rb
@@ -64,14 +64,23 @@ module Spree
     # This promotion provides the most discount, and if two promotions
     # have the same amount, then it will pick the latest one.
     def choose_best_promotion_adjustment
-      if best_promotion_adjustment
-        other_promotions = self.adjustments.promotion.where("id NOT IN (?)", best_promotion_adjustment.id)
+      if best_adjustments = best_promotion_adjustments_for_order
+        Adjustment.where(:id => best_adjustments.map(&:id)).update_all(:eligible => true)
+        other_promotions = order.all_adjustments.promotion.where("id NOT IN (?)", best_adjustments.map(&:id))
         other_promotions.update_all(:eligible => false)
       end
     end
 
+    def best_promotion_adjustments_for_order
+      promotion_adjustments = order.all_adjustments.eligible.includes(source: :promotion).promotion
+      return [] unless promotion_adjustments.present?
+      promotion_adjustments.group_by { |a| a.source.promotion }.min_by { |p, a| [a.map(&:amount).sum, -1 * p.updated_at.to_i] }.last
+    end
+    private :best_promotion_adjustments_for_order
+
     def best_promotion_adjustment
-      @best_promotion_adjustment ||= adjustments.promotion.eligible.reorder("amount ASC, created_at DESC").first
+      best_promotion_adjustments_for_order.find { |a| a.adjustable == item }
+    end
 
     def order
       item.is_a?(Spree::Order) ? item : item.order

--- a/core/spec/models/spree/item_adjustments_spec.rb
+++ b/core/spec/models/spree/item_adjustments_spec.rb
@@ -38,7 +38,7 @@ module Spree
         line_item.price = 20
         line_item.tax_category = tax_rate.tax_category
         line_item.save
-        create(:adjustment, :source => promotion_action, :adjustable => line_item)
+        create(:adjustment, :source => promotion_action, :adjustable => line_item, :order => order)
       end
 
       context "tax included in price" do
@@ -46,7 +46,8 @@ module Spree
           create(:adjustment, 
             :source => tax_rate,
             :adjustable => line_item,
-            :included => true
+            :included => true,
+            :order => order
           )
         end
 
@@ -85,12 +86,17 @@ module Spree
     context "best promotion is always applied" do
       let(:calculator) { Calculator::FlatRate.new(:preferred_amount => 10) }
 
-      let(:source) { Promotion::Actions::CreateItemAdjustments.create calculator: calculator }
+      def source
+        Promotion::Actions::CreateItemAdjustments.create(
+          calculator: calculator,
+          promotion: Promotion.create!(name: 'test promotion')
+        )
+      end
 
-      def create_adjustment(label, amount)
+      def create_adjustment(label, amount, options = {})
         create(:adjustment, :order      => order,
-                            :adjustable => line_item,
-                            :source     => source,
+                            :adjustable => options[:adjustable] || line_item,
+                            :source     => options[:source] || source,
                             :amount     => amount,
                             :state      => "closed",
                             :label      => label,
@@ -115,6 +121,59 @@ module Spree
         line_item.adjustments.promotion.eligible.first.label.should == 'Promotion C'
       end
 
+      context "comparing order and line item level adjustments" do
+        let(:order)               { create :order_with_line_items, line_items_count: 2 }
+        let(:line_item_1)         { order.line_items.first }
+        let(:line_item_2)         { order.line_items.last }
+        let(:order_promotion)     { Promotion.create! name: "Order promotion" }
+        let(:line_item_promotion) { Promotion.create! name: "Line item promotion" }
+        let(:order_source)        { Promotion::Actions::CreateAdjustment.create! calculator: calculator, promotion: order_promotion }
+        let(:line_item_source)    { Promotion::Actions::CreateAdjustment.create! calculator: calculator, promotion: line_item_promotion }
+        let!(:order_adjustment)   { create_adjustment("Order Promotion", order_discount, adjustable: order, source: order_source) }
+        let!(:item_adjustment_1)  { create_adjustment("Item Promotion 1", item_1_discount, adjustable: line_item_1, source: line_item_source) }
+        let!(:item_adjustment_2)  { create_adjustment("Item Promotion 2", item_2_discount, adjustable: line_item_2, source: line_item_source) }
+        before                    { Spree::Adjustment.update_all(eligible: true) }
+
+        context "the order level adjustment is greater than all of the line item adjustments for the same promotion put together" do
+          let(:order_discount)  { -100 }
+          let(:item_1_discount) { -30 }
+          let(:item_2_discount) { -40 }
+
+          it "chooses the order level adjustment" do
+            subject.choose_best_promotion_adjustment
+            expect(order_adjustment.reload).to be_eligible
+            expect(item_adjustment_1.reload).not_to be_eligible
+            expect(item_adjustment_2.reload).not_to be_eligible
+          end
+        end
+
+        context "the order level adjustment is less than all of the line item adjustments for the same promotion put together" do
+          let(:order_discount)  { -50 }
+          let(:item_1_discount) { -30 }
+          let(:item_2_discount) { -40 }
+
+          it "chooses all the line item level adjustments" do
+            subject.choose_best_promotion_adjustment
+            expect(order_adjustment.reload).not_to be_eligible
+            expect(item_adjustment_1.reload).to be_eligible
+            expect(item_adjustment_2.reload).to be_eligible
+          end
+        end
+
+        context "the order level adjustment is the same as all of the line item adjustments for the same promotion put together" do
+          let(:order_discount)  { -50 }
+          let(:item_1_discount) { -10 }
+          let(:item_2_discount) { -40 }
+
+          it "chooses just the order level adjustment" do
+            subject.choose_best_promotion_adjustment
+            expect(order_adjustment.reload).to be_eligible
+            expect(item_adjustment_1.reload).not_to be_eligible
+            expect(item_adjustment_2.reload).not_to be_eligible
+          end
+        end
+      end
+
       context "multiple adjustments and the best one is not eligible" do
         let!(:promo_a) { create_adjustment("Promotion A", -100) }
         let!(:promo_c) { create_adjustment("Promotion C", -300) }
@@ -127,7 +186,7 @@ module Spree
         # regression for #3274
         it "still makes the previous best eligible adjustment valid" do
           subject.choose_best_promotion_adjustment
-          line_item.adjustments.promotion.first.label.should == 'Promotion A'
+          line_item.adjustments.promotion.eligible.first.label.should == 'Promotion A'
         end
       end
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -659,7 +659,10 @@ describe Spree::Order do
   end
 
   context "ensure shipments will be updated" do
-    before { Spree::Shipment.create!(order: order) }
+    before do
+      Spree::Shipment.any_instance.stub(:order => order)
+      Spree::Shipment.create!(order: order)
+    end
 
     it "destroys current shipments" do
       order.ensure_updated_shipments

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -659,8 +659,9 @@ describe Spree::Order do
   end
 
   context "ensure shipments will be updated" do
+    let(:order) { Spree::Order.create }
+
     before do
-      Spree::Shipment.any_instance.stub(:order => order)
       Spree::Shipment.create!(order: order)
     end
 

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -2,11 +2,15 @@ require 'spec_helper'
 require 'benchmark'
 
 describe Spree::Shipment do
-  let(:order) { mock_model Spree::Order, backordered?: false,
-                                         canceled?: false,
-                                         can_ship?: true,
-                                         currency: 'USD',
-                                         touch: true }
+  let(:order) do
+    order = mock_model Spree::Order,  backordered?: false,
+                              canceled?: false,
+                              can_ship?: true,
+                              currency: 'USD',
+                              touch: true
+    order.stub(:all_adjustments => Spree::Adjustment.none)
+    order
+  end
   let(:shipping_method) { create(:shipping_method, name: "UPS") }
   let(:shipment) do
     shipment = Spree::Shipment.new

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -3,12 +3,12 @@ require 'benchmark'
 
 describe Spree::Shipment do
   let(:order) do
-    order = mock_model Spree::Order,  backordered?: false,
-                              canceled?: false,
-                              can_ship?: true,
-                              currency: 'USD',
-                              touch: true
-    order.stub(:all_adjustments => Spree::Adjustment.none)
+    order = mock_model Spree::Order, backordered?: false,
+                                     canceled?: false,
+                                     can_ship?: true,
+                                     currency: 'USD',
+                                     touch: true,
+                                     all_adjustments: Spree::Adjustment.none
     order
   end
   let(:shipping_method) { create(:shipping_method, name: "UPS") }


### PR DESCRIPTION
This is split out from #4775. It ensures that no order can ever have more than one promotion. It is my understanding that this is not desired behavior in Spree 2.2. I thus do not expect this pull request to be merged, but I wanted to present it for completeness and to give people an opportunity to cherry-pick these commits to their forks if they want this kind of behavior.
