### PR TITLE
provide status code on apply promotion code

### DIFF
--- a/api/app/views/spree/api/promotions/handler.v1.rabl
+++ b/api/app/views/spree/api/promotions/handler.v1.rabl
@@ -2,3 +2,4 @@ object false
 node(:success) { @handler.success }
 node(:error) { @handler.error }
 node(:successful) { @handler.successful? }
+node(:status_code) { @handler.status_code }

--- a/api/spec/controllers/spree/api/promotion_application_spec.rb
+++ b/api/spec/controllers/spree/api/promotion_application_spec.rb
@@ -26,6 +26,7 @@ module Spree::Api
         json_response["success"].should == "The coupon code was successfully applied to your order."
         json_response["error"].should be_blank
         json_response["successful"].should be_true
+        json_response["status_code"].should eq("coupon_code_applied")
       end
 
       context "with an expired promotion" do
@@ -41,6 +42,7 @@ module Spree::Api
           json_response["success"].should be_blank
           json_response["error"].should == "The coupon code is expired"
           json_response["successful"].should be_false
+          json_response["status_code"].should eq("coupon_code_expired")
         end
       end
     end

--- a/core/app/models/spree/promotion_handler/coupon.rb
+++ b/core/app/models/spree/promotion_handler/coupon.rb
@@ -2,7 +2,7 @@ module Spree
   module PromotionHandler
     class Coupon
       attr_reader :order
-      attr_accessor :error, :success
+      attr_accessor :error, :success, :status_code
 
       def initialize(order)
         @order = order
@@ -14,14 +14,24 @@ module Spree
             handle_present_promotion(promotion)
           else
             if Promotion.with_coupon_code(order.coupon_code).try(:expired?)
-              self.error = Spree.t(:coupon_code_expired)
+              set_error_code :coupon_code_expired
             else
-              self.error = Spree.t(:coupon_code_not_found)
+              set_error_code :coupon_code_not_found
             end
           end
         end
 
         self
+      end
+
+      def set_success_code(c)
+        @status_code = c
+        @success = Spree.t(c)
+      end
+
+      def set_error_code(c)
+        @status_code = c
+        @error = Spree.t(c)
       end
 
       def promotion
@@ -48,20 +58,20 @@ module Spree
         if result
           determine_promotion_application_result
         else
-          self.error = Spree.t(:coupon_code_unknown_error)
+          set_error_code :coupon_code_unknown_error
         end
       end
 
       def promotion_usage_limit_exceeded
-        self.error = Spree.t(:coupon_code_max_usage)
+        set_error_code :coupon_code_max_usage
       end
 
       def ineligible_for_this_order
-        self.error = Spree.t(:coupon_code_not_eligible)
+        set_error_code :coupon_code_not_eligible
       end
 
       def promotion_applied
-        self.error = Spree.t(:coupon_code_already_applied)
+        set_error_code :coupon_code_already_applied
       end
 
       def promotion_exists_on_order?(order, promotion)
@@ -82,15 +92,15 @@ module Spree
         if discount.eligible
           order.update_totals
           order.persist_totals
-          self.success = Spree.t(:coupon_code_applied)
+          set_success_code :coupon_code_applied
         else
           # if the promotion exists on an order, but wasn't found above,
           # we've already selected a better promotion
           if order.promotions.with_coupon_code(order.coupon_code)
-            self.error = Spree.t(:coupon_code_better_exists)
+            set_error_code :coupon_code_better_exists
           else
             # if the promotion was created after the order
-            self.error = Spree.t(:coupon_code_not_found)
+            set_error_code :coupon_code_not_found
           end
         end
       end

--- a/core/spec/models/spree/promotion_handler/coupon_spec.rb
+++ b/core/spec/models/spree/promotion_handler/coupon_spec.rb
@@ -10,7 +10,41 @@ module Spree
       it "returns self in apply" do
         expect(subject.apply).to be_a Coupon
       end
+     
+      context 'status messages' do 
+        let(:coupon) { Coupon.new(order) }
 
+        describe "#set_success_code" do
+          let(:status) { :coupon_code_applied }
+          subject { coupon.set_success_code status }
+
+          it 'should have status_code' do
+            subject
+            expect(coupon.status_code).to eq(status)
+          end
+
+          it 'should have success message' do
+            subject
+            expect(coupon.success).to eq(Spree.t(status))
+          end
+        end
+
+        describe "#set_error_code" do
+          let(:status) { :coupon_code_not_found }
+ 
+          subject { coupon.set_error_code status }
+
+          it 'should have status_code' do
+            subject
+            expect(coupon.status_code).to eq(status)
+          end
+
+          it 'should have error message' do
+            subject
+            expect(coupon.error).to eq(Spree.t(status))
+          end
+        end
+      end
 
       context "coupon code promotion doesnt exist" do
         before { Promotion.create name: "promo", :code => nil }


### PR DESCRIPTION
This change adds a status_code to the JSON response for the apply promotion code response object for `PUT /api/orders/:id/apply_coupon_code`. It's a little bit brittle to bind on the translation message from `Spree.t` and sometimes more granularity is needed then success/error. The status_code should hopefully solve this.
