### PR TITLE
Only allow Spree::Order filtering for ordered Variants.

### DIFF
--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -53,7 +53,7 @@
 
         <div class="field">
           <%= label_tag :q_line_items_variant_id_in, Spree.t(:sku) %>
-          <%= f.select :line_items_variant_id_in, Spree::Variant.pluck(:sku, :id), {:include_blank => true}, :class => 'select2' %>
+          <%= f.select :line_items_variant_id_in, Spree::Variant.having_orders.order(:sku).pluck(:sku, :id), {:include_blank => true}, :class => 'select2' %>
         </div>
       </div>
 

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -48,6 +48,10 @@ module Spree
       joins(:prices).where(deleted_at: nil).where('spree_prices.currency' => currency || Spree::Config[:currency]).where('spree_prices.amount IS NOT NULL')
     end
 
+    def self.having_orders
+      joins(:line_items).distinct
+    end
+
     def tax_category
       if self[:tax_category_id].nil?
         product.tax_category


### PR DESCRIPTION
This backports #6183 to 2-4-stable where the problem also exists.
