### PR TITLE
Remove line_items resource from routes.rb

### DIFF
--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -91,7 +91,6 @@ Spree::Core::Engine.add_routes do
       end
 
       resources :adjustments
-      resources :line_items
       resources :return_authorizations do
         member do
           put :fire


### PR DESCRIPTION
Hey,
It looks like this one line `resources :line_items` is unnecessary, there is no `line_items_controller.rb` in backend part.
