### PR TITLE
add debugger gems to sandbox

### DIFF
--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -12,6 +12,17 @@ cd ./sandbox
 echo "gem 'spree', :path => '..'" >> Gemfile
 echo "gem 'spree_auth_devise', :github => 'spree/spree_auth_devise', :branch => 'master'" >> Gemfile
 
+cat <<RUBY >> Gemfile
+group :test, :development do
+  platforms :ruby_19 do
+    gem 'pry-debugger'
+  end
+  platforms :ruby_20, :ruby_21 do
+    gem 'pry-byebug'
+  end
+end
+RUBY
+
 bundle install --gemfile Gemfile
 bundle exec rails g spree:install --auto-accept --user_class=Spree::User --enforce_available_locales=true
 bundle exec rails g spree:auth:install


### PR DESCRIPTION
in the same way as in [common_spree_dependencies](https://github.com/spree/spree/blob/adca6cf/common_spree_dependencies.rb#L34-L41)
