### PR TITLE
Order history should be reverse chronological

### DIFF
--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -65,7 +65,7 @@ module Spree
 
       def mine
         if current_api_user.persisted?
-          @orders = current_api_user.orders.ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
+          @orders = current_api_user.orders.reverse_chronological.ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
         else
           render "spree/api/errors/unauthorized", status: :unauthorized
         end

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -73,6 +73,18 @@ module Spree
         response.status.should == 200
         json_response["orders"].length.should == 0
       end
+
+      it "returns orders in reverse chronological order" do
+        order2 = create(:order, line_items: [line_item], user: order.user)
+        order2.created_at.should > order.created_at
+
+        api_get :mine
+        response.status.should == 200
+        json_response["pages"].should == 1
+        json_response["orders"].length.should == 2
+        json_response["orders"][0]["number"].should == order2.number
+        json_response["orders"][1]["number"].should == order.number
+      end
     end
 
     it "can view their own order" do

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -89,6 +89,8 @@ module Spree
     scope :created_between, ->(start_date, end_date) { where(created_at: start_date..end_date) }
     scope :completed_between, ->(start_date, end_date) { where(completed_at: start_date..end_date) }
 
+    scope :reverse_chronological, -> { order(created_at: :desc) }
+
     def self.by_customer(customer)
       joins(:user).where("#{Spree.user_class.table_name}.email" => customer)
     end


### PR DESCRIPTION
Right now, it is just returned in random database order. Might we want to backport this to 2-2-stable and 2-3-stable also?
