### PR TITLE
Update default same product rule

### DIFF
--- a/core/app/models/spree/return_item/exchange_variant_eligibility/same_product.rb
+++ b/core/app/models/spree/return_item/exchange_variant_eligibility/same_product.rb
@@ -3,7 +3,7 @@ module Spree
     class SameProduct
 
       def self.eligible_variants(variant)
-        Spree::Variant.where.not(id: variant.id).where(product_id: variant.product_id, is_master: false)
+        Spree::Variant.where(product_id: variant.product_id, is_master: false).in_stock
       end
     end
   end

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -41,6 +41,8 @@ module Spree
 
     after_touch :clear_in_stock_cache
 
+    scope :in_stock, -> { joins(:stock_items).where('count_on_hand > ? OR track_inventory = ?', 0, false) }
+
     def self.active(currency = nil)
       joins(:prices).where(deleted_at: nil).where('spree_prices.currency' => currency || Spree::Config[:currency]).where('spree_prices.amount IS NOT NULL')
     end

--- a/core/spec/models/spree/return_item/exchange_variant_eligibility/same_product_spec.rb
+++ b/core/spec/models/spree/return_item/exchange_variant_eligibility/same_product_spec.rb
@@ -4,15 +4,25 @@ module Spree
   module ReturnItem::ExchangeVariantEligibility
     describe SameProduct, :type => :model do
       describe ".eligible_variants" do
-        it "returns all other variants for the same product" do
-          product = create(:product, variants: 3.times.map { build(:variant) })
-          expect(SameProduct.eligible_variants(product.variants.first).sort).to eq product.variants[1..-1].sort
+        it "returns all variants for the same product" do
+          product = create(:product, variants: 3.times.map { create(:variant) })
+          product.variants.map { |v| v.stock_items.first.update_column(:count_on_hand, 10) }
+
+          expect(SameProduct.eligible_variants(product.variants.first).sort).to eq product.variants.sort
         end
 
         it "does not return variants for another product" do
           variant = create(:variant)
           other_product_variant = create(:variant)
           expect(SameProduct.eligible_variants(variant)).not_to include other_product_variant
+        end
+
+        it "only returns variants that are on hand" do
+          product = create(:product, variants: 2.times.map { create(:variant) })
+          in_stock_variant = product.variants.first
+
+          in_stock_variant.stock_items.first.update_column(:count_on_hand, 10)
+          expect(SameProduct.eligible_variants(in_stock_variant)).to eq [in_stock_variant]
         end
       end
     end

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -400,4 +400,15 @@ describe Spree::Variant, :type => :model do
       expect(variant.stock_movements.to_a).not_to be_empty
     end
   end
+
+  describe "in_stock scope" do
+    it "returns all in stock variants" do
+      in_stock_variant = create(:variant)
+      out_of_stock_variant = create(:variant)
+
+      in_stock_variant.stock_items.first.update_column(:count_on_hand, 10)
+
+      expect(Spree::Variant.in_stock).to eq [in_stock_variant]
+    end
+  end
 end


### PR DESCRIPTION
Working on pulling in the latest returns & exchange stuff from bonobos/spree/2-2-dev.

Changes:
- allows the SameProduct rule to exchange an item for the same item
- filters out out-of-stock variants for the SameProduct rule
