### PR TITLE
Avoid warnings when running migrations

### DIFF
--- a/core/db/migrate/20130228210442_create_shipping_method_zone.rb
+++ b/core/db/migrate/20130228210442_create_shipping_method_zone.rb
@@ -1,16 +1,15 @@
 class CreateShippingMethodZone < ActiveRecord::Migration
+  class ShippingMethodZone < ActiveRecord::Base
+    self.table_name = 'shipping_methods_zones'
+  end
   def up
     create_table :shipping_methods_zones, :id => false do |t|
       t.integer :shipping_method_id
       t.integer :zone_id
     end
-    # This association has been corrected in a latter migration
-    # but when this database migration runs, the table is still incorrectly named
-    # 'shipping_methods_zones' instead of 'spre_shipping_methods_zones'
-    Spree::ShippingMethod.has_and_belongs_to_many :zones, :join_table => 'shipping_methods_zones',
-                                                          :class_name => 'Spree::Zone',
-                                                          :foreign_key => 'shipping_method_id'
-    Spree::ShippingMethod.all.each{|sm| sm.zones << Spree::Zone.find(sm.zone_id)}
+    Spree::ShippingMethod.all.each do |sm|
+      ShippingMethodZone.create!(zone_id: sm.zone_id, shipping_method_id: sm.id)
+    end
 
     remove_column :spree_shipping_methods, :zone_id
   end

--- a/core/db/migrate/20130611054351_rename_shipping_methods_zones_to_spree_shipping_methods_zones.rb
+++ b/core/db/migrate/20130611054351_rename_shipping_methods_zones_to_spree_shipping_methods_zones.rb
@@ -1,10 +1,5 @@
 class RenameShippingMethodsZonesToSpreeShippingMethodsZones < ActiveRecord::Migration
   def change
     rename_table :shipping_methods_zones, :spree_shipping_methods_zones
-    # If Spree::ShippingMethod zones association was patched in
-    # CreateShippingMethodZone migrations, it needs to be patched back
-    Spree::ShippingMethod.has_and_belongs_to_many :zones, :join_table => 'spree_shipping_methods_zones',
-                                                          :class_name => 'Spree::Zone',
-                                                          :foreign_key => 'shipping_method_id'
   end
 end


### PR DESCRIPTION
This simpler migration avoids two warnings on every full migration,
which is part of every run of `rake test_app`

backported from https://github.com/solidusio/solidus/commit/87a344115273e377729de9c3de01e1d868e726b5
