### PR TITLE
Stock locations edit page design fix

### DIFF
--- a/backend/app/views/spree/admin/stock_locations/_form.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/_form.html.erb
@@ -1,94 +1,90 @@
 <div data-hook="admin_stock_locations_form_fields" class="row">
-  <div class="row">
-    <div class="alpha twelve columns">
-      <%= f.field_container :name do %>
-        <%= f.label :name, Spree.t(:name) %> <span class="required">*</span><br />
-        <%= f.text_field :name, :class => 'fullwidth' %>
-      <% end %><br>
-      <%= f.field_container :admin_name do %>
-        <%= f.label :admin_name, Spree.t(:internal_name) %>
-        <%= f.text_field :admin_name, :class => 'fullwidth', :label => false %>
-      <% end %>
-    </div>
-    <div class="omega four columns">
-      <%= f.field_container :active do %>
-        <label for="active"><%= Spree.t(:status) %></label>
-        <ul>
-          <li>
-            <%= f.label :active, Spree.t(:active) %>
-            <%= f.check_box :active %>
-          </li>
-          <li>
-            <%= f.label :default, Spree.t(:default) %>
-            <%= f.check_box :default %>
-          </li>
-          <li>
-            <%= f.label :backorderable_default, Spree.t(:backorderable_default) %>
-            <%= f.check_box :backorderable_default %>
-          </li>
-          <li>
-            <%= f.label :propagate_all_variants, Spree.t(:propagate_all_variants) %>
-            <%= f.check_box :propagate_all_variants %>
-          </li>
-        </ul>
-      <% end %>
+  <div class="alpha nine columns">
+    <%= f.field_container :name do %>
+      <%= f.label :name, Spree.t(:name) %> <span class="required">*</span><br />
+      <%= f.text_field :name, :class => 'fullwidth', required: true %>
+    <% end %>
+    <%= f.field_container :admin_name do %>
+      <%= f.label :admin_name, Spree.t(:internal_name) %>
+      <%= f.text_field :admin_name, :class => 'fullwidth', :label => false %>
+    <% end %>
+  </div>
+
+  <div class="omega three columns">
+    <%= f.field_container :active do %>
+      <label for="active"><%= Spree.t(:status) %></label>
+      <ul>
+        <li class="fullwidth">
+          <%= f.check_box :active %>
+          <%= f.label :active, Spree.t(:active) %>
+        </li>
+        <li class="fullwidth">
+          <%= f.check_box :default %>
+          <%= f.label :default, Spree.t(:default) %>
+        </li>
+        <li class="fullwidth">
+          <%= f.check_box :backorderable_default %>
+          <%= f.label :backorderable_default, Spree.t(:backorderable_default) %>
+        </li>
+        <li class="fullwidth">
+          <%= f.check_box :propagate_all_variants %>
+          <%= f.label :propagate_all_variants, Spree.t(:propagate_all_variants) %>
+        </li>
+      </ul>
+    <% end %>
+  </div>
+
+  <div class="alpha six columns">
+    <div class="field ">
+      <%= f.label :address1, Spree.t(:street_address) %>
+      <%= f.text_field :address1, :class => 'fullwidth' %>
     </div>
   </div>
 
-  <div class="row">
-    <div class="alpha four columns">
-      <div class="field ">
-        <%= f.label :address1, Spree.t(:street_address) %>
-        <%= f.text_field :address1, :class => 'fullwidth' %>
-      </div>
-    </div>
-
-    <div class="four columns">
-      <div class="field ">
-        <%= f.label :address2, Spree.t(:street_address_2) %>
-        <%= f.text_field :address2, :class => 'fullwidth' %>
-      </div>
-    </div>
-    <div class="four columns">
-      <div class="field ">
-        <%= f.label :city, Spree.t(:city) %>
-        <%= f.text_field :city, :class => 'fullwidth' %>
-      </div>
-    </div>
-
-    <div class="omega four columns">
-      <div class="field ">
-        <%= f.label :zipcode, Spree.t(:zip) %>
-        <%= f.text_field :zipcode, :class => 'fullwidth' %>
-      </div>
+  <div class="omega six columns">
+    <div class="field ">
+      <%= f.label :city, Spree.t(:city) %>
+      <%= f.text_field :city, :class => 'fullwidth' %>
     </div>
   </div>
 
