### PR TITLE
Only perform Order#reload when needed

### DIFF
--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -197,6 +197,7 @@ describe "Order Details", type: :feature, js: true do
             click_icon :save
 
             wait_for_ajax
+            order.reload
 
             expect(order.shipments.count).to eq(2)
             expect(order.shipments.last.backordered?).to eq(false)
@@ -213,6 +214,7 @@ describe "Order Details", type: :feature, js: true do
             click_icon :save
 
             wait_for_ajax
+            order.reload
 
             expect(order.shipments.count).to eq(1)
             expect(order.shipments.last.backordered?).to eq(false)
@@ -229,6 +231,7 @@ describe "Order Details", type: :feature, js: true do
             click_icon :save
 
             wait_for_ajax
+            order.reload
 
             expect(order.shipments.count).to eq(1)
             expect(order.shipments.last.backordered?).to eq(false)
@@ -324,6 +327,7 @@ describe "Order Details", type: :feature, js: true do
               click_icon :save
 
               wait_for_ajax
+              order.reload
 
               expect(order.shipments.count).to eq(1)
               expect(order.shipments.first.inventory_units_for(product.master).count).to eq(2)
@@ -343,6 +347,7 @@ describe "Order Details", type: :feature, js: true do
             click_icon :save
 
             wait_for_ajax
+            order.reload
 
             expect(order.shipments.count).to eq(2)
             expect(order.shipments.last.backordered?).to eq(false)
@@ -367,6 +372,7 @@ describe "Order Details", type: :feature, js: true do
           click_icon :save
 
           wait_for_ajax
+          order.reload
 
           expect(order.shipments.count).to eq(1)
           expect(order.shipments.last.inventory_units_for(product.master).count).to eq(2)

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -101,7 +101,7 @@ describe Spree::OrderContents, :type => :model do
         line_item = subject.add(variant, 3)
         subject.remove(variant)
 
-        expect(line_item.reload.quantity).to eq(2)
+        expect(line_item.quantity).to eq(2)
       end
     end
 
@@ -127,14 +127,15 @@ describe Spree::OrderContents, :type => :model do
       line_item = subject.add(variant, 3)
       subject.remove(variant, 1)
 
-      expect(line_item.reload.quantity).to eq(2)
+      expect(line_item.quantity).to eq(2)
     end
 
     it 'should remove line_item if quantity matches line_item quantity' do
       subject.add(variant, 1)
-      subject.remove(variant, 1)
+      removed_line_item = subject.remove(variant, 1)
 
-      expect(order.reload.find_line_item_by_variant(variant)).to be_nil
+      # Should reflect the change already in Order#line_item
+      expect(order.line_items).to_not include(removed_line_item)
     end
 
     it "should update order totals" do
@@ -163,7 +164,7 @@ describe Spree::OrderContents, :type => :model do
 
     it "changes item quantity" do
       subject.update_cart params
-      expect(shirt.reload.quantity).to eq 3
+      expect(shirt.quantity).to eq 3
     end
 
     it "updates order totals" do

--- a/core/spec/models/spree/tax_rate_spec.rb
+++ b/core/spec/models/spree/tax_rate_spec.rb
@@ -440,6 +440,7 @@ describe Spree::TaxRate, :type => :model do
             @new_zone.zone_members.create(:zoneable => @new_country)
             @order.ship_address = create(:address, :country => @new_country)
             @order.save
+            @order.reload
           end
 
           it "should not create positive adjustments" do

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -154,6 +154,13 @@ module Spree
           @differentiator.missing.each do |variant, quantity|
             @order.contents.remove(variant, quantity)
           end
+
+          # @order.contents.remove did transitively call reload in the past.
+          # Hiding the fact that the machine advanced already to "payment" state.
+          #
+          # As an intermediary step to optimize reloads out of high volume code path
+          # the reload was lifted here and will be removed by later passes.
+          @order.reload
         end
 
         if try_spree_current_user && try_spree_current_user.respond_to?(:payment_sources)

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -420,6 +420,6 @@ describe Spree::CheckoutController, :type => :controller do
 
     expect {
       spree_post :update, { :state => "payment" }
-    }.to change { order.line_items }
+    }.to change { order.reload.line_items.length }
   end
 end


### PR DESCRIPTION
- Removes all Order#reload calls from models, improving performance
  via not killing lazy/eager load caches.
- Does Order#reload where mostly specs need to sync its own record.
- Reduces chance lazy loading with N+1 pattern occurs from calculation
