### PR TITLE
Refactor Spree to make MOSS taxation possible

### DIFF
--- a/backend/spec/features/admin/orders/line_items_spec.rb
+++ b/backend/spec/features/admin/orders/line_items_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 # Tests for #3958's features
 describe "Order Line Items", type: :feature, js: true do
   stub_authorization!
-  
+
   before do
     # Removing the delivery step causes the order page to render a different
     # partial, called _line_items, which shows line items rather than shipments
@@ -27,7 +27,7 @@ describe "Order Line Items", type: :feature, js: true do
           expect(page).to have_content("10")
         end
         within '.line-item-total' do
-          expect(page).to have_content("$100.00")
+          expect(page).to have_content("$199.90")
         end
       end
     end

--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -17,7 +17,7 @@ module Spree
     end
 
     def display_price(product_or_variant)
-      product_or_variant.price_in(current_currency).display_price.to_html
+      product_or_variant.price_in(current_currency).display_price_including_vat_for(current_tax_zone).to_html
     end
 
     def link_to_tracking(shipment, options = {})

--- a/core/app/helpers/spree/products_helper.rb
+++ b/core/app/helpers/spree/products_helper.rb
@@ -54,7 +54,11 @@ module Spree
     def cache_key_for_products
       count = @products.count
       max_updated_at = (@products.maximum(:updated_at) || Date.today).to_s(:number)
-      "#{I18n.locale}/#{current_currency}/spree/products/all-#{params[:page]}-#{max_updated_at}-#{count}"
+      "#{I18n.locale}/#{current_currency}/#{current_tax_zone.try(:cache_key)}/spree/products/all-#{params[:page]}-#{max_updated_at}-#{count}"
+    end
+
+    def cache_key_for_product(product = @product)
+      "#{I18n.locale}/#{current_currency}/#{current_tax_zone.try(:cache_key)}/#{product.cache_key}"
     end
   end
 end

--- a/core/app/models/concerns/spree/default_price.rb
+++ b/core/app/models/concerns/spree/default_price.rb
@@ -8,7 +8,7 @@ module Spree
         class_name: 'Spree::Price',
         dependent: :destroy
 
-      delegate_belongs_to :default_price, :display_price, :display_amount, :price, :price=, :currency
+      delegate_belongs_to :default_price, :display_price, :display_amount, :price, :price=, :price_including_vat_for, :currency
 
       after_save :save_default_price
 

--- a/core/app/models/spree/calculator/default_tax.rb
+++ b/core/app/models/spree/calculator/default_tax.rb
@@ -38,11 +38,7 @@ module Spree
     def compute_shipping_rate(shipping_rate)
       if rate.included_in_price
         pre_tax_amount = shipping_rate.cost / (1 + rate.amount)
-        if rate.zone == shipping_rate.shipment.order.tax_zone
-          deduced_total_by_rate(pre_tax_amount, rate)
-        else
-          deduced_total_by_rate(pre_tax_amount, rate) * - 1
-        end
+        deduced_total_by_rate(pre_tax_amount, rate)
       else
         with_tax_amount = shipping_rate.cost * rate.amount
         round_to_two_places(with_tax_amount)

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -32,15 +32,20 @@ module Spree
     after_create :update_tax_charge
 
     delegate :name, :description, :sku, :should_track_inventory?, to: :variant
+    delegate :tax_zone, to: :order
 
     attr_accessor :target_shipment
 
     def copy_price
       if variant
-        self.price = variant.price if price.nil?
+        update_price if price.nil?
         self.cost_price = variant.cost_price if cost_price.nil?
         self.currency = variant.currency if currency.nil?
       end
+    end
+
+    def update_price
+      self.price = variant.price_including_vat_for(tax_zone)
     end
 
     def copy_tax_category

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -277,6 +277,13 @@ module Spree
       Spree::TaxRate.adjust(self, shipments) if shipments.any?
     end
 
+    def update_line_item_prices!
+      line_items.each do |line_item|
+        line_item.update_price
+        line_item.save
+      end
+    end
+
     def outstanding_balance
       if state == 'canceled'
         -1 * payment_total

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -87,6 +87,7 @@ module Spree
               before_transition from: :cart, do: :ensure_line_items_present
 
               if states[:address]
+                before_transition from: :address, do: :update_line_item_prices!
                 before_transition from: :address, do: :create_tax_charge!
                 before_transition to: :address, do: :assign_default_addresses!
                 before_transition from: :address, do: :persist_user_address!

--- a/core/app/models/spree/shipping_rate.rb
+++ b/core/app/models/spree/shipping_rate.rb
@@ -17,23 +17,19 @@ module Spree
 
     def display_price
       price = display_base_price.to_s
-      if tax_rate
-        tax_amount = calculate_tax_amount
-        if tax_amount != 0
-          if tax_rate.included_in_price?
-            if tax_amount > 0
-              amount = "#{display_tax_amount(tax_amount)} #{tax_rate.name}"
-              price += " (#{Spree.t(:incl)} #{amount})"
-            else
-              amount = "#{display_tax_amount(tax_amount*-1)} #{tax_rate.name}"
-              price += " (#{Spree.t(:excl)} #{amount})"
-            end
-          else
-            amount = "#{display_tax_amount(tax_amount)} #{tax_rate.name}"
-            price += " (+ #{amount})"
-          end
+
+      return price if tax_rate.nil?
+      tax_amount = calculate_tax_amount
+      if tax_amount != 0
+        if tax_rate.included_in_price?
+          amount = "#{display_tax_amount(tax_amount)} #{tax_rate.name}"
+          price += " (#{Spree.t(:incl)} #{amount})"
+        else
+          amount = "#{display_tax_amount(tax_amount)} #{tax_rate.name}"
+          price += " (+ #{amount})"
         end
       end
+
       price
     end
     alias_method :display_cost, :display_price

--- a/core/app/models/spree/stock/estimator.rb
+++ b/core/app/models/spree/stock/estimator.rb
@@ -28,22 +28,13 @@ module Spree
       def calculate_shipping_rates(package, ui_filter)
         shipping_methods(package, ui_filter).map do |shipping_method|
           cost = shipping_method.calculator.compute(package)
