### PR TITLE
Only run PromotionHandler::Coupon eligible line items

### DIFF
--- a/core/app/models/spree/promotion_handler/coupon.rb
+++ b/core/app/models/spree/promotion_handler/coupon.rb
@@ -86,7 +86,7 @@ module Spree
         }
 
         # Check for applied adjustments.
-        discount = order.line_item_adjustments.promotion.detect(&detector)
+        discount = order.line_item_adjustments.promotion.eligible.detect(&detector)
         discount ||= order.shipment_adjustments.promotion.detect(&detector)
         discount ||= order.adjustments.promotion.detect(&detector)
 

--- a/core/app/models/spree/promotion_handler/coupon.rb
+++ b/core/app/models/spree/promotion_handler/coupon.rb
@@ -86,7 +86,8 @@ module Spree
         }
 
         # Check for applied adjustments.
-        discount = order.line_item_adjustments.promotion.eligible.detect(&detector)
+        discount = order.line_item_adjustments.promotion.
+          eligible.detect(&detector)
         discount ||= order.shipment_adjustments.promotion.detect(&detector)
         discount ||= order.adjustments.promotion.detect(&detector)
 

--- a/core/app/models/spree/promotion_handler/coupon.rb
+++ b/core/app/models/spree/promotion_handler/coupon.rb
@@ -86,8 +86,7 @@ module Spree
         }
 
         # Check for applied adjustments.
-        discount = order.line_item_adjustments.promotion.
-          eligible.detect(&detector)
+        discount = order.line_item_adjustments.promotion.eligible.detect(&detector)
         discount ||= order.shipment_adjustments.promotion.detect(&detector)
         discount ||= order.adjustments.promotion.detect(&detector)
 

--- a/core/spec/models/spree/promotion_handler/coupon_spec.rb
+++ b/core/spec/models/spree/promotion_handler/coupon_spec.rb
@@ -106,7 +106,7 @@ module Spree
                     expect(line_item.adjustments.count).to eq(1)
                   end
 
-                  expect(order.reload.total).to eq(110) # only 2 items discounted
+                  expect(order.reload.total).to eq(110) # only 2 items
                 end
               end
 

--- a/core/spec/models/spree/promotion_handler/coupon_spec.rb
+++ b/core/spec/models/spree/promotion_handler/coupon_spec.rb
@@ -90,9 +90,11 @@ module Spree
                 expect(order.reload.total).to eq(100)
               end
 
-              context 'and first line item is not promotionable' do
+              context "and first line item is not promotionable" do
                 before(:each) do
-                  order.line_items.first.variant.product.update_attributes!(promotionable: false)
+                  order.line_items.first.variant.product.update_attributes!(
+                    promotionable: false
+                  )
                   order.reload
                 end
 
@@ -103,8 +105,8 @@ module Spree
                   order.line_items.each do |line_item|
                     expect(line_item.adjustments.count).to eq(1)
                   end
-                  # Ensure that applying the adjustment actually affects the order's total!
-                  expect(order.reload.total).to eq(110) #only 2 items discounted
+
+                  expect(order.reload.total).to eq(110) # only 2 items discounted
                 end
               end
 

--- a/core/spec/models/spree/promotion_handler/coupon_spec.rb
+++ b/core/spec/models/spree/promotion_handler/coupon_spec.rb
@@ -90,6 +90,24 @@ module Spree
                 expect(order.reload.total).to eq(100)
               end
 
+              context 'and first line item is not promotionable' do
+                before(:each) do
+                  order.line_items.first.variant.product.update_attributes!(promotionable: false)
+                  order.reload
+                end
+
+                it "successfully activates promo" do
+                  expect(order.total).to eq(130)
+                  subject.apply
+                  expect(subject.success).to be_present
+                  order.line_items.each do |line_item|
+                    expect(line_item.adjustments.count).to eq(1)
+                  end
+                  # Ensure that applying the adjustment actually affects the order's total!
+                  expect(order.reload.total).to eq(110) #only 2 items discounted
+                end
+              end
+
               it "coupon already applied to the order" do
                 subject.apply
                 expect(subject.success).to be_present


### PR DESCRIPTION
This line in the Coupon PromotionHandler
`order.line_item_adjustments.promotion.detect` ([link](https://github.com/spree/spree/blob/2-4-stable/core/app/models/spree/promotion_handler/coupon.rb#L89))

Will only get run against the first line item. If that line item is not marked promotionable, then the `#determine_promotion_application_result` incorrectly returns an error message, even though the coupon has in fact been successfully applied to the other eligible line items.

This is fixed in 3-0-stable through use of the new all_adjustment scope, but persists in 2-2-stable, 2-3-stable, and 2-4-stable
