### PR TITLE
Allow non credit card payment sources

### DIFF
--- a/api/spec/controllers/spree/api/v1/checkouts_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/checkouts_controller_spec.rb
@@ -229,12 +229,23 @@ module Spree
         expect(cc_errors).to include("Verification Value can't be blank")
       end
 
-      it "allow users to reuse a credit card" do
+      it "allow users to reuse a credit card using the existing_card parameter" do
         order.update_column(:state, "payment")
         credit_card = create(:credit_card, user_id: order.user_id, payment_method_id: @payment_method.id)
 
         api_put :update, id: order.to_param, order_token: order.guest_token,
           order: { existing_card: credit_card.id }
+
+        expect(response.status).to eq 200
+        expect(order.credit_cards).to match_array [credit_card]
+      end
+
+      it "allow users to reuse a credit card using the existing_user_payment_source_id parameter" do
+        order.update_column(:state, "payment")
+        credit_card = create(:credit_card, user_id: order.user_id, payment_method_id: @payment_method.id)
+
+        api_put :update, id: order.to_param, order_token: order.guest_token,
+          order: { existing_user_payment_source_id: credit_card.user_payment_source.id }
 
         expect(response.status).to eq 200
         expect(order.credit_cards).to match_array [credit_card]

--- a/api/spec/controllers/spree/api/v1/checkouts_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/checkouts_controller_spec.rb
@@ -240,12 +240,12 @@ module Spree
         expect(order.credit_cards).to match_array [credit_card]
       end
 
-      it "allow users to reuse a credit card using the existing_user_payment_source_id parameter" do
+      it "allow users to reuse a credit card using the existing_payment_source parameter" do
         order.update_column(:state, "payment")
         credit_card = create(:credit_card, user_id: order.user_id, payment_method_id: @payment_method.id)
 
         api_put :update, id: order.to_param, order_token: order.guest_token,
-          order: { existing_user_payment_source_id: credit_card.user_payment_source.id }
+          order: { existing_payment_source: credit_card.user_payment_source.id }
 
         expect(response.status).to eq 200
         expect(order.credit_cards).to match_array [credit_card]

--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -3,7 +3,7 @@ module Spree
     extend ActiveSupport::Concern
 
     include Spree::UserApiAuthentication
-    include Spree::UserPaymentSource
+    include Spree::UserPaymentSourceAssociations
     include Spree::UserReporting
     include Spree::RansackableAttributes
 

--- a/core/app/models/concerns/spree/user_payment_source_associations.rb
+++ b/core/app/models/concerns/spree/user_payment_source_associations.rb
@@ -3,7 +3,7 @@ module Spree
     extend ActiveSupport::Concern
 
     included do
-      has_many :user_payment_sources, foreign_key: "user_id"
+      has_many :user_payment_sources, foreign_key: "user_id", class_name: "Spree::UserPaymentSource"
       has_many :credit_cards,
                through: :user_payment_sources,
                source: :payment_source,

--- a/core/app/models/concerns/spree/user_payment_source_associations.rb
+++ b/core/app/models/concerns/spree/user_payment_source_associations.rb
@@ -9,7 +9,9 @@ module Spree
                source: :payment_source,
                source_type: 'Spree::CreditCard'
 
-      def default_credit_card; credit_cards.default.first; end
+      def default_payment_source
+        user_payment_sources.default.first.try(:payment_source)
+      end
 
       def payment_sources
         credit_cards.with_payment_profile

--- a/core/app/models/concerns/spree/user_payment_source_associations.rb
+++ b/core/app/models/concerns/spree/user_payment_source_associations.rb
@@ -1,9 +1,14 @@
 module Spree
-  module UserPaymentSource
+  module UserPaymentSourceAssociations
     extend ActiveSupport::Concern
 
     included do
-      has_many :credit_cards, class_name: "Spree::CreditCard", foreign_key: :user_id
+      has_many :user_payment_sources, foreign_key: "user_id"
+      has_many :credit_cards,
+               through: :user_payment_sources,
+               source: :payment_source,
+               source_type: 'Spree::CreditCard'
+
       def default_credit_card; credit_cards.default.first; end
 
       def payment_sources

--- a/core/app/models/spree/ability.rb
+++ b/core/app/models/spree/ability.rb
@@ -46,7 +46,7 @@ module Spree
         can [:read, :update], Order do |order, token|
           order.user == user || order.guest_token && token == order.guest_token
         end
-        can :display, CreditCard, user_id: user.id
+        can :display, CreditCard, user_payment_source: { user_id: user.id }
         can :display, Product
         can :display, ProductProperty
         can :display, Property

