### PR TITLE
Tiered promotion calculator

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/promotions.js
+++ b/backend/app/assets/javascripts/spree/backend/promotions.js
@@ -40,17 +40,17 @@ var initProductActions = function () {
   var tierInputNameTemplate = Handlebars.compile($('#tier-input-name').html());
 
   var originalTiers = $('.js-original-tiers').data('original-tiers');
-  $.each(originalTiers, function(base, percent) {
+  $.each(originalTiers, function(base, value) {
     var fieldName = tierInputNameTemplate({base: base}).trim();
     $('.js-tiers').append(tierFieldsTemplate({
       baseField: {value: base},
-      percentField: {name: fieldName, value: percent}
+      valueField: {name: fieldName, value: value}
     }));
   });
 
   $(document).on('click', '.js-add-tier', function(event) {
     event.preventDefault();
-    $('.js-tiers').append(tierFieldsTemplate({percentField: {name: null}}));
+    $('.js-tiers').append(tierFieldsTemplate({valueField: {name: null}}));
   });
 
   $(document).on('click', '.js-remove-tier', function(event) {
@@ -58,8 +58,8 @@ var initProductActions = function () {
   });
 
   $(document).on('change', '.js-base-input', function(event) {
-    var percentInput = $(this).parents('.tier').find('.js-percent-input');
-    percentInput.attr('name', tierInputNameTemplate({base: $(this).val()}).trim());
+    var valueInput = $(this).parents('.tier').find('.js-value-input');
+    valueInput.attr('name', tierInputNameTemplate({base: $(this).val()}).trim());
   });
 
   //

--- a/backend/app/assets/javascripts/spree/backend/promotions.js
+++ b/backend/app/assets/javascripts/spree/backend/promotions.js
@@ -34,6 +34,35 @@ var initProductActions = function () {
   });
 
   //
+  // Tiered Calculator
+  //
+  var tierFieldsTemplate = Handlebars.compile($('#tier-fields-template').html());
+  var tierInputNameTemplate = Handlebars.compile($('#tier-input-name').html());
+
+  var originalTiers = $('.js-original-tiers').data('original-tiers');
+  $.each(originalTiers, function(base, percent) {
+    var fieldName = tierInputNameTemplate({base: base}).trim();
+    $('.js-tiers').append(tierFieldsTemplate({
+      baseField: {value: base},
+      percentField: {name: fieldName, value: percent}
+    }));
+  });
+
+  $(document).on('click', '.js-add-tier', function(event) {
+    event.preventDefault();
+    $('.js-tiers').append(tierFieldsTemplate({percentField: {name: null}}));
+  });
+
+  $(document).on('click', '.js-remove-tier', function(event) {
+    $(this).parents('.tier').remove();
+  });
+
+  $(document).on('change', '.js-base-input', function(event) {
+    var percentInput = $(this).parents('.tier').find('.js-percent-input');
+    percentInput.attr('name', tierInputNameTemplate({base: $(this).val()}).trim());
+  });
+
+  //
   // CreateLineItems Promotion Action
   //
   (function () {

--- a/backend/app/assets/javascripts/spree/backend/promotions.js
+++ b/backend/app/assets/javascripts/spree/backend/promotions.js
@@ -36,31 +36,33 @@ var initProductActions = function () {
   //
   // Tiered Calculator
   //
-  var tierFieldsTemplate = Handlebars.compile($('#tier-fields-template').html());
-  var tierInputNameTemplate = Handlebars.compile($('#tier-input-name').html());
+  if ($('#tier-fields-template').length && $('#tier-input-name').length) {
+    var tierFieldsTemplate = Handlebars.compile($('#tier-fields-template').html());
+    var tierInputNameTemplate = Handlebars.compile($('#tier-input-name').html());
 
-  var originalTiers = $('.js-original-tiers').data('original-tiers');
-  $.each(originalTiers, function(base, value) {
-    var fieldName = tierInputNameTemplate({base: base}).trim();
-    $('.js-tiers').append(tierFieldsTemplate({
-      baseField: {value: base},
-      valueField: {name: fieldName, value: value}
-    }));
-  });
+    var originalTiers = $('.js-original-tiers').data('original-tiers');
+    $.each(originalTiers, function(base, value) {
+      var fieldName = tierInputNameTemplate({base: base}).trim();
+      $('.js-tiers').append(tierFieldsTemplate({
+        baseField: {value: base},
+        valueField: {name: fieldName, value: value}
+      }));
+    });
 
-  $(document).on('click', '.js-add-tier', function(event) {
-    event.preventDefault();
-    $('.js-tiers').append(tierFieldsTemplate({valueField: {name: null}}));
-  });
+    $(document).on('click', '.js-add-tier', function(event) {
+      event.preventDefault();
+      $('.js-tiers').append(tierFieldsTemplate({valueField: {name: null}}));
+    });
 
-  $(document).on('click', '.js-remove-tier', function(event) {
-    $(this).parents('.tier').remove();
-  });
+    $(document).on('click', '.js-remove-tier', function(event) {
+      $(this).parents('.tier').remove();
+    });
 
-  $(document).on('change', '.js-base-input', function(event) {
-    var valueInput = $(this).parents('.tier').find('.js-value-input');
-    valueInput.attr('name', tierInputNameTemplate({base: $(this).val()}).trim());
-  });
+    $(document).on('change', '.js-base-input', function(event) {
+      var valueInput = $(this).parents('.tier').find('.js-value-input');
+      valueInput.attr('name', tierInputNameTemplate({base: $(this).val()}).trim());
+    });
+  }
 
   //
   // CreateLineItems Promotion Action

--- a/backend/app/assets/stylesheets/spree/backend/sections/_promotions.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_promotions.scss
@@ -34,6 +34,25 @@
     margin-bottom: 0;
   }
 
+  .tier {
+    position: relative;
+    padding-bottom: 10px;
+
+    .remove {
+      position: absolute;
+      left: -15px;
+      top: 10px;
+
+      &:hover {
+        color: #c60f13;
+      }
+    }
+  }
+
+  .right-align {
+    text-align: right;
+  }
+
   .field {
     padding-bottom: 10px;
 

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -32,6 +32,45 @@ textarea {
   width: 100%;
 }
 
+.input-group {
+  position: relative;
+  display: table;
+  border-collapse: separate;
+
+  .form-control,
+  .input-group-addon {
+    display: table-cell;
+
+    &:first-child {
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
+    }
+    &:last-child {
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+    }
+  }
+
+  .form-control {
+    width: 100%;
+  }
+
+  .input-group-addon {
+    padding: 6px 10px;
+    border: 1px solid #cee1f4;
+    background: #eff5fc;
+    border-radius: 3px;
+
+    &:first-child {
+      border-right: none;
+    }
+
+    &:last-child {
+      border-left: none;
+    }
+  }
+}
+
 label {
   font-weight: 600;
   text-transform: uppercase;

--- a/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
@@ -35,6 +35,14 @@
   margin-right: -10px;
 }
 
+.container .column,
+.container .columns {
+  // Float container right instead of left.
+  .right {
+    float: right;
+  }
+}
+
 // Header
 //---------------------------------------------------
 #header {

--- a/backend/app/views/spree/admin/promotions/actions/_create_adjustment.html.erb
+++ b/backend/app/views/spree/admin/promotions/actions/_create_adjustment.html.erb
@@ -13,14 +13,15 @@
 
   <% unless promotion_action.new_record? %>
     <div class="settings field omega four columns">
-      <% promotion_action.calculator.preferences.keys.map do |key| %>
-        <% field_name = "#{param_prefix}[calculator_attributes][preferred_#{key}]" %>
-        <%= label_tag field_name, Spree.t(key.to_s) %>
-        <%= preference_field_tag(field_name,
-                                 promotion_action.calculator.get_preference(key),
-                                 :type => promotion_action.calculator.preference_type(key)) %>
+      <% type_name = promotion_action.calculator.type.demodulize.underscore %>
+      <% if lookup_context.exists?("fields",
+          ["spree/admin/promotions/calculators/#{type_name}"], true) %>
+        <%= render "spree/admin/promotions/calculators/#{type_name}/fields",
+          calculator: promotion_action.calculator, prefix: param_prefix %>
+      <% else %>
+        <%= render "spree/admin/promotions/calculators/default_fields",
+          calculator: promotion_action.calculator, prefix: param_prefix %>
       <% end %>
-      <%= hidden_field_tag "#{param_prefix}[calculator_attributes][id]", promotion_action.calculator.id %>
     </div>
   <% end %>
 </div>

--- a/backend/app/views/spree/admin/promotions/actions/_create_adjustment.html.erb
+++ b/backend/app/views/spree/admin/promotions/actions/_create_adjustment.html.erb
@@ -22,6 +22,7 @@
         <%= render "spree/admin/promotions/calculators/default_fields",
           calculator: promotion_action.calculator, prefix: param_prefix %>
       <% end %>
+      <%= hidden_field_tag "#{param_prefix}[calculator_attributes][id]", promotion_action.calculator.id %>
     </div>
   <% end %>
 </div>

--- a/backend/app/views/spree/admin/promotions/calculators/_default_fields.html.erb
+++ b/backend/app/views/spree/admin/promotions/calculators/_default_fields.html.erb
@@ -1,0 +1,10 @@
+<% calculator.preferences.keys.map do |key| %>
+  <% field_name = "#{prefix}[calculator_attributes][preferred_#{key}]" %>
+  <%= label_tag field_name, Spree.t(key.to_s) %>
+  <%= preference_field_tag(
+    field_name,
+    calculator.get_preference(key),
+    type: calculator.preference_type(key)) %>
+<% end %>
+<%= hidden_field_tag "#{prefix}[calculator_attributes][id]", calculator.id %>
+

--- a/backend/app/views/spree/admin/promotions/calculators/_default_fields.html.erb
+++ b/backend/app/views/spree/admin/promotions/calculators/_default_fields.html.erb
@@ -6,5 +6,3 @@
     calculator.get_preference(key),
     type: calculator.preference_type(key)) %>
 <% end %>
-<%= hidden_field_tag "#{prefix}[calculator_attributes][id]", calculator.id %>
-

--- a/backend/app/views/spree/admin/promotions/calculators/tiered_flat_rate/_fields.html.erb
+++ b/backend/app/views/spree/admin/promotions/calculators/tiered_flat_rate/_fields.html.erb
@@ -1,9 +1,9 @@
-<%= label_tag "#{prefix}[calculator_attributes][preferred_base_percent]",
-  Spree.t(:base_percent) %>
+<%= label_tag "#{prefix}[calculator_attributes][preferred_base_amount]",
+  Spree.t(:base_amount) %>
 <%= preference_field_tag(
-  "#{prefix}[calculator_attributes][preferred_base_percent]",
-  calculator.preferred_base_percent,
-  type: calculator.preference_type(:base_percent)) %>
+  "#{prefix}[calculator_attributes][preferred_base_amount]",
+  calculator.preferred_base_amount,
+  type: calculator.preference_type(:base_amount)) %>
 
 <%= label_tag nil, Spree.t(:tiers) %>
 <%= content_tag :div, nil, class: "hidden js-original-tiers",
@@ -26,11 +26,12 @@
     </div>
     <div class="two columns alpha omega right">
       <div class="input-group">
-        <input class="js-value-input form-control right-align"
+        <span class="input-group-addon">$</span>
+        <input class="js-value-input form-control"
           name="{{valueField.name}}" type="text" value={{valueField.value}}>
-        <span class="input-group-addon">%</span>
       </div>
     </div>
     <div class="clear"></div>
   </div>
 </script>
+

--- a/backend/app/views/spree/admin/promotions/calculators/tiered_percent/_fields.html.erb
+++ b/backend/app/views/spree/admin/promotions/calculators/tiered_percent/_fields.html.erb
@@ -1,0 +1,36 @@
+<%= label_tag "#{prefix}[calculator_attributes][preferred_base_percent]",
+  Spree.t(:base_percent) %>
+<%= preference_field_tag(
+  "#{prefix}[calculator_attributes][preferred_base_percent]",
+  calculator.preferred_base_percent,
+  type: calculator.preference_type(:base_percent)) %>
+
+<%= label_tag nil, Spree.t(:tiers) %>
+<%= content_tag :div, nil, class: "hidden js-original-tiers",
+  data: { :'original-tiers' => Hash[calculator.preferred_tiers.sort] } %>
+<div class="js-tiers"></div>
+<button class="fa fa-plus button js-add-tier"><%= Spree.t(:add) %></button>
+
+<script type="text/x-handlebars-template" id="tier-input-name">
+  <%= prefix %>[calculator_attributes][preferred_tiers][{{base}}]
+</script>
+
+<script type="text/x-handlebars-template" id="tier-fields-template">
+  <div class="fullwidth tier">
+    <a class="fa fa-trash remove js-remove-tier"></a>
+    <div class="two columns alpha omega">
+      <div class="input-group">
+        <span class="input-group-addon">$</span>
+        <input class="js-base-input form-control" type="text" value={{baseField.value}}>
+      </div>
+    </div>
+    <div class="two columns alpha omega right">
+      <div class="input-group">
+        <input class="js-percent-input form-control right-align"
+          name="{{percentField.name}}" type="text" value={{percentField.value}}>
+        <span class="input-group-addon">%</span>
+      </div>
+    </div>
+    <div class="clear"></div>
+  </div>
+</script>

--- a/backend/spec/features/admin/promotions/tiered_calculator_spec.rb
+++ b/backend/spec/features/admin/promotions/tiered_calculator_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+feature "Tiered Calculator Promotions" do
+  stub_authorization!
+
+  let(:promotion) { create :promotion }
+
+  background do
+    visit spree.edit_admin_promotion_path(promotion)
+  end
+
+  scenario "adding a tiered percent calculator", js: true do
+    select2 "Create whole-order adjustment", from: "Add action of type"
+    within('#action_fields') { click_button "Add" }
+
+    select2 "Tiered Percent", from: "Calculator"
+    within('#actions_container') { click_button "Update" }
+
+    within("#actions_container .settings") do
+      expect(page).to have_content("BASE PERCENT")
+      expect(page).to have_content("TIERS")
+
+      click_button "Add"
+    end
+
+    fill_in "Base Percent", with: 5
+
+    within(".tier") do
+      find("input:last-child").set(100)
+      find("input:first-child").set(10)
+    end
+
+    within('#actions_container') { click_button "Update" }
+
+    first_action = promotion.actions.first
+    expect(first_action.class).to eq Spree::Promotion::Actions::CreateAdjustment
+
+    first_action_calculator = first_action.calculator
+    expect(first_action_calculator.class).to eq Spree::Calculator::TieredPercent
+    expect(first_action_calculator.preferred_base_percent).to eq 5
+    expect(first_action_calculator.preferred_tiers).to eq Hash[100.0 => 10.0]
+  end
+
+  context "with an existing tiered flat rate calculator" do
+    let(:promotion) { create :promotion, :with_order_adjustment }
+
+    background do
+      action = promotion.actions.first
+
+      action.calculator = Spree::Calculator::TieredFlatRate.new
+      action.calculator.preferred_base_amount = 5
+      action.calculator.preferred_tiers = Hash[100 => 10, 200 => 15, 300 => 20]
+      action.calculator.save!
+
+      visit spree.edit_admin_promotion_path(promotion)
+    end
+
+    scenario "deleting a tier", js: true do
+      within(".tier:nth-child(2)") do
+        find(".remove").click
+      end
+
+      within('#actions_container') { click_button "Update" }
+
+      calculator = promotion.actions.first.calculator
+      expect(calculator.preferred_tiers).to eq Hash[100.0 => 10.0, 300.0 => 20.0]
+    end
+  end
+end

--- a/core/app/models/spree/calculator/tiered_flat_rate.rb
+++ b/core/app/models/spree/calculator/tiered_flat_rate.rb
@@ -1,0 +1,37 @@
+require_dependency 'spree/calculator'
+
+module Spree
+  class Calculator::TieredFlatRate < Calculator
+    preference :base_amount, :decimal, default: 0
+    preference :tiers, :hash, default: {}
+
+    before_validation do
+      # Convert tier values to decimals. Strings don't do us much good.
+      if preferred_tiers.is_a?(Hash)
+        self.preferred_tiers = Hash[*preferred_tiers.flatten.map(&:to_f)]
+      end
+    end
+
+    validate :preferred_tiers_content
+
+    def self.description
+      Spree.t(:tiered_flat_rate)
+    end
+
+    def compute(object)
+      base, amount = preferred_tiers.sort.reverse.detect{ |b,_| object.amount >= b }
+      amount || preferred_base_amount
+    end
+
+    private
+    def preferred_tiers_content
+      if preferred_tiers.is_a? Hash
+        unless preferred_tiers.keys.all?{ |k| k.is_a?(Numeric) && k > 0 }
+          errors.add(:base, :keys_should_be_positive_number)
+        end
+      else
+        errors.add(:preferred_tiers, :should_be_hash)
+      end
+    end
+  end
+end

--- a/core/app/models/spree/calculator/tiered_percent.rb
+++ b/core/app/models/spree/calculator/tiered_percent.rb
@@ -2,17 +2,43 @@ require_dependency 'spree/calculator'
 
 module Spree
   class Calculator::TieredPercent < Calculator
+    preference :base_percent, :decimal, default: 0
     preference :tiers, :hash, default: {}
 
-    validates :preferred_tiers, length: { maximum: 5 }
+    before_validation do
+      # Convert tier values to decimals. Strings don't do us much good.
+      if preferred_tiers.is_a?(Hash)
+        self.preferred_tiers = Hash[*preferred_tiers.flatten.map(&:to_f)]
+      end
+    end
+
+    validates :preferred_base_percent, numericality: {
+      greater_than_or_equal_to: 0,
+      less_than_or_equal_to: 100
+    }
+    validate :preferred_tiers_content
 
     def self.description
       Spree.t(:tiered_percent)
     end
 
     def compute(object)
-      range, percent = preferred_tiers.detect{ |r,_| r === object.amount }
-      (object.amount * (percent || 0) / 100).round(2)
+      base, percent = preferred_tiers.sort.reverse.detect{ |b,_| object.amount >= b }
+      (object.amount * (percent || preferred_base_percent) / 100).round(2)
+    end
+
+    private
+    def preferred_tiers_content
+      if preferred_tiers.is_a? Hash
+        unless preferred_tiers.keys.all?{ |k| k.is_a?(Numeric) && k > 0 }
+          errors.add(:base, :keys_should_be_positive_number)
+        end
+        unless preferred_tiers.values.all?{ |k| k.is_a?(Numeric) && k >= 0 && k <= 100 }
+          errors.add(:base, :values_should_be_percent)
+        end
+      else
+        errors.add(:preferred_tiers, :should_be_hash)
+      end
     end
   end
 end

--- a/core/app/models/spree/calculator/tiered_percent.rb
+++ b/core/app/models/spree/calculator/tiered_percent.rb
@@ -1,0 +1,18 @@
+require_dependency 'spree/calculator'
+
+module Spree
+  class Calculator::TieredPercent < Calculator
+    preference :tiers, :hash, default: {}
+
+    validates :preferred_tiers, length: { maximum: 5 }
+
+    def self.description
+      Spree.t(:tiered_percent)
+    end
+
+    def compute(object)
+      range, percent = preferred_tiers.detect{ |r,_| r === object.amount }
+      (object.amount * (percent || 0) / 100).round(2)
+    end
+  end
+end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -11,6 +11,8 @@ en:
         phone: Phone
         state: State
         zipcode: Zip Code
+      spree/calculator/tiered_percent:
+        preferred_tiers: Tiers
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -248,6 +250,12 @@ en:
         other: Zones
     errors:
       models:
+        spree/calculator/tiered_percent:
+          attributes:
+            preferred_tiers:
+              too_long:
+                one: "has a maximum of 1 tier"
+                other: "has a maximum of %{count} tiers"
         spree/classification:
           attributes:
             taxon_id:
@@ -1206,6 +1214,8 @@ en:
     there_are_no_items_for_this_order: There are no items for this order. Please add an item to the order to continue.
     there_were_problems_with_the_following_fields: There were problems with the following fields
     thumbnail: Thumbnail
+    tiers: Tiers
+    tiered_percent: Tiered Percent
     time: Time
     to_add_variants_you_must_first_define: To add variants, you must first define
     total: Total

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -11,6 +11,9 @@ en:
         phone: Phone
         state: State
         zipcode: Zip Code
+      spree/calculator/tiered_flat_rate:
+        preferred_base_amount: Base Amount
+        preferred_tiers: Tiers
       spree/calculator/tiered_percent:
         preferred_base_percent: Base Percent
         preferred_tiers: Tiers
@@ -251,6 +254,12 @@ en:
         other: Zones
     errors:
       models:
+        spree/calculator/tiered_flat_rate:
+          attributes:
+            base:
+              keys_should_be_positive_number: "Tier keys should all be numbers larger than 0"
+            preferred_tiers:
+              should_be_hash: "should be a hash"
         spree/calculator/tiered_percent:
           attributes:
             base:
@@ -472,6 +481,7 @@ en:
     backorderable: Backorderable
     backorders_allowed: backorders allowed
     balance_due: Balance Due
+    base_amount: Base Amount
     base_percent: Base Percent
     bill_address: Bill Address
     billing: Billing
@@ -1218,6 +1228,7 @@ en:
     there_were_problems_with_the_following_fields: There were problems with the following fields
     thumbnail: Thumbnail
     tiers: Tiers
+    tiered_flat_rate: Tiered Flat Rate
     tiered_percent: Tiered Percent
     time: Time
     to_add_variants_you_must_first_define: To add variants, you must first define

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -12,6 +12,7 @@ en:
         state: State
         zipcode: Zip Code
       spree/calculator/tiered_percent:
+        preferred_base_percent: Base Percent
         preferred_tiers: Tiers
       spree/country:
         iso: ISO
@@ -252,10 +253,11 @@ en:
       models:
         spree/calculator/tiered_percent:
           attributes:
+            base:
+              keys_should_be_positive_number: "Tier keys should all be numbers larger than 0"
+              values_should_be_percent: "Tier values should all be percentages between 0% and 100%"
             preferred_tiers:
-              too_long:
-                one: "has a maximum of 1 tier"
-                other: "has a maximum of %{count} tiers"
+              should_be_hash: "should be a hash"
         spree/classification:
           attributes:
             taxon_id:
@@ -470,6 +472,7 @@ en:
     backorderable: Backorderable
     backorders_allowed: backorders allowed
     balance_due: Balance Due
+    base_percent: Base Percent
     bill_address: Bill Address
     billing: Billing
     billing_address: Billing Address

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -48,7 +48,8 @@ module Spree
         app.config.spree.calculators.promotion_actions_create_adjustments = [
           Spree::Calculator::FlatPercentItemTotal,
           Spree::Calculator::FlatRate,
-          Spree::Calculator::FlexiRate
+          Spree::Calculator::FlexiRate,
+          Spree::Calculator::TieredPercent
         ]
 
         app.config.spree.calculators.add_class('promotion_actions_create_item_adjustments')

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -49,7 +49,8 @@ module Spree
           Spree::Calculator::FlatPercentItemTotal,
           Spree::Calculator::FlatRate,
           Spree::Calculator::FlexiRate,
-          Spree::Calculator::TieredPercent
+          Spree::Calculator::TieredPercent,
+          Spree::Calculator::TieredFlatRate
         ]
 
         app.config.spree.calculators.add_class('promotion_actions_create_item_adjustments')

--- a/core/spec/models/spree/calculator/tiered_flat_rate_spec.rb
+++ b/core/spec/models/spree/calculator/tiered_flat_rate_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe Spree::Calculator::TieredFlatRate do
+  let(:calculator) { Spree::Calculator::TieredFlatRate.new }
+
+  describe "#valid?" do
+    subject { calculator.valid? }
+    context "when tiers is not a hash" do
+      before { calculator.preferred_tiers = ["nope"] }
+      it { should be false }
+    end
+    context "when tiers is a hash" do
+      context "and one of the keys is not a positive number" do
+        before { calculator.preferred_tiers = { "nope" => 20 } }
+        it { should be false }
+      end
+    end
+  end
+
+  describe "#compute" do
+    let(:line_item) { mock_model Spree::LineItem, amount: amount }
+    before do
+      calculator.preferred_base_amount = 10
+      calculator.preferred_tiers = {
+        100 => 15,
+        200 => 20
+      }
+    end
+    subject { calculator.compute(line_item) }
+    context "when amount falls within the first tier" do
+      let(:amount) { 50 }
+      it { should eq 10 }
+    end
+    context "when amount falls within the second tier" do
+      let(:amount) { 150 }
+      it { should eq 15 }
+    end
+  end
+end
+

--- a/core/spec/models/spree/calculator/tiered_percent_spec.rb
+++ b/core/spec/models/spree/calculator/tiered_percent_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe Spree::Calculator::TieredPercent do
+  let(:calculator) { Spree::Calculator::TieredPercent.new }
+
+  describe "#valid?" do
+    subject { calculator.valid? }
+    context "when there are more than 5 tiers" do
+      before do
+        calculator.preferred_buckets = {
+          (0..100) => 10,
+          (100..200) => 15,
+          (200..300) => 20,
+          (300..400) => 25,
+          (400..500) => 30,
+          (500..600) => 35
+        }
+      end
+      it { should be false }
+    end
+  end
+
+  describe "#compute" do
+    let(:line_item) { mock_model Spree::LineItem, amount: amount }
+    before do
+      calculator.preferred_buckets = {
+        (0..100) => 10,
+        (100..200) => 15,
+        (200..300) => 20
+      }
+    end
+    subject { calculator.compute(line_item) }
+    context "when amount falls within the first tier" do
+      let(:amount) { 50 }
+      it { should eq 5 }
+    end
+    context "when amount falls within the second tier" do
+      let(:amount) { 150 }
+      it { should eq 22 }
+    end
+    context "when amount falls in two tiers" do
+      let(:amount) { 100 }
+      it { should eq 10 }
+    end
+    context "when amount falls outside of all tiers" do
+      let(:amount) { 500 }
+      it { should eq 0 }
+    end
+  end
+end


### PR DESCRIPTION
Two simple calculators that make it possible to offer tiered discounts in promotions. Basically, they provide the ability to have a promotion that will adjust it's rate based on the order total. For example, you could set up a tiered percentage discount as follows:

| Order Total | Discount |
| --- | --- |
| $50 | 5% |
| $100 | 10% |
| $250 | 25% |

Then for an order costing $127, the customer would receive a $12.70 (10%) discount. However, if the customer removed a couple of items from their cart, dropping their total to $68, the discount would only be $3.40 (5%). The calculator supports a theoretically unlimited number of tiers.

In order to make the admin usable, I updated the existing calculator views to be easily extensible. (By dynamically rendering a different partial based on which type of calculator was selected.)
