### PR TITLE
remove rescues that just re-raise the error

### DIFF
--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -36,7 +36,8 @@ module Spree
           order.updater.update
           if shipments_attrs.present?
             order.shipments.each_with_index do |shipment, index|
-              shipment.update_columns(cost: shipments_attrs[index][:cost].to_f) if shipments_attrs[index][:cost].present?
+              shipment_cost = shipments_attrs[index][:cost]
+              shipment.update_columns(cost: shipment_cost.to_f) if shipment_cost.present?
             end
           end
           order.reload

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -26,7 +26,7 @@ module Spree
             order.state = 'complete'
           end
 
-          params.delete(:user_id) unless user.try(:has_spree_role?, "admin") && params.key?(:user_id)
+          params.delete(:user_id) unless user.try(:has_spree_role?, "admin") && params.key? :user_id
 
           order.update_attributes!(params)
 

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -55,7 +55,7 @@ module Spree
             shipment.tracking = shipment_hash[:tracking]
             shipment.stock_location = Spree::StockLocation.find_by_admin_name(shipment_hash[:stock_location]) || Spree::StockLocation.find_by_name!(shipment_hash[:stock_location])
 
-            inventory_units = s[:inventory_units] || []
+            inventory_units = shipment_hash[:inventory_units] || []
             inventory_units.each do |iu|
               ensure_variant_id_from_params(iu)
 
@@ -73,9 +73,9 @@ module Spree
             end
 
             # Mark shipped if it should be.
-            if s[:shipped_at].present?
-              shipment.shipped_at = s[:shipped_at]
-              shipment.state      = 'shipped'
+            if shipment_hash[:shipped_at].present?
+              shipment.shipped_at = shipment_hash[:shipped_at]
+              shipment.state = 'shipped'
               shipment.inventory_units.each do |unit|
                 unit.state = 'shipped'
               end

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -41,9 +41,8 @@ module Spree
             end
           end
           order.reload
-        rescue Exception => e
+        ensure
           order.destroy if order && order.persisted?
-          raise e.message
         end
 
         def self.create_shipments_from_params(shipments_hash, order)

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -16,7 +16,7 @@ module Spree
           shipments_attrs = params.delete(:shipments_attributes)
 
           create_shipments_from_params(shipments_attrs, order)
-          create_line_items_from_params(params.delete(:line_items_attributes),order)
+          create_line_items_from_params(params.delete(:line_items_attributes), order)
           create_shipments_from_params(params.delete(:shipments_attributes), order)
           create_adjustments_from_params(params.delete(:adjustments_attributes), order)
           create_payments_from_params(params.delete(:payments_attributes), order)

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -50,10 +50,10 @@ module Spree
           return [] unless shipments_hash
 
           line_items = order.line_items
-          shipments_hash.each do |s|
+          shipments_hash.each do |shipment_hash|
             shipment = order.shipments.build
-            shipment.tracking       = s[:tracking]
-            shipment.stock_location = Spree::StockLocation.find_by_admin_name(s[:stock_location]) || Spree::StockLocation.find_by_name!(s[:stock_location])
+            shipment.tracking = shipment_hash[:tracking]
+            shipment.stock_location = Spree::StockLocation.find_by_admin_name(shipment_hash[:stock_location]) || Spree::StockLocation.find_by_name!(shipment_hash[:stock_location])
 
             inventory_units = s[:inventory_units] || []
             inventory_units.each do |iu|
@@ -83,8 +83,8 @@ module Spree
 
             shipment.save!
 
-            shipping_method = Spree::ShippingMethod.find_by_name(s[:shipping_method]) || Spree::ShippingMethod.find_by_admin_name!(s[:shipping_method])
-            rate = shipment.shipping_rates.create!(shipping_method: shipping_method, cost: s[:cost])
+            shipping_method = Spree::ShippingMethod.find_by_name(shipment_hash[:shipping_method]) || Spree::ShippingMethod.find_by_admin_name!(shipment_hash[:shipping_method])
+            rate = shipment.shipping_rates.create!(shipping_method: shipping_method, cost: shipment_hash[:cost])
             shipment.selected_shipping_rate_id = rate.id
             shipment.update_amounts
           end

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -56,8 +56,8 @@ module Spree
             shipment.stock_location = Spree::StockLocation.find_by_admin_name(shipment_hash[:stock_location]) || Spree::StockLocation.find_by_name!(shipment_hash[:stock_location])
 
             inventory_units = shipment_hash[:inventory_units] || []
