### PR TITLE
Spell 'user_with_addresses' factory name correctly

### DIFF
--- a/core/lib/spree/testing_support/factories/user_factory.rb
+++ b/core/lib/spree/testing_support/factories/user_factory.rb
@@ -14,7 +14,7 @@ FactoryGirl.define do
       spree_roles { [Spree::Role.find_by(name: 'admin') || create(:role, name: 'admin')] }
     end
 
-    factory :user_with_addreses do
+    factory :user_with_addresses, aliases: [:user_with_addreses] do
       ship_address
       bill_address
     end


### PR DESCRIPTION
Alias for incorrectly spelled name added as per https://github.com/thoughtbot/factory_girl/blob/master/GETTING_STARTED.md#aliases to ensure backwards compatibility.
