### PR TITLE
Fix n+1 queries in frontend app - HomeController#index for promotions

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -36,6 +36,12 @@ module Spree
     has_many :product_promotion_rules, class_name: 'Spree::ProductPromotionRule'
     has_many :promotion_rules, through: :product_promotion_rules, class_name: 'Spree::PromotionRule'
 
+    has_many :promotions, through: :promotion_rules, class_name: 'Spree::Promotion'
+
+    has_many :possible_promotions, -> { advertised.active }, through: :promotion_rules,
+                                                             class_name: 'Spree::Promotion',
+                                                             source: :promotion
+
     belongs_to :tax_category, class_name: 'Spree::TaxCategory'
     belongs_to :shipping_category, class_name: 'Spree::ShippingCategory', inverse_of: :products
 
@@ -208,11 +214,6 @@ module Spree
         product_property.value = property_value
         product_property.save!
       end
-    end
-
-    def possible_promotions
-      promotion_ids = promotion_rules.map(&:promotion_id).uniq
-      Spree::Promotion.advertised.where(id: promotion_ids).reject(&:expired?)
     end
 
     def total_on_hand

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -27,19 +27,16 @@ module Spree
 
     before_save :normalize_blank_values
 
-    scope :coupons, ->{ where("#{table_name}.code IS NOT NULL") }
+    scope :coupons, -> { where("#{table_name}.code IS NOT NULL") }
     scope :applied, lambda {
       joins(<<-SQL).uniq
         INNER JOIN spree_order_promotions
         ON spree_order_promotions.promotion_id = #{table_name}.id
       SQL
     }
+    scope :advertised, -> { where(advertise: true) }
 
     self.whitelisted_ransackable_attributes = ['path', 'promotion_category_id', 'code']
-
-    def self.advertised
-      where(advertise: true)
-    end
 
     def self.with_coupon_code(coupon_code)
       where("lower(#{table_name}.code) = ?", coupon_code.strip.downcase).first

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -12,17 +12,14 @@ end
 describe Spree::Product, :type => :model do
 
   describe 'Associations' do
-    it do
+    it 'should have many promotions' do
       is_expected.to have_many(:promotions).
-                     class_name('Spree::Promotion').
-                     through(:promotion_rules)
+        class_name('Spree::Promotion').through(:promotion_rules)
     end
 
-    it do
+    it 'should have many possible_promotions' do
       is_expected.to have_many(:possible_promotions).
-                     class_name('Spree::Promotion').
-                     through(:promotion_rules).
-                     source(:promotion)
+        class_name('Spree::Promotion').through(:promotion_rules).source(:promotion)
     end
   end
 

--- a/frontend/app/controllers/spree/home_controller.rb
+++ b/frontend/app/controllers/spree/home_controller.rb
@@ -5,7 +5,7 @@ module Spree
 
     def index
       @searcher = build_searcher(params.merge(include_images: true))
-      @products = @searcher.retrieve_products
+      @products = @searcher.retrieve_products.includes(:possible_promotions)
       @taxonomies = Spree::Taxonomy.includes(root: :children)
     end
   end

--- a/frontend/app/controllers/spree/products_controller.rb
+++ b/frontend/app/controllers/spree/products_controller.rb
@@ -10,7 +10,7 @@ module Spree
 
     def index
       @searcher = build_searcher(params.merge(include_images: true))
-      @products = @searcher.retrieve_products
+      @products = @searcher.retrieve_products.includes(:possible_promotions)
       @taxonomies = Spree::Taxonomy.includes(root: :children)
     end
 


### PR DESCRIPTION
In the frontend app - on main homepage (HomeController#index) - there are a couple of promotion_rule and promotion queries being fired for each Spree::Product. The reason can be found [here](https://github.com/spree/spree/blob/master/core/app/helpers/spree/products_helper.rb#L62).

Fixed it by making the _possible_promotions_ a through relation on Spree::Product so that it can be  eager-loaded while loading products.

Similarly, fixed for ProductsController#index as well.
