### PR TITLE
Refactor Spree to make MOSS taxation possible

### DIFF
--- a/backend/spec/features/admin/orders/line_items_spec.rb
+++ b/backend/spec/features/admin/orders/line_items_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 # Tests for #3958's features
 describe "Order Line Items", type: :feature, js: true do
   stub_authorization!
-  
+
   before do
     # Removing the delivery step causes the order page to render a different
     # partial, called _line_items, which shows line items rather than shipments
@@ -27,7 +27,7 @@ describe "Order Line Items", type: :feature, js: true do
           expect(page).to have_content("10")
         end
         within '.line-item-total' do
-          expect(page).to have_content("$100.00")
+          expect(page).to have_content("$199.90")
         end
       end
     end

--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -17,7 +17,10 @@ module Spree
     end
 
     def display_price(product_or_variant)
-      product_or_variant.price_in(current_currency).display_price.to_html
+      product_or_variant.
+        price_in(current_currency).
+        display_price_including_vat_for(current_tax_zone).
+        to_html
     end
 
     def link_to_tracking(shipment, options = {})

--- a/core/app/helpers/spree/products_helper.rb
+++ b/core/app/helpers/spree/products_helper.rb
@@ -54,7 +54,18 @@ module Spree
     def cache_key_for_products
       count = @products.count
       max_updated_at = (@products.maximum(:updated_at) || Date.today).to_s(:number)
-      "#{I18n.locale}/#{current_currency}/spree/products/all-#{params[:page]}-#{max_updated_at}-#{count}"
+      products_cache_keys = "spree/products/all-#{params[:page]}-#{max_updated_at}-#{count}"
+      (common_product_cache_keys + [products_cache_keys]).compact.join("/")
+    end
+
+    def cache_key_for_product(product = @product)
+      (common_product_cache_keys + [product.cache_key]).compact.join("/")
+    end
+
+    private
+
+    def common_product_cache_keys
+      [I18n.locale, current_currency, current_tax_zone.try(:cache_key)]
     end
   end
 end

--- a/core/app/models/concerns/spree/adjustment_source.rb
+++ b/core/app/models/concerns/spree/adjustment_source.rb
@@ -14,7 +14,7 @@ module Spree
       return if amount == 0
       adjustments.new(order: order,
                       adjustable: adjustable,
-                      label: label(amount),
+                      label: label,
                       amount: amount,
                       included: included).save
     end

--- a/core/app/models/concerns/spree/default_price.rb
+++ b/core/app/models/concerns/spree/default_price.rb
@@ -8,7 +8,13 @@ module Spree
         class_name: 'Spree::Price',
         dependent: :destroy
 
-      delegate_belongs_to :default_price, :display_price, :display_amount, :price, :price=, :currency
+      delegate_belongs_to :default_price,
+                          :display_price,
+                          :display_amount,
+                          :price,
+                          :price=,
+                          :price_including_vat_for,
+                          :currency
 
       after_save :save_default_price
 

--- a/core/app/models/concerns/spree/vat_price_calculation.rb
+++ b/core/app/models/concerns/spree/vat_price_calculation.rb
@@ -1,0 +1,39 @@
+module Spree
+  module VatPriceCalculation
+    def gross_amount(amount, zone, tax_category)
+      return amount unless outside_default_vat_zone?(zone)
+      round_to_two_places(add_foreign_vat_for(amount, zone, tax_category))
+    end
+
+    private
+
+    def add_foreign_vat_for(amount, zone, tax_category)
+      amount = net_amount(amount, tax_category)
+      amount_with_foreign_vat(amount, zone, tax_category)
+    end
+
+    def net_amount(amount, tax_category)
+      amount / (1 + included_tax_amount(default_zone, tax_category))
+    end
+
+    def amount_with_foreign_vat(amount, zone, tax_category)
+      amount * (1 + included_tax_amount(zone, tax_category))
+    end
+
+    def outside_default_vat_zone?(zone)
+      zone && default_zone && zone != default_zone
+    end
+
+    def included_tax_amount(zone, tax_category)
+      Spree::TaxRate.included_tax_amount_for(zone, tax_category).to_f
+    end
+
+    def default_zone
+      @_default_zone ||= Spree::Zone.default_tax
+    end
+
+    def round_to_two_places(amount)
+      BigDecimal.new(amount.to_s).round(2, BigDecimal::ROUND_HALF_UP)
+    end
+  end
+end

--- a/core/app/models/spree/calculator/default_tax.rb
+++ b/core/app/models/spree/calculator/default_tax.rb
@@ -38,11 +38,7 @@ module Spree
     def compute_shipping_rate(shipping_rate)
       if rate.included_in_price
         pre_tax_amount = shipping_rate.cost / (1 + rate.amount)
-        if rate.zone == shipping_rate.shipment.order.tax_zone
-          deduced_total_by_rate(pre_tax_amount, rate)
-        else
-          deduced_total_by_rate(pre_tax_amount, rate) * - 1
-        end
+        deduced_total_by_rate(pre_tax_amount, rate)
       else
         with_tax_amount = shipping_rate.cost * rate.amount
         round_to_two_places(with_tax_amount)

--- a/core/app/models/spree/calculator/default_tax.rb
+++ b/core/app/models/spree/calculator/default_tax.rb
@@ -2,6 +2,7 @@ require_dependency 'spree/calculator'
 
 module Spree
   class Calculator::DefaultTax < Calculator
+    include VatPriceCalculation
     def self.description
       Spree.t(:default_tax)
     end
@@ -51,13 +52,8 @@ module Spree
       self.calculable
     end
 
-    def round_to_two_places(amount)
-      BigDecimal.new(amount.to_s).round(2, BigDecimal::ROUND_HALF_UP)
-    end
-
     def deduced_total_by_rate(pre_tax_amount, rate)
       round_to_two_places(pre_tax_amount * rate.amount)
     end
-
   end
 end

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -32,15 +32,20 @@ module Spree
     after_create :update_tax_charge
 
     delegate :name, :description, :sku, :should_track_inventory?, to: :variant
+    delegate :tax_zone, to: :order
 
     attr_accessor :target_shipment
 
     def copy_price
       if variant
-        self.price = variant.price if price.nil?
+        update_price if price.nil?
         self.cost_price = variant.cost_price if cost_price.nil?
         self.currency = variant.currency if currency.nil?
       end
+    end
+
+    def update_price
+      self.price = variant.price_including_vat_for(tax_zone)
     end
 
     def copy_tax_category

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -278,9 +278,9 @@ module Spree
     end
 
     def update_line_item_prices!
-      line_items.each do |line_item|
-        line_item.update_price
-        line_item.save
+      transaction do
+        line_items.each(&:update_price)
+        save!
       end
     end
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -277,6 +277,13 @@ module Spree
       Spree::TaxRate.adjust(self, shipments) if shipments.any?
     end
 
