### PR TITLE
Spree Issue #5842 - Fix i18n for pluralized resource names in backend

### DIFF
--- a/backend/app/helpers/spree/admin/base_helper.rb
+++ b/backend/app/helpers/spree/admin/base_helper.rb
@@ -135,6 +135,11 @@ module Spree
         dom_id(record, 'spree')
       end
 
+      I18N_PLURAL_MANY_COUNT = 2.1
+      def plural_resource_name(resource_class)
+        resource_class.model_name.human(count: I18N_PLURAL_MANY_COUNT)
+      end
+
       private
         def attribute_name_for(field_name)
           field_name.gsub(' ', '_').downcase

--- a/backend/app/views/spree/admin/adjustments/index.html.erb
+++ b/backend/app/views/spree/admin/adjustments/index.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: 'spree/admin/shared/order_tabs', locals: { current: Spree.t(:adjustments)} %>
 
 <% content_for :page_title do %>
-   / <%= Spree::Adjustment.model_name.human(count: :many) %>
+   / <%= plural_resource_name(Spree::Adjustment) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -14,7 +14,7 @@
   </div>
 <% else %>
   <div class="alert alert-warning">
-    <%= Spree.t(:no_resource_found, resource: Spree::Adjustment.model_name.human(count: :many)) %>
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::Adjustment)) %>
   </div>
 <% end %>
 

--- a/backend/app/views/spree/admin/countries/index.html.erb
+++ b/backend/app/views/spree/admin/countries/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree::Country.model_name.human(count: :many) %>
+  <%= plural_resource_name(Spree::Country) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/customer_returns/edit.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/edit.html.erb
@@ -50,12 +50,12 @@
 <% end %>
 
 <fieldset data-hook="reimbursements">
-  <legend><%= Spree::Reimbursement.model_name.human(count: :many) %></legend>
+  <legend><%= plural_resource_name(Spree::Reimbursement) %></legend>
   <% if @customer_return.reimbursements.any? %>
     <%= render partial: 'reimbursements_table', locals: {reimbursements: @customer_return.reimbursements} %>
   <% else %>
     <div class="alert alert-info no-objects-found">
-      <%= Spree.t(:no_resource_found, resource: Spree::Reimbursement.model_name.human(count: :many)) %>
+      <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::Reimbursement)) %>
     </div>
   <% end %>
 </fieldset>

--- a/backend/app/views/spree/admin/customer_returns/index.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/index.html.erb
@@ -7,7 +7,7 @@
 <% end %>
 
 <% content_for :page_title do %>
-  / <%= Spree::CustomerReturn.model_name.human(count: :many) %>
+  / <%= plural_resource_name(Spree::CustomerReturn) %>
 <% end %>
 
 <% if @order.shipments.any?(&:shipped?) %>
@@ -45,7 +45,7 @@
     </table>
   <% else %>
     <div class="alert alert-info no-objects-found">
-      <%= Spree.t(:no_resource_found, resource: Spree::CustomerReturn.model_name.human(count: :many)) %>,
+      <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::CustomerReturn)) %>,
       <%= link_to(Spree.t(:add_one), spree.new_admin_order_customer_return_path(@order)) if can?(:create, Spree::CustomerReturn) %>!
     </div>
   <% end %>

--- a/backend/app/views/spree/admin/images/index.html.erb
+++ b/backend/app/views/spree/admin/images/index.html.erb
@@ -8,7 +8,7 @@
 
 <% unless @product.variant_images.any? %>
   <div class="alert alert-warning">
-    <%= Spree.t(:no_resource_found, resource: Spree::Image.model_name.human(count: :many)) %>.
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::Image)) %>.
   </div>
 <% else %>
   <table class="table sortable" data-hook="images_table" data-sortable-link="<%= update_positions_admin_product_images_url(@product) %>">

--- a/backend/app/views/spree/admin/option_types/index.html.erb
+++ b/backend/app/views/spree/admin/option_types/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree::OptionType.model_name.human(count: :many) %>
+  <%= plural_resource_name(Spree::OptionType) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -38,7 +38,7 @@
 </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: Spree::OptionType.model_name.human(count: :many)) %>,
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::OptionType)) %>,
     <%= link_to Spree.t(:add_one), new_object_url %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/orders/edit.html.erb
+++ b/backend/app/views/spree/admin/orders/edit.html.erb
@@ -10,7 +10,7 @@
 <%= render partial: 'spree/admin/shared/order_tabs', locals: { current: 'Shipments' } %>
 
 <% content_for :page_title do %>
