### PR TITLE
Fix order include duplication

### DIFF
--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -1,338 +1,338 @@
 module Spree
-  class Order
+  class Order < Spree::Base
     module Checkout
-      extend ActiveSupport::Concern
+      def self.included(klass)
+        klass.class_eval do
+          class_attribute :next_event_transitions
+          class_attribute :previous_states
+          class_attribute :checkout_flow
+          class_attribute :checkout_steps
+          class_attribute :removed_transitions
 
-      included do
-        class_attribute :next_event_transitions
-        class_attribute :previous_states
-        class_attribute :checkout_flow
-        class_attribute :checkout_steps
-        class_attribute :removed_transitions
+          self.checkout_steps ||= {}
+          self.next_event_transitions ||= []
+          self.previous_states ||= [:cart]
+          self.removed_transitions ||= []
 
-        self.checkout_steps ||= {}
-        self.next_event_transitions ||= []
-        self.previous_states ||= [:cart]
-        self.removed_transitions ||= []
-
-        def self.checkout_flow(&block)
-          if block_given?
-            @checkout_flow = block
-            define_state_machine!
-          else
-            @checkout_flow
+          def self.checkout_flow(&block)
+            if block_given?
+              @checkout_flow = block
+              define_state_machine!
+            else
+              @checkout_flow
+            end
           end
-        end
 
-        def self.define_state_machine!
-          self.checkout_steps = {}
-          self.next_event_transitions = []
-          self.previous_states = [:cart]
-          self.removed_transitions = []
+          def self.define_state_machine!
+            self.checkout_steps = {}
+            self.next_event_transitions = []
+            self.previous_states = [:cart]
+            self.removed_transitions = []
 
-          # Build the checkout flow using the checkout_flow defined either
-          # within the Order class, or a decorator for that class.
-          #
-          # This method may be called multiple times depending on if the
-          # checkout_flow is re-defined in a decorator or not.
-          instance_eval(&checkout_flow)
+            # Build the checkout flow using the checkout_flow defined either
+            # within the Order class, or a decorator for that class.
+            #
+            # This method may be called multiple times depending on if the
+            # checkout_flow is re-defined in a decorator or not.
+            instance_eval(&checkout_flow)
 
-          klass = self
+            klass = self
 
-          # To avoid a ton of warnings when the state machine is re-defined
-          StateMachines::Machine.ignore_method_conflicts = true
-          # To avoid multiple occurrences of the same transition being defined
-          # On first definition, state_machines will not be defined
-          state_machines.clear if respond_to?(:state_machines)
-          state_machine :state, initial: :cart, use_transactions: false, action: :save_state do
-            klass.next_event_transitions.each { |t| transition(t.merge(on: :next)) }
+            # To avoid a ton of warnings when the state machine is re-defined
+            StateMachines::Machine.ignore_method_conflicts = true
+            # To avoid multiple occurrences of the same transition being defined
+            # On first definition, state_machines will not be defined
+            state_machines.clear if respond_to?(:state_machines)
+            state_machine :state, initial: :cart, use_transactions: false, action: :save_state do
+              klass.next_event_transitions.each { |t| transition(t.merge(on: :next)) }
 
-            # Persist the state on the order
-            after_transition do |order, transition|
-              order.state = order.state
-              order.state_changes.create(
-                previous_state: transition.from,
-                next_state:     transition.to,
-                name:           'order',
-                user_id:        order.user_id
-              )
-              order.save
-            end
+              # Persist the state on the order
+              after_transition do |order, transition|
+                order.state = order.state
+                order.state_changes.create(
+                  previous_state: transition.from,
+                  next_state:     transition.to,
+                  name:           'order',
+                  user_id:        order.user_id
+                )
+                order.save
+              end
 
-            event :cancel do
-              transition to: :canceled, if: :allow_cancel?
-            end
+              event :cancel do
+                transition to: :canceled, if: :allow_cancel?
+              end
 
-            event :return do
-              transition to: :returned,
-                         from: [:complete, :awaiting_return, :canceled],
-                         if: :all_inventory_units_returned?
-            end
+              event :return do
+                transition to: :returned,
+                           from: [:complete, :awaiting_return, :canceled],
+                           if: :all_inventory_units_returned?
+              end
 
