### PR TITLE
fix circular argument warning

### DIFF
--- a/core/app/models/spree/adjustable/promotion_accumulator.rb
+++ b/core/app/models/spree/adjustable/promotion_accumulator.rb
@@ -30,7 +30,7 @@ module Spree
         add(promotions, promotion, source.promotion_id)
       end
 
-      def promotions_adjustments(promotion_id, adjustments = adjustments)
+      def promotions_adjustments(promotion_id, adjustments = adjustments())
         where(sources, promotion_id: promotion_id).map do |source|
           where(adjustments, source_id: source.id)
         end.flatten


### PR DESCRIPTION
When starting my Rails application I received this warning:

``` ruby
23:37:44 web.1    | => Booting Puma
23:37:44 web.1    | => Rails 4.2.0 application starting in development on http://localhost:3000
23:37:44 web.1    | => Run `rails server -h` for more startup options
23:37:44 web.1    | => Ctrl-C to shutdown server
23:37:46 worker.1 | /Users/benmorgan/.rvm/gems/ruby-2.2.0/bundler/gems/spree-be809f7c818b/core/app/models/spree/adjustable/promotion_accumulator.rb:33: warning: circular argument reference - adjustments
23:37:46 web.1    | /Users/benmorgan/.rvm/gems/ruby-2.2.0/bundler/gems/spree-be809f7c818b/core/app/models/spree/adjustable/promotion_accumulator.rb:33: warning: circular argument reference - adjustments
23:37:47 web.1    | Puma 2.11.0 starting...
23:37:47 web.1    | * Min threads: 0, max threads: 16
23:37:47 web.1    | * Environment: development
23:37:47 web.1    | * Listening on tcp://localhost:3000
```

Added `()` to remove the circular argument warning.
