### PR TITLE
Fix the cookie domain used for google analytics

### DIFF
--- a/frontend/app/views/spree/shared/_google_analytics.html.erb
+++ b/frontend/app/views/spree/shared/_google_analytics.html.erb
@@ -5,7 +5,7 @@
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-    ga('create', '<%= tracker.analytics_id %>','<%= current_store.url.sub(/(^www.)?/,'') %>');
+    ga('create', '<%= tracker.analytics_id %>', 'auto');
     ga('require', 'displayfeatures');
     ga('send', 'pageview');
 


### PR DESCRIPTION
- A change needed to make the google analytics integration compatible
  with the universal analytics engine. Should also work for the
  traditional code.

I'd like to see this backported to at least 2-3-stable.
