### PR TITLE
Add custom_params to completion_route

### DIFF
--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -113,8 +113,8 @@ module Spree
       end
 
       # Provides a route to redirect after order completion
-      def completion_route
-        spree.order_path(@order)
+      def completion_route(custom_params = nil)
+        spree.order_path(@order, custom_params)
       end
 
       def setup_for_current_state

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -113,7 +113,7 @@ module Spree
       end
 
       # Provides a route to redirect after order completion
-      def completion_route(custom_params=nil)
+      def completion_route(custom_params = nil)
         spree.order_path(@order, custom_params)
       end
 

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -113,7 +113,7 @@ module Spree
       end
 
       # Provides a route to redirect after order completion
-      def completion_route(custom_params = nil)
+      def completion_route(custom_params=nil)
         spree.order_path(@order, custom_params)
       end
 


### PR DESCRIPTION
Since the method `completion_route` is used instead of the path method it doesn't support setting parameters. It would be nice if we could pass parameters while still using the `completion_route` method.

This is a remake of #5658 to be merged into `master`
