### PR TITLE
Fix payments ordering when choose payment for risk analysis

### DIFF
--- a/backend/app/views/spree/admin/orders/edit.html.erb
+++ b/backend/app/views/spree/admin/orders/edit.html.erb
@@ -17,7 +17,7 @@
 </div>
 
 <% if @order.payments.exists? && @order.considered_risky? %>
-  <%= render 'spree/admin/orders/risk_analysis', latest_payment: @order.payments.order("created_at DESC").first %>
+  <%= render 'spree/admin/orders/risk_analysis', latest_payment: @order.payments.last %>
 <% end %>
 
 <%= render partial: 'add_product' if @order.shipment_state != 'shipped' && can?(:update, @order) %>


### PR DESCRIPTION
Spree::Payment has ordering by created_at by default.
When displaying order risk analysis Spree tries to select last payment for order and uses ordering payments by "created_at DESC" and then select first record, but it does not work. So we need either to use reorder or to rely on default ordering.
