### PR TITLE
Add index to SpreeStockItem variant_id

### DIFF
--- a/core/db/migrate/20150216173445_add_index_to_spree_stock_items_variant_id.rb
+++ b/core/db/migrate/20150216173445_add_index_to_spree_stock_items_variant_id.rb
@@ -1,0 +1,13 @@
+class AddIndexToSpreeStockItemsVariantId < ActiveRecord::Migration
+  def up
+    unless index_exists? :spree_stock_items, :variant_id
+      add_index :spree_stock_items, :variant_id
+    end
+  end
+
+  def down
+    if index_exists? :spree_stock_items, :variant_id
+      remove_index :spree_stock_items, :variant_id
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/spree/spree/blob/d76a3b57887660ef60635130589c787c1c9cc8e6/core/app/models/spree/return_item/exchange_variant_eligibility/same_product.rb#L5

Produces this SQL

```
SELECT 'spree_variants'.*
FROM 'spree_variants'
  INNER JOIN 'spree_stock_items'
  ON 'spree_stock_items'.'variant_id' = 'spree_variants'.'id'  # <-- Here
  AND 'spree_stock_items'.'deleted_at' IS NULL
WHERE 'spree_variants'.'deleted_at' IS NULL
  AND 'spree_variants'.'product_id' = 193159
  AND 'spree_variants'.'is_master' = 0
  AND (count_on_hand > 0 OR track_inventory = 0)
```
