### PR TITLE
Urgent patch: Adjustment#update! returning nil when !source.present.

### DIFF
--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -90,6 +90,7 @@ module Spree
     # If the adjustment has no source, do not attempt to re-calculate the amount.
     # Chances are likely that this was a manually created adjustment in the admin backend.
     def update!(target = nil)
+      amount = self.amount
       return amount if closed?
       if source.present?
         amount = source.compute_amount(target || adjustable)

--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -110,6 +110,11 @@ describe Spree::Adjustment, :type => :model do
   end
 
   context '#update!' do
+    # Regression test for #6689
+    it "correctly calculates for adjustments with no source" do
+      expect(adjustment.update!).to eq 5
+    end
+
     context "when adjustment is closed" do
       before { expect(adjustment).to receive(:closed?).and_return(true) }
 


### PR DESCRIPTION
Bug: Calling update! on an adjustment with no source always returns nil.

Ruby scopes variables by block scope, and onditionals do not open a new scope.
Essentially, what happens in this function, is that an `amount` var is
immediately defined (at the top of the function) and set to nil.

This then completely takes precedence over the `amount` instance method,
returning nil instead of the actual amount.

The fix is to use `self.amount` when referring to the method, although a much
better practice would be to not use vars that match real variables.

POC code sample, displaying the bug:

``` ruby
class A
  def amount
    1
  end

  def amount=
    "whatever"
  end

  def update!
    return amount if false
    if false
      amount = 2
    end
    amount
  end
end

A.new.update! # => nil
```

Also note that even if source was present, `amount=` never gets called because
`amount = 2` creates a local variable, while `self.amount = 2` would call the
function.

Analysis shows that code has been vulnerable since this specific commit: https://github.com/spree/spree/commit/3a3c94d8a4276a5a026a34015605bf1113f8b86c

Vulnerable versions include 2.2, 2.3 and 2.4.
