### PR TITLE
Fix the destruction cascade of slugs history

### DIFF
--- a/core/app/models/friendly_id/slug_decorator.rb
+++ b/core/app/models/friendly_id/slug_decorator.rb
@@ -1,0 +1,3 @@
+FriendlyId::Slug.class_eval do
+  acts_as_paranoid
+end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -444,10 +444,10 @@ module Spree
     end
 
     ##
-    # Check to see if any line item variants are soft, deleted.
+    # Check to see if any line item variants are soft deleted.
     # If so add error and restart checkout.
     def ensure_line_item_variants_are_not_deleted
-      if line_items.select{ |li| li.variant.destroyed? }.present?
+      if line_items.any?{ |li| !li.variant || li.variant.paranoia_destroyed? }
         errors.add(:base, Spree.t(:deleted_variants_present))
         restart_checkout_flow
         false

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -74,6 +74,7 @@ module Spree
     after_create :build_variants_from_option_values_hash, if: :option_values_hash
 
     after_destroy :punch_slug
+    after_restore :update_slug_history
 
     after_initialize :ensure_master
 
@@ -264,6 +265,10 @@ module Spree
 
     def punch_slug
       update_column :slug, "#{Time.now.to_i}_#{slug}" # punch slug with date prefix to allow reuse of original
+    end
+
+    def update_slug_history
+      self.save!
     end
 
     def anything_changed?

--- a/core/db/migrate/20150522181728_add_deleted_at_to_friendly_id_slugs.rb
+++ b/core/db/migrate/20150522181728_add_deleted_at_to_friendly_id_slugs.rb
@@ -1,0 +1,6 @@
+class AddDeletedAtToFriendlyIdSlugs < ActiveRecord::Migration
+  def change
+    add_column :friendly_id_slugs, :deleted_at, :datetime
+    add_index :friendly_id_slugs, :deleted_at
+  end
+end

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -101,6 +101,13 @@ module Spree
       initializer "spree.core.checking_migrations" do |app|
         Migrations.new(config, engine_name).check
       end
+
+      config.to_prepare do
+        # Load application's model / class decorators
+        Dir.glob(File.join(File.dirname(__FILE__), '../app/**/*_decorator*.rb')) do |c|
+          Rails.configuration.cache_classes ? require(c) : load(c)
+        end
+      end
     end
   end
 end

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -104,7 +104,7 @@ module Spree
 
       config.to_prepare do
         # Load application's model / class decorators
-        Dir.glob(File.join(File.dirname(__FILE__), '../app/**/*_decorator*.rb')) do |c|
+        Dir.glob(File.join(File.dirname(__FILE__), '../../../app/**/*_decorator*.rb')) do |c|
           Rails.configuration.cache_classes ? require(c) : load(c)
         end
       end

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -244,9 +244,28 @@ describe Spree::Product, :type => :model do
 
         expect(product2.slug).to eq 'test-456'
       end
-
     end
 
+    context 'history' do
+      before(:each) do
+        @product = create(:product)
+      end
+
+      it 'should keep the history when the product is destroyed' do
+        @product.destroy
+
+        expect(@product.slugs.with_deleted).to_not be_empty
+      end
+
+      it 'should update the history when the product is restored' do
+        @product.destroy
+
+        @product.restore(recursive: true)
+
+        latest_slug = @product.slugs.find_by slug: @product.slug
+        expect(latest_slug).to_not be_nil
+      end
+    end
   end
 
   context "properties" do
@@ -434,7 +453,7 @@ describe Spree::Product, :type => :model do
       expect(product.reload.total_on_hand).to eql(5)
     end
   end
-  
+
   # Regression spec for https://github.com/spree/spree/issues/5588
   context '#validate_master when duplicate SKUs entered' do
     let!(:first_product) { create(:product, sku: 'a-sku') }

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'kaminari', '~> 0.15', '>= 0.15.1'
   s.add_dependency 'monetize', '~> 1.1'
   s.add_dependency 'paperclip', '~> 4.2.0'
-  s.add_dependency 'paranoia', '~> 2.0.5'
+  s.add_dependency 'paranoia', '~> 2.1.0'
   s.add_dependency 'premailer-rails'
   s.add_dependency 'rails', '4.1.9'
   s.add_dependency 'ransack', '~> 1.4.1'


### PR DESCRIPTION
I saw that the add-on of friendly_id was changed from slugged to history to keep the history of slugs, on commit https://github.com/spree/spree/commit/e145a1631788cf7c19e4f1705b8c45a7a181cae6. This add-on creates a relationship [one_to_many](https://github.com/norman/friendly_id/blob/master/lib/friendly_id/history.rb) with a new model [Friendly::Slug](https://github.com/norman/friendly_id/blob/master/lib/friendly_id/slug.rb). However when the product is destroyed the slug history is deleted because it doesn't include **acts_as_paranoid**. So the main idea is lost when the history is deleted.

I tried a lot of alternatives to fix this and as result I did these changes.

Take a look and let me Know what did you think? If you have another idea I could change the PR.
