### PR TITLE
[guides] Adjust headers types to make them consistent throughout guides

### DIFF
--- a/guides/content/developer/advanced/developer_tips.md
+++ b/guides/content/developer/advanced/developer_tips.md
@@ -5,9 +5,9 @@ section: advanced
 
 This guide presents accumulated wisdom from person-years of Spree use.
 
-### Upgrade Considerations
+## Upgrade Considerations
 
-#### The important commands
+### The important commands
 
 `spree -update` was removed in favor of Bundler.
 
@@ -23,14 +23,14 @@ sandbox's customized files.
 This makes it easier to see when and how some file has changed – which
 is often useful if you need to update a customized version.
 
-#### Dos and Don'ts
+### Dos and Don'ts
 
 !!!
 Try to avoid modifying `config/boot.rb` and
 `config/environment.rb`: use [initializers](#initializers) instead.
 !!!
 
-#### Tracking changes for overridden code
+### Tracking changes for overridden code
 
 Be aware that core changes might have an impact on the components you
 have overridden in your project.
@@ -42,7 +42,7 @@ If you can help us generalise the core code so that your preferred
 effect is achieved by altering a few parameters, this will be more useful than duplicating several
 files. Ideas and suggestions are always welcome.
 
-#### Initializers
+### Initializers
 
 Initializers are run during startup, and are the recommended way to
 execute certain settings. You can put initializers in extensions, thus have a way to execute
@@ -51,14 +51,14 @@ extension-specific configurations.
 See the [extensions guide](extensions_tutorial.html#extension-initializers) for
 more information.
 
-### Debugging techniques
+## Debugging techniques
 
-#### Use tests!
+### Use tests!
 
 Use `rake spec` and `rake test` to test basic functioning after you've
 made changes.
 
-#### Analysing crashes on a non-local machine
+### Analysing crashes on a non-local machine
 
 If you're testing on a server, whether in production or development
 mode, the following code in one
@@ -78,9 +78,9 @@ logs.
     end
 <% end %>
 
-### Managing large projects
+## Managing large projects
 
-#### To fork or not to fork…
+### To fork or not to fork…
 
 Suppose there's a few details of Spree that you want to override due to
 personal or client preference,

--- a/guides/content/developer/advanced/seo.markdown
+++ b/guides/content/developer/advanced/seo.markdown
@@ -10,17 +10,17 @@ Search Engine Optimization features and future optimization development
 possibilities.
 
 
-### Existing Search Engine Optimization Features
+## Existing Search Engine Optimization Features
 
 Chapter 1 contains a description of the work that has been completed to
 address common search engine optimization issues.
 
-#### Relevant, Meaningful URLs
+### Relevant, Meaningful URLs
 
 The helper method `seo_url(taxon)` yields SEO friendly URLs such as [demo.spreecommerce.com/products/xm-direct2-interface-adapter](http://demo.spreecommerce.com/products/xm-direct2-interface-adapter) and [demo.spreecommerce.com/t/categories/headphones](http://demo.spreecommerce.com/t/categories/headphones).
 Each controller is configured to serve the content using these keyword-relevant, meaningful URLs.
 
-#### On Page Keyword Targeting
+### On Page Keyword Targeting
 
 Several enhancements have been made to improve on-page keyword
 targeting. The admin interface provides the ability to manage meta
@@ -29,14 +29,14 @@ tags are used throughout the site for product and taxonomy names. The
 ease of extension development and layout changes allows you to target
 keywords throughout the site.
 
-#### Clean Content
+### Clean Content
 
 Spree uses Skeleton, a responsive CSS framework that allows clean HTML
 that also responds well to any screen size. Having clean HTML with
 minimal inline JavaScript and CSS is considered to be a factor in search
 engine optimization.
 
-#### On Site Performance Optimization
+### On Site Performance Optimization
 
 Spree has been configured to serve one CSS and one JavaScript file on
 every page (excluding extension inclusions). Minimizing HTTP requests is
@@ -44,14 +44,14 @@ considered an important factor in search engine optimization as the
 server performance is an important influence in the search engine crawl
 behavior for a site.
 
-#### Google Analytics integration
+### Google Analytics integration
 
 Google Analytics has been integrated into the Spree core and can be
 managed from the "Analytics Trackers" section of the admin. Google
 Analytics is not included on your store if this preference is not set.
 The Google Analytics setup includes e-commerce conversion tracking.
 
-### Planned Search Engine Optimization Features
+## Planned Search Engine Optimization Features
 
 Although several common search engine optimization issues have been
 addressed, we are always looking for the new best practices in SEO.
@@ -59,7 +59,7 @@ Contributions to address issues will be very welcome. Visit the
 [contributing to spree section](contributing.html) to learn
 more about contributing.
 
-#### Product and Taxonomy Page Title Enhancements
+### Product and Taxonomy Page Title Enhancements
 
 Page titles are an important part of search engine optimization and
 should be meaningful and relevant to the page content. There are a few
@@ -68,13 +68,13 @@ Name" will appear in the beginning of each of your titles. When
 possible, we assign an appropriate title after that (product name, taxon
 name, etc), but when we can't do that, we use the "Default Seo Title".
 
-#### Alt Attribute on Product Images
+### Alt Attribute on Product Images
 
 The alt attribute on product images currently pulls data from product
 titles or the image filename. Enhancing the image alt tag can improve
 image search performance.
 
-#### Known Duplicate Content Issues
+### Known Duplicate Content Issues
 
 In the Spree demo, it is a known issue that
 [demo.spreecommerce.com](http://demo.spreecommerce.com/) contains
@@ -86,7 +86,7 @@ duplicate content pages may not only not be excluded from the main
 search engine index, but pages may also rank poorly in comparison to
 other sites where all external links go to one non-duplicated page.
 
-#### Integration of Content Management System or Content
+### Integration of Content Management System or Content
 
 There has been quite a bit of interest in development of [CMS
 integration into
@@ -96,7 +96,7 @@ not only can improve on page keyword targeting, but it also can improve
 the popularity of a site which can in turn improve search engine
 optimization.
 
-#### Tool Integration
+### Tool Integration
 
 In addition to integration of Google Analytics, several other tools can
 be implemented for SEO purposes such as Bing Webmaster Tools, Google
@@ -104,7 +104,7 @@ Webmaster Tools and Quantcast. Social media optimization tools such as
 Pinterest, Reddit, Digg, Delicious, Facebook, Google+ and Twitter may
 also be integrated to improve social networking site performance.
 
-### Spree SEO Extensions
+## Spree SEO Extensions
 
 The following list shows extensions that can improve search engine
 performance. Refer to the GitHub README for developer notes.
@@ -113,7 +113,7 @@ performance. Refer to the GitHub README for developer notes.
 -   [Spree Sitemap Generation](https://github.com/romul/spree_dynamic_sitemaps)
 -   [Product Reviews](https://github.com/spree/spree_reviews)
 
-### External Search Engine Optimization Efforts
+## External Search Engine Optimization Efforts
 
 Spree cannot control factors such as external links, quality of external
 links, server performance and capabilities. These areas should not be

--- a/guides/content/developer/customization/asset.markdown
+++ b/guides/content/developer/customization/asset.markdown
@@ -3,7 +3,7 @@ title: "Asset Customization"
 section: customization
 ---
 
-### Overview
+## Overview
 
 This guide covers how Spree manages its JavaScript, stylesheet and image
 assets and how you can extend and customize them including:
@@ -13,7 +13,7 @@ assets and how you can extend and customize them including:
 -   Managing extension specific assets
 -   Overriding Spree's core assets
 
-### Spree's Asset Pipeline
+## Spree's Asset Pipeline
 
 With the release of 3.1 Rails now supports powerful asset management
 features and Spree fully leverages these features to further extend and
@@ -53,7 +53,7 @@ Spree also generates four top level manifests (all.css & all.js, see
 above) that require all the core extension's and site specific
 stylesheets / JavaScript files.
 
-#### How core extensions (engines) manage assets
+### How core extensions (engines) manage assets
 
 All core engines have been updated to provide four asset manifests that
 are responsible for bundling up all the JavaScript files and stylesheets
@@ -93,14 +93,14 @@ External JavaScript libraries, stylesheets and images have also be
 relocated into vendor/assets (again Rails 3.1 standard approach), and
 all core extensions no longer have public directories.
 
-### Managing your application's assets
+## Managing your application's assets
 
 Assets that customize your Spree store should go inside the appropriate
 directories inside `vendor/assets/images/spree`, `vendor/assets/javascripts/spree`,
 or `vendor/assets/stylesheets/spree`. This is done so that these assets do
 not interfere with other parts of your application.
 
-### Managing your extension's assets
+## Managing your extension's assets
 
 We're suggesting that all third party extensions should adopt the same
 approach as Spree and provide the same four (or less depending on
@@ -115,7 +115,7 @@ a Rails generator to do so.
 For an example of an extension using a generator to install assets and
 migrations take a look at the [install_generator for spree_fancy](https://github.com/spree/spree_fancy/blob/master/lib/generators/spree_fancy/install/install_generator.rb).
 
-### Overriding Spree's core assets
+## Overriding Spree's core assets
 
 Overriding or replacing any of Spree's internal assets is even easier
 than before. It's recommended to attempt to replace as little as
@@ -127,7 +127,7 @@ themes with one noticeable difference: Extension & theme asset files
 will not be automatically included (see above for instructions on how to
 include asset files from your extensions / themes).
 
-#### Overriding individual CSS styles
+### Overriding individual CSS styles
 
 Say for example you want to replace the following CSS snippet:
 
@@ -155,7 +155,7 @@ The `frontend/all.css` manifest will automatically include `foo.css` and it
 will actually include both definitions with the one from `foo.css` being
 included last, hence it will be the rule applied.
 
-#### Overriding entire CSS files
+### Overriding entire CSS files
 
 To replace an entire stylesheet as provided by Spree you simply need to
 create a file with the same name and save it to the corresponding path
@@ -170,7 +170,7 @@ This same method can also be used to override stylesheets provided by
 third-party extensions.
 ***
 
-#### Overriding individual JavaScript functions
+### Overriding individual JavaScript functions
 
 A similar approach can be used for JavaScript functions. For example, if
 you wanted to override the `show_variant_images` method:
@@ -216,7 +216,7 @@ var show_variant_images = function(variant_id) {
 The resulting `frontend/all.js` would include both methods, with the latter
 being the one executed on request.
 
-#### Overriding entire JavaScript files
+### Overriding entire JavaScript files
 
 To replace an entire JavaScript file as provided by Spree you simply
 need to create a file with the same name and save it to the
@@ -231,7 +231,7 @@ This same method can be used to override JavaScript files provided
 by third-party extensions.
 ***
 
-#### Overriding images
+### Overriding images
 
 Finally, images can be replaced by substituting the required file into
 the same path within your application or extension as the file you would

--- a/guides/content/developer/customization/authentication.markdown
+++ b/guides/content/developer/customization/authentication.markdown
@@ -3,7 +3,7 @@ title: "Custom Authentication"
 section: customization
 ---
 
-### Overview
+## Overview
 
 This guide covers using a custom authentication setup with Spree, such
 as one provided by your own application. This is ideal in situations
@@ -13,7 +13,7 @@ reading this guide, you will be familiar with:
 
 -   Setting up Spree to work with your custom authentication
 
-### Background
+## Background
 
 Traditionally, applications that use Spree have needed to use the
 *Spree::User* model that came with the *spree_auth* component of Spree.
@@ -32,7 +32,7 @@ that wish to use their own authentication may do so, and applications
 that have previously used *spree_auth*'s functionality may continue
 doing so by using this gem.
 
-#### The User Model
+### The User Model
 
 This guide assumes that you have a pre-existing model inside your
 application that represents the users of your application already. This
@@ -47,7 +47,7 @@ of this guide the model we will be referring to **will** be called
 *User*. If your model is called something else, do some mental
 substitution wherever you see *User*.
 
-##### Initial Setup
+#### Initial Setup
 
 To begin using your custom *User* class, you must first edit Spree's
 initializer located at *config/initializers/spree.rb* by changing this
@@ -86,7 +86,7 @@ $ bundle exec rake db:migrate
 Next you will need to define some methods to tell Spree where to find
 your application's authentication routes.
 
-##### Authentication Helpers
+#### Authentication Helpers
 
 There are some authentication helpers of Spree's that you will need to
 possibly override. The file at *lib/spree/authentication_helpers.rb*
@@ -174,7 +174,7 @@ while the server is running will require a restart, as wth any other
 modification to other files in *lib*.
 ***
 
-### The User Model
+## The User Model
 
 Once you have specified *Spree.user_class* correctly, there will be
 some new methods added to your *User* class. The first of these methods
@@ -220,7 +220,7 @@ methods, used for the API key that is used with Spree. The next two
 methods are *generate_spree_api_key!* and *clear_spree_api_key*
 which will generate and clear the Spree API key respectively.
 
-### Login link
+## Login link
 
 To make the login link appear on Spree pages, you will need to use a
 Deface override. Create a new file at
@@ -262,7 +262,7 @@ allow users to logout, one to allow them to login, and one to allow them
 to signup. These links will be visible on all customer-facing pages of
 Spree.
 
-### Signup promotion
+## Signup promotion
 
 In Spree, there is a promotion that acts on the user signup which will
 not work correctly automatically when you're not using the standard

--- a/guides/content/developer/customization/logic.markdown
+++ b/guides/content/developer/customization/logic.markdown
@@ -10,7 +10,7 @@ your exact business requirements including:
 -   Changing the output from an existing Spree controller action
 -   Customizing the image handling functionality.
 
-### Extending Classes
+## Extending Classes
 
 All of Spree's business logic (models, controllers, helpers, etc) can
 easily be extended / overridden to meet your exact requirements using
@@ -47,7 +47,7 @@ app/controllers/spree/products_controller_decorator.rb
 The exact same format can be used to redefine an existing method.
 ***
 
-#### Accessing Product Data
+### Accessing Product Data
 
 If you extend the Products controller with a new method, you may very
 well want to access product data in that method. You can do so by using
@@ -68,14 +68,14 @@ the :load_data before_filter.
 permalink.
 ***
 
-### Overriding Controller Action Responses
+## Overriding Controller Action Responses
 
 With the release of 0.60.0 Spree now supports a new way of overriding or
 changing the output of an existing controller's action without needing
 to completely override the method (while also easily avoiding double
 render exceptions).
 
-#### respond_override method
+### respond_override method
 
 The **respond_override** method is used to customize the response from
 any action, and is built on top of Rails 3's **respond_with** method
@@ -101,7 +101,7 @@ using the following syntax:
     the desired custom response (i.e. render or redirect_to). A lambda
     must be passed to ensure the code is evaluated at the correct time.
 
-#### Example Usage
+### Example Usage
 
 If you wanted to render a custom partial for the index action of
 ProductsController, you could include the following in your
@@ -124,7 +124,7 @@ Admin::ProductsController, you would use:
     end
 <% end %>
 
-#### Caveats
+### Caveats
 
 -   If an action does not use **respond_with** to define its response
     the **respond_override** will not work.
@@ -134,7 +134,7 @@ Admin::ProductsController, you would use:
     state / logic within the lambda passed to prevent overriding all
     possible responses with the same override.
 
-### Product Images
+## Product Images
 
 Spree uses Thoughtbot's
 [paperclip](https://github.com/thoughtbot/paperclip) gem to manage
@@ -157,7 +157,7 @@ app model directory, and override the attachment sizes:
 You may also add additional image sizes for use in your templates
 (:micro for shopping cart view, for example).
 
-#### Image resizing option syntax
+### Image resizing option syntax
 
 Default behavior is to resize the image and maintain aspect ratio (i.e.
 the :product version of a 480x400 image will be 240x200). Some commonly

--- a/guides/content/developer/customization/s3_storage.markdown
+++ b/guides/content/developer/customization/s3_storage.markdown
@@ -3,12 +3,12 @@ title: "Use S3 for storage"
 section: customization
 ---
 
-### Overview
+## Overview
 
 Currently the Spree backend does not give you the option anymore to configure s3 for image storage.
 This guide covers how you can use S3 for storing assets in Spree.
 
-#### How to use S3
+### How to use S3
 
 Start with adding AWS-SDK to your gemfile with:  `gem 'aws-sdk'`, then install the gem by running `bundle install`.
 

--- a/guides/content/developer/customization/view.markdown
+++ b/guides/content/developer/customization/view.markdown
@@ -3,14 +3,14 @@ title: "View Customization"
 section: customization
 ---
 
-### Overview
+## Overview
 View customization allows you to extend or replace any view within a
 Spree store. This guide explains the options available, including:
 
 -   Using Deface for view customization
 -   Replacing entire view templates
 
-### Using Deface
+## Using Deface
 
 Deface is a standalone Rails library that enables you to customize Erb
 templates without needing to directly edit the underlying view file.
@@ -57,7 +57,7 @@ If you wanted to insert some code just before the +#registration+ div on the pag
 
 This override **inserts** <code><p>Registration is the future!</p></code> **before** the div with the id of "registration".
 
-#### Available actions
+### Available actions
 
 Deface applies an __action__ to element(s) matching the supplied CSS selector. These actions are passed when defining a new override are supplied as the key while the CSS selector for the target element(s) is the value, for example:
 
@@ -88,7 +88,7 @@ Deface currently supports the following actions:
 Not all actions are applicable to all elements. For example, <tt>:insert_top</tt> and <tt>:insert_bottom</tt> expects a parent element with children.
 ***
 
-#### Supplying content
+### Supplying content
 
 Deface supports three options for supplying content to be used by an override:
 
@@ -100,7 +100,7 @@ Deface supports three options for supplying content to be used by an override:
 As Deface operates on the Erb source the content supplied to an override can include Erb, it is not limited to just HTML. You also have access to all variables accessible in the original Erb context.
 ***
 
-#### Targeting elements
+### Targeting elements
 
 While Deface allows you to use a large subset of CSS3 style selectors (as provided by Nokogiri), the majority of Spree's views have been updated to include a custom HTML attribute (<tt>data-hook</tt>), which is designed to provide consistent targets for your overrides to use.
 
@@ -184,7 +184,7 @@ override to ensure maximum protection against changes:
  :insert_top => "[data-hook='thumbnails'], #thumbnails[data-hook]"
  ```
 
-#### Targeting ruby blocks
+### Targeting ruby blocks
 
 Deface evaluates all the selectors passed against the original erb view
 contents (and importantly not against the finished / generated HTML). In
@@ -232,7 +232,7 @@ selectors, for example:
 :insert_before => "erb[silent]:contains('elsif')"
 ```
 
-#### View upgrade protection
+### View upgrade protection
 
 To ensure upgrading between versions of Spree is as painless as
 possible, Deface supports an `:original` option that can contain a
@@ -255,7 +255,7 @@ source values before comparing, to reduce false warnings caused by basic
 whitespace differences.
 ***
 
-#### Organizing Overrides
+### Organizing Overrides
 
 The suggested method for organizing your overrides is to create a
 separate file for each override inside the **app/overrides** directory,
@@ -266,7 +266,7 @@ Using this method will ensure your overrides are compatible with
 future theming developments (editor).
 ***
 
-#### More information on Deface
+### More information on Deface
 
 For more information and sample overrides please refer to its
 [README](https://github.com/railsdog/deface) file on GitHub.
@@ -274,7 +274,7 @@ For more information and sample overrides please refer to its
 You can also see how Deface internals work, and test selectors using the
 [Deface Test Harness](http://deface.heroku.com) application.
 
-### Template Replacements
+## Template Replacements
 
 Sometimes the customization required to a view are so substantial that
 using a Deface override seems impractical. Spree also supports the
@@ -296,7 +296,7 @@ to get the location of the Spree code you're actually running and then
 copying the relevant file from there.
 ***
 
-#### Drawbacks of template replacements
+### Drawbacks of template replacements
 
 Whenever you copy an entire view into your extension or application you
 are adding a significant maintenance overhead to your application when

--- a/guides/content/developer/deployment/deployment_tips.markdown
+++ b/guides/content/developer/deployment/deployment_tips.markdown
@@ -11,7 +11,7 @@ for troubleshooting standard deployment issues, including:
 * Email configuration
 * and more ...
 
-### Serving Static Assets
+## Serving Static Assets
 
 Rails applications (including Spree) use the convention of storing
 public assets (images, JavaScripts, stylesheets, etc.) in a directory
@@ -21,7 +21,7 @@ the `public` directory. In production mode, however, Rails is not
 configured to serve public assets unless specifically enabled. This
 leaves you with two options.
 
-#### Configure Rails to Serve Public Assets
+### Configure Rails to Serve Public Assets
 
 Rails has a `config.serve_static_assets` setting that allows you to
 override its default behavior in the production environment. If you want
@@ -40,7 +40,7 @@ You should consider the advice of the Rails core team and let your
 webserver do what it does best (as described in the next section.)
 ***
 
-##### Configure the Web Server to Use the *public* Directory
+#### Configure the Web Server to Use the *public* Directory
 
 The recommended approach for handling static assets is to allow your web
 server to handle serving these files. If you want to follow this
@@ -69,7 +69,7 @@ Options ~~MultiViews
 
 Each web server will have its own method for doing this so please consult the appropriate documentation for more details.
 
-### Enabling SSL
+## Enabling SSL
 
 Spree supports SSL and contains a special filter to require SSL for certain sensitive pages It also has the ability to redirect SSL requests that do not require SSL back to standard unencrypted HTTP. The code for this is built right into Spree and is based on the
 [ssl_requirement](https://github.com/rails/ssl_requirement/tree/master) by David Heinemeier Hansson.
@@ -92,7 +92,7 @@ possible. You may, however, make minor changes such as disabling email
 or sending email to a test account instead of the designated recipient.
 ***
 
-#### SSL Preferences
+### SSL Preferences
 
 SSL behavior in Spree is determined by several different preferences.
 
@@ -105,7 +105,7 @@ SSL behavior in Spree is determined by several different preferences.
 For more information on preferences in general you may wish to read the
 [Preference Guide](preferences.html).
 
-#### Changing the Default Settings
+### Changing the Default Settings
 
 If you do not wish to use SSL in production or staging, or if you wish to enable SSL in development mode, you will have to change the `:allow_ssl_in_production` configuration setting. This can be done via the admin interface as shown below:
 
@@ -121,7 +121,7 @@ config.allow_ssl_in_staging = false
 
 ## Performance Tips
 
-### Running in Production Mode
+## Running in Production Mode
 
 If you are noticing that Spree seems to be running slowly you should
 make sure that you are running in "production mode." You can start your
@@ -134,11 +134,11 @@ $ bundle exec rails server -e production
 Please consult your web server documentation for more details on
 enabling production mode for your particular web server.
 
-### Passenger Timeout
+## Passenger Timeout
 
 If you are running on [Passenger](http://www.modrails.com) then you may be noticing that the first request to your Spree application is very slow if the application has been idle for some time (or you have just restarted.) Consider changing the [PassengerPoolIdleTime](http://www.modrails.com/documentation/Users%20guide%20Apache.html#PassengerPoolIdleTime) as described in the Passenger documentation.
 
-### Caching
+## Caching
 
 Most stores spend a lot of time serving up the same pages over and over
 again. In many cases, the content being served is exactly identical or

--- a/guides/content/developer/tutorials/migration.markdown
+++ b/guides/content/developer/tutorials/migration.markdown
@@ -18,7 +18,7 @@ working to update it. In the meantime if you see things in here that are
 confusing it's possible that they no longer apply, etc.
 !!!
 
-### Overview
+## Overview
 
 This guide is a mix of tips and information about the relevant APIs,
 intended to help simplify the process of getting a new site set up -
@@ -32,12 +32,12 @@ import legacy order details, so there's a short discussion on this.
 Finally, there are some tips about how to ease the theme development
 process.
 
-### Data Import Format
+## Data Import Format
 
 This part discusses some options for getting data into the system,
 including some discussion of using relevant formats.
 
-#### Direct SQL import
+### Direct SQL import
 
 Can we just format our data as SQL tables and import it directly? In
 principle yes, but it takes effort to get the format right,
@@ -51,7 +51,7 @@ moving between hosting platforms. Another is when cloning some project:
 collaborators can just import a database dump prepared by someone else,
 and save the time of the code import.
 
-#### Rails Fixtures
+### Rails Fixtures
 
 Spree uses fixtures to load up the sample data. It's a convenient
 format for small collections of data, but can be tricky when working with
@@ -61,7 +61,7 @@ need to be careful with validation.
 Note that Rails can dump slices of the database in fixture format. This
 is sometimes useful.
 
-#### SQL or XML legacy data
+### SQL or XML legacy data
 
 This is the case where you are working with legacy data in formats like
 SQL or XML, and the question is more how to get the useful data out.
@@ -79,7 +79,7 @@ help
 to use views or complex queries to flatten multi-table data into a
 single table - which can then be treated like a spreadsheet.
 
-#### Spreadsheet format
+### Spreadsheet format
 
 Most of the information about products can be flattened into
 spreadsheet
@@ -89,7 +89,7 @@ in this format.
 
 For example, your spreadsheet could have the following columns:
 
-#### Fixed Details
+### Fixed Details
 
 -    product name
 -    master price
@@ -101,10 +101,10 @@ For example, your spreadsheet could have the following columns:
 -    list of images
 -    description
 
-#### Several Properties
+### Several Properties
 -   one column for each property type used in your catalogue
 
-#### Variant Specifications
+### Variant Specifications
 -   option types for the product\
 -   one variant per column, each listing the option values and the price/sku
 
@@ -129,7 +129,7 @@ Another possibility for coding variants is to have each variant on a
 separate row, and to leave the fixed fields empty when a row is a variant of the
 last-introduced product. This is easier to read.
 
-#### Seed code
+### Seed code
 
 This is more a technique for getting the data loaded at the right time.
 Technically, the product catalogue is *seed data*, standard data which
@@ -149,7 +149,7 @@ If the order of loading is important, choose names for the files
 so that alphabetical order gives the correct load order…
 ***
 
-#### Important system-wide settings
+### Important system-wide settings
 
 A related but important topic is the Spree core settings that your app
 will need to function correctly, eg to disable backordering or to
@@ -159,13 +159,13 @@ interface, but we recommend using initializers for these. See the
 guide](preferences.html#persisting-modifications-to-preferences) for
 more info.
 
-### Catalog creation
+## Catalog creation
 
 This section covers everything relating to import of a product set,
 including the product details, variants, properties and options,
 images, and taxons.
 
-#### Preliminaries
+### Preliminaries
 
 Let's assume that you are working from a CSV-compatible format, and so
 are reading one product per row, and each row contains values for the fixed
@@ -176,7 +176,7 @@ upload scripts will call *save* at appropriate times or use
 *update_attribute+
 etc.
 
-#### Products
+### Products
 
 Products must have at least a name and a price in order to pass
 validation, and we set the description too.
@@ -198,7 +198,7 @@ displays.
 p.available_on = Time.now
 ```
 
-##### The Master variant
+#### The Master variant
 
 Every product has a master variant, and this is created automatically
 when the product is created. It is accessible via *p.master*, but note that many
@@ -210,14 +210,14 @@ The dimensions and weight fields should be self-explanatory.
 The *sku* field holds the product's stock code, and you will want to set
 this if the product does not have option variants.
 
-##### Stock levels
+#### Stock levels
 
 If you don't have option variants, then you may also need to register
 some stock for the master variant. The exact steps depend on how you
 have configured Spree's [inventory system](inventory.html), but most sites
 will just need to assign to *p.on_hand*, eg *p.on_hand = 100*.
 
-##### Shipping category
+#### Shipping category
 
 A product's [shipping category](shipments.html#shipping-categories) field
 provides product-specific information for the shipping
@@ -233,7 +233,7 @@ when required.
 p.shipping_category = Spree::ShippingCategory.where(:name => 'Type A').first_or_create
 ```
 
-##### Tax category
+#### Tax category
 
 This is a similar idea to the shipping category, and guides the
 calculation of product taxes, eg to distinguish clothing items from electrical
@@ -249,7 +249,7 @@ You can also fill in this information automatically at a *later* date,
 e.g. use the taxon information to decide which tax categories something
 belongs in.
 
-#### Taxons
+### Taxons
 
 Adding a product to a particular taxon is easy: just add the taxon to
 the list of taxons for a product.
@@ -312,7 +312,7 @@ taxonomy for brands and product ranges, like 'Guitars' with child
 'Acoustic'. You could use various property or option values to drive the
 creation of such taxonomies.
 
-#### Product Properties
+### Product Properties
 
 The first step is to create the property 'types'. These should be
 known in advance so you can define these at the start of the script. You
@@ -330,7 +330,7 @@ column, this means:
 Spree::ProductProperty.create :property => size_prop, :product => p, :value => size_info
 ```
 
-##### Product prototypes
+#### Product prototypes
 
 The admin interface uses a system of 'prototypes' to speed up data
 entry, which seeds a product with a given set of option types and (empty)
@@ -339,7 +339,7 @@ programmatically, since the code will need to do the hard work of
 creating variants and setting properties anyway. However, we mention it
 here for completeness.
 
-#### Variants
+### Variants
 
 Variants allow different versions of a product to be offered, e.g.
 allowing variations in size and color for clothing. If a product comes in only
@@ -358,7 +358,7 @@ code is tolerant of missing values. Certain extensions may be more
 strict, e.g. ones for providing advanced variant selection.
 ***
 
-##### Creating variants
+#### Creating variants
 
 New variants require only a product to be associated with, but it is
 useful to set an identifying *sku* code too. The price field is optional: if it is not
@@ -382,7 +382,7 @@ will just need to assign to *v.on_hand*, eg *v.on_hand = 100*.
 You now need to set some option types and values, so customers can
 choose between the variants.
 
-##### Option types
+#### Option types
 
 The option types to use will vary from product to product, so you will
 need to give this information for each product - or assume a default
@@ -398,7 +398,7 @@ p.option_types = option_names_col.map do |name|
 end
 ```
 
-##### Option values
+#### Option values
 
 Option values represent the choices possible for some option type.
 Again, you could declare them in advance, or use *where.first_or_create*. You'll
@@ -427,7 +427,7 @@ setup. It also avoids filling up a type with lots of similar options -
 and so reduces the number of options when using faceted search etc. You can
 also attach resources like color swatches to the more specific values.
 
-##### Ordering of option values
+#### Ordering of option values
 You might want option values to appear in a certain order, such as by
 increasing size or by alphabetical order. The *Spree::OptionValue* model uses
 *acts_as_list* for setting the order, and option types will use the *position* field when retrieving
@@ -452,7 +452,7 @@ color_type.option_values.sort_by(&:name).each_with_index do |val,pos|
 end
 ```
 
-##### Further reading
+#### Further reading
 
 [Steph Skardal](https://github.com/stephskardal) has produced a useful
 blog post on [product
@@ -460,7 +460,7 @@ optioning](http://blog.endpoint.com/2010/01/rails-ecommerce-spree-hooks-comments
 This discusses how the variant option representation works and how she
 used it to build an extension for enhanced product option selection.
 
-#### Product and Variant images
+### Product and Variant images
 
 Spree uses [paperclip](https://github.com/thoughtbot/paperclip) to
 manage image attachments and their various size formats. (See the [Customization Guide](logic#product-images) for info on altering the image formats.)


### PR DESCRIPTION
This changes headers sizes of part of guides. 

This way they are the same as in the rest of content and easier to access by creating anchor links to all headers
