### PR TITLE
Remove new reimbursement type button

### DIFF
--- a/backend/app/views/spree/admin/reimbursement_types/index.html.erb
+++ b/backend/app/views/spree/admin/reimbursement_types/index.html.erb
@@ -27,7 +27,6 @@
   </table>
 <% else %>
   <div class="alpha twelve columns no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/reimbursement_type')) %>,
-    <%= link_to Spree.t(:add_one), new_object_url %>!
+    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/reimbursement_type')) %>
   </div>
 <% end %>


### PR DESCRIPTION
ReimbursementType is not meant to be created through admin interface,
the existing new buttons references a non-existing route,
new_admin_reimbursement_type_url, which causes internal error.

This button is removed already for 3-0-stable and newer branch, patch is only needed for 2-4-stable.
