### PR TITLE
add valid #cancel method for check payment method

### DIFF
--- a/core/app/models/spree/payment_method/check.rb
+++ b/core/app/models/spree/payment_method/check.rb
@@ -14,13 +14,15 @@ module Spree
       payment.state != 'void'
     end
 
-    def capture(*args)
+    def capture(*)
       simulated_successful_billing_response
     end
 
-    def cancel(response); end
+    def cancel(*)
+      simulated_successful_billing_response
+    end
 
-    def void(*args)
+    def void(*)
       simulated_successful_billing_response
     end
 
@@ -28,7 +30,7 @@ module Spree
       false
     end
 
-    def credit(*args)
+    def credit(*)
       simulated_successful_billing_response
     end
 


### PR DESCRIPTION
`Check #cancel` it's not a valid response, so it's impossibile to cancel an order (`undefined method`success?' for nil:NilClass`)

The blank method was added here https://github.com/spree/spree/issues/5307 but looks like we need a valid response, not `nil`.

I have this problem on 3-0-stable
