### PR TITLE
Importing Spree::Shipments should use the admin_name rather than the name for finding the Shipping Method

### DIFF
--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -75,7 +75,7 @@ module Spree
 
               shipment.save!
 
-              shipping_method = find_shipping_method(s)
+              shipping_method = Spree::ShippingMethod.find_by_name(s[:shipping_method]) || Spree::ShippingMethod.find_by_admin_name!(s[:shipping_method])
               rate = shipment.shipping_rates.create!(:shipping_method => shipping_method,
                                                      :cost => s[:cost])
               shipment.selected_shipping_rate_id = rate.id
@@ -85,11 +85,6 @@ module Spree
               raise "Order import shipments: #{e.message} #{s}"
             end
           end
-        end
-
-        def self.find_shipping_method(shipment_hash)
-          ActiveSupport::Deprecation.warn "Importing a shipment's shipment method will start using find_by_admin_name! rather than find_by_name!", caller
-          Spree::ShippingMethod.find_by_name! shipment_hash[:shipping_method]
         end
 
         def self.create_line_items_from_params(line_items_hash, order)

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -75,7 +75,7 @@ module Spree
 
               shipment.save!
 
-              shipping_method = Spree::ShippingMethod.find_by_name!(s[:shipping_method])
+              shipping_method = find_shipping_method(s)
               rate = shipment.shipping_rates.create!(:shipping_method => shipping_method,
                                                      :cost => s[:cost])
               shipment.selected_shipping_rate_id = rate.id
@@ -85,6 +85,11 @@ module Spree
               raise "Order import shipments: #{e.message} #{s}"
             end
           end
+        end
+
+        def self.find_shipping_method(shipment_hash)
+          ActiveSupport::Deprecation.warn "Importing a shipment's shipment method will start using find_by_admin_name! rather than find_by_name!", caller
+          Spree::ShippingMethod.find_by_name! shipment_hash[:shipping_method]
         end
 
         def self.create_line_items_from_params(line_items_hash, order)


### PR DESCRIPTION
Our application ships from multiple stock locations, and each one has different shipping methods available to it depending on the country (e.g. Royal Mail in the UK, USPS in the US). However, we will want to use the same customer facing label for these (e.g. Free shipping), whilst having different internal names (i.e the admin_name, e.g. Royal Mail, USPS).

When importing orders, `Spree::Core::Importer::Order` uses `Spree::ShippingMethod.find_by_name!`, and we believe it should really use `Spree::ShippingMethod.find_by_admin_name!` to cover these situations.

However, so that we don't break existing implementations I decided to extract that call into it's own method with a deprecation warning so that we can easily override the call in the time being.
