### PR TITLE
Payment methods should display on admin payments screen

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/select_payments.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/select_payments.js.coffee
@@ -1,7 +1,0 @@
-$ ->
-  if $('.new_payment').is('*')
-    $('.payment-method-settings fieldset').addClass('hidden').first().removeClass('hidden')
-    $('input[name="payment[payment_method_id]"]').click ()->
-      $('.payment-method-settings fieldset').addClass('hidden')
-      id = $(this).parents('li').data('id')
-      $("fieldset[data-id='#{id}']").removeClass('hidden')


### PR DESCRIPTION
In the admin payments screen, payments were not displayed or able to be selected; see https://github.com/spree/spree/issues/6322 for details.

Removing the redundant coffee file, as described in that issue, appears to fix the issue, and payment methods will be displayed and can now be selected.
