### PR TITLE
Cleanup i18n duplication.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ test_app
 **/coverage
 */.sass-cache
 .localeapp
+.ruby-gemset

--- a/backend/app/views/spree/admin/adjustments/index.html.erb
+++ b/backend/app/views/spree/admin/adjustments/index.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: 'spree/admin/shared/order_tabs', locals: { current: 'Adjustments' } %>
 
 <% content_for :page_title do %>
-   / <%= Spree.t(:adjustments) %>
+   / <%= Spree::Adjustment.model_name.human(count: :many) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -12,7 +12,7 @@
   <%= render :partial => 'adjustments_table' %>
 <% else %>
   <div class="alert alert-warning">
-    <%= Spree.t(:no_adjustments_found) %>
+    <%= Spree.t(:no_resource_found, resource: Spree::Adjustment.model_name.human(count: :many)) %>
   </div>
 <% end %>
 

--- a/backend/app/views/spree/admin/countries/edit.html.erb
+++ b/backend/app/views/spree/admin/countries/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_country) %>
+  <%= Spree.t(:editing_resource, resource: Spree::Country.model_name.human) %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @country } %>

--- a/backend/app/views/spree/admin/countries/index.html.erb
+++ b/backend/app/views/spree/admin/countries/index.html.erb
@@ -1,7 +1,5 @@
-
-
 <% content_for :page_title do %>
-  <%= Spree.t(:listing_countries) %>
+  <%= Spree::Country.model_name.human(count: :many) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/countries/new.html.erb
+++ b/backend/app/views/spree/admin/countries/new.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= link_to_with_icon 'arrow-left', Spree.t(:back_to_countries_list), admin_countries_path, :class => 'btn btn-default' %>
+  <%= link_to_with_icon 'arrow-left', Spree.t(:back_to_resource_list, resource: Spree::Country.model_name.human), admin_countries_path, class: 'btn btn-default' %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @countries } %>

--- a/backend/app/views/spree/admin/customer_returns/edit.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/edit.html.erb
@@ -50,12 +50,12 @@
 <% end %>
 
 <fieldset data-hook="reimbursements">
-  <legend><%= Spree.t(:reimbursements) %></legend>
+  <legend><%= Spree::Reimbursement.model_name.human(count: :many) %></legend>
   <% if @customer_return.reimbursements.any? %>
     <%= render partial: 'reimbursements_table', locals: {reimbursements: @customer_return.reimbursements} %>
   <% else %>
     <div class="alert alert-info no-objects-found">
-      <%= Spree.t(:no_reimbursements_found) %>
+      <%= Spree.t(:no_resource_found, resource: Spree::Reimbursement.model_name.human(count: :many)) %>
     </div>
   <% end %>
 </fieldset>

--- a/backend/app/views/spree/admin/customer_returns/index.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/index.html.erb
@@ -7,7 +7,7 @@
 <% end %>
 
 <% content_for :page_title do %>
-  / <%= Spree.t(:customer_returns) %>
+  / <%= Spree::CustomerReturn.model_name.human(count: :many) %>
 <% end %>
 
 <% if @order.shipments.any?(&:shipped?) %>
@@ -45,7 +45,7 @@
     </table>
   <% else %>
     <div class="alert alert-info no-objects-found">
-      <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/customer_return')) %>,
+      <%= Spree.t(:no_resource_found, resource: Spree::CustomerReturn.model_name.human(count: :many)) %>,
       <%= link_to Spree.t(:add_one), spree.new_admin_order_customer_return_path(@order) %>!
     </div>
   <% end %>

--- a/backend/app/views/spree/admin/customer_returns/new.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/new.html.erb
@@ -53,7 +53,7 @@
 
   <div class="alert alert-info no-objects-found">
     <%= Spree.t(:all_items_have_been_returned) %>,
-    <%= link_to Spree.t(:back_to_customer_return_list), spree.admin_order_customer_returns_path(@order) %>.
+    <%= link_to Spree.t(:back_to_resource_list, resource: Spree::CustomerReturn.model_name.human), spree.admin_order_customer_returns_path(@order) %>.
   </div>
 
 <% end %>

--- a/backend/app/views/spree/admin/images/index.html.erb
+++ b/backend/app/views/spree/admin/images/index.html.erb
@@ -7,7 +7,7 @@
 <% has_variants = @product.has_variants? %>
 <% unless @product.variant_images.any? %>
   <div class="alert alert-warning">
