### PR TITLE
Cleaning models code for associations

### DIFF
--- a/core/app/models/spree/country.rb
+++ b/core/app/models/spree/country.rb
@@ -1,6 +1,6 @@
 module Spree
   class Country < Spree::Base
-    has_many :states, -> { order('name ASC') }, dependent: :destroy
+    has_many :states, -> { order(:name) }, dependent: :destroy
     has_many :addresses, dependent: :nullify
 
     has_many :zone_members,

--- a/core/app/models/spree/option_type.rb
+++ b/core/app/models/spree/option_type.rb
@@ -12,7 +12,7 @@ module Spree
     validates :name, presence: true, uniqueness: true
     validates :presentation, presence: true
 
-    default_scope { order("#{self.table_name}.position") }
+    default_scope { order(:position) }
 
     accepts_nested_attributes_for :option_values, reject_if: lambda { |ov| ov[:name].blank? || ov[:presentation].blank? }, allow_destroy: true
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -76,11 +76,11 @@ module Spree
 
     belongs_to :store, class_name: 'Spree::Store'
     has_many :state_changes, as: :stateful, dependent: :destroy
-    has_many :line_items, -> { order("#{LineItem.table_name}.created_at ASC") }, dependent: :destroy, inverse_of: :order
+    has_many :line_items, -> { order(:created_at) }, dependent: :destroy, inverse_of: :order
     has_many :payments, dependent: :destroy
     has_many :return_authorizations, dependent: :destroy, inverse_of: :order
     has_many :reimbursements, inverse_of: :order
-    has_many :adjustments, -> { order("#{Adjustment.table_name}.created_at ASC") }, as: :adjustable, dependent: :destroy
+    has_many :adjustments, -> { order(:created_at) }, as: :adjustable, dependent: :destroy
     has_many :line_item_adjustments, through: :line_items, source: :adjustments
     has_many :shipment_adjustments, through: :shipments, source: :adjustments
     has_many :inventory_units, inverse_of: :order

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -37,7 +37,7 @@ module Spree
 
     validates :amount, numericality: true
 
-    default_scope { order("#{self.table_name}.created_at") }
+    default_scope { order(:created_at) }
 
     scope :from_credit_card, -> { where(source_type: 'Spree::CreditCard') }
     scope :with_state, ->(s) { where(state: s.to_s) }

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -45,12 +45,12 @@ module Spree
       class_name: 'Spree::Variant'
 
     has_many :variants,
-      -> { where(is_master: false).order("#{::Spree::Variant.quoted_table_name}.position ASC") },
+      -> { where(is_master: false).order(:position) },
       inverse_of: :product,
       class_name: 'Spree::Variant'
 
     has_many :variants_including_master,
-      -> { order("#{::Spree::Variant.quoted_table_name}.position ASC") },
+      -> { order(:position) },
       inverse_of: :product,
       class_name: 'Spree::Variant',
       dependent: :destroy

--- a/core/app/models/spree/product_property.rb
+++ b/core/app/models/spree/product_property.rb
@@ -9,7 +9,7 @@ module Spree
 
     validates_with Spree::Validations::DbMaximumLengthValidator, field: :value
 
-    default_scope { order("#{self.table_name}.position") }
+    default_scope { order(:position) }
 
     self.whitelisted_ransackable_attributes = ['value']
 

--- a/core/app/models/spree/product_property.rb
+++ b/core/app/models/spree/product_property.rb
@@ -14,9 +14,7 @@ module Spree
     self.whitelisted_ransackable_attributes = ['value']
 
     # virtual attributes for use with AJAX completion stuff
-    def property_name
-      property.name if property
-    end
+    delegate :name, to: :property, prefix: true, allow_nil: true
 
     def property_name=(name)
       if name.present?

--- a/core/app/models/spree/promotion_rule_user.rb
+++ b/core/app/models/spree/promotion_rule_user.rb
@@ -1,6 +1,6 @@
 module Spree
   class PromotionRuleUser < Spree::Base
     belongs_to :promotion_rule, class_name: 'Spree::PromotionRule'
-    belongs_to :user, class_name: Spree.user_class.to_s
+    belongs_to :user, class_name: Spree.user_class
   end
 end

--- a/core/app/models/spree/role_user.rb
+++ b/core/app/models/spree/role_user.rb
@@ -1,6 +1,6 @@
 module Spree
   class RoleUser < Spree::Base
     belongs_to :role, class_name: 'Spree::Role'
