### PR TITLE
to let user change Carmen.i18n_backend.locale

### DIFF
--- a/core/db/default/spree/countries.rb
+++ b/core/db/default/spree/countries.rb
@@ -26,4 +26,4 @@ connection.execute <<-SQL
   VALUES (#{country_values.call});
 SQL
 
-Spree::Config[:default_country_id] = Spree::Country.find_by(name: "United States").id
+Spree::Config[:default_country_id] = Spree::Country.find_by(iso: "US").id

--- a/core/db/default/spree/zones.rb
+++ b/core/db/default/spree/zones.rb
@@ -1,17 +1,13 @@
 eu_vat = Spree::Zone.create!(name: "EU_VAT", description: "Countries that make up the EU VAT zone.")
 north_america = Spree::Zone.create!(name: "North America", description: "USA + Canada")
-
-["Poland", "Finland", "Portugal", "Romania", "Germany", "France",
- "Slovakia", "Hungary", "Slovenia", "Ireland", "Austria", "Spain",
- "Italy", "Belgium", "Sweden", "Latvia", "Bulgaria", "United Kingdom",
- "Lithuania", "Cyprus", "Luxembourg", "Malta", "Denmark", "Netherlands",
- "Estonia"].
+["PL", "FI", "PT", "RO", "DE", "FR", "SK", "HU", "SI", "IE", "AT", "ES", "IT",
+ "BE", "SE", "LV", "BG", "GB", "LT", "CY", "LU", "MT", "DK", "NL", "EE"].
 each do |name|
-  eu_vat.zone_members.create!(zoneable: Spree::Country.find_by!(name: name))
+  eu_vat.zone_members.create!(zoneable: Spree::Country.find_by!(iso: name))
 end
 
-["United States", "Canada"].each do |name|
-  north_america.zone_members.create!(zoneable: Spree::Country.find_by!(name: name))
+["US", "CA"].each do |name|
+  north_america.zone_members.create!(zoneable: Spree::Country.find_by!(iso: name))
 end
 
 

--- a/core/db/default/spree/zones.rb
+++ b/core/db/default/spree/zones.rb
@@ -1,12 +1,11 @@
 eu_vat = Spree::Zone.create!(name: "EU_VAT", description: "Countries that make up the EU VAT zone.")
 north_america = Spree::Zone.create!(name: "North America", description: "USA + Canada")
-["PL", "FI", "PT", "RO", "DE", "FR", "SK", "HU", "SI", "IE", "AT", "ES", "IT",
- "BE", "SE", "LV", "BG", "GB", "LT", "CY", "LU", "MT", "DK", "NL", "EE"].
+%w(PL FI PT RO DE FR SK HU SI IE AT ES IT BE SE LV BG GB LT CY LU MT DK NL EE).
 each do |name|
   eu_vat.zone_members.create!(zoneable: Spree::Country.find_by!(iso: name))
 end
 
-["US", "CA"].each do |name|
+%w(US CA).each do |name|
   north_america.zone_members.create!(zoneable: Spree::Country.find_by!(iso: name))
 end
 

--- a/guides/content/developer/customization/i18n.markdown
+++ b/guides/content/developer/customization/i18n.markdown
@@ -156,6 +156,19 @@ There are three configuration options for currency:
 * `Spree::Config[:currency_symbol_position]`: Whether to include the symbol before or after the monetary amount.
 * `Spree::Config[:display_currency]`: Whether or not to display the currency with prices.
 
+### Localizing Seed Data
+
+Spree use [Carmen](https://github.com/jim/carmen) to seed the Country and State data. You can localize the seed data by adding Carmen configuration to your `seeds.rb`. See example below:
+
+```ruby
+# add Carmen counfiguration with the following 2 lines
+require 'carmen'
+Carmen.i18n_backend.locale = :ja
+
+Spree::Core::Engine.load_seed if defined?(Spree::Core)
+Spree::Auth::Engine.load_seed if defined?(Spree::Auth)
+```
+
 ## Creating and Modifying Locales
 
 While we have used [LocaleApp](http://localeapp.com) in the past to manage the translations for the spree_i18n project, Localeapp does not have support for different branches within the same project. As such, please submit Pull Requests or issues directly to https://github.com/spree/spree_i18n for missing translations.

--- a/guides/content/release_notes/3_0_0.md
+++ b/guides/content/release_notes/3_0_0.md
@@ -134,32 +134,32 @@ You can view the full changes using [Github Compare](https://github.com/spree/sp
 
     Ben A. Morgan
 
-```text
-Passing a hash is now deprecated and will be removed in Spree 3.1.
-It is recommended that you pass it as an array instead.
+    ```text
+    Passing a hash is now deprecated and will be removed in Spree 3.1.
+    It is recommended that you pass it as an array instead.
 
-New Syntax:
+    New Syntax:
 
-{
-  "order": {
-    "line_items": [
-      { "variant_id": 123, "quantity": 1 },
-      { "variant_id": 456, "quantity": 1 }
-    ]
-  }
-}
-
-Old Syntax:
-
-{
-  "order": {
-    "line_items": {
-      "1": { "variant_id": 123, "quantity": 1 },
-      "2": { "variant_id": 123, "quantity": 1 }
+    {
+      "order": {
+        "line_items": [
+          { "variant_id": 123, "quantity": 1 },
+          { "variant_id": 456, "quantity": 1 }
+        ]
+      }
     }
-  }
-}
-```
+
+    Old Syntax:
+
+    {
+      "order": {
+        "line_items": {
+          "1": { "variant_id": 123, "quantity": 1 },
+          "2": { "variant_id": 123, "quantity": 1 }
+        }
+      }
+    }
+    ```
 
 * Enable configuration of `Carmen.i18n_backend.locale` at `seeds.rb`
 

--- a/guides/content/release_notes/3_0_0.md
+++ b/guides/content/release_notes/3_0_0.md
@@ -160,3 +160,21 @@ Old Syntax:
   }
 }
 ```
+
+* Enable configuration of `Carmen.i18n_backend.locale` at `seeds.rb`
+
+    You can localize the `Country` and `State` seed data by adding [Carmen](https://github.com/jim/carmen) configuration to your `seeds.rb`.  
+    See example below:
+
+    ```ruby
+    # add Carmen counfiguration with the following 2 lines
+    require 'carmen'
+    Carmen.i18n_backend.locale = :ja
+
+    Spree::Core::Engine.load_seed if defined?(Spree::Core)
+    Spree::Auth::Engine.load_seed if defined?(Spree::Auth)
+    ```
+
+    https://github.com/spree/spree/pull/6607
+
+    Tomoki Odaka

--- a/sample/db/samples/addresses.rb
+++ b/sample/db/samples/addresses.rb
@@ -1,4 +1,4 @@
-united_states = Spree::Country.find_by_name!("United States")
+united_states = Spree::Country.find_by_iso!("US")
 new_york = Spree::State.find_by_name!("New York")
 
 # Billing address


### PR DESCRIPTION
When I change the Carmen.i18n_backend.locale at db/seeds.rb of my app like 

```
require 'carmen'
Carmen.i18n_backend.locale = :ja
Spree::Core::Engine.load_seed if defined?(Spree::Core)
Spree::Auth::Engine.load_seed if defined?(Spree::Auth)
```

`rake db:seeds` and `rake spree_sample:load` fails because these task use
`Spree::Country.find_by!(name: name))` or `Spree::Country.find_by_name!("United States")`
`name` column value depends on locale.
So I change these task to use iso name.
I checked It can work.

Could you merge it?
