### PR TITLE
Remove preferences related to money formatting

### DIFF
--- a/api/app/views/spree/api/config/money.v1.rabl
+++ b/api/app/views/spree/api/config/money.v1.rabl
@@ -1,6 +1,2 @@
 object false
 node(:symbol) { ::Money.new(1, Spree::Config[:currency]).symbol }
-node(:symbol_position) { Spree::Config[:currency_symbol_position] }
-node(:no_cents) { Spree::Config[:hide_cents] }
-node(:decimal_mark) { Spree::Config[:currency_decimal_mark] }
-node(:thousands_separator) { Spree::Config[:currency_thousands_separator] }

--- a/api/spec/controllers/spree/api/config_controller_spec.rb
+++ b/api/spec/controllers/spree/api/config_controller_spec.rb
@@ -12,10 +12,6 @@ module Spree
       api_get :money
       expect(response).to be_success
       expect(json_response["symbol"]).to eq("$")
-      expect(json_response["symbol_position"]).to eq("before")
-      expect(json_response["no_cents"]).to eq(false)
-      expect(json_response["decimal_mark"]).to eq(".")
-      expect(json_response["thousands_separator"]).to eq(",")
     end
 
     it "returns some configuration settings" do

--- a/backend/app/controllers/spree/admin/general_settings_controller.rb
+++ b/backend/app/controllers/spree/admin/general_settings_controller.rb
@@ -7,7 +7,6 @@ module Spree
 
       def edit
         @preferences_security = [:check_for_spree_alerts]
-        @preferences_currency = [:display_currency, :hide_cents]
       end
 
       def update

--- a/backend/app/views/spree/admin/general_settings/edit.html.erb
+++ b/backend/app/views/spree/admin/general_settings/edit.html.erb
@@ -115,41 +115,9 @@
             </div>
 
             <div class="panel-body">
-              <% @preferences_currency.each do |key|
-                  type = Spree::Config.preference_type(key) %>
-                  <div class="checkbox">
-                    <%= label_tag key do %>
-                      <%= preference_field_tag(key, Spree::Config[key], :type => type) %>
-                      <%= Spree.t(key) %>
-                    <% end %>
-                  </div>
-              <% end %>
               <div class="form-group">
                 <%= label_tag :currency, Spree.t(:choose_currency) %>
                 <%= select_tag :currency, currency_options %>
-              </div>
-              <div class="form-group">
-                <label><%= Spree.t(:currency_symbol_position) %></label>
-                <div class="radio">
-                  <%= label_tag :currency_symbol_position_before do %>
-                    <%= radio_button_tag :currency_symbol_position, "before", Spree::Config[:currency_symbol_position] == "before" %>
-                    <%= Spree::Money.new(10, :symbol_position => "before") %>
-                  <% end %>
-                </div>
-                <div class="radio">
-                  <%= label_tag :currency_symbol_position_after do %>
-                    <%= radio_button_tag :currency_symbol_position, "after", Spree::Config[:currency_symbol_position] == "after" %>
-                    <%= Spree::Money.new(10, :symbol_position => "after") %>
-                  <% end %>
-                </div>
-              </div>
-              <div class="form-group">
-                <%= label_tag :currency_decimal_mark, Spree.t(:currency_decimal_mark) %>
-                <%= text_field_tag :currency_decimal_mark, Spree::Config[:currency_decimal_mark], :size => 3, :class => 'form-control' %>
-              </div>
-              <div class="form-group">
-                <%= label_tag :currency_thousands_separator, Spree.t(:currency_thousands_separator) %>
-                <%= text_field_tag :currency_thousands_separator, Spree::Config[:currency_thousands_separator], :size => 3, :class => 'form-control' %>
               </div>
             </div>
           </div>

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -59,7 +59,7 @@ describe "Products", type: :feature do
           context "uses руб as the currency symbol" do
             it "on the products listing page" do
               visit spree.admin_products_path
-              within_row(1) { expect(page).to have_content("₽19.99") }
+              within_row(1) { expect(page).to have_content("19.99 ₽") }
             end
           end
         end

--- a/backend/spec/features/admin/products/variant_spec.rb
+++ b/backend/spec/features/admin/products/variant_spec.rb
@@ -41,7 +41,7 @@ describe "Variants", type: :feature, js: true do
         context "uses руб as the currency symbol" do
           it "on the products listing page" do
             visit spree.admin_product_variants_path(product)
