### PR TITLE
Bump cancancan version to get rid deprecation warnings

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'acts_as_list', '~> 0.6'
   s.add_dependency 'awesome_nested_set', '~> 3.0.1'
   s.add_dependency 'carmen', '~> 1.0.0'
-  s.add_dependency 'cancancan', '~> 1.9.2'
+  s.add_dependency 'cancancan', '~> 1.10.1'
   s.add_dependency 'deface', '~> 1.0.0'
   s.add_dependency 'ffaker', '~> 1.16'
   s.add_dependency 'font-awesome-rails', '~> 4.0'


### PR DESCRIPTION
Bump cancancan version to get rid deprecation warnings like this:
`DEPRECATION WARNING: sanitize_sql_hash_for_conditions is deprecated, and will be removed in Rails 5.0`
