### PR TITLE
Refactor updating order item_total

### DIFF
--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -81,7 +81,7 @@ module Spree
     end
 
     def update_item_total
-      order.item_total = line_items.map(&:amount).sum
+      order.item_total = line_items.sum('price * quantity')
       update_order_total
     end
 


### PR DESCRIPTION
This simple PR changes the behavior of updating the `Order.item_total` from loading Active Record objects for each line item, to using the database to perform the sum calculation (as the rest of the `OrderUpdater` does).

The benefits of this are that there are no longer active record objects instantiated to perform the sum, which may seem inconsequential but in reality the line item objects may not be in memory when running through the order updater causing unnecessary objects to be created. 

Of course, the negative side of not using the `amount` method on the `LineItem` means some repetition but as this is so small I don't believe it's an issue. I haven't added any tests as the current suite handles this situation.
