### PR TITLE
Require at least one valid payment on transition to complete

### DIFF
--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -71,7 +71,7 @@ module Spree
 
               if states[:payment]
                 before_transition to: :complete do |order|
-                  if order.payment_required? && order.payments.empty?
+                  if order.payment_required? && order.payments.valid.empty?
                     order.errors.add(:base, Spree.t(:no_payment_found))
                     false
                   elsif order.payment_required?

--- a/core/spec/models/spree/order/state_machine_spec.rb
+++ b/core/spec/models/spree/order/state_machine_spec.rb
@@ -21,7 +21,7 @@ describe Spree::Order do
 
       context "when payment processing succeeds" do
         before do
-          order.stub payments: [1]
+          order.payments << FactoryGirl.create(:payment, state: 'checkout', order: order)
           order.stub process_payments: true
         end
 


### PR DESCRIPTION
This commit attempts to address an issue where it is possible to checkout with only invalid / failed payments. I believe the issue is due to process_payments! only considers unprocessed payments in it's loop. If every payment is failed / invalid, it will just loop over nothing but never adding an error to the model, thus allowing the `after_transition: :payment` to continue to the next steps.

https://github.com/spree/spree/blob/master/core/app/models/spree/order/payments.rb#L45

The result is that if a payment process fails legitimately for the first try i.e. Gateway rejects or invalid to Active Merchant, someone can simply do `order.next!` a second time and just move on. This is regardless of capture true/false on the Spree configuration key `allow_checkout_on_gateway_error`.

Supersedes:
https://github.com/spree/spree/pull/5206
