### PR TITLE
Remove new & edit Admin pages for reimbursement types

### DIFF
--- a/backend/app/views/spree/admin/reimbursement_types/edit.html.erb
+++ b/backend/app/views/spree/admin/reimbursement_types/edit.html.erb
@@ -1,4 +1,0 @@
-<%= render partial: 'spree/admin/shared/named_types/edit', locals: {
-  page_title: Spree.t(:editing_reimbursement_type),
-  back_button_text: Spree.t(:back_to_reimbursement_type_list)
-} %>

--- a/backend/app/views/spree/admin/reimbursement_types/index.html.erb
+++ b/backend/app/views/spree/admin/reimbursement_types/index.html.erb
@@ -1,5 +1,33 @@
-<%= render partial: 'spree/admin/shared/named_types/index', locals: {
-  page_title: Spree.t(:reimbursement_types),
-  new_button_text: Spree.t(:new_reimbursement_type),
-  resource_name: I18n.t(:other, scope: 'activerecord.models.spree/reimbursement_type')
-} %>
+<%= render partial: 'spree/admin/shared/configuration_menu' %>
+
+<% content_for :page_title do %>
+  <%= Spree.t(:reimbursement_types) %>
+<% end %>
+
+<% if @reimbursement_types.any? %>
+  <table class="index" id='listing_reimbursement_types' data-hook>
+    <thead>
+      <tr data-hook="reimbursement_types_header">
+        <th><%= Spree.t(:name) %></th>
+        <th><%= Spree.t(:type) %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @reimbursement_types.each do |reimbursement_type| %>
+        <tr id="<%= spree_dom_id reimbursement_type %>" data-hook="reimbursement_type_row" class="<%= cycle('odd', 'even')%>">
+          <td class="align-center">
+            <%= reimbursement_type.name.humanize %>
+          </td>
+          <td>
+            <%= reimbursement_type.type %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <div class="alpha twelve columns no-objects-found">
+    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/reimbursement_type')) %>,
+    <%= link_to Spree.t(:add_one), new_object_url %>!
+  </div>
+<% end %>

--- a/backend/app/views/spree/admin/reimbursement_types/new.html.erb
+++ b/backend/app/views/spree/admin/reimbursement_types/new.html.erb
@@ -1,4 +1,0 @@
-<%= render partial: 'spree/admin/shared/named_types/new', locals: {
-  page_title: Spree.t(:new_reimbursement_type),
-  back_button_text: Spree.t(:back_to_reimbursement_type_list)
-} %>

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -142,7 +142,7 @@ Spree::Core::Engine.add_routes do
       end
     end
 
-    resources :reimbursement_types, :except => [:show, :destroy]
+    resources :reimbursement_types, :only => [:index]
     resources :refund_reasons, :except => [:show, :destroy]
     resources :return_authorization_reasons, :except => [:show, :destroy]
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -828,7 +828,6 @@ en:
     new_prototype: New Prototype
     new_refund: New Refund
     new_refund_reason: New Refund Reason
-    new_reimbursement_type: New Reimbursement Type
     new_rma_reason: New RMA Reason
     new_return_authorization: New Return Authorization
     new_shipping_category: New Shipping Category

--- a/core/db/migrate/20140806144901_add_type_to_reimbursement_type.rb
+++ b/core/db/migrate/20140806144901_add_type_to_reimbursement_type.rb
@@ -3,6 +3,7 @@ class AddTypeToReimbursementType < ActiveRecord::Migration
     add_column :spree_reimbursement_types, :type, :string
     add_index :spree_reimbursement_types, :type
 
-    Spree::ReimbursementType.find_by(name: Spree::ReimbursementType::ORIGINAL).update_attributes(type: 'Spree::ReimbursementType::OriginalPayment')
+    Spree::ReimbursementType.reset_column_information
+    Spree::ReimbursementType.find_by(name: Spree::ReimbursementType::ORIGINAL).update_attributes!(type: 'Spree::ReimbursementType::OriginalPayment')
   end
 end


### PR DESCRIPTION
These are managed through code (e.g. migrations) rather than the Admin UI.
Leave an index page to display the current state.

Also:
- Fix a migration. It was failing silently because of cached column information
