### PR TITLE
Update edit.html.erb

### DIFF
--- a/backend/app/views/spree/admin/general_settings/edit.html.erb
+++ b/backend/app/views/spree/admin/general_settings/edit.html.erb
@@ -60,7 +60,7 @@
                 </div>
             <% end %>
           </fieldset>
-          <fieldset class="security no-border-bottom">
+          <fieldset class="no-border-bottom">
             <legend align="center"><%= Spree.t(:clear_cache)%></legend>
             <div>
               <%= Spree.t(:clear_cache_warning) %>


### PR DESCRIPTION
Removed class "security" from clear cache field-set, as this will cause other extension which uses deface and  depend on  ".row .security" to append itself twice. A notable example would be the spree_i18n extension's override, which appears twice and screws up locale selection dropdown at the frontend.
