### PR TITLE
adjustment_state (icon) returns 'fa fa-lock'

### DIFF
--- a/backend/app/helpers/spree/admin/adjustments_helper.rb
+++ b/backend/app/helpers/spree/admin/adjustments_helper.rb
@@ -4,7 +4,7 @@ module Spree
       def adjustment_state(adjustment)
         state = adjustment.state.to_sym
         icon = { closed: 'lock', open: 'unlock' }
-        content_tag(:span, '', class: icon[state])
+        content_tag(:span, '', class: "fa fa-#{ icon[state] }")
       end
 
       def display_adjustable(adjustable)


### PR DESCRIPTION
The adjustment_state helper returned `<span class="lock"></span>` which is not the correct html for an icon.

I edited the helper and it returns the right classname now.
So the icon is visible again.
