### PR TITLE
corrects fetch_cart urls

### DIFF
--- a/frontend/app/assets/javascripts/spree/frontend/cart.js.coffee
+++ b/frontend/app/assets/javascripts/spree/frontend/cart.js.coffee
@@ -10,6 +10,6 @@ Spree.ready ($) ->
 
 Spree.fetch_cart = ->
   $.ajax
-    url: Spree.pathFor("/cart_link"),
+    url: Spree.pathFor("cart_link"),
     success: (data) ->
       $('#link-to-cart').html data


### PR DESCRIPTION
Usage of `Spree.pathFor()` in `Spree.fetch_cart()` is incorrect and inconsistent to everywhere else on in the frontend.
