### PR TITLE
add missing required field labels

### DIFF
--- a/backend/app/views/spree/admin/option_types/edit.html.erb
+++ b/backend/app/views/spree/admin/option_types/edit.html.erb
@@ -23,8 +23,8 @@
     <table class="table table-condensed table-bordered sortable" data-hook data-sortable-link="<%= update_values_positions_admin_option_types_url %>">
       <thead data-hook="option_header">
         <tr>
-          <th colspan="2"><%= Spree.t(:name) %></th>
-          <th><%= Spree.t(:display) %></th>
+          <th colspan="2"><%= Spree.t(:name) %> <span class="required">*</span></th>
+          <th><%= Spree.t(:display) %> <span class="required">*</span></th>
           <th class="actions"></th>
         </tr>
       </thead>


### PR DESCRIPTION
When editing an Option Type, `name` and `presentation` fields are not marked as required, even when they are. I've added the required label.
