### PR TITLE
Improve readability in FlexiRate calculator labels

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -384,7 +384,7 @@ en:
     add_stock_management: Add Stock Management
     add_to_cart: Add To Cart
     add_variant: Add Variant
-    additional_item: Additional Item Cost
+    additional_item: Additional Item
     address1: Address
     address2: Address (contd.)
     adjustable: Adjustable
@@ -710,7 +710,7 @@ en:
     finalize: Finalize
     find_a_taxon: Find a Taxon
     finalized: Finalized
-    first_item: First Item Cost
+    first_item: First Item
     first_name: First Name
     first_name_begins_with: First Name Begins With
     flat_percent: Flat Percent


### PR DESCRIPTION
Based on discussion in #5659. Makes the following label changes to the FlexiRate calculator:
- "First Item Discount" --> "First Item"
- "Additional Item Discount" --> "Additional Item" 

Using "Discount" made sense in the context of the FlexiRate shipping calculator, but it did not make sense in the FlexiRate promotional calculator. These labels are more flexible and leave it up to the user to infer the context.
