### PR TITLE
Add default Refund Reason to seeds

### DIFF
--- a/core/db/default/spree/default_reimbursement_type.rb
+++ b/core/db/default/spree/default_reimbursement_type.rb
@@ -1,0 +1,1 @@
+Spree::RefundReason.find_or_create_by(name: "Return processing", mutable: false)


### PR DESCRIPTION
Creating a Refund will fail (quite miserably) if there's no refund reason. That reason has to have the name set to `Return processing` and the `mutable` flag set to `false`.

See https://github.com/spree/spree/blob/master/core/app/models/spree/refund_reason.rb#L5-L10

Right now, there is no way to add RefundReasons in the backend either, so
I guess this is more of a quick fix.
