### PR TITLE
(2-3-Stable) Better handling of coupon code Ajax call

### DIFF
--- a/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js.coffee
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js.coffee
@@ -61,6 +61,7 @@ Spree.ready ($) ->
           )
 
           coupon_status.removeClass();
+          result = false
           $.ajax({
             async: false,
             method: "PUT",
@@ -68,12 +69,13 @@ Spree.ready ($) ->
             success: (data) ->
               coupon_code_field.val('')
               coupon_status.addClass("success").html("Coupon code applied successfully.")
-              return true
+              result = true
             error: (xhr) ->
               handler = JSON.parse(xhr.responseText)
               coupon_status.addClass("error").html(handler["error"])
               $('.continue').attr('disabled', false)
-              return false
+              result = false
           })
+          return result
 
   Spree.onPayment()


### PR DESCRIPTION
The Ajax call made during the submit of the payment form was always submitting even if there was an error processing the coupon code. This fixes it and will not submit the form if there was a problem with the coupon code call.
