### PR TITLE
removes table existance (spree_stores) requirement for app boot

### DIFF
--- a/backend/app/views/spree/admin/reimbursements/edit.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/edit.html.erb
@@ -10,6 +10,8 @@
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @reimbursement } %>
 
+<div data-hook="before-reimbursement"></div>
+
 <%= form_for [:admin, @order, @reimbursement] do |f| %>
   <fieldset class='no-border-bottom'>
     <legend align='center'><%= Spree.t(:items_to_be_reimbursed) %></legend>

--- a/backend/app/views/spree/admin/reimbursements/show.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/show.html.erb
@@ -10,6 +10,8 @@
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @reimbursement } %>
 
+<div data-hook="before-reimbursement"></div>
+
 <fieldset class='no-border-bottom'>
   <legend align='center'><%= Spree.t(:items_reimbursed) %></legend>
   <table class="index reimbursement-reimbursement-items-table">

--- a/backend/app/views/spree/admin/return_authorizations/edit.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/edit.html.erb
@@ -28,3 +28,5 @@
     </div>
   </fieldset>
 <% end %>
+
+<div data-hook="bottom-of-return-authorization-edit"></div>

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -94,7 +94,9 @@ module Spree
       # support all the old preference methods with a warning
       define_method "preferred_#{old_preference_name}" do
         ActiveSupport::Deprecation.warn("#{old_preference_name} is no longer supported on Spree::Config, please access it through #{store_method} on Spree::Store")
-        Store.default.send(store_method)
+        if ActiveRecord::Base.connection.table_exists?(:spree_stores)
+          Store.default.send(store_method)
+        end
       end
     end
   end

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -58,7 +58,7 @@ module Spree
               end
 
               event :return do
-                transition to: :returned, from: [:complete, :awaiting_return, :canceled], if: :all_inventory_units_returned?
+                transition to: :returned, from: [:returned, :complete, :awaiting_return, :canceled], if: :all_inventory_units_returned?
               end
 
               event :resume do

--- a/core/config/initializers/user_class_extensions.rb
+++ b/core/config/initializers/user_class_extensions.rb
@@ -32,9 +32,9 @@ Spree::Core::Engine.config.to_prepare do
         spree_orders.incomplete.order('created_at DESC').first
       end
 
-      def analytics_id
-        id
-      end
+      # def analytics_id
+      #        id
+      #      end
     end
   end
 end


### PR DESCRIPTION
@JDutil this is necessary for me because my test environment bootstraps with 0 tables/0 records. Once it migrates, it then has records, and I can use a factory to insert a default record here.

But without the table existence the app can't boot up at all.

Generally I think any missing table that prevents the app from booting should be wrapped in a `table_exists?` since you will get a catch-22 if you need to boot the app in order to create or populate the table for the first time. 
