### PR TITLE
Product Slug improvements

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -21,7 +21,7 @@
 module Spree
   class Product < ActiveRecord::Base
     extend FriendlyId
-    friendly_id :name, use: :slugged
+    friendly_id :slug_candidates, use: :slugged
 
     acts_as_paranoid
     has_many :product_option_types, dependent: :destroy, inverse_of: :product
@@ -77,8 +77,11 @@ module Spree
     validates :price, presence: true, if: proc { Spree::Config[:require_master_price] }
     validates :shipping_category_id, presence: true
     validates :slug, length: { minimum: 3 }
+    validates :slug, uniqueness: true
 
     before_validation :normalize_slug, on: :update
+
+    after_destroy :punch_slug
 
     attr_accessor :option_values_hash
 
@@ -213,6 +216,7 @@ module Spree
     end
 
     private
+
       def normalize_slug
         self.slug = normalize_friendly_id(slug)
       end
@@ -265,6 +269,19 @@ module Spree
         taxonomy_ids_to_touch = taxons_to_touch.map(&:taxonomy_id).flatten.uniq
         Spree::Taxonomy.where(id: taxonomy_ids_to_touch).update_all(updated_at: Time.current)
       end
+
+      # Try building a slug based on the following fields in increasing order of specificity.
+      def slug_candidates
+        [
+            :name,
+            [:name, :sku]
+        ]
+      end
+
+      def punch_slug
+        update(slug: "#{Time.now.to_i}_#{slug}") # punch slug with date prefix to allow reuse of original
+      end
+
   end
 end
 

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -10,6 +10,7 @@ module ThirdParty
 end
 
 describe Spree::Product do
+
   context 'product instance' do
     let(:product) { create(:product) }
     let(:variant) { create(:variant, :product => product) }
@@ -225,6 +226,45 @@ describe Spree::Product do
         product.stock_items.first.should_not be_nil
       end
     end
+
+    context "slugs" do
+
+      it "normalizes slug on update validation" do
+        product.slug = "hey//joe"
+        product.valid?
+        expect(product.slug).not_to match "/"
+      end
+
+      it "renames slug on destroy" do
+        old_slug = product.slug
+        product.destroy
+        expect(old_slug).to_not eq product.slug
+      end
+
+      it "validates slug uniqueness" do
+        existing_product = product
+        new_product = create(:product)
+        new_product.slug = existing_product.slug
+
+        expect(new_product.valid?).to eq false
+      end
+
+      it "falls back to 'name-sku' for slug if regular name-based slug already in use" do
+        product1 = build(:product)
+        product1.name = "test"
+        product1.sku = "123"
+        product1.save!
+
+        product2 = build(:product)
+        product2.name = "test"
+        product2.sku = "456"
+        product2.save!
+
+        expect(product2.slug).to eq 'test-456'
+      end
+
+    end
+
   end
 
   context "properties" do
@@ -388,7 +428,7 @@ describe Spree::Product do
     end
   end
 
-  describe '#total_on_hand' do
+  context '#total_on_hand' do
     it 'should be infinite if track_inventory_levels is false' do
       Spree::Config[:track_inventory_levels] = false
       build(:product, :variants_including_master => [build(:master_variant)]).total_on_hand.should eql(Float::INFINITY)
@@ -406,13 +446,4 @@ describe Spree::Product do
     end
   end
 
-  describe "slugs" do
-    it "normalizes slug on update" do
-      product = stub_model Spree::Product
-      product.slug = "hey//joe"
-
-      product.valid?
-      expect(product.slug).not_to match "/"
-    end
-  end
 end


### PR DESCRIPTION
This PR modifies 3 behaviors of the product slug field:
1. Added unique validation on the slug field. A unique index already exists on this database field, so there is no reason not to have a unique valudation on the model as well
2. Modified slug generation to have a fallback, instead of relying solely on product name. See slug_candidates. This will attempt to use name-sku if name is already in use.
3. Restored "punch" functionality on product destroy. This will prepend a timestamp before the slug when a product is deleted, effectively releasing the "permalink" value for use by another product. This isn't strictly necessary, as Spree allows you to search deleted products in the admin and manually rename the value. However, it seems prudent to free up the permalink value when product is deleted. In terms of SEO, it's preferable to use the name-based value and not have a guid appended. Second point above should help with this, but I see no beneficial reason to retain slug value for a deleted product.

Also did some minor cleanup of the spec file while I was in there adding specs. 
