### PR TITLE
Promotion Categories

### DIFF
--- a/backend/app/controllers/spree/admin/promotion_categories_controller.rb
+++ b/backend/app/controllers/spree/admin/promotion_categories_controller.rb
@@ -1,0 +1,6 @@
+module Spree
+  module Admin
+    class PromotionCategoriesController < ResourceController
+    end
+  end
+end

--- a/backend/app/controllers/spree/admin/promotions_controller.rb
+++ b/backend/app/controllers/spree/admin/promotions_controller.rb
@@ -12,6 +12,7 @@ module Spree
 
         def load_data
           @calculators = Rails.application.config.spree.calculators.promotion_actions_create_adjustments
+          @promotion_categories = Spree::PromotionCategory.order(:name)
         end
 
         def collection

--- a/backend/app/views/spree/admin/promotion_categories/_form.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/_form.html.erb
@@ -1,0 +1,10 @@
+<%= render :partial => 'spree/shared/error_messages', :locals => { :target => @promotion } %>
+
+<div class='row'>
+  <div class='alpha six columns'>
+    <%= f.field_container :name do %>
+      <%= f.label :name %>
+      <%= f.text_field :name, :class => 'fullwidth' %>
+    <% end %>
+  </div>
+</div>

--- a/backend/app/views/spree/admin/promotion_categories/edit.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/edit.html.erb
@@ -1,0 +1,17 @@
+<% content_for :page_title do %>
+  <%= Spree.t(:editing_promotion_category) %>
+<% end %>
+
+<% content_for :page_actions do %>
+  <li>
+    <%= button_link_to Spree.t(:back_to_promotion_categories_list), spree.admin_promotion_categories_path, :icon => 'arrow-left' %>
+  </li>
+<% end %>
+
+<%= form_for @promotion_category, :url => object_url, :method => :put do |f| %>
+  <fieldset class="no-border-top">
+    <%= render :partial => 'form', :locals => { :f => f } %>
+    <%= render :partial => 'spree/admin/shared/edit_resource_links' %>
+  </fieldset>
+<% end %>
+

--- a/backend/app/views/spree/admin/promotion_categories/index.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/index.html.erb
@@ -1,0 +1,34 @@
+<% content_for :page_title do %>
+  <%= Spree::PromotionCategory.model_name.human(count: :many) %>
+<% end %>
+
+<% content_for :page_actions do %>
+  <li>
+    <%= button_link_to Spree.t(:new_promotion_category), spree.new_admin_promotion_category_path, :icon => 'plus' %>
+  </li>
+  <li>
+    <%= button_link_to Spree.t(:back_to_promotions_list), spree.admin_promotions_path, :icon => 'arrow-left' %>
+  </li>
+<% end %>
+
+<table>
+  <colgroup>
+    <col style="width: 85%">
+    <col style="width: 15%">
+  </colgroup>
+  <thead>
+    <th><%= Spree::PromotionCategory.human_attribute_name :name %></th>
+    <th class='actions'></th>
+  </thead>
+  <tbody>
+    <% @promotion_categories.each do |promotion_category| %>
+      <tr>
+        <td><%= promotion_category.name %></td>
+        <td class="actions">
+          <%= link_to_edit promotion_category, :no_text => true %>
+          <%= link_to_delete promotion_category, :no_text => true %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/backend/app/views/spree/admin/promotion_categories/new.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/new.html.erb
@@ -1,0 +1,16 @@
+<% content_for :page_title do %>
+  <%= Spree.t(:new_promotion_category) %>
+<% end %>
+
+<% content_for :page_actions do %>
+  <li>
+    <%= button_link_to Spree.t(:back_to_promotion_categories_list), spree.admin_promotion_categories_path, :icon => 'arrow-left' %>
+  </li>
+<% end %>
+
+<%= form_for :promotion_category, :url => collection_url do |f| %>
+  <fieldset class="no-border-top">
+    <%= render :partial => 'form', :locals => { :f => f } %>
+    <%= render :partial => 'spree/admin/shared/new_resource_links' %>
+  </fieldset>
+<% end %>

