### PR TITLE
Fixes #6888 and all other issues related to per_page dropdown

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -139,6 +139,32 @@ jQuery(function($) {
     }
   });
 
+  // per page dropdown
+  // preserves all selected filters / queries supplied by user
+  // changes only per_page value
+  $(".js-per-page-select").change(function() {
+    var form  = $(this).closest(".js-per-page-form");
+    var url   = form.attr('action');
+    var value = $(this).val().toString();
+    if (url.match(/\?/)) {
+      url += "&per_page=" + value;
+    } else {
+      url += "?per_page=" + value;
+    }
+    window.location = url;
+  });
+
+  // injects per_page settings to all available search forms
+  // so when user changes some filters / queries per_page is preserved
+  $(document).ready(function() {
+    var perPageDropdown = $(".js-per-page-select:first");
+    if (perPageDropdown.length) {
+      var perPageValue = perPageDropdown.val().toString();
+      var perPageInput = '<input type="hidden" name="per_page" value=' + perPageValue + ' />';
+      $("#table-filter form").append(perPageInput);
+    }
+  });
+
   // Enable sidebar toggle
   $("[data-toggle='offcanvas']").click(function(e) {
     e.preventDefault();

--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -99,6 +99,15 @@ module Spree
           { class: "form-control pull-right js-per-page-select" })
       end
 
+      # helper method to create proper url to apply per page filtering
+      # fixes https://github.com/spree/spree/issues/6888
+      def per_page_dropdown_params
+        args = params.clone
+        args.delete(:page)
+        args.delete(:per_page)
+        args
+      end
+
       # finds class for a given symbol / string
       #
       # Example :

--- a/backend/app/views/spree/admin/shared/_index_table_options.html.erb
+++ b/backend/app/views/spree/admin/shared/_index_table_options.html.erb
@@ -4,20 +4,10 @@
   </div>
   <div class="col-sm-6">
     <div class="pagination-wrap">
-      <%= form_tag({ action: :index }, { method: :get, class: 'js-per-page-form form-inline' }) do %>
+      <%= form_tag(per_page_dropdown_params, { method: :get, class: 'js-per-page-form form-inline' }) do %>
         <%= per_page_dropdown %>
       <% end %>
       <div class="clearfix"></div>
     </div>
   </div>
 </div>
-
-<% content_for :head do %>
-  <%= javascript_tag do %>
-    $(document).ready(function() {
-      $(".js-per-page-select").change(function() {
-        $(this).closest(".js-per-page-form").submit()
-      });
-    });
-  <% end %>
-<% end %>

--- a/backend/spec/features/admin/orders/listing_spec.rb
+++ b/backend/spec/features/admin/orders/listing_spec.rb
@@ -189,5 +189,34 @@ describe "Orders Listing", type: :feature do
         within("table#listing_orders") { expect(page).not_to have_content("R200") }
       end
     end
+
+    # regression tests for https://github.com/spree/spree/issues/6888
+    context "per page dropdown", js: true do
+      before do
+        select "45", from: "per_page"
+        sleep(1)
+        expect(page).to have_select("per_page", selected: "45")
+      end
+
+      it "adds per_page parameter to url" do
+        expect(current_url).to match(/per_page\=45/)
+      end
+
+      it "can be used with search filtering" do
+        click_on 'Filter'
+        fill_in "q_number_cont", with: "R200"
+        click_on 'Filter Results'
+        expect(page).not_to have_content("R100")
+        within_row(1) { expect(page).to have_content("R200") }
+        expect(current_url).to match(/per_page\=45/)
+        expect(page).to have_select("per_page", selected: "45")
+        select "60", from: "per_page"
+        sleep(1)
+        expect(page).to have_select("per_page", selected: "60")
+        expect(page).not_to have_content("R100")
+        within_row(1) { expect(page).to have_content("R200") }
+        expect(current_url).to match(/per_page\=60/)
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes bugs for admin per page dropdown:
- [X] User selects per page from dropdown -> user uses filtering/searching -> per page rollbacks to default value
- [X] User searches / filters records -> user selects per page from dropdown -> all filters are lost
- [X] feature specs

Related issues: #6888 
