### PR TITLE
Spree REST image API returning successful status code on create or update api although it has error.

### DIFF
--- a/api/app/controllers/spree/api/v1/images_controller.rb
+++ b/api/app/controllers/spree/api/v1/images_controller.rb
@@ -14,14 +14,21 @@ module Spree
 
         def create
           authorize! :create, Image
-          @image = scope.images.create(image_params)
-          respond_with(@image, status: 201, default_template: :show)
+          @image = scope.images.new(image_params)
+          if @image.save
+            respond_with(@image, status: 201, default_template: :show)
+          else
+            invalid_resource!(@image)
+          end
         end
 
         def update
           @image = scope.images.accessible_by(current_ability, :update).find(params[:id])
-          @image.update_attributes(image_params)
-          respond_with(@image, default_template: :show)
+          if @image.update_attributes(image_params)
+            respond_with(@image, default_template: :show)
+          else
+            invalid_resource!(@image)
+          end
         end
 
         def destroy

--- a/api/spec/controllers/spree/api/v1/images_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/images_controller_spec.rb
@@ -28,6 +28,15 @@ module Spree
         end.to change(Image, :count).by(1)
       end
 
+      it "can't upload a new image for a variant without attachment" do
+        api_post :create,
+                 image: { viewable_type: 'Spree::Variant',
+                          viewable_id: product.master.to_param
+                        },
+                 product_id: product.id
+        expect(response.status).to eq(422)
+      end
+
       context "working with an existing image" do
         let!(:product_image) { product.master.images.create!(:attachment => image('thinking-cat.jpg')) }
 
@@ -63,6 +72,13 @@ module Spree
           expect(response.status).to eq(200)
           expect(json_response).to have_attributes(attributes)
           expect(product_image.reload.position).to eq(2)
+        end
+
+        it "can't update a image without attachment" do
+          api_post :update,
+                   image: { attachment: nil },
+                   id: product_image.id, product_id: product.id
+          expect(response.status).to eq(422)
         end
 
         it "can delete an image" do


### PR DESCRIPTION
Resolve issue #6741
Image api returning wrong status code on error while create or update.
