### PR TITLE
Namespace resend event, simplify admin order partials

### DIFF
--- a/backend/app/helpers/spree/admin/orders_helper.rb
+++ b/backend/app/helpers/spree/admin/orders_helper.rb
@@ -2,14 +2,14 @@ module Spree
   module Admin
     module OrdersHelper
       # Renders all the extension partials that may have been specified in the extensions
-      def event_links
+      def event_links(order, events)
         links = []
-        @order_events.sort.each do |event|
-          if @order.send("can_#{event}?")
+        events.sort.each do |event|
+          if order.send("can_#{event}?")
             label = Spree.t(event, scope: 'admin.order.events', default: Spree.t(event))
             links << button_link_to(
               label.capitalize,
-              [event, :admin, @order],
+              [event, :admin, order],
               method: :put,
               icon: "#{event}",
               data: { confirm: Spree.t(:order_sure_want_to, event: label) }

--- a/backend/app/views/spree/admin/orders/_add_line_item.html.erb
+++ b/backend/app/views/spree/admin/orders/_add_line_item.html.erb
@@ -1,6 +1,6 @@
-<%= render :partial => "spree/admin/variants/autocomplete", :formats => :js %>
+<%= render partial: "spree/admin/variants/autocomplete", formats: :js %>
 
-<%= render :partial => "spree/admin/variants/autocomplete_line_items_stock", :formats => :js %>
+<%= render partial: "spree/admin/variants/autocomplete_line_items_stock", formats: :js %>
 
 <div id="add-line-item" data-hook class="panel panel-default">
   <div class="panel-heading">
@@ -13,5 +13,5 @@
     </div>
 
     <div id="stock_details"></div>
-  </div>  
+  </div>
 </div>

--- a/backend/app/views/spree/admin/orders/_add_product.html.erb
+++ b/backend/app/views/spree/admin/orders/_add_product.html.erb
@@ -1,10 +1,10 @@
-<%= render :partial => "spree/admin/variants/autocomplete", :formats => :js %>
-<%= render :partial => "spree/admin/variants/autocomplete_stock", :formats => :js %>
+<%= render partial: "spree/admin/variants/autocomplete", formats: :js %>
+<%= render partial: "spree/admin/variants/autocomplete_stock", formats: :js %>
 
 <div class="panel panel-default" id="add-line-item" data-hook>
   <div class="panel-heading">
     <h1 class="panel-title">
-      <%= Spree.t(:add_product) %>  
+      <%= Spree.t(:add_product) %>
     </h1>
   </div>
   <div class="panel-body">

--- a/backend/app/views/spree/admin/orders/_form.html.erb
+++ b/backend/app/views/spree/admin/orders/_form.html.erb
@@ -1,29 +1,29 @@
  <div data-hook="admin_order_form_fields">
   <% if @line_item.try(:errors).present? %>
-    <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @line_item } %>
+    <%= render 'spree/admin/shared/error_messages', target: @line_item %>
   <% end %>
 
   <% if Spree::Order.checkout_step_names.include?(:delivery) %>
-    <%= render :partial => "spree/admin/orders/shipment", :collection => @order.shipments.order(:created_at), :locals => { :order => order } %>
+    <%= render partial: "spree/admin/orders/shipment", collection: @order.shipments.order(:created_at), locals: {order: order} %>
   <% else %>
-    <%= render :partial => "spree/admin/orders/line_items", :locals => { :order => order } %>
+    <%= render "spree/admin/orders/line_items", order: order %>
   <% end %>
 
-  <%= render :partial => "spree/admin/orders/adjustments", :locals => {
-        :adjustments => @order.line_item_adjustments,
-        :order => order,
-        :title => Spree.t(:line_item_adjustments)
-   } %>
-  <%= render :partial => "spree/admin/orders/adjustments", :locals => {
-        :adjustments => @order.shipment_adjustments,
-        :order => order,
-        :title => Spree.t(:shipment_adjustments)
-   } %>
-  <%= render :partial => "spree/admin/orders/adjustments", :locals => {
-        :adjustments => @order.adjustments,
-        :order => order,
-        :title => Spree.t(:order_adjustments)
-   } %>
+  <%= render "spree/admin/orders/adjustments",
+        adjustments: @order.line_item_adjustments,
+        order: order,
+        title: Spree.t(:line_item_adjustments)
+  %>
+  <%= render "spree/admin/orders/adjustments",
+        adjustments: @order.shipment_adjustments,
+        order: order,
+        title: Spree.t(:shipment_adjustments)
+  %>
+  <%= render "spree/admin/orders/adjustments",
+        adjustments: @order.adjustments,
+        order: order,
+        title: Spree.t(:order_adjustments)
+  %>
 
   <% if order.line_items.exists? %>
     <div class="alert alert-success" id="order-total" data-hook="order_details_total">
