### PR TITLE
Allow for notification of API errors

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -10,6 +10,8 @@ module Spree
 
       attr_accessor :current_api_user
 
+      class_attribute :error_notifier
+
       before_action :set_content_type
       before_action :load_user
       before_action :authorize_for_order, if: Proc.new { order_token.present? }
@@ -96,6 +98,8 @@ module Spree
       def error_during_processing(exception)
         Rails.logger.error exception.message
         Rails.logger.error exception.backtrace.join("\n")
+
+        error_notifier.call(exception, self) if error_notifier
 
         render :text => { :exception => exception.message }.to_json,
           :status => 422 and return

--- a/api/spec/controllers/spree/api/base_controller_spec.rb
+++ b/api/spec/controllers/spree/api/base_controller_spec.rb
@@ -88,4 +88,40 @@ describe Spree::Api::BaseController do
   it "lets a subclass override the product associations that are eager-loaded" do
     controller.respond_to?(:product_includes, true).should be
   end
+
+  describe '#error_during_processing' do
+    controller(Spree::Api::BaseController) do
+      # GET /foo
+      # Simulates a failed API call.
+      def foo
+        raise StandardError
+      end
+    end
+
+    # What would be placed in config/initializers/spree.rb
+    Spree::Api::BaseController.error_notifier = Proc.new do |e, controller|
+      MockHoneybadger.notify_or_ignore(e, rack_env: controller.request.env) 
+    end
+
+    ##
+    # Fake HB alert class 
+    class MockHoneybadger
+      # https://github.com/honeybadger-io/honeybadger-ruby/blob/master/lib/honeybadger.rb#L136
+      def self.notify_or_ignore(exception, opts = {})
+      end
+    end
+
+    before do
+      user = double(:email => "spree@example.com")
+      user.stub_chain :spree_roles, pluck: []
+      controller.stub :try_spree_current_user => user
+      routes.draw { get 'foo' => 'anonymous#foo' }
+    end
+
+    it 'should notify notify_error_during_processing' do
+      expect(MockHoneybadger).to receive(:notify_or_ignore).once.with(kind_of(Exception), rack_env: kind_of(Hash))
+      api_get :foo
+      expect(response.status).to eq(422)
+    end
+  end
 end


### PR DESCRIPTION
Due to the way the rescue handlers are setup for the API, there's no easy way to alert Honeybadger/Airbrake/etc of an error in the API. Instead we have to check the client error JSON and debug from that which is not very ideal expecially if we don't control the client code. This is a simple change to let people decorate in a hook on `error_during_processing` so that we can notify on error.

This should help me get rid of one more `class_eval` and `alias_method_chain` in my application.

Thought this was more flexible to let people plug in whatever they want but open to doing the KISS solution below:

```
if defined?(Honeybadger) then Honeybadger.notify()
```
