### PR TITLE
Add actionable? to Promotion::Rules::Taxon

### DIFF
--- a/core/app/models/spree/promotion/rules/taxon.rb
+++ b/core/app/models/spree/promotion/rules/taxon.rb
@@ -26,6 +26,10 @@ module Spree
           eligibility_errors.empty?
         end
 
+        def actionable?(line_item)
+          taxon_product_ids.include? line_item.variant.product_id
+        end
+
         def taxon_ids_string
           taxons.pluck(:id).join(',')
         end
@@ -54,6 +58,10 @@ module Spree
 
         def taxons_in_order_including_parents(order)
           order_taxons_in_taxons_and_children(order).inject([]){ |taxons, taxon| taxons << taxon.self_and_ancestors }.flatten.uniq
+        end
+
+        def taxon_product_ids
+          Spree::Product.joins(:taxons).where(spree_taxons: {id: taxons.pluck(:id)}).pluck(:id).uniq
         end
       end
     end

--- a/core/spec/models/spree/promotion/rules/taxon_spec.rb
+++ b/core/spec/models/spree/promotion/rules/taxon_spec.rb
@@ -14,7 +14,6 @@ describe Spree::Promotion::Rules::Taxon, :type => :model do
 
     context 'with any match policy' do
       before do
-        order.line_items << create(:line_item, product: create(:product, taxons: [create(:taxon)]))
         rule.preferred_match_policy = 'any'
       end
 
@@ -22,6 +21,22 @@ describe Spree::Promotion::Rules::Taxon, :type => :model do
         order.products.first.taxons << taxon
         rule.taxons << taxon
         expect(rule).to be_eligible(order)
+      end
+
+      context 'when order contains items from different taxons' do
+        before do
+          order.products.first.taxons << taxon
+          rule.taxons << taxon
+        end
+
+        it 'should act on a product within the eligible taxon' do
+          expect(rule).to be_actionable(order.line_items.last)
+        end
+
+        it 'should not act on a product in another taxon' do
+          order.line_items << create(:line_item, product: create(:product, taxons: [taxon2]))
+          expect(rule).not_to be_actionable(order.line_items.last)
+        end
       end
 
       context "when order does not have any prefered taxon" do
@@ -45,7 +60,7 @@ describe Spree::Promotion::Rules::Taxon, :type => :model do
       end
     end
 
-    context 'with any match policy' do
+    context 'with all match policy' do
       before do
         rule.preferred_match_policy = 'all'
       end


### PR DESCRIPTION
The taxon promotion rule introduced in #4477 applied the promotion to all line items, regardless of their associated taxons. This fix ensures that the promotion will only be applied to products within the specified taxons of the promotion rule.
