### PR TITLE
:page params is used by another gem, check params[:page] before assuming it is for pagination

### DIFF
--- a/core/lib/spree/core/search/base.rb
+++ b/core/lib/spree/core/search/base.rb
@@ -89,10 +89,10 @@ module Spree
 
             per_page = params[:per_page].to_i
             @properties[:per_page] = per_page > 0 ? per_page : Spree::Config[:products_per_page]
-            if !params[:page].respond_to?(:to_i)
-              @properties[:page] = 1
-            else
+            if params[:page].respond_to?(:to_i)
               @properties[:page] = (params[:page].to_i <= 0) ? 1 : params[:page].to_i
+            else
+              @properties[:page] = 1              
             end
           end
       end

--- a/core/lib/spree/core/search/base.rb
+++ b/core/lib/spree/core/search/base.rb
@@ -89,7 +89,7 @@ module Spree
 
             per_page = params[:per_page].to_i
             @properties[:per_page] = per_page > 0 ? per_page : Spree::Config[:products_per_page]
-            @properties[:page] = (params[:page].to_i <= 0) ? 1 : params[:page].to_i
+            @properties[:page] = !params[:page].respond_to?(:to_i) ? 0 : ((params[:page].to_i <= 0) ? 1 : params[:page].to_i)
           end
       end
     end

--- a/core/lib/spree/core/search/base.rb
+++ b/core/lib/spree/core/search/base.rb
@@ -92,7 +92,7 @@ module Spree
             if params[:page].respond_to?(:to_i)
               @properties[:page] = (params[:page].to_i <= 0) ? 1 : params[:page].to_i
             else
-              @properties[:page] = 1              
+              @properties[:page] = 1
             end
           end
       end

--- a/core/lib/spree/core/search/base.rb
+++ b/core/lib/spree/core/search/base.rb
@@ -89,7 +89,11 @@ module Spree
 
             per_page = params[:per_page].to_i
             @properties[:per_page] = per_page > 0 ? per_page : Spree::Config[:products_per_page]
-            @properties[:page] = !params[:page].respond_to?(:to_i) ? 0 : ((params[:page].to_i <= 0) ? 1 : params[:page].to_i)
+            if !params[:page].respond_to?(:to_i)
+              @properties[:page] =  1
+            else
+              @properties[:page] = (params[:page].to_i <= 0) ? 1 : params[:page].to_i
+            end
           end
       end
     end

--- a/core/lib/spree/core/search/base.rb
+++ b/core/lib/spree/core/search/base.rb
@@ -90,7 +90,7 @@ module Spree
             per_page = params[:per_page].to_i
             @properties[:per_page] = per_page > 0 ? per_page : Spree::Config[:products_per_page]
             if !params[:page].respond_to?(:to_i)
-              @properties[:page] =  1
+              @properties[:page] = 1
             else
               @properties[:page] = (params[:page].to_i <= 0) ? 1 : params[:page].to_i
             end


### PR DESCRIPTION
The spree is combined with another gem, in my case, it is comfortable-mexican-sofa, 

The search functions trying to **_to_i**_ the `params[:page]` and it got errors 

```
undefined method `to_i' for #<ActionController::Parameters:0xeeb74c8>
```

https://github.com/comfy/comfortable-mexican-sofa/pull/594
