### PR TITLE
really not track inventory when inventory tracking is turned off

### DIFF
--- a/core/app/models/spree/stock/coordinator.rb
+++ b/core/app/models/spree/stock/coordinator.rb
@@ -32,7 +32,7 @@ module Spree
       def build_packages(packages = Array.new)
         StockLocation.active.each do |stock_location|
           if Spree::Config.track_inventory_levels
-            next unless stock_location.stock_items.where(:variant_id => inventory_units.map(&:variant_id).uniq).exists?
+            next unless stock_location.stock_items.where(variant_id: inventory_units.map(&:variant_id).uniq).exists?
           end
           packer = build_packer(stock_location, inventory_units)
           packages += packer.packages

--- a/core/app/models/spree/stock/coordinator.rb
+++ b/core/app/models/spree/stock/coordinator.rb
@@ -27,12 +27,13 @@ module Spree
       # to build a package because it would be empty. Plus we avoid errors down
       # the stack because it would assume the stock location has stock items
       # for the given order
-      # 
+      #
       # Returns an array of Package instances
       def build_packages(packages = Array.new)
         StockLocation.active.each do |stock_location|
-          next unless stock_location.stock_items.where(:variant_id => inventory_units.map(&:variant_id).uniq).exists?
-
+          if Spree::Config.track_inventory_levels
+            next unless stock_location.stock_items.where(:variant_id => inventory_units.map(&:variant_id).uniq).exists?
+          end
           packer = build_packer(stock_location, inventory_units)
           packages += packer.packages
         end

--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -77,8 +77,10 @@ module Spree
     end
 
     def move(variant, quantity, originator = nil)
-      stock_item_or_create(variant).stock_movements.create!(quantity: quantity,
+      if Config.track_inventory_levels
+        stock_item_or_create(variant).stock_movements.create!(quantity: quantity,
                                                             originator: originator)
+      end
     end
 
     def fill_status(variant, quantity)


### PR DESCRIPTION
Work in progress:
- [ ] add specs
- [ ] search for other places that handle stock and do not use Spree::Config.track_inventory_levels correctly
