### PR TITLE
Remove current method from gateway

### DIFF
--- a/core/app/models/spree/gateway.rb
+++ b/core/app/models/spree/gateway.rb
@@ -13,11 +13,6 @@ module Spree
       CreditCard
     end
 
-    # instantiates the selected gateway and configures with the options stored in the database
-    def self.current
-      super
-    end
-
     def provider
       gateway_options = options
       gateway_options.delete :login if gateway_options.has_key?(:login) and gateway_options[:login].nil?


### PR DESCRIPTION
current method has been removed from the parent class PaymentMethod.

Hence, this method is no longer required and giving exception.
