### PR TITLE
N plus 1 for properties in api product scope

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -142,11 +142,9 @@ module Spree
       end
 
       def find_product(id)
-        begin
-          product_scope.friendly.find(id.to_s)
-        rescue ActiveRecord::RecordNotFound
-          product_scope.find(id)
-        end
+        product_scope.friendly.find(id.to_s)
+      rescue ActiveRecord::RecordNotFound
+        product_scope.find(id)
       end
 
       def product_scope

--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -166,7 +166,7 @@ module Spree
       end
 
       def product_includes
-        [ :option_types, :taxons, :product_properties, variants: variants_associations, master: variants_associations ]
+        [ :option_types, :taxons, product_properties: :property, variants: variants_associations, master: variants_associations ]
       end
 
       def order_id

--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -15,8 +15,6 @@ module Spree
         :shipment_attributes,
         :taxonomy_attributes,
         :taxon_attributes,
-        :inventory_unit_attributes,
-        :return_authorization_attributes,
         :address_attributes,
         :country_attributes,
         :state_attributes,


### PR DESCRIPTION
Before:

``` ruby
20:45:15 web.1    | Processing by Spree::Api::ProductsController#index as JSON
20:45:15 web.1    |   Spree::User Load (0.8ms)  SELECT  "spree_users".* FROM "spree_users"  WHERE "spree_users"."deleted_at" IS NULL AND "spree_users"."id" = 1  ORDER BY "spree_users"."id" ASC LIMIT 1
20:45:15 web.1    |    (1.4ms)  SELECT "spree_roles"."name" FROM "spree_roles" INNER JOIN "spree_roles_users" ON "spree_roles"."id" = "spree_roles_users"."role_id" WHERE "spree_roles_users"."user_id" = $1  [["user_id", 1]]
20:45:15 web.1    |    (0.6ms)  SELECT COUNT(*) FROM "spree_roles" INNER JOIN "spree_roles_users" ON "spree_roles"."id" = "spree_roles_users"."role_id" WHERE "spree_roles_users"."user_id" = $1 AND "spree_roles"."name" = 'admin'  [["user_id", 1]]
20:45:15 web.1    |   CACHE (0.0ms)  SELECT COUNT(*) FROM "spree_roles" INNER JOIN "spree_roles_users" ON "spree_roles"."id" = "spree_roles_users"."role_id" WHERE "spree_roles_users"."user_id" = $1 AND "spree_roles"."name" = 'admin'  [["user_id", 1]]
20:45:15 web.1    |    (12.0ms)  SELECT COUNT(DISTINCT count_column) FROM (SELECT  DISTINCT "spree_products"."id" AS count_column FROM "spree_products"  WHERE ("spree_products".deleted_at IS NULL or "spree_products".deleted_at >= '2014-11-06 04:45:15.244178') LIMIT 25 OFFSET 0) subquery_for_count
20:45:15 web.1    |    (1.3ms)  SELECT DISTINCT COUNT(DISTINCT "spree_products"."id") FROM "spree_products"  WHERE ("spree_products".deleted_at IS NULL or "spree_products".deleted_at >= '2014-11-06 04:45:15.244178')
20:45:15 web.1    |   Spree::Product Load (1.9ms)  SELECT  DISTINCT "spree_products".* FROM "spree_products"  WHERE ("spree_products".deleted_at IS NULL or "spree_products".deleted_at >= '2014-11-06 04:45:15.244178') LIMIT 25 OFFSET 0
20:45:15 web.1    |   Spree::ProductOptionType Load (4.8ms)  SELECT "spree_product_option_types".* FROM "spree_product_option_types"  WHERE "spree_product_option_types"."product_id" IN (5, 9, 3, 13, 16, 6, 4, 10, 18, 17, 2, 11, 14, 7, 8, 15, 12, 1)
20:45:16 web.1    |   Spree::OptionType Load (2.9ms)  SELECT "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" IN (8, 9, 1, 3, 4, 6, 2, 5, 7)  ORDER BY spree_option_types.position
20:45:16 web.1    |   Spree::Variant Load (8.3ms)  SELECT "spree_variants".* FROM "spree_variants"  WHERE "spree_variants"."deleted_at" IS NULL AND "spree_variants"."is_master" = 'f' AND "spree_variants"."product_id" IN (5, 9, 3, 13, 16, 6, 4, 10, 18, 17, 2, 11, 14, 7, 8, 15, 12, 1)  ORDER BY "spree_variants".position ASC
20:45:16 web.1    |   HABTM_OptionValues Load (3.5ms)  SELECT "spree_option_values_variants".* FROM "spree_option_values_variants"  WHERE "spree_option_values_variants"."variant_id" IN (17, 28, 65, 18, 29, 19, 66, 20, 67, 30, 31, 68, 21, 32, 69, 22, 70, 23, 33, 34, 71, 24, 35, 72, 25, 73, 26, 36, 74, 37, 75, 38, 39, 76, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63)
20:45:16 web.1    |   Spree::OptionValue Load (3.1ms)  SELECT "spree_option_values".* FROM "spree_option_values"  WHERE "spree_option_values"."id" IN (18, 22, 24, 23, 19, 20, 21)
20:45:16 web.1    |   Spree::OptionType Load (0.5ms)  SELECT "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" IN (8, 9)  ORDER BY spree_option_types.position
20:45:16 web.1    |   Spree::Price Load (4.0ms)  SELECT "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."deleted_at" IS NULL AND "spree_prices"."currency" = 'USD' AND "spree_prices"."variant_id" IN (17, 28, 65, 18, 29, 19, 66, 20, 67, 30, 31, 68, 21, 32, 69, 22, 70, 23, 33, 34, 71, 24, 35, 72, 25, 73, 26, 36, 74, 37, 75, 38, 39, 76, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63)
20:45:16 web.1    |   Spree::Image Load (3.9ms)  SELECT "spree_assets".* FROM "spree_assets"  WHERE "spree_assets"."type" IN ('Spree::Image') AND "spree_assets"."viewable_type" = 'Spree::Variant' AND "spree_assets"."viewable_id" IN (17, 28, 65, 18, 29, 19, 66, 20, 67, 30, 31, 68, 21, 32, 69, 22, 70, 23, 33, 34, 71, 24, 35, 72, 25, 73, 26, 36, 74, 37, 75, 38, 39, 76, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63)  ORDER BY "spree_assets"."position" ASC
20:45:16 web.1    |   Spree::Variant Load (0.8ms)  SELECT "spree_variants".* FROM "spree_variants"  WHERE "spree_variants"."deleted_at" IS NULL AND "spree_variants"."is_master" = 't' AND "spree_variants"."product_id" IN (5, 9, 3, 13, 16, 6, 4, 10, 18, 17, 2, 11, 14, 7, 8, 15, 12, 1)
20:45:16 web.1    |   HABTM_OptionValues Load (0.6ms)  SELECT "spree_option_values_variants".* FROM "spree_option_values_variants"  WHERE "spree_option_values_variants"."variant_id" IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 64, 27)
20:45:16 web.1    |   Spree::Price Load (0.8ms)  SELECT "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."deleted_at" IS NULL AND "spree_prices"."currency" = 'USD' AND "spree_prices"."variant_id" IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 64, 27)
20:45:16 web.1    |   Spree::Image Load (1.0ms)  SELECT "spree_assets".* FROM "spree_assets"  WHERE "spree_assets"."type" IN ('Spree::Image') AND "spree_assets"."viewable_type" = 'Spree::Variant' AND "spree_assets"."viewable_id" IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 64, 27)  ORDER BY "spree_assets"."position" ASC
20:45:16 web.1    |   Cache digest for /Users/benmorgan/.rvm/gems/ruby-2.1.4/bundler/gems/spree-f6fc6d37d76d/api/app/views/spree/api/images/show.v1.rabl: 33fdb9c8886c5216c4f7f6feb2a11d9d
20:45:16 web.1    |   Cache digest for /Users/benmorgan/.rvm/gems/ruby-2.1.4/bundler/gems/spree-f6fc6d37d76d/api/app/views/spree/api/variants/small.v1.rabl: d9e77b4e90d09cd2bdd8fcc5815cec3c
20:45:16 web.1    |   Cache digest for /Users/benmorgan/.rvm/gems/ruby-2.1.4/bundler/gems/spree-f6fc6d37d76d/api/app/views/spree/api/products/show.v1.rabl: bb0ff27494b595d49c00a4d265b745f1
20:45:16 web.1    |   Spree::Preference Load (0.5ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/app_configuration/display_currency' LIMIT 1
20:45:16 web.1    |   Spree::Preference Load (0.4ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/app_configuration/currency_symbol_position' LIMIT 1
20:45:16 web.1    |   Spree::Preference Load (0.5ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/app_configuration/hide_cents' LIMIT 1
20:45:16 web.1    |   Spree::Preference Load (0.5ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/app_configuration/currency_decimal_mark' LIMIT 1
20:45:16 web.1    |   Spree::Preference Load (0.6ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/app_configuration/currency_thousands_separator' LIMIT 1
20:45:16 web.1    |   Spree::Preference Load (0.5ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/app_configuration/currency_sign_before_symbol' LIMIT 1
20:45:16 web.1    |    (6.3ms)  SELECT "spree_taxons".id FROM "spree_taxons" INNER JOIN "spree_products_taxons" ON "spree_taxons"."id" = "spree_products_taxons"."taxon_id" WHERE "spree_products_taxons"."product_id" = $1  [["product_id", 5]]
20:45:17 web.1    |   Spree::ProductProperty Load (3.9ms)  SELECT "spree_product_properties".* FROM "spree_product_properties"  WHERE "spree_product_properties"."product_id" = $1  ORDER BY spree_product_properties.position  [["product_id", 5]]
20:45:17 web.1    |   Spree::Property Load (2.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 1]]
20:45:17 web.1    |   Spree::Property Load (0.5ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 2]]
20:45:17 web.1    |   Spree::Property Load (0.4ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 3]]
20:45:17 web.1    |   Spree::Property Load (0.4ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 4]]
20:45:17 web.1    |   Spree::Property Load (0.4ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 5]]
20:45:17 web.1    |   Spree::Property Load (0.4ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 6]]
20:45:17 web.1    |   Spree::Property Load (0.3ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 7]]
20:45:17 web.1    |   Spree::Property Load (0.3ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 8]]
20:45:17 web.1    |    (0.7ms)  SELECT "spree_taxons".id FROM "spree_taxons" INNER JOIN "spree_products_taxons" ON "spree_taxons"."id" = "spree_products_taxons"."taxon_id" WHERE "spree_products_taxons"."product_id" = $1  [["product_id", 9]]
20:45:17 web.1    |   Spree::ProductProperty Load (0.6ms)  SELECT "spree_product_properties".* FROM "spree_product_properties"  WHERE "spree_product_properties"."product_id" = $1  ORDER BY spree_product_properties.position  [["product_id", 9]]
20:45:17 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 1]]
20:45:17 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 2]]
20:45:17 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 3]]
20:45:17 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 4]]
20:45:17 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 5]]
20:45:17 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 6]]
20:45:17 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 7]]
20:45:17 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 8]]
20:45:17 web.1    |    (0.7ms)  SELECT "spree_taxons".id FROM "spree_taxons" INNER JOIN "spree_products_taxons" ON "spree_taxons"."id" = "spree_products_taxons"."taxon_id" WHERE "spree_products_taxons"."product_id" = $1  [["product_id", 3]]
20:45:19 web.1    |   Spree::ProductProperty Load (0.5ms)  SELECT "spree_product_properties".* FROM "spree_product_properties"  WHERE "spree_product_properties"."product_id" = $1  ORDER BY spree_product_properties.position  [["product_id", 3]]
20:45:19 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 1]]
20:45:19 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 2]]
20:45:19 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 3]]
20:45:19 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 4]]
20:45:19 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 5]]
20:45:19 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 6]]
20:45:19 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 7]]
20:45:19 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 8]]
20:45:20 web.1    |    (0.7ms)  SELECT "spree_taxons".id FROM "spree_taxons" INNER JOIN "spree_products_taxons" ON "spree_taxons"."id" = "spree_products_taxons"."taxon_id" WHERE "spree_products_taxons"."product_id" = $1  [["product_id", 13]]
20:45:20 web.1    |   Spree::ProductProperty Load (0.5ms)  SELECT "spree_product_properties".* FROM "spree_product_properties"  WHERE "spree_product_properties"."product_id" = $1  ORDER BY spree_product_properties.position  [["product_id", 13]]
20:45:20 web.1    |   Spree::Property Load (0.3ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 9]]
20:45:20 web.1    |   Spree::Property Load (0.3ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 10]]
20:45:20 web.1    |    (0.8ms)  SELECT "spree_taxons".id FROM "spree_taxons" INNER JOIN "spree_products_taxons" ON "spree_taxons"."id" = "spree_products_taxons"."taxon_id" WHERE "spree_products_taxons"."product_id" = $1  [["product_id", 16]]
20:45:20 web.1    |   Spree::ProductProperty Load (0.5ms)  SELECT "spree_product_properties".* FROM "spree_product_properties"  WHERE "spree_product_properties"."product_id" = $1  ORDER BY spree_product_properties.position  [["product_id", 16]]
20:45:20 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 9]]
20:45:20 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 10]]
20:45:20 web.1    |    (0.6ms)  SELECT "spree_taxons".id FROM "spree_taxons" INNER JOIN "spree_products_taxons" ON "spree_taxons"."id" = "spree_products_taxons"."taxon_id" WHERE "spree_products_taxons"."product_id" = $1  [["product_id", 6]]
20:45:20 web.1    |   Spree::ProductProperty Load (0.5ms)  SELECT "spree_product_properties".* FROM "spree_product_properties"  WHERE "spree_product_properties"."product_id" = $1  ORDER BY spree_product_properties.position  [["product_id", 6]]
20:45:21 web.1    |    (0.4ms)  SELECT "spree_taxons".id FROM "spree_taxons" INNER JOIN "spree_products_taxons" ON "spree_taxons"."id" = "spree_products_taxons"."taxon_id" WHERE "spree_products_taxons"."product_id" = $1  [["product_id", 4]]
20:45:21 web.1    |   Spree::ProductProperty Load (0.6ms)  SELECT "spree_product_properties".* FROM "spree_product_properties"  WHERE "spree_product_properties"."product_id" = $1  ORDER BY spree_product_properties.position  [["product_id", 4]]
20:45:21 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 1]]
20:45:21 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 2]]
20:45:21 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 3]]
20:45:21 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 4]]
20:45:21 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 5]]
20:45:21 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 6]]
20:45:21 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 7]]
20:45:21 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 8]]
20:45:21 web.1    |    (0.4ms)  SELECT "spree_taxons".id FROM "spree_taxons" INNER JOIN "spree_products_taxons" ON "spree_taxons"."id" = "spree_products_taxons"."taxon_id" WHERE "spree_products_taxons"."product_id" = $1  [["product_id", 10]]
20:45:21 web.1    |   Spree::ProductProperty Load (0.4ms)  SELECT "spree_product_properties".* FROM "spree_product_properties"  WHERE "spree_product_properties"."product_id" = $1  ORDER BY spree_product_properties.position  [["product_id", 10]]
20:45:21 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 1]]
20:45:21 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 2]]
20:45:21 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 3]]
20:45:21 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 4]]
20:45:21 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 5]]
20:45:21 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 6]]
20:45:21 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 7]]
20:45:21 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 8]]
20:45:21 web.1    |    (0.5ms)  SELECT "spree_taxons".id FROM "spree_taxons" INNER JOIN "spree_products_taxons" ON "spree_taxons"."id" = "spree_products_taxons"."taxon_id" WHERE "spree_products_taxons"."product_id" = $1  [["product_id", 18]]
20:45:23 web.1    |   Spree::ProductProperty Load (0.3ms)  SELECT "spree_product_properties".* FROM "spree_product_properties"  WHERE "spree_product_properties"."product_id" = $1  ORDER BY spree_product_properties.position  [["product_id", 18]]
20:45:23 web.1    |    (0.3ms)  SELECT "spree_taxons".id FROM "spree_taxons" INNER JOIN "spree_products_taxons" ON "spree_taxons"."id" = "spree_products_taxons"."taxon_id" WHERE "spree_products_taxons"."product_id" = $1  [["product_id", 17]]
20:45:26 web.1    |   Spree::ProductProperty Load (0.3ms)  SELECT "spree_product_properties".* FROM "spree_product_properties"  WHERE "spree_product_properties"."product_id" = $1  ORDER BY spree_product_properties.position  [["product_id", 17]]
20:45:26 web.1    |    (0.4ms)  SELECT "spree_taxons".id FROM "spree_taxons" INNER JOIN "spree_products_taxons" ON "spree_taxons"."id" = "spree_products_taxons"."taxon_id" WHERE "spree_products_taxons"."product_id" = $1  [["product_id", 2]]
20:45:26 web.1    |   Spree::ProductProperty Load (0.3ms)  SELECT "spree_product_properties".* FROM "spree_product_properties"  WHERE "spree_product_properties"."product_id" = $1  ORDER BY spree_product_properties.position  [["product_id", 2]]
20:45:26 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 9]]
20:45:26 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 10]]
20:45:26 web.1    |   Spree::Property Load (0.3ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 11]]
20:45:27 web.1    |    (0.4ms)  SELECT "spree_taxons".id FROM "spree_taxons" INNER JOIN "spree_products_taxons" ON "spree_taxons"."id" = "spree_products_taxons"."taxon_id" WHERE "spree_products_taxons"."product_id" = $1  [["product_id", 11]]
20:45:27 web.1    |   Spree::ProductProperty Load (0.4ms)  SELECT "spree_product_properties".* FROM "spree_product_properties"  WHERE "spree_product_properties"."product_id" = $1  ORDER BY spree_product_properties.position  [["product_id", 11]]
20:45:27 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 9]]
20:45:27 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 10]]
20:45:27 web.1    |    (0.4ms)  SELECT "spree_taxons".id FROM "spree_taxons" INNER JOIN "spree_products_taxons" ON "spree_taxons"."id" = "spree_products_taxons"."taxon_id" WHERE "spree_products_taxons"."product_id" = $1  [["product_id", 14]]
20:45:27 web.1    |   Spree::ProductProperty Load (0.3ms)  SELECT "spree_product_properties".* FROM "spree_product_properties"  WHERE "spree_product_properties"."product_id" = $1  ORDER BY spree_product_properties.position  [["product_id", 14]]
20:45:27 web.1    |   CACHE (0.2ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 9]]
20:45:27 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 10]]
20:45:27 web.1    |    (0.4ms)  SELECT "spree_taxons".id FROM "spree_taxons" INNER JOIN "spree_products_taxons" ON "spree_taxons"."id" = "spree_products_taxons"."taxon_id" WHERE "spree_products_taxons"."product_id" = $1  [["product_id", 7]]
20:45:27 web.1    |   Spree::ProductProperty Load (0.3ms)  SELECT "spree_product_properties".* FROM "spree_product_properties"  WHERE "spree_product_properties"."product_id" = $1  ORDER BY spree_product_properties.position  [["product_id", 7]]
20:45:27 web.1    |    (0.4ms)  SELECT "spree_taxons".id FROM "spree_taxons" INNER JOIN "spree_products_taxons" ON "spree_taxons"."id" = "spree_products_taxons"."taxon_id" WHERE "spree_products_taxons"."product_id" = $1  [["product_id", 8]]
20:45:28 web.1    |   Spree::ProductProperty Load (0.3ms)  SELECT "spree_product_properties".* FROM "spree_product_properties"  WHERE "spree_product_properties"."product_id" = $1  ORDER BY spree_product_properties.position  [["product_id", 8]]
20:45:28 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 1]]
20:45:28 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 2]]
20:45:28 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 3]]
20:45:28 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 4]]
20:45:28 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 5]]
20:45:28 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 6]]
20:45:28 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 7]]
20:45:28 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 8]]
20:45:28 web.1    |    (0.4ms)  SELECT "spree_taxons".id FROM "spree_taxons" INNER JOIN "spree_products_taxons" ON "spree_taxons"."id" = "spree_products_taxons"."taxon_id" WHERE "spree_products_taxons"."product_id" = $1  [["product_id", 15]]
20:45:28 web.1    |   Spree::ProductProperty Load (0.3ms)  SELECT "spree_product_properties".* FROM "spree_product_properties"  WHERE "spree_product_properties"."product_id" = $1  ORDER BY spree_product_properties.position  [["product_id", 15]]
20:45:28 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 9]]
20:45:28 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 10]]
20:45:28 web.1    |    (0.4ms)  SELECT "spree_taxons".id FROM "spree_taxons" INNER JOIN "spree_products_taxons" ON "spree_taxons"."id" = "spree_products_taxons"."taxon_id" WHERE "spree_products_taxons"."product_id" = $1  [["product_id", 12]]
20:45:28 web.1    |   Spree::ProductProperty Load (0.3ms)  SELECT "spree_product_properties".* FROM "spree_product_properties"  WHERE "spree_product_properties"."product_id" = $1  ORDER BY spree_product_properties.position  [["product_id", 12]]
20:45:28 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 9]]
20:45:28 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 10]]
20:45:28 web.1    |    (0.4ms)  SELECT "spree_taxons".id FROM "spree_taxons" INNER JOIN "spree_products_taxons" ON "spree_taxons"."id" = "spree_products_taxons"."taxon_id" WHERE "spree_products_taxons"."product_id" = $1  [["product_id", 1]]
20:45:29 web.1    |   Spree::ProductProperty Load (0.4ms)  SELECT "spree_product_properties".* FROM "spree_product_properties"  WHERE "spree_product_properties"."product_id" = $1  ORDER BY spree_product_properties.position  [["product_id", 1]]
20:45:29 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 9]]
20:45:29 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 10]]
20:45:29 web.1    |   CACHE (0.0ms)  SELECT  "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" = $1 LIMIT 1  [["id", 11]]
20:45:29 web.1    |   Rendered /Users/benmorgan/.rvm/gems/ruby-2.1.4/bundler/gems/spree-f6fc6d37d76d/api/app/views/spree/api/products/index.v1.rabl (13472.6ms)
20:45:29 web.1    | Completed 200 OK in 14033ms (Views: 13876.7ms | ActiveRecord: 135.8ms)
20:45:29 web.1    | user: benmorgan
20:45:29 web.1    | /api/products
20:45:29 web.1    | N+1 Query detected
20:45:29 web.1    |   Spree::Product => [:product_properties]
20:45:29 web.1    |   Add to your finder: :include => [:product_properties]
20:45:29 web.1    | N+1 Query method call stack
20:45:29 web.1    | user: benmorgan
20:45:29 web.1    | /api/products
20:45:29 web.1    | N+1 Query detected
20:45:29 web.1    |   Spree::ProductProperty => [:property]
20:45:29 web.1    |   Add to your finder: :include => [:property]
20:45:29 web.1    | N+1 Query method call stack
```

