### PR TITLE
update readme for rails 4 asset precompilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,17 +204,23 @@ your Ruby objects on each request.  The introduction of the asset pipeline in
 Rails 3.1 made default performance in development mode significantly worse. There
 are, however, a few tricks to speeding up performance in development mode.
 
+First, in your `config/development.rb`:
+
+```ruby
+config.assets.debug = false
+```
+
 You can precompile your assets as follows:
 
 ```shell
-bundle exec rake assets:precompile:nondigest
+RAILS_ENV=development bundle exec rake assets:precompile
 ```
 
 If you want to remove precompiled assets (recommended before you commit to Git
 and push your changes) use the following rake task:
 
 ```shell
-bundle exec rake assets:clean
+RAILS_ENV=development bundle exec rake assets:clean
 ```
 
 Use Dedicated Spree Devise Authentication


### PR DESCRIPTION
When running `bundle exec rake assets:precompile:nondigest` the user will get an unknown rake task error. This is because `assets:precompile:nondigest` was removed in Rails 4. You are now recommended to use `rake assets:precompile`.

`rake assets:precompile` will digest your assets, but it will not compile them for the development environment. Therefore, we add `RAILS_ENV=development` to the front of the script. To ensure performance is maintained, we also want to turn off `config.assets.debug`.
