### PR TITLE
clear and create new order when empty cart

### DIFF
--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -100,6 +100,14 @@ module Spree
           order
         end
 
+        def clear_current_order
+          @current_order.destroy! if @current_order
+          @current_order = Spree::Order.new(current_order_params)
+          @current_order.user ||= try_spree_current_user
+          # See issue #3346 for reasons why this line is here
+          @current_order.created_by ||= try_spree_current_user
+          @current_order.save!
+        end
       end
     end
   end

--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -53,10 +53,7 @@ module Spree
     end
 
     def empty
-      if @order = current_order
-        @order.empty!
-      end
-
+      clear_current_order
       redirect_to spree.cart_path
     end
 


### PR DESCRIPTION
I saw a few issues which are relative to empty cart without clearing promotion or applied coupon.
For now, when you empty the cart. Spree only delete all the line items and relative adjustments, shipments/rates, and inventory units. It may cause some problem since order is not totally new.
Why not just destroy the old order and create a new one when empty cart?

Correct me if I got anything wrong. 
