### PR TITLE
Typo changes and admin end template optimisations.

### DIFF
--- a/backend/app/views/spree/admin/images/new.html.erb
+++ b/backend/app/views/spree/admin/images/new.html.erb
@@ -1,3 +1,5 @@
+<%= render partial: 'spree/admin/shared/product_tabs', locals: { current: :images } %>
+
 <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @product } %>
 
 <% content_for :page_title do %>

--- a/backend/app/views/spree/admin/return_authorizations/index.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/index.html.erb
@@ -43,7 +43,7 @@
     <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::ReturnAuthorization)) %>
   </div>
 <% else %>
-  <div data-hook="rma_cannont_create" class="alert alert-info no-objects-found">
+  <div data-hook="rma_cannot_create" class="alert alert-info no-objects-found">
     <%= Spree.t(:cannot_create_returns) %>
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/taxons/_form.html.erb
+++ b/backend/app/views/spree/admin/taxons/_form.html.erb
@@ -39,7 +39,7 @@
     <%= f.text_field :meta_description, :class => 'form-control', :rows => 6 %>
   <% end %>
 
-  <%= f.field_container :meta_description, class: ['form-group'] do %>
+  <%= f.field_container :meta_keywords, class: ['form-group'] do %>
     <%= f.label :meta_keywords, Spree.t(:meta_keywords) %>
     <%= f.text_field :meta_keywords, :class => 'form-control', :rows => 6 %>
   <% end %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -615,6 +615,7 @@ en:
     destination: Destination
     destroy: Destroy
     discount_amount: Discount Amount
+    discontinue_on: Discontinue On
     dismiss_banner: No. Thanks! I'm not interested, do not display this message again
     display: Display
     doesnt_track_inventory: It doesn't track inventory


### PR DESCRIPTION
1. add product tabs to new image view at backend
2. Typo fix: Change cannont to cannot
3. Change meta_description to meta_keywords for meta_keywords container
4. Add translation for :discontinue_on. It also addresses the warnings experienced while running backend specs.
