### PR TITLE
Fix properties search icon and failing spec

### DIFF
--- a/backend/app/views/spree/admin/properties/index.html.erb
+++ b/backend/app/views/spree/admin/properties/index.html.erb
@@ -33,7 +33,7 @@
         <div class="clear"></div>
 
         <div class="form-buttons actions filter-actions" data-hook="admin_pproperties_index_search_buttons">
-          <%= button Spree.t(:search), 'icon-search' %>
+          <%= button Spree.t(:search), 'search' %>
         </div>
     <% end %>
   </div>


### PR DESCRIPTION
Fixes a failing feature spec (Unable to find css ".fa-search") introduced in
2e9002a36b24b22f120bf9494b51a0fec3eebf4c.

Using the correct icon for the search button fixes this.
