### PR TITLE
allow custom url params on pathFor() JS links

### DIFF
--- a/core/app/assets/javascripts/spree.js.coffee.erb
+++ b/core/app/assets/javascripts/spree.js.coffee.erb
@@ -12,7 +12,7 @@ class window.Spree
 
   @pathFor: (path) ->
     locationOrigin = "#{window.location.protocol}//#{window.location.hostname}" + (if window.location.port then ":#{window.location.port}" else "")
-    "#{locationOrigin}#{@mountedAt()}#{path}"
+    @url("#{locationOrigin}#{@mountedAt()}#{path}", @url_params).toString()
 
   # Helper function to take a URL and add query parameters to it
   # Uses the JSUri library from here: https://github.com/derek-watson/jsUri
@@ -48,3 +48,6 @@ class window.Spree
     states_search: @pathFor('api/v1/states')
     apply_coupon_code: (order_id) ->
       Spree.pathFor("api/v1/orders/#{order_id}/apply_coupon_code")
+
+  @url_params:
+    {}


### PR DESCRIPTION
this changes nothing on Spree but will be used by spree_i18n to make JS urls locale-aware.
see https://github.com/spree-contrib/spree_i18n/issues/569
