### PR TITLE
Use rspec-retry to get past random phantomjs failures

### DIFF
--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -54,6 +54,16 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = false
 
+  # A workaround to deal with random failure caused by phantomjs. Turn it on
+  # by setting ENV['RSPEC_RETRY_COUNT']. Limit it to features tests where
+  # phantomjs is used.
+  config.before(:all, :type => :feature) do
+    if ENV['RSPEC_RETRY_COUNT']
+      config.verbose_retry       = true # show retry status in spec process
+      config.default_retry_count = ENV['RSPEC_RETRY_COUNT'].to_i
+    end
+  end
+
   config.before :suite do
     Capybara.match = :prefer_exact
     DatabaseCleaner.clean_with :truncation

--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -29,4 +29,5 @@ group :test do
   gem 'simplecov'
   gem 'webmock', '1.8.11'
   gem 'poltergeist', '1.5.0'
+  gem 'rspec-retry'
 end

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -66,6 +66,16 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = false
 
+  # A workaround to deal with random failure caused by phantomjs. Turn it on
+  # by setting ENV['RSPEC_RETRY_COUNT']. Limit it to features tests where
+  # phantomjs is used.
+  config.before(:all, :type => :feature) do
+    if ENV['RSPEC_RETRY_COUNT']
+      config.verbose_retry       = true # show retry status in spec process
+      config.default_retry_count = ENV['RSPEC_RETRY_COUNT'].to_i
+    end
+  end
+  
   if ENV['WEBDRIVER'] == 'accessible'
     config.around(:each, :inaccessible => true) do |example|
       Capybara::Accessible.skip_audit { example.run }


### PR DESCRIPTION
There are random rspec failures in backend's feature tests. This is caused by a well known issue in phantomjs. Sometimes it doesn't load the page element on time before the test start checking on it. There are various workarounds to deal with it: increase wait time, add sleep in failing tests, retry failling tests, etc.

This PR leverages rspec-retry gem to retry failling tests. It's limited only to features tests in frontend & backend where phantomjs is used. It's turned off by default. If anybody wants to enable it they can run rspec like this:

```
RSPEC_RETRY_COUNT=2 rspec
```

It will retry the test (up to two times) if it fails.
