### PR TITLE
Associate user address on copy

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -229,16 +229,15 @@ module Spree
 
     # Associates the specified user with the order.
     def associate_user!(user, override_email = true)
-      self.user = user
-      attrs_to_set = { user_id: user.id }
-      attrs_to_set[:email] = user.email if override_email
-      attrs_to_set[:created_by_id] = user.id if self.created_by.blank?
-      assign_attributes(attrs_to_set)
+      self.user         = user
+      self.email        = user.email if override_email
+      self.created_by ||= user
 
-      if persisted?
-        # immediately persist the changes we just made, but don't use save since we might have an invalid address associated
-        self.class.unscoped.where(id: id).update_all(attrs_to_set)
-      end
+      changes = slice(:user_id, :email, :created_by_id)
+
+      # immediately persist the changes we just made, but don't use save
+      # since we might have an invalid address associated
+      self.class.unscoped.where(id: self).update_all(changes)
     end
 
     def quantity_of(variant, options = {})

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -229,11 +229,13 @@ module Spree
 
     # Associates the specified user with the order.
     def associate_user!(user, override_email = true)
-      self.user         = user
-      self.email        = user.email if override_email
-      self.created_by ||= user
+      self.user           = user
+      self.email          = user.email if override_email
+      self.created_by   ||= user
+      self.bill_address ||= user.bill_address
+      self.ship_address ||= user.ship_address
 
-      changes = slice(:user_id, :email, :created_by_id)
+      changes = slice(:user_id, :email, :created_by_id, :bill_address_id, :ship_address_id)
 
       # immediately persist the changes we just made, but don't use save
       # since we might have an invalid address associated

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -665,59 +665,112 @@ describe Spree::Order, :type => :model do
     end
   end
 
-  context "#associate_user!" do
-    let!(:user) { FactoryGirl.create(:user) }
+  describe "#associate_user!" do
+    let(:user) { FactoryGirl.create(:user) }
+    let(:email) { user.email }
+    let(:created_by) { user }
+    let(:override_email) { true }
 
-    it "should associate a user with a persisted order" do
-      order = FactoryGirl.create(:order_with_line_items, created_by: nil)
-      order.user = nil
-      order.email = nil
-      order.associate_user!(user)
-      expect(order.user).to eq(user)
-      expect(order.email).to eq(user.email)
-      expect(order.created_by).to eq(user)
+    let(:order) { FactoryGirl.build(:order, order_attributes) }
 
-      # verify that the changes we made were persisted
-      order.reload
-      expect(order.user).to eq(user)
-      expect(order.email).to eq(user.email)
-      expect(order.created_by).to eq(user)
+    let(:order_attributes) do
+      {
+        user:       nil,
+        email:      nil,
+        created_by: nil
+      }
     end
 
-    it "should not overwrite the created_by if it already is set" do
-      creator = create(:user)
-      order = FactoryGirl.create(:order_with_line_items, created_by: creator)
+    def assert_expected_order_state
+      expect(order.user).to eql(user)
+      expect(order.user_id).to eql(user.id)
 
-      order.user = nil
-      order.email = nil
-      order.associate_user!(user)
-      expect(order.user).to eq(user)
-      expect(order.email).to eq(user.email)
-      expect(order.created_by).to eq(creator)
+      expect(order.email).to eql(email)
 
-      # verify that the changes we made were persisted
-      order.reload
-      expect(order.user).to eq(user)
-      expect(order.email).to eq(user.email)
-      expect(order.created_by).to eq(creator)
+      expect(order.created_by).to eql(created_by)
+      expect(order.created_by_id).to eql(created_by.id)
     end
 
-    it "should associate a user with a non-persisted order" do
-      order = Spree::Order.new
+    shared_examples_for "#associate_user!" do |persisted = false|
+      it "associates a user to an order" do
+        order.associate_user!(user, override_email)
+        assert_expected_order_state
+      end
 
