### PR TITLE
Split Orders / Consignments

### DIFF
--- a/core/app/models/spree/calculator/default_tax.rb
+++ b/core/app/models/spree/calculator/default_tax.rb
@@ -6,12 +6,11 @@ module Spree
       Spree.t(:default_tax)
     end
 
-    # Default tax calculator still needs to support orders for legacy reasons
+    # Default tax calculator still needs to support orders (now consignments) for legacy reasons
     # Orders created before Spree 2.1 had tax adjustments applied to the order, as a whole.
     # Orders created with Spree 2.2 and after, have them applied to the line items individually.
-    def compute_order(order)
-
-      matched_line_items = order.line_items.select do |line_item|
+    def compute_consignment(consignment)
+      matched_line_items = consignment.line_items.select do |line_item|
         line_item.tax_category == rate.tax_category
       end
 

--- a/core/app/models/spree/calculator/default_tax.rb
+++ b/core/app/models/spree/calculator/default_tax.rb
@@ -21,6 +21,7 @@ module Spree
         round_to_two_places(line_items_total * rate.amount)
       end
     end
+    alias_method :compute_order, :compute_consignment
 
     # When it comes to computing shipments or line items: same same.
     def compute_shipment_or_line_item(item)

--- a/core/app/models/spree/consignment.rb
+++ b/core/app/models/spree/consignment.rb
@@ -1,4 +1,6 @@
 module Spree
   class Consignment < Spree::Base
+    belongs_to :order
+    has_many :line_items, -> { order('spree_line_items.created_at ASC') }, dependent: :destroy
   end
 end

--- a/core/app/models/spree/consignment.rb
+++ b/core/app/models/spree/consignment.rb
@@ -1,0 +1,4 @@
+module Spree
+  class Consignment < Spree::Base
+  end
+end

--- a/core/app/models/spree/consignment.rb
+++ b/core/app/models/spree/consignment.rb
@@ -1,6 +1,6 @@
 module Spree
   class Consignment < Spree::Base
-    belongs_to :order
+    belongs_to :order, touch: true
     has_many :line_items, -> { order('spree_line_items.created_at ASC') }, dependent: :destroy
   end
 end

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -1,7 +1,8 @@
 module Spree
   class LineItem < Spree::Base
     before_validation :adjust_quantity
-    belongs_to :order, class_name: "Spree::Order", inverse_of: :line_items, touch: true
+    delegate :order, to: :consignment
+    belongs_to :consignment, class_name: "Spree::Consignment", inverse_of: :line_items, touch: true
     belongs_to :variant, class_name: "Spree::Variant", inverse_of: :line_items
     belongs_to :tax_category, class_name: "Spree::TaxCategory"
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -119,6 +119,10 @@ module Spree
         order_id: self.id)
     end
 
+    def multi_consignment?
+      consignments.count > 1
+    end
+
     # For compatiblity with Calculator::PriceSack
     def amount
       line_items.inject(0.0) { |sum, li| sum + li.amount }

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -31,6 +31,7 @@ module Spree
     alias_attribute :billing_address, :bill_address
 
     has_many :consignments
+    has_many :line_items, through: :consignments
 
     belongs_to :ship_address, foreign_key: :ship_address_id, class_name: 'Spree::Address'
     alias_attribute :shipping_address, :ship_address
@@ -38,7 +39,7 @@ module Spree
     alias_attribute :ship_total, :shipment_total
 
     has_many :state_changes, as: :stateful
-    has_many :line_items, -> { order('created_at ASC') }, dependent: :destroy, inverse_of: :order
+
     has_many :payments, dependent: :destroy
     has_many :return_authorizations, dependent: :destroy
     has_many :adjustments, -> { order("#{Adjustment.table_name}.created_at ASC") }, as: :adjustable, dependent: :destroy

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -30,6 +30,8 @@ module Spree
     belongs_to :bill_address, foreign_key: :bill_address_id, class_name: 'Spree::Address'
     alias_attribute :billing_address, :bill_address
 
+    has_many :consignments
+
     belongs_to :ship_address, foreign_key: :ship_address_id, class_name: 'Spree::Address'
     alias_attribute :shipping_address, :ship_address
 

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -26,7 +26,11 @@ module Spree
 
     def update_cart(params)
       if order.update_attributes(params)