-  / <%= Spree::Shipment.model_name.human(count: :many) %>
+  / <%= plural_resource_name(Spree::Shipment) %>
 <% end %>
 
 <div data-hook="admin_order_edit_header">

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree::Order.model_name.human(count: :many) %>
+  <%= plural_resource_name(Spree::Order) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -216,7 +216,7 @@
   </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: Spree::Order.model_name.human(count: :many)) %>,
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::Order)) %>,
     <%= link_to(Spree.t(:add_one), new_admin_order_url) if can? :create, Spree::Order %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/payment_methods/index.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree::PaymentMethod.model_name.human(count: :many) %>
+  <%= plural_resource_name(Spree::PaymentMethod) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -34,7 +34,7 @@
   </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: Spree::PaymentMethod.model_name.human(count: :many)) %>,
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::PaymentMethod)) %>,
     <%= link_to(Spree.t(:add_one), new_object_url) if can? :create, Spree::PaymentMethod %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree::Product.model_name.human(count: :many) %>
+  <%= plural_resource_name(Spree::Product) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -73,7 +73,7 @@
   </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: Spree::Product.model_name.human(count: :many)) %>,
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::Product)) %>,
     <%= link_to Spree.t(:add_one), new_object_url %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/promotion_categories/index.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree::PromotionCategory.model_name.human(count: :many) %>
+  <%= plural_resource_name(Spree::PromotionCategory) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -28,7 +28,7 @@
   </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: Spree::PromotionCategory.model_name.human(count: :many)) %>,
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::PromotionCategory)) %>,
     <%= link_to Spree.t(:add_one), new_object_url %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/promotions/index.html.erb
+++ b/backend/app/views/spree/admin/promotions/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree::Promotion.model_name.human(count: :many) %>
+  <%= plural_resource_name(Spree::Promotion) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -76,7 +76,7 @@
   </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: Spree::Promotion.model_name.human(count: :many)) %>,
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::Promotion)) %>,
     <%= link_to Spree.t(:add_one), new_object_url %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/properties/index.html.erb
+++ b/backend/app/views/spree/admin/properties/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree::Property.model_name.human(count: :many) %>
+  <%= plural_resource_name(Spree::Property) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -60,7 +60,7 @@
   </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: Spree::Property.model_name.human(count: :many)) %>,
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::Property)) %>,
     <%= link_to Spree.t(:add_one), new_object_url %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/prototypes/index.html.erb
+++ b/backend/app/views/spree/admin/prototypes/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree::Prototype.model_name.human(count: :many) %>
+  <%= plural_resource_name(Spree::Prototype) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -28,7 +28,7 @@
   </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: Spree::Prototype.model_name.human(count: :many)) %>,
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::Prototype)) %>,
     <%= link_to Spree.t(:add_one), new_object_url %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/refund_reasons/index.html.erb
+++ b/backend/app/views/spree/admin/refund_reasons/index.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: 'spree/admin/shared/named_types/index', locals: {
-  page_title: Spree::RefundReason.model_name.human(count: :many),
+  page_title: plural_resource_name(Spree::RefundReason),
   new_button_text: Spree.t(:new_refund_reason),
-  resource_name: Spree::RefundReason.model_name.human(count: :many),
+  resource_name: plural_resource_name(Spree::RefundReason),
   resource: Spree::RefundReason
 } %>

--- a/backend/app/views/spree/admin/reimbursement_types/index.html.erb
+++ b/backend/app/views/spree/admin/reimbursement_types/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree::ReimbursementType.model_name.human(count: :many) %>
+  <%= plural_resource_name(Spree::ReimbursementType) %>
 <% end %>
 
 <% if @reimbursement_types.any? %>
@@ -25,6 +25,6 @@
   </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: Spree::ReimbursementType.model_name.human(count: :many)) %>
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::ReimbursementType)) %>
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/return_authorization_reasons/index.html.erb
+++ b/backend/app/views/spree/admin/return_authorization_reasons/index.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: 'spree/admin/shared/named_types/index', locals: {
-  page_title: Spree::ReturnAuthorizationReason.model_name.human(count: :many),
+  page_title: plural_resource_name(Spree::ReturnAuthorizationReason),
   new_button_text: Spree.t(:new_rma_reason),
-  resource_name: Spree::ReturnAuthorizationReason.model_name.human(count: :many),
+  resource_name: plural_resource_name(Spree::ReturnAuthorizationReason),
   resource: Spree::RefundReason
 } %>