-          tax_category = shipping_method.tax_category
-          if tax_category
-            tax_rate = tax_category.tax_rates.detect do |rate|
-              # If the rate's zone matches the order's zone, a positive adjustment will be applied.
-              # If the rate is from the default tax zone, then a negative adjustment will be applied.
-              # See the tests in shipping_rate_spec.rb for an example of this.d
-              rate.zone == order.tax_zone || rate.zone.default_tax?
-            end
-          end
+          tax_rate = Spree::TaxRate.potential_rates_for_zone(order.tax_zone).
+            where(tax_category: shipping_method.tax_category).first
 
-          if cost
-            rate = shipping_method.shipping_rates.new(cost: cost)
-            rate.tax_rate = tax_rate if tax_rate
-          end
-
-          rate
+          shipping_method.shipping_rates.new(
+            cost: cost,
+            tax_rate: tax_rate
+          ) if cost
         end.compact
       end
 

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -1,14 +1,4 @@
 module Spree
-  class DefaultTaxZoneValidator < ActiveModel::Validator
-    def validate(record)
-      if record.included_in_price
-        record.errors.add(:included_in_price, Spree.t(:included_price_validation)) unless Zone.default_tax
-      end
-    end
-  end
-end
-
-module Spree
   class TaxRate < Spree::Base
     acts_as_paranoid
 
@@ -16,50 +6,30 @@ module Spree
     include Spree::AdjustmentSource
 
     belongs_to :zone, class_name: "Spree::Zone", inverse_of: :tax_rates
-    belongs_to :tax_category, class_name: "Spree::TaxCategory", inverse_of: :tax_rates
+    belongs_to :tax_category,
+      class_name: "Spree::TaxCategory",
+      inverse_of: :tax_rates
 
     validates :amount, presence: true, numericality: true
     validates :tax_category_id, presence: true
-    validates_with DefaultTaxZoneValidator
 
-    scope :by_zone, ->(zone) { where(zone_id: zone) }
+    scope :by_zone, -> (zone) { where(zone_id: zone.id) }
+    scope :potential_rates_for_zone,
+      -> (zone) do
+        where(zone_id: Spree::Zone.potential_matching_zones(zone).pluck(:id))
+      end
+    scope :for_default_zone,
+      -> { potential_rates_for_zone(Spree::Zone.default_tax) }
+    scope :for_tax_category,
+      -> (category) { where(tax_category_id: category.try(:id)) }
+    scope :included_in_price, -> { where(included_in_price: true) }
 
-    def self.potential_rates_for_zone(zone)
-      select("spree_tax_rates.*, spree_zones.default_tax").
-        joins(:zone).
-        merge(Spree::Zone.potential_matching_zones(zone)).
-        order("spree_zones.default_tax DESC")
-    end
-
-    # Gets the array of TaxRates appropriate for the specified order
+    # Gets the array of TaxRates appropriate for the specified tax zone
     def self.match(order_tax_zone)
       return [] unless order_tax_zone
-
-      potential_rates = potential_rates_for_zone(order_tax_zone)
-      rates = potential_rates.includes(zone: { zone_members: :zoneable }).load.select do |rate|
-        # Why "potentially"?
-        # Go see the documentation for that method.
-        rate.potentially_applicable?(order_tax_zone)
-      end
-
-      # Imagine with me this scenario:
-      # You are living in Spain and you have a store which ships to France.
-      # Spain is therefore your default tax rate.
-      # When you ship to Spain, you want the Spanish rate to apply.
-      # When you ship to France, you want the French rate to apply.
-      #
-      # Normally, Spree would notice that you have two potentially applicable
-      # tax rates for one particular item.
-      # When you ship to Spain, only the Spanish one will apply.
-      # When you ship to France, you'll see a Spanish refund AND a French tax.
-      # This little bit of code at the end stops the Spanish refund from appearing.
-      #
-      # For further discussion, see #4397 and #4327.
-      rates.delete_if do |rate|
-        rate.included_in_price? &&
-        (rates - [rate]).map(&:tax_category).include?(rate.tax_category)
-      end
+      potential_rates_for_zone(order_tax_zone)
     end
+
 
     # Pre-tax amounts must be stored so that we can calculate
     # correct rate amounts in the future. For example:
@@ -78,91 +48,45 @@ module Spree
       item.update_column(:pre_tax_amount, pre_tax_amount)
     end
 
-    # This method is best described by the documentation on #potentially_applicable?
+    # Deletes all tax adjustments, then applies all applicable rates
+    # to relevant items.
     def self.adjust(order, items)
       rates = match(order.tax_zone)
       tax_categories = rates.map(&:tax_category)
-      relevant_items, non_relevant_items = items.partition { |item| tax_categories.include?(item.tax_category) }
-      Spree::Adjustment.where(adjustable: relevant_items).tax.destroy_all # using destroy_all to ensure adjustment destroy callback fires.
+
+      # using destroy_all to ensure adjustment destroy callback fires.
+      Spree::Adjustment.where(adjustable: items).tax.destroy_all
+
+      relevant_items = items.select do |item|
+        tax_categories.include?(item.tax_category)
+      end
+
       relevant_items.each do |item|
-        relevant_rates = rates.select { |rate| rate.tax_category == item.tax_category }
+        relevant_rates = rates.select do |rate|
+          rate.tax_category == item.tax_category
+        end
         store_pre_tax_amount(item, relevant_rates)
         relevant_rates.each do |rate|
           rate.adjust(order, item)
         end
       end
-      non_relevant_items.each do |item|
-        if item.adjustments.tax.present?
-          item.adjustments.tax.destroy_all # using destroy_all to ensure adjustment destroy callback fires.
-          item.update_columns pre_tax_amount: 0
-        end
-      end
     end
 
