### PR TITLE
Finish replacing old refund system

### DIFF
--- a/api/app/controllers/spree/api/payments_controller.rb
+++ b/api/app/controllers/spree/api/payments_controller.rb
@@ -3,7 +3,7 @@ module Spree
     class PaymentsController < Spree::Api::BaseController
 
       before_filter :find_order
-      before_filter :find_payment, only: [:update, :show, :authorize, :purchase, :capture, :void, :credit]
+      before_filter :find_payment, only: [:update, :show, :authorize, :purchase, :capture, :void]
 
       def index
         @payments = @order.payments.ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
@@ -53,15 +53,6 @@ module Spree
 
       def void
         perform_payment_action(:void_transaction)
-      end
-
-      def credit
-        if params[:amount].to_f > @payment.credit_allowed
-          render 'credit_over_limit', status: 422
-        else
-          reason = Spree::RefundReason.find(params[:refund_reason_id])
-          perform_payment_action(:credit, reason, params[:amount])
-        end
       end
 
       private

--- a/api/spec/controllers/spree/api/payments_controller_spec.rb
+++ b/api/spec/controllers/spree/api/payments_controller_spec.rb
@@ -214,40 +214,6 @@ module Spree
             end
           end
         end
-
-        context "crediting" do
-          let!(:refund_reason) { create(:refund_reason) }
-
-          before do
-            payment.purchase!
-          end
-
-          it "can credit" do
-            api_put :credit, :id => payment.to_param, :refund_reason_id => refund_reason.id
-            response.status.should == 200
-            payment.reload.state.should == "completed"
-
-            # Ensure that a refund was created, and it has correct credit amount
-            refund = payment.refunds.last
-            refund.amount.to_f.should == 45.75
-          end
-
-          context "crediting fails" do
-            it "returns a 422 status" do
-              fake_response = ActiveMerchant::Billing::Response.new(false, 'NO CREDIT FOR YOU', {}, {})
-              Spree::Gateway::Bogus.any_instance.should_receive(:credit).and_return(fake_response)
-              api_put :credit, :id => payment.to_param, :refund_reason_id => refund_reason.id
-              response.status.should == 422
-              json_response["error"].should == "There was a problem with the payment gateway: NO CREDIT FOR YOU"
-            end
-
-            it "cannot credit over credit_allowed limit" do
-              api_put :credit, :id => payment.to_param, :amount => 1000000, :refund_reason_id => refund_reason.id
-              response.status.should == 422
-              json_response["error"].should == "This payment can only be credited up to 45.75. Please specify an amount less than or equal to this number."
-            end
-          end
-        end
       end
     end
   end

--- a/backend/app/controllers/spree/admin/payments_controller.rb
+++ b/backend/app/controllers/spree/admin/payments_controller.rb
@@ -11,7 +11,8 @@ module Spree
       respond_to :html
 
       def index
-        @payments = @order.payments
+        @payments = @order.payments.includes(:refunds => :reason)
+        @refunds = @payments.flat_map(&:refunds)
         redirect_to new_admin_order_payment_url(@order) if @payments.empty?
       end
 

--- a/backend/app/controllers/spree/admin/refunds_controller.rb
+++ b/backend/app/controllers/spree/admin/refunds_controller.rb
@@ -1,0 +1,31 @@
+module Spree
+  module Admin
+    class RefundsController < ResourceController
+      belongs_to 'spree/payment'
+      before_filter :load_order
+
+      helper_method :refund_reasons
+
+      private
+
+      def location_after_save
+        admin_order_payments_path(@payment.order)
+      end
+
+      def load_order
+        # the spree/admin/shared/order_tabs partial expects the @order instance variable to be set
+        @order = @payment.order if @payment
+      end
+
+      def refund_reasons
+        @refund_reasons ||= RefundReason.active.all
+      end
+
+      def build_resource
+        super.tap do |refund|
+          refund.amount = refund.payment.credit_allowed
+        end
+      end
+    end
+  end
+end

--- a/backend/app/views/spree/admin/payments/_list.html.erb
+++ b/backend/app/views/spree/admin/payments/_list.html.erb
@@ -5,6 +5,7 @@
       <th><%= "#{Spree.t('date')}/#{Spree.t('time')}" %></th>
       <th><%= Spree.t(:amount) %></th>
       <th><%= Spree.t(:payment_method) %></th>
