### PR TITLE
Variants need to be touched when a new stock location is created

### DIFF
--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -77,7 +77,10 @@ module Spree
       end
 
       def conditional_variant_touch
-        if !Spree::Config.binary_inventory_cache || (count_on_hand_changed? && count_on_hand_change.any?(&:zero?))
+        # the variant_id changes from nil when a new stock location is added
+        stock_changed = (count_on_hand_changed? && count_on_hand_change.any?(&:zero?)) || variant_id_changed?
+
+        if !Spree::Config.binary_inventory_cache || stock_changed
           variant.touch
         end
       end

--- a/core/spec/models/spree/stock_item_spec.rb
+++ b/core/spec/models/spree/stock_item_spec.rb
@@ -211,6 +211,14 @@ describe Spree::StockItem do
           end.not_to change { subject.variant.reload.updated_at }
         end
       end
+
+      context "when a new stock location is added" do
+        it "touches its variant" do
+          expect do
+            create(:stock_location)
+          end.to change { subject.variant.reload.updated_at }
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Added coverage and adjusted the logic in stock_item.conditional_variant_touch to make the necessary touch in the case that a new stock location is created.

Variants already get touched when stock items are changed but this case was not covered.
