### PR TITLE
Payment should remain pending until full amount captured.

### DIFF
--- a/backend/app/views/spree/admin/payments/_list.html.erb
+++ b/backend/app/views/spree/admin/payments/_list.html.erb
@@ -3,7 +3,7 @@
     <tr data-hook="payments_header">
       <th><%= Spree::Payment.human_attribute_name(:number) %></th>
       <th><%= "#{Spree.t('date')}/#{Spree.t('time')}" %></th>
-      <th class="text-center"><%= Spree.t(:amount) %></th>
+      <th class="text-center"><%= Spree.t(:captured_authorized) %></th>
       <th class="text-center"><%= Spree.t(:payment_method) %></th>
       <th class="text-center"><%= Spree.t(:transaction_id) %></th>
       <th class="text-center"><%= Spree.t(:payment_state) %></th>
@@ -15,7 +15,7 @@
       <tr id="<%= dom_id(payment) %>" data-hook="payments_row">
         <td><%= link_to payment.number, spree.admin_order_payment_path(@order, payment) %></td>
         <td><%= pretty_time(payment.created_at) %></td>
-        <td class="amount text-center"><%= payment.display_amount.to_html %></td>
+        <td class="amount text-center"><%= payment.display_captured_amount %> / <%= payment.display_amount.to_html %></td>
         <td class="text-center"><%= payment_method_name(payment) %></td>
         <td class="text-center"><%= payment.transaction_id %></td>
         <td class="text-center">

--- a/backend/app/views/spree/admin/payments/index.html.erb
+++ b/backend/app/views/spree/admin/payments/index.html.erb
@@ -1,9 +1,9 @@
-<%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => "Payments" } %>
+<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: "Payments" } %>
 
 <% content_for :page_actions do %>
   <% if @order.outstanding_balance? %>
     <span id="new_payment_section">
-      <%= button_link_to Spree.t(:new_payment), new_admin_order_payment_url(@order), :class => "btn-success", :icon => 'add' %>
+      <%= button_link_to Spree.t(:new_payment), new_admin_order_payment_url(@order), class: "btn-success", icon: 'add' %>
     </span>
   <% end %>
 <% end %>

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -61,7 +61,7 @@ module Spree
     end
 
     def update_payment_total
-      order.payment_total = payments.completed.sum(:amount)
+      order.payment_total = payments.joins(:capture_events).sum('spree_payment_capture_events.amount')
     end
 
     def update_shipment_total

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -2,7 +2,11 @@ module Spree
   class Payment < Spree::Base
     extend FriendlyId
     friendly_id :number, slug_column: :number, use: :slugged
-    
+
+    extend Spree::DisplayMoney
+    money_methods :amount, :captured_amount, :uncaptured_amount
+    alias :money :display_amount
+
     include Spree::Payment::Processing
     include Spree::NumberGenerator
 
@@ -105,11 +109,6 @@ module Spree
     def currency
       order.currency
     end
-
-    def money
-      Spree::Money.new(amount, { currency: currency })
-    end
-    alias display_amount money
 
     def amount=(amount)
       self[:amount] =

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -164,8 +164,12 @@ module Spree
       return true
     end
 
+    def captured_amount
+      capture_events.sum(:amount)
+    end
+
     def uncaptured_amount
-      amount - capture_events.sum(:amount)
+      amount - captured_amount
     end
 
     private

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -40,7 +40,12 @@ module Spree
 
           money = ::Money.new(amount, currency)
           capture_events.create!(amount: money.to_f)
-          handle_response(response, :complete, :failure)
+
+          if uncaptured_amount > 0
+            handle_response(response, :pend, :failure)
+          else
+            handle_response(response, :complete, :failure)
+          end
         end
       end
 

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -184,7 +184,8 @@ module Spree
       pending_payments =  order.pending_payments
                             .sort_by(&:uncaptured_amount).reverse
 
-      # NOTE Do we really need to force orders to have pending payments on dispatch?
+      # TODO: Do we really need to force orders to have pending payments on dispatch?
+      # No, but need at least a payment with a reuseable source i.e. cc token.
       if pending_payments.empty?
         raise Spree::Core::GatewayError, Spree.t(:no_pending_payments)
       else
@@ -208,9 +209,6 @@ module Spree
           shipment_to_pay -= capturable_amount
         end
       end
-    rescue Spree::Core::GatewayError => e
-      errors.add(:base, e.message)
-      return !!Spree::Config[:allow_checkout_on_gateway_error]
     end
 
     def ready_or_pending?

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -500,6 +500,7 @@ en:
     cannot_set_shipping_method_without_address: Cannot set shipping method until customer details are provided.
     capture: Capture
     capture_events: Capture events
