### PR TITLE
Admin side not addressing when order tracking is disabled properly

### DIFF
--- a/backend/app/views/spree/admin/variants/_autocomplete_line_items_stock.js.erb
+++ b/backend/app/views/spree/admin/variants/_autocomplete_line_items_stock.js.erb
@@ -12,7 +12,7 @@
     <tbody>
       <tr>
         <td>{{variant.name}}</td>
-        {{#if variant.should_track_inventory?}}
+        {{#if variant.track_inventory}}
           {{#if variant.total_on_hand}}
             <td class="text-center">{{variant.total_on_hand}}</td>
             <td class="text-center">

--- a/backend/app/views/spree/admin/variants/_autocomplete_line_items_stock.js.erb
+++ b/backend/app/views/spree/admin/variants/_autocomplete_line_items_stock.js.erb
@@ -1,5 +1,5 @@
 <script type='text/template' id='variant_line_items_autocomplete_stock_template'>
-  
+
   <label><%= Spree.t(:select_stock) %></label>
 
   <table class="stock-levels table table-bordered" data-hook="stock-levels">
@@ -12,7 +12,7 @@
     <tbody>
       <tr>
         <td>{{variant.name}}</td>
-        {{#if variant.track_inventory}}
+        {{#if variant.should_track_inventory?}}
           {{#if variant.total_on_hand}}
             <td class="text-center">{{variant.total_on_hand}}</td>
             <td class="text-center">

--- a/backend/app/views/spree/admin/variants/_autocomplete_stock.js.erb
+++ b/backend/app/views/spree/admin/variants/_autocomplete_stock.js.erb
@@ -18,7 +18,7 @@
               <input class="quantity form-control input-sm" id="stock_item_quantity" data-stock-location-id="{{this.stock_location_id}}" type="number" min="1" value="1">
             </td>
             <td class="actions actions-1">
-              <button class="btn btn-sm btn-default add_variant with-tip" data-stock-location-id="{{this.stock_location_id}}" title="<%= Spree.t(:add) %>" data-action="add">
+              <button class="btn btn-sm btn-success add_variant with-tip" data-stock-location-id="{{this.stock_location_id}}" title="<%= Spree.t(:add) %>" data-action="add">
                 <span class="icon icon-add"></span>
               </button>
             </td>

--- a/backend/app/views/spree/admin/variants/_autocomplete_stock.js.erb
+++ b/backend/app/views/spree/admin/variants/_autocomplete_stock.js.erb
@@ -1,5 +1,5 @@
 <script type='text/template' id='variant_autocomplete_stock_template'>
-  
+
   <label><%= Spree.t(:select_stock) %></label>
   <table class="table table-condensed table-bordered stock-levels no-marginb" data-hook="stock-levels">
     <thead>
@@ -12,8 +12,8 @@
       {{#each variant.stock_items}}
         <tr>
           <td>{{this.stock_location_name}}</td>
-          {{#unless ../variant.track_inventory}}
-            <td>It doesn't track inventory</td>
+          {{#unless ../variant.should_track_inventory?}}
+            <td><%= Spree.t(:doesnt_track_inventory) %></td>
             <td>
               <input class="quantity form-control input-sm" id="stock_item_quantity" data-stock-location-id="{{this.stock_location_id}}" type="number" min="1" value="1">
             </td>
@@ -32,7 +32,7 @@
                 <input class="quantity form-control input-sm" id="stock_item_quantity" data-stock-location-id="{{this.stock_location_id}}" type="number" min="1" value="1">
               </td>
               <td class="actions actions-1">
-                <button class="btn btn-sm btn-default add_variant with-tip" data-stock-location-id="{{this.stock_location_id}}" title="<%= Spree.t(:add) %>" data-action="add">
+                <button class="btn btn-sm btn-success add_variant with-tip" data-stock-location-id="{{this.stock_location_id}}" title="<%= Spree.t(:add) %>" data-action="add">
                   <span class="icon icon-add"></span>
                 </button>
               </td>
@@ -44,5 +44,5 @@
         </tr>
       {{/each}}
     </tbody>
-  </table>  
+  </table>
 </script>

--- a/backend/app/views/spree/admin/variants/_autocomplete_stock.js.erb
+++ b/backend/app/views/spree/admin/variants/_autocomplete_stock.js.erb
@@ -12,7 +12,7 @@
       {{#each variant.stock_items}}
         <tr>
           <td>{{this.stock_location_name}}</td>
-          {{#unless ../variant.should_track_inventory?}}
+          {{#unless ../variant.track_inventory}}
             <td><%= Spree.t(:doesnt_track_inventory) %></td>
             <td>
               <input class="quantity form-control input-sm" id="stock_item_quantity" data-stock-location-id="{{this.stock_location_id}}" type="number" min="1" value="1">

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -155,6 +155,27 @@ describe "Order Details", type: :feature, js: true do
         end
       end
 
+      context "site doesn't track inventory" do
+        before do
+          Spree::Config.set track_inventory_levels: false
+          product.master.update_column(:track_inventory, true)
+          product.master.stock_items.first.update_column(:backorderable, true)
+          product.master.stock_items.first.update_column(:count_on_hand, 0)
+        end
+
+        it "adds variant to order just fine" do
+          select2_search product.name, from: Spree.t(:name_or_sku)
+          within("table.stock-levels") do
+            fill_in "variant_quantity", with: 1
+            click_icon :add
+          end
+
+          within(".line-items") do
+            expect(page).to have_content(product.name)
+          end
+        end
+      end
+
       context "variant out of stock and not backorderable" do
         before do
           product.master.stock_items.first.update_column(:backorderable, false)
@@ -170,7 +191,6 @@ describe "Order Details", type: :feature, js: true do
         end
       end
     end
-
 
     context 'Shipment edit page' do
       let!(:stock_location2) { create(:stock_location_with_items, name: 'Clarksville') }

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -375,6 +375,42 @@ describe "Order Details", type: :feature, js: true do
             expect(order.shipments.last.inventory_units_for(product.master).count).to eq(1)
           end
         end
+
+        context "site doesn't track inventory" do
+          before do
+            Spree::Config.set track_inventory_levels: false
+            product.master.update_column(:track_inventory, true)
+            product.master.stock_items.first.update_column(:backorderable, true)
+            product.master.stock_items.first.update_column(:count_on_hand, 0)
+          end
+
+          it "adds variant to order just fine" do
+            select2_search product.name, from: Spree.t(:name_or_sku)
+            within("table.stock-levels") do
+              fill_in "stock_item_quantity", with: 1
+              click_icon :add
+            end
+
+            within(".stock-contents") do
+              expect(page).to have_content(product.name)
+            end
+          end
+        end
+
+        context "variant out of stock and not backorderable" do
+          before do
+            product.master.stock_items.first.update_column(:backorderable, false)
+            product.master.stock_items.first.update_column(:count_on_hand, 0)
+          end
+
+          it "displays out of stock instead of add button" do
+            select2_search product.name, from: Spree.t(:name_or_sku)
+
+            within("table.stock-levels") do
+              expect(page).to have_content(Spree.t(:out_of_stock))
+            end
+          end
+        end
       end
 
       context 'splitting to shipment' do

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -210,6 +210,10 @@ module Spree
       self.track_inventory? && Spree::Config.track_inventory_levels
     end
 
+    def track_inventory
+      self.should_track_inventory?
+    end
+
     def volume
       (width || 0) * (height || 0) * (depth || 0)
     end


### PR DESCRIPTION
Updated autocomplete stock partials to use the should_track_inventory? function instead of the track_inventory variable of the variant model so the functionality works as expected when inventory tracking is configured to be off
