### PR TITLE
Fix version number in application creation command

### DIFF
--- a/guides/content/developer/tutorials/getting_started_tutorial.md
+++ b/guides/content/developer/tutorials/getting_started_tutorial.md
@@ -56,7 +56,7 @@ The distribution of Spree as a Rubygem allows it to be used in a new Rails proje
 Let's start by creating a standard Rails application using the following command:
 
 ```bash
-$ rails _4.1.6_ new mystore
+$ rails _4.1.8_ new mystore
 ```
 
 ### Adding Spree to Your Rails Application


### PR DESCRIPTION
The documentation was updated for rails 4.1.8 but this command is still using 4.1.6
