### PR TITLE
Enable amounts per currency for flat rate promotions (fixes #5433) +

### DIFF
--- a/backend/spec/features/admin/configuration/shipping_methods_spec.rb
+++ b/backend/spec/features/admin/configuration/shipping_methods_spec.rb
@@ -23,9 +23,9 @@ describe "Shipping Methods", :type => :feature do
   context "show" do
     it "should display existing shipping methods" do
       within_row(1) do
-        expect(column_text(1)).to eq(shipping_method.name) 
+        expect(column_text(1)).to eq(shipping_method.name)
         expect(column_text(2)).to eq(zone.name)
-        expect(column_text(3)).to eq("Flat Rate")
+        expect(column_text(3)).to eq("Flat rate")
         expect(column_text(4)).to eq("Both")
       end
     end

--- a/core/app/models/spree/calculator/flat_rate.rb
+++ b/core/app/models/spree/calculator/flat_rate.rb
@@ -10,7 +10,11 @@ module Spree
     end
 
     def compute(object=nil)
-      self.preferred_amount
+      if object && preferred_currency.upcase == object.currency.upcase
+        preferred_amount
+      else
+        0
+      end
     end
   end
 end

--- a/core/lib/spree/testing_support/factories/calculator_factory.rb
+++ b/core/lib/spree/testing_support/factories/calculator_factory.rb
@@ -9,4 +9,12 @@ FactoryGirl.define do
 
   factory :default_tax_calculator, class: Spree::Calculator::DefaultTax do
   end
+
+  factory :shipping_calculator, class: Spree::Calculator::Shipping::FlatRate do
+    after(:create) { |c| c.set_preference(:amount, 10.0) }
+  end
+
+  factory :shipping_no_amount_calculator, class: Spree::Calculator::Shipping::FlatRate do
+    after(:create) { |c| c.set_preference(:amount, 0) }
+  end
 end

--- a/core/lib/spree/testing_support/factories/shipping_method_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipping_method_factory.rb
@@ -11,11 +11,11 @@ FactoryGirl.define do
     end
 
     factory :shipping_method, class: Spree::ShippingMethod do
-      association(:calculator, factory: :calculator, strategy: :build)
+      association(:calculator, factory: :shipping_calculator, strategy: :build)
     end
 
     factory :free_shipping_method, class: Spree::ShippingMethod do
-      association(:calculator, factory: :no_amount_calculator, strategy: :build)
+      association(:calculator, factory: :shipping_no_amount_calculator, strategy: :build)
     end
   end
 end

--- a/core/spec/models/spree/calculator/flat_rate_spec.rb
+++ b/core/spec/models/spree/calculator/flat_rate_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe Spree::Calculator::FlatRate, type: :model do
+  let(:calculator) { Spree::Calculator::FlatRate.new }
+
+  let(:order) do
+    mock_model(
+      Spree::Order, quantity: 10, currency: "USD"
+    )
+  end
+
+  context "compute" do
+    it "should compute the amount as the rate when currency matches the order's currency" do
+      calculator.preferred_amount = 25.0
+      calculator.preferred_currency = "GBP"
+      allow(order).to receive_messages currency: "GBP"
+      expect(calculator.compute(order).round(2)).to eq(25.0)
+    end
+
+    it "should compute the amount as 0 when currency does not match the order's currency" do
+      calculator.preferred_amount = 100.0
+      calculator.preferred_currency = "GBP"
+      allow(order).to receive_messages currency: "USD"
+      expect(calculator.compute(order).round(2)).to eq(0.0)
+    end
+
+    it "should compute the amount as 0 when currency is blank" do
+      calculator.preferred_amount = 100.0
+      calculator.preferred_currency = ""
+      allow(order).to receive_messages currency: "GBP"
+      expect(calculator.compute(order).round(2)).to eq(0.0)
+    end
+
+    it "should compute the amount as the rate when the currencies use different casing" do
+      calculator.preferred_amount = 100.0
+      calculator.preferred_currency = "gBp"
+      allow(order).to receive_messages currency: "GBP"
+      expect(calculator.compute(order).round(2)).to eq(100.0)
+    end
+
+    it "should compute the amount as 0 when there is no object" do
+      calculator.preferred_amount = 100.0
+      calculator.preferred_currency = "GBP"
+      expect(calculator.compute.round(2)).to eq(0.0)
+    end
+  end
+end


### PR DESCRIPTION
The flat rate's currency and the order's currency are compared and only if they match is the amount returned, 0 is returned otherwise; when the calculator returns 0 the promotion is not added to the order.

Currency was already a preference for the FlatRate calculator but it wasn't used.

Some tests did break with this fix in, it turns out the shipping factories were using the wrong calculators (as far as I can tell), which I've included a fix for - I switched the factories calculators to those in Spree::Calculator::Shipping.
