### PR TITLE
Expedited exchanges

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/returns/expedited_exchanges_warning.coffee
+++ b/backend/app/assets/javascripts/spree/backend/returns/expedited_exchanges_warning.coffee
@@ -1,0 +1,4 @@
+$ ->
+  $(document).on("change", ".return-items-table .return-item-exchange-selection", ->
+    $(".expedited-exchanges-warning").fadeIn()
+  )

--- a/backend/app/assets/stylesheets/spree/backend/sections/_return_authorizations.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_return_authorizations.scss
@@ -1,3 +1,5 @@
+@import "spree/backend/globals/variables";
+
 .return-items-table {
   .refund-amount-input {
     width: 80px;
@@ -9,4 +11,14 @@
     text-align: left;
     max-width: 150px;
   }
+}
+.expedited-exchanges-warning {
+  display: none;
+  color: black;
+  padding: 15px;
+  margin: 10px 0;
+  font-weight: bold;
+  background-color: $color-6;
+  border-radius: 4px;
+  opacity: 0.6;
 }

--- a/backend/app/views/spree/admin/reimbursements/edit.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/edit.html.erb
@@ -50,7 +50,11 @@
               <%= return_item.display_total %>
             </td>
             <td class="align-center">
-              <%= item_fields.collection_select :exchange_variant_id, return_item.eligible_exchange_variants, :id, :options_text, { include_blank: true }, { class: "select2 fullwidth" } %>
+              <% if return_item.exchange_processed? %>
+                <%= return_item.exchange_variant.options_text %>
+              <% else %>
+                <%= item_fields.collection_select :exchange_variant_id, return_item.eligible_exchange_variants, :id, :options_text, { include_blank: true }, { class: "select2 fullwidth return-item-exchange-selection" } %>
+              <% end %>
             </td>
           </tr>
 

--- a/backend/app/views/spree/admin/return_authorizations/_form.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/_form.html.erb
@@ -50,7 +50,11 @@
           </td>
           <td class="align-center">
             <% if inventory_unit.shipped? && allow_return_item_changes %>
-              <%= item_fields.collection_select :exchange_variant_id, return_item.eligible_exchange_variants, :id, :options_text, { include_blank: true }, { class: "select2 fullwidth" } %>
+              <% if return_item.exchange_processed? %>
+                <%= return_item.exchange_variant.options_text %>
+              <% else %>
+                <%= item_fields.collection_select :exchange_variant_id, return_item.eligible_exchange_variants, :id, :options_text, { include_blank: true }, { class: "select2 fullwidth return-item-exchange-selection" } %>
+              <% end %>
             <% end %>
           </td>
         </tr>
@@ -80,3 +84,7 @@
     <%= f.error_message_on :memo %>
   <% end %>
 </div>
+
+<% if Spree::Config[:expedited_exchanges] %>
+  <div class="expedited-exchanges-warning"><%= Spree.t(:expedited_exchanges_warning, days_window: Spree::Config[:expedited_exchanges_days_window]) %></div>
+<% end %>

--- a/core/Rakefile
+++ b/core/Rakefile
@@ -5,6 +5,7 @@ require 'rake/packagetask'
 require 'rubygems/package_task'
 require 'rspec/core/rake_task'
 require 'spree/testing_support/common_rake'
+load 'lib/tasks/exchanges.rake'
 
 Bundler::GemHelper.install_tasks
 RSpec::Core::RakeTask.new

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -47,6 +47,8 @@ module Spree
     preference :display_currency, :boolean, default: false
     preference :default_country_id, :integer
     preference :dismissed_spree_alerts, :string, default: ''
