### PR TITLE
Faster states and countries

### DIFF
--- a/core/db/default/spree/countries.rb
+++ b/core/db/default/spree/countries.rb
@@ -1,41 +1,23 @@
 require 'carmen'
 
 connection = ActiveRecord::Base.connection
-case connection.adapter_name
-when "PostgreSQL"
-  country_inserts = []
-  country_values = -> do
-    Carmen::Country.all.each do |country|
-      country_inserts << [country.name, country.alpha_3_code, country.alpha_2_code,
-                          country.name.upcase, country.numeric_code, "#{country.subregions?}"]
-    end
-    country_inserts.map do |country_insert|
-      country_insert.map do |country_value|
-        country_value.gsub("'", "''")
-      end.join("', '")
-    end.join("'), ('")
-  end
+country_inserts = []
 
-  connection.execute <<-SQL
-    INSERT INTO spree_countries ("name", "iso3", "iso", "iso_name", "numcode", "states_required")
-    VALUES ('#{country_values.call}');
-  SQL
-else
-  countries = []
+country_values = -> do
   Carmen::Country.all.each do |country|
-    countries << {
-      name: country.name,
-      iso3: country.alpha_3_code,
-      iso: country.alpha_2_code,
-      iso_name: country.name.upcase,
-      numcode: country.numeric_code,
-      states_required: country.subregions?
-    }
+    country_inserts << [country.name, country.alpha_3_code, country.alpha_2_code,
+                        country.name.upcase, country.numeric_code, "#{country.subregions?}"]
   end
-
-  ActiveRecord::Base.transaction do
-    Spree::Country.create!(countries)
-  end
+  country_inserts.map do |country_insert|
+    country_insert.map do |country_value|
+      country_value.gsub("'", "''")
+    end.join("', '")
+  end.join("'), ('")
 end
+
+connection.execute <<-SQL
+  INSERT INTO spree_countries ("name", "iso3", "iso", "iso_name", "numcode", "states_required")
+  VALUES ('#{country_values.call}');
+SQL
 
 Spree::Config[:default_country_id] = Spree::Country.find_by(name: "United States").id

--- a/core/db/default/spree/countries.rb
+++ b/core/db/default/spree/countries.rb
@@ -6,7 +6,7 @@ country_inserts = []
 country_values = -> do
   Carmen::Country.all.each do |country|
     country_inserts << [country.name, country.alpha_3_code, country.alpha_2_code,
-                        country.name.upcase, country.numeric_code, "#{country.subregions?}"]
+                        country.name.upcase, country.numeric_code, country.subregions?.to_s]
   end
   country_inserts.map do |country_insert|
     country_insert.map do |country_value|

--- a/core/db/default/spree/countries.rb
+++ b/core/db/default/spree/countries.rb
@@ -18,8 +18,11 @@ country_values = -> do
   country_inserts.join("), (")
 end
 
+columns = ["name", "iso3", "iso", "iso_name", "numcode", "states_required"]
+columns = connection.adapter_name =~ /MySQL/i ? columns.join(", ") : "\"#{columns.join('", "')}\""
+
 connection.execute <<-SQL
