### PR TITLE
Spree::ReimbursementType typo

### DIFF
--- a/backend/app/views/spree/admin/reimbursement_types/index.html.erb
+++ b/backend/app/views/spree/admin/reimbursement_types/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree::ReimburementType.model_name.human(count: :many) %>
+  <%= Spree::ReimbursementType.model_name.human(count: :many) %>
 <% end %>
 
 <% if @reimbursement_types.any? %>
@@ -25,7 +25,7 @@
   </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: Spree::ReimburementType.model_name.human(count: :many)) %>,
+    <%= Spree.t(:no_resource_found, resource: Spree::ReimbursementType.model_name.human(count: :many)) %>,
     <%= link_to Spree.t(:add_one), new_object_url %>!
   </div>
 <% end %>


### PR DESCRIPTION
In backend:

`Spree::ReimburementType` should be `Spree::ReimbursementType`
