### PR TITLE
Fix for issue #5306

### DIFF
--- a/backend/app/views/spree/admin/products/new.html.erb
+++ b/backend/app/views/spree/admin/products/new.html.erb
@@ -2,7 +2,8 @@
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @product } %>
 
-<%= form_for [:admin, @product], :html => { :multipart => true } do |f| %>
+<%= form_for [:admin, @product], method: :post, url: admin_products_path, :html => { :multipart => true } do |f| %>
+
   <fieldset data-hook="new_product">
 
     <legend align="center"><%= Spree.t(:new_product) %></legend>

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -270,11 +270,22 @@ module Spree
     end
 
     # there's a weird quirk with the delegate stuff that does not automatically save the delegate object
-    # when saving so we force a save using a hook.
+    # when saving so we force a save using a hook
+    # Fix for issue #5306
     def save_master
-      if master && (master.changed? || master.new_record? || (master.default_price && (master.default_price.changed? || master.default_price.new_record?)))
-        master.save
-        @nested_changes = true
+      begin
+        if master && (master.changed? || master.new_record? || (master.default_price && (master.default_price.changed? || master.default_price.new_record?)))
+          master.save!
+          @nested_changes = true
+        end
+
+      # If the master cannot be saved, the Product object will get its errors
+      # and will be destroyed
+      rescue ActiveRecord::RecordInvalid
+        master.errors.each do |att, error|
+          self.errors.add(att, error)
+        end
+        raise
       end
     end
 

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -41,14 +41,26 @@ describe Spree::Product do
     end
 
     context "master variant" do
+
       context "when master variant changed" do
         before do
           product.master.sku = "Something changed"
         end
 
         it "saves the master" do
-          product.master.should_receive(:save)
+          product.master.should_receive(:save!)
           product.save
+        end
+      end
+
+      context "when master variant is not valid" do
+        let(:other_product){ create(:product, sku: "TEST") }
+        before do
+          product.master.sku = other_product.sku
+        end
+
+        it "should not be saved" do
+          expect{ product.save! }.to raise_error
         end
       end
 
@@ -59,7 +71,7 @@ describe Spree::Product do
         end
 
         it "saves the master" do
-          product.master.should_receive(:save)
+          product.master.should_receive(:save!)
           product.save
         end
 
@@ -80,7 +92,7 @@ describe Spree::Product do
         end
 
         it "saves the master" do
-          product.master.should_receive(:save)
+          product.master.should_receive(:save!)
           product.save
         end
 
@@ -92,7 +104,7 @@ describe Spree::Product do
 
       context "when master variant and price haven't changed" do
         it "does not save the master" do
-          product.master.should_not_receive(:save)
+          product.master.should_not_receive(:save!)
           product.save
         end
       end

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -60,7 +60,7 @@ describe Spree::Product do
         end
 
         it "should not be saved" do
-          expect{ product.save! }.to raise_error
+          expect { product.save! }.to raise_error
         end
       end
 


### PR DESCRIPTION
See #5306

This fix forces the master variant (which is saved after the product) to throw an exception if validation fails.
because it is part of a before_save hook it will transient the product object as well.
Before the exception is raised, the errors are transferred from the master variant object to the product object so the UI can show them.

Another change is on the form_for function. The call now is more explicit because if the product is saved and then destroyed (because of the master variant validation failure) the regular form_for wont know it and will call the update action instead of the create which will result in an exception.
