### PR TITLE
Modify option_values presence validation in variant model

### DIFF
--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -38,7 +38,9 @@ module Spree
 
     validate :check_price
 
-    validates :option_values, presence: true, unless: :is_master?
+    ## Override +option_values_required?+ if it is not necessary
+    ## to have option_values present to create a variant.
+    validates :option_values, presence: true, if: :option_values_required_and_not_master?
 
     with_options numericality: { greater_than_or_equal_to: 0, allow_nil: true } do
       validates :cost_price
@@ -257,6 +259,14 @@ module Spree
     end
 
     private
+
+    def option_values_required_and_not_master?
+      option_values_required? && !is_master?
+    end
+
+    def option_values_required?
+      true
+    end
 
     def ensure_no_line_items
       if line_items.any?

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -9,8 +9,25 @@ describe Spree::Variant, :type => :model do
   it_behaves_like 'default_price'
 
   describe 'validations' do
-    it { expect(master_variant).to_not validate_presence_of(:option_values) }
-    it { expect(variant).to validate_presence_of(:option_values) }
+    context 'when option values are required' do
+      before do
+        allow(master_variant).to receive(:option_values_required?).and_return(true)
+        allow(variant).to receive(:option_values_required?).and_return(true)
+      end
+
+      it { expect(master_variant).to_not validate_presence_of(:option_values) }
+      it { expect(variant).to validate_presence_of(:option_values) }
+    end
+
+    context 'when option values are not required' do
+      before do
+        allow(master_variant).to receive(:option_values_required?).and_return(false)
+        allow(variant).to receive(:option_values_required?).and_return(false)
+      end
+
+      it { expect(master_variant).to_not validate_presence_of(:option_values) }
+      it { expect(variant).to_not validate_presence_of(:option_values) }
+    end
   end
 
   context 'sorting' do
@@ -702,6 +719,66 @@ describe Spree::Variant, :type => :model do
         it { expect(variant.available?).to be(false) }
       end
     end
+  end
+
+  describe '#option_values_required_and_not_master?' do
+    context 'when option values are required' do
+      before do
+        allow(variant).to receive(:option_values_required?).and_return(true)
+      end
+
+      context 'when master' do
+        before do
+          allow(variant).to receive(:is_master?).and_return(true)
+        end
+
+        subject { variant.send(:option_values_required_and_not_master?) }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when not master' do
+        before do
+          allow(variant).to receive(:is_master?).and_return(false)
+        end
+
+        subject { variant.send(:option_values_required_and_not_master?) }
+
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when option values are not required' do
+      before do
+        allow(variant).to receive(:option_values_required?).and_return(false)
+      end
+
+      context 'when master' do
+        before do
+          allow(variant).to receive(:is_master?).and_return(true)
+        end
+
+        subject { variant.send(:option_values_required_and_not_master?) }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when not master' do
+        before do
+          allow(variant).to receive(:is_master?).and_return(false)
+        end
+
+        subject { variant.send(:option_values_required_and_not_master?) }
+
+        it { is_expected.to be false }
+      end
+    end
+  end
+
+  describe '#option_values_required?' do
+    subject { variant.send(:option_values_required?) }
+
+    it { is_expected.to be true }
   end
 
   describe "#check_price" do


### PR DESCRIPTION
There may be cases in which we want variant not on the basis of option values, like in cases of gift cards, they are not differentiated on the basis of any option value.

So, it is good to have a way to bypass option_values presence validation.
