### PR TITLE
Skipping the set_current_order before filter on the cart link action

### DIFF
--- a/frontend/app/controllers/spree/store_controller.rb
+++ b/frontend/app/controllers/spree/store_controller.rb
@@ -2,6 +2,8 @@ module Spree
   class StoreController < Spree::BaseController
     include Spree::Core::ControllerHelpers::Order
 
+    skip_before_action :set_current_order, only: :cart_link
+
     def unauthorized
       render 'spree/shared/unauthorized', :layout => Spree::Config[:layout], :status => 401
     end


### PR DESCRIPTION
We're finding on our production site that the `cart_link` action is one of the busiest actions on the site.

Investigating further we found that it's loading the current order twice becuase the `set_current_order` before filter is loading the order and then the view and action are using the `simple_current_order` helper instead.

So this PR simply skips the `set_current_order` before action on the `cart_link`.
