### PR TITLE
Implemented fix for variant search on stock transfer page

### DIFF
--- a/backend/app/views/spree/admin/stock_transfers/new.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/new.html.erb
@@ -64,7 +64,7 @@
       <div class="alpha eight columns">
         <div class="field" id="stock_movement_variant_id_field">
           <%= label_tag 'variant_id', Spree.t(:variant) %>
-          <%= select_tag 'transfer_variant', {}, class: 'fullwidth' %>
+          <%= hidden_field_tag 'transfer_variant', {}, class: 'fullwidth' %>
         </div>
       </div>
       <div class="two columns">

--- a/backend/spec/features/admin/stock_transfer_spec.rb
+++ b/backend/spec/features/admin/stock_transfer_spec.rb
@@ -6,10 +6,13 @@ describe 'Stock Transfers', :js => true do
   it 'transfer between 2 locations' do
     source_location = create(:stock_location_with_items, :name => 'NY')
     destination_location = create(:stock_location, :name => 'SF')
+    variant = Spree::Variant.last
 
     visit spree.new_admin_stock_transfer_path
 
     fill_in 'reference', :with => 'PO 666'
+
+    select2_search variant.name, :from => 'Variant'
 
     click_button 'Add'
     click_button 'Transfer Stock'
@@ -17,6 +20,7 @@ describe 'Stock Transfers', :js => true do
     page.should have_content('STOCK TRANSFER REFERENCE PO 666')
     page.should have_content('NY')
     page.should have_content('SF')
+    page.should have_content(variant.name)
 
     transfer = Spree::StockTransfer.last
     transfer.should have(2).stock_movements
@@ -36,12 +40,14 @@ describe 'Stock Transfers', :js => true do
     it 'receive stock to a single location' do
       source_location = create(:stock_location_with_items, :name => 'NY')
       destination_location = create(:stock_location, :name => 'SF')
+      variant = Spree::Variant.last
 
       visit spree.new_admin_stock_transfer_path
 
       fill_in 'reference', :with => 'PO 666'
       check 'transfer_receive_stock'
       select('NY', :from => 'transfer_destination_location_id')
+      select2_search variant.name, :from => 'Variant'
 
       click_button 'Add'
       click_button 'Transfer Stock'
@@ -51,12 +57,14 @@ describe 'Stock Transfers', :js => true do
 
     it 'forced to only receive there is only one location' do
       source_location = create(:stock_location_with_items, :name => 'NY')
+      variant = Spree::Variant.last
 
       visit spree.new_admin_stock_transfer_path
 
       fill_in 'reference', :with => 'PO 666'
 
       select('NY', :from => 'transfer_destination_location_id')
+      select2_search variant.name, :from => 'Variant'
 
       click_button 'Add'
       click_button 'Transfer Stock'


### PR DESCRIPTION
Fixes the issue described at https://github.com/spree/spree/issues/4786.

Basically, allows the user the search for a variant rather than select from a pre-populated list when creating a stock transfer. This ensures that the user is always able to choose from all variants.
