### PR TITLE
allow guests to use the payments api for their orders

### DIFF
--- a/api/app/controllers/spree/api/payments_controller.rb
+++ b/api/app/controllers/spree/api/payments_controller.rb
@@ -59,7 +59,7 @@ module Spree
 
         def find_order
           @order = Spree::Order.find_by(number: order_id)
-          authorize! :read, @order
+          authorize! :read, @order, order_token
         end
 
         def find_payment

--- a/api/spec/controllers/spree/api/payments_controller_spec.rb
+++ b/api/spec/controllers/spree/api/payments_controller_spec.rb
@@ -64,6 +64,11 @@ module Spree
           api_get :index, :order_id => order.to_param
           assert_unauthorized!
         end
+
+        it "can view the payments for an order given the order token" do
+          api_get :index, :order_id => order.to_param, :order_token => order.guest_token
+          json_response["payments"].first.should have_attributes(attributes)
+        end
       end
     end
 


### PR DESCRIPTION
Working on a ember checkout app and found that guest users can't access the payments api because it doesn't check use order_token to authorize against orders.  Test and fix included.
