### PR TITLE
RFC - prevent checkout with all invalid payments

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -864,6 +864,7 @@ en:
     no_orders_found: No orders found
     no_payment_methods_found: No payment methods found
     no_payment_found: No payment found
+    no_payments_valid: No valid payments for order
     no_pending_payments: No pending payments
     no_products_found: No products found
     no_promotions_found: No promotions found

--- a/core/spec/models/spree/order/state_machine_spec.rb
+++ b/core/spec/models/spree/order/state_machine_spec.rb
@@ -21,7 +21,7 @@ describe Spree::Order do
 
       context "when payment processing succeeds" do
         before do
-          order.stub payments: [1]
+          order.payments << FactoryGirl.create(:payment, state: 'completed', order: order)
           order.stub process_payments: true
         end
 


### PR DESCRIPTION
This commit attempts to address an issue where it is possible to checkout with only invalid / failed payments. I believe the issue is due to process_payments! only considers pending payments. If every payment is failed / invalid, it will return true, this allowing the `after_transition: :payment` to continue to the next steps.

The result is that if a payment process fails legitimately for the first try i.e. Gateway rejects or invalid to Active Merchant, someone can simply do order.next! a second time and just move on. This is regardless of capture true/false on the Spree configuration key `allow_checkout_on_gateway_error`.

What's contained in this PR.

1) break out of after_transition block to make testing easier.
2) explicit return false when conditions not met
3) add check for no valid payments after process_payments
4) test changes and additions

Steps To Replicate
1) Add a known bad payment to Stripe Gateway i.e. cus_YYYYY, card_XXXXX
2) Invoke order.next and receive a gateway error.
3) Invoke order.next again.

Expected
1) Failure and still at payment state.

Actual
1) Moved on to confirm state and no errors.
