### PR TITLE
Add tax related components and move RMA amount to the return items

### DIFF
--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -106,8 +106,7 @@ module Spree
       ]
 
       @@return_authorization_attributes = [
-        :id, :number, :state, :amount, :order_id, :reason, :created_at,
-        :updated_at
+        :id, :number, :state, :order_id, :reason, :created_at, :updated_at
       ]
 
       @@address_attributes = [

--- a/api/spec/controllers/spree/api/return_authorizations_controller_spec.rb
+++ b/api/spec/controllers/spree/api/return_authorizations_controller_spec.rb
@@ -7,7 +7,7 @@ module Spree
     let!(:order) { create(:shipped_order) }
 
     let(:product) { create(:product) }
-    let(:attributes) { [:id, :reason, :amount, :state] }
+    let(:attributes) { [:id, :reason, :state] }
     let(:resource_scoping) { { :order_id => order.to_param } }
 
     before do
@@ -92,7 +92,7 @@ module Spree
 
       it "can learn how to create a new return authorization" do
         api_get :new
-        json_response["attributes"].should == ["id", "number", "state", "amount", "order_id", "reason", "created_at", "updated_at"]
+        json_response["attributes"].should == ["id", "number", "state", "order_id", "reason", "created_at", "updated_at"]
         required_attributes = json_response["required_attributes"]
         required_attributes.should include("order")
       end
@@ -100,7 +100,7 @@ module Spree
       it "can update a return authorization on the order" do
         FactoryGirl.create(:return_authorization, :order => order)
         return_authorization = order.return_authorizations.first
-        api_put :update, :id => return_authorization.id, :return_authorization => { :amount => 19.99 }
+        api_put :update, :id => return_authorization.id, :return_authorization => { :reason => "ABC" }
         response.status.should == 200
         json_response.should have_attributes(attributes)
       end
@@ -132,7 +132,7 @@ module Spree
       end
 
       it "can add a new return authorization to an existing order" do
-        api_post :create, :order_id => order.number, :return_authorization => { :amount => 14.22, :reason => "Defective" }
+        api_post :create, :order_id => order.number, :return_authorization => { :reason => "Defective" }
         response.status.should == 201
         json_response.should have_attributes(attributes)
         json_response["state"].should_not be_blank
@@ -141,16 +141,16 @@ module Spree
 
     context "as just another user" do
       it "cannot add a return authorization to the order" do
-        api_post :create, :return_autorization => { :order_id => order.number, :amount => 14.22, :reason => "Defective" }
+        api_post :create, :return_autorization => { :order_id => order.number, :reason => "Defective" }
         assert_unauthorized!
       end
 
       it "cannot update a return authorization on the order" do
         FactoryGirl.create(:return_authorization, :order => order)
         return_authorization = order.return_authorizations.first
-        api_put :update, :id => return_authorization.id, :return_authorization => { :amount => 19.99 }
+        api_put :update, :id => return_authorization.id, :return_authorization => { :reason => "ABC" }
         assert_unauthorized!
-        return_authorization.reload.amount.should_not == 19.99
+        return_authorization.reload.reason.should_not == "ABC"
       end
 
       it "cannot delete a return authorization on the order" do

--- a/backend/app/assets/stylesheets/spree/backend/sections/_return_authorizations.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_return_authorizations.scss
@@ -1,0 +1,5 @@
+.return-items-table {
+  .refund-amount-input {
+    width: 80px;
+  }
+}

--- a/backend/app/assets/stylesheets/spree/backend/spree_admin.scss
+++ b/backend/app/assets/stylesheets/spree/backend/spree_admin.scss
@@ -33,6 +33,7 @@
 @import 'spree/backend/sections/promotions';
 @import 'spree/backend/sections/edit_checkouts';
 @import 'spree/backend/sections/bulk_transfer';
+@import 'spree/backend/sections/return_authorizations';
 @import 'spree/backend/sections/tax_zones';
 @import 'spree/backend/sections/log_entries';
 @import 'spree/backend/sections/taxons';

--- a/backend/app/views/spree/admin/return_authorizations/_form.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/_form.html.erb
@@ -1,11 +1,18 @@
 <div data-hook="admin_return_authorization_form_fields">
-  <table class="index">
+  <table class="index return-items-table">
     <thead>
       <tr data-hook="rma_header">
-        <th><%= check_box_tag 'select-all' %></th>
+        <th>
+          <% if @return_authorization.updatable? %>
+            <%= check_box_tag 'select-all' %>
+          <% end %>
+        </th>
         <th><%= Spree.t(:product) %></th>
         <th><%= Spree.t(:state) %></th>
-        <th><%= Spree.t(:price) %></th>
+        <% if @allow_amount_edit %>
+          <th><%= Spree.t(:charged) %></th>
+        <% end %>
+        <th><%= Spree.t(:pre_tax_refund_amount) %></th>
       </tr>
     </thead>
     <tbody>
@@ -14,9 +21,9 @@
         <% inventory_unit = return_item.inventory_unit %>
         <tr>
           <td class="align-center" class="inventory-unit-checkbox">
-            <% if inventory_unit.shipped? %>
+            <% if inventory_unit.shipped? && @return_authorization.updatable? %>
               <%= item_fields.hidden_field :inventory_unit_id %>
-              <%= item_fields.check_box :_destroy, {checked: return_item.persisted?, class: 'add-item', "data-price" => inventory_unit.line_item.rounded_total_per_item}, '0', '1' %>
+              <%= item_fields.check_box :_destroy, {checked: return_item.persisted?, class: 'add-item', "data-price" => return_item.pre_tax_amount}, '0', '1' %>
             <% end %>
           </td>
           <td>
@@ -24,20 +31,30 @@
             <div class="variant-options"><%= inventory_unit.variant.options_text %></div>
           </td>
           <td class="align-center"><%= inventory_unit.state.humanize %></td>
-          <td class="align-center"><%= inventory_unit.line_item.display_rounded_total_per_item %></td>
+          <% if @allow_amount_edit %>
+            <td class="align-center">
+              <%= return_item.display_pre_tax_amount %>
+            </td>
+          <% end %>
+          <td class="align-center">
+            <% if inventory_unit.shipped? && @return_authorization.updatable? %>
+              <% if @allow_amount_edit %>
+                <%= item_fields.text_field :pre_tax_amount, { class: 'refund-amount-input' } %>
+              <% else %>
+                <%= item_fields.hidden_field :pre_tax_amount %>
+                <%= return_item.display_pre_tax_amount %>
+              <% end %>
+            <% else %>
+              <%= return_item.display_pre_tax_amount %>
+            <% end %>
+          </td>
         </tr>
       <% end %>
     </tbody>
   </table>
 
   <%= f.field_container :amount do %>
-    <%= f.label :amount, Spree.t(:amount) %> <span class="required">*</span><br />
-    <% if @return_authorization.received? %>
-      <%= @return_authorization.display_amount %>
-    <% else %>
-      <%= f.text_field :amount, {:style => 'width:80px;'} %> <%= Spree.t(:rma_value) %>: <span id="rma_value">0.00</span>
-      <%= f.error_message_on :amount %>
-    <% end %>
+    <%= Spree.t(:total_pre_tax_refund) %>: <span id="rma_value">0.00</span>
   <% end %>
 
   <%= f.field_container :reason do %>

--- a/backend/app/views/spree/admin/return_authorizations/index.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/index.html.erb
@@ -19,7 +19,7 @@
       <tr>
         <th><%= Spree.t(:rma_number) %></th>
         <th><%= Spree.t(:status) %></th>
-        <th><%= Spree.t(:amount) %></th>
+        <th><%= Spree.t(:pre_tax_total) %></th>
         <th><%= "#{Spree.t('date')}/#{Spree.t('time')}" %></th>
         <th class="actions"></th>
       </tr>
@@ -29,7 +29,7 @@
         <tr id="<%= spree_dom_id(return_authorization) %>" data-hook="rma_row" class="<%= cycle('odd', 'even')%>">
           <td><%= return_authorization.number %></td>
           <td><%= Spree.t(return_authorization.state.downcase) %></td>
-          <td><%= return_authorization.display_amount.to_html %></td>
+          <td><%= return_authorization.display_pre_tax_total.to_html %></td>
           <td><%= pretty_time(return_authorization.created_at) %></td>
           <td class="actions">
             <%= link_to_edit return_authorization, :no_text => true, :class => 'edit' %>

--- a/backend/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
@@ -12,7 +12,7 @@ describe Spree::Admin::ReturnAuthorizationsController do
   let(:params) do
     {
       order_id: order.to_param,
-      return_authorization: {amount: 0.0, reason: ""},
+      return_authorization: {reason: ""},
     }
   end
 
@@ -26,7 +26,7 @@ describe Spree::Admin::ReturnAuthorizationsController do
     let(:params) do
       super().merge({
         id: return_authorization.to_param,
-        return_authorization: {amount: 0.0, reason: ""}.merge(return_items_params),
+        return_authorization: {reason: ""}.merge(return_items_params),
       })
     end
 

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -44,6 +44,7 @@ module Spree
     scope :open, -> { where(state: 'open') }
     scope :closed, -> { where(state: 'closed') }
     scope :tax, -> { where(source_type: 'Spree::TaxRate') }
+    scope :non_tax, -> { where.not(source_type: 'Spree::TaxRate') }
     scope :price, -> { where(adjustable_type: 'Spree::LineItem') }
     scope :shipping, -> { where(adjustable_type: 'Spree::Shipment') }
     scope :optional, -> { where(mandatory: false) }

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -65,6 +65,7 @@ module Spree
     preference :show_raw_product_description, :boolean, :default => false
     preference :tax_using_ship_address, :boolean, default: true
     preference :track_inventory_levels, :boolean, default: true # Determines whether to track on_hand values for variants / products.
+    preference :allow_return_item_amount_editing, :boolean, default: false # Determines whether an admin is allowed to change a return item's pre-calculated amount
 
     # Default mail headers settings
     preference :send_core_emails, :boolean, :default => true

--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -67,6 +67,10 @@ module Spree
       Spree::Variant.unscoped { super }
     end
 
+    def rounded_pre_tax_amount
+      (weighted_order_adjustment_amount + weighted_line_item_pre_tax_amount).round(2, :down)
+    end
+
     private
 
       def allow_ship?
@@ -75,6 +79,23 @@ module Spree
 
       def update_order
         order.update!
+      end
+
+      def weighted_line_item_pre_tax_amount
+        line_item.pre_tax_amount * percentage_of_line_item
+      end
+
+      def weighted_order_adjustment_amount
+        order.adjustments.eligible.non_tax.sum(:amount) * percentage_of_order_total
+      end
+
+      def percentage_of_order_total
+        return 0.0 if order.pre_tax_item_amount.zero?
+        weighted_line_item_pre_tax_amount / order.pre_tax_item_amount
+      end
+
+      def percentage_of_line_item
+        1 / BigDecimal.new(line_item.quantity)
       end
   end
 end

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -95,16 +95,6 @@ module Spree
       Spree::Variant.unscoped { super }
     end
 
-    # Rounding down so that:
-    #   total_per_item * quantity <= total
-    def rounded_total_per_item
-      (total / quantity).round(2, :down)
-    end
-
-    def display_rounded_total_per_item
-      Spree::Money.new(rounded_total_per_item, { currency: currency })
-    end
-
     private
       def update_inventory
         if changed? || target_shipment.present?

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -127,6 +127,11 @@ module Spree
       line_items.inject(0.0) { |sum, li| sum + li.amount }
     end
 
+    # Sum of all line item amounts pre-tax
+    def pre_tax_item_amount
+      line_items.to_a.sum(&:pre_tax_amount)
+    end
+
     def currency
       self[:currency] || Spree::Config[:currency]
     end

--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -19,6 +19,10 @@ module Spree
       end
     end
 
+    def display_pre_tax_amount
+      Spree::Money.new(pre_tax_amount, { currency: currency })
+    end
+
     private
 
     def stock_item
@@ -26,6 +30,10 @@ module Spree
         variant_id: inventory_unit.variant_id,
         stock_location_id: return_authorization.stock_location_id,
       })
