### PR TITLE
jquery-rails update

### DIFF
--- a/backend/spree_backend.gemspec
+++ b/backend/spree_backend.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_api', version
   s.add_dependency 'spree_core', version
 
-  s.add_dependency 'bootstrap-sass',  '~> 3.3.1'
-  s.add_dependency 'jquery-rails',    '~> 4.0.3'
-  s.add_dependency 'jquery-ui-rails', '~> 5.0.0'
+  s.add_dependency 'bootstrap-sass',  '~> 3.3'
+  s.add_dependency 'jquery-rails',    '~> 4.0'
+  s.add_dependency 'jquery-ui-rails', '~> 5.0'
   s.add_dependency 'select2-rails',   '3.5.9.1' # 3.5.9.2 breaks several specs
 end

--- a/frontend/spree_frontend.gemspec
+++ b/frontend/spree_frontend.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'bootstrap-sass',  '>= 3.3.5.1', '< 3.4'
   s.add_dependency 'canonical-rails', '~> 0.0.4'
-  s.add_dependency 'jquery-rails',    '~> 4.0.3'
+  s.add_dependency 'jquery-rails',    '~> 4.0'
 
   s.add_development_dependency 'capybara-accessible'
 end


### PR DESCRIPTION
[jquery-rails](https://github.com/rails/jquery-rails) is currently locked for 4.0.x versions which conflicts with rails and many other gems
This causes problems with spree_cmd installation and many other
