### PR TITLE
adding missing new view templates for API endpoints

### DIFF
--- a/api/app/views/spree/api/v1/images/new.v1.rabl
+++ b/api/app/views/spree/api/v1/images/new.v1.rabl
@@ -1,0 +1,3 @@
+object false
+node(:attributes) { [*image_attributes] }
+node(:required_attributes) { required_fields_for(Spree::Image) }

--- a/api/app/views/spree/api/v1/option_types/new.v1.rabl
+++ b/api/app/views/spree/api/v1/option_types/new.v1.rabl
@@ -1,0 +1,3 @@
+object false
+node(:attributes) { [*option_type_attributes] }
+node(:required_attributes) { required_fields_for(Spree::OptionType) }

--- a/api/app/views/spree/api/v1/option_values/new.v1.rabl
+++ b/api/app/views/spree/api/v1/option_values/new.v1.rabl
@@ -1,0 +1,3 @@
+object false
+node(:attributes) { [*option_value_attributes] }
+node(:required_attributes) { required_fields_for(Spree::OptionValue) }


### PR DESCRIPTION
I've found a few API endpoints that are valid routes but are 404-ing right now
/api/v1/option_types/new
/api/v1/option_values/new
/api/v1/products/:product_id/images/new 

All are valid routes but 404 because missing views.  This commit just adds those missing views.