-            within_row(1) { expect(page).to have_content("₽19.99") }
+            within_row(1) { expect(page).to have_content("19.99 ₽") }
           end
         end
       end

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -35,16 +35,10 @@ module Spree
     preference :checkout_zone, :string, default: nil # replace with the name of a zone if you would like to limit the countries
     preference :company, :boolean, default: false # Request company field for billing and shipping addr
     preference :currency, :string, default: "USD"
-    preference :currency_decimal_mark, :string, default: "."
-    preference :currency_symbol_position, :string, default: "before"
-    preference :currency_sign_before_symbol, :boolean, default: true
-    preference :currency_thousands_separator, :string, default: ","
-    preference :display_currency, :boolean, default: false
     preference :default_country_id, :integer
     preference :dismissed_spree_alerts, :string, default: ''
     preference :expedited_exchanges, :boolean, default: false # NOTE this requires payment profiles to be supported on your gateway of choice as well as a delayed job handler to be configured with activejob. kicks off an exchange shipment upon return authorization save. charge customer if they do not return items within timely manner.
     preference :expedited_exchanges_days_window, :integer, default: 14 # the amount of days the customer has to return their item after the expedited exchange is shipped in order to avoid being charged
-    preference :hide_cents, :boolean, default: false
     preference :last_check_for_spree_alerts, :string, default: nil
     preference :layout, :string, default: 'spree/layouts/spree_application'
     preference :logo, :string, default: 'logo/spree_50.png'

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -572,10 +572,7 @@ en:
     credit_cards: Credit Cards
     credit_owed: Credit Owed
     currency: Currency
-    currency_decimal_mark: Currency decimal mark
     currency_settings: Currency Settings
-    currency_symbol_position: Put currency symbol before or after dollar amount?
-    currency_thousands_separator: Currency thousands separator
     current: Current
     current_promotion_usage: ! 'Current Usage: %{count}'
     customer: Customer
@@ -618,7 +615,6 @@ en:
     discount_amount: Discount Amount
     dismiss_banner: No. Thanks! I'm not interested, do not display this message again
     display: Display
-    display_currency: Display currency
     doesnt_track_inventory: It doesnt track inventory
     edit: Edit
     editing_resource: 'Editing %{resource}'
@@ -704,7 +700,6 @@ en:
     guest_user_account: Checkout as a Guest
     has_no_shipped_units: has no shipped units
     height: Height
-    hide_cents: Hide cents
     home: Home
     i18n:
       available_locales: Available Locales

--- a/core/lib/spree/money.rb
+++ b/core/lib/spree/money.rb
@@ -4,22 +4,22 @@ require 'money'
 
 module Spree
   class Money
+    class <<self
+      attr_accessor :default_formatting_rules
+    end
+    self.default_formatting_rules = {
+      # Ruby money currently has this as false, which is wrong for the vast
+      # majority of locales.
+      sign_before_symbol: true
+    }
+
     attr_reader :money
 
     delegate :cents, to: :money
 
     def initialize(amount, options={})
       @money = Monetize.parse([amount, (options[:currency] || Spree::Config[:currency])].join)
-      @options = {}
-      @options[:with_currency] = Spree::Config[:display_currency]
-      @options[:symbol_position] = Spree::Config[:currency_symbol_position].to_sym
-      @options[:no_cents] = Spree::Config[:hide_cents]
-      @options[:decimal_mark] = Spree::Config[:currency_decimal_mark]
-      @options[:thousands_separator] = Spree::Config[:currency_thousands_separator]
-      @options[:sign_before_symbol] = Spree::Config[:currency_sign_before_symbol]
-      @options.merge!(options)
-      # Must be a symbol because the Money gem doesn't do the conversion
-      @options[:symbol_position] = @options[:symbol_position].to_sym
+      @options = Spree::Money.default_formatting_rules.merge(options)
     end
 
     def to_s

--- a/core/spec/lib/spree/money_spec.rb
+++ b/core/spec/lib/spree/money_spec.rb
@@ -5,8 +5,6 @@ describe Spree::Money do
   before do
     configure_spree_preferences do |config|
       config.currency = "USD"
-      config.currency_symbol_position = :before
-      config.display_currency = false
     end
   end
 
