### PR TITLE
Fix order deadlocks

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -157,7 +157,7 @@ module Spree
     end
 
     def self.incomplete
-      where(completed_at: nil)
+      where(completed_at: nil).order(:created_at).reverse_order
     end
 
     # Use this method in other gems that wish to register their own custom logic

--- a/core/config/initializers/user_class_extensions.rb
+++ b/core/config/initializers/user_class_extensions.rb
@@ -21,10 +21,6 @@ Spree::Core::Engine.config.to_prepare do
         spree_roles.where(name: role_in_question.to_s).any?
       end
 
-      def last_incomplete_spree_order
-        orders.incomplete.order('created_at DESC').first
-      end
-
       def analytics_id
         id
       end

--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -8,44 +8,36 @@ module Spree
           before_filter :set_current_order
 
           helper_method :current_order
-          helper_method :simple_current_order
         end
 
-        # Used in the link_to_cart helper.
-        def simple_current_order
-
-          return @simple_current_order if @simple_current_order
-
-          @simple_current_order = find_order_by_token_or_user
-
-          if @simple_current_order
-            @simple_current_order.last_ip_address = ip_address
-            return @simple_current_order
-          else
-            @simple_current_order = Spree::Order.new
+        # The current incomplete order from the guest_token or users last incomplete carts
+        #
+        # @return [Spree::Order]
+        #   if current order is recoverable from token or history
+        #
+        # @return [nil]
+        def current_order
+          return @current_order if defined?(@current_order)
+          @current_order = find_order_by_token_or_user.try do |order|
+            order.last_ip_address = ip_address
+            order
           end
         end
 
-        # The current incomplete order from the guest_token for use in cart and during checkout
-        def current_order(options = {})
-          options[:create_order_if_necessary] ||= false
-
-          return @current_order if @current_order
-
-          @current_order = find_order_by_token_or_user(options, true)
-
-          if options[:create_order_if_necessary] && (@current_order.nil? || @current_order.completed?)
-            @current_order = Spree::Order.new(current_order_params)
-            @current_order.user ||= try_spree_current_user
-            # See issue #3346 for reasons why this line is here
-            @current_order.created_by ||= try_spree_current_user
-            @current_order.save!
-          end
-
-          if @current_order
-            @current_order.last_ip_address = ip_address
-            return @current_order
-          end
+        # The current order representing cart state
+        #
+        # Order is not persisted in case cart is pristine / empty.
+        #
+        # @return [Spree::Order]
+        def cart_order
+          @cart_order ||= current_order || Spree::Order.new(
+            store:           current_store,
+            user:            try_spree_current_user,
+            created_by:      try_spree_current_user,
+            last_ip_address: ip_address,
+            currency:        current_currency,
+            guest_token:     guest_token
+          )
         end
 
         def associate_user
@@ -56,11 +48,11 @@ module Spree
         end
 
         def set_current_order
-          if try_spree_current_user && current_order
-            try_spree_current_user.orders.incomplete.where('id != ?', current_order.id).each do |order|
-              current_order.merge!(order, try_spree_current_user)
-            end
-          end
+          current_order if try_spree_current_user
+        end
+
+        def current_currency
+          Config[:currency]
         end
 
         def ip_address
@@ -69,32 +61,37 @@ module Spree
 
         private
 
-        def last_incomplete_order
-          @last_incomplete_order ||= try_spree_current_user.last_incomplete_spree_order
+        def guest_token
+          cookies.signed[:guest_token].presence
         end
 
-        def current_order_params
-          { currency: current_currency, guest_token: cookies.signed[:guest_token], store_id: current_store.id, user_id: try_spree_current_user.try(:id) }
-        end
+        def find_order_by_token_or_user
+          user = try_spree_current_user
 
-        def find_order_by_token_or_user(options={}, with_adjustments = false)
-          options[:lock] ||= false
+          # Merge all incomplete orders
+          order = merge_orders(user.spree_orders) if user
 
-          # Find any incomplete orders for the guest_token
-          if with_adjustments
-            order = Spree::Order.incomplete.includes(:adjustments).lock(options[:lock]).find_by(current_order_params)
-          else
-            order = Spree::Order.incomplete.lock(options[:lock]).find_by(current_order_params)
-          end
+          # Merge all anonymous orders
+          order = merge_orders(anonymous_orders, order) if guest_token
 
-          # Find any incomplete orders for the current user
-          if order.nil? && try_spree_current_user
-            order = last_incomplete_order
-          end
+          # Associate the user to the order
+          order.try(:associate_user!, user) if user
 
           order
         end
 
+        def anonymous_orders
+          Spree::Order.where(guest_token: guest_token, user_id: nil)
+        end
+
+        def merge_orders(orders, other = nil)
+          orders.
+            incomplete.
+            where(currency: current_currency).
+            includes(:all_adjustments).
+            lock.
+            reduce(*other, :merge!)
+        end
       end
     end
   end

--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -69,7 +69,7 @@ module Spree
           user = try_spree_current_user
 
           # Merge all incomplete orders
