### PR TITLE
Better support for cancelling payments when order is cancelled 

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -643,6 +643,7 @@ module Spree
 
     def after_cancel
       shipments.each { |shipment| shipment.cancel! }
+      payments.pending.each { |payment| payment.cancel! } if Spree::Config[:auto_capture_on_dispatch]
       payments.completed.each { |payment| payment.cancel! }
       send_cancel_email
       self.update!

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -642,9 +642,9 @@ module Spree
     end
 
     def after_cancel
-      shipments.each { |shipment| shipment.cancel! }
-      payments.pending.each { |payment| payment.cancel! } if Spree::Config[:auto_capture_on_dispatch]
-      payments.completed.each { |payment| payment.cancel! }
+      shipments.each { &:cancel! }
+      payments.pending.each { &:cancel! } if Spree::Config[:auto_capture_on_dispatch]
+      payments.completed.each { &:cancel! }
       send_cancel_email
       self.update!
     end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -642,9 +642,9 @@ module Spree
     end
 
     def after_cancel
-      shipments.each { &:cancel! }
-      payments.pending.each { &:cancel! } if Spree::Config[:auto_capture_on_dispatch]
-      payments.completed.each { &:cancel! }
+      shipments.each(&:cancel!)
+      payments.pending.each(&:cancel!) if Spree::Config[:auto_capture_on_dispatch]
+      payments.completed.each(&:cancel!)
       send_cancel_email
       self.update!
     end

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -69,7 +69,19 @@ module Spree
       end
 
       def cancel!
-        payment_method.cancel(response_code)
+        protect_from_connection_error do
+
+          response = payment_method.cancel(response_code)
+
+          record_response(response)
+
+          if response.success?
+            self.response_code = response.authorization
+            self.void
+          else
+            gateway_error(response)
+          end
+        end
       end
 
       def gateway_options

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -70,14 +70,13 @@ module Spree
 
       def cancel!
         protect_from_connection_error do
-
           response = payment_method.cancel(response_code)
 
           record_response(response)
 
           if response.success?
             self.response_code = response.authorization
-            self.void
+            void
           else
             gateway_error(response)
           end


### PR DESCRIPTION
When the Spree::Config setting auto_capture_on_dispatch is set to true, payments are authorized, but only captured when the shipment is dispatched.

However, if that order is cancelled by the admin, the pending payment is not canceled, as it would by if auto_capture_on_dispatch was false.

This PR modifies the Spree::Order#after_cancel to also cancel any pending payments, when auto_capture_on_dispatch is true.

When a payment is canceled, the Spree::PaymentMethod#cancel is called.  However, the ActiveMerchant::Billing::Response returned by that method is ignored, and the payment's state is not modified.

This means that after cancelling a order, the payment still appears in it's original state in the Spree admin (pending or completed), while the transaction has been voided at the payment gateway.

This RP modifies Spree::Payment::Processing#cancel! to log the response from  Spree::PaymentMethod#cancel, and to void the payment on success, similar to how Spree::Payment::Processing#void! works.
