### PR TITLE
Don't assume default variant in JS. Let this be controlled by HTML marku...

### DIFF
--- a/frontend/app/assets/javascripts/store/product.js.coffee
+++ b/frontend/app/assets/javascripts/store/product.js.coffee
@@ -37,8 +37,9 @@ $ ->
   radios = ($ '#product-variants input[type="radio"]')
 
   if radios.length > 0
-    Spree.showVariantImages ($ '#product-variants input[type="radio"]').eq(0).attr('value')
-    Spree.updateVariantPrice radios.first()
+    selectedRadio = ($ '#product-variants input[type="radio"][checked="checked"]')
+    Spree.showVariantImages selectedRadio.attr('value')
+    Spree.updateVariantPrice selectedRadio
 
   Spree.addImageHandlers()
 


### PR DESCRIPTION
The default variant on the product product page is determined by _cart_form.html.erb . This logic is currently duplicated in product.js.coffee, but it shouldn't. This JS should be changed to simply honour whichever default variant chosen by _cart_form.html.erb.

This change is necessary to support listing of variants in Category view, a commonly requested behaviour, for example https://groups.google.com/forum/#!topic/spree-user/P5HHv1ZMBSE and http://stackoverflow.com/questions/8416257/spree-listing-variants-on-product-index-pages .

Without this change a user selecting a non-master variant from the Category view will be taken to the product page with the master images and price displayed, which is wrong. For example, the 3rd and 4th "products" on this page http://www.shopjoy.com.au/t/category/unique-gifts-and-novelty-products are actually variants. Without this JS change, if you clicked the 3rd product http://www.shopjoy.com.au/buy/framed-designer-origami?v=681 the rendered HTML would correctly pre-select the right variant radio button, but the JS would incorrectly display the master variant's images and price.

I'm sorry if my explanation is not very clear. It's tricky to explain but I feel this is an important change. Please yell if you want me to clarify further.
