### PR TITLE
update product legacy url redirect

### DIFF
--- a/frontend/spec/controllers/spree/products_controller_spec.rb
+++ b/frontend/spec/controllers/spree/products_controller_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe Spree::ProductsController, :type => :controller do
   let!(:product) { create(:product, :available_on => 1.year.from_now) }
+  let(:taxon) { create(:taxon) }
 
   # Regression test for #1390
   it "allows admins to view non-active products" do
@@ -51,6 +52,16 @@ describe Spree::ProductsController, :type => :controller do
       product.save!
       spree_get :show, id: product.id
       expect(response.status).to eq(301)
+    end
+
+    it "will keep url params on legacy url redirect" do
+      legacy_params = product.to_param
+      product.name = product.name + " Brand New"
+      product.slug = nil
+      product.save!
+      spree_get :show, id: legacy_params, taxon_id: taxon.id
+      expect(response.status).to eq(301)
+      expect(response.header["Location"]).to include("taxon_id=#{taxon.id}")
     end
   end
 end


### PR DESCRIPTION
i like the idea of this change https://github.com/spree/spree/commit/bb111595221f90caa3a688155825fb49071f9a33 but i think this should be improved:
- we must always keep all url params on redirect, like `taxon_id=` or any custom one.
- in some cases `request.path` is not the same as the actual browser url because of some rack filter and this lead to the worst thing: infinite loops. 
  one example is spree_i18n where the path comes with the locale prefix https://github.com/spree-contrib/spree_i18n/issues/589

~~the attached code fixes both this problems but i'm not totally sure that using `request.original_fullpath` will work for 100% of the stacks...~~

/cc @peterberkenbosch 
