### PR TITLE
Add array and hash to spree preferences

### DIFF
--- a/core/app/models/spree/preferences/preferable.rb
+++ b/core/app/models/spree/preferences/preferable.rb
@@ -120,6 +120,8 @@ module Spree::Preferences::Preferable
           value.try(:to_h)
         rescue TypeError
           Hash[*value]
+        rescue ArgumentError
+          raise 'An even count is required when passing an array to be converted to a hash'
         end
       else
         {}

--- a/core/app/models/spree/preferences/preferable.rb
+++ b/core/app/models/spree/preferences/preferable.rb
@@ -109,7 +109,21 @@ module Spree::Preferences::Preferable
     when :array
       value.is_a?(Array) ? value : (Array.wrap(value) || [])
     when :hash
-      value.is_a?(Hash) ? value : {}
+      case value.class.to_s
+      when "Hash"
+        value
+      when "String"
+        # only works with hashes whose keys are strings
+        JSON.parse value.gsub('=>', ':')
+      when "Array"
+        begin
+          value.try(:to_h)
+        rescue TypeError
+          Hash[*value]
+        end
+      else
+        {}
+      end
     else
       value
     end

--- a/core/app/models/spree/preferences/preferable.rb
+++ b/core/app/models/spree/preferences/preferable.rb
@@ -107,7 +107,7 @@ module Spree::Preferences::Preferable
          true
       end
     when :array
-      value.is_a?(Array) ? value : (Array.wrap(value) || [])
+      value.is_a?(Array) ? value : Array.wrap(value)
     when :hash
       case value.class.to_s
       when "Hash"

--- a/core/app/models/spree/preferences/preferable.rb
+++ b/core/app/models/spree/preferences/preferable.rb
@@ -107,7 +107,7 @@ module Spree::Preferences::Preferable
          true
       end
     when :array
-      value.is_a?(Array) ? value : []
+      value.is_a?(Array) ? value : (value.try(:to_a) || [])
     else
       value
     end

--- a/core/app/models/spree/preferences/preferable.rb
+++ b/core/app/models/spree/preferences/preferable.rb
@@ -108,6 +108,8 @@ module Spree::Preferences::Preferable
       end
     when :array
       value.is_a?(Array) ? value : (value.try(:to_a) || [])
+    when :hash
+      value.is_a?(Hash) ? value : {}
     else
       value
     end

--- a/core/app/models/spree/preferences/preferable.rb
+++ b/core/app/models/spree/preferences/preferable.rb
@@ -107,7 +107,7 @@ module Spree::Preferences::Preferable
          true
       end
     when :array
-      value.is_a?(Array) ? value : (value.try(:to_a) || [])
+      value.is_a?(Array) ? value : (Array.wrap(value) || [])
     when :hash
       value.is_a?(Hash) ? value : {}
     else

--- a/core/app/models/spree/preferences/preferable.rb
+++ b/core/app/models/spree/preferences/preferable.rb
@@ -106,6 +106,8 @@ module Spree::Preferences::Preferable
       else
          true
       end
+    when :array
+      value.is_a?(Array) ? value : []
     else
       value
     end

--- a/core/app/models/spree/preferences/preferable.rb
+++ b/core/app/models/spree/preferences/preferable.rb
@@ -110,7 +110,7 @@ module Spree::Preferences::Preferable
       value.is_a?(Array) ? value : Array.wrap(value)
     when :hash
       case value.class.to_s
-      when "Hash", "ActionController::Parameters"
+      when "Hash"
         value
       when "String"
         # only works with hashes whose keys are strings
@@ -124,7 +124,7 @@ module Spree::Preferences::Preferable
           raise 'An even count is required when passing an array to be converted to a hash'
         end
       else
-        {}
+        value.class.ancestors.include?(Hash) ? value : {}
       end
     else
       value

