### PR TITLE
Reimbursement email

### DIFF
--- a/core/app/mailers/spree/reimbursement_mailer.rb
+++ b/core/app/mailers/spree/reimbursement_mailer.rb
@@ -1,0 +1,10 @@
+module Spree
+  class ReimbursementMailer < BaseMailer
+      def reimbursement_email(reimbursement, resend = false)
+        @reimbursement = reimbursement.respond_to?(:id) ? reimbursement : Spree::Reimbursement.find(reimbursement)
+        subject = (resend ? "[#{Spree.t(:resend).upcase}] " : '')
+        subject += "#{Spree::Store.current.name} #{Spree.t('reimbursement_mailer.reimbursement_email.subject')} ##{@reimbursement.order.number}"
+        mail(to: @reimbursement.order.email, from: from_address, subject: subject)
+      end
+  end
+end

--- a/core/app/models/spree/reimbursement.rb
+++ b/core/app/models/spree/reimbursement.rb
@@ -53,6 +53,7 @@ module Spree
     self.reimbursement_failure_hooks = []
 
     state_machine :reimbursement_status, initial: :pending do
+      after_transition to: :reimbursed, do: :send_reimbursement_email
 
       event :errored do
         transition to: :errored, from: :pending
@@ -138,5 +139,8 @@ module Spree
       end
     end
 
+    def send_reimbursement_email
+      Spree::ReimbursementMailer.reimbursement_email(self).deliver
+    end
   end
 end

--- a/core/app/views/spree/reimbursement_mailer/reimbursement_email.text.erb
+++ b/core/app/views/spree/reimbursement_mailer/reimbursement_email.text.erb
@@ -1,0 +1,22 @@
+<%= Spree.t('reimbursement_mailer.reimbursement_email.dear_customer') %>
+
+<%= Spree.t('reimbursement_mailer.reimbursement_email.instructions') %>
+
+============================================================
+<%= Spree.t('reimbursement_mailer.reimbursement_email.refund_summary') %>
+============================================================
+<%= Spree.t('reimbursement_mailer.reimbursement_email.total_refunded', total: @reimbursement.display_total) %>
+
+<% if @reimbursement.return_items.exchange_requested.present? %>
+============================================================
+<%= Spree.t('reimbursement_mailer.reimbursement_email.exchange_summary') %>
+============================================================
+<% @reimbursement.return_items.exchange_requested.each do |return_item| %>
+<%= return_item.variant.sku %> <%= raw(return_item.variant.product.name) %> <%= "(#{raw(return_item.variant.options_text)})" if return_item.variant.options_text.present? -%> -> <%= return_item.exchange_variant.sku %> <%= raw(return_item.exchange_variant.product.name) if return_item.exchange_variant.options_text.present? %> <%= "(#{raw(return_item.exchange_variant.options_text)})" -%>
+<% end %>
+
+
+<% if @reimbursement.return_items.awaiting_return.present? && Spree::Config[:expedited_exchanges] %>
+<%= Spree.t('reimbursement_mailer.reimbursement_email.days_to_send', days: Spree::Config[:expedited_exchanges_days_window]) %>
+<% end %>
+<% end %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1109,6 +1109,16 @@ en:
     return_item_time_period_ineligible: Return item is outside the eligible time period
     return_items: Return Items
     return_items_cannot_be_associated_with_multiple_orders: Return items cannot be associated with multiple orders.
+    reimbursement_mailer:
+      reimbursement_email:
+        days_to_send: ! 'You have %{days} days to send back any items awaiting exchange.'
+        dear_customer: Dear Customer,
+        exchange_summary: Exchange Summary
+        for: for
+        instructions: Your reimbursement has been processed.
+        refund_summary: Refund Summary
+        subject: Reimbursement Notification
+        total_refunded: ! 'Total refunded: %{total}'
     return_number: Return Number
     return_quantity: Return Quantity
     returned: Returned

--- a/core/spec/mailers/reimbursement_mailer_spec.rb
+++ b/core/spec/mailers/reimbursement_mailer_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+require 'email_spec'
+
+describe Spree::ReimbursementMailer do
+  include EmailSpec::Helpers
+  include EmailSpec::Matchers
+
+  let(:reimbursement) { create(:reimbursement) }
+
+  context ":from not set explicitly" do
+    it "falls back to spree config" do
+      message = Spree::ReimbursementMailer.reimbursement_email(reimbursement)
+      expect(message.from).to eq [Spree::Config[:mails_from]]
+    end
+  end
+
+  it "accepts a reimbursement id as an alternative to a Reimbursement object" do
+    Spree::Reimbursement.should_receive(:find).with(reimbursement.id).and_return(reimbursement)
+
+    lambda {
+      reimbursement_email = Spree::ReimbursementMailer.reimbursement_email(reimbursement.id)
+    }.should_not raise_error
+  end
+
+  context "emails must be translatable" do
+    context "reimbursement_email" do
+      context "pt-BR locale" do
+        before do
+          I18n.enforce_available_locales = false
+          pt_br_shipped_email = { :spree => { :reimbursement_mailer => { :reimbursement_email => { :dear_customer => 'Caro Cliente,' } } } }
+          I18n.backend.store_translations :'pt-BR', pt_br_shipped_email
+          I18n.locale = :'pt-BR'
+        end
+
+        after do
+          I18n.locale = I18n.default_locale
+          I18n.enforce_available_locales = true
+        end
+
+        specify do
+          reimbursement_email = Spree::ReimbursementMailer.reimbursement_email(reimbursement)
+          reimbursement_email.body.should include("Caro Cliente,")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When a customer return is reimbursed, we can send the customer an email with details on the reimbursement which includes:
- The total amount refunded
- Any exchange information related to the order
