### PR TITLE
Spree CMD installer: spree_auth_devise/spree_gateway from rubygems

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 
 # New Spree Commerce roadmap announcement
 
-We are excited to announce a new [Spree Commerce development roadmap](https://github.com/spree/spree/wiki/Spree-Commerce-development-roadmap-2016) for 2016 along with the new [Core Team](https://github.com/spree/spree/wiki/Core-Team). 
+We are excited to announce a new [Spree Commerce development roadmap](https://github.com/spree/spree/wiki/Spree-Commerce-development-roadmap-2016) for 2016 along with the new [Core Team](https://github.com/spree/spree/wiki/Core-Team).
 
-Future Spree open-source efforts will be coordinated and managed jointly by [Spark Solutions](http://sparksolutions.co) and [Vinsol](http://vinsol.com/) developers who are working daily for merchants using Spree and who have hands on experience in Spree development, customization, maintenance and performance optimization. 
+Future Spree open-source efforts will be coordinated and managed jointly by [Spark Solutions](http://sparksolutions.co) and [Vinsol](http://vinsol.com/) developers who are working daily for merchants using Spree and who have hands on experience in Spree development, customization, maintenance and performance optimization.
 
 We would be excited to welcome new [Core Team](https://github.com/spree/spree/wiki/Core-Team) members! You can make history and join the Core Team. We will evaluate you as a candidate based on the volume and quality of the code contributed to the project as well as sustained efforts in improving the overall quality of the Spree community.
 
-We are determined to support the current contributor community and businesses running Spree worldwide. Spree will be developed and maintained with the next versions to follow. 
+We are determined to support the current contributor community and businesses running Spree worldwide. Spree will be developed and maintained with the next versions to follow.
 
 Together we’ll not only develop future versions but we’ll support Spree developers around the world (mailing list, Slack channel, GitHub issues) in their daily efforts including migrations from 2.x. to 3.x versions.
 
 **For general discussion and support inquiries please use**:
 * Spree Slack public channels: http://slack.spreecommerce.com/
-* Spree Mailing List: https://groups.google.com/forum/#!forum/spree-user 
+* Spree Mailing List: https://groups.google.com/forum/#!forum/spree-user
 
 
 **THIS README IS FOR THE MASTER BRANCH OF SPREE AND REFLECTS THE WORK CURRENTLY
@@ -103,11 +103,11 @@ Using stable builds and bleeding edge
 -------------
 
 To use a stable build of Spree, you can manually add Spree to your
-Rails application. To use the 3-0-stable branch of Spree, add this line to
+Rails application. Add this line to
 your Gemfile.
 
 ```ruby
-gem 'spree', github: 'spree/spree', branch: '3-0-stable'
+gem 'spree'
 ```
 
 Alternatively, if you want to use the bleeding edge version of Spree, use this

--- a/cmd/lib/spree_cmd/installer.rb
+++ b/cmd/lib/spree_cmd/installer.rb
@@ -97,13 +97,13 @@ module SpreeCmd
         if @install_default_gateways && @spree_gem_options[:branch]
           gem :spree_gateway, github: 'spree/spree_gateway', branch: @spree_gem_options[:branch]
         elsif @install_default_gateways
-          gem :spree_gateway, github: 'spree/spree_gateway'
+          gem :spree_gateway, '~> 3.0.0'
         end
 
         if @install_default_auth && @spree_gem_options[:branch]
           gem :spree_auth_devise, github: 'spree/spree_auth_devise', branch: @spree_gem_options[:branch]
         elsif @install_default_auth
-          gem :spree_auth_devise, github: 'spree/spree_auth_devise'
+          gem :spree_auth_devise, '~> 3.0.0'
         end
 
         run 'bundle install', :capture => true


### PR DESCRIPTION
Both **spree_auth_devise** and **spree_gateway** will be updated on RubyGems so we don't need to fetch them from Github. It's better and safer to do it the proper way - from RubyGems.
