### PR TITLE
add table name for Spree::Promotion.active scope

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -41,8 +41,8 @@ module Spree
     end
 
     def self.active
-      where('starts_at IS NULL OR starts_at < ?', Time.now).
-        where('expires_at IS NULL OR expires_at > ?', Time.now)
+      where('spree_promotions.starts_at IS NULL OR spree_promotions.starts_at < ?', Time.now).
+        where('spree_promotions.expires_at IS NULL OR spree_promotions.expires_at > ?', Time.now)
     end
 
     def self.order_activatable?(order)


### PR DESCRIPTION
Adding the table name to `.active` scope on Spree::Promotion model. I found this mandatory when playing with complex queries.
