### PR TITLE
Fix spec for ruby 2.0

### DIFF
--- a/core/spec/models/spree/return_authorization_spec.rb
+++ b/core/spec/models/spree/return_authorization_spec.rb
@@ -366,7 +366,7 @@ describe Spree::ReturnAuthorization do
       total_1 = pre_tax_amount_1 + additional_tax_total_1
       total_2 = pre_tax_amount_2 + additional_tax_total_2
       total_3 = pre_tax_amount_3 + additional_tax_total_3
-      subject.should eq total_1 + total_2 + total_3
+      subject.round(2).should eq total_1 + total_2 + total_3
     end
   end
 


### PR DESCRIPTION
With Ruby 2.0.0 p451 this was giving:

```
expected: 95.17
     got: #<BigDecimal: 95.17000000000001>
```