@@ -41,16 +41,16 @@
     <% @order.shipments.each do |shipment| %>
       shipments.push(
         <%== shipment.as_json(
-          :root => false,
-          :only => [
+          root: false,
+          only: [
             :id, :tracking, :number, :state, :stock_location_id
-          ], :include => [
+          ], include: [
             :inventory_units, :stock_location
           ]).to_json
         %>
       );
     <% end %>
 
-    <%= render :partial => 'spree/admin/shared/update_order_state', :handlers => [:js] %>
+    <%= render partial: 'spree/admin/shared/update_order_state', handlers: [:js] %>
   <% end %>
 </div>

--- a/backend/app/views/spree/admin/orders/_line_items.html.erb
+++ b/backend/app/views/spree/admin/orders/_line_items.html.erb
@@ -27,15 +27,15 @@
               <%= item.quantity %>
             </td>
             <td class="line-item-qty-edit is-hidden">
-              <%= number_field_tag :quantity, item.quantity, :min => 0, :class => "line_item_quantity form-control", :size => 5 %>
+              <%= number_field_tag :quantity, item.quantity, min: 0, class: "line_item_quantity form-control", size: 5 %>
             </td>
             <td class="line-item-total text-center"><%= line_item_shipment_price(item, item.quantity) %></td>
             <td class="cart-line-item-delete actions actions-4 text-center" data-hook="cart_line_item_delete">
               <% if can? :update, item %>
-                <%= link_to_with_icon 'arrow-left', Spree.t('actions.cancel'), "#", :class => 'cancel-line-item btn btn-default btn-sm', :data => {:action => 'cancel'}, :title => Spree.t('actions.cancel'), :style => 'display: none', :no_text => true %>
-                <%= link_to_with_icon 'save', Spree.t('actions.save'), "#", :class => 'save-line-item btn btn-success btn-sm', :no_text => true, :data => { :'line-item-id' => item.id, :action => 'save'}, :title => Spree.t('actions.save'), :style => 'display: none' %>
-                <%= link_to_with_icon 'edit', Spree.t('edit'), "#", :class => 'edit-line-item btn btn-primary btn-sm', :data => {:action => 'edit'}, :title => Spree.t('edit'), :no_text => true %>
-                <%= link_to_with_icon 'delete', Spree.t('delete'), "#", :class => 'delete-line-item btn btn-danger btn-sm', :data => { 'line-item-id' => item.id, :action => 'remove'}, :title => Spree.t('delete'), :no_text => true %>
+                <%= link_to_with_icon 'arrow-left', Spree.t('actions.cancel'), "#", class: 'cancel-line-item btn btn-default btn-sm', data: {action: 'cancel'}, title: Spree.t('actions.cancel'), style: 'display: none', no_text: true %>
+                <%= link_to_with_icon 'save', Spree.t('actions.save'), "#", class: 'save-line-item btn btn-success btn-sm', no_text: true, data: { :'line-item-id' => item.id, action: 'save'}, title: Spree.t('actions.save'), style: 'display: none' %>
+                <%= link_to_with_icon 'edit', Spree.t('edit'), "#", class: 'edit-line-item btn btn-primary btn-sm', data: {action: 'edit'}, title: Spree.t('edit'), no_text: true %>
+                <%= link_to_with_icon 'delete', Spree.t('delete'), "#", class: 'delete-line-item btn btn-danger btn-sm', data: { 'line-item-id' => item.id, action: 'remove'}, title: Spree.t('delete'), no_text: true %>
               <% end %>
             </td>
           </tr>

--- a/backend/app/views/spree/admin/orders/_line_items_edit_form.html.erb
+++ b/backend/app/views/spree/admin/orders/_line_items_edit_form.html.erb
@@ -1,24 +1,24 @@
 <div data-hook="admin_order_form_fields">
   <% if @line_item.try(:errors).present? %>
-      <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @line_item } %>
+      <%= render 'spree/admin/shared/error_messages', target: @line_item %>
   <% end %>
 
-  <%= render :partial => "spree/admin/orders/line_items", :locals => { :order => order } %>
-  <%= render :partial => "spree/admin/orders/adjustments", :locals => {
-          :adjustments => @order.line_item_adjustments,
-          :order => order,
-          :title => Spree.t(:line_item_adjustments)
-  } %>
-  <%= render :partial => "spree/admin/orders/adjustments", :locals => {
-          :adjustments => @order.shipment_adjustments,
-          :order => order,
-          :title => Spree.t(:shipment_adjustments)
-  } %>
-  <%= render :partial => "spree/admin/orders/adjustments", :locals => {
-          :adjustments => @order.adjustments,
-          :order => order,
-          :title => Spree.t(:order_adjustments)
-  } %>
+  <%= render "spree/admin/orders/line_items", order: order %>
+  <%= render "spree/admin/orders/adjustments",
+          adjustments: @order.line_item_adjustments,
+          order: order,
+          title: Spree.t(:line_item_adjustments)
+  %>
+  <%= render "spree/admin/orders/adjustments",
+          adjustments: @order.shipment_adjustments,
+          order: order,
+          title: Spree.t(:shipment_adjustments)
+  %>
+  <%= render "spree/admin/orders/adjustments",
+          adjustments: @order.adjustments,
+          order: order,
+          title: Spree.t(:order_adjustments)
+  %>
 
   <% if order.line_items.exists? %>
     <div class="alert alert-success" id="order-total" data-hook="order_details_total">
