### PR TITLE
Kill Spree::Configuration. This isn't Spree::Config.

### DIFF
--- a/core/app/models/spree/configuration.rb
+++ b/core/app/models/spree/configuration.rb
@@ -1,5 +1,0 @@
-module Spree
-  class Configuration < Spree::Base
-
-  end
-end

--- a/core/lib/spree/testing_support/factories/configuration_factory.rb
+++ b/core/lib/spree/testing_support/factories/configuration_factory.rb
@@ -1,6 +1,0 @@
-FactoryGirl.define do
-  factory :configuration, class: Spree::Configuration do
-    name 'Default Configuration'
-    type 'app_configuration'
-  end
-end

--- a/core/spec/models/spree/configuration_spec.rb
+++ b/core/spec/models/spree/configuration_spec.rb
@@ -1,5 +1,0 @@
-require 'spec_helper'
-
-describe Spree::Configuration, :type => :model do
-
-end


### PR DESCRIPTION
This is actually a thing that isn't Spree::Config. I would remove the
table entirely but I think its better to not do that in case someone is
using the table for other reasons and would rather remove it in a future
version.
