### PR TITLE
Allow admins to sepcify stock locations when adding line items to orders

### DIFF
--- a/api/app/controllers/spree/api/line_items_controller.rb
+++ b/api/app/controllers/spree/api/line_items_controller.rb
@@ -61,6 +61,7 @@ module Spree
           params.require(:line_item).permit(
               :quantity,
               :variant_id,
+              :stock_location_quantities,
               options: line_item_options
           )
         end

--- a/backend/app/assets/javascripts/spree/backend/line_items_on_order_edit.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/line_items_on_order_edit.js.erb
@@ -20,19 +20,32 @@ addVariant = function() {
     $('#stock_details').hide();
 
     var variant_id = $('input.variant_autocomplete').val();
-    var quantity = $("input.quantity[data-variant-id='" + variant_id + "']").val();
+    var total_quantity = 0;
+    var stock_location_quantities = {};
 
-    adjustLineItems(order_number, variant_id, quantity);
+    if ($(".stock-levels.untracked-inventory").length > 0) {
+        total_quantity = $("input#variant_quantity").val();
+    }
+    else {
+        var quantities = $("input.quantity[data-variant-id='" + variant_id + "']");
+
+        quantities.each(function() {
+            total_quantity += Number($(this).val());
+            stock_location_quantities[$(this).attr('data-stock-location-id')] = $(this).val();
+        });
+    }
+
+    adjustLineItems(order_number, variant_id, total_quantity, stock_location_quantities);
     return 1
 }
 
