### PR TITLE
Add type of error #raise_error in rspec inorder to remove warning

### DIFF
--- a/core/spec/models/spree/payment/store_credit_spec.rb
+++ b/core/spec/models/spree/payment/store_credit_spec.rb
@@ -51,7 +51,7 @@ describe 'Payment' do
       context 'does not cancel successfully' do
         it 'does not change the payment state' do
           expect(payment.payment_method).to receive(:cancel).with(payment.response_code) { failed_response }
-          expect { subject }.to raise_error
+          expect { subject }.to raise_error(Spree::Core::GatewayError)
           expect(payment.reload.state).not_to eq 'void'
         end
       end


### PR DESCRIPTION
Fixes warning given below which is faced during running specs of spree_core
- WARNING: Using the raise_error matcher without providing a specific error or message risks false positives, since raise_error will match when Ruby raises a NoMethodError, NameError or ArgumentError, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #. Instead consider providing a specific error class or message. This message can be supressed by setting: RSpec::Expectations.configuration.warn_about_potential_false_positives = false. Called from /Users/tan/Desktop/Project/spree-apps/spree-next/core/spec/models/spree/payment/store_credit_spec.rb:54:in `block (5 levels) in '.
