### PR TITLE
Allow feedback from customer details update.

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -1,3 +1,5 @@
 ## Spree Edge ##
 
-* Allow appropriate feedback on customer details update
+* Allow errors from customer details to be displayed. Previously any update to the customer details, successful or not, 
+would flash a success message. This resolves that by allowing errors to be displayed should they happen. By default there
+is no state past complete so there is no need to attempt next transition once the state is complete.

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -1,1 +1,3 @@
-## Spree 2.4.0 (unreleased) ##
+## Spree Edge ##
+
+* Allow appropriate feedback on customer details update

--- a/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
+++ b/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
@@ -23,34 +23,38 @@ module Spree
             if params[:guest_checkout] == "false"
               @order.associate_user!(Spree.user_class.find(params[:user_id]), @order.email.blank?)
             end
-            @order.next
-            @order.refresh_shipment_rates(ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END)
-            flash[:success] = Spree.t('customer_details_updated')
-            redirect_to edit_admin_order_url(@order)
+            @order.next unless @order.complete?
+            @order.refresh_shipment_rates(Spree::ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END)
+
+            if @order.errors.empty?
+              flash[:success] = Spree.t('customer_details_updated')
+              redirect_to edit_admin_order_url(@order)
+            else
+              render action: :edit
+            end
           else
             render action: :edit
           end
-
         end
 
         private
-          def order_params
-            params.require(:order).permit(
-              :email,
-              :use_billing,
-              bill_address_attributes: permitted_address_attributes,
-              ship_address_attributes: permitted_address_attributes
-            )
-          end
 
-          def load_order
-            @order = Order.includes(:adjustments).friendly.find(params[:order_id])
-          end
+        def order_params
+          params.require(:order).permit(
+            :email,
+            :use_billing,
+            bill_address_attributes: permitted_address_attributes,
+            ship_address_attributes: permitted_address_attributes
+          )
+        end
 
-          def model_class
-            Spree::Order
-          end
+        def load_order
+          @order = Order.includes(:adjustments).friendly.find(params[:order_id])
+        end
 
+        def model_class
+          Spree::Order
+        end
       end
     end
   end

--- a/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
@@ -24,6 +24,7 @@ describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
       it "does refresh the shipment rates with all shipping methods" do
         allow(order).to receive_messages(update_attributes: true)
         allow(order).to receive_messages(next: false)
+        allow(order).to receive_messages(complete?: true)
         expect(order).to receive(:refresh_shipment_rates)
           .with(Spree::ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END)
         attributes = {

--- a/guides/content/release_notes/3_1_0.md
+++ b/guides/content/release_notes/3_1_0.md
@@ -74,3 +74,7 @@ You can view the full changes using [Github Compare](https://github.com/spree/sp
 * Removed Spree::Alert
 
     [Jeff Dutil](https://github.com/spree/spree/pull/6516)
+    
+* Allow checkout errors to be displayed when updating customer details
+    
+    [Darby Perez](https://github.com/spree/spree/pull/6604)


### PR DESCRIPTION
Currently there is no/false feedback when updating customer details. The
success flash message would appear whether or not the next/update was successful.
This allows next/update to happen while allowing appropriate feedback.
