### PR TITLE
Added label class for invalid

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_labels.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_labels.scss
@@ -19,7 +19,8 @@
 // Red
 .label-failed,
 .label-considered_risky,
-.label-error {
+.label-error,
+.label-invalid {
   background-color: $brand-danger;
 }
 


### PR DESCRIPTION
Now an invalid payment has a red label. It had no label color at all.
