### PR TITLE
Validate price maximum.

### DIFF
--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -5,6 +5,7 @@ module Spree
 
     validate :check_price
     validates :amount, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
+    validate :validate_amount_maximum
 
     def display_amount
       money
@@ -50,5 +51,14 @@ module Spree
       price.to_d
     end
 
+    def maximum_amount
+      BigDecimal '999999.99'
+    end
+
+    def validate_amount_maximum
+      if amount > maximum_amount
+        errors.add :amount, I18n.t('errors.messages.less_than_or_equal_to', count: maximum_amount)
+      end
+    end
   end
 end

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -56,7 +56,7 @@ module Spree
     end
 
     def validate_amount_maximum
-      if amount > maximum_amount
+      if amount && amount > maximum_amount
         errors.add :amount, I18n.t('errors.messages.less_than_or_equal_to', count: maximum_amount)
       end
     end

--- a/core/spec/models/spree/price_spec.rb
+++ b/core/spec/models/spree/price_spec.rb
@@ -5,6 +5,11 @@ describe Spree::Price do
     let(:variant) { stub_model Spree::Variant }
     subject { Spree::Price.new variant: variant, amount: amount }
 
+    context 'when the amount is nil' do
+      let(:amount) { nil }
+      it { should be_valid }
+    end
+
     context 'when the amount is less than 0' do
       let(:amount) { -1 }
 

--- a/core/spec/models/spree/price_spec.rb
+++ b/core/spec/models/spree/price_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe Spree::Price do
+  describe 'validations' do
+    let(:variant) { stub_model Spree::Variant }
+    subject { Spree::Price.new variant: variant, amount: amount }
+
+    context 'when the amount is less than 0' do
+      let(:amount) { -1 }
+
+      it { should have(1).error_on(:amount) }
+      it 'populates errors' do
+        subject.valid?
+        expect(subject.errors.messages[:amount].first).to eq 'must be greater than or equal to 0'
+      end
+    end
+
+    context 'when the amount is greater than 999,999.99' do
+      let(:amount) { 1_000_000 }
+
+      it { should have(1).error_on(:amount) }
+      it 'populates errors' do
+        subject.valid?
+        expect(subject.errors.messages[:amount].first).to eq 'must be less than or equal to 999999.99'
+      end
+    end
+
+    context 'when the amount is between 0 and 999,999.99' do
+      let(:amount) { 100 }
+      it { should be_valid }
+    end
+  end
+end


### PR DESCRIPTION
Price is constrained to be precision: 8, scale: 2 at the database level, but
that validation isn't reflected in the model.

This will lead to errors when prices are 1,000,000 or above, which is a lot in
USD, but 1 million Vietnamese Dongs is less than $50 USD.
