### PR TITLE
Rework ReturnAuthorization-InventoryUnit relationship

### DIFF
--- a/api/app/controllers/spree/api/return_authorizations_controller.rb
+++ b/api/app/controllers/spree/api/return_authorizations_controller.rb
@@ -45,16 +45,6 @@ module Spree
         end
       end
 
-      def add
-        @return_authorization = order.return_authorizations.accessible_by(current_ability, :update).find(params[:id])
-        @return_authorization.add_variant params[:variant_id].to_i, params[:quantity].to_i
-        if @return_authorization.valid?
-          respond_with @return_authorization, default_template: :show
-        else
-          invalid_resource!(@return_authorization)
-        end
-      end
-
       def receive
         @return_authorization = order.return_authorizations.accessible_by(current_ability, :update).find(params[:id])
         if @return_authorization.receive

--- a/api/spec/controllers/spree/api/return_authorizations_controller_spec.rb
+++ b/api/spec/controllers/spree/api/return_authorizations_controller_spec.rb
@@ -105,35 +105,6 @@ module Spree
         json_response.should have_attributes(attributes)
       end
 
-      it "can add an inventory unit to a return authorization on the order" do
-        FactoryGirl.create(:return_authorization, :order => order)
-        return_authorization = order.return_authorizations.first
-        inventory_unit = return_authorization.returnable_inventory.first
-        inventory_unit.should be
-        return_authorization.inventory_units.should be_empty
-        api_put :add, :id => return_authorization.id, variant_id: inventory_unit.variant.id, quantity: 1
-        response.status.should == 200
-        json_response.should have_attributes(attributes)
-        return_authorization.reload.inventory_units.should_not be_empty
-      end
-
-      it "can mark a return authorization as received on the order with an inventory unit" do
-        FactoryGirl.create(:new_return_authorization, :order => order, :stock_location_id => order.shipments.first.stock_location.id)
-        return_authorization = order.return_authorizations.first
-        return_authorization.state.should == "authorized"
-
-        # prep (use a rspec context or a factory instead?)
-        inventory_unit = return_authorization.returnable_inventory.first
-        inventory_unit.should be
-        return_authorization.inventory_units.should be_empty
-        api_put :add, :id => return_authorization.id, variant_id: inventory_unit.variant.id, quantity: 1
-        # end prep
-
-        api_delete :receive, :id => return_authorization.id
-        response.status.should == 200
-        return_authorization.reload.state.should == "received"
-      end
-
       it "cannot mark a return authorization as received on the order with no inventory units" do
         FactoryGirl.create(:new_return_authorization, :order => order)
         return_authorization = order.return_authorizations.first

--- a/backend/app/views/spree/admin/return_authorizations/_form.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/_form.html.erb
@@ -2,33 +2,29 @@
   <table class="index">
     <thead>
       <tr data-hook="rma_header">
+        <th><%= check_box_tag 'select-all' %></th>
         <th><%= Spree.t(:product) %></th>
-        <th><%= Spree.t(:total_per_item) %></th>
-        <th><%= Spree.t(:quantity_shipped) %></th>
-        <th><%= Spree.t(:quantity_returned) %></th>
-        <th><%= Spree.t(:return_quantity) %></th>
+        <th><%= Spree.t(:state) %></th>
+        <th><%= Spree.t(:price) %></th>
       </tr>
     </thead>
     <tbody>
-      <% @return_authorization.order.line_items.each do |line_item| %>
-        <% next if line_item.inventory_units.shipped.none? %>
-        <tr id="<%= dom_id(line_item) %>" data-hook="rma_row" class="<%= cycle('odd', 'even')%>">
-          <td>
-            <div class="variant-name"><%= line_item.variant.name %></div>
-            <div class="variant-options"><%= line_item.variant.options_text %></div>
-          </td>
-          <td class="align-center"><%= line_item.display_rounded_total_per_item %></td>
-          <td class="align-center"><%= line_item.inventory_units.shipped.size %></td>
-          <td class="align-center"><%= line_item.inventory_units.returned.size %></td>
-          <td class="return_quantity align-center">
-            <% if @return_authorization.received? %>
-              <%= @return_authorization.inventory_units.group_by(&:variant)[line_item.variant].try(:size) || 0 %>
-            <% else %>
-              <% returning_count = @return_authorization.inventory_units.group_by(&:variant)[line_item.variant].try(:size) || 0 %>
-              <%= number_field_tag "return_quantity[#{line_item.variant.id}]", returning_count, { :style => 'width:100px;',
-                  :min => 0, :max => line_item.inventory_units.shipped.size, "data-line-item-id" => line_item.id} %>
+      <%= f.fields_for :return_authorization_inventory_units, @form_return_authorization_inventory_units do |unit_fields| %>
+        <% return_authorization_inventory_unit = unit_fields.object %>
+        <% inventory_unit = return_authorization_inventory_unit.inventory_unit %>
+        <tr>
+          <td class="align-center" class="inventory-unit-checkbox">
+            <% if inventory_unit.shipped? %>
+              <%= unit_fields.hidden_field :inventory_unit_id %>
+              <%= unit_fields.check_box :_destroy, {checked: return_authorization_inventory_unit.persisted?, class: 'add-item', "data-price" => inventory_unit.line_item.rounded_total_per_item}, '0', '1' %>
             <% end %>
           </td>
