### PR TITLE
Validate authenticity token on all actions but populate

### DIFF
--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -10,7 +10,7 @@ module Spree
 
     before_action :assign_order_with_lock, only: :update
     before_action :apply_coupon_code, only: :update
-    skip_before_action :verify_authenticity_token
+    skip_before_action :verify_authenticity_token, only: [:populate]
 
     def show
       @order = Order.find_by_number!(params[:id])


### PR DESCRIPTION
Since https://github.com/MountainRoseHerbs/spree/commit/95ea57058ab1c5e722b327b10747cd41e68a4deb the authenticity token validation was disabled for all cart actions. This is not a good idea. Actions like `#empty` and `#update`, ... should NOT be easily CSRF-able.

I agree that allowing populations without CSRF token makes _some_ sense. I see options to work around this issue, like edge side includes etc. But lets at least do a _mimimal_ negative security impact solution by default.

This commit is an incremental improvement in that sense.

This commit has no specs. As I typically do NOT specify behavior of the framework (unless its dynamically invoked).

I request a backport to at least `2-3-stable`.