-            event :resume do
-              transition to: :resumed, from: :canceled, if: :canceled?
-            end
+              event :resume do
+                transition to: :resumed, from: :canceled, if: :canceled?
+              end
 
-            event :authorize_return do
-              transition to: :awaiting_return
-            end
+              event :authorize_return do
+                transition to: :awaiting_return
+              end
 
-            if states[:payment]
-              before_transition to: :complete do |order|
-                if order.payment_required? && order.payments.valid.empty?
-                  order.errors.add(:base, Spree.t(:no_payment_found))
-                  false
-                elsif order.payment_required?
-                  order.process_payments!
+              if states[:payment]
+                before_transition to: :complete do |order|
+                  if order.payment_required? && order.payments.valid.empty?
+                    order.errors.add(:base, Spree.t(:no_payment_found))
+                    false
+                  elsif order.payment_required?
+                    order.process_payments!
+                  end
                 end
-              end
-              after_transition to: :complete, do: :persist_user_credit_card
-              before_transition to: :payment, do: :set_shipments_cost
-              before_transition to: :payment, do: :create_tax_charge!
-              before_transition to: :payment, do: :assign_default_credit_card
-            end
-
-            before_transition from: :cart, do: :ensure_line_items_present
-
-            if states[:address]
-              before_transition from: :address, do: :create_tax_charge!
-              before_transition to: :address, do: :assign_default_addresses!
-              before_transition from: :address, do: :persist_user_address!
-            end
-
-            if states[:delivery]
-              before_transition to: :delivery, do: :create_proposed_shipments
-              before_transition to: :delivery, do: :ensure_available_shipping_rates
-              before_transition to: :delivery, do: :set_shipments_cost
-              before_transition from: :delivery, do: :apply_free_shipping_promotions
-            end
-
-            before_transition to: :resumed, do: :ensure_line_item_variants_are_not_deleted
-            before_transition to: :resumed, do: :ensure_line_items_are_in_stock
-
-            before_transition to: :complete, do: :ensure_line_item_variants_are_not_deleted
-            before_transition to: :complete, do: :ensure_line_items_are_in_stock
-
-            after_transition to: :complete, do: :finalize!
-            after_transition to: :resumed,  do: :after_resume
-            after_transition to: :canceled, do: :after_cancel
-
-            after_transition from: any - :cart, to: any - [:confirm, :complete] do |order|
-              order.update_totals
-              order.persist_totals
-            end
-          end
-
-          alias_method :save_state, :save
-        end
-
-        def self.go_to_state(name, options = {})
-          self.checkout_steps[name] = options
-          previous_states.each do |state|
-            add_transition({ from: state, to: name }.merge(options))
-          end
-          if options[:if]
-            previous_states << name
-          else
-            self.previous_states = [name]
-          end
-        end
-
-        def self.insert_checkout_step(name, options = {})
-          before = options.delete(:before)
-          after = options.delete(:after) unless before
-          after = self.checkout_steps.keys.last unless before || after
-
-          cloned_steps = self.checkout_steps.clone
-          cloned_removed_transitions = self.removed_transitions.clone
-          checkout_flow do
-            cloned_steps.each_pair do |key, value|
-              go_to_state(name, options) if key == before
-              go_to_state(key, value)
-              go_to_state(name, options) if key == after
-            end
-            cloned_removed_transitions.each do |transition|
-              remove_transition(transition)
-            end
-          end
-        end
-
-        def self.remove_checkout_step(name)
-          cloned_steps = self.checkout_steps.clone
-          cloned_removed_transitions = self.removed_transitions.clone
-          checkout_flow do
-            cloned_steps.each_pair do |key, value|
-              go_to_state(key, value) unless key == name
-            end
-            cloned_removed_transitions.each do |transition|
-              remove_transition(transition)
-            end
-          end
-        end
-
-        def self.remove_transition(options = {})
-          self.removed_transitions << options
-          self.next_event_transitions.delete(find_transition(options))
-        end
-
-        def self.find_transition(options = {})
-          return nil if options.nil? || !options.include?(:from) || !options.include?(:to)
-          self.next_event_transitions.detect do |transition|
-            transition[options[:from].to_sym] == options[:to].to_sym
-          end
-        end
-
-        def self.checkout_step_names
-          self.checkout_steps.keys
-        end
-
-        def self.add_transition(options)
-          self.next_event_transitions << { options.delete(:from) => options.delete(:to) }.merge(options)
-        end
-
-        def checkout_steps
-          steps = (self.class.checkout_steps.each_with_object([]) do |(step, options), checkout_steps|
-            next if options.include?(:if) && !options[:if].call(self)
-            checkout_steps << step
-          end).map(&:to_s)
-          # Ensure there is always a complete step
-          steps << "complete" unless steps.include?("complete")
-          steps
-        end
-
-        def has_checkout_step?(step)
-          step.present? && self.checkout_steps.include?(step)
-        end
-
-        def passed_checkout_step?(step)
-          has_checkout_step?(step) && checkout_step_index(step) < checkout_step_index(state)
-        end
-
-        def checkout_step_index(step)
-          self.checkout_steps.index(step).to_i
-        end
-
-        def can_go_to_state?(state)
-          return false unless has_checkout_step?(self.state) && has_checkout_step?(state)
-          checkout_step_index(state) > checkout_step_index(self.state)
-        end
-
-        define_callbacks :updating_from_params, terminator: ->(_target, result) { result == false }
-
-        set_callback :updating_from_params, :before, :update_params_payment_source
-
-        def update_from_params(params, permitted_params, request_env = {})
-          success = false
-          @updating_params = params
-          run_callbacks :updating_from_params do
-            # Set existing card after setting permitted parameters because
-            # rails would slice parameters containg ruby objects, apparently
-            existing_card_id = @updating_params[:order] ? @updating_params[:order].delete(:existing_card) : nil
-
-            attributes = @updating_params[:order] ? @updating_params[:order].permit(permitted_params).delete_if { |_k, v| v.nil? } : {}
-
-            if existing_card_id.present?
-              credit_card = CreditCard.find existing_card_id
-              if credit_card.user_id != user_id || credit_card.user_id.blank?
-                raise Core::GatewayError.new Spree.t(:invalid_credit_card)
+                after_transition to: :complete, do: :persist_user_credit_card
+                before_transition to: :payment, do: :set_shipments_cost
+                before_transition to: :payment, do: :create_tax_charge!
+                before_transition to: :payment, do: :assign_default_credit_card
               end
 
