### PR TITLE
Incorrect refund calculation

### DIFF
--- a/core/app/models/concerns/spree/adjustment_source.rb
+++ b/core/app/models/concerns/spree/adjustment_source.rb
@@ -7,6 +7,10 @@ module Spree
       before_destroy :deals_with_adjustments_for_deleted_source
     end
 
+    def tax_affected?
+      false
+    end
+
     protected
 
     def create_adjustment(order, adjustable, included = nil)

--- a/core/app/models/concerns/spree/calculated_adjustments.rb
+++ b/core/app/models/concerns/spree/calculated_adjustments.rb
@@ -7,6 +7,7 @@ module Spree
       accepts_nested_attributes_for :calculator
       validates :calculator, presence: true
       delegate :compute, to: :calculator
+      delegate :tax_affected?, to: :calculator
 
       def self.calculators
         spree_calculators.send model_name_without_spree_namespace

--- a/core/app/models/spree/calculator.rb
+++ b/core/app/models/spree/calculator.rb
@@ -43,5 +43,9 @@ module Spree
     def available?(object)
       true
     end
+
+    def tax_affected?
+      false
+    end
   end
 end

--- a/core/app/models/spree/calculator/flat_percent_item_total.rb
+++ b/core/app/models/spree/calculator/flat_percent_item_total.rb
@@ -18,5 +18,9 @@ module Spree
         computed_amount
       end
     end
+
+    def tax_affected?
+      true
+    end
   end
 end

--- a/core/app/models/spree/calculator/percent_on_line_item.rb
+++ b/core/app/models/spree/calculator/percent_on_line_item.rb
@@ -10,6 +10,10 @@ module Spree
       def compute(object)
         (object.amount * preferred_percent) / 100
       end
+
+      def tax_affected?
+        true
+      end
     end
   end
 end

--- a/core/app/models/spree/calculator/percent_per_item.rb
+++ b/core/app/models/spree/calculator/percent_per_item.rb
@@ -22,6 +22,10 @@ module Spree
       end
     end
 
+    def tax_affected?
+      true
+    end
+
   private
 
     # Returns all products that match this calculator, but only if the calculator

--- a/core/app/models/spree/calculator/tiered_percent.rb
+++ b/core/app/models/spree/calculator/tiered_percent.rb
@@ -27,6 +27,10 @@ module Spree
       (object.amount * (percent || preferred_base_percent) / 100).round(2)
     end
 
+    def tax_affected?
+      true
+    end
+
     private
     def preferred_tiers_content
       if preferred_tiers.is_a? Hash

--- a/core/spec/models/spree/calculator/refunds/default_refund_amount_spec.rb
+++ b/core/spec/models/spree/calculator/refunds/default_refund_amount_spec.rb
@@ -1,20 +1,25 @@
 require 'spec_helper'
 
-describe Spree::Calculator::Returns::DefaultRefundAmount, type: :model do
+shared_context 'a default refund calculator' do
   let(:line_item_quantity) { 2 }
-  let(:price) { 100.0 }
+  let(:line_item_price) { 100.0 }
   let(:tax_amount) { 0.2 }
   let(:order) { create(:order) }
-  let(:line_item) { create(:line_item, price: price, quantity: line_item_quantity) }
-  let(:pre_tax_amount) { line_item.pre_tax_amount }
+
+  let(:tax_rate) do
+    create(:tax_rate, zone: create(:zone, default_tax: true),
+                      included_in_price: tax_included_in_price,
+                      amount: tax_amount)
+  end
+
   let(:inventory_unit) { build(:inventory_unit, order: order, line_item: line_item) }
-  let(:return_item) { build(:return_item, inventory_unit: inventory_unit ) }
+
+  let(:return_item) { build(:return_item, inventory_unit: inventory_unit) }
+
   let(:calculator) { Spree::Calculator::Returns::DefaultRefundAmount.new }
 
