### PR TITLE
WIP: Play with a way to start moving logic to POROs by delegating model behavior

### DIFF
--- a/core/app/behaviors/spree/finalize_order.rb
+++ b/core/app/behaviors/spree/finalize_order.rb
@@ -7,13 +7,13 @@ module Spree
     end
 
     ##
-    # Finalize an in-progress order's adjustments, and shipments 
+    # Finalize an in-progress order's adjustments, and shipments
     # after the payment has been processed and checkout is complete.
     def execute!
       lock_adjustments
       updater.update_payment_state
 
-      order.shipments.each do |s| 
+      order.shipments.each do |s|
         s.update!(order)
         FinalizeShipment.new(s).execute!
       end
@@ -24,7 +24,7 @@ module Spree
 
       order.touch :completed_at
 
-      order.deliver_order_confirmation_email unless order.confirmation_delivered?
+      order.deliver_order_confirmation_email if !order.confirmation_delivered?
 
       order.consider_risk
     end
@@ -32,12 +32,11 @@ module Spree
     private
 
     def lock_adjustments
-      order.all_adjustments.each{|a| a.close}
+      order.all_adjustments.each { |a| a.close }
     end
 
     def updater
       OrderUpdater.new(order)
     end
-
   end
 end

--- a/core/app/behaviors/spree/finalize_order.rb
+++ b/core/app/behaviors/spree/finalize_order.rb
@@ -1,0 +1,43 @@
+module Spree
+  class FinalizeOrder
+    attr_reader :order
+
+    def initialize(order)
+      @order = order
+    end
+
+    ##
+    # Finalize an in-progress order's adjustments, and shipments 
+    # after the payment has been processed and checkout is complete.
+    def execute!
+      lock_adjustments
+      updater.update_payment_state
+
+      order.shipments.each do |s| 
+        s.update!(order)
+        FinalizeShipment.new(s).execute!
+      end
+
+      updater.update_shipment_state
+      order.save!
+      updater.run_hooks
+
+      order.touch :completed_at
+
+      order.deliver_order_confirmation_email unless order.confirmation_delivered?
+
+      order.consider_risk
+    end
+
+    private
+
+    def lock_adjustments
+      order.all_adjustments.each{|a| a.close}
+    end
+
+    def updater
+      OrderUpdater.new(order)
+    end
+
+  end
+end

--- a/core/app/behaviors/spree/finalize_shipment.rb
+++ b/core/app/behaviors/spree/finalize_shipment.rb
@@ -13,6 +13,5 @@ module Spree
       InventoryUnit.finalize_units!(shipment.inventory_units)
       shipment.unstock_manifest
     end
-
   end
 end

--- a/core/app/behaviors/spree/finalize_shipment.rb
+++ b/core/app/behaviors/spree/finalize_shipment.rb
@@ -1,0 +1,18 @@
+module Spree
+  class FinalizeShipment
+    attr_reader :shipment
+
+    def initialize(shipment)
+      @shipment = shipment
+    end
+
+    ##
+    # Finalize the inventory units of a shipment and decrement the stock
+    # for the variants shipped.
+    def execute!
+      InventoryUnit.finalize_units!(shipment.inventory_units)
+      shipment.unstock_manifest
+    end
+
+  end
+end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -381,6 +381,7 @@ module Spree
     end
 
     def finalize!
+      puts "DEPRECATION WARNING: Order#finalize! will be deprecated, please call FinalizeOrder.new(order).execute! instead."
       FinalizeOrder.new(self).execute!
     end
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -382,7 +382,7 @@ module Spree
 
     def finalize!
       puts <<-EOS.strip_heredoc
-        DEPRECATION WARNING: Order#finalize! will be deprecated, 
+        DEPRECATION WARNING: Order#finalize! will be deprecated,
         please call FinalizeOrder.new(order).execute! instead.
       EOS
       FinalizeOrder.new(self).execute!

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -380,28 +380,8 @@ module Spree
       CreditCard.where(id: credit_card_ids)
     end
 
-    # Finalizes an in progress order after checkout is complete.
-    # Called after transition to complete state when payments will have been processed
     def finalize!
-      # lock all adjustments (coupon promotions, etc.)
-      all_adjustments.each{|a| a.close}
-
-      # update payment and shipment(s) states, and save
-      updater.update_payment_state
-      shipments.each do |shipment|
-        shipment.update!(self)
-        shipment.finalize!
-      end
-
-      updater.update_shipment_state
-      save!
-      updater.run_hooks
-
-      touch :completed_at
-
-      deliver_order_confirmation_email unless confirmation_delivered?
-
-      consider_risk
+      FinalizeOrder.new(self).execute!
     end
 
     def deliver_order_confirmation_email

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -381,7 +381,10 @@ module Spree
     end
 
     def finalize!
-      puts "DEPRECATION WARNING: Order#finalize! will be deprecated, please call FinalizeOrder.new(order).execute! instead."
+      puts <<-EOS.strip_heredoc
+        DEPRECATION WARNING: Order#finalize! will be deprecated, 
+        please call FinalizeOrder.new(order).execute! instead.
+      EOS
       FinalizeOrder.new(self).execute!
     end
 

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -146,6 +146,7 @@ module Spree
     end
 
     def finalize!
+      puts "DEPRECATION WARNING: Shipment#finalize! will be deprecated, please call FinalizeShipment.new(shipment).execute! instead."
       FinalizeShipment.new(self).execute!
     end
 

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -83,6 +83,10 @@ module Spree
     end
 
     def after_resume
+      unstock_manifest
+    end
+
+    def unstock_manifest
       manifest.each { |item| manifest_unstock(item) }
     end
 
@@ -142,8 +146,7 @@ module Spree
     end
 
     def finalize!
-      InventoryUnit.finalize_units!(inventory_units)
-      manifest.each { |item| manifest_unstock(item) }
+      FinalizeShipment.new(self).execute!
     end
 
     def include?(variant)

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -146,7 +146,10 @@ module Spree
     end
 
     def finalize!
-      puts "DEPRECATION WARNING: Shipment#finalize! will be deprecated, please call FinalizeShipment.new(shipment).execute! instead."
+      puts <<-EOS.strip_heredoc
+        DEPRECATION WARNING: Shipment#finalize! will be deprecated, 
+        please call FinalizeShipment.new(shipment).execute! instead.
+      EOS
       FinalizeShipment.new(self).execute!
     end
 

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -147,7 +147,7 @@ module Spree
 
     def finalize!
       puts <<-EOS.strip_heredoc
-        DEPRECATION WARNING: Shipment#finalize! will be deprecated, 
+        DEPRECATION WARNING: Shipment#finalize! will be deprecated,
         please call FinalizeShipment.new(shipment).execute! instead.
       EOS
       FinalizeShipment.new(self).execute!


### PR DESCRIPTION
This is an extremely small first step towards getting logic out of the
activerecord models, it should not change any behavior and ultimately
just adds a level of indirection, but it enables us to start separating
these responsibilities and developing a pattern of how to handle logic
separately from models, as well as allows us to see where things are
called implicitly so that we can invert that to be more explicit.

Relates to #5636
