### PR TITLE
Reorder send_core_emails preference

### DIFF
--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -49,6 +49,7 @@ module Spree
     preference :require_master_price, :boolean, default: true
     preference :restock_inventory, :boolean, default: true # Determines if a return item is restocked automatically once it has been received
     preference :return_eligibility_number_of_days, :integer, default: 365
+    preference :send_core_emails, :boolean, default: true # Default mail headers settings
     preference :shipping_instructions, :boolean, default: false # Request instructions/info for shipping
     preference :show_only_complete_orders_by_default, :boolean, default: true
     preference :show_variant_full_price, :boolean, default: false #Displays variant full price or difference with product price. Default false to be compatible with older behavior
@@ -56,9 +57,6 @@ module Spree
     preference :show_raw_product_description, :boolean, default: false
     preference :tax_using_ship_address, :boolean, default: true
     preference :track_inventory_levels, :boolean, default: true # Determines whether to track on_hand values for variants / products.
-
-    # Default mail headers settings
-    preference :send_core_emails, :boolean, default: true
 
     # searcher_class allows spree extension writers to provide their own Search class
     def searcher_class


### PR DESCRIPTION
All the preferences defined in AppConfiguration class are ordered alphabetically except send_core_emails, so it will be good to have it in the order too.