@@ -31,9 +31,9 @@
     var shipments = [];
 
     <% @order.shipments.each do |shipment| %>
-      shipments.push(<%== shipment.as_json(:root => false, :only => [:id, :tracking, :number, :state, :stock_location_id], :include => [:inventory_units, :stock_location]).to_json %>);
+      shipments.push(<%== shipment.as_json(root: false, only: [:id, :tracking, :number, :state, :stock_location_id], include: [:inventory_units, :stock_location]).to_json %>);
     <% end %>
 
-    <%= render :partial => 'spree/admin/shared/update_order_state', :handlers => [:js] %>
+    <%= render partial: 'spree/admin/shared/update_order_state', handlers: [:js] %>
   <% end %>
 </div>

--- a/backend/app/views/spree/admin/orders/_order_actions.html.erb
+++ b/backend/app/views/spree/admin/orders/_order_actions.html.erb
@@ -3,6 +3,10 @@
     <%= event_links(order, events) %>
   <% end %>
   <% if can?(:resend, order) %>
-    <%= button_link_to Spree.t(:resend), resend_admin_order_url(order), method: :post, icon: 'envelope' %>
+    <%= button_link_to Spree.t(:resend, scope: 'admin.order.events', default: Spree.t(:resend)),
+          resend_admin_order_url(order),
+          method: :post,
+          icon: 'envelope'
+    %>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/orders/_order_actions.html.erb
+++ b/backend/app/views/spree/admin/orders/_order_actions.html.erb
@@ -1,0 +1,8 @@
+<% content_for :page_actions do %>
+  <% if can?(:fire, order) %>
+    <%= event_links(order, events) %>
+  <% end %>
+  <% if can?(:resend, order) %>
+    <%= button_link_to Spree.t(:resend), resend_admin_order_url(order), method: :post, icon: 'envelope' %>
+  <% end %>
+<% end %>

--- a/backend/app/views/spree/admin/orders/cart.html.erb
+++ b/backend/app/views/spree/admin/orders/cart.html.erb
@@ -1,23 +1,16 @@
-<% content_for :page_actions do %>
-  <% if can?(:fire, @order) %>
-    <%= event_links %>
-  <% end %>
-  <% if can?(:resend, @order) %>
-    <%= button_link_to Spree.t(:resend), resend_admin_order_url(@order), method: :post, icon: 'envelope' %>
-  <% end %>
-<% end %>
+<%= render 'order_actions', order: @order, events: @order_events %>
 
-<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: :cart } %>
+<%= render 'spree/admin/shared/order_tabs', current: :cart %>
 
 <div data-hook="admin_order_edit_header">
-  <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @order } %>
+  <%= render 'spree/admin/shared/error_messages', target: @order %>
 </div>
 
 <% if @order.payments.exists? && @order.considered_risky? %>
   <%= render 'spree/admin/orders/risk_analysis', latest_payment: @order.payments.order("created_at DESC").first %>
 <% end %>
 
-<%= render partial: 'add_line_item' if can?(:update, @order) %>
+<%= render 'add_line_item' if can?(:update, @order) %>
 
 <% if @order.line_items.empty? %>
   <div class="alert alert-warning">
@@ -27,7 +20,7 @@
 
 <div data-hook="admin_order_edit_form">
   <div id="order-form-wrapper">
-    <%= render partial: 'line_items_edit_form', locals: { order: @order } %>
+    <%= render 'line_items_edit_form', order: @order %>
   </div>
 </div>
 
@@ -35,4 +28,4 @@
   <%= javascript_tag 'var expand_variants = true;' %>
 <% end %>
 
-<%= render partial: 'spree/admin/shared/order_summary' %>
+<%= render 'spree/admin/shared/order_summary' %>

--- a/backend/app/views/spree/admin/orders/customer_details/_form.html.erb
+++ b/backend/app/views/spree/admin/orders/customer_details/_form.html.erb
@@ -62,10 +62,10 @@
         <div class="panel-body">
           <% if can? :edit, @order.user %>
             <%= f.fields_for :bill_address do |ba_form| %>
