### PR TITLE
Fix documentation typo on test mailer rake task

### DIFF
--- a/core/lib/tasks/email.rake
+++ b/core/lib/tasks/email.rake
@@ -3,7 +3,7 @@ namespace :email do
   task test: :environment do
     unless ENV['EMAIL'].present?
       raise ArgumentError, "Must pass EMAIL environment variable. " \
-                           "Example: EMAIL=spree@example.com bundle exec rake test:email"
+                           "Example: EMAIL=spree@example.com bundle exec rake email:test"
     end
     Spree::TestMailer.test_email(ENV['EMAIL']).deliver_now
   end

--- a/core/lib/tasks/email.rake
+++ b/core/lib/tasks/email.rake
@@ -1,5 +1,5 @@
 namespace :email do
-  desc 'Sends test email to specified address - Example: EMAIL=spree@example.com bundle exec rake test:email'
+  desc 'Sends test email to specified address - Example: EMAIL=spree@example.com bundle exec rake email:test'
   task test: :environment do
     unless ENV['EMAIL'].present?
       raise ArgumentError, "Must pass EMAIL environment variable. " \


### PR DESCRIPTION
Failing to provide an email variable to the task, displays an example message.

```
bundle exec rake email:test
rake aborted!
ArgumentError: Must pass EMAIL environment variable. Example: EMAIL=spree@example.com bundle exec rake test:email
```

The rake task `test:email` does not exist:

```
bundle exec rake test:email EMAIL=test@example.com
rake aborted!
Don't know how to build task 'test:email'
```

The task `email:task` should be presented in the display message.
