### PR TITLE
Support line item adjustments in order importer

### DIFF
--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -170,13 +170,25 @@ module Spree
           return [] unless adjustments
           adjustments.each do |a|
             begin
-              adjustment = order.adjustments.build(
-                order:  order,
-                amount: a[:amount].to_f,
-                label:  a[:label]
-              )
-              adjustment.save!
-              adjustment.close!
+              if a[:sku] || a[:variant_id]
+                a = ensure_variant_id_from_params(a)
+                line_item = order.line_items.detect { |li| li.variant_id.to_i == a[:variant_id].to_i }
+                adjustment = line_item.adjustments.build(
+                  order: order,
+                  amount: a[:amount].to_f,
+                  label: a[:label]
+                )
+                adjustment.save!
+                adjustment.close!
+              else
+                adjustment = order.adjustments.build(
+                  order:  order,
+                  amount: a[:amount].to_f,
+                  label:  a[:label]
+                )
+                adjustment.save!
+                adjustment.close!
+              end
             rescue Exception => e
               raise "Order import adjustments: #{e.message} #{a}"
             end

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -390,11 +390,13 @@ module Spree
         expect(order.adjustments.first.amount).to eq -4.99
       end
 
-      it 'adds line item adjustments' do
+      it 'adds line item adjustments from promotion' do
+        line_items.first[:adjustments_attributes] = [
+          { label: 'Line Item Discount', amount: -4.99, promotion: true }
+        ]
         params = {
           line_items_attributes: line_items,
           adjustments_attributes: [
-            { label: 'Line Item Discount', amount: -4.99, variant_id: line_items.first[:variant_id] },
             { label: 'Order Discount', amount: -5.99 }
           ]
         }
@@ -405,15 +407,27 @@ module Spree
         expect(line_item_adjustment.closed?).to be true
         expect(line_item_adjustment.label).to eq 'Line Item Discount'
         expect(line_item_adjustment.amount).to eq -4.99
-
         expect(order.line_items.first.adjustment_total).to eq -4.99
+      end
 
-        order_adjustment = order.adjustments.first
-        expect(order_adjustment.closed?).to be true
-        expect(order_adjustment.label).to eq 'Order Discount'
-        expect(order_adjustment.amount).to eq -5.99
+      it 'adds line item adjustments from taxation' do
+        line_items.first[:adjustments_attributes] = [
+          { label: 'Line Item Tax', amount: -4.99, tax: true }
+        ]
+        params = {
+          line_items_attributes: line_items,
+          adjustments_attributes: [
+            { label: 'Order Discount', amount: -5.99 }
+          ]
+        }
 
-        expect(order.all_adjustments.count).to eq 2
+        order = Importer::Order.import(user, params)
+
+        line_item_adjustment = order.line_item_adjustments.first
+        expect(line_item_adjustment.closed?).to be true
+        expect(line_item_adjustment.label).to eq 'Line Item Tax'
+        expect(line_item_adjustment.amount).to eq -4.99
+        expect(order.line_items.first.adjustment_total).to eq -4.99
       end
 
       it "calculates final order total correctly" do

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -390,6 +390,30 @@ module Spree
         expect(order.adjustments.first.amount).to eq -4.99
       end
 
+      it 'adds line item adjustments' do
+        params = {
+          line_items_attributes: line_items,
+          adjustments_attributes: [
+            { label: 'Line Item Discount', amount: -4.99, variant_id: line_items.first[:variant_id] },
+            { label: 'Order Discount', amount: -5.99 }
+          ]
+        }
+
+        order = Importer::Order.import(user, params)
+
+        line_item_adjustment = order.line_item_adjustments.first
+        expect(line_item_adjustment.closed?).to be true
+        expect(line_item_adjustment.label).to eq 'Line Item Discount'
+        expect(line_item_adjustment.amount).to eq -4.99
+
+        order_adjustment = order.adjustments.first
+        expect(order_adjustment.closed?).to be true
+        expect(order_adjustment.label).to eq 'Order Discount'
+        expect(order_adjustment.amount).to eq -5.99
+
+        expect(order.all_adjustments.count).to eq 2
+      end
+
       it "calculates final order total correctly" do
         params = {
           adjustments_attributes: [

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -406,6 +406,8 @@ module Spree
         expect(line_item_adjustment.label).to eq 'Line Item Discount'
         expect(line_item_adjustment.amount).to eq -4.99
 
+        expect(order.line_items.first.adjustment_total).to eq -4.99
+
         order_adjustment = order.adjustments.first
         expect(order_adjustment.closed?).to be true
         expect(order_adjustment.label).to eq 'Order Discount'


### PR DESCRIPTION
This is a work in progress but I ran into issue #6231. As the code stands now, a line item's adjustment_total attribute isn't getting set correctly. I believe this is because the adjustment doesn't have a source and is therefore not a [promotion](https://github.com/spree/spree/blob/master/core/app/models/spree/adjustment.rb#L65) and it's not a tax.

I believe that adjustment_total is getting set [here](https://github.com/spree/spree/blob/master/core/app/models/spree/adjustable/adjustments_updater.rb#L43).
