### PR TITLE
Correcting initializers path for spree preferences.

### DIFF
--- a/guides/content/developer/core/preferences.md
+++ b/guides/content/developer/core/preferences.md
@@ -262,7 +262,7 @@ end
 ```
 
 ***
-Initializing preferences in `config/initializer.rb` will overwrite any changes that were made through the admin user interface when you restart.
+Initializing preferences in `config/initializers/spree.rb` will overwrite any changes that were made through the admin user interface when you restart.
 ***
 
 ### Configuration Through the Admin Interface


### PR DESCRIPTION
Following doesn't make sense as there has been no mention of initializer.rb file in whole preference guide page:

> Initializing preferences in `config/initializer.rb` will overwrite any changes that were made through the admin user interface when you restart.

It should be this instead:

> Initializing preferences in `config/initializers/spree.rb` will overwrite any changes that were made through the admin user interface when you restart.
