### PR TITLE
fix issue:  all prices will be found by product active scope

### DIFF
--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -186,9 +186,13 @@ module Spree
       where("#{Product.quoted_table_name}.deleted_at IS NULL or #{Product.quoted_table_name}.deleted_at >= ?", Time.zone.now)
     end
 
+    def self.currency_available(currency = nil)
+      joins(:master => :prices).where('spree_prices.currency' => currency || Spree::Config[:currency]).where('spree_prices.amount IS NOT NULL')
+    end
+    
     # Can't use add_search_scope for this as it needs a default argument
     def self.available(available_on = nil, currency = nil)
-      joins(:master => :prices).where("#{Product.quoted_table_name}.available_on <= ?", available_on || Time.now)
+      where("#{Product.quoted_table_name}.available_on <= ?", available_on || Time.now).currency_available(currency)
     end
     search_scopes << :available
 

--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -187,10 +187,10 @@ module Spree
     end
 
     def self.currency_available(currency = nil)
-      joins(:master => :prices).where('spree_prices.currency': currency || Spree::Config[:currency]) \
-      .where('spree_prices.amount IS NOT NULL')
+      joins(:master => :prices).where('spree_prices.currency': currency || Spree::Config[:currency]). \
+        where('spree_prices.amount IS NOT NULL')
     end
-    
+
     # Can't use add_search_scope for this as it needs a default argument
     def self.available(available_on = nil, currency = nil)
       where("#{Product.quoted_table_name}.available_on <= ?", available_on || Time.now).currency_available(currency)

--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -187,7 +187,8 @@ module Spree
     end
 
     def self.currency_available(currency = nil)
-      joins(:master => :prices).where('spree_prices.currency' => currency || Spree::Config[:currency]).where('spree_prices.amount IS NOT NULL')
+      joins(:master => :prices).where('spree_prices.currency': currency || Spree::Config[:currency]) \
+      .where('spree_prices.amount IS NOT NULL')
     end
     
     # Can't use add_search_scope for this as it needs a default argument


### PR DESCRIPTION
``` ruby
irb(main):057:0> Spree::Product.all.active.map(&:id)
  Spree::Product Load (0.9ms)  SELECT `spree_products`.* FROM `spree_products` INNER JOIN `spree_variants` ON `spree_variants`.`product_id` = `spree_products`.`id` AND `spree_variants`.`is_master` = 1 AND `spree_variants`.`deleted_at` IS NULL INNER JOIN `spree_prices` ON `spree_prices`.`variant_id` = `spree_variants`.`id` AND `spree_prices`.`deleted_at` IS NULL WHERE `spree_products`.`deleted_at` IS NULL AND (`spree_products`.deleted_at IS NULL or `spree_products`.deleted_at >= '2015-08-01 07:41:21.556990') AND (`spree_products`.available_on <= '2015-08-01 07:41:21.557380')
=> [1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 7, 8, 8, 8, 9, 9, 9, 10, 10, 10, 11, 11, 11, 12, 12, 12, 13, 13, 13, 14, 14, 14, 15, 15, 15, 16, 16, 16, 17, 18, 19, 20]
```
