### PR TITLE
Don't process refunds created with a transaction_id

### DIFF
--- a/core/app/models/spree/refund.rb
+++ b/core/app/models/spree/refund.rb
@@ -39,6 +39,8 @@ module Spree
     # attempts to perform the refund.
     # raises an error if the refund fails.
     def perform!
+      return true if transaction_id.present?
+
       credit_cents = Spree::Money.new(amount.to_f, currency: payment.currency).money.cents
 
       @response = process!(credit_cents)


### PR DESCRIPTION
If a transaction id exists, presumably it has already been processed.
This comes in handy when migrating over records from another system.
