### PR TITLE
tiny fix, to use address.full_name

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -346,7 +346,7 @@ module Spree
 
     def name
       if (address = bill_address || ship_address)
-        "#{address.firstname} #{address.lastname}"
+        address.full_name
       end
     end
 


### PR DESCRIPTION
Spree::Order#name is almost name as Spree::Address#full_name

It is better to use Spree::Address#full_name
