### PR TITLE
Add `Spree::Promotion#products` back.

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -99,6 +99,10 @@ module Spree
       end
     end
 
+    def products
+      rules.where(type: "Spree::Promotion::Rules::Product").map(&:products).flatten.uniq
+    end
+
     def usage_limit_exceeded?(promotable)
       usage_limit.present? && usage_limit > 0 && adjusted_credits_count(promotable) >= usage_limit
     end

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -237,6 +237,30 @@ describe Spree::Promotion do
     end
   end
 
+  context "#products" do
+    let(:promotion) { create(:promotion) }
+
+    context "when it has product rules with products associated" do
+      let(:promotion_rule) { Spree::Promotion::Rules::Product.new }
+
+      before do
+        promotion_rule.promotion = promotion
+        promotion_rule.products << create(:product)
+        promotion_rule.save
+      end
+
+      it "should have products" do
+        promotion.reload.products.size.should == 1
+      end
+    end
+
+    context "when there's no product rule associated" do
+      it "should not have products but still return an empty array" do
+        promotion.products.should be_blank
+      end
+    end
+  end
+
   context "#eligible?" do
     before do
       @order = create(:order)


### PR DESCRIPTION
This was removed in 6ff0e82, however it's still currently used in [frontend/app/views/spree/products/_promotions.html.erb](https://github.com/spree/spree/blob/master/frontend/app/views/spree/products/_promotions.html.erb#L9-L15)

So I added it back. Alternatively, we could remove it from the front end.
