### PR TITLE
Destroy dependent zone members.

### DIFF
--- a/core/app/models/spree/country.rb
+++ b/core/app/models/spree/country.rb
@@ -3,6 +3,8 @@ module Spree
     has_many :states, -> { order('name ASC') }, dependent: :destroy
     has_many :addresses, dependent: :nullify
 
+    has_many :zone_members, as: :zoneable, dependent: :destroy
+
     validates :name, :iso_name, presence: true
 
     def self.states_required_by_country_id

--- a/core/app/models/spree/state.rb
+++ b/core/app/models/spree/state.rb
@@ -3,6 +3,8 @@ module Spree
     belongs_to :country, class_name: 'Spree::Country'
     has_many :addresses, dependent: :nullify
 
+    has_many :zone_members, as: :zoneable, dependent: :destroy
+
     validates :country, :name, presence: true
 
     def self.find_all_by_name_or_abbr(name_or_abbr)


### PR DESCRIPTION
We ran into a serious issue where deleting a `Spree::State` on the admin panel would leave a ghost reference on the `Zone` via `ZoneMember`, completely breaking the checkout.
