### PR TITLE
Security fixes

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
+++ b/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
@@ -25,7 +25,7 @@ $(document).ready(function() {
           }
         },
         results: function(data, page) {
-          return { results: data }
+          return { results: data.users }
         }
       },
       dropdownCssClass: 'customer_search',
@@ -53,7 +53,7 @@ $(document).ready(function() {
             });
           });
         }
-        return customer.email;
+        return Select2.util.escapeMarkup(customer.email);
       }
     })
   }

--- a/backend/app/assets/javascripts/spree/backend/option_type_autocomplete.js
+++ b/backend/app/assets/javascripts/spree/backend/option_type_autocomplete.js
@@ -1,6 +1,10 @@
 $(document).ready(function () {
   'use strict';
 
+  function formatOptionType(option_type) {
+    return Select2.util.escapeMarkup(option_type.presentation + ' (' + option_type.name + ')');
+  }
+
   if ($('#product_option_type_ids').length > 0) {
     $('#product_option_type_ids').select2({
       placeholder: Spree.translations.option_type_placeholder,
@@ -32,12 +36,8 @@ $(document).ready(function () {
           };
         }
       },
-      formatResult: function (option_type) {
-        return option_type.presentation + ' (' + option_type.name + ')';
-      },
-      formatSelection: function (option_type) {
-        return option_type.presentation + ' (' + option_type.name + ')';
-      }
+      formatResult: formatOptionType,
+      formatSelection: formatOptionType
     });
   }
 });

--- a/backend/app/assets/javascripts/spree/backend/product_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/product_picker.js
@@ -5,6 +5,10 @@ $.fn.productAutocomplete = function (options) {
   options = options || {};
   var multiple = typeof(options.multiple) !== 'undefined' ? options.multiple : true;
 
+  function formatProduct(product) {
+    return Select2.util.escapeMarkup(product.name);
+  }
+
   this.select2({
     minimumInputLength: 3,
     multiple: multiple,
@@ -35,12 +39,8 @@ $.fn.productAutocomplete = function (options) {
         };
       }
     },
-    formatResult: function (product) {
-      return product.name;
-    },
-    formatSelection: function (product) {
-      return product.name;
-    }
+    formatResult: formatProduct,
+    formatSelection: formatProduct
   });
 };
 

--- a/backend/app/assets/javascripts/spree/backend/stock_movement.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_movement.js.coffee
@@ -15,5 +15,5 @@ jQuery ->
         return { results: data.stock_items, more: more }
     formatResult: (stock_item) ->
       variantTemplate({ variant: stock_item.variant })
-    formatSelection: (stock_item) ->
-      "#{stock_item.variant.name} (#{stock_item.variant.options_text})"
+    formatSelection: (stock_item, container, excapeMarkup) ->
+      Select2.util.escapeMarkup("#{stock_item.variant.name} (#{stock_item.variant.options_text})")

--- a/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js
+++ b/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js
@@ -1,6 +1,10 @@
 'use strict';
 
 var set_taxon_select = function(selector){
+  function formatTaxon(taxon) {
+    return Select2.util.escapeMarkup(taxon.pretty_name);
+  }
+
   if ($(selector).length > 0) {
     $(selector).select2({
       placeholder: Spree.translations.taxon_placeholder,
@@ -37,12 +41,8 @@ var set_taxon_select = function(selector){
           };
         }
       },
-      formatResult: function (taxon) {
-        return taxon.pretty_name;
-      },
-      formatSelection: function (taxon) {
-        return taxon.pretty_name;
-      }
+      formatResult: formatTaxon,
+      formatSelection: formatTaxon
     });
   }
 }

--- a/backend/app/assets/javascripts/spree/backend/taxons.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/taxons.js.coffee
@@ -1,8 +1,10 @@
 $(document).ready ->
   window.productTemplate = Handlebars.compile($('#product_template').text());
   $('#taxon_products').sortable({
-      handle: ".js-sort-handle"
-    });
+    handle: ".js-sort-handle"
+  });
+  formatTaxon = (taxon) ->
+    Select2.util.escapeMarkup(taxon.pretty_name)
   $('#taxon_products').on "sortstop", (event, ui) ->
     $.ajax
       url: Spree.routes.classifications_api,
