### PR TITLE
Fix order / adjustment presence in adjustments

### DIFF
--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -168,7 +168,7 @@ module Spree
     end
 
     context 'when shipment adjustments are present' do
-      let(:adjustment) { FactoryGirl.create(:adjustment) }
+      let(:adjustment) { FactoryGirl.create(:adjustment, order: order) }
 
       before do
         allow_any_instance_of(Order).to receive_messages :user => current_api_user
@@ -476,7 +476,7 @@ module Spree
       context "with a line item" do
         let(:order_with_line_items) do
           order = create(:order_with_line_items)
-          create(:adjustment, :adjustable => order)
+          create(:adjustment, order: order, adjustable: order)
           order
         end
 

--- a/backend/app/controllers/spree/admin/adjustments_controller.rb
+++ b/backend/app/controllers/spree/admin/adjustments_controller.rb
@@ -27,6 +27,12 @@ module Spree
         @order.reload.update!
       end
 
+      # Override method used to create a new instance to correctly
+      # associate adjustment with order
+      def build_resource
+        parent.adjustments.build(order: parent)
+      end
+
     end
   end
 end

--- a/backend/spec/features/admin/orders/adjustments_spec.rb
+++ b/backend/spec/features/admin/orders/adjustments_spec.rb
@@ -20,7 +20,7 @@ describe "Adjustments", :type => :feature do
       :amount => 10)
   end
 
-  let!(:adjustment) { order.adjustments.create!(label: 'Rebate', amount: 10) }
+  let!(:adjustment) { order.adjustments.create!(order: order, label: 'Rebate', amount: 10) }
 
   before(:each) do
     # To ensure the order totals are correct
@@ -31,6 +31,12 @@ describe "Adjustments", :type => :feature do
     click_link "Orders"
     within_row(1) { click_icon :edit }
     click_link "Adjustments"
+  end
+
+  after :each do
+    order.reload.all_adjustments.each do |adjustment|
+      expect(adjustment.order_id).to equal(order.id)
+    end
   end
 
   context "admin managing adjustments" do

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -26,6 +26,8 @@ module Spree
     belongs_to :source, polymorphic: true
     belongs_to :order, class_name: "Spree::Order"
 
+    validates :adjustable, presence: true
+    validates :order, presence: true
     validates :label, presence: true
     validates :amount, numericality: true
 
@@ -106,7 +108,7 @@ module Spree
 
     def update_adjustable_adjustment_total
       # Cause adjustable's total to be recalculated
-      Spree::ItemAdjustments.new(adjustable).update if adjustable
+      ItemAdjustments.new(adjustable).update
     end
 
   end

--- a/core/app/models/spree/item_adjustments.rb
+++ b/core/app/models/spree/item_adjustments.rb
@@ -27,7 +27,7 @@ module Spree
       #
       # It also fits the criteria for sales tax as outlined here:
       # http://www.boe.ca.gov/formspubs/pub113/
-      # 
+      #
       # Tax adjustments come in not one but *two* exciting flavours:
       # Included & additional
 

--- a/core/app/models/spree/promotion/actions/create_item_adjustments.rb
+++ b/core/app/models/spree/promotion/actions/create_item_adjustments.rb
@@ -40,9 +40,10 @@ module Spree
         # Ensure a negative amount which does not exceed the sum of the order's
         # item_total and ship_total
         def compute_amount(adjustable)
-          return 0 unless promotion.line_item_actionable? adjustable.order, adjustable
+          order = adjustable.is_a?(Order) ? adjustable : adjustable.order
+          return 0 unless promotion.line_item_actionable?(order, adjustable)
           promotion_amount = self.calculator.compute(adjustable).to_f.abs
-          
+
           [adjustable.amount, promotion_amount].min * -1
         end
 

