### PR TITLE
Updates guide ansible-ubuntu in developer/deployment section.

### DIFF
--- a/guides/content/developer/deployment/ansible-ubuntu.md
+++ b/guides/content/developer/deployment/ansible-ubuntu.md
@@ -88,6 +88,7 @@ Within the repository, there is a directory called "roles" which contains two su
 Within `roles/webserver/tasks/main.yml`, we have this:
 
 ```yaml
+- include: ruby.yml tags=ruby
 - include: deploy.yml tags=deploy
 - include: puma.yml tags=puma
 - include: nginx.yml tags=nginx
@@ -101,7 +102,7 @@ Within `roles/database/tasks.main.yml`, we have this:
 
 We can run the playbook with this command:
 
-    ansible-playbook ruby-webapp.yml -t deploy,postgresql,nginx
+    ansible-playbook ruby-webapp.yml -t ruby,deploy,postgresql,nginx
 
 The `-t` option tells Ansible that we want to run only the tasks tagged with those tags, in that order.
 

--- a/guides/content/developer/deployment/ansible-ubuntu.md
+++ b/guides/content/developer/deployment/ansible-ubuntu.md
@@ -11,7 +11,7 @@ Along with the [Manual Ubuntu Deployment Guide](/developer/manual-ubuntu.html), 
 
 To set up a server using Ansible, we're going to use what's referred to as a [playbook](http://www.ansibleworks.com/docs/playbooks.html). This particular playbook is available from [radar/ansible-rails-app](https://github.com/radar/ansible-rails-app) on GitHub and will install the following things:
 
-- Ruby 2.0.0-p253
+- Ruby 2.1
 - PostgreSQL 9.3
 - nginx
 - Puma (jungle)
@@ -57,9 +57,9 @@ app_name: spree
 
 ## stolen from https://github.com/jgrowl/ansible-playbook-ruby-from-src
 rubyTmpDir: /usr/local/src
-rubyUrl: http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p353.tar.gz
-rubyCompressedFile: ruby-2.0.0-p353.tar.gz
-rubyName: ruby-2.0.0-p353
+rubyUrl: http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0.tar.gz
+rubyCompressedFile: ruby-2.1.0.tar.gz
+rubyName: ruby-2.1.0
 tmpRubyPath: {{rubyTmpDir}}/{{rubyName}}
 ```
 


### PR DESCRIPTION
The current guide in in ansible-ubuntu lacks the step of installing ruby. It must be because the repo https://github.com/radar/ansible-rails-app/ is updated.

Also, the ruby version in the repo was changed to ruby 2.1 stable. This change has also been reflected.
