### PR TITLE
exchange expires_at to starts_at to fix test

### DIFF
--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -144,7 +144,7 @@ describe Spree::Promotion do
     end
 
     it "should not be expired if current time is within starts_at and expires_at range" do
-      promotion.expires_at = Time.now - 1.day
+      promotion.starts_at  = Time.now - 1.day
       promotion.expires_at = Time.now + 1.day
       promotion.should_not be_expired
     end


### PR DESCRIPTION
I think this spec had a big typo from ctrl-C ctrl-V