+    end
+
+    def currency
+      return_authorization.try(:currency) || Spree::Config[:currency]
     end
   end
 end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -448,6 +448,7 @@ en:
       other: 'Subtotal (%{count} items)'
     categories: Categories
     category: Category
+    charged: Charged
     check_for_spree_alerts: Check for Spree alerts
     checkout: Checkout
     choose_a_customer: Choose a customer
@@ -880,6 +881,8 @@ en:
     please_define_payment_methods: Please define some payment methods first.
     populate_get_error: Something went wrong. Please try adding the item again.
     powered_by: Powered by
+    pre_tax_refund_amount: Pre-Tax Refund Amount
+    pre_tax_total: Pre-Tax Total
     presentation: Presentation
     previous: Previous
     price: Price
@@ -1121,6 +1124,7 @@ en:
     to_add_variants_you_must_first_define: To add variants, you must first define
     total: Total
     total_per_item: Total per item
+    total_pre_tax_refund: Total Pre-Tax Refund
     total_price: Total price
     total_sales: Total Sales
     track_inventory: Track Inventory

--- a/core/db/migrate/20140710181204_add_amount_fields_to_return_items.rb
+++ b/core/db/migrate/20140710181204_add_amount_fields_to_return_items.rb
@@ -1,0 +1,7 @@
+class AddAmountFieldsToReturnItems < ActiveRecord::Migration
+  def change
+    add_column :spree_return_items, :pre_tax_amount, :decimal, precision: 10, scale: 2, default: 0.0, null: false
+    add_column :spree_return_items, :included_tax_total, :decimal, precision: 10, scale: 2, default: 0.0, null: false
+    add_column :spree_return_items, :additional_tax_total, :decimal, precision: 10, scale: 2, default: 0.0, null: false
+  end
+end

