### PR TITLE
Kill exception shadowing in API

### DIFF
--- a/api/app/controllers/spree/api/v1/shipments_controller.rb
+++ b/api/app/controllers/spree/api/v1/shipments_controller.rb
@@ -75,12 +75,24 @@ module Spree
 
         def transfer_to_location
           @stock_location = Spree::StockLocation.find(params[:stock_location_id])
+
+          unless @quantity > 0
+            unprocessable_entity('ArgumentError')
+            return
+          end
+
           @original_shipment.transfer_to_location(@variant, @quantity, @stock_location)
           render json: {success: true, message: Spree.t(:shipment_transfer_success)}, status: 201
         end
 
         def transfer_to_shipment
           @target_shipment  = Spree::Shipment.friendly.find(params[:target_shipment_number])
+
+          if @quantity < 0 || @target_shipment == @original_shipment
+            unprocessable_entity('ArgumentError')
+            return
+          end
+
           @original_shipment.transfer_to_shipment(@variant, @quantity, @target_shipment)
           render json: {success: true, message: Spree.t(:shipment_transfer_success)}, status: 201
         end

--- a/api/app/controllers/spree/api/v1/users_controller.rb
+++ b/api/app/controllers/spree/api/v1/users_controller.rb
@@ -3,6 +3,8 @@ module Spree
     module V1
       class UsersController < Spree::Api::BaseController
 
+        rescue_from Spree::Core::DestroyWithOrdersError, with: :error_during_processing
+
         def index
           @users = Spree.user_class.accessible_by(current_ability,:read).ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
           respond_with(@users)

--- a/api/spec/controllers/spree/api/v1/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/orders_controller_spec.rb
@@ -291,7 +291,9 @@ module Spree
     it "does not update line item needlessly" do
       expect(Order).to receive(:create!).and_return(order = Spree::Order.new)
       allow(order).to receive(:associate_user!)
-      allow(order).to receive_message_chain(:contents, :add).and_return(line_item = double('LineItem'))
+      line_item = double('LineItem')
+      allow(line_item).to receive_messages(save!: line_item)
+      allow(order).to receive_message_chain(:contents, :add).and_return(line_item)
       expect(line_item).not_to receive(:update_attributes)
       api_post :create, order: { line_items: [{ variant_id: variant.to_param, quantity: 5 }] }
     end

--- a/api/spec/controllers/spree/api/v1/shipments_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/shipments_controller_spec.rb
@@ -38,9 +38,9 @@ describe Spree::Api::V1::ShipmentsController, :type => :controller do
           shipment: { order_id: order.number },
           stock_location_id: stock_location.to_param
         }
-      end 
-      
-      subject do 
+      end
+
+      subject do
         api_post :create, params
       end
 

--- a/api/spec/controllers/spree/api/v1/states_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/states_controller_spec.rb
@@ -24,26 +24,29 @@ module Spree
     end
 
     context "pagination" do
+      let(:scope) { double('scope') }
+
       before do
-        expect(State).to receive(:accessible_by).and_return(@scope = double)
-        allow(@scope).to receive_message_chain(:ransack, :result, :includes, :order).and_return(@scope)
+        expect(scope).to receive_messages(last: state)
+        expect(State).to receive_messages(accessible_by: scope)
+        allow(scope).to receive_message_chain(:ransack, :result, :includes, :order).and_return(scope)
       end
 
       it "does not paginate states results when asked not to do so" do
-        expect(@scope).not_to receive(:page)
-        expect(@scope).not_to receive(:per)
+        expect(scope).not_to receive(:page)
+        expect(scope).not_to receive(:per)
         api_get :index
       end
 
       it "paginates when page parameter is passed through" do
-        expect(@scope).to receive(:page).with(1).and_return(@scope)
-        expect(@scope).to receive(:per).with(nil)
+        expect(scope).to receive(:page).with(1).and_return(scope)
+        expect(scope).to receive(:per).with(nil).and_return(scope)
         api_get :index, :page => 1
       end
 
       it "paginates when per_page parameter is passed through" do
-        expect(@scope).to receive(:page).with(nil).and_return(@scope)
-        expect(@scope).to receive(:per).with(25)
+        expect(scope).to receive(:page).with(nil).and_return(scope)
+        expect(scope).to receive(:per).with(25).and_return(scope)
         api_get :index, :per_page => 25
       end
     end
@@ -54,7 +57,7 @@ module Spree
 
       it "gets all states for a country" do
         country = create(:country, :states_required => true)
-        state.country = country 
+        state.country = country
         state.save
 
         api_get :index, :country_id => country.id


### PR DESCRIPTION
- Never rescue `Exception` without re-raising it.
- Mapping `Exception` to 422 is pure evil to API client developers that
  in presence of a server side bug still have to assume a client side
  error because of 4xx range.
- Changes to rescue domain specific exceptions, while letting unexpected
  exceptions from _real_ bugs pass through higher levels where _sane_
  developers/operators will have real monitoring available, just logging the
  error awayand mapping to 4xx range is not healthy
- Fixes all specs that had been silently failing because of unexpected
  exceptions and the mapping to 422 whithout any other kind of
  expectation signalling the failure to rspec.
- Removes API specific class attribute `error_handler` as error handling
  should be injected globally via a rack handler. Not specific to an API
  specific subset of the controller inheritance tree