+    def update_line_item_prices!
+      line_items.each do |line_item|
+        line_item.update_price
+        line_item.save
+      end
+    end
+
     def outstanding_balance
       if state == 'canceled'
         -1 * payment_total

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -87,6 +87,7 @@ module Spree
               before_transition from: :cart, do: :ensure_line_items_present
 
               if states[:address]
+                before_transition from: :address, do: :update_line_item_prices!
                 before_transition from: :address, do: :create_tax_charge!
                 before_transition to: :address, do: :assign_default_addresses!
                 before_transition from: :address, do: :persist_user_address!

--- a/core/app/models/spree/promotion_action.rb
+++ b/core/app/models/spree/promotion_action.rb
@@ -1,4 +1,4 @@
-# Base class for all types of promotion action.
+## Base class for all types of promotion action.
 # PromotionActions perform the necessary tasks when a promotion is activated by an event and determined to be eligible.
 module Spree
   class PromotionAction < Spree::Base
@@ -18,8 +18,8 @@ module Spree
 
     protected
 
-    def label(amount)
-      "#{Spree.t(:promotion)} (#{promotion.name})"
+    def label
+      Spree.t(:promotion_label, name: promotion.name)
     end
   end
 end

--- a/core/app/models/spree/shipping_rate.rb
+++ b/core/app/models/spree/shipping_rate.rb
@@ -7,35 +7,29 @@ module Spree
     delegate :order, :currency, to: :shipment
     delegate :name, to: :shipping_method
 
-    def display_base_price
-      Spree::Money.new(cost, currency: currency)
-    end
+    extend Spree::DisplayMoney
 
-    def calculate_tax_amount
-      tax_rate.calculator.compute_shipping_rate(self)
+    money_methods :base_price, :tax_amount
+
+    def base_price
+      cost
     end
 
     def display_price
       price = display_base_price.to_s
 
-      return price if tax_rate.nil?
-      tax_amount = calculate_tax_amount
-      if tax_amount != 0
-        if tax_rate.included_in_price?
-          amount = "#{display_tax_amount(tax_amount)} #{tax_rate.name}"
-          price += " (#{Spree.t(:incl)} #{amount})"
-        else
-          amount = "#{display_tax_amount(tax_amount)} #{tax_rate.name}"
-          price += " (+ #{amount})"
-        end
-      end
+      return price if tax_rate.nil? || tax_amount == 0
 
-      price
+      Spree.t tax_rate.included_in_price? ? :including_tax : :excluding_tax,
+              scope: "shipping_rates.display_price",
+              price: price,
+              tax_amount: display_tax_amount,
+              tax_rate_name: tax_rate.name
     end
     alias_method :display_cost, :display_price
 
-    def display_tax_amount(tax_amount)
-      Spree::Money.new(tax_amount, currency: currency)
+    def tax_amount
+      @_tax_amount ||= tax_rate.calculator.compute_shipping_rate(self)
     end
 
     def shipping_method

--- a/core/app/models/spree/shipping_rate.rb
+++ b/core/app/models/spree/shipping_rate.rb
@@ -17,23 +17,19 @@ module Spree
 
     def display_price
       price = display_base_price.to_s
-      if tax_rate
-        tax_amount = calculate_tax_amount
-        if tax_amount != 0
-          if tax_rate.included_in_price?
-            if tax_amount > 0
-              amount = "#{display_tax_amount(tax_amount)} #{tax_rate.name}"
-              price += " (#{Spree.t(:incl)} #{amount})"
-            else
-              amount = "#{display_tax_amount(tax_amount*-1)} #{tax_rate.name}"
-              price += " (#{Spree.t(:excl)} #{amount})"
-            end
-          else
-            amount = "#{display_tax_amount(tax_amount)} #{tax_rate.name}"
-            price += " (+ #{amount})"
-          end
+
+      return price if tax_rate.nil?
+      tax_amount = calculate_tax_amount
+      if tax_amount != 0
+        if tax_rate.included_in_price?
+          amount = "#{display_tax_amount(tax_amount)} #{tax_rate.name}"
+          price += " (#{Spree.t(:incl)} #{amount})"
+        else
+          amount = "#{display_tax_amount(tax_amount)} #{tax_rate.name}"
+          price += " (+ #{amount})"
         end
       end
+
       price
     end
     alias_method :display_cost, :display_price

--- a/core/app/models/spree/stock/estimator.rb
+++ b/core/app/models/spree/stock/estimator.rb
@@ -28,22 +28,13 @@ module Spree
       def calculate_shipping_rates(package, ui_filter)
         shipping_methods(package, ui_filter).map do |shipping_method|
           cost = shipping_method.calculator.compute(package)
-          tax_category = shipping_method.tax_category
-          if tax_category
-            tax_rate = tax_category.tax_rates.detect do |rate|
-              # If the rate's zone matches the order's zone, a positive adjustment will be applied.
-              # If the rate is from the default tax zone, then a negative adjustment will be applied.
-              # See the tests in shipping_rate_spec.rb for an example of this.d
-              rate.zone == order.tax_zone || rate.zone.default_tax?
-            end
-          end
+          tax_rate = Spree::TaxRate.potential_rates_for_zone(order.tax_zone).
+            where(tax_category: shipping_method.tax_category).first
 
-          if cost
-            rate = shipping_method.shipping_rates.new(cost: cost)
-            rate.tax_rate = tax_rate if tax_rate
-          end
-
-          rate
+          shipping_method.shipping_rates.new(
+            cost: cost,
+            tax_rate: tax_rate
+          ) if cost
         end.compact
       end
 

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -1,14 +1,4 @@
 module Spree
-  class DefaultTaxZoneValidator < ActiveModel::Validator
-    def validate(record)
-      if record.included_in_price
-        record.errors.add(:included_in_price, Spree.t(:included_price_validation)) unless Zone.default_tax
-      end
-    end
-  end
-end
-
-module Spree
   class TaxRate < Spree::Base
     acts_as_paranoid
 
@@ -16,49 +6,28 @@ module Spree
     include Spree::AdjustmentSource
 
     belongs_to :zone, class_name: "Spree::Zone", inverse_of: :tax_rates
-    belongs_to :tax_category, class_name: "Spree::TaxCategory", inverse_of: :tax_rates
+    belongs_to :tax_category,
+               class_name: "Spree::TaxCategory",
+               inverse_of: :tax_rates
 
     validates :amount, presence: true, numericality: true
     validates :tax_category_id, presence: true
-    validates_with DefaultTaxZoneValidator
 
