### PR TITLE
fix product slug validation format

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -90,7 +90,7 @@ module Spree
     validates :name, presence: true
     validates :price, presence: true, if: proc { Spree::Config[:require_master_price] }
     validates :shipping_category_id, presence: true
-    validates :slug, length: { minimum: 3 }, uniqueness: { allow_blank: true }
+    validates :slug, length: { minimum: 3 }, allow_blank: true, uniqueness: true
 
     attr_accessor :option_values_hash
 


### PR DESCRIPTION
I just upgrade to ruby 2.2.2 and rails 4.2.1 and see this happened.

I use spree_i18n in my project, so product slug is always null (spree_i18n saves it in translation table).
However, when I try to simply re-save a existing product. It gives me such error:

```
2.2.2 :006 >   product = Spree::Product.first
2.2.2 :009 >   product.save!
ActiveRecord::RecordInvalid: validation failed, slug is too short (min is 3 characters)
    from /Users/wuboy/.rvm/gems/ruby-2.2.2/gems/activerecord-4.2.1/lib/active_record/validations.rb:79:in `raise_record_invalid'
    from /Users/wuboy/.rvm/gems/ruby-2.2.2/gems/activerecord-4.2.1/lib/active_record/validations.rb:43:in `save!'
    from /Users/wuboy/.rvm/gems/ruby-2.2.2/gems/activerecord-4.2.1/lib/active_record/attribute_methods/dirty.rb:29:in `save!'
    from /Users/wuboy/.rvm/gems/ruby-2.2.2/gems/activerecord-4.2.1/lib/active_record/transactions.rb:291:in `block in save!'
    from /Users/wuboy/.rvm/gems/ruby-2.2.2/gems/activerecord-4.2.1/lib/active_record/transactions.rb:347:in `block in with_transaction_returning_status'
    from /Users/wuboy/.rvm/gems/ruby-2.2.2/gems/activerecord-4.2.1/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `block in transaction'
    from /Users/wuboy/.rvm/gems/ruby-2.2.2/gems/activerecord-4.2.1/lib/active_record/connection_adapters/abstract/transaction.rb:188:in `within_new_transaction'
    from /Users/wuboy/.rvm/gems/ruby-2.2.2/gems/activerecord-4.2.1/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `transaction'
    from /Users/wuboy/.rvm/gems/ruby-2.2.2/gems/activerecord-4.2.1/lib/active_record/transactions.rb:220:in `transaction'
    from /Users/wuboy/.rvm/gems/ruby-2.2.2/gems/activerecord-4.2.1/lib/active_record/transactions.rb:344:in `with_transaction_returning_status'
    from /Users/wuboy/.rvm/gems/ruby-2.2.2/gems/activerecord-4.2.1/lib/active_record/transactions.rb:291:in `save!'
    from (irb):9
```

I check Product validators, found out this line:

```
validates :slug, length: { minimum: 3 }, uniqueness: { allow_blank: true }
```

It generate such validators which don't include allow_blank validation in LengthValidator :

```
2.2.2 :014 > Spree::Product.validators
 => [..., #<ActiveModel::Validations::LengthValidator:0x007f88eadfc530 @attributes=[:slug], @options={:minimum=>3}>, #<ActiveRecord::Validations::UniquenessValidator:0x007f88e5727ae8 @attributes=[:slug], @options={:case_sensitive=>true, :allow_blank=>true}
```

I modify it to this:

```
validates :slug, length: { minimum: 3 }, allow_blank: true, uniqueness: true
```

and the validators now are:

```
[..., #<ActiveModel::Validations::LengthValidator:0x007ff9162d8478 @attributes=[:slug], @options={:allow_blank=>true, :minimum=>3}>, #<ActiveRecord::Validations::UniquenessValidator:0x007ff91333b788 @attributes=[:slug], @options={:case_sensitive=>true, :allow_blank=>true}, ...]
```

Which will apply to both allow_blank for LengthValidator and UniquenessValidator now.

I am not sure if it happened after I upgrade rails. But I think allow_blank outside uniqueness is better for this case.
