### PR TITLE
Be able to split and delete unshipped shipment items

### DIFF
--- a/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
@@ -33,11 +33,8 @@
       <% if((!shipment.shipped?) && can?(:update, item.line_item)) %>
         <%= link_to_with_icon 'cancel', Spree.t('actions.cancel'), "#", class: 'cancel-item  btn btn-primary btn-sm', data: { action: 'cancel' }, title: Spree.t('actions.cancel'), style: 'display: none', no_text: true %>
         <%= link_to_with_icon 'ok', Spree.t('actions.save'), "#", class: 'save-item btn btn-success btn-sm', data: {'shipment-number' => shipment.number, 'variant-id' => item.variant.id, action: 'save'}, title: Spree.t('actions.save'), style: 'display: none', no_text: true %>
-
-        <% if shipment.order.shipments.shipped.count == 0 %>
-          <%= link_to_with_icon 'split', Spree.t('split'), "#", class: 'split-item btn btn-primary btn-sm', data: {action: 'split', 'variant-id' => item.variant.id}, title: Spree.t('split'), no_text: true %>
-          <%= link_to_with_icon 'delete', Spree.t('delete'), "#", class: 'delete-item btn btn-danger btn-sm', data: { 'shipment-number' => shipment.number, 'variant-id' => item.variant.id, action: 'remove'}, title: Spree.t('delete'), no_text: true %>
-        <% end %>
+        <%= link_to_with_icon 'split', Spree.t('split'), "#", class: 'split-item btn btn-primary btn-sm', data: {action: 'split', 'variant-id' => item.variant.id}, title: Spree.t('split'), no_text: true %>
+        <%= link_to_with_icon 'delete', Spree.t('delete'), "#", class: 'delete-item btn btn-danger btn-sm', data: { 'shipment-number' => shipment.number, 'variant-id' => item.variant.id, action: 'remove'}, title: Spree.t('delete'), no_text: true %>
       <% end %>
     </td>
   </tr>


### PR DESCRIPTION
On order with multiple shipments:
The if statement prevents you to split or delete any items from a shipment if any other shipment is already shipped.

The if statement on line 33 `if((!shipment.shipped?) && can?(:update, item.line_item))` will prevent this for shipments which are shipped.
