### PR TITLE
RMA form fix and cancel fix

### DIFF
--- a/backend/app/views/spree/admin/return_authorizations/_form.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/_form.html.erb
@@ -49,7 +49,9 @@
             <% end %>
           </td>
           <td class="align-center">
-            <%= item_fields.collection_select :exchange_variant_id, return_item.eligible_exchange_variants, :id, :options_text, { include_blank: true }, { class: "select2 fullwidth" } %>
+            <% if inventory_unit.shipped? && allow_return_item_changes %>
+              <%= item_fields.collection_select :exchange_variant_id, return_item.eligible_exchange_variants, :id, :options_text, { include_blank: true }, { class: "select2 fullwidth" } %>
+            <% end %>
           </td>
         </tr>
       <% end %>

--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -18,6 +18,7 @@ module Spree
     validate :must_have_shipped_units, on: :create
 
     state_machine initial: :authorized do
+      before_transition to: :canceled, do: :cancel_return_items
 
       event :cancel do
         transition to: :canceled, from: :authorized
@@ -58,6 +59,10 @@ module Spree
           random = "RA#{Array.new(9){rand(9)}.join}"
           break random unless self.class.exists?(number: random)
         end
+      end
+
+      def cancel_return_items
+        return_items.each(&:cancel!)
       end
 
   end

--- a/core/spec/models/spree/return_authorization_spec.rb
+++ b/core/spec/models/spree/return_authorization_spec.rb
@@ -127,4 +127,19 @@ describe Spree::ReturnAuthorization do
       end
     end
   end
+
+  describe 'cancel_return_items' do
+    let(:return_authorization) { create(:return_authorization) }
+    let(:order) { return_authorization.order }
+    let!(:return_item) { return_authorization.return_items.create!(inventory_unit: order.inventory_units.first) }
+
+    subject {
+      return_authorization.cancel!
+    }
+
+    it 'cancels the associated return items' do
+      subject
+      expect(return_item.reception_status).to eq 'cancelled'
+    end
+  end
 end


### PR DESCRIPTION
- Remove form field when the return item cannot be added.  Looks weird and it also causes nested attributes to raise.
- Cancel associated return items when canceling an RMA.  Return Item validations will ensure they can be canceled.
