### PR TITLE
Refactor Line Item Promotion Actions & Eligibility

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -6,3 +6,11 @@
   shipment's total will be captured from the authorization. Fixes #4727
 
      Jeff Dutil
+
+* Added `actionable?` for Spree::Promotion::Rule. `actionable?` defines
+  if a promotion action can be applied to a specific line item. This
+  can be used to customize which line items can accept a promotion
+  action by defining its logic within the promotion rule rather than
+  relying on Spree's default behaviour. Fixes #5036
+
+    Gregor MacDougall

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -76,6 +76,9 @@ module Spree
       !!eligible_rules(promotable, {})
     end
 
+    # eligible_rules returns an array of promotion rules where eligible? is true for the promotable
+    # if there are no such rules, an empty array is returned
+    # if the rules make this promotable ineligible, then nil is returned (i.e. this promotable is not eligible)
     def eligible_rules(promotable, options = {})
       # Promotions without rules are eligible by default.
       return [] if rules.none?

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -111,13 +111,17 @@ module Spree
     end
 
     def line_item_actionable?(order, line_item)
-      rules = eligible_rules(order)
-      if rules.blank?
-        eligible? order
-      else
-        rules.send(match_all? ? :all? : :any?) do |rule|
-          rule.actionable? line_item
+      if eligible? order
+        rules = eligible_rules(order)
+        if rules.blank?
+          true
+        else
+          rules.send(match_all? ? :all? : :any?) do |rule|
+            rule.actionable? line_item
+          end
         end
+      else
+        false
       end
     end
 

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -49,6 +49,8 @@ module Spree
       order = payload[:order]
       return unless self.class.order_activatable?(order)
 
+      payload[:promotion] = self
+
       # Track results from actions to see if any action has been taken.
       # Actions should return nil/false if no action has been taken.
       # If an action returns true, then an action has been taken.
@@ -71,35 +73,25 @@ module Spree
     # called anytime order.update! happens
     def eligible?(promotable)
       return false if expired? || usage_limit_exceeded?(promotable)
-      rules_are_eligible?(promotable, {})
+      !!eligible_rules(promotable, {})
     end
 
-    def rules_are_eligible?(promotable, options = {})
+    def eligible_rules(promotable, options = {})
       # Promotions without rules are eligible by default.
-      return true if rules.none?
+      return [] if rules.none?
       eligible = lambda { |r| r.eligible?(promotable, options) }
       specific_rules = rules.for(promotable)
-      return true if specific_rules.none?
-      if match_policy == 'all'
+      return [] if specific_rules.none?
+
+      if match_all?
         # If there are rules for this promotion, but no rules for this
         # particular promotable, then the promotion is ineligible by default.
-        specific_rules.any? && specific_rules.all?(&eligible)
+        return nil unless specific_rules.all?(&eligible)
+        specific_rules
       else
-        # If there are no rules for this promotable, then this will return false.
-        # If there are rules for this promotable, but they are ineligible, this will return false.
-        specific_rules.any?(&eligible)
+        return nil unless specific_rules.any?(&eligible)
+        specific_rules.select(&eligible)
       end
-    end
-
-    # Products assigned to all product rules
-    def products
-      @products ||= self.rules.to_a.inject([]) do |products, rule|
-        rule.respond_to?(:products) ? products << rule.products : products
-      end.flatten.uniq
-    end
-
-    def product_ids
-      products.map(&:id)
     end
 
     def usage_limit_exceeded?(promotable)
@@ -118,11 +110,26 @@ module Spree
       credits.count
     end
 
+    def line_item_actionable?(order, line_item)
+      rules = eligible_rules(order)
+      if rules.blank?
+        eligible? order
+      else
+        rules.send(match_all? ? :all? : :any?) do |rule|
+          rule.actionable? line_item
+        end
+      end
+    end
+
     private
     def normalize_blank_values
       [:code, :path].each do |column|
         self[column] = nil if self[column].blank?
       end
