### PR TITLE
Test to see if a better coupon exists already

### DIFF
--- a/core/app/models/spree/promotion_handler/coupon.rb
+++ b/core/app/models/spree/promotion_handler/coupon.rb
@@ -81,8 +81,14 @@ module Spree
           order.persist_totals
           self.success = Spree.t(:coupon_code_applied)
         else
-          # if the promotion was created after the order
-          self.error = Spree.t(:coupon_code_not_found)
+          # if the promotion exists on an order, but wasn't found above,
+          # we've already selected a better promotion
+          if order.promotions.with_coupon_code(order.coupon_code)
+            self.error = Spree.t(:coupon_code_better_exists)
+          else
+            # if the promotion was created after the order
+            self.error = Spree.t(:coupon_code_not_found)
+          end
         end
       end
     end

--- a/core/spec/models/spree/promotion_handler/coupon_spec.rb
+++ b/core/spec/models/spree/promotion_handler/coupon_spec.rb
@@ -172,6 +172,19 @@ module Spree
               expect(coupon.successful?).to be_false
               expect(coupon.error).to eq Spree.t(:coupon_code_max_usage)
             end
+
+            context "when the a new coupon is less good" do
+              let!(:action_5) { Promotion::Actions::CreateAdjustment.create(promotion: promotion_5, calculator: calculator_5) }
+              let(:calculator_5) { Calculator::FlatRate.new(preferred_amount: 5) }
+              let!(:promotion_5) { Promotion.create name: "promo", :code => "5off"  }
+
+              it 'notifies of better deal' do
+                subject.apply
+                order.stub( { coupon_code: '5off' } )
+                coupon = Coupon.new(order).apply
+                expect(coupon.error).to eq Spree.t(:coupon_code_better_exists)
+              end
+            end
           end
         end
 


### PR DESCRIPTION
If we don't find the valid promo in all our places it could be
successfully applied, but it _is_ still on the order, it was accepted by
the order but a better one was used instead

This is #4790 rebased and pointed against master, instead of 2-2 stable.
