### PR TITLE
Simplify code for tax_category and like_any. Use faster query for check non-tracked variants

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -189,11 +189,7 @@ module Spree
     def set_property(property_name, property_value, property_presentation = property_name)
       ActiveRecord::Base.transaction do
         # Works around spree_i18n #301
-        property = if Property.exists?(name: property_name)
-          Property.find_by(name: property_name)
-        else
-          Property.create(name: property_name, presentation: property_presentation)
-        end
+        property = Property.create_with(presentation: property_presentation).find_or_create_by(name: property_name)
         product_property = ProductProperty.where(product: self, property: property).first_or_initialize
         product_property.value = property_value
         product_property.save!


### PR DESCRIPTION
For `tax_category` I followed convention from `master` method.

I used `find_by` like in `add_associations_from_prototype`.

In `like_any` I used `product` method to minimize number of arrays created in memory.

`any?` performs count on collection and this is slower than `SELECT 1 AS one` (in one of my production tables 102ms. vs 0.6ms.). I don't changed all `any?` to `exists?`, because this is efficient only in case, when association is not loaded.
