### PR TITLE
A promotion should not be eligible if it has no associated product.

### DIFF
--- a/core/app/models/spree/promotion/rules/product.rb
+++ b/core/app/models/spree/promotion/rules/product.rb
@@ -20,7 +20,7 @@ module Spree
         end
 
         def eligible?(order, options = {})
-          return true if eligible_products.empty?
+          return false if eligible_products.empty?
           if preferred_match_policy == 'all'
             eligible_products.all? {|p| order.products.include?(p) }
           elsif preferred_match_policy == 'any'

--- a/core/spec/models/spree/promotion/rules/product_spec.rb
+++ b/core/spec/models/spree/promotion/rules/product_spec.rb
@@ -6,9 +6,9 @@ describe Spree::Promotion::Rules::Product do
   context "#eligible?(order)" do
     let(:order) { Spree::Order.new }
 
-    it "should be eligible if there are no products" do
+    it "should not be eligible if there are no products" do
       rule.stub(:eligible_products => [])
-      rule.should be_eligible(order)
+      rule.should_not be_eligible(order)
     end
 
     before do


### PR DESCRIPTION
Right now if a product based promotion has no associated product it basically works like a regular promotion and is eligible to all orders with any product. I feel this is a bad idea. Here is a scenario to show why.

Let's say we have a product based promotion and it's linked to product A. Only orders with product A as a line item are eligible for the promotion. Later for some reason store owner delete product A and he/she may not be aware of (or forget) the link between the product and the promotion. Suddently this promotion will be eligible to any order, which very unlikely is the owner's intention.

This PR is trying to address that.
