### PR TITLE
Introduce DisplayMoney class mixin to clean up display_* method model logic.

### DIFF
--- a/core/app/models/concerns/spree/display_money.rb
+++ b/core/app/models/concerns/spree/display_money.rb
@@ -1,0 +1,32 @@
+module Spree
+  module DisplayMoney
+    ##
+    # Takes a list of methods that the base object wants to be able to use
+    # to display with Spree::Money, and turns them into display_* methods.
+    # Intended to help clean up some of the presentational logic that exists
+    # at the model layer.
+    #
+    #
+    # ==== Examples
+    # Decorate a method, with the default option of using the base object's 
+    # currency
+    #
+    #     extend Spree::DisplayMoney
+    #     money_methods :tax_amount, :price
+    #
+    # Decorate a method, but with some additional options
+    #     extend Spree::DisplayMoney
+    #     money_methods tax_amount: { currency: "CAD", no_cents: true }, :price
+    def money_methods(*args)
+      args.each do |money_method|
+        money_method = { money_method => {} } unless money_method.is_a? Hash
+        money_method.each do |method_name, opts|
+          define_method("display_#{method_name}") do
+            default_opts = respond_to?(:currency) ? { currency: currency } : {}
+            Spree::Money.new(send(method_name), default_opts.merge(opts))
+          end
+        end
+      end
+    end
+  end
+end

--- a/core/app/models/concerns/spree/user_reporting.rb
+++ b/core/app/models/concerns/spree/user_reporting.rb
@@ -1,11 +1,10 @@
 module Spree
   module UserReporting
+    extend DisplayMoney
+    money_methods :lifetime_value, :average_order_value
+
     def lifetime_value
       spree_orders.complete.pluck(:total).sum
-    end
-
-    def display_lifetime_value
-      Spree::Money.new(lifetime_value)
     end
 
     def order_count
@@ -18,10 +17,6 @@ module Spree
       else
         BigDecimal("0.00")
       end
-    end
-
-    def display_average_order_value
-      Spree::Money.new(average_order_value)
     end
   end
 end

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -63,16 +63,15 @@ module Spree
     scope :included, -> { where(included: true)  }
     scope :additional, -> { where(included: false) }
 
+    extend DisplayMoney
+    money_methods :amount
+
     def closed?
       state == "closed"
     end
 
     def currency
       adjustable ? adjustable.currency : Spree::Config[:currency]
-    end
-
-    def display_amount
-      Spree::Money.new(amount, { currency: currency })
     end
 
     def promotion?

--- a/core/app/models/spree/customer_return.rb
+++ b/core/app/models/spree/customer_return.rb
@@ -15,12 +15,11 @@ module Spree
 
     accepts_nested_attributes_for :return_items
 
+    extend DisplayMoney
+    money_methods pre_tax_total: { currency: Spree::Config[:currency] }
+
     def pre_tax_total
       return_items.sum(:pre_tax_amount)
-    end
-
-    def display_pre_tax_total
-      Spree::Money.new(pre_tax_total, { currency: Spree::Config[:currency] })
     end
 
     # Temporarily tie a customer_return to one order

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -12,6 +12,13 @@ module Spree
     include Spree::Order::CurrencyUpdater
     include Spree::Order::Payments
 
+    extend Spree::DisplayMoney
+    money_methods :outstanding_balance, :item_total, :adjustment_total,
+      :included_tax_total, :additional_tax_total, :tax_total,
+      :shipment_total, :total
+
+    alias :display_ship_total :display_shipment_total
+
     checkout_flow do
       go_to_state :address
       go_to_state :delivery
@@ -152,39 +159,6 @@ module Spree
 
     def currency
       self[:currency] || Spree::Config[:currency]
-    end
-
-    def display_outstanding_balance
-      Spree::Money.new(outstanding_balance, { currency: currency })
-    end
-
-    def display_item_total
-      Spree::Money.new(item_total, { currency: currency })
-    end
-
-    def display_adjustment_total
-      Spree::Money.new(adjustment_total, { currency: currency })
-    end
-
-    def display_included_tax_total
-      Spree::Money.new(included_tax_total, { currency: currency })
-    end
-
-    def display_additional_tax_total
-      Spree::Money.new(additional_tax_total, { currency: currency })
-    end
-
-    def display_tax_total
-      Spree::Money.new(tax_total, { currency: currency })
-    end
-
-    def display_shipment_total
-      Spree::Money.new(shipment_total, { currency: currency })
-    end
-    alias :display_ship_total :display_shipment_total
-
-    def display_total
-      Spree::Money.new(total, { currency: currency })
     end
 
     def shipping_discount

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -7,14 +7,8 @@ module Spree
     validates :amount, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
     validate :validate_amount_maximum
 
