### PR TITLE
Improve tax rate reads on checkout

### DIFF
--- a/core/app/models/spree/country.rb
+++ b/core/app/models/spree/country.rb
@@ -3,6 +3,13 @@ module Spree
     has_many :states, -> { order('name ASC') }, dependent: :destroy
     has_many :addresses, dependent: :nullify
 
+    has_many :zone_members,
+      -> { where(zoneable_type: 'Spree::Country') },
+      class_name: 'Spree::ZoneMember',
+      foreign_key: :zoneable_id
+
+    has_many :zones, through: :zone_members, class_name: 'Spree::Zone'
+
     validates :name, :iso_name, presence: true
 
     def self.states_required_by_country_id

--- a/core/app/models/spree/state.rb
+++ b/core/app/models/spree/state.rb
@@ -3,6 +3,13 @@ module Spree
     belongs_to :country, class_name: 'Spree::Country'
     has_many :addresses, dependent: :nullify
 
+    has_many :zone_members,
+      -> { where(zoneable_type: 'Spree::State') },
+      class_name: 'Spree::ZoneMember',
+      foreign_key: :zoneable_id
+
+    has_many :zones, through: :zone_members, class_name: 'Spree::Zone'
+
     validates :country, :name, presence: true
 
     def self.find_all_by_name_or_abbr(name_or_abbr)

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -30,13 +30,18 @@ module Spree
     scope :by_zone, ->(zone) { where(zone_id: zone) }
 
     def self.potential_rates_for_zone(zone)
-      joins(:zone).merge(Spree::Zone.potential_matching_zones(zone)).order('spree_zones.default_tax DESC')
+      select("spree_tax_rates.*, spree_zones.default_tax").
+        joins(:zone).
+        merge(Spree::Zone.potential_matching_zones(zone)).
+        order("spree_zones.default_tax DESC")
     end
 
     # Gets the array of TaxRates appropriate for the specified order
     def self.match(order_tax_zone)
       return [] unless order_tax_zone
-      rates = potential_rates_for_zone(order_tax_zone).includes(zone: { zone_members: :zoneable }).load.select do |rate|
+
+      potential_rates = potential_rates_for_zone(order_tax_zone)
+      rates = potential_rates.includes(zone: { zone_members: :zoneable }).load.select do |rate|
         # Why "potentially"?
         # Go see the documentation for that method.
         rate.potentially_applicable?(order_tax_zone)

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -29,10 +29,14 @@ module Spree
 
     scope :by_zone, ->(zone) { where(zone_id: zone) }
 
+    def self.potential_rates_for_zone(zone)
+      joins(:zone).merge(Spree::Zone.potential_matching_zones(zone)).order('spree_zones.default_tax DESC')
+    end
+
     # Gets the array of TaxRates appropriate for the specified order
     def self.match(order_tax_zone)
       return [] unless order_tax_zone
-      rates = includes(zone: { zone_members: :zoneable }).load.select do |rate|
+      rates = potential_rates_for_zone(order_tax_zone).includes(zone: { zone_members: :zoneable }).load.select do |rate|
         # Why "potentially"?
         # Go see the documentation for that method.
         rate.potentially_applicable?(order_tax_zone)

--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -2,15 +2,17 @@ module Spree
   class Zone < Spree::Base
     has_many :zone_members, dependent: :destroy, class_name: "Spree::ZoneMember", inverse_of: :zone
     has_many :tax_rates, dependent: :destroy, inverse_of: :zone
-    has_many :countries, through: :zone_members, source: :zoneable, source_type: 'Spree::Country'
-    has_many :states, through: :zone_members, source: :zoneable, source_type: 'Spree::State'
+    has_many :countries, through: :zone_members, source: :zoneable,
+      source_type: "Spree::Country"
+    has_many :states, through: :zone_members, source: :zoneable,
+      source_type: "Spree::State"
 
     has_and_belongs_to_many :shipping_methods, :join_table => 'spree_shipping_methods_zones'
 
     validates :name, presence: true, uniqueness: { allow_blank: true }
+
     after_save :remove_defunct_members
     after_save :remove_previous_default
-    before_save :set_cached_kind
 
     alias :members :zone_members
     accepts_nested_attributes_for :zone_members, allow_destroy: true, reject_if: proc { |a| a['zoneable_id'].blank? }
@@ -20,17 +22,15 @@ module Spree
     end
 
     def self.potential_matching_zones(zone)
-      if zone.kind == 'country'
+      if zone.country?
         # Match zones of the same kind with simialr countries
