### PR TITLE
Risky orders browser

### DIFF
--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -14,6 +14,12 @@ module Spree
         end
       end
 
+      def approve
+        authorize! :update, @order, params[:token]
+        @order.approved_by(try_spree_current_user)
+        respond_with(@order, :default_template => :show)
+      end
+
       def cancel
         authorize! :update, @order, params[:token]
         @order.cancel!

--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -15,7 +15,7 @@ module Spree
       end
 
       def approve
-        authorize! :update, @order, params[:token]
+        authorize! :approve, @order, params[:token]
         @order.approved_by(try_spree_current_user)
         respond_with(@order, default_template: :show)
       end

--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -17,7 +17,7 @@ module Spree
       def approve
         authorize! :update, @order, params[:token]
         @order.approved_by(try_spree_current_user)
-        respond_with(@order, :default_template => :show)
+        respond_with(@order, default_template: :show)
       end
 
       def cancel

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -19,6 +19,7 @@ Spree::Core::Engine.add_routes do
 
     concern :order_routes do
       member do
+        put :approve
         put :cancel
         put :empty
         put :apply_coupon_code

--- a/backend/app/assets/javascripts/spree/backend/orders/risky.js
+++ b/backend/app/assets/javascripts/spree/backend/orders/risky.js
@@ -1,26 +1,12 @@
 var activeRiskyOrder = 0;
 var totalRiskyOrders;
 
-$(document).ready(function(){
-  loadRiskyOrder();
-});
+$(document).ready(loadRiskyOrder);
 
-$(document).on('click', '.js-risky-next', function() {
-  nextRiskyOrder();
-});
-
-$(document).on('click', '.js-risky-prev', function() {
-  prevRiskyOrder();
-});
-
-$(document).on('click', '.js-risky-cancel', function() {
-  cancelRiskyOrder();
-});
-
-$(document).on('click', '.js-risky-approve', function() {
-  approveRiskyOrder();
-});
-
+$(document).on('click', '.js-risky-next', nextRiskyOrder);
+$(document).on('click', '.js-risky-prev', prevRiskyOrder);
+$(document).on('click', '.js-risky-cancel', cancelRiskyOrder);
+$(document).on('click', '.js-risky-approve', approveRiskyOrder);
 $(document).on('click', '.js-view-risky-order', function() {
   viewRiskyOrder($(this));
 });

