### PR TITLE
Detect old-style order refunds

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -659,7 +659,8 @@ module Spree
     end
 
     def has_non_reimbursement_related_refunds?
-      refunds.non_reimbursement.exists?
+      refunds.non_reimbursement.exists? ||
+        payments.offset_payment.exists? # how old versions of spree stored refunds
     end
 
     private

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -10,8 +10,7 @@ module Spree
     belongs_to :source, polymorphic: true
     belongs_to :payment_method, class_name: 'Spree::PaymentMethod'
 
-    has_many :offsets, -> { where("source_type = 'Spree::Payment' AND amount < 0 AND state = 'completed'") },
-      class_name: "Spree::Payment", foreign_key: :source_id
+    has_many :offsets, -> { offset_payment }, class_name: "Spree::Payment", foreign_key: :source_id
     has_many :log_entries, as: :source
     has_many :state_changes, as: :stateful
     has_many :capture_events, :class_name => 'Spree::PaymentCaptureEvent'
@@ -35,6 +34,8 @@ module Spree
 
     scope :from_credit_card, -> { where(source_type: 'Spree::CreditCard') }
     scope :with_state, ->(s) { where(state: s.to_s) }
+    # "offset" is reserved by activerecord
+    scope :offset_payment, -> { where("source_type = 'Spree::Payment' AND amount < 0 AND state = 'completed'") }
 
     scope :checkout, -> { with_state('checkout') }
     scope :completed, -> { with_state('completed') }

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -728,23 +728,38 @@ describe Spree::Order do
   end
 
   describe '#has_non_reimbursement_related_refunds?' do
-    let(:order) { create(:order_ready_to_ship) }
-    subject { order.has_non_reimbursement_related_refunds? }
+    subject do
+      order.has_non_reimbursement_related_refunds?
+    end
 
-    before(:each) do
-      order.payments.first.refunds = [refund]
-      order.save!
-      order.reload
+    context 'no refunds exist' do
+      it { should eq false }
     end
 
     context 'a non-reimbursement related refund exists' do
-      let(:refund) { create(:refund, reimbursement_id: nil, amount: 5)}
+      let(:order) { refund.payment.order }
+      let(:refund) { create(:refund, reimbursement_id: nil, amount: 5) }
+
+      it { should eq true }
+    end
+
+    context 'an old-style refund exists' do
+      let(:order) { create(:order_ready_to_ship) }
+      let(:payment) { order.payments.first.tap { |p| p.stub(profiles_supported: false) } }
+      let!(:refund_payment) {
+        build(:payment, amount: -1, order: order, state: 'completed', source: payment).tap do |p|
+          p.stub(profiles_supported?: false)
+          p.save!
+        end
+      }
 
       it { should eq true }
     end
 
     context 'a reimbursement related refund exists' do
+      let(:order) { refund.payment.order }
       let(:refund) { create(:refund, reimbursement_id: 123, amount: 5)}
+
       it { should eq false }
     end
   end


### PR DESCRIPTION
In the `Spree::Order#has_non_reimbursement_related_refunds?` method.

The old style was not migrated due to not enough information being stored and because of potential ambiguities, but we still need to account for it here.
