### PR TITLE
create stock location that passes validations

### DIFF
--- a/sample/db/samples/stock.rb
+++ b/sample/db/samples/stock.rb
@@ -1,8 +1,8 @@
 Spree::Sample.load_sample("variants")
 
-location = Spree::StockLocation.first_or_create! name: 'default'
+country =  Spree::Country.find_by(iso: 'US')
+location = Spree::StockLocation.first_or_create! name: 'default', address1: 'Example Street', city: 'City', zipcode: '12345', country: country, state: country.states.first
 location.active = true
-location.country =  Spree::Country.where(iso: 'US').first
 location.save!
 
 Spree::Variant.all.each do |variant|


### PR DESCRIPTION
In a Spree application perform as follows:

``` shell
$ rails new spree_app
$ cd spree_app && spree install -A
```

There should be an error along the lines of:

```
ActiveRecord::RecordInvalid: Validation of Address1 can't be blank, City can't be blank, Zipcode can't be blank, Country can't be blank, State name can't be blank failed
from /Users/benmorgan/.rvm/gems/ruby-2.0.0-p481/gems/activerecord-4.1.5/lib/active_record/validations.rb:57:in `save!'
```

In this commit, I fix the issue when creating a new stock location.
