### PR TITLE
Fix admin payment form not being displayed on payment method change

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/select_payments.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/select_payments.js.coffee
@@ -4,4 +4,4 @@ $ ->
     $('input[name="payment[payment_method_id]"]').click ()->
       $('.payment-method-settings fieldset').addClass('hidden')
       id = $(this).parents('li').data('id')
-      $("fieldset##{id}").removeClass('hidden')
+      $("fieldset[data-id='#{id}']").removeClass('hidden')

--- a/backend/app/views/spree/admin/payments/source_forms/_gateway.html.erb
+++ b/backend/app/views/spree/admin/payments/source_forms/_gateway.html.erb
@@ -1,4 +1,4 @@
-<fieldset class="no-border-bottom">
+<fieldset data-id='credit-card' class="no-border-bottom">
   <div class="field" data-hook="previous_cards">
     <% if previous_cards.any? %>
       <% previous_cards.each do |card| %>


### PR DESCRIPTION
The issue is also happening on 2-2-stable.

Changes are the same as https://github.com/spree/spree/pull/4974 but pull request is for 2-2-stable branch.
