### PR TITLE
Fix VAT calculation with percent discounts

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -130,8 +130,8 @@ module Spree
 
       def update_adjustments
         if quantity_changed?
-          update_tax_charge # Called to ensure pre_tax_amount is updated.
           recalculate_adjustments
+          update_tax_charge # Called to ensure pre_tax_amount is updated.
         end
       end
 

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -40,6 +40,7 @@ module Spree
       shipment.present? ? shipment.update_amounts : order.ensure_updated_shipments
       PromotionHandler::Cart.new(order, line_item).activate
       Adjustable::AdjustmentsUpdater.update(line_item)
+      TaxRate.adjust(order, [line_item])
       persist_totals
       line_item
     end


### PR DESCRIPTION
There was a bug with calculating VAT on order that have line items with percent discounts:
Say that I have variant with price 6000 (including VAT). I have a promotion with 50% discount. Tax rate is 25%. When I add variant in cart, total tax rate is 1200 (which is wrong, it should be 600), but when I add another (quantity is now 2), total tax rate is 1800 (1200 + 600). It seems that tax rate is calculated wrongly first time and correctly second time which is strange.

I fixed this by adding TaxRate.adjust(order, [line_item]) in OrderContents class, method after_add_or_remove, and changing the order of recalculate methods in LineItem class, in method update_adjustments.

I added a spec for this case in order_contents_spec, in promotions part. 
