### PR TITLE
Negative Count On Hand When Setting On Stock Item

### DIFF
--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -34,7 +34,7 @@ module Spree
 
     def set_count_on_hand(value)
       self.count_on_hand = value
-      process_backorders(count_on_hand - count_on_hand_was)
+      process_backorders(count_on_hand) if count_on_hand > 0
 
       self.save!
     end


### PR DESCRIPTION
Simple change but perhaps not a good change, I'm wondering if the philosophical concept of setting `count_on_hand` within negative ranges needs to be handled differently.

For example, if my count_on_hand is -1 and it is set to 0, the current implementation will see a delta of 1 and distribute that 1 item to a backordered order. But is this really new inventory coming in even when it's all negative? Or rather, are we simply just adjusting within a negative range and this really isn't inventory at all. My feeling is that we should be doing the second. For example if I have -9 Spree Mugs and I go to -8 mugs, I'm still in mug debt and and I shouldn't be distributing anything. To be overly metaphysical here, nothing is nothing, whether it's -99999 or -9 or 0.

With our 3PL relation, we see this scenario a bit. They are trying to make canonical corrections to Spree inventory and are using the set_count_on_hand instead of adjust_count_on_hand. When Spree has a -1, and our 3PL is correcting to 0, it's not adding inventory. it's just saying "You've got 0". This feels like a more intuitive way of setting `count_on_hand` vs adjusting +1 to make -1 go to zero. The side effect, is that orders are moving to ready when they should stay backordered.

Summary of changes
- Do not invoke backorder_process if we're dealing with negative ranges of set_count_on_hand
- Only backorder_process with the delta between a positive count_on_hand to zero, vs the previous negative number.

Open to discussion here especially how other people consider negative inventory. Perhaps the easier fix is to never let count_on_hand go negative?

:shrugs
