### PR TITLE
Let Maximum Value Length Be DB Driven (For Product Property Value)

### DIFF
--- a/core/app/models/spree/product_property.rb
+++ b/core/app/models/spree/product_property.rb
@@ -4,7 +4,8 @@ module Spree
     belongs_to :property, class_name: 'Spree::Property', inverse_of: :product_properties
 
     validates :property, presence: true
-    validates :value, length: { maximum: 255 }
+
+    validates_with Spree::Validations::DbMaximumLengthValidator, field: :value
 
     default_scope -> { order("#{self.table_name}.position") }
 

--- a/core/app/models/spree/validations/db_maximum_length_validator.rb
+++ b/core/app/models/spree/validations/db_maximum_length_validator.rb
@@ -1,0 +1,22 @@
+module Spree
+  module Validations
+    ##
+    # Validates a field based on the maximum length of the underlying DB field, if there is one.
+    class DbMaximumLengthValidator < ActiveModel::Validator
+
+      def initialize(options)
+        super
+        @field = options[:field].to_s
+        raise ArgumentError.new("a field must be specified to the validator") if @field.blank?
+      end
+
+      def validate(record)
+        limit = record.class.columns_hash[@field].limit
+        value = record[@field.to_sym]
+        if value && limit && value.to_s.length > limit 
+          record.errors.add(@field.to_sym, :too_long, count: limit)
+        end
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/validations/db_maximum_length_validator_spec.rb
+++ b/core/spec/models/spree/validations/db_maximum_length_validator_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe Spree::Validations::DbMaximumLengthValidator do
+  context 'when Spree::Product' do
+    Spree::Product.class_eval do
+      # Slug currently has no validation for maximum length
+      validates_with Spree::Validations::DbMaximumLengthValidator, field: :slug
+    end
+    let(:limit) { 255 } # The default limit of db.string.
+    let(:product) { create :product }
+    let(:slug) { "x" * (limit + 1)}
+
+    before do
+      product.slug = slug
+    end
+
+    subject { product.valid? }
+
+    it 'should maximum validate slug' do
+      subject
+      expect(product.errors[:slug]).to include(I18n.t("errors.messages.too_long", count: limit))
+    end
+  end
+end


### PR DESCRIPTION
This let's us let the ProductProperty value to be constrained by the underlying DB limit, not 255. If one does a migration to change the column, we're still in a bad spot due to the explicit validation.

Now packaged as ActiveModel::Validator for a) reusability and b) to avoid DB errors when there is no DB and the app is being initialized for some reason i.e. CI, Spree init scripts, etc.

Supersedes:
https://github.com/spree/spree/pull/5357
