### PR TITLE
Fix spec determinism

### DIFF
--- a/api/app/views/spree/api/v1/orders/show.v1.rabl
+++ b/api/app/views/spree/api/v1/orders/show.v1.rabl
@@ -25,9 +25,8 @@ child :payments => :payments do
   end
 
   child :source => :source do
-    attributes *payment_source_attributes
     if @current_user_roles.include?('admin')
-      attributes *payment_source_attributes.concat([:gateway_customer_profile_id, :gateway_payment_profile_id])
+      attributes *payment_source_attributes + [:gateway_customer_profile_id, :gateway_payment_profile_id]
     else
       attributes *payment_source_attributes
     end

--- a/api/spec/controllers/spree/api/v1/products_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/products_controller_spec.rb
@@ -433,7 +433,7 @@ module Spree
 
         it "puts the updated product in the given taxons" do
           api_put :update, id: product.to_param, product: { taxon_ids: [taxon_1.id, taxon_2.id] }
-          expect(json_response["taxon_ids"]).to eq([taxon_1.id, taxon_2.id])
+          expect(json_response["taxon_ids"].to_set).to eql([taxon_1.id, taxon_2.id].to_set)
         end
       end
 

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -174,6 +174,13 @@ describe Spree::Admin::OrdersController, type: :controller do
     let(:user) { create(:user) }
     let(:order) { create(:completed_order_with_totals, number: 'R987654321') }
 
+    def with_ability(ability)
+      Spree::Ability.register_ability(ability)
+      yield
+    ensure
+      Spree::Ability.remove_ability(ability)
+    end
+
     before do
       allow(Spree::Order).to receive_messages find: order
       allow(controller).to receive_messages spree_current_user: user
@@ -186,23 +193,23 @@ describe Spree::Admin::OrdersController, type: :controller do
     end
 
     it 'should grant access to users with an bar role' do
-      user.spree_roles << Spree::Role.find_or_create_by(name: 'bar')
-      Spree::Ability.register_ability(BarAbility)
-      spree_post :index
-      expect(response).to render_template :index
-      Spree::Ability.remove_ability(BarAbility)
+      with_ability(BarAbility) do
+        user.spree_roles << Spree::Role.find_or_create_by(name: 'bar')
+        spree_post :index
+        expect(response).to render_template :index
+      end
     end
 
     it 'should deny access to users with an bar role' do
-      allow(order).to receive(:update_attributes).and_return true
-      allow(order).to receive(:user).and_return Spree.user_class.new
-      allow(order).to receive(:token).and_return nil
-      user.spree_roles.clear
-      user.spree_roles << Spree::Role.find_or_create_by(name: 'bar')
-      Spree::Ability.register_ability(BarAbility)
-      spree_put :update, id: order.number
-      expect(response).to redirect_to('/unauthorized')
-      Spree::Ability.remove_ability(BarAbility)
+      with_ability(BarAbility) do
+        allow(order).to receive(:update_attributes).and_return true
+        allow(order).to receive(:user).and_return Spree.user_class.new
+        allow(order).to receive(:token).and_return nil
+        user.spree_roles.clear
+        user.spree_roles << Spree::Role.find_or_create_by(name: 'bar')
+        spree_put :update, id: order.number
+        expect(response).to redirect_to('/unauthorized')
+      end
     end
 
     it 'should deny access to users without an admin role' do
@@ -216,14 +223,15 @@ describe Spree::Admin::OrdersController, type: :controller do
 
       3.times { create(:completed_order_with_totals) }
       expect(Spree::Order.complete.count).to eq 4
-      Spree::Ability.register_ability(OrderSpecificAbility)
 
-      allow(user).to receive_messages has_spree_role?: false
-      spree_get :index
-      expect(response).to render_template :index
-      expect(assigns['orders'].size).to eq 1
-      expect(assigns['orders'].first.number).to eq number
-      expect(Spree::Order.accessible_by(Spree::Ability.new(user), :index).pluck(:number)).to eq  [number]
+      with_ability(OrderSpecificAbility) do
+        allow(user).to receive_messages has_spree_role?: false
+        spree_get :index
+        expect(response).to render_template :index
+        expect(assigns['orders'].size).to eq 1
+        expect(assigns['orders'].first.number).to eq number
+        expect(Spree::Order.accessible_by(Spree::Ability.new(user), :index).pluck(:number)).to eq  [number]
+      end
     end
   end
 

--- a/backend/spec/features/admin/configuration/states_spec.rb
+++ b/backend/spec/features/admin/configuration/states_spec.rb
@@ -9,19 +9,10 @@ describe "States", type: :feature do
     @hungary = Spree::Country.create!(:name => "Hungary", :iso_name => "Hungary")
   end
 
