### PR TITLE
Allow Product.orders

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -57,6 +57,9 @@ module Spree
     has_many :prices, -> { order('spree_variants.position, spree_variants.id, currency') }, through: :variants
 
     has_many :stock_items, through: :variants_including_master
+    
+    has_many :line_items, through: :variants_including_master
+    has_many :orders, through: :line_items
 
     delegate_belongs_to :master, :sku, :price, :currency, :display_amount, :display_price, :weight, :height, :width, :depth, :is_master, :has_default_price?, :cost_currency, :price_in, :amount_in
 

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -11,6 +11,7 @@ module Spree
 
     has_many :inventory_units
     has_many :line_items, inverse_of: :variant
+    has_many :orders, through: :line_items
 
     has_many :stock_items, dependent: :destroy, inverse_of: :variant
     has_many :stock_locations, through: :stock_items


### PR DESCRIPTION
One thing that our store admins need to do often is find the orders that have been made for a given product. This can be easily achieved by adding these `has_many through:` lines. This seems like a capability that other stores might find useful as well.
