### PR TITLE
Include classification position with taxons, slight undo of #5569

### DIFF
--- a/api/app/views/spree/api/products/show.v1.rabl
+++ b/api/app/views/spree/api/products/show.v1.rabl
@@ -22,6 +22,10 @@ child :product_properties => :product_properties do
   attributes *product_property_attributes
 end
 
-child :taxons => :taxons do
-  extends "spree/api/taxons/show"
+child :classifications => :classifications do
+  attributes :taxon_id, :position
+
+  child(:taxon) do
+    extends "spree/api/taxons/show"
+  end
 end

--- a/api/spec/controllers/spree/api/products_controller_spec.rb
+++ b/api/spec/controllers/spree/api/products_controller_spec.rb
@@ -196,7 +196,8 @@ module Spree
                                                                          :product_id,
                                                                          :property_name])
 
-        expect(json_response["taxons"].first).to have_attributes([:id, :name, :pretty_name, :permalink, :taxonomy_id, :parent_id])
+        expect(json_response["classifications"].first).to have_attributes([:taxon_id, :position, :taxon])
+        expect(json_response["classifications"].first['taxon']).to have_attributes([:id, :name, :pretty_name, :permalink, :taxonomy_id, :parent_id])
       end
 
       context "tracking is disabled" do


### PR DESCRIPTION
Spree has really useful classification position scores that are adjustable in the Admin. Let's expose this over the Product payload in the API and nest taxons under there.

I've broken the JSON contract that I provided in this PR below; it feels more logical to have classifications -> taxon, rather than two peer nodes of classifications and taxons, and certainly better than duplicating taxons as full payloads. I think this is ok since I'm the idiot that introduced taxons to begin with. 

Willing to keep the contract and have them both as peers.

https://github.com/spree/spree/pull/5569

If I had known about the slick classification Admin UI, I would've gone straight to this solution. :)
