### PR TITLE
Use symbol for variable `current` in views

### DIFF
--- a/backend/app/views/spree/admin/adjustments/edit.html.erb
+++ b/backend/app/views/spree/admin/adjustments/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current =>  Spree.t(:adjustments) } %>
+<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: :adjustments } %>
 
 <% content_for :page_title do %>
   / <%= Spree.t(:edit) %> <%= Spree.t(:adjustment) %>

--- a/backend/app/views/spree/admin/adjustments/index.html.erb
+++ b/backend/app/views/spree/admin/adjustments/index.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: Spree.t(:adjustments)} %>
+<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: :adjustments} %>
 
 <% content_for :page_title do %>
    / <%= plural_resource_name(Spree::Adjustment) %>
@@ -10,7 +10,7 @@
 
 <% if @adjustments.present? %>
   <div class="panel panel-default">
-    <%= render :partial => 'adjustments_table' %>
+    <%= render partial: 'adjustments_table' %>
   </div>
 <% else %>
   <div class="alert alert-warning">
@@ -23,7 +23,7 @@
     <div class="form-group">
       <%= text_field_tag "coupon_code", "", placeholder: Spree.t(:coupon_code), class: "form-control" %>
     </div>
-    <%= button Spree.t(:add_coupon_code), 'plus', 'submit', :id => "add_coupon_code" %>
+    <%= button Spree.t(:add_coupon_code), 'plus', 'submit', id: "add_coupon_code" %>
   </div>
 <% end %>
 

--- a/backend/app/views/spree/admin/adjustments/new.html.erb
+++ b/backend/app/views/spree/admin/adjustments/new.html.erb
@@ -1,19 +1,19 @@
-<%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => Spree.t(:adjustments) } %>
+<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: :adjustments } %>
 
 <% content_for :page_title do %>
   / <%= Spree.t(:new_adjustment) %>
 <% end %>
 
-<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @adjustment } %>
+<%= render partial: 'spree/admin/shared/error_messages', locals: { target: @adjustment } %>
 
-<%= form_for @adjustment, :url => admin_order_adjustments_path do |f| %>
+<%= form_for @adjustment, url: admin_order_adjustments_path do |f| %>
   <fieldset>
-    <%= render :partial => 'form', :locals => { :f => f } %>
+    <%= render partial: 'form', locals: { f: f } %>
 
     <div class="form-actions" data-hook="buttons">
       <%= button Spree.t(:continue), 'save' %>
       <span class="or"><%= Spree.t(:or) %></span>
-      <%= button_link_to Spree.t('actions.cancel'), spree.admin_order_adjustments_url(@order), :icon => 'delete' %>
+      <%= button_link_to Spree.t('actions.cancel'), spree.admin_order_adjustments_url(@order), icon: 'delete' %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/customer_returns/edit.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => Spree.t(:customer_returns) } %>
+<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: :customer_returns } %>
 
 <% content_for :page_title do %>
   / <%= Spree.t(:customer_return) %> #<%= @customer_return.number %>

--- a/backend/app/views/spree/admin/customer_returns/index.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/index.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => Spree.t(:customer_returns) } %>
+<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: :customer_returns } %>
 
 <% content_for :page_actions do %>
   <% if @order.shipments.any?(&:shipped?) && can?(:create, Spree::CustomerReturn) %>

--- a/backend/app/views/spree/admin/customer_returns/new.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/new.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => Spree.t(:customer_returns) } %>
+<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: :customer_returns } %>
 
 <% content_for :page_title do %>
   / <%= Spree.t(:new_customer_return) %>
@@ -6,7 +6,7 @@
 
 <% if @rma_return_items.any? %>
 
-  <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @customer_return } %>
+  <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @customer_return } %>
 
   <%= form_for [:admin, @order, @customer_return] do |f| %>
     <fieldset class="no-border-top">
@@ -32,7 +32,7 @@
       <div class="form-actions" data-hook="buttons">
         <%= button Spree.t(:create), 'save' %>
         <span class="or"><%= Spree.t(:or) %></span>
-        <%= button_link_to Spree.t('actions.cancel'), spree.admin_order_customer_returns_url(@order), :icon => 'delete' %>
+        <%= button_link_to Spree.t('actions.cancel'), spree.admin_order_customer_returns_url(@order), icon: 'delete' %>
       </div>
     </fieldset>
   <% end %>

--- a/backend/app/views/spree/admin/images/edit.html.erb
+++ b/backend/app/views/spree/admin/images/edit.html.erb
@@ -1,8 +1,8 @@
-<%= render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => 'Images' } %>
+<%= render partial: 'spree/admin/shared/product_tabs', locals: { current: :images } %>
 
-<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @image } %>
+<%= render partial: 'spree/admin/shared/error_messages', locals: { target: @image } %>
 
-<%= form_for [:admin, @product, @image], :html => { :multipart => true } do |f| %>
+<%= form_for [:admin, @product, @image], html: { multipart: true } do |f| %>
   <div data-hook="edit_image" class="panel panel-default">
     <div class="panel-heading">
       <h1 class="panel-title">
@@ -16,13 +16,13 @@
           <%= link_to image_tag(@image.attachment.url(:small)), @image.attachment.url(:product) %>
         </div>
         <div class="col-md-9">
-          <%= render :partial => 'form', :locals => { :f => f } %>
+          <%= render partial: 'form', locals: { f: f } %>
         </div>
 
         <div class="form-actions" data-hook="buttons">
           <%= button Spree.t('actions.update'), 'save' %>
           <span class="or"><%= Spree.t(:or) %></span>
