### PR TITLE
Adds the ability to set a reason why a state change happened on a order

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -22,7 +22,7 @@ module Spree
     end
 
     attr_reader :coupon_code
-    attr_accessor :temporary_address, :temporary_credit_card
+    attr_accessor :temporary_address, :temporary_credit_card, :state_change_reason
 
     if Spree.user_class
       belongs_to :user, class_name: Spree.user_class.to_s

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -48,7 +48,8 @@ module Spree
                   previous_state: transition.from,
                   next_state:     transition.to,
                   name:           'order',
-                  user_id:        order.user_id
+                  user_id:        order.user_id,
+                  reason:         order.state_change_reason
                 )
                 order.save
               end

--- a/core/db/migrate/20150706152110_add_reason_to_spree_state_changes.rb
+++ b/core/db/migrate/20150706152110_add_reason_to_spree_state_changes.rb
@@ -1,0 +1,5 @@
+class AddReasonToSpreeStateChanges < ActiveRecord::Migration
+  def change
+    add_column :spree_state_changes, :reason, :text
+  end
+end

--- a/core/spec/models/spree/order/state_machine_spec.rb
+++ b/core/spec/models/spree/order/state_machine_spec.rb
@@ -175,6 +175,14 @@ describe Spree::Order, type: :model do
         it "should set payment state to 'void'" do
           expect { order.cancel! }.to change{ order.reload.payment_state }.to("void")
         end
+
+        context "when a reason is set" do
+          it "should set the cancellation_reason on the state change" do
+            order.state_change_reason = "Unwanted Gift"
+            order.cancel!
+            expect(order.state_changes.first.reason).to eq "Unwanted Gift"
+          end
+        end
       end
 
       context "with shipped items" do


### PR DESCRIPTION
I think it would be useful to be able to store the reason why an order was canceled. For example found cheaper somewhere else.
Before I start building the frontend I wanted to check if this would be something you would consider merging?

Also can this be merge into 2.4 or are you only accepting new features on 3.0?

Thanks!
