### PR TITLE
Using more objects in memory during checkout

### DIFF
--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -17,7 +17,6 @@ describe "Order Details", type: :feature, js: true do
   context 'as Admin' do
     stub_authorization!
 
-
     context "cart edit page" do
       before do
         product.master.stock_items.first.update_column(:count_on_hand, 100)
@@ -155,7 +154,6 @@ describe "Order Details", type: :feature, js: true do
       end
     end
 
-
     context 'Shipment edit page' do
       let!(:stock_location2) { create(:stock_location_with_items, name: 'Clarksville') }
 
@@ -183,7 +181,7 @@ describe "Order Details", type: :feature, js: true do
             wait_for_ajax
 
             expect(order.shipments.count).to eq(2)
-            expect(order.shipments.last.backordered?).to eq(false)
+            expect(order.shipments.reload.last.backordered?).to eq(false)
             expect(order.shipments.first.inventory_units_for(product.master).count).to eq(1)
             expect(order.shipments.last.inventory_units_for(product.master).count).to eq(1)
           end
@@ -199,7 +197,7 @@ describe "Order Details", type: :feature, js: true do
             wait_for_ajax
 
             expect(order.shipments.count).to eq(1)
-            expect(order.shipments.last.backordered?).to eq(false)
+            expect(order.shipments.reload.last.backordered?).to eq(false)
             expect(order.shipments.first.inventory_units_for(product.master).count).to eq(2)
             expect(order.shipments.first.stock_location.id).to eq(stock_location2.id)
           end
@@ -215,7 +213,7 @@ describe "Order Details", type: :feature, js: true do
             wait_for_ajax
 
             expect(order.shipments.count).to eq(1)
-            expect(order.shipments.last.backordered?).to eq(false)
+            expect(order.shipments.reload.last.backordered?).to eq(false)
             expect(order.shipments.first.inventory_units_for(product.master).count).to eq(5)
             expect(order.shipments.first.stock_location.id).to eq(stock_location2.id)
           end
@@ -310,7 +308,7 @@ describe "Order Details", type: :feature, js: true do
               wait_for_ajax
 
               expect(order.shipments.count).to eq(1)
-              expect(order.shipments.first.inventory_units_for(product.master).count).to eq(2)
+              expect(order.shipments.reload.first.inventory_units_for(product.master).count).to eq(2)
               expect(order.shipments.first.stock_location.id).to eq(stock_location2.id)
             end
           end
@@ -319,6 +317,7 @@ describe "Order Details", type: :feature, js: true do
         context 'multiple items in cart' do
           it 'should have no problem splitting if multiple items are in the from shipment' do
             order.contents.add(create(:variant), 2)
+
             expect(order.shipments.count).to eq(1)
             expect(order.shipments.first.manifest.count).to eq(2)
 
@@ -329,13 +328,12 @@ describe "Order Details", type: :feature, js: true do
             wait_for_ajax
 
             expect(order.shipments.count).to eq(2)
-            expect(order.shipments.last.backordered?).to eq(false)
+            expect(order.reload.shipments.last.backordered?).to eq(false)
             expect(order.shipments.first.inventory_units_for(product.master).count).to eq(1)
             expect(order.shipments.last.inventory_units_for(product.master).count).to eq(1)
           end
         end
       end
-
 
       context 'splitting to shipment' do
         before do

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -103,7 +103,7 @@ module Spree
           updated_at: Time.now,
         )
         if promotion?
-          self.update_column(:eligible, source.promotion.eligible?(adjustable))
+          self.update_column(:eligible, source.promotion.eligible?(target || adjustable))
         end
       end
       amount
@@ -113,8 +113,8 @@ module Spree
 
     def update_adjustable_adjustment_total
       # Cause adjustable's total to be recalculated
+      # NOTE leads to bad performance loops and reloads
       Adjustable::AdjustmentsUpdater.update(adjustable)
     end
-
   end
 end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -147,6 +147,10 @@ module Spree
                        order_id: self.id)
     end
 
+    def non_order_adjustments
+      Adjustment.where("order_id = ? AND adjustable_type != 'Spree::Order'", id)
+    end
+
     # For compatiblity with Calculator::PriceSack
     def amount
       line_items.inject(0.0) { |sum, li| sum + li.amount }
@@ -444,8 +448,7 @@ module Spree
           current_line_item.quantity += other_order_line_item.quantity
           current_line_item.save!
         else
-          other_order_line_item.order_id = self.id
-          other_order_line_item.save!
+          line_items.push other_order_line_item
         end
       end
 

--- a/core/app/models/spree/promotion_action.rb
+++ b/core/app/models/spree/promotion_action.rb
@@ -22,6 +22,7 @@ module Spree
       amount = compute_amount(adjustable)
       return if amount == 0
       adjustment = adjustable.adjustments.new(order: order,
+                                              adjustable: adjustable,
                                               source: self,
                                               label: label,
                                               amount: amount)

--- a/core/spec/models/spree/adjustable/adjustments_updater_spec.rb
+++ b/core/spec/models/spree/adjustable/adjustments_updater_spec.rb
@@ -70,14 +70,12 @@ module Spree
         end
 
         context "tax excluded from price" do
