### PR TITLE
Allow disabling Spree Frontend

### DIFF
--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -47,6 +47,7 @@ module Spree
     preference :display_currency, :boolean, default: false
     preference :default_country_id, :integer
     preference :dismissed_spree_alerts, :string, default: ''
+    preference :enable_frontend, :boolean, default: true
     preference :expedited_exchanges, :boolean, default: false # NOTE this requires payment profiles to be supported on your gateway of choice as well as a delayed job handler to be configured with activejob. kicks off an exchange shipment upon return authorization save. charge customer if they do not return items within timely manner.
     preference :expedited_exchanges_days_window, :integer, default: 14 # the amount of days the customer has to return their item after the expedited exchange is shipped in order to avoid being charged
     preference :hide_cents, :boolean, default: false

--- a/frontend/app/controllers/spree/store_controller.rb
+++ b/frontend/app/controllers/spree/store_controller.rb
@@ -2,6 +2,8 @@ module Spree
   class StoreController < Spree::BaseController
     include Spree::Core::ControllerHelpers::Order
 
+    prepend_before_filter :check_if_frontend_enabled
+
     def unauthorized
       render 'spree/shared/unauthorized', :layout => Spree::Config[:layout], :status => 401
     end
@@ -33,6 +35,11 @@ module Spree
       def config_locale
         Spree::Frontend::Config[:locale]
       end
+
+      def check_if_frontend_enabled
+        render_404 if !Spree::Config[:enable_frontend]
+      end
+
   end
 end
 

--- a/frontend/spec/controllers/spree/stores_controller_spec.rb
+++ b/frontend/spec/controllers/spree/stores_controller_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe Spree::StoreController do
+
+  subject do
+    request
+    response.status
+  end
+
+  controller(Spree::StoreController) do
+    def index
+      render text: 'test'
+    end
+  end
+
+  let(:request) { get :index }
+
+  describe '#index' do
+    it { should == 200 }
+  end
+
+  describe 'disabling frontend' do
+
+    context 'when enabled' do
+      it { should == 200 }
+    end
+
+    context 'when disabled' do
+      before { Spree::Config[:enable_frontend] = false }
+      after  { Spree::Config[:enable_frontend] = true }
+
+      it { should == 404 }
+    end
+  end
+end


### PR DESCRIPTION
Via a config preference.

We use our own frontend along with spree-api and this change will allow us to easily disable the frontend on our prod boxes yet keep it enabled for development so that we can test that our spree changes are meshing well with spree frontend code.

We can also try to make sure that we prevent requests at the nginx layer, but this seems like a nice way to make sure we really close off access to frontend so that we never end up with customers accidentally hitting frontend endpoints and getting really confused.  Setting up a config will also allow other extensions (like spree_auth_devise) to read the same setting.
