### PR TITLE
Don't crash if there is no address to associate

### DIFF
--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -264,7 +264,7 @@ module Spree
           end
 
           def persist_user_address!
-            if !self.temporary_address && self.user && self.user.respond_to?(:persist_order_address)
+            if !self.temporary_address && self.user && self.user.respond_to?(:persist_order_address) && self.bill_address_id
               self.user.persist_order_address(self)
             end
           end

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -191,10 +191,23 @@ describe Spree::Order do
         order.state.should == "delivery"
       end
 
+      it "does not call persist_order_address if there is no address on the order" do
+        # otherwise, it will crash
+        order.stub(:ensure_available_shipping_rates => true)
+
+        order.user = FactoryGirl.create(:user)
+        order.save!
+
+        expect(order.user).to_not receive(:persist_order_address).with(order)
+        order.next!
+      end
+
       it "calls persist_order_address on the order's user" do
         order.stub(:ensure_available_shipping_rates => true)
 
         order.user = FactoryGirl.create(:user)
+        order.ship_address = FactoryGirl.create(:address)
+        order.bill_address = FactoryGirl.create(:address)
         order.save!
 
         expect(order.user).to receive(:persist_order_address).with(order)


### PR DESCRIPTION
Rather, just do nothing. This prevents a crash we've seen in production at 
Bonobos.
