### PR TITLE
Refactor location 2

### DIFF
--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -108,10 +108,7 @@ module Spree
 
       def ensure_one_default
         if self.default
-          StockLocation.where(default: true).where.not(id: self.id).each do |stock_location|
-            stock_location.default = false
-            stock_location.save!
-          end
+          StockLocation.where(default: true).where.not(id: self.id).update_all(default: false)
         end
       end
   end

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -29,7 +29,9 @@ module Spree
 
     def ensure_default_exists_and_is_unique
       if default
-        Store.where.not(id: id).update_all(default: false)
+        Store.where.not(id: id).each do |store|
+          store.update_attribute(:default, false)
+        end
       elsif Store.where(default: true).count == 0
         self.default = true
       end

--- a/core/spec/models/spree/store_spec.rb
+++ b/core/spec/models/spree/store_spec.rb
@@ -59,6 +59,6 @@ describe Spree::Store, :type => :model do
         expect(store_2.default).to be true
       end
     end
-   end
+  end
 
 end

--- a/core/spec/models/spree/store_spec.rb
+++ b/core/spec/models/spree/store_spec.rb
@@ -45,6 +45,20 @@ describe Spree::Store, :type => :model do
       expect(store_2.default).to be true
       expect(store.default).not_to be true
     end
-  end
+
+    context 'when store is not saved' do
+      before do
+        store.default = true
+        store.code = nil
+        store.save
+      end
+
+      it "ensure old default location still default" do
+        [store, store_2].each(&:reload)
+        expect(store.default).to be false
+        expect(store_2.default).to be true
+      end
+    end
+   end
 
 end


### PR DESCRIPTION
In store.rb
Avoid using update_all in before_save callback, as record might not get saved and update_all updates all records, leaving behind store without default store.

Also added spec for the same.

In store_location.rb

As it is called in after_save, we do not require to run callbacks and also avoid multiple update queries.
