### PR TITLE
Do not round decimals in preferences

### DIFF
--- a/core/app/models/spree/preferences/preferable.rb
+++ b/core/app/models/spree/preferences/preferable.rb
@@ -115,7 +115,7 @@ module Spree::Preferences::Preferable
     when :password
       value.to_s
     when :decimal
-      BigDecimal.new(value.to_s).round(2, BigDecimal::ROUND_HALF_UP)
+      BigDecimal.new(value.to_s)
     when :integer
       value.to_i
     when :boolean


### PR DESCRIPTION
Removing decimal rounding as per https://github.com/spree/spree/commit/ff792847a1fe93bd3d122c884de28b60676aed76

This is needed to make :unit_multiplier in spree_active_shipping gem work.
