### PR TITLE
Adjustment uniqueness

### DIFF
--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -30,7 +30,9 @@ module Spree
     validates :order, presence: true
     validates :label, presence: true
     validates :amount, numericality: true
-    validates :source_id, uniqueness: { scope: [:source_type, :adjustable_id, :adjustable_type] }, allow_nil: true
+    validates :source_id, 
+              uniqueness: { scope: [:source_type, :adjustable_id, :adjustable_type] }, 
+              allow_nil: true
 
     state_machine :state, initial: :open do
       event :close do

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -30,8 +30,8 @@ module Spree
     validates :order, presence: true
     validates :label, presence: true
     validates :amount, numericality: true
-    validates :source_id, 
-              uniqueness: { scope: [:source_type, :adjustable_id, :adjustable_type] }, 
+    validates :source_id,
+              uniqueness: { scope: [:source_type, :adjustable_id, :adjustable_type] },
               allow_nil: true
 
     state_machine :state, initial: :open do

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -30,6 +30,7 @@ module Spree
     validates :order, presence: true
     validates :label, presence: true
     validates :amount, numericality: true
+    validates :source_id, uniqueness: { scope: [:source_type, :adjustable_id, :adjustable_type] }, allow_nil: true
 
     state_machine :state, initial: :open do
       event :close do

--- a/core/app/models/spree/promotion/actions/create_adjustment.rb
+++ b/core/app/models/spree/promotion/actions/create_adjustment.rb
@@ -19,18 +19,17 @@ module Spree
         # `false` if the promotion has already been applied.
         def perform(options = {})
           order = options[:order]
-          return if promotion_credit_exists?(order)
 
           amount = compute_amount(order)
           return if amount == 0
