### PR TITLE
Correct objects name for stock location form labels

### DIFF
--- a/backend/app/views/spree/admin/stock_locations/_form.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/_form.html.erb
@@ -23,11 +23,11 @@
             <%= f.check_box :default %>
           </li>
           <li>
-            <%= f.label :active, Spree.t(:backorderable_default) %>
+            <%= f.label :backorderable_default, Spree.t(:backorderable_default) %>
             <%= f.check_box :backorderable_default %>
           </li>
           <li>
-            <%= f.label :active, Spree.t(:propagate_all_variants) %>
+            <%= f.label :propagate_all_variants, Spree.t(:propagate_all_variants) %>
             <%= f.check_box :propagate_all_variants %>
           </li>
         </ul>


### PR DESCRIPTION
I changed the object names to the right object names on the stock location form.
