### PR TITLE
Active Model Serializers Example using Spree::Zone

### DIFF
--- a/api/app/controllers/spree/api/zones_controller.rb
+++ b/api/app/controllers/spree/api/zones_controller.rb
@@ -20,7 +20,7 @@ module Spree
 
       def index
         @zones = Zone.accessible_by(current_ability, :read).order('name ASC').ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
-        respond_with(@zones)
+        render json: @zones, each_serializer: Spree::ZoneSerializer
       end
 
       def show

--- a/api/app/controllers/spree/api/zones_controller.rb
+++ b/api/app/controllers/spree/api/zones_controller.rb
@@ -42,6 +42,7 @@ module Spree
       end
 
       private
+
       def zone_params
         params.require(:zone).permit!
       end

--- a/api/app/controllers/spree/api/zones_controller.rb
+++ b/api/app/controllers/spree/api/zones_controller.rb
@@ -23,7 +23,9 @@ module Spree
         @zones = Zone.accessible_by(current_ability, :read).order('name ASC')
                  .includes(zone_members: :zoneable)
                  .ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
-        render json: @zones
+        render json: @zones, meta: {
+          count: @zones.count, pages: (params[:page] || 1), current_page: @zones.num_pages
+        }
       end
 
       def show

--- a/api/app/controllers/spree/api/zones_controller.rb
+++ b/api/app/controllers/spree/api/zones_controller.rb
@@ -1,8 +1,6 @@
 module Spree
   module Api
     class ZonesController < Spree::Api::BaseController
-      skip_before_action :authenticate_user
-
       def create
         authorize! :create, Zone
         @zone = Zone.new(map_nested_attributes_keys(Spree::Zone, zone_params))

--- a/api/app/controllers/spree/api/zones_controller.rb
+++ b/api/app/controllers/spree/api/zones_controller.rb
@@ -19,7 +19,9 @@ module Spree
       end
 
       def index
-        @zones = Zone.accessible_by(current_ability, :read).order('name ASC').ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
+        @zones = Zone.accessible_by(current_ability, :read).order('name ASC')
+                 .includes(zone_members: :zoneable)
+                 .ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
         render json: @zones, each_serializer: Spree::ZoneSerializer
       end
 

--- a/api/app/controllers/spree/api/zones_controller.rb
+++ b/api/app/controllers/spree/api/zones_controller.rb
@@ -1,6 +1,7 @@
 module Spree
   module Api
     class ZonesController < Spree::Api::BaseController
+      skip_before_action :authenticate_user
 
       def create
         authorize! :create, Zone
@@ -22,7 +23,7 @@ module Spree
         @zones = Zone.accessible_by(current_ability, :read).order('name ASC')
                  .includes(zone_members: :zoneable)
                  .ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
-        render json: @zones, each_serializer: Spree::ZoneSerializer
+        render json: @zones
       end
 
       def show

--- a/api/app/controllers/spree/api/zones_controller.rb
+++ b/api/app/controllers/spree/api/zones_controller.rb
@@ -18,9 +18,9 @@ module Spree
       end
 
       def index
-        @zones = Zone.accessible_by(current_ability, :read).order('name ASC')
-                 .includes(zone_members: :zoneable)
-                 .ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
+        @zones = Zone.accessible_by(current_ability, :read).order('name ASC').
+                 includes(zone_members: :zoneable).
+                 ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
         render json: @zones, meta: {
           count: @zones.count, pages: (params[:page] || 1), current_page: @zones.num_pages
         }

--- a/api/app/serializers/spree/base_serializer.rb
+++ b/api/app/serializers/spree/base_serializer.rb
@@ -1,4 +1,6 @@
 module Spree
   class BaseSerializer < ActiveModel::Serializer
+    cached
+    delegate :cache_key, to: :object
   end
 end

--- a/api/app/serializers/spree/base_serializer.rb
+++ b/api/app/serializers/spree/base_serializer.rb
@@ -1,0 +1,4 @@
+module Spree
+  class BaseSerializer < AcitveModel::Serializer
+  end
+end

--- a/api/app/serializers/spree/base_serializer.rb
+++ b/api/app/serializers/spree/base_serializer.rb
@@ -1,4 +1,4 @@
 module Spree
-  class BaseSerializer < AcitveModel::Serializer
+  class BaseSerializer < ActiveModel::Serializer
   end
 end

