### PR TITLE
Allow the specific capturing or authorization of payments on orders.

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -19,3 +19,7 @@
 *   Add attempt_authorization! and attempt_purchase! to the public interface of payments.
 
     Richard Wilson
+
+*   Add authorize_payments! and capture_payments! to the public interface of orders.
+
+    Richard Wilson

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -15,3 +15,7 @@
 *   Ensure transition to payment processing state happens outside transaction.
 
     Chris Salzberg
+
+*   Add attempt_authorization! and attempt_purchase! to the public interface of payments.
+
+    Richard Wilson

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -385,6 +385,14 @@ module Spree
       process_payments_with(:process!)
     end
 
+    def authorize_payments!
+      process_payments_with(:attempt_authorization!)
+    end
+
+    def capture_payments!
+      process_payments_with(:attempt_purchase!)
+    end
+
     def billing_firstname
       bill_address.try(:firstname)
     end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -382,22 +382,7 @@ module Spree
     #   :allow_checkout_on_gateway_error is set to false
     #
     def process_payments!
-      if pending_payments.empty?
-        raise Core::GatewayError.new Spree.t(:no_pending_payments)
-      else
-        pending_payments.each do |payment|
-          break if payment_total >= total
-
-          payment.process!
-
-          if payment.completed?
-            self.payment_total += payment.amount
-          end
-        end
-      end
-    rescue Core::GatewayError => e
-      result = !!Spree::Config[:allow_checkout_on_gateway_error]
-      errors.add(:base, e.message) and return result
+      process_payments_with(:process!)
     end
 
     def billing_firstname
@@ -642,5 +627,23 @@ module Spree
         self.currency = Spree::Config[:currency] if self[:currency].nil?
       end
 
+      def process_payments_with(method)
+        if pending_payments.empty?
+          raise Core::GatewayError.new Spree.t(:no_pending_payments)
+        else
+          pending_payments.each do |payment|
+            break if payment_total >= total
+
+            payment.public_send(method)
+
+            if payment.completed?
+              self.payment_total += payment.amount
+            end
+          end
+        end
+      rescue Core::GatewayError => e
+        result = !!Spree::Config[:allow_checkout_on_gateway_error]
+        errors.add(:base, e.message) and return result
+      end
   end
 end

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -2,13 +2,19 @@ module Spree
   class Payment < ActiveRecord::Base
     module Processing
       def process!
-        handle_payment_preconditions do
-          if payment_method.auto_capture?
-            purchase!
-          else
-            authorize!
-          end
+        if payment_method.auto_capture?
+          attempt_purchase!
+        else
+          attempt_authorization!
         end
+      end
+
+      def attempt_authorization!
+        handle_payment_preconditions { authorize! }
+      end
+
+      def attempt_purchase!
+        handle_payment_preconditions { purchase! }
       end
 
       def authorize!

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -338,6 +338,32 @@ describe Spree::Order do
     end
   end
 
+  context "#authorize_payments!" do
+    let(:payment) { stub_model(Spree::Payment) }
+    before { order.stub :pending_payments => [payment], :total => 10 }
+    subject { order.authorize_payments! }
+
+    it "processes payments with attempt_authorization!" do
+      expect(payment).to receive(:attempt_authorization!)
+      subject
+    end
+
+    it { should be_true }
+  end
+
+  context "#capture_payments!" do
+    let(:payment) { stub_model(Spree::Payment) }
+    before { order.stub :pending_payments => [payment], :total => 10 }
+    subject { order.capture_payments! }
+
+    it "processes payments with attempt_authorization!" do
+      expect(payment).to receive(:attempt_purchase!)
+      subject
+    end
+
+    it { should be_true }
+  end
+
   context "#outstanding_balance" do
     it "should return positive amount when payment_total is less than total" do
       order.payment_total = 20.20
@@ -349,7 +375,6 @@ describe Spree::Order do
       order.payment_total = 10.20
       order.outstanding_balance.should be_within(0.001).of(-2.00)
     end
-
   end
 
   context "#outstanding_balance?" do

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -132,7 +132,20 @@ describe Spree::Payment do
         expect { payment.process!}.to raise_error(Spree::Core::GatewayError)
         payment.state.should eq('invalid')
       end
+    end
 
+    describe "#attempt_authorization!" do
+      it "authorizes" do
+        expect(payment).to receive(:authorize!)
+        payment.attempt_authorization!
+      end
+    end
+
+    describe "#attempt_purchase!" do
+      it "purchases" do
+        expect(payment).to receive(:purchase!)
+        payment.attempt_purchase!
+      end
     end
 
     describe "#authorize!" do
@@ -800,13 +813,13 @@ describe Spree::Payment do
 
       context "amount contains a $ sign" do
         let(:amount) { '2,99 $' }
-        
+
         its(:amount) { should eql(BigDecimal('2.99')) }
       end
 
       context "amount is a number" do
         let(:amount) { 2.99 }
-        
+
         its(:amount) { should eql(BigDecimal('2.99')) }
       end
 


### PR DESCRIPTION
There are times when, regardless of store configuration or payment_method preferences we need to explicitly capture or purchase payments. An example of this is a review step between the complete and confirm states for spree order.
