### PR TITLE
Backend: when refreshing shipping rates, include backend-only shipping methods

### DIFF
--- a/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
+++ b/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
@@ -25,7 +25,7 @@ module Spree
             end
             while @order.next; end
 
-            @order.refresh_shipment_rates
+            @order.refresh_shipment_rates(false)
             flash[:success] = Spree.t('customer_details_updated')
             redirect_to admin_order_customer_path(@order)
           else

--- a/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
+++ b/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
@@ -25,7 +25,7 @@ module Spree
             end
             while @order.next; end
 
-            @order.refresh_shipment_rates(false)
+            @order.refresh_shipment_rates(ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END)
             flash[:success] = Spree.t('customer_details_updated')
             redirect_to admin_order_customer_path(@order)
           else

--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -54,7 +54,7 @@ module Spree
 
       def edit
         unless @order.completed?
-          @order.refresh_shipment_rates(false)
+          @order.refresh_shipment_rates(ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END)
         end
       end
 

--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -54,7 +54,7 @@ module Spree
 
       def edit
         unless @order.completed?
-          @order.refresh_shipment_rates
+          @order.refresh_shipment_rates(false)
         end
       end
 

--- a/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
@@ -2,18 +2,9 @@ require 'spec_helper'
 require 'cancan'
 require 'spree/testing_support/bar_ability'
 
-# Ability to test access to specific model instances
-# class OrderSpecificAbility
-#   include CanCan::Ability
+describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
 
-#   def initialize(user)
-#     can [:admin, :manage], Spree::Order, :number => 'R987654321'
-#   end
-# end
-
-describe Spree::Admin::Orders::CustomerDetailsController, :type => :controller do
-
-  context "with authorization" do
+  context 'with authorization' do
     stub_authorization!
 
     let(:order) do
@@ -29,18 +20,19 @@ describe Spree::Admin::Orders::CustomerDetailsController, :type => :controller d
       allow(Spree::Order).to receive_messages(find_by_number!: order)
     end
 
