### PR TITLE
New paradigm for customer refunds

### DIFF
--- a/api/spec/controllers/spree/api/payments_controller_spec.rb
+++ b/api/spec/controllers/spree/api/payments_controller_spec.rb
@@ -225,14 +225,14 @@ module Spree
             response.status.should == 200
             payment.reload.state.should == "completed"
 
-            # Ensure that a credit payment was created, and it has correct credit amount
-            credit_payment = Payment.where(:source_type => 'Spree::Payment', :source_id => payment.id).last
-            credit_payment.amount.to_f.should == -45.75
+            # Ensure that a refund was created, and it has correct credit amount
+            refund = payment.refunds.last
+            refund.amount.to_f.should == 45.75
           end
 
           context "crediting fails" do
             it "returns a 422 status" do
-              fake_response = double(:success? => false, :to_s => "NO CREDIT FOR YOU")
+              fake_response = ActiveMerchant::Billing::Response.new(false, 'NO CREDIT FOR YOU', {}, {})
               Spree::Gateway::Bogus.any_instance.should_receive(:credit).and_return(fake_response)
               api_put :credit, :id => payment.to_param
               response.status.should == 422

--- a/backend/app/views/spree/admin/payments/_list.html.erb
+++ b/backend/app/views/spree/admin/payments/_list.html.erb
@@ -1,6 +1,7 @@
 <table class="index" id='payments' data-order-id='<%= @order.number %>'>
   <thead>
     <tr data-hook="payments_header">
+      <th><%= Spree.t(:identifier) %></th>
       <th><%= "#{Spree.t('date')}/#{Spree.t('time')}" %></th>
       <th><%= Spree.t(:amount) %></th>
       <th><%= Spree.t(:payment_method) %></th>
@@ -10,8 +11,9 @@
   </thead>
   <tbody>
     <% payments.each do |payment| %>
-      <tr id="<%= dom_id(payment) %>" data-hook="payments_row" class="<%= cycle('odd', 'even')%>">
-        <td><%= link_to pretty_time(payment.created_at), spree.admin_order_payment_path(@order, payment) %></td>
+      <tr id="<%= dom_id(payment) %>" data-hook="payments_row" class="<%= cycle('odd', 'even', name: 'payment_table_cycle')%>">
+        <td><%= link_to payment.identifier, spree.admin_order_payment_path(@order, payment) %></td>
+        <td><%= pretty_time(payment.created_at) %></td>
         <td class="align-center amount"><%= payment.display_amount.to_html %></td>
         <td class="align-center"><%= payment_method_name(payment) %></td>
         <td class="align-center"> <span class="state <%= payment.state %>"><%= Spree.t(payment.state, :scope => :payment_states, :default => payment.state.capitalize) %></span></td>

--- a/backend/app/views/spree/admin/payments/_refunds.html.erb
+++ b/backend/app/views/spree/admin/payments/_refunds.html.erb
@@ -3,8 +3,8 @@
     <tr data-hook="refunds_header">
       <th><%= "#{Spree.t('date')}/#{Spree.t('time')}" %></th>
       <th><%= Spree.t(:payment_identifier) %></th>
-      <th><%= Spree.t(:payment_method) %></th>
       <th><%= Spree.t(:amount) %></th>
+      <th><%= Spree.t(:payment_method) %></th>
     </tr>
   </thead>
   <tbody>
@@ -12,8 +12,8 @@
       <tr id="<%= dom_id(refund) %>" data-hook="refunds_row" class="<%= cycle('odd', 'even', name: 'refund_table_cycle')%>">
         <td><%= pretty_time(refund.created_at) %></td>
         <td><%= refund.payment.identifier %></td>
-        <td class="align-center"><%= payment_method_name(refund.payment) %></td>
         <td class="align-center amount"><%= refund.display_amount %></td>
