### PR TITLE
Fix labels for inputs and misc. bug fixes.

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/sections/_adjustments_table.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_adjustments_table.scss
@@ -1,0 +1,8 @@
+[data-hook="adjustment_buttons"] {
+  tr {
+    div {
+      width: 50%;
+      float: left;
+    }
+  }
+}

--- a/backend/app/assets/stylesheets/spree/backend/spree_admin.scss
+++ b/backend/app/assets/stylesheets/spree/backend/spree_admin.scss
@@ -26,6 +26,7 @@
 @import 'spree/backend/plugins/token-input';
 @import 'spree/backend/plugins/jstree';
 
+@import 'spree/backend/sections/adjustments_table';
 @import 'spree/backend/sections/alerts';
 @import 'spree/backend/sections/orders';
 @import 'spree/backend/sections/overview';

--- a/backend/app/views/spree/admin/adjustments/_adjustments_table.html.erb
+++ b/backend/app/views/spree/admin/adjustments/_adjustments_table.html.erb
@@ -10,10 +10,14 @@
   </thead>
   <tbody>
     <%= render :partial => "adjustment", :collection => @adjustments %>
-    <tr>
+    <tr data-hook="adjustment_buttons">
       <td class="align-center" colspan='4'>
-        <%= button_to Spree.t(:open_all_adjustments), open_adjustments_admin_order_path(@order), :method => :get %>&nbsp;
-        <%= button_to Spree.t(:close_all_adjustments), close_adjustments_admin_order_path(@order), :method => :get %>
+        <div>
+          <%= button_to Spree.t(:open_all_adjustments), open_adjustments_admin_order_path(@order), method: :get %>
+        </div>
+        <div>
+          <%= button_to Spree.t(:close_all_adjustments), close_adjustments_admin_order_path(@order), method: :get %>
+        </div>
       </td>
       <td class='actions'>&nbsp;</td>
     </tr>

--- a/backend/app/views/spree/admin/images/_form.html.erb
+++ b/backend/app/views/spree/admin/images/_form.html.erb
@@ -1,17 +1,17 @@
 <div data-hook="admin_image_form_fields">
   <div class="four columns alpha">
     <div data-hook="file" class="field">
-      <%= f.label Spree.t(:filename) %><br>
+      <%= f.label :attachment, Spree.t(:filename) %><br>
       <%= f.file_field :attachment %>
     </div>
     <div data-hook="variant" class="field">
-      <%= f.label Spree::Variant.model_name.human %><br>
-      <%= f.select :viewable_id, @variants, {}, {:class => 'select2 fullwidth'} %>
+      <%= f.label :viewable_id, Spree::Variant.model_name.human %><br>
+      <%= f.select :viewable_id, @variants, {}, { class: 'select2 fullwidth' } %>
     </div>
   </div>
   <div data-hook="alt_text" class="field omega five columns">
-    <%= f.label Spree.t(:alt_text) %><br>
-    <%= f.text_area :alt, :rows => 4, :class => 'fullwidth' %>
+    <%= f.label :alt, Spree.t(:alt_text) %><br>
+    <%= f.text_area :alt, rows: 4, class: 'fullwidth' %>
   </div>
 </div>
 

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -17,7 +17,7 @@
     <%= search_form_for [:admin, @search] do |f| %>
       <div class="field-block alpha four columns">
         <div class="date-range-filter field">
-          <%= label_tag nil, Spree.t(:date_range) %>
+          <%= label_tag :q_created_at_gt, Spree.t(:date_range) %>
           <div class="date-range-fields">
             <%= f.text_field :created_at_gt, :class => 'datepicker datepicker-from', :value => params[:q][:created_at_gt], :placeholder => Spree.t(:start) %>
 
@@ -30,34 +30,34 @@
         </div>
 
         <div class="field">
