### PR TITLE
Remove environment form Spree::Tracker

### DIFF
--- a/backend/app/helpers/spree/admin/base_helper.rb
+++ b/backend/app/helpers/spree/admin/base_helper.rb
@@ -135,12 +135,6 @@ module Spree
         dom_id(record, 'spree')
       end
 
-      def rails_environments
-        @@rails_environments ||= Dir.glob("#{Rails.root}/config/environments/*.rb")
-                                    .map { |f| File.basename(f, ".rb") }
-                                    .sort
-      end
-
       private
         def attribute_name_for(field_name)
           field_name.gsub(' ', '_').downcase

--- a/backend/app/views/spree/admin/trackers/_form.html.erb
+++ b/backend/app/views/spree/admin/trackers/_form.html.erb
@@ -6,12 +6,6 @@
     </div>
   </div>
   <div class="col-md-4">
-    <div data-hook="environment" class="form-group">
-      <%= label_tag nil, Spree.t(:environment) %>
-      <%= collection_select(:tracker, :environment, rails_environments, :to_s, :titleize, {}, {:id => 'tracker-env', :class => 'select2'}) %>
-    </div>
-  </div>
-  <div class="col-md-4">
     <div data-hook="active" class="form-group">
       <%= label_tag nil, Spree.t(:active) %>
       <div class="radio">

--- a/backend/app/views/spree/admin/trackers/index.html.erb
+++ b/backend/app/views/spree/admin/trackers/index.html.erb
@@ -17,7 +17,6 @@
     <thead>
       <tr data-hook="admin_trackers_index_headers">
         <th><%= Spree.t(:google_analytics_id) %></th>
-        <th><%= Spree.t(:environment) %></th>
         <th class="text-center"><%= Spree.t(:active) %></th>
         <th class="actions"></th>
       </tr>
@@ -26,7 +25,6 @@
       <% @trackers.each do |tracker|%>
         <tr id="<%= spree_dom_id tracker %>" data-hook="admin_trackers_index_rows">
           <td><%= tracker.analytics_id %></td>
-          <td><%= tracker.environment.to_s.titleize %></td>
           <td class="text-center"><%= tracker.active ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>
           <td class="actions text-right">
             <%= link_to_edit tracker, :no_text => true %>

--- a/backend/spec/helpers/admin/base_helper_spec.rb
+++ b/backend/spec/helpers/admin/base_helper_spec.rb
@@ -15,10 +15,4 @@ describe Spree::Admin::BaseHelper, :type => :helper do
     end
   end
 
-  context "rails environments" do
-    it "returns the existing environments" do
-      expect(rails_environments).to eql ["development","production", "test"]
-    end
-  end
-
 end

--- a/core/app/models/spree/tracker.rb
+++ b/core/app/models/spree/tracker.rb
@@ -1,7 +1,7 @@
 module Spree
   class Tracker < Spree::Base
     def self.current
-      tracker = where(active: true, environment: Rails.env).first
+      tracker = where(active: true).first
       tracker.analytics_id.present? ? tracker : nil if tracker
     end
   end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -645,7 +645,6 @@ en:
     enable_mail_delivery: Enable Mail Delivery
     end: End
     ending_in: Ending in
-    environment: Environment
     error: error
     errors:
       messages:

--- a/core/db/migrate/20150128032538_remove_environment_from_tracker.rb
+++ b/core/db/migrate/20150128032538_remove_environment_from_tracker.rb
@@ -1,0 +1,6 @@
+class RemoveEnvironmentFromTracker < ActiveRecord::Migration
+  def up
+    Spree::Tracker.where('environment != ?', Rails.env).update_all(active: false)
+    remove_column :spree_trackers, :environment
+  end
+end

--- a/core/lib/spree/testing_support/factories/tracker_factory.rb
+++ b/core/lib/spree/testing_support/factories/tracker_factory.rb
@@ -1,6 +1,5 @@
 FactoryGirl.define do
   factory :tracker, class: Spree::Tracker do
-    environment { Rails.env }
     analytics_id 'A100'
     active true
   end

--- a/core/spec/models/spree/tracker_spec.rb
+++ b/core/spec/models/spree/tracker_spec.rb
@@ -4,7 +4,7 @@ describe Spree::Tracker, :type => :model do
   describe "current" do
     before(:each) { @tracker = create(:tracker) }
 
-    it "returns the first active tracker for the environment" do
+    it "returns the first active tracker" do
       expect(Spree::Tracker.current).to eq(@tracker)
     end
 


### PR DESCRIPTION
Much like Spree::PaymentMethod's environment was killed #5822, this
removes the environment setttings from the tracker. Its a poor
anti-feature that we've decided to kill.
