### PR TITLE
Improve default return eligibility rules

### DIFF
--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -51,8 +51,8 @@ module Spree
     before_save :set_exchange_pre_tax_amount
 
     state_machine :reception_status, initial: :awaiting do
-      before_transition to: :received, do: :process_inventory_unit!
       after_transition to: :received, do: :attempt_accept
+      after_transition to: :received, do: :process_inventory_unit!
 
       event :receive do
         transition to: :received, from: :awaiting

--- a/core/app/models/spree/return_item/eligibility_validator/default.rb
+++ b/core/app/models/spree/return_item/eligibility_validator/default.rb
@@ -4,6 +4,8 @@ module Spree
     self.permitted_eligibility_validators = [
                                               ReturnItem::EligibilityValidator::TimeSincePurchase,
                                               ReturnItem::EligibilityValidator::RMARequired,
+                                              ReturnItem::EligibilityValidator::InventoryShipped,
+                                              ReturnItem::EligibilityValidator::NoReimbursements,
                                             ]
 
     def eligible_for_return?

--- a/core/app/models/spree/return_item/eligibility_validator/inventory_shipped.rb
+++ b/core/app/models/spree/return_item/eligibility_validator/inventory_shipped.rb
@@ -1,0 +1,16 @@
+module Spree
+  class ReturnItem::EligibilityValidator::InventoryShipped < Spree::ReturnItem::EligibilityValidator::BaseValidator
+    def eligible_for_return?
+      if @return_item.inventory_unit.shipped?
+        return true
+      else
+        add_error(:inventory_unit_shipped, Spree.t('return_item_inventory_unit_ineligible'))
+        return false
+      end
+    end
+
+    def requires_manual_intervention?
+      @errors.present?
+    end
+  end
+end

--- a/core/app/models/spree/return_item/eligibility_validator/no_reimbursements.rb
+++ b/core/app/models/spree/return_item/eligibility_validator/no_reimbursements.rb
@@ -1,0 +1,16 @@
+module Spree
+  class ReturnItem::EligibilityValidator::NoReimbursements < Spree::ReturnItem::EligibilityValidator::BaseValidator
+    def eligible_for_return?
+      if Spree::ReturnItem.where(inventory_unit: @return_item.inventory_unit).where.not(reimbursement_id: nil).any?
+        add_error(:inventory_unit_reimbursed, Spree.t('return_item_inventory_unit_reimbursed'))
+        return false
+      else
+        return true
+      end
+    end
+
+    def requires_manual_intervention?
+      @errors.present?
+    end
+  end
+end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1169,6 +1169,8 @@ en:
     return_authorization_reasons: Return Authorization Reasons
     return_authorization_updated: Return authorization updated
     return_authorizations: Return Authorizations
+    return_item_inventory_unit_ineligible: Return item's inventory unit must be shipped
+    return_item_inventory_unit_reimbursed: Return item's inventory unit is already reimbursed
     return_item_rma_ineligible: Return item requires an RMA
     return_item_time_period_ineligible: Return item is outside the eligible time period
     return_items: Return Items

--- a/core/spec/models/spree/return_item/eligibility_validator/inventory_shipped_spec.rb
+++ b/core/spec/models/spree/return_item/eligibility_validator/inventory_shipped_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+describe Spree::ReturnItem::EligibilityValidator::InventoryShipped do
+  let(:return_item) { create(:return_item) }
+  let(:validator)   { Spree::ReturnItem::EligibilityValidator::InventoryShipped.new(return_item) }
+
+  describe "#eligible_for_return?" do
+    before { return_item.inventory_unit.stub(:shipped?).and_return(true) }
+
+    subject { validator.eligible_for_return? }
+
+    context "the associated inventory unit is shipped" do
+      it "returns true" do
+        expect(subject).to eq true
+      end
+    end
+
+    context "the associated inventory unit is not shipped" do
+      before { return_item.inventory_unit.stub(:shipped?).and_return(false) }
+
+      it "returns false" do
+        expect(subject).to eq false
+      end
+
+      it "sets an error" do
+        subject
+        expect(validator.errors[:inventory_unit_shipped]).to eq Spree.t('return_item_inventory_unit_ineligible')
+      end
+    end
+  end
+
+  describe "#requires_manual_intervention?" do
+    subject { validator.requires_manual_intervention? }
+
+    context "not eligible for return" do
+      before do
+        return_item.inventory_unit.stub(:shipped?).and_return(false)
+        validator.eligible_for_return?
+      end
+
+      it 'returns true if errors were added' do
+        subject.should eq true
+      end
+    end
+
+    context "eligible for return" do
+      before do
+        return_item.inventory_unit.stub(:shipped?).and_return(true)
+        validator.eligible_for_return?
+      end
+
+      it 'returns false if no errors were added' do
+        subject.should eq false
+      end
+    end
+
+  end
+end

--- a/core/spec/models/spree/return_item/eligibility_validator/no_reimbursements_spec.rb
+++ b/core/spec/models/spree/return_item/eligibility_validator/no_reimbursements_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe Spree::ReturnItem::EligibilityValidator::NoReimbursements do
+  let(:validator) { Spree::ReturnItem::EligibilityValidator::NoReimbursements.new(return_item) }
+
+  describe "#eligible_for_return?" do
+
+    subject { validator.eligible_for_return? }
+
+    context "inventory unit has already been reimbursed" do
+      let(:reimbursement) { create(:reimbursement) }
+      let(:return_item)   { reimbursement.return_items.last }
+
+      it "returns false" do
+        expect(subject).to eq false
+      end
+
+      it "sets an error" do
+        subject
+        expect(validator.errors[:inventory_unit_reimbursed]).to eq Spree.t('return_item_inventory_unit_reimbursed')
+      end
+    end
+
+    context "inventory unit has not been reimbursed" do
+      let(:return_item) { create(:return_item) }
+
+      it "returns true" do
+        expect(subject).to eq true
+      end
+    end
+  end
+
+  describe "#requires_manual_intervention?" do
+    subject { validator.requires_manual_intervention? }
+
+    context "not eligible for return" do
+      let(:reimbursement) { create(:reimbursement) }
+      let(:return_item)   { reimbursement.return_items.last }
+
+      before do
+        validator.eligible_for_return?
+      end
+
+      it 'returns true if errors were added' do
+        subject.should eq true
+      end
+    end
+
+    context "eligible for return" do
+      let(:return_item) { create(:return_item) }
+
+      before do
+        validator.eligible_for_return?
+      end
+
+      it 'returns false if no errors were added' do
+        subject.should eq false
+      end
+    end
+  end
+end


### PR DESCRIPTION
Verifies that a return item’s inventory unit is in a shipped state and that there are no other reimbursements already associated with the inventory unit.

`process_inventory_unit!` is now called after calling `attempt_accept` as we wouldn’t want to process the inventory unit if it’s not accepted.