-          <%= label_tag nil, Spree.t(:status) %>
+          <%= label_tag :q_state_eq, Spree.t(:status) %>
           <%= f.select :state_eq, Spree::Order.state_machines[:state].states.collect {|s| [Spree.t("order_state.#{s.name}"), s.value]}, {:include_blank => true}, :class => 'select2' %>
         </div>
 
         <div class="field">
-          <%= label_tag nil, Spree.t(:promotion) %>
+          <%= label_tag :q_promotions_id_in, Spree.t(:promotion) %>
           <%= f.select :promotions_id_in, Spree::Promotion.applied.pluck(:name, :id), {:include_blank => true}, :class => 'select2' %>
         </div>
       </div>
 
       <div class="four columns">
         <div class="field">
-          <%= label_tag nil, Spree.t(:order_number, :number => '') %>
+          <%= label_tag :q_number_cont, Spree.t(:order_number, :number => '') %>
           <%= f.text_field :number_cont %>
         </div>
         <div class="field">
-          <%= label_tag nil, Spree.t(:email) %>
+          <%= label_tag :q_email_cont, Spree.t(:email) %>
           <%= f.text_field :email_cont %>
         </div>
       </div>
 
       <div class="four columns">
         <div class="field">
-          <%= label_tag nil, Spree.t(:first_name_begins_with) %>
+          <%= label_tag :q_bill_address_firstname_start, Spree.t(:first_name_begins_with) %>
           <%= f.text_field :bill_address_firstname_start, :size => 25 %>
         </div>
         <div class="field">
-          <%= label_tag nil, Spree.t(:last_name_begins_with) %>
+          <%= label_tag :q_bill_address_lastname_start, Spree.t(:last_name_begins_with) %>
           <%= f.text_field :bill_address_lastname_start, :size => 25%>
         </div>
       </div>
@@ -65,11 +65,11 @@
       <div class="omega four columns">
         <div class="field checkbox">
           <label>
-            <%= f.check_box :completed_at_not_null, {:checked => @show_only_completed}, '1', '0' %>
+            <%= f.check_box :q_completed_at_not_null, {:checked => @show_only_completed}, '1', '0' %>
             <%= Spree.t(:show_only_complete_orders) %>
           </label>
           <label>
-            <%= f.check_box :considered_risky_eq, {:checked => (params[:q][:considered_risky_eq] == '1')}, '1', '' %>
+            <%= f.check_box :q_considered_risky_eq, {:checked => (params[:q][:considered_risky_eq] == '1')}, '1', '' %>
             <%= Spree.t(:show_only_considered_risky) %>
           </label>
         </div>

--- a/backend/app/views/spree/admin/payment_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/_form.html.erb
@@ -16,15 +16,15 @@
         <% end %>
       </div>
       <div data-hook="environment" class="field">
-        <%= label_tag nil, Spree.t(:environment) %>
+        <%= label_tag :payment_method_environment, Spree.t(:environment) %>
         <%= collection_select(:payment_method, :environment, rails_environments, :to_s, :titleize, {}, {:id => 'gtwy-env', :class => 'select2 fullwidth'}) %>
       </div>
       <div data-hook="display" class="field">
-        <%= label_tag nil, Spree.t(:display) %>
+        <%= label_tag :payment_method_display_on, Spree.t(:display) %>
         <%= select(:payment_method, :display_on, Spree::PaymentMethod::DISPLAY.collect { |display| [Spree.t(display), display == :both ? nil : display.to_s] }, {}, {:class => 'select2 fullwidth'}) %>
       </div>
       <div data-hook="auto_capture" class="field">
-        <%= label_tag nil, Spree.t(:auto_capture) %>
+        <%= label_tag :payment_method_auto_capture, Spree.t(:auto_capture) %>
         <%= select(:payment_method, :auto_capture, [["#{Spree.t(:use_app_default)} (#{Spree::Config[:auto_capture]})", ''], [Spree.t(:say_yes), true], [Spree.t(:say_no), false]], {}, {:class => 'select2 fullwidth'}) %>
       </div>
       <div data-hook="active" class="field">
