### PR TITLE
restrict cost_price to admin users through the api

### DIFF
--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -5,6 +5,7 @@ module Spree
         :product_attributes,
         :product_property_attributes,
         :variant_attributes,
+        :variant_attributes_admin,
         :image_attributes,
         :option_value_attributes,
         :order_attributes,
@@ -58,8 +59,9 @@ module Spree
 
       @@variant_attributes = [
         :id, :name, :sku, :price, :weight, :height, :width, :depth, :is_master,
-        :cost_price, :slug, :description, :track_inventory
+        :slug, :description, :track_inventory
       ]
+      @@variant_attributes_admin = @@variant_attributes + [:cost_price]
 
       @@image_attributes = [
         :id, :position, :attachment_content_type, :attachment_file_name, :type,

--- a/api/app/views/spree/api/variants/small.v1.rabl
+++ b/api/app/views/spree/api/variants/small.v1.rabl
@@ -1,4 +1,8 @@
-attributes *variant_attributes
+if @current_api_user.has_spree_role?('admin')
+  attributes *variant_attributes_admin
+else
+  attributes *variant_attributes
+end
 cache [I18n.locale, 'small_variant', root_object]
 
 node(:display_price) { |p| p.display_price.to_s }

--- a/api/spec/controllers/spree/api/variants_controller_spec.rb
+++ b/api/spec/controllers/spree/api/variants_controller_spec.rb
@@ -37,7 +37,7 @@ module Spree
       json_response['pages'].should == 3
     end
 
-    it 'can query the results through a paramter' do
+    it 'can query the results through a parameter' do
       expected_result = create(:variant, :sku => 'FOOBAR')
       api_get :index, :q => { :sku_cont => 'FOO' }
       json_response['count'].should == 1
@@ -68,6 +68,11 @@ module Spree
                                                                                :product_url,
                                                                                :large_url])
 
+    end
+
+    it 'variants returned do not contain cost price data' do
+      api_get :index
+      expect(json_response["variants"].first.has_key?(:cost_price)).to eq false
     end
 
     # Regression test for #2141
@@ -178,6 +183,11 @@ module Spree
         api_delete :destroy, :id => variant.to_param
         response.status.should == 204
         lambda { Spree::Variant.find(variant.id) }.should raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it 'variants returned contain cost price data' do
+        api_get :index
+        expect(json_response["variants"].first.has_key?(:cost_price)).to eq true
       end
     end
 


### PR DESCRIPTION
I imagine stores don't wish to share their cost price openly. This change limits cost price value to admin users through the api.
This becomes even more important if you configure the application to allow open access to the api, as it used to be in 2.0 and earlier. 
