### PR TITLE
Fix Product Picker to lookup SKU.

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/product_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/product_picker.js
@@ -22,8 +22,7 @@ $.fn.productAutocomplete = function (options) {
       data: function (term, page) {
         return {
           q: {
-            name_cont: term,
-            sku_cont: term
+            name_or_master_sku_cont: term,
           },
           m: 'OR',
           token: Spree.api_key


### PR DESCRIPTION
**Before:**
    Ransack was not finding sku on product, thereby it was not including
    it in the search.

``` sql
   (232.8ms)  SELECT COUNT(DISTINCT count_column) FROM (SELECT  DISTINCT `spree_products`.`id` AS count_column FROM `spree_products` WHERE `spree_products`.`deleted_at` IS NULL AND (`spree_products`.`name` LIKE '%08025%') LIMIT 25 OFFSET 0) subquery_for_count
   (230.9ms)  SELECT DISTINCT COUNT(DISTINCT `spree_products`.`id`) FROM `spree_products` WHERE `spree_products`.`deleted_at` IS NULL AND (`spree_products`.`name` LIKE '%08025%')
  Spree::Product Load (230.3ms)  SELECT  DISTINCT `spree_products`.* FROM `spree_products` WHERE `spree_products`.`deleted_at` IS NULL AND (`spree_products`.`name` LIKE '%08025%') LIMIT 25 OFFSET 0
```

---

**After:**
    Sku is correctly looked up on the product master.
    *However, the SQL lookups take significantly longer due to missing text indices (Gin/Gist for Postgres, don't know the equivalents for MySQL) *

``` sql
   (329.5ms)  SELECT COUNT(DISTINCT count_column) FROM (SELECT  DISTINCT `spree_products`.`id` AS count_column FROM `spree_products` LEFT OUTER JOIN `spree_variants` ON `spree_variants`.`product_id` = `spree_products`.`id` AND `spree_variants`.`is_master` = 1 AND `spree_variants`.`deleted_at` IS NULL WHERE `spree_products`.`deleted_at` IS NULL AND (`spree_products`.`name` LIKE '%08025%' OR `spree_variants`.`sku` LIKE '%08025%') LIMIT 25 OFFSET 0) subquery_for_count
   (4669.6ms)  SELECT DISTINCT COUNT(DISTINCT `spree_products`.`id`) FROM `spree_products` LEFT OUTER JOIN `spree_variants` ON `spree_variants`.`product_id` = `spree_products`.`id` AND `spree_variants`.`is_master` = 1 AND `spree_variants`.`deleted_at` IS NULL WHERE `spree_products`.`deleted_at` IS NULL AND (`spree_products`.`name` LIKE '%08025%' OR `spree_variants`.`sku` LIKE '%08025%')
  Spree::Product Load (326.2ms)  SELECT  DISTINCT `spree_products`.* FROM `spree_products` LEFT OUTER JOIN `spree_variants` ON `spree_variants`.`product_id` = `spree_products`.`id` AND `spree_variants`.`is_master` = 1 AND `spree_variants`.`deleted_at` IS NULL WHERE `spree_products`.`deleted_at` IS NULL AND (`spree_products`.`name` LIKE '%08025%' OR `spree_variants`.`sku` LIKE '%08025%') LIMIT 25 OFFSET 0
```
