### PR TITLE
Adding Spree::LineItem#discounted_money

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -57,6 +57,10 @@ module Spree
       amount + promo_total
     end
 
+    def discounted_money
+      Spree::Money.new(discounted_amount, { currency: currency })
+    end
+
     def final_amount
       amount + adjustment_total
     end
@@ -110,7 +114,7 @@ module Spree
 
       def update_adjustments
         if quantity_changed?
-          update_tax_charge # Called to ensure pre_tax_amount is updated. 
+          update_tax_charge # Called to ensure pre_tax_amount is updated.
           recalculate_adjustments
         end
       end

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -124,6 +124,12 @@ describe Spree::LineItem do
     end
   end
 
+  describe "#discounted_money" do
+    it "should return a money object with the discounted amount" do
+      expect(line_item.discounted_money.to_s).to eq "$10.00"
+    end
+  end
+
   describe '.currency' do
     it 'returns the globally configured currency' do
       line_item.currency == 'USD'


### PR DESCRIPTION
In our app we're needing to display the discounted amount on our views, so we've added Spree::LineItem#discounted_money to make this easier.

Is this something that would be useful in general?
