### PR TITLE
add missing role translations

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -825,6 +825,7 @@ en:
     new_refund_reason: New Refund Reason
     new_rma_reason: New RMA Reason
     new_return_authorization: New Return Authorization
+    new_role: New Role
     new_shipping_category: New Shipping Category
     new_shipping_method: New Shipping Method
     new_shipment_at_location: New shipment at location
@@ -1131,6 +1132,7 @@ en:
     rma_number: RMA Number
     rma_value: RMA Value
     roles: Roles
+    role_id: Role ID
     rules: Rules
     safe: Safe
     sales_total: Sales Total


### PR DESCRIPTION
While trying out the new roles configuration, I received these missing translation errors.

`new_role` is used [here](https://github.com/spree/spree/blob/88fc133e85a01d0bdb247c06c106e31e8775f0bf/backend/app/views/spree/admin/roles/index.html.erb#L6) and `role_id` is used [here](https://github.com/spree/spree/blob/88fc133e85a01d0bdb247c06c106e31e8775f0bf/backend/app/views/spree/admin/roles/index.html.erb#L13).
