### PR TITLE
Added support for customizable backend path via preference admin_path

### DIFF
--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,5 +1,5 @@
 Spree::Core::Engine.add_routes do
-  namespace :admin do
+  namespace :admin, path: Spree::Config.admin_path do
     get '/search/users', to: "search#users", as: :search_users
     get '/search/products', to: "search#products", as: :search_products
 
@@ -177,5 +177,5 @@ Spree::Core::Engine.add_routes do
     end
   end
 
-  get '/admin', to: 'admin/root#index', as: :admin
+  get Spree::Config.admin_path, to: 'admin/root#index', as: :admin
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,5 +1,5 @@
 Spree::Core::Engine.add_routes do
-  namespace :admin, path: Spree::Config.admin_path do
+  namespace :admin, path: Spree.admin_path do
     get '/search/users', to: "search#users", as: :search_users
     get '/search/products', to: "search#products", as: :search_products
 
@@ -177,5 +177,5 @@ Spree::Core::Engine.add_routes do
     end
   end
 
-  get Spree::Config.admin_path, to: 'admin/root#index', as: :admin
+  get Spree.admin_path, to: 'admin/root#index', as: :admin
 end

--- a/backend/spec/routing/admin_path_spec.rb
+++ b/backend/spec/routing/admin_path_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+module Spree
+  module Admin
+    RSpec.describe "AdminPath", :type => :routing do
+
+      it "shoud route to admin by default" do
+        expect( spree.admin_path ).to eq("/admin")
+      end
+
+      it "should route to the the configured path" do 
+        Spree.admin_path = "/secret"
+        Rails.application.reload_routes!
+        expect( spree.admin_path ).to eq("/secret")
+
+        # restore the path for other tests
+        Spree.admin_path = "/admin"
+        Rails.application.reload_routes!
+        expect( spree.admin_path ).to eq("/admin")
+      end
+
+    end
+  end
+end

--- a/backend/spec/routing/admin_path_spec.rb
+++ b/backend/spec/routing/admin_path_spec.rb
@@ -2,23 +2,21 @@ require 'spec_helper'
 
 module Spree
   module Admin
-    RSpec.describe "AdminPath", :type => :routing do
-
+    RSpec.describe "AdminPath", type: :routing do
       it "shoud route to admin by default" do
-        expect( spree.admin_path ).to eq("/admin")
+        expect(spree.admin_path).to eq("/admin")
       end
 
-      it "should route to the the configured path" do 
+      it "should route to the the configured path" do
         Spree.admin_path = "/secret"
         Rails.application.reload_routes!
-        expect( spree.admin_path ).to eq("/secret")
+        expect(spree.admin_path).to eq("/secret")
 
         # restore the path for other tests
         Spree.admin_path = "/admin"
         Rails.application.reload_routes!
-        expect( spree.admin_path ).to eq("/admin")
+        expect(spree.admin_path).to eq("/admin")
       end
-
     end
   end
 end

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -23,6 +23,7 @@ module Spree
     preference :address_requires_state, :boolean, default: true # should state/state_name be required
     preference :admin_interface_logo, :string, default: 'logo/spree_50.png'
     preference :admin_products_per_page, :integer, default: 10
+    preference :admin_path, :string, default: "/admin"
     preference :allow_checkout_on_gateway_error, :boolean, default: false
     preference :allow_guest_checkout, :boolean, default: true
     preference :alternative_shipping_phone, :boolean, default: false # Request extra phone for ship addr

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -23,7 +23,6 @@ module Spree
     preference :address_requires_state, :boolean, default: true # should state/state_name be required
     preference :admin_interface_logo, :string, default: 'logo/spree_50.png'
     preference :admin_products_per_page, :integer, default: 10
-    preference :admin_path, :string, default: "/admin"
     preference :allow_checkout_on_gateway_error, :boolean, default: false
     preference :allow_guest_checkout, :boolean, default: true
     preference :alternative_shipping_phone, :boolean, default: false # Request extra phone for ship addr

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -27,6 +27,9 @@ module Spree
     end
   end
 
+  mattr_accessor :admin_path
+  @@admin_path = "/admin"
+
   # Used to configure Spree.
   #
   # Example:

--- a/guides/content/release_notes/3_1_0.md
+++ b/guides/content/release_notes/3_1_0.md
@@ -115,3 +115,16 @@ You can view the full changes using [Github Compare](https://github.com/spree/sp
   * Subclass the `DefaultTax` calculator
 
     [Martin Meyerhoff](https://github.com/spree/spree/pull/6662)
+
+* Added `Spree.admin_path` option for a dynamic admin path; making automated 'script' attacks on the backend more difficult. 
+
+  You can simply configure the option by assigning the path in your Spree initializer:
+  ```ruby
+  Spree.admin_path = "/my-secret-backend"
+  ```
+
+  NOTE: Plugins are not converted and still use the default /admin path. But these plugins can be 
+  changed easily by adding the `path: Spree.admin_path` option in the routes.
+
+    [Rick Blommers](https://github.com/spree/spree/pull/6739)
+  


### PR DESCRIPTION
It would be very nice if it was possible to make the backend path configurable. For example use /secret-admin-path as the admin path.

With this pull-request it becomes possible to change the admin path via the normal Spree initializer:

``` ruby
Spree.config do |config|
  config.admin_path = "/secret-admin-path"
end
```

The main reason for this feature request is to make it harder to automate 'script' attacks when a security vulnerability is present. 
## details

I've only changed 3 lines of code, and everything seems to remain backwards compatible.

Added a new preference to configure the path: (in Spree::AppConfiguration)

``` ruby
    preference :admin_path, :string, default: "/admin"
```

Added this configuration setting to the backend/config/routes.rb file

``` ruby
  namespace :admin, path: Spree::Config.admin_path do
     # .. everyting unchanged
     get Spree::Config.admin_path, to: 'admin/root#index', as: :admin
  end
```
## notes

Plugins are not converted and still use the default /admin path. But these plugins can be changed easily by adding the path: Spree::Config.admin_path option!

Today I've issued a bug for this. This solution is a bit different, it uses a normal spree configuration setting. (previous issue involved a module attribute)

See my blog post for the full details:
http://www.gamecreatures.com/blog/2015/09/17/spree-commerce-custom-admin-routes-attempt-2/
