### PR TITLE
sprockets-rails >= 2.1.4

### DIFF
--- a/backend/config/initializers/assets.rb
+++ b/backend/config/initializers/assets.rb
@@ -1,0 +1,1 @@
+Rails.application.config.assets.precompile += %w( jquery-ui/* )

--- a/frontend/app/views/spree/shared/_head.html.erb
+++ b/frontend/app/views/spree/shared/_head.html.erb
@@ -4,7 +4,7 @@
 <meta content="width=device-width, initial-scale=1.0, maximum-scale=1" name="viewport">
 <%== meta_data_tags %>
 <%= canonical_tag(current_store.url) %>
-<%= favicon_link_tag image_path('favicon.ico') %>
+<%= favicon_link_tag 'favicon.ico' %>
 <%= stylesheet_link_tag 'spree/frontend/all', :media => 'screen' %>
 <%= csrf_meta_tags %>
 <%= javascript_include_tag 'spree/frontend/all' %>


### PR DESCRIPTION
A fresh installation of spree will install sprockets-rails 2.1.4, or greater if possible. It seems that something changed, both frontend and backend assets fails (first caused by favicon_link_tag, second by asset_path)
