### PR TITLE
backend: fix actions buttons ordering

### DIFF
--- a/backend/app/views/spree/admin/taxonomies/edit.erb
+++ b/backend/app/views/spree/admin/taxonomies/edit.erb
@@ -24,9 +24,9 @@
     </div>
 
     <div class="form-actions">
-      <%= button_link_to Spree.t('actions.cancel'), admin_taxonomies_path, icon: 'delete' %>
-      <span class="or"><%= Spree.t(:or) %></span>
       <%= button Spree.t('actions.update'), 'ok', 'submit', { class: 'btn-success' } %>
+      <span class="or"><%= Spree.t(:or) %></span>
+      <%= button_link_to Spree.t('actions.cancel'), admin_taxonomies_path, icon: 'delete' %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/taxons/edit.html.erb
+++ b/backend/app/views/spree/admin/taxons/edit.html.erb
@@ -8,9 +8,9 @@
   <%= render 'form', f: f %>
 
   <div class="form-actions" data-hook="buttons">
-    <%= button_link_to Spree.t('actions.cancel'), edit_admin_taxonomy_url(@taxonomy), icon: "remove" %>
-    <%= Spree.t(:or) %>
     <%= button Spree.t('actions.update'), 'save' %>
+    <%= Spree.t(:or) %>
+    <%= button_link_to Spree.t('actions.cancel'), edit_admin_taxonomy_url(@taxonomy), icon: "remove" %>
   </div>
 <% end %>
 


### PR DESCRIPTION
on taxons and taxonomies they're swapped compared to all other resources
