### PR TITLE
Convert order state fields to selects. Closes #6143

### DIFF
--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -50,21 +50,21 @@
         <div class="col-md-4">
           <div class="form-group">
             <%= label_tag :q_state_eq, Spree.t(:status) %>
-            <%= f.select :state_eq, Spree::Order.state_machines[:state].states.collect {|s| [Spree.t("order_state.#{s.name}"), s.value]}, {:include_blank => true}, :class => 'select2 js-filterable' %>
+            <%= f.select :state_eq, Spree::Order.state_machines[:state].states.map {|s| [Spree.t("order_state.#{s.name}"), s.value]}, {:include_blank => true}, :class => 'select2 js-filterable' %>
           </div>
         </div>
 
         <div class="col-md-4">
           <div class="form-group">
             <%= label_tag :q_payment_state_eq, Spree.t(:payment_state) %>
-            <%= f.text_field :payment_state_eq, class: 'form-control js-filterable' %>
+            <%= f.select :payment_state_eq, Spree::Order::PAYMENT_STATES.map {|s| [Spree.t("payment_states.#{s}"), s]}, {:include_blank => true}, :class => 'select2 js-filterable' %>
           </div>
         </div>
 
         <div class="col-md-4">
           <div class="form-group">
             <%= label_tag :q_shipment_state_eq, Spree.t(:shipment_state) %>
-            <%= f.text_field :shipment_state_eq, class: 'form-control js-filterable' %>
+            <%= f.select :shipment_state_eq, Spree::Order::SHIPMENT_STATES.map {|s| [Spree.t("shipment_states.#{s}"), s]}, {:include_blank => true}, :class => 'select2 js-filterable' %>
           </div>
         </div>
 

--- a/backend/spec/features/admin/orders/listing_spec.rb
+++ b/backend/spec/features/admin/orders/listing_spec.rb
@@ -159,5 +159,22 @@ describe "Orders Listing", type: :feature, js: true do
       expect(page).not_to have_content("R200")
     end
 
+    context "filter on shipment state" do
+      it "only shows the orders with the selected shipment state" do
+        select Spree.t("payment_states.#{order1.shipment_state}"), from: "Shipment State"
+        click_on 'Filter Results'
+        within_row(1) { expect(page).to have_content("R100") }
+        within("table#listing_orders") { expect(page).not_to have_content("R200") }
+      end
+    end
+
+    context "filter on payment state" do
+      it "only shows the orders with the selected payment state" do
+        select Spree.t("payment_states.#{order1.payment_state}"), from: "Payment State"
+        click_on 'Filter Results'
+        within_row(1) { expect(page).to have_content("R100") }
+        within("table#listing_orders") { expect(page).not_to have_content("R200") }
+      end
+    end
   end
 end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -3,6 +3,9 @@ require 'spree/order/checkout'
 
 module Spree
   class Order < Spree::Base
+    PAYMENT_STATES = %w(balance_due checkout completed credit_owed failed paid pending processing void).freeze
+    SHIPMENT_STATES = %w(backorder canceled partial pending ready shipped).freeze
+
     extend FriendlyId
     friendly_id :number, slug_column: :number, use: :slugged
 


### PR DESCRIPTION
This converts the table list filter payment and shipment state fields into selects.

**CAUTION** This is currently broken, because of https://github.com/spree/spree/issues/6143#issuecomment-78479874

Also, this has #6161 already merged in. If #6161 gets accepted and the payment and shipment state value issue is solved I will happily rebase this branch, to provide a clean patch.
