### PR TITLE
Remove shipped_shipments

### DIFF
--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -64,7 +64,7 @@ module Spree
         unless @order.completed?
           @order.refresh_shipment_rates
         end
-        if @order.shipped_shipments.count > 0
+        if @order.shipments.shipped.count > 0
           redirect_to edit_admin_order_url(@order)
         end
       end

--- a/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
@@ -25,7 +25,7 @@
       <% if((!shipment.shipped?) && can?(:update, item.line_item)) %>
         <%= link_to_with_icon 'cancel', Spree.t('actions.cancel'), "#", class: 'cancel-item  btn btn-primary btn-sm', data: { action: 'cancel' }, title: Spree.t('actions.cancel'), style: 'display: none', no_text: true %>
         <%= link_to_with_icon 'ok', Spree.t('actions.save'), "#", :class => 'save-item btn btn-success btn-sm', :data => {'shipment-number' => shipment.number, 'variant-id' => item.variant.id, :action => 'save'}, :title => Spree.t('actions.save'), :style => 'display: none', :no_text => true %>
-        <% if shipment.order.shipped_shipments.count == 0 %>
+        <% if shipment.order.shipments.shipped.count == 0 %>
           <%= link_to_with_icon 'split', Spree.t('split'), "#", :class => 'split-item btn btn-primary btn-sm', :data => {:action => 'split', 'variant-id' => item.variant.id}, :title => Spree.t('split'), :no_text => true %>
           <%= link_to_with_icon 'delete', Spree.t('delete'), "#", :class => 'delete-item btn btn-danger btn-sm', :data => { 'shipment-number' => shipment.number, 'variant-id' => item.variant.id, :action => 'remove'}, :title => Spree.t('delete'), :no_text => true %>
         <% end %>

--- a/backend/app/views/spree/admin/shared/_order_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_order_tabs.html.erb
@@ -5,7 +5,7 @@
 
 <% content_for :sidebar do %>
   <ul class="nav nav-pills nav-stacked" data-hook="admin_order_tabs">
-    <% if ((can? :update, @order) && (@order.shipments.count == 0 || @order.shipped_shipments.count == 0)) %>
+    <% if ((can? :update, @order) && (@order.shipments.count == 0 || @order.shipments.shipped.count == 0)) %>
       <li<%== ' class="active"' if current == 'Cart' %> data-hook='admin_order_tabs_cart_details'>
         <%= link_to_with_icon 'edit', Spree.t(:cart), cart_admin_order_url(@order) %>
       </li>

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -246,10 +246,6 @@ module Spree
       end
     end
 
-    def shipped_shipments
-      shipments.shipped
-    end
-
     def contains?(variant, options = {})
       find_line_item_by_variant(variant, options).present?
     end


### PR DESCRIPTION
This one is actually used, but was only ever used in the commit that
added it.

Is no easier or clearer to use that instead of shipments.shipped, and
killing it removes a method from Spree::Order, which is good.
