### PR TITLE
general case competing promo pseudo

### DIFF
--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -44,6 +44,11 @@ module Spree
     after_create :update_adjustable_adjustment_total
     after_destroy :update_adjustable_adjustment_total
 
+
+    class_attribute :competing_discount_source_types
+
+    self.competing_discount_source_types = ['Spree::PromotionAction']
+
     scope :open, -> { where(state: 'open') }
     scope :closed, -> { where(state: 'closed') }
     scope :tax, -> { where(source_type: 'Spree::TaxRate') }
@@ -62,6 +67,7 @@ module Spree
     scope :return_authorization, -> { where(source_type: "Spree::ReturnAuthorization") }
     scope :included, -> { where(included: true)  }
     scope :additional, -> { where(included: false) }
+    scope :competing_discounts, -> { where(source_type: competing_discount_source_types)}
 
     extend DisplayMoney
     money_methods :amount

--- a/core/app/models/spree/item_adjustments.rb
+++ b/core/app/models/spree/item_adjustments.rb
@@ -38,7 +38,7 @@ module Spree
       # Additional tax adjustments are the opposite, affecting the final total.
       promo_total = 0
       run_callbacks :promo_adjustments do
-        promotion_total = adjustments.promotion.reload.map do |adjustment|
+        promotion_total = adjustments.competing_discounts.reload.map do |adjustment|
           adjustment.update!(@item)
         end.compact.sum
 
@@ -70,13 +70,13 @@ module Spree
     # have the same amount, then it will pick the latest one.
     def choose_best_promotion_adjustment
       if best_promotion_adjustment
-        other_promotions = self.adjustments.promotion.where.not(id: best_promotion_adjustment.id)
+        other_promotions = self.adjustments.competing_discounts.where.not(id: best_promotion_adjustment.id)
         other_promotions.update_all(:eligible => false)
       end
     end
 
     def best_promotion_adjustment
-      @best_promotion_adjustment ||= adjustments.promotion.eligible.reorder("amount ASC, created_at DESC, id DESC").first
+      @best_promotion_adjustment ||= adjustments.competing_discounts.eligible.reorder("amount ASC, created_at DESC, id DESC").first
     end
   end
 end


### PR DESCRIPTION
We have a [BulkDiscount](https://github.com/darbs/Spree-Bulk-Discount) gem that creates adjustments on line_items based on the quantities. 

The BulkDiscount "competes" with the traditional promotions (they don't stack, the best one is chosen) and there is no way to hook into the current Spree::ItemAdjustments update_adjustments method cleanly. This approach would allow adjustments created by other sources to compete for the spot of best_promotion_adjustment by registering themselves in the Spree::Adjustments.competing_discount_source_types.

Ex:

```
Spree::Adjustments.competing_discount_source_types << "MyOtherDiscountClass"
```

Another use cases where other people may desire the functionality is price books (blanket pricing modifications for different groups of users, "employee", "vip", "regular").
