### PR TITLE
Removing ability to view an order by passing the guest token

### DIFF
--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -81,7 +81,6 @@ module Spree
     end
 
     def check_authorization
-      cookies.permanent.signed[:guest_token] = params[:token] if params[:token]
       order = Spree::Order.find_by_number(params[:id]) || current_order
 
       if order

--- a/frontend/config/routes.rb
+++ b/frontend/config/routes.rb
@@ -17,7 +17,6 @@ Spree::Core::Engine.add_routes do
   end
 
   get '/orders/populate', :to => populate_redirect
-  get '/orders/:id/token/:token' => 'orders#show', :as => :token_order
 
   resources :orders, :except => [:index, :new, :create, :destroy] do
     post :populate, :on => :collection

--- a/frontend/spec/controllers/spree/orders_controller_ability_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_ability_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Spree
-  describe OrdersController, :type => :controller do
+  describe OrdersController, type: :controller do
     let(:user) { create(:user) }
     let(:guest_user) { create(:user) }
     let(:order) { Spree::Order.create }
@@ -12,8 +12,8 @@ module Spree
 
       before do
         cookies.signed[:guest_token] = token
-        allow(controller).to receive_messages :current_order => order
-        allow(controller).to receive_messages :spree_current_user => user
+        allow(controller).to receive_messages current_order: order
+        allow(controller).to receive_messages spree_current_user: user
       end
 
       context '#populate' do
@@ -23,7 +23,7 @@ module Spree
         end
         it "should check against the specified order" do
           expect(controller).to receive(:authorize!).with(:edit, specified_order, token)
-          spree_post :populate, :id => specified_order.number
+          spree_post :populate, id: specified_order.number
         end
       end
 
@@ -34,7 +34,7 @@ module Spree
         end
         it "should check against the specified order" do
           expect(controller).to receive(:authorize!).with(:edit, specified_order, token)
-          spree_get :edit, :id => specified_order.number
+          spree_get :edit, id: specified_order.number
         end
       end
 
@@ -42,12 +42,12 @@ module Spree
         it 'should check if user is authorized for :edit' do
           allow(order).to receive :update_attributes
           expect(controller).to receive(:authorize!).with(:edit, order, token)
-          spree_post :update, :order => { :email => "foo@bar.com" }
+          spree_post :update, order: { email: "foo@bar.com" }
         end
         it "should check against the specified order" do
           allow(order).to receive :update_attributes
           expect(controller).to receive(:authorize!).with(:edit, specified_order, token)
-          spree_post :update, :order => { :email => "foo@bar.com" }, :id => specified_order.number
+          spree_post :update, order: { email: "foo@bar.com" }, id: specified_order.number
         end
       end
 
@@ -58,20 +58,20 @@ module Spree
         end
         it "should check against the specified order" do
           expect(controller).to receive(:authorize!).with(:edit, specified_order, token)
-          spree_post :empty, :id => specified_order.number
+          spree_post :empty, id: specified_order.number
         end
       end
 
       context "#show" do
         it "should check against the specified order" do
           expect(controller).to receive(:authorize!).with(:edit, specified_order, token)
-          spree_get :show, :id => specified_order.number
+          spree_get :show, id: specified_order.number
         end
       end
     end
 
     context 'when no authenticated user' do
-      let(:order) { create(:order, :number => 'R123') }
+      let(:order) { create(:order, number: 'R123') }
 
       context '#show' do
         context 'when guest_token correct' do
@@ -79,14 +79,14 @@ module Spree
 
           it 'displays the page' do
             expect(controller).to receive(:authorize!).with(:edit, order, order.guest_token)
-            spree_get :show, { :id => 'R123' }
+            spree_get :show, { id: 'R123' }
             expect(response.code).to eq('200')
           end
         end
 
         context 'when guest_token not present' do
           it 'should respond with 404' do
-            spree_get :show, {:id => 'R123'}
+            spree_get :show, { id: 'R123'}
             expect(response.code).to eq('404')
           end
         end

--- a/frontend/spec/controllers/spree/orders_controller_ability_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_ability_spec.rb
@@ -2,21 +2,16 @@ require 'spec_helper'
 
 module Spree
   describe OrdersController, :type => :controller do
-    ORDER_TOKEN = 'ORDER_TOKEN'
-
     let(:user) { create(:user) }
     let(:guest_user) { create(:user) }
     let(:order) { Spree::Order.create }
-
-    it 'should understand order routes with token' do
-      expect(spree.token_order_path('R123456', 'ABCDEF')).to eq('/orders/R123456/token/ABCDEF')
-    end
 
     context 'when an order exists in the cookies.signed' do
       let(:token) { 'some_token' }
       let(:specified_order) { create(:order) }
 
       before do
