### PR TITLE
Changed infromation about required version of phantomjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,10 +285,10 @@ please ensure that you have a postgres user:
 createuser -s -r postgres
 ```
 
-And also ensure that you have [PhantomJS](http://phantomjs.org/) installed as well:
+And also ensure that you have [PhantomJS](http://phantomjs.org/) in version 1.8 installed as well:
 
 ```shell
-brew update && brew install phantomjs
+brew update && brew install phantomjs182
 ```
 
 To execute all the tests, you may want to run this command at the


### PR DESCRIPTION
Installing phaontomjs from brew, usign `brew install phantomjs` results in getting it in version 2.0.0 [link to formula](https://github.com/Homebrew/homebrew/blob/master/Library/Formula/phantomjs.rb). Unfortunately this version does not work with Cliver and raises the following error `Could not find an executable 'phantomjs' that matched the requirements '~> 1.8', '>= 1.8.1'. Found versions were {"/usr/local/bin/phantomjs"=>"2.0.0"}.` while running tests.

In order to have test properly working you need to obtain phantomjs in version 1.8, which can be downloaded via brew using `brew remove phantomjs182`, please see [the formula](https://github.com/homebrew/homebrew-versions/blob/master/phantomjs182.rb)

I think that we need to state clearly which version of phantomjs is needed in order to run.
