### PR TITLE
Add missing translation

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -750,6 +750,7 @@ en:
     new_zone: New Zone
     next: Next
     no_actions_added: No actions added
+    no_images_found: No images found
     no_orders_found: No orders found
     no_payment_methods_found: No payment methods found
     no_payment_found: No payment found


### PR DESCRIPTION
Can be seen if you edit photos for a product with no photos in the the backend.
