### PR TITLE
Use gross amount for return items

### DIFF
--- a/backend/app/controllers/spree/admin/return_authorizations_controller.rb
+++ b/backend/app/controllers/spree/admin/return_authorizations_controller.rb
@@ -29,7 +29,7 @@ module Spree
         unassociated_inventory_units = all_inventory_units - associated_inventory_units
 
         new_return_items = unassociated_inventory_units.map do |new_unit|
-          Spree::ReturnItem.new(inventory_unit: new_unit).tap(&:set_default_pre_tax_amount)
+          Spree::ReturnItem.new(inventory_unit: new_unit).tap(&:set_default_amount)
         end
 
         @form_return_items = (@return_authorization.return_items + new_return_items).sort_by(&:inventory_unit_id)

--- a/backend/app/views/spree/admin/customer_returns/_return_item_decision.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_return_item_decision.html.erb
@@ -3,7 +3,7 @@
     <tr>
       <th><%= Spree.t(:product) %></th>
       <th><%= Spree.t(:sku) %></th>
-      <th><%= Spree.t(:pre_tax_amount) %></th>
+      <th><%= Spree.t(:amount) %></th>
       <th><%= Spree.t(:preferred_reimbursement_type) %></th>
       <th><%= Spree.t(:exchange_for) %></th>
       <th><%= Spree.t(:acceptance_errors) %></th>
@@ -23,7 +23,7 @@
           <%= return_item.inventory_unit.variant.sku %>
         </td>
         <td>
-          <%= return_item.display_pre_tax_amount %>
+          <%= return_item.display_amount %>
         </td>
         <td>
           <%= reimbursement_type_name(return_item.preferred_reimbursement_type) %>

--- a/backend/app/views/spree/admin/customer_returns/_return_item_selection.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_return_item_selection.html.erb
@@ -6,7 +6,7 @@
       </th>
       <th><%= Spree.t(:product) %></th>
       <th><%= Spree.t(:sku) %></th>
-      <th><%= Spree.t(:pre_tax_amount) %></th>
+      <th><%= Spree.t(:amount) %></th>
       <th><%= Spree.t(:exchange_for) %></th>
       <th><%= Spree.t(:resellable) %></th>
     </tr>
@@ -19,9 +19,9 @@
           <div style="display:none">
             <%= item_fields.hidden_field :inventory_unit_id %>
             <%= item_fields.hidden_field :return_authorization_id %>
-            <%= item_fields.hidden_field :pre_tax_amount %>
+            <%= item_fields.hidden_field :amount %>
           </div>
-          <%= item_fields.check_box :returned, {checked: false, class: 'add-item', "data-price" => return_item.pre_tax_amount}, '1', '0' %>
+          <%= item_fields.check_box :returned, {checked: false, class: 'add-item', "data-price" => return_item.amount}, '1', '0' %>
         </td>
         <td>
           <div class="variant-name"><%= return_item.inventory_unit.variant.name %></div>
@@ -31,7 +31,7 @@
           <%= return_item.inventory_unit.variant.sku %>
         </td>
         <td class="align-center">
-          <%= return_item.display_pre_tax_amount %>
+          <%= return_item.display_amount %>
         </td>
         <td class="align-center">
           <%= return_item.exchange_variant.try(:exchange_name) %>

--- a/backend/app/views/spree/admin/customer_returns/index.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/index.html.erb
@@ -17,7 +17,7 @@
       <thead data-hook="customer_return_header">
         <tr>
           <th><%= Spree.t(:return_number) %></th>
-          <th><%= Spree.t(:pre_tax_total) %></th>
+          <th><%= Spree.t(:amount) %></th>
           <th><%= "#{Spree.t('date')}/#{Spree.t('time')}" %></th>
           <th><%= Spree.t(:reimbursement_status) %></th>
           <th></th>
@@ -27,7 +27,7 @@
         <% @customer_returns.each do |customer_return| %>
           <tr id="<%= spree_dom_id(customer_return) %>" data-hook="customer_return_row">
             <td><%= link_to customer_return.number, edit_admin_order_customer_return_path(@order, customer_return) %></td>
