### PR TITLE
fix duplicate user_id for last_incomplete_spree_order

### DIFF
--- a/core/config/initializers/user_class_extensions.rb
+++ b/core/config/initializers/user_class_extensions.rb
@@ -21,7 +21,7 @@ Spree::Core::Engine.config.to_prepare do
       end
 
       def last_incomplete_spree_order
-        spree_orders.incomplete.where(user_id: self.id).order('created_at DESC').first
+        spree_orders.incomplete.order('created_at DESC').first
       end
     end
   end


### PR DESCRIPTION
Remove duplicate `user_id` search condition for the `last_incomplete_spree_order` method 
