### PR TITLE
Fix uncaptured amount calculation

### DIFF
--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -18,7 +18,6 @@ module Spree
 
     before_validation :validate_source
     before_create :set_unique_identifier
-    before_save :update_uncaptured_amount
 
     after_save :create_payment_profile, if: :profiles_supported?
 
@@ -146,6 +145,10 @@ module Spree
       return true
     end
 
+    def uncaptured_amount
+      amount - capture_events.sum(:amount)
+    end
+
     private
 
       def validate_source
@@ -194,10 +197,6 @@ module Spree
 
       def generate_identifier
         Array.new(8){ IDENTIFIER_CHARS.sample }.join
-      end
-
-      def update_uncaptured_amount
-        self.uncaptured_amount = amount - capture_events.sum(:amount)
       end
   end
 end

--- a/core/db/migrate/20140616202624_remove_uncaptured_amount_from_spree_payments.rb
+++ b/core/db/migrate/20140616202624_remove_uncaptured_amount_from_spree_payments.rb
@@ -1,0 +1,5 @@
+class RemoveUncapturedAmountFromSpreePayments < ActiveRecord::Migration
+  def change
+    remove_column :spree_payments, :uncaptured_amount
+  end
+end

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -19,6 +19,7 @@ describe Spree::Payment do
     payment.source = card
     payment.order = order
     payment.payment_method = gateway
+    payment.amount = 5
     payment
   end
 
@@ -52,10 +53,17 @@ describe Spree::Payment do
   end
 
   context '#uncaptured_amount' do
-    it "sets uncaptured amount on save" do
-      expect(payment.uncaptured_amount).to eq(0)
-      payment.save
-      expect(payment.uncaptured_amount).to eq(payment.amount)
+    context "calculates based on capture events" do
+      it "with 0 capture events" do
+        expect(payment.uncaptured_amount).to eq(5.0)
+      end
+
+      it "with some capture events" do
+        payment.save
+        payment.capture_events.create!(amount: 2.0)
+        payment.capture_events.create!(amount: 3.0)
+        expect(payment.uncaptured_amount).to eq(0)
+      end
     end
   end
 


### PR DESCRIPTION
Under certain circumstances, Payment's uncaptured_amount won't always have the correct value in the database. After discussing in #spree-dev IRC, it seems like there is no reason we shouldn't just calculate this value on the fly instead of trying to keep the database in sync.
- Remove the callback attempting to save the uncaptured amount to the database
- Add a new method to calculate the uncaptured amount
- Remove database column
- Specs
