### PR TITLE
Fix variant price modifier amount

### DIFF
--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -177,7 +177,7 @@ module Spree
       return 0 unless options.present?
 
       options.keys.map { |key|
-        m = "#{options[key]}_price_modifier_amount".to_sym
+        m = "#{key}_price_modifier_amount".to_sym
         if self.respond_to? m
           self.send(m, options[key])
         else


### PR DESCRIPTION
Compare the following two lines in Spree::Variant...
https://github.com/spree/spree/blob/master/core/app/models/spree/variant.rb#L167
https://github.com/spree/spree/blob/master/core/app/models/spree/variant.rb#L180

It looks to me like line 167 is correct and line 180 should match.
