### PR TITLE
Fix the link to add a new stock transfer

### DIFF
--- a/backend/app/views/spree/admin/stock_transfers/index.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/index.html.erb
@@ -75,7 +75,7 @@
 <% else %>
   <div class="alert alert-info no-objects-found">
     <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::StockTransfer)) %>,
-    <%= link_to(Spree.t(:add_one), new_object_url) if can? :create, Spree::StockTransfer %>!
+    <%= link_to(Spree.t(:add_one), new_admin_stock_transfer_path) if can? :create, Spree::StockTransfer %>!
   </div>
 <% end %>
 


### PR DESCRIPTION
The link to add a new stock transfer in the stock transfers index view's "no objects found notice" is currently broken.