@@ -32,10 +34,8 @@ $(document).ready ->
           more = page < data.pages;
           results: data['taxons'],
           more: more
-      formatResult: (taxon) ->
-        taxon.pretty_name;
-      formatSelection: (taxon) ->
-        taxon.pretty_name;
+      formatResult: formatTaxon,
+      formatSelection: formatTaxon
 
   $('#taxon_id').on "change", (e) ->
     el = $('#taxon_products')

--- a/backend/app/assets/javascripts/spree/backend/user_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/user_picker.js
@@ -1,6 +1,10 @@
 $.fn.userAutocomplete = function () {
   'use strict';
 
+  function formatUser(user) {
+    return Select2.util.escapeMarkup(user.email);
+  }
+
   this.select2({
     minimumInputLength: 1,
     multiple: true,
@@ -8,7 +12,7 @@ $.fn.userAutocomplete = function () {
       $.get(Spree.routes.user_search, {
         ids: element.val()
       }, function (data) {
-        callback(data);
+        callback(data.users);
       });
     },
     ajax: {
@@ -22,16 +26,12 @@ $.fn.userAutocomplete = function () {
       },
       results: function (data) {
         return {
-          results: data
+          results: data.users
         };
       }
     },
-    formatResult: function (user) {
-      return user.email;
-    },
-    formatSelection: function (user) {
-      return user.email;
-    }
+    formatResult: formatUser,
+    formatSelection: formatUser
   });
 };
 

--- a/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js.coffee
@@ -31,8 +31,8 @@ $.fn.variantAutocomplete = ->
         results: data["variants"]
 
     formatResult: formatVariantResult
-    formatSelection: (variant) ->
+    formatSelection: (variant, container, escapeMarkup) ->
       if !!variant.options_text
-        variant.name + " (#{variant.options_text})"
+        Select2.util.escapeMarkup("#{variant.name} (#{variant.options_text})")
       else
-        variant.name
+        Select2.util.escapeMarkup(variant.name)

--- a/backend/app/helpers/spree/admin/adjustments_helper.rb
+++ b/backend/app/helpers/spree/admin/adjustments_helper.rb
@@ -22,7 +22,7 @@ module Spree
         parts << variant.product.name
         parts << "(#{variant.options_text})" if variant.options_text.present?
         parts << line_item.display_total
-        parts.join("<br>").html_safe
+        safe_join(parts, "<br />".html_safe)
       end
 
       def display_shipment(shipment)

--- a/backend/app/helpers/spree/admin/base_helper.rb
+++ b/backend/app/helpers/spree/admin/base_helper.rb
@@ -8,7 +8,7 @@ module Spree
           flash_class = "info" if flash[:notice]
           flash_class = "success" if flash[:success]
           flash_div = content_tag(:div, message, class: "alert alert-#{flash_class} alert-auto-disappear")
-          content_tag(:div, flash_div, class: 'col-md-12')          
+          content_tag(:div, flash_div, class: 'col-md-12')
         end
       end
 
@@ -26,7 +26,7 @@ module Spree
         obj = object.respond_to?(:errors) ? object : instance_variable_get("@#{object}")
 
         if obj && obj.errors[method].present?
-          errors = obj.errors[method].map { |err| h(err) }.join('<br />').html_safe
+          errors = safe_join(obj.errors[method], '<br />'.html_safe)
           content_tag(:span, errors, class: 'formError')
         else
           ''
@@ -117,12 +117,13 @@ module Spree
 
       def preference_fields(object, form)
         return unless object.respond_to?(:preferences)
-        object.preferences.keys.map{ |key|
-        if object.has_preference?(key)
-          form.label("preferred_#{key}", Spree.t(key) + ": ") +
-            preference_field_for(form, "preferred_#{key}", type: object.preference_type(key))
-        end
-        }.join("<br />").html_safe
+        fields = object.preferences.keys.map { |key|
+          if object.has_preference?(key)
+            form.label("preferred_#{key}", Spree.t(key) + ": ") +
+              preference_field_for(form, "preferred_#{key}", type: object.preference_type(key))
+          end
+        }
+        safe_join(fields, '<br />'.html_safe)
       end
 
       # renders hidden field and link to remove record using nested_attributes

