### PR TITLE
Implement exchanges

### DIFF
--- a/backend/app/views/spree/admin/customer_returns/_return_item_decision.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_return_item_decision.html.erb
@@ -4,6 +4,7 @@
       <th><%= Spree.t(:product) %></th>
       <th><%= Spree.t(:reception_status) %></th>
       <th><%= Spree.t(:pre_tax_refund_amount) %></th>
+      <th><%= Spree.t(:exchange_for) %></th>
       <th class="actions"></th>
     </tr>
   </thead>
@@ -16,6 +17,7 @@
         </td>
         <td class="align-center"><%= return_item.reception_status.humanize %></td>
         <td class="align-center"><%= return_item.display_pre_tax_amount %></td>
+        <td class="align-center"><%= return_item.exchange_variant.try(:options_text) %></td>
         <td class='actions'>
           <%= button_to [:admin, return_item], { class: 'fa fa-thumbs-up icon_link no-text with-tip', params: { "return_item[acceptance_status]" => 'accepted' }, "data-action" => 'save', title: Spree.t(:accept), method: 'put' } do %>
             Spree.t(:accept)

--- a/backend/app/views/spree/admin/customer_returns/_return_item_detail.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_return_item_detail.html.erb
@@ -4,6 +4,7 @@
       <th><%= Spree.t(:product) %></th>
       <th><%= Spree.t(:reception_status) %></th>
       <th><%= Spree.t(:pre_tax_refund_amount) %></th>
+      <th><%= Spree.t(:exchange_for) %></th>
     </tr>
   </thead>
   <tbody>
@@ -17,6 +18,7 @@
         <td class="align-center">
           <%= return_item.display_pre_tax_amount %>
         </td>
+        <td class="align-center"><%= return_item.exchange_variant.try(:options_text) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/backend/app/views/spree/admin/customer_returns/_return_item_table.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_return_item_table.html.erb
@@ -12,6 +12,7 @@
           <th><%= Spree.t(:charged) %></th>
         <% end %>
         <th><%= Spree.t(:pre_tax_refund_amount) %></th>
+        <th><%= Spree.t(:exchange_for) %></th>
       </tr>
     </thead>
     <tbody>
@@ -48,6 +49,9 @@
             <% else %>
               <%= return_item.display_pre_tax_amount %>
             <% end %>
+          </td>
+          <td class="align-center">
+            <%= item_fields.collection_select :exchange_variant_id, return_item.eligible_exchange_variants, :id, :options_text, { include_blank: true }, { class: "select2 fullwidth" } %>
           </td>
         </tr>
       <% end %>

--- a/backend/app/views/spree/admin/return_authorizations/_form.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/_form.html.erb
@@ -15,6 +15,7 @@
           <th><%= Spree.t(:charged) %></th>
         <% end %>
         <th><%= Spree.t(:pre_tax_refund_amount) %></th>
+        <th><%= Spree.t(:exchange_for) %></th>
       </tr>
     </thead>
     <tbody>
@@ -49,6 +50,9 @@
             <% else %>
               <%= return_item.display_pre_tax_amount %>
             <% end %>
+          </td>
+          <td class="align-center">
+            <%= item_fields.collection_select :exchange_variant_id, return_item.eligible_exchange_variants, :id, :options_text, { include_blank: true }, { class: "select2 fullwidth" } %>
           </td>
         </tr>
       <% end %>

--- a/core/app/models/spree/exchange.rb
+++ b/core/app/models/spree/exchange.rb
@@ -1,0 +1,42 @@
+module Spree
+  class Exchange
+
+    def initialize(order, return_items)
+      @order = order
+      @return_items = return_items
+    end
+
+    def description
+      @return_items.map do |return_item|
+        "#{return_item.variant.options_text} => #{return_item.exchange_variant.options_text}"
+      end.join(" | ")
+    end
+
+    def display_amount
+      Spree::Money.new @return_items.map(&:total).sum
+    end
+
+    def perform!
+      shipments = Spree::Stock::Coordinator.new(@order, @return_items.map(&:build_exchange_inventory_unit)).shipments
+      @order.shipments += shipments
+      @order.save!
+      shipments.each do |shipment|
+        shipment.update!(@order)
+        shipment.finalize!
+      end
+    end
+
+    def to_key
+      nil
+    end
+
+    def self.param_key
+      "spree_exchange"
+    end
+
+    def self.model_name
+      Spree::Exchange
+    end
+
+  end
+end