-            inventory_units.each do |iu|
-              ensure_variant_id_from_params(iu)
+            inventory_units.each do |inventory_unit|
+              ensure_variant_id_from_params(inventory_unit)
 
               unit = shipment.inventory_units.build
               unit.order = order
@@ -65,10 +65,10 @@ module Spree
               # Spree expects a Inventory Unit to always reference a line
               # item and variant otherwise users might get exceptions when
               # trying to view these units. Note the Importer might not be
-              # able to find the line item if line_item.variant_id |= iu.variant_id
-              unit.variant_id = iu[:variant_id]
+              # able to find the line item if line_item.variant_id |= inventory_unit.variant_id
+              unit.variant_id = inventory_unit[:variant_id]
               unit.line_item_id = line_items.select do |line_item|
-                line_item.variant_id.to_i == iu[:variant_id].to_i
+                line_item.variant_id.to_i == inventory_unit[:variant_id].to_i
               end.first.try(:id)
             end
 

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -161,8 +161,8 @@ module Spree
           payments_hash.each do |p|
             payment = order.payments.build order: order
             payment.amount = p[:amount].to_f
-            # Order API should be using state as that's the normal payment field.
-            # spree_wombat serializes payment state as status so imported orders should fall back to status field.
+            # Order API should be using state as that's the normal payment field. spree_wombat
+            # serializes payment state as status so imported orders should fall back to status field
             payment.state = p[:state] || p[:status] || 'completed'
             payment.payment_method = Spree::PaymentMethod.find_by_name!(p[:payment_method])
             payment.source = create_source_payment_from_params(p[:source], payment) if p[:source]

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -145,12 +145,9 @@ module Spree
 
         def self.create_adjustments_from_params(adjustments, order)
           return [] unless adjustments
-          adjustments.each do |a|
-            adjustment = order.adjustments.build(
-              order:  order,
-              amount: a[:amount].to_f,
-              label:  a[:label]
-            )
+          adjustments.each do |adjustment|
+            amount, label = adjustment[:amount].to_f, adjustment[:label]
+            adjustment = order.adjustments.build(order: order, amount: amount, label: label)
             adjustment.save!
             adjustment.close!
           end

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -67,8 +67,8 @@ module Spree
               # trying to view these units. Note the Importer might not be
               # able to find the line item if line_item.variant_id |= iu.variant_id
               unit.variant_id = iu[:variant_id]
-              unit.line_item_id = line_items.select do |l|
-                l.variant_id.to_i == iu[:variant_id].to_i
+              unit.line_item_id = line_items.select do |line_item|
+                line_item.variant_id.to_i == iu[:variant_id].to_i
               end.first.try(:id)
             end
 

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -26,7 +26,7 @@ module Spree
             order.state = 'complete'
           end
 
-          params.delete(:user_id) unless user.try(:has_spree_role?, "admin") && params.key? :user_id
+          params.delete :user_id unless user.try(:has_spree_role?, "admin") && params.key?(:user_id)
 
           order.update_attributes!(params)
 

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -186,11 +186,9 @@ module Spree
         def self.ensure_variant_id_from_params(hash)
           sku = hash.delete(:sku)
           unless hash[:variant_id].present?
-            hash[:variant_id] = Spree::Variant.active.find_by_sku!(sku).id
+            hash[:variant_id] = Spree::Variant.active.find_by!(sku: sku).id
           end
           hash
-        rescue ActiveRecord::RecordNotFound => e
-          raise "Ensure order import variant: Variant w/SKU #{sku} not found."
         end
 
         def self.ensure_country_id_from_params(address)

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -83,8 +83,7 @@ module Spree
             shipment.save!
 
             shipping_method = Spree::ShippingMethod.find_by_name(s[:shipping_method]) || Spree::ShippingMethod.find_by_admin_name!(s[:shipping_method])
-            rate = shipment.shipping_rates.create!(:shipping_method => shipping_method,
-                                                   :cost => s[:cost])
+            rate = shipment.shipping_rates.create!(shipping_method: shipping_method, cost: s[:cost])
             shipment.selected_shipping_rate_id = rate.id
             shipment.update_amounts
           end

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -41,7 +41,7 @@ module Spree
             end
           end
           order.reload
