### PR TITLE
[guides] Improve consistency of ruby markdown code

### DIFF
--- a/guides/content/developer/advanced/developer_tips.md
+++ b/guides/content/developer/advanced/developer_tips.md
@@ -5,9 +5,9 @@ section: advanced
 
 This guide presents accumulated wisdom from person-years of Spree use.
 
-### Upgrade Considerations
+## Upgrade Considerations
 
-#### The important commands
+### The important commands
 
 `spree -update` was removed in favor of Bundler.
 
@@ -23,14 +23,14 @@ sandbox's customized files.
 This makes it easier to see when and how some file has changed – which
 is often useful if you need to update a customized version.
 
-#### Dos and Don'ts
+### Dos and Don'ts
 
 !!!
 Try to avoid modifying `config/boot.rb` and
 `config/environment.rb`: use [initializers](#initializers) instead.
 !!!
 
-#### Tracking changes for overridden code
+### Tracking changes for overridden code
 
 Be aware that core changes might have an impact on the components you
 have overridden in your project.
@@ -42,7 +42,7 @@ If you can help us generalise the core code so that your preferred
 effect is achieved by altering a few parameters, this will be more useful than duplicating several
 files. Ideas and suggestions are always welcome.
 
-#### Initializers
+### Initializers
 
 Initializers are run during startup, and are the recommended way to
 execute certain settings. You can put initializers in extensions, thus have a way to execute
@@ -51,14 +51,14 @@ extension-specific configurations.
 See the [extensions guide](extensions_tutorial.html#extension-initializers) for
 more information.
 
-### Debugging techniques
+## Debugging techniques
 
-#### Use tests!
+### Use tests!
 
 Use `rake spec` and `rake test` to test basic functioning after you've
 made changes.
 
-#### Analysing crashes on a non-local machine
+### Analysing crashes on a non-local machine
 
 If you're testing on a server, whether in production or development
 mode, the following code in one
@@ -78,9 +78,9 @@ Spree::BaseController.class_eval do
 end
 ```
 
-### Managing large projects
+## Managing large projects
 
-#### To fork or not to fork…
+### To fork or not to fork…
 
 Suppose there's a few details of Spree that you want to override due to
 personal or client preference,

--- a/guides/content/developer/advanced/developer_tips.md
+++ b/guides/content/developer/advanced/developer_tips.md
@@ -69,14 +69,14 @@ show the detailed error page
 instead of `404.html`, so you don't have to hunt through the server
 logs.
 
-<% ruby do %>
-    Spree::BaseController.class_eval do
-      def local_request?
-        ENV["RAILS_ENV"] !="production" || current_user.present? &&
-          current_user.has_role?(:admin)
-      end
-    end
-<% end %>
+```ruby
+Spree::BaseController.class_eval do
+  def local_request?
+    ENV["RAILS_ENV"] !="production" || current_user.present? &&
+      current_user.has_role?(:admin)
+  end
+end
+```
 
 ### Managing large projects
 

--- a/guides/content/developer/advanced/seo.markdown
+++ b/guides/content/developer/advanced/seo.markdown
@@ -10,17 +10,17 @@ Search Engine Optimization features and future optimization development
 possibilities.
 
 
-### Existing Search Engine Optimization Features
+## Existing Search Engine Optimization Features
 
 Chapter 1 contains a description of the work that has been completed to
 address common search engine optimization issues.
 
-#### Relevant, Meaningful URLs
+### Relevant, Meaningful URLs
 
 The helper method `seo_url(taxon)` yields SEO friendly URLs such as [demo.spreecommerce.com/products/xm-direct2-interface-adapter](http://demo.spreecommerce.com/products/xm-direct2-interface-adapter) and [demo.spreecommerce.com/t/categories/headphones](http://demo.spreecommerce.com/t/categories/headphones).
 Each controller is configured to serve the content using these keyword-relevant, meaningful URLs.
 
-#### On Page Keyword Targeting
+### On Page Keyword Targeting
 
 Several enhancements have been made to improve on-page keyword
 targeting. The admin interface provides the ability to manage meta
@@ -29,14 +29,14 @@ tags are used throughout the site for product and taxonomy names. The
 ease of extension development and layout changes allows you to target
 keywords throughout the site.
 
-#### Clean Content
+### Clean Content
 
 Spree uses Skeleton, a responsive CSS framework that allows clean HTML
 that also responds well to any screen size. Having clean HTML with
 minimal inline JavaScript and CSS is considered to be a factor in search
 engine optimization.
 
-#### On Site Performance Optimization
+### On Site Performance Optimization
 
 Spree has been configured to serve one CSS and one JavaScript file on
 every page (excluding extension inclusions). Minimizing HTTP requests is
@@ -44,14 +44,14 @@ considered an important factor in search engine optimization as the
 server performance is an important influence in the search engine crawl
 behavior for a site.
 
-#### Google Analytics integration
+### Google Analytics integration
 
 Google Analytics has been integrated into the Spree core and can be
 managed from the "Analytics Trackers" section of the admin. Google
 Analytics is not included on your store if this preference is not set.
 The Google Analytics setup includes e-commerce conversion tracking.
 
-### Planned Search Engine Optimization Features
+## Planned Search Engine Optimization Features
 
 Although several common search engine optimization issues have been
 addressed, we are always looking for the new best practices in SEO.
@@ -59,7 +59,7 @@ Contributions to address issues will be very welcome. Visit the
 [contributing to spree section](contributing.html) to learn
 more about contributing.
 
-#### Product and Taxonomy Page Title Enhancements
+### Product and Taxonomy Page Title Enhancements
 
 Page titles are an important part of search engine optimization and
 should be meaningful and relevant to the page content. There are a few
@@ -68,13 +68,13 @@ Name" will appear in the beginning of each of your titles. When
 possible, we assign an appropriate title after that (product name, taxon
 name, etc), but when we can't do that, we use the "Default Seo Title".
 
-#### Alt Attribute on Product Images
+### Alt Attribute on Product Images
 
 The alt attribute on product images currently pulls data from product
 titles or the image filename. Enhancing the image alt tag can improve
 image search performance.
 
-#### Known Duplicate Content Issues
+### Known Duplicate Content Issues
 
 In the Spree demo, it is a known issue that
 [demo.spreecommerce.com](http://demo.spreecommerce.com/) contains
@@ -86,7 +86,7 @@ duplicate content pages may not only not be excluded from the main
 search engine index, but pages may also rank poorly in comparison to
 other sites where all external links go to one non-duplicated page.
 
-#### Integration of Content Management System or Content
+### Integration of Content Management System or Content
 
 There has been quite a bit of interest in development of [CMS
 integration into
@@ -96,7 +96,7 @@ not only can improve on page keyword targeting, but it also can improve
 the popularity of a site which can in turn improve search engine
 optimization.
 
-#### Tool Integration
+### Tool Integration
 
 In addition to integration of Google Analytics, several other tools can
 be implemented for SEO purposes such as Bing Webmaster Tools, Google
@@ -104,7 +104,7 @@ Webmaster Tools and Quantcast. Social media optimization tools such as
 Pinterest, Reddit, Digg, Delicious, Facebook, Google+ and Twitter may
 also be integrated to improve social networking site performance.
 
-### Spree SEO Extensions
+## Spree SEO Extensions
 
 The following list shows extensions that can improve search engine
 performance. Refer to the GitHub README for developer notes.
@@ -113,7 +113,7 @@ performance. Refer to the GitHub README for developer notes.
 -   [Spree Sitemap Generation](https://github.com/romul/spree_dynamic_sitemaps)
 -   [Product Reviews](https://github.com/spree/spree_reviews)
 
-### External Search Engine Optimization Efforts
+## External Search Engine Optimization Efforts
 
 Spree cannot control factors such as external links, quality of external
 links, server performance and capabilities. These areas should not be

--- a/guides/content/developer/core/adjustments.md
+++ b/guides/content/developer/core/adjustments.md
@@ -40,9 +40,11 @@ An adjustment's `label` attribute can be used as a good indicator of where the a
 
 There are some helper methods to return the different types of adjustments:
 
-    scope :shipping, -> { where(adjustable_type: 'Spree::Shipment') }
-    scope :included, -> { where(included: true)  }
-    scope :additional, -> { where(included: false) }
+```ruby
+scope :shipping, -> { where(adjustable_type: 'Spree::Shipment') }
+scope :included, -> { where(included: true)  }
+scope :additional, -> { where(included: false) }
+```
 
 * `open`: All open adjustments.
 * `eligible`: All eligible adjustments for the order. Useful for determining which adjustments are applying to the adjustable.

--- a/guides/content/developer/core/calculators.md
+++ b/guides/content/developer/core/calculators.md
@@ -186,7 +186,7 @@ config.spree.calculators.promotion_actions_create_adjustments << CustomCalculato
 
 For example if your calculator is placed in `app/models/spree/calculator/shipping/my_own_calculator.rb` you should call:
 
-```
+```ruby
 config = Rails.application.config
 config.spree.calculators.shipping_methods << Spree::Calculator::Shipping::MyOwnCalculator
 ```

--- a/guides/content/developer/core/promotions.md
+++ b/guides/content/developer/core/promotions.md
@@ -158,7 +158,7 @@ This file can be as simple as an empty file if your rule requires no parameters,
 
 And finally, your new rule must have a name and description defined for the locale you will be using it in. For English, edit `config/locales/en.yml` and add the following to support our new example rule:
 
-```
+```yml
 en:
   spree:
     promotion_rule_types:

--- a/guides/content/developer/customization/asset.markdown
+++ b/guides/content/developer/customization/asset.markdown
@@ -3,7 +3,7 @@ title: "Asset Customization"
 section: customization
 ---
 
-### Overview
+## Overview
 
 This guide covers how Spree manages its JavaScript, stylesheet and image
 assets and how you can extend and customize them including:
@@ -13,7 +13,7 @@ assets and how you can extend and customize them including:
 -   Managing extension specific assets
 -   Overriding Spree's core assets
 
-### Spree's Asset Pipeline
+## Spree's Asset Pipeline
 
 With the release of 3.1 Rails now supports powerful asset management
 features and Spree fully leverages these features to further extend and
@@ -53,7 +53,7 @@ Spree also generates four top level manifests (all.css & all.js, see
 above) that require all the core extension's and site specific
 stylesheets / JavaScript files.
 
-#### How core extensions (engines) manage assets
+### How core extensions (engines) manage assets
 
 All core engines have been updated to provide four asset manifests that
 are responsible for bundling up all the JavaScript files and stylesheets
@@ -93,14 +93,14 @@ External JavaScript libraries, stylesheets and images have also be
 relocated into vendor/assets (again Rails 3.1 standard approach), and
 all core extensions no longer have public directories.
 
-### Managing your application's assets
+## Managing your application's assets
 
 Assets that customize your Spree store should go inside the appropriate
 directories inside `vendor/assets/images/spree`, `vendor/assets/javascripts/spree`,
 or `vendor/assets/stylesheets/spree`. This is done so that these assets do
 not interfere with other parts of your application.
 
-### Managing your extension's assets
+## Managing your extension's assets
 
 We're suggesting that all third party extensions should adopt the same
 approach as Spree and provide the same four (or less depending on
@@ -115,7 +115,7 @@ a Rails generator to do so.
 For an example of an extension using a generator to install assets and
 migrations take a look at the [install_generator for spree_fancy](https://github.com/spree/spree_fancy/blob/master/lib/generators/spree_fancy/install/install_generator.rb).
 
-### Overriding Spree's core assets
+## Overriding Spree's core assets
 
 Overriding or replacing any of Spree's internal assets is even easier
 than before. It's recommended to attempt to replace as little as
@@ -127,7 +127,7 @@ themes with one noticeable difference: Extension & theme asset files
 will not be automatically included (see above for instructions on how to
 include asset files from your extensions / themes).
 
-#### Overriding individual CSS styles
+### Overriding individual CSS styles
 
 Say for example you want to replace the following CSS snippet:
 
@@ -155,7 +155,7 @@ The `frontend/all.css` manifest will automatically include `foo.css` and it
 will actually include both definitions with the one from `foo.css` being
 included last, hence it will be the rule applied.
 
-#### Overriding entire CSS files
+### Overriding entire CSS files
 
 To replace an entire stylesheet as provided by Spree you simply need to
 create a file with the same name and save it to the corresponding path
@@ -170,7 +170,7 @@ This same method can also be used to override stylesheets provided by
 third-party extensions.
 ***
 
-#### Overriding individual JavaScript functions
+### Overriding individual JavaScript functions
 
 A similar approach can be used for JavaScript functions. For example, if
 you wanted to override the `show_variant_images` method:
@@ -216,7 +216,7 @@ var show_variant_images = function(variant_id) {
 The resulting `frontend/all.js` would include both methods, with the latter
 being the one executed on request.
 
-#### Overriding entire JavaScript files
+### Overriding entire JavaScript files
 
 To replace an entire JavaScript file as provided by Spree you simply
 need to create a file with the same name and save it to the
@@ -231,7 +231,7 @@ This same method can be used to override JavaScript files provided
 by third-party extensions.
 ***
 
-#### Overriding images
+### Overriding images
 
 Finally, images can be replaced by substituting the required file into
 the same path within your application or extension as the file you would

--- a/guides/content/developer/customization/asset.markdown
+++ b/guides/content/developer/customization/asset.markdown
@@ -80,14 +80,14 @@ These manifests are included by default by the
 relevant all.css or all.js in the host Spree application. For example,
 `vendor/assets/javascripts/spree/backend/all.js` includes:
 
-<% ruby do %>
-    //= require jquery
-    //= require jquery_ujs
+```ruby
+//= require jquery
+//= require jquery_ujs
 
-    //= require spree/backend
+//= require spree/backend
 
-    //= require_tree .
-<% end %>
+//= require_tree .
+```
 
 External JavaScript libraries, stylesheets and images have also be
 relocated into vendor/assets (again Rails 3.1 standard approach), and

--- a/guides/content/developer/customization/authentication.markdown
+++ b/guides/content/developer/customization/authentication.markdown
@@ -23,9 +23,9 @@ opt-in. If you have an application that has used the *spree_auth*
 component in the past and you wish to continue doing so, you will need
 to add this extra line to your *Gemfile*:
 
-<% ruby do %>
-    gem 'spree_auth_devise', :git => "git://github.com/spree/spree_auth_devise"
-<% end %>
+```ruby
+gem 'spree_auth_devise', :git => "git://github.com/spree/spree_auth_devise"
+```
 
 By having this authentication component outside of Spree, applications
 that wish to use their own authentication may do so, and applications
@@ -53,15 +53,15 @@ To begin using your custom *User* class, you must first edit Spree's
 initializer located at *config/initializers/spree.rb* by changing this
 line:
 
-<% ruby do %>
-    Spree.user_class = "Spree::User"
-<% end %>
+```ruby
+Spree.user_class = "Spree::User"
+```
 
 To this:
 
-<% ruby do %>
-    Spree.user_class = "User"
-<% end %>
+```ruby
+Spree.user_class = "User"
+```
 
 Next, you need to run the custom user generator for Spree which will
 create two files. The first is a migration that will add the necessary
@@ -92,38 +92,38 @@ There are some authentication helpers of Spree's that you will need to
 possibly override. The file at *lib/spree/authentication_helpers.rb*
 contains the following code to help you do that:
 
-<% ruby do %>
-    module Spree
-      module AuthenticationHelpers
-         def self.included(receiver)
-           receiver.send :helper_method, :spree_login_path
-           receiver.send :helper_method, :spree_signup_path
-           receiver.send :helper_method, :spree_logout_path
-           receiver.send :helper_method, :spree_current_user
-         end
+```ruby
+module Spree
+  module AuthenticationHelpers
+     def self.included(receiver)
+       receiver.send :helper_method, :spree_login_path
+       receiver.send :helper_method, :spree_signup_path
+       receiver.send :helper_method, :spree_logout_path
+       receiver.send :helper_method, :spree_current_user
+     end
 
-         def spree_current_user
-           current_person
-         end
+     def spree_current_user
+       current_person
+     end
 
-         def spree_login_path
-           main_app.login_path
-         end
+     def spree_login_path
+       main_app.login_path
+     end
 
-         def spree_signup_path
-           main_app.signup_path
-         end
+     def spree_signup_path
+       main_app.signup_path
+     end
 
-         def spree_logout_path
-           main_app.logout_path
-         end
-       end
-    end
+     def spree_logout_path
+       main_app.logout_path
+     end
+   end
+end
 
-    Spree::BaseController.send      :include, Spree::AuthenticationHelpers
-    Spree::Api::BaseController.send :include, Spree::AuthenticationHelpers
-    ApplicationController.send      :include, Spree::AuthenticationHelpers
-<% end %>
+Spree::BaseController.send      :include, Spree::AuthenticationHelpers
+Spree::Api::BaseController.send :include, Spree::AuthenticationHelpers
+ApplicationController.send      :include, Spree::AuthenticationHelpers
+```
 
 Each of the methods defined in this module return values that are the
 most common in Rails applications today, but you may need to customize
@@ -151,13 +151,13 @@ You will need to define the *login_path*, *signup_path* and
 *logout_path* routes yourself, by using code like this inside your
 application's *config/routes.rb* if you're using Devise:
 
-<% ruby do %>
-    devise_scope :person do
-      get '/login', :to => "devise/sessions#new"
-      get '/signup', :to => "devise/registrations#new"
-      delete '/logout', :to => "devise/sessions#destroy"
-    end
-<% end %>
+```ruby
+devise_scope :person do
+  get '/login', :to => "devise/sessions#new"
+  get '/signup', :to => "devise/registrations#new"
+  delete '/logout', :to => "devise/sessions#destroy"
+end
+```
 
 Of course, this code will be different if you're not using Devise.
 Simply do not use the *devise_scope* method and change the controllers
@@ -199,17 +199,17 @@ Spree to check if the user is authorized to perform specific actions,
 such as accessing the admin section. Admin users of your system should
 be assigned the Spree admin role, like this:
 
-<% ruby do %>
-    user = User.find_by(email: "master@example.com")
-    user.spree_roles << Spree::Role.find_or_create_by(name: "admin")
-<% end %>
+```ruby
+user = User.find_by(email: "master@example.com")
+user.spree_roles << Spree::Role.find_or_create_by(name: "admin")
+```
 
 To test that this has worked, use the *has_spree_role?* method, like
 this:
 
-<% ruby do %>
-    user.has_spree_role?("admin")
-<% end %>
+```ruby
+user.has_spree_role?("admin")
+```
 
 If this returns *true*, then the user has admin permissions within
 Spree.
@@ -226,14 +226,14 @@ To make the login link appear on Spree pages, you will need to use a
 Deface override. Create a new file at
 *app/overrides/auth_login_bar.rb* and put this content inside it:
 
-<% ruby do %>
-    Deface::Override.new(:virtual_path => "spree/shared/_nav_bar",
-     :name => "auth_shared_login_bar",
-     :insert_before => "li#search-bar",
-     :partial => "spree/shared/login_bar",
-     :disabled => false,
-     :original => 'eb3fa668cd98b6a1c75c36420ef1b238a1fc55ad')
-<% end %>
+```ruby
+Deface::Override.new(:virtual_path => "spree/shared/_nav_bar",
+  :name => "auth_shared_login_bar",
+  :insert_before => "li#search-bar",
+  :partial => "spree/shared/login_bar",
+  :disabled => false,
+  :original => 'eb3fa668cd98b6a1c75c36420ef1b238a1fc55ad')
+```
 
 This override references a partial called "spree/shared/login_bar".
 This will live in a new partial called
@@ -271,9 +271,9 @@ this event after a user has successfully signed up in your application
 by setting a session variable after successful signup in whatever
 controller deals with user signup:
 
-<% ruby do %>
-    session[:spree_user_signup] = true
-<% end %>
+```ruby
+session[:spree_user_signup] = true
+```
 
 This line will cause the Spree event notifiers to be notified of this
 event and to apply any promotions to an order that are triggered once a

--- a/guides/content/developer/customization/authentication.markdown
+++ b/guides/content/developer/customization/authentication.markdown
@@ -3,7 +3,7 @@ title: "Custom Authentication"
 section: customization
 ---
 
-### Overview
+## Overview
 
 This guide covers using a custom authentication setup with Spree, such
 as one provided by your own application. This is ideal in situations
@@ -13,7 +13,7 @@ reading this guide, you will be familiar with:
 
 -   Setting up Spree to work with your custom authentication
 
-### Background
+## Background
 
 Traditionally, applications that use Spree have needed to use the
 *Spree::User* model that came with the *spree_auth* component of Spree.
@@ -32,7 +32,7 @@ that wish to use their own authentication may do so, and applications
 that have previously used *spree_auth*'s functionality may continue
 doing so by using this gem.
 
-#### The User Model
+### The User Model
 
 This guide assumes that you have a pre-existing model inside your
 application that represents the users of your application already. This
@@ -47,7 +47,7 @@ of this guide the model we will be referring to **will** be called
 *User*. If your model is called something else, do some mental
 substitution wherever you see *User*.
 
-##### Initial Setup
+#### Initial Setup
 
 To begin using your custom *User* class, you must first edit Spree's
 initializer located at *config/initializers/spree.rb* by changing this
@@ -86,7 +86,7 @@ $ bundle exec rake db:migrate
 Next you will need to define some methods to tell Spree where to find
 your application's authentication routes.
 
-##### Authentication Helpers
+#### Authentication Helpers
 
 There are some authentication helpers of Spree's that you will need to
 possibly override. The file at *lib/spree/authentication_helpers.rb*
@@ -174,7 +174,7 @@ while the server is running will require a restart, as wth any other
 modification to other files in *lib*.
 ***
 
-### The User Model
+## The User Model
 
 Once you have specified *Spree.user_class* correctly, there will be
 some new methods added to your *User* class. The first of these methods
@@ -220,7 +220,7 @@ methods, used for the API key that is used with Spree. The next two
 methods are *generate_spree_api_key!* and *clear_spree_api_key*
 which will generate and clear the Spree API key respectively.
 
-### Login link
+## Login link
 
 To make the login link appear on Spree pages, you will need to use a
 Deface override. Create a new file at
@@ -262,7 +262,7 @@ allow users to logout, one to allow them to login, and one to allow them
 to signup. These links will be visible on all customer-facing pages of
 Spree.
 
-### Signup promotion
+## Signup promotion
 
 In Spree, there is a promotion that acts on the user signup which will
 not work correctly automatically when you're not using the standard

--- a/guides/content/developer/customization/logic.markdown
+++ b/guides/content/developer/customization/logic.markdown
@@ -24,24 +24,24 @@ extension is to create a file within the relevant **app/models/spree** or
 **Adding a custom method to the Product model:**
 app/models/spree/product_decorator.rb
 
-<% ruby do %>
-    Spree::Product.class_eval do
-      def some_method
-        ...
-      end
-    end
-<% end %>
+```ruby
+Spree::Product.class_eval do
+  def some_method
+    ...
+  end
+end
+```
 
 **Adding a custom action to the ProductsController:**
 app/controllers/spree/products_controller_decorator.rb
 
-<% ruby do %>
-    Spree::ProductsController.class_eval do
-      def some_action
-        ...
-      end
-    end
-<% end %>
+```ruby
+Spree::ProductsController.class_eval do
+  def some_action
+    ...
+  end
+end
+```
 
 ***
 The exact same format can be used to redefine an existing method.
@@ -53,15 +53,15 @@ If you extend the Products controller with a new method, you may very
 well want to access product data in that method. You can do so by using
 the :load_data before_filter.
 
-<% ruby do %>
-    Spree::ProductsController.class_eval do
-      before_filter :load_data, :only => :some_action
+```ruby
+Spree::ProductsController.class_eval do
+  before_filter :load_data, :only => :some_action
 
-      def some_action
-        ...
-      end
-    end
-<% end %>
+  def some_action
+    ...
+  end
+end
+```
 
 ***
 :load_data will use params[:id] to lookup the product by its
@@ -82,9 +82,9 @@ any action, and is built on top of Rails 3's **respond_with** method
 (that all Spree controllers are now using). It accepts a hash of options
 using the following syntax:
 
-<% ruby do %>
-    respond_override :action_name => { :format =>  { :result => lambda { ... response ... } } }
-<% end %>
+```ruby
+respond_override :action_name => { :format =>  { :result => lambda { ... response ... } } }
+```
 
 -   **:action_name** - Can be any existing action within a controller
     (i.e. :update, :create, :new), provided that action is using
@@ -107,22 +107,22 @@ If you wanted to render a custom partial for the index action of
 ProductsController, you could include the following in your
 **app/controllers/spree/products_controller_decorator.rb** file.
 
-<% ruby do %>
-    Spree::ProductsController.class_eval do
-      respond_override :index => { :html =>
-        { :success => lambda { render 'shared/some_file' } } }
-    end
-<% end %>
+```ruby
+Spree::ProductsController.class_eval do
+  respond_override :index => { :html =>
+    { :success => lambda { render 'shared/some_file' } } }
+end
+```
 
 Or if you wanted to redirect on the failure to create in
 Admin::ProductsController, you would use:
 
-<% ruby do %>
-    Spree::Admin::ProductsController.class_eval do
-      respond_override :create => { :html => { :failure => lambda {
-        redirect_to some_url } } }
-    end
-<% end %>
+```ruby
+Spree::Admin::ProductsController.class_eval do
+  respond_override :create => { :html => { :failure => lambda {
+    redirect_to some_url } } }
+end
+```
 
 #### Caveats
 
@@ -143,16 +143,16 @@ the Image class. If you want to modify the default Spree product and
 thumbnail image sizes, simply create an image_decorator.rb file in your
 app model directory, and override the attachment sizes:
 
-<% ruby do %>
-    Spree::Image.class_eval do
-      attachment_definitions[:attachment][:styles] = {
-        :mini => '48x48>', # thumbs under image
-        :small => '100x100>', # images on category view
-        :product => '240x240>', # full product image
-        :large => '600x600>' # light box image
-      }
-    end
-<% end %>
+```ruby
+Spree::Image.class_eval do
+  attachment_definitions[:attachment][:styles] = {
+    :mini => '48x48>', # thumbs under image
+    :small => '100x100>', # images on category view
+    :product => '240x240>', # full product image
+    :large => '600x600>' # light box image
+  }
+end
+```
 
 You may also add additional image sizes for use in your templates
 (:micro for shopping cart view, for example).

--- a/guides/content/developer/customization/logic.markdown
+++ b/guides/content/developer/customization/logic.markdown
@@ -10,7 +10,7 @@ your exact business requirements including:
 -   Changing the output from an existing Spree controller action
 -   Customizing the image handling functionality.
 
-### Extending Classes
+## Extending Classes
 
 All of Spree's business logic (models, controllers, helpers, etc) can
 easily be extended / overridden to meet your exact requirements using
@@ -47,7 +47,7 @@ end
 The exact same format can be used to redefine an existing method.
 ***
 
-#### Accessing Product Data
+### Accessing Product Data
 
 If you extend the Products controller with a new method, you may very
 well want to access product data in that method. You can do so by using
@@ -68,14 +68,14 @@ end
 permalink.
 ***
 
-### Overriding Controller Action Responses
+## Overriding Controller Action Responses
 
 With the release of 0.60.0 Spree now supports a new way of overriding or
 changing the output of an existing controller's action without needing
 to completely override the method (while also easily avoiding double
 render exceptions).
 
-#### respond_override method
+### respond_override method
 
 The **respond_override** method is used to customize the response from
 any action, and is built on top of Rails 3's **respond_with** method
@@ -101,7 +101,7 @@ respond_override :action_name => { :format =>  { :result => lambda { ... respons
     the desired custom response (i.e. render or redirect_to). A lambda
     must be passed to ensure the code is evaluated at the correct time.
 
-#### Example Usage
+### Example Usage
 
 If you wanted to render a custom partial for the index action of
 ProductsController, you could include the following in your
@@ -124,7 +124,7 @@ Spree::Admin::ProductsController.class_eval do
 end
 ```
 
-#### Caveats
+### Caveats
 
 -   If an action does not use **respond_with** to define its response
     the **respond_override** will not work.
@@ -134,7 +134,7 @@ end
     state / logic within the lambda passed to prevent overriding all
     possible responses with the same override.
 
-### Product Images
+## Product Images
 
 Spree uses Thoughtbot's
 [paperclip](https://github.com/thoughtbot/paperclip) gem to manage
@@ -157,7 +157,7 @@ end
 You may also add additional image sizes for use in your templates
 (:micro for shopping cart view, for example).
 
-#### Image resizing option syntax
+### Image resizing option syntax
 
 Default behavior is to resize the image and maintain aspect ratio (i.e.
 the :product version of a 480x400 image will be 240x200). Some commonly

--- a/guides/content/developer/customization/s3_storage.markdown
+++ b/guides/content/developer/customization/s3_storage.markdown
@@ -3,12 +3,12 @@ title: "Use S3 for storage"
 section: customization
 ---
 
-### Overview
+## Overview
 
 Currently the Spree backend does not give you the option anymore to configure s3 for image storage.
 This guide covers how you can use S3 for storing assets in Spree.
 
-#### How to use S3
+### How to use S3
 
 Start with adding AWS-SDK to your gemfile with:  `gem 'aws-sdk'`, then install the gem by running `bundle install`.
 

--- a/guides/content/developer/customization/view.markdown
+++ b/guides/content/developer/customization/view.markdown
@@ -3,14 +3,14 @@ title: "View Customization"
 section: customization
 ---
 
-### Overview
+## Overview
 View customization allows you to extend or replace any view within a
 Spree store. This guide explains the options available, including:
 
 -   Using Deface for view customization
 -   Replacing entire view templates
 
-### Using Deface
+## Using Deface
 
 Deface is a standalone Rails library that enables you to customize Erb
 templates without needing to directly edit the underlying view file.
@@ -57,7 +57,7 @@ Deface::Override.new(:virtual_path  => "spree/checkout/registration",
 
 This override **inserts** <code><p>Registration is the future!</p></code> **before** the div with the id of "registration".
 
-#### Available actions
+### Available actions
 
 Deface applies an __action__ to element(s) matching the supplied CSS selector. These actions are passed when defining a new override are supplied as the key while the CSS selector for the target element(s) is the value, for example:
 
@@ -88,7 +88,7 @@ Deface currently supports the following actions:
 Not all actions are applicable to all elements. For example, <tt>:insert_top</tt> and <tt>:insert_bottom</tt> expects a parent element with children.
 ***
 
-#### Supplying content
+### Supplying content
 
 Deface supports three options for supplying content to be used by an override:
 
@@ -100,7 +100,7 @@ Deface supports three options for supplying content to be used by an override:
 As Deface operates on the Erb source the content supplied to an override can include Erb, it is not limited to just HTML. You also have access to all variables accessible in the original Erb context.
 ***
 
-#### Targeting elements
+### Targeting elements
 
 While Deface allows you to use a large subset of CSS3 style selectors (as provided by Nokogiri), the majority of Spree's views have been updated to include a custom HTML attribute (<tt>data-hook</tt>), which is designed to provide consistent targets for your overrides to use.
 
@@ -184,7 +184,7 @@ override to ensure maximum protection against changes:
  :insert_top => "[data-hook='thumbnails'], #thumbnails[data-hook]"
  ```
 
-#### Targeting ruby blocks
+### Targeting ruby blocks
 
 Deface evaluates all the selectors passed against the original erb view
 contents (and importantly not against the finished / generated HTML). In
@@ -232,7 +232,7 @@ selectors, for example:
 :insert_before => "erb[silent]:contains('elsif')"
 ```
 
-#### View upgrade protection
+### View upgrade protection
 
 To ensure upgrading between versions of Spree is as painless as
 possible, Deface supports an `:original` option that can contain a
@@ -255,7 +255,7 @@ source values before comparing, to reduce false warnings caused by basic
 whitespace differences.
 ***
 
-#### Organizing Overrides
+### Organizing Overrides
 
 The suggested method for organizing your overrides is to create a
 separate file for each override inside the **app/overrides** directory,
@@ -266,7 +266,7 @@ Using this method will ensure your overrides are compatible with
 future theming developments (editor).
 ***
 
-#### More information on Deface
+### More information on Deface
 
 For more information and sample overrides please refer to its
 [README](https://github.com/railsdog/deface) file on GitHub.
@@ -274,7 +274,7 @@ For more information and sample overrides please refer to its
 You can also see how Deface internals work, and test selectors using the
 [Deface Test Harness](http://deface.heroku.com) application.
 
-### Template Replacements
+## Template Replacements
 
 Sometimes the customization required to a view are so substantial that
 using a Deface override seems impractical. Spree also supports the
@@ -296,7 +296,7 @@ to get the location of the Spree code you're actually running and then
 copying the relevant file from there.
 ***
 
-#### Drawbacks of template replacements
+### Drawbacks of template replacements
 
 Whenever you copy an entire view into your extension or application you
 are adding a significant maintenance overhead to your application when

--- a/guides/content/developer/customization/view.markdown
+++ b/guides/content/developer/customization/view.markdown
@@ -48,12 +48,12 @@ this:
 
 If you wanted to insert some code just before the +#registration+ div on the page you would define an override as follows:
 
-<% ruby do %>
-    Deface::Override.new(:virtual_path  => "spree/checkout/registration",
-                         :insert_before => "div#registration",
-                         :text          => "<p>Registration is the future!</p>",
-                         :name          => "registration_future")
-<% end %>
+```ruby
+Deface::Override.new(:virtual_path  => "spree/checkout/registration",
+                     :insert_before => "div#registration",
+                     :text          => "<p>Registration is the future!</p>",
+                     :name          => "registration_future")
+```
 
 This override **inserts** <code><p>Registration is the future!</p></code> **before** the div with the id of "registration".
 
@@ -61,13 +61,13 @@ This override **inserts** <code><p>Registration is the future!</p></code> **befo
 
 Deface applies an __action__ to element(s) matching the supplied CSS selector. These actions are passed when defining a new override are supplied as the key while the CSS selector for the target element(s) is the value, for example:
 
-<% ruby do %>
-  :remove => "p.junk"
+```ruby
+:remove => "p.junk"
 
-  :insert_after => "div#wow p.header"
+:insert_after => "div#wow p.header"
 
-  :insert_bottom => "ul#giant-list"
-<% end %>
+:insert_bottom => "ul#giant-list"
+```
 
 Deface currently supports the following actions:
 
@@ -227,7 +227,7 @@ So you can target ruby code blocks with the same standard CSS3 style
 selectors, for example:
 
 ```ruby
- :replace => "erb[loud]:contains('t(:products)')"
+:replace => "erb[loud]:contains('t(:products)')"
 
 :insert_before => "erb[silent]:contains('elsif')"
 ```

--- a/guides/content/developer/deployment/deployment_tips.markdown
+++ b/guides/content/developer/deployment/deployment_tips.markdown
@@ -11,7 +11,7 @@ for troubleshooting standard deployment issues, including:
 * Email configuration
 * and more ...
 
-### Serving Static Assets
+## Serving Static Assets
 
 Rails applications (including Spree) use the convention of storing
 public assets (images, JavaScripts, stylesheets, etc.) in a directory
@@ -21,7 +21,7 @@ the `public` directory. In production mode, however, Rails is not
 configured to serve public assets unless specifically enabled. This
 leaves you with two options.
 
-#### Configure Rails to Serve Public Assets
+### Configure Rails to Serve Public Assets
 
 Rails has a `config.serve_static_assets` setting that allows you to
 override its default behavior in the production environment. If you want
@@ -40,7 +40,7 @@ You should consider the advice of the Rails core team and let your
 webserver do what it does best (as described in the next section.)
 ***
 
-##### Configure the Web Server to Use the *public* Directory
+#### Configure the Web Server to Use the *public* Directory
 
 The recommended approach for handling static assets is to allow your web
 server to handle serving these files. If you want to follow this
@@ -69,7 +69,7 @@ Options ~~MultiViews
 
 Each web server will have its own method for doing this so please consult the appropriate documentation for more details.
 
-### Enabling SSL
+## Enabling SSL
 
 Spree supports SSL and contains a special filter to require SSL for certain sensitive pages It also has the ability to redirect SSL requests that do not require SSL back to standard unencrypted HTTP. The code for this is built right into Spree and is based on the
 [ssl_requirement](https://github.com/rails/ssl_requirement/tree/master) by David Heinemeier Hansson.
@@ -92,7 +92,7 @@ possible. You may, however, make minor changes such as disabling email
 or sending email to a test account instead of the designated recipient.
 ***
 
-#### SSL Preferences
+### SSL Preferences
 
 SSL behavior in Spree is determined by several different preferences.
 
@@ -105,7 +105,7 @@ SSL behavior in Spree is determined by several different preferences.
 For more information on preferences in general you may wish to read the
 [Preference Guide](preferences.html).
 
-#### Changing the Default Settings
+### Changing the Default Settings
 
 If you do not wish to use SSL in production or staging, or if you wish to enable SSL in development mode, you will have to change the `:allow_ssl_in_production` configuration setting. This can be done via the admin interface as shown below:
 
@@ -121,7 +121,7 @@ config.allow_ssl_in_staging = false
 
 ## Performance Tips
 
-### Running in Production Mode
+## Running in Production Mode
 
 If you are noticing that Spree seems to be running slowly you should
 make sure that you are running in "production mode." You can start your
@@ -134,11 +134,11 @@ $ bundle exec rails server -e production
 Please consult your web server documentation for more details on
 enabling production mode for your particular web server.
 
-### Passenger Timeout
+## Passenger Timeout
 
 If you are running on [Passenger](http://www.modrails.com) then you may be noticing that the first request to your Spree application is very slow if the application has been idle for some time (or you have just restarted.) Consider changing the [PassengerPoolIdleTime](http://www.modrails.com/documentation/Users%20guide%20Apache.html#PassengerPoolIdleTime) as described in the Passenger documentation.
 
-### Caching
+## Caching
 
 Most stores spend a lot of time serving up the same pages over and over
 again. In many cases, the content being served is exactly identical or

--- a/guides/content/developer/tutorials/migration.markdown
+++ b/guides/content/developer/tutorials/migration.markdown
@@ -18,7 +18,7 @@ working to update it. In the meantime if you see things in here that are
 confusing it's possible that they no longer apply, etc.
 !!!
 
-### Overview
+## Overview
 
 This guide is a mix of tips and information about the relevant APIs,
 intended to help simplify the process of getting a new site set up -
@@ -32,12 +32,12 @@ import legacy order details, so there's a short discussion on this.
 Finally, there are some tips about how to ease the theme development
 process.
 
-### Data Import Format
+## Data Import Format
 
 This part discusses some options for getting data into the system,
 including some discussion of using relevant formats.
 
-#### Direct SQL import
+### Direct SQL import
 
 Can we just format our data as SQL tables and import it directly? In
 principle yes, but it takes effort to get the format right,
@@ -51,7 +51,7 @@ moving between hosting platforms. Another is when cloning some project:
 collaborators can just import a database dump prepared by someone else,
 and save the time of the code import.
 
-#### Rails Fixtures
+### Rails Fixtures
 
 Spree uses fixtures to load up the sample data. It's a convenient
 format for small collections of data, but can be tricky when working with
@@ -61,7 +61,7 @@ need to be careful with validation.
 Note that Rails can dump slices of the database in fixture format. This
 is sometimes useful.
 
-#### SQL or XML legacy data
+### SQL or XML legacy data
 
 This is the case where you are working with legacy data in formats like
 SQL or XML, and the question is more how to get the useful data out.
@@ -79,7 +79,7 @@ help
 to use views or complex queries to flatten multi-table data into a
 single table - which can then be treated like a spreadsheet.
 
-#### Spreadsheet format
+### Spreadsheet format
 
 Most of the information about products can be flattened into
 spreadsheet
@@ -89,7 +89,7 @@ in this format.
 
 For example, your spreadsheet could have the following columns:
 
-#### Fixed Details
+### Fixed Details
 
 -    product name
 -    master price
@@ -101,10 +101,10 @@ For example, your spreadsheet could have the following columns:
 -    list of images
 -    description
 
-#### Several Properties
+### Several Properties
 -   one column for each property type used in your catalogue
 
-#### Variant Specifications
+### Variant Specifications
 -   option types for the product\
 -   one variant per column, each listing the option values and the price/sku
 
@@ -129,7 +129,7 @@ Another possibility for coding variants is to have each variant on a
 separate row, and to leave the fixed fields empty when a row is a variant of the
 last-introduced product. This is easier to read.
 
-#### Seed code
+### Seed code
 
 This is more a technique for getting the data loaded at the right time.
 Technically, the product catalogue is *seed data*, standard data which
@@ -149,7 +149,7 @@ If the order of loading is important, choose names for the files
 so that alphabetical order gives the correct load order…
 ***
 
-#### Important system-wide settings
+### Important system-wide settings
 
 A related but important topic is the Spree core settings that your app
 will need to function correctly, eg to disable backordering or to
@@ -159,13 +159,13 @@ interface, but we recommend using initializers for these. See the
 guide](preferences.html#persisting-modifications-to-preferences) for
 more info.
 
-### Catalog creation
+## Catalog creation
 
 This section covers everything relating to import of a product set,
 including the product details, variants, properties and options,
 images, and taxons.
 
-#### Preliminaries
+### Preliminaries
 
 Let's assume that you are working from a CSV-compatible format, and so
 are reading one product per row, and each row contains values for the fixed
@@ -176,7 +176,7 @@ upload scripts will call *save* at appropriate times or use
 *update_attribute+
 etc.
 
-#### Products
+### Products
 
 Products must have at least a name and a price in order to pass
 validation, and we set the description too.
@@ -198,7 +198,7 @@ displays.
 p.available_on = Time.now
 ```
 
-##### The Master variant
+#### The Master variant
 
 Every product has a master variant, and this is created automatically
 when the product is created. It is accessible via *p.master*, but note that many
@@ -210,14 +210,14 @@ The dimensions and weight fields should be self-explanatory.
 The *sku* field holds the product's stock code, and you will want to set
 this if the product does not have option variants.
 
-##### Stock levels
+#### Stock levels
 
 If you don't have option variants, then you may also need to register
 some stock for the master variant. The exact steps depend on how you
 have configured Spree's [inventory system](inventory.html), but most sites
 will just need to assign to *p.on_hand*, eg *p.on_hand = 100*.
 
-##### Shipping category
+#### Shipping category
 
 A product's [shipping category](shipments.html#shipping-categories) field
 provides product-specific information for the shipping
@@ -233,7 +233,7 @@ when required.
 p.shipping_category = Spree::ShippingCategory.where(:name => 'Type A').first_or_create
 ```
 
-##### Tax category
+#### Tax category
 
 This is a similar idea to the shipping category, and guides the
 calculation of product taxes, eg to distinguish clothing items from electrical
@@ -249,7 +249,7 @@ You can also fill in this information automatically at a *later* date,
 e.g. use the taxon information to decide which tax categories something
 belongs in.
 
-#### Taxons
+### Taxons
 
 Adding a product to a particular taxon is easy: just add the taxon to
 the list of taxons for a product.
@@ -312,7 +312,7 @@ taxonomy for brands and product ranges, like 'Guitars' with child
 'Acoustic'. You could use various property or option values to drive the
 creation of such taxonomies.
 
-#### Product Properties
+### Product Properties
 
 The first step is to create the property 'types'. These should be
 known in advance so you can define these at the start of the script. You
@@ -330,7 +330,7 @@ column, this means:
 Spree::ProductProperty.create :property => size_prop, :product => p, :value => size_info
 ```
 
-##### Product prototypes
+#### Product prototypes
 
 The admin interface uses a system of 'prototypes' to speed up data
 entry, which seeds a product with a given set of option types and (empty)
@@ -339,7 +339,7 @@ programmatically, since the code will need to do the hard work of
 creating variants and setting properties anyway. However, we mention it
 here for completeness.
 
-#### Variants
+### Variants
 
 Variants allow different versions of a product to be offered, e.g.
 allowing variations in size and color for clothing. If a product comes in only
@@ -358,7 +358,7 @@ code is tolerant of missing values. Certain extensions may be more
 strict, e.g. ones for providing advanced variant selection.
 ***
 
-##### Creating variants
+#### Creating variants
 
 New variants require only a product to be associated with, but it is
 useful to set an identifying *sku* code too. The price field is optional: if it is not
@@ -382,7 +382,7 @@ will just need to assign to *v.on_hand*, eg *v.on_hand = 100*.
 You now need to set some option types and values, so customers can
 choose between the variants.
 
-##### Option types
+#### Option types
 
 The option types to use will vary from product to product, so you will
 need to give this information for each product - or assume a default
@@ -398,7 +398,7 @@ p.option_types = option_names_col.map do |name|
 end
 ```
 
-##### Option values
+#### Option values
 
 Option values represent the choices possible for some option type.
 Again, you could declare them in advance, or use *where.first_or_create*. You'll
@@ -427,7 +427,7 @@ setup. It also avoids filling up a type with lots of similar options -
 and so reduces the number of options when using faceted search etc. You can
 also attach resources like color swatches to the more specific values.
 
-##### Ordering of option values
+#### Ordering of option values
 You might want option values to appear in a certain order, such as by
 increasing size or by alphabetical order. The *Spree::OptionValue* model uses
 *acts_as_list* for setting the order, and option types will use the *position* field when retrieving
@@ -452,7 +452,7 @@ color_type.option_values.sort_by(&:name).each_with_index do |val,pos|
 end
 ```
 
-##### Further reading
+#### Further reading
 
 [Steph Skardal](https://github.com/stephskardal) has produced a useful
 blog post on [product
@@ -460,7 +460,7 @@ optioning](http://blog.endpoint.com/2010/01/rails-ecommerce-spree-hooks-comments
 This discusses how the variant option representation works and how she
 used it to build an extension for enhanced product option selection.
 
-#### Product and Variant images
+### Product and Variant images
 
 Spree uses [paperclip](https://github.com/thoughtbot/paperclip) to
 manage image attachments and their various size formats. (See the [Customization Guide](logic#product-images) for info on altering the image formats.)

--- a/guides/content/release_notes/0_30_0.md
+++ b/guides/content/release_notes/0_30_0.md
@@ -192,9 +192,9 @@ So now you have a new Rails 3.x application and you've moved over your
 custom files. Its time to add the Spree gem into the mix. Edit your
 *Gemfile* and add the following entry:
 
-<% ruby do %>
-    gem 'spree', '0.30.0'
-<% end %>
+```ruby
+gem 'spree', '0.30.0'
+```
 
 Then install the Spree gem using the familiar Bundler approach:
 

--- a/guides/content/release_notes/0_40_0.md
+++ b/guides/content/release_notes/0_40_0.md
@@ -144,25 +144,25 @@ The *Order* model is one such model in Spree where this interface is
 already in use. The following code snippet shows how to add this
 functionality through the use of the *token_resource* declaration:
 
-<%ruby do %>
-    Order.class_eval do
-     token_resource
-    end
-<% end %>
+```ruby
+Order.class_eval do
+  token_resource
+end
+```
 
 If we examine the default CanCan permissions for *Order* we can see how
 tokens can be used to grant access in cases where the user is not
 authenticated.
 
-<%ruby do %>
-    can :read, Order do |order, token|
-     order.user  user || order.token && token  order.token
-    end
-    can :update, Order do |order, token|
-     order.user  user || order.token && token  order.token
-    end
-    can :create, Order
-<% end %>
+```ruby
+can :read, Order do |order, token|
+  order.user  user || order.token && token  order.token
+end
+can :update, Order do |order, token|
+  order.user  user || order.token && token  order.token
+end
+can :create, Order
+```
 
 This configuration states that in order to read or update an order, you
 must be either authenticated as the correct user, or supply the correct
@@ -172,9 +172,9 @@ The final step is to ensure that the token is passed to CanCan when the
 authorization is performed. Most controllers will do this automatically
 if they declare *resource_controller*.
 
-<% ruby do %>
-    authorize! action, resource, session[:access_token]
-<% end %>
+```ruby
+authorize! action, resource, session[:access_token]
+```
 
 ***
 Since *OrdersController* does not implement *resource_controller*

--- a/guides/content/release_notes/0_70_0.md
+++ b/guides/content/release_notes/0_70_0.md
@@ -60,10 +60,9 @@ action:
 Both themes can be installed by just adding a reference to the git
 repository to your Gemfile, ie:
 
-<% ruby do %>
-        gem 'spree_blue_theme', :git =>
-        'git://github.com/spree/spree_blue_theme.git'
-<% end %>
+```ruby
+gem 'spree_blue_theme', :git => 'git://github.com/spree/spree_blue_theme.git'
+```
 
 # Experimental SCSS/SASS Theme
 
@@ -263,31 +262,31 @@ end
 Rails 3.1 simplifies the `config/boot.rb` file significantly, so update
 yours to match:
 
-<% ruby do %>
-    require 'rubygems'
+```ruby
+require 'rubygems'
 
-    # Set up gems listed in the Gemfile.
-    ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', *FILE*)
+# Set up gems listed in the Gemfile.
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', *FILE*)
 
-    require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
-<% end %>
+require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+```
 
 ### Enable the asset pipeline
 
 Add the following line to `config/application.rb`, this will enable the
 Asset Pipeline feature (required by 0.70.0):
 
-<% ruby do %>
-    config.assets.enabled = true
-<% end %>
+```ruby
+config.assets.enabled = true
+```
 
 ### Remove deprecated configuration
 
 Remove the following line from `config/environments/development.rb`.
 
-<% ruby do %>
-    config.action_view.debug_rjs = true
-<% end %>
+```ruby
+config.action_view.debug_rjs = true
+```
 
 ### Retire lib/spree_site.rb
 
@@ -314,9 +313,9 @@ below.
 Also ensure the following line is **not** present in
 config/application.rb:
 
-<%ruby do %>
-    require 'spree_site'
-<% end %>
+```ruby
+require 'spree_site'
+```
 
 ## Update gems & generate Spree files
 
@@ -343,10 +342,10 @@ After running the generator above, it's best to check to make sure you
 do not have multiple copies of the following line, in
 `config/application.rb`:
 
-<% ruby do %>
-    config.middleware.use "RedirectLegacyProductUrl"
-    config.middleware.use "SeoAssist"
-<% end %>
+```ruby
+config.middleware.use "RedirectLegacyProductUrl"
+config.middleware.use "SeoAssist"
+```
 
 ### Update your database
 
@@ -425,9 +424,9 @@ To include your previously defined old style theming hooks from
 `lib/site_hooks.rb` add the following to the bottom of
 `config/application.rb`
 
-<%ruby do %>
- require 'lib/site_hooks'
-<% end %>
+```ruby
+require 'lib/site_hooks'
+```
 
 ***
 The development log will include suggested replacement Deface

--- a/guides/content/release_notes/1_0_0.md
+++ b/guides/content/release_notes/1_0_0.md
@@ -55,17 +55,17 @@ the *spree* routing proxy, so that Rails will route to Spree's
 application. Routing helpers referencing Spree parts must now be written
 like this:
 
-<% ruby do %>
-    spree.product_url
-<% end %>
+```ruby
+spree.product_url
+```
 
 Conversely, to reference routes from the main application within a
 controller, view or template from Spree, you must use the *main_app*
 routing proxy like this:
 
-<% ruby do %>
-    main_app.root_url
-<% end %>
+```ruby
+main_app.root_url
+```
 
 If you encounter errors where routing methods you think should be there
 are not available, ensure that you aren't trying to call a Spree route
@@ -78,9 +78,9 @@ When *rails g spree:install* is run inside an application, it will
 install Spree, mounting the *Spree::Core::Engine* component by inserting
 this line automatically into *config/routes.rb*:
 
-<% ruby do %>
-    mount Spree::Core::Engine, :at => "/"
-<% end %>
+```ruby
+mount Spree::Core::Engine, :at => "/"
+```
 
 By default, all Spree routes will be available at the root of your
 domain. For example, if your domain is http://shop.com, Spree's
@@ -91,9 +91,9 @@ You can customize this simply by changing the *:at* specification in
 http://bobsite.com and you would like Spree to be mounted at /shop, you
 can write this:
 
-<% ruby do %>
-    mount Spree::Core::Engine, :at => "/shop"
-<% end %>
+```ruby
+mount Spree::Core::Engine, :at => "/shop"
+```
 
 The different parts of Spree (Auth, API, Dash & Promo) all extend the
 Core's routes, and so they will be mounted as well if they are available
@@ -153,12 +153,12 @@ We have moved all the gateways out of core (except bogus) to the [Spree
 Gateway Gem](https://github.com/spree/spree_gateway). You can add this
 gem to your Gemfile if you need one of those gateways.
 
-<% ruby do %>
-    gem 'spree'
+```ruby
+gem 'spree'
 
-    #  add to your Gemfile after the Spree gem
-    gem 'spree_gateway'
-<% end %>
+#  add to your Gemfile after the Spree gem
+gem 'spree_gateway'
+```
 
 The gateways available in the [Spree Gateway
 Gem](https://github.com/spree/spree_gateway) are community supported.
@@ -184,10 +184,10 @@ The lines for middleware in *config/application.rb* within a host
 application are now deprecated. When upgrading to Spree 1.0 you must
 remove these two lines from *config/application.rb*:
 
-<% ruby do %>
+```ruby
 config.middleware.use "SeoAssist"
 config.middleware.use "RedirectLegacyProductUrl"
-<% end %>
+```
 
 These two pieces of middleware are now automatically included by the
 `Spree::Core::Engine`.
@@ -337,9 +337,9 @@ steps.
 You will want to begin the update process by updating the Spree gem in
 your Gemfile to reference version 1.0.0.
 
-<% ruby do %>
-    gem 'spree', '1.0.0'
-<% end %>
+```ruby
+gem 'spree', '1.0.0'
+```
 
 Next, you will need to update this gem using this command:
 
@@ -366,15 +366,15 @@ You will need to update your routes file in order for Spree's routes to
 be correctly loaded. You will need to add `mount Spree::Core::Engine,
 :at => '/'` as shown below.
 
-<% ruby do %>
-    #config/routes.rb
-    YourStore::Application.routes.draw do
-        mount Spree::Core::Engine, :at => '/'
-
-        # your application's custom routes
-        …
-    end
-<% end %>
+```ruby
+#config/routes.rb
+YourStore::Application.routes.draw do
+  mount Spree::Core::Engine, :at => '/'
+  
+  # your application's custom routes
+  …
+end
+```
 
 If you're mounting Spree at the default root path, it is recommended to
 place your application's custom routes beneath Spree's mounted routes as
@@ -389,21 +389,21 @@ option to something different, such as *:at => '/shop'*.
 Remove the following two lines from **config/application.rb** in your
 application:
 
-<% ruby do %>
+```ruby
 config.middleware.use "SeoAssist"
 config.middleware.use "RedirectLegacyProductUrl"
-<% end %>
+```
 
 These two pieces of middleware are now automatically included by Spree.
 If you have no desire to use these pieces of middleware, you can now
 remove them by placing these two lines into your
 **config/application.rb**:
 
-<% ruby do %>
-    config.middleware.delete "Spree::Core::Middleware::SeoAssist"
-    config.middleware.delete
-    "Spree::Core::Middleware::RedirectLegacyProductUrl"
-<% end %>
+```ruby
+config.middleware.delete "Spree::Core::Middleware::SeoAssist"
+config.middleware.delete
+"Spree::Core::Middleware::RedirectLegacyProductUrl"
+```
 
 ## Migrations
 

--- a/guides/content/release_notes/2_4_0.md
+++ b/guides/content/release_notes/2_4_0.md
@@ -32,12 +32,12 @@ If you have implemented your own authentication system instead of using spree_au
 or you have implemented your own adjustment source please ensure you change your
 concerns to the new namespace:
 
-<% ruby do %>
-    Spree::Core::AdjustmentSource => Spree::AdjustmentSource
-    Spree::Core::CalculatedAdjustments => Spree::CalculatedAdjustments
-    Spree::Core::UserAddress => Spree::UserAddress
-    Spree::Core::UserPaymentSource => Spree::UserPaymentSource
-<% end %>
+```ruby
+Spree::Core::AdjustmentSource => Spree::AdjustmentSource
+Spree::Core::CalculatedAdjustments => Spree::CalculatedAdjustments
+Spree::Core::UserAddress => Spree::UserAddress
+Spree::Core::UserPaymentSource => Spree::UserPaymentSource
+```
 
 Also please review each of the noteable changes, and ensure your customizations
 or extensions are not effected. If you are effected by a change, and have any


### PR DESCRIPTION
Hey,
While reading official guides I noticed that in [several](https://guides.spreecommerce.com/developer/authentication.html#the-user-model) [places](https://guides.spreecommerce.com/developer/authentication.html#login-link) markdown of ruby code is missing or is different than in the [rest of](https://guides.spreecommerce.com/developer/payments.html#auto-capturing) [guides](https://guides.spreecommerce.com/developer/promotions.html#registering-a-new-action)

After investigating, I saw that there was `<% ruby do %>` used instead of ````ruby`. I changed that and  added code blocks to couple of places where I saw them missing

Let me know what you think and if I should go further with guides fixes, because I see more things that can be improved. Thanks :)