-        order.line_items = order.line_items.select {|li| li.quantity > 0 }
+        order.consignments.each do |consignment|
+          consignment.line_items = consignment.line_items.select {|li| li.quantity > 0 }
+          consignment.save!
+        end
+
         # Update totals, then check if the order is eligible for any cart promotions.
         # If we do not update first, then the item total will be wrong and ItemTotal
         # promotion rules would not be triggered.

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -64,7 +64,8 @@ module Spree
           line_item.quantity += quantity.to_i
           line_item.currency = currency unless currency.nil?
         else
-          line_item = order.line_items.new(quantity: quantity, variant: variant)
+          consignment = order.consignments.first || order.consignments.create!
+          line_item = consignment.line_items.new(quantity: quantity, variant: variant)
           line_item.target_shipment = shipment
           if currency
             line_item.currency = currency

--- a/core/app/models/spree/promotion/actions/create_item_adjustments.rb
+++ b/core/app/models/spree/promotion/actions/create_item_adjustments.rb
@@ -19,7 +19,7 @@ module Spree
           # coverts to meaning NOT IN (NULL) and the DB isn't happy about that.
           already_adjusted_line_items = [0] + self.adjustments.pluck(:adjustable_id)
           result = false
-          order.line_items.where("id NOT IN (?)", already_adjusted_line_items).find_each do |line_item|
+          order.line_items.where("#{::Spree::LineItem.quoted_table_name}.id NOT IN (?)", already_adjusted_line_items).find_each do |line_item|
             current_result = self.create_adjustment(line_item, order)
             result ||= current_result
           end

--- a/core/db/migrate/20140721171506_add_consignments_to_orders.rb
+++ b/core/db/migrate/20140721171506_add_consignments_to_orders.rb
@@ -1,0 +1,23 @@
+class AddConsignmentsToOrders < ActiveRecord::Migration
+  def change
+    create_table :spree_consignments do |t|
+      t.string   "number",                 limit: 32
+      t.integer  "order_id"
+      t.decimal  "item_total",                        precision: 10, scale: 2, default: 0.0,     null: false
+      t.decimal  "total",                             precision: 10, scale: 2, default: 0.0,     null: false
+      t.decimal  "adjustment_total",                  precision: 10, scale: 2, default: 0.0,     null: false
+      t.datetime "completed_at"
+      t.integer  "ship_address_id"
+      t.integer  "shipping_method_id"
+      t.string   "shipment_state"
+      t.text     "special_instructions"
+      t.datetime "created_at"
+      t.datetime "updated_at"
+      t.decimal  "shipment_total",                    precision: 10, scale: 2, default: 0.0,     null: false
+      t.decimal  "additional_tax_total",              precision: 10, scale: 2, default: 0.0
+      t.decimal  "promo_total",                       precision: 10, scale: 2, default: 0.0
+      t.decimal  "included_tax_total",                precision: 10, scale: 2, default: 0.0,     null: false
+      t.integer  "item_count",                                                 default: 0
+    end
+  end
+end

--- a/core/db/migrate/20140722090439_add_consignment_id_to_line_items.rb
+++ b/core/db/migrate/20140722090439_add_consignment_id_to_line_items.rb
@@ -1,0 +1,7 @@
+class AddConsignmentIdToLineItems < ActiveRecord::Migration
+  def change
+    change_table :spree_line_items do |t|
+      t.integer :consignment_id
+    end
+  end
+end

--- a/core/lib/spree/testing_support/factories/line_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/line_item_factory.rb
@@ -2,7 +2,6 @@ FactoryGirl.define do
   factory :line_item, class: Spree::LineItem do
     quantity 1
     price { BigDecimal.new('10.00') }
-    order
     ignore do
       association :product
     end

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -7,7 +7,8 @@ FactoryGirl.define do
 
     factory :order_with_totals do
       after(:create) do |order|
-        create(:line_item, order: order)
+        consignment = order.consignments.create!
+        create(:line_item, consignment: consignment)
         order.line_items.reload # to ensure order.line_items is accessible after
       end
     end
@@ -21,7 +22,8 @@ FactoryGirl.define do
       end
 
       after(:create) do |order, evaluator|
