### PR TITLE
add default cache to common usage models

### DIFF
--- a/core/app/models/concerns/spree/default_cacheable.rb
+++ b/core/app/models/concerns/spree/default_cacheable.rb
@@ -1,0 +1,50 @@
+module Spree
+  module DefaultCacheable
+    extend ActiveSupport::Concern
+    included do
+      before_save :ensure_default
+      before_save :reload_cache
+    end
+
+    module ClassMethods
+      def default_cache_key
+        "#{Rails.application.class.parent_name.underscore}_default_#{name.demodulize.underscore}"
+      end
+
+      def default_query
+        column_names.include?('default') ?
+          where(default: true).first : column_names.include?('is_default') ?
+          where(is_default: true).first : first
+      end
+
+      def default
+        Rails.cache.fetch(default_cache_key) do
+          default_query
+        end
+      end
+    end
+
+    private
+
+    def ensure_default
+      if respond_to?(:default)
+        if default
+          self.class.where(default: true).where.not(id: id).update_all(default: false, updated_at: Time.current)
+        else
+          self.default = true if self.class.where(default: true).count.zero?
+        end
+      elsif respond_to?(:is_default)
+        if is_default
+          self.class.where(is_default: true).where.not(id: id).update_all(is_default: false, updated_at: Time.current)
+        else
+          self.is_default = true if self.class.where(is_default: true).count.zero?
+        end
+      end
+    end
+
+    def reload_cache
+      Rails.cache.delete(self.class.default_cache_key)
+    end
+  end
+end
+

--- a/core/app/models/spree/country.rb
+++ b/core/app/models/spree/country.rb
@@ -13,9 +13,13 @@ module Spree
 
     validates :name, :iso_name, presence: true
 
+    before_save :clear_cache
+
     def self.default
-      country_id = Spree::Config[:default_country_id]
-      country_id.present? ? find(country_id) : find_by!(iso: 'US')
+      Rails.cache.fetch("#{Rails.application.class.parent_name.underscore}_default_country") do
+        country_id = Spree::Config[:default_country_id]
+        country_id.present? ? find(country_id) : find_by!(iso: 'US')
+      end
     end
 
     def <=>(other)
@@ -24,6 +28,11 @@ module Spree
 
     def to_s
       name
+    end
+
+    private
+    def clear_cache
+      Rails.cache.delete("#{Rails.application.class.parent_name.underscore}_default_country")
     end
   end
 end

--- a/core/app/models/spree/country.rb
+++ b/core/app/models/spree/country.rb
@@ -13,13 +13,11 @@ module Spree
 
     validates :name, :iso_name, presence: true
 
-    before_save :clear_cache
+    include DefaultCacheable
 
-    def self.default
-      Rails.cache.fetch("#{Rails.application.class.parent_name.underscore}_default_country") do
-        country_id = Spree::Config[:default_country_id]
-        country_id.present? ? find(country_id) : find_by!(iso: 'US')
-      end
+    def self.default_query
+      country_id = Spree::Config[:default_country_id]
+      country_id.present? ? where(country_id).first : where(iso: 'US').first
     end
 
     def <=>(other)
@@ -28,11 +26,6 @@ module Spree
 
     def to_s
       name
-    end
-
-    private
-    def clear_cache
-      Rails.cache.delete("#{Rails.application.class.parent_name.underscore}_default_country")
     end
   end
 end

--- a/core/app/models/spree/shipping_category.rb
+++ b/core/app/models/spree/shipping_category.rb
@@ -7,5 +7,18 @@ module Spree
       has_many :shipping_method_categories
     end
     has_many :shipping_methods, through: :shipping_method_categories
+    
+    before_save :clear_cache
+
+    def self.default
+      Rails.cache.fetch("#{Rails.application.class.parent_name.underscore}_default_shipping_category") do
+        first
+      end
+    end
+
+    private
+    def clear_cache
+      Rails.cache.delete("#{Rails.application.class.parent_name.underscore}_default_shipping_category")
+    end    
   end
 end

--- a/core/app/models/spree/shipping_category.rb
+++ b/core/app/models/spree/shipping_category.rb
@@ -7,18 +7,7 @@ module Spree
       has_many :shipping_method_categories
     end
     has_many :shipping_methods, through: :shipping_method_categories
-    
-    before_save :clear_cache
 
-    def self.default
-      Rails.cache.fetch("#{Rails.application.class.parent_name.underscore}_default_shipping_category") do
-        first
-      end
-    end
-
-    private
-    def clear_cache
-      Rails.cache.delete("#{Rails.application.class.parent_name.underscore}_default_shipping_category")
-    end    
+    include DefaultCacheable
   end
 end

--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -15,6 +15,8 @@ module Spree
     after_create :create_stock_items, if: :propagate_all_variants?
     after_save :ensure_one_default
 
+    before_save :clear_cache
+
     def state_text
       state.try(:abbr) || state.try(:name) || state_name
     end
@@ -99,6 +101,16 @@ module Spree
       end
     end
 