-          order = merge_orders(user.spree_orders) if user
+          order = merge_orders(user.orders) if user
 
           # Merge all anonymous orders
           order = merge_orders(anonymous_orders, order) if guest_token

--- a/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
@@ -75,7 +75,7 @@ describe Spree::Core::ControllerHelpers::Auth, type: :controller do
     end
     context 'when logged in' do
       before do
-        allow(controller).to receive_messages(try_spree_current_user: double('User', to_param: 1, spree_orders: Spree::Order.none))
+        allow(controller).to receive_messages(try_spree_current_user: double('User', to_param: 1, orders: Spree::Order.none))
       end
       it 'redirects unauthorized path' do
         get :index

--- a/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
@@ -75,7 +75,7 @@ describe Spree::Core::ControllerHelpers::Auth, type: :controller do
     end
     context 'when logged in' do
       before do
-        allow(controller).to receive_messages(try_spree_current_user: double('User', id: 1, last_incomplete_spree_order: nil))
+        allow(controller).to receive_messages(try_spree_current_user: double('User', to_param: 1, spree_orders: Spree::Order.none))
       end
       it 'redirects unauthorized path' do
         get :index

--- a/core/spec/lib/spree/core/controller_helpers/order_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/order_spec.rb
@@ -7,49 +7,296 @@ end
 describe Spree::Core::ControllerHelpers::Order, type: :controller do
   controller(FakesController) {}
 
-  let(:user) { create(:user) }
-  let(:order) { create(:order, user: user) }
-  let(:store) { create(:store) }
+  let(:user)        { create(:user)              }
+  let(:order)       { create(:order, user: user) }
+  let(:guest_token) { nil                        }
 
-  describe '#simple_current_order' do
-    before { allow(controller).to receive_messages(try_spree_current_user: user) }
-    it "returns an empty order" do
-      expect(controller.simple_current_order.item_count).to eq 0
-    end
-    it 'returns Spree::Order instance' do
-      allow(controller).to receive_messages(cookies: double(signed: { guest_token: order.guest_token }))
-      expect(controller.simple_current_order).to eq order
+  before do
+    allow(controller).to receive_messages(try_spree_current_user: user)
+    allow(controller).to receive_message_chain(:cookies, :signed)
+      .and_return(guest_token: guest_token)
+  end
+
+  shared_examples_for 'idempotent method' do
+    it 'is idempotent' do
+      expect(apply).to be(apply)
     end
   end
 
   describe '#current_order' do
-    before {
-      allow(controller).to receive_messages(current_store: store)
-      allow(controller).to receive_messages(try_spree_current_user: user)
-    }
-    context 'create_order_if_necessary option is false' do
-      let!(:order) { create :order, user: user }
-      it 'returns current order' do
-        expect(controller.current_order).to eq order
-      end
+    let(:relation) { double('relation').as_null_object }
+
+    def apply
+      controller.current_order
     end
-    context 'create_order_if_necessary option is true' do
-      it 'creates new order' do
-        expect {
-          controller.current_order(create_order_if_necessary: true)
-        }.to change(Spree::Order, :count).to(1)
+
+    shared_examples_for 'order found' do
+      it 'returns an order' do
+        expect(apply).to be_instance_of(Spree::Order)
       end
 
-      it 'assigns the current_store id' do
-        controller.current_order(create_order_if_necessary: true)
-        expect(Spree::Order.last.store_id).to eq store.id
+      it 'returns a persisted order' do
+        expect(apply.persisted?).to be(true)
       end
