### PR TITLE
Use find_by instead of where().first

### DIFF
--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -19,7 +19,7 @@ module Spree
     self.whitelisted_ransackable_attributes = ['description']
 
     def self.default_tax
-      where(default_tax: true).first
+      find_by(default_tax: true)
     end
 
     def self.potential_matching_zones(zone)


### PR DESCRIPTION
Extra ORDER BY  query is not  needed.
And even recommended in rails-style-guide
https://github.com/bbatsov/rails-style-guide#find_by

Queries:
  Spree::Zone.find_by(default_tax: true)
    SELECT  `spree_zones`.\* FROM `spree_zones` WHERE `spree_zones`.`default_tax` = 1 LIMIT 1

  Spree::Zone.default_tax
    SELECT  `spree_zones`.\* FROM `spree_zones` WHERE `spree_zones`.`default_tax` = 1  ORDER BY `spree_zones`.`id` ASC LIMIT 1

Got following results after benchmark
Spree::Zone.count
   (3.1ms)  SELECT COUNT(*) FROM `spree_zones`
 => 6028 

Spree::Zone.reset_column_information

time = Benchmark.measure do
  Spree::Zone.find_by(default_tax: true)
end

Spree::Zone.reset_column_information

time1 = Benchmark.measure do
  Spree::Zone.where(default_tax: true).first
end

puts time, time1

 0.010000   0.000000   0.010000 (  0.006699)
 0.010000   0.000000   0.010000 (  0.009527)
 => nil 
