### PR TITLE
Allow a shipment to transition to shipped when its order is canceled

### DIFF
--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -58,7 +58,7 @@ module Spree
               end
 
               event :return do
-                transition to: :returned, from: [:complete, :awaiting_return], if: :all_inventory_units_returned?
+                transition to: :returned, from: [:complete, :awaiting_return, :canceled], if: :all_inventory_units_returned?
               end
 
               event :resume do

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -43,7 +43,7 @@ module Spree
       end
 
       event :ship do
-        transition from: :ready, to: :shipped
+        transition from: [:ready, :canceled], to: :shipped
       end
       after_transition to: :shipped, do: :after_ship
 
@@ -61,7 +61,7 @@ module Spree
         }
         transition from: :canceled, to: :pending
       end
-      after_transition from: :canceled, to: [:pending, :ready], do: :after_resume
+      after_transition from: :canceled, to: [:pending, :ready, :shipped], do: :after_resume
 
       after_transition do |shipment, transition|
         shipment.state_changes.create!(


### PR DESCRIPTION
Depending on how shipments are fulfilled, it may be possible to end up in a state where an order has been canceled but has still been shipped.

For instance, a shipment fulfiller may process orders that are ready for shipment and then transitions the shipment to shipped in Spree once they have shipped the order. However, the order may be canceled in Spree before the shipment fulfiller has reported back that it has been shipped. This causes the order to be in the canceled state when it has really been shipped.

It would be nice to be allowed to transition from canceled to shipped in cases like these to have better order monitoring. Additionally, if Spree thinks the order has been canceled and not yet shipped, no RMAs or customer returns could be created. Allowing a transition from canceled to shipped eliminates this potential problem.
