### PR TITLE
Fix OpenSSL::Digest::Digest is deprecated

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activemerchant', '~> 1.43.1'
   s.add_dependency 'acts_as_list', '= 0.3.0'
   s.add_dependency 'awesome_nested_set', '~> 3.0.0.rc.3'
-  s.add_dependency 'aws-sdk', '1.27.0'
+  s.add_dependency 'aws-sdk', '1.47.0'
   s.add_dependency 'cancan', '~> 1.6.10'
   s.add_dependency 'deface', '~> 1.0.0'
   s.add_dependency 'ffaker', '~> 1.16'


### PR DESCRIPTION
For spree master the dependency for 'aws-sdk' is '1.27.0', but that
version has the issue https://github.com/aws/aws-sdk-ruby/pull/434
“OpenSSL::Digest::Digest is deprecated OpenSSL::Digest::Digest is
deprecated; use OpenSSL::Digest for Ruby 2.1 and aws-sdk-ruby”  that is
fixed in 'aws-sdk' is '1.47.0' that is the current version. I did the
bump to '1.47.0' in the spree_core.gemspec file
