### PR TITLE
Update payment_total on void.

### DIFF
--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -205,7 +205,7 @@ module Spree
       end
 
       def update_order
-        if self.completed?
+        if completed? || void?
           order.updater.update_payment_total
         end
 

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -477,6 +477,21 @@ describe Spree::Payment, :type => :model do
       end
     end
 
+    context 'when the payment was completed but now void' do
+      let(:payment) do
+        Spree::Payment.create(
+          amount: 100,
+          order: order,
+          state: 'completed'
+        )
+      end
+
+      it 'updates order payment total' do
+        payment.void
+        expect(order.payment_total).to eq 0
+      end
+    end
+
     context "completed orders" do
       before { allow(order).to receive_messages completed?: true }
 


### PR DESCRIPTION
Currently an orders payment total is not updated when a payment is
voided. This leads to a variety of things which are not correct. If $100
is paid on an order, then that payment is voided, it will reset the
payment_total to $0, rather than leaving it at $100.

Fixes #5822
