### PR TITLE
Remove validation unique_per_promotion in promotion_rule and modify options_for_promotion_rule_types for same.

### DIFF
--- a/backend/app/helpers/spree/promotion_rules_helper.rb
+++ b/backend/app/helpers/spree/promotion_rules_helper.rb
@@ -1,13 +1,9 @@
 module Spree
   module PromotionRulesHelper
-
     def options_for_promotion_rule_types(promotion)
-      existing = promotion.rules.map { |rule| rule.class.name }
-      rule_names = Rails.application.config.spree.promotions.rules.map(&:name).reject{ |r| existing.include? r }
+      rule_names = Rails.application.config.spree.promotions.rules.map(&:name)
       options = rule_names.map { |name| [ Spree.t("promotion_rule_types.#{name.demodulize.underscore}.name"), name] }
       options_for_select(options)
     end
- 
   end
 end
-

--- a/backend/spec/helpers/promotion_rules_helper_spec.rb
+++ b/backend/spec/helpers/promotion_rules_helper_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 module Spree
  describe Spree::PromotionRulesHelper, :type => :helper do
-   it "does not include existing rules in options" do
+   it "should include existing rules in options" do
      promotion = Spree::Promotion.new
      promotion.promotion_rules << Spree::Promotion::Rules::ItemTotal.new
 
      options = helper.options_for_promotion_rule_types(promotion)
-     expect(options).not_to match(/ItemTotal/)
+     expect(options).to match(/ItemTotal/)
    end
  end
 end

--- a/core/app/models/spree/promotion_rule.rb
+++ b/core/app/models/spree/promotion_rule.rb
@@ -5,8 +5,6 @@ module Spree
 
     scope :of_type, ->(t) { where(type: t) }
 
-    validate :unique_per_promotion, on: :create
-
     def self.for(promotable)
       all.select { |rule| rule.applicable?(promotable) }
     end
@@ -30,11 +28,6 @@ module Spree
     end
 
     private
-    def unique_per_promotion
-      if Spree::PromotionRule.exists?(promotion_id: promotion_id, type: self.class.name)
-        errors[:base] << "Promotion already contains this rule type"
-      end
-    end
 
     def eligibility_error_message(key, options = {})
       Spree.t(key, Hash[scope: [:eligibility_errors, :messages]].merge(options))

--- a/core/spec/models/spree/promotion_rule_spec.rb
+++ b/core/spec/models/spree/promotion_rule_spec.rb
@@ -5,25 +5,8 @@ module Spree
 
     class BadTestRule < Spree::PromotionRule; end
 
-    class TestRule < Spree::PromotionRule
-      def eligible?
-        true
-      end
-    end
-
     it "should force developer to implement eligible? method" do
       expect { BadTestRule.new.eligible? }.to raise_error(ArgumentError)
     end
-
-    it "validates unique rules for a promotion" do
-      p1 = TestRule.new
-      p1.promotion_id = 1
-      p1.save
-
-      p2 = TestRule.new
-      p2.promotion_id = 1
-      expect(p2).not_to be_valid
-    end
-
   end
 end


### PR DESCRIPTION
The validation is removed because there is no requirement to not allow two same rule can be applied to a same order.

But there may be cases like if a coupon code can be applied to a set of products either (A, B and C) or (A, D and C). So this case can only be solved if we may have multiple rules of same type product.
