### PR TITLE
Close a table in variant autocomplete

### DIFF
--- a/backend/app/views/spree/admin/variants/_autocomplete_stock.js.erb
+++ b/backend/app/views/spree/admin/variants/_autocomplete_stock.js.erb
@@ -48,5 +48,6 @@
             </tr>
           {{/each}}
         </tbody>
+      </table>
   </fieldset>
 </script>


### PR DESCRIPTION
There was no table closing tag in the variants autocomplete.
