### PR TITLE
Add is_backorderable to variant and small RABL view

### DIFF
--- a/api/app/views/spree/api/variants/small.v1.rabl
+++ b/api/app/views/spree/api/variants/small.v1.rabl
@@ -5,6 +5,7 @@ attributes *variant_attributes
 node(:display_price) { |p| p.display_price.to_s }
 node(:options_text) { |v| v.options_text }
 node(:in_stock) { |v| v.in_stock? }
+node(:is_backorderable) { |v| v.is_backorderable? }
 
 child :option_values => :option_values do
   attributes *option_value_attributes

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -23,7 +23,7 @@ module Spree
     has_one :default_price,
       -> { where currency: Spree::Config[:currency] },
       class_name: 'Spree::Price', inverse_of: :variant
-      
+
     delegate_belongs_to :default_price, :display_price, :display_amount, :price, :price=, :currency
 
     has_many :prices,
@@ -64,6 +64,10 @@ module Spree
     # returns number of units currently on backorder for this variant.
     def on_backorder
       inventory_units.with_state('backordered').size
+    end
+
+    def is_backorderable?
+      Spree::Stock::Quantifier.new(self).backorderable?
     end
 
     def options_text
@@ -167,7 +171,7 @@ module Spree
       options.keys.map { |key|
         m = "#{options[key]}_price_modifier_amount".to_sym
         if self.respond_to? m
-          self.send(m, options[key]) 
+          self.send(m, options[key])
         else
           0
         end

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -351,6 +351,16 @@ describe Spree::Variant, :type => :model do
     end
   end
 
+  describe '#is_backorderable' do
+    let(:variant) { build(:variant) }
+    subject { variant.is_backorderable? }
+
+    it 'should invoke Spree::Stock::Quantifier' do
+      expect_any_instance_of(Spree::Stock::Quantifier).to receive(:backorderable?) { true }
+      subject
+    end
+  end
+
   describe '#total_on_hand' do
     it 'should be infinite if track_inventory_levels is false' do
       Spree::Config[:track_inventory_levels] = false


### PR DESCRIPTION
Uses the Stock::Quantifier to determine if a variant is backorderable. Adds it to the JSON API in the small RABL view. 
