### PR TITLE
Improved layout for alert message on reimbursements/edit

### DIFF
--- a/backend/app/views/spree/admin/reimbursements/edit.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/edit.html.erb
@@ -84,9 +84,9 @@
   </table>
 
   <% if @order.has_non_reimbursement_related_refunds? %>
-    <span class="alert alert-danger">
+    <div class="alert alert-danger">
       <%= "#{Spree.t('note')}: #{Spree.t('this_order_has_already_received_a_refund')}. #{Spree.t('make_sure_the_above_reimbursement_amount_is_correct')}." %>
-    </span>
+    </div>
   <% end %>
 
   <div class="form-actions" data-hook="reimburse-buttons">


### PR DESCRIPTION
Improved layout for alert message on reimbursements/edit.

It was a span, alerts needs to be displayed as a div, so its a block element.
Layout collapsed because it was a span.
