### PR TITLE
Refactor gateway options to its own class.

### DIFF
--- a/core/app/models/spree/payment/gateway_options.rb
+++ b/core/app/models/spree/payment/gateway_options.rb
@@ -1,0 +1,86 @@
+module Spree
+  class Payment
+    class GatewayOptions
+      def initialize(payment)
+        @payment = payment
+      end
+
+      def email
+        order.email
+      end
+
+      def customer
+        order.email
+      end
+
+      def customer_id
+        order.user_id
+      end
+
+      def ip
+        order.last_ip_address
+      end
+
+      def order_id
+        "#{order.number}-#{@payment.identifier}"
+      end
+
+      def shipping
+        order.ship_total * 100
+      end
+
+      def tax
+        order.additional_tax_total * 100
+      end
+
+      def subtotal
+        order.item_total * 100
+      end
+
+      def discount
+        order.promo_total * 100
+      end
+
+      def currency
+        @payment.currency
+      end
+
+      def billing_address
+        order.bill_address.try(:active_merchant_hash)
+      end
+
+      def shipping_address
+        order.ship_address.try(:active_merchant_hash)
+      end
+
+      def hash_methods
+        [
+          :email,
+          :customer,
+          :customer_id,
+          :ip,
+          :order_id,
+          :shipping,
+          :tax,
+          :subtotal,
+          :discount,
+          :currency,
+          :billing_address,
+          :shipping_address
+        ]
+      end
+
+      def to_hash
+        Hash[hash_methods.map do |method|
+          [method, send(method)]
+        end]
+      end
+
+      private
+
+      def order
+        @payment.order
+      end
+    end
+  end
+end

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -1,6 +1,12 @@
 module Spree
   class Payment < Spree::Base
     module Processing
+      extend ActiveSupport::Concern
+      included do
+        class_attribute :gateway_options_class
+        self.gateway_options_class = Spree::Payment::GatewayOptions
+      end
+
       def process!
         if payment_method && payment_method.auto_capture?
           purchase!
@@ -69,26 +75,7 @@ module Spree
 
       def gateway_options
         order.reload
-        options = { :email       => order.email,
-                    :customer    => order.email,
-                    :customer_id => order.user_id,
-                    :ip          => order.last_ip_address,
-                    # Need to pass in a unique identifier here to make some
-                    # payment gateways happy.
-                    #
-                    # For more information, please see Spree::Payment#set_unique_identifier
-                    :order_id    => gateway_order_id }
-
-        options.merge!({ :shipping => order.ship_total * 100,
-                         :tax      => order.additional_tax_total * 100,
-                         :subtotal => order.item_total * 100,
-                         :discount => order.promo_total * 100,
-                         :currency => currency })
-
-        options.merge!({ :billing_address  => order.bill_address.try(:active_merchant_hash),
-                        :shipping_address => order.ship_address.try(:active_merchant_hash) })
-
-        options
+        gateway_options_class.new(self).to_hash
       end
 
       private
@@ -188,11 +175,6 @@ module Spree
         return if payment_method.environment == Rails.env
         message = Spree.t(:gateway_config_unavailable) + " - #{Rails.env}"
         raise Core::GatewayError.new(message)
-      end
-
-      # The unique identifier to be passed in to the payment gateway
-      def gateway_order_id
-        "#{order.number}-#{self.identifier}"
       end
 
       def token_based?

--- a/core/spec/models/spree/payment/gateway_options_spec.rb
+++ b/core/spec/models/spree/payment/gateway_options_spec.rb
@@ -1,0 +1,119 @@
+require "spec_helper"
+
+RSpec.describe Spree::Payment::GatewayOptions, type: :model do
+  let(:options) { Spree::Payment::GatewayOptions.new(payment) }
+
+  let(:payment) do
+    double(
+      Spree::Payment,
+      order: order,
+      identifier: "P1566",
+      currency: "EUR"
+    )
+  end
+
+  let(:order) do
+    double(
+      Spree::Order,
+      email: "test@email.com",
+      user_id: 144,
+      last_ip_address: "0.0.0.0",
+      number: "R1444",
+      ship_total: "12.44".to_d,
+      additional_tax_total: "1.53".to_d,
+      item_total: "15.11".to_d,
+      promo_total: "2.57".to_d,
+      bill_address: bill_address,
+      ship_address: ship_address
+    )
+  end
+
+  let(:bill_address) do
+    double Spree::Address, active_merchant_hash: { bill: :address }
+  end
+  let(:ship_address) do
+    double Spree::Address, active_merchant_hash: { ship: :address }
+  end
+
+  describe "#email" do
+    subject { options.email }
+    it { should == "test@email.com" }
+  end
+
+  describe "#customer" do
+    subject { options.customer }
+    it { should == "test@email.com" }
+  end
+
+  describe "#customer_id" do
+    subject { options.customer_id }
+    it { should == 144 }
+  end
+
+  describe "#ip" do
+    subject { options.ip }
+    it { should == "0.0.0.0" }
+  end
+
+  describe "#order_id" do
+    subject { options.order_id }
+    it { should == "R1444-P1566" }
+  end
+
+  describe "#shipping" do
+    subject { options.shipping }
+    it { should == 1244 }
+  end
+
+  describe "#tax" do
+    subject { options.tax }
+    it { should == 153 }
+  end
+
+  describe "#subtotal" do
+    subject { options.subtotal }
+    it { should == 1511 }
+  end
+
+  describe "#discount" do
+    subject { options.discount }
+    it { should == 257 }
+  end
+
+  describe "#currency" do
+    subject { options.currency }
+    it { should == "EUR" }
+  end
+
+  describe "#billing_address" do
+    subject { options.billing_address }
+    it { should == { bill: :address } }
+  end
+
+  describe "#shipping_address" do
+    subject { options.shipping_address }
+    it { should == { ship: :address } }
+  end
+
+  describe "#to_hash" do
+    subject { options.to_hash }
+    let(:expected) do
+      {
+        email: "test@email.com",
+        customer: "test@email.com",
+        customer_id: 144,
+        ip: "0.0.0.0",
+        order_id: "R1444-P1566",
+        shipping: "1244".to_d,
+        tax: "153".to_d,
+        subtotal: "1511".to_d,
+        discount: "257".to_d,
+        currency: "EUR",
+        billing_address: { bill: :address },
+        shipping_address: { ship: :address }
+      }
+    end
+    it { should == expected }
+  end
+
+end


### PR DESCRIPTION
I ran in to a problem where I wanted to customize the options that are being passed along to ActiveMerchant. This is something which happens commonly, as different gateways have many different requirements.

There wasn't an easy way to add a value to the hash, so I extracted the logic in to a separate class, making it easy to customize it in the future.

``` Ruby
class CustomGatewayOptions < Spree::Payment::GatewayOptions
  def hash_methods
    super + [:extra_description]
  end
  def extra_description
    "This is needed for some reason"
  end
end
```

Then in an initializer:

``` Ruby
Spree.config do |config|
  config.class_gateway_options = 'CustomGatewayOptions'
end
```

This will allow these options to individually be changes by stores, and they can remove or add options as needed by overriding hash_methods.
