### PR TITLE
fix: ensure the acts_as_list initializer executes before the spree.re…

### DIFF
--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -34,7 +34,7 @@ module Spree
         ]
       end
 
-      initializer 'spree.register.payment_methods' do |app|
+      initializer 'spree.register.payment_methods', after: 'acts_as_list.insert_into_active_record' do |app|
         app.config.spree.payment_methods = [
           Spree::Gateway::Bogus,
           Spree::Gateway::BogusSimple,


### PR DESCRIPTION
…gister.payment_methods initializer

depending on the order of operations, an error will result that might look like this:
activerecord-4.2.5/lib/active_record/dynamic_matchers.rb:26:in `method_missing': undefined local variable or method`acts_as_list' for#Class:0x007f930ce08700 (NameError)