After:

``` ruby
20:57:58 web.1    | Processing by Spree::Api::ProductsController#index as JSON
20:57:58 web.1    |   Spree::User Load (0.9ms)  SELECT  "spree_users".* FROM "spree_users"  WHERE "spree_users"."deleted_at" IS NULL AND "spree_users"."id" = 1  ORDER BY "spree_users"."id" ASC LIMIT 1
20:57:58 web.1    |    (0.7ms)  SELECT "spree_roles"."name" FROM "spree_roles" INNER JOIN "spree_roles_users" ON "spree_roles"."id" = "spree_roles_users"."role_id" WHERE "spree_roles_users"."user_id" = $1  [["user_id", 1]]
20:57:58 web.1    |    (0.8ms)  SELECT COUNT(*) FROM "spree_roles" INNER JOIN "spree_roles_users" ON "spree_roles"."id" = "spree_roles_users"."role_id" WHERE "spree_roles_users"."user_id" = $1 AND "spree_roles"."name" = 'admin'  [["user_id", 1]]
20:57:58 web.1    |   CACHE (0.0ms)  SELECT COUNT(*) FROM "spree_roles" INNER JOIN "spree_roles_users" ON "spree_roles"."id" = "spree_roles_users"."role_id" WHERE "spree_roles_users"."user_id" = $1 AND "spree_roles"."name" = 'admin'  [["user_id", 1]]
20:57:58 web.1    |    (1.0ms)  SELECT COUNT(DISTINCT count_column) FROM (SELECT  DISTINCT "spree_products"."id" AS count_column FROM "spree_products"  WHERE ("spree_products".deleted_at IS NULL or "spree_products".deleted_at >= '2014-11-06 04:57:58.292874') LIMIT 25 OFFSET 0) subquery_for_count
20:57:58 web.1    |    (0.8ms)  SELECT DISTINCT COUNT(DISTINCT "spree_products"."id") FROM "spree_products"  WHERE ("spree_products".deleted_at IS NULL or "spree_products".deleted_at >= '2014-11-06 04:57:58.292874')
20:57:58 web.1    |   Spree::Product Load (1.3ms)  SELECT  DISTINCT "spree_products".* FROM "spree_products"  WHERE ("spree_products".deleted_at IS NULL or "spree_products".deleted_at >= '2014-11-06 04:57:58.292874') LIMIT 25 OFFSET 0
20:57:59 web.1    |   Spree::ProductOptionType Load (0.9ms)  SELECT "spree_product_option_types".* FROM "spree_product_option_types"  WHERE "spree_product_option_types"."product_id" IN (5, 9, 3, 13, 16, 6, 4, 10, 18, 17, 2, 11, 14, 7, 8, 15, 12, 1)
20:57:59 web.1    |   Spree::OptionType Load (0.8ms)  SELECT "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" IN (8, 9, 1, 3, 4, 6, 2, 5, 7)  ORDER BY spree_option_types.position
20:57:59 web.1    |   Spree::Classification Load (0.8ms)  SELECT "spree_products_taxons".* FROM "spree_products_taxons"  WHERE "spree_products_taxons"."product_id" IN (5, 9, 3, 13, 16, 6, 4, 10, 18, 17, 2, 11, 14, 7, 8, 15, 12, 1)
20:57:59 web.1    |   Spree::Taxon Load (0.7ms)  SELECT "spree_taxons".* FROM "spree_taxons"  WHERE "spree_taxons"."id" IN (7, 11, 6, 10, 4, 8, 13, 3, 9)
20:57:59 web.1    |   Spree::ProductProperty Load (1.4ms)  SELECT "spree_product_properties".* FROM "spree_product_properties"  WHERE "spree_product_properties"."product_id" IN (5, 9, 3, 13, 16, 6, 4, 10, 18, 17, 2, 11, 14, 7, 8, 15, 12, 1)  ORDER BY spree_product_properties.position
20:57:59 web.1    |   Spree::Property Load (1.7ms)  SELECT "spree_properties".* FROM "spree_properties"  WHERE "spree_properties"."id" IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
20:57:59 web.1    |   Spree::Variant Load (2.6ms)  SELECT "spree_variants".* FROM "spree_variants"  WHERE "spree_variants"."deleted_at" IS NULL AND "spree_variants"."is_master" = 'f' AND "spree_variants"."product_id" IN (5, 9, 3, 13, 16, 6, 4, 10, 18, 17, 2, 11, 14, 7, 8, 15, 12, 1)  ORDER BY "spree_variants".position ASC
20:57:59 web.1    |   HABTM_OptionValues Load (1.2ms)  SELECT "spree_option_values_variants".* FROM "spree_option_values_variants"  WHERE "spree_option_values_variants"."variant_id" IN (17, 28, 65, 18, 29, 19, 66, 20, 67, 30, 31, 68, 21, 32, 69, 22, 70, 23, 33, 34, 71, 24, 35, 72, 25, 73, 26, 36, 74, 37, 75, 38, 39, 76, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63)
20:57:59 web.1    |   Spree::OptionValue Load (1.3ms)  SELECT "spree_option_values".* FROM "spree_option_values"  WHERE "spree_option_values"."id" IN (18, 22, 24, 23, 19, 20, 21)
20:57:59 web.1    |   Spree::OptionType Load (0.6ms)  SELECT "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" IN (8, 9)  ORDER BY spree_option_types.position
20:57:59 web.1    |   Spree::Preference Load (0.8ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/app_configuration/currency' LIMIT 1
20:58:00 web.1    |   Spree::Price Load (1.9ms)  SELECT "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."deleted_at" IS NULL AND "spree_prices"."currency" = 'USD' AND "spree_prices"."variant_id" IN (17, 28, 65, 18, 29, 19, 66, 20, 67, 30, 31, 68, 21, 32, 69, 22, 70, 23, 33, 34, 71, 24, 35, 72, 25, 73, 26, 36, 74, 37, 75, 38, 39, 76, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63)
20:58:00 web.1    |   Spree::Image Load (1.4ms)  SELECT "spree_assets".* FROM "spree_assets"  WHERE "spree_assets"."type" IN ('Spree::Image') AND "spree_assets"."viewable_type" = 'Spree::Variant' AND "spree_assets"."viewable_id" IN (17, 28, 65, 18, 29, 19, 66, 20, 67, 30, 31, 68, 21, 32, 69, 22, 70, 23, 33, 34, 71, 24, 35, 72, 25, 73, 26, 36, 74, 37, 75, 38, 39, 76, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63)  ORDER BY "spree_assets"."position" ASC
20:58:00 web.1    |   Spree::Variant Load (1.1ms)  SELECT "spree_variants".* FROM "spree_variants"  WHERE "spree_variants"."deleted_at" IS NULL AND "spree_variants"."is_master" = 't' AND "spree_variants"."product_id" IN (5, 9, 3, 13, 16, 6, 4, 10, 18, 17, 2, 11, 14, 7, 8, 15, 12, 1)
20:58:00 web.1    |   HABTM_OptionValues Load (0.6ms)  SELECT "spree_option_values_variants".* FROM "spree_option_values_variants"  WHERE "spree_option_values_variants"."variant_id" IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 64, 27)
20:58:00 web.1    |   Spree::Price Load (1.0ms)  SELECT "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."deleted_at" IS NULL AND "spree_prices"."currency" = 'USD' AND "spree_prices"."variant_id" IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 64, 27)
20:58:00 web.1    |   Spree::Image Load (1.5ms)  SELECT "spree_assets".* FROM "spree_assets"  WHERE "spree_assets"."type" IN ('Spree::Image') AND "spree_assets"."viewable_type" = 'Spree::Variant' AND "spree_assets"."viewable_id" IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 64, 27)  ORDER BY "spree_assets"."position" ASC
20:58:00 web.1    |   Spree::Preference Load (0.6ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/app_configuration/display_currency' LIMIT 1
20:58:00 web.1    |   Spree::Preference Load (0.6ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/app_configuration/currency_symbol_position' LIMIT 1
20:58:00 web.1    |   Spree::Preference Load (0.6ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/app_configuration/hide_cents' LIMIT 1
20:58:00 web.1    |   Spree::Preference Load (0.7ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/app_configuration/currency_decimal_mark' LIMIT 1
20:58:00 web.1    |   Spree::Preference Load (0.7ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/app_configuration/currency_thousands_separator' LIMIT 1
20:58:00 web.1    |   Spree::Preference Load (0.5ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/app_configuration/currency_sign_before_symbol' LIMIT 1
20:58:11 web.1    |   Rendered /Users/benmorgan/.rvm/gems/ruby-2.1.4/bundler/gems/spree-f6fc6d37d76d/api/app/views/spree/api/products/index.v1.rabl (12419.8ms)
20:58:11 web.1    | Completed 200 OK in 13034ms (Views: 12834.5ms | ActiveRecord: 99.2ms)
```

Also, in the `Spree::Api::ApiHelpers::ATTRIBUTES` there were two duplicate symbols. One was `:inventory_unit_attributes` and the other `:return_autorization_attributes`. Found it when I randomly clicked on `:inventory_unit_attributes` and Sublime Text highlighted the second one. Decided to check for others and there were.

Also, for `#find_product` I refactored and removed the `begin` and `end`. Its implicit in ruby that the beginning and end of a method are, well, the beginning and end. 
