### PR TITLE
Allow adjustments to be included in tax calculations

### DIFF
--- a/core/app/models/spree/adjustable/adjuster/promotion.rb
+++ b/core/app/models/spree/adjustable/adjuster/promotion.rb
@@ -32,7 +32,7 @@ module Spree
 
         def update_totals(promo_total)
           @totals[:promo_total] = promo_total
-          @totals[:adjustment_total] += promo_total
+          @totals[:taxable_adjustment_total] += promo_total
         end
       end
     end

--- a/core/app/models/spree/adjustable/adjuster/tax.rb
+++ b/core/app/models/spree/adjustable/adjuster/tax.rb
@@ -19,7 +19,7 @@ module Spree
         def update_totals(included_tax_total, additional_tax_total)
           @totals[:included_tax_total] = included_tax_total
           @totals[:additional_tax_total] = additional_tax_total
-          @totals[:adjustment_total] += additional_tax_total
+          @totals[:non_taxable_adjustment_total] += additional_tax_total
         end
       end
     end

--- a/core/app/models/spree/adjustable/adjuster/tax.rb
+++ b/core/app/models/spree/adjustable/adjuster/tax.rb
@@ -19,7 +19,6 @@ module Spree
         def update_totals(included_tax_total, additional_tax_total)
           @totals[:included_tax_total] = included_tax_total
           @totals[:additional_tax_total] = additional_tax_total
-          @totals[:non_taxable_adjustment_total] += additional_tax_total
         end
       end
     end

--- a/core/app/models/spree/adjustable/adjustments_updater.rb
+++ b/core/app/models/spree/adjustable/adjustments_updater.rb
@@ -28,7 +28,9 @@ module Spree
 
       def persist_totals(totals)
         attributes = totals
-        attributes[:adjustment_total] = totals[:non_taxable_adjustment_total] + totals[:taxable_adjustment_total]
+        attributes[:adjustment_total] = totals[:non_taxable_adjustment_total] +
+                                        totals[:taxable_adjustment_total] +
+                                        totals[:additional_tax_total]
         attributes[:updated_at] = Time.now
         @adjustable.update_columns(totals)
       end

--- a/core/app/models/spree/adjustable/adjustments_updater.rb
+++ b/core/app/models/spree/adjustable/adjustments_updater.rb
@@ -13,7 +13,10 @@ module Spree
       def update
         return unless @adjustable.persisted?
 
-        totals = { adjustment_total: 0 }
+        totals = {
+          non_taxable_adjustment_total: 0,
+          taxable_adjustment_total: 0
+        }
         adjusters.each do |klass|
           klass.adjust(@adjustable, totals)
         end
@@ -25,6 +28,7 @@ module Spree
 
       def persist_totals(totals)
         attributes = totals
+        attributes[:adjustment_total] = totals[:non_taxable_adjustment_total] + totals[:taxable_adjustment_total]
         attributes[:updated_at] = Time.now
         @adjustable.update_columns(totals)
       end

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -15,10 +15,10 @@ module Spree
 
     validates :variant, presence: true
     validates :quantity, numericality: {
-      only_integer: true,
-      greater_than: -1,
-      message: Spree.t('validation.must_be_int')
-    }
+                         only_integer: true,
+                         greater_than: -1,
+                         message: Spree.t('validation.must_be_int')
+                       }
     validates :price, numericality: true
     validates_with Stock::AvailabilityValidator
 
@@ -30,6 +30,7 @@ module Spree
     after_save :update_adjustments
 
     after_create :update_tax_charge
+    # after_create :update_adjustment_total
 
     delegate :name, :description, :sku, :should_track_inventory?, to: :variant
     delegate :tax_zone, to: :order
@@ -63,16 +64,20 @@ module Spree
     def amount
       price * quantity
     end
+
     alias subtotal amount
 
-    def discounted_amount
-      amount + promo_total
+    def adjusted_amount
+      amount + taxable_adjustment_total
     end
+
     alias discounted_money display_discounted_amount
