### PR TITLE
Add blank to ShippingMethod's TaxCategory select

### DIFF
--- a/backend/app/views/spree/admin/shipping_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/_form.html.erb
@@ -77,7 +77,7 @@
     <fieldset class="tax_categories no-border-bottom">
       <legend align="center"><%= Spree.t(:tax_category) %></legend>
         <%= f.field_container :categories do %>
-          <%= f.select :tax_category_id, @tax_categories.map { |tc| [tc.name, tc.id] }, {}, :class => "select2 fullwidth" %>
+          <%= f.select :tax_category_id, @tax_categories.map { |tc| [tc.name, tc.id] }, {include_blank: true}, class: "select2 fullwidth" %>
           <%= error_message_on :shipping_method, :tax_category_id %>
         <% end %>
     </fieldset>


### PR DESCRIPTION
Addresses https://github.com/spree/spree/issues/4914

Now ShippingMethods whose `tax_category` is `nil` will display a blank selector rather than falsely displaying the first TaxCategory in the system.

Note that due to the UI implementation it appears to be impossible to return to selecting `nil` after a TaxCategory has been selected.
