### PR TITLE
Deleted the continue button from adjustment index

### DIFF
--- a/backend/app/views/spree/admin/adjustments/index.html.erb
+++ b/backend/app/views/spree/admin/adjustments/index.html.erb
@@ -20,5 +20,3 @@
 <%= javascript_tag do -%>
   var order_number = '<%= @order.number %>';
 <% end -%>
-
-<%= button_link_to Spree.t(:continue), @order.cart? ? new_admin_order_payment_url(@order) : admin_orders_url, :icon => 'arrow-right' %>


### PR DESCRIPTION
On the adjustment index (in the admin) was a continue button.
The button only shows up on this page, it's a leftover from the old 'manual add an order' proces in the admin.

I deleted it.