-        ensure
+        rescue
           order.destroy if order && order.persisted?
         end
 

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -41,8 +41,9 @@ module Spree
             end
           end
           order.reload
-        rescue
+        rescue Exception => error
           order.destroy if order && order.persisted?
+          raise error
         end
 
         def self.create_shipments_from_params(shipments_hash, order)

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -4,47 +4,45 @@ module Spree
       class Order
 
         def self.import(user, params)
-          begin
-            ensure_country_id_from_params params[:ship_address_attributes]
-            ensure_state_id_from_params params[:ship_address_attributes]
-            ensure_country_id_from_params params[:bill_address_attributes]
-            ensure_state_id_from_params params[:bill_address_attributes]
+          ensure_country_id_from_params params[:ship_address_attributes]
+          ensure_state_id_from_params params[:ship_address_attributes]
+          ensure_country_id_from_params params[:bill_address_attributes]
+          ensure_state_id_from_params params[:bill_address_attributes]
 
-            create_params = params.slice :currency
-            order = Spree::Order.create! create_params
-            order.associate_user!(user)
+          create_params = params.slice :currency
+          order = Spree::Order.create! create_params
+          order.associate_user!(user)
 
-            shipments_attrs = params.delete(:shipments_attributes)
+          shipments_attrs = params.delete(:shipments_attributes)
 
-            create_shipments_from_params(shipments_attrs, order)
-            create_line_items_from_params(params.delete(:line_items_attributes),order)
-            create_shipments_from_params(params.delete(:shipments_attributes), order)
-            create_adjustments_from_params(params.delete(:adjustments_attributes), order)
-            create_payments_from_params(params.delete(:payments_attributes), order)
+          create_shipments_from_params(shipments_attrs, order)
+          create_line_items_from_params(params.delete(:line_items_attributes),order)
+          create_shipments_from_params(params.delete(:shipments_attributes), order)
+          create_adjustments_from_params(params.delete(:adjustments_attributes), order)
+          create_payments_from_params(params.delete(:payments_attributes), order)
 
-            if completed_at = params.delete(:completed_at)
-              order.completed_at = completed_at
-              order.state = 'complete'
-            end
-
-            params.delete(:user_id) unless user.try(:has_spree_role?, "admin") && params.key?(:user_id)
-
-            order.update_attributes!(params)
-
-            order.create_proposed_shipments unless shipments_attrs.present?
-
-            # Really ensure that the order totals & states are correct
-            order.updater.update
-            if shipments_attrs.present?
-              order.shipments.each_with_index do |shipment, index|
-                shipment.update_columns(cost: shipments_attrs[index][:cost].to_f) if shipments_attrs[index][:cost].present?
-              end
-            end
-            order.reload
-          rescue Exception => e
-            order.destroy if order && order.persisted?
-            raise e.message
+          if completed_at = params.delete(:completed_at)
+            order.completed_at = completed_at
+            order.state = 'complete'
           end
+
+          params.delete(:user_id) unless user.try(:has_spree_role?, "admin") && params.key?(:user_id)
+
+          order.update_attributes!(params)
+
+          order.create_proposed_shipments unless shipments_attrs.present?
+
+          # Really ensure that the order totals & states are correct
+          order.updater.update
+          if shipments_attrs.present?
+            order.shipments.each_with_index do |shipment, index|
+              shipment.update_columns(cost: shipments_attrs[index][:cost].to_f) if shipments_attrs[index][:cost].present?
+            end
+          end
+          order.reload
+        rescue Exception => e
+          order.destroy if order && order.persisted?
+          raise e.message
         end
 
         def self.create_shipments_from_params(shipments_hash, order)
@@ -52,48 +50,43 @@ module Spree
 
           line_items = order.line_items
           shipments_hash.each do |s|
-            begin
-              shipment = order.shipments.build
-              shipment.tracking       = s[:tracking]
-              shipment.stock_location = Spree::StockLocation.find_by_admin_name(s[:stock_location]) || Spree::StockLocation.find_by_name!(s[:stock_location])
+            shipment = order.shipments.build
+            shipment.tracking       = s[:tracking]
+            shipment.stock_location = Spree::StockLocation.find_by_admin_name(s[:stock_location]) || Spree::StockLocation.find_by_name!(s[:stock_location])
 