-              credit_card.verification_value = params[:cvc_confirm] if params[:cvc_confirm].present?
+              before_transition from: :cart, do: :ensure_line_items_present
 
-              attributes[:payments_attributes].first[:source] = credit_card
-              attributes[:payments_attributes].first[:payment_method_id] = credit_card.payment_method_id
-              attributes[:payments_attributes].first.delete :source_attributes
+              if states[:address]
+                before_transition from: :address, do: :create_tax_charge!
+                before_transition to: :address, do: :assign_default_addresses!
+                before_transition from: :address, do: :persist_user_address!
+              end
+
+              if states[:delivery]
+                before_transition to: :delivery, do: :create_proposed_shipments
+                before_transition to: :delivery, do: :ensure_available_shipping_rates
+                before_transition to: :delivery, do: :set_shipments_cost
+                before_transition from: :delivery, do: :apply_free_shipping_promotions
+              end
+
+              before_transition to: :resumed, do: :ensure_line_item_variants_are_not_deleted
+              before_transition to: :resumed, do: :ensure_line_items_are_in_stock
+
+              before_transition to: :complete, do: :ensure_line_item_variants_are_not_deleted
+              before_transition to: :complete, do: :ensure_line_items_are_in_stock
+
+              after_transition to: :complete, do: :finalize!
+              after_transition to: :resumed,  do: :after_resume
+              after_transition to: :canceled, do: :after_cancel
+
+              after_transition from: any - :cart, to: any - [:confirm, :complete] do |order|
+                order.update_totals
+                order.persist_totals
+              end
             end
 
