### PR TITLE
Update find_line_item_by_variant

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -315,7 +315,7 @@ module Spree
       line_item ? line_item.quantity : 0
     end
 
-    def find_line_item_by_variant(variant, options = {})
+    def find_line_item_by_variant(variant, options = nil)
       line_items.detect { |line_item|
                     line_item.variant_id == variant.id &&
                     line_item_options_match(line_item, options)


### PR DESCRIPTION
The method `find_line_item_by_variant` in order.rb triggers the line_items matcher regardless if there are options by passing an empty hash.

Lines like `order.find_line_item_by_variant(variant)` should match only by variant when no options are provided, else this requires the matcher be true when called from `find_line_item_by_variant` and false everywhere else as seen in the spec: 

```
it "does not match line item without options" do
        allow(order).to receive(:foos_match).and_return(false)
        expect(order.line_item_options_match(@line_items.first, {})).to be false
      end
```
