### PR TITLE
spree cmd installer: don't use strict versioning for spree

### DIFF
--- a/cmd/lib/spree_cmd/installer.rb
+++ b/cmd/lib/spree_cmd/installer.rb
@@ -128,7 +128,7 @@ module SpreeCmd
       def gem(name, gem_options={})
         say_status :gemfile, name
         parts = ["'#{name}'"]
-        parts << ["'#{gem_options.delete(:version)}'"] if gem_options[:version]
+        parts << ["'~> #{gem_options.delete(:version)}'"] if gem_options[:version]
         gem_options.each { |key, value| parts << "#{key}: '#{value}'" }
         append_file 'Gemfile', "\ngem #{parts.join(', ')}", :verbose => false
       end


### PR DESCRIPTION
prevents version locking for minor stable releases
