### PR TITLE
Remove unused method from Spree::OrderUpdater

### DIFF
--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -170,10 +170,5 @@ module Spree
       order.state_changed('payment') if last_state != order.payment_state
       order.payment_state
     end
-
-    private
-      def round_money(n)
-        (n * 100).round / 100.0
-      end
   end
 end


### PR DESCRIPTION
Its dead code. Ideally you guys would run coverage analysis to kill dead code like this during development cycles.
