### PR TITLE
Add active tabs

### DIFF
--- a/backend/app/models/spree/backend_configuration.rb
+++ b/backend/app/models/spree/backend_configuration.rb
@@ -1,5 +1,21 @@
 module Spree
   class BackendConfiguration < Preferences::Configuration
-    preference :locale, :string, :default => Rails.application.config.i18n.default_locale
+    preference :locale, :string, default: Rails.application.config.i18n.default_locale
+
+    ORDER_TABS         ||= [:orders, :payments, :creditcard_payments,
+                            :shipments, :credit_cards, :return_authorizations,
+                            :customer_returns, :adjustments, :customer_details]
+    PRODUCT_TABS       ||= [:products, :option_types, :properties, :prototypes,
+                            :variants, :product_properties, :taxonomies,
+                            :taxons]
+    REPORT_TABS        ||= [:reports]
+    CONFIGURATION_TABS ||= [:configurations, :general_settings, :tax_categories,
+                            :tax_rates, :zones, :countries, :states,
+                            :payment_methods, :shipping_methods,
+                            :shipping_categories, :stock_transfers,
+                            :stock_locations, :trackers, :refund_reasons,
+                            :reimbursement_types, :return_authorization_reasons]
+    PROMOTION_TABS     ||= [:promotions, :promotion_categories]
+    USER_TABS          ||= [:users]
   end
 end

--- a/backend/app/views/spree/admin/shared/_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_tabs.html.erb
@@ -1,16 +1,21 @@
 <% if can? :admin, Spree::Order %>
   <%= tab :orders, :payments, :creditcard_payments, :shipments, :credit_cards, :return_authorizations, :customer_returns, :icon => 'shopping-cart' %>
 <% end %>
+
 <% if can? :admin, Spree::Product %>
   <%= tab :products, :option_types, :properties, :prototypes, :variants, :product_properties, :taxonomies, :taxons, :icon => 'th-large' %>
 <% end %>
+
 <% if can? :admin, Spree::Admin::ReportsController %>
   <%= tab :reports, :icon => 'file'  %>
 <% end %>
 <%= tab :configurations, :general_settings, :tax_categories, :tax_rates, :zones, :countries, :states, :payment_methods, :shipping_methods, :shipping_categories, :stock_transfers, :stock_locations, :trackers, :label => 'configuration', :icon => 'wrench', :url => spree.edit_admin_general_settings_path %>
+
+
 <% if can? :admin, Spree::Promotion %>
   <%= tab(:promotions, :url => spree.admin_promotions_path, :icon => 'bullhorn') %>
 <% end %>
+
 <% if Spree.user_class && can?(:admin, Spree.user_class) %>
   <%= tab(:users, :url => spree.admin_users_path, :icon => 'user') %>
 <% end %>

--- a/backend/app/views/spree/admin/shared/_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_tabs.html.erb
@@ -1,5 +1,5 @@
 <% if can? :admin, Spree::Order %>
-  <%= tab :orders, :payments, :creditcard_payments, :shipments, :credit_cards, :return_authorizations, :customer_returns, icon: 'shopping-cart' %>
+  <%= tab :orders, :payments, :creditcard_payments, :shipments, :credit_cards, :return_authorizations, :customer_returns, :adjustments, :customer_details, icon: 'shopping-cart' %>
 <% end %>
 
 <% if can? :admin, Spree::Product %>
@@ -10,10 +10,10 @@
   <%= tab :reports, icon: 'file'  %>
 <% end %>
 
-<%= tab :configurations, :general_settings, :tax_categories, :tax_rates, :zones, :countries, :states, :payment_methods, :shipping_methods, :shipping_categories, :stock_transfers, :stock_locations, :trackers, label: 'configuration', icon: 'wrench', url: spree.edit_admin_general_settings_path %>
+<%= tab :configurations, :general_settings, :tax_categories, :tax_rates, :zones, :countries, :states, :payment_methods, :shipping_methods, :shipping_categories, :stock_transfers, :stock_locations, :trackers, :refund_reasons, :reimbursement_types, :return_authorization_reasons, label: 'configuration', icon: 'wrench', url: spree.edit_admin_general_settings_path %>
 
 <% if can? :admin, Spree::Promotion %>
-  <%= tab(:promotions, url: spree.admin_promotions_path, icon: 'bullhorn') %>
+  <%= tab(:promotions, :promotion_categories, url: spree.admin_promotions_path, icon: 'bullhorn') %>
 <% end %>
 
 <% if Spree.user_class && can?(:admin, Spree.user_class) %>