+
+      it 'sets the created_by attribute in the order' do
+        expect(apply.created_by).to be(user)
+      end
+
+      it 'sets the last_ip_address attribute in the order' do
+        expect(apply.last_ip_address).to eql('0.0.0.0')
+      end
+
+      it 'eager loads all adjustments' do
+        expect(apply.association(:all_adjustments).loaded?).to be(true)
+      end
+    end
+
+    shared_examples_for 'order not found' do
+      it 'returns nil' do
+        expect(apply).to be_nil
+      end
+    end
+
+    shared_examples_for 'incomplete order returned' do
+      include_examples 'order found'
+
+      it 'returns the incomplete order' do
+        expect(apply).to eql(order)
+      end
+
+      context 'locking behaviour' do
+        before do
+          expect(user).to receive(:spree_orders).and_return(relation)
+
+          expect(relation).to receive(:where).with(currency: 'USD')
+            .and_return(relation)
+        end
+
+        it 'locks the order' do
+          expect(apply).to be(relation)
+          expect(relation).to have_received(:lock).with(no_args)
+        end
+      end
+    end
+
+    shared_examples_for 'anonymous order returned' do
+      include_examples 'order found'
+
+      it 'returns the anonymous order' do
+        expect(apply).to eql(anonymous_order)
+      end
+
+      context 'locking behaviour' do
+        before do
+          stub_const('Spree::Order', relation)
+
+          expect(relation).to receive(:where)
+            .with(guest_token: guest_token, user_id: nil)
+            .and_return(relation)
+
+          expect(relation).to receive(:where).with(currency: 'USD')
+            .and_return(relation)
+        end
+
+        it 'locks the order' do
+          expect(apply).to be(relation)
+          expect(relation).to have_received(:lock).with(no_args)
+        end
+      end
+    end
+
+    shared_context 'blank guest token' do
+      let(:guest_token) { '' }
+    end
+
+    shared_context 'non-blank guest token' do
+      let(:guest_token) { 'ABC123' }
+    end
+
+    shared_context 'setup anonymous order' do
+      let!(:anonymous_order) do
+        create(
+          :order_with_totals,
+          guest_token: guest_token,
+          user:        nil,
+          email:       nil
+        )
+      end
+    end
+
+    context 'when the user is present' do
+      # This record should never be returned due to the incomplete
+      # scope being used on the order lookup
+      let!(:completed_order) do
+        create(:order, completed_at: Time.at(0), user: user)
+      end
+
+      context 'with no incomplete orders' do
+        let!(:order) { nil }
+
+        context 'with no guest token' do
+          include_context  'blank guest token'
+          include_examples 'order not found'
+          include_examples 'idempotent method'
+
+          it 'does not query for anonymous users' do
+            stub_const('Spree::Order', relation)
+            expect(relation).to_not receive(:where)
+              .with(guest_token: nil, user_id: nil)
+            apply
+          end
+        end
+
+        context 'with a guest token' do
+          include_context 'non-blank guest token'
+
+          context 'with no anonymous orders' do
+            include_examples 'order not found'
+            include_examples 'idempotent method'
+          end
+
+          context 'with anonymous orders' do
+            include_context  'setup anonymous order'
+            include_examples 'anonymous order returned'
+            include_examples 'idempotent method'
+
+            it 'associates the user with the order' do
+              expect { apply }.to change { anonymous_order.reload.user }
+                .from(nil)
+                .to(user)
+            end
+          end
+        end
+      end
+
+      context 'with an incomplete order' do
+        let!(:order) do
+          create(:order_with_totals, user: user)
+        end
+
+        context 'with no guest token' do
+          include_context  'blank guest token'
+          include_examples 'incomplete order returned'
+          include_examples 'idempotent method'
+        end
+
+        context 'with a guest token' do
+          include_context 'non-blank guest token'
+
+          context 'with no anonymous orders' do
+            include_examples 'incomplete order returned'
+            include_examples 'idempotent method'
+          end
+
+          context 'with anonymous orders' do
+            include_context  'setup anonymous order'
+            include_examples 'incomplete order returned'
+            include_examples 'idempotent method'
+
+            it 'merges the anonymous order into the incomplete order' do
+              variants = [order, anonymous_order].flat_map(&:variants)
+              expect(apply.variants).to eq(variants)
+            end
+          end
+        end
+      end
+    end
+
+    context 'when the user is not present' do
+      let!(:order) { nil }
+      let(:user)   { nil }
+
+      # This record should never be returned due to the guard clause
+      # that wraps the anonymous order lookup
+      let!(:anonymous_order_with_blank_guest_token) do
+        create(
+          :order_with_totals,
+          guest_token: '',
+          user:        nil,
+          email:       nil
+        )
+      end
+
+      context 'with no guest token' do
+        include_context  'blank guest token'
+        include_examples 'order not found'
+        include_examples 'idempotent method'
+      end
+
+      context 'with a guest token' do
+        include_context 'non-blank guest token'
+
+        context 'with no anonymous orders' do
+          include_examples 'order not found'
+          include_examples 'idempotent method'
+        end
+
+        context 'with anonymous orders' do
+          include_context  'setup anonymous order'
+          include_examples 'anonymous order returned'
+          include_examples 'idempotent method'
+
+          it 'does not associate the user with the order' do
+            expect { apply }.to_not change { anonymous_order.reload.user }
+              .from(nil)
+          end
+        end
+      end
+    end
+  end
+
+  describe '#cart_order' do
+    def apply
+      controller.cart_order
+    end
+
+    before do
+      allow(controller).to receive(:current_order).and_return(current_order)
+    end
+
+    context 'current order is found' do
+      let(:current_order) { order }
+
+      it 'returns the current order' do
+        expect(apply).to be(current_order)
+      end
+
+      include_examples 'idempotent method'
+    end
+
+    context 'current order is not found' do
+      let(:current_order) { nil      }
+      let(:guest_token)   { 'ABC123' }
+
+      let(:new_order) do
+        build(
+          :order,
+          bill_address:    nil,
+          ship_address:    nil,
+          email:           nil,
+          currency:        'USD',
+          user:            user,
+          created_by:      user,
+          store:           nil,
+          last_ip_address: '0.0.0.0',
+          guest_token:     guest_token
+        )
+      end
+
+      it 'initializes a new order' do
+        order = apply
+        expect(order).to be_kind_of(Spree::Order)
+        expect(order.attributes).to eql(new_order.attributes)
+      end
+
+      include_examples 'idempotent method'
     end
   end
 
   describe '#associate_user' do
     before do
