### PR TITLE
Remove unused check on product images

### DIFF
--- a/backend/app/views/spree/admin/images/index.html.erb
+++ b/backend/app/views/spree/admin/images/index.html.erb
@@ -4,7 +4,7 @@
   <%= button_link_to Spree.t(:new_image), new_admin_product_image_url(@product), { class: "btn-success", icon: 'add', id: 'new_image_link' } %>
 <% end %>
 
-<% unless @product.images.any? || @product.variant_images.any? %>
+<% unless @product.variant_images.any? %>
   <div class="alert alert-warning">
     <%= Spree.t(:no_images_found) %>.
   </div>


### PR DESCRIPTION
Only the @product.variant_images are used in the view.

@product.images is just the images on the master variant, which is
included in @product.variant_images
