### PR TITLE
Fix return authorization's cancel button if its return items can't be cancelled

### DIFF
--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -29,7 +29,7 @@ module Spree
       before_transition to: :canceled, do: :cancel_return_items
 
       event :cancel do
-        transition to: :canceled, from: :authorized
+        transition to: :canceled, from: :authorized, if: lambda { |return_authorization| return_authorization.can_cancel_return_items? }
       end
 
     end
@@ -53,6 +53,10 @@ module Spree
       customer_returns.exists?
     end
 
+    def can_cancel_return_items?
+      return_items.any?(&:can_cancel?) || return_items.blank?
+    end
+
     private
 
       def must_have_shipped_units
@@ -69,7 +73,7 @@ module Spree
       end
 
       def cancel_return_items
-        return_items.each(&:cancel!)
+        return_items.each { |item| item.cancel! if item.can_cancel? }
       end
 
       def generate_expedited_exchange_reimbursements


### PR DESCRIPTION
When return authorization is being [cancelled](https://github.com/spree/spree/blob/master/core/app/models/spree/return_authorization.rb#L29), its return items are [cancelled](https://github.com/spree/spree/blob/master/core/app/models/spree/return_authorization.rb#L71-L73) as well. When they are in [state](https://github.com/spree/spree/blob/master/core/app/models/spree/return_item.rb#L62-L64) from which they can't be cancelled, an error occurs.

This hides `cancel` button from [return authorization menu](https://github.com/spree/spree/blob/master/backend/app/views/spree/admin/return_authorizations/edit.html.erb#L2) when its line items can't be cancelled

Fixes #5804
