### PR TITLE
Two tiny style fixes for backend

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_date-picker.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_date-picker.scss
@@ -9,6 +9,7 @@
 
 #ui-datepicker-div {
   @include border-radius($border-radius);
+
   border-color: $color-3;
   padding: 0;
   margin-top: 10px;
@@ -23,6 +24,7 @@
     margin-top: -10px;
     left: 25px;
     z-index: 1;
+    display: block;
   }
 
   .ui-datepicker-header {
@@ -47,14 +49,15 @@
       }
 
       .ui-icon {
+        @extend [class^="icon-"]:before;
+        @extend .fa;
+
         background-image: none;
         text-indent: 0;
         color: $color-1;
         width: 10px;
         margin-left: -5px;
-        @extend [class^="icon-"]:before;
-        @extend .fa;
-
+        
         &:hover {
           color: very-light($color-2, 25);
         }

--- a/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
@@ -51,6 +51,10 @@ nav.menu {
         color: $color-body-text;
       }
 
+      &.fa:before {
+        padding-right: 4px;
+      }
+
       &:hover {
         i {
           color: $color-2;


### PR DESCRIPTION
Hey @radar! Two very small fixes for backend. 
First fixes arrow style for datepicker - it should be triangle but was square because of one missing line in css. 
Second adds small padding to top navigation (account/logout/visit store).

P.S. I want to start contributing again to spree, so this is just a "cold start". I hope more to come.
