### PR TITLE
remove TaxRate.default method

### DIFF
--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -82,20 +82,6 @@ module Spree
       end
     end
 
-    # For Vat the default rate is the rate that is configured for the default category
-    # It is needed for every price calculation (as all customer facing prices include vat )
-    # The function returns the actual amount, which may be 0 in case of wrong setup, but is never nil
-    def self.default
-      category = TaxCategory.includes(:tax_rates).where(is_default: true).first
-      return 0 unless category
-
-      address ||= Address.new(country_id: Spree::Config[:default_country_id])
-      rate = category.tax_rates.detect { |rate| rate.zone.include? address }.try(:amount)
-
-      rate || 0
-    end
-
-
     # Tax rates can *potentially* be applicable to an order.
     # We do not know if they are/aren't until we attempt to apply these rates to
     # the items contained within the Order itself.

--- a/core/spec/models/spree/tax_rate_spec.rb
+++ b/core/spec/models/spree/tax_rate_spec.rb
@@ -201,48 +201,6 @@ describe Spree::TaxRate do
     end
   end
 
-  context "default" do
-    let(:tax_category) { create(:tax_category) }
-    let(:country) { create(:country) }
-    let(:calculator) { Spree::Calculator::FlatRate.new }
-
-    context "when there is no default tax_category" do
-      before { tax_category.is_default = false }
-
-      it "should return 0" do
-        Spree::TaxRate.default.should == 0
-      end
-    end
-
-    context "when there is a default tax_category" do
-      before { tax_category.update_column :is_default, true }
-
-      context "when the default category has tax rates in the default tax zone" do
-        before(:each) do
-          Spree::Config[:default_country_id] = country.id
-          @zone = create(:zone, :name => "Country Zone", :default_tax => true)
-          @zone.zone_members.create(:zoneable => country)
-          rate = Spree::TaxRate.create(
-            :amount => 1,
-            :zone => @zone,
-            :tax_category => tax_category,
-            :calculator => calculator
-          )
-        end
-
-        it "should return the correct tax_rate" do
-          Spree::TaxRate.default.to_f.should == 1.0
-        end
-      end
-
-      context "when the default category has no tax rates in the default tax zone" do
-        it "should return 0" do
-          Spree::TaxRate.default.should == 0
-        end
-      end
-    end
-  end
-
   context "#adjust" do
     before do
       @country = create(:country)


### PR DESCRIPTION
I couldn't anything that was actually using this code.

Is it obsolete or was it provided for some extension to use?