@@ -32,11 +32,11 @@
         <ul>
           <li>
             <%= radio_button :payment_method, :active, true %>
-            <%= label_tag nil, Spree.t(:say_yes) %>
+            <%= label_tag :payment_method_active_true, Spree.t(:say_yes) %>
           </li>
           <li>
             <%= radio_button :payment_method, :active, false %>
-            <%= label_tag nil, Spree.t(:say_no) %>
+            <%= label_tag :payment_method_active_false, Spree.t(:say_no) %>
           </li>
         </ul>
       </div>
@@ -44,11 +44,11 @@
 
     <div class="omega eight columns">
       <div data-hook="name" class="field">
-        <%= label_tag nil, Spree.t(:name) %>
+        <%= label_tag :payment_method_name, Spree.t(:name) %>
         <%= text_field :payment_method, :name, :class => 'fullwidth' %>
       </div>
       <div data-hook="description" class="field">
-        <%= label_tag nil, Spree.t(:description) %>
+        <%= label_tag :payment_method_description, Spree.t(:description) %>
         <%= text_area :payment_method, :description, {:cols => 60, :rows => 6, :class => 'fullwidth'} %>
       </div>
     </div>

--- a/backend/app/views/spree/admin/products/stock.html.erb
+++ b/backend/app/views/spree/admin/products/stock.html.erb
@@ -37,7 +37,7 @@
             <%= form_tag admin_product_variants_including_master_path(@product, variant, format: :js), method: :put, class: 'toggle_variant_track_inventory' do %>
                 <%= check_box_tag 'track_inventory', 1, variant.track_inventory?,
                                   class: 'track_inventory_checkbox' %>
-                <%= Spree.t(:track_inventory) %>
+                <%= label_tag :track_inventory, Spree.t(:track_inventory) %>
                 <%= hidden_field_tag 'variant[track_inventory]', variant.track_inventory?,
                     class: 'variant_track_inventory',
                     id: "variant_track_inventory_#{variant.id}" %>

--- a/backend/app/views/spree/admin/promotions/_actions.html.erb
+++ b/backend/app/views/spree/admin/promotions/_actions.html.erb
@@ -9,7 +9,7 @@
         <%= select_tag 'action_type', options, :class => 'select2 fullwidth' %>  
       </div>
       <div class="filter-actions actions">
-        <%= button Spree.t(:add), 'plus', :class => 'fullwidth' %>
+        <%= button Spree.t(:add), 'plus' %>
       </div>
     </fieldset>
   <% end %>

--- a/backend/app/views/spree/admin/promotions/actions/_create_line_items.html.erb
+++ b/backend/app/views/spree/admin/promotions/actions/_create_line_items.html.erb
@@ -10,14 +10,14 @@
   <% line_items.each_with_index do |line_item, index| %>
     <div class="add-line-item">
       <div class="row">
-        <div class="field alpha eight columns">
-          <% line_item_prefix = "#{param_prefix}[promotion_action_line_items_attributes][#{index}]" %>
-          <%= hidden_field_tag "#{line_item_prefix}[variant_id]", line_item.variant_id, :class => "variant_autocomplete fullwidth" %>
+        <% line_item_prefix = "#{param_prefix}[promotion_action_line_items_attributes][#{index}]" %>
+        <div class="field alpha six columns">
+          <%= label_tag "#{line_item_prefix}_variant_id", Spree.t(:variant) %>
+          <%= hidden_field_tag "#{line_item_prefix}[variant_id]", line_item.variant_id, class: "variant_autocomplete fullwidth" %>
         </div>
