### PR TITLE
Only save taxon descendants when permalink changes

### DIFF
--- a/backend/app/controllers/spree/admin/taxons_controller.rb
+++ b/backend/app/controllers/spree/admin/taxons_controller.rb
@@ -66,8 +66,8 @@ module Spree
           parent_permalink += "/" unless parent_permalink.blank?
           params[:taxon][:permalink] = parent_permalink + params[:permalink_part]
         end
-        #check if we need to rename child taxons if parent name or permalink changes
-        @update_children = true if params[:taxon][:name] != @taxon.name || params[:taxon][:permalink] != @taxon.permalink
+        #check if we need to rename child taxons if parent name and permalink changes
+        @update_children = true if params[:taxon][:name] != @taxon.name && params[:taxon][:permalink] != @taxon.permalink
 
         if @taxon.update_attributes(taxon_params)
           flash[:success] = flash_message_for(@taxon, :successfully_updated)


### PR DESCRIPTION
When you update a taxon if checks if the taxon descendants need to be updated too.

Why should we update the descendants if only the name changes?
It's only necessary if the permalink changes.

If you have a lot of descendants taxons the save becomes really slow, if we only do this when necessary you can easily improve a taxon name without saving all the descendants.