+        cookies.signed[:guest_token] = token
         allow(controller).to receive_messages :current_order => order
         allow(controller).to receive_messages :spree_current_user => user
       end
@@ -24,22 +19,22 @@ module Spree
       context '#populate' do
         it 'should check if user is authorized for :edit' do
           expect(controller).to receive(:authorize!).with(:edit, order, token)
-          spree_post :populate, :token => token
+          spree_post :populate
         end
         it "should check against the specified order" do
           expect(controller).to receive(:authorize!).with(:edit, specified_order, token)
-          spree_post :populate, :id => specified_order.number, :token => token
+          spree_post :populate, :id => specified_order.number
         end
       end
 
       context '#edit' do
         it 'should check if user is authorized for :edit' do
           expect(controller).to receive(:authorize!).with(:edit, order, token)
-          spree_get :edit, :token => token
+          spree_get :edit
         end
         it "should check against the specified order" do
           expect(controller).to receive(:authorize!).with(:edit, specified_order, token)
-          spree_get :edit, :id => specified_order.number, :token => token
+          spree_get :edit, :id => specified_order.number
         end
       end
 
@@ -47,30 +42,30 @@ module Spree
         it 'should check if user is authorized for :edit' do
           allow(order).to receive :update_attributes
           expect(controller).to receive(:authorize!).with(:edit, order, token)
-          spree_post :update, :order => { :email => "foo@bar.com" }, :token => token
+          spree_post :update, :order => { :email => "foo@bar.com" }
         end
         it "should check against the specified order" do
           allow(order).to receive :update_attributes
           expect(controller).to receive(:authorize!).with(:edit, specified_order, token)
-          spree_post :update, :order => { :email => "foo@bar.com" }, :id => specified_order.number, :token => token
+          spree_post :update, :order => { :email => "foo@bar.com" }, :id => specified_order.number
         end
       end
 
       context '#empty' do
         it 'should check if user is authorized for :edit' do
           expect(controller).to receive(:authorize!).with(:edit, order, token)
-          spree_post :empty, :token => token
+          spree_post :empty
         end
         it "should check against the specified order" do
           expect(controller).to receive(:authorize!).with(:edit, specified_order, token)
-          spree_post :empty, :id => specified_order.number, :token => token
+          spree_post :empty, :id => specified_order.number
         end
       end
 
       context "#show" do
         it "should check against the specified order" do
           expect(controller).to receive(:authorize!).with(:edit, specified_order, token)
-          spree_get :show, :id => specified_order.number, :token => token
+          spree_get :show, :id => specified_order.number
         end
       end
     end
@@ -79,20 +74,17 @@ module Spree
       let(:order) { create(:order, :number => 'R123') }
 
       context '#show' do
-        context 'when token parameter present' do
-          it 'always ooverride existing token when passing a new one' do
-            cookies.signed[:guest_token] = "soo wrong"
-            spree_get :show, { :id => 'R123', :token => order.guest_token }
-            expect(cookies.signed[:guest_token]).to eq(order.guest_token)
-          end
+        context 'when guest_token correct' do
+          before { cookies.signed[:guest_token] = order.guest_token }
 
-          it 'should store as guest_token in session' do
-            spree_get :show, {:id => 'R123', :token => order.guest_token }
-            expect(cookies.signed[:guest_token]).to eq(order.guest_token)
+          it 'displays the page' do
+            expect(controller).to receive(:authorize!).with(:edit, order, order.guest_token)
+            spree_get :show, { :id => 'R123' }
+            expect(response.code).to eq('200')
           end
         end
 
-        context 'when no token present' do
+        context 'when guest_token not present' do
           it 'should respond with 404' do
             spree_get :show, {:id => 'R123'}
             expect(response.code).to eq('404')

--- a/guides/content/developer/tutorials/security.md
+++ b/guides/content/developer/tutorials/security.md
@@ -257,18 +257,6 @@ The final step is to ensure that the token is passed to CanCan when the authoriz
 authorize! action, resource, session[:access_token]
 ```
 
-Of course this also assumes that the token has been stored in the session. Generally this can be achieved with a route that maps the token to the correct parameter:
-
-```ruby
-get '/orders/:id/token/:token' => 'orders#show', :as => :token_order
-```
-
-This is followed by a call to store the token in the session for possible future access.
-
-```ruby
-  session[:access_token] ||= params[:token]
-```
-
 ## Credit Card Data
 
 ### PCI Compliance


### PR DESCRIPTION
This is to avoid the order success page being accessible to a third party with access to the URL with the token as there is sensitive customer information on that page.
