### PR TITLE
Associate new exchange orders with the same store as the original order

### DIFF
--- a/core/lib/tasks/exchanges.rake
+++ b/core/lib/tasks/exchanges.rake
@@ -19,9 +19,13 @@ namespace :exchanges do
         inventory_units = return_items.map(&:exchange_inventory_unit)
 
         original_order = shipment.order
-        order = Spree::Order.create!(bill_address: original_order.bill_address,
-                                    ship_address: original_order.ship_address,
-                                    email: original_order.email)
+        order_attributes = {
+          bill_address: original_order.bill_address,
+          ship_address: original_order.ship_address,
+          email: original_order.email
+        }
+        order_attributes[:store_id] = original_order.store_id if original_order.respond_to?(:store_id)
+        order = Spree::Order.create!(order_attributes)
 
         order.associate_user!(original_order.user) if original_order.user
 

--- a/core/spec/lib/tasks/exchanges_spec.rb
+++ b/core/spec/lib/tasks/exchanges_spec.rb
@@ -96,6 +96,13 @@ describe "exchanges:charge_unreturned_items" do
         expect { subject.invoke }.not_to change { Spree::Order.count }
       end
 
+      it "associates the store of the original order with the exchange order" do
+        Spree::Order.any_instance.stub(:store_id).and_return(123)
+
+        expect(Spree::Order).to receive(:create!).once.with(hash_including({store_id: 123})) { |attrs| Spree::Order.new(attrs.except(:store_id)).tap(&:save!) }
+        subject.invoke
+      end
+
       context "there is no card from the previous order" do
         let!(:credit_card) { create(:credit_card, user: order.user, default: true, gateway_customer_profile_id: "BGS-123") }
         before { Spree::Order.any_instance.stub(:valid_credit_cards) { [] } }


### PR DESCRIPTION
An order that is created for an unreturned exchange should retain the same store id as the original order.
