### PR TITLE
Improved logic for payment state on canceled orders. 

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -297,7 +297,11 @@ module Spree
     end
 
     def outstanding_balance
-      total - payment_total
+      if self.state == 'canceled' && self.payments.present? && self.payments.last.state == "completed"
+        -1 * payment_total
+      else
+        total - payment_total
+      end
     end
 
     def outstanding_balance?

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -297,7 +297,7 @@ module Spree
     end
 
     def outstanding_balance
-      if self.state == 'canceled' && self.payments.present? && self.payments.last.state == "completed"
+      if self.state == 'canceled' && self.payments.present? && self.payments.completed.size > 0
         -1 * payment_total
       else
         total - payment_total

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -147,6 +147,10 @@ module Spree
       last_state = order.payment_state
       if payments.present? && payments.last.state == 'failed'
         order.payment_state = 'failed'
+      elsif !payments.present? && order.state == 'canceled'
+        order.payment_state = 'void'
+      elsif order.state == 'canceled' && order.payment_total == 0 && payments.last.state == 'completed'
+        order.payment_state = 'void'
       else
         order.payment_state = 'balance_due' if order.outstanding_balance > 0
         order.payment_state = 'credit_owed' if order.outstanding_balance < 0

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -149,7 +149,7 @@ module Spree
         order.payment_state = 'failed'
       elsif !payments.present? && order.state == 'canceled'
         order.payment_state = 'void'
-      elsif order.state == 'canceled' && order.payment_total == 0 && payments.last.state == 'completed'
+      elsif order.state == 'canceled' && order.payment_total == 0 && payments.completed.size > 0
         order.payment_state = 'void'
       else
         order.payment_state = 'balance_due' if order.outstanding_balance > 0

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -6,7 +6,7 @@ module Spree
     let(:updater) { Spree::OrderUpdater.new(order) }
 
     context "order totals" do
-      before do 
+      before do
         2.times do
           create(:line_item, :order => order, price: 10)
         end
@@ -127,6 +127,48 @@ module Spree
           }.to change { order.payment_state }.to 'paid'
         end
       end
+
+      context "order is canceled" do
+
+        before do
+          order.state = 'canceled'
+        end
+
+        context "and is still unpaid" do
+          it "is void" do
+            order.payment_total = 0
+            order.total = 30
+            expect {
+              updater.update_payment_state
+            }.to change { order.payment_state }.to 'void'
+          end
+        end
+
+        context "and is paid" do
+
+          it "is credit_owed" do
+            order.payment_total = 30
+            order.total = 30
+            order.stub_chain(:payments, :last, :state).and_return('completed')
+            expect {
+              updater.update_payment_state
+            }.to change { order.payment_state }.to 'credit_owed'
+          end
+
+        end
+
+        context "and payment is refunded" do
+          it "is void" do
+            order.payment_total = 0
+            order.total = 30
+            order.stub_chain(:payments, :last, :state).and_return('completed')
+            expect {
+              updater.update_payment_state
+            }.to change { order.payment_state }.to 'void'
+          end
+        end
+      end
+
     end
 
     it "state change" do

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -150,6 +150,7 @@ module Spree
             order.payment_total = 30
             order.total = 30
             order.stub_chain(:payments, :last, :state).and_return('completed')
+            order.stub_chain(:payments, :completed, :size).and_return(1)
             expect {
               updater.update_payment_state
             }.to change { order.payment_state }.to 'credit_owed'
@@ -162,6 +163,7 @@ module Spree
             order.payment_total = 0
             order.total = 30
             order.stub_chain(:payments, :last, :state).and_return('completed')
+            order.stub_chain(:payments, :completed, :size).and_return(2)
             expect {
               updater.update_payment_state
             }.to change { order.payment_state }.to 'void'


### PR DESCRIPTION
#5106

add more logic to outstancing balance and order updater to set the correct payment_state on the order when the order is canceled.

Do not merge yet. Need some more edge cases to make sure we have all the bases covered.
