### PR TITLE
add code of conduct from contributor covenant v1.2

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,22 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic addresses, without explicit permission
+* Other unethical or unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles to every aspect of managing this project. Project maintainers who do not follow or enforce the Code of Conduct may be permanently removed from the project team.
+
+This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
+
+This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.2.0, available at [http://contributor-covenant.org/version/1/2/0/](http://contributor-covenant.org/version/1/2/0/)


### PR DESCRIPTION
> # Contributor Covenant
> 
> Open Source has always been a foundation of the Internet, and with the advent of social open source networks this is more true than ever. But open source projects suffer from a startling lack of diversity of participants, including women, people of color, and other minority populations.
> 
> Part of this problem lies with the projects themselves. Insensitive language, thoughtless use of pronouns, projects with sexualized or culturally inappropriate names, and the pervasive cult of meritocracy make contributing to open source a daunting prospect for many people.
> ## A Small Step Forward
> 
> An easy way to begin addressing this problem is to be overt in our openness, welcoming all people to contribute, and pledging in return to value them as human beings and to foster an atmosphere of kindness, cooperation, and understanding.
> 
> The Contributor Covenant can be one way to express these values. Pledge your respect and appreciation for contributors and participants in your open source project by adding an explicit CODE_OF_CONDUCT.md to your project repository.
> ## Contributor Covenant v1.2.0
> 
> You can view and download Version 1.2 of the Contributor Covenant here in markdown, HTML, or plain text. Note that since the Contributor Covenant uses semantic versioning for revisions, all URLs are permanent.
> 
> ...
> ## How to Contribute
> 
> This project is itself open source, and its repository can be found here. Contributions in the form of issues and pull requests are welcome and encouraged.

http://contributor-covenant.org/

---

cc @CoralineAda