+    end
+
+    def match_all?
+      match_policy == 'all'
     end
   end
 end

--- a/core/app/models/spree/promotion/rules/product.rb
+++ b/core/app/models/spree/promotion/rules/product.rb
@@ -30,6 +30,10 @@ module Spree
           end
         end
 
+        def actionable?(line_item)
+          product_ids.include? line_item.variant.product_id
+        end
+
         def product_ids_string
           product_ids.join(',')
         end

--- a/core/app/models/spree/promotion_rule.rb
+++ b/core/app/models/spree/promotion_rule.rb
@@ -20,6 +20,12 @@ module Spree
       raise 'eligible? should be implemented in a sub-class of Spree::PromotionRule'
     end
 
+    # This states if a promotion can be applied to the specified line item
+    # It is true by default, but can be overridden by promotion rules to provide conditions
+    def actionable?(line_item)
+      true
+    end
+
     private
     def unique_per_promotion
       if Spree::PromotionRule.exists?(promotion_id: promotion_id, type: self.class.name)

--- a/core/spec/models/spree/item_adjustments_spec.rb
+++ b/core/spec/models/spree/item_adjustments_spec.rb
@@ -158,11 +158,10 @@ module Spree
             line_item_promos[promo_sequence[1]].activate order: order
 
             order.reload
-            order.all_adjustments.count.should eq(2), "Expected two adjustments (using sequence #{promo_sequence})"
+            order.all_adjustments.count.should eq(1), "Expected one adjustment (using sequence #{promo_sequence})"
             order.all_adjustments.eligible.count.should eq(1), "Expected one elegible adjustment (using sequence #{promo_sequence})"
-            # TODO: Really, with the rule we've applied to these promos, we'd expect line_item_promo2
-            # to be selected; however, all of the rules are currently completely broken for line-item-
-            # level promos. To make this spec work for now we just roll with current behavior.
+            # line_item_promo1 is the only one that has thus far met the order total threshold, it is the only promo which should be applied.
+            order.all_adjustments.first.source.promotion.should eq(line_item_promo1), "Expected line_item_promo1 to be used (using sequence #{promo_sequence})"
 
             order.contents.add create(:variant, price: 10), 1
             order.save

--- a/core/spec/models/spree/promotion/actions/create_adjustment_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_adjustment_spec.rb
@@ -4,6 +4,7 @@ describe Spree::Promotion::Actions::CreateAdjustment do
   let(:order) { create(:order_with_line_items, :line_items_count => 1) }
   let(:promotion) { create(:promotion) }
   let(:action) { Spree::Promotion::Actions::CreateAdjustment.new }
+  let(:payload) { { order: order } }
 
   # From promotion spec:
   context "#perform" do
@@ -16,7 +17,7 @@ describe Spree::Promotion::Actions::CreateAdjustment do
     # Regression test for #3966
     it "does not apply an adjustment if the amount is 0" do
       action.calculator.preferred_amount = 0
-      action.perform(:order => order)
+      action.perform(payload)
       promotion.credits_count.should == 0
       order.adjustments.count.should == 0
     end
@@ -24,14 +25,14 @@ describe Spree::Promotion::Actions::CreateAdjustment do
     it "should create a discount with correct negative amount" do
       order.shipments.create!(:cost => 10)
 
-      action.perform(:order => order)
+      action.perform(payload)
       promotion.credits_count.should == 1
       order.adjustments.count.should == 1
       order.adjustments.first.amount.to_i.should == -10
     end
 
     it "should create a discount accessible through both order_id and adjustable_id" do
-      action.perform(:order => order)
+      action.perform(payload)
       order.adjustments.count.should == 1
       order.all_adjustments.count.should == 1
     end
@@ -39,8 +40,8 @@ describe Spree::Promotion::Actions::CreateAdjustment do
     it "should not create a discount when order already has one from this promotion" do
       order.shipments.create!(:cost => 10)
 
