### PR TITLE
[guides] Add missing headers to Overview sections

### DIFF
--- a/guides/content/developer/advanced/developer_tips.md
+++ b/guides/content/developer/advanced/developer_tips.md
@@ -3,6 +3,8 @@ title: "Developer Tips and Tricks"
 section: advanced
 ---
 
+## Overview
+
 This guide presents accumulated wisdom from person-years of Spree use.
 
 ## Upgrade Considerations

--- a/guides/content/developer/advanced/seo.markdown
+++ b/guides/content/developer/advanced/seo.markdown
@@ -3,6 +3,8 @@ title: "Seo Considerations"
 section: advanced
 ---
 
+## Overview
+
 Search Engine Optimization is an important area to address when
 implementing and developing an ecommerce solution to ensure competitive
 search engine performance. The following guide outlines current Spree

--- a/guides/content/developer/core/taxation.md
+++ b/guides/content/developer/core/taxation.md
@@ -3,7 +3,7 @@ title: Taxation
 section: core
 ---
 
-# Overview
+## Overview
 
 Spree represents taxes for an order by using `tax_categories` and `tax_rates`.
 

--- a/guides/content/developer/customization/checkout.md
+++ b/guides/content/developer/customization/checkout.md
@@ -11,7 +11,7 @@ The customization of the flow of the checkout can be done by using Spree's `chec
 
 ## Default Checkout Steps
 
-The Spree checkout process consists of the following steps. With the exception of the Registration step, each of these steps corresponds to a state of the `Spree::Order` object):
+The Spree checkout process consists of the following steps. With the exception of the Registration step, each of these steps corresponds to a state of the `Spree::Order` object:
 
 * Registration (Optional - only if using spree_auth_devise extension, can be toggled through the `Spree::Auth::Config[:registration_step]` configuration setting)
 * Address Information

--- a/guides/content/developer/customization/i18n.markdown
+++ b/guides/content/developer/customization/i18n.markdown
@@ -3,6 +3,8 @@ title: "Internationalization"
 section: customization
 ---
 
+## Overview
+
 This guide covers how Spree uses Rails' internationalization features, and how
 you can leverage and extend these features in your Spree contributions and
 extensions.

--- a/guides/content/developer/customization/logic.markdown
+++ b/guides/content/developer/customization/logic.markdown
@@ -3,6 +3,8 @@ title: Logic Customization
 section: customization
 ---
 
+## Overview
+
 This guide explains how to customize the internal Spree code to meet
 your exact business requirements including:
 

--- a/guides/content/developer/deployment/deployment-service.md
+++ b/guides/content/developer/deployment/deployment-service.md
@@ -3,6 +3,8 @@ title: Deployment Service
 section: deployment
 ---
 
+## Overview
+
 The Spree Deployment Service is a free tool that allows you to configure
 and deploy the Spree Software Stack on any dedicated cloud, virtual
 private or physical server.

--- a/guides/content/developer/deployment/deployment_tips.markdown
+++ b/guides/content/developer/deployment/deployment_tips.markdown
@@ -3,6 +3,8 @@ title: "Deployment Tips"
 section: deployment
 ---
 
+## Overview
+
 This guide is intended to provide some generally useful hints and tips\
 for troubleshooting standard deployment issues, including:
 

--- a/guides/content/developer/source/contributing.md
+++ b/guides/content/developer/source/contributing.md
@@ -11,19 +11,19 @@ Spree is an open source project. Anyone can use the code, but more importantly, 
 * How to contribute fixes and improvements to the core
 * Information on how to improve the documentation
 
-### Who can contribute?
+## Who can contribute?
 
 Spree is an open source project and as such contributions are always welcome. Our community is one which encourages involvement from all developers regardless of their ability level. We ask that you be patient with the other members of the community and maintain a respectful attitude towards other people's work. Open source is a great way to learn a new technology so don't be afraid to jump right in, even if you are new to Ruby/Rails.
 
-### Before you contribute
+## Before you contribute
 
 Open source projects tend to be a collaborative effort. Since many people are relying upon Spree for their real world applications, changes to the code can have major implications. Before you write a bug fix or code a new feature, you should find out if anybody is interested in your proposed change. You may find that the thing you're trying to "fix" is actually desired behavior. You might also discover that someone else is working on it. Either way you can save yourself valuable time by announcing your intentions before starting work.
 