+      <th><%= Spree.t(:transaction_id) %></th>
       <th><%= Spree.t(:payment_state) %></th>
       <th class="actions"></th>
     </tr>
@@ -16,10 +17,15 @@
         <td><%= pretty_time(payment.created_at) %></td>
         <td class="align-center amount"><%= payment.display_amount.to_html %></td>
         <td class="align-center"><%= payment_method_name(payment) %></td>
+        <td class="align-center"><%= payment.transaction_id %></td>
         <td class="align-center"> <span class="state <%= payment.state %>"><%= Spree.t(payment.state, :scope => :payment_states, :default => payment.state.capitalize) %></span></td>
         <td class="actions">
           <% payment.actions.each do |action| %>
-            <%= link_to_with_icon action, Spree.t(action), fire_admin_order_payment_path(@order, payment, :e => action), :method => :put, :no_text => true, :data => {:action => action} %>
+            <% if action == 'credit' %>
+              <%= link_to_with_icon 'reply', Spree.t(:refund), new_admin_order_payment_refund_path(@order, payment), no_text: true %>
+            <% else %>
+              <%= link_to_with_icon action, Spree.t(action), fire_admin_order_payment_path(@order, payment, :e => action), :method => :put, :no_text => true, :data => {:action => action} %>
+            <% end %>
           <% end %>
         </td>
       </tr>

--- a/backend/app/views/spree/admin/payments/_refunds.html.erb
+++ b/backend/app/views/spree/admin/payments/_refunds.html.erb
@@ -5,15 +5,23 @@
       <th><%= Spree.t(:payment_identifier) %></th>
       <th><%= Spree.t(:amount) %></th>
       <th><%= Spree.t(:payment_method) %></th>
+      <th><%= Spree.t(:transaction_id) %></th>
+      <th><%= Spree.t(:reason) %></th>
+      <th class="actions"></th>
     </tr>
   </thead>
   <tbody>
     <% refunds.each do |refund| %>
       <tr id="<%= dom_id(refund) %>" data-hook="refunds_row" class="<%= cycle('odd', 'even', name: 'refund_table_cycle')%>">
         <td><%= pretty_time(refund.created_at) %></td>
-        <td><%= refund.payment.identifier %></td>
+        <td class="align-center"><%= refund.payment.identifier %></td>
         <td class="align-center amount"><%= refund.display_amount %></td>
         <td class="align-center"><%= payment_method_name(refund.payment) %></td>
+        <td class="align-center"><%= refund.transaction_id %></td>
+        <td class="align-center"><%= truncate(refund.reason.name, length: 100) %></td>
+        <td class="actions">
+          <%= link_to_with_icon 'edit', Spree.t(:edit), edit_admin_order_payment_refund_path(refund.payment.order, refund.payment, refund), no_text: true %>
+        </td>
       </tr>
     <% end %>
   </tbody>

--- a/backend/app/views/spree/admin/payments/index.html.erb
+++ b/backend/app/views/spree/admin/payments/index.html.erb
@@ -24,7 +24,6 @@
     <%= render :partial => 'list', :locals => { :payments => @payments } %>
   </fieldset>
 
-  <% @refunds = @payments.flat_map(&:refunds) %>
   <% if @refunds.any? %>
     <fieldset data-hook="payment_list" class="no-border-bottom">
       <legend align="center"><%= Spree.t(:refunds) %></legend>

