### PR TITLE
Removed accidentally committed # binding.pry

### DIFF
--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -97,7 +97,6 @@ RSpec.configure do |config|
   config.after(:each, :type => :feature) do |example|
     missing_translations = page.body.scan(/translation missing: #{I18n.locale}\.(.*?)[\s<\"&]/)
     if missing_translations.any?
-      #binding.pry
       puts "Found missing translations: #{missing_translations.inspect}"
       puts "In spec: #{example.location}"
     end


### PR DESCRIPTION
This was introduced in 08bed4f0, seems like by mistake.
