### PR TITLE
Removed recommendation to use SSL on all pages

### DIFF
--- a/guides/content/release_notes/3_0_0.md
+++ b/guides/content/release_notes/3_0_0.md
@@ -48,8 +48,6 @@ SSLRequirement controller concern was removed in favor of using Rails built in [
 
 If you were previously using ssl_required in any controllers you should now use force_ssl.
 
-It is also recommended that you enable config.force_ssl = true within your production.rb file which will enforce SSL on every page.
-
 ## Full Changelog
 
 You can view the full changes using [Github Compare](https://github.com/spree/spree/compare/2-4-stable...3-0-stable).


### PR DESCRIPTION
Is there any reason for recommending force SSL on pages with no sensitive data?

Someone performing a MITM attack can already see the host with SSL enabled, and there really isn't any value in protecting what category or product a user is browsing (as long as they aren't logged in).

Speed isn't a big deal for most users on stable connections, but mobile is becoming more common alongside emerging markets growing in ecommerce and for those users it can be an issue.

The SSL handshakes will also put a bit more load on the server - but that isn't too big of a concern.
