### PR TITLE
Raise an exchange error if we can't ship all requested items

### DIFF
--- a/core/spec/models/spree/exchange_spec.rb
+++ b/core/spec/models/spree/exchange_spec.rb
@@ -45,6 +45,18 @@ module Spree
         expect(new_inventory_units.first.original_return_item).to eq return_item
         expect(new_inventory_units.first.line_item).to eq return_item.inventory_unit.line_item
       end
+
+      context "when it cannot create shipments for all items" do
+        before do
+          StockItem.where(:variant_id => return_item.exchange_variant_id).destroy_all
+        end
+
+        it 'raises an UnableToCreateShipments error' do
+          expect {
+            subject
+          }.to raise_error(Spree::Exchange::UnableToCreateShipments)
+        end
+      end
     end
 
     describe "#to_key" do # for dom_id


### PR DESCRIPTION
This will prevent an exchange from failing silently when, for example, a stale return authorization admin page gets submitted requesting an expedited exchange for an item for which there is no longer any stock available.