-      expect do
+      unless persisted
+        it "does not persist the order" do
+          expect { order.associate_user!(user) }
+            .to_not change(order, :persisted?)
+            .from(false)
+        end
+      end
+    end
+
+    context "when email is set" do
+      let(:order_attributes) { super().merge(email: 'test@example.com') }
+
+      context "when email should be overridden" do
+        it_should_behave_like "#associate_user!"
+      end
+
+      context "when email should not be overridden" do
+        let(:override_email) { false }
+        let(:email) { 'test@example.com' }
+
+        it_should_behave_like "#associate_user!"
+      end
+    end
+
+    context "when created_by is set" do
+      let(:order_attributes) { super().merge(created_by: created_by) }
+      let(:created_by) { create(:user) }
+
+      it_should_behave_like "#associate_user!"
+    end
+
+    context "when the user is not persisted" do
+      let(:user) { FactoryGirl.build(:user) }
+
+      it "does not persist the user" do
+        expect { order.associate_user!(user) }
+          .to_not change(user, :persisted?)
+          .from(false)
+      end
+
+      it_should_behave_like "#associate_user!"
+    end
+
+    context "when the order is persisted" do
+      let(:order) { FactoryGirl.create(:order, order_attributes) }
+
+      it "associates a user to a persisted order" do
         order.associate_user!(user)
-      end.to change { [order.user, order.email] }.from([nil, nil]).to([user, user.email])
-    end
+        order.reload
+        assert_expected_order_state
+      end
 
-    it "should not persist an invalid address" do
-      address = Spree::Address.new
-      order.user = nil
-      order.email = nil
-      order.ship_address = address
-      expect do
+      it "does not persist other changes to the order" do
+        order.state = 'complete'
         order.associate_user!(user)
-      end.not_to change { address.persisted? }.from(false)
+        order.reload
+        expect(order.state).to eql('cart')
+      end
+
+      it "does not change any other orders" do
+        other = FactoryGirl.create(:order)
+        order.associate_user!(user)
+        expect(other.reload.user).to_not eql(user)
+      end
+
+      it "is not affected by scoping" do
+        order.class.where.not(id: order).scoping do
+          order.associate_user!(user)
+        end
+        order.reload
+        assert_expected_order_state
+      end
+
+      it_should_behave_like "#associate_user!", true
     end
   end
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -666,18 +666,22 @@ describe Spree::Order, :type => :model do
   end
 
   describe "#associate_user!" do
-    let(:user) { FactoryGirl.create(:user) }
+    let(:user) { FactoryGirl.create(:user_with_addreses) }
     let(:email) { user.email }
     let(:created_by) { user }
+    let(:bill_address) { user.bill_address }
+    let(:ship_address) { user.ship_address }
     let(:override_email) { true }
 
     let(:order) { FactoryGirl.build(:order, order_attributes) }
 
     let(:order_attributes) do
       {
-        user:       nil,
-        email:      nil,
-        created_by: nil
+        user:         nil,
+        email:        nil,
+        created_by:   nil,
+        bill_address: nil,
+        ship_address: nil
       }
     end
 
@@ -689,6 +693,12 @@ describe Spree::Order, :type => :model do
 
       expect(order.created_by).to eql(created_by)
       expect(order.created_by_id).to eql(created_by.id)
+
+      expect(order.bill_address).to eql(bill_address)
+      expect(order.bill_address_id).to eql(bill_address.id)
+
+      expect(order.ship_address).to eql(ship_address)
+      expect(order.ship_address_id).to eql(ship_address.id)
     end
 
     shared_examples_for "#associate_user!" do |persisted = false|
@@ -723,13 +733,27 @@ describe Spree::Order, :type => :model do
 
     context "when created_by is set" do
       let(:order_attributes) { super().merge(created_by: created_by) }
-      let(:created_by) { create(:user) }
+      let(:created_by) { create(:user_with_addreses) }
+
+      it_should_behave_like "#associate_user!"
+    end
+
+    context "when bill_address is set" do
+      let(:order_attributes) { super().merge(bill_address: bill_address) }
+      let(:bill_address) { FactoryGirl.build(:address) }
+
+      it_should_behave_like "#associate_user!"
+    end
+
+    context "when ship_address is set" do
+      let(:order_attributes) { super().merge(ship_address: ship_address) }
+      let(:ship_address) { FactoryGirl.build(:address) }
 
       it_should_behave_like "#associate_user!"
     end
 
     context "when the user is not persisted" do
-      let(:user) { FactoryGirl.build(:user) }
+      let(:user) { FactoryGirl.build(:user_with_addreses) }
 
       it "does not persist the user" do
         expect { order.associate_user!(user) }


### PR DESCRIPTION
This fixes a bug where addresses where not correctly associated with users, leading to the UX issue of asking the user to enter its address again on a 2nd checkout.
