### PR TITLE
Better Handle of Destroyed Variants in Order Line Items

### DIFF
--- a/api/app/controllers/spree/api/line_items_controller.rb
+++ b/api/app/controllers/spree/api/line_items_controller.rb
@@ -24,7 +24,7 @@ module Spree
 
       def destroy
         @line_item = find_line_item
-        variant = Spree::Variant.find(@line_item.variant_id)
+        variant = Spree::Variant.unscoped.find(@line_item.variant_id)
         @order.contents.remove(variant, @line_item.quantity)
         respond_with(@line_item, status: 204)
       end

--- a/api/app/views/spree/api/variants/small.v1.rabl
+++ b/api/app/views/spree/api/variants/small.v1.rabl
@@ -7,6 +7,7 @@ node(:options_text) { |v| v.options_text }
 node(:in_stock) { |v| v.in_stock? }
 node(:is_backorderable) { |v| v.is_backorderable? }
 node(:total_on_hand) { |v| v.total_on_hand }
+node(:is_destroyed) { |v| v.destroyed? }
 
 child :option_values => :option_values do
   attributes *option_value_attributes

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -185,6 +185,7 @@ module Spree
           expect(variant['in_stock']).to eq(false)
           expect(variant['total_on_hand']).to eq(0)
           expect(variant['is_backorderable']).to eq(true)
+          expect(variant['is_destroyed']).to eq(false)
         end
       end
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -430,6 +430,19 @@ module Spree
       line_items.select(&:insufficient_stock?)
     end
 
+    ##
+    # Check to see if any line item variants are soft, deleted.
+    # If so add error and restart checkout.
+    def ensure_line_item_variants_are_not_deleted
+      if line_items.select{ |li| li.variant.destroyed? }.present?
+        errors.add(:base, Spree.t(:deleted_variants_present))
+        restart_checkout_flow
+        false
+      else
+        true
+      end
+    end
+
     def ensure_line_items_are_in_stock
       if insufficient_stock_lines.present?
         errors.add(:base, Spree.t(:insufficient_stock_lines_present))

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -99,8 +99,10 @@ module Spree
                 before_transition from: :delivery, do: :apply_free_shipping_promotions
               end
 
+              before_transition to: :resumed, do: :ensure_line_item_variants_are_not_deleted
               before_transition to: :resumed, do: :ensure_line_items_are_in_stock
 
+              before_transition to: :complete, do: :ensure_line_item_variants_are_not_deleted
               before_transition to: :complete, do: :ensure_line_items_are_in_stock
 
               after_transition to: :complete, do: :finalize!

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -614,6 +614,7 @@ en:
     default_tax: Default Tax
     default_tax_zone: Default Tax Zone
     delete: Delete
+    deleted_variants_present: Some line items in this order have products that are no longer available.
     delivery: Delivery
     depth: Depth
     description: Description

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -540,6 +540,7 @@ describe Spree::Order, :type => :model do
     it "does not attempt to process payments" do
       allow(order).to receive_message_chain(:line_items, :present?) { true }
       allow(order).to receive(:ensure_line_items_are_in_stock) { true }
+      allow(order).to receive(:ensure_line_item_variants_are_not_deleted) { true }
       expect(order).not_to receive(:payment_required?)
       expect(order).not_to receive(:process_payments!)
       order.next!

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -181,6 +181,44 @@ describe Spree::Order, :type => :model do
     end
   end
 
+  describe '#ensure_line_item_variants_are_not_deleted' do
+    subject { order.ensure_line_item_variants_are_not_deleted }
+
+    let(:order) { create :order_with_line_items }
+
+    context 'when variant is destroyed' do
+      before do
+        allow(order).to receive(:restart_checkout_flow)
+        order.line_items.first.variant.destroy
+      end
+
+      it 'should restart checkout flow' do
+        expect(order).to receive(:restart_checkout_flow).once
+        subject
+      end
+
+      it 'should have error message' do
+        subject
+        expect(order.errors[:base]).to include(Spree.t(:deleted_variants_present))
+      end
+
+      it 'should be false' do
+        expect(subject).to be_falsey
+      end
+    end
+
+    context 'when no variants are destroyed' do
+      it 'should not restart checkout' do
+        expect(order).to receive(:restart_checkout_flow).never
+        subject
+      end
+
+      it 'should be true' do
+        expect(subject).to be_truthy
+      end
+    end
+  end
+
   describe '#ensure_line_items_are_in_stock' do
     subject { order.ensure_line_items_are_in_stock }
 


### PR DESCRIPTION
This PR tries to better handle an order checkout where there is a line item of a soft-deleted product over the API. The experience we are seeing is that a product gets soft-deleted, but there is no way for a) a user to remove it from their order due to an HTTP 422 on `Variant.find` b) any feedback that they won't be able to checkout for this.

https://github.com/spree/spree/blob/master/api/app/controllers/spree/api/line_items_controller.rb#L27

To solve this, this PR introduces:
1) An Variant.unscoped on the API Line Items #delete controller method so that the item can be found and deleted.
2) An is_destroyed field in the variant payload in orders#show so that the FE can tell the user they have N/A items in their cart.
3) Guard on the checkout state machine to insure there is no checkout with deleted variants before moving to complete.

I think this should be enough to prevent a checkout, inform the user, and let them take corrective action over the API when there are deleted variants in line items.

The alternative approach was to listen to a variant destroy and start purging line_items from incomplete orders...but this felt way more dangerous. Not sure.
