### PR TITLE
Fix variant sorting

### DIFF
--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -1,6 +1,7 @@
 module Spree
   class Variant < Spree::Base
     acts_as_paranoid
+    acts_as_list
 
     include Spree::DefaultPrice
 

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -7,6 +7,12 @@ describe Spree::Variant, :type => :model do
 
   it_behaves_like 'default_price'
 
+  context 'sorting' do
+    it 'responds to set_list_position' do
+      expect(variant.respond_to?(:set_list_position)).to eq(true)
+    end
+  end
+
   context "validations" do
     it "should validate price is greater than 0" do
       variant.price = -1


### PR DESCRIPTION
The fix for Spree::Image sorting in #5947 inadvertantly broke sorting for
models that don't explicitly include acts_as_list (thus gaining access to the
set_list_position method). Taxon sorting was fixed in #6037, but variant
sorting was still broken. This commit adds acts_as_list to Spree::Variant as
well.