-    # Tax rates can *potentially* be applicable to an order.
-    # We do not know if they are/aren't until we attempt to apply these rates to
-    # the items contained within the Order itself.
-    # For instance, if a rate passes the criteria outlined in this method,
-    # but then has a tax category that doesn't match against any of the line items
-    # inside of the order, then that tax rate will not be applicable to anything.
-    # For instance:
-    #
-    # Zones:
-    #   - Spain (default tax zone)
-    #   - France
-    #
-    # Tax rates: (note: amounts below do not actually reflect real VAT rates)
-    #   21% inclusive - "Clothing" - Spain
-    #   18% inclusive - "Clothing" - France
-    #   10% inclusive - "Food" - Spain
-    #   8% inclusive - "Food" - France
-    #   5% inclusive - "Hotels" - Spain
-    #   2% inclusive - "Hotels" - France
-    #
-    # Order has:
-    #   Line Item #1 - Tax Category: Clothing
-    #   Line Item #2 - Tax Category: Food
-    #
-    # Tax rates that should be selected:
-    #
-    #  21% inclusive - "Clothing" - Spain
-    #  10% inclusive - "Food" - Spain
-    #
-    # If the order's address changes to one in France, then the tax will be recalculated:
-    #
-    #  18% inclusive - "Clothing" - France
-    #  8% inclusive - "Food" - France
-    #
-    # Note here that the "Hotels" tax rates will not be used at all.
-    # This is because there are no items which have the tax category of "Hotels".
-    #
-    # Under no circumstances should negative adjustments be applied for the Spanish tax rates.
-    #
-    # Those rates should never come into play at all and only the French rates should apply.
-    def potentially_applicable?(order_tax_zone)
-      # If the rate's zone matches the order's tax zone, then it's applicable.
-      self.zone == order_tax_zone ||
-      # If the rate's zone *contains* the order's tax zone, then it's applicable.
-      self.zone.contains?(order_tax_zone) ||
-      # 1) The rate's zone is the default zone, then it's always applicable.
-      (self.included_in_price? && self.zone.default_tax)
+    def self.included_tax_amount_for(zone, category)
+      return 0 unless zone
+      potential_rates_for_zone(zone).included_in_price.
+        for_tax_category(category).pluck(:amount).sum
     end
 
     def adjust(order, item)
-      included = included_in_price && default_zone_or_zone_match?(order)
-      create_adjustment(order, item, included)
+      create_adjustment(order, item, included_in_price)
     end
 
     def compute_amount(item)
-      refund = included_in_price && !default_zone_or_zone_match?(item.order)
-      compute(item) * (refund ? -1 : 1)
+      compute(item)
     end
 
     private
-
-    def default_zone_or_zone_match?(order)
-      Zone.default_tax.try(:contains?, order.tax_zone) || order.tax_zone == zone
-    end
 
     def label(adjustment_amount)
       label = ""

--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -25,8 +25,7 @@ module Spree
       if zone.country?
         # Match zones of the same kind with simialr countries
         joins(countries: :zones).
-          where('zone_members_spree_countries_join.zone_id = ? OR ' +
-                'spree_zones.default_tax = ?', zone.id, true).
+          where('zone_members_spree_countries_join.zone_id = ?', zone.id).
           uniq
       else
         # Match zones of the same kind with similar states in AND match zones
@@ -35,11 +34,9 @@ module Spree
           "(spree_zone_members.zoneable_type = 'Spree::State' AND
             spree_zone_members.zoneable_id IN (?))
            OR (spree_zone_members.zoneable_type = 'Spree::Country' AND
-            spree_zone_members.zoneable_id IN (?))
-           OR default_tax = ?",
+            spree_zone_members.zoneable_id IN (?))",
           zone.state_ids,
-          zone.states.pluck(:country_id),
-          true
+          zone.states.pluck(:country_id)
         ).uniq
       end
     end

--- a/core/lib/spree/core/controller_helpers/store.rb
+++ b/core/lib/spree/core/controller_helpers/store.rb
@@ -7,6 +7,7 @@ module Spree
         included do
           helper_method :current_currency
           helper_method :current_store
+          helper_method :current_tax_zone
         end
 
         def current_currency
@@ -15,6 +16,14 @@ module Spree
 
         def current_store
           @current_store ||= Spree::Store.current(request.env['SERVER_NAME'])
+        end
+
+        def current_tax_zone
+          if current_order
+            current_order.tax_zone
+          else
+            Spree::Zone.default_tax
+          end
         end
       end
     end

--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -134,4 +134,71 @@ describe Spree::BaseHelper, type: :helper do
       expect(pretty_time(DateTime.new(2012, 5, 6, 13, 33))).to eq "May 06, 2012  1:33 PM"
     end
   end
+
+  describe '#display_price' do
+    let!(:product) { create(:product) }
+    let(:current_currency) { "USD" }
+
+    context "when there is no current order" do
+      let (:current_tax_zone) { nil }
+
+      it 'returns the price including default vat' do
+        expect(display_price(product)).to eq('$19.99')
+      end
+
+      context "with a default VAT" do
+        let(:current_tax_zone) { create(:zone_with_country, default_tax: true) }
+        let!(:tax_rate) do
+          create(:tax_rate,
+            included_in_price: true,
+            zone: current_tax_zone,
+            tax_category: product.tax_category,
+            amount: 0.2
+          )
+        end
+
+        it "returns the price adding the VAT" do
+          expect(display_price(product)).to eq("$19.99")
+        end
+      end
+    end
+
+    context "with an order that has a tax zone" do
+      let(:current_tax_zone) { create(:zone_with_country) }
+      let(:current_order)  { Spree::Order.new }
+      let(:default_zone) { create(:zone_with_country, default_tax: true) }
+
+      let!(:default_vat) do
+        create(:tax_rate,
+          included_in_price: true,
+          zone: default_zone,
+          tax_category: product.tax_category,
+          amount: 0.2
+        )
+      end
+
+      context "that matches no VAT" do
+        it "returns the price excluding VAT" do
+          expect(display_price(product)).to eq("$16.66")
+        end
+      end
+
+      context "that matches a VAT" do
+        let!(:other_vat) do
+          create(:tax_rate,
+            included_in_price: true,
+            zone: current_tax_zone,
+            tax_category: product.tax_category,
+            amount: 0.4
+          )
+        end
+
+        it "returns the price adding the VAT" do
+          expect(display_price(product)).to eq("$23.32")
+        end
+      end
+
+    end
+
+  end
 end

--- a/core/spec/lib/spree/core/controller_helpers/store_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/store_spec.rb
@@ -13,4 +13,59 @@ describe Spree::Core::ControllerHelpers::Store, type: :controller do
       expect(controller.current_store).to eq store
     end
   end