-            <td><%= customer_return.display_pre_tax_total.to_html %></td>
+            <td><%= customer_return.display_amount.to_html %></td>
             <td><%= pretty_time(customer_return.created_at) %></td>
             <td>
               <% if customer_return.fully_reimbursed? %>

--- a/backend/app/views/spree/admin/reimbursements/edit.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/edit.html.erb
@@ -39,7 +39,7 @@
               ) %>
             </td>
             <td>
-              <%= item_fields.text_field :pre_tax_amount, { class: 'refund-amount-input form-control' } %>
+              <%= item_fields.text_field :amount, { class: 'refund-amount-input form-control' } %>
             </td>
             <td>
               <%= return_item.display_total %>

--- a/backend/app/views/spree/admin/reimbursements/show.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/show.html.erb
@@ -15,7 +15,7 @@
         <th><%= Spree.t(:preferred_reimbursement_type) %></th>
         <th><%= Spree.t(:reimbursement_type_override) %></th>
         <th><%= Spree.t(:exchange_for) %></th>
-        <th><%= Spree.t(:pre_tax_amount) %></th>
+        <th><%= Spree.t(:amount) %></th>
         <th><%= Spree.t(:total) %></th>
       </tr>
     </thead>
@@ -36,7 +36,7 @@
             <%= return_item.exchange_variant.try(:exchange_name) %>
           </td>
           <td>
-            <%= return_item.display_pre_tax_amount %>
+            <%= return_item.display_amount %>
           </td>
           <td>
             <%= return_item.display_total %>

--- a/backend/app/views/spree/admin/return_authorizations/_form.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/_form.html.erb
@@ -26,7 +26,7 @@
           <td class="inventory-unit-checkbox">
             <% if editable %>
               <%= item_fields.hidden_field :inventory_unit_id %>
-              <%= item_fields.check_box :_destroy, {checked: return_item.persisted?, class: 'add-item', "data-price" => return_item.pre_tax_amount}, '0', '1' %>
+              <%= item_fields.check_box :_destroy, {checked: return_item.persisted?, class: 'add-item', "data-price" => return_item.amount}, '0', '1' %>
             <% end %>
           </td>
           <td>
@@ -35,13 +35,13 @@
           </td>
           <td><%= inventory_unit.state.humanize %></td>
           <td>
-            <%= return_item.display_pre_tax_amount %>
+            <%= return_item.display_amount %>
           </td>
           <td>
             <% if editable %>
-              <%= item_fields.text_field :pre_tax_amount, { class: 'refund-amount-input form-control' } %>
+              <%= item_fields.text_field :amount, { class: 'refund-amount-input form-control' } %>
             <% else %>
-              <%= return_item.display_pre_tax_amount %>
+              <%= return_item.display_amount %>
             <% end %>
           </td>
           <td>

--- a/backend/app/views/spree/admin/return_authorizations/index.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/index.html.erb
@@ -16,7 +16,7 @@
       <tr>
         <th><%= Spree.t(:rma_number) %></th>
         <th><%= Spree.t(:status) %></th>
-        <th><%= Spree.t(:pre_tax_total) %></th>
+        <th><%= Spree.t(:amount) %></th>
         <th><%= "#{Spree.t('date')}/#{Spree.t('time')}" %></th>
         <th></th>
       </tr>
@@ -26,7 +26,7 @@
         <tr id="<%= spree_dom_id(return_authorization) %>" data-hook="rma_row">
           <td><%= return_authorization.number %></td>
           <td><%= Spree.t(return_authorization.state.downcase) %></td>
-          <td><%= return_authorization.display_pre_tax_total.to_html %></td>
+          <td><%= return_authorization.display_amount.to_html %></td>
           <td><%= pretty_time(return_authorization.created_at) %></td>
           <td class="actions actions-2">
             <%= link_to_edit(return_authorization, no_text: true, class: 'edit') if can?(:edit, return_authorization) %>

