### PR TITLE
Only reload shipment items on item adjustment

### DIFF
--- a/core/app/models/spree/item_adjustments.rb
+++ b/core/app/models/spree/item_adjustments.rb
@@ -9,8 +9,9 @@ module Spree
 
     def initialize(item)
       @item = item
+
       # Don't attempt to reload the item from the DB if it's not there
-      @item.reload if @item.persisted?
+      @item.reload if @item.instance_of?(Shipment) && @item.persisted?
     end
 
     def update
@@ -27,7 +28,7 @@ module Spree
       #
       # It also fits the criteria for sales tax as outlined here:
       # http://www.boe.ca.gov/formspubs/pub113/
-      # 
+      #
       # Tax adjustments come in not one but *two* exciting flavours:
       # Included & additional
 


### PR DESCRIPTION
The original issue fixed by https://github.com/spree/spree/commit/a4b209c7288198124a735d99203102d86be6a935
only affected shipment calculations. Removing the reload for LineItems
allows them, and more important their descendants to be eager loaded.

Also it less frequently nukes lazy load caches, resulting in a small (but under load measurable) performance improvement. It has no semantic differences.

This is part of a series of commits that leads to a more fundamental performance improvement.

I'd like to see this backported at least to `2-3-stable`.
