### PR TITLE
Base transaction wrapper for updating positions

### DIFF
--- a/backend/app/controllers/spree/admin/option_types_controller.rb
+++ b/backend/app/controllers/spree/admin/option_types_controller.rb
@@ -4,13 +4,15 @@ module Spree
       before_action :setup_new_option_value, only: :edit
 
       def update_values_positions
-        params[:positions].each do |id, index|
-          OptionValue.where(:id => id).update_all(:position => index)
+        ActiveRecord::Base.transaction do
+          params[:positions].each do |id, index|
+            Spree::OptionValue.where(id: id).update_all(position: index)
+          end
         end
 
         respond_to do |format|
           format.html { redirect_to admin_product_variants_url(params[:product_id]) }
-          format.js  { render :text => 'Ok' }
+          format.js { render text: 'Ok' }
         end
       end
 

--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -70,12 +70,14 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
   end
 
   def update_positions
-    params[:positions].each do |id, index|
-      model_class.find(id).update_attributes(:position => index)
+    ActiveRecord::Base.transaction do
+      params[:positions].each do |id, index|
+        model_class.find(id).update_attributes(position: index)
+      end
     end
 
     respond_to do |format|
-      format.js  { render :text => 'Ok' }
+      format.js { render text: 'Ok' }
     end
   end
 


### PR DESCRIPTION
This should provide a minor performance improvement for those who have a _lot_ of option values, option types, or anything that uses positions.

Data setup:

The data that I was using was from spree_sample: `rake spree_sample:load`. It provided enough data to test.

The issue with update positions is that it runs updates one by one by one. This means AR sets up a connection and closes it one by one by one. What if it could just connect, run all the SQL at once, and then close? This would help shave a few milliseconds off; only noticeable for large spree applications.

First change was to the `Spree::Admin::OptionTypesController#update_values_positions`. Simply go to an option type and drag and drop it in different places, causing the API request to be fired.

Before:

