### PR TITLE
bootstrap shipping method form

### DIFF
--- a/backend/app/views/spree/admin/shipping_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/_form.html.erb
@@ -2,17 +2,17 @@
   <div class="row">
     <div data-hook="admin_shipping_method_form_name_field" class="col-md-6">
       <%= f.field_container :name, :class => ['form-group'] do %>
-        <%= f.label :name, Spree.t(:name) %>
-        <%= f.text_field :name, :class => 'form-control' %>
-        <%= error_message_on :shipping_method, :name %>
+          <%= f.label :name, Spree.t(:name) %>
+          <%= f.text_field :name, :class => 'form-control' %>
+          <%= error_message_on :shipping_method, :name %>
       <% end %>
     </div>
 
     <div data-hook="admin_shipping_method_form_display_field" class="col-md-6">
       <%= f.field_container :display_on, :class => ['form-group'] do %>
-        <%= f.label :display_on, Spree.t(:display) %>
-        <%= select(:shipping_method, :display_on, Spree::ShippingMethod::DISPLAY.collect { |display| [Spree.t(display), display == :both ? nil : display.to_s] }, {}, {:class => 'select2'}) %>
-        <%= error_message_on :shipping_method, :display_on %>
+          <%= f.label :display_on, Spree.t(:display) %>
+          <%= select(:shipping_method, :display_on, Spree::ShippingMethod::DISPLAY.collect { |display| [Spree.t(display), display == :both ? nil : display.to_s] }, {}, {:class => 'select2'}) %>
+          <%= error_message_on :shipping_method, :display_on %>
       <% end %>
     </div>
   </div>
@@ -20,25 +20,25 @@
   <div class="row">
     <div data-hook="admin_shipping_method_form_internal_name_field" class="col-md-4">
       <%= f.field_container :admin_name, :class => ['form-group'] do %>
-        <%= f.label :admin_name, Spree.t(:internal_name) %>
-        <%= f.text_field :admin_name, :class => 'form-control', :label => false  %>
-        <%= error_message_on :shipping_method, :admin_name %>
+          <%= f.label :admin_name, Spree.t(:internal_name) %>
+          <%= f.text_field :admin_name, :class => 'form-control', :label => false %>
+          <%= error_message_on :shipping_method, :admin_name %>
       <% end %>
     </div>
 
     <div data-hook="admin_shipping_method_form_code" class="col-md-4">
       <%= f.field_container :code, :class => ['form-group'] do %>
-        <%= f.label :code, Spree.t(:code) %>
-        <%= f.text_field :code, :class => 'form-control', :label => false  %>
-        <%= error_message_on :shipping_method, :code %>
+          <%= f.label :code, Spree.t(:code) %>
+          <%= f.text_field :code, :class => 'form-control', :label => false %>
+          <%= error_message_on :shipping_method, :code %>
       <% end %>
     </div>
 
     <div data-hook="admin_shipping_method_form_tracking_url_field" class="col-md-4">
       <%= f.field_container :tracking_url, :class => ['form-group'] do %>
-        <%= f.label :tracking_url, Spree.t(:tracking_url) %>
-        <%= f.text_field :tracking_url, :class => 'form-control', :placeholder => Spree.t(:tracking_url_placeholder) %>
-        <%= error_message_on :shipping_method, :tracking_url %>
+          <%= f.label :tracking_url, Spree.t(:tracking_url) %>
+          <%= f.text_field :tracking_url, :class => 'form-control', :placeholder => Spree.t(:tracking_url_placeholder) %>
+          <%= error_message_on :shipping_method, :tracking_url %>
       <% end %>
     </div>
   </div>
@@ -55,13 +55,15 @@
 
       <div class="panel-body">
         <%= f.field_container :categories, :class => ['form-group'] do %>
-          <% Spree::ShippingCategory.all.each do |category| %>
-            <%= label_tag do %>
-              <%= check_box_tag('shipping_method[shipping_categories][]', category.id, @shipping_method.shipping_categories.include?(category)) %>
-              <%= category.name %>
+            <% Spree::ShippingCategory.all.each do |category| %>
+                <div class="checkbox">
+                  <%= label_tag do %>
+                      <%= check_box_tag('shipping_method[shipping_categories][]', category.id, @shipping_method.shipping_categories.include?(category)) %>
+                      <%= category.name %>
+                  <% end %>
+                </div>
             <% end %>
-          <% end %>
-          <%= error_message_on :shipping_method, :shipping_category_id %>
+            <%= error_message_on :shipping_method, :shipping_category_id %>
         <% end %>
       </div>
     </div>
