### PR TITLE
Improve readability in FlexiRate calculator labels

### DIFF
--- a/core/app/models/spree/calculator/flexi_rate.rb
+++ b/core/app/models/spree/calculator/flexi_rate.rb
@@ -2,10 +2,10 @@ require_dependency 'spree/calculator'
 
 module Spree
   class Calculator::FlexiRate < Calculator
-    preference :first_item,      :decimal, default: 0.0
-    preference :additional_item, :decimal, default: 0.0
-    preference :max_items,       :integer, default: 0
-    preference :currency,        :string,  default: ->{ Spree::Config[:currency] }
+    preference :first_item_discount,      :decimal, default: 0.0
+    preference :additional_item_discount, :decimal, default: 0.0
+    preference :max_items,                :integer, default: 0
+    preference :currency,                 :string,  default: ->{ Spree::Config[:currency] }
 
     def self.description
       Spree.t(:flexible_rate)
@@ -21,9 +21,9 @@ module Spree
       items_count = object.quantity
       items_count.times do |i|
         if i == 0
-          sum += self.preferred_first_item.to_f
+          sum += self.preferred_first_item_discount.to_f
         elsif ((max > 0) && (i <= (max - 1))) || (max == 0)
-          sum += self.preferred_additional_item.to_f
+          sum += self.preferred_additional_item_discount.to_f
         end
       end
 

--- a/core/app/models/spree/calculator/shipping/flexi_rate.rb
+++ b/core/app/models/spree/calculator/shipping/flexi_rate.rb
@@ -3,10 +3,10 @@ require_dependency 'spree/shipping_calculator'
 module Spree
   module Calculator::Shipping
     class FlexiRate < ShippingCalculator
-      preference :first_item,      :decimal, default: 0.0
-      preference :additional_item, :decimal, default: 0.0
-      preference :max_items,       :integer, default: 0
-      preference :currency,        :string,  default: ->{ Spree::Config[:currency] }
+      preference :first_item_cost,      :decimal, default: 0.0
+      preference :additional_item_cost, :decimal, default: 0.0
+      preference :max_items,            :integer, default: 0
+      preference :currency,             :string,  default: ->{ Spree::Config[:currency] }
 
       def self.description
         Spree.t(:shipping_flexible_rate)
@@ -22,9 +22,9 @@ module Spree
         quantity.times do |i|
           # check max value to avoid divide by 0 errors
           if (max == 0 && i == 0) || (max > 0) && (i % max == 0)
-            sum += self.preferred_first_item.to_f
+            sum += self.preferred_first_item_cost.to_f
           else
-            sum += self.preferred_additional_item.to_f
+            sum += self.preferred_additional_item_cost.to_f
           end
         end
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -384,7 +384,8 @@ en:
     add_stock_management: Add Stock Management
     add_to_cart: Add To Cart
     add_variant: Add Variant
-    additional_item: Additional Item Cost
+    additional_item_cost: Additional Item Cost
+    additional_item_discount: Additional Item Discount
     address1: Address
     address2: Address (contd.)
     adjustable: Adjustable
@@ -710,7 +711,8 @@ en:
     finalize: Finalize
     find_a_taxon: Find a Taxon
     finalized: Finalized
-    first_item: First Item Cost
+    first_item_cost: First Item Cost
+    first_item_discount: First Item Discount
     first_name: First Name
     first_name_begins_with: First Name Begins With
     flat_percent: Flat Percent

--- a/core/spec/models/spree/calculator/flexi_rate_spec.rb
+++ b/core/spec/models/spree/calculator/flexi_rate_spec.rb
@@ -15,27 +15,27 @@ describe Spree::Calculator::FlexiRate, :type => :model do
     end
 
     it "should compute amount correctly when first_item has a value" do
-      allow(calculator).to receive_messages :preferred_first_item => 1.0
+      allow(calculator).to receive_messages :preferred_first_item_discount => 1.0
       expect(calculator.compute(order).round(2)).to eq(1.0)
     end
 
     it "should compute amount correctly when additional_items has a value" do
-      allow(calculator).to receive_messages :preferred_additional_item => 1.0
+      allow(calculator).to receive_messages :preferred_additional_item_discount => 1.0
       expect(calculator.compute(order).round(2)).to eq(9.0)
     end
 
     it "should compute amount correctly when additional_items and first_item have values" do
-      allow(calculator).to receive_messages :preferred_first_item => 5.0, :preferred_additional_item => 1.0
+      allow(calculator).to receive_messages :preferred_first_item_discount => 5.0, :preferred_additional_item_discount => 1.0
       expect(calculator.compute(order).round(2)).to eq(14.0)
     end
 
     it "should compute amount correctly when additional_items and first_item have values AND max items has value" do
-      allow(calculator).to receive_messages :preferred_first_item => 5.0, :preferred_additional_item => 1.0, :preferred_max_items => 3
+      allow(calculator).to receive_messages :preferred_first_item_discount => 5.0, :preferred_additional_item_discount => 1.0, :preferred_max_items => 3
       expect(calculator.compute(order).round(2)).to eq(7.0)
     end
 
     it "should allow creation of new object with all the attributes" do
-      Spree::Calculator::FlexiRate.new(:preferred_first_item => 1, :preferred_additional_item => 1, :preferred_max_items => 1)
+      Spree::Calculator::FlexiRate.new(:preferred_first_item_discount => 1, :preferred_additional_item_discount => 1, :preferred_max_items => 1)
     end
   end
 end

--- a/core/spec/models/spree/calculator/shipping/flexi_rate_spec.rb
+++ b/core/spec/models/spree/calculator/shipping/flexi_rate_spec.rb
@@ -18,31 +18,31 @@ module Spree
         end
 
         it "should compute amount correctly when first_item has a value" do
-          subject.preferred_first_item = 1.0
+          subject.preferred_first_item_cost = 1.0
           expect(subject.compute(package).round(2)).to eq(1.0)
         end
 
         it "should compute amount correctly when additional_items has a value" do
-          subject.preferred_additional_item = 1.0
+          subject.preferred_additional_item_cost = 1.0
           expect(subject.compute(package).round(2)).to eq(9.0)
         end
 
         it "should compute amount correctly when additional_items and first_item have values" do
-          subject.preferred_first_item = 5.0
-          subject.preferred_additional_item = 1.0
+          subject.preferred_first_item_cost = 5.0
+          subject.preferred_additional_item_cost = 1.0
           expect(subject.compute(package).round(2)).to eq(14.0)
         end
 
         it "should compute amount correctly when additional_items and first_item have values AND max items has value" do
-          subject.preferred_first_item = 5.0
-          subject.preferred_additional_item = 1.0
+          subject.preferred_first_item_cost = 5.0
+          subject.preferred_additional_item_cost = 1.0
           subject.preferred_max_items = 3
           expect(subject.compute(package).round(2)).to eq(26.0)
         end
 
         it "should allow creation of new object with all the attributes" do
-          FlexiRate.new(:preferred_first_item => 1,
-                        :preferred_additional_item => 1,
+          FlexiRate.new(:preferred_first_item_cost => 1,
+                        :preferred_additional_item_cost => 1,
                         :preferred_max_items => 1)
         end
       end


### PR DESCRIPTION
Based on discussion in https://github.com/bonobos/spree/pull/49 regarding #5007. Changes the FlexiRate promotion labels to read "First Item Discount" and "First Adjustment Discount". Because the labels are also used in the shipping FlexiRate calculator, this change was a bit more complicated than just a simple change to en.yml. But, I think it improves readability and intent in the UI as well as the code. 
