### PR TITLE
Order importer will set created_at on payment if present

### DIFF
--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -192,6 +192,7 @@ module Spree
               # Order API should be using state as that's the normal payment field.
               # spree_wombat serializes payment state as status so imported orders should fall back to status field.
               payment.state = p[:state] || p[:status] || 'completed'
+              payment.created_at = p[:created_at] if p[:created_at]
               payment.payment_method = Spree::PaymentMethod.find_by_name!(p[:payment_method])
               payment.source = create_source_payment_from_params(p[:source], payment) if p[:source]
               payment.save!

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -49,14 +49,14 @@ module Spree
                    completed_at: Time.now,
                    line_items_attributes: line_items }
 
-        order = Importer::Order.import(user,params)
+        order = Importer::Order.import(user, params)
         expect(order).to be_completed
         expect(order.state).to eq 'complete'
       end
 
       it "assigns order[email] over user email to order" do
         params = { email: 'wooowww@test.com' }
-        order = Importer::Order.import(user,params)
+        order = Importer::Order.import(user, params)
         expect(order.email).to eq params[:email]
       end
 
@@ -90,7 +90,7 @@ module Spree
         params = { :line_items_attributes => line_items }
 
         expect(Importer::Order).to receive(:ensure_variant_id_from_params).and_return({variant_id: variant.id, quantity: 5})
-        order = Importer::Order.import(user,params)
+        order = Importer::Order.import(user, params)
         expect(order.user).to eq(nil)
         line_item = order.line_items.first
         expect(line_item.quantity).to eq(5)
@@ -102,7 +102,7 @@ module Spree
         params = { line_items_attributes: line_items }
 
         expect {
-          order = Importer::Order.import(user,params)
+          order = Importer::Order.import(user, params)
         }.to raise_error /XXX/
       end
 
@@ -118,7 +118,7 @@ module Spree
       it 'can build an order from API with variant sku' do
         params = { line_items_attributes: [{ sku: sku, quantity: 5 }] }
 
-        order = Importer::Order.import(user,params)
+        order = Importer::Order.import(user, params)
 
         line_item = order.line_items.first
         expect(line_item.variant_id).to eq(variant_id)
@@ -128,7 +128,7 @@ module Spree
       it 'handles exceptions when sku is not found' do
         params = { line_items_attributes: [{ sku: 'XXX', quantity: 5 }] }
         expect {
-          order = Importer::Order.import(user,params)
+          order = Importer::Order.import(user, params)
         }.to raise_error /XXX/
       end
 
@@ -136,7 +136,7 @@ module Spree
         params = { :ship_address_attributes => ship_address,
                    :line_items_attributes => line_items }
 
-        order = Importer::Order.import(user,params)
+        order = Importer::Order.import(user, params)
         expect(order.ship_address.address1).to eq '123 Testable Way'
       end
 
@@ -146,7 +146,7 @@ module Spree
         params = { :ship_address_attributes => ship_address,
                    :line_items_attributes => line_items }
 
-        order = Importer::Order.import(user,params)
+        order = Importer::Order.import(user, params)
         expect(order.ship_address.country.iso).to eq 'US'
       end
 
@@ -157,7 +157,7 @@ module Spree
                    :line_items_attributes => line_items }
 
         expect {
-          order = Importer::Order.import(user,params)
+          order = Importer::Order.import(user, params)
         }.to raise_error /XXX/
       end
 
@@ -169,7 +169,7 @@ module Spree
           line_items_attributes: line_items
         }
 
-        order = Importer::Order.import(user,params)
+        order = Importer::Order.import(user, params)
         expect(order.ship_address.state.name).to eq 'Alabama'
       end
 
@@ -180,7 +180,7 @@ module Spree
           params = {
             currency: "GBP"
           }
-          order = Importer::Order.import(user,params)
+          order = Importer::Order.import(user, params)
           expect(order.currency).to eq "GBP"
         end
 
@@ -213,7 +213,7 @@ module Spree
         end
 
         it 'sets states name instead of state id' do
-          order = Importer::Order.import(user,params)
+          order = Importer::Order.import(user, params)
           expect(order.ship_address.state_name).to eq other_state.name
         end
       end
@@ -224,7 +224,7 @@ module Spree
         params = { :ship_address_attributes => ship_address,
                    :line_items_attributes => line_items }
 
-        order = Importer::Order.import(user,params)
+        order = Importer::Order.import(user, params)
         expect(order.ship_address.state_name).to eq 'XXX'
       end
 
@@ -329,7 +329,7 @@ module Spree
         it "raises if cant find stock location" do
           params[:shipments_attributes][0][:stock_location] = "doesnt exist"
           expect {
-            order = Importer::Order.import(user,params)
+            order = Importer::Order.import(user, params)
           }.to raise_error
         end
 
