### PR TITLE
Promotion tabs

### DIFF
--- a/backend/app/views/spree/admin/promotion_categories/edit.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/edit.html.erb
@@ -7,6 +7,7 @@
     <%= button_link_to Spree.t(:back_to_promotion_categories_list), spree.admin_promotion_categories_path, :icon => 'arrow-left' %>
   </li>
 <% end %>
+<%= render 'spree/admin/shared/promotion_sub_menu' %>
 
 <%= form_for @promotion_category, :url => object_url, :method => :put do |f| %>
   <fieldset class="no-border-top">

--- a/backend/app/views/spree/admin/promotion_categories/edit.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/edit.html.erb
@@ -14,4 +14,3 @@
     <%= render :partial => 'spree/admin/shared/edit_resource_links' %>
   </fieldset>
 <% end %>
-

--- a/backend/app/views/spree/admin/promotion_categories/edit.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/edit.html.erb
@@ -2,11 +2,6 @@
   <%= Spree.t(:editing_promotion_category) %>
 <% end %>
 
-<% content_for :page_actions do %>
-  <li>
-    <%= button_link_to Spree.t(:back_to_promotion_categories_list), spree.admin_promotion_categories_path, :icon => 'arrow-left' %>
-  </li>
-<% end %>
 <%= render 'spree/admin/shared/promotion_sub_menu' %>
 
 <%= form_for @promotion_category, :url => object_url, :method => :put do |f| %>

--- a/backend/app/views/spree/admin/promotion_categories/index.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/index.html.erb
@@ -6,9 +6,6 @@
   <li>
     <%= button_link_to Spree.t(:new_promotion_category), spree.new_admin_promotion_category_path, :icon => 'plus' %>
   </li>
-  <li>
-    <%= button_link_to Spree.t(:back_to_promotions_list), spree.admin_promotions_path, :icon => 'arrow-left' %>
-  </li>
 <% end %>
 
 <%= render 'spree/admin/shared/promotion_sub_menu' %>

--- a/backend/app/views/spree/admin/promotion_categories/index.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/index.html.erb
@@ -11,6 +11,8 @@
   </li>
 <% end %>
 
+<%= render 'spree/admin/shared/promotion_sub_menu' %>
+
 <table>
   <colgroup>
     <col style="width: 85%">

--- a/backend/app/views/spree/admin/promotion_categories/new.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/new.html.erb
@@ -7,6 +7,7 @@
     <%= button_link_to Spree.t(:back_to_promotion_categories_list), spree.admin_promotion_categories_path, :icon => 'arrow-left' %>
   </li>
 <% end %>
+<%= render 'spree/admin/shared/promotion_sub_menu' %>
 
 <%= form_for :promotion_category, :url => collection_url do |f| %>
   <fieldset class="no-border-top">

--- a/backend/app/views/spree/admin/promotion_categories/new.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/new.html.erb
@@ -2,11 +2,6 @@
   <%= Spree.t(:new_promotion_category) %>
 <% end %>
 
-<% content_for :page_actions do %>
-  <li>
-    <%= button_link_to Spree.t(:back_to_promotion_categories_list), spree.admin_promotion_categories_path, :icon => 'arrow-left' %>
-  </li>
-<% end %>
 <%= render 'spree/admin/shared/promotion_sub_menu' %>
 
 <%= form_for :promotion_category, :url => collection_url do |f| %>

--- a/backend/app/views/spree/admin/promotions/edit.html.erb
+++ b/backend/app/views/spree/admin/promotions/edit.html.erb
@@ -7,6 +7,7 @@
     <%= button_link_to Spree.t(:back_to_promotions_list), admin_promotions_path, :icon => 'arrow-left' %>
   </li>
 <% end %>
+<%= render 'spree/admin/shared/promotion_sub_menu' %>
 
 <%= form_for @promotion, :url => object_url, :method => :put do |f| %>
   <fieldset class="no-border-top">

