### PR TITLE
Order with failed payments

### DIFF
--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -79,7 +79,9 @@ module Spree
                     order.errors.add(:base, Spree.t(:no_payment_found))
                     false
                   elsif order.payment_required?
-                    order.process_payments!.tap { |success| order.handle_failed_payments unless success }
+                    order.process_payments!.tap do |success|
+                      order.handle_failed_payments unless success
+                    end
                   end
                 end
                 after_transition to: :complete, do: :persist_user_credit_card

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -70,12 +70,16 @@ module Spree
               end
 
               if states[:payment]
+                event :payment_failed do
+                  transition to: :payment, from: :confirm
+                end
+
                 before_transition to: :complete do |order|
                   if order.payment_required? && order.payments.valid.empty?
                     order.errors.add(:base, Spree.t(:no_payment_found))
                     false
                   elsif order.payment_required?
-                    order.process_payments!
+                    order.process_payments!.tap { |success| order.handle_failed_payments unless success }
                   end
                 end
                 after_transition to: :complete, do: :persist_user_credit_card
@@ -289,6 +293,12 @@ module Spree
               cc = self.user.default_credit_card
               self.payments.create!(payment_method_id: cc.payment_method_id, source: cc)
             end
+          end
+
+          def handle_failed_payments
+            errors = self.errors[:base]
+            self.payment_failed!
+            errors.each { |error| self.errors.add(:base, error) }
           end
 
           private


### PR DESCRIPTION
If there are multiple payments on an order and the first one fails during checkout, the order does not transition to complete as expected. However, if one tries to complete the order again and the second payment processes properly, the order will complete even though a previous payment had failed.

This prevents an order from completing when a payment fails and puts the order back in the address state.