-      action.perform(:order => order)
-      action.perform(:order => order)
+      action.perform(payload)
+      action.perform(payload)
       promotion.credits_count.should == 1
     end
   end
@@ -53,7 +54,7 @@ describe Spree::Promotion::Actions::CreateAdjustment do
 
     context "when order is not complete" do
       it "should not keep the adjustment" do
-        action.perform(:order => order)
+        action.perform(payload)
         action.destroy
         order.adjustments.count.should == 0
       end
@@ -65,7 +66,7 @@ describe Spree::Promotion::Actions::CreateAdjustment do
       end
 
       before(:each) do
-        action.perform(:order => order)
+        action.perform(payload)
         action.destroy
       end
 

--- a/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
@@ -8,6 +8,7 @@ module Spree
         let(:promotion) { create(:promotion) }
         let(:action) { CreateItemAdjustments.new }
         let!(:line_item) { create(:line_item, :order => order) }
+        let(:payload) { { order: order, promotion: promotion } }
 
         before { action.stub(:promotion => promotion) }
 
@@ -19,7 +20,7 @@ module Spree
             end
 
             it "does not create an adjustment when calculator returns 0" do
-              action.perform(order: order)
+              action.perform(payload)
               action.adjustments.should be_empty
             end
           end
@@ -31,29 +32,32 @@ module Spree
             end
 
             it "creates adjustment with item as adjustable" do
-              action.perform(order: order)
+              action.perform(payload)
               action.adjustments.count.should == 1
               line_item.reload.adjustments.should == action.adjustments
             end
 
             it "creates adjustment with self as source" do
-              action.perform(order: order)
+              action.perform(payload)
               expect(line_item.reload.adjustments.first.source).to eq action
             end
 
             it "does not perform twice on the same item" do
-              2.times { action.perform(order: order) }
+              2.times { action.perform(payload) }
               action.adjustments.count.should == 1
             end
 
             context "with products rules" do
-              before do
-                promotion.stub(:product_ids => [line_item.product.id])
-              end
               let!(:second_line_item) { create(:line_item, :order => order) }
+              let(:rule) { double Spree::Promotion::Rules::Product }
+
+              before do
+                promotion.stub(:eligible_rules) { [rule] }
+                rule.stub(:actionable?).and_return(true, false)
+              end
 
               it "does not create an adjustmenty for line_items not in product rule" do
-                action.perform(order: order)
+                action.perform(payload)
                 expect(action.adjustments.count).to eql 1
                 expect(line_item.reload.adjustments).to match_array action.adjustments
                 expect(second_line_item.reload.adjustments).to be_empty

--- a/core/spec/models/spree/promotion/actions/create_line_items_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_line_items_spec.rb
@@ -6,6 +6,7 @@ describe Spree::Promotion::Actions::CreateLineItems do
   let(:promotion) { stub_model(Spree::Promotion) }
   let(:shirt) { create(:variant) }
   let(:mug) { create(:variant) }
+  let(:payload) { { order: order } }
 
   context "#perform" do
     before do
@@ -26,7 +27,7 @@ describe Spree::Promotion::Actions::CreateLineItems do
       end
 
       it "adds line items to order with correct variant and quantity" do
-        action.perform(:order => order)
+        action.perform(payload)
         order.line_items.count.should == 2
         line_item = order.line_items.find_by_variant_id(mug.id)
         line_item.should_not be_nil
@@ -35,7 +36,7 @@ describe Spree::Promotion::Actions::CreateLineItems do
 
       it "only adds the delta of quantity to an order" do
         order.contents.add(shirt, 1)
-        action.perform(:order => order)
+        action.perform(payload)
         line_item = order.line_items.find_by_variant_id(shirt.id)
         line_item.should_not be_nil
         line_item.quantity.should == 2
@@ -43,7 +44,7 @@ describe Spree::Promotion::Actions::CreateLineItems do
 
       it "doesn't add if the quantity is greater" do
         order.contents.add(shirt, 3)
