### PR TITLE
Remove inventory unit touch on Shipment.

### DIFF
--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -2,7 +2,7 @@ module Spree
   class InventoryUnit < Spree::Base
     belongs_to :variant, class_name: "Spree::Variant", inverse_of: :inventory_units
     belongs_to :order, class_name: "Spree::Order", inverse_of: :inventory_units
-    belongs_to :shipment, class_name: "Spree::Shipment", touch: true, inverse_of: :inventory_units
+    belongs_to :shipment, class_name: "Spree::Shipment", inverse_of: :inventory_units
     belongs_to :return_authorization, class_name: "Spree::ReturnAuthorization", inverse_of: :inventory_units
     belongs_to :line_item, class_name: "Spree::LineItem", inverse_of: :inventory_units
 

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -3,7 +3,7 @@ require 'ostruct'
 module Spree
   class Shipment < Spree::Base
     belongs_to :address, class_name: 'Spree::Address', inverse_of: :shipments
-    belongs_to :order, class_name: 'Spree::Order', touch: true, inverse_of: :shipments
+    belongs_to :order, class_name: 'Spree::Order', inverse_of: :shipments
     belongs_to :stock_location, class_name: 'Spree::StockLocation'
 
     has_many :adjustments, as: :adjustable, dependent: :delete_all


### PR DESCRIPTION
In progress ..

This improves performance when creating inventory units by not touching
shipment after every inventory unit insert.

I think I am missing the reason for those touches, but if we remove them, this one will be improved:

``` sql
SQL (0.3ms)  INSERT INTO "spree_inventory_units" ("created_at", "line_item_id", "order_id", "shipment_id", "state", "updated_at", "variant_id") VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING "id"  [["created_at", "2014-12-16 21:16:46.557801"], ["line_item_id", 43], ["order_id", 50], ["shipment_id", 50], ["state", "backordered"], ["updated_at", "2014-12-16 21:16:46.557801"], ["variant_id", 75]]
  SQL (0.4ms)  UPDATE "spree_shipments" SET "updated_at" = '2014-12-16 21:16:46.559330' WHERE "spree_shipments"."id" = 50
  SQL (0.5ms)  UPDATE "spree_orders" SET "updated_at" = '2014-12-16 21:16:46.560664' WHERE "spree_orders"."id" = 50
  SQL (0.2ms)  INSERT INTO "spree_inventory_units" ("created_at", "line_item_id", "order_id", "shipment_id", "state", "updated_at", "variant_id") VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING "id"  [["created_at", "2014-12-16 21:16:46.562032"], ["line_item_id", 43], ["order_id", 50], ["shipment_id", 50], ["state", "backordered"], ["updated_at", "2014-12-16 21:16:46.562032"], ["variant_id", 75]]
  SQL (0.8ms)  UPDATE "spree_shipments" SET "updated_at" = '2014-12-16 21:16:46.562927' WHERE "spree_shipments"."id" = 50
  SQL (0.7ms)  UPDATE "spree_orders" SET "updated_at" = '2014-12-16 21:16:46.564415' WHERE "spree_orders"."id" = 50

```

The updates actually take longer than the inventory unit inserts.
