### PR TITLE
Fix of bug in `Spree::LocalizedNumber.parse`

### DIFF
--- a/core/lib/spree/localized_number.rb
+++ b/core/lib/spree/localized_number.rb
@@ -8,7 +8,9 @@ module Spree
       separator, delimiter = I18n.t([:'number.currency.format.separator', :'number.currency.format.delimiter'])
       non_number_characters = /[^0-9\-#{separator}]/
 
-      # strip everything else first
+      # work on a copy, prevent original argument modification
+      number = number.dup
+      # strip everything else first, including thousands delimiter
       number.gsub!(non_number_characters, '')
       # then replace the locale-specific decimal separator with the standard separator if necessary
       number.gsub!(separator, '.') unless separator == '.'

--- a/core/spec/lib/spree/localized_number_spec.rb
+++ b/core/spec/lib/spree/localized_number_spec.rb
@@ -33,6 +33,16 @@ describe Spree::LocalizedNumber do
         expect(subject.class.parse(1599.99)).to eql 1599.99
       end
     end
+
+    context "string argument" do
+      it "should not be modified" do
+        I18n.locale = :de
+        number = '1.599,99'
+        number_bak = number.dup
+        subject.class.parse(number)
+        expect(number).to eql(number_bak)
+      end
+    end
   end
 
 end


### PR DESCRIPTION
Fix of side-effect in `Spree::LocalizedNumber.parse`, which mangles object passed as its argument.

Current code unexpectedly alters its `number` argument with `String#gsub!` method, so in effect it also mangles the original object passed for parsing.

```
number_to_parse = "1 234,56"
parsed_number = Spree::LocalizedNumber.parse(number_to_parse)  # returns 1234.56
p number_to_parse    # "1234.56"  <- original object altered !
```
