### PR TITLE
Fix to payment_spec

### DIFF
--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -172,6 +172,7 @@ describe Spree::Payment do
       end
 
       it "should log the response" do
+        payment.save!
         payment.log_entries.should_receive(:create!).with(:details => anything)
         payment.authorize!
       end
@@ -223,6 +224,7 @@ describe Spree::Payment do
       end
 
       it "should log the response" do
+        payment.save!
         payment.log_entries.should_receive(:create!).with(:details => anything)
         payment.purchase!
       end
@@ -450,6 +452,7 @@ describe Spree::Payment do
       end
 
       it "should log the response" do
+        payment.save!
         payment.log_entries.should_receive(:create!).with(:details => anything)
         payment.credit!
       end


### PR DESCRIPTION
Added payment.save! to 3 failing tests that were looking for
payment.log_entries to receive :create!. Due to the parent not being
saved, the method was not received and the test failed. Now fixed.
