### PR TITLE
Removed leftover <br> tags after labels as a result of #6232

### DIFF
--- a/frontend/app/views/spree/address/_form.html.erb
+++ b/frontend/app/views/spree/address/_form.html.erb
@@ -15,7 +15,7 @@
   </p>
   <% if Spree::Config[:company] %>
     <p class="form-group" id=<%="#{address_id}company" %>>
-      <%= form.label :company, Spree.t(:company) %><br />
+      <%= form.label :company, Spree.t(:company) %>
       <%= form.text_field :company, :class => 'form-control' %>
     </p>
   <% end %>
@@ -26,7 +26,7 @@
     <%= form.text_field :address1, :class => 'form-control  required' %>
   </p>
   <p class="form-group" id=<%="#{address_id}address2" %>>
-    <%= form.label :address2, Spree.t(:street_address_2) %><br />
+    <%= form.label :address2, Spree.t(:street_address_2) %>
     <%= form.text_field :address2, :class => 'form-control' %>
   </p>
   <p class="form-group" id=<%="#{address_id}city" %>>
@@ -85,7 +85,7 @@
   </p>
   <% if Spree::Config[:alternative_shipping_phone] %>
     <p class="form-group" id=<%="#{address_id}altphone" %>>
-      <%= form.label :alternative_phone, Spree.t(:alternative_phone) %><br />
+      <%= form.label :alternative_phone, Spree.t(:alternative_phone) %>
       <%= form.phone_field :alternative_phone, :class => 'form-control' %>
     </p>
   <% end %>

--- a/frontend/app/views/spree/checkout/_payment.html.erb
+++ b/frontend/app/views/spree/checkout/_payment.html.erb
@@ -9,7 +9,6 @@
         <label for="use_existing_card_yes">
           <%= Spree.t(:use_existing_cc) %>
         </label>
-        <br/>
         <%= radio_button_tag 'use_existing_card', 'no' %>
         <label for="use_existing_card_no">
           <%= Spree.t(:use_new_cc_or_payment_method) %>
@@ -58,7 +57,7 @@
     </ul>
 
     <p class='field' data-hook='coupon_code'>
-      <%= form.label :coupon_code %><br />
+      <%= form.label :coupon_code %>
       <%= form.text_field :coupon_code, :class => 'form-control' %>
     </p>
   </div>


### PR DESCRIPTION
#6232 Moved required field asterisks inside the label tags in the frontend views and removed the `<br>` tags on those lines to make styling easier. There were several other field labels that were not required that did not get their corresponding `<br>` tags removed to be consistent. This PR fixes that.
