### PR TITLE
Fix formatting in examples section

### DIFF
--- a/cmd/README.md
+++ b/cmd/README.md
@@ -34,13 +34,13 @@ Examples
 --------
 
 If you want to accept all the defaults pass --auto_accept
-
+```
 spree install my_store --edge --auto_accept
-
+```
 to use a local clone of Spree, pass the --path option
-
+```
 spree install my_store --path=../spree
-
+```
 
 Options
 -------


### PR DESCRIPTION
This bugged me a bit as I read through the `spree_cmd` gems description.

The PR will correct this minor formatting error.
