### PR TITLE
fix n+1 for variants index action

### DIFF
--- a/backend/app/controllers/spree/admin/variants_controller.rb
+++ b/backend/app/controllers/spree/admin/variants_controller.rb
@@ -33,7 +33,7 @@ module Spree
           @deleted = (params.key?(:deleted) && params[:deleted] == "on") ? "checked" : ""
 
           if @deleted.blank?
-            @collection ||= super
+            @collection ||= super.includes(:default_price, option_values: :option_type)
           else
             @collection ||= Variant.only_deleted.where(:product_id => parent.id)
           end


### PR DESCRIPTION
Before:

``` sql
15:48:27 web.1   | Processing by Spree::Admin::VariantsController#index as HTML
15:48:27 web.1   |   Parameters: {"product_id"=>"the-girls-short-sleeve-t-shirt"}
15:48:27 web.1   |   Spree::Preference Load (0.5ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/backend_configuration/locale' LIMIT 1
15:48:27 web.1   |   Spree::User Load (0.9ms)  SELECT  "spree_users".* FROM "spree_users"  WHERE "spree_users"."deleted_at" IS NULL AND "spree_users"."id" = 1  ORDER BY "spree_users"."id" ASC LIMIT 1
15:48:27 web.1   |   Spree::Preference Load (0.5ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/app_configuration/currency' LIMIT 1
15:48:27 web.1   |   Spree::Store Load (0.9ms)  SELECT  "spree_stores".* FROM "spree_stores"  WHERE (url like '%localhost%')  ORDER BY "spree_stores"."id" ASC LIMIT 1
15:48:27 web.1   |   Spree::Store Load (0.9ms)  SELECT  "spree_stores".* FROM "spree_stores"  WHERE "spree_stores"."default" = 't'  ORDER BY "spree_stores"."id" ASC LIMIT 1
15:48:27 web.1   |   Spree::Order Load (1.1ms)  SELECT  "spree_orders".* FROM "spree_orders"  WHERE "spree_orders"."completed_at" IS NULL AND "spree_orders"."currency" = 'USD' AND "spree_orders"."guest_token" = 'I1834Yp4JKcP8v1JXl7V_g' AND "spree_orders"."store_id" = 1 AND "spree_orders"."user_id" = 1 LIMIT 1
15:48:27 web.1   |   Spree::Order Load (0.6ms)  SELECT  "spree_orders".* FROM "spree_orders"  WHERE "spree_orders"."user_id" = $1 AND "spree_orders"."completed_at" IS NULL AND "spree_orders"."user_id" = 1  ORDER BY created_at DESC LIMIT 1  [["user_id", 1]]
15:48:27 web.1   |   Spree::Order Load (0.4ms)  SELECT "spree_orders".* FROM "spree_orders"  WHERE "spree_orders"."user_id" = $1 AND "spree_orders"."completed_at" IS NULL AND (id != 2)  [["user_id", 1]]
15:48:27 web.1   |   Spree::Promotion::Actions::FreeShipping Load (0.5ms)  SELECT  "spree_promotion_actions".* FROM "spree_promotion_actions"  WHERE "spree_promotion_actions"."type" IN ('Spree::Promotion::Actions::FreeShipping') AND "spree_promotion_actions"."deleted_at" IS NULL LIMIT 1
15:48:27 web.1   |   Spree::Preference Load (0.7ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/app_configuration/redirect_https_to_http' LIMIT 1
15:48:27 web.1   |   Spree::Preference Load (0.5ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/app_configuration/allow_ssl_in_development_and_test' LIMIT 1
15:48:27 web.1   |    (0.4ms)  SELECT COUNT(*) FROM "spree_roles" INNER JOIN "spree_roles_users" ON "spree_roles"."id" = "spree_roles_users"."role_id" WHERE "spree_roles_users"."user_id" = $1 AND "spree_roles"."name" = 'admin'  [["user_id", 1]]
15:48:27 web.1   |   Spree::Product Load (0.9ms)  SELECT  "spree_products".* FROM "spree_products"  WHERE "spree_products"."deleted_at" IS NULL AND "spree_products"."slug" = 'the-girls-short-sleeve-t-shirt' LIMIT 1
15:48:27 web.1   |   Rendered /Users/benmorgan/.rvm/gems/ruby-2.1.5/bundler/gems/spree-2199541a7ee0/backend/app/views/spree/admin/shared/_product_sub_menu.html.erb (39.1ms)
15:48:27 web.1   |   Spree::Variant Load (1.0ms)  SELECT  "spree_variants".* FROM "spree_variants"  WHERE "spree_variants"."deleted_at" IS NULL AND "spree_variants"."product_id" = $1 AND "spree_variants"."is_master" = 't' LIMIT 1  [["product_id", 8]]
15:48:27 web.1   |   Rendered /Users/benmorgan/.rvm/gems/ruby-2.1.5/bundler/gems/spree-2199541a7ee0/backend/app/views/spree/admin/shared/_product_tabs.html.erb (56.4ms)
15:48:27 web.1   |   Spree::Variant Exists (0.7ms)  SELECT  1 AS one FROM "spree_variants"  WHERE "spree_variants"."deleted_at" IS NULL AND "spree_variants"."product_id" = $1 AND "spree_variants"."is_master" = 'f' LIMIT 1  [["product_id", 8]]
15:48:27 web.1   |   Spree::Variant Load (0.7ms)  SELECT "spree_variants".* FROM "spree_variants"  WHERE "spree_variants"."deleted_at" IS NULL AND "spree_variants"."product_id" = $1 AND "spree_variants"."is_master" = 'f'  ORDER BY "spree_variants".position ASC  [["product_id", 8]]
15:48:27 web.1   |   Spree::OptionValue Load (0.5ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 311]]
15:48:27 web.1   |   Spree::OptionType Load (0.4ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:27 web.1   |   Spree::OptionType Load (0.3ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:28 web.1   |   Spree::Price Load (0.4ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 311]]
15:48:28 web.1   |   Spree::Preference Load (0.6ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/app_configuration/display_currency' LIMIT 1
15:48:28 web.1   |   Spree::Preference Load (0.5ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/app_configuration/currency_symbol_position' LIMIT 1
15:48:28 web.1   |   Spree::Preference Load (0.4ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/app_configuration/hide_cents' LIMIT 1
15:48:28 web.1   |   Spree::Preference Load (0.7ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/app_configuration/currency_decimal_mark' LIMIT 1
15:48:28 web.1   |   Spree::Preference Load (0.5ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/app_configuration/currency_thousands_separator' LIMIT 1
15:48:28 web.1   |   Spree::Preference Load (0.5ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/app_configuration/currency_sign_before_symbol' LIMIT 1
15:48:28 web.1   |   Spree::OptionValue Load (0.4ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 312]]
15:48:28 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:28 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:28 web.1   |   Spree::Price Load (0.3ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 312]]
15:48:28 web.1   |   Spree::OptionValue Load (0.5ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 313]]
15:48:28 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:28 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:28 web.1   |   Spree::Price Load (0.3ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 313]]
15:48:28 web.1   |   Spree::OptionValue Load (0.3ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 314]]
15:48:28 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:28 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:28 web.1   |   Spree::Price Load (0.3ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 314]]
15:48:28 web.1   |   Spree::OptionValue Load (0.6ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 315]]
15:48:28 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:28 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:28 web.1   |   Spree::Price Load (0.3ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 315]]
15:48:28 web.1   |   Spree::OptionValue Load (0.4ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 316]]
15:48:28 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:28 web.1   |   CACHE (0.1ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:28 web.1   |   Spree::Price Load (0.3ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 316]]
15:48:28 web.1   |   Spree::OptionValue Load (0.4ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 317]]
15:48:28 web.1   |   CACHE (0.1ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:28 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:28 web.1   |   Spree::Price Load (0.3ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 317]]
15:48:28 web.1   |   Spree::OptionValue Load (0.4ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 318]]
15:48:28 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:28 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:28 web.1   |   Spree::Price Load (0.3ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 318]]
15:48:28 web.1   |   Spree::OptionValue Load (0.5ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 319]]
15:48:28 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:28 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:28 web.1   |   Spree::Price Load (0.3ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 319]]
15:48:28 web.1   |   Spree::OptionValue Load (0.4ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 320]]
15:48:28 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:28 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:28 web.1   |   Spree::Price Load (0.3ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 320]]
15:48:28 web.1   |   Spree::OptionValue Load (0.5ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 321]]
15:48:28 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:28 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:28 web.1   |   Spree::Price Load (0.5ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 321]]
15:48:28 web.1   |   Spree::OptionValue Load (0.4ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 322]]
15:48:28 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:28 web.1   |   CACHE (0.1ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:28 web.1   |   Spree::Price Load (0.3ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 322]]
15:48:28 web.1   |   Spree::OptionValue Load (0.5ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 287]]
15:48:28 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:28 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:28 web.1   |   Spree::Price Load (0.3ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 287]]
15:48:28 web.1   |   Spree::OptionValue Load (0.3ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 288]]
15:48:28 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:28 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:28 web.1   |   Spree::Price Load (0.3ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 288]]
15:48:28 web.1   |   Spree::OptionValue Load (0.6ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 289]]
15:48:28 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:28 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:28 web.1   |   Spree::Price Load (0.6ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 289]]
15:48:28 web.1   |   Spree::OptionValue Load (0.9ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 290]]
15:48:28 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:28 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:28 web.1   |   Spree::Price Load (0.3ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 290]]
15:48:28 web.1   |   Spree::OptionValue Load (0.3ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 291]]
15:48:28 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:28 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:28 web.1   |   Spree::Price Load (0.3ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 291]]
15:48:29 web.1   |   Spree::OptionValue Load (0.4ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 292]]
15:48:29 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:29 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:29 web.1   |   Spree::Price Load (0.3ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 292]]
15:48:29 web.1   |   Spree::OptionValue Load (0.3ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 293]]
15:48:29 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:29 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:29 web.1   |   Spree::Price Load (0.3ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 293]]
15:48:29 web.1   |   Spree::OptionValue Load (0.4ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 294]]
15:48:29 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:29 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:29 web.1   |   Spree::Price Load (0.3ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 294]]
15:48:29 web.1   |   Spree::OptionValue Load (0.4ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 295]]
15:48:29 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:29 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:29 web.1   |   Spree::Price Load (0.3ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 295]]
15:48:29 web.1   |   Spree::OptionValue Load (0.4ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 296]]
15:48:29 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:29 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:29 web.1   |   Spree::Price Load (0.3ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 296]]
15:48:29 web.1   |   Spree::OptionValue Load (0.3ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 297]]
15:48:29 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:29 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:29 web.1   |   Spree::Price Load (0.3ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 297]]
15:48:29 web.1   |   Spree::OptionValue Load (0.3ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 298]]
15:48:29 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:29 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:29 web.1   |   Spree::Price Load (0.3ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 298]]
15:48:29 web.1   |   Spree::OptionValue Load (0.3ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 299]]
15:48:29 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:29 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:29 web.1   |   Spree::Price Load (0.4ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 299]]
15:48:29 web.1   |   Spree::OptionValue Load (0.3ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 300]]
15:48:29 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:29 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:29 web.1   |   Spree::Price Load (0.3ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 300]]
15:48:29 web.1   |   Spree::OptionValue Load (0.3ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 301]]
15:48:29 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:29 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:29 web.1   |   Spree::Price Load (0.4ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 301]]
15:48:29 web.1   |   Spree::OptionValue Load (0.3ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 302]]
15:48:29 web.1   |   CACHE (0.1ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:29 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:29 web.1   |   Spree::Price Load (0.3ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 302]]
15:48:29 web.1   |   Spree::OptionValue Load (0.4ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 303]]
15:48:29 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:29 web.1   |   CACHE (0.1ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:29 web.1   |   Spree::Price Load (0.3ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 303]]
15:48:29 web.1   |   Spree::OptionValue Load (0.3ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 304]]
15:48:29 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:29 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:29 web.1   |   Spree::Price Load (0.3ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 304]]
15:48:29 web.1   |   Spree::OptionValue Load (0.4ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 305]]
15:48:29 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:29 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:29 web.1   |   Spree::Price Load (0.4ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 305]]
15:48:29 web.1   |   Spree::OptionValue Load (0.3ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 306]]
15:48:29 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:29 web.1   |   CACHE (0.1ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:29 web.1   |   Spree::Price Load (0.4ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 306]]
15:48:29 web.1   |   Spree::OptionValue Load (0.3ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 307]]
15:48:29 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:29 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:30 web.1   |   Spree::Price Load (0.3ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 307]]
15:48:30 web.1   |   Spree::OptionValue Load (0.4ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 308]]
15:48:30 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:30 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:30 web.1   |   Spree::Price Load (0.3ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 308]]
15:48:30 web.1   |   Spree::OptionValue Load (0.4ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 309]]
15:48:30 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:30 web.1   |   CACHE (0.1ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:30 web.1   |   Spree::Price Load (0.5ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 309]]
15:48:30 web.1   |   Spree::OptionValue Load (0.4ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 310]]
15:48:30 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:30 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:30 web.1   |   Spree::Price Load (0.3ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 310]]
15:48:30 web.1   |   Spree::OptionValue Load (0.4ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 323]]
15:48:30 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:30 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:30 web.1   |   Spree::Price Load (0.4ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 323]]
15:48:30 web.1   |   Spree::OptionValue Load (0.4ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 324]]
15:48:30 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:30 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:30 web.1   |   Spree::Price Load (0.3ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 324]]
15:48:30 web.1   |   Spree::OptionValue Load (0.4ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 325]]
15:48:30 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:30 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:30 web.1   |   Spree::Price Load (0.3ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 325]]
15:48:30 web.1   |   Spree::OptionValue Load (0.3ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 326]]
15:48:30 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:30 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:30 web.1   |   Spree::Price Load (0.4ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 326]]
15:48:30 web.1   |   Spree::OptionValue Load (0.4ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 327]]
15:48:30 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:30 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:30 web.1   |   Spree::Price Load (0.3ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 327]]
15:48:30 web.1   |   Spree::OptionValue Load (0.3ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = $1  [["variant_id", 328]]
15:48:30 web.1   |   CACHE (0.0ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
15:48:30 web.1   |   CACHE (0.1ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
15:48:30 web.1   |   Spree::Price Load (0.4ms)  SELECT  "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."variant_id" = $1 AND "spree_prices"."currency" = 'USD' LIMIT 1  [["variant_id", 328]]
15:48:30 web.1   |   Spree::ProductOptionType Exists (0.3ms)  SELECT  1 AS one FROM "spree_product_option_types"  WHERE "spree_product_option_types"."product_id" = $1 LIMIT 1  [["product_id", 8]]
15:48:30 web.1   |   Rendered /Users/benmorgan/.rvm/gems/ruby-2.1.5/bundler/gems/spree-2199541a7ee0/backend/app/views/spree/admin/variants/index.html.erb within spree/layouts/admin (2805.0ms)
15:48:32 web.1   | Completed 200 OK in 5238ms (Views: 4797.3ms | ActiveRecord: 87.1ms)
```

