### PR TITLE
Backend: Add route for `reimbursements#index`

### DIFF
--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -105,7 +105,7 @@ Spree::Core::Engine.add_routes do
         resources :refunds, only: [:new, :create, :edit, :update]
       end
 
-      resources :reimbursements, only: [:create, :show, :edit, :update] do
+      resources :reimbursements, only: [:index, :create, :show, :edit, :update] do
         member do
           post :perform
         end


### PR DESCRIPTION
There's a view for this route, and when creating a reimbursement,
you will be redirected there at some point.