-    <%= Spree.t(:no_images_found) %>.
+    <%= Spree.t(:no_resource_found, resource: Spree::Image.model_name.human(count: :many)) %>.
   </div>
 <% else %>
   <table class="table sortable" data-hook="images_table" data-sortable-link="<%= update_positions_admin_product_images_url(@product) %>">

--- a/backend/app/views/spree/admin/option_types/edit.html.erb
+++ b/backend/app/views/spree/admin/option_types/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_option_type) %> <span class="green">"<%= @option_type.name %>"</span>
+  <%= Spree.t(:editing_resource, resource: Spree::OptionType.model_name.human) %> <span class="green">"<%= @option_type.name %>"</span>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/option_types/index.html.erb
+++ b/backend/app/views/spree/admin/option_types/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:option_types) %>
+  <%= Spree::OptionType.model_name.human(count: :many) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -36,7 +36,7 @@
 </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/option_type')) %>,
+    <%= Spree.t(:no_resource_found, resource: Spree::OptionType.model_name.human(count: :many)) %>,
     <%= link_to Spree.t(:add_one), spree.new_admin_option_type_path %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/orders/edit.html.erb
+++ b/backend/app/views/spree/admin/orders/edit.html.erb
@@ -10,7 +10,7 @@
 <%= render partial: 'spree/admin/shared/order_tabs', locals: { current: 'Shipments' } %>
 
 <% content_for :page_title do %>
-  / <%= Spree.t(:shipments) %>
+  / <%= Spree::Shipment.model_name.human(count: :many) %>
 <% end %>
 
 <div data-hook="admin_order_edit_header">

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:listing_orders) %>
+  <%= Spree::Order.model_name.human(count: :many) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -162,7 +162,7 @@
   </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/order')) %>,
+    <%= Spree.t(:no_resource_found, resource: Spree::Order.model_name.human(count: :many)) %>,
     <%= link_to Spree.t(:add_one), spree.new_admin_order_path %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/payment_methods/edit.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_payment_method) %> / <%= @payment_method.name %>
+  <%= Spree.t(:editing_resource, resource: Spree::PaymentMethod.model_name.human) %> / <%= @payment_method.name %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @payment_method } %>

--- a/backend/app/views/spree/admin/payment_methods/index.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:payment_methods) %>
+  <%= Spree::PaymentMethod.model_name.human(count: :many) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -36,7 +36,7 @@
   </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/payment_method')) %>,
+    <%= Spree.t(:no_resource_found, resource: Spree::PaymentMethod.model_name.human(count: :many)) %>,
     <%= link_to Spree.t(:add_one), spree.new_admin_payment_method_path %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:listing_products) %>
+  <%= Spree::Product.model_name.human(count: :many) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -65,7 +65,7 @@
   </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/product')) %>,
+    <%= Spree.t(:no_resource_found, resource: Spree::Product.model_name.human(count: :many)) %>,
     <%= link_to Spree.t(:add_one), spree.new_admin_product_path %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/promotion_categories/edit.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_promotion_category) %>
+  <%= Spree.t(:editing_resource, resource: Spree::PromotionCategory.model_name.human) %>
 <% end %>
 
 <%= form_for @promotion_category, :url => object_url, :method => :put do |f| %>

--- a/backend/app/views/spree/admin/promotion_categories/index.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/index.html.erb
@@ -26,7 +26,7 @@
   </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/promotion_category')) %>,
+    <%= Spree.t(:no_resource_found, resource: Spree::PromotionCategory.model_name.human(count: :many)) %>,
     <%= link_to Spree.t(:add_one), spree.new_admin_promotion_category_path %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/promotions/edit.html.erb
+++ b/backend/app/views/spree/admin/promotions/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_promotion) %>
+  <%= Spree.t(:editing_resource, resource: Spree::Promotion.model_name.human) %>
 <% end %>
 
 <%= form_for @promotion, :url => object_url, :method => :put do |f| %>

--- a/backend/app/views/spree/admin/promotions/index.html.erb
+++ b/backend/app/views/spree/admin/promotions/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:promotions) %>
+  <%= Spree::Promotion.model_name.human(count: :many) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -70,7 +70,7 @@
   </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/promotion')) %>,
+    <%= Spree.t(:no_resource_found, resource: Spree::Promotion.model_name.human(count: :many)) %>,
     <%= link_to Spree.t(:add_one), spree.new_admin_promotion_path %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/properties/edit.html.erb
+++ b/backend/app/views/spree/admin/properties/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_property) %>
+  <%= Spree.t(:editing_resource, resource: Spree::Property.model_name.human) %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @property } %>

