### PR TITLE
Revert "HTTP Patch makes direct update_attributes call on Spree::Order"

### DIFF
--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -59,15 +59,7 @@ module Spree
         find_order(true)
         authorize! :update, @order, order_token
 
-        result = if request.patch?
-          # This will update the order without a checkout reset.
-          @order.update_attributes(order_params)
-        else
-          # This will reset checkout back to address and delete all shipments.
-          @order.contents.update_cart(order_params)
-        end
-
-        if result
+        if @order.contents.update_cart(order_params)
           user_id = params[:order][:user_id]
           if current_api_user.has_spree_role?('admin') && user_id
             @order.associate_user!(Spree.user_class.find(user_id))

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -28,28 +28,6 @@ module Spree
       stub_authentication!
     end
 
-    describe 'PATCH #update' do
-      subject { api_patch :update, id: order.to_param, order: { email: "foo@bar.com" } }
-
-      before do
-        allow_any_instance_of(Spree::Order).to receive_messages :user => current_api_user
-      end
-
-      it 'should be ok' do
-        expect(subject).to be_ok
-      end
-
-      it 'should not invoke OrderContents#update_cart' do
-        expect_any_instance_of(Spree::OrderContents).to_not receive(:update_cart)
-        subject
-      end
-
-      it 'should update the email' do
-        subject
-        expect(order.reload.email).to eq('foo@bar.com')
-      end
-    end
-
     it "cannot view all orders" do
       api_get :index
       assert_unauthorized!

--- a/api/spec/support/controller_hacks.rb
+++ b/api/spec/support/controller_hacks.rb
@@ -12,10 +12,6 @@ module ControllerHacks
     api_process(action, params, session, flash, "PUT")
   end
 
-  def api_patch(action, params={}, session=nil, flash=nil)
-    api_process(action, params, session, flash, "PATCH")
-  end
-
   def api_delete(action, params={}, session=nil, flash=nil)
     api_process(action, params, session, flash, "DELETE")
   end


### PR DESCRIPTION
This reverts commit 5860545b329169016acedffea43b9324c3989f11.

We're trying to move things away from direct activerecord updates and toward
defined interfaces (like order.contents) so we don't want to expose
'update_attributes' directly.

Also, this is not really a valid usage of PATCH vs PUT.  Both of these methods
perform partial updates.  One of them just does it in a different way to avoid
a problem in the code.

cc @HoyaBoya @JDutil @jhawthorn @gmacdougall @cbrunsdon

See also Issue #5543 and PR #5544 which were the motivation for this code.

If we really need to keep this functionality I wonder if we should consider
providing a separate endpoint like `PUT /api/order_metadata` which only allows
updating 'safe' attributes like email, special_instructions...I'm struggling
to think of any other attributes like that in stock Spree.  In general it seems
dangerous to be updating parts of an order and trying to sidestep certain
checks, etc.

Or maybe we need to just figure out a better solution for
'ensure_updated_shipments' that doesn't require reverting the state every time.

Thoughts?
