### PR TITLE
Fix Track Inventory checkbox in Product > Stock

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/variant_management.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/variant_management.js.coffee
@@ -1,10 +1,10 @@
 jQuery ->
   $('.track_inventory_checkbox').on 'click', ->
-    $(@).siblings('.variant_track_inventory').val($(@).is(':checked'))
-    $(@).parents('form').submit()
+    $(this).siblings('.variant_track_inventory').val($(this).is(':checked'))
+    $(this).parents('form').submit()
   $('.toggle_variant_track_inventory').on 'submit', ->
     $.ajax
       type: @method
       url: @action
-      data: $(@).serialize()
+      data: $(this).serialize()
     false

--- a/backend/app/assets/javascripts/spree/backend/variant_management.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/variant_management.js.coffee
@@ -1,5 +1,6 @@
 jQuery ->
   $('.track_inventory_checkbox').on 'click', ->
+    $(@).siblings('.variant_track_inventory').val($(@).is(':checked'))
     $(@).parents('form').submit()
   $('.toggle_variant_track_inventory').on 'submit', ->
     $.ajax

--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -33,7 +33,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
       flash[:success] = flash_message_for(@object, :successfully_updated)
       respond_with(@object) do |format|
         format.html { redirect_to location_after_save }
-        format.js   { render layout: false }
+        format.js { render layout: false }
       end
     else
       invoke_callbacks(:update, :fails)
@@ -240,6 +240,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
     end
   end
 
+  # This method should be overridden when object_name does not match the controller name
   def object_name
   end
 

--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -33,7 +33,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
       flash[:success] = flash_message_for(@object, :successfully_updated)
       respond_with(@object) do |format|
         format.html { redirect_to location_after_save }
-        format.js   { render :layout => false }
+        format.js   { render layout: false }
       end
     else
       invoke_callbacks(:update, :fails)
@@ -125,7 +125,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
     if parent_data
       parent_model_name = parent_data[:model_name]
     end
-    @resource = Spree::Admin::Resource.new controller_path, controller_name, parent_model_name
+    @resource = Spree::Admin::Resource.new controller_path, controller_name, parent_model_name, object_name
   end
 
   def load_resource
@@ -238,6 +238,9 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
     else
       spree.polymorphic_url([:admin, model_class], options)
     end
+  end
+
+  def object_name
   end
 
   # Allow all attributes to be updatable.

--- a/backend/app/controllers/spree/admin/variants_including_master_controller.rb
+++ b/backend/app/controllers/spree/admin/variants_including_master_controller.rb
@@ -1,7 +1,7 @@
 module Spree
   module Admin
     class VariantsIncludingMasterController < VariantsController
-      belongs_to 'spree/product', find_by: :slug
+      belongs_to "spree/product", find_by: :slug
 
       def model_class
         Spree::Variant

--- a/backend/app/controllers/spree/admin/variants_including_master_controller.rb
+++ b/backend/app/controllers/spree/admin/variants_including_master_controller.rb
@@ -1,6 +1,7 @@
 module Spree
   module Admin
     class VariantsIncludingMasterController < VariantsController
+      belongs_to 'spree/product', find_by: :slug
 
       def model_class
         Spree::Variant

--- a/backend/app/models/spree/admin/resource.rb
+++ b/backend/app/models/spree/admin/resource.rb
@@ -1,10 +1,11 @@
 module Spree
   module Admin
     class Resource
-      def initialize(controller_path, controller_name, parent_model)
+      def initialize(controller_path, controller_name, parent_model, object_name)
         @controller_path = controller_path
         @controller_name = controller_name
         @parent_model = parent_model
+        @object_name = object_name
       end
 
       def sub_namespace_parts
@@ -24,6 +25,7 @@ module Spree
       end
 
       def object_name
+        return @object_name if @object_name
         sub_namespace = sub_namespace_parts.join('_')
         sub_namespace = "#{sub_namespace}_" if sub_namespace.length > 0
         "#{sub_namespace}#{@controller_name.singularize}"

--- a/backend/app/models/spree/admin/resource.rb
+++ b/backend/app/models/spree/admin/resource.rb
@@ -1,7 +1,7 @@
 module Spree
   module Admin
     class Resource
-      def initialize(controller_path, controller_name, parent_model, object_name)
+      def initialize(controller_path, controller_name, parent_model, object_name = nil)
         @controller_path = controller_path
         @controller_name = controller_name
         @parent_model = parent_model

--- a/backend/app/views/spree/admin/products/stock.html.erb
+++ b/backend/app/views/spree/admin/products/stock.html.erb
@@ -26,17 +26,17 @@
             </td>
             <td>
               <%= variant.sku_and_options_text %>
