### PR TITLE
Stop spree_sample:load creating a duplicate ShippingCategory record

### DIFF
--- a/sample/db/samples/shipping_categories.rb
+++ b/sample/db/samples/shipping_categories.rb
@@ -1,1 +1,1 @@
-Spree::ShippingCategory.create!(:name => "Default")
+Spree::ShippingCategory.find_or_create_by!(:name => "Default")


### PR DESCRIPTION
Spree::ShippingCategory.create!(:name => "Default") is run in the [following migration](https://github.com/spree/spree/blob/master/core/db/migrate/20130830001033_add_shipping_category_to_shipping_methods_and_products.rb) therefore a create command here would create a duplicate if a db:migrate had been run prior. shipping_categories.rb could be removed from samples completely but users of db:reset (that uses db:schema:load and loads the db from schema not migrations) would need it to be created here.