-#### Mailing List
+### Mailing List
 
 One of the best places for communication is the [spree-user mailing list](http://groups.google.com/group/spree-user). You can search this list of previous discussions and get a sense for whether you're trying to address something new.
 
-#### IRC
+### IRC
 
 There is a #spree chat room on the irc.freenode.net network. Sometimes the core contributors hang out there and you can get some feedback on your idea. More information on how to connect is on our [blog](http://spreecommerce.com/blog/irc-101).
 
@@ -31,7 +31,7 @@ There is a #spree chat room on the irc.freenode.net network. Sometimes the core 
 The #spree chat room is not monitored as carefully as the mailing list. Sometimes you'll get lucky and someone will answer your question but we can't provide real time responses to everyone with a question/problem/idea. The mailing list is a much better way to communicate, and it gives everyone the chance to provide a thoughtful response. It's also more permanent than anything discussed on IRC.
 !!!
 
-#### Notification via GitHub Issues
+### Notification via GitHub Issues
 
 You can also search existing bug reports/issues and file a new one if you do not find an issue relevant to your proposed change. See [Filing an Issue](#filing-an-issue) for more details.
 
@@ -39,7 +39,7 @@ You can also search existing bug reports/issues and file a new one if you do not
 The important thing is that you communicate your intention in advance of doing a lot of work. Simple bug fixes and non-controversial changes do not require this approach but you can save some time by suggesting an improvement and having it rejected before you write a bunch of the code.
 ***
 
-### Spree's Release Policy
+## Spree's Release Policy
 
 * Deprecation warnings are to be added in patch releases (i.e. 2.2.1) and the code being deprecated will only be removed in minor versions. For example, if a deprecation warning is added in 2.2.1, 2.2.2 will still contain the same deprecation warning but in 2.3.0 the deprecation warning and the code will be gone.
 
@@ -57,7 +57,7 @@ To determine how often minor branches of Spree are released, please check the [R
 
 We strongly encourage people to upgrade to using the latest Spree releases to avoid being stuck on a release that is no longer maintained.
 
-### Filing an Issue
+## Filing an Issue
 
 If you would like to file a bug report, please create an issue in our [GitHub Issues Tracker](https://github.com/spree/spree/issues). You should do a basic search of the issues database before creating a new issue to ensure that you are not creating a duplicate issue.
 
@@ -75,11 +75,11 @@ Without this information, we may be unable to debug your issue promptly. This in
 Please do not assign labels or create new labels to your issue. We will assign the appropriate labels to ensure your ticket is handled in the appropriate manner.
 ***
 
-#### When to File an Issue
+### When to File an Issue
 
 You should file an issue if you have found (or suspect) a bug in the "core" functionality of Spree. If you have found a bug in one of the extensions, please file an issue with the appropriate extension project in GitHub. If you're not sure if the behavior you're experiencing is intentional just ask on the mailing list and someone will encourage you to file a ticket if your issue sounds like a bug (as opposed to a feature.)
 
-#### How We Prioritize Issues
+### How We Prioritize Issues
 
 Spree is a very large project with lots of activity. We try our best to respond to all of the questions and issues our users have.  We use the following criteria to prioritize issues:
 
@@ -95,7 +95,7 @@ We give highest priority to issues where the answer is "yes" to all of these que
 You need to include a brief description of the problem and simple steps needed to reproduce it. If you fail to supply this minimum level of information your issue will likely be ignored.
 ***
 
-#### Providing a Patch
+### Providing a Patch
 
 If you are filing an issue and supplying a patch at the same time, please file a ["Pull Request"](#creating-a-pull-request) instead. The pull request will also create an issue at the same time but it's superior to just creating an issue because the code and issue can be linked.
 
@@ -119,7 +119,7 @@ This command will apply the commits from the pull request to the current branch,
 For this reason, there is no need to create multiple pull requests for Spree's different branches. Please only create one pull request per change and simply mention inside the pull request that it can apply to multiple branches. If a patch does not apply cleanly to a branch, the Spree team may ask you for another one which applies to the other branch.
 ***
 
-### Feature Requests
+## Feature Requests
 
 We're interested in hearing your ideas for new features but creating feature requests in the Issue Tracker is not the proper way to ask for a feature. A feature request is any idea you have to improve the software experience that is not strictly related to a bug or error of omission.
 
@@ -131,7 +131,7 @@ Feature requests that are accompanied by source code are always welcome. In this
 Feature requests without accompanying code will be closed immediately. We simply cannot respond efficiently to feature requests through our Issue Tracker. If you want to suggest a feature, please use the [mailing list](http://groups.google.com/group/spree-user).
 !!!
 
-### Creating a Pull Request
+## Creating a Pull Request
 
 If you are going to contribute code to the Spree project, the best mechanism for doing this is to create a pull request in GitHub. If you're unfamiliar with the general concept of pull requests you may want to read more on [pull requests in GitHub](https://help.github.com/articles/using-pull-requests).
 
@@ -139,7 +139,7 @@ If you are going to contribute code to the Spree project, the best mechanism for
 If your code is associated with an existing issue then you can [provide a patch](#providing-a-patch) instead of creating a pull request.
 ***
 
-#### Creating a Fork
+### Creating a Fork
 
 The official Spree source code is maintained in GitHub under the [spree/spree](https://github.com/spree/spree) project. There is a [core team](http://spreecommerce.com/core_team) of developers who are responsible for maintaining the quality of the source code. Your changes will ultimately need to be merged into the official project by a core member.
 
@@ -149,7 +149,7 @@ Thanks to [GitHub](https://github.com/), however, you do not have to wait for a 
 See the GitHub guide on [creating forks](https://help.github.com/articles/fork-a-repo) for more details.
 ***
 
-#### Topic Branches
+### Topic Branches
 
 Git branches are "cheap." Creating branches in Git is incredibly easy and it's an ideal way to isolate a specific set of changes. By keeping a specific set of changes isolated, it will help us to navigate your fork and apply only the changes we're interested in. You should create a clean branch based on the latest spree/master when doing this. It is important you follow these steps exactly, it will prevent you from accidentally including unrelated changes from your local repository into the branch.
 
@@ -182,7 +182,7 @@ You should probably also clean up after yourself a little. The branch has been p
 $ git branch -D fix-css-for-error-flash
 ```
 
-#### Follow the Coding Conventions
+### Follow the Coding Conventions
 
 Spree follows a simple set of coding style conventions.
 
@@ -201,7 +201,7 @@ Spree follows a simple set of coding style conventions.
 
 These are some guidelines and please use your best judgment in using them.
 
-#### Including a Test
+### Including a Test
 
 Ideally your pull request will also include a test that verifies a bug (or the absence of the new feature) before your fix and also verifies proper functionality when you are finished. Please read the [Testing Guide](testing) for more information on writing and running your tests.
 
@@ -209,7 +209,7 @@ Ideally your pull request will also include a test that verifies a bug (or the a
 Pull requests with tests are given top priority. Failure to include a test will likely delay acceptance of your patch.
 ***
 
-#### Creating the Pull Request
+### Creating the Pull Request
 
 Once your code is ready to go and you have pushed your [topic branch](#topic-branches) to GitHub then you are ready to create the pull request and notify the Spree team that your contribution is ready. You do this by browsing your project in GitHub and changing to the topic branch you just pushed. Once you are on the topic branch simply create a pull request by pressing the "Pull Request" button.
 
@@ -217,7 +217,7 @@ Once your code is ready to go and you have pushed your [topic branch](#topic-bra
 The GitHub guide on [pull requests](https://help.github.com/articles/using-pull-requests) describes this in more detail with screenshots if you're still confused on this part.
 ***
 
-### Contributing to the Documentation
+## Contributing to the Documentation
 
 Improvements to the documentation are encouraged. The primary source of documentation are the guides (_HINT: You are reading one now._). You may make edits to the guide in your fork and then pull request for them to be updated to this site.
 
@@ -237,7 +237,7 @@ $ nanoc compile
 $ nanoc view
 ```
 
-### Markdown Conventions
+## Markdown Conventions
 
 It is helpful to standardize some markdown conventions so readers learn to recognize visual cues as they work their way through the documentation and tutorials. Following are the conventions used for the Spree documentation:
 

--- a/guides/content/developer/source/getting_help.md
+++ b/guides/content/developer/source/getting_help.md
@@ -3,6 +3,8 @@ title: Getting Help
 section: source-code
 ---
 
+## Overview
+
 There may be times when using Spree that the documentation doesn't answer all
 the questions you may have. There are several other places on the internet where
 you can go to ask Spree questions, and they are covered in this guide.

--- a/guides/content/developer/source/navigating.md
+++ b/guides/content/developer/source/navigating.md
@@ -3,6 +3,8 @@ title: Navigating the Source
 section: source-code
 ---
 
+## Overview
+
 This guide covers obtaining and running the source code. This is
 primarily for developers who are interested in contributing code to the
 Spree project or fixing the source code themselves. It is not necessary

--- a/guides/content/developer/tutorials/migration.markdown
+++ b/guides/content/developer/tutorials/migration.markdown
@@ -3,6 +3,8 @@ title: Migrating to Spree
 section: advanced
 ---
 
+## Overview
+
 This section explains how to convert existing sites or data sets for
 use with Spree. It is a mix of tips and information about the relevant
 APIs, and so is definitely intended for developers. After reading it you

--- a/guides/content/developer/upgrades/one-dot-oh-to-one-dot-one.md
+++ b/guides/content/developer/upgrades/one-dot-oh-to-one-dot-one.md
@@ -3,6 +3,8 @@ title: Upgrading Spree from 1.0.x to 1.1.x
 section: upgrades
 ---
 
+## Overview
+
 This guide covers upgrading a 1.0.x Spree store, to a 1.1.x store. This
 guide has been written from the perspective of a blank Spree 1.0.x store with
 no extensions.

--- a/guides/content/developer/upgrades/one-dot-one-to-one-dot-two.md
+++ b/guides/content/developer/upgrades/one-dot-one-to-one-dot-two.md
@@ -3,6 +3,8 @@ title: Upgrading Spree from 1.1.x to 1.2.x
 section: upgrades
 ---
 
+## Overview
+
 This guide covers upgrading a 1.1.x Spree store, to a 1.2.x store. This
 guide has been written from the perspective of a blank Spree 1.1.x store with
 no extensions.

--- a/guides/content/developer/upgrades/one-dot-three-to-two-dot-oh.md
+++ b/guides/content/developer/upgrades/one-dot-three-to-two-dot-oh.md
@@ -3,6 +3,8 @@ title: Upgrading Spree from 1.3.x to 2.0.x
 section: upgrades
 ---
 
+## Overview
+
 This guide covers upgrading a 1.3.x Spree store, to a 2.0.x store. This
 guide has been written from the perspective of a blank Spree 1.3.x store with
 no extensions.

--- a/guides/content/developer/upgrades/one-dot-two-to-one-dot-three.md
+++ b/guides/content/developer/upgrades/one-dot-two-to-one-dot-three.md
@@ -3,6 +3,8 @@ title: Upgrading Spree from 1.2.x to 1.3.x
 section: upgrades
 ---
 
+## Overview
+
 This guide covers upgrading a 1.2.x Spree store, to a 1.3.x store. This
 guide has been written from the perspective of a blank Spree 1.2.x store with
 no extensions.

--- a/guides/content/developer/upgrades/point-seventy-to-one-dot-oh.md
+++ b/guides/content/developer/upgrades/point-seventy-to-one-dot-oh.md
@@ -3,6 +3,8 @@ title: Upgrading Spree from 0.70.x to 1.0.x
 section: upgrades
 ---
 
+## Overview
+
 This guide covers upgrading a 0.70.x Spree store, to a 1.0.x store. This
 guide has been written from the perspective of a blank Spree 0.70.x store with
 no extensions.

--- a/guides/content/developer/upgrades/point-sixty-to-point-seventy.md
+++ b/guides/content/developer/upgrades/point-sixty-to-point-seventy.md
@@ -3,6 +3,8 @@ title: Upgrading Spree from 0.60.x to 0.70.x
 section: upgrades
 ---
 
+## Overview
+
 This guide covers upgrading a 0.60.x Spree store, to a 0.70.x store. This
 guide has been written from the perspective of a blank Spree 0.60.x store with
 no extensions.

--- a/guides/content/developer/upgrades/two-dot-oh-to-two-dot-one.md
+++ b/guides/content/developer/upgrades/two-dot-oh-to-two-dot-one.md
@@ -3,6 +3,8 @@ title: Upgrading Spree from 2.0.x to 2.1.x
 section: upgrades
 ---
 
+## Overview
+
 This guide covers upgrading a 2.0.x Spree store, to a 2.1.x store. This
 guide has been written from the perspective of a blank Spree 2.0.x store with
 no extensions.

--- a/guides/content/developer/upgrades/two-dot-one-to-two-dot-two.md
+++ b/guides/content/developer/upgrades/two-dot-one-to-two-dot-two.md
@@ -3,6 +3,8 @@ title: Upgrading Spree from 2.1.x to 2.2.x
 section: upgrades
 ---
 
+## Overview
+
 This guide covers upgrading a 2.1.x Spree store, to a 2.2.x store. This
 guide has been written from the perspective of a blank Spree 2.1.x store with
 no extensions.

--- a/guides/content/developer/upgrades/two-dot-two-to-two-dot-three.md
+++ b/guides/content/developer/upgrades/two-dot-two-to-two-dot-three.md
@@ -3,6 +3,8 @@ title: Upgrading Spree from 2.2.x to 2.3.x
 section: upgrades
 ---
 
+## Overview
+
 This guide covers upgrading a 2.2.x Spree store, to a 2.3.x store. This
 guide has been written from the perspective of a blank Spree 2.2.x store with
 no extensions.


### PR DESCRIPTION
This adds `Overview` headers to those parts of guides where it was missing, this way it's more coherent
It also adjusts size of headers in `contributing` page to same size as on other guides pages
