### PR TITLE
Allow order admin search via sku

### DIFF
--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -45,9 +45,15 @@
           <%= label_tag :q_number_cont, Spree.t(:order_number, :number => '') %>
           <%= f.text_field :number_cont %>
         </div>
+
         <div class="field">
           <%= label_tag :q_email_cont, Spree.t(:email) %>
           <%= f.text_field :email_cont %>
+        </div>
+
+        <div class="field">
+          <%= label_tag :q_line_items_variant_id_in, Spree.t(:sku) %>
+          <%= f.select :line_items_variant_id_in, Spree::Variant.pluck(:sku, :id), {:include_blank => true}, :class => 'select2' %>
         </div>
       </div>
 


### PR DESCRIPTION
This PR allows admins to search for orders based on SKUs in the order. This is potentially a performance hit if there are thousands of SKUs when populating the select widget, but I imagine the same problem exists for the promotions filter drop down as well.

![screen shot 2014-10-16 at 4 22 49 pm](https://cloud.githubusercontent.com/assets/134368/4669962/b39b2286-5572-11e4-9d78-83a0fe183262.png)
