### PR TITLE
Food For Thought - Introduce Active Model Better Errors to API

### DIFF
--- a/api/app/views/spree/api/errors/invalid_resource.v1.rabl
+++ b/api/app/views/spree/api/errors/invalid_resource.v1.rabl
@@ -1,3 +1,7 @@
 object false
 node(:error) { I18n.t(:invalid_resource, :scope => "spree.api") }
 node(:errors) { @resource.errors.to_hash }
+node(:error_codes) do
+  @resource.errors.set_reporter(:hash, :machine)
+  @resource.errors.to_hash
+end

--- a/api/lib/spree/api/controller_setup.rb
+++ b/api/lib/spree/api/controller_setup.rb
@@ -1,4 +1,5 @@
 require 'spree/api/responders'
+require 'active_model/better_errors'
 
 module Spree
   module Api

--- a/api/spec/controllers/spree/api/addresses_controller_spec.rb
+++ b/api/spec/controllers/spree/api/addresses_controller_spec.rb
@@ -29,10 +29,10 @@ module Spree
       it "receives the errors object if address is invalid" do
         api_put :update, :id => @address.id, :order_id => @order.number,
                          :address => { :address1 => "" }
-
         expect(json_response['error']).not_to be_nil
         expect(json_response['errors']).not_to be_nil
         expect(json_response['errors']['address1'].first).to eq "can't be blank"
+        expect(json_response['error_codes']['address1'].first).to eq({'type' => 'blank'})
       end
     end
 

--- a/api/spree_api.gemspec
+++ b/api/spree_api.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = version
 
   gem.add_dependency 'spree_core', version
+  gem.add_dependency 'active_model-better_errors', '~> 1.6.2'
   gem.add_dependency 'rabl', '~> 0.9.4.pre1'
   gem.add_dependency 'versioncake', '~> 2.3.1'
 end


### PR DESCRIPTION
I'm kinda of half expecting this PR to be rejected but here we go....

Right now, API errors are really hard to digest from a client perspective because we are forced to bind to translation messages. This was first encountered with apply_promo_codes and addressed by storing the translation code on the model:

https://github.com/spree/spree/commit/feb143b0477d2850facd59044c43d0e01276bb37

I want to propose a more global change to start using the Spree translation symbols as error codes along with the existing Active Model error messages. This is done via the active_model-better_errors gem. I thought this was a better approach than monkeying ActiveModel::Errors, and based on my understanding of the code, there's no other way where it keeps track of the translation symbols once a message is added.

https://github.com/rails/rails/blob/master/activemodel/lib/active_model/errors.rb#L299-L307

So we introduce this new gem, and then we display error_codes in the various RABL locations where we want API friendly error messages vs human friendly error messages.

I'm open to ideas here, but the current API feels a tad brittle, especially as I try to handle inventory insufficient issues during our API driven checkout process.
