### PR TITLE
Fix variant price validation to allow nil

### DIFF
--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -32,8 +32,9 @@ module Spree
       inverse_of: :variant
 
     validate :check_price
+
     validates :cost_price, numericality: { greater_than_or_equal_to: 0, allow_nil: true }
-    validates :price, numericality: { greater_than_or_equal_to: 0 }
+    validates :price,      numericality: { greater_than_or_equal_to: 0, allow_nil: true }
     validates_uniqueness_of :sku, allow_blank: true, conditions: -> { where(deleted_at: nil) }
 
     before_validation :set_cost_currency


### PR DESCRIPTION
- The check_price validation already asserts presence, or not depending on
  the system config, and unnecessarily validations are done when
  the master variant price is not required.

I'd like to see this backported to at least 2-3-stable.
