### PR TITLE
Serializers initial work

### DIFF
--- a/api/app/serializers/spree/base_serializer.rb
+++ b/api/app/serializers/spree/base_serializer.rb
@@ -1,0 +1,9 @@
+module Spree
+  class BaseSerializer < ActiveModel::Serializer
+    extend Spree::Api::ApiHelpers
+
+    def self.attribute_keys
+      name.sub('Serializer', '').constantize.column_names
+    end
+  end
+end

--- a/api/lib/spree/api.rb
+++ b/api/lib/spree/api.rb
@@ -1,6 +1,7 @@
 require 'spree/core'
 
 require 'rabl'
+require 'active_model_serializers'
 
 module Spree
   module Api

--- a/api/spec/serializers/spree/base_serializer_spec.rb
+++ b/api/spec/serializers/spree/base_serializer_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe Spree::BaseSerializer do
+  subject { described_class }
+
+  describe '.attribute_keys' do
+    it 'should return the column names' do
+      allow(Spree::Base).to receive(:column_names) { 'example' }
+      expect(subject.attribute_keys).to eql 'example'
+    end
+  end
+end

--- a/api/spree_api.gemspec
+++ b/api/spree_api.gemspec
@@ -18,5 +18,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'spree_core', version
   gem.add_dependency 'rabl', '~> 0.9.4.pre1'
+  gem.add_dependency 'active_model_serializers', '~> 0.8.3'
   gem.add_dependency 'versioncake', '~> 2.3.1'
 end


### PR DESCRIPTION
This is the initial work for adding AMS. It simply adds a `Spree::BaseSerializer` and a `Spree::BaseSerializer.attribute_keys` method.

The purpose of the `.attribute_keys` method will allow a developer to hook into a serializer and easily override the attributes for a serializer. If they would like to add more its as easy as:

``` ruby
Spree::AddressSerializer.class_eval do
  def self.attribute_keys
    super + %w(continent planet solar_system galaxy)
  end
end
```

Assuming the `Spree::AddressSerializer` is as follows:

``` ruby
module Spree
  class AddressSerializer < Spree::BaseSerializer
    attributes(*attribute_keys)
  end
end
```