--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -7,6 +7,7 @@ module Spree
     belongs_to :line_item, class_name: "Spree::LineItem", inverse_of: :inventory_units
 
     has_many :return_items, inverse_of: :inventory_unit
+    has_one :original_return_item, class_name: "Spree::ReturnItem", foreign_key: :exchange_inventory_unit_id
 
     scope :backordered, -> { where state: 'backordered' }
     scope :on_hand, -> { where state: 'on_hand' }

--- a/core/app/models/spree/reimbursement.rb
+++ b/core/app/models/spree/reimbursement.rb
@@ -112,6 +112,10 @@ module Spree
       reimbursement_performer.simulate(self)
     end
 
+    def return_items_requiring_exchange
+      return_items.select(&:exchange_required?)
+    end
+
     private
 
     def generate_number

--- a/core/app/models/spree/return_item/exchange_variant_eligibility/same_option_value.rb
+++ b/core/app/models/spree/return_item/exchange_variant_eligibility/same_option_value.rb
@@ -1,0 +1,34 @@
+module Spree
+  module ReturnItem::ExchangeVariantEligibility
+    class SameOptionValue
+      class_attribute :option_type_restrictions
+      self.option_type_restrictions = []
+      # This can be configured in an initializer, e.g.:
+      # Spree::ReturnItem::ExchangeVariantEligibility::SameOptionValue.option_type_restrictions = ["size", "color"]
+      #
+      # This restriction causes only variants that share the same option value for the
+      # specified option types to be returned. e.g.:
+      #
+      # option_type_restrictions = ["color", "waist"]
+      # Variant: blue pants with 32 waist and 30 inseam
+      #
+      # can be exchanged for:
+      # blue pants with 32 waist and 31 inseam
+      #
+      # cannot be exchanged for:
+      # green pants with 32 waist and 30 inseam
+      # blue pants with 34 waist and 32 inseam
+
+      def self.eligible_variants(variant)
+        product_variants = SameProduct.eligible_variants(variant).includes(option_values: :option_type)
+
+        relevant_option_values = variant.option_values.select { |ov| option_type_restrictions.include? ov.option_type.name }
+        if relevant_option_values.present?
+          product_variants.select { |v| (relevant_option_values & v.option_values) == relevant_option_values }
+        else
+          product_variants
+        end
+      end
+    end
+  end
+end

--- a/core/app/models/spree/return_item/exchange_variant_eligibility/same_product.rb
+++ b/core/app/models/spree/return_item/exchange_variant_eligibility/same_product.rb
@@ -1,0 +1,10 @@
+module Spree
+  module ReturnItem::ExchangeVariantEligibility
+    class SameProduct
+
+      def self.eligible_variants(variant)
+        Spree::Variant.where.not(id: variant.id).where(product_id: variant.product_id, is_master: false)
+      end
+    end
+  end
+end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -641,6 +641,7 @@ en:
           signup: User signup
     exceptions:
       count_on_hand_setter: Cannot set count_on_hand manually, as it is set automatically by the recalculate_count_on_hand callback. Please use `update_column(:count_on_hand, value)` instead.
+    exchange_for: Exchange for
     excl: excl.
     expiration: Expiration
     extension: Extension

--- a/core/db/migrate/20140729133613_add_exchange_inventory_unit_foreign_keys.rb
+++ b/core/db/migrate/20140729133613_add_exchange_inventory_unit_foreign_keys.rb
@@ -1,0 +1,7 @@
+class AddExchangeInventoryUnitForeignKeys < ActiveRecord::Migration
+  def change
+    add_column :spree_return_items, :exchange_inventory_unit_id, :integer
+
+    add_index :spree_return_items, :exchange_inventory_unit_id
+  end
+end

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -38,7 +38,7 @@ module Spree
 
     @@checkout_attributes = [:email, :use_billing, :shipping_method_id, :coupon_code, :special_instructions]
 
-    @@customer_return_attributes = [:stock_location_id, return_items_attributes: [:id, :inventory_unit_id, :return_authorization_id, :returned, :pre_tax_amount, :acceptance_status]]
+    @@customer_return_attributes = [:stock_location_id, return_items_attributes: [:id, :inventory_unit_id, :return_authorization_id, :returned, :pre_tax_amount, :acceptance_status, :exchange_variant_id]]
 
     @@image_attributes = [:alt, :attachment, :position, :viewable_type, :viewable_id]
 

