### PR TITLE
Use InventoryUnitBuilder in order importer

### DIFF
--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -56,32 +56,20 @@ module Spree
               shipment.tracking       = s[:tracking]
               shipment.stock_location = Spree::StockLocation.find_by_admin_name(s[:stock_location]) || Spree::StockLocation.find_by_name!(s[:stock_location])
 
-              inventory_units = s[:inventory_units] || []
-              inventory_units.each do |iu|
-                ensure_variant_id_from_params(iu)
-
-                unit = shipment.inventory_units.build
-                unit.order = order
-
-                # Spree expects a Inventory Unit to always reference a line
-                # item and variant otherwise users might get exceptions when
-                # trying to view these units. Note the Importer might not be
-                # able to find the line item if line_item.variant_id |= iu.variant_id
-                unit.variant_id = iu[:variant_id]
-                unit.line_item_id = line_items.select do |l|
-                  l.variant_id.to_i == iu[:variant_id].to_i
-                end.first.try(:id)
-              end
+              inventory_unit_builder = Spree::Stock::InventoryUnitBuilder.new(order)
+              inventory_units = inventory_unit_builder.units
 
               # Mark shipped if it should be.
               if s[:shipped_at].present?
                 shipment.shipped_at = s[:shipped_at]
                 shipment.state      = 'shipped'
                 shipment.inventory_units.each do |unit|
+                  unit.pending = false
                   unit.state = 'shipped'
                 end
               end
 
+              inventory_units.each(&:save!)
               shipment.save!
 
               shipping_method = Spree::ShippingMethod.find_by_name(s[:shipping_method]) || Spree::ShippingMethod.find_by_admin_name!(s[:shipping_method])

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -49,32 +49,45 @@ module Spree
         def self.create_shipments_from_params(shipments_hash, order)
           return [] unless shipments_hash
 
-          line_items = order.line_items
+          inventory_units = Spree::Stock::InventoryUnitBuilder.new(order).units
+
           shipments_hash.each do |s|
             begin
               shipment = order.shipments.build
               shipment.tracking       = s[:tracking]
               shipment.stock_location = Spree::StockLocation.find_by_admin_name(s[:stock_location]) || Spree::StockLocation.find_by_name!(s[:stock_location])
 
-              inventory_unit_builder = Spree::Stock::InventoryUnitBuilder.new(order)
-              inventory_units = inventory_unit_builder.units
+              shipment_units = s[:inventory_units] || []
+              shipment_units.each do |su|
+                ensure_variant_id_from_params(su)
 
-              # Mark shipped if it should be.
-              if s[:shipped_at].present?
-                shipment.shipped_at = s[:shipped_at]
-                shipment.state      = 'shipped'
-                shipment.inventory_units.each do |unit|
-                  unit.pending = false
-                  unit.state = 'shipped'
+                inventory_unit = inventory_units.detect { |iu| iu.variant_id.to_i == su[:variant_id].to_i }
+
+                if inventory_unit.present?
+                  inventory_unit.shipment = shipment
+
+                  if s[:shipped_at].present?
+                    inventory_unit.pending = false
+                    inventory_unit.state = 'shipped'
+                  end
+
+                  inventory_unit.save!
+
+                  # Don't assign shipments to this inventory unit more than once
+                  inventory_units.delete(inventory_unit)
                 end
               end
 
-              inventory_units.each(&:save!)
+              if s[:shipped_at].present?
+                shipment.shipped_at = s[:shipped_at]
+                shipment.state      = 'shipped'
+              end
+
               shipment.save!
 
               shipping_method = Spree::ShippingMethod.find_by_name(s[:shipping_method]) || Spree::ShippingMethod.find_by_admin_name!(s[:shipping_method])
-              rate = shipment.shipping_rates.create!(:shipping_method => shipping_method,
-                                                     :cost => s[:cost])
+              rate = shipment.shipping_rates.create!(shipping_method: shipping_method, cost: s[:cost])
+
               shipment.selected_shipping_rate_id = rate.id
               shipment.update_amounts
 


### PR DESCRIPTION
The order importer was not creating inventory units correctly when using the spree-product-assembly extension. An assembly's inventory unit variant.id != line_item.id, so no line_item.id is assigned. There are comments in the importer explaining that this can be an issue. The workaround is to use Spree::Stock::InventoryUnitBuilder which properly builds inventory units for assembly and non-assembly line items.

Note: The specs aren't passing for this PR. Fixing the specs depends on the changes in #6088.
