### PR TITLE
User store location when signing in. fixes #5125 

### DIFF
--- a/core/lib/spree/core/controller_helpers/auth.rb
+++ b/core/lib/spree/core/controller_helpers/auth.rb
@@ -8,7 +8,7 @@ module Spree
           helper_method :try_spree_current_user
 
           rescue_from CanCan::AccessDenied do |exception|
-            unauthorized
+            redirect_unauthorized_access
           end
         end
 
@@ -20,7 +20,7 @@ module Spree
         # Redirect as appropriate when an access request fails.  The default action is to redirect to the login screen.
         # Override this method in your controllers if you want to have special behavior in case the user is not authorized
         # to access the requested action.  For example, a popup window might simply close itself.
-        def unauthorized
+        def redirect_unauthorized_access
           if try_spree_current_user
             flash[:error] = Spree.t(:authorization_failure)
             redirect_to '/unauthorized'


### PR DESCRIPTION
This behavior occurs because the `Spree::Core::ControllerHelpers::Auth#unauthorized`  was overridden in `Spree::StoreController#unauthorized`.

I change the `Spree::Core::ControllerHelpers::Auth#unauthorized` to `Spree::Core::ControllerHelpers::Auth#redirect_unauthorized_access`.

Now we can just call `authorize! :action resource`.
