### PR TITLE
Add required attributes to required product admin form fields

### DIFF
--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -4,7 +4,7 @@
     <div data-hook="admin_product_form_name">
       <%= f.field_container :name do %>
         <%= f.label :name, raw(Spree.t(:name) + content_tag(:span, ' *', :class => 'required')) %>
-        <%= f.text_field :name, :class => 'fullwidth title' %>
+        <%= f.text_field :name, :class => 'fullwidth title', :required => true %>
         <%= f.error_message_on :name %>
       <% end %>
     </div>
@@ -12,7 +12,7 @@
     <div data-hook="admin_product_form_slug">
       <%= f.field_container :slug do %>
         <%= f.label :slug, raw(Spree.t(:slug) + content_tag(:span, ' *',  :class => "required")) %>
-        <%= f.text_field :slug, :class => 'fullwidth title' %>
+        <%= f.text_field :slug, :class => 'fullwidth title', :required => true %>
         <%= f.error_message_on :slug %>
       <% end %>
     </div>
@@ -30,7 +30,7 @@
     <div data-hook="admin_product_form_price">
     <%= f.field_container :price do %>
       <%= f.label :price, raw(Spree.t(:master_price) + content_tag(:span, ' *', :class => "required")) %>
-      <%= f.text_field :price, :value => number_to_currency(@product.price, :unit => '') %>
+      <%= f.text_field :price, :value => number_to_currency(@product.price, :unit => ''), :required => true %>
       <%= f.error_message_on :price %>
     <% end %>
     </div>
@@ -42,6 +42,7 @@
         <%= f.error_message_on :cost_price %>
       <% end %>
     </div>
+
     <div data-hook="admin_product_form_cost_currency" class="omega two columns">
       <%= f.field_container :cost_currency do %>
         <%= f.label :cost_currency, Spree.t(:cost_currency) %>

--- a/backend/app/views/spree/admin/products/new.html.erb
+++ b/backend/app/views/spree/admin/products/new.html.erb
@@ -10,7 +10,7 @@
 
     <%= f.field_container :name do %>
       <%= f.label :name, Spree.t(:name) %> <span class="required">*</span><br />
-      <%= f.text_field :name, :class => 'fullwidth title' %>
+      <%= f.text_field :name, :class => 'fullwidth title', :required => true %>
       <%= f.error_message_on :name %>
     <% end %>
 
@@ -35,7 +35,7 @@
       <div data-hook="new_product_price" class="four columns">
         <%= f.field_container :price do %>
           <%= f.label :price, Spree.t(:master_price) %> <span class="required">*</span><br />
-          <%= f.text_field :price, :value => number_to_currency(@product.price, :unit => ''), :class => 'fullwidth' %>
+          <%= f.text_field :price, :value => number_to_currency(@product.price, :unit => ''), :class => 'fullwidth', :required => true %>
           <%= f.error_message_on :price %>
         <% end %>
       </div>
@@ -54,7 +54,7 @@
       <div data-hook="new_product_shipping_category" class="alpha four columns">
         <%= f.field_container :shipping_category do %>
           <%= f.label :shipping_category_id, Spree.t(:shipping_categories) %><span class="required">*</span><br />
-          <%= f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2 fullwidth' }) %>
+          <%= f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2 fullwidth', :required => true }) %>
           <%= f.error_message_on :shipping_category_id %>
         <% end %>
       </div>

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -170,10 +170,13 @@ describe "Products" do
       end
 
       it "should keep option values selected if validation fails", :js => true do
+        fill_in "product_name", :with => "Baseball Cap"
+        fill_in "product_sku", :with => "B100"
+        fill_in "product_price", :with => "100"
         select "Size", :from => "Prototype"
         check "Large"
         click_button "Create"
-        page.should have_content("Name can't be blank")
+        page.should have_content("Shipping category can't be blank")
         field_labeled("Size").should be_checked
         field_labeled("Large").should be_checked
         field_labeled("Small").should_not be_checked
@@ -203,8 +206,11 @@ describe "Products" do
       end
 
       it "should show validation errors", :js => true do
+        fill_in "product_name", :with => "Baseball Cap"
+        fill_in "product_sku", :with => "B100"
+        fill_in "product_price", :with => "100"
         click_button "Create"
-        page.should have_content("Name can't be blank")
+        page.should have_content("Shipping category can't be blank")
       end
 
       context "using a locale with a different decimal format " do


### PR DESCRIPTION
- Adjust spec example inputs to allow submit with that restrictions.

These changes reflect domain model restrictions in the admin forms for a nicer user experience.
