### PR TITLE
Remove environment from payment_method

### DIFF
--- a/api/app/views/spree/api/orders/payment.v1.rabl
+++ b/api/app/views/spree/api/orders/payment.v1.rabl
@@ -1,3 +1,3 @@
 child :available_payment_methods => :payment_methods do
-  attributes :id, :name, :environment, :method_type
+  attributes :id, :name, :method_type
 end

--- a/api/app/views/spree/api/orders/show.v1.rabl
+++ b/api/app/views/spree/api/orders/show.v1.rabl
@@ -21,7 +21,7 @@ child :payments => :payments do
   attributes *payment_attributes
 
   child :payment_method => :payment_method do
-    attributes :id, :name, :environment
+    attributes :id, :name
   end
 
   child :source => :source do

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -4,8 +4,6 @@ module Spree
     DISPLAY = [:both, :front_end, :back_end]
     default_scope { where(deleted_at: nil) }
 
-    scope :production, -> { where(environment: 'production') }
-
     validates :name, presence: true
 
     has_many :payments, class_name: "Spree::Payment", inverse_of: :payment_method
@@ -29,13 +27,12 @@ module Spree
     def self.available(display_on = 'both')
       all.select do |p|
         p.active &&
-        (p.display_on == display_on.to_s || p.display_on.blank?) &&
-        (p.environment == Rails.env || p.environment.blank?)
+        (p.display_on == display_on.to_s || p.display_on.blank?)
       end
     end
 
     def self.active?
-      where(type: self.to_s, environment: Rails.env, active: true).count > 0
+      where(type: self.to_s, active: true).count > 0
     end
 
     def method_type

--- a/core/app/models/spree/refund.rb
+++ b/core/app/models/spree/refund.rb
@@ -11,7 +11,6 @@ module Spree
     validates :transaction_id, presence: true, on: :update # can't require this on create because the before_create needs to run first
     validates :amount, presence: true, numericality: {greater_than: 0}
 
-    validate :check_payment_environment, on: :create, if: :payment
     validate :amount_is_less_than_or_equal_to_allowed_amount, on: :create
 
     after_create :perform!
@@ -67,15 +66,6 @@ module Spree
     rescue ActiveMerchant::ConnectionError => e
       logger.error(Spree.t(:gateway_error) + "  #{e.inspect}")
       raise Core::GatewayError.new(Spree.t(:unable_to_connect_to_gateway))
-    end
-
-    # Saftey check to make sure we're not accidentally performing operations on a live gateway.
-    # Ex. When testing in staging environment with a copy of production data.
-    def check_payment_environment
-      if payment.payment_method.environment != Rails.env
-        message = Spree.t(:gateway_config_unavailable) + " - #{Rails.env}"
-        errors.add(:base, message)
-      end
     end
 
     def create_log_entry

--- a/core/db/migrate/20150121022521_remove_environment_from_payment_method.rb
+++ b/core/db/migrate/20150121022521_remove_environment_from_payment_method.rb
@@ -1,0 +1,6 @@
+class RemoveEnvironmentFromPaymentMethod < ActiveRecord::Migration
+  def up
+    Spree::PaymentMethod.where('environment != ?', Rails.env).update_all(active: false)
+    remove_column :spree_payment_methods, :environment
+  end
+end

--- a/core/lib/spree/testing_support/factories/payment_method_factory.rb
+++ b/core/lib/spree/testing_support/factories/payment_method_factory.rb
@@ -1,18 +1,15 @@
 FactoryGirl.define do
   factory :check_payment_method, class: Spree::PaymentMethod::Check do
     name 'Check'
-    environment 'test'
   end
 
   factory :credit_card_payment_method, class: Spree::Gateway::Bogus do
     name 'Credit Card'
-    environment 'test'
   end
 
   # authorize.net was moved to spree_gateway.
   # Leaving this factory in place with bogus in case anyone is using it.
   factory :simple_credit_card_payment_method, class: Spree::Gateway::BogusSimple do
     name 'Credit Card'
-    environment 'test'
   end
 end

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -14,10 +14,6 @@ describe Spree::CreditCard, type: :model do
     Spree::Payment.state_machine.states.keys
   end
 
-  def stub_rails_env(environment)
-    allow(Rails).to receive_messages(env: ActiveSupport::StringInquirer.new(environment))
-  end
-
   let(:credit_card) { Spree::CreditCard.new }
 
   before(:each) do
@@ -35,7 +31,6 @@ describe Spree::CreditCard, type: :model do
       capture: @success_response,
       void: @success_response,
       credit: @success_response,
-      environment: 'test'
     )
 
     allow(@payment).to receive_messages payment_method: @payment_gateway

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -553,7 +553,6 @@ describe Spree::Order, :type => :model do
         :name => "Fake",
         :active => true,
         :display_on => "front_end",
-        :environment => Rails.env
       })
       expect(order.available_payment_methods).to include(payment_method)
     end
@@ -563,7 +562,6 @@ describe Spree::Order, :type => :model do
         :name => "Fake",
         :active => true,
         :display_on => "both",
-        :environment => Rails.env
       })
       expect(order.available_payment_methods).to include(payment_method)
     end
@@ -573,7 +571,6 @@ describe Spree::Order, :type => :model do
         :name => "Fake",
         :active => true,
         :display_on => "both",
-        :environment => Rails.env
       })
       expect(order.available_payment_methods.count).to eq(1)
       expect(order.available_payment_methods).to include(payment_method)

--- a/core/spec/models/spree/payment_method_spec.rb
+++ b/core/spec/models/spree/payment_method_spec.rb
@@ -8,7 +8,6 @@ describe Spree::PaymentMethod, :type => :model do
           :name => 'Display Both',
           :display_on => display_on,
           :active => true,
