### PR TITLE
Updating rspec-rails to 3.4.0

### DIFF
--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -27,7 +27,7 @@ group :test do
   gem 'rspec-activemodel-mocks', '~> 1.0.2'
   gem 'rspec-collection_matchers'
   gem 'rspec-its'
-  gem 'rspec-rails', '~> 3.3.1'
+  gem 'rspec-rails', '3.4.0'
   gem 'simplecov'
   gem 'webmock', '1.8.11'
   gem 'poltergeist', '1.6.0'


### PR DESCRIPTION
3.4.1 has problems with a few examples of ability spec
