### PR TITLE
Rename return_authorization_inventory_units to return_items

### DIFF
--- a/backend/app/controllers/spree/admin/return_authorizations_controller.rb
+++ b/backend/app/controllers/spree/admin/return_authorizations_controller.rb
@@ -2,7 +2,7 @@ module Spree
   module Admin
     class ReturnAuthorizationsController < ResourceController
       belongs_to 'spree/order', :find_by => :number
-      before_filter :load_return_authorization_inventory_units, except: [:fire, :destroy, :index]
+      before_filter :load_return_items, except: [:fire, :destroy, :index]
 
       def fire
         @return_authorization.send("#{params[:e]}!")
@@ -12,16 +12,16 @@ module Spree
 
       private
 
-      # To satisfy how nested attributes works we want to create placeholder ReturnAuthorizationInventoryUnits for
+      # To satisfy how nested attributes works we want to create placeholder ReturnItems for
       # any InventoryUnits that have not already been added to the ReturnAuthorization.
-      def load_return_authorization_inventory_units
+      def load_return_items
         all_inventory_unit_ids = @return_authorization.order.inventory_units.map(&:id)
-        rma_inventory_unit_ids = @return_authorization.return_authorization_inventory_units.map(&:inventory_unit_id)
+        rma_inventory_unit_ids = @return_authorization.return_items.map(&:inventory_unit_id)
 
         new_ids = all_inventory_unit_ids - rma_inventory_unit_ids
-        new_units = new_ids.map { |new_id| Spree::ReturnAuthorizationInventoryUnit.new(inventory_unit_id: new_id) }
+        new_return_items = new_ids.map { |new_id| Spree::ReturnItem.new(inventory_unit_id: new_id) }
 
-        @form_return_authorization_inventory_units = (@return_authorization.return_authorization_inventory_units + new_units).sort_by(&:inventory_unit_id)
+        @form_return_items = (@return_authorization.return_items + new_return_items).sort_by(&:inventory_unit_id)
       end
 
     end

--- a/backend/app/views/spree/admin/return_authorizations/_form.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/_form.html.erb
@@ -9,14 +9,14 @@
       </tr>
     </thead>
     <tbody>
-      <%= f.fields_for :return_authorization_inventory_units, @form_return_authorization_inventory_units do |unit_fields| %>
-        <% return_authorization_inventory_unit = unit_fields.object %>
-        <% inventory_unit = return_authorization_inventory_unit.inventory_unit %>
+      <%= f.fields_for :return_items, @form_return_items do |item_fields| %>
+        <% return_item = item_fields.object %>
+        <% inventory_unit = return_item.inventory_unit %>
         <tr>
           <td class="align-center" class="inventory-unit-checkbox">
             <% if inventory_unit.shipped? %>
-              <%= unit_fields.hidden_field :inventory_unit_id %>
-              <%= unit_fields.check_box :_destroy, {checked: return_authorization_inventory_unit.persisted?, class: 'add-item', "data-price" => inventory_unit.line_item.rounded_total_per_item}, '0', '1' %>
+              <%= item_fields.hidden_field :inventory_unit_id %>
+              <%= item_fields.check_box :_destroy, {checked: return_item.persisted?, class: 'add-item', "data-price" => inventory_unit.line_item.rounded_total_per_item}, '0', '1' %>
             <% end %>
           </td>
           <td>

--- a/backend/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
@@ -26,55 +26,55 @@ describe Spree::Admin::ReturnAuthorizationsController do
     let(:params) do
       super().merge({
         id: return_authorization.to_param,
-        return_authorization: {amount: 0.0, reason: ""}.merge(inventory_units_params),
+        return_authorization: {amount: 0.0, reason: ""}.merge(return_items_params),
       })
     end
 
     subject { spree_put :update, params }
 
     context "adding an item" do
