### PR TITLE
API Orders - Display Adjustment Total was missing from the nodes

### DIFF
--- a/api/app/views/spree/api/v1/orders/order.v1.rabl
+++ b/api/app/views/spree/api/v1/orders/order.v1.rabl
@@ -5,5 +5,6 @@ node(:total_quantity) { |o| o.line_items.sum(:quantity) }
 node(:display_total) { |o| o.display_total.to_s }
 node(:display_ship_total) { |o| o.display_ship_total }
 node(:display_tax_total) { |o| o.display_tax_total }
+node(:display_adjustment_total) { |o| o.display_adjustment_total }
 node(:token) { |o| o.guest_token }
 node(:checkout_steps) { |o| o.checkout_steps }


### PR DESCRIPTION
Adjustment total is shown but not its display counterpart, unlike all the other totals.
