### PR TITLE
check preference exist before fetch

### DIFF
--- a/backend/app/helpers/spree/admin/base_helper.rb
+++ b/backend/app/helpers/spree/admin/base_helper.rb
@@ -118,10 +118,10 @@ module Spree
       def preference_fields(object, form)
         return unless object.respond_to?(:preferences)
         object.preferences.keys.map{ |key|
-
+        if object.has_preference?(key)
           form.label("preferred_#{key}", Spree.t(key) + ": ") +
             preference_field_for(form, "preferred_#{key}", type: object.preference_type(key))
-
+        end
         }.join("<br />").html_safe
       end
 


### PR DESCRIPTION
If you try to switch payment methods without recreate it. Sometimes different methods have different preferences. It should check preference available before fetch the preference.

```
ActionView::Template::Error (test_mode preference not defined):
     8:         <%= collection_select(:payment_method, :type, @providers, :to_s, :name, {}, {:id => 'gtwy-type', :class => 'select2'}) %>
     9:
    10:         <% unless @object.new_record? %>
    11:           <%= preference_fields(@object, f) %>
    12:
    13:           <% if @object.respond_to?(:preferences) %>
    14:             <div id="gateway-settings-warning" class="info warning"><%= Spree.t(:provider_settings_warning) %></div>
  /home/makeanegg/web/cross/shared/bundle/ruby/2.2.0/bundler/gems/spree-8147dcaac7c6/core/app/models/spree/preferences/preferable.rb:62:in `has_preference!'
  /home/makeanegg/web/cross/shared/bundle/ruby/2.2.0/bundler/gems/spree-8147dcaac7c6/core/app/models/spree/preferences/preferable.rb:52:in `preference_type'
  /home/makeanegg/web/cross/shared/bundle/ruby/2.2.0/bundler/gems/spree-8147dcaac7c6/backend/app/helpers/spree/admin/base_helper.rb:123:in `block in preference_fields'
  /home/makeanegg/web/cross/shared/bundle/ruby/2.2.0/bundler/gems/spree-8147dcaac7c6/backend/app/helpers/spree/admin/base_helper.rb:120:in `map'
  /home/makeanegg/web/cross/shared/bundle/ruby/2.2.0/bundler/gems/spree-8147dcaac7c6/backend/app/helpers/spree/admin/base_helper.rb:120:in `preference_fields'
  /home/makeanegg/web/cross/shared/bundle/ruby/2.2.0/bundler/gems/spree-8147dcaac7c6/backend/app/views/spree/admin/payment_methods/_form.html.erb:11:in `_df50e33665a5dfecd4e7f44b4617e844'
```
