### PR TITLE
fix Order#reload method signature

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -572,7 +572,7 @@ module Spree
       self.ensure_updated_shipments
     end
 
-    def reload
+    def reload(options=nil)
       remove_instance_variable(:@tax_zone) if defined?(@tax_zone)
       super
     end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -628,4 +628,13 @@ describe Spree::Order do
       order.tax_total.should eq 30
     end
   end
+
+  # Regression test for #4923
+  context "locking" do
+    let(:order) { Spree::Order.create } # need a persisted in order to test locking
+
+    it 'can lock' do
+      expect { order.with_lock {} }.to_not raise_error
+    end
+  end
 end


### PR DESCRIPTION
ActiveRecord::Base#reload accepts an `options` argument: https://github.com/rails/rails/blob/v4.1.4/activerecord/lib/active_record/persistence.rb#L386
This code was failing for me:

```
>> Spree::Order.first.with_lock { }
ArgumentError: wrong number of arguments (1 for 0)
from /Users/jordan/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/bundler/gems/spree-287d40eaf236/core/app/models/spree/order.rb:592:in `reload'
```
