### PR TITLE
Ffaker bump

### DIFF
--- a/core/lib/spree/testing_support/factories.rb
+++ b/core/lib/spree/testing_support/factories.rb
@@ -11,9 +11,9 @@ Dir["#{File.dirname(__FILE__)}/factories/**"].each do |f|
 end
 
 FactoryGirl.define do
-  sequence(:random_string)      { Faker::Lorem.sentence }
-  sequence(:random_description) { Faker::Lorem.paragraphs(1 + Kernel.rand(5)).join("\n") }
-  sequence(:random_email)       { Faker::Internet.email }
+  sequence(:random_string)      { FFaker::Lorem.sentence }
+  sequence(:random_description) { FFaker::Lorem.paragraphs(1 + Kernel.rand(5)).join("\n") }
+  sequence(:random_email)       { FFaker::Internet.email }
 
   sequence(:sku) { |n| "SKU-#{n}" }
 end

--- a/core/lib/spree/testing_support/factories.rb
+++ b/core/lib/spree/testing_support/factories.rb
@@ -11,9 +11,9 @@ Dir["#{File.dirname(__FILE__)}/factories/**"].each do |f|
 end
 
 FactoryGirl.define do
-  sequence(:random_string)      { FFaker::Lorem.sentence }
+  sequence(:random_string) { FFaker::Lorem.sentence }
   sequence(:random_description) { FFaker::Lorem.paragraphs(1 + Kernel.rand(5)).join("\n") }
-  sequence(:random_email)       { FFaker::Internet.email }
+  sequence(:random_email) { FFaker::Internet.email }
 
   sequence(:sku) { |n| "SKU-#{n}" }
 end

--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -103,7 +103,7 @@ describe Spree::BaseHelper, type: :helper do
       # Because the controller_name method returns "test"
       # controller_name is used by this method to infer what it is supposed
       # to be generating meta_data_tags for
-      text = Faker::Lorem.paragraphs(2).join(" ")
+      text = FFaker::Lorem.paragraphs(2).join(" ")
       @test = Spree::Product.new(:description => text)
       tags = Nokogiri::HTML.parse(meta_data_tags)
       content = tags.css("meta[name=description]").first["content"]

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'carmen', '~> 1.0.0'
   s.add_dependency 'cancancan', '~> 1.10.1'
   s.add_dependency 'deface', '~> 1.0.0'
-  s.add_dependency 'ffaker', '~> 1.16'
+  s.add_dependency 'ffaker', '~> 2.0.0'
   s.add_dependency 'font-awesome-rails', '~> 4.0'
   s.add_dependency 'friendly_id', '~> 5.1.0'
   s.add_dependency 'highline', '~> 1.6.18' # Necessary for the install generator

--- a/sample/db/samples/addresses.rb
+++ b/sample/db/samples/addresses.rb
@@ -3,24 +3,24 @@ new_york = Spree::State.find_by_name!("New York")
 
 # Billing address
 Spree::Address.create!(
-  :firstname => Faker::Name.first_name,
-  :lastname => Faker::Name.last_name,
-  :address1 => Faker::Address.street_address,
-  :address2 => Faker::Address.secondary_address,
-  :city => Faker::Address.city,
+  :firstname => FFaker::Name.first_name,
+  :lastname => FFaker::Name.last_name,
+  :address1 => FFaker::Address.street_address,
+  :address2 => FFaker::Address.secondary_address,
+  :city => FFaker::Address.city,
   :state => new_york,
   :zipcode => 16804,
   :country => united_states,
-  :phone => Faker::PhoneNumber.phone_number)
+  :phone => FFaker::PhoneNumber.phone_number)
 
 #Shipping address
 Spree::Address.create!(
-  :firstname => Faker::Name.first_name,
-  :lastname => Faker::Name.last_name,
-  :address1 => Faker::Address.street_address,
-  :address2 => Faker::Address.secondary_address,
-  :city => Faker::Address.city,
+  :firstname => FFaker::Name.first_name,
+  :lastname => FFaker::Name.last_name,
+  :address1 => FFaker::Address.street_address,
+  :address2 => FFaker::Address.secondary_address,
+  :city => FFaker::Address.city,
   :state => new_york,
   :zipcode => 16804,
   :country => united_states,
-  :phone => Faker::PhoneNumber.phone_number)
+  :phone => FFaker::PhoneNumber.phone_number)

--- a/sample/db/samples/addresses.rb
+++ b/sample/db/samples/addresses.rb
@@ -3,24 +3,24 @@ new_york = Spree::State.find_by_name!("New York")
 
 # Billing address
 Spree::Address.create!(
-  :firstname => FFaker::Name.first_name,
-  :lastname => FFaker::Name.last_name,
-  :address1 => FFaker::Address.street_address,
-  :address2 => FFaker::Address.secondary_address,
-  :city => FFaker::Address.city,
-  :state => new_york,
-  :zipcode => 16804,
-  :country => united_states,
-  :phone => FFaker::PhoneNumber.phone_number)
+  firstname: FFaker::Name.first_name,
+  lastname: FFaker::Name.last_name,
+  address1: FFaker::Address.street_address,
+  address2: FFaker::Address.secondary_address,
+  city: FFaker::Address.city,
+  state: new_york,
+  zipcode: 16804,
+  country: united_states,
+  phone: FFaker::PhoneNumber.phone_number)
 
 #Shipping address
 Spree::Address.create!(
-  :firstname => FFaker::Name.first_name,
-  :lastname => FFaker::Name.last_name,
-  :address1 => FFaker::Address.street_address,
-  :address2 => FFaker::Address.secondary_address,
-  :city => FFaker::Address.city,
-  :state => new_york,
-  :zipcode => 16804,
-  :country => united_states,
-  :phone => FFaker::PhoneNumber.phone_number)
+  firstname: FFaker::Name.first_name,
+  lastname: FFaker::Name.last_name,
+  address1: FFaker::Address.street_address,
+  address2: FFaker::Address.secondary_address,
+  city: FFaker::Address.city,
+  state: new_york,
+  zipcode: 16804,
+  country: united_states,
+  phone: FFaker::PhoneNumber.phone_number)

--- a/sample/db/samples/products.rb
+++ b/sample/db/samples/products.rb
@@ -5,7 +5,7 @@ clothing = Spree::TaxCategory.find_by_name!("Clothing")
 shipping_category = Spree::ShippingCategory.find_by_name!("Default")
 
 default_attrs = {
-  :description => Faker::Lorem.paragraph,
+  :description => FFaker::Lorem.paragraph,
   :available_on => Time.zone.now
 }
 

--- a/sample/db/samples/products.rb
+++ b/sample/db/samples/products.rb
@@ -5,8 +5,8 @@ clothing = Spree::TaxCategory.find_by_name!("Clothing")
 shipping_category = Spree::ShippingCategory.find_by_name!("Default")
 
 default_attrs = {
-  :description => FFaker::Lorem.paragraph,
-  :available_on => Time.zone.now
+  description: FFaker::Lorem.paragraph,
+  available_on: Time.zone.now
 }
 
 products = [


### PR DESCRIPTION
FFaker at versio 2.0 namespaces itself to FFaker, instead of overriding the Faker namespace used by the similar/related faker gem.  (EmmanuelOga/ffaker#179)

This allows other rails apps using Spree to also use faker without getting namespace collisions.
