### PR TITLE
Kill exception shadowing

### DIFF
--- a/core/app/models/spree/stock/estimator.rb
+++ b/core/app/models/spree/stock/estimator.rb
@@ -49,22 +49,13 @@ module Spree
       def shipping_methods(package, display_filter)
         package.shipping_methods.select do |ship_method|
           calculator = ship_method.calculator
-          begin
-            ship_method.available_to_display(display_filter) &&
-            ship_method.include?(order.ship_address) &&
-            calculator.available?(package) &&
-            (calculator.preferences[:currency].blank? ||
-             calculator.preferences[:currency] == currency)
-          rescue Exception => exception
-            log_calculator_exception(ship_method, exception)
-          end
-        end
-      end
 
-      def log_calculator_exception(ship_method, exception)
-        Rails.logger.info("Something went wrong calculating rates with the #{ship_method.name} (ID=#{ship_method.id}) shipping method.")
-        Rails.logger.info("*" * 50)
-        Rails.logger.info(exception.backtrace.join("\n"))
+          ship_method.available_to_display(display_filter) &&
+          ship_method.include?(order.ship_address) &&
+          calculator.available?(package) &&
+          (calculator.preferences[:currency].blank? ||
+           calculator.preferences[:currency] == currency)
+        end
       end
     end
   end

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -70,14 +70,6 @@ module Spree
           it_should_behave_like "shipping rate doesn't match"
         end
 
-        context "when the shipping method's calculator raises an exception" do
-          before do
-            allow_any_instance_of(ShippingMethod).to receive_message_chain(:calculator, :available?).and_raise(Exception, "Something went wrong!")
-            expect(subject).to receive(:log_calculator_exception)
-          end
-          it_should_behave_like "shipping rate doesn't match"
-        end
-
         it "sorts shipping rates by cost" do
           shipping_methods = 3.times.map { create(:shipping_method) }
           allow(shipping_methods[0]).to receive_message_chain(:calculator, :compute).and_return(5.00)


### PR DESCRIPTION
- The code used to rescue any exception. Even exceptions operators /
  developers want to stop the world.
- When we want to allow a certain set of exceptions to be shadowed we
  should use shipment rate calculation specific exception lists that still
  allow shipment-unrelated exceptions to stop the world.
- When the downstream libraries do not provide matchable exceptions
  these should be fixed instead of adding a debugging burden to everyone
  having to work with shipment rate calculation.
