### PR TITLE
Display output of state to match the form

### DIFF
--- a/frontend/app/views/spree/shared/_address.html.erb
+++ b/frontend/app/views/spree/shared/_address.html.erb
@@ -18,7 +18,9 @@
     </div>
     <div class="local">
       <span class="locality"><%= address.city %></span>
-      <span class="region"><%= address.state_text %></span>
+      <% if Spree::Config[:address_requires_state] %>
+        <span class="region"><%= address.state_text %></span>
+      <% end %>
       <span class="postal-code"><%= address.zipcode %></span>
       <div class="country-name"><%= address.country.try(:name) %></div>
     </div>


### PR DESCRIPTION
It seems if frontend/app/views/spree/address/_form.html.erb hides the state completely when this config flag
is enabled we should also hide it here. This was causing confusion for some UK users were the "state" was
not desired but due to automatic data population from another system it was populating the state with the
"town". So users were seeing info they did not enter and had not be requested.

This commit updates the templates to match for consistency.
