### PR TITLE
[guides] Fix expanding Upgrade Guides when any of it's guides is open

### DIFF
--- a/guides/layouts/developer/_sidebar.html
+++ b/guides/layouts/developer/_sidebar.html
@@ -91,7 +91,7 @@
       </li>
       <li class='js-topic'>
         <h3>
-          <a href="#" class="js-expand-btn collapsed toggle-advanced-menu"><i class="icon-right-open"></i></a>
+          <a href="#" class="js-expand-btn collapsed toggle-upgrades-menu"><i class="icon-right-open"></i></a>
           <%= link_to 'Upgrade Guides', '/developer/upgrades/index' %>
         </h3>
         <ul class="js-guides">


### PR DESCRIPTION
This is a small fix of Guides menu. It fixes `Upgrade Guides` section not expanding when any of it's guides is open
![selection_048](https://cloud.githubusercontent.com/assets/1530318/5646031/62884d2e-9677-11e4-80dd-8dab47283187.png)
https://guides.spreecommerce.com/developer/upgrades/index.html
