### PR TITLE
Allow more options than tax zone for price calculation

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -19,7 +19,7 @@ module Spree
     def display_price(product_or_variant)
       product_or_variant.
         price_in(current_currency).
-        display_price_including_vat_for(current_tax_zone).
+        display_price_including_vat_for(current_price_options).
         to_html
     end
 

--- a/core/app/helpers/spree/products_helper.rb
+++ b/core/app/helpers/spree/products_helper.rb
@@ -65,7 +65,13 @@ module Spree
     private
 
     def common_product_cache_keys
-      [I18n.locale, current_currency, current_tax_zone.try(:cache_key)]
+      [I18n.locale, current_currency] + price_options_cache_key
+    end
+
+    def price_options_cache_key
+      current_price_options.sort.map(&:last).map do |value|
+        value.try(:cache_key) || value
+      end
     end
   end
 end

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -47,7 +47,7 @@ module Spree
     end
 
     def update_price
-      self.price = variant.price_including_vat_for(tax_zone)
+      self.price = variant.price_including_vat_for(tax_zone: tax_zone)
     end
 
     def copy_tax_category

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -24,12 +24,13 @@ module Spree
       self[:amount] = Spree::LocalizedNumber.parse(price)
     end
 
-    def price_including_vat_for(zone)
-      gross_amount(price, zone, variant.tax_category)
+    def price_including_vat_for(price_options)
+      options = price_options.merge(tax_category: variant.tax_category)
+      gross_amount(price, options)
     end
 
-    def display_price_including_vat_for(zone)
-      Spree::Money.new(price_including_vat_for(zone), currency: currency)
+    def display_price_including_vat_for(price_options)
+      Spree::Money.new(price_including_vat_for(price_options), currency: currency)
     end
 
     # Remove variant default_scope `deleted_at: nil`

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -71,11 +71,11 @@ module Spree
       end
     end
 
-    def self.included_tax_amount_for(zone, category)
-      return 0 unless zone && category
-      potential_rates_for_zone(zone).
+    def self.included_tax_amount_for(options)
+      return 0 unless options[:tax_zone] && options[:tax_category]
+      potential_rates_for_zone(options[:tax_zone]).
         included_in_price.
-        for_tax_category(category).
+        for_tax_category(options[:tax_category]).
         pluck(:amount).sum
     end
 

--- a/core/lib/spree/core/controller_helpers/store.rb
+++ b/core/lib/spree/core/controller_helpers/store.rb
@@ -18,6 +18,12 @@ module Spree
           @current_store ||= Spree::Store.current(request.env['SERVER_NAME'])
         end
 
