### PR TITLE
Handling Fees

### DIFF
--- a/backend/app/controllers/spree/admin/stock_locations_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_locations_controller.rb
@@ -3,6 +3,7 @@ module Spree
     class StockLocationsController < ResourceController
 
       before_action :set_country, only: :new
+      before_action :load_data, except: [:index]
 
       private
 
@@ -18,6 +19,10 @@ module Spree
           flash[:error] = Spree.t(:stock_locations_need_a_default_country)
           redirect_to admin_stock_locations_path and return
         end
+      end
+      
+      def load_data
+        @calculators = StockLocation.calculators.sort_by(&:name)
       end
 
     end

--- a/backend/app/views/spree/admin/stock_locations/_form.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/_form.html.erb
@@ -91,6 +91,10 @@
       </div>
     </div>
   </div>
+
+  <div data-hook="admin_stock_location_form_calculator_fields" class="omega six columns">
+    <%= render partial: "spree/admin/shared/calculator_fields", locals: { f: f } %>
+  </div>
 </div>
 
 <% content_for :head do %>

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -47,6 +47,7 @@ module Spree
     scope :non_tax, -> { where.not(source_type: 'Spree::TaxRate') }
     scope :price, -> { where(adjustable_type: 'Spree::LineItem') }
     scope :shipping, -> { where(adjustable_type: 'Spree::Shipment') }
+    scope :handling, -> { where(source_type: 'Spree::StockLocation') }
     scope :optional, -> { where(mandatory: false) }
     scope :eligible, -> { where(eligible: true) }
     scope :charge, -> { where("#{quoted_table_name}.amount >= 0") }

--- a/core/app/models/spree/calculator/shipping/flat_percent_item_total.rb
+++ b/core/app/models/spree/calculator/shipping/flat_percent_item_total.rb
@@ -10,9 +10,15 @@ module Spree
       end
 
       def compute_package(package)
-        content_items = package.contents
-        item_total = total(content_items)
-        value = item_total * BigDecimal(self.preferred_flat_percent.to_s) / 100.0
+        compute_price(total(package.contents))
+      end
+      
+      def compute_shipment(shipment)
+        compute_price(total(shipment.manifest))
+      end
+      
+      def compute_price(price)
+        value = price * BigDecimal(self.preferred_flat_percent.to_s) / 100.0
         (value * 100).round.to_f / 100
       end
     end

--- a/core/app/models/spree/calculator/shipping/flat_rate.rb
+++ b/core/app/models/spree/calculator/shipping/flat_rate.rb
@@ -13,6 +13,10 @@ module Spree
       def compute_package(package)
         self.preferred_amount
       end
+
+      def compute_shipment(shipment)
+        self.preferred_amount
+      end
     end
   end
 end

--- a/core/app/models/spree/calculator/shipping/flexi_rate.rb
+++ b/core/app/models/spree/calculator/shipping/flexi_rate.rb
@@ -13,11 +13,16 @@ module Spree
       end
 
       def compute_package(package)
-        content_items = package.contents
+        compute_quantity(package.contents.sum(&:quantity), preferred_max_items)
+      end
+      
+      def compute_shipment(shipment)
+        compute_quantity(shipment.manifest.sum(&:quantity), preferred_max_items)
+      end
+      
+      def compute_quantity(quantity, max)
         sum = 0
-        max = self.preferred_max_items.to_i
-        items_count = content_items.map(&:quantity).sum
-        items_count.times do |i|
+        quantity.times do |i|
           # check max value to avoid divide by 0 errors
           if (max == 0 && i == 0) || (max > 0) && (i % max == 0)
             sum += self.preferred_first_item.to_f
@@ -26,7 +31,7 @@ module Spree
           end
         end
 
-        sum
+        return sum
       end
     end
   end

--- a/core/app/models/spree/calculator/shipping/handling_charge_on_variant.rb
+++ b/core/app/models/spree/calculator/shipping/handling_charge_on_variant.rb
@@ -1,0 +1,18 @@
+require_dependency 'spree/shipping_calculator'
+
+module Spree
+  module Calculator::Shipping
+    class HandlingChargeOnVariant < ShippingCalculator
+      preference :currency, :string, default: ->{ Spree::Config[:currency] }
+
+      def self.description
+        Spree.t(:shipping_handling_charge_on_variant)
+      end
+
+      def compute_shipment(shipment)
+        compute_quantity(shipment.manifest.sum{|item| item.quantity * item.variant.handling_charge})
+      end
+      
+    end
+  end
+end

