### PR TITLE
Moving body_id assignment outside of caching block on product detail view

### DIFF
--- a/frontend/app/views/spree/products/show.html.erb
+++ b/frontend/app/views/spree/products/show.html.erb
@@ -1,6 +1,6 @@
+<% @body_id = 'product-details' %>
 <% cache [I18n.locale, current_currency, @product] do %>
   <div data-hook="product_show" itemscope itemtype="http://schema.org/Product">
-    <% @body_id = 'product-details' %>
 
     <div class="col-md-4" data-hook="product_left_part">
       <div data-hook="product_left_part_wrap">


### PR DESCRIPTION
Ran into an issue on our staging server where the id on the body tag wasn't behaving appropriately when enabling `config.action_controller.perform_caching`. Moving the `@body_id = 'product-details'` assignment outside of the cache block resolves it. 
