### PR TITLE
Fix exception when date is nil

### DIFF
--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -171,7 +171,7 @@
     <tbody>
     <% @orders.each do |order| %>
       <tr data-hook="admin_orders_index_rows" class="state-<%= order.state.downcase %> <%= cycle('odd', 'even') %>">
-        <td><%= l (@show_only_completed ? order.completed_at : order.created_at).to_date %></td>
+        <td><%= l (@show_only_completed ? order.completed_at : order.created_at).try(&:to_date) %></td>
         <td><%= link_to order.number, edit_admin_order_path(order) %></td>
         <td>
           <span class="label label-<%= order.considered_risky ? 'considered_risky' : 'considered_safe' %>">


### PR DESCRIPTION
The @show_only_completed does not filter orders where completed_at is not filled out.
This only solves the ActionView::Template::Error (undefined method `to_date' for nil:NilClass) exception. I18n.l will still drop exception when receives nil instead of a date.
