### PR TITLE
stack level too deep in rails 4.1.6

### DIFF
--- a/backend/app/views/spree/admin/orders/_form.html.erb
+++ b/backend/app/views/spree/admin/orders/_form.html.erb
@@ -36,9 +36,8 @@
     var shipments = [];
 
     <% @order.shipments.each do |shipment| %>
-      shipments.push(<%== shipment.to_json(:root => false, :include => [:inventory_units, :stock_location]) %>);
+            shipments.push(<%== shipment.as_json(:root => false, :only => [:id, :tracking, :number, :state, :stock_location_id], :include => [:inventory_units, :stock_location]).to_json %>);
     <% end %>
-
     <%= render :partial => 'spree/admin/shared/update_order_state', :handlers => [:js] %>
   <% end -%>
 </div>

--- a/backend/app/views/spree/admin/orders/_line_items_edit_form.html.erb
+++ b/backend/app/views/spree/admin/orders/_line_items_edit_form.html.erb
@@ -32,7 +32,7 @@
       var shipments = [];
 
       <% @order.shipments.each do |shipment| %>
-          shipments.push(<%== shipment.to_json(:root => false, :include => [:inventory_units, :stock_location]) %>);
+            shipments.push(<%== shipment.as_json(:root => false, :only => [:id, :tracking, :number, :state, :stock_location_id], :include => [:inventory_units, :stock_location]).to_json %>);
       <% end %>
 
       <%= render :partial => 'spree/admin/shared/update_order_state', :handlers => [:js] %>


### PR DESCRIPTION
I am trying to upgrade spree to latest version and use rails 4.1.6.
However, when I go into admin order editing page. It gives me stack level too deep error.
I found out the problem is in admin order form javascript section.

```
<% @order.shipments.each do |shipment| %>
  shipments.push(<%== shipment.to_json(:root => false, :include => [:inventory_units, :stock_location]) %>);
<% end %>
```

After I remove these two lines, everything is fine.
I had searched in the whole spree backend, I didn't see any usage of the part of code.
I think it's just legacy code and can be removed safely.

Here is the error log:

```
[2014-10-19 10:31:20.705] [893fc6f0]
SystemStackError (stack level too deep):
  activerecord (4.1.6) lib/active_record/connection_adapters/abstract/connection_pool.rb:629
```
