### PR TITLE
Getting ready for Teatro.io stage server

### DIFF
--- a/.teatro.yml
+++ b/.teatro.yml
@@ -1,0 +1,20 @@
+stage:
+  before:
+    - export SECRET_KEY_BASE=abc
+    - bundle exec rake sandbox
+    - echo 'Rails.logger = Logger.new(STDOUT)' > sandbox/config/initializers/logger_stdout.rb
+    - cd sandbox
+    - ln -sf $PWD/public $PWD/../public
+
+  run:
+    # pwd is sanbox
+    - bundle exec rails server
+
+  database:
+    # actually do nothing (and prevent default Teatro behavior): `rake sandbox` already did everything
+    - true
+
+config:
+  database: postgresql
+  services:
+    - postgresql


### PR DESCRIPTION
Hey!

I am developer at Teatro.io and I want to offer you our service — it automatically creates a staging server for each opened pull request.

Seems like your demo app (https://github.com/spree/demo) is out-of-date. That's what I want to help you with.

Teatro.io is free for open source projects — some large projects like GitLab (https://github.com/gitlabhq/gitlabhq/pull/7140 ), ErrBit (works out-of-the-box, @ndbroadbent approved Teatro), Rails Admin (https://github.com/sferik/rails_admin/pull/2029) and others are already using Teatro as free stage servers.

Here's URL of Teatro stage server for my fork of Spree: http://teatro-stage.semenyukdmitriy-spree-23fe8f973bd67524b0e7.ttrcloud.com/. Awesome, isn't it?

When you connect project to Teatro, we'll automatically post a comment (via @TeatroIO) with like to unique stage server that was made for this specific branch (see https://github.com/semenyukdmitriy/spree/pull/1 for example).

To use Teatro you need:
— sign in using Github account on http://Teatro.io
— add your project

**Benefits**:
— demo for new users (always up to date!)
— the way to test changes: each Pull Request gets separate stage server
— FREE for open source!

Have any questions? — Post a comment.
