### PR TITLE
correct for value for defualt tax of a zone to match input id

### DIFF
--- a/backend/app/views/spree/admin/zones/_form.html.erb
+++ b/backend/app/views/spree/admin/zones/_form.html.erb
@@ -14,7 +14,7 @@
 
     <div data-hook="default" class="field">
       <%= zone_form.check_box :default_tax %>
-      <%= label_tag Spree.t(:default_tax_zone) %>
+      <%= label_tag :zone_default_tax, Spree.t(:default_tax_zone) %>
     </div>
 
     <div data-hook="type" class="field">


### PR DESCRIPTION
Before:

![screen shot 2014-09-27 at 6 04 40 pm](https://cloud.githubusercontent.com/assets/3117356/4432764/7ed975a0-46ab-11e4-9d48-71738a156b8f.png)

After:

![screen shot 2014-09-27 at 6 05 41 pm](https://cloud.githubusercontent.com/assets/3117356/4432767/a113c1ca-46ab-11e4-8d94-2085ed7c8147.png)

The `for` attribute of the default zone tax label now matches the `id` attribute of the input checkbox for the default tax zone.
