### PR TITLE
set the order#payment_state to the correct state when order is canceled

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -314,25 +314,25 @@ module Spree
     end
 
     def find_line_item_by_variant(variant, options = {})
-      line_items.detect { |line_item| 
+      line_items.detect { |line_item|
                     line_item.variant_id == variant.id &&
                     line_item_options_match(line_item, options)
                   }
     end
-    
-    # This method enables extensions to participate in the 
+
+    # This method enables extensions to participate in the
     # "Are these line items equal" decision.
     #
     # When adding to cart, an extension would send something like:
     # params[:product_customizations]={...}
-    #                                 
+    #
     # and would provide:
     #
     # def product_customizations_match
     def line_item_options_match(line_item, options)
       return true unless options
 
-      self.line_item_comparison_hooks.all? { |hook| 
+      self.line_item_comparison_hooks.all? { |hook|
         self.send(hook, line_item, options)
       }
     end
@@ -438,12 +438,12 @@ module Spree
       order.line_items.each do |other_order_line_item|
         next unless other_order_line_item.currency == currency
 
-        # Compare the line items of the other order with mine. 
+        # Compare the line items of the other order with mine.
         # Make sure you allow any extensions to chime in on whether or
         # not the extension-specific parts of the line item match
-        current_line_item = self.line_items.detect { |my_li| 
-                      my_li.variant == other_order_line_item.variant && 
-                      self.line_item_comparison_hooks.all? { |hook| 
+        current_line_item = self.line_items.detect { |my_li|
+                      my_li.variant == other_order_line_item.variant &&
+                      self.line_item_comparison_hooks.all? { |hook|
                         self.send(hook, my_li, other_order_line_item)
                       }
                     }
@@ -660,9 +660,7 @@ module Spree
     def after_cancel
       shipments.each { |shipment| shipment.cancel! }
       payments.completed.each { |payment| payment.cancel! }
-
       send_cancel_email
-      self.update_column(:payment_state, 'credit_owed') unless shipped?
       self.update!
     end
 

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -168,6 +168,7 @@ module Spree
         order.payment_state = 'paid' if !order.outstanding_balance?
       end
       order.state_changed('payment') if last_state != order.payment_state
+      order.payment_state
     end
 
     private

--- a/core/spec/models/spree/order/state_machine_spec.rb
+++ b/core/spec/models/spree/order/state_machine_spec.rb
@@ -155,6 +155,9 @@ describe Spree::Order do
     end
 
     context "resets payment state" do
+
+      let(:payment) { create(:payment) }
+
       before do
         # TODO: This is ugly :(
         # Stubs methods that cause unwanted side effects in this test
@@ -163,13 +166,15 @@ describe Spree::Order do
         order.stub :has_available_shipment
         order.stub :restock_items!
         shipment.stub(:cancel!)
+        payment.stub(:cancel!)
+        order.stub_chain(:payments, :valid, :size).and_return(1)
+        order.stub_chain(:payments, :completed).and_return([payment])
+        order.stub_chain(:payments, :last).and_return(payment)
       end
 
       context "without shipped items" do
-        it "should set payment state to 'credit owed'" do
-          # Regression test for #3711
-          order.should_receive(:update_column).with(:payment_state, 'credit_owed')
-          order.cancel!
+        it "should set payment state to 'void'" do
+          expect { order.cancel! }.to change{ order.reload.payment_state }.to("void")
         end
       end
 


### PR DESCRIPTION
Fixes #5278
Closes #5279

return the new payment state in the update_payment_state, and add some spacing in the spec.

remove the stub to make sure this is not always returning "pending" _doh_
