### PR TITLE
Fix duplicated promotion rule

### DIFF
--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -71,7 +71,6 @@ module Spree
           Spree::Promotion::Rules::FirstOrder,
           Spree::Promotion::Rules::UserLoggedIn,
           Spree::Promotion::Rules::OneUsePerUser,
-          Spree::Promotion::Rules::UserLoggedIn,
           Spree::Promotion::Rules::Taxon,
         ]
       end


### PR DESCRIPTION
I just notice UserLoggedIn promotion rule is duplicated. It was a merge error.
