### PR TITLE
Fixed problem when destroying tax_rate that has offers dependent

### DIFF
--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -163,6 +163,8 @@ module Spree
 
     # This method is used by Adjustment#update to recalculate the cost.
     def compute_amount(item)
+      return 0 unless calculator
+      
       if included_in_price
         if default_zone_or_zone_match?(item.order.tax_zone)
           calculator.compute(item)


### PR DESCRIPTION
Returning 0 when calculator does not exists.
