### PR TITLE
add hook for additional eager load relationship

### DIFF
--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -70,6 +70,7 @@ module Spree
     preference :show_raw_product_description, :boolean, :default => false
     preference :tax_using_ship_address, :boolean, default: true
     preference :track_inventory_levels, :boolean, default: true # Determines whether to track on_hand values for variants / products.
+    preference :additional_eagerload_scopes, :default => []
 
     # Default mail headers settings
     preference :send_core_emails, :boolean, :default => true

--- a/core/lib/spree/core/search/base.rb
+++ b/core/lib/spree/core/search/base.rb
@@ -37,7 +37,16 @@ module Spree
             base_scope = get_products_conditions_for(base_scope, keywords)
             base_scope = add_search_scopes(base_scope)
             base_scope = add_eagerload_scopes(base_scope)
+            base_scope = add_additional_eagerload_scopes(base_scope)
             base_scope
+          end
+
+          def add_additional_eagerload_scopes scope
+            if Spree::Config[:additional_eagerload_scopes].blank?
+              scope
+            else
+              scope.includes(Spree::Config[:additional_eagerload_scopes])
+            end
           end
 
           def add_eagerload_scopes scope


### PR DESCRIPTION
For spree extensions, sometimes you will add customized relationship to product.
However, there is not a hook for extensions to add "includes" eager load statement to avoid n+1 query issue.
For example, if I include spree_i18n extension without override anything and go to /products. 
It will look up translations for each products:

```
  Spree::Product::Translation Load (0.4ms)  SELECT `spree_product_translations`.* FROM `spree_product_translations`  WHERE `spree_product_translations`.`spree_product_id` = 5
  Spree::Product::Translation Load (0.4ms)  SELECT `spree_product_translations`.* FROM `spree_product_translations`  WHERE `spree_product_translations`.`spree_product_id` = 4
... etc
```

That's pretty bad for performance. So I add a preference "additional_eagerload_scopes" and a hook for base_scope. You can add your dynamic eager load relationships.

For spree_i18n, I can just make a initializer like this:

```
Spree::Config[:additional_eagerload_scopes] ||= []
Spree::Config[:additional_eagerload_scopes].push(:translations) if defined?(SpreeI18n)
```

and SQL will become eager load one:

```
Spree::Product::Translation Load (0.5ms)  SELECT `spree_product_translations`.* FROM `spree_product_translations`  WHERE `spree_product_translations`.`spree_product_id` IN (5, 4, 26, 2, 3, 13, 28, 27, 17, 8, 9, 14)
```
