### PR TITLE
Default credit card

### DIFF
--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -1,7 +1,7 @@
 module Spree
   class CreditCard < Spree::Base
     belongs_to :payment_method
-    belongs_to :user, class: Spree.user_class, foreign_key: 'user_id'
+    belongs_to :user, class_name: Spree.user_class, foreign_key: 'user_id'
     has_many :payments, as: :source
 
     before_save :set_last_digits

--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -1,9 +1,12 @@
 module Spree
   class CreditCard < Spree::Base
     belongs_to :payment_method
+    belongs_to :user, class: Spree.user_class, foreign_key: 'user_id'
     has_many :payments, as: :source
 
     before_save :set_last_digits
+
+    after_save :ensure_one_default
 
     attr_accessor :number, :verification_value, :encrypted_data
 
@@ -15,6 +18,7 @@ module Spree
     validate :expiry_not_in_the_past
 
     scope :with_payment_profile, -> { where('gateway_customer_profile_id IS NOT NULL') }
+    scope :default, -> { where(default: true) }
 
     # needed for some of the ActiveMerchant gateways (eg. SagePay)
     alias_attribute :brand, :cc_type
@@ -143,6 +147,15 @@ module Spree
 
     def require_card_numbers?
       !self.encrypted_data.present? && !self.has_payment_profile?
+    end
+
+    def ensure_one_default
+      if self.user_id && self.default
+        CreditCard.where(default: true).where.not(id: self.id).where(user_id: self.user_id).each do |ucc|
+          ucc.default = false
+          ucc.save!
+        end
+      end
     end
   end
 end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -16,7 +16,7 @@ module Spree
     end
 
     attr_reader :coupon_code
-    attr_accessor :temporary_address
+    attr_accessor :temporary_address, :temporary_credit_card
 
     if Spree.user_class
       belongs_to :user, class_name: Spree.user_class.to_s
@@ -337,6 +337,11 @@ module Spree
 
     def credit_cards
       credit_card_ids = payments.from_credit_card.pluck(:source_id).uniq
+      CreditCard.where(id: credit_card_ids)
+    end
+
+    def valid_credit_cards
+      credit_card_ids = payments.from_credit_card.valid.pluck(:source_id).uniq
       CreditCard.where(id: credit_card_ids)
     end
 

--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -89,9 +89,9 @@ module Spree
 
       def ensure_one_default
         if self.default
-          StockLocation.where.not(id: self.id).each do |stock_location|
+          StockLocation.where(default: true).where.not(id: self.id).each do |stock_location|
             stock_location.default = false
-            stock_location.save! if stock_location.changed?
+            stock_location.save!
           end
         end
       end

--- a/core/config/initializers/user_class_extensions.rb
+++ b/core/config/initializers/user_class_extensions.rb
@@ -5,22 +5,22 @@ Spree::Core::Engine.config.to_prepare do
       include Spree::UserReporting
       include Spree::UserApiAuthentication
       has_and_belongs_to_many :spree_roles,
-                              join_table: 'spree_roles_users',
-                              foreign_key: "user_id",
-                              class_name: "Spree::Role"
+                              :join_table => 'spree_roles_users',
+                              :foreign_key => "user_id",
+                              :class_name => "Spree::Role"
 
-      has_many :spree_orders, foreign_key: "user_id", class_name: "Spree::Order"
+      has_many :spree_orders, :foreign_key => "user_id", :class_name => "Spree::Order"
 
-      belongs_to :ship_address, class_name: 'Spree::Address'
-      belongs_to :bill_address, class_name: 'Spree::Address'
+      belongs_to :ship_address, :class_name => 'Spree::Address'
+      belongs_to :bill_address, :class_name => 'Spree::Address'
 
       # has_spree_role? simply needs to return true or false whether a user has a role or not.
       def has_spree_role?(role_in_question)
-        spree_roles.where(name: role_in_question.to_s).any?
+        spree_roles.where(:name => role_in_question.to_s).any?
       end
 
       def last_incomplete_spree_order
-        spree_orders.incomplete.where(created_by_id: self.id).order('created_at DESC').first
+        spree_orders.incomplete.where(:created_by_id => self.id).order('created_at DESC').first
       end
     end
   end