-      allow(controller).to receive_messages(current_order: order, try_spree_current_user: user)
+      allow(controller).to receive_messages(current_order: order)
     end
     context "user's email is blank" do
       let(:user) { create(:user, email: '') }
@@ -67,29 +314,48 @@ describe Spree::Core::ControllerHelpers::Order, type: :controller do
   end
 
   describe '#set_current_order' do
-    let(:incomplete_order) { create(:order, user: user) }
-    before { allow(controller).to receive_messages(try_spree_current_user: user) }
+    def apply
+      controller.set_current_order
+    end
 
-    context 'when current order not equal to users incomplete orders' do
-      before { allow(controller).to receive_messages(current_order: order, last_incomplete_order: incomplete_order, cookies: double(signed: { guest_token: 'guest_token' })) }
+    context 'with a user' do
+      before do
+        allow(controller).to receive_messages(current_order: order)
+      end
 
-      it 'calls Spree::Order#merge! method' do
-        expect(order).to receive(:merge!).with(incomplete_order, user)
-        controller.set_current_order
+      it 'initializes the current order' do
+        expect(controller).to receive_messages(current_order: order)
+        apply
+      end
+
+      it 'returns the current order' do
+        expect(apply).to be(order)
+      end
+    end
+
+    context 'without a user' do
+      let(:user) { nil }
+
+      it 'does not initialize the current order' do
+        expect(controller).to_not receive(:current_order)
+        apply
+      end
+
+      it 'returns nil' do
+        expect(apply).to be(nil)
       end
     end
   end
 
   describe '#current_currency' do
     it 'returns current currency' do
-      Spree::Config[:currency] = 'USD'
-      expect(controller.current_currency).to eq 'USD'
+      expect(controller.current_currency).to eql('USD')
     end
   end
 
   describe '#ip_address' do
     it 'returns remote ip' do
-      expect(controller.ip_address).to eq request.remote_ip
+      expect(controller.ip_address).to eql(request.remote_ip)
     end
   end
 end

--- a/core/spec/lib/spree/core/controller_helpers/order_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/order_spec.rb
@@ -67,7 +67,7 @@ describe Spree::Core::ControllerHelpers::Order, type: :controller do
 
       context 'locking behaviour' do
         before do
-          expect(user).to receive(:spree_orders).and_return(relation)
+          expect(user).to receive(:orders).and_return(relation)
 
           expect(relation).to receive(:where).with(currency: 'USD')
             .and_return(relation)

--- a/core/spec/models/spree/user_spec.rb
+++ b/core/spec/models/spree/user_spec.rb
@@ -2,39 +2,34 @@ require 'spec_helper'
 
 describe Spree::LegacyUser, :type => :model do
   # Regression test for #2844 + #3346
-  context "#last_incomplete_order" do
+  context '#incomplete_orders' do
     let!(:user) { create(:user) }
-    let!(:order) { create(:order, bill_address: create(:address), ship_address: create(:address)) }
 
-    let!(:order_1) { create(:order, :created_at => 1.day.ago, :user => user, :created_by => user) }
-    let!(:order_2) { create(:order, :user => user, :created_by => user) }
-    let!(:order_3) { create(:order, :user => user, :created_by => create(:user)) }
-
-    it "returns correct order" do
-      expect(user.last_incomplete_spree_order).to eq order_3
+    let!(:order) do
+      create(:order, bill_address: create(:address), ship_address: create(:address))
     end
 
-    context "persists order address" do
-      it "copies over order addresses" do
-        expect {
+    context 'persists order address' do
+      it 'copies over order addresses' do
+        expect do
           user.persist_order_address(order)
-        }.to change { Spree::Address.count }.by(2)
+        end.to change { Spree::Address.count }.by(2)
 
-        expect(user.bill_address).to eq order.bill_address
-        expect(user.ship_address).to eq order.ship_address
+        expect(user.bill_address).to eq(order.bill_address)
+        expect(user.ship_address).to eq(order.ship_address)
       end
 
-      it "doesnt create new addresses if user has already" do
+      it 'doesnt create new addresses if user has already' do
         user.update_column(:bill_address_id, create(:address))
         user.update_column(:ship_address_id, create(:address))
         user.reload
 
-        expect {
+        expect do
           user.persist_order_address(order)
-        }.not_to change { Spree::Address.count }
+        end.not_to change { Spree::Address.count }
       end
 
-      it "set both bill and ship address id on subject" do
+      it 'set both bill and ship address id on subject' do
         user.persist_order_address(order)
 
         expect(user.bill_address_id).not_to be_blank
@@ -42,27 +37,33 @@ describe Spree::LegacyUser, :type => :model do
       end
     end
 
-    context "payment source" do
+    context 'payment source' do
       let(:payment_method) { create(:credit_card_payment_method) }
+
       let!(:cc) do
