### PR TITLE
Use Rails environments instead of DB configurations

### DIFF
--- a/backend/app/helpers/spree/admin/base_helper.rb
+++ b/backend/app/helpers/spree/admin/base_helper.rb
@@ -159,6 +159,12 @@ module Spree
         dom_id(record, 'spree')
       end
 
+      def rails_environments
+        @@rails_environments ||= Dir.glob("./config/environments/*.rb")
+                                    .map { |f| File.basename(f, ".rb") }
+                                    .sort
+      end
+
       private
         def attribute_name_for(field_name)
           field_name.gsub(' ', '_').downcase

--- a/backend/app/views/spree/admin/payment_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/_form.html.erb
@@ -14,10 +14,10 @@
             <div id="gateway-settings-warning" class="info warning"><%= Spree.t(:provider_settings_warning) %></div>
           <% end %>
         <% end %>
-      </div>      
+      </div>
       <div data-hook="environment" class="field">
         <%= label_tag nil, Spree.t(:environment) %>
-        <%= collection_select(:payment_method, :environment, Rails.configuration.database_configuration.keys.sort, :to_s, :titleize, {}, {:id => 'gtwy-env', :class => 'select2 fullwidth'}) %>        
+        <%= collection_select(:payment_method, :environment, rails_environments, :to_s, :titleize, {}, {:id => 'gtwy-env', :class => 'select2 fullwidth'}) %>
       </div>
       <div data-hook="display" class="field">
         <%= label_tag nil, Spree.t(:display) %>
@@ -33,7 +33,7 @@
           <li>
             <%= radio_button :payment_method, :active, true %>
             <%= label_tag nil, Spree.t(:say_yes) %>
-          </li>        
+          </li>
           <li>
             <%= radio_button :payment_method, :active, false %>
             <%= label_tag nil, Spree.t(:say_no) %>
@@ -41,7 +41,7 @@
         </ul>
       </div>
     </div>
-    
+
     <div class="omega eight columns">
       <div data-hook="name" class="field">
         <%= label_tag nil, Spree.t(:name) %>
@@ -50,9 +50,9 @@
       <div data-hook="description" class="field">
         <%= label_tag nil, Spree.t(:description) %>
         <%= text_area :payment_method, :description, {:cols => 60, :rows => 6, :class => 'fullwidth'} %>
-      </div>  
+      </div>
     </div>
-    
+
   </div>
 </div>
 

--- a/backend/app/views/spree/admin/trackers/_form.html.erb
+++ b/backend/app/views/spree/admin/trackers/_form.html.erb
@@ -8,7 +8,7 @@
   <div class="four columns">
     <div data-hook="environment" class="field">
       <%= label_tag nil, Spree.t(:environment) %>
-      <%= collection_select(:tracker, :environment, Rails.configuration.database_configuration.keys.sort, :to_s, :titleize, {}, {:id => 'tracker-env', :class => 'select2 fullwidth'}) %>
+      <%= collection_select(:tracker, :environment, rails_environments, :to_s, :titleize, {}, {:id => 'tracker-env', :class => 'select2 fullwidth'}) %>
     </div>
   </div>
   <div class="omega four columns">
@@ -26,9 +26,9 @@
       </ul>
     </div>
   </div>
-  
+
   <div class="clear"></div>
 
   <div data-hook="additional_tracker_fields"></div>
-  
+
 </div>


### PR DESCRIPTION
In the admin forms for `Spree::PaymentMethod` and `Spree::Tracker` the collection used for the environment field is the database configuration keys. This is wrong and it becomes quite apparent in the case of applications that connect to more than one database. This PR replaces said collection with a collection of the available environment configurations in '/config/environments/'.

The methods that validate the `environment` attribute for these classes already compare them against `Rails.env`, so no changes are needed there.
