### PR TITLE
bump activemerchant to 1.46

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files        = Dir['LICENSE', 'README.md', 'app/**/*', 'config/**/*', 'lib/**/*', 'db/**/*', 'vendor/**/*']
   s.require_path = 'lib'
 
-  s.add_dependency 'activemerchant', '~> 1.44.1'
+  s.add_dependency 'activemerchant', '~> 1.46.0'
   s.add_dependency 'acts_as_list', '~> 0.6'
   s.add_dependency 'awesome_nested_set', '~> 3.0.1'
   s.add_dependency 'carmen', '~> 1.0.0'


### PR DESCRIPTION
When running RSpec on a Spree 3 project, I was given these deprecation warnings:

```
DEPRECATION WARNING: superclass_delegating_accessor is deprecated and will be removed from Rails 5.0 (use class_attribute instead). (called from <class:Beanstream> at /Users/benmorgan/.rvm/gems/ruby-2.2.0/bundler/gems/spree_gateway-1bec4c0dbdcf/app/models/spree/gateway/beanstream.rb:77)
DEPRECATION WARNING: superclass_delegating_accessor is deprecated and will be removed from Rails 5.0 (use class_attribute instead). (called from <class:Beanstream> at /Users/benmorgan/.rvm/gems/ruby-2.2.0/bundler/gems/spree_gateway-1bec4c0dbdcf/app/models/spree/gateway/beanstream.rb:77)
DEPRECATION WARNING: superclass_delegating_accessor is deprecated and will be removed from Rails 5.0 (use class_attribute instead). (called from <class:Beanstream> at /Users/benmorgan/.rvm/gems/ruby-2.2.0/bundler/gems/spree_gateway-1bec4c0dbdcf/app/models/spree/gateway/beanstream.rb:77)
DEPRECATION WARNING: superclass_delegating_accessor is deprecated and will be removed from Rails 5.0 (use class_attribute instead). (called from <class:Beanstream> at /Users/benmorgan/.rvm/gems/ruby-2.2.0/bundler/gems/spree_gateway-1bec4c0dbdcf/app/models/spree/gateway/beanstream.rb:77)
DEPRECATION WARNING: superclass_delegating_accessor is deprecated and will be removed from Rails 5.0 (use class_attribute instead). (called from <class:Beanstream> at /Users/benmorgan/.rvm/gems/ruby-2.2.0/bundler/gems/spree_gateway-1bec4c0dbdcf/app/models/spree/gateway/beanstream.rb:77)
DEPRECATION WARNING: superclass_delegating_accessor is deprecated and will be removed from Rails 5.0 (use class_attribute instead). (called from <class:Beanstream> at /Users/benmorgan/.rvm/gems/ruby-2.2.0/bundler/gems/spree_gateway-1bec4c0dbdcf/app/models/spree/gateway/beanstream.rb:77)
DEPRECATION WARNING: superclass_delegating_accessor is deprecated and will be removed from Rails 5.0 (use class_attribute instead). (called from <class:Beanstream> at /Users/benmorgan/.rvm/gems/ruby-2.2.0/bundler/gems/spree_gateway-1bec4c0dbdcf/app/models/spree/gateway/beanstream.rb:77)
DEPRECATION WARNING: superclass_delegating_accessor is deprecated and will be removed from Rails 5.0 (use class_attribute instead). (called from <class:Beanstream> at /Users/benmorgan/.rvm/gems/ruby-2.2.0/bundler/gems/spree_gateway-1bec4c0dbdcf/app/models/spree/gateway/beanstream.rb:77)
```

I traced it back to ActiveMerchant. Hoping that bumping to 1.46.0 will fix this issue.
