### PR TITLE
migrataion to copy current product slug values into slug history table

### DIFF
--- a/core/db/migrate/20140723214541_copy_product_slugs_to_slug_history.rb
+++ b/core/db/migrate/20140723214541_copy_product_slugs_to_slug_history.rb
@@ -1,0 +1,15 @@
+class CopyProductSlugsToSlugHistory < ActiveRecord::Migration
+  def change
+
+	# do what sql does best: copy all slugs into history table in a single query
+	# rather than load potentially millions of products into memory
+	Spree::Product.connection.execute <<-SQL
+INSERT INTO #{FriendlyId::Slug.table_name} (slug, sluggable_id, sluggable_type, created_at)
+  SELECT slug, id, '#{Spree::Product.to_s}', #{ActiveRecord::Base.send(:sanitize_sql_array, ['?', Time.current])} 
+  FROM #{Spree::Product.table_name}
+  WHERE slug IS NOT NULL
+  ORDER BY id
+SQL
+
+  end
+end


### PR DESCRIPTION
Per request from https://github.com/spree/spree/pull/5021.

This copies current slug values into slug history table. Slugs are only copied into this table by FriendlyId gem when changed, and then only the new value is set in the table (seems to me should be old value since history table is a fallback), so this migration ensures all current values can serve as a fallback when slugs are changed. This effectively enables immediate slug history tracking upon migration.

I did this as a sql migration, rather than AR syntax, to ensure that large product tables would not slow down migration significantly. 
Alternate, AR-syntax implementation would have looked something like this:

```
Spree::Product.select(:id, :slug).where.not(slug: nil).order_by(:id).find_each do |p|
  FriendlyId::Slug.create!(slug: p.slug, sluggable_id: p.id, sluggable_type: p.class.to_s)
end
```

The AR implementation has the major downside of eventually loading every product record into memory. Since recent discussions have suggested product tables with records in the millions (due to paranoid deletion), the SQL approach seems safer.
