### PR TITLE
Authorization fix for shipment manifests

### DIFF
--- a/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
@@ -20,7 +20,7 @@
     <td class="item-total align-center"><%= line_item_shipment_price(line_item, item.quantity) %></td>
     <% unless shipment.shipped? %>
       <td class="cart-item-delete actions" data-hook="cart_item_delete">
-        <% if can? :update, item %>
+        <% if can? :update, shipment %>
           <%= link_to '', '#', :class => 'save-item icon_link icon-ok no-text with-tip', :data => {'shipment-number' => shipment.number, 'variant-id' => item.variant.id, :action => 'save'}, :title => Spree.t('actions.save'), :style => 'display: none' %>
           <%= link_to '', '#', :class => 'cancel-item icon_link icon-cancel no-text with-tip', :data => {:action => 'cancel'}, :title => Spree.t('actions.cancel'), :style => 'display: none' %>
           <%= link_to '', '#', :class => 'edit-item icon_link icon-edit no-text with-tip', :data => {:action => 'edit'}, :title => Spree.t('edit') %>


### PR DESCRIPTION
When editing a shipment with limited permissions (e.g. a point of sale role), the shipment manifest authorization fails. Specifically this code:

```
<% shipment.manifest.each do |item| %>
[...]
<% if can? :update, item %>
```

The item variable is a shipment manifest, which is an OpenStruct. This doesn't fit well into the authorization scheme used throughout.

To fix, I made the authorization check be against the shipment as a whole:

```
<% if can? :update, shipment %>
```

I made the update against 2-0-stable, as that's the version I'm using - however, a quick look indicates this code is still being used in master, so presumably all release branches should be updated.
