### PR TITLE
Remove extra " in banner comment

### DIFF
--- a/cmd/lib/spree_cmd/extension.rb
+++ b/cmd/lib/spree_cmd/extension.rb
@@ -38,7 +38,7 @@ module SpreeCmd
         Please update the Versionfile to designate compatibility with different versions of Spree.
         See http://spreecommerce.com/documentation/extensions.html#versionfile
 
-        Consider listing your extension in the official extension registry http://spreecommerce.com/extensions"
+        Consider listing your extension in the official extension registry http://spreecommerce.com/extensions
 
         #{'*' * 80}
       }


### PR DESCRIPTION
Might have been leftover from when the banner was a simple double-quoted string.
