### PR TITLE
Avoid browser default font on backend icons

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/shared/_icons.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_icons.scss
@@ -46,3 +46,8 @@ button, a {
 .icon-user          { @extend .fa-user; }
 .icon-signout       { @extend .fa-sign-out; }
 .icon-external-link { @extend .fa-external-link; }
+
+// Avoid ugly default browser font (usually a serif) when an element has an icon AND text
+.fa {
+  font-family: "FontAwesome", $base-font-family !important;
+}


### PR DESCRIPTION
In the Spree backend UI, icons are used by adding classes to existing elements, without adding something like `<i class="icon-something"></i>`.
But font-awesome-rails sets the font-family to just `FontAwesome`, which results in the browser default font-family (usually, Times New Roman) being used for any text that appears next to an icon (on Firefox, at least).
Screenshot: http://adobe.ly/1mb9oOH
