### PR TITLE
Initialize master variants with `is_master: true`

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -255,7 +255,7 @@ module Spree
 
     def ensure_master
       return unless new_record?
-      self.master ||= Variant.new
+      self.master ||= build_master
     end
 
     def normalize_slug

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -443,4 +443,9 @@ describe Spree::Product, :type => :model do
     subject { second_product }
     it { is_expected.to be_invalid }
   end
+
+  it "initializes a master variant when building a product" do
+    product = Spree::Product.new
+    expect(product.master.is_master).to be true
+  end
 end


### PR DESCRIPTION
Always initialize master variants as master, so proper validations can be applied to them.

Without this fix, https://github.com/spree/spree/commit/14b6bacf77ab68a6ae8691c9909607481c807232 makes it impossible to have validations that should only apply to non-master variants, because `is_master` is only set to `true` _after_ the master variant is saved.
