### PR TITLE
Use builder to initialize related record

### DIFF
--- a/core/lib/spree/core/delegate_belongs_to.rb
+++ b/core/lib/spree/core/delegate_belongs_to.rb
@@ -75,7 +75,7 @@ module DelegateBelongsTo
 
   def delegator_for(association, attr, *args)
     return if self.class.column_names.include?(attr.to_s)
-    send("#{association}=", self.class.reflect_on_association(association).klass.new) if send(association).nil?
+    send "build_#{association}" if send(association).nil?
     if args.empty?
       send(association).send(attr)
     else
@@ -85,7 +85,7 @@ module DelegateBelongsTo
 
   def delegator_for_setter(association, attr, val)
     return if self.class.column_names.include?(attr.to_s)
-    send("#{association}=", self.class.reflect_on_association(association).klass.new) if send(association).nil?
+    send "build_#{association}" if send(association).nil?
     send(association).send("#{attr}=", val)
   end
   protected :delegator_for


### PR DESCRIPTION
When automatically creating a related record via delegated attributes prefer the
`build_*` method instead of doing a straight assignment from an instance of the
class of the related object. This ensures relationship constraints are followed.
Without the meta-programming mess this is basically the difference between:

```
product.master = Spree::Variant.new
```

and

```
product.build_master
```

This is important because `Spree::Product.new(price: 0).master.is_master` will return `false` as
the assignment of `price` (a delegated attribute) will cause a new variant to be assigned to master
but that variant won't have the `is_master` flag automatically set.

I believe this is sort of fixed up by `set_master_variants_default`[1] in the case of
products but this is a more general fix. It might be worth investigating if the callback
can be removed. Not causing any real performance issue but had having unnecessary
code hanging around.
1. https://github.com/spree/spree/blob/master/core/app/models/spree/product.rb#L322
