### PR TITLE
ThreadLocal the Current API User

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -16,6 +16,7 @@ module Spree
       before_action :load_user
       before_action :authorize_for_order, if: Proc.new { order_token.present? }
       before_action :authenticate_user
+      before_action :thread_localize_user
       before_action :load_user_roles
 
       after_filter  :set_jsonp_format
@@ -80,6 +81,12 @@ module Spree
             # An anonymous user
             @current_api_user = Spree.user_class.new
           end
+        end
+      end
+
+      def thread_localize_user
+        if @current_api_user
+          Thread.current[:current_api_user] = @current_api_user
         end
       end
 

--- a/api/spec/controllers/spree/api/base_controller_spec.rb
+++ b/api/spec/controllers/spree/api/base_controller_spec.rb
@@ -12,8 +12,9 @@ describe Spree::Api::BaseController, :type => :controller do
   end
 
   context "signed in as a user using an authentication extension" do
+    let(:user) { double(email: "spree@example.com") }
+
     before do
-      user = double(:email => "spree@example.com")
       allow(user).to receive_message_chain :spree_roles, pluck: []
       allow(controller).to receive_messages :try_spree_current_user => user
     end
@@ -22,6 +23,11 @@ describe Spree::Api::BaseController, :type => :controller do
       api_get :index
       expect(json_response).to eq({ "products" => [] })
       expect(response.status).to eq(200)
+    end
+
+    it 'thread localizes the current_api_user' do
+      api_get :index
+      expect(Thread.current[:current_api_user]).to eq(user)
     end
   end
 


### PR DESCRIPTION
This PR places the `current_api_user` into Thread Local storage to potentially use throughout Spree. I understand general pros/cons of leveraging ThreadLocal and this PR is intended to be a  "dig your own grave" kinda thing, where it's there if you need it but to be used judiciously.

In this particular case, I need to understand which API user is making a POST /api/shipments call at the calculator level. If it is our 3PL, the calculator needs to change the prices from what an Admin or End User sees. I've thought about this a bunch of a different ways, i.e. making the 3Pl place an adjustment, trying to determine via the Order and Shipment States, Creating a 3PL Only Shipment With 3PL Calculator but these all encountered issues and for now, I'd like to have the option of adjusting the calculator's computation based on the current_api_user. Rather than change every single method signature to make this happen, `Thread.current[:current_api_user]` seems to be the smallest impact change possible, with the risk that the calculator's behavior is more opaque with how it works, per the general tradeoffs of a ThreadLocal pattern.
