### PR TITLE
CVE-2015-3226 (Rails bumps to 4.1.11)

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'monetize', '~> 1.1'
   s.add_dependency 'paperclip', '~> 4.2.0'
   s.add_dependency 'paranoia', '~> 2.0.5'
-  s.add_dependency 'rails', '4.1.9'
+  s.add_dependency 'rails', '4.1.11'
   s.add_dependency 'ransack', '~> 1.4.1'
   s.add_dependency 'state_machine', '1.2.0'
   s.add_dependency 'stringex', '~> 1.5.1'


### PR DESCRIPTION
@JDutil -- Not sure how you handle these, bug we have a zero-day vulnerability (announced about 1 ½ hours ago by Rails-security)

Might it be easier for the community if Spree was locked only to the version release (4.1) and not the bugfix release (4.1.11) ?  That way I wouldn't have to wait for you to assemble the patch before pushing this live. 
