### PR TITLE
Order history should be by completed_at, not created_at

### DIFF
--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -73,16 +73,24 @@ module Spree
         json_response["orders"].length.should == 0
       end
 
-      it "returns orders in reverse chronological order" do
-        order2 = create(:order, line_items: [line_item], user: order.user)
+      it "returns orders in reverse chronological order by completed_at" do
+        order.update_columns completed_at: Time.now
+
+        order2 = Order.create user: order.user, completed_at: Time.now - 1.day
         order2.created_at.should > order.created_at
+        order3 = Order.create user: order.user, completed_at: nil
+        order3.created_at.should > order2.created_at
+        order4 = Order.create user: order.user, completed_at: nil
+        order4.created_at.should > order3.created_at
 
         api_get :mine
         response.status.should == 200
         json_response["pages"].should == 1
-        json_response["orders"].length.should == 2
-        json_response["orders"][0]["number"].should == order2.number
-        json_response["orders"][1]["number"].should == order.number
+        json_response["orders"].length.should == 4
+        json_response["orders"][0]["number"].should == order.number
+        json_response["orders"][1]["number"].should == order2.number
+        json_response["orders"][2]["number"].should == order4.number
+        json_response["orders"][3]["number"].should == order3.number
       end
     end
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -89,7 +89,8 @@ module Spree
     scope :created_between, ->(start_date, end_date) { where(created_at: start_date..end_date) }
     scope :completed_between, ->(start_date, end_date) { where(completed_at: start_date..end_date) }
 
-    scope :reverse_chronological, -> { order(created_at: :desc) }
+    # shows completed orders first, by their completed_at date, then uncompleted orders by their created_at
+    scope :reverse_chronological, -> { order('spree_orders.completed_at IS NULL', completed_at: :desc, created_at: :desc) }
 
     def self.by_customer(customer)
       joins(:user).where("#{Spree.user_class.table_name}.email" => customer)


### PR DESCRIPTION
Otherwise, orders that use an old cart appear way out of order. This will show
completed orders first, ordered by completed_at desc, then the rest ordered by
created_at desc.

Sorry for the piecemeal PRs here...
