### PR TITLE
Remove some unused ReturnAuthorizationController code

### DIFF
--- a/api/app/controllers/spree/api/return_authorizations_controller.rb
+++ b/api/app/controllers/spree/api/return_authorizations_controller.rb
@@ -45,15 +45,6 @@ module Spree
         end
       end
 
-      def receive
-        @return_authorization = order.return_authorizations.accessible_by(current_ability, :update).find(params[:id])
-        if @return_authorization.receive
-          respond_with @return_authorization, default_template: :show
-        else
-          invalid_resource!(@return_authorization)
-        end
-      end
-
       def cancel
         @return_authorization = order.return_authorizations.accessible_by(current_ability, :update).find(params[:id])
         if @return_authorization.cancel

--- a/api/spec/controllers/spree/api/return_authorizations_controller_spec.rb
+++ b/api/spec/controllers/spree/api/return_authorizations_controller_spec.rb
@@ -105,15 +105,6 @@ module Spree
         expect(json_response).to have_attributes(attributes)
       end
 
-      it "cannot mark a return authorization as received on the order with no inventory units" do
-        FactoryGirl.create(:new_return_authorization, :order => order)
-        return_authorization = order.return_authorizations.first
-        expect(return_authorization.state).to eq("authorized")
-        api_delete :receive, :id => return_authorization.id
-        expect(response.status).to eq(422)
-        expect(return_authorization.reload.state).to eq("authorized")
-      end
-
       it "can cancel a return authorization on the order" do
         FactoryGirl.create(:new_return_authorization, :order => order)
         return_authorization = order.return_authorizations.first


### PR DESCRIPTION
"receive" no longer applies to ReturnAuthorization. "Receiving" has been moved to CustomerReturn.
