### PR TITLE
Fix products classification page grid layout

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/sections/_taxons.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_taxons.scss
@@ -13,3 +13,9 @@
   
   margin: 10px;
 }
+
+#taxon_products {
+  > li {
+    height: 170px;
+  }
+}


### PR DESCRIPTION
The drag-to-sort page for sorting products within taxon breaks when product blocks have different height. The grid goes crazy when some products have longer names that are wrapped in more lines than other.

Not nice:

![not_nice](http://i.imgur.com/BhMjQWd.png)

Nicer:

![nicer](http://i.imgur.com/I6n4Ck8.png)

With this patch, very long names will be cut off by overflow, but it's still better than having a broken grid. It looks awful when there are many rows of products.
