### PR TITLE
Add additional padding to admin main-part

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_main.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_main.scss
@@ -1,6 +1,7 @@
 #main-part {
+  padding: 15px 35px 0;
   &.sidebar-collapsed {
-    padding-left: 65px;
+    padding-left: 85px;
   }
 }
 


### PR DESCRIPTION
In /admin the sidebar and main content use the default 15px gutter between two columns (the same which then divides the subsections of the main content). Adding extra spacing between these two sections makes the layout more balanced and easier on the eyes.
