### PR TITLE
Locking sprockets-rails to 2.x - fixes failing API specs & more

### DIFF
--- a/backend/spree_backend.gemspec
+++ b/backend/spree_backend.gemspec
@@ -25,5 +25,4 @@ Gem::Specification.new do |s|
   s.add_dependency 'jquery-rails',    '~> 4.0.3'
   s.add_dependency 'jquery-ui-rails', '~> 5.0.0'
   s.add_dependency 'select2-rails',   '3.5.9.1' # 3.5.9.2 breaks several specs
-  s.add_dependency 'sprockets-rails', '~> 2.2'
 end

--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -7,6 +7,7 @@ gem 'coffee-rails', '~> 4.0.0'
 gem 'sass-rails', '~> 5.0.0'
 gem 'sqlite3', platforms: [:ruby, :mingw, :mswin, :x64_mingw]
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
+gem 'sprockets-rails', '~> 2.0'
 
 platforms :jruby do
   gem 'jruby-openssl'

--- a/frontend/spree_frontend.gemspec
+++ b/frontend/spree_frontend.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'bootstrap-sass',  '>= 3.3.5.1', '< 3.4'
   s.add_dependency 'canonical-rails', '~> 0.0.4'
   s.add_dependency 'jquery-rails',    '~> 4.0.3'
-  s.add_dependency 'sprockets-rails', '~> 2.2'
 
   s.add_development_dependency 'capybara-accessible'
 end


### PR DESCRIPTION
Temporary solution - in future we will work on full Sprockets 3.x support
