### PR TITLE
Estimator tweaks improvements (performance)

### DIFF
--- a/core/app/models/spree/stock/inventory_unit_builder.rb
+++ b/core/app/models/spree/stock/inventory_unit_builder.rb
@@ -8,10 +8,19 @@ module Spree
       def units
         @order.line_items.flat_map do |line_item|
           line_item.quantity.times.map do |i|
-            @order.inventory_units.build(
+            @order.inventory_units.includes(
+              variant: {
+                product: {
+                  shipping_category: {
+                    shipping_methods: [:calculator, { zones: :zone_members }]
+                  }
+                }
+              }
+            ).build(
               pending: true,
               variant: line_item.variant,
-              line_item: line_item
+              line_item: line_item,
+              order: @order
             )
           end
         end


### PR DESCRIPTION
These were part of https://github.com/spree/spree/pull/5676 but I'm moving them here just so we only focus on the `order.contents.add` action there. I was too naive thinking I could review both add to card and the transition to shipment state in one shot.

Dont intend to do any more work here for the time being. Unless someone finds any issue with the changes or we get a broken build it can be merged soon into master. Reviews are much appreciated.
