### PR TITLE
Replace select of sku with simple text field in orders filter

### DIFF
--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -52,8 +52,8 @@
         </div>
 
         <div class="field">
-          <%= label_tag :q_line_items_variant_id_in, Spree.t(:sku) %>
-          <%= f.select :line_items_variant_id_in, Spree::Variant.having_orders.order(:sku).pluck(:sku, :id), {:include_blank => true}, :class => 'select2' %>
+          <%= label_tag :q_line_items_variant_sku_eq, Spree.t(:sku) %>
+          <%= f.text_field :line_items_variant_sku_eq %>
         </div>
       </div>
 

--- a/backend/spec/features/admin/orders/listing_spec.rb
+++ b/backend/spec/features/admin/orders/listing_spec.rb
@@ -85,13 +85,9 @@ describe "Orders Listing", type: :feature, js: true do
       expect(page).not_to have_content("R200")
     end
 
-    it "should be able to filter on variant_id" do
+    it "should be able to filter on variant_sku" do
       click_on 'Filter'
-      # Insure we have the SKU in the options
-      expect(find('#q_line_items_variant_id_in').all('option').collect(&:text)).to include(@order1.line_items.first.variant.sku)
-
-      # Select and filter
-      find('#q_line_items_variant_id_in').find(:xpath, 'option[2]').select_option
+      fill_in "q_line_items_variant_sku_eq", with: @order1.line_items.first.variant.sku
       click_on 'Filter Results'
 
       within_row(1) do


### PR DESCRIPTION
Replace select of sku with simple text field in orders filter because of big performance issues. 
Fixes #6225
