### PR TITLE
Find refund payment by number instead of ID

### DIFF
--- a/backend/app/controllers/spree/admin/refunds_controller.rb
+++ b/backend/app/controllers/spree/admin/refunds_controller.rb
@@ -1,7 +1,7 @@
 module Spree
   module Admin
     class RefundsController < ResourceController
-      belongs_to 'spree/payment'
+      belongs_to 'spree/payment', find_by: :number
       before_action :load_order
 
       helper_method :refund_reasons

--- a/backend/spec/controllers/spree/admin/refunds_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/refunds_controller_spec.rb
@@ -11,8 +11,8 @@ describe Spree::Admin::RefundsController do
       subject do
         spree_post :create,
                    refund: { amount: "50.0", refund_reason_id: "1" },
-                   order_id: payment.order_id,
-                   payment_id: payment.id
+                   order_id: payment.order.to_param,
+                   payment_id: payment.to_param
       end
 
       before(:each) do


### PR DESCRIPTION
You couldn’t create a refund of a payment because the resource controller was trying to find the payment by ID.
A payment number was passed instead of an ID so it errored.
I changed this in the controller so a number is passed now, changed the specs for this as well.
