### PR TITLE
Allow customer created return authorizations through the API

### DIFF
--- a/api/app/controllers/spree/api/return_authorizations_controller.rb
+++ b/api/app/controllers/spree/api/return_authorizations_controller.rb
@@ -3,8 +3,8 @@ module Spree
     class ReturnAuthorizationsController < Spree::Api::BaseController
 
       def create
-        authorize! :create, ReturnAuthorization
         @return_authorization = order.return_authorizations.build(return_authorization_params)
+        authorize! :create, @return_authorization
         if @return_authorization.save
           respond_with(@return_authorization, status: 201, default_template: :show)
         else

--- a/api/spec/controllers/spree/api/return_authorizations_controller_spec.rb
+++ b/api/spec/controllers/spree/api/return_authorizations_controller_spec.rb
@@ -14,6 +14,20 @@ module Spree
       stub_authentication!
     end
 
+    shared_examples_for 'a return authorization creator' do
+      it "can create a new return authorization" do
+        stock_location = FactoryGirl.create(:stock_location)
+        reason = FactoryGirl.create(:return_authorization_reason)
+        rma_params = { :stock_location_id => stock_location.id,
+                       :return_authorization_reason_id => reason.id,
+                       :memo => "Defective" }
+        api_post :create, :order_id => order.number, :return_authorization => rma_params
+        response.status.should == 201
+        json_response.should have_attributes(attributes)
+        json_response["state"].should_not be_blank
+      end
+    end
+
     context "as the order owner" do
       before do
         allow_any_instance_of(Order).to receive_messages :user => current_api_user
@@ -34,10 +48,7 @@ module Spree
         assert_unauthorized!
       end
 
-      it "cannot create a new return authorization" do
-        api_post :create
-        assert_unauthorized!
-      end
+      it_behaves_like "a return authorization creator"
 
       it "cannot update a return authorization" do
         api_put :update
@@ -47,6 +58,17 @@ module Spree
       it "cannot delete a return authorization" do
         api_delete :destroy
         assert_not_found!
+      end
+    end
+
+    context "as another non-admin user that's not the order's owner" do
+      before do
+        Order.any_instance.stub :user => create(:user)
+      end
+
+      it "cannot create a new return authorization" do
+        api_post :create
+        assert_unauthorized!
       end
     end
 
@@ -122,17 +144,7 @@ module Spree
         expect { return_authorization.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
-      it "can add a new return authorization to an existing order" do
-        stock_location = FactoryGirl.create(:stock_location)
-        reason = FactoryGirl.create(:return_authorization_reason)
-        rma_params = { :stock_location_id => stock_location.id,
-                       :return_authorization_reason_id => reason.id,
-                       :memo => "Defective" }
-        api_post :create, :order_id => order.number, :return_authorization => rma_params
-        expect(response.status).to eq(201)
-        expect(json_response).to have_attributes(attributes)
-        expect(json_response["state"]).not_to be_blank
-      end
+      it_behaves_like "a return authorization creator"
     end
 
     context "as just another user" do

--- a/core/app/models/spree/ability.rb
+++ b/core/app/models/spree/ability.rb
@@ -46,6 +46,9 @@ module Spree
         can [:read, :update], Order do |order, token|
           order.user == user || order.guest_token && token == order.guest_token
         end
+        can :create, ReturnAuthorization do |return_authorization|
+          return_authorization.order.user == user
+        end
         can :display, CreditCard, user_id: user.id
         can :display, Product
         can :display, ProductProperty

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -65,7 +65,7 @@ module Spree
 
     @@property_attributes = [:name, :presentation]
 
-    @@return_authorization_attributes = [:amount, :memo, :stock_location_id, :inventory_units_attributes, :return_authorization_reason_id]
+    @@return_authorization_attributes = [:memo, :stock_location_id, :return_authorization_reason_id, return_items_attributes: [:inventory_unit_id, :exchange_variant_id]]
 
     @@shipment_attributes = [
       :order, :special_instructions, :stock_location_id, :id,


### PR DESCRIPTION
The creation of return authorizations through the API was currently only available to admins. This change allows the customer to create return authorizations for orders they are associated with.
