### PR TITLE
Improved admin header css

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/spree_admin.css.scss
+++ b/backend/app/assets/stylesheets/spree/backend/spree_admin.css.scss
@@ -52,6 +52,13 @@
   }
 }
 
+header.header.logged-out {
+  margin-top: 3em;
+  .logo {
+    background: none;
+  }
+}
+
 .content {
   background-color: white;
   padding-top: 0;

--- a/backend/app/views/spree/admin/shared/_header.html.erb
+++ b/backend/app/views/spree/admin/shared/_header.html.erb
@@ -1,14 +1,16 @@
-<header class="header">
+<% admin = try_spree_current_user.try(:has_spree_role?, "admin") %>
+
+<header class="header <%= admin ? "logged-in" : "logged-out" %>">
   <%= link_to image_tag(Spree::Config[:admin_interface_logo], id: 'logo'), spree.admin_path, class: "logo" %>
-  <nav class="navbar navbar-static-top" role="navigation">
-    <% if can? :admin, Spree::Order %>
-    <a href="#" class="navbar-btn sidebar-toggle" data-toggle="offcanvas" role="button">
-      <span class="sr-only">Toggle navigation</span>
-      <span class="icon-bar"></span>
-      <span class="icon-bar"></span>
-      <span class="icon-bar"></span>
-    </a>
-    <div class="navbar-right" data-hook="admin_login_navigation_bar"></div>
-    <% end %>
-  </nav>
+  <% if admin %>
+    <nav class="navbar navbar-static-top" role="navigation">
+      <a href="#" class="navbar-btn sidebar-toggle" data-toggle="offcanvas" role="button">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </a>
+      <div class="navbar-right" data-hook="admin_login_navigation_bar"></div>
+    </nav>
+  <% end %>
 </header>

--- a/backend/app/views/spree/admin/state_changes/index.html.erb
+++ b/backend/app/views/spree/admin/state_changes/index.html.erb
@@ -4,10 +4,7 @@
   <%= Spree::StateChange.human_attribute_name(:state_changes) %>
 <% end %>
 
-<% if @state_changes.none? %>
-  <p><%= Spree.t(:no_state_changes) %></p>
-<% else %>
-
+<% if @state_changes.any? %>
   <table class="table" id="listing_order_state_changes" data-hook>
     <thead>
       <tr data-hook="admin_orders_state_changes_headers">
@@ -38,4 +35,8 @@
       <% end %>
     </tbody>
   </table>
+<% end %>
+  <div class="alert alert-info no-objects-found">
+    <%= Spree.t(:no_state_changes) %>
+  </div>
 <% end %>


### PR DESCRIPTION
Improved admin header css for more clean admin login (see https://github.com/spree/spree_auth_devise/pull/244).
