### PR TITLE
Create tax adjustment label with inclusive information if applicable

### DIFF
--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -201,6 +201,8 @@ module Spree
         label = ""
         label << (name.present? ? name : tax_category.name) + " "
         label << (show_rate_in_label? ? "#{amount * 100}%" : "")
+        label << " (#{Spree.t(:included_in_price)})" if included_in_price?
+        label
       end
 
   end


### PR DESCRIPTION
So that it would be less confusing when looking at the order detail page below where tax adjustment label indicates "(Incldued in Price)" and all dollar amounts can add up.

![screen shot 2014-08-20 at 9 34 36 am](https://cloud.githubusercontent.com/assets/5523239/3984481/7cd36e6e-2888-11e4-85fb-d928264ffb2f.png)