--- a/backend/app/views/spree/admin/properties/index.html.erb
+++ b/backend/app/views/spree/admin/properties/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:properties) %>
+  <%= Spree::Property.model_name.human(count: :many) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -53,7 +53,7 @@
   </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/property')) %>,
+    <%= Spree.t(:no_resource_found, resource: Spree::Property.model_name.human(count: :many)) %>,
     <%= link_to Spree.t(:add_one), spree.new_admin_property_path %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/prototypes/edit.html.erb
+++ b/backend/app/views/spree/admin/prototypes/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_prototype) %>
+  <%= Spree.t(:editing_resource, resource: Spree::Prototype.model_name.human) %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @prototype } %>

--- a/backend/app/views/spree/admin/prototypes/index.html.erb
+++ b/backend/app/views/spree/admin/prototypes/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:prototypes) %>
+  <%= Spree::Prototype.model_name.human(count: :many) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -28,7 +28,7 @@
   </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/prototype')) %>,
+    <%= Spree.t(:no_resource_found, resource: Spree::Prototype.model_name.human(count: :many)) %>,
     <%= link_to Spree.t(:add_one), spree.new_admin_prototype_path %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/refund_reasons/edit.html.erb
+++ b/backend/app/views/spree/admin/refund_reasons/edit.html.erb
@@ -1,4 +1,4 @@
 <%= render partial: 'spree/admin/shared/named_types/edit', locals: {
-  page_title: Spree.t(:editing_refund_reason),
-  back_button_text: Spree.t(:back_to_refund_reason_list)
+  page_title: Spree.t(:editing_resource, resource: Spree::RefundReason.model_name.human),
+  back_button_text: Spree.t(:back_to_resource_list, resource: Spree::RefundReason.model_name.human)
 } %>

--- a/backend/app/views/spree/admin/refund_reasons/index.html.erb
+++ b/backend/app/views/spree/admin/refund_reasons/index.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: 'spree/admin/shared/named_types/index', locals: {
-  page_title: Spree.t(:refund_reasons),
+  page_title: Spree::RefundReason.model_name.human(count: :many),
   new_button_text: Spree.t(:new_refund_reason),
-  resource_name: I18n.t(:other, scope: 'activerecord.models.spree/refund_reason')
+  resource_name: Spree::RefundReason.model_name.human(count: :many)
 } %>

--- a/backend/app/views/spree/admin/refund_reasons/new.html.erb
+++ b/backend/app/views/spree/admin/refund_reasons/new.html.erb
@@ -1,4 +1,4 @@
 <%= render partial: 'spree/admin/shared/named_types/new', locals: {
   page_title: Spree.t(:new_refund_reason),
-  back_button_text: Spree.t(:back_to_refund_reason_list)
+  back_button_text: Spree.t(:back_to_resource_list, resource: Spree::RefundReason.model_name.human)
 } %>

--- a/backend/app/views/spree/admin/refunds/edit.html.erb
+++ b/backend/app/views/spree/admin/refunds/edit.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :page_title do %>
   / <%= link_to "#{Spree.t(:payment)} #{@refund.payment.id}", admin_order_payment_path(@refund.payment.order, @refund.payment) %>
-  / <%= Spree.t(:editing_refund) %> <%= @refund.id %>
+  / <%= Spree.t(:editing_resource, resource: Spree::Refund.model_name.human) %> <%= @refund.id %>
 <% end %>
 
 <%= form_for [:admin, @refund.payment.order, @refund.payment, @refund] do |f| %>

--- a/backend/app/views/spree/admin/reimbursement_types/index.html.erb
+++ b/backend/app/views/spree/admin/reimbursement_types/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:reimbursement_types) %>
+  <%= Spree::ReimburementType.model_name.human(count: :many) %>
 <% end %>
 
 <% if @reimbursement_types.any? %>
@@ -25,7 +25,7 @@
   </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/reimbursement_type')) %>,
+    <%= Spree.t(:no_resource_found, resource: Spree::ReimburementType.model_name.human(count: :many)) %>,
     <%= link_to Spree.t(:add_one), new_object_url %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/reimbursements/edit.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Customer Returns' } %>
 
 <% content_for :page_title do %>
-  / <%= Spree.t(:editing_reimbursement) %> #<%= @reimbursement.number %>
+  / <%= Spree.t(:editing_resource, resource: Spree::Reimbursement.model_name.human) %> #<%= @reimbursement.number %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @reimbursement } %>

