### PR TITLE
Change order updater to refresh shipment rates and amounts on change

### DIFF
--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -49,7 +49,12 @@ module Spree
 
     # give each of the shipments a chance to update themselves
     def update_shipments
-      shipments.each { |shipment| shipment.update!(order) if shipment.persisted? }
+      shipments.each do |shipment|
+        next unless shipment.persisted?
+        shipment.update!(order)
+        shipment.refresh_rates
+        shipment.update_amounts
+      end
     end
 
     def update_payment_total

--- a/core/spec/models/spree/order/state_machine_spec.rb
+++ b/core/spec/models/spree/order/state_machine_spec.rb
@@ -100,7 +100,7 @@ describe Spree::Order do
                               stub_model(Spree::InventoryUnit, :variant => variant) ]}
     let!(:shipment) do
       shipment = stub_model(Spree::Shipment)
-      shipment.stub :inventory_units => inventory_units
+      shipment.stub :inventory_units => inventory_units, :order => order
       order.stub :shipments => [shipment]
       shipment
     end

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -201,7 +201,7 @@ module Spree
       end
 
       it "updates each shipment" do
-        shipment = stub_model(Spree::Shipment)
+        shipment = stub_model(Spree::Shipment, :order => order)
         shipments = [shipment]
         order.stub :shipments => shipments
         shipments.stub :states => []
@@ -210,6 +210,24 @@ module Spree
         shipments.stub :shipped => []
 
         shipment.should_receive(:update!).with(order)
+        updater.update_shipments
+      end
+
+      it "refreshes shipment rates" do
+        shipment = stub_model(Spree::Shipment, :order => order)
+        shipments = [shipment]
+        order.stub :shipments => shipments
+
+        shipment.should_receive(:refresh_rates)
+        updater.update_shipments
+      end
+
+      it "updates the shipment amount" do
+        shipment = stub_model(Spree::Shipment, :order => order)
+        shipments = [shipment]
+        order.stub :shipments => shipments
+
+        shipment.should_receive(:update_amounts)
         updater.update_shipments
       end
     end

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -508,6 +508,7 @@ describe Spree::Shipment do
         Spree::Config[:auto_capture_on_dispatch] = true
         @order = create :completed_order_with_pending_payment
         @shipment = @order.shipments.first
+        @shipment.cost = @order.ship_total
       end
 
       it "shipments ready for an order if the order is unpaid" do


### PR DESCRIPTION
This change will refresh the shipment rates and amounts when a completed order state changes.

One specific example would be if the order line item quantity is changed in the admin menus we want the order shipment and shipping total to update.

[Fix #5222]