--- a/core/app/models/spree/preferences/preferable.rb
+++ b/core/app/models/spree/preferences/preferable.rb
@@ -110,7 +110,7 @@ module Spree::Preferences::Preferable
       value.is_a?(Array) ? value : Array.wrap(value)
     when :hash
       case value.class.to_s
-      when "Hash"
+      when "Hash", "ActionController::Parameters"
         value
       when "String"
         # only works with hashes whose keys are strings

--- a/core/spec/models/spree/calculator/tiered_flat_rate_spec.rb
+++ b/core/spec/models/spree/calculator/tiered_flat_rate_spec.rb
@@ -6,7 +6,7 @@ describe Spree::Calculator::TieredFlatRate do
   describe "#valid?" do
     subject { calculator.valid? }
     context "when tiers is not a hash" do
-      before { calculator.preferred_tiers = ["nope"] }
+      before { calculator.preferred_tiers = ["nope", 0] }
       it { should be false }
     end
     context "when tiers is a hash" do

--- a/core/spec/models/spree/calculator/tiered_percent_spec.rb
+++ b/core/spec/models/spree/calculator/tiered_percent_spec.rb
@@ -14,7 +14,7 @@ describe Spree::Calculator::TieredPercent do
       it { should be false }
     end
     context "when tiers is not a hash" do
-      before { calculator.preferred_tiers = ["nope"] }
+      before { calculator.preferred_tiers = ["nope", 0] }
       it { should be false }
     end
     context "when tiers is a hash" do

--- a/core/spec/models/spree/preferences/preferable_spec.rb
+++ b/core/spec/models/spree/preferences/preferable_spec.rb
@@ -216,6 +216,12 @@ describe Spree::Preferences::Preferable do
         expect(@a.preferences[:is_hash]).to eql({1 => 2, 3 => 4})
       end
 
+      it "with ancestor of a hash" do
+        ancestor_of_hash = ActionController::Parameters.new({ key: :value })
+        @a.set_preference(:is_hash, ancestor_of_hash)
+        expect(@a.preferences[:is_hash]).to eql({"key" => :value})
+      end
+
       it "with string" do
         @a.set_preference(:is_hash, "{\"0\"=>{\"answer\"=>\"1\", \"value\"=>\"No\"}}")
         @a.preferences[:is_hash].should be_is_a(Hash)

--- a/core/spec/models/spree/preferences/preferable_spec.rb
+++ b/core/spec/models/spree/preferences/preferable_spec.rb
@@ -211,6 +211,11 @@ describe Spree::Preferences::Preferable do
         @a.preferences[:is_hash].should be_is_a(Hash)
       end
 
+      it "with hash and keys are integers" do
+        @a.set_preference(:is_hash, {1 => 2, 3 => 4})
+        expect(@a.preferences[:is_hash]).to eql({1 => 2, 3 => 4})
+      end
+
       it "with string" do
         @a.set_preference(:is_hash, "{\"0\"=>{\"answer\"=>\"1\", \"value\"=>\"No\"}}")
         @a.preferences[:is_hash].should be_is_a(Hash)

--- a/core/spec/models/spree/preferences/preferable_spec.rb
+++ b/core/spec/models/spree/preferences/preferable_spec.rb
@@ -201,6 +201,43 @@ describe Spree::Preferences::Preferable do
       end
     end
 
