### PR TITLE
remove extra dependent destroy

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -40,9 +40,8 @@ module Spree
     has_one :master,
       -> { where is_master: true },
       inverse_of: :product,
-      class_name: 'Spree::Variant',
-      dependent: :destroy
-
+      class_name: 'Spree::Variant'
+      
     has_many :variants,
       -> { where(is_master: false).order("#{::Spree::Variant.quoted_table_name}.position ASC") },
       inverse_of: :product,

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -103,7 +103,7 @@ describe Spree::Product do
         it "should set deleted_at value" do
           product.destroy
           product.deleted_at.should_not be_nil
-          product.master.deleted_at.should_not be_nil
+          product.master.reload.deleted_at.should_not be_nil
         end
       end
     end


### PR DESCRIPTION
Writing dependent : destroy in association of has_many variants_including_master will destroy all the variants associated with the product including the master when we destroy the product

There is no need to write it twice.
