### PR TITLE
Take adjustments into consideration when calculating RMA totals

### DIFF
--- a/backend/app/views/spree/admin/return_authorizations/_form.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/_form.html.erb
@@ -3,28 +3,30 @@
     <thead>
       <tr data-hook="rma_header">
         <th><%= Spree.t(:product) %></th>
+        <th><%= Spree.t(:total_per_item) %></th>
         <th><%= Spree.t(:quantity_shipped) %></th>
         <th><%= Spree.t(:quantity_returned) %></th>
         <th><%= Spree.t(:return_quantity) %></th>
       </tr>
     </thead>
     <tbody>
-      <% @return_authorization.order.shipments.shipped.collect{|s| s.inventory_units.to_a}.flatten.group_by(&:variant).each do | variant, units| %>
-        <tr id="<%= dom_id(variant) %>" data-hook="rma_row" class="<%= cycle('odd', 'even')%>">
+      <% @return_authorization.order.line_items.each do |line_item| %>
+        <% next if line_item.inventory_units.shipped.none? %>
+        <tr id="<%= dom_id(line_item) %>" data-hook="rma_row" class="<%= cycle('odd', 'even')%>">
           <td>
-            <div class="variant-name"><%= variant.name %></div>
-            <div class="variant-options"><%= variant.options_text %></div>
+            <div class="variant-name"><%= line_item.variant.name %></div>
+            <div class="variant-options"><%= line_item.variant.options_text %></div>
           </td>
-          <td class="align-center"><%= units.select(&:shipped?).size %></td>
-          <td class="align-center"><%= units.select(&:returned?).size %></td>
+          <td class="align-center"><%= line_item.display_rounded_total_per_item %></td>
+          <td class="align-center"><%= line_item.inventory_units.shipped.size %></td>
+          <td class="align-center"><%= line_item.inventory_units.returned.size %></td>
           <td class="return_quantity align-center">
             <% if @return_authorization.received? %>
-              <%= @return_authorization.inventory_units.group_by(&:variant)[variant].try(:size) || 0 %>
-            <% elsif units.select(&:shipped?).empty? %>
-              0
+              <%= @return_authorization.inventory_units.group_by(&:variant)[line_item.variant].try(:size) || 0 %>
             <% else %>
-              <%= number_field_tag "return_quantity[#{variant.id}]",
-                @return_authorization.inventory_units.group_by(&:variant)[variant].try(:size) || 0, {:style => 'width:100px;', :min => 0} %>
+              <% returning_count = @return_authorization.inventory_units.group_by(&:variant)[line_item.variant].try(:size) || 0 %>
+              <%= number_field_tag "return_quantity[#{line_item.variant.id}]", returning_count, { :style => 'width:100px;',
+                  :min => 0, :max => line_item.inventory_units.shipped.size, "data-line-item-id" => line_item.id} %>
             <% end %>
           </td>
         </tr>
@@ -56,9 +58,9 @@
 </div>
 
 <script>
-  var line_item_prices = {};
-  <% @return_authorization.order.line_items.group_by(&:variant).each do | variant, items| %>
-    line_item_prices[<%= variant.id.to_s %>] = <%= items.first.price %>;
+  var line_item_amounts = {};
+  <% @return_authorization.order.line_items.each do |line_item| %>
+    line_item_amounts[<%= line_item.id.to_s %>] = <%= line_item.rounded_total_per_item %>;
   <% end %>
 
   $(document).ready(function(){
@@ -66,8 +68,8 @@
     $("td.return_quantity input").on('change', function() {
       var rma_amount = 0;
       $.each($("td.return_quantity input"), function(i, input) {
-        var variant_id = $(input).prop('id').replace("return_quantity_", "");
-         rma_amount += line_item_prices[variant_id] * $(input).val()
+        var line_item_id = $(input).data('line-item-id');
+        rma_amount += line_item_amounts[line_item_id] * $(input).val();
       });
 
       if(!isNaN(rma_amount)){

--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -7,7 +7,9 @@ module Spree
     belongs_to :line_item, class_name: "Spree::LineItem", inverse_of: :inventory_units
 
     scope :backordered, -> { where state: 'backordered' }
+    scope :on_hand, -> { where state: 'on_hand' }
     scope :shipped, -> { where state: 'shipped' }
+    scope :returned, -> { where state: 'returned' }
     scope :backordered_per_variant, ->(stock_item) do
       includes(:shipment, :order)
         .where("spree_shipments.state != 'canceled'").references(:shipment)

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -58,7 +58,7 @@ module Spree
     end
 
     def final_amount
-      amount + adjustment_total.to_f
+      amount + adjustment_total
     end
     alias total final_amount
 
@@ -93,6 +93,16 @@ module Spree
     # Remove variant default_scope `deleted_at: nil`
     def variant
       Spree::Variant.unscoped { super }
+    end
+
+    # Rounding down so that:
+    #   total_per_item * quantity <= total
+    def rounded_total_per_item
+      (total / quantity).round(2, :down)
+    end
+
+    def display_rounded_total_per_item
+      Spree::Money.new(rounded_total_per_item, { currency: currency })
     end
 
     private

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1106,6 +1106,7 @@ en:
     time: Time
     to_add_variants_you_must_first_define: To add variants, you must first define
     total: Total
+    total_per_item: Total per item
     total_price: Total price
     total_sales: Total Sales
     track_inventory: Track Inventory

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -148,6 +148,44 @@ describe Spree::LineItem do
     end
   end
 
+  describe '#rounded_total_per_item' do
+    context "adjustments are evenly divided between items" do
+      before do
+        line_item.price = 10
+        line_item.quantity = 2
+        line_item.adjustment_total = -4
+      end
+
+      it "returns the exact total" do
+        line_item.rounded_total_per_item.should eq 8
+      end
+    end
+
+    context "adjustments are not evenly divided between items" do
+      before do
+        line_item.price = 2
+        line_item.quantity = 3
+        line_item.adjustment_total = -4
+      end
+
+      it "returns the rounded down total" do
+        line_item.rounded_total_per_item.should eq 0.66
+      end
+    end
+  end
+
+  describe '#display_rounded_total_per_item' do
+    before do
+      line_item.price = 10.4
+      line_item.quantity = 1
+      line_item.adjustment_total = 0
+    end
+
+    it "returns a Spree::Money representing total per item" do
+      line_item.display_rounded_total_per_item.to_s.should == "$10.40"
+    end
+  end
+
   context "has inventory (completed order so items were already unstocked)" do
     let(:order) { Spree::Order.create(email: 'spree@example.com') }
     let(:variant) { create(:variant) }


### PR DESCRIPTION
- Added #total_per_item to line_item that calculates total per item including adjustments
- Added new column in the RMA admin screen to display the total per item for a variant
- Updated javascript that suggests the RMA total to use the total per item when calculating