--- a/backend/app/views/spree/admin/promotions/_form.html.erb
+++ b/backend/app/views/spree/admin/promotions/_form.html.erb
@@ -28,6 +28,11 @@
         <%= f.label :description %><br />
         <%= f.text_area :description, :rows => 7, :class => 'fullwidth' %>
       <% end %>
+
+      <%= f.field_container :category do %>
+        <%= f.label :promotion_category %><br />
+        <%= f.collection_select(:promotion_category_id, @promotion_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2 fullwidth' }) %>
+      <% end %>
     </div>
   </div>
 

--- a/backend/app/views/spree/admin/promotions/index.html.erb
+++ b/backend/app/views/spree/admin/promotions/index.html.erb
@@ -4,6 +4,9 @@
 
 <% content_for :page_actions do %>
   <li>
+    <%= button_link_to Spree.t(:manage_promotion_categories), spree.admin_promotion_categories_path, :icon => 'bars' %>
+  </li>
+  <li>
     <%= button_link_to Spree.t(:new_promotion), spree.new_admin_promotion_path, :icon => 'plus' %>
   </li>
 <% end %>
@@ -15,24 +18,31 @@
 <% content_for :table_filter do %>
   <div data-hook="admin_promotions_index_search">
     <%= search_form_for [:admin, @search] do |f| %>
-      <div class="five columns">
+      <div class="four columns alpha">
         <div class="field">
           <%= label_tag nil, 'name' %>
           <%= f.text_field :name_cont, tabindex: 1 %>
         </div>
       </div>
 
-      <div class="five columns">
+      <div class="four columns">
         <div class="field">
           <%= label_tag nil, 'code' %>
           <%= f.text_field :code_cont, tabindex: 1 %>
         </div>
       </div>
 
-      <div class="five columns">
+      <div class="four columns">
         <div class="field">
           <%= label_tag nil, 'path' %>
           <%= f.text_field :path_cont, tabindex: 1 %>
+        </div>
+      </div>
+
+      <div class="four columns omega">
+        <div class="field">
+          <%= label_tag nil, 'promotion category' %><br>
+          <%= f.collection_select(:promotion_category_id_eq, @promotion_categories, :id, :name, { :include_blank => Spree.t('match_choices.all') }, { :class => 'select2 fullwidth' }) %>
         </div>
       </div>
 

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -9,6 +9,8 @@ Spree::Core::Engine.add_routes do
       resources :promotion_actions
     end
 
+    resources :promotion_categories, :except => [:show]
+
     resources :zones
 
     resources :countries do

--- a/backend/spec/controllers/spree/admin/promotions_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/promotions_controller_spec.rb
@@ -5,11 +5,17 @@ describe Spree::Admin::PromotionsController do
 
   let!(:promotion1) { create(:promotion, name: "name1", code: "code1", path: "path1") }
   let!(:promotion2) { create(:promotion, name: "name2", code: "code2", path: "path2") }
+  let!(:category) { create :promotion_category }
 
   context "#index" do
     it "succeeds" do
       spree_get :index
       expect(assigns[:promotions]).to match_array [promotion2, promotion1]
+    end
+
+    it "assigns promotion categories" do
+      spree_get :index
+      expect(assigns[:promotion_categories]).to match_array [category]
     end
 
     context "search" do

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -3,6 +3,8 @@ module Spree
     MATCH_POLICIES = %w(all any)
     UNACTIVATABLE_ORDER_STATES = ["complete", "awaiting_return", "returned"]
 
+    belongs_to :promotion_category
+
     has_many :promotion_rules, autosave: true, dependent: :destroy
     alias_method :rules, :promotion_rules
 

--- a/core/app/models/spree/promotion_category.rb
+++ b/core/app/models/spree/promotion_category.rb
@@ -1,0 +1,6 @@
+module Spree
+  class PromotionCategory < Spree::Base
+    validates_presence_of :name
+    has_many :promotions
+  end
+end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -87,6 +87,8 @@ en:
         path: Path
         starts_at: Starts At
         usage_limit: Usage Limit
+      spree/promotion_category:
+        name: Name
       spree/property:
         name: Name
         presentation: Presentation
@@ -171,6 +173,9 @@ en:
       spree/promotion:
         one: Promotion
         other: Promotions
+      spree/promotion_category:
+        one: Promotion Category
+        other: Promotion Categories
       spree/property:
         one: Property
         other: Properties
@@ -420,6 +425,7 @@ en:
     back_to_payments_list: Back To Payments List
     back_to_products_list: Back To Products List
     back_to_promotions_list: Back To Promotions List
+    back_to_promotion_categories_list: Back To Promotions Categories List
     back_to_properties_list: Back To Properties List
     back_to_prototypes_list: Back To Prototypes List
     back_to_reports_list: Back To Reports List
@@ -566,6 +572,7 @@ en:
     editing_payment_method: Editing Payment Method
     editing_product: Editing Product
     editing_promotion: Editing Promotion
+    editing_promotion_category: Editing Promotion
     editing_property: Editing Property
     editing_prototype: Editing Prototype
     edit_refund_reason: Edit Refund Reason
@@ -720,6 +727,7 @@ en:
     logout: Logout
     look_for_similar_items: Look for similar items
     make_refund: Make refund
+    manage_promotion_categories: Manage Promotion Categories
     master_price: Master Price
     match_choices:
       all: All
@@ -751,6 +759,7 @@ en:
     new_payment_method: New Payment Method
     new_product: New Product
     new_promotion: New Promotion
+    new_promotion_category: New Promotion Category
     new_property: New Property
     new_prototype: New Prototype
     new_refund: New Refund

--- a/core/db/migrate/20140715182625_create_spree_promotion_categories.rb
+++ b/core/db/migrate/20140715182625_create_spree_promotion_categories.rb
@@ -1,0 +1,11 @@
+class CreateSpreePromotionCategories < ActiveRecord::Migration
+  def change
+    create_table :spree_promotion_categories do |t|
+      t.string :name
+      t.timestamps
+    end
+
+    add_column :spree_promotions, :promotion_category_id, :integer
+    add_index :spree_promotions, :promotion_category_id
+  end
+end

--- a/core/lib/spree/testing_support/factories/promotion_category_factory.rb
+++ b/core/lib/spree/testing_support/factories/promotion_category_factory.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :promotion_category, class: Spree::PromotionCategory do
+    name 'Promotion Category'
+  end
+end
+

--- a/core/spec/models/spree/promotion_category_spec.rb
+++ b/core/spec/models/spree/promotion_category_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe Spree::PromotionCategory do
+  describe 'validation' do
+    let(:name) { 'Nom' }
+    subject { Spree::PromotionCategory.new name: name }
+
+    context 'when all required attributes are specified' do
+      it { should be_valid }
+    end
+
+    context 'when name is missing' do
+      let(:name) { nil }
+      it { should_not be_valid }
+    end
+  end
+end


### PR DESCRIPTION
This allows a promotion to be categorized on the administration interface for easy sorting. It helps an administrator in sorting through promotions, which can be a bit unwieldy. This has no effect on promotions from the front end.

Examples of usage:
### Apply a filter on the search page.

![screenshot from 2014-07-16 15 36 15](https://cloud.githubusercontent.com/assets/764390/3606673/cd5f6258-0d39-11e4-95ff-7f483df1c9d6.png)
### You can click the link to manage promotions to be taken to a basic CRUD for managing promotion categories.

![screenshot from 2014-07-16 15 36 29](https://cloud.githubusercontent.com/assets/764390/3606674/cd5fcc98-0d39-11e4-8ed6-4b85ab6bfce2.png)
### The individual promotion page will allow you to select the promotion category for this promotion.

![screenshot from 2014-07-16 15 37 05](https://cloud.githubusercontent.com/assets/764390/3606675/cd61430c-0d39-11e4-80ac-3764a732458d.png)
