### PR TITLE
Fix Order#merge! for custom comparison hooks.

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -446,7 +446,7 @@ module Spree
         current_line_item = self.line_items.detect { |my_li|
                       my_li.variant == other_order_line_item.variant &&
                       self.line_item_comparison_hooks.all? { |hook|
-                        self.send(hook, my_li, other_order_line_item)
+                        self.send(hook, my_li, other_order_line_item.serializable_hash)
                       }
                     }
         if current_line_item

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -295,14 +295,12 @@ describe Spree::Order, :type => :model do
 
       context "2 equal line items" do
         before do
-          allow(order_1).to receive(:foos_match).and_return(true)
-
-          order_1.contents.add(variant, 1, {foos: {}})
-          order_2.contents.add(variant, 1, {foos: {}})
+          @line_item_1 = order_1.contents.add(variant, 1, {foos: {}})
+          @line_item_2 = order_2.contents.add(variant, 1, {foos: {}})
         end
 
         specify do
-          #order_1.should_receive(:foos_match)
+          expect(order_1).to receive(:foos_match).with(@line_item_1, kind_of(Hash)).and_return(true)
           order_1.merge!(order_2)
           expect(order_1.line_items.count).to eq(1)
 


### PR DESCRIPTION
Custom comparison hooks expect a Hash as `options` parameter,
but a LineItem object was passed instead.
