### PR TITLE
Allow order admin to filter on risky

### DIFF
--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -34,6 +34,10 @@
           <%= f.select :state_eq, Spree::Order.state_machines[:state].states.collect {|s| [Spree.t("order_state.#{s.name}"), s.value]}, {:include_blank => true}, :class => 'select2' %>
         </div>
 
+        <div class="field">
+          <%= label_tag nil, Spree.t(:promotion) %>
+          <%= f.select :promotions_id_in, Spree::Promotion.applied.pluck(:name, :id), {:include_blank => true}, :class => 'select2' %>
+        </div>
       </div>
 
       <div class="four columns">
@@ -64,10 +68,10 @@
             <%= f.check_box :completed_at_not_null, {:checked => @show_only_completed}, '1', '0' %>
             <%= Spree.t(:show_only_complete_orders) %>
           </label>
-        </div>
-        <div class="field">
-          <%= label_tag nil, Spree.t(:promotion) %>
-          <%= f.select :promotions_id_in, Spree::Promotion.applied.pluck(:name, :id), {:include_blank => true}, :class => 'select2' %>
+          <label>
+            <%= f.check_box :considered_risky_eq, {:checked => (params[:q][:considered_risky_eq] == '1')}, '1', '' %>
+            <%= Spree.t(:show_only_considered_risky) %>
+          </label>
         </div>
       </div>
 

--- a/backend/spec/features/admin/orders/listing_spec.rb
+++ b/backend/spec/features/admin/orders/listing_spec.rb
@@ -64,6 +64,21 @@ describe "Orders Listing" do
       within("table#listing_orders") { page.should_not have_content("R100") }
     end
 
+    it "should be able to filter risky orders" do
+      # Check risky and filter
+      check "q_considered_risky_eq"
+      click_button "Filter Results"
+
+      # Insure checkbox still checked
+      find("#q_considered_risky_eq").should be_checked
+      # Insure we have the risky order, R100
+      within_row(1) do
+        page.should have_content("R100")
+      end
+      # Insure the non risky order is not present
+      page.should_not have_content("R200")
+    end
+
     context "when pagination is really short" do
       before do
         @old_per_page = Spree::Config[:orders_per_page]

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1225,6 +1225,7 @@ en:
     show_active: Show Active
     show_deleted: Show Deleted
     show_only_complete_orders: Only show complete orders
+    show_only_considered_risky: Only show risky orders
     show_rate_in_label: Show rate in label
     sku: SKU
     skus: SKUs


### PR DESCRIPTION
This adds a checkbox to let there be a ransack search for risky orders. The pain point I'm trying to address is for our E-Com Operations people to quickly identify these orders and start the process of review and approve so it can be fulfilled.

Right now, it's a bit difficult to find these in the existing Admin with all of the pagination etc.

Couple of notes:
1) Had to move things around and hopefully this layout looks ok.
2) The text in the screenshot for the risky checkbox is before I added the `Spree.t` translation.

Let me know what people think and if there is an easier way for Spree Admins to do this, then I'm happy to hear it and kill this PR.

![screen shot 2014-10-01 at 12 13 01 pm](https://cloud.githubusercontent.com/assets/134368/4479994/64593bbc-4993-11e4-8764-0fce616e5019.png)
