### PR TITLE
Fix credit card related specs to work beyond 2014.

### DIFF
--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -1,11 +1,13 @@
 require 'spec_helper'
 
-describe Spree::CreditCard, :type => :model do
+describe Spree::CreditCard, type: :model do
   let(:valid_credit_card_attributes) do
-    { :number => '4111111111111111',
-      :verification_value => '123',
-      :expiry => "12 / 14",
-      :name => "Spree Commerce" }
+    {
+      number: '4111111111111111',
+      verification_value: '123',
+      expiry: "12 / #{(Time.now.year + 1).to_s.last(2)}",
+      name: 'Spree Commerce'
+    }
   end
 
   def self.payment_states

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -13,16 +13,7 @@ describe Spree::Payment, :type => :model do
   let(:avs_code) { 'D' }
   let(:cvv_code) { 'M' }
 
-  let(:card) do
-    Spree::CreditCard.create!(
-      number: "4111111111111111",
-      month: "12",
-      year: "2014",
-      verification_value: "123",
-      name: "Name",
-      imported: false
-    )
-  end
+  let(:card) { create :credit_card }
 
   let(:payment) do
     payment = Spree::Payment.new
@@ -517,27 +508,22 @@ describe Spree::Payment, :type => :model do
       end
 
       context "with multiple payment attempts" do
+        let(:attributes) { attributes_for(:credit_card) }
         it "should not try to create profiles on old failed payment attempts" do
           allow_any_instance_of(Spree::Payment).to receive(:payment_method) { gateway }
 
-          order.payments.create!(source_attributes: {number: "4111111111111115",
-                                                    month: "12",
-                                                    year: "2014",
-                                                    verification_value: "123",
-                                                    name: "Name"
-          },
-          :payment_method => gateway,
-          :amount => 100)
+          order.payments.create!(
+            source_attributes: attributes,
+            payment_method: gateway,
+            amount: 100
+          )
           expect(gateway).to receive(:create_profile).exactly :once
           expect(order.payments.count).to eq(1)
-          order.payments.create!(source_attributes: {number: "4111111111111111",
-                                                    month: "12",
-                                                    year: "2014",
-                                                    verification_value: "123",
-                                                    name: "Name"
-          },
-          :payment_method => gateway,
-          :amount => 100)
+          order.payments.create!(
+            source_attributes: attributes,
+            payment_method: gateway,
+            amount: 100
+          )
         end
 
       end


### PR DESCRIPTION
There are a couple places in the code where it uses 2014 as the expiry
for a credit card. That's all fine and dandy for the next month or so,
but come January 1. This should make sure that everyone stays happy.

This change should also be merged in to 2-4-stable, as those tests will start
failing on January 1, 2015 without this change.
