### PR TITLE
Refactor not query.

### DIFF
--- a/core/app/models/spree/promotion/actions/create_item_adjustments.rb
+++ b/core/app/models/spree/promotion/actions/create_item_adjustments.rb
@@ -14,12 +14,11 @@ module Spree
 
         def perform(payload = {})
           order = payload[:order]
-          # Find only the line items which have not already been adjusted by this promotion
-          # HACK: Need to use [0] because `pluck` may return an empty array, which AR helpfully
-          # coverts to meaning NOT IN (NULL) and the DB isn't happy about that.
-          already_adjusted_line_items = [0] + self.adjustments.pluck(:adjustable_id)
+
+          already_adjusted_line_items = self.adjustments.pluck(:adjustable_id)
           result = false
-          order.line_items.where("id NOT IN (?)", already_adjusted_line_items).find_each do |line_item|
+
+          order.line_items.where.not(id: already_adjusted_line_items).find_each do |line_item|
             current_result = self.create_adjustment(line_item, order)
             result ||= current_result
           end


### PR DESCRIPTION
Previously there was a hack in place to deal with attributes not in an
empty list of attributes. Rails 4 has a helpful .not method which lets
us do this a little bit better.

I was in the area, so I figured I'd clean it up.
### Query before (without Hack)

```
[1] pry(main)> Spree::Order.last.line_items.where('id not in (?)', []).pluck(:id)
  Spree::Order Load (0.4ms)  SELECT  "spree_orders".* FROM "spree_orders"   ORDER BY "spree_orders"."id" DESC LIMIT 1
   (0.2ms)  SELECT "spree_line_items"."id" FROM "spree_line_items"  WHERE "spree_line_items"."order_id" = ? AND (id not in (NULL))  ORDER BY created_at ASC  [["order_id", 8]]
=> []
```
### Query after (no hack required)

```
[2] pry(main)> Spree::Order.last.line_items.where.not(id: []).pluck(:id)
  Spree::Order Load (0.4ms)  SELECT  "spree_orders".* FROM "spree_orders"   ORDER BY "spree_orders"."id" DESC LIMIT 1
   (0.2ms)  SELECT "spree_line_items"."id" FROM "spree_line_items"  WHERE "spree_line_items"."order_id" = ? AND (1=1)  ORDER BY created_at ASC  [["order_id", 8]]
=> [17, 18]
[3] pry(main)> Spree::Order.last.line_items.where.not(id: [18]).pluck(:id)
  Spree::Order Load (0.4ms)  SELECT  "spree_orders".* FROM "spree_orders"   ORDER BY "spree_orders"."id" DESC LIMIT 1
   (0.3ms)  SELECT "spree_line_items"."id" FROM "spree_line_items"  WHERE "spree_line_items"."order_id" = ? AND ("spree_line_items"."id" NOT IN (18))  ORDER BY created_at ASC  [["order_id", 8]]
=> [17]
```
