### PR TITLE
Correct initial state for checkouts API spec

### DIFF
--- a/api/spec/controllers/spree/api/v1/checkouts_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/checkouts_controller_spec.rb
@@ -241,7 +241,7 @@ module Spree
       end
 
       it "can transition from confirm to complete" do
-        order.update_columns(completed_at: Time.current, state: 'complete')
+        order.update_columns(state: 'confirm')
         allow_any_instance_of(Spree::Order).to receive_messages(payment_required?: false)
         api_put :update, id: order.to_param, order_token: order.guest_token
         expect(json_response['state']).to eq('complete')


### PR DESCRIPTION
This particular spec appears to intend to confirm that the `PUT` request updates the order from `confirm` to `complete`. However since [this commit](https://github.com/spree/spree/commit/0041f772651355e7c00c5ccba552f6652a16d651#diff-40c38c85d1d530f05baa1867558c0048R214) the initial state has incorrectly had the order already in the `complete` state:

``` ruby
it "can transition from confirm to complete" do
  order.update_columns(completed_at: Time.current, state: 'complete')
  allow_any_instance_of(Spree::Order).to receive_messages(payment_required?: false)
  api_put :update, id: order.to_param, order_token: order.guest_token
  expect(json_response['state']).to eq('complete')
  expect(response.status).to eq(200)
end
```

I've fixed the spec and also confirmed the spec can fail by breaking the implementation.

This change applies to master, 3-0-stable and 2-4-stable. I'm not 100% clear on what the contributing guide means when it says I should only have to create one PR so please let me know if I need to do anything else.

Thanks to @timrossinfo who was pairing with me when we found this.
