### PR TITLE
Cleanup of #5166

### DIFF
--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -63,25 +63,23 @@ module Spree
       end
 
       def transfer_to_location
-        success, message = @original_shipment.transfer_to_location(@variant, @quantity, @stock_location)
-        status = success ? 201 : 422
-        render json: {success: success, message: message}, status: status
+        @stock_location = Spree::StockLocation.find(params[:stock_location_id])
+        @original_shipment.transfer_to_location(@variant, @quantity, @stock_location)
+        render json: {success: true, message: Spree.t(:shipment_transfer_success)}, status: 201
       end
 
       def transfer_to_shipment
-        success, message = @original_shipment.transfer_to_shipment(@variant, @quantity, @target_shipment)
-        status = success ? 201 : 422
-        render json: {success: success, message: message}, status: status
+        @target_shipment  = Spree::Shipment.find_by!(number: params[:target_shipment_number])
+        @original_shipment.transfer_to_shipment(@variant, @quantity, @target_shipment)
+        render json: {success: true, message: Spree.t(:shipment_transfer_success)}, status: 201
       end
 
       private
 
       def load_transfer_params
         @original_shipment         = Spree::Shipment.where(number: params[:original_shipment_number]).first
-        @target_shipment           = params[:target_shipment_number] ? Spree::Shipment.where(number: params[:target_shipment_number]).first : nil
         @variant                   = Spree::Variant.find(params[:variant_id])
         @quantity                  = params[:quantity].to_i
-        @stock_location            = params[:stock_location_id] ? Spree::StockLocation.find(params[:stock_location_id]) : nil
         authorize! :read, @original_shipment
         authorize! :create, Shipment
       end

--- a/backend/app/views/spree/admin/orders/_form.html.erb
+++ b/backend/app/views/spree/admin/orders/_form.html.erb
@@ -4,7 +4,7 @@
   <% end %>
 
   <% if Spree::Order.checkout_step_names.include?(:delivery) %>
-    <%= render :partial => "spree/admin/orders/shipment", :collection => @order.shipments, :locals => { :order => order } %>
+    <%= render :partial => "spree/admin/orders/shipment", :collection => @order.shipments.order(:created_at), :locals => { :order => order } %>
   <% else %>
     <%= render :partial => "spree/admin/orders/line_items", :locals => { :order => order } %>
   <% end %>

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -84,7 +84,7 @@ module Spree
           end
         end
 
-        line_item.save
+        line_item.save!
         line_item
       end
 

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -351,64 +351,43 @@ module Spree
     end
 
     def transfer_to_location(variant, quantity, stock_location)
-      success = true
-      message = Spree.t(:shipment_transfer_success)
-      if (quantity <= 0 || !enough_stock_at_destination_location(variant, quantity, stock_location))
-        return [false, Spree.t(:shipment_transfer_error)]
+      if quantity <= 0
+        raise ArgumentError
       end
 
-      begin
-        transaction do
-          self.order.contents.remove(variant, quantity, {shipment: self})
-          new_shipment = self.order.shipments.create!(stock_location: stock_location)
-          self.order.contents.add(variant, quantity, {shipment: new_shipment})
+      transaction do
+        new_shipment = order.shipments.create!(stock_location: stock_location)
 
-          new_shipment.refresh_rates
-          new_shipment.save!
-        end
-      rescue Exception => e
-        Rails.logger.error e.message
-        message  = Spree.t(:shipment_transfer_error)
-        success = false
+        order.contents.remove(variant, quantity, {shipment: self})
+        order.contents.add(variant, quantity, {shipment: new_shipment})
+
+        refresh_rates
+        save!
+        new_shipment.refresh_rates
+        new_shipment.save!
       end
-
-      [success, message]
     end
 
     def transfer_to_shipment(variant, quantity, shipment_to_transfer_to)
-      success = true
-      message = Spree.t(:shipment_transfer_success)
-
       quantity_already_shipment_to_transfer_to = shipment_to_transfer_to.manifest.find{|mi| mi.line_item.variant == variant}.try(:quantity) || 0
       final_quantity = quantity + quantity_already_shipment_to_transfer_to
 
-      if (quantity <= 0 || self.id == shipment_to_transfer_to.id || !enough_stock_at_destination_location(variant, final_quantity, shipment_to_transfer_to.stock_location))
-        return [false, Spree.t(:shipment_transfer_error)]
+      if (quantity <= 0 || self == shipment_to_transfer_to)
+        raise ArgumentError
       end
 
-      begin
-        transaction do
-          self.order.contents.remove(variant, quantity, {shipment: self})
-          shipment_to_transfer_to.order.contents.add(variant, quantity, {shipment: shipment_to_transfer_to})
-          shipment_to_transfer_to.refresh_rates
-          shipment_to_transfer_to.save!
-        end
-      rescue Exception => e
-        Rails.logger.error e.message
-        message  = Spree.t(:shipment_transfer_error)
-        success = false
-      end
+      transaction do
+        order.contents.remove(variant, quantity, {shipment: self})
+        order.contents.add(variant, quantity, {shipment: shipment_to_transfer_to})
 
-      [success, message]
+        refresh_rates
+        save!
+        shipment_to_transfer_to.refresh_rates
+        shipment_to_transfer_to.save!
+      end
     end
 
     private
-
-      def enough_stock_at_destination_location(variant, quantity, stock_location)
-        stock_item = Spree::StockItem.where(variant: variant).
-                                      where(stock_location: stock_location).first
-        (stock_item.count_on_hand >= quantity || stock_item.backorderable)
-      end
 
       def after_ship
         ShipmentHandler.factory(self).perform


### PR DESCRIPTION
This improves the quality of some of the code introduced in b252e9adcd02b5b0f0f89cdcfae583e72ae12fb7.

Of note this:
- Fixes some spurious failures due to postgresql ordering
- Raises exceptions from `transfer_to_location` and `transfer_to_shipment` rather than returning `[bool, string]`

I believe all tests are still passing.