--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -1,7 +1,6 @@
 module Spree
   class CreditCard < Spree::PaymentSource
     before_save :set_last_digits
-    after_save :ensure_one_default
 
     # As of rails 4.2 string columns always return strings, we can override it on model level.
     attribute :month, Type::Integer.new
@@ -16,8 +15,6 @@ module Spree
       validates :number, :verification_value, presence: true, unless: :imported
       validates :name, presence: true
     end
-
-    scope :default, -> { where(default: true) }
 
     # needed for some of the ActiveMerchant gateways (eg. SagePay)
     alias_attribute :brand, :cc_type
@@ -110,13 +107,6 @@ module Spree
 
     def require_card_numbers?
       !self.encrypted_data.present? && !self.has_payment_profile?
-    end
-
-    def ensure_one_default
-      if self.user_id && self.default
-        CreditCard.where(default: true, user_id: self.user_id).where.not(id: self.id)
-          .update_all(default: false)
-      end
     end
   end
 end

--- a/core/app/models/spree/gateway.rb
+++ b/core/app/models/spree/gateway.rb
@@ -14,7 +14,7 @@ module Spree
     end
 
     def payment_sources
-      payment_source_class.where(payment_method_id: self.id)
+      payment_source_class.where(payment_method_id: id)
     end
 
     # instantiates the selected gateway and configures with the options stored in the database
@@ -89,9 +89,9 @@ module Spree
     private
 
     def sources_by_user_id(user_id)
-      self.payment_sources.
+      payment_sources.
         joins(:user_payment_source).
-        where(spree_user_payment_sources: {user_id: user_id}).
+        where(spree_user_payment_sources: { user_id: user_id }).
         with_payment_profile
     end
   end

--- a/core/app/models/spree/legacy_user.rb
+++ b/core/app/models/spree/legacy_user.rb
@@ -2,7 +2,7 @@
 module Spree
   class LegacyUser < Spree::Base
     include UserAddress
-    include UserPaymentSource
+    include UserPaymentSourceAssociations
     include UserMethods
 
     self.table_name = 'spree_users'

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -54,7 +54,8 @@ module Spree
     self.whitelisted_ransackable_attributes =  %w[completed_at created_at email number state payment_state shipment_state total considered_risky]
 
     attr_reader :coupon_code
-    attr_accessor :temporary_address, :temporary_credit_card
+    attr_accessor :temporary_address, :temporary_payment_source
+    alias_attribute :temporary_credit_card, :temporary_payment_source
 
     if Spree.user_class
       belongs_to :user, class_name: Spree.user_class.to_s
@@ -362,6 +363,14 @@ module Spree
     def valid_credit_cards
       credit_card_ids = payments.from_credit_card.valid.pluck(:source_id).uniq
       CreditCard.where(id: credit_card_ids)
+    end
+
+    def payment_sources
+      payments.with_payment_source.map(&:source).uniq
+    end
+
+    def valid_payment_sources
+      payments.with_payment_source.valid.map(&:source).uniq
     end
 
     # Finalizes an in progress order after checkout is complete.

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -227,16 +227,14 @@ module Spree
               # Set existing payment source after setting permitted parameters because
               # rails would slice parameters containg ruby objects, apparently
               existing_user_payment_source_id = if @updating_params[:order]
-                @updating_params[:order].delete(:existing_user_payment_source_id)
-              else
-                nil
-              end
+                                                  @updating_params[:order].delete(:existing_user_payment_source_id)
+                                                end
 
               attributes = if @updating_params[:order]
-                @updating_params[:order].permit(permitted_params).delete_if { |_k, v| v.nil? }
-              else
-                {}
-              end
+                             @updating_params[:order].permit(permitted_params).delete_if { |_k, v| v.nil? }
+                           else
+                             {}
+                           end
 
               if existing_user_payment_source_id.present?
                 payment_source = UserPaymentSource.find(existing_user_payment_source_id).payment_source

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -309,7 +309,7 @@ module Spree
           #
           #   {
           #     "order": {
-          #       "existing_credit_card": "2"
+          #       "existing_card": "2"
           #     }
           #   }
           #

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -43,6 +43,7 @@ module Spree
     default_scope { order(:created_at) }
 
     scope :from_credit_card, -> { where(source_type: 'Spree::CreditCard') }
+    scope :with_payment_source, -> { where.not(source_type: 'Spree::Payment') }
     scope :with_state, ->(s) { where(state: s.to_s) }
     # "offset" is reserved by activerecord
     scope :offset_payment, -> { where("source_type = 'Spree::Payment' AND amount < 0 AND state = 'completed'") }

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -135,7 +135,7 @@ module Spree
       if source_attributes.present? && source.blank? && payment_method.try(:payment_source_class)
         self.source = payment_method.payment_source_class.new(source_attributes)
         self.source.payment_method_id = payment_method.id
