### PR TITLE
Fix payment status for orders with a void payment

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -291,7 +291,7 @@ module Spree
     end
 
     def outstanding_balance
-      if self.state == 'canceled' && self.payments.present? && self.payments.completed.size > 0
+      if state == 'canceled'
         -1 * payment_total
       else
         total - payment_total

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -160,9 +160,7 @@ module Spree
       last_state = order.payment_state
       if payments.present? && payments.valid.size == 0
         order.payment_state = 'failed'
-      elsif !payments.present? && order.state == 'canceled'
-        order.payment_state = 'void'
-      elsif order.state == 'canceled' && order.payment_total == 0 && payments.completed.size > 0
+      elsif order.state == 'canceled' && order.payment_total == 0
         order.payment_state = 'void'
       else
         order.payment_state = 'balance_due' if order.outstanding_balance > 0

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -185,8 +185,6 @@ module Spree
           it "is void" do
             order.payment_total = 0
             order.total = 30
-            allow(order).to receive_message_chain(:payments, :valid, :size).and_return(1)
-            allow(order).to receive_message_chain(:payments, :completed, :size).and_return(2)
             expect {
               updater.update_payment_state
             }.to change { order.payment_state }.to 'void'


### PR DESCRIPTION
There was some very strange logic surrounding the calculation of `outstanding_balance` and the order's `payment_state`.

In both of these there is a check for `payments.completed.size`, to "ensure there is a completed payment", which I believe should be removed. If the only payment on an order becomes void, there will be no completed payments, so the payment state will (incorrectly) be considered `balance_due` and the `outstanding_balance` will incorrectly be the order's total.

This change introduced no failing tests, and allowed removing some unnecessary stubbing of the System Under Test.
