### PR TITLE
Remove some bad factory values

### DIFF
--- a/core/lib/spree/testing_support/factories/return_authorization_factory.rb
+++ b/core/lib/spree/testing_support/factories/return_authorization_factory.rb
@@ -1,6 +1,5 @@
 FactoryGirl.define do
   factory :return_authorization, class: Spree::ReturnAuthorization do
-    number '100'
     association(:order, factory: :shipped_order)
     association(:stock_location, factory: :stock_location)
     association(:reason, factory: :return_authorization_reason)

--- a/core/lib/spree/testing_support/factories/shipment_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipment_factory.rb
@@ -1,7 +1,6 @@
 FactoryGirl.define do
   factory :shipment, class: Spree::Shipment do
     tracking 'U10000'
-    number '100'
     cost 100.00
     state 'pending'
     order


### PR DESCRIPTION
These numbers are autogenerated by the models so we don't need to set them in the factories.

On top of that, the numbers were being set 1) without their normal prefixes, 2) to the exact same value for every instance of the factory, 3) to the exact same values in two different factories.  These things caused errors in our app specs due to cross-model collisions that were a bit of a pain to track down.
