### PR TITLE
Added 'var' to define the function

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js.erb
@@ -1,6 +1,6 @@
 'use strict';
 
-set_taxon_select = function(){
+var set_taxon_select = function(){
   if ($('#product_taxon_ids').length > 0) {
     $('#product_taxon_ids').select2({
       placeholder: Spree.translations.taxon_placeholder,


### PR DESCRIPTION
Causes error when trying to load a page that uses this; such as the product edit page.

```
Uncaught ReferenceError: set_taxon_select is not defined
```
