### PR TITLE
update release notes

### DIFF
--- a/guides/content/release_notes/3_0_0.md
+++ b/guides/content/release_notes/3_0_0.md
@@ -128,7 +128,7 @@ You can view the full changes using [Github Compare](https://github.com/spree/sp
 
     https://github.com/spree/spree/pull/6097
 
-* Moved current_currency helper from Spree::Core::ControllerHelpers::Order to Spree::Core::ControllerHelpers::Order.
+* Moved current_currency helper from Spree::Core::ControllerHelpers::Order to Spree::Core::ControllerHelpers::Store.
 
 * The line items order population endpoint used to accept a hash, it now accepts an array. When submitting a Post request to `/api/line_items` you will receive this deprecation warning:
 


### PR DESCRIPTION
current_currency has been moved to Spree::Core::ControllerHelpers::Store
