### PR TITLE
Show backend shipment methods in admin order UI

### DIFF
--- a/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
+++ b/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
@@ -24,7 +24,7 @@ module Spree
               @order.associate_user!(Spree.user_class.find(params[:user_id]), @order.email.blank?)
             end
             @order.next
-            @order.refresh_shipment_rates
+            @order.refresh_shipment_rates(false)
             flash[:success] = Spree.t('customer_details_updated')
             redirect_to edit_admin_order_url(@order)
           else

--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -57,13 +57,13 @@ module Spree
         can_not_transition_without_customer_info
 
         unless @order.completed?
-          @order.refresh_shipment_rates
+          @order.refresh_shipment_rates(false)
         end
       end
 
       def cart
         unless @order.completed?
-          @order.refresh_shipment_rates
+          @order.refresh_shipment_rates(false)
         end
         if @order.shipped_shipments.count > 0
           redirect_to edit_admin_order_url(@order)

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -549,8 +549,8 @@ module Spree
       self.next! if self.line_items.size > 0
     end
 
-    def refresh_shipment_rates
-      shipments.map &:refresh_rates
+    def refresh_shipment_rates(frontend_only = true)
+      shipments.map.map { |s| s.refresh_rates(frontend_only) }
     end
 
     def shipping_eq_billing_address?

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -216,14 +216,14 @@ module Spree
       self.ready? || self.pending?
     end
 
-    def refresh_rates
+    def refresh_rates(frontend_only = true)
       return shipping_rates if shipped?
       return [] unless can_get_rates?
 
       # StockEstimator.new assigment below will replace the current shipping_method
       original_shipping_method_id = shipping_method.try(:id)
 
-      self.shipping_rates = Stock::Estimator.new(order).shipping_rates(to_package)
+      self.shipping_rates = Stock::Estimator.new(order).shipping_rates(to_package, frontend_only)
 
       if shipping_method
         selected_rate = shipping_rates.detect { |rate|


### PR DESCRIPTION
Fixes the issue where backend only shipment methods do not display in the backend UI.

The master branch interfaces changed a bit, so will need to rework this slightly to apply to master.

Am I missing something on the backend shipment methods? They should be available in this list, correct?