-              inventory_units = s[:inventory_units] || []
-              inventory_units.each do |iu|
-                ensure_variant_id_from_params(iu)
+            inventory_units = s[:inventory_units] || []
+            inventory_units.each do |iu|
+              ensure_variant_id_from_params(iu)
 
-                unit = shipment.inventory_units.build
-                unit.order = order
+              unit = shipment.inventory_units.build
+              unit.order = order
 
-                # Spree expects a Inventory Unit to always reference a line
-                # item and variant otherwise users might get exceptions when
-                # trying to view these units. Note the Importer might not be
-                # able to find the line item if line_item.variant_id |= iu.variant_id
-                unit.variant_id = iu[:variant_id]
-                unit.line_item_id = line_items.select do |l|
-                  l.variant_id.to_i == iu[:variant_id].to_i
-                end.first.try(:id)
-              end
-
-              # Mark shipped if it should be.
-              if s[:shipped_at].present?
-                shipment.shipped_at = s[:shipped_at]
-                shipment.state      = 'shipped'
-                shipment.inventory_units.each do |unit|
-                  unit.state = 'shipped'
-                end
-              end
-
-              shipment.save!
-
-              shipping_method = Spree::ShippingMethod.find_by_name(s[:shipping_method]) || Spree::ShippingMethod.find_by_admin_name!(s[:shipping_method])
-              rate = shipment.shipping_rates.create!(:shipping_method => shipping_method,
-                                                     :cost => s[:cost])
-              shipment.selected_shipping_rate_id = rate.id
-              shipment.update_amounts
-
-            rescue Exception => e
-              raise "Order import shipments: #{e.message} #{s}"
+              # Spree expects a Inventory Unit to always reference a line
+              # item and variant otherwise users might get exceptions when
+              # trying to view these units. Note the Importer might not be
+              # able to find the line item if line_item.variant_id |= iu.variant_id
+              unit.variant_id = iu[:variant_id]
+              unit.line_item_id = line_items.select do |l|
+                l.variant_id.to_i == iu[:variant_id].to_i
+              end.first.try(:id)
             end
+
+            # Mark shipped if it should be.
+            if s[:shipped_at].present?
+              shipment.shipped_at = s[:shipped_at]
+              shipment.state      = 'shipped'
+              shipment.inventory_units.each do |unit|
+                unit.state = 'shipped'
+              end
+            end
+
+            shipment.save!
+
+            shipping_method = Spree::ShippingMethod.find_by_name(s[:shipping_method]) || Spree::ShippingMethod.find_by_admin_name!(s[:shipping_method])
+            rate = shipment.shipping_rates.create!(:shipping_method => shipping_method,
+                                                   :cost => s[:cost])
+            shipment.selected_shipping_rate_id = rate.id
+            shipment.update_amounts
           end
         end
 
@@ -129,39 +122,23 @@ module Spree
             EOS
 
             line_items.each_key do |k|
-              begin
-                extra_params = line_items[k].except(:variant_id, :quantity, :sku)
-                line_item = ensure_variant_id_from_params(line_items[k])
-                variant = Spree::Variant.find(line_item[:variant_id])
-                line_item = order.contents.add(variant, line_item[:quantity])
-                # Raise any errors with saving to prevent import succeeding with line items
-                # failing silently.
-                if extra_params.present?
-                  line_item.update_attributes!(extra_params)
-                else
-                  line_item.save!
-                end
-              rescue Exception => e
-                raise "Order import line items: #{e.message} #{line_item}"
-              end
+              extra_params = line_items[k].except(:variant_id, :quantity, :sku)
+              line_item = ensure_variant_id_from_params(line_items[k])
+              variant = Spree::Variant.find(line_item[:variant_id])
+              line_item = order.contents.add(variant, line_item[:quantity])
+              # Raise any errors with saving to prevent import succeeding with line items
+              # failing silently.
+              extra_params.present? ? line_item.update_attributes!(extra_params) : line_item.save!
             end
           when Array
             line_items.each do |line_item|
