### PR TITLE
Change the default canonical URL for a store to example.com

### DIFF
--- a/core/db/default/spree/stores.rb
+++ b/core/db/default/spree/stores.rb
@@ -3,7 +3,7 @@ unless Spree::Store.where(code: 'spree').exists?
   Spree::Store.new do |s|
     s.code              = 'spree'
     s.name              = 'Spree Demo Site'
-    s.url               = 'demo.spreecommerce.com'
+    s.url               = 'example.com'
     s.mail_from_address = 'spree@example.com'
   end.save!
 end


### PR DESCRIPTION
[Fixes #5674]
