### PR TITLE
Add correct scope for quantity not available translation

### DIFF
--- a/core/app/models/spree/stock/availability_validator.rb
+++ b/core/app/models/spree/stock/availability_validator.rb
@@ -17,6 +17,7 @@ module Spree
 
         line_item.errors[:quantity] << Spree.t(
           :selected_quantity_not_available,
+          scope: :order_populator,
           item: display_name.inspect
         )
       end


### PR DESCRIPTION
Looks like the scope had been removed at some point, resulting in a missing translation error.
