### PR TITLE
Increase scale on `pre_tax_amount` columns

### DIFF
--- a/core/db/migrate/20150609093816_increase_scale_on_pre_tax_amounts.rb
+++ b/core/db/migrate/20150609093816_increase_scale_on_pre_tax_amounts.rb
@@ -1,0 +1,6 @@
+class IncreaseScaleOnPreTaxAmounts < ActiveRecord::Migration
+  def change
+    change_column :spree_line_items, :pre_tax_amount, :decimal, precision: 12, scale: 4, default: 0.0, null: false
+    change_column :spree_shipments, :pre_tax_amount, :decimal, precision: 12, scale: 4, default: 0.0, null: false
+  end
+end

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -269,4 +269,12 @@ describe Spree::LineItem, :type => :model do
       expect(line_item.price).to eq 21.98
     end
   end
+
+  describe "precision of pre_tax_amount" do
+    let!(:line_item) { create :line_item, pre_tax_amount: 4.2051 }
+
+    it "keeps four digits of precision even when reloading" do
+      expect(line_item.reload.pre_tax_amount).to eq(4.2051)
+    end
+  end
 end

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -27,6 +27,15 @@ describe Spree::Shipment, :type => :model do
       variant_id: order.line_items.first.variant_id,
       line_item_id: order.line_items.first.id
     )
+
+  end
+
+  describe "precision of pre_tax_amount" do
+    let!(:line_item) { create :line_item, pre_tax_amount: 4.2051 }
+
+    it "keeps four digits of precision even when reloading" do
+      expect(line_item.reload.pre_tax_amount).to eq(4.2051)
+    end
   end
 
   # Regression test for #4063


### PR DESCRIPTION
The `pre_tax_amount` column is used when calculating VATs. When the
precision is too low for this field, rounding errors occur.

For a line item with a price of 4.92 $ and a tax rate of 17%, the
calculation has to go like this:

```
4.92 / 1.17 = 4.205128205128205
line_item.save
-->
    pre_tax_amount: 4.205128205128205
    pre_tax_amount (rounded): 4.21
    included_tax_amount 71 ct.
    amount 4.92
```

Without this PR, whenever the line item is saved and reloaded, and then
the taxes are re-calculated, the calculation wrongly goes like this:

```
4.92 / 1.17 = 4.205128205128205
line_item.save
-->
    pre_tax_amount: 4.21
    included_tax_amount: 72 ct.
    amount: 4.92
```

That's an error: `4.21 + 72 != 2.92`.

This should not affect any display_\* methods, as those use
`Spree::Money`, which takes care of good rounding.
