### PR TITLE
Move set_shipments_cost call to Order#update_from_params

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -9,10 +9,7 @@ module Spree
     checkout_flow do
       go_to_state :address
       go_to_state :delivery
-      go_to_state :payment, if: ->(order) do
-        order.set_shipments_cost if order.shipments.any?
-        order.payment_required?
-      end
+      go_to_state :payment, if: ->(order) { order.payment_required? }
       go_to_state :confirm, if: ->(order) { order.confirmation_required? }
       go_to_state :complete
       remove_transition from: :delivery, to: :confirm

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -230,6 +230,7 @@ module Spree
               end
 
               success = self.update_attributes(attributes)
+              set_shipments_cost if self.shipments.any?
             end
             @updating_params = nil
             success

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -192,6 +192,7 @@ describe Spree::Order do
         context "with a shipment that has a price" do
           before do
             shipment.shipping_rates.first.update_column(:cost, 10)
+            order.set_shipments_cost
           end
 
           it "transitions to payment" do
@@ -203,6 +204,7 @@ describe Spree::Order do
         context "with a shipment that is free" do
           before do
             shipment.shipping_rates.first.update_column(:cost, 0)
+            order.set_shipments_cost
           end
 
           it "skips payment, transitions to complete" do

--- a/frontend/spec/features/free_item_spec.rb
+++ b/frontend/spec/features/free_item_spec.rb
@@ -1,0 +1,87 @@
+require 'spec_helper'
+
+# Gigantic regression test for #2191
+describe "Free shipping promotions", :js => true do
+  let!(:country) { create(:country, :name => "United States of America", :states_required => true) }
+  let!(:state) { create(:state, :name => "Alabama", :country => country) }
+  let!(:zone) { create(:zone) }
+  let!(:shipping_method) do 
+    sm = create(:shipping_method)
+    sm.calculator.preferred_amount = 10
+    sm.calculator.save
+    sm
+  end
+
+  let!(:payment_method) { create(:check_payment_method) }
+  let!(:product) { create(:product, :name => "RoR Mug", :price => 20) }
+  let!(:free_product) { create(:product, :name => "RoR Shirt", :price => 20) }
+  let!(:promotion) do
+    promotion = Spree::Promotion.create!(:name       => "Free Shirt!",
+                                         :starts_at  => 1.day.ago,
+                                         :expires_at => 1.day.from_now,
+                                         :code       => "freeshirt")
+
+    action_1 = Spree::Promotion::Actions::CreateLineItems.new
+    action_1.promotion_action_line_items.build(
+      :variant => free_product.master,
+      :quantity => 1
+    )
+    action_1.promotion = promotion
+    action_1.save
+
+    action_2 = Spree::Promotion::Actions::CreateAdjustment.new
+    action_2.calculator = Spree::Calculator::FlatRate.new
+    action_2.calculator.preferred_amount = 20
+    action_2.promotion = promotion
+
+    action_2.save
+
+    promotion.reload # so that promotion.actions is available
+  end
+
+  context "promotion with free line item" do
+    before do
+
+      visit spree.root_path
+      click_link "RoR Mug"
+      click_button "add-to-cart-button"
+      fill_in "order_coupon_code", :with => "freeshirt"
+      click_button "Update"
+
+      all("a.delete").first.click # Delete the first line item
+      page.should_not have_content("RoR Mug")
+      page.should have_content("RoR Shirt")
+      page.should have_content("Adjustment: Promotion (Free Shirt!) -$20.00")
+      page.should have_content("Total $0.00")
+
+      click_button "Checkout"
+      fill_in "order_email", :with => "spree@example.com"
+      fill_in "First Name", :with => "John"
+      fill_in "Last Name", :with => "Smith"
+      fill_in "Street Address", :with => "1 John Street"
+      fill_in "City", :with => "City of John"
+      fill_in "Zip", :with => "01337"
+      select country.name, :from => "Country"
+      select state.name, :from => "order[bill_address_attributes][state_id]"
+      fill_in "Phone", :with => "555-555-5555"
+
+      # To shipping method screen
+      click_button "Save and Continue"
+      # To payment screen
+      click_button "Save and Continue"
+    end
+
+    # The actual regression test for #2191
+    it "does not skip the payment step" do
+      # The bug is that it skips the payment step because the shipment cost has not been set for the order.
+      # Therefore we are checking here that it's *definitely* on the payment step and hasn't jumped to complete.
+      page.current_url.should =~ /checkout\/payment/
+
+      within("#checkout-summary") do
+        page.should have_content("Shipping total  $10.00")
+        page.should have_content("Promotion (Free Shirt!): -$20.00")
+        page.should have_content("Order Total: $10.00")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This stops the method from being called whenever Order#checkout_steps is called and thereby reduces some queries that shouldn't be happening.

A much neater fix for #2191.

This should apply to 2-2-stable, 2-3-stable and master.