-          Spree::Adjustment.create!(
+          adjustment = Spree::Adjustment.new(
             amount: amount,
             order: order,
             adjustable: order,
             source: self,
             label: "#{Spree.t(:promotion)} (#{promotion.name})"
           )
-          true
+          adjustment.save
         end
 
         # Ensure a negative amount which does not exceed the sum of the order's
@@ -41,15 +40,6 @@ module Spree
         end
 
         private
-          # Tells us if there if the specified promotion is already associated with the line item
-          # regardless of whether or not its currently eligible. Useful because generally
-          # you would only want a promotion action to apply to order no more than once.
-          #
-          # Receives an adjustment +source+ (here a PromotionAction object) and tells
-          # if the order has adjustments from that already
-          def promotion_credit_exists?(adjustable)
-            self.adjustments.where(:adjustable_id => adjustable.id).exists?
-          end
 
           def ensure_action_has_calculator
             return if self.calculator

--- a/core/app/models/spree/promotion/actions/create_item_adjustments.rb
+++ b/core/app/models/spree/promotion/actions/create_item_adjustments.rb
@@ -28,13 +28,13 @@ module Spree
         def create_adjustment(adjustable, order)
           amount = self.compute_amount(adjustable)
           return if amount == 0
-          self.adjustments.create!(
+          adjustment = self.adjustments.new(
             amount: amount,
             adjustable: adjustable,
             order: order,
             label: "#{Spree.t(:promotion)} (#{promotion.name})",
-          )
-          true
+          ) 
+          adjustment.save
         end
 
         # Ensure a negative amount which does not exceed the sum of the order's
@@ -48,15 +48,6 @@ module Spree
         end
 
         private
-          # Tells us if there if the specified promotion is already associated with the line item
-          # regardless of whether or not its currently eligible. Useful because generally
-          # you would only want a promotion action to apply to line item no more than once.
-          #
-          # Receives an adjustment +source+ (here a PromotionAction object) and tells
-          # if the order has adjustments from that already
-          def promotion_credit_exists?(adjustable)
-            self.adjustments.where(:adjustable_id => adjustable.id).exists?
-          end
 
           def ensure_action_has_calculator
             return if self.calculator

--- a/core/app/models/spree/promotion/actions/create_item_adjustments.rb
+++ b/core/app/models/spree/promotion/actions/create_item_adjustments.rb
@@ -28,12 +28,12 @@ module Spree
         def create_adjustment(adjustable, order)
           amount = self.compute_amount(adjustable)
           return if amount == 0
-          adjustment = self.adjustments.new(
+          adjustment = adjustments.new(
             amount: amount,
             adjustable: adjustable,
             order: order,
             label: "#{Spree.t(:promotion)} (#{promotion.name})",
-          ) 
+          )
           adjustment.save
         end
 

--- a/core/app/models/spree/promotion/actions/free_shipping.rb
+++ b/core/app/models/spree/promotion/actions/free_shipping.rb
@@ -5,14 +5,13 @@ module Spree
         def perform(payload={})
           order = payload[:order]
           results = order.shipments.map do |shipment|
-            return false if promotion_credit_exists?(shipment)
-            shipment.adjustments.create!(
+            adjustment = shipment.adjustments.new(
               order: shipment.order, 
               amount: compute_amount(shipment),
               source: self,
               label: label,
             )
-            true
+            adjustment.save
           end
           # Did we actually end up applying any adjustments?
           # If so, then this action should be classed as 'successful'
@@ -25,12 +24,6 @@ module Spree
 
         def compute_amount(shipment)
           shipment.cost * -1
-        end
-
-        private
-
-        def promotion_credit_exists?(shipment)
-          shipment.adjustments.where(:source_id => self.id).exists?
         end
       end
     end

--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -30,6 +30,24 @@ describe Spree::Adjustment, :type => :model do
       expect(adjustment.adjustable).to receive(:touch)
       adjustment.save
     end
+
+    context 'same source and adjustable twice in a row' do
+      let(:source) { Spree::Promotion::Actions::CreateAdjustment.create }
+
+      def create_adjustment
+        order.adjustments.new(label: "Adjustment", amount: 5, order: order, source: source)
+      end
+
+      before do 
+        allow(Spree::ItemAdjustments).to receive(:new).and_return(double(update: true))
+        order.save
+      end
+
+      it 'only saves the first one' do
+        expect(create_adjustment.save).to be(true)
+        expect(create_adjustment.save).to be(false)
+      end
+    end
   end
 
   describe 'non_tax scope' do

--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -38,7 +38,7 @@ describe Spree::Adjustment, :type => :model do
         order.adjustments.new(label: "Adjustment", amount: 5, order: order, source: source)
       end
 
-      before do 
+      before do
         allow(Spree::ItemAdjustments).to receive(:new).and_return(double(update: true))
         order.save
       end

--- a/core/spec/models/spree/item_adjustments_spec.rb
+++ b/core/spec/models/spree/item_adjustments_spec.rb
@@ -102,12 +102,14 @@ module Spree
     context "best promotion is always applied" do
       let(:calculator) { Calculator::FlatRate.new(:preferred_amount => 10) }
 
-      let(:source) { Promotion::Actions::CreateItemAdjustments.create calculator: calculator }
+      def create_source
+        Promotion::Actions::CreateItemAdjustments.create(calculator: calculator)
+      end
 
       def create_adjustment(label, amount)
         create(:adjustment, :order      => order,
                             :adjustable => line_item,
-                            :source     => source,
+                            :source     => create_source,
                             :amount     => amount,
                             :state      => "closed",
                             :label      => label,

--- a/core/spec/models/spree/item_adjustments_spec.rb
+++ b/core/spec/models/spree/item_adjustments_spec.rb
@@ -107,13 +107,13 @@ module Spree
       end
 
       def create_adjustment(label, amount)
-        create(:adjustment, :order      => order,
-                            :adjustable => line_item,
-                            :source     => create_source,
-                            :amount     => amount,
-                            :state      => "closed",
-                            :label      => label,
-                            :mandatory  => false)
+        create(:adjustment, order:      order,
+                            adjustable: line_item,
+                            source:     create_source,
+                            amount:     amount,
+                            state:      "closed",
+                            label:      label,
+                            mandatory:  false)
       end
 
       it "should make all but the most valuable promotion adjustment ineligible, leaving non promotion adjustments alone" do

--- a/core/spec/models/spree/promotion/actions/create_adjustment_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_adjustment_spec.rb
@@ -37,13 +37,6 @@ describe Spree::Promotion::Actions::CreateAdjustment, :type => :model do
       expect(order.all_adjustments.count).to eq(1)
     end
 
-    it "should not create a discount when order already has one from this promotion" do
-      order.shipments.create!(:cost => 10)
-
-      action.perform(payload)
-      action.perform(payload)
-      expect(promotion.credits_count).to eq(1)
-    end
   end
 
   context "#destroy" do

--- a/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
@@ -45,11 +45,6 @@ module Spree
               expect(line_item.reload.adjustments.first.source).to eq action
             end
 
-            it "does not perform twice on the same item" do
-              2.times { action.perform(payload) }
-              expect(action.adjustments.count).to eq(1)
-            end
-
             context "with products rules" do
               let!(:second_line_item) { create(:line_item, :order => order) }
               let(:rule) { double Spree::Promotion::Rules::Product }

--- a/core/spec/models/spree/promotion/actions/free_shipping_spec.rb
+++ b/core/spec/models/spree/promotion/actions/free_shipping_spec.rb
@@ -24,11 +24,5 @@ describe Spree::Promotion::Actions::FreeShipping, :type => :model do
       expect(order.shipment_adjustments.last.amount.to_i).to eq(-100)
     end
 
-    it "should not create a discount when order already has one from this promotion" do
-      expect(action.perform(payload)).to be true
-      expect(action.perform(payload)).to be false
-      expect(promotion.credits_count).to eq(2)
-      expect(order.shipment_adjustments.count).to eq(2)
-    end
   end
 end


### PR DESCRIPTION
Replaces #promotion_credit_exists? guards on promotion actions with validation on adjustment
