### PR TITLE
Product delete fails when slug length more than 244 chars

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -264,7 +264,7 @@ module Spree
 
     def punch_slug
       # punch slug with date prefix to allow reuse of original
-      update_column :slug, "#{Time.now.to_i}_#{slug}" unless frozen?
+      update_column :slug, "#{Time.now.to_i}_#{slug}"[0..254] unless frozen?
     end
 
     def anything_changed?

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -203,10 +203,26 @@ describe Spree::Product, :type => :model do
         expect(product.slug).not_to match "/"
       end
 
-      it "renames slug on destroy" do
-        old_slug = product.slug
-        product.destroy
-        expect(old_slug).to_not eq product.slug
+      context "when product destroyed" do
+
+        it "renames slug" do
+          expect { product.destroy }.to change { product.slug }
+        end
+
+        context "when slug is already at or near max length" do
+
+          before do
+            product.slug = "x" * 255
+            product.save!
+          end
+
+          it "truncates renamed slug to ensure it remains within length limit" do
+            product.destroy
+            expect(product.slug.length).to eq 255
+          end
+
+        end
+
       end
 
       it "validates slug uniqueness" do


### PR DESCRIPTION
Modify punch_slug to ensure total slug length does not surpass maximum default size of varchar(255). Without this, you cannot delete a product that has a slug longer than 244 chars, because punch_slug prepends 11 characters on paranoid delete.

The 255 limit is based on default translation from ActiveRecord string field to mysql and postgres varchar(255).
