### PR TITLE
Ignore "order_completed" flash on rails 4.1

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -68,10 +68,10 @@ module Spree
     end
 
     def flash_messages(opts = {})
-      opts[:ignore_types] = [:order_completed].concat(Array(opts[:ignore_types]) || [])
+      ignore_types = ["order_completed"].concat(Array(opts[:ignore_types]).map(&:to_s) || [])
 
       flash.each do |msg_type, text|
-        unless opts[:ignore_types].include?(msg_type)
+        unless ignore_types.include?(msg_type)
           concat(content_tag :div, text, class: "flash #{msg_type}")
         end
       end

--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -71,7 +71,7 @@ describe Spree::BaseHelper do
 
   # Regression test for #2034
   context "flash_message" do
-    let(:flash) { {:notice => "ok", :foo => "foo", :bar => "bar"} }
+    let(:flash) { {"notice" => "ok", "foo" => "foo", "bar" => "bar"} }
 
     it "should output all flash content" do
       flash_messages


### PR DESCRIPTION
The code to ignore the "order_completed" flash in base_helper isn't working on rails 4.1. If you refer to the source you'll see that keys are being stringified on assignment and because of that we need to ignore flashes based on strings instead of symbols. 

Relavant link to see how keys are stringified in 4.1 when new flashes are assigned:
https://github.com/rails/rails/blob/4-1-stable/actionpack/lib/action_dispatch/middleware/flash.rb
