### PR TITLE
Make refreshing rates safer for the backend.

### DIFF
--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -63,7 +63,7 @@ module Spree
 
       def cart
         unless @order.completed?
-          @order.refresh_shipment_rates
+          @order.refresh_shipment_rates Spree::ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END
         end
         if @order.shipments.shipped.count > 0
           redirect_to edit_admin_order_url(@order)

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -51,11 +51,11 @@ module Spree
 
 
     # give each of the shipments a chance to update themselves
-    def update_shipments
+    def update_shipments shipping_method_filter = Spree::ShippingMethod::DISPLAY_ON_FRONT_END
       shipments.each do |shipment|
         next unless shipment.persisted?
         shipment.update!(order)
-        shipment.refresh_rates
+        shipment.refresh_rates shipping_method_filter
         shipment.update_amounts
       end
     end


### PR DESCRIPTION
If a shipping option is only available for the backend you can easily
loose that selection. Visiting the cart page on an incomplete order
results it is being lost since the rate refresh uses the default of
frontend only.

Also if you manaully trigger an shipping update it will be lost since
there is not an option to specify if backend options should be included.
This commit allows that option to be specified.