+    def self.default
+      Rails.cache.fetch("#{Rails.application.class.parent_name.underscore}_default_stock_location") do
+        default_location = where(default: true).first
+        if default_location.blank? && (default_location = first)
+          default_location.update(default: true)
+        end
+        default_location
+      end
+    end
+
     private
       def create_stock_items
         Variant.includes(:product).find_each do |variant|
@@ -110,6 +122,10 @@ module Spree
         if self.default
           StockLocation.where(default: true).where.not(id: self.id).update_all(default: false)
         end
+      end
+
+      def clear_cache
+        Rails.cache.delete("#{Rails.application.class.parent_name.underscore}_default_stock_location")
       end
   end
 end

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -20,7 +20,7 @@ module Spree
     end
 
     def self.default
-      Rails.cache.fetch("default_store") do
+      Rails.cache.fetch("#{Rails.application.class.parent_name.underscore}_default_store") do
         where(default: true).first || new
       end
     end
@@ -44,7 +44,7 @@ module Spree
     end
 
     def clear_cache
-      Rails.cache.delete("default_store")
+      Rails.cache.delete("#{Rails.application.class.parent_name.underscore}_default_store")
     end
   end
 end

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -7,44 +7,27 @@ module Spree
       validates :name, :url, :mail_from_address
     end
 
-    before_save :ensure_default_exists_and_is_unique
     before_destroy :validate_not_default
 
     scope :by_url, lambda { |url| where("url like ?", "%#{url}%") }
 
-    before_save :clear_cache
+    include DefaultCacheable
 
     def self.current(domain = nil)
       current_store = domain ? Store.by_url(domain).first : nil
       current_store || Store.default
     end
 
-    def self.default
-      Rails.cache.fetch("#{Rails.application.class.parent_name.underscore}_default_store") do
-        where(default: true).first || new
-      end
+    def self.default_query
+      where(default: true).first || first || new
     end
 
     private
-
-    def ensure_default_exists_and_is_unique
-      if default
-        Store.where.not(id: id).each do |store|
-          store.update_attribute(:default, false)
-        end
-      elsif Store.where(default: true).count.zero?
-        self.default = true
-      end
-    end
 
     def validate_not_default
       if default
         errors.add(:base, :cannot_destroy_default_store)
       end
-    end
-
-    def clear_cache
-      Rails.cache.delete("#{Rails.application.class.parent_name.underscore}_default_store")
     end
   end
 end

--- a/core/app/models/spree/tax_category.rb
+++ b/core/app/models/spree/tax_category.rb
@@ -7,12 +7,25 @@ module Spree
 
     before_save :set_default_category
 
+    before_save :clear_cache
+
     def set_default_category
       #set existing default tax category to false if this one has been marked as default
 
       if is_default && tax_category = self.class.where(is_default: true).where.not(id: id).first
         tax_category.update_columns(is_default: false, updated_at: Time.current)
       end
+    end
+
+    def self.default
+      Rails.cache.fetch("#{Rails.application.class.parent_name.underscore}_default_tax_category") do
+        where(is_default: true).first
+      end
+    end
+
+    private
+    def clear_cache
+      Rails.cache.delete("#{Rails.application.class.parent_name.underscore}_default_tax_category")
     end
   end
 end

--- a/core/app/models/spree/tax_category.rb
+++ b/core/app/models/spree/tax_category.rb
@@ -5,27 +5,6 @@ module Spree
 
     has_many :tax_rates, dependent: :destroy, inverse_of: :tax_category
 
-    before_save :set_default_category
-
-    before_save :clear_cache
-
-    def set_default_category
-      #set existing default tax category to false if this one has been marked as default
-
-      if is_default && tax_category = self.class.where(is_default: true).where.not(id: id).first
-        tax_category.update_columns(is_default: false, updated_at: Time.current)
-      end
-    end
-
-    def self.default
-      Rails.cache.fetch("#{Rails.application.class.parent_name.underscore}_default_tax_category") do
-        where(is_default: true).first
-      end
-    end
-
-    private
-    def clear_cache
-      Rails.cache.delete("#{Rails.application.class.parent_name.underscore}_default_tax_category")
-    end
+    include DefaultCacheable
   end
 end

--- a/core/spec/models/spree/store_spec.rb
+++ b/core/spec/models/spree/store_spec.rb
@@ -53,7 +53,7 @@ describe Spree::Store, :type => :model do
         store.save
       end
 
-      it "ensure old default location still default" do
+      it "ensure old default store still default" do
         [store, store_2].each(&:reload)
         expect(store.default).to be false
         expect(store_2.default).to be true


### PR DESCRIPTION
ShippingCategory, StockLocation, Store, Country are fetched very frequently but update so few time.
It's not efficient to query database all the time. we can just keep them in cache.

the cache key add #{Rails.application.class.parent_name.underscore} to avoid when you have two app on the same server.
They will access the same redis/memcached storage. If you use the same cache key. It will get confused.
