### PR TITLE
Loosened the version required for select2-rails.

### DIFF
--- a/backend/spree_backend.gemspec
+++ b/backend/spree_backend.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'jquery-rails', '~> 3.1.0'
   s.add_dependency 'jquery-ui-rails', '~> 4.1.0'
-  s.add_dependency 'select2-rails', '~> 3'
+  s.add_dependency 'select2-rails', '~> 3.5.0'
 
   s.add_development_dependency 'email_spec', '~> 1.2.1'
 end

--- a/backend/spree_backend.gemspec
+++ b/backend/spree_backend.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'jquery-rails', '~> 3.1.0'
   s.add_dependency 'jquery-ui-rails', '~> 4.1.0'
-  s.add_dependency 'select2-rails', '~> 3.4.7'
+  s.add_dependency 'select2-rails', '~> 3'
 
   s.add_development_dependency 'email_spec', '~> 1.2.1'
 end


### PR DESCRIPTION
I was unable to install spree edge because of a dependency conflict between versions of sprockets. This fix allows for a later version of select2-rails to be used that is not dependent on sass-rails, which is what is dependent on sprockets.

``` shell
Bundler could not find compatible versions for gem "sprockets":
  In Gemfile:
    spree (>= 0) ruby depends on
      spree_backend (= 2.3.0.beta) ruby depends on
        select2-rails (~> 3.4.7) ruby depends on
          sass-rails (>= 0) ruby depends on
            sprockets (~> 2.0.0) ruby

    spree (>= 0) ruby depends on
      spree_core (= 2.3.0.beta) ruby depends on
        rails (~> 4.1.0) ruby depends on
          sprockets-rails (~> 2.0) ruby depends on
            sprockets (2.12.1)

Bundler could not find compatible versions for gem "sprockets-rails":
  In Gemfile:
    spree (>= 0) ruby depends on
      spree_backend (= 2.3.0.beta) ruby depends on
        select2-rails (~> 3.4.7) ruby depends on
          sass-rails (>= 0) ruby depends on
            sprockets-rails (~> 2.0.0) ruby

    spree (>= 0) ruby depends on
      spree_core (= 2.3.0.beta) ruby depends on
        rails (~> 4.1.0) ruby depends on
          sprockets-rails (2.1.3)

Bundler could not find compatible versions for gem "railties":
  In Gemfile:
    spree (>= 0) ruby depends on
      spree_backend (= 2.3.0.beta) ruby depends on
        select2-rails (~> 3.4.7) ruby depends on
          sass-rails (>= 0) ruby depends on
            railties (~> 3.1.0) ruby

    spree (>= 0) ruby depends on
      spree_core (= 2.3.0.beta) ruby depends on
        rails (~> 4.1.0) ruby depends on
          railties (4.1.0)
```
