### PR TITLE
Change the template for extension.gemspec to uncomment author and cha…

### DIFF
--- a/cmd/lib/spree_cmd/templates/extension/extension.gemspec
+++ b/cmd/lib/spree_cmd/templates/extension/extension.gemspec
@@ -3,11 +3,11 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = '<%= file_name %>'
   s.version     = '<%= spree_version %>'
-  s.summary     = 'TODO: Add gem summary here'
-  s.description = 'TODO: Add (optional) gem description here'
+  s.summary     = 'Add gem summary here'
+  s.description = 'Add (optional) gem description here'
   s.required_ruby_version = '>= 2.0.0'
 
-  # s.author    = 'You'
+  s.author    = 'You'
   # s.email     = 'you@example.com'
   # s.homepage  = 'http://www.spreecommerce.com'
 


### PR DESCRIPTION
…nge summary and description to avoid the error: gemspec is not valid. The validation error was 'authors may not be empty' and bundle install fails when any new extension is added --skip-ci

If this is an intended behaviour then please let me know, i'll raise a request to make changes to the guides for extensions.
