### PR TITLE
use :include_blank instead of :prompt

### DIFF
--- a/backend/app/views/spree/admin/variants/_form.html.erb
+++ b/backend/app/views/spree/admin/variants/_form.html.erb
@@ -5,7 +5,7 @@
         <div class="form-group" data-hook="presentation">
           <%= label :new_variant, option_type.presentation %>
           <%= f.collection_select 'option_value_ids', option_type.option_values, :id, :presentation,
-            { :prompt => true }, { :name => 'variant[option_value_ids][]', :class => 'select2' } %>
+            { :include_blank => true }, { :name => 'variant[option_value_ids][]', :class => 'select2' } %>
         </div>
       <% end %>
 


### PR DESCRIPTION
This `prompt` select options **does not add a blank value** in this situation, so i think we should use `include_blank` here.

At the moment this select force the user to always submit an option value for each product option, if not already present on the variant.
It's also impossible to see if a variant has an option value or not, because the first is always selected.
I don't think this is the expected behaviour.
