### PR TITLE
Use the core File class instead of Spree::File

### DIFF
--- a/backend/app/helpers/spree/admin/base_helper.rb
+++ b/backend/app/helpers/spree/admin/base_helper.rb
@@ -161,7 +161,7 @@ module Spree
 
       def rails_environments
         @@rails_environments ||= Dir.glob("#{Rails.root}/config/environments/*.rb")
-                                    .map { |f| File.basename(f, ".rb") }
+                                    .map { |f| ::File.basename(f, ".rb") }
                                     .sort
       end
 


### PR DESCRIPTION
When eager loading classes in production, this File constant is a different constant than in development
