### PR TITLE
Update Google Analytics

### DIFF
--- a/frontend/app/views/spree/shared/_google_analytics.html.erb
+++ b/frontend/app/views/spree/shared/_google_analytics.html.erb
@@ -6,6 +6,7 @@
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
     ga('create', '<%= tracker.analytics_id %>','<%= Spree::Config[:site_url].sub!(/(^www.)?/,'') %>');
+    ga('require', 'displayfeatures');
     ga('send', 'pageview');
 
     <% if flash[:commerce_tracking] && @order.present? %>


### PR DESCRIPTION
Backport to 2-2-stable of https://github.com/spree/spree/pull/5030

Updates GA tracking code to support Display Advertising. See: https://support.google.com/analytics/answer/2444872 for more.