--- a/backend/app/views/spree/admin/return_authorizations/index.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/index.html.erb
@@ -40,7 +40,7 @@
   </table>
 <% elsif @order.shipments.any?(&:shipped?) %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: Spree::ReturnAuthorization.model_name.human(count: :many)) %>
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::ReturnAuthorization)) %>
   </div>
 <% else %>
   <div data-hook="rma_cannont_create" class="alert alert-info no-objects-found">

--- a/backend/app/views/spree/admin/roles/index.html.erb
+++ b/backend/app/views/spree/admin/roles/index.html.erb
@@ -28,7 +28,7 @@
   </table>
 <% else %>
   <div class="alert alert-warning">
-    <%= Spree.t(:no_resource_found, resource: Spree::Role.model_name.human(count: :many)) %>,
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::Role)) %>,
     <%= link_to(Spree.t(:add_one), new_object_url) if can? :create, Spree::Role %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/shipping_categories/index.html.erb
+++ b/backend/app/views/spree/admin/shipping_categories/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree::ShippingCategory.model_name.human(count: :many) %>
+  <%= plural_resource_name(Spree::ShippingCategory) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -28,7 +28,7 @@
   </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: Spree::ShippingCategory.model_name.human(count: :many)) %>,
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::ShippingCategory)) %>,
     <%= link_to(Spree.t(:add_one), new_object_url) if can? :create, Spree::ShippingCategory %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/shipping_methods/index.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree::ShippingMethod.model_name.human(count: :many) %>
+  <%= plural_resource_name(Spree::ShippingMethod) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -34,7 +34,7 @@
   </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: Spree::ShippingMethod.model_name.human(count: :many)) %>,
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::ShippingMethod)) %>,
     <%= link_to(Spree.t(:add_one), new_object_url) if can? :create, Spree::PaymentMethod %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/state_changes/index.html.erb
+++ b/backend/app/views/spree/admin/state_changes/index.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: 'spree/admin/shared/order_tabs', locals: { current: 'State Changes' } %>
 
 <% content_for :page_title do %>
-  <%= Spree::StateChange.model_name.human(count: :many) %>
+  <%= plural_resource_name(Spree::StateChange) %>
 <% end %>
 
 <% if @state_changes.any? %>

--- a/backend/app/views/spree/admin/states/index.html.erb
+++ b/backend/app/views/spree/admin/states/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree::State.model_name.human(count: :many) %>
+  <%= plural_resource_name(Spree::State) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/stock_locations/index.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree::StockLocation.model_name.human(count: :many) %>
+  <%= plural_resource_name(Spree::StockLocation) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -35,7 +35,7 @@
   </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: Spree::StockLocation.model_name.human(count: :many)) %>,
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::StockLocation)) %>,
     <%= link_to(Spree.t(:add_one), new_object_url) if can? :create, Spree::StockLocation %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/stock_movements/index.html.erb
+++ b/backend/app/views/spree/admin/stock_movements/index.html.erb
@@ -35,7 +35,7 @@
 </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: Spree::StockMovement.model_name.human(count: :many)) %>,
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::StockMovement)) %>,
     <%= link_to Spree.t(:add_one), spree.new_admin_stock_location_stock_movement_path(@stock_location) %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/stock_transfers/index.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree::StockTransfer.model_name.human(count: :many) %>
+  <%= plural_resource_name(Spree::StockTransfer) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -74,7 +74,7 @@
   </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: Spree::StockTransfer.model_name.human(count: :many)) %>,
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::StockTransfer)) %>,
     <%= link_to(Spree.t(:add_one), new_object_url) if can? :create, Spree::StockTransfer %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/stock_transfers/show.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree::StockTransfer.model_name.human(count: :many) %> (<%= @stock_transfer.number %>)
+  <%= plural_resource_name(Spree::StockTransfer) %> (<%= @stock_transfer.number %>)
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/tax_categories/index.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree::TaxCategory.model_name.human(count: :many) %>
+  <%= plural_resource_name(Spree::TaxCategory) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -36,7 +36,7 @@
 </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: Spree::TaxCategory.model_name.human(count: :many)) %>,
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::TaxCategory)) %>,
     <%= link_to(Spree.t(:add_one), new_object_url) if can? :create, Spree::TaxCategory %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/tax_rates/index.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree::TaxRate.model_name.human(count: :many) %>
