### PR TITLE
Modify rspec-activemodel-mocks-patch.rb to also allow upper versions of …

### DIFF
--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -24,7 +24,7 @@ group :test do
   gem 'email_spec'
   gem 'factory_girl_rails', '~> 4.5.0'
   gem 'launchy'
-  gem 'rspec-activemodel-mocks'
+  gem 'rspec-activemodel-mocks', '~> 1.0.2'
   gem 'rspec-collection_matchers'
   gem 'rspec-its'
   gem 'rspec-rails', '~> 3.3'

--- a/core/spec/support/rspec-activemodel-mocks-patch.rb
+++ b/core/spec/support/rspec-activemodel-mocks-patch.rb
@@ -1,8 +1,0 @@
-# Manually applied the patch from https://github.com/jdelStrother/rspec-activemodel-mocks/commit/1211c347c5a574739616ccadf4b3b54686f9051f
-unless Gem.loaded_specs['rspec-activemodel-mocks'].version.to_s =~ /1.0.\d/
-  raise "RSpec-ActiveModel-Mocks version has changed, please check if the behaviour has already been fixed: https://github.com/rspec/rspec-activemodel-mocks/pull/10
-If so, this patch might be obsolete-"
-end
-RSpec::ActiveModel::Mocks::Mocks::ActiveRecordInstanceMethods.class_eval do
-  alias_method :_read_attribute, :[]
-end

--- a/core/spec/support/rspec-activemodel-mocks-patch.rb
+++ b/core/spec/support/rspec-activemodel-mocks-patch.rb
@@ -1,5 +1,5 @@
 # Manually applied the patch from https://github.com/jdelStrother/rspec-activemodel-mocks/commit/1211c347c5a574739616ccadf4b3b54686f9051f
-if Gem.loaded_specs['rspec-activemodel-mocks'].version.to_s != "1.0.1"
+unless Gem.loaded_specs['rspec-activemodel-mocks'].version.to_s =~ /1.0.\d/
   raise "RSpec-ActiveModel-Mocks version has changed, please check if the behaviour has already been fixed: https://github.com/rspec/rspec-activemodel-mocks/pull/10
 If so, this patch might be obsolete-"
 end


### PR DESCRIPTION
…1.0.1
