### PR TITLE
Fix track_inventory on big variant rabl template

### DIFF
--- a/api/app/views/spree/api/v1/variants/big.v1.rabl
+++ b/api/app/views/spree/api/v1/variants/big.v1.rabl
@@ -1,14 +1,8 @@
 object @variant
-attributes *variant_attributes
 
 cache [I18n.locale, @current_user_roles.include?('admin'), 'big_variant', root_object]
 
 extends "spree/api/v1/variants/small"
-
-node :total_on_hand do
-  root_object.total_on_hand
-end
-
 
 child(:stock_items => :stock_items) do
   attributes :id, :count_on_hand, :stock_location_id, :backorderable


### PR DESCRIPTION
The api/variant/big.v1.rabl template is pulling in variant_attributes and extends the small.v1.rabl template (which already provides the attributes). This prevents the fix from pull request d04b292a711130ba18d4ee642445feee0a4d3c05 from working against the big.v1.rabl template.

The variant_attributes only needs to be defined in one of the templates, so I removed it from big.v1.rabl.
