### PR TITLE
Product Model improved save_master condition readability

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -274,11 +274,24 @@ module Spree
       @nested_changes = false
     end
 
+    def master_updated?
+      master &&
+      master.changed? ||
+      master.new_record? ||
+      (
+        master.default_price &&
+        (
+          master.default_price.changed? ||
+          master.default_price.new_record?
+        )
+      )
+    end
+
     # there's a weird quirk with the delegate stuff that does not automatically save the delegate object
     # when saving so we force a save using a hook
     # Fix for issue #5306
     def save_master
-      if master && (master.changed? || master.new_record? || (master.default_price && (master.default_price.changed? || master.default_price.new_record?)))
+      if master_updated?
         master.save!
         @nested_changes = true
       end


### PR DESCRIPTION
Simple change to make the code a bit more readable, no functionality implications. Suggesting this is merged to master only as there is no direct benefit to merging to other branches and as always a (very small in this case) chance of conflicting with custom code.
