### PR TITLE
Introduce Tax Code to Tax Category

### DIFF
--- a/backend/app/views/spree/admin/tax_categories/_form.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/_form.html.erb
@@ -3,7 +3,14 @@
     <%= f.field_container :name do %>
       <%= f.label :name, Spree.t(:name) %>
       <%= f.text_field :name, :class => 'fullwidth' %>
-    <% end %>  
+    <% end %>
+  </div>
+
+  <div class="two columns">
+    <%= f.field_container :tax_code do %>
+      <%= f.label :tax_code, Spree.t(:tax_code) %>
+      <%= f.text_field :tax_code, :class => 'fullwidth' %>
+    <% end %>
   </div>
   
   <div class="five columns">

--- a/backend/app/views/spree/admin/tax_categories/index.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/index.html.erb
@@ -15,7 +15,8 @@
 <% if @tax_categories.any? %>
 <table class="index" id='listing_tax_categories' data-hook>
   <colgroup>
-    <col style="width: 30%" />
+    <col style="width: 20%" />
+    <col style="width: 10%" />
     <col style="width: 40%" />
     <col style="width: 15%" />
     <col style="width: 15%" />
@@ -23,6 +24,7 @@
   <thead>
     <tr data-hook="tax_header">
       <th><%= Spree.t(:name) %></th>
+      <th><%= Spree.t(:tax_code) %></th>
       <th><%= Spree.t(:description) %></th>
       <th><%= Spree.t(:default) %></th>
       <th class="actions"></th>
@@ -35,6 +37,7 @@
     %>
       <tr id="<%= spree_dom_id tax_category %>" data-hook="tax_row" class="<%= cycle('odd', 'even')%>">
         <td class="align-center"><%= tax_category.name %></td>
+        <td class="align-center"><%= tax_category.tax_code %></td>
         <td class="align-center"><%= tax_category.description %></td>
         <td class="align-center"><%= tax_category.is_default? ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>
         <td class="actions">

--- a/backend/spec/controllers/spree/admin/tax_categories_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/tax_categories_controller_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+module Spree
+  module Admin
+    describe TaxCategoriesController do
+      stub_authorization!
+
+      describe 'GET #index' do
+        subject { spree_get :index }
+
+        it 'should be successful' do
+          expect(subject).to be_success
+        end
+      end
+
+      describe 'PUT #update' do
+        let(:tax_category) { create :tax_category }
+    
+        subject { spree_put :update, {id: tax_category.id, tax_category: { name: 'Foo', tax_code: 'Bar' }}}
+
+        it 'should redirect' do
+          expect(subject).to be_redirect
+        end
+
+        it 'should update' do
+          subject
+          tax_category.reload
+          expect(tax_category.name).to eq('Foo')
+          expect(tax_category.tax_code).to eq('Bar')
+        end
+      end
+    end
+  end
+end

--- a/backend/spec/features/admin/configuration/tax_categories_spec.rb
+++ b/backend/spec/features/admin/configuration/tax_categories_spec.rb
@@ -10,13 +10,14 @@ describe "Tax Categories" do
 
   context "admin visiting tax categories list" do
     it "should display the existing tax categories" do
-      create(:tax_category, :name => "Clothing", :description => "For Clothing")
+      create(:tax_category, :name => "Clothing", :tax_code => "CL001", :description => "For Clothing")
       click_link "Tax Categories"
       page.should have_content("Listing Tax Categories")
       within_row(1) do
         column_text(1).should == "Clothing"
-        column_text(2).should == "For Clothing"
-        column_text(3).should == "No"
+        column_text(2).should == "CL001"
+        column_text(3).should == "For Clothing"
+        column_text(4).should == "No"
       end
     end
   end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1267,6 +1267,7 @@ en:
     tax_included: "Tax (incl.)"
     tax_categories: Tax Categories
     tax_category: Tax Category
+    tax_code: Tax Code
     tax_rate_amount_explanation: Tax rates are a decimal amount to aid in calculations, (i.e. if the tax rate is 5% then enter 0.05)
     tax_rates: Tax Rates
     taxon: Taxon

--- a/core/db/migrate/20140924164824_add_code_to_spree_tax_categories.rb
+++ b/core/db/migrate/20140924164824_add_code_to_spree_tax_categories.rb
@@ -1,0 +1,5 @@
+class AddCodeToSpreeTaxCategories < ActiveRecord::Migration
+  def change
+    add_column :spree_tax_categories, :tax_code, :string
+  end
+end


### PR DESCRIPTION
This PR introduces a simple Tax Code field that can be used to manage important information that maybe meaningful to something external to Spree, i.e. Avalara, IRS, Accounting Team, etc. The current fields of name and description don't really cater towards keeping "code" like information around.

http://developer.avalara.com/api-docs/designing-your-integration/gettax

In my particular case, I need to associate a code to a shipping method for Avalara, i.e FR0000000 in order for me to properly calculate shipping taxes (in another project) and I'm not sure I want to keep it under name or description, nor do I want to decorate the shipping_method model directly.

I know this could just belong as a Spree decoration in my application, but seeing if there's an interest to make this a part of core.

What's contained in this PR.
1) Migration.
2) Simple controller tests for tax category.
3) Changes to index and _form for tax category. 
