### PR TITLE
include children in spree taxon load

### DIFF
--- a/api/app/controllers/spree/api/taxons_controller.rb
+++ b/api/app/controllers/spree/api/taxons_controller.rb
@@ -6,9 +6,9 @@ module Spree
           @taxons = taxonomy.root.children
         else
           if params[:ids]
-            @taxons = Spree::Taxon.accessible_by(current_ability, :read).where(id: params[:ids].split(','))
+            @taxons = Spree::Taxon.includes(:children).accessible_by(current_ability, :read).where(id: params[:ids].split(','))
           else
-            @taxons = Spree::Taxon.accessible_by(current_ability, :read).order(:taxonomy_id, :lft).ransack(params[:q]).result
+            @taxons = Spree::Taxon.includes(:children).accessible_by(current_ability, :read).order(:taxonomy_id, :lft).ransack(params[:q]).result
           end
         end
 


### PR DESCRIPTION
Similar to #5519 but for taxons.

Before:

``` ruby
Processing by Spree::Api::TaxonsController#index as JSON
  Parameters: {"ids"=>"7,9"}
  Spree::User Load (0.8ms)  SELECT  "spree_users".* FROM "spree_users"  WHERE "spree_users"."deleted_at" IS NULL AND "spree_users"."id" = 1  ORDER BY "spree_users"."id" ASC LIMIT 1
   (0.5ms)  SELECT "spree_roles"."name" FROM "spree_roles" INNER JOIN "spree_roles_users" ON "spree_roles"."id" = "spree_roles_users"."role_id" WHERE "spree_roles_users"."user_id" = $1  [["user_id", 1]]
   (0.5ms)  SELECT COUNT(*) FROM "spree_roles" INNER JOIN "spree_roles_users" ON "spree_roles"."id" = "spree_roles_users"."role_id" WHERE "spree_roles_users"."user_id" = $1 AND "spree_roles"."name" = 'admin'  [["user_id", 1]]
  CACHE (0.0ms)  SELECT COUNT(*) FROM "spree_roles" INNER JOIN "spree_roles_users" ON "spree_roles"."id" = "spree_roles_users"."role_id" WHERE "spree_roles_users"."user_id" = $1 AND "spree_roles"."name" = 'admin'  [["user_id", 1]]
   (0.7ms)  SELECT COUNT(count_column) FROM (SELECT  1 AS count_column FROM "spree_taxons"  WHERE "spree_taxons"."id" IN (7, 9) LIMIT 25 OFFSET 0) subquery_for_count
   (0.5ms)  SELECT COUNT(*) FROM "spree_taxons"  WHERE "spree_taxons"."id" IN (7, 9)
  Spree::Taxon Load (0.9ms)  SELECT  "spree_taxons".* FROM "spree_taxons"  WHERE "spree_taxons"."id" IN (7, 9) LIMIT 25 OFFSET 0
  Spree::Taxon Load (0.5ms)  SELECT "spree_taxons".* FROM "spree_taxons"  WHERE "spree_taxons"."parent_id" = $1  ORDER BY "lft"  [["parent_id", 9]]
  Spree::Taxon Load (0.8ms)  SELECT "spree_taxons".* FROM "spree_taxons"  WHERE ("spree_taxons"."lft" <= 16) AND ("spree_taxons"."rgt" >= 17) AND ("spree_taxons"."id" != 9)  ORDER BY "spree_taxons"."lft"
  Spree::Taxon Load (0.8ms)  SELECT "spree_taxons".* FROM "spree_taxons"  WHERE "spree_taxons"."parent_id" = $1  ORDER BY "lft"  [["parent_id", 7]]
  Spree::Taxon Load (0.8ms)  SELECT "spree_taxons".* FROM "spree_taxons"  WHERE ("spree_taxons"."lft" <= 9) AND ("spree_taxons"."rgt" >= 10) AND ("spree_taxons"."id" != 7)  ORDER BY "spree_taxons"."lft"
  Rendered /Users/benmorgan/.rvm/gems/ruby-2.1.2/bundler/gems/spree-e2b8f984c514/api/app/views/spree/api/taxons/index.v1.rabl (207.1ms)
Completed 200 OK in 543ms (Views: 510.6ms | ActiveRecord: 6.9ms)
```

After:

``` ruby
Started GET "/api/taxons?ids=7,9" for 127.0.0.1 at 2014-10-24 20:04:23 -0700
Processing by Spree::Api::TaxonsController#index as JSON
  Parameters: {"ids"=>"7,9"}
  Spree::User Load (0.9ms)  SELECT  "spree_users".* FROM "spree_users"  WHERE "spree_users"."deleted_at" IS NULL AND "spree_users"."id" = 1  ORDER BY "spree_users"."id" ASC LIMIT 1
   (0.3ms)  SELECT "spree_roles"."name" FROM "spree_roles" INNER JOIN "spree_roles_users" ON "spree_roles"."id" = "spree_roles_users"."role_id" WHERE "spree_roles_users"."user_id" = $1  [["user_id", 1]]
   (0.3ms)  SELECT COUNT(*) FROM "spree_roles" INNER JOIN "spree_roles_users" ON "spree_roles"."id" = "spree_roles_users"."role_id" WHERE "spree_roles_users"."user_id" = $1 AND "spree_roles"."name" = 'admin'  [["user_id", 1]]
  CACHE (0.0ms)  SELECT COUNT(*) FROM "spree_roles" INNER JOIN "spree_roles_users" ON "spree_roles"."id" = "spree_roles_users"."role_id" WHERE "spree_roles_users"."user_id" = $1 AND "spree_roles"."name" = 'admin'  [["user_id", 1]]
   (0.9ms)  SELECT COUNT(count_column) FROM (SELECT  1 AS count_column FROM "spree_taxons"  WHERE "spree_taxons"."id" IN (7, 9) LIMIT 25 OFFSET 0) subquery_for_count
   (0.6ms)  SELECT COUNT(*) FROM "spree_taxons"  WHERE "spree_taxons"."id" IN (7, 9)
  Spree::Taxon Load (0.6ms)  SELECT  "spree_taxons".* FROM "spree_taxons"  WHERE "spree_taxons"."id" IN (7, 9) LIMIT 25 OFFSET 0
  Spree::Taxon Load (0.6ms)  SELECT "spree_taxons".* FROM "spree_taxons"  WHERE "spree_taxons"."parent_id" IN (9, 7)  ORDER BY "lft"
  Spree::Taxon Load (0.7ms)  SELECT "spree_taxons".* FROM "spree_taxons"  WHERE ("spree_taxons"."lft" <= 16) AND ("spree_taxons"."rgt" >= 17) AND ("spree_taxons"."id" != 9)  ORDER BY "spree_taxons"."lft"
  Spree::Taxon Load (0.6ms)  SELECT "spree_taxons".* FROM "spree_taxons"  WHERE ("spree_taxons"."lft" <= 9) AND ("spree_taxons"."rgt" >= 10) AND ("spree_taxons"."id" != 7)  ORDER BY "spree_taxons"."lft"
  Rendered /Users/benmorgan/.rvm/gems/ruby-2.1.2/bundler/gems/spree-e2b8f984c514/api/app/views/spree/api/taxons/index.v1.rabl (161.8ms)
Completed 200 OK in 492ms (Views: 466.5ms | ActiveRecord: 5.6ms)
```
