### PR TITLE
remove 2-3-stable gem dependencies

### DIFF
--- a/cmd/lib/spree_cmd/templates/extension/Gemfile
+++ b/cmd/lib/spree_cmd/templates/extension/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'spree', github: 'spree/spree', branch: '2-3-stable'
+gem 'spree', github: 'spree/spree', branch: 'master'
 # Provides basic authentication functionality for testing parts of your engine
-gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: '2-3-stable'
+gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: 'master'
 
 gemspec

--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -10,7 +10,7 @@ fi
 
 cd ./sandbox
 echo "gem 'spree', :path => '..'" >> Gemfile
-echo "gem 'spree_auth_devise', :github => 'spree/spree_auth_devise', :branch => '2-3-stable'" >> Gemfile
+echo "gem 'spree_auth_devise', :github => 'spree/spree_auth_devise', :branch => 'master'" >> Gemfile
 
 bundle install --gemfile Gemfile
 bundle exec rails g spree:install --auto-accept --user_class=Spree::User


### PR DESCRIPTION
since spree got bumped to 2.4.0.beta

this was breaking `bundle exec rake sandbox`
