### PR TITLE
Reduce number of AJAX calls in variant autocomplete

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js.coffee
@@ -19,6 +19,7 @@ $.fn.variantAutocomplete = ->
         callback data
     ajax:
       url: Spree.url(Spree.routes.variants_api)
+      quietMillis: 200
       datatype: "json"
       data: (term, page) ->
         q:


### PR DESCRIPTION
The product search in the admin order entry page can be quite slow. This reduces the number of AJAX calls that Select2 makes to the API.
