### PR TITLE
add :hash and :array to preference type

### DIFF
--- a/core/app/models/spree/preferences/preferable.rb
+++ b/core/app/models/spree/preferences/preferable.rb
@@ -106,6 +106,18 @@ module Spree::Preferences::Preferable
       else
          true
       end
+    when :hash
+      if value.instance_of?(Hash)
+        value
+      else
+        {}
+      end
+    when :array
+      if value.instance_of?(Array)
+        value
+      else
+        []
+      end      
     else
       value
     end


### PR DESCRIPTION
It's quite often to save hash or array data to database. Add :hash and :array type to preference can save a lot of works.
