### PR TITLE
Add Spree::Admin::RootController for redirecting purposes.

### DIFF
--- a/backend/app/controllers/spree/admin/root_controller.rb
+++ b/backend/app/controllers/spree/admin/root_controller.rb
@@ -1,0 +1,17 @@
+module Spree
+  module Admin
+    class RootController < Spree::Admin::BaseController
+
+      skip_before_filter :authorize_admin
+
+      def index
+        redirect_to admin_root_redirect_path
+      end
+
+      protected
+      def admin_root_redirect_path
+        spree.admin_orders_path
+      end
+    end
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,5 +1,5 @@
 Spree::Core::Engine.add_routes do
-  get '/admin', :to => 'admin/orders#index', :as => :admin
+  get '/admin', :to => 'admin/root#index', :as => :admin
 
   namespace :admin do
     get '/search/users', :to => "search#users", :as => :search_users

--- a/backend/spec/controllers/spree/admin/root_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/root_controller_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe Spree::Admin::RootController do
+
+  context "unauthorized request" do
+
+    before :each do
+      Spree::Admin::RootController.any_instance.stub(:spree_current_user).and_return(nil)
+    end
+
+    it "redirects to orders path by default" do
+      get :index, use_route: 'admin'
+
+      expect(response).to redirect_to '/admin/orders'
+    end
+  end
+
+  context "authorized request" do
+    stub_authorization!
+
+    it "redirects to orders path by default" do
+      get :index, use_route: 'admin'
+
+      expect(response).to redirect_to '/admin/orders'
+    end
+
+    it "redirects to wherever admin_root_redirects_path tells it to" do
+      Spree::Admin::RootController.any_instance.stub(:admin_root_redirect_path).and_return('/grooot')
+
+      get :index, use_route: 'admin'
+
+      expect(response).to redirect_to '/grooot'
+    end
+  end
+end


### PR DESCRIPTION
**Note** I don't see how to use the same PR against different branches, so this is the same as #5345 but for 2-3-stable.

Currently, is really difficult to redirect to a different tab when the
user has logged in if said users cannot at least :admin, :index
`Spree::Order`s.

This commit adds a controller that handles `/admin` route so anyone can
easily redirect to another page (or implement any other logic).
## Why

As seen in [Spree Guides > Advanced Topics > Security > Custom Roles in the Admin Namespace](http://guides.spreecommerce.com/developer/security.html#custom-roles-in-the-admin-namespace), one can createa new role that has partial access to the admin panel. Sadly, if the new role has not access at all to `Spree::Order`s, then it will get an authorization failure. This cannot be done using `after_signin_path_for` from Devise since somehow `authorize_admin` is being called both before it and after it, so the redirection done is the one caused by the `authorize!` failing.

This PR aims to provide a simple way to produce such redirections. Currently has been tested on master (commit 620b640e9e) and 2-3-stable (commit a733136a1e98). I'm willing to try them in before version (down to 2-0-stable), but running `build.sh` takes over 30 minutes so I will do it just if you are interested on it.