+    preference :expedited_exchanges, :boolean, default: false # NOTE this requires payment profiles to be supported on your gateway of choice as well as a delayed job handler to be configured with activejob. kicks off an exchange shipment upon return authorization save. charge customer if they do not return items within timely manner.
+    preference :expedited_exchanges_days_window, :integer, default: 14 # the amount of days the customer has to return their item after the expedited exchange is shipped in order to avoid being charged
     preference :hide_cents, :boolean, default: false
     preference :last_check_for_spree_alerts, :string, default: nil
     preference :layout, :string, default: 'spree/layouts/spree_application'

--- a/core/app/models/spree/reimbursement.rb
+++ b/core/app/models/spree/reimbursement.rb
@@ -9,7 +9,6 @@ module Spree
     has_many :return_items, inverse_of: :reimbursement
 
     validates :order, presence: true
-    validates :customer_return, presence: true
     validate :validate_return_items_belong_to_same_order
 
     accepts_nested_attributes_for :return_items, allow_destroy: true
@@ -82,7 +81,7 @@ module Spree
     def calculated_total
       # rounding down to handle edge cases for consecutive partial returns where rounding
       # might cause us to try to reimburse more than was originally billed
-      return_items.to_a.sum(&:total).round(2, :down)
+      return_items.to_a.sum(&:total).to_d.round(2, :down)
     end
 
     def paid_amount

--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -10,12 +10,20 @@ module Spree
     belongs_to :reason, class_name: 'Spree::ReturnAuthorizationReason', foreign_key: :return_authorization_reason_id
     before_create :generate_number
 
+    after_save :generate_expedited_exchange_reimbursements
+
     accepts_nested_attributes_for :return_items, allow_destroy: true
 
     validates :order, presence: true
     validates :reason, presence: true
     validates :stock_location, presence: true
     validate :must_have_shipped_units, on: :create
+
+
+    # These are called prior to generating expedited exchanges shipments.
+    # Should respond to a "call" method that takes the list of return items
+    class_attribute :pre_expedited_exchange_hooks
+    self.pre_expedited_exchange_hooks = []
 
     state_machine initial: :authorized do
       before_transition to: :canceled, do: :cancel_return_items
@@ -65,5 +73,23 @@ module Spree
         return_items.each(&:cancel!)
       end
 
+      def generate_expedited_exchange_reimbursements
+        return unless Spree::Config[:expedited_exchanges]
+
+        items_to_exchange = return_items.select(&:exchange_required?)
+        items_to_exchange.each(&:attempt_accept)
+        items_to_exchange.select!(&:accepted?)
+        pre_expedited_exchange_hooks.each { |h| h.call items_to_exchange }
+
+        reimbursement = Reimbursement.new(return_items: items_to_exchange, order: order)
+
+        if reimbursement.save
+          reimbursement.perform!
+        else
+          errors.add(:base, reimbursement.errors.full_messages)
+          raise ActiveRecord::RecordInvalid.new(self)
+        end
+
+      end
   end
 end

--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -37,11 +37,15 @@ module Spree
     scope :decided, -> { where.not(acceptance_status: %w(pending manual_intervention_required)) }
     scope :reimbursed, -> { where.not(reimbursement_id: nil) }
     scope :not_reimbursed, -> { where(reimbursement_id: nil) }
+    scope :exchange_requested, -> { where.not(exchange_variant: nil) }
+    scope :exchange_processed, -> { where.not(exchange_inventory_unit: nil) }
+    scope :exchange_required, -> { exchange_requested.where(exchange_inventory_unit: nil) }
 
     serialize :acceptance_status_errors
 
     delegate :eligible_for_return?, :requires_manual_intervention?, to: :validator
     delegate :variant, to: :inventory_unit
+    delegate :shipment, to: :inventory_unit
 
     before_create :set_default_pre_tax_amount, unless: :pre_tax_amount_changed?
     before_save :set_exchange_pre_tax_amount
@@ -132,7 +136,11 @@ module Spree
       # for pricing information for if the inventory unit is
       # ever returned. This means that the inventory unit's line_item
       # will have a different variant than the inventory unit itself