--- a/backend/app/views/spree/admin/refunds/edit.html.erb
+++ b/backend/app/views/spree/admin/refunds/edit.html.erb
@@ -1,0 +1,31 @@
+<%= render partial: 'spree/admin/shared/order_tabs', locals: {current: 'Payments'} %>
+
+<% content_for :page_title do %>
+  <i class="fa fa-arrow-right"></i> <%= link_to "#{Spree.t(:payment)} #{@refund.payment.id}", admin_order_payment_path(@refund.payment.order, @refund.payment) %>
+  <i class="fa fa-arrow-right"></i> <%= Spree.t(:editing_refund) %> <%= @refund.id %>
+<% end %>
+
+<%= form_for [:admin, @refund.payment.order, @refund.payment, @refund] do |f| %>
+  <fieldset class="no-border-top">
+    <div data-hook="admin_refund_form_fields" class="row">
+      <div class="alpha three columns">
+        <div class="field">
+          <%= Spree.t(:amount) %><br/>
+          <%= @refund.amount %>
+        </div>
+      </div>
+      <div class="alpha three columns">
+        <div class="field">
+          <%= f.label :refund_reason_id, Spree.t(:reason) %><br/>
+          <%= f.collection_select(:refund_reason_id, refund_reasons, :id, :name, {}, {class: 'select2 fullwidth'}) %>
+        </div>
+      </div>
+    </div>
+
+    <div class="form-buttons filter-actions actions" data-hook="buttons">
+      <%= button Spree.t('actions.save'), 'ok' %>
+      <span class="or"><%= Spree.t(:or) %></span>
+      <%= button_link_to Spree.t('actions.cancel'), admin_order_payments_url(@refund.payment.order), icon: 'remove' %>
+    </div>
+  </fieldset>
+<% end %>

--- a/backend/app/views/spree/admin/refunds/new.html.erb
+++ b/backend/app/views/spree/admin/refunds/new.html.erb
@@ -1,0 +1,43 @@
+<%= render partial: 'spree/admin/shared/order_tabs', locals: {current: 'Payments'} %>
+
+<% content_for :page_title do %>
+  <i class="fa fa-arrow-right"></i> <%= link_to "#{Spree.t(:payment)} #{@refund.payment.id}", admin_order_payment_path(@refund.payment.order, @refund.payment) %>
+  <i class="fa fa-arrow-right"></i> <%= Spree.t(:new_refund) %>
+<% end %>
+
+<%= form_for [:admin, @refund.payment.order, @refund.payment, @refund] do |f| %>
+  <fieldset class="no-border-top">
+    <div data-hook="admin_refund_form_fields" class="row">
+      <div class="alpha three columns">
+        <div class="field">
+          <%= Spree.t(:payment_amount) %><br/>
+          <%= @refund.payment.amount %>
+        </div>
+      </div>
+      <div class="alpha three columns">
+        <div class="field">
+          <%= Spree.t(:credit_allowed) %><br/>
+          <%= @refund.payment.credit_allowed %>
+        </div>
+      </div>
+      <div class="alpha three columns">
+        <div class="field">
+          <%= f.label :amount, Spree.t(:amount) %><br/>
+          <%= f.text_field :amount, class: 'fullwidth' %>
+        </div>
+      </div>
+      <div class="alpha three columns">
+        <div class="field">
+          <%= f.label :refund_reason_id, Spree.t(:reason) %><br/>
+          <%= f.collection_select(:refund_reason_id, refund_reasons, :id, :name, {include_blank: true}, {class: 'select2 fullwidth'}) %>
+        </div>
+      </div>
+    </div>
+
+    <div class="form-buttons filter-actions actions" data-hook="buttons">
+      <%= button Spree.t(:refund), 'ok' %>
+      <span class="or"><%= Spree.t(:or) %></span>
+      <%= button_link_to Spree.t('actions.cancel'), admin_order_payments_url(@refund.payment.order), icon: 'remove' %>
+    </div>
+  </fieldset>
+<% end %>

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -94,6 +94,7 @@ Spree::Core::Engine.add_routes do
         end
 
         resources :log_entries
+        resources :refunds, only: [:new, :edit, :create, :update]
       end
     end
 

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -70,7 +70,7 @@ describe 'Payments' do
       within_row(1) do
         column_text(3).should == '$150.00'
         column_text(4).should == 'Credit Card'
-        column_text(5).should == 'CHECKOUT'
+        column_text(6).should == 'CHECKOUT'
       end
 
       click_icon :void
@@ -80,7 +80,7 @@ describe 'Payments' do
       within_row(1) do
         column_text(3).should == '$150.00'
         column_text(4).should == 'Credit Card'
-        column_text(5).should == 'VOID'
+        column_text(6).should == 'VOID'
       end
 
       click_on 'New Payment'

