### PR TITLE
Added without_children = true in taxon autocomplete API Call

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js.erb
@@ -20,6 +20,7 @@ $(document).ready(function () {
           return {
             per_page: 50,
             page: page,
+            without_children: true,
             q: {
               name_cont: term
             },


### PR DESCRIPTION
We do not need taxon children in edit product taxon autocomplete. As we were loading taxon children, the response from the server was slow and the children are not used anywhere in autocomplete. My response time have gone down to 900ms from 6 sec after this change (I have around 300 taxons).
