### PR TITLE
Adds proposed functionality which enhances the ability of extensions to ...

### DIFF
--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -11,7 +11,7 @@ module Spree
         variant = Spree::Variant.find(params[:variant_id])
         quantity = params[:quantity].to_i
         @shipment = @order.shipments.create(stock_location_id: params[:stock_location_id])
-        @order.contents.add(variant, quantity, nil, @shipment)
+        @order.contents.add(variant, quantity, {shipment: @shipment})
 
         @shipment.refresh_rates
         @shipment.save!

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -95,6 +95,12 @@ module Spree
       Spree::Variant.unscoped { super }
     end
 
+    def build_options(options)
+      options.keys.each do |key|
+        self.send("build_#{key}",options[key])
+      end
+    end
+
     private
       def update_inventory
         if changed? || target_shipment.present?

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -279,11 +279,11 @@ module Spree
       shipments.shipped
     end
 
-    def contains?(variant, options = nil)
+    def contains?(variant, options = {})
       find_line_item_by_variant(variant, options).present?
     end
 
-    def quantity_of(variant, options = nil)
+    def quantity_of(variant, options = {})
       line_item = find_line_item_by_variant(variant, options)
       line_item ? line_item.quantity : 0
     end

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -6,8 +6,8 @@ module Spree
       @order = order
     end
 
-    def add(variant, quantity = 1, currency = nil, shipment = nil)
-      line_item = add_to_line_item(variant, quantity, currency, shipment)
+    def add(variant, quantity = 1, options = {})
+      line_item = add_to_line_item(variant, quantity, options)
       reload_totals
       PromotionHandler::Cart.new(order, line_item).activate
       ItemAdjustments.new(line_item).update
@@ -15,8 +15,8 @@ module Spree
       line_item
     end
 
-    def remove(variant, quantity = 1, shipment = nil)
-      line_item = remove_from_line_item(variant, quantity, shipment)
+    def remove(variant, quantity = 1, options = {})
+      line_item = remove_from_line_item(variant, quantity, options)
       reload_totals
       PromotionHandler::Cart.new(order, line_item).activate
       ItemAdjustments.new(line_item).update
@@ -56,8 +56,11 @@ module Spree
         order.reload
       end
 
-      def add_to_line_item(variant, quantity, currency=nil, shipment=nil)
-        line_item = grab_line_item_by_variant(variant)
+    def add_to_line_item(variant, quantity, options = {})
+        line_item = grab_line_item_by_variant(variant, false, options)
+
+        currency = options.delete(:currency)
+        shipment = options.delete(:shipment)
 
         if line_item
           line_item.target_shipment = shipment
@@ -66,11 +69,16 @@ module Spree
         else
           line_item = order.line_items.new(quantity: quantity, variant: variant)
           line_item.target_shipment = shipment
+          
+          line_item.build_options(options) if options
+
           if currency
             line_item.currency = currency
-            line_item.price    = variant.price_in(currency).amount
+            line_item.price    = variant.price_in(currency).amount + 
+                                 variant.price_modifier_amount_in(currency, options)
           else
-            line_item.price    = variant.price
+            line_item.price    = variant.price + 
+                                 variant.price_modifier_amount(options)
           end
         end
 
@@ -78,10 +86,10 @@ module Spree
         line_item
       end
 
-      def remove_from_line_item(variant, quantity, shipment=nil)
-        line_item = grab_line_item_by_variant(variant, true)
+      def remove_from_line_item(variant, quantity, options = {})
+        line_item = grab_line_item_by_variant(variant, true, options)
         line_item.quantity -= quantity
-        line_item.target_shipment= shipment
+        line_item.target_shipment= options[:shipment]
 
         if line_item.quantity == 0
           line_item.destroy
@@ -92,8 +100,8 @@ module Spree
         line_item
       end
 
-      def grab_line_item_by_variant(variant, raise_error = false)
-        line_item = order.find_line_item_by_variant(variant)
+      def grab_line_item_by_variant(variant, raise_error = false, options = {})
+        line_item = order.find_line_item_by_variant(variant, options)
 
         if !line_item.present? && raise_error
           raise ActiveRecord::RecordNotFound, "Line item not found for variant #{variant.sku}"

--- a/core/app/models/spree/order_populator.rb
+++ b/core/app/models/spree/order_populator.rb
@@ -10,8 +10,8 @@ module Spree
     end
 
     
-    def populate(variant_id, quantity)
-      attempt_cart_add(variant_id, quantity)
+    def populate(variant_id, quantity, options={})
+      attempt_cart_add(variant_id, quantity, options)
       valid?
     end
 
@@ -21,7 +21,7 @@ module Spree
 
     private
 
-    def attempt_cart_add(variant_id, quantity)
+    def attempt_cart_add(variant_id, quantity, options={})
       quantity = quantity.to_i
       # 2,147,483,647 is crazy.
       # See issue #2695.
@@ -32,7 +32,7 @@ module Spree
 
       variant = Spree::Variant.find(variant_id)
       if quantity > 0
-        line_item = @order.contents.add(variant, quantity, currency)
+        line_item = @order.contents.add(variant, quantity, options.merge(currency: currency))
         unless line_item.valid?
           errors.add(:base, line_item.errors.messages.values.join(" "))
           return false

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -147,6 +147,32 @@ module Spree
       price_in(currency).try(:amount)
     end
 
+    def price_modifier_amount_in(currency, options = {})
+      return 0 unless options.present?
+
+      options.keys.map { |key|
+        m = "#{key}_price_modifier_amount_in".to_sym
+        if self.respond_to? m
+          self.send(m, currency, options[key])
+        else
+          0
+        end
+      }.sum
+    end
+
+    def price_modifier_amount(options = {})
+      return 0 unless options.present?
+
+      options.keys.map { |key|
+        m = "#{options[key]}_price_modifier_amount".to_sym
+        if self.respond_to? m
+          self.send(m, options[key]) 
+        else
+          0
+        end
+      }.sum
+    end
+
     def name_and_sku
       "#{name} - #{sku}"
     end

--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -45,7 +45,7 @@ module Spree
     # Adds a new item to the order (creating a new order if none already exists)
     def populate
       populator = Spree::OrderPopulator.new(current_order(create_order_if_necessary: true), current_currency)
-      if populator.populate(params[:variant_id], params[:quantity])
+      if populator.populate(params[:variant_id], params[:quantity], params[:options])
         current_order.ensure_updated_shipments
 
         respond_with(@order) do |format|


### PR DESCRIPTION
...customize line items and the entire cart composition process

This work is a follow-up to https://github.com/spree/spree/pull/4546.

EDIT: I don't really intend for this to be pulled into a stable branch (2-3 in this case).  I wanted to provide some mostly-working code as a reference point for discussion.  I could then take the feedback and put into a 'proper' PR for master.

Please see: https://github.com/jsqu99/spree_product_customizations (a rework of 1/2 of the spree_flexi_variants extension (github.com/jsqu99/spree_flexi_variants)) as an example of how these changes would be used by an extension.

There's a lot here, but the basic idea is to allow extensions to follow some basic conventions in order to hook into the "add to cart" process without major surgery involving the core spree order code.

Related to this is the ability to know if two line items match and how to instruct spree to make those determinations.

I'll keep the description light here and let the code be reviewed as a first step.

Please see the referenced initial pull request above as background.
