### PR TITLE
Improve store performance for orders with total quantity > 1000

### DIFF
--- a/core/app/models/spree/stock/content_item.rb
+++ b/core/app/models/spree/stock/content_item.rb
@@ -36,6 +36,17 @@ module Spree
         price * quantity
       end
 
+      def hash
+        # XOR operation to get a unique combo hash
+        inventory_unit.hash ^ state.hash
+      end
+
+      def eql?(other)
+        other.class == self.class &&
+          other.inventory_unit == inventory_unit &&
+          (!other.state || other.state == state)
+      end
+
       def quantity
         # Since inventory units don't have a quantity,
         # make this always 1 for now, leaving ourselves

--- a/core/app/models/spree/stock/package.rb
+++ b/core/app/models/spree/stock/package.rb
@@ -4,14 +4,14 @@ module Spree
       attr_reader :stock_location, :contents
       attr_accessor :shipping_rates
 
-      def initialize(stock_location, contents=[])
+      def initialize(stock_location, contents = nil)
         @stock_location = stock_location
-        @contents = contents
+        @contents = contents || Set.new
         @shipping_rates = Array.new
       end
 
       def add(inventory_unit, state = :on_hand)
-        contents << ContentItem.new(inventory_unit, state) unless find_item(inventory_unit)
+        contents << ContentItem.new(inventory_unit, state)
       end
 
       def add_multiple(inventory_units, state = :on_hand)

--- a/core/app/models/spree/stock/splitter/weight.rb
+++ b/core/app/models/spree/stock/splitter/weight.rb
@@ -21,7 +21,9 @@ module Spree
           removed = []
           while package.weight > self.threshold
             break if package.contents.size == 1
-            removed << package.contents.shift
+            item_to_remove = package.contents.first
+            package.contents.delete(item_to_remove)
+            removed << item_to_remove
           end
           removed
         end


### PR DESCRIPTION
by refactoring Package#add

Before the change => `Package#contents` was an array, and finding content items using `detect` was very costly as per the performance measurements below.

After the change => `Package#contents` is a Set. A set contains only unique items by definition. To properly allow Ruby to compare the `content items` in the set, the #hash and the #eql? methods have to be defined on the `Content Item` class as per this example in the  [Ruby Docs](http://www.ruby-doc.org/core-2.1.5/Hash.html#class-Hash-label-Hash+Keys)

partially contributes to the fix of #5706

``` ruby


# Spree 3.0 latest

                           user     system      total        real
1000 Inventory Units:  3.490000   0.060000   3.550000 (  3.732619)
2000 Inventory Units: 10.760000   0.120000  10.880000 ( 11.182196)
3000 Inventory Units: 23.590000   0.210000  23.800000 ( 24.274458)

# commenting out Spree::Stock::Package#add -> #unless find_item(inventory_unit)
# (no comparison is performed)
                           user     system      total        real
1000 Inventory Units:  1.910000   0.070000   1.980000 (  2.165775)
2000 Inventory Units:  3.460000   0.130000   3.590000 (  3.921917)
3000 Inventory Units:  5.400000   0.180000   5.580000 (  6.061517)


# After converting Package.contents to a Set from Array
                           user     system      total        real
1000 Inventory Units:  2.100000   0.070000   2.170000 (  2.376794)
2000 Inventory Units:  3.700000   0.140000   3.840000 (  4.187232)
3000 Inventory Units:  5.620000   0.200000   5.820000 (  6.382836)

```

---

After the change, `#find_item` is only used by `#remove`. Please advise if `#remove` should also receive a better implementation.

Feedback is appreciated!
