### PR TITLE
Restore "Add pry and pry debuggers to common spree dependencies"

### DIFF
--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -23,10 +23,18 @@ group :test do
   gem 'email_spec', '1.4.0'
   gem 'factory_girl_rails', '~> 4.4.0'
   gem 'launchy'
-  gem 'pry'
   gem 'rspec-rails', '~> 2.14.0'
   gem 'simplecov'
   gem 'webmock', '1.8.11'
   gem 'poltergeist', '1.5.0'
   gem 'timecop'
+end
+
+group :test, :development do
+  platforms :ruby_19 do
+    gem 'pry-debugger'
+  end
+  platforms :ruby_20, :ruby_21 do
+    gem 'pry-byebug'
+  end
 end


### PR DESCRIPTION
This reverts commit 7006953963f65e69c14c6f88f2a2e87e83d8b20d.

Was breaking CI but that should be fixable by updating bundler on the CI.

@huoxito Where was the CI error happening?  This should work fine even on Ruby 1.9.x as long as an up-to-date version of bundler is installed.
Example: https://gist.github.com/jordan-brough/05ad6d1387d23558b651
