### PR TITLE
Add admin_tabs data hook to admin main menu

### DIFF
--- a/backend/app/views/spree/admin/shared/_main_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_main_menu.html.erb
@@ -1,35 +1,37 @@
-<% if can? :admin, Spree::Order %>
-  <ul class="nav nav-sidebar">
-    <%= tab *Spree::BackendConfiguration::ORDER_TABS, icon: 'shopping-cart' %>
-  </ul>
-<% end %>
+<div data-hook="admin_tabs">
+  <% if can? :admin, Spree::Order %>
+    <ul class="nav nav-sidebar">
+      <%= tab *Spree::BackendConfiguration::ORDER_TABS, icon: 'shopping-cart' %>
+    </ul>
+  <% end %>
 
-<% if can? :admin, Spree::Product %>
-  <ul class="nav nav-sidebar">
-    <%= main_menu_tree Spree.t(:products), icon: "th-large", sub_menu: "product", url: "#sidebar-product" %>
-  </ul>
-<% end %>
+  <% if can? :admin, Spree::Product %>
+    <ul class="nav nav-sidebar">
+      <%= main_menu_tree Spree.t(:products), icon: "th-large", sub_menu: "product", url: "#sidebar-product" %>
+    </ul>
+  <% end %>
 
-<% if can? :admin, Spree::Admin::ReportsController %>
-  <ul class="nav nav-sidebar">
-    <%= tab *Spree::BackendConfiguration::REPORT_TABS, icon: 'file'  %>
-  </ul>
-<% end %>
+  <% if can? :admin, Spree::Admin::ReportsController %>
+    <ul class="nav nav-sidebar">
+      <%= tab *Spree::BackendConfiguration::REPORT_TABS, icon: 'file'  %>
+    </ul>
+  <% end %>
 
-<% if can? :admin, Spree::Promotion %>
-  <ul class="nav nav-sidebar">
-    <%= main_menu_tree Spree.t(:promotions), icon: "gift", sub_menu: "promotion", url: "#sidebar-promotions" %>
-  </ul>
-<% end %>
+  <% if can? :admin, Spree::Promotion %>
+    <ul class="nav nav-sidebar">
+      <%= main_menu_tree Spree.t(:promotions), icon: "gift", sub_menu: "promotion", url: "#sidebar-promotions" %>
+    </ul>
+  <% end %>
 
-<% if Spree.user_class && can?(:admin, Spree.user_class) %>
-  <ul class="nav nav-sidebar">
-    <%= tab *Spree::BackendConfiguration::USER_TABS, url: spree.admin_users_path, icon: 'user' %>
-  </ul>
-<% end %>
+  <% if Spree.user_class && can?(:admin, Spree.user_class) %>
+    <ul class="nav nav-sidebar">
+      <%= tab *Spree::BackendConfiguration::USER_TABS, url: spree.admin_users_path, icon: 'user' %>
+    </ul>
+  <% end %>
 
-<% if can? :admin, current_store %>
-  <ul class="nav nav-sidebar">
-    <%= main_menu_tree Spree.t(:configurations), icon: "wrench", sub_menu: "configuration", url: "#sidebar-configuration" %>
-  </ul>
-<% end %>
+  <% if can? :admin, current_store %>
+    <ul class="nav nav-sidebar">
+      <%= main_menu_tree Spree.t(:configurations), icon: "wrench", sub_menu: "configuration", url: "#sidebar-configuration" %>
+    </ul>
+  <% end %>
+</div>

--- a/backend/app/views/spree/admin/shared/_main_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_main_menu.html.erb
@@ -1,37 +1,35 @@
-<div data-hook="admin_tabs">
-  <% if can? :admin, Spree::Order %>
-    <ul class="nav nav-sidebar">
-      <%= tab *Spree::BackendConfiguration::ORDER_TABS, icon: 'shopping-cart' %>
-    </ul>
-  <% end %>
+<% if can? :admin, Spree::Order %>
+  <ul class="nav nav-sidebar">
+    <%= tab *Spree::BackendConfiguration::ORDER_TABS, icon: 'shopping-cart' %>
+  </ul>
+<% end %>
 
