### PR TITLE
add missing has_many orders for Spree::Store

### DIFF
--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -1,5 +1,7 @@
 module Spree
   class Store < Spree::Base
+    has_many :orders, class_name: "Spree::Order"
+
     validates :code, presence: true, uniqueness: { allow_blank: true }
     validates :name, presence: true
     validates :url, presence: true


### PR DESCRIPTION
In the `Spree::Order` model, there is a `belongs_to` for `Spree::Store`, but when I went to do `Spree::Store.current.orders << order`, it didn't work. I then noticed that there was no `has_many :orders` association.

I'm not sure if this was intentional, but this PR adds the association in.
