### PR TITLE
Introduce mutant dependency

### DIFF
--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -30,6 +30,7 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
 
 require 'database_cleaner'
 require 'ffaker'
+require 'timeout'
 
 require 'spree/testing_support/authorization_helpers'
 require 'spree/testing_support/factories'
@@ -88,6 +89,10 @@ RSpec.configure do |config|
     wait_for_ajax if RSpec.current_example.metadata[:js]
 
     DatabaseCleaner.clean
+  end
+
+  config.around do |example|
+    Timeout.timeout(20, &example)
   end
 
   config.after(:each, :type => :feature) do |example|

--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -33,6 +33,7 @@ group :test do
   gem 'poltergeist', '1.6.0'
   gem 'timecop'
   gem 'with_model'
+  gem 'mutant-rspec', '~> 0.7.9'
 end
 
 group :test, :development do

--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -68,6 +68,6 @@ RSpec.configure do |config|
   end
 
   config.around do |example|
-    Timeout.timeout(10, &example)
+    Timeout.timeout(20, &example)
   end
 end


### PR DESCRIPTION
As explained in a longer [comment](https://github.com/MountainRoseHerbs/spree/commit/46908180cfa24d4988c079bec65985ca9c5c3404#commitcomment-11756438) we develop all our changes on top of spree under mutation coverage via [mutant](https://github.com/mbj/mutant).

Having to constantly push and pop the mutant setup from our branches against master (to validate the upstream change) in between to adapting our changes that had been developed against `2-3-stable` against master hurts.

For reducing that pain I'd like to get the (minimal) setup merged.

What this change does:
- Adds the gem dependency
- Sets up a unit test timeout to kill mutations to infinite loops "deterministically" (as deterministic timeouts under ruby are) The timeout was choosen to work well under CircleCI. On less DB heavy tests it can be much smaller, but finer granularity can be done later.

What this change does NOT:
- Force contributors to use mutant (I can highly recommend it, but thats another topic)
- Change the CI to assert a specific amount of mutation coverage before passing the build

Advice on running mutant against spree subprojects:

``` bash
cd $subproject
bundle exec rake test_app
RAILS_ENV=test bundle exec mutant -r ./spec/dummy/config/environment.rb -j1 --use rspec $your_subject_match_expression # Like Spree::User#some_method
```

`-j1` because sprees heavy database dependent tests do not work well under mutants concurrency, and there is no concurrency aware DB isolation strategy setup that works universally (I'll maybe PR it later) on subjects that are not DB dependent it can be left out to get more speed.