+    alias_method :discounted_amount, :adjusted_amount
 
     def final_amount
       amount + adjustment_total
     end
+
     alias total final_amount
     alias money display_total
 
@@ -107,46 +112,47 @@ module Spree
 
       if currency
         self.currency = currency
-        self.price    = variant.price_in(currency).amount +
-                        variant.price_modifier_amount_in(currency, opts)
+        self.price = variant.price_in(currency).amount +
+          variant.price_modifier_amount_in(currency, opts)
       else
-        self.price    = variant.price +
-                        variant.price_modifier_amount(opts)
+        self.price = variant.price +
+          variant.price_modifier_amount(opts)
       end
 
       self.assign_attributes opts
     end
 
     private
-      def update_inventory
-        if (changed? || target_shipment.present?) && self.order.has_checkout_step?("delivery")
-          Spree::OrderInventory.new(self.order, self).verify(target_shipment)
-        end
-      end
 
-      def destroy_inventory_units
-        inventory_units.destroy_all
+    def update_inventory
+      if (changed? || target_shipment.present?) && self.order.has_checkout_step?("delivery")
+        Spree::OrderInventory.new(self.order, self).verify(target_shipment)
       end
+    end
 
-      def update_adjustments
-        if quantity_changed?
-          update_tax_charge # Called to ensure pre_tax_amount is updated.
-          recalculate_adjustments
-        end
-      end
+    def destroy_inventory_units
+      inventory_units.destroy_all
+    end
 
-      def recalculate_adjustments
-        Adjustable::AdjustmentsUpdater.update(self)
+    def update_adjustments
+      if quantity_changed?
+        update_tax_charge # Called to ensure pre_tax_amount is updated.
+        recalculate_adjustments
       end
+    end
 
-      def update_tax_charge
-        Spree::TaxRate.adjust(order, [self])
-      end
+    def recalculate_adjustments
+      Adjustable::AdjustmentsUpdater.update(self)
+    end
 
-      def ensure_proper_currency
-        unless currency == order.currency
-          errors.add(:currency, :must_match_order_currency)
-        end
+    def update_tax_charge
+      Spree::TaxRate.adjust(order, [self])
+    end
+
+    def ensure_proper_currency
+      unless currency == order.currency
+        errors.add(:currency, :must_match_order_currency)
       end
+    end
   end
 end

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -14,11 +14,12 @@ module Spree
     before_validation :copy_tax_category
 
     validates :variant, presence: true
-    validates :quantity, numericality: {
-                         only_integer: true,
-                         greater_than: -1,
-                         message: Spree.t('validation.must_be_int')
-                       }
+    validates :quantity, numericality:
+                        {
+                          only_integer: true,
+                          greater_than: -1,
+                          message: Spree.t('validation.must_be_int')
+                        }
     validates :price, numericality: true
     validates_with Stock::AvailabilityValidator
 
@@ -103,13 +104,20 @@ module Spree
       Spree::Variant.unscoped { super }
     end
 
-    def options=(options={})
+    def options=(options = {})
       return unless options.present?
 
       opts = options.dup # we will be deleting from the hash, so leave the caller's copy intact
 
       currency = opts.delete(:currency) || order.try(:currency)
 
+      update_price_from_modifier(currency, opts)
+      assign_attributes opts
+    end
+
+    private
+
+    def update_price_from_modifier(currency, opts)
       if currency
         self.currency = currency
         self.price = variant.price_in(currency).amount +
@@ -118,15 +126,11 @@ module Spree
         self.price = variant.price +
           variant.price_modifier_amount(opts)
       end
-
-      self.assign_attributes opts
     end
 
-    private
-
     def update_inventory
-      if (changed? || target_shipment.present?) && self.order.has_checkout_step?("delivery")
-        Spree::OrderInventory.new(self.order, self).verify(target_shipment)
+      if (changed? || target_shipment.present?) && order.has_checkout_step?("delivery")
+        Spree::OrderInventory.new(order, self).verify(target_shipment)
       end
     end
 

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -67,12 +67,12 @@ module Spree
 
     alias subtotal amount
 
