### PR TITLE
Fix the backend logo sizing.

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_main.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_main.scss
@@ -3,3 +3,8 @@
     padding-left: 65px;
   }
 }
+
+#logo {
+  width: auto;
+  height: 20px;
+}

--- a/backend/app/views/spree/admin/shared/_header.html.erb
+++ b/backend/app/views/spree/admin/shared/_header.html.erb
@@ -6,7 +6,11 @@
     <div class="container-fluid">
       <div class="row">
         <div class="navbar-header col-sm-3 col-md-2">
-          <%= link_to image_tag(Spree::Config[:admin_interface_logo], id: 'logo', height: '100%'), spree.admin_path, class: "logo navbar-brand" %>
+          <%= link_to(
+            image_tag(Spree::Config[:admin_interface_logo], id: 'logo'),
+            spree.admin_path,
+            class: "logo navbar-brand"
+          ) %>
           <% if admin %>
             <span class="navbar-toggle" id="sidebar-toggle">
               <span class="icon-bar"></span>


### PR DESCRIPTION
The former value of `100%` will show logos (especially) SVGs too large (this only happens in Safari for me).

Since the top bar is always `20px` high, it makes sense to also set this height to the logo. This way retina images and svgs always get the right height. In order to keep the ratio we need to set the `width` value as well.
