### PR TITLE
Add a command to install Spree Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ gem install rails -v 4.2.2
 gem install spree
 rails _4.2.2_ new my_store
 spree install my_store
+cd my_store
+rails g spree:auth:install
 ```
 
 This will add the Spree gem to your Gemfile, create initializers, copy migrations


### PR DESCRIPTION
I have added a command to install Spree Auth, so the Devise secret is added to the initialization file.

This also creates the admin user, needed to logging to the backend.