+        # Return a Hash of things that influence the prices displayed in your shop.
+        #
+        # By default, the only thing that influences prices that is the current order's +tax_zone+
+        # (to facilitate differing prices depending on VAT rate for digital products in Europe, see
+        # https://github.com/spree/spree/pull/6295 and https://github.com/spree/spree/pull/6662).
+        #
         def current_price_options
           {
             tax_zone: current_tax_zone

--- a/core/lib/spree/core/controller_helpers/store.rb
+++ b/core/lib/spree/core/controller_helpers/store.rb
@@ -24,6 +24,16 @@ module Spree
         # (to facilitate differing prices depending on VAT rate for digital products in Europe, see
         # https://github.com/spree/spree/pull/6295 and https://github.com/spree/spree/pull/6662).
         #
+        # If your prices depend on something else, overwrite this method and add
+        # more key/value pairs to the Hash it returns.
+        #
+        # Be careful though to also patch the following parts of Spree accordingly:
+        #
+        # * `Spree::VatPriceCalculation#gross_amount`
+        # * `Spree::LineItem#update_price`
+        # * `Spree::Stock::Estimator#taxation_options_for`
+        # * Subclass the `DefaultTax` calculator
+        #
         def current_price_options
           {
             tax_zone: current_tax_zone

--- a/core/lib/spree/core/controller_helpers/store.rb
+++ b/core/lib/spree/core/controller_helpers/store.rb
@@ -7,7 +7,7 @@ module Spree
         included do
           helper_method :current_currency
           helper_method :current_store
-          helper_method :current_tax_zone
+          helper_method :current_price_options
         end
 
         def current_currency
@@ -17,6 +17,14 @@ module Spree
         def current_store
           @current_store ||= Spree::Store.current(request.env['SERVER_NAME'])
         end
+
+        def current_price_options
+          {
+            tax_zone: current_tax_zone
+          }
+        end
+
+        private
 
         def current_tax_zone
           current_order.try(:tax_zone) || Spree::Zone.default_tax

--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -138,6 +138,7 @@ describe Spree::BaseHelper, type: :helper do
   describe "#display_price" do
     let!(:product) { create(:product) }
     let(:current_currency) { "USD" }
+    let(:current_price_options) { { tax_zone: current_tax_zone } }
 
     context "when there is no current order" do
       let (:current_tax_zone) { nil }

--- a/core/spec/lib/spree/core/controller_helpers/store_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/store_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 class FakesController < ApplicationController
+  include Spree::Core::ControllerHelpers::Auth
+  include Spree::Core::ControllerHelpers::Order
   include Spree::Core::ControllerHelpers::Store
 end
 
@@ -14,8 +16,8 @@ describe Spree::Core::ControllerHelpers::Store, type: :controller do
     end
   end
 
-  describe "#current_tax_zone" do
-    subject { controller.current_tax_zone }
+  describe "#current_price_options" do
+    subject(:current_price_options) { controller.current_price_options }
 
     context "when there is a default tax zone" do
       let(:default_zone) { Spree::Zone.new }
@@ -26,7 +28,7 @@ describe Spree::Core::ControllerHelpers::Store, type: :controller do
 
       context "when there is no current order" do
         it "returns the default tax zone" do
-          is_expected.to eq(default_zone)
+          is_expected.to include(tax_zone: default_zone)
         end
       end
 
@@ -39,7 +41,7 @@ describe Spree::Core::ControllerHelpers::Store, type: :controller do
           allow(controller).to receive(:current_order).and_return(current_order)
         end
 
-        it { is_expected.to eq(other_zone) }
+        it { is_expected.to include(tax_zone: other_zone) }
       end
     end
 
@@ -49,7 +51,9 @@ describe Spree::Core::ControllerHelpers::Store, type: :controller do
       end
 
       context "when there is no current order" do
-        it { is_expected.to be_nil }
+        it "return nil when asked for the current tax zone" do
+          expect(current_price_options[:tax_zone]).to be_nil
+        end
       end
 
       context "when there is a current order" do
@@ -61,7 +65,7 @@ describe Spree::Core::ControllerHelpers::Store, type: :controller do
           allow(controller).to receive(:current_order).and_return(current_order)
         end
 
-        it { is_expected.to eq(other_zone) }
+        it { is_expected.to include(tax_zone: other_zone) }
       end
     end
   end

--- a/core/spec/models/spree/concerns/vat_price_calculation_spec.rb
+++ b/core/spec/models/spree/concerns/vat_price_calculation_spec.rb
@@ -12,14 +12,20 @@ module Spree
     describe "#gross_amount" do
       let(:zone) { Zone.new }
       let(:tax_category) { TaxCategory.new }
+      let(:price_options) do
+        {
+          tax_zone: zone,
+          tax_category: tax_category
+        }
+      end
       let(:amount) { 100 }
 
-      subject { test_class.new.gross_amount(amount, zone, tax_category) }
+      subject(:gross_amount) { test_class.new.gross_amount(amount, price_options) }
 
       context "with no default zone set" do
         it "does not call TaxRate.included_tax_amount_for" do
           expect(TaxRate).not_to receive(:included_tax_amount_for)
-          subject
+          gross_amount
         end
       end
 
@@ -27,7 +33,7 @@ module Spree
         let(:zone) { nil }
         it "does not call TaxRate.included_tax_amount_for" do
           expect(TaxRate).not_to receive(:included_tax_amount_for)
-          subject
+          gross_amount
         end
       end
 
@@ -42,7 +48,7 @@ module Spree
 
           it "does not call 'TaxRate.included_tax_amount_for'" do
             expect(TaxRate).not_to receive(:included_tax_amount_for)
-            subject
+            gross_amount
           end
         end
 
@@ -51,7 +57,7 @@ module Spree
 
           it "calls TaxRate.included_tax_amount_for two times" do
             expect(TaxRate).to receive(:included_tax_amount_for).twice
-            subject
+            gross_amount
           end
         end
       end

--- a/core/spec/models/spree/tax_rate_spec.rb
+++ b/core/spec/models/spree/tax_rate_spec.rb
@@ -342,9 +342,17 @@ describe Spree::TaxRate, :type => :model do
              zone: create(:zone_with_country),
              amount: 0.1
     end
+    let(:price_options) do
+      {
+        tax_zone: order.tax_zone,
+        tax_category: line_item.tax_category
+      }
+    end
+
 
     let(:line_item) { order.line_items.first }
-    subject { Spree::TaxRate.included_tax_amount_for(order.tax_zone, line_item.tax_category) }
+    subject(:included_tax_amount) { Spree::TaxRate.included_tax_amount_for(price_options) }
+
     it 'will only get me tax amounts from tax_rates that match' do
       expect(subject).to eq(included_tax_rate.amount + other_included_tax_rate.amount)
     end

--- a/guides/content/release_notes/3_1_0.md
+++ b/guides/content/release_notes/3_1_0.md
@@ -99,3 +99,19 @@ You can view the full changes using [Github Compare](https://github.com/spree/sp
   See https://github.com/spree/spree/blob/master/core/app/models/spree/refund_reason.rb#L5-L10
 
     [Martin Meyerhoff](https://github.com/spree/spree/pull/6528)
+
+* Add a `current_price_options` helper to guide price calculation in the shop
+
+  When you use dynamic prices (as detailed above), those prices will depend on something
+  (like the tax zon of the current order, or whether your customer is a business customer).
+  These option are set using the new `current_price_options` helper. If your prices depend on
+  something else, overwrite this method and add more key/value pairs to the Hash it returns.
+
+  Be careful though to also patch the following parts of Spree accordingly:
+
+  * `Spree::VatPriceCalculation#gross_amount`
+  * `Spree::LineItem#update_price`
+  * `Spree::Stock::Estimator#taxation_options_for`
+  * Subclass the `DefaultTax` calculator
+
+    [Martin Meyerhoff](https://github.com/spree/spree/pull/6662)


### PR DESCRIPTION
Our client needs to display different prices to different customers. The MOSS
refactoring in https://github.com/spree/spree/commit/a1172606f27ee2e71f097bf301df9f99881ad2f5 has enabled different prices for different tax zones, which is great,
but they also need to display prices excluding VAT for _some_ business customers.

The logic for that is (while in accordance with EU tax law) rather custom. This PR
is supposed only to enable passing more than just the tax zone as options for price calculation.

In order to accomplish this, the `current_tax_zone` helper is replaced with a `current_price_options` helper which returns a Hash. All the values of that Hash are used to calculate product cache keys. I took care to order those so that we don't end up with different caches for the same content.

The changes in this PR comprise the following:
- Remove current_tax_zone helper and replace with current_price_options
- Adapt product cache key to price options hash
- Adapt base helper to call #price_including_vat_for with price_options hash
- Adapt price model for price_options hash
- Adapt VAT price calculation module
- Use new #included_tax_amount signature
- Adapt tax_rate.rb
- Adapt line_item.rb
- Adapt stock_estimator.rb
- Add tests for edge case price options

FYI: With this branch, you can override the `current_price_options` helper and the `VatPriceCalculation#gross_amount` to customize how prices are displayed. You'll also have to subclass the `DefaultTaxCalculator` to customize how taxes are calculated on your shiny custom prices, and you'll have to edit `LineItem#update_price` to also be in accordance. We don't see all these changes in the Spree core, but without this PR, that kind of logic would be very difficult to implement. 
