### PR TITLE
Fix NoMethodError keys

### DIFF
--- a/api/app/controllers/spree/api/v1/taxons_controller.rb
+++ b/api/app/controllers/spree/api/v1/taxons_controller.rb
@@ -65,7 +65,7 @@ module Spree
           # Returns the products sorted by their position with the classification
           # Products#index does not do the sorting.
           taxon = Spree::Taxon.find(params[:id])
-          @products = taxon.products.ransack(params[:q]).result
+          @products = taxon.products.ransack(params[:q] || {}).result
           @products = @products.page(params[:page]).per(params[:per_page] || 500)
           render "spree/api/v1/products/index"
         end


### PR DESCRIPTION
When there's no q in params, it throws an error through ransack not finding a hash in `params[:q]`.
