### PR TITLE
Add postal code validation using the Twitter Cldr gem

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -1,5 +1,7 @@
 module Spree
   class Address < Spree::Base
+    require 'twitter_cldr'
+
     belongs_to :country, class_name: "Spree::Country"
     belongs_to :state, class_name: "Spree::State"
 
@@ -9,7 +11,7 @@ module Spree
     validates :zipcode, presence: true, if: :require_zipcode?
     validates :phone, presence: true, if: :require_phone?
 
-    validate :state_validate
+    validate :state_validate, :postal_code_validate
 
     alias_attribute :first_name, :firstname
     alias_attribute :last_name, :lastname
@@ -126,6 +128,14 @@ module Spree
 
         # ensure at least one state field is populated
         errors.add :state, :blank if state.blank? && state_name.blank?
+      end
+
+      def postal_code_validate
+        return if country.blank? || country.iso.blank? || !require_zipcode?
+        return if !TwitterCldr::Shared::PostalCodes.territories.include?(country.iso.downcase.to_sym)
+
+        postal_code = TwitterCldr::Shared::PostalCodes.for_territory(country.iso)
+        errors.add(:zipcode, :invalid) if !postal_code.valid?(zipcode.to_s)
       end
   end
 end

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -34,7 +34,7 @@ module Spree
          :city => 'Washington',
          :country_id => country.id,
          :state_id => state.id,
-         :zipcode => '666',
+         :zipcode => '66666',
          :phone => '666-666-6666'
       }}
 
@@ -281,7 +281,7 @@ module Spree
 
         order = Importer::Order.import(user,params)
         expect(order.item_total).to eq(166.1)
-        expect(order.total).to eq(163.1) # = item_total (166.1) - adjustment_total (3.00) 
+        expect(order.total).to eq(163.1) # = item_total (166.1) - adjustment_total (3.00)
 
       end
 

--- a/core/spec/models/spree/address_spec.rb
+++ b/core/spec/models/spree/address_spec.rb
@@ -19,7 +19,7 @@ describe Spree::Address do
                          :phone => 'phone',
                          :state_id => state.id,
                          :state_name => state.name,
-                         :zipcode => 'zip_code')
+                         :zipcode => '10001')
 
       cloned = original.clone
 
@@ -137,7 +137,42 @@ describe Spree::Address do
     it "requires zipcode" do
       address.zipcode = ""
       address.valid?
-      address.should have(1).error_on(:zipcode)
+      address.errors['zipcode'].should include("can't be blank")
+    end
+
+    context "zipcode validation" do
+      it "validates the zipcode" do
+        address.country.stub(:iso).and_return('US')
+        address.zipcode = 'abc'
+        address.valid?
+        address.errors['zipcode'].should include('is invalid')
+      end
+
+      context 'does not validate' do
+        it 'does not have a country' do
+          address.country = nil
+          address.valid?
+          address.errors['zipcode'].should_not include('is invalid')
+        end
+
+        it 'does not have an iso' do
+          address.country.stub(:iso).and_return(nil)
+          address.valid?
+          address.errors['zipcode'].should_not include('is invalid')
+        end
+
+        it 'does not have a zipcode' do
+          address.zipcode = ""
+          address.valid?
+          address.errors['zipcode'].should_not include('is invalid')
+        end
+
+        it 'does not have a supported country iso' do
+          address.country.stub(:iso).and_return('BO')
+          address.valid?
+          address.errors['zipcode'].should_not include('is invalid')
+        end
+      end
     end
 
     context "phone not required" do

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -38,5 +38,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'state_machine', '1.2.0'
   s.add_dependency 'stringex', '~> 1.5.1'
   s.add_dependency 'truncate_html', '0.9.2'
+  s.add_dependency 'twitter_cldr', '~> 3.0'
 
 end


### PR DESCRIPTION
We would like the ability to validate international postal code formats before accepting them. To do this, we use the twitter cldr gem. We only attempt to validate if the address has a country with an iso that is supported by TwitterCldr.
