### PR TITLE
Use all_adjustments to access order promotion adjustments

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -105,7 +105,8 @@ module Spree
     end
 
     def adjusted_credits_count(promotable)
-      credits_count - promotable.adjustments.promotion.where(:source_id => actions.pluck(:id)).count
+      adjustments = promotable.is_a?(Order) ? promotable.all_adjustments : promotable.adjustments
+      credits_count - adjustments.promotion.where(:source_id => actions.pluck(:id)).count
     end
 
     def credits

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -207,6 +207,52 @@ describe Spree::Promotion do
     end
   end
 
+  context "#adjusted_credits_count" do
+    let(:order) { create :order }
+    let(:line_item) { create :line_item, order: order }
+    let(:promotion) { Spree::Promotion.create name: "promo", :code => "10off" }
+    let(:order_action) {
+      action = Spree::Promotion::Actions::CreateAdjustment.create(calculator: Spree::Calculator::FlatPercentItemTotal.new)
+      promotion.actions << action
+      action
+    }
+    let(:item_action) {
+      action = Spree::Promotion::Actions::CreateItemAdjustments.create(calculator: Spree::Calculator::FlatPercentItemTotal.new)
+      promotion.actions << action
+      action
+    }
+    let(:order_adjustment) do
+      Spree::Adjustment.create!(
+        :source => order_action,
+        :amount => 10,
+        :adjustable => order,
+        :order => order,
+        :label => "Promotional adjustment"
+      )
+    end
+    let(:item_adjustment) do
+      Spree::Adjustment.create!(
+        :source => item_action,
+        :amount => 10,
+        :adjustable => line_item,
+        :order => order,
+        :label => "Promotional adjustment"
+      )
+    end
+
+    it "counts order level adjustments" do
+      expect(order_adjustment.adjustable).to eq(order)
+      expect(promotion.credits_count).to eq(1)
+      expect(promotion.adjusted_credits_count(order)).to eq(0)
+    end
+
+    it "counts item level adjustments" do
+      expect(item_adjustment.adjustable).to eq(line_item)
+      expect(promotion.credits_count).to eq(1)
+      expect(promotion.adjusted_credits_count(order)).to eq(0)
+    end
+  end
+
   context "#products" do
     let(:promotion) { create(:promotion) }
 


### PR DESCRIPTION
Because the promotion could be at line item level in which case order.adjustments is empty.

So far one small issue is found being caused by this (there could be more serious issue not found yet). Steps to reproduce it:
1. Create a line item level promotion (%10 off) with usage_limit be 1.
2. Add a product to the cart (only one item in the cart after this).
3. Apply the promotion code. It's successfully applied.
4. Apply the promotion code again.

Expected: "The coupon code has already been applied to this order".
Actual: "Coupon code usage limit exceeded."