-          <%= button_link_to Spree.t('actions.cancel'), spree.admin_product_images_url(@product), :id => 'cancel_link', :icon => 'delete' %>
+          <%= button_link_to Spree.t('actions.cancel'), spree.admin_product_images_url(@product), id: 'cancel_link', icon: 'delete' %>
         </div>
       </div>
     </div>

--- a/backend/app/views/spree/admin/images/index.html.erb
+++ b/backend/app/views/spree/admin/images/index.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'spree/admin/shared/product_tabs', locals: { current: 'Images' } %>
+<%= render partial: 'spree/admin/shared/product_tabs', locals: { current: :images } %>
 
 <% content_for :page_actions do %>
   <%= button_link_to(Spree.t(:new_image), spree.new_admin_product_image_url(@product), { class: "btn-success", icon: 'add', id: 'new_image_link' }) if can? :create, Spree::Image %>

--- a/backend/app/views/spree/admin/log_entries/index.html.erb
+++ b/backend/app/views/spree/admin/log_entries/index.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/order_tabs', locals: { current: 'Payments' }%>
+<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: :payments }%>
 
 <% content_for :page_title do %>
   /
@@ -8,7 +8,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:logs), spree.admin_order_payment_log_entries_url(@order, @payment), :icon => 'file' %>
+  <%= button_link_to Spree.t(:logs), spree.admin_order_payment_log_entries_url(@order, @payment), icon: 'file' %>
 <% end %>
 
 <table class="table" id='listing_log_entries'>

--- a/backend/app/views/spree/admin/orders/cart.html.erb
+++ b/backend/app/views/spree/admin/orders/cart.html.erb
@@ -3,21 +3,21 @@
     <%= event_links %>
   <% end %>
   <% if can?(:resend, @order) %>
-    <%= button_link_to Spree.t(:resend), resend_admin_order_url(@order), :method => :post, :icon => 'envelope' %>
+    <%= button_link_to Spree.t(:resend), resend_admin_order_url(@order), method: :post, icon: 'envelope' %>
   <% end %>
 <% end %>
 
-<%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Cart' } %>
+<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: :cart } %>
 
 <div data-hook="admin_order_edit_header">
-  <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @order } %>
+  <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @order } %>
 </div>
 
 <% if @order.payments.exists? && @order.considered_risky? %>
   <%= render 'spree/admin/orders/risk_analysis', latest_payment: @order.payments.order("created_at DESC").first %>
 <% end %>
 
-<%= render :partial => 'add_line_item' if can?(:update, @order) %>
+<%= render partial: 'add_line_item' if can?(:update, @order) %>
 
 <% if @order.line_items.empty? %>
   <div class="alert alert-warning">
@@ -27,7 +27,7 @@
 
 <div data-hook="admin_order_edit_form">
   <div id="order-form-wrapper">
-    <%= render :partial => 'line_items_edit_form', :locals => { :order => @order } %>
+    <%= render partial: 'line_items_edit_form', locals: { order: @order } %>
   </div>
 </div>
 

--- a/backend/app/views/spree/admin/orders/customer_details/edit.html.erb
+++ b/backend/app/views/spree/admin/orders/customer_details/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: 'Customer Details' } %>
+<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: :customer_details } %>
 
 <% content_for :page_title do %>
   / <%= Spree.t(:customer_details) %>

--- a/backend/app/views/spree/admin/orders/edit.html.erb
+++ b/backend/app/views/spree/admin/orders/edit.html.erb
@@ -7,7 +7,7 @@
   <% end %>
 <% end %>
 
-<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: 'Shipments' } %>
+<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: :shipments } %>
 
 <% content_for :page_title do %>
   / <%= plural_resource_name(Spree::Shipment) %>

--- a/backend/app/views/spree/admin/payments/credit.html.erb
+++ b/backend/app/views/spree/admin/payments/credit.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Creditcards' } %>
+<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: :credit_cards } %>
 
 <% content_for :page_title do %>
   / <%= Spree.t(:refund) %>

--- a/backend/app/views/spree/admin/payments/index.html.erb
+++ b/backend/app/views/spree/admin/payments/index.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: "Payments" } %>
+<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: :payments } %>
 
 <% content_for :page_actions do %>
   <% if @order.outstanding_balance? && can?(:create, Spree::Payment) %>

--- a/backend/app/views/spree/admin/payments/new.html.erb
+++ b/backend/app/views/spree/admin/payments/new.html.erb
@@ -1,15 +1,15 @@
-<%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Payments' } %>
+<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: :payments } %>
 
 <% content_for :page_title do %>
   / <%= Spree.t(:new_payment) %>
 <% end %>
 
 <% if @payment_methods.any? %>
-  <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @payment } %>
+  <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @payment } %>
 
-  <%= form_for @payment, :url => admin_order_payments_path(@order) do |f| %>
+  <%= form_for @payment, url: admin_order_payments_path(@order) do |f| %>
     <fieldset>
-      <%= render :partial => 'form', :locals => { :f => f } %>
+      <%= render partial: 'form', locals: { f: f } %>
 
       <div class="form-actions" data-hook="buttons">
         <%= button @order.cart? ? Spree.t('actions.continue') : Spree.t('actions.update'), @order.cart? ? 'arrow-right' : 'save' %>

--- a/backend/app/views/spree/admin/payments/show.html.erb
+++ b/backend/app/views/spree/admin/payments/show.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Payments' } %>
+<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: :payments } %>
 
 <% content_for :page_title do %>
   /
@@ -7,17 +7,17 @@
   <%= payment_method_name(@payment) %>
   /
   <span class="state <%= @payment.state %>">