+          <td>
+            <div class="variant-name"><%= inventory_unit.variant.name %></div>
+            <div class="variant-options"><%= inventory_unit.variant.options_text %></div>
+          </td>
+          <td class="align-center"><%= inventory_unit.state.humanize %></td>
+          <td class="align-center"><%= inventory_unit.line_item.display_rounded_total_per_item %></td>
         </tr>
       <% end %>
     </tbody>
@@ -36,11 +32,11 @@
 
   <%= f.field_container :amount do %>
     <%= f.label :amount, Spree.t(:amount) %> <span class="required">*</span><br />
-    <% if @return_authorization.updatable? %>
+    <% if @return_authorization.received? %>
+      <%= @return_authorization.display_amount %>
+    <% else %>
       <%= f.text_field :amount, {:style => 'width:80px;'} %> <%= Spree.t(:rma_value) %>: <span id="rma_value">0.00</span>
       <%= f.error_message_on :amount %>
-    <% else %>
-      <%= @return_authorization.display_amount %>
     <% end %>
   <% end %>
 
@@ -58,23 +54,26 @@
 </div>
 
 <script>
-  var line_item_amounts = {};
-  <% @return_authorization.order.line_items.each do |line_item| %>
-    line_item_amounts[<%= line_item.id.to_s %>] = <%= line_item.rounded_total_per_item %>;
-  <% end %>
-
   $(document).ready(function(){
-    var rma_amount = 0;
-    $("td.return_quantity input").on('change', function() {
+    function updateSuggestedAmount() {
+      $("span#rma_value").html()
       var rma_amount = 0;
-      $.each($("td.return_quantity input"), function(i, input) {
-        var line_item_id = $(input).data('line-item-id');
-        rma_amount += line_item_amounts[line_item_id] * $(input).val();
+      $.each($("input.add-item:checked"), function(i, checkbox) {
+        rma_amount += $(checkbox).data("price");
       });
 
       if(!isNaN(rma_amount)){
         $("span#rma_value").html(rma_amount.toFixed(2));
       }
-    })
+    }
+
+    updateSuggestedAmount();
+
+    $("input#select-all").on("change", function() {
+      $("input.add-item").prop('checked', this.checked);
+      updateSuggestedAmount();
+    });
+
+    $("input.add-item").on("change", updateSuggestedAmount);
   });
 </script>

--- a/backend/app/views/spree/admin/return_authorizations/new.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/new.html.erb
@@ -14,7 +14,7 @@
     <%= render :partial => 'form', :locals => { :f => f } %>
 
     <div class="form-buttons filter-actions actions" data-hook="buttons">
-      <%= button Spree.t(:continue), 'arrow-right' %>
+      <%= button Spree.t(:create), 'ok' %>
       <span class="or"><%= Spree.t(:or) %></span>
       <%= button_link_to Spree.t('actions.cancel'), admin_order_return_authorizations_url(@order), :icon => 'remove' %>
     </div>

--- a/backend/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
@@ -4,9 +4,79 @@ describe Spree::Admin::ReturnAuthorizationsController do
   stub_authorization!
 
   # Regression test for #1370 #3
-  let!(:order) { create(:order) }
+  let!(:order) { create(:shipped_order, line_items_count: 3) }
+  let(:inventory_unit_1) { order.inventory_units.order('id asc')[0] }
+  let(:inventory_unit_2) { order.inventory_units.order('id asc')[1] }
+  let(:inventory_unit_3) { order.inventory_units.order('id asc')[2] }
+
+  let(:params) do
+    {
+      order_id: order.to_param,
+      return_authorization: {amount: 0.0, reason: ""},
+    }
+  end
+
   it "can create a return authorization" do
-    spree_post :create, :order_id => order.to_param, :return_authorization => { :amount => 0.0, :reason => "" }
-    response.should be_success
+    spree_post :create, params
+    response.should redirect_to spree.admin_order_return_authorizations_path(order)
+  end
+
+  context 'update' do
+    let(:return_authorization) { create(:return_authorization, order: order) }
+    let(:params) do
+      super().merge({
+        id: return_authorization.to_param,
+        return_authorization: {amount: 0.0, reason: ""}.merge(inventory_units_params),
+      })
+    end
+
+    subject { spree_put :update, params }
+
+    context "adding an item" do
+      let(:inventory_units_params) do
+        {
+          return_authorization_inventory_units_attributes: {
+            '0' => {inventory_unit_id: inventory_unit_1.to_param},
+          }
+        }
+      end
+
+      context 'without existing items' do
+        it 'creates a new unit' do
+          expect { subject }.to change { Spree::ReturnAuthorizationInventoryUnit.count }.by(1)
+        end
+      end
+
+      context 'with existing items' do
+        let!(:return_authorization_inventory_unit) {
+          create(:return_authorization_inventory_unit, return_authorization: return_authorization, inventory_unit: inventory_unit_1)
+        }
+
+        it 'does not create new units' do
+          expect { subject }.to_not change { Spree::ReturnAuthorizationInventoryUnit.count }
+          expect(assigns[:return_authorization].errors['return_authorization_inventory_units.inventory_unit']).to eq ["has already been taken"]
+        end
+      end
+    end
+
+    context "removing an item" do
+      let!(:return_authorization_inventory_unit) {
+        create(:return_authorization_inventory_unit, return_authorization: return_authorization, inventory_unit: inventory_unit_1)
+      }
+
+      let(:inventory_units_params) do
+        {
+          return_authorization_inventory_units_attributes: {
+            '0' => {id: return_authorization_inventory_unit.to_param, _destroy: '1'},
+          }
+        }
+      end
+
+      context 'with existing items' do
+        it 'removes the unit' do
+          expect { subject }.to change { Spree::ReturnAuthorizationInventoryUnit.count }.by(-1)
+        end
+      end
+    end
   end
 end

--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -6,6 +6,8 @@ module Spree
     belongs_to :return_authorization, class_name: "Spree::ReturnAuthorization"
     belongs_to :line_item, class_name: "Spree::LineItem", inverse_of: :inventory_units
 
+    has_many :return_authorization_inventory_units, inverse_of: :inventory_unit
+
     scope :backordered, -> { where state: 'backordered' }
     scope :on_hand, -> { where state: 'on_hand' }
     scope :shipped, -> { where state: 'shipped' }

--- a/core/app/models/spree/return_authorization_inventory_unit.rb
+++ b/core/app/models/spree/return_authorization_inventory_unit.rb
@@ -1,0 +1,31 @@
+module Spree
+  class ReturnAuthorizationInventoryUnit < Spree::Base
+    belongs_to :return_authorization, inverse_of: :return_authorization_inventory_units
+    belongs_to :inventory_unit, inverse_of: :return_authorization_inventory_units
+    belongs_to :exchange_variant, class: 'Spree::Variant'
+
+    validates :return_authorization, presence: true
+    validates :inventory_unit, presence: true, uniqueness: {scope: :return_authorization}
+
+    scope :received, -> { where.not(received_at: nil) }
+
+    def receive!
+      update_attributes!(received_at: Time.now)
+
+      inventory_unit.return!
+
+      if inventory_unit.variant.should_track_inventory? && stock_item
+        Spree::StockMovement.create!(stock_item_id: stock_item.id, quantity: 1)
+      end
+    end
+
+    private
+
+    def stock_item
+      Spree::StockItem.find_by({
+        variant_id: inventory_unit.variant_id,
+        stock_location_id: return_authorization.stock_location_id,
+      })
+    end
+  end
+end

--- a/core/db/migrate/20140702140656_create_spree_return_authorization_inventory_unit.rb
+++ b/core/db/migrate/20140702140656_create_spree_return_authorization_inventory_unit.rb
@@ -1,0 +1,52 @@
+class CreateSpreeReturnAuthorizationInventoryUnit < ActiveRecord::Migration
+  def up
+    create_table :spree_return_authorization_inventory_units do |t|
+      t.integer :return_authorization_id
+      t.integer :inventory_unit_id
+      t.integer :exchange_variant_id
+      t.datetime :received_at
+
+      t.timestamps
+    end
+
+    execute(<<-SQL)
+      insert into spree_return_authorization_inventory_units
+        (
+          return_authorization_id,
+          inventory_unit_id,
+          received_at,
+          created_at,
+          updated_at
+        )
+      select
+        return_authorization_id,
+        id,
+        case state
+          when 'returned' then updated_at
+          when 'refunded' then updated_at
+          else null
+        end,
+        created_at,
+        '#{Time.now.to_s(:db)}'
+      from spree_inventory_units
+      where return_authorization_id is not null;
+    SQL
+
+    remove_column :spree_inventory_units, :return_authorization_id
+  end
+
+  def down
+    add_column :spree_inventory_units, :return_authorization_id, :integer, after: :shipment_id
+
+    execute(<<-SQL)
+      update spree_inventory_units
+      set return_authorization_id = spree_return_authorization_inventory_units.return_authorization_id
+      from spree_return_authorization_inventory_units
+      where spree_return_authorization_inventory_units.inventory_unit_id = spree_inventory_units.id
+    SQL
+
+    add_index :spree_inventory_units, :return_authorization_id, name: "index_spree_inventory_units_on_return_authorization_id"
+
+    drop_table :spree_return_authorization_inventory_units
+  end
+end

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -60,7 +60,7 @@ module Spree
 
     @@property_attributes = [:name, :presentation]
 
-    @@return_authorization_attributes = [:amount, :reason, :stock_location_id]
+    @@return_authorization_attributes = [:amount, :reason, :stock_location_id, :inventory_units_attributes]
 
     @@shipment_attributes = [
       :order, :special_instructions, :stock_location_id, :id,

--- a/core/lib/spree/testing_support/factories/return_authorization_factory.rb
+++ b/core/lib/spree/testing_support/factories/return_authorization_factory.rb
@@ -10,4 +10,9 @@ FactoryGirl.define do
   factory :new_return_authorization, class: Spree::ReturnAuthorization do
     association(:order, factory: :shipped_order)
   end
+
+  factory :return_authorization_inventory_unit, class: Spree::ReturnAuthorizationInventoryUnit do
+    association(:return_authorization, factory: :return_authorization)
+    association(:inventory_unit, factory: :inventory_unit)
+  end
 end

--- a/core/lib/spree/testing_support/factories/shipment_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipment_factory.rb
@@ -13,6 +13,7 @@ FactoryGirl.define do
       shipment.order.line_items.each do |line_item|
         line_item.quantity.times do
           shipment.inventory_units.create(
+            order_id: shipment.order_id,
             variant_id: line_item.variant_id,
             line_item_id: line_item.id
           )

--- a/core/spec/models/spree/return_authorization_inventory_unit_spec.rb
+++ b/core/spec/models/spree/return_authorization_inventory_unit_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe Spree::ReturnAuthorizationInventoryUnit do
+  describe '#receive!' do
+    let(:return_authorization_inventory_unit) {
+      create(:return_authorization_inventory_unit, {
+        return_authorization: return_authorization,
+        inventory_unit: inventory_unit,
+      })
+    }
+
+    let(:order) { create(:shipped_order, line_items_count: 1) }
+    let(:return_authorization) { create(:return_authorization, order: order, stock_location: stock_location) }
+    let(:stock_location) { create(:stock_location) }
+    let(:inventory_unit) { order.line_items.first.inventory_units.first }
+    let(:stock_item) { stock_location.stock_items.find_by(variant_id: inventory_unit.variant_id) }
+    let(:now) { Time.now }
+
+    subject { return_authorization_inventory_unit.receive! }
+
+    it 'updates received_at' do
+      Timecop.freeze(now) { subject }
+      expect(return_authorization_inventory_unit.received_at).to eq now
+    end
+
+    it 'returns the inventory unit' do
+      subject
+      expect(inventory_unit.reload.state).to eq 'returned'
+    end
+
+    context 'with a stock location' do
+      it 'increases the count on hand' do
+        expect { subject }.to change { stock_item.reload.count_on_hand }.by(1)
+      end
+
+      context 'when variant does not track inventory' do
+        before do
+          inventory_unit.variant.update_attributes!(track_inventory: false)
+        end
+
+        it 'does not increase the count on hand' do
+          expect { subject }.to_not change { stock_item.reload.count_on_hand }
+        end
+      end
+    end
+
+    context 'without a stock location' do
+      let(:stock_location) { nil }
+
+      it 'still works' do
+        expect { subject }.to_not raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Create a join table: `ReturnAuthorizationInventoryUnit`
  - Allows inventory units to be part of multiple RMAs (e.g., if an initial RMA was cancelled) while still retaining historical data
  - Migrate existing data into the new table
  - Drop the `inventory_units.return_authorization_id` column
- Start using nested attributes for adding/removing InventoryUnits to ReturnAuthorizations
  - Remove the `API::ReturnAuthorizationsController#add` endpoint (use nested attributes instead)
- Pave the way for exchanges with an `exchange_variant_id` field
- Update the admin interface for `Admin::ReturnAuthorizationsController`:
  - No longer group inventory units by variant.  This will be important for allowing per-unit data, such as for exchanges

Created by @richardnuno and @jordan-brough
