### PR TITLE
add missing views for image, option_type, option_value API controllers

### DIFF
--- a/api/app/views/spree/api/v1/images/new.v1.rabl
+++ b/api/app/views/spree/api/v1/images/new.v1.rabl
@@ -1,0 +1,3 @@
+object false
+node(:attributes) { [*image_attributes] }
+node(:required_attributes) { required_fields_for(Spree::Image) }

--- a/api/app/views/spree/api/v1/option_types/new.v1.rabl
+++ b/api/app/views/spree/api/v1/option_types/new.v1.rabl
@@ -1,0 +1,3 @@
+object false
+node(:attributes) { [*option_type_attributes] }
+node(:required_attributes) { required_fields_for(Spree::OptionType) }

--- a/api/app/views/spree/api/v1/option_values/new.v1.rabl
+++ b/api/app/views/spree/api/v1/option_values/new.v1.rabl
@@ -1,0 +1,3 @@
+object false
+node(:attributes) { [*option_value_attributes] }
+node(:required_attributes) { required_fields_for(Spree::OptionValue) }

--- a/api/spec/controllers/spree/api/v1/images_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/images_controller_spec.rb
@@ -16,6 +16,12 @@ module Spree
     context "as an admin" do
       sign_in_as_admin!
 
+      it "can learn how to create a new image" do
+        api_get :new, product_id: product.id
+        expect(json_response["attributes"]).to eq(attributes.map(&:to_s))
+        expect(json_response["required_attributes"]).to be_empty
+      end
+
       it "can upload a new image for a variant" do
         expect do
           api_post :create,

--- a/api/spec/controllers/spree/api/v1/option_types_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/option_types_controller_spec.rb
@@ -4,7 +4,7 @@ module Spree
   describe Api::V1::OptionTypesController, :type => :controller do
     render_views
 
-    let(:attributes) { [:id, :name, :position, :presentation] }
+    let(:attributes) { [:id, :name, :presentation, :position] }
     let!(:option_value) { create(:option_value) }
     let!(:option_type) { option_value.option_type }
 
@@ -15,7 +15,7 @@ module Spree
     def check_option_values(option_values)
       expect(option_values.count).to eq(1)
       expect(option_values.first).to have_attributes([:id, :name, :presentation,
-                                                  :option_type_name, :option_type_id])
+                                                      :option_type_id, :option_type_name])
     end
 
     it "can list all option types" do
@@ -46,6 +46,12 @@ module Spree
       api_get :show, :id => option_type.id
       expect(json_response).to have_attributes(attributes)
       check_option_values(json_response["option_values"])
+    end
+
+    it "can learn how to create a new option type" do
+      api_get :new
+      expect(json_response["attributes"]).to eq(attributes.map(&:to_s))
+      expect(json_response["required_attributes"]).to_not be_empty
     end
 
     it "cannot create a new option type" do

--- a/api/spec/controllers/spree/api/v1/option_values_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/option_values_controller_spec.rb
@@ -4,7 +4,7 @@ module Spree
   describe Api::V1::OptionValuesController, :type => :controller do
     render_views
 
-    let(:attributes) { [:id, :name, :presentation, :option_type_name, :option_type_name] }
+    let(:attributes) { [:id, :name, :presentation, :option_type_name, :option_type_id, :option_type_presentation] }
     let!(:option_value) { create(:option_value) }
     let!(:option_type) { option_value.option_type }
 
@@ -85,6 +85,12 @@ module Spree
 
       context "as an admin" do
         sign_in_as_admin!
+
+        it "can learn how to create a new option value" do
+          api_get :new
+          expect(json_response["attributes"]).to eq(attributes.map(&:to_s))
+          expect(json_response["required_attributes"]).to_not be_empty
+        end
 
         it "can create an option value" do
           api_post :create, :option_value => {


### PR DESCRIPTION
I've found a few API endpoints that are valid routes but are 404-ing right now
/api/v1/option_types/new
/api/v1/option_values/new
/api/v1/products/:product_id/images/new

All are valid routes but 404 because missing views. This commit adds those missing views plus a spec for each.
