### PR TITLE
Fixed several rendering issues with variant autocomplete

### DIFF
--- a/backend/app/views/spree/admin/orders/_add_line_item.html.erb
+++ b/backend/app/views/spree/admin/orders/_add_line_item.html.erb
@@ -9,7 +9,7 @@
   <div class="panel-body">
     <div data-hook="add_product_name" class="form-group">
       <%= label_tag :add_line_item_variant_id, Spree.t(:name_or_sku) %>
-      <%= hidden_field_tag :add_line_item_variant_id, "", :class => "variant_autocomplete" %>
+      <%= hidden_field_tag :add_line_item_variant_id, "", class: "variant_autocomplete fullwidth-input" %>
     </div>
 
     <div id="stock_details"></div>

--- a/backend/app/views/spree/admin/orders/_add_product.html.erb
+++ b/backend/app/views/spree/admin/orders/_add_product.html.erb
@@ -10,7 +10,7 @@
   <div class="panel-body">
     <div data-hook="add_product_name">
       <%= label_tag :add_variant_id, Spree.t(:name_or_sku) %>
-      <%= hidden_field_tag :add_variant_id, "", :class => "variant_autocomplete" %>
+      <%= hidden_field_tag :add_variant_id, "", class: "variant_autocomplete fullwidth-input" %>
     </div>
 
     <div id="stock_details"></div>

--- a/backend/app/views/spree/admin/promotions/actions/_create_line_items.html.erb
+++ b/backend/app/views/spree/admin/promotions/actions/_create_line_items.html.erb
@@ -13,7 +13,7 @@
         <% line_item_prefix = "#{param_prefix}[promotion_action_line_items_attributes][#{index}]" %>
         <div class="form-group">
           <%= label_tag "#{line_item_prefix}_variant_id", Spree.t(:variant) %>
-          <%= hidden_field_tag "#{line_item_prefix}[variant_id]", line_item.variant_id, class: "variant_autocomplete" %>
+          <%= hidden_field_tag "#{line_item_prefix}[variant_id]", line_item.variant_id, class: "variant_autocomplete fullwidth-input" %>
         </div>
         <div class="form-group no-marginb">
           <%= label_tag "#{line_item_prefix}_quantity", Spree.t(:quantity) %>

--- a/backend/app/views/spree/admin/variants/_autocomplete.js.erb
+++ b/backend/app/views/spree/admin/variants/_autocomplete.js.erb
@@ -1,13 +1,11 @@
 <script type='text/template' id='variant_autocomplete_template'>
   <div class='variant-autocomplete-item media'>
     <figure class='variant-image media-left'>
-      <span class="thumbnail no-marginb">
-        {{#if variant.image }}
-          <img src='{{variant.image}}' />
-        {{ else }}
-          <img src='<%= image_path("noimage/mini.png") %>' />
-        {{/if}}
-      </span>
+      {{#if variant.image }}
+        <img src='{{variant.image}}' class="thumbnail no-marginb" />
+      {{ else }}
+        <img src='<%= image_path("noimage/mini.png") %>' class="thumbnail no-marginb" />
+      {{/if}}
     </figure>
 
     <div class='variant-details media-body'>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -815,7 +815,7 @@ en:
     my_orders: My Orders
     name: Name
     name_on_card: Name on card
-    name_or_sku: Name or SKU (enter at least first 4 characters of product name)
+    name_or_sku: Name or SKU (enter at least first 3 characters of product name)
     new: New
     new_adjustment: New Adjustment
     new_customer: New Customer


### PR DESCRIPTION
I noticed that the images for variant autocomplete weren't rendering correctly in a few places. I fixed the thumbnails and made the fields wider.
### Add Line Item Promotion Action Before

![screen shot 2015-05-11 at 2 52 06 pm](https://cloud.githubusercontent.com/assets/77801/7576684/74c72d36-f7f5-11e4-8775-780aae9fbb80.png)
### Add Line Item Promotion Action After

![screen shot 2015-05-11 at 3 16 19 pm](https://cloud.githubusercontent.com/assets/77801/7576685/78e79fea-f7f5-11e4-90a5-20791d0f2b2b.png)
### Add Line Item to Order Before

![screen shot 2015-05-11 at 3 44 22 pm](https://cloud.githubusercontent.com/assets/77801/7576679/67485252-f7f5-11e4-8f03-d50e57213fd9.png)
### Add Line Item to Order After

![screen shot 2015-05-11 at 3 49 19 pm](https://cloud.githubusercontent.com/assets/77801/7576681/69ada7ea-f7f5-11e4-8300-0d1f3fb18332.png)
