### PR TITLE
add an image factory

### DIFF
--- a/core/lib/spree/testing_support/factories/image_factory.rb
+++ b/core/lib/spree/testing_support/factories/image_factory.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :image, class: Spree::Image do
+    attachment URI.parse('http://upload.wikimedia.org/wikipedia/en/c/c0/Les_Horribles_Cernettes_in_1992.jpg')
+  end
+end


### PR DESCRIPTION
The Horrible Cernettes were a "high energy" rock band from CERN in 1992. First image on the internet.