+        <td class="align-center"><%= payment_method_name(refund.payment) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/backend/app/views/spree/admin/payments/_refunds.html.erb
+++ b/backend/app/views/spree/admin/payments/_refunds.html.erb
@@ -1,0 +1,20 @@
+<table class="index" id='payments' data-order-id='<%= @order.number %>'>
+  <thead>
+    <tr data-hook="refunds_header">
+      <th><%= "#{Spree.t('date')}/#{Spree.t('time')}" %></th>
+      <th><%= Spree.t(:payment_identifier) %></th>
+      <th><%= Spree.t(:payment_method) %></th>
+      <th><%= Spree.t(:amount) %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% refunds.each do |refund| %>
+      <tr id="<%= dom_id(refund) %>" data-hook="refunds_row" class="<%= cycle('odd', 'even', name: 'refund_table_cycle')%>">
+        <td><%= pretty_time(refund.created_at) %></td>
+        <td><%= refund.payment.identifier %></td>
+        <td class="align-center"><%= payment_method_name(refund.payment) %></td>
+        <td class="align-center amount"><%= refund.display_amount %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/backend/app/views/spree/admin/payments/index.html.erb
+++ b/backend/app/views/spree/admin/payments/index.html.erb
@@ -18,7 +18,20 @@
 <% end %>
 
 <% if @payments.any? %>
-  <%= render :partial => 'list', :locals => { :payments => @payments } %>
+
+  <fieldset data-hook="payment_list" class="no-border-bottom">
+    <legend align="center"><%= Spree.t(:payments) %></legend>
+    <%= render :partial => 'list', :locals => { :payments => @payments } %>
+  </fieldset>
+
+  <% @refunds = @payments.flat_map(&:refunds) %>
+  <% if @refunds.any? %>
+    <fieldset data-hook="payment_list" class="no-border-bottom">
+      <legend align="center"><%= Spree.t(:refunds) %></legend>
+      <%= render :partial => 'refunds', :locals => { :refunds => @refunds } %>
+    </fieldset>
+  <% end %>
+
 <% else %>
   <div class="alpha twelve columns no-objects-found"><%= Spree.t(:order_has_no_payments) %></div>
 <% end %>

--- a/backend/app/views/spree/admin/return_authorizations/_form.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/_form.html.erb
@@ -18,13 +18,13 @@
           <td class="align-center"><%= units.select(&:shipped?).size %></td>
           <td class="align-center"><%= units.select(&:returned?).size %></td>
           <td class="return_quantity align-center">
-            <% if @return_authorization.received? %>
-              <%= @return_authorization.inventory_units.group_by(&:variant)[variant].try(:size) || 0 %>
-            <% elsif units.select(&:shipped?).empty? %>
+            <% if units.select(&:shipped?).empty? %>
               0
-            <% else %>
+            <% elsif @return_authorization.updatable? %>
               <%= number_field_tag "return_quantity[#{variant.id}]",
                 @return_authorization.inventory_units.group_by(&:variant)[variant].try(:size) || 0, {:style => 'width:100px;', :min => 0} %>
+            <% else %>
+              <%= @return_authorization.inventory_units.group_by(&:variant)[variant].try(:size) || 0 %>
             <% end %>
           </td>
         </tr>
@@ -34,11 +34,11 @@
 
   <%= f.field_container :amount do %>
     <%= f.label :amount, Spree.t(:amount) %> <span class="required">*</span><br />
-    <% if @return_authorization.received? %>
-      <%= @return_authorization.display_amount %>
-    <% else %>
+    <% if @return_authorization.updatable? %>
       <%= f.text_field :amount, {:style => 'width:80px;'} %> <%= Spree.t(:rma_value) %>: <span id="rma_value">0.00</span>
       <%= f.error_message_on :amount %>
+    <% else %>
+      <%= @return_authorization.display_amount %>
     <% end %>
   <% end %>
 

--- a/backend/app/views/spree/admin/return_authorizations/edit.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/edit.html.erb
@@ -9,6 +9,11 @@
       <%= button_link_to Spree.t('actions.cancel'), fire_admin_order_return_authorization_url(@order, @return_authorization, :e => 'cancel'), :method => :put, :data => { :confirm => Spree.t(:are_you_sure) }, :icon => 'remove' %>
     <% end %>
   </li>
+  <li>
+    <% if @return_authorization.can_refund? %>
+      <%= button_link_to Spree.t('actions.refund'), fire_admin_order_return_authorization_url(@order, @return_authorization, :e => 'refund'), :method => :put, :data => { :confirm => Spree.t(:are_you_sure) }, :icon => 'reply' %>
+    <% end %>
+  </li>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Return Authorizations' } %>

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -15,6 +15,7 @@ module Spree
     has_many :log_entries, as: :source
     has_many :state_changes, as: :stateful
     has_many :capture_events, :class_name => 'Spree::PaymentCaptureEvent'