--- a/core/db/migrate/20140710190048_drop_return_authorization_amount.rb
+++ b/core/db/migrate/20140710190048_drop_return_authorization_amount.rb
@@ -1,0 +1,5 @@
+class DropReturnAuthorizationAmount < ActiveRecord::Migration
+  def change
+    remove_column :spree_return_authorizations, :amount
+  end
+end

--- a/core/lib/spree/testing_support/factories/line_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/line_item_factory.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :line_item, class: Spree::LineItem do
     quantity 1
     price { BigDecimal.new('10.00') }
+    pre_tax_amount { BigDecimal.new('10.00') }
     order
     ignore do
       association :product

--- a/core/lib/spree/testing_support/factories/promotion_factory.rb
+++ b/core/lib/spree/testing_support/factories/promotion_factory.rb
@@ -17,12 +17,12 @@ FactoryGirl.define do
 
     trait :with_order_adjustment do
       ignore do
-        order_adjustment_amount 10
+        weighted_order_adjustment_amount 10
       end
 
       after(:create) do |promotion, evaluator|
         calculator = Spree::Calculator::FlatRate.new
-        calculator.preferred_amount = evaluator.order_adjustment_amount
+        calculator.preferred_amount = evaluator.weighted_order_adjustment_amount
         action = Spree::Promotion::Actions::CreateAdjustment.create!(:calculator => calculator)
         promotion.actions << action
         promotion.save!

