### PR TITLE
Fix broken rspec

### DIFF
--- a/api/spec/controllers/spree/api/payments_controller_spec.rb
+++ b/api/spec/controllers/spree/api/payments_controller_spec.rb
@@ -66,7 +66,7 @@ module Spree
         end
 
         it "can view the payments for an order given the order token" do
-          api_get :index, :order_id => order.to_param, :order_token => order.guest_token
+          api_get :index, :order_id => order.to_param, :order_token => order.token
           json_response["payments"].first.should have_attributes(attributes)
         end
       end


### PR DESCRIPTION
order#guest_token is not available in 2.2 because the changes https://github.com/spree/spree/commit/4687e608b49236c2850500b026a9fbbab37dc96c were only made to 2-3 and master.
