### PR TITLE
Fixed very long query for taxons on /admin/taxons

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -42,8 +42,6 @@ module Spree
         end
       end
 
-      private
-
       def content_type
         case params[:format]
         when "json"
@@ -52,6 +50,8 @@ module Spree
           "text/xml; charset=utf-8"
         end
       end
+
+      private
 
       def set_content_type
         headers["Content-Type"] = content_type

--- a/backend/app/assets/javascripts/spree/backend/taxons.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/taxons.js.coffee
@@ -24,6 +24,7 @@ $(document).ready ->
         data: (term, page) ->
           per_page: 50,
           page: page,
+          without_children: true,
           token: Spree.api_key,
           q:
             name_cont: term


### PR DESCRIPTION
On /admin/taxons request for taxons very long because of the children

Spree::Taxon.count == 12
Completed 200 OK in 2525ms (Views: 2457.4ms | ActiveRecord: 40.2ms)
vs
Completed 200 OK in 642ms (Views: 580.3ms | ActiveRecord: 26.7ms)

Spree::Taxon.count == 106
Completed 200 OK in 15949ms (Views: 15715.5ms | ActiveRecord: 211.6ms)
vs
Completed 200 OK in 985ms (Views: 865.0ms | ActiveRecord: 89.7ms)
