### PR TITLE
Fixes table_filter form path

### DIFF
--- a/backend/app/views/spree/admin/shared/_table_filter.html.erb
+++ b/backend/app/views/spree/admin/shared/_table_filter.html.erb
@@ -8,7 +8,7 @@
             <%= Spree.t(:filter) %>
           </button>
         </span>
-        <%= form_tag nil, id: "quick-search" do %>
+        <%= form_tag request.fullpath, id: "quick-search" do %>
           <%= text_field_tag :quick_search, nil, class: "form-control js-quick-search", placeholder: Spree.t(:quick_search) %>
         <% end %>
       </div>


### PR DESCRIPTION
Before `nil` was used, that fails if the view is used outside of the
spree engine.

Also `request.fullpath` is much more readable than `nil` and does
exactly the same..
