### PR TITLE
Fix potential tax calculation issues with charging of unreturned expedited exchanges

### DIFF
--- a/core/lib/tasks/exchanges.rake
+++ b/core/lib/tasks/exchanges.rake
@@ -43,6 +43,9 @@ namespace :exchanges do
                                  amount: order.total)
         end
 
+        # the order builds a shipment on its own on transition to delivery, but we want
+        # the original exchange shipment, not the built one
+        order.shipments.destroy_all
         shipment.update_attributes!(order_id: order.id)
         order.update_attributes!(state: "confirm")
 

--- a/core/lib/tasks/exchanges.rake
+++ b/core/lib/tasks/exchanges.rake
@@ -32,19 +32,22 @@ namespace :exchanges do
         end
 
         order.reload.update!
+        while order.next; end
 
-        card_to_reuse = original_order.valid_credit_cards.first
-        card_to_reuse = original_order.user.credit_cards.default.first if !card_to_reuse && original_order.user
-        Spree::Payment.create!(order: order,
-                               payment_method_id: card_to_reuse.try(:payment_method_id),
-                               source: card_to_reuse,
-                               amount: order.total)
+        unless order.payments.present?
+          card_to_reuse = original_order.valid_credit_cards.first
+          card_to_reuse = original_order.user.credit_cards.default.first if !card_to_reuse && original_order.user
+          Spree::Payment.create!(order: order,
+                                 payment_method_id: card_to_reuse.try(:payment_method_id),
+                                 source: card_to_reuse,
+                                 amount: order.total)
+        end
 
         shipment.update_attributes!(order_id: order.id)
         order.update_attributes!(state: "confirm")
 
-        order.next!
-        order.reload.update!
+        order.reload.next!
+        order.update!
         order.finalize!
 
         failed_orders << order unless order.completed? && order.valid?

--- a/core/spec/lib/tasks/exchanges_spec.rb
+++ b/core/spec/lib/tasks/exchanges_spec.rb
@@ -57,6 +57,8 @@ describe "exchanges:charge_unreturned_items" do
 
       it "moves the shipment for the unreturned items to the new order" do
         subject.invoke
+        new_order = Spree::Order.last
+        expect(new_order.shipments.count).to eq 1
         expect(return_item_2.reload.exchange_shipment.order).to eq Spree::Order.last
       end
 
@@ -92,9 +94,6 @@ describe "exchanges:charge_unreturned_items" do
         subject.invoke
         subject.reenable
         expect { subject.invoke }.not_to change { Spree::Order.count }
-      end
-
-      it "does not process two payments" do
       end
 
       context "there is no card from the previous order" do


### PR DESCRIPTION
- Test that taxes are included
- Make sure to hit all state machine transition events

Conflicts:
    core/lib/tasks/exchanges.rake
