### PR TITLE
Create compatible friendly_id version for spree_i18n

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'deface', '~> 1.0.0'
   s.add_dependency 'ffaker', '~> 1.16'
   s.add_dependency 'font-awesome-rails', '~> 4.0'
-  s.add_dependency 'friendly_id', '~> 5.0.4'
+  s.add_dependency 'friendly_id', '~> 5.1.0'
   s.add_dependency 'highline', '~> 1.6.18' # Necessary for the install generator
   s.add_dependency 'httparty', '~> 0.11' # For checking alerts.
   s.add_dependency 'json', '~> 1.7'


### PR DESCRIPTION
spree_i18n use friendly_id 5.1
