### PR TITLE
Remove register method from Calculator

### DIFF
--- a/core/app/models/spree/calculator.rb
+++ b/core/app/models/spree/calculator.rb
@@ -27,11 +27,6 @@ module Spree
       'Base Calculator'
     end
 
-    ###################################################################
-
-    def self.register(*klasses)
-    end
-
     # Returns all calculators applicable for kind of work
     def self.calculators
       Rails.application.config.spree.calculators


### PR DESCRIPTION
We are not using this method anymore. Now, we use to register calculators like this -

config = Rails.application.config
config.spree.calculators.tax_rates << CustomCalculator
config.spree.calculators.shipping_methods << CustomCalculator
config.spree.calculators.promotion_actions_create_adjustments << CustomCalculator
