### PR TITLE
Associate default user address in pre-transition callback

### DIFF
--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -500,6 +500,7 @@ module Spree
           end
 
           before do
+            order.bill_address = FactoryGirl.create(:address)
             order.ship_address = FactoryGirl.create(:address)
             order.next!
             order.save

--- a/backend/app/views/spree/admin/users/_user_page_actions.html.erb
+++ b/backend/app/views/spree/admin/users/_user_page_actions.html.erb
@@ -2,4 +2,7 @@
   <li>
     <%= button_link_to Spree.t(:back_to_users_list), spree.admin_users_path, :icon => 'arrow-left' %>
   </li>
+  <li>
+    <%= button_link_to Spree.t(:create_new_order), spree.new_admin_order_path(user_id: @user.id), :icon => 'plus' %>
+  </li>
 <% end %>

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -16,6 +16,7 @@ module Spree
     end
 
     attr_reader :coupon_code
+    attr_accessor :temporary_address
 
     if Spree.user_class
       belongs_to :user, class_name: Spree.user_class.to_s

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -254,10 +254,10 @@ module Spree
 
           def assign_default_addresses!
             if self.user
-              self.bill_address ||= user.bill_address.try(:clone) if user.bill_address.try(:valid?)
+              self.bill_address = user.bill_address.try(:clone) if !self.bill_address_id && user.bill_address.try(:valid?)
               # Skip setting ship address if order doesn't have a delivery checkout step
               # to avoid triggering validations on shipping address
-              self.ship_address ||= user.ship_address.try(:clone) if user.ship_address.try(:valid?) && self.checkout_steps.include?("delivery")
+              self.ship_address = user.ship_address.try(:clone) if !self.ship_address_id && user.ship_address.try(:valid?) && self.checkout_steps.include?("delivery")
             end
           end
 

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -38,8 +38,8 @@ module Spree
             # To avoid multiple occurrences of the same transition being defined
             # On first definition, state_machines will not be defined
             state_machines.clear if respond_to?(:state_machines)
-            state_machine :state, :initial => :cart, :use_transactions => false, :action => :save_state do
-              klass.next_event_transitions.each { |t| transition(t.merge(:on => :next)) }
+            state_machine :state, initial: :cart, use_transactions: false, action: :save_state do
+              klass.next_event_transitions.each { |t| transition(t.merge(on: :next)) }
 
               # Persist the state on the order
               after_transition do |order, transition|
@@ -54,23 +54,23 @@ module Spree
               end
 
               event :cancel do
-                transition :to => :canceled, :if => :allow_cancel?
+                transition to: :canceled, if: :allow_cancel?
               end
 
               event :return do
-                transition :to => :returned, :from => [:complete, :awaiting_return], :if => :all_inventory_units_returned?
+                transition to: :returned, from: [:complete, :awaiting_return], if: :all_inventory_units_returned?
               end
 
               event :resume do
-                transition :to => :resumed, :from => :canceled, :if => :canceled?
+                transition to: :resumed, from: :canceled, if: :canceled?
               end
 
               event :authorize_return do
-                transition :to => :awaiting_return
+                transition to: :awaiting_return
               end
 
               if states[:payment]
-                before_transition :to => :complete do |order|
+                before_transition to: :complete do |order|
                   if order.payment_required? && order.payments.empty?
                     order.errors.add(:base, Spree.t(:no_payment_found))
                     false
@@ -80,30 +80,30 @@ module Spree
                 end
               end
 
-              before_transition :from => :cart, :do => :ensure_line_items_present
+              before_transition from: :cart, do: :ensure_line_items_present
 
               if states[:address]
-                before_transition :from => :address, :do => :create_tax_charge!
-                before_transition :to => :address, :do => :assign_default_addresses!
-                before_transition :from => :address, :do => :persist_user_address!
+                before_transition from: :address, do: :create_tax_charge!
+                before_transition to: :address, do: :assign_default_addresses!
+                before_transition from: :address, do: :persist_user_address!
               end
 
               if states[:payment]
-                before_transition :to => :payment, :do => :set_shipments_cost
-                before_transition :to => :payment, :do => :create_tax_charge!
+                before_transition to: :payment, do: :set_shipments_cost
+                before_transition to: :payment, do: :create_tax_charge!
               end
 
               if states[:delivery]