-    scope :by_zone, ->(zone) { where(zone_id: zone) }
+    scope :by_zone, -> (zone) { where(zone_id: zone.id) }
+    scope :potential_rates_for_zone,
+          -> (zone) do
+            where(zone_id: Spree::Zone.potential_matching_zones(zone).pluck(:id))
+          end
+    scope :for_default_zone,
+          -> { potential_rates_for_zone(Spree::Zone.default_tax) }
+    scope :for_tax_category,
+          -> (category) { where(tax_category_id: category.try(:id)) }
+    scope :included_in_price, -> { where(included_in_price: true) }
 
-    def self.potential_rates_for_zone(zone)
-      select("spree_tax_rates.*, spree_zones.default_tax").
-        joins(:zone).
-        merge(Spree::Zone.potential_matching_zones(zone)).
-        order("spree_zones.default_tax DESC")
-    end
-
-    # Gets the array of TaxRates appropriate for the specified order
+    # Gets the array of TaxRates appropriate for the specified tax zone
     def self.match(order_tax_zone)
       return [] unless order_tax_zone
-
-      potential_rates = potential_rates_for_zone(order_tax_zone)
-      rates = potential_rates.includes(zone: { zone_members: :zoneable }).load.select do |rate|
-        # Why "potentially"?
-        # Go see the documentation for that method.
-        rate.potentially_applicable?(order_tax_zone)
-      end
-
-      # Imagine with me this scenario:
-      # You are living in Spain and you have a store which ships to France.
-      # Spain is therefore your default tax rate.
-      # When you ship to Spain, you want the Spanish rate to apply.
-      # When you ship to France, you want the French rate to apply.
-      #
-      # Normally, Spree would notice that you have two potentially applicable
-      # tax rates for one particular item.
-      # When you ship to Spain, only the Spanish one will apply.
-      # When you ship to France, you'll see a Spanish refund AND a French tax.
-      # This little bit of code at the end stops the Spanish refund from appearing.
-      #
-      # For further discussion, see #4397 and #4327.
-      rates.delete_if do |rate|
-        rate.included_in_price? &&
-        (rates - [rate]).map(&:tax_category).include?(rate.tax_category)
-      end
+      potential_rates_for_zone(order_tax_zone)
     end
 
     # Pre-tax amounts must be stored so that we can calculate
@@ -66,9 +35,9 @@ module Spree
     # https://github.com/spree/spree/issues/4318#issuecomment-34723428
     def self.store_pre_tax_amount(item, rates)
       pre_tax_amount = case item
-        when Spree::LineItem then item.discounted_amount
-        when Spree::Shipment then item.discounted_cost
-        end
+                       when Spree::LineItem then item.discounted_amount
+                       when Spree::Shipment then item.discounted_cost
+                       end
 
       included_rates = rates.select(&:included_in_price)
       if included_rates.any?
@@ -78,99 +47,61 @@ module Spree
       item.update_column(:pre_tax_amount, pre_tax_amount)
     end
 
-    # This method is best described by the documentation on #potentially_applicable?
+    # Deletes all tax adjustments, then applies all applicable rates
+    # to relevant items.
     def self.adjust(order, items)
       rates = match(order.tax_zone)
       tax_categories = rates.map(&:tax_category)
-      relevant_items, non_relevant_items = items.partition { |item| tax_categories.include?(item.tax_category) }
-      Spree::Adjustment.where(adjustable: relevant_items).tax.destroy_all # using destroy_all to ensure adjustment destroy callback fires.
+
+      # using destroy_all to ensure adjustment destroy callback fires.
+      Spree::Adjustment.where(adjustable: items).tax.destroy_all
+
+      relevant_items = items.select do |item|
+        tax_categories.include?(item.tax_category)
+      end
+
       relevant_items.each do |item|
-        relevant_rates = rates.select { |rate| rate.tax_category == item.tax_category }
+        relevant_rates = rates.select do |rate|
+          rate.tax_category == item.tax_category
+        end
         store_pre_tax_amount(item, relevant_rates)
         relevant_rates.each do |rate|
           rate.adjust(order, item)
         end
       end
-      non_relevant_items.each do |item|
-        if item.adjustments.tax.present?
-          item.adjustments.tax.destroy_all # using destroy_all to ensure adjustment destroy callback fires.
-          item.update_columns pre_tax_amount: 0
-        end
-      end
     end
 
-    # Tax rates can *potentially* be applicable to an order.
-    # We do not know if they are/aren't until we attempt to apply these rates to
-    # the items contained within the Order itself.
-    # For instance, if a rate passes the criteria outlined in this method,
-    # but then has a tax category that doesn't match against any of the line items
-    # inside of the order, then that tax rate will not be applicable to anything.
-    # For instance:
-    #
-    # Zones:
-    #   - Spain (default tax zone)
-    #   - France
-    #
-    # Tax rates: (note: amounts below do not actually reflect real VAT rates)
-    #   21% inclusive - "Clothing" - Spain
-    #   18% inclusive - "Clothing" - France
-    #   10% inclusive - "Food" - Spain
-    #   8% inclusive - "Food" - France
-    #   5% inclusive - "Hotels" - Spain
-    #   2% inclusive - "Hotels" - France
-    #
-    # Order has:
-    #   Line Item #1 - Tax Category: Clothing
-    #   Line Item #2 - Tax Category: Food
-    #
-    # Tax rates that should be selected:
-    #
-    #  21% inclusive - "Clothing" - Spain
-    #  10% inclusive - "Food" - Spain
-    #
-    # If the order's address changes to one in France, then the tax will be recalculated:
-    #
-    #  18% inclusive - "Clothing" - France
-    #  8% inclusive - "Food" - France
-    #
-    # Note here that the "Hotels" tax rates will not be used at all.
-    # This is because there are no items which have the tax category of "Hotels".
-    #
-    # Under no circumstances should negative adjustments be applied for the Spanish tax rates.
-    #
-    # Those rates should never come into play at all and only the French rates should apply.
-    def potentially_applicable?(order_tax_zone)
-      # If the rate's zone matches the order's tax zone, then it's applicable.
-      self.zone == order_tax_zone ||
-      # If the rate's zone *contains* the order's tax zone, then it's applicable.
-      self.zone.contains?(order_tax_zone) ||
-      # 1) The rate's zone is the default zone, then it's always applicable.
-      (self.included_in_price? && self.zone.default_tax)
+    def self.included_tax_amount_for(zone, category)
+      return 0 unless zone && category
+      potential_rates_for_zone(zone).
+        included_in_price.
+        for_tax_category(category).
+        pluck(:amount).sum
     end
 
     def adjust(order, item)
-      included = included_in_price && default_zone_or_zone_match?(order)
-      create_adjustment(order, item, included)
+      create_adjustment(order, item, included_in_price)
     end
 
     def compute_amount(item)
-      refund = included_in_price && !default_zone_or_zone_match?(item.order)
-      compute(item) * (refund ? -1 : 1)
+      compute(item)
     end
 
     private
 
