### PR TITLE
Order cancellation spec

### DIFF
--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -70,6 +70,7 @@ module Spree
 
       def cancel!
         payment_method.cancel(response_code)
+        void
       end
 
       def gateway_options

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -25,7 +25,6 @@ describe Spree::Order, :type => :model do
         state: "completed"
       )
     end
-    let(:payment_method) { double }
     it "should mark the payments as void" do
       allow_any_instance_of(Spree::Gateway::Bogus).to receive(:cancel).and_return(true)
       order.cancel

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -15,6 +15,25 @@ describe Spree::Order, :type => :model do
     allow(Spree::LegacyUser).to receive_messages(:current => mock_model(Spree::LegacyUser, :id => 123))
   end
 
+  context "#cancel" do
+    let(:order) { create(:completed_order_with_totals) }
+    let!(:payment) do
+      create(
+        :payment,
+        order: order,
+        amount: order.total,
+        state: "completed"
+      )
+    end
+    let(:payment_method) { double }
+    it "should mark the payments as void" do
+      allow_any_instance_of(Spree::Gateway::Bogus).to receive(:cancel).and_return(true)
+      order.cancel
+      order.reload
+      expect(order.payments.first).to be_void
+    end
+  end
+
   context "#canceled_by" do
     let(:admin_user) { create :admin_user }
     let(:order) { create :order }


### PR DESCRIPTION
Currently Spree does not change the state of the payment in an order after cancellation. The payment remains in a `complete` state even though the payment has been refunded on the gateway. 

This presents the following problems:
- order shows as 'credit owed'
- no indication that the voiding of the payment went through
- the payment as per Spree's knowledge, can be refunded again, but this will result in an error from the payment gateway

This PR is a work in progress that for now just adds a spec to show what we believe is a correct behaviour - but we are looking for feedback on this.

We encountered this problem when upgrading from Spree 2.3 to 2.4 - specifically when the `cancel` method was added to the `spree_gateway` gem in this PR: https://github.com/spree/spree_gateway/pull/204

In the old implementation of the _Spree::Payment::Processing_ class the `cancel!` method had an if-case which would either try and call `cancel` on the gateway, or just use the `credit!` method. Since Stripe did not have a `cancel` method, it would subsequently use the `credit!` method, which would create a 2nd payment, but leave the original one still in completed state. It looks like this: 
![](http://puu.sh/iIdPI/1440ba462c.png)

This behaviour does not seem correct - the first payment should be marked as void; but the order would end up in a paid state, and we had an indication that a refund had been processed.

Right now, when you cancel an order you end up with only 1 payment in the complete state, which is wrong. A proposed solution would be to just call `void` at the end of the `cancel` method in processing, as such: 

```
def cancel!
  payment_method.cancel(response_code)
  self.void
end
```
