### PR TITLE
Attempt to auto-accept ReturnItems when received.

### DIFF
--- a/backend/app/views/spree/admin/customer_returns/_return_item_table.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_return_item_table.html.erb
@@ -16,7 +16,6 @@
     </thead>
     <tbody>
       <%= f.fields_for :return_items, return_items do |item_fields| %>
-        <%= item_fields.hidden_field :acceptance_status, value: 'accepted' %>
         <% return_item = item_fields.object %>
         <% inventory_unit = return_item.inventory_unit %>
         <tr>

--- a/backend/spec/controllers/spree/admin/customer_returns_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/customer_returns_controller_spec.rb
@@ -101,9 +101,8 @@ module Spree
 
       describe "#show" do
         let(:order)           { customer_return.order }
-        let(:customer_return) { create(:customer_return, line_items_count: 4) }
+        let(:customer_return) { create(:customer_return, line_items_count: 3) }
 
-        let!(:pending_return_item)             { customer_return.return_items.order('id').fourth }
         let!(:accepted_return_item)            { customer_return.return_items.order('id').first.tap(&:accept!) }
         let!(:rejected_return_item)            { customer_return.return_items.order('id').second.tap(&:reject!)}
         let!(:manual_intervention_return_item) { customer_return.return_items.order('id').third.tap(&:require_manual_intervention!) }
@@ -137,7 +136,7 @@ module Spree
         end
 
         it "loads the return items that are still pending" do
-          expect(assigns(:pending_return_items)).to eq [pending_return_item]
+          expect(assigns(:pending_return_items)).to eq []
         end
       end
 

--- a/backend/spec/controllers/spree/admin/return_items_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/return_items_controller_spec.rb
@@ -6,8 +6,8 @@ describe Spree::Admin::ReturnItemsController do
   describe '#update' do
     let(:customer_return) { create(:customer_return) }
     let(:return_item) { customer_return.return_items.first }
-    let(:old_acceptance_status) { 'pending' }
-    let(:new_acceptance_status) { 'accepted' }
+    let(:old_acceptance_status) { 'accepted' }
+    let(:new_acceptance_status) { 'rejected' }
 
     subject do
       spree_put :update, id: return_item.to_param, return_item: {acceptance_status: new_acceptance_status}

--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -28,6 +28,7 @@ module Spree
 
     state_machine :reception_status, initial: :awaiting do
       before_transition to: :received, do: :process_inventory_unit!
+      after_transition to: :received, do: :attempt_accept
 
       event :receive do
         transition to: :received, from: :awaiting
@@ -45,6 +46,7 @@ module Spree
 
     state_machine :acceptance_status, initial: :pending do
       event :attempt_accept do
+        transition to: :accepted, from: :accepted
         transition to: :accepted, from: :pending, if: -> (return_item) { return_item.eligible_for_return? }
         transition to: :manual_intervention_required, from: :pending, if: -> (return_item) { return_item.requires_manual_intervention? }
         transition to: :rejected, from: :pending
@@ -52,17 +54,17 @@ module Spree
 
       # bypasses eligibility checks
       event :accept do
-        transition to: :accepted, from: [:pending, :manual_intervention_required]
+        transition to: :accepted, from: [:accepted, :pending, :manual_intervention_required]
       end
 
       # bypasses eligibility checks
       event :reject do
-        transition to: :rejected, from: [:pending, :manual_intervention_required]
+        transition to: :rejected, from: [:accepted, :pending, :manual_intervention_required]
       end
 
       # bypasses eligibility checks
       event :require_manual_intervention do
-        transition to: :manual_intervention_required, from: :pending
+        transition to: :manual_intervention_required, from: [:accepted, :pending, :manual_intervention_required]
       end
 
       after_transition any => any, :do => :persist_acceptance_status_errors

--- a/core/spec/models/spree/return_item_spec.rb
+++ b/core/spec/models/spree/return_item_spec.rb
@@ -15,6 +15,7 @@ describe Spree::ReturnItem do
 
   before do
     Spree::Order.any_instance.stub(return!: true)
+    return_item.stub(:eligible_for_return?).and_return(true)
   end
 
   describe '#receive!' do
@@ -29,11 +30,15 @@ describe Spree::ReturnItem do
 
     subject { return_item.receive! }
 
-    before { return_item.stub(:eligible_for_return?).and_return(true) }
 
     it 'returns the inventory unit' do
       subject
       expect(inventory_unit.reload.state).to eq 'returned'
+    end
+
+    it 'attempts to accept the return item' do
+      return_item.should_receive(:attempt_accept)
+      subject
     end
 
     context 'with a stock location' do
@@ -186,7 +191,7 @@ describe Spree::ReturnItem do
       end
     end
 
-    (all_acceptance_statuses - ['pending']).each do |invalid_transition_status|
+    (all_acceptance_statuses - ['accepted', 'pending']).each do |invalid_transition_status|
       context "return_item has an acceptance status of #{invalid_transition_status}" do
         it_behaves_like "an invalid state transition", invalid_transition_status, 'accepted'
       end
@@ -251,7 +256,7 @@ describe Spree::ReturnItem do
       end
     end
 
-    (all_acceptance_statuses - ['pending', 'manual_intervention_required']).each do |invalid_transition_status|
+    (all_acceptance_statuses - ['accepted', 'pending', 'manual_intervention_required']).each do |invalid_transition_status|
       context "return_item has an acceptance status of #{invalid_transition_status}" do
         it_behaves_like "an invalid state transition", invalid_transition_status, 'rejected'
       end
@@ -277,7 +282,7 @@ describe Spree::ReturnItem do
       end
     end
 
-    (all_acceptance_statuses - ['pending', 'manual_intervention_required']).each do |invalid_transition_status|
+    (all_acceptance_statuses - ['accepted', 'pending', 'manual_intervention_required']).each do |invalid_transition_status|
       context "return_item has an acceptance status of #{invalid_transition_status}" do
         it_behaves_like "an invalid state transition", invalid_transition_status, 'accepted'
       end
@@ -303,7 +308,7 @@ describe Spree::ReturnItem do
       end
     end
 
-    (all_acceptance_statuses - ['pending']).each do |invalid_transition_status|
+    (all_acceptance_statuses - ['accepted', 'pending', 'manual_intervention_required']).each do |invalid_transition_status|
       context "return_item has an acceptance status of #{invalid_transition_status}" do
         it_behaves_like "an invalid state transition", invalid_transition_status, 'manual_intervention_required'
       end


### PR DESCRIPTION
When a ReturnItem is received, attempt to accept it as well. Since the received hook is called when a customer return is created, associated return items will only ever be in a pending state for exceptional cases.
