### PR TITLE
Save many queries in products store

### DIFF
--- a/core/app/helpers/spree/products_helper.rb
+++ b/core/app/helpers/spree/products_helper.rb
@@ -52,7 +52,7 @@ module Spree
     end
 
     def cache_key_for_products
-      count = @products.count
+      count = @products.length
       max_updated_at = (@products.maximum(:updated_at) || Date.today).to_s(:number)
       products_cache_keys = "spree/products/all-#{params[:page]}-#{max_updated_at}-#{count}"
       (common_product_cache_keys + [products_cache_keys]).compact.join("/")

--- a/core/spec/helpers/products_helper_spec.rb
+++ b/core/spec/helpers/products_helper_spec.rb
@@ -206,7 +206,7 @@ THIS IS THE BEST PRODUCT EVER!
       context 'when there is a maximum updated date' do
         let(:updated_at) { Date.new(2011, 12, 13) }
         before :each do
-          allow(@products).to receive(:count) { 5 }
+          allow(@products).to receive(:length).and_return(5)
           allow(@products).to receive(:maximum).with(:updated_at) { updated_at }
         end
 
@@ -216,7 +216,7 @@ THIS IS THE BEST PRODUCT EVER!
       context 'when there is no considered maximum updated date' do
         let(:today) { Date.new(2013, 12, 11) }
         before :each do
-          allow(@products).to receive(:count) { 1234567 }
+          allow(@products).to receive(:length).and_return(1234567)
           allow(@products).to receive(:maximum).with(:updated_at) { nil }
           allow(Date).to receive(:today) { today }
         end

--- a/frontend/app/views/spree/products/index.html.erb
+++ b/frontend/app/views/spree/products/index.html.erb
@@ -1,4 +1,4 @@
-<% if "spree/products" == params[:controller] && @taxon || !@taxonomies.empty? %>
+<% if "spree/products" == params[:controller] && @taxon || @taxonomies.present? %>
   <% content_for :sidebar do %>
     <div data-hook="homepage_sidebar_navigation">
       <% if "spree/products" == params[:controller] && @taxon %>
@@ -12,7 +12,7 @@
 
 <% if params[:keywords] %>
   <div data-hook="search_results">
-    <% if @products.empty? %>
+    <% if !@products.present? %>
       <h6 class="search-results-title"><%= Spree.t(:no_products_found) %></h6>
     <% else %>
       <%= render :partial => 'spree/shared/products', :locals => { :products => @products, :taxon => @taxon } %>

--- a/frontend/app/views/spree/shared/_products.html.erb
+++ b/frontend/app/views/spree/shared/_products.html.erb
@@ -1,11 +1,5 @@
-<% content_for :head do %>
-  <% if products.respond_to?(:num_pages) %>
-    <%= rel_next_prev_link_tags products %>
-  <% end %>
-<% end %>
-
 <div data-hook="products_search_results_heading">
-  <% if products.empty? %>
+  <% if !products.present? %>
     <div data-hook="products_search_results_heading_no_results_found">
       <%= Spree.t(:no_products_found) %>
     </div>
@@ -16,7 +10,7 @@
   <% end %>
 </div>
 
-<% if products.any? %>
+<% if products.present? %>
   <div id="products" class="row" data-hook>
     <% products.each do |product| %>
       <% url = spree.product_url(product, taxon_id: @taxon.try(:id)) %>
@@ -41,8 +35,10 @@
     <% end %>
     <% reset_cycle("classes") %>
   </div>
+
+  <% if products.respond_to?(:num_pages) %>
+    <%= paginate products, theme: 'twitter-bootstrap-3' %>
+  <% end %>
+
 <% end %>
 
-<% if products.respond_to?(:num_pages) %>
-  <%= paginate products, theme: 'twitter-bootstrap-3' %>
-<% end %>


### PR DESCRIPTION
Count queries and cached count queries for products are reduced and pagination in content_for :head was not required so it was removed
Now only 3 queries regarding products listing are fired 1 count (pagination) , 1 max query, 1 data load query
Also one count query saved by using length instead of count to load data because it is required on the page.