--- a/backend/app/views/spree/admin/promotions/edit.html.erb
+++ b/backend/app/views/spree/admin/promotions/edit.html.erb
@@ -2,11 +2,6 @@
   <%= Spree.t(:editing_promotion) %>
 <% end %>
 
-<% content_for :page_actions do %>
-  <li>
-    <%= button_link_to Spree.t(:back_to_promotions_list), admin_promotions_path, :icon => 'arrow-left' %>
-  </li>
-<% end %>
 <%= render 'spree/admin/shared/promotion_sub_menu' %>
 
 <%= form_for @promotion, :url => object_url, :method => :put do |f| %>

--- a/backend/app/views/spree/admin/promotions/index.html.erb
+++ b/backend/app/views/spree/admin/promotions/index.html.erb
@@ -11,6 +11,8 @@
   </li>
 <% end %>
 
+<%= render 'spree/admin/shared/promotion_sub_menu' %>
+
 <% content_for :table_filter_title do %>
   <%= Spree.t(:search) %>
 <% end %>

--- a/backend/app/views/spree/admin/promotions/index.html.erb
+++ b/backend/app/views/spree/admin/promotions/index.html.erb
@@ -4,9 +4,6 @@
 
 <% content_for :page_actions do %>
   <li>
-    <%= button_link_to Spree.t(:manage_promotion_categories), spree.admin_promotion_categories_path, :icon => 'bars' %>
-  </li>
-  <li>
     <%= button_link_to Spree.t(:new_promotion), spree.new_admin_promotion_path, :icon => 'plus' %>
   </li>
 <% end %>

--- a/backend/app/views/spree/admin/promotions/new.html.erb
+++ b/backend/app/views/spree/admin/promotions/new.html.erb
@@ -7,6 +7,7 @@
     <%= button_link_to Spree.t(:back_to_promotions_list), spree.admin_promotions_path, :icon => 'arrow-left' %>
   </li>
 <% end %>
+<%= render 'spree/admin/shared/promotion_sub_menu' %>
 
 <%= form_for :promotion, :url => collection_url do |f| %>
   <fieldset class="no-border-top">

--- a/backend/app/views/spree/admin/promotions/new.html.erb
+++ b/backend/app/views/spree/admin/promotions/new.html.erb
@@ -2,11 +2,6 @@
   <%= Spree.t(:new_promotion) %>
 <% end %>
 
-<% content_for :page_actions do %>
-  <li>
-    <%= button_link_to Spree.t(:back_to_promotions_list), spree.admin_promotions_path, :icon => 'arrow-left' %>
-  </li>
-<% end %>
 <%= render 'spree/admin/shared/promotion_sub_menu' %>
 
 <%= form_for :promotion, :url => collection_url do |f| %>

--- a/backend/app/views/spree/admin/shared/_promotion_sub_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_promotion_sub_menu.html.erb
@@ -1,0 +1,6 @@
+<% content_for :sub_menu do %>
+  <ul id="sub_nav" data-hook="admin_promotion_sub_tabs" class="inline-menu">
+    <%= tab :promotions %>
+    <%= tab :promotion_categories %>
+  </ul>
+<% end %>


### PR DESCRIPTION
Merci @gmacdougall for your work on promotion categories. I noticed it was doing a lot of managing for the "management of promotion categories" in the page actions. The buttons was getting kinda confusing.

I decided that I would take the promotions and give it a sub menu to compensate for this.

This was the before:

![screen shot 2014-10-22 at 2 43 10 pm](https://cloud.githubusercontent.com/assets/3117356/4744897/74036dba-5a34-11e4-92dc-771a26a3faa9.png)

This is the after:

![screen shot 2014-10-22 at 2 40 23 pm](https://cloud.githubusercontent.com/assets/3117356/4744891/64ba0cd8-5a34-11e4-8df2-e98f18b76ae2.png)

I might also be doing another PR for setting up the new page to load on the same page as the index. This is functionality that is present on the option types, properties, prototypes, and probably a few other pages. Thinking we could keep this consistent and add it for promotions and promotion categories later on.