-    <%= Spree.t(@payment.state, :scope => :payment_states, :default => @payment.state.capitalize) %>
+    <%= Spree.t(@payment.state, scope: :payment_states, default: @payment.state.capitalize) %>
   </span>
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:logs), spree.admin_order_payment_log_entries_url(@order, @payment), :icon => 'file' %>
+  <%= button_link_to Spree.t(:logs), spree.admin_order_payment_log_entries_url(@order, @payment), icon: 'file' %>
 <% end %>
 
-<%= render :partial => "spree/admin/payments/source_views/#{@payment.payment_method.method_type}",
-           :locals => {
-             :payment => @payment.source.is_a?(Spree::Payment) ? @payment.source : @payment
+<%= render partial: "spree/admin/payments/source_views/#{@payment.payment_method.method_type}",
+           locals: {
+             payment: @payment.source.is_a?(Spree::Payment) ? @payment.source : @payment
            }
 %>
 

--- a/backend/app/views/spree/admin/product_properties/index.html.erb
+++ b/backend/app/views/spree/admin/product_properties/index.html.erb
@@ -1,12 +1,12 @@
-<%= render 'spree/admin/shared/product_tabs', :current => 'Product Properties' %>
-<%= render 'spree/admin/shared/error_messages', :target => @product %>
+<%= render 'spree/admin/shared/product_tabs', current: :properties %>
+<%= render 'spree/admin/shared/error_messages', target: @product %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to(Spree.t(:add_product_properties), "javascript:;", { :icon => 'add', :'data-target' => "tbody#product_properties", :class => 'btn-success spree_add_fields' }) %>
-  <span class="js-new-ptype-link"><%= button_link_to Spree.t(:select_from_prototype), available_admin_prototypes_url, { :icon => 'properties', :remote => true, 'data-update' => 'prototypes', :class => 'btn-default' } %></span>
+  <%= button_link_to(Spree.t(:add_product_properties), "javascript:;", { icon: 'add', :'data-target' => "tbody#product_properties", class: 'btn-success spree_add_fields' }) %>
+  <span class="js-new-ptype-link"><%= button_link_to Spree.t(:select_from_prototype), available_admin_prototypes_url, { icon: 'properties', remote: true, 'data-update' => 'prototypes', class: 'btn-default' } %></span>
 <% end if can? :create, Spree::ProductProperty %>
 
-<%= form_for @product, :url => spree.admin_product_url(@product), :method => :put do |f| %>
+<%= form_for @product, url: spree.admin_product_url(@product), method: :put do |f| %>
   <fieldset>
     <div id="prototypes" data-hook></div>
 
@@ -20,7 +20,7 @@
       </thead>
       <tbody id="product_properties" data-hook>
         <%= f.fields_for :product_properties do |pp_form| %>
-          <%= render 'product_property_fields', :f => pp_form %>
+          <%= render 'product_property_fields', f: pp_form %>
         <% end %>
       </tbody>
     </table>

--- a/backend/app/views/spree/admin/products/edit.html.erb
+++ b/backend/app/views/spree/admin/products/edit.html.erb
@@ -1,15 +1,15 @@
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::Product) %>
-    <%= button_link_to Spree.t(:new_product), new_object_url, { :class => "btn-success", :icon => 'add', :id => 'admin_new_product' } %>
+    <%= button_link_to Spree.t(:new_product), new_object_url, { class: "btn-success", icon: 'add', id: 'admin_new_product' } %>
   <% end %>
 <% end %>
 
-<%= render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => 'Product Details' } %>
-<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @product } %>
+<%= render partial: 'spree/admin/shared/product_tabs', locals: {current: :details} %>
+<%= render partial: 'spree/admin/shared/error_messages', locals: { target: @product } %>
 
-<%= form_for [:admin, @product], :method => :put, :html => { :multipart => true } do |f| %>
+<%= form_for [:admin, @product], method: :put, html: { multipart: true } do |f| %>
   <fieldset>
-    <%= render :partial => 'form', :locals => { :f => f } %>
-    <%= render :partial => 'spree/admin/shared/edit_resource_links' %>
+    <%= render partial: 'form', locals: { f: f } %>
+    <%= render partial: 'spree/admin/shared/edit_resource_links' %>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/products/stock.html.erb
+++ b/backend/app/views/spree/admin/products/stock.html.erb
@@ -1,5 +1,5 @@
-<%= render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => 'Stock Management' } %>
-<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @product } %>
+<%= render partial: 'spree/admin/shared/product_tabs', locals: {current: :stock} %>
+<%= render partial: 'spree/admin/shared/error_messages', locals: { target: @product } %>
 
 <% if can? :create, Spree::StockMovement %>
   <div id="add_stock_form" class="panel panel-default">

--- a/backend/app/views/spree/admin/refunds/edit.html.erb
+++ b/backend/app/views/spree/admin/refunds/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: "Payments" } %>
+<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: :payments } %>
 
 <% content_for :page_title do %>
   / <%= link_to "#{Spree.t(:payment)} #{@refund.payment.id}", admin_order_payment_path(@refund.payment.order, @refund.payment) %>
@@ -21,7 +21,7 @@
     <div class="form-actions" data-hook="buttons">
       <%= button Spree.t('actions.save'), 'save' %>
       <span class="or"><%= Spree.t(:or) %></span>
