### PR TITLE
Multi payment issues

### DIFF
--- a/core/app/models/spree/gateway/bogus.rb
+++ b/core/app/models/spree/gateway/bogus.rb
@@ -19,8 +19,9 @@ module Spree
 
     def create_profile(payment)
       # simulate the storage of credit card profile using remote service
-      success = VALID_CCS.include? payment.source.number
-      payment.source.update_attributes(:gateway_customer_profile_id => generate_profile_id(success))
+      if success = VALID_CCS.include?(payment.source.number)
+        payment.source.update_attributes(:gateway_customer_profile_id => generate_profile_id(success))
+      end
     end
 
     def authorize(money, credit_card, options = {})

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -166,7 +166,8 @@ module Spree
       end
 
       def create_payment_profile
-        return unless source.respond_to?(:has_payment_profile?) && !source.has_payment_profile?
+        return unless source.respond_to?(:has_payment_profile?) && !source.has_payment_profile? &&
+          state != 'invalid' && state != 'failed'
 
         payment_method.create_profile(self)
       rescue ActiveMerchant::ConnectionError => e
@@ -174,8 +175,10 @@ module Spree
       end
 
       def invalidate_old_payments
-        order.payments.with_state('checkout').where("id != ?", self.id).each do |payment|
-          payment.invalidate!
+        if state != 'invalid' and state != 'failed'
+          order.payments.with_state('checkout').where("id != ?", self.id).each do |payment|
+            payment.invalidate!
+          end
         end
       end
 


### PR DESCRIPTION
Found some strange behavior when retrying payments.  
1. A good payment after a bad one would try to generate a profile for the bad payment which would fail with an exception that would bubble up and make it seem like the good payment had failed.  
2. A bad payment after a good one would mark the good one as invalid. 

These tests/fixes should address them.