-  <div class="row">
-    <div class="alpha eight columns">
-      <div class="field ">
-        <%= f.label :country_id, Spree.t(:country) %>
-        <span id="country"><%= f.collection_select :country_id, available_countries, :id, :name, {}, {:class => 'select2 fullwidth'} %></span>
-      </div>
+  <div class="alpha six columns">
+    <div class="field ">
+      <%= f.label :address2, Spree.t(:street_address_2) %>
+      <%= f.text_field :address2, :class => 'fullwidth' %>
     </div>
+  </div>
 
-    <div class="four columns">
-      <div class="field ">
-        <% if f.object.country %>
-          <%= f.label :state_id, Spree.t(:state) %>
-          <span id="state" class="region">
-            <%= f.text_field :state_name, :style => "display: #{f.object.country.states.empty? ? 'block' : 'none' };", :disabled => !f.object.country.states.empty?, :class => 'fullwidth state_name' %>
-            <%= f.collection_select :state_id, f.object.country.states.sort, :id, :name, {:include_blank => true}, {:class => 'select2 fullwidth', :style => "display: #{f.object.country.states.empty? ? 'none' : 'block' };", :disabled => f.object.country.states.empty?} %>
-          </span>
-        <% end %>
-      </div>
+  <div class="three columns">
+    <div class="field ">
+      <%= f.label :zipcode, Spree.t(:zip) %>
+      <%= f.text_field :zipcode, :class => 'fullwidth' %>
     </div>
+  </div>
 
-    <div class="omega four columns">
-      <div class="field ">
-        <%= f.label :phone, Spree.t(:phone) %>
-        <%= f.phone_field :phone, :class => 'fullwidth' %>
-      </div>
+  <div class="omega three columns">
+    <div class="field ">
+      <%= f.label :phone, Spree.t(:phone) %>
+      <%= f.phone_field :phone, :class => 'fullwidth' %>
+    </div>
+  </div>
+
+  <div class="alpha six columns">
+    <div class="field ">
+      <%= f.label :country_id, Spree.t(:country) %>
+      <span id="country"><%= f.collection_select :country_id, available_countries, :id, :name, {}, {:class => 'select2 fullwidth'} %></span>
+    </div>
+  </div>
+
+  <div class="omega six columns">
+    <div class="field ">
+      <% if f.object.country %>
+        <%= f.label :state_id, Spree.t(:state) %>
+        <span id="state" class="region">
+          <%= f.text_field :state_name, :style => "display: #{f.object.country.states.empty? ? 'block' : 'none' };", :disabled => !f.object.country.states.empty?, :class => 'fullwidth state_name' %>
+          <%= f.collection_select :state_id, f.object.country.states.sort, :id, :name, {:include_blank => true}, {:class => 'select2 fullwidth', :style => "display: #{f.object.country.states.empty? ? 'none' : 'block' };", :disabled => f.object.country.states.empty?} %>
+        </span>
+      <% end %>
     </div>
   </div>
 </div>

--- a/backend/app/views/spree/admin/stock_locations/_form.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/_form.html.erb
@@ -1,32 +1,36 @@
 <div data-hook="admin_stock_locations_form_fields" class="row">
-  <div class="alpha nine columns">
-    <%= f.field_container :name do %>
-      <%= f.label :name, Spree.t(:name) %> <span class="required">*</span><br />
-      <%= f.text_field :name, :class => 'fullwidth', required: true %>
-    <% end %>
-    <%= f.field_container :admin_name do %>
-      <%= f.label :admin_name, Spree.t(:internal_name) %>
-      <%= f.text_field :admin_name, :class => 'fullwidth', :label => false %>
-    <% end %>
+  <div class="alpha nine columns" data-hook="stock_location_names">
+    <div data-hook="stock_location_name">
+      <%= f.field_container :name do %>
+        <%= f.label :name, Spree.t(:name) %> <span class="required">*</span><br />
+        <%= f.text_field :name, class: 'fullwidth', required: true %>
+      <% end %>
+    </div>
+    <div data-hook="stock_location_admin_name">
+      <%= f.field_container :admin_name do %>
+        <%= f.label :admin_name, Spree.t(:internal_name) %>
+        <%= f.text_field :admin_name, class: 'fullwidth', label: false %>
+      <% end %>
+    </div>
   </div>
 
-  <div class="omega three columns">
+  <div class="omega three columns" data-hook="stock_location_status">
     <%= f.field_container :active do %>
       <label for="active"><%= Spree.t(:status) %></label>
       <ul>
-        <li class="fullwidth">
+        <li class="fullwidth" data-hook="stock_location_active">
           <%= f.check_box :active %>
           <%= f.label :active, Spree.t(:active) %>
         </li>