-adjustLineItems = function(order_number, variant_id, quantity){
+adjustLineItems = function(order_number, variant_id, quantity, stock_location_quantities){
     var url = Spree.routes.orders_api + "/" + order_number + '/line_items';
 
     $.ajax({
         type: "POST",
         url: Spree.url(url),
-        data: { line_item: {variant_id: variant_id, quantity: quantity }}
+        data: { line_item: {variant_id: variant_id, quantity: quantity,  stock_location_quantities: stock_location_quantities}}
     }).done(function( msg ) {
         window.Spree.advanceOrder();
         window.location.reload();

--- a/backend/app/views/spree/admin/variants/_autocomplete_line_items_stock.js.erb
+++ b/backend/app/views/spree/admin/variants/_autocomplete_line_items_stock.js.erb
@@ -1,46 +1,52 @@
 <script type='text/template' id='variant_line_items_autocomplete_stock_template'>
-  
+
   <label><%= Spree.t(:select_stock) %></label>
 
-  <table class="stock-levels table table-bordered" data-hook="stock-levels">
-    <thead>
-      <th><%= Spree.t(:name) %></th>
-      <th class="text-center"><%= Spree.t(:count_on_hand) %></th>
-      <th class="text-center"><%= Spree.t(:quantity) %></th>
-      <th></th>
-    </thead>
-    <tbody>
-      <tr>
-        <td>{{variant.name}}</td>
-        {{#if variant.track_inventory}}
-          {{#if variant.total_on_hand}}
-            <td class="text-center">{{variant.total_on_hand}}</td>
+  {{#if variant.track_inventory}}
+    <table class="stock-levels table table-bordered" data-hook="stock-levels">
+      <thead>
+        <th><%= Spree.t(:name) %></th>
+        <th class="text-center"><%= Spree.t(:location) %></th>
+        <th class="text-center"><%= Spree.t(:count_on_hand) %></th>
+        <th class="text-center"><%= Spree.t(:quantity) %></th>
+        <th></th>
+      </thead>
+      <tbody>
+        {{#each variant.stock_items}}
+          <tr>
+            <td>{{#unless @index}}{{../../variant.name}}{{/unless}}</td>
+            <td class="text-center">{{stock_location_name}}</td>
+            <td class="text-center">{{count_on_hand}}</td>
             <td class="text-center">
-              <input class="quantity form-control" id="variant_quantity" data-variant-id="{{variant.id}}" type="number" min="1" value="1">
+              <input class="quantity form-control variant_quantity" id="variant_quantity" id="quantity_{{@index}}" data-variant-id="{{../variant.id}}" data-stock-location-id="{{stock_location_id}}" type="number" min="1" value="1">
             </td>
-            <td class="actions actions-1 text-center">
-              <button class="btn btn-sm btn-success add_variant with-tip" data-variant-id="{{variant.id}}" title="<%= Spree.t(:add) %>" data-action="add">
-                <span class="icon icon-add"></span>
-                </button>
-            </td>
-          {{else}}
-            <td class="text-center"><%= Spree.t(:out_of_stock) %></td>
-            <td class="text-center">0</td>
-            <td></td>
-            <td></td>
-          {{/if}}
-        {{else}}
-          <td class="text-center"><%= Spree.t(:doesnt_track_inventory) %></td>
+          </tr>
+        {{/each}}
+      </tbody>
+    </table>
+  {{else}}
+    <table class="stock-levels table table-bordered untracked-inventory" data-hook="stock-levels">
+      <thead>
+        <th><%= Spree.t(:name) %></th>
+        <th class="text-center"><%= Spree.t(:count_on_hand) %></th>
+        <th class="text-center"><%= Spree.t(:quantity) %></th>
+        <th></th>
+      </thead>
+      <tbody>
+        <tr>
+          <td>{{variant.name}}</td>
+          <td class="text-center">No inventory necessary</td>
           <td class="text-center">
             <input class="quantity form-control" id="variant_quantity" data-variant-id="{{variant.id}}" type="number" min="1" value="1">
           </td>
-          <td class="actions actions-1 text-center">
-            <button class="btn btn-sm btn-success add_variant with-tip" data-variant-id="{{variant.id}}" title="<%= Spree.t(:add) %>" data-action="add">
-              <span class="icon icon-add"></span>
-            </button>
-          </td>
-        {{/if}}
-      </tr>
-    </tbody>
-  </table>
+        </tr>
+      </tbody>
+    </table>
+  {{/if}}
+
+  <fieldset class="no-border-bottom">
+    <legend align="center" class="stock-location">
+      <button class="add_variant no-text fa fa-plus icon_link"  title="<%= Spree.t(:add) %>" data-action="add"><%= Spree.t(:add) %></button>
+    </legend>
+  </fieldset>
 </script>

--- a/backend/spec/features/admin/orders/new_order_spec.rb
+++ b/backend/spec/features/admin/orders/new_order_spec.rb
@@ -21,7 +21,12 @@ describe "New Order", :type => :feature do
 
   it "completes new order succesfully without using the cart", js: true do
     select2_search product.name, from: Spree.t(:name_or_sku)
-    click_icon :add
+
+    within("table.stock-levels") do
+      fill_in "quantity_0", with: 2
+    end
+
+    click_icon :plus
     wait_for_ajax
     click_on "Customer"
 
@@ -51,9 +56,11 @@ describe "New Order", :type => :feature do
       select2_search product.name, from: Spree.t(:name_or_sku)
 
       within("table.stock-levels") do
-        fill_in "variant_quantity", with: 2
-        click_icon :add
+        fill_in "quantity_0", with: 2
       end
+
+      click_icon :plus
+      wait_for_ajax
 
       within(".line-items") do
         expect(page).to have_content(product.name)
@@ -85,7 +92,13 @@ describe "New Order", :type => :feature do
 
     it "can still see line items" do
       select2_search product.name, from: Spree.t(:name_or_sku)
-      click_icon :add
+
+      within("table.stock-levels") do
+        fill_in "quantity_0", with: 1
+      end
+
+      click_icon :plus
+      wait_for_ajax
       within(".line-items") do
         within(".line-item-name") do
           expect(page).to have_content(product.name)

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -41,9 +41,11 @@ describe "Order Details", type: :feature, js: true do
       it "can add an item to a shipment" do
         select2_search "spree t-shirt", from: Spree.t(:name_or_sku)
         within("table.stock-levels") do
-          fill_in "variant_quantity", with: 2
-          click_icon :add
+          fill_in "quantity_0", with: 2
         end
+
+        click_icon :plus
+        wait_for_ajax
 
         within("#order_total") do
           expect(page).to have_content("$80.00")
@@ -146,8 +148,10 @@ describe "Order Details", type: :feature, js: true do
           select2_search tote.name, from: Spree.t(:name_or_sku)
           within("table.stock-levels") do
             fill_in "variant_quantity", with: 1
-            click_icon :add
           end
+
+          click_icon :plus
+          wait_for_ajax
 
           within(".line-items") do
             expect(page).to have_content(tote.name)
@@ -165,7 +169,7 @@ describe "Order Details", type: :feature, js: true do
           select2_search product.name, from: Spree.t(:name_or_sku)
 
           within("table.stock-levels") do
-            expect(page).to have_content(Spree.t(:out_of_stock))
+            expect(page).to have_content(0)
           end
         end
       end

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -10,6 +10,9 @@ module Spree
     has_many :adjustments, as: :adjustable, dependent: :destroy
     has_many :inventory_units, inverse_of: :line_item
 
+    has_many :line_item_stock_locations, class_name: "Spree::LineItemStockLocation"
+    has_many :stock_locations, through: :line_item_stock_locations
+
     before_validation :copy_price
     before_validation :copy_tax_category
 

--- a/core/app/models/spree/line_item_stock_location.rb
+++ b/core/app/models/spree/line_item_stock_location.rb
@@ -1,0 +1,6 @@
+module Spree
+  class LineItemStockLocation < ActiveRecord::Base
+    belongs_to :line_item, class_name: "Spree::LineItem"
+    belongs_to :stock_location, class_name: "Spree::StockLocation"
+  end
+end

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -79,6 +79,7 @@ module Spree
           line_item = order.line_items.new(quantity: quantity,
                                             variant: variant,
                                             options: opts)
+          create_line_item_stock_locations(line_item, options[:stock_location_quantities])
         end
         line_item.target_shipment = options[:shipment] if options.has_key? :shipment
         line_item.save!
@@ -107,6 +108,13 @@ module Spree
         end
 
         line_item
+      end
+
+      def create_line_item_stock_locations(line_item, stock_location_quantities)
+        return unless stock_location_quantities.present?
+        stock_location_quantities.each do |stock_location_id, quantity|
+          line_item.line_item_stock_locations.build(stock_location_id: stock_location_id, quantity: quantity) unless quantity.to_i.zero?
+        end
       end
   end
 end

--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -4,6 +4,9 @@ module Spree
     has_many :stock_items, dependent: :delete_all, inverse_of: :stock_location
     has_many :stock_movements, through: :stock_items
 
+    has_many :line_item_stock_locations, class_name: "Spree::LineItemStockLocation"
+    has_many :line_items, through: :line_item_stock_locations
+
     belongs_to :state, class_name: 'Spree::State'
     belongs_to :country, class_name: 'Spree::Country'
 

--- a/core/db/migrate/20150116155245_create_line_item_stock_locations.rb
+++ b/core/db/migrate/20150116155245_create_line_item_stock_locations.rb
@@ -1,0 +1,12 @@
+class CreateLineItemStockLocations < ActiveRecord::Migration
+  def change
+    create_table :spree_line_item_stock_locations do |t|
+      t.integer :line_item_id
+      t.integer :stock_location_id
+      t.integer :quantity
+      t.timestamps
+    end
+
+    add_index :spree_line_item_stock_locations, :line_item_id
+  end
+end

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 describe Spree::OrderContents, :type => :model do
   let(:order) { Spree::Order.create }
   let(:variant) { create(:variant) }
+  let!(:stock_location) { variant.stock_locations.first }
+  let(:stock_location_2) { create(:stock_location) }
 
   subject { described_class.new(order) }
 
@@ -52,6 +54,14 @@ describe Spree::OrderContents, :type => :model do
 
       expect(order.item_total.to_f).to eq(19.99)
       expect(order.total.to_f).to eq(19.99)
+    end
+
+    it "should create stock location associations if provided" do
+      line_item = subject.add(variant, 3, stock_location_quantities: {stock_location.id => 1, stock_location_2.id => 2})
+      line_item_stock_locations = line_item.line_item_stock_locations
+      expect(line_item_stock_locations.count).to eq(2)
+      expect(line_item_stock_locations.map(&:quantity)).to eq ([1, 2])
+      expect(line_item_stock_locations.map(&:stock_location_id)).to eq([stock_location.id, stock_location_2.id])
     end
 
     context "running promotions" do


### PR DESCRIPTION
- Bubble up stock locations (both active and inactive) to make them administrable on a line item level through the admin
  - Admin add to cart view shows a table of all stock locations which you can pull stock from
  - Add association from line item to many stock locations
  - Create associated stock locations when adding a line item through admin
  - StockCoordinator will first look for a line item's stock locations, and if not specified, pull from active stock locations like before.
