### PR TITLE
Optimise cart link

### DIFF
--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -22,6 +22,8 @@ module Spree
           if @simple_current_order
             @simple_current_order.last_ip_address = ip_address
             return @simple_current_order
+          else
+            @simple_current_order = Spree::Order.new
           end
         end
 

--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -28,7 +28,6 @@ module Spree
         # The current incomplete order from the guest_token for use in cart and during checkout
         def current_order(options = {})
           options[:create_order_if_necessary] ||= false
-          options[:lock] ||= false
 
           return @current_order if @current_order
 
@@ -82,6 +81,7 @@ module Spree
         end
 
         def find_order_by_token_or_user(options={})
+          options[:lock] ||= false
 
           # Find any incomplete orders for the guest_token
           order = Spree::Order.incomplete.includes(:adjustments).lock(options[:lock]).find_by(current_order_params)

--- a/core/spec/lib/spree/core/controller_helpers/order_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/order_spec.rb
@@ -12,7 +12,7 @@ describe Spree::Core::ControllerHelpers::Order, type: :controller do
 
   describe '#simple_current_order' do
     before { allow(controller).to receive_messages(try_spree_current_user: user) }
-    it 'returns an empty order' do
+    it "returns an empty order" do
       expect(controller.simple_current_order.item_count).to eq 0
     end
     it 'returns Spree::Order instance' do

--- a/core/spec/lib/spree/core/controller_helpers/order_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/order_spec.rb
@@ -12,8 +12,8 @@ describe Spree::Core::ControllerHelpers::Order, type: :controller do
 
   describe '#simple_current_order' do
     before { allow(controller).to receive_messages(try_spree_current_user: user) }
-    it 'returns nil' do
-      expect(controller.simple_current_order).to be_nil
+    it 'returns an empty order' do
+      expect(controller.simple_current_order.item_count).to eq 0
     end
     it 'returns Spree::Order instance' do
       allow(controller).to receive_messages(cookies: double(signed: { guest_token: order.guest_token }))


### PR DESCRIPTION
Here's a couple of tweaks to optimise cart_link:
- in `Spree::Core::ControllerHelpers::Order#find_order_by_token_or_user` ensures that the `option[:lock]` defaults to false for both `simple_current_order` and `current_order`
- in `Spree::Core::ControllerHelpers::Order#simple_current_order` if the order isn't found, return a new empty order that is then memoized instead of returning nil - this avoids hitting the DB twice

The really big optimisation we found though was to index the `spree_orders.guest_token` column - is it appropriate to add this to this PR? 
