### PR TITLE
Fix to only one tab selected when any link is clicked in admin products sub menu

### DIFF
--- a/backend/app/views/spree/admin/shared/sub_menu/_product.html.erb
+++ b/backend/app/views/spree/admin/shared/sub_menu/_product.html.erb
@@ -1,5 +1,5 @@
 <ul id="sidebar-product" class="collapse nav nav-pills nav-stacked" data-hook="admin_product_sub_tabs">
-  <%= tab *Spree::BackendConfiguration::PRODUCT_TABS %>
+  <%= tab :products %>
   <%= tab :option_types, :match_path => '/option_types' %>
   <%= tab :properties %>
   <%= tab :prototypes %>


### PR DESCRIPTION
In Admin -> SideBar -> Products tab
Click on any link in sub-menu , products link will be highlighted with the clicked link
Now after the fix, only the clicked link will be highlighted
