### PR TITLE
add cache for default store and current tracker.

### DIFF
--- a/core/app/models/spree/tracker.rb
+++ b/core/app/models/spree/tracker.rb
@@ -1,8 +1,17 @@
 module Spree
   class Tracker < Spree::Base
+    before_save :clear_cache
+
     def self.current
-      tracker = where(active: true).first
+      tracker = Rails.cache.fetch("current_tracker") do
+        where(active: true).first
+      end
       tracker.analytics_id.present? ? tracker : nil if tracker
+    end
+
+
+    def clear_cache
+      Rails.cache.delete("current_tracker")
     end
   end
 end


### PR DESCRIPTION
default Store and current Tracker are loaded in almost EVERY page.
However they always load from database without cache.

Let's cache it and invalidate it only when data update
