### PR TITLE
Reimbursement updates 2

### DIFF
--- a/backend/app/views/spree/admin/customer_returns/_reimbursements_table.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_reimbursements_table.html.erb
@@ -11,7 +11,7 @@
   <tbody>
     <% reimbursements.each do |reimbursement| %>
       <tr id="<%= spree_dom_id(reimbursement) %>" data-hook="reimbursement_row" class="<%= cycle('odd', 'even')%>">
-        <td><%= link_to reimbursement.number, url_for([:edit, :admin, @order, reimbursement]) %></td>
+        <td><%= link_to reimbursement.number, url_for([:admin, @order, reimbursement]) %></td>
         <td><%= reimbursement.display_total %></td>
         <td>
           <span class="state <%= reimbursement_status_color(reimbursement) %>">
@@ -20,7 +20,9 @@
         </td>
         <td><%= pretty_time(reimbursement.created_at) %></td>
         <td class="actions">
-          <%= link_to_edit_url url_for([:edit, :admin, @order, reimbursement]), title: "admin_edit_#{dom_id(reimbursement)}", no_text: true %>
+          <% if !reimbursement.reimbursed? %>
+            <%= link_to_edit_url url_for([:edit, :admin, @order, reimbursement]), title: "admin_edit_#{dom_id(reimbursement)}", no_text: true %>
+          <% end %>
         </td>
       </tr>
     <% end %>

--- a/backend/app/views/spree/admin/payments/index.html.erb
+++ b/backend/app/views/spree/admin/payments/index.html.erb
@@ -27,7 +27,7 @@
   <% if @refunds.any? %>
     <fieldset data-hook="payment_list" class="no-border-bottom">
       <legend align="center"><%= Spree.t(:refunds) %></legend>
-      <%= render :partial => 'refunds', :locals => { :refunds => @refunds } %>
+      <%= render :partial => 'spree/admin/shared/refunds', :locals => { :refunds => @refunds, show_actions: true } %>
     </fieldset>
   <% end %>
 

--- a/backend/app/views/spree/admin/reimbursements/edit.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/edit.html.erb
@@ -58,10 +58,12 @@
     </tbody>
   </table>
   <div class="form-buttons filter-actions actions" data-hook="buttons">
-    <%= button_to [:perform, :admin, @order, @reimbursement], {class: 'button fa fa-reply', method: 'post'} do %>
-      <%= Spree.t(:reimburse) %>
+    <% if !@reimbursement.reimbursed? %>
+      <%= button_to [:perform, :admin, @order, @reimbursement], {class: 'button fa fa-reply', method: 'post'} do %>
+        <%= Spree.t(:reimburse) %>
+      <% end %>
+      <span class="or"><%= Spree.t(:or) %></span>
+      <%= button_link_to Spree.t('actions.cancel'), url_for([:admin, @order, @reimbursement.customer_return]), :icon => 'remove' %>
     <% end %>
-    <span class="or"><%= Spree.t(:or) %></span>
-    <%= button_link_to Spree.t('actions.cancel'), url_for([:admin, @order, @reimbursement.customer_return]), :icon => 'remove' %>
   </div>
 </fieldset>