-  before do
-    create(:tax_rate, zone: create(:zone, default_tax: true),
-                      included_in_price: true,
-                      amount: tax_amount)
+  before(:each) do
+    tax_rate
     order.line_items << line_item
     order.updater.update_totals
   end
@@ -27,22 +32,25 @@ describe Spree::Calculator::Returns::DefaultRefundAmount, type: :model do
     end
 
     context 'order adjustments' do
+      let(:promotion_action) do
+        calculator = Spree::Calculator::FlatPercentItemTotal.new
+        calculator.preferred_flat_percent = 40
+        Spree::Promotion::Actions::CreateAdjustment.create!(calculator: calculator,
+                                                            promotion: create(:promotion))
+      end
+
       let(:adjustment_amount) { order.item_total * -0.4 }
 
-      before do
-        order.adjustments << create(:adjustment, order: order,
-                                                 amount: adjustment_amount,
-                                                 eligible: true,
-                                                 label: 'Adjustment',
-                                                 source_type: 'Spree::Order')
-        order.adjustments.first.update_attributes(amount: adjustment_amount)
+      before(:each) do
+        promotion_action.perform(order: order)
+        order.save!
         order.updater.update_totals
       end
 
-      it { is_expected.to eq (pre_tax_amount - adjustment_amount.abs) / line_item_quantity }
+      it { is_expected.to be_within(0.001).of(adjustment_refund_amount) }
 
       context 'refund amount * line item quantity with tax applied' do
-        subject { (calculator.compute(return_item) * line_item_quantity) * (1 + tax_amount) }
+        subject { full_refund_amount }
         it { is_expected.to eq order.total }
       end
     end
@@ -63,7 +71,45 @@ describe Spree::Calculator::Returns::DefaultRefundAmount, type: :model do
   end
 
   context 'pre_tax_amount is zero' do
-    let(:price)  { 0.0 }
+    let(:line_item_price)  { 0.0 }
     it { should eq 0.0 }
+  end
+end
+
+describe Spree::Calculator::Returns::DefaultRefundAmount, type: :model do
+  context 'tax included in price' do
+    let(:tax_included_in_price) { true }
+    let(:pre_tax_amount) { line_item.pre_tax_amount }
+
+    let(:line_item) { create(:line_item, price: line_item_price, quantity: line_item_quantity) }
+
+    let(:adjustment_refund_amount) do
+      (line_item_price + (adjustment_amount / 2)) / (1 + tax_amount)
+    end
+
+    let(:full_refund_amount) do
+      (calculator.compute(return_item) * (1 + tax_amount)).round * line_item_quantity
+    end
+
+    it_should_behave_like 'a default refund calculator'
+  end
+
+  context 'tax additional to price' do
+    let(:tax_included_in_price) { false }
+    let(:pre_tax_amount) { line_item_price * line_item_quantity }
+
+    let(:line_item) { create(:line_item, price: line_item_price,
+                                         quantity: line_item_quantity,
+                                         pre_tax_amount: pre_tax_amount) }
+
+    let(:adjustment_refund_amount) do
+      (pre_tax_amount - adjustment_amount.abs) / line_item_quantity
+    end
+
+    let(:full_refund_amount) do
+      (calculator.compute(return_item) * line_item_quantity) + order.additional_tax_total
+    end
+
+    it_should_behave_like 'a default refund calculator'
   end
 end

--- a/core/spec/models/spree/calculator/refunds/default_refund_amount_spec.rb
+++ b/core/spec/models/spree/calculator/refunds/default_refund_amount_spec.rb
@@ -36,6 +36,11 @@ describe Spree::Calculator::Returns::DefaultRefundAmount, :type => :model do
       end
 
       it { is_expected.to eq (line_item.pre_tax_amount - adjustment_amount.abs) / line_item_quantity }
+
+      context 'refund amount * line item quantity with tax applied' do
+        subject { (calculator.compute(return_item) * line_item_quantity) * (1 + tax_amount) }
+        it { is_expected.to eq order.total }
+      end
     end
 
     context "shipping adjustments" do

