### PR TITLE
Return item cancellation

### DIFF
--- a/backend/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
@@ -171,14 +171,18 @@ describe Spree::Admin::ReturnAuthorizationsController do
         end
       end
 
-      context 'with existing items' do
-        let!(:return_item) do
-          create(:return_item, return_authorization: return_authorization, inventory_unit: inventory_unit_1)
+      context 'with existing completed items' do
+        let!(:completed_return_item) do
+          create(:return_item, {
+            return_authorization: return_authorization,
+            inventory_unit: inventory_unit_1,
+            reception_status: 'received',
+          })
         end
 
         it 'does not create new items' do
           expect { subject }.to_not change { Spree::ReturnItem.count }
-          expect(assigns[:return_authorization].errors['return_items.inventory_unit']).to eq ["has already been taken"]
+          expect(assigns[:return_authorization].errors['return_items.inventory_unit']).to eq ["#{inventory_unit_1.id} has already been taken by return item #{completed_return_item.id}"]
         end
       end
     end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -273,7 +273,8 @@ en:
           attributes:
             reimbursement:
               cannot_be_associated_unless_accepted: cannot be associated to a return item that is not accepted.
-
+            inventory_unit:
+              other_completed_return_item_exists: "%{inventory_unit_id} has already been taken by return item %{return_item_id}"
 
   devise:
     confirmations:


### PR DESCRIPTION
Creating a new return item should cancel any other return items with the same inventory unit.
This ensures an inventory unit can only be active in a single RMA at a time.
This allows history to be preserved but still allow new RMAs to be created to replace old ones.
