### PR TITLE
Right no objects found message for new stock transfer

### DIFF
--- a/backend/app/views/spree/admin/stock_transfers/new.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/new.html.erb
@@ -82,8 +82,7 @@
     </fieldset>
 
     <div class="alpha twelve columns no-objects-found">
-      <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/stock_transfer')) %>,
-      <%= link_to Spree.t(:add_one), spree.new_admin_tax_rate_path %>!
+      <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/variant')) %>.
     </div>
 
     <div id="transfer-variants-table" class="twelve columns alpha" style="display:none">


### PR DESCRIPTION
Found in 2-3-stable, but also in master.

When you add a new stock transfer you have to add variants.
Onload the page always shows an message, because you didn't add variants yet.
The message said: `No Stock Transfers found, Add One!`

The `Add One` link went to `new_admin_tax_rate_path`.

I think this is just a copy-paste mistake.

I corrected it and now it says `No Variants found.`.