--- a/core/app/models/spree/calculator/shipping/per_item.rb
+++ b/core/app/models/spree/calculator/shipping/per_item.rb
@@ -11,8 +11,15 @@ module Spree
       end
 
       def compute_package(package)
-        content_items = package.contents
-        self.preferred_amount * content_items.sum { |item| item.quantity }
+        compute_quantity(package.contents.sum(&:quantity))
+      end
+      
+      def compute_shipment(shipment)
+        compute_quantity(shipment.manifest.sum(&:quantity))
+      end
+      
+      def compute_quantity(quantity)
+        self.preferred_amount * quantity
       end
     end
   end

--- a/core/app/models/spree/calculator/shipping/price_sack.rb
+++ b/core/app/models/spree/calculator/shipping/price_sack.rb
@@ -13,8 +13,15 @@ module Spree
       end
 
       def compute_package(package)
-        content_items = package.contents
-        if total(content_items) < self.preferred_minimal_amount
+        compute_price(total(package.contents))
+      end
+      
+      def compute_shipment(shipment)
+        compute_price(total(shipment.manifest))
+      end
+      
+      def compute_price(price)
+        if price < self.preferred_minimal_amount
           self.preferred_normal_amount
         else
           self.preferred_discount_amount

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -63,7 +63,7 @@ module Spree
 
     delegate_belongs_to :master, :sku, :price, :currency, :display_amount, :display_price, :weight, :height, :width, :depth, :is_master, :has_default_price?, :cost_currency, :price_in, :amount_in
 
-    delegate_belongs_to :master, :cost_price
+    delegate_belongs_to :master, :cost_price, :handling_charge
 
     after_create :set_master_variant_defaults
     after_create :add_properties_and_option_types_from_prototype

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -133,7 +133,9 @@ module Spree
     end
 
     def final_price
-      discounted_cost + tax_total
+      discounted_cost + tax_total + handling_total
+      # TODO: Cleaner to just return `cost + adjustment_total`?
+      # (adjustment_total includes discounts, tax, & handling, along with other potential adjustments)
     end
 
     def final_price_with_items
@@ -145,9 +147,8 @@ module Spree
       manifest.each { |item| manifest_unstock(item) }
     end
 
-    def final_price
-      discounted_cost + tax_total + handling_total
-      # TODO: Cleaner to just return `cost + adjustment_total`?
+    def include?(variant)
+      inventory_units_for(variant).present?
     end
 
     def inventory_units_for(variant)
@@ -387,7 +388,7 @@ module Spree
         shipment_to_transfer_to.save!
       end
     end
-    
+
     private
 
       def after_ship

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -12,6 +12,7 @@ module Spree
     has_many :shipping_methods, through: :shipping_rates
     has_many :state_changes, as: :stateful
 
+    after_save :apply_handling_fee, if: :stock_location_id_changed?
     after_save :update_adjustments
 
     before_validation :set_cost_zero_when_nil
@@ -144,8 +145,9 @@ module Spree
       manifest.each { |item| manifest_unstock(item) }
     end
 
-    def include?(variant)
-      inventory_units_for(variant).present?
+    def final_price
+      discounted_cost + tax_total + handling_total
+      # TODO: Cleaner to just return `cost + adjustment_total`?
     end
 
     def inventory_units_for(variant)
@@ -383,6 +385,22 @@ module Spree
         save!
         shipment_to_transfer_to.refresh_rates
         shipment_to_transfer_to.save!
+      end
+    end
+    
+    def apply_handling_fee
+      adjustments.handling.destroy_all
+      if stock_location.calculator
+        amount = stock_location.calculator.compute(self)
+        unless amount == 0
+          adjustments.create!({
+            source: stock_location,
+            adjustable: self,
+            amount: amount,
+            order: order,
+            label: "Handling"
+            })
+        end
       end
     end
 

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -388,26 +388,26 @@ module Spree
       end
     end
     
-    def apply_handling_fee
-      adjustments.handling.destroy_all
-      if stock_location.calculator
-        amount = stock_location.calculator.compute(self)
-        unless amount == 0
-          adjustments.create!({
-            source: stock_location,
-            adjustable: self,
-            amount: amount,
-            order: order,
-            label: "Handling"
-            })
-        end
-      end
-    end
-
     private
 
       def after_ship
         ShipmentHandler.factory(self).perform