--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -91,9 +91,7 @@ module Spree
     # Indicates whether its possible to credit the payment.  Note that most gateways require that the
     # payment be settled first which generally happens within 12-24 hours of the transaction.
     def can_credit?(payment)
-      return false unless payment.completed?
-      return false unless payment.order.payment_state == 'credit_owed'
-      payment.credit_allowed > 0
+      payment.completed? && payment.credit_allowed > 0
     end
 
     def has_payment_profile?

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -80,22 +80,8 @@ module Spree
         end
       end
 
-      def credit!(reason, credit_amount=nil, return_authorization=nil)
-        Spree::Refund.perform!(self, reason, (credit_amount || credit_allowed).to_f, return_authorization)
-      end
-
       def cancel!
-        if payment_method.respond_to?(:cancel)
-          payment_method.cancel(response_code)
-        else
-          credit!(credit_allowed.abs)
-        end
-      end
-
-      def partial_credit(reason, amount)
-        return if amount > credit_allowed
-        started_processing!
-        credit!(reason, amount)
+        payment_method.cancel(response_code)
       end
 
       def gateway_options

--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -82,7 +82,11 @@ module Spree
       order.payments.completed.each do |payment|
         break if amount_due <= 0
         credit_allowed = [payment.credit_allowed, amount_due].min
-        payment.credit!(Spree::RefundReason.return_processing_reason, credit_allowed, self)
+        payment.refunds.create!({
+          amount: credit_allowed,
+          return_authorization: self,
+          reason: Spree::RefundReason.return_processing_reason,
+        })
       end
 
       case amount_due

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -254,6 +254,11 @@ en:
             base:
               amount_due_less_than_zero: Amount due is less than zero
               amount_due_greater_than_zero: Unable to refund full amount
+        spree/refund:
+          attributes:
+            amount:
+              greater_than_allowed: is greater than the allowed amount.
+
   devise:
     confirmations:
       confirmed: Your account was successfully confirmed. You are now signed in.
@@ -562,6 +567,7 @@ en:
     editing_promotion: Editing Promotion
     editing_property: Editing Property
     editing_prototype: Editing Prototype
+    edit_refund_reason: Edit Refund Reason
     editing_refund_reason: Editing Refund Reason
     editing_rma_reason: Editing RMA Reason
     editing_shipping_category: Editing Shipping Category
@@ -746,6 +752,7 @@ en:
     new_promotion: New Promotion
     new_property: New Property
     new_prototype: New Prototype
+    new_refund: New Refund
     new_refund_reason: New Refund Reason
     new_rma_reason: New RMA Reason
     new_return_authorization: New Return Authorization
@@ -1152,6 +1159,7 @@ en:
     tracking_number: Tracking Number
     tracking_url: Tracking URL
     tracking_url_placeholder: e.g. http://quickship.com/package?num=:tracking
+    transaction_id: Transaction ID
     transfer_from_location: Transfer From
     transfer_stock: Transfer Stock
     transfer_to_location: Transfer To

--- a/core/lib/spree/testing_support/factories/refund_factory.rb
+++ b/core/lib/spree/testing_support/factories/refund_factory.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     amount 100.00
     transaction_id 'TEST123'
     association(:payment, state: 'completed')
-    association(:refund_reason)
+    association(:reason, factory: :refund_reason)
   end
 
   factory :refund_reason, class: Spree::RefundReason do

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -64,11 +64,6 @@ describe Spree::CreditCard do
       credit_card.can_credit?(payment).should be_false
     end
 
-    it "should be false when order payment_state is not 'credit_owed'" do
-      payment = mock_model(Spree::Payment, completed?: true, order: mock_model(Spree::Order, payment_state: 'paid'))
-      credit_card.can_credit?(payment).should be_false
-    end
-
     it "should be false when credit_allowed is zero" do
       payment = mock_model(Spree::Payment, completed?: true, credit_allowed: 0, order: mock_model(Spree::Order, payment_state: 'credit_owed'))
       credit_card.can_credit?(payment).should be_false

--- a/core/spec/models/spree/refund_spec.rb
+++ b/core/spec/models/spree/refund_spec.rb
@@ -2,20 +2,43 @@ require 'spec_helper'
 
 describe Spree::Refund do
 
