### PR TITLE
Added missing partial for check payment method. Fix for Issue 6643

### DIFF
--- a/backend/app/views/spree/admin/payments/source_views/_check.html.erb
+++ b/backend/app/views/spree/admin/payments/source_views/_check.html.erb
@@ -1,3 +1,0 @@
-<fieldset data-hook="check">
-  <legend><%= Spree.t(:check) %></legend>
-</fieldset>

--- a/backend/app/views/spree/admin/payments/source_views/_check.html.erb
+++ b/backend/app/views/spree/admin/payments/source_views/_check.html.erb
@@ -1,0 +1,3 @@
+<fieldset data-hook="check">
+  <legend><%= Spree.t(:check) %></legend>
+</fieldset>


### PR DESCRIPTION
I have just added the empty file since `payment.source` is nil when mode of payment is check. This makes sure that the missing partial for check payment methods does not occur.

PS: Suggest me if there is a more elegant way of solving the issue 