``` sql
16:49:36 web.1  | Started POST "/admin/option_types/update_values_positions" for 127.0.0.1 at 2015-01-04 16:49:36 -0500
16:49:36 web.1  | Processing by Spree::Admin::OptionTypesController#update_values_positions as JS
16:49:36 web.1  |   Parameters: {"positions"=>{"4"=>"0", "1"=>"1", "2"=>"2", "3"=>"3"}}
16:49:36 web.1  |   Spree::User Load (0.8ms)  SELECT  "spree_users".* FROM "spree_users"  WHERE "spree_users"."deleted_at" IS NULL AND "spree_users"."id" = 1  ORDER BY "spree_users"."id" ASC LIMIT 1
16:49:36 web.1  |   Spree::Store Load (0.6ms)  SELECT  "spree_stores".* FROM "spree_stores"  WHERE (url like '%localhost%')  ORDER BY "spree_stores"."id" ASC LIMIT 1
16:49:36 web.1  |   Spree::Store Load (1.0ms)  SELECT  "spree_stores".* FROM "spree_stores"  WHERE "spree_stores"."default" = 't'  ORDER BY "spree_stores"."id" ASC LIMIT 1
16:49:36 web.1  |   Spree::Order Load (0.9ms)  SELECT  "spree_orders".* FROM "spree_orders"  WHERE "spree_orders"."completed_at" IS NULL AND "spree_orders"."currency" = 'USD' AND "spree_orders"."guest_token" = '5DrPt1c8YOkQXkeWYzzb4w' AND "spree_orders"."store_id" = 1 AND "spree_orders"."user_id" = 1 LIMIT 1
16:49:36 web.1  |   Spree::Order Load (0.7ms)  SELECT  "spree_orders".* FROM "spree_orders"  WHERE "spree_orders"."user_id" = $1 AND "spree_orders"."completed_at" IS NULL AND "spree_orders"."user_id" = 1  ORDER BY created_at DESC LIMIT 1  [["user_id", 1]]
16:49:36 web.1  |   Spree::Preference Load (0.5ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/backend_configuration/locale' LIMIT 1
16:49:36 web.1  |    (0.7ms)  SELECT COUNT(*) FROM "spree_roles" INNER JOIN "spree_roles_users" ON "spree_roles"."id" = "spree_roles_users"."role_id" WHERE "spree_roles_users"."user_id" = $1 AND "spree_roles"."name" = 'admin'  [["user_id", 1]]
16:49:36 web.1  |   Alchemy::Site Load (0.9ms)  SELECT  "alchemy_sites".* FROM "alchemy_sites"  WHERE "alchemy_sites"."host" = 'localhost'  ORDER BY "alchemy_sites"."id" ASC LIMIT 1
16:49:36 web.1  |   Alchemy::Site Load (0.6ms)  SELECT "alchemy_sites".* FROM "alchemy_sites"
16:49:36 web.1  |   Alchemy::Site Load (0.5ms)  SELECT  "alchemy_sites".* FROM "alchemy_sites"   ORDER BY "alchemy_sites"."id" ASC LIMIT 1
16:49:36 web.1  |   Alchemy::Language Load (0.6ms)  SELECT  "alchemy_languages".* FROM "alchemy_languages"  WHERE "alchemy_languages"."site_id" = 1 AND "alchemy_languages"."id" = 1 LIMIT 1
16:49:36 web.1  |   Alchemy::Language Load (0.5ms)  SELECT  "alchemy_languages".* FROM "alchemy_languages"  WHERE "alchemy_languages"."site_id" = 1 AND "alchemy_languages"."language_code" = 'en' AND "alchemy_languages"."country_code" = '' LIMIT 1
16:49:36 web.1  |   SQL (1.9ms)  UPDATE "spree_option_values" SET "position" = 0 WHERE "spree_option_values"."id" = 4
16:49:36 web.1  |   SQL (0.8ms)  UPDATE "spree_option_values" SET "position" = 1 WHERE "spree_option_values"."id" = 1
16:49:36 web.1  |   SQL (0.8ms)  UPDATE "spree_option_values" SET "position" = 2 WHERE "spree_option_values"."id" = 2
16:49:36 web.1  |   SQL (0.9ms)  UPDATE "spree_option_values" SET "position" = 3 WHERE "spree_option_values"."id" = 3
16:49:36 web.1  |   Rendered text template (0.0ms)
16:49:36 web.1  | Completed 200 OK in 77ms (Views: 3.4ms | ActiveRecord: 12.8ms)

16:49:48 web.1  | Started POST "/admin/option_types/update_values_positions" for 127.0.0.1 at 2015-01-04 16:49:48 -0500
16:49:48 web.1  | Processing by Spree::Admin::OptionTypesController#update_values_positions as JS
16:49:48 web.1  |   Parameters: {"positions"=>{"1"=>"0", "4"=>"1", "2"=>"2", "3"=>"3"}}
16:49:48 web.1  |   Spree::User Load (0.7ms)  SELECT  "spree_users".* FROM "spree_users"  WHERE "spree_users"."deleted_at" IS NULL AND "spree_users"."id" = 1  ORDER BY "spree_users"."id" ASC LIMIT 1
16:49:48 web.1  |   Spree::Store Load (0.7ms)  SELECT  "spree_stores".* FROM "spree_stores"  WHERE (url like '%localhost%')  ORDER BY "spree_stores"."id" ASC LIMIT 1
16:49:48 web.1  |   Spree::Store Load (0.5ms)  SELECT  "spree_stores".* FROM "spree_stores"  WHERE "spree_stores"."default" = 't'  ORDER BY "spree_stores"."id" ASC LIMIT 1
16:49:48 web.1  |   Spree::Order Load (0.8ms)  SELECT  "spree_orders".* FROM "spree_orders"  WHERE "spree_orders"."completed_at" IS NULL AND "spree_orders"."currency" = 'USD' AND "spree_orders"."guest_token" = '5DrPt1c8YOkQXkeWYzzb4w' AND "spree_orders"."store_id" = 1 AND "spree_orders"."user_id" = 1 LIMIT 1
16:49:48 web.1  |   Spree::Order Load (0.7ms)  SELECT  "spree_orders".* FROM "spree_orders"  WHERE "spree_orders"."user_id" = $1 AND "spree_orders"."completed_at" IS NULL AND "spree_orders"."user_id" = 1  ORDER BY created_at DESC LIMIT 1  [["user_id", 1]]
16:49:48 web.1  |   Spree::Preference Load (0.7ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/backend_configuration/locale' LIMIT 1
16:49:48 web.1  |    (0.8ms)  SELECT COUNT(*) FROM "spree_roles" INNER JOIN "spree_roles_users" ON "spree_roles"."id" = "spree_roles_users"."role_id" WHERE "spree_roles_users"."user_id" = $1 AND "spree_roles"."name" = 'admin'  [["user_id", 1]]
16:49:48 web.1  |   Alchemy::Site Load (0.6ms)  SELECT  "alchemy_sites".* FROM "alchemy_sites"  WHERE "alchemy_sites"."host" = 'localhost'  ORDER BY "alchemy_sites"."id" ASC LIMIT 1
16:49:48 web.1  |   Alchemy::Site Load (0.4ms)  SELECT "alchemy_sites".* FROM "alchemy_sites"
16:49:48 web.1  |   Alchemy::Site Load (0.6ms)  SELECT  "alchemy_sites".* FROM "alchemy_sites"   ORDER BY "alchemy_sites"."id" ASC LIMIT 1
16:49:48 web.1  |   Alchemy::Language Load (0.9ms)  SELECT  "alchemy_languages".* FROM "alchemy_languages"  WHERE "alchemy_languages"."site_id" = 1 AND "alchemy_languages"."id" = 1 LIMIT 1
16:49:48 web.1  |   Alchemy::Language Load (0.6ms)  SELECT  "alchemy_languages".* FROM "alchemy_languages"  WHERE "alchemy_languages"."site_id" = 1 AND "alchemy_languages"."language_code" = 'en' AND "alchemy_languages"."country_code" = '' LIMIT 1
16:49:48 web.1  |   SQL (0.8ms)  UPDATE "spree_option_values" SET "position" = 0 WHERE "spree_option_values"."id" = 1
16:49:48 web.1  |   SQL (1.5ms)  UPDATE "spree_option_values" SET "position" = 1 WHERE "spree_option_values"."id" = 4
16:49:48 web.1  |   SQL (0.9ms)  UPDATE "spree_option_values" SET "position" = 2 WHERE "spree_option_values"."id" = 2
16:49:48 web.1  |   SQL (0.7ms)  UPDATE "spree_option_values" SET "position" = 3 WHERE "spree_option_values"."id" = 3
16:49:48 web.1  |   Rendered text template (0.0ms)
16:49:48 web.1  | Completed 200 OK in 88ms (Views: 0.9ms | ActiveRecord: 11.9ms)

16:49:53 web.1  | Started POST "/admin/option_types/update_values_positions" for 127.0.0.1 at 2015-01-04 16:49:53 -0500
16:49:53 web.1  | Processing by Spree::Admin::OptionTypesController#update_values_positions as JS
16:49:53 web.1  |   Parameters: {"positions"=>{"1"=>"0", "2"=>"1", "4"=>"2", "3"=>"3"}}
16:49:53 web.1  |   Spree::User Load (0.7ms)  SELECT  "spree_users".* FROM "spree_users"  WHERE "spree_users"."deleted_at" IS NULL AND "spree_users"."id" = 1  ORDER BY "spree_users"."id" ASC LIMIT 1
16:49:53 web.1  |   Spree::Store Load (0.8ms)  SELECT  "spree_stores".* FROM "spree_stores"  WHERE (url like '%localhost%')  ORDER BY "spree_stores"."id" ASC LIMIT 1
16:49:53 web.1  |   Spree::Store Load (0.7ms)  SELECT  "spree_stores".* FROM "spree_stores"  WHERE "spree_stores"."default" = 't'  ORDER BY "spree_stores"."id" ASC LIMIT 1
16:49:53 web.1  |   Spree::Order Load (0.9ms)  SELECT  "spree_orders".* FROM "spree_orders"  WHERE "spree_orders"."completed_at" IS NULL AND "spree_orders"."currency" = 'USD' AND "spree_orders"."guest_token" = '5DrPt1c8YOkQXkeWYzzb4w' AND "spree_orders"."store_id" = 1 AND "spree_orders"."user_id" = 1 LIMIT 1
16:49:53 web.1  |   Spree::Order Load (1.5ms)  SELECT  "spree_orders".* FROM "spree_orders"  WHERE "spree_orders"."user_id" = $1 AND "spree_orders"."completed_at" IS NULL AND "spree_orders"."user_id" = 1  ORDER BY created_at DESC LIMIT 1  [["user_id", 1]]
16:49:53 web.1  |   Spree::Preference Load (0.5ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/backend_configuration/locale' LIMIT 1
16:49:53 web.1  |    (0.6ms)  SELECT COUNT(*) FROM "spree_roles" INNER JOIN "spree_roles_users" ON "spree_roles"."id" = "spree_roles_users"."role_id" WHERE "spree_roles_users"."user_id" = $1 AND "spree_roles"."name" = 'admin'  [["user_id", 1]]
16:49:53 web.1  |   Alchemy::Site Load (2.7ms)  SELECT  "alchemy_sites".* FROM "alchemy_sites"  WHERE "alchemy_sites"."host" = 'localhost'  ORDER BY "alchemy_sites"."id" ASC LIMIT 1
16:49:53 web.1  |   Alchemy::Site Load (0.4ms)  SELECT "alchemy_sites".* FROM "alchemy_sites"
16:49:53 web.1  |   Alchemy::Site Load (0.6ms)  SELECT  "alchemy_sites".* FROM "alchemy_sites"   ORDER BY "alchemy_sites"."id" ASC LIMIT 1
16:49:53 web.1  |   Alchemy::Language Load (0.7ms)  SELECT  "alchemy_languages".* FROM "alchemy_languages"  WHERE "alchemy_languages"."site_id" = 1 AND "alchemy_languages"."id" = 1 LIMIT 1
16:49:53 web.1  |   Alchemy::Language Load (0.6ms)  SELECT  "alchemy_languages".* FROM "alchemy_languages"  WHERE "alchemy_languages"."site_id" = 1 AND "alchemy_languages"."language_code" = 'en' AND "alchemy_languages"."country_code" = '' LIMIT 1
16:49:53 web.1  |   SQL (0.8ms)  UPDATE "spree_option_values" SET "position" = 0 WHERE "spree_option_values"."id" = 1
16:49:53 web.1  |   SQL (0.8ms)  UPDATE "spree_option_values" SET "position" = 1 WHERE "spree_option_values"."id" = 2
16:49:53 web.1  |   SQL (0.8ms)  UPDATE "spree_option_values" SET "position" = 2 WHERE "spree_option_values"."id" = 4
16:49:53 web.1  |   SQL (0.8ms)  UPDATE "spree_option_values" SET "position" = 3 WHERE "spree_option_values"."id" = 3
16:49:53 web.1  |   Rendered text template (0.0ms)
16:49:53 web.1  | Completed 200 OK in 77ms (Views: 0.7ms | ActiveRecord: 14.0ms)
```

After:

