### PR TITLE
Let PaymentMethod create a customer profile using a payment profile

### DIFF
--- a/core/app/models/spree/gateway/bogus.rb
+++ b/core/app/models/spree/gateway/bogus.rb
@@ -18,6 +18,7 @@ module Spree
     end
 
     def create_profile(payment)
+      return if payment.source.has_payment_profile?
       # simulate the storage of credit card profile using remote service
       success = VALID_CCS.include? payment.source.number
       payment.source.update_attributes(:gateway_customer_profile_id => generate_profile_id(success))

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -183,6 +183,8 @@ module Spree
       end
 
       def create_payment_profile
+        # Payment profile cannot be created without source
+        return unless source
         # Imported payments shouldn't create a payment profile.
         return if source.imported
 

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -183,7 +183,6 @@ module Spree
       end
 
       def create_payment_profile
-        return unless source.respond_to?(:has_payment_profile?) && !source.has_payment_profile?
         # Imported payments shouldn't create a payment profile.
         return if source.imported
 


### PR DESCRIPTION
In the original code, `payment_method.create_profile` is called only when the source has neither a customer profile nor a payment profile.
This patch removes that check in order to create a customer profile using a payment profile.

**I notice this change breaks compatibility, and tests are actually failing.**
I will fix tests and other problems if the spree team find this change reasonable.
# Background:

Several payment gateways provides a client side token.
One example is Stripe. When a user selects Stripe for payment on a Spree site, Stripe's javascript library sends the card information directly to Stripe server, not through Spree server.
I'm a developer of WebPay, a payment gateway in Japan, and now trying to implement Spree payment method.

I found that `Spree::Payment` did not call `create_profile` when `payment_profile` exists for the source (in this case, CreditCard).
Because our payment_profile_ids (i.e. client side tokens) are one-time, the payment method must create  a customer_profile_id (we call it "server side token") from a payment_profile_id if a new card is used.
We care so much about PCI DSS and safety of buyers' information, then sending raw card data to the Spree server is unacceptable.
However, the conversion will decrease if the shop enforce typing card information every time.

I found the same problem occurred with Stripe gateway.

IMO, payment gateways should be responsible for whether to create or update profile_id, and the framework should not restrict operations.
Therefore I submit this request. I would like to discuss.
