### PR TITLE
Fix admin payment form not being displayed on payment method change

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/select_payments.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/select_payments.js.coffee
@@ -4,4 +4,4 @@ $ ->
     $('input[name="payment[payment_method_id]"]').click ()->
       $('.payment-method-settings fieldset').addClass('hidden')
       id = $(this).parents('li').data('id')
-      $("fieldset##{id}").removeClass('hidden')
+      $("fieldset[data-id='#{id}']").removeClass('hidden')

--- a/backend/app/views/spree/admin/payments/source_forms/_gateway.html.erb
+++ b/backend/app/views/spree/admin/payments/source_forms/_gateway.html.erb
@@ -1,4 +1,4 @@
-<fieldset class="no-border-bottom">
+<fieldset data-id='credit-card' class="no-border-bottom">
   <div class="field" data-hook="previous_cards">
     <% if previous_cards.any? %>
       <% previous_cards.each do |card| %>


### PR DESCRIPTION
When there are multiple payment methods, clicking the radio button for a payment method other than the first causes the payment forms to not be displayed.

How to replicate in sandbox:
1. Create an order through the admin until the payment state is reached
2. Create a new payment for the order (at this point the credit card form should be visible)
3. Click the Check radio button
4. Click the Credit Card radio button
5. The credit card form is no longer visible
