### PR TITLE
Revert "Added ability to perform address actions outside scope of an order"

### DIFF
--- a/api/app/controllers/spree/api/addresses_controller.rb
+++ b/api/app/controllers/spree/api/addresses_controller.rb
@@ -4,12 +4,14 @@ module Spree
       before_action :find_order
 
       def show
-        load_and_authorize_address(:read)
+        authorize! :read, @order, order_token
+        find_address
         respond_with(@address)
       end
 
       def update
-        load_and_authorize_address(:update)
+        authorize! :update, @order, order_token
+        find_address
 
         if @address.update_attributes(address_params)
           respond_with(@address, :default_template => :show)
@@ -24,29 +26,16 @@ module Spree
         end
 
         def find_order
-          @order = Spree::Order.find_by!(number: order_id) if order_id
+          @order = Spree::Order.find_by!(number: order_id)
         end
 
         def find_address
-          if @order
-            @address = if @order.bill_address_id == params[:id].to_i
-              @order.bill_address
-            elsif @order.ship_address_id == params[:id].to_i
-              @order.ship_address
-            else
-              raise CanCan::AccessDenied
-            end
+          @address = if @order.bill_address_id == params[:id].to_i
+            @order.bill_address
+          elsif @order.ship_address_id == params[:id].to_i
+            @order.ship_address
           else
-            @address = Spree::Address.find(params[:id])
-          end
-        end
-
-        def load_and_authorize_address(permission)
-          find_address
-          if @order
-            authorize! permission, @order, order_token
-          else
-            authorize! permission, @address
+            raise CanCan::AccessDenied
           end
         end
     end

--- a/api/spec/controllers/spree/api/addresses_controller_spec.rb
+++ b/api/spec/controllers/spree/api/addresses_controller_spec.rb
@@ -7,75 +7,49 @@ module Spree
     before do
       stub_authentication!
       @address = create(:address)
+      @order = create(:order, :bill_address => @address)
     end
-    
-    context "with order" do
+
+    context "with their own address" do
       before do
-        @order = create(:order, :bill_address => @address)
-      end
-      
-      context "with their own address" do
-        before do
-          Order.any_instance.stub :user => current_api_user
-        end
-
-        it "gets an address" do
-          api_get :show, :id => @address.id, :order_id => @order.number
-          json_response['address1'].should eq @address.address1
-        end
-
-        it "updates an address" do
-          api_put :update, :id => @address.id, :order_id => @order.number,
-                           :address => { :address1 => "123 Test Lane" }
-          json_response['address1'].should eq '123 Test Lane'
-        end
-
-        it "receives the errors object if address is invalid" do
-          api_put :update, :id => @address.id, :order_id => @order.number,
-                           :address => { :address1 => "" }
-
-          json_response['error'].should_not be_nil
-          json_response['errors'].should_not be_nil
-          json_response['errors']['address1'].first.should eq "can't be blank"
-        end
+        Order.any_instance.stub :user => current_api_user
       end
 
-      context "on an address that does not belong to this order" do
-        before do
-          @order.bill_address_id = nil
-          @order.ship_address = nil
-        end
+      it "gets an address" do
+        api_get :show, :id => @address.id, :order_id => @order.number
+        json_response['address1'].should eq @address.address1
+      end
 
-        it "cannot retreive address information" do
-          api_get :show, :id => @address.id, :order_id => @order.number
-          assert_unauthorized!
-        end
+      it "updates an address" do
+        api_put :update, :id => @address.id, :order_id => @order.number,
+                         :address => { :address1 => "123 Test Lane" }
+        json_response['address1'].should eq '123 Test Lane'
+      end
 
-        it "cannot update address information" do
-          api_get :update, :id => @address.id, :order_id => @order.number
-          assert_unauthorized!
-        end
+      it "receives the errors object if address is invalid" do
+        api_put :update, :id => @address.id, :order_id => @order.number,
+                         :address => { :address1 => "" }
+
+        json_response['error'].should_not be_nil
+        json_response['errors'].should_not be_nil
+        json_response['errors']['address1'].first.should eq "can't be blank"
       end
     end
-    
-    context "without order" do
-      context "with their own address" do
-        before do
-          Address.any_instance.stub :user => current_api_user
-        end
 
-        it "gets an address" do
-          api_get :show, :id => @address.id
-          json_response['address1'].should eq @address.address1
-        end
+    context "on an address that does not belong to this order" do
+      before do
+        @order.bill_address_id = nil
+        @order.ship_address = nil
       end
 
-      context "on an address that does not belong to this user" do
-        it "cannot update address information" do
-          api_put :update, :id => @address.id, :address => { :address1 => "123 Test Lane" }
-          json_response['address1'].should be_nil
-          assert_unauthorized!
-        end
+      it "cannot retreive address information" do
+        api_get :show, :id => @address.id, :order_id => @order.number
+        assert_unauthorized!
+      end
+
+      it "cannot update address information" do
+        api_get :update, :id => @address.id, :order_id => @order.number
+        assert_unauthorized!
       end
     end
   end

--- a/core/app/models/spree/ability.rb
+++ b/core/app/models/spree/ability.rb
@@ -46,10 +46,6 @@ module Spree
         can [:read, :update], Order do |order, token|
           order.user == user || order.guest_token && token == order.guest_token
         end
-        can [:create, :read], Address
-        can :update, Address do |address|
-          user.bill_address == address || user.ship_address == address
-        end
         can :display, CreditCard, user_id: user.id
         can :display, Product
         can :display, ProductProperty

--- a/guides/content/api/addresses.md
+++ b/guides/content/api/addresses.md
@@ -8,7 +8,7 @@ description: Use the Spree Commerce storefront API to access Address data.
 Retrieve details about a particular address:
 
 ```text
-GET /api/addresses/1```
+GET /api/orders/1/addresses/1```
 
 ### Response
 
@@ -20,7 +20,7 @@ GET /api/addresses/1```
 To update an address, make a request like this:
 
 ```text
-PUT /api/addresses/1?address[firstname]=Ryan```
+PUT /api/orders/1/addresses/1?address[firstname]=Ryan```
 
 This request will update the `firstname` field for an address to the value of \"Ryan\"
 


### PR DESCRIPTION
This code is unreachable in stock spree because there is no route to get to Api::AddressesController without going through an order.
And the unreachable code is insecure by default -- if a store did add an "/api/address/:id" route then any Api user would be able to read any other user's addresses simply by guessing the id because that's how the permissions were added in ability.rb.
It seems like it would be better to just remove this or else make it a fully supported, reachable, and secure endpoint in stock Spree.

cc @dustineichler (since he opened the original PR adding this) -- since this obviously doesn't work out of the box, is there any reason that any of these required changes couldn't all just be added external to Spree wherever you're adding the other missing pieces?

This reverts commit 229cdf4284fa56528a06c0c86830b19a7f49c3df.

Conflicts:
    api/app/controllers/spree/api/addresses_controller.rb
    core/app/models/spree/ability.rb
