### PR TITLE
Make Shipment.cost default to 0

### DIFF
--- a/core/db/migrate/20140804185157_add_default_to_shipment_cost.rb
+++ b/core/db/migrate/20140804185157_add_default_to_shipment_cost.rb
@@ -1,0 +1,10 @@
+class AddDefaultToShipmentCost < ActiveRecord::Migration
+  def up
+    change_column :spree_shipments, :cost, :decimal, precision: 10, scale: 2, default: 0.0
+    Spree::Shipment.where(cost: nil).update_all(cost: 0)
+  end
+
+  def down
+    change_column :spree_shipments, :cost, :decimal, precision: 10, scale: 2
+  end
+end


### PR DESCRIPTION
Since upgrading to Spree 2.2, I've noticed exceptions getting thrown by, for instance [`cost + promo_cost`](https://github.com/spree/spree/blob/2-2-stable/core/app/models/spree/shipment.rb#L151) throwing `NoMethodError: undefined method '+' for nil:NilClass`.

Looking into my db schema, I see that virtually all decimal figures in Spree default to 0, but it looks like for some reason `spree_shipments.cost` didn't get that default. This migration helps ensure a smooth upgrade path from earlier Spree releases to 2.2.
