### PR TITLE
Removing non existent items from params to avoid bug when clicking on re...

### DIFF
--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -29,7 +29,7 @@ module Spree
     end
 
     def update_cart(params)
-      if order.update_attributes(params)
+      if order.update_attributes(filter_order_items(params))
         order.line_items = order.line_items.select { |li| li.quantity > 0 }
         # Update totals, then check if the order is eligible for any cart promotions.
         # If we do not update first, then the item total will be wrong and ItemTotal
@@ -45,6 +45,16 @@ module Spree
     end
 
     private
+
+      def filter_order_items(params)
+        filtered_params = params.symbolize_keys
+        params[:line_items_attributes].each_pair do |id, value|
+          line_item_id = value[:id]
+          filtered_params[:line_items_attributes].delete(id) unless Spree::LineItem.find_by_id(line_item_id.to_i)
+        end
+        filtered_params
+      end
+
       def order_updater
         @updater ||= OrderUpdater.new(order)
       end

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -175,7 +175,8 @@ describe Spree::OrderContents do
     context "submits item quantity 0" do
       let(:params) do
         { line_items_attributes: {
-          "0" => { id: shirt.id, quantity: 0 }
+          "0" => { id: shirt.id, quantity: 0 },
+          "1" => { id: "666", quantity: 0}
         } }
       end
 
@@ -184,6 +185,15 @@ describe Spree::OrderContents do
           subject.update_cart params
         }.to change { subject.order.line_items.count }
       end
+
+      it "doesnt try to update unexistent items" do
+        filtered_params = { line_items_attributes: {
+          "0" => { id: shirt.id, quantity: 0 },
+        } }
+        expect(subject.order).to receive(:update_attributes).with(filtered_params)
+        subject.update_cart params
+      end
+
     end
 
     it "ensures updated shipments" do


### PR DESCRIPTION
...move multiple times or when clicking on multiple remove buttons

For issue #5304. Filter items being updated on OrderContents so it doesn't try to update items that have already been removed.