-        self.source.user_id = self.order.user_id if self.order
+        self.source.user = self.order.user if self.order
       end
     end
 

--- a/core/app/models/spree/payment_source.rb
+++ b/core/app/models/spree/payment_source.rb
@@ -1,0 +1,58 @@
+module Spree
+  class PaymentSource < Spree::Base
+    self.abstract_class = true
+
+    belongs_to :payment_method
+
+    # Refactor me to polymorphic association
+    belongs_to :user, class_name: Spree.user_class, foreign_key: 'user_id'
+    has_many :payments, as: :source
+
+    # TODO This has to go into the UserPaymentSource class
+    # after_save :ensure_one_default
+
+    attr_accessor :imported
+
+    scope :with_payment_profile, -> { where('gateway_customer_profile_id IS NOT NULL') }
+    scope :default, -> { where(default: true) }
+
+    def display_number
+      raise NotImplementedError, "Please implement '#{display_number})' in your Payment Source: #{self.class.name}"
+    end
+
+    def actions
+      %w{capture void credit}
+    end
+
+    # Indicates whether its possible to capture the payment
+    def can_capture?(payment)
+      payment.pending? || payment.checkout?
+    end
+
+    # Indicates whether its possible to void the payment.
+    def can_void?(payment)
+      !payment.failed? && !payment.void?
+    end
+
+    # Indicates whether its possible to credit the payment.  Note that most gateways require that the
+    # payment be settled first which generally happens within 12-24 hours of the transaction.
+    def can_credit?(payment)
+      payment.completed? && payment.credit_allowed > 0
+    end
+
+    def has_payment_profile?
+      gateway_customer_profile_id.present?
+    end
+
+    # ActiveMerchant needs first_name/last_name because we pass it a Spree::CreditCard and it calls those methods on it.
+    # Looking at the ActiveMerchant source code we should probably be calling #to_active_merchant before passing
+    # the object to ActiveMerchant but this should do for now.
+    def first_name
+      name.to_s.split(/[[:space:]]/, 2)[0]
+    end
+
+    def last_name
+      name.to_s.split(/[[:space:]]/, 2)[1]
+    end
+  end
+end

--- a/core/app/models/spree/user_payment_source.rb
+++ b/core/app/models/spree/user_payment_source.rb
@@ -1,0 +1,18 @@
+module Spree
+  class UserPaymentSource < ActiveRecord::Base
+    after_save :ensure_one_default
+
+    belongs_to :user, class_name: Spree.user_class, foreign_key: 'user_id'
+    belongs_to :payment_source, polymorphic: true
+
+    private
+
+    def ensure_one_default
+      if self.user_id && self.default
+        self.class.where(default: true).where.not(id: self.id).where(user_id: self.user_id).each do |ucc|
+          ucc.update_columns(default: false)
+        end
+      end
+    end
+  end
+end

--- a/core/app/models/spree/user_payment_source.rb
+++ b/core/app/models/spree/user_payment_source.rb
@@ -5,11 +5,13 @@ module Spree
     belongs_to :user, class_name: Spree.user_class, foreign_key: 'user_id'
     belongs_to :payment_source, polymorphic: true
 
+    scope :default, -> { where(default: true) }
+
     private
 
     def ensure_one_default
       if self.user_id && self.default
-        self.class.where(default: true).where.not(id: self.id).where(user_id: self.user_id).each do |ucc|
+        self.class.default.where.not(id: self.id).where(user_id: self.user_id).each do |ucc|
           ucc.update_columns(default: false)
         end
       end

--- a/core/db/migrate/20151013111930_create_spree_user_payment_sources.rb
+++ b/core/db/migrate/20151013111930_create_spree_user_payment_sources.rb
@@ -2,7 +2,9 @@ class CreateSpreeUserPaymentSources < ActiveRecord::Migration
   def change
     create_table :spree_user_payment_sources do |t|
       t.references :user, index: true, foreign_key: false
-      t.references :payment_source, polymorphic: true, index: {name: "index_users_payment_sources"}
+      t.references :payment_source,
+                   polymorphic: true,
+                   index: { name: "index_users_payment_sources" }
       t.boolean :default
 
       t.timestamps null: false

--- a/core/db/migrate/20151013111930_create_spree_user_payment_sources.rb
+++ b/core/db/migrate/20151013111930_create_spree_user_payment_sources.rb
@@ -9,5 +9,13 @@ class CreateSpreeUserPaymentSources < ActiveRecord::Migration
 
       t.timestamps null: false
     end
