### PR TITLE
Promotion categories single page workflow

### DIFF
--- a/backend/app/views/spree/admin/promotion_categories/index.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/index.html.erb
@@ -4,11 +4,13 @@
 
 <% content_for :page_actions do %>
   <li>
-    <%= button_link_to Spree.t(:new_promotion_category), spree.new_admin_promotion_category_path, :icon => 'plus' %>
+    <%= button_link_to Spree.t(:new_promotion_category), spree.new_admin_promotion_category_path, icon: 'plus', remote: true, id: 'new_promotion_category_link' %>
   </li>
 <% end %>
 
 <%= render 'spree/admin/shared/promotion_sub_menu' %>
+
+<div id="new_promotion_category"></div>
 
 <% if @promotion_categories.any? %>
   <table>
@@ -35,6 +37,6 @@
 <% else %>
   <div class="alpha sixteen columns no-objects-found">
     <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/promotion_category')) %>
-    <%= link_to Spree.t(:add_one) + '!', spree.new_admin_promotion_category_path %>
+    <%= link_to Spree.t(:add_one) + '!', spree.new_admin_promotion_category_path, remote: true, id: 'new_promotion_category_link' %>
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/promotion_categories/index.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/index.html.erb
@@ -10,24 +10,31 @@
 
 <%= render 'spree/admin/shared/promotion_sub_menu' %>
 
-<table>
-  <colgroup>
-    <col style="width: 85%">
-    <col style="width: 15%">
-  </colgroup>
-  <thead>
-    <th><%= Spree::PromotionCategory.human_attribute_name :name %></th>
-    <th class='actions'></th>
-  </thead>
-  <tbody>
-    <% @promotion_categories.each do |promotion_category| %>
-      <tr>
-        <td><%= promotion_category.name %></td>
-        <td class="actions">
-          <%= link_to_edit promotion_category, :no_text => true %>
-          <%= link_to_delete promotion_category, :no_text => true %>
-        </td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<% if @promotion_categories.any? %>
+  <table>
+    <colgroup>
+      <col style="width: 85%">
+      <col style="width: 15%">
+    </colgroup>
+    <thead>
+      <th><%= Spree::PromotionCategory.human_attribute_name :name %></th>
+      <th class='actions'></th>
+    </thead>
+    <tbody>
+      <% @promotion_categories.each do |promotion_category| %>
+        <tr>
+          <td><%= promotion_category.name %></td>
+          <td class="actions">
+            <%= link_to_edit promotion_category, :no_text => true %>
+            <%= link_to_delete promotion_category, :no_text => true %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <div class="alpha sixteen columns no-objects-found">
+    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/promotion_category')) %>
+    <%= link_to Spree.t(:add_one) + '!', spree.new_admin_promotion_category_path %>
+  </div>
+<% end %>

--- a/backend/app/views/spree/admin/promotion_categories/new.js.erb
+++ b/backend/app/views/spree/admin/promotion_categories/new.js.erb
@@ -1,0 +1,5 @@
+$("#new_promotion_category").html('<%= escape_javascript(render template: "spree/admin/promotion_categories/new", formats: [:html], handlers: [:erb]) %>');
+<% unless Rails.env.test? %>
+  $('.select2').select2();
+<% end %>
+$("#new_promotion_category_link").parent().hide();

--- a/backend/app/views/spree/admin/promotions/index.html.erb
+++ b/backend/app/views/spree/admin/promotions/index.html.erb
@@ -99,7 +99,7 @@
     </tbody>
   </table>
 <% else %>
-  <div class="alpha twelve columns no-objects-found">
+  <div class="alpha omega sixteen columns no-objects-found">
     <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/promotion')) %>,
     <%= link_to Spree.t(:add_one), spree.new_admin_promotion_path %>!
   </div>


### PR DESCRIPTION
When there are no promotion categories, we show an "add on" link.

Also, when adding a new promotion, I've made it so that it loads the new page on the index page to make it mimic the rest of Spree.

I also noticed that when no promotions are list, we were doing twelve columns instead of sixteen; fixed that.