-      <%= button_link_to Spree.t('actions.cancel'), spree.admin_order_payments_url(@refund.payment.order), :icon => "delete" %>
+      <%= button_link_to Spree.t('actions.cancel'), spree.admin_order_payments_url(@refund.payment.order), icon: "delete" %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/refunds/new.html.erb
+++ b/backend/app/views/spree/admin/refunds/new.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'spree/admin/shared/order_tabs', locals: {current: 'Payments'} %>
+<%= render partial: 'spree/admin/shared/order_tabs', locals: {current: :payments} %>
 
 <% content_for :page_title do %>
   / <%= link_to "#{Spree.t(:payment)} #{@refund.payment.id}", admin_order_payment_path(@refund.payment.order, @refund.payment) %>
@@ -29,7 +29,7 @@
     <div class="form-actions" data-hook="buttons">
       <%= button Spree.t(:refund), 'save' %>
       <span class="or"><%= Spree.t(:or) %></span>
-      <%= button_link_to Spree.t('actions.cancel'), spree.admin_order_payments_url(@refund.payment.order), :icon => "delete" %>
+      <%= button_link_to Spree.t('actions.cancel'), spree.admin_order_payments_url(@refund.payment.order), icon: "delete" %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/reimbursements/edit.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/edit.html.erb
@@ -1,10 +1,10 @@
-<%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Customer Returns' } %>
+<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: :customer_returns } %>
 
 <% content_for :page_title do %>
   / <%= Spree.t(:editing_resource, resource: Spree::Reimbursement.model_name.human) %> #<%= @reimbursement.number %>
 <% end %>
 
-<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @reimbursement } %>
+<%= render partial: 'spree/admin/shared/error_messages', locals: { target: @reimbursement } %>
 
 <%= form_for [:admin, @order, @reimbursement] do |f| %>
   <fieldset class='no-border-bottom'>
@@ -96,7 +96,7 @@
         <%= Spree.t(:reimburse) %>
       <% end %>
       <span class="or"><%= Spree.t(:or) %></span>
-      <%= button_link_to Spree.t('actions.cancel'), url_for([:admin, @order, @reimbursement.customer_return]), :icon => 'remove-sign' %>
+      <%= button_link_to Spree.t('actions.cancel'), url_for([:admin, @order, @reimbursement.customer_return]), icon: 'remove-sign' %>
     <% end %>
   </div>
 </fieldset>

--- a/backend/app/views/spree/admin/reimbursements/index.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/index.html.erb
@@ -1,10 +1,10 @@
-<%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Reimbursements' } %>
+<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: :reimbursements } %>
 
 <% content_for :page_title do %>
   / <%= Spree.t(:edit_reimbursement) %>
 <% end %>
 
-<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @customer_return } %>
+<%= render partial: 'spree/admin/shared/error_messages', locals: { target: @customer_return } %>
 
 <table class="table">
   <thead data-hook="customer_return_header">

--- a/backend/app/views/spree/admin/reimbursements/show.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/show.html.erb
@@ -1,10 +1,10 @@
-<%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Customer Returns' } %>
+<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: :customer_returns } %>
 
 <% content_for :page_title do %>
   / <%= Spree::Reimbursement.model_name.human %> #<%= @reimbursement.number %>
 <% end %>
 
-<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @reimbursement } %>
+<%= render partial: 'spree/admin/shared/error_messages', locals: { target: @reimbursement } %>
 
 <fieldset class='no-border-bottom'>
   <legend><%= Spree.t(:items_reimbursed) %></legend>

--- a/backend/app/views/spree/admin/return_authorizations/edit.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/edit.html.erb
@@ -1,26 +1,26 @@
 <% content_for :page_actions do %>
   <% if @return_authorization.can_cancel? %>
-    <%= button_link_to Spree.t('actions.cancel'), fire_admin_order_return_authorization_url(@order, @return_authorization, e: 'cancel'), method: :put, data: { confirm: Spree.t(:are_you_sure) }, :icon => "delete" %>
+    <%= button_link_to Spree.t('actions.cancel'), fire_admin_order_return_authorization_url(@order, @return_authorization, e: 'cancel'), method: :put, data: { confirm: Spree.t(:are_you_sure) }, icon: "delete" %>
   <% end %>
   <%= button_link_to Spree.t(:back), spree.admin_order_return_authorizations_url(@order), icon: 'arrow-left' %>
 <% end %>
 
-<%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Return Authorizations' } %>
+<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: :return_authorizations } %>
 
 <% content_for :page_title do %>
   / <%= Spree.t(:return_authorization) %> <%= @return_authorization.number %> (<%= Spree.t(@return_authorization.state.downcase) %>)
 <% end %>
 
-<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @return_authorization } %>
+<%= render partial: 'spree/admin/shared/error_messages', locals: { target: @return_authorization } %>
 
 <%= form_for [:admin, @order, @return_authorization] do |f| %>
   <fieldset>
-    <%= render :partial => 'form', :locals => { :f => f } %>
+    <%= render partial: 'form', locals: { f: f } %>
 
     <div class="form-actions" data-hook="buttons">
       <%= button Spree.t('actions.update'), 'repeat' %>
       <span class="or"><%= Spree.t(:or) %></span>
-      <%= button_link_to Spree.t('actions.cancel'), spree.admin_order_return_authorizations_url(@order), :icon => 'delete' %>
+      <%= button_link_to Spree.t('actions.cancel'), spree.admin_order_return_authorizations_url(@order), icon: 'delete' %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/return_authorizations/index.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/index.html.erb
@@ -1,8 +1,8 @@
-<%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Return Authorizations' } %>
+<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: :return_authorizations } %>
 
 <% content_for :page_actions do %>
   <% if @order.shipments.any?(&:shipped?) && can?(:create, Spree::ReturnAuthorization) %>