+    has_many :refunds, inverse_of: :payment
 
     before_validation :validate_source
     before_create :set_unique_identifier
@@ -42,6 +43,11 @@ module Spree
     after_rollback :persist_invalid
 
     validates :amount, numericality: true
+
+    # transaction_id is much easier to understand
+    def transaction_id
+      response_code
+    end
 
     def persist_invalid
       return unless ['failed', 'invalid'].include?(state)
@@ -112,7 +118,7 @@ module Spree
     end
 
     def credit_allowed
-      amount - offsets_total.abs
+      amount - (offsets_total.abs + refunds.sum(:amount))
     end
 
     def can_credit?

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -80,35 +80,8 @@ module Spree
         end
       end
 
-      def credit!(credit_amount=nil)
-        protect_from_connection_error do
-          check_environment
-
-          credit_amount ||= credit_allowed >= order.outstanding_balance.abs ? order.outstanding_balance.abs : credit_allowed.abs
-          credit_amount = credit_amount.to_f
-          credit_cents = Spree::Money.new(credit_amount, currency: currency).money.cents
-
-          if payment_method.payment_profiles_supported?
-            response = payment_method.credit(credit_cents, source, response_code, gateway_options)
-          else
-            response = payment_method.credit(credit_cents, response_code, gateway_options)
-          end
-
-          record_response(response)
-
-          if response.success?
-            self.class.create!(
-              :order => order,
-              :source => self,
-              :payment_method => payment_method,
-              :amount => credit_amount.abs * -1,
-              :response_code => response.authorization,
-              :state => 'completed'
-            )
-          else
-            gateway_error(response)
-          end
-        end
+      def credit!(credit_amount=nil, return_authorization=nil)
+        Spree::Refund.perform!(self, (credit_amount || credit_allowed).to_f, return_authorization)
       end
 
       def cancel!

--- a/core/app/models/spree/refund.rb
+++ b/core/app/models/spree/refund.rb
@@ -1,0 +1,74 @@
+module Spree
+  class Refund < Spree::Base
+    belongs_to :payment, inverse_of: :refunds
+    belongs_to :return_authorization # optional
+
+    has_many :log_entries, as: :source
+
+    validates :payment, presence: true
+    validates :transaction_id, presence: true
+    validates :amount, presence: true, numericality: {greater_than: 0}
+
+    # attempts to perform the refund
+    # if successful it returns the refund, otherwise it raises
+    def self.perform!(payment, amount, return_authorization=nil)
+      check_amount(amount)
+      check_environment(payment)
+
+      credit_cents = Spree::Money.new(amount.to_f, currency: payment.currency).money.cents
+
+      response = process!(payment, credit_cents)
+
+      refund = create!({
+        payment: payment,
+        return_authorization: return_authorization,
+        transaction_id: response.authorization,
+        amount: amount,
+      })
+
+      refund.log_entries.create!(details: response.to_yaml)
+
+      refund
+    end
+
+    # return an activemerchant response object if successful or else raise an error
+    def self.process!(payment, credit_cents)
+      response = if payment.payment_method.payment_profiles_supported?
+        payment.payment_method.credit(credit_cents, payment.source, payment.transaction_id, {})
+      else
+        payment.payment_method.credit(credit_cents, payment.transaction_id, {})
+      end
+
+      if !response.success?
+        logger.error(Spree.t(:gateway_error) + "  #{response.to_yaml}")
+        text = response.params['message'] || response.params['response_reason_text'] || response.message
+        raise Core::GatewayError.new(text)
+      end
+
+      response
+    rescue ActiveMerchant::ConnectionError => e
+      logger.error(Spree.t(:gateway_error) + "  #{e.inspect}")
+      raise Core::GatewayError.new(Spree.t(:unable_to_connect_to_gateway))
+    end
+
+    # Saftey check to make sure we're not accidentally performing operations on a live gateway.
+    # Ex. When testing in staging environment with a copy of production data.
+    def self.check_environment(payment)
+      return if payment.payment_method.environment == Rails.env
+      message = Spree.t(:gateway_config_unavailable) + " - #{Rails.env}"
+      raise Core::GatewayError.new(message)
+    end
+
+    def self.check_amount(amount)
+      unless amount > 0
+        raise Core::GatewayError.new(Spree.t(:refund_amount_must_be_greater_than_zero))
+      end
+    end
+
+    def money
+      Spree::Money.new(amount, { currency: payment.currency })
+    end
+    alias display_amount money
+
+  end
+end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -242,6 +242,11 @@ en:
           attributes:
             currency:
               must_match_order_currency: "Must match order currency"
