### PR TITLE
Set promo adjustment to 0 when not actionable

### DIFF
--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -51,6 +51,7 @@ module Spree
     scope :eligible, -> { where(eligible: true) }
     scope :charge, -> { where("#{quoted_table_name}.amount >= 0") }
     scope :credit, -> { where("#{quoted_table_name}.amount < 0") }
+    scope :nonzero, -> { where("#{quoted_table_name}.amount != 0") }
     scope :promotion, -> { where(source_type: 'Spree::PromotionAction') }
     scope :return_authorization, -> { where(source_type: "Spree::ReturnAuthorization") }
     scope :included, -> { where(included: true)  }

--- a/core/app/models/spree/promotion/actions/create_item_adjustments.rb
+++ b/core/app/models/spree/promotion/actions/create_item_adjustments.rb
@@ -40,6 +40,7 @@ module Spree
         # Ensure a negative amount which does not exceed the sum of the order's
         # item_total and ship_total
         def compute_amount(adjustable)
+          return 0 unless promotion.line_item_actionable? adjustable.order, adjustable
           promotion_amount = self.calculator.compute(adjustable).to_f.abs
           
           [adjustable.amount, promotion_amount].min * -1

--- a/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
@@ -69,19 +69,29 @@ module Spree
         context "#compute_amount" do
           before { promotion.promotion_actions = [action] }
 
-          it "calls compute on the calculator" do
-            action.calculator.should_receive(:compute).with(line_item)
-            action.compute_amount(line_item)
-          end
-
-          context "calculator returns amount greater than item total" do
-            before do
-              action.calculator.should_receive(:compute).with(line_item).and_return(300)
-              line_item.stub(amount: 100)
+          context "when the adjustable is actionable" do
+            it "calls compute on the calculator" do
+              action.calculator.should_receive(:compute).with(line_item)
+              action.compute_amount(line_item)
             end
 
-            it "does not exceed it" do
-              action.compute_amount(line_item).should eql(-100)
+            context "calculator returns amount greater than item total" do
+              before do
+                action.calculator.should_receive(:compute).with(line_item).and_return(300)
+                line_item.stub(amount: 100)
+              end
+
+              it "does not exceed it" do
+                action.compute_amount(line_item).should eql(-100)
+              end
+            end
+          end
+
+          context "when the adjustable is not actionable" do
+            before { allow(promotion).to receive(:line_item_actionable?) { false } }
+
+            it 'returns 0' do
+              expect(action.compute_amount(line_item)).to eql(0)
             end
           end
         end

--- a/frontend/app/views/spree/checkout/_summary.html.erb
+++ b/frontend/app/views/spree/checkout/_summary.html.erb
@@ -7,9 +7,9 @@
       <td><strong><%= order.display_item_total.to_html %></strong></td>
     </tr>
 
-    <% if order.line_item_adjustments.exists? %>
+    <% if order.line_item_adjustments.nonzero.exists? %>
       <tbody data-hook="order_details_promotion_adjustments">
-        <% order.line_item_adjustments.promotion.eligible.group_by(&:label).each do |label, adjustments| %>
+        <% order.line_item_adjustments.nonzero.promotion.eligible.group_by(&:label).each do |label, adjustments| %>
           <tr class="total">
             <td><%= label %></td>
             <td><%= Spree::Money.new(adjustments.sum(&:amount), currency: order.currency).to_html %></td>
@@ -19,7 +19,7 @@
     <% end %>
 
     <tbody data-hook="order_details_tax_adjustments">
-      <% order.all_adjustments.tax.eligible.group_by(&:label).each do |label, adjustments| %>
+      <% order.all_adjustments.nonzero.tax.eligible.group_by(&:label).each do |label, adjustments| %>
         <tr class="total">
           <td><%= label %></td>
           <td><%= Spree::Money.new(adjustments.sum(&:amount), currency: order.currency).to_html %></td>
@@ -33,9 +33,9 @@
         <td><%= Spree::Money.new(order.shipments.to_a.sum(&:cost), currency: order.currency).to_html %></td>
       </tr>
 
-      <% if order.shipment_adjustments.exists? %>
+      <% if order.shipment_adjustments.nonzero.exists? %>
         <tbody data-hook="order_details_shipment_promotion_adjustments">
-          <% order.shipment_adjustments.promotion.eligible.group_by(&:label).each do |label, adjustments| %>
+          <% order.shipment_adjustments.nonzero.promotion.eligible.group_by(&:label).each do |label, adjustments| %>
             <tr class="total">
               <td><%= label %></td>
               <td><%= Spree::Money.new(adjustments.sum(&:amount), currency: order.currency).to_html %></td>
@@ -45,9 +45,9 @@
       <% end %>
     <% end %>
 
-    <% if order.adjustments.eligible.exists? %>
+    <% if order.adjustments.nonzero.eligible.exists? %>
       <tbody id="summary-order-charges" data-hook>
-        <% order.adjustments.eligible.each do |adjustment| %>
+        <% order.adjustments.nonzero.eligible.each do |adjustment| %>
         <% next if (adjustment.source_type == 'Spree::TaxRate') and (adjustment.amount == 0) %>
           <tr class="total">
             <td><%= adjustment.label %>: </td>

--- a/frontend/app/views/spree/orders/_adjustment_row.html.erb
+++ b/frontend/app/views/spree/orders/_adjustment_row.html.erb
@@ -1,6 +1,8 @@
-<tr class="adjustment">
-  <td colspan="4" align='right'><h5><%= type %>: <%= label %></h5></td>
-  <td colspan='2'>
-    <h5><%= Spree::Money.new(adjustments.sum(&:amount), :currency => @order.currency) %></h5>
-  </td>
-</tr>
+<% if adjustments.sum(&:amount) != 0 %>
+  <tr class="adjustment">
+    <td colspan="4" align='right'><h5><%= type %>: <%= label %></h5></td>
+    <td colspan='2'>
+      <h5><%= Spree::Money.new(adjustments.sum(&:amount), :currency => @order.currency) %></h5>
+    </td>
+  </tr>
+<% end %>

--- a/frontend/app/views/spree/orders/_form.html.erb
+++ b/frontend/app/views/spree/orders/_form.html.erb
@@ -12,7 +12,7 @@
   <tbody id="line_items" data-hook>
     <%= render partial: 'spree/orders/line_item', collection: order_form.object.line_items, locals: {order_form: order_form} %>
   </tbody>
-  <% if @order.adjustments.exists? || @order.line_item_adjustments.exists? || @order.shipment_adjustments.exists? || @order.shipments.any? %>
+  <% if @order.adjustments.nonzero.exists? || @order.line_item_adjustments.nonzero.exists? || @order.shipment_adjustments.nonzero.exists? || @order.shipments.any? %>
     <tr class="cart-subtotal">
       <td colspan="4" align='right'><h5><%= Spree.t(:cart_subtotal, :count => @order.line_items.sum(:quantity)) %></h5></th>
       <td colspan><h5><%= order_form.object.display_item_total %></h5></td>


### PR DESCRIPTION
If an order qualifies for a line item promotion due to meeting some condition
(say, 10% off 5 or more), and the cart is updated so that the line item
promotion no longer qualifies, this will ensure that the line item promotion
is set to zero.

There is additionally some changes to hide promotions which are zero, as
they're not super interesting. The promotions are zero-d out and hidden so
that if at some point in the future the order re-qualifies, the amount will be
set correctly.
