### PR TITLE
Migrate old shipping calculators without instantiating

### DIFF
--- a/core/db/migrate/20130830001159_migrate_old_shipping_calculators.rb
+++ b/core/db/migrate/20130830001159_migrate_old_shipping_calculators.rb
@@ -1,15 +1,28 @@
 class MigrateOldShippingCalculators < ActiveRecord::Migration
   def up
     Spree::ShippingMethod.all.each do |shipping_method|
-      old_calculator = shipping_method.calculator
-      next if old_calculator.class < Spree::ShippingCalculator # We don't want to mess with new shipping calculators
-      new_calculator = eval(old_calculator.class.name.sub("::Calculator::", "::Calculator::Shipping::")).new
+      old_calculator_id = ActiveRecord::Base.connection.select_values(
+        "SELECT id FROM spree_calculators WHERE calculable_type = 'Spree::ShippingMethod' AND calculable_id = #{shipping_method.id}"
+      ).first
+      old_calculator_class_name = ActiveRecord::Base.connection.select_values(
+        "SELECT type FROM spree_calculators WHERE id = '#{old_calculator_id}'"
+      ).first
+      next if old_calculator_class_name.start_with? 'Spree::Calculator::Shipping'
+      old_calculator_calculable_id = ActiveRecord::Base.connection.select_values(
+        "SELECT calculable_id FROM spree_calculators WHERE id = '#{old_calculator_id}'"
+      ).first
+
+      new_calculator = eval(old_calculator_class_name.sub("::Calculator::", "::Calculator::Shipping::")).new
+      new_calculator.calculable_id = old_calculator_calculable_id
+      new_calculator.calculable_type = 'Spree::ShippingMethod'
       new_calculator.preferences.keys.each do |pref|
+        preference_key = old_calculator_class_name.snakecase + "/#{pref.to_s}/#{old_calculator_id}"
+        old_preference = Spree::Preference.where(key: preference_key).first
+        next if old_preference.nil?
         # Preferences can't be read/set by name, you have to prefix preferred_
         pref_method = "preferred_#{pref}"
-        new_calculator.send("#{pref_method}=", old_calculator.send(pref_method))
+        new_calculator.send("#{pref_method}=", old_preference.value)
       end
-      new_calculator.calculable = old_calculator.calculable
       new_calculator.save
     end
   end

--- a/core/db/migrate/20130830001159_migrate_old_shipping_calculators.rb
+++ b/core/db/migrate/20130830001159_migrate_old_shipping_calculators.rb
@@ -12,11 +12,11 @@ class MigrateOldShippingCalculators < ActiveRecord::Migration
         "SELECT calculable_id FROM spree_calculators WHERE id = '#{old_calculator_id}'"
       ).first
 
-      new_calculator = eval(old_calculator_class_name.sub("::Calculator::", "::Calculator::Shipping::")).new
+      new_calculator = eval(old_calculator_class_name.sub('::Calculator::', '::Calculator::Shipping::')).new
       new_calculator.calculable_id = old_calculator_calculable_id
       new_calculator.calculable_type = 'Spree::ShippingMethod'
       new_calculator.preferences.keys.each do |pref|
-        preference_key = old_calculator_class_name.snakecase + "/#{pref.to_s}/#{old_calculator_id}"
+        preference_key = old_calculator_class_name.snakecase + "/#{pref}/#{old_calculator_id}"
         old_preference = Spree::Preference.where(key: preference_key).first
         next if old_preference.nil?
         # Preferences can't be read/set by name, you have to prefix preferred_


### PR DESCRIPTION
I often work with clients on Spree 1.3 who want to upgrade to a current version, but not deploy the intermediate versions. To do this, I need to re-run migrations. The migrate_old_shipping_calculators migration assumes that old shipping calculators will be available to instantiate. If I remove the files with the old class definitions, I can no longer run the migration.

This changes the migration to extract data from the old calculator records with SQL queries instead of instantiating them. It should produce identical results, but it can migrate databases with old calculator records even if the calculator files have been deleted.
