### PR TITLE
Use order’s completed_at to determine time since purchase

### DIFF
--- a/core/app/models/spree/return_item/eligibility_validator/default.rb
+++ b/core/app/models/spree/return_item/eligibility_validator/default.rb
@@ -2,6 +2,7 @@ module Spree
   class ReturnItem::EligibilityValidator::Default < Spree::ReturnItem::EligibilityValidator::BaseValidator
     class_attribute :permitted_eligibility_validators
     self.permitted_eligibility_validators = [
+                                              ReturnItem::EligibilityValidator::OrderCompleted,
                                               ReturnItem::EligibilityValidator::TimeSincePurchase,
                                               ReturnItem::EligibilityValidator::RMARequired,
                                               ReturnItem::EligibilityValidator::InventoryShipped,

--- a/core/app/models/spree/return_item/eligibility_validator/order_completed.rb
+++ b/core/app/models/spree/return_item/eligibility_validator/order_completed.rb
@@ -1,0 +1,16 @@
+module Spree
+  class ReturnItem::EligibilityValidator::OrderCompleted < Spree::ReturnItem::EligibilityValidator::BaseValidator
+    def eligible_for_return?
+      if @return_item.inventory_unit.order.completed?
+        return true
+      else
+        add_error(:order_not_completed, Spree.t('return_item_order_not_completed'))
+        return false
+      end
+    end
+
+    def requires_manual_intervention?
+      false
+    end
+  end
+end

--- a/core/app/models/spree/return_item/eligibility_validator/time_since_purchase.rb
+++ b/core/app/models/spree/return_item/eligibility_validator/time_since_purchase.rb
@@ -1,7 +1,7 @@
 module Spree
   class ReturnItem::EligibilityValidator::TimeSincePurchase < Spree::ReturnItem::EligibilityValidator::BaseValidator
     def eligible_for_return?
-      if (@return_item.inventory_unit.created_at + Spree::Config[:return_eligibility_number_of_days].days) > Time.now
+      if (@return_item.inventory_unit.order.completed_at + Spree::Config[:return_eligibility_number_of_days].days) > Time.now
         return true
       else
         add_error(:number_of_days, Spree.t('return_item_time_period_ineligible'))

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1172,6 +1172,7 @@ en:
     return_authorizations: Return Authorizations
     return_item_inventory_unit_ineligible: Return item's inventory unit must be shipped
     return_item_inventory_unit_reimbursed: Return item's inventory unit is already reimbursed
+    return_item_order_not_completed: Return item's order must be completed
     return_item_rma_ineligible: Return item requires an RMA
     return_item_time_period_ineligible: Return item is outside the eligible time period
     return_items: Return Items

--- a/core/spec/models/spree/customer_return_spec.rb
+++ b/core/spec/models/spree/customer_return_spec.rb
@@ -129,7 +129,7 @@ describe Spree::CustomerReturn, :type => :model do
   end
 
   context ".after_save" do
-    let(:inventory_unit)  { create(:inventory_unit, state: 'shipped') }
+    let(:inventory_unit)  { create(:inventory_unit, state: 'shipped', order: create(:shipped_order)) }
     let(:return_item)     { create(:return_item, inventory_unit: inventory_unit) }
 
     context "to the initial stock location" do

--- a/core/spec/models/spree/return_item/eligibility_validator/order_completed_spec.rb
+++ b/core/spec/models/spree/return_item/eligibility_validator/order_completed_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe Spree::ReturnItem::EligibilityValidator::OrderCompleted do
+  let(:inventory_unit) { create(:inventory_unit, order: order) }
+  let(:return_item)    { create(:return_item, inventory_unit: inventory_unit) }
+  let(:validator)      { Spree::ReturnItem::EligibilityValidator::OrderCompleted.new(return_item) }
+
+  describe "#eligible_for_return?" do
+    subject { validator.eligible_for_return? }
+
+    context "the order was completed" do
+      let(:order) { create(:completed_order_with_totals) }
+
+      it "returns true" do
+        expect(subject).to be true
+      end
+    end
+
+    context "the order is not completed" do
+      let(:order) { create(:order) }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+
+      it "sets an error" do
+        subject
+        expect(validator.errors[:order_not_completed]).to eq Spree.t('return_item_order_not_completed')
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/return_item/eligibility_validator/time_since_purchase_spec.rb
+++ b/core/spec/models/spree/return_item/eligibility_validator/time_since_purchase_spec.rb
@@ -1,24 +1,25 @@
 require 'spec_helper'
 
 describe Spree::ReturnItem::EligibilityValidator::TimeSincePurchase, :type => :model do
-  let(:return_item) { create(:return_item) }
-  let(:validator) { Spree::ReturnItem::EligibilityValidator::TimeSincePurchase.new(return_item) }
+  let(:inventory_unit) { create(:inventory_unit, order: create(:shipped_order)) }
+  let(:return_item)    { create(:return_item, inventory_unit: inventory_unit) }
+  let(:validator)      { Spree::ReturnItem::EligibilityValidator::TimeSincePurchase.new(return_item) }
 
   describe "#eligible_for_return?" do
     subject { validator.eligible_for_return? }
 
     context "it is within the return timeframe" do
       it "returns true" do
-        created_at = return_item.inventory_unit.created_at - (Spree::Config[:return_eligibility_number_of_days].days / 2)
-        allow(return_item.inventory_unit).to receive(:created_at).and_return(created_at)
+        completed_at = return_item.inventory_unit.order.completed_at - (Spree::Config[:return_eligibility_number_of_days].days / 2)
+        return_item.inventory_unit.order.update_attributes(completed_at: completed_at)
         expect(subject).to be true
       end
     end
 
     context "it is past the return timeframe" do
       before do
-        created_at = return_item.inventory_unit.created_at - Spree::Config[:return_eligibility_number_of_days].days - 1.day
-        allow(return_item.inventory_unit).to receive(:created_at).and_return(created_at)
+        completed_at = return_item.inventory_unit.order.completed_at - Spree::Config[:return_eligibility_number_of_days].days - 1.day
+        return_item.inventory_unit.order.update_attributes(completed_at: completed_at)
       end
 
       it "returns false" do

--- a/core/spec/models/spree/return_item_spec.rb
+++ b/core/spec/models/spree/return_item_spec.rb
@@ -153,7 +153,8 @@ describe Spree::ReturnItem, :type => :model do
   end
 
   describe "#receive" do
-    let(:return_item) { create(:return_item, reception_status: status) }
+    let(:inventory_unit) { create(:inventory_unit, order: create(:shipped_order)) }
+    let(:return_item)    { create(:return_item, reception_status: status, inventory_unit: inventory_unit) }
 
     subject { return_item.receive! }
 


### PR DESCRIPTION
- Added another eligibility validator that ensures an order is completed before running any of the other validators
- Changed the TimeSincePurchase validator to check the order’s completed_at date instead of the inventory_unit’s created_at date. This fixes an issue where the time since purchase of an inventory unit that is part of an exchange shipment would be calculated as the time since the exchange was created instead of the time since the original purchase was made.