--- a/core/db/migrate/20141101231208_fix_adjustment_order_presence.rb
+++ b/core/db/migrate/20141101231208_fix_adjustment_order_presence.rb
@@ -1,0 +1,8 @@
+class FixAdjustmentOrderPresence < ActiveRecord::Migration
+  def change
+    say 'Fixing adjustments without direct order reference'
+    Spree::Adjustment.where(order: nil).find_each do |adjustment|
+      adjustment.udpate_attributes!(adjustable: adjustment.adjustable.order)
+    end
+  end
+end

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -120,8 +120,11 @@ module Spree
           return [] unless adjustments
           adjustments.each do |a|
             begin
-              adjustment = order.adjustments.build(:amount => a[:amount].to_f,
-                                                  :label => a[:label])
+              adjustment = order.adjustments.build(
+                order:  order,
+                amount: a[:amount].to_f,
+                label:  a[:label]
+              )
               adjustment.save!
               adjustment.close!
             rescue Exception => e

--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -5,11 +5,16 @@ require 'spec_helper'
 
 describe Spree::Adjustment, :type => :model do
 
-  let(:order) { mock_model(Spree::Order, update!: nil) }
-  let(:adjustment) { Spree::Adjustment.create(:label => "Adjustment", :amount => 5) }
+  let(:order) { Spree::Order.new }
+
+  before do
+    allow(order).to receive(:update!)
+  end
+
+  let(:adjustment) { Spree::Adjustment.create!(label: 'Adjustment', adjustable: order, order: order, amount: 5) }
 
   context '#create & #destroy' do
-    let(:adjustment) { Spree::Adjustment.new(label: "Adjustment", amount: 5, adjustable: create(:line_item)) }
+    let(:adjustment) { Spree::Adjustment.new(label: "Adjustment", amount: 5, order: order, adjustable: create(:line_item)) }
 
     it 'calls #update_adjustable_adjustment_total' do
       expect(adjustment).to receive(:update_adjustable_adjustment_total).twice
@@ -19,7 +24,7 @@ describe Spree::Adjustment, :type => :model do
   end
 
   context '#save' do
-    let(:adjustment) { Spree::Adjustment.create(label: "Adjustment", amount: 5, adjustable: create(:line_item)) }
+    let(:adjustment) { Spree::Adjustment.create(label: "Adjustment", amount: 5, order: order, adjustable: create(:line_item)) }
 
     it 'touches the adjustable' do
       expect(adjustment.adjustable).to receive(:touch)
@@ -32,9 +37,9 @@ describe Spree::Adjustment, :type => :model do
       Spree::Adjustment.non_tax.to_a
     end
 
-    let!(:tax_adjustment) { create(:adjustment, source: create(:tax_rate)) }
-    let!(:non_tax_adjustment_with_source) { create(:adjustment, source_type: 'Spree::Order', source_id: nil) }
-    let!(:non_tax_adjustment_without_source) { create(:adjustment, source: nil) }
+    let!(:tax_adjustment) { create(:adjustment, order: order, source: create(:tax_rate))                   }
+    let!(:non_tax_adjustment_with_source) { create(:adjustment, order: order, source_type: 'Spree::Order', source_id: nil) }
+    let!(:non_tax_adjustment_without_source) { create(:adjustment, order: order, source: nil)                                 }
 
     it 'select non-tax adjustments' do
       expect(subject).to_not include tax_adjustment
@@ -44,7 +49,7 @@ describe Spree::Adjustment, :type => :model do
   end
 
   context "adjustment state" do
-    let(:adjustment) { create(:adjustment, state: 'open') }
+    let(:adjustment) { create(:adjustment, order: order, state: 'open') }
 
     context "#closed?" do
       it "is true when adjustment state is closed" do

--- a/core/spec/models/spree/calculator/refunds/default_refund_amount_spec.rb
+++ b/core/spec/models/spree/calculator/refunds/default_refund_amount_spec.rb
@@ -22,7 +22,7 @@ describe Spree::Calculator::Returns::DefaultRefundAmount, :type => :model do
       let(:adjustment_amount) { -10.0 }
 
       before do