--- a/core/lib/spree/testing_support/factories/return_authorization_factory.rb
+++ b/core/lib/spree/testing_support/factories/return_authorization_factory.rb
@@ -1,7 +1,6 @@
 FactoryGirl.define do
   factory :return_authorization, class: Spree::ReturnAuthorization do
     number '100'
-    amount 100.00
     association(:order, factory: :shipped_order)
     reason 'no particular reason'
     state 'received'

--- a/core/spec/models/spree/inventory_unit_spec.rb
+++ b/core/spec/models/spree/inventory_unit_spec.rb
@@ -122,4 +122,38 @@ describe Spree::InventoryUnit do
       inventory_units.any?(&:pending).should be_false
     end
   end
+
+  describe "#rounded_pre_tax_amount" do
+    let(:order)           { create(:order) }
+    let(:line_item_count) { 2 }
+    let(:pre_tax_amount)  { 100.0 }
+    let(:line_item)       { create(:line_item, price: 100.0, quantity: line_item_count, pre_tax_amount: pre_tax_amount) }
+
+    before { order.line_items << line_item }
+
+    subject { build(:inventory_unit, order: order, line_item: line_item) }
+
+    context "no promotions or taxes" do
+      its(:rounded_pre_tax_amount) { should eq pre_tax_amount / line_item_count }
+    end
+
+    context "order adjustments" do
+      let(:adjustment_amount) { -10.0 }
+
+      before do
+        order.adjustments << create(:adjustment, amount: adjustment_amount, eligible: true, label: 'Adjustment', source_type: 'Spree::Order')
+        order.adjustments.first.update_attributes(amount: adjustment_amount)
+      end
+
+      its(:rounded_pre_tax_amount) { should eq (pre_tax_amount - adjustment_amount.abs) / line_item_count }
+    end
+
+    context "shipping adjustments" do
+      let(:adjustment_total) { -50.0 }
+
+      before { order.shipments << Spree::Shipment.new(adjustment_total: adjustment_total) }
+
+      its(:rounded_pre_tax_amount) { should eq pre_tax_amount / line_item_count }
+    end
+  end
 end

