### PR TITLE
Use save! when modifying the order

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -408,10 +408,10 @@ module Spree
         current_line_item = self.line_items.find_by(variant: line_item.variant)
         if current_line_item
           current_line_item.quantity += line_item.quantity
-          current_line_item.save
+          current_line_item.save!
         else
           line_item.order_id = self.id
-          line_item.save
+          line_item.save!
         end
       end
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -331,7 +331,7 @@ module Spree
       end
 
       updater.update_shipment_state
-      save
+      save!
       updater.run_hooks
 
       touch :completed_at


### PR DESCRIPTION
`save` will silently ignore any errors. It is much better to raise an error than to silently fail.
