### PR TITLE
Rename *_filter callbacks to *_action callbacks

### DIFF
--- a/api/app/controllers/spree/api/addresses_controller.rb
+++ b/api/app/controllers/spree/api/addresses_controller.rb
@@ -1,7 +1,7 @@
 module Spree
   module Api
     class AddressesController < Spree::Api::BaseController
-      before_filter :find_order
+      before_action :find_order
 
       def show
         load_and_authorize_address(:read)

--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -10,11 +10,11 @@ module Spree
 
       attr_accessor :current_api_user
 
-      before_filter :set_content_type
-      before_filter :load_user
-      before_filter :authorize_for_order, :if => Proc.new { order_token.present? }
-      before_filter :authenticate_user
-      before_filter :load_user_roles
+      before_action :set_content_type
+      before_action :load_user
+      before_action :authorize_for_order, if: Proc.new { order_token.present? }
+      before_action :authenticate_user
+      before_action :load_user_roles
 
       after_filter  :set_jsonp_format
 

--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -1,12 +1,12 @@
 module Spree
   module Api
     class CheckoutsController < Spree::Api::BaseController
-      before_filter :associate_user, only: :update
+      before_action :associate_user, only: :update
 
       include Spree::Core::ControllerHelpers::Auth
       include Spree::Core::ControllerHelpers::Order
       # This before_filter comes from Spree::Core::ControllerHelpers::Order
-      skip_before_filter :set_current_order
+      skip_before_action :set_current_order
 
       def next
         load_order(true)

--- a/api/app/controllers/spree/api/countries_controller.rb
+++ b/api/app/controllers/spree/api/countries_controller.rb
@@ -1,8 +1,8 @@
 module Spree
   module Api
     class CountriesController < Spree::Api::BaseController
-      skip_before_filter :check_for_user_or_api_key
-      skip_before_filter :authenticate_user
+      skip_before_action :check_for_user_or_api_key
+      skip_before_action :authenticate_user
 
       def index
         @countries = Country.accessible_by(current_ability, :read).ransack(params[:q]).result.

--- a/api/app/controllers/spree/api/credit_cards_controller.rb
+++ b/api/app/controllers/spree/api/credit_cards_controller.rb
@@ -1,7 +1,7 @@
 module Spree
   module Api
     class CreditCardsController < Spree::Api::BaseController
-      before_filter :user
+      before_action :user
 
       def index
         @credit_cards = Spree::CreditCard

--- a/api/app/controllers/spree/api/inventory_units_controller.rb
+++ b/api/app/controllers/spree/api/inventory_units_controller.rb
@@ -1,7 +1,7 @@
 module Spree
   module Api
     class InventoryUnitsController < Spree::Api::BaseController
-      before_filter :prepare_event, :only => :update
+      before_action :prepare_event, only: :update
 
       def show
         @inventory_unit = inventory_unit

--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -1,10 +1,10 @@
 module Spree
   module Api
     class OrdersController < Spree::Api::BaseController
-      skip_before_filter :check_for_user_or_api_key, only: :apply_coupon_code
-      skip_before_filter :authenticate_user, only: :apply_coupon_code
+      skip_before_action :check_for_user_or_api_key, only: :apply_coupon_code
+      skip_before_action :authenticate_user, only: :apply_coupon_code
 
-      before_filter :find_order, except: [:create, :mine, :current, :index, :update]
+      before_action :find_order, except: [:create, :mine, :current, :index, :update]
 
       # Dynamically defines our stores checkout steps to ensure we check authorization on each step.
       Order.checkout_steps.keys.each do |step|

--- a/api/app/controllers/spree/api/payments_controller.rb
+++ b/api/app/controllers/spree/api/payments_controller.rb
@@ -2,8 +2,8 @@ module Spree
   module Api
     class PaymentsController < Spree::Api::BaseController
 
-      before_filter :find_order
-      before_filter :find_payment, only: [:update, :show, :authorize, :purchase, :capture, :void]
+      before_action :find_order
+      before_action :find_payment, only: [:update, :show, :authorize, :purchase, :capture, :void]
 
       def index
         @payments = @order.payments.ransack(params[:q]).result.page(params[:page]).per(params[:per_page])

