### PR TITLE
Improved email validation

### DIFF
--- a/core/lib/spree/core/validators/email.rb
+++ b/core/lib/spree/core/validators/email.rb
@@ -1,10 +1,10 @@
 class EmailValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    unless value =~ %r{^(|(([A-Za-z0-9]+_+)|
+    unless value =~ %r{\A(([A-Za-z0-9]+_+)|
                           ([A-Za-z0-9]+\-+)|
                           ([A-Za-z0-9]+\.+)|
                           ([A-Za-z0-9]+\++))*[A-Za-z0-9]+@((\w+\-+)|
-                          (\w+\.))*\w{1,63}\.[a-zA-Z]{2,6})$}xi
+                          (\w+\.))*\w{1,63}\.[a-zA-Z]{2,6}\z}xi
       record.errors.add(attribute, :invalid, { value: value }.merge!(options))
     end
   end

--- a/core/lib/spree/core/validators/email.rb
+++ b/core/lib/spree/core/validators/email.rb
@@ -3,7 +3,7 @@ class EmailValidator < ActiveModel::EachValidator
     unless value =~ %r{\A(([A-Za-z0-9]+_+)|
                           ([A-Za-z0-9]+\-+)|
                           ([A-Za-z0-9]+\.+)|
-                          ([A-Za-z0-9]+\++))*[A-Za-z0-9]+@((\w+\-+)|
+                          ([A-Za-z0-9]+\++))*[A-Za-z0-9_]+@((\w+\-+)|
                           (\w+\.))*\w{1,63}\.[a-zA-Z]{2,6}\z}xi
       record.errors.add(attribute, :invalid, { value: value }.merge!(options))
     end

--- a/core/lib/spree/core/validators/email.rb
+++ b/core/lib/spree/core/validators/email.rb
@@ -1,7 +1,11 @@
 class EmailValidator < ActiveModel::EachValidator
-  def validate_each(record,attribute,value)
-    unless value =~ /\A([^@\.]|[^@\.]([^@\s]*)[^@\.])@([^@\s]+\.)+[^@\s]+\z/
-      record.errors.add(attribute, :invalid, {:value => value}.merge!(options))
+  def validate_each(record, attribute, value)
+    unless value =~ %r{^(|(([A-Za-z0-9]+_+)|
+                          ([A-Za-z0-9]+\-+)|
+                          ([A-Za-z0-9]+\.+)|
+                          ([A-Za-z0-9]+\++))*[A-Za-z0-9]+@((\w+\-+)|
+                          (\w+\.))*\w{1,63}\.[a-zA-Z]{2,6})$}xi
+      record.errors.add(attribute, :invalid, { value: value }.merge!(options))
     end
   end
 end

--- a/core/spec/lib/spree/core/validators/email_spec.rb
+++ b/core/spec/lib/spree/core/validators/email_spec.rb
@@ -19,6 +19,8 @@ describe EmailValidator do
   ]}
   let(:invalid_emails) {[
     'invalid email@email.com',
+    'invalidemail @email.com',
+    'invalidemail@email..com',
     '.invalid.email@email.com',
     'invalid.email.@email.com',
     '@email.com',

--- a/core/spec/lib/spree/core/validators/email_spec.rb
+++ b/core/spec/lib/spree/core/validators/email_spec.rb
@@ -18,6 +18,8 @@ describe EmailValidator do
     'valid.email@email.com'
   ]}
   let(:invalid_emails) {[
+    '',
+    ' ',
     'invalid email@email.com',
     'invalidemail @email.com',
     'invalidemail@email..com',

--- a/core/spec/lib/spree/core/validators/email_spec.rb
+++ b/core/spec/lib/spree/core/validators/email_spec.rb
@@ -15,6 +15,7 @@ describe EmailValidator do
     'valid+email@email.com',
     'valid-email@email.com',
     'valid_email@email.com',
+    'validemail_@email.com',
     'valid.email@email.com'
   ]}
   let(:invalid_emails) {[


### PR DESCRIPTION
We've noticed a few invalid emails slip through our application so we're proposing a change to the Regex used for email validation.

The regex is adapted from here: http://stackoverflow.com/questions/4770133/rails-regex-for-email-validation