--- a/backend/app/views/spree/admin/reimbursements/show.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/show.html.erb
@@ -1,7 +1,7 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Customer Returns' } %>
 
 <% content_for :page_title do %>
-  / <%= Spree.t(:reimbursement) %> #<%= @reimbursement.number %>
+  / <%= Spree::Reimbursement.model_name.human %> #<%= @reimbursement.number %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @reimbursement } %>

--- a/backend/app/views/spree/admin/reports/index.html.erb
+++ b/backend/app/views/spree/admin/reports/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:listing_reports) %>
+  <%= Spree.t(:reports) %>
 <% end %>
 
 <table class="table">

--- a/backend/app/views/spree/admin/reports/sales_total.html.erb
+++ b/backend/app/views/spree/admin/reports/sales_total.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= link_to_with_icon 'arrow-left', Spree.t(:back_to_reports_list), spree.admin_reports_url, :class => 'btn btn-default' %>
+  <%= link_to_with_icon 'arrow-left', Spree.t(:back_to_resource_list, resource: Spree.t(:report)), spree.admin_reports_url, class: 'btn btn-default' %>
 <% end %>
 
 <div class="well">

--- a/backend/app/views/spree/admin/return_authorization_reasons/index.html.erb
+++ b/backend/app/views/spree/admin/return_authorization_reasons/index.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: 'spree/admin/shared/named_types/index', locals: {
-  page_title: Spree.t(:return_authorization_reasons),
+  page_title: Spree::ReturnAuthorizationReason.model_name.human(count: :many),
   new_button_text: Spree.t(:new_rma_reason),
-  resource_name: I18n.t(:other, scope: 'activerecord.models.spree/return_authorization_reason')
+  resource_name: Spree::ReturnAuthorizationReason.model_name.human(count: :many)
 } %>

--- a/backend/app/views/spree/admin/return_authorizations/index.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/index.html.erb
@@ -40,7 +40,7 @@
   </table>
 <% elsif @order.shipments.any?(&:shipped?) %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_returns_found) %>
+    <%= Spree.t(:no_resource_found, resource: Spree::ReturnAuthorization.model_name.human(count: :many)) %>
   </div>
 <% else %>
   <div data-hook="rma_cannont_create" class="alert alert-info no-objects-found">

--- a/backend/app/views/spree/admin/shipping_categories/edit.html.erb
+++ b/backend/app/views/spree/admin/shipping_categories/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_shipping_category) %>
+  <%= Spree.t(:editing_resource, resource: Spree::ShippingCategory.model_name.human) %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @shipping_category } %>

--- a/backend/app/views/spree/admin/shipping_categories/index.html.erb
+++ b/backend/app/views/spree/admin/shipping_categories/index.html.erb
@@ -1,7 +1,5 @@
-
-
 <% content_for :page_title do %>
-  <%= Spree.t(:shipping_categories) %>
+  <%= Spree::ShippingCategory.model_name.human(count: :many) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -32,7 +30,7 @@
   </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/shipping_category')) %>,
+    <%= Spree.t(:no_resource_found, resource: Spree::ShippingCategory.model_name.human(count: :many)) %>,
     <%= link_to Spree.t(:add_one), spree.new_admin_shipping_category_path %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/shipping_methods/edit.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_shipping_method) %>
+  <%= Spree.t(:editing_resource, resource: Spree::ShippingMethod.model_name.human) %>
 <% end %>
 
 <div data-hook="admin_shipping_method_edit_form_header">

--- a/backend/app/views/spree/admin/shipping_methods/index.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/index.html.erb
@@ -1,7 +1,5 @@
-
-
 <% content_for :page_title do %>
-  <%= Spree.t(:shipping_methods) %>
+  <%= Spree::ShippingMethod.model_name.human(count: :many) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -38,7 +36,7 @@
   </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/shipping_method')) %>,
+    <%= Spree.t(:no_resource_found, resource: Spree::ShippingMethod.model_name.human(count: :many)) %>,
     <%= link_to Spree.t(:add_one), spree.new_admin_shipping_method_path %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/state_changes/index.html.erb
+++ b/backend/app/views/spree/admin/state_changes/index.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: 'spree/admin/shared/order_tabs', locals: { current: 'State Changes' } %>
 
 <% content_for :page_title do %>
-  <%= Spree::StateChange.human_attribute_name(:state_changes) %>
+  <%= Spree::StateChange.model_name.human(count: :many) %>
 <% end %>
 
 <% if @state_changes.any? %>