--- a/api/app/controllers/spree/api/product_properties_controller.rb
+++ b/api/app/controllers/spree/api/product_properties_controller.rb
@@ -2,8 +2,8 @@ module Spree
   module Api
     class ProductPropertiesController < Spree::Api::BaseController
 
-      before_filter :find_product
-      before_filter :product_property, only: [:show, :update, :destroy]
+      before_action :find_product
+      before_action :product_property, only: [:show, :update, :destroy]
 
       def index
         @product_properties = @product.product_properties.accessible_by(current_ability, :read).

--- a/api/app/controllers/spree/api/properties_controller.rb
+++ b/api/app/controllers/spree/api/properties_controller.rb
@@ -2,7 +2,7 @@ module Spree
   module Api
     class PropertiesController < Spree::Api::BaseController
 
-      before_filter :find_property, only: [:show, :update, :destroy]
+      before_action :find_property, only: [:show, :update, :destroy]
 
       def index
         @properties = Spree::Property.accessible_by(current_ability, :read)

--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -2,8 +2,8 @@ module Spree
   module Api
     class ShipmentsController < Spree::Api::BaseController
 
-      before_filter :find_and_update_shipment, only: [:ship, :ready, :add, :remove]
-      before_filter :load_transfer_params, only: [:transfer_to_location, :transfer_to_shipment]
+      before_action :find_and_update_shipment, only: [:ship, :ready, :add, :remove]
+      before_action :load_transfer_params, only: [:transfer_to_location, :transfer_to_shipment]
 
       def create
         @order = Spree::Order.find_by!(number: params[:shipment][:order_id])

--- a/api/app/controllers/spree/api/states_controller.rb
+++ b/api/app/controllers/spree/api/states_controller.rb
@@ -1,9 +1,9 @@
 module Spree
   module Api
     class StatesController < Spree::Api::BaseController
-      skip_before_filter :set_expiry
-      skip_before_filter :check_for_user_or_api_key
-      skip_before_filter :authenticate_user
+      skip_before_action :set_expiry
+      skip_before_action :check_for_user_or_api_key
+      skip_before_action :authenticate_user
 
       def index
         @states = scope.ransack(params[:q]).result.

--- a/api/app/controllers/spree/api/stock_items_controller.rb
+++ b/api/app/controllers/spree/api/stock_items_controller.rb
@@ -1,7 +1,7 @@
 module Spree
   module Api
     class StockItemsController < Spree::Api::BaseController
-      before_filter :stock_location, except: [:update, :destroy]
+      before_action :stock_location, except: [:update, :destroy]
 
       def index
         @stock_items = scope.ransack(params[:q]).result.page(params[:page]).per(params[:per_page])

--- a/api/app/controllers/spree/api/stock_movements_controller.rb
+++ b/api/app/controllers/spree/api/stock_movements_controller.rb
@@ -1,7 +1,7 @@
 module Spree
   module Api
     class StockMovementsController < Spree::Api::BaseController
-      before_filter :stock_location, except: [:update, :destroy]
+      before_action :stock_location, except: [:update, :destroy]
 
       def index
         authorize! :read, StockMovement

--- a/api/app/controllers/spree/api/variants_controller.rb
+++ b/api/app/controllers/spree/api/variants_controller.rb
@@ -1,7 +1,7 @@
 module Spree
   module Api
     class VariantsController < Spree::Api::BaseController
-      before_filter :product
+      before_action :product
 
       def create
         authorize! :create, Variant

--- a/backend/app/controllers/spree/admin/adjustments_controller.rb
+++ b/backend/app/controllers/spree/admin/adjustments_controller.rb
@@ -8,7 +8,7 @@ module Spree
       destroy.after :update_totals
       update.after :update_totals
 
-      skip_before_filter :load_resource, only: [:toggle_state, :edit, :update, :destroy]
+      skip_before_action :load_resource, only: [:toggle_state, :edit, :update, :destroy]
 
       def destroy
         find_adjustment

--- a/backend/app/controllers/spree/admin/base_controller.rb
+++ b/backend/app/controllers/spree/admin/base_controller.rb
@@ -7,8 +7,8 @@ module Spree
       helper 'spree/admin/tables'
       layout '/spree/layouts/admin'
 
