### PR TITLE
Calculate tax total correctly which depends on the item that could be an...

### DIFF
--- a/core/app/models/spree/item_adjustments.rb
+++ b/core/app/models/spree/item_adjustments.rb
@@ -47,8 +47,9 @@ module Spree
       included_tax_total = 0
       additional_tax_total = 0
       run_callbacks :tax_adjustments do
-        included_tax_total = adjustments.tax.included.reload.map(&:update!).compact.sum
-        additional_tax_total = adjustments.tax.additional.reload.map(&:update!).compact.sum
+        tax = (item.respond_to?(:all_adjustments) ? item.all_adjustments : item.adjustments).tax
+        included_tax_total = tax.included.reload.map(&:update!).compact.sum
+        additional_tax_total = tax.additional.reload.map(&:update!).compact.sum
       end
 
       item.update_columns(

--- a/core/spec/models/spree/item_adjustments_spec.rb
+++ b/core/spec/models/spree/item_adjustments_spec.rb
@@ -6,6 +6,7 @@ module Spree
     let(:line_item) { order.line_items.first }
 
     let(:subject) { ItemAdjustments.new(line_item) }
+    let(:order_subject) { ItemAdjustments.new(order) }
 
     context '#update' do
       it "updates a linked adjustment" do
@@ -46,6 +47,7 @@ module Spree
           create(:adjustment, 
             :source => tax_rate,
             :adjustable => line_item,
+            :order => order,
             :included => true
           )
         end
@@ -58,6 +60,13 @@ module Spree
           line_item.promo_total.should == -10
           line_item.adjustment_total.should == -10
         end
+
+        it "tax linked to order" do
+          order_subject.update_adjustments
+          order.reload
+          order.included_tax_total.should == 0.5
+          order.additional_tax_total.should == 00
+        end
       end
 
       context "tax excluded from price" do
@@ -65,6 +74,7 @@ module Spree
           create(:adjustment, 
             :source => tax_rate,
             :adjustable => line_item,
+            :order => order,
             :included => false
           )
         end
@@ -78,6 +88,13 @@ module Spree
           line_item.additional_tax_total.should == 0.5
           line_item.promo_total.should == -10
           line_item.adjustment_total.should == -9.5
+        end
+
+        it "tax linked to order" do
+          order_subject.update_adjustments
+          order.reload
+          order.included_tax_total.should == 0
+          order.additional_tax_total.should == 0.5
         end
       end
     end


### PR DESCRIPTION
... Order or a LineItem. Tax adjustments are stored differently in these two cases.

This fixes https://github.com/spree/spree/issues/4829