--- a/backend/app/views/spree/admin/states/edit.html.erb
+++ b/backend/app/views/spree/admin/states/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_state) %> / <%= @state.name %>
+  <%= Spree.t(:editing_resource, resource: Spree::State.model_name.human) %> / <%= @state.name %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @state } %>

--- a/backend/app/views/spree/admin/states/index.html.erb
+++ b/backend/app/views/spree/admin/states/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:states) %>
+  <%= Spree::State.model_name.human(count: :many) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/stock_locations/edit.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/edit.html.erb
@@ -1,10 +1,10 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_stock_location) %> /
+  <%= Spree.t(:editing_resource, resource: Spree::StockLocation.model_name.human) %> /
   <%= @stock_location.name %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li><%= link_to_with_icon 'arrow-left', Spree.t(:back_to_stock_locations_list), admin_stock_locations_path, :class => 'btn btn-default' %></li>
+  <%= link_to_with_icon 'arrow-left', Spree.t(:back_to_resource_list, resource: Spree::StockLocation.model_name.human), admin_stock_locations_path, class: 'btn btn-default' %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @stock_location } %>

--- a/backend/app/views/spree/admin/stock_locations/index.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:stock_locations) %>
+  <%= Spree::StockLocation.model_name.human(count: :many) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -36,7 +36,7 @@
   </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/stock_location')) %>,
+    <%= Spree.t(:no_resource_found, resource: Spree::StockLocation.model_name.human(count: :many)) %>,
     <%= link_to Spree.t(:add_one), spree.new_admin_stock_location_path %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/stock_movements/edit.html.erb
+++ b/backend/app/views/spree/admin/stock_movements/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_stock_movement) %>
+  <%= Spree.t(:editing_resource, resource: Spree::StockMovement.model_name.human) %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li><%= link_to_with_icon 'arrow-left', Spree.t(:back_to_stock_movements_list), admin_stock_location_stock_movements_path(stock_location), :class => 'btn btn-default' %></li>
+  <%= link_to_with_icon 'arrow-left', Spree.t(:back_to_resource_list, resource: Spree::StockMovement.model_name.human), admin_stock_location_stock_movements_path(stock_location), class: 'btn btn-default' %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @stock_movement } %>

--- a/backend/app/views/spree/admin/stock_movements/index.html.erb
+++ b/backend/app/views/spree/admin/stock_movements/index.html.erb
@@ -1,16 +1,10 @@
-
-
 <% content_for :page_title do %>
   <%= Spree.t(:stock_movements_for_stock_location, stock_location_name: @stock_location.name) %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li>
-    <%= button_link_to Spree.t(:new_stock_movement), new_admin_stock_location_stock_movement_path(@stock_location),  icon: 'plus', id: 'admin_new_stock_movement_link' %>
-  </li>
-  <li>
-    <%= link_to_with_icon 'arrow-left', Spree.t(:back_to_stock_locations_list), admin_stock_locations_path, :class => 'btn btn-default' %>
-  </li>
+  <%= button_link_to Spree.t(:new_stock_movement), new_admin_stock_location_stock_movement_path(@stock_location), icon: 'plus', id: 'admin_new_stock_movement_link' %>
+  <%= link_to_with_icon 'arrow-left', Spree.t(:back_to_resource_list, resource: Spree::StockLocation.model_name.human), admin_stock_locations_path, class: 'btn btn-default' %>
 <% end %>
 
 <% if @stock_movements.any? %>
@@ -41,7 +35,7 @@
 </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/stock_movement')) %>,
+    <%= Spree.t(:no_resource_found, resource: Spree::StockMovement.model_name.human(count: :many)) %>,
     <%= link_to Spree.t(:add_one), spree.new_admin_stock_location_stock_movement_path(@stock_location) %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/stock_transfers/index.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/index.html.erb
@@ -1,7 +1,5 @@
-
-
 <% content_for :page_title do %>
-  <%= Spree.t(:stock_transfers) %>
+  <%= Spree::StockTransfer.model_name.human(count: :many) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -76,7 +74,7 @@
   </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/stock_transfer')) %>,
+    <%= Spree.t(:no_resource_found, resource: Spree::StockTransfer.model_name.human(count: :many)) %>,
     <%= link_to Spree.t(:add_one), spree.new_admin_stock_transfer_path %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/stock_transfers/show.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t('stock_transfer') %> (<%= @stock_transfer.number %>)
