### PR TITLE
JS fix for admin resource destroy success message

### DIFF
--- a/backend/app/views/spree/admin/shared/_destroy.js.erb
+++ b/backend/app/views/spree/admin/shared/_destroy.js.erb
@@ -1,6 +1,6 @@
 <% success = flash.discard(:success)
 if success %>
-  show_flash('success', "<%= success %>")
+  show_flash('success', "<%= j success %>")
 <% end %>
 
 <%= render :partial => '/spree/admin/shared/update_order_state' if @order %>


### PR DESCRIPTION
Out of the box you will never run into a situation where this text needs escaping, however, it is possible that a third party extension will set a success message with quotes (or in the situation I ran into, a missing translation can cause this).

This will cleanly apply to 2-3-stable and 2-4-stable if desired, I haven't tested previous versions but can't imagine any issues.
