### PR TITLE
Remove automatic payment creation with default cards

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,4 +1,7 @@
-## Spree 3.0.0 (unreleased) ##
+## Spree 3.0.0 ##
 
 * Renamed ItemAdjustments to Adjustable::AdjustmentsUpdater.
 * Removed allow_ssl_in_* preferences from spree
+
+## Spree Edge ##
+* Remove automatic payment creation with default card on before payment transition

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -89,7 +89,6 @@ module Spree
               after_transition to: :complete, do: :persist_user_credit_card
               before_transition to: :payment, do: :set_shipments_cost
               before_transition to: :payment, do: :create_tax_charge!
-              before_transition to: :payment, do: :assign_default_credit_card
             end
 
             before_transition from: :cart, do: :ensure_line_items_present
@@ -290,13 +289,6 @@ module Spree
             default_cc.user_id = user_id
             default_cc.default = true
             default_cc.save
-          end
-        end
-
-        def assign_default_credit_card
-          if payments.from_credit_card.count == 0 && user_has_valid_default_card? && payment_required?
-            cc = user.default_credit_card
-            payments.create!(payment_method_id: cc.payment_method_id, source: cc, amount: total)
           end
         end
 

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -380,37 +380,6 @@ describe Spree::Order, :type => :model do
       end
     end
 
-    context "to payment" do
-      before do
-        @default_credit_card = FactoryGirl.create(:credit_card)
-        order.user = mock_model(Spree::LegacyUser, default_credit_card: @default_credit_card, email: 'spree@example.org')
-
-        allow(order).to receive_messages(payment_required?: true)
-        allow(order).to receive_messages(total: 20.00)
-        order.state = 'delivery'
-        order.save!
-      end
-
-      it "assigns the user's default credit card" do
-        order.next!
-        order.reload
-
-        expect(order.state).to eq 'payment'
-        expect(order.payments.count).to eq 1
-        expect(order.payments.first.amount).to eq 20.00
-        expect(order.payments.first.source).to eq @default_credit_card
-      end
-
-      it "only generates payment if payment required" do
-        allow(order).to receive_messages(payment_required?: false)
-        order.next!
-        order.reload
-
-        expect(order.state).to eq 'complete'
-        expect(order.payments.count).to eq 0
-      end
-    end
-
     context "from payment" do
       before do
         order.state = 'payment'

--- a/guides/content/release_notes/3_1_0.md
+++ b/guides/content/release_notes/3_1_0.md
@@ -74,3 +74,7 @@ You can view the full changes using [Github Compare](https://github.com/spree/sp
 * Removed Spree::Alert
 
     [Jeff Dutil](https://github.com/spree/spree/pull/6516)
+    
+* Remove automatic payment creation with default credit card
+
+    [Darby Perez](https://github.com/spree/spree/pull/6601)


### PR DESCRIPTION
This commit removes the process of creating a payment with default credit card automatically. Proposing removal since there is no clear need for this and issues arise when payment methods are set to auto-capture. 

Resolves #6499