-  <% if can? :admin, Spree::Product %>
-    <ul class="nav nav-sidebar">
-      <%= main_menu_tree Spree.t(:products), icon: "th-large", sub_menu: "product", url: "#sidebar-product" %>
-    </ul>
-  <% end %>
+<% if can? :admin, Spree::Product %>
+  <ul class="nav nav-sidebar">
+    <%= main_menu_tree Spree.t(:products), icon: "th-large", sub_menu: "product", url: "#sidebar-product" %>
+  </ul>
+<% end %>
 
-  <% if can? :admin, Spree::Admin::ReportsController %>
-    <ul class="nav nav-sidebar">
-      <%= tab *Spree::BackendConfiguration::REPORT_TABS, icon: 'file'  %>
-    </ul>
-  <% end %>
+<% if can? :admin, Spree::Admin::ReportsController %>
+  <ul class="nav nav-sidebar">
+    <%= tab *Spree::BackendConfiguration::REPORT_TABS, icon: 'file'  %>
+  </ul>
+<% end %>
 
-  <% if can? :admin, Spree::Promotion %>
-    <ul class="nav nav-sidebar">
-      <%= main_menu_tree Spree.t(:promotions), icon: "gift", sub_menu: "promotion", url: "#sidebar-promotions" %>
-    </ul>
-  <% end %>
+<% if can? :admin, Spree::Promotion %>
+  <ul class="nav nav-sidebar">
+    <%= main_menu_tree Spree.t(:promotions), icon: "gift", sub_menu: "promotion", url: "#sidebar-promotions" %>
+  </ul>
+<% end %>
 
-  <% if Spree.user_class && can?(:admin, Spree.user_class) %>
-    <ul class="nav nav-sidebar">
-      <%= tab *Spree::BackendConfiguration::USER_TABS, url: spree.admin_users_path, icon: 'user' %>
-    </ul>
-  <% end %>
+<% if Spree.user_class && can?(:admin, Spree.user_class) %>
+  <ul class="nav nav-sidebar">
+    <%= tab *Spree::BackendConfiguration::USER_TABS, url: spree.admin_users_path, icon: 'user' %>
+  </ul>
+<% end %>
 
-  <% if can? :admin, current_store %>
-    <ul class="nav nav-sidebar">
-      <%= main_menu_tree Spree.t(:configurations), icon: "wrench", sub_menu: "configuration", url: "#sidebar-configuration" %>
-    </ul>
-  <% end %>
-</div>
+<% if can? :admin, current_store %>
+  <ul class="nav nav-sidebar">
+    <%= main_menu_tree Spree.t(:configurations), icon: "wrench", sub_menu: "configuration", url: "#sidebar-configuration" %>
+  </ul>
+<% end %>

--- a/backend/app/views/spree/layouts/admin.html.erb
+++ b/backend/app/views/spree/layouts/admin.html.erb
@@ -30,7 +30,7 @@
         <%#-------------------------------------------------%>
         <%# Sidebar                                         %>
         <%#-------------------------------------------------%>
-        <div class="col-sm-3 col-md-2 hidden-xs sidebar" id="main-sidebar">
+        <div class="col-sm-3 col-md-2 hidden-xs sidebar" id="main-sidebar" data-hook="admin_tabs">
           <%= render partial: 'spree/admin/shared/main_menu' %>
         </div>
 


### PR DESCRIPTION
Trying to update spree_drop_ship to spree 3.0 it seems admin_tabs data-hook is missing.

I see that admin menu has changed so maybe there is a better way to add new tabs from an extension. (a class eval in Spree::BackendConfiguration ?) If not please consider to re-add it. Thanks :)
