### PR TITLE
Replace newlines with spaces in line-item description

### DIFF
--- a/core/app/helpers/spree/products_helper.rb
+++ b/core/app/helpers/spree/products_helper.rb
@@ -45,7 +45,7 @@ module Spree
 
     def line_item_description_text description_text
       if description_text.present?
-        truncate(strip_tags(description_text.gsub('&nbsp;', ' ').gsub(/\r?\n\r?\n/, ' ')), length: 100)
+        truncate(strip_tags(description_text.gsub('&nbsp;', ' ').squish), length: 100)
       else
         Spree.t(:product_has_no_description)
       end

--- a/core/app/helpers/spree/products_helper.rb
+++ b/core/app/helpers/spree/products_helper.rb
@@ -45,7 +45,7 @@ module Spree
 
     def line_item_description_text description_text
       if description_text.present?
-        truncate(strip_tags(description_text.gsub('&nbsp;', ' ').gsub(/\r?\n\r?\n/, '')), length: 100)
+        truncate(strip_tags(description_text.gsub('&nbsp;', ' ').gsub(/\r?\n\r?\n/, ' ')), length: 100)
       else
         Spree.t(:product_has_no_description)
       end

--- a/core/spec/helpers/products_helper_spec.rb
+++ b/core/spec/helpers/products_helper_spec.rb
@@ -173,6 +173,10 @@ THIS IS THE BEST PRODUCT EVER!
         let(:description) { 'test&nbsp;desc' }
         it { is_expected.to eq('test desc') }
       end
+      context 'description has line endings' do
+        let(:description) { "test\n\r\ndesc" }
+        it { is_expected.to eq('test desc') }
+      end
     end
 
     context "#line_item_description" do


### PR DESCRIPTION
Fixup for issue #6288. The original fix removed the line-items,
but that results in weirdly glued-together words.
This commit also contains a spec that reproduces the error and tests it.

I've committed an extra refactoring to replace the custom newline detection with Rails' [`squish`](http://api.rubyonrails.org/classes/String.html#method-i-squish) helper.
