### PR TITLE
Make taxons in Product API # show more useful

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -168,7 +168,7 @@ module Spree
       end
 
       def product_includes
-        [ :option_types, variants: variants_associations, master: variants_associations ]
+        [ :option_types, :taxons, :product_properties, variants: variants_associations, master: variants_associations ]
       end
 
       def order_id

--- a/api/app/views/spree/api/products/show.v1.rabl
+++ b/api/app/views/spree/api/products/show.v1.rabl
@@ -21,3 +21,7 @@ end
 child :product_properties => :product_properties do
   attributes *product_property_attributes
 end
+
+child :taxons => :taxons do
+  extends "spree/api/taxons/show"
+end

--- a/api/spec/controllers/spree/api/products_controller_spec.rb
+++ b/api/spec/controllers/spree/api/products_controller_spec.rb
@@ -172,7 +172,10 @@ module Spree
         product.variants.create!
         product.variants.first.images.create!(:attachment => image("thinking-cat.jpg"))
         product.set_property("spree", "rocks")
+        product.taxons << create(:taxon)
+
         api_get :show, :id => product.to_param
+
         expect(json_response).to have_attributes(show_attributes)
         expect(json_response['variants'].first).to have_attributes([:name,
                                                               :is_master,
@@ -192,6 +195,8 @@ module Spree
         expect(json_response["product_properties"].first).to have_attributes([:value,
                                                                          :product_id,
                                                                          :property_name])
+
+        expect(json_response["taxons"].first).to have_attributes([:id, :name, :pretty_name, :permalink, :taxonomy_id, :parent_id])
       end
 
       context "tracking is disabled" do


### PR DESCRIPTION
The current taxon_ids payload in the Product GET /products/:id API is kinda hard to work with right now. By just returning IDs, it guarantees that I need to make subsequent API calls to resolve the taxon. This is due to the taxon endpoint being nested under taxonomies. This means, I need to a) Search all the taxonomies to see if it has the taxon ID, then with that taxonomy_id b) GET /api/taxonomies/:taxonomy_id/taxons/:taxon_id to find the information I need.

This change simply adds the taxons to the product JSON rabl to avoid extra API calls.

Not sure about the performance about this. If it's a real bear, then perhaps the compromise is to provide taxon URLs to be lazy resolved like below. It won't get rid of the extra calls but it will make it easier to navigate the current API a bit easier.

```
{
   taxon_ids: [2, 3].
   taxon_urls: [
     'http://somewhere.com/api/taxonomies/1/taxons/2',
     'http://somewhere.com/api/taxonomies/1/taxons/3'
   ]
}
```
