### PR TITLE
Use Spree::DisplayMoney for displaying line items

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -49,6 +49,12 @@ module Spree
       end
     end
 
+    extend DisplayMoney
+    money_methods :amount, :subtotal, :discounted_amount, :final_amount, :total, :price
+
+    alias single_money display_price
+    alias single_display_amount display_price
+
     def amount
       price * quantity
     end
@@ -57,26 +63,13 @@ module Spree
     def discounted_amount
       amount + promo_total
     end
-
-    def discounted_money
-      Spree::Money.new(discounted_amount, { currency: currency })
-    end
+    alias discounted_money display_discounted_amount
 
     def final_amount
       amount + adjustment_total
     end
     alias total final_amount
-
-    def single_money
-      Spree::Money.new(price, { currency: currency })
-    end
-    alias single_display_amount single_money
-
-    def money
-      Spree::Money.new(amount, { currency: currency })
-    end
-    alias display_total money
-    alias display_amount money
+    alias money display_total
 
     def invalid_quantity_check
       self.quantity = 0 if quantity.nil? || quantity < 0

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -119,18 +119,12 @@ describe Spree::LineItem, :type => :model do
     end
   end
 
-  describe '.discounted_amount' do
+  describe '#discounted_amount' do
     it "returns the amount minus any discounts" do
       line_item.price = 10
       line_item.quantity = 2
       line_item.promo_total = -5
       expect(line_item.discounted_amount).to eq(15)
-    end
-  end
-
-  describe "#discounted_money" do
-    it "should return a money object with the discounted amount" do
-      expect(line_item.discounted_money.to_s).to eq "$10.00"
     end
   end
 
@@ -140,7 +134,13 @@ describe Spree::LineItem, :type => :model do
     end
   end
 
-  describe ".money" do
+  describe "#discounted_money" do
+    it "should return a money object with the discounted amount" do
+      expect(line_item.discounted_money.to_s).to eq "$10.00"
+    end
+  end
+
+  describe "#money" do
     before do
       line_item.price = 3.50
       line_item.quantity = 2
@@ -149,10 +149,15 @@ describe Spree::LineItem, :type => :model do
     it "returns a Spree::Money representing the total for this line item" do
       expect(line_item.money.to_s).to eq("$7.00")
     end
+
   end
 
-  describe '.single_money' do
-    before { line_item.price = 3.50 }
+  describe '#single_money' do
+    before do
+      line_item.price = 3.50
+      line_item.quantity = 2
+    end
+
     it "returns a Spree::Money representing the price for one variant" do
       expect(line_item.single_money.to_s).to eq("$3.50")
     end


### PR DESCRIPTION
Spree::LineItem has a couple of methods that do exactly the same as the ones defined by Spree::DisplayMoney.money_methods. Use those and put some aliases, so line-item.rb becomes a little shorter. 
