### PR TITLE
Add missing translation of store credit

### DIFF
--- a/backend/app/views/spree/admin/payments/source_views/_storecredit.html.erb
+++ b/backend/app/views/spree/admin/payments/source_views/_storecredit.html.erb
@@ -1,5 +1,5 @@
 <fieldset data-hook="store_credit">
-  <legend><%= Spree.t( Spree::StoreCredit.model_name.human ) %></legend>
+  <legend><%= Spree.t(:store_credit) %></legend>
   <table class="table table-condensed table-bordered">
     <tr>
       <th width="20%"><%= Spree.t(:used) %>:</th>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1339,6 +1339,7 @@ en:
     stock_transfers: Stock Transfers
     stop: Stop
     store: Store
+    store_credit: Store Credit
     store_credit:
       credit: "Credit"
       authorized: "Authorized"

--- a/frontend/app/views/spree/checkout/_summary.html.erb
+++ b/frontend/app/views/spree/checkout/_summary.html.erb
@@ -64,7 +64,7 @@
 
     <% if order.using_store_credit? %>
       <tr data-hook="order_details_store_credit">
-        <td><%= Spree.t( Spree::StoreCredit.model_name.human ) %>:</strong></td>
+        <td><%= Spree.t(:store_credit) %>:</strong></td>
         <td><span id='summary-store-credit'><%= order.display_total_applied_store_credit.to_html %></span></td>
       </tr>
     <% end %>


### PR DESCRIPTION
- Changing Spree.t(Spree::StoreCredit.model_name.human) to Spree.t(:store_credit) in _summary.html.erb since earlier code used to send 'Store Credit' for translation and Spree.t would only try find translation of 'Store' instead for whole 'Store Credit'. Avoided using Spree::StoreCredit.model_name.human.downcase.parameterize.underscore.
- Found missing translations: [["spree.Store"]] In spec: ./spec/features/checkout_spec.rb:530
  Added translation for store_credit