+
+  describe '#current_tax_zone' do
+
+    subject { controller.current_tax_zone }
+
+    context 'when there is a default tax zone' do
+
+      let(:default_zone) { Spree::Zone.new }
+
+      before do
+        allow(Spree::Zone).to receive(:default_tax).and_return(default_zone)
+      end
+
+      context 'when there is no current order' do
+        it 'returns the default tax zone' do
+          is_expected.to eq(default_zone)
+        end
+      end
+
+      context 'when there is a current order' do
+        let(:other_zone) { Spree::Zone.new }
+        let(:current_order) { Spree::Order.new }
+
+        before do
+          allow(current_order).to receive(:tax_zone).and_return(other_zone)
+          allow(controller).to receive(:current_order).and_return(current_order)
+        end
+
+        it { is_expected.to eq(other_zone) }
+      end
+    end
+
+    context 'when there is no default tax zone' do
+
+      before do
+        allow(Spree::Zone).to receive(:default_tax).and_return(nil)
+      end
+
+      context 'when there is no current order' do
+        it { is_expected.to be_nil }
+      end
+
+      context 'when there is a current order' do
+        let(:other_zone) { Spree::Zone.new }
+        let(:current_order) { Spree::Order.new }
+
+        before do
+          allow(current_order).to receive(:tax_zone).and_return(other_zone)
+          allow(controller).to receive(:current_order).and_return(current_order)
+        end
+
+        it { is_expected.to eq(other_zone) }
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/calculator/default_tax_spec.rb
+++ b/core/spec/models/spree/calculator/default_tax_spec.rb
@@ -88,7 +88,6 @@ describe Spree::Calculator::DefaultTax, :type => :model do
             expect(calculator.compute(line_item)).to eql 1.38
           end
         end
-
         it "should be equal to the item's full price * rate" do
           Spree::TaxRate.store_pre_tax_amount(line_item, [rate])
           expect(calculator.compute(line_item)).to eql 1.43
@@ -121,6 +120,32 @@ describe Spree::Calculator::DefaultTax, :type => :model do
         shipment.promo_total = -1
         # 5% of 14
         expect(calculator.compute(shipment)).to eq(0.7)
+      end
+    end
+  end
+
+  context "when given a line_item" do
+    let(:rate) { create(:tax_rate, amount: 0.07, included_in_price: true) }
+    let(:line_item) { create(:line_item, quantity: 50, price: 8.50) }
+
+    subject { Spree::Calculator::DefaultTax.new(calculable: rate).compute_line_item(line_item) }
+
+    describe "#compute_line_item" do
+      it "computes the line item right" do
+        Spree::TaxRate.store_pre_tax_amount(line_item, [rate])
+        expect(subject).to eq(27.80)
+      end
+
+      context "with a 40$ promo" do
+
+        before do
+          allow(line_item).to receive(:promo_total).and_return(BigDecimal.new("-40"))
+          Spree::TaxRate.store_pre_tax_amount(line_item, [rate])
+        end
+
+        it "computes the line item right" do
+          expect(subject).to eq(25.19)
+        end
       end
     end
   end

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -110,6 +110,16 @@ describe Spree::LineItem, :type => :model do
     end
   end
 
+  # test for copying prices when the vat changes
+  context '#update_price' do
+    it 'copies over a variants differing price for another vat zone' do
+      expect(line_item.variant).to receive(:price_including_vat_for).and_return(12)
+      line_item.price = 10
+      line_item.update_price
+      expect(line_item.price).to eq(12)
+    end
+  end
+
   # Test for #3481
   context '#copy_tax_category' do
     it "copies over a variant's tax category" do

--- a/core/spec/models/spree/moss_taxes_spec.rb
+++ b/core/spec/models/spree/moss_taxes_spec.rb
@@ -1,0 +1,132 @@
+require 'spec_helper'
+
+describe Spree::TaxRate, :type => :model do
+  context '#adjust for moss' do
+    let(:germany) { create :country, name: "Germany" }
+    let(:india) { create :country, name: "India" }
+    let(:france) { create :country, name: "France" }
+    let(:france_zone) { create :zone_with_country, name: "France Zone" }
+    let(:germany_zone) { create :zone_with_country, name: "Germany Zone", default_tax: true }
+    let(:india_zone) { create :zone_with_country, name: "India" }
+    let(:moss_category) { Spree::TaxCategory.create(name: "Digital Goods") }
+    let(:normal_category) { Spree::TaxCategory.create(name: "Analogue Goods") }
+    let(:eu_zone) { create(:zone, name: "EU" ) }
+
+    let!(:german_vat) do
+      Spree::TaxRate.create(
+        name: "German VAT",
+        amount: 0.19,
+        calculator: Spree::Calculator::DefaultTax.create,
+        tax_category: moss_category,
+        zone: germany_zone,
+        included_in_price: true
+      )
+    end
+    let!(:french_vat) do
+      Spree::TaxRate.create(
+        name: "French VAT",
+        amount: 0.25,
+        calculator: Spree::Calculator::DefaultTax.create,
+        tax_category: moss_category,
+        zone: france_zone,
+        included_in_price: true
+      )
+    end
+    let!(:eu_vat) do
+      Spree::TaxRate.create(
+        name: "EU_VAT",
+        amount: 0.19,
+        calculator: Spree::Calculator::DefaultTax.create,
+        tax_category: normal_category,
+        zone: eu_zone,
+        included_in_price: true
+      )
+    end
+
+    let(:download) { create(:product, tax_category: moss_category, price: 100) }
+    let(:tshirt) { create(:product, tax_category: normal_category, price: 100) }
+    let(:order) { Spree::Order.create }
+
+    before do
+      germany_zone.zone_members.create(zoneable: germany)
+      france_zone.zone_members.create(zoneable: france)
+      india_zone.zone_members.create(zoneable: india)
+      eu_zone.zone_members.create(zoneable: germany)
+      eu_zone.zone_members.create(zoneable: france)
+    end
+
+    context 'a download' do
+      before do
+        order.contents.add(download.master, 1)
+      end
+
+      it 'without an adress costs 100 euros including tax' do
+        Spree::TaxRate.adjust(order, order.line_items)
+        order.update!
+        expect(order.display_total).to eq(Spree::Money.new(100))
+        expect(order.included_tax_total).to eq(15.97)
+      end
+
+      it 'to germany costs 100 euros including tax' do
+        allow(order).to receive(:tax_zone).and_return(germany_zone)
+        Spree::TaxRate.adjust(order, order.line_items)
+        order.update!
+        expect(order.display_total).to eq(Spree::Money.new(100))
+        expect(order.included_tax_total).to eq(15.97)
+      end
+
+      it 'to france costs more including tax' do
+        allow(order).to receive(:tax_zone).and_return(france_zone)
+        order.update_line_item_prices!
+        Spree::TaxRate.adjust(order, order.line_items)
+        order.update!
+        expect(order.display_total).to eq(Spree::Money.new(105.04))
+        expect(order.included_tax_total).to eq(21.01)
+        expect(order.additional_tax_total).to eq(0)
+      end
+
+      it 'to somewhere else costs the net amount' do
+        allow(order).to receive(:tax_zone).and_return(india_zone)
+        order.update_line_item_prices!
+        Spree::TaxRate.adjust(order, order.line_items)
+        order.update!
+        expect(order.included_tax_total).to eq(0)
+        expect(order.included_tax_total).to eq(0)
+        expect(order.display_total).to eq(Spree::Money.new(84.03))
+      end
+    end
+
+    context 'a t-shirt' do
+      before do
+        order.contents.add(tshirt.master, 1)
+      end
+
+      it 'to germany costs 100 euros including tax' do
+        allow(order).to receive(:tax_zone).and_return(germany_zone)
+        Spree::TaxRate.adjust(order, order.line_items)
+        order.update!
+        expect(order.display_total).to eq(Spree::Money.new(100))
+        expect(order.included_tax_total).to eq(15.97)
+      end
+
+      it 'to france costs 100 euros including tax' do
+        allow(order).to receive(:tax_zone).and_return(france_zone)
+        order.update_line_item_prices!
+        Spree::TaxRate.adjust(order, order.line_items)
+        order.update!
+        expect(order.display_total).to eq(Spree::Money.new(100.00))
+        expect(order.included_tax_total).to eq(15.97)
+        expect(order.additional_tax_total).to eq(0)
+      end
+
+      it 'to somewhere else costs the net amount' do
+        allow(order).to receive(:tax_zone).and_return(india_zone)
+        order.update_line_item_prices!
+        Spree::TaxRate.adjust(order, order.line_items)
+        order.update!
+        expect(order.included_tax_total).to eq(0)
+        expect(order.display_total).to eq(Spree::Money.new(84.03))
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -172,6 +172,9 @@ describe Spree::Order, :type => :model do
       it "updates totals" do
         allow(order).to receive_messages(:ensure_available_shipping_rates => true)
         line_item = FactoryGirl.create(:line_item, :price => 10, :adjustment_total => 10)