@@ -25,23 +23,15 @@ describe Spree::Money do
       money = Spree::Money.new(10, :with_currency => true, :html => false)
       expect(money.to_s).to eq("$10.00 USD")
     end
-
-    it "config option" do
-      Spree::Config[:display_currency] = true
-      money = Spree::Money.new(10, :html => false)
-      expect(money.to_s).to eq("$10.00 USD")
-    end
   end
 
   context "hide cents" do
     it "hides cents suffix" do
-      Spree::Config[:hide_cents] = true
-      money = Spree::Money.new(10)
+      money = Spree::Money.new(10, no_cents: true)
       expect(money.to_s).to eq("$10")
     end
 
     it "shows cents suffix" do
-      Spree::Config[:hide_cents] = false
       money = Spree::Money.new(10)
       expect(money.to_s).to eq("$10.00")
     end
@@ -75,8 +65,7 @@ describe Spree::Money do
     end
 
     it "config option" do
-      Spree::Config[:currency_symbol_position] = :after
-      money = Spree::Money.new(10, :html => false)
+      money = Spree::Money.new(10, symbol_position: :after, html: false)
       expect(money.to_s).to eq("10.00 $")
     end
   end
@@ -91,20 +80,12 @@ describe Spree::Money do
       money = Spree::Money.new(-10, :sign_before_symbol => false)
       expect(money.to_s).to eq("$-10.00")
     end
-
-    it "config option" do
-      Spree::Config[:currency_sign_before_symbol] = false
-      money = Spree::Money.new(-10)
-      expect(money.to_s).to eq("$-10.00")
-    end
   end
 
   context "JPY" do
     before do
       configure_spree_preferences do |config|
         config.currency = "JPY"
-        config.currency_symbol_position = :before
-        config.display_currency = false
       end
     end
 
@@ -118,40 +99,23 @@ describe Spree::Money do
     before do
       configure_spree_preferences do |config|
         config.currency = "EUR"
-        config.currency_symbol_position = :after
-        config.display_currency = false
       end
     end
 
     # Regression test for #2634
     it "formats as plain by default" do
-      money = Spree::Money.new(10)
+      money = Spree::Money.new(10, symbol_position: :after)
       expect(money.to_s).to eq("10.00 €")
     end
 
-    # Regression test for #2632
-    it "acknowledges decimal mark option" do
-      Spree::Config[:currency_decimal_mark] = ","
-      money = Spree::Money.new(10)
-      expect(money.to_s).to eq("10,00 €")
-    end
-
-    # Regression test for #2632
-    it "acknowledges thousands separator option" do
-      Spree::Config[:currency_thousands_separator] = "."
-      money = Spree::Money.new(1000)
-      expect(money.to_s).to eq("1.000.00 €")
-    end
-
     it "formats as HTML if asked (nicely) to" do
-      money = Spree::Money.new(10)
+      money = Spree::Money.new(10, symbol_position: :after)
       # The HTML'ified version of "10.00 €"
       expect(money.to_html).to eq("10.00&nbsp;&#x20AC;")
     end
 
     it "formats as HTML with currency" do
-      Spree::Config[:display_currency] = true
-      money = Spree::Money.new(10)
+      money = Spree::Money.new(10, symbol_position: :after, with_currency: true)
       # The HTML'ified version of "10.00 €"
       expect(money.to_html).to eq("10.00&nbsp;&#x20AC; <span class=\"currency\">EUR</span>")
     end

--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -111,20 +111,8 @@ describe Spree::Adjustment, :type => :model do
   context "#display_amount" do
     before { adjustment.amount = 10.55 }
 
-    context "with display_currency set to true" do
-      before { Spree::Config[:display_currency] = true }
-
-      it "shows the currency" do
-        expect(adjustment.display_amount.to_s).to eq "$10.55 USD"
-      end
-    end
-
-    context "with display_currency set to false" do
-      before { Spree::Config[:display_currency] = false }
-
-      it "does not include the currency" do
-        expect(adjustment.display_amount.to_s).to eq "$10.55"
-      end
+    it "shows the amount" do
+      expect(adjustment.display_amount.to_s).to eq "$10.55"
     end
 
     context "with currency set to JPY" do

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -115,20 +115,8 @@ describe Spree::Product, :type => :model do
     context "#display_price" do
       before { product.price = 10.55 }
 