-  describe '.perform!' do
-    let(:payment_amount) { 100.0 }
+  describe 'create' do
+    let(:amount) { 100.0 }
+    let(:amount_in_cents) { amount * 100 }
+
     let(:authorization) { "TEST12" }
-    let(:payment) { create(:payment) }
+
+    let(:payment) { create(:payment, amount: payment_amount, payment_method: payment_method) }
+    let(:payment_amount) { amount*2 }
+    let(:payment_method) { create(:credit_card_payment_method, environment: payment_method_environment) }
+    let(:payment_method_environment) { 'test' }
+
     let(:refund_reason) { create(:refund_reason) }
 
-    subject { Spree::Refund.perform!(payment, refund_reason, payment_amount) }
+    let(:gateway_response) {
+      ActiveMerchant::Billing::Response.new(
+        gateway_response_success,
+        gateway_response_message,
+        gateway_response_params,
+        gateway_response_options
+      )
+    }
+    let(:gateway_response_success) { true }
+    let(:gateway_response_message) { "" }
+    let(:gateway_response_params) { {} }
+    let(:gateway_response_options) { {} }
+
+    subject { create(:refund, payment: payment, amount: amount, reason: refund_reason) }
+
+    before do
+      payment.payment_method
+        .stub(:credit)
+        .with(amount_in_cents, payment.source, payment.transaction_id, {})
+        .and_return(gateway_response)
+    end
 
     context "processing is successful" do
-      let(:response) {
-        ActiveMerchant::Billing::Response.new(true, "", {}, { authorization: authorization })
-      }
-
-      before { Spree::Refund.should_receive(:process!) { response } }
+      let(:gateway_response_options) { { authorization: authorization } }
 
       it 'should create a refund' do
         expect{ subject }.to change{ Spree::Refund.count }.by(1)
@@ -30,7 +53,7 @@ describe Spree::Refund do
       end
 
       it 'should save the passed amount as the refund amount' do
-        expect(subject.amount).to eq payment_amount
+        expect(subject.amount).to eq amount
       end
 
       it 'should create a log entry' do
@@ -39,102 +62,51 @@ describe Spree::Refund do
     end
 
     context "processing fails" do
-      before do
-        Spree::Refund.should_receive(:process!)
-          .and_raise(Spree::Core::GatewayError)
-      end
+      let(:gateway_response_success) { false }
+      let(:gateway_response_message) { "failure message" }
 
       it 'should raise error and not create a refund' do
         expect do
-          expect { subject }.to raise_error(Spree::Core::GatewayError)
+          expect { subject }.to raise_error(Spree::Core::GatewayError, gateway_response_message)
         end.to_not change{ Spree::Refund.count }
       end
     end
-  end
-
-  describe '.process!' do
-    let(:payment) { create(:payment) }
-    let(:credit_cents) { 10_00 }
-    let(:response) {
-      ActiveMerchant::Billing::Response.new(response_success, response_message, {}, {})
-    }
-    let(:response_message) { "response message" }
-    let(:response_success) { true }
-    let(:support_payment_profiles) { true }
-
-    before do
-      payment.payment_method.stub(:payment_profiles_supported?) { support_payment_profiles }
-    end
-
-    subject { Spree::Refund.process!(payment, credit_cents) }
 
     context 'without payment profiles supported' do
-      let(:support_payment_profiles) { false }
-
       before do
-        payment.payment_method
-          .should_receive(:credit)
-          .with(credit_cents, payment.transaction_id, {})
-          .and_return(response)
+        payment.payment_method.stub(:payment_profiles_supported?) { false }
       end
 
-      it 'should supply the payment source' do
+      it 'should not supply the payment source' do
+        payment.payment_method
+          .should_receive(:credit)
+          .with(amount * 100, payment.transaction_id, {})
+          .and_return(gateway_response)
+
         subject
       end
     end
 
     context 'with payment profiles supported' do
-      let(:support_payment_profiles) { true }
-
       before do
-        payment.payment_method
-          .should_receive(:credit)
-          .with(credit_cents, payment.source, payment.transaction_id, {})
-          .and_return(response)
+        payment.payment_method.stub(:payment_profiles_supported?) { true }
       end
 
       it 'should supply the payment source' do
