### PR TITLE
Avoid recursion on the create_line_items promotion action

### DIFF
--- a/core/app/models/spree/promotion/actions/create_line_items.rb
+++ b/core/app/models/spree/promotion/actions/create_line_items.rb
@@ -39,14 +39,23 @@ module Spree
           order = options[:order]
           return unless self.eligible? order
 
+          action_taken = false
           promotion_action_line_items.each do |item|
             current_quantity = order.quantity_of(item.variant)
-            if current_quantity < item.quantity
-              order.contents.add(item.variant, item.quantity - current_quantity)
+            if current_quantity < item.quantity && item_available?(item)
+              line_item = order.contents.add(item.variant, item.quantity - current_quantity)
+              action_taken = true if line_item.try(:valid?)
             end
           end
-          true
+          action_taken
         end
+
+        # Checks that there's enough stock to add the line item to the order
+        def item_available?(item)
+          quantifier = Spree::Stock::Quantifier.new(item.variant)
+          quantifier.can_supply? item.quantity
+        end
+
       end
     end
   end

--- a/core/spec/models/spree/promotion/actions/create_line_items_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_line_items_spec.rb
@@ -9,29 +9,29 @@ describe Spree::Promotion::Actions::CreateLineItems, :type => :model do
 
   def empty_stock(variant)
     variant.stock_items.update_all(backorderable: false)
-    variant.stock_items.each { |i| i.reduce_count_on_hand_to_zero }
+    variant.stock_items.each(&:reduce_count_on_hand_to_zero)
   end
 
   context "#perform" do
     before do
-      allow(action).to receive_messages :promotion => promotion
+      allow(action).to receive_messages promotion: promotion
       action.promotion_action_line_items.create!(
-        :variant => mug,
-        :quantity => 1
+        variant: mug,
+        quantity: 1
       )
       action.promotion_action_line_items.create!(
-        :variant => shirt,
-        :quantity => 2
+        variant: shirt,
+        quantity: 2
       )
     end
 
     context "order is eligible" do
       before do
-        allow(promotion).to receive_messages :eligible => true
+        allow(promotion).to receive_messages eligible: true
       end
 
       it "adds line items to order with correct variant and quantity" do
-        action.perform(:order => order)
+        action.perform(order: order)
         expect(order.line_items.count).to eq(2)
         line_item = order.line_items.find_by_variant_id(mug.id)
         expect(line_item).not_to be_nil
@@ -40,7 +40,7 @@ describe Spree::Promotion::Actions::CreateLineItems, :type => :model do
 
       it "only adds the delta of quantity to an order" do
         order.contents.add(shirt, 1)
-        action.perform(:order => order)
+        action.perform(order: order)
         line_item = order.line_items.find_by_variant_id(shirt.id)
         expect(line_item).not_to be_nil
         expect(line_item.quantity).to eq(2)
@@ -48,7 +48,7 @@ describe Spree::Promotion::Actions::CreateLineItems, :type => :model do
 
       it "doesn't add if the quantity is greater" do
         order.contents.add(shirt, 3)
-        action.perform(:order => order)
+        action.perform(order: order)
         line_item = order.line_items.find_by_variant_id(shirt.id)
         expect(line_item).not_to be_nil
         expect(line_item.quantity).to eq(3)
@@ -59,21 +59,26 @@ describe Spree::Promotion::Actions::CreateLineItems, :type => :model do
         empty_stock(shirt)
 
         expect(order.contents).to_not receive(:add)
-        action.perform(:order => order)
+        action.perform(order: order)
       end
     end
   end
 
-  describe '#item_available?' do
-    let(:item_out_of_stock) { action.promotion_action_line_items.create!(:variant => mug, :quantity => 1) }
-    let(:item_in_stock) { action.promotion_action_line_items.create!(:variant => shirt, :quantity => 1) }
+  describe "#item_available?" do
+    let(:item_out_of_stock) do
+      action.promotion_action_line_items.create!(:variant => mug, :quantity => 1)
+    end
 
-    it "returns false if the item is out of stock" do 
+    let(:item_in_stock) do
+      action.promotion_action_line_items.create!(:variant => shirt, :quantity => 1)
+    end
+
+    it "returns false if the item is out of stock" do
       empty_stock(mug)
       expect(action.item_available? item_out_of_stock).to be false
     end
 
-    it "returns true if the item is in stock" do 
+    it "returns true if the item is in stock" do
       expect(action.item_available? item_in_stock).to be true
     end
   end


### PR DESCRIPTION
#### What's this PR do?

This PR is aimed to fix #5787 and #5784 

Basically, if the variant that `Spree::Promotion::Actions::CreateLineItems` is out of stock and isn't backorderable an infinite loop will be created as the call to `order.contents.add` will run through all promotions associated with the order trying to add the item again and triggering the promotion action again. This PR prevents that by not calling `order.contents.add` if the item is out of stock.

Also with this PR `Spree::Promotion::Actions::CreateLineItems` will only return `true` when it actually has added a valid line item to the order and `false` otherwise
