### PR TITLE
Load variants with valid prices

### DIFF
--- a/api/app/controllers/spree/api/v1/variants_controller.rb
+++ b/api/app/controllers/spree/api/v1/variants_controller.rb
@@ -24,8 +24,8 @@ module Spree
         # we render on the view so we better update it any time a node is included
         # or removed from the views.
         def index
-          @variants = scope.includes({ option_values: :option_type }, :product, :default_price, :images, { stock_items: :stock_location })
-            .ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
+          @variants = scope.includes(*variant_includes).for_currency_and_available_price_amount.
+                      ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
           respond_with(@variants)
         end
 
@@ -33,8 +33,7 @@ module Spree
         end
 
         def show
-          @variant = scope.includes({ option_values: :option_type }, :option_values, :product, :default_price, :images, { stock_items: :stock_location })
-            .find(params[:id])
+          @variant = scope.includes(*variant_includes).find(params[:id])
           respond_with(@variant)
         end
 
@@ -48,27 +47,33 @@ module Spree
         end
 
         private
-          def product
-            @product ||= Spree::Product.accessible_by(current_ability, :read).friendly.find(params[:product_id]) if params[:product_id]
+
+        def product
+          @product ||= Spree::Product.accessible_by(current_ability, :read).
+                       friendly.find(params[:product_id]) if params[:product_id]
+        end
+
+        def scope
+          variants = if @product
+                       @product.variants_including_master
+                     else
+                       Variant
+                     end
+
+          if current_ability.can?(:manage, Variant) && params[:show_deleted]
+            variants = variants.with_deleted
           end
 
-          def scope
-            if @product
-              variants = @product.variants_including_master
-            else
-              variants = Variant
-            end
+          variants.accessible_by(current_ability, :read)
+        end
 
-            if current_ability.can?(:manage, Variant) && params[:show_deleted]
-              variants = variants.with_deleted
-            end
+        def variant_params
+          params.require(:variant).permit(permitted_variant_attributes)
+        end
 
-            variants.accessible_by(current_ability, :read)
-          end
-
-          def variant_params
-            params.require(:variant).permit(permitted_variant_attributes)
-          end
+        def variant_includes
+          [{ option_values: :option_type }, :product, :default_price, :images, { stock_items: :stock_location }]
+        end
       end
     end
   end

--- a/api/spec/controllers/spree/api/v1/variants_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/variants_controller_spec.rb
@@ -20,6 +20,21 @@ module Spree
       stub_authentication!
     end
 
+    describe "#variant_includes" do
+      let(:variants_includes_list) do
+        [{ option_values: :option_type }, :product,
+          :default_price, :images, { stock_items: :stock_location }]
+      end
+      it { expect(controller).to receive(:variant_includes).and_return(variants_includes_list) }
+      after { api_get :index }
+    end
+
+    it "adds for_currency_and_available_price_amount scope to variants list" do
+      expect(Spree::Variant).to receive(:for_currency_and_available_price_amount).
+        and_return(Spree::Variant.for_currency_and_available_price_amount)
+      api_get :index
+    end
+
     it "can see a paginated list of variants" do
       api_get :index
       first_variant = json_response["variants"].first
@@ -157,7 +172,7 @@ module Spree
       # Test for #2141
       context "deleted variants" do
         before do
-          variant.update_column(:deleted_at, Time.current)
+          variant.update_columns(deleted_at: Time.current, discontinue_on: Time.current + 1)
         end
 
         it "are visible by admin" do

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -59,7 +59,7 @@ module Spree
 
     scope :not_deleted, -> { where("#{Variant.quoted_table_name}.deleted_at IS NULL") }
 
-    scope :for_currency_and_available_price_amount, -> (currency) do
+    scope :for_currency_and_available_price_amount, -> (currency = nil) do
       currency ||= Spree::Config[:currency]
       joins(:prices).where("spree_prices.currency = ?", currency).where("spree_prices.amount IS NOT NULL").uniq
     end

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -135,6 +135,14 @@ describe Spree::Variant, :type => :model do
           expect(Spree::Variant.for_currency_and_available_price_amount(currency)).to eq([variant])
         end
       end
+
+      context 'when currency parameter is nil' do
+        let!(:price_1) { create(:price, currency: currency, variant: variant, amount: 10) }
+
+        before { Spree::Config[:currency] = currency }
+
+        it { expect(Spree::Variant.for_currency_and_available_price_amount).to include(variant) }
+      end
     end
 
     describe '.active' do


### PR DESCRIPTION
While creating Order from backend, we can select variants with currency different from the configuration settings, which leads to exception while adding to cart. To fix this, add currency scope to api/variants#index action.
Optimized variant includes list for api/variants controller.
