### PR TITLE
Add volume methods

### DIFF
--- a/core/app/models/spree/stock/content_item.rb
+++ b/core/app/models/spree/stock/content_item.rb
@@ -43,6 +43,10 @@ module Spree
         # but this massively simplifies things for now
         1
       end
+
+      def volume
+        variant.volume * quantity
+      end
     end
   end
 end

--- a/core/app/models/spree/stock/package.rb
+++ b/core/app/models/spree/stock/package.rb
@@ -91,6 +91,10 @@ module Spree
       def contents_by_weight
         contents.sort { |x, y| y.weight <=> x.weight }
       end
+
+      def volume
+        contents.sum(&:volume)
+      end
     end
   end
 end

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -43,6 +43,14 @@ module Spree
 
     scope :in_stock, -> { joins(:stock_items).where('count_on_hand > ? OR track_inventory = ?', 0, false) }
 
+    LOCALIZED_NUMBERS = %w(cost_price weight depth width height)
+
+    LOCALIZED_NUMBERS.each do |m|
+      define_method("#{m}=") do |argument|
+        self[m] = Spree::LocalizedNumber.parse(argument) if argument.present?
+      end
+    end
+
     def self.active(currency = nil)
       joins(:prices).where(deleted_at: nil).where('spree_prices.currency' => currency || Spree::Config[:currency]).where('spree_prices.amount IS NOT NULL')
     end
@@ -57,14 +65,6 @@ module Spree
       else
         TaxCategory.find(self[:tax_category_id])
       end
-    end
-
-    def cost_price=(price)
-      self[:cost_price] = Spree::LocalizedNumber.parse(price) if price.present?
-    end
-
-    def weight=(weight)
-      self[:weight] = Spree::LocalizedNumber.parse(weight) if weight.present?
     end
 
     # returns number of units currently on backorder for this variant.
@@ -211,6 +211,10 @@ module Spree
     # This considers both variant tracking flag and site-wide inventory tracking settings
     def should_track_inventory?
       self.track_inventory? && Spree::Config.track_inventory_levels
+    end
+
+    def volume
+      (width || 0) * (height || 0) * (depth || 0)
     end
 
     private

--- a/core/spec/models/spree/stock/content_item_spec.rb
+++ b/core/spec/models/spree/stock/content_item_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+module Spree
+  module Stock
+    describe ContentItem, type: :model do
+      let(:variant) { build(:variant, weight: 25.0) }
+      subject { ContentItem.new(build(:inventory_unit, variant: variant)) }
+
+      context "#volume" do
+        it "calculate the total volume of the variant" do
+          expect(subject.volume).to eq variant.volume * subject.quantity
+        end
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/stock/package_spec.rb
+++ b/core/spec/models/spree/stock/package_spec.rb
@@ -167,6 +167,17 @@ module Spree
           end
         end
       end
+
+      context "#volume" do
+        it "calculates the sum of the volume of all the items" do
+          contents = [ContentItem.new(build(:inventory_unit, variant: build(:variant))),
+                      ContentItem.new(build(:inventory_unit, variant: build(:variant))),
+                      ContentItem.new(build(:inventory_unit, variant: build(:variant))),
+                      ContentItem.new(build(:inventory_unit, variant: build(:variant)))]
+          package = Package.new(stock_location, contents)
+          expect(package.volume).to eq contents.sum(&:volume)
+        end
+      end
     end
   end
 end

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -497,4 +497,18 @@ describe Spree::Variant, :type => :model do
       expect(Spree::Variant.in_stock).to eq [in_stock_variant]
     end
   end
+
+  context "#volume" do
+    let(:variant_zero_width) { create(:variant, width: 0) }
+    let(:variant) { create(:variant) }
+
+    it "it is zero if any dimension parameter is zero" do
+      expect(variant_zero_width.volume).to eq 0
+    end
+
+    it "return the volume if the dimension parameters are different of zero" do
+      volume_expected = variant.width * variant.depth * variant.height
+      expect(variant.volume).to eq (volume_expected)
+    end
+  end
 end


### PR DESCRIPTION
While trying to create a calculator that calculate the shipping cost based on the volumetric weight, I saw the need of having a `#volume` on content item. I think that more people will be able to create this type of calculator easily.

Thanks!
