### PR TITLE
add Base.spree_base_scopes method

### DIFF
--- a/core/app/models/spree/base.rb
+++ b/core/app/models/spree/base.rb
@@ -12,4 +12,8 @@ class Spree::Base < ActiveRecord::Base
   end
 
   self.abstract_class = true
+
+  def self.spree_base_scopes
+    all
+  end
 end

--- a/core/lib/spree/core/search/base.rb
+++ b/core/lib/spree/core/search/base.rb
@@ -17,7 +17,8 @@ module Spree
           curr_page = page || 1
 
           unless Spree::Config.show_products_without_price
-            @products = @products.where("spree_prices.amount IS NOT NULL").where("spree_prices.currency" => current_currency)
+            @products = @products.where("spree_prices.amount IS NOT NULL").
+                                  where("spree_prices.currency" => current_currency)
           end
           @products = @products.page(curr_page).per(per_page)
         end
@@ -32,7 +33,7 @@ module Spree
 
         protected
           def get_base_scope
-            base_scope = Spree::Product.active
+            base_scope = Spree::Product.spree_base_scopes.active
             base_scope = base_scope.in_taxon(taxon) unless taxon.blank?
             base_scope = get_products_conditions_for(base_scope, keywords)
             base_scope = add_search_scopes(base_scope)

--- a/frontend/app/controllers/spree/products_controller.rb
+++ b/frontend/app/controllers/spree/products_controller.rb
@@ -15,7 +15,10 @@ module Spree
     end
 
     def show
-      @variants = @product.variants_including_master.active(current_currency).includes([:option_values, :images])
+      @variants = @product.variants_including_master.
+                           spree_base_scopes.
+                           active(current_currency).
+                           includes([:option_values, :images])
       @product_properties = @product.product_properties.includes(:property)
       @taxon = Spree::Taxon.find(params[:taxon_id]) if params[:taxon_id]
       redirect_if_legacy_path


### PR DESCRIPTION
This has no impact on base Spree apps but it's useful for extensions that want to add some important "default scopes".
Those default scopes are not automagically applied everywhere as in `default_scope`, which is bad and problematic.
Instead, we can manually add them on main queries and encourage their use (just added a few here, more to come).

The main use case is `spree_i18n` that will do this:

``` ruby
module Translatable
  class_methods do
    def spree_base_scopes
      super.includes(:translations).references(:translations)
    end
  end
end
```

and finally fix the N+1 queries problem in a pretty clean way.

Thougths?
