### PR TITLE
Added background to open/closed labels for adjustments.

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_labels.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_labels.scss
@@ -7,7 +7,8 @@
 .label-ready,
 .label-active,
 .label-success,
-.label-sold
+.label-sold,
+.label-open
 {
   background-color: $brand-success;
 
@@ -20,7 +21,8 @@
 .label-failed,
 .label-considered_risky,
 .label-error,
-.label-invalid {
+.label-invalid,
+.label-closed {
   background-color: $brand-danger;
 }
 


### PR DESCRIPTION
This is a one commit CSS change so that "open" and "closed" labels show up for the adjustments page of the orders in Spree 3