-                before_transition :to => :delivery, :do => :create_proposed_shipments
-                before_transition :to => :delivery, :do => :ensure_available_shipping_rates
-                before_transition :from => :delivery, :do => :apply_free_shipping_promotions
+                before_transition to: :delivery, do: :create_proposed_shipments
+                before_transition to: :delivery, do: :ensure_available_shipping_rates
+                before_transition from: :delivery, do: :apply_free_shipping_promotions
               end
 
-              after_transition :to => :complete, :do => :finalize!
-              after_transition :to => :resumed,  :do => :after_resume
-              after_transition :to => :canceled, :do => :after_cancel
+              after_transition to: :complete, do: :finalize!
+              after_transition to: :resumed,  do: :after_resume
+              after_transition to: :canceled, do: :after_cancel
 
-              after_transition :from => any - :cart, :to => any - [:confirm, :complete] do |order|
+              after_transition from: any - :cart, to: any - [:confirm, :complete] do |order|
                 order.update_totals
                 order.persist_totals
               end
@@ -115,7 +115,7 @@ module Spree
           def self.go_to_state(name, options={})
             self.checkout_steps[name] = options
             previous_states.each do |state|
-              add_transition({:from => state, :to => name}.merge(options))
+              add_transition({from: state, to: name}.merge(options))
             end
             if options[:if]
               self.previous_states << name

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -254,11 +254,10 @@ module Spree
 
           def assign_default_addresses!
             if self.user
-              self.bill_address ||= user.bill_address.try(:clone)
+              self.bill_address ||= user.bill_address.try(:clone) if user.bill_address.try(:valid?)
               # Skip setting ship address if order doesn't have a delivery checkout step
               # to avoid triggering validations on shipping address
-              self.ship_address ||= user.ship_address.try(:clone) if self.checkout_steps.include? "delivery"
-              self.save!
+              self.ship_address ||= user.ship_address.try(:clone) if user.ship_address.try(:valid?) && self.checkout_steps.include?("delivery")
             end
           end
 

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -23,6 +23,8 @@ module Spree
               order.state = 'complete'
             end
 
+            params.delete(:user_id) unless user.try(:has_spree_role?, "admin") && params.key?(:user_id)
+
             order.update_attributes!(params)
             # Really ensure that the order totals are correct
             order.update_totals

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -60,6 +60,32 @@ module Spree
         expect(order.email).to eq params[:email]
       end
 
+      context "assigning a user to an order" do
+        let(:other_user) { stub_model(LegacyUser, :email => 'dana@scully.com') }
+
+        context "as an admin" do
+          before { user.stub :has_spree_role? => true }
+
+          context "a user's id is not provided" do
+            # this is a regression spec for an issue we ran into at Bonobos
+            it "doesn't unassociate the admin from the order" do
+              params = { }
+              order = Importer::Order.import(user, params)
+              expect(order.user_id).to eq(user.id)
+            end
+          end
+        end
+
+        context "as a user" do
+          before { user.stub :has_spree_role? => false }
+          it "does not assign the order to the other user" do
+            params = { user_id: other_user.id }
+            order = Importer::Order.import(user, params)
+            expect(order.user_id).to eq(user.id)
+          end
+        end
+      end
+
       it 'can build an order from API with just line items' do
         params = { :line_items_attributes => line_items }
 

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -121,6 +121,11 @@ describe Spree::Order do
           order.state.should == "address"
         end
 
+        it "doesn't raise an error if the default address is invalid" do
+          order.user = mock_model(Spree::LegacyUser, ship_address: Spree::Address.new, bill_address: Spree::Address.new)
+          expect { order.next! }.to_not raise_error
+        end
+
         context "with default addresses" do
           let(:default_address) { FactoryGirl.create(:address) }
 

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -104,17 +104,55 @@ describe Spree::Order do
       order.state.should == "cart"
     end
 
-    it "transitions to address" do
-      order.line_items << FactoryGirl.create(:line_item)
-      order.email = "user@example.com"
-      order.next!
-      assert_state_changed(order, 'cart', 'address')
-      order.state.should == "address"
-    end
+    context "to address" do
+      before do
+        order.email = "user@example.com"
+        order.save!
+      end
 
