### PR TITLE
Add the reimbursement to ReimbursementHelpers.create_creditable params

### DIFF
--- a/core/app/models/spree/reimbursement_type/reimbursement_helpers.rb
+++ b/core/app/models/spree/reimbursement_type/reimbursement_helpers.rb
@@ -37,14 +37,14 @@ module Spree
     # If you have multiple methods of crediting a customer, overwrite this method
     # Must return an array of objects the respond to #description, #display_amount
     def create_credit(reimbursement, unpaid_amount, simulate)
-      creditable = create_creditable(unpaid_amount)
+      creditable = create_creditable(reimbursement, unpaid_amount)
       credit = reimbursement.credits.build(creditable: creditable, amount: unpaid_amount)
       simulate ? credit.readonly! : credit.save!
       credit
     end
 
-    def create_creditable(unpaid_amount)
-      Spree::Reimbursement::Credit.default_creditable_class.new(amount: unpaid_amount)
+    def create_creditable(reimbursement, unpaid_amount)
+      Spree::Reimbursement::Credit.default_creditable_class.new(reimbursement: reimbursement, amount: unpaid_amount)
     end
   end
 end


### PR DESCRIPTION
This is needed to associate the creditable instance with the reimbursement, and to get other useful information out of the reimbursement for creditable creation