-    <%= button_link_to Spree.t(:new_return_authorization), new_admin_order_return_authorization_url(@order), :class => "btn-success", :icon => 'add' %>
+    <%= button_link_to Spree.t(:new_return_authorization), new_admin_order_return_authorization_url(@order), class: "btn-success", icon: 'add' %>
   <% end %>
 <% end %>
 
@@ -29,9 +29,9 @@
           <td><%= return_authorization.display_pre_tax_total.to_html %></td>
           <td><%= pretty_time(return_authorization.created_at) %></td>
           <td class="actions actions-2">
-            <%= link_to_edit(return_authorization, :no_text => true, :class => 'edit') if can?(:edit, return_authorization) %>
+            <%= link_to_edit(return_authorization, no_text: true, class: 'edit') if can?(:edit, return_authorization) %>
             <% if can?(:delete, return_authorization) && !return_authorization.customer_returned_items? %>
-              <%= link_to_delete return_authorization, :no_text => true %>
+              <%= link_to_delete return_authorization, no_text: true %>
             <% end %>
           </td>
         </tr>

--- a/backend/app/views/spree/admin/return_authorizations/new.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/new.html.erb
@@ -1,18 +1,18 @@
-<%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Return Authorizations' } %>
+<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: :return_authorizations } %>
 
 <% content_for :page_title do %>
   / <%= Spree.t(:new_return_authorization) %>
 <% end %>
 
-<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @return_authorization } %>
+<%= render partial: 'spree/admin/shared/error_messages', locals: { target: @return_authorization } %>
 <%= form_for [:admin, @order, @return_authorization] do |f| %>
   <fieldset>
-    <%= render :partial => 'form', :locals => { :f => f } %>
+    <%= render partial: 'form', locals: { f: f } %>
 
     <div class="form-actions" data-hook="buttons">
       <%= button Spree.t(:create), 'save' %>
       <span class="or"><%= Spree.t(:or) %></span>
-      <%= button_link_to Spree.t('actions.cancel'), spree.admin_order_return_authorizations_url(@order), :icon => 'delete' %>
+      <%= button_link_to Spree.t('actions.cancel'), spree.admin_order_return_authorizations_url(@order), icon: 'delete' %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/shared/_order_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_order_tabs.html.erb
@@ -6,53 +6,53 @@
 <% content_for :sidebar do %>
   <ul class="nav nav-pills nav-stacked" data-hook="admin_order_tabs">
     <% if ((can? :update, @order) && (@order.shipments.count == 0 || @order.shipments.shipped.count == 0)) %>
-      <li<%== ' class="active"' if current == 'Cart' %> data-hook='admin_order_tabs_cart_details'>
+      <li<%== ' class="active"' if current == :cart %> data-hook='admin_order_tabs_cart_details'>
         <%= link_to_with_icon 'edit', Spree.t(:cart), cart_admin_order_url(@order) %>
       </li>
     <% end %>
 
     <% if can?(:update, @order) && @order.checkout_steps.include?("address") %>
-      <li<%== ' class="active"' if current == 'Customer Details' %> data-hook='admin_order_tabs_customer_details'>
+      <li<%== ' class="active"' if current == :customer_details %> data-hook='admin_order_tabs_customer_details'>
         <%= link_to_with_icon 'user', Spree.t(:customer), spree.admin_order_customer_url(@order) %>
       </li>
     <% end %>
 
     <% if can? :update, @order %>
-      <li<%== ' class="active"' if current == 'Shipments' %> data-hook='admin_order_tabs_shipment_details'>
+      <li<%== ' class="active"' if current == :shipments %> data-hook='admin_order_tabs_shipment_details'>
         <%= link_to_with_icon 'road', Spree.t(:shipments), edit_admin_order_url(@order) %>
       </li>
     <% end %>
 
     <% if can? :index, Spree::Adjustment %>
-      <li<%== ' class="active"' if current == 'Adjustments' %> data-hook='admin_order_tabs_adjustments'>
+      <li<%== ' class="active"' if current == :adjustments %> data-hook='admin_order_tabs_adjustments'>
         <%= link_to_with_icon 'wrench', Spree.t(:adjustments), spree.admin_order_adjustments_url(@order) %>
       </li>
     <% end %>
 
     <% if can?(:index, Spree::Payment) %>
-      <li<%== ' class="active"' if current == 'Payments' %> data-hook='admin_order_tabs_payments'>
+      <li<%== ' class="active"' if current == :payments %> data-hook='admin_order_tabs_payments'>
         <%= link_to_with_icon 'credit-card', Spree.t(:payments), spree.admin_order_payments_url(@order) %>
       </li>
     <% end %>
 
     <% if can? :index, Spree::ReturnAuthorization %>
       <% if @order.completed? %>
-        <li<%== ' class="active"' if current == 'Returns' %> data-hook='admin_order_tabs_return_authorizations'>
-          <%= link_to_with_icon 'transfer', Spree.t(:returns), spree.admin_order_return_authorizations_url(@order) %>
+        <li<%== ' class="active"' if current == :return_authorizations %> data-hook='admin_order_tabs_return_authorizations'>
+          <%= link_to_with_icon 'transfer', Spree.t(:return_authorizations), spree.admin_order_return_authorizations_url(@order) %>
         </li>
       <% end %>
     <% end %>
 
     <% if can? :index, Spree::CustomerReturn %>
       <% if @order.completed? %>
