### PR TITLE
Add payment editable

### DIFF
--- a/api/app/controllers/spree/api/v1/payments_controller.rb
+++ b/api/app/controllers/spree/api/v1/payments_controller.rb
@@ -27,7 +27,7 @@ module Spree
 
         def update
           authorize! params[:action], @payment
-          if ! @payment.pending?
+          if !@payment.editable?
             render 'update_forbidden', status: 403
           elsif @payment.update_attributes(payment_params)
             respond_with(@payment, default_template: :show)

--- a/api/spec/controllers/spree/api/v1/payments_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/payments_controller_spec.rb
@@ -105,26 +105,37 @@ module Spree
 
       context "for a given payment" do
         context "updating" do
-          it "can update" do
-            payment.update_attributes(:state => 'pending')
-            api_put :update, :id => payment.to_param, :payment => { :amount => 2.01 }
-            expect(response.status).to eq(200)
-            expect(payment.reload.amount).to eq(2.01)
+          context "when the state is checkout" do
+            it "can update" do
+              payment.update_attributes(state: 'checkout')
+              api_put(:update, id: payment.to_param, payment: { amount: 2.01 })
+              expect(response.status).to be(200)
+              expect(payment.reload.amount).to eq(2.01)
+            end
+          end
+
+          context "when the state is pending" do
+            it "can update" do
+              payment.update_attributes(state: 'pending')
+              api_put(:update, id: payment.to_param, payment: { amount: 2.01 })
+              expect(response.status).to be(200)
+              expect(payment.reload.amount).to eq(2.01)
+            end
           end
 
           context "update fails" do
             it "returns a 422 status when the amount is invalid" do
-              payment.update_attributes(:state => 'pending')
-              api_put :update, :id => payment.to_param, :payment => { :amount => 'invalid' }
-              expect(response.status).to eq(422)
-              expect(json_response["error"]).to eq("Invalid resource. Please fix errors and try again.")
+              payment.update_attributes(state: 'pending')
+              api_put(:update, id: payment.to_param, payment: { amount: 'invalid' })
+              expect(response.status).to be(422)
+              expect(json_response['error']).to eql('Invalid resource. Please fix errors and try again.')
             end
 
             it "returns a 403 status when the payment is not pending" do
-              payment.update_attributes(:state => 'completed')
-              api_put :update, :id => payment.to_param, :payment => { :amount => 2.01 }
-              expect(response.status).to eq(403)
-              expect(json_response["error"]).to eq("This payment cannot be updated because it is completed.")
+              payment.update_attributes(state: 'completed')
+              api_put(:update, id: payment.to_param, payment: { amount: 2.01 })
+              expect(response.status).to be(403)
+              expect(json_response['error']).to eql('This payment cannot be updated because it is completed.')
             end
           end
         end

--- a/backend/app/assets/javascripts/spree/backend/payments/edit.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/payments/edit.js.coffee
@@ -7,9 +7,9 @@ jQuery ($) ->
       @json = $.getJSON @url.toString(), (data) =>
         @data = data
 
-    if_pending: (callback) ->
+    if_editable: (callback) ->
       @json.done (data) ->
-        callback() if data.state is 'pending'
+        callback() if data.state in ['checkout', 'pending']
 
     update: (attributes, success) ->
       jqXHR = $.ajax