--- a/backend/app/views/spree/admin/shared/_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_tabs.html.erb
@@ -1,21 +1,21 @@
 <% if can? :admin, Spree::Order %>
-  <%= tab :orders, :payments, :creditcard_payments, :shipments, :credit_cards, :return_authorizations, :customer_returns, :icon => 'shopping-cart' %>
+  <%= tab :orders, :payments, :creditcard_payments, :shipments, :credit_cards, :return_authorizations, :customer_returns, icon: 'shopping-cart' %>
 <% end %>
 
 <% if can? :admin, Spree::Product %>
-  <%= tab :products, :option_types, :properties, :prototypes, :variants, :product_properties, :taxonomies, :taxons, :icon => 'th-large' %>
+  <%= tab :products, :option_types, :properties, :prototypes, :variants, :product_properties, :taxonomies, :taxons, icon: 'th-large' %>
 <% end %>
 
 <% if can? :admin, Spree::Admin::ReportsController %>
-  <%= tab :reports, :icon => 'file'  %>
+  <%= tab :reports, icon: 'file'  %>
 <% end %>
-<%= tab :configurations, :general_settings, :tax_categories, :tax_rates, :zones, :countries, :states, :payment_methods, :shipping_methods, :shipping_categories, :stock_transfers, :stock_locations, :trackers, :label => 'configuration', :icon => 'wrench', :url => spree.edit_admin_general_settings_path %>
 
+<%= tab :configurations, :general_settings, :tax_categories, :tax_rates, :zones, :countries, :states, :payment_methods, :shipping_methods, :shipping_categories, :stock_transfers, :stock_locations, :trackers, label: 'configuration', icon: 'wrench', url: spree.edit_admin_general_settings_path %>
 
 <% if can? :admin, Spree::Promotion %>
-  <%= tab(:promotions, :url => spree.admin_promotions_path, :icon => 'bullhorn') %>
+  <%= tab(:promotions, url: spree.admin_promotions_path, icon: 'bullhorn') %>
 <% end %>
 
 <% if Spree.user_class && can?(:admin, Spree.user_class) %>
-  <%= tab(:users, :url => spree.admin_users_path, :icon => 'user') %>
+  <%= tab(:users, url: spree.admin_users_path, icon: 'user') %>
 <% end %>

--- a/backend/app/views/spree/admin/shared/_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_tabs.html.erb
@@ -1,21 +1,21 @@
 <% if can? :admin, Spree::Order %>
-  <%= tab *ORDER_TABS, icon: 'shopping-cart' %>
+  <%= tab *Spree::BackendConfiguration::ORDER_TABS, icon: 'shopping-cart' %>
 <% end %>
 
 <% if can? :admin, Spree::Product %>
-  <%= tab *PRODUCT_TABS, icon: 'th-large' %>
+  <%= tab *Spree::BackendConfiguration::PRODUCT_TABS, icon: 'th-large' %>
 <% end %>
 
 <% if can? :admin, Spree::Admin::ReportsController %>
-  <%= tab *REPORT_TABS, icon: 'file'  %>
+  <%= tab *Spree::BackendConfiguration::REPORT_TABS, icon: 'file'  %>
 <% end %>
 
-<%= tab *CONFIGURATION_TABS, label: 'configuration', icon: 'wrench', url: spree.edit_admin_general_settings_path %>
+<%= tab *Spree::BackendConfiguration::CONFIGURATION_TABS, label: 'configuration', icon: 'wrench', url: spree.edit_admin_general_settings_path %>
 
 <% if can? :admin, Spree::Promotion %>
-  <%= tab *PROMOTION_TABS, url: spree.admin_promotions_path, icon: 'bullhorn' %>
+  <%= tab *Spree::BackendConfiguration::PROMOTION_TABS, url: spree.admin_promotions_path, icon: 'bullhorn' %>
 <% end %>
 
 <% if Spree.user_class && can?(:admin, Spree.user_class) %>
-  <%= tab *USER_TABS, url: spree.admin_users_path, icon: 'user' %>
+  <%= tab *Spree::BackendConfiguration::USER_TABS, url: spree.admin_users_path, icon: 'user' %>
 <% end %>

