### PR TITLE
Extends Product#set_property with optional property_presentation

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -184,13 +184,13 @@ module Spree
       product_properties.find_by(property: prop).try(:value)
     end
 
-    def set_property(property_name, property_value)
+    def set_property(property_name, property_value, property_presentation = property_name)
       ActiveRecord::Base.transaction do
         # Works around spree_i18n #301
         property = if Property.exists?(name: property_name)
           Property.where(name: property_name).first
         else
-          Property.create(name: property_name, presentation: property_name)
+          Property.create(name: property_name, presentation: property_presentation)
         end
         product_property = ProductProperty.where(product: self, property: property).first_or_initialize
         product_property.value = property_value

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -282,6 +282,23 @@ describe Spree::Product, :type => :model do
       }.to change { product.properties.length }.by(1)
     end
 
+    context 'optional property_presentation' do
+      subject { Spree::Property.where(name: 'foo').first.presentation }
+      let(:name) { 'foo' }
+      let(:presentation) { 'baz' }
+
+      describe 'is not used' do
+        before { product.set_property(name, 'bar') }
+        it { is_expected.to eq name }
+      end
+
+      describe 'is used' do
+        before { product.set_property(name, 'bar', presentation) }
+        it { is_expected.to eq presentation }
+      end
+    end
+
+
     # Regression test for #2455
     it "should not overwrite properties' presentation names" do
       Spree::Property.where(:name => 'foo').first_or_create!(:presentation => "Foo's Presentation Name")

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -298,7 +298,6 @@ describe Spree::Product, :type => :model do
       end
     end
 
-
     # Regression test for #2455
     it "should not overwrite properties' presentation names" do
       Spree::Property.where(:name => 'foo').first_or_create!(:presentation => "Foo's Presentation Name")


### PR DESCRIPTION
As someone who sometimes wants to set a `Property` on `Product` together with presentation, I would like to be able to use optional argument which defaults to `property_name`.

Tests will be provided at later time provided this is a worthy contribution.
