### PR TITLE
Maintain classification positions on association collection removal

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -333,10 +333,7 @@ module Spree
 
     def remove_taxon(taxon)
       removed_classifications = classifications.where(taxon: taxon)
-
-      removed_classifications.each do |classification|
-        classification.remove_from_list
-      end
+      removed_classifications.each &:remove_from_list
     end
   end
 end

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -31,7 +31,7 @@ module Spree
     has_many :properties, through: :product_properties
 
     has_many :classifications, dependent: :delete_all, inverse_of: :product
-    has_many :taxons, through: :classifications
+    has_many :taxons, through: :classifications, before_remove: :remove_taxon
     has_and_belongs_to_many :promotion_rules, join_table: :spree_products_promotion_rules
 
     belongs_to :tax_category, class_name: 'Spree::TaxCategory'
@@ -331,6 +331,13 @@ module Spree
       Spree::Taxonomy.where(id: taxonomy_ids_to_touch).update_all(updated_at: Time.current)
     end
 
+    def remove_taxon(taxon)
+      removed_classifications = classifications.where(taxon: taxon)
+
+      removed_classifications.each do |classification|
+        classification.remove_from_list
+      end
+    end
   end
 end
 

--- a/core/spec/models/spree/classification_spec.rb
+++ b/core/spec/models/spree/classification_spec.rb
@@ -21,8 +21,8 @@ module Spree
     end
 
     def positions_to_be_valid(taxon)
-      taxon.reload
-      expect(taxon.classifications.map(&:position)).to eq((1..taxon.classifications.count).to_a)
+      positions = taxon.reload.classifications.map(&:position)
+      expect(positions).to eq((1..taxon.classifications.count).to_a)
     end
 
     it "has a valid fixtures" do

--- a/core/spec/models/spree/classification_spec.rb
+++ b/core/spec/models/spree/classification_spec.rb
@@ -11,5 +11,83 @@ module Spree
       expect(add_taxon).to raise_error(ActiveRecord::RecordInvalid)
     end
 
+    let(:taxon_with_5_products) do
+      products = []
+      5.times do
+        products << create(:base_product)
+      end
+
+      create(:taxon, products: products)
+    end
+
+    def positions_to_be_valid(taxon)
+      taxon.reload
+      expect(taxon.classifications.map(&:position)).to eq((1..taxon.classifications.count).to_a)
+    end
+
+    it "has a valid fixtures" do
+      expect positions_to_be_valid(taxon_with_5_products)
+      expect(Spree::Classification.count).to eq 5
+    end
+
+    context "removing product from taxon" do
+      before :each do
+        p = taxon_with_5_products.products[1]
+        expect(p.classifications.first.position).to eq(2)
+        taxon_with_5_products.products.destroy(p)
+      end
+
+      it "resets positions" do
+        expect positions_to_be_valid(taxon_with_5_products)
+      end
+    end
+
+    context "replacing taxon's products" do
+      before :each do
+        products = taxon_with_5_products.products.to_a
+        products.pop(1)
+        taxon_with_5_products.products = products
+        taxon_with_5_products.save!
+      end
+
+      it "resets positions" do
+        expect positions_to_be_valid(taxon_with_5_products)
+      end
+    end
+
+    context "removing taxon from product" do
+      before :each do
+        p = taxon_with_5_products.products[1]
+        p.taxons.destroy(taxon_with_5_products)
+        p.save!
+      end
+
+      it "resets positions" do
+        expect positions_to_be_valid(taxon_with_5_products)
+      end
+    end
+
+    context "replacing product's taxons" do
+      before :each do
+        p = taxon_with_5_products.products[1]
+        p.taxons = []
+        p.save!
+      end
+
+      it "resets positions" do
+        expect positions_to_be_valid(taxon_with_5_products)
+      end
+    end
+
+    context "destroying classification" do
+      before :each do
+        classification = taxon_with_5_products.classifications[1]
+        classification.destroy
+      end
+
+      it "resets positions" do
+        expect positions_to_be_valid(taxon_with_5_products)
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes integrity of classifications.

Product update action adds/removes taxons via `taxons =`, which does not trigger destroy callbacks on classification. So the positions need to be via a `before_remove` callback.

Fixes #6238
