### PR TITLE
Deleted the ajax spinner on the states index

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/admin.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/admin.js.erb
@@ -127,15 +127,12 @@ $(document).ready(function(){
   handle_date_picker_fields();
   $(".observe_field").on('change', function() {
     target = $(this).data("update");
-    ajax_indicator = $(this).data("ajax-indicator") || '#busy_indicator';
     $(target).hide();
-    $(ajax_indicator).show();
     $.ajax({ dataType: 'html',
              url: $(this).data("base-url")+encodeURIComponent($(this).val()),
              type: 'get',
              success: function(data){
                $(target).html(data);
-               $(ajax_indicator).hide();
                $(target).show();
              }
     });

--- a/backend/app/views/spree/admin/states/index.html.erb
+++ b/backend/app/views/spree/admin/states/index.html.erb
@@ -17,8 +17,6 @@
   </select>
 </div>
 
-<%= image_tag 'select2-spinner.gif', :plugin => 'spree', :style => 'display:none;', :id => 'busy_indicator' %>
-
 <div id="state-list" data-hook>
   <%= render :partial => 'state_list'%>
 </div>


### PR DESCRIPTION
There is only 1 observe_field in the Spree admin, found here:
https://github.com/spree/spree/blob/master/backend/app/views/spree/admin/states/index.html.erb#L15

When you change that field the javascript from admin.js will show a loading indicator.
But there is also a global loading indicator, which will be shown on every ajaxStart, shown here:
https://github.com/spree/spree/blob/master/backend/app/assets/javascripts/spree/backend/progress.coffee#L23

At this moment 2 spinners are shown.
So this spinner on the states index could be deprecated, the global spinner will handle it.
