### PR TITLE
Partial payment capturing splits remaining payment amount into new recor...

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_labels.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_labels.scss
@@ -1,6 +1,7 @@
 // Green
 .label-completed,
 .label-complete,
+.label-considered_safe,
 .label-paid,
 .label-shipped,
 .label-ready,
@@ -9,7 +10,7 @@
 .label-sold
 {
   background-color: $brand-success;
-  
+
   a {
     color: white !important;
   }
@@ -38,15 +39,11 @@
 .label-canceled,
 .label-void,
 .label-inactive,
-.label-notice {
+.label-notice,
+.label-partial {
   background-color: $brand-warning;
 
   a {
     color: white !important;
   }
-}
-
-// Grey
-.label-considered_safe {
-  background-color: #777;
 }

--- a/backend/app/views/spree/admin/payments/_list.html.erb
+++ b/backend/app/views/spree/admin/payments/_list.html.erb
@@ -15,7 +15,7 @@
       <tr id="<%= dom_id(payment) %>" data-hook="payments_row">
         <td><%= link_to payment.number, spree.admin_order_payment_path(@order, payment) %></td>
         <td><%= pretty_time(payment.created_at) %></td>
-        <td class="amount text-center"><%= payment.display_amount.to_html %></td>
+        <td class="amount text-center"><%= payment.display_amount %></td>
         <td class="text-center"><%= payment_method_name(payment) %></td>
         <td class="text-center"><%= payment.transaction_id %></td>
         <td class="text-center">

--- a/backend/app/views/spree/admin/payments/index.html.erb
+++ b/backend/app/views/spree/admin/payments/index.html.erb
@@ -1,9 +1,9 @@
-<%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => "Payments" } %>
+<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: "Payments" } %>
 
 <% content_for :page_actions do %>
   <% if @order.outstanding_balance? %>
     <span id="new_payment_section">
-      <%= button_link_to Spree.t(:new_payment), new_admin_order_payment_url(@order), :class => "btn-success", :icon => 'add' %>
+      <%= button_link_to Spree.t(:new_payment), new_admin_order_payment_url(@order), class: "btn-success", icon: 'add' %>
     </span>
   <% end %>
 <% end %>

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -2,7 +2,7 @@ module Spree
   class Payment < Spree::Base
     extend FriendlyId
     friendly_id :number, slug_column: :number, use: :slugged
-    
+
     include Spree::Payment::Processing
     include Spree::NumberGenerator
 
@@ -165,8 +165,12 @@ module Spree
       return true
     end
 
+    def captured_amount
+      capture_events.sum(:amount)
+    end
+
     def uncaptured_amount
-      amount - capture_events.sum(:amount)
+      amount - captured_amount
     end
 
     private
@@ -203,6 +207,20 @@ module Spree
           order.payments.with_state('checkout').where("id != ?", self.id).each do |payment|
             payment.invalidate!
           end
+        end
+      end
+
+      def split_uncaptured_amount
+        if uncaptured_amount > 0
+          order.payments.create! amount: uncaptured_amount,
+                                 avs_response: avs_response,
+                                 cvv_response_code: cvv_response_code,
+                                 cvv_response_message: cvv_response_message,
+                                 payment_method: payment_method,
+                                 response_code: response_code,
+                                 source: source,
+                                 state: 'pending'
+          update_attributes(amount: captured_amount)
         end
       end
 

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -184,33 +184,26 @@ module Spree
       pending_payments =  order.pending_payments
                             .sort_by(&:uncaptured_amount).reverse
 
-      # NOTE Do we really need to force orders to have pending payments on dispatch?
-      if pending_payments.empty?
-        raise Spree::Core::GatewayError, Spree.t(:no_pending_payments)
-      else
-        shipment_to_pay = final_price_with_items
-        payments_amount = 0
+      shipment_to_pay = final_price_with_items
+      payments_amount = 0
 
-        payments_pool = pending_payments.each_with_object([]) do |payment, pool|
-          next if payments_amount >= shipment_to_pay
-          payments_amount += payment.uncaptured_amount
-          pool << payment
-        end
-
-        payments_pool.each do |payment|
-          capturable_amount = if payment.amount >= shipment_to_pay
-                                shipment_to_pay
-                              else
-                                payment.amount
-                              end
-          cents = (capturable_amount * 100).to_i
-          payment.capture!(cents)
-          shipment_to_pay -= capturable_amount
-        end
+      payments_pool = pending_payments.each_with_object([]) do |payment, pool|
+        break if payments_amount >= shipment_to_pay
+        payments_amount += payment.uncaptured_amount
+        pool << payment
       end
