### PR TITLE
Global product promotion blacklist

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/sections/_products.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_products.scss
@@ -14,6 +14,10 @@
   input, select, textarea, .select2-container {
     width: 100%;
   }
+  input[type="checkbox"] {
+    width: auto;
+    vertical-align: bottom;
+  }
 }
 
 [data-hook="admin_product_form_multiple_variants"] {

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -20,7 +20,7 @@
     <div data-hook="admin_product_form_description">
       <%= f.field_container :description do %>
         <%= f.label :description, Spree.t(:description) %>
-        <%= f.text_area :description, {:rows => "#{unless @product.has_variants? then '20' else '13' end}", :class => 'fullwidth'} %>
+        <%= f.text_area :description, {:rows => "#{unless @product.has_variants? then '22' else '15' end}", :class => 'fullwidth'} %>
         <%= f.error_message_on :description %>
       <% end %>
     </div>
@@ -57,6 +57,14 @@
         <%= f.label :available_on, Spree.t(:available_on) %>
         <%= f.error_message_on :available_on %>
         <%= f.text_field :available_on, :value => datepicker_field_value(@product.available_on), :class => 'datepicker' %>
+      <% end %>
+    </div>
+
+    <div data-hook="admin_product_form_promotionable">
+      <%= f.field_container :promotionable do %>
+        <%= f.label :promotionable do %>
+          <%= f.check_box :promotionable %> <%= Spree.t(:promotionable) %>
+        <% end %>
       <% end %>
     </div>
 

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -103,16 +103,6 @@ module Spree
       usage_limit.present? && usage_limit > 0 && adjusted_credits_count(promotable) >= usage_limit
     end
 
-    def blacklisted?(promotable)
-      case promotable
-      when Spree::LineItem
-        !promotable.product.promotionable?
-      when Spree::Order
-        promotable.line_items.any? &&
-          !promotable.line_items.joins(:product).where(spree_products: {promotionable: true}).any?
-      end
-    end
-
     def adjusted_credits_count(promotable)
       credits_count - promotable.adjustments.promotion.where(:source_id => actions.pluck(:id)).count
     end
@@ -145,6 +135,16 @@ module Spree
     end
 
     private
+    def blacklisted?(promotable)
+      case promotable
+      when Spree::LineItem
+        !promotable.product.promotionable?
+      when Spree::Order
+        promotable.line_items.any? &&
+          !promotable.line_items.joins(:product).where(spree_products: {promotionable: true}).any?
+      end
+    end
+
     def normalize_blank_values
       [:code, :path].each do |column|
         self[column] = nil if self[column].blank?

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -938,7 +938,7 @@ en:
         manual: Manually choose
     products: Products
     promotion: Promotion
-    promotionable: Promotionable
+    promotionable: Promotable
     promotion_action: Promotion Action
     promotion_action_types:
       create_adjustment:

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -938,6 +938,7 @@ en:
         manual: Manually choose
     products: Products
     promotion: Promotion
+    promotionable: Promotionable
     promotion_action: Promotion Action
     promotion_action_types:
       create_adjustment:

--- a/core/db/migrate/20140728225422_add_promotionable_to_spree_products.rb
+++ b/core/db/migrate/20140728225422_add_promotionable_to_spree_products.rb
@@ -1,0 +1,5 @@
+class AddPromotionableToSpreeProducts < ActiveRecord::Migration
+  def change
+    add_column :spree_products, :promotionable, :boolean, default: true
+  end
+end

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -162,43 +162,6 @@ describe Spree::Promotion do
     end
   end
 
-  context "#blacklisted?" do
-    subject { promotion.blacklisted?(promotable) }
-    context "when promotable is a Spree::LineItem" do
-      let(:promotable) { create :line_item }
-      let(:product) { promotable.product }
-      before do
-        product.promotionable = promotionable
-      end
-      context "and product is promotionable" do
-        let(:promotionable) { true }
-        it { should be false }
-      end
-      context "and product is not promotionable" do
-        let(:promotionable) { false }
-        it { should be true }
-      end
-    end
-    context "when promotable is a Spree::Order" do
-      let(:promotable) { create :order }
-      context "and it is empty" do
-        it { should be false }
-      end
-      context "and it contains items" do
-        let!(:line_item) { create(:line_item, order: promotable) }
-        context "and the items are all non-promotionable" do
-          before do
-            line_item.product.update_column(:promotionable, false)
-          end
-          it { should be true }
-        end
-        context "and at least one item is promotionable" do
-          it { should be false }
-        end
-      end
-    end
-  end
-
   context "#expired" do
     it "should not be exipired" do
       promotion.should_not be_expired
@@ -275,22 +238,44 @@ describe Spree::Promotion do
   end
 
   context "#eligible?" do
-    before do
-      @order = create(:order)
-      promotion.name = "Foo"
-      calculator = Spree::Calculator::FlatRate.new
-      action_params = { :promotion => promotion, :calculator => calculator }
-      @action = Spree::Promotion::Actions::CreateAdjustment.create(action_params)
+    let(:promotable) { create :order }
+    subject { promotion.eligible?(promotable) }
+    context "when promotion is expired" do
+      before { promotion.expires_at = Time.now - 10.days }
+      it { should be false }
     end
-
-    context "when it is expired" do
-      before { promotion.stub(:expired? => true) }
-      specify { promotion.should_not be_eligible(@order) }
+    context "when promotable is a Spree::LineItem" do
+      let(:promotable) { create :line_item }
+      let(:product) { promotable.product }
+      before do
+        product.promotionable = promotionable
+      end
+      context "and product is promotionable" do
+        let(:promotionable) { true }
+        it { should be true }
+      end
+      context "and product is not promotionable" do
+        let(:promotionable) { false }
+        it { should be false }
+      end
     end
-
-    context "when it is not expired" do
-      before { promotion.expires_at = Time.now + 1.day }
-      specify { promotion.should be_eligible(@order) }
+    context "when promotable is a Spree::Order" do
+      let(:promotable) { create :order }
+      context "and it is empty" do
+        it { should be true }
+      end
+      context "and it contains items" do
+        let!(:line_item) { create(:line_item, order: promotable) }
+        context "and the items are all non-promotionable" do
+          before do
+            line_item.product.update_column(:promotionable, false)
+          end
+          it { should be false }
+        end
+        context "and at least one item is promotionable" do
+          it { should be true }
+        end
+      end
     end
   end
 

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -162,6 +162,43 @@ describe Spree::Promotion do
     end
   end
 
+  context "#blacklisted?" do
+    subject { promotion.blacklisted?(promotable) }
+    context "when promotable is a Spree::LineItem" do
+      let(:promotable) { create :line_item }
+      let(:product) { promotable.product }
+      before do
+        product.promotionable = promotionable
+      end
+      context "and product is promotionable" do
+        let(:promotionable) { true }
+        it { should be false }
+      end
+      context "and product is not promotionable" do
+        let(:promotionable) { false }
+        it { should be true }
+      end
+    end
+    context "when promotable is a Spree::Order" do
+      let(:promotable) { create :order }
+      context "and it is empty" do
+        it { should be false }
+      end
+      context "and it contains items" do
+        let!(:line_item) { create(:line_item, order: promotable) }
+        context "and the items are all non-promotionable" do
+          before do
+            line_item.product.update_column(:promotionable, false)
+          end
+          it { should be true }
+        end
+        context "and at least one item is promotionable" do
+          it { should be false }
+        end
+      end
+    end
+  end
+
   context "#expired" do
     it "should not be exipired" do
       promotion.should_not be_expired


### PR DESCRIPTION
Any products not marked as `promotionable` will not have promotions applied to them. Also, orders containing only non-promotionable items won't have order-level promotions applied.

Not sure if there's a desire for such functionality in core, but figured I'd push up a pull-request and find out.
