### PR TITLE
Use Time.current instead of Time.now to prevent time.zone issues

### DIFF
--- a/core/app/models/concerns/spree/adjustment_source.rb
+++ b/core/app/models/concerns/spree/adjustment_source.rb
@@ -52,7 +52,7 @@ module Spree
       adjustment_scope.where("spree_orders.completed_at IS NOT NULL").each do |adjustment|
         adjustment.update_columns(
           source_id: nil,
-          updated_at: Time.now,
+          updated_at: Time.current,
         )
       end
     end

--- a/core/app/models/spree/adjustable/adjustments_updater.rb
+++ b/core/app/models/spree/adjustable/adjustments_updater.rb
@@ -31,7 +31,7 @@ module Spree
         attributes[:adjustment_total] = totals[:non_taxable_adjustment_total] +
                                         totals[:taxable_adjustment_total] +
                                         totals[:additional_tax_total]
-        attributes[:updated_at] = Time.now
+        attributes[:updated_at] = Time.current
         @adjustable.update_columns(totals)
       end
 

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -89,7 +89,7 @@ module Spree
     def update!(target = adjustable)
       return amount if closed? || source.blank?
       amount = source.compute_amount(target)
-      attributes = { amount: amount, updated_at: Time.now }
+      attributes = { amount: amount, updated_at: Time.current }
       attributes[:eligible] = source.promotion.eligible?(target) if promotion?
       update_columns(attributes)
       amount

--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -53,7 +53,7 @@ module Spree
       inventory_units.map do |iu|
         iu.update_columns(
           pending: false,
-          updated_at: Time.now,
+          updated_at: Time.current,
         )
       end
     end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -519,7 +519,7 @@ module Spree
     def restart_checkout_flow
       self.update_columns(
         state: 'cart',
-        updated_at: Time.now,
+        updated_at: Time.current,
       )
       self.next! if self.line_items.size > 0
     end
@@ -547,7 +547,7 @@ module Spree
         cancel!
         self.update_columns(
           canceler_id: user.id,
-          canceled_at: Time.now,
+          canceled_at: Time.current,
         )
       end
     end
@@ -557,7 +557,7 @@ module Spree
         approve!
         self.update_columns(
           approver_id: user.id,
-          approved_at: Time.now,
+          approved_at: Time.current,
         )
       end
     end

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -7,7 +7,7 @@ module Spree
     end
 
     def add(variant, quantity = 1, options = {})
-      timestamp = Time.now
+      timestamp = Time.current
       line_item = add_to_line_item(variant, quantity, options)
       options[:line_item_created] = true if timestamp <= line_item.created_at
       after_add_or_remove(line_item, options)

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -110,7 +110,7 @@ module Spree
         shipment_total: order.shipment_total,
         promo_total: order.promo_total,
         total: order.total,
-        updated_at: Time.now,
+        updated_at: Time.current,
       )
     end
 

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -262,7 +262,7 @@ module Spree
 
     def punch_slug
       # punch slug with date prefix to allow reuse of original
-      update_column :slug, "#{Time.now.to_i}_#{slug}"[0..254] unless frozen?
+      update_column :slug, "#{Time.current.to_i}_#{slug}"[0..254] unless frozen?
     end
 
     def update_slug_history

--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -188,7 +188,7 @@ module Spree
 
     # Can't use add_search_scope for this as it needs a default argument
     def self.available(available_on = nil, currency = nil)
-      joins(:master => :prices).where("#{Product.quoted_table_name}.available_on <= ?", available_on || Time.now)
+      joins(:master => :prices).where("#{Product.quoted_table_name}.available_on <= ?", available_on || Time.current)
     end
     search_scopes << :available
 

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -46,8 +46,8 @@ module Spree
     end
 
     def self.active
-      where('spree_promotions.starts_at IS NULL OR spree_promotions.starts_at < ?', Time.now).
-        where('spree_promotions.expires_at IS NULL OR spree_promotions.expires_at > ?', Time.now)
+      where('spree_promotions.starts_at IS NULL OR spree_promotions.starts_at < ?', Time.current).
+        where('spree_promotions.expires_at IS NULL OR spree_promotions.expires_at > ?', Time.current)
     end
 
     def self.order_activatable?(order)
@@ -55,7 +55,7 @@ module Spree
     end
 
     def expired?
-      !!(starts_at && Time.now < starts_at || expires_at && Time.now > expires_at)
+      !!(starts_at && Time.current < starts_at || expires_at && Time.current > expires_at)
     end
 
     def activate(payload)

