### PR TITLE
allow for arbitrary promo adjustments to compete

### DIFF
--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -44,6 +44,11 @@ module Spree
     after_create :update_adjustable_adjustment_total
     after_destroy :update_adjustable_adjustment_total
 
+
+    class_attribute :competing_promos_source_types
+
+    self.competing_promos_source_types = ['Spree::PromotionAction']
+
     scope :open, -> { where(state: 'open') }
     scope :closed, -> { where(state: 'closed') }
     scope :tax, -> { where(source_type: 'Spree::TaxRate') }
@@ -62,6 +67,7 @@ module Spree
     scope :return_authorization, -> { where(source_type: "Spree::ReturnAuthorization") }
     scope :included, -> { where(included: true)  }
     scope :additional, -> { where(included: false) }
+    scope :competing_promos, -> { where(source_type: competing_promos_source_types)}
 
     extend DisplayMoney
     money_methods :amount

--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -37,16 +37,52 @@ describe Spree::Adjustment, :type => :model do
       Spree::Adjustment.non_tax.to_a
     end
 
-    let!(:tax_adjustment) { create(:adjustment, order: order, source: create(:tax_rate))                   }
+    let!(:tax_adjustment) { create(:adjustment, order: order, source: create(:tax_rate)) }
     let!(:non_tax_adjustment_with_source) { create(:adjustment, order: order, source_type: 'Spree::Order', source_id: nil) }
-    let!(:non_tax_adjustment_without_source) { create(:adjustment, order: order, source: nil)                                 }
+    let!(:non_tax_adjustment_without_source) { create(:adjustment, order: order, source: nil) }
 
     it 'select non-tax adjustments' do
       expect(subject).to_not include tax_adjustment
-      expect(subject).to     include non_tax_adjustment_with_source
-      expect(subject).to     include non_tax_adjustment_without_source
+      expect(subject).to include non_tax_adjustment_with_source
+      expect(subject).to include non_tax_adjustment_without_source
     end
   end
+
+  describe 'competing_promos scope' do
+    subject do
+      Spree::Adjustment.competing_promos.to_a
+    end
+
+
+    let!(:promotion_adjustment) { create(:adjustment, order: order, source_type: 'Spree::PromotionAction', source_id: nil) }
+    let!(:custom_adjustment_with_source) { create(:adjustment, order: order, source_type: 'Custom', source_id: nil) }
+    let!(:non_promotion_adjustment_with_source) { create(:adjustment, order: order, source_type: 'Spree::Order', source_id: nil) }
+    let!(:non_promotion_adjustment_without_source) { create(:adjustment, order: order, source: nil) }
+
+
+    context 'no custom source_types have been added to competing_promos' do
+      before { Spree::Adjustment.competing_promos_source_types = ['Spree::PromotionAction'] }
+
+      it 'selects promotion adjustments by default' do
+        expect(subject).to include promotion_adjustment
+        expect(subject).to_not include custom_adjustment_with_source
+        expect(subject).to_not include non_promotion_adjustment_with_source
+        expect(subject).to_not include non_promotion_adjustment_without_source
+      end
+    end
+
+    context 'a custom source_type has been added to competing_promos' do
+      before { Spree::Adjustment.competing_promos_source_types = ['Spree::PromotionAction', 'Custom'] }
+
+      it 'selects adjustments with registered source_types' do
+        expect(subject).to include promotion_adjustment
+        expect(subject).to include custom_adjustment_with_source
+        expect(subject).to_not include non_promotion_adjustment_with_source
+        expect(subject).to_not include non_promotion_adjustment_without_source
+      end
+    end
+  end
+
 
   context "adjustment state" do
     let(:adjustment) { create(:adjustment, order: order, state: 'open') }


### PR DESCRIPTION
This is in favor of #5729, and includes specs and has been updated to refactored AdjustmentUpdater.

This allows for arbitrary adjustment types to compete for the best_promo_adjustment spot by registering with the Spree::Adjustment.competing_promos_source_types attribute.

I changed the `best_promotion_adjustment` method name to `best_promo_adjustment` to make it more clear that we are looking for the best promo, which includes but isn't limited to the "Promotion" adjustments (in the Spree::Promotion sense). 

I almost think changing everywhere the term 'promo' is used to 'discount' would make some subtleties clearer and the language more general. For instance, the promo_total isn't necessarily the same as the best Promotion, it is just the best discount, no matter where it originated; changing it discount_total would make this more obvious. I feel like it would make adjustment_updater also feel more general case; every store has a concept of taxes and discounts, whereas a "promotion" is a specific type of discount.

I would love feedback on the approach here, as well as the specs.
