### PR TITLE
Turbolinks friendly frontend

### DIFF
--- a/core/app/assets/javascripts/spree.js.coffee.erb
+++ b/core/app/assets/javascripts/spree.js.coffee.erb
@@ -3,6 +3,10 @@ class window.Spree
   @ready: (callback) ->
     jQuery(document).ready(callback)
 
+    # fire ready callbacks also on turbolinks page change event
+    jQuery(document).on 'page:load', ->
+      callback(jQuery)
+
   @mountedAt: ->
     "<%= Rails.application.routes.url_helpers.spree_path %>"
 

--- a/frontend/app/assets/javascripts/spree/frontend/product.js.coffee
+++ b/frontend/app/assets/javascripts/spree/frontend/product.js.coffee
@@ -1,4 +1,4 @@
-$ ->
+Spree.ready ($) ->
   Spree.addImageHandlers = ->
     thumbnails = ($ '#product-images ul.thumbnails')
     ($ '#main-image').data 'selectedThumb', ($ '#main-image img').attr('src')


### PR DESCRIPTION
This change allows all Spree frontend javascript to work seamlessly with Turbolinks, while not disturbing if Turbolinks is not present.
