### PR TITLE
fixing a js error in spree/backend/admin.js

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -7,7 +7,9 @@ Hopefully, this will evolve into a propper class.
 jQuery(function($) {
 
   // Add some tips
-  $('.with-tip').tooltip();
+  $(document).on('ready', function() {
+    $('.with-tip').tooltip();
+  });
 
   $('.js-show-index-filters').click(function(){
     $(".filter-well").slideToggle();


### PR DESCRIPTION
$('.with-tip').tooltip() is throwing a js error when we include bootstrap-sprockets from an external application instead of from spree.

Its happening because of a race condition(timing issue).

It should be run after the DOM is loaded and this commit fixes that problem.
