### PR TITLE
removes window.location.origin

### DIFF
--- a/core/app/assets/javascripts/spree.js.coffee.erb
+++ b/core/app/assets/javascripts/spree.js.coffee.erb
@@ -7,7 +7,8 @@ class window.Spree
     "<%= Rails.application.routes.url_helpers.spree_path %>"
 
   @pathFor: (path) ->
-    "#{window.location.origin}#{@mountedAt()}#{path}"
+    locationOrigin = "#{window.location.protocol}//#{window.location.hostname}" + (if window.location.port then ":#{window.location.port}" else "")
+    "#{locationOrigin}#{@mountedAt()}#{path}"
 
   # Helper function to take a URL and add query parameters to it
   # Uses the JSUri library from here: https://github.com/derek-watson/jsUri


### PR DESCRIPTION
window.location.origin isn't supported by Internet Explorer, according to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window.location#Browser_compatibility).

This results in Spree.pathFor() not returning a absolute url.

eg.  `Spree.pathFor('cart') => 'undefined/cart` in IE

Whilst not as elegant as calling window.location.origin this solution returns the same value, and so allow `Spree.pathFor()` to work cross browser.
