### PR TITLE
Standardizing use of colons in checkout summary

### DIFF
--- a/frontend/app/views/spree/checkout/_summary.html.erb
+++ b/frontend/app/views/spree/checkout/_summary.html.erb
@@ -29,7 +29,7 @@
 
     <% if order.passed_checkout_step?("delivery") && order.shipments.any? %>
       <tr data-hook="shipping_total">
-        <td><%= Spree.t(:shipping_total) %></td>
+        <td><%= Spree.t(:shipping_total) %>:</td>
         <td><%= Spree::Money.new(order.shipments.to_a.sum(&:cost), currency: order.currency).to_html %></td>
       </tr>
 
@@ -37,7 +37,7 @@
         <tbody data-hook="order_details_shipment_promotion_adjustments">
           <% order.shipment_adjustments.nonzero.promotion.eligible.group_by(&:label).each do |label, adjustments| %>
             <tr class="total">
-              <td><%= label %></td>
+              <td><%= label %>:</td>
               <td><%= Spree::Money.new(adjustments.sum(&:amount), currency: order.currency).to_html %></td>
             </tr>
           <% end %>
@@ -50,7 +50,7 @@
         <% order.adjustments.nonzero.eligible.each do |adjustment| %>
         <% next if (adjustment.source_type == 'Spree::TaxRate') and (adjustment.amount == 0) %>
           <tr class="total">
-            <td><%= adjustment.label %>: </td>
+            <td><%= adjustment.label %>:</td>
             <td><%= adjustment.display_amount.to_html %></td>
           </tr>
         <% end %>


### PR DESCRIPTION
I noticed that some fields were displayed with a colon, some with a colon and space, and some with no punctuation. This PR standardizes them all to use a colon, which seemed the most popular choice in Spree.
