### PR TITLE
Only consider eligible promos for used_by?

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -147,7 +147,21 @@ module Spree
     end
 
     def used_by?(user, excluded_orders = [])
-      orders.where.not(id: excluded_orders.map(&:id)).complete.where(user_id: user.id).exists?
+      [
+        :adjustments,
+        :line_item_adjustments,
+        :shipment_adjustments
+      ].any? do |adjustment_type|
+        user.orders.complete.joins(adjustment_type).where(
+          spree_adjustments: {
+            source_type: 'Spree::PromotionAction',
+            source_id: actions.map(&:id),
+            eligible: true
+          }
+        ).where.not(
+          id: excluded_orders.map(&:id)
+        ).any?
+      end
     end
 
     private

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -482,21 +482,37 @@ describe Spree::Promotion, :type => :model do
   describe '#used_by?' do
     subject { promotion.used_by? user, [excluded_order] }
 
-    let(:promotion) { Spree::Promotion.create! name: 'Test Used By' }
+    let(:promotion) { create :promotion, :with_order_adjustment }
     let(:user) { create :user }
-    let(:order) { create :completed_order_with_totals }
-    let(:excluded_order) { create :completed_order_with_totals }
+    let(:order) { create :order_with_line_items, user: user }
+    let(:excluded_order) { create :order_with_line_items, user: user }
 
-    before { promotion.orders << order }
+    before do
+      order.user_id = user.id
+      order.save!
+    end
 
     context 'when the user has used this promo' do
       before do
-        order.user_id = user.id
+        promotion.activate(order: order)
+        order.update!
+        order.completed_at = Time.now
         order.save!
       end
 
       context 'when the order is complete' do
         it { is_expected.to be true }
+
+        context 'when the promotion was not eligible' do
+          let(:adjustment) { order.adjustments.first }
+
+          before do
+            adjustment.eligible = false
+            adjustment.save!
+          end
+
+          it { is_expected.to be false }
+        end
 
         context 'when the only matching order is the excluded order' do
           let(:excluded_order) { order }
@@ -505,7 +521,7 @@ describe Spree::Promotion, :type => :model do
       end
 
       context 'when the order is not complete' do
-        let(:order) { create :order }
+        let(:order) { create :order, user: user }
         it { is_expected.to be false }
       end
     end


### PR DESCRIPTION
Previously this would consider a promo used as long it was assigned to
an order, even if this promo was not eligible (as in the case of when it
was overridden by a better promo).

In order to check if a promo was eligble, it needs to change the way the
associations were joined, as it now needs to check on adjustments
instead of just if the order is associated with the promotion.

The test is changed to set up a full promotion with adjustments, and
actions.
