### PR TITLE
Fix product description meta tag

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -47,7 +47,7 @@ module Spree
       end
 
       if meta[:description].blank? && object.kind_of?(Spree::Product)
-        meta[:description] = strip_tags(truncate(object.description, length: 160, separator: ' '))
+        meta[:description] = truncate(strip_tags(object.description), length: 160, separator: ' ')
       end
 
       meta.reverse_merge!({


### PR DESCRIPTION
`strip_tags` must be before `truncate` to work properly
