### PR TITLE
support callbacks on clear cache, support custom callbacks

### DIFF
--- a/backend/app/controllers/spree/admin/general_settings_controller.rb
+++ b/backend/app/controllers/spree/admin/general_settings_controller.rb
@@ -1,6 +1,8 @@
 module Spree
   module Admin
     class GeneralSettingsController < Spree::Admin::BaseController
+      include Spree::Backend::Callbacks
+
       before_action :set_store
 
       def edit
@@ -33,6 +35,7 @@ module Spree
 
       def clear_cache
         Rails.cache.clear
+        invoke_callbacks(:clear_cache, :after)
         head :no_content
       end
 

--- a/backend/lib/spree/backend/callbacks.rb
+++ b/backend/lib/spree/backend/callbacks.rb
@@ -28,6 +28,11 @@ module Spree
           @callbacks ||= {}
           @callbacks[:destroy] ||= Spree::ActionCallbacks.new
         end
+
+        def custom_callback(action)
+          @callbacks ||= {}
+          @callbacks[action] ||= Spree::ActionCallbacks.new
+        end
       end
 
       protected

--- a/backend/spec/controllers/spree/admin/general_settings_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/general_settings_controller_spec.rb
@@ -2,17 +2,40 @@ require 'spec_helper'
 
 describe Spree::Admin::GeneralSettingsController, type: :controller do
   let(:user) { create(:user) }
-  let(:mock_user) { mock_model Spree.user_class }
 
   before do
     allow(controller).to receive_messages :spree_current_user => user
     user.spree_roles << Spree::Role.find_or_create_by(name: 'admin')
   end
 
-  context '#clear_cache' do
-    it 'grant access to users with an admin role' do
-      spree_post :clear_cache
-      expect(response.status).to eq(204)
+  describe '#clear_cache' do
+    subject { spree_post :clear_cache }
+
+    shared_examples 'a HTTP 204 response' do
+      it 'grant access to users with an admin role' do
+        subject
+        expect(response.status).to eq(204)
+      end
+    end
+
+    context 'when no callback' do
+      it_behaves_like 'a HTTP 204 response'
+    end
+
+    context 'when callback implemented' do
+      Spree::Admin::GeneralSettingsController.class_eval do
+        custom_callback(:clear_cache).after :foo
+
+        def foo
+          # Make a call to Akamai, CloudFlare, etc invalidation....
+        end
+      end
+
+      before do
+        expect(controller).to receive(:foo).once
+      end
+
+      it_behaves_like 'a HTTP 204 response'
     end
   end
 end


### PR DESCRIPTION
This is a follow up to the PR below. It adds a callback that allows developers to then make cache invalidation calls elsewhere, i.e. Akamai API. etc. Also adds a change to the callbacks concern to allow for custom actions.

https://github.com/spree/spree/pull/5615

Apologies for not getting this in on one PR....
