### PR TITLE
Solve exception caused if search param is blank ('&search=')

### DIFF
--- a/core/lib/spree/core/search/base.rb
+++ b/core/lib/spree/core/search/base.rb
@@ -70,7 +70,7 @@ module Spree
               else
                 base_scope = base_scope.merge(Spree::Product.ransack({scope_name => scope_attribute}).result)
               end
-            end if search
+            end if search.is_a?(Hash)
             base_scope
           end
 

--- a/frontend/app/views/spree/shared/_filters.html.erb
+++ b/frontend/app/views/spree/shared/_filters.html.erb
@@ -16,7 +16,7 @@
                      id="<%= label %>"
                      name="search[<%= filter[:scope].to_s %>][]"
                      value="<%= val %>"
-                     <%= params[:search] && params[:search][filter[:scope]] && params[:search][filter[:scope]].include?(val.to_s) ? "checked" : "" %> />
+                     <%= params[:search].present? && params[:search][filter[:scope]] && params[:search][filter[:scope]].include?(val.to_s) ? "checked" : "" %> />
               <label class="nowrap" for="<%= label %>"> <%= nm %> </label>
             </li>
           <% end %>


### PR DESCRIPTION
Hi all,

while working on product filters, found that if the 'search' param is blank (`&search=`), it causes an exception as it is parsed as a string and Spree::Core::Search::Base#add_search_scopes tries to run `.each` on it, causing the exception (`undefined method 'each' for "":String`).

I modified `core/lib/spree/core/search/base.rb#add_search_scopes` ([relevant code](https://github.com/spree/spree/blob/master/core/lib/spree/core/search/base.rb#L66-L73)) to only iterate if 'search' is a hash ([relevant code](https://github.com/Whelton/spree/blob/master/core/lib/spree/core/search/base.rb#L73)).

I also modified the filters partial `frontend/app/views/spree/shared/_filters.html.erb` to check if the 'search' param is present (`.present?` returns false if the value is an empty string, even if key is there), so as not to also cause an exception if 'search' param is blank.

Ran into it as I was adding hidden form fields to the searchbox to retain any filters. Found this exception causing issue on other live Spree stores.

Thank you.
