### PR TITLE
ensure correct order for payments query in OrderUpdater

### DIFF
--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -145,7 +145,7 @@ module Spree
     # The +payment_state+ value helps with reporting, etc. since it provides a quick and easy way to locate Orders needing attention.
     def update_payment_state
       last_state = order.payment_state
-      if payments.present? && payments.last.state == 'failed'
+      if payments.present? && payments.order('id asc').last.state == 'failed'
         order.payment_state = 'failed'
       else
         order.payment_state = 'balance_due' if order.outstanding_balance > 0


### PR DESCRIPTION
".last" without a sort order is not guaranteed to return any particular item, especially in postgres.

"If sorting is not chosen, the rows will be returned in an unspecified order"
http://www.postgresql.org/docs/9.3/interactive/queries-order.html

I couldn't think of a reasonable way to write a spec around this since the sort order is just unspecified.