-        order.adjustments << create(:adjustment, amount: adjustment_amount, eligible: true, label: 'Adjustment', source_type: 'Spree::Order')
+        order.adjustments << create(:adjustment, order: order, amount: adjustment_amount, eligible: true, label: 'Adjustment', source_type: 'Spree::Order')
         order.adjustments.first.update_attributes(amount: adjustment_amount)
       end
 

--- a/core/spec/models/spree/item_adjustments_spec.rb
+++ b/core/spec/models/spree/item_adjustments_spec.rb
@@ -11,7 +11,7 @@ module Spree
     context '#update' do
       it "updates a linked adjustment" do
         tax_rate = create(:tax_rate, :amount => 0.05)
-        adjustment = create(:adjustment, :source => tax_rate, :adjustable => line_item)
+        adjustment = create(:adjustment, order: order, source: tax_rate, adjustable: line_item)
         line_item.price = 10
         line_item.tax_category = tax_rate.tax_category
 
@@ -39,12 +39,12 @@ module Spree
         line_item.price = 20
         line_item.tax_category = tax_rate.tax_category
         line_item.save
-        create(:adjustment, :source => promotion_action, :adjustable => line_item)
+        create(:adjustment, order: order, source: promotion_action, adjustable: line_item)
       end
 
       context "tax included in price" do
         before do
