### PR TITLE
Trigger "authorize_return" order event. 

### DIFF
--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -9,6 +9,7 @@ module Spree
     belongs_to :stock_location
     belongs_to :reason, class_name: 'Spree::ReturnAuthorizationReason', foreign_key: :return_authorization_reason_id
     before_create :generate_number
+    after_create :authorize_return
 
     after_save :generate_expedited_exchange_reimbursements
 
@@ -60,6 +61,10 @@ module Spree
     end
 
     private
+
+      def authorize_return
+        order.authorize_return!
+      end
 
       def must_have_shipped_units
         if order.nil? || order.inventory_units.shipped.none?

--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -63,7 +63,7 @@ module Spree
     private
 
       def authorize_return
-        order.authorize_return!
+        order.authorize_return! unless order.nil?
       end
 
       def must_have_shipped_units

--- a/core/spec/models/spree/return_authorization_spec.rb
+++ b/core/spec/models/spree/return_authorization_spec.rb
@@ -84,6 +84,18 @@ describe Spree::ReturnAuthorization, :type => :model do
     end
   end
 
+  describe ".after_create" do
+    describe "#authorize_return" do
+      context "return is authorized" do
+        let(:return_authorization) { create(:return_authorization) }
+        it "order state is 'awaiting_return'" do
+          return_authorization.save
+          expect(return_authorization.order.state).to eq('awaiting_return')
+        end
+      end
+    end
+  end
+
   describe ".before_create" do
     describe "#generate_number" do
       context "number is assigned" do


### PR DESCRIPTION
Till now the order event "authorize_return"  was never triggered, hence the order could not be in the state "awaiting return".

`order/checkout.rb`

```
event :authorize_return do
  transition to: :awaiting_return
end
```
