### PR TITLE
Move store credits in core

### DIFF
--- a/api/app/controllers/spree/api/store_credit_events_controller.rb
+++ b/api/app/controllers/spree/api/store_credit_events_controller.rb
@@ -1,0 +1,9 @@
+class Spree::Api::StoreCreditEventsController < Spree::Api::BaseController
+  def mine
+    if current_api_user.persisted?
+      @store_credit_events = current_api_user.store_credit_events.exposed_events.page(params[:page]).per(params[:per_page]).reverse_chronological
+    else
+      render "spree/api/errors/unauthorized", status: :unauthorized
+    end
+  end
+end

--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -28,7 +28,8 @@ module Spree
         :stock_location_attributes,
         :stock_movement_attributes,
         :stock_item_attributes,
-        :promotion_attributes
+        :promotion_attributes,
+        :store_credit_history_attributes
       ]
 
       mattr_reader *ATTRIBUTES
@@ -75,7 +76,14 @@ module Spree
         :user_id, :created_at, :updated_at, :completed_at, :payment_total,
         :shipment_state, :payment_state, :email, :special_instructions, :channel,
         :included_tax_total, :additional_tax_total, :display_included_tax_total,
-        :display_additional_tax_total, :tax_total, :currency
+        :display_additional_tax_total, :tax_total, :currency, :covered_by_store_credit,
+        :display_total_applicable_store_credit, :order_total_after_store_credit,
+        :display_order_total_after_store_credit, :total_applicable_store_credit,
+        :display_total_available_store_credit, :display_store_credit_remaining_after_capture
+      ]
+
+      @@store_credit_history_attributes = [
+        :display_amount, :display_user_total_amount, :display_action, :display_event_date
       ]
 
       @@line_item_attributes = [:id, :quantity, :price, :variant_id]

--- a/api/spec/controllers/spree/api/store_credit_events_controller_spec.rb
+++ b/api/spec/controllers/spree/api/store_credit_events_controller_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+describe Spree::Api::StoreCreditEventsController do
+  render_views
+
+  stub_api_controller_authentication!
+
+  describe "GET mine" do
+
+    subject { spree_get :mine, { format: :json } }
+
+    before { controller.stub(current_api_user: current_api_user) }
+
+    context "the current api user is not persisted" do
+      let(:current_api_user) { double(persisted?: false) }
+
+      before { subject }
+
+      it "returns a 401" do
+        response.status.should eq 401
+      end
+    end
+
+    context "the current api user is authenticated" do
+      let(:current_api_user) { order.user }
+      let(:order) { create(:order, line_items: [line_item]) }
+
+      context "the user doesn't have store credit" do
+        let(:current_api_user) { create(:user) }
+
+        before { subject }
+
+        it "should set the events variable to empty list" do
+          assigns(:store_credit_events).should eq []
+        end
+
+        it "returns a 200" do
+          subject.status.should eq 200
+        end
+      end
+
+      context "the user has store credit" do
+        let(:store_credit)     { create(:store_credit, user: api_user) }
+        let(:current_api_user) { store_credit.user }
+
+        before { subject }
+
+        it "should contain one store credit event" do
+          assigns(:store_credit_events).size.should eq 1
+        end
+
+        it "should contain the store credit allocation event" do
+          assigns(:store_credit_events).first.should eq store_credit.store_credit_events.first
+        end
+
+        it "returns a 200" do
+          subject.status.should eq 200
+        end
+      end
+    end
+  end
+end

--- a/backend/app/controllers/spree/admin/payments_controller.rb
+++ b/backend/app/controllers/spree/admin/payments_controller.rb
@@ -7,6 +7,8 @@ module Spree
       before_action :load_payment, except: [:create, :new, :index]
       before_action :load_data
       before_action :can_not_transition_without_customer_info
+      before_action :load_user_store_credits, only: :new
+      before_action :handle_store_credit_create, only: :create
 
       respond_to :html
 
@@ -97,6 +99,33 @@ module Spree
 
       def model_class
         Spree::Payment
+      end
+
+      def load_user_store_credits
+        @store_credits = if @order.user
+          @order.user.store_credits.reject { |store_credit| store_credit.amount_remaining.zero? }
+        end
+      end
+
+      def handle_store_credit_create
+        @payment = @order.payments.build(object_params)
+        if @payment.store_credit?
+          if store_credit_id = params["payment"]["store_credit_id"].presence
+            store_credit = @order.user.store_credits.find(store_credit_id)
+            amount = [ params[:payment][:amount].to_f,
+                       store_credit.amount_remaining,
+                       @order.outstanding_balance ].min
+
+            auth_code = store_credit.generate_authorization_code
+            @payment.assign_attributes(source: store_credit,
+                                       amount: amount,
+                                       response_code: auth_code)
+
+          else
+            flash[:error] = Spree.t("admin.store_credits.no_store_credit_selected")
+            redirect_to spree.admin_order_payments_path(@order) and return false
+          end
+        end
       end
     end
   end

--- a/backend/app/controllers/spree/admin/store_credits_controller.rb
+++ b/backend/app/controllers/spree/admin/store_credits_controller.rb
@@ -1,0 +1,93 @@
+module Spree
+  module Admin
+    class StoreCreditError < StandardError; end
+
+    class StoreCreditsController < Spree::Admin::BaseController
+
+      before_filter :load_user
+      before_filter :load_categories, only: [:new, :edit]
+      before_filter :load_store_credit, only: [:new, :edit, :update]
+
+      def index
+        @store_credits = @user.store_credits.reverse_order
+      end
+
+      def create
+        @store_credit = @user.store_credits.build(
+          permitted_store_credit_params.merge({
+            created_by: try_spree_current_user,
+            action_originator: try_spree_current_user,
+          })
+        )
+
+        if @store_credit.save
+          flash[:success] = flash_message_for(@store_credit, :successfully_created)
+          redirect_to admin_user_store_credits_path(@user)
+        else
+          load_categories
+          flash[:error] = "#{Spree.t("admin.store_credits.unable_to_create")} #{@store_credit.errors.full_messages}"
+          render :new
+        end
+      end
+
+      def update
+        @store_credit.assign_attributes(permitted_store_credit_params)
+        @store_credit.created_by = try_spree_current_user
+
+        if @store_credit.save
+          flash[:success] = flash_message_for(@store_credit, :successfully_updated)
+          redirect_to admin_user_store_credits_path(@user)
+        else
+          load_categories
+          flash[:error] = "#{Spree.t("admin.store_credits.unable_to_update")} #{@store_credit.errors.full_messages}"
+          render :edit
+        end
+      end
+
+      def destroy
+        @store_credit = @user.store_credits.find(params[:id])
+        ensure_unused_store_credit
+
+        if @store_credit.destroy
+          respond_with(@store_credit) do |format|
+            format.html { redirect_to admin_user_store_credits_path(@user) }
+            format.js  { render_js_for_destroy }
+          end
+        else
+          render text: "#{Spree.t("admin.store_credits.unable_to_delete")} #{@store_credit.errors.full_messages}", status: :unprocessable_entity
+        end
+      end
+
+      protected
+
+      def permitted_store_credit_params
+        params.require(:store_credit).permit(permitted_attributes).merge(currency: Spree::Config[:currency])
+      end
+
+      private
+
+      def load_user
+        @user = Spree::User.find(params[:user_id])
+      end
+
+      def load_categories
+        @credit_categories = Spree::StoreCreditCategory.all.order(:name)
+      end
+
+      def load_store_credit
+        @store_credit = Spree::StoreCredit.find_by_id(params[:id]) || Spree::StoreCredit.new
+      end
+
+      def permitted_attributes
+        [:amount, :category_id, :memo]
+      end
+
+      def ensure_unused_store_credit
+        unless @store_credit.amount_used.zero?
+          raise StoreCreditError.new(Spree.t('admin.store_credits.errors.cannot_change_used_store_credit'))
+        end
+      end
+
+    end
+  end
+end

--- a/backend/app/views/spree/admin/payments/source_forms/_storecredit.html.erb
+++ b/backend/app/views/spree/admin/payments/source_forms/_storecredit.html.erb
@@ -1,0 +1,15 @@
+<div class="alpha omega nine columns">
+  <fieldset data-id='store-credit' class="no-border-bottom">
+    <% if @store_credits.blank? %>
+      <div class='no-objects-found'><%= Spree.t('store_credit_payment_method.user_has_no_store_credits') %></div>
+    <% else %>
+      <div>
+        <div class='field'>
+          <%= select_tag "payment[store_credit_id]",
+                options_for_select(@store_credits.map { |sc| ["#{Spree::Money.new(sc.amount_remaining).to_s} (#{sc.category_name})", sc.id] }, nil),
+                { :class => 'select2 fullwidth', include_blank: true, placeholder: Spree.t('store_credit_payment_method.select_one_store_credit') } %>
+        </div>
+      </div>
+    <% end %>
+  </fieldset>
+</div>

--- a/backend/app/views/spree/admin/shared/_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_menu.html.erb
@@ -7,3 +7,12 @@
     </div>
   </div>
 </nav>
+
+<% if request.fullpath.match(/^\/admin\/users/) %>
+  <% content_for :sub_menu do %>
+    <ul id="sub_nav" class="inline-menu">
+      <%= tab :users %>
+      <%= tab :gift_cards, :match_path => '/users/gift_cards' %>
+    </ul>
+  <% end %>
+<% end %>

--- a/backend/app/views/spree/admin/store_credits/_form.html.erb
+++ b/backend/app/views/spree/admin/store_credits/_form.html.erb
@@ -1,0 +1,24 @@
+<div data-hook="admin_store_credit_form_fields" class="row">
+  <div class="alpha twelve columns">
+    <%= f.field_container :amount do %>
+      <%= f.label :amount, Spree.t(:amount) %> <span class="required">*</span><br />
+      <%= f.number_field :amount, min: 0.00, step: :any %>
+      <%= f.error_message_on :amount %>
+    <% end %>
+  </div>
+  <div class="alpha twelve columns">
+    <%= f.field_container :category do %>
+      <%= f.label :category, Spree.t(:reason) %> <span class="required">*</span><br />
+      <%= f.select :category_id, options_from_collection_for_select(@credit_categories, :id, :name, f.object.category.try(:id)),
+        { include_blank: true }, { class: 'select2 fullwidth', placeholder: Spree.t("admin.store_credits.select_reason") } %>
+      <%= f.error_message_on :category %>
+    <% end %>
+  </div>
+  <div data-hook="admin_store_credit_memo_field" class="alpha twelve columns">
+    <%= f.field_container :memo do %>
+      <%= f.label :memo, Spree.t(:memo) %>
+      <%= f.text_area :memo, class: "fullwidth" %>
+      <%= f.error_message_on :memo %>
+    <% end %>
+  </div>
+</div>

--- a/backend/app/views/spree/admin/store_credits/edit.html.erb
+++ b/backend/app/views/spree/admin/store_credits/edit.html.erb
@@ -1,0 +1,16 @@
+<% content_for :page_title do %>
+  <%= link_to "#{Spree.t(:editing_user)} #{@user.email}", edit_admin_user_url(@user) %>
+<% end %>
+
+<%= render :partial => 'spree/admin/users/sidebar', :locals => { :current => :store_credits } %>
+<% content_for :page_actions do %>
+  <li><%= link_to_with_icon 'arrow-left', Spree.t("admin.store_credits.back_to_store_credit_list"), admin_user_store_credits_path(@user), class: 'button' %></li>
+<% end %>
+
+<%= form_for [:admin, @user, @store_credit] do |f| %>
+  <fieldset>
+    <legend align="center"><%= Spree.t("admin.store_credits.edit") %></legend>
+    <%= render :partial => 'form', :locals => { :f => f } %>
+    <%= render :partial => 'spree/admin/shared/edit_resource_links', :locals => { :collection_url => admin_user_store_credits_path(@user) } %>
+  </fieldset>
+<% end %>

--- a/backend/app/views/spree/admin/store_credits/index.html.erb
+++ b/backend/app/views/spree/admin/store_credits/index.html.erb
@@ -1,0 +1,56 @@
+<% content_for :page_title do %>
+  <%= link_to "#{Spree.t(:editing_user)} #{@user.email}", edit_admin_user_url(@user) %>
+<% end %>
+
+<%= render :partial => 'spree/admin/users/sidebar', :locals => { :current => :store_credits } %>
+<% content_for :page_actions do %>
+  <li><%= link_to_with_icon 'arrow-left', Spree.t("admin.store_credits.back_to_user_list"), admin_users_path, class: 'button' %></li>
+  <li><%= link_to_with_icon 'plus', Spree.t("admin.store_credits.add"), new_admin_user_store_credit_path(@user), class: 'button' %></li>
+<% end %>
+
+<% if @store_credits.any? %>
+  <table>
+    <thead>
+      <th><%= Spree.t("admin.store_credits.credited_html_header").html_safe %></th>
+      <th><%= Spree.t("admin.store_credits.used_html_header").html_safe %></th>
+      <th><%= Spree.t("admin.store_credits.type_html_header").html_safe %></th>
+      <th><%= Spree.t("admin.store_credits.created_by") %></th>
+      <th><%= Spree.t("admin.store_credits.issued_on") %></th>
+      <th data-hook="admin_store_credits_index_header_actions" class="actions"></th>
+    <thead>
+    <tbody>
+      <% @store_credits.each do |store_credit| %>
+        <tr>
+          <td class='align-center'>
+            <span><%= store_credit.display_amount.to_html %></span>
+          </td>
+          <td class='align-center'>
+            <span><%= store_credit.display_amount_used.to_html %></span>
+          </td>
+          <td class='align-center'>
+            <span><%= store_credit.category_name %></span>
+          </td>
+          <td>
+            <span><%= store_credit.created_by_email %></span>
+          </td>
+          <td class='align-center'>
+            <span><%= l store_credit.created_at.to_date %></span>
+          </td>
+          <td class="actions" data-hook="admin_store_credits_index_row_actions">
+            <% unless store_credit.amount_remaining.zero? %>
+              <%= link_to_edit_url edit_admin_user_store_credit_path(@user, store_credit), { no_text: true, class: 'edit' } if can?(:edit, store_credit) %>
+            <% end %>
+            <% if store_credit.amount_used.zero? %>
+              <%= link_to_delete store_credit, { no_text: true, class: 'edit', url: admin_user_store_credit_path(@user, store_credit) } if can?(:destroy, store_credit) %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <div class="alpha twelve columns no-objects-found">
+    <%= Spree.t(:no_resource_found, resource: Spree.t("admin.store_credits.resource_name")) %>,
+    <%= link_to Spree.t(:add_one), spree.new_admin_user_store_credit_path(@user) %>!
+  </div>
+<% end %>

--- a/backend/app/views/spree/admin/store_credits/new.html.erb
+++ b/backend/app/views/spree/admin/store_credits/new.html.erb
@@ -1,0 +1,16 @@
+<% content_for :page_title do %>
+  <%= link_to "#{Spree.t(:editing_user)} #{@user.email}", edit_admin_user_url(@user) %>
+<% end %>
+
+<%= render :partial => 'spree/admin/users/sidebar', :locals => { :current => :store_credits } %>
+<% content_for :page_actions do %>
+  <li><%= link_to_with_icon 'arrow-left', Spree.t("admin.store_credits.back_to_store_credit_list"), admin_user_store_credits_path(@user), class: 'button' %></li>
+<% end %>
+
+<%= form_for [:admin, @user, @store_credit] do |f| %>
+  <fieldset>
+    <legend align="center"><%= Spree.t("admin.store_credits.new") %></legend>
+    <%= render :partial => 'form', :locals => { :f => f } %>
+    <%= render :partial => 'spree/admin/shared/new_resource_links', :locals => { :collection_url => admin_user_store_credits_path(@user) } %>
+  </fieldset>
+<% end %>

