### PR TITLE
move user class extensions to a module

### DIFF
--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -1,0 +1,39 @@
+module Spree
+  module UserMethods
+    extend ActiveSupport::Concern
+
+    include Spree::UserApiAuthentication
+    include Spree::UserPaymentSource
+    include Spree::UserReporting
+    include Spree::RansackableAttributes
+
+    included do
+      has_many :role_users, class_name: 'Spree::RoleUser', foreign_key: :user_id
+      has_many :spree_roles, through: :role_users, class_name: 'Spree::Role', source: :role
+
+      has_many :promotion_rule_users, class_name: 'Spree::PromotionRuleUser'
+      has_many :promotion_rules, through: :promotion_rule_users, class_name: 'Spree::PromotionRule'
+
+      has_many :orders, foreign_key: :user_id, class_name: "Spree::Order"
+
+      belongs_to :ship_address, class_name: 'Spree::Address'
+      belongs_to :bill_address, class_name: 'Spree::Address'
+
+      self.whitelisted_ransackable_associations = %w[bill_address ship_address]
+      self.whitelisted_ransackable_attributes = %w[id email]
+    end
+
+    # has_spree_role? simply needs to return true or false whether a user has a role or not.
+    def has_spree_role?(role_in_question)
+      spree_roles.where(name: role_in_question.to_s).any?
+    end
+
+    def last_incomplete_spree_order
+      orders.incomplete.order('created_at DESC').first
+    end
+
+    def analytics_id
+      id
+    end
+  end
+end

--- a/core/app/models/spree/legacy_user.rb
+++ b/core/app/models/spree/legacy_user.rb
@@ -3,16 +3,11 @@ module Spree
   class LegacyUser < Spree::Base
     include UserAddress
     include UserPaymentSource
+    include UserMethods
 
     self.table_name = 'spree_users'
 
-    has_many :orders, foreign_key: :user_id
-
     before_destroy :check_completed_orders
-
-    def has_spree_role?(role)
-      true
-    end
 
     attr_accessor :password
     attr_accessor :password_confirmation

--- a/core/config/initializers/user_class_extensions.rb
+++ b/core/config/initializers/user_class_extensions.rb
@@ -1,41 +1,10 @@
+# Ensure that Spree.user_class includes the UserMethods concern
+# Previously these methods were injected automatically onto the class, which we
+# are still doing for compatability, but with a warning.
+
 Spree::Core::Engine.config.to_prepare do
-  if Spree.user_class
-    Spree.user_class.class_eval do
-      include Spree::UserApiAuthentication
-      include Spree::UserPaymentSource
-      include Spree::UserReporting
-
-      has_many :role_users, class_name: 'Spree::RoleUser', foreign_key: :user_id
-      has_many :spree_roles, through: :role_users, class_name: 'Spree::Role', source: :role
-
-      has_many :promotion_rule_users, class_name: 'Spree::PromotionRuleUser'
-      has_many :promotion_rules, through: :promotion_rule_users, class_name: 'Spree::PromotionRule'
-
-      has_many :orders, foreign_key: :user_id, class_name: "Spree::Order"
-
-      belongs_to :ship_address, class_name: 'Spree::Address'
-      belongs_to :bill_address, class_name: 'Spree::Address'
-
-      def self.ransackable_associations(auth_object=nil)
-        %w[bill_address ship_address]
-      end
-
-      def self.ransackable_attributes(auth_object=nil)
-        %w[id email]
-      end
-
-      # has_spree_role? simply needs to return true or false whether a user has a role or not.
-      def has_spree_role?(role_in_question)
-        spree_roles.where(name: role_in_question.to_s).any?
-      end
-
-      def last_incomplete_spree_order
-        orders.incomplete.order('created_at DESC').first
-      end
-
-      def analytics_id
-        id
-      end
-    end
+  if Spree.user_class && !Spree.user_class.included_modules.include?(Spree::UserMethods)
+    ActiveSupport::Deprecation.warn "#{Spree.user_class} must include Spree::UserMethods"
+    Spree.user_class.include Spree::UserMethods
   end
 end

--- a/core/spec/models/spree/concerns/user_methods_spec.rb
+++ b/core/spec/models/spree/concerns/user_methods_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe Spree::UserMethods do
+  let(:test_user) { create :user }
+
+  describe '#has_spree_role?' do
+    subject { test_user.has_spree_role? name }
+
+    let(:role) { Spree::Role.create(name: name) }
+    let(:name) { 'test' }
+
+    context 'with a role' do
+      before { test_user.spree_roles << role }
+      it { is_expected.to be_truthy }
+    end
+
+    context 'without a role' do
+      it { is_expected.to be_falsy }
+    end
+  end
+
+  describe '#last_incomplete_spree_order' do
+    subject { test_user.last_incomplete_spree_order }
+
+    context 'with an incomplete order' do
+      let(:last_incomplete_order) { create :order, user: test_user }
+
+      before do
+        create(:order, user: test_user, created_at: 1.day.ago)
+        create(:order, user: create(:user))
+        last_incomplete_order
+      end
+
+      it { is_expected.to eq last_incomplete_order }
+    end
+
+    context 'without an incomplete order' do
+      it { is_expected.to be_nil }
+    end
+  end
+end


### PR DESCRIPTION
(some code taken from Solidus, @deereb and @forkata)
this is a cleaner solution and allow easier User modification

I also had to update the ransack whitelisting to work like all the other models
