### PR TITLE
While splitting, don't fire ajax call if original and target shipments are same.

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/shipments.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js.erb
@@ -246,7 +246,8 @@ completeItemSplit = function(event) {
   var target_shipment_number = selected_shipment.data('shipment-number');
   var new_shipment = selected_shipment.data('new-shipment');
 
-  if (stock_location_id != 'new_shipment') {
+  //Don't fire ajax if original and target shipments are same
+  if (original_shipment_number != target_shipment_number) {
     // first remove item(s) from original shipment
     $.ajax({
       type: "PUT",


### PR DESCRIPTION
Is this right? I am new to spree. I figured this out while I was working on my project, but I am not really sure. If this is the correct way to avoid ajax call while splitting, we can make changes in other branches too.