@@ -138,8 +138,8 @@ jQuery ($) ->
       separator = Spree.translations.currency_separator
       amount.replace(///[^\d#{separator}]///g, '')
 
-  # Attach ShowPaymentView to each pending payment in the table
+  # Attach ShowPaymentView to each editable payment in the table
   $('.admin tr[data-hook=payments_row]').each ->
     $el = $(@)
     payment = new Payment($el.prop('id').match(/\d+$/))
-    payment.if_pending -> new ShowPaymentView($el, payment)
+    payment.if_editable -> new ShowPaymentView($el, payment)

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -100,53 +100,55 @@ describe 'Payments', type: :feature, js: true do
       expect(page).to have_content('Please define some payment methods first.')
     end
 
-    context 'payment is pending', js: true do
-      let(:state) { 'pending' }
+    %w[checkout pending].each do |state|
+      context "payment is #{state.inspect}", js: true do
+        let(:state) { state }
 
-      it 'allows the amount to be edited by clicking on the edit button then saving' do
-        within_row(1) do
-          click_icon(:edit)
-          fill_in('amount', with: '$1')
-          click_icon(:save)
-          expect(page).to have_selector('td.amount span', text: '$1.00')
-          expect(payment.reload.amount).to eq(1.00)
+        it 'allows the amount to be edited by clicking on the edit button then saving' do
+          within_row(1) do
+            click_icon(:edit)
+            fill_in('amount', with: '$1')
+            click_icon(:save)
+            expect(page).to have_selector('td.amount span', text: '$1.00')
+            expect(payment.reload.amount).to eq(1.00)
+          end
         end
-      end
 
-      it 'allows the amount to be edited by clicking on the amount then saving' do
-        within_row(1) do
-          find('td.amount span').click
-          fill_in('amount', with: '$1.01')
-          click_icon(:save)
-          expect(page).to have_selector('td.amount span', text: '$1.01')
-          expect(payment.reload.amount).to eq(1.01)
+        it 'allows the amount to be edited by clicking on the amount then saving' do
+          within_row(1) do
+            find('td.amount span').click
+            fill_in('amount', with: '$1.01')
+            click_icon(:save)
+            expect(page).to have_selector('td.amount span', text: '$1.01')
+            expect(payment.reload.amount).to eq(1.01)
+          end
         end
-      end
 
-      it 'allows the amount change to be cancelled by clicking on the cancel button' do
-        within_row(1) do
-          click_icon(:edit)
+        it 'allows the amount change to be cancelled by clicking on the cancel button' do
+          within_row(1) do
+            click_icon(:edit)
 
-          # Can't use fill_in here, as under poltergeist that will unfocus (and
-          # thus submit) the field under poltergeist
-          find('td.amount input').click
-          page.execute_script("$('td.amount input').val('$1')")
+            # Can't use fill_in here, as under poltergeist that will unfocus (and
+            # thus submit) the field under poltergeist
+            find('td.amount input').click
+            page.execute_script("$('td.amount input').val('$1')")
 
-          click_icon(:cancel)
-          expect(page).to have_selector('td.amount span', text: '$150.00')
-          expect(payment.reload.amount).to eq(150.00)
+            click_icon(:cancel)
+            expect(page).to have_selector('td.amount span', text: '$150.00')
+            expect(payment.reload.amount).to eq(150.00)
+          end
         end
-      end
 
-      it 'displays an error when the amount is invalid' do
-        within_row(1) do
-          click_icon(:edit)
-          fill_in('amount', with: 'invalid')
-          click_icon(:save)
-          expect(find('td.amount input').value).to eq('invalid')
-          expect(payment.reload.amount).to eq(150.00)
+        it 'displays an error when the amount is invalid' do
+          within_row(1) do
+            click_icon(:edit)
+            fill_in('amount', with: 'invalid')
+            click_icon(:save)
+            expect(find('td.amount input').value).to eq('invalid')
+            expect(payment.reload.amount).to eq(150.00)
+          end
+          expect(page).to have_selector('.flash.error', text: 'Invalid resource. Please fix errors and try again.')
         end
-        expect(page).to have_selector('.alert-error', text: 'Invalid resource. Please fix errors and try again.')
       end
     end
 

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -173,6 +173,10 @@ module Spree
       amount - captured_amount
     end
 
+    def editable?
+      checkout? || pending?
+    end
+
     private
 
       def validate_source

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -877,6 +877,34 @@ describe Spree::Payment, :type => :model do
     end
   end
 
+  describe "#editable?" do
+    subject { payment }
+
+    before do
+      subject.state = state
+    end
+
+    context "when the state is 'checkout'" do
+      let(:state) { 'checkout' }
+
+      its(:editable?) { should be(true) }
+    end
+
+    context "when the state is 'pending'" do
+      let(:state) { 'pending' }
+
+      its(:editable?) { should be(true) }
+    end
+
+    %w[processing completed failed void invalid].each do |state|
+      context "when the state is '#{state}'" do
+        let(:state) { state }
+
+        its(:editable?) { should be(false) }
+      end
+    end
+  end
+
   # Regression test for #4072 (kinda)
   # The need for this was discovered in the research for #4072
   context "state changes" do


### PR DESCRIPTION
This allows payments to be edited both in `checkout` and `pending` state. Something that regularly happens for our client.

This is NOT related to the deadlock / performance fixes, we are upstreaming these weeks.
