### PR TITLE
Make sure cart adjustments partial gets rendered if there are shipments.

### DIFF
--- a/frontend/app/views/spree/orders/_form.html.erb
+++ b/frontend/app/views/spree/orders/_form.html.erb
@@ -12,7 +12,7 @@
   <tbody id="line_items" data-hook>
     <%= render partial: 'line_item', collection: order_form.object.line_items, locals: {order_form: order_form} %>
   </tbody>
-  <% if @order.adjustments.exists? || @order.line_item_adjustments.exists? || @order.shipment_adjustments.exists? %>
+  <% if @order.adjustments.exists? || @order.line_item_adjustments.exists? || @order.shipment_adjustments.exists? || @order.shipments.any? %>
     <tr class="cart-subtotal">
       <td colspan="4" align='right'><h5><%= Spree.t(:cart_subtotal, :count => @order.line_items.sum(:quantity)) %></h5></th>
       <td colspan><h5><%= order_form.object.display_item_total %></h5></td>


### PR DESCRIPTION
Right now, if there are shipments on an order but no adjustments, the adjustment partial does not get rendered in the cart view. However, that partial needs to be rendered if there are shipments because it is responsible for displaying the shipping charges. The order total at the bottom of the cart includes the shipping charges but the because the cart only shows the line items, the customer is confused about the line items total / order total mismatch.

This fix makes sure the partial is being rendered if there are shipments.
