### PR TITLE
Remove credit card expiry validation.

### DIFF
--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -18,8 +18,6 @@ module Spree
     validates :name, presence: true, if: :require_card_numbers?, on: :create
     validates :verification_value, presence: true, if: :require_card_numbers?, on: :create, unless: :imported
 
-    validate :expiry_not_in_the_past
-
     scope :with_payment_profile, -> { where('gateway_customer_profile_id IS NOT NULL') }
     scope :default, -> { where(default: true) }
 
@@ -134,19 +132,6 @@ module Spree
     end
 
     private
-
-    def expiry_not_in_the_past
-      if year.present? && month.present?
-        if month.to_i < 1 || month.to_i > 12
-          errors.add(:base, :expiry_invalid)
-        else
-          current = Time.current
-          if year.to_i < current.year or (year.to_i == current.year and month.to_i < current.month)
-            errors.add(:base, :card_expired)
-          end
-        end
-      end
-    end
 
     def require_card_numbers?
       !self.encrypted_data.present? && !self.has_payment_profile?

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -90,63 +90,6 @@ describe Spree::CreditCard, type: :model do
       expect(credit_card.error_on(:name).size).to eq(1)
     end
 
-    # Regression spec for #4971
-    it "should not bomb out when given an invalid expiry" do
-      credit_card.month = 13
-      credit_card.year = Time.now.year + 1
-      expect(credit_card).not_to be_valid
-      expect(credit_card.errors[:base]).to eq(["Card expiration is invalid"])
-    end
-
-    it "should validate expiration is not in the past" do
-      credit_card.month = 1.month.ago.month
-      credit_card.year = 1.month.ago.year
-      expect(credit_card).not_to be_valid
-      expect(credit_card.errors[:base]).to eq(["Card has expired"])
-    end
-
-    it "should not be expired expiring on the current month" do
-      credit_card.attributes = valid_credit_card_attributes
-      credit_card.month = Time.zone.now.month
-      credit_card.year = Time.zone.now.year
-      expect(credit_card).to be_valid
-    end
-
-    it "should handle TZ correctly" do
-      # The card is valid according to the system clock's local time
-      # (Time.now).
-      # However it has expired in rails's configured time zone (Time.current),
-      # which is the value we should be respecting.
-      time = Time.new(2014, 04, 30, 23, 0, 0, "-07:00")
-      Timecop.freeze(time) do
-        credit_card.month = 1.month.ago.month
-        credit_card.year = 1.month.ago.year
-        expect(credit_card).not_to be_valid
-        expect(credit_card.errors[:base]).to eq(["Card has expired"])
-      end
-    end
-
-    it "does not run expiration in the past validation if month is not set" do
-      credit_card.month = nil
-      credit_card.year = Time.now.year
-      expect(credit_card).not_to be_valid
-      expect(credit_card.errors[:base]).to be_blank
-    end
-
-    it "does not run expiration in the past validation if year is not set" do
-      credit_card.month = Time.now.month
-      credit_card.year = nil
-      expect(credit_card).not_to be_valid
-      expect(credit_card.errors[:base]).to be_blank
-    end
-
-    it "does not run expiration in the past validation if year and month are empty" do
-      credit_card.year = ""
-      credit_card.month = ""
-      expect(credit_card).not_to be_valid
-      expect(credit_card.errors[:card]).to be_blank
-    end
-
     it "should only validate on create" do
       credit_card.attributes = valid_credit_card_attributes
       credit_card.save


### PR DESCRIPTION
This validation causes issues when attempting to create refunds for a
payment where the credit card has expired.

An example that I experienced was someone who had a credit card that expired on 12 / 2014, who made a purchase late in the month. We attempted to credit the user with a partial refund due to a return in January, 2015. Our payment gateway allowed us to refund the credit card, however, the refund payment was not created in Spree as it was associated with a credit card that had expired.

I feel this logic is best left up to the payment gateway. They decide
whether a credit card is expired or not.
