### PR TITLE
bump rabl

### DIFF
--- a/api/spree_api.gemspec
+++ b/api/spree_api.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |gem|
   gem.version       = version
 
   gem.add_dependency 'spree_core', version
-  gem.add_dependency 'rabl', '~> 0.9.4.pre1'
+  gem.add_dependency 'rabl', '~> 0.11.6'
   gem.add_dependency 'versioncake', '~> 2.3.1'
 end


### PR DESCRIPTION
This bumps rabl to 0.11.6. I was experiencing some `lookup_context` errors in my spree application. I hope this helps.

Since Rabl hasn't been bumped in a while, I'm guessing its from failing specs. I'll sit and fix them after CI has finished; if I can.