+        spree/return_authorization:
+          attributes:
+            base:
+              amount_due_less_than_zero: Amount due is less than zero
+              amount_due_greater_than_zero: Unable to refund full amount
   devise:
     confirmations:
       confirmed: Your account was successfully confirmed. You are now signed in.
@@ -302,6 +307,7 @@ en:
       list: List
       listing: Listing
       new: New
+      refund: Refund
       save: Save
       update: Update
     activate: Activate
@@ -631,6 +637,7 @@ en:
       this_file_language: English (US)
       translations: Translations
     icon: Icon
+    identifier: Identifier
     image: Image
     images: Images
     inactive: Inactive
@@ -840,6 +847,7 @@ en:
     pay: pay
     payment: Payment
     payment_could_not_be_created: Payment could not be created.
+    payment_identifier: Payment Identifier
     payment_information: Payment Information
     payment_method: Payment Method
     payment_methods: Payment Methods
@@ -948,6 +956,8 @@ en:
     received: Received
     reference: Reference
     refund: Refund
+    refunds: Refunds
+    refund_amount_must_be_greater_than_zero: Refund amount must be greater than zero
     register: Register
     registration: Registration
     remember_me: Remember me

--- a/core/db/migrate/20140625214618_create_spree_refunds.rb
+++ b/core/db/migrate/20140625214618_create_spree_refunds.rb
@@ -1,0 +1,12 @@
+class CreateSpreeRefunds < ActiveRecord::Migration
+  def change
+    create_table :spree_refunds do |t|
+      t.integer :payment_id
+      t.integer :return_authorization_id
+      t.decimal :amount, precision: 10, scale: 2, default: 0.0, null: false
+      t.string :transaction_id
+
+      t.timestamps
+    end
+  end
+end

--- a/core/lib/spree/testing_support/factories/refund_factory.rb
+++ b/core/lib/spree/testing_support/factories/refund_factory.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :refund, class: Spree::Refund do
+    amount 100.00
+    transaction_id 'TEST123'
+    association(:payment, state: 'completed')
+  end
+end

