### PR TITLE
allow spree image to be extensible

### DIFF
--- a/core/app/models/spree/image.rb
+++ b/core/app/models/spree/image.rb
@@ -1,16 +1,14 @@
 module Spree
-  class Image < Asset
+  class Image < Spree::Asset
     validate :no_attachment_errors
 
-    has_attached_file :attachment,
-                      styles: { mini: '48x48>', small: '100x100>', product: '240x240>', large: '600x600>' },
-                      default_style: :product,
-                      url: '/spree/products/:id/:style/:basename.:extension',
-                      path: ':rails_root/public/spree/products/:id/:style/:basename.:extension',
+    has_attached_file :attachment, styles: styles, default_style: model,
+                      url: "#{namespace}/#{model.to_s.pluralize}/:id/:style/:basename.:extension",
+                      path: ":rails_root/public#{namespace}/#{model.to_s.pluralize}/:id/:style/:basename.:extension",
                       convert_options: { all: '-strip -auto-orient -colorspace sRGB' }
-    validates_attachment :attachment,
-      :presence => true,
-      :content_type => { :content_type => %w(image/jpeg image/jpg image/png image/gif) }
+    validates_attachment :attachment, presence: true, content_type: {
+      content_type: %w(image/jpeg image/jpg image/png image/gif)
+    }
 
     # save the w,h of the original image (from which others can be calculated)
     # we need to look at the write-queue for images which have not been saved yet
@@ -30,14 +28,28 @@ module Spree
       self.attachment_height = geometry.height
     end
 
+    def model
+      :product
+    end
+
+    def namespace
+      '/spree'
+    end
+
     # if there are errors from the plugin, then add a more meaningful message
     def no_attachment_errors
       unless attachment.errors.empty?
         # uncomment this to get rid of the less-than-useful interim messages
         # errors.clear
-        errors.add :attachment, "Paperclip returned errors for file '#{attachment_file_name}' - check ImageMagick installation or image source file."
+        errors.add :attachment, "Paperclip returned errors for file '#{attachment_file_name}'" \
+                                " - check ImageMagick installation or image source file."
         false
       end
+    end
+
+    def styles
+      styles = { mini: '48x48>', small: '100x100>', large: '600x600>' }
+      styles[model] = '240x240>'
     end
   end
 end


### PR DESCRIPTION
These changes allow the `Spree::Image` model to be more developer friendly. If you are wanting to create a `Avatar` model and you do as so:

``` ruby
class Avatar < Spree::Image
end
```

You would be left wondering why the avatar images are being placed in a `spree/products` folder. Its clear to me that some developers would like to use `Spree::Image` to create, well, images.

This PR also expands Spree Core's API by adding a `model` method and a `namespace` method. The `model` should return a symbol while the `namespace` method should return a string with a leading slash.
