### PR TITLE
Added admin return index screens

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_labels.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_labels.scss
@@ -7,7 +7,8 @@
 .label-ready,
 .label-active,
 .label-success,
-.label-sold
+.label-sold,
+.label-authorized
 {
   background-color: $brand-success;
 

--- a/backend/app/assets/stylesheets/spree/backend/components/_page_header.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_page_header.scss
@@ -9,14 +9,16 @@
 
   &.with-page-tabs {
     border-bottom: 0;
-    padding-bottom: 0;
     margin-bottom: 6px;
+    padding-bottom: 0;
+
     h1 {
       margin-bottom: 8px;
     }
+
     .nav-tabs {
-      padding-top: 15px;
       padding-left: 15px;
+      padding-top: 15px;
     }
   }
 

--- a/backend/app/assets/stylesheets/spree/backend/components/_page_header.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_page_header.scss
@@ -7,6 +7,19 @@
     line-height: 38px;
   }
 
+  &.with-page-tabs {
+    border-bottom: 0;
+    padding-bottom: 0;
+    margin-bottom: 6px;
+    h1 {
+      margin-bottom: 8px;
+    }
+    .nav-tabs {
+      padding-top: 15px;
+      padding-left: 15px;
+    }
+  }
+
   .page-actions {
     text-align: right;
 

--- a/backend/app/controllers/spree/admin/return_index_controller.rb
+++ b/backend/app/controllers/spree/admin/return_index_controller.rb
@@ -1,0 +1,46 @@
+module Spree
+  module Admin
+    class ReturnIndexController < BaseController
+      define_callbacks :load_collection
+      #set_callback :load_collection, :after, :paginate_collection
+      set_callback :load_collection, :after, :search
+
+      def return_authorizations
+        @collection = collection(Spree::ReturnAuthorization)
+        respond_with(@collection)
+      end
+
+      def customer_returns
+        @collection = collection(Spree::CustomerReturn)
+        respond_with(@collection)
+      end
+
+      private
+
+      def collection(resource)
+        return @collection if @collection.present?
+        params[:q] ||= {}
+
+        @collection = resource.all
+        # @search needs to be defined as this is passed to search_form_for
+        @search = @collection.ransack(params[:q])
+        @collection = @search.result.
+              page(params[:page]).
+              per(params[:per_page] || Spree::Config[:admin_products_per_page])
+
+        @collection
+      end
+
+      def paginate_collection
+        @collection = @collection.order(id: :desc).
+          page(params[:page]).
+          per(params[:per_page] || Spree::Config[:admin_products_per_page])
+      end
+
+      def search
+        @search = @collection.ransack(params[:q])
+        @collection = @search.result
+      end
+    end
+  end
+end

--- a/backend/app/controllers/spree/admin/return_index_controller.rb
+++ b/backend/app/controllers/spree/admin/return_index_controller.rb
@@ -1,10 +1,6 @@
 module Spree
   module Admin
     class ReturnIndexController < BaseController
-      define_callbacks :load_collection
-      #set_callback :load_collection, :after, :paginate_collection
-      set_callback :load_collection, :after, :search
-
       def return_authorizations
         @collection = collection(Spree::ReturnAuthorization)
         respond_with(@collection)
@@ -29,17 +25,6 @@ module Spree
               per(params[:per_page] || Spree::Config[:admin_products_per_page])
 
         @collection
-      end
-
-      def paginate_collection
-        @collection = @collection.order(id: :desc).
-          page(params[:page]).
-          per(params[:per_page] || Spree::Config[:admin_products_per_page])
-      end
-
-      def search
-        @search = @collection.ransack(params[:q])
-        @collection = @search.result
       end
     end
   end

--- a/backend/app/views/spree/admin/return_index/customer_returns.html.erb
+++ b/backend/app/views/spree/admin/return_index/customer_returns.html.erb
@@ -1,0 +1,60 @@
+<% content_for :page_title do %>
+  <%= Spree.t(:customer_returns) %>
+<% end %>
+
+<% content_for :table_filter do %>
+  <div data-hook="admin_return_authorisations_index_filters">
+    <%= search_form_for [:admin, @search], url: admin_customer_returns_index_path do |f| %>
+      <div class="row">
+        <div class="col-md-12">
+          <div class="form-group">
+            <%= f.label :number_cont, Spree.t(:number) %>
+            <%= f.text_field :number_cont, class: "form-control js-quick-search-target" %>
+          </div>
+        </div>
+      </div>
+      <div data-hook="admin_return_authorisations_index_filters_buttons" class="form-actions">
+        <%= button Spree.t(:search), 'search' %>
+      </div>
+    <% end %>
+  </div>
+<% end %>
+
+<% if @collection.any? %>
+  <table class="table">
+    <thead>
+      <tr data-hook="rate_header">
+        <th><%= Spree.t(:created_at) %></th>
+        <th><%= Spree.t(:number) %></th>
+        <th><%= Spree.t(:order) %></th>
+        <th><%= Spree.t(:reimbursement_status) %></th>
+        <th><%= Spree.t(:pre_tax_total) %></th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @collection.each do |customer_return| %>
+        <tr id="<%= spree_dom_id customer_return %>" data-hook="customer_return_row">
+          <td><%= customer_return.created_at.to_date %></td>
+          <td><%= link_to customer_return.number, edit_admin_order_customer_return_path(customer_return.order, customer_return) %></td>
+          <td><%= link_to customer_return.order.number, edit_admin_order_path(customer_return.order) %></td>
+          <td>
+            <% if customer_return.fully_reimbursed? %>
+              <span class="label label-success"><%= Spree.t(:reimbursed) %></span>
+            <% else %>
+              <span class="label label-info"><%= Spree.t(:incomplete) %></span>
+            <% end %>
+          </td>
+          <td><%= customer_return.display_pre_tax_total.to_html %></td>
+          <td class="actions actions-1 text-right">
+            <%= link_to_edit_url edit_admin_order_customer_return_path(customer_return.order, customer_return), no_text: true %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <div class="alert alert-info no-objects-found">
+    <%= Spree.t(:no_resource_found, resource: Spree::CustomerReturn.model_name.human(count: :many)) %>.
+  </div>
+<% end %>

--- a/backend/app/views/spree/admin/return_index/customer_returns.html.erb
+++ b/backend/app/views/spree/admin/return_index/customer_returns.html.erb
@@ -20,6 +20,8 @@
   </div>
 <% end %>
 
+<%= render partial: 'spree/admin/shared/index_table_options', locals: { collection: @collection, per_page_action: :customer_returns } %>
+
 <% if @collection.any? %>
   <table class="table">
     <thead>
@@ -58,3 +60,5 @@
     <%= Spree.t(:no_resource_found, resource: Spree::CustomerReturn.model_name.human(count: :many)) %>.
   </div>
 <% end %>
+
+<%= render partial: 'spree/admin/shared/index_table_options', locals: { collection: @collection, per_page_action: :customer_returns } %>

--- a/backend/app/views/spree/admin/return_index/return_authorizations.html.erb
+++ b/backend/app/views/spree/admin/return_index/return_authorizations.html.erb
@@ -1,0 +1,76 @@
+<% content_for :page_title do %>
+  <%= Spree.t(:return_authorizations) %>
+<% end %>
+
+<% content_for :page_tabs do %>
+  <li class="<%= "active" if params[:q][:state_eq].blank? %>">
+    <%= link_to Spree.t(:all), admin_return_authorizations_index_path %>
+  </li>
+  <li class="<%= "active" if params[:q][:state_eq] == "authorized" %>">
+    <%= link_to Spree.t(:authorized), params.merge({q: {state_eq: :authorized}}) %>
+  </li>
+  <li class="<%= "active" if params[:q][:state_eq] == "canceled" %>">
+    <%= link_to Spree.t(:canceled), params.merge({q: {state_eq: :canceled}}) %>
+  </li>
+<% end %>
+
+<% content_for :table_filter do %>
+  <div data-hook="admin_return_authorisations_index_filters">
+    <%= search_form_for [:admin, @search], url: admin_return_authorizations_index_path do |f| %>
+      <div class="row">
+        <div class="col-md-6">
+          <div class="form-group">
+            <%= f.label :number_cont, Spree.t(:number) %>
+            <%= f.text_field :number_cont, class: "form-control js-quick-search-target" %>
+          </div>
+        </div>
+        <div class="col-md-6">
+          <div class="form-group">
+            <%= label_tag :q_state_eq, Spree.t(:status) %>
+            <%= f.select :state_eq, Spree::ReturnAuthorization.state_machines[:state].states.collect {|s| [Spree.t("return_authorization_states.#{s.name}"), s.value]}, {include_blank: true}, class: 'select2' %>
+          </div>
+        </div>
+      </div>
+      <div data-hook="admin_return_authorisations_index_filters_buttons" class="form-actions">
+        <%= button Spree.t(:search), 'search' %>
+      </div>
+    <% end %>
+  </div>
+<% end %>
+
+<%= render partial: 'spree/admin/shared/index_table_options', locals: { collection: @collection, per_page_action: :return_authorizations } %>
+
+<% if @collection.any? %>
+  <table class="table">
+    <thead>
+      <tr data-hook="rate_header">
+        <th><%= Spree.t(:created_at) %></th>
+        <th><%= Spree.t(:number) %></th>
+        <th><%= Spree.t(:order) %></th>
+        <th><%= Spree.t(:state) %></th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @collection.each do |return_authorization| %>
+        <tr id="<%= spree_dom_id return_authorization %>" data-hook="return_authorization_row">
+          <td><%= return_authorization.created_at.to_date %></td>
+          <td><%= link_to return_authorization.number, edit_admin_order_return_authorization_path(return_authorization.order, return_authorization) %></td>
+          <td><%= link_to return_authorization.order.number, edit_admin_order_path(return_authorization.order) %></td>
+          <td>
+            <span class="label label-<%= return_authorization.state %>"><%= Spree.t("return_authorization_states.#{return_authorization.state}") %></span>
+          </td>
+          <td class="actions actions-1 text-right">
+            <%= link_to_edit return_authorization, url: edit_admin_order_return_authorization_path(return_authorization.order, return_authorization), no_text: true %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <div class="alert alert-info no-objects-found">
+    <%= Spree.t(:no_resource_found, resource: Spree::ReturnAuthorization.model_name.human(count: :many)) %>.
+  </div>
+<% end %>
+
+<%= render partial: 'spree/admin/shared/index_table_options', locals: { collection: @collection, per_page_action: :return_authorizations } %>

--- a/backend/app/views/spree/admin/shared/_index_table_options.html.erb
+++ b/backend/app/views/spree/admin/shared/_index_table_options.html.erb
@@ -4,7 +4,7 @@
   </div>
   <div class="col-sm-6">
     <div class="pagination-wrap">
-      <%= form_tag({ :action => "index"}, { :method => "get", :id => "js-per-page-form", :class => 'form-inline' }) do %>
+      <%= form_tag({ action: (defined?(per_page_action) ?  per_page_action : :index)}, { method: :get, id: 'js-per-page-form', class: 'form-inline' }) do %>
         <%= per_page_dropdown %>
       <% end %>
       <div class="clearfix"></div>

--- a/backend/app/views/spree/admin/shared/_main_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_main_menu.html.erb
@@ -4,6 +4,12 @@
   </ul>
 <% end %>
 
+<% if can?(:admin, Spree::ReturnAuthorization) || can?(:admin, Spree::CustomerReturn) %>
+  <ul class="nav nav-sidebar">
+    <%= main_menu_tree Spree.t(:returns), icon: "transfer", sub_menu: "returns", url: "#sidebar-returns" %>
+  </ul>
+<% end %>
+
 <% if can? :admin, Spree::Product %>
   <ul class="nav nav-sidebar">
     <%= main_menu_tree Spree.t(:products), icon: "th-large", sub_menu: "product", url: "#sidebar-product" %>

--- a/backend/app/views/spree/admin/shared/sub_menu/_returns.html.erb
+++ b/backend/app/views/spree/admin/shared/sub_menu/_returns.html.erb
@@ -1,0 +1,4 @@
+<ul id="sidebar-returns" class="collapse nav nav-pills nav-stacked" data-hook="admin_returns_sub_tabs">
+  <%= tab :return_authorizations, url: admin_return_authorizations_index_path, match_path: '/return_index/return_authorizations' %>
+  <%= tab :customer_returns, url: admin_customer_returns_index_path, match_path: '/return_index/customer_returns' %>
+</ul>

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -113,6 +113,9 @@ Spree::Core::Engine.add_routes do
       end
     end
 
+    get '/return_index/return_authorizations', to: "return_index#return_authorizations", as: :return_authorizations_index
+    get '/return_index/customer_returns', to: "return_index#customer_returns", as: :customer_returns_index
+
     resource :general_settings do
       collection do
         post :dismiss_alert


### PR DESCRIPTION
I added return index screens to the admin.
The returns index screens provide a listing of returns authorizations and customer returns.
So you can browse them more easy instead of accessing them trough an order.

Screens :)
## Return Authorization index

![screen_shot_2015-02-18_at_15_32_05](https://cloud.githubusercontent.com/assets/106335/6248974/34d264fe-b784-11e4-818e-3556516e73a5.png)
## Active filter on a index

![screen_shot_2015-02-18_at_15_32_27](https://cloud.githubusercontent.com/assets/106335/6248980/3fcf5c86-b784-11e4-92d6-289befc4b807.png)
## Customer Returns index

![screen_shot_2015-02-18_at_15_32_42](https://cloud.githubusercontent.com/assets/106335/6248986/49122fee-b784-11e4-9d95-0e77fb072c2d.png)

This is just the basic beginning.
More filters and search options would be handy for the future.
