### PR TITLE
Removed unnecessary call to states in countries#index

### DIFF
--- a/api/app/controllers/spree/api/v1/countries_controller.rb
+++ b/api/app/controllers/spree/api/v1/countries_controller.rb
@@ -7,7 +7,7 @@ module Spree
 
         def index
           @countries = Country.accessible_by(current_ability, :read).ransack(params[:q]).result.
-                       includes(:states).order('name ASC').
+                       order('name ASC').
                        page(params[:page]).per(params[:per_page])
           country = Country.order("updated_at ASC").last
           if stale?(country)


### PR DESCRIPTION
https://github.com/spree/spree/issues/6440 : 

In `/api/app/controllers/spree/api/v1/countries_controller.rb`, line 10, the states are included but are not rendered in the rabl. This makes an unnecessary long API call to retrieve the countries.