-        <li<%== ' class="active"' if current == 'Customer Returns' %>>
+        <li<%== ' class="active"' if current == :customer_returns %>>
           <%= link_to_with_icon 'transfer', Spree.t(:customer_returns), spree.admin_order_customer_returns_url(@order) %>
         </li>
       <% end %>
     <% end %>
 
     <% if can? :update, @order %>
-      <li<%== ' class="active"' if current == 'State Changes' %> data-hook='admin_order_tabs_state_changes'>
+      <li<%== ' class="active"' if current == :state_changes %> data-hook='admin_order_tabs_state_changes'>
         <%= link_to_with_icon 'refresh', Spree::StateChange.human_attribute_name(:state_changes), spree.admin_order_state_changes_url(@order) %>
       </li>
     <% end %>

--- a/backend/app/views/spree/admin/shared/_product_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_product_tabs.html.erb
@@ -5,19 +5,19 @@
 
 <% content_for :sidebar do %>
   <ul class="nav nav-pills nav-stacked" data-hook="admin_product_tabs">
-    <%= content_tag :li, :class => ('active' if current == 'Product Details') do %>
+    <%= content_tag :li, class: ('active' if current == :details) do %>
       <%= link_to_with_icon 'edit', Spree.t(:details), edit_admin_product_url(@product) %>
     <% end if can?(:admin, Spree::Product) %>
-    <%= content_tag :li, :class => ('active' if current == 'Images') do %>
+    <%= content_tag :li, class: ('active' if current == :images) do %>
       <%= link_to_with_icon 'picture', Spree.t(:images), spree.admin_product_images_url(@product) %>
     <% end if can?(:admin, Spree::Image) %>
-    <%= content_tag :li, :class => ('active' if current == 'Variants') do %>
+    <%= content_tag :li, class: ('active' if current == :variants) do %>
       <%= link_to_with_icon 'th-large', Spree.t(:variants),  spree.admin_product_variants_url(@product) %>
     <% end if can?(:admin, Spree::Variant) %>
-    <%= content_tag :li, :class => ('active' if current == 'Product Properties') do %>
+    <%= content_tag :li, class: ('active' if current == :properties) do %>
       <%= link_to_with_icon 'list-alt', Spree.t(:properties), spree.admin_product_product_properties_url(@product) %>
     <% end if can?(:admin, Spree::ProductProperty) %>
-    <%= content_tag :li, :class => ('active' if current == 'Stock Management') do %>
+    <%= content_tag :li, class: ('active' if current == :stock) do %>
       <%= link_to_with_icon 'home', Spree.t(:stock), stock_admin_product_url(@product) %>
     <% end if can?(:stock, Spree::Product) %>
   </ul>

--- a/backend/app/views/spree/admin/state_changes/index.html.erb
+++ b/backend/app/views/spree/admin/state_changes/index.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: 'State Changes' } %>
+<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: :state_changes } %>
 
 <% content_for :page_title do %>
   <%= plural_resource_name(Spree::StateChange) %>

--- a/backend/app/views/spree/admin/users/addresses.html.erb
+++ b/backend/app/views/spree/admin/users/addresses.html.erb
@@ -2,21 +2,21 @@
   <%= link_to "#{@user.email}", edit_admin_user_url(@user) %> / <%= Spree.t(:editing_resource, resource: plural_resource_name(Spree::Address)) %>
 <% end %>
 
-<%= render :partial => 'spree/admin/users/sidebar', :locals => { :current => :address } %>
-<%= render :partial => 'spree/admin/users/user_page_actions' %>
+<%= render partial: 'spree/admin/users/sidebar', locals: { current: :address } %>
+<%= render partial: 'spree/admin/users/user_page_actions' %>
 
 <div data-hook="admin_user_addresses" id="admin_user_edit_addresses">
   <div data-hook="admin_user_edit_form_header">
-    <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @user } %>
+    <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @user } %>
   </div>
 
   <div data-hook="admin_user_address_edit_form">
     <%= form_for [:admin, @user], as: :user, url: addresses_admin_user_url(@user), method: :put do |f| %>
 
-      <%= render :partial => 'addresses_form', :locals => { :f => f } %>
+      <%= render partial: 'addresses_form', locals: { f: f } %>
 
       <div class="form-actions text-center well" data-hook="admin_user_edit_form_button">
-        <%= render :partial => 'spree/admin/shared/edit_resource_links', :locals => { :collection_url => spree.admin_users_url } %>
+        <%= render partial: 'spree/admin/shared/edit_resource_links', locals: { collection_url: spree.admin_users_url } %>
       </div>
     <% end %>
   </div>

--- a/backend/app/views/spree/admin/users/edit.html.erb
+++ b/backend/app/views/spree/admin/users/edit.html.erb
@@ -2,8 +2,8 @@
   <%= Spree.t(:editing_user) %> <%= @user.email %>
 <% end %>
 
-<%= render :partial => 'spree/admin/users/sidebar', :locals => { :current => :account } %>
-<%= render :partial => 'spree/admin/users/user_page_actions' %>
+<%= render partial: 'spree/admin/users/sidebar', locals: { current: :account } %>
+<%= render partial: 'spree/admin/users/user_page_actions' %>
 
 <div data-hook="admin_user_edit_general_settings" class="panel panel-default">
   <div class="panel-heading">
@@ -14,15 +14,15 @@
 
   <div class="panel-body">
     <div data-hook="admin_user_edit_form_header">
-      <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @user } %>
+      <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @user } %>
     </div>
 
     <div data-hook="admin_user_edit_form">
       <%= form_for [:admin, @user], as: :user, url: spree.admin_user_url(@user), method: :put do |f| %>
-        <%= render :partial => 'form', :locals => { :f => f } %>
+        <%= render partial: 'form', locals: { f: f } %>
 
         <div data-hook="admin_user_edit_form_button">
