### PR TITLE
Default order_factory line_items_count to 1

### DIFF
--- a/api/spec/controllers/spree/api/line_items_controller_spec.rb
+++ b/api/spec/controllers/spree/api/line_items_controller_spec.rb
@@ -4,7 +4,7 @@ module Spree
   describe Api::LineItemsController do
     render_views
 
-    let!(:order) { create(:order_with_line_items) }
+    let!(:order) { create(:order_with_line_items, line_items_count: 1) }
 
     let(:product) { create(:product) }
     let(:attributes) { [:id, :quantity, :price, :variant, :total, :display_amount, :single_display_amount] }
@@ -60,7 +60,7 @@ module Spree
         api_post :create, :line_item => { :variant_id => product.master.to_param, :quantity => 1 }
         response.status.should == 201
         order.reload
-        order.line_items.count.should == 6 # 5 original due to factory, + 1 in this test
+        order.line_items.count.should == 2 # 1 original due to factory, + 1 in this test
         json_response.should have_attributes(attributes)
         json_response["quantity"].should == 11
       end
@@ -70,7 +70,7 @@ module Spree
         api_put :update, :id => line_item.id, :line_item => { :quantity => 101 }
         response.status.should == 200
         order.reload
-        order.total.should == 1050 # 50 original due to factory, + 1000 in this test
+        order.total.should == 1010 # 10 original due to factory, + 1000 in this test
         json_response.should have_attributes(attributes)
         json_response["quantity"].should == 101
       end
@@ -80,7 +80,7 @@ module Spree
         api_delete :destroy, :id => line_item.id
         response.status.should == 204
         order.reload
-        order.line_items.count.should == 4 # 5 original due to factory, - 1 in this test
+        order.line_items.count.should == 0 # 1 original due to factory, - 1 in this test
         lambda { line_item.reload }.should raise_error(ActiveRecord::RecordNotFound)
       end
 

--- a/backend/spec/features/admin/orders/adjustments_spec.rb
+++ b/backend/spec/features/admin/orders/adjustments_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe "Adjustments" do
   stub_authorization!
 
-  let!(:order) { create(:completed_order_with_totals) }
+  let!(:order) { create(:completed_order_with_totals, line_items_count: 5) }
   let!(:line_item) do
     line_item = order.line_items.first
     # so we can be sure of a determinate price in our assertions

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -14,7 +14,7 @@ describe 'Payments' do
       )
     end
 
-    let(:order) { create(:completed_order_with_totals, number: 'R100') }
+    let(:order) { create(:completed_order_with_totals, number: 'R100', line_items_count: 5) }
     let(:state) { 'checkout' }
 
     before do

--- a/backend/spec/features/admin/orders/shipments_spec.rb
+++ b/backend/spec/features/admin/orders/shipments_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe "Shipments" do
   stub_authorization!
 
-  let!(:order) { create(:order_ready_to_ship, :number => "R100", :state => "complete") }
+  let!(:order) { create(:order_ready_to_ship, :number => "R100", :state => "complete", :line_items_count => 5) }
 
   # Regression test for #4025
   context "a shipment without a shipping method" do

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -21,7 +21,7 @@ FactoryGirl.define do
       ship_address
 
       ignore do
-        line_items_count 5
+        line_items_count 1
         shipment_cost 100
       end
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -651,10 +651,10 @@ describe Spree::Order do
 
   describe '#quantity' do
     # Uses a persisted record, as the quantity is retrieved via a DB count
-    let(:order) { create :order_with_line_items }
+    let(:order) { create :order_with_line_items, line_items_count: 3 }
 
     it 'sums the quantity of all line items' do
-      expect(order.quantity).to eq 5
+      expect(order.quantity).to eq 3
     end
   end
 


### PR DESCRIPTION
This took 40 seconds off of the "core" specs on my computer (3min30s -> 2min50s).  I didn't measure the other suites.
Given the speedup it seems like a reasonable thing to do for the cases where you only really need a single item.
