### PR TITLE
fix api orders_controller_spec

### DIFF
--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -18,14 +18,6 @@ module Spree
 
     let(:address_params) { { :country_id => Country.first.id, :state_id => State.first.id } }
 
-    let(:billing_address) { { :firstname => "Tiago", :lastname => "Motta", :address1 => "Av Paulista",
-                              :city => "Sao Paulo", :zipcode => "35762", :phone => "12345678",
-                              :country_id => Country.first.id, :state_id => State.first.id} }
-
-    let(:shipping_address) { { :firstname => "Tiago", :lastname => "Motta", :address1 => "Av Paulista",
-                               :city => "Sao Paulo", :zipcode => "35762", :phone => "12345678",
-                               :country_id => Country.first.id, :state_id => State.first.id} }
-
     let(:current_api_user) do
       user = Spree.user_class.new(:email => "spree@example.com")
       user.generate_spree_api_key!
@@ -359,13 +351,14 @@ module Spree
       let!(:line_item) { order.contents.add(variant, 1) }
       let!(:payment_method) { create(:check_payment_method) }
 
-      let(:address_params) { { :country_id => Country.first.id, :state_id => State.first.id } }
+      let(:address_params) { { :country_id => country.id } }
       let(:billing_address) { { :firstname => "Tiago", :lastname => "Motta", :address1 => "Av Paulista",
-                                :city => "Sao Paulo", :zipcode => "35762", :phone => "12345678",
-                                :country_id => Country.first.id, :state_id => State.first.id} }
+                                :city => "Sao Paulo", :zipcode => "01310-300", :phone => "12345678",
+                                :country_id => country.id} }
       let(:shipping_address) { { :firstname => "Tiago", :lastname => "Motta", :address1 => "Av Paulista",
-                                 :city => "Sao Paulo", :zipcode => "35762", :phone => "12345678",
-                                 :country_id => Country.first.id, :state_id => State.first.id} }
+                                 :city => "Sao Paulo", :zipcode => "01310-300", :phone => "12345678",
+                                 :country_id => country.id} }
+      let(:country) { create(:country, {name: "Brazil", iso_name: "BRAZIL", iso: "BR", iso3: "BRA", numcode: 76 })}
 
       before do
         allow_any_instance_of(Order).to receive_messages user: current_api_user


### PR DESCRIPTION
Zipcode validation was failing in our fork because we have extra validation and the country didn't match up in these.
Also, remove some unused rspec address definitions.
