### PR TITLE
Add delegation to Stock::Quantifier in Variant

### DIFF
--- a/core/app/models/spree/stock/quantifier.rb
+++ b/core/app/models/spree/stock/quantifier.rb
@@ -20,7 +20,7 @@ module Spree
         stock_items.any?(&:backorderable)
       end
 
-      def can_supply?(required)
+      def can_supply?(required=1)
         total_on_hand >= required || backorderable?
       end
 

--- a/core/app/models/spree/stock/quantifier.rb
+++ b/core/app/models/spree/stock/quantifier.rb
@@ -20,7 +20,7 @@ module Spree
         stock_items.any?(&:backorderable)
       end
 
-      def can_supply?(required=1)
+      def can_supply?(required = 1)
         total_on_hand >= required || backorderable?
       end
 

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -77,10 +77,6 @@ module Spree
       inventory_units.with_state('backordered').size
     end
 
-    def is_backorderable?
-      Spree::Stock::Quantifier.new(self).backorderable?
-    end
-
     def options_text
       values = self.option_values.sort do |a, b|
         a.option_type.position <=> b.option_type.position
@@ -204,13 +200,9 @@ module Spree
       end
     end
 
-    def can_supply?(quantity=1)
-      Spree::Stock::Quantifier.new(self).can_supply?(quantity)
-    end
+    delegate :total_on_hand, :can_supply?, :backorderable?, to: :quantifier
 
-    def total_on_hand
-      Spree::Stock::Quantifier.new(self).total_on_hand
-    end
+    alias is_backorderable? backorderable?
 
     # Shortcut method to determine if inventory tracking is enabled for this variant
     # This considers both variant tracking flag and site-wide inventory tracking settings
@@ -227,6 +219,10 @@ module Spree
     end
 
     private
+
+      def quantifier
+        Spree::Stock::Quantifier.new(self)
+      end
 
       def set_master_out_of_stock
         if product.master && product.master.in_stock?

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -226,15 +226,15 @@ module Spree
 
     def set_master_out_of_stock
       if product.master && product.master.in_stock?
-        product.master.stock_items.update_all(:backorderable => false)
-        product.master.stock_items.each { |item| item.reduce_count_on_hand_to_zero }
+        product.master.stock_items.update_all(backorderable: false)
+        product.master.stock_items.each(&:reduce_count_on_hand_to_zero)
       end
     end
 
     # Ensures a new variant takes the product master price when price is not supplied
     def check_price
       if price.nil? && Spree::Config[:require_master_price]
-        raise 'No master variant found to infer price' unless (product && product.master)
+        raise 'No master variant found to infer price' unless product && product.master
         raise 'Must supply price for variant or master.price for product.' if self == product.master
         self.price = product.master.price
       end

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -220,45 +220,45 @@ module Spree
 
     private
 
-      def quantifier
-        Spree::Stock::Quantifier.new(self)
-      end
+    def quantifier
+      Spree::Stock::Quantifier.new(self)
+    end
 
-      def set_master_out_of_stock
-        if product.master && product.master.in_stock?
-          product.master.stock_items.update_all(:backorderable => false)
-          product.master.stock_items.each { |item| item.reduce_count_on_hand_to_zero }
-        end
+    def set_master_out_of_stock
+      if product.master && product.master.in_stock?
+        product.master.stock_items.update_all(:backorderable => false)
+        product.master.stock_items.each { |item| item.reduce_count_on_hand_to_zero }
       end
+    end
 
-      # Ensures a new variant takes the product master price when price is not supplied
-      def check_price
-        if price.nil? && Spree::Config[:require_master_price]
-          raise 'No master variant found to infer price' unless (product && product.master)
-          raise 'Must supply price for variant or master.price for product.' if self == product.master
-          self.price = product.master.price
-        end
-        if currency.nil?
-          self.currency = Spree::Config[:currency]
-        end
+    # Ensures a new variant takes the product master price when price is not supplied
+    def check_price
+      if price.nil? && Spree::Config[:require_master_price]
+        raise 'No master variant found to infer price' unless (product && product.master)
+        raise 'Must supply price for variant or master.price for product.' if self == product.master
+        self.price = product.master.price
       end
+      if currency.nil?
+        self.currency = Spree::Config[:currency]
+      end
+    end
 
-      def set_cost_currency
-        self.cost_currency = Spree::Config[:currency] if cost_currency.nil? || cost_currency.empty?
-      end
+    def set_cost_currency
+      self.cost_currency = Spree::Config[:currency] if cost_currency.nil? || cost_currency.empty?
+    end
 
-      def create_stock_items
-        StockLocation.where(propagate_all_variants: true).each do |stock_location|
-          stock_location.propagate_variant(self)
-        end
+    def create_stock_items
+      StockLocation.where(propagate_all_variants: true).each do |stock_location|
+        stock_location.propagate_variant(self)
       end
+    end
 
-      def in_stock_cache_key
-        "variant-#{id}-in_stock"
-      end
+    def in_stock_cache_key
+      "variant-#{id}-in_stock"
+    end
 
-      def clear_in_stock_cache
-        Rails.cache.delete(in_stock_cache_key)
-      end
+    def clear_in_stock_cache
+      Rails.cache.delete(in_stock_cache_key)
+    end
   end
 end


### PR DESCRIPTION
I saw in `Spree::Variant` that `Spree::Stock::Quantifier.new(self)` was used three times. In all cases we just delegate method to this instance.

I moved default value of quantity to `Stock::Quantifier`, because otherwise delegation will not work.

Should I add cache to `quantifier` method? It's so small class, so this wont give noticeable performance boost.
