### PR TITLE
Stock locations controller refactor

### DIFF
--- a/backend/app/controllers/spree/admin/stock_locations_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_locations_controller.rb
@@ -6,12 +6,10 @@ module Spree
       private
 
       def set_country
-        begin
-          @stock_location.country = Spree::Country.default
-        rescue ActiveRecord::RecordNotFound
-          flash[:error] = Spree.t(:stock_locations_need_a_default_country)
-          redirect_to admin_stock_locations_path and return
-        end
+        @stock_location.country = Spree::Country.default
+      rescue ActiveRecord::RecordNotFound
+        flash[:error] = Spree.t(:stock_locations_need_a_default_country)
+        redirect_to admin_stock_locations_path and return
       end
     end
   end

--- a/backend/app/controllers/spree/admin/stock_locations_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_locations_controller.rb
@@ -1,25 +1,18 @@
 module Spree
   module Admin
     class StockLocationsController < ResourceController
-
       before_action :set_country, only: :new
 
       private
 
       def set_country
         begin
-          if Spree::Config[:default_country_id].present?
-            @stock_location.country = Spree::Country.find(Spree::Config[:default_country_id])
-          else
-            @stock_location.country = Spree::Country.find_by!(iso: 'US')
-          end
-
+          @stock_location.country = Spree::Country.default
         rescue ActiveRecord::RecordNotFound
           flash[:error] = Spree.t(:stock_locations_need_a_default_country)
           redirect_to admin_stock_locations_path and return
         end
       end
-
     end
   end
 end

--- a/core/app/models/spree/country.rb
+++ b/core/app/models/spree/country.rb
@@ -20,11 +20,7 @@ module Spree
 
     def self.default
       country_id = Spree::Config[:default_country_id]
-      if country_id.present?
-        find(country_id)
-      else
-        find_by!(iso: 'US')
-      end
+      country_id.present? ? find(country_id) : find_by!(iso: 'US')
     end
 
     def <=>(other)

--- a/core/app/models/spree/country.rb
+++ b/core/app/models/spree/country.rb
@@ -20,9 +20,9 @@ module Spree
 
     def self.default
       if Spree::Config[:default_country_id].present?
-        Spree::Country.find(Spree::Config[:default_country_id])
+        self.find(Spree::Config[:default_country_id])
       else
-        Spree::Country.find_by!(iso: 'US')
+        self.find_by!(iso: 'US')
       end
     end
 

--- a/core/app/models/spree/country.rb
+++ b/core/app/models/spree/country.rb
@@ -19,8 +19,9 @@ module Spree
     end
 
     def self.default
-      if Spree::Config[:default_country_id].present?
-        find(Spree::Config[:default_country_id])
+      country_id = Spree::Config[:default_country_id]
+      if country_id.present?
+        find(country_id)
       else
         find_by!(iso: 'US')
       end

--- a/core/app/models/spree/country.rb
+++ b/core/app/models/spree/country.rb
@@ -18,6 +18,14 @@ module Spree
       states_required
     end
 
+    def self.default
+      if Spree::Config[:default_country_id].present?
+        Spree::Country.find(Spree::Config[:default_country_id])
+      else
+        Spree::Country.find_by!(iso: 'US')
+      end
+    end
+
     def <=>(other)
       name <=> other.name
     end

--- a/core/app/models/spree/country.rb
+++ b/core/app/models/spree/country.rb
@@ -20,9 +20,9 @@ module Spree
 
     def self.default
       if Spree::Config[:default_country_id].present?
-        self.find(Spree::Config[:default_country_id])
+        find(Spree::Config[:default_country_id])
       else
-        self.find_by!(iso: 'US')
+        find_by!(iso: 'US')
       end
     end
 

--- a/core/spec/models/spree/country_spec.rb
+++ b/core/spec/models/spree/country_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
-describe Spree::Country, :type => :model do
+describe Spree::Country, type: :model do
   it "can find all countries group by states required" do
-    country_states_required= Spree::Country.create({:name => "Canada", :iso_name => "CAN", :states_required => true})
-    country_states_not_required= Spree::Country.create({:name => "France", :iso_name => "FR", :states_required => false})
+    country_states_required = Spree::Country.create({ name: "Canada", iso_name: "CAN", states_required: true })
+    country_states_not_required = Spree::Country.create({ name: "France", iso_name: "FR", states_required: false })
     states_required = Spree::Country.states_required_by_country_id
     expect(states_required[country_states_required.id.to_s]).to be true
     expect(states_required[country_states_not_required.id.to_s]).to be false

--- a/core/spec/models/spree/country_spec.rb
+++ b/core/spec/models/spree/country_spec.rb
@@ -12,4 +12,19 @@ describe Spree::Country, type: :model do
   it "returns that the states are required for an invalid country" do
     expect(Spree::Country.states_required_by_country_id['i do not exit']).to be true
   end
+
+  describe '.default' do
+    let(:america) { create :country }
+    let(:canada)  { create :country, name: 'Canada' }
+
+    it 'will return the country from the config' do
+      Spree::Config[:default_country_id] = canada.id
+      expect(described_class.default.id).to eql canada.id
+    end
+
+    it 'will return the US if config is not set' do
+      america.touch
+      expect(described_class.default.id).to eql america.id
+    end
+  end
 end


### PR DESCRIPTION
Finding the default country probably shouldn't be in the controller... In this PR I move a lot of the `set_country` functionality out to the country model giving Spree a `Spree::Country#default` method. Will provide a unit test.
