### PR TITLE
Fix form button links, use already existing partial

### DIFF
--- a/backend/app/views/spree/admin/payment_methods/edit.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/edit.html.erb
@@ -6,13 +6,11 @@
   <%= back_to_list_button(Spree::PaymentMethod.model_name.human, admin_payment_methods_path) %>
 <% end %>
 
-<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @payment_method } %>
+<%= render partial: 'spree/admin/shared/error_messages', locals: { target: @payment_method } %>
 
-<%= form_for @payment_method, :url => admin_payment_method_path(@payment_method) do |f| %>
+<%= form_for @payment_method, url: admin_payment_method_path(@payment_method) do |f| %>
   <fieldset>
-    <%= render :partial => 'form', :locals => { :f => f } %>
-    <div data-hook="buttons" class="actions">
-      <%= button Spree.t('actions.update'), 'save' %>
-    </div>
+    <%= render partial: 'form', locals: { f: f } %>
+    <%= render partial: 'spree/admin/shared/edit_resource_links' %>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/payment_methods/new.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/new.html.erb
@@ -6,13 +6,11 @@
   <%= back_to_list_button(Spree::PaymentMethod.model_name.human, admin_payment_methods_path) %>
 <% end %>
 
-<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @payment_method } %>
+<%= render partial: 'spree/admin/shared/error_messages', locals: { target: @payment_method } %>
 
-<%= form_for @payment_method, :url => collection_url do |f| %>
+<%= form_for @payment_method, url: collection_url do |f| %>
   <fieldset>
-    <%= render :partial => 'form', :locals => { :f => f } %>
-    <div data-hook="buttons" class="actions">
-      <%= button Spree.t(:create), 'save' %>
-    </div>
+    <%= render partial: 'form', locals: { f: f } %>
+    <%= render partial: 'spree/admin/shared/new_resource_links' %>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/taxonomies/new.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/new.html.erb
@@ -8,9 +8,7 @@
 
 <%= form_for [:admin, @taxonomy] do |f| %>
   <fieldset>
-    <%= render :partial => 'form', :locals => { :f => f } %>
-    <div class="form-actions" data-hook="buttons">
-      <%= button Spree.t(:create), 'save' %>
-    </div>
+    <%= render partial: 'form', locals: { f: f } %>
+    <%= render partial: 'spree/admin/shared/new_resource_links' %>
   </fieldset>
 <% end %>


### PR DESCRIPTION
- Add missing cancel buttons on form. Use existing new and edit partial for it.
- Used new ruby syntax instead of =>