-      let(:inventory_units_params) do
+      let(:return_items_params) do
         {
-          return_authorization_inventory_units_attributes: {
+          return_items_attributes: {
             '0' => {inventory_unit_id: inventory_unit_1.to_param},
           }
         }
       end
 
       context 'without existing items' do
-        it 'creates a new unit' do
-          expect { subject }.to change { Spree::ReturnAuthorizationInventoryUnit.count }.by(1)
+        it 'creates a new item' do
+          expect { subject }.to change { Spree::ReturnItem.count }.by(1)
         end
       end
 
       context 'with existing items' do
-        let!(:return_authorization_inventory_unit) {
-          create(:return_authorization_inventory_unit, return_authorization: return_authorization, inventory_unit: inventory_unit_1)
+        let!(:return_item) {
+          create(:return_item, return_authorization: return_authorization, inventory_unit: inventory_unit_1)
         }
 
-        it 'does not create new units' do
-          expect { subject }.to_not change { Spree::ReturnAuthorizationInventoryUnit.count }
-          expect(assigns[:return_authorization].errors['return_authorization_inventory_units.inventory_unit']).to eq ["has already been taken"]
+        it 'does not create new items' do
+          expect { subject }.to_not change { Spree::ReturnItem.count }
+          expect(assigns[:return_authorization].errors['return_items.inventory_unit']).to eq ["has already been taken"]
         end
       end
     end
 
     context "removing an item" do
-      let!(:return_authorization_inventory_unit) {
-        create(:return_authorization_inventory_unit, return_authorization: return_authorization, inventory_unit: inventory_unit_1)
+      let!(:return_item) {
+        create(:return_item, return_authorization: return_authorization, inventory_unit: inventory_unit_1)
       }
 
-      let(:inventory_units_params) do
+      let(:return_items_params) do
         {
-          return_authorization_inventory_units_attributes: {
-            '0' => {id: return_authorization_inventory_unit.to_param, _destroy: '1'},
+          return_items_attributes: {
+            '0' => {id: return_item.to_param, _destroy: '1'},
           }
         }
       end
 
       context 'with existing items' do
-        it 'removes the unit' do
-          expect { subject }.to change { Spree::ReturnAuthorizationInventoryUnit.count }.by(-1)
+        it 'removes the item' do
+          expect { subject }.to change { Spree::ReturnItem.count }.by(-1)
         end
       end
     end

--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -6,7 +6,7 @@ module Spree
     belongs_to :return_authorization, class_name: "Spree::ReturnAuthorization"
     belongs_to :line_item, class_name: "Spree::LineItem", inverse_of: :inventory_units
 
-    has_many :return_authorization_inventory_units, inverse_of: :inventory_unit
+    has_many :return_items, inverse_of: :inventory_unit
 
     scope :backordered, -> { where state: 'backordered' }
     scope :on_hand, -> { where state: 'on_hand' }

--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -2,14 +2,14 @@ module Spree
   class ReturnAuthorization < Spree::Base
     belongs_to :order, class_name: 'Spree::Order'
 
-    has_many :return_authorization_inventory_units, inverse_of: :return_authorization, dependent: :destroy
-    has_many :inventory_units, through: :return_authorization_inventory_units
+    has_many :return_items, inverse_of: :return_authorization, dependent: :destroy
+    has_many :inventory_units, through: :return_items
     has_many :refunds
     belongs_to :stock_location
     before_create :generate_number
     before_validation :force_positive_amount
 
-    accepts_nested_attributes_for :return_authorization_inventory_units, allow_destroy: true
+    accepts_nested_attributes_for :return_items, allow_destroy: true
 
     validates :order, presence: true
     validates :amount, numericality: { greater_than_or_equal_to: 0 }
@@ -99,7 +99,7 @@ module Spree
       end
 
       def process_return
-        return_authorization_inventory_units.includes(:inventory_unit).each(&:receive!)
+        return_items.includes(:inventory_unit).each(&:receive!)
 
         order.return if inventory_units.all?(&:returned?)
       end

--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -1,7 +1,7 @@
 module Spree
-  class ReturnAuthorizationInventoryUnit < Spree::Base
-    belongs_to :return_authorization, inverse_of: :return_authorization_inventory_units
-    belongs_to :inventory_unit, inverse_of: :return_authorization_inventory_units
+  class ReturnItem < Spree::Base
+    belongs_to :return_authorization, inverse_of: :return_items
+    belongs_to :inventory_unit, inverse_of: :return_items
     belongs_to :exchange_variant, class: 'Spree::Variant'
 
     validates :return_authorization, presence: true

--- a/core/db/migrate/20140707125621_rename_return_authorization_inventory_unit_to_return_items.rb
+++ b/core/db/migrate/20140707125621_rename_return_authorization_inventory_unit_to_return_items.rb
@@ -1,0 +1,5 @@
+class RenameReturnAuthorizationInventoryUnitToReturnItems < ActiveRecord::Migration
+  def change
+    rename_table :spree_return_authorization_inventory_units, :spree_return_items
+  end
+end

--- a/core/lib/spree/testing_support/factories/return_authorization_factory.rb
+++ b/core/lib/spree/testing_support/factories/return_authorization_factory.rb
@@ -11,7 +11,7 @@ FactoryGirl.define do
     association(:order, factory: :shipped_order)
   end
 
-  factory :return_authorization_inventory_unit, class: Spree::ReturnAuthorizationInventoryUnit do
+  factory :return_item, class: Spree::ReturnItem do
     association(:return_authorization, factory: :return_authorization)
     association(:inventory_unit, factory: :inventory_unit)
   end

--- a/core/spec/models/spree/return_authorization_spec.rb
+++ b/core/spec/models/spree/return_authorization_spec.rb
@@ -57,7 +57,7 @@ describe Spree::ReturnAuthorization do
     let(:inventory_unit) { order.shipments.first.inventory_units.first }
 
     context "to the initial stock location" do
-      let!(:return_authorization_inventory_unit) { create(:return_authorization_inventory_unit, inventory_unit: inventory_unit, return_authorization: return_authorization) }
+      let!(:return_item) { create(:return_item, inventory_unit: inventory_unit, return_authorization: return_authorization) }
 
       before do
         return_authorization.stub(:stock_location_id => inventory_unit.shipment.stock_location.id)
@@ -90,7 +90,7 @@ describe Spree::ReturnAuthorization do
 
     context "to a different stock location" do
       let(:new_stock_location) { create(:stock_location, :name => "other") }
-      let!(:return_authorization_inventory_unit) { create(:return_authorization_inventory_unit, inventory_unit: inventory_unit, return_authorization: return_authorization) }
+      let!(:return_item) { create(:return_item, inventory_unit: inventory_unit, return_authorization: return_authorization) }
 
       before do
         return_authorization.stub(:stock_location_id => new_stock_location.id)

--- a/core/spec/models/spree/return_item_spec.rb
+++ b/core/spec/models/spree/return_item_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
-describe Spree::ReturnAuthorizationInventoryUnit do
+describe Spree::ReturnItem do
   describe '#receive!' do
-    let(:return_authorization_inventory_unit) {
-      create(:return_authorization_inventory_unit, {
+    let(:return_item) {
+      create(:return_item, {
         return_authorization: return_authorization,
         inventory_unit: inventory_unit,
       })
@@ -16,11 +16,11 @@ describe Spree::ReturnAuthorizationInventoryUnit do
     let(:stock_item) { stock_location.stock_items.find_by(variant_id: inventory_unit.variant_id) }
     let(:now) { Time.now }
 
-    subject { return_authorization_inventory_unit.receive! }
+    subject { return_item.receive! }
 
     it 'updates received_at' do
       Timecop.freeze(now) { subject }
-      expect(return_authorization_inventory_unit.received_at).to eq now
+      expect(return_item.received_at).to eq now
     end
 
     it 'returns the inventory unit' do


### PR DESCRIPTION
Shortening the name of return_authorization_inventory_units since it was becoming a nuisance.

Generated by @jordan-brough and @richardnuno
