### PR TITLE
fix #4826 ambiguous column name

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -30,7 +30,7 @@ module Spree
     end
 
     def self.with_coupon_code(coupon_code)
-      where("lower(code) = ?", coupon_code.strip.downcase).first
+      where("lower(#{self.table_name}.code) = ?", coupon_code.strip.downcase).first
     end
 
     def self.active


### PR DESCRIPTION
This error happens when we include `:promotion_rules` in `Spree::PromotionHandler::Coupon.promotion`.  `Spree::PromotionRule`  already have `:code`
