### PR TITLE
refactor shipping calculator compute methods

### DIFF
--- a/core/app/models/spree/calculator/shipping/flat_percent_item_total.rb
+++ b/core/app/models/spree/calculator/shipping/flat_percent_item_total.rb
@@ -10,10 +10,10 @@ module Spree
       end
 
       def compute_package(package)
-        compute_price(total(package.contents))
+        compute_from_price(total(package.contents))
       end
 
-      def compute_price(price)
+      def compute_from_price(price)
         value = price * BigDecimal(self.preferred_flat_percent.to_s) / 100.0
         (value * 100).round.to_f / 100
       end

--- a/core/app/models/spree/calculator/shipping/flat_percent_item_total.rb
+++ b/core/app/models/spree/calculator/shipping/flat_percent_item_total.rb
@@ -10,9 +10,11 @@ module Spree
       end
 
       def compute_package(package)
-        content_items = package.contents
-        item_total = total(content_items)
-        value = item_total * BigDecimal(self.preferred_flat_percent.to_s) / 100.0
+        compute_price(total(package.contents))
+      end
+
+      def compute_price(price)
+        value = price * BigDecimal(self.preferred_flat_percent.to_s) / 100.0
         (value * 100).round.to_f / 100
       end
     end

--- a/core/app/models/spree/calculator/shipping/flexi_rate.rb
+++ b/core/app/models/spree/calculator/shipping/flexi_rate.rb
@@ -13,11 +13,13 @@ module Spree
       end
 
       def compute_package(package)
-        content_items = package.contents
+        compute_quantity(package.contents.sum(&:quantity))
+      end
+
+      def compute_quantity(quantity)
         sum = 0
         max = self.preferred_max_items.to_i
-        items_count = content_items.map(&:quantity).sum
-        items_count.times do |i|
+        quantity.times do |i|
           # check max value to avoid divide by 0 errors
           if (max == 0 && i == 0) || (max > 0) && (i % max == 0)
             sum += self.preferred_first_item.to_f

--- a/core/app/models/spree/calculator/shipping/flexi_rate.rb
+++ b/core/app/models/spree/calculator/shipping/flexi_rate.rb
@@ -13,10 +13,10 @@ module Spree
       end
 
       def compute_package(package)
-        compute_quantity(package.contents.sum(&:quantity))
+        compute_from_quantity(package.contents.sum(&:quantity))
       end
 
-      def compute_quantity(quantity)
+      def compute_from_quantity(quantity)
         sum = 0
         max = self.preferred_max_items.to_i
         quantity.times do |i|

--- a/core/app/models/spree/calculator/shipping/per_item.rb
+++ b/core/app/models/spree/calculator/shipping/per_item.rb
@@ -11,8 +11,11 @@ module Spree
       end
 
       def compute_package(package)
-        content_items = package.contents
-        self.preferred_amount * content_items.sum { |item| item.quantity }
+        compute_quantity(package.contents.sum(&:quantity))
+      end
+
+      def compute_quantity(quantity)
+        self.preferred_amount * quantity
       end
     end
   end

--- a/core/app/models/spree/calculator/shipping/per_item.rb
+++ b/core/app/models/spree/calculator/shipping/per_item.rb
@@ -11,10 +11,10 @@ module Spree
       end
 
       def compute_package(package)
-        compute_quantity(package.contents.sum(&:quantity))
+        compute_from_quantity(package.contents.sum(&:quantity))
       end
 
-      def compute_quantity(quantity)
+      def compute_from_quantity(quantity)
         self.preferred_amount * quantity
       end
     end

--- a/core/app/models/spree/calculator/shipping/price_sack.rb
+++ b/core/app/models/spree/calculator/shipping/price_sack.rb
@@ -13,10 +13,10 @@ module Spree
       end
 
       def compute_package(package)
-        compute_price(total(package.contents))
+        compute_from_price(total(package.contents))
       end
 
-      def compute_price(price)
+      def compute_from_price(price)
         if price < self.preferred_minimal_amount
           self.preferred_normal_amount
         else

--- a/core/app/models/spree/calculator/shipping/price_sack.rb
+++ b/core/app/models/spree/calculator/shipping/price_sack.rb
@@ -13,8 +13,11 @@ module Spree
       end
 
       def compute_package(package)
-        content_items = package.contents
-        if total(content_items) < self.preferred_minimal_amount
+        compute_price(total(package.contents))
+      end
+
+      def compute_price(price)
+        if price < self.preferred_minimal_amount
           self.preferred_normal_amount
         else
           self.preferred_discount_amount


### PR DESCRIPTION
Most of the shipping calculator `compute` methods take a `package` as an argument, but the underlying computation is being done on a more fundamental property -- like `price`, or `quantity`.

By factoring out the parts that are package-dependent from the parts that are price- or quantity-dependent, we make it easier for people to extend the functionality of these calculators -- for instance, by extending them to compute on `shipments` as well as `packages`, or in any number of other ways. This way we can have the core functionality in the `compute_price` or `compute_quantity` methods and not have to duplicate that logic.
