### PR TITLE
Apply sourceless line item adjustments to adjustment_total

### DIFF
--- a/core/app/models/spree/adjustable/adjustments_updater.rb
+++ b/core/app/models/spree/adjustable/adjustments_updater.rb
@@ -14,6 +14,7 @@ module Spree
         return unless persisted?
         update_promo_adjustments
         update_tax_adjustments
+        update_sourceless_adjustments
         persist_totals
       end
 
@@ -35,12 +36,16 @@ module Spree
         @additional_tax_total = tax.additional.reload.map(&:update!).compact.sum
       end
 
+      def update_sourceless_adjustments
+        @sourceless_total = adjustments.sourceless.reload.map(&:update!).compact.sum
+      end
+
       def persist_totals
         adjustable.update_columns(
           promo_total: @promo_total,
           included_tax_total: @included_tax_total,
           additional_tax_total: @additional_tax_total,
-          adjustment_total: @promo_total + @additional_tax_total,
+          adjustment_total: @promo_total + @additional_tax_total + @sourceless_total,
           updated_at: Time.now
         )
       end

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -55,6 +55,7 @@ module Spree
       source_type = arel_table[:source_type]
       where(source_type.not_eq('Spree::TaxRate').or source_type.eq(nil))
     end
+    scope :sourceless, -> { where(source_type: nil) }
     scope :price, -> { where(adjustable_type: 'Spree::LineItem') }
     scope :shipping, -> { where(adjustable_type: 'Spree::Shipment') }
     scope :optional, -> { where(mandatory: false) }

--- a/core/spec/models/spree/adjustable/adjustments_updater_spec.rb
+++ b/core/spec/models/spree/adjustable/adjustments_updater_spec.rb
@@ -279,8 +279,20 @@ module Spree
           expect(line_item.adjustments.promotion.eligible.count).to eq(1)
           expect(line_item.adjustments.promotion.eligible.first.amount.to_i).to eq(-200)
         end
-      end
 
+        context "sourceless adjustments are accounted for" do
+          before do
+            create(:adjustment, adjustable: line_item, order: order, amount: -5, source: nil)
+          end
+
+          it "should apply the sourceless line item adjustment" do
+            subject.update
+            expect(line_item.adjustments.count).to eq(1)
+            expect(line_item.adjustments.first.source_type).to be_nil
+            expect(line_item.adjustment_total).to eq(-5)
+          end
+        end
+      end
     end
   end
 end

--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -50,6 +50,22 @@ describe Spree::Adjustment, :type => :model do
     end
   end
 
+  describe 'sourceless scope' do
+    subject do
+      Spree::Adjustment.sourceless.to_a
+    end
+
+    let!(:tax_adjustment) { create(:adjustment, order: order, source: create(:tax_rate)) }
+    let!(:non_tax_adjustment_with_source) { create(:adjustment, order: order, source_type: 'Spree::Order', source_id: nil) }
+    let!(:non_tax_adjustment_without_source) { create(:adjustment, order: order, source: nil) }
+
+    it 'selects sourceless adjustments' do
+      expect(subject).to_not include tax_adjustment
+      expect(subject).to_not include non_tax_adjustment_with_source
+      expect(subject).to include non_tax_adjustment_without_source
+    end
+  end
+
   describe 'competing_promos scope' do    
     before do
       allow_any_instance_of(Spree::Adjustment).to receive(:update_adjustable_adjustment_total).and_return(true)


### PR DESCRIPTION
Line Item adjustments required a source_type of 'Spree::TaxRate' or 'Spree::PromotionAction'. This patch allows for line item adjustments without a source. We have these adjustments from our past orders (the promotion is external to Spree but still needs accounting for).

Fixes #6231.
