### PR TITLE
Update payment total after refund is processed

### DIFF
--- a/core/Gemfile
+++ b/core/Gemfile
@@ -1,3 +1,5 @@
 eval(File.read(File.dirname(__FILE__) + '/../common_spree_dependencies.rb'))
 
+gem 'pry-rails'
+
 gemspec

--- a/core/Gemfile
+++ b/core/Gemfile
@@ -1,5 +1,3 @@
 eval(File.read(File.dirname(__FILE__) + '/../common_spree_dependencies.rb'))
 
-gem 'pry-rails'
-
 gemspec

--- a/core/app/models/spree/refund.rb
+++ b/core/app/models/spree/refund.rb
@@ -47,6 +47,7 @@ module Spree
 
       self.transaction_id = @response.authorization
       update_columns(transaction_id: transaction_id)
+      update_order
     end
 
     # return an activemerchant response object if successful or else raise an error
@@ -86,6 +87,10 @@ module Spree
       if amount > payment.credit_allowed
         errors.add(:amount, :greater_than_allowed)
       end
+    end
+
+    def update_order
+      payment.order.updater.update
     end
   end
 end

--- a/core/spec/models/spree/refund_spec.rb
+++ b/core/spec/models/spree/refund_spec.rb
@@ -92,6 +92,11 @@ describe Spree::Refund, :type => :model do
         subject
       end
 
+      it 'should update the payment total' do
+        expect(payment.order.updater).to receive(:update)
+        subject
+      end
+
     end
 
     context "processing fails" do


### PR DESCRIPTION
This change will ensure that an order's payment state and payment total is properly reflected when a refund is applied. 

Before: 

![screen shot 2015-03-08 at 8 00 17 pm](https://cloud.githubusercontent.com/assets/12205/6548574/eaa5ecf8-c5d3-11e4-8328-333c90528dd1.png)

With refund applied
![screen shot 2015-03-08 at 8 01 32 pm](https://cloud.githubusercontent.com/assets/12205/6548573/eaa5d9ca-c5d3-11e4-824b-2a8ceeed3780.png)

After:

![screen shot 2015-03-08 at 8 43 06 pm](https://cloud.githubusercontent.com/assets/12205/6548583/0cc41a8a-c5d4-11e4-9670-b11839f8a3f9.png)
![screen shot 2015-03-08 at 8 43 51 pm](https://cloud.githubusercontent.com/assets/12205/6548582/0cc32648-c5d4-11e4-80b2-4e62f7378a64.png)
