### PR TITLE
Add deletion protection for promotion actions

### DIFF
--- a/core/app/models/spree/promotion_action.rb
+++ b/core/app/models/spree/promotion_action.rb
@@ -2,6 +2,8 @@
 # PromotionActions perform the necessary tasks when a promotion is activated by an event and determined to be eligible.
 module Spree
   class PromotionAction < Spree::Base
+    acts_as_paranoid
+
     belongs_to :promotion, class_name: 'Spree::Promotion'
 
     scope :of_type, ->(t) { where(type: t) }

--- a/core/db/migrate/20140609201656_add_deleted_at_to_spree_promotion_actions.rb
+++ b/core/db/migrate/20140609201656_add_deleted_at_to_spree_promotion_actions.rb
@@ -1,0 +1,6 @@
+class AddDeletedAtToSpreePromotionActions < ActiveRecord::Migration
+  def change
+    add_column :spree_promotion_actions, :deleted_at, :datetime
+    add_index :spree_promotion_actions, :deleted_at
+  end
+end


### PR DESCRIPTION
When promotion actions get destroyed, all of their completed adjustments
then have a reference to a non-existent source, which causes data issues
when trying to understand what promotion an adjustment was for.

Since promotion actions get destroyed when a promotion changes how it is
applied, which can happen somewhat frequently, adding a paranoia around
it will allow a paper trail back to the original promotion.
