### PR TITLE
Use exchange_name for exchanged variants

### DIFF
--- a/backend/app/views/spree/admin/return_authorizations/_form.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/_form.html.erb
@@ -52,9 +52,9 @@
           <td>
             <% if editable %>
               <% if return_item.exchange_processed? %>
-                <%= return_item.exchange_variant.options_text %>
+                <%= return_item.exchange_variant.exchange_name %>
               <% else %>
-                <%= item_fields.collection_select :exchange_variant_id, return_item.eligible_exchange_variants, :id, :options_text, { include_blank: true }, { class: "select2 return-item-exchange-selection" } %>
+                <%= item_fields.collection_select :exchange_variant_id, return_item.eligible_exchange_variants, :id, :exchange_name, { include_blank: true }, { class: "select2 return-item-exchange-selection" } %>
               <% end %>
             <% end %>
           </td>


### PR DESCRIPTION
Use exchange_name instead of options_text for the case when the variant is a master (and has no options_text).

Applies to 3-0-stable and 2-4-stable.