-              begin
-                extra_params = line_item.except(:variant_id, :quantity, :sku)
-                line_item = ensure_variant_id_from_params(line_item)
-                variant = Spree::Variant.find(line_item[:variant_id])
-                line_item = order.contents.add(variant, line_item[:quantity])
-                # Raise any errors with saving to prevent import succeeding with line items
-                # failing silently.
-                if extra_params.present?
-                  line_item.update_attributes!(extra_params)
-                else
-                  line_item.save!
-                end
-              rescue Exception => e
-                raise "Order import line items: #{e.message} #{line_item}"
-              end
+              extra_params = line_item.except(:variant_id, :quantity, :sku)
+              line_item = ensure_variant_id_from_params(line_item)
+              variant = Spree::Variant.find(line_item[:variant_id])
+              line_item = order.contents.add(variant, line_item[:quantity])
+              # Raise any errors with saving to prevent import succeeding with line items
+              # failing silently.
+              extra_params.present? ? line_item.update_attributes!(extra_params) : line_item.save!
             end
           end
         end
@@ -169,117 +146,91 @@ module Spree
         def self.create_adjustments_from_params(adjustments, order)
           return [] unless adjustments
           adjustments.each do |a|
-            begin
-              adjustment = order.adjustments.build(
-                order:  order,
-                amount: a[:amount].to_f,
-                label:  a[:label]
-              )
-              adjustment.save!
-              adjustment.close!
-            rescue Exception => e
-              raise "Order import adjustments: #{e.message} #{a}"
-            end
+            adjustment = order.adjustments.build(
+              order:  order,
+              amount: a[:amount].to_f,
+              label:  a[:label]
+            )
+            adjustment.save!
+            adjustment.close!
           end
         end
 
         def self.create_payments_from_params(payments_hash, order)
           return [] unless payments_hash
           payments_hash.each do |p|
-            begin
-              payment = order.payments.build order: order
-              payment.amount = p[:amount].to_f
-              # Order API should be using state as that's the normal payment field.
-              # spree_wombat serializes payment state as status so imported orders should fall back to status field.
-              payment.state = p[:state] || p[:status] || 'completed'
-              payment.payment_method = Spree::PaymentMethod.find_by_name!(p[:payment_method])
-              payment.source = create_source_payment_from_params(p[:source], payment) if p[:source]
-              payment.save!
-            rescue Exception => e
-              raise "Order import payments: #{e.message} #{p}"
-            end
+            payment = order.payments.build order: order
+            payment.amount = p[:amount].to_f
+            # Order API should be using state as that's the normal payment field.
+            # spree_wombat serializes payment state as status so imported orders should fall back to status field.
+            payment.state = p[:state] || p[:status] || 'completed'
+            payment.payment_method = Spree::PaymentMethod.find_by_name!(p[:payment_method])
+            payment.source = create_source_payment_from_params(p[:source], payment) if p[:source]
+            payment.save!
           end
         end
 
         def self.create_source_payment_from_params(source_hash, payment)
-          begin
-            Spree::CreditCard.create(
-              month: source_hash[:month],
-              year: source_hash[:year],
-              cc_type: source_hash[:cc_type],
-              last_digits: source_hash[:last_digits],
-              name: source_hash[:name],
-              payment_method: payment.payment_method,
-              gateway_customer_profile_id: source_hash[:gateway_customer_profile_id],
-              gateway_payment_profile_id: source_hash[:gateway_payment_profile_id],
-              imported: true
-            )
-          rescue Exception => e
-            raise "Order import source payments: #{e.message} #{source_hash}"
-          end
+          Spree::CreditCard.create(
+            month: source_hash[:month],
+            year: source_hash[:year],
+            cc_type: source_hash[:cc_type],
+            last_digits: source_hash[:last_digits],
+            name: source_hash[:name],
+            payment_method: payment.payment_method,
+            gateway_customer_profile_id: source_hash[:gateway_customer_profile_id],
+            gateway_payment_profile_id: source_hash[:gateway_payment_profile_id],
+            imported: true
+          )
         end
 
         def self.ensure_variant_id_from_params(hash)
-          begin
-            sku = hash.delete(:sku)
-            unless hash[:variant_id].present?
-              hash[:variant_id] = Spree::Variant.active.find_by_sku!(sku).id
-            end
-            hash
-          rescue ActiveRecord::RecordNotFound => e
-            raise "Ensure order import variant: Variant w/SKU #{sku} not found."
-          rescue Exception => e
-            raise "Ensure order import variant: #{e.message} #{hash}"
+          sku = hash.delete(:sku)
+          unless hash[:variant_id].present?
+            hash[:variant_id] = Spree::Variant.active.find_by_sku!(sku).id
           end
