### PR TITLE
Need to include token to get taxons after 2.4.5

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js.erb
@@ -7,7 +7,8 @@ var set_taxon_select = function(){
       multiple: true,
       initSelection: function (element, callback) {
         var url = Spree.url(Spree.routes.taxons_search, {
-          ids: element.val()
+          ids: element.val(),
+          token: Spree.api_key
         });
         return $.getJSON(url, null, function (data) {
           return callback(data['taxons']);


### PR DESCRIPTION
If not included, the request returns 401 unauthorized
