### PR TITLE
Clickable ransack filters

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/admin.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/admin.js.erb
@@ -112,6 +112,33 @@ jQuery(function($) {
     }
   });
 
+  // Clickable ransack filters
+  $(".js-add-filter").click(function() {
+    var ransack_field = $(this).data("ransack-field");
+    var ransack_value = $(this).data("ransack-value");
+
+    $("#" + ransack_field).val(ransack_value);
+    $("#table-filter form").submit();
+  });
+
+  $(document).on("click", ".js-delete-filter", function() {
+    var ransack_field = $(this).parents(".js-filter").data("ransack-field");
+
+    $("#" + ransack_field).val('');
+    $("#table-filter form").submit();
+  });
+
+  $(".js-filterable").each(function(){
+    if($(this).val()){
+      var ransack_field = $(this).attr("id");
+      var ransack_value = $(this).val();
+      var filter = '<span class="js-filter label label-default" data-ransack-field="' + ransack_field + '">' + ransack_value + '<span class="icon icon-delete js-delete-filter"></span></span>';
+
+      $(".js-filters").show();
+      $(".js-filters").append(filter);
+    }
+  });
+
   // Enable sidebar toggle
   $("[data-toggle='offcanvas']").click(function(e) {
     e.preventDefault();

--- a/backend/app/assets/stylesheets/spree/backend/components/_tables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_tables.scss
@@ -23,3 +23,20 @@ table.table {
     }
   }
 }
+
+.table-active-filters {
+  display: none;
+  margin: -0.5em 0 0.9em 0;
+  .label {
+    margin-right: 0.5em;
+    font-size: 85%;
+    &:hover {
+      opacity: 0.8;
+    }
+    span.icon {
+      margin-left: 0.4em;
+      font-size: 75%;
+      cursor: pointer;
+    }
+  }
+}

--- a/backend/app/assets/stylesheets/spree/backend/components/_tables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_tables.scss
@@ -19,6 +19,15 @@ table.table {
     tr {
       td {
         vertical-align: middle;
+        .filterable {
+          font-size: 0.8em;
+          margin-left: 0.2em;
+          color: white; // hidden, but space is reserved for the icon
+          cursor: pointer;
+        }
+      }
+      &:hover td .filterable {
+        color: #666;
       }
     }
   }
@@ -34,8 +43,8 @@ table.table {
       opacity: 0.8;
     }
     span.icon {
-      margin-left: 0.4em;
-      font-size: 75%;
+      margin: 0.3em 0 0 0.6em;
+      font-size: 80%;
       cursor: pointer;
     }
   }

