### PR TITLE
Update order shipment total on transition to delivery

### DIFF
--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -95,6 +95,7 @@ module Spree
               if states[:delivery]
                 before_transition to: :delivery, do: :create_proposed_shipments
                 before_transition to: :delivery, do: :ensure_available_shipping_rates
+                before_transition to: :delivery, do: :set_shipments_cost
                 before_transition from: :delivery, do: :apply_free_shipping_promotions
               end
 


### PR DESCRIPTION
When an order moves from address to delivery, I am noticing that for shipments, there is a selected_shipping_rate already picked. However, the shipping_total on the order does not reflect this rate. 

This PR invokes the shipment_total update call in a transition to delivery to account for the defaulted option.

Replicate steps, on a order that has just moved from address to delivery:

```
irb(main):022:0> order.shipments.first.cost.to_f
=> 0.0
irb(main):023:0> order.shipments.first.selected_shipping_rate
=> #<Spree::ShippingRate id: 1900, shipment_id: 623, shipping_method_id: 6, selected: true, cost: #<BigDecimal:7f57aa22b510,'0.395E1',18(18)>, created_at: "2014-09-16 19:43:44", updated_at: "2014-09-16 19:43:44", tax_rate_id: 1>
irb(main):024:0> order.shipments.first.selected_shipping_rate.cost.to_f
=> 3.95
irb(main):025:0> order.set_shipments_cost
=> true
irb(main):026:0> order.reload.shipment_total.to_f
=> 3.95
irb(main):027:0> order.shipments.first.cost.to_f
=> 3.95
```
