### PR TITLE
Fix the usage of url helpers in navigation.

### DIFF
--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -31,7 +31,7 @@ module Spree
         selected = if options[:match_path].is_a? Regexp
           request.fullpath =~ options[:match_path]
         elsif options[:match_path]
-          request.fullpath.starts_with?("#{admin_path}#{options[:match_path]}")
+          request.fullpath.starts_with?("#{spree.admin_path}#{options[:match_path]}")
         else
           args.include?(controller.controller_name.to_sym)
         end

--- a/backend/app/views/spree/admin/adjustments/edit.html.erb
+++ b/backend/app/views/spree/admin/adjustments/edit.html.erb
@@ -13,7 +13,7 @@
     <div class="form-actions" data-hook="buttons">
       <%= button Spree.t(:continue), 'save' %>
       <span class="or"><%= Spree.t(:or) %></span>
-      <%= button_link_to Spree.t('actions.cancel'), admin_order_adjustments_url(@order), icon: 'delete' %>
+      <%= button_link_to Spree.t('actions.cancel'), spree.admin_order_adjustments_url(@order), icon: 'delete' %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/adjustments/new.html.erb
+++ b/backend/app/views/spree/admin/adjustments/new.html.erb
@@ -13,7 +13,7 @@
     <div class="form-actions" data-hook="buttons">
       <%= button Spree.t(:continue), 'save' %>
       <span class="or"><%= Spree.t(:or) %></span>
-      <%= button_link_to Spree.t('actions.cancel'), admin_order_adjustments_url(@order), :icon => 'delete' %>
+      <%= button_link_to Spree.t('actions.cancel'), spree.admin_order_adjustments_url(@order), :icon => 'delete' %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/customer_returns/new.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/new.html.erb
@@ -44,7 +44,7 @@
       <div class="form-actions" data-hook="buttons">
         <%= button Spree.t(:create), 'save' %>
         <span class="or"><%= Spree.t(:or) %></span>
-        <%= button_link_to Spree.t('actions.cancel'), admin_order_customer_returns_url(@order), :icon => 'delete' %>
+        <%= button_link_to Spree.t('actions.cancel'), spree.admin_order_customer_returns_url(@order), :icon => 'delete' %>
       </div>
     </fieldset>
   <% end %>

--- a/backend/app/views/spree/admin/images/edit.html.erb
+++ b/backend/app/views/spree/admin/images/edit.html.erb
@@ -22,7 +22,7 @@
         <div class="form-actions" data-hook="buttons">
           <%= button Spree.t('actions.update'), 'save' %>
           <span class="or"><%= Spree.t(:or) %></span>
-          <%= button_link_to Spree.t('actions.cancel'), admin_product_images_url(@product), :id => 'cancel_link', :icon => 'delete' %>
+          <%= button_link_to Spree.t('actions.cancel'), spree.admin_product_images_url(@product), :id => 'cancel_link', :icon => 'delete' %>
         </div>
       </div>
     </div>

--- a/backend/app/views/spree/admin/images/index.html.erb
+++ b/backend/app/views/spree/admin/images/index.html.erb
@@ -44,7 +44,7 @@
           <td><%= image.alt %></td>
           <td class="actions actions-2 text-right">
             <%= link_to_with_icon 'edit', Spree.t(:edit), edit_admin_product_image_url(@product, image), class: 'btn btn-primary btn-sm', no_text: true, data: { action: 'edit' } %>
-            <%= link_to_delete image, { url: admin_product_image_url(@product, image), no_text: true } %>
+            <%= link_to_delete image, { url: spree.admin_product_image_url(@product, image), no_text: true } %>
           </td>
         </tr>
       <% end %>

--- a/backend/app/views/spree/admin/images/new.html.erb
+++ b/backend/app/views/spree/admin/images/new.html.erb
@@ -11,7 +11,7 @@
     <div class="form-actions" data-hook="buttons">
       <%= button Spree.t('actions.update'), 'save' %>
       <span class="or"><%= Spree.t(:or) %></span>
