### PR TITLE
Dollar value line item calculators

### DIFF
--- a/core/app/models/spree/calculator/flat_percent_item_total.rb
+++ b/core/app/models/spree/calculator/flat_percent_item_total.rb
@@ -8,9 +8,8 @@ module Spree
       Spree.t(:flat_percent)
     end
 
-    def compute(line_item)
-      value = line_item.amount * BigDecimal(self.preferred_flat_percent.to_s) / 100.0
-      (value * 100).round.to_f / 100
+    def compute(object)
+      (object.amount * preferred_flat_percent / 100).round(2)
     end
   end
 end

--- a/core/app/models/spree/calculator/flexi_rate.rb
+++ b/core/app/models/spree/calculator/flexi_rate.rb
@@ -18,7 +18,7 @@ module Spree
     def compute(object)
       sum = 0
       max = self.preferred_max_items.to_i
-      items_count = object.line_items.map(&:quantity).sum
+      items_count = object.quantity
       items_count.times do |i|
         if i == 0
           sum += self.preferred_first_item.to_f

--- a/core/app/models/spree/calculator/percent_on_line_item.rb
+++ b/core/app/models/spree/calculator/percent_on_line_item.rb
@@ -8,7 +8,7 @@ module Spree
       end
 
       def compute(object)
-        ((object.price * object.quantity) * preferred_percent) / 100
+        (object.amount * preferred_percent) / 100
       end
     end
   end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -580,6 +580,10 @@ module Spree
       included_tax_total + additional_tax_total
     end
 
+    def quantity
+      line_items.sum(:quantity)
+    end
+
     private
 
       def link_by_email

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -1,7 +1,7 @@
 module Spree
   class OrderUpdater
     attr_reader :order
-    delegate :payments, :line_items, :adjustments, :all_adjustments, :shipments, :update_hooks, to: :order
+    delegate :payments, :line_items, :adjustments, :all_adjustments, :shipments, :update_hooks, :quantity, to: :order
 
     def initialize(order)
       @order = order
@@ -77,7 +77,7 @@ module Spree
     end
 
     def update_item_count
-      order.item_count = line_items.sum(:quantity)
+      order.item_count = quantity
     end
 
     def update_item_total

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -53,7 +53,9 @@ module Spree
 
         app.config.spree.calculators.add_class('promotion_actions_create_item_adjustments')
         app.config.spree.calculators.promotion_actions_create_item_adjustments = [
-          Spree::Calculator::PercentOnLineItem
+          Spree::Calculator::PercentOnLineItem,
+          Spree::Calculator::FlatRate,
+          Spree::Calculator::FlexiRate
         ]
       end
 

--- a/core/spec/models/spree/calculator/flexi_rate_spec.rb
+++ b/core/spec/models/spree/calculator/flexi_rate_spec.rb
@@ -5,11 +5,7 @@ describe Spree::Calculator::FlexiRate do
 
   let(:order) do
     mock_model(
-      Spree::Order,
-      :line_items => [
-        mock_model(Spree::LineItem, :amount => 10, :quantity => 4),
-        mock_model(Spree::LineItem, :amount => 20, :quantity => 6)
-      ]
+      Spree::Order, quantity: 10
     )
   end
 

--- a/core/spec/models/spree/calculator/percent_on_line_item_spec.rb
+++ b/core/spec/models/spree/calculator/percent_on_line_item_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module Spree
   class Calculator
     describe PercentOnLineItem do
-      let(:line_item) { double("LineItem", price: 10, quantity: 10) }
+      let(:line_item) { double("LineItem", amount: 100) }
 
       before { subject.preferred_percent = 15 }
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -648,4 +648,13 @@ describe Spree::Order do
       expect(subject.pre_tax_item_amount).to eq 19.0
     end
   end
+
+  describe '#quantity' do
+    # Uses a persisted record, as the quantity is retrieved via a DB count
+    let(:order) { create :order_with_line_items }
+
+    it 'sums the quantity of all line items' do
+      expect(order.quantity).to eq 5
+    end
+  end
 end


### PR DESCRIPTION
This allows store administrators to create dollar value off promotions, like $5 off all Ruby on Rails merchandise.  The flat rate calculator for line items will currently allow an admin to deduct a flat rate off of the total regardless of how many items have been ordered.

For example, a FlatRate of $5 off mugs results in the following on an order:
![screenshot from 2014-07-17 14 53 24](https://cloud.githubusercontent.com/assets/764390/3620205/01368494-0dfd-11e4-941e-fd15e95f2cf5.png)

It gives $5 off per line item matching the rules of the order, regardless of quantity ordered. If the desire is to give $5 per order, the Flexi Rate calculator does a great job:

![screenshot from 2014-07-17 14 54 14](https://cloud.githubusercontent.com/assets/764390/3620207/0137694a-0dfd-11e4-8346-ec79111a6072.png)
![screenshot from 2014-07-17 14 54 26](https://cloud.githubusercontent.com/assets/764390/3620206/0136c760-0dfd-11e4-87f5-7b27fd947e58.png)
