### PR TITLE
Update 20150309161154_ensure_payments_have_numbers.rb

### DIFF
--- a/core/db/migrate/20150309161154_ensure_payments_have_numbers.rb
+++ b/core/db/migrate/20150309161154_ensure_payments_have_numbers.rb
@@ -1,8 +1,10 @@
 class EnsurePaymentsHaveNumbers < ActiveRecord::Migration
   def change
+    add_index :spree_payments, :number unless index_exists?(:spree_payments, :number)
     Spree::Payment.where(number: nil).find_each do |payment|
       payment.generate_number
       payment.update_columns(number: payment.number)
     end
+    remove_index :spree_payments, :number if index_exists?(:spree_payments, :number)
   end
 end

--- a/core/db/migrate/20150309161154_ensure_payments_have_numbers.rb
+++ b/core/db/migrate/20150309161154_ensure_payments_have_numbers.rb
@@ -5,6 +5,5 @@ class EnsurePaymentsHaveNumbers < ActiveRecord::Migration
       payment.generate_number
       payment.update_columns(number: payment.number)
     end
-    remove_index :spree_payments, :number if index_exists?(:spree_payments, :number)
   end
 end


### PR DESCRIPTION
Adding an index before running this migration (and removing it afterwards, although of course we can keep it around if desired) made this migration run on my app in 6 minutes, rather than 24 hours!

It immensely speeds up the _n_ number of `EXISTS` queries that will be triggered by the `payment.generate_number` calls, as discussed in https://github.com/spree/spree/issues/6726.
