### PR TITLE
Add index action for Images to API fixes spree/spree#5081

### DIFF
--- a/api/app/controllers/spree/api/images_controller.rb
+++ b/api/app/controllers/spree/api/images_controller.rb
@@ -2,6 +2,11 @@ module Spree
   module Api
     class ImagesController < Spree::Api::BaseController
 
+      def index
+        @images = scope.images.accessible_by(current_ability, :read)
+        respond_with(@images)
+      end
+
       def show
         @image = Image.accessible_by(current_ability, :read).find(params[:id])
         respond_with(@image)

--- a/api/app/views/spree/api/images/index.v1.rabl
+++ b/api/app/views/spree/api/images/index.v1.rabl
@@ -1,0 +1,4 @@
+object false
+child(@images => :images) do
+  extends "spree/api/images/show"
+end

--- a/api/spec/controllers/spree/api/images_controller_spec.rb
+++ b/api/spec/controllers/spree/api/images_controller_spec.rb
@@ -31,6 +31,32 @@ module Spree
       context "working with an existing image" do
         let!(:product_image) { product.master.images.create!(:attachment => image('thinking-cat.jpg')) }
 
+        it "can get a single product image" do
+          api_get :show, :id => product_image.id, :product_id => product.id
+          response.status.should == 200
+          json_response.should have_attributes(attributes)
+        end
+
+        it "can get a single variant image" do
+          api_get :show, :id => product_image.id, :variant_id => product.master.id
+          response.status.should == 200
+          json_response.should have_attributes(attributes)
+        end
+
+        it "can get a list of product images" do
+          api_get :index, :product_id => product.id
+          response.status.should == 200
+          json_response.should have_key("images")
+          json_response["images"].first.should have_attributes(attributes)
+        end
+
+        it "can get a list of variant images" do
+          api_get :index, :variant_id => product.master.id
+          response.status.should == 200
+          json_response.should have_key("images")
+          json_response["images"].first.should have_attributes(attributes)
+        end
+
         it "can update image data" do
           product_image.position.should == 1
           api_post :update, :image => { :position => 2 }, :id => product_image.id, :product_id => product.id


### PR DESCRIPTION
#5081
- Added index action to Images controller
- Added rabl view for images index 
- Tests for both products and variants

In the Index action, if the scope is nil (either `product_id` or `variant_id` is not passed as a param), the index action fails 422.  Not sure if we should raise a missing parameter error?  I couldn't find any other examples in that API that do that but let me know. Thanks! 
