### PR TITLE
real remove after fadeout in spree_remove_fields

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/admin.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/admin.js.erb
@@ -191,7 +191,9 @@ $(document).ready(function(){
     el.prev("input[type=hidden]").val("1");
     el.closest(".fields").hide();
     if (el.prop("href").substr(-1) == '#') {
-      el.parents("tr").fadeOut('hide');
+      el.parents("tr").fadeOut('hide', function() {
+        $(this).remove();
+      });
     }else if (el.prop("href")) {
       $.ajax({
         type: 'POST',


### PR DESCRIPTION
I use spree_remove_fields class in my customize resource which is a nested attribute of it's parent model form. I try to remove the item and submit the whole parent form. But the item still exist in my submit parameters. I check this callback function and realize that the tr line is only hidden not remove. How about remove it directly after fade out?
