### PR TITLE
Css helper classes + help-block improvements

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/shared/_base.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_base.scss
@@ -12,6 +12,6 @@ body {
 
 // No-margin and no-padding helper classes
 @each $side in top bottom left right {
-  .no-margin-#{$side}  {margin-#{side}: 0}
-  .no-padding-#{$side} {padding-#{side}: 0}
+  .no-margin-#{$side}  { margin-#{side}: 0; }
+  .no-padding-#{$side} { padding-#{side}: 0; }
 }

--- a/backend/app/assets/stylesheets/spree/backend/shared/_base.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_base.scss
@@ -10,6 +10,8 @@ body {
   display: none;
 }
 
-.no-padding-bottom {
-  padding-bottom: 0;
+// No-margin and no-padding helper classes
+@each $side in top bottom left right {
+  .no-margin-#{$side}  {margin-#{side}: 0}
+  .no-padding-#{$side} {padding-#{side}: 0}
 }

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -45,7 +45,7 @@ input.form-control {
 }
 
 .help-block {
-  color: $medium-grey;
+  color: color: lighten($gray-light, 20);
   font-weight: 300;
 }
 

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -45,10 +45,10 @@ input.form-control {
 }
 
 .help-block {
-  color: #A6A6A6;
+  color: $medium-grey;
   font-weight: 300;
 }
 
 .checkbox > .help-block {
-  margin-top: 0px;
+  margin-top: 0;
 }

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -43,3 +43,12 @@ input.form-control {
   display: block;
   width: 100%;
 }
+
+.help-block {
+  color: #A6A6A6;
+  font-weight: 300;
+}
+
+.checkbox > .help-block {
+  margin-top: 0px;
+}

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -45,7 +45,7 @@ input.form-control {
 }
 
 .help-block {
-  color: color: lighten($gray-light, 20);
+  color: lighten($gray-light, 20);
   font-weight: 300;
 }
 


### PR DESCRIPTION
Hello
i've decided to add some css helpers and help-block improvements i've been always using in every spree project. Nothing fancy, just couple of small things. Mainly no-margin/no-padding css helpers and tiny improvement of form help-blocks. You can see how it looks here:
- https://github.com/spree-contrib/spree_i18n/pull/549
- https://github.com/spree-contrib/spree_multi_currency/pull/39#issuecomment-91491846

![](https://cloud.githubusercontent.com/assets/581569/7085182/7552db04-df74-11e4-9f54-ef058429a1c6.png)