-        create(:credit_card, user_id: user.id, payment_method: payment_method, gateway_customer_profile_id: "2342343")
+        create(
+          :credit_card,
+          user_id:                     user.id,
+          payment_method:              payment_method,
+          gateway_customer_profile_id: '2342343'
+        )
       end
 
       it "has payment sources" do
         expect(user.payment_sources.first.gateway_customer_profile_id).not_to be_empty
       end
 
-      it "drops payment source" do
+      it 'drops payment source' do
         user.drop_payment_source cc
-        expect(cc.gateway_customer_profile_id).to be_nil
+        expect(cc.gateway_customer_profile_id).to be(nil)
       end
     end
   end
 end
 
 describe Spree.user_class, :type => :model do
-  context "reporting" do
-    let(:order_value) { BigDecimal.new("80.94") }
+  context 'reporting' do
+    let(:order_value) { BigDecimal.new('80.94') }
     let(:order_count) { 4 }
     let(:orders) { Array.new(order_count, double(total: order_value)) }
 
@@ -75,55 +76,55 @@ describe Spree.user_class, :type => :model do
       allow(subject).to receive(:orders).and_return(double(complete: orders))
     end
 
-    describe "#lifetime_value" do
-      context "with orders" do
+    describe '#lifetime_value' do
+      context 'with orders' do
         before { load_orders }
-        it "returns the total of completed orders for the user" do
-          expect(subject.lifetime_value).to eq (order_count * order_value)
+        it 'returns the total of completed orders for the user' do
+          expect(subject.lifetime_value).to eql(order_count * order_value)
         end
       end
-      context "without orders" do
-        it "returns 0.00" do
-          expect(subject.lifetime_value).to eq BigDecimal("0.00")
+      context 'without orders' do
+        it 'returns 0.00' do
+          expect(subject.lifetime_value).to eq(BigDecimal('0.00'))
         end
       end
     end
 
-    describe "#display_lifetime_value" do
-      it "returns a Spree::Money version of lifetime_value" do
-        value = BigDecimal("500.05")
+    describe '#display_lifetime_value' do
+      it 'returns a Spree::Money version of lifetime_value' do
+        value = BigDecimal('500.05')
         allow(subject).to receive(:lifetime_value).and_return(value)
-        expect(subject.display_lifetime_value).to eq Spree::Money.new(value)
+        expect(subject.display_lifetime_value).to eq(Spree::Money.new(value))
       end
     end
 
-    describe "#order_count" do
+    describe '#order_count' do
       before { load_orders }
-      it "returns the count of completed orders for the user" do
-        expect(subject.order_count).to eq BigDecimal(order_count)
+      it 'returns the count of completed orders for the user' do
+        expect(subject.order_count).to eql(BigDecimal(order_count))
       end
     end
 
-    describe "#average_order_value" do
-      context "with orders" do
+    describe '#average_order_value' do
+      context 'with orders' do
         before { load_orders }
-        it "returns the average completed order price for the user" do
-          expect(subject.average_order_value).to eq order_value
+        it 'returns the average completed order price for the user' do
+          expect(subject.average_order_value).to eql(order_value)
         end
       end
-      context "without orders" do
-        it "returns 0.00" do
-          expect(subject.average_order_value).to eq BigDecimal("0.00")
+      context 'without orders' do
+        it 'returns 0.00' do
+          expect(subject.average_order_value).to eql(BigDecimal('0.00'))
         end
       end
     end
 
-    describe "#display_average_order_value" do
+    describe '#display_average_order_value' do
       before { load_orders }
-      it "returns a Spree::Money version of average_order_value" do
-        value = BigDecimal("500.05")
+      it 'returns a Spree::Money version of average_order_value' do
+        value = BigDecimal('500.05')
         allow(subject).to receive(:average_order_value).and_return(value)
-        expect(subject.display_average_order_value).to eq Spree::Money.new(value)
+        expect(subject.display_average_order_value).to eq(Spree::Money.new(value))
       end
     end
   end

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -4,7 +4,7 @@ module Spree
   # checkout which has nothing to do with updating an order that this approach
   # is waranted.
   class CheckoutController < Spree::StoreController
-    before_action :load_order_with_lock
+    before_action :load_order
     before_action :ensure_valid_state_lock_version, only: [:update]
     before_action :set_state_if_present
 
@@ -82,8 +82,8 @@ module Spree
       false
     end
 
-    def load_order_with_lock
-      @order = current_order(lock: true)
+    def load_order
+      @order = current_order
       redirect_to(spree.cart_path) && return unless @order
     end
 

--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -6,7 +6,7 @@ module Spree
 
     respond_to :html
 
-    before_action :assign_order_with_lock, only: :update
+    before_action :assign_order, only: :update
     skip_before_action :verify_authenticity_token, only: [:populate]
 
     def show
@@ -32,13 +32,13 @@ module Spree
 
     # Shows the current incomplete order from the session
     def edit
-      @order = current_order || Order.incomplete.find_or_initialize_by(guest_token: cookies.signed[:guest_token])
+      @order = cart_order
       associate_user
     end
 
     # Adds a new item to the order (creating a new order if none already exists)
     def populate