--- a/core/spec/models/spree/item_adjustments_spec.rb
+++ b/core/spec/models/spree/item_adjustments_spec.rb
@@ -116,8 +116,8 @@ module Spree
       end
 
       context "when previously ineligible promotions become available" do
-        let(:order_promo1) { create(:promotion, :with_order_adjustment, :with_item_total_rule, order_adjustment_amount: 5, item_total_threshold_amount: 10) }
-        let(:order_promo2) { create(:promotion, :with_order_adjustment, :with_item_total_rule, order_adjustment_amount: 10, item_total_threshold_amount: 20) }
+        let(:order_promo1) { create(:promotion, :with_order_adjustment, :with_item_total_rule, weighted_order_adjustment_amount: 5, item_total_threshold_amount: 10) }
+        let(:order_promo2) { create(:promotion, :with_order_adjustment, :with_item_total_rule, weighted_order_adjustment_amount: 10, item_total_threshold_amount: 20) }
         let(:order_promos) { [ order_promo1, order_promo2 ] }
         let(:line_item_promo1) { create(:promotion, :with_line_item_adjustment, :with_item_total_rule, adjustment_rate: 2.5, item_total_threshold_amount: 10) }
         let(:line_item_promo2) { create(:promotion, :with_line_item_adjustment, :with_item_total_rule, adjustment_rate: 5, item_total_threshold_amount: 20) }

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -148,44 +148,6 @@ describe Spree::LineItem do
     end
   end
 
-  describe '#rounded_total_per_item' do
-    context "adjustments are evenly divided between items" do
-      before do
-        line_item.price = 10
-        line_item.quantity = 2
-        line_item.adjustment_total = -4
-      end
-
-      it "returns the exact total" do
-        line_item.rounded_total_per_item.should eq 8
-      end
-    end
-
-    context "adjustments are not evenly divided between items" do
-      before do
-        line_item.price = 2
-        line_item.quantity = 3
-        line_item.adjustment_total = -4
-      end
-
-      it "returns the rounded down total" do
-        line_item.rounded_total_per_item.should eq 0.66
-      end
-    end
-  end
-
-  describe '#display_rounded_total_per_item' do
-    before do
-      line_item.price = 10.4
-      line_item.quantity = 1
-      line_item.adjustment_total = 0
-    end
-
-    it "returns a Spree::Money representing total per item" do
-      line_item.display_rounded_total_per_item.to_s.should == "$10.40"
-    end
-  end
-
   context "has inventory (completed order so items were already unstocked)" do
     let(:order) { Spree::Order.create(email: 'spree@example.com') }
     let(:variant) { create(:variant) }

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -637,4 +637,15 @@ describe Spree::Order do
       expect { order.with_lock {} }.to_not raise_error
     end
   end
+
+  describe "#pre_tax_item_amount" do
+    it "sums all of the line items' pre tax amounts" do
+      subject.line_items = [
+        Spree::LineItem.new(price: 10, quantity: 2, pre_tax_amount: 5.0),
+        Spree::LineItem.new(price: 30, quantity: 1, pre_tax_amount: 14.0),
+      ]
+
+      expect(subject.pre_tax_item_amount).to eq 19.0
+    end
+  end
 end

--- a/core/spec/models/spree/return_item_spec.rb
+++ b/core/spec/models/spree/return_item_spec.rb
@@ -52,4 +52,13 @@ describe Spree::ReturnItem do
       end
     end
   end
+
+  describe "#display_pre_tax_amount" do
+    let(:pre_tax_amount) { 21.22 }
+    let(:return_item) { Spree::ReturnItem.new(pre_tax_amount: pre_tax_amount) }
+
+    it "returns a Spree::Money" do
+      return_item.display_pre_tax_amount.should == Spree::Money.new(pre_tax_amount)
+    end
+  end
 end


### PR DESCRIPTION
This change aims to bring the rma amount calculation over to the return items. This allows us to handle returns where only part of the authorized items in the RMA are returned. Since the amount (and tax) information is kept at the return item level we have more control as to what gets refunded to the customer.

Keeping the tax information on the return item will also allow Spree users to integrate with a third party tax calculator to determine how much tax to return per refunded item.

Depends on the acceptance of https://github.com/spree/spree/pull/4945

Generated by: @jordan-brough and @richardnuno