-    rescue Spree::Core::GatewayError => e
-      errors.add(:base, e.message)
-      return !!Spree::Config[:allow_checkout_on_gateway_error]
+
+      payments_pool.each do |payment|
+        capturable_amount = if payment.amount >= shipment_to_pay
+                              shipment_to_pay
+                            else
+                              payment.amount
+                            end
+
+        cents = (capturable_amount * 100).to_i
+        payment.capture!(cents)
+        shipment_to_pay -= capturable_amount
+      end
     end
 
     def ready_or_pending?

--- a/core/spec/lib/tasks/exchanges_spec.rb
+++ b/core/spec/lib/tasks/exchanges_spec.rb
@@ -39,7 +39,6 @@ describe "exchanges:charge_unreturned_items" do
       it "does not create a new order" do
         expect { subject.invoke }.not_to change { Spree::Order.count }
       end
-
     end
 
     context "more than the config allowed days have passed" do

--- a/core/spec/models/spree/order/state_machine_spec.rb
+++ b/core/spec/models/spree/order/state_machine_spec.rb
@@ -180,9 +180,9 @@ describe Spree::Order, :type => :model do
 
       context "with shipped items" do
         before do
-          allow(order).to receive_messages :shipment_state => 'partial'
-          allow(order).to receive_messages :outstanding_balance? => false
-          allow(order).to receive_messages :payment_state => "paid"
+          allow(order).to receive_messages shipment_state: 'partial'
+          allow(order).to receive_messages outstanding_balance?: false
+          allow(order).to receive_messages payment_state: "paid"
         end
 
         it "should not alter the payment state" do
@@ -209,9 +209,9 @@ describe Spree::Order, :type => :model do
   # Another regression test for #729
   context "#resume" do
     before do
-      allow(order).to receive_messages :email => "user@spreecommerce.com"
-      allow(order).to receive_messages :state => "canceled"
-      allow(order).to receive_messages :allow_resume? => true
+      allow(order).to receive_messages email: "user@spreecommerce.com"
+      allow(order).to receive_messages state: "canceled"
+      allow(order).to receive_messages allow_resume?: true
 
       # Stubs method that cause unwanted side effects in this test
       allow(order).to receive :has_available_shipment

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -1,21 +1,20 @@
 require 'spec_helper'
 
 module Spree
-  describe OrderUpdater, :type => :model do
+  describe OrderUpdater, type: :model do
     let(:order) { Spree::Order.create }
     let(:updater) { Spree::OrderUpdater.new(order) }
 
     context "order totals" do
       before do
         2.times do
-          create(:line_item, :order => order, price: 10)
+          create(:line_item, order: order, price: 10)
         end
       end
 
       it "updates payment totals" do
         allow(order).to receive_message_chain(:payments, :completed, :sum).and_return(10)
-
-        updater.update_totals
+        updater.update_payment_total
         expect(order.payment_total).to eq(10)
       end
 
@@ -25,14 +24,14 @@ module Spree
       end
 
       it "update shipment total" do
-        create(:shipment, :order => order, :cost => 10)
+        create(:shipment, order: order, cost: 10)
         updater.update_shipment_total
         expect(order.shipment_total).to eq(10)
       end
 
       context 'with order promotion followed by line item addition' do
