### PR TITLE
Use public send instead of send to protect privacy of methods

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -25,7 +25,7 @@ module Spree
     end
 
     def self.default(user = nil, kind = "bill")
-      if user && user_address = user.send(:"#{kind}_address")
+      if user && user_address = user.public_send(:"#{kind}_address")
         user_address.clone
       else
         build_default


### PR DESCRIPTION
Using the `send` method stems from the fact that send can even send private methods to an object.
This can be dangerous for an application internally, and also leaves it vulnerable to external, malicious attacks.
`public_send` which does send only publicly-accessible methods to the object that is its receiver.
