### PR TITLE
add missing respond_with to some API controllers and add tests 

### DIFF
--- a/api/app/controllers/spree/api/inventory_units_controller.rb
+++ b/api/app/controllers/spree/api/inventory_units_controller.rb
@@ -5,6 +5,7 @@ module Spree
 
       def show
         @inventory_unit = inventory_unit
+        respond_with(@inventory_unit)
       end
 
       def update

--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -17,7 +17,7 @@ module Spree
       def cancel
         authorize! :update, @order, params[:token]
         @order.cancel!
-        render :show
+        respond_with(@order, :default_template => :show)
       end
 
       def create

--- a/api/app/controllers/spree/api/products_controller.rb
+++ b/api/app/controllers/spree/api/products_controller.rb
@@ -12,6 +12,7 @@ module Spree
         @products = @products.distinct.page(params[:page]).per(params[:per_page])
         expires_in 15.minutes, :public => true
         headers['Surrogate-Control'] = "max-age=#{15.minutes}"
+        respond_with(@products)
       end
 
       def show
@@ -19,6 +20,7 @@ module Spree
         expires_in 15.minutes, :public => true
         headers['Surrogate-Control'] = "max-age=#{15.minutes}"
         headers['Surrogate-Key'] = "product_id=1"
+        respond_with(@product)
       end
 
       # Takes besides the products attributes either an array of variants or

--- a/api/spec/controllers/spree/api/products_controller_spec.rb
+++ b/api/spec/controllers/spree/api/products_controller_spec.rb
@@ -67,6 +67,34 @@ module Spree
         json_response["per_page"].should == Kaminari.config.default_per_page
       end
 
+      context "specifying a rabl template for a custom action" do
+        before do
+          Spree::Api::ProductsController.class_eval do
+            def custom_show
+              @product = find_product(params[:id])
+              respond_with(@product)
+            end
+          end
+        end
+
+        it "uses the specified custom template through the request header" do
+          request.headers['X-Spree-Template'] = 'show'
+          api_get :custom_show, :id => product.id
+          response.should render_template('spree/api/products/show')
+        end
+
+        it "uses the specified custom template through the template URL parameter" do
+          api_get :custom_show, :id => product.id, :template => 'show'
+          response.should render_template('spree/api/products/show')
+        end
+
+        it "falls back to the default template if the specified template does not exist" do
+          request.headers['X-Spree-Template'] = 'invoice'
+          api_get :show, :id => product.id
+          response.should render_template('spree/api/products/show')
+        end
+      end
+
       context "product has more than one price" do
         before { product.master.prices.create currency: "EUR", amount: 22 }
 


### PR DESCRIPTION
spree/spree#4967
- update spec to test custom rabl template
- ~~inject custom view into dummy app~~
- ensure usage of respond_with for OrdersController and InventoryUnitsController
- add respond_with to ProductsController

~~In the spec for testing custom rabl template rendering I actually create a rabl template and place it into the dummy app and then delete if after the test runs.  This is the only clean way I could think of doing it while still testing the full functionality.  Let me know if there's a better way that doesn't involve writing the actual view file~~  thanks! 
