### PR TITLE
to enable states order change

### DIFF
--- a/api/app/controllers/spree/api/v1/states_controller.rb
+++ b/api/app/controllers/spree/api/v1/states_controller.rb
@@ -7,8 +7,7 @@ module Spree
         skip_before_action :authenticate_user
 
         def index
-          @states = scope.ransack(params[:q]).result.
-                      includes(:country).order('name ASC')
+          @states = scope.ransack(params[:q]).result.includes(:country)
 
           if params[:page] || params[:per_page]
             @states = @states.page(params[:page]).per(params[:per_page])
@@ -29,9 +28,9 @@ module Spree
           def scope
             if params[:country_id]
               @country = Country.accessible_by(current_ability, :read).find(params[:country_id])
-              return @country.states.accessible_by(current_ability, :read)
+              return @country.states.accessible_by(current_ability, :read).order('name ASC')
             else
-              return State.accessible_by(current_ability, :read)
+              return State.accessible_by(current_ability, :read).order('name ASC')
             end
           end
       end

--- a/api/spec/controllers/spree/api/v1/states_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/states_controller_spec.rb
@@ -29,7 +29,8 @@ module Spree
       before do
         expect(scope).to receive_messages(last: state)
         expect(State).to receive_messages(accessible_by: scope)
-        allow(scope).to receive_message_chain(:ransack, :result, :includes, :order).and_return(scope)
+        expect(scope).to receive_messages(order: scope)
+        allow(scope).to receive_message_chain(:ransack, :result, :includes).and_return(scope)
       end
 
       it "does not paginate states results when asked not to do so" do

--- a/core/app/models/spree/country.rb
+++ b/core/app/models/spree/country.rb
@@ -1,6 +1,6 @@
 module Spree
   class Country < Spree::Base
-    has_many :states, -> { order('name ASC') }, dependent: :destroy
+    has_many :states, dependent: :destroy
     has_many :addresses, dependent: :nullify
 
     has_many :zone_members,


### PR DESCRIPTION
It is difficult to change States order now,
But default order is strange in Japan.

After accept my change, I can easily change the order of state by override Spree::Api::V1::StatesController#scope
