### PR TITLE
Adding an .editorconfig to Spree

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,28 +6,17 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-indent_size = 4
+indent_size = 2
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
-tab_width = 4
+tab_width = 2
 
 [**.rb]
-indent_size = 2
 max_line_length = 80
-tab_width = 2
-
-[**.html, **.html.erb]
-indent_size = 2
-tab_width = 4
 
 [**.js, **.coffee]
-indent_size = 4
 max_line_length = 120
-
-[**.css, **.scss, **.sass]
-indent_size = 2
-tab_width = 2
 
 [*.md]
 trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,33 @@
+# http://EditorConfig.org
+# https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+tab_width = 4
+
+[**.rb]
+indent_size = 2
+max_line_length = 80
+tab_width = 2
+
+[**.html, **.html.erb]
+indent_size = 2
+tab_width = 4
+
+[**.js, **.coffee]
+indent_size = 4
+max_line_length = 120
+
+[**.css, **.scss, **.sass]
+indent_size = 2
+tab_width = 2
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Adding a [.editorconfig](http://editorconfig.org/) will help keep stylistic consistency in the Spree codebase.

While most of us have these rules set up at an IDE level, many Open Source projects - [Ruby](https://github.com/ruby/ruby/blob/trunk/.editorconfig) included - have one defined. So why not Spree?

Developers without the plugin for their favourite editor can download it here - http://editorconfig.org/#download

I have compiled this editorconfig from ones I have used in the past on other projects, however I am open to refining it get a common consensus.

If this PR is accepted should the installation of the plugin be suggested in the syntax section of CONTRIBUTING.md? 
