### PR TITLE
suggest fix for tables overlapping the sidebar

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/shared/_base.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_base.scss
@@ -2,6 +2,10 @@ body {
   padding-top: $navbar-height + 2px;
 }
 
+.table-wrapper {
+  overflow: auto;
+}
+
 .row {
   padding: 0 0 15px 0;
 }

--- a/backend/app/views/spree/admin/payments/index.html.erb
+++ b/backend/app/views/spree/admin/payments/index.html.erb
@@ -20,7 +20,7 @@
 
 <% if @payments.any? %>
 
-  <div data-hook="payment_list" class="panel panel-default no-border-bottom">
+  <div data-hook="payment_list" class="panel panel-default no-border-bottom table-wrapper">
     <%= render partial: 'list', locals: { payments: @payments } %>
   </div>
 


### PR DESCRIPTION
wrap table in div, set div overflow to auto

The problem where the sidebar hovers over the table is especially prevalent when selecting the payments tab on an order.

<img width="396" alt="screen shot 2016-02-02 at 10 49 40 am" src="https://cloud.githubusercontent.com/assets/3095315/12755108/1bfdd46a-c99c-11e5-9b2a-df7d17efa37b.png">
