### PR TITLE
Ensures that ActionMailer::Base.default_url_options[:host] is always set (required for new emails)

### DIFF
--- a/core/app/mailers/spree/base_mailer.rb
+++ b/core/app/mailers/spree/base_mailer.rb
@@ -1,6 +1,5 @@
 module Spree
   class BaseMailer < ActionMailer::Base
-
     def from_address
       Spree::Store.current.mail_from_address
     end
@@ -10,9 +9,19 @@ module Spree
     end
     helper_method :money
 
-    def mail(headers={}, &block)
+    def mail(headers = {}, &block)
+      ensure_default_action_mailer_url_host
       super if Spree::Config[:send_core_emails]
     end
 
+    private
+
+    # this ensures that ActionMailer::Base.default_url_options[:host] is always set
+    # this is only a fail-safe solution if developer didn't set this in environment files
+    # http://guides.rubyonrails.org/action_mailer_basics.html#generating-urls-in-action-mailer-views
+    def ensure_default_action_mailer_url_host
+      ActionMailer::Base.default_url_options ||= {}
+      ActionMailer::Base.default_url_options[:host] ||= Spree::Store.current.url
+    end
   end
 end

--- a/core/lib/generators/spree/dummy/templates/rails/test.rb
+++ b/core/lib/generators/spree/dummy/templates/rails/test.rb
@@ -28,7 +28,6 @@ Dummy::Application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
   ActionMailer::Base.default from: "spree@example.com"
-  config.action_mailer.default_url_options = { host: "test.host" }
 
 
   # Print deprecation notices to the stderr

--- a/core/spec/mailers/test_mailer_spec.rb
+++ b/core/spec/mailers/test_mailer_spec.rb
@@ -18,7 +18,20 @@ describe Spree::TestMailer, :type => :mailer do
 
   it "confirm_email accepts a user id as an alternative to a User object" do
     expect {
-      test_email = Spree::TestMailer.test_email('test@example.com')
+      Spree::TestMailer.test_email('test@example.com')
     }.not_to raise_error
+  end
+
+  context "action mailer host" do
+    it "falls back to spree store url" do
+      Spree::TestMailer.test_email('test@example.com')
+      expect(ActionMailer::Base.default_url_options[:host]).to eq(Spree::Store.current.url)
+    end
+
+    it "uses developer set host" do
+      ActionMailer::Base.default_url_options[:host] = 'test.test'
+      Spree::TestMailer.test_email('test@example.com')
+      expect(ActionMailer::Base.default_url_options[:host]).to eq('test.test')
+    end
   end
 end


### PR DESCRIPTION
If `ActionMailer::Base.default_url_options[:host]` is not set by the developer in environment files it will fall back to `Spree::Store.current.url`, so sending out emails will work out the box.