-      super(variant: exchange_variant, line_item: inventory_unit.line_item) if exchange_required?
+      super(variant: exchange_variant, line_item: inventory_unit.line_item, order: inventory_unit.order) if exchange_required?
+    end
+
+    def exchange_shipment
+      exchange_inventory_unit.try(:shipment)
     end
 
     def set_default_pre_tax_amount

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -652,6 +652,7 @@ en:
     exceptions:
       count_on_hand_setter: Cannot set count_on_hand manually, as it is set automatically by the recalculate_count_on_hand callback. Please use `update_column(:count_on_hand, value)` instead.
     exchange_for: Exchange for
+    expedited_exchanges_warning: "Any specified exchanges will ship to the customer immediately upon saving. The customer will be charged the full amount of the item if they do not return the original item within %{days_window} days."
     excl: excl.
     expiration: Expiration
     extension: Extension

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -4,6 +4,10 @@ module Spree
       isolate_namespace Spree
       engine_name 'spree'
 
+      rake_tasks do
+        load File.join(root, "lib", "tasks", "exchanges.rake")
+      end
+
       initializer "spree.environment", :before => :load_config_initializers do |app|
         app.config.spree = Spree::Core::Environment.new
         Spree::Config = app.config.spree.preferences #legacy access

--- a/core/lib/spree/testing_support/factories/credit_card_factory.rb
+++ b/core/lib/spree/testing_support/factories/credit_card_factory.rb
@@ -5,5 +5,6 @@ FactoryGirl.define do
     year { Time.now.year }
     number '4111111111111111'
     name 'Spree Commerce'
+    association(:payment_method, factory: :credit_card_payment_method)
   end
 end

--- a/core/lib/spree/testing_support/factories/return_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/return_item_factory.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :return_item, class: Spree::ReturnItem do
-    association(:inventory_unit, factory: :inventory_unit)
+    association(:inventory_unit, factory: :inventory_unit, state: :shipped)
     association(:return_authorization, factory: :return_authorization)
 
     factory :exchange_return_item do

--- a/core/lib/tasks/exchanges.rake
+++ b/core/lib/tasks/exchanges.rake
@@ -1,0 +1,60 @@
+namespace :exchanges do
+  desc %q{Takes unreturned exchanged items and creates a new order to charge
+  the customer for not returning them}
+  task charge_unreturned_items: :environment do
+
+    unreturned_return_items =  Spree::ReturnItem.awaiting_return.exchange_processed.joins(:exchange_inventory_unit).where([
+      "spree_inventory_units.created_at < :days_ago",
+      days_ago: Spree::Config[:expedited_exchanges_days_window].days.ago
+    ]).to_a
+
+    # Determine that a return item has already been deemed unreturned and therefore charged
+    # by the fact that its exchange inventory unit has popped off to a different order
+    unreturned_return_items.select! { |ri| ri.inventory_unit.order_id == ri.exchange_inventory_unit.order_id }
+
+    failed_orders = []
+
+    unreturned_return_items.group_by(&:exchange_shipment).each do |shipment, return_items|
+      begin
+        inventory_units = return_items.map(&:exchange_inventory_unit)
+
+        original_order = shipment.order
+        order = Spree::Order.create!(bill_address: original_order.bill_address,
+                                    ship_address: original_order.ship_address,
+                                    email: original_order.email)
+
+        order.associate_user!(original_order.user) if original_order.user
+
+        return_items.group_by(&:exchange_variant).map do |variant, variant_return_items|
+          variant_inventory_units = variant_return_items.map(&:exchange_inventory_unit)
+          line_item = Spree::LineItem.create!(variant: variant, quantity: variant_return_items.count, order: order)
+          variant_inventory_units.each { |i| i.update_attributes!(line_item_id: line_item.id, order_id: order.id) }
+        end
+
+        order.reload.update!
+
+        card_to_reuse = original_order.valid_credit_cards.first
+        card_to_reuse = original_order.user.credit_cards.default.first if !card_to_reuse && original_order.user
+        Spree::Payment.create!(order: order,
+                               payment_method_id: card_to_reuse.try(:payment_method_id),
+                               source: card_to_reuse,
+                               amount: order.total)
+
+        shipment.update_attributes!(order_id: order.id)
+        order.update_attributes!(state: "confirm")
+
+        order.next!
+        order.reload.update!
+        order.finalize!
+
+        failed_orders << order unless order.completed? && order.valid?
+      rescue
+        failed_orders << order
+      end
+    end
+    failure_message = failed_orders.map { |o| "#{o.number} - #{o.errors.full_messages}" }.join(", ")
+    raise UnableToChargeForUnreturnedItems.new(failure_message) if failed_orders.present?
+  end
+end
+
+class UnableToChargeForUnreturnedItems < StandardError; end

