### PR TITLE
Improving performance of migration add_line_item_id_to_spree_inventory_u...

### DIFF
--- a/core/db/migrate/20131118183431_add_line_item_id_to_spree_inventory_units.rb
+++ b/core/db/migrate/20131118183431_add_line_item_id_to_spree_inventory_units.rb
@@ -5,9 +5,7 @@ class AddLineItemIdToSpreeInventoryUnits < ActiveRecord::Migration
       add_column :spree_inventory_units, :line_item_id, :integer
       add_index :spree_inventory_units, :line_item_id
 
-      shipments = Spree::Shipment.includes(:inventory_units, :order)
-
-      shipments.find_each do |shipment|
+      Spree::Shipment.includes(:inventory_units, :order).find_each do |shipment|
         shipment.inventory_units.group_by(&:variant).each do |variant, units|
 
           line_item = shipment.order.find_line_item_by_variant(variant)


### PR DESCRIPTION
...nits

I noticed when I ran these commands on the console that the line

```
shipments = Spree::Shipment.includes(:inventory_units, :order)
```

would load a tremendous amount of stuff from the database, negating the performance savings by the `find_each` method. This may even be a Rails bug. Putting the `includes` and the `find_each` into the same line fixed performance issues immediately.