-            if attributes[:payments_attributes]
-              attributes[:payments_attributes].first[:request_env] = request_env
+            alias_method :save_state, :save
+          end
+
+          def self.go_to_state(name, options = {})
+            self.checkout_steps[name] = options
+            previous_states.each do |state|
+              add_transition({ from: state, to: name }.merge(options))
             end
-
-            success = update_attributes(attributes)
-            set_shipments_cost if shipments.any?
-          end
-
-          @updating_params = nil
-          success
-        end
-
-        def assign_default_addresses!
-          if user
-            clone_billing
-            # Skip setting ship address if order doesn't have a delivery checkout step
-            # to avoid triggering validations on shipping address
-            clone_shipping if checkout_steps.include?("delivery")
-          end
-        end
-
-        def clone_billing
-          if !bill_address_id && user.bill_address.try(:valid?)
-            self.bill_address = user.bill_address.try(:clone)
-          end
-        end
-
-        def clone_shipping
-          if !ship_address_id && user.ship_address.try(:valid?)
-            self.ship_address = user.ship_address.try(:clone)
-          end
-        end
-
-        def persist_user_address!
-          if !temporary_address && user && user.respond_to?(:persist_order_address) && bill_address_id
-            user.persist_order_address(self)
-          end
-        end
-
-        def persist_user_credit_card
-          if !temporary_credit_card && user_id && valid_credit_cards.present?
-            default_cc = valid_credit_cards.first
-            default_cc.user_id = user_id
-            default_cc.default = true
-            default_cc.save
-          end
-        end
-
-        def assign_default_credit_card
-          if payments.from_credit_card.count == 0 && user_has_valid_default_card? && payment_required?
-            cc = user.default_credit_card
-            payments.create!(payment_method_id: cc.payment_method_id, source: cc, amount: total)
-          end
-        end
-
-        def user_has_valid_default_card?
-          user && user.default_credit_card.try(:valid?)
-        end
-
-        private
-
-        # For payment step, filter order parameters to produce the expected nested
-        # attributes for a single payment and its source, discarding attributes
-        # for payment methods other than the one selected
-        #
-        # In case a existing credit card is provided it needs to build the payment
-        # attributes from scratch so we can set the amount. example payload:
-        #
-        #   {
-        #     "order": {
-        #       "existing_card": "2"
-        #     }
-        #   }
-        #
-        def update_params_payment_source
-          if @updating_params[:payment_source].present?
-            source_params = @updating_params.
-                            delete(:payment_source)[@updating_params[:order][:payments_attributes].
-                                                    first[:payment_method_id].to_s]
-
-            if source_params
-              @updating_params[:order][:payments_attributes].first[:source_attributes] = source_params
+            if options[:if]
+              previous_states << name
+            else
+              self.previous_states = [name]
             end
           end
 