--- a/backend/app/views/spree/admin/users/_sidebar.html.erb
+++ b/backend/app/views/spree/admin/users/_sidebar.html.erb
@@ -17,6 +17,12 @@
       <li<%== ' class="active"' if current == :items %>>
         <%= link_to_with_icon 'edit', Spree.t(:"admin.user.items"), items_admin_user_path(@user) %>
       </li>
+      <li<%== ' class="active"' if current == :store_credits %>>
+        <%= link_to_with_icon 'money', Spree.t(:"admin.user.store_credit"), admin_user_store_credits_path(@user) %>
+      </li>
+      <li<%== ' class="active"' if current == :gift_cards %>>
+        <%= link_to_with_icon 'gift', Spree.t(:"admin.gift_cards.redeem_gift_card"), lookup_admin_user_gift_cards_path(@user) %>
+      </li>
     </ul>
 
     <fieldset data-hook="admin_user_lifetime_stats">

--- a/backend/app/views/spree/api/store_credit_events/mine.v1.rabl
+++ b/backend/app/views/spree/api/store_credit_events/mine.v1.rabl
@@ -1,0 +1,10 @@
+object false
+
+child(@store_credit_events => :store_credit_events) do
+  attributes *store_credit_history_attributes
+  node(:order_number) { |event| event.order.try(:number) }
+end
+
+node(:count) { @store_credit_events.count }
+node(:current_page) { params[:page] || 1 }
+node(:pages) { @store_credit_events.num_pages }

--- a/backend/spec/controllers/spree/admin/payments_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/payments_controller_spec.rb
@@ -92,6 +92,106 @@ module Spree
         end
       end
 
+      describe "GET new store credit" do
+
+        subject { spree_get :new, order_id: order.to_param }
+
+        context "the order does not have an associated user" do
+          let(:order) { create(:store_credits_order_without_user) }
+
+          before { subject }
+
+          it "should set the store credits variable to nil" do
+            assigns(:store_credits).should be_nil
+          end
+        end
+
+        context "the user does not have any store credits" do
+          let(:order) { create(:order) }
+
+          before { subject }
+
+          it "should set the store credits variable to an empty list" do
+            assigns(:store_credits).should be_empty
+          end
+        end
+
+        context "the user has store credits" do
+          let(:store_credit) { create(:store_credit) }
+          let(:order)        { create(:order, user: store_credit.user) }
+
+          before { subject }
+
+          it "should set the store credits variable to contain the user's store credit" do
+            assigns(:store_credits).should eq [store_credit]
+          end
+        end
+      end
+
+      describe "POST create store credit" do
+        let(:payment_params) do
+          {
+            amount: 10.0,
+            payment_method_id: payment.payment_method_id
+          }
+        end
+
+        subject { spree_post :create, order_id: order.to_param, payment: payment_params }
+
+        context "the payment method is store credit" do
+          let(:order)   { payment.order }
+          let(:payment) { create(:store_credit_payment) }
+
+          before do
+            payment.source.update_attributes(user_id: order.user.id)
+          end
+
+          context "a store credit id is provided" do
+            let(:payment_params) do
+              {
+                amount: 10.0,
+                store_credit_id: payment.source.id,
+                payment_method_id: payment.payment_method_id
+              }
+            end
+
+            it "should redirect to the payments page" do
+              subject
+              response.should redirect_to spree.admin_order_payments_path(order)
+            end
+
+            it "creates a store credit payment" do
+              expect { subject }.to change { Spree::Payment.where(source_type: "Spree::StoreCredit").count }.by(1)
+            end
+          end
+
+          context "a store credit id is not provided" do
+            it "should redirect to the payments page" do
+              subject
+              response.should redirect_to spree.admin_order_payments_path(order)
+            end
+
+            it "does not create any store credit payment" do
+              expect { subject }.to_not change { Spree::Payment.where(source_type: "Spree::StoreCredit").count }
+            end
+          end
+        end
+
+        context "the payment method is not store credit" do
+          let(:order)   { payment.order }
+          let(:payment) { create(:payment) }
+
+          it "should redirect to the payments page" do
+            subject
+            response.should redirect_to spree.admin_order_payments_path(order)
+          end
+
+          it "does not create any store credit payment" do
+            expect { subject }.to_not change { Spree::Payment.where(source_type: "Spree::StoreCredit").count }
+          end
+        end
+      end
+
     end
   end
 end

--- a/backend/spec/controllers/spree/admin/store_credits_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/store_credits_controller_spec.rb
@@ -1,0 +1,284 @@
+require 'spec_helper'
+
+shared_examples "category loader" do
+  it "sets the credit_categories variable to a list of categories sorted by category name " do
+    assigns(:credit_categories).should eq [a_credit_category, b_credit_category]
+  end
+end
+
+shared_examples "prevents changing used store credits" do
+  before do
+    store_credit.update_attributes(amount_used: 10.0)
+  end
+
+  it "raises an error" do
+    expect { subject }.to raise_error(Spree::Admin::StoreCreditError)
+  end
+end
+
+describe Spree::Admin::StoreCreditsController do
+  stub_authorization!
+  let(:user) { create(:user) }
+  let(:admin_user) { create(:admin_user) }
+
+  let!(:b_credit_category) { create(:store_credit_category, name: "B category") }
+  let!(:a_credit_category) { create(:store_credit_category, name: "A category") }
+
+  describe "GET index" do
+
+    before { spree_get :index, user_id: user.id }
+
+    context "the user does not have any store credits" do
+      it "sets the store_credits variable to an empty list" do
+        assigns(:store_credits).should be_empty
+      end
+    end
+
+    context "the user has store credits" do
+      let(:store_credit) { create(:store_credit, user: user) }
+
+      it "sets the store_credits variable to a list containing the store credits" do
+        assigns(:store_credits).should eq [store_credit]
+      end
+    end
+  end
+
+  describe "GET new" do
+    let!(:store_credit)      { create(:store_credit, category: a_credit_category) }
+
+    before { spree_get :new, user_id: user.id }
+
+    it_behaves_like "category loader"
+
+    it "sets the store_credit variable to a new store credit model" do
+      assigns(:store_credit).should_not be_persisted
+    end
+  end
+
+  describe "POST create" do
+    subject { spree_post :create, parameters }
+
+    before  {
+      controller.stub(try_spree_current_user: admin_user)
+      create(:primary_credit_type)
+    }
+
+    context "the passed parameters are valid" do
+      let(:parameters) do
+        {
+          user_id: user.id,
+          store_credit: {
+            amount: 1.00,
+            category_id: a_credit_category.id
+          }
+        }
+      end
+
+      it "redirects to index" do
+        subject.should redirect_to spree.admin_user_store_credits_path(user)
+      end
+
+      it "creates a new store credit" do
+        expect { subject }.to change(Spree::StoreCredit, :count).by(1)
+      end
+
+      it "associates the store credit with the user" do
+        subject
+        user.reload.store_credits.count.should eq 1
+      end
+
+      it "assigns the store credit's created by to the current user" do
+        subject
+        user.reload.store_credits.first.created_by.should eq admin_user
+      end
+
+      it 'sets the admin as the store credit event originator' do
+        expect { subject }.to change { Spree::StoreCreditEvent.count }.by(1)
+        expect(Spree::StoreCreditEvent.last.originator).to eq admin_user
+      end
+    end
+
+    context "the passed parameters are invalid" do
+      let(:parameters) do
+        {
+          user_id: user.id,
+          store_credit: {
+            amount: -1.00,
+            category_id: a_credit_category.id
+          }
+        }
+      end
+
+      before { subject }
+
+      it "renders the new action" do
+        response.should render_template :new
+      end
+
+      it_behaves_like "category loader"
+    end
+  end
+
+  describe "GET edit" do
+    let!(:store_credit)      { create(:store_credit, category: a_credit_category) }
+
+    before { spree_get :edit, user_id: user.id, id: store_credit.id }
+
+    it_behaves_like "category loader"
+
+    it "sets the store_credit variable to the persisted store credit" do
+      assigns(:store_credit).should eq store_credit
+    end
+  end
+
+  describe "PUT update" do
+    let!(:store_credit) { create(:store_credit, user: user, category: b_credit_category) }
+
+    subject { spree_put :update, parameters }
+
+    before  { controller.stub(try_spree_current_user: admin_user) }
+
+    context "the passed parameters are valid" do
+      let(:updated_amount) { 300.0 }
+
+      let(:parameters) do
+        {
+          user_id: user.id,
+          id: store_credit.id,
+          store_credit: {
+            amount: updated_amount,
+            category_id: a_credit_category.id
+          }
+        }
+      end
+
+      context "the store credit has been partially used" do
+        before { store_credit.update_attributes(amount_used: 10.0) }
+
+        context "the new amount is greater than the used amount" do
+          let(:updated_amount) { 11.0 }
+          it "updates the amount to be the passed in amount" do
+            subject
+            store_credit.reload.amount.should eq updated_amount
+          end
+        end
+
+        context "the new amount is less than the used amount" do
+          let(:updated_amount) { 9.0 }
+          it "does not update the amount" do
+            expect { subject }.not_to change { store_credit.reload.amount }
+          end
+
+          it "responds with an error message" do
+            subject
+            expect(flash.now[:error]).to match "Unable to update"
+            expect(flash.now[:error]).to match "greater than the credited amount"
+          end
+        end
+      end
+
+      context "the store credit has not been used" do
+        it "redirects to index" do
+          subject.should redirect_to spree.admin_user_store_credits_path(user)
+        end
+
+        it "does not create a new store credit" do
+          expect { subject }.to_not change(Spree::StoreCredit, :count)
+        end
+
+        it "assigns the store credit's created by to the current user" do
+          subject
+          store_credit.reload.created_by.should eq admin_user
+        end
+
+        it "updates passed amount" do
+          subject
+          store_credit.reload.amount.should eq updated_amount
+        end
+
+        it "updates passed category" do
+          subject
+          store_credit.reload.category.should eq a_credit_category
+        end
+
+        it "maintains the user association" do
+          subject
+          store_credit.reload.user.should eq user
+        end
+      end
+    end
+
+    context "the passed parameters are invalid" do
+      let(:parameters) do
+        {
+          user_id: user.id,
+          id: store_credit.id,
+          store_credit: {
+            amount: -1.00,
+            category_id: a_credit_category.id
+          }
+        }
+      end
+
+      before { subject }
+
+      it "renders the edit action" do
+        response.should render_template :edit
+      end
+
+      it_behaves_like "category loader"
+    end
+  end
+
+  describe "DELETE destroy" do
+    let!(:store_credit) { create(:store_credit, user: user, category: b_credit_category) }
+
+    context "the store credit has been used" do
+      subject { spree_delete :destroy, user_id: user.id, id: store_credit.id }
+
+      it_behaves_like "prevents changing used store credits"
+    end
+
+    context "the destroy is unsuccessful" do
+      before do
+        Spree::StoreCredit.any_instance.stub(destroy: false)
+        subject
+      end
+
+      subject { spree_delete :destroy, user_id: user.id, id: store_credit.id }
+
+      it "returns a 422" do
+        response.status.should eq 422
+      end
+
+      it "returns an error message" do
+        response.body.should match Spree.t("admin.store_credits.unable_to_delete")
+      end
+    end
+
+    context "html request" do
+      subject { spree_delete :destroy, user_id: user.id, id: store_credit.id }
+
+      it "redirects to index" do
+        subject.should redirect_to spree.admin_user_store_credits_path(user)
+      end
+
+      it "deletes the store credit" do
+        expect { subject }.to change(Spree::StoreCredit, :count).by(-1)
+      end
+    end
+
+    context "js request" do
+      subject { spree_delete :destroy, user_id: user.id, id: store_credit.id, format: :js }
+
+      it "returns a 200 status code" do
+        subject
+        response.code.should eq "200"
+      end
+
+      it "deletes the store credit" do
+        expect { subject }.to change(Spree::StoreCredit, :count).by(-1)
+      end
+    end
+  end
+end

--- a/backend/spec/features/admin/store_credits_spec.rb
+++ b/backend/spec/features/admin/store_credits_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+describe "Store credits admin" do
+  stub_authorization!
+  let!(:admin_user)   { create(:admin_user) }
+  let!(:store_credit) { create(:store_credit) }
+
+  describe "visiting the store credits page" do
+    before do
+      visit spree.admin_path
+      click_link "Users"
+    end
+
+    it "should be on the store credits page" do
+      click_link store_credit.user.email
+      click_link "Store Credit"
+      page.current_path.should eq spree.admin_user_store_credits_path(store_credit.user)
+
+      store_credit_table = page.find(".twelve.columns > table")
+      store_credit_table.all('tr').count.should eq 1
+      store_credit_table.should have_content(Spree::Money.new(store_credit.amount).to_s)
+      store_credit_table.should have_content(Spree::Money.new(store_credit.amount_used).to_s)
+      store_credit_table.should have_content(store_credit.category_name)
+      store_credit_table.should have_content(store_credit.created_by_email)
+    end
+  end
+
+  describe "creating store credit" do
+    before do
+      visit spree.admin_path
+      click_link "Users"
+      click_link store_credit.user.email
+      click_link "Store Credit"
+      Spree::Admin::StoreCreditsController.any_instance.stub(try_spree_current_user: admin_user)
+    end
+
+    it "should create store credit and associate it with the user" do
+      click_link "Add store credit"
+      page.fill_in "store_credit_amount", with: "102.00"
+      select "Exchange", from: "store_credit_category_id"
+      click_button "Create"
+
+      page.current_path.should eq spree.admin_user_store_credits_path(store_credit.user)
+      store_credit_table = page.find(".twelve.columns > table")
+      store_credit_table.all('tr').count.should eq 2
+      Spree::StoreCredit.count.should eq 2
+    end
+  end
+
+  describe "updating store credit" do
+    let(:updated_amount) { "99.0" }
+
+    before do
+      visit spree.admin_path
+      click_link "Users"
+      click_link store_credit.user.email
+      click_link "Store Credit"
+      Spree::Admin::StoreCreditsController.any_instance.stub(try_spree_current_user: admin_user)
+    end
+
+    it "should create store credit and associate it with the user" do
+      click_link "Edit"
+      page.fill_in "store_credit_amount", with: updated_amount
+      click_button "Update"
+
+      page.current_path.should eq spree.admin_user_store_credits_path(store_credit.user)
+      store_credit_table = page.find(".twelve.columns > table")
+      store_credit_table.should have_content(Spree::Money.new(updated_amount).to_s)
+      store_credit.reload.amount.to_f.should eq updated_amount.to_f
+    end
+  end
+
+end

--- a/core/app/models/concerns/spree/user_store_credit.rb
+++ b/core/app/models/concerns/spree/user_store_credit.rb
@@ -1,0 +1,16 @@
+module Spree
+  module UserStoreCredit
+    extend ActiveSupport::Concern
+
+    included do
+
+      has_many :store_credits, -> { includes(:credit_type) }
+      has_many :store_credit_events, through: :store_credits
+
+      def total_available_store_credit
+        store_credits.reload.to_a.sum{ |credit| credit.amount_remaining }
+      end
+      
+    end
+  end
+end

