### PR TITLE
Refactor sales_total report, better performance when having many orders

### DIFF
--- a/backend/app/controllers/spree/admin/reports_controller.rb
+++ b/backend/app/controllers/spree/admin/reports_controller.rb
@@ -38,8 +38,6 @@ module Spree
           params[:q][:completed_at_lt] = Time.zone.parse(params[:q][:completed_at_lt]).end_of_day rescue ""
         end
 
-        params[:q][:s] ||= "completed_at desc"
-
         @search = Order.complete.ransack(params[:q])
         @orders = @search.result
         @totals = {}

--- a/backend/app/controllers/spree/admin/reports_controller.rb
+++ b/backend/app/controllers/spree/admin/reports_controller.rb
@@ -50,7 +50,11 @@ module Spree
         currencies = item_total.keys
 
         currencies.each do |currency|
-          @totals[currency] = { item_total: Spree::Money.new(item_total[currency], currency: currency).money, adjustment_total: Spree::Money.new(adjustment_total[currency], currency: currency).money, sales_total: Spree::Money.new(sales_total[currency], currency: currency).money }
+          @totals[currency] = {
+            item_total: Spree::Money.new(item_total[currency], currency: currency).money,
+            adjustment_total: Spree::Money.new(adjustment_total[currency], currency: currency).money,
+            sales_total: Spree::Money.new(sales_total[currency], currency: currency).money
+          }
         end
       end
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -157,10 +157,6 @@ module Spree
       line_items.to_a.sum(&:pre_tax_amount)
     end
 
-    def currency
-      self[:currency] || Spree::Config[:currency]
-    end
-
     def shipping_discount
       shipment_adjustments.eligible.sum(:amount) * - 1
     end

--- a/core/db/migrate/20150108191235_update_orders_from_nil_to_default_currency.rb
+++ b/core/db/migrate/20150108191235_update_orders_from_nil_to_default_currency.rb
@@ -1,0 +1,8 @@
+class UpdateOrdersFromNilToDefaultCurrency < ActiveRecord::Migration
+  def up
+    Spree::Order.where(currency: nil).update_all(currency: Spree::Config[:currency])
+  end
+
+  def down
+  end
+end


### PR DESCRIPTION
Currently the sales report performs really slow when having a big number of orders (+1000). Basically because it's iterating through each order and adding each value.

This uses the SUM sql operator to boost performance.