-          if @updating_params[:order] && (@updating_params[:order][:payments_attributes] ||
-                                          @updating_params[:order][:existing_card])
-            @updating_params[:order][:payments_attributes] ||= [{}]
-            @updating_params[:order][:payments_attributes].first[:amount] = total
+          def self.insert_checkout_step(name, options = {})
+            before = options.delete(:before)
+            after = options.delete(:after) unless before
+            after = self.checkout_steps.keys.last unless before || after
+
+            cloned_steps = self.checkout_steps.clone
+            cloned_removed_transitions = self.removed_transitions.clone
+            checkout_flow do
+              cloned_steps.each_pair do |key, value|
+                go_to_state(name, options) if key == before
+                go_to_state(key, value)
+                go_to_state(name, options) if key == after
+              end
+              cloned_removed_transitions.each do |transition|
+                remove_transition(transition)
+              end
+            end
+          end
+
+          def self.remove_checkout_step(name)
+            cloned_steps = self.checkout_steps.clone
+            cloned_removed_transitions = self.removed_transitions.clone
+            checkout_flow do
+              cloned_steps.each_pair do |key, value|
+                go_to_state(key, value) unless key == name
+              end
+              cloned_removed_transitions.each do |transition|
+                remove_transition(transition)
+              end
+            end
+          end
+
+          def self.remove_transition(options = {})
+            self.removed_transitions << options
+            self.next_event_transitions.delete(find_transition(options))
+          end
+
+          def self.find_transition(options = {})
+            return nil if options.nil? || !options.include?(:from) || !options.include?(:to)
+            self.next_event_transitions.detect do |transition|
+              transition[options[:from].to_sym] == options[:to].to_sym
+            end
+          end
+
+          def self.checkout_step_names
+            self.checkout_steps.keys
+          end
+
+          def self.add_transition(options)
+            self.next_event_transitions << { options.delete(:from) => options.delete(:to) }.merge(options)
+          end
+
+          def checkout_steps
+            steps = (self.class.checkout_steps.each_with_object([]) do |(step, options), checkout_steps|
+              next if options.include?(:if) && !options[:if].call(self)
+              checkout_steps << step
+            end).map(&:to_s)
+            # Ensure there is always a complete step
+            steps << "complete" unless steps.include?("complete")
+            steps
+          end
+
+          def has_checkout_step?(step)
+            step.present? && self.checkout_steps.include?(step)
+          end
+
+          def passed_checkout_step?(step)
+            has_checkout_step?(step) && checkout_step_index(step) < checkout_step_index(state)
+          end
+
+          def checkout_step_index(step)
+            self.checkout_steps.index(step).to_i
+          end
+
+          def can_go_to_state?(state)
+            return false unless has_checkout_step?(self.state) && has_checkout_step?(state)
+            checkout_step_index(state) > checkout_step_index(self.state)
+          end
+
+          define_callbacks :updating_from_params, terminator: ->(_target, result) { result == false }
+
+          set_callback :updating_from_params, :before, :update_params_payment_source
+
+          def update_from_params(params, permitted_params, request_env = {})
+            success = false
+            @updating_params = params
+            run_callbacks :updating_from_params do
+              # Set existing card after setting permitted parameters because
+              # rails would slice parameters containg ruby objects, apparently
+              existing_card_id = @updating_params[:order] ? @updating_params[:order].delete(:existing_card) : nil
+
+              attributes = @updating_params[:order] ? @updating_params[:order].permit(permitted_params).delete_if { |_k, v| v.nil? } : {}
+
+              if existing_card_id.present?
+                credit_card = CreditCard.find existing_card_id
+                if credit_card.user_id != user_id || credit_card.user_id.blank?
+                  raise Core::GatewayError.new Spree.t(:invalid_credit_card)
+                end
+
+                credit_card.verification_value = params[:cvc_confirm] if params[:cvc_confirm].present?
+
+                attributes[:payments_attributes].first[:source] = credit_card
+                attributes[:payments_attributes].first[:payment_method_id] = credit_card.payment_method_id
+                attributes[:payments_attributes].first.delete :source_attributes
+              end
+
+              if attributes[:payments_attributes]
+                attributes[:payments_attributes].first[:request_env] = request_env
+              end
+
+              success = update_attributes(attributes)
+              set_shipments_cost if shipments.any?
+            end
+
+            @updating_params = nil
+            success
+          end
+
+          def assign_default_addresses!
+            if user
+              clone_billing
+              # Skip setting ship address if order doesn't have a delivery checkout step
+              # to avoid triggering validations on shipping address
+              clone_shipping if checkout_steps.include?("delivery")
+            end
+          end
+
+          def clone_billing
+            if !bill_address_id && user.bill_address.try(:valid?)
+              self.bill_address = user.bill_address.try(:clone)
+            end
+          end
+
+          def clone_shipping
+            if !ship_address_id && user.ship_address.try(:valid?)
+              self.ship_address = user.ship_address.try(:clone)
+            end
+          end
+
+          def persist_user_address!
+            if !temporary_address && user && user.respond_to?(:persist_order_address) && bill_address_id
+              user.persist_order_address(self)
+            end
+          end
+
+          def persist_user_credit_card
+            if !temporary_credit_card && user_id && valid_credit_cards.present?
+              default_cc = valid_credit_cards.first
+              default_cc.user_id = user_id
+              default_cc.default = true
+              default_cc.save
+            end
+          end
+
+          def assign_default_credit_card
+            if payments.from_credit_card.count == 0 && user_has_valid_default_card? && payment_required?
+              cc = user.default_credit_card
+              payments.create!(payment_method_id: cc.payment_method_id, source: cc, amount: total)
+            end
+          end
+
+          def user_has_valid_default_card?
+            user && user.default_credit_card.try(:valid?)
+          end
+
+          private
+
+          # For payment step, filter order parameters to produce the expected nested
+          # attributes for a single payment and its source, discarding attributes
+          # for payment methods other than the one selected
+          #
+          # In case a existing credit card is provided it needs to build the payment
+          # attributes from scratch so we can set the amount. example payload:
+          #
+          #   {
+          #     "order": {
+          #       "existing_card": "2"
+          #     }
+          #   }
+          #
+          def update_params_payment_source
+            if @updating_params[:payment_source].present?
+              source_params = @updating_params.
+                              delete(:payment_source)[@updating_params[:order][:payments_attributes].
+                                                      first[:payment_method_id].to_s]
+
+              if source_params
+                @updating_params[:order][:payments_attributes].first[:source_attributes] = source_params
+              end
+            end
+
+            if @updating_params[:order] && (@updating_params[:order][:payments_attributes] ||
+                                            @updating_params[:order][:existing_card])
+              @updating_params[:order][:payments_attributes] ||= [{}]
+              @updating_params[:order][:payments_attributes].first[:amount] = total
+            end
           end
         end
       end

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -51,9 +51,9 @@ module Spree
                 order.state = order.state
                 order.state_changes.create(
                   previous_state: transition.from,
-                  next_state:     transition.to,
-                  name:           'order',
-                  user_id:        order.user_id
+                  next_state: transition.to,
+                  name: 'order',
+                  user_id: order.user_id
                 )
                 order.save
               end
