### PR TITLE
FIX spree/spree#5930 and spree/spree#5931 Spree.t in hard code English strings for adjustment

### DIFF
--- a/backend/app/views/spree/admin/adjustments/_adjustments_table.html.erb
+++ b/backend/app/views/spree/admin/adjustments/_adjustments_table.html.erb
@@ -1,5 +1,5 @@
 <div class="panel-heading">
-  <h3 class="panel-title">Order Adjustments</h3>
+  <h3 class="panel-title"><%= Spree.t(:order_adjustments) %></h3>
 </div>
 
 <table class="table table-bordered adjustments" data-hook="adjustments">

--- a/backend/app/views/spree/admin/adjustments/edit.html.erb
+++ b/backend/app/views/spree/admin/adjustments/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Adjustments' } %>
+<%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current =>  Spree.t(:adjustments) } %>
 
 <% content_for :page_title do %>
   / <%= Spree.t(:edit) %> <%= Spree.t(:adjustment) %>

--- a/backend/app/views/spree/admin/adjustments/index.html.erb
+++ b/backend/app/views/spree/admin/adjustments/index.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: 'Adjustments' } %>
+<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: Spree.t(:adjustments)} %>
 
 <% content_for :page_title do %>
    / <%= Spree::Adjustment.model_name.human(count: :many) %>

--- a/backend/app/views/spree/admin/adjustments/new.html.erb
+++ b/backend/app/views/spree/admin/adjustments/new.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Adjustments' } %>
+<%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => Spree.t(:adjustments) } %>
 
 <% content_for :page_title do %>
   / <%= Spree.t(:new_adjustment) %>

--- a/backend/app/views/spree/admin/customer_returns/edit.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Customer Returns' } %>
+<%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => Spree.t(:customer_returns) } %>
 
 <% content_for :page_title do %>
   / <%= Spree.t(:customer_return) %> #<%= @customer_return.number %>

--- a/backend/app/views/spree/admin/customer_returns/index.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/index.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Customer Returns' } %>
+<%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => Spree.t(:customer_returns) } %>
 
 <% content_for :page_actions do %>
   <% if @order.shipments.any?(&:shipped?) %>

--- a/backend/app/views/spree/admin/customer_returns/new.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/new.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Customer Returns' } %>
+<%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => Spree.t(:customer_returns) } %>
 
 <% content_for :page_title do %>
   / <%= Spree.t(:new_customer_return) %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -561,8 +561,6 @@ en:
     coupon_code_not_eligible: This coupon code is not eligible for this order
     coupon_code_not_found: The coupon code you entered doesn't exist. Please try again.
     coupon_code_unknown_error: This coupon code could not be applied to the cart at this time.
-    customer_return: Customer Return
-    customer_returns: Customer Returns
     create: Create
     create_a_new_account: Create a new account
     create_new_order: Create new order
@@ -583,6 +581,8 @@ en:
     customer: Customer
     customer_details: Customer Details
     customer_details_updated: Customer Details Updated
+    customer_return: Customer Return
+    customer_returns: Customer Returns
     customer_search: Customer Search
     cut: Cut
     cvv_response: CVV Response


### PR DESCRIPTION
It's a very straight forward fix. Replacing the hard code English strings for corresponding `Spree.t()`
