### PR TITLE
Create a default calculator to determine a return item's default refund ...

### DIFF
--- a/backend/app/controllers/spree/admin/return_authorizations_controller.rb
+++ b/backend/app/controllers/spree/admin/return_authorizations_controller.rb
@@ -29,7 +29,7 @@ module Spree
         unassociated_inventory_units = all_inventory_units - associated_inventory_units
 
         new_return_items = unassociated_inventory_units.map do |new_unit|
-          Spree::ReturnItem.new(inventory_unit: new_unit, pre_tax_amount: rounded_pre_tax_amount(new_unit.pre_tax_amount))
+          Spree::ReturnItem.new(inventory_unit: new_unit).tap(&:set_default_pre_tax_amount)
         end
 
         @form_return_items = (@return_authorization.return_items + new_return_items).sort_by(&:inventory_unit_id)
@@ -45,10 +45,6 @@ module Spree
         if @return_authorization.reason && !@return_authorization.reason.active?
           @reasons << @return_authorization.reason
         end
-      end
-
-      def rounded_pre_tax_amount(amount)
-        amount.round(Spree::ReturnItem.columns_hash['pre_tax_amount'].scale)
       end
     end
   end

--- a/core/app/models/spree/calculator/returns/default_refund_amount.rb
+++ b/core/app/models/spree/calculator/returns/default_refund_amount.rb
@@ -1,0 +1,36 @@
+require_dependency 'spree/returns_calculator'
+
+module Spree
+  module Calculator::Returns
+    class DefaultRefundAmount < ReturnsCalculator
+
+      def self.description
+        Spree.t(:default_refund_amount)
+      end
+
+      def compute(return_item)
+        return 0.0.to_d if return_item.exchange_requested?
+        weighted_order_adjustment_amount(return_item.inventory_unit) + weighted_line_item_pre_tax_amount(return_item.inventory_unit)
+      end
+
+      private
+
+      def weighted_order_adjustment_amount(inventory_unit)
+        inventory_unit.order.adjustments.eligible.non_tax.sum(:amount) * percentage_of_order_total(inventory_unit)
+      end
+
+      def weighted_line_item_pre_tax_amount(inventory_unit)
+        inventory_unit.line_item.pre_tax_amount * percentage_of_line_item(inventory_unit)
+      end
+
+      def percentage_of_order_total(inventory_unit)
+       return 0.0 if inventory_unit.order.pre_tax_item_amount.zero?
+       weighted_line_item_pre_tax_amount(inventory_unit) / inventory_unit.order.pre_tax_item_amount
+     end
+
+     def percentage_of_line_item(inventory_unit)
+       1 / BigDecimal.new(inventory_unit.line_item.quantity)
+     end
+   end
+ end
+end

--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -69,12 +69,7 @@ module Spree
     end
 
     def current_or_new_return_item
-      current_return_item || Spree::ReturnItem.new(inventory_unit: self,
-                                                   pre_tax_amount: pre_tax_amount)
-    end
-
-    def pre_tax_amount
-      weighted_order_adjustment_amount + weighted_line_item_pre_tax_amount
+      Spree::ReturnItem.from_inventory_unit(self)
     end
 
     def additional_tax_total
@@ -93,19 +88,6 @@ module Spree
 
       def update_order
         order.update!
-      end
-
-      def weighted_line_item_pre_tax_amount
-        line_item.pre_tax_amount * percentage_of_line_item
-      end
-
-      def weighted_order_adjustment_amount
-        order.adjustments.eligible.non_tax.sum(:amount) * percentage_of_order_total
-      end
-
-      def percentage_of_order_total
-        return 0.0 if order.pre_tax_item_amount.zero?
-        weighted_line_item_pre_tax_amount / order.pre_tax_item_amount
       end
 
       def percentage_of_line_item

--- a/core/app/models/spree/reimbursement_tax_calculator.rb
+++ b/core/app/models/spree/reimbursement_tax_calculator.rb
@@ -21,7 +21,7 @@ module Spree
       private
 
       def set_tax!(return_item)
-        percent_of_tax = (return_item.pre_tax_amount <= 0) ? 0 : return_item.pre_tax_amount / return_item.inventory_unit.pre_tax_amount
+        percent_of_tax = (return_item.pre_tax_amount <= 0) ? 0 : return_item.pre_tax_amount / Spree::ReturnItem.refund_amount_calculator.new.compute(return_item)
 
         additional_tax_total = percent_of_tax * return_item.inventory_unit.additional_tax_total
         included_tax_total   = percent_of_tax * return_item.inventory_unit.included_tax_total

--- a/core/app/models/spree/returns_calculator.rb
+++ b/core/app/models/spree/returns_calculator.rb
@@ -1,0 +1,8 @@
+module Spree
+  class ReturnsCalculator < Calculator
+
+    def compute(return_item)
+      raise NotImplementedError, "Please implement 'compute(return_item)' in your calculator: #{self.class.name}"
+    end
+  end
+end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -583,6 +583,7 @@ en:
       js_format: yy/mm/dd
     date_range: Date Range
     default: Default
+    default_refund_amount: Default Refund Amount
     default_tax: Default Tax
     default_tax_zone: Default Tax Zone
     delete: Delete

--- a/core/lib/spree/testing_support/factories/customer_return_factory.rb
+++ b/core/lib/spree/testing_support/factories/customer_return_factory.rb
@@ -12,10 +12,7 @@ FactoryGirl.define do
       shipped_order = create(:shipped_order, line_items_count: evaluator.line_items_count)
 
       shipped_order.inventory_units.take(evaluator.return_items_count).each do |inventory_unit|
