### PR TITLE
add back to countries list translation

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -462,6 +462,7 @@ en:
     back_end: Backend
     backordered: Backordered
     back_to_adjustments_list: Back To Adjustments List
+    back_to_countries_list: Back to Countries List
     back_to_customer_return: Back To Customer Return
     back_to_customer_return_list: Back To Customer Return List
     back_to_images_list: Back To Images List


### PR DESCRIPTION
I would have included this PR #5736, but that appears to be a commit that can go into 2-4-stable and master. This PR can only be merge with 2-4-stable.

There was a missing translation [here](https://github.com/spree/spree/blob/2-4-stable/backend/app/views/spree/admin/countries/edit.html.erb#L9) that I was unable to find in the locals.