--- a/backend/app/views/spree/admin/reimbursements/show.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/show.html.erb
@@ -1,0 +1,43 @@
+<%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Customer Returns' } %>
+
+<% content_for :page_title do %>
+  <i class="fa fa-arrow-right"></i> <%= Spree.t(:reimbursement) %> #<%= @reimbursement.number %>
+<% end %>
+
+<% content_for :page_actions do %>
+  <li><%= button_link_to Spree.t(:back_to_customer_return), url_for([:admin, @order, @reimbursement.customer_return]), :icon => 'arrow-left' %></li>
+<% end %>
+
+<%= render :partial => 'spree/shared/error_messages', :locals => { :target => @reimbursement } %>
+
+<fieldset class='no-border-bottom'>
+  <legend align='center'><%= Spree.t(:return_items) %></legend>
+  <table class="index reimbursement-return-items-table">
+    <thead>
+      <tr>
+        <th><%= Spree.t(:product) %></th>
+        <th><%= Spree.t(:inventory_state) %></th>
+        <th><%= Spree.t(:total) %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @reimbursement.return_items.each do |return_item| %>
+        <tr>
+          <td>
+            <div class="variant-name"><%= return_item.inventory_unit.variant.name %></div>
+            <div class="variant-options"><%= return_item.inventory_unit.variant.options_text %></div>
+          </td>
+          <td class="align-center"><%= return_item.inventory_unit.state.humanize %></td>
+          <td class="align-center">
+            <%= return_item.display_total %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</fieldset>
+
+<fieldset class="no-border-bottom">
+  <legend align='center'><%= Spree.t(:refunds) %></legend>
+  <%= render :partial => 'spree/admin/shared/refunds', :locals => { :refunds => @reimbursement.refunds, show_actions: false } %>
+</fieldset>

--- a/backend/app/views/spree/admin/shared/_refunds.html.erb
+++ b/backend/app/views/spree/admin/shared/_refunds.html.erb
@@ -7,7 +7,9 @@
       <th><%= Spree.t(:payment_method) %></th>
       <th><%= Spree.t(:transaction_id) %></th>
       <th><%= Spree.t(:reason) %></th>
-      <th class="actions"></th>
+      <% if show_actions %>
+        <th class="actions"></th>
+      <% end %>
     </tr>
   </thead>
   <tbody>
@@ -19,9 +21,11 @@
         <td class="align-center"><%= payment_method_name(refund.payment) %></td>
         <td class="align-center"><%= refund.transaction_id %></td>
         <td class="align-center"><%= truncate(refund.reason.name, length: 100) %></td>
-        <td class="actions">
-          <%= link_to_with_icon 'edit', Spree.t(:edit), edit_admin_order_payment_refund_path(refund.payment.order, refund.payment, refund), no_text: true %>
-        </td>
+        <% if show_actions %>
+          <td class="actions">
+            <%= link_to_with_icon 'edit', Spree.t(:edit), edit_admin_order_payment_refund_path(refund.payment.order, refund.payment, refund), no_text: true %>
+          </td>
+        <% end %>
       </tr>
     <% end %>
   </tbody>

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -104,7 +104,7 @@ Spree::Core::Engine.add_routes do
         resources :refunds, only: [:new, :edit, :create, :update]
       end
 
-      resources :reimbursements, only: [:create, :edit] do
+      resources :reimbursements, only: [:create, :edit, :show] do
         member do
           post :perform
         end

--- a/core/app/models/spree/reimbursement.rb
+++ b/core/app/models/spree/reimbursement.rb
@@ -70,7 +70,9 @@ module Spree
     end
 
     def calculated_total
-      return_items.to_a.sum(&:total)
+      # rounding down to handle edge cases for consecutive partial returns where rounding
+      # might cause us to try to reimburse more than was originally billed
+      return_items.to_a.sum(&:total).round(2, :down)
     end
 
     def paid_amount

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1061,6 +1061,7 @@ en:
     return_authorization_updated: Return authorization updated
     return_authorizations: Return Authorizations
     return_item_time_period_ineligible: Return item is outside the eligible time period
+    return_items: Return Items
     return_items_cannot_be_associated_with_multiple_orders: Return items cannot be associated with multiple orders.
     return_number: Return Number
     return_quantity: Return Quantity

--- a/core/spec/models/spree/reimbursement_performer_spec.rb
+++ b/core/spec/models/spree/reimbursement_performer_spec.rb
@@ -5,6 +5,8 @@ describe Spree::ReimbursementPerformer do
   let(:reimbursement) { create(:reimbursement, return_items_count: 1) }
   let(:payment) { reimbursement.order.payments.first }
 
+  let!(:default_refund_reason) { Spree::RefundReason.find_or_create_by!(name: Spree::RefundReason::RETURN_PROCESSING_REASON, mutable: false) }
+
   before do
     reimbursement.update!(total: reimbursement.calculated_total)
   end

