### PR TITLE
Resume shipment from canceled logic

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -64,9 +64,6 @@ module Spree
         transition from: :canceled, to: :ready, if: lambda { |shipment|
           shipment.determine_state(shipment.order) == 'ready'
         }
-        transition from: :canceled, to: :pending, if: lambda { |shipment|
-          shipment.determine_state(shipment.order) == 'ready'
-        }
         transition from: :canceled, to: :pending
       end
       after_transition from: :canceled, to: [:pending, :ready, :shipped], do: :after_resume

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -62,10 +62,10 @@ module Spree
 
       event :resume do
         transition from: :canceled, to: :ready, if: lambda { |shipment|
-          shipment.determine_state(shipment.order) == :ready
+          shipment.determine_state(shipment.order) == 'ready'
         }
         transition from: :canceled, to: :pending, if: lambda { |shipment|
-          shipment.determine_state(shipment.order) == :ready
+          shipment.determine_state(shipment.order) == 'ready'
         }
         transition from: :canceled, to: :pending
       end

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -443,7 +443,7 @@ describe Spree::Shipment, :type => :model do
       allow(shipment.order).to receive(:update!)
 
       shipment.state = 'canceled'
-      expect(shipment).to receive(:determine_state).and_return(:ready)
+      expect(shipment).to receive(:determine_state).and_return('ready')
       expect(shipment).to receive(:after_resume)
       shipment.resume!
       expect(shipment.state).to eq 'ready'

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -439,7 +439,7 @@ describe Spree::Shipment, :type => :model do
   end
 
   context "#resume" do
-    it 'will determine new state based on order' do
+    it 'transitions state to ready if the order is ready' do
       allow(shipment.order).to receive(:update!)
 
       shipment.state = 'canceled'
@@ -449,22 +449,22 @@ describe Spree::Shipment, :type => :model do
       expect(shipment.state).to eq 'ready'
     end
 
+    it 'transitions state to pending if the order is not ready' do
+      allow(shipment.order).to receive(:update!)
+
+      shipment.state = 'canceled'
+      expect(shipment).to receive(:determine_state).and_return('pending')
+      expect(shipment).to receive(:after_resume)
+      shipment.resume!
+      # Shipment is pending because order is already paid
+      expect(shipment.state).to eq 'pending'
+    end
+
     it 'unstocks them items' do
       allow(shipment).to receive_message_chain(inventory_units: [mock_model(Spree::InventoryUnit, line_item: line_item, variant: variant)])
       shipment.stock_location = mock_model(Spree::StockLocation)
       expect(shipment.stock_location).to receive(:unstock).with(variant, 1, shipment)
       shipment.after_resume
-    end
-
-    it 'will determine new state based on order' do
-      allow(shipment.order).to receive(:update!)
-
-      shipment.state = 'canceled'
-      expect(shipment).to receive(:determine_state).twice.and_return('ready')
-      expect(shipment).to receive(:after_resume)
-      shipment.resume!
-      # Shipment is pending because order is already paid
-      expect(shipment.state).to eq 'pending'
     end
   end
 


### PR DESCRIPTION
Hi,

While documenting the `Spree::Shipment` state machine today I noticed some bugs in the logic handling resumption from a canceled state. Specifically, there are duplicate, contradictory transitions from the `:canceled` state on a `:resume` event:

![spree shipment_state](https://cloud.githubusercontent.com/assets/383376/8569859/a330831a-2573-11e5-9418-8242bbb88e9c.jpg)

The [relevant state machine code](https://github.com/spree/spree/blob/10df25f1fbd852eef0491d7ffa3331fe1b4b9042/core/app/models/spree/shipment.rb#L64-L70) looks like this:

``` ruby
# core/app/models/spree/shipment.rb
event :resume do
  transition from: :canceled, to: :ready, if: lambda { |shipment|
    shipment.determine_state(shipment.order) == :ready
  }
  transition from: :canceled, to: :pending, if: lambda { |shipment|
    shipment.determine_state(shipment.order) == :ready
  }
  transition from: :canceled, to: :pending
end
```

This is broken in a couple of ways:
- `Spree::Shipment#determine_state` returns strings, not symbols, so the comparisons will always fail
- Even if the comparisons are fixed, the second condition never applies:
  - if the order state is `'ready'` then the first condition applies, and the shipment will transition to `:ready`.
  - If the order state is not `'ready'`, then the second condition is overridden by the final, duplicate clause, and the shipment transitions to `:pending` regardless.

The current effect is that the shipment always transitions from `:canceled` to `:pending` on a `:resume` event.
### Tests

There are two passing tests for this behaviour, but they're a bit broken themselves.

The first, [asserting that a shipment with a `'ready'` order will transition to `:ready`](https://github.com/spree/spree/blob/8bd0f1ce1cf2ca7185ed18e65c596f85e70a7131/core/spec/models/spree/shipment_spec.rb#L442-L450), passes only because the `#determine_state` method has been [incorrectly stubbed](https://github.com/spree/spree/blob/8bd0f1ce1cf2ca7185ed18e65c596f85e70a7131/core/spec/models/spree/shipment_spec.rb#L446) to return a symbol, not a string.

The second, contradictory test, [asserting that a shipment with a `'ready'` order will transition to `:pending`](https://github.com/spree/spree/blob/8bd0f1ce1cf2ca7185ed18e65c596f85e70a7131/core/spec/models/spree/shipment_spec.rb#L459-L467), passes only because of the third, unconditional state machine transition (and because it _correctly_ stubs the `#determine_state` method to return a string, meaning the first conditional doesn't succeed).
### Fixes

This PR currently only has two commits - one to fix the incorrect stubbing in the tests, and another to fix the comparisons so that they compare strings. The result of these changes is that the second test now correctly fails.

I would be happy to provide a full fix, but I'm not sure what the expected behaviour is. The transition logic was introduced in [this commit](https://github.com/spree/spree/commit/82ba2a7828a9572398637f95b4a9a91fae050739), which doesn't provide much clue as to the intentions behind the change.

As best I can tell the current behaviour has been in place since [early 2013](https://github.com/spree/spree/commit/f156409cf285e8a0bfd5e77e6df559b70a70e245#commitcomment-3302976). It _seems_ as though the original intention was to transition to `:ready` if `#determine_state` returned `'ready'`, and `:pending` otherwise, but it'd be great if someone with a better idea of the implications of that change could weigh in before I start making changes. If the bug has gone unnoticed for ~2 years, maybe that complexity is unnecessary after all.

Cheers,
Simon
