### PR TITLE
Add state_text to StockLocation

### DIFF
--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -13,6 +13,10 @@ module Spree
 
     after_create :create_stock_items, :if => "self.propagate_all_variants?"
 
+    def state_text
+      state.try(:abbr) || state.try(:name) || state_name
+    end
+    
     # Wrapper for creating a new stock item respecting the backorderable config
     def propagate_variant(variant)
       self.stock_items.create!(variant: variant, backorderable: self.backorderable_default)

--- a/core/spec/models/spree/stock_location_spec.rb
+++ b/core/spec/models/spree/stock_location_spec.rb
@@ -201,5 +201,25 @@ module Spree
         end
       end
     end
+    
+    context '#state_text' do
+      context 'state is blank' do
+        subject { StockLocation.create(name: "testing", state: nil, state_name: 'virginia') }
+        specify { subject.state_text.should == 'virginia' }
+      end
+
+      context 'both name and abbr is present' do
+        let(:state) { stub_model(Spree::State, name: 'virginia', abbr: 'va') }
+        subject { StockLocation.create(name: "testing", state: state, state_name: nil) }
+        specify { subject.state_text.should == 'va' }
+      end
+
+      context 'only name is present' do
+        let(:state) { stub_model(Spree::State, name: 'virginia', abbr: nil) }
+        subject { StockLocation.create(name: "testing", state: state, state_name: nil) }
+        specify { subject.state_text.should == 'virginia' }
+      end
+    end
+
   end
 end


### PR DESCRIPTION
I'm working on a revision to `Spree::TaxCloud`, and we use the `StockLocation` addresses pretty heavily. It'd be a huge help to have the `state_text` method that exists in the [`Spree::Address` model](https://github.com/spree/spree/blob/master/core/app/models/spree/address.rb#L39).
