### PR TITLE
More user friendly promotion rule errors.

### DIFF
--- a/core/app/models/spree/promotion/rules/first_order.rb
+++ b/core/app/models/spree/promotion/rules/first_order.rb
@@ -9,20 +9,18 @@ module Spree
         end
 
         def eligible?(order, options = {})
-          @eligibility_errors = ActiveModel::Errors.new(self)
-
           @user = order.try(:user) || options[:user]
           @email = order.email
 
           if user || email
             if !completed_orders.blank? && completed_orders.first != order
-              @eligibility_errors.add(:base, eligibility_error_message(:not_first_order))
+              eligibility_errors.add(:base, eligibility_error_message(:not_first_order))
             end
           else
-            @eligibility_errors.add(:base, eligibility_error_message(:no_user_or_email_specified))
+            eligibility_errors.add(:base, eligibility_error_message(:no_user_or_email_specified))
           end
 
-          @eligibility_errors.empty?
+          eligibility_errors.empty?
         end
 
         private

--- a/core/app/models/spree/promotion/rules/first_order.rb
+++ b/core/app/models/spree/promotion/rules/first_order.rb
@@ -9,14 +9,20 @@ module Spree
         end
 
         def eligible?(order, options = {})
+          @eligibility_errors = ActiveModel::Errors.new(self)
+
           @user = order.try(:user) || options[:user]
           @email = order.email
 
           if user || email
-            completed_orders.blank? || (completed_orders.first == order)
+            if !completed_orders.blank? && completed_orders.first != order
+              @eligibility_errors.add(:base, eligibility_error_message(:not_first_order))
+            end
           else
-            false
+            @eligibility_errors.add(:base, eligibility_error_message(:no_user_or_email_specified))
           end
+
+          @eligibility_errors.empty?
         end
 
         private

--- a/core/app/models/spree/promotion/rules/item_total.rb
+++ b/core/app/models/spree/promotion/rules/item_total.rb
@@ -14,8 +14,20 @@ module Spree
         end
 
         def eligible?(order, options = {})
+          @eligibility_errors = ActiveModel::Errors.new(self)
+
           item_total = order.item_total
-          item_total.send(preferred_operator == 'gte' ? :>= : :>, BigDecimal.new(preferred_amount.to_s))
+          unless item_total.send(preferred_operator == 'gte' ? :>= : :>, BigDecimal.new(preferred_amount.to_s))
+            amount = Spree::Money.new(preferred_amount).to_s
+            message = if preferred_operator == 'gte'
+                        eligibility_error_message(:item_total_less_than, amount: amount)
+                      else
+                        eligibility_error_message(:item_total_less_than_or_equal, amount: amount)
+                      end
+            @eligibility_errors.add(:base, message)
+          end
+
+          @eligibility_errors.empty?
         end
       end
     end

--- a/core/app/models/spree/promotion/rules/item_total.rb
+++ b/core/app/models/spree/promotion/rules/item_total.rb
@@ -14,20 +14,25 @@ module Spree
         end
 
         def eligible?(order, options = {})
-          @eligibility_errors = ActiveModel::Errors.new(self)
-
           item_total = order.item_total
           unless item_total.send(preferred_operator == 'gte' ? :>= : :>, BigDecimal.new(preferred_amount.to_s))
-            amount = Spree::Money.new(preferred_amount).to_s
-            message = if preferred_operator == 'gte'
-                        eligibility_error_message(:item_total_less_than, amount: amount)
-                      else
-                        eligibility_error_message(:item_total_less_than_or_equal, amount: amount)
-                      end
-            @eligibility_errors.add(:base, message)
+            eligibility_errors.add(:base, ineligible_message)
           end
 
-          @eligibility_errors.empty?
+          eligibility_errors.empty?
+        end
+
+        private
+        def formatted_amount
+          Spree::Money.new(preferred_amount).to_s
+        end
+
+        def ineligible_message
+          if preferred_operator == 'gte'
+            eligibility_error_message(:item_total_less_than, amount: formatted_amount)
+          else
+            eligibility_error_message(:item_total_less_than_or_equal, amount: formatted_amount)
+          end
         end
       end
     end

--- a/core/app/models/spree/promotion/rules/one_use_per_user.rb
+++ b/core/app/models/spree/promotion/rules/one_use_per_user.rb
@@ -7,7 +7,15 @@ module Spree
         end
 
         def eligible?(order, options = {})