+
+    Spree::CreditCard.find_each do |credit_card|
+      Spree::UserPaymentSource.create(
+        user_id: credit_card.user_id,
+        payment_source_id: credit_card.id,
+        payment_source_class: "Spree::CreditCard"
+      )
+    end
   end
 end

--- a/core/db/migrate/20151013111930_create_spree_user_payment_sources.rb
+++ b/core/db/migrate/20151013111930_create_spree_user_payment_sources.rb
@@ -1,0 +1,11 @@
+class CreateSpreeUserPaymentSources < ActiveRecord::Migration
+  def change
+    create_table :spree_user_payment_sources do |t|
+      t.references :user, index: true, foreign_key: true
+      t.references :payment_source, polymorphic: true, index: {name: "index_users_payment_sources"}
+      t.boolean :default
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/core/db/migrate/20151013111930_create_spree_user_payment_sources.rb
+++ b/core/db/migrate/20151013111930_create_spree_user_payment_sources.rb
@@ -1,7 +1,7 @@
 class CreateSpreeUserPaymentSources < ActiveRecord::Migration
   def change
     create_table :spree_user_payment_sources do |t|
-      t.references :user, index: true, foreign_key: true
+      t.references :user, index: true, foreign_key: false
       t.references :payment_source, polymorphic: true, index: {name: "index_users_payment_sources"}
       t.boolean :default
 

--- a/core/db/migrate/20151013114643_remove_default_and_user_id_from_credit_cards.rb
+++ b/core/db/migrate/20151013114643_remove_default_and_user_id_from_credit_cards.rb
@@ -1,0 +1,6 @@
+class RemoveDefaultAndUserIdFromCreditCards < ActiveRecord::Migration
+  def change
+    remove_column :spree_credit_cards, :default, :boolean
+    remove_column :spree_credit_cards, :user_id, :integer
+  end
+end

--- a/core/lib/spree/testing_support/factories/credit_card_factory.rb
+++ b/core/lib/spree/testing_support/factories/credit_card_factory.rb
@@ -1,10 +1,23 @@
 FactoryGirl.define do
   factory :credit_card, class: Spree::CreditCard do
+    transient do
+      user nil
+      user_id nil
+      default false
+    end
+
     verification_value 123
     month 12
     year { 1.year.from_now.year }
     number '4111111111111111'
     name 'Spree Commerce'
     association(:payment_method, factory: :credit_card_payment_method)
+
+    after(:build) do |credit_card, evaluator|
+      credit_card.create_user_payment_source(
+        user_id: evaluator.user_id || evaluator.user.try(:id),
+        default: evaluator.default
+      )
+    end
   end
 end

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -16,6 +16,8 @@ describe Spree::CreditCard, type: :model do
 
   let(:credit_card) { Spree::CreditCard.new }
 
+  it_behaves_like 'a payment source'
+
   before(:each) do
 
     @order = create(:order)
@@ -38,37 +40,6 @@ describe Spree::CreditCard, type: :model do
 
   it 'should respond to track_data' do
     expect(credit_card.respond_to?(:track_data)).to be true
-  end
-
-  context "#can_capture?" do
-    it "should be true if payment is pending" do
-      payment = mock_model(Spree::Payment, pending?: true, created_at: Time.current)
-      expect(credit_card.can_capture?(payment)).to be true
-    end
-
-    it "should be true if payment is checkout" do
-      payment = mock_model(Spree::Payment, pending?: false, checkout?: true, created_at: Time.current)
-      expect(credit_card.can_capture?(payment)).to be true
-    end
-  end
-
-  context "#can_void?" do
-    it "should be true if payment is not void" do
-      payment = mock_model(Spree::Payment, failed?: false, void?: false)
-      expect(credit_card.can_void?(payment)).to be true
-    end
-  end
-
-  context "#can_credit?" do
-    it "should be false if payment is not completed" do
-      payment = mock_model(Spree::Payment, completed?: false)
-      expect(credit_card.can_credit?(payment)).to be false
-    end
-
-    it "should be false when credit_allowed is zero" do
-      payment = mock_model(Spree::Payment, completed?: true, credit_allowed: 0, order: mock_model(Spree::Order, payment_state: 'credit_owed'))
-      expect(credit_card.can_credit?(payment)).to be false
-    end
   end
 
   context "#valid?" do
@@ -241,12 +212,6 @@ describe Spree::CreditCard, type: :model do
       credit_card.number = nil
       credit_card.cc_type = ''
       expect(credit_card.cc_type).to eq('')
