### PR TITLE
Extract availability check in validator

### DIFF
--- a/core/app/models/spree/stock/availability_validator.rb
+++ b/core/app/models/spree/stock/availability_validator.rb
@@ -4,12 +4,11 @@ module Spree
       def validate(line_item)
         unit_count = line_item.inventory_units.size
         return if unit_count >= line_item.quantity
+
         quantity = line_item.quantity - unit_count
         return if quantity.zero?
 
-        quantifier = Stock::Quantifier.new(line_item.variant)
-
-        return if quantifier.can_supply?(quantity)
+        return if item_available?(line_item, quantity)
 
         variant = line_item.variant
         display_name = "#{variant.name}"
@@ -19,6 +18,12 @@ module Spree
           :selected_quantity_not_available,
           item: display_name.inspect
         )
+      end
+
+      private
+
+      def item_available?(line_item, quantity)
+        Stock::Quantifier.new(line_item.variant).can_supply?(quantity)
       end
     end
   end


### PR DESCRIPTION
This allows better extendability as you can override only one method if you want to change how you calculate remaining stock.

We are currently implementing a feature which requires us to take the number of items that customers have added to their cart (but haven't checked out yet) into account. With that, we need to pass in customer's current (pending) order to the `Stock::Quantifier`. With this extraction, that means we can override only one method and not the whole `validate` method to get the validator to work corectly.

The tests still pass, so there's no test attaching to this PR.

Please let me know if you have any question or concern.
