### PR TITLE
HTTP Patch makes direct update_attributes call on Spree::Order

### DIFF
--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -59,7 +59,15 @@ module Spree
         find_order(true)
         authorize! :update, @order, order_token
 
-        if @order.contents.update_cart(order_params)
+        result = if request.patch?
+          # This will update the order without a checkout reset.
+          @order.update_attributes(order_params)
+        else
+          # This will reset checkout back to address and delete all shipments.
+          @order.contents.update_cart(order_params)
+        end
+
+        if result
           user_id = params[:order][:user_id]
           if current_api_user.has_spree_role?('admin') && user_id
             @order.associate_user!(Spree.user_class.find(user_id))

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -36,6 +36,28 @@ module Spree
       stub_authentication!
     end
 
+    describe 'PATCH #update' do
+      subject { api_patch :update, id: order.to_param, order: { email: "foo@bar.com" } }
+
+      before do
+        allow_any_instance_of(Spree::Order).to receive_messages :user => current_api_user
+      end
+
+      it 'should be ok' do
+        expect(subject).to be_ok
+      end
+
+      it 'should not invoke OrderContents#update_cart' do
+        expect_any_instance_of(Spree::OrderContents).to_not receive(:update_cart)
+        subject
+      end
+
+      it 'should update the email' do
+        subject
+        expect(order.reload.email).to eq('foo@bar.com')
+      end
+    end
+
     it "cannot view all orders" do
       api_get :index
       assert_unauthorized!

--- a/api/spec/support/controller_hacks.rb
+++ b/api/spec/support/controller_hacks.rb
@@ -12,6 +12,10 @@ module ControllerHacks
     api_process(action, params, session, flash, "PUT")
   end
 
+  def api_patch(action, params={}, session=nil, flash=nil)
+    api_process(action, params, session, flash, "PATCH")
+  end
+
   def api_delete(action, params={}, session=nil, flash=nil)
     api_process(action, params, session, flash, "DELETE")
   end


### PR DESCRIPTION
Potential solution to this issue:

https://github.com/spree/spree/issues/5543

This PR allows the API Orders endpoint to PATCH an order and just update the attributes, without going through OrderContents update_cart. This will fix the scenario where we want to update a simple field in the Spree::Order, like email or a decorated gift_message in the middle of checkout.

As is, any change PUT #update will reset the entire checkout flow.  By providing PATCH, we're letting API clients make these simple field changes without causing checkout to get recycled.
