### PR TITLE
Move old ReturnAuthorizations to LegacyReturnAuthorizations

### DIFF
--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -93,7 +93,7 @@ module Spree
 
       def generate_number
         self.number ||= loop do
-          random = "RMA#{Array.new(9){rand(9)}.join}"
+          random = "RA#{Array.new(9){rand(9)}.join}"
           break random unless self.class.exists?(number: random)
         end
       end

--- a/core/db/migrate/20140702140656_create_spree_return_authorization_inventory_unit.rb
+++ b/core/db/migrate/20140702140656_create_spree_return_authorization_inventory_unit.rb
@@ -1,5 +1,5 @@
 class CreateSpreeReturnAuthorizationInventoryUnit < ActiveRecord::Migration
-  def up
+  def change
     create_table :spree_return_authorization_inventory_units do |t|
       t.integer :return_authorization_id
       t.integer :inventory_unit_id
@@ -8,45 +8,5 @@ class CreateSpreeReturnAuthorizationInventoryUnit < ActiveRecord::Migration
 
       t.timestamps
     end
-
-    execute(<<-SQL)
-      insert into spree_return_authorization_inventory_units
-        (
-          return_authorization_id,
-          inventory_unit_id,
-          received_at,
-          created_at,
-          updated_at
-        )
-      select
-        return_authorization_id,
-        id,
-        case state
-          when 'returned' then updated_at
-          when 'refunded' then updated_at
-          else null
-        end,
-        created_at,
-        '#{Time.now.to_s(:db)}'
-      from spree_inventory_units
-      where return_authorization_id is not null;
-    SQL
-
-    remove_column :spree_inventory_units, :return_authorization_id
-  end
-
-  def down
-    add_column :spree_inventory_units, :return_authorization_id, :integer, after: :shipment_id
-
-    execute(<<-SQL)
-      update spree_inventory_units
-      set return_authorization_id = spree_return_authorization_inventory_units.return_authorization_id
-      from spree_return_authorization_inventory_units
-      where spree_return_authorization_inventory_units.inventory_unit_id = spree_inventory_units.id
-    SQL
-
-    add_index :spree_inventory_units, :return_authorization_id, name: "index_spree_inventory_units_on_return_authorization_id"
-
-    drop_table :spree_return_authorization_inventory_units
   end
 end

--- a/core/db/migrate/20140710041921_recreate_spree_return_authorizations.rb
+++ b/core/db/migrate/20140710041921_recreate_spree_return_authorizations.rb
@@ -1,0 +1,55 @@
+class RecreateSpreeReturnAuthorizations < ActiveRecord::Migration
+  def up
+    # If the app has any legacy return authorizations then rename the table & columns and leave them there
+    # for the spree_legacy_return_authorizations extension to pick up with.
+    # Otherwise just drop the tables/columns as they are no longer used in stock spree.  The spree_legacy_return_authorizations
+    # extension will recreate these tables for dev environments & etc as needed.
+    if Spree::ReturnAuthorization.exists?
+      rename_table :spree_return_authorizations, :spree_legacy_return_authorizations
+      rename_column :spree_inventory_units, :return_authorization_id, :legacy_return_authorization_id
+    else
+      drop_table :spree_return_authorizations
+      remove_column :spree_inventory_units, :return_authorization_id
+    end
+
+    Spree::Adjustment.where(source_type: 'Spree::ReturnAuthorization').update_all(source_type: 'Spree::LegacyReturnAuthorization')
+
+    # For now just recreate the table as it was.  Future changes to the schema (including dropping "amount") will be coming in a
+    # separate commit.
+    create_table :spree_return_authorizations do |t|
+      t.string   "number"
+      t.string   "state"
+      t.decimal  "amount", precision: 10, scale: 2, default: 0.0, null: false
+      t.integer  "order_id"
+      t.text     "reason"
+      t.datetime "created_at"
+      t.datetime "updated_at"
+      t.integer  "stock_location_id"
+    end
+
+  end
+
+  def down
+    drop_table :spree_return_authorizations
+
+    Spree::Adjustment.where(source_type: 'Spree::LegacyReturnAuthorization').update_all(source_type: 'Spree::ReturnAuthorization')
+
+    if table_exists?(:spree_legacy_return_authorizations)
+      rename_table :spree_legacy_return_authorizations, :spree_return_authorizations
+      rename_column :spree_inventory_units, :legacy_return_authorization_id, :return_authorization_id
+    else
+      create_table :spree_return_authorizations do |t|
+        t.string   "number"
+        t.string   "state"
+        t.decimal  "amount", precision: 10, scale: 2, default: 0.0, null: false
+        t.integer  "order_id"
+        t.text     "reason"
+        t.datetime "created_at"
+        t.datetime "updated_at"
+        t.integer  "stock_location_id"
+      end
+      add_column :spree_inventory_units, :return_authorization_id, :integer, after: :shipment_id
+      add_index :spree_inventory_units, :return_authorization_id
+    end
+  end
+end

--- a/core/spec/models/spree/return_authorization_spec.rb
+++ b/core/spec/models/spree/return_authorization_spec.rb
@@ -33,9 +33,9 @@ describe Spree::ReturnAuthorization do
 
         before { return_authorization.stub valid?: true }
 
-        it "should assign number with random RMA number" do
+        it "should assign number with random RA number" do
           return_authorization.save
-          return_authorization.number.should =~ /RMA\d{9}/
+          return_authorization.number.should =~ /RA\d{9}/
         end
       end
     end


### PR DESCRIPTION
After spending a lot of time working on migrating old return authorization data, it's become clear that doing so would be too error prone without presenting considerable risk of damaging existing data.  And/or forever incumbering future development work on Spree by requiring lots of edge cases and special considerations for legacy data.

Instead of migrating the old data, we instead renamed the existing table "return_authorizations" to "legacy_return_authorizations" and created a [spree_legacy_return_authorizations extension](https://github.com/bonobos/spree_legacy_return_authorizations).  Stores that are migrating from old versions of Spree can include that extension to continue viewing and closing-out their legacy data.  The extension does not allow creating any new legacy data.

Some of the reasons that migrating old data would be dangerous are:
- The old system used adjustments and negative payments to provide refunds, whereas the new system uses the "Refund" model.
- The old system does not provide a direct (i.e. completely reliable) link between negative adjustments and return authorizations.
  - The negative adjustment is linked to the order and has a label of "RMA Credit" but it is not linked to the ReturnAuthorization, and an order can have multiple return authorizations.
- The old system does not provide a direct link between negative payments and return authorizations.  See above bullet, plus in the old system it was very possible to create a negative payment that refunded not only the return authorization but also any other negative adjustment that happened to be pending at the time of the negative payment.
- The old system does not store tax amounts separately.  The new system will have fields dedicated to storing tax refund amounts, and trying to pull the data apart was proving very difficult and error prone, especially when you consider that tax zones may have been added/changed or tax rates changed since the time of the refund.  Leaving tax data blank for legacy data also presents unfortunate edge cases and problems.
- The old system never marked a return authorzation as refunded, and figuring that out (see above items) was error prone.  And leaving the return authorzations as non-refunded in the new system could have dangerous side effects.

All these things together made us think that we and other spree stores with legacy return data would be better served by keeping the old data as it was and providing the above extension to display and finish closing out any in-flight return authorizations.

Notes:
- This modifies an existing migration. We're assuming no one is running off spree master and that that's OK at this point.
- We change the "RMA" number prefix to "RA" to prevent conflicts between the old and new tables.

Created by @richardnuno and @jordan-brough
