### PR TITLE
Allow Admins To Flush Rails Cache

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/general_settings.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/general_settings.js.coffee
@@ -1,0 +1,13 @@
+$(@).ready( ->
+  $('[data-hook=general_settings_clear_cache] #clear_cache').click ->
+    $.ajax
+      type: 'POST'
+      url: '/admin/general_settings/clear_cache'
+      success: ->
+        show_flash 'success', "Cache was flushed."
+      error: (msg) ->
+        if msg.responseJSON["error"]
+          show_flash 'error', msg.responseJSON["error"]
+        else
+          show_flash 'error', "There was a problem while flushing cache."
+)

--- a/backend/app/controllers/spree/admin/general_settings_controller.rb
+++ b/backend/app/controllers/spree/admin/general_settings_controller.rb
@@ -31,6 +31,11 @@ module Spree
         end
       end
 
+      def clear_cache
+        Rails.cache.clear
+        head :no_content
+      end
+
       private
       def store_params
         params.require(:store).permit(permitted_params)

--- a/backend/app/views/spree/admin/general_settings/edit.html.erb
+++ b/backend/app/views/spree/admin/general_settings/edit.html.erb
@@ -60,6 +60,15 @@
                 </div>
             <% end %>
           </fieldset>
+          <fieldset class="security no-border-bottom">
+            <legend align="center"><%= Spree.t(:clear_cache)%></legend>
+            <div>
+              <%= Spree.t(:clear_cache_warning) %>
+            </div>
+            <div class="field" data-hook="general_settings_clear_cache">
+              <%= button Spree.t(:clear_cache), '', 'button', id: "clear_cache" %>
+            </div>
+          </fieldset>
         </div>
         <div class="omega six columns">
           <fieldset class="currency no-border-bottom">

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -113,6 +113,7 @@ Spree::Core::Engine.add_routes do
     resource :general_settings do
       collection do
         post :dismiss_alert
+        post :clear_cache
       end
     end
 

--- a/backend/spec/controllers/spree/admin/general_settings_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/general_settings_controller_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Spree::Admin::GeneralSettingsController, type: :controller do
+  let(:user) { create(:user) }
+  let(:mock_user) { mock_model Spree.user_class }
+
+  before do
+    allow(controller).to receive_messages :spree_current_user => user
+    user.spree_roles << Spree::Role.find_or_create_by(name: 'admin')
+  end
+
+  context '#clear_cache' do
+    it 'grant access to users with an admin role' do
+      spree_post :clear_cache
+      expect(response.status).to eq(204)
+    end
+  end
+end

--- a/backend/spec/features/admin/configuration/general_settings_spec.rb
+++ b/backend/spec/features/admin/configuration/general_settings_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "General Settings", :type => :feature do
+describe "General Settings", type: :feature, js: true do
   stub_authorization!
 
   before(:each) do
@@ -29,6 +29,17 @@ describe "General Settings", :type => :feature do
       assert_successful_update_message(:general_settings)
       expect(find("#store_name").value).to eq("Spree Demo Site99")
       expect(find("#store_mail_from_address").value).to eq("spree@example.org")
+    end
+  end
+
+  context "clearing the cache" do
+    it "should clear the cache" do
+      expect(page).to_not have_content(Spree.t(:clear_cache_ok))
+      expect(page).to have_content(Spree.t(:clear_cache_warning))
+
+      click_button "Clear Cache"
+
+      expect(page).to have_content(Spree.t(:clear_cache_ok))
     end
   end
 end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -528,6 +528,9 @@ en:
     choose_dashboard_locale: Choose Dashboard Locale
     choose_location: Choose location
     city: City
+    clear_cache: Clear Cache
+    clear_cache_ok: Cache was flushed
+    clear_cache_warning: Clearing cache will temporarily reduce the performance of your store.
     click_and_drag_on_the_products_to_sort_them: Click and drag on the products to sort them.
     clone: Clone
     close: Close


### PR DESCRIPTION
This PR puts a simple clear Rails cache button on the Admin -> General Settings.

This isn't a long term fix for all of the necessary cache busting that needs to happen when models change, but this is hoping to alleviate the tons of requests from API clients, other engineers, E-Com managers, to "why haven't these changes taken effect" i.e. when re-ordering classification position for products and taxons. The end result is some engineer having to log to console to fire off a a `Rails.cache.flush` cause "it's important that something on the store changes".

On a side note, I remember Magento having both a clear cache and clear object cache. Hehehe. Good times.

Thoughts welcome....

![screen shot 2014-11-14 at 6 42 11 pm](https://cloud.githubusercontent.com/assets/134368/5055236/7350cbf4-6c2e-11e4-8fb8-275ba81cdbe2.png)

![screen shot 2014-11-14 at 6 42 17 pm](https://cloud.githubusercontent.com/assets/134368/5055237/79645934-6c2e-11e4-99b3-4daa2a1c8aa9.png)