-      <%= button_link_to Spree.t('actions.cancel'), admin_product_images_url(@product), icon: 'delete', id: 'cancel_link' %>
+      <%= button_link_to Spree.t('actions.cancel'), spree.admin_product_images_url(@product), icon: 'delete', id: 'cancel_link' %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/orders/_line_item.html.erb
+++ b/backend/app/views/spree/admin/orders/_line_item.html.erb
@@ -14,7 +14,7 @@
   </td>
   <td data-hook="admin_order_form_line_item_actions" class="actions">
     <%= link_to_delete f.object, { 
-      url: admin_order_line_item_url(@order.number, f.object), 
+      url: spree.admin_order_line_item_url(@order.number, f.object), 
       no_text: true 
     } %>
   </td>

--- a/backend/app/views/spree/admin/orders/customer_details/edit.html.erb
+++ b/backend/app/views/spree/admin/orders/customer_details/edit.html.erb
@@ -18,7 +18,7 @@
 
 <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @order } %>
 
-<%= form_for @order, url: admin_order_customer_url(@order) do |f| %>
+<%= form_for @order, url: spree.admin_order_customer_url(@order) do |f| %>
   <%= render 'form', f: f %>
 <% end %>
 

--- a/backend/app/views/spree/admin/payments/new.html.erb
+++ b/backend/app/views/spree/admin/payments/new.html.erb
@@ -20,6 +20,6 @@
 <% else %>
   <div class="alert alert-info">
     <%= Spree.t(:cannot_create_payment_without_payment_methods) %>
-    <%= link_to Spree.t(:please_define_payment_methods), admin_payment_methods_url %>
+    <%= link_to Spree.t(:please_define_payment_methods), spree.admin_payment_methods_url %>
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/product_properties/index.html.erb
+++ b/backend/app/views/spree/admin/product_properties/index.html.erb
@@ -6,7 +6,7 @@
   <span class="js-new-ptype-link"><%= button_link_to Spree.t(:select_from_prototype), available_admin_prototypes_url, { :icon => 'properties', :remote => true, 'data-update' => 'prototypes', :class => 'btn-default' } %></span>
 <% end %>
 
-<%= form_for @product, :url => admin_product_url(@product), :method => :put do |f| %>
+<%= form_for @product, :url => spree.admin_product_url(@product), :method => :put do |f| %>
   <fieldset>
     <div id="prototypes" data-hook></div>
 

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -78,7 +78,7 @@
           </div>
           <div class="info-actions">
             <% if can?(:admin, Spree::Variant) %>
-              <%= link_to_with_icon 'variants', 'Manage Variants', admin_product_variants_url(@product), class: "btn btn-default" %>
+              <%= link_to_with_icon 'variants', 'Manage Variants', spree.admin_product_variants_url(@product), class: "btn btn-default" %>
             <% end %>
           </div>
         </div>

