### PR TITLE
When restarting checkout, go to cart and then call next to trigger transition hooks

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -561,9 +561,10 @@ module Spree
 
     def restart_checkout_flow
       self.update_columns(
-        state: checkout_steps.first,
+        state: 'cart',
         updated_at: Time.now,
       )
+      self.next
     end
 
     def refresh_shipment_rates


### PR DESCRIPTION
I've implemented some transition hooks that I'd like to trigger when someone updates their cart and restarts the checkout flow. The problem is that calling `checkout_steps.first` simply updates the order state column to `address`, so when a customer then clicks checkout, any `_transition from: :cart` and `_transition to: :address` hooks are ignored.

This code change results in 3 failing spec tests, although I can't reproduce the failures in higher level feature tests or using the actual site.

First, does anyone see any problems with this change or a better way of accomplishing the same task; and secondly, how to make the tests pass.
