### PR TITLE
Fix admin order open/close adjustments to affect all adjustments

### DIFF
--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -109,16 +109,16 @@ module Spree
       end
 
       def open_adjustments
-        adjustments = @order.adjustments.where(:state => 'closed')
-        adjustments.update_all(:state => 'open')
+        adjustments = @order.all_adjustments.where(state: 'closed')
+        adjustments.update_all(state: 'open')
         flash[:success] = Spree.t(:all_adjustments_opened)
 
         respond_with(@order) { |format| format.html { redirect_to :back } }
       end
 
       def close_adjustments
-        adjustments = @order.adjustments.where(:state => 'open')
-        adjustments.update_all(:state => 'closed')
+        adjustments = @order.all_adjustments.where(state: 'open')
+        adjustments.update_all(state: 'closed')
         flash[:success] = Spree.t(:all_adjustments_closed)
 
         respond_with(@order) { |format| format.html { redirect_to :back } }

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -25,8 +25,22 @@ describe Spree::Admin::OrdersController, :type => :controller do
       end
     end
 
-    let(:order) { mock_model(Spree::Order, :completed? => true, :total => 100, :number => 'R123456789', billing_address: mock_model(Spree::Address)) }
-    before { allow(Spree::Order).to receive_messages :find_by_number! => order }
+    let(:order) do
+      mock_model(
+        Spree::Order,
+        completed?:      true,
+        total:           100,
+        number:          'R123456789',
+        all_adjustments: adjustments,
+        billing_address: mock_model(Spree::Address)
+      )
+    end
+
+    let(:adjustments) { double('adjustments') }
+
+    before do
+      allow(Spree::Order).to receive_messages(find_by_number!: order)
+    end
 
     context "#approve" do
       it "approves an order" do
@@ -100,6 +114,58 @@ describe Spree::Admin::OrdersController, :type => :controller do
           line_items_variant_id_in: Spree::Order.first.variants.map(&:id)
         }
         expect(assigns[:orders].map { |o| o.number }.count).to eq 1
+      end
+    end
+
+    context "#open_adjustments" do
+      let(:closed) { double('closed_adjustments') }
+
+      before do
+        allow(adjustments).to receive(:where).and_return(closed)
+        allow(closed).to receive(:update_all)
+      end
+
+      it "changes all the closed adjustments to open" do
+        expect(adjustments).to receive(:where).with(state: 'closed')
+          .and_return(closed)
+        expect(closed).to receive(:update_all).with(state: 'open')
+        spree_post :open_adjustments, id: order.number
+      end
+
+      it "sets the flash success message" do
+        spree_post :open_adjustments, id: order.number
+        expect(flash[:success]).to eql('All adjustments successfully opened!')
+      end
+
+      it "redirects back" do
+        spree_post :open_adjustments, id: order.number
+        expect(response).to redirect_to(:back)
+      end
+    end
+
+    context "#close_adjustments" do
+      let(:open) { double('open_adjustments') }
+
+      before do
+        allow(adjustments).to receive(:where).and_return(open)
+        allow(open).to receive(:update_all)
+      end
+
+      it "changes all the open adjustments to closed" do
+        expect(adjustments).to receive(:where).with(state: 'open')
+          .and_return(open)
+        expect(open).to receive(:update_all).with(state: 'closed')
+        spree_post :close_adjustments, id: order.number
+      end
+
+      it "sets the flash success message" do
+        spree_post :close_adjustments, id: order.number
+        expect(flash[:success]).to eql('All adjustments successfully closed!')
+      end
+
+      it "redirects back" do
+        spree_post :close_adjustments, id: order.number
+        expect(response).to redirect_to(:back)
       end
     end
   end


### PR DESCRIPTION
- The previous code was just opening and closing the order-specific
  adjustments, not the line items or shipping adjustments.

I'd like to see this backported to at least 2-3-stable.