@@ -403,86 +403,96 @@ module Spree
           ]
         }
 
-        order = Importer::Order.import(user,params)
+        order = Importer::Order.import(user, params)
         expect(order.item_total).to eq(166.1)
         expect(order.total).to eq(163.1) # = item_total (166.1) - adjustment_total (3.00)
       end
 
       it 'handles adjustment building exceptions' do
-        params = { :adjustments_attributes => [
+        params = { adjustments_attributes: [
             { amount: 'XXX' },
             { label: 'Promotion Discount', amount: '-3.00' }] }
 
         expect {
-          order = Importer::Order.import(user,params)
+          order = Importer::Order.import(user, params)
         }.to raise_error /XXX/
       end
 
       it 'builds a payment using state' do
-        params = { :payments_attributes => [{ amount: '4.99',
-                                              payment_method: payment_method.name,
-                                              state: 'completed' }] }
-        order = Importer::Order.import(user,params)
+        params = { payments_attributes: [{ amount: '4.99',
+                                           payment_method: payment_method.name,
+                                           state: 'completed' }] }
+        order = Importer::Order.import(user, params)
         expect(order.payments.first.amount).to eq 4.99
       end
 
       it 'builds a payment using status as fallback' do
-        params = { :payments_attributes => [{ amount: '4.99',
-                                              payment_method: payment_method.name,
-                                              status: 'completed' }] }
-        order = Importer::Order.import(user,params)
+        params = { payments_attributes: [{ amount: '4.99',
+                                           payment_method: payment_method.name,
+                                           status: 'completed' }] }
+        order = Importer::Order.import(user, params)
         expect(order.payments.first.amount).to eq 4.99
       end
 
       it 'handles payment building exceptions' do
-        params = { :payments_attributes => [{ amount: '4.99',
-                                              payment_method: 'XXX' }] }
+        params = { payments_attributes: [{ amount: '4.99',
+                                           payment_method: 'XXX' }] }
         expect {
           order = Importer::Order.import(user, params)
         }.to raise_error /XXX/
       end
 
       it 'build a source payment using years and month' do
-        params = { :payments_attributes => [{
-                                              amount: '4.99',
-                                              payment_method: payment_method.name,
-                                              status: 'completed',
-                                              source: {
-                                                name: 'Fox',
-                                                last_digits: "7424",
-                                                cc_type: "visa",
-                                                year: '2022',
-                                                month: "5"
-                                              }
-                                            }]}
+        params = { payments_attributes: [{
+                                           amount: '4.99',
+                                           payment_method: payment_method.name,
+                                           status: 'completed',
+                                           source: {
+                                             name: 'Fox',
+                                             last_digits: "7424",
+                                             cc_type: "visa",
+                                             year: '2022',
+                                             month: "5"
+                                           }
+                                         }]}
 
         order = Importer::Order.import(user, params)
         expect(order.payments.first.source.last_digits).to eq '7424'
       end
 
       it 'handles source building exceptions when do not have years and month' do
-        params = { :payments_attributes => [{
-                                              amount: '4.99',
-                                              payment_method: payment_method.name,
-                                              status: 'completed',
-                                              source: {
-                                                name: 'Fox',
-                                                last_digits: "7424",
-                                                cc_type: "visa"
-                                              }
-                                            }]}
+        params = { payments_attributes: [{
+                                           amount: '4.99',
+                                           payment_method: payment_method.name,
+                                           status: 'completed',
+                                           source: {
+                                             name: 'Fox',
+                                             last_digits: "7424",
+                                             cc_type: "visa"
+                                           }
+                                         }]}
 
         expect {
           order = Importer::Order.import(user, params)
         }.to raise_error /Validation failed: Credit card Month is not a number, Credit card Year is not a number/
       end
 
+      it 'builds a payment with an optional completed_at' do
+        created_at = 2.days.ago
+        params = { payments_attributes: [{ amount: '4.99',
+                                           payment_method: payment_method.name,
+                                           state: 'completed',
+                                           created_at: created_at }] }
+        order = Importer::Order.import(user, params)
+        expect(order.payments.first.created_at).to eq created_at
+      end
+
       context "raises error" do
         it "clears out order from db" do
-          params = { :payments_attributes => [{ payment_method: "XXX" }] }
+          params = { payments_attributes: [{ payment_method: "XXX" }] }
           count = Order.count
 
-          expect { order = Importer::Order.import(user,params) }.to raise_error
+          expect { order = Importer::Order.import(user, params) }.to raise_error
           expect(Order.count).to eq count
         end
       end

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -102,16 +102,16 @@ module Spree
         params = { line_items_attributes: line_items }
 
         expect {
-          order = Importer::Order.import(user, params)
+          Importer::Order.import(user, params)
         }.to raise_error /XXX/
       end
 
       it 'handles line_item updating exceptions' do
         line_items.first[:currency] = 'GBP'
-        params = { :line_items_attributes => line_items }
+        params = { line_items_attributes: line_items }
 
         expect {
-          order = Importer::Order.import(user, params)
+          Importer::Order.import(user, params)
         }.to raise_error /Validation failed/
       end
 
@@ -128,7 +128,7 @@ module Spree
       it 'handles exceptions when sku is not found' do
         params = { line_items_attributes: [{ sku: 'XXX', quantity: 5 }] }
         expect {
-          order = Importer::Order.import(user, params)
+          Importer::Order.import(user, params)
         }.to raise_error /XXX/
       end
 
@@ -153,11 +153,11 @@ module Spree
       it 'handles country lookup exceptions' do
         ship_address.delete(:country_id)
         ship_address[:country] = { 'iso' => 'XXX' }
-        params = { :ship_address_attributes => ship_address,
-                   :line_items_attributes => line_items }
+        params = { ship_address_attributes: ship_address,
+                   line_items_attributes: line_items }
 
         expect {
-          order = Importer::Order.import(user, params)
+          Importer::Order.import(user, params)
         }.to raise_error /XXX/
       end
 
@@ -329,7 +329,7 @@ module Spree
         it "raises if cant find stock location" do
           params[:shipments_attributes][0][:stock_location] = "doesnt exist"
           expect {
-            order = Importer::Order.import(user, params)
+            Importer::Order.import(user, params)
           }.to raise_error
         end
 
@@ -414,7 +414,7 @@ module Spree
             { label: 'Promotion Discount', amount: '-3.00' }] }
 
         expect {
-          order = Importer::Order.import(user, params)
+          Importer::Order.import(user, params)
         }.to raise_error /XXX/
       end
 
