### PR TITLE
Removed confirmation message from RMA edit page

### DIFF
--- a/backend/app/views/spree/admin/return_authorizations/edit.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/edit.html.erb
@@ -1,12 +1,12 @@
 <% content_for :page_actions do %>
   <li>
     <% if @return_authorization.can_receive? %>
-      <%= button_link_to Spree.t(:receive), fire_admin_order_return_authorization_url(@order, @return_authorization, :e => 'receive'), :method => :put, :data => { :confirm => Spree.t(:are_you_sure) }, :icon => 'download-alt' %>
+      <%= button_link_to Spree.t(:receive), fire_admin_order_return_authorization_url(@order, @return_authorization, :e => 'receive'), :method => :put, :icon => 'download-alt' %>
     <% end %>
   </li>
   <li>
     <% if @return_authorization.can_cancel? %>
-      <%= button_link_to Spree.t('actions.cancel'), fire_admin_order_return_authorization_url(@order, @return_authorization, :e => 'cancel'), :method => :put, :data => { :confirm => Spree.t(:are_you_sure) }, :icon => 'remove' %>
+      <%= button_link_to Spree.t('actions.cancel'), fire_admin_order_return_authorization_url(@order, @return_authorization, :e => 'cancel'), :method => :put, :icon => 'remove' %>
     <% end %>
   </li>
 <% end %>


### PR DESCRIPTION
When I tried to confirm (mark as received) a RMA a javascript confirm popup shows up twice.
After that the page did not reload, saw a quick "Loading" message but nothing happened.
Same if you press the Cancel button.

I tested this and some how the `:data => { :confirm => Spree.t(:are_you_sure) }` in the button_link_to tags causes this behavior.

I removed the confirm messages and the returns works perfect again.
