### PR TITLE
Fixed null timestamp deprecation warnings

### DIFF
--- a/core/db/migrate/20150118210639_create_spree_store_credits.rb
+++ b/core/db/migrate/20150118210639_create_spree_store_credits.rb
@@ -13,7 +13,7 @@ class CreateSpreeStoreCredits < ActiveRecord::Migration
       t.integer :originator_id
       t.string :originator_type
       t.integer :type_id
-      t.timestamps
+      t.timestamps null: false
     end
 
     add_index :spree_store_credits, :deleted_at

--- a/core/db/migrate/20150118211500_create_spree_store_credit_categories.rb
+++ b/core/db/migrate/20150118211500_create_spree_store_credit_categories.rb
@@ -2,7 +2,7 @@ class CreateSpreeStoreCreditCategories < ActiveRecord::Migration
   def change
     create_table :spree_store_credit_categories do |t|
       t.string :name
-      t.timestamps
+      t.timestamps null: false
     end
   end
 end

--- a/core/db/migrate/20150118212051_create_spree_store_credit_events.rb
+++ b/core/db/migrate/20150118212051_create_spree_store_credit_events.rb
@@ -9,7 +9,7 @@ class CreateSpreeStoreCreditEvents < ActiveRecord::Migration
       t.integer  :originator_id
       t.string   :originator_type
       t.datetime :deleted_at
-      t.timestamps
+      t.timestamps null: false
     end
     add_index :spree_store_credit_events, :store_credit_id
     add_index :spree_store_credit_events, [:originator_id, :originator_type], name: :spree_store_credit_events_originator

--- a/core/db/migrate/20150118212101_create_spree_store_credit_types.rb
+++ b/core/db/migrate/20150118212101_create_spree_store_credit_types.rb
@@ -3,7 +3,7 @@ class CreateSpreeStoreCreditTypes < ActiveRecord::Migration
     create_table :spree_store_credit_types do |t|
       t.string :name
       t.integer :priority
-      t.timestamps
+      t.timestamps null: false
     end
     add_index :spree_store_credit_types, :priority
   end


### PR DESCRIPTION
I noticed the Rails 5 null timestamps deprecation messages while running the specs on the store credit branch and figured I'd send a quick PR to take care of them.