+        v = line_item.variant
+        v.price = 10
+        v.save
         order.line_items << line_item
         tax_rate = create(:tax_rate, :tax_category => line_item.tax_category, :amount => 0.05)
         allow(Spree::TaxRate).to receive_messages :match => [tax_rate]
@@ -182,6 +185,24 @@ describe Spree::Order, :type => :model do
         expect(order.additional_tax_total).to eq(0.5)
         expect(order.included_tax_total).to eq(0)
         expect(order.total).to eq(10.5)
+      end
+
+      it 'updates prices' do
+        allow(order).to receive_messages(:ensure_available_shipping_rates => true)
+        line_item = FactoryGirl.create(:line_item, :price => 10, :adjustment_total => 10)
+        v = line_item.variant
+        v.price = 20
+        v.save
+        order.line_items << line_item
+        tax_rate = create(:tax_rate, included_in_price: true, tax_category: line_item.tax_category, amount: 0.05)
+        allow(Spree::TaxRate).to receive_messages :match => [tax_rate]
+        FactoryGirl.create(:tax_adjustment, :adjustable => line_item, :source => tax_rate, order: order)
+        order.email = "user@example.com"
+        order.next!
+        expect(order.adjustment_total).to eq(0)
+        expect(order.additional_tax_total).to eq(0)
+        expect(order.included_tax_total).to eq(0.95)
+        expect(order.total).to eq(20)
       end
 
       it "transitions to delivery" do

--- a/core/spec/models/spree/price_spec.rb
+++ b/core/spec/models/spree/price_spec.rb
@@ -39,4 +39,55 @@ describe Spree::Price, :type => :model do
       it { is_expected.to be_valid }
     end
   end
+
+  describe '#price_including_vat_for(zone)' do
+    let(:variant) { stub_model Spree::Variant }
+    let(:default_zone) { Spree::Zone.new }
+    let(:zone) { Spree::Zone.new }
+    let(:amount) { 10 }
+    subject { Spree::Price.new variant: variant, amount: amount }
+
+    context 'when called with a non-default zone' do
+      before do
+        expect(subject).to receive(:default_zone).at_least(:once).and_return(default_zone)
+        allow(subject).to receive(:included_tax_amount).with(default_zone) { 0.19 }
+        allow(subject).to receive(:included_tax_amount).with(zone) { 0.25 }
+      end
+
+      it "returns the correct price including another VAT to two digits" do
+        expect(subject.price_including_vat_for(zone)).to eq(10.50)
+      end
+    end
+
+
+    context 'when called from the default zone' do
+      before do
+        expect(subject).to receive(:default_zone).at_least(:once).and_return(zone)
+      end
+
+      it "returns the correct price" do
+        expect(subject).to receive(:price).and_call_original
+        expect(subject.price_including_vat_for(zone)).to eq(10.00)
+      end
+    end
+
+    context 'when no default zone is set' do
+      before do
+        expect(subject).to receive(:default_zone).at_least(:once).and_return(nil)
+      end
+
+      it "returns the correct price" do
+        expect(subject).to receive(:price).and_call_original
+        expect(subject.price_including_vat_for(zone)).to eq(10.00)
+      end
+    end
+  end
+
+  describe '#display_price_including_vat_for(zone)' do
+    subject { Spree::Price.new amount: 10 }
+    it 'calls #price_including_vat_for' do
+      expect(subject).to receive(:price_including_vat_for)
+      subject.display_price_including_vat_for(nil)
+    end
+  end
 end

--- a/core/spec/models/spree/reimbursement_spec.rb
+++ b/core/spec/models/spree/reimbursement_spec.rb
@@ -50,7 +50,7 @@ describe Spree::Reimbursement, type: :model do
     let!(:adjustments)            { [] } # placeholder to ensure it gets run prior the "before" at this level
 
     let!(:tax_rate)               { nil }
