### PR TITLE
Refactor the duplicate request prevention code ( order.with_lock )

### DIFF
--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -7,7 +7,7 @@ module Spree
     ssl_required
 
     before_action :load_order_with_lock
-    before_filter :ensure_valid_order_version, only: [:update]
+    before_filter :ensure_valid_state_lock_version, only: [:update]
     before_filter :set_state_if_present
 
     before_action :ensure_order_not_completed
@@ -76,7 +76,7 @@ module Spree
         redirect_to spree.cart_path and return unless @order
       end
 
-      def ensure_valid_state
+      def ensure_valid_state_lock_version
         if params[:order] && params[:order][:state_lock_version]
           @order.with_lock do
             unless @order.state_lock_version == params[:order][:state_lock_version].to_i

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -7,6 +7,8 @@ module Spree
     ssl_required
 
     before_action :load_order_with_lock
+    before_filter :ensure_valid_order_version, only: [:update]
+    before_filter :set_state_if_present
 
     before_action :ensure_order_not_completed
     before_action :ensure_checkout_allowed
@@ -72,9 +74,11 @@ module Spree
       def load_order_with_lock
         @order = current_order(lock: true)
         redirect_to spree.cart_path and return unless @order
+      end
 
-        @order.with_lock do
-          if params[:order] && params[:order][:state_lock_version]
+      def ensure_valid_state
+        if params[:order] && params[:order][:state_lock_version]
+          @order.with_lock do
             unless @order.state_lock_version == params[:order][:state_lock_version].to_i
               flash[:error] = Spree.t(:order_already_updated)
               redirect_to checkout_state_path(@order.state) and return
@@ -82,6 +86,9 @@ module Spree
             @order.increment!(:state_lock_version)
           end
         end
+      end
+
+      def set_state_if_present
 
         if params[:state]
           redirect_to checkout_state_path(@order.state) if @order.can_go_to_state?(params[:state]) && !skip_state_validation?

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -237,6 +237,11 @@ describe Spree::CheckoutController do
         order.update_columns(state_lock_version: 2, state: "address")
       end
 
+      it "order should receieve ensure_valid_order_version callback" do
+        expect_any_instance_of(described_class).to receive(:ensure_valid_state_lock_version)
+        spree_post :update, post_params
+      end
+
       it "order should receieve with_lock message" do
         expect(order).to receive(:with_lock)
         spree_post :update, post_params

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -223,19 +223,27 @@ describe Spree::CheckoutController do
 
     # Regression test for #4190
     context "state_lock_version incorrect" do
+      let(:post_params) {
+        {
+          state: "address",
+          order: {
+            bill_address_attributes: order.bill_address.attributes.except("created_at", "updated_at"),
+            state_lock_version: 1,
+            use_billing: true
+          }
+        }
+      }
       before do
         order.update_columns(state_lock_version: 2, state: "address")
       end
 
+      it "order should receieve with_lock message" do
+        expect(order).to receive(:with_lock)
+        spree_post :update, post_params
+      end
+
       it "redirects back to current state" do
-        spree_post :update, {
-            state: "address",
-            order: {
-              bill_address_attributes: order.bill_address.attributes.except("created_at", "updated_at"),
-              state_lock_version: 1,
-              use_billing: true
-            }
-        }
+        spree_post :update, post_params
         expect(response).to redirect_to spree.checkout_state_path('address')
         expect(flash[:error]).to eq "The order has already been updated."
       end


### PR DESCRIPTION
- break the lock code out into a seperate callback
- ensure it only operates on an update
- add specs