--- a/core/app/models/spree/calculator/returns/default_refund_amount.rb
+++ b/core/app/models/spree/calculator/returns/default_refund_amount.rb
@@ -10,7 +10,7 @@ module Spree
 
       def compute(return_item)
         return 0.0.to_d if return_item.exchange_requested?
-        weighted_order_adjustment_amount(return_item.inventory_unit) + weighted_line_item_pre_tax_amount(return_item.inventory_unit)
+        weighted_order_adjustment_amount(return_item.inventory_unit) + weighted_line_item_amount(return_item.inventory_unit)
       end
 
       private
@@ -19,13 +19,13 @@ module Spree
         inventory_unit.order.adjustments.eligible.non_tax.sum(:amount) * percentage_of_order_total(inventory_unit)
       end
 
-      def weighted_line_item_pre_tax_amount(inventory_unit)
-        inventory_unit.line_item.pre_tax_amount * percentage_of_line_item(inventory_unit)
+      def weighted_line_item_amount(inventory_unit)
+        inventory_unit.line_item.discounted_amount * percentage_of_line_item(inventory_unit)
       end
 
       def percentage_of_order_total(inventory_unit)
-       return 0.0 if inventory_unit.order.pre_tax_item_amount.zero?
-       weighted_line_item_pre_tax_amount(inventory_unit) / inventory_unit.order.pre_tax_item_amount
+       return 0.0 if inventory_unit.order.discounted_item_amount.zero?
+       weighted_line_item_amount(inventory_unit) / inventory_unit.order.discounted_item_amount
      end
 
      def percentage_of_line_item(inventory_unit)

--- a/core/app/models/spree/customer_return.rb
+++ b/core/app/models/spree/customer_return.rb
@@ -16,7 +16,7 @@ module Spree
     accepts_nested_attributes_for :return_items
 
     extend DisplayMoney
-    money_methods pre_tax_total: { currency: Spree::Config[:currency] }
+    money_methods amount: { currency: Spree::Config[:currency] }
 
     delegate :id, to: :order, prefix: true, allow_nil: true
 

--- a/core/app/models/spree/customer_return.rb
+++ b/core/app/models/spree/customer_return.rb
@@ -35,8 +35,8 @@ module Spree
     end
 
 
-    def pre_tax_total
-      return_items.sum(:pre_tax_amount)
+    def amount
+      return_items.sum(:amount)
     end
 
     private

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -185,6 +185,11 @@ module Spree
       line_items.to_a.sum(&:pre_tax_amount)
     end
 
+    # Sum of all line item amounts after promotions, before added tax
+    def discounted_item_amount
+      line_items.to_a.sum(&:discounted_amount)
+    end
+
     def currency
       self[:currency] || Spree::Config[:currency]
     end

--- a/core/app/models/spree/reimbursement_tax_calculator.rb
+++ b/core/app/models/spree/reimbursement_tax_calculator.rb
@@ -23,10 +23,10 @@ module Spree
       def set_tax!(return_item)
         calculated_refund = Spree::ReturnItem.refund_amount_calculator.new.compute(return_item)
 
-        percent_of_tax = if return_item.pre_tax_amount <= 0 || calculated_refund <= 0
+        percent_of_tax = if return_item.amount <= 0 || calculated_refund <= 0
           0
         else
-          return_item.pre_tax_amount / calculated_refund
+          return_item.amount / calculated_refund
         end
 
         additional_tax_total = percent_of_tax * return_item.inventory_unit.additional_tax_total

--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -36,12 +36,12 @@ module Spree
     end
 
     extend DisplayMoney
-    money_methods :pre_tax_total
+    money_methods :amount
 
     self.whitelisted_ransackable_attributes = ['memo']
 
-    def pre_tax_total
-      return_items.sum(:pre_tax_amount)
+    def amount
+      return_items.sum(:amount)
     end
 
     def currency
@@ -49,7 +49,7 @@ module Spree
     end
 
     def refundable_amount