-        customer_return.return_items << build(:return_item, {
-          inventory_unit: inventory_unit,
-          pre_tax_amount: inventory_unit.pre_tax_amount,
-        })
+        customer_return.return_items << build(:return_item, inventory_unit: inventory_unit)
       end
     end
 

--- a/core/lib/spree/testing_support/factories/inventory_unit_factory.rb
+++ b/core/lib/spree/testing_support/factories/inventory_unit_factory.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :inventory_unit, class: Spree::InventoryUnit do
     variant
     order
+    line_item
     state 'on_hand'
     association(:shipment, factory: :shipment, state: 'pending')
     # return_authorization

--- a/core/spec/models/spree/calculator/refunds/default_refund_amount_spec.rb
+++ b/core/spec/models/spree/calculator/refunds/default_refund_amount_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe Spree::Calculator::Returns::DefaultRefundAmount do
+  let(:order)           { create(:order) }
+  let(:line_item_quantity) { 2 }
+  let(:pre_tax_amount)  { 100.0 }
+  let(:line_item)       { create(:line_item, price: 100.0, quantity: line_item_quantity, pre_tax_amount: pre_tax_amount) }
+  let(:inventory_unit) { build(:inventory_unit, order: order, line_item: line_item) }
+  let(:return_item) { build(:return_item, inventory_unit: inventory_unit ) }
+  let(:calculator) { Spree::Calculator::Returns::DefaultRefundAmount.new }
+
+  before { order.line_items << line_item }
+
+  subject { calculator.compute(return_item) }
+
+  context "not an exchange" do
+    context "no promotions or taxes" do
+      it { should eq pre_tax_amount / line_item_quantity }
+    end
+
+    context "order adjustments" do
+      let(:adjustment_amount) { -10.0 }
+
+      before do
+        order.adjustments << create(:adjustment, amount: adjustment_amount, eligible: true, label: 'Adjustment', source_type: 'Spree::Order')
+        order.adjustments.first.update_attributes(amount: adjustment_amount)
+      end
+
+      it { should eq (pre_tax_amount - adjustment_amount.abs) / line_item_quantity }
+    end
+
+    context "shipping adjustments" do
+      let(:adjustment_total) { -50.0 }
+
+      before { order.shipments << Spree::Shipment.new(adjustment_total: adjustment_total) }
+
+      it { should eq pre_tax_amount / line_item_quantity }
+    end
+  end
+
+  context "an exchange" do
+    let(:return_item) { build(:exchange_return_item) }
+
+    it { should eq 0.0 }
+  end
+end

--- a/core/spec/models/spree/inventory_unit_spec.rb
+++ b/core/spec/models/spree/inventory_unit_spec.rb
@@ -154,40 +154,6 @@ describe Spree::InventoryUnit do
     end
   end
 
-  describe "#pre_tax_amount" do
-    let(:order)           { create(:order) }
-    let(:line_item_quantity) { 2 }
-    let(:pre_tax_amount)  { 100.0 }
-    let(:line_item)       { create(:line_item, price: 100.0, quantity: line_item_quantity, pre_tax_amount: pre_tax_amount) }
-
-    before { order.line_items << line_item }
-
-    subject { build(:inventory_unit, order: order, line_item: line_item) }
-
-    context "no promotions or taxes" do
-      its(:pre_tax_amount) { should eq pre_tax_amount / line_item_quantity }
-    end
-
-    context "order adjustments" do
-      let(:adjustment_amount) { -10.0 }
-
-      before do
-        order.adjustments << create(:adjustment, amount: adjustment_amount, eligible: true, label: 'Adjustment', source_type: 'Spree::Order')
-        order.adjustments.first.update_attributes(amount: adjustment_amount)
-      end
-
-      its(:pre_tax_amount) { should eq (pre_tax_amount - adjustment_amount.abs) / line_item_quantity }
-    end
-
-    context "shipping adjustments" do
-      let(:adjustment_total) { -50.0 }
-
-      before { order.shipments << Spree::Shipment.new(adjustment_total: adjustment_total) }
-
-      its(:pre_tax_amount) { should eq pre_tax_amount / line_item_quantity }
-    end
-  end
-
   describe '#additional_tax_total' do
     let(:quantity) { 2 }
     let(:line_item_additional_tax_total)  { 10.00 }

--- a/core/spec/models/spree/reimbursement_spec.rb
+++ b/core/spec/models/spree/reimbursement_spec.rb
@@ -59,7 +59,7 @@ describe Spree::Reimbursement do
     let(:payment)                 { build(:payment, amount: payment_amount, order: order, state: 'completed') }
     let(:payment_amount)          { order.total }
     let(:customer_return)         { build(:customer_return, return_items: [return_item]) }
-    let(:return_item)             { build(:return_item, pre_tax_amount: inventory_unit.pre_tax_amount, inventory_unit: inventory_unit) }
+    let(:return_item)             { build(:return_item, inventory_unit: inventory_unit) }
 
     let!(:default_refund_reason) { Spree::RefundReason.find_or_create_by!(name: Spree::RefundReason::RETURN_PROCESSING_REASON, mutable: false) }
 

--- a/core/spec/models/spree/returns_calculator_spec.rb
+++ b/core/spec/models/spree/returns_calculator_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+module Spree
+  describe ReturnsCalculator do
+    let(:return_item) { build(:return_item) }
+    subject { ReturnsCalculator.new }
+
+    it 'compute_shipment must be overridden' do
+      expect {
+        subject.compute(return_item)
+      }.to raise_error
+    end
+  end
+end


### PR DESCRIPTION
...amount.

Moved a lot of calculations from inventory_unit into a calculator. The calculator can be overwritten in the return item if different calculations are needed to determine a return item's pre-tax amount.