-  INSERT INTO spree_countries ("name", "iso3", "iso", "iso_name", "numcode", "states_required")
+  INSERT INTO spree_countries (#{columns})
   VALUES (#{country_values.call});
 SQL
 

--- a/core/db/default/spree/countries.rb
+++ b/core/db/default/spree/countries.rb
@@ -1,19 +1,41 @@
 require 'carmen'
 
-countries = []
-Carmen::Country.all.each do |country|
-  countries << {
-    name: country.name,
-    iso3: country.alpha_3_code,
-    iso: country.alpha_2_code,
-    iso_name: country.name.upcase,
-    numcode: country.numeric_code,
-    states_required: country.subregions?
-  }
-end
+connection = ActiveRecord::Base.connection
+case connection.adapter_name
+when "PostgreSQL"
+  country_inserts = []
+  country_values = -> do
+    Carmen::Country.all.each do |country|
+      country_inserts << [country.name, country.alpha_3_code, country.alpha_2_code,
+                          country.name.upcase, country.numeric_code, "#{country.subregions?}"]
+    end
+    country_inserts.map do |country_insert|
+      country_insert.map do |country_value|
+        country_value.gsub("'", "''")
+      end.join("', '")
+    end.join("'), ('")
+  end
 
-ActiveRecord::Base.transaction do
-  Spree::Country.create!(countries)
+  connection.execute <<-SQL
+    INSERT INTO spree_countries ("name", "iso3", "iso", "iso_name", "numcode", "states_required")
+    VALUES ('#{country_values.call}');
+  SQL
+else
+  countries = []
+  Carmen::Country.all.each do |country|
+    countries << {
+      name: country.name,
+      iso3: country.alpha_3_code,
+      iso: country.alpha_2_code,
+      iso_name: country.name.upcase,
+      numcode: country.numeric_code,
+      states_required: country.subregions?
+    }
+  end
+
+  ActiveRecord::Base.transaction do
+    Spree::Country.create!(countries)
+  end
 end
 
 Spree::Config[:default_country_id] = Spree::Country.find_by(name: "United States").id

--- a/core/db/default/spree/states.rb
+++ b/core/db/default/spree/states.rb
@@ -24,18 +24,20 @@ when "PostgreSQL"
     VALUES ('#{state_values.call}');
   SQL
 else
-  Spree::Country.all.each do |country|
-    carmen_country = Carmen::Country.named(country.name)
-    @states ||= []
-    if carmen_country.subregions?
-      carmen_country.subregions.each do |subregion|
-        @states << {
-          name: subregion.name,
-          abbr: subregion.code,
-          country: country
-        }
+  ActiveRecord::Base.transaction do
+    Spree::Country.all.each do |country|
+      carmen_country = Carmen::Country.named(country.name)
+      @states ||= []
+      if carmen_country.subregions?
+        carmen_country.subregions.each do |subregion|
+          @states << {
+            name: subregion.name,
+            abbr: subregion.code,
+            country: country
+          }
+        end
       end
     end
+    Spree::State.create!(@states)
   end
-  Spree::State.create!(@states)
 end

--- a/core/db/default/spree/states.rb
+++ b/core/db/default/spree/states.rb
@@ -1,43 +1,23 @@
 connection = ActiveRecord::Base.connection
-case connection.adapter_name
-when "PostgreSQL"
-  state_inserts = []
+state_inserts = []
 
-  state_values = -> do
-    Spree::Country.all.each do |country|
-      carmen_country = Carmen::Country.named(country.name)
-      if carmen_country.subregions?
-        carmen_country.subregions.each do |subregion|
-          state_inserts << [subregion.name, subregion.code, country.id.to_s]
-        end
+state_values = -> do
+  Spree::Country.all.each do |country|
+    carmen_country = Carmen::Country.named(country.name)
+    if carmen_country.subregions?
+      carmen_country.subregions.each do |subregion|
+        state_inserts << [subregion.name, subregion.code, country.id.to_s]
       end
     end
-    state_inserts.map do |state_insert|
-      state_insert.map do |state_value|
-        state_value.gsub("'", "''")
-      end.join("', '")
-    end.join("'), ('")
   end
-
-  connection.execute <<-SQL
-    INSERT INTO spree_states ("name", "abbr", "country_id")
-    VALUES ('#{state_values.call}');
-  SQL
-else
-  ActiveRecord::Base.transaction do
-    Spree::Country.all.each do |country|
-      carmen_country = Carmen::Country.named(country.name)
-      @states ||= []
-      if carmen_country.subregions?
-        carmen_country.subregions.each do |subregion|
-          @states << {
-            name: subregion.name,
-            abbr: subregion.code,
-            country: country
-          }
-        end
-      end
-    end
-    Spree::State.create!(@states)
-  end
+  state_inserts.map do |state_insert|
+    state_insert.map do |state_value|
+      state_value.gsub("'", "''")
+    end.join("', '")
+  end.join("'), ('")
 end
+
+connection.execute <<-SQL
+  INSERT INTO spree_states ("name", "abbr", "country_id")
+  VALUES ('#{state_values.call}');
+SQL

--- a/core/db/default/spree/states.rb
+++ b/core/db/default/spree/states.rb
@@ -2,18 +2,17 @@ connection = ActiveRecord::Base.connection
 state_inserts = []
 
 state_values = -> do
-  Spree::Country.all.each do |country|
+  Spree::Country.where(states_required: true).each do |country|
     carmen_country = Carmen::Country.named(country.name)
-    if carmen_country.subregions?
-      carmen_country.subregions.each do |subregion|
-        name       = connection.quote subregion.name
-        abbr       = connection.quote subregion.code
-        country_id = connection.quote country.id
+    carmen_country.subregions.each do |subregion|
+      name       = connection.quote subregion.name
+      abbr       = connection.quote subregion.code
+      country_id = connection.quote country.id
 
-        state_inserts << [name, abbr, country_id].join(", ")
-      end
+      state_inserts << [name, abbr, country_id].join(", ")
     end
   end
+
   state_inserts.join("), (")
 end
 

--- a/core/db/default/spree/states.rb
+++ b/core/db/default/spree/states.rb
@@ -1,4 +1,29 @@
-ActiveRecord::Base.transaction do
+connection = ActiveRecord::Base.connection
+case connection.adapter_name
+when "PostgreSQL"
+  state_inserts = []
+
+  state_values = -> do
+    Spree::Country.all.each do |country|
+      carmen_country = Carmen::Country.named(country.name)
+      if carmen_country.subregions?
+        carmen_country.subregions.each do |subregion|
+          state_inserts << [subregion.name, subregion.code, country.id.to_s]
+        end
+      end
+    end
+    state_inserts.map do |state_insert|
+      state_insert.map do |state_value|
+        state_value.gsub("'", "''")
+      end.join("', '")
+    end.join("'), ('")
+  end
+
+  connection.execute <<-SQL
+    INSERT INTO spree_states ("name", "abbr", "country_id")
+    VALUES ('#{state_values.call}');
+  SQL
+else
   Spree::Country.all.each do |country|
     carmen_country = Carmen::Country.named(country.name)
     @states ||= []

--- a/core/db/default/spree/states.rb
+++ b/core/db/default/spree/states.rb
@@ -16,8 +16,9 @@ state_values = -> do
   state_inserts.map { |x| "(#{x})" }
 end
 
-columns = ["name", "abbr", "country_id"]
-columns = connection.adapter_name =~ /MySQL/i ? columns.join(", ") : "\"#{columns.join('", "')}\""
+columns = ["name", "abbr", "country_id"].map do |column|
+  connection.quote_column_name column
+end.join(', ')
 
 state_values.call.each_slice(500) do |state_values_batch|
   connection.execute <<-SQL

--- a/core/db/default/spree/states.rb
+++ b/core/db/default/spree/states.rb
@@ -13,8 +13,7 @@ state_values = -> do
     end
   end
 
-  state_inserts = "(" + state_inserts.join("), (") + ")"
-  state_inserts.gsub("), (", "), i (").split(", i ") # the i is to make the splitting accurate
+  state_inserts.map { |x| "(#{x})" }
 end
 
 columns = ["name", "abbr", "country_id"]


### PR DESCRIPTION
In PR #5477 we were able to increase the seed database dramatically by using Carmen. In doing so, we end up adding a _lot_ of data for an initial seed. Quite often, it would take ~1-2 seconds to add the countries and about ~14-16 seconds to add the states.

This PR is to help fix that issue. I noted that it would take about 2 seconds for the states to be added via a mass insert. Guess what: it now takes ~1 second to add 3 thousand rows.

While making the code for states, I decided to do a test run with a small amount of data (the countries) and was able to round down what would take (for me) 1.2 seconds down to 0.1 seconds.

If this PR is acceptable, I'll add a `when` for `"MySQL"` and get some performance in over there when seeding.
