### PR TITLE
Fix Spree::Promotion not applying all of the time.

### DIFF
--- a/core/spec/models/spree/promotion_handler/cart_spec.rb
+++ b/core/spec/models/spree/promotion_handler/cart_spec.rb
@@ -82,6 +82,21 @@ module Spree
           include_context "creates the adjustment"
         end
       end
+
+      context "activates promotions associated with the order" do
+        let(:promo) { create :promotion_with_item_adjustment, adjustment_rate: 5, code: 'promo' }
+        let(:adjustable) { line_item }
+
+        before do
+          order.promotions << promo
+        end
+
+        it "creates the adjustment" do
+          expect {
+            subject.activate
+          }.to change { adjustable.adjustments.count }.by(1)
+        end
+      end
     end
   end
 end

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -421,4 +421,28 @@ describe Spree::Promotion do
       it { should be false }
     end
   end
+
+  describe "adding items to the cart" do
+    let(:order) { create :order }
+    let(:line_item) { create :line_item, order: order }
+    let(:promo) { create :promotion_with_item_adjustment, adjustment_rate: 5, code: 'promo' }
+    let(:variant) { create :variant }
+
+    it "updates the promotions for new line items" do
+      expect(line_item.adjustments).to be_empty
+      expect(order.adjustment_total).to eq 0
+
+      promo.activate order: order
+      order.update!
+
+      expect(line_item.adjustments).to have(1).item
+      expect(order.adjustment_total).to eq -5
+
+      other_line_item = order.contents.add(variant, 1, order.currency)
+
+      expect(other_line_item).not_to eq line_item
+      expect(other_line_item.adjustments).to have(1).item
+      expect(order.adjustment_total).to eq -10
+    end
+  end
 end


### PR DESCRIPTION
There was a specific case in which promotions added to an order would not apply to new items added to the cart. This corrects that by having the PromotionHandler activate all promotions already associated with the order as well as any with a blank code and path.

Steps to reproduce:
1. Create promotion with either a code or a path.
2. Add item to cart.
3. Apply promotion to order.
4. Add another applicable item to the cart.

The newly added item would not have the existing promotion applied to it. With this change, that is not that case. Yay!

Might also fix #4621

If people have an adverse reaction to the Arel I can update this to use straight SQL instead.