-          :environment => 'test',
           :description => 'foofah'
         )
       end

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -5,7 +5,7 @@ describe Spree::Payment, :type => :model do
   let(:refund_reason) { create(:refund_reason) }
 
   let(:gateway) do
-    gateway = Spree::Gateway::Bogus.new(:environment => 'test', :active => true)
+    gateway = Spree::Gateway::Bogus.new(:active => true)
     allow(gateway).to receive_messages :source_required => true
     gateway
   end
@@ -171,13 +171,6 @@ describe Spree::Payment, :type => :model do
         payment.authorize!
       end
 
-      context "when gateway does not match the environment" do
-        it "should raise an exception" do
-          allow(gateway).to receive_messages :environment => "foo"
-          expect { payment.authorize! }.to raise_error(Spree::Core::GatewayError)
-        end
-      end
-
       context "if successful" do
         before do
           expect(payment.payment_method).to receive(:authorize).with(amount_in_cents,
@@ -221,13 +214,6 @@ describe Spree::Payment, :type => :model do
         payment.save!
         expect(payment.log_entries).to receive(:create!).with(details: anything)
         payment.purchase!
-      end
-
-      context "when gateway does not match the environment" do
-        it "should raise an exception" do
-          allow(gateway).to receive_messages :environment => "foo"
-          expect { payment.purchase!  }.to raise_error(Spree::Core::GatewayError)
-        end
       end
 
       context "if successful" do
@@ -366,13 +352,6 @@ describe Spree::Payment, :type => :model do
       it "should log the response" do
         expect(payment.log_entries).to receive(:create!).with(:details => anything)
         payment.void_transaction!
-      end
-
-      context "when gateway does not match the environment" do
-        it "should raise an exception" do
-          allow(gateway).to receive_messages :environment => "foo"
-          expect { payment.void_transaction! }.to raise_error(Spree::Core::GatewayError)
-        end
       end
 
       context "if successful" do

--- a/core/spec/models/spree/refund_spec.rb
+++ b/core/spec/models/spree/refund_spec.rb
@@ -10,8 +10,7 @@ describe Spree::Refund, :type => :model do
 
     let(:payment) { create(:payment, amount: payment_amount, payment_method: payment_method) }
     let(:payment_amount) { amount*2 }
-    let(:payment_method) { create(:credit_card_payment_method, environment: payment_method_environment) }
-    let(:payment_method_environment) { 'test' }
+    let(:payment_method) { create(:credit_card_payment_method) }
 
     let(:refund_reason) { create(:refund_reason) }
 
@@ -145,17 +144,6 @@ describe Spree::Refund, :type => :model do
 
       it 'raises Spree::Core::GatewayError' do
         expect { subject }.to raise_error(Spree::Core::GatewayError, Spree.t(:unable_to_connect_to_gateway))
-      end
-    end
-
-    context 'with the incorrect payment method environment' do
-      let(:payment_method_environment) { 'development' }
-
-      it 'raises a Spree::Core::GatewayError' do
-        expect { subject }.to raise_error { |error|
-          expect(error).to be_a(ActiveRecord::RecordInvalid)
-          expect(error.record.errors.full_messages).to eq [Spree.t(:gateway_config_unavailable) + " - test"]
-        }
       end
     end
 

--- a/guides/content/api/checkouts.md
+++ b/guides/content/api/checkouts.md
@@ -463,8 +463,7 @@ For more information on payments, view the [payments documentation](payments).
       "updated_at": "2014-07-06T19:55:08.308Z",
       "payment_method": {
         "id": 1,
-        "name": "Credit Card",
-        "environment": "development"
+        "name": "Credit Card"
       },
       "source": {
         "id": 2,

--- a/guides/content/developer/core/payments.md
+++ b/guides/content/developer/core/payments.md
@@ -44,7 +44,6 @@ A `PaymentMethod` can have the following attributes:
 * `name`: The visible name for this payment method
 * `description`: The description for this payment method
 * `active`: Whether or not this payment method is active. Set it `false` to hide it in frontend.
-* `environment`: The Rails environment (`Rails.env`) where this payment method is active
 * `display_on`: Determines where the payment method can be visible. Values can be `front` for frontend, `back` for backend or `both` for both.
 
 ### Payment Method Visibility
@@ -55,8 +54,7 @@ The appearance of the payment methods on the frontend and backend depend on seve
 def self.available(display_on = 'both')
   all.select do |p|
     p.active &&
-    (p.display_on == display_on.to_s || p.display_on.blank?) &&
-    (p.environment == Rails.env || p.environment.blank?)
+    (p.display_on == display_on.to_s || p.display_on.blank?)
   end
 end
 ```

--- a/guides/content/user/payments/payment_methods.md
+++ b/guides/content/user/payments/payment_methods.md
@@ -42,14 +42,6 @@ If you installed the [Spree_Gateway](https://github.com/spree/spree_gateway) ext
 
 ![Select Payment Gateway Provider](/images/user/payments/add_payment_provider.jpg)
 
-#### Environment
-
-Choose the environment where you would like to enable the payment method. The choices are:
-
-* **Development** - Used by developers when they are testing a Spree store on their local machine.
-* **Production** - Select if you want the payment gateway to appear on the customer-facing area of your store.
-* **Test** - Used by developers who are testing their Spree store, typically with our [test suite](/developer/testing.html).
-
 #### Display
 
 Select whether you want the payment method to appear on the Frontend or the Backend of your store, or both.


### PR DESCRIPTION
This anti-feature adds complexity to both the code and the payment
method interface. End-users don't (and shouldn't) understand what this
does it does not follow any standard rails conventions.

Removing this "feature" is a net benefit to the codebase.
