### PR TITLE
Fix db:bootstrap task

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -624,7 +624,7 @@ en:
     editing_payment_method: Editing Payment Method
     editing_product: Editing Product
     editing_promotion: Editing Promotion
-    editing_promotion_category: Editing Promotion
+    editing_promotion_category: Editing Promotion Category
     editing_property: Editing Property
     editing_prototype: Editing Prototype
     edit_refund_reason: Edit Refund Reason

--- a/core/db/migrate/20130611054351_rename_shipping_methods_zones_to_spree_shipping_methods_zones.rb
+++ b/core/db/migrate/20130611054351_rename_shipping_methods_zones_to_spree_shipping_methods_zones.rb
@@ -1,5 +1,10 @@
 class RenameShippingMethodsZonesToSpreeShippingMethodsZones < ActiveRecord::Migration
   def change
     rename_table :shipping_methods_zones, :spree_shipping_methods_zones
+    # If Spree::ShippingMethod zones association was patched in
+    # CreateShippingMethodZone migrations, it needs to be patched back
+    Spree::ShippingMethod.has_and_belongs_to_many :zones, :join_table => 'spree_shipping_methods_zones',
+                                                          :class_name => 'Spree::Zone',
+                                                          :foreign_key => 'shipping_method_id'
   end
 end

--- a/core/lib/tasks/core.rake
+++ b/core/lib/tasks/core.rake
@@ -86,8 +86,8 @@ use rake db:load_file[/absolute/path/to/sample/filename.rb]}
     end
 
     if load_sample
-      #prevent errors for missing attributes (since rails 3.1 upgrade)
-
+      # Reload models' attributes in case they were loaded in old migrations with wrong attributes
+      ActiveRecord::Base.descendants.each(&:reset_column_information)
       Rake::Task["spree_sample:load"].invoke
     end
 


### PR DESCRIPTION
Migrations, when loaded, are breaking `spree_sample:load` subtask of `db:bootstrap`. The problem with migrations is that they patch models and load them while DB has outdated schema, resulting in "blast from the past" kind of models.

This PR fixes the `db:bootstrap` by patching back the Product model when its association is renamed in later migration and by reloading all loaded models' attributes before `spree_sample:load`.
