### PR TITLE
Speed up rename_adjustment_fields migration

### DIFF
--- a/core/db/migrate/20130807024302_rename_adjustment_fields.rb
+++ b/core/db/migrate/20130807024302_rename_adjustment_fields.rb
@@ -7,11 +7,8 @@ class RenameAdjustmentFields < ActiveRecord::Migration
 
     # This enables the Spree::Order#all_adjustments association to work correctly
     Spree::Adjustment.reset_column_information
-    Spree::Adjustment.find_each do |adjustment|
-      if adjustment.adjustable.is_a?(Spree::Order)
-        adjustment.order = adjustment.adjustable
-        adjustment.save
-      end
+    Spree::Adjustment.where(adjustable_type: "Spree::Order").find_each do |adjustment|
+      adjustment.update_column(:order_id, adjustment.adjustable_id)
     end
   end
 end


### PR DESCRIPTION
I went to perform this migration on our production db while our store was in maintenance mode and realized it was going to take many hours -- it was loading some million or so Order objects, one at a time.

The first change is that we go from loading all Adjustments and asking whether _each_  one's `adjustable` is an Order to just scoping the Adjustment call to only ask for the ones that are. That saved us about one million `if` statements.

The second change is to simply copy the `adjustable_id` directly over to `order_id` without ever fetching the Order record -- who needs it? This saved us about one million ActiveRecord queries.

Happy to pass the fruits along to others on the 2.1--2.2 upgrade path!
