### PR TITLE
Promotion Rule: One Use Per User

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -128,6 +128,10 @@ module Spree
       end
     end
 
+    def used_by?(user, excluded_orders = [])
+      orders.where.not(id: excluded_orders.map(&:id)).complete.where(user_id: user.id).exists?
+    end
+
     private
     def normalize_blank_values
       [:code, :path].each do |column|

--- a/core/app/models/spree/promotion/rules/one_use_per_user.rb
+++ b/core/app/models/spree/promotion/rules/one_use_per_user.rb
@@ -1,0 +1,16 @@
+module Spree
+  class Promotion
+    module Rules
+      class OneUsePerUser < PromotionRule
+        def applicable?(promotable)
+          promotable.is_a?(Spree::Order)
+        end
+
+        def eligible?(order, options = {})
+          order.user.present? && !promotion.used_by?(order.user, [order])
+        end
+      end
+    end
+  end
+end
+

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -959,6 +959,9 @@ en:
       landing_page:
         description: Customer must have visited the specified page
         name: Landing Page
+      one_use_per_user:
+        description: Only One Use Per User
+        name: One Use Per User
       product:
         description: Order includes specified product(s)
         name: Product(s)

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -69,7 +69,8 @@ module Spree
           Spree::Promotion::Rules::Product,
           Spree::Promotion::Rules::User,
           Spree::Promotion::Rules::FirstOrder,
-          Spree::Promotion::Rules::UserLoggedIn]
+          Spree::Promotion::Rules::UserLoggedIn,
+          Spree::Promotion::Rules::OneUsePerUser]
       end
 
       initializer 'spree.promo.register.promotions.actions' do |app|

--- a/core/spec/models/spree/promotion/rules/one_use_per_user_spec.rb
+++ b/core/spec/models/spree/promotion/rules/one_use_per_user_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe Spree::Promotion::Rules::OneUsePerUser do
+  let(:rule) { described_class.new }
+
+  describe '#eligible?(order)' do
+    subject { rule.eligible?(order) }
+    let(:order) { double Spree::Order, user: user }
+    let(:user) { double Spree::LegacyUser }
+    let(:promotion) { stub_model Spree::Promotion, used_by?: used_by }
+    let(:used_by) { false }
+
+    before { rule.promotion = promotion }
+
+    context 'when the order is assigned to a user' do
+      context 'when the user has used this promotion before' do
+        let(:used_by) { true }
+
+        it { should be false }
+      end
+
+      context 'when the user has not used this promotion before' do
+        it { should be true }
+      end
+    end
+
+    context 'when the order is not assigned to a user' do
+      let(:user) { nil }
+      it { should be false }
+    end
+  end
+end

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -385,4 +385,40 @@ describe Spree::Promotion do
       end
     end
   end
+
+  describe '#used_by?' do
+    subject { promotion.used_by? user, [excluded_order] }
+
+    let(:promotion) { Spree::Promotion.create! name: 'Test Used By' }
+    let(:user) { double Spree::LegacyUser, id: 2 }
+    let(:order) { create :completed_order_with_totals }
+    let(:excluded_order) { double Spree::Order, id: 3}
+
+    before { promotion.orders << order }
+
+    context 'when the user has used this promo' do
+      before do
+        order.user_id = user.id
+        order.save!
+      end
+
+      context 'when the order is complete' do
+        it { should be true }
+
+        context 'when the only matching order is the excluded order' do
+          let(:excluded_order) { order }
+          it { should be false }
+        end
+      end
+
+      context 'when the order is not complete' do
+        let(:order) { create :order }
+        it { should be false }
+      end
+    end
+
+    context 'when the user nas not used this promo' do
+      it { should be false }
+    end
+  end
 end


### PR DESCRIPTION
This will limit a promotion from being used multiple times by a single
user.
