### PR TITLE
Spree::Zone#country_list fix

### DIFF
--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -61,7 +61,7 @@ module Spree
       @countries ||= case kind
                      when 'country' then zoneables
                      when 'state' then zoneables.collect(&:country)
-                     else nil
+                     else []
                      end.flatten.compact.uniq
     end
 


### PR DESCRIPTION
Just fixing wrong default value of case expression - should return an Array instance, ie. `[]` instead of `nil`.
