### PR TITLE
Make create endpoint require important params

### DIFF
--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -6,11 +6,11 @@ module Spree
       before_action :load_transfer_params, only: [:transfer_to_location, :transfer_to_shipment]
 
       def create
-        @order = Spree::Order.find_by!(number: params[:shipment][:order_id])
+        @order = Spree::Order.find_by!(number: params.fetch(:shipment).fetch(:order_id))
         authorize! :read, @order
         authorize! :create, Shipment
         quantity = params[:quantity].to_i
-        @shipment = @order.shipments.create(stock_location_id: params[:stock_location_id])
+        @shipment = @order.shipments.create(stock_location_id: params.fetch(:stock_location_id))
         @order.contents.add(variant, quantity, {shipment: @shipment})
 
         @shipment.save!


### PR DESCRIPTION
It's possible for the /api/shipments POST create to execute without checking all of the parameters passed. In my particular case, if the `stock_location_id` is not passed, then we see a RABL error when trying to render the stock location name.

https://github.com/spree/spree/blob/master/api/app/views/spree/api/shipments/show.v1.rabl#L5

```
{"exception":"undefined method `name' for nil:NilClass"}
```

This change leverages `params.fetch` to raise the appropriate ActionController::ParameterMissing error so that the API can tell the client it's missing key values, per the Spree API docs.
