### PR TITLE
Fixes admin zones sorting

### DIFF
--- a/backend/app/controllers/spree/admin/zones_controller.rb
+++ b/backend/app/controllers/spree/admin/zones_controller.rb
@@ -11,7 +11,7 @@ module Spree
 
         def collection
           params[:q] ||= {}
-          params[:q][:s] ||= "ascend_by_name"
+          params[:q][:s] ||= "name asc"
           @search = super.ransack(params[:q])
           @zones = @search.result.page(params[:page]).per(params[:per_page])
         end


### PR DESCRIPTION
not sure what `ascend_by_name` is but it's not a valid ransack scope.
