### PR TITLE
Remove some now unnessecary indexes.

### DIFF
--- a/core/db/migrate/20150317174308_remove_duplicated_indexes_from_multi_columns.rb
+++ b/core/db/migrate/20150317174308_remove_duplicated_indexes_from_multi_columns.rb
@@ -1,0 +1,18 @@
+class RemoveDuplicatedIndexesFromMultiColumns < ActiveRecord::Migration
+  def change
+    remove_index :spree_adjustments, name: "index_adjustments_on_order_id"
+    remove_index :spree_option_types_prototypes, :prototype_id
+    add_index :spree_option_types_prototypes, :option_type_id
+    remove_index :spree_option_values_variants, name: 'index_option_values_variants_on_option_value_and_variant'
+    remove_index :spree_option_values_variants, :variant_id
+    add_index :spree_option_values_variants, :option_value_id
+    remove_index :spree_orders, :user_id
+    remove_index :spree_orders_promotions, [:order_id, :promotion_id]
+    add_index :spree_orders_promotions, :order_id
+    remove_index :spree_products_promotion_rules, name: "index_products_promotion_rules_on_promotion_rule_id"
+    remove_index :spree_promotion_rules_users, name: "index_promotion_rules_users_on_user_id"
+    remove_index :spree_properties_prototypes, :prototype_id
+    remove_index :spree_stock_items, :stock_location_id
+    remove_index :spree_taxons_prototypes, :prototype_id
+  end
+end


### PR DESCRIPTION
Read more here: https://github.com/spree/spree/commit/940a382dff9a2bb88013c4aa25d59a3d7484ec9e#commitcomment-10242033

I'm not sure if on some join tables if we would want to do both for query planner to work both ways for example:
    add_index :spree_orders_promotions, [:promotion_id, :order_id]
    add_index :spree_orders_promotions, [:order_id, :promotion_id]

/cc @gmacdougall @mvidaurre
