### PR TITLE
Fix N+1 on Shipment#to_package call to variant from Differentiator

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -272,7 +272,7 @@ module Spree
 
     def to_package
       package = Stock::Package.new(stock_location)
-      inventory_units.group_by(&:state).each do |state, state_inventory_units|
+      inventory_units.includes(:variant).joins(:variant).group_by(&:state).each do |state, state_inventory_units|
         package.add_multiple state_inventory_units, state.to_sym
       end
       package

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -205,8 +205,12 @@ describe Spree::Shipment, :type => :model do
            build(:inventory_unit, line_item: line_item, variant: variant, state: 'backordered')]
         end
 
-        it 'should use symbols for states when adding contents to package' do
+        before do
           allow(shipment).to receive(:inventory_units) { inventory_units }
+          allow(inventory_units).to receive_message_chain(:includes, :joins).and_return inventory_units
+        end
+
+        it 'should use symbols for states when adding contents to package' do
           package = shipment.to_package
           expect(package.on_hand.count).to eq 1
           expect(package.backordered.count).to eq 1


### PR DESCRIPTION
On checkout/delivery page, a page refresh calls out to the
`Stock::Differentiator`, which loads a variant from each `inventory_unit`

The fix eliminates N+1 sql select for each variant.

Ex:

``` sql
  CACHE (0.0ms)  SELECT  "spree_variants".* FROM "spree_variants"  WHERE "spree_variants"."id" = $1 LIMIT 1  [["id", 1]]
  CACHE (0.0ms)  SELECT  "spree_variants".* FROM "spree_variants"  WHERE "spree_variants"."id" = $1 LIMIT 1  [["id", 1]]
  CACHE (0.0ms)  SELECT  "spree_variants".* FROM "spree_variants"  WHERE "spree_variants"."id" = $1 LIMIT 1  [["id", 1]]
```