-    belongs_to :user, class_name: Spree.user_class.to_s
+    belongs_to :user, class_name: Spree.user_class
   end
 end

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -14,7 +14,7 @@ module Spree
 
     has_many :adjustments, as: :adjustable, dependent: :delete_all
     has_many :inventory_units, dependent: :delete_all, inverse_of: :shipment
-    has_many :shipping_rates, -> { order('cost ASC') }, dependent: :delete_all
+    has_many :shipping_rates, -> { order(:cost) }, dependent: :delete_all
     has_many :shipping_methods, through: :shipping_rates
     has_many :state_changes, as: :stateful
 

--- a/core/app/models/spree/state.rb
+++ b/core/app/models/spree/state.rb
@@ -20,7 +20,7 @@ module Spree
     # blank is added elsewhere, if needed
     def self.states_group_by_country_id
       state_info = Hash.new { |h, k| h[k] = [] }
-      self.order('name ASC').each { |state|
+      self.order(:name).each { |state|
         state_info[state.country_id.to_s].push [state.id, state.name]
       }
       state_info

--- a/core/app/models/spree/state_change.rb
+++ b/core/app/models/spree/state_change.rb
@@ -1,6 +1,6 @@
 module Spree
   class StateChange < Spree::Base
-    belongs_to :user, class_name: Spree.user_class.to_s
+    belongs_to :user, class_name: Spree.user_class
     belongs_to :stateful, polymorphic: true
 
     def <=>(other)

--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -12,7 +12,7 @@ module Spree
     scope :active, -> { where(active: true) }
     scope :order_default, -> { order(default: :desc, name: :asc) }
 
-    after_create :create_stock_items, :if => "self.propagate_all_variants?"
+    after_create :create_stock_items, if: :propagate_all_variants?
     after_save :ensure_one_default
 
     def state_text

--- a/core/app/models/spree/stock_movement.rb
+++ b/core/app/models/spree/stock_movement.rb
@@ -13,7 +13,7 @@ module Spree
                  allow_nil: true
               }
 
-    scope :recent, -> { order('created_at DESC') }
+    scope :recent, -> { order(created_at: :desc) }
 
     self.whitelisted_ransackable_attributes = ['quantity']
 

--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -14,7 +14,7 @@ module Spree
     has_many :products, through: :classifications
 
     has_many :prototype_taxons, class_name: 'Spree::PrototypeTaxon'
-    has_many :prototypes, through: :prototype_taxons, class_name: 'Spree::PrototypeTaxon'
+    has_many :prototypes, through: :prototype_taxons, class_name: 'Spree::Prototype'
 
     has_many :promotion_rule_taxons, class_name: 'Spree::PromotionRuleTaxon'
     has_many :promotion_rules, through: :promotion_rule_taxons, class_name: 'Spree::PromotionRule'

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -160,15 +160,17 @@ describe Spree::Product, :type => :model do
     end
 
     describe 'Variants sorting' do
+      ORDER_REGEXP = /ORDER BY (\`|\")spree_variants(\`|\").(\'|\")position(\'|\") ASC/
+
       context 'without master variant' do
         it 'sorts variants by position' do
-          expect(product.variants.to_sql).to match(/ORDER BY (\`|\")spree_variants(\`|\").position ASC/)
+          expect(product.variants.to_sql).to match(ORDER_REGEXP)
         end
       end
 
       context 'with master variant' do
         it 'sorts variants by position' do
-          expect(product.variants_including_master.to_sql).to match(/ORDER BY (\`|\")spree_variants(\`|\").position ASC/)
+          expect(product.variants_including_master.to_sql).to match(ORDER_REGEXP)
         end
       end
     end


### PR DESCRIPTION
I started using Spree as backend for my store. I checked code and I realized, that some parts of it (as in long living projects) could be changed.

Because all models are in same namespace, we can skip `class_name` attribute for most of them. Most changes are related only with that change. 

Sometimes I fixed orders from `order("#{ ::Spree::Order.quoted_table_name }.created_at ASC")` to simply `order(:created_at)`

In one place I found possible bug. It's association `prototypes` in `Taxon` model.

I created a lot of commits, just in case, when I need to revert some of them. If this PR will be accepted, I can create one commit from all of them.