-      order    = current_order(create_order_if_necessary: true)
+      order    = cart_order
       variant  = Spree::Variant.find(params[:variant_id])
       quantity = params[:quantity].to_i
       options  = params[:options] || {}
@@ -100,8 +100,8 @@ module Spree
         end
       end
 
-      def assign_order_with_lock
-        @order = current_order(lock: true)
+      def assign_order
+        @order = current_order
         unless @order
           flash[:error] = Spree.t(:order_not_found)
           redirect_to root_path and return

--- a/frontend/app/controllers/spree/store_controller.rb
+++ b/frontend/app/controllers/spree/store_controller.rb
@@ -10,7 +10,7 @@ module Spree
 
     def cart_link
       render partial: 'spree/shared/link_to_cart'
-      fresh_when(simple_current_order)
+      fresh_when(current_order)
     end
 
     protected

--- a/frontend/app/helpers/spree/frontend_helper.rb
+++ b/frontend/app/helpers/spree/frontend_helper.rb
@@ -64,15 +64,15 @@ module Spree
       text = text ? h(text) : Spree.t('cart')
       css_class = nil
 
-      if simple_current_order.nil? or simple_current_order.item_count.zero?
-        text = "<span class='glyphicon glyphicon-shopping-cart'></span> #{text}: (#{Spree.t('empty')})"
+      if current_order.nil? || current_order.item_count.zero?
+        text = "#{text}: (#{Spree.t('empty')})"
         css_class = 'empty'
       else
-        text = "<span class='glyphicon glyphicon-shopping-cart'></span> #{text}: (#{simple_current_order.item_count})  <span class='amount'>#{simple_current_order.display_total.to_html}</span>"
+        text = "#{text}: (#{current_order.item_count})  <span class='amount'>#{current_order.display_total.to_html}</span>"
         css_class = 'full'
       end
 
-      link_to text.html_safe, spree.cart_path, :class => "cart-info #{css_class}"
+      link_to text.html_safe, spree.cart_path, class: "cart-info #{css_class}"
     end
 
     # helper to determine if its appropriate to show the store menu

--- a/frontend/spec/controllers/spree/current_order_tracking_spec.rb
+++ b/frontend/spec/controllers/spree/current_order_tracking_spec.rb
@@ -14,8 +14,8 @@ describe 'current order tracking', :type => :controller do
   it 'automatically tracks who the order was created by & IP address' do
     allow(controller).to receive_messages(:try_spree_current_user => user)
     get :index
-    expect(controller.current_order(create_order_if_necessary: true).created_by).to eq controller.try_spree_current_user
-    expect(controller.current_order.last_ip_address).to eq "0.0.0.0"
+    expect(controller.cart_order.created_by).to eql(controller.try_spree_current_user)
+    expect(controller.cart_order.last_ip_address).to eql('0.0.0.0')
   end
 
   context "current order creation" do

--- a/frontend/spec/controllers/spree/home_controller_spec.rb
+++ b/frontend/spec/controllers/spree/home_controller_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
-describe Spree::HomeController, :type => :controller do
+describe Spree::HomeController, type: :controller do
   it "provides current user to the searcher class" do
-    user = mock_model(Spree.user_class, :spree_orders => Spree::Order.none, :spree_api_key => 'fake')
-    allow(controller).to receive_messages :try_spree_current_user => user
+    user = mock_model(Spree.user_class, orders: Spree::Order.none, spree_api_key: 'fake')
+    allow(controller).to receive_messages try_spree_current_user: user
     expect_any_instance_of(Spree::Config.searcher_class).to receive(:current_user=).with(user)
     spree_get :index
     expect(response.status).to eq(200)

--- a/frontend/spec/controllers/spree/home_controller_spec.rb
+++ b/frontend/spec/controllers/spree/home_controller_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Spree::HomeController, :type => :controller do
   it "provides current user to the searcher class" do
-    user = mock_model(Spree.user_class, :last_incomplete_spree_order => nil, :spree_api_key => 'fake')
+    user = mock_model(Spree.user_class, :spree_orders => Spree::Order.none, :spree_api_key => 'fake')
     allow(controller).to receive_messages :try_spree_current_user => user
     expect_any_instance_of(Spree::Config.searcher_class).to receive(:current_user=).with(user)
     spree_get :index

--- a/frontend/spec/controllers/spree/orders_controller_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_spec.rb
@@ -14,10 +14,10 @@ describe Spree::OrdersController, :type => :controller do
     end
 
     context "#populate" do
-      it "should create a new order when none specified" do
+      it "should not persist empty orders" do
         spree_post :populate, {}, {}
         expect(cookies.signed[:guest_token]).not_to be_blank
-        expect(Spree::Order.find_by_guest_token(cookies.signed[:guest_token])).to be_persisted
+        expect(Spree::Order.find_by_guest_token(cookies.signed[:guest_token])).to be(nil)
       end
 
       context "with Variant" do
@@ -103,7 +103,7 @@ describe Spree::OrdersController, :type => :controller do
     # Regression test for #2750
     context "#update" do
       before do
