### PR TITLE
Pass item to Adjustment#update to avoid N+1

### DIFF
--- a/core/app/models/spree/item_adjustments.rb
+++ b/core/app/models/spree/item_adjustments.rb
@@ -27,7 +27,7 @@ module Spree
       #
       # It also fits the criteria for sales tax as outlined here:
       # http://www.boe.ca.gov/formspubs/pub113/
-      # 
+      #
       # Tax adjustments come in not one but *two* exciting flavours:
       # Included & additional
 
@@ -37,7 +37,10 @@ module Spree
       # Additional tax adjustments are the opposite, affecting the final total.
       promo_total = 0
       run_callbacks :promo_adjustments do
-        promotion_total = adjustments.promotion.reload.map(&:update!).compact.sum
+        promotion_total = adjustments.promotion.reload.map do |adjustment|
+          adjustment.update!(@item)
+        end.compact.sum
+
         unless promotion_total == 0
           choose_best_promotion_adjustment
         end


### PR DESCRIPTION
This simple change utilizes a property of `Adjustment#update!` where you can pass in the adjustable to avoid a lazy load lookup. Reducing an N+1 instance with a small, but under load measurable performance improvement. It has no semantic changes.

I'd like to see this backported to at least 2-3-stable.