-  # TODO: For whatever reason, rendering of the states page takes a non-trivial amount of time
-  # Therefore we navigate to it, and wait until what we see is visible
   def go_to_states_page
     visit spree.admin_country_states_path(country)
-    counter = 0
-    until page.has_css?("#new_state_link")
-      if counter < 10
-        sleep(2)
-        counter += 1
-      else
-        raise "Could not see new state link!"
-      end
-    end
+    expect(page).to have_selector('#new_state_link')
+    page.execute_script('$.fx.off = true')
   end
 
   context "admin visiting states listing" do
@@ -51,7 +42,7 @@ describe "States", type: :feature do
       set_select2_field "#country", @hungary.id
       # Just so the change event actually gets triggered in this spec
       # It is definitely triggered in the "real world"
-      page.execute_script("$('#country').trigger('change');")
+      page.execute_script("$('#country').change();")
 
       click_link "new_state_link"
       fill_in "state_name", with: "Pest megye"

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -45,6 +45,9 @@ require 'paperclip/matchers'
 require 'capybara/poltergeist'
 Capybara.javascript_driver = :poltergeist
 
+# Set timeout to something high enough to allow CI to pass
+Capybara.default_wait_time = 10
+
 RSpec.configure do |config|
   config.color = true
   config.fail_fast = ENV['FAIL_FAST'] || false

--- a/build-ci.rb
+++ b/build-ci.rb
@@ -82,7 +82,7 @@ private
   # @return [Boolean]
   #   the success of the tests
   def run_tests
-    system(%w[bundle exec rspec spec])
+    system(%w[bundle exec rspec spec --order random])
   end
 
   # Execute system command via execve

--- a/core/lib/spree/testing_support/common_rake.rb
+++ b/core/lib/spree/testing_support/common_rake.rb
@@ -16,15 +16,10 @@ namespace :common do
     Spree::InstallGenerator.start ["--lib_name=#{ENV['LIB_NAME']}", "--auto-accept", "--migrate=false", "--seed=false", "--sample=false", "--quiet", "--user_class=#{args[:user_class]}"]
 
     puts "Setting up dummy database..."
-    cmd = "bundle exec rake db:drop db:create db:migrate"
+    system("bundle exec rake db:drop db:create db:migrate > #{File::NULL}")
 
-    if RUBY_PLATFORM =~ /mswin|mingw/ # windows
-      cmd += " >nul"
-    else
-      cmd += " >/dev/null"
-    end
-
-    system(cmd)
+    puts "Precompiling assets..."
+    system("bundle exec rake assets:precompile > #{File::NULL}")
 
     begin
       require "generators/#{ENV['LIB_NAME']}/install/install_generator"

--- a/core/spec/mailers/order_mailer_spec.rb
+++ b/core/spec/mailers/order_mailer_spec.rb
@@ -5,6 +5,8 @@ describe Spree::OrderMailer, :type => :mailer do
   include EmailSpec::Helpers
   include EmailSpec::Matchers
 
+  before { create(:store) }
+
   let(:order) do
     order = stub_model(Spree::Order)
     product = stub_model(Spree::Product, :name => %Q{The "BEST" product})

--- a/core/spec/mailers/shipment_mailer_spec.rb
+++ b/core/spec/mailers/shipment_mailer_spec.rb
@@ -5,6 +5,8 @@ describe Spree::ShipmentMailer, :type => :mailer do
   include EmailSpec::Helpers
   include EmailSpec::Matchers
 
+  before { create(:store) }
+
   let(:shipment) do
     order = stub_model(Spree::Order)
     product = stub_model(Spree::Product, :name => %Q{The "BEST" product})

--- a/core/spec/mailers/test_mailer_spec.rb
+++ b/core/spec/mailers/test_mailer_spec.rb
@@ -5,6 +5,8 @@ describe Spree::TestMailer, :type => :mailer do
   include EmailSpec::Helpers
   include EmailSpec::Matchers
 
+  before { create(:store) }
+
   let(:user) { create(:user) }
 
   context ":from not set explicitly" do

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -4,6 +4,8 @@ describe Spree::LineItem, :type => :model do
   let(:order) { create :order_with_line_items, line_items_count: 1 }
   let(:line_item) { order.line_items.first }
 
+  before { create(:store) }
+
   context '#save' do
     it 'touches the order' do
       expect(line_item.order).to receive(:touch)

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -4,6 +4,8 @@ require 'spree/testing_support/order_walkthrough'
 describe Spree::Order, :type => :model do
   let(:order) { Spree::Order.new }
 
