### PR TITLE
Optimize available_countries

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -118,7 +118,7 @@ module Spree
       countries.collect do |country|
         country.name = Spree.t(country.iso, scope: 'country_names', default: country.name)
         country
-      end.sort { |a, b| a.name.parameterize <=> b.name.parameterize }
+      end.sort_by { |c| c.name.parameterize }
     end
 
     def seo_url(taxon)


### PR DESCRIPTION
`.parameterize` is a little bit slow. With the existing code, it was run twice for each comparison. Using `sort_by`, we run it only once per each country.

One way to look at this (for anyone bored or into comp sci) is that we were running `parameterize` `O(N log N)` times (being the number of comparisons sort will do). With sort_by we will run `parameterize` `O(N)` times and only run the (much faster) string comparison `O(N log N)` times.

An [unscientific benchmark](https://gist.github.com/jhawthorn/e3ff375ff246ddce982f) on a 2.2 sandbox shows this improving `available_countries` from about 165 ms to about 30 ms.

This can be applied as far back as 2-0-stable