+  <%= plural_resource_name(Spree::TaxRate) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -40,7 +40,7 @@
   </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: Spree::TaxRate.model_name.human(count: :many)) %>,
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::TaxRate)) %>,
     <%= link_to(Spree.t(:add_one), new_object_url) if can? :create, Spree::TaxRate %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/taxonomies/index.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree::Taxonomy.model_name.human(count: :many) %>
+  <%= plural_resource_name(Spree::Taxonomy) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -12,7 +12,7 @@
   </div>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: Spree::Taxonomy.model_name.human(count: :many)) %>,
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::Taxonomy)) %>,
     <%= link_to Spree.t(:add_one), new_object_url %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/trackers/index.html.erb
+++ b/backend/app/views/spree/admin/trackers/index.html.erb
@@ -36,7 +36,7 @@
   </table>
 <% else %>
   <div class="alert alert-warning">
-    <%= Spree.t(:no_resource_found, resource: Spree::Tracker.model_name.human(count: :many)) %>,
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::Tracker)) %>,
     <%= link_to(Spree.t(:add_one), new_object_url) if can? :create, Spree::Tracker %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/users/addresses.html.erb
+++ b/backend/app/views/spree/admin/users/addresses.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= link_to "#{@user.email}", edit_admin_user_url(@user) %> / <%= Spree.t(:editing_resource, resource: Spree::Address.model_name.human(count: :many)) %>
+  <%= link_to "#{@user.email}", edit_admin_user_url(@user) %> / <%= Spree.t(:editing_resource, resource: plural_resource_name(Spree::Address)) %>
 <% end %>
 
 <%= render :partial => 'spree/admin/users/sidebar', :locals => { :current => :address } %>

--- a/backend/app/views/spree/admin/users/items.html.erb
+++ b/backend/app/views/spree/admin/users/items.html.erb
@@ -53,7 +53,7 @@
     </table>
   <% else %>
     <div class="alert alert-info no-objects-found">
-      <%= Spree.t(:no_resource_found, resource: Spree::Order.model_name.human(count: :many)) %>,
+      <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::Order)) %>,
       <%= link_to Spree.t(:add_one), spree.new_admin_order_path %>!
     </div>
   <% end %>

--- a/backend/app/views/spree/admin/users/orders.html.erb
+++ b/backend/app/views/spree/admin/users/orders.html.erb
@@ -40,7 +40,7 @@
     </table>
   <% else %>
     <div class="alert alert-info no-objects-found">
-      <%= Spree.t(:no_resource_found, resource: Spree::Order.model_name.human(count: :many)) %>,
+      <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::Order)) %>,
       <%= link_to Spree.t(:add_one), spree.new_admin_order_path %>!
     </div>
   <% end %>

--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -39,7 +39,7 @@
   </table>
 <% else %>
   <div class="no-objects-found alert alert-info">
-    <%= Spree.t(:no_resource_found, resource: Spree::Variant.model_name.human(count: :many)) %>,
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::Variant)) %>,
     <%= link_to(Spree.t(:add_one), spree.new_admin_product_variant_path(@product)) if can? :create, Spree::Variant %>!
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/zones/index.html.erb
+++ b/backend/app/views/spree/admin/zones/index.html.erb
@@ -36,7 +36,7 @@
   </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: Spree::Zone.model_name.human(count: :many)) %>,
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::Zone)) %>,
     <%= link_to(Spree.t(:add_one), new_object_url) if can? :create, Spree::Zone %>!
   </div>
 <% end %>

--- a/backend/spec/helpers/admin/base_helper_spec.rb
+++ b/backend/spec/helpers/admin/base_helper_spec.rb
@@ -15,4 +15,10 @@ describe Spree::Admin::BaseHelper, :type => :helper do
     end
   end
 
+  context "#plural_resource_name" do
+    it "should return correct form of class" do
+      resource_class = Spree::Product
+      expect(plural_resource_name(resource_class)).to eq("Products")
+    end
+  end
 end


### PR DESCRIPTION
Fixes #5842 and it's done similar way to https://github.com/activeadmin/activeadmin/pull/2791

It is strongly useful for languages with custom pluralization mechanisms in rails_i18n gem (e.g. Russian, Polish...)

I believe it can be applied to multiple branches. 

If I screwed anything let me know. It's my first contribution to **spree** project. 