-    end
-  end
-
-  context "#associations" do
-    it "should be able to access its payments" do
-      expect { credit_card.payments.to_a }.not_to raise_error
     end
   end
 

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -215,26 +215,6 @@ describe Spree::CreditCard, type: :model do
     end
   end
 
-  context "#first_name" do
-    before do
-      credit_card.name = "Ludwig van Beethoven"
-    end
-
-    it "extracts the first name" do
-      expect(credit_card.first_name).to eq "Ludwig"
-    end
-  end
-
-  context "#last_name" do
-    before do
-      credit_card.name = "Ludwig van Beethoven"
-    end
-
-    it "extracts the last name" do
-      expect(credit_card.last_name).to eq "van Beethoven"
-    end
-  end
-
   context "#to_active_merchant" do
     before do
       credit_card.number = "4111111111111111"

--- a/core/spec/models/spree/gateway_spec.rb
+++ b/core/spec/models/spree/gateway_spec.rb
@@ -44,7 +44,7 @@ describe Spree::Gateway, :type => :model do
     end
 
     it "finds credit cards associated with the order user" do
-      cc.update_column :user_id, 1
+      cc.user_payment_source.update_column :user_id, 1
       allow(payment.order).to receive_messages completed?: false
 
       expect(no_card.reusable_sources(payment.order)).to be_empty

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -753,9 +753,9 @@ describe Spree::Order, :type => :model do
           end
 
           it 'does not attempt to permit existing_card' do
-            expect {
+            expect do
               order.update_from_params(params, permitted_params)
-            }.not_to raise_error
+            end.not_to raise_error
           end
         end
 
@@ -770,12 +770,11 @@ describe Spree::Order, :type => :model do
           end
 
           it 'does not attempt to permit existing_payment_source' do
-            expect {
+            expect do
               order.update_from_params(params, permitted_params)
-            }.not_to raise_error
+            end.not_to raise_error
           end
         end
