### PR TITLE
Rails 4.2.2 security patch (3-0-stable)

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'paperclip', '~> 4.2.0'
   s.add_dependency 'paranoia', '~> 2.1.0'
   s.add_dependency 'premailer-rails'
-  s.add_dependency 'rails', '~> 4.2.0'
+  s.add_dependency 'rails', '~> 4.2.2'
   s.add_dependency 'ransack', '~> 1.4.1'
   s.add_dependency 'responders'
   s.add_dependency 'state_machines-activerecord', '~> 0.2'


### PR DESCRIPTION
This picks up the security releases from 2015-06-16.