+  <%= Spree::StockTransfer.model_name.human(count: :many) %> (<%= @stock_transfer.number %>)
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/tax_categories/edit.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/edit.html.erb
@@ -1,11 +1,9 @@
-
-
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_tax_category) %>
+  <%= Spree.t(:editing_resource, resource: Spree::TaxCategory.model_name.human) %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li><%= link_to_with_icon 'arrow-left', Spree.t(:back_to_tax_categories_list), admin_tax_categories_path, :class => 'btn btn-default' %></li>
+  <%= link_to_with_icon 'arrow-left', Spree.t(:back_to_resource_list, resource: Spree::TaxCategory.model_name.human), admin_tax_categories_path, class: 'btn btn-default' %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @tax_category } %>

--- a/backend/app/views/spree/admin/tax_categories/index.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:listing_tax_categories) %>
+  <%= Spree::TaxCategory.model_name.human(count: :many) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -36,7 +36,7 @@
 </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/tax_category')) %>,
+    <%= Spree.t(:no_resource_found, resource: Spree::TaxCategory.model_name.human(count: :many)) %>,
     <%= link_to Spree.t(:add_one), spree.new_admin_tax_category_path %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/tax_categories/new.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/new.html.erb
@@ -1,13 +1,10 @@
-
-
 <% content_for :page_title do %>
   <%= Spree.t(:new_tax_category) %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li><%= link_to_with_icon 'arrow-left', Spree.t(:back_to_tax_categories_list), admin_tax_categories_path, :class => 'btn btn-default' %></li>
+  <%= link_to_with_icon 'arrow-left', Spree.t(:back_to_resource_list, resource: Spree::TaxCategory.model_name.human), admin_tax_categories_path, class: 'btn btn-default' %>
 <% end %>
-
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @tax_category } %>
 

--- a/backend/app/views/spree/admin/tax_rates/edit.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_tax_rate) %>
+  <%= Spree.t(:editing_resource, resource: Spree::TaxRate.model_name.human) %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @tax_rate } %>

--- a/backend/app/views/spree/admin/tax_rates/index.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:tax_rates) %>
+  <%= Spree::TaxRate.model_name.human(count: :many) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -42,7 +42,7 @@
   </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/tax_rate')) %>,
+    <%= Spree.t(:no_resource_found, resource: Spree::TaxRate.model_name.human(count: :many)) %>,
     <%= link_to Spree.t(:add_one), spree.new_admin_tax_rate_path %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/taxonomies/index.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/index.html.erb
@@ -1,11 +1,10 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:taxonomies) %>
+  <%= Spree::Taxonomy.model_name.human(count: :many) %>
 <% end %>
 
 <% content_for :page_actions do %>
   <%= button_link_to Spree.t(:new_taxonomy), spree.new_admin_taxonomy_url, :class => "btn-success", :icon => 'add', :id => 'admin_new_taxonomy_link' %>
 <% end %>
-
 
 <% if @taxonomies.any? %>
   <div id="list-taxonomies" data-hook>
@@ -13,7 +12,7 @@
   </div>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/taxonomy')) %>,
+    <%= Spree.t(:no_resource_found, resource: Spree::Taxonomy.model_name.human(count: :many)) %>,
     <%= link_to Spree.t(:add_one), spree.new_admin_taxonomy_path %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/trackers/edit.html.erb
+++ b/backend/app/views/spree/admin/trackers/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_tracker) %>
+  <%= Spree.t(:editing_resource, resource: Spree::Tracker.model_name.human) %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @tracker } %>

--- a/backend/app/views/spree/admin/trackers/index.html.erb
+++ b/backend/app/views/spree/admin/trackers/index.html.erb
@@ -1,5 +1,3 @@
-
-
 <% content_for :page_title do %>
   <%= Spree.t(:analytics_trackers) %>
 <% end %>
@@ -42,7 +40,7 @@
   </table>
 <% else %>
   <div class="alert alert-warning">
-    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/tracker')) %>,
+    <%= Spree.t(:no_resource_found, resource: Spree::Tracker.model_name.human(count: :many)) %>,
     <%= link_to Spree.t(:add_one), new_object_url %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/users/addresses.html.erb
+++ b/backend/app/views/spree/admin/users/addresses.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= link_to "#{@user.email}", edit_admin_user_url(@user) %> / <%= Spree.t(:"editing_addresses") %>
+  <%= link_to "#{@user.email}", edit_admin_user_url(@user) %> / <%= Spree.t(:editing_resource, resource: Spree::Address.model_name.human(count: :many)) %>
 <% end %>
 
 <%= render :partial => 'spree/admin/users/sidebar', :locals => { :current => :address } %>

