### PR TITLE
Order by reverse created_at in Admin::UsersController

### DIFF
--- a/backend/app/controllers/spree/admin/users_controller.rb
+++ b/backend/app/controllers/spree/admin/users_controller.rb
@@ -66,7 +66,7 @@ module Spree
 
       def orders
         params[:q] ||= {}
-        @search = Spree::Order.ransack(params[:q].merge(user_id_eq: @user.id))
+        @search = Spree::Order.reverse_chronological.ransack(params[:q].merge(user_id_eq: @user.id))
         @orders = @search.result.page(params[:page]).per(Spree::Config[:admin_products_per_page])
       end
 


### PR DESCRIPTION
Similar to https://github.com/spree/spree/pull/5024 - but for the Admin::UsersController.

(Note that because we're looking at a single user, it probably doesn't matter much whether we use `completed_at` or `created_at`.)
