### PR TITLE
Add missing indexes.

### DIFF
--- a/core/db/migrate/20140703213124_add_missing_indexes.rb
+++ b/core/db/migrate/20140703213124_add_missing_indexes.rb
@@ -1,0 +1,47 @@
+class AddMissingIndexes < ActiveRecord::Migration
+  def change
+    # Below, add a composite index on [:adjustable_type, :adjustable_id]
+    remove_index :spree_adjustments, name: "index_adjustments_on_order_id", column: :order_id
+
+    # Below, add a composite index on [:viewable_type, :viewable_id]
+    remove_index :spree_assets, name: "index_assets_on_viewable_id", column: :viewable_id
+
+    # There doesn't seem to be any reason for this index
+    remove_index :spree_assets, name: "index_assets_on_viewable_type_and_type", column: [:viewable_type, :type]
+
+    add_index :spree_adjustments, :order_id
+    add_index :spree_adjustments, [:adjustable_type, :adjustable_id]
+    add_index :spree_assets, [:viewable_type, :viewable_id]
+    add_index :spree_inventory_units, :return_authorization_id
+    add_index :spree_line_items, :tax_category_id
+    add_index :spree_log_entries, [:source_type, :source_id]
+    add_index :spree_option_types_prototypes, :option_type_id
+    add_index :spree_option_types_prototypes, :prototype_id
+    add_index :spree_option_values_variants, :option_value_id
+    add_index :spree_orders, :approver_id
+    add_index :spree_orders_promotions, :order_id
+    add_index :spree_orders_promotions, :promotion_id
+    add_index :spree_payments, [:source_id, :source_type]
+    add_index :spree_product_option_types, :option_type_id
+    add_index :spree_product_option_types, :product_id
+    add_index :spree_products_taxons, [:product_id, :position]
+    add_index :spree_promotion_action_line_items, :promotion_action_id
+    add_index :spree_promotion_action_line_items, :variant_id
+    add_index :spree_promotion_rules, :promotion_id
+    add_index :spree_promotion_rules, [:id, :type]
+    add_index :spree_properties_prototypes, :property_id
+    add_index :spree_properties_prototypes, :prototype_id
+    add_index :spree_return_authorizations, :order_id
+    add_index :spree_shipping_method_categories, :shipping_category_id
+    add_index :spree_shipping_methods_zones, :shipping_method_id
+    add_index :spree_shipping_methods_zones, :zone_id
+    add_index :spree_shipping_rates, :shipment_id
+    add_index :spree_shipping_rates, :shipping_method_id
+    add_index :spree_states, [:country_id, :name]
+    add_index :spree_stock_items, :variant_id
+    add_index :spree_tax_rates, :tax_category_id
+    add_index :spree_tax_rates, :zone_id
+    add_index :spree_zone_members, :zone_id
+    add_index :spree_zone_members, [:zoneable_id, :zoneable_type]
+  end
+end


### PR DESCRIPTION
Add a bunch of indexes that seem to be missing.

When reviewing, don't accept this blindly. Please take a look and see if what I did makes sense. My approach was:
- Read through schema.rb, focusing on columns ending in _id (but also some with _type).
- If A belongs_to B and it would be likely to start from B and look up A (or if I found some code that starts from B and looks up A), make sure the index exists. E.g., there are lots of references to `order.adjustments` in the code, so I added an index on `order_id` in the `spree_adjustments` table.
- If A belongs_to B and it would be _unlikely_ to start from B and look up A, don't bother adding an index. E.g., you're not likely to have a Spree::Address and look up its associated Spree::Order.
- When in doubt, sometimes I chose to add the index and sometimes I didn't. Depending on how much doubt I had. :grinning: 

I removed a few indexes as well, and commented the reasons for removal.

Deciding which columns to index is hard. People usually either forget to index an abc_id column when they create it, or they index the abc_id column upon creation. In either case, that decision is made without benchmarking because the column has just been created, so you have to go with an educated guess. In my case I could have used benchmarks because these are existing columns. I didn't, though, because every Spree store is different and because I found so many unindexed columns that it didn't seem practical. I couldn't just use specs speed as a proxy because the specs don't deal with large amounts of data that would be influenced by indexes.

So I took my best stab at it.
