### PR TITLE
Fixed deprecation warning (spree_cmd). 2-3-stable

### DIFF
--- a/cmd/lib/spree_cmd/templates/extension/spec/spec_helper.rb.tt
+++ b/cmd/lib/spree_cmd/templates/extension/spec/spec_helper.rb.tt
@@ -36,6 +36,9 @@ require '<%= file_name %>/factories'
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
 
+  # Infer an example group's spec type from the file location.
+  config.infer_spec_type_from_file_location!
+
   # == URL Helpers
   #
   # Allows access to Spree's routes in specs:
@@ -70,7 +73,7 @@ RSpec.configure do |config|
 
   # Before each spec check if it is a Javascript test and switch between using database transactions or not where necessary.
   config.before :each do
-    DatabaseCleaner.strategy = example.metadata[:js] ? :truncation : :transaction
+    DatabaseCleaner.strategy = RSpec.current_example.metadata[:js] ? :truncation : :transaction
     DatabaseCleaner.start
   end
 


### PR DESCRIPTION
```
spree extension extension_name
bundle install 
bundle exec rake test_app
bundle exec rspec spec
```

It will raise deprecation warning. 
The following is that reason.
- RSpec::Core::ExampleGroup#example is deprecated and will be removed in RSpec 3
- rspec-rails 3 will no longer automatically infer an example group's spec type from the file location.

[Gemfile.lock](https://gist.github.com/BlackPrincess/68135a6dd487c35a98ce)