@@ -444,17 +444,17 @@ module Spree
 
       it 'build a source payment using years and month' do
         params = { payments_attributes: [{
-                                           amount: '4.99',
-                                           payment_method: payment_method.name,
-                                           status: 'completed',
-                                           source: {
-                                             name: 'Fox',
-                                             last_digits: "7424",
-                                             cc_type: "visa",
-                                             year: '2022',
-                                             month: "5"
-                                           }
-                                         }]}
+                                          amount: '4.99',
+                                          payment_method: payment_method.name,
+                                          status: 'completed',
+                                          source: {
+                                            name: 'Fox',
+                                            last_digits: "7424",
+                                            cc_type: "visa",
+                                            year: '2022',
+                                            month: "5"
+                                          }
+                                        }] }
 
         order = Importer::Order.import(user, params)
         expect(order.payments.first.source.last_digits).to eq '7424'
@@ -462,29 +462,29 @@ module Spree
 
       it 'handles source building exceptions when do not have years and month' do
         params = { payments_attributes: [{
-                                           amount: '4.99',
-                                           payment_method: payment_method.name,
-                                           status: 'completed',
-                                           source: {
-                                             name: 'Fox',
-                                             last_digits: "7424",
-                                             cc_type: "visa"
-                                           }
-                                         }]}
+                                          amount: '4.99',
+                                          payment_method: payment_method.name,
+                                          status: 'completed',
+                                          source: {
+                                            name: 'Fox',
+                                            last_digits: "7424",
+                                            cc_type: "visa"
+                                          }
+                                        }] }
 
         expect {
           order = Importer::Order.import(user, params)
         }.to raise_error /Validation failed: Credit card Month is not a number, Credit card Year is not a number/
       end
 
-      it 'builds a payment with an optional completed_at' do
+      it 'builds a payment with an optional created_at' do
         created_at = 2.days.ago
         params = { payments_attributes: [{ amount: '4.99',
                                            payment_method: payment_method.name,
                                            state: 'completed',
                                            created_at: created_at }] }
         order = Importer::Order.import(user, params)
-        expect(order.payments.first.created_at).to eq created_at
+        expect(order.payments.first.created_at).to be_within(0.1).of created_at
       end
 
       context "raises error" do
@@ -492,7 +492,7 @@ module Spree
           params = { payments_attributes: [{ payment_method: "XXX" }] }
           count = Order.count
 
-          expect { order = Importer::Order.import(user, params) }.to raise_error
+          expect { Importer::Order.import(user, params) }.to raise_error
           expect(Order.count).to eq count
         end
       end


### PR DESCRIPTION
This allows the created_at attribute of a payment to be passed in while creating an order with the order importer.
