### PR TITLE
Restore accessor method `package.order`

### DIFF
--- a/core/app/models/spree/stock/package.rb
+++ b/core/app/models/spree/stock/package.rb
@@ -23,6 +23,12 @@ module Spree
         @contents -= [item] if item
       end
 
+      # Fix regression that removed package.order.
+      # Find it dynamically through an inventory_unit.
+      def order
+        contents.detect {|item| !!item.try(:inventory_unit).try(:order) }.try(:inventory_unit).try(:order)
+      end
+
       def weight
         contents.sum(&:weight)
       end

--- a/core/spec/models/spree/stock/package_spec.rb
+++ b/core/spec/models/spree/stock/package_spec.rb
@@ -139,6 +139,25 @@ module Spree
           end
         end
       end
+
+      describe "#order" do
+        let(:unit) { build_inventory_unit }
+        context "there is an inventory unit" do
+
+          before { subject.add unit }
+
+          it "returns an order" do
+            expect(subject.order).to be_a_kind_of Spree::Order
+            expect(subject.order).to eq unit.order
+          end
+        end
+
+        context "there is no inventory unit" do
+          it "returns nil" do
+            expect(subject.order).to eq nil
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Restore accessor method `package.order`, now computing it based on the first inventory_unit.

Added specs to detect the regression.
This caused significant problems in spree_active_shipping, which relies on `package.order.ship_address`
