### PR TITLE
Update ruby version for circle builds

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ machine:
   services:
     - postgresql
   ruby:
-    version: 2.1.3
+    version: 2.1.4
 dependencies:
   override:
     - ./build-ci.rb install


### PR DESCRIPTION
I think it makes sense to test against the latest stable version. As its also the one we run in production I'd love to make sure all development in spree is done against this one.