-    def adjusted_amount
+    def taxable_amount
       amount + taxable_adjustment_total
     end
 
     alias discounted_money display_discounted_amount
-    alias_method :discounted_amount, :adjusted_amount
+    alias_method :discounted_amount, :taxable_amount
 
     def final_amount
       amount + adjustment_total

--- a/core/db/migrate/20150626181949_add_taxable_adjustment_total_to_line_item.rb
+++ b/core/db/migrate/20150626181949_add_taxable_adjustment_total_to_line_item.rb
@@ -1,13 +1,19 @@
 class AddTaxableAdjustmentTotalToLineItem < ActiveRecord::Migration
   def change
-    add_column :spree_line_items, :taxable_adjustment_total, :decimal, precision: 10, scale: 2, default: 0.0, null: false
-    add_column :spree_line_items, :non_taxable_adjustment_total, :decimal, precision: 10, scale: 2, default: 0.0, null: false
+    add_column :spree_line_items, :taxable_adjustment_total, :decimal,
+               precision: 10, scale: 2, default: 0.0, null: false
+    add_column :spree_line_items, :non_taxable_adjustment_total, :decimal,
+               precision: 10, scale: 2, default: 0.0, null: false
 
-    add_column :spree_shipments, :taxable_adjustment_total, :decimal, precision: 10, scale: 2, default: 0.0, null: false
-    add_column :spree_shipments, :non_taxable_adjustment_total, :decimal, precision: 10, scale: 2, default: 0.0, null: false
+    add_column :spree_shipments, :taxable_adjustment_total, :decimal,
+               precision: 10, scale: 2, default: 0.0, null: false
+    add_column :spree_shipments, :non_taxable_adjustment_total, :decimal,
+               precision: 10, scale: 2, default: 0.0, null: false
 
-    add_column :spree_orders, :taxable_adjustment_total, :decimal, precision: 10, scale: 2, default: 0.0, null: false
-    add_column :spree_orders, :non_taxable_adjustment_total, :decimal, precision: 10, scale: 2, default: 0.0, null: false
+    add_column :spree_orders, :taxable_adjustment_total, :decimal,
+               precision: 10, scale: 2, default: 0.0, null: false
+    add_column :spree_orders, :non_taxable_adjustment_total, :decimal,
+               precision: 10, scale: 2, default: 0.0, null: false
     # TODO migration that updates old orders
   end
 end

--- a/core/db/migrate/20150626181949_add_taxable_adjustment_total_to_line_item.rb
+++ b/core/db/migrate/20150626181949_add_taxable_adjustment_total_to_line_item.rb
@@ -1,0 +1,13 @@
+class AddTaxableAdjustmentTotalToLineItem < ActiveRecord::Migration
+  def change
+    add_column :spree_line_items, :taxable_adjustment_total, :decimal, precision: 10, scale: 2, default: 0.0, null: false
+    add_column :spree_line_items, :non_taxable_adjustment_total, :decimal, precision: 10, scale: 2, default: 0.0, null: false
+
+    add_column :spree_shipments, :taxable_adjustment_total, :decimal, precision: 10, scale: 2, default: 0.0, null: false
+    add_column :spree_shipments, :non_taxable_adjustment_total, :decimal, precision: 10, scale: 2, default: 0.0, null: false
+
+    add_column :spree_orders, :taxable_adjustment_total, :decimal, precision: 10, scale: 2, default: 0.0, null: false
+    add_column :spree_orders, :non_taxable_adjustment_total, :decimal, precision: 10, scale: 2, default: 0.0, null: false
+    # TODO migration that updates old orders
+  end
+end

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -414,7 +414,6 @@ module Spree
         }
 
         order = Importer::Order.import(user, params)
-
         line_item_adjustment = order.line_item_adjustments.first
         expect(line_item_adjustment.closed?).to be true
         expect(line_item_adjustment.label).to eq 'Line Item Discount'

