### PR TITLE
Removing non existent items from params

### DIFF
--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -307,6 +307,7 @@ module Spree
                                  :country_id => Country.first.id, :state_id => State.first.id} }
 
       before do
+        Spree::LineItem.stub(:find_by_id).and_return(Spree::LineItem.new)
         Order.any_instance.stub :user => current_api_user
         order.next # Switch from cart to address
         order.bill_address = nil

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -29,7 +29,7 @@ module Spree
     end
 
     def update_cart(params)
-      if order.update_attributes(params)
+      if order.update_attributes(filter_order_items(params))
         order.line_items = order.line_items.select { |li| li.quantity > 0 }
         # Update totals, then check if the order is eligible for any cart promotions.
         # If we do not update first, then the item total will be wrong and ItemTotal
@@ -45,6 +45,16 @@ module Spree
     end
 
     private
+
+      def filter_order_items(params)
+        filtered_params = params.symbolize_keys
+        params[:line_items_attributes].each_pair do |id, value|
+          line_item_id = value[:id]
+          filtered_params[:line_items_attributes].delete(id) unless Spree::LineItem.find_by_id(line_item_id.to_i)
+        end
+        filtered_params
+      end
+
       def order_updater
         @updater ||= OrderUpdater.new(order)
       end

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -48,7 +48,7 @@ module Spree
 
       def filter_order_items(params)
         filtered_params = params.symbolize_keys
-        return filtered_params if filtered_params[:line_items_attributes][:id]
+        return filtered_params if filtered_params[:line_items_attributes].nil? || filtered_params[:line_items_attributes][:id]
           
         params[:line_items_attributes].each_pair do |id, value|
           line_item_id = value[:id]

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -48,6 +48,8 @@ module Spree
 
       def filter_order_items(params)
         filtered_params = params.symbolize_keys
+        return filtered_params if filtered_params[:line_items_attributes][:id]
+          
         params[:line_items_attributes].each_pair do |id, value|
           line_item_id = value[:id]
           filtered_params[:line_items_attributes].delete(id) unless Spree::LineItem.find_by_id(line_item_id.to_i)

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -175,7 +175,8 @@ describe Spree::OrderContents do
     context "submits item quantity 0" do
       let(:params) do
         { line_items_attributes: {
-          "0" => { id: shirt.id, quantity: 0 }
+          "0" => { id: shirt.id, quantity: 0 },
+          "1" => { id: "666", quantity: 0}
         } }
       end
 
@@ -184,6 +185,15 @@ describe Spree::OrderContents do
           subject.update_cart params
         }.to change { subject.order.line_items.count }
       end
+
+      it "doesnt try to update unexistent items" do
+        filtered_params = { line_items_attributes: {
+          "0" => { id: shirt.id, quantity: 0 },
+        } }
+        expect(subject.order).to receive(:update_attributes).with(filtered_params)
+        subject.update_cart params
+      end
+
     end
 
     it "ensures updated shipments" do

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -194,6 +194,12 @@ describe Spree::OrderContents do
         subject.update_cart params
       end
 
+      it "should not filter if there is only one line item" do
+        single_line_item_params = { line_items_attributes: { id: shirt.id, quantity: 0 } }
+        expect(subject.order).to receive(:update_attributes).with(single_line_item_params)
+        subject.update_cart single_line_item_params
+      end
+
     end
 
     it "ensures updated shipments" do


### PR DESCRIPTION
Filtering line items that don't exist when updating an order, so it doesn't fail when two items are removed in sequence.

Now it's also dealing with other cases, as in when no or only one item is being updated (not filtering anything in that case).
