### PR TITLE
Rails 4.1.11 security patch (2-4-stable)

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'paperclip', '~> 4.2.0'
   s.add_dependency 'paranoia', '~> 2.1.0'
   s.add_dependency 'premailer-rails'
-  s.add_dependency 'rails', '4.1.9'
+  s.add_dependency 'rails', '~> 4.1.11'
   s.add_dependency 'ransack', '~> 1.4.1'
   s.add_dependency 'state_machine', '1.2.0'
   s.add_dependency 'stringex', '~> 1.5.1'


### PR DESCRIPTION
This allows `bundle update` to run correctly and pick up the security releases from 2015-06-16.
