### PR TITLE
Fix broken rspec

### DIFF
--- a/api/spec/controllers/spree/api/users_controller_spec.rb
+++ b/api/spec/controllers/spree/api/users_controller_spec.rb
@@ -4,7 +4,7 @@ module Spree
   describe Api::UsersController, :type => :controller do
     render_views
 
-    let(:user) { create(:user, spree_api_key: rand) }
+    let(:user) { create(:user, spree_api_key: rand.to_s) }
     let(:stranger) { create(:user, :email => 'stranger@example.com') }
     let(:attributes) { [:id, :email, :created_at, :updated_at] }
 


### PR DESCRIPTION
This PR fixes the "Invalid API key (xxxxxxxx) specified." error which was caused by float -> string conversion being truncated for certain DB.
