### PR TITLE
Add GA user id tracking (2-3-stable)

### DIFF
--- a/core/config/initializers/user_class_extensions.rb
+++ b/core/config/initializers/user_class_extensions.rb
@@ -23,6 +23,10 @@ Spree::Core::Engine.config.to_prepare do
       def last_incomplete_spree_order
         spree_orders.incomplete.where(user_id: self.id).order('created_at DESC').first
       end
+
+      def analytics_id
+        id
+      end
     end
   end
 end

--- a/frontend/app/views/spree/shared/_google_analytics.html.erb
+++ b/frontend/app/views/spree/shared/_google_analytics.html.erb
@@ -5,7 +5,11 @@
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-    ga('create', '<%= tracker.analytics_id %>', 'auto');
+    <% if user_analytics_id = try_spree_current_user.try(:analytics_id) %>
+      ga('create', { 'trackingId': '<%= tracker.analytics_id %>', 'cookieDomain': 'auto', 'userId': '<%= user_analytics_id %>' });
+    <% else %>
+      ga('create', '<%= tracker.analytics_id %>', 'auto');
+    <% end %>
     ga('require', 'displayfeatures');
     ga('send', 'pageview');
 


### PR DESCRIPTION
This is for 2-3-stable.  If its desired / accepted, I'll push up one for master, 2-4, 3-0, etc.

See [GA's docs](https://developers.google.com/analytics/devguides/collection/analyticsjs/user-id) for more info on the feature.  They say it should be **a unique, persistent, and non-personally identifiable ID string representing a user**, hence the actual ID value, and not email or something.
