### PR TITLE
Removes redundant closing li

### DIFF
--- a/backend/app/views/spree/admin/shared/_product_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_product_tabs.html.erb
@@ -24,7 +24,6 @@
       <%= content_tag :li, :class => ('active' if current == 'Stock Management') do %>
         <%= link_to_with_icon 'tasks', Spree.t(:stock_management), stock_admin_product_url(@product) %>
       <% end if can?(:stock, Spree::Product) %>
-      </li>
     </ul>
   </nav>
 


### PR DESCRIPTION
admin/shared/_product_tabs.html.erb has a trailing closing li tag that isn't needed as we are using tag helpers.

Whilst I'm pretty sure this doesn't cause any issues, its just a small bit of housekeeping.