--- a/core/lib/spree/testing_support/factories/return_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/return_item_factory.rb
@@ -2,5 +2,9 @@ FactoryGirl.define do
   factory :return_item, class: Spree::ReturnItem do
     association(:inventory_unit, factory: :inventory_unit)
     association(:return_authorization, factory: :return_authorization)
+
+    factory :exchange_return_item do
+      association(:exchange_variant, factory: :variant)
+    end
   end
 end

--- a/core/spec/models/spree/exchange_spec.rb
+++ b/core/spec/models/spree/exchange_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+module Spree
+  describe Exchange do
+    let(:order) { Spree::Order.new }
+
+    let(:return_item_1) { build(:exchange_return_item) }
+    let(:return_item_2) { build(:exchange_return_item) }
+    let(:return_items) { [return_item_1, return_item_2] }
+    let(:exchange) { Exchange.new(order, return_items) }
+
+    describe "#description" do
+      before do
+        return_item_1.stub(:variant) { double(options_text: "foo") }
+        return_item_1.stub(:exchange_variant) { double(options_text: "bar") }
+        return_item_2.stub(:variant) { double(options_text: "baz") }
+        return_item_2.stub(:exchange_variant) { double(options_text: "qux") }
+      end
+
+      it "describes the return items' change in options" do
+        expect(exchange.description).to match /foo => bar/
+        expect(exchange.description).to match /baz => qux/
+      end
+    end
+
+    describe "#display_amount" do
+      it "is the total amount of all return items" do
+        expect(exchange.display_amount).to eq Spree::Money.new(0.0)
+      end
+    end
+
+    describe "#perform!" do
+      let(:return_item) { create(:exchange_return_item) }
+      let(:return_items) { [return_item] }
+      let(:order) { return_item.return_authorization.order }
+      subject { exchange.perform! }
+      before { return_item.exchange_variant.stock_items.first.adjust_count_on_hand(20) }
+
+      it "creates shipments for the order with the return items exchange inventory units" do
+        expect { subject }.to change { order.shipments.count }.by(1)
+        new_shipment = order.shipments.last
+        expect(new_shipment).to be_ready
+        new_inventory_units = new_shipment.inventory_units
+        expect(new_inventory_units.count).to eq 1
+        expect(new_inventory_units.first.original_return_item).to eq return_item
+        expect(new_inventory_units.first.line_item).to eq return_item.inventory_unit.line_item
+      end
+    end
+
+    describe "#to_key" do # for dom_id
+      it { expect(Exchange.new(nil, nil).to_key).to be_nil }
+    end
+
+    describe ".param_key" do # for dom_id
+      it { expect(Exchange.param_key).to eq "spree_exchange" }
+    end
+
+    describe ".model_name" do # for dom_id
+      it { expect(Exchange.model_name).to eq Spree::Exchange }
+    end
+
+  end
+end

--- a/core/spec/models/spree/reimbursement_spec.rb
+++ b/core/spec/models/spree/reimbursement_spec.rb
@@ -133,6 +133,23 @@ describe Spree::Reimbursement do
       end
     end
 
+    context "when exchange is required" do
+      let(:exchange_variant) { build(:variant) }
+      before { return_item.exchange_variant = exchange_variant }
+      it "generates an exchange shipment for the order for the exchange items" do
+        expect { subject }.to change { order.reload.shipments.count }.by 1
+        expect(order.shipments.last.inventory_units.first.variant).to eq exchange_variant
+      end
+    end
+
+  end
+
+  describe "#return_items_requiring_exchange" do
+    it "returns only the return items that require an exchange" do
+      return_items = [double(exchange_required?: true), double(exchange_required?: true),double(exchange_required?: false)]
+      subject.stub(:return_items) { return_items }
+      expect(subject.return_items_requiring_exchange).to eq return_items.take(2)
+    end
   end
 
 end

