### PR TITLE
Fixes typo, handles adjustable order without order_id

### DIFF
--- a/core/db/migrate/20141101231208_fix_adjustment_order_presence.rb
+++ b/core/db/migrate/20141101231208_fix_adjustment_order_presence.rb
@@ -2,7 +2,12 @@ class FixAdjustmentOrderPresence < ActiveRecord::Migration
   def change
     say 'Fixing adjustments without direct order reference'
     Spree::Adjustment.where(order: nil).find_each do |adjustment|
-      adjustment.udpate_attributes!(adjustable: adjustment.adjustable.order)
+      adjustable = adjustment.adjustable
+      if adjustable.is_a? Spree::Order
+        adjustment.update_attributes!(order_id: adjustable.id)
+      else
+        adjustment.update_attributes!(adjustable: adjustable.order)
+      end
     end
   end
 end


### PR DESCRIPTION
1. udpate?! Fixes typo. 
2. We had many adjustments where adjustable was a Spree::Order, but without order_id set, which caused the migration to fail. This handles that case and sets the order_id if so.
