### PR TITLE
orders/_form: opened td should close with /td, not /th

### DIFF
--- a/frontend/app/views/spree/orders/_form.html.erb
+++ b/frontend/app/views/spree/orders/_form.html.erb
@@ -14,14 +14,14 @@
   </tbody>
   <% if @order.adjustments.nonzero.exists? || @order.line_item_adjustments.nonzero.exists? || @order.shipment_adjustments.nonzero.exists? || @order.shipments.any? %>
     <tr class="cart-subtotal">
-      <td colspan="4" align='right'><h5><%= Spree.t(:cart_subtotal, :count => @order.line_items.sum(:quantity)) %></h5></th>
+      <td colspan="4" align='right'><h5><%= Spree.t(:cart_subtotal, :count => @order.line_items.sum(:quantity)) %></h5></td>
       <td colspan><h5><%= order_form.object.display_item_total %></h5></td>
       <td></td>
     </tr>
     <%= render "spree/orders/adjustments" %>
   <% end %>
   <tr class="warning cart-total">
-    <td colspan="4" align='right'><h5><%= Spree.t(:total) %></h5></th>
+    <td colspan="4" align='right'><h5><%= Spree.t(:total) %></h5></td>
     <td class="lead" colspan><%= order_form.object.display_total %></td>
     <td></td>
   </tr>


### PR DESCRIPTION
This is really minor, but I stumbled upon this one when doing some html validation.