-    let!(:tax_zone)               { create(:zone, default_tax: true) }
+    let!(:tax_zone)               { create(:zone_with_country, default_tax: true) }
 
     let(:order)                   { create(:order_with_line_items, state: 'payment', line_items_count: 1, line_items_price: line_items_price, shipment_cost: 0) }
     let(:line_items_price)        { BigDecimal.new(10) }
@@ -118,7 +118,7 @@ describe Spree::Reimbursement, type: :model do
           subject
         }.to change { Spree::Refund.count }.by(1)
         return_item.reload
-        expect(return_item.included_tax_total).to be < 0
+        expect(return_item.included_tax_total).to be > 0
         expect(return_item.included_tax_total).to eq line_item.included_tax_total
         expect(reimbursement.total).to eq (line_item.pre_tax_amount + line_item.included_tax_total).round(2, :down)
         expect(Spree::Refund.last.amount).to eq (line_item.pre_tax_amount + line_item.included_tax_total).round(2, :down)

--- a/core/spec/models/spree/reimbursement_tax_calculator_spec.rb
+++ b/core/spec/models/spree/reimbursement_tax_calculator_spec.rb
@@ -24,8 +24,15 @@ describe Spree::ReimbursementTaxCalculator, :type => :model do
   end
 
   context 'with additional tax' do
-    let!(:tax_rate) { create(:tax_rate, name: "Sales Tax", amount: 0.10, included_in_price: false, zone: tax_zone) }
-    let(:tax_zone) { create(:zone, default_tax: true) }
+    let!(:tax_rate) do
+      create(:tax_rate,
+        name: "Sales Tax",
+        amount: 0.10,
+        included_in_price: false,
+        tax_category: create(:tax_category),
+        zone: create(:zone_with_country, default_tax: true)
+      )
+    end
 
     it 'sets additional_tax_total on the return items' do
       subject
@@ -37,14 +44,21 @@ describe Spree::ReimbursementTaxCalculator, :type => :model do
   end
 
   context 'with included tax' do
-    let!(:tax_rate) { create(:tax_rate, name: "VAT Tax", amount: 0.1, included_in_price: true, zone: tax_zone) }
-    let(:tax_zone) { create(:zone, default_tax: true) }
+    let!(:tax_rate) do
+      create(:tax_rate,
+        name: "VAT Tax",
+        amount: 0.10,
+        included_in_price: true,
+        tax_category: create(:tax_category),
+        zone: create(:zone_with_country, default_tax: true)
+      )
+    end
 
     it 'sets included_tax_total on the return items' do
       subject
       return_item.reload
 
-      expect(return_item.included_tax_total).to be < 0
+      expect(return_item.included_tax_total).to be > 0
       expect(return_item.included_tax_total).to eq line_item.included_tax_total
     end
   end

--- a/core/spec/models/spree/shipping_rate_spec.rb
+++ b/core/spec/models/spree/shipping_rate_spec.rb
@@ -11,20 +11,20 @@ describe Spree::ShippingRate, :type => :model do
 
   context "#display_price" do
     context "when tax included in price" do
+      let!(:default_zone) { create(:zone, :default_tax => true) }
+      let(:default_tax_rate) do
+        create(:tax_rate,
+          :name => "VAT",
+          :amount => 0.1,
+          :included_in_price => true,
+          :zone => default_zone)
+      end
       context "when the tax rate is from the default zone" do
-        let!(:zone) { create(:zone, :default_tax => true) }
-        let(:tax_rate) do 
-          create(:tax_rate,
-            :name => "VAT",
-            :amount => 0.1,
-            :included_in_price => true,
-            :zone => zone)
-        end
 
-        before { shipping_rate.tax_rate = tax_rate }
+        before { shipping_rate.tax_rate = default_tax_rate }
 
         it "shows correct tax amount" do
-          expect(shipping_rate.display_price.to_s).to eq("$10.00 (incl. $0.91 #{tax_rate.name})")
+          expect(shipping_rate.display_price.to_s).to eq("$10.00 (incl. $0.91 #{default_tax_rate.name})")
         end
 
         context "when cost is zero" do
@@ -38,20 +38,21 @@ describe Spree::ShippingRate, :type => :model do
         end
       end
 
-      context "when the tax rate is from a non-default zone" do
-        let!(:default_zone) { create(:zone, :default_tax => true) }
+      context "when the tax rate is from another zone" do
         let!(:non_default_zone) { create(:zone, :default_tax => false) }
-        let(:tax_rate) do
+
+        let(:non_default_tax_rate) do
           create(:tax_rate,
             :name => "VAT",
-            :amount => 0.1,
+            :amount => 0.2,
             :included_in_price => true,
             :zone => non_default_zone)
         end
-        before { shipping_rate.tax_rate = tax_rate }
+        before { shipping_rate.tax_rate = non_default_tax_rate }
 
-        it "shows correct tax amount" do
-          expect(shipping_rate.display_price.to_s).to eq("$10.00 (excl. $0.91 #{tax_rate.name})")
+        pending "I would expect this to be analogue to line items: First calculate the net price, then add the foreign VAT.\n"+
+                "However, I'm still waiting for the requirements to be properly defined here. " do
+          expect(shipping_rate.display_price.to_s).to eq("$10.91 (incl. $1.82 #{non_default_tax_rate.name})")
         end
 
         context "when cost is zero" do

--- a/core/spec/models/spree/tax_rate_spec.rb
+++ b/core/spec/models/spree/tax_rate_spec.rb
@@ -98,10 +98,7 @@ describe Spree::TaxRate, :type => :model do
         context "when the order has the same tax zone" do
           before do
             allow(order).to receive_messages :tax_zone => @zone
-            allow(order).to receive_messages :tax_address => tax_address
           end
-
-          let(:tax_address) { stub_model(Spree::Address) }
 
           context "when the tax is not a VAT" do
             it { is_expected.to eq([rate]) }
@@ -116,41 +113,21 @@ describe Spree::TaxRate, :type => :model do
         context "when the order has a different tax zone" do
           before do
             allow(order).to receive_messages :tax_zone => create(:zone, :name => "Other Zone")
-            allow(order).to receive_messages :tax_address => tax_address
           end
 
