### PR TITLE
Change product_url to product_path.

### DIFF
--- a/frontend/app/views/spree/shared/_products.html.erb
+++ b/frontend/app/views/spree/shared/_products.html.erb
@@ -31,7 +31,9 @@
           <%= link_to small_image(product, :itemprop => "image"), url, :itemprop => 'url' %>
         </div>
         <%= link_to truncate(product.name, :length => 50), url, :class => 'info', :itemprop => "name", :title => product.name %>
-        <span class="price selling" itemprop="price"><%= display_price(product) %></span>
+        <span itemprop="offers" itemscope itemtype="http://schema.org/Offer">
+          <span class="price selling" itemprop="price"><%= display_price(product) %>
+        </span>
       <% end %>
     </li>
   <% end %>

--- a/frontend/app/views/spree/shared/_products.html.erb
+++ b/frontend/app/views/spree/shared/_products.html.erb
@@ -24,7 +24,7 @@
 <% if products.any? %>
 <ul id="products" class="inline product-listing" data-hook>
   <% products.each do |product| %>
-    <% url = product_url(product, :taxon_id => @taxon.try(:id)) %>
+    <% url = product_path(product, :taxon_id => @taxon.try(:id)) %>
     <li id="product_<%= product.id %>" class="columns three <%= cycle("alpha", "secondary", "", "omega secondary", :name => "classes") %>" data-hook="products_list_item" itemscope itemtype="http://schema.org/Product">
       <% cache(@taxon.present? ? [I18n.locale, current_currency, @taxon, product] : [I18n.locale, current_currency, product]) do %>
         <div class="product-image">


### PR DESCRIPTION
I'm not sure why product_url was introduced, but I'm currently encountering
issues in production where it's not respecting subdomains, HTTPS, and ports
correctly.

Nearly everything else in Spree links to stuff using the _path helpers, which
I like a lot better.
