### PR TITLE
Allow for shipment adjustments to be viewed from API

### DIFF
--- a/api/app/views/spree/api/shipments/small.v1.rabl
+++ b/api/app/views/spree/api/shipments/small.v1.rabl
@@ -31,3 +31,7 @@ child :manifest => :manifest do
   node(:quantity) { |m| m.quantity }
   node(:states) { |m| m.states }
 end
+
+child :adjustments => :adjustments do
+  extends "spree/api/adjustments/show"
+end

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -145,6 +145,27 @@ module Spree
       expect(json_response["adjustments"]).to be_empty
     end
 
+    context 'when shipment adjustments are present' do
+      let(:adjustment) { FactoryGirl.create(:adjustment) }
+
+      before do
+        allow_any_instance_of(Order).to receive_messages :user => current_api_user
+        shipment = FactoryGirl.create(:shipment, order: order)
+        shipment.adjustments << adjustment
+      end
+
+      subject { api_get :show, :id => order.to_param }
+
+      it 'contains adjustments in JSON' do
+        subject
+        # Test to insure shipment has adjustments
+        shipment = json_response['shipments'][0]
+        expect(shipment).to_not be_nil
+        expect(shipment['adjustments'][0]).not_to be_empty
+        expect(shipment['adjustments'][0]['label']).to eq(adjustment.label)
+      end
+    end
+
     it "orders contain the basic checkout steps" do
       allow_any_instance_of(Order).to receive_messages :user => current_api_user
       api_get :show, :id => order.to_param


### PR DESCRIPTION
If there are adjustments on a shipment i.e. Free Shipping, then it would be nice to see it via the API. This feels pretty reasonable since line items are showing their adjustments. Shipping should be the same way, me thinks.