-    def default_zone_or_zone_match?(order)
-      Zone.default_tax.try(:contains?, order.tax_zone) || order.tax_zone == zone
+    def label
+      Spree.t included_in_price? ? :including_tax : :excluding_tax,
+              scope: "adjustment_labels.tax_rates",
+              name: name.presence || tax_category.name,
+              amount: amount_for_label
     end
 
-    def label(adjustment_amount)
-      label = ""
-      label << Spree.t(:refund) << ' ' if adjustment_amount < 0
-      label << (name.present? ? name : tax_category.name) + " "
-      label << (show_rate_in_label? ? "#{amount * 100}%" : "")
-      label << " (#{Spree.t(:included_in_price)})" if included_in_price?
-      label
+    def amount_for_label
+      return "" unless show_rate_in_label?
+      " " + ActiveSupport::NumberHelper::NumberToPercentageConverter.convert(
+        amount * 100,
+        locale: I18n.locale
+      )
     end
   end
 end

--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -25,8 +25,7 @@ module Spree
       if zone.country?
         # Match zones of the same kind with simialr countries
         joins(countries: :zones).
-          where('zone_members_spree_countries_join.zone_id = ? OR ' +
-                'spree_zones.default_tax = ?', zone.id, true).
+          where("zone_members_spree_countries_join.zone_id = ?", zone.id).
           uniq
       else
         # Match zones of the same kind with similar states in AND match zones
@@ -35,11 +34,9 @@ module Spree
           "(spree_zone_members.zoneable_type = 'Spree::State' AND
             spree_zone_members.zoneable_id IN (?))
            OR (spree_zone_members.zoneable_type = 'Spree::Country' AND
-            spree_zone_members.zoneable_id IN (?))
-           OR default_tax = ?",
+            spree_zone_members.zoneable_id IN (?))",
           zone.state_ids,
-          zone.states.pluck(:country_id),
-          true
+          zone.states.pluck(:country_id)
         ).uniq
       end
     end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1020,6 +1020,7 @@ en:
       match_policies:
         all: Match all of these rules
         any: Match any of these rules
+    promotion_label: 'Promotion (%{name})'
     promotion_rule: Promotion Rule
     promotion_rule_types:
       first_order:

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -317,7 +317,6 @@ en:
             base:
               cannot_destroy_default_store: Cannot destroy the default Store.
 
-
   devise:
     confirmations:
       confirmed: Your account was successfully confirmed. You are now signed in.
@@ -356,6 +355,7 @@ en:
     user_sessions:
       signed_in: Signed in successfully.
       signed_out: Signed out successfully.
+
   errors:
     messages:
       already_confirmed: was already confirmed
@@ -364,6 +364,12 @@ en:
       not_saved:
         one: ! '1 error prohibited this %{resource} from being saved:'
         other: ! '%{count} errors prohibited this %{resource} from being saved:'
+
+  number:
+    percentage:
+      format:
+        precision: 1
+
   spree:
     abbreviation: Abbreviation
     accept: Accept
@@ -409,6 +415,10 @@ en:
     adjustable: Adjustable
     adjustment: Adjustment
     adjustment_amount: Amount
+    adjustment_labels:
+      tax_rates:
+        including_tax: '%{name}%{amount} (Included in Price)'
+        excluding_tax: '%{name}%{amount}'
     adjustment_successfully_closed: Adjustment has been successfully closed!
     adjustment_successfully_opened: Adjustment has been successfully opened!
     adjustment_total: Adjustment Total
@@ -1201,6 +1211,10 @@ en:
     shipping_method: Shipping Method
     shipping_methods: Shipping Methods
     shipping_price_sack: Price sack
+    shipping_rates:
+      display_price:
+        including_tax: "%{price} (incl. %{tax_amount} %{tax_rate_name})"
+        excluding_tax: "%{price} (+ %{tax_amount} %{tax_rate_name})"
     shipping_total: Shipping total
     shop_by_taxonomy: Shop by %{taxonomy}
     shopping_cart: Shopping Cart

--- a/core/lib/spree/core/controller_helpers/store.rb
+++ b/core/lib/spree/core/controller_helpers/store.rb
@@ -7,6 +7,7 @@ module Spree
         included do
           helper_method :current_currency
           helper_method :current_store
+          helper_method :current_tax_zone
         end
 
         def current_currency
@@ -15,6 +16,14 @@ module Spree
 
         def current_store
           @current_store ||= Spree::Store.current(request.env['SERVER_NAME'])
+        end
+
+        def current_tax_zone
+          if current_order
+            current_order.tax_zone
+          else
+            Spree::Zone.default_tax
+          end
         end
       end
     end

--- a/core/lib/spree/core/controller_helpers/store.rb
+++ b/core/lib/spree/core/controller_helpers/store.rb
@@ -19,11 +19,7 @@ module Spree
         end
 
         def current_tax_zone
-          if current_order
-            current_order.tax_zone
-          else
-            Spree::Zone.default_tax
-          end
+          current_order.try(:tax_zone) || Spree::Zone.default_tax
         end
       end
     end

--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -134,4 +134,66 @@ describe Spree::BaseHelper, type: :helper do
       expect(pretty_time(DateTime.new(2012, 5, 6, 13, 33))).to eq "May 06, 2012  1:33 PM"
     end
   end
+
+  describe "#display_price" do
+    let!(:product) { create(:product) }
+    let(:current_currency) { "USD" }
+
+    context "when there is no current order" do
+      let (:current_tax_zone) { nil }
+
+      it "returns the price including default vat" do
+        expect(display_price(product)).to eq("$19.99")
+      end
+
+      context "with a default VAT" do
+        let(:current_tax_zone) { create(:zone_with_country, default_tax: true) }
+        let!(:tax_rate) do
+          create :tax_rate,
+                 included_in_price: true,
+                 zone: current_tax_zone,
+                 tax_category: product.tax_category,
+                 amount: 0.2
+        end
+
+        it "returns the price adding the VAT" do
+          expect(display_price(product)).to eq("$19.99")
+        end
+      end
+    end
+
+    context "with an order that has a tax zone" do
+      let(:current_tax_zone) { create(:zone_with_country) }
+      let(:current_order) { Spree::Order.new }
+      let(:default_zone) { create(:zone_with_country, default_tax: true) }
+
+      let!(:default_vat) do
+        create :tax_rate,
+               included_in_price: true,
+               zone: default_zone,
+               tax_category: product.tax_category,
+               amount: 0.2
+      end
+
+      context "that matches no VAT" do
+        it "returns the price excluding VAT" do
+          expect(display_price(product)).to eq("$16.66")
+        end
+      end
+
+      context "that matches a VAT" do
+        let!(:other_vat) do
+          create :tax_rate,
+                 included_in_price: true,
+                 zone: current_tax_zone,
+                 tax_category: product.tax_category,
+                 amount: 0.4
+        end
+
+        it "returns the price adding the VAT" do
+          expect(display_price(product)).to eq("$23.32")
+        end
+      end
+    end
+  end
 end

