### PR TITLE
[backend] Hiding option values handle if object is not persisted

### DIFF
--- a/backend/app/views/spree/admin/option_types/_option_value_fields.html.erb
+++ b/backend/app/views/spree/admin/option_types/_option_value_fields.html.erb
@@ -1,9 +1,11 @@
 <tr class="option_value fields" id="spree_<%= dom_id(f.object) %>"  data-hook="option_value" class="<%= cycle('odd', 'even')%>">
-  <td class="no-border">
-    <span class="handle"></span>
-    <%= f.hidden_field :id %>
-  </td>
-  <td class="name"><%= f.text_field :name %></td>
+  <% if f.object.persisted? %>
+    <td class="no-border">
+      <span class="handle"></span>
+      <%= f.hidden_field :id %>
+    </td>
+  <% end %>
+  <td colspan="<%= f.object.persisted? ? '' : '2' %>" class="name"><%= f.text_field :name %></td>
   <td class="presentation"><%= f.text_field :presentation %></td>
   <td class="actions"><%= link_to_remove_fields Spree.t(:remove), f, :no_text => true %></td>
 </tr>

--- a/backend/app/views/spree/admin/option_types/edit.html.erb
+++ b/backend/app/views/spree/admin/option_types/edit.html.erb
@@ -32,15 +32,8 @@
         </tr>
       </thead>
       <tbody id="option_values">
-        <% if @option_type.option_values.empty? %>
-          <tr id="none" data-hook="option_none" class="<%= cycle('odd', 'even')%>">
-            <td colspan="2"><%= Spree.t(:none) %></td>
-            <td class="actions"></td>
-          </tr>
-        <% else %>
-          <%= f.fields_for :option_values do |option_value_form| %>
-            <%= render :partial => 'option_value_fields', :locals => { :f => option_value_form } %>
-          <% end %>
+        <%= f.fields_for :option_values, @option_values do |option_value_form| %>
+          <%= render :partial => 'option_value_fields', :locals => { :f => option_value_form } %>
         <% end %>
       </tbody>
     </table>


### PR DESCRIPTION
Hi @JDutil,

This pull request references the issue #4836.

Since the [update_positions](https://github.com/spree/spree/blob/eaaea6cd21fb5dfbf06a00c871b12934d62ec67e/backend/app/controllers/spree/admin/resource_controller.rb#L72-L80) method did not have any verification on the `params[:position]` null values, I thought the [update_values_positions](https://github.com/spree/spree/blob/eaaea6cd21fb5dfbf06a00c871b12934d62ec67e/backend/app/controllers/spree/admin/option_types_controller.rb#L6-L15) should not have this verification as well, and it should be done on the front end.

As the `@option_type.option_values` are built with the `before_action` [setup_new_option_value](https://github.com/spree/spree/blob/eaaea6cd21fb5dfbf06a00c871b12934d62ec67e/backend/app/controllers/spree/admin/option_types_controller.rb#L33-L35), the only verification I thought it should be done for showing the sorting handle is the persisted state of the option_values nested objects, as you can see in the `_option_value_fields.html.erb` partial of this pull request.

I also noticed that the verification of the emptiness of `@option_type.option_values` on the [option_types/edit.html.erb - L35-L44](https://github.com/spree/spree/blob/eaaea6cd21fb5dfbf06a00c871b12934d62ec67e/backend/app/views/spree/admin/option_types/edit.html.erb#L35-L44) always returned false because of the mentioned `before_action`, so I removed it.

Please, let me know if this helps, or I should work on something else :)