-          before do
+          it "tax applies to line item" do
             create(:adjustment, source: tax_rate,
                                 adjustable: line_item,
                                 order: order,
                                 included: false)
-          end
 
-          it "tax applies to line item" do
             subject.update
             line_item.reload
             # Taxable amount is: $20 (base) - $10 (promotion) = $10
@@ -89,6 +87,14 @@ module Spree
           end
 
           it "tax linked to order" do
+            order.adjustments.create!(
+              amount: 100.0,
+              label: 'order adj',
+              source: tax_rate,
+              adjustable: line_item,
+              order: order,
+              included: false
+            )
             order_subject.update
             order.reload
             expect(order.included_tax_total).to eq(0)

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -248,7 +248,8 @@ describe Spree::Order, :type => :model do
     let(:order) { stub_model(Spree::Order, item_count: 2) }
 
     before do
-      allow(order).to receive_messages(:line_items => line_items = [1, 2])
+      line_items = [Spree::LineItem.new, Spree::LineItem.new]
+      allow(order).to receive_messages(line_items: line_items)
       allow(order).to receive_messages(:adjustments => adjustments = [])
     end
 

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -43,7 +43,15 @@ module Spree
 
         before do
           updater.update
-          create(:adjustment, source: promotion_action, adjustable: order, order: order)
+
+          order.adjustments.create! do |a|
+            a.source = promotion_action
+            a.adjustable = order
+            a.order = order
+            a.label = 'a'
+            a.amount = -3
+          end
+
           create(:line_item, :order => order, price: 10) # in addition to the two already created
           updater.update
         end

--- a/core/spec/models/spree/promotion_handler/coupon_spec.rb
+++ b/core/spec/models/spree/promotion_handler/coupon_spec.rb
@@ -238,6 +238,7 @@ module Spree
             @order = Spree::Order.create!
             allow(@order).to receive_messages :coupon_code => "10off"
           end
+
           context "and the product price is less than promo discount" do
             before(:each) do
               3.times do |i|
@@ -245,17 +246,21 @@ module Spree
                 @order.contents.add(taxable.master, 1)
               end
             end
+
             it "successfully applies the promo" do
               # 3 * (9 + 0.9)
               expect(@order.total).to eq(29.7)
+
               coupon = Coupon.new(@order)
               coupon.apply
               expect(coupon.success).to be_present
+
               # 3 * ((9 - [9,10].min) + 0)
               expect(@order.reload.total).to eq(0)
               expect(@order.additional_tax_total).to eq(0)
             end
           end
+
           context "and the product price is greater than promo discount" do
             before(:each) do
               3.times do |i|
@@ -274,6 +279,7 @@ module Spree
               expect(@order.additional_tax_total).to eq(3.6)
             end
           end
+
           context "and multiple quantity per line item" do
             before(:each) do
               twnty_off = Promotion.create name: "promo", :code => "20off"
@@ -288,6 +294,7 @@ module Spree
                 @order.contents.add(taxable.master, 2)
               end
             end
+
             it "successfully applies the promo" do
               # 3 * ((2 * 10) + 2.0)
               expect(@order.total.to_f).to eq(66)
@@ -316,7 +323,6 @@ module Spree
             expect(order.line_items.pluck(:variant_id)).to include(variant.id)
           end
         end
-
       end
     end
   end

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -419,6 +419,6 @@ describe Spree::CheckoutController, :type => :controller do
 
     expect {
       spree_post :update, { :state => "payment" }
-    }.to change { order.line_items }
+    }.to change { order.line_items.to_a }
   end
 end


### PR DESCRIPTION
I've been trying to address some points we always consider when thinking of how to resolve / improve spree performance. Working with objects in memory, doing less `object.reload` and saying good bye to famous `order.update!`.

I started by trying to reduce db queries / ar object loads when adding items to cart (`order.contents.add`), could go as far as running about half less db queries, see https://gist.github.com/huoxito/3d8bcf0d8fa24f54f429, and I've been trying to somehow benchmark this but I'm not really sure how to do it best yet.

These are some from a simple `Benchmark.measure` script https://gist.github.com/huoxito/2e0bc0b97420eb032329. The difference is not much at all really from a simple default spree install (with sample data only). But I'm curious to see how this would go with some more real world store scenario.

Also started looking at the transition from address => delivery and made some changes on the Stock::Estimator to reduce the number of hits on db as well.

I couldn't make all specs pass yet mostly because I'd need more time to catch where is it exactly we're missing fresh data and using the out of date objects from the database (there are some NOTEs on the code though that should help narrow down the hot spots). 

Overall I feel like the end result here is going to be more code and possibly more complex code but I can't really see how else we can achieve better performance. Personally every time I've done something like `order.reload` is because I had lost track of the method calls and just reloading the object, or everything inside spree, would be the easiest way to go.

will still try to make those specs green but I wanted to share this with everyone to get feedback since I've spent already quite a decent amount of time on it.

// @BDQ @JDutil 
