### PR TITLE
Fix variant price diff upstream

### DIFF
--- a/core/app/helpers/spree/products_helper.rb
+++ b/core/app/helpers/spree/products_helper.rb
@@ -13,7 +13,7 @@ module Spree
     def variant_price_diff(variant)
       variant_amount = variant.amount_in(current_currency)
       product_amount = variant.product.amount_in(current_currency)
-      return if variant_amount == product_amount
+      return if variant_amount == product_amount || product_amount.nil?
       diff   = variant.amount_in(current_currency) - product_amount
       amount = Spree::Money.new(diff.abs, currency: current_currency).to_html
       label  = diff > 0 ? :add : :subtract

--- a/core/app/helpers/spree/products_helper.rb
+++ b/core/app/helpers/spree/products_helper.rb
@@ -11,14 +11,13 @@ module Spree
 
     # returns the formatted price for the specified variant as a difference from product price
     def variant_price_diff(variant)
-      diff = variant.amount_in(current_currency) - variant.product.amount_in(current_currency)
-      return nil if diff == 0
-      amount = Spree::Money.new(diff.abs, { currency: current_currency }).to_html
-      if diff > 0
-        "(#{Spree.t(:add)}: #{amount})".html_safe
-      else
-        "(#{Spree.t(:subtract)}: #{amount})".html_safe
-      end
+      variant_amount = variant.amount_in(current_currency)
+      product_amount = variant.product.amount_in(current_currency)
+      return if variant_amount == product_amount
+      diff   = variant.amount_in(current_currency) - product_amount
+      amount = Spree::Money.new(diff.abs, currency: current_currency).to_html
+      label  = diff > 0 ? :add : :subtract
+      "(#{Spree.t(label)}: #{amount})".html_safe
     end
 
     # returns the formatted full price for the variant, if at least one variant price differs from product price

--- a/core/spec/helpers/products_helper_spec.rb
+++ b/core/spec/helpers/products_helper_spec.rb
@@ -31,6 +31,12 @@ module Spree
         it { should be_nil }
       end
 
+      context "when the master has no price" do
+        let(:product_price) { nil }
+
+        it { should be_nil }
+      end
+
       context "when currency is default" do
         context "when variant is more than master" do
           let(:variant_price) { 15 }


### PR DESCRIPTION
This fixes a crash in case a products master variants price is `nil`.

[https://circleci.com/gh/MountainRoseHerbs/spree/296](Our CI passes this branch). With the addition of our CI setup that is excluded from this PR.