-        create_list(:line_item, evaluator.line_items_count, order: order)
+        consignment = order.consignments.create!
+        create_list(:line_item, evaluator.line_items_count, consignment: consignment)
         order.line_items.reload
 
         create(:shipment, order: order)

--- a/core/lib/spree/testing_support/order_walkthrough.rb
+++ b/core/lib/spree/testing_support/order_walkthrough.rb
@@ -21,7 +21,8 @@ class OrderWalkthrough
     end
 
     order = Spree::Order.create!(:email => "spree@example.com")
-    add_line_item!(order)
+    consignment = order.consignments.create!
+    add_line_item!(consignment)
     order.next!
 
     end_state_position = states.index(state.to_sym)
@@ -34,9 +35,9 @@ class OrderWalkthrough
 
   private
 
-  def self.add_line_item!(order)
-    FactoryGirl.create(:line_item, order: order)
-    order.reload
+  def self.add_line_item!(consignment)
+    FactoryGirl.create(:line_item, consignment: consignment)
+    consignment.reload
   end
 
   def self.address(order)

--- a/core/spec/models/spree/calculator/default_tax_spec.rb
+++ b/core/spec/models/spree/calculator/default_tax_spec.rb
@@ -8,16 +8,17 @@ describe Spree::Calculator::DefaultTax do
   let(:included_in_price) { false }
   let!(:calculator) { Spree::Calculator::DefaultTax.new(:calculable => rate ) }
   let!(:order) { create(:order) }
-  let!(:line_item) { create(:line_item, :price => 10, :quantity => 3, :tax_category => tax_category) }
+  let!(:consignment) { order.consignments.new }
+  let!(:line_item) { create(:line_item, :price => 10, :quantity => 3, :tax_category => tax_category, :consignment => consignment) }
   let!(:shipment) { create(:shipment, :cost => 15) }
 
   context "#compute" do
-    context "when given an order" do
+    context "when given an consignment" do
       let!(:line_item_1) { line_item }
-      let!(:line_item_2) { create(:line_item, :price => 10, :quantity => 3, :tax_category => tax_category) }
+      let!(:line_item_2) { create(:line_item, :price => 10, :quantity => 3, :tax_category => tax_category, :consignment => consignment) }
 
       before do
-        order.stub :line_items => [line_item_1, line_item_2]
+        consignment.stub :line_items => [line_item_1, line_item_2]
       end
 
       context "when no line items match the tax category" do
@@ -27,7 +28,7 @@ describe Spree::Calculator::DefaultTax do
         end
 
         it "should be 0" do
-          calculator.compute(order).should == 0
+          calculator.compute(consignment).should == 0
         end
       end
 
@@ -38,7 +39,7 @@ describe Spree::Calculator::DefaultTax do
         end
 
         it "should be equal to the item total * rate" do
-          calculator.compute(order).should == 1.5
+          calculator.compute(consignment).should == 1.5
         end
 
         context "correctly rounds to within two decimal places" do
@@ -49,7 +50,7 @@ describe Spree::Calculator::DefaultTax do
 
           specify do
             # Amount is 0.51665, which will be rounded to...
-            calculator.compute(order).should == 0.52
+            calculator.compute(consignment).should == 0.52
           end
 
         end
@@ -57,7 +58,7 @@ describe Spree::Calculator::DefaultTax do
 
       context "when more than one item matches the tax category" do
         it "should be equal to the sum of the item totals * rate" do
-          calculator.compute(order).should == 3
+          calculator.compute(consignment).should == 3
         end
       end
 
@@ -69,7 +70,7 @@ describe Spree::Calculator::DefaultTax do
           # ex pre-tax = $57.14
           # 57.14 + %5 = 59.997 (or "close enough" to $60)
           # 60 - 57.14 = $2.86
-          expect(calculator.compute(order).to_f).to eql 2.86
+          expect(calculator.compute(consignment).to_f).to eql 2.86
         end
       end
     end

--- a/core/spec/models/spree/calculator_spec.rb
+++ b/core/spec/models/spree/calculator_spec.rb
@@ -3,7 +3,8 @@ require 'spec_helper'
 describe Spree::Calculator do
 
   let(:order) { create(:order) }
