### PR TITLE
Making in_stock? cache expirable after 24 hours

### DIFF
--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -181,7 +181,7 @@ module Spree
     end
 
     def in_stock?
-      Rails.cache.fetch(in_stock_cache_key) do
+      Rails.cache.fetch(in_stock_cache_key, expires_in: 24.hours) do
         total_on_hand > 0
       end
     end


### PR DESCRIPTION
in_stock is cached forever and sometimes the inventory is modified externally or something happens that get's out of sync, with this, at least it'd be expired after a day and recalculated
