### PR TITLE
Fixes right admin sidebar text distortion.

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/spree_admin.css.scss
+++ b/backend/app/assets/stylesheets/spree/backend/spree_admin.css.scss
@@ -253,9 +253,16 @@ ul {
   border-left: 1px solid $color-border;
   ul.nav {
     margin-top: 63px;
-    li .icon-link span.icon {
-      float: left;
-      margin: 2px 6px 0 0;
+    li {
+      a {
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+      }
+      .icon-link span.icon {
+        float: left;
+        margin: 2px 6px 0 0;
+      }
     }
     &.nav-stacked > li {
       height: 42px !important;


### PR DESCRIPTION
Right admin sidebar has a fixed with of 170px, when adding elements to this the text get distorted in many cases. English translations are normally short while most other translations have much longer words. _Title for tooltip should normally be set to display the full word._

Before:
![screen shot 2014-12-15 at 16 09 52](https://cloud.githubusercontent.com/assets/66969/5437982/e93f6588-8474-11e4-8c38-317e123c312a.png)

After:
![screen shot 2014-12-15 at 16 11 49](https://cloud.githubusercontent.com/assets/66969/5437998/1c4ea754-8475-11e4-88e8-b01566fbcde1.png)
