### PR TITLE
Use local fixture for Image factory.

### DIFF
--- a/core/lib/spree/testing_support/factories/image_factory.rb
+++ b/core/lib/spree/testing_support/factories/image_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
   factory :image, class: Spree::Image do
-    attachment URI.parse('http://upload.wikimedia.org/wikipedia/en/c/c0/Les_Horribles_Cernettes_in_1992.jpg')
+    attachment { File.new(Spree::Core::Engine.root + "spec/fixtures" + 'thinking-cat.jpg') }
   end
 end


### PR DESCRIPTION
- faster tests
- no internet connection needed