--- a/api/app/serializers/spree/zone_member_serializer.rb
+++ b/api/app/serializers/spree/zone_member_serializer.rb
@@ -1,0 +1,5 @@
+module Spree
+  class ZoneMemberSerializer < Spree::BaseSerializer
+    attributes :id, :name, :zoneable_type, :zoneable_id
+  end
+end

--- a/api/app/serializers/spree/zone_serializer.rb
+++ b/api/app/serializers/spree/zone_serializer.rb
@@ -1,0 +1,7 @@
+module Spree
+  class ZoneSerializer < Spree::BaseSerializer
+    attributes :id, :name, :description
+
+    has_many :zone_members
+  end
+end

--- a/api/app/views/spree/api/zones/index.v1.rabl
+++ b/api/app/views/spree/api/zones/index.v1.rabl
@@ -1,7 +1,0 @@
-object false
-child(@zones => :zones) do
-  extends 'spree/api/zones/show'
-end
-node(:count) { @zones.count }
-node(:current_page) { params[:page] || 1 }
-node(:pages) { @zones.num_pages }

--- a/api/lib/spree/api.rb
+++ b/api/lib/spree/api.rb
@@ -1,6 +1,7 @@
 require 'spree/core'
 
 require 'rabl'
+require 'active_model_serializers'
 
 module Spree
   module Api

--- a/api/spree_api.gemspec
+++ b/api/spree_api.gemspec
@@ -18,5 +18,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'spree_core', version
   gem.add_dependency 'rabl', '~> 0.9.4.pre1'
+  gem.add_dependency 'active_model_serializers', '~> 0.8.3'
   gem.add_dependency 'versioncake', '~> 2.3.1'
 end

--- a/core/app/models/spree/zone_member.rb
+++ b/core/app/models/spree/zone_member.rb
@@ -4,8 +4,7 @@ module Spree
     belongs_to :zoneable, polymorphic: true
 
     def name
-      return nil if zoneable.nil?
-      zoneable.name
+      zoneable.try :name
     end
   end
 end


### PR DESCRIPTION
The purpose of this PR is to direct attention and thought, as well as to an example, in moving away from RABL and towards AMS. Some collaborators and developers have shown an interest in moving to AMS. I'm hoping this PR can help identify how that may happen, and how we could reach the goal by or on the release of Spree 4.

The first problem, at the large level, is the amount of work that it would take to move Spree from RABL to AMS. My proposal would be to let AMS and RABL co-exist and slowly deprecate the RABL templates per 3.x release until 4.0 is reached. In the beginning, we can focus on deprecating some of the smaller RABL templates such as Zones and Countries. This would allow us to identify key issues before they become sizeable as well as make rollbacks that won't be costly to the users.

One of the conundrums with AMS is the version number. It seems that the two current stable releases are 0.8.3 and 0.9.3, however there is also the upcoming 0.10.0 which is maturing. It was a concern to some developers that AMS might not provide the caching support that they may require for their applications. Since AMS 0.9 does not include caching, this leaves 0.8.3 and the upcoming 0.10.0. Caching has recently been added back into AMS with different syntax, which means maintenance would be required when bumping AMS in the future.

Caching was setup in the `Spree::BaseSerializer`. This way, all serializers inheriting from `Spree::BaseSerializer` will be naturally cached and when the time comes to bump to AMS 0.10 we can change the caching syntax in a single place. However, what if you do not wish to cache a serializer? Such as a rapidly changing `Spree::OrderSerializer`?

Attributes is also another thing to be discussed. Serializers which can _only_ be viewed by admins via the API can probably benefit from a simple `column_names` method such as the `Spree::ZoneSerializer`. If there is still information missing, they can be obtained by adding the method names as symbols to the `attributes` arguments.

Another concern is the meta information. You'll notice that I was able to pass the page and count information for zones via a meta key. This changes the API's design.

This description has touched enough of my concerns in moving from AMS to RABL. To begin moving to AMS, I would target the low hanging fruit of the RABL templates and begin deprecating from there for Spree 3.1.

Some questions:
- Should the serializers be placed in core or within the API?
- What happens when you need different serializers for different jobs? The [variants views](https://github.com/spree/spree/tree/3-0-stable/api/app/views/spree/api/variants) list two sizes and three verbs.
