### PR TITLE
Update to paranoia 2.1.x

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -363,10 +363,10 @@ module Spree
     end
 
     ##
-    # Check to see if any line item variants are soft, deleted.
+    # Check to see if any line item variants are soft deleted.
     # If so add error and restart checkout.
     def ensure_line_item_variants_are_not_deleted
-      if line_items.select{ |li| li.variant.destroyed? }.present?
+      if line_items.any?{ |li| !li.variant || li.variant.paranoia_destroyed? }
         errors.add(:base, Spree.t(:deleted_variants_present))
         restart_checkout_flow
         false

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'kaminari', '~> 0.15', '>= 0.15.1'
   s.add_dependency 'monetize', '~> 1.1'
   s.add_dependency 'paperclip', '~> 4.2.0'
-  s.add_dependency 'paranoia', '~> 2.0'
+  s.add_dependency 'paranoia', '~> 2.1.0'
   s.add_dependency 'premailer-rails'
   s.add_dependency 'rails', '~> 4.1.8'
   s.add_dependency 'ransack', '~> 1.4.1'


### PR DESCRIPTION
Fixes compatibility with paranoia 2.1.0 where `AR::Base#destroyed?` is no longer overridden.

Previous version restriction on paranoia was probably too loose. It now restricts to 2.1.x