-      before_filter :check_alerts
-      before_filter :authorize_admin
+      before_action :check_alerts
+      before_action :authorize_admin
 
       protected
 

--- a/backend/app/controllers/spree/admin/customer_returns_controller.rb
+++ b/backend/app/controllers/spree/admin/customer_returns_controller.rb
@@ -3,8 +3,8 @@ module Spree
     class CustomerReturnsController < ResourceController
       belongs_to 'spree/order', find_by: :number
 
-      before_filter :parent # ensure order gets loaded to support our pseudo parent-child relationship
-      before_filter :load_form_data, only: [:new, :edit]
+      before_action :parent # ensure order gets loaded to support our pseudo parent-child relationship
+      before_action :load_form_data, only: [:new, :edit]
 
       create.before :build_return_items_from_params
       create.fails  :load_form_data

--- a/backend/app/controllers/spree/admin/general_settings_controller.rb
+++ b/backend/app/controllers/spree/admin/general_settings_controller.rb
@@ -1,7 +1,7 @@
 module Spree
   module Admin
     class GeneralSettingsController < Spree::Admin::BaseController
-      before_filter :set_store
+      before_action :set_store
 
       def edit
         @preferences_security = [:allow_ssl_in_production,

--- a/backend/app/controllers/spree/admin/images_controller.rb
+++ b/backend/app/controllers/spree/admin/images_controller.rb
@@ -1,7 +1,7 @@
 module Spree
   module Admin
     class ImagesController < ResourceController
-      before_filter :load_data
+      before_action :load_data
 
       create.before :set_viewable
       update.before :set_viewable

--- a/backend/app/controllers/spree/admin/line_items_controller.rb
+++ b/backend/app/controllers/spree/admin/line_items_controller.rb
@@ -3,8 +3,8 @@ module Spree
     class LineItemsController < Spree::Admin::BaseController
       layout nil, :only => [:create, :destroy, :update]
 
-      before_filter :load_order
-      before_filter :load_line_item, :only => [:destroy, :update]
+      before_action :load_order
+      before_action :load_line_item, only: [:destroy, :update]
 
       respond_to :html, :js
 

--- a/backend/app/controllers/spree/admin/log_entries_controller.rb
+++ b/backend/app/controllers/spree/admin/log_entries_controller.rb
@@ -1,7 +1,7 @@
 module Spree
   module Admin
     class LogEntriesController < Spree::Admin::BaseController
-      before_filter :find_order_and_payment
+      before_action :find_order_and_payment
 
       def index
         @log_entries = @payment.log_entries

--- a/backend/app/controllers/spree/admin/option_types_controller.rb
+++ b/backend/app/controllers/spree/admin/option_types_controller.rb
@@ -1,7 +1,7 @@
 module Spree
   module Admin
     class OptionTypesController < ResourceController
-      before_filter :setup_new_option_value, :only => [:edit]
+      before_action :setup_new_option_value, only: :edit
 
       def update_values_positions
         params[:positions].each do |id, index|

--- a/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
+++ b/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
@@ -2,7 +2,7 @@ module Spree
   module Admin
     module Orders
       class CustomerDetailsController < Spree::Admin::BaseController
-        before_filter :load_order
+        before_action :load_order
 
         def show
           edit

--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -1,8 +1,8 @@
 module Spree
   module Admin
     class OrdersController < Spree::Admin::BaseController
-      before_filter :initialize_order_events
-      before_filter :load_order, :only => [:edit, :update, :cancel, :resume, :approve, :resend, :open_adjustments, :close_adjustments, :cart]
+      before_action :initialize_order_events
+      before_action :load_order, only: [:edit, :update, :cancel, :resume, :approve, :resend, :open_adjustments, :close_adjustments, :cart]
 
       respond_to :html
 

--- a/backend/app/controllers/spree/admin/payment_methods_controller.rb
+++ b/backend/app/controllers/spree/admin/payment_methods_controller.rb
@@ -1,9 +1,9 @@
 module Spree
   module Admin
     class PaymentMethodsController < ResourceController
-      skip_before_filter :load_resource, :only => [:create]
-      before_filter :load_data
-      before_filter :validate_payment_method_provider, :only => :create
+      skip_before_action :load_resource, only: :create
+      before_action :load_data
+      before_action :validate_payment_method_provider, only: :create
 
       respond_to :html
 

--- a/backend/app/controllers/spree/admin/payments_controller.rb
+++ b/backend/app/controllers/spree/admin/payments_controller.rb
@@ -3,10 +3,10 @@ module Spree
     class PaymentsController < Spree::Admin::BaseController
       include Spree::Backend::Callbacks
 
-      before_filter :load_order, :only => [:create, :new, :index, :fire]
-      before_filter :load_payment, :except => [:create, :new, :index]
-      before_filter :load_data
-      before_filter :can_not_transition_without_customer_info
+      before_action :load_order, only: [:create, :new, :index, :fire]
+      before_action :load_payment, except: [:create, :new, :index]
+      before_action :load_data
+      before_action :can_not_transition_without_customer_info
 
       respond_to :html
 

--- a/backend/app/controllers/spree/admin/product_properties_controller.rb
+++ b/backend/app/controllers/spree/admin/product_properties_controller.rb
@@ -2,8 +2,8 @@ module Spree
   module Admin
     class ProductPropertiesController < ResourceController
       belongs_to 'spree/product', :find_by => :slug
-      before_filter :find_properties
-      before_filter :setup_property, :only => [:index]
+      before_action :find_properties
+      before_action :setup_property, only: :index
 
       private
         def find_properties

--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -3,7 +3,7 @@ module Spree
     class ProductsController < ResourceController
       helper 'spree/products'
 
-      before_filter :load_data, :except => :index
+      before_action :load_data, except: :index
       create.before :create_before
       update.before :update_before
       helper_method :clone_object_url

--- a/backend/app/controllers/spree/admin/promotion_actions_controller.rb
+++ b/backend/app/controllers/spree/admin/promotion_actions_controller.rb
@@ -1,6 +1,6 @@
 class Spree::Admin::PromotionActionsController < Spree::Admin::BaseController
-  before_filter :load_promotion, :only => [:create, :destroy]
-  before_filter :validate_promotion_action_type, :only => :create
+  before_action :load_promotion, only: [:create, :destroy]
+  before_action :validate_promotion_action_type, only: :create
 
   def create
     @calculators = Spree::Promotion::Actions::CreateAdjustment.calculators

--- a/backend/app/controllers/spree/admin/promotion_rules_controller.rb
+++ b/backend/app/controllers/spree/admin/promotion_rules_controller.rb
@@ -1,8 +1,8 @@
 class Spree::Admin::PromotionRulesController < Spree::Admin::BaseController
   helper 'spree/promotion_rules'
 
-  before_filter :load_promotion, :only => [:create, :destroy]
-  before_filter :validate_promotion_rule_type, :only => :create
+  before_action :load_promotion, only: [:create, :destroy]
+  before_action :validate_promotion_rule_type, only: :create
 
   def create
     # Remove type key from this hash so that we don't attempt

--- a/backend/app/controllers/spree/admin/promotions_controller.rb
+++ b/backend/app/controllers/spree/admin/promotions_controller.rb
@@ -1,7 +1,7 @@
 module Spree
   module Admin
     class PromotionsController < ResourceController
-      before_filter :load_data
+      before_action :load_data
 
       helper 'spree/promotion_rules'
 

--- a/backend/app/controllers/spree/admin/refunds_controller.rb
+++ b/backend/app/controllers/spree/admin/refunds_controller.rb
@@ -2,7 +2,7 @@ module Spree
   module Admin
     class RefundsController < ResourceController
       belongs_to 'spree/payment'
-      before_filter :load_order
+      before_action :load_order
 
       helper_method :refund_reasons
 

--- a/backend/app/controllers/spree/admin/reimbursements_controller.rb
+++ b/backend/app/controllers/spree/admin/reimbursements_controller.rb
@@ -3,7 +3,7 @@ module Spree
     class ReimbursementsController < ResourceController
       belongs_to 'spree/order', find_by: :number
 
-      before_filter :load_simulated_refunds, only: :edit
+      before_action :load_simulated_refunds, only: :edit
 
       def perform
         @reimbursement.perform!

--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -2,7 +2,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
   include Spree::Backend::Callbacks
 
   helper_method :new_object_url, :edit_object_url, :object_url, :collection_url
-  before_filter :load_resource, :except => [:update_positions]
+  before_action :load_resource, except: :update_positions
   rescue_from ActiveRecord::RecordNotFound, :with => :resource_not_found
 
   respond_to :html

--- a/backend/app/controllers/spree/admin/return_authorizations_controller.rb
+++ b/backend/app/controllers/spree/admin/return_authorizations_controller.rb
@@ -3,7 +3,7 @@ module Spree
     class ReturnAuthorizationsController < ResourceController
       belongs_to 'spree/order', :find_by => :number
 
-      before_filter :load_form_data, only: [:new, :edit]
+      before_action :load_form_data, only: [:new, :edit]
       create.fails  :load_form_data
       update.fails  :load_form_data
 

--- a/backend/app/controllers/spree/admin/search_controller.rb
+++ b/backend/app/controllers/spree/admin/search_controller.rb
@@ -2,7 +2,7 @@ module Spree
   module Admin
     class SearchController < Spree::Admin::BaseController
       # http://spreecommerce.com/blog/2010/11/02/json-hijacking-vulnerability/
-      before_filter :check_json_authenticity, :only => :index
+      before_action :check_json_authenticity, only: :index
       respond_to :json
 
       # TODO: Clean this up by moving searching out to user_class_extensions

--- a/backend/app/controllers/spree/admin/shipping_methods_controller.rb
+++ b/backend/app/controllers/spree/admin/shipping_methods_controller.rb
@@ -1,9 +1,9 @@
 module Spree
   module Admin
     class ShippingMethodsController < ResourceController
-      before_filter :load_data, :except => [:index]
-      before_filter :set_shipping_category, :only => [:create, :update]
-      before_filter :set_zones, :only => [:create, :update]
+      before_action :load_data, except: :index
+      before_action :set_shipping_category, only: [:create, :update]
+      before_action :set_zones, only: [:create, :update]
 
       def destroy
         @object.destroy

--- a/backend/app/controllers/spree/admin/states_controller.rb
+++ b/backend/app/controllers/spree/admin/states_controller.rb
@@ -2,7 +2,7 @@ module Spree
   module Admin
     class StatesController < ResourceController
       belongs_to 'spree/country'
-      before_filter :load_data
+      before_action :load_data
 
       def index
         respond_with(@collection) do |format|

--- a/backend/app/controllers/spree/admin/stock_items_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_items_controller.rb
@@ -1,7 +1,7 @@
 module Spree
   module Admin
     class StockItemsController < Spree::Admin::BaseController
-      before_filter :determine_backorderable, only: :update
+      before_action :determine_backorderable, only: :update
 
       def update
         stock_item.save

--- a/backend/app/controllers/spree/admin/stock_locations_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_locations_controller.rb
@@ -2,7 +2,7 @@ module Spree
   module Admin
     class StockLocationsController < ResourceController
 
-      before_filter :set_country, :only => :new
+      before_action :set_country, only: :new
 
       private
 

--- a/backend/app/controllers/spree/admin/stock_transfers_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_transfers_controller.rb
@@ -1,7 +1,7 @@
 module Spree
   module Admin
     class StockTransfersController < Admin::BaseController
-      before_filter :load_stock_locations, :only => :index
+      before_action :load_stock_locations, only: :index
 
       def index
         @q = StockTransfer.ransack(params[:q])

--- a/backend/app/controllers/spree/admin/tax_rates_controller.rb
+++ b/backend/app/controllers/spree/admin/tax_rates_controller.rb
@@ -1,7 +1,7 @@
 module Spree
   module Admin
     class TaxRatesController < ResourceController
-      before_filter :load_data
+      before_action :load_data
 
       private
 

--- a/backend/app/controllers/spree/admin/users_controller.rb
+++ b/backend/app/controllers/spree/admin/users_controller.rb
@@ -3,11 +3,11 @@ module Spree
     class UsersController < ResourceController
       rescue_from Spree::Core::DestroyWithOrdersError, :with => :user_destroy_with_orders_error
 
-      after_filter :sign_in_if_change_own_password, :only => :update
+      after_action :sign_in_if_change_own_password, only: :update
 
       # http://spreecommerce.com/blog/2010/11/02/json-hijacking-vulnerability/
-      before_filter :check_json_authenticity, :only => :index
-      before_filter :load_roles
+      before_action :check_json_authenticity, only: :index
+      before_action :load_roles
 
       def index
         respond_with(@collection) do |format|

--- a/backend/app/controllers/spree/admin/variants_controller.rb
+++ b/backend/app/controllers/spree/admin/variants_controller.rb
@@ -3,7 +3,7 @@ module Spree
     class VariantsController < ResourceController
       belongs_to 'spree/product', :find_by => :slug
       new_action.before :new_before
-      before_filter :load_data, :only => [:new, :create, :edit, :update]
+      before_action :load_data, only: [:new, :create, :edit, :update]
 
       # override the destory method to set deleted_at value
       # instead of actually deleting the product.

--- a/backend/app/controllers/spree/admin/zones_controller.rb
+++ b/backend/app/controllers/spree/admin/zones_controller.rb
@@ -1,7 +1,7 @@
 module Spree
   module Admin
     class ZonesController < ResourceController
-      before_filter :load_data, :except => [:index]
+      before_action :load_data, except: :index
 
       def new
         @zone.zone_members.build

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -6,18 +6,18 @@ module Spree
   class CheckoutController < Spree::StoreController
     ssl_required
 
-    before_filter :load_order_with_lock
+    before_action :load_order_with_lock
 
-    before_filter :ensure_order_not_completed
-    before_filter :ensure_checkout_allowed
-    before_filter :ensure_sufficient_stock_lines
-    before_filter :ensure_valid_state
+    before_action :ensure_order_not_completed
+    before_action :ensure_checkout_allowed
+    before_action :ensure_sufficient_stock_lines
+    before_action :ensure_valid_state
 
-    before_filter :associate_user
-    before_filter :check_authorization
-    before_filter :apply_coupon_code
+    before_action :associate_user
+    before_action :check_authorization
+    before_action :apply_coupon_code
 
-    before_filter :setup_for_current_state
+    before_action :setup_for_current_state
 
     helper 'spree/orders'
 

--- a/frontend/app/controllers/spree/content_controller.rb
+++ b/frontend/app/controllers/spree/content_controller.rb
@@ -2,7 +2,7 @@ module Spree
   class ContentController < Spree::StoreController
     # Don't serve local files or static assets
     before_filter { render_404 if params[:path] =~ /(\.|\\)/ }
-    after_filter :fire_visited_path, :only => :show
+    after_action :fire_visited_path, only: :show
 
     rescue_from ActionView::MissingTemplate, :with => :render_404
 

--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -2,15 +2,15 @@ module Spree
   class OrdersController < Spree::StoreController
     ssl_required :show
 
-    before_filter :check_authorization
+    before_action :check_authorization
     rescue_from ActiveRecord::RecordNotFound, :with => :render_404
     helper 'spree/products', 'spree/orders'
 
     respond_to :html
 
-    before_filter :assign_order_with_lock, only: :update
-    before_filter :apply_coupon_code, only: :update
-    skip_before_filter :verify_authenticity_token
+    before_action :assign_order_with_lock, only: :update
+    before_action :apply_coupon_code, only: :update
+    skip_before_action :verify_authenticity_token
 
     def show
       @order = Order.find_by_number!(params[:id])

--- a/frontend/app/controllers/spree/products_controller.rb
+++ b/frontend/app/controllers/spree/products_controller.rb
@@ -1,7 +1,7 @@
 module Spree
   class ProductsController < Spree::StoreController
-    before_filter :load_product, :only => :show
-    before_filter :load_taxon, :only => :index
+    before_action :load_product, only: :show
+    before_action :load_taxon, only: :index
 
     rescue_from ActiveRecord::RecordNotFound, :with => :render_404
     helper 'spree/taxons'


### PR DESCRIPTION
Deprecate *_filter callbacks on Rails 4.2.0

See https://github.com/rails/rails/commit/6c5f43bab8206747a8591435b2aa0ff7051ad3de
