### PR TITLE
Fix spelling of 'Documentation' in footer.

### DIFF
--- a/guides/layouts/_footer.html
+++ b/guides/layouts/_footer.html
@@ -19,7 +19,7 @@
           <h3 class="block-title">Developers</h3>
           <ul>
             <li><a href="http://spreecommerce.com/storefront">Overview</a></li>
-            <li><a href="http://guides.spreecommerce.com/developer">Documenation</a></li>
+            <li><a href="http://guides.spreecommerce.com/developer">Documentation</a></li>
             <li><a href="http://spreecommerce.com/storefront">Community</a></li>
             <li><a href="http://spreecommerce.com/license">License</a></li>
           </ul>


### PR DESCRIPTION
Spelling error can be seen on the guides homepage - https://guides.spreecommerce.com/
