### PR TITLE
use active job for creating stock items

### DIFF
--- a/backend/app/jobs/spree/create_stock_items_job.rb
+++ b/backend/app/jobs/spree/create_stock_items_job.rb
@@ -3,12 +3,10 @@ module Spree
     queue_as :default
 
     def perform(stock_location_id)
-      ::Mutex.new.synchronize do
-        stock_location = StockLocation.find(stock_location_id)
+      stock_location = StockLocation.find(stock_location_id)
 
-        Variant.find_each do |variant|
-          stock_location.propagate_variant variant
-        end
+      Variant.find_each do |variant|
+        stock_location.propagate_variant variant
       end
     end
   end

--- a/backend/app/jobs/spree/create_stock_items_job.rb
+++ b/backend/app/jobs/spree/create_stock_items_job.rb
@@ -1,0 +1,15 @@
+module Spree
+  class CreateStockItemsJob < ActiveJob::Base
+    queue_as :default
+
+    def perform(stock_location_id)
+      ::Mutex.new.synchronize do
+        stock_location = StockLocation.find(stock_location_id)
+
+        Variant.find_each do |variant|
+          stock_location.propagate_variant variant
+        end
+      end
+    end
+  end
+end

--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -12,7 +12,7 @@ module Spree
     scope :active, -> { where(active: true) }
     scope :order_default, -> { order(default: :desc, name: :asc) }
 
-    after_create :create_stock_items, :if => "self.propagate_all_variants?"
+    after_commit :create_stock_items, on: :create, if: "self.propagate_all_variants?"
     after_save :ensure_one_default
 
     def state_text

--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -107,7 +107,15 @@ module Spree
 
     private
       def create_stock_items
-        Variant.find_each { |variant| self.propagate_variant(variant) }
+        CreateStockItemsJob.enqueue id
+      rescue NoMethodError
+        begin
+          CreateStockItemsJob.perform_later id
+        rescue NoMethodError
+          raise 'You are currently using an unsupported version of ActiveJob. ' \
+                'We are currently trying to call either `enqueue` or `perform_later`, ' \
+                'but we are unable to queue the job.'
+        end
       end
 
       def ensure_one_default


### PR DESCRIPTION
This one is going to break some tests :)

Here, I've moved stock item creation out into a job. This is because it takes, on my development machine, ~2 minutes to complete.

Version 0 (Rails 4.1 compatible) uses `enqueue` to perform jobs. I am currently using version 0 of Active Job with Spree 2.4 and its working fine. In Rails 4.2, the method for adding jobs to the queue was renamed to `perform_later`.

I think there's a lot of work to be done, but I feel like this is the first step in trying to get AJ into Spree for performance reasons.

I'm thinking of having a `defined? ActiveJob` check so that users can cherry-pick this code into Spree 2.4.

Thoughts?
