### PR TITLE
Show total in stock in variant payload of API

### DIFF
--- a/api/app/views/spree/api/variants/small.v1.rabl
+++ b/api/app/views/spree/api/variants/small.v1.rabl
@@ -6,6 +6,7 @@ node(:display_price) { |p| p.display_price.to_s }
 node(:options_text) { |v| v.options_text }
 node(:in_stock) { |v| v.in_stock? }
 node(:is_backorderable) { |v| v.is_backorderable? }
+node(:total_on_hand) { |v| v.total_on_hand }
 
 child :option_values => :option_values do
   attributes *option_value_attributes

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -167,24 +167,41 @@ module Spree
       expect(json_response["adjustments"]).to be_empty
     end
 
-    context 'when shipment adjustments are present' do
+    describe 'GET #show' do
+      let(:order) { create :order_with_line_items }
       let(:adjustment) { FactoryGirl.create(:adjustment, order: order) }
+
+      subject { api_get :show, id: order.to_param }
 
       before do
         allow_any_instance_of(Order).to receive_messages :user => current_api_user
-        shipment = FactoryGirl.create(:shipment, order: order)
-        shipment.adjustments << adjustment
       end
 
-      subject { api_get :show, :id => order.to_param }
+      context 'when inventory information is present' do
+        it 'contains stock information on variant' do
+          subject
+          variant = json_response['line_items'][0]['variant']
+          expect(variant).to_not be_nil
+          expect(variant['in_stock']).to eq(false)
+          expect(variant['total_on_hand']).to eq(0)
+          expect(variant['is_backorderable']).to eq(true)
+        end
+      end
 
-      it 'contains adjustments in JSON' do
-        subject
-        # Test to insure shipment has adjustments
-        shipment = json_response['shipments'][0]
-        expect(shipment).to_not be_nil
-        expect(shipment['adjustments'][0]).not_to be_empty
-        expect(shipment['adjustments'][0]['label']).to eq(adjustment.label)
+      context 'when shipment adjustments are present' do
+        before do
+          order.shipments.first.adjustments << adjustment
+        end
+
+        it 'contains adjustments on shipment' do
+          subject
+
+          # Test to insure shipment has adjustments
+          shipment = json_response['shipments'][0]
+          expect(shipment).to_not be_nil
+          expect(shipment['adjustments'][0]).not_to be_empty
+          expect(shipment['adjustments'][0]['label']).to eq(adjustment.label)
+        end
       end
     end
 


### PR DESCRIPTION
Showing a simple in_stock true / false doesn't provide the right granularity when we are trying to inform the user that they have X items in their cart but we only have Y in stock, please adjust their quantity. We still want people to have the chance to checkout with what they have.

This change adds the `total_on_hand` to the RABL.

This might occur for resurrected carts that are X months old, or when we bounce a user out of checkout for inventory reasons back to their cart to make corrections.

Question: 

Do we need to also cache this total_in_hand if it us being used in Rabl if this is being cached?

https://github.com/spree/spree/blob/master/core/app/models/spree/variant.rb#L185-L189
