### PR TITLE
Added configuration_menu to stock locations pages

### DIFF
--- a/backend/app/views/spree/admin/stock_locations/edit.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/edit.html.erb
@@ -1,3 +1,5 @@
+<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+
 <% content_for :page_title do %>
   <%= Spree.t(:editing_stock_location) %> <i class="fa fa-arrow-right"></i>
   <%= @stock_location.name %>

--- a/backend/app/views/spree/admin/stock_locations/new.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/new.html.erb
@@ -1,3 +1,5 @@
+<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+
 <% content_for :page_title do %>
   <%= Spree.t(:new_stock_location) %>
 <% end %>


### PR DESCRIPTION
The configuration_menu was missing on the stock locations edit and new page.
