### PR TITLE
(OOS) Out of Stock Product page: better handling of cart form user experience

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -161,6 +161,11 @@ module Spree
       !!discontinue_on && discontinue_on <= Time.current
     end
 
+    # determine if any variant (including master) can be supplied
+    def can_supply?
+      variants_including_master.any?(&:can_supply?)
+    end
+
     # split variants list into hash which shows mapping of opt value onto matching variants
     # eg categorise_variants_from_option(color) => {"red" -> [...], "blue" -> [...]}
     def categorise_variants_from_option(opt_type)

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -148,6 +148,17 @@ describe Spree::Product, :type => :model do
       end
     end
 
+    context "#can_supply?" do
+      it "should be true" do
+        expect(product.can_supply?).to be(true)
+      end
+
+      it "should be false" do
+        product.variants_including_master.each { |v| v.stock_items.update_all count_on_hand: 0, backorderable: false }
+        expect(product.can_supply?).to be(false)
+      end
+    end
+
     context "variants_and_option_values" do
       let!(:high) { create(:variant, product: product) }
       let!(:low) { create(:variant, product: product) }

--- a/frontend/app/assets/javascripts/spree/frontend/product.js.coffee
+++ b/frontend/app/assets/javascripts/spree/frontend/product.js.coffee
@@ -33,15 +33,22 @@ Spree.ready ($) ->
   Spree.updateVariantPrice = (variant) ->
     variantPrice = variant.data('price')
     ($ '.price.selling').text(variantPrice) if variantPrice
+
+  Spree.disableCartForm = (variant) ->
+    inStock = variant.data('in-stock')
+    $('#add-to-cart-button').attr('disabled', !inStock)
+
   radios = ($ '#product-variants input[type="radio"]')
 
   if radios.length > 0
     selectedRadio = ($ '#product-variants input[type="radio"][checked="checked"]')
     Spree.showVariantImages selectedRadio.attr('value')
     Spree.updateVariantPrice selectedRadio
+    Spree.disableCartForm selectedRadio
+
+    radios.click (event) ->
+      Spree.showVariantImages @value
+      Spree.updateVariantPrice ($ this)
+      Spree.disableCartForm ($ this)
 
   Spree.addImageHandlers()
-
-  radios.click (event) ->
-    Spree.showVariantImages @value
-    Spree.updateVariantPrice ($ this)

--- a/frontend/app/views/spree/products/_cart_form.html.erb
+++ b/frontend/app/views/spree/products/_cart_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for :order, :url => populate_orders_path do |f| %>
+<%= form_for :order, url: populate_orders_path do |f| %>
   <div class="row" id="inside-product-cart-form" data-hook="inside_product_cart_form" itemprop="offers" itemscope itemtype="https://schema.org/Offer">
     <% if @product.variants_and_option_values(current_currency).any? %>
       <div id="product-variants" class="col-md-6">
@@ -6,7 +6,10 @@
         <ul class="list-group">
           <% @product.variants_and_option_values(current_currency).each_with_index do |variant, index| %>
             <li>
-              <%= radio_button_tag "variant_id", variant.id, index == 0, 'data-price' => variant.price_in(current_currency).money  %>
+              <%= radio_button_tag "variant_id", variant.id, index == 0,
+                  'data-price' => variant.price_in(current_currency).money, 
+                  'data-in-stock' => variant.can_supply?
+              %>
               <%= label_tag "variant_id_#{ variant.id }" do %>
                 <span class="variant-description">
                   <%= variant_options variant %>
@@ -26,7 +29,7 @@
       <%= hidden_field_tag "variant_id", @product.master.id %>
     <% end %>
 
-    <% if @product.price_in(current_currency) and !@product.price.nil? %>
+    <% if @product.price_in(current_currency) && !@product.price.nil? %>
       <div data-hook="product_price" class="col-md-5">
         <div id="product-price">
           <h6 class="product-section-title"><%= Spree.t(:price) %></h6>
@@ -45,22 +48,28 @@
           <% end %>
         </div>
 
-        <div class="add-to-cart">
-          <br/>
-          <div class="input-group">
-            <%= number_field_tag :quantity, 1, :class => 'title form-control', :min => 1 %>
-            <span class="input-group-btn">
-              <%= button_tag :class => 'btn btn-success', :id => 'add-to-cart-button', :type => :submit do %>
-                <%= Spree.t(:add_to_cart) %>
-              <% end %>
-            </span>
+        <% if @product.can_supply? %>
+          <div class="add-to-cart">
+            <br />
+            <div class="input-group">
+              <%= number_field_tag :quantity, 1, class: 'title form-control', min: 1 %>
+              <span class="input-group-btn">
+                <%= button_tag class: 'btn btn-success', id: 'add-to-cart-button', type: :submit do %>
+                  <%= Spree.t(:add_to_cart) %>
+                <% end %>
+              </span>
+            </div>
           </div>
-        </div>
+        <% end %>
       </div>
     <% else %>
       <div id="product-price">
-        <br>
-        <div><span class="price selling" itemprop="price"><%= Spree.t('product_not_available_in_this_currency') %></span></div>
+        <br />
+        <div>
+          <span class="price selling" itemprop="price">
+            <%= Spree.t('product_not_available_in_this_currency') %>
+          </span>
+        </div>
       </div>
     <% end %>
   </div>

--- a/frontend/spec/features/products_spec.rb
+++ b/frontend/spec/features/products_spec.rb
@@ -156,6 +156,15 @@ describe "Visiting Products", type: :feature, inaccessible: true do
         expect(page).not_to have_content Spree.t(:out_of_stock)
       end
     end
+
+    it "doesn't display cart form if all variants (including master) are out of stock" do
+      product.variants_including_master.each { |v| v.stock_items.update_all count_on_hand: 0, backorderable: false }
+
+      click_link product.name
+      within("[data-hook=product_price]") do
+        expect(page).not_to have_content Spree.t(:add_to_cart)
+      end
+    end
   end
 
   context "a product with variants, images only for the variants" do
@@ -172,6 +181,28 @@ describe "Visiting Products", type: :feature, inaccessible: true do
     it "should not display no image available" do
       visit spree.root_path
       expect(page).to have_xpath("//img[contains(@src,'thinking-cat')]")
+    end
+  end
+
+  context "an out of stock product without variants" do
+    let(:product) { Spree::Product.find_by_name("Ruby on Rails Tote") }
+
+    before do
+      product.master.stock_items.update_all count_on_hand: 0, backorderable: false
+    end
+
+    it "does display out of stock for master product" do
+      click_link product.name
+      within("#product-price") do
+        expect(page).to have_content Spree.t(:out_of_stock)
+      end
+    end
+
+    it "doesn't display cart form if master is out of stock" do
+      click_link product.name
+      within("[data-hook=product_price]") do
+        expect(page).not_to have_content Spree.t(:add_to_cart)
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #6941 which led to bad user experience and user frustration :)
### Product with variants
- out of stock variant when selected will disable the cart form's submit button
- out of stock variant will have "out of stock" notice near the variant name
### Product without variants
- out of stock notice visible under the price
- cart form not rendered at all  
- [x] out of stock cart form hidden for products without variants
- [x] javascript handling of changing variants and disabling cart form submit for out of stocked ones
- [x] feature specs
- [X] unit specs
- [X] fix typos
