### PR TITLE
Change an inventory unit to be removed when it's line item is removed

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -24,6 +24,7 @@ module Spree
 
     validate :ensure_proper_currency
     before_destroy :update_inventory
+    before_destroy :destroy_inventory_units
 
     after_save :update_inventory
     after_save :update_adjustments
@@ -121,6 +122,10 @@ module Spree
         if (changed? || target_shipment.present?) && self.order.has_checkout_step?("delivery")
           Spree::OrderInventory.new(self.order, self).verify(target_shipment)
         end
+      end
+
+      def destroy_inventory_units
+        inventory_units.destroy_all
       end
 
       def update_adjustments

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -26,6 +26,10 @@ describe Spree::LineItem, :type => :model do
       expect_any_instance_of(Spree::OrderInventory).to receive(:verify)
       line_item.destroy
     end
+
+    it "deletes inventory units" do
+      expect { line_item.destroy }.to change { line_item.inventory_units.count }.from(1).to(0)
+    end
   end
 
   context "#save" do


### PR DESCRIPTION
- This will fix the foreign key violation when a line item is removed
  in the cart.

Note a normal `dependent: destroy` attribute for the association will NOT work, as this fires before the `before_destroy :update_inventory` hook, confusing the `OrderInventory#verify` with a state its not prepared for.

I see an improvement possible where `OrderInventory#verify` would not rely on that invariant, but I think this PR is an iterative improvement.

I'd like to see this backported to at least 2-3-stable.
