### PR TITLE
Fix for ReimbursementTypeValidator

### DIFF
--- a/core/app/models/spree/reimbursement/reimbursement_type_validator.rb
+++ b/core/app/models/spree/reimbursement/reimbursement_type_validator.rb
@@ -1,7 +1,10 @@
 module Spree
   module Reimbursement::ReimbursementTypeValidator
     def valid_preferred_reimbursement_type?(return_item)
-      !past_reimbursable_time_period?(return_item) || return_item.preferred_reimbursement_type == expired_reimbursement_type
+      preferred_type = return_item.preferred_reimbursement_type.class
+
+      !past_reimbursable_time_period?(return_item) ||
+        preferred_type == expired_reimbursement_type
     end
 
     def past_reimbursable_time_period?(return_item)

--- a/core/spec/models/spree/reimbursement/reimbursement_type_validator_spec.rb
+++ b/core/spec/models/spree/reimbursement/reimbursement_type_validator_spec.rb
@@ -6,19 +6,24 @@ module Spree
       include Spree::Reimbursement::ReimbursementTypeValidator
 
       class_attribute :expired_reimbursement_type
-      self.expired_reimbursement_type = Spree::ReimbursementType::OriginalPayment
+      self.expired_reimbursement_type = Spree::ReimbursementType::Credit
 
       class_attribute :refund_time_constraint
       self.refund_time_constraint = 90.days
     end
 
-    let(:return_item)   { create(:return_item) }
-    let(:dummy)         { DummyClass.new }
+    let(:return_item) do
+      create(
+        :return_item,
+        preferred_reimbursement_type: preferred_reimbursement_type
+      )
+    end
+    let(:dummy) { DummyClass.new }
+    let(:preferred_reimbursement_type) { Spree::ReimbursementType::Credit.new }
 
     describe '#valid_preferred_reimbursement_type?' do
       before do
         allow(dummy).to receive(:past_reimbursable_time_period?).and_return(true)
-        allow(return_item).to receive(:preferred_reimbursement_type).and_return(Spree::ReimbursementType::Credit)
       end
 
       subject { dummy.valid_preferred_reimbursement_type?(return_item) }
@@ -30,13 +35,14 @@ module Spree
         end
 
         it 'if the return items preferred method of reimbursement is the expired method of reimbursement' do
-          allow(return_item).to receive(:preferred_reimbursement_type).and_return(dummy.expired_reimbursement_type)
           expect(subject).to be true
         end
       end
 
       context 'is invalid' do
         it 'if the return item is past the eligible time period and the preferred method of reimbursement is not the expired method of reimbursement' do
+          return_item.preferred_reimbursement_type =
+            Spree::ReimbursementType::OriginalPayment.new
           expect(subject).to be false
         end
       end


### PR DESCRIPTION
Working on pulling in the latest returns & exchange stuff from bonobos/spree/2-2-dev.

Return items preferred reimbursement type returns an instance, not a class. Comparison in reimbursement type validator was always returning false.
