### PR TITLE
Fix classifications ordering

### DIFF
--- a/core/app/models/spree/classification.rb
+++ b/core/app/models/spree/classification.rb
@@ -1,7 +1,7 @@
 module Spree
   class Classification < Spree::Base
     self.table_name = 'spree_products_taxons'
-    acts_as_list
+    acts_as_list scope: :taxon
     belongs_to :product, class_name: "Spree::Product", inverse_of: :classifications
     belongs_to :taxon, class_name: "Spree::Taxon", inverse_of: :classifications
 

--- a/core/db/migrate/20141105213646_update_classifications_positions.rb
+++ b/core/db/migrate/20141105213646_update_classifications_positions.rb
@@ -1,8 +1,8 @@
 class UpdateClassificationsPositions < ActiveRecord::Migration
   def up
-    Spree::Taxon.each do |taxon|
+    Spree::Taxon.all.each do |taxon|
       taxon.classifications.each_with_index do |c12n, i|
-        c12n.set_list_position(i)
+        c12n.set_list_position(i + 1)
       end
     end
   end

--- a/core/db/migrate/20141105213646_update_classifications_positions.rb
+++ b/core/db/migrate/20141105213646_update_classifications_positions.rb
@@ -1,0 +1,9 @@
+class UpdateClassificationsPositions < ActiveRecord::Migration
+  def up
+    Spree::Taxon.each do |taxon|
+      taxon.classifications.each_with_index do |c12n, i|
+        c12n.set_list_position(i)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This branch fixes #5578 by doing the following:
- adds scope to `acts_as_list` in `Spree::Classification`;
- adds migration to rebuild all classification lists as scoped;
- alters the spec for product scopes to test for expected behaviour.

I'll be using your CI server to test against regressions, because on my machine the whole suite takes nearly 1h to finish. So excuse me if there will be several commits.