--- a/backend/app/assets/stylesheets/spree/backend/shared/_base.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_base.scss
@@ -9,3 +9,7 @@ body {
 .is-hidden {
   display: none;
 }
+
+.no-padding-bottom {
+  padding-bottom: 0;
+}

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -11,10 +11,10 @@
 
     <%= search_form_for [:admin, @search] do |f| %>
       <div class="row">
-        <div class="date-range-filter col-md-6">
+        <div class="date-range-filter col-md-8">
           <div class="form-group">
             <%= label_tag :q_created_at_gt, Spree.t(:date_range) %>
-            <div class="row">
+            <div class="row no-padding-bottom">
               <div class="col-md-6">
                 <div class="input-group">
                   <%= f.text_field :created_at_gt, :class => 'datepicker datepicker-from form-control', :value => params[:q][:created_at_gt], :placeholder => Spree.t(:start) %>
@@ -36,14 +36,18 @@
           </div>
         </div>
 
-        <div class="col-md-3">
+        <div class="col-md-4">
           <div class="form-group">
             <%= label_tag :q_number_cont, Spree.t(:order_number, :number => '') %>
             <%= f.text_field :number_cont, class: 'form-control js-quick-search-target' %>
           </div>
         </div>
 
-        <div class="col-md-3">
+      </div>
+
+      <div class="row">
+
+        <div class="col-md-4">
           <div class="form-group">
             <%= label_tag :q_state_eq, Spree.t(:status) %>
             <%= f.select :state_eq, Spree::Order.state_machines[:state].states.collect {|s| [Spree.t("order_state.#{s.name}"), s.value]}, {:include_blank => true}, :class => 'select2 js-filterable' %>
@@ -54,13 +58,6 @@
           <div class="form-group">
             <%= label_tag :q_payment_state_eq, Spree.t(:payment_state) %>
             <%= f.text_field :payment_state_eq, class: 'form-control js-filterable' %>
-          </div>
-        </div>
-
-        <div class="col-md-4">
-          <div class="form-group">
-            <%= label_tag :q_shipment_state_eq, Spree.t(:shipment_state) %>
-            <%= f.text_field :shipment_state_eq, class: 'form-control js-filterable' %>
           </div>
         </div>
 

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -8,10 +8,10 @@
 
 <% content_for :table_filter do %>
   <div data-hook="admin_orders_index_search">
-    
+
     <%= search_form_for [:admin, @search] do |f| %>
       <div class="row">
-        
+
         <div class="date-range-filter col-md-6">
           <div class="form-group">
             <%= label_tag :q_created_at_gt, Spree.t(:date_range) %>
@@ -23,7 +23,7 @@
                     <i class="icon icon-calendar"></i>
                   </span>
                 </div>
-                
+
               </div>
               <div class="col-md-6">
                 <div class="input-group">
@@ -47,14 +47,28 @@
         <div class="col-md-3">
           <div class="form-group">
             <%= label_tag :q_state_eq, Spree.t(:status) %>
-            <%= f.select :state_eq, Spree::Order.state_machines[:state].states.collect {|s| [Spree.t("order_state.#{s.name}"), s.value]}, {:include_blank => true}, :class => 'select2' %>
+            <%= f.select :state_eq, Spree::Order.state_machines[:state].states.collect {|s| [Spree.t("order_state.#{s.name}"), s.value]}, {:include_blank => true}, :class => 'select2 js-filterable' %>
+          </div>
+        </div>
+
+        <div class="col-md-4">
+          <div class="form-group">
+            <%= label_tag :q_payment_state_eq, Spree.t(:payment_state) %>
+            <%= f.text_field :payment_state_eq, class: 'form-control js-filterable' %>
+          </div>
+        </div>
+
+        <div class="col-md-4">
+          <div class="form-group">
+            <%= label_tag :q_shipment_state_eq, Spree.t(:shipment_state) %>
+            <%= f.text_field :shipment_state_eq, class: 'form-control js-filterable' %>
           </div>
         </div>
 
       </div>
 
       <div class="row">
-        
+
         <div class="col-md-4">
           <div class="form-group">
             <%= label_tag :q_bill_address_firstname_start, Spree.t(:first_name_begins_with) %>
@@ -72,7 +86,7 @@
         <div class="col-md-4">
           <div class="form-group">
             <%= label_tag :q_email_cont, Spree.t(:email) %>
-            <%= f.text_field :email_cont, class: 'form-control' %>
+            <%= f.text_field :email_cont, class: 'form-control js-filterable' %>
           </div>
         </div>
 
@@ -97,14 +111,14 @@
         <div class="col-md-4">
 
           <div class="form-group">
-            
+
             <div class="checkbox">
               <%= label_tag 'q_completed_at_not_null' do %>
                 <%= f.check_box :completed_at_not_null, {:checked => @show_only_completed}, '1', '0' %>
                 <%= Spree.t(:show_only_complete_orders) %>
               <% end %>
             </div>
-            
+
             <div class="checkbox">
               <%= label_tag 'q_considered_risky_eq' do %>
                 <%= f.check_box :considered_risky_eq, {:checked => (params[:q][:considered_risky_eq] == '1')}, '1', '' %>
@@ -162,20 +176,19 @@
           </span>
         </td>
         <td>
-          <span class="label label-<%= order.state.downcase %>">
-            <%= Spree.t("order_state.#{order.state.downcase}") %>
-          </span>
+          <span class="label label-<%= order.state.downcase %>"><%= Spree.t("order_state.#{order.state.downcase}") %></span>
+          <span class="icon icon-filter filterable js-add-filter" data-ransack-field="q_state_eq" data-ransack-value="<%= order.state %>"></span>
         </td>
         <td>
-          <span class="label label-<%= order.payment_state %>">
-            <%= link_to Spree.t("payment_states.#{order.payment_state}"), admin_order_payments_path(order) if order.payment_state %>
-          </span>
+          <% if order.payment_state %>
+            <span class="label label-<%= order.payment_state %>"><%= link_to Spree.t("payment_states.#{order.payment_state}"), admin_order_payments_path(order) %></span>
+            <span class="icon icon-filter filterable js-add-filter" data-ransack-field="q_payment_state_eq" data-ransack-value="<%= order.payment_state %>"></span>
+          <% end %>
         </td>
         <% if Spree::Order.checkout_step_names.include?(:delivery) %>
           <td>
-            <span class="label label-<%= order.shipment_state %>">
-              <%= Spree.t("shipment_states.#{order.shipment_state}") if order.shipment_state %>
-            </span>
+            <span class="label label-<%= order.shipment_state %>"><%= Spree.t("shipment_states.#{order.shipment_state}") if order.shipment_state %></span>
+            <span class="icon icon-filter filterable js-add-filter" data-ransack-field="q_shipment_state_eq" data-ransack-value="<%= order.shipment_state %>"></span>
           </td>
         <% end %>
         <td>
@@ -183,6 +196,9 @@
             <%= link_to order.email, edit_admin_user_path(order.user) %>
           <% else %>
             <%= mail_to order.email %>
+          <% end %>
+          <% if order.user || order.email %>
+            <span class="icon icon-filter filterable js-add-filter" data-ransack-field="q_email_cont" data-ransack-value="<%= order.email %>"></span>
           <% end %>
         </td>
         <td><%= order.display_total.to_html %></td>

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -11,7 +11,6 @@
 
     <%= search_form_for [:admin, @search] do |f| %>
       <div class="row">
-
         <div class="date-range-filter col-md-6">
           <div class="form-group">
             <%= label_tag :q_created_at_gt, Spree.t(:date_range) %>
@@ -55,6 +54,13 @@
           <div class="form-group">
             <%= label_tag :q_payment_state_eq, Spree.t(:payment_state) %>
             <%= f.text_field :payment_state_eq, class: 'form-control js-filterable' %>
+          </div>
+        </div>
+
+        <div class="col-md-4">
+          <div class="form-group">
+            <%= label_tag :q_shipment_state_eq, Spree.t(:shipment_state) %>
+            <%= f.text_field :shipment_state_eq, class: 'form-control js-filterable' %>
           </div>
         </div>
 

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -190,8 +190,10 @@
         </td>
         <% if Spree::Order.checkout_step_names.include?(:delivery) %>
           <td>
-            <span class="label label-<%= order.shipment_state %>"><%= Spree.t("shipment_states.#{order.shipment_state}") if order.shipment_state %></span>
-            <span class="icon icon-filter filterable js-add-filter" data-ransack-field="q_shipment_state_eq" data-ransack-value="<%= order.shipment_state %>"></span>
+            <% if order.shipment_state %>
+              <span class="label label-<%= order.shipment_state %>"><%= Spree.t("shipment_states.#{order.shipment_state}") %></span>
+              <span class="icon icon-filter filterable js-add-filter" data-ransack-field="q_shipment_state_eq" data-ransack-value="<%= order.shipment_state %>"></span>
+            <% end %>
           </td>
         <% end %>
         <td>

--- a/backend/app/views/spree/admin/shared/_table_filter.html.erb
+++ b/backend/app/views/spree/admin/shared/_table_filter.html.erb
@@ -19,4 +19,6 @@
       <% end %>
     </div>
   </div>
+
+  <div class="table-active-filters js-filters"></div>
 <% end %>

--- a/backend/spec/features/admin/orders/listing_spec.rb
+++ b/backend/spec/features/admin/orders/listing_spec.rb
@@ -145,5 +145,19 @@ describe "Orders Listing", type: :feature, js: true do
         within("table#listing_orders") { expect(page).not_to have_content("R200") }
       end
     end
+
+    it "should be able to apply a ransack filter by clicking a quickfilter icon" do
+      label_pending = page.find '.label-pending'
+      parent_td = label_pending.find(:xpath, '..')
+
+      # Click the quick filter Pending for order #R100
+      within(parent_td) do
+        find('.js-add-filter').click
+      end
+
+      expect(page).to have_content("R100")
+      expect(page).not_to have_content("R200")
+    end
+
   end
 end


### PR DESCRIPTION
With some javascript and minor html changes I created clickable ransack filters.
By hovering a table row filters show up behind the filterable data.
When you click it the filters are added trough javascript (it just submits the search form).
You can remove the filters by just delete them from the active filters.
Please let me know what you think about this, if this needs any specs please let me know.

![screen_shot_2014-12-26_at_18_28_59](https://cloud.githubusercontent.com/assets/106335/5558572/2e42baf2-8d2d-11e4-8060-90b3239232f6.png)
