### PR TITLE
Adjustments upgrade migration should fail on save / destroy fail

### DIFF
--- a/core/db/migrate/20130807024301_upgrade_adjustments.rb
+++ b/core/db/migrate/20130807024301_upgrade_adjustments.rb
@@ -9,13 +9,13 @@ class UpgradeAdjustments < ActiveRecord::Migration
       # Account for possible invalid data
       next if adjustment.source.nil?
       adjustment.source.update_column(:cost, adjustment.amount)
-      adjustment.destroy
+      adjustment.destroy!
     end
 
     # Tax adjustments have their sources altered
     Spree::Adjustment.where(:originator_type => "Spree::TaxRate").find_each do |adjustment|
       adjustment.source = adjustment.originator
-      adjustment.save
+      adjustment.save!
     end
 
     # Promotion adjustments have their source altered also
@@ -33,7 +33,7 @@ class UpgradeAdjustments < ActiveRecord::Migration
         # Fail silently. This is primarily in instances where the calculator no longer exists
       end
 
-      adjustment.save
+      adjustment.save!
     end
   end
 end


### PR DESCRIPTION
See title, simple change, suggested by @athal7 in #5984.
