### PR TITLE
State machine for return_items

### DIFF
--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -7,11 +7,40 @@ module Spree
     validates :return_authorization, presence: true
     validates :inventory_unit, presence: true, uniqueness: {scope: :return_authorization}
 
-    scope :received, -> { where.not(received_at: nil) }
+    state_machine :reception_status, initial: :awaiting do
+      before_transition to: :received, do: :process_inventory_units!
 
-    def receive!
-      update_attributes!(received_at: Time.now)
+      event :receive do
+        transition to: :received, from: :awaiting
+      end
 
+      event :cancel do
+        transition to: :cancelled, from: :awaiting
+      end
+
+      event :give do
+        transition to: :given_to_customer, from: :awaiting
+      end
+
+    end
+
+    state_machine :acceptance_status, initial: :not_received do
+
+      event :accept do
+        transition to: :accepted, from: :not_received
+      end
+
+      event :reject do
+        transition to: :rejected, from: :not_received
+      end
+
+      event :require_manual_intervention do
+        transition to: :manual_intervention_required, from: :not_received
+      end
+
+    end
+
+    def process_inventory_units!
       inventory_unit.return!
 
       if inventory_unit.variant.should_track_inventory? && stock_item

--- a/core/db/migrate/20140716204111_drop_received_at_on_return_items.rb
+++ b/core/db/migrate/20140716204111_drop_received_at_on_return_items.rb
@@ -1,0 +1,9 @@
+class DropReceivedAtOnReturnItems < ActiveRecord::Migration
+  def up
+    remove_column :spree_return_items, :received_at
+  end
+
+  def down
+    add_column :spree_return_items, :received_at, :datetime
+  end
+end

--- a/core/db/migrate/20140716212330_add_reception_and_acceptance_status_to_return_items.rb
+++ b/core/db/migrate/20140716212330_add_reception_and_acceptance_status_to_return_items.rb
@@ -1,0 +1,6 @@
+class AddReceptionAndAcceptanceStatusToReturnItems < ActiveRecord::Migration
+  def change
+    add_column :spree_return_items, :reception_status, :string
+    add_column :spree_return_items, :acceptance_status, :string
+  end
+end

--- a/core/lib/spree/testing_support/factories/return_authorization_factory.rb
+++ b/core/lib/spree/testing_support/factories/return_authorization_factory.rb
@@ -14,7 +14,7 @@ FactoryGirl.define do
 
   factory :return_item, class: Spree::ReturnItem do
     association(:return_authorization, factory: :return_authorization)
-    association(:inventory_unit, factory: :inventory_unit)
+    association(:inventory_unit, factory: :inventory_unit, state: 'shipped')
   end
 
   factory :return_authorization_reason, class: Spree::ReturnAuthorizationReason do

--- a/core/spec/models/spree/return_item_spec.rb
+++ b/core/spec/models/spree/return_item_spec.rb
@@ -1,7 +1,19 @@
 require 'spec_helper'
 
+shared_examples "an invalid state transition" do |status, expected_status|
+  let(:status) { status }
+
+  it "cannot transition to #{expected_status}" do
+    expect { subject }.to raise_error(StateMachine::InvalidTransition)
+  end
+end
+
 describe Spree::ReturnItem do
