### PR TITLE
Allow the specific authorization or capture of payments on orders.

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Spree 2.4.0 (unreleased) ##
 
+* Add authorize_payments! and capture_payments! to the public interface of orders.
+
+    Richard Wilson
+
 * Spree no longer holds aws-sdk as a core dependency. In case you use it
   you need to add it to your Gemfile. See paperclip README for reference on
   scenarios where this is needed https://github.com/thoughtbot/paperclip/tree/v4.1.1#understanding-storage

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -10,6 +10,7 @@ module Spree
 
     include Spree::Order::Checkout
     include Spree::Order::CurrencyUpdater
+    include Spree::Order::Payments
 
     checkout_flow do
       go_to_state :address
@@ -416,42 +417,6 @@ module Spree
       @available_payment_methods ||= (PaymentMethod.available(:front_end) + PaymentMethod.available(:both)).uniq
     end
 
-    def pending_payments
-      payments.select { |payment| payment.pending? }
-    end
-
-    def unprocessed_payments
-      payments.select { |payment| payment.checkout? }
-    end
-
-    # processes any pending payments and must return a boolean as it's
-    # return value is used by the checkout state_machine to determine
-    # success or failure of the 'complete' event for the order
-    #
-    # Returns:
-    #
-    # - true if all pending_payments processed successfully
-    #
-    # - true if a payment failed, ie. raised a GatewayError
-    #   which gets rescued and converted to TRUE when
-    #   :allow_checkout_gateway_error is set to true
-    #
-    # - false if a payment failed, ie. raised a GatewayError
-    #   which gets rescued and converted to FALSE when
-    #   :allow_checkout_on_gateway_error is set to false
-    #
-    def process_payments!
-      process_payments_with(:process!)
-    end
-
-    def authorize_payments!
-      process_payments_with(:authorize!)
-    end
-
-    def capture_payments!
-      process_payments_with(:purchase!)
-    end
-
     def billing_firstname
       bill_address.try(:firstname)
     end
@@ -723,21 +688,6 @@ module Spree
         random_token = SecureRandom.urlsafe_base64(nil, false)
         break random_token unless self.class.exists?(guest_token: random_token)
       end
-    end
-
-    def process_payments_with(method)
-      unprocessed_payments.each do |payment|
-        break if payment_total >= total
-
-        payment.public_send(method)
-
-        if payment.completed?
-          self.payment_total += payment.amount
-        end
-      end
-    rescue Core::GatewayError => e
-      result = !!Spree::Config[:allow_checkout_on_gateway_error]
-      errors.add(:base, e.message) and return result
     end
   end
 end

--- a/core/app/models/spree/order/payments.rb
+++ b/core/app/models/spree/order/payments.rb
@@ -1,0 +1,61 @@
+module Spree
+  class Order < Spree::Base
+    module Payments
+      extend ActiveSupport::Concern
+      included do
+        # processes any pending payments and must return a boolean as it's
+        # return value is used by the checkout state_machine to determine
+        # success or failure of the 'complete' event for the order
+        #
+        # Returns:
+        #
+        # - true if all pending_payments processed successfully
+        #
+        # - true if a payment failed, ie. raised a GatewayError
+        #   which gets rescued and converted to TRUE when
+        #   :allow_checkout_gateway_error is set to true
+        #
+        # - false if a payment failed, ie. raised a GatewayError
+        #   which gets rescued and converted to FALSE when
+        #   :allow_checkout_on_gateway_error is set to false
+        #
+        def process_payments!
+          process_payments_with(:process!)
+        end
+
+        def authorize_payments!
+          process_payments_with(:authorize!)
+        end
+
+        def capture_payments!
+          process_payments_with(:purchase!)
+        end
+
+        def pending_payments
+          payments.select { |payment| payment.pending? }
+        end
+
+        def unprocessed_payments
+          payments.select { |payment| payment.checkout? }
+        end
+
+        private
+
+        def process_payments_with(method)
+          unprocessed_payments.each do |payment|
+            break if payment_total >= total
+
+            payment.public_send(method)
+
+            if payment.completed?
+              self.payment_total += payment.amount
+            end
+          end
+        rescue Core::GatewayError => e
+          result = !!Spree::Config[:allow_checkout_on_gateway_error]
+          errors.add(:base, e.message) and return result
+        end
+      end
+    end
+  end
+end

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -2,22 +2,11 @@ module Spree
   class Payment < Spree::Base
     module Processing
       def process!
