### PR TITLE
enable to void invalid payment

### DIFF
--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -81,7 +81,7 @@ module Spree
         transition from: [:processing, :pending, :checkout], to: :completed
       end
       event :void do
-        transition from: [:pending, :processing, :completed, :checkout], to: :void
+        transition from: [:pending, :processing, :completed, :checkout, :invalid], to: :void
       end
       # when the card brand isnt supported
       event :invalidate do


### PR DESCRIPTION
I face a strange situation.
Administrator can not do anything to invalid state payments.
Administrator want to void it, but can not.

So I simply add the path from "invalid" to "void" transition.