-      order.pre_tax_item_amount + order.promo_total
+      order.discounted_item_amount + order.promo_total
     end
 
     def customer_returned_items?

--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -73,7 +73,7 @@ module Spree
     end
 
     extend DisplayMoney
-    money_methods :pre_tax_amount, :total
+    money_methods :pre_tax_amount, :amount, :total
 
     def reception_completed?
       COMPLETED_RECEPTION_STATUSES.include?(reception_status)
@@ -123,7 +123,7 @@ module Spree
     end
 
     def total
-      pre_tax_amount + included_tax_total + additional_tax_total
+      amount + additional_tax_total
     end
 
     def eligible_exchange_variants
@@ -144,7 +144,7 @@ module Spree
     end
 
     def set_default_pre_tax_amount
-      self.pre_tax_amount = refund_amount_calculator.new.compute(self)
+      self.amount = refund_amount_calculator.new.compute(self)
     end
 
     private

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1006,7 +1006,6 @@ en:
     powered_by: Powered by
     pre_tax_refund_amount: Pre-Tax Refund Amount
     pre_tax_amount: Pre-Tax Amount
-    pre_tax_total: Pre-Tax Total
     preferred_reimbursement_type: Preferred Reimbursement Type
     presentation: Presentation
     previous: Previous

--- a/core/db/migrate/20151026093607_change_return_item_pre_tax_amount_to_amount.rb
+++ b/core/db/migrate/20151026093607_change_return_item_pre_tax_amount_to_amount.rb
@@ -1,0 +1,14 @@
+class ChangeReturnItemPreTaxAmountToAmount < ActiveRecord::Migration
+  def change
+    # set pre_tax_amount on shipments to discounted_amount - included_tax_total
+    # so that the null: false option on the shipment pre_tax_amount doesn't generate
+    # errors.
+    #
+    execute(<<-SQL)
+      UPDATE spree_return_items
+      SET pre_tax_amount = pre_tax_amount + included_tax_total;
+    SQL
+
+    rename_column :spree_return_items, :pre_tax_amount, :amount
+  end
+end

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -40,7 +40,7 @@ module Spree
       :coupon_code, :email, :shipping_method_id, :special_instructions, :use_billing
     ]
 
-    @@customer_return_attributes = [:stock_location_id, return_items_attributes: [:id, :inventory_unit_id, :return_authorization_id, :returned, :pre_tax_amount, :acceptance_status, :exchange_variant_id, :resellable]]
+    @@customer_return_attributes = [:stock_location_id, return_items_attributes: [:id, :inventory_unit_id, :return_authorization_id, :returned, :amount, :acceptance_status, :exchange_variant_id, :resellable]]
 
     @@image_attributes = [:alt, :attachment, :position, :viewable_type, :viewable_id]
 

--- a/core/spec/models/spree/calculator/refunds/default_refund_amount_spec.rb
+++ b/core/spec/models/spree/calculator/refunds/default_refund_amount_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe Spree::Calculator::Returns::DefaultRefundAmount, :type => :model do
   let(:order)           { create(:order) }
   let(:line_item_quantity) { 2 }
-  let(:pre_tax_amount)  { 100.0 }
-  let(:line_item)       { create(:line_item, price: 100.0, quantity: line_item_quantity, pre_tax_amount: pre_tax_amount) }
+  let(:line_item_price)  { 100.0 }
+  let(:line_item)       { create(:line_item, price: line_item_price, quantity: line_item_quantity) }
   let(:inventory_unit) { build(:inventory_unit, order: order, line_item: line_item) }
   let(:return_item) { build(:return_item, inventory_unit: inventory_unit ) }
   let(:calculator) { Spree::Calculator::Returns::DefaultRefundAmount.new }
@@ -15,7 +15,7 @@ describe Spree::Calculator::Returns::DefaultRefundAmount, :type => :model do
 
   context "not an exchange" do
     context "no promotions or taxes" do
-      it { is_expected.to eq pre_tax_amount / line_item_quantity }
+      it { is_expected.to eq line_item_price }
     end
 
     context "order adjustments" do