-        joins(:zone_members).where(
-          "(spree_zone_members.zoneable_type = 'Spree::Country' AND
-            spree_zone_members.zoneable_id IN (?))
-           OR default_tax = ?",
-          zone.country_ids,
-          true
-        ).uniq
+        joins(countries: :zones).
+          where('zone_members_spree_countries_join.zone_id = ? OR ' +
+                'spree_zones.default_tax = ?', zone.id, true).
+          uniq
       else
-        # Match zones of the same kind with similar states in AND match zones that have the states countries in
+        # Match zones of the same kind with similar states in AND match zones
+        # that have the states countries in
         joins(:zone_members).where(
           "(spree_zone_members.zoneable_type = 'Spree::State' AND
             spree_zone_members.zoneable_id IN (?))
@@ -60,18 +60,22 @@ module Spree
       matches.first
     end
 
-    def set_cached_kind
-      self.cached_kind = kind
-    end
-
     def kind
-      return cached_kind if cached_kind
-
-      humanize_kind if valid_members?
+      if kind?
+        super
+      else
+        not_nil_scope = members.where.not(zoneable_type: nil)
+        zone_type = not_nil_scope.order('created_at ASC').pluck(:zoneable_type).last
+        zone_type.demodulize.underscore if zone_type
+      end
     end
 
-    def kind=(value)
-      # do nothing - just here to satisfy the form
+    def country?
+      kind == 'country'
+    end
+
+    def state?
+      kind == 'state'
     end
 
     def include?(address)
@@ -147,13 +151,7 @@ module Spree
     end
 
     private
-
-      def humanize_kind
-        members.last.zoneable_type.demodulize.underscore
-      end
-
       def remove_defunct_members
-        self.reload
         if zone_members.any?
           zone_members.where('zoneable_id IS NULL OR zoneable_type != ?', "Spree::#{kind.classify}").destroy_all
         end
@@ -171,10 +169,6 @@ module Spree
           member.zoneable_id = id
           members << member
         end
-      end
-
-      def valid_members?
-        members.any? && !members.any? { |member| member.try(:zoneable_type).nil? }
       end
   end
 end

--- a/core/db/migrate/20140911173301_add_cached_kind_to_zone.rb
+++ b/core/db/migrate/20140911173301_add_cached_kind_to_zone.rb
@@ -1,0 +1,9 @@
+class AddCachedKindToZone < ActiveRecord::Migration
+  def change
+    add_column :spree_zones, :cached_kind, :string
+
+    add_index :spree_zones, :cached_kind
+
+    Spree::Zone.all.each { |zone| zone.set_cached_kind && zone.save! }
+  end
+end

--- a/core/db/migrate/20140911173301_add_cached_kind_to_zone.rb
+++ b/core/db/migrate/20140911173301_add_cached_kind_to_zone.rb
@@ -1,9 +1,0 @@
-class AddCachedKindToZone < ActiveRecord::Migration
-  def change
-    add_column :spree_zones, :cached_kind, :string
-
-    add_index :spree_zones, :cached_kind
-
-    Spree::Zone.all.each { |zone| zone.set_cached_kind && zone.save! }
-  end
-end

--- a/core/db/migrate/20140911173301_add_kind_to_zone.rb
+++ b/core/db/migrate/20140911173301_add_kind_to_zone.rb
@@ -1,0 +1,11 @@
+class AddKindToZone < ActiveRecord::Migration
+  def change
+    add_column :spree_zones, :kind, :string
+    add_index :spree_zones, :kind
+
+    Spree::Zone.find_each do |zone|
+      last_type = zone.members.where.not(zoneable_type: nil).pluck(:zoneable_type).last
+      zone.update_column :kind, last_type.demodulize.underscore if last_type
+    end
+  end
+end

--- a/core/lib/spree/testing_support/factories/zone_factory.rb
+++ b/core/lib/spree/testing_support/factories/zone_factory.rb
@@ -13,5 +13,13 @@ FactoryGirl.define do
   factory :zone, class: Spree::Zone do
     name { generate(:random_string) }
     description { generate(:random_string) }
+
+    factory :zone_with_country do
+      zone_members do |proxy|
+        zone = proxy.instance_eval { @instance }
+        country = create(:country)
+        [Spree::ZoneMember.create(zoneable: country, zone: zone)]
+      end
+    end
   end
 end


### PR DESCRIPTION
Worked with @RhysStansfield on this one. They were seeing very slow requests, about 20s, on checkout due to the store having hundred tax rates. This patch persists the `zone.kind` on the db and adds up a scope on tax_rate.match so we instantiate less ar objects.

// @JDutil 
