### PR TITLE
Use updated versioncake configuration options

### DIFF
--- a/api/lib/spree/api/engine.rb
+++ b/api/lib/spree/api/engine.rb
@@ -1,4 +1,5 @@
 require 'rails/engine'
+require 'versioncake'
 
 module Spree
   module Api
@@ -16,8 +17,8 @@ module Spree
         config.json_engine = ActiveSupport::JSON
       end
 
-      config.view_versions = [1]
-      config.view_version_extraction_strategy = :http_header
+      config.versioncake.supported_version_numbers = [1]
+      config.versioncake.extraction_strategy = :http_header
 
       initializer "spree.api.environment", :before => :load_config_initializers do |app|
         Spree::Api::Config = Spree::ApiConfiguration.new


### PR DESCRIPTION
When versioncake was [updated to 2.1](https://github.com/spree/spree/commit/f0fae734bac830f436de1bb30eb54e94df9d6f8e), the [configuration changes](https://github.com/bwillis/versioncake#configuration-changes) weren't also applied.

Because of this, the default globs for view files were really long and slow, and my admin dashboard was taking 3 seconds to load. With this fix, it takes under a second.