--- a/core/app/models/spree/return_item/eligibility_validator/time_since_purchase.rb
+++ b/core/app/models/spree/return_item/eligibility_validator/time_since_purchase.rb
@@ -1,7 +1,7 @@
 module Spree
   class ReturnItem::EligibilityValidator::TimeSincePurchase < Spree::ReturnItem::EligibilityValidator::BaseValidator
     def eligible_for_return?
-      if (@return_item.inventory_unit.order.completed_at + Spree::Config[:return_eligibility_number_of_days].days) > Time.now
+      if (@return_item.inventory_unit.order.completed_at + Spree::Config[:return_eligibility_number_of_days].days) > Time.current
         return true
       else
         add_error(:number_of_days, Spree.t('return_item_time_period_ineligible'))

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -251,7 +251,7 @@ module Spree
 
     def shipped=(value)
       return unless value == '1' && shipped_at.nil?
-      self.shipped_at = Time.now
+      self.shipped_at = Time.current
     end
 
     def shipping_method
@@ -286,7 +286,7 @@ module Spree
         self.update_columns(
           cost: selected_shipping_rate.cost,
           adjustment_total: adjustments.additional.map(&:update!).compact.sum,
-          updated_at: Time.now,
+          updated_at: Time.current,
         )
       end
     end
@@ -308,7 +308,7 @@ module Spree
           # (via Order#paid?) affects the shipment state (YAY)
           self.update_columns(
             state: determine_state(order),
-            updated_at: Time.now
+            updated_at: Time.current
           )
 
           # And then it's time to update shipment states and finally persist
@@ -329,7 +329,7 @@ module Spree
       new_state = determine_state(order)
       update_columns(
         state: new_state,
-        updated_at: Time.now,
+        updated_at: Time.current,
       )
       after_ship if new_state == 'shipped' and old_state != 'shipped'
     end

--- a/core/app/models/spree/shipment_handler.rb
+++ b/core/app/models/spree/shipment_handler.rb
@@ -36,7 +36,7 @@ module Spree
         new_state = OrderUpdater.new(order).update_shipment_state
         order.update_columns(
                              shipment_state: new_state,
-                             updated_at: Time.now,
+                             updated_at: Time.current,
                              )
       end
   end

--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -68,7 +68,7 @@ module Spree
       item = stock_item_or_create(variant)
       item.update_columns(
         count_on_hand: item.count_on_hand + quantity,
-        updated_at: Time.now
+        updated_at: Time.current
       )
     end
 

--- a/core/app/models/spree/tax_category.rb
+++ b/core/app/models/spree/tax_category.rb
@@ -14,7 +14,7 @@ module Spree
         unless tax_category == self
           tax_category.update_columns(
             is_default: false,
-            updated_at: Time.now,
+            updated_at: Time.current,
           )
         end
       end

--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -92,7 +92,7 @@ module Spree
 
     def touch_ancestors_and_taxonomy
       # Touches all ancestors at once to avoid recursive taxonomy touch, and reduce queries.
-      self.class.where(id: ancestors.pluck(:id)).update_all(updated_at: Time.now)
+      self.class.where(id: ancestors.pluck(:id)).update_all(updated_at: Time.current)
       # Have taxonomy touch happen in #touch_ancestors_and_taxonomy rather than association option in order for imports to override.
       taxonomy.try!(:touch)
     end

--- a/guides/content/release_notes/3_1_0.md
+++ b/guides/content/release_notes/3_1_0.md
@@ -127,4 +127,8 @@ You can view the full changes using [Github Compare](https://github.com/spree/sp
   changed easily by adding the `path: Spree.admin_path` option in the routes.
 
     [Rick Blommers](https://github.com/spree/spree/pull/6739)
+
+* Change to Use Time.current instead of Time.now
+
+    [Abhishek Jain](https://github.com/spree/spree/pull/6761)
   

--- a/guides/content/release_notes/3_1_0.md
+++ b/guides/content/release_notes/3_1_0.md
@@ -130,5 +130,8 @@ You can view the full changes using [Github Compare](https://github.com/spree/sp
 
 * Change to Use Time.current instead of Time.now
 
+    Rails uses config.time_zone to set time zone for the application, but Time.now uses server time zone instead
+    of using set config.time_zone. So, in order to use application time zone we need to use Time.current/Time.zone.now.
+
     [Abhishek Jain](https://github.com/spree/spree/pull/6761)
   


### PR DESCRIPTION
It is much better to use Time.current than Time.now as it takes application zone into consideration.