-          order.user.present? && !promotion.used_by?(order.user, [order])
+          if order.user.present?
+            if promotion.used_by?(order.user, [order])
+              eligibility_errors.add(:base, eligibility_error_message(:limit_once_per_user))
+            end
+          else
+            eligibility_errors.add(:base, eligibility_error_message(:no_user_specified))
+          end
+
+          eligibility_errors.empty?
         end
       end
     end

--- a/core/app/models/spree/promotion/rules/product.rb
+++ b/core/app/models/spree/promotion/rules/product.rb
@@ -21,13 +21,22 @@ module Spree
 
         def eligible?(order, options = {})
           return true if eligible_products.empty?
+
           if preferred_match_policy == 'all'
-            eligible_products.all? {|p| order.products.include?(p) }
+            unless eligible_products.all? {|p| order.products.include?(p) }
+              eligibility_errors.add(:base, eligibility_error_message(:missing_product))
+            end
           elsif preferred_match_policy == 'any'
-            order.products.any? {|p| eligible_products.include?(p) }
+            unless order.products.any? {|p| eligible_products.include?(p) }
+              eligibility_errors.add(:base, eligibility_error_message(:no_applicable_products))
+            end
           else
-            order.products.none? {|p| eligible_products.include?(p) }
+            unless order.products.none? {|p| eligible_products.include?(p) }
+              eligibility_errors.add(:base, eligibility_error_message(:has_excluded_product))
+            end
           end
+
+          eligibility_errors.empty?
         end
 
         def actionable?(line_item)

--- a/core/app/models/spree/promotion/rules/taxon.rb
+++ b/core/app/models/spree/promotion/rules/taxon.rb
@@ -13,11 +13,17 @@ module Spree
 
         def eligible?(order, options = {})
           if preferred_match_policy == 'all'
-            (taxons.to_a - taxons_in_order_including_parents(order)).empty?
+            unless (taxons.to_a - taxons_in_order_including_parents(order)).empty?
+              eligibility_errors.add(:base, eligibility_error_message(:missing_taxon))
+            end
           else
             order_taxons = taxons_in_order_including_parents(order)
-            taxons.any?{ |taxon| order_taxons.include? taxon }
+            unless taxons.any?{ |taxon| order_taxons.include? taxon }
+              eligibility_errors.add(:base, eligibility_error_message(:no_matching_taxons))
+            end
           end
+
+          eligibility_errors.empty?
         end
 
         def taxon_ids_string

--- a/core/app/models/spree/promotion/rules/user_logged_in.rb
+++ b/core/app/models/spree/promotion/rules/user_logged_in.rb
@@ -7,7 +7,10 @@ module Spree
         end
 
         def eligible?(order, options = {})
-          return order.user.present?
+          unless order.user.present?
+            eligibility_errors.add(:base, eligibility_error_message(:no_user_specified))
+          end
+          eligibility_errors.empty?
         end
       end
     end

--- a/core/app/models/spree/promotion_handler/coupon.rb
+++ b/core/app/models/spree/promotion_handler/coupon.rb
@@ -37,7 +37,10 @@ module Spree
       def handle_present_promotion(promotion)
         return promotion_usage_limit_exceeded if promotion.usage_limit_exceeded?(order)
         return promotion_applied if promotion_exists_on_order?(order, promotion)
-        return ineligible_for_this_order unless promotion.eligible?(order)
+        unless promotion.eligible?(order)
+          self.error = promotion.eligibility_errors.full_messages.first unless promotion.eligibility_errors.blank?
+          return (self.error || ineligible_for_this_order)
+        end
 
         # If any of the actions for the promotion return `true`,
         # then result here will also be `true`.

--- a/core/app/models/spree/promotion_rule.rb
+++ b/core/app/models/spree/promotion_rule.rb
@@ -1,6 +1,8 @@
 # Base class for all promotion rules
 module Spree
   class PromotionRule < Spree::Base
+    attr_reader :eligibility_errors
+
     belongs_to :promotion, class_name: 'Spree::Promotion', inverse_of: :promotion_rules
 
     scope :of_type, ->(t) { where(type: t) }
@@ -33,5 +35,8 @@ module Spree
       end
     end
 
+    def eligibility_error_message(key)
+      Spree.t(key, scope: 'eligibility_errors.messages')
+    end
   end
 end

--- a/core/app/models/spree/promotion_rule.rb
+++ b/core/app/models/spree/promotion_rule.rb
@@ -35,8 +35,8 @@ module Spree
       end
     end
 
-    def eligibility_error_message(key)
-      Spree.t(key, scope: 'eligibility_errors.messages')
+    def eligibility_error_message(key, options = {})
+      Spree.t(key, Hash[scope: 'eligibility_errors.messages'].merge(options))
     end
   end
 end