-        if payment_method && payment_method.source_required?
-          if source
-            if !processing?
-              if payment_method.supports?(source) || token_based?
-                if payment_method.auto_capture?
-                  purchase!
-                else
-                  authorize!
-                end
-              else
-                invalidate!
-                raise Core::GatewayError.new(Spree.t(:payment_method_not_supported))
-              end
-            end
+        handle_payment_preconditions do
+          if payment_method.auto_capture?
+            purchase!
           else
-            raise Core::GatewayError.new(Spree.t(:payment_processing_failed))
+            authorize!
           end
         end
       end
@@ -109,6 +98,27 @@ module Spree
       end
 
       private
+
+      def handle_payment_preconditions(&block)
+        unless block_given?
+          raise ArgumentError.new("handle_payment_preconditions must be called with a block")
+        end
+
+        if payment_method && payment_method.source_required?
+          if source
+            if !processing?
+              if payment_method.supports?(source) || token_based?
+                yield
+              else
+                invalidate!
+                raise Core::GatewayError.new(Spree.t(:payment_method_not_supported))
+              end
+            end
+          else
+            raise Core::GatewayError.new(Spree.t(:payment_processing_failed))
+          end
+        end
+      end
 
       def gateway_action(source, action, success_state)
         protect_from_connection_error do

--- a/core/spec/models/spree/order/payment_spec.rb
+++ b/core/spec/models/spree/order/payment_spec.rb
@@ -117,6 +117,32 @@ module Spree
       end
     end
 
+    context "#authorize_payments!" do
+      let(:payment) { stub_model(Spree::Payment) }
+      before { order.stub :unprocessed_payments => [payment], :total => 10 }
+      subject { order.authorize_payments! }
+
+      it "processes payments with attempt_authorization!" do
+        expect(payment).to receive(:authorize!)
+        subject
+      end
+
+      it { should be_true }
+    end
+
+    context "#capture_payments!" do
+      let(:payment) { stub_model(Spree::Payment) }
+      before { order.stub :unprocessed_payments => [payment], :total => 10 }
+      subject { order.capture_payments! }
+
+      it "processes payments with attempt_authorization!" do
+        expect(payment).to receive(:purchase!)
+        subject
+      end
+
+      it { should be_true }
+    end
+
     context "#outstanding_balance" do
       it "should return positive amount when payment_total is less than total" do
         order.payment_total = 20.20

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -112,22 +112,17 @@ describe Spree::Payment do
   end
 
   context "processing" do
-    before do
-      payment.stub(:update_order)
-      payment.stub(:create_payment_profile)
-    end
-
     describe "#process!" do
       it "should purchase if with auto_capture" do
         payment.payment_method.should_receive(:auto_capture?).and_return(true)
-        payment.should_receive(:purchase!)
         payment.process!
+        expect(payment).to be_completed
       end
 
       it "should authorize without auto_capture" do
         payment.payment_method.should_receive(:auto_capture?).and_return(false)
-        payment.should_receive(:authorize!)
         payment.process!
+        expect(payment).to be_pending
       end
 
       it "should make the state 'processing'" do
@@ -418,8 +413,6 @@ describe Spree::Payment do
     it "should return nil without trying to process the source" do
       payment.state = 'processing'
 
-      payment.should_not_receive(:authorize!)
-      payment.should_not_receive(:purchase!)
       payment.process!.should be_nil
     end
   end


### PR DESCRIPTION
There are times when, regardless of store configuration or payment_method preferences we need to explicitly capture or purchase payments. An example of this is a review step between the complete and confirm states for spree order.
