### PR TITLE
Ensure shipments are also destroyed when the order is emptied.

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -439,8 +439,9 @@ module Spree
     def empty!
       line_items.destroy_all
       updater.update_item_count
-
       adjustments.destroy_all
+      shipments.destroy_all
+
       update_totals
       persist_totals
     end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -53,7 +53,7 @@ describe Spree::Order do
       credit_card_payment_method = create(:credit_card_payment_method)
       attributes = {
         :payments_attributes => [
-          { 
+          {
             :payment_method_id => credit_card_payment_method.id,
             :source_attributes => {
               :name => "Ryan Bigg",
@@ -284,7 +284,7 @@ describe Spree::Order do
       end
 
       context "and order is approved" do
-        before do 
+        before do
           order.stub :approved? => true
         end
 
@@ -437,7 +437,7 @@ describe Spree::Order do
 
   context "empty!" do
     let(:order) { stub_model(Spree::Order, item_count: 2) }
-    
+
     before do
       order.stub(:line_items => line_items = [1, 2])
       order.stub(:adjustments => adjustments = [])
@@ -446,6 +446,7 @@ describe Spree::Order do
     it "clears out line items, adjustments and update totals" do
       expect(order.line_items).to receive(:destroy_all)
       expect(order.adjustments).to receive(:destroy_all)
+      expect(order.shipments).to receive(:destroy_all)
       expect(order.updater).to receive(:update_totals)
       expect(order.updater).to receive(:persist_totals)
 


### PR DESCRIPTION
There is an issue when attempting to clear a cart at later states in the checkout process.

Specifically, taking a cart to the confirm step (or any step where shipments are created) and emptying your cart will make the order unviewable in the admin interface.

This is because the shipments aren't destroyed when the order is reset. Welcome any feedback.
