### PR TITLE
Have reimbursements touch their customer returns

### DIFF
--- a/core/app/models/spree/reimbursement.rb
+++ b/core/app/models/spree/reimbursement.rb
@@ -3,7 +3,7 @@ module Spree
     class IncompleteReimbursement < StandardError; end
 
     belongs_to :order, inverse_of: :reimbursements
-    belongs_to :customer_return, inverse_of: :reimbursements
+    belongs_to :customer_return, inverse_of: :reimbursements, touch: true
 
     has_many :refunds, inverse_of: :reimbursement
     has_many :credits, inverse_of: :reimbursement, class_name: 'Spree::Reimbursement::Credit'


### PR DESCRIPTION
For example, completing a reimbursement may mean that a customer return is now fully reimbursed, etc.