@@ -26,7 +26,7 @@ describe Spree::Calculator::Returns::DefaultRefundAmount, :type => :model do
         order.adjustments.first.update_attributes(amount: adjustment_amount)
       end
 
-      it { is_expected.to eq (pre_tax_amount - adjustment_amount.abs) / line_item_quantity }
+      it { is_expected.to eq line_item_price - (adjustment_amount.abs / line_item_quantity) }
     end
 
     context "shipping adjustments" do
@@ -34,7 +34,7 @@ describe Spree::Calculator::Returns::DefaultRefundAmount, :type => :model do
 
       before { order.shipments << Spree::Shipment.new(adjustment_total: adjustment_total) }
 
-      it { is_expected.to eq pre_tax_amount / line_item_quantity }
+      it { is_expected.to eq line_item_price }
     end
   end
 
@@ -44,8 +44,8 @@ describe Spree::Calculator::Returns::DefaultRefundAmount, :type => :model do
     it { is_expected.to eq 0.0 }
   end
 
-  context "pre_tax_amount is zero" do
-    let(:pre_tax_amount)  { 0.0 }
+  context "line item price is zero" do
+    let(:line_item_price)  { 0.0 }
     it { should eq 0.0 }
   end
 end

--- a/core/spec/models/spree/customer_return_spec.rb
+++ b/core/spec/models/spree/customer_return_spec.rb
@@ -79,18 +79,18 @@ describe Spree::CustomerReturn, :type => :model do
     end
   end
 
-  describe "#pre_tax_total" do
-    let(:pre_tax_amount)  { 15.0 }
+  describe "#amount" do
+    let(:amount)  { 15.0 }
     let(:customer_return) { create(:customer_return, line_items_count: 2) }
 
     before do
-      Spree::ReturnItem.where(customer_return_id: customer_return.id).update_all(pre_tax_amount: pre_tax_amount)
+      Spree::ReturnItem.where(customer_return_id: customer_return.id).update_all(amount: amount)
     end
 
-    subject { customer_return.pre_tax_total }
+    subject { customer_return.amount }
 
-    it "returns the sum of the return item's pre_tax_amount" do
-      expect(subject).to eq (pre_tax_amount * 2)
+    it "returns the sum of the return item's amount" do
+      expect(subject).to eq (amount * 2)
     end
   end
 

--- a/core/spec/models/spree/customer_return_spec.rb
+++ b/core/spec/models/spree/customer_return_spec.rb
@@ -94,12 +94,12 @@ describe Spree::CustomerReturn, :type => :model do
     end
   end
 
-  describe "#display_pre_tax_total" do
+  describe "#display_amount" do
     let(:customer_return) { Spree::CustomerReturn.new }
 
     it "returns a Spree::Money" do
-      allow(customer_return).to receive_messages(pre_tax_total: 21.22)
-      expect(customer_return.display_pre_tax_total).to eq(Spree::Money.new(21.22))
+      allow(customer_return).to receive_messages(amount: 21.22)
+      expect(customer_return.display_amount).to eq(Spree::Money.new(21.22))
     end
   end
 

--- a/core/spec/models/spree/reimbursement_spec.rb
+++ b/core/spec/models/spree/reimbursement_spec.rb
@@ -136,8 +136,8 @@ describe Spree::Reimbursement, type: :model do
       subject { reimbursement.calculated_total }
 
       before do
-        reimbursement.return_items << Spree::ReturnItem.new(pre_tax_amount: 10.003)
-        reimbursement.return_items << Spree::ReturnItem.new(pre_tax_amount: 10.003)
+        reimbursement.return_items << Spree::ReturnItem.new(amount: 10.003)
+        reimbursement.return_items << Spree::ReturnItem.new(amount: 10.003)
       end
 
       it 'rounds down' do
@@ -151,7 +151,7 @@ describe Spree::Reimbursement, type: :model do
       subject { reimbursement.calculated_total }
 
       before do
