### PR TITLE
Don't join(master: :prices) on Product#available.

### DIFF
--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -188,7 +188,7 @@ module Spree
 
     # Can't use add_search_scope for this as it needs a default argument
     def self.available(available_on = nil, currency = nil)
-      joins(:master => :prices).where("#{Product.quoted_table_name}.available_on <= ?", available_on || Time.now)
+      where("#{Product.quoted_table_name}.available_on <= ?", available_on || Time.now)
     end
     search_scopes << :available
 


### PR DESCRIPTION
Gets rid of two joins that aren't used at all in the query, and brings huge performance benefits. The joins were previously used, but the functionality was removed. https://github.com/spree/spree/commit/8403be61e46a46608f9a7a8a10bff1b8e110ba58
