### PR TITLE
allow Product#really_destroy!

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -263,7 +263,8 @@ module Spree
     end
 
     def punch_slug
-      update_column :slug, "#{Time.now.to_i}_#{slug}" # punch slug with date prefix to allow reuse of original
+      # punch slug with date prefix to allow reuse of original
+      update_column :slug, "#{Time.now.to_i}_#{slug}" unless frozen?
     end
 
     def anything_changed?

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -178,7 +178,6 @@ describe Spree::Product, :type => :model do
     end
 
     context "has stock movements" do
-      let(:product) { create(:product) }
       let(:variant) { product.master }
       let(:stock_item) { variant.stock_items.first }
 
@@ -190,7 +189,6 @@ describe Spree::Product, :type => :model do
 
     # Regression test for #3737
     context "has stock items" do
-      let(:product) { create(:product) }
       it "can retrieve stock items" do
         expect(product.master.stock_items.first).not_to be_nil
         expect(product.stock_items.first).not_to be_nil
@@ -235,6 +233,11 @@ describe Spree::Product, :type => :model do
 
     end
 
+    context "hard deletion" do
+      it "doesnt raise ActiveRecordError error" do
+        expect { product.really_destroy! }.to_not raise_error
+      end
+    end
   end
 
   context "properties" do
@@ -399,6 +402,8 @@ describe Spree::Product, :type => :model do
   end
 
   context '#total_on_hand' do
+    let(:product) { create(:product) }
+
     it 'should be infinite if track_inventory_levels is false' do
       Spree::Config[:track_inventory_levels] = false
       expect(build(:product, :variants_including_master => [build(:master_variant)]).total_on_hand).to eql(Float::INFINITY)
@@ -410,19 +415,17 @@ describe Spree::Product, :type => :model do
     end
 
     it 'should return sum of stock items count_on_hand' do
-      product = create(:product)
       product.stock_items.first.set_count_on_hand 5
       product.variants_including_master(true) # force load association
       expect(product.total_on_hand).to eql(5)
     end
 
     it 'should return sum of stock items count_on_hand when variants_including_master is not loaded' do
-      product = create(:product)
       product.stock_items.first.set_count_on_hand 5
       expect(product.reload.total_on_hand).to eql(5)
     end
   end
-  
+
   # Regression spec for https://github.com/spree/spree/issues/5588
   context '#validate_master when duplicate SKUs entered' do
     let!(:first_product) { create(:product, sku: 'a-sku') }


### PR DESCRIPTION
this fixes the use of `paranoia` gem's `really_destroy!` method, otherwise we get:

```
RuntimeError: can't modify frozen Hash
...
    from .../gems/spree_core-2.4.4/app/models/spree/product.rb:266:in `punch_slug'
```
