### PR TITLE
line_item_adjustments should't include all

### DIFF
--- a/frontend/app/views/spree/shared/_order_details.html.erb
+++ b/frontend/app/views/spree/shared/_order_details.html.erb
@@ -92,9 +92,9 @@
   </tfoot>
 
   <% if order.line_item_adjustments.exists? %>
-    <% if order.all_adjustments.promotion.eligible.exists? %>
+    <% if order.line_item_adjustments.promotion.eligible.exists? %>
       <tfoot id="price-adjustments" data-hook="order_details_price_adjustments">
-        <% order.all_adjustments.promotion.eligible.group_by(&:label).each do |label, adjustments| %>
+        <% order.line_item_adjustments.promotion.eligible.group_by(&:label).each do |label, adjustments| %>
          <tr class="total">
            <td colspan="4"><%= Spree.t(:promotion) %>: <strong><%= label %></strong></td>
            <td class="total"><span><%= Spree::Money.new(adjustments.sum(&:amount), currency: order.currency) %></span></td>


### PR DESCRIPTION
Obviously it's a wrong copy-paste bug.

line_item_adjustments should sum only line_item_adjustments amount, not all_adjustments.
