### PR TITLE
Added a straightforward Dockerfile for local sandbox work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,90 @@
+# This Dockerfile builds Spree from master in a container and  sets up
+# the 'sandbox' test app.
+#
+# From there you'll be able to run the test suite or a web server.
+#
+# Basic usage:
+# 
+#  $ docker build --tag="spree-master-local" .
+#  $ docker run -t -i spree-master-local tmux
+#
+#  (From within the container)
+#
+#  Rails console:
+#    $ bundle exec rails c
+#
+#  Externally-accessible rails server:
+#    $ bundle exec rails s
+#
+# To rebuild from scratch:
+#  $ docker build --no-cache=true --tag="spree-master-local" .
+#
+# Browser testing:
+#  To map container port 3000 to localhost port 3333:
+#  $ docker run -t -i -p 127.0.0.1:3333:3000 spree-master-local tmux
+#
+
+############################################################
+# BASE IMAGE
+############################################################
+
+# See https://github.com/phusion/passenger-docker for details on this image. 
+FROM phusion/passenger-ruby21:0.9.10
+
+############################################################
+# ENVIRONMENT
+############################################################
+
+# Set $HOME to /root for preparatory setup
+ENV HOME /root
+
+# Use phusion/baseimage-docker's init process.
+CMD ["/sbin/my_init"]
+
+# Expose container port 3000 for access from outside of the container
+EXPOSE 3000
+
+############################################################
+# PACKAGES
+############################################################
+
+RUN   apt-get update --fix-missing
+
+# tmux can help simplify interactive work inside the container.
+RUN   apt-get -y install tmux
+
+# Base spree requests all three databases for testing.
+# DB client gems require the dev packages to compile.
+RUN   apt-get -y install postgresql     libpq-dev
+RUN   apt-get -y install mysql-server   libmysqlclient-dev
+RUN   apt-get -y install sqlite3        libsqlite3-dev
+
+# Clean up APT when done.
+RUN   apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+
+############################################################
+# APP + GEMS
+############################################################
+
+# Create local gem_home folder (bundler cache defaults to $GEM_HOME)
+RUN       mkdir    /home/app/gem_home
+ENV       GEM_HOME /home/app/gem_home
+
+# Copy your local git copy of Spree install to container
+ADD       ./  /home/app/spree
+
+# Ensure the folders we just created belong to the unprivileged user
+RUN       chown -R app:app /home/app
+
+USER      app
+WORKDIR   /home/app/spree
+
+# Local artifacts for simpler permissions
+RUN       bundle install
+RUN       bundle exec rake sandbox
+WORKDIR   /home/app/spree/sandbox
+RUN       bundle install
+
+# Switch back to app user's $HOME for interactive work
+ENV       HOME /home/app

--- a/README.md
+++ b/README.md
@@ -190,6 +190,42 @@ cd sandbox
 rails server
 ```
 
+### Test Drive Spree On Your Machine With Docker
+
+Users wishing to do an extended test drive of Spree on their own hardware without
+setting up all of Spree's dependencies can use [Docker](http://www.docker.com).
+Executing [our Dockerfile](Dockerfile) will get you a basic linux container running whichever
+git release of Spree you choose to download.
+
+1. [Install a build of Docker suitable for your OS](https://docs.docker.com/installation/).
+Solutions are available for Linux, OSX, and Windows.
+
+2. Use `git` to download Spree from Github: `git clone https://github.com/spree/spree.git`
+
+3. Switch to the newly created `spree` folder and build and run a Docker container from it:
+  ```sh
+  cd spree
+  # build the current spree checkout and tag the result as spree-master-local
+  docker build --tag="spree-master-local" .
+  # run spree-master-local in interactive mode, exposing port 3000 to the host
+  docker run -t -i -p 127.0.0.1:3333:3000 spree-master-local tmux
+  ```
+
+4. You should now be inside a shell session running on your container.  From here,
+you can do anything you want with Spree.  Try running the web application!
+  ```sh
+# from within the container:
+  bundle exec rails s
+# You should see the Spree application start and listen on port 3000 in the container.
+  ```
+
+5. Now that Spree is listening on port 3000 within the container, open it in a browser.
+Since the container's port 3000 is mapped to the host port 3333, open
+[http://localhost:3333](http://localhost:3333) and you should see Spree.
+
+From here you can do whatever you want in the container - play with different configurations,
+run the test suite, or rebuild the container using a different git branch of Spree. 
+
 Performance
 -----------
 


### PR DESCRIPTION
I created a Dockerfile to allow for simple containerized execution of the `sandbox` app from master.  I'm sure there's tons of improvement to be done here, but I wanted to submit what I had in hopes that others will improve upon it.

cc @geekoncoffee @jhawthorn