--- a/core/spec/lib/tasks/exchanges_spec.rb
+++ b/core/spec/lib/tasks/exchanges_spec.rb
@@ -1,0 +1,117 @@
+require 'spec_helper'
+
+describe "exchanges:charge_unreturned_items" do
+  include_context "rake"
+
+  its(:prerequisites) { should include("environment") }
+
+  context "there are no unreturned items" do
+    it { expect { subject.invoke }.not_to change { Spree::Order.count } }
+  end
+
+  context "there are unreturned items" do
+    let!(:order) { create(:shipped_order, line_items_count: 2) }
+    let(:return_item_1) { create(:exchange_return_item, inventory_unit: order.inventory_units.first) }
+    let(:return_item_2) { create(:exchange_return_item, inventory_unit: order.inventory_units.last) }
+    let!(:rma) { create(:return_authorization, order: order, return_items: [return_item_1, return_item_2]) }
+
+    context "fewer than the config allowed days have passed" do
+
+      before do
+        @original_expedited_exchanges_pref = Spree::Config[:expedited_exchanges]
+        Spree::Config[:expedited_exchanges] = true
+
+        rma.save!
+        return_item_1.receive!
+        Timecop.travel (Spree::Config[:expedited_exchanges_days_window] - 1).days
+      end
+
+      after do
+        Timecop.return
+        Spree::Config[:expedited_exchanges] = @original_expedited_exchanges_pref
+      end
+
+    end
+
+    context "more than the config allowed days have passed" do
+
+      before do
+        @original_expedited_exchanges_pref = Spree::Config[:expedited_exchanges]
+        Spree::Config[:expedited_exchanges] = true
+
+        rma.save!
+        return_item_1.receive!
+        Timecop.travel (Spree::Config[:expedited_exchanges_days_window] + 1).days
+      end
+
+      after do
+        Timecop.return
+        Spree::Config[:expedited_exchanges] = @original_expedited_exchanges_pref
+      end
+
+      it "creates a new completed order" do
+        expect { subject.invoke }.to change { Spree::Order.count }
+        expect(Spree::Order.last).to be_completed
+      end
+
+      it "moves the shipment for the unreturned items to the new order" do
+        subject.invoke
+        expect(return_item_2.reload.exchange_shipment.order).to eq Spree::Order.last
+      end
+
+      it "creates line items on the order for the unreturned items" do
+        subject.invoke
+        expect(Spree::Order.last.line_items.map(&:variant)).to eq [return_item_2.exchange_variant]
+      end
+
+      it "associates the exchanges inventory units with the new line items" do
+        subject.invoke
+        expect(return_item_2.reload.exchange_inventory_unit.try(:line_item).try(:order)).to eq Spree::Order.last
+      end
+
+      it "uses the credit card from the previous order" do
+        subject.invoke
+        new_order = Spree::Order.last
+        expect(new_order.credit_cards).to be_present
+        expect(new_order.credit_cards.first).to eq order.valid_credit_cards.first
+      end
+
+      it "authorizes the order for the full amount of the unreturned items" do
+        subject.invoke
+        new_order = Spree::Order.last
+        expected_amount = return_item_2.reload.exchange_variant.price
+        expect(new_order.total).to eq expected_amount
+        payment = new_order.payments.first
+        expect(payment.amount).to eq expected_amount
+        expect(payment).to be_pending
+        expect(new_order.item_total).to eq expected_amount
+      end
+
+      it "does not attempt to create a new order for the item more than once" do
+        subject.invoke
+        subject.reenable
+        expect { subject.invoke }.not_to change { Spree::Order.count }
+      end
+
+      context "there is no card from the previous order" do
+        let!(:credit_card) { create(:credit_card, user: order.user, default: true, gateway_customer_profile_id: "BGS-123") }
+        before { Spree::Order.any_instance.stub(:valid_credit_cards) { [] } }
+
+        it "attempts to use the user's default card" do
+          subject.invoke
+          new_order = Spree::Order.last
+          expect(new_order.credit_cards).to be_present
+          expect(new_order.credit_cards.first).to eq credit_card
+        end
+      end
+
+      context "it is unable to authorize the credit card" do
+        before { Spree::Payment.any_instance.stub(:authorize!).and_raise(RuntimeError) }
+
+        it "raises an error with the order" do
+          expect { subject.invoke }.to raise_error(UnableToChargeForUnreturnedItems)
+        end
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/return_item_spec.rb
+++ b/core/spec/models/spree/return_item_spec.rb
@@ -490,12 +490,29 @@ describe Spree::ReturnItem do
           expect(subject).not_to be_persisted
           expect(subject.original_return_item).to eq return_item
           expect(subject.line_item).to eq return_item.inventory_unit.line_item
