### PR TITLE
Validate return item’s exchange variant eligibility

### DIFF
--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -20,6 +20,7 @@ module Spree
     belongs_to :preferred_reimbursement_type, class_name: 'Spree::ReimbursementType'
     belongs_to :override_reimbursement_type, class_name: 'Spree::ReimbursementType'
 
+    validate :eligible_exchange_variant
     validate :belongs_to_same_customer_order
     validate :validate_acceptance_status_for_reimbursement
     validates :inventory_unit, presence: true
@@ -178,6 +179,13 @@ module Spree
 
       if customer_return.order_id != inventory_unit.order_id
         errors.add(:base, Spree.t(:return_items_cannot_be_associated_with_multiple_orders))
+      end
+    end
+
+    def eligible_exchange_variant
+      return unless exchange_variant && exchange_variant_id_changed?
+      unless eligible_exchange_variants.include?(exchange_variant)
+        errors.add(:base, Spree.t(:invalid_exchange_variant))
       end
     end
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -785,6 +785,7 @@ en:
     intercept_email_instructions: Override email recipient and replace with this address.
     internal_name: Internal Name
     invalid_credit_card: Invalid credit card.
+    invalid_exchange_variant: Invalid exchange variant.
     invalid_payment_provider: Invalid payment provider.
     invalid_promotion_action: Invalid promotion action.
     invalid_promotion_rule: Invalid promotion rule.

--- a/core/lib/spree/testing_support/factories/return_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/return_item_factory.rb
@@ -4,7 +4,11 @@ FactoryGirl.define do
     association(:return_authorization, factory: :return_authorization)
 
     factory :exchange_return_item do
-      association(:exchange_variant, factory: :variant)
+      after(:build) do |return_item|
+        # set track_inventory to false to ensure it passes the in_stock check
+        return_item.inventory_unit.variant.update_column(:track_inventory, false)
+        return_item.exchange_variant = return_item.inventory_unit.variant
+      end
     end
   end
 end

--- a/core/spec/models/spree/return_item_spec.rb
+++ b/core/spec/models/spree/return_item_spec.rb
@@ -464,7 +464,11 @@ describe Spree::ReturnItem, :type => :model do
     let(:return_item) { build(:return_item) }
 
     context "the return item is intended to be exchanged" do
-      before { return_item.exchange_variant = build(:variant) }
+      before do
+        return_item.inventory_unit.variant.update_column(:track_inventory, false)
+        return_item.exchange_variant = return_item.inventory_unit.variant
+      end
+
       it do
         return_item.pre_tax_amount = 5.0
         return_item.save!
@@ -575,6 +579,80 @@ describe Spree::ReturnItem, :type => :model do
       it 'is invalid' do
         expect(subject).to_not be_valid
         expect(subject.errors.to_a).to eq ["Inventory unit #{subject.inventory_unit_id} has already been taken by return item #{old_return_item.id}"]
+      end
+    end
+  end
+
+  describe "valid exchange variant" do
+    subject { return_item }
+
+    before  { subject.save }
+
+    context "return item doesn't have an exchange variant" do
+      let(:return_item) { create(:return_item) }
+
+      it "is valid" do
+        expect(subject).to be_valid
+      end
+    end
+
+    context "return item has an exchange variant" do
+      let(:return_item)      { create(:exchange_return_item) }
+      let(:exchange_variant) { create(:on_demand_variant, product: return_item.inventory_unit.variant.product) }
+
+      context "the exchange variant is eligible" do
+        before { return_item.exchange_variant = exchange_variant }
+
+        it "is valid" do
+          expect(subject).to be_valid
+        end
+      end
+
+      context "the exchange variant is not eligible" do
+        context "new return item" do
+          let(:return_item)      { build(:return_item) }
+          let(:exchange_variant) { create(:variant, product: return_item.inventory_unit.variant.product) }
+
+          before { return_item.exchange_variant = exchange_variant }
+
+          it "is invalid" do
+            expect(subject).to_not be_valid
+          end
+
+          it "adds an error message about the invalid exchange variant" do
+            subject.valid?
+            expect(subject.errors.to_a).to eq ["Invalid exchange variant."]
+          end
+        end
+
+        context "the exchange variant has been updated" do
+          before do
+            other_variant = create(:variant)
+            return_item.exchange_variant_id = other_variant.id
+            subject.valid?
+          end
+
+          it "is invalid" do
+            expect(subject).to_not be_valid
+          end
+
+          it "adds an error message about the invalid exchange variant" do
+            expect(subject.errors.to_a).to eq ["Invalid exchange variant."]
+          end
+        end
+
+        context "the exchange variant has not been updated" do
+          before do
+            other_variant = create(:variant)
+            return_item.update_column(:exchange_variant_id, other_variant.id)
+            return_item.reload
+            subject.valid?
+          end
+
+          it "is valid" do
+            expect(subject).to be_valid
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Add a model level validation that checks whether a return item’s exchange variant is eligible for exchange. The validation will be performed when an exchange variant is present and the exchange variant has changed (including on creation).
