### PR TITLE
Update MoveOrderTokenFromTokenizedPermission migration to work w/ jruby

### DIFF
--- a/core/db/migrate/20140530024945_move_order_token_from_tokenized_permission.rb
+++ b/core/db/migrate/20140530024945_move_order_token_from_tokenized_permission.rb
@@ -10,7 +10,7 @@ class MoveOrderTokenFromTokenizedPermission < ActiveRecord::Migration
       Spree::Order.includes(:tokenized_permission).each do |o|
         o.update_column :guest_token, o.tokenized_permission.token
       end
-    when 'Mysql2'
+    when 'Mysql2', 'MySQL'
       execute "UPDATE spree_orders, spree_tokenized_permissions
                SET spree_orders.guest_token = spree_tokenized_permissions.token
                WHERE spree_tokenized_permissions.permissable_id = spree_orders.id


### PR DESCRIPTION
jruby mysql adapter uses [adapter_name 'MySQL'](https://github.com/jruby/activerecord-jdbc-adapter/blob/master/lib/arjdbc/mysql/adapter.rb#L109). Not recognizing this causes migrations to bomb out on jruby due to invalid SQL syntax.
