### PR TITLE
Fix issue on checkouts controller.

### DIFF
--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -57,7 +57,7 @@ module Spree
     def insufficient_payment?
       params[:state] == "confirm" &&
         @order.payment_required? &&
-        @order.payments.valid.sum(:amount) != @order.amount
+        @order.payments.valid.sum(:amount) != @order.total
     end
 
     def correct_state


### PR DESCRIPTION
This is a bug which occurs preventing orders from moving past the
payment state when promotions, or other adjustments are applied to the
order.

order.total is the amount to be paid, order.amount is the total of the
line items.

This issue was introduced in #5754