-    def display_amount
-      money
-    end
-    alias :display_price :display_amount
-
-    def money
-      Spree::Money.new(amount || 0, { currency: currency })
-    end
+    extend DisplayMoney
+    money_methods :amount, :price
 
     def price
       amount

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -10,6 +10,10 @@ module Spree
     extend DisplayMoney
     money_methods :amount, :price
 
+    def money
+      Spree::Money.new(amount || 0, { currency: currency })
+    end
+
     def price
       amount
     end

--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -34,12 +34,11 @@ module Spree
 
     end
 
+    extend DisplayMoney
+    money_methods :pre_tax_total
+
     def pre_tax_total
       return_items.sum(:pre_tax_amount)
-    end
-
-    def display_pre_tax_total
-      Spree::Money.new(pre_tax_total, { currency: currency })
     end
 
     def currency

--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -67,6 +67,9 @@ module Spree
       end
     end
 
+    extend DisplayMoney
+    money_methods :pre_tax_amount, :total
+
     def reception_completed?
       COMPLETED_RECEPTION_STATUSES.include?(reception_status)
     end
@@ -114,16 +117,8 @@ module Spree
       exchange_requested? && !exchange_processed?
     end
 
-    def display_pre_tax_amount
-      Spree::Money.new(pre_tax_amount, { currency: currency })
-    end
-
     def total
       pre_tax_amount + additional_tax_total
-    end
-
-    def display_total
-      Spree::Money.new(total, { currency: currency })
     end
 
     def eligible_exchange_variants

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -74,6 +74,10 @@ module Spree
       end
     end
 
+    extend DisplayMoney
+    money_methods :cost, :discounted_cost, :final_price, :item_cost
+    alias display_amount display_cost
+
     def add_shipping_method(shipping_method, selected = false)
       shipping_rates.create(shipping_method: shipping_method, selected: selected, cost: cost)
     end
@@ -111,23 +115,6 @@ module Spree
       cost + promo_total
     end
     alias discounted_amount discounted_cost
-
-    def display_cost
-      Spree::Money.new(cost, { currency: currency })
-    end
-    alias display_amount display_cost
-
-    def display_discounted_cost
-      Spree::Money.new(discounted_cost, { currency: currency })
-    end
-
-    def display_final_price
-      Spree::Money.new(final_price, { currency: currency })
-    end
-
-    def display_item_cost
-      Spree::Money.new(item_cost, { currency: currency })
-    end
 
     def editable_by?(user)
       !shipped?

--- a/core/spec/models/spree/concerns/display_money_spec.rb
+++ b/core/spec/models/spree/concerns/display_money_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+module Spree
+
+  describe DisplayMoney do
+    let(:test_class) do
+      Class.new do
+        extend DisplayMoney
+        def total; 10.0; end
+      end
+    end
+
+    describe ".money_methods" do
+      before { test_class.money_methods :total }
+
+      context "currency is not defined" do
+        it "generates a display_method that builds a Spree::Money without options" do
+          expect(test_class.new.display_total).to eq Spree::Money.new(10.0)
+        end
+      end
+
+      context "currency is defined" do
+        before { test_class.class_eval { def currency; "USD"; end } }
+
+        it "generates a display_* method that builds a Spree::Money with currency" do
+          expect(test_class.new.display_total).to eq Spree::Money.new(10.0, currency: "USD")
+        end
+      end
+
+      context "with multiple + options" do
+        before do
+          test_class.class_eval { def amount; 20.0; end }
+          test_class.money_methods :total, amount: { no_cents: true }
+        end
+
+        it "generates a display_* method that builds a Spree::Money with the specified options" do
+          expect(test_class.new.display_total).to eq Spree::Money.new(10.0)
+          expect(test_class.new.display_amount).to eq Spree::Money.new(20.0, no_cents: true)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
There are a lot of model-level methods named display_ that just wrap a
numeric in a Spree::Money object. Rather than taking up space and mental
overhead in the models, this class mixin allows for defining of those
desired display_methods in a tidier way (with some configuration), in an effort to make some of
these models smaller and easier to reason about.
