### PR TITLE
Add discontinued at to products and variants3

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -136,6 +136,9 @@ module Spree
           unless params[:show_deleted]
             scope = scope.not_deleted
           end
+          unless params[:show_discontinued]
+            scope = scope.not_discontinued
+          end
         else
           scope = Product.accessible_by(current_ability, :read).active.includes(*product_includes)
         end

--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -180,7 +180,7 @@ show_flash = function(type, message) {
     flash_div = $('<div class="alert alert-' + type + '" />');
     $('#content').prepend(flash_div);
   }
-  flash_div.html(message).show().delay(5000).slideUp();
+  flash_div.html(message).show().delay(10000).slideUp();
 }
 
 

--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -44,9 +44,14 @@ module Spree
 
       def destroy
         @product = Product.friendly.find(params[:id])
-        @product.destroy
 
-        flash[:success] = Spree.t('notice_messages.product_deleted')
+        begin
+          # TODO: why is @product.destroy raising ActiveRecord::RecordNotDestroyed instead of failing with false result
+          @product.destroy
+          flash[:success] = Spree.t('notice_messages.product_deleted')
+        rescue ActiveRecord::RecordNotDestroyed => e
+          flash[:error] = Spree.t('notice_messages.product_not_deleted')
+        end
 
         respond_with(@product) do |format|
           format.html { redirect_to collection_url }

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -60,6 +60,14 @@
         <% end %>
       </div>
 
+      <div data-hook="admin_product_form_discontinue_on">
+        <%= f.field_container :discontinue_on, class: ['form-group'] do %>
+          <%= f.label :discontinue_on, Spree.t(:discontinue_on) %>
+          <%= f.error_message_on :discontinue_on %>
+          <%= f.text_field :discontinue_on, value: datepicker_field_value(@product.discontinue_on), class: 'datepicker form-control' %>
+        <% end %>
+      </div>
+
       <% if @product.has_variants? %>
         <div data-hook="admin_product_form_multiple_variants" class="well">
           <%= f.label :skus, Spree.t(:sku).pluralize %>

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -31,6 +31,13 @@
               <%= Spree.t(:show_deleted) %>
             </label>
           </div>
+
+          <div class="field checkbox">
+            <label>
+              <%= f.check_box :discontinue_on_null, {:checked => params[:q][:discontinue_on_null] == '0'}, '0', '1' %>
+              <%= Spree.t(:show_discontinued ) %>
+            </label>
+          </div>
         </div>
       </div>
       <div data-hook="admin_products_index_search_buttons" class="form-actions">
@@ -48,6 +55,8 @@
     <thead>
       <tr data-hook="admin_products_index_headers">
         <th><%= Spree.t(:sku) %></th>
+        <th><%= Spree.t(:status) %></th>
+
         <th colspan="2"><%= sort_link @search,:name, Spree.t(:name), { default_order: "desc" }, {title: 'admin_products_listing_name_title'} %></th>
         <th class="text-center">
           <%= sort_link @search, :master_default_price_amount, Spree.t(:master_price), {}, {title: 'admin_products_listing_price_title'} %>
@@ -59,6 +68,7 @@
       <% @collection.each do |product| %>
           <tr <%== "style='color: red;'" if product.deleted? %> id="<%= spree_dom_id product %>" data-hook="admin_products_index_rows" class="<%= cycle('odd', 'even') %>">
             <td class="sku"><%= product.sku rescue '' %></td>
+            <td class="status"><%= available_status(product) %> </td>
             <td class="image"><%= mini_image product %></td>
             <td><%= link_to product.try(:name), edit_admin_product_path(product) %></td>
             <td class="text-center"><%= product.display_price.to_html rescue '' %></td>

--- a/backend/app/views/spree/admin/shared/_destroy.js.erb
+++ b/backend/app/views/spree/admin/shared/_destroy.js.erb
@@ -3,4 +3,8 @@ if success %>
   show_flash('success', "<%= j success %>")
 <% end %>
 