+      end
+
+      def apply_handling_fee
+        adjustments.handling.destroy_all
+        if stock_location.calculator
+          amount = stock_location.calculator.compute(self)
+          unless amount == 0
+            adjustments.create!({
+              source: stock_location,
+              adjustable: self,
+              amount: amount,
+              order: order,
+              label: "Handling"
+              })
+          end
+        end
       end
 
       def can_get_rates?

--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -1,5 +1,9 @@
 module Spree
   class StockLocation < Spree::Base
+    include Spree::Core::CalculatedAdjustments
+    include Spree::Core::AdjustmentSource
+    has_many :adjustments, as: :source
+    
     has_many :shipments
     has_many :stock_items, dependent: :delete_all
     has_many :stock_movements, through: :stock_items
@@ -14,6 +18,10 @@ module Spree
 
     after_create :create_stock_items, :if => "self.propagate_all_variants?"
     after_save :ensure_one_default
+    
+    def compute_amount(item)
+      calculator.compute(item)
+    end    
 
     def state_text
       state.try(:abbr) || state.try(:name) || state_name

--- a/core/db/migrate/20140910014850_add_handling_charge_to_variants.rb
+++ b/core/db/migrate/20140910014850_add_handling_charge_to_variants.rb
@@ -1,0 +1,5 @@
+class AddHandlingChargeToVariants < ActiveRecord::Migration
+  def change
+    add_column :spree_variants, :handling_charge, :decimal, precision: 10, scale: 2, default: 0.0
+  end
+end

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -21,6 +21,14 @@ module Spree
             Spree::Calculator::Shipping::PerItem,
             Spree::Calculator::Shipping::PriceSack]
 
+        app.config.spree.calculators.add_class('stock_locations')
+        app.config.spree.calculators.stock_locations = [
+            Spree::Calculator::Shipping::FlatPercentItemTotal,
+            Spree::Calculator::Shipping::FlatRate,
+            Spree::Calculator::Shipping::FlexiRate,
+            Spree::Calculator::Shipping::PerItem,
+            Spree::Calculator::Shipping::PriceSack]
+
          app.config.spree.calculators.tax_rates = [
             Spree::Calculator::DefaultTax]
       end

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -27,7 +27,8 @@ module Spree
             Spree::Calculator::Shipping::FlatRate,
             Spree::Calculator::Shipping::FlexiRate,
             Spree::Calculator::Shipping::PerItem,
-            Spree::Calculator::Shipping::PriceSack]
+            Spree::Calculator::Shipping::PriceSack,
+            Spree::Calculator::Shipping::HandlingChargeOnVariant]
 
          app.config.spree.calculators.tax_rates = [
             Spree::Calculator::DefaultTax]

--- a/core/lib/spree/testing_support/factories/stock_location_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_location_factory.rb
@@ -24,5 +24,10 @@ FactoryGirl.define do
         stock_location.stock_items.where(:variant_id => product_2.master.id).first.adjust_count_on_hand(20)
       end
     end
+    
+    factory :stock_location_with_handling_fee do
+      association(:calculator, factory: :calculator, strategy: :build)
+    end
+
   end
 end

--- a/frontend/app/views/spree/checkout/_summary.html.erb
+++ b/frontend/app/views/spree/checkout/_summary.html.erb
@@ -29,7 +29,7 @@
 
     <% if order.passed_checkout_step?("delivery") && order.shipments.any? %>
       <tr data-hook="shipping_total">
-        <td><%= Spree.t(:shipping_total) %></td>
+        <td><%= Spree.t(:shipping_total) %>:</td>
         <td><%= Spree::Money.new(order.shipments.to_a.sum(&:cost), currency: order.currency).to_html %></td>
       </tr>
 
@@ -37,7 +37,7 @@
         <tbody data-hook="order_details_shipment_promotion_adjustments">
           <% order.shipment_adjustments.nonzero.promotion.eligible.group_by(&:label).each do |label, adjustments| %>
             <tr class="total">
-              <td><%= label %></td>
+              <td><%= label %>:</td>
               <td><%= Spree::Money.new(adjustments.sum(&:amount), currency: order.currency).to_html %></td>
             </tr>
           <% end %>
@@ -45,12 +45,23 @@
       <% end %>
     <% end %>
 
