### PR TITLE
Add missing tab locale key :promotion_categories

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -431,6 +431,7 @@ en:
         overview: Overview
         products: Products
         promotions: Promotions
+        promotion_categories: Promotion Categories
         properties: Properties
         prototypes: Prototypes
         reports: Reports


### PR DESCRIPTION
This has been confirmed and updated in `spree_i18n` master branch.
