### PR TITLE
Destroy shipments when verifying available rates

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -636,7 +636,7 @@ module Spree
       if shipments.empty? || shipments.any? { |shipment| shipment.shipping_rates.blank? }
         # After this point, order redirects back to 'address' state and asks user to pick a proper address
         # Therefore, shipments are not necessary at this point.
-        shipments.delete_all
+        shipments.destroy_all
         errors.add(:base, Spree.t(:items_cannot_be_shipped)) and return false
       end
     end


### PR DESCRIPTION
Prefer correctness over premature optimization.

With the delete_all there is not a cascade delete of related objects including the inventory unit.
When building an order on the backend this causes orphaned inventory unit records which
manifest themselves confusingly in the RMA area as you have rows for each line item.

This was noted as a comment[1] on the original commit and a PR was requested. This is that PR.
1. https://github.com/spree/spree/commit/aadb5ae66eb1f51b563c5d998a9d8a53c731c241#commitcomment-9487805
