### PR TITLE
update price maximum value validation

### DIFF
--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -3,11 +3,16 @@ module Spree
     include VatPriceCalculation
 
     acts_as_paranoid
+
+    MAXIMUM_AMOUNT = BigDecimal('99_999_999.99')
+
     belongs_to :variant, class_name: 'Spree::Variant', inverse_of: :prices, touch: true
 
     validate :check_price
-    validates :amount, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
-    validate :validate_amount_maximum
+    validates :amount, allow_nil: true, numericality: {
+      greater_than_or_equal_to: 0,
+      less_than_or_equal_to: MAXIMUM_AMOUNT
+    }
 
     extend DisplayMoney
     money_methods :amount, :price
@@ -44,16 +49,6 @@ module Spree
 
     def check_price
       self.currency ||= Spree::Config[:currency]
-    end
-
-    def maximum_amount
-      BigDecimal '999999.99'
-    end
-
-    def validate_amount_maximum
-      if amount && amount > maximum_amount
-        errors.add :amount, I18n.t('errors.messages.less_than_or_equal_to', count: maximum_amount)
-      end
     end
   end
 end

--- a/core/spec/models/spree/price_spec.rb
+++ b/core/spec/models/spree/price_spec.rb
@@ -22,20 +22,20 @@ describe Spree::Price, :type => :model do
       end
     end
 
-    context 'when the amount is greater than 999,999.99' do
-      let(:amount) { 1_000_000 }
+    context 'when the amount is greater than maximum amount' do
+      let(:amount) { Spree::Price::MAXIMUM_AMOUNT + 1 }
 
       it 'has 1 error_on' do
         expect(subject.error_on(:amount).size).to eq(1)
       end
       it 'populates errors' do
         subject.valid?
-        expect(subject.errors.messages[:amount].first).to eq 'must be less than or equal to 999999.99'
+        expect(subject.errors.messages[:amount].first).to eq "must be less than or equal to #{Spree::Price::MAXIMUM_AMOUNT}"
       end
     end
 
-    context 'when the amount is between 0 and 999,999.99' do
-      let(:amount) { 100 }
+    context 'when the amount is between 0 and the maximum amount' do
+      let(:amount) { Spree::Price::MAXIMUM_AMOUNT }
       it { is_expected.to be_valid }
     end
   end

--- a/guides/content/developer/core/products.md
+++ b/guides/content/developer/core/products.md
@@ -110,8 +110,6 @@ $ product.price
 => "15.99"
 ```
 
-If you have products where prices are greater than 9999999.99 then you should decorate `Spree::Price` and customize `maximum_amount` method in order to support the prices.
-
 To find a list of currencies that this product is available in, call `prices` to get a list of related `Price` objects:
 
 ```bash


### PR DESCRIPTION
validation was not in sync with actual database field precision.
not sure why this was added to the doc instead of actually fixing it on https://github.com/spree/spree/pull/6145
made method public for easier testing

/cc @ronzalo 
