### PR TITLE
Relaxing acts_as_list dependency.

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
 
   s.add_dependency 'activemerchant', '~> 1.44.1'
-  s.add_dependency 'acts_as_list', '= 0.3.0'
+  s.add_dependency 'acts_as_list', '~> 0.3'
   s.add_dependency 'awesome_nested_set', '~> 3.0.1'
   s.add_dependency 'carmen', '~> 1.0.0'
   s.add_dependency 'cancancan', '~> 1.9.2'


### PR DESCRIPTION
0.5.0 is currently the latest, and I've run spree_core tests against 0.4.0 and 0.5.0 for both 2-4-stable and master. Figure it's fine to relax this (rather than insisting on a specific version, unless there was a reason for doing that in the first place?).
