### PR TITLE
Fixed redundant condition in the order "returned" state

### DIFF
--- a/core/app/models/spree/customer_return.rb
+++ b/core/app/models/spree/customer_return.rb
@@ -63,7 +63,7 @@ module Spree
 
     def process_return!
       return_items.each(&:receive!)
-      order.return! if order.all_inventory_units_returned?
+      order.return!
     end
 
     def return_items_belong_to_same_order


### PR DESCRIPTION
In the way the "return" event in handled in Spree, there is a redundant condition that we could remove.

Line 65 in `order/checkout.rb`, the same condition appears already:

```
event :return do
  transition to: :returned,
             from: [:complete, :awaiting_return, :canceled],
             if: :all_inventory_units_returned?
end
```

It feels it's much better to put the eventual logic about the state machine in the order model rather than in the CustomerReturn model.