--- a/core/app/models/spree/legacy_user.rb
+++ b/core/app/models/spree/legacy_user.rb
@@ -3,6 +3,7 @@ module Spree
   class LegacyUser < Spree::Base
     include UserAddress
     include UserPaymentSource
+    include UserStoreCredit
 
     self.table_name = 'spree_users'
 

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -102,6 +102,8 @@ module Spree
               before_transition to: :resumed, do: :ensure_line_item_variants_are_not_deleted
               before_transition to: :resumed, do: :ensure_line_items_are_in_stock
 
+              before_transition to: :confirm, do: :add_store_credit_payments
+
               before_transition to: :complete, do: :ensure_line_item_variants_are_not_deleted
               before_transition to: :complete, do: :ensure_line_items_are_in_stock
 

--- a/core/app/models/spree/order/store_credits.rb
+++ b/core/app/models/spree/order/store_credits.rb
@@ -6,6 +6,8 @@ module Spree
       included do
 
         def add_store_credit_payments
+          existing_credit_card_payment.destroy if covered_by_store_credit?
+          
           payments.store_credits.where(state: 'checkout').map(&:invalidate!)
 
           remaining_total = outstanding_balance

--- a/core/app/models/spree/order/store_credits.rb
+++ b/core/app/models/spree/order/store_credits.rb
@@ -1,0 +1,111 @@
+module Spree
+  class Order < Spree::Base
+    module StoreCredits
+      extend ActiveSupport::Concern
+
+      included do
+
+        def add_store_credit_payments
+          payments.store_credits.where(state: 'checkout').map(&:invalidate!)
+
+          remaining_total = outstanding_balance
+
+          if user && user.store_credits.any?
+            payment_method = Spree::PaymentMethod.find_by_type('Spree::PaymentMethod::StoreCredit')
+            raise "Store credit payment method could not be found" unless payment_method
+
+            user.store_credits.order_by_priority.each do |credit|
+              break if remaining_total.zero?
+              next if credit.amount_remaining.zero?
+
+              amount_to_take = store_credit_amount(credit, remaining_total)
+              create_store_credit_payment(payment_method, credit, amount_to_take)
+              remaining_total -= amount_to_take
+            end
+          end
+
+          reconcile_with_credit_card(existing_credit_card_payment, remaining_total)
+
+          if payments.valid.sum(:amount) != total
+            errors.add(:base, Spree.t("store_credit.errors.unable_to_fund")) and return false
+          end
+        end
+
+        def covered_by_store_credit?
+          return false unless user
+          user.total_available_store_credit >= total
+        end
+        alias_method :covered_by_store_credit, :covered_by_store_credit?
+
+        def total_available_store_credit
+          return 0.0 unless user
+          user.total_available_store_credit
+        end
+
+        def order_total_after_store_credit
+          total - total_applicable_store_credit
+        end
+
+        def total_applicable_store_credit
+          if confirm? || complete?
+            payments.store_credits.valid.sum(:amount)
+          else
+            [total, (user.try(:total_available_store_credit) || 0.0)].min
+          end
+        end
+
+        def display_total_applicable_store_credit
+          Spree::Money.new(-total_applicable_store_credit, { currency: currency })
+        end
+
+        def display_order_total_after_store_credit
+          Spree::Money.new(order_total_after_store_credit, { currency: currency })
+        end
+
+        def display_total_available_store_credit
+          Spree::Money.new(total_available_store_credit, { currency: currency })
+        end
+
+        def display_store_credit_remaining_after_capture
+          Spree::Money.new(total_available_store_credit - total_applicable_store_credit, { currency: currency })
+        end
+
+        private
+
+        def existing_credit_card_payment
+          other_payments = payments.valid.not_store_credits
+          raise "Found #{other_payments.size} payments and only expected 1" if other_payments.size > 1
+          other_payments.first
+        end
+
+        def reconcile_with_credit_card(other_payment, amount)
+          return unless other_payment
+
+          unless other_payment.source.is_a?(Spree::CreditCard)
+            raise "Found unexpected payment method. Credit cards are the only other supported payment type"
+          end
+
+          if amount.zero?
+            other_payment.invalidate!
+          else
+            other_payment.update_attributes!(amount: amount)
+          end
+        end
+
+        def create_store_credit_payment(payment_method, credit, amount)
+          payments.create!(source: credit,
+                           payment_method: payment_method,
+                           amount: amount,
+                           state: 'checkout',
+                           response_code: credit.generate_authorization_code)
+        end
+
+        def store_credit_amount(credit, total)
+          [credit.amount_remaining, total].min
+        end
+    
+      end
+
+    end
+  end
+end

--- a/core/app/models/spree/order/store_credits.rb
+++ b/core/app/models/spree/order/store_credits.rb
@@ -46,6 +46,10 @@ module Spree
           total - total_applicable_store_credit
         end
 
+        def using_store_credit?
+          total_applicable_store_credit > 0
+        end
+
         def total_applicable_store_credit
           if confirm? || complete?
             payments.store_credits.valid.sum(:amount)

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -64,7 +64,12 @@ module Spree
       end
 
       def cancel!
-        payment_method.cancel(response_code)
+        if store_credit?
+          canceled = payment_method.cancel(response_code)
+          self.void if canceled
+        else
+          payment_method.cancel(response_code)
+        end
       end
 
       def gateway_options

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -38,6 +38,10 @@ module Spree
       where(type: self.to_s, environment: Rails.env, active: true).count > 0
     end
 
+    def store_credit?
+      self.class == Spree::PaymentMethod::StoreCredit
+    end
+
     def method_type
       type.demodulize.downcase
     end

--- a/core/app/models/spree/reimbursement_type/reimbursement_helpers.rb
+++ b/core/app/models/spree/reimbursement_type/reimbursement_helpers.rb
@@ -44,7 +44,13 @@ module Spree
     end
 
     def create_creditable(reimbursement, unpaid_amount)
-      Spree::Reimbursement::Credit.default_creditable_class.new(reimbursement: reimbursement, amount: unpaid_amount)
+      category = Spree::StoreCreditCategory.default_reimbursement_category(category_options(reimbursement))
+      Spree::StoreCredit.new(user: reimbursement.order.user, amount: unpaid_amount, category: category, created_by: Spree::StoreCredit.default_created_by, memo: "Refund for uncreditable payments on order #{reimbursement.order.number}", currency: reimbursement.order.currency)
+    end
+
+    # overwrite if you need options for the default reimbursement category
+    def category_options(reimbursement)
+      {}
     end
   end
 end

--- a/core/app/models/spree/reimbursement_type/store_credit.rb
+++ b/core/app/models/spree/reimbursement_type/store_credit.rb
@@ -1,0 +1,27 @@
+class Spree::ReimbursementType::StoreCredit < Spree::ReimbursementType
+  extend Spree::ReimbursementType::ReimbursementHelpers
+
+  class << self
+    def reimburse(reimbursement, return_items, simulate)
+      unpaid_amount = return_items.sum(&:total).to_d.round(2, :down)
+      payments = store_credit_payments(reimbursement)
+      reimbursement_list = []
+
+      # Credit each store credit that was used on the order
+      reimbursement_list, unpaid_amount = create_refunds(reimbursement, payments, unpaid_amount, simulate, reimbursement_list)
+
+      # If there is any amount left to pay out to the customer, then create credit with that amount
+      if unpaid_amount > 0.0
+        reimbursement_list, unpaid_amount = create_credits(reimbursement, unpaid_amount, simulate, reimbursement_list)
+      end
+
+      reimbursement_list
+    end
+
+    private
+
+    def store_credit_payments(reimbursement)
+      reimbursement.order.payments.completed.store_credits
+    end
+  end
+end

--- a/core/app/models/spree/store_credit.rb
+++ b/core/app/models/spree/store_credit.rb
@@ -1,0 +1,245 @@
+class Spree::StoreCredit < ActiveRecord::Base
+  acts_as_paranoid
+
+  VOID_ACTION       = 'void'
+  CREDIT_ACTION     = 'credit'
+  CAPTURE_ACTION    = 'capture'
+  ELIGIBLE_ACTION   = 'eligible'
+  AUTHORIZE_ACTION  = 'authorize'
+  ALLOCATION_ACTION = 'allocation'
+
+  DEFAULT_CREATED_BY_EMAIL = "spree@example.com"
+
+  belongs_to :user
+  belongs_to :category, class_name: "Spree::StoreCreditCategory"
+  belongs_to :created_by, class_name: "Spree::User"
+  belongs_to :credit_type, class_name: 'Spree::StoreCreditType', :foreign_key => 'type_id'
+  has_many :store_credit_events
+
+  validates_presence_of :user_id, :category_id, :type_id, :created_by_id, :currency
+  validates_numericality_of :amount, { greater_than: 0 }
+  validates_numericality_of :amount_used, { greater_than_or_equal_to: 0 }
+  validate :amount_used_less_than_or_equal_to_amount
+  validate :amount_authorized_less_than_or_equal_to_amount
+
+  delegate :name, to: :category, prefix: true
+  delegate :email, to: :created_by, prefix: true
+
+  scope :order_by_priority, -> { includes(:credit_type).order('spree_store_credit_types.priority ASC') }
+
+  before_validation :associate_credit_type
+  after_save :store_event
+  before_destroy :validate_no_amount_used
+
+  attr_accessor :action, :action_amount, :action_originator, :action_authorization_code
+
+  def display_amount
+    Spree::Money.new(amount)
+  end
+
+  def display_amount_used
+    Spree::Money.new(amount_used)
+  end
+
+  def amount_remaining
+    amount - amount_used - amount_authorized
+  end
+
+  def authorize(amount, order_currency, options={})
+    authorization_code = options[:action_authorization_code]
+    if authorization_code
+      if store_credit_events.find_by(action: AUTHORIZE_ACTION, authorization_code: authorization_code)
+        # Don't authorize again on capture
+        return true
+      end
+    else
+      authorization_code = generate_authorization_code
+    end
+
+    if validate_authorization(amount, order_currency)
+      update_attributes!({
+        action: AUTHORIZE_ACTION,
+        action_amount: amount,
+        action_originator: options[:action_originator],
+        action_authorization_code: authorization_code,
+
+        amount_authorized: self.amount_authorized + amount,
+      })
+      authorization_code
+    else
+      errors.add(:base, Spree.t('store_credit_payment_method.insufficient_authorized_amount'))
+      false
+    end
+  end
+
+  def validate_authorization(amount, order_currency)
+    if amount_remaining.to_d < amount.to_d
+      errors.add(:base, Spree.t('store_credit_payment_method.insufficient_funds'))
+    elsif currency != order_currency
+      errors.add(:base, Spree.t('store_credit_payment_method.currency_mismatch'))
+    end
+    return errors.blank?
+  end
+
+  def capture(amount, authorization_code, order_currency, options={})
+    return false unless authorize(amount, order_currency, action_authorization_code: authorization_code)
+
+    if amount <= amount_authorized
+      if currency != order_currency
+        errors.add(:base, Spree.t('store_credit_payment_method.currency_mismatch'))
+        false
+      else
+        update_attributes!({
+          action: CAPTURE_ACTION,
+          action_amount: amount,
+          action_originator: options[:action_originator],
+          action_authorization_code: authorization_code,
+
+          amount_used: self.amount_used + amount,
+          amount_authorized: self.amount_authorized - amount,
+        })
+        authorization_code
+      end
+    else
+      errors.add(:base, Spree.t('store_credit_payment_method.insufficient_authorized_amount'))
+      false
+    end
+  end
+
+  def void(authorization_code, options={})
+    if auth_event = store_credit_events.find_by(action: AUTHORIZE_ACTION, authorization_code: authorization_code)
+      self.update_attributes!({
+        action: VOID_ACTION,
+        action_amount: auth_event.amount,
+        action_authorization_code: authorization_code,
+        action_originator: options[:action_originator],
+
+        amount_authorized: amount_authorized - auth_event.amount,
+      })
+      true
+    else
+      errors.add(:base, Spree.t('store_credit_payment_method.unable_to_void', auth_code: authorization_code))
+      false
+    end
+  end
+
+  def credit(amount, authorization_code, order_currency, options={})
+    # Find the amount related to this authorization_code in order to add the store credit back
+    capture_event = store_credit_events.find_by(action: CAPTURE_ACTION, authorization_code: authorization_code)
+
+    if currency != order_currency  # sanity check to make sure the order currency hasn't changed since the auth
+      errors.add(:base, Spree.t('store_credit_payment_method.currency_mismatch'))
+      false
+    elsif capture_event && amount <= capture_event.amount
+      action_attributes = {
+        action: CREDIT_ACTION,
+        action_amount: amount,
+        action_originator: options[:action_originator],
+        action_authorization_code: authorization_code,
+      }
+      create_credit_record(amount, action_attributes)
+      true
+    else
+      errors.add(:base, Spree.t('store_credit_payment_method.unable_to_credit', auth_code: authorization_code))
+      false
+    end
+  end
+
+  def actions
+    [CAPTURE_ACTION, VOID_ACTION, CREDIT_ACTION]
+  end
+
+  def can_capture?(payment)
+    payment.pending? || payment.checkout?
+  end
+
+  def can_void?(payment)
+    payment.pending?
+  end
+
+  def can_credit?(payment)
+    payment.completed? && payment.credit_allowed > 0
+  end
+
+  def generate_authorization_code
+    "#{self.id}-SC-#{Time.now.utc.strftime("%Y%m%d%H%M%S%6N")}"
+  end
+
+  class << self
+    def default_created_by
+      Spree.user_class.find_by(email: DEFAULT_CREATED_BY_EMAIL)
+    end
+  end
+
+  private
+
+  def create_credit_record(amount, action_attributes={})
+    # Setting credit_to_new_allocation to true will create a new allocation anytime #credit is called
+    # If it is not set, it will update the store credit's amount in place
+    credit = if Spree::StoreCredits::Configuration.credit_to_new_allocation
+      Spree::StoreCredit.new({
+        amount: amount,
+        user_id: self.user_id,
+        category_id: self.category_id,
+        created_by_id: self.created_by_id,
+        currency: self.currency,
+        type_id: self.type_id,
+        memo: credit_allocation_memo,
+      })
+    else
+      self.amount_used = amount_used - amount
+      self
+    end
+
+    credit.assign_attributes(action_attributes)
+    credit.save!
+  end
+
+  def credit_allocation_memo
+    "This is a credit from store credit ID #{self.id}"
+  end
+
+  def store_event
+    return unless amount_changed? || amount_used_changed? || amount_authorized_changed? || action == ELIGIBLE_ACTION
+
+    event = if action
+      store_credit_events.build(action: action)
+    else
+      store_credit_events.where(action: ALLOCATION_ACTION).first_or_initialize
+    end
+
+    event.update_attributes!({
+      amount: action_amount || amount,
+      authorization_code: action_authorization_code || event.authorization_code || generate_authorization_code,
+      user_total_amount: user.total_available_store_credit,
+      originator: action_originator,
+    })
+  end
+
+  def amount_used_less_than_or_equal_to_amount
+    return true if amount_used.nil?
+
+    if amount_used > amount
+      errors.add(:amount_used, Spree.t('admin.store_credits.errors.amount_used_cannot_be_greater'))
+    end
+  end
+
+  def amount_authorized_less_than_or_equal_to_amount
+    if (amount_used + amount_authorized) > amount
+      errors.add(:amount_authorized, Spree.t('admin.store_credits.errors.amount_authorized_exceeds_total_credit'))
+    end
+  end
+
+  def validate_no_amount_used
+    if amount_used > 0
+      errors.add(:amount_used, 'is greater than zero. Can not delete store credit')
+    end
+  end
+
+  def associate_credit_type
+    unless self.type_id
+      credit_type_name = category.try(:non_expiring?) ? 'Non-expiring' : 'Expiring'
+      self.credit_type = Spree::StoreCreditType.find_by_name(credit_type_name)
+    end
+  end
+end

