### PR TITLE
ensure orders are destroyed when a store is destroyed

### DIFF
--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -1,6 +1,6 @@
 module Spree
   class Store < Spree::Base
-    has_many :orders, class_name: "Spree::Order"
+    has_many :orders, class_name: "Spree::Order", dependent: :destroy
 
     validates :code, presence: true, uniqueness: { allow_blank: true }
     validates :name, presence: true


### PR DESCRIPTION
When a store is destroyed, we should destroy the orders. An Order is paranoid, so they don't actually get destroyed. Say a user creates a store, gets some orders, and then (what Shopify considers) "Closes Shop", then the orders should get destroyed as well.
