### PR TITLE
Move .required asterisk inside label on frontend forms, resolves #6232

### DIFF
--- a/frontend/app/views/spree/address/_form.html.erb
+++ b/frontend/app/views/spree/address/_form.html.erb
@@ -2,11 +2,15 @@
 
 <div class="inner" data-hook=<%="#{address_type}_inner" %>>
   <p class="form-group" id=<%="#{address_id}firstname" %>>
-    <%= form.label :firstname, Spree.t(:first_name) %><span class="required">*</span><br />
+    <%= form.label :firstname do %>
+      <%= Spree.t(:first_name) %><abbr class="required" title="required">*</abbr>
+    <% end %>
     <%= form.text_field :firstname, :class => 'form-control required' %>
   </p>
   <p class="form-group" id=<%="#{address_id}lastname" %>>
-    <%= form.label :lastname, Spree.t(:last_name) %><span class="required">*</span><br />
+    <%= form.label :lastname do %>
+      <%= Spree.t(:last_name) %><abbr class="required" title="required">*</abbr>
+    <% end %>
     <%= form.text_field :lastname, :class => 'form-control required' %>
   </p>
   <% if Spree::Config[:company] %>
@@ -16,7 +20,9 @@
     </p>
   <% end %>
   <p class="form-group" id=<%="#{address_id}address1" %>>
-    <%= form.label :address1, Spree.t(:street_address) %><span class="required">*</span><br />
+    <%= form.label :address1 do %>
+      <%= Spree.t(:street_address) %><abbr class="required" title="required">*</abbr>
+    <% end %>
     <%= form.text_field :address1, :class => 'form-control  required' %>
   </p>
   <p class="form-group" id=<%="#{address_id}address2" %>>
@@ -24,11 +30,15 @@
     <%= form.text_field :address2, :class => 'form-control' %>
   </p>
   <p class="form-group" id=<%="#{address_id}city" %>>
-    <%= form.label :city, Spree.t(:city) %><span class="required">*</span><br />
+    <%= form.label :city do %>
+      <%= Spree.t(:city) %><abbr class="required" title="required">*</abbr>
+    <% end %>
     <%= form.text_field :city, :class => 'form-control required' %>
   </p>
   <p class="form-group" id=<%="#{address_id}country" %>>
-    <%= form.label :country_id, Spree.t(:country) %><span class="required">*</span><br />
+    <%= form.label :country_id do %>
+      <%= Spree.t(:country) %><abbr class="required" title="required">*</abbr>
+    <% end %>
     <span id=<%="#{address_id}country-selection" %>>
       <%= form.collection_select :country_id, available_countries, :id, :name, {}, {:class => 'form-control required'} %>
     </span>
@@ -37,7 +47,9 @@
   <% if Spree::Config[:address_requires_state] %>
     <p class="form-group" id=<%="#{address_id}state" %>>
       <% have_states = !address.country.states.empty? %>
-      <%= form.label :state, Spree.t(:state) %><span class='required' id=<%="#{address_id}state-required"%>>*</span><br/>
+      <%= form.label :state do %>
+        <%= Spree.t(:state) %><abbr class='required' title="required" id=<%="#{address_id}state-required"%>>*</abbr>
+      <% end %>
 
       <% state_elements = [
          form.collection_select(:state_id, address.country.states,
@@ -60,11 +72,15 @@
   <% end %>
 
   <p class="form-group" id=<%="#{address_id}zipcode" %>>
-    <%= form.label :zipcode, Spree.t(:zip) %><% if address.require_zipcode? %><span class="required">*</span><br /><% end %>
+    <%= form.label :zipcode do %>
+      <%= Spree.t(:zip) %><% if address.require_zipcode? %><abbr class="required" title="required">*</abbr><% end %>
+    <% end %>
     <%= form.text_field :zipcode, :class => "form-control #{'required' if address.require_zipcode?}" %>
   </p>
   <p class="form-group" id=<%="#{address_id}phone" %>>
-    <%= form.label :phone, Spree.t(:phone) %><% if address.require_phone? %><span class="required">*</span><br /><% end %>
+    <%= form.label :phone do %>
+      <%= Spree.t(:phone) %><% if address.require_phone? %><abbr class="required" title="required">*</abbr><% end %>
+    <% end %>
     <%= form.phone_field :phone, :class => "form-control #{'required' if address.require_phone?}" %>
   </p>
   <% if Spree::Config[:alternative_shipping_phone] %>

--- a/frontend/app/views/spree/checkout/payment/_gateway.html.erb
+++ b/frontend/app/views/spree/checkout/payment/_gateway.html.erb
@@ -3,12 +3,16 @@
   <% param_prefix = "payment_source[#{payment_method.id}]" %>
 
   <p class="field">
-    <%= label_tag "name_on_card_#{payment_method.id}", Spree.t(:name_on_card) %><span class="required">*</span><br />
+    <%= label_tag "name_on_card_#{payment_method.id}" do %>
+      <%= Spree.t(:name_on_card) %><abbr class="required" title="required">*</abbr>
+    <% end %>
     <%= text_field_tag "#{param_prefix}[name]", "#{@order.billing_firstname} #{@order.billing_lastname}", { id: "name_on_card_#{payment_method.id}", :class => 'form-control required'} %>
   </p>
 
   <p class="field" data-hook="card_number">
-    <%= label_tag "card_number", Spree.t(:card_number) %><span class="required">*</span><br />
+    <%= label_tag "card_number" do %>
+      <%= Spree.t(:card_number) %><abbr class="required" title="required">*</abbr>
+    <% end %>
     <% options_hash = Rails.env.production? ? {:autocomplete => 'off'} : {} %>
     <%= text_field_tag "#{param_prefix}[number]", '', options_hash.merge(:id => 'card_number', :class => 'form-control required cardNumber', :size => 19, :maxlength => 19, :autocomplete => "off") %>
     &nbsp;
@@ -20,11 +24,15 @@
   </p>
   <div class="row">
     <div class="col-md-8 field" data-hook="card_expiration">
-      <%= label_tag "card_expiry", Spree.t(:expiration) %><span class="required">*</span><br />
+      <%= label_tag "card_expiry" do %>
+        <%= Spree.t(:expiration) %><abbr class="required" title="required">*</abbr>
+      <% end %>
       <%= text_field_tag "#{param_prefix}[expiry]", '', :id => 'card_expiry', :class => "form-control required cardExpiry", :placeholder => "MM / YY" %>
     </div>
     <div class="col-md-4 field" data-hook="card_code">
-      <%= label_tag "card_code", Spree.t(:card_code) %><span class="required">*</span><br />
+      <%= label_tag "card_code" do %>
+        <%= Spree.t(:card_code) %><abbr class="required" title="required">*</abbr>
+      <% end %>
       <%= text_field_tag "#{param_prefix}[verification_value]", '', options_hash.merge(:id => 'card_code', :class => 'form-control required cardCode', :size => 5) %>
       <%= link_to "(#{Spree.t(:what_is_this)})", spree.content_path('cvv'), :target => '_blank', "data-hook" => "cvv_link", :id => "cvv_link" %>
     </div>


### PR DESCRIPTION
This is to move the required \* inside the label tag on all frontend forms and remove the `br` tag to simplify styling. I've also changed the span tag to an abbr with appropriate title attribute as commonly used for accessibility.
