### PR TITLE
available scope now care about 'currency' params

### DIFF
--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -188,7 +188,9 @@ module Spree
 
     # Can't use add_search_scope for this as it needs a default argument
     def self.available(available_on = nil, currency = nil)
-      joins(:master => :prices).where("#{Product.quoted_table_name}.available_on <= ?", available_on || Time.now)
+      joins(:master => :prices)
+       .where("#{Product.quoted_table_name}.available_on <= ?", available_on || Time.now)
+       .where("#{Price.quoted_table_name}.currency = ?", currency || Spree::Config.currency)
     end
     search_scopes << :available
 

--- a/core/spec/models/spree/product/scopes_spec.rb
+++ b/core/spec/models/spree/product/scopes_spec.rb
@@ -143,4 +143,26 @@ describe "Product scopes" do
       end
     end
   end
+
+  context "available scope" do
+    let!(:eur_price) { create(:price, currency: 'EUR', variant_id: product.master.id) }
+
+    it "returns products with default currency" do
+      expect(Spree::Product.available.count).to eq 1
+    end
+
+    context "with a specific time" do
+      it "returns products available before passed time" do
+        expect(Spree::Product.available(Time.now).count).to eq 1
+        expect(Spree::Product.available(Time.at(0)).count).to eq 0
+      end
+    end
+
+    context "with a specific currency" do
+      it "returns products with specific currency" do
+        expect(Spree::Product.available(nil, "EUR").count).to eq 1
+        expect(Spree::Product.available(nil, "BTC").count).to eq 0
+      end
+    end
+  end
 end


### PR DESCRIPTION
I noticed that if a product has 2 prices with different currencies, the  Spree::Product.available scope returns the product more than one time.
Spree::Product.available ignores the currency param. I added the .where conditions on  Spree::Price table
