### PR TITLE
Display return acceptance errors in Admin UI

### DIFF
--- a/backend/app/views/spree/admin/customer_returns/_return_item_decision.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_return_item_decision.html.erb
@@ -6,6 +6,7 @@
       <th><%= Spree.t(:pre_tax_amount) %></th>
       <th><%= Spree.t(:preferred_reimbursement_type) %></th>
       <th><%= Spree.t(:exchange_for) %></th>
+      <th><%= Spree.t(:acceptance_errors) %></th>
       <% if show_decision %>
         <th class="actions"></th>
       <% end %>
@@ -29,6 +30,9 @@
         </td>
         <td class="align-center">
           <%= return_item.exchange_variant.try(:options_text) %>
+        </td>
+        <td class="align-center">
+          <%= return_item.acceptance_status_errors %>
         </td>
         <% if show_decision %>
           <td class='actions'>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -348,6 +348,7 @@ en:
     abbreviation: Abbreviation
     accept: Accept
     acceptance_status: Acceptance status
+    acceptance_errors: Acceptance errors
     accepted: Accepted
     account: Account
     account_updated: Account updated


### PR DESCRIPTION
So admins know what rule caused an item to be rejected or placed in the manual_intervention_require state.