--- a/core/spec/models/spree/calculator/refunds/default_refund_amount_spec.rb
+++ b/core/spec/models/spree/calculator/refunds/default_refund_amount_spec.rb
@@ -98,9 +98,11 @@ describe Spree::Calculator::Returns::DefaultRefundAmount, type: :model do
     let(:tax_included_in_price) { false }
     let(:pre_tax_amount) { line_item_price * line_item_quantity }
 
-    let(:line_item) { create(:line_item, price: line_item_price,
-                                         quantity: line_item_quantity,
-                                         pre_tax_amount: pre_tax_amount) }
+    let(:line_item) do
+      create(:line_item, price: line_item_price,
+                         quantity: line_item_quantity,
+                         pre_tax_amount: pre_tax_amount)
+    end
 
     let(:adjustment_refund_amount) do
       (pre_tax_amount - adjustment_amount.abs) / line_item_quantity

--- a/core/spec/models/spree/calculator/refunds/default_refund_amount_spec.rb
+++ b/core/spec/models/spree/calculator/refunds/default_refund_amount_spec.rb
@@ -1,14 +1,15 @@
 require 'spec_helper'
 
-describe Spree::Calculator::Returns::DefaultRefundAmount, :type => :model do
-  let(:order)           { create(:order) }
+describe Spree::Calculator::Returns::DefaultRefundAmount, type: :model do
   let(:line_item_quantity) { 2 }
   let(:price) { 100.0 }
-  let(:line_item)       { create(:line_item, price: price, quantity: line_item_quantity) }
+  let(:tax_amount) { 0.2 }
+  let(:order) { create(:order) }
+  let(:line_item) { create(:line_item, price: price, quantity: line_item_quantity) }
+  let(:pre_tax_amount) { line_item.pre_tax_amount }
   let(:inventory_unit) { build(:inventory_unit, order: order, line_item: line_item) }
   let(:return_item) { build(:return_item, inventory_unit: inventory_unit ) }
   let(:calculator) { Spree::Calculator::Returns::DefaultRefundAmount.new }
