### PR TITLE
add select2 call after loading new images

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/images/index.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/images/index.js.coffee
@@ -13,3 +13,4 @@ $ ->
       )
       success: (r) ->
         ($ '#images').html r
+        ($ '.select2').select2()


### PR DESCRIPTION
When on the product page of spree and you go to add new images, you get this display:

![screen shot 2014-09-18 at 3 18 39 pm](https://cloud.githubusercontent.com/assets/3117356/4328185/ca96080e-3f81-11e4-95f9-b172f2aabdc5.png)

I noticed that the select tag has a `select2` class, but it wasn't loading up the select2 dropdown. Since select 2 uses JavaScript, I've gone and recalled it after the new page is loaded. The page now appears as so after visiting the new images page:

![screen shot 2014-09-18 at 3 20 29 pm](https://cloud.githubusercontent.com/assets/3117356/4328201/099de01c-3f82-11e4-8ef6-afcda6fcc0b7.png)
