### PR TITLE
Refactor Spree::OrderContents#add_to_line_item

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -102,7 +102,7 @@ module Spree
     def options=(options={})
       opts = options.dup # we will be deleting from the hash, so leave the caller's copy intact
 
-      currency = opts.delete(:currency) || order.currency
+      currency = opts.delete(:currency) || order.try(:currency)
       self.target_shipment = opts.delete(:shipment) if opts.has_key?(:shipment)
 
       if currency

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -99,6 +99,24 @@ module Spree
       Spree::Variant.unscoped { super }
     end
 
+    def options=(options={})
+      opts = options.dup # we will be deleting from the hash, so leave the caller's copy intact
+
+      currency = opts.delete(:currency) || order.currency
+      self.target_shipment = opts.delete(:shipment) if opts.has_key?(:shipment)
+
+      if currency
+        self.currency = currency
+        self.price    = variant.price_in(currency).amount +
+                        variant.price_modifier_amount_in(currency, opts)
+      else
+        self.price    = variant.price +
+                        variant.price_modifier_amount(opts)
+      end
+
+      opts.each { |key, value| self.send "#{key}=", value }
+    end
+
     private
       def update_inventory
         if (changed? || target_shipment.present?) && self.order.has_checkout_step?("delivery")

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -114,7 +114,7 @@ module Spree
                         variant.price_modifier_amount(opts)
       end
 
-      opts.each { |key, value| self.send "#{key}=", value }
+      self.assign_attributes opts
     end
 
     private

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -57,31 +57,16 @@ module Spree
 
       def add_to_line_item(variant, quantity, options = {})
         line_item = grab_line_item_by_variant(variant, false, options)
-        
-        opts = options.dup # we will be deleting from the hash, so leave the caller's copy intact
-        currency = opts.delete(:currency) || order.currency
-        shipment = opts.delete(:shipment)
-        
+
         if line_item
-          line_item.target_shipment = shipment
+          line_item.target_shipment = options[:shipment] if options.has_key? :shipment
           line_item.quantity += quantity.to_i
           line_item.currency = currency unless currency.nil?
         else
-          line_item = order.line_items.new({quantity: quantity, 
-                                            variant: variant}.
-                                              merge(
-                                                ActionController::Parameters.new(opts).
-                                                  permit(PermittedAttributes.line_item_attributes)))
-          line_item.target_shipment = shipment
-          
-          if currency
-            line_item.currency = currency
-            line_item.price    = variant.price_in(currency).amount + 
-                                 variant.price_modifier_amount_in(currency, opts)
-          else
-            line_item.price    = variant.price + 
-                                 variant.price_modifier_amount(opts)
-          end
+          opts = { currency: order.currency }.merge ActionController::Parameters.new(options).permit(PermittedAttributes.line_item_attributes)
+          line_item = order.line_items.new(quantity: quantity,
+                                            variant: variant,
+                                            options: opts)
         end
 
         line_item.save!

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -63,7 +63,8 @@ module Spree
           line_item.quantity += quantity.to_i
           line_item.currency = currency unless currency.nil?
         else
-          opts = { currency: order.currency }.merge ActionController::Parameters.new(options).permit(PermittedAttributes.line_item_attributes)
+          opts = { currency: order.currency }.merge ActionController::Parameters.new(options).
+                                              permit(PermittedAttributes.line_item_attributes)
           line_item = order.line_items.new(quantity: quantity,
                                             variant: variant,
                                             options: opts)

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -232,4 +232,18 @@ describe Spree::LineItem do
       expect(line_item).to have(1).error_on(:currency)
     end
   end
+
+  describe "#options=" do
+    it "updates the data provided in the options" do
+      line_item.options = { price: 123 }
+      expect(line_item.price).to eq 123
+    end
+
+    it "updates the price based on the options provided" do
+      expect(line_item).to receive(:gift_wrap=).with(true)
+      expect(line_item.variant).to receive(:gift_wrap_price_modifier_amount_in).with("USD", true).and_return 1.99
+      line_item.options = { gift_wrap: true }
+      expect(line_item.price).to eq 21.98
+    end
+  end
 end

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -234,6 +234,10 @@ describe Spree::LineItem do
   end
 
   describe "#options=" do
+    it "can handle updating a blank line item with no order" do
+      line_item.options = { price: 123 }
+    end
+
     it "updates the data provided in the options" do
       line_item.options = { price: 123 }
       expect(line_item.price).to eq 123


### PR DESCRIPTION
Our application has personalised products (e.g. you can have your own name and inscription on the product), and we want to allow:
- users to provide the product options when adding a product to the cart
- users to edit their product options once they've added the product to the cart from the cart page
- customer support to be able to edit the product options on completed orders from the admin section 

The work done by @jsqu99 to enable customisable products only allowed the first of these use cases, so here's a proposal to enable it for the others. 

We refactored Spree::OrderContents#add_to_line_item so that the logic of setting the line item price based on the product options is reusable when creating an updating a line item.

There's one section which could do with I'm not too happy with, I will comment that individually.
