### PR TITLE
Refactor stock related service objects to deal with inventory units.

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -14,3 +14,9 @@
   relying on Spree's default behaviour. Fixes #5036
 
     Gregor MacDougall
+
+* Refactored Stock::Coordinator to optionally accept a list of inventory units 
+  for an order so that shipments can be created for an order that do not comprise
+  only of the order's line items.
+
+     Andrew Thal

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -488,13 +488,7 @@ module Spree
     def create_proposed_shipments
       adjustments.shipping.delete_all
       shipments.destroy_all
-
-      packages = Spree::Stock::Coordinator.new(self).packages
-      packages.each do |package|
-        shipments << package.to_shipment
-      end
-
-      shipments
+      self.shipments = Spree::Stock::Coordinator.new(self).shipments
     end
 
     def apply_free_shipping_promotions
@@ -665,5 +659,6 @@ module Spree
           break random_token unless self.class.exists?(guest_token: random_token)
         end
       end
+
   end
 end

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -281,13 +281,9 @@ module Spree
     end
 
     def to_package
-      package = Stock::Package.new(stock_location, order)
-      grouped_inventory_units = inventory_units.includes(:line_item).group_by do |iu|
-        [iu.line_item, iu.state_name]
-      end
-
-      grouped_inventory_units.each do |(line_item, state_name), inventory_units|
-        package.add line_item, inventory_units.count, state_name
+      package = Stock::Package.new(stock_location)
+      inventory_units.group_by(&:state).each do |state, state_inventory_units|
+        package.add_multiple state_inventory_units, state.to_sym
       end
       package
     end

--- a/core/app/models/spree/shipping_calculator.rb
+++ b/core/app/models/spree/shipping_calculator.rb
@@ -15,7 +15,7 @@ module Spree
 
     private
     def total(content_items)
-      content_items.sum { |item| item.quantity * item.variant.price }
+      content_items.map(&:amount).sum
     end
   end
 end

--- a/core/app/models/spree/stock/adjuster.rb
+++ b/core/app/models/spree/stock/adjuster.rb
@@ -3,25 +3,24 @@
 module Spree
   module Stock
     class Adjuster
-      attr_accessor :variant, :need, :status
+      attr_accessor :inventory_unit, :status, :fulfilled
 
-      def initialize(variant, quantity, status)
-        @variant = variant
-        @need = quantity
+      def initialize(inventory_unit, status)
+        @inventory_unit = inventory_unit
         @status = status
+        @fulfilled = false
       end
 
-      def adjust(item)
-        if item.quantity >= need
-          item.quantity = need
-          @need = 0
-        elsif item.quantity < need
-          @need -= item.quantity
+      def adjust(package)
+        if fulfilled?
+          package.remove(inventory_unit)
+        else
+          self.fulfilled = true
         end
       end
 
       def fulfilled?
-        @need == 0
+        fulfilled
       end
     end
   end

--- a/core/app/models/spree/stock/content_item.rb
+++ b/core/app/models/spree/stock/content_item.rb
@@ -1,0 +1,48 @@
+module Spree
+  module Stock
+    class ContentItem
+      attr_accessor :inventory_unit, :state
+
+      def initialize(inventory_unit, state = :on_hand)
+        @inventory_unit = inventory_unit
+        @state = state
+      end
+
+      def variant
+        inventory_unit.variant
+      end
+
+      def weight
+        variant.weight * quantity
+      end
+
+      def line_item
+        inventory_unit.line_item
+      end
+
+      def on_hand?
+        state.to_s == "on_hand"
+      end
+
+      def backordered?
+        state.to_s == "backordered"
+      end
+
+      def price
+        variant.price
+      end
+
+      def amount
+        price * quantity
+      end
+
+      def quantity
+        # Since inventory units don't have a quantity,
+        # make this always 1 for now, leaving ourselves
+        # open to a different possibility in the future,
+        # but this massively simplifies things for now
+        1
+      end
+    end
+  end
+end

--- a/core/app/models/spree/stock/estimator.rb
+++ b/core/app/models/spree/stock/estimator.rb
@@ -35,7 +35,7 @@ module Spree
               # If the rate's zone matches the order's zone, a positive adjustment will be applied.
               # If the rate is from the default tax zone, then a negative adjustment will be applied.
               # See the tests in shipping_rate_spec.rb for an example of this.d
