### PR TITLE
Disassociate inventory units when a ReturnAuthorization is destroyed

### DIFF
--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -2,7 +2,7 @@ module Spree
   class ReturnAuthorization < ActiveRecord::Base
     belongs_to :order, class_name: 'Spree::Order'
 
-    has_many :inventory_units
+    has_many :inventory_units, dependent: :nullify
     belongs_to :stock_location
     before_create :generate_number
     before_save :force_positive_amount

--- a/core/spec/models/spree/return_authorization_spec.rb
+++ b/core/spec/models/spree/return_authorization_spec.rb
@@ -196,4 +196,17 @@ describe Spree::ReturnAuthorization do
       return_authorization.returnable_inventory.should == []
     end
   end
+
+  context "destroy" do
+    before do
+      return_authorization.add_variant(variant.id, 1)
+      return_authorization.destroy
+    end
+
+    # Regression test for #4935
+    it "disassociates inventory units" do
+      expect(Spree::InventoryUnit.where(return_authorization_id: return_authorization.id).count).to eq 0
+    end
+  end
+
 end


### PR DESCRIPTION
Avoid leaving the inventory units in a bad state.

This is based on the 2-2-stable branch.  It would be great to get it in as a fix.