-        let(:promotion) { Spree::Promotion.create!(:name => "10% off") }
-        let(:calculator) { Calculator::FlatPercentItemTotal.new(:preferred_flat_percent => 10) }
+        let(:promotion) { Spree::Promotion.create!(name: "10% off") }
+        let(:calculator) { Calculator::FlatPercentItemTotal.new(preferred_flat_percent: 10) }
 
         let(:promotion_action) do
           Promotion::Actions::CreateAdjustment.create!({
@@ -44,7 +43,7 @@ module Spree
         before do
           updater.update
           create(:adjustment, source: promotion_action, adjustable: order, order: order)
-          create(:line_item, :order => order, price: 10) # in addition to the two already created
+          create(:line_item, order: order, price: 10) # in addition to the two already created
           updater.update
         end
 
@@ -57,9 +56,9 @@ module Spree
         # A line item will not have both additional and included tax,
         # so please just humour me for now.
         order.line_items.first.update_columns({
-          :adjustment_total => 10.05,
-          :additional_tax_total => 0.05,
-          :included_tax_total => 0.05,
+          adjustment_total: 10.05,
+          additional_tax_total: 0.05,
+          included_tax_total: 0.05,
         })
         updater.update_adjustment_total
         expect(order.adjustment_total).to eq(10.05)
@@ -70,14 +69,14 @@ module Spree
 
     context "updating shipment state" do
       before do
-        allow(order).to receive_messages :backordered? => false
+        allow(order).to receive_messages backordered?: false
         allow(order).to receive_message_chain(:shipments, :shipped, :count).and_return(0)
         allow(order).to receive_message_chain(:shipments, :ready, :count).and_return(0)
         allow(order).to receive_message_chain(:shipments, :pending, :count).and_return(0)
       end
 
       it "is backordered" do
-        allow(order).to receive_messages :backordered? => true
+        allow(order).to receive_messages backordered?: true
         updater.update_shipment_state
 
         expect(order.shipment_state).to eq('backorder')
@@ -197,12 +196,12 @@ module Spree
     it "state change" do
       order.shipment_state = 'shipped'
       state_changes = double
-      allow(order).to receive_messages :state_changes => state_changes
+      allow(order).to receive_messages state_changes: state_changes
       expect(state_changes).to receive(:create).with(
-        :previous_state => nil,
-        :next_state => 'shipped',
-        :name => 'shipment',
-        :user_id => nil
+        previous_state: nil,
+        next_state: 'shipped',
+        name: 'shipment',
+        user_id: nil
       )
 
       order.state_changed('shipment')
@@ -222,31 +221,31 @@ module Spree
       end
 
       it "updates each shipment" do
-        shipment = stub_model(Spree::Shipment, :order => order)
+        shipment = stub_model(Spree::Shipment, order: order)
         shipments = [shipment]
-        allow(order).to receive_messages :shipments => shipments
-        allow(shipments).to receive_messages :states => []
-        allow(shipments).to receive_messages :ready => []
-        allow(shipments).to receive_messages :pending => []
-        allow(shipments).to receive_messages :shipped => []
+        allow(order).to receive_messages shipments: shipments
+        allow(shipments).to receive_messages states: []
+        allow(shipments).to receive_messages ready: []
+        allow(shipments).to receive_messages pending: []
+        allow(shipments).to receive_messages shipped: []
 
         expect(shipment).to receive(:update!).with(order)
         updater.update_shipments
       end
 
       it "refreshes shipment rates" do
-        shipment = stub_model(Spree::Shipment, :order => order)
+        shipment = stub_model(Spree::Shipment, order: order)
         shipments = [shipment]
-        allow(order).to receive_messages :shipments => shipments
+        allow(order).to receive_messages shipments: shipments
 
         expect(shipment).to receive(:refresh_rates)
         updater.update_shipments
       end
 
       it "updates the shipment amount" do
-        shipment = stub_model(Spree::Shipment, :order => order)
+        shipment = stub_model(Spree::Shipment, order: order)
         shipments = [shipment]
-        allow(order).to receive_messages :shipments => shipments
+        allow(order).to receive_messages shipments: shipments
 
         expect(shipment).to receive(:update_amounts)
         updater.update_shipments
@@ -269,11 +268,11 @@ module Spree
       it "doesnt update each shipment" do
         shipment = stub_model(Spree::Shipment)
         shipments = [shipment]
-        allow(order).to receive_messages :shipments => shipments
-        allow(shipments).to receive_messages :states => []
-        allow(shipments).to receive_messages :ready => []
-        allow(shipments).to receive_messages :pending => []
-        allow(shipments).to receive_messages :shipped => []
+        allow(order).to receive_messages shipments: shipments
+        allow(shipments).to receive_messages states: []
+        allow(shipments).to receive_messages ready: []
+        allow(shipments).to receive_messages pending: []
+        allow(shipments).to receive_messages shipped: []
 
         allow(updater).to receive(:update_totals) # Otherwise this gets called and causes a scene
         expect(updater).not_to receive(:update_shipments).with(order)

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -56,6 +56,21 @@ describe Spree::Payment, :type => :model do
 
   end
 
+  context "#captured_amount" do
+    context "calculates based on capture events" do
+      it "with 0 capture events" do
+        expect(payment.captured_amount).to eq(0)
+      end
+
+      it "with some capture events" do
+        payment.save
+        payment.capture_events.create!(amount: 2.0)
+        payment.capture_events.create!(amount: 3.0)
+        expect(payment.captured_amount).to eq(5)
+      end
+    end
+  end
+
   context '#uncaptured_amount' do
     context "calculates based on capture events" do
       it "with 0 capture events" do
@@ -273,32 +288,49 @@ describe Spree::Payment, :type => :model do
         end
 
         context "if successful" do
-          before do
-            expect(payment.payment_method).to receive(:capture).with(payment.money.money.cents, payment.response_code, anything).and_return(success_response)
+          context 'for entire amount' do
+            before do
+              expect(payment.payment_method).to receive(:capture).with(payment.display_amount.money.cents, payment.response_code, anything).and_return(success_response)
+            end
+
+            it "should make payment complete" do
+              expect(payment).to receive(:complete!)
+              payment.capture!
+            end
+
+            it "logs capture events" do
+              payment.capture!
+              expect(payment.capture_events.count).to eq(1)
+              expect(payment.capture_events.first.amount).to eq(payment.amount)
+            end
           end
 
-          it "should make payment complete" do
-            expect(payment).to receive(:complete!)
-            payment.capture!
-          end
+          context 'for partial amount' do
+            let(:original_amount) { payment.money.money.cents }
+            let(:capture_amount) { original_amount - 100 }
 
-          it "logs capture events" do
-            payment.capture!
-            expect(payment.capture_events.count).to eq(1)
-            expect(payment.capture_events.first.amount).to eq(payment.amount)
-          end
-        end
+            before do
+              expect(payment.payment_method).to receive(:capture).with(capture_amount, payment.response_code, anything).and_return(success_response)
+            end
 
-        context "capturing a partial amount" do
-          it "logs capture events" do
-            payment.capture!(5000)
-            expect(payment.capture_events.count).to eq(1)
-            expect(payment.capture_events.first.amount).to eq(50)
-          end
+            it "should make payment complete & create pending payment for remaining amount" do
+              expect(payment).to receive(:complete!)
+              payment.capture!(capture_amount)
+              order = payment.order
+              payments = order.payments
 
-          it "stores the uncaptured amount on the payment" do
-            payment.capture!(6000)
-            expect(payment.uncaptured_amount).to eq(40) # 100 - 60 = 40
+              expect(payments.size).to eq 2
+              expect(payments.pending.first.amount).to eq 1
+              # Payment stays processing for spec because of receive(:complete!) stub.
+              expect(payments.processing.first.amount).to eq(capture_amount / 100)
+              expect(payments.processing.first.source).to eq(payments.pending.first.source)
+            end
+
+            it "logs capture events" do
+              payment.capture!(capture_amount)
+              expect(payment.capture_events.count).to eq(1)
+              expect(payment.capture_events.first.amount).to eq(capture_amount / 100)
+            end
           end
         end
 
@@ -443,9 +475,9 @@ describe Spree::Payment, :type => :model do
   end
 
   describe "#save" do
-    context "completed payments" do
-      it "updates order payment total" do
-        payment = Spree::Payment.create(:amount => 100, :order => order, state: "completed")
+    context "captured payments" do
+      it "update order payment total" do
+        payment = create(:payment, order: order, state: 'completed')
         expect(order.payment_total).to eq payment.amount
       end
     end

--- a/core/spec/models/spree/reimbursement_spec.rb
+++ b/core/spec/models/spree/reimbursement_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Spree::Reimbursement, :type => :model do
+describe Spree::Reimbursement, type: :model do
 
   describe ".before_create" do
     describe "#generate_number" do

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -99,9 +99,12 @@ describe Spree::Shipment, :type => :model do
     end
   end
 
-  it "#item_cost" do
-    shipment = create(:shipment, order: create(:order_with_totals))
-    expect(shipment.item_cost).to eql(10.0)
+  context "#item_cost" do
+    it 'should equal line items final amount with tax' do
+      shipment = create(:shipment, order: create(:order_with_totals))
+      create :tax_adjustment, adjustable: shipment.order.line_items.first, order: shipment.order
+      expect(shipment.item_cost).to eql(11.0)
+    end
   end
 
   it "#discounted_cost" do
@@ -543,7 +546,9 @@ describe Spree::Shipment, :type => :model do
 
           expect(payment.amount).to eq payment.uncaptured_amount
           @shipment.ship!
-          expect(payment.reload.uncaptured_amount).to eq 50
+          expect(payment.captured_amount).to eq @order.total
+          expect(payment.captured_amount).to eq payment.amount
+          expect(payment.order.payments.pending.first.amount).to eq 50
         end
       end
     end

--- a/frontend/app/views/spree/orders/edit.html.erb
+++ b/frontend/app/views/spree/orders/edit.html.erb
@@ -21,7 +21,7 @@
 
           <div class="links col-md-6 navbar-form pull-right text-right" data-hook="cart_buttons">
             <div class="form-group">
-            <%= order_form.text_field :coupon_code, :size => 10, :placeholder => Spree.t(:coupon_code), class: "form-control form-control-inline" %></div>
+            <%= order_form.text_field :coupon_code, :size => 12, :placeholder => Spree.t(:coupon_code), class: "form-control form-control-inline" %></div>
             <%= button_tag :class => 'btn btn-primary', :id => 'update-button' do %>
               <%= Spree.t(:update) %>
             <% end %>


### PR DESCRIPTION
...d.

When using Config.auto_capture_on_dispatch to capture partial payment for
a single shipment we must split out the remaining amount to capture into
it's own record.  This is due to the OrderUpdater.update_payment_total
expecting completed payment records to be fully captured.

Fixes #5952
