### PR TITLE
Remove 'disabled' from inputs in payments

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/payments/new.js
+++ b/backend/app/assets/javascripts/spree/backend/payments/new.js
@@ -14,7 +14,7 @@ $(document).ready(function() {
         $('.payment-methods').hide();
         $('.payment-methods input').prop('disabled', true);
         if (this.checked) {
-          $('#payment_method_' + this.value).prop('disabled', false);
+          $('#payment_method_' + this.value + ' input').prop('disabled', false);
           $('#payment_method_' + this.value).show();
         }
       }
@@ -23,11 +23,11 @@ $(document).ready(function() {
     $('.payment_methods_radios').each(
       function() {
         if (this.checked) {
-          $('#payment_method_' + this.value).prop('disabled', false);
+          $('#payment_method_' + this.value + ' input').prop('disabled', false);
           $('#payment_method_' + this.value).show();
         } else {
           $('#payment_method_' + this.value).hide();
-          $('#payment_method_' + this.value).prop('disabled', true);
+          $('#payment_method_' + this.value + ' input').prop('disabled', true);
         }
 
         if ($("#card_new" + this.value).is("*")) {


### PR DESCRIPTION
With the Aug 27 commit, 14cff5f361cb8010099d463a56da18d121c54efc, the inputs under `.payment-method` are being disabled on line 15 but never correctly undisabled. This fixes that issue. Looks like it is affecting most branches.
