### PR TITLE
Reimbursements model & Manual intervention resolution for Returns

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/admin.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/admin.js.erb
@@ -47,7 +47,7 @@ jQuery(function($) {
   setTimeout('$(".flash").fadeOut()', 5000);
 
   // Highlight hovered table column
-  $('table tbody tr td.actions a').hover(function(){
+  $('table tbody tr td.actions').find('a, button').hover(function(){
     var tr = $(this).closest('tr');
     var klass = 'highlight action-' + $(this).data('action')
     tr.addClass(klass)

--- a/backend/app/assets/javascripts/spree/backend/returns/return_item_selection.js
+++ b/backend/app/assets/javascripts/spree/backend/returns/return_item_selection.js
@@ -7,7 +7,7 @@ $(document).ready(function() {
       var totalPretaxRefund = 0;
       var checkedItems = formFields.find('input.add-item:checked');
       $.each(checkedItems, function(i, checkbox) {
-        totalPretaxRefund += $(checkbox).data('price');
+        totalPretaxRefund += parseFloat($(checkbox).parents('tr').find('.refund-amount-input').val());
       });
 
       var displayTotal = isNaN(totalPretaxRefund) ? '' : totalPretaxRefund.toFixed(2);
@@ -23,5 +23,6 @@ $(document).ready(function() {
     });
 
     formFields.find('input.add-item').on('change', updateSuggestedAmount);
+    formFields.find('.refund-amount-input').on('keyup', updateSuggestedAmount);
   }
 });

--- a/backend/app/assets/stylesheets/spree/backend/globals/_variables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/globals/_variables.scss
@@ -122,20 +122,28 @@ $color-ste-inactive-bg:          $color-notice !default;
 $color-ste-inactive-text:        $color-1 !default;
 $color-ste-considered_risky-bg:  $color-error !default;
 $color-ste-considered_risky-text:$color-1 !default;
+$color-ste-success-bg:           $color-success !default;
+$color-ste-success-text:         $color-1 !default;
+$color-ste-notice-bg:            $color-notice !default;
+$color-ste-notice-text:          $color-1 !default;
+$color-ste-error-bg:             $color-error !default;
+$color-ste-error-text:           $color-1 !default;
 
 // Available states
 $states: completed, complete, sold, pending, awaiting_return, returned, credit_owed, paid, shipped, balance_due, backorder, checkout, cart, address,
-delivery, payment, confirm, canceled, ready, void, active, inactive, considered_risky !default;
+delivery, payment, confirm, canceled, ready, void, active, inactive, considered_risky, success, notice, error !default;
 
 $states-bg-colors: $color-ste-completed-bg, $color-ste-complete-bg, $color-ste-sold-bg, $color-ste-pending-bg, $color-ste-awaiting_return-bg,
 $color-ste-returned-bg, $color-ste-credit_owed-bg, $color-ste-paid-bg, $color-ste-shipped-bg, $color-ste-balance_due-bg, $color-ste-backorder-bg, 
 $color-ste-checkout-bg, $color-ste-cart-bg, $color-ste-address-bg, $color-ste-delivery-bg, $color-ste-payment-bg, $color-ste-confirm-bg, 
-$color-ste-canceled-bg, $color-ste-ready-bg, $color-ste-void-bg, $color-ste-active-bg, $color-ste-inactive-bg, $color-ste-considered_risky-bg !default;
+$color-ste-canceled-bg, $color-ste-ready-bg, $color-ste-void-bg, $color-ste-active-bg, $color-ste-inactive-bg, $color-ste-considered_risky-bg,
+$color-ste-success-bg, $color-ste-notice-bg, $color-ste-error-bg !default;
 
 $states-text-colors: $color-ste-completed-text, $color-ste-complete-text, $color-ste-sold-text, $color-ste-pending-text, $color-ste-awaiting_return-text, 
 $color-ste-returned-text, $color-ste-credit_owed-text, $color-ste-paid-text, $color-ste-shipped-text, $color-ste-balance_due-text, $color-ste-backorder-text, 
 $color-ste-checkout-text, $color-ste-cart-text, $color-ste-address-text, $color-ste-delivery-text, $color-ste-payment-text, $color-ste-confirm-text, 
-$color-ste-canceled-text, $color-ste-ready-text, $color-ste-void-text, $color-ste-active-text, $color-ste-inactive-text, $color-ste-considered_risky-text !default;
+$color-ste-canceled-text, $color-ste-ready-text, $color-ste-void-text, $color-ste-active-text, $color-ste-inactive-text, $color-ste-considered_risky-text,
+$color-ste-success-text, $color-ste-notice-text, $color-ste-error-text !default;
 
 // Available actions
 $actions: edit, clone, remove, void, capture, save, cancel, mail !default;

--- a/backend/app/assets/stylesheets/spree/backend/sections/_return_authorizations.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_return_authorizations.scss
@@ -2,4 +2,7 @@
   .refund-amount-input {
     width: 80px;
   }
+  .fa-thumbs-up {
+    margin-bottom: 10px;
+  }
 }

--- a/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
@@ -92,6 +92,14 @@ table {
         background-color: $color-notice;
         color: $color-1;
       }
+      .fa-thumbs-up:hover {
+        background-color: $color-success;
+        color: $color-1;
+      }
+      .fa-thumbs-down:hover {
+        background-color: $color-error;
+        color: $color-1;
+      }
     }
 
     input[type="number"],

--- a/backend/app/controllers/spree/admin/reimbursements_controller.rb
+++ b/backend/app/controllers/spree/admin/reimbursements_controller.rb
@@ -1,0 +1,33 @@
+module Spree
+  module Admin
+    class ReimbursementsController < ResourceController
+      belongs_to 'spree/order', find_by: :number
+
+      before_filter :load_return_item_ids, only: :create
+      before_filter :load_simulated_refunds, only: :edit
+
+      def perform
+        @reimbursement.perform!
+        redirect_to url_for([:admin, @order, @reimbursement.customer_return])
+      end
+
+      private
+
+      def load_return_item_ids
+        if params[:return_item_ids].present?
+          params[:reimbursement] ||= ActiveSupport::HashWithIndifferentAccess.new
+          params[:reimbursement][:return_item_ids] = params[:return_item_ids].split(',')
+        end
+      end
+
+      def location_after_save
+        edit_admin_order_reimbursement_path(@order, @reimbursement)
+      end
+
+      def load_simulated_refunds
+        @reimbursement_items = @reimbursement.simulate
+      end
+
+    end
+  end
+end

--- a/backend/app/controllers/spree/admin/return_authorizations_controller.rb
+++ b/backend/app/controllers/spree/admin/return_authorizations_controller.rb
@@ -19,7 +19,7 @@ module Spree
         load_return_items
         load_return_authorization_reasons
 
-        @allow_amount_edit = Spree::Config[:allow_return_item_amount_editing]
+        @allow_amount_edit = can?(:manage, Spree::CustomerReturn)
       end
 
       # To satisfy how nested attributes works we want to create placeholder ReturnItems for

--- a/backend/app/controllers/spree/admin/return_items_controller.rb
+++ b/backend/app/controllers/spree/admin/return_items_controller.rb
@@ -1,0 +1,9 @@
+module Spree
+  module Admin
+    class ReturnItemsController < ResourceController
+      def location_after_save
+        admin_order_customer_return_path(@return_item.customer_return.order, @return_item.customer_return)
+      end
+    end
+  end
+end

--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -145,7 +145,7 @@ module Spree
       end
 
       def configurations_sidebar_menu_item(link_text, url, options = {})
-        is_active = url.ends_with?(controller.controller_name) || 
+        is_active = url.ends_with?(controller.controller_name) ||
                     url.ends_with?("#{controller.controller_name}/edit") ||
                     url.ends_with?("#{controller.controller_name.singularize}/edit")
         options.merge!(:class => is_active ? 'active' : nil)

--- a/backend/app/helpers/spree/admin/reimbursements_helper.rb
+++ b/backend/app/helpers/spree/admin/reimbursements_helper.rb
@@ -1,0 +1,14 @@
+module Spree
+  module Admin
+    module ReimbursementsHelper
+      def reimbursement_status_color(reimbursement)
+        case reimbursement.reimbursement_status
+        when 'reimbursed' then 'success'
+        when 'pending' then 'notice'
+        when 'errored' then 'error'
+        else raise "unknown reimbursement status: #{reimbursement.reimbursement_status}"
+        end
+      end
+    end
+  end
+end

--- a/backend/app/views/spree/admin/customer_returns/_reimbursements_table.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_reimbursements_table.html.erb
@@ -1,0 +1,28 @@
+<table class="index">
+  <thead data-hook="customer_return_header">
+    <tr>
+      <th><%= Spree.t(:number) %></th>
+      <th><%= Spree.t(:total) %></th>
+      <th><%= Spree.t(:status) %></th>
+      <th><%= "#{Spree.t('date')}/#{Spree.t('time')}" %></th>
+      <th class="actions"></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% reimbursements.each do |reimbursement| %>
+      <tr id="<%= spree_dom_id(reimbursement) %>" data-hook="reimbursement_row" class="<%= cycle('odd', 'even')%>">
+        <td><%= link_to reimbursement.number, url_for([:edit, :admin, @order, reimbursement]) %></td>
+        <td><%= reimbursement.display_total %></td>
+        <td>
+          <span class="state <%= reimbursement_status_color(reimbursement) %>">
+            <%= reimbursement.reimbursement_status %>
+          </span>
+        </td>
+        <td><%= pretty_time(reimbursement.created_at) %></td>
+        <td class="actions">
+          <%= link_to_edit_url url_for([:edit, :admin, @order, reimbursement]), title: "admin_edit_#{dom_id(reimbursement)}", no_text: true %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/backend/app/views/spree/admin/customer_returns/_return_item_decision.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_return_item_decision.html.erb
@@ -1,0 +1,30 @@
+<table class="show return-items-table">
+  <thead>
+    <tr>
+      <th><%= Spree.t(:product) %></th>
+      <th><%= Spree.t(:reception_status) %></th>
+      <th><%= Spree.t(:pre_tax_refund_amount) %></th>
+      <th class="actions"></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% return_items.each do |return_item| %>
+      <tr>
+        <td>
+          <div class="variant-name"><%= return_item.inventory_unit.variant.name %></div>
+          <div class="variant-options"><%= return_item.inventory_unit.variant.options_text %></div>
+        </td>
+        <td class="align-center"><%= return_item.reception_status.humanize %></td>
+        <td class="align-center"><%= return_item.display_pre_tax_amount %></td>
+        <td class='actions'>
+          <%= button_to [:admin, return_item], { class: 'fa fa-thumbs-up icon_link no-text with-tip', params: { "return_item[acceptance_status]" => 'accepted' }, "data-action" => 'save', title: Spree.t(:accept), method: 'put' } do %>
+            Spree.t(:accept)
+          <% end %>
+          <%= button_to [:admin, return_item], { class: 'fa fa-thumbs-down icon_link no-text with-tip', params: { "return_item[acceptance_status]" => 'rejected' }, "data-action" => 'remove', title: Spree.t(:reject), method: 'put' } do %>
+            Spree.t(:reject)
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/backend/app/views/spree/admin/customer_returns/_return_item_detail.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_return_item_detail.html.erb
@@ -1,0 +1,23 @@
+<table class="show return-items-table">
+  <thead>
+    <tr>
+      <th><%= Spree.t(:product) %></th>
+      <th><%= Spree.t(:reception_status) %></th>
+      <th><%= Spree.t(:pre_tax_refund_amount) %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% return_items.each do |return_item| %>
+      <tr>
+        <td>
+          <div class="variant-name"><%= return_item.inventory_unit.variant.name %></div>
+          <div class="variant-options"><%= return_item.inventory_unit.variant.options_text %></div>
+        </td>
+        <td class="align-center"><%= return_item.reception_status.humanize %></td>
+        <td class="align-center">
+          <%= return_item.display_pre_tax_amount %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/backend/app/views/spree/admin/customer_returns/_return_item_table.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_return_item_table.html.erb
@@ -16,6 +16,7 @@
     </thead>
     <tbody>
       <%= f.fields_for :return_items, return_items do |item_fields| %>
+        <%= item_fields.hidden_field :acceptance_status, value: 'accepted' %>
         <% return_item = item_fields.object %>
         <% inventory_unit = return_item.inventory_unit %>
         <tr>
@@ -41,7 +42,7 @@
               <% if allow_amount_edit %>
                 <%= item_fields.text_field :pre_tax_amount, { class: 'refund-amount-input' } %>
               <% else %>
-                <%= item_fields.hidden_field :pre_tax_amount %>
+                <%= item_fields.hidden_field :pre_tax_amount, { class: 'refund-amount-input' } %>
                 <%= return_item.display_pre_tax_amount %>
               <% end %>
             <% else %>

--- a/backend/app/views/spree/admin/customer_returns/index.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/index.html.erb
@@ -23,23 +23,26 @@
         <tr>
           <th><%= Spree.t(:return_number) %></th>
           <th><%= Spree.t(:pre_tax_total) %></th>
-          <th><%= Spree.t(:refunded_amount) %></th>
           <th><%= "#{Spree.t('date')}/#{Spree.t('time')}" %></th>
+          <th><%= Spree.t(:reimbursement_status) %></th>
           <th class="actions"></th>
         </tr>
       </thead>
       <tbody>
         <% @customer_returns.each do |customer_return| %>
           <tr id="<%= spree_dom_id(customer_return) %>" data-hook="customer_return_row" class="<%= cycle('odd', 'even')%>">
-            <td><%= customer_return.number %></td>
+            <td><%= link_to customer_return.number, spree.admin_order_customer_return_path(@order, customer_return) %></td>
             <td><%= customer_return.display_pre_tax_total.to_html %></td>
-            <td><%= customer_return.display_refund_total.to_html %></td>
             <td><%= pretty_time(customer_return.created_at) %></td>
-            <td class="actions">
-              <% unless customer_return.refunded? %>
-                <%= link_to_with_icon :reply, Spree.t('actions.refund'), refund_admin_order_customer_return_path(@order, customer_return),
-                  method: :put, no_text: true, data: { action: :green, confirm: Spree.t(:are_you_sure) } %>
+            <td>
+              <% if customer_return.fully_reimbursed? %>
+                <span class="state success"><%= Spree.t(:reimbursed) %></span>
+              <% else %>
+                <span class="state notice"><%= Spree.t(:incomplete) %></span>
               <% end %>
+            </td>
+            <td class='actions align-center' data-hook="admin_orders_customer_returns_index_row_actions">
+              <%= link_to_edit_url admin_order_customer_return_path(@order, customer_return), title: "admin_edit_#{dom_id(customer_return)}", no_text: true %>
             </td>
           </tr>
         <% end %>
@@ -55,7 +58,7 @@
   <%= paginate @customer_returns %>
 
 <% else %>
-  <div data-hook="customer_return_cannont_create" class="no-objects-found">
+  <div data-hook="customer_return_cannot_create" class="no-objects-found">
     <%= Spree.t(:cannot_create_customer_returns) %>
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/customer_returns/show.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/show.html.erb
@@ -1,0 +1,66 @@
+<%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Customer Returns' } %>
+
+<% content_for :page_title do %>
+  <i class="fa fa-arrow-right"></i> <%= Spree.t(:customer_return) %> #<%= @customer_return.number %>
+<% end %>
+
+<% content_for :page_actions do %>
+  <li><%= button_link_to Spree.t(:back_to_customer_return_list), spree.admin_order_customer_returns_url(@order), :icon => 'arrow-left' %></li>
+<% end %>
+
+<% if @manual_intervention_return_items.any? %>
+  <fieldset data-hook="manual_intervention_return_items" class="no-border-bottom">
+    <legend align="center"><%= Spree.t(:manual_intervention_required) %></legend>
+    <%= render partial: 'return_item_decision', locals: { return_items: @manual_intervention_return_items } %>
+  </fieldset>
+<% end %>
+
+<% if @pending_return_items.any? %>
+  <fieldset data-hook="accepted_return_items" class="no-border-bottom">
+    <legend align="center"><%= Spree.t(:pending) %></legend>
+    <%= render partial: 'return_item_decision', locals: { return_items: @pending_return_items } %>
+  </fieldset>
+<% end %>
+
+<% if @accepted_return_items.any? %>
+  <fieldset data-hook="accepted_return_items" class="no-border-bottom">
+    <legend align="center"><%= Spree.t(:accepted) %></legend>
+    <%= render partial: 'return_item_detail', locals: { return_items: @accepted_return_items } %>
+  </fieldset>
+<% end %>
+
+<% if @rejected_return_items.any? %>
+  <fieldset data-hook="rejected_return_items" class="no-border-bottom">
+    <legend align="center"><%= Spree.t(:rejected) %></legend>
+    <%= render partial: 'return_item_detail', locals: { return_items: @rejected_return_items } %>
+  </fieldset>
+<% end %>
+
+<fieldset data-hook="reimbursements" class="no-border-bottom">
+  <legend align="center"><%= Spree.t(:reimbursements) %></legend>
+  <% if @customer_return.completely_decided? %>
+    <% if @customer_return.reimbursements.any? %>
+      <%= render partial: 'reimbursements_table', locals: {reimbursements: @customer_return.reimbursements} %>
+    <% else %>
+      <div class='align-center'>
+        <%= button_to(
+          [:admin, @order, Spree::Reimbursement.new],
+          {
+            class: 'button fa fa-reply',
+            params: {
+              "return_item_ids" => @customer_return.return_items.map(&:id).join(','),
+              "reimbursement[customer_return_id]" => @customer_return.id,
+            },
+            method: 'post',
+          }
+        ) do %>
+          <%= Spree.t(:create_reimbursement) %>
+        <% end %>
+      </div>
+    <% end %>
+  <% else %>
+    <div class="no-objects-found">
+      <%= Spree.t(:unable_to_create_reimbursements) %>
+    </div>
+  <% end %>
+</fieldset>

--- a/backend/app/views/spree/admin/reimbursements/edit.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/edit.html.erb
@@ -1,0 +1,67 @@
+<%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Customer Returns' } %>
+
+<% content_for :page_title do %>
+  <i class="fa fa-arrow-right"></i> <%= Spree.t(:editing_reimbursement) %> #<%= @reimbursement.number %>
+<% end %>
+
+<% content_for :page_actions do %>
+  <li><%= button_link_to Spree.t(:back_to_customer_return), url_for([:admin, @order, @reimbursement.customer_return]), :icon => 'arrow-left' %></li>
+<% end %>
+
+<%= render :partial => 'spree/shared/error_messages', :locals => { :target => @reimbursement } %>
+
+<fieldset class='no-border-bottom'>
+  <legend align='center'><%= Spree.t(:items_to_be_reimbursed) %></legend>
+  <table class="index reimbursement-return-items-table">
+    <thead>
+      <tr>
+        <th><%= Spree.t(:product) %></th>
+        <th><%= Spree.t(:inventory_state) %></th>
+        <th><%= Spree.t(:total) %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @reimbursement.return_items.each do |return_item| %>
+        <tr>
+          <td>
+            <div class="variant-name"><%= return_item.inventory_unit.variant.name %></div>
+            <div class="variant-options"><%= return_item.inventory_unit.variant.options_text %></div>
+          </td>
+          <td class="align-center"><%= return_item.inventory_unit.state.humanize %></td>
+          <td class="align-center">
+            <%= return_item.display_total %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</fieldset>
+
+<fieldset>
+  <legend align='center'><%= Spree.t(:calculated_reimbursements) %></legend>
+  <table class="index">
+    <thead data-hook="customer_return_header">
+      <tr>
+        <th><%= Spree.t(:reimbursement_type) %></th>
+        <th><%= Spree.t(:description) %></th>
+        <th><%= Spree.t(:amount) %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @reimbursement_items.each do |reimbursement_item| %>
+        <tr id="<%= spree_dom_id(reimbursement_item) %>" data-hook="reimbursement_reimbursement_item_row" class="<%= cycle('odd', 'even')%>">
+          <td><%= reimbursement_item.class.name.demodulize %></td>
+          <td><%= reimbursement_item.description %></td>
+          <td><%= reimbursement_item.display_amount %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+  <div class="form-buttons filter-actions actions" data-hook="buttons">
+    <%= button_to [:perform, :admin, @order, @reimbursement], {class: 'button fa fa-reply', method: 'post'} do %>
+      <%= Spree.t(:reimburse) %>
+    <% end %>
+    <span class="or"><%= Spree.t(:or) %></span>
+    <%= button_link_to Spree.t('actions.cancel'), url_for([:admin, @order, @reimbursement.customer_return]), :icon => 'remove' %>
+  </div>
+</fieldset>

--- a/backend/app/views/spree/admin/reimbursements/index.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/index.html.erb
@@ -1,0 +1,34 @@
+<%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Reimbursements' } %>
+
+<% content_for :page_title do %>
+  <i class="fa fa-arrow-right"></i> <%= Spree.t(:edit_reimbursement) %>
+<% end %>
+
+<% content_for :page_actions do %>
+  <li><%= button_link_to Spree.t(:back_to_customer_return_list), spree.admin_order_customer_returns_url(@order), :icon => 'arrow-left' %></li>
+<% end %>
+
+<%= render :partial => 'spree/shared/error_messages', :locals => { :target => @customer_return } %>
+
+<table class="index">
+  <thead data-hook="customer_return_header">
+    <tr>
+      <th><%= Spree.t(:id) %></th>
+      <th><%= Spree.t(:total) %></th>
+      <th><%= Spree.t(:status) %></th>
+      <th><%= "#{Spree.t('date')}/#{Spree.t('time')}" %></th>
+      <th class="actions"></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @reimbursements.each do |reimbursement| %>
+      <tr id="<%= spree_dom_id(reimbursement) %>" data-hook="reimbursement_row" class="<%= cycle('odd', 'even')%>">
+        <td><%= reimbursement.id %></td>
+        <td><%= reimbursement.total %></td>
+        <td><%= reimbursement.reimbursement_status %></td>
+        <td><%= pretty_time(reimbursement.created_at) %></td>
+        <td></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/backend/app/views/spree/admin/return_authorizations/_form.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/_form.html.erb
@@ -43,7 +43,7 @@
               <% if @allow_amount_edit %>
                 <%= item_fields.text_field :pre_tax_amount, { class: 'refund-amount-input' } %>
               <% else %>
-                <%= item_fields.hidden_field :pre_tax_amount %>
+                <%= item_fields.hidden_field :pre_tax_amount, { class: 'refund-amount-input' } %>
                 <%= return_item.display_pre_tax_amount %>
               <% end %>
             <% else %>

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -82,7 +82,7 @@ Spree::Core::Engine.add_routes do
       end
 
       resource :customer, :controller => "orders/customer_details"
-      resources :customer_returns, only: [:index, :new, :create] do
+      resources :customer_returns, only: [:index, :show, :new, :create, :update] do
         member do
           put :refund
         end
@@ -103,6 +103,12 @@ Spree::Core::Engine.add_routes do
         resources :log_entries
         resources :refunds, only: [:new, :edit, :create, :update]
       end
+
+      resources :reimbursements, only: [:create, :edit] do
+        member do
+          post :perform
+        end
+      end
     end
 
     resource :general_settings do
@@ -111,9 +117,11 @@ Spree::Core::Engine.add_routes do
       end
     end
 
+    resources :return_items, only: [:update]
+
     resources :taxonomies do
       collection do
-      	post :update_positions
+        post :update_positions
       end
       member do
         get :get_children

--- a/backend/spec/controllers/spree/admin/reimbursements_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/reimbursements_controller_spec.rb
@@ -1,0 +1,90 @@
+require 'spec_helper'
+
+describe Spree::Admin::ReimbursementsController do
+  stub_authorization!
+
+  let!(:default_refund_reason) do
+    Spree::RefundReason.find_or_create_by!(name: Spree::RefundReason::RETURN_PROCESSING_REASON, mutable: false)
+  end
+
+  describe '#create' do
+    let(:customer_return)  { create(:customer_return, line_items_count: 1) }
+    let(:order) { customer_return.order }
+    let(:return_item) { customer_return.return_items.first }
+    let(:payment) { order.payments.first }
+
+    before do
+      customer_return.return_items.map(&:accept!)
+    end
+
+    context "nested attributes" do
+      let(:reimbursement_params) do
+        {
+          customer_return_id: customer_return.to_param,
+          return_item_ids: [return_item.id],
+        }
+      end
+
+      subject do
+        spree_post :create, order_id: order.to_param, reimbursement: reimbursement_params
+      end
+
+      it 'creates the reimbursement' do
+        expect { subject }.to change { order.reimbursements.count }.by(1)
+        expect(assigns(:reimbursement).return_items).to include(return_item)
+      end
+
+      it 'redirects to the edit page' do
+        subject
+        expect(response).to redirect_to(spree.edit_admin_order_reimbursement_path(order, assigns(:reimbursement)))
+      end
+    end
+
+    context "comma separated ids" do
+      let(:customer_return)    { create(:customer_return, line_items_count: 2) }
+      let(:second_return_item) { customer_return.return_items.last }
+      let(:return_item_ids)    { [return_item.id, second_return_item.id].join(',') }
+
+      let(:reimbursement_params) do
+        {
+          customer_return_id: customer_return.to_param,
+        }
+      end
+
+      subject do
+        spree_post :create, order_id: order.to_param, reimbursement: reimbursement_params, return_item_ids: return_item_ids
+      end
+
+      it 'creates the reimbursement' do
+        expect { subject }.to change { order.reimbursements.count }.by(1)
+        expect(assigns(:reimbursement).return_items).to include(return_item)
+        expect(assigns(:reimbursement).return_items).to include(second_return_item)
+      end
+    end
+  end
+
+  describe "#perform" do
+    let(:reimbursement) { create(:reimbursement) }
+    let(:customer_return) { reimbursement.customer_return }
+    let(:order) { reimbursement.order }
+    let(:return_items) { reimbursement.return_items }
+    let(:payment) { order.payments.first }
+
+    subject do
+      spree_post :perform, order_id: order.to_param, id: reimbursement.to_param
+    end
+
+    it 'redirects to customer return page' do
+      subject
+      expect(response).to redirect_to spree.admin_order_customer_return_path(order, customer_return)
+    end
+
+    it 'performs the reimbursement' do
+      expect {
+        subject
+      }.to change { payment.refunds.count }.by(1)
+      expect(payment.refunds.last.amount).to be > 0
+      expect(payment.refunds.last.amount).to eq return_items.to_a.sum(&:total)
+    end
+  end
+end

--- a/backend/spec/controllers/spree/admin/return_items_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/return_items_controller_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe Spree::Admin::ReturnItemsController do
+  stub_authorization!
+
+  describe '#update' do
+    let(:customer_return) { create(:customer_return) }
+    let(:return_item) { customer_return.return_items.first }
+    let(:old_acceptance_status) { 'pending' }
+    let(:new_acceptance_status) { 'accepted' }
+
+    subject do
+      spree_put :update, id: return_item.to_param, return_item: {acceptance_status: new_acceptance_status}
+    end
+
+    it 'updates the return item' do
+      expect {
+        subject
+      }.to change { return_item.reload.acceptance_status }.from(old_acceptance_status).to(new_acceptance_status)
+    end
+
+    it 'redirects to the custome return' do
+      subject
+      expect(response).to redirect_to spree.admin_order_customer_return_path(customer_return.order, customer_return)
+    end
+  end
+end

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -60,6 +60,7 @@ RSpec.configure do |config|
   end
 
   config.before(:each) do
+    Rails.cache.clear
     WebMock.disable!
     if example.metadata[:js]
       DatabaseCleaner.strategy = :truncation

--- a/core/app/models/spree/customer_return.rb
+++ b/core/app/models/spree/customer_return.rb
@@ -1,13 +1,10 @@
 module Spree
   class CustomerReturn < Spree::Base
-    class_attribute :return_item_tax_calculator
-    self.return_item_tax_calculator = ReturnItemTaxCalculator
-
     belongs_to :stock_location
 
-    has_many :refunds, inverse_of: :customer_return
     has_many :return_items, inverse_of: :customer_return
     has_many :return_authorizations, through: :return_items
+    has_many :reimbursements, inverse_of: :customer_return
 
     after_create :process_return!
     before_create :generate_number
@@ -36,56 +33,12 @@ module Spree
       order.try(:id)
     end
 
-    #
-    # Refunds
-    #
-
-    def refund
-      return_item_tax_calculator.call return_items.includes(inventory_unit: {line_item: :order}).to_a
-
-      # For now type and order of retrieved payments are not specified
-      order.payments.completed.each do |payment|
-        break unless amount_due > 0
-        credit_allowed = [payment.credit_allowed, amount_due].min
-        payment.refunds.create!({
-          customer_return: self,
-          amount: credit_allowed,
-          reason: Spree::RefundReason.return_processing_reason,
-        })
-      end
-
-      errors.add(:base, Spree.t("validation.amount_due_less_than_zero")) if amount_due < 0
-      errors.add(:base, Spree.t("validation.amount_due_greater_than_zero")) if amount_due > 0
-      errors.blank?
+    def fully_reimbursed?
+      completely_decided? && return_items.accepted.includes(:reimbursement).all? { |return_item| return_item.reimbursement.try(:reimbursed?) }
     end
 
-    def pre_tax_total
-      return_items.sum(:pre_tax_amount)
-    end
-
-    def additional_tax_total
-      return_items.sum(:additional_tax_total)
-    end
-
-    def total
-      pre_tax_total + additional_tax_total
-    end
-
-    def refund_total
-      refunds.sum(:amount)
-    end
-
-    def display_refund_total
-      Spree::Money.new(refund_total, { currency: Spree::Config[:currency] })
-    end
-
-    def amount_due
-      # rounds down to avoid edge cases where we might try to refund more than is available
-      (total - refunds.sum(:amount)).round(2, :down)
-    end
-
-    def refunded?
-      amount_due.zero?
+    def completely_decided?
+      !return_items.undecided.exists?
     end
 
     private

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -39,6 +39,7 @@ module Spree
     has_many :line_items, -> { order('created_at ASC') }, dependent: :destroy, inverse_of: :order
     has_many :payments, dependent: :destroy
     has_many :return_authorizations, dependent: :destroy
+    has_many :reimbursements, inverse_of: :order
     has_many :adjustments, -> { order("#{Adjustment.table_name}.created_at ASC") }, as: :adjustable, dependent: :destroy
     has_many :line_item_adjustments, through: :line_items, source: :adjustments
     has_many :shipment_adjustments, through: :shipments, source: :adjustments

--- a/core/app/models/spree/refund.rb
+++ b/core/app/models/spree/refund.rb
@@ -1,8 +1,8 @@
 module Spree
   class Refund < Spree::Base
     belongs_to :payment, inverse_of: :refunds
-    belongs_to :customer_return # optional
     belongs_to :reason, class_name: 'Spree::RefundReason', foreign_key: :refund_reason_id
+    belongs_to :reimbursement, inverse_of: :refunds
 
     has_many :log_entries, as: :source
 
@@ -21,6 +21,16 @@ module Spree
       Spree::Money.new(amount, { currency: payment.currency })
     end
     alias display_amount money
+
+    class << self
+      def total_amount_reimbursed_for(reimbursement)
+        reimbursement.refunds.to_a.sum(&:amount)
+      end
+    end
+
+    def description
+      payment.payment_method.name
+    end
 
     private
 

--- a/core/app/models/spree/reimbursement.rb
+++ b/core/app/models/spree/reimbursement.rb
@@ -1,0 +1,131 @@
+module Spree
+  class Reimbursement < ActiveRecord::Base
+    class IncompleteReimbursement < StandardError; end
+
+    belongs_to :order, inverse_of: :reimbursements
+    belongs_to :customer_return, inverse_of: :reimbursements
+
+    has_many :refunds, inverse_of: :reimbursement
+    has_many :return_items, inverse_of: :reimbursement
+
+    validates :order, presence: true
+    validates :customer_return, presence: true
+    validate :validate_return_items_belong_to_same_order
+
+    accepts_nested_attributes_for :return_items, allow_destroy: true
+
+    before_create :generate_number
+
+    # The return_item_tax_calculator property should be set to an object that responds to "call"
+    # and accepts an array of ReturnItems. Invoking "call" should update the tax fields on the
+    # supplied ReturnItems.
+    # This allows a store to easily integrate with third party tax services.
+    class_attribute :return_item_tax_calculator
+    self.return_item_tax_calculator = ReturnItemTaxCalculator
+    # A separate attribute here allows you to use a more performant calculator for estimates
+    # and a different one (e.g. one that hits a 3rd party API) for the final caluclations.
+    class_attribute :return_item_simulator_tax_calculator
+    self.return_item_simulator_tax_calculator = ReturnItemTaxCalculator
+
+    # The reimbursement_models property should contain an array of all models that provide
+    # reimbursements.
+    # This allows a store to incorporate custom reimbursement methods that Spree doesn't know about.
+    # Each model must implement a "total_amount_reimbursed_for" method.
+    # Example:
+    #   Refund.total_amount_reimbursed_for(reimbursement)
+    # See the `reimbursement_generator` property regarding the generation of custom reimbursements.
+    class_attribute :reimbursement_models
+    self.reimbursement_models = [Refund]
+
+    # The reimbursement_performer property should be set to an object that responds to the following methods:
+    # - #perform
+    # - #simulate
+    # see ReimbursementPerformer for details.
+    # This allows a store to customize their reimbursement methods and logic.
+    class_attribute :reimbursement_performer
+    self.reimbursement_performer = ReimbursementPerformer
+
+    # These are called if the call to "reimburse!" succeeds.
+    class_attribute :reimbursement_success_hooks
+    self.reimbursement_success_hooks = []
+
+    # These are called if the call to "reimburse!" fails.
+    class_attribute :reimbursement_failure_hooks
+    self.reimbursement_failure_hooks = []
+
+    state_machine :reimbursement_status, initial: :pending do
+
+      event :errored do
+        transition to: :errored, from: :pending
+      end
+
+      event :reimbursed do
+        transition to: :reimbursed, from: [:pending, :errored]
+      end
+
+    end
+
+    def display_total
+      Spree::Money.new(total, { currency: order.currency })
+    end
+
+    def calculated_total
+      return_items.to_a.sum(&:total)
+    end
+
+    def paid_amount
+      reimbursement_models.sum do |model|
+        model.total_amount_reimbursed_for(self)
+      end
+    end
+
+    def unpaid_amount
+      total - paid_amount
+    end
+
+    def perform!
+      return_item_tax_calculator.call(
+        return_items.includes(inventory_unit: {line_item: :order}).to_a
+      )
+      reload
+      update!(total: calculated_total)
+
+      reimbursement_performer.perform(self)
+
+      if unpaid_amount.zero?
+        reimbursed!
+        reimbursement_success_hooks.each { |h| h.call self }
+      else
+        errored!
+        reimbursement_failure_hooks.each { |h| h.call self }
+        raise IncompleteReimbursement, Spree.t("validation.unpaid_amount_not_zero", amount: unpaid_amount)
+      end
+    end
+
+    def simulate
+      return_item_simulator_tax_calculator.call(
+        return_items.includes(inventory_unit: {line_item: :order}).to_a
+      )
+      reload
+      update!(total: calculated_total)
+
+      reimbursement_performer.simulate(self)
+    end
+
+    private
+
+    def generate_number
+      self.number ||= loop do
+        random = "RI#{Array.new(9){rand(9)}.join}"
+        break random unless self.class.exists?(number: random)
+      end
+    end
+
+    def validate_return_items_belong_to_same_order
+      if return_items.any? { |ri| ri.inventory_unit.order_id != order_id }
+        errors.add(:base, :return_items_order_id_does_not_match)
+      end
+    end
+
+  end
+end

--- a/core/app/models/spree/reimbursement_performer.rb
+++ b/core/app/models/spree/reimbursement_performer.rb
@@ -1,0 +1,52 @@
+module Spree
+
+  class ReimbursementPerformer
+
+    class << self
+
+      # Simulate performing the reimbursement without actually saving anything or refunding money, etc.
+      # This must return an array of objects that respond to the following methods:
+      # - #description
+      # - #display_amount
+      # so they can be displayed in the Admin UI appropriately.
+      def simulate(reimbursement)
+        execute(reimbursement, true)
+      end
+
+      # Actually perform the reimbursement
+      def perform(reimbursement)
+        execute(reimbursement, false)
+      end
+
+      private
+
+      def execute(reimbursement, simulate)
+        # For now type and order of retrieved payments are not specified
+        unpaid_amount = reimbursement.unpaid_amount
+        reimbursement.order.payments.completed.map do |payment|
+          break if unpaid_amount <= 0
+          next if payment.credit_allowed.zero?
+
+          amount = [unpaid_amount, payment.credit_allowed].min
+
+          refund = reimbursement.refunds.build({
+            payment: payment,
+            amount: amount,
+            reason: Spree::RefundReason.return_processing_reason,
+          })
+
+          if simulate
+            refund.readonly!
+          else
+            refund.save!
+          end
+          unpaid_amount -= amount
+          refund
+        end
+      end
+
+    end
+
+  end
+
+end

--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -1,8 +1,5 @@
 module Spree
   class ReturnAuthorization < Spree::Base
-    class_attribute :return_item_tax_calculator
-    self.return_item_tax_calculator = ReturnItemTaxCalculator
-
     belongs_to :order, class_name: 'Spree::Order'
 
     has_many :return_items, inverse_of: :return_authorization, dependent: :destroy

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -188,6 +188,9 @@ en:
       spree/refund_reason:
         one: Refund Reason
         other: Refund Reasons
+      spree/reimbursement:
+        one: Reimbursement
+        other: Reimbursements
       spree/return_authorization:
         one: Return Authorization
         other: Return Authorizations
@@ -261,6 +264,15 @@ en:
           attributes:
             amount:
               greater_than_allowed: is greater than the allowed amount.
+        spree/reimbursement:
+          attributes:
+            base:
+              return_items_order_id_does_not_match: One or more of the return items specified do not belong to the same order as the reimbursement.
+        spree/return_item:
+          attributes:
+            reimbursement:
+              cannot_be_associated_unless_accepted: cannot be associated to a return item that is not accepted.
+
 
   devise:
     confirmations:
@@ -310,6 +322,8 @@ en:
         other: ! '%{count} errors prohibited this %{resource} from being saved:'
   spree:
     abbreviation: Abbreviation
+    accept: Accept
+    accepted: Accepted
     account: Account
     account_updated: Account updated
     action: Action
@@ -415,6 +429,7 @@ en:
     back_end: Backend
     backordered: Backordered
     back_to_adjustments_list: Back To Adjustments List
+    back_to_customer_return: Back To Customer Return
     back_to_customer_return_list: Back To Customer Return List
     back_to_images_list: Back To Images List
     back_to_option_types_list: Back To Option Types List
@@ -450,6 +465,7 @@ en:
     billing: Billing
     billing_address: Billing Address
     both: Both
+    calculated_reimbursements: Calculated Reimbursements
     calculator: Calculator
     calculator_settings_warning: If you are changing the calculator type, you must save first before you can edit the calculator settings
     cancel: cancel
@@ -522,6 +538,7 @@ en:
     customer_returns: Customer Returns
     create: Create
     create_a_new_account: Create a new account
+    create_reimbursement: Create reimbursement
     created_at: Created At
     credit: Credit
     credit_card: Credit Card
@@ -580,6 +597,7 @@ en:
     editing_prototype: Editing Prototype
     edit_refund_reason: Edit Refund Reason
     editing_refund_reason: Editing Refund Reason
+    editing_reimbursement: Editing Reimbursement
     editing_rma_reason: Editing RMA Reason
     editing_shipping_category: Editing Shipping Category
     editing_shipping_method: Editing Shipping Method
@@ -677,6 +695,7 @@ en:
     incl: incl.
     included_in_price: Included in Price
     included_price_validation: cannot be selected unless you have set a Default Tax Zone
+    incomplete: Incomplete
     instructions_to_reset_password: Please enter your email on the form below
     insufficient_stock: Insufficient stock available, only %{on_hand} remaining
     intercept_email_address: Intercept Email Address
@@ -689,6 +708,7 @@ en:
     inventory: Inventory
     inventory_adjustment: Inventory Adjustment
     inventory_error_flash_for_insufficient_quantity: An item in your cart has become unavailable.
+    inventory_state: Inventory State
     is_not_available_to_shipment_address: is not available to shipment address
     iso_name: Iso Name
     item: Item
@@ -700,6 +720,7 @@ en:
         gte: greater than or equal to
     items_cannot_be_shipped: We are unable to calculate shipping rates for the selected items.
     items_in_rmas: Items in Return Authorizations
+    items_to_be_reimbursed: Items to be reimbursed
     jirafe: Jirafe
     landing_page_rule:
       path: Path
@@ -732,6 +753,7 @@ en:
     look_for_similar_items: Look for similar items
     make_refund: Make refund
     manage_promotion_categories: Manage Promotion Categories
+    manual_intervention_required: Manual intervention required
     master_price: Master Price
     match_choices:
       all: All
@@ -915,6 +937,7 @@ en:
     percent: Percent
     percent_per_item: Percent Per Item
     permalink: Permalink
+    pending: Pending
     phone: Phone
     place_order: Place Order
     please_define_payment_methods: Please define some payment methods first.
@@ -1003,6 +1026,7 @@ en:
     receive: receive
     receive_stock: Receive Stock
     received: Received
+    reception_status: Reception Status
     reference: Reference
     refund: Refund
     refund_amount_must_be_greater_than_zero: Refund amount must be greater than zero
@@ -1012,6 +1036,14 @@ en:
     refund_amount_must_be_greater_than_zero: Refund amount must be greater than zero
     register: Register
     registration: Registration
+    reimburse: Reimburse
+    reimbursed: Reimbursed
+    reimbursement_perform_failed: "Reimbursement could not be performed.  Error: %{error}"
+    reimbursement_status: Reimbursement status
+    reimbursement_type: Reimbursement type
+    reimbursements: Reimbursements
+    reject: Reject
+    rejected: Rejected
     remember_me: Remember me
     remove: Remove
     rename: Rename
@@ -1192,6 +1224,7 @@ en:
     type: Type
     type_to_search: Type to search
     unable_to_connect_to_gateway: Unable to connect to gateway.
+    unable_to_create_reimbursements: Unable to create reimbursements because there are items pending manual intervention.
     under_price: Under %{price}
     unlock: Unlock
     unrecognized_card_type: Unrecognized card type
@@ -1208,8 +1241,7 @@ en:
       choose_users: Choose users
     users: Users
     validation:
-      amount_due_less_than_zero: Amount due is less than zero
-      amount_due_greater_than_zero: Unable to refund full amount
+      unpaid_amount_not_zero: "Amount was not fully reimbursed. Still due: %{amount}"
       cannot_be_less_than_shipped_units: cannot be less than the number of shipped units.
       cannot_destory_line_item_as_inventory_units_have_shipped: Cannot destory line item as some inventory units have shipped.
       exceeds_available_stock: exceeds available stock. Please ensure line items have a valid quantity.

--- a/core/db/migrate/20140725131539_create_spree_reimbursements.rb
+++ b/core/db/migrate/20140725131539_create_spree_reimbursements.rb
@@ -1,0 +1,21 @@
+class CreateSpreeReimbursements < ActiveRecord::Migration
+  def change
+    create_table :spree_reimbursements do |t|
+      t.string :number
+      t.string :reimbursement_status
+      t.integer :customer_return_id
+      t.integer :order_id
+      t.decimal :total, precision: 10, scale: 2
+
+      t.timestamps
+    end
+
+    add_index :spree_reimbursements, :customer_return_id
+    add_index :spree_reimbursements, :order_id
+
+    remove_column :spree_refunds, :customer_return_id, :integer
+    add_column :spree_refunds, :reimbursement_id, :integer
+
+    add_column :spree_return_items, :reimbursement_id, :integer
+  end
+end

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -38,7 +38,7 @@ module Spree
 
     @@checkout_attributes = [:email, :use_billing, :shipping_method_id, :coupon_code, :special_instructions]
 
-    @@customer_return_attributes = [:stock_location_id, return_items_attributes: [:id, :inventory_unit_id, :return_authorization_id, :returned, :pre_tax_amount]]
+    @@customer_return_attributes = [:stock_location_id, return_items_attributes: [:id, :inventory_unit_id, :return_authorization_id, :returned, :pre_tax_amount, :acceptance_status]]
 
     @@image_attributes = [:alt, :attachment, :position, :viewable_type, :viewable_id]
 

--- a/core/lib/spree/testing_support/factories/customer_return_factory.rb
+++ b/core/lib/spree/testing_support/factories/customer_return_factory.rb
@@ -1,12 +1,34 @@
 FactoryGirl.define do
+
   factory :customer_return, class: Spree::CustomerReturn do
     association(:stock_location, factory: :stock_location)
-    factory :customer_return_with_return_items do
-      before(:create) do |customer_return, evaluator|
-        shipped_order = create(:shipped_order)
-        customer_return.return_items << create(:return_item, inventory_unit: create(:inventory_unit, state: 'shipped', order: shipped_order))
-        customer_return.return_items << create(:return_item, inventory_unit: create(:inventory_unit, state: 'shipped', order: shipped_order))
+
+    ignore do
+      line_items_count 1
+      return_items_count { line_items_count }
+    end
+
+    before(:create) do |customer_return, evaluator|
+      shipped_order = create(:shipped_order, line_items_count: evaluator.line_items_count)
+
+      shipped_order.inventory_units.take(evaluator.return_items_count).each do |inventory_unit|
+        customer_return.return_items << build(:return_item, {
+          inventory_unit: inventory_unit,
+          pre_tax_amount: inventory_unit.pre_tax_amount,
+        })
+      end
+    end
+
+    factory :customer_return_with_accepted_items do
+      after(:create) do |customer_return|
+        customer_return.return_items.each(&:accept!)
       end
     end
   end
+
+  # for the case when you want to supply existing return items instead of generating some
+  factory :customer_return_without_return_items, class: Spree::CustomerReturn do
+    association(:stock_location, factory: :stock_location)
+  end
+
 end

--- a/core/lib/spree/testing_support/factories/reimbursement_factory.rb
+++ b/core/lib/spree/testing_support/factories/reimbursement_factory.rb
@@ -1,0 +1,12 @@
+FactoryGirl.define do
+  factory :reimbursement, class: Spree::Reimbursement do
+    association(:customer_return, factory: :customer_return_with_accepted_items)
+
+    before(:create) do |reimbursement, evaluator|
+      reimbursement.order ||= reimbursement.customer_return.order
+      if reimbursement.return_items.empty?
+        reimbursement.return_items = reimbursement.customer_return.return_items
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/refund_spec.rb
+++ b/core/spec/models/spree/refund_spec.rb
@@ -138,4 +138,31 @@ describe Spree::Refund do
       end
     end
   end
+
+  describe 'total_amount_reimbursed_for' do
+    let(:customer_return) { reimbursement.customer_return}
+    let(:reimbursement) { create(:reimbursement) }
+    let!(:default_refund_reason) { Spree::RefundReason.find_or_create_by!(name: Spree::RefundReason::RETURN_PROCESSING_REASON, mutable: false) }
+
+    subject { Spree::Refund.total_amount_reimbursed_for(reimbursement) }
+
+    context 'with reimbursements performed' do
+      before do
+        reimbursement.perform!
+      end
+
+      it 'returns the total amount' do
+        amount = Spree::Refund.total_amount_reimbursed_for(reimbursement)
+        expect(amount).to be > 0
+        expect(amount).to eq reimbursement.total
+      end
+    end
+
+    context 'without reimbursements performed' do
+      it 'returns zero' do
+        amount = Spree::Refund.total_amount_reimbursed_for(reimbursement)
+        expect(amount).to eq 0
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/reimbursement_spec.rb
+++ b/core/spec/models/spree/reimbursement_spec.rb
@@ -1,0 +1,138 @@
+require 'spec_helper'
+
+describe Spree::Reimbursement do
+
+  describe ".before_create" do
+    describe "#generate_number" do
+      context "number is assigned" do
+        let(:number)        { '123' }
+        let(:reimbursement) { Spree::Reimbursement.new(number: number) }
+
+        it "should return the assigned number" do
+          reimbursement.save
+          expect(reimbursement.number).to eq number
+        end
+      end
+
+      context "number is not assigned" do
+        let(:reimbursement) { Spree::Reimbursement.new(number: nil) }
+
+        before do
+          reimbursement.stub(valid?: true)
+        end
+
+        it "should assign number with random RI number" do
+          reimbursement.save
+          expect(reimbursement.number).to be =~ /RI\d{9}/
+        end
+      end
+    end
+  end
+
+  describe "#display_total" do
+    let(:total)         { 100.50 }
+    let(:currency)      { "USD" }
+    let(:order)         { Spree::Order.new(currency: currency) }
+    let(:reimbursement) { Spree::Reimbursement.new(total: total, order: order) }
+
+    subject { reimbursement.display_total }
+
+    it "returns the value as a Spree::Money instance" do
+      expect(subject).to eq Spree::Money.new(total)
+    end
+
+    it "uses the order's currency" do
+      expect(subject.money.currency.to_s).to eq currency
+    end
+  end
+
+  describe "#perform!" do
+    let!(:adjustments)            { [] } # placeholder to ensure it gets run prior the "before" at this level
+
+    let!(:tax_rate)               { nil }
+    let!(:tax_zone)               { create(:zone, default_tax: true) }
+
+    let(:order)                   { create(:order_with_line_items, state: 'payment', line_items_count: 1, line_items_price: line_items_price, shipment_cost: 0) }
+    let(:line_items_price)        { BigDecimal.new(10) }
+    let(:line_item)               { order.line_items.first }
+    let(:inventory_unit)          { line_item.inventory_units.first }
+    let(:payment)                 { build(:payment, amount: payment_amount, order: order, state: 'completed') }
+    let(:payment_amount)          { order.total }
+    let(:customer_return)         { build(:customer_return, return_items: [return_item]) }
+    let(:return_item)             { build(:return_item, pre_tax_amount: inventory_unit.pre_tax_amount, inventory_unit: inventory_unit) }
+
+    let!(:default_refund_reason) { Spree::RefundReason.find_or_create_by!(name: Spree::RefundReason::RETURN_PROCESSING_REASON, mutable: false) }
+
+    let(:reimbursement) { create(:reimbursement, customer_return: customer_return, order: order, return_items: [return_item]) }
+
+    subject { reimbursement.perform! }
+
+    before do
+      order.shipments.each do |shipment|
+        shipment.inventory_units.update_all state: 'shipped'
+        shipment.update_column('state', 'shipped')
+      end
+      order.reload
+      order.update!
+      if payment
+        payment.save!
+        order.next! # confirm
+      end
+      order.next! # completed
+      customer_return.save!
+      return_item.accept!
+    end
+
+    it "refunds the total amount" do
+      subject
+      expect(reimbursement.unpaid_amount).to eq 0
+    end
+
+    it "creates a refund" do
+      expect {
+        subject
+      }.to change{ Spree::Refund.count }.by(1)
+      Spree::Refund.last.amount.should eq order.total
+    end
+
+    context 'with additional tax' do
+      let!(:tax_rate) { create(:tax_rate, name: "Sales Tax", amount: 0.10, included_in_price: false, zone: tax_zone) }
+
+      it 'saves the additional tax and refunds the total' do
+        expect {
+          subject
+        }.to change { Spree::Refund.count }.by(1)
+        return_item.reload
+        expect(return_item.additional_tax_total).to be > 0
+        expect(return_item.additional_tax_total).to eq line_item.additional_tax_total
+        expect(reimbursement.total).to eq line_item.pre_tax_amount + line_item.additional_tax_total
+        expect(Spree::Refund.last.amount).to eq line_item.pre_tax_amount + line_item.additional_tax_total
+      end
+    end
+
+    context 'with included tax' do
+      let!(:tax_rate) { create(:tax_rate, name: "VAT Tax", amount: 0.1, included_in_price: true, zone: tax_zone) }
+
+      it 'saves the additional tax and refunds the total' do
+        expect {
+          subject
+        }.to change { Spree::Refund.count }.by(1)
+        return_item.reload
+        expect(return_item.included_tax_total).to be < 0
+        expect(return_item.included_tax_total).to eq line_item.included_tax_total
+        expect(reimbursement.total).to eq line_item.pre_tax_amount
+        expect(Spree::Refund.last.amount).to eq line_item.pre_tax_amount
+      end
+    end
+
+    context 'when reimbursement cannot be fully performed' do
+      let!(:non_return_refund) { create(:refund, amount: 1, payment: payment) }
+
+      it 'raises IncompleteReimbursement error' do
+        expect { subject }.to raise_error(Spree::Reimbursement::IncompleteReimbursement)
+      end
+    end
+
+  end
+
+end

--- a/core/spec/models/spree/return_authorization_spec.rb
+++ b/core/spec/models/spree/return_authorization_spec.rb
@@ -111,7 +111,7 @@ describe Spree::ReturnAuthorization do
     subject { return_authorization.customer_returned_items? }
 
     context "has associated customer returns" do
-      let(:customer_return) { create(:customer_return_with_return_items) }
+      let(:customer_return) { create(:customer_return) }
       let(:return_authorization) { customer_return.return_authorizations.first }
 
       it "returns true" do

--- a/core/spec/models/spree/stock_location_spec.rb
+++ b/core/spec/models/spree/stock_location_spec.rb
@@ -206,7 +206,7 @@ module Spree
         subject { create(:stock_location) }
         let(:variant) { create(:base_variant) }
 
-        it 'zero on_hand and backordered', focus: true do
+        it 'zero on_hand and backordered' do
           subject
           variant.stock_items.destroy_all
           on_hand, backordered = subject.fill_status(variant, 1)


### PR DESCRIPTION
- New Reimbursement model which encapsulates the concept of reimbursing a set of accepted return items, which will be reimbursed via one or more reimbursement methods (e.g., refunds, exchanges, store credits, etc)
- Moved refund logic from customer return into Reimbursement
- Ability to resolve "manual_intervention_required" returns items in the Admin UI
- Provide preview of how reimbursements will be parceled out before performing them
- Add a default "ReimbursementPerformer" that figures out how to distribute a reimbursement

Other enhancements/fixes:
- Suggested amounts now update on input changes
- Add generic "success/notice/error" state colors
- New Admin show page for customer returns
- Remove customer return refund endpoint
- new Admin ReimbursementsController & ReturnItemsController

Created by @richardnuno & @jordan-brough