-        action.perform(:order => order)
+        action.perform(payload)
         line_item = order.line_items.find_by_variant_id(shirt.id)
         line_item.should_not be_nil
         line_item.quantity.should == 3

--- a/core/spec/models/spree/promotion/actions/free_shipping_spec.rb
+++ b/core/spec/models/spree/promotion/actions/free_shipping_spec.rb
@@ -4,6 +4,7 @@ describe Spree::Promotion::Actions::FreeShipping do
   let(:order) { create(:completed_order_with_totals) }
   let(:promotion) { create(:promotion) }
   let(:action) { Spree::Promotion::Actions::FreeShipping.create }
+  let(:payload) { { order: order } }
 
   # From promotion spec:
   context "#perform" do
@@ -16,7 +17,7 @@ describe Spree::Promotion::Actions::FreeShipping do
       order.shipments.count.should == 2
       order.shipments.first.cost.should == 100
       order.shipments.last.cost.should == 100
-      action.perform(:order => order).should be_true
+      action.perform(payload).should be_true
       promotion.credits_count.should == 2
       order.shipment_adjustments.count.should == 2
       order.shipment_adjustments.first.amount.to_i.should == -100
@@ -24,8 +25,8 @@ describe Spree::Promotion::Actions::FreeShipping do
     end
 
     it "should not create a discount when order already has one from this promotion" do
-      action.perform(:order => order).should be_true
-      action.perform(:order => order).should be_false
+      action.perform(payload).should be_true
+      action.perform(payload).should be_false
       promotion.credits_count.should == 2
       order.shipment_adjustments.count.should == 2
     end

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -237,34 +237,6 @@ describe Spree::Promotion do
     end
   end
 
-  context "#products" do
-    let(:promotion) { create(:promotion) }
-
-    context "when it has product rules with products associated" do
-      let(:promotion_rule) { Spree::Promotion::Rules::Product.new }
-
-      before do
-        promotion_rule.promotion = promotion
-        promotion_rule.products << create(:product)
-        promotion_rule.save
-      end
-
-      it "should have products" do
-        promotion.reload.products.size.should == 1
-      end
-    end
-
-    context "when there's no product rule associated" do
-      before(:each) do
-        promotion.stub_chain(:rules, :to_a).and_return([mock_model(Spree::Promotion::Rules::User)])
-      end
-
-      it "should not have products but still return an empty array" do
-        promotion.products.should be_blank
-      end
-    end
-  end
-
   context "#eligible?" do
     before do
       @order = create(:order)
@@ -285,16 +257,16 @@ describe Spree::Promotion do
     end
   end
 
-  context "#rules_are_eligible?" do
+  context "#eligible_rules" do
     let(:promotable) { double('Promotable') }
     it "true if there are no rules" do
-      promotion.rules_are_eligible?(promotable).should be_true
+      promotion.eligible_rules(promotable).should eq []
     end
 
     it "true if there are no applicable rules" do
       promotion.promotion_rules = [stub_model(Spree::PromotionRule, :eligible? => true, :applicable? => false)]
       promotion.promotion_rules.stub(:for).and_return([])
-      promotion.rules_are_eligible?(promotable).should be_true
+      promotion.eligible_rules(promotable).should eq []
     end
 
     context "with 'all' match policy" do
@@ -308,7 +280,7 @@ describe Spree::Promotion do
 
         promotion.promotion_rules = [promo1, promo2]
         promotion.promotion_rules.stub(:for).and_return(promotion.promotion_rules)
-        promotion.rules_are_eligible?(promotable).should be_true
+        promotion.eligible_rules(promotable).should eq [promo1, promo2]
       end
 
       it "should not have eligible rules if any of the rules is not eligible" do
@@ -319,7 +291,7 @@ describe Spree::Promotion do
 
         promotion.promotion_rules = [promo1, promo2]
         promotion.promotion_rules.stub(:for).and_return(promotion.promotion_rules)
