### PR TITLE
remove permitted_resource_params as it is already present in resource co...

### DIFF
--- a/backend/app/controllers/spree/admin/reimbursements_controller.rb
+++ b/backend/app/controllers/spree/admin/reimbursements_controller.rb
@@ -33,12 +33,6 @@ module Spree
       def load_simulated_refunds
         @reimbursement_objects = @reimbursement.simulate
       end
-
-      # TODO: Remove this when https://github.com/spree/spree/pull/5158 gets merged in
-      def permitted_resource_params
-        params[object_name].present? ? super : ActionController::Parameters.new
-      end
-
     end
   end
 end


### PR DESCRIPTION
https://github.com/spree/spree/pull/5158 is merged and resource_controller now uses the method, so removing the duplication as already mentioned too.
