### PR TITLE
Refactor products_controller move #find_order to before_action and ad…

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -124,9 +124,10 @@ module Spree
       end
 
       def find_product(id)
-        product_scope.friendly.find(id.to_s)
+        @product = product_scope.friendly.find(id.to_s)
       rescue ActiveRecord::RecordNotFound
-        product_scope.find(id)
+        @product = product_scope.find_by(id: id)
+        not_found unless @product
       end
 
       def product_scope

--- a/api/app/controllers/spree/api/v1/product_properties_controller.rb
+++ b/api/app/controllers/spree/api/v1/product_properties_controller.rb
@@ -2,7 +2,7 @@ module Spree
   module Api
     module V1
       class ProductPropertiesController < Spree::Api::BaseController
-        before_action :find_product
+        before_action :find_product, :authorize_product!
         before_action :product_property, only: [:show, :update, :destroy]
 
         def index
@@ -52,7 +52,10 @@ module Spree
         private
 
         def find_product
-          @product = super(params[:product_id])
+          super(params[:product_id])
+        end
+
+        def authorize_product!
           authorize! :read, @product
         end
 

--- a/api/app/controllers/spree/api/v1/products_controller.rb
+++ b/api/app/controllers/spree/api/v1/products_controller.rb
@@ -2,6 +2,7 @@ module Spree
   module Api
     module V1
       class ProductsController < Spree::Api::BaseController
+        before_action :find_product, only: [:update, :show, :destroy]
 
         def index
           if params[:ids]
@@ -17,7 +18,6 @@ module Spree
         end
 
         def show
-          @product = find_product(params[:id])
           expires_in 15.minutes, :public => true
           headers['Surrogate-Control'] = "max-age=#{15.minutes}"
           headers['Surrogate-Key'] = "product_id=1"
@@ -73,7 +73,6 @@ module Spree
         end
 
         def update
-          @product = find_product(params[:id])
           authorize! :update, @product
 
           options = { variants_attrs: variants_params, options_attrs: option_types_params }
@@ -87,39 +86,43 @@ module Spree
         end
 
         def destroy
-          @product = find_product(params[:id])
           authorize! :destroy, @product
           @product.destroy
           respond_with(@product, :status => 204)
         end
 
         private
-          def product_params
-            params.require(:product).permit(permitted_product_attributes)
-          end
 
-          def variants_params
-            variants_key = if params[:product].has_key? :variants
-              :variants
-            else
-              :variants_attributes
-            end
+        def product_params
+          params.require(:product).permit(permitted_product_attributes)
+        end
 
-            params.require(:product).permit(
-              variants_key => [permitted_variant_attributes, :id],
-            ).delete(variants_key) || []
-          end
+        def find_product
+          super(params[:id])
+        end
 
-          def option_types_params
-            params[:product].fetch(:option_types, [])
-          end
+        def variants_params
+          variants_key = if params[:product].has_key? :variants
+                           :variants
+                         else
+                           :variants_attributes
+                         end
 
-          def set_up_shipping_category
-            if shipping_category = params[:product].delete(:shipping_category)
-              id = ShippingCategory.find_or_create_by(name: shipping_category).id
-              params[:product][:shipping_category_id] = id
-            end
+          params.require(:product).permit(
+            variants_key => [permitted_variant_attributes, :id],
+          ).delete(variants_key) || []
+        end
+
+        def option_types_params
+          params[:product].fetch(:option_types, [])
+        end
+
+        def set_up_shipping_category
+          if shipping_category = params[:product].delete(:shipping_category)
+            id = ShippingCategory.find_or_create_by(name: shipping_category).id
+            params[:product][:shipping_category_id] = id
           end
+        end
       end
     end
   end


### PR DESCRIPTION
…d specs for find order
- Avoid raising exception #find_product rather handle it explicitly.
- Move find_product to before_action in ProductsController
- Add specs for #find_product
- ReIndent all private methods in ProductsController to fix Hound issues related to indentation.
- Segregate #find_product and #authorize_product! to avoid double render error.
