### PR TITLE
Info for products with multiple variants (Issue #2256)

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/sections/_products.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_products.scss
@@ -16,6 +16,12 @@
   }
 }
 
+[data-hook="admin_product_form_multiple_variants"] {
+  .info-actions {
+    text-align: right;
+  }
+}
+
 .outstanding-balance {
   margin-bottom: 15px;
   text-transform: uppercase;

--- a/backend/app/assets/stylesheets/spree/backend/shared/_typography.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_typography.scss
@@ -77,6 +77,12 @@ ul {
   }
 }
 
+ul.text_list {
+  border-top: none;
+  margin: 0;
+  list-style: disc inside none;
+}
+
 dl {
   width: 100%;
   overflow: hidden;

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -60,7 +60,26 @@
       <% end %>
     </div>
 
-    <% unless @product.has_variants? %>
+    <% if @product.has_variants? %>
+      <div data-hook="admin_product_form_multiple_variants">
+        <%= f.label :skus, Spree.t(:sku).pluralize %>
+        <span class="info">This product has <%= pluralize( @product.variants.count, 'variant' ) %>:
+          <ul class="text_list">
+            <% @product.variants.first(5).each do |variant| %>
+              <li><%= variant.sku %></li>
+            <% end %>
+          </ul>
+          <% if @product.variants.count > 5 %>
+            and <%= pluralize( @product.variants.count - 5, 'other' ) %>
+          <% end %>
+        </span>
+        <div class="info-actions">
+          <% if can?(:admin, Spree::Variant) %>
+            <%= link_to_with_icon 'th-large', 'Manage Variants',  admin_product_variants_url(@product) %>
+          <% end %>
+        </div>
+      </div>
+    <% else %>
       <div data-hook="admin_product_form_sku">
         <%= f.field_container :sku do %>
           <%= f.label :sku, Spree.t(:sku) %>


### PR DESCRIPTION
Setting SKUs for products with multiple variants can be confusing for novice users.

This adds a note on the product form in the place where the SKU field would normally appear. It lists several variant SKUs and invites the user to manage product variants.
