### PR TITLE
Returns Taxation

### DIFF
--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -67,8 +67,16 @@ module Spree
       Spree::Variant.unscoped { super }
     end
 
-    def rounded_pre_tax_amount
-      (weighted_order_adjustment_amount + weighted_line_item_pre_tax_amount).round(2, :down)
+    def pre_tax_amount
+      weighted_order_adjustment_amount + weighted_line_item_pre_tax_amount
+    end
+
+    def additional_tax_total
+      line_item.additional_tax_total * percentage_of_line_item
+    end
+
+    def included_tax_total
+      line_item.included_tax_total * percentage_of_line_item
     end
 
     private

--- a/core/app/models/spree/return_authorization_tax_calculator.rb
+++ b/core/app/models/spree/return_authorization_tax_calculator.rb
@@ -1,0 +1,38 @@
+module Spree
+
+  # Tax calculation is broken out at this level to allow easy integration with 3rd party
+  # taxation systems.  Those systems are usually geared toward calculating all items at once
+  # rather than one at a time.
+  #
+  # To use an alternative tax calculator do this:
+  #    Spree::ReturnAuthorization.return_item_tax_calculator = calculator_object
+  # where `calculator_object` is an object that responds to "call" and accepts an array of return items
+
+  class ReturnAuthorizationTaxCalculator
+
+    class << self
+
+      def call(return_items)
+        return_items.each do |return_item|
+          set_tax!(return_item)
+        end
+      end
+
+      private
+
+      def set_tax!(return_item)
+        percent_of_tax = (return_item.pre_tax_amount <= 0) ? 0 : return_item.pre_tax_amount / return_item.inventory_unit.pre_tax_amount
+
+        additional_tax_total = percent_of_tax * return_item.inventory_unit.additional_tax_total
+        included_tax_total   = percent_of_tax * return_item.inventory_unit.included_tax_total
+
+        return_item.update_attributes!({
+          additional_tax_total: additional_tax_total,
+          included_tax_total:   included_tax_total,
+        })
+      end
+    end
+
+  end
+
+end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -254,6 +254,7 @@ en:
             base:
               amount_due_less_than_zero: Amount due is less than zero
               amount_due_greater_than_zero: Unable to refund full amount
+              insufficent_funds_available: Amount due is greater than amount available for refunds
         spree/refund:
           attributes:
             amount:

--- a/core/db/migrate/20140723152808_increase_return_item_pre_tax_amount_precision.rb
+++ b/core/db/migrate/20140723152808_increase_return_item_pre_tax_amount_precision.rb
@@ -1,0 +1,13 @@
+class IncreaseReturnItemPreTaxAmountPrecision < ActiveRecord::Migration
+  def up
+    change_column :spree_return_items, :pre_tax_amount, :decimal, precision: 12, scale: 4, default: 0.0, null: false
+    change_column :spree_return_items, :included_tax_total, :decimal, precision: 12, scale: 4, default: 0.0, null: false
+    change_column :spree_return_items, :additional_tax_total, :decimal, precision: 12, scale: 4, default: 0.0, null: false
+  end
+
+  def down
+    change_column :spree_return_items, :pre_tax_amount, :decimal, precision: 10, scale: 2, default: 0.0, null: false
+    change_column :spree_return_items, :included_tax_total, :decimal, precision: 10, scale: 2, default: 0.0, null: false
+    change_column :spree_return_items, :additional_tax_total, :decimal, precision: 10, scale: 2, default: 0.0, null: false
+  end
+end

--- a/core/lib/spree/testing_support/factories/line_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/line_item_factory.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :line_item, class: Spree::LineItem do
     quantity 1
     price { BigDecimal.new('10.00') }
-    pre_tax_amount { BigDecimal.new('10.00') }
+    pre_tax_amount { price }
     order
     ignore do
       association :product

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -5,9 +5,13 @@ FactoryGirl.define do
     completed_at nil
     email { user.email }
 
+    ignore do
+      line_items_price BigDecimal.new(10)
+    end
+
     factory :order_with_totals do
-      after(:create) do |order|
-        create(:line_item, order: order)
+      after(:create) do |order, evaluator|
+        create(:line_item, order: order, price: evaluator.line_items_price)
         order.line_items.reload # to ensure order.line_items is accessible after
       end
     end
@@ -18,13 +22,14 @@ FactoryGirl.define do
 
       ignore do
         line_items_count 5
+        shipment_cost 100
       end
 
       after(:create) do |order, evaluator|
-        create_list(:line_item, evaluator.line_items_count, order: order)
+        create_list(:line_item, evaluator.line_items_count, order: order, price: evaluator.line_items_price)
         order.line_items.reload
 
-        create(:shipment, order: order)
+        create(:shipment, order: order, cost: evaluator.shipment_cost)
         order.shipments.reload
 
         order.update!

--- a/core/spec/models/spree/inventory_unit_spec.rb
+++ b/core/spec/models/spree/inventory_unit_spec.rb
@@ -123,18 +123,18 @@ describe Spree::InventoryUnit do
     end
   end
 
-  describe "#rounded_pre_tax_amount" do
+  describe "#pre_tax_amount" do
     let(:order)           { create(:order) }
-    let(:line_item_count) { 2 }
+    let(:line_item_quantity) { 2 }
     let(:pre_tax_amount)  { 100.0 }