-          <%= render :partial => 'spree/admin/shared/edit_resource_links', :locals => { :collection_url => spree.admin_users_url } %>
+          <%= render partial: 'spree/admin/shared/edit_resource_links', locals: { collection_url: spree.admin_users_url } %>
         </div>
       <% end %>
     </div>
@@ -32,7 +32,7 @@
 <div data-hook="admin_user_api_key" id="admin_user_edit_api_key" class="panel panel-default">
   <div class="panel-heading">
     <h1 class="panel-title">
-      <%= Spree.t('access', :scope => 'api') %>
+      <%= Spree.t('access', scope: 'api') %>
     </h1>
   </div>
 
@@ -40,29 +40,29 @@
     <% if @user.spree_api_key.present? %>
       <div class="form-group">
         <div id="current-api-key">
-          <label><%= Spree.t('key', :scope => 'api') %>: </label>
+          <label><%= Spree.t('key', scope: 'api') %>: </label>
           <strong><%= @user.spree_api_key %></strong>
         </div>
       </div>
       <div class="form-actions">
-        <%= form_tag spree.clear_api_key_admin_user_path(@user), :method => :put do %>
-          <%= button Spree.t('clear_key', :scope => 'api'), 'delete', 'submit', class: "btn-danger" %>
+        <%= form_tag spree.clear_api_key_admin_user_path(@user), method: :put do %>
+          <%= button Spree.t('clear_key', scope: 'api'), 'delete', 'submit', class: "btn-danger" %>
         <% end %>
 
         <span class="or"><%= Spree.t(:or)%></span>
 
-        <%= form_tag spree.generate_api_key_admin_user_path(@user), :method => :put do %>
-          <%= button Spree.t('regenerate_key', :scope => 'api'), 'save' %>
+        <%= form_tag spree.generate_api_key_admin_user_path(@user), method: :put do %>
+          <%= button Spree.t('regenerate_key', scope: 'api'), 'save' %>
         <% end %>
       </div>
 
     <% else %>
 
-      <div class="alert alert-warning"><%= Spree.t('no_key', :scope => 'api') %></div>
+      <div class="alert alert-warning"><%= Spree.t('no_key', scope: 'api') %></div>
 
       <div class="form-actions">
-        <%= form_tag spree.generate_api_key_admin_user_path(@user), :method => :put do %>
-          <%= button Spree.t('generate_key', :scope => 'api'), 'key' %>
+        <%= form_tag spree.generate_api_key_admin_user_path(@user), method: :put do %>
+          <%= button Spree.t('generate_key', scope: 'api'), 'key' %>
         <% end %>
       </div>
     <% end %>

--- a/backend/app/views/spree/admin/users/items.html.erb
+++ b/backend/app/views/spree/admin/users/items.html.erb
@@ -2,8 +2,8 @@
   <%= link_to "#{@user.email}", edit_admin_user_url(@user) %> / <%= Spree.t(:"admin.user.items_purchased") %>
 <% end %>
 
-<%= render :partial => 'spree/admin/users/sidebar', :locals => { :current => :items } %>
-<%= render :partial => 'spree/admin/users/user_page_actions' %>
+<%= render partial: 'spree/admin/users/sidebar', locals: { current: :items } %>
+<%= render partial: 'spree/admin/users/user_page_actions' %>
 
 <fieldset data-hook="admin_user_items_purchased">
   <%= paginate @orders %>
@@ -12,13 +12,13 @@
     <%# TODO add search interface %>
     <table class="table table-condensed table-bordered stock-contents" id="listing_items" data-hook="stock-contents">
       <thead>
-        <th><%= sort_link @search, :completed_at, I18n.t(:completed_at, :scope => 'activerecord.attributes.spree/order'), {}, {:title => 'orders_completed_at_title'} %></th>
+        <th><%= sort_link @search, :completed_at, I18n.t(:completed_at, scope: 'activerecord.attributes.spree/order'), {}, {title: 'orders_completed_at_title'} %></th>
         <th colspan=2><%= Spree.t(:description) %></th>
-        <th><%= I18n.t(:price, :scope => 'activerecord.attributes.spree/line_item') %></th>
-        <th><%= I18n.t(:quantity, :scope => 'activerecord.attributes.spree/line_item') %></th>
+        <th><%= I18n.t(:price, scope: 'activerecord.attributes.spree/line_item') %></th>
+        <th><%= I18n.t(:quantity, scope: 'activerecord.attributes.spree/line_item') %></th>
         <th><%= Spree.t(:total) %></th>
-        <th><%= sort_link @search, :state, I18n.t(:state, :scope => 'activerecord.attributes.spree/order'), {}, {:title => 'orders_state_title'} %></th>
-        <th><%= sort_link @search, :number, Spree.t(:order_num, :scope => 'admin.user'), {}, {:title => 'orders_number_title'} %></th>
+        <th><%= sort_link @search, :state, I18n.t(:state, scope: 'activerecord.attributes.spree/order'), {}, {title: 'orders_state_title'} %></th>
+        <th><%= sort_link @search, :number, Spree.t(:order_num, scope: 'admin.user'), {}, {title: 'orders_number_title'} %></th>
       </thead>
       <tbody>
         <% @orders.each do |order| %>

--- a/backend/app/views/spree/admin/users/orders.html.erb
+++ b/backend/app/views/spree/admin/users/orders.html.erb
@@ -2,8 +2,8 @@
   <%= link_to "#{@user.email}", edit_admin_user_url(@user) %> / <%= Spree.t(:"admin.user.order_history") %>
 <% end %>
 