--- a/core/spec/models/spree/return_item/exchange_variant_eligibility/same_option_value_spec.rb
+++ b/core/spec/models/spree/return_item/exchange_variant_eligibility/same_option_value_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+module Spree
+  module ReturnItem::ExchangeVariantEligibility
+    describe SameOptionValue do
+      describe ".eligible_variants" do
+        let(:color_option_type) { create(:option_type, name: "color") }
+        let(:waist_option_type) { create(:option_type, name: "waist") }
+        let(:inseam_option_type) { create(:option_type, name: "inseam") }
+
+        let(:blue_option_value) { create(:option_value, name: "blue", option_type: color_option_type) }
+        let(:red_option_value) { create(:option_value, name: "red", option_type: color_option_type) }
+
+        let(:three_two_waist_option_value) { create(:option_value, name: 32, option_type: waist_option_type) }
+        let(:three_four_waist_option_value) { create(:option_value, name: 34, option_type: waist_option_type) }
+
+        let(:three_zero_inseam_option_value) { create(:option_value, name: 30, option_type: inseam_option_type) }
+        let(:three_one_inseam_option_value) { create(:option_value, name: 31, option_type: inseam_option_type) }
+
+        let(:product) { create(:product, option_types: [color_option_type, waist_option_type, inseam_option_type]) }
+
+        let(:variant) { create(:variant, product: product, option_values: [blue_option_value, three_two_waist_option_value, three_zero_inseam_option_value]) }
+
+        before do
+          @original_option_type_restrictions = SameOptionValue.option_type_restrictions
+          SameOptionValue.option_type_restrictions = ["color", "waist"]
+        end
+
+        after { SameOptionValue.option_type_restrictions = @original_option_type_restrictions }
+
+        subject { SameOptionValue.eligible_variants(variant) }
+
+        it "returns all other variants for the same product with the same option value for the specified option type" do
+          same_option_values_variant = create(:variant, product: product, option_values: [blue_option_value, three_two_waist_option_value, three_one_inseam_option_value])
+          different_color_option_value_variant = create(:variant, product: product, option_values: [red_option_value, three_two_waist_option_value, three_one_inseam_option_value])
+          different_waist_option_value_variant = create(:variant, product: product, option_values: [blue_option_value, three_four_waist_option_value, three_one_inseam_option_value])
+
+          expect(subject).to eq [same_option_values_variant]
+        end
+
+        it "does not return variants for another product" do
+          other_product_variant = create(:variant)
+          expect(subject).not_to include other_product_variant
+        end
+
+        context "no option value restrictions are specified" do
+          before do
+            @original_option_type_restrictions = SameOptionValue.option_type_restrictions
+            SameOptionValue.option_type_restrictions = []
+          end
+
+          after { SameOptionValue.option_type_restrictions = @original_option_type_restrictions }
+
+          it "returns all variants for the product" do
+            same_option_values_variant = create(:variant, product: product, option_values: [blue_option_value, three_two_waist_option_value, three_one_inseam_option_value])
+            different_color_option_value_variant = create(:variant, product: product, option_values: [red_option_value, three_two_waist_option_value, three_one_inseam_option_value])
+            different_waist_option_value_variant = create(:variant, product: product, option_values: [blue_option_value, three_four_waist_option_value, three_one_inseam_option_value])
+
+            expect(subject.sort).to eq [same_option_values_variant, different_waist_option_value_variant, different_color_option_value_variant].sort
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/core/spec/models/spree/return_item/exchange_variant_eligibility/same_product_spec.rb
+++ b/core/spec/models/spree/return_item/exchange_variant_eligibility/same_product_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+module Spree
+  module ReturnItem::ExchangeVariantEligibility
+    describe SameProduct do
+      describe ".eligible_variants" do
+        it "returns all other variants for the same product" do
+          product = create(:product, variants: 3.times.map { build(:variant) })
+          expect(SameProduct.eligible_variants(product.variants.first).sort).to eq product.variants[1..-1].sort
+        end
+
+        it "does not return variants for another product" do
+          variant = create(:variant)
+          other_product_variant = create(:variant)
+          expect(SameProduct.eligible_variants(variant)).not_to include other_product_variant
+        end
+      end
+    end
+  end
+end
+

--- a/core/spec/models/spree/return_item_spec.rb
+++ b/core/spec/models/spree/return_item_spec.rb
@@ -335,4 +335,113 @@ describe Spree::ReturnItem do
       end
     end
   end
