### PR TITLE
Silence two warnings

### DIFF
--- a/core/lib/generators/spree/install/install_generator.rb
+++ b/core/lib/generators/spree/install/install_generator.rb
@@ -13,6 +13,7 @@ module Spree
     class_option :admin_email, :type => :string
     class_option :admin_password, :type => :string
     class_option :lib_name, :type => :string, :default => 'spree'
+    class_option :enforce_available_locales, :type => :boolean, :default => nil
 
     def self.source_paths
       paths = self.superclass.source_paths
@@ -100,6 +101,13 @@ Disallow: /account
       end
     end
       APP
+
+      if !options[:enforce_available_locales].nil?
+        application <<-APP
+    # Prevent this deprecation message: https://github.com/svenfuchs/i18n/commit/3b6e56e
+    I18n.enforce_available_locales = #{options[:enforce_available_locales]}
+        APP
+      end
     end
 
     def include_seed_data

--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -13,4 +13,5 @@ echo "gem 'spree', :path => '..'" >> Gemfile
 echo "gem 'spree_auth_devise', :github => 'spree/spree_auth_devise', :branch => 'master'" >> Gemfile
 
 bundle install --gemfile Gemfile
-bundle exec rails g spree:install --auto-accept --user_class=Spree::User
+bundle exec rails g spree:install --auto-accept --user_class=Spree::User --enforce_available_locales=true
+bundle exec rails g spree:auth:install


### PR DESCRIPTION
NOTE:  I don't know if these are the best fixes for these issues.  I'm happy to change to or investigate different solutions, just let me know.  It just would be really nice to not see these all the time in the "sandbox" app. :)

Silences this:

```
[WARNING] You are not setting Devise.secret_key within your application!
You must set this in config/initializers/devise.rb. Here's an example:
```

And this:

```
[deprecated] I18n.enforce_available_locales will default to true in the future. If you really want to skip validation of your locale you can set I18n.enforce_available_locales = false to avoid this message.
```

in the sandbox app.
