### PR TITLE
Easier AdjustmentsUpdater extension

### DIFF
--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -44,10 +44,6 @@ module Spree
     after_create :update_adjustable_adjustment_total
     after_destroy :update_adjustable_adjustment_total
 
-    class_attribute :competing_promos_source_types
-
-    self.competing_promos_source_types = ['Spree::PromotionAction']
-
     scope :open, -> { where(state: 'open') }
     scope :closed, -> { where(state: 'closed') }
     scope :tax, -> { where(source_type: 'Spree::TaxRate') }
@@ -66,7 +62,7 @@ module Spree
     scope :return_authorization, -> { where(source_type: "Spree::ReturnAuthorization") }
     scope :is_included, -> { where(included: true) }
     scope :additional, -> { where(included: false) }
-    scope :competing_promos, -> { where(source_type: competing_promos_source_types) }
+    scope :competing_promos, -> { where(source_type: Rails.application.config.spree.competing_promos_source_types) }
 
     extend DisplayMoney
     money_methods :amount

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -39,6 +39,13 @@ module Spree
             Spree::PaymentMethod::Check ]
       end
 
+      initializer 'spree.register.competing_promos_source_types' do |app|
+        app.config.spree.add_class('competing_promos_source_types')
+        app.config.spree.competing_promos_source_types = [
+          Spree::PromotionAction
+        ]
+      end
+
       # We need to define promotions rules here so extensions and existing apps
       # can add their custom classes on their initializer files
       initializer 'spree.promo.environment' do |app|

--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -50,7 +50,7 @@ describe Spree::Adjustment, :type => :model do
     end
   end
 
-  describe 'competing_promos scope' do    
+  describe 'competing_promos scope' do
     before do
       allow_any_instance_of(Spree::Adjustment).to receive(:update_adjustable_adjustment_total).and_return(true)
     end
@@ -65,8 +65,6 @@ describe Spree::Adjustment, :type => :model do
     let!(:non_promotion_adjustment_without_source) { create(:adjustment, order: order, source: nil) }
 
     context 'no custom source_types have been added to competing_promos' do
-      before { Spree::Adjustment.competing_promos_source_types = ['Spree::PromotionAction'] }
-
       it 'selects promotion adjustments by default' do
         expect(subject).to include promotion_adjustment
         expect(subject).to_not include custom_adjustment_with_source
@@ -76,7 +74,8 @@ describe Spree::Adjustment, :type => :model do
     end
 
     context 'a custom source_type has been added to competing_promos' do
-      before { Spree::Adjustment.competing_promos_source_types = ['Spree::PromotionAction', 'Custom'] }
+      before { Rails.application.config.spree.competing_promos_source_types = ['Spree::PromotionAction', 'Custom'] }
+      after { Rails.application.config.spree.competing_promos_source_types = ['Spree::PromotionAction'] }
 
       it 'selects adjustments with registered source_types' do
         expect(subject).to include promotion_adjustment


### PR DESCRIPTION
Applies to 3-0-stable.

This allows for extensions to register their own methods with AdjustmentUpdater. 