--- a/core/spec/models/spree/reimbursement_performer_spec.rb
+++ b/core/spec/models/spree/reimbursement_performer_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+describe Spree::ReimbursementPerformer do
+
+  let(:reimbursement) { create(:reimbursement, return_items_count: 1) }
+  let(:payment) { reimbursement.order.payments.first }
+
+  before do
+    reimbursement.update!(total: reimbursement.calculated_total)
+  end
+
+  describe '.simulate' do
+    subject { Spree::ReimbursementPerformer.simulate(reimbursement) }
+
+    it 'returns an array of readonly refunds' do
+      expect(subject).to be_an Array
+      expect(subject.map(&:class)).to eq [Spree::Refund]
+      expect(subject.map(&:readonly?)).to be_true
+    end
+
+    context 'when no credit is allowed on the payment' do
+      before do
+        Spree::Payment.any_instance.should_receive(:credit_allowed).and_return 0
+      end
+
+      it 'returns an empty array' do
+        expect(subject).to eq []
+      end
+    end
+  end
+
+  describe '.perform' do
+    subject { Spree::ReimbursementPerformer.perform(reimbursement) }
+
+    it 'returns an array refunds' do
+      expect(subject).to be_an Array
+      expect(subject.map(&:class)).to eq [Spree::Refund]
+    end
+
+    it 'performs the refund' do
+      expect {
+        subject
+      }.to change { payment.refunds.count }.by(1)
+      expect(payment.refunds.sum(:amount)).to eq reimbursement.return_items.to_a.sum(&:total)
+    end
+
+    context 'when no credit is allowed on the payment' do
+      before do
+        Spree::Payment.any_instance.should_receive(:credit_allowed).and_return 0
+      end
+
+      it 'returns an empty array' do
+        expect(subject).to eq []
+      end
+
+      it 'performs the refund' do
+        expect {
+          subject
+        }.to_not change { payment.refunds.count }
+      end
+    end
+  end
+
+end

--- a/core/spec/models/spree/reimbursement_spec.rb
+++ b/core/spec/models/spree/reimbursement_spec.rb
@@ -120,8 +120,8 @@ describe Spree::Reimbursement do
         return_item.reload
         expect(return_item.included_tax_total).to be < 0
         expect(return_item.included_tax_total).to eq line_item.included_tax_total
-        expect(reimbursement.total).to eq line_item.pre_tax_amount
-        expect(Spree::Refund.last.amount).to eq line_item.pre_tax_amount
+        expect(reimbursement.total).to eq line_item.pre_tax_amount.round(2, :down)
+        expect(Spree::Refund.last.amount).to eq line_item.pre_tax_amount.round(2, :down)
       end
     end
 
@@ -152,4 +152,20 @@ describe Spree::Reimbursement do
     end
   end
 
+  describe "#calculated_total" do
+    context 'with return item amounts that would round up' do
+      let(:reimbursement) { Spree::Reimbursement.new }
+
+      subject { reimbursement.calculated_total }
+
+      before do
+        reimbursement.return_items << Spree::ReturnItem.new(pre_tax_amount: 10.003)
+        reimbursement.return_items << Spree::ReturnItem.new(pre_tax_amount: 10.003)
+      end
+
+      it 'rounds down' do
+        expect(subject).to eq 20
+      end
+    end
+  end
 end


### PR DESCRIPTION
Specs for ReimbursementPerformer
- Add specs for ReimbursementPerformer

Reimbursement Admin UI updates
- Don't show edit button for reimbursement if reimbursement has been finalized
- Add an admin reimbursements show page

Fix rounding issue
- Add some rounding in reimbursements to handle edge cases where multiple consecutive partial refunds
  on the same order might result in rounding errors where we'd reimburse more than was originally
  billed.

I have these as separate commits since they're separate issues but let me know if you'd prefer me to squash them all into a single commit.