--- a/core/spec/helpers/products_helper_spec.rb
+++ b/core/spec/helpers/products_helper_spec.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require 'spec_helper'
+require "spec_helper"
 
 module Spree
   describe ProductsHelper, :type => :helper do
@@ -193,10 +193,13 @@ THIS IS THE BEST PRODUCT EVER!
     end
 
     context '#cache_key_for_products' do
+      let(:zone) { Spree::Zone.new }
+
       subject { helper.cache_key_for_products }
       before(:each) do
         @products = double('products collection')
         allow(helper).to receive(:params) { {:page => 10} }
+        allow(helper).to receive(:current_tax_zone) { zone }
       end
 
       context 'when there is a maximum updated date' do
@@ -206,7 +209,7 @@ THIS IS THE BEST PRODUCT EVER!
           allow(@products).to receive(:maximum).with(:updated_at) { updated_at }
         end
 
-        it { is_expected.to eq('en/USD/spree/products/all-10-20111213-5') }
+        it { is_expected.to eq("en/USD/#{zone.cache_key}/spree/products/all-10-20111213-5") }
       end
 
       context 'when there is no considered maximum updated date' do
@@ -217,7 +220,30 @@ THIS IS THE BEST PRODUCT EVER!
           allow(Date).to receive(:today) { today }
         end
 
-        it { is_expected.to eq('en/USD/spree/products/all-10-20131211-1234567') }
+        it { is_expected.to eq("en/USD/#{zone.cache_key}/spree/products/all-10-20131211-1234567") }
+      end
+    end
+
+    context "#cache_key_for_product" do
+      let(:product) { Spree::Product.new }
+      subject { helper.cache_key_for_product(product) }
+
+      before do
+        allow(helper).to receive(:current_tax_zone) { zone }
+      end
+
+      context "when there is a current tax zone" do
+        let(:zone) { Spree::Zone.new }
+
+        it "includes the current_tax_zone" do
+          is_expected.to have_content(zone.cache_key)
+        end
+      end
+
+      context "when there is no current tax zone" do
+        let(:zone) { nil }
+
+        it { is_expected.to eq("en/USD/#{product.cache_key}") }
       end
     end
   end

--- a/core/spec/lib/spree/core/controller_helpers/store_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/store_spec.rb
@@ -13,4 +13,56 @@ describe Spree::Core::ControllerHelpers::Store, type: :controller do
       expect(controller.current_store).to eq store
     end
   end
+
+  describe "#current_tax_zone" do
+    subject { controller.current_tax_zone }
+
+    context "when there is a default tax zone" do
+      let(:default_zone) { Spree::Zone.new }
+
+      before do
+        allow(Spree::Zone).to receive(:default_tax).and_return(default_zone)
+      end
+
+      context "when there is no current order" do
+        it "returns the default tax zone" do
+          is_expected.to eq(default_zone)
+        end
+      end
+
+      context "when there is a current order" do
+        let(:other_zone) { Spree::Zone.new }
+        let(:current_order) { Spree::Order.new }
+
+        before do
+          allow(current_order).to receive(:tax_zone).and_return(other_zone)
+          allow(controller).to receive(:current_order).and_return(current_order)
+        end
+
+        it { is_expected.to eq(other_zone) }
+      end
+    end
+
+    context "when there is no default tax zone" do
+      before do
+        allow(Spree::Zone).to receive(:default_tax).and_return(nil)
+      end
+
+      context "when there is no current order" do
+        it { is_expected.to be_nil }
+      end
+
+      context "when there is a current order" do
+        let(:other_zone) { Spree::Zone.new }
+        let(:current_order) { Spree::Order.new }
+
+        before do
+          allow(current_order).to receive(:tax_zone).and_return(other_zone)
+          allow(controller).to receive(:current_order).and_return(current_order)
+        end
+
+        it { is_expected.to eq(other_zone) }
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/concerns/vat_price_calculation_spec.rb
+++ b/core/spec/models/spree/concerns/vat_price_calculation_spec.rb
@@ -1,0 +1,60 @@
+require "spec_helper"
+
+module Spree
+  describe VatPriceCalculation do
+    let(:test_class) do
+      Class.new do
+        include VatPriceCalculation
+        def total; 10.0; end
+      end
+    end
+
+    describe "#gross_amount" do
+      let(:zone) { Zone.new }
+      let(:tax_category) { TaxCategory.new }
+      let(:amount) { 100 }
+
+      subject { test_class.new.gross_amount(amount, zone, tax_category) }
+
+      context "with no default zone set" do
+        it "does not call TaxRate.included_tax_amount_for" do
+          expect(TaxRate).not_to receive(:included_tax_amount_for)
+          subject
+        end
+      end
+
+      context "with no zone given" do
+        let(:zone) { nil }
+        it "does not call TaxRate.included_tax_amount_for" do
+          expect(TaxRate).not_to receive(:included_tax_amount_for)
+          subject
+        end
+      end
+
+      context "with a default zone set" do
+        let(:default_zone) { Spree::Zone.new }
+        before do
+          allow(Spree::Zone).to receive(:default_tax).and_return(default_zone)
+        end
+
+        context "and zone equal to the default zone" do
+          let(:zone) { default_zone }
+
+          it "does not call 'TaxRate.included_tax_amount_for'" do
+            expect(TaxRate).not_to receive(:included_tax_amount_for)
+            subject
+          end
+        end
+
+        context "and zone not equal to default zone" do
+          let(:zone) { Spree::Zone.new }
+
+          it "calls TaxRate.included_tax_amount_for two times" do
+            expect(TaxRate).to receive(:included_tax_amount_for).twice
+            subject
+          end
+        end
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -110,6 +110,16 @@ describe Spree::LineItem, :type => :model do
     end
   end
 
+  # test for copying prices when the vat changes
+  context "#update_price" do
+    it "copies over a variants differing price for another vat zone" do
+      expect(line_item.variant).to receive(:price_including_vat_for).and_return(12)
+      line_item.price = 10
+      line_item.update_price
+      expect(line_item.price).to eq(12)
+    end
+  end
+
   # Test for #3481
   context '#copy_tax_category' do
     it "copies over a variant's tax category" do

--- a/core/spec/models/spree/price_spec.rb
+++ b/core/spec/models/spree/price_spec.rb
@@ -45,13 +45,16 @@ describe Spree::Price, :type => :model do
     let(:default_zone) { Spree::Zone.new }
     let(:zone) { Spree::Zone.new }
     let(:amount) { 10 }