@@ -77,15 +79,17 @@
 
       <div class="panel-body">
         <%= f.field_container :zones, :class => ['form-group'] do %>
-          <% shipping_method_zones = @shipping_method.zones.to_a %>
-          <% Spree::Zone.all.each do |zone| %>
-            <%= label_tag do %>
-              <%= check_box_tag('shipping_method[zones][]', zone.id, shipping_method_zones.include?(zone)) %>
-              <%= zone.name %>
+            <% shipping_method_zones = @shipping_method.zones.to_a %>
+            <% Spree::Zone.all.each do |zone| %>
+                <div class="checkbox">
+                  <%= label_tag do %>
+                      <%= check_box_tag('shipping_method[zones][]', zone.id, shipping_method_zones.include?(zone)) %>
+                      <%= zone.name %>
+                  <% end %>
+                </div>
             <% end %>
-          <% end %>
-          <%= error_message_on :shipping_method, :zone_id %>
-        <% end %>  
+            <%= error_message_on :shipping_method, :zone_id %>
+        <% end %>
       </div>
     </div>
   </div>
@@ -93,7 +97,7 @@
 
 <div class="row">
   <div data-hook="admin_shipping_method_form_calculator_fields" class="col-md-6">
-    <%= render :partial => 'spree/admin/shared/calculator_fields', :locals => { :f => f } %>
+    <%= render :partial => 'spree/admin/shared/calculator_fields', :locals => {:f => f} %>
   </div>
 
   <div class="col-md-6">
@@ -106,8 +110,8 @@
 
       <div class="panel-body">
         <%= f.field_container :categories, :class => ['form-group'] do %>
-          <%= f.select :tax_category_id, @tax_categories.map { |tc| [tc.name, tc.id] }, {include_blank: true}, class: "select2" %>
-          <%= error_message_on :shipping_method, :tax_category_id %>
+            <%= f.select :tax_category_id, @tax_categories.map { |tc| [tc.name, tc.id] }, {include_blank: true}, class: "select2" %>
+            <%= error_message_on :shipping_method, :tax_category_id %>
         <% end %>
       </div>
     </div>

--- a/backend/app/views/spree/admin/shipping_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/_form.html.erb
@@ -2,17 +2,17 @@
   <div class="row">
     <div data-hook="admin_shipping_method_form_name_field" class="col-md-6">
       <%= f.field_container :name, :class => ['form-group'] do %>
-          <%= f.label :name, Spree.t(:name) %>
-          <%= f.text_field :name, :class => 'form-control' %>
-          <%= error_message_on :shipping_method, :name %>
+        <%= f.label :name, Spree.t(:name) %>
+        <%= f.text_field :name, :class => 'form-control' %>
+        <%= error_message_on :shipping_method, :name %>
       <% end %>
     </div>
 
     <div data-hook="admin_shipping_method_form_display_field" class="col-md-6">
       <%= f.field_container :display_on, :class => ['form-group'] do %>
-          <%= f.label :display_on, Spree.t(:display) %>
-          <%= select(:shipping_method, :display_on, Spree::ShippingMethod::DISPLAY.collect { |display| [Spree.t(display), display == :both ? nil : display.to_s] }, {}, {:class => 'select2'}) %>
-          <%= error_message_on :shipping_method, :display_on %>
+        <%= f.label :display_on, Spree.t(:display) %>
+        <%= select(:shipping_method, :display_on, Spree::ShippingMethod::DISPLAY.collect { |display| [Spree.t(display), display == :both ? nil : display.to_s] }, {}, { :class => 'select2' }) %>
+        <%= error_message_on :shipping_method, :display_on %>
       <% end %>
     </div>
   </div>
@@ -20,25 +20,25 @@
   <div class="row">
     <div data-hook="admin_shipping_method_form_internal_name_field" class="col-md-4">
       <%= f.field_container :admin_name, :class => ['form-group'] do %>
-          <%= f.label :admin_name, Spree.t(:internal_name) %>
-          <%= f.text_field :admin_name, :class => 'form-control', :label => false %>
-          <%= error_message_on :shipping_method, :admin_name %>
+        <%= f.label :admin_name, Spree.t(:internal_name) %>
+        <%= f.text_field :admin_name, :class => 'form-control', :label => false %>
+        <%= error_message_on :shipping_method, :admin_name %>
       <% end %>
     </div>
 
     <div data-hook="admin_shipping_method_form_code" class="col-md-4">
       <%= f.field_container :code, :class => ['form-group'] do %>
