### PR TITLE
switch calls so that completed? predicate is called first

### DIFF
--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -35,7 +35,7 @@ module Spree
 
           return if after_update_attributes
 
-          if @order.next || @order.completed?  
+          if @order.completed? || @order.next
             state_callback(:after)
             respond_with(@order, default_template: 'spree/api/orders/show')
           else


### PR DESCRIPTION
This is an interesting bug fix.

When you submit an order to the API that is completed, then you would receive:

``` json
{
    "error": "Invalid resource. Please fix errors and try again.",
    "errors": {
        "state": [
            "cannot transition via \"next\""
        ]
    }
}
```

I've switched the two methods around so that `completed?` is called first instead of `#next`.