-      </div>
-      <div class="row">
-        <div class="field omega eight columns">
-          <%= number_field_tag "#{line_item_prefix}[quantity]", line_item.quantity, :min => 1, :class => 'fullwidth' %>
+        <div class="field omega two columns">
+          <%= label_tag "#{line_item_prefix}_quantity", Spree.t(:quantity) %>
+          <%= number_field_tag "#{line_item_prefix}[quantity]", line_item.quantity, min: 1, class: 'fullwidth' %>
         </div>
       </div>
     </div>

--- a/backend/app/views/spree/admin/promotions/index.html.erb
+++ b/backend/app/views/spree/admin/promotions/index.html.erb
@@ -20,28 +20,28 @@
     <%= search_form_for [:admin, @search] do |f| %>
       <div class="four columns alpha">
         <div class="field">
-          <%= label_tag nil, Spree.t(:name) %>
+          <%= label_tag :q_name_cont, Spree.t(:name) %>
           <%= f.text_field :name_cont, tabindex: 1 %>
         </div>
       </div>
 
       <div class="four columns">
         <div class="field">
-          <%= label_tag nil, Spree.t(:code) %>
+          <%= label_tag :q_code_cont, Spree.t(:code) %>
           <%= f.text_field :code_cont, tabindex: 1 %>
         </div>
       </div>
 
       <div class="four columns">
         <div class="field">
-          <%= label_tag nil, Spree.t(:path) %>
+          <%= label_tag :q_path_cont, Spree.t(:path) %>
           <%= f.text_field :path_cont, tabindex: 1 %>
         </div>
       </div>
 
       <div class="four columns omega">
         <div class="field">
-          <%= label_tag nil, 'promotion category' %><br>
+          <%= label_tag :q_promotion_category_id_eq, 'promotion category' %><br>
           <%= f.collection_select(:promotion_category_id_eq, @promotion_categories, :id, :name, { :include_blank => Spree.t('match_choices.all') }, { :class => 'select2 fullwidth' }) %>
         </div>
       </div>

--- a/backend/app/views/spree/admin/shared/_report_order_criteria.html.erb
+++ b/backend/app/views/spree/admin/shared/_report_order_criteria.html.erb
@@ -1,17 +1,17 @@
 <%= search_form_for @search, :url => spree.sales_total_admin_reports_path  do |s| %>
-    <div class="date-range-filter field align-center">
-        <%= label_tag nil, Spree.t(:start), :class => 'inline' %>
-        <%= s.text_field :completed_at_gt, :class => 'datepicker datepicker-from', :value => datepicker_field_value(params[:q][:completed_at_gt]) %>
+  <div class="date-range-filter field align-center">
+    <%= label_tag nil, Spree.t(:start), :class => 'inline' %>
+    <%= s.text_field :completed_at_gt, :class => 'datepicker datepicker-from', :value => datepicker_field_value(params[:q][:completed_at_gt]) %>
         
-        <span class="range-divider">
-          <i class="fa fa-arrow-right"></i>
-        </span>
+    <span class="range-divider">
+      <i class="fa fa-arrow-right"></i>
+    </span>
 
-        <%= s.text_field :completed_at_lt, :class => 'datepicker datepicker-to', :value => datepicker_field_value(params[:q][:completed_at_lt]) %>
-        <%= label_tag nil, Spree.t(:end), :class => 'inline' %>
-    </div>
+    <%= s.text_field :completed_at_lt, :class => 'datepicker datepicker-to', :value => datepicker_field_value(params[:q][:completed_at_lt]) %>
+    <%= label_tag nil, Spree.t(:end), :class => 'inline' %>
+  </div>
 
-    <div class="actions filter-actions">
-      <%= button Spree.t(:search), 'search'  %>
-    </div>
+  <div class="actions filter-actions">
+    <%= button Spree.t(:search), 'search'  %>
+  </div>
 <% end %>

--- a/backend/app/views/spree/admin/shared/_report_order_criteria.html.erb
+++ b/backend/app/views/spree/admin/shared/_report_order_criteria.html.erb
@@ -1,6 +1,6 @@
 <%= search_form_for @search, :url => spree.sales_total_admin_reports_path  do |s| %>
   <div class="date-range-filter field align-center">
