### PR TITLE
Fix Admin create order from user

### DIFF
--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -128,7 +128,7 @@ module Spree
       private
         def order_params
           params[:created_by_id] = try_spree_current_user.try(:id)
-          params.permit(:created_by_id)
+          params.permit(:created_by_id, :user_id)
         end
 
         def load_order


### PR DESCRIPTION
Properly creates an order from a user by permitting the user_id param.
