### PR TITLE
If ShippingCalculator has an empty string currency, it matches to all currencies.

### DIFF
--- a/core/app/models/spree/stock/estimator.rb
+++ b/core/app/models/spree/stock/estimator.rb
@@ -54,7 +54,7 @@ module Spree
           begin
             ship_method.include?(order.ship_address) &&
             calculator.available?(package) &&
-            (calculator.preferences[:currency].nil? ||
+            (calculator.preferences[:currency].blank? ||
              calculator.preferences[:currency] == currency)
           rescue Exception => exception
             log_calculator_exception(ship_method, exception)


### PR DESCRIPTION
Right now, if the currency value is nil, the shipping calculator applies to all currencies. However, from the form, the currency field is taken as "", not nil and thus the calculator matches none of the currencies.

This change is basically a `nil?` to `blank?`
