### PR TITLE
check relevant_items length before destroy_all

### DIFF
--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -83,7 +83,7 @@ module Spree
       rates = match(order.tax_zone)
       tax_categories = rates.map(&:tax_category)
       relevant_items, non_relevant_items = items.partition { |item| tax_categories.include?(item.tax_category) }
-      Spree::Adjustment.where(adjustable: relevant_items).tax.destroy_all # using destroy_all to ensure adjustment destroy callback fires.
+      Spree::Adjustment.where(adjustable: relevant_items).tax.destroy_all if relevant_items.length > 0 # using destroy_all to ensure adjustment destroy callback fires.
       relevant_items.each do |item|
         relevant_rates = rates.select { |rate| rate.tax_category == item.tax_category }
         store_pre_tax_amount(item, relevant_rates)


### PR DESCRIPTION
If relevant_items is empty array, Spree::Adjustment.where(adjustable: relevant_items).tax.destroy_all will result in following error:

NoMethodError (undefined method `primary_key' for Spree::Adjustable:Module):
  activerecord (4.1.10) lib/active_record/reflection.rb:504:in`primary_key'
  activerecord (4.1.10) lib/active_record/reflection.rb:272:in `association_primary_key'
  activerecord (4.1.10) lib/active_record/relation/predicate_builder.rb:64:in`expand'
  activerecord (4.1.10) lib/active_record/relation/predicate_builder.rb:43:in `block in build_from_hash'
  activerecord (4.1.10) lib/active_record/relation/predicate_builder.rb:21:in`each'
  activerecord (4.1.10) lib/active_record/relation/predicate_builder.rb:21:in `build_from_hash'
  activerecord (4.1.10) lib/active_record/relation/query_methods.rb:954:in`build_where'
  activerecord (4.1.10) lib/active_record/relation/query_methods.rb:572:in `where!'
  activerecord (4.1.10) lib/active_record/relation/query_methods.rb:559:in`where'
  activerecord (4.1.10) lib/active_record/querying.rb:10:in `where'
  /home/hiway/web/hiway_backend/shared/bundle/ruby/2.1.0/bundler/gems/spree-7837fd164059/core/app/models/spree/tax_rate.rb:86:in`adjust'
  /home/hiway/web/hiway_backend/shared/bundle/ruby/2.1.0/bundler/gems/spree-7837fd164059/core/app/models/spree/line_item.rb:145:in `update_tax_charge'
  activesupport (4.1.10) lib/active_support/callbacks.rb:429:in`block in make_lambda'
  activesupport (4.1.10) lib/active_support/callbacks.rb:224:in `call'
  activesupport (4.1.10) lib/active_support/callbacks.rb:224:in`block in halting_and_conditional'
  activesupport (4.1.10) lib/active_support/callbacks.rb:503:in `call'
  activesupport (4.1.10) lib/active_support/callbacks.rb:503:in`block in call'
  activesupport (4.1.10) lib/active_support/callbacks.rb:503:in `each'
  activesupport (4.1.10) lib/active_support/callbacks.rb:503:in`call'
  activesupport (4.1.10) lib/active_support/callbacks.rb:86:in `run_callbacks'
  activerecord (4.1.10) lib/active_record/callbacks.rb:306:in`_create_record'
  activerecord (4.1.10) lib/active_record/timestamp.rb:57:in `_create_record'
  activerecord (4.1.10) lib/active_record/persistence.rb:484:in`create_or_update'
  activerecord (4.1.10) lib/active_record/callbacks.rb:302:in `block in create_or_update'
  activesupport (4.1.10) lib/active_support/callbacks.rb:113:in`call'
  activesupport (4.1.10) lib/active_support/callbacks.rb:113:in `call'
  activesupport (4.1.10) lib/active_support/callbacks.rb:552:in`block (2 levels) in compile'
  activesupport (4.1.10) lib/active_support/callbacks.rb:502:in `call'
  activesupport (4.1.10) lib/active_support/callbacks.rb:502:in`call'
  activesupport (4.1.10) lib/active_support/callbacks.rb:86:in `run_callbacks'
  activerecord (4.1.10) lib/active_record/callbacks.rb:302:in`create_or_update'
  activerecord (4.1.10) lib/active_record/persistence.rb:125:in `save!'
  activerecord (4.1.10) lib/active_record/validations.rb:57:in`save!'
  activerecord (4.1.10) lib/active_record/attribute_methods/dirty.rb:29:in `save!'
  activerecord (4.1.10) lib/active_record/transactions.rb:273:in`block in save!'
activerecord (4.1.10) lib/active_record/transactions.rb:329:in `block in with_transaction_returning_status'
  activerecord (4.1.10) lib/active_record/connection_adapters/abstract/database_statements.rb:201:in`block in transaction'
  activerecord (4.1.10) lib/active_record/connection_adapters/abstract/database_statements.rb:209:in `within_new_transaction'
  activerecord (4.1.10) lib/active_record/connection_adapters/abstract/database_statements.rb:201:in`transaction'
  activerecord (4.1.10) lib/active_record/transactions.rb:208:in `transaction'
  activerecord (4.1.10) lib/active_record/transactions.rb:326:in`with_transaction_returning_status'
  activerecord (4.1.10) lib/active_record/transactions.rb:273:in `save!'
  /home/hiway/web/hiway_backend/shared/bundle/ruby/2.1.0/bundler/gems/spree-7837fd164059/core/app/models/spree/order_contents.rb:84:in`add_to_line_item'
  /home/hiway/web/hiway_backend/shared/bundle/ruby/2.1.0/bundler/gems/spree-7837fd164059/core/app/models/spree/order_contents.rb:10:in `add'
  /home/hiway/web/hiway_backend/shared/bundle/ruby/2.1.0/bundler/gems/spree-7837fd164059/core/app/models/spree/order_populator.rb:36:in`attempt_cart_add'
  /home/hiway/web/hiway_backend/shared/bundle/ruby/2.1.0/bundler/gems/spree-7837fd164059/core/app/models/spree/order_populator.rb:15:in `populate'
  /home/hiway/web/hiway_backend/shared/bundle/ruby/2.1.0/bundler/gems/spree-7837fd164059/frontend/app/controllers/spree/orders_controller.rb:45:in`populate'
