### PR TITLE
Remove blank display_on in admin/payment_methods/edit

### DIFF
--- a/backend/app/views/spree/admin/payment_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/_form.html.erb
@@ -17,7 +17,7 @@
       </div>
       <div data-hook="display" class="form-group">
         <%= label_tag :payment_method_display_on, Spree.t(:display) %>
-        <%= select(:payment_method, :display_on, Spree::PaymentMethod::DISPLAY.collect { |display| [Spree.t(display), display == :both ? nil : display.to_s] }, {}, {:class => 'select2'}) %>
+        <%= select(:payment_method, :display_on, Spree::PaymentMethod::DISPLAY.collect { |display| [Spree.t(display), display.to_s] }, {}, {:class => 'select2'}) %>
       </div>
       <div data-hook="auto_capture" class="form-group">
         <%= label_tag :payment_method_auto_capture, Spree.t(:auto_capture) %>

--- a/backend/app/views/spree/admin/payment_methods/index.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/index.html.erb
@@ -28,7 +28,7 @@
           </td>
           <td><%= method.name %></td>
           <td><%= method.type %></td>
-          <td class="text-center"><%= method.display_on.blank? ? Spree.t(:both) : Spree.t(method.display_on) %></td>
+          <td class="text-center"><%= Spree.t(method.display_on) %></td>
           <td class="text-center"><%= method.active ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>
           <td data-hook="admin_payment_methods_index_row_actions" class="actions actions-2 text-right">
             <%= link_to_edit(method, :no_text => true) if can? :edit, method %>


### PR DESCRIPTION
Since d1574446, blank value of display_on is no longer treated equally with :both.

I discovered it when a newly setup store using current edge Spree could not proceed with checkout (using PaypalExpress official extension) because no payment method has been displayed to choose from, despite having it (apparently) set to "Both" in backend. Turns out choosing "Both" in backend resulted in `""` (blank) value of `display_on`.

Follows up the discussion under #6540 .
