### PR TITLE
Added configuration_menu to the 'add country' page

### DIFF
--- a/backend/app/views/spree/admin/countries/new.html.erb
+++ b/backend/app/views/spree/admin/countries/new.html.erb
@@ -1,3 +1,5 @@
+<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+
 <% content_for :page_title do %>
   <%= Spree.t(:new_country) %>
 <% end %>


### PR DESCRIPTION
The 'add country' page was missing the configuration menu.

I added it.
