### PR TITLE
Add credit method to Check payment method

### DIFF
--- a/core/app/models/spree/payment_method/check.rb
+++ b/core/app/models/spree/payment_method/check.rb
@@ -15,17 +15,27 @@ module Spree
     end
 
     def capture(*args)
-      ActiveMerchant::Billing::Response.new(true, "", {}, {})
+      simulated_successful_billing_response
     end
 
     def cancel(response); end
 
     def void(*args)
-      ActiveMerchant::Billing::Response.new(true, "", {}, {})
+      simulated_successful_billing_response
     end
 
     def source_required?
       false
+    end
+
+    def credit(*args)
+      simulated_successful_billing_response
+    end
+
+    private
+
+    def simulated_successful_billing_response
+      ActiveMerchant::Billing::Response.new(true, "", {}, {})
     end
   end
 end


### PR DESCRIPTION
When using the `Check` payment method, you can not create a reimbursement
as the `ReimbursementPerfomer` always creates a `Spree::Refund`, which calls
the `#credit` method on the payment method originally used.

This fix adds a `credit` method on the `check` payment method.

It also refactors the simulated successful billing response into a private method.
