### PR TITLE
Wrap product taxons partial in hook

### DIFF
--- a/frontend/app/views/spree/products/_taxons.html.erb
+++ b/frontend/app/views/spree/products/_taxons.html.erb
@@ -1,10 +1,8 @@
 <% if @product.taxons.present? %>
   <h3 class="product-section-title"><%= Spree.t(:look_for_similar_items) %></h3>
-  <div data-hook>
-    <ul class="list-group" id="similar_items_by_taxon" data-hook>
-      <% @product.taxons.each do |taxon| %>
-        <li class="list-group-item"><%= link_to taxon.name, seo_url(taxon) %></li>
-      <% end %>
-    </ul>
-  </div>
+  <ul class="list-group" id="similar_items_by_taxon" data-hook>
+    <% @product.taxons.each do |taxon| %>
+      <li class="list-group-item"><%= link_to taxon.name, seo_url(taxon) %></li>
+    <% end %>
+  </ul>
 <% end %>

--- a/frontend/app/views/spree/products/_taxons.html.erb
+++ b/frontend/app/views/spree/products/_taxons.html.erb
@@ -1,4 +1,4 @@
-<% if !@product.taxons.blank? %>
+<% if @product.taxons.present? %>
   <div id="taxon-crumbs" data-hook class=" five ">
     <h3 class="product-section-title"><%= Spree.t(:look_for_similar_items) %></h3>
     <div data-hook="product_taxons">

--- a/frontend/app/views/spree/products/_taxons.html.erb
+++ b/frontend/app/views/spree/products/_taxons.html.erb
@@ -1,12 +1,10 @@
 <% if @product.taxons.present? %>
-  <div id="taxon-crumbs" data-hook class=" five ">
-    <h3 class="product-section-title"><%= Spree.t(:look_for_similar_items) %></h3>
-    <div data-hook="product_taxons">
-      <ul class="list-group" id="similar_items_by_taxon" data-hook>
-        <% @product.taxons.each do |taxon| %>
-          <li class="list-group-item"><%= link_to taxon.name, seo_url(taxon) %></li>
-        <% end %>
-      </ul>
-    </div>
+  <h3 class="product-section-title"><%= Spree.t(:look_for_similar_items) %></h3>
+  <div data-hook>
+    <ul class="list-group" id="similar_items_by_taxon" data-hook>
+      <% @product.taxons.each do |taxon| %>
+        <li class="list-group-item"><%= link_to taxon.name, seo_url(taxon) %></li>
+      <% end %>
+    </ul>
   </div>
 <% end %>

--- a/frontend/app/views/spree/products/show.html.erb
+++ b/frontend/app/views/spree/products/show.html.erb
@@ -39,7 +39,9 @@
           </div>
         </div>
 
-        <%= render :partial => 'taxons' %>
+        <div id="taxon-crumbs" class=" five " data-hook="product_taxons">
+          <%= render :partial => 'taxons' %>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Unlike the rest of `products#show`, the taxons partial had the `data-hook` div inside it, instead of outside it. This makes it more brittle to override, because in the future the partial may be re-used elsewhere and any deface overrides would override all instances of the partial, not just the products#show page.

I also swapped a double-negative conditional check inside the partial.

This is a breaking change for anyone currently overriding the partial with Deface; as that override will stop working. I'm unsure what the guidelines are about this?
