### PR TITLE
Moving admin index route to bottom of routes file

### DIFF
--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,6 +1,4 @@
 Spree::Core::Engine.add_routes do
-  get '/admin', :to => 'admin/orders#index', :as => :admin
-
   namespace :admin do
     get '/search/users', :to => "search#users", :as => :search_users
 
@@ -172,4 +170,6 @@ Spree::Core::Engine.add_routes do
       end
     end
   end
+
+  get '/admin', :to => 'admin/orders#index', :as => :admin
 end


### PR DESCRIPTION
In our app we've overridden the admin homepage with a dashboard view.

However, because the admin root route was at the top of the routes file, the pagination on the orders page was broken in our app (i.e. links are `/admin?page=2` rather than `/admin/orders?page=2`).

Putting the route at the bottom of the file fixes this.