--- a/core/config/initializers/user_class_extensions.rb
+++ b/core/config/initializers/user_class_extensions.rb
@@ -5,22 +5,22 @@ Spree::Core::Engine.config.to_prepare do
       include Spree::UserReporting
       include Spree::UserApiAuthentication
       has_and_belongs_to_many :spree_roles,
-                              :join_table => 'spree_roles_users',
-                              :foreign_key => "user_id",
-                              :class_name => "Spree::Role"
+                              join_table: 'spree_roles_users',
+                              foreign_key: "user_id",
+                              class_name: "Spree::Role"
 
-      has_many :spree_orders, :foreign_key => "user_id", :class_name => "Spree::Order"
+      has_many :spree_orders, foreign_key: "user_id", class_name: "Spree::Order"
 
-      belongs_to :ship_address, :class_name => 'Spree::Address'
-      belongs_to :bill_address, :class_name => 'Spree::Address'
+      belongs_to :ship_address, class_name: 'Spree::Address'
+      belongs_to :bill_address, class_name: 'Spree::Address'
 
       # has_spree_role? simply needs to return true or false whether a user has a role or not.
       def has_spree_role?(role_in_question)
-        spree_roles.where(:name => role_in_question.to_s).any?
+        spree_roles.where(name: role_in_question.to_s).any?
       end
 
       def last_incomplete_spree_order
-        spree_orders.incomplete.where(:created_by_id => self.id).order('created_at DESC').first
+        spree_orders.incomplete.where(created_by_id: self.id).order('created_at DESC').first
       end
     end
   end

--- a/core/db/migrate/20140805171035_add_default_to_spree_credit_cards.rb
+++ b/core/db/migrate/20140805171035_add_default_to_spree_credit_cards.rb
@@ -1,0 +1,5 @@
+class AddDefaultToSpreeCreditCards < ActiveRecord::Migration
+  def change
+    add_column :spree_credit_cards, :default, :boolean, null: false, default: false
+  end
+end

--- a/core/db/migrate/20140805171219_make_existing_credit_cards_default.rb
+++ b/core/db/migrate/20140805171219_make_existing_credit_cards_default.rb
@@ -1,0 +1,10 @@
+class MakeExistingCreditCardsDefault < ActiveRecord::Migration
+  def up
+    # set the newest credit card for every user to be the default; SQL technique from
+    # http://stackoverflow.com/questions/121387/fetch-the-row-which-has-the-max-value-for-a-column
+    Spree::CreditCard.where.not(user_id: nil).joins("LEFT OUTER JOIN spree_credit_cards cc2 ON cc2.user_id = spree_credit_cards.user_id AND spree_credit_cards.created_at < cc2.created_at").where("cc2.user_id IS NULL").update_all(default: true)
+  end
+  def down
+    # do nothing
+  end
+end

--- a/core/lib/spree/core/user_payment_source.rb
+++ b/core/lib/spree/core/user_payment_source.rb
@@ -5,6 +5,7 @@ module Spree
 
       included do
         has_many :credit_cards, class_name: "Spree::CreditCard", foreign_key: :user_id
+        def default_credit_card; credit_cards.default.first; end
 
         def payment_sources
           credit_cards.with_payment_profile

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -329,4 +329,19 @@ describe Spree::CreditCard do
       am_card.verification_value.should == 123
     end
   end
+
+  it 'ensures only one credit card per user is default at a time' do
+    user = FactoryGirl.create(:user)
+    first = FactoryGirl.create(:credit_card, user: user, default: true)
+    second = FactoryGirl.create(:credit_card, user: user, default: true)
+
+    first.reload.default.should eq false
+    second.reload.default.should eq true
+
+    first.default = true
+    first.save!
+
+    first.reload.default.should eq true
+    second.reload.default.should eq false
+  end
 end

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -344,4 +344,12 @@ describe Spree::CreditCard do
     first.reload.default.should eq true
     second.reload.default.should eq false
   end
+
+  it 'allows default credit cards for different users' do
+    first = FactoryGirl.create(:credit_card, user: FactoryGirl.create(:user), default: true)
+    second = FactoryGirl.create(:credit_card, user: FactoryGirl.create(:user), default: true)
+
+    first.reload.default.should eq true
+    second.reload.default.should eq true
+  end
 end


### PR DESCRIPTION
This does the following:
- When an order is completed, associate its credit card to its user, and mark that card as default
- When an order gets to the payment step and doesn't have any payments, add the default card
