### PR TITLE
include option values when loading option values from option types

### DIFF
--- a/api/app/controllers/spree/api/option_types_controller.rb
+++ b/api/app/controllers/spree/api/option_types_controller.rb
@@ -3,9 +3,9 @@ module Spree
     class OptionTypesController < Spree::Api::BaseController
       def index
         if params[:ids]
-          @option_types = Spree::OptionType.accessible_by(current_ability, :read).where(:id => params[:ids].split(','))
+          @option_types = Spree::OptionType.includes(:option_values).accessible_by(current_ability, :read).where(id: params[:ids].split(','))
         else
-          @option_types = Spree::OptionType.accessible_by(current_ability, :read).load.ransack(params[:q]).result
+          @option_types = Spree::OptionType.includes(:option_values).accessible_by(current_ability, :read).load.ransack(params[:q]).result
         end
         respond_with(@option_types)
       end


### PR DESCRIPTION
Noticed an n+1 when visiting the product page. It would do an API call to receive the option values.

Before:

``` ruby
Started GET "/api/option_types?ids=6,1,3,5,7,8,10,4" for 127.0.0.1 at 2014-10-22 16:44:41 -0700
Processing by Spree::Api::OptionTypesController#index as JSON
  Parameters: {"ids"=>"6,1,3,5,7,8,10,4"}
  Spree::User Load (0.9ms)  SELECT  "spree_users".* FROM "spree_users"  WHERE "spree_users"."deleted_at" IS NULL AND "spree_users"."id" = 1  ORDER BY "spree_users"."id" ASC LIMIT 1
   (0.6ms)  SELECT "spree_roles"."name" FROM "spree_roles" INNER JOIN "spree_roles_users" ON "spree_roles"."id" = "spree_roles_users"."role_id" WHERE "spree_roles_users"."user_id" = $1  [["user_id", 1]]
   (0.3ms)  SELECT COUNT(*) FROM "spree_roles" INNER JOIN "spree_roles_users" ON "spree_roles"."id" = "spree_roles_users"."role_id" WHERE "spree_roles_users"."user_id" = $1 AND "spree_roles"."name" = 'admin'  [["user_id", 1]]
  CACHE (0.0ms)  SELECT COUNT(*) FROM "spree_roles" INNER JOIN "spree_roles_users" ON "spree_roles"."id" = "spree_roles_users"."role_id" WHERE "spree_roles_users"."user_id" = $1 AND "spree_roles"."name" = 'admin'  [["user_id", 1]]
  Spree::OptionType Load (0.5ms)  SELECT "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" IN (6, 1, 3, 5, 7, 8, 10, 4)  ORDER BY spree_option_types.position
  Spree::OptionValue Load (0.5ms)  SELECT "spree_option_values".* FROM "spree_option_values"  WHERE "spree_option_values"."option_type_id" = $1  ORDER BY "spree_option_values"."position" ASC  [["option_type_id", 6]]
  Spree::OptionValue Load (0.3ms)  SELECT "spree_option_values".* FROM "spree_option_values"  WHERE "spree_option_values"."option_type_id" = $1  ORDER BY "spree_option_values"."position" ASC  [["option_type_id", 1]]
  Spree::OptionValue Load (0.4ms)  SELECT "spree_option_values".* FROM "spree_option_values"  WHERE "spree_option_values"."option_type_id" = $1  ORDER BY "spree_option_values"."position" ASC  [["option_type_id", 3]]
  Spree::OptionValue Load (0.4ms)  SELECT "spree_option_values".* FROM "spree_option_values"  WHERE "spree_option_values"."option_type_id" = $1  ORDER BY "spree_option_values"."position" ASC  [["option_type_id", 5]]
  Spree::OptionValue Load (0.5ms)  SELECT "spree_option_values".* FROM "spree_option_values"  WHERE "spree_option_values"."option_type_id" = $1  ORDER BY "spree_option_values"."position" ASC  [["option_type_id", 7]]
  Spree::OptionValue Load (0.4ms)  SELECT "spree_option_values".* FROM "spree_option_values"  WHERE "spree_option_values"."option_type_id" = $1  ORDER BY "spree_option_values"."position" ASC  [["option_type_id", 8]]
  Spree::OptionValue Load (0.3ms)  SELECT "spree_option_values".* FROM "spree_option_values"  WHERE "spree_option_values"."option_type_id" = $1  ORDER BY "spree_option_values"."position" ASC  [["option_type_id", 10]]
  Spree::OptionValue Load (0.4ms)  SELECT "spree_option_values".* FROM "spree_option_values"  WHERE "spree_option_values"."option_type_id" = $1  ORDER BY "spree_option_values"."position" ASC  [["option_type_id", 4]]
  Rendered /Users/benmorgan/.rvm/gems/ruby-2.1.2/bundler/gems/spree-29c7c625696e/api/app/views/spree/api/option_types/index.v1.rabl (627.6ms)
Completed 200 OK in 946ms (Views: 919.9ms | ActiveRecord: 7.1ms)
```

After:

``` ruby
Started GET "/api/option_types?ids=6,1,3,5,7,8,10,4" for 127.0.0.1 at 2014-10-22 16:48:25 -0700
Processing by Spree::Api::OptionTypesController#index as JSON
  Parameters: {"ids"=>"6,1,3,5,7,8,10,4"}
  Spree::User Load (0.8ms)  SELECT  "spree_users".* FROM "spree_users"  WHERE "spree_users"."deleted_at" IS NULL AND "spree_users"."id" = 1  ORDER BY "spree_users"."id" ASC LIMIT 1
   (0.7ms)  SELECT "spree_roles"."name" FROM "spree_roles" INNER JOIN "spree_roles_users" ON "spree_roles"."id" = "spree_roles_users"."role_id" WHERE "spree_roles_users"."user_id" = $1  [["user_id", 1]]
   (0.5ms)  SELECT COUNT(*) FROM "spree_roles" INNER JOIN "spree_roles_users" ON "spree_roles"."id" = "spree_roles_users"."role_id" WHERE "spree_roles_users"."user_id" = $1 AND "spree_roles"."name" = 'admin'  [["user_id", 1]]
  CACHE (0.0ms)  SELECT COUNT(*) FROM "spree_roles" INNER JOIN "spree_roles_users" ON "spree_roles"."id" = "spree_roles_users"."role_id" WHERE "spree_roles_users"."user_id" = $1 AND "spree_roles"."name" = 'admin'  [["user_id", 1]]
  Spree::OptionType Load (0.6ms)  SELECT "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" IN (6, 1, 3, 5, 7, 8, 10, 4)  ORDER BY spree_option_types.position
  Spree::OptionValue Load (0.7ms)  SELECT "spree_option_values".* FROM "spree_option_values"  WHERE "spree_option_values"."option_type_id" IN (6, 1, 3, 5, 7, 8, 10, 4)  ORDER BY "spree_option_values"."position" ASC
  Rendered /Users/benmorgan/.rvm/gems/ruby-2.1.2/bundler/gems/spree-29c7c625696e/api/app/views/spree/api/option_types/index.v1.rabl (524.9ms)
Completed 200 OK in 829ms (Views: 800.6ms | ActiveRecord: 6.4ms)
```