+  before { create(:store) }
+
   def assert_state_changed(order, from, to)
     state_change_exists = order.state_changes.where(:previous_state => from, :next_state => to).exists?
     assert state_change_exists, "Expected order to transition from #{from} to #{to}, but didn't."

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -41,8 +41,13 @@ describe Spree::Order, :type => :model do
 
     it '.remove_transition' do
       options = {:from => transitions.first.keys.first, :to => transitions.first.values.first}
-      allow(Spree::Order).to receive(:next_event_transition).and_return([options])
+      expect(Spree::Order).to receive_messages(
+        removed_transitions:    [],
+        next_event_transitions: transitions.dup
+      )
       expect(Spree::Order.remove_transition(options)).to be_truthy
+      expect(Spree::Order.removed_transitions).to eql([options])
+      expect(Spree::Order.next_event_transitions).to_not include(transitions.first)
     end
 
     it '.remove_transition when contract was broken' do

--- a/core/spec/models/spree/order/finalizing_spec.rb
+++ b/core/spec/models/spree/order/finalizing_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 describe Spree::Order, :type => :model do
   let(:order) { stub_model("Spree::Order") }
 
+  before { create(:store) }
+
   context "#finalize!" do
     let(:order) { Spree::Order.create(email: 'test@example.com') }
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -11,6 +11,7 @@ describe Spree::Order, :type => :model do
   let(:order) { stub_model(Spree::Order, :user => user) }
 
   before do
+    create(:store)
     allow(Spree::LegacyUser).to receive_messages(:current => mock_model(Spree::LegacyUser, :id => 123))
   end
 

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -29,14 +29,10 @@ describe Spree::Product, :type => :model do
       end
 
       it 'calls #duplicate_extra' do
-        Spree::Product.class_eval do
-          def duplicate_extra(old_product)
-            self.name = old_product.name.reverse
-          end
-        end
-
-        clone = product.duplicate
-        expect(clone.name).to eq(product.name.reverse)
+        expect_any_instance_of(Spree::Product).to receive(:duplicate_extra)
+          .with(product)
+        expect(product).to_not receive(:duplicate_extra)
+        product.duplicate
       end
     end
 

--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -55,4 +55,19 @@ RSpec.configure do |config|
 
   config.include FactoryGirl::Syntax::Methods
   config.include Spree::TestingSupport::Preferences
+
+  # Clean out the database state before the tests run
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  # Wrap all db isolated tests in a transaction
+  config.around(db: :isolate) do |example|
+    DatabaseCleaner.cleaning(&example)
+  end
+
+  config.around do |example|
+    Timeout.timeout(10, &example)
+  end
 end

--- a/frontend/spec/features/cart_spec.rb
+++ b/frontend/spec/features/cart_spec.rb
@@ -34,8 +34,9 @@ describe "Cart", type: :feature, inaccessible: true do
     visit spree.root_path
     click_link "RoR Mug"
     click_button "add-to-cart-button"
+    line_item = Spree::LineItem.first!
     within("#line_items") do
-      click_link "delete_line_item_1"
+      click_link "delete_line_item_#{line_item.id}"
     end
 
     expect(page).to_not have_content("Line items quantity must be an integer")
@@ -77,6 +78,7 @@ describe "Cart", type: :feature, inaccessible: true do
       expect(page).to have_content(product.name)
     end
   end
+
   it "should have a surrounding element with data-hook='cart_container'" do
     visit spree.cart_path
     expect(page).to have_selector("div[data-hook='cart_container']")

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -74,6 +74,13 @@ RSpec.configure do |config|
     end
   end
 
+  # Ensure DB is clean, so that transaction isolated specs see
+  # pristine state.
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :truncation
+    DatabaseCleaner.clean
+  end
+
   config.before(:each) do
     WebMock.disable!
     if RSpec.current_example.metadata[:js]


### PR DESCRIPTION
This PR upstreams the fixes for (almost) all sources of indeterminism we found in the 2-3-stable branch

I see that master build on CircleCI are still affected by all sorts of indeterminism, and sporadic failures. Many of these should go away with this PR.

We also add `--order random` rspec option to the builds on Circle (note NOT to the developers local spec runs, but we highly recommend to do so soon) with this PR allowing to identify even more sources of indeterminism.

For our 2-3-stable fork this patch set reduced the "random failure rate" by both headless and more unit a like specs by a magnitude.

I'll remove the `[WIP]` tag in this branches title once all builds for each commit are green against master.
