### PR TITLE
Sidebar Caching on production causing a taxon highlighting lock

### DIFF
--- a/frontend/app/views/spree/shared/_taxonomies.html.erb
+++ b/frontend/app/views/spree/shared/_taxonomies.html.erb
@@ -2,7 +2,7 @@
 
 <nav id="taxonomies" class="sidebar-item" data-hook>
   <% @taxonomies.each do |taxonomy| %>
-    <% cache [I18n.locale, taxonomy, max_level] do %>
+    <% cache [I18n.locale, taxonomy, max_level, @taxon] do %>
       <h4 class='taxonomy-root'><%= Spree.t(:shop_by_taxonomy, :taxonomy => taxonomy.name) %></h4>
       <%= taxons_tree(taxonomy.root, @taxon, max_level) %>
     <% end %>


### PR DESCRIPTION
On production the sidebar caching is causing a case where a taxon on the sidebar stays highlighted until manually clicking clear cache.