@@ -113,7 +113,7 @@ module Spree
               before_transition to: :complete, do: :ensure_line_items_are_in_stock
 
               after_transition to: :complete, do: :finalize!
-              after_transition to: :resumed,  do: :after_resume
+              after_transition to: :resumed, do: :after_resume
               after_transition to: :canceled, do: :after_cancel
 
               after_transition from: any - :cart, to: any - [:confirm, :complete] do |order|

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Order < Spree::Base
+  class Order
     module Checkout
       extend ActiveSupport::Concern
 


### PR DESCRIPTION
After updating my Gemfile with the following settings:

``` ruby
github 'spree', branch: '3-0-stable' do
  gem 'spree_backend'
  gem 'spree_sample'
end
```

The generate Gemfile.lock references were:

``` yaml
GIT
  remote: git://github.com/spree/spree.git
  revision: 222ae3a9dfa98356d052ff0472a4663d9c5c3f79
  branch: 3-0-stable
  specs:
    spree_api (3.0.3.beta)
      rabl (~> 0.9.4.pre1)
      spree_core (= 3.0.3.beta)
      versioncake (~> 2.3.1)
    spree_backend (3.0.3.beta)
      bootstrap-sass (~> 3.3.1)
      jquery-rails (~> 4.0.3)
      jquery-ui-rails (~> 5.0.0)
      select2-rails (= 3.5.9.1)
      spree_api (= 3.0.3.beta)
      spree_core (= 3.0.3.beta)
      sprockets-rails (~> 2.2)
    spree_core (3.0.3.beta)
      activemerchant (~> 1.47.0)
      acts_as_list (~> 0.6)
      awesome_nested_set (~> 3.0.1)
      cancancan (~> 1.10.1)
      carmen (~> 1.0.0)
      deface (~> 1.0.0)
      ffaker (~> 1.16)
      font-awesome-rails (~> 4.0)
      friendly_id (~> 5.1.0)
      highline (~> 1.6.18)
      httparty (~> 0.11)
      json (~> 1.7)
      kaminari (~> 0.15, >= 0.15.1)
      monetize (~> 1.1)
      paperclip (~> 4.2.0)
      paranoia (~> 2.1.0)
      premailer-rails
      rails (~> 4.2.2)
      ransack (~> 1.4.1)
      responders
      state_machines-activerecord (~> 0.2)
      stringex
      truncate_html (= 0.9.2)
      twitter_cldr (~> 3.0)
    spree_sample (3.0.3.beta)
      spree_core (= 3.0.3.beta)
```

I then booted my rails application with `foreman start`.

