### PR TITLE
Fix factories to generate unique SKUs

### DIFF
--- a/api/spec/controllers/spree/api/stock_items_controller_spec.rb
+++ b/api/spec/controllers/spree/api/stock_items_controller_spec.rb
@@ -55,7 +55,7 @@ module Spree
       it 'cannot list of stock items' do
         api_get :index, stock_location_id: stock_location.to_param
         json_response['stock_items'].first.should have_attributes(attributes)
-        json_response['stock_items'].first['variant']['sku'].should include 'ABC'
+        json_response['stock_items'].first['variant']['sku'].should include 'SKU'
       end
 
       it 'requires a stock_location_id to be passed as a parameter' do

--- a/core/lib/spree/testing_support/factories.rb
+++ b/core/lib/spree/testing_support/factories.rb
@@ -14,4 +14,6 @@ FactoryGirl.define do
   sequence(:random_string)      { Faker::Lorem.sentence }
   sequence(:random_description) { Faker::Lorem.paragraphs(1 + Kernel.rand(5)).join("\n") }
   sequence(:random_email)       { Faker::Internet.email }
+
+  sequence(:sku) { |n| "SKU-#{n}" }
 end

--- a/core/lib/spree/testing_support/factories/product_factory.rb
+++ b/core/lib/spree/testing_support/factories/product_factory.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
     description { generate(:random_description) }
     price 19.99
     cost_price 17.00
-    sku { "ABC-#{Kernel.rand(9999)}" }
+    sku { generate(:sku) }
     available_on { 1.year.ago }
     deleted_at nil
     shipping_category { |r| Spree::ShippingCategory.first || r.association(:shipping_category) }

--- a/core/lib/spree/testing_support/factories/variant_factory.rb
+++ b/core/lib/spree/testing_support/factories/variant_factory.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
   factory :base_variant, class: Spree::Variant do
     price 19.99
     cost_price 17.00
-    sku    { SecureRandom.hex }
+    sku    { generate(:sku)          }
     weight { generate(:random_float) }
     height { generate(:random_float) }
     width  { generate(:random_float) }

--- a/core/spec/models/spree/product_duplicator_spec.rb
+++ b/core/spec/models/spree/product_duplicator_spec.rb
@@ -72,7 +72,7 @@ module Spree
       end
 
       it "will set an unique sku" do
-        expect(new_product.sku).to include "COPY OF ABC"
+        expect(new_product.sku).to include "COPY OF SKU"
       end
 
       it "copied the properties" do


### PR DESCRIPTION
- Choosing random SKUs even from a high range can yield duplicates resulting in build failures.
- Kernel.rand(9999) was definitively never a good choice due the birthday paradoxon lets manifest a duplicate quite often
- Uses sequentially generated SKUs defined from a single shared and reusable generator.
- Please backport to at least 2-3-stable, should apply cleanly there.
