### PR TITLE
Order quantity promotion rule (2-4-stable)

### DIFF
--- a/backend/app/views/spree/admin/promotions/rules/_item_quantity.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_item_quantity.html.erb
@@ -1,0 +1,8 @@
+<div class="field alpha four columns">
+  <%= select_tag "#{param_prefix}[preferred_operator_min]", options_for_select(Spree::Promotion::Rules::ItemQuantity::OPERATORS_MIN.map{|o| [Spree.t("item_quantity_rule.operators.#{o}"),o]}, promotion_rule.preferred_operator_min), { class: 'select2 select_item_quantity fullwidth' } %>
+  <%= select_tag "#{param_prefix}[preferred_operator_max]", options_for_select(Spree::Promotion::Rules::ItemQuantity::OPERATORS_MAX.map{|o| [Spree.t("item_quantity_rule.operators.#{o}"),o]}, promotion_rule.preferred_operator_max), { class: 'select2 select_item_quantity fullwidth' } %>
+</div>
+<div class="field omega four columns">
+  <%= text_field_tag "#{param_prefix}[preferred_quantity_min]", promotion_rule.preferred_quantity_min, class: 'fullwidth' %>
+  <%= text_field_tag "#{param_prefix}[preferred_quantity_max]", promotion_rule.preferred_quantity_max, class: 'fullwidth' %>
+</div>

--- a/core/app/models/spree/promotion/rules/item_quantity.rb
+++ b/core/app/models/spree/promotion/rules/item_quantity.rb
@@ -9,9 +9,8 @@ module Spree
         preference :quantity_max, :integer, default: 1000
         preference :operator_max, :string, default: '<'
 
-
         OPERATORS_MIN = ['gt', 'gte']
-        OPERATORS_MAX = ['lt','lte']
+        OPERATORS_MAX = ['lt', 'lte']
 
         def applicable?(promotable)
           promotable.is_a?(Spree::Order)
@@ -46,7 +45,6 @@ module Spree
             eligibility_error_message(:item_quantity_less_than_or_equal, quantity: preferred_quantity_min)
           end
         end
-
       end
     end
   end

--- a/core/app/models/spree/promotion/rules/item_quantity.rb
+++ b/core/app/models/spree/promotion/rules/item_quantity.rb
@@ -1,0 +1,53 @@
+# A rule to apply to an order greater than (or greater than or equal to)
+# a specific quantity of line items
+module Spree
+  class Promotion
+    module Rules
+      class ItemQuantity < PromotionRule
+        preference :quantity_min, :integer, default: 1
+        preference :operator_min, :string, default: '>'
+        preference :quantity_max, :integer, default: 1000
+        preference :operator_max, :string, default: '<'
+
+
+        OPERATORS_MIN = ['gt', 'gte']
+        OPERATORS_MAX = ['lt','lte']
+
+        def applicable?(promotable)
+          promotable.is_a?(Spree::Order)
+        end
+
+        def eligible?(order, options = {})
+          quantity = order.quantity
+
+          lower_limit_condition = quantity.send(preferred_operator_min == 'gte' ? :>= : :>, preferred_quantity_min)
+          upper_limit_condition = quantity.send(preferred_operator_max == 'lte' ? :<= : :<, preferred_quantity_max)
+
+          eligibility_errors.add(:base, ineligible_message_max) unless upper_limit_condition
+          eligibility_errors.add(:base, ineligible_message_min) unless lower_limit_condition
+
+          eligibility_errors.empty?
+        end
+
+        private
+
+        def ineligible_message_max
+          if preferred_operator_max == 'gte'
+            eligibility_error_message(:item_quantity_more_than_or_equal, quantity: preferred_quantity_max)
+          else
+            eligibility_error_message(:item_quantity_more_than, quantity: preferred_quantity_max)
+          end
+        end
+
+        def ineligible_message_min
+          if preferred_operator_min == 'gte'
+            eligibility_error_message(:item_quantity_less_than, quantity: preferred_quantity_min)
+          else
+            eligibility_error_message(:item_quantity_less_than_or_equal, quantity: preferred_quantity_min)
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -663,6 +663,10 @@ en:
         item_total_less_than_or_equal: This coupon code can't be applied to orders less than or equal to %{amount}.
         item_total_more_than: This coupon code can't be applied to orders higher than %{amount}.
         item_total_more_than_or_equal: This coupon code can't be applied to orders higher than or equal to %{amount}.
