### PR TITLE
Fix gitignore to exclude vendor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,15 +38,13 @@ spree_test
 testapp
 **/spec/dummy
 tmp
-vendor/rails
-vendor/extensions/google_base
 public/google_base.xml
 public/template_google_base.xml
 coverage/*
 var
 TAGS
 nbproject
-vendor/extensions/theme_default/app/stylesheets/*.css
+vendor
 tags
 *.swp
 rerun.txt


### PR DESCRIPTION
- Build scripts install to ./vendor, after testing something locally via
  the officially supported method `git status` should still list a
  pristine repository.

Please backport to at least 2-3-stable.
