### PR TITLE
Update checkout.rb

### DIFF
--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -296,7 +296,7 @@ module Spree
           end
 
           def user_has_valid_default_card?
-            user && user.default_credit_card.try(:valid?)
+            user && user.default_credit_card.try(:valid?) && !user.default_credit_card.payment_method.nil?
           end
 
           private


### PR DESCRIPTION
Validate the default credit card's payment method exists.

When deleting a payment method that has a credit card defaulted to a user, the user can not pass checkout as requires "valid payment method". This ensures that if we load their credit card, it has a valid payment method.
