### PR TITLE
Fix wrong association class bug in User PromotionRule

### DIFF
--- a/core/app/models/spree/promotion/rules/user.rb
+++ b/core/app/models/spree/promotion/rules/user.rb
@@ -6,7 +6,7 @@ module Spree
 
         has_many :promotion_rule_users, class_name: 'Spree::PromotionRuleUser',
                                         foreign_key: :promotion_rule_id
-        has_many :users, through: :promotion_rule_users, class_name: ::Spree.user_class.to_s
+        has_many :users, through: :promotion_rule_users, class_name: "::#{Spree.user_class.to_s}"
 
         def applicable?(promotable)
           promotable.is_a?(Spree::Order)


### PR DESCRIPTION
We have a custom User class in our app. It is unsurprisingly called "User".
The `Spree::Promotion::Rules::User` class has an association to `:users` set,
where the class name is bound to be `::Spree.user_class`. In our app, this evaluates to
`User`. Since the namespacing `::` were missing, the rule would return a collection
of instances of `Spree::Promotion::Rules::User` instead of actual users.

This concern has been addressed in the `belongs_to` association in the same file (forcing
the correct namespace by interpolating `::` in front of whatever is returned by `Spree.user_class`).
I use the same technique also for the `has_many` association.
