### PR TITLE
Update 20141217215630_update_product_slug_index.rb

### DIFF
--- a/core/db/migrate/20141217215630_update_product_slug_index.rb
+++ b/core/db/migrate/20141217215630_update_product_slug_index.rb
@@ -1,6 +1,6 @@
 class UpdateProductSlugIndex < ActiveRecord::Migration
   def change
-    remove_index :spree_products, :slug
+    remove_index :spree_products, :slug if index_exists?(:spree_products, :slug)
     add_index :spree_products, :slug, unique: true
   end
 end


### PR DESCRIPTION
In migrating my app from the latest `2-4-stable` branch to the latest `3-0-stable` branch, I encountered the following error:

```
ArgumentError: Index name 'index_spree_products_on_slug' on table 'spree_products' does not exist
```

Adding this conditional prevents the migration from crashing if the index doesn't exist, and still removes it if it does.
