### PR TITLE
Add API endpoint /api/shipments/mine

### DIFF
--- a/api/app/views/spree/api/shipments/big.v1.rabl
+++ b/api/app/views/spree/api/shipments/big.v1.rabl
@@ -1,0 +1,48 @@
+object @shipment
+cache @shipment
+attributes *shipment_attributes
+
+child selected_shipping_rate: :selected_shipping_rate do
+  extends "spree/api/shipping_rates/show"
+end
+
+child inventory_units: :inventory_units do
+  object @inventory_unit
+  attributes *inventory_unit_attributes
+
+  child :variant do
+    extends "spree/api/variants/small"
+    attributes :product_id
+    child(images: :images) { extends "spree/api/images/show" }
+  end
+
+  child :line_item do
+    attributes *line_item_attributes
+    node(:single_display_amount) { |li| li.single_display_amount.to_s }
+    node(:display_amount) { |li| li.display_amount.to_s }
+    node(:total) { |li| li.total }
+  end
+end
+
+child order: :order do
+  extends "spree/api/orders/order"
+
+  child billing_address: :bill_address do
+    extends "spree/api/addresses/show"
+  end
+
+  child shipping_address: :ship_address do
+    extends "spree/api/addresses/show"
+  end
+
+  child adjustments: :adjustments do
+    extends "spree/api/adjustments/show"
+  end
+
+  child payments: :payments do
+    attributes :id, :amount, :display_amount, :state
+    child payment_method: :payment_method do
+      attributes :id, :name
+    end
+  end
+end

--- a/api/app/views/spree/api/shipments/mine.v1.rabl
+++ b/api/app/views/spree/api/shipments/mine.v1.rabl
@@ -1,0 +1,9 @@
+object false
+
+node(:count) { @shipments.count }
+node(:current_page) { params[:page] || 1 }
+node(:pages) { @shipments.num_pages }
+
+child(@shipments => :shipments) do
+  extends "spree/api/shipments/big"
+end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -75,6 +75,7 @@ Spree::Core::Engine.add_routes do
       collection do
         post 'transfer_to_location'
         post 'transfer_to_shipment'
+        get :mine
       end
 
       member do

--- a/api/spec/controllers/spree/api/shipments_controller_spec.rb
+++ b/api/spec/controllers/spree/api/shipments_controller_spec.rb
@@ -115,5 +115,53 @@ describe Spree::Api::ShipmentsController do
       end
 
     end
+
+    describe '#mine' do
+      subject do
+        api_get :mine, format: 'json', params: params
+      end
+
+      let(:params) { {} }
+
+      before { subject }
+
+      context "the current api user is authenticated and has orders" do
+        let(:current_api_user) { shipped_order.user }
+        let(:shipped_order) { create(:shipped_order) }
+
+        it 'succeeds' do
+          expect(response.status).to eq 200
+        end
+
+        describe 'json output' do
+          render_views
+
+          let(:rendered_shipment_ids) { json_response['shipments'].map { |s| s['id'] } }
+
+          it 'contains the shipments' do
+            expect(rendered_shipment_ids).to match_array current_api_user.orders.flat_map(&:shipments).map(&:id)
+          end
+        end
+
+        context 'with filtering' do
+          let(:params) { {q: {order_completed_at_not_null: 1}} }
+
+          let!(:incomplete_order) { create(:order, user: current_api_user) }
+
+          it 'filters' do
+            expect(assigns(:shipments).map(&:id)).to match_array current_api_user.orders.complete.flat_map(&:shipments).map(&:id)
+          end
+        end
+      end
+
+      context "the current api user is not persisted" do
+        let(:current_api_user) { Spree.user_class.new }
+
+        it "returns a 401" do
+          response.status.should == 401
+        end
+      end
+    end
+
   end
 end

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -28,6 +28,8 @@ module Spree
     scope :shipped, -> { with_state('shipped') }
     scope :trackable, -> { where("tracking IS NOT NULL AND tracking != ''") }
     scope :with_state, ->(*s) { where(state: s) }
+    # sort by most recent shipped_at, falling back to created_at. add "id desc" to make specs that involve this scope more deterministic.
+    scope :reverse_chronological, -> { order('coalesce(spree_shipments.shipped_at, spree_shipments.created_at) desc', id: :desc) }
 
     # shipment state machine (see http://github.com/pluginaweek/state_machine/tree/master for details)
     state_machine initial: :pending, use_transactions: false do

--- a/guides/content/api/shipments.md
+++ b/guides/content/api/shipments.md
@@ -5,6 +5,36 @@ description: Use the Spree Commerce storefront API to access Shipment data.
 
 # Shipments API
 
+## Mine
+
+Retrieve a list of the current user's shipments by making this request:
+
+```text
+GET /api/shipments/mine```
+
+Shipments are paginated and can be iterated through by passing along a `page` parameter:
+
+```text
+GET /api/shipments/mine?page=2```
+
+### Parameters
+
+page
+: The page number of shipments to display.
+
+per_page
+: The number of shipments to return per page.
+
+### Response
+
+<%= headers 200 %>
+<%= json(:shipment) do |h|
+{ count: 25,
+  current_page: 1,
+  pages: 5,
+  shipments: [h] }
+end %>
+
 ## Create
 
 <%= admin_only %>

--- a/guides/layouts/api/_sidebar.html
+++ b/guides/layouts/api/_sidebar.html
@@ -313,6 +313,10 @@
         <ul class="js-guides">
           <li>
             <i class="icon-dot"></i>
+            <%= link_to "Mine", 'shipments', 'mine' %>
+          </li>
+          <li>
+            <i class="icon-dot"></i>
             <%= link_to "Create", 'shipments', 'create' %>
           </li>
           <li>


### PR DESCRIPTION
With expedited exchanges we now have times when stores will be interested in deep details of a single shipment, without having to grab all the details of all shipments in an order.

Trying to prevent a bunch of n+1 queries with a bunch of includes.