+    captured_authorized: Captured / Authorized
     card_code: Card Code
     card_number: Card Number
     card_type: Brand

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -56,7 +56,7 @@ FactoryGirl.define do
           shipment_state 'ready'
 
           after(:create) do |order|
-            create(:payment, amount: order.total, order: order, state: 'completed')
+            create(:payment_completed, amount: order.total, order: order)
             order.shipments.each do |shipment|
               shipment.inventory_units.update_all state: 'on_hand'
               shipment.update_column('state', 'ready')

--- a/core/lib/spree/testing_support/factories/payment_factory.rb
+++ b/core/lib/spree/testing_support/factories/payment_factory.rb
@@ -6,6 +6,12 @@ FactoryGirl.define do
     order
     state 'checkout'
     response_code '12345'
+
+    factory :payment_completed do
+      after :build do |p|
+        p.capture!(p.amount * 100)
+      end
+    end
   end
 
   factory :check_payment, class: Spree::Payment do

--- a/core/spec/lib/tasks/exchanges_spec.rb
+++ b/core/spec/lib/tasks/exchanges_spec.rb
@@ -39,7 +39,6 @@ describe "exchanges:charge_unreturned_items" do
       it "does not create a new order" do
         expect { subject.invoke }.not_to change { Spree::Order.count }
       end
-
     end
 
     context "more than the config allowed days have passed" do

--- a/core/spec/models/spree/order/state_machine_spec.rb
+++ b/core/spec/models/spree/order/state_machine_spec.rb
@@ -169,6 +169,7 @@ describe Spree::Order, :type => :model do
         allow(payment).to receive(:cancel!)
         allow(order).to receive_message_chain(:payments, :valid, :size).and_return(1)
         allow(order).to receive_message_chain(:payments, :completed).and_return([payment])
+        allow(order).to receive_message_chain(:payments, :joins).and_return([payment])
         allow(order).to receive_message_chain(:payments, :last).and_return(payment)
       end
 
@@ -180,9 +181,9 @@ describe Spree::Order, :type => :model do
 
       context "with shipped items" do
         before do
-          allow(order).to receive_messages :shipment_state => 'partial'
-          allow(order).to receive_messages :outstanding_balance? => false
-          allow(order).to receive_messages :payment_state => "paid"
+          allow(order).to receive_messages shipment_state: 'partial'
+          allow(order).to receive_messages outstanding_balance?: false
+          allow(order).to receive_messages payment_state: "paid"
         end
 
         it "should not alter the payment state" do
@@ -197,6 +198,7 @@ describe Spree::Order, :type => :model do
         it "should automatically refund all payments" do
           allow(order).to receive_message_chain(:payments, :valid, :size).and_return(1)
           allow(order).to receive_message_chain(:payments, :completed).and_return([payment])
+          allow(order).to receive_message_chain(:payments, :joins).and_return([payment])
           allow(order).to receive_message_chain(:payments, :last).and_return(payment)
           expect(payment).to receive(:cancel!)
           order.cancel!
@@ -209,9 +211,9 @@ describe Spree::Order, :type => :model do
   # Another regression test for #729
   context "#resume" do
     before do
-      allow(order).to receive_messages :email => "user@spreecommerce.com"
-      allow(order).to receive_messages :state => "canceled"
-      allow(order).to receive_messages :allow_resume? => true
+      allow(order).to receive_messages email: "user@spreecommerce.com"
+      allow(order).to receive_messages state: "canceled"
+      allow(order).to receive_messages allow_resume?: true
 
       # Stubs method that cause unwanted side effects in this test
       allow(order).to receive :has_available_shipment

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -1,22 +1,27 @@
 require 'spec_helper'
 
 module Spree
-  describe OrderUpdater, :type => :model do
+  describe OrderUpdater, type: :model do
     let(:order) { Spree::Order.create }
     let(:updater) { Spree::OrderUpdater.new(order) }
 
     context "order totals" do
       before do
         2.times do
-          create(:line_item, :order => order, price: 10)
+          create(:line_item, order: order, price: 10)
         end
       end
 
-      it "updates payment totals" do
-        allow(order).to receive_message_chain(:payments, :completed, :sum).and_return(10)
+      it "update payment total should calculate captured amount" do
+        payment = create(:payment)
+        order   = payment.order
+        expect(order.payment_total).to eq(0)
 
