### PR TITLE
Only update promo_total for promotions

### DIFF
--- a/core/app/models/spree/adjustable/adjuster/promotion.rb
+++ b/core/app/models/spree/adjustable/adjuster/promotion.rb
@@ -6,7 +6,7 @@ module Spree
           promo_adjustments = adjustments.competing_promos.reload.map { |a| a.update!(adjustable) }
           promos_total = promo_adjustments.compact.sum
           choose_best_promo_adjustment unless promos_total == 0
-          promo_total = best_promo_adjustment.try(:amount).to_f
+          promo_total = best_promo_adjustment.try(:amount).to_f if best_promo_adjustment.try(:promotion?)
 
           update_totals(promo_total)
         end
@@ -31,6 +31,7 @@ module Spree
         end
 
         def update_totals(promo_total)
+          promo_total ||= 0.0
           @totals[:promo_total] = promo_total
           @totals[:taxable_adjustment_total] += promo_total
         end

--- a/core/spec/models/spree/adjustable/adjuster/promotion_spec.rb
+++ b/core/spec/models/spree/adjustable/adjuster/promotion_spec.rb
@@ -24,7 +24,7 @@ describe Spree::Adjustable::Adjuster::Promotion, type: :model do
     describe "competing promos" do
       before { Spree::Adjustment.competing_promos_source_types = ['Spree::PromotionAction', 'Custom'] }
 
-      it "only does not updated promo total for competing discounts" do
+      it "do not update promo_total" do
         create(:adjustment,
                order: order,
                adjustable: line_item,
@@ -34,7 +34,7 @@ describe Spree::Adjustable::Adjuster::Promotion, type: :model do
                label: "Other",
                mandatory: false)
         create_adjustment("Promotion A", -2.50)
-        
+
         subject.update
         expect(line_item.promo_total).to eql 0.0
       end

--- a/core/spec/models/spree/adjustable/adjuster/promotion_spec.rb
+++ b/core/spec/models/spree/adjustable/adjuster/promotion_spec.rb
@@ -21,6 +21,25 @@ describe Spree::Adjustable::Adjuster::Promotion, type: :model do
              mandatory: false)
     end
 
+    describe "competing promos" do
+      before { Spree::Adjustment.competing_promos_source_types = ['Spree::PromotionAction', 'Custom'] }
+
+      it "only does not updated promo total for competing discounts" do
+        create(:adjustment,
+               order: order,
+               adjustable: line_item,
+               source_type: 'Custom',
+               source_id: nil,
+               amount: -3.50,
+               label: "Other",
+               mandatory: false)
+        create_adjustment("Promotion A", -2.50)
+        
+        subject.update
+        expect(line_item.promo_total).to eql 0.0
+      end
+    end
+
     it "should use only the most valuable promotion" do
       create_adjustment("Promotion A", -100)
       create_adjustment("Promotion B", -200)


### PR DESCRIPTION
Previously when Adjusters were added, I incorrectly made the promo_total to include any competing promotion total. However promo_total should only reflect Spree::Promotion's not any competing_promos since they may or may not be a Spree::Promotion. 