--- a/core/app/models/spree/promotion_rule.rb
+++ b/core/app/models/spree/promotion_rule.rb
@@ -1,8 +1,6 @@
 # Base class for all promotion rules
 module Spree
   class PromotionRule < Spree::Base
-    attr_reader :eligibility_errors
-
     belongs_to :promotion, class_name: 'Spree::Promotion', inverse_of: :promotion_rules
 
     scope :of_type, ->(t) { where(type: t) }
@@ -26,6 +24,10 @@ module Spree
     # It is true by default, but can be overridden by promotion rules to provide conditions
     def actionable?(line_item)
       true
+    end
+
+    def eligibility_errors
+      @eligibility_errors ||= ActiveModel::Errors.new(self)
     end
 
     private

--- a/core/app/models/spree/promotion_rule.rb
+++ b/core/app/models/spree/promotion_rule.rb
@@ -38,7 +38,7 @@ module Spree
     end
 
     def eligibility_error_message(key, options = {})
-      Spree.t(key, Hash[scope: 'eligibility_errors.messages'].merge(options))
+      Spree.t(key, Hash[scope: [:eligibility_errors, :messages]].merge(options))
     end
   end
 end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -645,7 +645,9 @@ en:
       messages:
         item_total_less_than: This coupon code can't be applied to orders less than %{amount}.
         item_total_less_than_or_equal: This coupon code can't be applied to orders less than or equal to %{amount}.
+        limit_once_per_user: This coupon code can only be used once per user.
         no_user_or_email_specified: You need to login or provide your email before applying this coupon code.
+        no_user_specified: You need to login before applying this coupon code.
         not_first_order: This coupon code can only be applied to your first order.
     email: Email
     empty: Empty

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1258,7 +1258,7 @@ en:
     taxon_edit: Edit Taxon
     taxon_placeholder: Add a Taxon
     taxon_rule:
-      choose_products: Choose taxon
+      choose_taxons: Choose taxons
       label: Order must contain %{select} of these taxons
       match_all: all
       match_any: at least one

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -643,9 +643,12 @@ en:
     editing_zone: Editing Zone
     eligibility_errors:
       messages:
+        has_excluded_product: Your cart contains a product that prevents this coupon code from being applied.
         item_total_less_than: This coupon code can't be applied to orders less than %{amount}.
         item_total_less_than_or_equal: This coupon code can't be applied to orders less than or equal to %{amount}.
         limit_once_per_user: This coupon code can only be used once per user.
+        missing_product: This coupon code can't be applied because you don't have all of the necessary products in your cart.
+        no_applicable_products: You need to add an applicable product before applying this coupon code.
         no_user_or_email_specified: You need to login or provide your email before applying this coupon code.
         no_user_specified: You need to login before applying this coupon code.
         not_first_order: This coupon code can only be applied to your first order.

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -641,6 +641,10 @@ en:
     editing_tracker: Editing Tracker
     editing_user: Editing User
     editing_zone: Editing Zone
+    eligibility_errors:
+      messages:
+        no_user_or_email_specified: You need to login or provide your email before applying this coupon code.
+        not_first_order: This coupon code can only be applied to your first order.
     email: Email
     empty: Empty
     empty_cart: Empty Cart

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -648,7 +648,9 @@ en:
         item_total_less_than_or_equal: This coupon code can't be applied to orders less than or equal to %{amount}.
         limit_once_per_user: This coupon code can only be used once per user.
         missing_product: This coupon code can't be applied because you don't have all of the necessary products in your cart.
+        missing_taxon: You need to add a product from all applicable categories before applying this coupon code.
         no_applicable_products: You need to add an applicable product before applying this coupon code.
+        no_matching_taxons: You need to add a product from an applicable category before applying this coupon code.
         no_user_or_email_specified: You need to login or provide your email before applying this coupon code.
         no_user_specified: You need to login before applying this coupon code.
         not_first_order: This coupon code can only be applied to your first order.

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -643,6 +643,8 @@ en:
     editing_zone: Editing Zone
     eligibility_errors:
       messages:
+        item_total_less_than: This coupon code can't be applied to orders less than %{amount}.
+        item_total_less_than_or_equal: This coupon code can't be applied to orders less than or equal to %{amount}.
         no_user_or_email_specified: You need to login or provide your email before applying this coupon code.
         not_first_order: This coupon code can only be applied to your first order.
     email: Email

--- a/core/spec/models/spree/promotion/rules/item_total_spec.rb
+++ b/core/spec/models/spree/promotion/rules/item_total_spec.rb
@@ -14,14 +14,28 @@ describe Spree::Promotion::Rules::ItemTotal do
       rule.should be_eligible(order)
     end
 
