### PR TITLE
remove top and bottom pixels from admin nav

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
@@ -80,6 +80,11 @@ nav.menu {
       position: relative;
       text-align: center;
 
+      @media(max-width: 1009px) {
+        top: -3px;
+        margin-bottom: -5px;
+      }
+
       i {
         display: inline;
       }


### PR DESCRIPTION
This has been a bug in the CSS that has been bugging me since the dawn of time. Spent five minutes of my life time to get this fixed.

The original design:

![screen shot 2014-07-07 at 1 20 56 pm](https://cloud.githubusercontent.com/assets/3117356/3501555/a1aafe0c-0617-11e4-9c1e-ba3204f53043.png)
![screen shot 2014-07-07 at 1 21 02 pm](https://cloud.githubusercontent.com/assets/3117356/3501558/ad95aeb0-0617-11e4-840e-1e76b1e0e868.png)
![screen shot 2014-07-07 at 1 21 06 pm](https://cloud.githubusercontent.com/assets/3117356/3501562/b1d1fc0e-0617-11e4-9984-d8303af58a00.png)
![screen shot 2014-07-07 at 1 21 09 pm](https://cloud.githubusercontent.com/assets/3117356/3501564/b76af26a-0617-11e4-9c20-b34f501ce3dc.png)

The fix:

![screen shot 2014-07-07 at 1 38 23 pm](https://cloud.githubusercontent.com/assets/3117356/3501582/d5c0a444-0617-11e4-9abc-8ba9d35c7920.png)
![screen shot 2014-07-07 at 1 38 28 pm](https://cloud.githubusercontent.com/assets/3117356/3501583/d5c0caaa-0617-11e4-8ba0-d9c9e4d66b26.png)
![screen shot 2014-07-07 at 1 38 31 pm](https://cloud.githubusercontent.com/assets/3117356/3501584/d5c10402-0617-11e4-8872-03d79e7d6aac.png)
![screen shot 2014-07-07 at 1 38 33 pm](https://cloud.githubusercontent.com/assets/3117356/3501585/d5c255e6-0617-11e4-9116-0d552fdc6eda.png)
![screen shot 2014-07-07 at 1 38 36 pm](https://cloud.githubusercontent.com/assets/3117356/3501586/d5c26234-0617-11e4-9b53-996393736907.png)

When I was editing, I thought about just upping the padding to 28px top and bottom, which worked in dev tools, but did not work when reloading the page. Those stupid 3 pixels just added themselves on top.

The Hack:

``` css
@media(max-width: 1009px) {
  top: -3px;
  margin-bottom: -5px;
}
```
