### PR TITLE
Add StateMachines::Machine.ignore_method_conflicts in initializer

### DIFF
--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -38,8 +38,6 @@ module Spree
 
             klass = self
 
-            # To avoid a ton of warnings when the state machine is re-defined
-            StateMachines::Machine.ignore_method_conflicts = true
             # To avoid multiple occurrences of the same transition being defined
             # On first definition, state_machines will not be defined
             state_machines.clear if respond_to?(:state_machines)

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -15,6 +15,10 @@ require 'ransack'
 require 'responders'
 require 'state_machines-activerecord'
 
+# This is required because ActiveModel::Validations#invalid? conflicts with the
+# invalid state of a Payment. In the future this should be removed.
+StateMachines::Machine.ignore_method_conflicts = true
+
 module Spree
 
   mattr_accessor :user_class


### PR DESCRIPTION
This PR removed the ugly warning from State Machines gem. In the future, it should be handled better. Based on https://github.com/solidusio/solidus/commit/cefd6a744324f8f2b32b5fcada4dc3ccb7f2a5f1
