### PR TITLE
Add return item eligibility validator and associated state machine updat...

### DIFF
--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -59,6 +59,7 @@ module Spree
     preference :customer_returns_per_page, :integer, default: 15
     preference :redirect_https_to_http, :boolean, :default => false
     preference :require_master_price, :boolean, default: true
+    preference :return_eligibility_number_of_days, :integer, default: 365
     preference :shipment_inc_vat, :boolean, default: false
     preference :shipping_instructions, :boolean, default: false # Request instructions/info for shipping
     preference :show_only_complete_orders_by_default, :boolean, default: true

--- a/core/app/models/spree/return_item/return_eligibility_validator.rb
+++ b/core/app/models/spree/return_item/return_eligibility_validator.rb
@@ -1,0 +1,24 @@
+module Spree
+  class ReturnItem::ReturnEligibilityValidator
+    attr_reader :errors
+
+    def initialize(return_item)
+      @return_item = return_item
+      @errors = {}
+    end
+
+    def eligible_for_return?
+      if (@return_item.inventory_unit.created_at + Spree::Config[:return_eligibility_number_of_days].days) > Time.now
+        return true
+      else
+        @errors[:number_of_days] = Spree.t('return_item_time_period_ineligible')
+        return false
+      end
+    end
+
+    # Overwrite this if there are conditions in which you'd like to manually intervene
+    def requires_manual_intervention?
+      false
+    end
+  end
+end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1009,6 +1009,7 @@ en:
     refund_reasons: Refund Reasons
     refunded_amount: Refunded Amount
     refunds: Refunds
+    refund_amount_must_be_greater_than_zero: Refund amount must be greater than zero
     register: Register
     registration: Registration
     remember_me: Remember me
@@ -1025,6 +1026,7 @@ en:
     return_authorization_reasons: Return Authorization Reasons
     return_authorization_updated: Return authorization updated
     return_authorizations: Return Authorizations
+    return_item_time_period_ineligible: Return item is outside the eligible time period
     return_items_cannot_be_associated_with_multiple_orders: Return items cannot be associated with multiple orders.
     return_number: Return Number
     return_quantity: Return Quantity

--- a/core/db/migrate/20140730155938_add_acceptance_status_errors_to_return_item.rb
+++ b/core/db/migrate/20140730155938_add_acceptance_status_errors_to_return_item.rb
@@ -1,0 +1,5 @@
+class AddAcceptanceStatusErrorsToReturnItem < ActiveRecord::Migration
+  def change
+    add_column :spree_return_items, :acceptance_status_errors, :text
+  end
+end

--- a/core/spec/models/spree/return_item/return_eligibility_validator_spec.rb
+++ b/core/spec/models/spree/return_item/return_eligibility_validator_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe Spree::ReturnItem::ReturnEligibilityValidator do
+  let(:return_item) { create(:return_item) }
+  let(:validator) { Spree::ReturnItem::ReturnEligibilityValidator.new(return_item) }
+
+  describe "#eligible_for_return?" do
+    subject { validator.eligible_for_return? }
+
+    context "it is within the return timeframe" do
+      it "returns true" do
+        created_at = return_item.inventory_unit.created_at - (Spree::Config[:return_eligibility_number_of_days].days / 2)
+        return_item.inventory_unit.stub(:created_at).and_return(created_at)
+        expect(subject).to be true
+      end
+    end
+
+    context "it is past the return timeframe" do
+      before do
+        created_at = return_item.inventory_unit.created_at - Spree::Config[:return_eligibility_number_of_days].days - 1.day
+        return_item.inventory_unit.stub(:created_at).and_return(created_at)
+      end
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+
+      it "sets an error" do
+        subject
+        expect(validator.errors[:number_of_days]).to eq Spree.t('return_item_time_period_ineligible')
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Add a PORO to determine if an item should be returned, manually intervened, or rejected
- Add state changes to Return Item state machine that use this eligibility validator
- Add a column on return item to store any reason that the validator might return about its rejection/manual intervention status. This is going to be used in an admin panel currently being worked on by @richardnuno and @jordan-brough 
- Default rule: If it has been less than 365 days since the item has been purchased, it can be returned, otherwise reject. Allows for people to write their own customized rules pretty easily.
