### PR TITLE
Remove a duplication in api routes

### DIFF
--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -63,7 +63,7 @@ Spree::Core::Engine.add_routes do
     resources :option_values
 
     get '/orders/mine', to: 'orders#mine', as: 'my_orders'
-    get "/orders/current", to: "orders#current", to: "orders#current", as: "current_order"
+    get "/orders/current", to: "orders#current", as: "current_order"
 
     resources :orders, concerns: :order_routes
 


### PR DESCRIPTION
``` ruby
-    get "/orders/current", to: "orders#current", to: "orders#current", as: "current_order"
+    get "/orders/current", to: "orders#current", as: "current_order"
```