--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -161,7 +161,7 @@ module Spree
         options[:class] = (options[:class].to_s + " icon-link with-tip action-#{icon_name}").strip
         options[:class] += ' no-text' if options[:no_text]
         options[:title] = text if options[:no_text]
-        text = options[:no_text] ? '' : raw("<span class='text'>#{text}</span>")
+        text = options[:no_text] ? '' : content_tag(:span, text, class: 'text')
         options.delete(:no_text)
         if icon_name
           icon = content_tag(:span, '', class: "icon icon-#{icon_name}")

--- a/backend/app/helpers/spree/admin/orders_helper.rb
+++ b/backend/app/helpers/spree/admin/orders_helper.rb
@@ -16,7 +16,7 @@ module Spree
             )
           end
         end
-        links.join(' ').html_safe
+        safe_join(links, '&nbsp;'.html_safe)
       end
 
       def line_item_shipment_price(line_item, quantity)

--- a/backend/app/helpers/spree/admin/products_helper.rb
+++ b/backend/app/helpers/spree/admin/products_helper.rb
@@ -9,7 +9,8 @@ module Spree
                       :selected => ('selected' if selected)) do
             (taxon.ancestors.pluck(:name) + [taxon.name]).join(" -> ")
           end
-        end.join("").html_safe
+        end
+        safe_join(options)
       end
 
       def option_types_options_for(product)
@@ -20,7 +21,8 @@ module Spree
                       :selected => ('selected' if selected)) do
             option_type.name
           end
-        end.join("").html_safe
+        end
+        safe_join(options)
       end
     end
   end

--- a/backend/app/helpers/spree/admin/stock_movements_helper.rb
+++ b/backend/app/helpers/spree/admin/stock_movements_helper.rb
@@ -15,9 +15,9 @@ module Spree
 
       def display_variant(stock_movement)
         variant = stock_movement.stock_item.variant
-        output = variant.name
-        output += "<br>(#{variant.options_text})" unless variant.options_text.blank?
-        output.html_safe
+        output = [variant.name]
+        output << variant.options_text unless variant.options_text.blank?
+        safe_join(output, '<br />'.html_safe)
       end
     end
   end

--- a/backend/app/views/spree/admin/search/users.rabl
+++ b/backend/app/views/spree/admin/search/users.rabl
@@ -1,4 +1,4 @@
-collection(@users)
+collection(@users => :users)
 attributes :email, :id
 address_fields = [:firstname, :lastname,
   :address1, :address2,

--- a/frontend/app/helpers/spree/frontend_helper.rb
+++ b/frontend/app/helpers/spree/frontend_helper.rb
@@ -84,10 +84,11 @@ module Spree
     def taxons_tree(root_taxon, current_taxon, max_level = 1)
       return '' if max_level < 1 || root_taxon.leaf?
       content_tag :div, class: 'list-group' do
-        root_taxon.children.map do |taxon|
+        taxons = root_taxon.children.map do |taxon|
           css_class = (current_taxon && current_taxon.self_and_ancestors.include?(taxon)) ? 'list-group-item active' : 'list-group-item'
           link_to(taxon.name, seo_url(taxon), class: css_class) + taxons_tree(taxon, current_taxon, max_level - 1)
-        end.join("\n").html_safe
+        end
+        safe_join(taxons, "\n")
       end
     end
   end


### PR DESCRIPTION
Fixes supplied by @jhawthorn - thank you!

**select2 will render HTML returned from formatResult and formatSelection.**

Users are intended to use the escapeMarkup method when writing these
methods.

An attacker could inject HTML into the admin be signing up with a
specially crafted email address.

**If link_to_with_icon was called with an unsafe (!html_safe?) text attribute it would render it on the page without escaping.**

This is never used in an unsafe way in the spree admin itself, but
it could be dangerous in custom admin components.

**Use safe_join instead of html_safe where possible**

These methods were joining safe and unsafe strings and then considering the output safe.

Especially concerning are display_line_item and display_variant could likely allow an user with admin permissions to inject HTML unescaped into the admin.

**admin/search#users should be top-level JSON object**

Returning a top level array is vulnerable to JSON hijacking, as the
JSON can be interpreted as valid javascript.
