### PR TITLE
Feature: Disable user input on the page completely with a simple modal 

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1311,6 +1311,7 @@ en:
     tracking_url: Tracking URL
     tracking_url_placeholder: e.g. http://quickship.com/package?num=:tracking
     transaction_id: Transaction ID
+    transaction_processing: Transaction Processing
     transfer_from_location: Transfer From
     transfer_stock: Transfer Stock
     transfer_to_location: Transfer To

--- a/frontend/app/assets/javascripts/spree/frontend/checkout.js.coffee
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout.js.coffee
@@ -5,7 +5,15 @@
 
 Spree.disableSaveOnClick = ->
   ($ 'form.edit_order').submit ->
-    ($ this).find(':submit, :image').attr('disabled', true).removeClass('primary').addClass 'disabled'
+    disableSave(this)
 
+Spree.disableUserInputOnClick = ->
+  ($ 'form.edit_order').submit ->
+    disableSave(this)
+    $('.modal-background').css('display','block')
+    $('.modal-foreground').css('display','block')
+
+disableSave = (selector)->
+  ($ selector).find(':submit, :image').attr('disabled', true).removeClass('primary').addClass 'disabled'
 Spree.ready ($) ->
   Spree.Checkout = {}

--- a/frontend/app/assets/stylesheets/spree/frontend/screen.css.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/screen.css.scss
@@ -930,6 +930,36 @@ p[data-hook="use_billing"] {
   }
 }
 
+.modal-background {
+  display: none;
+  width: 100%;
+  height: 100%;
+  background: black;
+  opacity: 0.5;
+  top: 0;
+  position: fixed;
+  left: 0;
+  z-index: 9998;
+}
+
+.modal-foreground {
+  display: none;
+  position: fixed;
+  z-index: 9999;
+  left: 50%;
+  top: 50%;
+  margin-left: -100px;
+  margin-top: 0px;
+  background: white;
+  width: auto;
+  height: auto;
+  border: 2px solid black;
+  font-weight: bold;
+  font-size: 1.2em;
+  padding: 25px;
+  text-align: center;
+}
+
 /*--------------------------------------*/
 /* Cart
 /*--------------------------------------*/

--- a/frontend/app/views/spree/checkout/_payment.html.erb
+++ b/frontend/app/views/spree/checkout/_payment.html.erb
@@ -64,5 +64,10 @@
 
 <div class="form-buttons" data-hook="buttons">
   <%= submit_tag Spree.t(:save_and_continue), :class => 'continue button primary' %>
-  <script>Spree.disableSaveOnClick();</script>
+  <script>Spree.disableUserInputOnClick();</script>
+  <div class="modal-background"></div>
+  <div class="modal-foreground">
+    <%= Spree.t(:transaction_processing) %>
+  </div>
+
 </div>


### PR DESCRIPTION
when hitting save and continue on the payments page.

This indicates to the user that their payment is processing and removes the ability to navigate away from the page whilst waiting for the payment to finalise.

Sponsored by Two Red Kites' open source day!
