### PR TITLE
Create tests for generate_order_number options

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -3,6 +3,11 @@ require 'spree/order/checkout'
 
 module Spree
   class Order < Spree::Base
+
+    ORDER_NUMBER_LENGTH  = 9
+    ORDER_NUMBER_LETTERS = false
+    ORDER_NUMBER_PREFIX  = 'R'
+
     include Spree::Order::Checkout
     include Spree::Order::CurrencyUpdater
 
@@ -274,13 +279,13 @@ module Spree
     end
 
     def generate_order_number(options = {})
-      options[:length] ||= 9
-      options[:letters] ||= false
-      options[:prefix] ||= 'R'
-      
+      options[:length]  ||= ORDER_NUMBER_LENGTH
+      options[:letters] ||= ORDER_NUMBER_LETTERS
+      options[:prefix]  ||= ORDER_NUMBER_PREFIX
+
       possible = (0..9).to_a
       possible += ('A'..'Z').to_a if options[:letters]
-      
+
       self.number ||= loop do
         # Make a random number.
         random = "#{options[:prefix]}#{(0...options[:length]).map { possible.shuffle.first }.join}"
@@ -291,7 +296,7 @@ module Spree
         else
           break random
         end
-      end	  
+      end
     end
 
     def shipped_shipments

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 
 class FakeCalculator < Spree::Calculator
@@ -523,9 +521,31 @@ describe Spree::Order do
   end
 
   context "#generate_order_number" do
-    it "should generate a random string" do
-      order.generate_order_number.is_a?(String).should be_true
-      (order.generate_order_number.to_s.length > 0).should be_true
+    context "when no configure" do
+      let(:default_length) { Spree::Order::ORDER_NUMBER_LENGTH + Spree::Order::ORDER_NUMBER_PREFIX.length }
+      subject(:order_number) { order.generate_order_number }
+      its(:class)  { should eq String }
+      its(:length) { should eq default_length }
+      it { should match /^#{Spree::Order::ORDER_NUMBER_PREFIX}/ }
+    end
+
+    context "when length option is 5" do
+      let(:option_length) { 5 + Spree::Order::ORDER_NUMBER_PREFIX.length }
+      it "should be option length for order number" do
+        expect(order.generate_order_number(length: 5).length).to eq option_length
+      end
+    end
+
+    context "when letters option is true" do
+      it "generates order number include letter" do
+        expect(order.generate_order_number(length: 100, letters: true)).to match /[A-Z]/
+      end
+    end
+
+    context "when prefix option is 'P'" do
+      it "generates order number and it prefix is 'P'" do
+        expect(order.generate_order_number(prefix: 'P')).to match /^P/
+      end
     end
   end
 


### PR DESCRIPTION
I created tests for generate_order_number options.

Related PR https://github.com/spree/spree/pull/5126
