### PR TITLE
Added some missing translation keys

### DIFF
--- a/backend/app/views/spree/admin/products/_autocomplete.js.erb
+++ b/backend/app/views/spree/admin/products/_autocomplete.js.erb
@@ -6,7 +6,7 @@
         <span class="caret"></span>
       </button>
       <ul class="dropdown-menu" role="menu" data-hook="taxon_product_dropdown">
-        <li><a href="javascript:;" class="edit-product js-edit-product"><%= Spree.t(:edit_product) %></a></li>
+        <li><a href="javascript:;" class="edit-product js-edit-product"><%= Spree.t(:edit) %></a></li>
         <li><a href="javascript:;" class="delete-product js-delete-product"><%= Spree.t(:delete_from_taxon) %></a></li>
       </ul>
     </div>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -606,6 +606,7 @@ en:
     default_tax: Default Tax
     default_tax_zone: Default Tax Zone
     delete: Delete
+    delete_from_taxon: Delete From Taxon
     deleted_variants_present: Some line items in this order have products that are no longer available.
     delivery: Delivery
     depth: Depth
@@ -826,6 +827,7 @@ en:
     new_refund_reason: New Refund Reason
     new_rma_reason: New RMA Reason
     new_return_authorization: New Return Authorization
+    new_role: New Role
     new_shipping_category: New Shipping Category
     new_shipping_method: New Shipping Method
     new_shipment_at_location: New shipment at location
@@ -1132,6 +1134,7 @@ en:
     rma_credit: RMA Credit
     rma_number: RMA Number
     rma_value: RMA Value
+    role_id: Role ID
     roles: Roles
     rules: Rules
     safe: Safe


### PR DESCRIPTION
To get rid messages like

```
Found missing translations: [["spree.new_role"], ["spree.role_id"]]
In spec: ./spec/features/admin/configuration/roles_spec.rb:15
```

and to allow translate them in spree_i18n.
