### PR TITLE
Code style fix

### DIFF
--- a/core/app/models/spree/stock/splitter/base.rb
+++ b/core/app/models/spree/stock/splitter/base.rb
@@ -15,6 +15,7 @@ module Spree
         end
 
         private
+        
         def return_next(packages)
           next_splitter ? next_splitter.split(packages) : packages
         end

--- a/core/app/models/spree/stock/splitter/shipping_category.rb
+++ b/core/app/models/spree/stock/splitter/shipping_category.rb
@@ -11,6 +11,7 @@ module Spree
         end
 
         private
+
         def split_by_category(package)
           categories = Hash.new { |hash, key| hash[key] = [] }
           package.contents.each do |item|

--- a/core/app/models/spree/stock/splitter/weight.rb
+++ b/core/app/models/spree/stock/splitter/weight.rb
@@ -17,6 +17,7 @@ module Spree
         end
 
         private
+  
         def reduce(package)
           removed = []
           while package.weight > self.threshold


### PR DESCRIPTION
I'm leaving one blank line below `private`
According to:
https://github.com/bbatsov/ruby-style-guide#classes--modules

`Indent the public, protected, and private methods as much the method definitions they apply to. Leave one blank line above the visibility modifier and one blank line below in order to emphasize that it applies to all methods below it.`
