### PR TITLE
Removed Cancel button from the Add Stock form

### DIFF
--- a/backend/app/views/spree/admin/products/_add_stock_form.html.erb
+++ b/backend/app/views/spree/admin/products/_add_stock_form.html.erb
@@ -37,8 +37,6 @@
 
     <div class="form-actions text-center" data-hook="buttons">
       <%= button Spree.t(:add_stock), 'plus' %>
-      <span class="or"><%= Spree.t(:or) %></span>
-      <%= button_link_to Spree.t('actions.cancel'), collection_url, :icon => 'delete' %>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
I just noticed that the cancel button on the Add Stock form (while editing a product) sends the user to the product index. This isn't very intuitive. It should clear the form values, but even that seems unnecessary.
