### PR TITLE
Don't create refunds for payments with negative amounts

### DIFF
--- a/core/app/models/spree/reimbursement_type/reimbursement_helpers.rb
+++ b/core/app/models/spree/reimbursement_type/reimbursement_helpers.rb
@@ -3,7 +3,7 @@ module Spree
     def create_refunds(reimbursement, payments, unpaid_amount, simulate, reimbursement_list = [])
       payments.map do |payment|
         break if unpaid_amount <= 0
-        next if payment.credit_allowed.zero?
+        next unless payment.can_credit?
 
         amount = [unpaid_amount, payment.credit_allowed].min
         reimbursement_list << create_refund(reimbursement, payment, amount, simulate)

--- a/core/spec/models/spree/reimbursement_type/original_payment_spec.rb
+++ b/core/spec/models/spree/reimbursement_type/original_payment_spec.rb
@@ -40,6 +40,16 @@ module Spree
           expect(subject).to eq []
         end
       end
+
+      context 'when a payment is negative' do
+        before do
+          Spree::Payment.any_instance.should_receive(:amount).and_return -100
+        end
+
+        it 'returns an empty array' do
+          expect(subject).to eq []
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Currently, if a payment is negative, we will still attempt to create a refund for it. Refunds can't have a negative amount and throw an exception when trying to save.
