### PR TITLE
Make migration more tolerant of deleted Variants

### DIFF
--- a/core/db/migrate/20131118183431_add_line_item_id_to_spree_inventory_units.rb
+++ b/core/db/migrate/20131118183431_add_line_item_id_to_spree_inventory_units.rb
@@ -8,9 +8,9 @@ class AddLineItemIdToSpreeInventoryUnits < ActiveRecord::Migration
       shipments = Spree::Shipment.includes(:inventory_units, :order)
 
       shipments.find_each do |shipment|
-        shipment.inventory_units.group_by(&:variant).each do |variant, units|
+        shipment.inventory_units.group_by(&:variant_id).each do |variant, units|
 
-          line_item = shipment.order.find_line_item_by_variant(variant)
+          line_item = shipment.order.line_items.find_by(variant_id: variant_id)
           next unless line_item
 
           Spree::InventoryUnit.where(id: units.map(&:id)).update_all(line_item_id: line_item.id)


### PR DESCRIPTION
This migration bailed for me when it found an old order (before Spree used `acts_as_paranoid`) with a line_item referencing a Variant that no longer existed.

Making the migration use `variant_id` instead of `variant.id` fixed this problem for me, and I suspect will make the migration path smoother for other people who have been using Spree since before the `paranoia` gem.