--- a/core/app/models/spree/store_credit_category.rb
+++ b/core/app/models/spree/store_credit_category.rb
@@ -1,0 +1,15 @@
+class Spree::StoreCreditCategory < ActiveRecord::Base
+  def non_expiring?
+    non_expiring_category_types.include? name
+  end
+
+  def non_expiring_category_types
+    Spree::StoreCredits::Configuration.non_expiring_credit_types
+  end
+
+  class << self
+    def default_reimbursement_category(options = {})
+      Spree::StoreCreditCategory.first
+    end
+  end
+end

--- a/core/app/models/spree/store_credit_event.rb
+++ b/core/app/models/spree/store_credit_event.rb
@@ -1,0 +1,42 @@
+module Spree
+  class StoreCreditEvent < ActiveRecord::Base
+    acts_as_paranoid
+
+    belongs_to :store_credit
+    belongs_to :originator, polymorphic: true
+
+    scope :exposed_events, -> { where.not(action: [Spree::StoreCredit::ELIGIBLE_ACTION, Spree::StoreCredit::AUTHORIZE_ACTION]) }
+    scope :reverse_chronological, -> { order(created_at: :desc) }
+
+    delegate :currency, to: :store_credit
+
+    def display_amount
+      Spree::Money.new(amount, { currency: currency })
+    end
+
+    def display_user_total_amount
+      Spree::Money.new(user_total_amount, { currency: currency })
+    end
+
+    def display_event_date
+      I18n.l(created_at, format: :date_slash)
+    end
+
+    def display_action
+      case action
+      when Spree::StoreCredit::CAPTURE_ACTION
+        Spree.t('store_credit.captured')
+      when Spree::StoreCredit::AUTHORIZE_ACTION
+        Spree.t('store_credit.authorized')
+      when Spree::StoreCredit::ALLOCATION_ACTION
+        Spree.t('store_credit.allocated')
+      when Spree::StoreCredit::VOID_ACTION, Spree::StoreCredit::CREDIT_ACTION
+        Spree.t('store_credit.credit')
+      end
+    end
+
+    def order
+      Spree::Payment.find_by_response_code(authorization_code).try(:order)
+    end
+  end
+end

--- a/core/app/models/spree/store_credit_type.rb
+++ b/core/app/models/spree/store_credit_type.rb
@@ -1,0 +1,6 @@
+module Spree
+  class StoreCreditType < ActiveRecord::Base
+    DEFAULT_TYPE_NAME = 'Expiring'
+    has_many :store_credits, class_name: 'Spree::StoreCredit', foreign_key: 'type_id'
+  end
+end

--- a/core/app/models/spree/store_credits/configuration.rb
+++ b/core/app/models/spree/store_credits/configuration.rb
@@ -1,0 +1,17 @@
+module Spree::StoreCredits::Configuration
+  class << self
+    require 'ostruct'
+
+    delegate :non_expiring_credit_types, :credit_to_new_allocation, to: :configs
+
+    def set_configs(options = {})
+      @configs = OpenStruct.new(options)
+    end
+
+    private
+
+    def configs
+      @configs
+    end
+  end
+end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1,6 +1,8 @@
 en:
   activerecord:
     attributes:
+      spree/store_credit:
+        amount_used: "Amount used"
       spree/address:
         address1: Address
         address2: Address (contd.)
@@ -345,6 +347,12 @@ en:
       not_saved:
         one: ! '1 error prohibited this %{resource} from being saved:'
         other: ! '%{count} errors prohibited this %{resource} from being saved:'
+  date:
+    formats:
+      date_slash: '%m/%d/%Y'
+  time:
+    formats:
+      date_slash: '%m/%d/%Y'
   spree:
     abbreviation: Abbreviation
     accept: Accept
@@ -395,6 +403,28 @@ en:
     adjustment_total: Adjustment Total
     adjustments: Adjustments
     admin:
+      store_credits:
+        add: "Add store credit"
+        new: "New store credit"
+        edit: "Editing store credit"
+        back_to_user_list: "Back to user list"
+        back_to_store_credit_list: "Back to store credit list"
+        credited_html_header: "Amount<br/>Credited"
+        used_html_header: "Amount<br/>Used"
+        type_html_header: "Credit<br/>Type"
+        created_by: "Created By"
+        issued_on: "Issued On"
+        select_reason: "Select a reason for this store credit"
+        unable_to_create: "Unable to create store credit"
+        unable_to_update: "Unable to update store credit"
+        unable_to_delete: "Unable to delete store credit"
+        resource_name: "store credits"
+        no_store_credit_selected: "No store credit was selected"
+        errors:
+          cannot_change_used_store_credit: "Store credit that has been claimed cannot be changed"
+          amount_used_cannot_be_greater: "cannot be greater than the credited amount"
+          amount_authorized_exceeds_total_credit: " exceeds the available credit"
+          amount_used_not_zero: "is greater than zero. Can not delete store credit"
       tab:
         configuration: Configuration
         option_types: Option Types
@@ -416,6 +446,7 @@ en:
         order_history: Order History
         order_num: "Order #"
         orders: Orders
+        store_credit: "Store Credit"
         user_information: User Information
     administration: Administration
     agree_to_privacy_policy: Agree to Privacy Policy
@@ -1264,6 +1295,24 @@ en:
     stock_transfers: Stock Transfers
     stop: Stop
     store: Store
