### PR TITLE
Product Show div should have row bootstrap class

### DIFF
--- a/frontend/app/views/spree/products/show.html.erb
+++ b/frontend/app/views/spree/products/show.html.erb
@@ -1,7 +1,7 @@
 <% @body_id = 'product-details' %>
 
 <% cache cache_key_for_product do %>
-  <div data-hook="product_show" itemscope itemtype="https://schema.org/Product">
+  <div data-hook="product_show" class="row" itemscope itemtype="https://schema.org/Product">
     <div class="col-md-4" data-hook="product_left_part">
       <div data-hook="product_left_part_wrap">
         <div id="product-images" data-hook="product_images">


### PR DESCRIPTION
We have the collision between the main grid, in the application layout, and the nested one, which is in this file. Added class row for parent div[data-hook="product_show"].
