### PR TITLE
add missing product and taxon translations

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -606,6 +606,7 @@ en:
     default_tax: Default Tax
     default_tax_zone: Default Tax Zone
     delete: Delete
+    delete_from_taxon: Delete from Taxon
     deleted_variants_present: Some line items in this order have products that are no longer available.
     delivery: Delivery
     depth: Depth
@@ -618,6 +619,7 @@ en:
     display: Display
     doesnt_track_inventory: It doesnt track inventory
     edit: Edit
+    edit_product: Edit Product
     editing_resource: 'Editing %{resource}'
     editing_rma_reason: Editing RMA Reason
     editing_user: Editing User


### PR DESCRIPTION
I was looking at some CircleCI output and noticed the missing translations:

![screen shot 2015-02-17 at 9 41 41 am](https://cloud.githubusercontent.com/assets/3117356/6233683/8a3534e0-b689-11e4-84a9-7c5b3c099fb2.png)