-        <li class="fullwidth">
+        <li class="fullwidth" data-hook="stock_location_default">
           <%= f.check_box :default %>
           <%= f.label :default, Spree.t(:default) %>
         </li>
-        <li class="fullwidth">
+        <li class="fullwidth" data-hook="stock_location_backorderable_default">
           <%= f.check_box :backorderable_default %>
           <%= f.label :backorderable_default, Spree.t(:backorderable_default) %>
         </li>
-        <li class="fullwidth">
+        <li class="fullwidth" data-hook="stock_location_propagate_all_variants">
           <%= f.check_box :propagate_all_variants %>
           <%= f.label :propagate_all_variants, Spree.t(:propagate_all_variants) %>
         </li>
@@ -34,42 +38,42 @@
     <% end %>
   </div>
 
-  <div class="alpha six columns field">
+  <div class="alpha six columns field" data-hook="stock_location_address1">
     <%= f.label :address1, Spree.t(:street_address) %>
-    <%= f.text_field :address1, :class => 'fullwidth' %>
+    <%= f.text_field :address1, class: 'fullwidth' %>
   </div>
 
-  <div class="omega six columns field">
+  <div class="omega six columns field" data-hook="stock_location_city">
     <%= f.label :city, Spree.t(:city) %>
-    <%= f.text_field :city, :class => 'fullwidth' %>
+    <%= f.text_field :city, class: 'fullwidth' %>
   </div>
 
-  <div class="alpha six columns field">
+  <div class="alpha six columns field" data-hook="stock_location_address2">
     <%= f.label :address2, Spree.t(:street_address_2) %>
-    <%= f.text_field :address2, :class => 'fullwidth' %>
+    <%= f.text_field :address2, class: 'fullwidth' %>
   </div>
 
-  <div class="three columns field">
+  <div class="three columns field" data-hook="stock_location_zipcode">
     <%= f.label :zipcode, Spree.t(:zip) %>
-    <%= f.text_field :zipcode, :class => 'fullwidth' %>
+    <%= f.text_field :zipcode, class: 'fullwidth' %>
   </div>
 
-  <div class="omega three columns field">
+  <div class="omega three columns field" data-hook="stock_location_phone">
     <%= f.label :phone, Spree.t(:phone) %>
-    <%= f.phone_field :phone, :class => 'fullwidth' %>
+    <%= f.phone_field :phone, class: 'fullwidth' %>
   </div>
 
-  <div class="alpha six columns field">
+  <div class="alpha six columns field" data-hook="stock_location_country">
     <%= f.label :country_id, Spree.t(:country) %>
-    <span id="country"><%= f.collection_select :country_id, available_countries, :id, :name, {}, {:class => 'select2 fullwidth'} %></span>
+    <span id="country"><%= f.collection_select :country_id, available_countries, :id, :name, {}, { class: 'select2 fullwidth' } %></span>
   </div>
 
-  <div class="omega six columns field">
+  <div class="omega six columns field" data-hook="stock_location_state">
     <% if f.object.country %>
       <%= f.label :state_id, Spree.t(:state) %>
       <span id="state" class="region">
-        <%= f.text_field :state_name, :style => "display: #{f.object.country.states.empty? ? 'block' : 'none' };", :disabled => !f.object.country.states.empty?, :class => 'fullwidth state_name' %>
-        <%= f.collection_select :state_id, f.object.country.states.sort, :id, :name, {:include_blank => true}, {:class => 'select2 fullwidth', :style => "display: #{f.object.country.states.empty? ? 'none' : 'block' };", :disabled => f.object.country.states.empty?} %>
+        <%= f.text_field :state_name, style: "display: #{f.object.country.states.empty? ? 'block' : 'none' };", disabled: !f.object.country.states.empty?, class: 'fullwidth state_name' %>
+        <%= f.collection_select :state_id, f.object.country.states.sort, :id, :name, { include_blank: true }, {class: 'select2 fullwidth', style: "display: #{f.object.country.states.empty? ? 'none' : 'block' };", disabled: f.object.country.states.empty?} %>
       </span>
     <% end %>
   </div>

--- a/backend/app/views/spree/admin/stock_locations/_form.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/_form.html.erb
@@ -34,58 +34,44 @@
     <% end %>
   </div>
 