``` sql
16:52:00 web.1  | Started POST "/admin/option_types/update_values_positions" for 127.0.0.1 at 2015-01-04 16:52:00 -0500
16:52:00 web.1  | /Users/benmorgan/.rvm/gems/ruby-2.2.0/bundler/gems/spree-4da14fa0fd9c/api/config/routes.rb:65: warning: duplicated key at line 65 ignored: :to
16:52:01 web.1  | Processing by Spree::Admin::OptionTypesController#update_values_positions as JS
16:52:01 web.1  |   Parameters: {"positions"=>{"1"=>"0", "4"=>"1", "2"=>"2", "3"=>"3"}}
16:52:01 web.1  |   Spree::User Load (2.7ms)  SELECT  "spree_users".* FROM "spree_users"  WHERE "spree_users"."deleted_at" IS NULL AND "spree_users"."id" = 1  ORDER BY "spree_users"."id" ASC LIMIT 1
16:52:01 web.1  |   Spree::Store Load (1.6ms)  SELECT  "spree_stores".* FROM "spree_stores"  WHERE (url like '%localhost%')  ORDER BY "spree_stores"."id" ASC LIMIT 1
16:52:01 web.1  |   Spree::Store Load (1.1ms)  SELECT  "spree_stores".* FROM "spree_stores"  WHERE "spree_stores"."default" = 't'  ORDER BY "spree_stores"."id" ASC LIMIT 1
16:52:01 web.1  |   Spree::Order Load (2.3ms)  SELECT  "spree_orders".* FROM "spree_orders"  WHERE "spree_orders"."completed_at" IS NULL AND "spree_orders"."currency" = 'USD' AND "spree_orders"."guest_token" = '5DrPt1c8YOkQXkeWYzzb4w' AND "spree_orders"."store_id" = 1 AND "spree_orders"."user_id" = 1 LIMIT 1
16:52:01 web.1  |   Spree::Order Load (0.7ms)  SELECT  "spree_orders".* FROM "spree_orders"  WHERE "spree_orders"."user_id" = $1 AND "spree_orders"."completed_at" IS NULL AND "spree_orders"."user_id" = 1  ORDER BY created_at DESC LIMIT 1  [["user_id", 1]]
16:52:01 web.1  |   Spree::Preference Load (1.6ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/backend_configuration/locale' LIMIT 1
16:52:01 web.1  |    (2.2ms)  SELECT COUNT(*) FROM "spree_roles" INNER JOIN "spree_roles_users" ON "spree_roles"."id" = "spree_roles_users"."role_id" WHERE "spree_roles_users"."user_id" = $1 AND "spree_roles"."name" = 'admin'  [["user_id", 1]]
16:52:02 web.1  |   Alchemy::Site Load (0.8ms)  SELECT  "alchemy_sites".* FROM "alchemy_sites"  WHERE "alchemy_sites"."host" = 'localhost'  ORDER BY "alchemy_sites"."id" ASC LIMIT 1
16:52:02 web.1  |   Alchemy::Site Load (0.8ms)  SELECT "alchemy_sites".* FROM "alchemy_sites"
16:52:02 web.1  |   Alchemy::Site Load (0.9ms)  SELECT  "alchemy_sites".* FROM "alchemy_sites"   ORDER BY "alchemy_sites"."id" ASC LIMIT 1
16:52:02 web.1  |   Alchemy::Language Load (1.0ms)  SELECT  "alchemy_languages".* FROM "alchemy_languages"  WHERE "alchemy_languages"."site_id" = 1 AND "alchemy_languages"."id" = 1 LIMIT 1
16:52:02 web.1  |   Alchemy::Language Load (0.9ms)  SELECT  "alchemy_languages".* FROM "alchemy_languages"  WHERE "alchemy_languages"."site_id" = 1 AND "alchemy_languages"."language_code" = 'en' AND "alchemy_languages"."country_code" = '' LIMIT 1
16:52:02 web.1  |    (4.2ms)  BEGIN
16:52:02 web.1  |   SQL (1.6ms)  UPDATE "spree_option_values" SET "position" = 0 WHERE "spree_option_values"."id" = 1
16:52:02 web.1  |   SQL (0.6ms)  UPDATE "spree_option_values" SET "position" = 1 WHERE "spree_option_values"."id" = 4
16:52:02 web.1  |   SQL (0.9ms)  UPDATE "spree_option_values" SET "position" = 2 WHERE "spree_option_values"."id" = 2
16:52:02 web.1  |   SQL (0.5ms)  UPDATE "spree_option_values" SET "position" = 3 WHERE "spree_option_values"."id" = 3
16:52:02 web.1  |    (0.6ms)  COMMIT
16:52:02 web.1  |   Rendered text template (0.0ms)
16:52:02 web.1  | Completed 200 OK in 488ms (Views: 1.0ms | ActiveRecord: 85.3ms)

16:52:06 web.1  | Started POST "/admin/option_types/update_values_positions" for 127.0.0.1 at 2015-01-04 16:52:06 -0500
16:52:06 web.1  | Processing by Spree::Admin::OptionTypesController#update_values_positions as JS
16:52:06 web.1  |   Parameters: {"positions"=>{"4"=>"0", "1"=>"1", "2"=>"2", "3"=>"3"}}
16:52:06 web.1  |   Spree::User Load (2.0ms)  SELECT  "spree_users".* FROM "spree_users"  WHERE "spree_users"."deleted_at" IS NULL AND "spree_users"."id" = 1  ORDER BY "spree_users"."id" ASC LIMIT 1
16:52:06 web.1  |   Spree::Store Load (0.7ms)  SELECT  "spree_stores".* FROM "spree_stores"  WHERE (url like '%localhost%')  ORDER BY "spree_stores"."id" ASC LIMIT 1
16:52:06 web.1  |   Spree::Store Load (0.5ms)  SELECT  "spree_stores".* FROM "spree_stores"  WHERE "spree_stores"."default" = 't'  ORDER BY "spree_stores"."id" ASC LIMIT 1
16:52:06 web.1  |   Spree::Order Load (0.8ms)  SELECT  "spree_orders".* FROM "spree_orders"  WHERE "spree_orders"."completed_at" IS NULL AND "spree_orders"."currency" = 'USD' AND "spree_orders"."guest_token" = '5DrPt1c8YOkQXkeWYzzb4w' AND "spree_orders"."store_id" = 1 AND "spree_orders"."user_id" = 1 LIMIT 1
16:52:06 web.1  |   Spree::Order Load (0.8ms)  SELECT  "spree_orders".* FROM "spree_orders"  WHERE "spree_orders"."user_id" = $1 AND "spree_orders"."completed_at" IS NULL AND "spree_orders"."user_id" = 1  ORDER BY created_at DESC LIMIT 1  [["user_id", 1]]
16:52:06 web.1  |   Spree::Preference Load (0.6ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/backend_configuration/locale' LIMIT 1
16:52:06 web.1  |    (0.7ms)  SELECT COUNT(*) FROM "spree_roles" INNER JOIN "spree_roles_users" ON "spree_roles"."id" = "spree_roles_users"."role_id" WHERE "spree_roles_users"."user_id" = $1 AND "spree_roles"."name" = 'admin'  [["user_id", 1]]
16:52:06 web.1  |   Alchemy::Site Load (0.7ms)  SELECT  "alchemy_sites".* FROM "alchemy_sites"  WHERE "alchemy_sites"."host" = 'localhost'  ORDER BY "alchemy_sites"."id" ASC LIMIT 1
16:52:06 web.1  |   Alchemy::Site Load (0.4ms)  SELECT "alchemy_sites".* FROM "alchemy_sites"
16:52:06 web.1  |   Alchemy::Site Load (0.5ms)  SELECT  "alchemy_sites".* FROM "alchemy_sites"   ORDER BY "alchemy_sites"."id" ASC LIMIT 1
16:52:06 web.1  |   Alchemy::Language Load (0.6ms)  SELECT  "alchemy_languages".* FROM "alchemy_languages"  WHERE "alchemy_languages"."site_id" = 1 AND "alchemy_languages"."id" = 1 LIMIT 1
16:52:06 web.1  |   Alchemy::Language Load (0.9ms)  SELECT  "alchemy_languages".* FROM "alchemy_languages"  WHERE "alchemy_languages"."site_id" = 1 AND "alchemy_languages"."language_code" = 'en' AND "alchemy_languages"."country_code" = '' LIMIT 1
16:52:06 web.1  |    (0.2ms)  BEGIN
16:52:06 web.1  |   SQL (0.5ms)  UPDATE "spree_option_values" SET "position" = 0 WHERE "spree_option_values"."id" = 4
16:52:06 web.1  |   SQL (0.4ms)  UPDATE "spree_option_values" SET "position" = 1 WHERE "spree_option_values"."id" = 1
16:52:06 web.1  |   SQL (0.5ms)  UPDATE "spree_option_values" SET "position" = 2 WHERE "spree_option_values"."id" = 2
16:52:06 web.1  |   SQL (1.1ms)  UPDATE "spree_option_values" SET "position" = 3 WHERE "spree_option_values"."id" = 3
16:52:06 web.1  |    (0.5ms)  COMMIT
16:52:06 web.1  |   Rendered text template (0.0ms)
16:52:06 web.1  | Completed 200 OK in 78ms (Views: 0.8ms | ActiveRecord: 12.3ms)

16:52:16 web.1  | Started POST "/admin/option_types/update_values_positions" for 127.0.0.1 at 2015-01-04 16:52:16 -0500
16:52:16 web.1  | Processing by Spree::Admin::OptionTypesController#update_values_positions as JS
16:52:16 web.1  |   Parameters: {"positions"=>{"4"=>"0", "2"=>"1", "1"=>"2", "3"=>"3"}}
16:52:16 web.1  |   Spree::User Load (0.9ms)  SELECT  "spree_users".* FROM "spree_users"  WHERE "spree_users"."deleted_at" IS NULL AND "spree_users"."id" = 1  ORDER BY "spree_users"."id" ASC LIMIT 1
16:52:16 web.1  |   Spree::Store Load (0.8ms)  SELECT  "spree_stores".* FROM "spree_stores"  WHERE (url like '%localhost%')  ORDER BY "spree_stores"."id" ASC LIMIT 1
16:52:16 web.1  |   Spree::Store Load (0.7ms)  SELECT  "spree_stores".* FROM "spree_stores"  WHERE "spree_stores"."default" = 't'  ORDER BY "spree_stores"."id" ASC LIMIT 1
16:52:16 web.1  |   Spree::Order Load (0.9ms)  SELECT  "spree_orders".* FROM "spree_orders"  WHERE "spree_orders"."completed_at" IS NULL AND "spree_orders"."currency" = 'USD' AND "spree_orders"."guest_token" = '5DrPt1c8YOkQXkeWYzzb4w' AND "spree_orders"."store_id" = 1 AND "spree_orders"."user_id" = 1 LIMIT 1
16:52:16 web.1  |   Spree::Order Load (0.7ms)  SELECT  "spree_orders".* FROM "spree_orders"  WHERE "spree_orders"."user_id" = $1 AND "spree_orders"."completed_at" IS NULL AND "spree_orders"."user_id" = 1  ORDER BY created_at DESC LIMIT 1  [["user_id", 1]]
16:52:16 web.1  |   Spree::Preference Load (0.5ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/backend_configuration/locale' LIMIT 1
16:52:16 web.1  |    (0.8ms)  SELECT COUNT(*) FROM "spree_roles" INNER JOIN "spree_roles_users" ON "spree_roles"."id" = "spree_roles_users"."role_id" WHERE "spree_roles_users"."user_id" = $1 AND "spree_roles"."name" = 'admin'  [["user_id", 1]]
16:52:16 web.1  |   Alchemy::Site Load (0.9ms)  SELECT  "alchemy_sites".* FROM "alchemy_sites"  WHERE "alchemy_sites"."host" = 'localhost'  ORDER BY "alchemy_sites"."id" ASC LIMIT 1
16:52:16 web.1  |   Alchemy::Site Load (0.5ms)  SELECT "alchemy_sites".* FROM "alchemy_sites"
16:52:16 web.1  |   Alchemy::Site Load (0.5ms)  SELECT  "alchemy_sites".* FROM "alchemy_sites"   ORDER BY "alchemy_sites"."id" ASC LIMIT 1
16:52:16 web.1  |   Alchemy::Language Load (0.9ms)  SELECT  "alchemy_languages".* FROM "alchemy_languages"  WHERE "alchemy_languages"."site_id" = 1 AND "alchemy_languages"."id" = 1 LIMIT 1
16:52:16 web.1  |   Alchemy::Language Load (0.6ms)  SELECT  "alchemy_languages".* FROM "alchemy_languages"  WHERE "alchemy_languages"."site_id" = 1 AND "alchemy_languages"."language_code" = 'en' AND "alchemy_languages"."country_code" = '' LIMIT 1
16:52:16 web.1  |    (0.2ms)  BEGIN
16:52:16 web.1  |   SQL (0.4ms)  UPDATE "spree_option_values" SET "position" = 0 WHERE "spree_option_values"."id" = 4
16:52:16 web.1  |   SQL (0.4ms)  UPDATE "spree_option_values" SET "position" = 1 WHERE "spree_option_values"."id" = 2
16:52:16 web.1  |   SQL (0.5ms)  UPDATE "spree_option_values" SET "position" = 2 WHERE "spree_option_values"."id" = 1
16:52:16 web.1  |   SQL (0.5ms)  UPDATE "spree_option_values" SET "position" = 3 WHERE "spree_option_values"."id" = 3
16:52:16 web.1  |    (0.6ms)  COMMIT
16:52:16 web.1  |   Rendered text template (0.0ms)
16:52:16 web.1  | Completed 200 OK in 77ms (Views: 1.1ms | ActiveRecord: 11.2ms)
```

