### PR TITLE
Highlight total_pre_tax_refund in return authorization form

### DIFF
--- a/backend/app/views/spree/admin/return_authorizations/_form.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/_form.html.erb
@@ -63,7 +63,7 @@
     </tbody>
   </table>
 
-  <%= f.field_container :amount, class: ['form-group'] do %>
+  <%= f.field_container :amount, class: ['alert alert-info'] do %>
     <%= Spree.t(:total_pre_tax_refund) %>: <span id="total_pre_tax_refund">0.00</span>
   <% end %>
 


### PR DESCRIPTION
Highlight total_pre_tax_refund in the return authorization form.

It just was a piece of text which didn't really stand out in the form.
