### PR TITLE
code reload aware shipping calculators detection in Spree::ShippingMethod class

### DIFF
--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -39,7 +39,8 @@ module Spree
     end
 
     def self.calculators
-      spree_calculators.send(model_name_without_spree_namespace).select{ |c| c < Spree::ShippingCalculator }
+      spree_calculators.send(model_name_without_spree_namespace)
+        .select { |c| c.to_s.constantize < Spree::ShippingCalculator }
     end
 
     # Some shipping methods are only meant to be set via backend


### PR DESCRIPTION
It's specially useful for development with use of `spring` gem and other mechanisms which do partial app code reloads.

fixes #4522 