-  let(:tax_amount) { 0.2 }
 
   before do
     create(:tax_rate, zone: create(:zone, default_tax: true),
@@ -18,24 +19,27 @@ describe Spree::Calculator::Returns::DefaultRefundAmount, :type => :model do
     order.updater.update_totals
   end
 
-
   subject { calculator.compute(return_item) }
 
-  context "not an exchange" do
-    context "no promotions or taxes" do
-      it { is_expected.to eq line_item.pre_tax_amount / line_item_quantity }
+  context 'not an exchange' do
+    context 'no promotions or taxes' do
+      it { is_expected.to eq pre_tax_amount / line_item_quantity }
     end
 
-    context "order adjustments" do
+    context 'order adjustments' do
       let(:adjustment_amount) { order.item_total * -0.4 }
 
       before do
-        order.adjustments << create(:adjustment, order: order, amount: adjustment_amount, eligible: true, label: 'Adjustment', source_type: 'Spree::Order')
+        order.adjustments << create(:adjustment, order: order,
+                                                 amount: adjustment_amount,
+                                                 eligible: true,
+                                                 label: 'Adjustment',
+                                                 source_type: 'Spree::Order')
         order.adjustments.first.update_attributes(amount: adjustment_amount)
         order.updater.update_totals
       end
 
-      it { is_expected.to eq (line_item.pre_tax_amount - adjustment_amount.abs) / line_item_quantity }
+      it { is_expected.to eq (pre_tax_amount - adjustment_amount.abs) / line_item_quantity }
 
       context 'refund amount * line item quantity with tax applied' do
         subject { (calculator.compute(return_item) * line_item_quantity) * (1 + tax_amount) }
@@ -43,22 +47,22 @@ describe Spree::Calculator::Returns::DefaultRefundAmount, :type => :model do
       end
     end
 
-    context "shipping adjustments" do
+    context 'shipping adjustments' do
       let(:adjustment_total) { -50.0 }
 
       before { order.shipments << Spree::Shipment.new(adjustment_total: adjustment_total) }
 
-      it { is_expected.to eq line_item.pre_tax_amount / line_item_quantity }
+      it { is_expected.to eq pre_tax_amount / line_item_quantity }
     end
   end
 
-  context "an exchange" do
+  context 'an exchange' do
     let(:return_item) { build(:exchange_return_item) }
 
     it { is_expected.to eq 0.0 }
   end
 
-  context "pre_tax_amount is zero" do
+  context 'pre_tax_amount is zero' do
     let(:price)  { 0.0 }
     it { should eq 0.0 }
   end

--- a/core/spec/models/spree/calculator/refunds/default_refund_amount_spec.rb
+++ b/core/spec/models/spree/calculator/refunds/default_refund_amount_spec.rb
@@ -3,30 +3,39 @@ require 'spec_helper'
 describe Spree::Calculator::Returns::DefaultRefundAmount, :type => :model do
   let(:order)           { create(:order) }
   let(:line_item_quantity) { 2 }
-  let(:pre_tax_amount)  { 100.0 }
-  let(:line_item)       { create(:line_item, price: 100.0, quantity: line_item_quantity, pre_tax_amount: pre_tax_amount) }
+  let(:price) { 100.0 }
+  let(:line_item)       { create(:line_item, price: price, quantity: line_item_quantity) }
   let(:inventory_unit) { build(:inventory_unit, order: order, line_item: line_item) }
   let(:return_item) { build(:return_item, inventory_unit: inventory_unit ) }
   let(:calculator) { Spree::Calculator::Returns::DefaultRefundAmount.new }
+  let(:tax_amount) { 0.2 }
 
-  before { order.line_items << line_item }
+  before do
+    create(:tax_rate, zone: create(:zone, default_tax: true),
+                      included_in_price: true,
+                      amount: tax_amount)
+    order.line_items << line_item
+    order.updater.update_totals
+  end
+
 
   subject { calculator.compute(return_item) }
 
   context "not an exchange" do
     context "no promotions or taxes" do
-      it { is_expected.to eq pre_tax_amount / line_item_quantity }
+      it { is_expected.to eq line_item.pre_tax_amount / line_item_quantity }
     end
 
     context "order adjustments" do
-      let(:adjustment_amount) { -10.0 }
+      let(:adjustment_amount) { order.item_total * -0.4 }
 
       before do
         order.adjustments << create(:adjustment, order: order, amount: adjustment_amount, eligible: true, label: 'Adjustment', source_type: 'Spree::Order')
         order.adjustments.first.update_attributes(amount: adjustment_amount)
+        order.updater.update_totals
       end
 
-      it { is_expected.to eq (pre_tax_amount - adjustment_amount.abs) / line_item_quantity }
+      it { is_expected.to eq (line_item.pre_tax_amount - adjustment_amount.abs) / line_item_quantity }
     end
 
     context "shipping adjustments" do
@@ -34,7 +43,7 @@ describe Spree::Calculator::Returns::DefaultRefundAmount, :type => :model do
 
       before { order.shipments << Spree::Shipment.new(adjustment_total: adjustment_total) }
 
-      it { is_expected.to eq pre_tax_amount / line_item_quantity }
+      it { is_expected.to eq line_item.pre_tax_amount / line_item_quantity }
     end
   end
 
@@ -45,7 +54,7 @@ describe Spree::Calculator::Returns::DefaultRefundAmount, :type => :model do
   end
 
   context "pre_tax_amount is zero" do
-    let(:pre_tax_amount)  { 0.0 }
+    let(:price)  { 0.0 }
     it { should eq 0.0 }
   end
 end


### PR DESCRIPTION
I've added a failing test to request feedback on this potential incorrect refund calculation.

In the test for Spree::Calculator::Refunds::DefaultRefundAmount I have introduced a tax rate and then added an example that tests that had the full order been refunded, the correct amount would have been refunded. The test fails because even if we refunded both line items, the combined total with tax applied is less than the order total.

This _is_ a bug right?

Related to: #5915 
