### PR TITLE
Remove invalid call to $.css. Fixes #6319.

### DIFF
--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -206,10 +206,4 @@
     <div data-hook="admin_product_form_additional_fields"></div>
 
   </div>
-
-  <% unless Rails.env.test? %>
-    <script>
-      $('.select2-container').css();
-    </script>
-  <% end %>
 </div>


### PR DESCRIPTION
https://github.com/spree/spree/commit/94127f54c68fb3f3f21f6a3440be460d191ebecd introduces a bug by calling $.css without arguments. For details see https://api.jquery.com/css/ .

Fixed at eurucamp 2015 :heart_eyes: in collaboration with @robinboening for https://rubyissues.ongoodbits.
