### PR TITLE
add rails-i18n to spree_core

### DIFF
--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -16,6 +16,7 @@ end
 
 gem 'coffee-rails', '~> 4.0.0'
 gem 'sass-rails', '~> 4.0.0'
+gem 'rails-i18n'
 
 group :test do
   gem 'capybara', '~> 2.1'

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -38,5 +38,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'state_machine', '1.2.0'
   s.add_dependency 'stringex', '~> 1.5.1'
   s.add_dependency 'truncate_html', '0.9.2'
+  s.add_dependency 'rails-i18n'
 
 end


### PR DESCRIPTION
We were getting 12 failing specs in spree_core, all related to localization (example below), which are resolved by referencing rails-i18n in the project. I added the ref to gemspec as well, because I assume since the specs need to have it, the gem also requires it.

Sample of failing core specs for me and my entire team on 2-2-stable:

```
  1) Spree::OrderMailer emails must be translatable pt-BR locale confirm_email
     Failure/Error: I18n.locale = :'pt-BR'
     I18n::InvalidLocale:
       :"pt-BR" is not a valid locale
     # ./spec/mailers/order_mailer_spec.rb:89:in `block (4 levels) in <top (required)>'

  2) Spree::OrderMailer emails must be translatable pt-BR locale cancel_email
     Failure/Error: I18n.locale = :'pt-BR'
     I18n::InvalidLocale:
       :"pt-BR" is not a valid locale
     # ./spec/mailers/order_mailer_spec.rb:89:in `block (4 levels) in <top (required)>'

  3) Spree::ShipmentMailer emails must be translatable shipped_email pt-BR locale
     Failure/Error: I18n.locale = :'pt-BR'
     I18n::InvalidLocale:
       :"pt-BR" is not a valid locale
     # ./spec/mailers/shipment_mailer_spec.rb:45:in `block (5 levels) in <top (required)>'

  4) Spree::Payment#amount= when the locale uses a comma as a decimal separator amount is a decimal amount
     Failure/Error: I18n.locale = :fr
     I18n::InvalidLocale:
       :fr is not a valid locale
     # ./spec/models/spree/payment_spec.rb:802:in `block (4 levels) in <top (required)>'

  5) Spree::Payment#amount= when the locale uses a comma as a decimal separator amount contains a $ sign amount
     Failure/Error: I18n.locale = :fr
     I18n::InvalidLocale:
       :fr is not a valid locale
     # ./spec/models/spree/payment_spec.rb:802:in `block (4 levels) in <top (required)>'

  6) Spree::Payment#amount= when the locale uses a comma as a decimal separator amount is a number amount
     Failure/Error: I18n.locale = :fr
     I18n::InvalidLocale:
       :fr is not a valid locale
     # ./spec/models/spree/payment_spec.rb:802:in `block (4 levels) in <top (required)>'

  7) Spree::Payment#amount= when the locale uses a comma as a decimal separator amount contains a negative sign amount
     Failure/Error: I18n.locale = :fr
     I18n::InvalidLocale:
       :fr is not a valid locale
     # ./spec/models/spree/payment_spec.rb:802:in `block (4 levels) in <top (required)>'

  8) Spree::Payment#amount= when the locale uses a comma as a decimal separator amount uses a dot as a decimal separator amount
     Failure/Error: I18n.locale = :fr
     I18n::InvalidLocale:
       :fr is not a valid locale
     # ./spec/models/spree/payment_spec.rb:802:in `block (4 levels) in <top (required)>'

  9) Spree::Variant price parsing price= with decimal comma captures the proper amount for a formatted price
     Failure/Error: I18n.locale = :de
     I18n::InvalidLocale:
       :de is not a valid locale
     # ./spec/models/spree/variant_spec.rb:124:in `block (5 levels) in <top (required)>'

  10) Spree::Variant price parsing price= with a numeric price uses the price as is
     Failure/Error: I18n.locale = :de
     I18n::InvalidLocale:
       :de is not a valid locale
     # ./spec/models/spree/variant_spec.rb:132:in `block (5 levels) in <top (required)>'

  11) Spree::Variant price parsing cost_price= with decimal comma captures the proper amount for a formatted price
     Failure/Error: I18n.locale = :de
     I18n::InvalidLocale:
       :de is not a valid locale
     # ./spec/models/spree/variant_spec.rb:149:in `block (5 levels) in <top (required)>'

  12) Spree::Variant price parsing cost_price= with a numeric price uses the price as is
     Failure/Error: I18n.locale = :de
     I18n::InvalidLocale:
       :de is not a valid locale
     # ./spec/models/spree/variant_spec.rb:157:in `block (5 levels) in <top (required)>'
```
