### PR TITLE
Always store the pre_tax_amount for the provided item

### DIFF
--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -58,16 +58,17 @@ module Spree
     # correct rate amounts in the future. For example:
     # https://github.com/spree/spree/issues/4318#issuecomment-34723428
     def self.store_pre_tax_amount(item, rates)
-      if rates.any? { |r| r.included_in_price }
-        case item
-        when Spree::LineItem
-          item_amount = item.discounted_amount
-        when Spree::Shipment
-          item_amount = item.discounted_cost
+      pre_tax_amount = case item
+        when Spree::LineItem then item.discounted_amount
+        when Spree::Shipment then item.discounted_cost
         end
-        pre_tax_amount = item_amount / (1 + rates.map(&:amount).sum)
-        item.update_column(:pre_tax_amount, pre_tax_amount)
+
+      included_rates = rates.select(&:included_in_price)
+      if included_rates.any?
+        pre_tax_amount /= (1 + included_rates.map(&:amount).sum)
       end
+
+      item.update_column(:pre_tax_amount, pre_tax_amount)
     end
 
     # This method is best described by the documentation on #potentially_applicable?

--- a/core/db/migrate/20140709160534_backfill_line_item_pre_tax_amount.rb
+++ b/core/db/migrate/20140709160534_backfill_line_item_pre_tax_amount.rb
@@ -1,0 +1,10 @@
+class BackfillLineItemPreTaxAmount < ActiveRecord::Migration
+  def change
+    # set pre_tax_amount to discounted_amount - included_tax_total
+    execute(<<-SQL)
+      UPDATE spree_line_items
+      SET pre_tax_amount = ((price * quantity) + promo_total) - included_tax_total
+      WHERE pre_tax_amount IS NULL;
+    SQL
+  end
+end

--- a/core/spec/models/spree/tax_rate_spec.rb
+++ b/core/spec/models/spree/tax_rate_spec.rb
@@ -168,6 +168,8 @@ describe Spree::TaxRate do
     context "with line items" do
       let(:line_item) do
         stub_model(Spree::LineItem,
+          :price => 10.0,
+          :quantity => 1,
           :tax_category => tax_category_1,
           :variant => stub_model(Spree::Variant)
         )
@@ -187,7 +189,7 @@ describe Spree::TaxRate do
     end
 
     context "with shipments" do
-      let(:shipments) { [stub_model(Spree::Shipment, :tax_category => tax_category_1)] }
+      let(:shipments) { [stub_model(Spree::Shipment, :cost => 10.0, :tax_category => tax_category_1)] }
 
       before do
         Spree::TaxRate.stub :match => [rate_1, rate_2]


### PR DESCRIPTION
Allows access to pre_tax_amount regardless of whether the item has included tax or not.

Contains migration to backfill nil pre_tax_amounts to the line_item's discounted_amount - included_tax_total.
