### PR TITLE
Allow partial emails when searching for orders

### DIFF
--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -43,7 +43,7 @@
         </div>
         <div class="field">
           <%= label_tag nil, Spree.t(:email) %>
-          <%= f.email_field :email_cont %>
+          <%= f.text_field :email_cont %>
         </div>
       </div>
 


### PR DESCRIPTION
Using the `email_field` tag makes it impossible to search for orders by a partial email address using Chrome or Firefox:
![screen shot 2014-08-26 at 5 59 29 pm](https://cloud.githubusercontent.com/assets/540762/4138722/c94c3f1c-3393-11e4-858e-13ab7e581af9.png)
