### PR TITLE
Removed spree_dom_id function from reimbursement edit page

### DIFF
--- a/backend/app/views/spree/admin/reimbursements/edit.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/edit.html.erb
@@ -74,7 +74,7 @@
     </thead>
     <tbody>
       <% @reimbursement_objects.each do |reimbursement_object| %>
-        <tr id="<%= spree_dom_id(reimbursement_object) %>" data-hook="reimbursement_reimbursement_object_row">
+        <tr data-hook="reimbursement_reimbursement_object_row">
           <td><%= reimbursement_object.class.name.demodulize %></td>
           <td><%= reimbursement_object.description %></td>
           <td><%= reimbursement_object.display_amount %></td>


### PR DESCRIPTION
Fixes https://github.com/spree/spree/issues/6147