+    let(:tax_category) { Spree::TaxCategory.new }
     subject { Spree::Price.new variant: variant, amount: amount }
 
     context 'when called with a non-default zone' do
       before do
+        allow(variant).to receive(:tax_category).and_return(tax_category)
         expect(subject).to receive(:default_zone).at_least(:once).and_return(default_zone)
-        allow(subject).to receive(:included_tax_amount).with(default_zone) { 0.19 }
-        allow(subject).to receive(:included_tax_amount).with(zone) { 0.25 }
+        allow(subject).to receive(:apply_foreign_vat?).and_return(true)
+        allow(subject).to receive(:included_tax_amount).with(default_zone, tax_category) { 0.19 }
+        allow(subject).to receive(:included_tax_amount).with(zone, tax_category) { 0.25 }
       end
 
       it "returns the correct price including another VAT to two digits" do
@@ -61,6 +64,7 @@ describe Spree::Price, :type => :model do
 
     context 'when called from the default zone' do
       before do
+        allow(variant).to receive(:tax_category).and_return(tax_category)
         expect(subject).to receive(:default_zone).at_least(:once).and_return(zone)
       end
 
@@ -72,6 +76,7 @@ describe Spree::Price, :type => :model do
 
     context 'when no default zone is set' do
       before do
+        allow(variant).to receive(:tax_category).and_return(tax_category)
         expect(subject).to receive(:default_zone).at_least(:once).and_return(nil)
       end
 

--- a/core/spec/models/spree/price_spec.rb
+++ b/core/spec/models/spree/price_spec.rb
@@ -39,4 +39,54 @@ describe Spree::Price, :type => :model do
       it { is_expected.to be_valid }
     end
   end
+
+  describe '#price_including_vat_for(zone)' do
+    let(:variant) { stub_model Spree::Variant }
+    let(:default_zone) { Spree::Zone.new }
+    let(:zone) { Spree::Zone.new }
+    let(:amount) { 10 }
+    subject { Spree::Price.new variant: variant, amount: amount }
+
+    context 'when called with a non-default zone' do
+      before do
+        expect(subject).to receive(:default_zone).at_least(:once).and_return(default_zone)
+        allow(subject).to receive(:included_tax_amount).with(default_zone) { 0.19 }
+        allow(subject).to receive(:included_tax_amount).with(zone) { 0.25 }
+      end
+
+      it "returns the correct price including another VAT to two digits" do
+        expect(subject.price_including_vat_for(zone)).to eq(10.50)
+      end
+    end
+
+    context 'when called from the default zone' do
+      before do
+        expect(subject).to receive(:default_zone).at_least(:once).and_return(zone)
+      end
+
+      it "returns the correct price" do
+        expect(subject).to receive(:price).and_call_original
+        expect(subject.price_including_vat_for(zone)).to eq(10.00)
+      end
+    end
+
+    context 'when no default zone is set' do
+      before do
+        expect(subject).to receive(:default_zone).at_least(:once).and_return(nil)
+      end
+
+      it "returns the correct price" do
+        expect(subject).to receive(:price).and_call_original
+        expect(subject.price_including_vat_for(zone)).to eq(10.00)
+      end
+    end
+  end
+
+  describe '#display_price_including_vat_for(zone)' do
+    subject { Spree::Price.new amount: 10 }
+    it 'calls #price_including_vat_for' do
+      expect(subject).to receive(:price_including_vat_for)
+      subject.display_price_including_vat_for(nil)
+    end
+  end
 end

--- a/core/spec/models/spree/reimbursement_spec.rb
+++ b/core/spec/models/spree/reimbursement_spec.rb
@@ -50,7 +50,7 @@ describe Spree::Reimbursement, type: :model do
     let!(:adjustments)            { [] } # placeholder to ensure it gets run prior the "before" at this level
 
     let!(:tax_rate)               { nil }
-    let!(:tax_zone)               { create(:zone, default_tax: true) }
+    let!(:tax_zone) { create(:zone_with_country, default_tax: true) }
 
     let(:order)                   { create(:order_with_line_items, state: 'payment', line_items_count: 1, line_items_price: line_items_price, shipment_cost: 0) }
     let(:line_items_price)        { BigDecimal.new(10) }
@@ -118,7 +118,7 @@ describe Spree::Reimbursement, type: :model do
           subject
         }.to change { Spree::Refund.count }.by(1)
         return_item.reload
-        expect(return_item.included_tax_total).to be < 0
+        expect(return_item.included_tax_total).to be > 0
         expect(return_item.included_tax_total).to eq line_item.included_tax_total
         expect(reimbursement.total).to eq (line_item.pre_tax_amount + line_item.included_tax_total).round(2, :down)
         expect(Spree::Refund.last.amount).to eq (line_item.pre_tax_amount + line_item.included_tax_total).round(2, :down)

--- a/core/spec/models/spree/reimbursement_tax_calculator_spec.rb
+++ b/core/spec/models/spree/reimbursement_tax_calculator_spec.rb
@@ -24,8 +24,14 @@ describe Spree::ReimbursementTaxCalculator, :type => :model do
   end
 
   context 'with additional tax' do
-    let!(:tax_rate) { create(:tax_rate, name: "Sales Tax", amount: 0.10, included_in_price: false, zone: tax_zone) }
-    let(:tax_zone) { create(:zone, default_tax: true) }
+    let!(:tax_rate) do
+      create :tax_rate,
+             name: "Sales Tax",
+             amount: 0.10,
+             included_in_price: false,
+             tax_category: create(:tax_category),
+             zone: create(:zone_with_country, default_tax: true)
+    end
 
     it 'sets additional_tax_total on the return items' do
       subject
@@ -37,14 +43,20 @@ describe Spree::ReimbursementTaxCalculator, :type => :model do
   end
 
   context 'with included tax' do
-    let!(:tax_rate) { create(:tax_rate, name: "VAT Tax", amount: 0.1, included_in_price: true, zone: tax_zone) }
-    let(:tax_zone) { create(:zone, default_tax: true) }
+    let!(:tax_rate) do
+      create :tax_rate,
+             name: "VAT Tax",
+             amount: 0.10,
+             included_in_price: true,
+             tax_category: create(:tax_category),
+             zone: create(:zone_with_country, default_tax: true)
+    end
 
     it 'sets included_tax_total on the return items' do
       subject
       return_item.reload
 
-      expect(return_item.included_tax_total).to be < 0
+      expect(return_item.included_tax_total).to be > 0
       expect(return_item.included_tax_total).to eq line_item.included_tax_total
     end
   end

--- a/core/spec/models/spree/shipping_rate_spec.rb
+++ b/core/spec/models/spree/shipping_rate_spec.rb
@@ -11,20 +11,20 @@ describe Spree::ShippingRate, :type => :model do
 
   context "#display_price" do
     context "when tax included in price" do
