### PR TITLE
Remove skip_before_action for #check_for_user_or_api_key and #set_exp…

### DIFF
--- a/api/app/controllers/spree/api/v1/countries_controller.rb
+++ b/api/app/controllers/spree/api/v1/countries_controller.rb
@@ -2,7 +2,6 @@ module Spree
   module Api
     module V1
       class CountriesController < Spree::Api::BaseController
-        skip_before_action :check_for_user_or_api_key
         skip_before_action :authenticate_user
 
         def index

--- a/api/app/controllers/spree/api/v1/orders_controller.rb
+++ b/api/app/controllers/spree/api/v1/orders_controller.rb
@@ -2,7 +2,6 @@ module Spree
   module Api
     module V1
       class OrdersController < Spree::Api::BaseController
-        skip_before_action :check_for_user_or_api_key, only: :apply_coupon_code
         skip_before_action :authenticate_user, only: :apply_coupon_code
 
         before_action :find_order, except: [:create, :mine, :current, :index, :update]

--- a/api/app/controllers/spree/api/v1/states_controller.rb
+++ b/api/app/controllers/spree/api/v1/states_controller.rb
@@ -2,8 +2,6 @@ module Spree
   module Api
     module V1
       class StatesController < Spree::Api::BaseController
-        skip_before_action :set_expiry
-        skip_before_action :check_for_user_or_api_key
         skip_before_action :authenticate_user
 
         def index


### PR DESCRIPTION
…iry since their definition is already removed

These were removed in these specified commits:

spree@3006d4a

spree@a0c727c