-      context "with display_currency set to true" do
-        before { Spree::Config[:display_currency] = true }
-
-        it "shows the currency" do
-          expect(product.display_price.to_s).to eq("$10.55 USD")
-        end
-      end
-
-      context "with display_currency set to false" do
-        before { Spree::Config[:display_currency] = false }
-
-        it "does not include the currency" do
-          expect(product.display_price.to_s).to eq("$10.55")
-        end
+      it "shows the amount" do
+        expect(product.display_price.to_s).to eq("$10.55")
       end
 
       context "with currency set to JPY" do

--- a/frontend/spec/features/products_spec.rb
+++ b/frontend/spec/features/products_spec.rb
@@ -80,7 +80,7 @@ describe "Visiting Products", type: :feature, inaccessible: true do
         visit spree.root_path
         within("#product_#{product.id}") do
           within(".price") do
-            expect(page).to have_content("₽19.99")
+            expect(page).to have_content("19.99 ₽")
           end
         end
       end
@@ -88,7 +88,7 @@ describe "Visiting Products", type: :feature, inaccessible: true do
       it "on product page" do
         visit spree.product_path(product)
         within(".price") do
-          expect(page).to have_content("₽19.99")
+          expect(page).to have_content("19.99 ₽")
         end
       end
 
@@ -97,7 +97,7 @@ describe "Visiting Products", type: :feature, inaccessible: true do
         click_button "Add To Cart"
         click_link "Home"
         within(".cart-info") do
-          expect(page).to have_content("₽19.99")
+          expect(page).to have_content("19.99 ₽")
         end
       end
 
@@ -108,7 +108,7 @@ describe "Visiting Products", type: :feature, inaccessible: true do
         fill_in "order_email", with: "test@example.com"
         click_button 'Continue'
         within("tr[data-hook=item_total]") do
-          expect(page).to have_content("₽19.99")
+          expect(page).to have_content("19.99 ₽")
         end
       end
     end
@@ -127,7 +127,6 @@ describe "Visiting Products", type: :feature, inaccessible: true do
     let!(:variant) { product.variants.create!(:price => 5.59) }
 
     before do
-      Spree::Config[:display_currency] = true
       # Need to have two images to trigger the error
       image = File.open(File.expand_path('../../fixtures/thinking-cat.jpg', __FILE__))
       product.images.create!(:attachment => image)
@@ -155,15 +154,6 @@ describe "Visiting Products", type: :feature, inaccessible: true do
       click_link product.name
       within("#product-price") do
         expect(page).not_to have_content Spree.t(:out_of_stock)
-      end
-    end
-
-    # Regression test for #4342
-    it "does not fail when display_currency is true" do
-      Spree::Config[:display_currency] = true
-      click_link product.name
-      within("#cart-form") do
-        find('input[type=radio]')
       end
     end
   end

--- a/guides/content/developer/core/preferences.md
+++ b/guides/content/developer/core/preferences.md
@@ -380,14 +380,6 @@ Determines whether or not a field for "Company" displays on the checkout pages f
 
 The three-letter currency code for the currency that prices will be displayed in. Defaults to "USD".
 
-`currency_symbol_position`
-
-The position of the symbol for a currency. Can be either `before` or `after`. Defaults to `before`.
-
-`display_currency`
-
-Determines whether or not a currency is displayed with a price. Defaults to `false`.
-
 `default_country_id`
 
 The default country's id. Defaults to 214, as this is the id for the United States within the seed data.


### PR DESCRIPTION
I want these removed for a few reasons: Money has built-in defaults per-currency for formatting, the existing preferences override these which is bad for a multi-currency store. This also provides worse default for any non-USD stores for the same reasons. This also causes 6 preference lookups, and thus cache lookups, for each instantiation of a Spree::Money object.

RubyMoney does most of this better by default:
- The decimal mark and thousands separator are taken from i18n, allowing multilingual sites to now format their moneys correctly.
- symbol_first is configured by RubyMoney per-currency, this allows
  multi-currency sites to now correctly format their currencies. This is also better for new single currency sites, as there is no longer a need to configure this.

sign_before_symbol was the one exception, where our default was different (I would argue better) than the RubyMoney team's. So I have added Spree::Money.default_formatting_rules, which is analogous to Money..default_formatting_rules which has a default of {sign_before_symbol: true}.

This Spree::Money.default_formatting_rules can also be used in place of the existing preference values.
