### PR TITLE
EagerLoadPolymorphicError in ImagesController

### DIFF
--- a/backend/app/controllers/spree/admin/images_controller.rb
+++ b/backend/app/controllers/spree/admin/images_controller.rb
@@ -36,13 +36,13 @@ module Spree
 
       def variant_index_includes
         [
-          variant_images: [viewable: { option_values: :option_type }]
+            :variant_images
         ]
       end
 
       def variant_edit_includes
         [
-          variants_including_master: { option_values: :option_type, images: :viewable }
+            variants_including_master: [{option_values: :option_type}, :images]
         ]
       end
     end


### PR DESCRIPTION
Variants has_many Images using polymorphic relationship.
A polymorphic relationship can't just use includes or joins directly since it require additional join condition.
Besides, I didn't see any n+1 query in my log which may cause performance issue.
It load one product, and all variants and images as well.

ActiveRecord::EagerLoadPolymorphicError in Spree::Admin::ImagesController#edit

Started GET "/admin/products/wt-13/images/28/edit" for 127.0.0.1 at 2014-12-23 14:53:27 +0800
Processing by Spree::Admin::ImagesController#edit as HTML
  Parameters: {"product_id"=>"wt-13", "id"=>"28"}
  Spree::User Load (0.4ms)  SELECT  `refinery_users`.\* FROM `refinery_users`  WHERE `refinery_users`.`id` = 1  ORDER BY `refinery_users`.`id` ASC LIMIT 1
   (0.5ms)  SELECT COUNT(_) FROM `spree_roles` INNER JOIN `spree_roles_users` ON `spree_roles`.`id` = `spree_roles_users`.`role_id` WHERE `spree_roles_users`.`user_id` = 1 AND `spree_roles`.`name` = 'admin'
   (0.4ms)  SELECT COUNT(_) FROM `spree_roles` INNER JOIN `spree_roles_users` ON `spree_roles`.`id` = `spree_roles_users`.`role_id` WHERE `spree_roles_users`.`user_id` = 1 AND `spree_roles`.`name` = 'sales'
  Spree::Image Load (0.5ms)  SELECT  `spree_assets`.\* FROM `spree_assets`  WHERE `spree_assets`.`type` IN ('Spree::Image') AND `spree_assets`.`id` = 28 LIMIT 1
Completed 500 Internal Server Error in 98ms

ActiveRecord::EagerLoadPolymorphicError (Cannot eagerly load the polymorphic association :viewable):
  polyamorous (1.1.0) lib/polyamorous/activerecord_4.1/join_dependency.rb:36:in `block in build_with_polymorphism'
  polyamorous (1.1.0) lib/polyamorous/activerecord_4.1/join_dependency.rb:21:in`each'
  polyamorous (1.1.0) lib/polyamorous/activerecord_4.1/join_dependency.rb:21:in `map'
  polyamorous (1.1.0) lib/polyamorous/activerecord_4.1/join_dependency.rb:21:in`build_with_polymorphism'
  polyamorous (1.1.0) lib/polyamorous/activerecord_4.1/join_dependency.rb:39:in `block in build_with_polymorphism'
  polyamorous (1.1.0) lib/polyamorous/activerecord_4.1/join_dependency.rb:21:in`each'
  polyamorous (1.1.0) lib/polyamorous/activerecord_4.1/join_dependency.rb:21:in `map'
  polyamorous (1.1.0) lib/polyamorous/activerecord_4.1/join_dependency.rb:21:in`build_with_polymorphism'
  polyamorous (1.1.0) lib/polyamorous/activerecord_4.1/join_dependency.rb:39:in `block in build_with_polymorphism'
  polyamorous (1.1.0) lib/polyamorous/activerecord_4.1/join_dependency.rb:21:in`each'
  polyamorous (1.1.0) lib/polyamorous/activerecord_4.1/join_dependency.rb:21:in `map'
  polyamorous (1.1.0) lib/polyamorous/activerecord_4.1/join_dependency.rb:21:in`build_with_polymorphism'
  activerecord (4.1.8) lib/active_record/associations/join_dependency.rb:99:in `initialize'
