### PR TITLE
Namespace Order Events

### DIFF
--- a/backend/app/helpers/spree/admin/orders_helper.rb
+++ b/backend/app/helpers/spree/admin/orders_helper.rb
@@ -6,10 +6,14 @@ module Spree
         links = []
         @order_events.sort.each do |event|
           if @order.send("can_#{event}?")
-            links << button_link_to(Spree.t(event).capitalize, [event, :admin, @order],
-                                    :method => :put,
-                                    :icon => "#{event}",
-                                    :data => { :confirm => Spree.t(:order_sure_want_to, :event => Spree.t(event)) })
+            label = Spree.t(event, scope: 'admin.order.events', default: Spree.t(event))
+            links << button_link_to(
+              label.capitalize,
+              [event, :admin, @order],
+              method: :put,
+              icon: "#{event}",
+              data: { confirm: Spree.t(:order_sure_want_to, event: label) }
+            )
           end
         end
         links.join(' ').html_safe

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -437,6 +437,11 @@ en:
         taxonomies: Taxonomies
         taxons: Taxons
         users: Users
+      order:
+        events:
+          approve: approve
+          cancel: cancel
+          resume: resume
       user:
         account: Account
         addresses: Addresses


### PR DESCRIPTION
In German, to 'cancel' an order has to be a specific word ("stornieren") that is different from e.g.  canceling a UI dialog ("abbrechen"). Since "cancel" is used in the `event_links` helper for the `Cancel order` button, I get a (for a German) slightly confusing thing that hints at me being able to somehow "close" an order.

This commit introduces namespacing just for this helper. I will also provide a PR to provide the necessary translations to the German translation in `spree_i18n`.

Since other Spree extension might be using this helper and only provide non-namespaced event translations, I call `Spree.t` with `default: Spree.t(event)`.
