### PR TITLE
Delegate accessor line_item.sku to variant

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -24,7 +24,7 @@ module Spree
     after_save :update_order
     after_destroy :update_order
 
-    delegate :name, :description, :should_track_inventory?, to: :variant
+    delegate :name, :description, :sku, :should_track_inventory?, to: :variant
 
     attr_accessor :target_shipment
 


### PR DESCRIPTION
I noticed that Spree has really helpful delegate methods on the `line_item` for `name` and `description` (technically these are double-delegated, to the `product` via the `variant`), and I thought it might be convenient to have a similar delegate accessor for the `sku`, which often appears near `name` and `description` in views.
