### PR TITLE
Added code to shipping methods model, API, Admin

### DIFF
--- a/api/app/views/spree/api/shipments/small.v1.rabl
+++ b/api/app/views/spree/api/shipments/small.v1.rabl
@@ -14,7 +14,7 @@ child :selected_shipping_rate => :selected_shipping_rate do
 end
 
 child :shipping_methods => :shipping_methods do
-  attributes :id, :name
+  attributes :id, :code, :name
   child :zones => :zones do
     attributes :id, :name, :description
   end

--- a/api/app/views/spree/api/shipping_rates/show.v1.rabl
+++ b/api/app/views/spree/api/shipping_rates/show.v1.rabl
@@ -1,2 +1,2 @@
-attributes  :id, :name, :cost, :selected, :shipping_method_id
+attributes  :id, :name, :cost, :selected, :shipping_method_id, :shipping_method_code
 node(:display_cost) { |sr| sr.display_cost.to_s }

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -529,6 +529,7 @@ module Spree
             json_shipping_method = shipment["shipping_methods"][0]
             json_shipping_method["id"].should == shipping_method.id
             json_shipping_method["name"].should == shipping_method.name
+            json_shipping_method["code"].should == shipping_method.code
             json_shipping_method["zones"].should_not be_empty
             json_shipping_method["shipping_categories"].should_not be_empty
 
@@ -540,6 +541,7 @@ module Spree
             shipping_rate["cost"].should == "10.0"
             shipping_rate["selected"].should be true
             shipping_rate["display_cost"].should == "$10.00"
+            shipping_rate["shipping_method_code"].should == json_shipping_method["code"]
 
             shipment["stock_location_name"].should_not be_blank
             manifest_item = shipment["manifest"][0]

--- a/backend/app/views/spree/admin/shipping_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/_form.html.erb
@@ -23,6 +23,14 @@
         <%= error_message_on :shipping_method, :admin_name %>
       <% end %>
     </div>
+
+    <div data-hook="admin_shipping_method_form_code" class="omega six columns">
+      <%= f.field_container :code do %>
+        <%= f.label :code, Spree.t(:code) %><br />
+        <%= f.text_field :code, :class => 'fullwidth', :label => false  %>
+        <%= error_message_on :shipping_method, :code %>
+      <% end %>
+    </div>
   </div>
 
   <div data-hook="admin_shipping_method_form_tracking_url_field" class="alpha twelve columns">

--- a/core/app/models/spree/shipping_rate.rb
+++ b/core/app/models/spree/shipping_rate.rb
@@ -46,6 +46,10 @@ module Spree
       Spree::ShippingMethod.unscoped { super }
     end
 
+    def shipping_method_code
+      shipping_method.code
+    end
+
     def tax_rate
       Spree::TaxRate.unscoped { super }
     end

--- a/core/db/migrate/20141002191113_add_code_to_spree_shipping_methods.rb
+++ b/core/db/migrate/20141002191113_add_code_to_spree_shipping_methods.rb
@@ -1,0 +1,5 @@
+class AddCodeToSpreeShippingMethods < ActiveRecord::Migration
+  def change
+    add_column :spree_shipping_methods, :code, :string
+  end
+end

--- a/core/lib/spree/testing_support/factories/shipping_method_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipping_method_factory.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :base_shipping_method, class: Spree::ShippingMethod do
     zones { |a| [Spree::Zone.global] }
     name 'UPS Ground'
+    code 'UPS_GROUND'
 
     before(:create) do |shipping_method, evaluator|
       if shipping_method.shipping_categories.empty?

--- a/core/spec/models/spree/shipping_rate_spec.rb
+++ b/core/spec/models/spree/shipping_rate_spec.rb
@@ -128,4 +128,14 @@ describe Spree::ShippingRate do
       expect(shipping_rate.tax_rate).to eq(tax_rate)
     end
   end
+
+  context "#shipping_method_code" do
+    before do
+      shipping_method.code = "THE_CODE"
+    end
+
+    it 'should be shipping_method.code' do
+      expect(shipping_rate.shipping_method_code).to eq("THE_CODE")
+    end
+  end
 end


### PR DESCRIPTION
This PR adds a code field to shipping methods and allows it to be read via the API. It can be configured via the Admin (screen attached).

The situation I am trying to work out is that our fulfillment provider needs a "sku" like field to know what shipping provider to use for the order. In past integrations with other systems, they are use to seeing "shipping as a line item" with it's own SKU and quantity of 1. 

The expectation, like a sku, is that a shipping_method.code could represent an immutable value that is safe to bind against when figuring out what shipping method to use.

![screen shot 2014-10-02 at 3 56 06 pm](https://cloud.githubusercontent.com/assets/134368/4498673/507aa2f6-4a7a-11e4-9f7e-f7872791fa98.png)
