### PR TITLE
Make best-promotion query more deterministic

### DIFF
--- a/core/app/models/spree/item_adjustments.rb
+++ b/core/app/models/spree/item_adjustments.rb
@@ -71,7 +71,7 @@ module Spree
     end
 
     def best_promotion_adjustment
-      @best_promotion_adjustment ||= adjustments.promotion.eligible.reorder("amount ASC, created_at DESC").first
+      @best_promotion_adjustment ||= adjustments.promotion.eligible.reorder("amount ASC, created_at DESC, id DESC").first
     end
   end
 end

--- a/core/spec/models/spree/item_adjustments_spec.rb
+++ b/core/spec/models/spree/item_adjustments_spec.rb
@@ -115,6 +115,20 @@ module Spree
         line_item.adjustments.promotion.eligible.first.label.should == 'Promotion C'
       end
 
+      it "should choose the most recent promotion adjustment when amounts are equal" do
+        # Using Timecop is a regression test
+        Timecop.freeze do
+          create_adjustment("Promotion A", -200)
+          create_adjustment("Promotion B", -200)
+        end
+        line_item.adjustments.each {|a| a.update_column(:eligible, true)}
+
+        subject.choose_best_promotion_adjustment
+
+        line_item.adjustments.promotion.eligible.count.should == 1
+        line_item.adjustments.promotion.eligible.first.label.should == 'Promotion B'
+      end
+
       context "when previously ineligible promotions become available" do
         let(:order_promo1) { create(:promotion, :with_order_adjustment, :with_item_total_rule, order_adjustment_amount: 5, item_total_threshold_amount: 10) }
         let(:order_promo2) { create(:promotion, :with_order_adjustment, :with_item_total_rule, order_adjustment_amount: 10, item_total_threshold_amount: 20) }


### PR DESCRIPTION
Mostly for the benefit of the specs under MySQL.

This query was generating some sporadic spec failures for me when using MySQL as the database. This is because MySQL does not store fractional seconds so the "created_at" was sometimes the same value for two adjustments when running specs. And when created_at is identical the query below would actually pick the earlier adjustment instead of the more recent one.  Adding "id" as a fallback ordering fixes this problem and makes the behavior more deterministic.

The issue is reproduceable in postgres as well by using Timecop.
