### PR TITLE
Promotion actions do not need to calculate amount before creating adjustments

### DIFF
--- a/backend/spec/features/admin/orders/adjustments_spec.rb
+++ b/backend/spec/features/admin/orders/adjustments_spec.rb
@@ -68,7 +68,7 @@ describe "Adjustments", type: :feature do
 
     context "with validation errors" do
       it "should not create a new adjustment" do
-        fill_in "adjustment_amount", with: ""
+        fill_in "adjustment_amount", with: "Not a number"
         fill_in "adjustment_label", with: ""
         click_button "Continue"
         expect(page).to have_content("Label can't be blank")
@@ -100,7 +100,7 @@ describe "Adjustments", type: :feature do
 
     context "with validation errors" do
       it "should not update the adjustment" do
-        fill_in "adjustment_amount", with: ""
+        fill_in "adjustment_amount", with: "not a number"
         fill_in "adjustment_label", with: ""
         click_button "Continue"
         expect(page).to have_content("Label can't be blank")

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -93,6 +93,7 @@ module Spree
       return amount if closed?
       if source.present?
         amount = source.compute_amount(target || adjustable)
+        destroy and return 0 if amount == 0 && promotion?
         self.update_columns(
           amount: amount,
           updated_at: Time.now,

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -43,6 +43,7 @@ module Spree
 
     after_create :update_adjustable_adjustment_total
     after_destroy :update_adjustable_adjustment_total
+    before_validation -> { self.amount ||= 0.0 }
 
     scope :open, -> { where(state: 'open') }
     scope :closed, -> { where(state: 'closed') }

--- a/core/app/models/spree/promotion/actions/create_adjustment.rb
+++ b/core/app/models/spree/promotion/actions/create_adjustment.rb
@@ -21,10 +21,7 @@ module Spree
           order = options[:order]
           return if promotion_credit_exists?(order)
 
-          amount = compute_amount(order)
-          return if amount == 0
           Spree::Adjustment.create!(
-            amount: amount,
             order: order,
             adjustable: order,
             source: self,

--- a/core/app/models/spree/promotion/actions/create_item_adjustments.rb
+++ b/core/app/models/spree/promotion/actions/create_item_adjustments.rb
@@ -26,10 +26,7 @@ module Spree
         end
 
         def create_adjustment(adjustable, order)
-          amount = self.compute_amount(adjustable)
-          return if amount == 0
           self.adjustments.create!(
-            amount: amount,
             adjustable: adjustable,
             order: order,
             label: "#{Spree.t(:promotion)} (#{promotion.name})",

--- a/core/app/models/spree/promotion/actions/free_shipping.rb
+++ b/core/app/models/spree/promotion/actions/free_shipping.rb
@@ -8,7 +8,6 @@ module Spree
             return false if promotion_credit_exists?(shipment)
             shipment.adjustments.create!(
               order: shipment.order, 
-              amount: compute_amount(shipment),
               source: self,
               label: label,
             )

--- a/core/spec/models/spree/promotion/actions/create_adjustment_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_adjustment_spec.rb
@@ -14,14 +14,6 @@ describe Spree::Promotion::Actions::CreateAdjustment, :type => :model do
       allow(action).to receive_messages(:promotion => promotion)
     end
 
-    # Regression test for #3966
-    it "does not apply an adjustment if the amount is 0" do
-      action.calculator.preferred_amount = 0
-      action.perform(payload)
-      expect(promotion.credits_count).to eq(0)
-      expect(order.adjustments.count).to eq(0)
-    end
-
     it "should create a discount with correct negative amount" do
       order.shipments.create!(:cost => 10)
 

--- a/core/spec/models/spree/promotion/actions/create_adjustment_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_adjustment_spec.rb
@@ -14,6 +14,15 @@ describe Spree::Promotion::Actions::CreateAdjustment, :type => :model do
       allow(action).to receive_messages(:promotion => promotion)
     end
 
+    # Regression test for #3966
+    it "does not apply an adjustment if the amount is 0" do
+      action.calculator.preferred_amount = 0
+      action.calculator.save
+      action.perform(payload)
+      expect(promotion.credits_count).to eq(0)
+      expect(order.adjustments.count).to eq(0)
+    end
+
     it "should create a discount with correct negative amount" do
       order.shipments.create!(:cost => 10)
 

--- a/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
@@ -16,17 +16,6 @@ module Spree
         end
 
         context "#perform" do
-          # Regression test for #3966
-          context "when calculator computes 0" do
-            before do
-              allow(action).to receive_messages :compute_amount => 0
-            end
-
-            it "does not create an adjustment when calculator returns 0" do
-              action.perform(payload)
-              expect(action.adjustments).to be_empty
-            end
-          end
 
           context "when calculator returns a non-zero value" do
             before do

--- a/core/spec/models/spree/promotion_handler/coupon_spec.rb
+++ b/core/spec/models/spree/promotion_handler/coupon_spec.rb
@@ -161,7 +161,7 @@ module Spree
         context "with a whole-order adjustment action" do
           let!(:action) { Promotion::Actions::CreateAdjustment.create(promotion: promotion, calculator: calculator) }
           context "right coupon given" do
-            let(:order) { create(:order) }
+            let(:order) { create(:order_with_line_items) }
             let(:calculator) { Calculator::FlatRate.new(preferred_amount: 10) }
 
             before do

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -220,7 +220,7 @@ describe Spree::Promotion, :type => :model do
     end
 
     let!(:action) do
-      calculator = Spree::Calculator::FlatRate.new
+      calculator = Spree::Calculator::FlatRate.new(preferred_amount: 10)
       action_params = { :promotion => promotion, :calculator => calculator }
       action = Spree::Promotion::Actions::CreateAdjustment.create(action_params)
       promotion.actions << action
@@ -228,7 +228,7 @@ describe Spree::Promotion, :type => :model do
     end
 
     let!(:adjustment) do
-      order = create(:order)
+      order = create(:order_with_line_items)
       Spree::Adjustment.create!(
         order:      order,
         adjustable: order,


### PR DESCRIPTION
Spree::Adjustment re-calculates all adjustments when one is created, so its redundant to do the calculation twice.

Original behaviour was designed to check if the amount was 0 and then not add adjustment if so. However it is unclear why this behaviour is desirable as adjustments that previously calculate an amount of 0 may not do so later.