-        promotion.rules_are_eligible?(promotable).should be_false
+        promotion.eligible_rules(promotable).should be_nil
       end
     end
 
@@ -333,7 +305,63 @@ describe Spree::Promotion do
         true_rule.stub(:eligible? => true)
         promotion.stub(:rules => [true_rule])
         promotion.stub_chain(:rules, :for).and_return([true_rule])
-        promotion.rules_are_eligible?(promotable).should be_true
+        promotion.eligible_rules(promotable).should eq [true_rule]
+      end
+    end
+  end
+
+  describe '#line_item_actionable?' do
+    let(:order) { double Spree::Order }
+    let(:line_item) { double Spree::LineItem}
+    let(:true_rule) { double Spree::PromotionRule, eligible?: true, applicable?: true, actionable?: true }
+    let(:false_rule) { double Spree::PromotionRule, eligible?: true, applicable?: true, actionable?: false }
+    let(:rules) { [] }
+
+    before do
+      promotion.stub(:rules) { rules }
+      rules.stub(:for) { rules }
+    end
+
+    subject { promotion.line_item_actionable? order, line_item }
+
+    context 'when there are no rules' do
+      context 'when the order is eligible for promotion' do
+        it { should be }
+      end
+
+      context 'when the order is not eligible for the promotion' do
+        before { promotion.starts_at = Time.current + 2.days }
+        it { should_not be }
+      end
+    end
+
+    context 'when therea are rules' do
+      context 'when the match policy is all' do
+        before { promotion.match_policy = 'all' }
+
+        context 'when all rules allow action on the line item' do
+          let(:rules) { [true_rule] }
+          it { should be}
+        end
+
+        context 'when at least one rule does not allow action on the line item' do
+          let(:rules) { [true_rule, false_rule] }
+          it { should_not be}
+        end
+      end
+
+      context 'when the match policy is any' do
+        before { promotion.match_policy = 'any' }
+
+        context 'when at least one rule allows action on the line item' do
+          let(:rules) { [true_rule, false_rule] }
+          it { should be }
+        end
+
+        context 'when no rules allow action on the line item' do
+          let(:rules) { [false_rule] }
+          it { should_not be}
+        end
       end
     end
   end

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -324,46 +324,46 @@ describe Spree::Promotion do
 
     subject { promotion.line_item_actionable? order, line_item }
 
-    context 'when there are no rules' do
-      context 'when the order is eligible for promotion' do
+    context 'when the order is eligible for promotion' do
+      context 'when there are no rules' do
         it { should be }
       end
+
+      context 'when there are rules' do
+        context 'when the match policy is all' do
+          before { promotion.match_policy = 'all' }
+
+          context 'when all rules allow action on the line item' do
+            let(:rules) { [true_rule] }
+            it { should be}
+          end
+
+          context 'when at least one rule does not allow action on the line item' do
+            let(:rules) { [true_rule, false_rule] }
+            it { should_not be}
+          end
+        end
+
+        context 'when the match policy is any' do
+          before { promotion.match_policy = 'any' }
+
+          context 'when at least one rule allows action on the line item' do
+            let(:rules) { [true_rule, false_rule] }
+            it { should be }
+          end
+
+          context 'when no rules allow action on the line item' do
+            let(:rules) { [false_rule] }
+            it { should_not be}
+          end
+        end
+      end
+    end
 
       context 'when the order is not eligible for the promotion' do
         before { promotion.starts_at = Time.current + 2.days }
         it { should_not be }
       end
