### PR TITLE
Make reimbursement credit descriptions more descriptive

### DIFF
--- a/core/app/models/spree/reimbursement/credit.rb
+++ b/core/app/models/spree/reimbursement/credit.rb
@@ -15,7 +15,7 @@ module Spree
     end
 
     def description
-      Spree.t('credit')
+      creditable.class.name.demodulize
     end
 
     def display_amount

--- a/core/spec/models/spree/reimbursement/credit_spec.rb
+++ b/core/spec/models/spree/reimbursement/credit_spec.rb
@@ -18,10 +18,10 @@ module Spree
     end
 
     describe '#description' do
-      let(:credit) { Spree::Reimbursement::Credit.new(amount: 100) }
+      let(:credit) { Spree::Reimbursement::Credit.new(amount: 100, creditable: mock_model(Spree::PaymentMethod::Check)) }
 
-      it "should be 'Credit'" do
-        credit.description.should eq Spree.t('credit')
+      it "should be the creditable's class name" do
+        credit.description.should eq 'Check'
       end
     end
 


### PR DESCRIPTION
- Use the creditable's class name