-              <%= render partial: 'spree/admin/shared/address_form', locals: { f: ba_form, type: "billing" } %>
+              <%= render 'spree/admin/shared/address_form', f: ba_form, type: "billing" %>
             <% end %>
           <% else %>
-            <%= render partial: 'spree/admin/shared/address', locals: { address: @order.bill_address } %>
+            <%= render 'spree/admin/shared/address', address: @order.bill_address %>
           <% end %>
         </div>
       </div>
@@ -86,10 +86,10 @@
                 </span>
               </div>
 
-              <%= render partial: 'spree/admin/shared/address_form', locals: { f: sa_form, type: 'shipping' } %>
+              <%= render 'spree/admin/shared/address_form', f: sa_form, type: 'shipping' %>
             <% end %>
           <% else %>
-            <%= render partial: 'spree/admin/shared/address', locals: { address: @order.ship_address } %>
+            <%= render 'spree/admin/shared/address', address: @order.ship_address %>
           <% end %>
         </div>
       </div>

--- a/backend/app/views/spree/admin/orders/customer_details/edit.html.erb
+++ b/backend/app/views/spree/admin/orders/customer_details/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: :customer_details } %>
+<%= render 'spree/admin/shared/order_tabs', current: :customer_details %>
 
 <% content_for :page_title do %>
   / <%= Spree.t(:customer_details) %>
@@ -18,7 +18,7 @@
   </div>
 <% end %>
 
-<%= render partial: 'spree/admin/shared/error_messages', locals: { target: @order } %>
+<%= render 'spree/admin/shared/error_messages', target: @order %>
 
 <%= form_for @order, url: spree.admin_order_customer_url(@order) do |f| %>
   <%= render 'form', f: f %>
@@ -26,4 +26,4 @@
 
 <br>
 
-<%= render partial: 'spree/admin/shared/order_summary' %>
+<%= render 'spree/admin/shared/order_summary' %>

--- a/backend/app/views/spree/admin/orders/edit.html.erb
+++ b/backend/app/views/spree/admin/orders/edit.html.erb
@@ -1,27 +1,20 @@
-<% content_for :page_actions do %>
-  <% if can?(:fire, @order) %>
-    <%= event_links %>
-  <% end %>
-  <% if can?(:resend, @order) %>
-    <%= button_link_to Spree.t(:resend), resend_admin_order_url(@order), method: :post, icon: 'envelope' %>
-  <% end %>
-<% end %>
+<%= render 'order_actions', order: @order, events: @order_events %>
 
-<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: :shipments } %>
+<%= render 'spree/admin/shared/order_tabs', current: :shipments %>
 
 <% content_for :page_title do %>
   / <%= plural_resource_name(Spree::Shipment) %>
 <% end %>
 
 <div data-hook="admin_order_edit_header">
-  <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @order } %>
+  <%= render 'spree/admin/shared/error_messages', target: @order %>
 </div>
 
 <% if @order.payments.valid.any? && @order.considered_risky? %>
   <%= render 'spree/admin/orders/risk_analysis', latest_payment: @order.payments.valid.last %>
 <% end %>
 
-<%= render partial: 'add_product' if @order.shipment_state != 'shipped' && can?(:update, @order) %>
+<%= render 'add_product' if @order.shipment_state != 'shipped' && can?(:update, @order) %>
 
 <% if @order.line_items.empty? %>
   <div class="alert alert-warning">
@@ -39,4 +32,4 @@
   <%= javascript_tag 'var expand_variants = true;' %>
 <% end %>
 
-<%= render partial: 'spree/admin/shared/order_summary' %>
+<%= render 'spree/admin/shared/order_summary' %>

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -145,7 +145,7 @@
 
 <% end %>
 
-<%= render :partial => 'spree/admin/shared/index_table_options', :locals => { :collection => @orders } %>
+<%= render 'spree/admin/shared/index_table_options', collection: @orders %>
 
 <% if @orders.any? %>
   <table class="table" id="listing_orders" data-hook>
@@ -221,4 +221,4 @@
   </div>
 <% end %>
 
-<%= render :partial => 'spree/admin/shared/index_table_options', :locals => { :collection => @orders, :simple => true } %>
+<%= render 'spree/admin/shared/index_table_options', collection: @orders, simple: true %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -442,6 +442,7 @@ en:
           approve: approve
           cancel: cancel
           resume: resume
+          resend: Resend
       user:
         account: Account
         addresses: Addresses
@@ -1113,7 +1114,6 @@ en:
     report: Report
     reports: Reports
     resellable: Resellable
-    resend: Resend
     reset_password: Reset my password
     response_code: Response Code
     resume: resume


### PR DESCRIPTION
Four minor changes: 
- `resend` event namespaced like `cancel`, `resume` and `approve`
- Move order actions ("events") into partial
- Remove Ruby 1.8 Hash syntax (while I was at it)
- Have event_links helper use local variables