-    <%= label_tag nil, Spree.t(:start), :class => 'inline' %>
+    <%= label_tag :q_completed_at_gt, Spree.t(:start), :class => 'inline' %>
     <%= s.text_field :completed_at_gt, :class => 'datepicker datepicker-from', :value => datepicker_field_value(params[:q][:completed_at_gt]) %>
         
     <span class="range-divider">
@@ -8,7 +8,7 @@
     </span>
 
     <%= s.text_field :completed_at_lt, :class => 'datepicker datepicker-to', :value => datepicker_field_value(params[:q][:completed_at_lt]) %>
-    <%= label_tag nil, Spree.t(:end), :class => 'inline' %>
+    <%= label_tag :q_completed_at_lt, Spree.t(:end), :class => 'inline' %>
   </div>
 
   <div class="actions filter-actions">

--- a/backend/app/views/spree/admin/shared/_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_tabs.html.erb
@@ -2,7 +2,7 @@
   <%= tab :orders, :payments, :creditcard_payments, :shipments, :credit_cards, :return_authorizations, :customer_returns, :icon => 'shopping-cart' %>
 <% end %>
 <% if can? :admin, Spree::Product %>
-  <%= tab :products, :option_types, :properties, :prototypes, :variants, :product_properties, :taxonomies, :icon => 'th-large' %>
+  <%= tab :products, :option_types, :properties, :prototypes, :variants, :product_properties, :taxonomies, :taxons, :icon => 'th-large' %>
 <% end %>
 <% if can? :admin, Spree::Admin::ReportsController %>
   <%= tab :reports, :icon => 'file'  %>

--- a/backend/app/views/spree/admin/shipping_categories/_form.html.erb
+++ b/backend/app/views/spree/admin/shipping_categories/_form.html.erb
@@ -1,6 +1,6 @@
 <div data-hook="admin_shipping_category_form_fields">
   <div data-hook="name" class="field align-center">
-    <%= label_tag Spree.t(:name) %><br>
+    <%= label_tag :shipping_category_name, Spree.t(:name) %><br>
     <%= f.text_field :name %>    
   </div>
 </div>

--- a/backend/app/views/spree/admin/stock_transfers/new.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/new.html.erb
@@ -69,8 +69,8 @@
       </div>
       <div class="two columns">
         <div class="field" id="stock_movement_quantity_field">
-          <%= label_tag 'quantity', Spree.t(:quantity) %>
-          <%= number_field_tag 'transfer_variant_quantity', 1, class: 'fullwidth', min: 0 %>
+          <%= label_tag :transfer_variant_quantity, Spree.t(:quantity) %>
+          <%= number_field_tag :transfer_variant_quantity, 1, class: 'fullwidth', min: 0 %>
         </div>
       </div>
       <div class="two columns omega">

--- a/backend/app/views/spree/admin/taxons/index.html.erb
+++ b/backend/app/views/spree/admin/taxons/index.html.erb
@@ -1,3 +1,7 @@
+<% content_for :page_title do %>
+  <%= Spree.t(:taxons) %>
+<% end %>
+
 <% content_for :table_filter_title do %>
   <%= Spree.t(:choose_a_taxon_to_sort_products_for) %>
 <% end %>

--- a/backend/app/views/spree/admin/trackers/_form.html.erb
+++ b/backend/app/views/spree/admin/trackers/_form.html.erb
@@ -1,13 +1,13 @@
 <div data-hook="admin_tracker_form_fields" class="row">
   <div class="alpha four columns">
     <div data-hook="analytics_id" class="field">
-      <%= label_tag nil, Spree.t(:google_analytics_id) %>
+      <%= label_tag :tracker_analytics_id, Spree.t(:google_analytics_id) %>
       <%= text_field :tracker, :analytics_id, :class => 'fullwidth' %>
     </div>
   </div>
   <div class="four columns">
     <div data-hook="environment" class="field">
