### PR TITLE
Deleted unnecessary javascript includes

### DIFF
--- a/backend/app/views/spree/admin/orders/customer_details/_form.html.erb
+++ b/backend/app/views/spree/admin/orders/customer_details/_form.html.erb
@@ -14,7 +14,7 @@
           <div class="form-group">
             <%= f.label :email, Spree.t(:email) %>
             <%= f.email_field :email, class: 'form-control' %>
-          </div>  
+          </div>
         </div>
         <div class="col-md-4">
           <div class="form-group">
@@ -43,9 +43,9 @@
             <% end %>
           </div>
         </div>
-      </div>  
+      </div>
     </div>
-    
+
   </div>
 
   <div class="row">
@@ -58,7 +58,7 @@
         <div class="panel-body">
           <%= f.fields_for :bill_address do |ba_form| %>
             <%= render partial: 'spree/admin/shared/address_form', locals: { f: ba_form, type: "billing" } %>
-          <% end %>  
+          <% end %>
         </div>
       </div>
     </div>
@@ -87,8 +87,4 @@
   <div class="form-actions" data-hook="buttons">
     <%= button Spree.t('actions.update'), 'save' %>
   </div>
-
-  <% content_for :head do %>
-    <%= javascript_include_tag 'spree/backend/address_states.js' %>
-  <% end %>
 </div>

--- a/backend/app/views/spree/admin/stock_locations/_form.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/_form.html.erb
@@ -86,7 +86,6 @@
 </div>
 
 <% content_for :head do %>
-  <%= javascript_include_tag 'spree/backend/address_states.js' %>
   <%= javascript_tag do -%>
     $(document).ready(function(){
       $('span#country .select2').on('change', function() { update_state(''); });


### PR DESCRIPTION
I deleted some unnecessary javascript includes in the admin templates.
The javascript files got loaded twice, because all backend javascript are loaded anyway.
