### PR TITLE
redirect_back_or_default should check HTTP_REFERER before choosing default

### DIFF
--- a/core/lib/spree/core/controller_helpers/auth.rb
+++ b/core/lib/spree/core/controller_helpers/auth.rb
@@ -19,7 +19,7 @@ module Spree
         end
 
         def redirect_back_or_default(default)
-          redirect_to(session["spree_user_return_to"] || default)
+          redirect_to(session["spree_user_return_to"] || request.env["HTTP_REFERER"] || default)
           session["spree_user_return_to"] = nil
         end
 

--- a/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
@@ -23,6 +23,11 @@ describe Spree::Core::ControllerHelpers::Auth, type: :controller do
       get :index
       expect(response).to redirect_to('/redirect')
     end
+    it 'redirects to HTTP_REFERER' do
+      request.env["HTTP_REFERER"] = '/dummy_redirect'
+      get :index
+      expect(response).to redirect_to('/dummy_redirect')
+    end
     it 'redirects to default page' do
       get :index
       expect(response).to redirect_to('/')

--- a/frontend/spec/controllers/spree/orders_controller_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_spec.rb
@@ -34,7 +34,7 @@ describe Spree::OrdersController, :type => :controller do
         end
 
         it "shows an error when population fails" do
-          request.env["HTTP_REFERER"] = spree.root_path
+          request.env["HTTP_REFERER"] = '/dummy_redirect'
           allow_any_instance_of(Spree::LineItem).to(
             receive(:valid?).and_return(false)
           )
@@ -45,19 +45,19 @@ describe Spree::OrdersController, :type => :controller do
 
           spree_post :populate, variant_id: variant.id, quantity: 5
 
-          expect(response).to redirect_to(spree.root_path)
+          expect(response).to redirect_to('/dummy_redirect')
           expect(flash[:error]).to eq("Order population failed")
         end
 
         it "shows an error when quantity is invalid" do
-          request.env["HTTP_REFERER"] = spree.root_path
+          request.env["HTTP_REFERER"] = '/dummy_redirect'
 
           spree_post(
             :populate,
             variant_id: variant.id, quantity: -1
           )
 
-          expect(response).to redirect_to(spree.root_path)
+          expect(response).to redirect_to('/dummy_redirect')
           expect(flash[:error]).to eq(
             Spree.t(:please_enter_reasonable_quantity)
           )


### PR DESCRIPTION
Fixes an issue where users add an out-of-stock item to the cart, and instead of taking them back to that product’s page, it always returns to the root path.

This bug was originally introduced by the fix for #5261

This fix can (and should) also be safely back ported into 3-0-stable.
