### PR TITLE
More aggressive order state transitions.

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/line_items_on_order_edit.js
+++ b/backend/app/assets/javascripts/spree/backend/line_items_on_order_edit.js
@@ -41,7 +41,6 @@ adjustLineItems = function(order_number, variant_id, quantity){
         }
     }).done(function( msg ) {
         window.Spree.advanceOrder();
-        window.location.reload();
     }).fail(function(msg) {
         alert(msg.responseJSON.message)
     });

--- a/backend/app/assets/javascripts/spree/backend/shipments.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js.erb
@@ -62,7 +62,7 @@ $(document).ready(function () {
         token: Spree.api_key
       }
     }).done(function () {
-      window.location.reload();
+      window.Spree.advanceOrder();
     }).error(function (msg) {
       console.log(msg);
     });

--- a/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
+++ b/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
@@ -23,7 +23,8 @@ module Spree
             if params[:guest_checkout] == "false"
               @order.associate_user!(Spree.user_class.find(params[:user_id]), @order.email.blank?)
             end
-            @order.next
+            # Transition it as far as it will go.
+            while @order.next; end
             @order.refresh_shipment_rates(ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END)
             flash[:success] = Spree.t('customer_details_updated')
             redirect_to edit_admin_order_url(@order)


### PR DESCRIPTION
When building the backend there are a few places where the order state
does not end up where it should be. This commit correct those in two
areas.
1. When saving the customer details it does an `order.next` but you
   would have to save it multiple times to get to the furthest state.
   This makes it behave in the same way that other parts of the backend
   work (adding cart item, adding payment) so that the state is
   transitioned as far as possible.
2. Although they look visually similar the add item on the cart page
   and the shipment page are different implemention (although I think
   they have close to the same goal and wonder if the two implementations
   are needed). When adding an item to the cart it calls the `advanceOrder`
   method but it doesn't do this when adding an item via the shipment
   page. This causes the order to remain in the `cart` stage even though
   it might be able to move along. I also removed the reload from the
   JS when adding an item to the cart as `advanceOrder` automatically
   reloads when done (and reloading before `advanceOrder` is done might
   cause an issue on some situations where the reload happens before the
   `advanceOrder` can really get to the server).
