### PR TITLE
Make some strings on admin product edit form translatable

### DIFF
--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -62,7 +62,7 @@
 
     <% if @product.has_variants? %>
       <div data-hook="admin_product_form_multiple_variants">
-        <%= f.label :skus, Spree.t(:sku).pluralize %>
+        <%= f.label :skus, Spree.t(:skus) %>
         <span class="info">
           <%= Spree.t(:info_product_has_multiple_skus, count: @product.variants.count) %>
           <ul class="text_list">
@@ -76,7 +76,7 @@
         </span>
         <div class="info-actions">
           <% if can?(:admin, Spree::Variant) %>
-            <%= link_to_with_icon 'th-large', 'Manage Variants',  admin_product_variants_url(@product) %>
+            <%= link_to_with_icon 'th-large', Spree.t(:manage_variants),  admin_product_variants_url(@product) %>
           <% end %>
         </div>
       </div>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -719,6 +719,7 @@ en:
     logout: Logout
     look_for_similar_items: Look for similar items
     make_refund: Make refund
+    manage_variants: Manage Variants
     master_price: Master Price
     match_choices:
       all: All
@@ -1073,6 +1074,7 @@ en:
     show_only_considered_risky: Only show risky orders
     show_rate_in_label: Show rate in label
     sku: SKU
+    skus: SKU's
     slug: Slug
     source: Source
     special_instructions: Special Instructions


### PR DESCRIPTION
You have this in `2-4-stable` and `master`, so I hope it'll make to `2-3-stable` too.