-  let!(:line_item) { create(:line_item, :order => order) }
+  let(:consignment) { order.consignments.create! }
+  let!(:line_item) { create(:line_item, :consignment => consignment) }
   let(:shipment) { create(:shipment, :order => order, :stock_location => create(:stock_location_with_items)) }
 
   context "with computable" do

--- a/core/spec/models/spree/order/adjustments_spec.rb
+++ b/core/spec/models/spree/order/adjustments_spec.rb
@@ -25,7 +25,8 @@ describe Spree::Order do
     before do
       # Don't care about available payment methods in this test
       persisted_order.stub(:has_available_payment => false)
-      persisted_order.line_items << line_item
+      persisted_order.consignments.create!
+      persisted_order.consignments.first.line_items << line_item
       create(:adjustment, :amount => -line_item.amount, :label => "Promotion", :adjustable => line_item)
       persisted_order.state = 'delivery'
       persisted_order.save # To ensure new state_change event

--- a/core/spec/models/spree/order/adjustments_spec.rb
+++ b/core/spec/models/spree/order/adjustments_spec.rb
@@ -13,7 +13,8 @@ describe Spree::Order do
   # Regression test for #2191
   context "when an order has an adjustment that zeroes the total, but another adjustment for shipping that raises it above zero" do
     let!(:persisted_order) { create(:order) }
-    let!(:line_item) { create(:line_item) }
+    let!(:consignment) { persisted_order.consignments.create! }
+    let!(:line_item) { create(:line_item, consignment: consignment) }
     let!(:shipping_method) do
       sm = create(:shipping_method)
       sm.calculator.preferred_amount = 10

--- a/core/spec/models/spree/order/currency_updater_spec.rb
+++ b/core/spec/models/spree/order/currency_updater_spec.rb
@@ -3,13 +3,14 @@ require 'spec_helper'
 describe Spree::Order do
   context 'CurrencyUpdater' do
     context "when changing order currency" do
-      let!(:line_item) { create(:line_item) }
+      let!(:consignment) { create(:order).consignments.create! }
+      let!(:line_item) { create(:line_item, consignment: consignment) }
       let!(:euro_price) { create(:price, variant: line_item.variant, amount: 8, currency: 'EUR') }
 
       context "#homogenize_line_item_currencies" do
         it "succeeds without error" do
           expect { line_item.order.update_attributes!(currency: 'EUR') }.to_not raise_error
-        end      
+        end
 
         it "changes the line_item currencies" do
           expect { line_item.order.update_attributes!(currency: 'EUR') }.to change{ line_item.reload.currency }.from('USD').to('EUR')

--- a/core/spec/models/spree/order_consignments_spec.rb
+++ b/core/spec/models/spree/order_consignments_spec.rb
@@ -1,0 +1,20 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe Spree::Order do
+  describe "#multi_consignment?" do
+    it "should be false when there is only one consignment" do
+      @order = Spree::Order.create
+      @order.consignments.create!
+      @order.should_not be_multi_consignment
+    end
+
+    it "should be true otherwise" do
+      @order = Spree::Order.create
+      @order.consignments.create!
+      @order.consignments.create!
+      @order.should be_multi_consignment
+    end
+  end
+end

--- a/core/spec/models/spree/order_inventory_spec.rb
+++ b/core/spec/models/spree/order_inventory_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe Spree::OrderInventory do
   let(:order) { create :completed_order_with_totals }
+  let(:consignment) { order.consignments.create! }
   let(:line_item) { order.line_items.first }
 
   subject { described_class.new(order, line_item) }
@@ -208,7 +209,7 @@ describe Spree::OrderInventory do
       end
 
       context "inventory unit line item and variant points to different products" do
-        let(:different_line_item) { create(:line_item) }
+        let(:different_line_item) { create(:line_item, consignment: consignment) }
 
         let!(:different_inventory) do
           shipment.set_up_inventory("on_hand", variant, order, different_line_item)

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -589,8 +589,9 @@ describe Spree::Order do
   context "#amount" do
     before do
       @order = create(:order, :user => user)