-
       end
 
       context 'has allowed params' do

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -670,7 +670,7 @@ describe Spree::Order, :type => :model do
         ActionController::Parameters.new(
           order: {
             payments_attributes: [{ payment_method_id: 1 }],
-            existing_user_payment_source_id: credit_card.user_payment_source.id
+            existing_payment_source: credit_card.user_payment_source.id
           },
           cvc_confirm: "737",
           payment_source: {
@@ -686,7 +686,7 @@ describe Spree::Order, :type => :model do
       before { order.user = FactoryGirl.create(:user) }
 
       it "sets confirmation value when its available via :cvc_confirm" do
-        allow(Spree::UserPaymentSource).to receive_message_chain(:find, :payment_source).and_return(credit_card)
+        allow(Spree::UserPaymentSource).to receive_message_chain(:find_by, :payment_source).and_return(credit_card)
         expect(credit_card).to receive(:verification_value=)
         order.update_from_params(params, permitted_params)
       end
@@ -726,32 +726,56 @@ describe Spree::Order, :type => :model do
         order.update_from_params(params, permitted_params)
       end
 
-      context 'has existing_card param' do
+      context 'has existing_card or existing_payment_source param' do
         let(:permitted_params) do
           Spree::PermittedAttributes.checkout_attributes +
             [payments_attributes: Spree::PermittedAttributes.payment_attributes]
         end
         let(:credit_card) { create(:credit_card, user_id: order.user_id) }
-        let(:params) do
-          ActionController::Parameters.new(
-            order: { payments_attributes: [{payment_method_id: 1}], existing_card: credit_card.id }
-          )
-        end
 
         before do
           Dummy::Application.config.action_controller.action_on_unpermitted_parameters = :raise
-          order.user_id = 3
+          order.user = FactoryGirl.create(:user)
         end
 
         after do
           Dummy::Application.config.action_controller.action_on_unpermitted_parameters = :log
         end
 
-        it 'does not attempt to permit existing_card' do
-          expect {
-            order.update_from_params(params, permitted_params)
-          }.not_to raise_error
+        context "with an existing_card parameter" do
+          let(:params) do
+            ActionController::Parameters.new(
+              order: {
+                payments_attributes: [{ payment_method_id: 1 }],
+                existing_card: credit_card.id
+              }
+            )
+          end
+
+          it 'does not attempt to permit existing_card' do
+            expect {
+              order.update_from_params(params, permitted_params)
+            }.not_to raise_error
+          end
         end
+
+        context "with an existing_payment_source parameter" do
+          let(:params) do
+            ActionController::Parameters.new(
+              order: {
+                payments_attributes: [{ payment_method_id: 1 }],
+                existing_payment_source: credit_card.user_payment_source.id
+              }
+            )
+          end
+
+          it 'does not attempt to permit existing_payment_source' do
+            expect {
+              order.update_from_params(params, permitted_params)
+            }.not_to raise_error
+          end
+        end
+
       end
 
       context 'has allowed params' do

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -489,13 +489,13 @@ describe Spree::Order, :type => :model do
       it "makes the current credit card a user's default credit card" do
         order.next!
         expect(order.state).to eq 'complete'
-        expect(order.user.reload.default_credit_card.try(:id)).to eq(order.credit_cards.first.id)
+        expect(order.user.reload.default_payment_source.try(:id)).to eq(order.payment_sources.first.id)
       end
 
       it "does not assign a default credit card if temporary_credit_card is set" do
         order.temporary_credit_card = true
         order.next!
-        expect(order.user.reload.default_credit_card).to be_nil
+        expect(order.user.reload.default_payment_source).to be_nil
       end
     end
   end

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -668,7 +668,10 @@ describe Spree::Order, :type => :model do
 
       let(:params) do
         ActionController::Parameters.new(
-          order: { payments_attributes: [{payment_method_id: 1}], existing_user_payment_source_id: credit_card.user_payment_source.id },
+          order: {
+            payments_attributes: [{ payment_method_id: 1 }],
+            existing_user_payment_source_id: credit_card.user_payment_source.id
+          },
           cvc_confirm: "737",
           payment_source: {
             "1" => { name: "Luis Braga",

--- a/core/spec/models/spree/payment_source_spec.rb
+++ b/core/spec/models/spree/payment_source_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe Spree::PaymentSource, type: :model do
+  it 'is an abstract class' do
+    expect do
+      described_class.new
+    end.to raise_error(NotImplementedError)
+  end
+end

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -578,7 +578,6 @@ describe Spree::Payment, :type => :model do
         let(:attributes) { attributes_for(:credit_card) }
         it "should not try to create profiles on old failed payment attempts" do
           allow_any_instance_of(Spree::Payment).to receive(:payment_method) { gateway }
-
           order.payments.create!(
             source_attributes: attributes,
             payment_method: gateway,
@@ -647,7 +646,7 @@ describe Spree::Payment, :type => :model do
       order = create(:order)
       source = order.payments.new(params).source
 
-      expect(source.user_id).to eq order.user_id
+      expect(source.user).to eq order.user
       expect(source.payment_method_id).to eq gateway.id
     end
 

--- a/core/spec/support/concerns/payment_source.rb
+++ b/core/spec/support/concerns/payment_source.rb
@@ -13,35 +13,35 @@ RSpec.shared_examples "a payment source" do
 
   context "#can_capture?" do
     it "should be true if payment is pending" do
-      payment = mock_model(Spree::Payment, pending?: true, created_at: Time.current)
+      payment = instance_double(Spree::Payment, pending?: true, created_at: Time.current)
       expect(payment_source.can_capture?(payment)).to be true
     end
 
     it "should be true if payment is checkout" do
-      payment = mock_model(Spree::Payment, pending?: false, checkout?: true, created_at: Time.current)
+      payment = instance_double(Spree::Payment, pending?: false, checkout?: true, created_at: Time.current)
       expect(payment_source.can_capture?(payment)).to be true
     end
   end
 
   context "#can_void?" do
     it "should be true if payment is not void" do
-      payment = mock_model(Spree::Payment, failed?: false, void?: false)
+      payment = instance_double(Spree::Payment, failed?: false, void?: false)
       expect(payment_source.can_void?(payment)).to be true
     end
   end
 
   context "#can_credit?" do
     it "should be false if payment is not completed" do
-      payment = mock_model(Spree::Payment, completed?: false)
+      payment = instance_double(Spree::Payment, completed?: false)
       expect(payment_source.can_credit?(payment)).to be false
     end
 
     it "should be false when credit_allowed is zero" do
-      payment = mock_model(
+      payment = instance_double(
         Spree::Payment,
         completed?: true,
         credit_allowed: 0,
-        order: mock_model(Spree::Order, payment_state: 'credit_owed')
+        order: instance_double(Spree::Order, payment_state: 'credit_owed')
       )
       expect(payment_source.can_credit?(payment)).to be false
     end
@@ -49,21 +49,21 @@ RSpec.shared_examples "a payment source" do
 
   context "#first_name" do
     before do
-      credit_card.name = "Ludwig van Beethoven"
+      payment_source.name = "Ludwig van Beethoven"
     end
 
     it "extracts the first name" do
-      expect(credit_card.first_name).to eq "Ludwig"
+      expect(payment_source.first_name).to eq "Ludwig"
     end
   end
 
   context "#last_name" do
     before do
-      credit_card.name = "Ludwig van Beethoven"
+      payment_source.name = "Ludwig van Beethoven"
     end
 
     it "extracts the last name" do
-      expect(credit_card.last_name).to eq "van Beethoven"
+      expect(payment_source.last_name).to eq "van Beethoven"
     end
   end
 end

--- a/core/spec/support/concerns/payment_source.rb
+++ b/core/spec/support/concerns/payment_source.rb
@@ -38,11 +38,11 @@ RSpec.shared_examples "a payment source" do
 
     it "should be false when credit_allowed is zero" do
       payment = mock_model(
-                  Spree::Payment,
-                  completed?: true,
-                  credit_allowed: 0,
-                  order: mock_model(Spree::Order, payment_state: 'credit_owed')
-                )
+        Spree::Payment,
+        completed?: true,
+        credit_allowed: 0,
+        order: mock_model(Spree::Order, payment_state: 'credit_owed')
+      )
       expect(payment_source.can_credit?(payment)).to be false
     end
   end

--- a/core/spec/support/concerns/payment_source.rb
+++ b/core/spec/support/concerns/payment_source.rb
@@ -1,12 +1,14 @@
 RSpec.shared_examples "a payment source" do
-  let(:payment_source) { described_class.new }
+  subject(:payment_source) { described_class.new }
 
-  describe '#name' do
-    it 'has to be implemented' do
-      expect do
-        payment_source.name
-      end.not_to raise_error
-    end
+  describe 'attributes' do
+    it { is_expected.to respond_to(:imported) }
+    it { is_expected.to respond_to(:name) }
+  end
+
+  context "#associations" do
+    it { is_expected.to respond_to(:payments) }
+    it { is_expected.to respond_to(:user) }
   end
 
   context "#can_capture?" do
@@ -40,9 +42,23 @@ RSpec.shared_examples "a payment source" do
     end
   end
 
-  context "#associations" do
-    it "should be able to access its payments" do
-      expect { credit_card.payments.to_a }.not_to raise_error
+  context "#first_name" do
+    before do
+      credit_card.name = "Ludwig van Beethoven"
+    end
+
+    it "extracts the first name" do
+      expect(credit_card.first_name).to eq "Ludwig"
+    end
+  end
+
+  context "#last_name" do
+    before do
+      credit_card.name = "Ludwig van Beethoven"
+    end
+
+    it "extracts the last name" do
+      expect(credit_card.last_name).to eq "van Beethoven"
     end
   end
 end

--- a/core/spec/support/concerns/payment_source.rb
+++ b/core/spec/support/concerns/payment_source.rb
@@ -1,0 +1,48 @@
+RSpec.shared_examples "a payment source" do
+  let(:payment_source) { described_class.new }
+
+  describe '#name' do
+    it 'has to be implemented' do
+      expect do
+        payment_source.name
+      end.not_to raise_error
+    end
+  end
+
+  context "#can_capture?" do
+    it "should be true if payment is pending" do
+      payment = mock_model(Spree::Payment, pending?: true, created_at: Time.current)
+      expect(payment_source.can_capture?(payment)).to be true
+    end
+
+    it "should be true if payment is checkout" do
+      payment = mock_model(Spree::Payment, pending?: false, checkout?: true, created_at: Time.current)
+      expect(payment_source.can_capture?(payment)).to be true
+    end
+  end
+
+  context "#can_void?" do
+    it "should be true if payment is not void" do
+      payment = mock_model(Spree::Payment, failed?: false, void?: false)
+      expect(payment_source.can_void?(payment)).to be true
+    end
+  end
+
+  context "#can_credit?" do
+    it "should be false if payment is not completed" do
+      payment = mock_model(Spree::Payment, completed?: false)
+      expect(payment_source.can_credit?(payment)).to be false
+    end
+
+    it "should be false when credit_allowed is zero" do
+      payment = mock_model(Spree::Payment, completed?: true, credit_allowed: 0, order: mock_model(Spree::Order, payment_state: 'credit_owed'))
+      expect(payment_source.can_credit?(payment)).to be false
+    end
+  end
+
+  context "#associations" do
+    it "should be able to access its payments" do
+      expect { credit_card.payments.to_a }.not_to raise_error
+    end
+  end
+end

--- a/core/spec/support/concerns/payment_source.rb
+++ b/core/spec/support/concerns/payment_source.rb
@@ -37,7 +37,12 @@ RSpec.shared_examples "a payment source" do
     end
 
     it "should be false when credit_allowed is zero" do
-      payment = mock_model(Spree::Payment, completed?: true, credit_allowed: 0, order: mock_model(Spree::Order, payment_state: 'credit_owed'))
+      payment = mock_model(
+                  Spree::Payment,
+                  completed?: true,
+                  credit_allowed: 0,
+                  order: mock_model(Spree::Order, payment_state: 'credit_owed')
+                )
       expect(payment_source.can_credit?(payment)).to be false
     end
   end

--- a/frontend/app/views/spree/checkout/_payment.html.erb
+++ b/frontend/app/views/spree/checkout/_payment.html.erb
@@ -25,7 +25,7 @@
                   <td><%= card.display_number %></td>
                   <td><%= card.month %> / <%= card.year %></td>
                   <td>
-                    <%= radio_button_tag "order[existing_card]", card.id, (card == @payment_sources.first), { class: "existing-cc-radio" }  %>
+                    <%= radio_button_tag "order[existing_user_payment_source_id]", card.id, (card == @payment_sources.first), { class: "existing-cc-radio" }  %>
                   </td>
                 </tr>
               <% end %>

--- a/frontend/app/views/spree/checkout/_payment.html.erb
+++ b/frontend/app/views/spree/checkout/_payment.html.erb
@@ -25,7 +25,7 @@
                   <td><%= card.display_number %></td>
                   <td><%= card.month %> / <%= card.year %></td>
                   <td>
-                    <%= radio_button_tag "order[existing_user_payment_source_id]", card.id, (card == @payment_sources.first), { class: "existing-cc-radio" }  %>
+                    <%= radio_button_tag "order[existing_payment_source]", card.id, (card == @payment_sources.first), { class: "existing-cc-radio" }  %>
                   </td>
                 </tr>
               <% end %>

--- a/guides/content/release_notes/3_1_0.md
+++ b/guides/content/release_notes/3_1_0.md
@@ -33,7 +33,7 @@ to check for notifications.
 Soft deleting means that the records are left in the database but behave as if they are really deleted. Because associations from other objects (like line itmes to variant) won't normally see the deleted, core code is forced (unnaturally) to use scopes like ```.with_deleted```
 
 We are fixing this by adding new feilds 'Discontinue On' to products & variants (discontinue_on)
-                                                        
+
 This fixes a design flaw in that in most stores these objects really should not be considered "deleted."  The approach proposed solves the underlying flaw and all the related bugs caused by this flaw in the following ways:
 
 - Migrate the timestamps deleted_at to discontinue_on (when possible), and un-delete the deleted variants (when there is not matching SKU) and products (when there is no matching slug)
@@ -137,14 +137,14 @@ You can view the full changes using [Github Compare](https://github.com/spree/sp
 
     [Martin Meyerhoff](https://github.com/spree/spree/pull/6662)
 
-* Added `Spree.admin_path` option for a dynamic admin path; making automated 'script' attacks on the backend more difficult. 
+* Added `Spree.admin_path` option for a dynamic admin path; making automated 'script' attacks on the backend more difficult.
 
   You can simply configure the option by assigning the path in your Spree initializer:
   ```ruby
   Spree.admin_path = "/my-secret-backend"
   ```
 
-  NOTE: Plugins are not converted and still use the default /admin path. But these plugins can be 
+  NOTE: Plugins are not converted and still use the default /admin path. But these plugins can be
   changed easily by adding the `path: Spree.admin_path` option in the routes.
 
     [Rick Blommers](https://github.com/spree/spree/pull/6739)
@@ -159,3 +159,9 @@ You can view the full changes using [Github Compare](https://github.com/spree/sp
 * Removed Order#has_available_shipment, which was unnecessary since it always returned nil
 
     [Tanmay Sinha](https://github.com/spree/spree/pull/7007)
+
+* Allow Spree::Order and your user model to have other payment sources than credit cards
+
+    Previously, Spree had the `Spree::CreditCard` model hardcoded as the only payment source available. In order to be able to accommodate other types of payment sources (think direct debit payments in the EU, there is now a join Model called `UserPaymentSource`). Also, the order model has been updated to set a default payment source instead of a default credit card.
+
+    [Martin Meyerhoff](https://github.com/spree/spree/pull/6831)


### PR DESCRIPTION
We have a number of reusable payment sources that are not credit cards. However, the `payment_sources` method on the `Spree.user_class` model is a simple `has_many` that can only get Credit cards.

This PR adds a join table between the user and the different payment source models to accomodate for the ensuing Polymorphism. Common code for all payment sources is abstracted into a `Spree::PaymentSource` base class, and the common tests are extracted into `shared_examples` for all Payment sources.

Consequently, also the code for re-using existing payment sources in  `order/checkout.rb` had to be adapted.

This is a rather large PR. Please have a careful look at it; I'm happy to integrate comments and criticism.
