### PR TITLE
Let Product Property value have length validation of db column length

### DIFF
--- a/core/app/models/spree/product_property.rb
+++ b/core/app/models/spree/product_property.rb
@@ -4,7 +4,7 @@ module Spree
     belongs_to :property, class_name: 'Spree::Property', inverse_of: :product_properties
 
     validates :property, presence: true
-    validates :value, length: { maximum: 255 }
+    validates :value, length: { maximum: (Spree::ProductProperty.columns_hash["value"].limit || Float::INFINITY )} rescue ActiveRecord::StatementInvalid
 
     default_scope -> { order("#{self.table_name}.position") }
 


### PR DESCRIPTION
The validation is explicit to 255 which makes it impossible to decorate Spree to increase the columns length after a DB migration is performed. This should allow it to be dynamic to whatever the DB says, with an extra precaution to use Infinity for DB text which is nil limit and raises an error on the validation.

/cc @jordan-brough

Of note, no additional tests provided. I feel that's up to the implementing Spree app that changes the 255 default to provide an app specific test and that the current test is fine. In the case of my change to move the column from string to text:

```
require 'rails_helper'

describe Spree::ProductProperty do
  describe '#valid?' do
    describe 'value' do
      let(:property) { create :property }
      let(:product_property) { Spree::ProductProperty.new(value: value, property: property) }
      subject { product_property.valid? }

      context 'when the column is db.text and the limit is nil' do
        let(:value) do
          "x" * 512
        end

        it 'should be true when the value is greater than 255' do
          subject
          puts product_property.errors[:value].first
          expect(subject).to be_truthy
        end
      end
    end
  end
end
```
