### PR TITLE
Add ability to pass selector to set_taxon_select js-function

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js.erb
@@ -1,8 +1,8 @@
 'use strict';
 
-var set_taxon_select = function(){
-  if ($('#product_taxon_ids').length > 0) {
-    $('#product_taxon_ids').select2({
+var set_taxon_select = function(selector){
+  if ($(selector).length > 0) {
+    $(selector).select2({
       placeholder: Spree.translations.taxon_placeholder,
       multiple: true,
       initSelection: function (element, callback) {
@@ -47,5 +47,5 @@ var set_taxon_select = function(){
 }
 
 $(document).ready(function () {
-  set_taxon_select()
+  set_taxon_select('#product_taxon_ids')
 });

--- a/backend/app/views/spree/admin/promotion_rules/create.js.erb
+++ b/backend/app/views/spree/admin/promotion_rules/create.js.erb
@@ -7,4 +7,4 @@ $('.user_picker').userAutocomplete();
 $('#promotion_rule_type').html('<%= escape_javascript options_for_promotion_rule_types(@promotion) %>');
 $('#promotion_rule_type').select2();
 
-set_taxon_select()
+set_taxon_select('#product_taxon_ids')


### PR DESCRIPTION
Can be useful for extensions or for main app to be able to call set_taxon_select for other selector without copy-paste.
