### PR TITLE
Fix initSelection of variant autocomplete

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js.coffee
@@ -15,7 +15,7 @@ $.fn.variantAutocomplete = ->
     placeholder: Spree.translations.variant_placeholder
     minimumInputLength: 3
     initSelection: (element, callback) ->
-      $.get Spree.routes.variants_search + "/" + element.val(), {}, (data) ->
+      $.get Spree.routes.variants_api + "/" + element.val(), { token: Spree.api_key }, (data) ->
         callback data
     ajax:
       url: Spree.url(Spree.routes.variants_api)


### PR DESCRIPTION
It looks like at some point during the API refactoring this route got missed, meaning that the initial selection for variant autocomplete fields was never being loaded.
