### PR TITLE
Remove order.contains?

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -238,10 +238,6 @@ module Spree
       end
     end
 
-    def contains?(variant, options = {})
-      find_line_item_by_variant(variant, options).present?
-    end
-
     def quantity_of(variant, options = {})
       line_item = find_line_item_by_variant(variant, options)
       line_item ? line_item.quantity : 0

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -602,10 +602,6 @@ describe Spree::Order, :type => :model do
       allow(order).to receive_messages(:line_items => @line_items)
     end
 
-    it "contains?" do
-      expect(order.contains?(@variant1)).to be true
-    end
-
     it "gets the quantity of a given variant" do
       expect(order.quantity_of(@variant1)).to eq(1)
 


### PR DESCRIPTION
What are we checking to see if it contains? Variants, appearently. But
its not used anywhere and isn't useful so I propose it die.