--- a/backend/app/assets/javascripts/spree/backend/orders/risky.js
+++ b/backend/app/assets/javascripts/spree/backend/orders/risky.js
@@ -70,15 +70,15 @@ function setRiskyOrder(data){
   // assign the class to the current active tr
   $('table#listing_risky_orders tbody tr:eq(' + activeRiskyOrder + ')').addClass('info');
 
-  if(totalRiskyOrders === 0){
-    // no navigation is shown
-  } else if(activeRiskyOrder === 0){
-    showRiskyNav('next');
-  } else if (activeRiskyOrder == totalRiskyOrders) {
-    showRiskyNav('prev');
-  } else {
-    showRiskyNav('next');
-    showRiskyNav('prev');
+  if(!totalRiskyOrders === 0){
+    if(activeRiskyOrder === 0){
+      showRiskyNav('next');
+    } else if (activeRiskyOrder == totalRiskyOrders) {
+      showRiskyNav('prev');
+    } else {
+      showRiskyNav('next');
+      showRiskyNav('prev');
+    }
   }
 }
 
@@ -108,9 +108,9 @@ function getOrderNumber(){
 }
 
 function noRiskyOrdersFound(){
-  var alert_no_risky_found = '<div class="alert alert-success">No risky orders found</div>';
+  var alertNoRiskyFound = '<div class="alert alert-success">No risky orders found</div>';
 
   $('.js-risky-order-info').html('');
-  $(alert_no_risky_found).insertAfter('table#listing_risky_orders');
+  $(alertNoRiskyFound).insertAfter('table#listing_risky_orders');
   $('table#listing_risky_orders').remove();
 }

--- a/backend/app/assets/javascripts/spree/backend/orders/risky.js
+++ b/backend/app/assets/javascripts/spree/backend/orders/risky.js
@@ -49,14 +49,18 @@ function loadRiskyOrder(){
   // totalRiskyOrders should be calculated again
   totalRiskyOrders = $('table#listing_risky_orders tbody tr').length-1;
 
-  $.ajax({
-    type: 'GET',
-    url: '/admin/orders/' + getOrderNumber() + '/risky_order_info'
-  }).done(function (data) {
-    setRiskyOrder(data);
-  }).error(function (msg) {
-    console.log(msg);
-  });
+  if(totalRiskyOrders >= 0){
+    $.ajax({
+      type: 'GET',
+      url: '/admin/orders/' + getOrderNumber() + '/risky_order_info'
+    }).done(function (data) {
+      setRiskyOrder(data);
+    }).error(function (msg) {
+      console.log(msg);
+    });
+  } else {
+    noRiskyOrdersFound();
+  }
 }
 
 function setRiskyOrder(data){
@@ -66,7 +70,9 @@ function setRiskyOrder(data){
   // assign the class to the current active tr
   $('table#listing_risky_orders tbody tr:eq(' + activeRiskyOrder + ')').addClass('info');
 
-  if(activeRiskyOrder === 0){
+  if(totalRiskyOrders === 0){
+    // no navigation is shown
+  } else if(activeRiskyOrder === 0){
     showRiskyNav('next');
   } else if (activeRiskyOrder == totalRiskyOrders) {
     showRiskyNav('prev');
@@ -99,4 +105,12 @@ function showRiskyNav(type){
 
 function getOrderNumber(){
   return $('table#listing_risky_orders tbody tr:eq(' + activeRiskyOrder + ')').data('order-number');
+}
+
+function noRiskyOrdersFound(){
+  var alert_no_risky_found = '<div class="alert alert-success">No risky orders found</div>';
+
+  $('.js-risky-order-info').html('');
+  $(alert_no_risky_found).insertAfter('table#listing_risky_orders');
+  $('table#listing_risky_orders').remove();
 }

--- a/backend/app/assets/javascripts/spree/backend/orders/risky.js
+++ b/backend/app/assets/javascripts/spree/backend/orders/risky.js
@@ -12,12 +12,12 @@ $(document).on('click', '.js-view-risky-order', function() {
 });
 
 function cancelRiskyOrder(){
-  var url = Spree.routes.orders_api + "/" + getOrderNumber() + '/cancel';
+  var url = Spree.routes.orders_api + '/' + getOrderNumber() + '/cancel';
   riskyAjaxActionHandler(url);
 }
 
 function approveRiskyOrder(){
-  var url = Spree.routes.orders_api + "/" + getOrderNumber() + '/approve';
+  var url = Spree.routes.orders_api + '/' + getOrderNumber() + '/approve';
   riskyAjaxActionHandler(url);
 }
 
@@ -66,7 +66,7 @@ function setRiskyOrder(data){
   // assign the class to the current active tr
   $('table#listing_risky_orders tbody tr:eq(' + activeRiskyOrder + ')').addClass('info');
 
-  if(activeRiskyOrder == 0){
+  if(activeRiskyOrder === 0){
     showRiskyNav('next');
   } else if (activeRiskyOrder == totalRiskyOrders) {
     showRiskyNav('prev');
@@ -86,13 +86,14 @@ function prevRiskyOrder(){
   loadRiskyOrder();
 }
 
-function viewRiskyOrder(clicked_element){
-  activeRiskyOrder = clicked_element.parents('tr').index();
+function viewRiskyOrder(clickedElement){
+  activeRiskyOrder = clickedElement.parents('tr').index();
   loadRiskyOrder();
 }
 
 function showRiskyNav(type){
-  // need to use .css here, we want the element to be inline block instead of inline (.show())
+  // Need to use .css() here instead of .show()
+  // We want the element to be inline block instead of inline
   $('.js-risky-' + type).css('display', 'inline-block');
 }
 

--- a/backend/app/assets/javascripts/spree/backend/orders/risky.js
+++ b/backend/app/assets/javascripts/spree/backend/orders/risky.js
@@ -1,4 +1,4 @@
-var riskyOrderCount = 0;
+var activeRiskyOrder = 0;
 var totalRiskyOrders;
 
 $(document).ready(function(){
@@ -53,7 +53,7 @@ function processOrderActionSuccess(){
 }
 
 function removeOrderFromTable(){
-  var deletedOrder = $('table#listing_risky_orders tbody tr:eq(' + riskyOrderCount + ')');
+  var deletedOrder = $('table#listing_risky_orders tbody tr:eq(' + activeRiskyOrder + ')');
 
   deletedOrder.slideUp();
   deletedOrder.remove();
@@ -76,34 +76,41 @@ function loadRiskyOrder(){
 
 function setRiskyOrder(data){
   $('.js-risky-order-info').html(data);
-  $('table#listing_risky_orders tbody tr').removeClass('success');
-  $('table#listing_risky_orders tbody tr:eq(' + riskyOrderCount + ')').addClass('success');
+  // remove the success class from every tr
+  $('table#listing_risky_orders tbody tr').removeClass('info');
+  // assign the class to the current active tr
+  $('table#listing_risky_orders tbody tr:eq(' + activeRiskyOrder + ')').addClass('info');
 
-  if(riskyOrderCount == 0){
-    $('.js-risky-next').show();
-  } else if (riskyOrderCount == totalRiskyOrders) {
-    $('.js-risky-prev').show();
+  if(activeRiskyOrder == 0){
+    showRiskyNav('next');
+  } else if (activeRiskyOrder == totalRiskyOrders) {
+    showRiskyNav('prev');
   } else {
-    $('.js-risky-next').show();
-    $('.js-risky-prev').show();
+    showRiskyNav('next');
+    showRiskyNav('prev');
   }
 }
 
 function nextRiskyOrder(){
-  riskyOrderCount++;
+  activeRiskyOrder++;
   loadRiskyOrder();
 }
 
 function prevRiskyOrder(){
-  riskyOrderCount--;
+  activeRiskyOrder--;
   loadRiskyOrder();
 }
 
 function viewRiskyOrder(clicked_element){
-  riskyOrderCount = clicked_element.parents('tr').index();
+  activeRiskyOrder = clicked_element.parents('tr').index();
   loadRiskyOrder();
 }
 
+function showRiskyNav(type){
+  // need to use .css here, we want the element to be inline block instead of inline (.show())
+  $('.js-risky-' + type).css('display', 'inline-block');
+}
+
 function getOrderNumber(){
-  return $('table#listing_risky_orders tbody tr:eq(' + riskyOrderCount + ')').data('order-number');
+  return $('table#listing_risky_orders tbody tr:eq(' + activeRiskyOrder + ')').data('order-number');
 }

--- a/backend/app/assets/javascripts/spree/backend/orders/risky.js
+++ b/backend/app/assets/javascripts/spree/backend/orders/risky.js
@@ -70,7 +70,7 @@ function setRiskyOrder(data){
   // assign the class to the current active tr
   $('table#listing_risky_orders tbody tr:eq(' + activeRiskyOrder + ')').addClass('info');
 
-  if(!totalRiskyOrders === 0){
+  if(!(totalRiskyOrders === 0)){
     if(activeRiskyOrder === 0){
       showRiskyNav('next');
     } else if (activeRiskyOrder == totalRiskyOrders) {

--- a/backend/app/assets/javascripts/spree/backend/orders/risky.js
+++ b/backend/app/assets/javascripts/spree/backend/orders/risky.js
@@ -1,0 +1,114 @@
+var riskyOrderCount = 0;
+var totalRiskyOrders;
+
+$(document).ready(function(){
+  loadRiskyOrder();
+  $("#progress").fadeIn();
+});
+
+$(document).on('click', '.js-risky-next', function() {
+  nextRiskyOrder();
+});
+
+$(document).on('click', '.js-risky-prev', function() {
+  prevRiskyOrder();
+});
+
+$(document).on('click', '.js-risky-cancel', function() {
+  cancelRiskyOrder();
+});
+
+$(document).on('click', '.js-risky-approve', function() {
+  approveRiskyOrder();
+});
+$(document).on('click', '.js-view-risky-order', function() {
+  viewRiskyOrder($(this));
+});
+
+function cancelRiskyOrder(){
+  $.ajax({
+    type: 'PUT',
+    url: Spree.routes.orders_api + "/" + getOrderNumber() + '/cancel'
+  }).done(function (data) {
+    processCancelledOrder();
+  }).error(function (msg) {
+    console.log(msg);
+  });
+}
+
+function approveRiskyOrder(){
+  $.ajax({
+    type: 'PUT',
+    url: Spree.routes.orders_api + "/" + getOrderNumber() + '/approve'
+  }).done(function (data) {
+    processApprovedOrder();
+  }).error(function (msg) {
+    console.log(msg);
+  });
+}
+
+function processCancelledOrder(){
+  removeOrderFromTable();
+  loadRiskyOrder();
+}
+
+function processApprovedOrder(){
+  removeOrderFromTable();
+  loadRiskyOrder();
+}
+
+function removeOrderFromTable(){
+  var deletedOrder = $('table#listing_risky_orders tbody tr:eq(' + riskyOrderCount + ')');
+
+  deletedOrder.slideUp();
+  deletedOrder.remove();
+}
+
+function loadRiskyOrder(){
+  // totalRiskyOrders calculated here because after every cancel the
+  // totalRiskyOrders should be calculated again
+  totalRiskyOrders = $('table#listing_risky_orders tbody tr').length-1;
+
+  $.ajax({
+    type: 'GET',
+    url: '/admin/orders/' + getOrderNumber() + '/risky_order_info'
+  }).done(function (data) {
+    setRiskyOrder(data);
+  }).error(function (msg) {
+    console.log(msg);
+  });
+}
+
+function setRiskyOrder(data){
+  $('.js-risky-order-info').html(data);
+  $('table#listing_risky_orders tbody tr').removeClass("success");
+  $('table#listing_risky_orders tbody tr:eq(' + riskyOrderCount + ')').addClass("success");
+
+  if(riskyOrderCount == 0){
+    $(".js-risky-next").show();
+  } else if (riskyOrderCount == totalRiskyOrders) {
+    $(".js-risky-prev").show();
+  } else {
+    $(".js-risky-next").show();
+    $(".js-risky-prev").show();
+  }
+}
+
+function nextRiskyOrder(){
+  riskyOrderCount++;
+  loadRiskyOrder();
+}
+
+function prevRiskyOrder(){
+  riskyOrderCount--;
+  loadRiskyOrder();
+}
+
+function viewRiskyOrder(clicked_element){
+  riskyOrderCount = clicked_element.parents("tr").index();
+  loadRiskyOrder();
+}
+
+function getOrderNumber(){
+  return $('table#listing_risky_orders tbody tr:eq(' + riskyOrderCount + ')').data('order-number');
+}

--- a/backend/app/assets/javascripts/spree/backend/orders/risky.js
+++ b/backend/app/assets/javascripts/spree/backend/orders/risky.js
@@ -12,20 +12,19 @@ $(document).on('click', '.js-view-risky-order', function() {
 });
 
 function cancelRiskyOrder(){
-  $.ajax({
-    type: 'PUT',
-    url: Spree.routes.orders_api + "/" + getOrderNumber() + '/cancel'
-  }).done(function (data) {
-    processOrderActionSuccess();
-  }).error(function (msg) {
-    console.log(msg);
-  });
+  var url = Spree.routes.orders_api + "/" + getOrderNumber() + '/cancel';
+  riskyAjaxActionHandler(url);
 }
 
 function approveRiskyOrder(){
+  var url = Spree.routes.orders_api + "/" + getOrderNumber() + '/approve';
+  riskyAjaxActionHandler(url);
+}
+
+function riskyAjaxActionHandler(url){
   $.ajax({
     type: 'PUT',
-    url: Spree.routes.orders_api + "/" + getOrderNumber() + '/approve'
+    url: url
   }).done(function (data) {
     processOrderActionSuccess();
   }).error(function (msg) {

--- a/backend/app/assets/javascripts/spree/backend/orders/risky.js
+++ b/backend/app/assets/javascripts/spree/backend/orders/risky.js
@@ -25,7 +25,7 @@ function riskyAjaxActionHandler(url){
   $.ajax({
     type: 'PUT',
     url: url
-  }).done(function (data) {
+  }).done(function () {
     processOrderActionSuccess();
   }).error(function (msg) {
     console.log(msg);

--- a/backend/app/assets/javascripts/spree/backend/orders/risky.js
+++ b/backend/app/assets/javascripts/spree/backend/orders/risky.js
@@ -3,7 +3,6 @@ var totalRiskyOrders;
 
 $(document).ready(function(){
   loadRiskyOrder();
-  $("#progress").fadeIn();
 });
 
 $(document).on('click', '.js-risky-next', function() {
@@ -21,6 +20,7 @@ $(document).on('click', '.js-risky-cancel', function() {
 $(document).on('click', '.js-risky-approve', function() {
   approveRiskyOrder();
 });
+
 $(document).on('click', '.js-view-risky-order', function() {
   viewRiskyOrder($(this));
 });
@@ -30,7 +30,7 @@ function cancelRiskyOrder(){
     type: 'PUT',
     url: Spree.routes.orders_api + "/" + getOrderNumber() + '/cancel'
   }).done(function (data) {
-    processCancelledOrder();
+    processOrderActionSuccess();
   }).error(function (msg) {
     console.log(msg);
   });
@@ -41,18 +41,13 @@ function approveRiskyOrder(){
     type: 'PUT',
     url: Spree.routes.orders_api + "/" + getOrderNumber() + '/approve'
   }).done(function (data) {
-    processApprovedOrder();
+    processOrderActionSuccess();
   }).error(function (msg) {
     console.log(msg);
   });
 }
 
-function processCancelledOrder(){
-  removeOrderFromTable();
-  loadRiskyOrder();
-}
-
-function processApprovedOrder(){
+function processOrderActionSuccess(){
   removeOrderFromTable();
   loadRiskyOrder();
 }
@@ -81,16 +76,16 @@ function loadRiskyOrder(){
 
 function setRiskyOrder(data){
   $('.js-risky-order-info').html(data);
-  $('table#listing_risky_orders tbody tr').removeClass("success");
-  $('table#listing_risky_orders tbody tr:eq(' + riskyOrderCount + ')').addClass("success");
+  $('table#listing_risky_orders tbody tr').removeClass('success');
+  $('table#listing_risky_orders tbody tr:eq(' + riskyOrderCount + ')').addClass('success');
 
   if(riskyOrderCount == 0){
-    $(".js-risky-next").show();
+    $('.js-risky-next').show();
   } else if (riskyOrderCount == totalRiskyOrders) {
-    $(".js-risky-prev").show();
+    $('.js-risky-prev').show();
   } else {
-    $(".js-risky-next").show();
-    $(".js-risky-prev").show();
+    $('.js-risky-next').show();
+    $('.js-risky-prev').show();
   }
 }
 
@@ -105,7 +100,7 @@ function prevRiskyOrder(){
 }
 
 function viewRiskyOrder(clicked_element){
-  riskyOrderCount = clicked_element.parents("tr").index();
+  riskyOrderCount = clicked_element.parents('tr').index();
   loadRiskyOrder();
 }
 

--- a/backend/app/assets/stylesheets/spree/backend/sections/_risky.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_risky.scss
@@ -1,0 +1,8 @@
+.risky-order-info {
+  h3.order-number {
+    margin: 0 0 20px 0;
+  }
+  .panel:last-of-type {
+    margin-bottom: 0;
+  }
+}

--- a/backend/app/assets/stylesheets/spree/backend/sections/_risky.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_risky.scss
@@ -1,4 +1,11 @@
 .risky-order-info {
+  .next-prev {
+    min-width: 200px;
+    text-align: right;
+    a {
+      margin-left: 8px;
+    }
+  }
   h3.order-number {
     margin: 0 0 20px 0;
   }

--- a/backend/app/assets/stylesheets/spree/backend/shared/_listings.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_listings.scss
@@ -1,0 +1,10 @@
+.index-pagination-row {
+  .pagination {
+    margin: 0;
+  }
+  .pagination-per-page {
+    .form-control {
+      height: 30px;
+    }
+  }
+}

--- a/backend/app/assets/stylesheets/spree/backend/spree_admin.css.scss
+++ b/backend/app/assets/stylesheets/spree/backend/spree_admin.css.scss
@@ -17,6 +17,7 @@
 @import 'components/taxon_products_view';
 
 @import 'sections/account';
+@import 'sections/risky';
 
 @import 'plugins/select2';
 @import 'plugins/jquery_ui';

--- a/backend/app/assets/stylesheets/spree/backend/spree_admin.css.scss
+++ b/backend/app/assets/stylesheets/spree/backend/spree_admin.css.scss
@@ -24,3 +24,4 @@
 
 @import 'shared/base';
 @import 'shared/forms';
+@import 'shared/listings';

--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -6,8 +6,6 @@ module Spree
 
       respond_to :html
 
-      layout :determine_layout
-
       def index
         params[:q] ||= {}
         params[:q][:completed_at_not_null] ||= '1' if Spree::Config[:show_only_complete_orders_by_default]
@@ -62,7 +60,9 @@ module Spree
           per(params[:per_page] || Spree::Config[:orders_per_page])
       end
 
-      def risky_order_info; end
+      def risky_order_info
+        render layout: false
+      end
 
       def new
         @order = Order.create(order_params)
@@ -159,10 +159,6 @@ module Spree
 
         def model_class
           Spree::Order
-        end
-
-        def determine_layout
-          return false if action_name == "risky_order_info"
         end
     end
   end

--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -48,12 +48,12 @@ module Spree
       end
 
       def risky
-        @search = Order.accessible_by(current_ability, :index)
-                       .complete
-                       .where(considered_risky: true)
-                       .where.not(state: 'canceled')
-                       .order(completed_at: :desc)
-                       .ransack(params[:q])
+        @search = Order.accessible_by(current_ability, :index).
+                        complete.
+                        where(considered_risky: true).
+                        where.not(state: 'canceled').
+                        order(completed_at: :desc).
+                        ransack(params[:q])
 
         @orders = @search.result(distinct: true).
           page(params[:page]).

--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -49,7 +49,7 @@ module Spree
 
       def risky
         @search = Order.accessible_by(current_ability, :index)
-                       .where.not(completed_at: nil)
+                       .complete
                        .where(considered_risky: true)
                        .where.not(state: 'canceled')
                        .order(completed_at: :desc)

--- a/backend/app/views/spree/admin/orders/_risk_analysis.html.erb
+++ b/backend/app/views/spree/admin/orders/_risk_analysis.html.erb
@@ -1,13 +1,12 @@
-<fieldset id="risk_analysis">
-  <legend><%= "#{Spree.t(:risk_analysis)}: #{Spree.t(:not) unless @order.is_risky?} #{Spree.t(:risky)}" %></legend>
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <h3 class="panel-title"><%= "#{Spree.t(:risk_analysis)}: #{Spree.t(:not) unless @order.is_risky?} #{Spree.t(:risky)}" %></h3>
+  </div>
+
   <table class="table table-condensed table-bordered">
-    <thead>
-      <th><%= Spree.t('risk')%></th>
-      <th><%= Spree.t('status')%></th>
-    </thead>
-    <tbody id="risk-analysis" data-hook="order_details_adjustments"  class="with-border">
+    <tbody class="additional-info">
       <tr class="">
-        <td>
+        <td width="40%">
           <strong><%= Spree.t(:failed_payment_attempts) %>:</strong>
         </td>
         <td>
@@ -44,4 +43,4 @@
       </tr>
     </tbody>
   </table>
-</fieldset>
+</div>

--- a/backend/app/views/spree/admin/orders/_risk_analysis.html.erb
+++ b/backend/app/views/spree/admin/orders/_risk_analysis.html.erb
@@ -3,9 +3,9 @@
     <h3 class="panel-title"><%= "#{Spree.t(:risk_analysis)}: #{Spree.t(:not) unless @order.is_risky?} #{Spree.t(:risky)}" %></h3>
   </div>
 
-  <table class="table table-condensed table-bordered">
+  <table class="table table-bordered">
     <tbody class="additional-info">
-      <tr class="">
+      <tr>
         <td width="40%">
           <strong><%= Spree.t(:failed_payment_attempts) %>:</strong>
         </td>

--- a/backend/app/views/spree/admin/orders/risky.html.erb
+++ b/backend/app/views/spree/admin/orders/risky.html.erb
@@ -1,0 +1,71 @@
+<% content_for :page_title do %>
+  <%= Spree.t(:risky_orders) %>
+<% end %>
+
+<% if @orders.any? %>
+  <div class="row">
+    <div class="col-md-7">
+      <%= render :partial => 'spree/admin/shared/index_table_options', :locals => { :collection => @orders } %>
+
+      <table class="table" id="listing_risky_orders" data-hook>
+        <thead>
+          <tr data-hook="admin_risky_orders_index_headers">
+            <% if @show_only_completed %>
+              <th><%= sort_link @search, :completed_at,   I18n.t(:completed_at, :scope => 'activerecord.attributes.spree/order') %></th>
+            <% else %>
+              <th><%= sort_link @search, :created_at,     I18n.t(:created_at, :scope => 'activerecord.attributes.spree/order') %></th>
+            <% end %>
+            <th><%= sort_link @search, :number,           I18n.t(:number, :scope => 'activerecord.attributes.spree/order') %></th>
+            <th><%= sort_link @search, :considered_risky, I18n.t(:considered_risky, :scope => 'activerecord.attributes.spree/order') %></th>
+            <th><%= sort_link @search, :payment_state,    I18n.t(:payment_state, :scope => 'activerecord.attributes.spree/order') %></th>
+            <th><%= sort_link @search, :email,            I18n.t(:email, :scope => 'activerecord.attributes.spree/order') %></th>
+            <th><%= sort_link @search, :total,            I18n.t(:total, :scope => 'activerecord.attributes.spree/order') %></th>
+            <th data-hook="admin_orders_index_header_actions" class="actions"></th>
+          </tr>
+        </thead>
+        <tbody>
+        <% @orders.each do |order| %>
+          <tr data-hook="admin_risky_orders_index_rows" data-order-number="<%= order.number %>">
+            <td><%= l (@show_only_completed ? order.completed_at : order.created_at).to_date %></td>
+            <td>
+              <%= link_to order.number, edit_admin_order_path(order) %>
+              <%= "C" if order.can_cancel? %>
+            </td>
+            <td>
+              <span class="label label-<%= order.considered_risky ? 'considered_risky' : 'considered_safe' %>">
+                <%= order.considered_risky ? Spree.t("risky") : Spree.t("safe") %>
+              </span>
+            </td>
+            <td>
+              <% if order.payment_state %>
+                <span class="label label-<%= order.payment_state %>"><%= link_to Spree.t("payment_states.#{order.payment_state}"), admin_order_payments_path(order) %></span>
+              <% end %>
+            </td>
+            <td>
+              <% if order.user %>
+                <%= link_to order.email, edit_admin_user_path(order.user) %>
+              <% else %>
+                <%= mail_to order.email %>
+              <% end %>
+            </td>
+            <td><%= order.display_total.to_html %></td>
+            <td class='actions actions-1'>
+              <%= link_to_with_icon 'search', Spree.t(:details), "javascript:;", :class => 'btn btn-default btn-sm js-view-risky-order', :title => Spree.t(:details), :no_text => true %>
+            </td>
+          </tr>
+        <% end %>
+        </tbody>
+      </table>
+
+      <%= render :partial => 'spree/admin/shared/index_table_options', :locals => { :collection => @orders, :simple => true } %>
+    </div>
+    <div class="col-md-5 js-risky-order-info">
+
+    </div>
+  </div>
+
+<% else %>
+  <div class="alert alert-info no-objects-found">
+    <%= Spree.t(:no_risky_orders_found) %>
+  </div>
+<% end %>

--- a/backend/app/views/spree/admin/orders/risky.html.erb
+++ b/backend/app/views/spree/admin/orders/risky.html.erb
@@ -29,7 +29,6 @@
             <td><%= l (@show_only_completed ? order.completed_at : order.created_at).to_date %></td>
             <td>
               <%= link_to order.number, edit_admin_order_path(order) %>
-              <%= "C" if order.can_cancel? %>
             </td>
             <td>
               <span class="label label-<%= order.considered_risky ? 'considered_risky' : 'considered_safe' %>">
@@ -49,7 +48,7 @@
               <% end %>
             </td>
             <td><%= order.display_total.to_html %></td>
-            <td class='actions actions-1'>
+            <td class='actions text-center'>
               <%= link_to_with_icon 'search', Spree.t(:details), "javascript:;", :class => 'btn btn-default btn-sm js-view-risky-order', :title => Spree.t(:details), :no_text => true %>
             </td>
           </tr>

--- a/backend/app/views/spree/admin/orders/risky/_line_items.html.erb
+++ b/backend/app/views/spree/admin/orders/risky/_line_items.html.erb
@@ -1,0 +1,34 @@
+<% if order.line_items.exists? %>
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h1 class="panel-title">
+        <%= Spree.t(:order_line_items) %>
+      </h1>
+    </div>
+    <table class="table table-bordered line-items" data-hook="line-items">
+      <thead>
+        <th colspan="2"><%= Spree.t(:name) %></th>
+        <th class="text-center"><%= Spree.t(:price) %></th>
+        <th class="text-center"><%= Spree.t(:quantity) %></th>
+        <th class="text-center"><%= Spree.t(:total_price) %></th>
+      </thead>
+      <tbody>
+        <% order.line_items.each do |item| %>
+          <tr class="line-item" id="line-item-<%= item.id %>">
+            <td class="line-item-image image text-center">
+              <%= mini_image(item.variant) %>
+            </td>
+            <td class="line-item-name">
+              <%= item.variant.product.name %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>
+            </td>
+            <td class="line-item-price text-center"><%= item.single_money.to_html %></td>
+            <td class="line-item-qty-show text-center">
+              <%= item.quantity %>
+            </td>
+            <td class="line-item-total text-center"><%= line_item_shipment_price(item, item.quantity) %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+<% end %>

--- a/backend/app/views/spree/admin/orders/risky_order_info.html.erb
+++ b/backend/app/views/spree/admin/orders/risky_order_info.html.erb
@@ -1,36 +1,58 @@
 <div class="well risky-order-info">
-  <div class="pull-right next-prev">
-    <%= link_to 'javascript:;', class: "btn btn-default btn-sm js-risky-prev is-hidden" do %>
-      <span class="icon icon-arrow-left"></span>
-      <%= Spree.t(:previous) %>
-    <% end %>
-    <%= link_to 'javascript:;', class: "btn btn-default btn-sm js-risky-next is-hidden" do %>
-      <%= Spree.t(:next) %>
-      <span class="icon icon-arrow-right"></span>
-    <% end %>
-  </div>
+
   <h3 class="order-number">
     <%= @order.number %>
   </h3>
 
-  <% if @order.can_cancel? || @order.can_approve? %>
-    <div class="panel panel-default js-order-options">
-      <div class="panel-body">
-        <%= link_to_with_icon('delete', Spree.t(:cancel_order),
-          'javascript:;',
-          class: "btn btn-danger btn-sm js-risky-cancel") if @order.can_cancel?
-        %>
-        <%= link_to_with_icon('ok', Spree.t(:approve_order),
-          'javascript:;',
-          class: "btn btn-success btn-sm js-risky-approve") if @order.can_approve?
-        %>
-      </div>
+  <div class="row">
+    <div class="col-md-6">
+      <%= link_to_with_icon('delete', Spree.t(:cancel),
+        'javascript:;',
+        class: "btn btn-danger btn-sm js-risky-cancel") if @order.can_cancel?
+      %>
+      <%= link_to_with_icon('ok', Spree.t(:approve),
+        'javascript:;',
+        class: "btn btn-success btn-sm js-risky-approve") if @order.can_approve?
+      %>
     </div>
-  <% end %>
+    <div class="col-md-6 next-prev">
+      <%= link_to 'javascript:;', class: "btn btn-default btn-sm js-risky-next is-hidden pull-right" do %>
+        <%= Spree.t(:next) %>
+        <span class="icon icon-arrow-right"></span>
+      <% end %>
+
+      <%= link_to 'javascript:;', class: "btn btn-default btn-sm js-risky-prev is-hidden pull-right" do %>
+        <span class="icon icon-arrow-left"></span>
+        <%= Spree.t(:previous) %>
+      <% end %>
+    </div>
+  </div>
 
   <% if @order.payments.exists? && @order.considered_risky? %>
     <%= render 'spree/admin/orders/risk_analysis', latest_payment: @order.payments.valid.last %>
   <% end %>
 
-  <%= render partial: 'spree/admin/shared/order_summary' %>
+  <%= render :partial => 'spree/admin/orders/risky/line_items', :locals => { :order => @order } %>
+
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h3 class="panel-title"><%= Spree.t(:customer_addresses) %></h3>
+    </div>
+
+    <table class="table table-bordered">
+      <tbody>
+        <tr>
+          <td width="50%">
+            <strong><%= Spree.t(:shipping_addresses) %></strong><br/>
+            <%= render partial: 'spree/admin/shared/address', locals: { address: @order.ship_address } %>
+          </td>
+          <td width="50%">
+            <strong><%= Spree.t(:billing_addresses) %></strong><br/>
+            <%= render partial: 'spree/admin/shared/address', locals: { address: @order.bill_address } %>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
 </div>

--- a/backend/app/views/spree/admin/orders/risky_order_info.html.erb
+++ b/backend/app/views/spree/admin/orders/risky_order_info.html.erb
@@ -1,0 +1,29 @@
+<div class="well risky-order-info">
+  <div class="pull-right">
+    <%= button_link_to Spree.t(:prev),
+      'javascript:;',
+      class: "btn btn-default btn-sm js-risky-prev is-hidden"
+    %>
+    <%= button_link_to Spree.t(:next),
+      'javascript:;',
+      class: "btn btn-default btn-sm js-risky-next is-hidden"
+    %>
+    <%= button_link_to(Spree.t(:cancel),
+      'javascript:;',
+      class: "btn btn-danger btn-sm js-risky-cancel") if @order.can_cancel?
+    %>
+    <%= button_link_to(Spree.t(:approve),
+      'javascript:;',
+      class: "btn btn-success btn-sm js-risky-approve") if @order.can_approve?
+    %>
+  </div>
+  <h3 class="order-number">
+    <%= @order.number %>
+  </h3>
+
+  <% if @order.payments.exists? && @order.considered_risky? %>
+    <%= render 'spree/admin/orders/risk_analysis', latest_payment: @order.payments.valid.last %>
+  <% end %>
+
+  <%= render partial: 'spree/admin/shared/order_summary' %>
+</div>

--- a/backend/app/views/spree/admin/orders/risky_order_info.html.erb
+++ b/backend/app/views/spree/admin/orders/risky_order_info.html.erb
@@ -1,25 +1,32 @@
 <div class="well risky-order-info">
-  <div class="pull-right">
-    <%= button_link_to Spree.t(:prev),
-      'javascript:;',
-      class: "btn btn-default btn-sm js-risky-prev is-hidden"
-    %>
-    <%= button_link_to Spree.t(:next),
-      'javascript:;',
-      class: "btn btn-default btn-sm js-risky-next is-hidden"
-    %>
-    <%= button_link_to(Spree.t(:cancel),
-      'javascript:;',
-      class: "btn btn-danger btn-sm js-risky-cancel") if @order.can_cancel?
-    %>
-    <%= button_link_to(Spree.t(:approve),
-      'javascript:;',
-      class: "btn btn-success btn-sm js-risky-approve") if @order.can_approve?
-    %>
+  <div class="pull-right next-prev">
+    <%= link_to 'javascript:;', class: "btn btn-default btn-sm js-risky-prev is-hidden" do %>
+      <span class="icon icon-arrow-left"></span>
+      <%= Spree.t(:previous) %>
+    <% end %>
+    <%= link_to 'javascript:;', class: "btn btn-default btn-sm js-risky-next is-hidden" do %>
+      <%= Spree.t(:next) %>
+      <span class="icon icon-arrow-right"></span>
+    <% end %>
   </div>
   <h3 class="order-number">
     <%= @order.number %>
   </h3>
+
+  <% if @order.can_cancel? || @order.can_approve? %>
+    <div class="panel panel-default js-order-options">
+      <div class="panel-body">
+        <%= link_to_with_icon('delete', Spree.t(:cancel_order),
+          'javascript:;',
+          class: "btn btn-danger btn-sm js-risky-cancel") if @order.can_cancel?
+        %>
+        <%= link_to_with_icon('ok', Spree.t(:approve_order),
+          'javascript:;',
+          class: "btn btn-success btn-sm js-risky-approve") if @order.can_approve?
+        %>
+      </div>
+    </div>
+  <% end %>
 
   <% if @order.payments.exists? && @order.considered_risky? %>
     <%= render 'spree/admin/orders/risk_analysis', latest_payment: @order.payments.valid.last %>

--- a/backend/app/views/spree/admin/shared/_address.html.erb
+++ b/backend/app/views/spree/admin/shared/_address.html.erb
@@ -1,0 +1,38 @@
+<div class="address vcard">
+  <div class="fn"><%= address.full_name %></div>
+  <% unless address.company.blank? %>
+    <div class="org">
+      <%= address.company %>
+    </div>
+  <% end %>
+  <div class="adr">
+    <div class="street-address">
+      <div class="street-address-line">
+        <%= address.address1 %>
+      </div>
+      <% unless address.address2.blank? %>
+        <div class="street-address-line">
+          <%= address.address2 %>
+        </div>
+      <% end %>
+    </div>
+    <div class="local">
+      <span class="locality"><%= address.city %></span>
+      <span class="region"><%= address.state_text %></span>
+      <span class="postal-code"><%= address.zipcode %></span>
+      <div class="country-name"><%= address.country.try(:name) %></div>
+    </div>
+  </div>
+  <% unless address.phone.blank? %>
+    <div class="tel">
+      <span class="type"><%= Spree.t(:phone) %></span>
+      <%= address.phone %>
+    </div>
+  <% end %>
+  <% unless address.alternative_phone.blank? %>
+    <div class="alternative-phone tel">
+      <span class="type"><%= Spree.t(:alternative_phone) %></span>
+      <%= address.alternative_phone %>
+    </div>
+  <% end %>
+</div>

--- a/backend/app/views/spree/admin/shared/_index_table_options.html.erb
+++ b/backend/app/views/spree/admin/shared/_index_table_options.html.erb
@@ -4,7 +4,7 @@
   </div>
   <div class="col-sm-6">
     <div class="pagination-wrap pagination-per-page">
-      <%= form_tag({ :action => "index"}, { :method => "get", :id => "js-per-page-form", :class => 'form-inline' }) do %>
+      <%= form_tag({}, { :method => "get", :id => "js-per-page-form", :class => 'form-inline' }) do %>
         <%= per_page_dropdown %>
       <% end %>
       <div class="clearfix"></div>

--- a/backend/app/views/spree/admin/shared/_index_table_options.html.erb
+++ b/backend/app/views/spree/admin/shared/_index_table_options.html.erb
@@ -3,7 +3,7 @@
     <%= paginate collection %>
   </div>
   <div class="col-sm-6">
-    <div class="pagination-wrap">
+    <div class="pagination-wrap pagination-per-page">
       <%= form_tag({ :action => "index"}, { :method => "get", :id => "js-per-page-form", :class => 'form-inline' }) do %>
         <%= per_page_dropdown %>
       <% end %>

--- a/backend/app/views/spree/admin/shared/_main_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_main_menu.html.erb
@@ -1,6 +1,6 @@
 <% if can? :admin, Spree::Order %>
   <ul class="nav nav-sidebar">
-    <%= tab *Spree::BackendConfiguration::ORDER_TABS, icon: 'shopping-cart' %>
+    <%= main_menu_tree Spree.t(:orders), icon: "shopping-cart", sub_menu: "order", url: "#sidebar-order" %>
   </ul>
 <% end %>
 

--- a/backend/app/views/spree/admin/shared/_order_summary.html.erb
+++ b/backend/app/views/spree/admin/shared/_order_summary.html.erb
@@ -6,7 +6,7 @@
   <table class="table table-condensed table-bordered" id="order_tab_summary" data-hook>
     <tbody class="additional-info">
       <tr>
-        <td id="order_status" width="35%" data-hook>
+        <td id="order_status" width="40%" data-hook>
           <strong><%= Spree.t(:status) %>:</strong>
         </td>
         <td>

--- a/backend/app/views/spree/admin/shared/sub_menu/_order.html.erb
+++ b/backend/app/views/spree/admin/shared/sub_menu/_order.html.erb
@@ -1,0 +1,4 @@
+<ul id="sidebar-order" class="collapse nav nav-pills nav-stacked" data-hook="admin_order_sub_tabs">
+  <%= tab *Spree::BackendConfiguration::ORDER_TABS %>
+  <%= tab :risky_orders %>
+</ul>

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -79,6 +79,7 @@ Spree::Core::Engine.add_routes do
         put :approve
         put :cancel
         put :resume
+        get :risky_order_info
       end
 
       resources :state_changes, only: [:index]
@@ -112,6 +113,7 @@ Spree::Core::Engine.add_routes do
         end
       end
     end
+    get '/orders/risky', to: "orders#risky", as: :risky_orders
 
     resource :general_settings do
       collection do


### PR DESCRIPTION
I created a listing for risky orders.
This listing should be useful for customer service people who have to handle risky orders on a daily base.
## Risky order listing

![screen_shot_2015-02-04_at_17_35_01](https://cloud.githubusercontent.com/assets/106335/6045738/7ac28e8a-ac94-11e4-8981-169924df5ac0.png)

The listing generates a quick view of the order on the right side of the screen.
You can approve or cancel the order.
After the action the order disappears from the list and you will automatically jump to the next order.

The idea is that you can't start with the first and just work your way down to the last by simply clicking accept or cancel.

Need to do:
1) Write specs

I like to hear your opinion about this screen!