-        reimbursement.return_items << Spree::ReturnItem.new(pre_tax_amount: 19.998)
+        reimbursement.return_items << Spree::ReturnItem.new(amount: 19.998)
       end
 
       it 'rounds up' do

--- a/core/spec/models/spree/return_authorization_spec.rb
+++ b/core/spec/models/spree/return_authorization_spec.rb
@@ -91,52 +91,52 @@ describe Spree::ReturnAuthorization, :type => :model do
     end
   end
 
-  describe "#pre_tax_total" do
-    let(:pre_tax_amount_1) { 15.0 }
-    let!(:return_item_1) { create(:return_item, return_authorization: return_authorization, pre_tax_amount: pre_tax_amount_1) }
+  describe "#amount" do
+    let(:amount_1) { 15.0 }
+    let!(:return_item_1) { create(:return_item, return_authorization: return_authorization, amount: amount_1) }
 
-    let(:pre_tax_amount_2) { 50.0 }
-    let!(:return_item_2) { create(:return_item, return_authorization: return_authorization, pre_tax_amount: pre_tax_amount_2) }
+    let(:amount_2) { 50.0 }
+    let!(:return_item_2) { create(:return_item, return_authorization: return_authorization, amount: amount_2) }
 
-    let(:pre_tax_amount_3) { 5.0 }
-    let!(:return_item_3) { create(:return_item, return_authorization: return_authorization, pre_tax_amount: pre_tax_amount_3) }
+    let(:amount_3) { 5.0 }
+    let!(:return_item_3) { create(:return_item, return_authorization: return_authorization, amount: amount_3) }
 
-    subject { return_authorization.pre_tax_total }
+    subject { return_authorization.amount }
 
     it "sums it's associated return_item's pre-tax amounts" do
-      expect(subject).to eq (pre_tax_amount_1 + pre_tax_amount_2 + pre_tax_amount_3)
+      expect(subject).to eq (amount_1 + amount_2 + amount_3)
     end
   end
 
-  describe "#display_pre_tax_total" do
+  describe "#display_amount" do
     it "returns a Spree::Money" do
-      allow(return_authorization).to receive_messages(pre_tax_total: 21.22)
-      expect(return_authorization.display_pre_tax_total).to eq(Spree::Money.new(21.22))
+      allow(return_authorization).to receive_messages(amount: 21.22)
+      expect(return_authorization.display_amount).to eq(Spree::Money.new(21.22))
     end
   end
 
   describe "#refundable_amount" do
-    let(:weighted_line_item_pre_tax_amount) { 5.0 }
-    let(:line_item_count)                   { return_authorization.order.line_items.count }
+    let(:line_item_price) { 5.0 }
+    let(:line_item_count) { return_authorization.order.line_items.count }
 
     subject { return_authorization.refundable_amount }
 
     before do
-      return_authorization.order.line_items.update_all(pre_tax_amount: weighted_line_item_pre_tax_amount)
+      return_authorization.order.line_items.update_all(price: line_item_price)
       return_authorization.order.update_attribute(:promo_total, promo_total)
     end
 
     context "no promotions" do
       let(:promo_total) { 0.0 }
       it "returns the pre-tax line item total" do
-        expect(subject).to eq (weighted_line_item_pre_tax_amount * line_item_count)
+        expect(subject).to eq (line_item_price * line_item_count)
       end
     end
 
     context "promotions" do
       let(:promo_total) { -10.0 }
       it "returns the pre-tax line item total minus the order level promotion value" do
-        expect(subject).to eq (weighted_line_item_pre_tax_amount * line_item_count) + promo_total
+        expect(subject).to eq (line_item_price * line_item_count) + promo_total
       end
     end
   end

--- a/core/spec/models/spree/return_item_spec.rb
+++ b/core/spec/models/spree/return_item_spec.rb
@@ -83,12 +83,12 @@ describe Spree::ReturnItem, :type => :model do
     end
   end
 
