### PR TITLE
Enable/disable every input in payment forms

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/payments/new.js
+++ b/backend/app/assets/javascripts/spree/backend/payments/new.js
@@ -12,9 +12,9 @@ $(document).ready(function() {
     $('.payment_methods_radios').click(
       function() {
         $('.payment-methods').hide();
-        $('.payment-methods input').prop('disabled', true);
+        $('.payment-methods :input').prop('disabled', true);
         if (this.checked) {
-          $('#payment_method_' + this.value + ' input').prop('disabled', false);
+          $('#payment_method_' + this.value + ' :input').prop('disabled', false);
           $('#payment_method_' + this.value).show();
         }
       }
@@ -23,11 +23,11 @@ $(document).ready(function() {
     $('.payment_methods_radios').each(
       function() {
         if (this.checked) {
-          $('#payment_method_' + this.value + ' input').prop('disabled', false);
+          $('#payment_method_' + this.value + ' :input').prop('disabled', false);
           $('#payment_method_' + this.value).show();
         } else {
           $('#payment_method_' + this.value).hide();
-          $('#payment_method_' + this.value + ' input').prop('disabled', true);
+          $('#payment_method_' + this.value + ' :input').prop('disabled', true);
         }
 
         if ($("#card_new" + this.value).is("*")) {


### PR DESCRIPTION
If a payment form contains a select or textarea element it's not disabled when the fields are hidden and are always submitted.
