### PR TITLE
Nil-error for guest orders in customer details

### DIFF
--- a/backend/app/views/spree/admin/orders/customer_details/_form.html.erb
+++ b/backend/app/views/spree/admin/orders/customer_details/_form.html.erb
@@ -16,7 +16,7 @@
             <% if can? :edit, @order.user %>
               <%= f.email_field :email, class: 'form-control' %>
             <% else %>
-              <p><%= @order.user.email %></p>
+              <p><%= @order.user.try(:email) || @order.email %></p>
             <% end %>
           </div>
         </div>


### PR DESCRIPTION
When you don't have edit user permission, viewing customer details 
raises an error.
