### PR TITLE
Remove named parameter for jruby compatibility

### DIFF
--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -44,19 +44,19 @@ module Spree
       end
 
       # Single main menu item
-      def main_menu_item text, url: nil, icon: nil
+      def main_menu_item(text, url, icon)
         link_to url do
           content_tag(:span, nil, class: "icon icon-#{icon}") +
-          content_tag(:span, " #{text}") +
-          content_tag(:span, nil, class: "icon icon-chevron-left pull-right")
+            content_tag(:span, " #{text}") +
+            content_tag(:span, nil, class: "icon icon-chevron-left pull-right")
         end
       end
 
       # Main menu tree menu
-      def main_menu_tree text, icon: nil, sub_menu: nil
+      def main_menu_tree(text, icon, sub_menu)
         content_tag :li, class: "treeview" do
-          main_menu_item(text, url: "javascript:;", icon: icon) +
-          render(partial: "spree/admin/shared/sub_menu/#{sub_menu}")
+          main_menu_item(text, "javascript:;", icon) +
+            render(partial: "spree/admin/shared/sub_menu/#{sub_menu}")
         end
       end
 

--- a/backend/app/views/spree/admin/shared/_main_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_main_menu.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% if can? :admin, Spree::Product %>
-  <%= main_menu_tree Spree.t(:products), icon: "products", sub_menu: "product" %>
+  <%= main_menu_tree Spree.t(:products), "products", "product" %>
 <% end %>
 
 <% if can? :admin, Spree::Admin::ReportsController %>
@@ -11,7 +11,7 @@
 <% end %>
 
 <% if can? :admin, Spree::Promotion %>
-  <%= main_menu_tree Spree.t(:promotions), icon: "promotion", sub_menu: "promotion" %>
+  <%= main_menu_tree Spree.t(:promotions), "promotion", "promotion" %>
 <% end %>
 
 <% if Spree.user_class && can?(:admin, Spree.user_class) %>
@@ -19,5 +19,5 @@
 <% end %>
 
 <% if can? :admin, current_store %>
-  <%= main_menu_tree Spree.t(:configurations), icon: "wrench", sub_menu: "configuration" %>
+  <%= main_menu_tree Spree.t(:configurations), "wrench", "configuration" %>
 <% end %>


### PR DESCRIPTION
With this fix, spree can be run on jruby