+        payment.payment_method
+          .should_receive(:credit)
+          .with(amount_in_cents, payment.source, payment.transaction_id, {})
+          .and_return(gateway_response)
+
         subject
       end
     end
 
-    context 'with successful response' do
-      let(:response_success) { true }
-
+    context 'with an activemerchant gateway connection error' do
       before do
         payment.payment_method
           .should_receive(:credit)
-          .with(credit_cents, payment.source, payment.transaction_id, {})
-          .and_return(response)
-      end
-
-      it 'returns the response' do
-        expect(subject).to eq response
-      end
-    end
-
-    context 'with unsuccessful response' do
-      let(:response_success) { false }
-
-      before do
-        payment.payment_method
-          .should_receive(:credit)
-          .with(credit_cents, payment.source, payment.transaction_id, {})
-          .and_return(response)
-      end
-
-      it 'raises Spree::Core:GatewayError' do
-        expect { subject }.to raise_error(Spree::Core::GatewayError, response_message)
-      end
-    end
-
-    context 'with activemerchant gateway connection error' do
-      let(:response_success) { false }
-
-      before do
-        payment.payment_method
-          .should_receive(:credit)
-          .with(credit_cents, payment.source, payment.transaction_id, {})
+          .with(amount_in_cents, payment.source, payment.transaction_id, {})
           .and_raise(ActiveMerchant::ConnectionError)
       end
 
@@ -142,55 +114,27 @@ describe Spree::Refund do
         expect { subject }.to raise_error(Spree::Core::GatewayError, Spree.t(:unable_to_connect_to_gateway))
       end
     end
-  end
 
-  describe '.check_environment' do
-    subject { Spree::Refund.check_environment(payment) }
-
-    let(:payment) { create(:payment, payment_method: payment_method) }
-    let(:payment_method) { create(:credit_card_payment_method, environment: payment_method_environment) }
-    let(:payment_method_environment) { 'test' }
-
-    context 'correct payment method environment' do
-      it 'does not raise' do
-        expect { subject }.not_to raise_error
-      end
-    end
-
-    context 'incorrect payment method environment' do
+    context 'with the incorrect payment method environment' do
       let(:payment_method_environment) { 'development' }
 
       it 'raises a Spree::Core::GatewayError' do
-        expect { subject }.to raise_error(Spree::Core::GatewayError)
-      end
-    end
-  end
-
-  describe '.check_amount' do
-
-    subject { Spree::Refund.check_amount(amount) }
-
-    context 'amount is less tha zero' do
-      let(:amount) { -1.0 }
-
-      it 'raises Spree::Core::GatewayError' do
-        expect { subject }.to raise_error(Spree::Core::GatewayError, Spree.t(:refund_amount_must_be_greater_than_zero))
+        expect { subject }.to raise_error { |error|
+          expect(error).to be_a(ActiveRecord::RecordInvalid)
+          expect(error.record.errors.full_messages).to eq [Spree.t(:gateway_config_unavailable) + " - test"]
+        }
       end
     end
 
-    context 'amount is zero' do
-      let(:amount) { 0.0 }
+    context 'with amount too large' do
+      let(:payment_amount) { 10 }
+      let(:amount) { payment_amount*2 }
 
-      it 'raises Spree::Core::GatewayError' do
-        expect { subject }.to raise_error(Spree::Core::GatewayError, Spree.t(:refund_amount_must_be_greater_than_zero))
-      end
-    end
-
-    context 'amount is larger than zero' do
-      let(:amount) { 10.0 }
-
-      it 'does not raise an error' do
-        expect { subject }.to_not raise_error
+      it 'is invalid' do
+        expect { subject }.to raise_error { |error|
+          expect(error).to be_a(ActiveRecord::RecordInvalid)
+          expect(error.record.errors.full_messages).to eq ["Amount #{I18n.t('activerecord.errors.models.spree/refund.attributes.amount.greater_than_allowed')}"]
+        }
       end
     end
   end


### PR DESCRIPTION
- Stop requiring negative adjustments in order to perform refunds
- Add new admin pages to manage refunds
- Remove Payment#credit! (and associated controller actions) and instead use refund objects that are linked to payments
- Update Payment#cancel so that it no longer falls back to a full refund
- Refactor some code in the Refund model
