### PR TITLE
Show error message when adding items to order in admin fails

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/line_items_on_order_edit.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/line_items_on_order_edit.js.erb
@@ -36,6 +36,8 @@ adjustLineItems = function(order_number, variant_id, quantity){
     }).done(function( msg ) {
         window.Spree.advanceOrder();
         window.location.reload();
+    }).fail(function(msg) {
+        alert(msg.responseJSON.message)
     });
 
 }

--- a/backend/app/assets/javascripts/spree/backend/shipments.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js.erb
@@ -157,6 +157,8 @@ adjustShipmentItems = function(shipment_number, variant_id, quantity){
         data: { variant_id: variant_id, quantity: new_quantity }
       }).done(function( msg ) {
         window.location.reload();
+      }).fail(function(msg) {
+        alert(msg.responseJSON.message)
       });
     }
 }

--- a/backend/spec/features/admin/orders/new_order_spec.rb
+++ b/backend/spec/features/admin/orders/new_order_spec.rb
@@ -22,6 +22,7 @@ describe "New Order", :type => :feature do
   it "completes new order succesfully without using the cart", js: true do
     select2_search product.name, from: Spree.t(:name_or_sku)
     click_icon :add
+    wait_for_ajax
     click_on "Customer"
 
     within "#select-customer" do


### PR DESCRIPTION
If an error occurs when admins are adding items to orders, there is no indication of what went wrong. This will present a defined message from the response to admins so they know what happened.
