### PR TITLE
WIP Line item calculations of order adjustments

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -27,7 +27,6 @@ module Spree
 
     after_save :update_inventory
     after_save :update_adjustments
-    after_save :recalculate_external_adjustment_total
 
     after_create :update_tax_charge
 
@@ -62,6 +61,10 @@ module Spree
     # https://github.com/spree/spree/blob/6ac5b6d0106405b88f66310c7a7cc4e7149e3543/core/app/models/spree/tax_rate.rb#L58
     def pre_tax_amount
       read_attribute(:pre_tax_amount) || (discounted_amount - included_tax_total)
+    end
+
+    def total_taxes
+      additional_tax_total + included_tax_total
     end
 
     def final_amount
@@ -113,17 +116,6 @@ module Spree
         if quantity_changed?
           update_tax_charge # Called to ensure pre_tax_amount is updated. 
           recalculate_adjustments
-        end
-      end
-
-      def pre_tax_percentage_of_order
-        return 0.0 if order.pre_tax_item_amount.zero?
-        pre_tax_amount / order.pre_tax_item_amount
-      end
-
-      def recalculate_external_adjustment_total
-        unless pre_tax_percentage_of_order.zero?
-          update_columns(external_adjustment_total: (order.adjustment_total * pre_tax_percentage_of_order).round(2))
         end
       end
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -124,6 +124,11 @@ module Spree
       line_items.inject(0.0) { |sum, li| sum + li.amount }
     end
 
+    # Sum of all line item amounts pre-tax
+    def pre_tax_item_amount
+      line_items.inject(0.0) { |sum, li| sum + li.pre_tax_amount }
+    end
+
     def currency
       self[:currency] || Spree::Config[:currency]
     end

--- a/core/app/models/spree/returns/line_item_return.rb
+++ b/core/app/models/spree/returns/line_item_return.rb
@@ -1,0 +1,47 @@
+module Spree
+  module Returns
+    class LineItemReturn
+      attr_reader :line_item, :quantity
+      delegate :order, to: :line_item
+
+      def initialize(line_item, quantity)
+        line_item.is_a?(Spree::LineItem) ? @line_item = line_item : raise("Line Item Required")
+        quantity.is_a?(Integer) ? @quantity = quantity : raise("Quantity Required")
+      end
+
+      # TODO a method that actually executes the return of a line item
+      # verify that amount_to_return for non-returned line items doesn't change
+      # def return
+      #   # choose and do correct type of refund, store with association to line item
+      #   line_item.update_attributes(returned_amount: amount_to_return)
+      # end
+
+      def amount_to_return
+        (amount_of_order_adjustment + pre_tax_amount + tax_amount).round(2)
+      end
+
+      private
+
+      def pre_tax_amount
+        line_item.pre_tax_amount * percentage_of_line_item
+      end
+
+      def tax_amount
+        line_item.total_taxes * percentage_of_line_item
+      end
+
+      def amount_of_order_adjustment
+        order.adjustment_total * percentage_of_order
+      end
+
+      def percentage_of_order
+        return 0.0 if order.pre_tax_item_amount.zero?
+        pre_tax_amount / order.pre_tax_item_amount
+      end
+
+      def percentage_of_line_item
+        BigDecimal.new(quantity) / BigDecimal.new(line_item.quantity)
+      end
+    end
+  end
+end

--- a/core/db/migrate/20140609213940_add_external_adjustment_total_to_spree_line_items.rb
+++ b/core/db/migrate/20140609213940_add_external_adjustment_total_to_spree_line_items.rb
@@ -1,5 +1,0 @@
-class AddExternalAdjustmentTotalToSpreeLineItems < ActiveRecord::Migration
-  def change
-    add_column :spree_line_items, :external_adjustment_total, :decimal, precision: 10, scale: 2, null: false, default: 0.0
-  end
-end

--- a/core/db/migrate/20140609213940_add_external_adjustment_total_to_spree_line_items.rb
+++ b/core/db/migrate/20140609213940_add_external_adjustment_total_to_spree_line_items.rb
@@ -1,0 +1,5 @@
+class AddExternalAdjustmentTotalToSpreeLineItems < ActiveRecord::Migration
+  def change
+    add_column :spree_line_items, :external_adjustment_total, :decimal, precision: 10, scale: 2, null: false, default: 0.0
+  end
+end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -624,4 +624,15 @@ describe Spree::Order do
       order.tax_total.should eq 30
     end
   end
+
+  describe "#pre_tax_item_amount" do
+    it "sums all of the line items' pre tax amounts" do
+      subject.line_items = [
+        Spree::LineItem.new(price: 10, quantity: 2, included_tax_total: 2, additional_tax_total: 8, promo_total: -5),
+        Spree::LineItem.new(price: 30, quantity: 1, included_tax_total: 4, additional_tax_total: 10, promo_total: -20),
+      ]
+
+      expect(subject.pre_tax_item_amount).to eq 19.0
+    end
+  end
 end

--- a/core/spec/models/spree/returns/line_item_return_spec.rb
+++ b/core/spec/models/spree/returns/line_item_return_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+module Spree
+  module Returns
+    describe LineItemReturn do
+      let(:order)     { Order.new }
+      let(:line_item) { LineItem.new(price: 100.0, quantity: 2) }
+      let(:quantity)  { 1 }
+
+      before { order.line_items << line_item }
+      subject { LineItemReturn.new(line_item, quantity) }
+
+      describe "#initialize" do
+        it "requires a valid line_item" do
+          expect { LineItemReturn.new(Object.new, 1) }.to raise_error "Line Item Required"
+          expect { LineItemReturn.new(build(:line_item), 1) }.not_to raise_error
+        end
+
+        it "requires a valid quantity" do
+          expect { LineItemReturn.new(build(:line_item), "foo") }.to raise_error "Quantity Required"
+          expect { LineItemReturn.new(build(:line_item), 1) }.not_to raise_error
+        end
+      end
+
+      describe "#amount_to_return" do
+
+        context "no promotions or taxes" do
+          its(:amount_to_return) { should eq line_item.price }
+        end
+
+        context "line item promotions" do
+          before { line_item.promo_total = -20.0 }
+          its(:amount_to_return) { should eq line_item.price - 10 }
+        end
+
+        context "included taxes" do
+          before { line_item.included_tax_total = 20.0 }
+          # TODO i dont think this is right, but don't have a full understanding of included vs additional tax
+          its(:amount_to_return) { should eq line_item.price }
+        end
+
+        context "additional taxes" do
+          before { line_item.additional_tax_total = 20.0 }
+          # TODO i dont think this is right, but don't have a full understanding of included vs additional tax
+          its(:amount_to_return) { should eq line_item.price + 10 }
+        end
+
+        context "order adjustments" do
+          before do
+            order.adjustment_total = -30
+            order.line_items << LineItem.new(price: 100.0, quantity: 1)
+          end
+          its(:amount_to_return) { should eq line_item.price - 10 }
+        end
+
+        context "shipping adjustments" do
+          before { order.shipments << Shipment.new(adjustment_total: -50) }
+          its(:amount_to_return) { should eq line_item.price }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
If we know at order time how much of the order adjustments are
applicable to a line item, then:
- when a refund of a single line item for an order is made, then we can accurately calculate the amount due to the customer.
- we can do proper accounting for those line items