+
+  describe "#exchange_requested?" do
+    context "exchange variant exists" do
+      before { subject.stub(:exchange_variant) { mock_model(Spree::Variant) } }
+      it { expect(subject.exchange_requested?).to eq true }
+    end
+    context "exchange variant does not exist" do
+      before { subject.stub(:exchange_variant) { nil } }
+      it { expect(subject.exchange_requested?).to eq false }
+    end
+  end
+
+  describe "#exchange_processed?" do
+    context "exchange inventory unit exists" do
+      before { subject.stub(:exchange_inventory_unit) { mock_model(Spree::InventoryUnit) } }
+      it { expect(subject.exchange_processed?).to eq true }
+    end
+    context "exchange inventory unit does not exist" do
+      before { subject.stub(:exchange_inventory_unit) { nil } }
+      it { expect(subject.exchange_processed?).to eq false }
+    end
+  end
+
+  describe "#exchange_required?" do
+    context "exchange has been requested and not yet processed" do
+      before do
+        subject.stub(:exchange_requested?) { true }
+        subject.stub(:exchange_processed?) { false }
+      end
+
+      it { expect(subject.exchange_required?).to be_true }
+    end
+
+    context "exchange has not been requested" do
+      before { subject.stub(:exchange_requested?) { false } }
+      it { expect(subject.exchange_required?).to be_false }
+    end
+
+    context "exchange has been requested and processed" do
+      before do
+        subject.stub(:exchange_requested?) { true }
+        subject.stub(:exchange_processed?) { true }
+      end
+      it { expect(subject.exchange_required?).to be_false }
+    end
+  end
+
+  describe "#eligible_exchange_variants" do
+    it "uses the exchange variant calculator to compute possible variants to exchange for" do
+      return_item = build(:return_item)
+      expect(Spree::ReturnItem.exchange_variant_engine).to receive(:eligible_variants).with(return_item.variant)
+      return_item.eligible_exchange_variants
+    end
+  end
+
+  describe ".exchange_variant_engine" do
+    it "defaults to the same product calculator" do
+      expect(Spree::ReturnItem.exchange_variant_engine).to eq Spree::ReturnItem::ExchangeVariantEligibility::SameProduct
+    end
+  end
+
+  describe "exchange pre_tax_amount" do
+    let(:return_item) { build(:return_item) }
+
+    context "the return item is intended to be exchanged" do
+      before { return_item.exchange_variant = build(:variant) }
+      it do
+        return_item.pre_tax_amount = 5.0
+        return_item.save!
+        expect(return_item.reload.pre_tax_amount).to eq 0.0
+      end
+    end
+
+    context "the return item is not intended to be exchanged" do
+      it do
+        return_item.pre_tax_amount = 5.0
+        return_item.save!
+        expect(return_item.reload.pre_tax_amount).to eq 5.0
+      end
+    end
+  end
+
+  describe "#build_exchange_inventory_unit" do
+    let(:return_item) { build(:return_item) }
+    subject { return_item.build_exchange_inventory_unit }
+
+    context "the return item is intended to be exchanged" do
+      before { return_item.stub(:exchange_variant).and_return(mock_model(Spree::Variant)) }
+
+      context "an exchange inventory unit already exists" do
+        before { return_item.stub(:exchange_inventory_unit).and_return(mock_model(Spree::InventoryUnit)) }
+        it { expect(subject).to be_nil }
+      end
+
+      context "no exchange inventory unit exists" do
+        it "builds a pending inventory unit with references to the return item, variant, and previous inventory unit" do
+          expect(subject.variant).to eq return_item.exchange_variant
+          expect(subject.pending).to eq true
+          expect(subject).not_to be_persisted
+          expect(subject.original_return_item).to eq return_item
+          expect(subject.line_item).to eq return_item.inventory_unit.line_item
+        end
+      end
+    end
+
+    context "the return item is not intended to be exchanged" do
+      it { expect(subject).to be_nil }
+    end
+  end
 end


### PR DESCRIPTION
When a return item has an exchange variant associated to it, when the customer return is processed, that return item is not refunded, but rather the exchange variant is grouped into a new shipment for the existing order with other exchanges for the customer return. 

No new line items are created and no money is refunded for the exchanged items. 

The new inventory units are associated to the original like item so as to allow refund calculation for future returns of this item. 

There are different eligibility rules that stores can implement to determine what variants can be exchanged for, the default being any variant for the same product. 
