### PR TITLE
Order importer should create line items before shipments

### DIFF
--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -16,9 +16,8 @@ module Spree
 
             shipments_attrs = params.delete(:shipments_attributes)
 
-            create_shipments_from_params(shipments_attrs, order)
             create_line_items_from_params(params.delete(:line_items_attributes),order)
-            create_shipments_from_params(params.delete(:shipments_attributes), order)
+            create_shipments_from_params(shipments_attrs, order)
             create_adjustments_from_params(params.delete(:adjustments_attributes), order)
             create_payments_from_params(params.delete(:payments_attributes), order)
 

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -272,6 +272,7 @@ module Spree
       context "shipments" do
         let(:params) do
           {
+            line_items_attributes: line_items,
             shipments_attributes: [
               {
                 tracking: '123456789',
@@ -285,7 +286,7 @@ module Spree
         end
 
         it 'ensures variant exists and is not deleted' do
-          expect(Importer::Order).to receive(:ensure_variant_id_from_params)
+          expect(Importer::Order).to receive(:ensure_variant_id_from_params).exactly(2).times { line_items.first }
           order = Importer::Order.import(user,params)
         end
 


### PR DESCRIPTION
Importing an order with the following attributes returns an order without a shipment:

``` ruby
{
  line_items_attributes: [ { variant_id: variant.id, quantity: 1 } ],
  shipments_attributes: [ {
    cost: '14.99',
    shipping_method: shipping_method.name,
    stock_location: stock_location.name,
    inventory_units: [ { sku: sku } ]
  } ]
}
```

The shipment gets created prior to the creation of the line items. Later on, Spree::Order.ensure_updated_shipments deletes the shipment when the line items are being created. This PR reverses the order of the line items and shipments creation to prevent this from happening.
