### PR TITLE
Check Inventory And Restart Checkout If Insufficient

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -432,7 +432,11 @@ module Spree
 
     def ensure_line_items_are_in_stock
       if insufficient_stock_lines.present?
-        errors.add(:base, Spree.t(:insufficient_stock_lines_present)) and return false
+        errors.add(:base, Spree.t(:insufficient_stock_lines_present))
+        restart_checkout_flow
+        false
+      else
+        true
       end
     end
 

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -101,6 +101,8 @@ module Spree
 
               before_transition to: :resumed, do: :ensure_line_items_are_in_stock
 
+              before_transition to: :complete, do: :ensure_line_items_are_in_stock
+
               after_transition to: :complete, do: :finalize!
               after_transition to: :resumed,  do: :after_resume
               after_transition to: :canceled, do: :after_cancel

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -538,7 +538,8 @@ describe Spree::Order, :type => :model do
     end
 
     it "does not attempt to process payments" do
-      allow(order).to receive_message_chain(:line_items, :present?).and_return(true)
+      allow(order).to receive_message_chain(:line_items, :present?) { true }
+      allow(order).to receive(:ensure_line_items_are_in_stock) { true }
       expect(order).not_to receive(:payment_required?)
       expect(order).not_to receive(:process_payments!)
       order.next!

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -181,6 +181,31 @@ describe Spree::Order, :type => :model do
     end
   end
 
+  describe '#ensure_line_items_are_in_stock' do
+    subject { order.ensure_line_items_are_in_stock }
+
+    let(:line_item) { mock_model Spree::LineItem, :insufficient_stock? => true }
+
+    before do
+      allow(order).to receive(:restart_checkout_flow)
+      allow(order).to receive_messages(:line_items => [line_item])
+    end
+
+    it 'should restart checkout flow' do
+      expect(order).to receive(:restart_checkout_flow).once
+      subject
+    end
+
+    it 'should have error message' do
+      subject
+      expect(order.errors[:base]).to include(Spree.t(:insufficient_stock_lines_present))
+    end
+
+    it 'should be false' do
+      expect(subject).to be_falsey
+    end
+  end
+
   context "empty!" do
     let(:order) { stub_model(Spree::Order, item_count: 2) }
 


### PR DESCRIPTION
This PR tries to handle the case where at the final stages of checkout, inventory is sniped from the user. Currently, the validation below kicks in and the checkout stops. The order is left as 'complete' with no shipping or payments.

https://github.com/spree/spree/blob/master/core/app/models/spree/stock_item.rb#L11

Unfortunately the user can't recover the order and remove the offending items and re-checkout due to our API client implementation of not letting a user edit a "complete" order (which seems to be sensible). The end result is that the cart has just disappeared. :disappointed: 

This PR attempts to fix this by making a call to `ensure_line_items_are_in_stock` before complete, and having that implementation re-set checkout so the state can go back to `cart`. This should let the user make the appropriate changes.

Forgot to mention that the variant has to have inventory tracked and non-backorderable. Easiest way to replicate is to add an item to cart...get to the last steps of checkout, reduce inventory in Admin, then push the complete button.