+        item_quantity_less_than: This coupon code can't be applied to orders with less than %{quantity} items.
+        item_quantity_less_than_or_equal: This coupon code can't be applied to orders with items quantity less than or equal to %{quantity}.
+        item_quantity_more_than: This coupon code can't be applied to orders with items quantity higher than %{quantity}.
+        item_quantity_more_than_or_equal: This coupon code can't be applied to orders with items quantity higher than or equal to %{quantity}.
         limit_once_per_user: This coupon code can only be used once per user.
         missing_product: This coupon code can't be applied because you don't have all of the necessary products in your cart.
         missing_taxon: You need to add a product from all applicable categories before applying this coupon code.
@@ -786,6 +790,12 @@ en:
     item_description: Item Description
     item_total: Item Total
     item_total_rule:
+      operators:
+        gt: greater than
+        gte: greater than or equal to
+        lt: less than
+        lte: less than or equal to
+    item_quantity_rule:
       operators:
         gt: greater than
         gte: greater than or equal to
@@ -1077,6 +1087,9 @@ en:
       item_total:
         description: Order total meets these criteria
         name: Item total
+      item_quantity:
+        description: Order quantity meets these criteria
+        name: Item Quantity
       landing_page:
         description: Customer must have visited the specified page
         name: Landing Page

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -72,6 +72,7 @@ module Spree
       config.after_initialize do
         Rails.application.config.spree.promotions.rules.concat [
           Spree::Promotion::Rules::ItemTotal,
+          Spree::Promotion::Rules::ItemQuantity,
           Spree::Promotion::Rules::Product,
           Spree::Promotion::Rules::User,
           Spree::Promotion::Rules::FirstOrder,

--- a/core/spec/models/spree/promotion/rules/item_quantity_spec.rb
+++ b/core/spec/models/spree/promotion/rules/item_quantity_spec.rb
@@ -1,0 +1,281 @@
+require 'spec_helper'
+
+describe Spree::Promotion::Rules::ItemQuantity, :type => :model do
+  let(:rule) { Spree::Promotion::Rules::ItemQuantity.new }
+  let(:order) { double(:order) }
+
+  before { rule.preferred_quantity_min = 4 }
+  before { rule.preferred_quantity_max = 10 }
+
+  context "preferred operator_min set to gt and preferred operator_max set to lt" do
+    before do
+      rule.preferred_operator_min = 'gt'
+      rule.preferred_operator_max = 'lt'
+    end
+
+    context "and item quantity is lower than prefered maximum quantity" do
+
+      context "and item quantity is higher than prefered minimum quantity" do
+        it "should be eligible" do
+          allow(order).to receive_messages quantity: 5
+          expect(rule).to be_eligible(order)
+        end
+      end
+
+      context "and item number is equal to the prefered minimum number" do
+        before { allow(order).to receive_messages quantity: 4 }
+
+        it "should not be eligible" do
+          expect(rule).to_not be_eligible(order)
+        end
+
+        it "set an error message" do
+          rule.eligible?(order)
+          expect(rule.eligibility_errors.full_messages.first).
+            to eq "This coupon code can't be applied to orders with items quantity less than or equal to 4."
+        end
+      end
+
+      context "and quantity is lower to the prefered minimum quantity" do
+        before { allow(order).to receive_messages quantity: 3 }
+
+        it "should not be eligible" do
+          expect(rule).to_not be_eligible(order)
+        end
+
+        it "set an error message" do
+          rule.eligible?(order)
+          expect(rule.eligibility_errors.full_messages.first).
+            to eq "This coupon code can't be applied to orders with items quantity less than or equal to 4."
+        end
+      end
+    end
+
+    context "and quantity is equal to the prefered maximum quantity" do
+      before { allow(order).to receive_messages quantity: 10 }
+
+      it "should not be eligible" do
+        expect(rule).to_not be_eligible(order)
+      end
+
+      it "set an error message" do
+        rule.eligible?(order)
+        expect(rule.eligibility_errors.full_messages.first).
+          to eq "This coupon code can't be applied to orders with items quantity higher than 10."
+      end
+    end
+
+    context "and quantity is higher than the prefered maximum quantity" do
+      before { allow(order).to receive_messages quantity: 15 }
+
+      it "should not be eligible" do
+        expect(rule).to_not be_eligible(order)
+      end
+
+      it "set an error message" do
+        rule.eligible?(order)
+        expect(rule.eligibility_errors.full_messages.first).
+          to eq "This coupon code can't be applied to orders with items quantity higher than 10."
+      end
+    end
+
+  end
+
+  context "preferred operator set to gt and preferred operator_max set to lte" do
+    before do
+      rule.preferred_operator_min = 'gt'
+      rule.preferred_operator_max = 'lte'
+    end
+
+    context "and quantity is lower than prefered maximum quantity" do
+
+      context "and quantity is higher than prefered minimum quantity" do
+        it "should be eligible" do
+          allow(order).to receive_messages quantity: 6
+          expect(rule).to be_eligible(order)
+        end
+      end
+
+      context "and quantity is equal to the prefered minimum quantity" do
+
+        before { allow(order).to receive_messages quantity: 4 }
+
+        it "should not be eligible" do
+          expect(rule).to_not be_eligible(order)
+        end
+
+        it "set an error message" do
+          rule.eligible?(order)
+          expect(rule.eligibility_errors.full_messages.first).
+            to eq "This coupon code can't be applied to orders with items quantity less than or equal to 4."
+        end
+      end
+
+      context "and quantity is lower to the prefered minimum quantity" do
+        before { allow(order).to receive_messages quantity: 2 }
+
+        it "should not be eligible" do
+          expect(rule).to_not be_eligible(order)
+        end
+
+        it "set an error message" do
+          rule.eligible?(order)
+          expect(rule.eligibility_errors.full_messages.first).
+            to eq "This coupon code can't be applied to orders with items quantity less than or equal to 4."
+        end
+      end
+    end
+
+    context "and quantity is equal to the prefered maximum quantity" do
+      before { allow(order).to receive_messages quantity: 10 }
+
+      it "should not be eligible" do
+        expect(rule).to be_eligible(order)
+      end
+    end
+
+    context "and quantity is higher than the prefered maximum quantity" do
+      before { allow(order).to receive_messages quantity: 15 }
+
+      it "should not be eligible" do
+        expect(rule).to_not be_eligible(order)
+      end
+
+      it "set an error message" do
+        rule.eligible?(order)
+        expect(rule.eligibility_errors.full_messages.first).
+          to eq "This coupon code can't be applied to orders with items quantity higher than 10."
+      end
+    end
+  end
+
+  context "preferred operator set to gte and preferred operator_max set to lt" do
+    before do
+      rule.preferred_operator_min = 'gte'
+      rule.preferred_operator_max = 'lt'
+    end
+
+    context "and quantity is lower than prefered maximum quantity" do
+
+      context "and quantity is higher than prefered minimum quantity" do
+        it "should be eligible" do
+          allow(order).to receive_messages quantity: 6
+          expect(rule).to be_eligible(order)
+        end
+      end
+
+      context "and quantity is equal to the prefered minimum quantity" do
+
+        before { allow(order).to receive_messages quantity: 4 }
+
+        it "should not be eligible" do
+          expect(rule).to be_eligible(order)
+        end
+      end
+
+      context "and quantity is lower to the prefered minimum quantity" do
+        before { allow(order).to receive_messages quantity: 3 }
+
+        it "should not be eligible" do
+          expect(rule).to_not be_eligible(order)
+        end
+
+        it "set an error message" do
+          rule.eligible?(order)
+          expect(rule.eligibility_errors.full_messages.first).
+            to eq "This coupon code can't be applied to orders with less than 4 items."
+        end
+      end
+    end
+
+    context "and quantity is equal to the prefered maximum quantity" do
+      before { allow(order).to receive_messages quantity: 10 }
+
+      it "should not be eligible" do
+        expect(rule).to_not be_eligible(order)
+      end
+
+      it "set an error message" do
+        rule.eligible?(order)
+        expect(rule.eligibility_errors.full_messages.first).
+          to eq "This coupon code can't be applied to orders with items quantity higher than 10."
+      end
+    end
+
+    context "and quantity is higher than the prefered maximum quantity" do
+      before { allow(order).to receive_messages quantity: 15 }
+
+      it "should not be eligible" do
+        expect(rule).to_not be_eligible(order)
+      end
+
+      it "set an error message" do
+        rule.eligible?(order)
+        expect(rule.eligibility_errors.full_messages.first).
+          to eq "This coupon code can't be applied to orders with items quantity higher than 10."
+      end
+    end
+
+  end
+
+  context "preferred operator set to gte and preferred operator_max set to lte" do
+    before do
+      rule.preferred_operator_min = 'gte'
+      rule.preferred_operator_max = 'lte'
+    end
+
+    context "and quantity is lower than prefered maximum quantity" do
+      context "and quantity is higher than prefered minimum quantity" do
+        it "should be eligible" do
+          allow(order).to receive_messages quantity: 6
+          expect(rule).to be_eligible(order)
+        end
+      end
+
+      context "and quantity is equal to the prefered minimum quantity" do
+
+        before { allow(order).to receive_messages quantity: 4 }
+
+        it "should not be eligible" do
+          expect(rule).to be_eligible(order)
+        end
+      end
+
+      context "and quantity is lower to the prefered minimum quantity" do
+        before { allow(order).to receive_messages quantity: 2 }
+
+        it "should not be eligible" do
+          expect(rule).to_not be_eligible(order)
+        end
+
+        it "set an error message" do
+          rule.eligible?(order)
+          expect(rule.eligibility_errors.full_messages.first).
+            to eq "This coupon code can't be applied to orders with less than 4 items."
+        end
+      end
+    end
+
+    context "and quantity is equal to the prefered maximum quantity" do
+      before { allow(order).to receive_messages quantity: 10 }
+
+      it "should not be eligible" do
+        expect(rule).to be_eligible(order)
+      end
+    end
+
+    context "and quantity is higher than the prefered maximum quantity" do
+      before { allow(order).to receive_messages quantity: 15 }
+
+      it "should not be eligible" do
+        expect(rule).to_not be_eligible(order)
+      end
+
+      it "set an error message" do
+        rule.eligible?(order)
+        expect(rule.eligibility_errors.full_messages.first).
+          to eq "This coupon code can't be applied to orders with items quantity higher than 10."
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/promotion/rules/item_quantity_spec.rb
+++ b/core/spec/models/spree/promotion/rules/item_quantity_spec.rb
@@ -129,7 +129,7 @@ describe Spree::Promotion::Rules::ItemQuantity, :type => :model do
     context "and quantity is equal to the prefered maximum quantity" do
       before { allow(order).to receive_messages quantity: 10 }
 
-      it "should not be eligible" do
+      it "should be eligible" do
         expect(rule).to be_eligible(order)
       end
     end
@@ -168,7 +168,7 @@ describe Spree::Promotion::Rules::ItemQuantity, :type => :model do
 
         before { allow(order).to receive_messages quantity: 4 }
 
-        it "should not be eligible" do
+        it "should be eligible" do
           expect(rule).to be_eligible(order)
         end
       end
@@ -236,7 +236,7 @@ describe Spree::Promotion::Rules::ItemQuantity, :type => :model do
 
         before { allow(order).to receive_messages quantity: 4 }
 
-        it "should not be eligible" do
+        it "should be eligible" do
           expect(rule).to be_eligible(order)
         end
       end
@@ -259,7 +259,7 @@ describe Spree::Promotion::Rules::ItemQuantity, :type => :model do
     context "and quantity is equal to the prefered maximum quantity" do
       before { allow(order).to receive_messages quantity: 10 }
 
-      it "should not be eligible" do
+      it "should be eligible" do
         expect(rule).to be_eligible(order)
       end
     end

--- a/core/spec/models/spree/promotion/rules/item_total_spec.rb
+++ b/core/spec/models/spree/promotion/rules/item_total_spec.rb
@@ -130,7 +130,7 @@ describe Spree::Promotion::Rules::ItemTotal, :type => :model do
     context "and item total is equal to the prefered maximum amount" do
       before { allow(order).to receive_messages item_total: 60 }
 
-      it "should not be eligible" do
+      it "should be eligible" do
         expect(rule).to be_eligible(order)
       end
     end
@@ -169,7 +169,7 @@ describe Spree::Promotion::Rules::ItemTotal, :type => :model do
 
         before { allow(order).to receive_messages item_total: 50 }
 
-        it "should not be eligible" do
+        it "should be eligible" do
           expect(rule).to be_eligible(order)
         end
       end
@@ -237,7 +237,7 @@ describe Spree::Promotion::Rules::ItemTotal, :type => :model do
 
         before { allow(order).to receive_messages item_total: 50 }
 
-        it "should not be eligible" do
+        it "should be eligible" do
           expect(rule).to be_eligible(order)
         end
       end
@@ -260,7 +260,7 @@ describe Spree::Promotion::Rules::ItemTotal, :type => :model do
     context "and item total is equal to the prefered maximum amount" do
       before { allow(order).to receive_messages item_total: 60 }
 
-      it "should not be eligible" do
+      it "should be eligible" do
         expect(rule).to be_eligible(order)
       end
     end


### PR DESCRIPTION
This is the same of https://github.com/spree/spree/pull/5957 but for 2-4-stable, the only thing that changed is the rule view.
