### PR TITLE
Don't reimburse return item if preferred method is invalid

### DIFF
--- a/core/app/models/spree/reimbursement/reimbursement_type_engine.rb
+++ b/core/app/models/spree/reimbursement/reimbursement_type_engine.rb
@@ -1,5 +1,7 @@
 module Spree
   class Reimbursement::ReimbursementTypeEngine
+    include Spree::Reimbursement::ReimbursementTypeValidator
+
     class_attribute :refund_time_constraint
     self.refund_time_constraint = 90.days
 
@@ -19,16 +21,15 @@ module Spree
 
     def calculate_reimbursement_types
       @return_items.each do |return_item|
-        shipped_at = return_item.inventory_unit.shipment.shipped_at
-
         if return_item.exchange_required?
           add_reimbursement_type(return_item, exchange_reimbursement_type)
         elsif return_item.override_reimbursement_type.present?
           add_reimbursement_type(return_item, return_item.override_reimbursement_type)
-        elsif shipped_at && shipped_at < refund_time_constraint.ago
-          add_reimbursement_type(return_item, expired_reimbursement_type)
         elsif return_item.preferred_reimbursement_type.present?
+          next unless valid_preferred_reimbursement_type?(return_item)
           add_reimbursement_type(return_item, return_item.preferred_reimbursement_type)
+        elsif past_reimbursable_time_period?(return_item)
+          add_reimbursement_type(return_item, expired_reimbursement_type)
         else
           add_reimbursement_type(return_item, default_reimbursement_type)
         end

--- a/core/app/models/spree/reimbursement/reimbursement_type_validator.rb
+++ b/core/app/models/spree/reimbursement/reimbursement_type_validator.rb
@@ -1,0 +1,12 @@
+module Spree
+  module Reimbursement::ReimbursementTypeValidator
+    def valid_preferred_reimbursement_type?(return_item)
+      !past_reimbursable_time_period?(return_item) || return_item.preferred_reimbursement_type == expired_reimbursement_type
+    end
+
+    def past_reimbursable_time_period?(return_item)
+      shipped_at = return_item.inventory_unit.shipment.shipped_at
+      shipped_at && shipped_at < refund_time_constraint.ago
+    end
+  end
+end

--- a/core/spec/models/spree/reimbursement/reimbursement_type_validator_spec.rb
+++ b/core/spec/models/spree/reimbursement/reimbursement_type_validator_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+module Spree
+  describe Reimbursement::ReimbursementTypeValidator do
+    class DummyClass
+      include Spree::Reimbursement::ReimbursementTypeValidator
+      
+      class_attribute :expired_reimbursement_type
+      self.expired_reimbursement_type = Spree::ReimbursementType::OriginalPayment
+
+      class_attribute :refund_time_constraint
+      self.refund_time_constraint = 90.days
+    end
+
+    let(:return_item)   { create(:return_item) }
+    let(:dummy)         { DummyClass.new }
+
+    describe '#valid_preferred_reimbursement_type?' do
+      before do
+        dummy.stub(:past_reimbursable_time_period?).and_return(true)
+        return_item.stub(:preferred_reimbursement_type).and_return(Spree::ReimbursementType::Credit)
+      end
+
+      subject { dummy.valid_preferred_reimbursement_type?(return_item) }
+
+      context 'is valid' do
+        it 'if it is not past the reimbursable time period' do
+          dummy.stub(:past_reimbursable_time_period?).and_return(false)
+          subject.should be_true
+        end
+
+        it 'if the return items preferred method of reimbursement is the expired method of reimbursement' do
+          return_item.stub(:preferred_reimbursement_type).and_return(dummy.expired_reimbursement_type)
+          subject.should be_true
+        end
+      end
+
+      context 'is invalid' do
+        it 'if the return item is past the eligible time period and the preferred method of reimbursement is not the expired method of reimbursement' do
+          subject.should be_false
+        end
+      end
+    end
+
+    describe '#past_reimbursable_time_period?' do
+      subject { dummy.past_reimbursable_time_period?(return_item) }
+
+      before do
+        return_item.stub_chain(:inventory_unit, :shipment, :shipped_at).and_return(shipped_at)
+      end
+
+      context 'it has not shipped' do
+        let(:shipped_at) { nil }
+
+        it 'is not past the reimbursable time period' do
+          subject.should be_false
+        end
+      end
+
+      context 'it has shipped and it is more recent than the time constraint' do
+        let(:shipped_at) { (dummy.refund_time_constraint - 1.day).ago }
+
+        it 'is not past the reimbursable time period' do
+          subject.should be_false
+        end
+      end
+
+      context 'it has shipped and it is further in the past than the time constraint' do
+        let(:shipped_at) { (dummy.refund_time_constraint + 1.day).ago }
+
+        it 'is past the reimbursable time period' do
+          subject.should be_true
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- The preferred method is invalid if it is past the reimbursable time period and the preferred method is not the expired method of reimbursing