--- a/backend/app/views/spree/admin/products/new.html.erb
+++ b/backend/app/views/spree/admin/products/new.html.erb
@@ -68,7 +68,7 @@
 <script type="text/javascript">
 //<![CDATA[
   (function($){
-    var base_url = "<%= admin_prototypes_url %>";
+    var base_url = "<%= spree.admin_prototypes_url %>";
     var prototype_select = $('#product_prototype_id');
     prototype_select.change(function() {
       var id = prototype_select.val();

--- a/backend/app/views/spree/admin/refunds/edit.html.erb
+++ b/backend/app/views/spree/admin/refunds/edit.html.erb
@@ -21,7 +21,7 @@
     <div class="form-actions" data-hook="buttons">
       <%= button Spree.t('actions.save'), 'save' %>
       <span class="or"><%= Spree.t(:or) %></span>
-      <%= button_link_to Spree.t('actions.cancel'), admin_order_payments_url(@refund.payment.order), :icon => "delete" %>
+      <%= button_link_to Spree.t('actions.cancel'), spree.admin_order_payments_url(@refund.payment.order), :icon => "delete" %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/refunds/new.html.erb
+++ b/backend/app/views/spree/admin/refunds/new.html.erb
@@ -29,7 +29,7 @@
     <div class="form-actions" data-hook="buttons">
       <%= button Spree.t(:refund), 'save' %>
       <span class="or"><%= Spree.t(:or) %></span>
-      <%= button_link_to Spree.t('actions.cancel'), admin_order_payments_url(@refund.payment.order), :icon => "delete" %>
+      <%= button_link_to Spree.t('actions.cancel'), spree.admin_order_payments_url(@refund.payment.order), :icon => "delete" %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/return_authorizations/edit.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/edit.html.erb
@@ -24,7 +24,7 @@
     <div class="form-actions" data-hook="buttons">
       <%= button Spree.t('actions.update'), 'repeat' %>
       <span class="or"><%= Spree.t(:or) %></span>
-      <%= button_link_to Spree.t('actions.cancel'), admin_order_return_authorizations_url(@order), :icon => 'delete' %>
+      <%= button_link_to Spree.t('actions.cancel'), spree.admin_order_return_authorizations_url(@order), :icon => 'delete' %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/return_authorizations/new.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/new.html.erb
@@ -12,7 +12,7 @@
     <div class="form-actions" data-hook="buttons">
       <%= button Spree.t(:create), 'save' %>
       <span class="or"><%= Spree.t(:or) %></span>
-      <%= button_link_to Spree.t('actions.cancel'), admin_order_return_authorizations_url(@order), :icon => 'delete' %>
+      <%= button_link_to Spree.t('actions.cancel'), spree.admin_order_return_authorizations_url(@order), :icon => 'delete' %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/shared/_order_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_order_tabs.html.erb
@@ -13,7 +13,7 @@
 
     <% if can?(:update, @order) && @order.checkout_steps.include?("address") %>
       <li<%== ' class="active"' if current == 'Customer Details' %> data-hook='admin_order_tabs_customer_details'>
-        <%= link_to_with_icon 'user', Spree.t(:customer), admin_order_customer_url(@order) %>
+        <%= link_to_with_icon 'user', Spree.t(:customer), spree.admin_order_customer_url(@order) %>
       </li>
     <% end %>
 
@@ -25,20 +25,20 @@
 
     <% if can? :index, Spree::Adjustment %>
       <li<%== ' class="active"' if current == 'Adjustments' %> data-hook='admin_order_tabs_adjustments'>
-        <%= link_to_with_icon 'wrench', Spree.t(:adjustments), admin_order_adjustments_url(@order) %>
+        <%= link_to_with_icon 'wrench', Spree.t(:adjustments), spree.admin_order_adjustments_url(@order) %>
       </li>
     <% end %>
 
     <% if can?(:index, Spree::Payment) %>
       <li<%== ' class="active"' if current == 'Payments' %> data-hook='admin_order_tabs_payments'>
-        <%= link_to_with_icon 'credit-card', Spree.t(:payments), admin_order_payments_url(@order) %>
+        <%= link_to_with_icon 'credit-card', Spree.t(:payments), spree.admin_order_payments_url(@order) %>
       </li>
     <% end %>
 
     <% if can? :index, Spree::ReturnAuthorization %>
       <% if @order.completed? %>
         <li<%== ' class="active"' if current == 'Returns' %> data-hook='admin_order_tabs_return_authorizations'>
-          <%= link_to_with_icon 'transfer', Spree.t(:returns), admin_order_return_authorizations_url(@order) %>
+          <%= link_to_with_icon 'transfer', Spree.t(:returns), spree.admin_order_return_authorizations_url(@order) %>
         </li>
       <% end %>
     <% end %>
@@ -46,14 +46,14 @@
     <% if can? :index, Spree::CustomerReturn %>
       <% if @order.completed? %>
         <li<%== ' class="active"' if current == 'Customer Returns' %>>
-          <%= link_to_with_icon 'transfer', Spree.t(:customer_returns), admin_order_customer_returns_url(@order) %>
+          <%= link_to_with_icon 'transfer', Spree.t(:customer_returns), spree.admin_order_customer_returns_url(@order) %>
         </li>
       <% end %>
     <% end %>
 
     <% if can? :update, @order %>
       <li<%== ' class="active"' if current == 'State Changes' %> data-hook='admin_order_tabs_state_changes'>
-        <%= link_to_with_icon 'refresh', Spree::StateChange.human_attribute_name(:state_changes), admin_order_state_changes_url(@order) %>
+        <%= link_to_with_icon 'refresh', Spree::StateChange.human_attribute_name(:state_changes), spree.admin_order_state_changes_url(@order) %>
       </li>
     <% end %>
   </ul>

--- a/backend/app/views/spree/admin/shared/_product_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_product_tabs.html.erb
@@ -9,13 +9,13 @@
       <%= link_to_with_icon 'edit', Spree.t(:details), edit_admin_product_url(@product) %>
     <% end if can?(:admin, Spree::Product) %>
     <%= content_tag :li, :class => ('active' if current == 'Images') do %>
-      <%= link_to_with_icon 'picture', Spree.t(:images), admin_product_images_url(@product) %>
+      <%= link_to_with_icon 'picture', Spree.t(:images), spree.admin_product_images_url(@product) %>
     <% end if can?(:admin, Spree::Image) %>
     <%= content_tag :li, :class => ('active' if current == 'Variants') do %>
-      <%= link_to_with_icon 'th-large', Spree.t(:variants),  admin_product_variants_url(@product) %>
+      <%= link_to_with_icon 'th-large', Spree.t(:variants),  spree.admin_product_variants_url(@product) %>
     <% end if can?(:admin, Spree::Variant) %>
     <%= content_tag :li, :class => ('active' if current == 'Product Properties') do %>
-      <%= link_to_with_icon 'list-alt', Spree.t(:properties), admin_product_product_properties_url(@product) %>
+      <%= link_to_with_icon 'list-alt', Spree.t(:properties), spree.admin_product_product_properties_url(@product) %>
     <% end if can?(:admin, Spree::ProductProperty) %>
     <%= content_tag :li, :class => ('active' if current == 'Stock Management') do %>
       <%= link_to_with_icon 'home', Spree.t(:stock), stock_admin_product_url(@product) %>

--- a/backend/app/views/spree/admin/shared/sub_menu/_configuration.html.erb
+++ b/backend/app/views/spree/admin/shared/sub_menu/_configuration.html.erb
@@ -1,22 +1,22 @@
 <ul data-hook="admin_configurations_sidebar_menu" class="collapse nav nav-pills nav-stacked" id="sidebar-configuration">
-  <%= configurations_sidebar_menu_item Spree.t(:general_settings), edit_admin_general_settings_path %>
-  <%= configurations_sidebar_menu_item Spree.t(:tax_categories), admin_tax_categories_path %>
-  <%= configurations_sidebar_menu_item Spree.t(:tax_rates), admin_tax_rates_path %>
-  <%= configurations_sidebar_menu_item Spree.t(:zones), admin_zones_path %>
-  <%= configurations_sidebar_menu_item Spree.t(:countries), admin_countries_path %>
+  <%= configurations_sidebar_menu_item Spree.t(:general_settings), spree.edit_admin_general_settings_path %>
+  <%= configurations_sidebar_menu_item Spree.t(:tax_categories), spree.admin_tax_categories_path %>
+  <%= configurations_sidebar_menu_item Spree.t(:tax_rates), spree.admin_tax_rates_path %>
+  <%= configurations_sidebar_menu_item Spree.t(:zones), spree.admin_zones_path %>
+  <%= configurations_sidebar_menu_item Spree.t(:countries), spree.admin_countries_path %>
 
   <% if country = Spree::Country.find_by_id(Spree::Config[:default_country_id]) || Spree::Country.first %>
-    <%= configurations_sidebar_menu_item Spree.t(:states), admin_country_states_path(country) %>
+    <%= configurations_sidebar_menu_item Spree.t(:states), spree.admin_country_states_path(country) %>
   <% end %>
 
-  <%= configurations_sidebar_menu_item Spree.t(:payment_methods), admin_payment_methods_path %>
-  <%= configurations_sidebar_menu_item Spree.t(:shipping_methods), admin_shipping_methods_path %>
-  <%= configurations_sidebar_menu_item Spree.t(:shipping_categories), admin_shipping_categories_path %>
-  <%= configurations_sidebar_menu_item Spree.t(:stock_transfers), admin_stock_transfers_path %>
+  <%= configurations_sidebar_menu_item Spree.t(:payment_methods), spree.admin_payment_methods_path %>
+  <%= configurations_sidebar_menu_item Spree.t(:shipping_methods), spree.admin_shipping_methods_path %>
+  <%= configurations_sidebar_menu_item Spree.t(:shipping_categories), spree.admin_shipping_categories_path %>
+  <%= configurations_sidebar_menu_item Spree.t(:stock_transfers), spree.admin_stock_transfers_path %>
   <%= configurations_sidebar_menu_item Spree.t(:stock_locations), spree.admin_stock_locations_path %>
-  <%= configurations_sidebar_menu_item Spree.t(:analytics_trackers), admin_trackers_path %>
-  <%= configurations_sidebar_menu_item Spree.t(:refund_reasons), admin_refund_reasons_path %>
-  <%= configurations_sidebar_menu_item Spree.t(:reimbursement_types), admin_reimbursement_types_path %>
-  <%= configurations_sidebar_menu_item Spree.t(:return_authorization_reasons), admin_return_authorization_reasons_path %>
-  <%= configurations_sidebar_menu_item Spree.t(:roles), admin_roles_path %>  
+  <%= configurations_sidebar_menu_item Spree.t(:analytics_trackers), spree.admin_trackers_path %>
+  <%= configurations_sidebar_menu_item Spree.t(:refund_reasons), spree.admin_refund_reasons_path %>
+  <%= configurations_sidebar_menu_item Spree.t(:reimbursement_types), spree.admin_reimbursement_types_path %>
+  <%= configurations_sidebar_menu_item Spree.t(:return_authorization_reasons), spree.admin_return_authorization_reasons_path %>
+  <%= configurations_sidebar_menu_item Spree.t(:roles), spree.admin_roles_path %>
 </ul>

--- a/backend/app/views/spree/admin/users/_sidebar.html.erb
+++ b/backend/app/views/spree/admin/users/_sidebar.html.erb
@@ -1,16 +1,16 @@
 <% content_for :sidebar do %>
   <ul class="nav nav-pills nav-stacked" data-hook="admin_user_tab_options">
     <li<%== ' class="active"' if current == :account %>>
-      <%= link_to_with_icon 'user', Spree.t(:"admin.user.account"), edit_admin_user_path(@user) %>
+      <%= link_to_with_icon 'user', Spree.t(:"admin.user.account"), spree.edit_admin_user_path(@user) %>
     </li>
     <li<%== ' class="active"' if current == :address %>>
-      <%= link_to_with_icon 'user', Spree.t(:"admin.user.addresses"), addresses_admin_user_path(@user) %>
+      <%= link_to_with_icon 'user', Spree.t(:"admin.user.addresses"), spree.addresses_admin_user_path(@user) %>
     </li>
     <li<%== ' class="active"' if current == :orders %>>
-      <%= link_to_with_icon 'shopping-cart', Spree.t(:"admin.user.orders"), orders_admin_user_path(@user) %>
+      <%= link_to_with_icon 'shopping-cart', Spree.t(:"admin.user.orders"), spree.orders_admin_user_path(@user) %>
     </li>
     <li<%== ' class="active"' if current == :items %>>
-      <%= link_to_with_icon 'edit', Spree.t(:"admin.user.items"), items_admin_user_path(@user) %>
+      <%= link_to_with_icon 'edit', Spree.t(:"admin.user.items"), spree.items_admin_user_path(@user) %>
     </li>
   </ul>
 <% end %>

--- a/backend/app/views/spree/admin/users/addresses.html.erb
+++ b/backend/app/views/spree/admin/users/addresses.html.erb
@@ -16,7 +16,7 @@
       <%= render :partial => 'addresses_form', :locals => { :f => f } %>
 
       <div class="form-actions text-center well" data-hook="admin_user_edit_form_button">
-        <%= render :partial => 'spree/admin/shared/edit_resource_links', :locals => { :collection_url => admin_users_url } %>
+        <%= render :partial => 'spree/admin/shared/edit_resource_links', :locals => { :collection_url => spree.admin_users_url } %>
       </div>
     <% end %>
   </div>

--- a/backend/app/views/spree/admin/users/edit.html.erb
+++ b/backend/app/views/spree/admin/users/edit.html.erb
@@ -18,11 +18,11 @@
     </div>
 
     <div data-hook="admin_user_edit_form">
-      <%= form_for [:admin, @user], as: :user, url: admin_user_url(@user), method: :put do |f| %>
+      <%= form_for [:admin, @user], as: :user, url: spree.admin_user_url(@user), method: :put do |f| %>
         <%= render :partial => 'form', :locals => { :f => f } %>
 
         <div data-hook="admin_user_edit_form_button">
-          <%= render :partial => 'spree/admin/shared/edit_resource_links', :locals => { :collection_url => admin_users_url } %>
+          <%= render :partial => 'spree/admin/shared/edit_resource_links', :locals => { :collection_url => spree.admin_users_url } %>
         </div>
       <% end %>
     </div>

--- a/backend/app/views/spree/admin/users/index.html.erb
+++ b/backend/app/views/spree/admin/users/index.html.erb
@@ -12,7 +12,7 @@
 
 <% content_for :table_filter do %>
   <div data-hook="admin_users_index_search">
-    <%= search_form_for [:admin, @search], url: admin_users_url do |f| %>
+    <%= search_form_for [:admin, @search], url: spree.admin_users_url do |f| %>
       <div class="form-group">
         <%= f.label Spree.t(:email) %>
         <%= f.text_field :email_cont, class: "form-control js-quick-search-target" %>

--- a/backend/app/views/spree/admin/users/new.html.erb
+++ b/backend/app/views/spree/admin/users/new.html.erb
@@ -7,7 +7,7 @@
 </div>
 
 <div data-hook="admin_user_new_form">
-  <%= form_for [:admin, @user], url: admin_users_url, method: :post do |f| %>
+  <%= form_for [:admin, @user], url: spree.admin_users_url, method: :post do |f| %>
     <%= render :partial => 'form', :locals => { :f => f } %>
 
     <div data-hook="admin_user_new_form_buttons">

--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -45,13 +45,13 @@
 <% if @product.empty_option_values? %>
   <p class='first_add_option_types no-objects-found' data-hook="first_add_option_types">
     <%= Spree.t(:to_add_variants_you_must_first_define) %>
-    <%= link_to Spree.t(:option_types), admin_product_url(@product) %>
+    <%= link_to Spree.t(:option_types), spree.admin_product_url(@product) %>
     <%= Spree.t(:and) %>
-    <%= link_to Spree.t(:option_values), admin_option_types_url %>
+    <%= link_to Spree.t(:option_values), spree.admin_option_types_url %>
   </p>
 <% else %>
   <% content_for :page_actions do %>
     <%= button_link_to Spree.t(:new_variant), new_admin_product_variant_url(@product), { :remote => :true, :icon => 'add', :'data-update' => 'new_variant', :class => 'btn-success', id: 'new_var_link' } %>
-    <%= button_link_to (@deleted.blank? ? Spree.t(:show_deleted) : Spree.t(:show_active)), admin_product_variants_url(@product, :deleted => @deleted.blank? ? "on" : "off"), { :class => 'btn-default', :icon => 'filter' } %>
+    <%= button_link_to (@deleted.blank? ? Spree.t(:show_deleted) : Spree.t(:show_active)), spree.admin_product_variants_url(@product, :deleted => @deleted.blank? ? "on" : "off"), { :class => 'btn-default', :icon => 'filter' } %>
   <% end %>
 <% end %>

--- a/backend/spec/helpers/admin/navigation_helper_spec.rb
+++ b/backend/spec/helpers/admin/navigation_helper_spec.rb
@@ -44,8 +44,7 @@ describe Spree::Admin::NavigationHelper, type: :helper do
 
       context "when match_path option is supplied" do
         before do
-          allow(helper).to receive(:admin_path).and_return("/somepath")
-          allow(helper).to receive(:request).and_return(double(ActionDispatch::Request, fullpath: "/somepath/orders/edit/1"))
+          allow(helper).to receive(:request).and_return(double(ActionDispatch::Request, fullpath: "/admin/orders/edit/1"))
         end
 
         it "should be selected if the fullpath matches" do


### PR DESCRIPTION
If one has a custom controller with a tab in the spree main navigation, then we need to tell spree to call the url helpers on the `spree` routing proxy object. The helpers are not known to the current scope (i.e. an engine or the main app).
