### PR TITLE
Fixes Zone #contains? n+1 query performance.

### DIFF
--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -72,12 +72,12 @@ module Spree
     # All zoneables belonging to the zone members.  Will be a collection of either
     # countries or states depending on the zone type.
     def zoneables
-      members.collect(&:zoneable)
+      members.includes(:zoneable).collect(&:zoneable)
     end
 
     def country_ids
       if kind == 'country'
-        members.collect(&:zoneable_id)
+        members.pluck(:zoneable_id)
       else
         []
       end
@@ -85,7 +85,7 @@ module Spree
 
     def state_ids
       if kind == 'state'
-        members.collect(&:zoneable_id)
+        members.pluck(:zoneable_id)
       else
         []
       end
@@ -118,9 +118,9 @@ module Spree
       return false if zone_members.empty? || target.zone_members.empty?
 
       if kind == target.kind
-        return false if target.zoneables.any? { |target_zoneable| zoneables.exclude?(target_zoneable) }
+        return false if (target.zoneables.collect(&:id) - zoneables.collect(&:id)).present?
       else
-        return false if target.zoneables.any? { |target_state| zoneables.exclude?(target_state.country) }
+        return false if (target.zoneables.collect(&:country).collect(&:id) - zoneables.collect(&:id)).present?
       end
       true
     end


### PR DESCRIPTION
Following a similar logic to #4579, the `Zone` `contains?` method performs a n+1 lookup. This affects performance with zones that contain a lot of members.

I think that the existing tests in `zone_spec` cover the changes in the code as no new functionality has been added.
