### PR TITLE
Add destroyed variants to be removed from a shipment

### DIFF
--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -9,7 +9,6 @@ module Spree
         @order = Spree::Order.find_by!(number: params[:shipment][:order_id])
         authorize! :read, @order
         authorize! :create, Shipment
-        variant = Spree::Variant.find(params[:variant_id])
         quantity = params[:quantity].to_i
         @shipment = @order.shipments.create(stock_location_id: params[:stock_location_id])
         @order.contents.add(variant, quantity, {shipment: @shipment})
@@ -45,7 +44,6 @@ module Spree
       end
 
       def add
-        variant = Spree::Variant.find(params[:variant_id])
         quantity = params[:quantity].to_i
 
         @shipment.order.contents.add(variant, quantity, {shipment: @shipment})
@@ -54,7 +52,6 @@ module Spree
       end
 
       def remove
-        variant = Spree::Variant.find(params[:variant_id])
         quantity = params[:quantity].to_i
 
         @shipment.order.contents.remove(variant, quantity, {shipment: @shipment})
@@ -96,6 +93,10 @@ module Spree
         else
           {}
         end
+      end
+
+      def variant
+        @variant ||= Spree::Variant.unscoped.find(params.fetch(:variant_id))
       end
     end
   end

--- a/api/spec/controllers/spree/api/shipments_controller_spec.rb
+++ b/api/spec/controllers/spree/api/shipments_controller_spec.rb
@@ -84,7 +84,16 @@ describe Spree::Api::ShipmentsController do
         api_put :remove, { variant_id: variant.to_param, quantity: 1 }
         response.status.should == 200
         json_response['manifest'].detect { |h| h['variant']['id'] == variant.id }["quantity"].should == 1
-     end
+      end
+
+      it 'removes a destroyed variant from a shipment' do
+        order.contents.add(variant, 2)
+        variant.destroy
+
+        api_put :remove, { variant_id: variant.to_param, quantity: 1 }
+        response.status.should == 200
+        json_response['manifest'].detect { |h| h['variant']['id'] == variant.id }["quantity"].should == 1
+      end
     end
 
     context "can transition a shipment from ready to ship" do


### PR DESCRIPTION
This change allows a destroyed variant to be removed from a shipment. Previously, if a variant was destroyed it was impossible to remove it from a shipment.