+      let!(:default_zone) { create(:zone, :default_tax => true) }
+      let(:default_tax_rate) do
+        create(:tax_rate,
+          :name => "VAT",
+          :amount => 0.1,
+          :included_in_price => true,
+          :zone => default_zone)
+      end
       context "when the tax rate is from the default zone" do
-        let!(:zone) { create(:zone, :default_tax => true) }
-        let(:tax_rate) do 
-          create(:tax_rate,
-            :name => "VAT",
-            :amount => 0.1,
-            :included_in_price => true,
-            :zone => zone)
-        end
 
-        before { shipping_rate.tax_rate = tax_rate }
+        before { shipping_rate.tax_rate = default_tax_rate }
 
         it "shows correct tax amount" do
-          expect(shipping_rate.display_price.to_s).to eq("$10.00 (incl. $0.91 #{tax_rate.name})")
+          expect(shipping_rate.display_price.to_s).to eq("$10.00 (incl. $0.91 #{default_tax_rate.name})")
         end
 
         context "when cost is zero" do
@@ -38,20 +38,21 @@ describe Spree::ShippingRate, :type => :model do
         end
       end
 
-      context "when the tax rate is from a non-default zone" do
-        let!(:default_zone) { create(:zone, :default_tax => true) }
+      context "when the tax rate is from another zone" do
         let!(:non_default_zone) { create(:zone, :default_tax => false) }
-        let(:tax_rate) do
+
+        let(:non_default_tax_rate) do
           create(:tax_rate,
             :name => "VAT",
-            :amount => 0.1,
+            :amount => 0.2,
             :included_in_price => true,
             :zone => non_default_zone)
         end
-        before { shipping_rate.tax_rate = tax_rate }
+        before { shipping_rate.tax_rate = non_default_tax_rate }
 
-        it "shows correct tax amount" do
-          expect(shipping_rate.display_price.to_s).to eq("$10.00 (excl. $0.91 #{tax_rate.name})")
+        pending "I would expect this to be analogue to line items: First calculate the net price, then add the foreign VAT.\n"+
+                "However, I'm still waiting for the requirements to be properly defined here. " do
+          expect(shipping_rate.display_price.to_s).to eq("$10.91 (incl. $1.82 #{non_default_tax_rate.name})")
         end
 
         context "when cost is zero" do

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -148,6 +148,62 @@ module Spree
             expect(shipping_rates.first.tax_rate).to eq(tax_rate)
           end
         end
+
+        context "VAT price calculation" do
+          let(:tax_category) { create :tax_category }
+          let!(:shipping_method) { create(:shipping_method, tax_category: tax_category) }
+
+          let(:default_zone) { create(:zone_with_country, default_tax: true) }
+          let!(:default_vat) do
+            create :tax_rate,
+                   included_in_price: true,
+                   zone: default_zone,
+                   amount: 0.2,
+                   tax_category: shipping_method.tax_category
+          end
+
+          context "when the order does not have a tax zone" do
+            before { allow(order).to receive(:tax_zone).and_return nil }
+            it_should_behave_like "shipping rate matches"
+          end
+
+          context "when the order's tax zone is the default zone" do
+            before { allow(order).to receive(:tax_zone).and_return(default_zone) }
+            it_should_behave_like "shipping rate matches"
+          end
+
+          context "when the order's tax zone is a non-VAT zone" do
+            let!(:zone_without_vat) { create(:zone_with_country) }
+            before { allow(order).to receive(:tax_zone).and_return(zone_without_vat) }
+
+            it 'deducts the default VAT from the cost' do
+              shipping_rates = subject.shipping_rates(package)
+              # deduct default vat: 4.00 / 1.2 = 3.33 (rounded)
+              expect(shipping_rates.first.cost).to eq(3.33)
+            end
+          end
+
+          context "when the order's tax zone is a zone with VAT outside the default zone" do
+            let(:other_vat_zone) { create(:zone_with_country) }
+            let!(:other_vat) do
+              create :tax_rate,
+                     included_in_price: true,
+                     zone: other_vat_zone,
+                     amount: 0.3,
+                     tax_category: shipping_method.tax_category
+            end
+
+            before { allow(order).to receive(:tax_zone).and_return(other_vat_zone) }
+
+            it 'deducts the default vat and applies the foreign vat to calculate the price' do
+              shipping_rates = subject.shipping_rates(package)
+              #
+              # deduct default vat: 4.00 / 1.2 = 3.33 (rounded)
+              # apply foreign vat: 3.33 * 1.3 = 4.33 (rounded)
+              expect(shipping_rates.first.cost).to eq(4.33)
+            end
+          end
+        end
       end
     end
   end

--- a/core/spec/models/spree/zone_spec.rb
+++ b/core/spec/models/spree/zone_spec.rb
@@ -327,10 +327,6 @@ describe Spree::Zone, :type => :model do
       it "only returns each zone once" do
         expect(@result.select { |z| z == zone }.size).to be 1
       end
-
-      it "will include the default_tax zone" do
-        expect(@result).to include(default_tax_zone)
-      end
     end
 
     context "finding potential matches for a state zone" do
@@ -363,10 +359,6 @@ describe Spree::Zone, :type => :model do
 
       it "only returns each zone once" do
         expect(@result.select { |z| z == zone }.size).to be 1
-      end
-
-      it "will include the default tax zone" do
-        expect(@result).to include(default_tax_zone)
       end
     end
   end

--- a/core/spec/support/concerns/default_price_spec.rb
+++ b/core/spec/support/concerns/default_price_spec.rb
@@ -22,6 +22,15 @@ shared_examples_for "default_price" do
     subject { instance.default_price }
 
     its(:class) { should eql Spree::Price }
+    it 'delegates price' do
+      expect(instance.default_price). to receive(:price)
+      instance.price
+    end
+
+    it 'delegates price_including_vat_for' do
+      expect(instance.default_price). to receive(:price_including_vat_for)
+      instance.price_including_vat_for
+    end
   end
 
   its(:has_default_price?) { should be_truthy }

--- a/frontend/app/views/spree/products/show.html.erb
+++ b/frontend/app/views/spree/products/show.html.erb
@@ -1,6 +1,6 @@
 <% @body_id = 'product-details' %>
 
-<% cache [I18n.locale, current_currency, @product] do %>
+<% cache cache_key_for_product do %>
   <div data-hook="product_show" itemscope itemtype="http://schema.org/Product">
     <div class="col-md-4" data-hook="product_left_part">
       <div data-hook="product_left_part_wrap">