-        allow(user).to receive :last_incomplete_spree_order
+        allow(user).to receive(:spree_orders).and_return(Spree::Order.none)
         allow(controller).to receive :set_current_order
       end
 

--- a/frontend/spec/controllers/spree/orders_controller_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_spec.rb
@@ -103,12 +103,12 @@ describe Spree::OrdersController, :type => :controller do
     # Regression test for #2750
     context "#update" do
       before do
-        allow(user).to receive(:spree_orders).and_return(Spree::Order.none)
+        allow(user).to receive(:orders).and_return(Spree::Order.none)
         allow(controller).to receive :set_current_order
       end
 
       it "cannot update a blank order" do
-        spree_put :update, :order => { :email => "foo" }
+        spree_put :update, order: { email: "foo" }
         expect(flash[:error]).to eq(Spree.t(:order_not_found))
         expect(response).to redirect_to(spree.root_path)
       end

--- a/frontend/spec/controllers/spree/products_controller_spec.rb
+++ b/frontend/spec/controllers/spree/products_controller_spec.rb
@@ -6,7 +6,7 @@ describe Spree::ProductsController, :type => :controller do
 
   # Regression test for #1390
   it "allows admins to view non-active products" do
-    allow(controller).to receive_messages :spree_current_user => mock_model(Spree.user_class, :has_spree_role? => true, :last_incomplete_spree_order => nil, :spree_api_key => 'fake')
+    allow(controller).to receive_messages :spree_current_user => mock_model(Spree.user_class, :has_spree_role? => true, :spree_orders => Spree::Order.none, :spree_api_key => 'fake')
     spree_get :show, :id => product.to_param
     expect(response.status).to eq(200)
   end
@@ -17,7 +17,7 @@ describe Spree::ProductsController, :type => :controller do
   end
 
   it "should provide the current user to the searcher class" do
-    user = mock_model(Spree.user_class, :last_incomplete_spree_order => nil, :spree_api_key => 'fake')
+    user = mock_model(Spree.user_class, :spree_orders => Spree::Order.none, :spree_api_key => 'fake')
     allow(controller).to receive_messages :spree_current_user => user
     expect_any_instance_of(Spree::Config.searcher_class).to receive(:current_user=).with(user)
     spree_get :index
@@ -26,7 +26,7 @@ describe Spree::ProductsController, :type => :controller do
 
   # Regression test for #2249
   it "doesn't error when given an invalid referer" do
-    current_user = mock_model(Spree.user_class, :has_spree_role? => true, :last_incomplete_spree_order => nil, :generate_spree_api_key! => nil)
+    current_user = mock_model(Spree.user_class, :has_spree_role? => true, :spree_orders => Spree::Order.none, :generate_spree_api_key! => nil)
     allow(controller).to receive_messages :spree_current_user => current_user
     request.env['HTTP_REFERER'] = "not|a$url"
 

--- a/frontend/spec/controllers/spree/products_controller_spec.rb
+++ b/frontend/spec/controllers/spree/products_controller_spec.rb
@@ -1,24 +1,24 @@
 require 'spec_helper'
 
-describe Spree::ProductsController, :type => :controller do
-  let!(:product) { create(:product, :available_on => 1.year.from_now) }
+describe Spree::ProductsController, type: :controller do
+  let!(:product) { create(:product, available_on: 1.year.from_now) }
   let(:taxon) { create(:taxon) }
 
   # Regression test for #1390
   it "allows admins to view non-active products" do
-    allow(controller).to receive_messages :spree_current_user => mock_model(Spree.user_class, :has_spree_role? => true, :spree_orders => Spree::Order.none, :spree_api_key => 'fake')
-    spree_get :show, :id => product.to_param
+    allow(controller).to receive_messages spree_current_user: mock_model(Spree.user_class, has_spree_role?: true, orders: Spree::Order.none, spree_api_key: 'fake')
+    spree_get :show, id: product.to_param
     expect(response.status).to eq(200)
   end
 
   it "cannot view non-active products" do
-    spree_get :show, :id => product.to_param
+    spree_get :show, id: product.to_param
     expect(response.status).to eq(404)
   end
 
   it "should provide the current user to the searcher class" do
-    user = mock_model(Spree.user_class, :spree_orders => Spree::Order.none, :spree_api_key => 'fake')
-    allow(controller).to receive_messages :spree_current_user => user
+    user = mock_model(Spree.user_class, orders: Spree::Order.none, spree_api_key: 'fake')
+    allow(controller).to receive_messages spree_current_user: user
     expect_any_instance_of(Spree::Config.searcher_class).to receive(:current_user=).with(user)
     spree_get :index
     expect(response.status).to eq(200)
@@ -26,12 +26,12 @@ describe Spree::ProductsController, :type => :controller do
 
   # Regression test for #2249
   it "doesn't error when given an invalid referer" do
