### PR TITLE
Adding data-hooks to search results header

### DIFF
--- a/frontend/app/views/spree/shared/_products.html.erb
+++ b/frontend/app/views/spree/shared/_products.html.erb
@@ -9,11 +9,17 @@
   <% end %>
 <% end %>
 
-<% if products.empty? %>
-  <%= Spree.t(:no_products_found) %>
-<% elsif params.key?(:keywords) %>
-  <h6 class="search-results-title"><%= Spree.t(:search_results, :keywords => h(params[:keywords])) %></h6>
-<% end %>
+<div data-hook="products_search_results_heading">
+  <% if products.empty? %>
+    <div data-hook="products_search_results_heading_no_results_found">
+      <%= Spree.t(:no_products_found) %>
+    </div>
+  <% elsif params.key?(:keywords) %>
+    <div data-hook="products_search_results_heading_results_found">
+      <h6 class="search-results-title"><%= Spree.t(:search_results, :keywords => h(params[:keywords])) %></h6>
+    </div>
+  <% end %>
+</div>
 
 <% if products.any? %>
 <ul id="products" class="inline product-listing" data-hook>


### PR DESCRIPTION
Our app modifies the look of the page when no results are found, and in order to do that we have to override this entire partial. I'm thinking that adding some data-hooks might make it easier for folks like us to modify just a part of the partial if needed.