-              <%= form_tag admin_product_variants_including_master_path(@product, variant, format: :js), method: :post, class: 'toggle_variant_track_inventory' do %>
+              <%= form_tag admin_product_variants_including_master_path(@product, variant, format: :js), method: :put, class: 'toggle_variant_track_inventory' do %>
                 <div class="checkbox">
                   <%= label_tag :track_inventory do %>
                     <%= check_box_tag 'track_inventory', 1, variant.track_inventory?,
                                       class: 'track_inventory_checkbox' %>
                     <%= Spree.t(:track_inventory) %>
+                    <%= hidden_field_tag 'variant[track_inventory]', variant.track_inventory?,
+			class: 'variant_track_inventory',
+			id: "variant_track_inventory_#{variant.id}" %>
                   <% end %>
                 </div>
-                <%= hidden_field_tag 'variant[track_inventory]', variant.track_inventory?,
-                    class: 'variant_track_inventory',
-                    id: "variant_track_inventory_#{variant.id}" %>
               <% end if can?(:update, @product) && can?(:update, variant) %>
             </td>
 

--- a/backend/app/views/spree/admin/variants/update.js.erb
+++ b/backend/app/views/spree/admin/variants/update.js.erb
@@ -1,0 +1,1 @@
+<%= @object.as_json %>

--- a/backend/spec/features/admin/products/stock_management_spec.rb
+++ b/backend/spec/features/admin/products/stock_management_spec.rb
@@ -28,7 +28,7 @@ describe "Stock Management", type: :feature, js: true do
       end
     end
 
-    context "toggle track inventory for a vaniant's stock item" do
+    context "toggle track inventory for a variant's stock item" do
       let(:track_inventory) { find ".track_inventory_checkbox" }
 
       before do
@@ -42,7 +42,6 @@ describe "Stock Management", type: :feature, js: true do
         expect(track_inventory).not_to be_checked
       end
     end
-
 
     # Regression test for #2896
     # The regression was that unchecking the last checkbox caused a redirect

--- a/backend/spec/features/admin/products/stock_management_spec.rb
+++ b/backend/spec/features/admin/products/stock_management_spec.rb
@@ -28,6 +28,22 @@ describe "Stock Management", type: :feature, js: true do
       end
     end
 
+    context "toggle track inventory for a vaniant's stock item" do
+      let(:track_inventory) { find ".track_inventory_checkbox" }
+
+      before do
+        expect(track_inventory).to be_checked
+        track_inventory.set(false)
+        wait_for_ajax
+      end
+
+      it "persists the value when page reloaded", js: true do
+        visit current_path
+        expect(track_inventory).not_to be_checked
+      end
+    end
+
+
     # Regression test for #2896
     # The regression was that unchecking the last checkbox caused a redirect
     # to happen. By ensuring that we're still on an /admin/products URL, we

--- a/backend/spec/models/spree/resource_spec.rb
+++ b/backend/spec/models/spree/resource_spec.rb
@@ -14,6 +14,7 @@ module Spree
     describe Resource, type: :model do
       let(:resource_base) { Resource.new('spree/admin/test', 'test', 'widget') }
       let(:resource_submodule) { Resource.new('spree/admin/submodule/test', 'test', 'widget') }
+      let(:resource_object_name) { Resource.new('spree/admin/test', 'test', 'gadget', 'widget') }
 
       it "can get base model class" do
         expect(resource_base.model_class).to eq(Spree::Test)
@@ -37,6 +38,10 @@ module Spree
 
       it "can get submodule object name" do
         expect(resource_submodule.object_name).to eq('submodule_test')
+      end
+
+      it "can get overridden object name" do
+        expect(resource_object_name.object_name).to eq('widget')
       end
     end
   end


### PR DESCRIPTION
We were seeing routing errors while changing the Track Inventory flag in the Product > Stock page. The issue was introduced in #5954. 
- A routing error was introduced in [spree/admin/products/stock.html.erb](https://github.com/spree/spree/blob/master/backend/app/views/spree/admin/products/stock.html.erb#L29) by using a POST method when updating a resource that only had an update route.
- The [backend/app/assets/javascripts/spree/backend/variant_management.js.coffee](https://github.com/spree/spree/blob/master/backend/app/assets/javascripts/spree/backend/variant_management.js.coffee) wasn't updating the value of 'variant[track_inventory]' hidden field in [backend/app/views/spree/admin/products/stock.html.erb](https://github.com/spree/spree/blob/master/backend/app/views/spree/admin/products/stock.html.erb#L37-L39). Some CoffeeScript was missing and the selector in the missing CoffeeScript was not applying correctly.
- Overriding object_name in [spree/admin/controllers/variants_including_master_controller.rb](https://github.com/spree/spree/blob/master/backend/app/controllers/spree/admin/variants_including_master_controller.rb#L9-L11) is not supported by the new Resource model.