After:

``` sql
15:45:21 web.1   | Processing by Spree::Admin::VariantsController#index as HTML
15:45:21 web.1   |   Parameters: {"product_id"=>"the-girls-short-sleeve-t-shirt"}
15:45:21 web.1   |   Spree::Preference Load (0.6ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/backend_configuration/locale' LIMIT 1
15:45:21 web.1   |   Spree::User Load (0.7ms)  SELECT  "spree_users".* FROM "spree_users"  WHERE "spree_users"."deleted_at" IS NULL AND "spree_users"."id" = 1  ORDER BY "spree_users"."id" ASC LIMIT 1
15:45:21 web.1   |   Spree::Store Load (0.5ms)  SELECT  "spree_stores".* FROM "spree_stores"  WHERE (url like '%localhost%')  ORDER BY "spree_stores"."id" ASC LIMIT 1
15:45:21 web.1   |   Spree::Store Load (0.5ms)  SELECT  "spree_stores".* FROM "spree_stores"  WHERE "spree_stores"."default" = 't'  ORDER BY "spree_stores"."id" ASC LIMIT 1
15:45:21 web.1   |   Spree::Order Load (0.8ms)  SELECT  "spree_orders".* FROM "spree_orders"  WHERE "spree_orders"."completed_at" IS NULL AND "spree_orders"."currency" = 'USD' AND "spree_orders"."guest_token" = 'I1834Yp4JKcP8v1JXl7V_g' AND "spree_orders"."store_id" = 1 AND "spree_orders"."user_id" = 1 LIMIT 1
15:45:21 web.1   |   Spree::Order Load (0.4ms)  SELECT  "spree_orders".* FROM "spree_orders"  WHERE "spree_orders"."user_id" = $1 AND "spree_orders"."completed_at" IS NULL AND "spree_orders"."user_id" = 1  ORDER BY created_at DESC LIMIT 1  [["user_id", 1]]
15:45:21 web.1   |   Spree::Order Load (0.3ms)  SELECT "spree_orders".* FROM "spree_orders"  WHERE "spree_orders"."user_id" = $1 AND "spree_orders"."completed_at" IS NULL AND (id != 2)  [["user_id", 1]]
15:45:21 web.1   |    (0.4ms)  SELECT COUNT(*) FROM "spree_roles" INNER JOIN "spree_roles_users" ON "spree_roles"."id" = "spree_roles_users"."role_id" WHERE "spree_roles_users"."user_id" = $1 AND "spree_roles"."name" = 'admin'  [["user_id", 1]]
15:45:21 web.1   |   Spree::Product Load (0.6ms)  SELECT  "spree_products".* FROM "spree_products"  WHERE "spree_products"."deleted_at" IS NULL AND "spree_products"."slug" = 'the-girls-short-sleeve-t-shirt' LIMIT 1
15:45:21 web.1   |   Rendered /Users/benmorgan/.rvm/gems/ruby-2.1.5/bundler/gems/spree-2199541a7ee0/backend/app/views/spree/admin/shared/_product_sub_menu.html.erb (27.9ms)
15:45:21 web.1   |   Spree::Variant Load (0.4ms)  SELECT  "spree_variants".* FROM "spree_variants"  WHERE "spree_variants"."deleted_at" IS NULL AND "spree_variants"."product_id" = $1 AND "spree_variants"."is_master" = 't' LIMIT 1  [["product_id", 8]]
15:45:21 web.1   |   Rendered /Users/benmorgan/.rvm/gems/ruby-2.1.5/bundler/gems/spree-2199541a7ee0/backend/app/views/spree/admin/shared/_product_tabs.html.erb (37.9ms)
15:45:21 web.1   |    (0.8ms)  SELECT COUNT(*) FROM "spree_variants"  WHERE "spree_variants"."deleted_at" IS NULL AND "spree_variants"."product_id" = $1 AND "spree_variants"."is_master" = 'f'  [["product_id", 8]]
15:45:21 web.1   |   Spree::Variant Load (0.7ms)  SELECT "spree_variants".* FROM "spree_variants"  WHERE "spree_variants"."deleted_at" IS NULL AND "spree_variants"."product_id" = $1 AND "spree_variants"."is_master" = 'f'  ORDER BY "spree_variants".position ASC  [["product_id", 8]]
15:45:21 web.1   |   Spree::Price Load (1.2ms)  SELECT "spree_prices".* FROM "spree_prices"  WHERE "spree_prices"."deleted_at" IS NULL AND "spree_prices"."currency" = 'USD' AND "spree_prices"."variant_id" IN (311, 312, 313, 314, 315, 316, 317, 318, 319, 320, 321, 322, 287, 288, 289, 290, 291, 292, 293, 294, 295, 296, 297, 298, 299, 300, 301, 302, 303, 304, 305, 306, 307, 308, 309, 310, 323, 324, 325, 326, 327, 328)
15:45:21 web.1   |   HABTM_OptionValues Load (0.7ms)  SELECT "spree_option_values_variants".* FROM "spree_option_values_variants"  WHERE "spree_option_values_variants"."variant_id" IN (311, 312, 313, 314, 315, 316, 317, 318, 319, 320, 321, 322, 287, 288, 289, 290, 291, 292, 293, 294, 295, 296, 297, 298, 299, 300, 301, 302, 303, 304, 305, 306, 307, 308, 309, 310, 323, 324, 325, 326, 327, 328)
15:45:22 web.1   |   Spree::OptionValue Load (0.6ms)  SELECT "spree_option_values".* FROM "spree_option_values"  WHERE "spree_option_values"."id" IN (26, 4, 27, 28, 29, 14, 5, 16, 25, 6, 1, 2, 3)
15:45:22 web.1   |   Spree::OptionType Load (0.5ms)  SELECT "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" IN (1, 2)  ORDER BY spree_option_types.position
15:45:22 web.1   |   Spree::Variant Exists (0.5ms)  SELECT  1 AS one FROM "spree_variants"  WHERE "spree_variants"."deleted_at" IS NULL AND "spree_variants"."product_id" = $1 AND "spree_variants"."is_master" = 'f' LIMIT 1  [["product_id", 8]]
15:45:22 web.1   |   Spree::ProductOptionType Exists (0.4ms)  SELECT  1 AS one FROM "spree_product_option_types"  WHERE "spree_product_option_types"."product_id" = $1 LIMIT 1  [["product_id", 8]]
15:45:23 web.1   |   Rendered /Users/benmorgan/.rvm/gems/ruby-2.1.5/bundler/gems/spree-2199541a7ee0/backend/app/views/spree/admin/variants/index.html.erb within spree/layouts/admin (1229.3ms)
15:45:24 web.1   | Completed 200 OK in 3561ms (Views: 3227.9ms | ActiveRecord: 45.7ms)
```
