### PR TITLE
Change an inventory unit to be removed when it's line item is removed

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -8,7 +8,7 @@ module Spree
     has_one :product, through: :variant
 
     has_many :adjustments, as: :adjustable, dependent: :destroy
-    has_many :inventory_units, inverse_of: :line_item
+    has_many :inventory_units, dependent: :destroy, inverse_of: :line_item
 
     before_validation :copy_price
     before_validation :copy_tax_category


### PR DESCRIPTION
- This will fix the foreign key violation when a line item is removed
  in the cart.
