### PR TITLE
introduce ability to not collapse line item in order

### DIFF
--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -123,6 +123,16 @@
         <%= f.error_message_on :tax_category %>
       <% end %>
     </div>
+
+    <div data-hook="admin_product_form_uncollapsible_line_item" class="field checkbox">
+      <%= f.field_container :uncollapsible_line_item do %>
+        <%= f.label :uncollapsible_line_item do %>
+          <%= f.check_box :uncollapsible_line_item %>
+          <%= Spree.t(:uncollapsible_line_item) %>
+        <% end %>
+        <%= f.error_message_on :uncollapsible_line_item %>
+      <% end %>
+    </div>
   </div>
 
   <div class="twelve columns alpha omega">

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -59,7 +59,7 @@ module Spree
       def add_to_line_item(variant, quantity, currency=nil, shipment=nil, options = {})
         line_item = grab_line_item_by_variant(variant, false, options)
 
-        if line_item
+        if line_item && !line_item.variant.product.uncollapsible_line_item
           line_item.target_shipment = shipment
           line_item.quantity += quantity.to_i
           line_item.currency = currency unless currency.nil?

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1190,6 +1190,7 @@ en:
     type: Type
     type_to_search: Type to search
     unable_to_connect_to_gateway: Unable to connect to gateway.
+    uncollapsible_line_item: Uncollapsible Line Item
     under_price: Under %{price}
     unlock: Unlock
     unrecognized_card_type: Unrecognized card type

--- a/core/db/migrate/20140729233341_add_uncollapsible_line_item_to_spree_product.rb
+++ b/core/db/migrate/20140729233341_add_uncollapsible_line_item_to_spree_product.rb
@@ -1,0 +1,5 @@
+class AddUncollapsibleLineItemToSpreeProduct < ActiveRecord::Migration
+  def change
+    add_column :spree_products, :uncollapsible_line_item, :boolean, default: false
+  end
+end

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -59,7 +59,7 @@ module Spree
       :meta_keywords, :price, :sku, :deleted_at, :prototype_id,
       :option_values_hash, :weight, :height, :width, :depth,
       :shipping_category_id, :tax_category_id,
-      :taxon_ids, :option_type_ids, :cost_currency, :cost_price]
+      :taxon_ids, :option_type_ids, :cost_currency, :cost_price, :uncollapsible_line_item]
 
     @@property_attributes = [:name, :presentation]
 

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -15,6 +15,19 @@ describe Spree::OrderContents do
       end
     end
 
+    context 'given an product with uncollapsible_line_item true' do
+      let(:product) { create :product, uncollapsible_line_item: true }
+      let(:variant) { product.master }
+
+      it 'should have two separate line items of quantity 1' do
+        2.times { subject.add(variant) }
+        expect(order.line_items.size).to eq 2
+        order.line_items.each do |line_item| 
+          expect(line_item.quantity).to eq 1
+        end
+      end
+    end
+
     it 'should add line item if one does not exist' do
       line_item = subject.add(variant, 1)
       line_item.quantity.should == 1


### PR DESCRIPTION
This PR represents some work to prevent line_items from being collapsed when added to an order. Usually this behavior is ok, but there are some cases where we do not want to do that. For example, given the sample Spree Store, suppose we want to sell custom Apache Baseball Jerseys where a custom last name can be stitched on the back.

I extend Spree to support a "name_on_back" field on Spree Line Item that I collect when adding to cart. I add one jersey where the name_on_back is Huoxito. I add a second jersey with name_on_back is Ortiz.

If I decide I don't want to buy Huoxito a Jersey anymore, there's no way to manage this with collapsed line items. I have to delete the entire line_item and start over.

This will keep the line items separate by setting a flag for a product in Admin for this scenario.

Screens below of changes. 

NOTE: I debated on whether to submit back in a PR or keep local but the `OrderContents#add_to_line_item` has already changed from 2.3.1 to edge making a `class_eval` monkey patch seemingly untenable for the long term. The real world example, by the way, is selling gift cards, but not via the Spree extension. We collect custom messaging, recipient, etc, and we didn't want the gift card line items to collapse.

![screen shot 2014-07-29 at 8 41 42 pm](https://cloud.githubusercontent.com/assets/134368/3743973/1622fece-1784-11e4-9a76-6194878f03e9.png)

![screen shot 2014-07-29 at 8 43 50 pm](https://cloud.githubusercontent.com/assets/134368/3743975/18fef986-1784-11e4-86b3-b3849a31c1ea.png)
