### PR TITLE
2.4 upgrade guides now correctly suggest Rails 4.1.8 version

### DIFF
--- a/guides/content/developer/upgrades/two-dot-three-to-two-dot-four.md
+++ b/guides/content/developer/upgrades/two-dot-three-to-two-dot-four.md
@@ -14,10 +14,10 @@ version of Spree will have a 2-4-stable branch.
 
 ## Upgrade Rails
 
-For this Spree release, you will need to upgrade your Rails version to at least 4.1.6.
+For this Spree release, you will need to upgrade your Rails version to at least 4.1.8.
 
 ```ruby
-gem 'rails', '~> 4.1.6'
+gem 'rails', '~> 4.1.8'
 ```
 
 ## Upgrade Spree


### PR DESCRIPTION
Spree 2.4 upgrade guides state that Rails 4.1.6 is the minimal version while gemspec of spree_core in current 2-4-stable branch depends on 4.1.8. Changed the upgrade guides to reflect that.