-  <div class="alpha six columns">
-    <div class="field ">
-      <%= f.label :address1, Spree.t(:street_address) %>
-      <%= f.text_field :address1, :class => 'fullwidth' %>
-    </div>
+  <div class="alpha six columns field">
+    <%= f.label :address1, Spree.t(:street_address) %>
+    <%= f.text_field :address1, :class => 'fullwidth' %>
   </div>
 
-  <div class="omega six columns">
-    <div class="field ">
-      <%= f.label :city, Spree.t(:city) %>
-      <%= f.text_field :city, :class => 'fullwidth' %>
-    </div>
+  <div class="omega six columns field">
+    <%= f.label :city, Spree.t(:city) %>
+    <%= f.text_field :city, :class => 'fullwidth' %>
   </div>
 
-  <div class="alpha six columns">
-    <div class="field ">
-      <%= f.label :address2, Spree.t(:street_address_2) %>
-      <%= f.text_field :address2, :class => 'fullwidth' %>
-    </div>
+  <div class="alpha six columns field">
+    <%= f.label :address2, Spree.t(:street_address_2) %>
+    <%= f.text_field :address2, :class => 'fullwidth' %>
   </div>
 
-  <div class="three columns">
-    <div class="field ">
-      <%= f.label :zipcode, Spree.t(:zip) %>
-      <%= f.text_field :zipcode, :class => 'fullwidth' %>
-    </div>
+  <div class="three columns field">
+    <%= f.label :zipcode, Spree.t(:zip) %>
+    <%= f.text_field :zipcode, :class => 'fullwidth' %>
   </div>
 
-  <div class="omega three columns">
-    <div class="field ">
-      <%= f.label :phone, Spree.t(:phone) %>
-      <%= f.phone_field :phone, :class => 'fullwidth' %>
-    </div>
+  <div class="omega three columns field">
+    <%= f.label :phone, Spree.t(:phone) %>
+    <%= f.phone_field :phone, :class => 'fullwidth' %>
   </div>
 
-  <div class="alpha six columns">
-    <div class="field ">
-      <%= f.label :country_id, Spree.t(:country) %>
-      <span id="country"><%= f.collection_select :country_id, available_countries, :id, :name, {}, {:class => 'select2 fullwidth'} %></span>
-    </div>
+  <div class="alpha six columns field">
+    <%= f.label :country_id, Spree.t(:country) %>
+    <span id="country"><%= f.collection_select :country_id, available_countries, :id, :name, {}, {:class => 'select2 fullwidth'} %></span>
   </div>
 
-  <div class="omega six columns">
-    <div class="field ">
-      <% if f.object.country %>
-        <%= f.label :state_id, Spree.t(:state) %>
-        <span id="state" class="region">
-          <%= f.text_field :state_name, :style => "display: #{f.object.country.states.empty? ? 'block' : 'none' };", :disabled => !f.object.country.states.empty?, :class => 'fullwidth state_name' %>
-          <%= f.collection_select :state_id, f.object.country.states.sort, :id, :name, {:include_blank => true}, {:class => 'select2 fullwidth', :style => "display: #{f.object.country.states.empty? ? 'none' : 'block' };", :disabled => f.object.country.states.empty?} %>
-        </span>
-      <% end %>
-    </div>
+  <div class="omega six columns field">
+    <% if f.object.country %>
+      <%= f.label :state_id, Spree.t(:state) %>
+      <span id="state" class="region">
+        <%= f.text_field :state_name, :style => "display: #{f.object.country.states.empty? ? 'block' : 'none' };", :disabled => !f.object.country.states.empty?, :class => 'fullwidth state_name' %>
+        <%= f.collection_select :state_id, f.object.country.states.sort, :id, :name, {:include_blank => true}, {:class => 'select2 fullwidth', :style => "display: #{f.object.country.states.empty? ? 'none' : 'block' };", :disabled => f.object.country.states.empty?} %>
+      </span>
+    <% end %>
   </div>
 </div>
 


### PR DESCRIPTION
The stock location edit page recently suffered some misfortune when #5404 was merged. I took the time to give it a revamp in design when it had only twelve columns to work with, not sixteen.

I also added data hooks as well for the fields so that developers can effectively deface it.

Before:

![screen shot 2014-10-24 at 3 38 40 am](https://cloud.githubusercontent.com/assets/3117356/4768423/f3348fca-5b69-11e4-8a51-566e2738465e.png)

After:

![screen shot 2014-10-24 at 3 38 01 am](https://cloud.githubusercontent.com/assets/3117356/4768419/df401606-5b69-11e4-8207-1c3cc03e29bf.png)
