### PR TITLE
Handle case when `date.month_names' translation is missing

### DIFF
--- a/backend/app/views/spree/admin/shared/_translations.html.erb
+++ b/backend/app/views/spree/admin/shared/_translations.html.erb
@@ -20,7 +20,8 @@
     :find_a_taxon             => Spree.t(:find_a_taxon),
     :item_stock_placeholder   => Spree.t(:choose_location),
     :loading                  => Spree.t(:loading),
-    :month_names              => I18n.t(:month_names, :scope => :date).reject(&:blank?),
+    :month_names              => I18n.t(:month_names, :scope => :date).instance_eval {|o|
+                                     o.try(:reject, &:blank?) || o},
     :more                     => Spree.t(:more),
     :name                     => Spree.t(:name),
     :next                     => Spree.t(:next),


### PR DESCRIPTION
Fixes unhandled situation when translation record for `'date.month_names'` is missing.
`I18.t` returns then `String` instance, which obviously does not respond to `:reject` method so it leads to `NoMethodError` exception and Rails template rendering error.