-              rate.zone == package.order.tax_zone || rate.zone.default_tax?
+              rate.zone == order.tax_zone || rate.zone.default_tax?
             end
           end
 

--- a/core/app/models/spree/stock/inventory_unit_builder.rb
+++ b/core/app/models/spree/stock/inventory_unit_builder.rb
@@ -1,0 +1,21 @@
+module Spree
+  module Stock
+    class InventoryUnitBuilder
+      def initialize(order)
+        @order = order
+      end
+
+      def units
+        @order.line_items.flat_map do |line_item|
+          line_item.quantity.times.map do |i|
+            InventoryUnit.new(
+              pending: true,
+              variant: line_item.variant,
+              line_item: line_item
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/core/app/models/spree/stock/packer.rb
+++ b/core/app/models/spree/stock/packer.rb
@@ -1,11 +1,11 @@
 module Spree
   module Stock
     class Packer
-      attr_reader :stock_location, :order, :splitters
+      attr_reader :stock_location, :inventory_units, :splitters
 
-      def initialize(stock_location, order, splitters=[Splitter::Base])
+      def initialize(stock_location, inventory_units, splitters=[Splitter::Base])
         @stock_location = stock_location
-        @order = order
+        @inventory_units = inventory_units
         @splitters = splitters
       end
 
@@ -18,17 +18,19 @@ module Spree
       end
 
       def default_package
-        package = Package.new(stock_location, order)
-        order.line_items.each do |line_item|
-          if line_item.should_track_inventory?
-            next unless stock_location.stock_item(line_item.variant)
+        package = Package.new(stock_location)
+        inventory_units.group_by(&:variant).each do |variant, variant_inventory_units|
+          units = variant_inventory_units.clone
+          if variant.should_track_inventory?
+            next unless stock_location.stock_item(variant)
 
-            on_hand, backordered = stock_location.fill_status(line_item.variant, line_item.quantity)
-            package.add line_item, on_hand, :on_hand if on_hand > 0
-            package.add line_item, backordered, :backordered if backordered > 0
+            on_hand, backordered = stock_location.fill_status(variant, units.count)
+            package.add_multiple units.slice!(0, on_hand), :on_hand if on_hand > 0
+            package.add_multiple units.slice!(0, backordered), :backordered if backordered > 0
           else
-            package.add line_item, line_item.quantity, :on_hand
+            package.add_multiple units
           end
+
         end
         package
       end

--- a/core/app/models/spree/stock/prioritizer.rb
+++ b/core/app/models/spree/stock/prioritizer.rb
@@ -1,10 +1,10 @@
 module Spree
   module Stock
     class Prioritizer
-      attr_reader :packages, :order
+      attr_reader :packages, :inventory_units
 
-      def initialize(order, packages, adjuster_class=Adjuster)
-        @order = order
+      def initialize(inventory_units, packages, adjuster_class=Adjuster)
+        @inventory_units = inventory_units
         @packages = packages
         @adjuster_class = adjuster_class
       end
@@ -18,8 +18,8 @@ module Spree
 
       private
       def adjust_packages
-        order.line_items.each do |line_item|
-          adjuster = @adjuster_class.new(line_item.variant, line_item.quantity, :on_hand)
+        inventory_units.each do |inventory_unit|
+          adjuster = @adjuster_class.new(inventory_unit, :on_hand)
 
           visit_packages(adjuster)
 
@@ -30,8 +30,8 @@ module Spree
 
       def visit_packages(adjuster)
         packages.each do |package|
-          item = package.find_item adjuster.variant, adjuster.status
-          adjuster.adjust(item) if item
+          item = package.find_item adjuster.inventory_unit, adjuster.status
+          adjuster.adjust(package) if item
         end
       end
 

--- a/core/app/models/spree/stock/splitter/base.rb
+++ b/core/app/models/spree/stock/splitter/base.rb
@@ -8,7 +8,7 @@ module Spree
           @packer = packer
           @next_splitter = next_splitter
         end
-        delegate :stock_location, :order, to: :packer
+        delegate :stock_location, to: :packer
 
         def split(packages)
           return_next(packages)
@@ -20,7 +20,7 @@ module Spree
         end
 
         def build_package(contents=[])
-          Spree::Stock::Package.new(stock_location, order, contents)
+          Spree::Stock::Package.new(stock_location, contents)
         end
       end
     end

--- a/core/lib/spree/testing_support/factories/stock_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_factory.rb
@@ -12,19 +12,20 @@ FactoryGirl.define do
   factory :stock_package, class: Spree::Stock::Package do
     ignore do
       stock_location { build(:stock_location) }
-      order { create(:order_with_line_items, line_items_count: 2) }
-      contents []
+      contents       { [] }
+      variants_contents { {} }
     end
 
-    initialize_with { new(stock_location, order, contents) }
+    initialize_with { new(stock_location, contents) }
+
+    after(:build) do |package, evaluator|
+      evaluator.variants_contents.each do |variant, count|
+        package.add_multiple build_list(:inventory_unit, count, variant: variant)
+      end
+    end
 
     factory :stock_package_fulfilled do
-      after(:build) do |package, evaluator|
-        evaluator.order.line_items.reload
-        evaluator.order.line_items.each do |line_item|
-          package.add line_item, line_item.quantity, :on_hand
-        end
-      end
+      ignore { variants_contents { { build(:variant) => 2 } } }
     end
   end
 end

--- a/core/spec/models/spree/calculator/shipping/flat_percent_item_total_spec.rb
+++ b/core/spec/models/spree/calculator/shipping/flat_percent_item_total_spec.rb
@@ -10,14 +10,7 @@ module Spree
       let(:line_item2) { build(:line_item, variant: variant2) }
 
       let(:package) do
-        Stock::Package.new(
-          build(:stock_location),
-          mock_model(Order),
-          [
-            Stock::Package::ContentItem.new(line_item1, variant1, 2),
-            Stock::Package::ContentItem.new(line_item2, variant2, 1)
-          ]
-        )
+        build(:stock_package, variants_contents: { variant1 => 2, variant2 => 1 })
       end
 
       subject { FlatPercentItemTotal.new(:preferred_flat_percent => 10) }

--- a/core/spec/models/spree/calculator/shipping/flat_rate_spec.rb
+++ b/core/spec/models/spree/calculator/shipping/flat_rate_spec.rb
@@ -3,24 +3,10 @@ require 'spec_helper'
 module Spree
   module Calculator::Shipping
     describe FlatRate do
-      let(:variant1) { build(:variant) }
-      let(:variant2) { build(:variant) }
-
-      let(:package) do
-        Stock::Package.new(
-          build(:stock_location),
-          mock_model(Order),
-          [
-            Stock::Package::ContentItem.new(variant1, 2),
-            Stock::Package::ContentItem.new(variant2, 1)
-          ]
-        )
-      end
-
       subject { Calculator::Shipping::FlatRate.new(:preferred_amount => 4.00) }
 
       it 'always returns the same rate' do
-        expect(subject.compute(package)).to eql 4.00
+        expect(subject.compute(build(:stock_package_fulfilled))).to eql 4.00
       end
     end
   end

--- a/core/spec/models/spree/calculator/shipping/flexi_rate_spec.rb
+++ b/core/spec/models/spree/calculator/shipping/flexi_rate_spec.rb
@@ -6,18 +6,8 @@ module Spree
       let(:variant1) { build(:variant, :price => 10) }
       let(:variant2) { build(:variant, :price => 20) }
 
-      let(:line_item1) { build(:line_item, variant: variant1) }
-      let(:line_item2) { build(:line_item, variant: variant2) }
-
       let(:package) do
-        Stock::Package.new(
-          build(:stock_location),
-          mock_model(Order),
-          [
-            Stock::Package::ContentItem.new(line_item1, variant1, 4),
-            Stock::Package::ContentItem.new(line_item2, variant2, 6)
-          ]
-        )
+        build(:stock_package, variants_contents: { variant1 => 4, variant2 => 6 })
       end
 
       let(:subject) { FlexiRate.new }

--- a/core/spec/models/spree/calculator/shipping/per_item_spec.rb
+++ b/core/spec/models/spree/calculator/shipping/per_item_spec.rb
@@ -6,18 +6,8 @@ module Spree
       let(:variant1) { build(:variant) }
       let(:variant2) { build(:variant) }
 
-      let(:line_item1) { build(:line_item, variant: variant1) }
-      let(:line_item2) { build(:line_item, variant: variant2) }
-
       let(:package) do
-        Stock::Package.new(
-          build(:stock_location),
-          mock_model(Order),
-          [
-            Stock::Package::ContentItem.new(line_item1, variant1, 5),
-            Stock::Package::ContentItem.new(line_item2, variant2, 3)
-          ]
-        )
+        build(:stock_package, variants_contents: { variant1 => 5, variant2 => 3 })
       end
 
       subject { PerItem.new(:preferred_amount => 10) }

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -657,4 +657,14 @@ describe Spree::Order do
       expect(order.quantity).to eq 5
     end
   end
+
+  describe "#create_proposed_shipments" do
+    it "assigns the coordinator returned shipments to its shipments" do
+      shipment = build(:shipment)
+      Spree::Stock::Coordinator.any_instance.stub(:shipments).and_return([shipment])
+      subject.create_proposed_shipments
+      expect(subject.shipments).to eq [shipment]
+    end
+
+  end
 end

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -206,7 +206,7 @@ describe Spree::Shipment do
         end
 
         it 'should use symbols for states when adding contents to package' do
-          shipment.stub_chain(:inventory_units, includes: inventory_units)
+          shipment.stub(:inventory_units) { inventory_units }
           package = shipment.to_package
           package.on_hand.count.should eq 1
           package.backordered.count.should eq 1

--- a/core/spec/models/spree/shipping_calculator_spec.rb
+++ b/core/spec/models/spree/shipping_calculator_spec.rb
@@ -5,18 +5,8 @@ module Spree
     let(:variant1) { build(:variant, :price => 10) }
     let(:variant2) { build(:variant, :price => 20) }
 
-    let(:line_item1) { build(:line_item, variant: variant1) }
-    let(:line_item2) { build(:line_item, variant: variant2) }
-
     let(:package) do
-      Stock::Package.new(
-        build(:stock_location),
-        mock_model(Order),
-        [
-          Stock::Package::ContentItem.new(line_item1, variant1, 2),
-          Stock::Package::ContentItem.new(line_item2, variant2, 1)
-        ]
-      )
+      build(:stock_package, variants_contents: { variant1 => 2, variant2 => 1 })
     end
 
     subject { ShippingCalculator.new }

--- a/core/spec/models/spree/stock/coordinator_spec.rb
+++ b/core/spec/models/spree/stock/coordinator_spec.rb
@@ -16,6 +16,23 @@ module Spree
         end
       end
 
+      describe "#shipments" do
+        let(:packages) { [build(:stock_package_fulfilled), build(:stock_package_fulfilled)] }
+
+        before { subject.stub(:packages).and_return(packages) }
+
+        it "turns packages into shipments" do
+          shipments = subject.shipments
+          expect(shipments.count).to eq packages.count
+          shipments.each { |shipment| expect(shipment).to be_a Shipment }
+        end
+
+        it "puts the order's ship address on the shipments" do
+          shipments = subject.shipments
+          shipments.each { |shipment| expect(shipment.address).to eq order.ship_address }
+        end
+      end
+
       context "build packages" do
         it "builds a package for every stock location" do
           subject.packages.count == StockLocation.count

--- a/core/spec/models/spree/stock/differentiator_spec.rb
+++ b/core/spec/models/spree/stock/differentiator_spec.rb
@@ -6,21 +6,22 @@ module Spree
       let(:variant1) { mock_model(Variant) }
       let(:variant2) { mock_model(Variant) }
 
+      let(:line_item1) { build(:line_item, variant: variant1, quantity: 2) }
+      let(:line_item2) { build(:line_item, variant: variant2, quantity: 2) }
+
       let(:stock_location) { mock_model(StockLocation) }
 
-      let(:line_items) do
-        [mock_model(LineItem, variant: variant1, quantity: 2),
-         mock_model(LineItem, variant: variant2, quantity: 2)]
-      end
+      let(:inventory_unit1) { build(:inventory_unit, variant: variant1, line_item: line_item1) }
+      let(:inventory_unit2) { build(:inventory_unit, variant: variant2, line_item: line_item2) }
 
-      let(:order) { mock_model(Order, line_items: line_items) }
+      let(:order) { mock_model(Order, line_items: [line_item1, line_item2]) }
 
       let(:package1) do
-        Package.new(stock_location, order).tap { |p| p.add(line_items.first, 1) }
+        Package.new(stock_location).tap { |p| p.add(inventory_unit1) }
       end
 
       let(:package2) do
-        Package.new(stock_location, order).tap { |p| p.add(line_items.last, 1) }
+        Package.new(stock_location).tap { |p| p.add(inventory_unit2) }
       end
 
       let(:packages) { [package1, package2] }

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -4,8 +4,9 @@ module Spree
   module Stock
     describe Estimator do
       let!(:shipping_method) { create(:shipping_method) }
-      let(:package) { build(:stock_package_fulfilled) }
-      let(:order) { package.order }
+      let(:package) { build(:stock_package, contents: inventory_units.map { |i| ContentItem.new(inventory_unit) }) }
+      let(:order) { build(:order_with_line_items) }
+      let(:inventory_units) { order.inventory_units }
 
       subject { Estimator.new(order) }
 

--- a/core/spec/models/spree/stock/inventory_unit_builder_spec.rb
+++ b/core/spec/models/spree/stock/inventory_unit_builder_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+module Spree
+  module Stock
+    describe InventoryUnitBuilder do
+      let(:line_item_1) { build(:line_item) }
+      let(:line_item_2) { build(:line_item, quantity: 2) }
+      let(:order) { build(:order, line_items: [line_item_1, line_item_2]) }
+
+      subject { InventoryUnitBuilder.new(order) }
+
+      describe "#units" do
+        it "returns an inventory unit for each quantity for the order's line items" do
+          units = subject.units
+          expect(units.count).to eq 3
+          expect(units.first.line_item).to eq line_item_1
+          expect(units.first.variant).to eq line_item_1.variant
+
+          expect(units[1].line_item).to eq line_item_2
+          expect(units[1].variant).to eq line_item_2.variant
+
+          expect(units[2].line_item).to eq line_item_2
+          expect(units[2].variant).to eq line_item_2.variant
+        end
+
+        it "builds the inventory units as pending" do
+          expect(subject.units.map(&:pending).uniq).to eq [true]
+        end
+
+      end
+
+    end
+  end
+end

--- a/core/spec/models/spree/stock/package_spec.rb
+++ b/core/spec/models/spree/stock/package_spec.rb
@@ -4,27 +4,30 @@ module Spree
   module Stock
     describe Package do
       let(:variant) { build(:variant, weight: 25.0) }
-      let(:line_item) { build(:line_item, variant: variant) }
       let(:stock_location) { build(:stock_location) }
       let(:order) { build(:order) }
 
-      subject { Package.new(stock_location, order) }
+      subject { Package.new(stock_location) }
+
+      def build_inventory_unit
+        build(:inventory_unit, variant: variant)
+      end
 
       it 'calculates the weight of all the contents' do
-        subject.add line_item, 4
+        4.times { subject.add build_inventory_unit }
         subject.weight.should == 100.0
       end
 
       it 'filters by on_hand and backordered' do
-        subject.add line_item, 4, :on_hand
-        subject.add line_item, 3, :backordered
-        subject.on_hand.count.should eq 1
-        subject.backordered.count.should eq 1
+        4.times { subject.add build_inventory_unit }
+        3.times { subject.add build_inventory_unit, :backordered }
+        subject.on_hand.count.should eq 4
+        subject.backordered.count.should eq 3
       end
 
       it 'calculates the quantity by state' do
-        subject.add line_item, 4, :on_hand
-        subject.add line_item, 3, :backordered
+        4.times { subject.add build_inventory_unit }
+        3.times { subject.add build_inventory_unit, :backordered }
 
         subject.quantity.should eq 7
         subject.quantity(:on_hand).should eq 4
@@ -32,14 +35,16 @@ module Spree
       end
 
       it 'returns nil for content item not found' do
-        item = subject.find_item(variant, :on_hand)
+        unit = build_inventory_unit
+        item = subject.find_item(unit, :on_hand)
         item.should be_nil
       end
 
-      it 'finds content item for a variant' do
-        subject.add line_item, 4, :on_hand
-        item = subject.find_item(variant, :on_hand)
-        item.quantity.should eq 4
+      it 'finds content item for an inventory unit' do
+        unit = build_inventory_unit
+        subject.add unit
+        item = subject.find_item(unit, :on_hand)
+        item.quantity.should eq 1
       end
 
       # Contains regression test for #2804
@@ -53,61 +58,85 @@ module Spree
         variant1 = mock_model(Variant, shipping_category: category1)
         variant2 = mock_model(Variant, shipping_category: category2)
         variant3 = mock_model(Variant, shipping_category: nil)
-        contents = [Package::ContentItem.new(line_item, variant1, 1),
-                    Package::ContentItem.new(line_item, variant1, 1),
-                    Package::ContentItem.new(line_item, variant2, 1),
-                    Package::ContentItem.new(line_item, variant3, 1)]
+        contents = [ContentItem.new(build(:inventory_unit, variant: variant1)),
+                    ContentItem.new(build(:inventory_unit, variant: variant1)),
+                    ContentItem.new(build(:inventory_unit, variant: variant2)),
+                    ContentItem.new(build(:inventory_unit, variant: variant3))]
 
-        package = Package.new(stock_location, order, contents)
+        package = Package.new(stock_location, contents)
         package.shipping_methods.should == [method1]
       end
 
       it 'builds an empty list of shipping methods when no categories' do
         variant  = mock_model(Variant, shipping_category: nil)
-        contents = [Package::ContentItem.new(line_item, variant, 1)]
-        package  = Package.new(stock_location, order, contents)
+        contents = [ContentItem.new(build(:inventory_unit, variant: variant))]
+        package  = Package.new(stock_location, contents)
         package.shipping_methods.should be_empty
       end
 
       it "can convert to a shipment" do
-        subject.add line_item, 2, :on_hand, variant
-        subject.add line_item, 1, :backordered, variant
+        2.times { subject.add build_inventory_unit }
+        subject.add build_inventory_unit, :backordered
 
         shipping_method = build(:shipping_method)
         subject.shipping_rates = [ Spree::ShippingRate.new(shipping_method: shipping_method, cost: 10.00, selected: true) ]
 
         shipment = subject.to_shipment
-        expect(shipment.address).to eq subject.order.ship_address
-        expect(shipment.order).to eq subject.order
         expect(shipment.stock_location).to eq subject.stock_location
         expect(shipment.inventory_units.size).to eq 3
 
         first_unit = shipment.inventory_units.first
         expect(first_unit.variant).to eq variant
         expect(first_unit.state).to eq 'on_hand'
-        expect(first_unit.order).to eq subject.order
         expect(first_unit).to be_pending
 
         last_unit = shipment.inventory_units.last
         expect(last_unit.variant).to eq variant
         expect(last_unit.state).to eq 'backordered'
-        expect(last_unit.order).to eq subject.order
 
         expect(shipment.shipping_method).to eq shipping_method
       end
 
-      context "line item and variant don't refer same product" do
-        let(:other_variant) { build(:variant) }
+      it 'does not add an inventory unit to a package twice' do
+        # since inventory units currently don't have a quantity
+        unit = build_inventory_unit
+        subject.add unit
+        subject.add unit
+        expect(subject.quantity).to eq 1
+        expect(subject.contents.first.inventory_unit).to eq unit
+        expect(subject.contents.first.quantity).to eq 1
+      end
 
-        before { subject.add(line_item, 4, :on_hand, other_variant) }
-
-        it "cant find the item given wrong variant" do
-          expect(subject.find_item(variant, :on_hand)).to be_nil
+      describe "#add_multiple" do
+        it "adds multiple inventory units" do
+          expect { subject.add_multiple [build_inventory_unit, build_inventory_unit] }.to change { subject.quantity }.by(2)
         end
 
-        it "finds the item when given proper variant and line item" do
-          expect(subject.find_item(other_variant, :on_hand)).to eq subject.contents.last
-          expect(subject.find_item(other_variant, :on_hand, line_item)).to eq subject.contents.last
+        it "allows adding with a state" do
+          expect { subject.add_multiple [build_inventory_unit, build_inventory_unit], :backordered }.to change { subject.backordered.count }.by(2)
+        end
+
+        it "defaults to adding with the on hand state" do
+          expect { subject.add_multiple [build_inventory_unit, build_inventory_unit] }.to change { subject.on_hand.count }.by(2)
+        end
+      end
+
+      describe "#remove" do
+        let(:unit) { build_inventory_unit }
+        context "there is a content item for the inventory unit" do
+
+          before { subject.add unit }
+
+          it "removes that content item" do
+            expect { subject.remove(unit) }.to change { subject.quantity }.by(-1)
+            expect(subject.contents.map(&:inventory_unit)).not_to include unit
+          end
+        end
+
+        context "there is no content item for the inventory unit" do
+          it "doesn't change the set of content items" do
+            expect { subject.remove(unit) }.not_to change { subject.quantity }
+          end
         end
       end
     end

--- a/core/spec/models/spree/stock/splitter/backordered_spec.rb
+++ b/core/spec/models/spree/stock/splitter/backordered_spec.rb
@@ -5,23 +5,23 @@ module Spree
     module Splitter
       describe Backordered do
         let(:variant) { build(:variant) }
-        let(:line_item) { build(:line_item, variant: variant) }
+
         let(:packer) { build(:stock_packer) }
 
         subject { Backordered.new(packer) }
 
         it 'splits packages by status' do
-          package = Package.new(packer.stock_location, packer.order)
-          package.add line_item, 4, :on_hand
-          package.add line_item, 5, :backordered
+          package = Package.new(packer.stock_location)
+          4.times { package.add build(:inventory_unit, variant: variant) }
+          5.times { package.add build(:inventory_unit, variant: variant), :backordered }
 
           packages = subject.split([package])
           packages.count.should eq 2
           packages.first.quantity.should eq 4
-          packages.first.on_hand.count.should eq 1
+          packages.first.on_hand.count.should eq 4
           packages.first.backordered.count.should eq 0
 
-          packages[1].quantity.should eq 5
+          packages[1].contents.count.should eq 5
         end
       end
     end

--- a/core/spec/models/spree/stock/splitter/weight_spec.rb
+++ b/core/spec/models/spree/stock/splitter/weight_spec.rb
@@ -6,25 +6,20 @@ module Spree
       describe Weight do
         let(:packer) { build(:stock_packer) }
         let(:variant) { build(:base_variant, :weight => 100) }
-        let(:line_item) { build(:line_item, variant: variant) }
 
         subject { Weight.new(packer) }
 
         it 'splits and keeps splitting until all packages are underweight' do
-          package = Package.new(packer.stock_location, packer.order)
-          package.add line_item, 1
-          package.add line_item, 1
-          package.add line_item, 1
-          package.add line_item, 1
+          package = Package.new(packer.stock_location)
+          4.times { package.add build(:inventory_unit, variant: variant) }
           packages = subject.split([package])
           packages.size.should eq 4
         end
 
         it 'handles packages that can not be reduced' do
-          package = Package.new(packer.stock_location, packer.order)
+          package = Package.new(packer.stock_location)
           variant.stub(:weight => 200)
-          package.add line_item, 4
-          package.add line_item, 4
+          2.times { package.add build(:inventory_unit, variant: variant) }
           packages = subject.split([package])
           packages.size.should eq 2
         end


### PR DESCRIPTION
Prior to this change, stock related service objects (coordinator, packer,
prioritizer, package, adjuster) were tightly coupled to orders and line
items, such that they would only create a set of shipments for the set
of line items for an order.

This change makes those objects work with inventory units, which enables
future enhancements that would create shipments for an order that are
not necessarily tied to the initial purchase (e.g. upcoming exchanges
work).
