### PR TITLE
Fix example to contain expectation

### DIFF
--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -675,7 +675,7 @@ describe Spree::Shipment do
   context "#destroy" do
     it "destroys linked shipping_rates" do
       reflection = Spree::Shipment.reflect_on_association(:shipping_rates)
-      reflection.options[:dependent] = :destroy
+      expect(reflection.options[:dependent]).to be(:delete_all)
     end
   end
 


### PR DESCRIPTION
As discussed in https://github.com/spree/spree/commit/fa60f6e9c5fb4f0b43a1fc1556484ec96f0d6772#commitcomment-8038673 I'm submitting this PR to fix an example group that did not contained any expectation.

I personally prefer to spec the effect of hook like options such as `dependant: :destroy_all` instead to peek into implementation details. But this would be subject of another PR.

Please note that some unrelated specs in the core project fail before and with this patch:

```
Failures:

  1) exchanges:charge_unreturned_items there are unreturned items more than the config allowed days have passed there is no card from the previous order attempts to use the user's default card
     Failure/Error: expect { subject.invoke }.to change { Spree::Payment.count }.by(1)
     UnableToChargeForUnreturnedItems:
       R563390007 - ["No payment found"]
     # ./lib/tasks/exchanges.rake:62:in `block (2 levels) in <top (required)>'
     # /home/mbj/.gem/ruby/2.1.3/gems/rake-10.3.2/lib/rake/task.rb:240:in `call'
     # /home/mbj/.gem/ruby/2.1.3/gems/rake-10.3.2/lib/rake/task.rb:240:in `block in execute'
     # /home/mbj/.gem/ruby/2.1.3/gems/rake-10.3.2/lib/rake/task.rb:235:in `each'
     # /home/mbj/.gem/ruby/2.1.3/gems/rake-10.3.2/lib/rake/task.rb:235:in `execute'
     # /home/mbj/.gem/ruby/2.1.3/gems/rake-10.3.2/lib/rake/task.rb:179:in `block in invoke_with_call_chain'
     # /home/mbj/.gem/ruby/2.1.3/gems/rake-10.3.2/lib/rake/task.rb:172:in `invoke_with_call_chain'
     # /home/mbj/.gem/ruby/2.1.3/gems/rake-10.3.2/lib/rake/task.rb:165:in `invoke'
     # ./spec/lib/tasks/exchanges_spec.rb:104:in `block (6 levels) in <top (required)>'
     # ./spec/lib/tasks/exchanges_spec.rb:104:in `block (5 levels) in <top (required)>'
     # /home/mbj/.gem/ruby/2.1.3/gems/rspec-retry-0.3.0/lib/rspec/retry.rb:36:in `block (3 levels) in apply'
     # /home/mbj/.gem/ruby/2.1.3/gems/rspec-retry-0.3.0/lib/rspec/retry.rb:27:in `times'
     # /home/mbj/.gem/ruby/2.1.3/gems/rspec-retry-0.3.0/lib/rspec/retry.rb:27:in `block (2 levels) in apply'

```
