### PR TITLE
Add spec for Spree::Calculator::Shipping::PriceSack

### DIFF
--- a/core/spec/models/spree/calculator/shipping/price_sack_spec.rb
+++ b/core/spec/models/spree/calculator/shipping/price_sack_spec.rb
@@ -1,30 +1,29 @@
 require 'spec_helper'
 
-describe Spree::Calculator::PriceSack, :type => :model do
-  let(:calculator) do
-    calculator = Spree::Calculator::PriceSack.new
-    calculator.preferred_minimal_amount = 5
-    calculator.preferred_normal_amount = 10
-    calculator.preferred_discount_amount = 1
-    calculator
-  end
+module Spree
+  module Calculator::Shipping
+    describe PriceSack do
+      let(:variant) { build(:variant, price: 2) }
+      subject(:calculator) do
+        calculator = PriceSack.new
+        calculator.preferred_minimal_amount = 5
+        calculator.preferred_normal_amount = 10
+        calculator.preferred_discount_amount = 1
+        calculator
+      end
 
-  let(:order) { stub_model(Spree::Order) }
-  let(:shipment) { stub_model(Spree::Shipment, :amount => 10) }
+      let(:normal_package) do
+        build(:stock_package, variants_contents: { variant => 2 })
+      end
 
-  # Regression test for #714 and #739
-  it "computes with an order object" do
-    calculator.compute(order)
-  end
+      let(:discount_package) do
+        build(:stock_package, variants_contents: { variant => 4 })
+      end
 
-  # Regression test for #1156
-  it "computes with a shipment object" do
-    calculator.compute(shipment)
-  end
-
-  # Regression test for #2055
-  it "computes the correct amount" do
-    expect(calculator.compute(2)).to eq(calculator.preferred_normal_amount)
-    expect(calculator.compute(6)).to eq(calculator.preferred_discount_amount)
+      it 'computes the correct amount' do
+        expect(calculator.compute(normal_package)).to eq(calculator.preferred_normal_amount)
+        expect(calculator.compute(discount_package)).to eq(calculator.preferred_discount_amount)
+      end
+    end
   end
 end


### PR DESCRIPTION
Spec was describing wrong Calculator.
Pull request according to #6565 
