### PR TITLE
return 204 for PUT /orders/empty

### DIFF
--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -34,7 +34,7 @@ module Spree
       def empty
         authorize! :update, @order, order_token
         @order.empty!
-        render text: nil, status: 200
+        render text: nil, status: 204
       end
 
       def index

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -384,7 +384,7 @@ module Spree
         it "can empty an order" do
           order_with_line_items.adjustments.count.should be == 1
           api_put :empty, :id => order_with_line_items.to_param
-          response.status.should == 200
+          response.status.should == 204
           order_with_line_items.reload
           order_with_line_items.line_items.should be_empty
           order_with_line_items.adjustments.should be_empty


### PR DESCRIPTION
Not a big deal but if we are not going to return a payload back in PUT /api/orders/:id/empty, perhaps 204 is a more accurate status code. It's the more HTTP/RESTful way of expressing OK, No-Content.

For those of us writing clients, it just eliminates one extra check for a response body before running it through a JSON parser.