+          expect(subject.order).to eq return_item.inventory_unit.order
         end
       end
     end
 
     context "the return item is not intended to be exchanged" do
       it { expect(subject).to be_nil }
+    end
+  end
+
+  describe "#exchange_shipment" do
+    it "returns the exchange inventory unit's shipment" do
+      inventory_unit = build(:inventory_unit)
+      subject.exchange_inventory_unit = inventory_unit
+      expect(subject.exchange_shipment).to eq inventory_unit.shipment
+    end
+  end
+
+  describe "#shipment" do
+    it "returns the inventory unit's shipment" do
+      inventory_unit = build(:inventory_unit)
+      subject.inventory_unit = inventory_unit
+      expect(subject.shipment).to eq inventory_unit.shipment
     end
   end
 

--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -7,6 +7,7 @@ if ENV["COVERAGE"]
     add_group 'Mailers', 'app/mailers'
     add_group 'Models', 'app/models'
     add_group 'Views', 'app/views'
+    add_group 'Jobs', 'app/jobs'
     add_group 'Libraries', 'lib'
   end
 end
@@ -27,6 +28,7 @@ require 'ffaker'
 
 require "support/big_decimal"
 require "support/test_gateway"
+require "support/rake"
 
 if ENV["CHECK_TRANSLATIONS"]
   require "spree/testing_support/i18n"

--- a/core/spec/support/rake.rb
+++ b/core/spec/support/rake.rb
@@ -1,0 +1,13 @@
+require "rake"
+
+shared_context "rake" do
+  let(:task_name) { self.class.top_level_description }
+  let(:task_path) { "lib/tasks/#{task_name.split(":").first}" }
+  subject         { Rake::Task[task_name] }
+
+  before do
+    Rake::Task.define_task(:environment)
+    load File.expand_path(Rails.root + "../../#{task_path}.rake")
+    subject.reenable
+  end
+end


### PR DESCRIPTION
When a return authorization is saved
Given a return item has a requested exchange
Then an exchange shipment for the exchange items for the return authorization are generated immediately

Given an exchange shipment has been generated pre-return
Given a customer has not returned their item after X days
Then create a new order with the exchange shipment and capture payment for the full amount of the items
