### PR TITLE
always generate api key for backend users

### DIFF
--- a/backend/app/controllers/spree/admin/base_controller.rb
+++ b/backend/app/controllers/spree/admin/base_controller.rb
@@ -6,6 +6,7 @@ module Spree
       layout '/spree/layouts/admin'
 
       before_action :authorize_admin
+      before_action :generate_admin_api_key
 
       protected
 

--- a/backend/spec/controllers/spree/admin/base_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/base_controller_spec.rb
@@ -22,4 +22,25 @@ describe Spree::Admin::BaseController, type: :controller do
       expect(response).to redirect_to '/root'
     end
   end
+
+  context "#generate_api_key" do
+    let(:user) { mock_model(Spree.user_class) }
+
+    before do
+      allow(controller).to receive(:authorize_admin) { true }
+      allow(controller).to receive(:try_spree_current_user) { user }
+    end
+
+    it "generates the API key for a user when they visit" do
+      expect(user).to receive(:spree_api_key).and_return(nil)
+      expect(user).to receive(:generate_spree_api_key!)
+      get :index
+    end
+
+    it "does not attempt to regenerate the API key if the key is already set" do
+      expect(user).to receive(:spree_api_key).and_return('fake')
+      expect(user).not_to receive(:generate_spree_api_key!)
+      get :index
+    end
+  end
 end


### PR DESCRIPTION
the (unused) method was already there