--- a/backend/app/views/spree/admin/shared/_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_tabs.html.erb
@@ -13,9 +13,9 @@
 <%= tab :configurations, :general_settings, :tax_categories, :tax_rates, :zones, :countries, :states, :payment_methods, :shipping_methods, :shipping_categories, :stock_transfers, :stock_locations, :trackers, :refund_reasons, :reimbursement_types, :return_authorization_reasons, label: 'configuration', icon: 'wrench', url: spree.edit_admin_general_settings_path %>
 
 <% if can? :admin, Spree::Promotion %>
-  <%= tab(:promotions, :promotion_categories, url: spree.admin_promotions_path, icon: 'bullhorn') %>
+  <%= tab :promotions, :promotion_categories, url: spree.admin_promotions_path, icon: 'bullhorn' %>
 <% end %>
 
 <% if Spree.user_class && can?(:admin, Spree.user_class) %>
-  <%= tab(:users, url: spree.admin_users_path, icon: 'user') %>
+  <%= tab :users, url: spree.admin_users_path, icon: 'user' %>
 <% end %>

--- a/backend/app/views/spree/admin/shared/_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_tabs.html.erb
@@ -1,21 +1,21 @@
 <% if can? :admin, Spree::Order %>
-  <%= tab :orders, :payments, :creditcard_payments, :shipments, :credit_cards, :return_authorizations, :customer_returns, :adjustments, :customer_details, icon: 'shopping-cart' %>
+  <%= tab *ORDER_TABS, icon: 'shopping-cart' %>
 <% end %>
 
 <% if can? :admin, Spree::Product %>
-  <%= tab :products, :option_types, :properties, :prototypes, :variants, :product_properties, :taxonomies, :taxons, icon: 'th-large' %>
+  <%= tab *PRODUCT_TABS, icon: 'th-large' %>
 <% end %>
 
 <% if can? :admin, Spree::Admin::ReportsController %>
-  <%= tab :reports, icon: 'file'  %>
+  <%= tab *REPORT_TABS, icon: 'file'  %>
 <% end %>
 
-<%= tab :configurations, :general_settings, :tax_categories, :tax_rates, :zones, :countries, :states, :payment_methods, :shipping_methods, :shipping_categories, :stock_transfers, :stock_locations, :trackers, :refund_reasons, :reimbursement_types, :return_authorization_reasons, label: 'configuration', icon: 'wrench', url: spree.edit_admin_general_settings_path %>
+<%= tab *CONFIGURATION_TABS, label: 'configuration', icon: 'wrench', url: spree.edit_admin_general_settings_path %>
 
 <% if can? :admin, Spree::Promotion %>
-  <%= tab :promotions, :promotion_categories, url: spree.admin_promotions_path, icon: 'bullhorn' %>
+  <%= tab *PROMOTION_TABS, url: spree.admin_promotions_path, icon: 'bullhorn' %>
 <% end %>
 
 <% if Spree.user_class && can?(:admin, Spree.user_class) %>
-  <%= tab :users, url: spree.admin_users_path, icon: 'user' %>
+  <%= tab *USER_TABS, url: spree.admin_users_path, icon: 'user' %>
 <% end %>

--- a/backend/app/views/spree/admin/taxonomies/new.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/new.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:new_taxonomy) %>

--- a/backend/app/views/spree/admin/taxonomies/new.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/new.html.erb
@@ -10,6 +10,8 @@
   </li>
 <% end %>
 
+<%= render 'spree/admin/shared/product_sub_menu' %>
+
 <%= form_for [:admin, @taxonomy] do |f| %>
 
   <%= render :partial => 'form', :locals => { :f => f } %>


### PR DESCRIPTION
This is a bug fix and a feature.

In here are two fixes. The first is that I added the missing active tabs for `:adjustments, :customer_details, :refund_reasons, :reimbursement_types, :return_authorization_reasons, and :promotion_categories`. The second fix was f587e65 where the product sub menu for new taxonomies was not loading. It loads now.

The feature is that the tabs were abstracted into the `Spree::BackendConfiguration` model. This means that you do not have to overwrite the tabs file to add new active tabs. If you're creating an extension, you can instead perform `CONFIGURATION_TABS << :active_shipping_settings` and the memoization of the constants will ensure that `CONFIGURATION_TABS` does not lose `:active_shipping_settings` as one of its values. Also, the memoization would prevent reassignment of constants in concurrent environments (i.e. when you're using Sidekiq or Puma).

If this PR is accepted, then we should add that to the spree extensions developer guide so that users are aware.