-          context "when the order has a tax_address" do
-            let(:tax_address) { stub_model(Spree::Address) }
-
-            context "when the tax is a VAT" do
-              let(:included_in_price) { true }
-              # The rate should match in this instance because:
-              # 1) It's the default rate (and as such, a negative adjustment should apply)
-              it { is_expected.to eq([rate]) }
-            end
-
-            context "when the tax is not VAT" do
-              it "returns no tax rate" do
-                expect(subject).to be_empty
-              end
+          context "when the tax is a VAT" do
+            let(:included_in_price) { true }
+            # The rate should NOT match in this instance because:
+            # The order has a different tax zone, and the price is
+            # henceforth a net price and will not change.
+            it 'return no tax rate' do
+              expect(subject).to be_empty
             end
           end
 
-          context "when the order does not have a tax_address" do
-            let(:tax_address) { nil}
-
-            context "when the tax is a VAT" do
-              let(:included_in_price) { true }
-              # The rate should match in this instance because:
-              # 1) The order has no tax address by this stage
-              # 2) With no tax address, it has no tax zone
-              # 3) Therefore, we assume the default tax zone
-              # 4) This default zone has a default tax rate.
-              it { is_expected.to eq([rate]) }
-            end
-
-            context "when the tax is not a VAT" do
-              it { is_expected.to be_empty }
+          context "when the tax is not VAT" do
+            it "returns no tax rate" do
+              expect(subject).to be_empty
             end
           end
         end
@@ -200,6 +177,51 @@ describe Spree::TaxRate, :type => :model do
         expect(rate_2).not_to receive(:adjust)
         Spree::TaxRate.adjust(order, shipments)
       end
+    end
+  end
+
+  context ".included_tax_amount_for" do
+    let!(:order) { create :order_with_line_items }
+    let!(:included_tax_rate) do
+      create(:tax_rate,
+        included_in_price: true,
+        tax_category: order.line_items.first.tax_category,
+        zone: order.tax_zone,
+        amount: 0.4
+      )
+    end
+
+    let!(:other_included_tax_rate) do
+      create(:tax_rate,
+        included_in_price: true,
+        tax_category: order.line_items.first.tax_category,
+        zone: order.tax_zone,
+        amount: 0.05
+      )
+    end
+
+    let!(:additional_tax_rate) do
+      create(:tax_rate,
+        included_in_price: false,
+        tax_category: order.line_items.first.tax_category,
+        zone: order.tax_zone,
+        amount: 0.2
+      )
+    end
+
+    let!(:included_tax_rate_from_somewhere_else) do
+      create(:tax_rate,
+        included_in_price: true,
+        tax_category: order.line_items.first.tax_category,
+        zone: create(:zone_with_country),
+        amount: 0.1
+      )
+    end
+
+    let(:line_item) { order.line_items.first }
+    subject { Spree::TaxRate.included_tax_amount_for(order.tax_zone, line_item.tax_category) }
+    it 'will only get me tax amounts from tax_rates that match' do
+      expect(subject).to eq(included_tax_rate.amount + other_included_tax_rate.amount)
     end
   end
 
@@ -254,7 +276,7 @@ describe Spree::TaxRate, :type => :model do
         context "when zone is contained by default tax zone" do
           it "should create two adjustments, one for each tax rate" do
             Spree::TaxRate.adjust(@order, @order.line_items)
-            expect(line_item.adjustments.count).to eq(1)
+            expect(line_item.adjustments.count).to eq(2)
           end
 
           it "should not create a tax refund" do
@@ -265,11 +287,14 @@ describe Spree::TaxRate, :type => :model do
 
         context "when order's zone is neither the default zone, or included in the default zone, but matches the rate's zone" do
           before do
-            # With no zone members, this zone will not contain anything
-            # Previously:
-            # Zone.stub_chain :default_tax, :contains? => false
-            @zone.zone_members.delete_all
+            new_rate = Spree::TaxRate.create(amount: 0.2,
+              included_in_price: true,
+              calculator: Spree::Calculator::DefaultTax.create,
+              tax_category: @category,
+              zone: create(:zone_with_country))
+            allow(@order).to receive(:tax_zone).and_return(new_rate.zone)
           end
+
           it "should create an adjustment" do
             Spree::TaxRate.adjust(@order, @order.line_items)
             expect(line_item.adjustments.charge.count).to eq(1)
@@ -295,9 +320,9 @@ describe Spree::TaxRate, :type => :model do
             expect(line_item.adjustments.charge.count).to eq(0)
           end
 
-          it "should create a tax refund for each tax rate" do
+          it "should not create a tax refund for each tax rate" do
             Spree::TaxRate.adjust(@order, @order.line_items)
-            expect(line_item.adjustments.credit.count).to eq(1)
+            expect(line_item.adjustments.credit.count).to eq(0)
           end
         end
 
@@ -372,7 +397,7 @@ describe Spree::TaxRate, :type => :model do
 
           it "price adjustments should be accurate" do
             included_tax = @order.line_item_adjustments.sum(:amount)
-            expect(@price_before_taxes + included_tax).to eq(line_item.price)
+            expect(@price_before_taxes + included_tax).to eq(line_item.total)
           end
         end
       end

--- a/core/spec/models/spree/zone_spec.rb
+++ b/core/spec/models/spree/zone_spec.rb
@@ -327,10 +327,6 @@ describe Spree::Zone, :type => :model do
       it "only returns each zone once" do
         expect(@result.select { |z| z == zone }.size).to be 1
       end
-
-      it "will include the default_tax zone" do
-        expect(@result).to include(default_tax_zone)
-      end
     end
 
     context "finding potential matches for a state zone" do
@@ -363,10 +359,6 @@ describe Spree::Zone, :type => :model do
 
       it "only returns each zone once" do
         expect(@result.select { |z| z == zone }.size).to be 1
-      end
-
-      it "will include the default tax zone" do
-        expect(@result).to include(default_tax_zone)
       end
     end
   end

--- a/core/spec/support/concerns/default_price_spec.rb
+++ b/core/spec/support/concerns/default_price_spec.rb
@@ -22,6 +22,15 @@ shared_examples_for "default_price" do
     subject { instance.default_price }
 
     its(:class) { should eql Spree::Price }
+    it 'delegates price' do
+      expect(instance.default_price). to receive(:price)
+      instance.price
+    end
+
+    it 'delegates price_including_vat_for' do
+      expect(instance.default_price). to receive(:price_including_vat_for)
+      instance.price_including_vat_for
+    end
   end
 
   its(:has_default_price?) { should be_truthy }

