### PR TITLE
Add mail from address field to general settings page

### DIFF
--- a/backend/app/views/spree/admin/general_settings/edit.html.erb
+++ b/backend/app/views/spree/admin/general_settings/edit.html.erb
@@ -39,6 +39,12 @@
           <br />
           <%= f.text_field :url, class: 'fullwidth'  %>
         </div>
+
+        <div class="field">
+          <%= f.label :mail_from_address %>
+          <br />
+          <%= f.text_field :mail_from_address, class: 'fullwidth'  %>
+        </div>
       <% end %>
 
       <div class="row">

--- a/backend/spec/features/admin/configuration/general_settings_spec.rb
+++ b/backend/spec/features/admin/configuration/general_settings_spec.rb
@@ -4,7 +4,8 @@ describe "General Settings" do
   stub_authorization!
 
   before(:each) do
-    store = create(:store, name: 'Test Store', url: 'test.example.org')
+    store = create(:store, name: 'Test Store', url: 'test.example.org',
+                           mail_from_address: 'test@example.org')
     visit spree.admin_path
     click_link "Configuration"
     click_link "General Settings"
@@ -15,16 +16,19 @@ describe "General Settings" do
       page.should have_content("General Settings")
       find("#store_name").value.should == "Test Store"
       find("#store_url").value.should == "test.example.org"
+      find("#store_mail_from_address").value.should == "test@example.org"
     end
   end
 
   context "editing general settings (admin)" do
     it "should be able to update the site name" do
       fill_in "store_name", :with => "Spree Demo Site99"
+      fill_in "store_mail_from_address", :with => "spree@example.org"
       click_button "Update"
 
       assert_successful_update_message(:general_settings)
       find("#store_name").value.should == "Spree Demo Site99"
+      find("#store_mail_from_address").value.should == "spree@example.org"
     end
   end
 end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -105,6 +105,7 @@ en:
         meta_keywords: Meta Keywords
         seo_title: Seo Title
         name: Site Name
+        mail_from_address: Mail From Address
       spree/tax_category:
         description: Description
         name: Name

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -29,7 +29,7 @@ module Spree
 
     @@address_attributes = [
       :id, :firstname, :lastname, :first_name, :last_name,
-      :address1, :address2, :city, :country_id, :state_id, 
+      :address1, :address2, :city, :country_id, :state_id,
       :zipcode, :phone, :state_name, :alternative_phone, :company,
       :country => [:iso, :name, :iso3, :iso_name],
       :state => [:name, :abbr]
@@ -69,7 +69,7 @@ module Spree
     # month / year may be provided by some sources, or others may elect to use one field
     @@source_attributes = [
       :number, :month, :year, :expiry, :verification_value,
-      :first_name, :last_name, :cc_type, :gateway_customer_profile_id, 
+      :first_name, :last_name, :cc_type, :gateway_customer_profile_id,
       :gateway_payment_profile_id, :last_digits, :name, :encrypted_data]
 
     @@stock_item_attributes = [:variant, :stock_location, :backorderable, :variant_id]

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -83,7 +83,7 @@ module Spree
       :quantity, :stock_item, :stock_item_id, :originator, :action]
 
     @@store_attributes = [:name, :url, :seo_title, :meta_keywords,
-                         :meta_description, :default_currency]
+                         :meta_description, :default_currency, :mail_from_address]
 
     @@taxonomy_attributes = [:name]
 


### PR DESCRIPTION
Can't change mail_from_address column of spree_stores table on general setting page so update the form.
