### PR TITLE
Added alias modify to abilitys

### DIFF
--- a/core/app/models/spree/ability.rb
+++ b/core/app/models/spree/ability.rb
@@ -32,6 +32,7 @@ module Spree
       alias_action :new_action, to: :create
       alias_action :show, to: :read
       alias_action :index, :read, to: :display
+      alias_action :create, :update, :destroy, to: :modify
 
       user ||= Spree.user_class.new
 


### PR DESCRIPTION
Introduced alias modify.
Modify implies you can mutates an object BUT not necessarily perform all actions.
For example you may be able to create, edit or destroy an order (therefore view it's edit screen) but you cannot approve an order (which would be included with the manage action).