-  describe '#receive!' do
+
+  all_reception_statuses = Spree::ReturnItem.state_machines[:reception_status].states.map(&:name).map(&:to_s)
+  all_acceptance_statuses = Spree::ReturnItem.state_machines[:acceptance_status].states.map(&:name).map(&:to_s)
+
+  describe '#process_inventory_units!' do
     let(:return_item) {
       create(:return_item, {
         return_authorization: return_authorization,
@@ -16,12 +28,7 @@ describe Spree::ReturnItem do
     let(:stock_item) { stock_location.stock_items.find_by(variant_id: inventory_unit.variant_id) }
     let(:now) { Time.now }
 
-    subject { return_item.receive! }
-
-    it 'updates received_at' do
-      Timecop.freeze(now) { subject }
-      expect(return_item.received_at).to eq now
-    end
+    subject { return_item.process_inventory_units! }
 
     it 'returns the inventory unit' do
       subject
@@ -59,6 +66,158 @@ describe Spree::ReturnItem do
 
     it "returns a Spree::Money" do
       return_item.display_pre_tax_amount.should == Spree::Money.new(pre_tax_amount)
+    end
+  end
+
+  describe "reception_status state_machine" do
+    subject(:return_item) { create(:return_item) }
+
+    it "starts off in the awaiting state" do
+      expect(return_item).to be_awaiting
+    end
+  end
+
+  describe "acceptance_status state_machine" do
+    subject(:return_item) { create(:return_item) }
+
+    it "starts off in the not_received state" do
+      expect(return_item).to be_not_received
+    end
+  end
+
+  describe "#receive" do
+    let(:return_item) { create(:return_item, reception_status: status) }
+
+    subject { return_item.receive! }
+
+    context "awaiting status" do
+      let(:status) { 'awaiting' }
+
+      before { subject }
+
+      it "transitions successfully" do
+        expect(return_item).to be_received
+      end
+
+      it "marks the inventory unit as returned" do
+        expect(return_item.inventory_unit).to be_returned
+      end
+    end
+
+    (all_reception_statuses - ['awaiting']).each do |invalid_transition_status|
+      context "return_item has a reception status of #{invalid_transition_status}" do
+        it_behaves_like "an invalid state transition", invalid_transition_status, 'received'
+      end
+    end
+  end
+
+  describe "#cancel" do
+    let(:return_item) { create(:return_item, reception_status: status) }
+
+    subject { return_item.cancel! }
+
+    context "awaiting status" do
+      let(:status) { 'awaiting' }
+
+      before { subject }
+
+      it "transitions successfully" do
+        expect(return_item).to be_cancelled
+      end
+    end
+
+    (all_reception_statuses - ['awaiting']).each do |invalid_transition_status|
+      context "return_item has a reception status of #{invalid_transition_status}" do
+        it_behaves_like "an invalid state transition", invalid_transition_status, 'cancelled'
+      end
+    end
+  end
+
+  describe "#give" do
+    let(:return_item) { create(:return_item, reception_status: status) }
+
+    subject { return_item.give! }
+
+    context "awaiting status" do
+      let(:status) { 'awaiting' }
+
+      before { subject }
+
+      it "transitions successfully" do
+        expect(return_item).to be_given_to_customer
+      end
+    end
+
+    (all_reception_statuses - ['awaiting']).each do |invalid_transition_status|
+      context "return_item has a reception status of #{invalid_transition_status}" do
+        it_behaves_like "an invalid state transition", invalid_transition_status, 'give_to_customer'
+      end
+    end
+  end
+
+  describe "#accept" do
+    let(:return_item) { create(:return_item, acceptance_status: status) }
+
+    subject { return_item.accept! }
+
+    context "not_received status" do
+      let(:status) { 'not_received' }
+
+      before { subject }
+
+      it "transitions successfully" do
+        expect(return_item).to be_accepted
+      end
+    end
+
+    (all_acceptance_statuses - ['not_received']).each do |invalid_transition_status|
+      context "return_item has an acceptance status of #{invalid_transition_status}" do
+        it_behaves_like "an invalid state transition", invalid_transition_status, 'accepted'
+      end
+    end
+  end
+
+  describe "#reject" do
+    let(:return_item) { create(:return_item, acceptance_status: status) }
+
+    subject { return_item.reject! }
+
+    context "not_received status" do
+      let(:status) { 'not_received' }
+
+      before { subject }
+
+      it "transitions successfully" do
+        expect(return_item).to be_rejected
+      end
+    end
+
+    (all_acceptance_statuses - ['not_received']).each do |invalid_transition_status|
+      context "return_item has an acceptance status of #{invalid_transition_status}" do
+        it_behaves_like "an invalid state transition", invalid_transition_status, 'rejected'
+      end
+    end
+  end
+
+  describe "#require_manual_intervention" do
+    let(:return_item) { create(:return_item, acceptance_status: status) }
+
+    subject { return_item.require_manual_intervention! }
+
+    context "not_received status" do
+      let(:status) { 'not_received' }
+
+      before { subject }
+
+      it "transitions successfully" do
+        expect(return_item).to be_manual_intervention_required
+      end
+    end
+
+    (all_acceptance_statuses - ['not_received']).each do |invalid_transition_status|
+      context "return_item has an acceptance status of #{invalid_transition_status}" do
+        it_behaves_like "an invalid state transition", invalid_transition_status, 'manual_intervention_required'
+      end
     end
   end
 end


### PR DESCRIPTION
Adds two state machines to return items.

One indicates if the item has been physically received, cancelled or given to the customer.

The other indicates, when received, if it was deemed acceptable for return or not.
