### PR TITLE
Remove extra query to searcher in products partial.

### DIFF
--- a/frontend/app/views/spree/shared/_products.html.erb
+++ b/frontend/app/views/spree/shared/_products.html.erb
@@ -1,11 +1,6 @@
-<%
-  paginated_products = @searcher.retrieve_products if params.key?(:keywords)
-  paginated_products ||= products
-%>
-
 <% content_for :head do %>
-  <% if paginated_products.respond_to?(:num_pages) %>
-    <%= rel_next_prev_link_tags paginated_products %>
+  <% if products.respond_to?(:num_pages) %>
+    <%= rel_next_prev_link_tags products %>
   <% end %>
 <% end %>
 
@@ -45,6 +40,6 @@
   </div>
 <% end %>
 
-<% if paginated_products.respond_to?(:num_pages) %>
-  <%= paginate paginated_products, theme: 'twitter-bootstrap-3' %>
+<% if products.respond_to?(:num_pages) %>
+  <%= paginate products, theme: 'twitter-bootstrap-3' %>
 <% end %>


### PR DESCRIPTION
Pretty much any time we create a searcher we also store the results in a
products variable. That means the code in the view was doing an extra query,
hitting the database instead of just using the cached result.

Should be backported to all versions (was introduced in v0.10.0).
