### PR TITLE
Fix unpermitted param  during checkout payment update to fix #6203

### DIFF
--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -235,6 +235,8 @@ module Spree
 
               # Set existing card after setting permitted parameters because
               # rails would slice parameters containg ruby objects, apparently
+             #  existing_card_id = @updating_params[:order] ? @updating_params[:order][:existing_card] : nil
+
               if existing_card_id.present?
                 credit_card = CreditCard.find existing_card_id
                 if credit_card.user_id != self.user_id || credit_card.user_id.blank?

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -229,12 +229,12 @@ module Spree
             success = false
             @updating_params = params
             run_callbacks :updating_from_params do
+              existing_card_id = @updating_params[:order] ? @updating_params[:order].delete(:existing_card) : nil
+
               attributes = @updating_params[:order] ? @updating_params[:order].permit(permitted_params).delete_if { |k,v| v.nil? } : {}
 
               # Set existing card after setting permitted parameters because
               # rails would slice parameters containg ruby objects, apparently
-              existing_card_id = @updating_params[:order] ? @updating_params[:order][:existing_card] : nil
-
               if existing_card_id.present?
                 credit_card = CreditCard.find existing_card_id
                 if credit_card.user_id != self.user_id || credit_card.user_id.blank?

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -695,6 +695,34 @@ describe Spree::Order, :type => :model do
         order.update_from_params(params, permitted_params)
       end
 
+      context 'has existing_card param' do
+        let(:permitted_params) do
+          Spree::PermittedAttributes.checkout_attributes +
+            [payments_attributes: Spree::PermittedAttributes.payment_attributes]
+        end
+        let(:credit_card) { create(:credit_card, user_id: order.user_id) }
+        let(:params) do
+          ActionController::Parameters.new(
+            order: { payments_attributes: [{payment_method_id: 1}], existing_card: credit_card.id }
+          )
+        end
+
+        before do
+          Dummy::Application.config.action_controller.action_on_unpermitted_parameters = :raise
+          order.user_id = 3
+        end
+
+        after do
+          Dummy::Application.config.action_controller.action_on_unpermitted_parameters = :log
+        end
+
+        it 'does not attempt to permit existing_card' do
+          expect {
+            order.update_from_params(params, permitted_params)
+          }.not_to raise_error
+        end
+      end
+
       context 'has allowed params' do
         let(:params) { ActionController::Parameters.new(order: {  good_param: 'okay' } ) }
 


### PR DESCRIPTION
Retrieve the `:existing_card` param and remove it from the params hash before calling `.permit`.
