### PR TITLE
Return valid credit cards in the order API response during checkout

### DIFF
--- a/api/app/views/spree/api/orders/show.v1.rabl
+++ b/api/app/views/spree/api/orders/show.v1.rabl
@@ -46,3 +46,7 @@ end
 node :permissions do
   { can_update: current_ability.can?(:update, root_object) }
 end
+
+child :valid_credit_cards => :credit_cards do
+  extends "spree/api/credit_cards/show"
+end


### PR DESCRIPTION
Having this data is useful on the frontend for displaying credit card info during checkout.
