### PR TITLE
Remove persist_invalid from order

### DIFF
--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -30,7 +30,6 @@ module Spree
     attr_accessor :source_attributes, :request_env
 
     after_initialize :build_source
-    after_rollback :persist_invalid
 
     validates :amount, numericality: true
 
@@ -53,12 +52,6 @@ module Spree
     # transaction_id is much easier to understand
     def transaction_id
       response_code
-    end
-
-    def persist_invalid
-      return unless ['failed', 'invalid'].include?(state)
-      state_will_change!
-      save
     end
 
     # order state machine (see http://github.com/pluginaweek/state_machine/tree/master for details)

--- a/core/spec/lib/search/base_spec.rb
+++ b/core/spec/lib/search/base_spec.rb
@@ -4,9 +4,6 @@ describe Spree::Core::Search::Base do
 
   before do
     include Spree::Core::ProductFilters
-    Spree::Product.delete_all # FIXME product leaks
-    Spree::Taxon.destroy_all
-
     @taxon = create(:taxon, name: "Ruby on Rails")
 
     @product1 = create(:product, name: "RoR Mug", price: 9.00)

--- a/core/spec/lib/spree/core/controller_helpers/order_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/order_spec.rb
@@ -24,7 +24,6 @@ describe Spree::Core::ControllerHelpers::Order, type: :controller do
 
   describe '#current_order' do
     before {
-      Spree::Order.destroy_all # TODO data is leaking between specs as database_cleaner or rspec 3 was broken in Rails 4.1.6 & 4.0.10
       allow(controller).to receive_messages(current_store: store)
       allow(controller).to receive_messages(try_spree_current_user: user)
     }

--- a/core/spec/models/spree/order/tax_spec.rb
+++ b/core/spec/models/spree/order/tax_spec.rb
@@ -11,8 +11,6 @@ module Spree
       let(:zone) { create :zone }
 
       context "when no zones exist" do
-        before { Spree::Zone.destroy_all }
-
         it "should return nil" do
           expect(order.tax_zone).to be_nil
         end

--- a/core/spec/models/spree/payment_method_spec.rb
+++ b/core/spec/models/spree/payment_method_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 describe Spree::PaymentMethod, :type => :model do
   describe "#available" do
     before do
-      Spree::PaymentMethod.destroy_all # TODO data is leaking between specs as database_cleaner or rspec 3 was broken in Rails 4.1.6 & 4.0.10
       [nil, 'both', 'front_end', 'back_end'].each do |display_on|
         Spree::Gateway::Test.create(
           :name => 'Display Both',

--- a/core/spec/models/spree/state_spec.rb
+++ b/core/spec/models/spree/state_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
 describe Spree::State, :type => :model do
-  before(:all) do
-    Spree::State.destroy_all
-  end
-
   it "can find a state by name or abbr" do
     state = create(:state, :name => "California", :abbr => "CA")
     expect(Spree::State.find_all_by_name_or_abbr("California")).to include(state)

--- a/core/spec/models/spree/stock/quantifier_spec.rb
+++ b/core/spec/models/spree/stock/quantifier_spec.rb
@@ -12,8 +12,6 @@ module Spree
   module Stock
     describe Quantifier, :type => :model do
 
-      before(:all) { Spree::StockLocation.destroy_all } #FIXME leaky database
-
       let!(:stock_location) { create :stock_location_with_items  }
       let!(:stock_item) { stock_location.stock_items.order(:id).first }
 


### PR DESCRIPTION
This plugs up our "leaky database". You'll also notice no test removals.

Also no lines of code added at all, for that matter.