+          hash
+        rescue ActiveRecord::RecordNotFound => e
+          raise "Ensure order import variant: Variant w/SKU #{sku} not found."
         end
 
         def self.ensure_country_id_from_params(address)
           return if address.nil? or address[:country_id].present? or address[:country].nil?
 
-          begin
-            search = {}
-            if name = address[:country]['name']
-              search[:name] = name
-            elsif iso_name = address[:country]['iso_name']
-              search[:iso_name] = iso_name.upcase
-            elsif iso = address[:country]['iso']
-              search[:iso] = iso.upcase
-            elsif iso3 = address[:country]['iso3']
-              search[:iso3] = iso3.upcase
-            end
-
-            address.delete(:country)
-            address[:country_id] = Spree::Country.where(search).first!.id
-
-          rescue Exception => e
-            raise "Ensure order import address country: #{e.message} #{search}"
+          search = {}
+          if name = address[:country]['name']
+            search[:name] = name
+          elsif iso_name = address[:country]['iso_name']
+            search[:iso_name] = iso_name.upcase
+          elsif iso = address[:country]['iso']
+            search[:iso] = iso.upcase
+          elsif iso3 = address[:country]['iso3']
+            search[:iso3] = iso3.upcase
           end
+
+          address.delete(:country)
+          address[:country_id] = Spree::Country.where(search).first!.id
         end
 
         def self.ensure_state_id_from_params(address)
           return if address.nil? or address[:state_id].present? or address[:state].nil?
 
-          begin
-            search = {}
-            if name = address[:state]['name']
-              search[:name] = name
-            elsif abbr = address[:state]['abbr']
-              search[:abbr] = abbr.upcase
-            end
+          search = {}
+          if name = address[:state]['name']
+            search[:name] = name
+          elsif abbr = address[:state]['abbr']
+            search[:abbr] = abbr.upcase
+          end
 
-            address.delete(:state)
-            search[:country_id] = address[:country_id]
+          address.delete(:state)
+          search[:country_id] = address[:country_id]
 
-            if state = Spree::State.where(search).first
-              address[:state_id] = state.id
-            else
-              address[:state_name] = search[:name] || search[:abbr]
-            end
-          rescue Exception => e
-            raise "Ensure order import address state: #{e.message} #{search}"
+          if state = Spree::State.where(search).first
+            address[:state_id] = state.id
+          else
+            address[:state_name] = search[:name] || search[:abbr]
           end
         end
-
       end
     end
   end

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -193,7 +193,7 @@ module Spree
         end
 
         def self.ensure_country_id_from_params(address)
-          return if address.nil? or address[:country_id].present? or address[:country].nil?
+          return if address.nil? || address[:country_id].present? || address[:country].nil?
 
           search = {}
           if name = address[:country]['name']

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -125,13 +125,6 @@ module Spree
         expect(line_item.quantity).to eq(5)
       end
 
-      it 'handles exceptions when sku is not found' do
-        params = { line_items_attributes: [{ sku: 'XXX', quantity: 5 }] }
-        expect {
-          order = Importer::Order.import(user,params)
-        }.to raise_error /XXX/
-      end
-
       it 'can build an order from API shipping address' do
         params = { :ship_address_attributes => ship_address,
                    :line_items_attributes => line_items }
@@ -148,17 +141,6 @@ module Spree
 
         order = Importer::Order.import(user,params)
         expect(order.ship_address.country.iso).to eq 'US'
-      end
-
-      it 'handles country lookup exceptions' do
-        ship_address.delete(:country_id)
-        ship_address[:country] = { 'iso' => 'XXX' }
-        params = { :ship_address_attributes => ship_address,
-                   :line_items_attributes => line_items }
-
-        expect {
-          order = Importer::Order.import(user,params)
-        }.to raise_error /XXX/
       end
 
       it 'can build an order from API with state attributes' do
@@ -254,13 +236,6 @@ module Spree
         end
       end
 
-      it "raises with proper message when cant find country" do
-        address = { country: { "name" => "NoNoCountry" } }
-        expect {
-          Importer::Order.ensure_country_id_from_params(address)
-        }.to raise_error /NoNoCountry/
-      end
-
       it 'ensures_state_id for state fields' do
         [:name, :abbr].each do |field|
           address = { country_id: country.id, state: { field => state.send(field) } }
@@ -352,15 +327,6 @@ module Spree
         end
       end
 
