### PR TITLE
Fix AvailabilityValidator for saved records

### DIFF
--- a/core/app/models/spree/stock/availability_validator.rb
+++ b/core/app/models/spree/stock/availability_validator.rb
@@ -2,13 +2,9 @@ module Spree
   module Stock
     class AvailabilityValidator < ActiveModel::Validator
       def validate(line_item)
-        if shipment = line_item.target_shipment
-          units = shipment.inventory_units_for(line_item.variant)
-          return if units.count > line_item.quantity
-          quantity = line_item.quantity - units.count
-        else
-          quantity = line_item.quantity
-        end
+        unit_count = line_item.inventory_units.size
+        return if unit_count >= line_item.quantity
+        quantity = line_item.quantity - unit_count
 
         quantifier = Stock::Quantifier.new(line_item.variant)
 

--- a/core/spec/models/spree/stock/availability_validator_spec.rb
+++ b/core/spec/models/spree/stock/availability_validator_spec.rb
@@ -3,19 +3,26 @@ require 'spec_helper'
 module Spree
   module Stock
     describe AvailabilityValidator do
-      let!(:line_item) { double(quantity: 5, target_shipment: nil, variant_id: 1, variant: double.as_null_object, errors: double('errors')) }
+      let!(:line_item) { double(quantity: 5, variant_id: 1, variant: double.as_null_object, errors: double('errors'), inventory_units: []) }
 
       subject { described_class.new }
 
       it 'should be valid when supply is sufficient' do
         Stock::Quantifier.any_instance.stub(can_supply?: true)
-        line_item.errors.should_not_receive(:[]).with(:quantity)
+        line_item.should_not_receive(:errors)
         subject.validate(line_item)
       end
 
       it 'should be invalid when supply is insufficent' do
         Stock::Quantifier.any_instance.stub(can_supply?: false)
         line_item.errors.should_receive(:[]).with(:quantity).and_return []
+        subject.validate(line_item)
+      end
+
+      it 'should consider existing inventory_units sufficient' do
+        Stock::Quantifier.any_instance.stub(can_supply?: false)
+        line_item.should_not_receive(:errors)
+        line_item.stub(inventory_units: [double] * 5)
         subject.validate(line_item)
       end
     end


### PR DESCRIPTION
Previously `AvailabilityValidator` only considered inventory_units on the target_shipment of a line_item. Since target_shipment is not persisted, a saved line_item would become invalid when its variant ran out of available inventory even if the inventory_units were already reserved.
