### PR TITLE
Line-through ineligible adjustments.

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/sections/_adjustments_table.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_adjustments_table.scss
@@ -6,3 +6,7 @@
     }
   }
 }
+
+.ineligible td {
+  text-decoration: line-through;
+}

--- a/backend/app/views/spree/admin/adjustments/_adjustment.html.erb
+++ b/backend/app/views/spree/admin/adjustments/_adjustment.html.erb
@@ -2,7 +2,13 @@
   @edit_url = edit_admin_order_adjustment_path(@order, adjustment)
   @delete_url = admin_order_adjustment_path(@order, adjustment)
 %>
-<tr id="<%= spree_dom_id(adjustment) %>" data-hook="adjustment_row" class="<%= cycle('odd', 'even')%>">
+<%= content_tag :tr,
+                id: spree_dom_id(adjustment),
+                data: { hook: "adjustment_row" },
+                class: [
+                  cycle('odd', 'even'),
+                  (adjustment.eligible? ? 'eligible' : 'ineligible')
+                ] do %>
   <td class="align-center"><%= display_adjustable(adjustment.adjustable) %></td>
   <td class="align-center"><%= adjustment.label %></td>
   <td class="align-center"><%= adjustment.display_amount.to_html %></td>
@@ -13,4 +19,4 @@
       <%= link_to_delete adjustment, :no_text => true %>
     <% end %>
   </td>
-</tr>
+<% end %>


### PR DESCRIPTION
Make it clear if an adjustment is ineligible in the admin area by adding a line through it.

![image](https://cloud.githubusercontent.com/assets/764390/5150489/02654564-71a1-11e4-8f80-281821757e18.png)