-      it 'handles shipment building exceptions' do
-        params = { :shipments_attributes => [{ tracking: '123456789',
-                                               cost: '4.99',
-                                               shipping_method: 'XXX',
-                                               inventory_units: [{ sku: sku }]
-                                             }] }
-        expect { Importer::Order.import(user, params) }.to raise_error /XXX/
-      end
-
       it 'adds adjustments' do
         params = { adjustments_attributes: [
             { label: 'Shipping Discount', amount: -4.99 },
@@ -391,16 +357,6 @@ module Spree
         expect(order.total).to eq(163.1) # = item_total (166.1) - adjustment_total (3.00)
       end
 
-      it 'handles adjustment building exceptions' do
-        params = { :adjustments_attributes => [
-            { amount: 'XXX' },
-            { label: 'Promotion Discount', amount: '-3.00' }] }
-
-        expect {
-          order = Importer::Order.import(user,params)
-        }.to raise_error /XXX/
-      end
-
       it 'builds a payment using state' do
         params = { :payments_attributes => [{ amount: '4.99',
                                               payment_method: payment_method.name,
@@ -415,14 +371,6 @@ module Spree
                                               status: 'completed' }] }
         order = Importer::Order.import(user,params)
         expect(order.payments.first.amount).to eq 4.99
-      end
-
-      it 'handles payment building exceptions' do
-        params = { :payments_attributes => [{ amount: '4.99',
-                                              payment_method: 'XXX' }] }
-        expect {
-          order = Importer::Order.import(user, params)
-        }.to raise_error /XXX/
       end
 
       it 'build a source payment using years and month' do


### PR DESCRIPTION
I've been working with with `Spree::Core::Importer::Order` lately and the amount of exception handling has led to some painful debugging. I didn't really understand why the `rescue`s were being called in a large amount of the methods. It was simply capturing a highly detailed ruby message, and then reraising a message that wasn't so helpful. When I submitting a poor payment, the error message was:

``` ruby
2.2.0 :131 > order_importer.create_payments_from_params params, order
RuntimeError: Order import payments: no implicit conversion of Symbol into Integer [:amount, #<BigDecimal:7fdfbc9d54d8,'0.16E2',9(18)>]
    from /Users/benmorgan/.rvm/gems/ruby-2.2.0/bundler/gems/spree-47d064d3faa3/core/lib/spree/core/importer/order.rb:199:in `rescue in block in create_payments_from_params'
    from /Users/benmorgan/.rvm/gems/ruby-2.2.0/bundler/gems/spree-47d064d3faa3/core/lib/spree/core/importer/order.rb:189:in `block in create_payments_from_params'
    from /Users/benmorgan/.rvm/gems/ruby-2.2.0/bundler/gems/spree-47d064d3faa3/core/lib/spree/core/importer/order.rb:188:in `each'
    from /Users/benmorgan/.rvm/gems/ruby-2.2.0/bundler/gems/spree-47d064d3faa3/core/lib/spree/core/importer/order.rb:188:in `create_payments_from_params'
    from (irb):131
    from /Users/benmorgan/.rvm/gems/ruby-2.2.0/gems/railties-4.2.0/lib/rails/commands/console.rb:110:in `start'
    from /Users/benmorgan/.rvm/gems/ruby-2.2.0/gems/railties-4.2.0/lib/rails/commands/console.rb:9:in `start'
    from /Users/benmorgan/.rvm/gems/ruby-2.2.0/gems/zeus-0.15.4/lib/zeus/rails.rb:136:in `console'
    from /Users/benmorgan/.rvm/gems/ruby-2.2.0/gems/zeus-0.15.4/lib/zeus.rb:148:in `block in command'
    from /Users/benmorgan/.rvm/gems/ruby-2.2.0/gems/zeus-0.15.4/lib/zeus.rb:135:in `fork'
    from /Users/benmorgan/.rvm/gems/ruby-2.2.0/gems/zeus-0.15.4/lib/zeus.rb:135:in `command'
    from /Users/benmorgan/.rvm/gems/ruby-2.2.0/gems/zeus-0.15.4/lib/zeus.rb:50:in `go'
    from -e:1:in `<main>'
```

What line did this error occur on? 199 is where the `raise` was and 189 is where the `begin` was. `raise` also adds a lot of overheard in a ruby program. Usually adding a toll to the performance.

This PR removes an anti-patten from Spree.
