### PR TITLE
Add ability to track admin canceler

### DIFF
--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -84,7 +84,7 @@ module Spree
       end
 
       def cancel
-        @order.cancel!
+        @order.canceled_by(try_spree_current_user)
         flash[:success] = Spree.t(:order_canceled)
         redirect_to :back
       end

--- a/backend/app/views/spree/admin/shared/_order_summary.html.erb
+++ b/backend/app/views/spree/admin/shared/_order_summary.html.erb
@@ -37,5 +37,12 @@
       <dt><%= Spree.t(:approved_at) %></dt>
       <dd><%= pretty_time(@order.approved_at) %></dd>
     <% end %>
+
+    <% if @order.canceled? && @order.canceler && @order.canceled_at %>
+      <dt><%= Spree.t(:canceler) %></dt>
+      <dd><%= @order.canceler.email %></td>
+      <dt><%= Spree.t(:canceled_at) %></dt>
+      <dd><%= pretty_time(@order.canceled_at) %></dd>
+    <% end %>
   </dl>
 </header>

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -38,7 +38,7 @@ describe Spree::Admin::OrdersController do
 
     context "#cancel" do
       it "cancels an order" do
-        expect(order).to receive(:cancel!)
+        expect(order).to receive(:canceled_by).with(controller.try_spree_current_user)
         spree_put :cancel, id: order.number
         expect(flash[:success]).to eq Spree.t(:order_canceled)
       end

--- a/backend/spec/features/admin/orders/cancelling_and_resuming_spec.rb
+++ b/backend/spec/features/admin/orders/cancelling_and_resuming_spec.rb
@@ -1,7 +1,14 @@
 require 'spec_helper'
 
 describe "Cancelling + Resuming" do
+
   stub_authorization!
+
+  let(:user) { double('id' => 123, 'has_spree_role?' => true) }
+
+  before do
+    allow_any_instance_of(Spree::Admin::BaseController).to receive(:try_spree_current_user).and_return(user)
+  end
 
   let(:order) do 
     order = create(:order)

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -28,10 +28,12 @@ module Spree
       belongs_to :user, class_name: Spree.user_class.to_s
       belongs_to :created_by, class_name: Spree.user_class.to_s
       belongs_to :approver, class_name: Spree.user_class.to_s
+      belongs_to :canceler, class_name: Spree.user_class.to_s
     else
       belongs_to :user
       belongs_to :created_by
       belongs_to :approver
+      belongs_to :canceler
     end
 
     belongs_to :bill_address, foreign_key: :bill_address_id, class_name: 'Spree::Address'
@@ -560,6 +562,16 @@ module Spree
 
     def is_risky?
       self.payments.risky.count > 0
+    end
+
+    def canceled_by(user)
+      self.transaction do
+        cancel!
+        self.update_columns(
+          canceler_id: user.id,
+          canceled_at: Time.now,
+        )
+      end
     end
 
     def approved_by(user)

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -500,6 +500,8 @@ en:
     calculator: Calculator
     calculator_settings_warning: If you are changing the calculator type, you must save first before you can edit the calculator settings
     cancel: cancel
+    canceler: Canceler
+    canceled_at: Canceled at
     cannot_create_payment_without_payment_methods: You cannot create a payment for an order without any payment methods defined.
     cannot_create_customer_returns: Cannot create customer returns as this order has no shipped units.
     cannot_create_returns: Cannot create returns as this order has no shipped units.

--- a/core/db/migrate/20141007230328_add_cancel_audit_fields_to_spree_orders.rb
+++ b/core/db/migrate/20141007230328_add_cancel_audit_fields_to_spree_orders.rb
@@ -1,0 +1,6 @@
+class AddCancelAuditFieldsToSpreeOrders < ActiveRecord::Migration
+  def change
+    add_column :spree_orders, :canceled_at, :datetime
+    add_column :spree_orders, :canceler_id, :integer
+  end
+end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -14,6 +14,37 @@ describe Spree::Order do
     Spree::LegacyUser.stub(:current => mock_model(Spree::LegacyUser, :id => 123))
   end
 
+  context "#canceled_by" do
+    let(:admin_user) { create :admin_user }
+    let(:order) { create :order }
+
+    before do
+      allow(order).to receive(:cancel!)
+    end
+
+    subject { order.canceled_by(admin_user) }
+
+    it 'should cancel the order' do
+      expect(order).to receive(:cancel!)
+      subject
+    end
+
+    it 'should save canceler_id' do
+      subject
+      expect(order.reload.canceler_id).to eq(admin_user.id)
+    end
+
+    it 'should save canceled_at' do
+      subject
+      expect(order.reload.canceled_at).to_not be_nil
+    end
+
+    it 'should have canceler' do
+      subject
+      expect(order.reload.canceler).to eq(admin_user)
+    end
+  end
+
   context "#create" do
     let(:order) { Spree::Order.create }
 


### PR DESCRIPTION
This PR adds the ability to track the admin user who canceled an order. The information is displayed in the order summary left side below the approver information. Nil checks were taken as a precaution (perhaps un-necessarily?) when the cancelation is done outside of admin and the order is canceled but no admin did it.

![screen shot 2014-10-08 at 10 36 10 am](https://cloud.githubusercontent.com/assets/134368/4560904/9963be30-4ef8-11e4-849f-f00a22485664.png)
