### PR TITLE
Fix product classifications page layout & text

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/sections/_taxons.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_taxons.scss
@@ -13,3 +13,9 @@
   
   margin: 10px;
 }
+
+#taxon_products {
+  > li {
+    height: 170px;
+  }
+}

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -474,7 +474,7 @@ en:
     choose_dashboard_locale: Choose Dashboard Locale
     choose_location: Choose location
     city: City
-    click_and_drag_on_the_products_to_sort_them: 'Click &amp; drag on the products to sort them.'
+    click_and_drag_on_the_products_to_sort_them: Click and drag on the products to sort them
     clone: Clone
     close: Close
     close_all_adjustments: Close All Adjustments


### PR DESCRIPTION
Same as #5580, plus replace "&amp;amp;" with "and"