--- a/core/spec/models/spree/calculator/default_tax_spec.rb
+++ b/core/spec/models/spree/calculator/default_tax_spec.rb
@@ -1,23 +1,23 @@
 require 'spec_helper'
 
-describe Spree::Calculator::DefaultTax, :type => :model do
+describe Spree::Calculator::DefaultTax, type: :model do
   let!(:country) { create(:country) }
-  let!(:zone) { create(:zone, :name => "Country Zone", :default_tax => true, :zone_members => []) }
-  let!(:tax_category) { create(:tax_category, :tax_rates => []) }
-  let!(:rate) { create(:tax_rate, :tax_category => tax_category, :amount => 0.05, :included_in_price => included_in_price) }
+  let!(:zone) { create(:zone, name: "Country Zone", default_tax: true, zone_members: []) }
+  let!(:tax_category) { create(:tax_category, tax_rates: []) }
+  let!(:rate) { create(:tax_rate, tax_category: tax_category, amount: 0.05, included_in_price: included_in_price) }
   let(:included_in_price) { false }
-  let!(:calculator) { Spree::Calculator::DefaultTax.new(:calculable => rate ) }
+  let!(:calculator) { Spree::Calculator::DefaultTax.new(calculable: rate) }
   let!(:order) { create(:order) }
-  let!(:line_item) { create(:line_item, :price => 10, :quantity => 3, :tax_category => tax_category) }
-  let!(:shipment) { create(:shipment, :cost => 15) }
+  let!(:line_item) { create(:line_item, price: 10, quantity: 3, tax_category: tax_category) }
+  let!(:shipment) { create(:shipment, cost: 15) }
 
   context "#compute" do
     context "when given an order" do
       let!(:line_item_1) { line_item }
-      let!(:line_item_2) { create(:line_item, :price => 10, :quantity => 3, :tax_category => tax_category) }
+      let!(:line_item_2) { create(:line_item, price: 10, quantity: 3, tax_category: tax_category) }
 
       before do
-        allow(order).to receive_messages :line_items => [line_item_1, line_item_2]
+        allow(order).to receive_messages line_items: [line_item_1, line_item_2]
       end
 
       context "when no line items match the tax category" do
@@ -51,7 +51,6 @@ describe Spree::Calculator::DefaultTax, :type => :model do
             # Amount is 0.51665, which will be rounded to...
             expect(calculator.compute(order)).to eq(0.52)
           end
-
         end
       end
 
@@ -77,7 +76,6 @@ describe Spree::Calculator::DefaultTax, :type => :model do
     context "when tax is included in price" do
       let(:included_in_price) { true }
       context "when the variant matches the tax category" do
-
         context "when line item is discounted" do
           before do
             line_item.taxable_adjustment_total = -1

--- a/core/spec/models/spree/calculator/default_tax_spec.rb
+++ b/core/spec/models/spree/calculator/default_tax_spec.rb
@@ -80,7 +80,7 @@ describe Spree::Calculator::DefaultTax, :type => :model do
 
         context "when line item is discounted" do
           before do
-            line_item.promo_total = -1
+            line_item.taxable_adjustment_total = -1
             Spree::TaxRate.store_pre_tax_amount(line_item, [rate])
           end
 
@@ -97,7 +97,7 @@ describe Spree::Calculator::DefaultTax, :type => :model do
 
     context "when tax is not included in price" do
       context "when the line item is discounted" do
-        before { line_item.promo_total = -1 }
+        before { line_item.taxable_adjustment_total = -1 }
 
         it "should be equal to the item's pre-tax total * rate" do
           expect(calculator.compute(line_item)).to eq(1.45)
@@ -141,7 +141,7 @@ describe Spree::Calculator::DefaultTax, :type => :model do
 
       context "with a 40$ promo" do
         before do
-          allow(line_item).to receive(:promo_total).and_return(BigDecimal.new("-40"))
+          allow(line_item).to receive(:taxable_adjustment_total).and_return(BigDecimal.new("-40"))
           Spree::TaxRate.store_pre_tax_amount(line_item, [rate])
         end
 

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Spree::LineItem, :type => :model do
+describe Spree::LineItem, type: :model do
   let(:order) { create :order_with_line_items, line_items_count: 1 }
   let(:line_item) { order.line_items.first }
 
