### PR TITLE
Refactor eligibility errors for promotion rules

### DIFF
--- a/core/app/models/spree/promotion/rules/first_order.rb
+++ b/core/app/models/spree/promotion/rules/first_order.rb
@@ -14,10 +14,10 @@ module Spree
 
           if user || email
             if !completed_orders.blank? && completed_orders.first != order
-              eligibility_errors.add(:base, eligibility_error_message(:not_first_order))
+              add_eligibility_error(:not_first_order)
             end
           else
-            eligibility_errors.add(:base, eligibility_error_message(:no_user_or_email_specified))
+            add_eligibility_error(:no_user_or_email_specified)
           end
 
           eligibility_errors.empty?

--- a/core/app/models/spree/promotion/rules/item_total.rb
+++ b/core/app/models/spree/promotion/rules/item_total.rb
@@ -30,6 +30,7 @@ module Spree
         end
 
         private
+
         def formatted_amount_min
           Spree::Money.new(preferred_amount_min).to_s
         end

--- a/core/app/models/spree/promotion/rules/one_use_per_user.rb
+++ b/core/app/models/spree/promotion/rules/one_use_per_user.rb
@@ -7,12 +7,10 @@ module Spree
         end
 
         def eligible?(order, options = {})
-          if order.user.present?
-            if promotion.used_by?(order.user, [order])
-              eligibility_errors.add(:base, eligibility_error_message(:limit_once_per_user))
-            end
+          if order.user.present? && promotion.used_by?(order.user, [order])
+            add_eligibility_error(:limit_once_per_user)
           else
-            eligibility_errors.add(:base, eligibility_error_message(:no_user_specified))
+            add_eligibility_error(:no_user_specified)
           end
 
           eligibility_errors.empty?

--- a/core/app/models/spree/promotion/rules/product.rb
+++ b/core/app/models/spree/promotion/rules/product.rb
@@ -24,15 +24,15 @@ module Spree
 
           if preferred_match_policy == 'all'
             unless eligible_products.all? {|p| order.products.include?(p) }
-              eligibility_errors.add(:base, eligibility_error_message(:missing_product))
+              add_eligibility_error(:missing_product)
             end
           elsif preferred_match_policy == 'any'
             unless order.products.any? {|p| eligible_products.include?(p) }
-              eligibility_errors.add(:base, eligibility_error_message(:no_applicable_products))
+              add_eligibility_error(:no_applicable_products)
             end
           else
             unless order.products.none? {|p| eligible_products.include?(p) }
-              eligibility_errors.add(:base, eligibility_error_message(:has_excluded_product))
+              add_eligibility_error(:has_excluded_product)
             end
           end
 

--- a/core/app/models/spree/promotion/rules/taxon.rb
+++ b/core/app/models/spree/promotion/rules/taxon.rb
@@ -18,7 +18,7 @@ module Spree
             end
           else
             order_taxons = taxons_in_order_including_parents(order)
-            add_eligibility_error(:no_matching_taxons) unless taxons.any?(&order_taxons.method(:include?))
+            add_eligibility_error(:no_matching_taxons) unless any_taxons?
           end
 
           eligibility_errors.empty?
@@ -60,6 +60,10 @@ module Spree
 
         def taxon_product_ids
           Spree::Product.joins(:taxons).where(spree_taxons: {id: taxons.pluck(:id)}).pluck(:id).uniq
+        end
+
+        def any_taxons?
+          taxons.any?(&order_taxons.method(:include?))
         end
       end
     end

--- a/core/app/models/spree/promotion/rules/taxon.rb
+++ b/core/app/models/spree/promotion/rules/taxon.rb
@@ -14,13 +14,11 @@ module Spree
         def eligible?(order, options = {})
           if preferred_match_policy == 'all'
             unless (taxons.to_a - taxons_in_order_including_parents(order)).empty?
-              eligibility_errors.add(:base, eligibility_error_message(:missing_taxon))
+              add_eligibility_error(:missing_taxon)
             end
           else
             order_taxons = taxons_in_order_including_parents(order)
-            unless taxons.any?{ |taxon| order_taxons.include? taxon }
-              eligibility_errors.add(:base, eligibility_error_message(:no_matching_taxons))
-            end
+            add_eligibility_error(:no_matching_taxons) unless taxons.any?(&order_taxons.method(:include?))
           end
 
           eligibility_errors.empty?

--- a/core/app/models/spree/promotion/rules/user_logged_in.rb
+++ b/core/app/models/spree/promotion/rules/user_logged_in.rb
@@ -7,9 +7,7 @@ module Spree
         end
 
         def eligible?(order, options = {})
-          unless order.user.present?
-            eligibility_errors.add(:base, eligibility_error_message(:no_user_specified))
-          end
+          add_eligibility_error(:no_user_specified) unless order.user.present?
           eligibility_errors.empty?
         end
       end

--- a/core/app/models/spree/promotion_rule.rb
+++ b/core/app/models/spree/promotion_rule.rb
@@ -29,6 +29,10 @@ module Spree
       @eligibility_errors ||= ActiveModel::Errors.new(self)
     end
 
+    def add_eligibility_error(message)
+      eligibility_errors.add(:base, eligibility_error_message(message))
+    end
+
     private
     def unique_per_promotion
       if Spree::PromotionRule.exists?(promotion_id: promotion_id, type: self.class.name)

--- a/core/app/models/spree/promotion_rule.rb
+++ b/core/app/models/spree/promotion_rule.rb
@@ -3,7 +3,7 @@ module Spree
   class PromotionRule < Spree::Base
     belongs_to :promotion, class_name: 'Spree::Promotion', inverse_of: :promotion_rules
 
-    scope :of_type, ->(t) { where(type: t) }
+    scope :of_type, -> (t) { where(type: t) }
 
     validate :unique_per_promotion, on: :create
 
@@ -34,6 +34,7 @@ module Spree
     end
 
     private
+
     def unique_per_promotion
       if Spree::PromotionRule.exists?(promotion_id: promotion_id, type: self.class.name)
         errors[:base] << "Promotion already contains this rule type"


### PR DESCRIPTION
I noticed that adding eligibility errors required a long tedious line. Added the method `#add_eligibility_error` to simplify things.