-      @order.line_items = [create(:line_item, :price => 1.0, :quantity => 2),
-                           create(:line_item, :price => 1.0, :quantity => 1)]
+      @consignment = @order.consignments.create!
+      @consignment.line_items << [create(:line_item, :price => 1.0, :quantity => 2, consignment: @consignment),
+                           create(:line_item, :price => 1.0, :quantity => 1, consignment: @consignment)]
     end
     it "should return the correct lum sum of items" do
       @order.amount.should == 3.0

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -8,7 +8,8 @@ module Spree
     context "order totals" do
       before do 
         2.times do
-          create(:line_item, :order => order, price: 10)
+          consignment = order.consignments.create!
+          create(:line_item, :consignment => consignment, price: 10)
         end
       end
 

--- a/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
@@ -50,7 +50,7 @@ module Spree
               before do
                 promotion.stub(:product_ids => [line_item.product.id])
               end
-              let!(:second_line_item) { create(:line_item, :order => order) }
+              let!(:second_line_item) { create(:line_item, :consignment => order.consignments.create!) }
 
               it "does not create an adjustmenty for line_items not in product rule" do
                 action.perform(order: order)

--- a/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
@@ -7,7 +7,7 @@ module Spree
         let(:order) { create(:order) }
         let(:promotion) { create(:promotion) }
         let(:action) { CreateItemAdjustments.new }
-        let!(:line_item) { create(:line_item, :order => order) }
+        let!(:line_item) { create(:line_item, :consignment => order.consignments.create!) }
 
         before { action.stub(:promotion => promotion) }
 

--- a/core/spec/models/spree/promotion_handler/cart_spec.rb
+++ b/core/spec/models/spree/promotion_handler/cart_spec.rb
@@ -3,8 +3,9 @@ require 'spec_helper'
 module Spree
   module PromotionHandler
     describe Cart do
-      let(:line_item) { create(:line_item) }
-      let(:order) { line_item.order }
+      let(:order) { create(:order) }
+      let(:consignment) { order.consignments.create! }
+      let(:line_item) { create(:line_item, consignment: consignment) }
 
       let(:promotion) { Promotion.create(name: "At line items") }
       let(:calculator) { Calculator::FlatPercentItemTotal.new(preferred_flat_percent: 10) }

--- a/core/spec/models/spree/variant/scopes_spec.rb
+++ b/core/spec/models/spree/variant/scopes_spec.rb
@@ -4,12 +4,13 @@ describe "Variant scopes" do
   let!(:product) { create(:product) }
   let!(:variant_1) { create(:variant, :product => product) }
   let!(:variant_2) { create(:variant, :product => product) }
+  let!(:consignment) { Spree::Order.create!.consignments.create! }
 
   it ".descend_by_popularity" do
     # Requires a product with at least two variants, where one has a higher number of
     # orders than the other
     Spree::LineItem.delete_all # FIXME leaky database - too many line_items
-    create(:line_item, :variant => variant_1)
+    create(:line_item, :variant => variant_1, consignment: consignment)
     Spree::Variant.descend_by_popularity.first.should == variant_1
   end
 


### PR DESCRIPTION
We have a client with the need to allow users to make multiple orders but only pay once. The use case is something like a corporate customer buying each of his/her best clients christmas gifts. The corporate customer could add everything to the basket, and then split the order into different "Consignments". Each client could live in a different country, so taxation and shipping restrictions must still apply to each individual consignment. (Amazon.com have a nice implementation of this themselves)

We're trying to work out how to model this best within Spree. We have tried adapting the existing checkout process to add extra steps, but would like model this requirement _properly_. I know this is a somewhat esoteric requirement. So, as a first draft:
- `Order --> LineItem` becomes `Order --> Consignment --> LineItem`
- A consignment would deal with taxation, shipping etc.
- An order would sum up the cost of consignments and deal with payment details, checkout flow etc. as normal. It would also retain most of its existing interface, merely delegating details to the individual consignments where appropriate.

Obviously this would require a fairly large change to `spree_core`, is there any more appetite for a feature like this, and do you think this would be a decent approach? We would like to implement this in such a way that it could be merged back into core if there was enough interest.

Please see this PR for our first pass at implementing this, it's not even 10% complete, but we wanted your advice! Curious to any thoughts you may have.