-    context "#update" do
-      it "does refresh the shipment rates with all shipping methods" do
-        allow(order).to receive_messages :update_attributes => true
-        allow(order).to receive_messages :next => false
-        expect(order).to receive(:refresh_shipment_rates).with(false)
+    context '#update' do
+      it 'does refresh the shipment rates with all shipping methods' do
+        allow(order).to receive_messages(update_attributes: true)
+        allow(order).to receive_messages(next: false)
+        expect(order).to receive(:refresh_shipment_rates)
+          .with(Spree::ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END)
         attributes = {
-          :order_id => order.number,
-          :order => {
-            :email => '',
-            :use_billing => '',
-            :bill_address_attributes => {},
-            :ship_address_attributes => {}
+          order_id: order.number,
+          order: {
+            email: '',
+            use_billing: '',
+            bill_address_attributes: {},
+            ship_address_attributes: {}
           }
         }
         spree_put :update, attributes

--- a/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+require 'cancan'
+require 'spree/testing_support/bar_ability'
+
+# Ability to test access to specific model instances
+# class OrderSpecificAbility
+#   include CanCan::Ability
+
+#   def initialize(user)
+#     can [:admin, :manage], Spree::Order, :number => 'R987654321'
+#   end
+# end
+
+describe Spree::Admin::Orders::CustomerDetailsController, :type => :controller do
+
+  context "with authorization" do
+    stub_authorization!
+
+    let(:order) do
+      mock_model(
+        Spree::Order,
+        total:           100,
+        number:          'R123456789',
+        billing_address: mock_model(Spree::Address)
+      )
+    end
+
+    before do
+      allow(Spree::Order).to receive_messages(find_by_number!: order)
+    end
+
+    context "#update" do
+      it "does refresh the shipment rates with all shipping methods" do
+        allow(order).to receive_messages :update_attributes => true
+        allow(order).to receive_messages :next => false
+        expect(order).to receive(:refresh_shipment_rates).with(false)
+        attributes = {
+          :order_id => order.number,
+          :order => {
+            :email => '',
+            :use_billing => '',
+            :bill_address_attributes => {},
+            :ship_address_attributes => {}
+          }
+        }
+        spree_put :update, attributes
+      end
+    end
+  end
+end

--- a/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
@@ -1,17 +1,17 @@
-require 'spec_helper'
-require 'cancan'
-require 'spree/testing_support/bar_ability'
+require "spec_helper"
+require "cancan"
+require "spree/testing_support/bar_ability"
 
 describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
 
-  context 'with authorization' do
+  context "with authorization" do
     stub_authorization!
 
     let(:order) do
       mock_model(
         Spree::Order,
         total:           100,
-        number:          'R123456789',
+        number:          "R123456789",
         billing_address: mock_model(Spree::Address)
       )
     end
@@ -20,8 +20,8 @@ describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
       allow(Spree::Order).to receive_messages(find_by_number!: order)
     end
 
-    context '#update' do
-      it 'does refresh the shipment rates with all shipping methods' do
+    context "#update" do
+      it "does refresh the shipment rates with all shipping methods" do
         allow(order).to receive_messages(update_attributes: true)
         allow(order).to receive_messages(next: false)
         expect(order).to receive(:refresh_shipment_rates)
@@ -29,8 +29,8 @@ describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
         attributes = {
           order_id: order.number,
           order: {
-            email: '',
-            use_billing: '',
+            email: "",
+            use_billing: "",
             bill_address_attributes: {},
             ship_address_attributes: {}
           }

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -99,6 +99,20 @@ describe "Order Details", type: :feature, js: true do
         expect(page).to have_content("Default")
       end
 
+      it "can assign a back-end only shipping method" do
+        create(:shipping_method, name: 'Backdoor', display_on: 'back_end')
+        order = create(:completed_order_with_totals, frontend_only: false)
+        visit spree.edit_admin_order_path(order)
+        within("table.index tr.show-method") do
+          click_icon :edit
+        end
+        select2 "Backdoor", :from => "Shipping Method"
+        click_icon :ok
+
+        expect(page).not_to have_css('#selected_shipping_rate_id')
+        expect(page).to have_content("Backdoor")
+      end
+
       it "will show the variant sku" do
         order = create(:completed_order_with_totals)
         visit spree.edit_admin_order_path(order)
@@ -200,7 +214,7 @@ describe "Order Details", type: :feature, js: true do
           end
         end
       end
-      
+
       context "with special_instructions present" do
         let(:order) { create(:order, :state => 'complete', :completed_at => "2011-02-01 12:36:15", :number => "R100", :special_instructions => "Very special instructions here") }
         it "will show the special_instructions" do
@@ -233,7 +247,7 @@ describe "Order Details", type: :feature, js: true do
   end
 
   context 'with only read permissions' do
-    before do 
+    before do
       allow_any_instance_of(Spree::Admin::BaseController).to receive(:spree_current_user).and_return(nil)
     end
 

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -100,16 +100,16 @@ describe "Order Details", type: :feature, js: true do
       end
 
       it "can assign a back-end only shipping method" do
-        create(:shipping_method, name: 'Backdoor', display_on: 'back_end')
-        order = create(:completed_order_with_totals,
+        create(:shipping_method, name: "Backdoor", display_on: "back_end")
+        order = create(
+          :completed_order_with_totals,
           shipping_method_filter: Spree::ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END
         )
         visit spree.edit_admin_order_path(order)
         within("table.index tr.show-method") do
           click_icon :edit
         end
-        save_and_open_page
-        select2 "Backdoor", :from => "Shipping Method"
+        select2 "Backdoor", from: "Shipping Method"
         click_icon :ok
 
         expect(page).not_to have_css('#selected_shipping_rate_id')

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -101,11 +101,14 @@ describe "Order Details", type: :feature, js: true do
 
       it "can assign a back-end only shipping method" do
         create(:shipping_method, name: 'Backdoor', display_on: 'back_end')
-        order = create(:completed_order_with_totals, frontend_only: false)
+        order = create(:completed_order_with_totals,
+          shipping_method_filter: Spree::ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END
+        )
         visit spree.edit_admin_order_path(order)
         within("table.index tr.show-method") do
           click_icon :edit
         end
+        save_and_open_page
         select2 "Backdoor", :from => "Shipping Method"
         click_icon :ok
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -529,8 +529,8 @@ module Spree
       )
     end
 
-    def refresh_shipment_rates
-      shipments.map &:refresh_rates
+    def refresh_shipment_rates(frontend_only = true)
+      shipments.map { |s| s.refresh_rates(frontend_only) }
     end
 
     def shipping_eq_billing_address?

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -529,8 +529,8 @@ module Spree
       )
     end
 
-    def refresh_shipment_rates(frontend_only = true)
-      shipments.map { |s| s.refresh_rates(frontend_only) }
+    def refresh_shipment_rates(shipping_method_filter = ShippingMethod::DISPLAY_ON_FRONT_END)
+      shipments.map { |s| s.refresh_rates(shipping_method_filter) }
     end
 
     def shipping_eq_billing_address?

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -122,7 +122,8 @@ module Spree
       # StockEstimator.new assigment below will replace the current shipping_method
       original_shipping_method_id = shipping_method.try(:id)
 
-      self.shipping_rates = Stock::Estimator.new(order).shipping_rates(to_package, shipping_method_filter)
+      self.shipping_rates = Stock::Estimator.new(order)
+        .shipping_rates(to_package, shipping_method_filter)
 
       if shipping_method
         selected_rate = shipping_rates.detect { |rate|

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -115,14 +115,14 @@ module Spree
       selected_shipping_rate.try(:tax_rate).try(:tax_category)
     end
 
-    def refresh_rates(frontend_only = true)
+    def refresh_rates(shipping_method_filter = ShippingMethod::DISPLAY_ON_FRONT_END)
       return shipping_rates if shipped?
       return [] unless can_get_rates?
 
       # StockEstimator.new assigment below will replace the current shipping_method
       original_shipping_method_id = shipping_method.try(:id)
 
-      self.shipping_rates = Stock::Estimator.new(order).shipping_rates(to_package, frontend_only)
+      self.shipping_rates = Stock::Estimator.new(order).shipping_rates(to_package, shipping_method_filter)
 
       if shipping_method
         selected_rate = shipping_rates.detect { |rate|

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -122,8 +122,8 @@ module Spree
       # StockEstimator.new assigment below will replace the current shipping_method
       original_shipping_method_id = shipping_method.try(:id)
 
-      self.shipping_rates = Stock::Estimator.new(order)
-        .shipping_rates(to_package, shipping_method_filter)
+      self.shipping_rates = Stock::Estimator.new(order).
+        shipping_rates(to_package, shipping_method_filter)
 
       if shipping_method
         selected_rate = shipping_rates.detect { |rate|

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -115,14 +115,14 @@ module Spree
       selected_shipping_rate.try(:tax_rate).try(:tax_category)
     end
 
-    def refresh_rates
+    def refresh_rates(frontend_only = true)
       return shipping_rates if shipped?
       return [] unless can_get_rates?
 
       # StockEstimator.new assigment below will replace the current shipping_method
       original_shipping_method_id = shipping_method.try(:id)
 
-      self.shipping_rates = Stock::Estimator.new(order).shipping_rates(to_package)
+      self.shipping_rates = Stock::Estimator.new(order).shipping_rates(to_package, frontend_only)
 
       if shipping_method
         selected_rate = shipping_rates.detect { |rate|

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -5,8 +5,9 @@ module Spree
     DISPLAY = [:both, :front_end, :back_end]
 
     # Used for #refresh_rates
+    DISPLAY_ON_FRONT_AND_BACK_END = 0
     DISPLAY_ON_FRONT_END = 1
-    DISPLAY_ON_FRONT_AND_BACK_END = 2
+    DISPLAY_ON_BACK_END = 2
 
     default_scope -> { where(deleted_at: nil) }
 

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -51,10 +51,10 @@ module Spree
       Spree::TaxCategory.unscoped { super }
     end
 
-    def available_to_ui(ui_filter)
-      ui_filter == DISPLAY_ON_FRONT_AND_BACK_END ||
-      (method.frontend? && ui_filter == DISPLAY_ON_FRONT_END) ||
-      (!method.frontend? && ui_filter == DISPLAY_ON_BACK_END)
+    def available_to_display(display_filter)
+      display_filter == DISPLAY_ON_FRONT_AND_BACK_END ||
+      (frontend? && display_filter == DISPLAY_ON_FRONT_END) ||
+      (!frontend? && display_filter == DISPLAY_ON_BACK_END)
     end
 
     private

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -51,6 +51,12 @@ module Spree
       Spree::TaxCategory.unscoped { super }
     end
 
+    def available_to_ui(ui_filter)
+      ui_filter == DISPLAY_ON_FRONT_AND_BACK_END ||
+      (method.frontend? && ui_filter == DISPLAY_ON_FRONT_END) ||
+      (!method.frontend? && ui_filter == DISPLAY_ON_BACK_END)
+    end
+
     private
       def compute_amount(calculable)
         self.calculator.compute(calculable)

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -4,6 +4,10 @@ module Spree
     include Spree::Core::CalculatedAdjustments
     DISPLAY = [:both, :front_end, :back_end]
 
+    # Used for #refresh_rates
+    DISPLAY_ON_FRONT_END = 1
+    DISPLAY_ON_FRONT_AND_BACK_END = 2
+
     default_scope -> { where(deleted_at: nil) }
 
     has_many :shipping_method_categories, :dependent => :destroy

--- a/core/app/models/spree/stock/estimator.rb
+++ b/core/app/models/spree/stock/estimator.rb
@@ -51,9 +51,7 @@ module Spree
         package.shipping_methods.select do |ship_method|
           calculator = ship_method.calculator
           begin
-            (ui_filter == ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END ||
-            (method.frontend? && ui_filter == ShippingMethod::DISPLAY_ON_FRONT_END) ||
-            (!method.frontend? && ui_filter == ShippingMethod::DISPLAY_ON_BACK_END)) &&
+            ship_method.available_to_ui(ui_filter) &&
             ship_method.include?(order.ship_address) &&
             calculator.available?(package) &&
             (calculator.preferences[:currency].blank? ||

--- a/core/app/models/spree/stock/estimator.rb
+++ b/core/app/models/spree/stock/estimator.rb
@@ -9,10 +9,7 @@ module Spree
       end
 
       def shipping_rates(package, shipping_method_filter = ShippingMethod::DISPLAY_ON_FRONT_END)
-        rates = calculate_shipping_rates(package)
-        if shipping_method_filter == ShippingMethod::DISPLAY_ON_FRONT_END
-          rates.select! { |rate| rate.shipping_method.frontend? }
-        end
+        rates = calculate_shipping_rates(package, shipping_method_filter)
         choose_default_shipping_rate(rates)
         sort_shipping_rates(rates)
       end
@@ -28,8 +25,8 @@ module Spree
         shipping_rates.sort_by!(&:cost)
       end
 
-      def calculate_shipping_rates(package)
-        shipping_methods(package).map do |shipping_method|
+      def calculate_shipping_rates(package, ui_filter)
+        shipping_methods(package, ui_filter).map do |shipping_method|
           cost = shipping_method.calculator.compute(package)
           tax_category = shipping_method.tax_category
           if tax_category
@@ -50,10 +47,13 @@ module Spree
         end.compact
       end
 
-      def shipping_methods(package)
+      def shipping_methods(package, ui_filter)
         package.shipping_methods.select do |ship_method|
           calculator = ship_method.calculator
           begin
+            (ui_filter == ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END ||
+            (method.frontend? && ui_filter == ShippingMethod::DISPLAY_ON_FRONT_END) ||
+            (!method.frontend? && ui_filter == ShippingMethod::DISPLAY_ON_BACK_END)) &&
             ship_method.include?(order.ship_address) &&
             calculator.available?(package) &&
             (calculator.preferences[:currency].blank? ||

--- a/core/app/models/spree/stock/estimator.rb
+++ b/core/app/models/spree/stock/estimator.rb
@@ -47,11 +47,11 @@ module Spree
         end.compact
       end
 
-      def shipping_methods(package, ui_filter)
+      def shipping_methods(package, display_filter)
         package.shipping_methods.select do |ship_method|
           calculator = ship_method.calculator
           begin
-            ship_method.available_to_ui(ui_filter) &&
+            ship_method.available_to_display(display_filter) &&
             ship_method.include?(order.ship_address) &&
             calculator.available?(package) &&
             (calculator.preferences[:currency].blank? ||

--- a/core/app/models/spree/stock/estimator.rb
+++ b/core/app/models/spree/stock/estimator.rb
@@ -8,9 +8,11 @@ module Spree
         @currency = order.currency
       end
 
-      def shipping_rates(package, frontend_only = true)
+      def shipping_rates(package, shipping_method_filter = ShippingMethod::DISPLAY_ON_FRONT_END)
         rates = calculate_shipping_rates(package)
-        rates.select! { |rate| rate.shipping_method.frontend? } if frontend_only
+        if shipping_method_filter == ShippingMethod::DISPLAY_ON_FRONT_END
+          rates.select! { |rate| rate.shipping_method.frontend? }
+        end
         choose_default_shipping_rate(rates)
         sort_shipping_rates(rates)
       end

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -18,6 +18,7 @@ FactoryGirl.define do
 
       transient do
         line_items_count 5
+        frontend_only true
       end
 
       after(:create) do |order, evaluator|
@@ -33,8 +34,8 @@ FactoryGirl.define do
       factory :completed_order_with_totals do
         state 'complete'
 
-        after(:create) do |order|
-          order.refresh_shipment_rates
+        after(:create) do |order, evaluator|
+          order.refresh_shipment_rates(evaluator.frontend_only)
           order.update_column(:completed_at, Time.now)
         end
 

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -18,7 +18,7 @@ FactoryGirl.define do
 
       transient do
         line_items_count 5
-        frontend_only true
+        shipping_method_filter Spree::ShippingMethod::DISPLAY_ON_FRONT_END
       end
 
       after(:create) do |order, evaluator|
@@ -35,7 +35,7 @@ FactoryGirl.define do
         state 'complete'
 
         after(:create) do |order, evaluator|
-          order.refresh_shipment_rates(evaluator.frontend_only)
+          order.refresh_shipment_rates(evaluator.shipping_method_filter)
           order.update_column(:completed_at, Time.now)
         end
 

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -117,7 +117,7 @@ module Spree
           before do
             allow(backend_method).to receive_message_chain(:calculator, :compute).and_return(0.00)
             allow(generic_method).to receive_message_chain(:calculator, :compute).and_return(5.00)
-            allow(subject).to receive(:shipping_methods).and_return([backend_method, generic_method])
+            allow(package).to receive(:shipping_methods).and_return([backend_method, generic_method])
           end
 
           it "does not return backend rates at all" do

--- a/core/spec/models/spree/stock_location_spec.rb
+++ b/core/spec/models/spree/stock_location_spec.rb
@@ -201,7 +201,7 @@ module Spree
         subject { create(:stock_location) }
         let(:variant) { create(:base_variant) }
 
-        it 'zero on_hand and backordered', focus: true do
+        it 'zero on_hand and backordered' do
           subject
           variant.stock_items.destroy_all
           on_hand, backordered = subject.fill_status(variant, 1)


### PR DESCRIPTION
Fixes #5755 
