### PR TITLE
call reimbursement with id method

### DIFF
--- a/core/app/models/spree/reimbursement.rb
+++ b/core/app/models/spree/reimbursement.rb
@@ -142,7 +142,7 @@ module Spree
     end
 
     def send_reimbursement_email
-      Spree::ReimbursementMailer.reimbursement_email(self).deliver
+      Spree::ReimbursementMailer.reimbursement_email(self.id).deliver
     end
   end
 end


### PR DESCRIPTION
When using Resque or Sidekiq for background jobs, its best practice to simply introduce a string or an integer instead of an object.

Throughout spree's models, one will find that the emails use the id to fetch the data instead of passing the full object.

Here, I pass the id method into the reimbursement email to ensure that the `Spree::ReimbursementMailer` is compliant with the Resque and Sidekiq best practices.
