### PR TITLE
Let's not load all of the promotion codes in the admin interface

### DIFF
--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -67,7 +67,7 @@
         </div>
         <div class="field">
           <%= label_tag nil, Spree.t(:promotion) %>
-          <%= f.select :promotions_id_in, Spree::Promotion.all.collect {|p| [p.name, p.id]}, {:include_blank => true}, :class => 'select2' %>
+          <%= f.select :promotions_id_in, Spree::Promotion.applied.pluck(:name, :id), {:include_blank => true}, :class => 'select2' %>
         </div>
       </div>
 

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -27,6 +27,7 @@ module Spree
     before_save :normalize_blank_values
 
     scope :coupons, ->{ where("#{table_name}.code IS NOT NULL") }
+    scope :applied, -> { joins(:orders).uniq }
 
     def self.advertised
       where(advertise: true)

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -36,6 +36,16 @@ describe Spree::Promotion do
     end
   end
 
+  describe ".applied" do
+    it "scopes promotions that have been applied to an order only" do
+      promotion = Spree::Promotion.create! name: "test", code: ''
+      expect(Spree::Promotion.applied).to be_empty
+
+      promotion.orders << create(:order)
+      expect(Spree::Promotion.applied.first).to eq promotion
+    end
+  end
+
   describe ".advertised" do
     let(:promotion) { create(:promotion) }
     let(:advertised_promotion) { create(:promotion, :advertise => true) }


### PR DESCRIPTION
We have hundreds if not thousands of Promotions in our application.

The admin interface (orders index page) is currently loading all promotions (i.e. `Spree::Promotion.all.collect {|p| [p.name, p.id]}`) to display a drop down of all promotions.

This is slow.

This PR will only load promotion codes that have been applied to an order, and use pluck rather than collect to load the promotion name and id.
