### PR TITLE
Get rid of all the role related logic in Spree::Admin::UsersController

### DIFF
--- a/backend/app/controllers/spree/admin/users_controller.rb
+++ b/backend/app/controllers/spree/admin/users_controller.rb
@@ -7,8 +7,6 @@ module Spree
 
       # http://spreecommerce.com/blog/2010/11/02/json-hijacking-vulnerability/
       before_action :check_json_authenticity, only: :index
-      before_action :load_roles
-      before_action :extract_roles_from_params, only: [:create, :update]
 
       def index
         respond_with(@collection) do |format|
@@ -22,11 +20,8 @@ module Spree
       end
 
       def create
-
         @user = Spree.user_class.new(user_params)
         if @user.save
-          set_roles
-
           flash.now[:success] = flash_message_for(@user, :successfully_created)
           render :edit
         else
@@ -41,7 +36,6 @@ module Spree
         end
 
         if @user.update_attributes(user_params)
-          set_roles
           flash.now[:success] = Spree.t(:account_updated)
         end
 
@@ -112,21 +106,9 @@ module Spree
 
       private
 
-      def set_roles
-        if @roles_ids
-          @user.spree_roles = Spree::Role.where(id: @roles_ids)
-        end
-      end
-
-      def extract_roles_from_params
-        if params[:user]
-          @roles_ids = params[:user].delete("spree_role_ids")
-        end
-      end
-
       def user_params
         params.require(:user).permit(permitted_user_attributes |
-                                     [:spree_role_ids,
+                                     [spree_role_ids: [],
                                       ship_address_attributes: permitted_address_attributes,
                                       bill_address_attributes: permitted_address_attributes])
       end
@@ -156,10 +138,6 @@ module Spree
         if try_spree_current_user == @user && @user.password.present?
           sign_in(@user, event: :authentication, bypass: true)
         end
-      end
-
-      def load_roles
-        @roles = Spree::Role.all
       end
     end
   end

--- a/backend/app/views/spree/admin/users/_form.html.erb
+++ b/backend/app/views/spree/admin/users/_form.html.erb
@@ -8,15 +8,14 @@
 
     <div data-hook="admin_user_form_roles" class="form-group">
       <strong><%= Spree.t(:roles) %></strong>
-      <% @roles.each do |role| %>
+      <%= f.collection_check_boxes :spree_role_ids, Spree::Role.all, :id, :name do |role_form| %>
         <div class="checkbox">
-          <%= label_tag "user_spree_role_#{role.name}" do %>
-            <%= check_box_tag 'user[spree_role_ids][]', role.id, @user.spree_roles.include?(role), :id => "user_spree_role_#{role.name}" %>
-            <%= role.name %>
+          <%= role_form.label for: "user_spree_role_#{role_form.object.name}" do %>
+            <%= role_form.check_box id: "user_spree_role_#{role_form.object.name}" %>
+            <%= role_form.object.name %>
           <% end %>
         </div>
       <% end %>
-      <%= hidden_field_tag 'user[spree_role_ids][]', '' %>
     </div>
 
   </div>
@@ -28,7 +27,7 @@
       <%= f.error_message_on :password %>
     <% end %>
 
-    <%= f.field_container :password, class: ['form-group'] do %>
+    <%= f.field_container :password_confirmation, class: ['form-group'] do %>
       <%= f.label :password_confirmation, Spree.t(:confirm_password) %>
       <%= f.password_field :password_confirmation, :class => 'form-control' %>
       <%= f.error_message_on :password_confirmation %>


### PR DESCRIPTION
In this PR - **Spree::Admin::UsersController** has been cleaned up. 
All the roles related extra code has been removed by making use of [collection_check_boxes](http://apidock.com/rails/v4.0.2/ActionView/Helpers/FormOptionsHelper/collection_check_boxes) helper.

Following 2 bugs have been fixed:
- If a role is checked and form submitted but invalid - role becomes unchecked.
- If there is password_confirmation doesn't match password field - it displays error message but w/o any highlight.
