### PR TITLE
Fixes missing </div> on order edit page 

### DIFF
--- a/frontend/app/views/spree/orders/edit.html.erb
+++ b/frontend/app/views/spree/orders/edit.html.erb
@@ -18,12 +18,13 @@
 
           <div class="links col-md-6 navbar-form pull-right text-right" data-hook="cart_buttons">
             <div class="form-group">
-            <%= button_tag class: 'btn btn-primary', id: 'update-button' do %>
-              <%= Spree.t(:update) %>
-            <% end %>
-            <%= button_tag class: 'btn btn-lg btn-success', id: 'checkout-link', name: 'checkout' do %>
-              <%= Spree.t(:checkout) %>
-            <% end %>
+              <%= button_tag class: 'btn btn-primary', id: 'update-button' do %>
+                <%= Spree.t(:update) %>
+              <% end %>
+              <%= button_tag class: 'btn btn-lg btn-success', id: 'checkout-link', name: 'checkout' do %>
+                <%= Spree.t(:checkout) %>
+              <% end %>
+            </div>
           </div>
         </div>
       <% end %>


### PR DESCRIPTION
This was causing the rest of the template to render improperly. It was simply missed due to indentation mistake
