### PR TITLE
Refactor Promotion.applied scope to query faster

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -27,7 +27,10 @@ module Spree
     before_save :normalize_blank_values
 
     scope :coupons, ->{ where("#{table_name}.code IS NOT NULL") }
-    scope :applied, -> { joins(:orders).uniq }
+
+    order_join_table = reflect_on_association(:orders).join_table
+
+    scope :applied, -> { joins("INNER JOIN #{order_join_table} ON #{order_join_table}.promotion_id = #{table_name}.id").uniq }
 
     def self.advertised
       where(advertise: true)


### PR DESCRIPTION
Before the scope did two joins. Joining the join table and than the orders table. As joining the join table is sufficient to define the result set removing one layer of joins significantly speeds up the operation on large order tables.

In our case it reduced the time to render `/admin` with the order index from 4sec to around 2seconds. (Yeah big orders table).

Most likely this is also helpful for other bigger spree installations.
