### PR TITLE
Round down on original payment and credit reimbursement types.

### DIFF
--- a/core/app/models/spree/reimbursement_type/credit.rb
+++ b/core/app/models/spree/reimbursement_type/credit.rb
@@ -4,7 +4,7 @@ module Spree
 
     class << self
       def reimburse(reimbursement, return_items, simulate)
-        unpaid_amount = return_items.sum(&:total).round(2)
+        unpaid_amount = return_items.sum(&:total).round(2, :down)
         reimbursement_list, unpaid_amount = create_credits(reimbursement, unpaid_amount, simulate)
         reimbursement_list
       end

--- a/core/app/models/spree/reimbursement_type/original_payment.rb
+++ b/core/app/models/spree/reimbursement_type/original_payment.rb
@@ -3,7 +3,7 @@ class Spree::ReimbursementType::OriginalPayment < Spree::ReimbursementType
 
   class << self
     def reimburse(reimbursement, return_items, simulate)
-      unpaid_amount = return_items.sum(&:total).round(2)
+      unpaid_amount = return_items.sum(&:total).round(2, :down)
       payments = reimbursement.order.payments.completed
 
       refund_list, unpaid_amount = create_refunds(reimbursement, payments, unpaid_amount, simulate)


### PR DESCRIPTION
Working on pulling in the latest returns & exchange stuff from bonobos/spree/2-2-dev.

Add a bit of leniency in the edge-of-edge cases on multiple reimbursement types and rounding issues. See code comments.
