### PR TITLE
Fix Spree::OrderWalkthrough.up_to to not transition past the action

### DIFF
--- a/core/lib/spree/testing_support/order_walkthrough.rb
+++ b/core/lib/spree/testing_support/order_walkthrough.rb
@@ -30,7 +30,7 @@ class OrderWalkthrough
     order.next!
 
     end_state_position = states.index(state.to_sym)
-    states[0..end_state_position].each do |state|
+    states[0...end_state_position].each do |state|
       send(state, order)
     end
 

--- a/frontend/spec/controllers/spree/checkout_controller_with_views_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_with_views_spec.rb
@@ -22,7 +22,7 @@ describe Spree::CheckoutController, type: :controller do
       before do
         # Using a let block won't acknowledge the currency setting
         # Therefore we just do it like this...
-        order = OrderWalkthrough.up_to(:address)
+        order = OrderWalkthrough.up_to(:delivery)
         allow(controller).to receive_messages current_order: order
       end
 

--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -96,7 +96,7 @@ describe "Checkout", type: :feature, inaccessible: true, js: true do
   # Regression test for #2694 and #4117
   context "doesn't allow bad credit card numbers" do
     before(:each) do
-      order = OrderWalkthrough.up_to(:delivery)
+      order = OrderWalkthrough.up_to(:payment)
       allow(order).to receive_messages confirmation_required?: true
       allow(order).to receive_messages(:available_payment_methods => [ create(:credit_card_payment_method) ])
 
@@ -109,7 +109,7 @@ describe "Checkout", type: :feature, inaccessible: true, js: true do
     end
 
     it "redirects to payment page", inaccessible: true, js: true do
-      visit spree.checkout_state_path(:delivery)
+      visit spree.checkout_state_path(:payment)
       click_button "Save and Continue"
       choose "Credit Card"
       fill_in "Card Number", with: '123'
@@ -149,7 +149,7 @@ describe "Checkout", type: :feature, inaccessible: true, js: true do
     let!(:user) { create(:user) }
 
     let!(:order) do
-      order = OrderWalkthrough.up_to(:delivery)
+      order = OrderWalkthrough.up_to(:payment)
       allow(order).to receive_messages confirmation_required?: true
 
       order.reload
@@ -198,7 +198,7 @@ describe "Checkout", type: :feature, inaccessible: true, js: true do
 
     before do
       Capybara.ignore_hidden_elements = false
-      order = OrderWalkthrough.up_to(:delivery)
+      order = OrderWalkthrough.up_to(:payment)
       allow(order).to receive_messages(available_payment_methods: [check_payment,credit_cart_payment])
       order.user = create(:user)
       order.update!
@@ -231,7 +231,7 @@ describe "Checkout", type: :feature, inaccessible: true, js: true do
     end
 
     before do
-      order = OrderWalkthrough.up_to(:delivery)
+      order = OrderWalkthrough.up_to(:payment)
       allow(order).to receive_messages(available_payment_methods: [bogus])
 
       allow_any_instance_of(Spree::CheckoutController).to receive_messages(current_order: order)
@@ -473,15 +473,14 @@ describe "Checkout", type: :feature, inaccessible: true, js: true do
 
   context "when order is completed" do
     let!(:user) { create(:user) }
-    let!(:order) { OrderWalkthrough.up_to(:delivery) }
+    let!(:order) { OrderWalkthrough.up_to(:payment) }
 
     before(:each) do
       allow_any_instance_of(Spree::CheckoutController).to receive_messages(current_order: order)
       allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: user)
       allow_any_instance_of(Spree::OrdersController).to receive_messages(try_spree_current_user: user)
 
-      visit spree.checkout_state_path(:delivery)
-      click_button "Save and Continue"
+      visit spree.checkout_state_path(:payment)
       click_button "Save and Continue"
     end
 

--- a/frontend/spec/features/checkout_unshippable_spec.rb
+++ b/frontend/spec/features/checkout_unshippable_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe "checkout with unshippable items", type: :feature, inaccessible: true do
   let!(:stock_location) { create(:stock_location) }
-  let(:order) { OrderWalkthrough.up_to(:address) }
+  let(:order) { OrderWalkthrough.up_to(:delivery) }
 
   before do
     OrderWalkthrough.add_line_item!(order)


### PR DESCRIPTION
- Previously specifying :address, or any other state, will cause this
  method to transition to the _next_ action after it. I believe, based
  on the name of the method, this is incorrect. It is the intention of
  someone using this method to transition to the specific state they
  specified, not whatever comes after it.