+        payment.capture!(500)
+        updater = Spree::OrderUpdater.new(order)
         updater.update_totals
-        expect(order.payment_total).to eq(10)
+
+        expect(order.payment_total).to eq(5)
       end
 
       it "update item total" do
@@ -25,14 +30,14 @@ module Spree
       end
 
       it "update shipment total" do
-        create(:shipment, :order => order, :cost => 10)
+        create(:shipment, order: order, cost: 10)
         updater.update_shipment_total
         expect(order.shipment_total).to eq(10)
       end
 
       context 'with order promotion followed by line item addition' do
-        let(:promotion) { Spree::Promotion.create!(:name => "10% off") }
-        let(:calculator) { Calculator::FlatPercentItemTotal.new(:preferred_flat_percent => 10) }
+        let(:promotion) { Spree::Promotion.create!(name: "10% off") }
+        let(:calculator) { Calculator::FlatPercentItemTotal.new(preferred_flat_percent: 10) }
 
         let(:promotion_action) do
           Promotion::Actions::CreateAdjustment.create!({
@@ -44,7 +49,7 @@ module Spree
         before do
           updater.update
           create(:adjustment, source: promotion_action, adjustable: order, order: order)
-          create(:line_item, :order => order, price: 10) # in addition to the two already created
+          create(:line_item, order: order, price: 10) # in addition to the two already created
           updater.update
         end
 
@@ -57,9 +62,9 @@ module Spree
         # A line item will not have both additional and included tax,
         # so please just humour me for now.
         order.line_items.first.update_columns({
-          :adjustment_total => 10.05,
-          :additional_tax_total => 0.05,
-          :included_tax_total => 0.05,
+          adjustment_total: 10.05,
+          additional_tax_total: 0.05,
+          included_tax_total: 0.05,
         })
         updater.update_adjustment_total
         expect(order.adjustment_total).to eq(10.05)
@@ -70,14 +75,14 @@ module Spree
 
     context "updating shipment state" do
       before do
-        allow(order).to receive_messages :backordered? => false
+        allow(order).to receive_messages backordered?: false
         allow(order).to receive_message_chain(:shipments, :shipped, :count).and_return(0)
         allow(order).to receive_message_chain(:shipments, :ready, :count).and_return(0)
         allow(order).to receive_message_chain(:shipments, :pending, :count).and_return(0)
       end
 
       it "is backordered" do
-        allow(order).to receive_messages :backordered? => true
+        allow(order).to receive_messages backordered?: true
         updater.update_shipment_state
 
         expect(order.shipment_state).to eq('backorder')
@@ -197,12 +202,12 @@ module Spree
     it "state change" do
       order.shipment_state = 'shipped'
       state_changes = double
-      allow(order).to receive_messages :state_changes => state_changes
+      allow(order).to receive_messages state_changes: state_changes
       expect(state_changes).to receive(:create).with(
-        :previous_state => nil,
-        :next_state => 'shipped',
-        :name => 'shipment',
-        :user_id => nil
+        previous_state: nil,
+        next_state: 'shipped',
+        name: 'shipment',
+        user_id: nil
       )
 
       order.state_changed('shipment')
@@ -222,31 +227,31 @@ module Spree
       end
 
       it "updates each shipment" do
-        shipment = stub_model(Spree::Shipment, :order => order)
+        shipment = stub_model(Spree::Shipment, order: order)
         shipments = [shipment]
-        allow(order).to receive_messages :shipments => shipments
-        allow(shipments).to receive_messages :states => []
-        allow(shipments).to receive_messages :ready => []
-        allow(shipments).to receive_messages :pending => []
-        allow(shipments).to receive_messages :shipped => []
+        allow(order).to receive_messages shipments: shipments
+        allow(shipments).to receive_messages states: []
+        allow(shipments).to receive_messages ready: []
+        allow(shipments).to receive_messages pending: []
+        allow(shipments).to receive_messages shipped: []
 
         expect(shipment).to receive(:update!).with(order)
         updater.update_shipments
       end
 
       it "refreshes shipment rates" do
-        shipment = stub_model(Spree::Shipment, :order => order)
+        shipment = stub_model(Spree::Shipment, order: order)
         shipments = [shipment]
-        allow(order).to receive_messages :shipments => shipments
+        allow(order).to receive_messages shipments: shipments
 
         expect(shipment).to receive(:refresh_rates)
         updater.update_shipments
       end
 
       it "updates the shipment amount" do
-        shipment = stub_model(Spree::Shipment, :order => order)
+        shipment = stub_model(Spree::Shipment, order: order)
         shipments = [shipment]
-        allow(order).to receive_messages :shipments => shipments
+        allow(order).to receive_messages shipments: shipments
 
         expect(shipment).to receive(:update_amounts)
         updater.update_shipments
@@ -269,11 +274,11 @@ module Spree
       it "doesnt update each shipment" do
         shipment = stub_model(Spree::Shipment)
         shipments = [shipment]
-        allow(order).to receive_messages :shipments => shipments
-        allow(shipments).to receive_messages :states => []
-        allow(shipments).to receive_messages :ready => []
-        allow(shipments).to receive_messages :pending => []
-        allow(shipments).to receive_messages :shipped => []
+        allow(order).to receive_messages shipments: shipments
+        allow(shipments).to receive_messages states: []
+        allow(shipments).to receive_messages ready: []
+        allow(shipments).to receive_messages pending: []
+        allow(shipments).to receive_messages shipped: []
 
         allow(updater).to receive(:update_totals) # Otherwise this gets called and causes a scene
         expect(updater).not_to receive(:update_shipments).with(order)

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -56,6 +56,21 @@ describe Spree::Payment, :type => :model do
 
   end
 
+  context "#captured_amount" do
+    context "calculates based on capture events" do
+      it "with 0 capture events" do
+        expect(payment.captured_amount).to eq(0)
+      end
+
+      it "with some capture events" do
+        payment.save
+        payment.capture_events.create!(amount: 2.0)
+        payment.capture_events.create!(amount: 3.0)
+        expect(payment.captured_amount).to eq(5)
+      end
+    end
+  end
+
   context '#uncaptured_amount' do
     context "calculates based on capture events" do
       it "with 0 capture events" do
@@ -462,9 +477,9 @@ describe Spree::Payment, :type => :model do
   end
 
   describe "#save" do
-    context "completed payments" do
-      it "updates order payment total" do
-        payment = Spree::Payment.create(:amount => 100, :order => order, state: "completed")
+    context "captured payments" do
+      it "update order payment total" do
+        payment = create(:payment_completed, order: order)
         expect(order.payment_total).to eq payment.amount
       end
     end

--- a/core/spec/models/spree/reimbursement_spec.rb
+++ b/core/spec/models/spree/reimbursement_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Spree::Reimbursement, :type => :model do
+describe Spree::Reimbursement, type: :model do
 
   describe ".before_create" do
     describe "#generate_number" do
@@ -56,7 +56,7 @@ describe Spree::Reimbursement, :type => :model do
     let(:line_items_price)        { BigDecimal.new(10) }
     let(:line_item)               { order.line_items.first }
     let(:inventory_unit)          { line_item.inventory_units.first }
-    let(:payment)                 { build(:payment, amount: payment_amount, order: order, state: 'completed') }
+    let(:payment)                 { build(:payment_completed, amount: payment_amount, order: order) }
     let(:payment_amount)          { order.total }
     let(:customer_return)         { build(:customer_return, return_items: [return_item]) }
     let(:return_item)             { build(:return_item, inventory_unit: inventory_unit) }

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -99,9 +99,12 @@ describe Spree::Shipment, :type => :model do
     end
   end
 
-  it "#item_cost" do
-    shipment = create(:shipment, order: create(:order_with_totals))
-    expect(shipment.item_cost).to eql(10.0)
+  context "#item_cost" do
+    it 'should equal line items final amount with tax' do
+      shipment = create(:shipment, order: create(:order_with_totals))
+      create :tax_adjustment, adjustable: shipment.order.line_items.first, order: shipment.order
+      expect(shipment.item_cost).to eql(11.0)
+    end
   end
 
   it "#discounted_cost" do

--- a/frontend/app/views/spree/orders/edit.html.erb
+++ b/frontend/app/views/spree/orders/edit.html.erb
@@ -21,7 +21,7 @@
 
           <div class="links col-md-6 navbar-form pull-right text-right" data-hook="cart_buttons">
             <div class="form-group">
-            <%= order_form.text_field :coupon_code, :size => 10, :placeholder => Spree.t(:coupon_code), class: "form-control form-control-inline" %></div>
+            <%= order_form.text_field :coupon_code, :size => 12, :placeholder => Spree.t(:coupon_code), class: "form-control form-control-inline" %></div>
             <%= button_tag :class => 'btn btn-primary', :id => 'update-button' do %>
               <%= Spree.t(:update) %>
             <% end %>


### PR DESCRIPTION
It is misleading if your capturing payment on each shipment dispatched to display the payment as complete until the full amount is captured.
