### PR TITLE
Copies options hash before deleting entries (and affecting the caller's ...

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -37,3 +37,24 @@
   becomes the default credit card for that user. On future orders, we automatically
   add that default card as a payment when the order reaches the payment step.
     Magnus von Koeller
+
+* Provided hooks for extensions to seamlessly integrate with the order population workflow.
+  Extensions make use of the convention of passing parameters during the 'add to cart' 
+  action https://github.com/spree/spree/blob/master/core/app/models/spree/order_populator.rb#L12
+  with a prefix like [:options][:voucher_attributes] (in the case of the spree_vouchers 
+  extension).  The extension then provides some methods named according to what was passed in 
+  like:
+  
+  https://github.com/spree-contrib/spree_vouchers/blob/master/app/models/spree/order_decorator.rb#L51
+  
+  to determine if these possible line item customizations affect the line item equality condition and
+  
+  https://github.com/spree-contrib/spree_vouchers/blob/master/app/models/spree/variant_decorator.rb#L3
+  
+  to adjust a line item's price if necessary.
+  
+  https://github.com/spree/spree/blob/master/core/app/models/spree/order_contents.rb#L70
+  shows how we expect inbound parameters (such as the voucher_attributes) to be saved in a 
+  nested_attributes fashion.
+  
+    Jeff Squires

--- a/core/app/models/spree/order_populator.rb
+++ b/core/app/models/spree/order_populator.rb
@@ -9,7 +9,7 @@ module Spree
       @errors = ActiveModel::Errors.new(self)
     end
 
-    def populate(variant_id, quantity, options= {})
+    def populate(variant_id, quantity, options = {})
       # protect against passing a nil hash being passed in
       # due to an empty params[:options]
       attempt_cart_add(variant_id, quantity, options || {})


### PR DESCRIPTION
...copy)

updates changelog