-      <%= label_tag nil, Spree.t(:environment) %>
+      <%= label_tag :tracker_environment, Spree.t(:environment) %>
       <%= collection_select(:tracker, :environment, rails_environments, :to_s, :titleize, {}, {:id => 'tracker-env', :class => 'select2 fullwidth'}) %>
     </div>
   </div>
@@ -17,11 +17,11 @@
       <ul>
         <li>
           <%= radio_button(:tracker, :active, true) %>
-          <%= Spree.t(:say_yes) %>
+          <%= label_tag :tracker_active_true, Spree.t(:say_yes) %>
         </li>
         <li>
           <%= radio_button(:tracker, :active, false) %>
-          <%= Spree.t(:say_no) %>
+          <%= label_tag :tracker_active_false, Spree.t(:say_no) %>
         </li>
       </ul>
     </div>

--- a/backend/app/views/spree/admin/users/_form.html.erb
+++ b/backend/app/views/spree/admin/users/_form.html.erb
@@ -12,7 +12,7 @@
         <% @roles.each do |role| %>
           <li>
             <%= check_box_tag 'user[spree_role_ids][]', role.id, @user.spree_roles.include?(role), :id => "user_spree_role_#{role.name}" %>
-            <%= label_tag role.name %>
+            <%= label_tag "user_spree_role_#{role.name}", role.name %>
           </li>
         <% end %>
       </ul>

--- a/backend/app/views/spree/admin/users/index.html.erb
+++ b/backend/app/views/spree/admin/users/index.html.erb
@@ -42,7 +42,7 @@
   <div class="box align-center" data-hook="admin_users_index_search">
     <%= search_form_for [:admin, @search], url: admin_users_url do |f| %>
       <div class="field">
-        <%= f.label Spree.t(:email) %> <br>
+        <%= f.label :email_cont, Spree.t(:email) %> <br>
         <%= f.text_field :email_cont, :class => 'fullwidth' %>
       </div>
       <div data-hook="admin_users_index_search_buttons">

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -525,7 +525,7 @@ en:
     choose_dashboard_locale: Choose Dashboard Locale
     choose_location: Choose location
     city: City
-    click_and_drag_on_the_products_to_sort_them: 'Click &amp; drag on the products to sort them.'
+    click_and_drag_on_the_products_to_sort_them: Click and drag on the products to sort them.
     clone: Clone
     close: Close
     close_all_adjustments: Close All Adjustments


### PR DESCRIPTION
This one should come as a treat :)

While I was searching for bad labels, I found that there was a button rendering `type="{:class=>&quot;fullwidth&quot;}"` inside of the HTML which is fixed in b55633a. Then we have another label fix commit.

I also discovered on the taxons page that it says `Click &amp; drag on the products to sort them.`  I have gone and removed the `&amp;` and now its just using the standard `and` word; see 0eff6e4. Also on the taxons page, there was no page title; added in d25c0a73d3fff57de0df18a501c540bf72e6d52f. The taxons page was also not highlighting the products tab in the menu as being active. I've gone and added the taxons to the products tab method in 1cad3de.

The adjust buttons weren't looking great on their own rows. Therefore, I went and made them look a little better in 42a263d. See screenshot:

![screen shot 2014-10-06 at 1 32 37 am](https://cloud.githubusercontent.com/assets/3117356/4523133/5c8fcf74-4d33-11e4-811c-62b714f16c16.png)

I don't see any reason to give them both their own rows. I wasn't able to use the `six columns` to fix this, so I went, floated them, and added a 50% width. Here's how they look now:

![screen shot 2014-10-06 at 1 35 58 am](https://cloud.githubusercontent.com/assets/3117356/4523166/d414dad0-4d33-11e4-8d7c-974fefa77c94.png)
