### PR TITLE
Only charge for unreturned exchanges when the new item is in the shipped state.

### DIFF
--- a/core/lib/tasks/exchanges.rake
+++ b/core/lib/tasks/exchanges.rake
@@ -4,8 +4,8 @@ namespace :exchanges do
   task charge_unreturned_items: :environment do
 
     unreturned_return_items =  Spree::ReturnItem.awaiting_return.exchange_processed.joins(:exchange_inventory_unit).where([
-      "spree_inventory_units.created_at < :days_ago",
-      days_ago: Spree::Config[:expedited_exchanges_days_window].days.ago
+      "spree_inventory_units.created_at < :days_ago AND spree_inventory_units.state = :iu_state",
+      days_ago: Spree::Config[:expedited_exchanges_days_window].days.ago, iu_state: "shipped"
     ]).to_a
 
     # Determine that a return item has already been deemed unreturned and therefore charged


### PR DESCRIPTION
- In the case when the customer returns the new item, we don't want to
  charge them for changing their mind.
- In the case when the shipment was caught on its way out and is still
  'on hand', but the customer has not received inventory, we don't want
  to charge them for our internal mistakenly placed shipment.
