### PR TITLE
possible fix for order details feature spec intermittent failure

### DIFF
--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -391,6 +391,9 @@ describe "Order Details", type: :feature, js: true do
               click_icon :add
             end
 
+            wait_for_ajax
+            order.reload
+
             within(".stock-contents") do
               expect(page).to have_content(product.name)
             end


### PR DESCRIPTION
Order Details as Admin Shipment edit page splitting to location site doesn't track inventory adds variant to order just fine
     Failure/Error: <strong class="stock-location-name" data-hook="stock-location-name">'<%= shipment.stock_location.name %>'</strong>

```
 ActionView::Template::Error:
   undefined method `name' for nil:NilClass
 # ./app/views/spree/admin/orders/_shipment.html.erb:11:in `_2a382851226fede67e83ab5d23f42b28'
 # ./app/views/spree/admin/orders/_form.html.erb:7:in `_341c3a92611a288ddfd99b90244598bd'
 # ./app/views/spree/admin/orders/edit.html.erb:27:in `_4c091a7d6bf48017c84f71cc1e11d9cf'
 # ------------------
 # --- Caused by: ---
 # NoMethodError:
 #   undefined method `name' for nil:NilClass
 #   ./app/views/spree/admin/orders/_shipment.html.erb:11:in `_2a382851226fede67e83ab5d23f42b28'
```