+<% if error = flash.discard(:error) %>
+show_flash('warning', "<%= j error %>")
+<% end %>
+
 <%= render :partial => '/spree/admin/shared/update_order_state' if @order %>

--- a/backend/app/views/spree/admin/variants/_form.html.erb
+++ b/backend/app/views/spree/admin/variants/_form.html.erb
@@ -28,6 +28,13 @@
         <%= f.label :tax_category_id, Spree.t(:tax_category) %>
         <%= f.collection_select(:tax_category_id, @tax_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2' }) %>
       </div>
+
+      <div class="form-group" data-hook="discontinue_on">
+
+          <%= f.label :discontinue_on, Spree.t(:discontinue_on) %>
+          <%= f.error_message_on :discontinue_on %>
+          <%= f.text_field :discontinue_on, value: datepicker_field_value(@variant.discontinue_on), class: 'datepicker form-control' %>
+      </div>
     </div>
   </div>
 

--- a/core/app/helpers/spree/products_helper.rb
+++ b/core/app/helpers/spree/products_helper.rb
@@ -62,6 +62,19 @@ module Spree
       (common_product_cache_keys + [product.cache_key, product.possible_promotions]).compact.join("/")
     end
 
+    def available_status(product) # will return a human readable string
+      return Spree.t(:discontinued)  if product.discontinued?
+      return Spree.t(:deleted)  if product.deleted?
+
+      if product.available?
+        Spree.t(:available)
+      elsif product.available_on && product.available_on.future?
+        Spree.t(:pending_sale)
+      else
+        Spree.t(:no_available_date_set)
+      end
+    end
+
     private
 
     def common_product_cache_keys

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -99,10 +99,8 @@ module Spree
       !sufficient_stock?
     end
 
-
-    # Remove variant default_scope `deleted_at: nil`
-    def variant
-      Spree::Variant.unscoped { super }
+    def product
+      variant.product
     end
 
     def options=(options = {})

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -417,10 +417,10 @@ module Spree
     end
 
     ##
-    # Check to see if any line item variants are soft deleted.
+    # Check to see if any line item variants are discontinued.
     # If so add error and restart checkout.
-    def ensure_line_item_variants_are_not_deleted
-      if line_items.any?{ |li| !li.variant || li.variant.paranoia_destroyed? }
+    def ensure_line_item_variants_are_not_discontinued
+      if line_items.any?{ |li| !li.variant || li.variant.discontinued? }
         errors.add(:base, Spree.t(:deleted_variants_present))
         restart_checkout_flow
         false

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -106,10 +106,10 @@ module Spree
                 before_transition from: :delivery, do: :apply_free_shipping_promotions
               end
 
-              before_transition to: :resumed, do: :ensure_line_item_variants_are_not_deleted
+              before_transition to: :resumed, do: :ensure_line_item_variants_are_not_discontinued
               before_transition to: :resumed, do: :ensure_line_items_are_in_stock
 
-              before_transition to: :complete, do: :ensure_line_item_variants_are_not_deleted
+              before_transition to: :complete, do: :ensure_line_item_variants_are_not_discontinued
               before_transition to: :complete, do: :ensure_line_items_are_in_stock
 
               after_transition to: :complete, do: :finalize!

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -84,6 +84,7 @@ module Spree
     after_save :run_touch_callbacks, if: :anything_changed?
     after_save :reset_nested_changes
     after_touch :touch_taxons
+    before_destroy :ensure_no_line_items
 
     before_validation :normalize_slug, on: :update
     before_validation :validate_master
@@ -147,7 +148,15 @@ module Spree
     # deleted products and products with nil or future available_on date
     # are not available
     def available?
-      !(available_on.nil? || available_on.future?) && !deleted?
+      !(available_on.nil? || available_on.future?) && !deleted? && !discontinued?
+    end
+
+    def discontinue!
+      update_column(:discontinue_on,  Time.now)
+    end
+
+    def discontinued?
+      !!discontinue_on && discontinue_on <= Time.now
     end
 
     # split variants list into hash which shows mapping of opt value onto matching variants
@@ -343,6 +352,13 @@ module Spree
     def touch_taxons
       Spree::Taxon.where(id: taxon_and_ancestors.map(&:id)).update_all(updated_at: Time.current)
       Spree::Taxonomy.where(id: taxonomy_ids).update_all(updated_at: Time.current)
+    end
+
+    def ensure_no_line_items
+      if line_items.any?
+        errors.add(:base, Spree.t(:cannot_destroy_if_attached_to_line_items))
+        return false
+      end
     end
 
     def remove_taxon(taxon)

--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -186,14 +186,19 @@ module Spree
       where("#{Product.quoted_table_name}.deleted_at IS NULL or #{Product.quoted_table_name}.deleted_at >= ?", Time.zone.now)
     end
 
+    add_search_scope :not_discontinued do
+      where("#{Product.quoted_table_name}.discontinue_on IS NULL or #{Product.quoted_table_name}.discontinue_on >= ?", Time.zone.now)
+    end
+    search_scopes << :not_discontinued
+
     # Can't use add_search_scope for this as it needs a default argument
     def self.available(available_on = nil, currency = nil)
-      joins(:master => :prices).where("#{Product.quoted_table_name}.available_on <= ?", available_on || Time.current)
+      not_discontinued.joins(:master => :prices).where("#{Product.quoted_table_name}.available_on <= ?", available_on || Time.current)
     end
     search_scopes << :available
 
     def self.active(currency = nil)
-      not_deleted.available(nil, currency)
+      not_discontinued.available(nil, currency)
     end
     search_scopes << :active
 

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -40,10 +40,12 @@ module Spree
 
     after_create :create_stock_items
     after_create :set_master_out_of_stock, unless: :is_master?
+    before_destroy :ensure_no_line_items
 
     after_touch :clear_in_stock_cache
 
     scope :in_stock, -> { joins(:stock_items).where('count_on_hand > ? OR track_inventory = ?', 0, false) }
+    scope :not_discontinued, -> { where("#{Variant.quoted_table_name}.discontinue_on IS NULL OR #{Variant.quoted_table_name}.discontinue_on <= ?",  Time.now) }
 
     LOCALIZED_NUMBERS = %w(cost_price weight depth width height)
 
@@ -57,7 +59,7 @@ module Spree
     self.whitelisted_ransackable_attributes = %w[weight sku]
 
     def self.active(currency = nil)
-      joins(:prices).where(deleted_at: nil).where('spree_prices.currency' => currency || Spree::Config[:currency]).where('spree_prices.amount IS NOT NULL')
+      not_discontinued.joins(:prices).where(deleted_at: nil).where('spree_prices.currency' => currency || Spree::Config[:currency]).where('spree_prices.amount IS NOT NULL')
     end
 
     def self.having_orders
@@ -222,7 +224,22 @@ module Spree
       (width || 0) + (height || 0) + (depth || 0)
     end
 
+    def discontinue!
+      update_column(:discontinue_on, Time.now)
+    end
+
+    def discontinued?
+      !!discontinue_on && discontinue_on <= Time.now
+    end
+
     private
+
+    def ensure_no_line_items
+      if line_items.any?
+        errors.add(:base, Spree.t(:cannot_destroy_if_attached_to_line_items))
+        return false
+      end
+    end
 
     def quantifier
       Spree::Stock::Quantifier.new(self)

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -77,6 +77,7 @@ en:
         name: Name
       spree/product:
         available_on: Available On
+        discontinue_on: Discontinue On
         cost_currency: Cost Currency
         cost_price: Cost Price
         description: Description
@@ -298,6 +299,10 @@ en:
           attributes:
             currency:
               must_match_order_currency: "Must match order currency"
+        spree/product:
+          attributes:
+            base:
+              cannot_destroy_if_attached_to_line_items: Cannot delete products once they are attached to line items.
         spree/refund:
           attributes:
             amount:
@@ -316,6 +321,10 @@ en:
           attributes:
             base:
               cannot_destroy_default_store: Cannot destroy the default Store.
+        spree/variant:
+          attributes:
+            base:
+              cannot_destroy_if_attached_to_line_items: Cannot delete variants once they are attached to line items.
 
   devise:
     confirmations:
@@ -485,6 +494,7 @@ en:
     authorized: Authorized
     auto_capture: Auto Capture
     available_on: Available On
+    available: Available
     average_order_value: Average Order Value
     avs_response: AVS Response
     back: Back
@@ -622,6 +632,7 @@ en:
     default_tax: Default Tax
     default_tax_zone: Default Tax Zone
     delete: Delete
+    deleted: Deleted
     delete_from_taxon: Delete From Taxon
     deleted_variants_present: Some line items in this order have products that are no longer available.
     delivery: Delivery
@@ -631,6 +642,7 @@ en:
     destination: Destination
     destroy: Destroy
     discount_amount: Discount Amount
+    discontinued: Discontinued
     dismiss_banner: No. Thanks! I'm not interested, do not display this message again
     display: Display
     doesnt_track_inventory: It doesn't track inventory
@@ -863,6 +875,7 @@ en:
     new_zone: New Zone
     next: Next
     no_actions_added: No actions added
+    no_available_date_set: No available date set
     no_payment_found: No payment found
     no_pending_payments: No pending payments
     no_products_found: No products found
@@ -984,6 +997,7 @@ en:
     percent_per_item: Percent Per Item
     permalink: Permalink
     pending: Pending
+    pending_sale: Pending Sale
     phone: Phone
     place_order: Place Order
     please_define_payment_methods: Please define some payment methods first.
@@ -1227,6 +1241,7 @@ en:
     show: Show
     show_active: Show Active
     show_deleted: Show Deleted
+    show_discontinued: Show Discontinued
     show_only_complete_orders: Only show complete orders
     show_only_considered_risky: Only show risky orders
     show_rate_in_label: Show rate in label

--- a/core/db/migrate/20150819154308_add_discontinued_to_products_and_variants.rb
+++ b/core/db/migrate/20150819154308_add_discontinued_to_products_and_variants.rb
@@ -1,0 +1,68 @@
+class AddDiscontinuedToProductsAndVariants < ActiveRecord::Migration
+  def up
+    add_column :spree_products, :discontinue_on, :datetime, after: :available_on
+    add_column :spree_variants, :discontinue_on, :datetime, after: :deleted_at
+
+    add_index :spree_products, :discontinue_on
+    add_index :spree_variants, :discontinue_on
+
+    puts "Warning: This migration changes the meaning of 'deleted'. Before this change, 'deleted' meant products that were no longer being sold in your store. After this change, you can only delete a product or variant if it has not already been sold to a customer (a model-level check enforces this). Instead, you should use the new field 'discontinue_on' for products or variants which were sold in the past but no longer for sale. This fixes bugs when other objects are attached to deleted products and variants. (Even though acts_as_paranoid gem keeps the records in the database, most associations are automatically scoped to exclude the deleted records.) In thew meaning of 'deleted,' you can still use the delete function on products & variants which are *truly user-error mistakes*, specifically before an order has been placed or the items have gone on sale. You also must use the soft-delete function (which still works after this change) to clean up slug (product) and SKU (variant) duplicates. Otherwise, you should generally over ever need to discontinue products.
+
+Data Fix: We will attempt to reverse engineer the old meaning of 'deleted' (no longer for sale) to the new database field 'discontinue_on'. However, since Slugs and SKUs cannot be duplicated on Products and Variants, we cannot gaurantee this to be foolproof if you have deteled Products and Variants that have duplicate Slugs or SKUs in non-deleted records. In these cases, we recommend you use the additional rake task to clean up your old records (see rake db:fix_orphan_line_items). If you have such records, this migration will leave them in place, preferring the non-deleted records over the deleted ones. However, since old line items will still be associated with deleted objects, you will still the bugs in your app until you run:
+
+rake db:fix_orphan_line_items
+
+We will print out a report of the data we are fixing now: "
+
+    Spree::Product.only_deleted.each do |product|
+      # determine if there is a slug duplicate
+      the_dup = Spree::Product.find_by(slug: product.slug)
+      if the_dup.nil?
+        # check to see if there are line items attached to any variants
+        if Spree::Variant.with_deleted.where(product_id: product.id).map(&:line_items).any?
+          puts "recovering deleted product id #{product.id} ... this will un-delete the record and set it to be discontinued"
+
+          old_deleted = product.deleted_at
+          product.update_column(:deleted_at, nil) # for some reason .recover doesn't appear to be a method
+          product.update_column(:discontinue_on, old_deleted)
+        else
+          puts "leaving product id #{product.id} deleted because there are no line items attached to it..."
+        end
+      else
+        puts "leaving product id #{product.id} deleted because there is a duplicate slug for '#{product.slug}' (product id #{the_dup.id}) "
+        if variants.map(&:line_items).any?
+          puts "WARNING: You may still have bugs with product id #{product.id} (#{product.name}) until you run rake db:fix_orphan_line_items"
+        end
+      end
+    end
+
+    Spree::Variant.only_deleted.each do |variant|
+      # determine if there is a slug duplicate
+      the_dup = Spree::Variant.find_by(sku: variant.sku)
+      if the_dup.nil?
+        # check to see if there are line items attached to any variants
+        if variant.line_items.any?
+          puts "recovering deleted variant id #{variant.id} ... this will un-delete the record and set it to be discontinued"
+          old_deleted = variant.deleted_at
+          variant.update_column(:deleted_at, nil) # for some reason .recover doesn't appear to be a method
+          variant.update_column(:discontinue_on, old_deleted)
+        else
+          puts "leaving variant id #{variant.id} deleted because there are no line items attached to it..."
+        end
+      else
+        puts "leaving variant id #{variant.id} deleted because there is a duplicate SKU for '#{variant.sku}' (variant id #{the_dup.id}) "
+        if variant.line_items.any?
+          puts "WARNING: You may still have bugs with variant id #{variant.id} (#{variant.name}) until you run rake db:fix_orphan_line_items"
+        end
+      end
+    end
+  end
+
+  def down
+    execute "UPDATE `spree_products` SET `deleted_at` = `discontinue_on` WHERE `deleted_at` IS NULL"
+    execute "UPDATE `spree_variants` SET `deleted_at` = `discontinue_on` WHERE `deleted_at` IS NULL"
+
+    remove_column :spree_products, :discontinue_on
+    remove_column :spree_variants, :discontinue_on
+  end
+end

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -57,7 +57,7 @@ module Spree
     @@product_properties_attributes = [:property_name, :value, :position]
 
     @@product_attributes = [
-      :name, :description, :available_on, :permalink, :meta_description,
+      :name, :description, :available_on, :discontinue_on, :permalink, :meta_description,
       :meta_keywords, :price, :sku, :deleted_at, :prototype_id,
       :option_values_hash, :weight, :height, :width, :depth,
       :shipping_category_id, :tax_category_id,
@@ -102,7 +102,7 @@ module Spree
     @@user_attributes = [:email, :password, :password_confirmation]
 
     @@variant_attributes = [
-      :name, :presentation, :cost_price, :lock_version,
+      :name, :presentation, :cost_price, :discontinue_on, :lock_version,
       :position, :track_inventory,
       :product_id, :product, :option_values_attributes, :price,
       :weight, :height, :width, :depth, :sku, :cost_currency,

--- a/core/spec/models/spree/inventory_unit_spec.rb
+++ b/core/spec/models/spree/inventory_unit_spec.rb
@@ -102,23 +102,6 @@ describe Spree::InventoryUnit, :type => :model do
 
   end
 
-  context "variants deleted" do
-    let!(:unit) do
-      Spree::InventoryUnit.create(variant: stock_item.variant)
-    end
-
-    it "can still fetch variant" do
-      unit.variant.destroy
-      expect(unit.reload.variant).to be_a Spree::Variant
-    end
-
-    it "can still fetch variants by eager loading (remove default_scope)" do
-      skip "find a way to remove default scope when eager loading associations"
-      unit.variant.destroy
-      expect(Spree::InventoryUnit.joins(:variant).includes(:variant).first.variant).to be_a Spree::Variant
-    end
-  end
-
   context "#finalize_units!" do
     let!(:stock_location) { create(:stock_location) }
     let(:variant) { create(:variant) }

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -13,17 +13,19 @@ describe Spree::LineItem, type: :model do
     end
   end
 
-  context '#destroy' do
-    it "fetches deleted products" do
-      line_item.product.destroy
+  context "#discontinued" do
+    it "fetches discontinued products" do
+      line_item.product.discontinue!
       expect(line_item.reload.product).to be_a Spree::Product
     end
 
-    it "fetches deleted variants" do
-      line_item.variant.destroy
+    it "fetches discontinued variants" do
+      line_item.variant.discontinue!
       expect(line_item.reload.variant).to be_a Spree::Variant
     end
+  end
 
+  context "#destroy" do
     it "returns inventory when a line item is destroyed" do
       expect_any_instance_of(Spree::OrderInventory).to receive(:verify)
       line_item.destroy

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -550,7 +550,7 @@ describe Spree::Order, :type => :model do
     it "does not attempt to process payments" do
       allow(order).to receive_message_chain(:line_items, :present?) { true }
       allow(order).to receive(:ensure_line_items_are_in_stock) { true }
-      allow(order).to receive(:ensure_line_item_variants_are_not_deleted) { true }
+      allow(order).to receive(:ensure_line_item_variants_are_not_discontinued) { true }
       expect(order).not_to receive(:payment_required?)
       expect(order).not_to receive(:process_payments!)
       order.next!

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -203,15 +203,15 @@ describe Spree::Order, :type => :model do
     end
   end
 
-  describe '#ensure_line_item_variants_are_not_deleted' do
-    subject { order.ensure_line_item_variants_are_not_deleted }
+  describe "#ensure_line_item_variants_are_not_discontinued" do
+    subject { order.ensure_line_item_variants_are_not_discontinued }
 
     let(:order) { create :order_with_line_items }
 
     context 'when variant is destroyed' do
       before do
         allow(order).to receive(:restart_checkout_flow)
-        order.line_items.first.variant.destroy
+        order.line_items.first.variant.discontinue!
       end
 
       it 'should restart checkout flow' do

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -487,4 +487,26 @@ describe Spree::Product, :type => :model do
     product = Spree::Product.new
     expect(product.master.is_master).to be true
   end
+
+  context "#discontinue!" do
+    let(:product) { create(:product, sku: 'a-sku') }
+
+    it "sets the discontinued" do
+      product.discontinue!
+      product.reload
+      expect(product.discontinued?).to be(true)
+    end
+  end
+
+  context "#discontinued?" do
+    let(:product_live) { build(:product, sku: "a-sku") }
+    it "should be false" do
+      expect(product_live.discontinued?).to be(false)
+    end
+
+    let(:product_discontinued) { build(:product, sku: "a-sku", discontinue_on: Time.now - 1.day)  }
+    it "should be true" do
+      expect(product_discontinued.discontinued?).to be(true)
+    end
+  end
 end

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -520,4 +520,26 @@ describe Spree::Variant, :type => :model do
       expect(variant.dimension).to eq (dimension_expected)
     end
   end
+
+  context "#discontinue!" do
+    let(:variant) { create(:variant) }
+
+    it "sets the discontinued" do
+      variant.discontinue!
+      variant.reload
+      expect(variant.discontinued?).to be(true)
+    end
+  end
+
+  context "#discontinued?" do
+    let(:variant_live) { build(:variant) }
+    it "should be false" do
+      expect(variant_live.discontinued?).to be(false)
+    end
+
+    let(:variant_discontinued) { build(:variant, discontinue_on: Time.now - 1.day) }
+    it "should be true" do
+      expect(variant_discontinued.discontinued?).to be(true)
+    end
+  end
 end

--- a/guides/content/release_notes/3_1_0.md
+++ b/guides/content/release_notes/3_1_0.md
@@ -29,7 +29,7 @@ For more information, see the [taxation guide](https://guides.spreecommerce.com/
 Spree Alert model has been removed, and will no longer ping alerts.spreecommerce.com
 to check for notifications.
 
-### Future Discontinue of Products & Vairiants
+### Future Discontinue of Products & Variants
 Soft deleting means that the records are left in the database but behave as if they are really deleted. Because associations from other objects (like line itmes to variant) won't normally see the deleted, core code is forced (unnaturally) to use scopes like ```.with_deleted```
 
 We are fixing this by adding new feilds 'Discontinue On' to products & variants (discontinue_on)

--- a/guides/content/release_notes/3_1_0.md
+++ b/guides/content/release_notes/3_1_0.md
@@ -29,6 +29,27 @@ For more information, see the [taxation guide](https://guides.spreecommerce.com/
 Spree Alert model has been removed, and will no longer ping alerts.spreecommerce.com
 to check for notifications.
 
+### Future Discontinue of Products & Vairiants
+Soft deleting means that the records are left in the database but behave as if they are really deleted. Because associations from other objects (like line itmes to variant) won't normally see the deleted, core code is forced (unnaturally) to use scopes like ```.with_deleted```
+
+We are fixing this by adding new feilds 'Discontinue On' to products & variants (discontinue_on)
+                                                        
+This fixes a design flaw in that in most stores these objects really should not be considered "deleted."  The approach proposed solves the underlying flaw and all the related bugs caused by this flaw in the following ways:
+
+- Migrate the timestamps deleted_at to discontinue_on (when possible), and un-delete the deleted variants (when there is not matching SKU) and products (when there is no matching slug)
+
+- Redefine scopes Products object (see active, not_discontinued, etc)
+
+- Removes all references to unscope association chains from other objects to the Product & Variant objects in places where unscope is used explicitly to work-around the default scope problem. (This is a big win because it makes the associations cleaner and easier to work with.)
+
+- Although it is slightly counter-intuitive, we have left the deleted_at fields in place (although their data will be moved to discontinued_at field and their values will be reset to NULL in the db migration). You can (and should!) use deleting to remove human-error mistakes (real mistakes) before the items get sold in your store, or in the case when you have duplicate slugs (Products) or SKUs (Variants) in your database. In those special cases only, you should continue to use delete. In all other cases, use the new discontinue_on feature.
+
+- You can only delete a Product or Variant if no orders have been placed for that product/variant. Once the variant is associated with a Line item, it can never be "deleted," and instead you must use the new discontinue_on feature. Model-level checks (before_destroy) enforce this.
+
+- Note: The DB migration should fix your database correctly unless you have created new Products & Variants with matching slugs/SKUs of deleted records. In this case, you must use the included rake db:fix_orphan_line_items task to clean up your records. Both the schema migration and the script are very pro-active in helping you fix your own database.
+
+
+
 ## Upgrade
 
 ### Update Gemfile & Run Migrations


### PR DESCRIPTION
Spree's current implementation uses act_as_paranoid to implement a ActiveRecord-wide "soft-delete" of Products and Variants. Unfortunately, soft deleting means that the records are left in the database but behave as if they are really deleted.

Because associations from other objects (like line itmes to variant) won't normally see the deleted, core code is forced (unnaturally) to use scopes .with_deleted 

https://github.com/spree/spree/blob/master/core/app/models/spree/product.rb#L224

Not only does this abstract magic get in the way of acts_as_paranoid's true intention, but  in a worse example, it becomes necessary to overload an AR belongs_to with a magic method.

https://github.com/spree/spree/blob/master/core/app/models/spree/line_item.rb#L106

This hack above solves the problem that when looking at a past order with line items attached to deleted variants you can't load the variants because the objects appear to be missing in Active Record.

The design flaw here is that these objects really should not be considered "deleted." The word is wrong, the concept is wrong, and the implementation bends over backwards to accomodate the flawed design. 

The approach proposed solves the underlying flaw _and all the related bugs cuased by this flaw_ in the following ways:
- [x] Adds a field discontinue_on to Products and Variants. 
- [x] Migrate the timestamps deleted_at to discontinue_on (when possible), and un-delete the deleted variants (when there is not matching SKU) and products (when there is no matching slug)
- [x] Redefine the available scope on the Products object as so. Notice that the not_discontinued scope is added to the end of whatever scope chain is here. This is necessary because we no longer have the default_scope weeding out discontinued products:
  
  ```
    add_search_scope :not_discontinued do
      where("#{Product.quoted_table_name}.discontinue_on IS NULL or #{Product.quoted_table_name}.discontinue_on >= ?", Time.zone.now)
    end
    search_scopes << :not_discontinued
  
    # Can't use add_search_scope for this as it needs a default argument
    def self.available(available_on = nil, currency = nil)
      not_discontinued.joins(:master => :prices).where("#{Product.quoted_table_name}.available_on <= ?", available_on || Time.now)
    end
    search_scopes << :available
  
    def self.active(currency = nil)
      not_discontinued.available(nil, currency)
    end
  ```
- [x] Add a `not_discontinued` scope on the Variant object:
  
  ```
    scope :not_discontinued, -> { where("#{Variant.quoted_table_name}.discontinue_on IS NULL OR #{Variant.quoted_table_name}.discontinue_on <= ?",  Time.now) }
  ```

(the active class method has been changed to include this scope)
- [x] Removes all references to unscope association chains from other objects to the Product & Variant objects in places where unscope is used explicitly to work-around the default scope problem. (This is a big win because it makes the associations cleaner and easier to work with.)
- [x] Finally, although it is slightly counter-intuitive, I have actually left the deleted_at fields in place (although their data will be moved to discontinued_at field and their values will be reset to NULL in the db migration). You can (and should!) use deleting to remove human-error mistakes (real mistakes) before the items get sold in your store, or in the case when you have duplicate slugs (Products) or SKUs (Variants) in your database. In those special cases only, you should continue to use delete. In all other cases, use the new discontinue_on feature. 
- [x] You can only delete a Product or Variant if no orders have been placed for that product/variant. Once the variant is associated with a Line item, it can never be "deleted," and instead you must use the new discontinue_on feature. Model-level checks (`before_destroy`) enforce this.
- [x] Note: The DB migration should fix your database correctly unless you have created new Products & Variants with matching slugs/SKUs of deleted records. In this case, you must use the included `rake db:fix_orphan_line_items` task to clean up your records. Both the schema migration and the script are very pro-active in helping you fix your own database. 
- [x] Not only do we fix _all_ product & variant `undefined method XYZ for nil` bugs (and all the bugs yet-to-be-created), but we also get a new feature: You can now schedule a product or variant to be discontinued in the future. Neato!
- [x] The Admin interface now shows a distinction between discontinued & deleted, as well as options for searching for discontinued products. 
- [x] update Spree's release notes https://github.com/spree/spree/blob/master/guides/content/release_notes/3_1_0.md
- [x] When I delete a Product or Variant that has associated line items, fail gracefully in admin
