### PR TITLE
Make it possible to select a default stock location

### DIFF
--- a/backend/app/controllers/spree/admin/stock_transfers_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_transfers_controller.rb
@@ -37,7 +37,7 @@ module Spree
 
       private
       def load_stock_locations
-        @stock_locations = Spree::StockLocation.active.order('name ASC')
+        @stock_locations = Spree::StockLocation.active.order_default
       end
 
       def source_location

--- a/backend/app/views/spree/admin/return_authorizations/_form.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/_form.html.erb
@@ -59,7 +59,7 @@
 
   <%= f.field_container :stock_location do %>
     <%= f.label :stock_location, Spree.t(:stock_location) %>
-    <%= f.select :stock_location_id, Spree::StockLocation.active.to_a.collect{|l|[l.name, l.id]}, {include_blank: true}, {class: 'select2 fullwidth', "data-placeholder" => Spree.t(:select_a_stock_location)} %>
+    <%= f.select :stock_location_id, Spree::StockLocation.order_default.active.to_a.collect{|l|[l.name, l.id]}, {include_blank: true}, {class: 'select2 fullwidth', "data-placeholder" => Spree.t(:select_a_stock_location)} %>
     <%= f.error_message_on :stock_location_id %>
   <% end %>
 

--- a/backend/app/views/spree/admin/stock_locations/_form.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/_form.html.erb
@@ -19,6 +19,10 @@
             <%= f.check_box :active %>
           </li>
           <li>
+            <%= f.label :default, Spree.t(:default) %>
+            <%= f.check_box :default %>
+          </li>
+          <li>
             <%= f.label :active, Spree.t(:backorderable_default) %>
             <%= f.check_box :backorderable_default %>
           </li>

--- a/core/db/migrate/20130213191427_create_default_stock.rb
+++ b/core/db/migrate/20130213191427_create_default_stock.rb
@@ -1,6 +1,7 @@
 class CreateDefaultStock < ActiveRecord::Migration
   def up
     Spree::StockLocation.skip_callback(:create, :after, :create_stock_items)
+    Spree::StockLocation.skip_callback(:save, :after, :ensure_one_default)
     Spree::StockItem.skip_callback(:save, :after, :process_backorders)
     location = Spree::StockLocation.new(name: 'default')
     location.save(validate: false)

--- a/core/db/migrate/20140717185932_add_default_to_spree_stock_locations.rb
+++ b/core/db/migrate/20140717185932_add_default_to_spree_stock_locations.rb
@@ -1,0 +1,5 @@
+class AddDefaultToSpreeStockLocations < ActiveRecord::Migration
+  def change
+    add_column :spree_stock_locations, :default, :boolean, null: false, default: false
+  end
+end

--- a/core/spec/models/spree/stock_location_spec.rb
+++ b/core/spec/models/spree/stock_location_spec.rb
@@ -133,6 +133,20 @@ module Spree
       Spree::StockLocation.active.count.should eq 1
     end
 
+    it 'ensures only one stock location is default at a time' do
+      first = create(:stock_location, :active => true, :default => true)
+      second = create(:stock_location, :active => true, :default => true)
+
+      first.reload.default.should eq false
+      second.reload.default.should eq true
+
+      first.default = true
+      first.save!
+
+      first.reload.default.should eq true
+      second.reload.default.should eq false
+    end
+
     context 'fill_status' do
       it 'all on_hand with no backordered' do
         on_hand, backordered = subject.fill_status(variant, 5)


### PR DESCRIPTION
When creating returns, the stock locations are currently shown in
whatever order the database returns. This allows designating a default
stock location, which will always show up first. That makes setting up
an RMA easier as we don't have to remember to choose the right location
every time.
