### PR TITLE
Add a combination of optimitistic and pesimistic locking to prevent dupl...

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -80,6 +80,7 @@ module Spree
 
     before_create :create_token
     before_create :link_by_email
+    before_create :set_version_uuid
     before_update :homogenize_line_item_currencies, if: :currency_changed?
 
     validates :email, presence: true, if: :require_email
@@ -637,10 +638,22 @@ module Spree
         payments.offset_payment.exists? # how old versions of spree stored refunds
     end
 
+    def update_version_uuid
+      update_column(:version_uuid, secure_random_uuid)
+    end
+
     private
 
     def link_by_email
       self.email = user.email if self.user
+    end
+
+    def set_version_uuid
+      self.version_uuid = secure_random_uuid
+    end
+
+    def secure_random_uuid
+      SecureRandom.uuid
     end
 
     # Determine if email is required (we don't want validation errors before we hit the checkout)

--- a/core/db/migrate/20141020105656_add_version_uuid_to_orders.rb
+++ b/core/db/migrate/20141020105656_add_version_uuid_to_orders.rb
@@ -1,0 +1,5 @@
+class AddVersionUuidToOrders < ActiveRecord::Migration
+  def change
+    add_column :spree_orders, :version_uuid, :uuid
+  end
+end

--- a/frontend/app/views/spree/checkout/edit.html.erb
+++ b/frontend/app/views/spree/checkout/edit.html.erb
@@ -13,6 +13,7 @@
           <p class="field" style='clear: both'>
             <%= form.label :email %><br />
             <%= form.text_field :email %>
+            <%= form.hidden_field :version_uuid %>
           </p>
         <% end %>
         <%= render @order.state, :form => form %>


### PR DESCRIPTION
...iscate requests causing random behaviour for the order checkout process

e.g. double shipments