-          <%= f.label :code, Spree.t(:code) %>
-          <%= f.text_field :code, :class => 'form-control', :label => false %>
-          <%= error_message_on :shipping_method, :code %>
+        <%= f.label :code, Spree.t(:code) %>
+        <%= f.text_field :code, :class => 'form-control', :label => false %>
+        <%= error_message_on :shipping_method, :code %>
       <% end %>
     </div>
 
     <div data-hook="admin_shipping_method_form_tracking_url_field" class="col-md-4">
       <%= f.field_container :tracking_url, :class => ['form-group'] do %>
-          <%= f.label :tracking_url, Spree.t(:tracking_url) %>
-          <%= f.text_field :tracking_url, :class => 'form-control', :placeholder => Spree.t(:tracking_url_placeholder) %>
-          <%= error_message_on :shipping_method, :tracking_url %>
+        <%= f.label :tracking_url, Spree.t(:tracking_url) %>
+        <%= f.text_field :tracking_url, :class => 'form-control', :placeholder => Spree.t(:tracking_url_placeholder) %>
+        <%= error_message_on :shipping_method, :tracking_url %>
       <% end %>
     </div>
   </div>
@@ -55,15 +55,15 @@
 
       <div class="panel-body">
         <%= f.field_container :categories, :class => ['form-group'] do %>
-            <% Spree::ShippingCategory.all.each do |category| %>
-                <div class="checkbox">
-                  <%= label_tag do %>
-                      <%= check_box_tag('shipping_method[shipping_categories][]', category.id, @shipping_method.shipping_categories.include?(category)) %>
-                      <%= category.name %>
-                  <% end %>
-                </div>
-            <% end %>
-            <%= error_message_on :shipping_method, :shipping_category_id %>
+          <% Spree::ShippingCategory.all.each do |category| %>
+            <div class="checkbox">
+              <%= label_tag do %>
+                <%= check_box_tag('shipping_method[shipping_categories][]', category.id, @shipping_method.shipping_categories.include?(category)) %>
+                <%= category.name %>
+              <% end %>
+            </div>
+          <% end %>
+          <%= error_message_on :shipping_method, :shipping_category_id %>
         <% end %>
       </div>
     </div>
@@ -79,16 +79,16 @@
 
       <div class="panel-body">
         <%= f.field_container :zones, :class => ['form-group'] do %>
-            <% shipping_method_zones = @shipping_method.zones.to_a %>
-            <% Spree::Zone.all.each do |zone| %>
-                <div class="checkbox">
-                  <%= label_tag do %>
-                      <%= check_box_tag('shipping_method[zones][]', zone.id, shipping_method_zones.include?(zone)) %>
-                      <%= zone.name %>
-                  <% end %>
-                </div>
-            <% end %>
-            <%= error_message_on :shipping_method, :zone_id %>
+          <% shipping_method_zones = @shipping_method.zones.to_a %>
+          <% Spree::Zone.all.each do |zone| %>
+            <div class="checkbox">
+              <%= label_tag do %>
+                <%= check_box_tag('shipping_method[zones][]', zone.id, shipping_method_zones.include?(zone)) %>
+                <%= zone.name %>
+              <% end %>
+            </div>
+          <% end %>
+          <%= error_message_on :shipping_method, :zone_id %>
         <% end %>
       </div>
     </div>
@@ -97,7 +97,7 @@
 
 <div class="row">
   <div data-hook="admin_shipping_method_form_calculator_fields" class="col-md-6">
-    <%= render :partial => 'spree/admin/shared/calculator_fields', :locals => {:f => f} %>
+    <%= render :partial => 'spree/admin/shared/calculator_fields', :locals => { :f => f } %>
   </div>
 
   <div class="col-md-6">
@@ -110,8 +110,8 @@
 
       <div class="panel-body">
         <%= f.field_container :categories, :class => ['form-group'] do %>
-            <%= f.select :tax_category_id, @tax_categories.map { |tc| [tc.name, tc.id] }, {include_blank: true}, class: "select2" %>
-            <%= error_message_on :shipping_method, :tax_category_id %>
+          <%= f.select :tax_category_id, @tax_categories.map { |tc| [tc.name, tc.id] }, { include_blank: true }, class: "select2" %>
+          <%= error_message_on :shipping_method, :tax_category_id %>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
In the shipping method form, the categories and zones get busy when displayed inline. This adds the [default Bootstrap formatting](http://getbootstrap.com/css/#default-%28stacked%29) for multiple checkboxes.

good for 3-0-stable.