The next performance change was for the `Spree::Admin::ResourceController#update_positions` which also had an AR wrapper around similar SQL. To create, simply drag and drop different option types in random places.

Before:

``` sql
16:54:32 web.1  | Started POST "/admin/option_types/update_positions" for 127.0.0.1 at 2015-01-04 16:54:32 -0500
16:54:32 web.1  | /Users/benmorgan/.rvm/gems/ruby-2.2.0/bundler/gems/spree-4da14fa0fd9c/api/config/routes.rb:65: warning: duplicated key at line 65 ignored: :to
16:54:33 web.1  | Processing by Spree::Admin::OptionTypesController#update_positions as JS
16:54:33 web.1  |   Parameters: {"positions"=>{"1"=>"0", "3"=>"1", "2"=>"2"}}
16:54:33 web.1  |   Spree::User Load (4.9ms)  SELECT  "spree_users".* FROM "spree_users"  WHERE "spree_users"."deleted_at" IS NULL AND "spree_users"."id" = 1  ORDER BY "spree_users"."id" ASC LIMIT 1
16:54:34 web.1  |   Spree::Store Load (10.8ms)  SELECT  "spree_stores".* FROM "spree_stores"  WHERE (url like '%localhost%')  ORDER BY "spree_stores"."id" ASC LIMIT 1
16:54:34 web.1  |   Spree::Store Load (0.6ms)  SELECT  "spree_stores".* FROM "spree_stores"  WHERE "spree_stores"."default" = 't'  ORDER BY "spree_stores"."id" ASC LIMIT 1
16:54:34 web.1  |   Spree::Order Load (2.2ms)  SELECT  "spree_orders".* FROM "spree_orders"  WHERE "spree_orders"."completed_at" IS NULL AND "spree_orders"."currency" = 'USD' AND "spree_orders"."guest_token" = '5DrPt1c8YOkQXkeWYzzb4w' AND "spree_orders"."store_id" = 1 AND "spree_orders"."user_id" = 1 LIMIT 1
16:54:34 web.1  |   Spree::Order Load (2.3ms)  SELECT  "spree_orders".* FROM "spree_orders"  WHERE "spree_orders"."user_id" = $1 AND "spree_orders"."completed_at" IS NULL AND "spree_orders"."user_id" = 1  ORDER BY created_at DESC LIMIT 1  [["user_id", 1]]
16:54:34 web.1  |   Spree::Preference Load (0.5ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/backend_configuration/locale' LIMIT 1
16:54:34 web.1  |    (2.1ms)  SELECT COUNT(*) FROM "spree_roles" INNER JOIN "spree_roles_users" ON "spree_roles"."id" = "spree_roles_users"."role_id" WHERE "spree_roles_users"."user_id" = $1 AND "spree_roles"."name" = 'admin'  [["user_id", 1]]
16:54:34 web.1  |   Alchemy::Site Load (0.8ms)  SELECT  "alchemy_sites".* FROM "alchemy_sites"  WHERE "alchemy_sites"."host" = 'localhost'  ORDER BY "alchemy_sites"."id" ASC LIMIT 1
16:54:34 web.1  |   Alchemy::Site Load (0.6ms)  SELECT "alchemy_sites".* FROM "alchemy_sites"
16:54:34 web.1  |   Alchemy::Site Load (2.6ms)  SELECT  "alchemy_sites".* FROM "alchemy_sites"   ORDER BY "alchemy_sites"."id" ASC LIMIT 1
16:54:34 web.1  |   Alchemy::Language Load (0.8ms)  SELECT  "alchemy_languages".* FROM "alchemy_languages"  WHERE "alchemy_languages"."site_id" = 1 AND "alchemy_languages"."id" = 1 LIMIT 1
16:54:34 web.1  |   Alchemy::Language Load (0.9ms)  SELECT  "alchemy_languages".* FROM "alchemy_languages"  WHERE "alchemy_languages"."site_id" = 1 AND "alchemy_languages"."language_code" = 'en' AND "alchemy_languages"."country_code" = '' LIMIT 1
16:54:34 web.1  |   Spree::OptionType Load (0.6ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
16:54:34 web.1  |    (0.2ms)  BEGIN
16:54:34 web.1  |   Spree::OptionType Exists (1.7ms)  SELECT  1 AS one FROM "spree_option_types"  WHERE ("spree_option_types"."name" = 'tshirt-size' AND "spree_option_types"."id" != 1) LIMIT 1
16:54:34 web.1  |   SQL (0.6ms)  UPDATE "spree_option_types" SET "position" = $1, "updated_at" = $2 WHERE "spree_option_types"."id" = 1  [["position", 0], ["updated_at", "2015-01-04 21:54:34.576979"]]
16:54:34 web.1  |    (2.5ms)  COMMIT
16:54:34 web.1  |   Spree::OptionType Load (1.4ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 3]]
16:54:34 web.1  |    (0.1ms)  BEGIN
16:54:34 web.1  |   Spree::OptionType Exists (0.4ms)  SELECT  1 AS one FROM "spree_option_types"  WHERE ("spree_option_types"."name" = 'example' AND "spree_option_types"."id" != 3) LIMIT 1
16:54:34 web.1  |   SQL (0.4ms)  UPDATE "spree_option_types" SET "position" = $1, "updated_at" = $2 WHERE "spree_option_types"."id" = 3  [["position", 1], ["updated_at", "2015-01-04 21:54:34.610785"]]
16:54:34 web.1  |    (0.6ms)  COMMIT
16:54:34 web.1  |   Spree::OptionType Load (1.7ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
16:54:34 web.1  |    (0.2ms)  BEGIN
16:54:34 web.1  |   Spree::OptionType Exists (0.6ms)  SELECT  1 AS one FROM "spree_option_types"  WHERE ("spree_option_types"."name" = 'tshirt-color' AND "spree_option_types"."id" != 2) LIMIT 1
16:54:34 web.1  |    (0.2ms)  COMMIT
16:54:34 web.1  |   Rendered text template (0.0ms)
16:54:34 web.1  | Completed 200 OK in 732ms (Views: 1.3ms | ActiveRecord: 83.9ms)

16:54:43 web.1  | Started POST "/admin/option_types/update_positions" for 127.0.0.1 at 2015-01-04 16:54:43 -0500
16:54:43 web.1  | Processing by Spree::Admin::OptionTypesController#update_positions as JS
16:54:43 web.1  |   Parameters: {"positions"=>{"1"=>"0", "2"=>"1", "3"=>"2"}}
16:54:43 web.1  |   Spree::User Load (0.7ms)  SELECT  "spree_users".* FROM "spree_users"  WHERE "spree_users"."deleted_at" IS NULL AND "spree_users"."id" = 1  ORDER BY "spree_users"."id" ASC LIMIT 1
16:54:43 web.1  |   Spree::Store Load (1.0ms)  SELECT  "spree_stores".* FROM "spree_stores"  WHERE (url like '%localhost%')  ORDER BY "spree_stores"."id" ASC LIMIT 1
16:54:43 web.1  |   Spree::Store Load (0.6ms)  SELECT  "spree_stores".* FROM "spree_stores"  WHERE "spree_stores"."default" = 't'  ORDER BY "spree_stores"."id" ASC LIMIT 1
16:54:43 web.1  |   Spree::Order Load (1.8ms)  SELECT  "spree_orders".* FROM "spree_orders"  WHERE "spree_orders"."completed_at" IS NULL AND "spree_orders"."currency" = 'USD' AND "spree_orders"."guest_token" = '5DrPt1c8YOkQXkeWYzzb4w' AND "spree_orders"."store_id" = 1 AND "spree_orders"."user_id" = 1 LIMIT 1
16:54:43 web.1  |   Spree::Order Load (0.4ms)  SELECT  "spree_orders".* FROM "spree_orders"  WHERE "spree_orders"."user_id" = $1 AND "spree_orders"."completed_at" IS NULL AND "spree_orders"."user_id" = 1  ORDER BY created_at DESC LIMIT 1  [["user_id", 1]]
16:54:43 web.1  |   Spree::Preference Load (0.6ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/backend_configuration/locale' LIMIT 1
16:54:43 web.1  |    (0.4ms)  SELECT COUNT(*) FROM "spree_roles" INNER JOIN "spree_roles_users" ON "spree_roles"."id" = "spree_roles_users"."role_id" WHERE "spree_roles_users"."user_id" = $1 AND "spree_roles"."name" = 'admin'  [["user_id", 1]]
16:54:43 web.1  |   Alchemy::Site Load (0.9ms)  SELECT  "alchemy_sites".* FROM "alchemy_sites"  WHERE "alchemy_sites"."host" = 'localhost'  ORDER BY "alchemy_sites"."id" ASC LIMIT 1
16:54:43 web.1  |   Alchemy::Site Load (0.5ms)  SELECT "alchemy_sites".* FROM "alchemy_sites"
16:54:43 web.1  |   Alchemy::Site Load (4.0ms)  SELECT  "alchemy_sites".* FROM "alchemy_sites"   ORDER BY "alchemy_sites"."id" ASC LIMIT 1
16:54:43 web.1  |   Alchemy::Language Load (0.6ms)  SELECT  "alchemy_languages".* FROM "alchemy_languages"  WHERE "alchemy_languages"."site_id" = 1 AND "alchemy_languages"."id" = 1 LIMIT 1
16:54:43 web.1  |   Alchemy::Language Load (1.3ms)  SELECT  "alchemy_languages".* FROM "alchemy_languages"  WHERE "alchemy_languages"."site_id" = 1 AND "alchemy_languages"."language_code" = 'en' AND "alchemy_languages"."country_code" = '' LIMIT 1
16:54:43 web.1  |   Spree::OptionType Load (0.5ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
16:54:43 web.1  |    (0.2ms)  BEGIN
16:54:43 web.1  |   Spree::OptionType Exists (0.7ms)  SELECT  1 AS one FROM "spree_option_types"  WHERE ("spree_option_types"."name" = 'tshirt-size' AND "spree_option_types"."id" != 1) LIMIT 1
16:54:43 web.1  |    (0.2ms)  COMMIT
16:54:43 web.1  |   Spree::OptionType Load (0.5ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
16:54:43 web.1  |    (0.2ms)  BEGIN
16:54:43 web.1  |   Spree::OptionType Exists (0.4ms)  SELECT  1 AS one FROM "spree_option_types"  WHERE ("spree_option_types"."name" = 'tshirt-color' AND "spree_option_types"."id" != 2) LIMIT 1
16:54:43 web.1  |   SQL (0.5ms)  UPDATE "spree_option_types" SET "position" = $1, "updated_at" = $2 WHERE "spree_option_types"."id" = 2  [["position", 1], ["updated_at", "2015-01-04 21:54:43.288658"]]
16:54:43 web.1  |    (0.5ms)  COMMIT
16:54:43 web.1  |   Spree::OptionType Load (0.4ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 3]]
16:54:43 web.1  |    (0.2ms)  BEGIN
16:54:43 web.1  |   Spree::OptionType Exists (0.5ms)  SELECT  1 AS one FROM "spree_option_types"  WHERE ("spree_option_types"."name" = 'example' AND "spree_option_types"."id" != 3) LIMIT 1
16:54:43 web.1  |   SQL (0.4ms)  UPDATE "spree_option_types" SET "position" = $1, "updated_at" = $2 WHERE "spree_option_types"."id" = 3  [["position", 2], ["updated_at", "2015-01-04 21:54:43.309573"]]
16:54:43 web.1  |    (0.5ms)  COMMIT
16:54:43 web.1  |   Rendered text template (0.0ms)
16:54:43 web.1  | Completed 200 OK in 133ms (Views: 0.7ms | ActiveRecord: 18.3ms)

16:54:45 web.1  | Started POST "/admin/option_types/update_positions" for 127.0.0.1 at 2015-01-04 16:54:45 -0500
16:54:45 web.1  | Processing by Spree::Admin::OptionTypesController#update_positions as JS
16:54:45 web.1  |   Parameters: {"positions"=>{"1"=>"0", "3"=>"1", "2"=>"2"}}
16:54:45 web.1  |   Spree::User Load (0.7ms)  SELECT  "spree_users".* FROM "spree_users"  WHERE "spree_users"."deleted_at" IS NULL AND "spree_users"."id" = 1  ORDER BY "spree_users"."id" ASC LIMIT 1
16:54:45 web.1  |   Spree::Store Load (0.6ms)  SELECT  "spree_stores".* FROM "spree_stores"  WHERE (url like '%localhost%')  ORDER BY "spree_stores"."id" ASC LIMIT 1
16:54:45 web.1  |   Spree::Store Load (0.9ms)  SELECT  "spree_stores".* FROM "spree_stores"  WHERE "spree_stores"."default" = 't'  ORDER BY "spree_stores"."id" ASC LIMIT 1
16:54:45 web.1  |   Spree::Order Load (0.8ms)  SELECT  "spree_orders".* FROM "spree_orders"  WHERE "spree_orders"."completed_at" IS NULL AND "spree_orders"."currency" = 'USD' AND "spree_orders"."guest_token" = '5DrPt1c8YOkQXkeWYzzb4w' AND "spree_orders"."store_id" = 1 AND "spree_orders"."user_id" = 1 LIMIT 1
16:54:45 web.1  |   Spree::Order Load (0.7ms)  SELECT  "spree_orders".* FROM "spree_orders"  WHERE "spree_orders"."user_id" = $1 AND "spree_orders"."completed_at" IS NULL AND "spree_orders"."user_id" = 1  ORDER BY created_at DESC LIMIT 1  [["user_id", 1]]
16:54:45 web.1  |   Spree::Preference Load (0.8ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/backend_configuration/locale' LIMIT 1
16:54:45 web.1  |    (0.8ms)  SELECT COUNT(*) FROM "spree_roles" INNER JOIN "spree_roles_users" ON "spree_roles"."id" = "spree_roles_users"."role_id" WHERE "spree_roles_users"."user_id" = $1 AND "spree_roles"."name" = 'admin'  [["user_id", 1]]
16:54:45 web.1  |   Alchemy::Site Load (0.6ms)  SELECT  "alchemy_sites".* FROM "alchemy_sites"  WHERE "alchemy_sites"."host" = 'localhost'  ORDER BY "alchemy_sites"."id" ASC LIMIT 1
16:54:45 web.1  |   Alchemy::Site Load (0.3ms)  SELECT "alchemy_sites".* FROM "alchemy_sites"
16:54:45 web.1  |   Alchemy::Site Load (0.6ms)  SELECT  "alchemy_sites".* FROM "alchemy_sites"   ORDER BY "alchemy_sites"."id" ASC LIMIT 1
16:54:45 web.1  |   Alchemy::Language Load (0.8ms)  SELECT  "alchemy_languages".* FROM "alchemy_languages"  WHERE "alchemy_languages"."site_id" = 1 AND "alchemy_languages"."id" = 1 LIMIT 1
16:54:45 web.1  |   Alchemy::Language Load (0.6ms)  SELECT  "alchemy_languages".* FROM "alchemy_languages"  WHERE "alchemy_languages"."site_id" = 1 AND "alchemy_languages"."language_code" = 'en' AND "alchemy_languages"."country_code" = '' LIMIT 1
16:54:45 web.1  |   Spree::OptionType Load (0.5ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
16:54:45 web.1  |    (0.4ms)  BEGIN
16:54:45 web.1  |   Spree::OptionType Exists (0.7ms)  SELECT  1 AS one FROM "spree_option_types"  WHERE ("spree_option_types"."name" = 'tshirt-size' AND "spree_option_types"."id" != 1) LIMIT 1
16:54:45 web.1  |    (0.2ms)  COMMIT
16:54:45 web.1  |   Spree::OptionType Load (0.4ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 3]]
16:54:45 web.1  |    (0.2ms)  BEGIN
16:54:45 web.1  |   Spree::OptionType Exists (0.7ms)  SELECT  1 AS one FROM "spree_option_types"  WHERE ("spree_option_types"."name" = 'example' AND "spree_option_types"."id" != 3) LIMIT 1
16:54:45 web.1  |   SQL (0.5ms)  UPDATE "spree_option_types" SET "position" = $1, "updated_at" = $2 WHERE "spree_option_types"."id" = 3  [["position", 1], ["updated_at", "2015-01-04 21:54:45.951789"]]
16:54:45 web.1  |    (0.5ms)  COMMIT
16:54:45 web.1  |   Spree::OptionType Load (0.5ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
16:54:45 web.1  |    (0.1ms)  BEGIN
16:54:45 web.1  |   Spree::OptionType Exists (0.4ms)  SELECT  1 AS one FROM "spree_option_types"  WHERE ("spree_option_types"."name" = 'tshirt-color' AND "spree_option_types"."id" != 2) LIMIT 1
16:54:45 web.1  |   SQL (0.4ms)  UPDATE "spree_option_types" SET "position" = $1, "updated_at" = $2 WHERE "spree_option_types"."id" = 2  [["position", 2], ["updated_at", "2015-01-04 21:54:45.972212"]]
16:54:45 web.1  |    (0.5ms)  COMMIT
16:54:45 web.1  |   Rendered text template (0.0ms)
16:54:45 web.1  | Completed 200 OK in 109ms (Views: 0.9ms | ActiveRecord: 14.1ms)
```