--- a/core/spec/models/spree/refund_spec.rb
+++ b/core/spec/models/spree/refund_spec.rb
@@ -1,0 +1,196 @@
+require 'spec_helper'
+
+describe Spree::Refund do
+
+  describe '.perform!' do
+    let(:payment_amount) { 100.0 }
+    let(:authorization) { "TEST12" }
+    let(:payment) { create(:payment) }
+
+    subject { Spree::Refund.perform!(payment, payment_amount) }
+
+    context "processing is successful" do
+      let(:response) {
+        ActiveMerchant::Billing::Response.new(true, "", {}, { authorization: authorization })
+      }
+
+      before { Spree::Refund.should_receive(:process!) { response } }
+
+      it 'should create a refund' do
+        expect{ subject }.to change{ Spree::Refund.count }.by(1)
+      end
+
+      it 'return the newly created refund' do
+        expect(subject).to be_a(Spree::Refund)
+      end
+
+      it 'should save the returned authorization value' do
+        expect(subject.transaction_id).to eq authorization
+      end
+
+      it 'should save the passed amount as the refund amount' do
+        expect(subject.amount).to eq payment_amount
+      end
+
+      it 'should create a log entry' do
+        expect(subject.log_entries).to be_present
+      end
+    end
+
+    context "processing fails" do
+      before do
+        Spree::Refund.should_receive(:process!)
+          .and_raise(Spree::Core::GatewayError)
+      end
+
+      it 'should raise error and not create a refund' do
+        expect do
+          expect { subject }.to raise_error(Spree::Core::GatewayError)
+        end.to_not change{ Spree::Refund.count }
+      end
+    end
+  end
+
+  describe '.process!' do
+    let(:payment) { create(:payment) }
+    let(:credit_cents) { 10_00 }
+    let(:response) {
+      ActiveMerchant::Billing::Response.new(response_success, response_message, {}, {})
+    }
+    let(:response_message) { "response message" }
+    let(:response_success) { true }
+    let(:support_payment_profiles) { true }
+
+    before do
+      payment.payment_method.stub(:payment_profiles_supported?) { support_payment_profiles }
+    end
+
+    subject { Spree::Refund.process!(payment, credit_cents) }
+
+    context 'without payment profiles supported' do
+      let(:support_payment_profiles) { false }
+
+      before do
+        payment.payment_method
+          .should_receive(:credit)
+          .with(credit_cents, payment.transaction_id, {})
+          .and_return(response)
+      end
+
+      it 'should supply the payment source' do
+        subject
+      end
+    end
+
+    context 'with payment profiles supported' do
+      let(:support_payment_profiles) { true }
+
+      before do
+        payment.payment_method
+          .should_receive(:credit)
+          .with(credit_cents, payment.source, payment.transaction_id, {})
+          .and_return(response)
+      end
+
+      it 'should supply the payment source' do
+        subject
+      end
+    end
+
+    context 'with successful response' do
+      let(:response_success) { true }
+
+      before do
+        payment.payment_method
+          .should_receive(:credit)
+          .with(credit_cents, payment.source, payment.transaction_id, {})
+          .and_return(response)
+      end
+
+      it 'returns the response' do
+        expect(subject).to eq response
+      end
+    end
+
+    context 'with unsuccessful response' do
+      let(:response_success) { false }
+
+      before do
+        payment.payment_method
+          .should_receive(:credit)
+          .with(credit_cents, payment.source, payment.transaction_id, {})
+          .and_return(response)
+      end
+
+      it 'raises Spree::Core:GatewayError' do
+        expect { subject }.to raise_error(Spree::Core::GatewayError, response_message)
+      end
+    end
+
+    context 'with activemerchant gateway connection error' do
+      let(:response_success) { false }
+
+      before do
+        payment.payment_method
+          .should_receive(:credit)
+          .with(credit_cents, payment.source, payment.transaction_id, {})
+          .and_raise(ActiveMerchant::ConnectionError)
+      end
+
+      it 'raises Spree::Core::GatewayError' do
+        expect { subject }.to raise_error(Spree::Core::GatewayError, Spree.t(:unable_to_connect_to_gateway))
+      end
+    end
+  end
+
+  describe '.check_environment' do
+    subject { Spree::Refund.check_environment(payment) }
+
+    let(:payment) { create(:payment, payment_method: payment_method) }
+    let(:payment_method) { create(:credit_card_payment_method, environment: payment_method_environment) }
+    let(:payment_method_environment) { 'test' }
+
+    context 'correct payment method environment' do
+      it 'does not raise' do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context 'incorrect payment method environment' do
+      let(:payment_method_environment) { 'development' }
+
+      it 'raises a Spree::Core::GatewayError' do
+        expect { subject }.to raise_error(Spree::Core::GatewayError)
+      end
+    end
+  end
+
+  describe '.check_amount' do
+
+    subject { Spree::Refund.check_amount(amount) }
+
+    context 'amount is less tha zero' do
+      let(:amount) { -1.0 }
+
+      it 'raises Spree::Core::GatewayError' do
+        expect { subject }.to raise_error(Spree::Core::GatewayError, Spree.t(:refund_amount_must_be_greater_than_zero))
+      end
+    end
+
+    context 'amount is zero' do
+      let(:amount) { 0.0 }
+
+      it 'raises Spree::Core::GatewayError' do
+        expect { subject }.to raise_error(Spree::Core::GatewayError, Spree.t(:refund_amount_must_be_greater_than_zero))
+      end
+    end
+
+    context 'amount is larger than zero' do
+      let(:amount) { 10.0 }
+
+      it 'does not raise an error' do
+        expect { subject }.to_not raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
Initial step in a larger piece of returns & exchanges improvements.

Major
- new "refunded" state for return authorizations
- separation of refunds from payments
  - add a new refund model
  - use "refunds" in place of negative payments
  - stop generating order adjustments when receiving return authorizations
    - we no longer need to create order adjustments in order to provide refunds
- updated admin ui
  - added a "refund" button in the return authorization flow
  - list refunds along with payments
  - add payment identifier column to payments list

Minor
- extra validation on `ReturnAuthorization#force_positive_amount`
- improve some existing specs by using real `ActiveMerchant::Billing::Response` objects instead of doubles

Generated by @jordan-brough & @richardnuno
