### PR TITLE
Moves the inline #table-filter style into css file.

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_filters.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_filters.scss
@@ -1,4 +1,5 @@
 #table-filter {
+  display: none;
   border-top-left-radius: 0;
   border-top-right-radius: 0;
   margin-top: 20px;

--- a/backend/app/views/spree/admin/shared/_table_filter.html.erb
+++ b/backend/app/views/spree/admin/shared/_table_filter.html.erb
@@ -13,7 +13,7 @@
         <% end %>
       </div>
       <% unless defined?(simple) %>
-        <div id="table-filter" data-hook class="well filter-well" style="display: none">
+        <div id="table-filter" data-hook class="well filter-well">
           <%= yield :table_filter %>
         </div>
       <% end %>

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -66,7 +66,7 @@ describe "Products", type: :feature do
       end
     end
 
-    context "searching products", js: true do
+    context "searching products" do
       it "should be able to search deleted products" do
         create(:product, name: 'apache baseball cap', deleted_at: "2011-01-06 18:21:13")
         create(:product, name: 'zomg shirt')
@@ -75,14 +75,12 @@ describe "Products", type: :feature do
         expect(page).to have_content("zomg shirt")
         expect(page).not_to have_content("apache baseball cap")
 
-        click_on 'Filter'
         check "Show Deleted"
         click_on 'Search'
 
         expect(page).to have_content("zomg shirt")
         expect(page).to have_content("apache baseball cap")
 
-        click_on 'Filter'
         uncheck "Show Deleted"
         click_on 'Search'
 
@@ -96,7 +94,6 @@ describe "Products", type: :feature do
         create(:product, name: 'zomg shirt')
 
         visit spree.admin_products_path
-        click_on 'Filter'
         fill_in "q_name_cont", with: "ap"
         click_on 'Search'
 
@@ -104,7 +101,6 @@ describe "Products", type: :feature do
         expect(page).to have_content("apache baseball cap2")
         expect(page).not_to have_content("zomg shirt")
 
-        click_on 'Filter'
         fill_in "q_variants_including_master_sku_cont", with: "A1"
         click_on 'Search'
 


### PR DESCRIPTION
The list table filter was hidden via an inline css style. Changing this to be part of the already existing `#table-filter` css rule, we are able to run feature specs without the javascript driver.

This speeds up the test suite and hopefully prevents "every now and then" failing specs from failing.

Fixes #5877
