### PR TITLE
Added translation to promotionable label

### DIFF
--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -101,7 +101,7 @@
 
         <div data-hook="admin_product_form_promotionable">
           <%= f.field_container :promotionable, class: ['form-group'] do %>
-              <%= f.label :promotionable %>
+              <%= f.label :promotionable, Spree.t(:promotionable) %>
               <%= f.error_message_on :promotionable %>
               <%= f.check_box :promotionable, class: 'form-control' %>
           <% end %>


### PR DESCRIPTION
Checkbox "PROMOTIONABLE" (admin panel->product edit page) doesn't translate. I added Spree.t call to do this.
