### PR TITLE
Add slug history to product

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -21,7 +21,7 @@
 module Spree
   class Product < Spree::Base
     extend FriendlyId
-    friendly_id :slug_candidates, use: :slugged
+    friendly_id :slug_candidates, use: :history
 
     acts_as_paranoid
 

--- a/core/config/initializers/friendly_id.rb
+++ b/core/config/initializers/friendly_id.rb
@@ -1,0 +1,88 @@
+# FriendlyId Global Configuration
+#
+# Use this to set up shared configuration options for your entire application.
+# Any of the configuration options shown here can also be applied to single
+# models by passing arguments to the `friendly_id` class method or defining
+# methods in your model.
+#
+# To learn more, check out the guide:
+#
+# http://norman.github.io/friendly_id/file.Guide.html
+
+FriendlyId.defaults do |config|
+  # ## Reserved Words
+  #
+  # Some words could conflict with Rails's routes when used as slugs, or are
+  # undesirable to allow as slugs. Edit this list as needed for your app.
+  config.use :reserved
+
+  config.reserved_words = %w(new edit index session login logout users admin
+    stylesheets assets javascripts images)
+
+  #  ## Friendly Finders
+  #
+  # Uncomment this to use friendly finders in all models. By default, if
+  # you wish to find a record by its friendly id, you must do:
+  #
+  #    MyModel.friendly.find('foo')
+  #
+  # If you uncomment this, you can do:
+  #
+  #    MyModel.find('foo')
+  #
+  # This is significantly more convenient but may not be appropriate for
+  # all applications, so you must explicity opt-in to this behavior. You can
+  # always also configure it on a per-model basis if you prefer.
+  #
+  # Something else to consider is that using the :finders addon boosts
+  # performance because it will avoid Rails-internal code that makes runtime
+  # calls to `Module.extend`.
+  #
+  # config.use :finders
+  #
+  # ## Slugs
+  #
+  # Most applications will use the :slugged module everywhere. If you wish
+  # to do so, uncomment the following line.
+  #
+  # config.use :slugged
+  #
+  # By default, FriendlyId's :slugged addon expects the slug column to be named
+  # 'slug', but you can change it if you wish.
+  #
+  # config.slug_column = 'slug'
+  #
+  # When FriendlyId can not generate a unique ID from your base method, it appends
+  # a UUID, separated by a single dash. You can configure the character used as the
+  # separator. If you're upgrading from FriendlyId 4, you may wish to replace this
+  # with two dashes.
+  #
+  # config.sequence_separator = '-'
+  #
+  #  ## Tips and Tricks
+  #
+  #  ### Controlling when slugs are generated
+  #
+  # As of FriendlyId 5.0, new slugs are generated only when the slug field is
+  # nil, but if you're using a column as your base method can change this
+  # behavior by overriding the `should_generate_new_friendly_id` method that
+  # FriendlyId adds to your model. The change below makes FriendlyId 5.0 behave
+  # more like 4.0.
+  #
+  # config.use Module.new {
+  #   def should_generate_new_friendly_id?
+  #     slug.blank? || <your_column_name_here>_changed?
+  #   end
+  # }
+  #
+  # FriendlyId uses Rails's `parameterize` method to generate slugs, but for
+  # languages that don't use the Roman alphabet, that's not usually suffient. Here
+  # we use the Babosa library to transliterate Russian Cyrillic slugs to ASCII. If
+  # you use this, don't forget to add "babosa" to your Gemfile.
+  #
+  # config.use Module.new {
+  #   def normalize_friendly_id(text)
+  #     text.to_slug.normalize! :transliterations => [:russian, :latin]
+  #   end
+  # }
+end

--- a/core/db/migrate/20140718195325_create_friendly_id_slugs.rb
+++ b/core/db/migrate/20140718195325_create_friendly_id_slugs.rb
@@ -1,0 +1,15 @@
+class CreateFriendlyIdSlugs < ActiveRecord::Migration
+  def change
+    create_table :friendly_id_slugs do |t|
+      t.string   :slug,           :null => false
+      t.integer  :sluggable_id,   :null => false
+      t.string   :sluggable_type, :limit => 50
+      t.string   :scope
+      t.datetime :created_at
+    end
+    add_index :friendly_id_slugs, :sluggable_id
+    add_index :friendly_id_slugs, [:slug, :sluggable_type]
+    add_index :friendly_id_slugs, [:slug, :sluggable_type, :scope], :unique => true
+    add_index :friendly_id_slugs, :sluggable_type
+  end
+end


### PR DESCRIPTION
Ability to have historical slugs for products, to avoid 404s when a slug changes. Leverages friendly_id history.

A bit more can be found about friendly_id history here:
http://rubydoc.info/github/norman/friendly_id/master/FriendlyId/History
