### PR TITLE
add states constant to order model

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -4,6 +4,9 @@ require 'spree/order/checkout'
 module Spree
   class Order < Spree::Base
     extend FriendlyId
+
+    STATES = ['cart', 'address', 'delivery', 'payment', 'confirm', 'complete']
+
     friendly_id :number, slug_column: :number, use: :slugged
 
     include Spree::Order::Checkout

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -14,6 +14,8 @@ describe Spree::Order, :type => :model do
     allow(Spree::LegacyUser).to receive_messages(:current => mock_model(Spree::LegacyUser, :id => 123))
   end
 
+  its(:class) { should be_const_defined(:STATES) }
+
   context "#canceled_by" do
     let(:admin_user) { create :admin_user }
     let(:order) { create :order }


### PR DESCRIPTION
Something I've always been looking for in Spree is an array to list the states an order could be in, so, here it is.
