### PR TITLE
When selecting a customer via the customer search in admin, not all the details populate

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/address_states.js
+++ b/backend/app/assets/javascripts/spree/backend/address_states.js
@@ -1,4 +1,4 @@
-var update_state = function (region) {
+var update_state = function (region, done) {
   'use strict';
 
   var country = $('span#' + region + 'country .select2').select2('val');
@@ -27,5 +27,7 @@ var update_state = function (region) {
       state_input.prop('disabled', false).show();
       state_select.select2('destroy').hide();
     }
+
+    if(done) done();
   });
 };

--- a/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
+++ b/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
@@ -28,11 +28,25 @@ $(document).ready(function() {
       dropdownCssClass: 'customer_search',
       formatResult: formatCustomerResult,
       formatSelection: function (customer) {
+        var billAddress = customer.bill_address;
         $('#order_email').val(customer.email);
         $('#user_id').val(customer.id);
         $('#guest_checkout_true').prop("checked", false);
         $('#guest_checkout_false').prop("checked", true);
         $('#guest_checkout_false').prop("disabled", false);
+        $('#order_bill_address_attributes_firstname').val(billAddress.firstname);
+        $('#order_bill_address_attributes_lastname').val(billAddress.lastname);
+        $('#order_bill_address_attributes_address1').val(billAddress.address1);
+        $('#order_bill_address_attributes_address2').val(billAddress.address2);
+        $('#order_bill_address_attributes_city').val(billAddress.city);
+        $('#order_bill_address_attributes_zipcode').val(billAddress.zipcode);
+        $('#order_bill_address_attributes_phone').val(billAddress.phone);
+
+        $('#order_bill_address_attributes_country_id').select2("val", billAddress.country_id).promise().done(function () {
+            update_state('b', function () {
+                $('#order_bill_address_attributes_state_id').select2("val", billAddress.state_id);
+            });
+        });
 
         return customer.email;
       }


### PR DESCRIPTION
This feature populates all customer billing address fields, and uses a promise to update the country and state as well.

Sponsored by Two Red Kites' open source day!
