### PR TITLE
Fix payment sample card for 2015

### DIFF
--- a/sample/db/samples/payments.rb
+++ b/sample/db/samples/payments.rb
@@ -12,7 +12,7 @@ end
 # reference it as such. Make it explicit here that this table has been renamed.
 Spree::CreditCard.table_name = 'spree_credit_cards'
 
-creditcard = Spree::CreditCard.create(:cc_type => 'visa', :month => 12, :year => 2014, :last_digits => '1111',
+creditcard = Spree::CreditCard.create(:cc_type => 'visa', :month => 12, :year => 2.years.from_now.year, :last_digits => '1111',
                                       :name => 'Sean Schofield', :gateway_customer_profile_id => 'BGS-1234')
 
 Spree::Order.all.each_with_index do |order, index|


### PR DESCRIPTION
Fixes loading the samples

```
  1) Load samples doesn't raise any error
     Failure/Error: expect {
       expected no Exception, got #<ActiveRecord::RecordInvalid: Validation failed: Credit card  Card has expired> with backtrace:
         # ./db/samples/payments.rb:20:in `block in <top (required)>'
         # ./db/samples/payments.rb:18:in `<top (required)>'
         # ./lib/spree/sample.rb:13:in `load_sample'
         # ./lib/spree_sample.rb:28:in `load_samples'
         # ./spec/lib/load_sample_spec.rb:15:in `block (3 levels) in <top (required)>'
         # ./spec/lib/load_sample_spec.rb:14:in `block (2 levels) in <top (required)>'
     # ./spec/lib/load_sample_spec.rb:14:in `block (2 levels) in <top (required)>'
```
