### PR TITLE
Do not trigger full order update when fulfilling a backordered order

### DIFF
--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -21,7 +21,7 @@ module Spree
       event :fill_backorder do
         transition to: :on_hand, from: :backordered
       end
-      after_transition on: :fill_backorder, do: :update_order
+      after_transition on: :fill_backorder, do: :fulfill_order
 
       event :ship do
         transition to: :shipped, if: :allow_ship?
@@ -69,9 +69,9 @@ module Spree
         Spree::Config[:allow_backorder_shipping] || self.on_hand?
       end
 
-      def update_order
+      def fulfill_order
         self.reload
-        order.update!
+        order.fulfill!
       end
   end
 end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -356,6 +356,12 @@ module Spree
       consider_risk
     end
 
+    def fulfill!
+      shipments.each { |shipment| shipment.update!(self) if shipment.persisted? }
+      updater.update_shipment_state
+      save!
+    end
+
     def deliver_order_confirmation_email
       OrderMailer.confirm_email(self.id).deliver
       update_column(:confirmation_delivered, true)

--- a/core/spec/models/spree/inventory_unit_spec.rb
+++ b/core/spec/models/spree/inventory_unit_spec.rb
@@ -6,28 +6,31 @@ describe Spree::InventoryUnit do
 
   context "#backordered_for_stock_item" do
     let(:order) do
-      order = create(:order)
-      order.state = 'complete'
+      order = create(:order, state: 'complete', ship_address: create(:ship_address))
       order.completed_at = Time.now
+      create(:shipment, order: order, stock_location: stock_location)
+      order.shipments.reload
+      create(:line_item, order: order, variant: stock_item.variant)
+      order.line_items.reload
       order.tap(&:save!)
     end
 
     let(:shipment) do
-      shipment = Spree::Shipment.new
-      shipment.stock_location = stock_location
-      shipment.shipping_methods << create(:shipping_method)
-      shipment.order = order
-      # We don't care about this in this test
-      shipment.stub(:ensure_correct_adjustment)
-      shipment.tap(&:save!)
+      order.shipments.first
+    end
+
+    let(:shipping_method) do
+      shipment.shipping_methods.first
     end
 
     let!(:unit) do
-      unit = shipment.inventory_units.build
+      unit = shipment.inventory_units.first
       unit.state = 'backordered'
-      unit.variant_id = stock_item.variant.id
-      unit.order_id = order.id
       unit.tap(&:save!)
+    end
+
+    before do
+      stock_item.set_count_on_hand(-2)
     end
 
     # Regression for #3066
@@ -56,6 +59,13 @@ describe Spree::InventoryUnit do
       other_variant_unit.save!
 
       Spree::InventoryUnit.backordered_for_stock_item(stock_item).should_not include(other_variant_unit)
+    end
+
+    it "does not change shipping cost when fulfilling the order" do
+      current_shipment_cost = shipment.cost
+      shipping_method.calculator.set_preference(:amount, current_shipment_cost + 5.0)
+      stock_item.set_count_on_hand(0)
+      expect(shipment.reload.cost).to eq(current_shipment_cost)
     end
 
     context "other shipments" do


### PR DESCRIPTION
This PR fixes the following issue:
1. Place an order with two products and both are in backordered. Make sure there was shipping cost. As shown below.
   ![screen shot 2014-12-30 at 1 40 46 pm](https://cloud.githubusercontent.com/assets/5523239/5583320/55d01b86-902b-11e4-8605-1dc2c7e76383.png)
2. Update the shipping method with higher cost ($5 -> $8 in this test).
3. Increase product1 inventory to fill the backorder. Now the shipping cost for the order is changed to $8 (shown belown).
   ![screen shot 2014-12-30 at 1 41 43 pm](https://cloud.githubusercontent.com/assets/5523239/5583341/a41ec116-902b-11e4-88f1-e3bad7101073.png)
4. Increase product2 inventory to fulfill the whole order. Now a paid order becomes balance due because shipping cost is changed.
   ![screen shot 2014-12-30 at 1 42 09 pm](https://cloud.githubusercontent.com/assets/5523239/5583351/d4bce60e-902b-11e4-9d75-51b05fdf8966.png)

This is really a bad user experience. The root cause is that when we fulfill an order we do order.update! and it refreshes the shipping rates and updated the shipping cost. It was introduced by: https://github.com/spree/spree/commit/2e220b2f5eb20c9534ee6c17906ec09ca72fcb85 When an order is changed (quantity increased, split, etc.) we do need to recalculate shipping cost. But when an order is fulfilled simply by increasing the inventory we shouldn't do full order update. This PR is trying to address that.