-    end
-
-    context 'when therea are rules' do
-      context 'when the match policy is all' do
-        before { promotion.match_policy = 'all' }
-
-        context 'when all rules allow action on the line item' do
-          let(:rules) { [true_rule] }
-          it { should be}
-        end
-
-        context 'when at least one rule does not allow action on the line item' do
-          let(:rules) { [true_rule, false_rule] }
-          it { should_not be}
-        end
-      end
-
-      context 'when the match policy is any' do
-        before { promotion.match_policy = 'any' }
-
-        context 'when at least one rule allows action on the line item' do
-          let(:rules) { [true_rule, false_rule] }
-          it { should be }
-        end
-
-        context 'when no rules allow action on the line item' do
-          let(:rules) { [false_rule] }
-          it { should_not be}
-        end
-      end
-    end
   end
 
   # regression for #4059


### PR DESCRIPTION
### What is this?

This is a significant refactor to the way that line item promotions are declared eligible for a particular order. The main purpose of this is to remove a couple significant hacks required in order to get the product based line item promotions to function. That functionality is highly desired to be extensible, so I have extracted it to be calculated with the rules class.

This functionality is not used for adjustments which are not line item adjustments.

---
### What has changed?

The major components of this are:

`Spree::Promotion::Rules::Rule#actionable?(line_item)`

This code determines if a specific rule can be applied to a particular line item. The goal of this is to be able to extract functionality like this [restriction on products](https://github.com/spree/spree/blob/master/core/app/models/spree/promotion/actions/create_item_adjustments.rb#L31) can be defined in the appropriate rule, rather than in the action. This will allow Spree, and store owners to define more complex logic for eligibility within promotion rules.

`Spree::Promotion#line_item_actionable?(order, line_item)`

This determines if a particular line item can have actions applied to it. It must match either any, or all of the rules (depending on match policy). If true, then the action can be applied to this line item. This returns true by default, and should be changed to restrict what is and is not actionable based upon criteria specific to that rule.

`Spree::Promotion#eligible_rules(promotable, options = {})`

This is a version of `rules_are_eligible?` which returns the eligible rules rather than true/false. `rules_are_eligible?` now uses this internally.

Additionally, there are a couple of changes to the product promotion rule to use this new code for activiation, and to the `create_item_adjustments` action to do similar things.

---
### What does this let me do now?

You can now create more advanced restrictions similar to the product based restriction, with logic contained only in the rules class. As shown by the product rule, previously some hacks were required to implement this logic correctly. A few ideas of rules that you can create easily now.

First, define a rule:

``` Ruby
class Spree::Promotion::Rules::FancyNewRule < Spree::PromotionRule
  def applicable?(promotable)
    promotable.is_a?(Spree::Order)
  end
end
```

Then define actionable?  Some examples:
- Promotion only on variants 1, 2, and 3

``` Ruby
def actionable?(line_item)
  [1, 2, 3].include? line_item.variant_id
end
```
- Promotion on items that contain the word "Spree"

``` Ruby
def actionable?(line_item)
  line_item.variant.name.include? "Spree"
end
```
- Promotion on items that are currently $13.37 USD

``` Ruby
def actionable?(line_item)
  line_item.variant.price_in('USD').amount == '13.37'.to_d
end
```

---
### What should eligible? be?

Eligible? determines if I am can apply this promotion to my order. In the case of dealing with line item adjustments, eligible? should be true if any of the line_items are actionable?

As an example:

``` Ruby
def eligible?(order, options = {})
  order.line_items.any? { |line_item| actionable? line_item }
end
```

You can also apply additional criteria at this level. A great example is the product rule as it exists now:

``` Ruby
def eligible?(order, options = {})
  return true if eligible_products.empty?
  if preferred_match_policy == 'all'
   eligible_products.all? {|p| order.products.include?(p) }
  elsif preferred_match_policy == 'any'
    order.products.any? {|p| eligible_products.include?(p) }
  else
    order.products.none? {|p| eligible_products.include?(p) }
  end
end

def actionable?(line_item)
  product_ids.include? line_item.variant.product_id
end
```

Eligible does the complicated logic to decide if we can apply this promotion to a particular order, and actionable? defines if we're allowed to apply the promotion action to a specified line item.
