### PR TITLE
Reduce the number of cascading touches.

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -67,7 +67,8 @@ module Spree
     after_create :build_variants_from_option_values_hash, if: :option_values_hash
 
     after_save :save_master
-    after_save :touch
+    after_save :touch, if: :anything_changed?
+    after_save :reset_nested_changes
     after_touch :touch_taxons
 
     delegate :images, to: :master, prefix: true
@@ -260,10 +261,21 @@ module Spree
       update(slug: "#{Time.now.to_i}_#{slug}") # punch slug with date prefix to allow reuse of original
     end
 
+    def anything_changed?
+      changed? || @nested_changes
+    end
+
+    def reset_nested_changes
+      @nested_changes = false
+    end
+
     # there's a weird quirk with the delegate stuff that does not automatically save the delegate object
     # when saving so we force a save using a hook.
     def save_master
-      master.save if master && (master.changed? || master.new_record? || (master.default_price && (master.default_price.changed? || master.default_price.new_record?)))
+      if master && (master.changed? || master.new_record? || (master.default_price && (master.default_price.changed? || master.default_price.new_record?)))
+        master.save
+        @nested_changes = true
+      end
     end
 
     # ensures the master variant is flagged as such

--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -11,7 +11,7 @@ module Spree
 
     delegate :weight, :should_track_inventory?, to: :variant
 
-    after_save :conditional_variant_touch
+    after_save :conditional_variant_touch, if: :changed?
     after_touch { variant.touch }
 
     def backordered_inventory_units

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -207,8 +207,12 @@ module Spree
         end
       end
 
+      def default_price_changed?
+        default_price && (default_price.changed? || default_price.new_record?)
+      end
+
       def save_default_price
-        default_price.save if default_price && (default_price.changed? || default_price.new_record?)
+        default_price.save if default_price_changed?
       end
 
       def set_cost_currency


### PR DESCRIPTION
Please also bring this into 2-2-stable and 2-3-stable. :smile: 

For better performance when saving a product with many variants,
don't call `touch` when not necessary. 
- After saving a product, but neither the product nor its
  default price changed, don't touch it.
- After saving a stock item, only touch the variants if the stock
  item changed.

Background: in ActiveRecord, if a product has not changed,
product.save will not write to the DB--but it _will_ fire
the `after_save` callback. In that case there is no need to
touch anything.

Also factored out a method in variant.rb.
