### PR TITLE
Remove the permalink where like query in favour of equality.

### DIFF
--- a/core/lib/spree/core/permalinks.rb
+++ b/core/lib/spree/core/permalinks.rb
@@ -53,7 +53,7 @@ module Spree
 
           field = self.class.permalink_field
             # Do other links exist with this permalink?
-            other = self.class.where("#{self.class.table_name}.#{field} LIKE ?", "#{permalink_value}%")
+            other = self.class.where("#{self.class.table_name}.#{field} = ?", "#{permalink_value}")
             if other.any?
               # Find the existing permalink with the highest number, and increment that number.
               # (If none of the existing permalinks have a number, this will evaluate to 1.)


### PR DESCRIPTION
Where like **cannot** take advantage of database indices and therefore
has to do a full table scan every time. This change replaces the like
query with an exact match, not sure why spree was doing a prefix match
before, but I don't think this will break anything. Thoughts
appreciated.

We found this by looking at our newrelic traces over here at Lostmy.name