-    current_user = mock_model(Spree.user_class, :has_spree_role? => true, :spree_orders => Spree::Order.none, :generate_spree_api_key! => nil)
-    allow(controller).to receive_messages :spree_current_user => current_user
+    current_user = mock_model(Spree.user_class, has_spree_role?: true, orders: Spree::Order.none, generate_spree_api_key!: nil)
+    allow(controller).to receive_messages spree_current_user: current_user
     request.env['HTTP_REFERER'] = "not|a$url"
 
     # Previously a URI::InvalidURIError exception was being thrown
-    expect { spree_get :show, :id => product.to_param }.not_to raise_error
+    expect { spree_get :show, id: product.to_param }.not_to raise_error
   end
 
   context 'with history slugs present' do

--- a/frontend/spec/controllers/spree/taxons_controller_spec.rb
+++ b/frontend/spec/controllers/spree/taxons_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Spree::TaxonsController, :type => :controller do
   it "should provide the current user to the searcher class" do
     taxon = create(:taxon, :permalink => "test")
-    user = mock_model(Spree.user_class, :last_incomplete_spree_order => nil, :spree_api_key => 'fake')
+    user = mock_model(Spree.user_class, :spree_orders => Spree::Order.none, :spree_api_key => 'fake')
     allow(controller).to receive_messages :spree_current_user => user
     expect_any_instance_of(Spree::Config.searcher_class).to receive(:current_user=).with(user)
     spree_get :show, :id => taxon.permalink

--- a/frontend/spec/controllers/spree/taxons_controller_spec.rb
+++ b/frontend/spec/controllers/spree/taxons_controller_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
-describe Spree::TaxonsController, :type => :controller do
+describe Spree::TaxonsController, type: :controller do
   it "should provide the current user to the searcher class" do
-    taxon = create(:taxon, :permalink => "test")
-    user = mock_model(Spree.user_class, :spree_orders => Spree::Order.none, :spree_api_key => 'fake')
-    allow(controller).to receive_messages :spree_current_user => user
+    taxon = create(:taxon, permalink: "test")
+    user = mock_model(Spree.user_class, orders: Spree::Order.none, spree_api_key: 'fake')
+    allow(controller).to receive_messages spree_current_user: user
     expect_any_instance_of(Spree::Config.searcher_class).to receive(:current_user=).with(user)
-    spree_get :show, :id => taxon.permalink
+    spree_get :show, id: taxon.permalink
     expect(response.status).to eq(200)
   end
 end


### PR DESCRIPTION
- Remove unneded DB state cleanup
- Remove unneded stubbing of private interface
- Remove unneded memoization layer
- Remove spec setup duplication
- Fix specification holes for #current_order
- Fix locking for all query paths in #current_order
- Removes Spree::User.last_incomplete_spree order.
- Adds collection Spree::User.incomplete_spree orders for being able to
  lock records in one DB round trip
- Remove redundant persistance call
- Fix public interface smell
  - Refactor options based semantics of current_order out into cart_order
    method.
  - Removes the options paramter, making the methods properly memoizable
- Fix memoizers to memoize nil correctly
  - The current_order helper used to query for the same inexisting rows
    per call to `current_order`. There is only one call side that
    invalidates the current_order cache via active writes to the
    `@current_order` ivar.
- Fix tuple order to be deterministic
- Fix specification holes in #set_current_order
- Add specs that cover all selection logic
- Do not pass redundant user argument to Order#merge!
  When orders are found by current user, there is no need to pass it in.
- Add locking to #set_current_order
- Remove simple_current_order interface
- Refactor Spree::Core::ControllerHelpers::Order#cart_order
- Refactor Spree::Core::ControllerHelpers::Order#current_order
- This change centralizes all the merging of incomplete user and
  anonymous orders.
- Change order to always be associated to the user when set.
- Remove fix for #3346 since the created_by field is always set when
  associating the order to the user.
- Simplify specs to not depend on the implementation of current_order
- Refactor Spree::Core::ControllerHelpers::Order#current_currency
- Remove code that isn't necesarry from the specs and library
- Change Spree::Order.incomplete to return orders from newest to oldest
- Remove Spree::LegacyUser#incomplete_spree_orders
- Remove Spree::Core::ControllerHelpers::Order#current_order_params
- Kill mutations in Spree::Core::ControllerHelpers::Order

Conflicts:
    api/app/controllers/spree/api/orders_controller.rb
    core/app/helpers/spree/base_helper.rb
    core/config/initializers/user_class_extensions.rb
    core/lib/spree/core/controller_helpers/order.rb
    frontend/app/controllers/spree/checkout_controller.rb
    frontend/app/controllers/spree/orders_controller.rb
    frontend/app/controllers/spree/store_controller.rb
    frontend/spec/controllers/spree/orders_controller_spec.rb

Fixes #2683 

/cc @mbj @tesserakt @jasonfb I've attempted to cherry-picking @mbj and his teams work from https://github.com/MountainRoseHerbs/spree/commit/8e040d24daa20f3befba3fe38eebf369fe35ae11#diff-0a7e681efdb2cb600526df2c5af10039 to apply against master branch here.  Will see what specs have to say, and would be good to get your feedback.
