### PR TITLE
Removed destroy method from tax categories controller

### DIFF
--- a/backend/app/controllers/spree/admin/tax_categories_controller.rb
+++ b/backend/app/controllers/spree/admin/tax_categories_controller.rb
@@ -1,19 +1,6 @@
 module Spree
   module Admin
     class TaxCategoriesController < ResourceController
-      def destroy
-        if @object.destroy
-          flash[:success] = flash_message_for(@object, :successfully_removed)
-          respond_with(@object) do |format|
-            format.html { redirect_to collection_url }
-            format.js   { render :partial => "spree/admin/shared/destroy" }
-          end
-        else
-          respond_with(@object) do |format|
-            format.html { redirect_to collection_url }
-          end
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
The destroy method can be inherited from resources controller. Resources controller offers the exact same end result plus callbacks which give a bit more flexibility.

Suggesting this is only merged into master in case anyone has custom code that will have unintended effects when the callbacks that are in resources controller run.
