### PR TITLE
use all_adjustments when for shipment adjustment

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -487,7 +487,7 @@ module Spree
     end
 
     def create_proposed_shipments
-      adjustments.shipping.delete_all
+      all_adjustments.shipping.delete_all
       shipments.destroy_all
       self.shipments = Spree::Stock::Coordinator.new(self).shipments
     end


### PR DESCRIPTION
adjustments.shipping.delete_all give you this:

```
2.2.2 :175 >   order.adjustments.shipping.delete_all
  SQL (0.2ms)  DELETE FROM `spree_adjustments` WHERE `spree_adjustments`.`adjustable_id` = 1447 AND `spree_adjustments`.`adjustable_type` = 'Spree::Order' AND `spree_adjustments`.`adjustable_type` = 'Spree::Shipment'
```

This is obviously a bad query that can't fetch anything with ".`adjustable_type` = 'Spree::Order' AND `spree_adjustments`.`adjustable_type` = 'Spree::Shipment'"

We should use all_adjustments to delete shipping adjustment in an order.

```
2.2.2 :027 >   order.all_adjustments.shipping.delete_all
  SQL (0.5ms)  DELETE FROM `spree_adjustments` WHERE (order_id = 1447 OR (adjustable_id = 1447 AND adjustable_type = 'Spree::Order')) AND `spree_adjustments`.`adjustable_type` = 'Spree::Shipment'
```
