### PR TITLE
add counter cache from variants to stock items

### DIFF
--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -3,7 +3,7 @@ module Spree
     acts_as_paranoid
 
     belongs_to :stock_location, class_name: 'Spree::StockLocation', inverse_of: :stock_items
-    belongs_to :variant, class_name: 'Spree::Variant', inverse_of: :stock_items
+    belongs_to :variant, class_name: 'Spree::Variant', inverse_of: :stock_items, counter_cache: true
     has_many :stock_movements, inverse_of: :stock_item
 
     validates_presence_of :stock_location, :variant

--- a/core/db/migrate/20141023005240_add_counter_cache_from_spree_variants_to_spree_stock_items.rb
+++ b/core/db/migrate/20141023005240_add_counter_cache_from_spree_variants_to_spree_stock_items.rb
@@ -1,19 +1,10 @@
 class AddCounterCacheFromSpreeVariantsToSpreeStockItems < ActiveRecord::Migration
   def up
-    # Setup the column.
-    add_column :spree_variants, :stock_items_count, :integer
+    add_column :spree_variants, :stock_items_count, :integer, default: 0, null: false
 
-    # Reset the cached counters for stock items of already
-    # existing records.
     Spree::Variant.find_each do |variant|
       Spree::Variant.reset_counters(variant.id, :stock_items)
     end
-
-    # We are doing a defualt and null here because in some databases (pg)
-    # you will get an error for having a null value on an existing record.
-    # The known hack around this is to perform an add column and then a
-    # change column.
-    change_column :spree_variants, :stock_items_count, :integer, default: 0, null: false
   end
 
   def down

--- a/core/db/migrate/20141023005240_add_counter_cache_from_spree_variants_to_spree_stock_items.rb
+++ b/core/db/migrate/20141023005240_add_counter_cache_from_spree_variants_to_spree_stock_items.rb
@@ -1,0 +1,25 @@
+class AddCounterCacheFromSpreeVariantsToSpreeStockItems < ActiveRecord::Migration
+  def up
+    # Setup the column.
+    add_column :spree_variants, :stock_items_count, :integer
+
+    # Reset all of the cached information.
+    Spree::Variant.reset_column_information
+
+    # Reset the cached counters for stock items of already
+    # existing records.
+    Spree::Variant.find_each do |variant|
+      Spree::Variant.reset_counters(variant.id, :stock_items)
+    end
+
+    # We are doing a defualt and null here because in some databases (pg)
+    # you will get an error for having a null value on an existing record.
+    # The known hack around this is to perform an add column and then a
+    # change column.
+    change_column :spree_variants, :stock_items_count, :integer, default: 0, null: false
+  end
+
+  def down
+    remove_column :spree_variants, :stock_items_count
+  end
+end

--- a/core/db/migrate/20141023005240_add_counter_cache_from_spree_variants_to_spree_stock_items.rb
+++ b/core/db/migrate/20141023005240_add_counter_cache_from_spree_variants_to_spree_stock_items.rb
@@ -3,9 +3,6 @@ class AddCounterCacheFromSpreeVariantsToSpreeStockItems < ActiveRecord::Migratio
     # Setup the column.
     add_column :spree_variants, :stock_items_count, :integer
 
-    # Reset all of the cached information.
-    Spree::Variant.reset_column_information
-
     # Reset the cached counters for stock items of already
     # existing records.
     Spree::Variant.find_each do |variant|


### PR DESCRIPTION
This adds a counter cache for stock items.

While running bullet and deleting some option types, it recommended me to setup a counter cache for stock items. I decided to do so. This was the result of that effort.