+  <% if order.all_adjustments.handling.exists? %>
+    <tbody data-hook="order_details_shipment_handling_adjustments">
+      <% order.all_adjustments.handling.group_by(&:label).each do |label, adjustments| %>
+        <tr class="total">
+          <td><%= label %>:</td>
+          <td><%= Spree::Money.new(adjustments.sum(&:amount), currency: order.currency) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  <% end %>
+
     <% if order.adjustments.nonzero.eligible.exists? %>
       <tbody id="summary-order-charges" data-hook>
         <% order.adjustments.nonzero.eligible.each do |adjustment| %>
         <% next if (adjustment.source_type == 'Spree::TaxRate') and (adjustment.amount == 0) %>
           <tr class="total">
-            <td><%= adjustment.label %>: </td>
+            <td><%= adjustment.label %>:</td>
             <td><%= adjustment.display_amount.to_html %></td>
           </tr>
         <% end %>

--- a/frontend/app/views/spree/shared/_order_details.html.erb
+++ b/frontend/app/views/spree/shared/_order_details.html.erb
@@ -116,6 +116,17 @@
     <% end %>
   </tfoot>
 
+  <% if order.all_adjustments.handling.exists? %>
+    <tfoot id="tax-adjustments" data-hook="order_details_tax_adjustments">
+      <% order.all_adjustments.handling.group_by(&:label).each do |label, adjustments| %>
+        <tr class="total">
+          <td colspan="4"><%= label %>:</td>
+          <td class="total"><span><%= Spree::Money.new(adjustments.sum(&:amount), currency: order.currency) %></span></td>
+        </tr>
+      <% end %>
+    </tfoot>
+  <% end %>
+
   <% if order.all_adjustments.tax.exists? %>
     <tfoot id="tax-adjustments" data-hook="order_details_tax_adjustments">
       <% order.all_adjustments.tax.group_by(&:label).each do |label, adjustments| %>

--- a/frontend/spec/features/handling_spec.rb
+++ b/frontend/spec/features/handling_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe "Handling on shipping from certain stock locations", :js => true do
+  let!(:country) { create(:country, :states_required => true) }
+  let!(:state) { create(:state, :country => country) }
+  let!(:shipping_method) { create(:shipping_method) }
+  let!(:stock_location) { create(:stock_location_with_handling_fee) }
+  let!(:mug) { create(:product, :name => "RoR Mug") }
+  let!(:payment_method) { create(:check_payment_method) }
+  let!(:zone) { create(:zone) }
+
+  context "handling applied in checkout" do
+    before do
+
+      visit spree.root_path
+      click_link "RoR Mug"
+      click_button "add-to-cart-button"
+      click_button "Checkout"
+      fill_in "order_email", :with => "spree@example.com"
+      fill_in "First Name", :with => "John"
+      fill_in "Last Name", :with => "Smith"
+      fill_in "Street Address", :with => "1 John Street"
+      fill_in "City", :with => "City of John"
+      fill_in "Zip", :with => "01337"
+      select country.name, :from => "Country"
+      select state.name, :from => "order[bill_address_attributes][state_id]"
+      fill_in "Phone", :with => "555-555-5555"
+
+      # To shipping method screen
+      click_button "Save and Continue"
+      # To payment screen
+      click_button "Save and Continue"
+    end
+
+    it "displays the handling fee" do
+      within("#checkout-summary") do
+        page.should have_content("Item Total:  $10.00")
+        page.should have_content("Shipping:  $10.00")
+        page.should have_content("Handling:  $10.00")
+        page.should have_content("Order Total: $30.00")
+      end
+    end
+  end
+end


### PR DESCRIPTION
As discussed by myself in https://github.com/spree/spree/issues/5210 (and commented on by @jhirbour and @labber), and discussed with @peterberkenbosch and @JDutil in the Spree Google group (and with @radar in the Spree IRC channel a couple months ago), I've put some thought into implementing Handling Fees as `Adjustments` applied from a `StockLocation` to a `Shipment`.

Here's the result of that work, for your consideration and discussion. I'm interested in any feedback, and of course in working towards a merge if things are looking good.

Note that for a reason I'm not fully understanding at the moment, I'm seeing `core/app/models/spree/stock_location.rb:3:in '<class:StockLocation>': uninitialized constant Spree::Core::CalculatedAdjustments (NameError)` when I initialize the spec. If anyone has ideas, I assume it's an easy fix.

Note also that this involved a refactor of the shipping calculators' `compute_package` methods, which I think modularizes that code pretty nicely.

It seems to work quite well in the browser, and behaves as expected.

Cheers!
