### PR TITLE
add missing translation editing_country

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -636,6 +636,7 @@ en:
     display_currency: Display currency
     doesnt_track_inventory: It doesnt track inventory
     edit: Edit
+    editing_country: Editing Country
     editing_option_type: Editing Option Type
     editing_payment_method: Editing Payment Method
     editing_product: Editing Product


### PR DESCRIPTION
This translation is called from [here](https://github.com/spree/spree/blob/master/backend/app/views/spree/admin/countries/edit.html.erb#L2) and I was not able to find it in the locals.

Hope this helps.