``` yaml
# Procfile
web: spring rails server
cache: redis-server config/redis.conf
worker: bundle exec sidekiq -C config/sidekiq.yml
search: elasticsearch --config=/usr/local/opt/elasticsearch/config/elasticsearch.yml
```

The output and the reason for this bug fix is presented here:

``` log
$ fs
21:28:36 web.1    | started with pid 84344
21:28:36 cache.1  | started with pid 84346
21:28:36 worker.1 | started with pid 84348
21:28:36 search.1 | started with pid 84349
21:28:37 search.1 | [2015-07-21 21:28:37,556][INFO ][node                     ] [Sphinx] version[1.5.2], pid[84349], build[62ff986/2015-04-27T09:21:06Z]
21:28:37 search.1 | [2015-07-21 21:28:37,556][INFO ][node                     ] [Sphinx] initializing ...
21:28:37 search.1 | [2015-07-21 21:28:37,562][INFO ][plugins                  ] [Sphinx] loaded [], sites []
21:28:41 search.1 | [2015-07-21 21:28:41,175][INFO ][node                     ] [Sphinx] initialized
21:28:41 search.1 | [2015-07-21 21:28:41,177][INFO ][node                     ] [Sphinx] starting ...
21:28:41 search.1 | [2015-07-21 21:28:41,393][INFO ][transport                ] [Sphinx] bound_address {inet[/127.0.0.1:9300]}, publish_address {inet[/127.0.0.1:9300]}
21:28:41 search.1 | [2015-07-21 21:28:41,428][INFO ][discovery                ] [Sphinx] elasticsearch_brew/DJXdDnCKTVezO1D1ql4tjg
21:28:45 search.1 | [2015-07-21 21:28:45,212][INFO ][cluster.service          ] [Sphinx] new_master [Sphinx][DJXdDnCKTVezO1D1ql4tjg][BENJAMINs-MacBook-Pro.local][inet[/127.0.0.1:9300]], reason: zen-disco-join (elected_as_master)
21:28:45 search.1 | [2015-07-21 21:28:45,233][INFO ][http                     ] [Sphinx] bound_address {inet[/127.0.0.1:9200]}, publish_address {inet[/127.0.0.1:9200]}
21:28:45 search.1 | [2015-07-21 21:28:45,233][INFO ][node                     ] [Sphinx] started
21:28:46 search.1 | [2015-07-21 21:28:46,014][INFO ][gateway                  ] [Sphinx] recovered [1] indices into cluster_state
21:28:47 web.1    | => Booting Puma
21:28:47 web.1    | => Rails 4.2.3 application starting in development on http://0.0.0.0:3000
21:28:47 web.1    | => Run `rails server -h` for more startup options
21:28:47 web.1    | => Ctrl-C to shutdown server
21:28:51 web.1    | Puma 2.11.2 starting...
21:28:51 web.1    | * Min threads: 0, max threads: 16
21:28:51 web.1    | * Environment: development
21:28:51 web.1    | * Listening on tcp://0.0.0.0:3000
21:28:51 worker.1 | Cannot define multiple 'included' blocks for a Concern
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/activesupport-4.2.3/lib/active_support/concern.rb:126:in `included'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/bundler/gems/spree-222ae3a9dfa9/core/app/models/spree/order/checkout.rb:6:in `<module:Checkout>'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/bundler/gems/spree-222ae3a9dfa9/core/app/models/spree/order/checkout.rb:3:in `<class:Order>'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/bundler/gems/spree-222ae3a9dfa9/core/app/models/spree/order/checkout.rb:2:in `<module:Spree>'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/bundler/gems/spree-222ae3a9dfa9/core/app/models/spree/order/checkout.rb:1:in `<top (required)>'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:457:in `load'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:457:in `block in load_file'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:647:in `new_constants_in'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:456:in `load_file'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:354:in `require_or_load'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:317:in `depend_on'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:233:in `require_dependency'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/railties-4.2.3/lib/rails/engine.rb:472:in `block (2 levels) in eager_load!'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/railties-4.2.3/lib/rails/engine.rb:471:in `each'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/railties-4.2.3/lib/rails/engine.rb:471:in `block in eager_load!'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/railties-4.2.3/lib/rails/engine.rb:469:in `each'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/railties-4.2.3/lib/rails/engine.rb:469:in `eager_load!'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/railties-4.2.3/lib/rails/engine.rb:346:in `eager_load!'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/railties-4.2.3/lib/rails/application/finisher.rb:56:in `each'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/railties-4.2.3/lib/rails/application/finisher.rb:56:in `block in <module:Finisher>'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/railties-4.2.3/lib/rails/initializable.rb:30:in `instance_exec'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/railties-4.2.3/lib/rails/initializable.rb:30:in `run'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/railties-4.2.3/lib/rails/initializable.rb:55:in `block in run_initializers'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/tsort.rb:226:in `block in tsort_each'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/tsort.rb:348:in `block (2 levels) in each_strongly_connected_component'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/tsort.rb:429:in `each_strongly_connected_component_from'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/tsort.rb:347:in `block in each_strongly_connected_component'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/tsort.rb:345:in `each'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/tsort.rb:345:in `call'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/tsort.rb:345:in `each_strongly_connected_component'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/tsort.rb:224:in `tsort_each'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/tsort.rb:203:in `tsort_each'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/railties-4.2.3/lib/rails/initializable.rb:54:in `run_initializers'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/railties-4.2.3/lib/rails/application.rb:352:in `initialize!'
21:28:51 worker.1 | /Users/BenAMorgan/Sites/private/WholeNewHome/config/environment.rb:5:in `<top (required)>'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/skylight-0.6.0/lib/skylight/probes.rb:81:in `require'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/skylight-0.6.0/lib/skylight/probes.rb:81:in `require'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/polyglot-0.3.5/lib/polyglot.rb:65:in `require'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:274:in `block in require'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:240:in `load_dependency'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:274:in `require'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/sidekiq-3.3.4/lib/sidekiq/cli.rb:241:in `boot_system'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/sidekiq-3.3.4/lib/sidekiq/cli.rb:50:in `run'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/sidekiq-3.3.4/bin/sidekiq:8:in `<top (required)>'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/bin/sidekiq:23:in `load'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/bin/sidekiq:23:in `<main>'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/bin/ruby_executable_hooks:15:in `eval'
21:28:51 worker.1 | /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/bin/ruby_executable_hooks:15:in `<main>'
21:28:51 worker.1 | exited with code 1
21:28:51 system   | sending SIGTERM to all processes
21:28:51 web.1    | Exiting
21:28:51 search.1 | [2015-07-21 21:28:51,765][INFO ][node                     ] [Sphinx] stopping ...
21:28:51 search.1 | [2015-07-21 21:28:51,815][INFO ][node                     ] [Sphinx] stopped
21:28:51 search.1 | [2015-07-21 21:28:51,815][INFO ][node                     ] [Sphinx] closing ...
21:28:51 search.1 | [2015-07-21 21:28:51,821][INFO ][node                     ] [Sphinx] closed
21:28:51 cache.1  | exited with code 0
21:28:51 search.1 | exited with code 143
21:28:52 web.1    | terminated by SIGTERM
```

On investigation, I discovered that @darbs has updated the `Spree::Order::Checkout` module as an `ActiveSupport::Concern` in 11cd50c0f5936af23130b0394c0cd7964e48fdb3. As lovely as this is, this generated a regression inside of Spree. It caused the `Cannot define multiple 'included' blocks for a Concern` error; no class given by Rails, may be nice to give them a PR on this issue with a better error message.

I'm not too sure why this has occurred. My initial thought was that it was because `ActiveRecord::Base` was using  the `#included` method. After looking inside of [`ActiveRecord::Base`](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/base.rb) I wasn't able to see any instances where it was used, even in its dependencies.

Maybe we can change the modules out into concerns when Spree hits 4.0.

Anywho, my first attempt was to remove the `Spree::Base` in be1bc24, that way `ActiveSupport::Concern` doesn't think its working with a table. (It was an idea.) The error that I got from that was:

```
superclass mismatch for class Order
```

Then I realized: Just revert to the legacy since extending from `ActiveSupport::Concern` has generated a regression. After cff2e04 the rails application that I was working on didn't crash on server boot.
