### PR TITLE
Fix for Promotion::Rules::Product

### DIFF
--- a/core/app/models/spree/promotion/rules/product.rb
+++ b/core/app/models/spree/promotion/rules/product.rb
@@ -40,7 +40,14 @@ module Spree
         end
 
         def actionable?(line_item)
-          product_ids.include? line_item.variant.product_id
+          case preferred_match_policy
+          when 'any', 'all'
+            product_ids.include? line_item.variant.product_id
+          when 'none'
+            product_ids.exclude? line_item.variant.product_id
+          else
+            raise "unexpected match policy: #{preferred_match_policy.inspect}"
+          end
         end
 
         def product_ids_string

--- a/core/spec/models/spree/promotion/rules/product_spec.rb
+++ b/core/spec/models/spree/promotion/rules/product_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe Spree::Promotion::Rules::Product, :type => :model do
-  let(:rule) { Spree::Promotion::Rules::Product.new }
+  let(:rule) { Spree::Promotion::Rules::Product.new(rule_options) }
+  let(:rule_options) { {} }
 
   context "#eligible?(order)" do
     let(:order) { Spree::Order.new }
@@ -16,7 +17,7 @@ describe Spree::Promotion::Rules::Product, :type => :model do
     end
 
     context "with 'any' match policy" do
-      before { rule.preferred_match_policy = 'any' }
+      let(:rule_options) { super().merge(preferred_match_policy: 'any') }
 
       it "should be eligible if any of the products is in eligible products" do
         allow(order).to receive_messages(:products => [@product1, @product2])
@@ -39,7 +40,7 @@ describe Spree::Promotion::Rules::Product, :type => :model do
     end
 
     context "with 'all' match policy" do
-      before { rule.preferred_match_policy = 'all' }
+      let(:rule_options) { super().merge(preferred_match_policy: 'all') }
 
       it "should be eligible if all of the eligible products are ordered" do
         allow(order).to receive_messages(:products => [@product3, @product2, @product1])
@@ -62,7 +63,7 @@ describe Spree::Promotion::Rules::Product, :type => :model do
     end
 
     context "with 'none' match policy" do
-      before { rule.preferred_match_policy = 'none' }
+      let(:rule_options) { super().merge(preferred_match_policy: 'none') }
 
       it "should be eligible if none of the order's products are in eligible products" do
         allow(order).to receive_messages(:products => [@product1])
@@ -81,6 +82,61 @@ describe Spree::Promotion::Rules::Product, :type => :model do
           expect(rule.eligibility_errors.full_messages.first).
             to eq "Your cart contains a product that prevents this coupon code from being applied."
         end
+      end
+    end
+  end
+
+  describe '#actionable?' do
+    subject do
+      rule.actionable?(line_item)
+    end
+
+    let(:rule_line_item) { Spree::LineItem.new(product: rule_product) }
+    let(:other_line_item) { Spree::LineItem.new(product: other_product) }
+
+    let(:rule_options) { super().merge(products: [rule_product]) }
+    let(:rule_product) { mock_model(Spree::Product) }
+    let(:other_product) { mock_model(Spree::Product) }
+
+    context "with 'any' match policy" do
+      let(:rule_options) { super().merge(preferred_match_policy: 'any') }
+
+      context 'for product in rule' do
+        let(:line_item) { rule_line_item }
+        it { should be_truthy }
+      end
+
+      context 'for product not in rule' do
+        let(:line_item) { other_line_item }
+        it { should be_falsey }
+      end
+    end
+
+    context "with 'all' match policy" do
+      let(:rule_options) { super().merge(preferred_match_policy: 'all') }
+
+      context 'for product in rule' do
+        let(:line_item) { rule_line_item }
+        it { should be_truthy }
+      end
+
+      context 'for product not in rule' do
+        let(:line_item) { other_line_item }
+        it { should be_falsey }
+      end
+    end
+
+    context "with 'none' match policy" do
+      let(:rule_options) { super().merge(preferred_match_policy: 'none') }
+
+      context 'for product in rule' do
+        let(:line_item) { rule_line_item }
+        it { should be_falsey }
+      end
+
+      context 'for product not in rule' do
+        let(:line_item) { other_line_item }
+        it { should be_truthy }
       end
     end
   end


### PR DESCRIPTION
Using Promotion::Rules::Product rules with line item actions (Promotion::Actions::CreateItemAdjustments) was broken when the match_policy was "none".

It would be nice to backport this to 2.4 & 2.3 as well.
