### PR TITLE
Remove n+1 lookup values on stock item exist SQL call

### DIFF
--- a/core/app/models/spree/stock/coordinator.rb
+++ b/core/app/models/spree/stock/coordinator.rb
@@ -31,7 +31,7 @@ module Spree
       # Returns an array of Package instances
       def build_packages(packages = Array.new)
         StockLocation.active.each do |stock_location|
-          next unless stock_location.stock_items.where(:variant_id => inventory_units.map(&:variant_id)).exists?
+          next unless stock_location.stock_items.where(:variant_id => inventory_units.map(&:variant_id).uniq).exists?
 
           packer = build_packer(stock_location, inventory_units)
           packages += packer.packages


### PR DESCRIPTION
Fixes:

``` sql
Spree::StockItem Exists (4.7ms)  SELECT  1 AS one FROM "spree_stock_items"  WHERE 
"spree_stock_items"."deleted_at" IS NULL AND "spree_stock_items"."stock_location_id" = $1 AND 
"spree_stock_items"."variant_id" IN (1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
1, 1, 1, 1, 1, 1, 1, 1, 1, .... 
```