-    let(:line_item)       { create(:line_item, price: 100.0, quantity: line_item_count, pre_tax_amount: pre_tax_amount) }
+    let(:line_item)       { create(:line_item, price: 100.0, quantity: line_item_quantity, pre_tax_amount: pre_tax_amount) }
 
     before { order.line_items << line_item }
 
     subject { build(:inventory_unit, order: order, line_item: line_item) }
 
     context "no promotions or taxes" do
-      its(:rounded_pre_tax_amount) { should eq pre_tax_amount / line_item_count }
+      its(:pre_tax_amount) { should eq pre_tax_amount / line_item_quantity }
     end
 
     context "order adjustments" do
@@ -145,7 +145,7 @@ describe Spree::InventoryUnit do
         order.adjustments.first.update_attributes(amount: adjustment_amount)
       end
 
-      its(:rounded_pre_tax_amount) { should eq (pre_tax_amount - adjustment_amount.abs) / line_item_count }
+      its(:pre_tax_amount) { should eq (pre_tax_amount - adjustment_amount.abs) / line_item_quantity }
     end
 
     context "shipping adjustments" do
@@ -153,7 +153,45 @@ describe Spree::InventoryUnit do
 
       before { order.shipments << Spree::Shipment.new(adjustment_total: adjustment_total) }
 
-      its(:rounded_pre_tax_amount) { should eq pre_tax_amount / line_item_count }
+      its(:pre_tax_amount) { should eq pre_tax_amount / line_item_quantity }
+    end
+  end
+
+  describe '#additional_tax_total' do
+    let(:quantity) { 2 }
+    let(:line_item_additional_tax_total)  { 10.00 }
+    let(:line_item) do
+      build(:line_item, {
+        quantity: quantity,
+        additional_tax_total: line_item_additional_tax_total,
+      })
+    end
+
+    subject do
+      build(:inventory_unit, line_item: line_item)
+    end
+
+    it 'is the correct amount' do
+      expect(subject.additional_tax_total).to eq line_item_additional_tax_total / quantity
+    end
+  end
+
+  describe '#included_tax_total' do
+    let(:quantity) { 2 }
+    let(:line_item_included_tax_total)  { 10.00 }
+    let(:line_item) do
+      build(:line_item, {
+        quantity: quantity,
+        included_tax_total: line_item_included_tax_total,
+      })
+    end
+
+    subject do
+      build(:inventory_unit, line_item: line_item)
+    end
+
+    it 'is the correct amount' do
+      expect(subject.included_tax_total).to eq line_item_included_tax_total / quantity
     end
   end
 end

--- a/core/spec/models/spree/return_authorization_tax_calculator_spec.rb
+++ b/core/spec/models/spree/return_authorization_tax_calculator_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe Spree::ReturnAuthorizationTaxCalculator do
+
+  let!(:tax_zone) { create(:zone, default_tax: true) }
+  let!(:tax_rate) { nil }
+
+  let(:order) { create(:shipped_order, line_items_count: 2) }
+  let(:line_item_1) { order.line_items.first }
+  let(:line_item_2) { order.line_items.last }
+  let(:inventory_unit_1) { line_item_1.inventory_units.first }
+  let(:inventory_unit_2) { line_item_2.inventory_units.first }
+
+  let(:rma) { create(:return_authorization, order: order) }
+
+  let(:return_items) { [return_item_1, return_item_2] }
+  let(:return_item_1) { create(:return_item, pre_tax_amount: inventory_unit_1.pre_tax_amount, return_authorization: rma, inventory_unit: inventory_unit_1) }
+  let(:return_item_2) { create(:return_item, pre_tax_amount: inventory_unit_2.pre_tax_amount, return_authorization: rma, inventory_unit: inventory_unit_2) }
+
+  subject do
+    Spree::ReturnAuthorizationTaxCalculator.call(return_items)
+  end
+
+  context 'without taxes' do
+    let!(:tax_rate) { nil }
+
+    it 'leaves the return items additional_tax_total and included_tax_total at zero' do
+      subject
+
+      expect(return_item_1.additional_tax_total).to eq 0
+      expect(return_item_1.included_tax_total).to eq 0
+    end
+  end
+
+  context 'with additional tax' do
+    let!(:tax_rate) { create(:tax_rate, name: "Sales Tax", amount: 0.10, included_in_price: false, zone: tax_zone) }
+
+    it 'sets additional_tax_total on the return items' do
+      subject
+
+      expect(return_item_1.additional_tax_total).to be > 0
+      expect(return_item_1.additional_tax_total).to eq line_item_1.additional_tax_total
+    end
+  end
+
+  context 'with included tax' do
+    let!(:tax_rate) { create(:tax_rate, name: "VAT Tax", amount: 0.1, included_in_price: true, zone: tax_zone) }
+
+    it 'sets included_tax_total on the return items' do
+      subject
+
+      expect(return_item_1.included_tax_total).to be < 0
+      expect(return_item_1.included_tax_total).to eq line_item_1.included_tax_total
+    end
+  end
+end


### PR DESCRIPTION
Added a `ReturnAuthorization.return_item_tax_calculator` class attribute that is set to `Spree::ReturnAuthorizationTaxCalculator` by default.

When `ReturnAuthorization#process_refund` is called, the tax calculator is called with all return items and tax is calculated and stored on each return item and then the refund is performed with the new total.
Taxation is broken out like this to allow easy integration with third-party tax services.

Also:
- Moved some rounding further out since it was causing small but noticeable differences in refund amounts (off by 8 cents sometimes, for example).  And increase precision of some return_items fields along with that.
- Refactored return authorization controller specs so that the spec data is more correct
- Added an additional validation to #process_refund to abort the refund if we know we don't have enough funds to reimburse the customer fully
