### PR TITLE
Remove duplicate option type ids from prototype form

### DIFF
--- a/backend/app/views/spree/admin/prototypes/_form.html.erb
+++ b/backend/app/views/spree/admin/prototypes/_form.html.erb
@@ -25,9 +25,4 @@
       <%= f.select :taxon_ids, Spree::Taxon.all.map { |t| [t.name, t.id] }, {}, { multiple: true, class: "select2" } %>
     <% end %>
   </div>
-
-  <%= f.field_container :option_type_ids, class: ['form-group'] do %>
-    <%= f.label :option_type_ids, Spree.t(:option_types) %>
-    <%= f.select :option_type_ids, Spree::OptionType.all.map { |ot| [ot.presentation, ot.id] }, {}, { multiple: true, class: "select2" } %>
-  <% end %>
 </div>


### PR DESCRIPTION
Somehow there are now 2 option type selects in the prototype form. 
I removed it, because it looks like an accident for me.
