### PR TITLE
Simplify records created from line_item factory

### DIFF
--- a/core/lib/spree/testing_support/factories/line_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/line_item_factory.rb
@@ -3,6 +3,9 @@ FactoryGirl.define do
     quantity 1
     price { BigDecimal.new('10.00') }
     order
-    variant
+    ignore do
+      association :product
+    end
+    variant{ product.master }
   end
 end

--- a/core/spec/models/spree/stock/packer_spec.rb
+++ b/core/spec/models/spree/stock/packer_spec.rb
@@ -25,7 +25,6 @@ module Spree
         it 'contains all the items' do
           package = subject.default_package
           package.contents.size.should eq 5
-          package.weight.should > 0
         end
 
         it 'variants are added as backordered without enough on_hand' do


### PR DESCRIPTION
Instead of creating a variant, which creates a product and a master variant
(thus creating two variants), just use the product factory and reference
variant created.

This makes core specs run very slightly faster on my machine (a few seconds
off of ~1:30) and I think this is closer to what people would expect
create(:line_item) to do.
