### PR TITLE
promotions api show

### DIFF
--- a/api/app/controllers/spree/api/promotions_controller.rb
+++ b/api/app/controllers/spree/api/promotions_controller.rb
@@ -1,0 +1,26 @@
+module Spree
+  module Api
+    class PromotionsController < Spree::Api::BaseController
+      before_filter :requires_admin
+      before_filter :load_promotion
+
+      def show
+        if @promotion
+          respond_with(@promotion, default_template: :show)
+        else
+          raise ActiveRecord::RecordNotFound
+        end
+      end
+
+      private 
+        def requires_admin
+          return if @current_user_roles.include?("admin")
+          unauthorized and return
+        end
+
+        def load_promotion
+          @promotion = Spree::Promotion.find_by_id(params[:id]) || Spree::Promotion.with_coupon_code(params[:id])
+        end
+    end
+  end
+end

--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -29,7 +29,8 @@ module Spree
         :property_attributes,
         :stock_location_attributes,
         :stock_movement_attributes,
-        :stock_item_attributes
+        :stock_item_attributes,
+        :promotion_attributes
       ]
 
       mattr_reader *ATTRIBUTES
@@ -148,6 +149,10 @@ module Spree
       @@stock_item_attributes = [
         :id, :count_on_hand, :backorderable, :lock_version, :stock_location_id,
         :variant_id
+      ]
+
+      @@promotion_attributes = [
+         :id, :name, :description, :expires_at, :starts_at, :type, :usage_limit, :match_policy, :code, :advertise, :path
       ]
 
       def variant_attributes

--- a/api/app/views/spree/api/promotions/show.v1.rabl
+++ b/api/app/views/spree/api/promotions/show.v1.rabl
@@ -1,0 +1,2 @@
+object @promotion
+attributes *promotion_attributes

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -9,6 +9,8 @@ Spree::Core::Engine.add_routes do
   end
 
   namespace :api, defaults: { format: 'json' } do
+    resources :promotions, only: [:show]
+
     resources :products do
       resources :images
       resources :variants

--- a/api/spec/controllers/spree/api/promotions_controller_spec.rb
+++ b/api/spec/controllers/spree/api/promotions_controller_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+module Spree
+  describe Spree::Api::PromotionsController do
+    render_views
+
+    shared_examples "a JSON response" do
+      it 'should be ok' do
+        expect(subject).to be_ok
+      end
+
+      it 'should return JSON' do
+        payload = HashWithIndifferentAccess.new(JSON.parse(subject.body))
+        expect(payload).to_not be_nil
+        Spree::Api::ApiHelpers.promotion_attributes.each do |attribute|
+          expect(payload.has_key?(attribute)).to be_true
+        end
+      end
+    end
+
+    before do
+      stub_authentication!
+    end
+
+    let(:promotion) { create :promotion, code: '10off' }
+
+    describe 'GET #show' do
+      subject { api_get :show, id: id }
+
+      context 'when admin' do
+        sign_in_as_admin!
+
+        context 'when finding by id' do
+          let(:id) { promotion.id }
+
+          it_behaves_like "a JSON response"
+        end
+
+        context 'when finding by code' do
+          let(:id) { promotion.code }
+
+          it_behaves_like "a JSON response"
+        end
+
+        context 'when id does not exist' do
+          let(:id) { 'argh' }
+
+          it 'should be 404' do
+            expect(subject.status).to eq(404)
+          end
+        end
+      end
+
+      context 'when non admin' do
+        let(:id) { promotion.id }
+
+        it 'should be unauthorized' do
+          subject
+          assert_unauthorized!
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Super simple endpoint to get the details of a promotion via API. Requires admin role and searches by code or id. The attributes are the basic attributes in the promotion model and are enumerated in ApiHelpers.