-    it "should not be eligible when item total is equal to preferred amount" do
-      order.stub :item_total => 50
-      rule.should_not be_eligible(order)
+    context "when item total is equal to preferred amount" do
+      before { order.stub item_total: 50 }
+      it "is not eligible" do
+        rule.should_not be_eligible(order)
+      end
+      it "set an error message" do
+        rule.eligible?(order)
+        expect(rule.eligibility_errors.full_messages.first).
+          to eq "This coupon code can't be applied to orders less than or equal to $50.00."
+      end
     end
 
-    it "should not be eligible when item total is lower than to preferred amount" do
-      order.stub :item_total => 49
-      rule.should_not be_eligible(order)
+    context "when item total is lower than preferred amount" do
+      before { order.stub item_total: 49 }
+      it "is not eligible" do
+        rule.should_not be_eligible(order)
+      end
+      it "set an error message" do
+        rule.eligible?(order)
+        expect(rule.eligibility_errors.full_messages.first).
+          to eq "This coupon code can't be applied to orders less than or equal to $50.00."
+      end
     end
   end
 
@@ -38,9 +52,16 @@ describe Spree::Promotion::Rules::ItemTotal do
       rule.should be_eligible(order)
     end
 
-    it "should not be eligible when item total is lower than to preferred amount" do
-      order.stub :item_total => 49
-      rule.should_not be_eligible(order)
+    context "when item total is lower than preferred amount" do
+      before { order.stub item_total: 49 }
+      it "is not eligible" do
+        rule.should_not be_eligible(order)
+      end
+      it "set an error message" do
+        rule.eligible?(order)
+        expect(rule.eligibility_errors.full_messages.first).
+          to eq "This coupon code can't be applied to orders less than $50.00."
+      end
     end
   end
 end

--- a/core/spec/models/spree/promotion/rules/one_use_per_user_spec.rb
+++ b/core/spec/models/spree/promotion/rules/one_use_per_user_spec.rb
@@ -17,6 +17,11 @@ describe Spree::Promotion::Rules::OneUsePerUser do
         let(:used_by) { true }
 
         it { should be false }
+        it "sets an error message" do
+          subject
+          expect(rule.eligibility_errors.full_messages.first).
+            to eq "This coupon code can only be used once per user."
+        end
       end
 
       context 'when the user has not used this promotion before' do
@@ -27,6 +32,11 @@ describe Spree::Promotion::Rules::OneUsePerUser do
     context 'when the order is not assigned to a user' do
       let(:user) { nil }
       it { should be false }
+      it "sets an error message" do
+        subject
+        expect(rule.eligibility_errors.full_messages.first).
+          to eq "You need to login before applying this coupon code."
+      end
     end
   end
 end

--- a/core/spec/models/spree/promotion/rules/product_spec.rb
+++ b/core/spec/models/spree/promotion/rules/product_spec.rb
@@ -24,10 +24,17 @@ describe Spree::Promotion::Rules::Product do
         rule.should be_eligible(order)
       end
 
-      it "should not be eligible if none of the products is in eligible products" do
-        order.stub(:products => [@product1])
-        rule.stub(:eligible_products => [@product2, @product3])
-        rule.should_not be_eligible(order)
+      context "when none of the products are eligible products" do
+        before do
+          order.stub(products: [@product1])
+          rule.stub(eligible_products: [@product2, @product3])
+        end
+        it { rule.should_not be_eligible(order) }
+        it "sets an error message" do
+          rule.eligible?(order)
+          expect(rule.eligibility_errors.full_messages.first).
+            to eq "You need to add an applicable product before applying this coupon code."
+        end
       end
     end
 
@@ -40,10 +47,17 @@ describe Spree::Promotion::Rules::Product do
         rule.should be_eligible(order)
       end
 
-      it "should not be eligible if any of the eligible products is not ordered" do
-        order.stub(:products => [@product1, @product2])
-        rule.stub(:eligible_products => [@product1, @product2, @product3])
-        rule.should_not be_eligible(order)
+      context "when any of the eligible products is not ordered" do
+        before do
+          order.stub(products: [@product1, @product2])
+          rule.stub(eligible_products: [@product1, @product2, @product3])
+        end
+        it { rule.should_not be_eligible(order) }
+        it "sets an error message" do
+          rule.eligible?(order)
+          expect(rule.eligibility_errors.full_messages.first).
+            to eq "This coupon code can't be applied because you don't have all of the necessary products in your cart."
+        end
       end
     end
 
