### PR TITLE
Fix migration for nil adjustables or orders

### DIFF
--- a/core/db/migrate/20141101231208_fix_adjustment_order_presence.rb
+++ b/core/db/migrate/20141101231208_fix_adjustment_order_presence.rb
@@ -5,7 +5,7 @@ class FixAdjustmentOrderPresence < ActiveRecord::Migration
       adjustable = adjustment.adjustable
       if adjustable.is_a? Spree::Order
         adjustment.update_attributes!(order_id: adjustable.id)
-      else
+      elsif adjustable && adjustable.order
         adjustment.update_attributes!(adjustable: adjustable.order)
       end
     end


### PR DESCRIPTION
I noticed that this migration crashes when `adjustable.order = nil` or when `adjustable = nil`. Adding the following conditional will enable the migration to avoid these crashes.
