### PR TITLE
Enable to override exchanging percentage for gateway

### DIFF
--- a/core/app/models/spree/gateway.rb
+++ b/core/app/models/spree/gateway.rb
@@ -1,6 +1,6 @@
 module Spree
   class Gateway < PaymentMethod
-    FROM_DOLLAR_TO_CENT_PERCENTAGE = 100.0
+    FROM_DOLLAR_TO_CENT_RATE = 100.0
 
     delegate :authorize, :purchase, :capture, :void, :credit, to: :provider
 
@@ -47,8 +47,8 @@ module Spree
       'gateway'
     end
 
-    def exchange_percentage
-      FROM_DOLLAR_TO_CENT_PERCENTAGE
+    def exchange_multiplier
+      FROM_DOLLAR_TO_CENT_RATE
     end
 
     def supports?(source)

--- a/core/app/models/spree/gateway.rb
+++ b/core/app/models/spree/gateway.rb
@@ -1,5 +1,7 @@
 module Spree
   class Gateway < PaymentMethod
+    FROM_DOLLAR_TO_CENT_PERCENTAGE = 100.0
+
     delegate :authorize, :purchase, :capture, :void, :credit, to: :provider
 
     validates :name, :type, presence: true
@@ -43,6 +45,10 @@ module Spree
 
     def method_type
       'gateway'
+    end
+
+    def exchange_percentage
+      FROM_DOLLAR_TO_CENT_PERCENTAGE
     end
 
     def supports?(source)

--- a/core/app/models/spree/payment/gateway_options.rb
+++ b/core/app/models/spree/payment/gateway_options.rb
@@ -26,19 +26,19 @@ module Spree
       end
 
       def shipping
-        order.ship_total * 100
+        order.ship_total * exchange_percentage
       end
 
       def tax
-        order.additional_tax_total * 100
+        order.additional_tax_total * exchange_percentage
       end
 
       def subtotal
-        order.item_total * 100
+        order.item_total * exchange_percentage
       end
 
       def discount
-        order.promo_total * 100
+        order.promo_total * exchange_percentage
       end
 
       def currency
@@ -80,6 +80,10 @@ module Spree
 
       def order
         @payment.order
+      end
+
+      def exchange_percentage
+        @payment.payment_method.try(:exchange_percentage) || 1.0
       end
     end
   end

--- a/core/app/models/spree/payment/gateway_options.rb
+++ b/core/app/models/spree/payment/gateway_options.rb
@@ -26,19 +26,19 @@ module Spree
       end
 
       def shipping
-        order.ship_total * exchange_percentage
+        order.ship_total * exchange_multiplier
       end
 
       def tax
-        order.additional_tax_total * exchange_percentage
+        order.additional_tax_total * exchange_multiplier
       end
 
       def subtotal
-        order.item_total * exchange_percentage
+        order.item_total * exchange_multiplier
       end
 
       def discount
-        order.promo_total * exchange_percentage
+        order.promo_total * exchange_multiplier
       end
 
       def currency
@@ -82,8 +82,8 @@ module Spree
         @payment.order
       end
 
-      def exchange_percentage
-        @payment.payment_method.try(:exchange_percentage) || 1.0
+      def exchange_multiplier
+        @payment.payment_method.try(:exchange_multiplier) || 1.0
       end
     end
   end

--- a/core/spec/models/spree/gateway_spec.rb
+++ b/core/spec/models/spree/gateway_spec.rb
@@ -52,9 +52,10 @@ describe Spree::Gateway, :type => :model do
     end
   end
 
-  it "returns exchange percentage for gateway" do
+  it "returns exchange multiplier for gateway" do
     gateway = TestGateway.new
 
-    expect(gateway.exchange_percentage).to eq Spree::Gateway::FROM_DOLLAR_TO_CENT_PERCENTAGE
+    rate = Spree::Gateway::FROM_DOLLAR_TO_CENT_RATE
+    expect(gateway.exchange_multiplier).to eq rate
   end
 end

--- a/core/spec/models/spree/gateway_spec.rb
+++ b/core/spec/models/spree/gateway_spec.rb
@@ -51,4 +51,10 @@ describe Spree::Gateway, :type => :model do
       expect(has_card.reusable_sources(payment.order)).not_to be_empty
     end
   end
+
+  it "returns exchange percentage for gateway" do
+    gateway = TestGateway.new
+
+    expect(gateway.exchange_percentage).to eq Spree::Gateway::FROM_DOLLAR_TO_CENT_PERCENTAGE
+  end
 end

--- a/core/spec/models/spree/payment/gateway_options_spec.rb
+++ b/core/spec/models/spree/payment/gateway_options_spec.rb
@@ -8,7 +8,15 @@ RSpec.describe Spree::Payment::GatewayOptions, type: :model do
       Spree::Payment,
       order: order,
       number: "P1566",
-      currency: "EUR"
+      currency: "EUR",
+      payment_method: payment_method
+    )
+  end
+
+  let(:payment_method) do
+    double(
+      Spree::Gateway::Bogus,
+      exchange_percentage: Spree::Gateway::FROM_DOLLAR_TO_CENT_PERCENTAGE
     )
   end
 
@@ -31,6 +39,7 @@ RSpec.describe Spree::Payment::GatewayOptions, type: :model do
   let(:bill_address) do
     double Spree::Address, active_merchant_hash: { bill: :address }
   end
+
   let(:ship_address) do
     double Spree::Address, active_merchant_hash: { ship: :address }
   end
@@ -115,5 +124,4 @@ RSpec.describe Spree::Payment::GatewayOptions, type: :model do
     end
     it { should == expected }
   end
-
 end

--- a/core/spec/models/spree/payment/gateway_options_spec.rb
+++ b/core/spec/models/spree/payment/gateway_options_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Spree::Payment::GatewayOptions, type: :model do
   let(:payment_method) do
     double(
       Spree::Gateway::Bogus,
-      exchange_percentage: Spree::Gateway::FROM_DOLLAR_TO_CENT_PERCENTAGE
+      exchange_multiplier: Spree::Gateway::FROM_DOLLAR_TO_CENT_RATE
     )
   end
 


### PR DESCRIPTION
Spree will changes some prices from dollar to cent when requests to gateway.

e.g. https://github.com/spree/spree/blob/master/core/app/models/spree/payment/gateway_options.rb#L29

``` rb
      ...
      def shipping
        order.ship_total * 100
      end
      ...
```

Some gateways doesn't support cent currency.

I think we need to change `Spree::Payment::GatewayOptions`.
Please check a commit.

And, Please advise nice naming if `exchage_percentage` is not readable. :wink: 
