### PR TITLE
Updates the track_inventory JSON attribute on variant

### DIFF
--- a/api/app/views/spree/api/variants/small.v1.rabl
+++ b/api/app/views/spree/api/variants/small.v1.rabl
@@ -4,6 +4,7 @@ attributes *variant_attributes
 
 node(:display_price) { |p| p.display_price.to_s }
 node(:options_text) { |v| v.options_text }
+node(:track_inventory) { |v| v.should_track_inventory? }
 node(:in_stock) { |v| v.in_stock? }
 node(:is_backorderable) { |v| v.is_backorderable? }
 node(:total_on_hand) { |v| v.total_on_hand }


### PR DESCRIPTION
The JSON endpoint for variant doesn't respect the Spree::Config.track_inventory_levels setting. This updates the attribute to rely on Spree::Variant.should_track_inventory? which takes the setting into account.
