### PR TITLE
Fix build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,40 +8,46 @@ set_gemfile(){
   export BUNDLE_GEMFILE="`pwd`/Gemfile"
 }
 
+prepare_app(){
+  set_gemfile
+  bundle update --quiet
+  echo "Preparing test app..."
+  bundle exec rake test_app
+}
 # Target postgres. Override with: `DB=sqlite bash build.sh`
 export DB=${DB:-postgres}
 
 # Spree defaults
-echo "Setup Spree defaults and creating test application..."
+echo "Setup Spree defaults..."
 bundle check || bundle update --quiet
-bundle exec rake test_app
 
 # Spree API
 echo "**************************************"
 echo "* Setup Spree API and running RSpec..."
 echo "**************************************"
-cd api; set_gemfile; bundle update --quiet; bundle exec rspec spec
+cd api; prepare_app; bundle exec rspec spec
 
 # Spree Backend
 echo "******************************************"
 echo "* Setup Spree Backend and running RSpec..."
 echo "******************************************"
-cd ../backend; set_gemfile; bundle update --quiet; bundle exec rspec spec
+cd ../backend; prepare_app; bundle exec rspec spec
 
 # Spree Core
 echo "***************************************"
 echo "* Setup Spree Core and running RSpec..."
 echo "***************************************"
-cd ../core; set_gemfile; bundle update --quiet; bundle exec rspec spec
+cd ../core; prepare_app; bundle exec rspec spec
 
 # Spree Frontend
 echo "*******************************************"
 echo "* Setup Spree Frontend and running RSpec..."
 echo "*******************************************"
-cd ../frontend; set_gemfile; bundle update --quiet; bundle exec rspec spec
+cd ../frontend; prepare_app; bundle exec rspec spec
 
 # Spree Sample
 echo "*****************************************"
 echo "* Setup Spree Sample and running RSpec..."
 echo "*****************************************"
-cd ../sample; set_gemfile; bundle update --quiet; bundle exec rspec spec
+cd ../sample; prepare_app; bundle exec rspec spec
+


### PR DESCRIPTION
Moved `bundle exec rake test_app` call to each subapplication, which prevents from adding random js files to manifests (for example frontend/backend.js).

Previously, `bundle exec rake test_app` command has also created dummy folder for each subapplication separately.
