### PR TITLE
Adding validations for meta_* fields to match Database-constraints.

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -83,6 +83,8 @@ module Spree
     validates :shipping_category_id, presence: true
     validates :slug, length: { minimum: 3 }
     validates :slug, uniqueness: true
+    validates :meta_keywords, length: { maximum: 255 }
+    validates :meta_title, length: { maximum: 255 }
 
     before_validation :normalize_slug, on: :update
 

--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -11,6 +11,9 @@ module Spree
     before_create :set_permalink
 
     validates :name, presence: true
+    validates :meta_keywords, length: { maximum: 255 }
+    validates :meta_description, length: { maximum: 255 }
+    validates :meta_title, length: { maximum: 255 }
 
     after_touch :touch_ancestors_and_taxonomy
 


### PR DESCRIPTION
This fixes #5514. When using MySQL and inserting text into a string
field, the database will flunk if you commit over 255 characters.
This patch adds a few validations to make sure the various
meta_*-fields, using strings in the database, will contraint the lenght
with a maximum of 255 characters.
