### PR TITLE
Remove unnecessary test to determine if the order should be voided

### DIFF
--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -160,7 +160,7 @@ module Spree
       last_state = order.payment_state
       if payments.present? && payments.valid.size == 0
         order.payment_state = 'failed'
-      elsif order.state == 'canceled' && order.payment_total == 0
+      elsif order.state == 'canceled' && order.payment_total.zero?
         order.payment_state = 'void'
       else
         order.payment_state = 'balance_due' if order.outstanding_balance > 0

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -180,10 +180,11 @@ module Spree
 
         end
 
-        context "and payment is refunded" do
+        context "and the payment total is zero" do
           it "is void" do
             order.payment_total = 0
             order.total = 30
+            allow(order).to receive_message_chain(:payments, :valid, :size).and_return(1)
             expect {
               updater.update_payment_state
             }.to change { order.payment_state }.to 'void'


### PR DESCRIPTION
- The logic can be simplified so that if the payment total is zero
  (which indicates no payments, a capture + refund, or a void) the order
  payment_state should be set to void.