--- a/frontend/app/views/spree/products/show.html.erb
+++ b/frontend/app/views/spree/products/show.html.erb
@@ -1,6 +1,6 @@
 <% @body_id = 'product-details' %>
 
-<% cache [I18n.locale, current_currency, @product] do %>
+<% cache cache_key_for_product do %>
   <div data-hook="product_show" itemscope itemtype="http://schema.org/Product">
     <div class="col-md-4" data-hook="product_left_part">
       <div data-hook="product_left_part_wrap">

--- a/frontend/app/views/spree/shared/_products.html.erb
+++ b/frontend/app/views/spree/shared/_products.html.erb
@@ -27,7 +27,7 @@
       <% url = spree.product_url(product, taxon_id: @taxon.try(:id)) %>
       <div id="product_<%= product.id %>" class="col-md-3 col-sm-6 product-list-item" data-hook="products_list_item" itemscope itemtype="http://schema.org/Product">
         <div class="panel panel-default">
-          <% cache(@taxon.present? ? [I18n.locale, current_currency, @taxon, product] : [I18n.locale, current_currency, product]) do %>
+          <% cache(@taxon.present? ? [I18n.locale, current_currency, @taxon, product] : cache_key_for_product(product)) do %>
             <div class="panel-body text-center product-body">
               <%= link_to small_image(product, itemprop: "image"), url, itemprop: 'url' %><br/>
               <%= link_to truncate(product.name, length: 50), url, class: 'info', itemprop: "name", title: product.name %>

--- a/frontend/spec/features/caching/products_spec.rb
+++ b/frontend/spec/features/caching/products_spec.rb
@@ -10,8 +10,8 @@ describe 'products', :type => :feature, :caching => true do
     product2.update_column(:updated_at, 1.day.ago)
     # warm up the cache
     visit spree.root_path
-    assert_written_to_cache("views/en/USD/spree/products/all--#{product.updated_at.utc.to_s(:number)}")
-    assert_written_to_cache("views/en/USD/spree/products/#{product.id}-#{product.updated_at.utc.to_s(:number)}")
+    assert_written_to_cache("views/en/USD//spree/products/all--#{product.updated_at.utc.to_s(:number)}")
+    assert_written_to_cache("views/en/USD//spree/products/#{product.id}-#{product.updated_at.utc.to_s(:number)}")
     assert_written_to_cache("views/en/spree/taxonomies/#{taxonomy.id}")
     assert_written_to_cache("views/en/taxons/#{taxon.updated_at.utc.to_i}")
 
@@ -26,8 +26,8 @@ describe 'products', :type => :feature, :caching => true do
   it "busts the cache when a product is updated" do
     product.update_column(:updated_at, 1.day.from_now)
     visit spree.root_path
-    assert_written_to_cache("views/en/USD/spree/products/all--#{product.updated_at.utc.to_s(:number)}")
-    assert_written_to_cache("views/en/USD/spree/products/#{product.id}-#{product.updated_at.utc.to_s(:number)}")
+    assert_written_to_cache("views/en/USD//spree/products/all--#{product.updated_at.utc.to_s(:number)}")
+    assert_written_to_cache("views/en/USD//spree/products/#{product.id}-#{product.updated_at.utc.to_s(:number)}")
     expect(cache_writes.count).to eq(2)
   end
 
@@ -35,21 +35,21 @@ describe 'products', :type => :feature, :caching => true do
     product.destroy
     product2.destroy
     visit spree.root_path
-    assert_written_to_cache("views/en/USD/spree/products/all--#{Date.today.to_s(:number)}-0")
+    assert_written_to_cache("views/en/USD//spree/products/all--#{Date.today.to_s(:number)}-0")
     expect(cache_writes.count).to eq(1)
   end
 
   it "busts the cache when the newest product is deleted" do
     product.destroy
     visit spree.root_path
-    assert_written_to_cache("views/en/USD/spree/products/all--#{product2.updated_at.utc.to_s(:number)}")
+    assert_written_to_cache("views/en/USD//spree/products/all--#{product2.updated_at.utc.to_s(:number)}")
     expect(cache_writes.count).to eq(1)
   end
 
   it "busts the cache when an older product is deleted" do
     product2.destroy
     visit spree.root_path
-    assert_written_to_cache("views/en/USD/spree/products/all--#{product.updated_at.utc.to_s(:number)}")
+    assert_written_to_cache("views/en/USD//spree/products/all--#{product.updated_at.utc.to_s(:number)}")
     expect(cache_writes.count).to eq(1)
   end
 end


### PR DESCRIPTION
1. Add current_tax_zone helper

The `current_tax_zone` is needed for displaying the correct price
including VAT.

In order to cache product prices that depend on the current tax zone,
we need to add the current tax zone to the cache key for a single or
multiple products.
1. Display correct VAT prices
2. 1. Add Spree::Price#price_including_tax_for(zone)

This methods returns the correctly calculated gross price
for any zone that might have VAT. This way we can make sure to
always include the correct VAT in prices (even if they differ).

The method is delegated to Spree::Product and Spree::Variant.
1. 1. Amend display_price helper to use current tax zone
2. Copy price including VAT from Variant

This enables us to always have the same price as displayed
in the order. It also frees us from having to load default VAT
rates in `tax_rate.rb`.

The line item price will only ever be updated after the address
step in the state machine.

One expectation is changed in the back-end, because here the
price of the line items is updated from the variant, and those are
different.
1. Refactor Spree::Zone and Spree::TaxRate

When adjusting line items, do not include the default rates
in the Array of applicable rates. This was only necessary because
we could not be sure about the price being correct in the first place,
which is now fixed through ´Spree::Price#price_inlcuding_vat_for(zone)´.

As a consequence, I could refactor the stock estimator and fix
https://github.com/spree/spree/issues/6234.
1. Add rounding spec to tax_rate_spec.rb

This is mainly for posterity: I got stuck in rounding hell once, and
this test should ensure no-one else will have to.
1. Fix reimbursement expectations

The reimbursement spec expected negative adjustments for included tax,
which aren't necessary anymore - if your local tax zone does not include
the default VAT zone's VAT, the price is adjusted accordingly
beforehand.
1. Add test for MOSS taxes

This is an elaborate almost-integration-test for a particular setup
proving that it actually _is_ possible now to configure Spree for MOSS.