-    it "cannot transition to address without any line items" do
-      order.line_items.should be_blank
-      lambda { order.next! }.should raise_error(StateMachine::InvalidTransition, /#{Spree.t(:there_are_no_items_for_this_order)}/)
+      context "with a line item" do
+        before do
+          order.line_items << FactoryGirl.create(:line_item)
+        end
+
+        it "transitions to address" do
+          order.next!
+          assert_state_changed(order, 'cart', 'address')
+          order.state.should == "address"
+        end
+
+        context "with default addresses" do
+          let(:default_address) { FactoryGirl.create(:address) }
+
+          before do
+            order.user = FactoryGirl.create(:user, "#{address_kind}_address" => default_address)
+            order.next!
+            order.reload
+          end
+
+          shared_examples "it cloned the default address" do
+            it do
+              default_attributes = default_address.attributes
+              order_attributes = order.send("#{address_kind}_address".to_sym).try(:attributes) || {}
+
+              order_attributes.except('id', 'created_at', 'updated_at').should eql(default_attributes.except('id', 'created_at', 'updated_at'))
+            end
+          end
+
+          it_behaves_like "it cloned the default address" do
+            let(:address_kind) { 'ship' }
+          end
+
+          it_behaves_like "it cloned the default address" do
+            let(:address_kind) { 'bill' }
+          end
+        end
+      end
+
+      it "cannot transition to address without any line items" do
+        order.line_items.should be_blank
+        lambda { order.next! }.should raise_error(StateMachine::InvalidTransition, /#{Spree.t(:there_are_no_items_for_this_order)}/)
+      end
     end
 
     context "from address" do
@@ -146,6 +184,27 @@ describe Spree::Order do
         order.next!
         assert_state_changed(order, 'address', 'delivery')
         order.state.should == "delivery"
+      end
+
+      it "calls persist_order_address on the order's user" do
+        order.stub(:ensure_available_shipping_rates => true)
+
+        order.user = FactoryGirl.create(:user)
+        order.save!
+
+        expect(order.user).to receive(:persist_order_address).with(order)
+        order.next!
+      end
+
+      it "does not call persist_order_address on the order's user for a temporary address" do
+        order.stub(:ensure_available_shipping_rates => true)
+
+        order.user = FactoryGirl.create(:user)
+        order.temporary_address = true
+        order.save!
+
+        expect(order.user).to_not receive(:persist_order_address)
+        order.next!
       end
 
       context "cannot transition to delivery" do

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -26,7 +26,7 @@ module Spree
     # Updates the order and advances to the next state (when possible.)
     def update
       if @order.update_from_params(params, permitted_checkout_attributes, request.headers.env)
-        persist_user_address
+        @order.temporary_address = !params[:save_user_address]
         unless @order.next
           flash[:error] = @order.errors.full_messages.join("\n")
           redirect_to checkout_state_path(@order.state) and return
@@ -106,14 +106,11 @@ module Spree
         send(method_name) if respond_to?(method_name, true)
       end
 
-      # Skip setting ship address if order doesn't have a delivery checkout step
-      # to avoid triggering validations on shipping address
       def before_address
-        @order.bill_address ||= Address.default(try_spree_current_user, "bill")
-
-        if @order.checkout_steps.include? "delivery"
-          @order.ship_address ||= Address.default(try_spree_current_user, "ship")
-        end
+        # if the user has a default address, a callback takes care of setting
+        # that; but if he doesn't, we need to build an empty one here
+        @order.bill_address ||= Address.build_default
+        @order.ship_address ||= Address.build_default if @order.checkout_steps.include?('delivery')
       end
 
       def before_delivery
@@ -145,14 +142,6 @@ module Spree
 
       def check_authorization
         authorize!(:edit, current_order, cookies.signed[:guest_token])
-      end
-
-      def persist_user_address
-        if @order.checkout_steps.include? "address"
-          if @order.address? && try_spree_current_user.respond_to?(:persist_order_address)
-            try_spree_current_user.persist_order_address(@order) if params[:save_user_address]
-          end
-        end
       end
   end
 end

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -361,8 +361,7 @@ describe Spree::CheckoutController do
     end
 
     it "doesn't set shipping address on the order" do
-      expect(order).to receive(:bill_address)
-      expect(order).to_not receive(:ship_address)
+      expect(order).to_not receive(:ship_address=)
       spree_post :update
     end
 


### PR DESCRIPTION
Two advantages:
1. Centralizes this logic, as we want this to happen whether you create an order from frontend, backend or API.
2. Waits until the last possible moment to assign an address and will thus get the most recent default address, rather than the one at the time the cart was created.

This is as an alternative to [#4789](https://github.com/spree/spree/pull/4789) and based off the IRC discussion with @JDutil, @athal7 and @huoxito. cc/ @nhippenmeyer