@@ -67,7 +67,7 @@ describe Spree::LineItem, :type => :model do
     let(:variant) { create(:variant) }
 
     before do
-      create(:tax_rate, :zone => order.tax_zone, :tax_category => variant.tax_category)
+      create(:tax_rate, zone: order.tax_zone, tax_category: variant.tax_category)
     end
 
     context "when order has a tax zone" do
@@ -161,7 +161,6 @@ describe Spree::LineItem, :type => :model do
     it "returns a Spree::Money representing the total for this line item" do
       expect(line_item.money.to_s).to eq("$7.00")
     end
-
   end
 
   describe '#single_money' do

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -135,7 +135,7 @@ describe Spree::LineItem, :type => :model do
     it "returns the amount minus any discounts" do
       line_item.price = 10
       line_item.quantity = 2
-      line_item.promo_total = -5
+      line_item.taxable_adjustment_total = -5
       expect(line_item.discounted_amount).to eq(15)
     end
   end

--- a/guides/content/developer/core/adjustments.md
+++ b/guides/content/developer/core/adjustments.md
@@ -29,7 +29,7 @@ The *source* is the source of the adjustment. Typically a `Spree::TaxRate` objec
 
 The *adjustable* is the object being adjusted, which is either an order, line item or shipment.
 
-Adjustments can come from one of two locations:
+Adjustments can come from one of two locations within Spree's core:
 
 * Tax Rates
 * Promotions
@@ -109,22 +109,24 @@ To create a new adjuster for Spree, create a new ruby object that inherits from 
 module Spree
   module Adjustable
     module Adjuster
-      class Tax < Spree::Adjustable::Adjuster::Base
+      class MyAdjuster < Spree::Adjustable::Adjuster::Base
         def update
           ...
           #your ruby magic
           ...
-          update_totals(included_tax_total, additional_tax_total)
+          update_totals(some_total, my_other_total)
         end
 
         private
 
         # Note to persist your totals you need to update @totals
         # This is shown in a separate method for readability
-        def update_totals(included_tax_total, additional_tax_total)
-          @totals[:included_tax_total] = included_tax_total
-          @totals[:additional_tax_total] = additional_tax_total
-          @totals[:adjustment_total] += additional_tax_total
+        def update_totals(some_total, my_other_total)
+          # if you want to keep track of your total, 
+          # you will need the column defined
+          @totals[:total_you_want_to_track] += some_total
+          @totals[:taxable_adjustment_total] += some_total
+          @totals[:non_taxable_adjustment_total] += my_other_total
         end
       end
     end
@@ -137,8 +139,10 @@ Next you need to add the class to spree `Rails.application.config.spree.adjuster
 ```ruby
 # NOTE: it is advisable that that Tax be implemented last so Tax is calculated correctly
 app.config.spree.adjusters = [
+          Spree::Adjustable::Adjuster::MyAdjuster,
           Spree::Adjustable::Adjuster::Promotion,
-          Spree::Adjustable::Adjuster::Tax]
+          Spree::Adjustable::Adjuster::Tax
+          ]
 ```
 
 That's it! Your custom adjuster is ready to go.


### PR DESCRIPTION
Since adjustments on line_items were added there was no built in way to have them included
into tax calculations. Currently adjustment_total includes all adjustments whether it be tax,
promotions, etc. The problem is that tax was only calculated using amount + promo_total
and not any other adjustments that were added onto the line_item. So if an adjustment altered
the price in any way the tax would be incorrectly calculated.

To remedy this this PR introduces two new columns to line_items, shipments and orders.
The new columns (non_)taxable_adjustment_total are used to total all adjustments whose
value needs to be included in tax(eg. promotions, etc.) and adjustments that should not
be included in the tax calculations(eg. some fees).

TL;DR Increases extensibility by splitting adjustment totals on whether or not we want them included in tax.

Addresses #6535
