### PR TITLE
Change the default value for Spree::Adjustment.included to false.

### DIFF
--- a/core/app/models/concerns/spree/adjustment_source.rb
+++ b/core/app/models/concerns/spree/adjustment_source.rb
@@ -9,7 +9,7 @@ module Spree
 
     protected
 
-    def create_adjustment(order, adjustable, included = nil)
+    def create_adjustment(order, adjustable, included = false)
       amount = compute_amount(adjustable)
       return if amount == 0
       adjustments.new(order: order,


### PR DESCRIPTION
The database already did this, but Spree 3.0 moved the creation of Promotion Adjustments into AdjustmentSource.create_adjustment. The nil value would be saved to the DB, ignoring the default.

This caused orders with line item promotions to fail when attempting to use PayPal.

This change should be applied to `master` and `3-0-stable`.
