### PR TITLE
Add the ability to decide whether a return item is resellable

### DIFF
--- a/backend/app/views/spree/admin/customer_returns/_return_item_selection.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_return_item_selection.html.erb
@@ -8,6 +8,7 @@
       <th><%= Spree.t(:sku) %></th>
       <th><%= Spree.t(:pre_tax_amount) %></th>
       <th><%= Spree.t(:exchange_for) %></th>
+      <th><%= Spree.t(:resellable) %></th>
     </tr>
   </thead>
   <tbody>
@@ -34,6 +35,9 @@
         </td>
         <td class="align-center">
           <%= return_item.exchange_variant.try(:exchange_name) %>
+        </td>
+        <td class="align-center">
+          <%= item_fields.check_box :resellable, { checked: return_item.resellable } %>
         </td>
       </tr>
     <% end %>

--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -42,6 +42,7 @@ module Spree
     scope :exchange_requested, -> { where.not(exchange_variant: nil) }
     scope :exchange_processed, -> { where.not(exchange_inventory_unit: nil) }
     scope :exchange_required, -> { exchange_requested.where(exchange_inventory_unit: nil) }
+    scope :resellable, -> { where resellable: true }
 
     serialize :acceptance_status_errors
 
@@ -228,7 +229,7 @@ module Spree
     end
 
     def should_restock?
-      variant.should_track_inventory? && stock_item && Spree::Config[:restock_inventory]
+      resellable? && variant.should_track_inventory? && stock_item && Spree::Config[:restock_inventory]
     end
   end
 end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1100,6 +1100,7 @@ en:
     rename: Rename
     report: Report
     reports: Reports
+    resellable: Resellable
     resend: Resend
     reset_password: Reset my password
     response_code: Response Code

--- a/core/db/migrate/20150122145607_add_resellable_to_return_items.rb
+++ b/core/db/migrate/20150122145607_add_resellable_to_return_items.rb
@@ -1,0 +1,5 @@
+class AddResellableToReturnItems < ActiveRecord::Migration
+  def change
+    add_column :spree_return_items, :resellable, :boolean, default: true, null: false
+  end
+end

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -40,7 +40,7 @@ module Spree
       :coupon_code, :email, :shipping_method_id, :special_instructions, :use_billing
     ]
 
-    @@customer_return_attributes = [:stock_location_id, return_items_attributes: [:id, :inventory_unit_id, :return_authorization_id, :returned, :pre_tax_amount, :acceptance_status, :exchange_variant_id]]
+    @@customer_return_attributes = [:stock_location_id, return_items_attributes: [:id, :inventory_unit_id, :return_authorization_id, :returned, :pre_tax_amount, :acceptance_status, :exchange_variant_id, :resellable]]
 
     @@image_attributes = [:alt, :attachment, :position, :viewable_type, :viewable_id]
 

--- a/core/spec/models/spree/return_item_spec.rb
+++ b/core/spec/models/spree/return_item_spec.rb
@@ -54,6 +54,11 @@ describe Spree::ReturnItem, :type => :model do
         expect { subject }.to change { stock_item.reload.count_on_hand }.by(1)
       end
 
+      context "when the variant is not resellable" do
+        before { return_item.update_attributes(resellable: false) }
+        it { expect { subject }.not_to change { stock_item.reload.count_on_hand } }
+      end
+
       context 'when variant does not track inventory' do
         before do
           inventory_unit.update_attributes!(state: 'shipped')


### PR DESCRIPTION
- Enable the ability to choose whether a return item is resellable, which is factored into whether it should restock inventory counts for the related variant.
