### PR TITLE
Add um to spree countries

### DIFF
--- a/core/db/default/spree/countries.rb
+++ b/core/db/default/spree/countries.rb
@@ -227,7 +227,7 @@ Spree::Country.create!([
   { name: "Saint Kitts and Nevis", iso3: "KNA", iso: "KN", iso_name: "SAINT KITTS AND NEVIS", numcode: "659", states_required: true },
   { name: "Serbia", iso3: "SRB", iso: "RS", "iso_name" => "SERBIA", numcode: "999" },
   { name: "Montenegro", iso3: "MNE", iso: "ME", iso_name: "MONTENEGRO", numcode: "499" },
-  { name: "Jersey", iso3: "JEY", iso: "JE", iso_name: "JERSEY", numcode: "44" },
+  { name: "Jersey", iso3: "JEY", iso: "JE", iso_name: "JERSEY", numcode: "832" },
   { name: "United States Minor Outlying Islands", iso3: "UMI", iso: "UM", iso_name: "UNITED STATES MINOR OUTLYING ISLANDS", numcode: "581" },
 ])
 Spree::Config[:default_country_id] = Spree::Country.find_by(name: "United States").id

--- a/core/db/default/spree/countries.rb
+++ b/core/db/default/spree/countries.rb
@@ -227,6 +227,7 @@ Spree::Country.create!([
   { name: "Saint Kitts and Nevis", iso3: "KNA", iso: "KN", iso_name: "SAINT KITTS AND NEVIS", numcode: "659", states_required: true },
   { name: "Serbia", iso3: "SRB", iso: "RS", "iso_name" => "SERBIA", numcode: "999" },
   { name: "Montenegro", iso3: "MNE", iso: "ME", iso_name: "MONTENEGRO", numcode: "499" },
-  { name: "Jersey", iso3: "JEY", iso: "JE", iso_name: "JERSEY", numcode: "44" }
+  { name: "Jersey", iso3: "JEY", iso: "JE", iso_name: "JERSEY", numcode: "44" },
+  { name: "United States Minor Outlying Islands", iso3: "UMI", iso: "UM", iso_name: "UNITED STATES MINOR OUTLYING ISLANDS", numcode: "581" },
 ])
 Spree::Config[:default_country_id] = Spree::Country.find_by(name: "United States").id


### PR DESCRIPTION
Adding the "United States Minor Outlying Islands" country to the Spree default countries list.

Also fixing the number code for Jersey.
