### PR TITLE
Redirect when history slug is there.

### DIFF
--- a/frontend/app/controllers/spree/products_controller.rb
+++ b/frontend/app/controllers/spree/products_controller.rb
@@ -18,7 +18,7 @@ module Spree
       @variants = @product.variants_including_master.active(current_currency).includes([:option_values, :images])
       @product_properties = @product.product_properties.includes(:property)
       @taxon = Spree::Taxon.find(params[:taxon_id]) if params[:taxon_id]
-
+      
       # If an old id or a numeric id was used to find the record, then
       # the request path will not match the product_path, and we should do
       # a 301 redirect that uses the current friendly id.

--- a/frontend/app/controllers/spree/products_controller.rb
+++ b/frontend/app/controllers/spree/products_controller.rb
@@ -18,6 +18,13 @@ module Spree
       @variants = @product.variants_including_master.active(current_currency).includes([:option_values, :images])
       @product_properties = @product.product_properties.includes(:property)
       @taxon = Spree::Taxon.find(params[:taxon_id]) if params[:taxon_id]
+
+      # If an old id or a numeric id was used to find the record, then
+      # the request path will not match the product_path, and we should do
+      # a 301 redirect that uses the current friendly id.
+      if request.path != spree.product_path(@product)
+        return redirect_to @product, status: :moved_permanently
+      end
     end
 
     private

--- a/frontend/app/controllers/spree/products_controller.rb
+++ b/frontend/app/controllers/spree/products_controller.rb
@@ -18,7 +18,6 @@ module Spree
       @variants = @product.variants_including_master.active(current_currency).includes([:option_values, :images])
       @product_properties = @product.product_properties.includes(:property)
       @taxon = Spree::Taxon.find(params[:taxon_id]) if params[:taxon_id]
-      
       # If an old id or a numeric id was used to find the record, then
       # the request path will not match the product_path, and we should do
       # a 301 redirect that uses the current friendly id.

--- a/frontend/spec/controllers/spree/products_controller_spec.rb
+++ b/frontend/spec/controllers/spree/products_controller_spec.rb
@@ -34,8 +34,7 @@ describe Spree::ProductsController, :type => :controller do
   end
 
   context 'with history slugs present' do
-
-    let!(:product) { create(:product, :available_on => 1.day.ago) }
+    let!(:product) { create(:product, available_on: 1.day.ago) }
 
     it 'will redirect with a 301 with legacy url used' do
       legacy_params = product.to_param

--- a/frontend/spec/controllers/spree/products_controller_spec.rb
+++ b/frontend/spec/controllers/spree/products_controller_spec.rb
@@ -33,4 +33,26 @@ describe Spree::ProductsController, :type => :controller do
     expect { spree_get :show, :id => product.to_param }.not_to raise_error
   end
 
+  context 'with history slugs present' do
+
+    let!(:product) { create(:product, :available_on => 1.day.ago) }
+
+    it 'will redirect with a 301 with legacy url used' do
+      legacy_params = product.to_param
+      product.name = product.name + " Brand New"
+      product.slug = nil
+      product.save!
+      spree_get :show, id: legacy_params
+      expect(response.status).to eq(301)
+    end
+
+    it 'will redirect with a 301 with id used' do
+      legacy_params = product.to_param
+      product.name = product.name + " Brand New"
+      product.slug = nil
+      product.save!
+      spree_get :show, id: product.id
+      expect(response.status).to eq(301)
+    end
+  end
 end

--- a/frontend/spec/controllers/spree/products_controller_spec.rb
+++ b/frontend/spec/controllers/spree/products_controller_spec.rb
@@ -46,7 +46,6 @@ describe Spree::ProductsController, :type => :controller do
     end
 
     it 'will redirect with a 301 with id used' do
-      legacy_params = product.to_param
       product.name = product.name + " Brand New"
       product.slug = nil
       product.save!


### PR DESCRIPTION
Since we use the history option from FriendlyId, I updated the products controller to actually use that. So with this PR, when a legacy url or id is used, we redirect with a 301 to the current friendlyId slug. This will keep Google happy.
