### PR TITLE
Validate countries states_required attribute when states present

### DIFF
--- a/core/app/models/spree/country.rb
+++ b/core/app/models/spree/country.rb
@@ -14,6 +14,7 @@ module Spree
     before_destroy :ensure_not_default
 
     validates :name, :iso_name, presence: true, uniqueness: { case_sensitive: false, allow_blank: true }
+    validate :can_have_states?, if: :states_required_changed?
 
     def self.default
       country_id = Spree::Config[:default_country_id]
@@ -34,6 +35,12 @@ module Spree
       if id.eql?(Spree::Config[:default_country_id])
         errors.add(:base, Spree.t(:default_country_cannot_be_deleted))
         false
+      end
+    end
+
+    def can_have_states?
+      if !states_required? && states.present?
+        errors.add(:states_required, Spree.t(:states_required_invalid))
       end
     end
   end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1299,6 +1299,7 @@ en:
       shipped: Shipped
       void: Void
     states_required: States Required
+    states_required_invalid: is set to not allow states for this country.
     status: Status
     stock: Stock
     stock_location: Stock Location


### PR DESCRIPTION
Issue: states_required attribute of a country gets unchecked even if already has states.

Expected:
states_required attribute of a country shouldn't be unchecked if it already have states.
