### PR TITLE
Add associatin between shipping_method and stock_location

### DIFF
--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -20,6 +20,8 @@ module Spree
                                     :class_name => 'Spree::Zone',
                                     :foreign_key => 'shipping_method_id'
 
+    has_and_belongs_to_many :stock_locations
+
     belongs_to :tax_category, :class_name => 'Spree::TaxCategory'
 
     validates :name, presence: true

--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -3,6 +3,7 @@ module Spree
     has_many :shipments
     has_many :stock_items, dependent: :delete_all, inverse_of: :stock_location
     has_many :stock_movements, through: :stock_items
+    has_and_belongs_to_many :shipping_methods
 
     belongs_to :state, class_name: 'Spree::State'
     belongs_to :country, class_name: 'Spree::Country'

--- a/core/db/migrate/20150716124636_create_spree_shipping_methods_stock_locations.rb
+++ b/core/db/migrate/20150716124636_create_spree_shipping_methods_stock_locations.rb
@@ -1,0 +1,8 @@
+class CreateSpreeShippingMethodsStockLocations < ActiveRecord::Migration
+  def change
+    create_table :spree_shipping_methods_stock_locations do |t|
+      t.belongs_to :shipping_method
+      t.belongs_to :stock_location
+    end
+  end
+end


### PR DESCRIPTION
We have multiple stock locations and each stock location supports different shipping methods. I believe that it is not very unusual requirement especially if you are running international e-commerce business and stock locations are located in different countries and handle different stocks (it means you can't decide shipping method only by destination).

I send this PR only with model changes before making any front end changes. If you're happy about the model change, I am happy to work on frontend change. It'd be great if you could also advise me about any implications I might want to look at too.
