### PR TITLE
Reduce queries whenever _products are rendered.

### DIFF
--- a/core/lib/spree/core/search/base.rb
+++ b/core/lib/spree/core/search/base.rb
@@ -13,10 +13,9 @@ module Spree
         end
 
         def retrieve_products
-          @products_scope = get_base_scope
+          @products = get_base_scope
           curr_page = page || 1
 
-          @products = @products_scope.includes([:master => :prices])
           unless Spree::Config.show_products_without_price
             @products = @products.where("spree_prices.amount IS NOT NULL").where("spree_prices.currency" => current_currency)
           end
@@ -37,7 +36,16 @@ module Spree
             base_scope = base_scope.in_taxon(taxon) unless taxon.blank?
             base_scope = get_products_conditions_for(base_scope, keywords)
             base_scope = add_search_scopes(base_scope)
+            base_scope = add_eagerload_scopes(base_scope)
             base_scope
+          end
+
+          def add_eagerload_scopes scope
+            if include_images
+              scope.eager_load({master: [:prices, :images]})
+            else
+              scope.includes(master: :prices)
+            end
           end
 
           def add_search_scopes(base_scope)
@@ -64,6 +72,7 @@ module Spree
             @properties[:taxon] = params[:taxon].blank? ? nil : Spree::Taxon.find(params[:taxon])
             @properties[:keywords] = params[:keywords]
             @properties[:search] = params[:search]
+            @properties[:include_images] = params[:include_images]
 
             per_page = params[:per_page].to_i
             @properties[:per_page] = per_page > 0 ? per_page : Spree::Config[:products_per_page]

--- a/core/spec/lib/search/base_spec.rb
+++ b/core/spec/lib/search/base_spec.rb
@@ -16,6 +16,20 @@ describe Spree::Core::Search::Base do
     searcher.retrieve_products.count.should == 2
   end
 
+  context "when include_images is included in the initalization params" do
+    let(:params) {{ include_images: true }}
+    subject { described_class.new(params).retrieve_products }
+
+    before do
+      @product1.master.images.create(attachment_file_name: "Test")
+      @product1.reload
+    end
+
+    it "eager loads the images" do
+      expect(subject.to_sql).to match /LEFT OUTER JOIN "spree_assets"/
+    end
+  end
+
   it "switches to next page according to the page parameter" do
     @product3 = create(:product, :name => "RoR Pants", :price => 14.00)
 

--- a/frontend/app/controllers/spree/home_controller.rb
+++ b/frontend/app/controllers/spree/home_controller.rb
@@ -4,7 +4,7 @@ module Spree
     respond_to :html
 
     def index
-      @searcher = build_searcher(params)
+      @searcher = build_searcher(params.merge(include_images: true))
       @products = @searcher.retrieve_products
       @taxonomies = Spree::Taxonomy.includes(root: :children)
     end

--- a/frontend/app/controllers/spree/products_controller.rb
+++ b/frontend/app/controllers/spree/products_controller.rb
@@ -9,7 +9,7 @@ module Spree
     respond_to :html
 
     def index
-      @searcher = build_searcher(params)
+      @searcher = build_searcher(params.merge(include_images: true))
       @products = @searcher.retrieve_products
       @taxonomies = Spree::Taxonomy.includes(root: :children)
     end

--- a/frontend/app/controllers/spree/taxons_controller.rb
+++ b/frontend/app/controllers/spree/taxons_controller.rb
@@ -9,7 +9,7 @@ module Spree
       @taxon = Taxon.find_by_permalink!(params[:id])
       return unless @taxon
 
-      @searcher = build_searcher(params.merge(:taxon => @taxon.id))
+      @searcher = build_searcher(params.merge(taxon: @taxon.id, include_images: true))
       @products = @searcher.retrieve_products
       @taxonomies = Spree::Taxonomy.includes(root: :children)
     end


### PR DESCRIPTION
Before the change:
![without_change](https://cloud.githubusercontent.com/assets/1831235/4236032/56b2aa72-39c4-11e4-9eba-e302f554576b.png)

After the change:

![with_change](https://cloud.githubusercontent.com/assets/1831235/4236037/5eab9ef0-39c4-11e4-9808-b5ca6aabb63e.png)

The times are misleading, but the query reduction is accurate.
