### PR TITLE
use where(nil) as anonymous scope instead of all, closes #6817

### DIFF
--- a/core/app/models/spree/base.rb
+++ b/core/app/models/spree/base.rb
@@ -17,6 +17,6 @@ class Spree::Base < ActiveRecord::Base
   self.abstract_class = true
 
   def self.spree_base_scopes
-    all
+    where(nil)
   end
 end


### PR DESCRIPTION
following rails deprecations, similar to https://github.com/spree/spree/commit/2e0ddbaa5aedcbc8baae9379aaad5c1f4523166d