-  describe "#display_pre_tax_amount" do
-    let(:pre_tax_amount) { 21.22 }
-    let(:return_item) { build(:return_item, pre_tax_amount: pre_tax_amount) }
+  describe "#display_amount" do
+    let(:amount) { 21.22 }
+    let(:return_item) { build(:return_item, amount: amount) }
 
     it "returns a Spree::Money" do
-      expect(return_item.display_pre_tax_amount).to eq(Spree::Money.new(pre_tax_amount))
+      expect(return_item.display_amount).to eq(Spree::Money.new(amount))
     end
   end
 
@@ -98,28 +98,28 @@ describe Spree::ReturnItem, :type => :model do
     end
   end
 
-  describe "pre_tax_amount calculations on create" do
+  describe "amount calculations on create" do
     let(:inventory_unit) { build(:inventory_unit) }
     before { subject.save! }
 
-    context "pre tax amount is not specified" do
+    context "amount is not specified" do
       subject { build(:return_item, inventory_unit: inventory_unit) }
 
       context "not an exchange" do
-        it { expect(subject.pre_tax_amount).to eq Spree::Calculator::Returns::DefaultRefundAmount.new.compute(subject) }
+        it { expect(subject.amount).to eq Spree::Calculator::Returns::DefaultRefundAmount.new.compute(subject) }
       end
 
       context "an exchange" do
         subject { build(:exchange_return_item) }
 
-        it { expect(subject.pre_tax_amount).to eq 0.0 }
+        it { expect(subject.amount).to eq 0.0 }
       end
     end
 
-    context "pre tax amount is specified" do
-      subject { build(:return_item, inventory_unit: inventory_unit, pre_tax_amount: 100) }
+    context "amount is specified" do
+      subject { build(:return_item, inventory_unit: inventory_unit, amount: 100) }
 
-      it { expect(subject.pre_tax_amount).to eq 100 }
+      it { expect(subject.amount).to eq 100 }
     end
   end
 
@@ -466,7 +466,7 @@ describe Spree::ReturnItem, :type => :model do
     end
   end
 
-  describe "exchange pre_tax_amount" do
+  describe "exchange amount" do
     let(:return_item) { build(:return_item) }
 
     context "the return item is intended to be exchanged" do
@@ -476,17 +476,17 @@ describe Spree::ReturnItem, :type => :model do
       end
 
       it do
-        return_item.pre_tax_amount = 5.0
+        return_item.amount = 5.0
         return_item.save!
-        expect(return_item.reload.pre_tax_amount).to eq 0.0
+        expect(return_item.reload.amount).to eq 0.0
       end
     end
 
     context "the return item is not intended to be exchanged" do
       it do
-        return_item.pre_tax_amount = 5.0
+        return_item.amount = 5.0
         return_item.save!
-        expect(return_item.reload.pre_tax_amount).to eq 5.0
+        expect(return_item.reload.amount).to eq 5.0
       end
     end
   end
@@ -669,14 +669,14 @@ describe Spree::ReturnItem, :type => :model do
       create(
         :return_item,
         inventory_unit: inventory_unit,
-        included_tax_total: 10
+        included_tax_total: 2
       )
     end
 
-    it 'includes included tax total' do
-      expect(return_item.pre_tax_amount).to eq 10
-      expect(return_item.included_tax_total).to eq 10
-      expect(return_item.total).to eq 20
+    it 'does not include included tax total' do
+      expect(return_item.net_amount).to eq 8
+      expect(return_item.included_tax_total).to eq 2
+      expect(return_item.total).to eq 10
     end
   end
 end


### PR DESCRIPTION
Currently, return items are displayed and calculated using the line item's pre-tax-amounts. That's not very user-friendly in VAT countries: Prices are always displayed including VAT. 

This PR changes the `ReturnItem` so that it has an `amount` column that excludes additional tax (From the commit history I believe that's what `pre_tax_amount` was supposed to mean), but includes included tax. 

I also have a feeling that this work could be used to actually drop all reference to pre_tax_amounts everywhere, which would significantly simplify `tax_rate.rb`, too. 
