### PR TITLE
Bump to v3.0.0 from 3.0.0.rc2

### DIFF
--- a/core/lib/spree/core/version.rb
+++ b/core/lib/spree/core/version.rb
@@ -1,5 +1,5 @@
 module Spree
   def self.version
-    "3.0.0.rc2"
+    '3.0.0'
   end
 end


### PR DESCRIPTION
This makes it possible for us to create `3-0-stable` branches for extensions (after new gem release).

```
Bundler could not find compatible versions for gem "spree_core":
  In Gemfile:
    spree-faq (>= 0) ruby depends on
      spree_core (~> 3.0.0) ruby

    spree (>= 0) ruby depends on
      spree_core (3.0.0.rc2)
```