After:

``` sql
16:56:26 web.1  | Started POST "/admin/option_types/update_positions" for 127.0.0.1 at 2015-01-04 16:56:26 -0500
16:56:27 web.1  | /Users/benmorgan/.rvm/gems/ruby-2.2.0/bundler/gems/spree-4da14fa0fd9c/api/config/routes.rb:65: warning: duplicated key at line 65 ignored: :to
16:56:28 web.1  | Processing by Spree::Admin::OptionTypesController#update_positions as JS
16:56:28 web.1  |   Parameters: {"positions"=>{"3"=>"0", "1"=>"1", "2"=>"2"}}
16:56:28 web.1  |   Spree::User Load (0.7ms)  SELECT  "spree_users".* FROM "spree_users"  WHERE "spree_users"."deleted_at" IS NULL AND "spree_users"."id" = 1  ORDER BY "spree_users"."id" ASC LIMIT 1
16:56:28 web.1  |   Spree::Store Load (0.5ms)  SELECT  "spree_stores".* FROM "spree_stores"  WHERE (url like '%localhost%')  ORDER BY "spree_stores"."id" ASC LIMIT 1
16:56:28 web.1  |   Spree::Store Load (0.5ms)  SELECT  "spree_stores".* FROM "spree_stores"  WHERE "spree_stores"."default" = 't'  ORDER BY "spree_stores"."id" ASC LIMIT 1
16:56:28 web.1  |   Spree::Order Load (1.0ms)  SELECT  "spree_orders".* FROM "spree_orders"  WHERE "spree_orders"."completed_at" IS NULL AND "spree_orders"."currency" = 'USD' AND "spree_orders"."guest_token" = '5DrPt1c8YOkQXkeWYzzb4w' AND "spree_orders"."store_id" = 1 AND "spree_orders"."user_id" = 1 LIMIT 1
16:56:28 web.1  |   Spree::Order Load (0.7ms)  SELECT  "spree_orders".* FROM "spree_orders"  WHERE "spree_orders"."user_id" = $1 AND "spree_orders"."completed_at" IS NULL AND "spree_orders"."user_id" = 1  ORDER BY created_at DESC LIMIT 1  [["user_id", 1]]
16:56:28 web.1  |   Spree::Preference Load (0.5ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/backend_configuration/locale' LIMIT 1
16:56:28 web.1  |    (0.6ms)  SELECT COUNT(*) FROM "spree_roles" INNER JOIN "spree_roles_users" ON "spree_roles"."id" = "spree_roles_users"."role_id" WHERE "spree_roles_users"."user_id" = $1 AND "spree_roles"."name" = 'admin'  [["user_id", 1]]
16:56:28 web.1  |   Alchemy::Site Load (0.6ms)  SELECT  "alchemy_sites".* FROM "alchemy_sites"  WHERE "alchemy_sites"."host" = 'localhost'  ORDER BY "alchemy_sites"."id" ASC LIMIT 1
16:56:28 web.1  |   Alchemy::Site Load (0.4ms)  SELECT "alchemy_sites".* FROM "alchemy_sites"
16:56:28 web.1  |   Alchemy::Site Load (0.6ms)  SELECT  "alchemy_sites".* FROM "alchemy_sites"   ORDER BY "alchemy_sites"."id" ASC LIMIT 1
16:56:28 web.1  |   Alchemy::Language Load (1.0ms)  SELECT  "alchemy_languages".* FROM "alchemy_languages"  WHERE "alchemy_languages"."site_id" = 1 AND "alchemy_languages"."id" = 1 LIMIT 1
16:56:28 web.1  |   Alchemy::Language Load (0.6ms)  SELECT  "alchemy_languages".* FROM "alchemy_languages"  WHERE "alchemy_languages"."site_id" = 1 AND "alchemy_languages"."language_code" = 'en' AND "alchemy_languages"."country_code" = '' LIMIT 1
16:56:28 web.1  |    (0.5ms)  BEGIN
16:56:28 web.1  |   Spree::OptionType Load (0.3ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 3]]
16:56:28 web.1  |   Spree::OptionType Exists (1.5ms)  SELECT  1 AS one FROM "spree_option_types"  WHERE ("spree_option_types"."name" = 'example' AND "spree_option_types"."id" != 3) LIMIT 1
16:56:28 web.1  |   SQL (3.4ms)  UPDATE "spree_option_types" SET "position" = $1, "updated_at" = $2 WHERE "spree_option_types"."id" = 3  [["position", 0], ["updated_at", "2015-01-04 21:56:28.504080"]]
16:56:28 web.1  |   Spree::OptionType Load (0.3ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
16:56:28 web.1  |   Spree::OptionType Exists (0.5ms)  SELECT  1 AS one FROM "spree_option_types"  WHERE ("spree_option_types"."name" = 'tshirt-size' AND "spree_option_types"."id" != 1) LIMIT 1
16:56:28 web.1  |   SQL (0.6ms)  UPDATE "spree_option_types" SET "position" = $1, "updated_at" = $2 WHERE "spree_option_types"."id" = 1  [["position", 1], ["updated_at", "2015-01-04 21:56:28.524278"]]
16:56:28 web.1  |   Spree::OptionType Load (0.3ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
16:56:28 web.1  |   Spree::OptionType Exists (0.5ms)  SELECT  1 AS one FROM "spree_option_types"  WHERE ("spree_option_types"."name" = 'tshirt-color' AND "spree_option_types"."id" != 2) LIMIT 1
16:56:28 web.1  |    (0.5ms)  COMMIT
16:56:28 web.1  |   Rendered text template (0.0ms)
16:56:28 web.1  | Completed 200 OK in 422ms (Views: 1.0ms | ActiveRecord: 67.8ms)

16:56:30 web.1  | Started POST "/admin/option_types/update_positions" for 127.0.0.1 at 2015-01-04 16:56:30 -0500
16:56:30 web.1  | Processing by Spree::Admin::OptionTypesController#update_positions as JS
16:56:30 web.1  |   Parameters: {"positions"=>{"1"=>"0", "2"=>"1", "3"=>"2"}}
16:56:30 web.1  |   Spree::User Load (1.1ms)  SELECT  "spree_users".* FROM "spree_users"  WHERE "spree_users"."deleted_at" IS NULL AND "spree_users"."id" = 1  ORDER BY "spree_users"."id" ASC LIMIT 1
16:56:30 web.1  |   Spree::Store Load (0.6ms)  SELECT  "spree_stores".* FROM "spree_stores"  WHERE (url like '%localhost%')  ORDER BY "spree_stores"."id" ASC LIMIT 1
16:56:30 web.1  |   Spree::Store Load (0.6ms)  SELECT  "spree_stores".* FROM "spree_stores"  WHERE "spree_stores"."default" = 't'  ORDER BY "spree_stores"."id" ASC LIMIT 1
16:56:30 web.1  |   Spree::Order Load (1.0ms)  SELECT  "spree_orders".* FROM "spree_orders"  WHERE "spree_orders"."completed_at" IS NULL AND "spree_orders"."currency" = 'USD' AND "spree_orders"."guest_token" = '5DrPt1c8YOkQXkeWYzzb4w' AND "spree_orders"."store_id" = 1 AND "spree_orders"."user_id" = 1 LIMIT 1
16:56:30 web.1  |   Spree::Order Load (0.4ms)  SELECT  "spree_orders".* FROM "spree_orders"  WHERE "spree_orders"."user_id" = $1 AND "spree_orders"."completed_at" IS NULL AND "spree_orders"."user_id" = 1  ORDER BY created_at DESC LIMIT 1  [["user_id", 1]]
16:56:30 web.1  |   Spree::Preference Load (0.4ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/backend_configuration/locale' LIMIT 1
16:56:30 web.1  |    (0.4ms)  SELECT COUNT(*) FROM "spree_roles" INNER JOIN "spree_roles_users" ON "spree_roles"."id" = "spree_roles_users"."role_id" WHERE "spree_roles_users"."user_id" = $1 AND "spree_roles"."name" = 'admin'  [["user_id", 1]]
16:56:30 web.1  |   Alchemy::Site Load (0.7ms)  SELECT  "alchemy_sites".* FROM "alchemy_sites"  WHERE "alchemy_sites"."host" = 'localhost'  ORDER BY "alchemy_sites"."id" ASC LIMIT 1
16:56:30 web.1  |   Alchemy::Site Load (0.5ms)  SELECT "alchemy_sites".* FROM "alchemy_sites"
16:56:30 web.1  |   Alchemy::Site Load (0.4ms)  SELECT  "alchemy_sites".* FROM "alchemy_sites"   ORDER BY "alchemy_sites"."id" ASC LIMIT 1
16:56:30 web.1  |   Alchemy::Language Load (1.3ms)  SELECT  "alchemy_languages".* FROM "alchemy_languages"  WHERE "alchemy_languages"."site_id" = 1 AND "alchemy_languages"."id" = 1 LIMIT 1
16:56:30 web.1  |   Alchemy::Language Load (0.7ms)  SELECT  "alchemy_languages".* FROM "alchemy_languages"  WHERE "alchemy_languages"."site_id" = 1 AND "alchemy_languages"."language_code" = 'en' AND "alchemy_languages"."country_code" = '' LIMIT 1
16:56:30 web.1  |    (0.2ms)  BEGIN
16:56:30 web.1  |   Spree::OptionType Load (0.4ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
16:56:30 web.1  |   Spree::OptionType Exists (0.9ms)  SELECT  1 AS one FROM "spree_option_types"  WHERE ("spree_option_types"."name" = 'tshirt-size' AND "spree_option_types"."id" != 1) LIMIT 1
16:56:30 web.1  |   SQL (0.4ms)  UPDATE "spree_option_types" SET "position" = $1, "updated_at" = $2 WHERE "spree_option_types"."id" = 1  [["position", 0], ["updated_at", "2015-01-04 21:56:30.214466"]]
16:56:30 web.1  |   Spree::OptionType Load (0.5ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
16:56:30 web.1  |   Spree::OptionType Exists (0.7ms)  SELECT  1 AS one FROM "spree_option_types"  WHERE ("spree_option_types"."name" = 'tshirt-color' AND "spree_option_types"."id" != 2) LIMIT 1
16:56:30 web.1  |   SQL (0.5ms)  UPDATE "spree_option_types" SET "position" = $1, "updated_at" = $2 WHERE "spree_option_types"."id" = 2  [["position", 1], ["updated_at", "2015-01-04 21:56:30.233818"]]
16:56:30 web.1  |   Spree::OptionType Load (0.4ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 3]]
16:56:30 web.1  |   Spree::OptionType Exists (0.8ms)  SELECT  1 AS one FROM "spree_option_types"  WHERE ("spree_option_types"."name" = 'example' AND "spree_option_types"."id" != 3) LIMIT 1
16:56:30 web.1  |   SQL (0.4ms)  UPDATE "spree_option_types" SET "position" = $1, "updated_at" = $2 WHERE "spree_option_types"."id" = 3  [["position", 2], ["updated_at", "2015-01-04 21:56:30.249414"]]
16:56:30 web.1  |    (0.5ms)  COMMIT
16:56:30 web.1  |   Rendered text template (0.0ms)
16:56:30 web.1  | Completed 200 OK in 117ms (Views: 0.9ms | ActiveRecord: 13.8ms)

16:56:32 web.1  | Started POST "/admin/option_types/update_positions" for 127.0.0.1 at 2015-01-04 16:56:32 -0500
16:56:32 web.1  | Processing by Spree::Admin::OptionTypesController#update_positions as JS
16:56:32 web.1  |   Parameters: {"positions"=>{"2"=>"0", "1"=>"1", "3"=>"2"}}
16:56:32 web.1  |   Spree::User Load (0.9ms)  SELECT  "spree_users".* FROM "spree_users"  WHERE "spree_users"."deleted_at" IS NULL AND "spree_users"."id" = 1  ORDER BY "spree_users"."id" ASC LIMIT 1
16:56:32 web.1  |   Spree::Store Load (1.3ms)  SELECT  "spree_stores".* FROM "spree_stores"  WHERE (url like '%localhost%')  ORDER BY "spree_stores"."id" ASC LIMIT 1
16:56:32 web.1  |   Spree::Store Load (0.9ms)  SELECT  "spree_stores".* FROM "spree_stores"  WHERE "spree_stores"."default" = 't'  ORDER BY "spree_stores"."id" ASC LIMIT 1
16:56:32 web.1  |   Spree::Order Load (0.9ms)  SELECT  "spree_orders".* FROM "spree_orders"  WHERE "spree_orders"."completed_at" IS NULL AND "spree_orders"."currency" = 'USD' AND "spree_orders"."guest_token" = '5DrPt1c8YOkQXkeWYzzb4w' AND "spree_orders"."store_id" = 1 AND "spree_orders"."user_id" = 1 LIMIT 1
16:56:32 web.1  |   Spree::Order Load (1.2ms)  SELECT  "spree_orders".* FROM "spree_orders"  WHERE "spree_orders"."user_id" = $1 AND "spree_orders"."completed_at" IS NULL AND "spree_orders"."user_id" = 1  ORDER BY created_at DESC LIMIT 1  [["user_id", 1]]
16:56:32 web.1  |   Spree::Preference Load (0.5ms)  SELECT  "spree_preferences".* FROM "spree_preferences"  WHERE "spree_preferences"."key" = 'spree/backend_configuration/locale' LIMIT 1
16:56:32 web.1  |    (0.7ms)  SELECT COUNT(*) FROM "spree_roles" INNER JOIN "spree_roles_users" ON "spree_roles"."id" = "spree_roles_users"."role_id" WHERE "spree_roles_users"."user_id" = $1 AND "spree_roles"."name" = 'admin'  [["user_id", 1]]
16:56:32 web.1  |   Alchemy::Site Load (0.8ms)  SELECT  "alchemy_sites".* FROM "alchemy_sites"  WHERE "alchemy_sites"."host" = 'localhost'  ORDER BY "alchemy_sites"."id" ASC LIMIT 1
16:56:32 web.1  |   Alchemy::Site Load (0.7ms)  SELECT "alchemy_sites".* FROM "alchemy_sites"
16:56:32 web.1  |   Alchemy::Site Load (0.5ms)  SELECT  "alchemy_sites".* FROM "alchemy_sites"   ORDER BY "alchemy_sites"."id" ASC LIMIT 1
16:56:32 web.1  |   Alchemy::Language Load (1.2ms)  SELECT  "alchemy_languages".* FROM "alchemy_languages"  WHERE "alchemy_languages"."site_id" = 1 AND "alchemy_languages"."id" = 1 LIMIT 1
16:56:32 web.1  |   Alchemy::Language Load (1.0ms)  SELECT  "alchemy_languages".* FROM "alchemy_languages"  WHERE "alchemy_languages"."site_id" = 1 AND "alchemy_languages"."language_code" = 'en' AND "alchemy_languages"."country_code" = '' LIMIT 1
16:56:32 web.1  |    (0.1ms)  BEGIN
16:56:32 web.1  |   Spree::OptionType Load (0.4ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 2]]
16:56:32 web.1  |   Spree::OptionType Exists (0.5ms)  SELECT  1 AS one FROM "spree_option_types"  WHERE ("spree_option_types"."name" = 'tshirt-color' AND "spree_option_types"."id" != 2) LIMIT 1
16:56:32 web.1  |   SQL (0.4ms)  UPDATE "spree_option_types" SET "position" = $1, "updated_at" = $2 WHERE "spree_option_types"."id" = 2  [["position", 0], ["updated_at", "2015-01-04 21:56:32.868897"]]
16:56:32 web.1  |   Spree::OptionType Load (0.3ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
16:56:32 web.1  |   Spree::OptionType Exists (0.5ms)  SELECT  1 AS one FROM "spree_option_types"  WHERE ("spree_option_types"."name" = 'tshirt-size' AND "spree_option_types"."id" != 1) LIMIT 1
16:56:32 web.1  |   SQL (0.4ms)  UPDATE "spree_option_types" SET "position" = $1, "updated_at" = $2 WHERE "spree_option_types"."id" = 1  [["position", 1], ["updated_at", "2015-01-04 21:56:32.881404"]]
16:56:32 web.1  |   Spree::OptionType Load (0.4ms)  SELECT  "spree_option_types".* FROM "spree_option_types"  WHERE "spree_option_types"."id" = $1  ORDER BY spree_option_types.position LIMIT 1  [["id", 3]]
16:56:32 web.1  |   Spree::OptionType Exists (0.5ms)  SELECT  1 AS one FROM "spree_option_types"  WHERE ("spree_option_types"."name" = 'example' AND "spree_option_types"."id" != 3) LIMIT 1
16:56:32 web.1  |    (0.5ms)  COMMIT
16:56:32 web.1  |   Rendered text template (0.0ms)
16:56:32 web.1  | Completed 200 OK in 106ms (Views: 0.8ms | ActiveRecord: 14.6ms)
```
