### PR TITLE
Bump spree_api's rabl dependency to latest version and fix taxonomy tree rendering

### DIFF
--- a/api/app/views/spree/api/taxons/show.v1.rabl
+++ b/api/app/views/spree/api/taxons/show.v1.rabl
@@ -1,8 +1,6 @@
 object @taxon
 attributes *taxon_attributes
 
-node do |t|
-  child t.children => :taxons do
-    attributes *taxon_attributes
-  end
+child :children => :taxons do
+  attributes *taxon_attributes
 end

--- a/api/app/views/spree/api/taxons/taxons.v1.rabl
+++ b/api/app/views/spree/api/taxons/taxons.v1.rabl
@@ -1,7 +1,5 @@
-node do |t|
-  child t.children => :taxons do
-    attributes *taxon_attributes
+attributes *taxon_attributes
 
-    extends "spree/api/taxons/taxons"
-  end
+node :taxons do |t|
+  t.children.map { |c| partial("spree/api/taxons/taxons", :object => c) }
 end

--- a/api/spree_api.gemspec
+++ b/api/spree_api.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |gem|
   gem.version       = version
 
   gem.add_dependency 'spree_core', version
-  gem.add_dependency 'rabl', '~> 0.9.4.pre1'
+  gem.add_dependency 'rabl', '~> 0.11.6'
   gem.add_dependency 'versioncake', '~> 2.3.1'
 end


### PR DESCRIPTION
Relevant pull request: https://github.com/spree/spree/pull/5955

I noticed that updating to the latest version of rabl (`0.11.6`) in `spree_api` improved rendering time by 5x (there's a new caching layer in `0.11.1`), but due to some failing tests the PR above was never merged. 

The specs were failing due to rabl changing the way they render recursive templates using `extends`. I switched to using `partial` and `map` instead and was able to get the tests to pass.
