### PR TITLE
Add inverse_of for more associations involved in cart processing

### DIFF
--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -2,7 +2,7 @@ module Spree
   class ReturnAuthorization < Spree::Base
     belongs_to :order, class_name: 'Spree::Order', inverse_of: :return_authorizations
 
-    has_many :inventory_units, dependent: :nullify
+    has_many :inventory_units, dependent: :nullify, inverse_of: :return_authorization
     belongs_to :stock_location
     before_create :generate_number
     before_save :force_positive_amount


### PR DESCRIPTION
The 2.3 specific inverse_of addition. Related to https://github.com/spree/spree/pull/5488.
