### PR TITLE
ActiveMerchant::Billing::AuthorizeNetGateway is not supporting to maestr...

### DIFF
--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -99,7 +99,7 @@ module Spree
 
     def spree_cc_type
       return 'visa' if Rails.env.development?
-      cc_type
+      cc_type == 'maestro' ? 'master' : cc_type # ActiveMerchant::Billing::AuthorizeNetGateway is not supporting to maestro card.
     end
 
     private


### PR DESCRIPTION
ActiveMerchant::Billing::AuthorizeNetGateway is not supporting to maestro card it should be master.
If I check ActiveMerchant::Billing::AuthorizeNetGateway.supports?('maestro') is returning false.