-          create(:adjustment, 
+          create(:adjustment,
             :source => tax_rate,
             :adjustable => line_item,
             :order => order,
@@ -71,7 +71,7 @@ module Spree
 
       context "tax excluded from price" do
         before do
-          create(:adjustment, 
+          create(:adjustment,
             :source => tax_rate,
             :adjustable => line_item,
             :order => order,

--- a/core/spec/models/spree/order/adjustments_spec.rb
+++ b/core/spec/models/spree/order/adjustments_spec.rb
@@ -25,7 +25,7 @@ describe Spree::Order, :type => :model do
       # Don't care about available payment methods in this test
       allow(persisted_order).to receive_messages(:has_available_payment => false)
       persisted_order.line_items << line_item
-      create(:adjustment, :amount => -line_item.amount, :label => "Promotion", :adjustable => line_item)
+      create(:adjustment, amount: -line_item.amount, label: "Promotion", adjustable: line_item, order: persisted_order)
       persisted_order.state = 'delivery'
       persisted_order.save # To ensure new state_change event
     end

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -175,7 +175,7 @@ describe Spree::Order, :type => :model do
         order.line_items << line_item
         tax_rate = create(:tax_rate, :tax_category => line_item.tax_category, :amount => 0.05)
         allow(Spree::TaxRate).to receive_messages :match => [tax_rate]
-        FactoryGirl.create(:tax_adjustment, :adjustable => line_item, :source => tax_rate)
+        FactoryGirl.create(:tax_adjustment, :adjustable => line_item, :source => tax_rate, order: order)
         order.email = "user@example.com"
         order.next!
         expect(order.adjustment_total).to eq(0.5)

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -43,7 +43,7 @@ module Spree
 
         before do
           updater.update
-          create(:adjustment, :source => promotion_action, :adjustable => order)
+          create(:adjustment, source: promotion_action, adjustable: order, order: order)
           create(:line_item, :order => order, price: 10) # in addition to the two already created
           updater.update
         end

--- a/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
@@ -10,7 +10,10 @@ module Spree
         let!(:line_item) { create(:line_item, :order => order) }
         let(:payload) { { order: order, promotion: promotion } }
 
-        before { allow(action).to receive_messages(:promotion => promotion) }
+        before do
+          allow(action).to receive(:promotion).and_return(promotion)
+          promotion.promotion_actions = [action]
+        end
 
         context "#perform" do
           # Regression test for #3966
@@ -99,10 +102,11 @@ module Spree
         context "#destroy" do
           let!(:action) { CreateItemAdjustments.create! }
           let(:other_action) { CreateItemAdjustments.create! }
+          before { promotion.promotion_actions = [other_action] }
 
           it "destroys adjustments for incompleted orders" do
             order = Order.create
-            action.adjustments.create!(label: "Check", amount: 0, order: order)
+            action.adjustments.create!(label: "Check", amount: 0, order: order, adjustable: order)
 
             expect {
               action.destroy
@@ -111,7 +115,7 @@ module Spree
 
           it "nullifies adjustments for completed orders" do
             order = Order.create(completed_at: Time.now)
-            adjustment = action.adjustments.create!(label: "Check", amount: 0, order: order)
+            adjustment = action.adjustments.create!(label: "Check", amount: 0, order: order, adjustable: order)
 
             expect {
               action.destroy
@@ -119,7 +123,7 @@ module Spree
           end
 
           it "doesnt mess with unrelated adjustments" do
-            other_action.adjustments.create!(label: "Check", amount: 0)
+            other_action.adjustments.create!(label: "Check", amount: 0, order: order, adjustable: order)
 
             expect {
               action.destroy

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -228,10 +228,13 @@ describe Spree::Promotion, :type => :model do
     end
 
     let!(:adjustment) do
+      order = create(:order)
       Spree::Adjustment.create!(
-        :source => action,
-        :amount => 10,
-        :label => "Promotional adjustment"
+        order:      order,
+        adjustable: order,
+        source:     action,
+        amount:     10,
+        label:      'Promotional adjustment'
       )
     end
 

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -318,7 +318,7 @@ describe Spree::Shipment, :type => :model do
       # Regression test for #4347
       context "with adjustments" do
         before do
-          shipment.adjustments << Spree::Adjustment.create(:label => "Label", :amount => 5)
+          shipment.adjustments << Spree::Adjustment.create(order: order, label: "Label", amount: 5)
         end
 
         it "transitions to shipped" do
@@ -557,23 +557,25 @@ describe Spree::Shipment, :type => :model do
     end
 
     it "factors in additional adjustments to adjustment total" do
-      shipment.adjustments.create!({
-        :label => "Additional",
-        :amount => 5,
-        :included => false,
-        :state => "closed"
-      })
+      shipment.adjustments.create!(
+        order:    order,
+        label:    "Additional",
+        amount:   5,
+        included: false,
+        state:    "closed"
+      )
       shipment.update_amounts
       expect(shipment.reload.adjustment_total).to eq(5)
     end
 
     it "does not factor in included adjustments to adjustment total" do
-      shipment.adjustments.create!({
-        :label => "Included",
-        :amount => 5,
-        :included => true,
-        :state => "closed"
-      })
+      shipment.adjustments.create!(
+        order:    order,
+        label:    "Included",
+        amount:   5,
+        included: true,
+        state:    "closed"
+      )
       shipment.update_amounts
       expect(shipment.reload.adjustment_total).to eq(0)
     end

--- a/sample/db/samples/adjustments.rb
+++ b/sample/db/samples/adjustments.rb
@@ -6,6 +6,7 @@ last_order = Spree::Order.find_by_number!("R987654321")
 first_order.adjustments.create!(
   :amount => 0,
   :source => Spree::TaxRate.find_by_name!("North America"),
+  :order  => first_order,
   :label => "Tax",
   :state => "open",
   :mandatory => true)
@@ -13,6 +14,7 @@ first_order.adjustments.create!(
 last_order.adjustments.create!(
   :amount => 0,
   :source => Spree::TaxRate.find_by_name!("North America"),
+  :order  => last_order,
   :label => "Tax",
   :state => "open",
   :mandatory => true)


### PR DESCRIPTION
- Fix admin action producing adjustments without direct order reference.
- Add validation for the presence of adjustable
- Adjustments without an adjustable item do not make too much sense
- Add migration to fix old adjustments without direct order reference

This set of changes allows to promote `Order#all_adjustments` to a relation. This step is needed to ultimatively retarget all order specific adjustment reads / writes through this relation. Together with eager loading it gives a huge performance boost and fixes (for us) the deadlog issue as resources under contention will only be accessed through the same object graph.

These set of changes is an iterative improvement.

I'll PR the missing parts step by step to allow discussion.

Our CI passes this set of changes. https://circleci.com/gh/MountainRoseHerbs/spree/392

I'd like to see this backported to at least 2-3-stable.
