### PR TITLE
Cache clear on product drag and drop sort

### DIFF
--- a/api/spec/controllers/spree/api/classifications_controller_spec.rb
+++ b/api/spec/controllers/spree/api/classifications_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Spree
-  describe Api::ClassificationsController, :type => :controller do
+  describe Api::ClassificationsController, type: :controller do
     let(:taxon) do
       taxon = create(:taxon)
 
@@ -18,7 +18,7 @@ module Spree
 
     context "as a user" do
       it "cannot change the order of a product" do
-        api_put :update, :taxon_id => taxon, :product_id => taxon.products.first, :position => 1
+        api_put :update, taxon_id: taxon, product_id: taxon.products.first, position: 1
         expect(response.status).to eq(401)
       end
     end
@@ -29,9 +29,9 @@ module Spree
       let(:last_product) { taxon.products.last }
 
       it "can change the order a product" do
-        classification = taxon.classifications.find_by(:product_id => last_product.id)
+        classification = taxon.classifications.find_by(product_id: last_product.id)
         expect(classification.position).to eq(3)
-        api_put :update, :taxon_id => taxon, :product_id => last_product, :position => 0
+        api_put :update, taxon_id: taxon, product_id: last_product, position: 0
         expect(response.status).to eq(200)
         expect(classification.reload.position).to eq(1)
       end
@@ -39,7 +39,7 @@ module Spree
       it "should touch the taxon" do
         taxon.update_attributes(updated_at: Time.now - 10.seconds)
         taxon_last_updated_at = taxon.updated_at
-        api_put :update, :taxon_id => taxon, :product_id => last_product, :position => 0
+        api_put :update, taxon_id: taxon, product_id: last_product, position: 0
         taxon.reload
         expect(taxon_last_updated_at.to_i).to_not eq(taxon.updated_at.to_i)
       end

--- a/api/spec/controllers/spree/api/classifications_controller_spec.rb
+++ b/api/spec/controllers/spree/api/classifications_controller_spec.rb
@@ -4,6 +4,7 @@ module Spree
   describe Api::ClassificationsController, :type => :controller do
     let(:taxon) do
       taxon = create(:taxon)
+
       3.times do
         product = create(:product)
         product.taxons << taxon
@@ -25,13 +26,22 @@ module Spree
     context "as an admin" do
       sign_in_as_admin!
 
+      let(:last_product) { taxon.products.last }
+
       it "can change the order a product" do
-        last_product = taxon.products.last
         classification = taxon.classifications.find_by(:product_id => last_product.id)
         expect(classification.position).to eq(3)
         api_put :update, :taxon_id => taxon, :product_id => last_product, :position => 0
         expect(response.status).to eq(200)
         expect(classification.reload.position).to eq(1)
+      end
+
+      it "should touch the taxon" do
+        taxon.update_attributes(updated_at: Time.now - 10.seconds)
+        taxon_last_updated_at = taxon.updated_at
+        api_put :update, :taxon_id => taxon, :product_id => last_product, :position => 0
+        taxon.reload
+        expect(taxon_last_updated_at.to_i).to_not eq(taxon.updated_at.to_i)
       end
     end
   end

--- a/core/app/models/spree/classification.rb
+++ b/core/app/models/spree/classification.rb
@@ -3,7 +3,7 @@ module Spree
     self.table_name = 'spree_products_taxons'
     acts_as_list scope: :taxon
     belongs_to :product, class_name: "Spree::Product", inverse_of: :classifications
-    belongs_to :taxon, class_name: "Spree::Taxon", inverse_of: :classifications
+    belongs_to :taxon, class_name: "Spree::Taxon", inverse_of: :classifications, touch: true
 
     # For #3494
     validates_uniqueness_of :taxon_id, scope: :product_id, message: :already_linked

--- a/core/app/models/spree/classification.rb
+++ b/core/app/models/spree/classification.rb
@@ -6,6 +6,6 @@ module Spree
     belongs_to :taxon, class_name: "Spree::Taxon", inverse_of: :classifications
 
     # For #3494
-    validates_uniqueness_of :taxon_id, :scope => :product_id, :message => :already_linked
+    validates_uniqueness_of :taxon_id, scope: :product_id, message: :already_linked
   end
 end


### PR DESCRIPTION
When using the drag and drop admin interface for a products position with a taxon, when the Spree::Classification is saved the associated taxon should be touched so caching can be cleared.

Also tidies up some hashrockets.
