### PR TITLE
adds Spree::Config[:record_order_state_changes] (defaults to current …

### DIFF
--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -45,6 +45,7 @@ module Spree
     preference :products_per_page, :integer, default: 12
     preference :promotions_per_page, :integer, default: 15
     preference :customer_returns_per_page, :integer, default: 15
+    preference :record_order_state_changes, :boolean, default: true
     preference :require_master_price, :boolean, default: true
     preference :restock_inventory, :boolean, default: true # Determines if a return item is restocked automatically once it has been received
     preference :return_eligibility_number_of_days, :integer, default: 365

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -456,7 +456,7 @@ module Spree
 
     def state_changed(name)
       state = "#{name}_state"
-      if persisted?
+      if persisted? && Spree::Config[:record_order_state_changes]
         old_state = self.send("#{state}_was")
         new_state = self.send(state)
         unless old_state == new_state


### PR DESCRIPTION
…behavior, true); use to disable creation of records in spree_state_changes

Note: State changes currently have a design flaw in that user_id is not recorded correctly. (It is always the customer's id.). 

Instead of fixing flaw, this prepares for eventual replacement of feature by spinning out all auditing into Spree Extensions. As discussed, the vision is to remove auditing from from core and replace it with two possible extensions: one for acts-as-audited and an alternative for Paper trail, to give developers the choice as to their needs (and tolerance for large audit tables in their DB)

For any users of the state_change table, we have left the preference defaulted to true to preserve existing functionality. I would suggest that we target changing the default here false for this in Spree 4.0, but leave it defaulted to true for at least the rest of the 3.x line. 

TODO:
- [X] add specs
- [ ] refactor for developer-only preferences set on ruby objects Spree::Order.record_state_changes
