### PR TITLE
Always call registered extension line item comparison hooks

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -331,10 +331,9 @@ module Spree
     def line_item_options_match(line_item, options)
       return true unless options
 
-      options.keys.all? do |key|
-        !self.respond_to?("#{key}_match".to_sym) || 
-        self.send("#{key}_match".to_sym, line_item, options[key]) 
-      end
+      self.line_item_comparison_hooks.all? { |hook| 
+        self.send(hook, line_item, options)
+      }
     end
 
     # Creates new tax charges if there are any applicable rates. If prices already


### PR DESCRIPTION
Steps to reproduce:
1. Install an extension that registers the line_item_comparison_hook (e.g. https://github.com/jsqu99/spree_product_customizations)
2. Add a product to cart with customization.
3. Add the same product to cart without customization.

Expect: two line items: one with customization one without
Actual: one line item with customization (quantity doubled)

Apparently the codes that match new line item (without options) fails to distinguish it from the existing line item that has options. Because this codes https://github.com/spree/spree/blob/master/core/app/models/spree/order.rb#L334-L337 will not call the hook and always return true when there is no options passed in for the new item.

The fix proposed in this PR is to always call the registered hook. It's up to the extension to determine if there is a match or not.

CC @jsqu99 since this was your codes and this PR will break some of your extension like spree_vouchers and spree_product_customizations
