### PR TITLE
Fix images order on search results

### DIFF
--- a/core/lib/spree/core/search/base.rb
+++ b/core/lib/spree/core/search/base.rb
@@ -42,7 +42,7 @@ module Spree
 
           def add_eagerload_scopes scope
             if include_images
-              scope.eager_load({master: [:prices, :images]})
+              scope.includes({master: [:prices, :images]})
             else
               scope.includes(master: :prices)
             end

--- a/core/spec/lib/search/base_spec.rb
+++ b/core/spec/lib/search/base_spec.rb
@@ -17,16 +17,18 @@ describe Spree::Core::Search::Base do
   end
 
   context "when include_images is included in the initalization params" do
-    let(:params) {{ include_images: true }}
+    let(:params) {{ include_images: true, keyword: @product1.name }}
     subject { described_class.new(params).retrieve_products }
 
     before do
-      @product1.master.images.create(attachment_file_name: "Test")
+      @product1.master.images.create(attachment_file_name: "Test", position: 2)
+      @product1.master.images.create(attachment_file_name: "Test1", position: 1)
       @product1.reload
     end
 
-    it "eager loads the images" do
-      expect(subject.to_sql).to match /LEFT OUTER JOIN "spree_assets"/
+    it "returns images in correct order" do
+      expect(subject.first).to eq @product1
+      expect(subject.first.images).to eq @product1.master.images
     end
   end
 


### PR DESCRIPTION
It fixes regression that was introduced by https://github.com/spree/spree/pull/5352. When association is loaded using eager_load, it doesn't respect images ordering. Maybe its rails bug, and it should be fixed there or maybe its just better to use includes as its much better documented. Attached test is passing now, and failing on earlier version. 

To reproduce bug:
- Add new product with few photos
- Save
- Change photos order, move some photo to first position.

Photos will be returned in some default order, probably in the same order they were added.
