### PR TITLE
Link to "Return Authorization" instead of "Returns"

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1139,7 +1139,6 @@ en:
     return_number: Return Number
     return_quantity: Return Quantity
     returned: Returned
-    returns: Returns
     review: Review
     risk: Risk
     risk_analysis: Risk Analysis


### PR DESCRIPTION
On the edit order page, there's a link to the order's return authorizations.
This link is translated as "returns", which is confusing (the German translation
for example now has two links both saying "customer returns").

The key is only ever used in this instance, so when we change it to RMAs,
we can get rid of one translation key.
