### PR TITLE
Do not add indices on table spree_users

### DIFF
--- a/core/db/migrate/20150314013438_add_missing_indexes.rb
+++ b/core/db/migrate/20150314013438_add_missing_indexes.rb
@@ -1,27 +1,25 @@
 class AddMissingIndexes < ActiveRecord::Migration
   def change
-    add_index   :spree_promotion_rules_users, 
-                        [:user_id, :promotion_rule_id], 
+    add_index   :spree_promotion_rules_users,
+                        [:user_id, :promotion_rule_id],
                         name: 'index_promotion_rules_users_on_user_id_and_promotion_rule_id'
-    add_index   :spree_products_promotion_rules, 
-                        [:promotion_rule_id, :product_id], 
+    add_index   :spree_products_promotion_rules,
+                        [:promotion_rule_id, :product_id],
                         name: 'index_products_promotion_rules_on_promotion_rule_and_product'
     add_index :spree_orders, :canceler_id
     add_index :spree_orders, :store_id
     add_index :spree_orders_promotions, [:promotion_id, :order_id]
     add_index :spree_properties_prototypes, :prototype_id
-    add_index   :spree_properties_prototypes, 
-                        [:prototype_id, :property_id], 
+    add_index   :spree_properties_prototypes,
+                        [:prototype_id, :property_id],
                         name:  'index_properties_prototypes_on_prototype_and_property'
-    add_index :spree_users, :bill_address_id
-    add_index :spree_users, :ship_address_id
     add_index :spree_taxons_prototypes, [:prototype_id, :taxon_id]
     add_index :spree_option_types_prototypes, :prototype_id
-    add_index   :spree_option_types_prototypes, 
-                        [:prototype_id, :option_type_id], 
+    add_index   :spree_option_types_prototypes,
+                        [:prototype_id, :option_type_id],
                         name: 'index_option_types_prototypes_on_prototype_and_option_type'
-    add_index   :spree_option_values_variants, 
-                        [:option_value_id, :variant_id], 
+    add_index   :spree_option_values_variants,
+                        [:option_value_id, :variant_id],
                         name: 'index_option_values_variants_on_option_value_and_variant'
   end
 end


### PR DESCRIPTION
Spree does not come with a users table, spree_auth_devise does. If an
installation uses a custom user model, this migration will fail. 

This addresses https://github.com/spree/spree/issues/6301.