--- a/frontend/app/views/spree/shared/_products.html.erb
+++ b/frontend/app/views/spree/shared/_products.html.erb
@@ -22,7 +22,7 @@
       <% url = spree.product_url(product, taxon_id: @taxon.try(:id)) %>
       <div id="product_<%= product.id %>" class="col-md-3 col-sm-6 product-list-item" data-hook="products_list_item" itemscope itemtype="http://schema.org/Product">
         <div class="panel panel-default">
-          <% cache(@taxon.present? ? [I18n.locale, current_currency, @taxon, product] : [I18n.locale, current_currency, product]) do %>
+          <% cache(@taxon.present? ? [I18n.locale, current_currency, @taxon, product] : cache_key_for_product(product)) do %>
             <div class="panel-body text-center product-body">
               <%= link_to small_image(product, itemprop: "image"), url, itemprop: 'url' %><br/>
               <%= link_to truncate(product.name, length: 50), url, class: 'info', itemprop: "name", title: product.name %>

--- a/guides/content/developer/core/taxation.md
+++ b/guides/content/developer/core/taxation.md
@@ -105,16 +105,12 @@ Finally, if the taxable address (either the shipping or billing, depending on th
 
 Many jurisdictions have what is commonly referred to as a Value Added Tax (VAT.) In these cases the tax is typically applied to the price. This means that prices for items are "inclusive of tax" and no additional tax needs to be applied during checkout.
 
-In the case of tax inclusive pricing the store owner should enter all prices inclusive of tax. This makes it easy for Spree to display the tax inclusive price since it won't have to be constantly calculated on the fly.
+In the case of tax inclusive pricing the store owner can enter all prices inclusive of tax if their home country is the default zone. If there is no default zone set, any taxes that are included in the price will be added to the net prices on the fly depending on the current order's tax zone.
+
+If the current order's tax zone is outside the default zone, prices will be shown and used with only the included taxes for that zone applied. If there is no VAT for that zone (for example when the current order's shipping address is outside the EU), the net price will be shown and used.
 
 ***
 Keep in mind that each order records the price a customer paid (including the tax) as part of the line item record. This means you don't have to worry about changing prices or tax rates affecting older orders.
-***
-
-If you are going to designate one or more tax rates as being included in the price then you must first set up a default tax zone. Spree will not allow you to proceed without performing this step. This default zone is needed in cases where a customer might not be eligible to pay the tax.
-
-***
-You must choose a default tax zone if you are going to mark at a tax rate as being included in your product prices.
 ***
 
 When tax is included in the price there is no order adjustment needed (unlike the sales tax case). Stores are, however, typically interested in showing the amount of tax the user paid. These totals are for informational purposes only and do not affect the order total.
@@ -132,6 +128,25 @@ Now let's assume an additional tax rate of 10% on a "Consumer Electronics" tax c
 Finally, if the order's address is changed to being outside this tax zone, then there will be two negative adjustments applied to remove these tax rates from the order.
 
 ### Additional Examples
+
+
+#### Differing VATs for different product categories depending on the customer's zone
+
+As of January 1st, 2015, digital products sold within the EU must have the VAT of the receiving country applied. Physical products must have the seller's VAT applied. In order to set this up, please proceed as follows:
+
+1. Create zones for all EU countries and a zone for all EU countries except your home zone.
+
+2. Mark your home zone as the default zone so you can conveniently enter gross prices.
+
+3. Create a tax category "Digital products", and a tax category "Physical products".
+
+4. Add tax rates that are "included in tax" for the tax category "Physical goods" for all EU countries.
+
+5. Add two tax rates for the tax category "Physical products":
+  1. One for your home country, with your home country's VAT
+  2. One for the rest of the EU, also with your home country's VAT
+
+If you change the tax zone of the current order (by changing the relevant address), prices will now be shown and used including the correct VAT for the current order.
 
 !!!
 All of the examples in this guide are meant to be used for illustrative purposes. They are not meant to be used as definitive interpretations of tax law. You should consult your accountant or attorney for guidance on how much tax to collect and under what circumstances.

--- a/guides/content/release_notes/3_1_0.md
+++ b/guides/content/release_notes/3_1_0.md
@@ -14,6 +14,18 @@ Now that we're beginning to write a new API we've added a v1 namespace,
 and default routing /api requests to use /api/v1.  The /api/v2 will be opt-in
 until we feel it is complete, and have deprecated /api/v1 (likely for Spree 4).
 
+### Dynamic prices depending on zone for VAT countries
+
+The European Union has come up with new legislation requiring digital products
+to be taxed using the customer's shipping address. In turn, this means that prices
+have to be shown depending on the current order's tax zone.
+
+Your order will always use the price for the current tax zone. After the address step in
+the checkout process, the order will fetch the prices from the Variant again in order to
+make sure they're correct.
+
+For more information, see the [taxation guide](https://guides.spreecommerce.com/developer/taxation.html).
+
 ## Upgrade
 
 ### Update Gemfile & Run Migrations


### PR DESCRIPTION
1.  Add current_tax_zone helper
   
   The `current_tax_zone` is needed for displaying the correct price
   including VAT.
   
   In order to cache product prices that depend on the current tax zone, 
   we need to add the current tax zone to the cache key for a single or
   multiple products.
2.  Display correct VAT prices
   1. Add Spree::Price#price_including_tax_for(zone)
      
      This methods returns the correctly calculated gross price
      for any zone that might have VAT. This way we can make sure to
      always include the correct VAT in prices (even if they differ).
      
      The method is delegated to Spree::Product and Spree::Variant.
   2. Amend display_price helper to use current tax zone
3. Copy price including VAT from Variant
   
   This enables us to always have the same price as displayed
   in the order. It also frees us from having to load default VAT
   rates in `tax_rate.rb`.
   
   The line item price will only ever be updated after the address
   step in the state machine.
   
   One expectation is changed in the back-end, because here the
   price of the line items is updated from the variant, and those are
   different.
4. Refactor Spree::Zone and Spree::TaxRate
   
   When adjusting line items, do not include the default rates
   in the Array of applicable rates. This was only necessary because
   we could not be sure about the price being correct in the first place,
   which is now fixed through ´Spree::Price#price_inlcuding_vat_for(zone)´.
   
   As a consequence, I could refactor the stock estimator and fix
   https://github.com/spree/spree/issues/6234.
5. Add rounding spec to tax_rate_spec.rb
   
   This is mainly for posterity: I got stuck in rounding hell once, and
   this test should ensure no-one else will have to.
6. Fix reimbursement expectations
   
   The reimbursement spec expected negative adjustments for included tax,
   which aren't necessary anymore - if your local tax zone does not include
   the default VAT zone's VAT, the price is adjusted accordingly
   beforehand.
7. Add test for MOSS taxes
   
   This is an elaborate almost-integration-test for a particular setup
   proving that it actually _is_ possible now to configure Spree for MOSS.