@@ -56,10 +70,17 @@ describe Spree::Promotion::Rules::Product do
         rule.should be_eligible(order)
       end
 
-      it "should not be eligible if any of the order's products are in eligible products" do
-        order.stub(:products => [@product1, @product2])
-        rule.stub(:eligible_products => [@product2, @product3])
-        rule.should_not be_eligible(order)
+      context "when any of the order's products are in eligible products" do
+        before do
+          order.stub(products: [@product1, @product2])
+          rule.stub(eligible_products: [@product2, @product3])
+        end
+        it { rule.should_not be_eligible(order) }
+        it "sets an error message" do
+          rule.eligible?(order)
+          expect(rule.eligibility_errors.full_messages.first).
+            to eq "Your cart contains a product that prevents this coupon code from being applied."
+        end
       end
     end
   end

--- a/core/spec/models/spree/promotion/rules/taxon_spec.rb
+++ b/core/spec/models/spree/promotion/rules/taxon_spec.rb
@@ -24,9 +24,14 @@ describe Spree::Promotion::Rules::Taxon do
         expect(rule).to be_eligible(order)
       end
 
-      it 'is not eligile if order does not has any prefered taxon' do
-        rule.taxons << taxon2
-        expect(rule).not_to be_eligible(order)
+      context "when order does not have any prefered taxon" do
+        before { rule.taxons << taxon2 }
+        it { expect(rule).not_to be_eligible(order) }
+        it "sets an error message" do
+          rule.eligible?(order)
+          expect(rule.eligibility_errors.full_messages.first).
+            to eq "You need to add a product from an applicable category before applying this coupon code."
+        end
       end
 
       context 'when a product has a taxon child of a taxon rule' do
@@ -54,9 +59,14 @@ describe Spree::Promotion::Rules::Taxon do
         expect(rule).to be_eligible(order)
       end
 
-      it 'is not eligile if order does not has all prefered taxons' do
-        rule.taxons << taxon
-        expect(rule).not_to be_eligible(order)
+      context "when order does not have all prefered taxons" do
+        before { rule.taxons << taxon  }
+        it { expect(rule).not_to be_eligible(order) }
+        it "sets an error message" do
+          rule.eligible?(order)
+          expect(rule.eligibility_errors.full_messages.first).
+            to eq "You need to add a product from all applicable categories before applying this coupon code."
+        end
       end
 
       context 'when a product has a taxon child of a taxon rule' do

--- a/core/spec/models/spree/promotion/rules/user_logged_in_spec.rb
+++ b/core/spec/models/spree/promotion/rules/user_logged_in_spec.rb
@@ -13,9 +13,14 @@ describe Spree::Promotion::Rules::UserLoggedIn do
       rule.should be_eligible(order)
     end
 
-    it "should not be eligible if user is not logged in" do
-      order.stub(:user => nil) # better to be explicit here
-      rule.should_not be_eligible(order)
+    context "when user is not logged in" do
+      before { order.stub(:user => nil) } # better to be explicit here
+      it { expect(rule).not_to be_eligible(order) }
+      it "sets an error message" do
+        rule.eligible?(order)
+        expect(rule.eligibility_errors.full_messages.first).
+          to eq "You need to login before applying this coupon code."
+      end
     end
   end
 end

--- a/frontend/spec/features/coupon_code_spec.rb
+++ b/frontend/spec/features/coupon_code_spec.rb
@@ -119,7 +119,7 @@ describe "Coupon code promotions", :js => true do
 
           fill_in "order_coupon_code", :with => "onetwo"
           click_button "Update"
-          page.should have_content(Spree.t(:coupon_code_not_eligible))
+          page.should have_content(Spree.t(:item_total_less_than_or_equal, scope: [:eligibility_errors, :messages], amount: "$100.00"))
         end
       end
 


### PR DESCRIPTION
Modelled after ActiveRecord's validation errors, when `eligible?` is run the rule can populate `eligibility_errors` with any specific error messages it would like. The errors are then bubbled up to the promotion and then the promotion handler.

For example, if a store had a promotion granting user's 10% off their first order and a user attempts to add the promotion to their cart on a second order they will see:

![image](https://cloud.githubusercontent.com/assets/876067/3850215/59bc9596-1e82-11e4-9c23-a2b877cd9a6d.png)

Instead of the less helpful:

![image](https://cloud.githubusercontent.com/assets/876067/3850207/3cb9e44e-1e82-11e4-83bf-cc37252e95e7.png)

I've added reasonable error messages for most of the rules. The code will also fall back to the old error message if `eligibility_errors` is not populated.
