### PR TITLE
Be more consistent with permitted attributes in controllers

### DIFF
--- a/api/app/controllers/spree/api/users_controller.rb
+++ b/api/app/controllers/spree/api/users_controller.rb
@@ -46,9 +46,9 @@ module Spree
       end
 
       def user_params
-        params.require(:user).permit(PermittedAttributes.user_attributes |
-                                       [bill_address_attributes: PermittedAttributes.address_attributes,
-                                        ship_address_attributes: PermittedAttributes.address_attributes])
+        params.require(:user).permit(permitted_user_attributes |
+                                       [bill_address_attributes: permitted_address_attributes,
+                                        ship_address_attributes: permitted_address_attributes])
       end
 
     end

--- a/backend/app/controllers/spree/admin/general_settings_controller.rb
+++ b/backend/app/controllers/spree/admin/general_settings_controller.rb
@@ -41,11 +41,7 @@ module Spree
 
       private
       def store_params
-        params.require(:store).permit(permitted_params)
-      end
-
-      def permitted_params
-        Spree::PermittedAttributes.store_attributes
+        params.require(:store).permit(permitted_store_attributes)
       end
 
       def set_store

--- a/backend/app/controllers/spree/admin/taxons_controller.rb
+++ b/backend/app/controllers/spree/admin/taxons_controller.rb
@@ -73,7 +73,7 @@ module Spree
       private
 
       def taxon_params
-        params.require(:taxon).permit(permitted_params)
+        params.require(:taxon).permit(permitted_taxon_attributes)
       end
 
       def load_taxon
@@ -118,10 +118,6 @@ module Spree
         @taxon.set_permalink
         @taxon.save!
         @update_children = true
-      end
-
-      def permitted_params
-        Spree::PermittedAttributes.taxon_attributes
       end
     end
   end

--- a/backend/app/controllers/spree/admin/users_controller.rb
+++ b/backend/app/controllers/spree/admin/users_controller.rb
@@ -121,10 +121,10 @@ module Spree
       end
 
       def user_params
-        params.require(:user).permit(PermittedAttributes.user_attributes |
+        params.require(:user).permit(permitted_user_attributes |
                                      [:spree_role_ids,
-                                      ship_address_attributes: PermittedAttributes.address_attributes,
-                                      bill_address_attributes: PermittedAttributes.address_attributes])
+                                      ship_address_attributes: permitted_address_attributes,
+                                      bill_address_attributes: permitted_address_attributes])
       end
 
       # handling raise from Spree::Admin::ResourceController#destroy


### PR DESCRIPTION
Most of the controllers use the generated `permitted_*_attributes` methods to indirectly access `PermittedAttributes`, but there are a few that explicitly call `PermittedAttributes` making it more difficult to override those in a controller decorator.  This PR updates the few controllers that call `PermittedAttributes` and changes them to use the generated methods instead.
