### PR TITLE
Modify asset templates for test_app

### DIFF
--- a/core/lib/generators/spree/install/install_generator.rb
+++ b/core/lib/generators/spree/install/install_generator.rb
@@ -195,5 +195,23 @@ Spree::Auth::Engine.load_seed if defined?(Spree::Auth)
         puts "Enjoy!"
       end
     end
+
+    protected
+
+    def javascript_exists?(script)
+      extensions = %w(.coffee .erb .coffee.erb) + [""]
+      file_exists?(extensions, script)
+    end
+
+    def stylesheet_exists?(stylesheet)
+      extensions = %w(.scss .erb .scss.erb) + [""]
+      file_exists?(extensions, stylesheet)
+    end
+
+    def file_exists?(extensions, filename)
+      extensions.detect do |extension|
+        File.exists?("#{filename}.css#{extension}")
+      end
+    end
   end
 end

--- a/core/lib/generators/spree/install/templates/vendor/assets/javascripts/spree/backend/all.js
+++ b/core/lib/generators/spree/install/templates/vendor/assets/javascripts/spree/backend/all.js
@@ -8,6 +8,10 @@
 //= require jquery_ujs
 //= require spree/backend
 <% unless options[:lib_name] == 'spree' || options[:lib_name] == 'spree/backend' %>
-//= require spree/backend/<%= options[:lib_name].gsub("/", "_") %>
+  <% filename = "spree/backend/#{ options[:lib_name].gsub("/", "_") }" %>
+  <% filepath = File.join(File.dirname(__FILE__), "../../app/assets/javascripts/#{filename}") %>
+  <% if javascript_exists?(filepath) %>
+    //= require <%= filename %>
+  <% end %>
 <% end %>
 //= require_tree .

--- a/core/lib/generators/spree/install/templates/vendor/assets/javascripts/spree/frontend/all.js
+++ b/core/lib/generators/spree/install/templates/vendor/assets/javascripts/spree/frontend/all.js
@@ -8,6 +8,10 @@
 //= require jquery_ujs
 //= require spree/frontend
 <% unless options[:lib_name] == 'spree' || options[:lib_name] == 'spree/frontend' %>
-//= require spree/frontend/<%= options[:lib_name].gsub("/", "_") %>
+  <% filename = "spree/frontend/#{ options[:lib_name].gsub("/", "_") }" %>
+  <% filepath = File.join(File.dirname(__FILE__), "../../app/assets/javascripts/#{ filename }") %>
+  <% if javascript_exists?(filepath) %>
+    //= require <%= filename %>
+  <% end %>
 <% end %>
 //= require_tree .

--- a/core/lib/generators/spree/install/templates/vendor/assets/stylesheets/spree/backend/all.css
+++ b/core/lib/generators/spree/install/templates/vendor/assets/stylesheets/spree/backend/all.css
@@ -5,7 +5,11 @@
  *
  *= require spree/backend
 <% unless options[:lib_name] == 'spree' || options[:lib_name] == 'spree/backend'  %>
- *= require spree/backend/<%= options[:lib_name].gsub("/", "_") %>
+  <% filename = "spree/backend/#{ options[:lib_name].gsub("/", "_") }" %>
+  <% filepath = File.join(File.dirname(__FILE__), "../../app/assets/stylesheets/#{ filename }") %>
+  <% if stylesheet_exists?(filepath) %>
+    *= require <%= filename %>
+  <% end %>
 <% end %>
  *= require_self
  *= require_tree .

--- a/core/lib/generators/spree/install/templates/vendor/assets/stylesheets/spree/frontend/all.css
+++ b/core/lib/generators/spree/install/templates/vendor/assets/stylesheets/spree/frontend/all.css
@@ -5,7 +5,11 @@
  *
  *= require spree/frontend
 <% unless options[:lib_name] == 'spree' || options[:lib_name] == 'spree/frontend' %>
- *= require spree/frontend/<%= options[:lib_name].gsub("/", "_") %>
+  <% filename = "spree/frontend/#{ options[:lib_name].gsub("/", "_") }" %>
+  <% filepath = File.join(File.dirname(__FILE__), "../../app/assets/stylesheets/#{ filename }") %>
+  <% if stylesheet_exists?(filepath) %>
+    *= require <%= filename %>
+  <% end %>
 <% end %>
  *= require_self
  *= require_tree .


### PR DESCRIPTION
While building test_app, the generator requires asset files that may be absent in spree-extensions, which leads to build failure.
