### PR TITLE
Remove unnecessary method closed?

### DIFF
--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -73,10 +73,6 @@ module Spree
     extend DisplayMoney
     money_methods :amount
 
-    def closed?
-      state == "closed"
-    end
-
     def currency
       adjustable ? adjustable.currency : Spree::Config[:currency]
     end


### PR DESCRIPTION
`state_machine` provides this following boolean method.

Also did not remove specs so that the functioning of this method can be verified.