+    store_credit_payment_method:
+      unable_to_void: "Unable to void code: %{auth_code}"
+      unable_to_credit: "Unable to credit code: %{auth_code}"
+      successful_action: "Successful store credit %{action}"
+      unable_to_find: "Could not find store credit"
+      insufficient_funds: "Store credit amount remaining is not sufficient"
+      currency_mismatch: "Store credit currency does not match order currency"
+      insufficient_authorized_amount: "Unable to capture more than authorized amount"
+      unable_to_find_for_action: "Could not find store credit for auth code: %{auth_code} for action: %{action}"
+      user_has_no_store_credits: "User does not have any available store credit"
+      select_one_store_credit: "Select store credit to go towards remaining balance"
+    store_credit:
+      credit: "Credit"
+      authorized: "Authorized"
+      captured: "Used"
+      allocated: "Added"
+      errors:
+        unable_to_fund: "Unable to pay for order using store credits"
     street_address: Street Address
     street_address_2: Street Address (cont'd)
     subtotal: Subtotal

--- a/core/config/routes.rb
+++ b/core/config/routes.rb
@@ -1,1 +1,17 @@
 Spree::Core::Engine.draw_routes
+
+Spree::Core::Engine.routes.draw do
+  namespace :admin do
+    resources :users, only: [] do
+      resources :store_credits
+    end
+  end
+
+  namespace :api, defaults: { format: 'json' } do
+    resources :store_credit_events, only: [] do
+      collection do
+        get :mine
+      end
+    end
+  end
+end

--- a/core/db/default/spree/store_credits.rb
+++ b/core/db/default/spree/store_credits.rb
@@ -1,0 +1,6 @@
+Spree::PaymentMethod.find_or_create_by(type: "Spree::PaymentMethod::StoreCredit", name: "Store Credit", description: "Store credit.", active: true, environment: Rails.env, display_on: 'back_end')
+
+Spree::StoreCreditType.find_or_create_by(name: 'Expiring', priority: 1)
+Spree::StoreCreditType.find_or_create_by(name: 'Non-expiring', priority: 2)
+
+Spree::StoreCreditCategory.find_or_create_by(name: 'Gift Card')

--- a/core/db/migrate/20140523190528_create_spree_store_credit_tables.rb
+++ b/core/db/migrate/20140523190528_create_spree_store_credit_tables.rb
@@ -1,0 +1,53 @@
+class CreateSpreeStoreCreditTables < ActiveRecord::Migration
+  def change
+    create_table :spree_store_credit_categories do |t|
+      t.string :name
+      t.timestamps
+    end
+
+    create_table :spree_store_credits do |t|
+      t.references :user
+      t.references :category
+      t.references :created_by
+      t.integer :type_id
+      t.decimal :amount, precision: 8, scale: 2, default: 0.0, null: false
+      t.decimal :amount_used, precision: 8, scale: 2, default: 0.0, null: false
+      t.decimal :amount_authorized, precision: 8, scale: 2, default: 0.0, null: false
+      t.string :currency
+      t.text :memo
+      t.timestamps
+      t.datetime :deleted_at
+    end
+    add_index :spree_store_credits, :deleted_at
+    add_index :spree_store_credits, :user_id
+    add_index :spree_store_credits, :type_id
+
+    create_table :spree_store_credit_events do |t|
+      t.integer :store_credit_id,    null: false
+      t.string  :action,             null: false
+      t.integer :originator_id
+      t.string  :originator_type
+      t.decimal :amount,             precision: 8, scale: 2
+      t.decimal :user_total_amount,  precision: 8, scale: 2, default: 0.0, null: false
+      t.string  :authorization_code, null: false
+      t.timestamps
+      t.datetime :deleted_at
+    end
+    add_index :spree_store_credit_events, :store_credit_id
+
+    create_table :spree_store_credit_types do |t|
+      t.string :name
+      t.integer :priority
+      t.timestamps
+    end
+    add_index :spree_store_credit_types, :priority
+
+    default_type = Spree::StoreCreditType.find_or_create_by(name: 'Expiring', priority: 1)
+    Spree::StoreCredit.update_all(type_id: default_type.id)
+    Spree::StoreCreditType.find_or_create_by(name: 'Non-expiring', priority: 2)
+    Spree::ReimbursementType.find_or_create_by(name: 'Store Credit', type: 'Spree::ReimbursementType::StoreCredit')
+
+    return if Spree::PaymentMethod.find_by_type("Spree::PaymentMethod::StoreCredit")
+    Spree::PaymentMethod.create(type: "Spree::PaymentMethod::StoreCredit", name: "Store Credit", description: "Store credit.", active: true, environment: Rails.env)
+  end
+end

--- a/core/lib/spree/testing_support/factories/store_credits.rb
+++ b/core/lib/spree/testing_support/factories/store_credits.rb
@@ -1,0 +1,57 @@
+FactoryGirl.define do
+  sequence(:store_credits_order_number)  { |n| "R1000#{n}" }
+  # Define your Spree extensions Factories within this file to enable applications, and other extensions to use and override them.
+  #
+  # Example adding this to your spec_helper will load these Factories for use:
+  # require 'spree_store_credits/factories'
+  #
+
+  factory :store_credit, class: Spree::StoreCredit do
+    user             { create(:user) }
+    created_by       { create(:user) }
+    category         { create(:store_credit_category) }
+    amount           { 150.00 }
+    currency         { "USD" }
+    credit_type      { create(:primary_credit_type) }
+  end
+
+  factory :store_credit_category, class: Spree::StoreCreditCategory do
+    name             "Exchange"
+  end
+
+  factory :primary_credit_type, class: Spree::StoreCreditType do
+    name      Spree::StoreCreditType::DEFAULT_TYPE_NAME
+    priority  { "1" }
+  end
+
+  factory :secondary_credit_type, class: Spree::StoreCreditType do
+    name      { "Non-expiring" }
+    priority  { "2" }
+  end
+
+  factory :store_credit_payment_method, class: Spree::PaymentMethod::StoreCredit do
+    type          "Spree::PaymentMethod::StoreCredit"
+    name          "Store Credit"
+    description   "Store Credit"
+    active        true
+    environment   "test"
+    auto_capture  true
+  end
+
+  factory :store_credit_payment, class: Spree::Payment, parent: :payment do
+    association(:payment_method, factory: :store_credit_payment_method)
+    association(:source, factory: :store_credit)
+  end
+
+  factory :store_credit_auth_event, class: Spree::StoreCreditEvent do
+    store_credit       { create(:store_credit) }
+    action             { Spree::StoreCredit::AUTHORIZE_ACTION }
+    amount             { 100.00 }
+    authorization_code { "#{store_credit.id}-SC-20140602164814476128" }
+  end
+
+  factory :store_credits_order_without_user, class: Spree::Order do
+    number             { generate(:store_credits_order_number) }
+    bill_address
+  end
+end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -248,6 +248,58 @@ describe Spree::Order, :type => :model do
     end
   end
 
+  describe "#using_store_credit?" do
+    let(:order) { create(:order) }
+    subject { order.using_store_credit? } 
+
+    context "order is in the confirm state" do
+      before { order.update_attributes(state: 'confirm') }
+
+      context "when there is a store credit payment" do
+        let!(:store_credit_payment) { create(:store_credit_payment, order: order) } 
+        it { should be true }
+      end
+
+      context "when there is not store credit payment" do
+        it { should be false }
+      end
+    end
+
+    context "order is completed" do
+      before { order.update_attributes(state: 'complete') }
+
+      context "when there is a store credit payment" do
+        let!(:store_credit_payment) { create(:store_credit_payment, order: order) } 
+        it { should be true }
+      end
+
+      context "when there is not store credit payment" do
+        it { should be false }
+      end
+    end
+
+    context "order is in any state other than confirm or complete" do
+      context "the associated user has store credits" do
+        let(:store_credit) { create(:store_credit) }
+        let(:order)        { create(:order_with_line_items, user: store_credit.user) }
+
+        it { should be true }
+      end
+
+      context "the associated user does not have store credits" do
+        let(:order) { create(:order_with_line_items) }
+
+        it { should be false }
+      end
+
+      context "the order does not have an associated user" do
+        let(:order) { create(:store_credits_order_without_user) }
+
+        it { should be false }
+      end
+    end
+  end
+
   describe "#order_total_after_store_credit" do
     let(:order_total) { 100.0 }
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -6,6 +6,30 @@ class FakeCalculator < Spree::Calculator
   end
 end
 
+shared_examples "check total store credit from payments" do
+  context "with valid payments" do
+    let(:order)           { payment.order }
+    let!(:payment)        { create(:store_credit_payment) }
+    let!(:second_payment) { create(:store_credit_payment, order: order) }
+
+    subject { order }
+
+    it "returns the sum of the payment amounts" do
+      subject.total_applicable_store_credit.should eq (payment.amount + second_payment.amount)
+    end
+  end
+
+  context "without valid payments" do
+    let(:order) { create(:order) }
+
+    subject { order }
+
+    it "returns 0" do
+      subject.total_applicable_store_credit.should be_zero
+    end
+  end
+end
+
 describe Spree::Order, :type => :model do
   let(:user) { stub_model(Spree::LegacyUser, :email => "spree@example.com") }
   let(:order) { stub_model(Spree::Order, :user => user) }
@@ -14,6 +38,409 @@ describe Spree::Order, :type => :model do
     allow(Spree::LegacyUser).to receive_messages(:current => mock_model(Spree::LegacyUser, :id => 123))
   end
 
+  describe "#add_store_credit_payments" do
+    let(:order_total) { 500.00 }
+
+    before { create(:store_credit_payment_method) }
+
+    subject { order.add_store_credit_payments }
+
+    context "there is no store credit" do
+      let(:order)       { create(:store_credits_order_without_user, total: order_total) }
+
+      context "there is a credit card payment" do
+        let!(:cc_payment) { create(:payment, order: order) }
+
+        before do
+          # callbacks recalculate total based on line items
+          # this ensures the total is what we expect
+          order.update_column(:total, order_total)
+          subject
+          order.reload
+        end
+
+        it "charges the outstanding balance to the credit card" do
+          order.payments.count.should eq 1
+          order.payments.first.source.should be_a(Spree::CreditCard)
+          order.payments.first.amount.should eq order_total
+        end
+      end
+
+      context "there are no other payments" do
+        it "adds an error to the model" do
+          expect(subject).to be false
+          order.errors.full_messages.should include(Spree.t("store_credit.errors.unable_to_fund"))
+        end
+      end
+
+      context "there is a payment of an unknown type" do
+        let!(:check_payment) { create(:check_payment, order: order) }
+
+        it "raises an error" do
+          expect { subject }.to raise_error
+        end
+      end
+    end
+
+    context "there is enough store credit to pay for the entire order" do
+      let(:store_credit) { create(:store_credit, amount: order_total) }
+      let(:order)        { create(:order, user: store_credit.user, total: order_total) }
+
+      context "there are no other payments" do
+        before do
+          subject
+          order.reload
+        end
+
+        it "creates a store credit payment for the full amount" do
+          order.payments.count.should eq 1
+          order.payments.first.should be_store_credit
+          order.payments.first.amount.should eq order_total
+        end
+      end
+
+      context "there is a credit card payment" do
+        let!(:cc_payment) { create(:payment, order: order) }
+
+        before { subject }
+
+        it "should invalidate the credit card payment" do
+          cc_payment.reload.state.should == 'invalid'
+        end
+      end
+
+      context "there is a payment of an unknown type" do
+        let!(:check_payment) { create(:check_payment, order: order) }
+
+        it "raises an error" do
+          expect { subject }.to raise_error
+        end
+      end
+    end
+
+    context "the available store credit is not enough to pay for the entire order" do
+      let(:expected_cc_total)  { 100.0 }
+      let(:store_credit_total) { order_total - expected_cc_total }
+      let(:store_credit)       { create(:store_credit, amount: store_credit_total) }
+      let(:order)              { create(:order, user: store_credit.user, total: order_total) }
+
+
+      context "there are no other payments" do
+        it "adds an error to the model" do
+          expect(subject).to be false
+          order.errors.full_messages.should include(Spree.t("store_credit.errors.unable_to_fund"))
+        end
+      end
+
+      context "there is a credit card payment" do
+        let!(:cc_payment) { create(:payment, order: order) }
+
+        before do
+          # callbacks recalculate total based on line items
+          # this ensures the total is what we expect
+          order.update_column(:total, order_total)
+          subject
+          order.reload
+        end
+
+        it "charges the outstanding balance to the credit card" do
+          order.payments.count.should eq 2
+          order.payments.first.source.should be_a(Spree::CreditCard)
+          order.payments.first.amount.should eq expected_cc_total
+        end
+      end
+
+      context "there is a payment of an unknown type" do
+        let!(:check_payment) { create(:check_payment, order: order) }
+
+        it "raises an error" do
+          expect { subject }.to raise_error
+        end
+      end
+    end
+
+    context "there are multiple store credits" do
+      context "they have different credit type priorities" do
+        let(:amount_difference)       { 100 }
+        let!(:primary_store_credit)   { create(:store_credit, amount: (order_total - amount_difference)) }
+        let!(:secondary_store_credit) { create(:store_credit, amount: order_total, user: primary_store_credit.user, credit_type: create(:secondary_credit_type)) }
+        let(:order)                   { create(:order, user: primary_store_credit.user, total: order_total) }
+
+        before do
+          subject
+          order.reload
+        end
+
+        it "uses the primary store credit type over the secondary" do
+          primary_payment = order.payments.first
+          secondary_payment = order.payments.last
+
+          order.payments.size.should eq 2
+          primary_payment.source.should eq primary_store_credit
+          secondary_payment.source.should eq secondary_store_credit
+          primary_payment.amount.should eq(order_total - amount_difference)
+          secondary_payment.amount.should eq(amount_difference)
+        end
+      end
+    end
+  end
+
+  describe "#covered_by_store_credit" do
+    context "order doesn't have an associated user" do
+      subject { create(:store_credits_order_without_user) }
+
+      it "returns false" do
+        expect(subject.covered_by_store_credit).to be false
+      end
+    end
+
+    context "order has an associated user" do
+      let(:user) { create(:user) }
+
+      subject    { create(:order, user: user) }
+
+      context "user has enough store credit to pay for the order" do
+        before do
+          user.stub(total_available_store_credit: 10.0)
+          subject.stub(total: 5.0)
+        end
+
+        it "returns true" do
+          expect(subject.covered_by_store_credit).to be true
+        end
+      end
+
+      context "user does not have enough store credit to pay for the order" do
+        before do
+          user.stub(total_available_store_credit: 0.0)
+          subject.stub(total: 5.0)
+        end
+
+        it "returns false" do
+          expect(subject.covered_by_store_credit).to be false
+        end
+      end
+    end
+  end
+
+  describe "#total_available_store_credit" do
+    context "order does not have an associated user" do
+      subject { create(:store_credits_order_without_user) }
+
+      it "returns 0" do
+        subject.total_available_store_credit.should be_zero
+      end
+    end
+
+    context "order has an associated user" do
+      let(:user)                   { create(:user) }
+      let(:available_store_credit) { 25.0 }
+
+      subject { create(:order, user: user) }
+
+      before do
+        user.stub(total_available_store_credit: available_store_credit)
+      end
+
+      it "returns the user's available store credit" do
+        subject.total_available_store_credit.should eq available_store_credit
+      end
+    end
+  end
+
+  describe "#order_total_after_store_credit" do
+    let(:order_total) { 100.0 }
+
+    subject { create(:order, total: order_total) }
+
+    before do
+      subject.stub(total_applicable_store_credit: applicable_store_credit)
+    end
+
+    context "order's user has store credits" do
+      let(:applicable_store_credit) { 10.0 }
+
+      it "deducts the applicable store credit" do
+        subject.order_total_after_store_credit.should eq (order_total - applicable_store_credit)
+      end
+    end
+
+    context "order's user does not have any store credits" do
+      let(:applicable_store_credit) { 0.0 }
+
+      it "returns the order total" do
+        subject.order_total_after_store_credit.should eq order_total
+      end
+    end
+  end
+
+  describe "transition to complete" do
+    let(:order) { create(:order_with_line_items, state: 'confirm') }
+    let!(:payment) { create(:payment, order: order, state: 'pending') }
+    subject { order.next! }
+
+    it "calls #send_gift_card_emails" do
+      order.should_receive(:send_gift_card_emails)
+      subject
+    end
+
+  end
+
+  describe "#send_gift_card_emails" do
+
+    subject { order.send_gift_card_emails }
+
+    context "the order has gift cards" do
+      let(:gift_card) { create(:virtual_gift_card) }
+      let(:line_item) { gift_card.line_item }
+      let(:gift_card_2) { create(:virtual_gift_card, line_item: line_item) }
+      let(:order) { gift_card.line_item.order }
+
+      it "should call GiftCardMailer#send" do
+        expect(Spree::GiftCardMailer).to receive(:gift_card_email).with(gift_card).and_return(double(deliver: true))
+        expect(Spree::GiftCardMailer).to receive(:gift_card_email).with(gift_card_2).and_return(double(deliver: true))
+        subject
+      end
+    end
+
+    context "no gift cards" do
+      let(:order) { create(:order_with_line_items) }
+
+      it "should not call GiftCardMailer#send" do
+        expect(Spree::GiftCardMailer).to_not receive(:gift_card_email)
+        subject
+      end
+    end
+  end
+  
+  describe "#total_applicable_store_credit" do
+    context "order is in the confirm state" do
+      before { order.update_attributes(state: 'confirm') }
+      include_examples "check total store credit from payments"
+    end
+
+    context "order is completed" do
+      before { order.update_attributes(state: 'complete') }
+      include_examples "check total store credit from payments"
+    end
+
+    context "order is in any state other than confirm or complete" do
+      context "the associated user has store credits" do
+        let(:store_credit) { create(:store_credit) }
+        let(:order)        { create(:order, user: store_credit.user) }
+
+        subject { order }
+
+        context "the store credit is more than the order total" do
+          let(:order_total) { store_credit.amount - 1 }
+
+          before { order.update_attributes(total: order_total) }
+
+          it "returns the order total" do
+            subject.total_applicable_store_credit.should eq order_total
+          end
+        end
+
+        context "the store credit is less than the order total" do
+          let(:order_total) { store_credit.amount * 10 }
+
+          before { order.update_attributes(total: order_total) }
+
+          it "returns the store credit amount" do
+            subject.total_applicable_store_credit.should eq store_credit.amount
+          end
+        end
+      end
+
+      context "the associated user does not have store credits" do
+        let(:order) { create(:order) }
+
+        subject { order }
+
+        it "returns 0" do
+          subject.total_applicable_store_credit.should be_zero
+        end
+      end
+
+      context "the order does not have an associated user" do
+        subject { create(:store_credits_order_without_user) }
+
+        it "returns 0" do
+          subject.total_applicable_store_credit.should be_zero
+        end
+      end
+    end
+  end
+
+  describe "#display_total_applicable_store_credit" do
+    let(:total_applicable_store_credit) { 10.00 }
+
+    subject { create(:order) }
+
+    before { subject.stub(total_applicable_store_credit: total_applicable_store_credit) }
+
+    it "returns a money instance" do
+      subject.display_total_applicable_store_credit.should be_a(Spree::Money)
+    end
+
+    it "returns a negative amount" do
+      subject.display_total_applicable_store_credit.money.cents.should eq (total_applicable_store_credit * -100.0)
+    end
+  end
+
+  describe "#display_order_total_after_store_credit" do
+    let(:order_total_after_store_credit) { 10.00 }
+
+    subject { create(:order) }
+
+    before { subject.stub(order_total_after_store_credit: order_total_after_store_credit) }
+
+    it "returns a money instance" do
+      subject.display_order_total_after_store_credit.should be_a(Spree::Money)
+    end
+
+    it "returns the order_total_after_store_credit amount" do
+      subject.display_order_total_after_store_credit.money.cents.should eq (order_total_after_store_credit * 100.0)
+    end
+  end
+
+  describe "#display_total_available_store_credit" do
+    let(:total_available_store_credit) { 10.00 }
+
+    subject { create(:order) }
+
+    before { subject.stub(total_available_store_credit: total_available_store_credit) }
+
+    it "returns a money instance" do
+      subject.display_total_available_store_credit.should be_a(Spree::Money)
+    end
+
+    it "returns the total_available_store_credit amount" do
+      subject.display_total_available_store_credit.money.cents.should eq (total_available_store_credit * 100.0)
+    end
+  end
+
+  describe "#display_store_credit_remaining_after_capture" do
+    let(:total_available_store_credit)  { 10.00 }
+    let(:total_applicable_store_credit) { 5.00 }
+
+    subject { create(:order) }
+
+    before do
+      subject.stub(total_available_store_credit: total_available_store_credit,
+                   total_applicable_store_credit: total_applicable_store_credit)
+    end
+
+    it "returns a money instance" do
+      subject.display_store_credit_remaining_after_capture.should be_a(Spree::Money)
+    end
+
+    it "returns all of the user's available store credit minus what's applied to the order amount" do
+      amount_remaining = total_available_store_credit - total_applicable_store_credit
+      subject.display_store_credit_remaining_after_capture.money.cents.should eq (amount_remaining * 100.0)
+    end
+  end
+  
   context "#canceled_by" do
     let(:admin_user) { create :admin_user }
     let(:order) { create :order }

--- a/core/spec/models/spree/payment_method/store_credit_spec.rb
+++ b/core/spec/models/spree/payment_method/store_credit_spec.rb
@@ -1,0 +1,281 @@
+require 'spec_helper'
+
+describe Spree::PaymentMethod::StoreCredit do
+  let(:order)           { create(:order) }
+  let(:payment)         { create(:payment, order: order) }
+  let(:gateway_options) { payment.gateway_options }
+
+  context "#authorize" do
+    subject do
+      Spree::PaymentMethod::StoreCredit.new.authorize(auth_amount, store_credit, gateway_options)
+    end
+
+    let(:auth_amount) { store_credit.amount_remaining * 100 }
+    let(:store_credit) { create(:store_credit) }
+    let(:gateway_options) { super().merge(originator: originator) }
+    let(:originator) { nil }
+
+    context 'without an invalid store credit' do
+      let(:store_credit) { nil }
+      let(:auth_amount) { 10 }
+
+      it "declines an unknown store credit" do
+        expect(subject.success?).to be false
+        subject.message.should include Spree.t('store_credit_payment_method.unable_to_find')
+      end
+    end
+
+    context 'with insuffient funds' do
+      let(:auth_amount) { (store_credit.amount_remaining * 100) + 1 }
+
+      it "declines a store credit" do
+        expect(subject.success?).to be false
+        subject.message.should include Spree.t('store_credit_payment_method.insufficient_funds')
+      end
+    end
+
+    context 'when the currency does not match the order currency' do
+      let(:store_credit) { create(:store_credit, currency: 'AUD') }
+
+      it "declines the credit" do
+        expect(subject.success?).to be false
+        subject.message.should include Spree.t('store_credit_payment_method.currency_mismatch')
+      end
+    end
+
+    context 'with a valid request' do
+      it "authorizes a valid store credit" do
+        expect(subject.success?).to be true
+        subject.authorization.should_not be_nil
+      end
+
+      context 'with an originator' do
+        let(:originator) { double('originator') }
+
+        it 'passes the originator' do
+          Spree::StoreCredit.any_instance.should_receive(:authorize)
+            .with(anything, anything, action_originator: originator)
+          subject
+        end
+      end
+    end
+  end
+
+  context "#capture" do
+    subject do
+      Spree::PaymentMethod::StoreCredit.new.capture(capture_amount, auth_code, gateway_options)
+    end
+
+    let(:capture_amount) { 10_00 }
+    let(:auth_code) { auth_event.authorization_code }
+    let(:gateway_options) { super().merge(originator: originator) }
+
+    let(:authorized_amount) { capture_amount/100.0 }
+    let(:auth_event) { create(:store_credit_auth_event, store_credit: store_credit, amount: authorized_amount) }
+    let(:store_credit) { create(:store_credit, amount_authorized: authorized_amount) }
+    let(:originator) { nil }
+
+    context 'with an invalid auth code' do
+      let(:auth_code) { -1 }
+
+      it "declines an unknown store credit" do
+        expect(subject.success?).to be false
+        subject.message.should include Spree.t('store_credit_payment_method.unable_to_find')
+      end
+    end
+
+    context 'when unable to authorize the amount' do
+      let(:authorized_amount) { (capture_amount-1)/100 }
+
+      before do
+        Spree::StoreCredit.any_instance.stub(authorize: true)
+      end
+
+      it "declines a store credit" do
+        expect(subject.success?).to be false
+        subject.message.should include Spree.t('store_credit_payment_method.insufficient_authorized_amount')
+      end
+    end
+
+    context 'when the currency does not match the order currency' do
+      let(:store_credit) { create(:store_credit, currency: 'AUD', amount_authorized: authorized_amount) }
+
+      it "declines the credit" do
+        expect(subject.success?).to be false
+        subject.message.should include Spree.t('store_credit_payment_method.currency_mismatch')
+      end
+    end
+
+    context 'with a valid request' do
+      it "captures the store credit" do
+        subject.message.should include Spree.t('store_credit_payment_method.successful_action', action: Spree::StoreCredit::CAPTURE_ACTION)
+        expect(subject.success?).to be true
+      end
+
+      context 'with an originator' do
+        let(:originator) { double('originator') }
+
+        it 'passes the originator' do
+          Spree::StoreCredit.any_instance.should_receive(:capture)
+            .with(anything, anything, anything, action_originator: originator)
+          subject
+        end
+      end
+    end
+  end
+
+  context "#void" do
+    subject do
+      Spree::PaymentMethod::StoreCredit.new.void(auth_code, gateway_options)
+    end
+
+    let(:auth_code) { auth_event.authorization_code }
+    let(:gateway_options) { super().merge(originator: originator) }
+    let(:auth_event) { create(:store_credit_auth_event) }
+    let(:originator) { nil }
+
+    context 'with an invalid auth code' do
+      let(:auth_code) { 1 }
+
+      it "declines an unknown store credit" do
+        expect(subject.success?).to be false
+        subject.message.should include Spree.t('store_credit_payment_method.unable_to_find')
+      end
+    end
+
+    context 'when the store credit is not voided successfully' do
+      before { Spree::StoreCredit.any_instance.stub(void: false) }
+
+      it "returns an error response" do
+        expect(subject.success?).to be false
+      end
+    end
+
+    it "voids a valid store credit void request" do
+      expect(subject.success?).to be true
+      subject.message.should include Spree.t('store_credit_payment_method.successful_action', action: Spree::StoreCredit::VOID_ACTION)
+    end
+
+    context 'with an originator' do
+      let(:originator) { double('originator') }
+
+      it 'passes the originator' do
+        Spree::StoreCredit.any_instance.should_receive(:void)
+          .with(anything, action_originator: originator)
+        subject
+      end
+    end
+  end
+
+  context "#purchase" do
+    it "declines a purchase if it can't find a pending credit for the correct amount" do
+      amount = 100.0
+      store_credit = create(:store_credit)
+      auth_code = store_credit.generate_authorization_code
+      store_credit.store_credit_events.create!(action: Spree::StoreCredit::ELIGIBLE_ACTION,
+                                               amount: amount,
+                                               authorization_code: auth_code)
+      store_credit.store_credit_events.create!(action: Spree::StoreCredit::CAPTURE_ACTION,
+                                               amount: amount,
+                                               authorization_code: auth_code)
+
+      resp = subject.purchase(amount * 100.0, store_credit, gateway_options)
+      expect(resp.success?).to be false
+      resp.message.should include Spree.t('store_credit_payment_method.unable_to_find')
+    end
+
+    it "captures a purchase if it can find a pending credit for the correct amount" do
+      amount = 100.0
+      store_credit = create(:store_credit)
+      auth_code = store_credit.generate_authorization_code
+      store_credit.store_credit_events.create!(action: Spree::StoreCredit::ELIGIBLE_ACTION,
+                                               amount: amount,
+                                               authorization_code: auth_code)
+
+      resp = subject.purchase(amount * 100.0, store_credit, gateway_options)
+      expect(resp.success?).to be true
+      resp.message.should include Spree.t('store_credit_payment_method.successful_action', action: Spree::StoreCredit::CAPTURE_ACTION)
+    end
+  end
+
+  context "#credit" do
+    subject do
+      Spree::PaymentMethod::StoreCredit.new.credit(credit_amount, auth_code, gateway_options)
+    end
+
+    let(:credit_amount) { 100.0 }
+    let(:auth_code) { auth_event.authorization_code }
+    let(:gateway_options) { super().merge(originator: originator) }
+    let(:auth_event) { create(:store_credit_auth_event) }
+    let(:originator) { nil }
+
+    context 'with an invalid auth code' do
+      let(:auth_code) { 1 }
+
+      it "declines an unknown store credit" do
+        expect(subject.success?).to be false
+        subject.message.should include Spree.t('store_credit_payment_method.unable_to_find')
+      end
+    end
+
+    context "when the store credit isn't credited successfully" do
+      before { Spree::StoreCredit.any_instance.stub(credit: false) }
+
+      it "returns an error response" do
+        expect(subject.success?).to be false
+      end
+    end
+
+    context 'with a valid credit request' do
+      before { Spree::StoreCredit.any_instance.stub(credit: true) }
+
+      it "credits a valid store credit credit request" do
+        expect(subject.success?).to be true
+        subject.message.should include Spree.t('store_credit_payment_method.successful_action', action: Spree::StoreCredit::CREDIT_ACTION)
+      end
+    end
+
+    context 'with an originator' do
+      let(:originator) { double('originator') }
+
+      it 'passes the originator' do
+        Spree::StoreCredit.any_instance.should_receive(:credit)
+          .with(anything, anything, anything, action_originator: originator)
+        subject
+      end
+    end
+  end
+
+  context "#cancel" do
+    subject do
+      Spree::PaymentMethod::StoreCredit.new.cancel(auth_code)
+    end
+
+    let(:store_credit) { create(:store_credit, amount_used: captured_amount) }
+    let(:auth_code)    { "1-SC-20141111111111" }
+    let(:captured_amount) { 10.0 }
+
+    let!(:capture_event) { create(:store_credit_auth_event,
+                                    action: Spree::StoreCredit::CAPTURE_ACTION,
+                                    authorization_code: auth_code,
+                                    amount: captured_amount,
+                                    store_credit: store_credit) }
+
+    context "store credit event found" do
+      it "creates a store credit for the same amount that was captured" do
+        Spree::StoreCredit.any_instance.should_receive(:credit).with(captured_amount, auth_code, store_credit.currency)
+        subject
+      end
+    end
+
+    context "store credit event not found" do
+      subject do
+        Spree::PaymentMethod::StoreCredit.new.cancel('INVALID')
+      end
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -52,6 +52,55 @@ describe Spree::Payment, :type => :model do
     allow(payment.log_entries).to receive(:create!)
   end
 
+  context "#cancel!" do
+
+    subject do
+      payment.cancel!
+    end
+
+    context "a store credit" do
+
+      let(:store_credit) { create(:store_credit, amount_used: captured_amount) }
+      let(:auth_code)    { "1-SC-20141111111111" }
+      let(:captured_amount) { 10.0 }
+
+      let!(:capture_event) { create(:store_credit_auth_event,
+                                    action: Spree::StoreCredit::CAPTURE_ACTION,
+                                    authorization_code: auth_code,
+                                    amount: captured_amount,
+                                    store_credit: store_credit) }
+
+      let(:payment) { create(:store_credit_payment, response_code: auth_code) }
+
+      it "attemps to cancels the payment" do
+        payment.payment_method.should_receive(:cancel).with(payment.response_code)
+        subject
+      end
+
+      context "cancels successfully" do
+        it "voids the payment" do
+          expect { subject }.to change{ payment.state }.to('void')
+        end
+      end
+
+      context "does not cancel successfully" do
+        it "does not change the payment state" do
+          Spree::PaymentMethod::StoreCredit.any_instance.stub(:cancel).and_return(false)
+          expect { subject }.to_not change{ payment.state }
+        end
+      end
+    end
+
+    context "not a store credit" do
+      let(:payment) { create(:payment) }
+
+      it "should call super" do
+        payment.should_receive(:cancel!)
+        subject
+      end
+    end
+  end
+  
   context '.risky' do
 
     let!(:payment_1) { create(:payment, avs_response: 'Y', cvv_response_code: 'M', cvv_response_message: 'Match') }

--- a/core/spec/models/spree/reimbursement_type/store_credit_spec.rb
+++ b/core/spec/models/spree/reimbursement_type/store_credit_spec.rb
@@ -1,0 +1,97 @@
+require 'spec_helper'
+
+module Spree
+  describe ReimbursementType::StoreCredit do
+    let(:reimbursement)           { create(:reimbursement, return_items_count: 2) }
+    let(:return_item)             { reimbursement.return_items.first }
+    let(:return_item2)            { reimbursement.return_items.last }
+    let(:payment)                 { reimbursement.order.payments.first }
+    let(:simulate)                { false }
+    let!(:default_refund_reason)  { Spree::RefundReason.find_or_create_by!(name: Spree::RefundReason::RETURN_PROCESSING_REASON, mutable: false) }
+
+    let!(:primary_credit_type)    { create(:primary_credit_type) }
+    let!(:created_by_user)        { create(:user, email: Spree::StoreCredit::DEFAULT_CREATED_BY_EMAIL) }
+    let!(:default_reimbursement_category) { create(:store_credit_category) }
+
+    subject { Spree::ReimbursementType::StoreCredit.reimburse(reimbursement, [return_item, return_item2], simulate)}
+
+    before do
+      reimbursement.update!(total: reimbursement.calculated_total)
+    end
+
+    describe '.reimburse' do
+      context 'simulate is true' do
+        let(:simulate) { true }
+
+        context 'for store credits that the customer used' do
+          before do
+            Spree::ReimbursementType::StoreCredit.should_receive(:store_credit_payments).and_return([payment])
+          end
+
+          it 'creates readonly refunds for all store credit payments' do
+            expect(subject.map(&:class)).to eq [Spree::Refund]
+            expect(subject.map(&:readonly?)).to eq [true]
+          end
+
+          it 'does not save to the database' do
+            expect { subject }.to_not change { payment.refunds.count }
+          end
+        end
+
+        context 'for return items that were not paid for with store credit' do
+          before do
+            Spree::ReimbursementType::StoreCredit.should_receive(:store_credit_payments).and_return([])
+          end
+
+          context 'creates one readonly lump credit for all outstanding balance payable to the customer' do
+            it 'creates a credit that is read only' do
+              expect(subject.map(&:class)).to eq [Spree::Reimbursement::Credit]
+              expect(subject.map(&:readonly?)).to eq [true]
+            end
+
+            it 'creates a credit which amounts to the sum of the return items rounded down' do
+              return_item.should_receive(:total).and_return(10.0076)
+              return_item2.should_receive(:total).and_return(10.0023)
+              expect(subject.sum(&:amount)).to eq 20.0
+            end
+          end
+
+          it 'does not save to the database' do
+            expect { subject }.to_not change { Spree::Reimbursement::Credit.count }
+          end
+        end
+      end
+
+      context 'simulate is false' do
+        let(:simulate) { false }
+
+        context 'for store credits that the customer used' do
+          before do
+            Spree::ReimbursementType::StoreCredit.should_receive(:store_credit_payments).and_return([payment])
+          end
+
+          it 'performs refunds for all store credit payments' do
+            expect { subject }.to change { payment.refunds.count }.by(1)
+            expect(payment.refunds.sum(:amount)).to eq reimbursement.return_items.to_a.sum(&:total)
+          end
+        end
+
+        context 'for return items that were not paid for with store credit' do
+          before do
+            Spree::ReimbursementType::StoreCredit.should_receive(:store_credit_payments).and_return([])
+          end
+
+          it 'creates one lump credit for all outstanding balance payable to the customer' do
+            expect { subject }.to change { Spree::Reimbursement::Credit.count }.by(1)
+            expect(subject.sum(&:amount)).to eq reimbursement.return_items.to_a.sum(&:total)
+          end
+
+          it "creates a store credit with the same currency as the reimbursement's order" do
+            expect { subject }.to change { Spree::StoreCredit.count }.by(1)
+            Spree::StoreCredit.last.currency.should eq reimbursement.order.currency
+          end
+        end
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/store_credit_category_spec.rb
+++ b/core/spec/models/spree/store_credit_category_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe Spree::StoreCreditCategory, :type => :model do
+  describe "#non_expiring?" do
+    subject { build(:store_credit_category, name: category_name).non_expiring? }
+    
+    context "non-expiring type store credit" do
+      let(:category_name) { Spree::StoreCredits::Configuration.non_expiring_credit_types.first }
+
+      it "returns true" do
+        expect(subject).to be true
+      end
+    end
+
+    context "expiring type store credit" do
+      let(:category_name) { "Expiring" }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/store_credit_event_spec.rb
+++ b/core/spec/models/spree/store_credit_event_spec.rb
@@ -1,0 +1,107 @@
+require 'spec_helper'
+
+describe "StoreCreditEvent" do
+  describe "#display_amount" do
+    let(:event_amount) { 120.0 }
+
+    subject { create(:store_credit_auth_event, amount: event_amount) }
+
+    it "returns a Spree::Money instance" do
+      subject.display_amount.should be_instance_of(Spree::Money)
+    end
+
+    it "uses the events amount attribute" do
+      subject.display_amount.should eq Spree::Money.new(event_amount, { currency: subject.currency })
+    end
+  end
+
+  describe "#display_user_total_amount" do
+    let(:user_total_amount) { 300.0 }
+
+    subject { create(:store_credit_auth_event, user_total_amount: user_total_amount) }
+
+    it "returns a Spree::Money instance" do
+      subject.display_user_total_amount.should be_instance_of(Spree::Money)
+    end
+
+    it "uses the events user_total_amount attribute" do
+      subject.display_user_total_amount.should eq Spree::Money.new(user_total_amount, { currency: subject.currency })
+    end
+  end
+
+  describe "#display_event_date" do
+    let(:date) { DateTime.new(2014, 06, 1) }
+
+    subject { create(:store_credit_auth_event, created_at: date) }
+
+    it "returns the date the event was created with the format month/date/year" do
+      subject.display_event_date.should eq "06/01/2014"
+    end
+  end
+
+  describe "#display_action" do
+    subject { create(:store_credit_auth_event, action: action) }
+
+    context "capture event" do
+      let(:action) { Spree::StoreCredit::CAPTURE_ACTION }
+
+      it "returns used" do
+        subject.display_action.should eq Spree.t('store_credit.captured')
+      end
+    end
+
+    context "authorize event" do
+      let(:action) { Spree::StoreCredit::AUTHORIZE_ACTION }
+
+      it "returns authorized" do
+        subject.display_action.should eq Spree.t('store_credit.authorized')
+      end
+    end
+
+    context "allocation event" do
+      let(:action) { Spree::StoreCredit::ALLOCATION_ACTION }
+
+      it "returns added" do
+        subject.display_action.should eq Spree.t('store_credit.allocated')
+      end
+    end
+
+    context "void event" do
+      let(:action) { Spree::StoreCredit::VOID_ACTION }
+
+      it "returns credit" do
+        subject.display_action.should eq Spree.t('store_credit.credit')
+      end
+    end
+
+    context "credit event" do
+      let(:action) { Spree::StoreCredit::CREDIT_ACTION }
+
+      it "returns credit" do
+        subject.display_action.should eq Spree.t('store_credit.credit')
+      end
+    end
+  end
+
+  describe "#order" do
+    context "there is no associated payment with the event" do
+      subject { create(:store_credit_auth_event) }
+
+      it "returns nil" do
+        subject.order.should be_nil
+      end
+    end
+
+    context "there is an associated payment with the event" do
+      let(:authorization_code) { "1-SC-TEST" }
+      let(:order)              { create(:order) }
+      let!(:payment)           { create(:store_credit_payment, order: order, response_code: authorization_code) }
+
+      subject { create(:store_credit_auth_event, action: Spree::StoreCredit::CAPTURE_ACTION, authorization_code: authorization_code) }
+
+      it "returns the order associated with the payment" do
+        subject.order.should eq order
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/store_credit_spec.rb
+++ b/core/spec/models/spree/store_credit_spec.rb
@@ -1,0 +1,765 @@
+require 'spec_helper'
+
+describe "StoreCredit" do
+
+  let(:currency) { "TEST" }
+  let(:store_credit) { build(:store_credit, store_credit_attrs) }
+  let(:store_credit_attrs) { {} }
+
+
+  describe "callbacks" do
+    subject { store_credit.save }
+
+    context "amount used is greater than zero" do
+      let(:store_credit) { create(:store_credit, amount: 100, amount_used: 1) }
+      subject { store_credit.destroy }
+
+      it 'can not delete the store credit' do
+        subject
+        store_credit.reload.should eq store_credit
+        store_credit.errors[:amount_used].should include(Spree.t('admin.store_credits.errors.amount_used_not_zero'))
+      end
+    end
+
+    context "category is a non-expiring type" do
+      let!(:secondary_credit_type) { create(:secondary_credit_type) }
+      let(:store_credit) { build(:store_credit, credit_type: nil)}
+
+      before do
+        store_credit.category.stub(:non_expiring?).and_return(true)
+      end
+
+      it "sets the credit type to non-expiring" do
+        subject
+        store_credit.credit_type.name.should eq secondary_credit_type.name
+      end
+    end
+
+    context "category is an expiring type" do
+      before do
+        store_credit.category.stub(:non_expiring?).and_return(false)
+      end
+
+      it "sets the credit type to non-expiring" do
+        subject
+        store_credit.credit_type.name.should eq "Expiring"
+      end
+    end
+
+    context "the type is set" do
+      let!(:secondary_credit_type) { create(:secondary_credit_type)}
+      let(:store_credit) { build(:store_credit, credit_type: secondary_credit_type)}
+
+      before do
+        store_credit.category.stub(:non_expiring?).and_return(false)
+      end
+
+      it "doesn't overwrite the type" do
+        expect{ subject }.to_not change{ store_credit.credit_type }
+      end
+    end
+  end
+
+  describe "validations" do
+    describe "used amount should not be greater than the credited amount" do
+      context "the used amount is defined" do
+        let(:invalid_store_credit) { build(:store_credit, amount: 100, amount_used: 150) }
+
+        it "should not be valid" do
+          invalid_store_credit.should_not be_valid
+        end
+
+        it "should set the correct error message" do
+          invalid_store_credit.valid?
+          attribute_name = I18n.t('activerecord.attributes.spree/store_credit.amount_used')
+          validation_message = Spree.t('admin.store_credits.errors.amount_used_cannot_be_greater')
+          expected_error_message = "#{attribute_name} #{validation_message}"
+          invalid_store_credit.errors.full_messages.should include(expected_error_message)
+        end
+      end
+
+      context "the used amount is not defined yet" do
+        let(:store_credit) { build(:store_credit, amount: 100) }
+
+        it "should be valid" do
+          store_credit.should be_valid
+        end
+
+      end
+    end
+
+    describe "amount used less than or equal to amount" do
+      subject { build(:store_credit, amount_used: 101.0, amount: 100.0) }
+
+      it "is not valid" do
+        subject.should_not be_valid
+      end
+
+      it "adds an error message about the invalid amount used" do
+        subject.valid?
+        subject.errors[:amount_used].should include(Spree.t('admin.store_credits.errors.amount_used_cannot_be_greater'))
+      end
+    end
+
+    describe "amount authorized less than or equal to amount" do
+      subject { build(:store_credit, amount_authorized: 101.0, amount: 100.0) }
+
+      it "is not valid" do
+        subject.should_not be_valid
+      end
+
+      it "adds an error message about the invalid authorized amount" do
+        subject.valid?
+        subject.errors[:amount_authorized].should include(Spree.t('admin.store_credits.errors.amount_authorized_exceeds_total_credit'))
+      end
+    end
+  end
+
+  describe "#display_amount" do
+    it "returns a Spree::Money instance" do
+      store_credit.display_amount.should be_instance_of(Spree::Money)
+    end
+  end
+
+  describe "#display_amount_used" do
+    it "returns a Spree::Money instance" do
+      store_credit.display_amount_used.should be_instance_of(Spree::Money)
+    end
+  end
+
+  describe "#amount_remaining" do
+    context "the amount_used is not defined" do
+      context "the authorized amount is not defined" do
+        it "returns the credited amount" do
+          store_credit.amount_remaining.should eq store_credit.amount
+        end
+      end
+      context "the authorized amount is defined" do
+        let(:authorized_amount) { 15.00 }
+
+        before { store_credit.update_attributes(amount_authorized: authorized_amount) }
+
+        it "subtracts the authorized amount from the credited amount" do
+          store_credit.amount_remaining.should eq (store_credit.amount - authorized_amount)
+        end
+      end
+    end
+
+    context "the amount_used is defined" do
+      let(:amount_used) { 10.0 }
+
+      before { store_credit.update_attributes(amount_used: amount_used) }
+
+      context "the authorized amount is not defined" do
+        it "subtracts the amount used from the credited amount" do
+          store_credit.amount_remaining.should eq (store_credit.amount - amount_used)
+        end
+      end
+
+      context "the authorized amount is defined" do
+        let(:authorized_amount) { 15.00 }
+
+        before { store_credit.update_attributes(amount_authorized: authorized_amount) }
+
+        it "subtracts the amount used and the authorized amount from the credited amount" do
+          store_credit.amount_remaining.should eq (store_credit.amount - amount_used - authorized_amount)
+        end
+      end
+    end
+  end
+
+  describe "#authorize" do
+    context "amount is valid" do
+      let(:authorization_amount)       { 1.0 }
+      let(:added_authorization_amount) { 3.0 }
+      let(:originator) { nil }
+
+      context "amount has not been authorized yet" do
+
+        before { store_credit.update_attributes(amount_authorized: authorization_amount) }
+
+        it "returns true" do
+          expect(store_credit.authorize(store_credit.amount - authorization_amount, store_credit.currency)).to be_truthy
+        end
+
+        it "adds the new amount to authorized amount" do
+          store_credit.authorize(added_authorization_amount, store_credit.currency)
+          store_credit.reload.amount_authorized.should eq (authorization_amount + added_authorization_amount)
+        end
+
+        context "originator is present" do
+          with_model 'OriginatorThing'
+
+          let(:originator) { OriginatorThing.create! } # won't actually be a user. just giving it a valid model here
+
+          subject { store_credit.authorize(added_authorization_amount, store_credit.currency, action_originator: originator) }
+
+          it "records the originator" do
+            expect { subject }.to change { Spree::StoreCreditEvent.count }.by(1)
+            expect(Spree::StoreCreditEvent.last.originator).to eq originator
+          end
+        end
+      end
+
+      context "authorization has already happened" do
+        let!(:auth_event) { create(:store_credit_auth_event, store_credit: store_credit) }
+
+        before { store_credit.update_attributes(amount_authorized: store_credit.amount) }
+
+        it "returns true" do
+          expect(store_credit.authorize(store_credit.amount, store_credit.currency, action_authorization_code: auth_event.authorization_code)).to be true
+        end
+      end
+    end
+
+    context "amount is invalid" do
+      it "returns false" do
+        expect(store_credit.authorize(store_credit.amount * 2, store_credit.currency)).to be false
+      end
+    end
+  end
+
+  describe "#validate_authorization" do
+    context "insufficient funds" do
+      subject { store_credit.validate_authorization(store_credit.amount * 2, store_credit.currency) }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+
+      it "adds an error to the model" do
+        subject
+        store_credit.errors.full_messages.should include(Spree.t('store_credit_payment_method.insufficient_funds'))
+      end
+    end
+
+    context "currency mismatch" do
+      subject { store_credit.validate_authorization(store_credit.amount, "EUR") }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+
+      it "adds an error to the model" do
+        subject
+        store_credit.errors.full_messages.should include(Spree.t('store_credit_payment_method.currency_mismatch'))
+      end
+    end
+
+    context "valid authorization" do
+      subject { store_credit.validate_authorization(store_credit.amount, store_credit.currency) }
+
+      it "returns true" do
+        expect(subject).to be true
+      end
+    end
+
+    context 'troublesome floats' do
+      # 8.21.to_d < 8.21 => true
+      let(:store_credit_attrs) { {amount: 8.21} }
+
+      subject { store_credit.validate_authorization(store_credit_attrs[:amount], store_credit.currency) }
+
+      it { should be_truthy }
+    end
+  end
+
+  describe "#capture" do
+    let(:authorized_amount) { 10.00 }
+    let(:auth_code)         { "23-SC-20140602164814476128" }
+
+    before do
+      store_credit.update_attributes(amount_authorized: authorized_amount, amount_used: 0.0)
+      store_credit.stub(authorize: true)
+    end
+
+    context "insufficient funds" do
+      subject { store_credit.capture(authorized_amount * 2, auth_code,store_credit.currency) }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+
+      it "adds an error to the model" do
+        subject
+        store_credit.errors.full_messages.should include(Spree.t('store_credit_payment_method.insufficient_authorized_amount'))
+      end
+
+      it "does not update the store credit model" do
+        expect { subject }.to_not change { store_credit }
+      end
+    end
+
+    context "currency mismatch" do
+      subject { store_credit.capture(authorized_amount, auth_code, "EUR") }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+
+      it "adds an error to the model" do
+        subject
+        store_credit.errors.full_messages.should include(Spree.t('store_credit_payment_method.currency_mismatch'))
+      end
+
+      it "does not update the store credit model" do
+        expect { subject }.to_not change { store_credit }
+      end
+    end
+
+    context "valid capture" do
+      let(:remaining_authorized_amount) { 1 }
+      let(:originator) { nil }
+
+      subject { store_credit.capture(authorized_amount - remaining_authorized_amount, auth_code, store_credit.currency, action_originator: originator) }
+
+      it "returns true" do
+        expect(subject).to be_truthy
+      end
+
+      it "updates the authorized amount to the difference between the captured amount and the authorized amount" do
+        subject
+        store_credit.reload.amount_authorized.should eq remaining_authorized_amount
+      end
+
+      it "updates the used amount to the current used amount plus the captured amount" do
+        subject
+        store_credit.reload.amount_used.should eq authorized_amount - remaining_authorized_amount
+      end
+
+      context "originator is present" do
+        with_model 'OriginatorThing'
+
+        let(:originator) { OriginatorThing.create! } # won't actually be a user. just giving it a valid model here
+
+        it "records the originator" do
+          expect { subject }.to change { Spree::StoreCreditEvent.count }.by(1)
+          expect(Spree::StoreCreditEvent.last.originator).to eq originator
+        end
+      end
+    end
+  end
+
+  describe "#void" do
+    let(:auth_code)    { "1-SC-20141111111111" }
+    let(:store_credit) { create(:store_credit, amount_used: 150.0) }
+    let(:originator) { nil }
+
+    subject do
+      store_credit.void(auth_code, action_originator: originator)
+    end
+
+    context "no event found for auth_code" do
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+
+      it "adds an error to the model" do
+        subject
+        store_credit.errors.full_messages.should include(Spree.t('store_credit_payment_method.unable_to_void', auth_code: auth_code))
+      end
+    end
+
+    context "capture event found for auth_code" do
+      let(:captured_amount) { 10.0 }
+      let!(:capture_event) { create(:store_credit_auth_event,
+                                    action: Spree::StoreCredit::CAPTURE_ACTION,
+                                    authorization_code: auth_code,
+                                    amount: captured_amount,
+                                    store_credit: store_credit) }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+
+      it "does not change the amount used on the store credit" do
+        expect { subject }.to_not change{ store_credit.amount_used.to_f }
+      end
+    end
+
+    context "auth event found for auth_code" do
+      let(:auth_event) { create(:store_credit_auth_event) }
+
+      let(:authorized_amount) { 10.0 }
+      let!(:auth_event) { create(:store_credit_auth_event,
+                                 authorization_code: auth_code,
+                                 amount: authorized_amount,
+                                 store_credit: store_credit) }
+
+      it "returns true" do
+        expect(subject).to be true
+      end
+
+      it "returns the capture amount to the store credit" do
+        expect { subject }.to change{ store_credit.amount_authorized.to_f }.by(-authorized_amount)
+      end
+
+      context "originator is present" do
+        with_model 'OriginatorThing'
+
+        let(:originator) { OriginatorThing.create! } # won't actually be a user. just giving it a valid model here
+
+        it "records the originator" do
+          expect { subject }.to change { Spree::StoreCreditEvent.count }.by(1)
+          expect(Spree::StoreCreditEvent.last.originator).to eq originator
+        end
+      end
+    end
+  end
+
+  describe "#credit" do
+    let(:event_auth_code) { "1-SC-20141111111111" }
+    let(:amount_used)     { 10.0 }
+    let(:store_credit)    { create(:store_credit, amount_used: amount_used) }
+    let!(:capture_event)  { create(:store_credit_auth_event,
+                                   action: Spree::StoreCredit::CAPTURE_ACTION,
+                                   authorization_code: event_auth_code,
+                                   amount: captured_amount,
+                                   store_credit: store_credit) }
+    let(:originator) { nil }
+
+    subject { store_credit.credit(credit_amount, auth_code, currency, action_originator: originator) }
+
+    context "currency does not match" do
+      let(:currency)        { "AUD" }
+      let(:credit_amount)   { 5.0 }
+      let(:captured_amount) { 100.0 }
+      let(:auth_code)       { event_auth_code }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+
+      it "adds an error message about the currency mismatch" do
+        subject
+        store_credit.errors.full_messages.should include(Spree.t('store_credit_payment_method.currency_mismatch'))
+      end
+    end
+
+    context "unable to find capture event" do
+      let(:currency)        { "USD" }
+      let(:credit_amount)   { 5.0 }
+      let(:captured_amount) { 100.0 }
+      let(:auth_code)       { "UNKNOWN_CODE" }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+
+      it "adds an error message about the currency mismatch" do
+        subject
+        store_credit.errors.full_messages.should include(Spree.t('store_credit_payment_method.unable_to_credit', auth_code: auth_code))
+      end
+    end
+
+    context "amount is more than what is captured" do
+      let(:currency)        { "USD" }
+      let(:credit_amount)   { 100.0 }
+      let(:captured_amount) { 5.0 }
+      let(:auth_code)       { event_auth_code }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+
+      it "adds an error message about the currency mismatch" do
+        subject
+        store_credit.errors.full_messages.should include(Spree.t('store_credit_payment_method.unable_to_credit', auth_code: auth_code))
+      end
+    end
+
+    context "amount is successfully credited" do
+      let(:currency)        { "USD" }
+      let(:credit_amount)   { 5.0 }
+      let(:captured_amount) { 100.0 }
+      let(:auth_code)       { event_auth_code }
+
+      context "credit_to_new_allocation is set" do
+        before { Spree::StoreCredits::Configuration.stub(:credit_to_new_allocation).and_return(true) }
+
+        it "returns true" do
+          expect(subject).to be true
+        end
+
+        it "creates a new store credit record" do
+          expect { subject }.to change { Spree::StoreCredit.count }.by(1)
+        end
+
+        it "does not create a new store credit event on the parent store credit" do
+          expect { subject }.to_not change { store_credit.store_credit_events.count }
+        end
+
+        context "credits the passed amount to a new store credit record" do
+          before do
+            subject
+            @new_store_credit = Spree::StoreCredit.last
+          end
+
+          it "does not set the amount used on hte originating store credit" do
+            store_credit.reload.amount_used.should eq amount_used
+          end
+
+          it "sets the correct amount on the new store credit" do
+            @new_store_credit.amount.should eq credit_amount
+          end
+
+          [:user_id, :category_id, :created_by_id, :currency, :type_id].each do |attr|
+            it "sets attribute #{attr} inherited from the originating store credit" do
+              @new_store_credit.send(attr).should eq store_credit.send(attr)
+            end
+          end
+
+          it "sets a memo" do
+            @new_store_credit.memo.should eq "This is a credit from store credit ID #{store_credit.id}"
+          end
+        end
+
+        context "originator is present" do
+          with_model 'OriginatorThing'
+
+          let(:originator) { OriginatorThing.create! } # won't actually be a user. just giving it a valid model here
+
+          it "records the originator" do
+            expect { subject }.to change { Spree::StoreCreditEvent.count }.by(1)
+            expect(Spree::StoreCreditEvent.last.originator).to eq originator
+          end
+        end
+      end
+
+      context "credit_to_new_allocation is not set" do
+        it "returns true" do
+          expect(subject).to be true
+        end
+
+        it "credits the passed amount to the store credit amount used" do
+          subject
+          store_credit.reload.amount_used.should eq (amount_used - credit_amount)
+        end
+
+        it "creates a new store credit event" do
+          expect { subject }.to change { store_credit.store_credit_events.count }.by(1)
+        end
+      end
+    end
+  end
+
+  describe "#amount_used" do
+    context "amount used is not defined" do
+      subject { Spree::StoreCredit.new }
+
+      it "returns zero" do
+        subject.amount_used.should be_zero
+      end
+    end
+
+    context "amount used is defined" do
+      let(:amount_used) { 100.0 }
+
+      subject { create(:store_credit, amount_used: amount_used) }
+
+      it "returns the attribute value" do
+        subject.amount_used.should eq amount_used
+      end
+    end
+  end
+
+  describe "#amount_authorized" do
+    context "amount authorized is not defined" do
+      subject { Spree::StoreCredit.new }
+
+      it "returns zero" do
+        subject.amount_authorized.should be_zero
+      end
+    end
+
+    context "amount authorized is defined" do
+      let(:amount_authorized) { 100.0 }
+
+      subject { create(:store_credit, amount_authorized: amount_authorized) }
+
+      it "returns the attribute value" do
+        subject.amount_authorized.should eq amount_authorized
+      end
+    end
+  end
+
+  describe "#can_capture?" do
+    let(:store_credit) { create(:store_credit) }
+    let(:payment)      { create(:payment, state: payment_state) }
+
+    subject { store_credit.can_capture?(payment) }
+
+    context "pending payment" do
+      let(:payment_state) { 'pending' }
+
+      it "returns true" do
+        expect(subject).to be true
+      end
+    end
+
+    context "checkout payment" do
+      let(:payment_state) { 'checkout' }
+
+      it "returns true" do
+        expect(subject).to be true
+      end
+    end
+
+    context "void payment" do
+      let(:payment_state) { Spree::StoreCredit::VOID_ACTION }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+    end
+
+    context "invalid payment" do
+      let(:payment_state) { 'invalid' }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+    end
+
+    context "complete payment" do
+      let(:payment_state) { 'completed' }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+    end
+  end
+
+  describe "#can_void?" do
+    let(:store_credit) { create(:store_credit) }
+    let(:payment)      { create(:payment, state: payment_state) }
+
+    subject { store_credit.can_void?(payment) }
+
+    context "pending payment" do
+      let(:payment_state) { 'pending' }
+
+      it "returns true" do
+        expect(subject).to be true
+      end
+    end
+
+    context "checkout payment" do
+      let(:payment_state) { 'checkout' }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+    end
+
+    context "void payment" do
+      let(:payment_state) { Spree::StoreCredit::VOID_ACTION }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+    end
+
+    context "invalid payment" do
+      let(:payment_state) { 'invalid' }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+    end
+
+    context "complete payment" do
+      let(:payment_state) { 'completed' }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+    end
+  end
+
+  describe "#can_credit?" do
+    let(:store_credit) { create(:store_credit) }
+    let(:payment)      { create(:payment, state: payment_state) }
+
+    subject { store_credit.can_credit?(payment) }
+
+    context "payment is not completed" do
+      let(:payment_state) { "pending" }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+    end
+
+    context "payment is completed" do
+      let(:payment_state) { "completed" }
+
+      context "credit is owed on the order" do
+        before { payment.order.stub(payment_state: 'credit_owed') }
+
+        context "payment doesn't have allowed credit" do
+          before { payment.stub(credit_allowed: 0.0) }
+
+          it "returns false" do
+            expect(subject).to be false
+          end
+        end
+
+        context "payment has allowed credit" do
+          before { payment.stub(credit_allowed: 5.0) }
+
+          it "returns true" do
+            expect(subject).to be true
+          end
+        end
+      end
+    end
+
+    describe "#store_events" do
+      context "create" do
+        context "user has one store credit" do
+          let(:store_credit_amount) { 100.0 }
+
+          subject { create(:store_credit, amount: store_credit_amount) }
+
+          it "creates a store credit event" do
+            expect { subject }.to change { Spree::StoreCreditEvent.count }.by(1)
+          end
+
+          it "makes the store credit event an allocation event" do
+            subject.store_credit_events.first.action.should eq Spree::StoreCredit::ALLOCATION_ACTION
+          end
+
+          it "saves the user's total store credit in the event" do
+            subject.store_credit_events.first.user_total_amount.should eq store_credit_amount
+          end
+        end
+
+        context "user has multiple store credits" do
+          let(:store_credit_amount)            { 100.0 }
+          let(:additional_store_credit_amount) { 200.0 }
+
+          let(:user)                           { create(:user) }
+          let!(:store_credit)                  { create(:store_credit, user: user, amount: store_credit_amount) }
+
+          subject { create(:store_credit, user: user, amount: additional_store_credit_amount) }
+
+          it "saves the user's total store credit in the event" do
+            subject.store_credit_events.first.user_total_amount.should eq (store_credit_amount + additional_store_credit_amount)
+          end
+        end
+
+        context "an action is specified" do
+          it "creates an event with the set action" do
+            store_credit = build(:store_credit)
+            store_credit.action = Spree::StoreCredit::VOID_ACTION
+            store_credit.action_authorization_code = "1-SC-TEST"
+
+            expect { store_credit.save! }.to change { Spree::StoreCreditEvent.where(action: Spree::StoreCredit::VOID_ACTION).count }.by(1)
+          end
+        end
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/user_spec.rb
+++ b/core/spec/models/spree/user_spec.rb
@@ -126,5 +126,71 @@ describe Spree.user_class, :type => :model do
         expect(subject.display_average_order_value).to eq Spree::Money.new(value)
       end
     end
+
+    describe "#total_available_store_credit" do
+      context "user does not have any associated store credits" do
+        subject { create(:user) }
+
+        it "returns 0" do
+          subject.total_available_store_credit.should be_zero
+        end
+      end
+
+      context "user has several associated store credits" do
+        let(:user)                     { create(:user) }
+        let(:amount)                   { 120.25 }
+        let(:additional_amount)        { 55.75 }
+        let(:store_credit)             { create(:store_credit, user: user, amount: amount, amount_used: 0.0) }
+        let!(:additional_store_credit) { create(:store_credit, user: user, amount: additional_amount, amount_used: 0.0) }
+
+        subject { store_credit.user }
+
+        context "part of the store credit has been used" do
+          let(:amount_used) { 35.00 }
+
+          before { store_credit.update_attributes(amount_used: amount_used) }
+
+          context "part of the store credit has been authorized" do
+            let(:authorized_amount) { 10 }
+
+            before { additional_store_credit.update_attributes(amount_authorized: authorized_amount) }
+
+            it "returns sum of amounts minus used amount and authorized amount" do
+              subject.total_available_store_credit.to_f.should eq (amount + additional_amount - amount_used - authorized_amount)
+            end
+          end
+
+          context "there are no authorized amounts on any of the store credits" do
+            it "returns sum of amounts minus used amount" do
+              subject.total_available_store_credit.to_f.should eq (amount + additional_amount - amount_used)
+            end
+          end
+        end
+
+        context "store credits have never been used" do
+          context "part of the store credit has been authorized" do
+            let(:authorized_amount) { 10 }
+
+            before { additional_store_credit.update_attributes(amount_authorized: authorized_amount) }
+
+            it "returns sum of amounts minus authorized amount" do
+              subject.total_available_store_credit.to_f.should eq (amount + additional_amount - authorized_amount)
+            end
+          end
+
+          context "there are no authorized amounts on any of the store credits" do
+            it "returns sum of amounts" do
+              subject.total_available_store_credit.to_f.should eq (amount + additional_amount)
+            end
+          end
+        end
+
+        context "all store credits have never been used or authorized" do
+          it "returns sum of amounts" do
+            subject.total_available_store_credit.to_f.should eq (amount + additional_amount)
+          end
+        end
+      end
+    end
   end
 end

--- a/frontend/app/assets/stylesheets/spree/frontend/checkout_store_credits.css
+++ b/frontend/app/assets/stylesheets/spree/frontend/checkout_store_credits.css
@@ -1,0 +1,11 @@
+.bottom-accent-separator {
+  border-bottom: 2px solid black;
+}
+
+.top-accent-separator {
+  border-top: 2px solid black;
+}
+
+.top-accent-separator.light {
+  border-top: 1px solid #d9d9db;
+}

--- a/frontend/app/assets/stylesheets/spree/frontend/spree_store_credits.css
+++ b/frontend/app/assets/stylesheets/spree/frontend/spree_store_credits.css
@@ -1,0 +1,5 @@
+/*
+Placeholder manifest file.
+the installer will append this file to the app vendored assets here: 'vendor/assets/stylesheets/spree/frontend/all.css'
+ *= require_tree .
+*/

--- a/frontend/app/views/spree/checkout/_balance_due_sidebar.html.erb
+++ b/frontend/app/views/spree/checkout/_balance_due_sidebar.html.erb
@@ -1,0 +1,2 @@
+<td><strong>Balance Due:</strong></td>
+<td><strong><span id='summary-order-total'><%= order.display_order_total_after_store_credit.to_html %></span></strong></td>

--- a/frontend/app/views/spree/checkout/_payment.html.erb
+++ b/frontend/app/views/spree/checkout/_payment.html.erb
@@ -2,6 +2,8 @@
   <legend align="center"><%= Spree.t(:payment_information) %></legend>
   <div data-hook="checkout_payment_step">
 
+    <%= render(:partial => 'spree/checkout/payment_through_store_credit') %>
+
     <% if @payment_sources.present? %>
       <div class="card_options">
         <%= radio_button_tag 'use_existing_card', 'yes', true %>

--- a/frontend/app/views/spree/checkout/_payment_through_store_credit.html.erb
+++ b/frontend/app/views/spree/checkout/_payment_through_store_credit.html.erb
@@ -1,0 +1,9 @@
+<% if @order.using_store_credit? %>
+  <h6>Store credit will be applied for this order!</h6>
+  <p><%= Spree::Money.new(@order.total_applicable_store_credit, { currency: @order.currency }).to_html %> in store credit will be applied to this order (<%= @order.display_store_credit_remaining_after_capture.to_html %> remaining)</p>
+  <% if @order.covered_by_store_credit? %>
+    <p>Please enter payment information below. Your credit card will <strong>not</strong> be charged.</p>
+  <% else %>
+    <p>Please enter additional payment method below for the remaining total on your order.</p>
+  <% end %>
+<% end %>

--- a/frontend/app/views/spree/checkout/_store_credits_sidebar.html.erb
+++ b/frontend/app/views/spree/checkout/_store_credits_sidebar.html.erb
@@ -1,0 +1,10 @@
+<% if order.using_store_credit? %>
+  <tr class="top-accent-separator">
+    <td>Order Total:</td>
+    <td><span id='summary-sub-total'><%= order.display_total.to_html %></span></td>
+  </tr>
+  <tr class="bottom-accent-separator">
+    <td>Store Credit</td>
+    <td><strong><span id='summary-store-credit'><%= order.display_total_applicable_store_credit.to_html %></span></strong></td>
+  </tr>
+<% end %>

--- a/frontend/app/views/spree/checkout/_summary.html.erb
+++ b/frontend/app/views/spree/checkout/_summary.html.erb
@@ -57,9 +57,10 @@
       </tbody>
     <% end %>
 
+    <%= render(:partial => 'spree/checkout/store_credits_sidebar') %>
+
     <tr data-hook="order_total">
-      <td><strong><%= Spree.t(:order_total) %>:</strong></td>
-      <td><strong><span id='summary-order-total'><%= order.display_total.to_html %></span></strong></td>
+      <%= render(:partial => 'spree/checkout/balance_due_sidebar') %>
     </tr>
   </tbody>
 </table>

--- a/frontend/app/views/spree/shared/_order_details.html.erb
+++ b/frontend/app/views/spree/shared/_order_details.html.erb
@@ -82,8 +82,7 @@
   </tbody>
   <tfoot id="order-total" data-hook="order_details_total">
     <tr class="total">
-      <td colspan="4"><b><%= Spree.t(:order_total) %>:</b></td>
-      <td class="total"><span id="order_total"><%= @order.display_total.to_html %></span></td>
+      <%= render(:partial => 'spree/shared/order_details_total_charge') %>
     </tr>
   </tfoot>
 
@@ -136,5 +135,7 @@
       </tr>
     <% end %>
   </tfoot>
+
+  <%= render(:partial => 'spree/shared/order_details_store_credit', :locals => {:order => @order}) %>
 
 </table>

--- a/frontend/app/views/spree/shared/_order_details_store_credit.html.erb
+++ b/frontend/app/views/spree/shared/_order_details_store_credit.html.erb
@@ -1,0 +1,15 @@
+<% if order.using_store_credit? %>
+  <tfoot class="top-accent-separator light" id="order-total-without-cred">
+    <tr class="total">
+      <td colspan="4"><strong>Order Total</strong></td>
+      <td class="total"><span><%= order.display_total.to_html %></span></td>
+    </tr>
+  </tfoot>
+
+  <tfoot id="order-store-credit">
+    <tr class="total">
+      <td colspan="4"><strong>Store Credit</strong></td>
+      <td class="total"><span><%= order.display_total_applicable_store_credit.to_html %></span></td>
+    </tr>
+  </tfoot>
+<% end %>

--- a/frontend/app/views/spree/shared/_order_details_total_charge.html.erb
+++ b/frontend/app/views/spree/shared/_order_details_total_charge.html.erb
@@ -1,0 +1,2 @@
+<td colspan="4"><b>Balance Due:</b></td>
+<td class="total"><span id="order_total"><%= @order.display_order_total_after_store_credit.to_html %></span></td>


### PR DESCRIPTION
This is the starting point of merging store credits feature (but leave gift cards feature) from extension https://github.com/paulo-surfdome/spree_store_credit_payment_method/tree/move_credit_out into Spree.

Here is the approach we took: go through codes in the directories in https://github.com/paulo-surfdome/spree_store_credit_payment_method/tree/move_credit_out and copy (new file) or merge (decorator) store credits related codes into Spree. And at the same time remove those codes from the extension (Related PR: https://github.com/spree-contrib/spree_store_credit_payment_method/pull/24).

Right now the key components are done. Anyone can take from here.
- [x] merge app directory
- [x] merge bin directory
- [x] merge db directory
- [x] merge config directory
- [x] merge lib directory
- [x] merge spec directory
- [x] implement store frontend UI 