-<%= render :partial => 'spree/admin/users/sidebar', :locals => { :current => :orders } %>
-<%= render :partial => 'spree/admin/users/user_page_actions' %>
+<%= render partial: 'spree/admin/users/sidebar', locals: { current: :orders } %>
+<%= render partial: 'spree/admin/users/user_page_actions' %>
 
 <fieldset data-hook="admin_user_order_history">
   <%= paginate @orders %>
@@ -13,10 +13,10 @@
     <table class="table table-condensed table-bordered" id="listing_orders" data-hook>
       <thead>
         <tr data-hook="admin_orders_index_headers">
-          <th><%= sort_link @search, :completed_at,   I18n.t(:completed_at, :scope => 'activerecord.attributes.spree/order'), {}, {:title => 'orders_completed_at_title'} %></th>
-          <th><%= sort_link @search, :number,         I18n.t(:number, :scope => 'activerecord.attributes.spree/order'), {}, {:title => 'orders_number_title'} %></th>
-          <th><%= sort_link @search, :state,          I18n.t(:state, :scope => 'activerecord.attributes.spree/order'), {}, {:title => 'orders_state_title'} %></th>
-          <th><%= sort_link @search, :total,          I18n.t(:total, :scope => 'activerecord.attributes.spree/order'), {}, {:title => 'orders_total_title'} %></th>
+          <th><%= sort_link @search, :completed_at,   I18n.t(:completed_at, scope: 'activerecord.attributes.spree/order'), {}, {title: 'orders_completed_at_title'} %></th>
+          <th><%= sort_link @search, :number,         I18n.t(:number, scope: 'activerecord.attributes.spree/order'), {}, {title: 'orders_number_title'} %></th>
+          <th><%= sort_link @search, :state,          I18n.t(:state, scope: 'activerecord.attributes.spree/order'), {}, {title: 'orders_state_title'} %></th>
+          <th><%= sort_link @search, :total,          I18n.t(:total, scope: 'activerecord.attributes.spree/order'), {}, {title: 'orders_total_title'} %></th>
         </tr>
       </thead>
       <tbody>

--- a/backend/app/views/spree/admin/variants/edit.html.erb
+++ b/backend/app/views/spree/admin/variants/edit.html.erb
@@ -1,13 +1,13 @@
-<%= render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => 'Variants' } %>
+<%= render partial: 'spree/admin/shared/product_tabs', locals: { current: :variants } %>
 
-<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @variant } %>
+<%= render partial: 'spree/admin/shared/error_messages', locals: { target: @variant } %>
 
 <%= form_for [:admin, @product, @variant] do |f| %>
   <fieldset>
     <div data-hook="admin_variant_edit_form">
-      <%= render :partial => 'form', :locals => { :f => f } %>
+      <%= render partial: 'form', locals: { f: f } %>
     </div>
 
-    <%= render :partial => 'spree/admin/shared/edit_resource_links' %>
+    <%= render partial: 'spree/admin/shared/edit_resource_links' %>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/product_tabs', :locals => {:current => 'Variants'} %>
+<%= render partial: 'spree/admin/shared/product_tabs', locals: {current: :variants} %>
 
 <%# Place for new variant form %>
 <div id="new_variant" data-hook></div>
@@ -25,8 +25,8 @@
         <td><%= variant.display_price.to_html %></td>
         <td><%= variant.sku %></td>
         <td class="actions actions-2 text-right">
-          <%= link_to_edit(variant, :no_text => true) if can?(:edit, variant) && !variant.deleted? %>
-          <%= link_to_delete(variant, :no_text => true) if can?(:destroy, variant) && !variant.deleted? %>
+          <%= link_to_edit(variant, no_text: true) if can?(:edit, variant) && !variant.deleted? %>
+          <%= link_to_delete(variant, no_text: true) if can?(:destroy, variant) && !variant.deleted? %>
         </td>
       </tr>
       <% end %>
@@ -55,7 +55,7 @@
   <% end %>
 <% else %>
   <% content_for :page_actions do %>
-    <%= button_link_to(Spree.t(:new_variant), spree.new_admin_product_variant_url(@product), { :remote => :true, :icon => 'add', :'data-update' => 'new_variant', :class => 'btn-success', id: 'new_var_link' }) if can? :create, Spree::Variant %>
-    <%= button_link_to (@deleted.blank? ? Spree.t(:show_deleted) : Spree.t(:show_active)), spree.admin_product_variants_url(@product, :deleted => @deleted.blank? ? "on" : "off"), { :class => 'btn-default', :icon => 'filter' } %>
+    <%= button_link_to(Spree.t(:new_variant), spree.new_admin_product_variant_url(@product), { remote: :true, icon: 'add', :'data-update' => 'new_variant', class: 'btn-success', id: 'new_var_link' }) if can? :create, Spree::Variant %>
+    <%= button_link_to (@deleted.blank? ? Spree.t(:show_deleted) : Spree.t(:show_active)), spree.admin_product_variants_url(@product, deleted: @deleted.blank? ? "on" : "off"), { class: 'btn-default', icon: 'filter' } %>
   <% end %>
 <% end %>


### PR DESCRIPTION
The variable current holds something that indicates whether to
highlight certain navigation links. Sometimes, this variable contains a
non-internationalized string, sometimes an internationalized string, and
sometimes a symbol.

I think it's a good idea to make it a symbol always:
- Strings could be mistaken for something that needs to be translated
- No need to do those passes through `Spree.t`

This should also fix https://github.com/spree/spree/pull/6463.
