### PR TITLE
Make API base content_type method public.

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -42,8 +42,6 @@ module Spree
         end
       end
 
-      private
-
       def content_type
         case params[:format]
         when "json"
@@ -52,6 +50,8 @@ module Spree
           "text/xml; charset=utf-8"
         end
       end
+
+      private
 
       def set_content_type
         headers["Content-Type"] = content_type


### PR DESCRIPTION
This method needs to be public for use with extensions API controllers and resolve failing specs e.g. https://github.com/spree-contrib/spree_i18n/pull/539
