### PR TITLE
User password updating should not be required

### DIFF
--- a/backend/app/controllers/spree/admin/users_controller.rb
+++ b/backend/app/controllers/spree/admin/users_controller.rb
@@ -35,6 +35,10 @@ module Spree
       end
 
       def update
+        if params[:user][:password].blank? && params[:user][:password_confirmation].blank?
+          params[:user].delete(:password)
+          params[:user].delete(:password_confirmation)
+        end
 
         if @user.update_attributes(user_params)
           set_roles

--- a/backend/spec/controllers/spree/admin/users_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/users_controller_spec.rb
@@ -106,6 +106,13 @@ describe Spree::Admin::UsersController, :type => :controller do
       ))
       spree_put :update, { :id => mock_user.id, :user => { :bill_address_attributes => { :city => "New York" } } }
     end
+
+    it "allows updating without password resetting" do
+      expect(mock_user).to receive(:update_attributes).with(hash_not_including(
+        "password" => "", "password_confirmation" => ""
+      ))
+      spree_put :update, { :id => mock_user.id, :user => { :password => '', :password_confirmation => '', :email => 'spree@example.com' }}
+    end
   end
 
   describe "#orders" do

--- a/backend/spec/controllers/spree/admin/users_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/users_controller_spec.rb
@@ -108,10 +108,8 @@ describe Spree::Admin::UsersController, :type => :controller do
     end
 
     it "allows updating without password resetting" do
-      expect(mock_user).to receive(:update_attributes).with(hash_not_including(
-        "password" => "", "password_confirmation" => ""
-      ))
-      spree_put :update, { :id => mock_user.id, :user => { :password => '', :password_confirmation => '', :email => 'spree@example.com' }}
+      expect(mock_user).to receive(:update_attributes).with(hash_not_including(password: '', password_confirmation: ''))
+      spree_put :update, id: mock_user.id, user: { password: '', password_confirmation: '', email: 'spree@example.com' }
     end
   end
 


### PR DESCRIPTION
In the current implementation I'm getting an validation error, when I try to assign a new role to user without password updating:
http://monosnap.com/image/HGWEHg0FgRTdsjnwgacXM3dJiYWdxS
