### PR TITLE
Fix validation to skip performing a query if the field is blank

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -84,7 +84,7 @@ module Spree
 
     validates :email, presence: true, if: :require_email
     validates :email, email: true, if: :require_email, allow_blank: true
-    validates :number, uniqueness: true
+    validates :number, presence: true, uniqueness: { allow_blank: true }
     validate :has_available_shipment
 
     make_permalink field: :number

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -41,7 +41,7 @@ module Spree
       -> { where is_master: true },
       inverse_of: :product,
       class_name: 'Spree::Variant'
-      
+
     has_many :variants,
       -> { where(is_master: false).order("#{::Spree::Variant.quoted_table_name}.position ASC") },
       inverse_of: :product,
@@ -56,7 +56,7 @@ module Spree
     has_many :prices, -> { order('spree_variants.position, spree_variants.id, currency') }, through: :variants
 
     has_many :stock_items, through: :variants_including_master
-    
+
     has_many :line_items, through: :variants_including_master
     has_many :orders, through: :line_items
 
@@ -82,7 +82,8 @@ module Spree
     validates :price, presence: true, if: proc { Spree::Config[:require_master_price] }
     validates :shipping_category_id, presence: true
     validates :slug, length: { minimum: 3 }
-    validates :slug, uniqueness: true
+
+    validates :slug, uniqueness: { allow_blank: true }
     validates :meta_keywords, length: { maximum: 255 }
     validates :meta_title, length: { maximum: 255 }
 

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -20,7 +20,7 @@ module Spree
     validates_associated :rules
 
     validates :name, presence: true
-    validates :path, uniqueness: true, allow_blank: true
+    validates :path, uniqueness: { allow_blank: true }
     validates :usage_limit, numericality: { greater_than: 0, allow_nil: true }
     validates :description, length: { maximum: 255 }
 

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -1,7 +1,7 @@
 module Spree
   class Store < Spree::Base
 
-    validates :code, presence: true, uniqueness: true
+    validates :code, presence: true, uniqueness: { allow_blank: true }
     validates :name, presence: true
     validates :url, presence: true
     validates :mail_from_address, presence: true

--- a/core/app/models/spree/tax_category.rb
+++ b/core/app/models/spree/tax_category.rb
@@ -1,7 +1,7 @@
 module Spree
   class TaxCategory < Spree::Base
     acts_as_paranoid
-    validates :name, presence: true, uniqueness: { scope: :deleted_at }
+    validates :name, presence: true, uniqueness: { scope: :deleted_at, allow_blank: true }
 
     has_many :tax_rates, dependent: :destroy, inverse_of: :tax_category
 

--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -4,7 +4,7 @@ module Spree
     has_many :tax_rates, dependent: :destroy, inverse_of: :zone
     has_and_belongs_to_many :shipping_methods, :join_table => 'spree_shipping_methods_zones'
 
-    validates :name, presence: true, uniqueness: true
+    validates :name, presence: true, uniqueness: { allow_blank: true }
     after_save :remove_defunct_members
     after_save :remove_previous_default
 


### PR DESCRIPTION
Reduces the amount of queries when doing order / product / promotion / store / tax category / zone related validations. Without any real semantic difference.

We where able to observe a smaller performance improvement in a custom order related task with this unneded query removed. And fixed all adjacent instances also.

I think this change is an iterative improvement as it at least reduces the amount of noise being generated by SQL queries.

I'd like to see this backported to at least 2-3-stable.
