### PR TITLE
Update old migration with i18n workaround

### DIFF
--- a/core/db/migrate/20140309033438_create_store_from_preferences.rb
+++ b/core/db/migrate/20140309033438_create_store_from_preferences.rb
@@ -1,5 +1,12 @@
 class CreateStoreFromPreferences < ActiveRecord::Migration
   def change
+    # workaround for spree_i18n and Store translations
+    Spree::Store.class_eval do
+      def self.translated?(name)
+        false
+      end
+    end
+    
     preference_store = Spree::Preferences::Store.instance
     if store = Spree::Store.where(default: true).first
       store.meta_description = preference_store.get('spree/app_configuration/default_meta_description') {}


### PR DESCRIPTION
This should allow to create a new project with the `spree_i18n` gem and `Store` translation.

During this migration we don't have the store translation table yet, so the `save!` is going to fail.
see https://github.com/spree-contrib/spree_i18n/pull/533