--- a/backend/app/views/spree/admin/users/index.html.erb
+++ b/backend/app/views/spree/admin/users/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:listing_users) %>
+  <%= Spree.t(:users) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/users/items.html.erb
+++ b/backend/app/views/spree/admin/users/items.html.erb
@@ -53,7 +53,7 @@
     </table>
   <% else %>
     <div class="alert alert-info no-objects-found">
-      <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/order')) %>,
+      <%= Spree.t(:no_resource_found, resource: Spree::Order.model_name.human(count: :many)) %>,
       <%= link_to Spree.t(:add_one), spree.new_admin_order_path %>!
     </div>
   <% end %>

--- a/backend/app/views/spree/admin/users/orders.html.erb
+++ b/backend/app/views/spree/admin/users/orders.html.erb
@@ -40,7 +40,7 @@
     </table>
   <% else %>
     <div class="alert alert-info no-objects-found">
-      <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/order')) %>,
+      <%= Spree.t(:no_resource_found, resource: Spree::Order.model_name.human(count: :many)) %>,
       <%= link_to Spree.t(:add_one), spree.new_admin_order_path %>!
     </div>
   <% end %>

--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -1,5 +1,3 @@
-
-
 <%= render :partial => 'spree/admin/shared/product_tabs', :locals => {:current => 'Variants'} %>
 
 <%# Place for new variant form %>
@@ -39,7 +37,7 @@
   </table>
 <% else %>
   <div class="no-objects-found alert alert-info">
-    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/variant')) %>,
+    <%= Spree.t(:no_resource_found, resource: Spree::Variant.model_name.human(count: :many)) %>,
     <%= link_to Spree.t(:add_one), spree.new_admin_product_variant_path(@product) %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/zones/edit.html.erb
+++ b/backend/app/views/spree/admin/zones/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_zone) %>
+  <%= Spree.t(:editing_resource, resource: Spree::Zone.model_name.human) %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @zone } %>

--- a/backend/app/views/spree/admin/zones/index.html.erb
+++ b/backend/app/views/spree/admin/zones/index.html.erb
@@ -1,5 +1,3 @@
-
-
 <% content_for :page_title do %>
   <%= Spree.t(:zones) %>
 <% end %>
@@ -40,7 +38,7 @@
   </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/zone')) %>,
+    <%= Spree.t(:no_resource_found, resource: Spree::Zone.model_name.human(count: :many)) %>,
     <%= link_to Spree.t(:add_one), spree.new_admin_zone_path %>!
   </div>
 <% end %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -231,6 +231,9 @@ en:
       spree/state:
         one: State
         other: States
+      spree/state_change:
+        one: State Change
+        other: State Changes
       spree/stock_movement:
         one: Stock Movement
         other: Stock Movements
@@ -469,37 +472,11 @@ en:
     back: Back
     back_end: Backend
     backordered: Backordered
-    back_to_adjustments_list: Back To Adjustments List
-    back_to_customer_return: Back To Customer Return
-    back_to_customer_return_list: Back To Customer Return List
-    back_to_images_list: Back To Images List
-    back_to_option_types_list: Back To Option Types List
-    back_to_orders_list: Back To Orders List
+    back_to_resource_list: 'Back To %{resource} List'
     back_to_payment: Back To Payment
-    back_to_payment_methods_list: Back To Payment Methods List
-    back_to_payments_list: Back To Payments List
-    back_to_products_list: Back To Products List
-    back_to_promotions_list: Back To Promotions List
-    back_to_promotion_categories_list: Back To Promotions Categories List
-    back_to_properties_list: Back To Properties List
-    back_to_prototypes_list: Back To Prototypes List
-    back_to_reports_list: Back To Reports List
-    back_to_refund_reason_list: Back To Refund Reason List
-    back_to_reimbursement_type_list: Back To Reimbursement Type List
     back_to_rma_reason_list: Back To RMA Reason List
-    back_to_shipping_categories: Back To Shipping Categories
-    back_to_shipping_categories_list: Back To Shipping Categories List
-    back_to_shipping_methods_list: Back To Shipping Methods List
-    back_to_states_list: Back To States List
-    back_to_stock_locations_list: Back to Stock Locations List
-    back_to_stock_movements_list: Back to Stock Movements List
-    back_to_stock_transfers_list: Back to Stock Transfers List
     back_to_store: Go Back To Store
