### PR TITLE
More fully reset XHR populated fields

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
+++ b/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
@@ -52,7 +52,27 @@ $(document).ready(function() {
               $('#order_bill_address_attributes_state_id').select2("val", billAddress.state_id);
             });
           });
+        } else {
+          $('#order_bill_address_attributes_firstname').val('');
+          $('#order_bill_address_attributes_lastname').val('');
+          $('#order_bill_address_attributes_address1').val('');
+          $('#order_bill_address_attributes_address2').val('');
+          $('#order_bill_address_attributes_city').val('');
+          $('#order_bill_address_attributes_zipcode').val('');
+          $('#order_bill_address_attributes_phone').val('');
+          $('#order_bill_address_attributes_state_id').select2("val", '');
         }
+        
+        if( !$('#order_use_billing').prop('checked') ) $('#order_use_billing').click();
+        $('#order_ship_address_attributes_firstname').val('');
+        $('#order_ship_address_attributes_lastname').val('');
+        $('#order_ship_address_attributes_address1').val('');
+        $('#order_ship_address_attributes_address2').val('');
+        $('#order_ship_address_attributes_city').val('');
+        $('#order_ship_address_attributes_zipcode').val('');
+        $('#order_ship_address_attributes_phone').val('');
+        $('#order_ship_address_attributes_state_id').select2("val", '');
+        
         return customer.email;
       }
     })


### PR DESCRIPTION
If you switch customers it changes some values (such as e-mail) but the billing address field
is only changed if the new user has a billing field. This will clear out the existing billing fields
if the new user doesn't have a billing address.

Also the shipping address is never updated. This change clears out the shipping address of
possibly old info and reverts to the assumption that we want to use the billing address for
shipping.
