### PR TITLE
remove extra dependent destroy from variants

### DIFF
--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -21,8 +21,7 @@ module Spree
 
     has_one :default_price,
       -> { where currency: Spree::Config[:currency] },
-      class_name: 'Spree::Price',
-      dependent: :destroy
+      class_name: 'Spree::Price', inverse_of: :variant
 
     delegate_belongs_to :default_price, :display_price, :display_amount, :price, :price=, :currency
 

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -52,29 +52,10 @@ describe Spree::Product do
         end
       end
 
-      context "when master default price is a new record" do
-        before do
-          @price = product.master.build_default_price
-          @price.price = 12
-        end
-
-        it "saves the master" do
-          product.master.should_receive(:save)
-          product.save
-        end
-
-        it "saves the default price" do
-          proc do
-            product.save
-          end.should change{ @price.new_record? }.from(true).to(false)
-        end
-
-      end
-
       context "when master default price changed" do
         before do
           master = product.master
-          master.default_price = create(:price, :variant => master)
+          master.default_price.price = 11
           master.save!
           product.master.default_price.price = 12
         end


### PR DESCRIPTION
Similar is the case with variants.If we are specifying dependent destroy in prices, no need of specifying it again for default price.

Also, for this the specs needs to be corrected.
I have removed a portion of specs as we cannot create another default price for the master variant
since variant has one default price.If we try to build another default price, it should set the previous default price's variant_id to nil as per rails.
But since we have kept a notnull constraint on variant_id in price model, so it should raise an exception.
So the corresponding specs needed to be removed.
