### PR TITLE
Skip layout loading on JS action

### DIFF
--- a/backend/app/controllers/spree/admin/search_controller.rb
+++ b/backend/app/controllers/spree/admin/search_controller.rb
@@ -1,9 +1,11 @@
 module Spree
   module Admin
     class SearchController < Spree::Admin::BaseController
+      respond_to :json
+      layout false
+
       # http://spreecommerce.com/blog/2010/11/02/json-hijacking-vulnerability/
       before_action :check_json_authenticity, only: :index
-      respond_to :json
 
       # TODO: Clean this up by moving searching out to user_class_extensions
       # And then JSON building with something like Active Model Serializers

--- a/backend/app/controllers/spree/admin/taxonomies_controller.rb
+++ b/backend/app/controllers/spree/admin/taxonomies_controller.rb
@@ -1,12 +1,6 @@
 module Spree
   module Admin
     class TaxonomiesController < ResourceController
-      respond_to :json, only: [:get_children]
-
-      def get_children
-        @taxons = Taxon.find(params[:parent_id]).children
-      end
-
       private
 
       def location_after_save

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -125,9 +125,6 @@ Spree::Core::Engine.add_routes do
       collection do
         post :update_positions
       end
-      member do
-        get :get_children
-      end
       resources :taxons
     end
 


### PR DESCRIPTION
Looks like we are loading the layout (and deface overrides) on json-only controller `Admin::SearchController`.
Should be ~50% faster now

Also removing some dead code.

BTW why `SearchController#products` even exists? 
Should we use `Api::ProductsController#index` ?
