### PR TITLE
Remove unused user_id index from spree_state_changes

### DIFF
--- a/core/db/migrate/20150324104002_remove_user_index_from_spree_state_changes.rb
+++ b/core/db/migrate/20150324104002_remove_user_index_from_spree_state_changes.rb
@@ -1,0 +1,14 @@
+class RemoveUserIndexFromSpreeStateChanges < ActiveRecord::Migration
+  def up
+    if index_exists? :spree_state_changes, :user_id
+      remove_index :spree_state_changes, :user_id
+    end
+
+  end
+
+  def down
+    unless index_exists? :spree_state_changes, :user_id
+      add_index :spree_state_changes, :user_id
+    end
+  end
+end


### PR DESCRIPTION
This index isn't being used anywhere.

Closes #6217
