### PR TITLE
Fix images and prices order on search results with taxon

### DIFF
--- a/core/lib/spree/core/search/base.rb
+++ b/core/lib/spree/core/search/base.rb
@@ -41,11 +41,24 @@ module Spree
           end
 
           def add_eagerload_scopes scope
-            if include_images
-              scope.includes({master: [:prices, :images]})
-            else
-              scope.includes(master: :prices)
-            end
+            # TL;DR Switch from `preload` to `includes` as soon as Rails starts honoring
+            # `order` clauses on `has_many` associations when a `where` constraint
+            # affecting a joined table is present (see
+            # https://github.com/rails/rails/issues/6769).
+            #
+            # Ideally this would use `includes` instead of `preload` calls, leaving it
+            # up to Rails whether associated objects should be fetched in one big join
+            # or multiple independent queries. However as of Rails 4.1.8 any `order`
+            # defined on `has_many` associations are ignored when Rails builds a join
+            # query.
+            #
+            # Would we use `includes` in this particular case, Rails would do
+            # separate queries most of the time but opt for a join as soon as any
+            # `where` constraints affecting joined tables are added to the search;
+            # which is the case as soon as a taxon is added to the base scope.
+            scope = scope.preload(master: :prices)
+            scope = scope.preload(master: :images) if include_images
+            scope
           end
 
           def add_search_scopes(base_scope)

--- a/core/spec/lib/search/base_spec.rb
+++ b/core/spec/lib/search/base_spec.rb
@@ -5,9 +5,13 @@ describe Spree::Core::Search::Base do
   before do
     include Spree::Core::ProductFilters
     Spree::Product.delete_all # FIXME product leaks
+    Spree::Taxon.destroy_all
 
-    @product1 = create(:product, :name => "RoR Mug", :price => 9.00)
-    @product2 = create(:product, :name => "RoR Shirt", :price => 11.00)
+    @taxon = create(:taxon, name: "Ruby on Rails")
+
+    @product1 = create(:product, name: "RoR Mug", price: 9.00)
+    @product1.taxons << @taxon
+    @product2 = create(:product, name: "RoR Shirt", price: 11.00)
   end
 
   it "returns all products by default" do
@@ -17,7 +21,7 @@ describe Spree::Core::Search::Base do
   end
 
   context "when include_images is included in the initalization params" do
-    let(:params) {{ include_images: true, keyword: @product1.name }}
+    let(:params) { { include_images: true, keyword: @product1.name, taxon: @taxon.id } }
     subject { described_class.new(params).retrieve_products }
 
     before do


### PR DESCRIPTION
Extends on #5513 which fixed the product image and prices order of products loaded through the base search class. 
#5513 replaced `eager_load()` with `includes()`, in an effort to have Rails eagerly load images and prices in a separate query (due to a Rails issue outlined in rails/rails#6769). However `includes()` still resorts to joins instead of a separate query if one adds a `where()` condition on one of the included tables. Unfortunately such a condition is applied when supplying the base search class with a taxon parameter.

This fix uses `preload()` instead of `includes()` which forces Rails to always use a separate query when eagerly loading the images and prices.
