### PR TITLE
Use `load` rather than `require` for factories

### DIFF
--- a/core/lib/spree/testing_support/factories.rb
+++ b/core/lib/spree/testing_support/factories.rb
@@ -7,7 +7,7 @@ Spree::Zone.class_eval do
 end
 
 Dir["#{File.dirname(__FILE__)}/factories/**"].each do |f|
-  require File.expand_path(f)
+  load File.expand_path(f)
 end
 
 FactoryGirl.define do


### PR DESCRIPTION
When using factory_girl_rails and spring on an application, I found that none of the spree-provided factories were available to me. Using them when running the tests with spring resulted in `Factory Not Registered` errors. The factories work fine without spring.

This seems to do with the factory_girl_rails initializer, which reloads all factories after spring forks. `require` happens only once, so when factory_girl reloads the factories it no longer sees the spree factories I have required.

In my app, I changed `require "spree/testing_support/factories` to `load "spree/testing_support/factories.rb`, which will load each time that initializer is run. However, spree itself needs to `load` rather than `require` the individual factory files.
