### PR TITLE
Fix Asset position for different viewables.

### DIFF
--- a/core/app/models/spree/asset.rb
+++ b/core/app/models/spree/asset.rb
@@ -1,6 +1,6 @@
 module Spree
   class Asset < Spree::Base
     belongs_to :viewable, polymorphic: true, touch: true
-    acts_as_list scope: :viewable
+    acts_as_list scope: [:viewable_id, :viewable_type]
   end
 end

--- a/core/spec/models/spree/asset_spec.rb
+++ b/core/spec/models/spree/asset_spec.rb
@@ -11,4 +11,15 @@ describe Spree::Asset, :type => :model do
       end.to change { product.reload.updated_at }
     end
   end
+
+  describe "#acts_as_list scope" do
+    it "should start from first position for different viewables" do
+      asset1 = Spree::Asset.create(viewable_type: 'Spree::Image', viewable_id: 1)
+      asset2 = Spree::Asset.create(viewable_type: 'Spree::LineItem', viewable_id: 1)
+
+      expect(asset1.position).to eq 1
+      expect(asset2.position).to eq 1
+    end
+  end
+
 end


### PR DESCRIPTION
As per [Using acts_as_list in a polymorphic scope](http://jakeboxer.com/blog/2011/10/09/using-acts-as-list-in-a-polymorphic-scope/) `acts_as_list` simply appends `id` to the passed symbol to create a scope. 

The fix should apply a scope to the complete `viewable`
