### PR TITLE
Fix failing api spec

### DIFF
--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -514,7 +514,7 @@ module Spree
 
           orders = json_response[:orders]
           expect(orders.count).to be >= 3
-          expect(orders.map { |o| o[:id] }).to eq Order.pluck(:id)
+          expect(orders.map { |o| o[:id] }).to match_array Order.pluck(:id)
         end
 
         after { ActionController::Base.perform_caching = false }


### PR DESCRIPTION
ids aren't guaranteed to be returned in the same order, so change eq to match_array.
