### PR TITLE
Touch taxonomy when taxon is created/updated.

### DIFF
--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -2,7 +2,7 @@ module Spree
   class Taxon < Spree::Base
     acts_as_nested_set dependent: :destroy
 
-    belongs_to :taxonomy, class_name: 'Spree::Taxonomy', inverse_of: :taxons
+    belongs_to :taxonomy, class_name: 'Spree::Taxonomy', inverse_of: :taxons, touch: true
     has_many :classifications, -> { order(:position) }, dependent: :delete_all, inverse_of: :taxon
     has_many :products, through: :classifications
 


### PR DESCRIPTION
There is a cache within this block:
https://github.com/spree/spree/blob/7ff3bcc81af3a421ed0013511c6ee3049fb240c2/frontend/app/views/spree/shared/_taxonomies.html.erb#L4-L7

This cache needs to be invalidated so that the taxons_tree can be drawn
properly. Currently, new taxons, or modified taxons will not show up
until the Taxonomy is updated, or the cache is cleared.

Fixes #5810
