### PR TITLE
returns exchange_name as the product name and options_text if available

### DIFF
--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -86,7 +86,11 @@ module Spree
 
     # Default to master name
     def exchange_name
-      is_master? ? name : name + ' - ' + options_text
+      is_master? ? name : options_text
+    end
+
+    def descriptive_name
+      is_master? ? name + ' - Master' : name + ' - ' + options_text
     end
 
     # use deleted? rather than checking the attribute directly. this

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -86,7 +86,7 @@ module Spree
 
     # Default to master name
     def exchange_name
-      is_master? ? name : options_text
+      is_master? ? name : name + ' - ' + options_text
     end
 
     # use deleted? rather than checking the attribute directly. this

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -289,7 +289,7 @@ describe Spree::Variant, :type => :model do
     end
 
     context 'variant' do
-      it 'should return options text with name' do
+      it 'should return options text' do
         expect(variant.exchange_name).to eql 'Foo Type: Foo'
       end
     end
@@ -309,7 +309,7 @@ describe Spree::Variant, :type => :model do
     end
 
     context 'master variant' do
-      it 'should return name' do
+      it 'should return name with Master identifier' do
         expect(master.descriptive_name).to eql master.name + ' - Master'
       end
     end

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -263,8 +263,8 @@ describe Spree::Variant, :type => :model do
     end
 
     context 'variant' do
-      it 'should return options text' do
-        expect(variant.exchange_name).to eql 'Foo Type: Foo'
+      it 'should return options text with name' do
+        expect(variant.exchange_name).to eql variant.name + ' - Foo Type: Foo'
       end
     end
 

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -263,8 +263,60 @@ describe Spree::Variant, :type => :model do
     end
 
     context 'variant' do
+      it 'should return options text' do
+        expect(variant.exchange_name).to eql 'Foo Type: Foo'
+      end
+    end
+
+  end
+
+  describe 'exchange_name' do
+    let!(:variant) { create(:variant, option_values: []) }
+    let!(:master) { create(:master_variant) }
+
+    before do
+      variant.option_values << create(:option_value, {
+                                                     name: 'Foo',
+                                                     presentation: 'Foo',
+                                                     option_type: create(:option_type, position: 2, name: 'Foo Type', presentation: 'Foo Type')
+                                                   })
+    end
+
+    context 'master variant' do
+      it 'should return name' do
+        expect(master.exchange_name).to eql master.name
+      end
+    end
+
+    context 'variant' do
       it 'should return options text with name' do
-        expect(variant.exchange_name).to eql variant.name + ' - Foo Type: Foo'
+        expect(variant.exchange_name).to eql 'Foo Type: Foo'
+      end
+    end
+
+  end
+
+  describe 'descriptive_name' do
+    let!(:variant) { create(:variant, option_values: []) }
+    let!(:master) { create(:master_variant) }
+
+    before do
+      variant.option_values << create(:option_value, {
+                                                     name: 'Foo',
+                                                     presentation: 'Foo',
+                                                     option_type: create(:option_type, position: 2, name: 'Foo Type', presentation: 'Foo Type')
+                                                   })
+    end
+
+    context 'master variant' do
+      it 'should return name' do
+        expect(master.descriptive_name).to eql master.name + ' - Master'
+      end
+    end
+
+    context 'variant' do
+      it 'should return options text with name' do
+        expect(variant.descriptive_name).to eql variant.name + ' - Foo Type: Foo'
       end
     end
 


### PR DESCRIPTION
Instead of returning the product name OR the optional text for exchange_name, this change will always include the product name and specify the product if optional text was given.

I think this is the best practice. Thoughts?