-    back_to_tax_categories_list: Back To Tax Categories List
-    back_to_taxonomies_list: Back To Taxonomies List
-    back_to_trackers_list: Back To Trackers List
     back_to_users_list: Back To Users List
-    back_to_zones_list: Back To Zones List
     backorderable: Backorderable
     backorderable_default: Backorderable default
     backorders_allowed: backorders allowed
@@ -644,30 +621,9 @@ en:
     display_currency: Display currency
     doesnt_track_inventory: It doesnt track inventory
     edit: Edit
-    editing_country: Editing Country
-    editing_option_type: Editing Option Type
-    editing_payment_method: Editing Payment Method
-    editing_product: Editing Product
-    editing_promotion: Editing Promotion
-    editing_promotion_category: Editing Promotion Category
-    editing_property: Editing Property
-    editing_prototype: Editing Prototype
-    edit_refund_reason: Edit Refund Reason
-    editing_refund_reason: Editing Refund Reason
-    editing_reimbursement: Editing Reimbursement
-    editing_reimbursement_type: Editing Reimbursement Type
+    editing_resource: 'Editing %{resource}'
     editing_rma_reason: Editing RMA Reason
-    editing_shipping_category: Editing Shipping Category
-    editing_shipping_method: Editing Shipping Method
-    editing_state: Editing State
-    editing_stock_location: Editing Stock Location
-    editing_stock_movement: Editing Stock Movement
-    editing_tax_category: Editing Tax Category
-    editing_tax_rate: Editing Tax Rate
-    editing_tracker: Editing Tracker
-    editing_addresses: Editing Addresses
     editing_user: Editing User
-    editing_zone: Editing Zone
     eligibility_errors:
       messages:
         has_excluded_product: Your cart contains a product that prevents this coupon code from being applied.
@@ -817,12 +773,6 @@ en:
     lifetime_stats: Lifetime Stats
     line_item_adjustments: "Line item adjustments"
     list: List
-    listing_countries: Countries
-    listing_orders: Orders
-    listing_products: Products
-    listing_reports: Reports
-    listing_tax_categories: Tax Categories
-    listing_users: Users
     loading: Loading
     locale_changed: Locale Changed
     location: Location
@@ -900,24 +850,15 @@ en:
     new_zone: New Zone
     next: Next
     no_actions_added: No actions added
-    no_adjustments_found: No adjustments found
-    no_images_found: No images found
-    no_orders_found: No orders found
-    no_payment_methods_found: No payment methods found
     no_payment_found: No payment found
     no_pending_payments: No pending payments
     no_products_found: No products found
-    no_promotions_found: No promotions found
     no_results: No results
     no_rules_added: No rules added
-    no_resource_found: ! 'No %{resource} found'
+    no_resource_found: 'No %{resource} found'
     no_returns_found: No returns found
-    no_reimbursements_found: No reimbursements found
-    no_shipping_methods_found: No shipping methods found
     no_shipping_method_selected: No shipping method selected.
     no_state_changes: No state changes yet.
-    no_trackers_found: No Trackers Found
-    no_stock_locations_found: No stock locations found
     no_tracking_present: No tracking details provided.
     none: None
     none_selected: None Selected
@@ -1159,6 +1100,7 @@ en:
     remember_me: Remember me
     remove: Remove
     rename: Rename
+    report: Report
     reports: Reports
     resend: Resend
     reset_password: Reset my password
@@ -1304,6 +1246,7 @@ en:
       invalid: Invalid
       manual_intervention_required: Manual intervention required
       open: Open
+      order: Order
       on_hand: On hand
       payment: Payment
       pending: Pending


### PR DESCRIPTION
This removes duplicated i18n patterns for backend. Superseeds #5803

``` ruby
# old
Spree.t(:listing_countries) 
# new
# no locale key replacement, most views only used:
Spree.t(:countries) # these was replaced with:
Spree::Country.model_name.human(count: :many)

# old
Spree.t(:back_to_country_list)
# new - note this link not used consistent in backend.
Spree.t(:back_to_resource_list, resource: Spree::Country.model_name.human)

# old
Spree.t(:no_country_found)
# new - note this key was already partly used.
Spree.t(:no_resource_found, resource: Spree::Country.model_name.human)

# old
Spree.t(:editing_country)
# new
Spree.t(:editing_resource, resource: Spree::Country.model_name.human)
```

This removes 63 existing translations + adds ability for (new models) and Spree extensions to use same keys for their custom models.
