### PR TITLE
Improve localization of stock_locations/_form

### DIFF
--- a/backend/app/views/spree/admin/stock_locations/_form.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/_form.html.erb
@@ -12,7 +12,7 @@
     </div>
     <div class="omega four columns">
       <%= f.field_container :active do %>
-        <label for="active"><%= Spree.t(:state) %></label>
+        <label for="active"><%= Spree.t(:status) %></label>
         <ul>
           <li>
             <%= f.label :active, Spree.t(:active) %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -487,6 +487,7 @@ en:
     back_to_users_list: Back To Users List
     back_to_zones_list: Back To Zones List
     backorderable: Backorderable
+    backorderable_default: Backorderable default
     backorders_allowed: backorders allowed
     balance_due: Balance Due
     base_amount: Base Amount
@@ -1081,6 +1082,7 @@ en:
         name: Taxon(s)
     promotions: Promotions
     promotion_uses: Promotion uses
+    propagate_all_variants: Propagate all variants
     properties: Properties
     property: Property
     prototype: Prototype


### PR DESCRIPTION
In many, if not all, locales, the term "state" is translated by its geographical meaning, not as "condition, situation". This creates confusion, because users see this geographical term as a label to "state" checkboxes (active, backorderable default, propagate all variants) on stock location form. I changed the checkboxes group label to Status.

I also noticed that terms "backorderable_default" and "propagate_all_variants" are not translated, so I added them to locale file.
