### PR TITLE
More icons [backend].

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_icons.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_icons.scss
@@ -1,37 +1,251 @@
-// The less opiniated icons
-.icon {                 @extend .glyphicon }
-.icon-add {             @extend .glyphicon-plus }
-.icon-cog {             @extend .glyphicon-cog }
-.icon-edit {            @extend .glyphicon-pencil }
-.icon-capture {         @extend .glyphicon-ok }
-.icon-void {            @extend .glyphicon-remove }
-.icon-shopping-cart {   @extend .glyphicon-shopping-cart }
-.icon-file {            @extend .glyphicon-file }
-.icon-promotion {       @extend .glyphicon-bullhorn }
-.icon-user {            @extend .glyphicon-user }
-.icon-wrench {          @extend .glyphicon-wrench }
-.icon-credit-card {     @extend .glyphicon-credit-card }
-.icon-return {          @extend .glyphicon-share }
-.icon-shipment {        @extend .glyphicon-send }
-.icon-arrow-left {      @extend .glyphicon-arrow-left }
-.icon-arrow-right {     @extend .glyphicon-arrow-right }
-.icon-clone {           @extend .glyphicon-share }
-.icon-update {          @extend .glyphicon-refresh }
-.icon-cancel {          @extend .glyphicon-remove }
-.icon-split {           @extend .glyphicon-resize-full }
-.icon-save {            @extend .glyphicon-ok }
-.icon-show {            @extend .glyphicon-eye-open }
-.icon-delete {          @extend .glyphicon-remove }
-.icon-refund {          @extend .glyphicon-minus }
-.icon-move {            @extend .glyphicon-move }
-.icon-thumbs-up {       @extend .glyphicon-thumbs-up }
-.icon-thumbs-down {     @extend .glyphicon-thumbs-down }
-.icon-chevron-up {      @extend .glyphicon-chevron-up }
-.icon-chevron-down {    @extend .glyphicon-chevron-down }
-.icon-chevron-left {    @extend .glyphicon-chevron-left }
-.icon-chevron-right {   @extend .glyphicon-chevron-right }
-.icon-products {        @extend .glyphicon-th-large }
-.icon-variants {        @extend .glyphicon-th-large }
-.icon-images {          @extend .glyphicon-picture }
-.icon-properties {      @extend .glyphicon-tag }
-.icon-stock {           @extend .glyphicon-inbox }
+// Maps Glyphicons to Spree .icon prefix.
+// You can apply same pattern to extend with more icons.
+//
+// example:
+// glyphicon glyphicon-pencil => icon icon-edit
+//
+
+// All Glyphicons Halflings in Bootstrap v3.3.1.0
+$default_icons: (
+  adjust
+  align-center
+  align-justify
+  align-left
+  align-right
+  arrow-down
+  arrow-left
+  arrow-right
+  arrow-up
+  asterisk
+  backward
+  ban-circle
+  barcode
+  bell
+  bold
+  book
+  bookmark
+  briefcase
+  bullhorn
+  calendar
+  camera
+  certificate
+  check
+  chevron-down
+  chevron-left
+  chevron-right
+  chevron-up
+  circle-arrow-down
+  circle-arrow-left
+  circle-arrow-right
+  circle-arrow-up
+  cloud
+  cloud-download
+  cloud-upload
+  cog
+  collapse-down
+  collapse-up
+  comment
+  compressed
+  copyright-mark
+  credit-card
+  cutlery
+  dashboard
+  download
+  download-alt
+  earphone
+  eject
+  envelope
+  euro
+  exclamation-sign
+  expand
+  export
+  eye-close
+  eye-open
+  facetime-video
+  fast-backward
+  fast-forward
+  file
+  film
+  filter
+  fire
+  flag
+  flash
+  floppy-disk
+  floppy-open
+  floppy-remove
+  floppy-save
+  floppy-saved
+  folder-close
+  folder-open
+  font
+  forward
+  fullscreen
+  gbp
+  gift
+  glass
+  globe
+  hand-down
+  hand-left
+  hand-right
+  hand-up
+  hd-video
+  hdd
+  header
+  headphones
+  heart
+  heart-empty
+  home
+  import
+  inbox
+  indent-left
+  indent-right
+  info-sign
+  italic
+  leaf
+  link
+  list
+  list-alt
+  lock
+  log-in
+  log-out
+  magnet
+  map-marker
+  minus
+  minus-sign
+  move
+  music
+  new-window
+  off
+  ok
+  ok-circle
+  ok-sign
+  open
+  paperclip
+  pause
+  pencil
+  phone
+  phone-alt
+  picture
+  plane
+  play
+  play-circle
+  plus
+  plus-sign
+  print
+  pushpin
+  qrcode
+  question-sign
+  random
+  record
+  refresh
+  registration-mark
+  remove
+  remove-circle
+  remove-sign
+  repeat
+  resize-full
+  resize-horizontal
+  resize-small
+  resize-vertical
+  retweet
+  road
+  saved
+  screenshot
+  sd-video
+  search
+  send
+  share
+  share-alt
+  shopping-cart
+  signal
+  sort
+  sort-by-alphabet
+  sort-by-alphabet-alt
+  sort-by-attributes
+  sort-by-attributes-alt
+  sort-by-order
+  sort-by-order-alt
+  sound-5-1
+  sound-6-1
+  sound-7-1
+  sound-dolby
+  sound-stereo
+  star
+  star-empty
+  stats
+  step-backward
+  step-forward
+  stop
+  subtitles
+  tag
+  tags
+  tasks
+  text-height
+  text-width
+  th
+  th-large
+  th-list
+  thumbs-down
+  thumbs-up
+  time
+  tint
+  tower
+  transfer
+  trash
+  tree-conifer
+  tree-deciduous
+  unchecked
+  upload
+  usd
+  user
+  volume-down
+  volume-off
+  volume-up
+  warning-sign
+  wrench
+  zoom-in
+  zoom-out
+);
+
+// We prefer alias/remap these so its easy to understand which icon to use.
+// Note: If desired alias exist as default, then remove it from default Array,
+//       or write a smarter @each scope below that can actually override.
+// ==========> default | alias
+$alias_icons: (plus add)
+              (pencil edit)
+              (ok capture)
+              (remove void)
+              (bullhorn promotion)
+              (share return)
+              (send shipment)
+              (share clone)
+              (refresh update)
+              (remove cancel)
+              (resize-full split)
+              (ok save)
+              (eye-open show)
+              (remove delete)
+              (minus refund)
+              (th-large products)
+              (th-large variants)
+              (picture images)
+              (tag properties)
+              (inbox stock)
+              (usd money)
+              (globe translate);
+
+.icon {
+  @extend .glyphicon;
+
+  // Map defaults.
+  @each $icon in $default_icons {
+    &.icon-#{$icon} { @extend .glyphicon-#{$icon}; }
+  }
+
+  // Map and override with aliases.
+  @each $map in $alias_icons {
+    $icon:  nth($map, 1);
+    $alias: nth($map, 2);
+    &.icon-#{$alias} { @extend .glyphicon-#{$icon}; }
+  }
+}


### PR DESCRIPTION
This adds all Glyphicons Halflings that ships with Bootstrap v3.3.1.0. It also provides a more declarative way how to extend and map icons so custom icons can be used.

This also solves issue #5742 and skip need to change `link_to_with_icon` helper that is actually only one method that use custom icon namespace. Now all icons can be set from CSS and extended if other icons desired (like in many extensions).

Add 2 new aliases: 
- `money` using dollar/usd sign (should we not use Yuan? its the no1 economy today ;)).
- `translate` using globe (flag already default, but it looks more like a "way-point").