+    context "converts hash preferences to hash values" do
+      before do
+        A.preference :is_hash, :hash, default: {}
+      end
+
+      it "with hash" do
+        @a.set_preference(:is_hash, {})
+        @a.preferences[:is_hash].should be_is_a(Hash)
+      end
+
+      it "with string" do
+        @a.set_preference(:is_hash, "{\"0\"=>{\"answer\"=>\"1\", \"value\"=>\"No\"}}")
+        @a.preferences[:is_hash].should be_is_a(Hash)
+      end
+
+      it "with boolean" do
+        @a.set_preference(:is_hash, false)
+        @a.preferences[:is_hash].should be_is_a(Hash)
+        @a.set_preference(:is_hash, true)
+        @a.preferences[:is_hash].should be_is_a(Hash)
+      end
+
+      it "with single array" do
+        @a.set_preference(:is_hash, ["key", "value", "another key", "another value"])
+        @a.preferences[:is_hash].should be_is_a(Hash)
+        @a.preferences[:is_hash]["key"].should == "value"
+        @a.preferences[:is_hash]["another key"].should == "another value"
+      end
+
+      it "with a nested array" do
+        @a.set_preference(:is_hash, [["key", "value"], ["another key", "another value"]])
+        @a.preferences[:is_hash].should be_is_a(Hash)
+        @a.preferences[:is_hash]["key"].should == "value"
+        @a.preferences[:is_hash]["another key"].should == "another value"
+      end
+    end
+
     context "converts any preferences to any values" do
       before do
         A.preference :product_ids, :any, :default => []

--- a/core/spec/models/spree/preferences/preferable_spec.rb
+++ b/core/spec/models/spree/preferences/preferable_spec.rb
@@ -335,5 +335,3 @@ describe Spree::Preferences::Preferable do
   end
 
 end
-
-

--- a/core/spec/models/spree/preferences/preferable_spec.rb
+++ b/core/spec/models/spree/preferences/preferable_spec.rb
@@ -180,6 +180,27 @@ describe Spree::Preferences::Preferable do
       end
     end
 
+    context "converts array preferences to array values" do
+      before do
+        A.preference :is_array, :array, default: []
+      end
+
+      it "with arrays" do
+        @a.set_preference(:is_array, [])
+        @a.preferences[:is_array].should be_is_a(Array)
+      end
+
+      it "with string" do
+        @a.set_preference(:is_array, "string")
+        @a.preferences[:is_array].should be_is_a(Array)
+      end
+
+      it "with hash" do
+        @a.set_preference(:is_array, {})
+        @a.preferences[:is_array].should be_is_a(Array)
+      end
+    end
+
     context "converts any preferences to any values" do
       before do
         A.preference :product_ids, :any, :default => []

--- a/core/spec/models/spree/preferences/preferable_spec.rb
+++ b/core/spec/models/spree/preferences/preferable_spec.rb
@@ -223,7 +223,7 @@ describe Spree::Preferences::Preferable do
         @a.preferences[:is_hash].should be_is_a(Hash)
       end
 
-      it "with single array" do
+      it "with simple array" do
         @a.set_preference(:is_hash, ["key", "value", "another key", "another value"])
         @a.preferences[:is_hash].should be_is_a(Hash)
         @a.preferences[:is_hash]["key"].should == "value"
@@ -235,6 +235,10 @@ describe Spree::Preferences::Preferable do
         @a.preferences[:is_hash].should be_is_a(Hash)
         @a.preferences[:is_hash]["key"].should == "value"
         @a.preferences[:is_hash]["another key"].should == "another value"
+      end
+
+      it "with single array" do
+        expect { @a.set_preference(:is_hash, ["key"]) }.to raise_error(ArgumentError)
       end
     end
 


### PR DESCRIPTION
This will add hash and array support to the spree preferences. Currently, Hash's and Array's are handled by spree's any ability, but this is not effective when converting data.

Right now, when an array is submitted, it will be stored as an Array. If it is not an Array, it will use `#wrap` to make it an array, otherwise, return an empty array.

For the Hash, I've added quite a bit of functionality. When a string is submitted as a hash, there will be an attempted `JSON.parse` but this only works with hashes that are using strings for their keys. I thought about adding support for keys which are symbols, but this would be done using `eval` and it might compromise security.

When an array is submitted, we first attempt to try `.to_h` if they're on ruby 2.0. If so, it works. `to_h` only works on nested arrays, see specs for example, which may cause a `TypeError` to be raised. If so, then its not a nested Array and instead of running the array in via a `.to_h`, we attempt to create a new hash with the splat operator.
