### PR TITLE
Fix inline errors on back end forms

### DIFF
--- a/backend/app/views/spree/admin/countries/_form.html.erb
+++ b/backend/app/views/spree/admin/countries/_form.html.erb
@@ -1,12 +1,18 @@
 <div data-hook="admin_country_form_fields">
   <div data-hook="name" class="form-group">
-    <%= f.label :name, Spree.t(:name) %>
-    <%= f.text_field :name, :class => 'form-control' %>
+    <%= f.field_container :name, class: ["form-group"] do %>
+      <%= f.label :name, Spree.t(:name) %>
+      <%= f.text_field :name, :class => 'form-control' %>
+      <%= error_message_on :country, :name %>
+    <% end %>
   </div>
 
   <div data-hook="iso_name" class="form-group">
-    <%= f.label :iso_name, Spree.t(:iso_name) %>
-    <%= f.text_field :iso_name, :class => 'form-control' %>
+    <%= f.field_container :iso_name, class: ["form-group"] do %>
+      <%= f.label :iso_name, Spree.t(:iso_name) %>
+      <%= f.text_field :iso_name, :class => 'form-control' %>
+      <%= error_message_on :country, :iso_name %>
+    <% end %>
   </div>
 
   <div data-hook="states_required" class="checkbox">

--- a/backend/app/views/spree/admin/countries/new.html.erb
+++ b/backend/app/views/spree/admin/countries/new.html.erb
@@ -6,7 +6,7 @@
   <%= back_to_list_button(Spree::Country.model_name.human, admin_countries_path) %>
 <% end %>
 
-<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @countries } %>
+<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @country } %>
 
 <%= form_for [:admin, @country] do |f| %>
   <fieldset>

--- a/backend/app/views/spree/admin/promotion_categories/_form.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/_form.html.erb
@@ -1,8 +1,9 @@
-<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @promotion } %>
+<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @promotion_category } %>
 
 <%= f.field_container :name, class: ['form-group'] do %>
   <%= f.label :name %>
   <%= f.text_field :name, :class => 'form-control' %>
+  <%= error_message_on :promotion_category, :name %>
 <% end %>
 <%= f.field_container :code, class: ['form-group'] do %>
   <%= f.label :code %>

--- a/backend/app/views/spree/admin/promotions/_form.html.erb
+++ b/backend/app/views/spree/admin/promotions/_form.html.erb
@@ -5,6 +5,7 @@
     <%= f.field_container :name, class: ['form-group'] do %>
       <%= f.label :name %>
       <%= f.text_field :name, :class => 'form-control' %>
+      <%= error_message_on :promotion, :name %>
     <% end %>
 
     <%= f.field_container :code, class: ['form-group'] do %>

--- a/backend/app/views/spree/admin/roles/_form.html.erb
+++ b/backend/app/views/spree/admin/roles/_form.html.erb
@@ -1,7 +1,10 @@
 <div data-hook="admin_role_form_fields">
   <div data-hook="role_name" class="form-group">
-    <%= f.label :name, Spree.t(:name) %> <span class="required">*</span>
-    <%= f.text_field :name, class: 'form-control' %>
+    <%= f.field_container :name, class: ["form-group"] do %>
+      <%= f.label :name, Spree.t(:name) %> <span class="required">*</span>
+      <%= f.text_field :name, class: 'form-control' %>
+      <%= error_message_on :role, :name %>
+    <% end %>
   </div>
 
   <div data-hook="additional_role_fields"></div>

--- a/backend/app/views/spree/admin/roles/edit.html.erb
+++ b/backend/app/views/spree/admin/roles/edit.html.erb
@@ -6,6 +6,8 @@
   <%= back_to_list_button(Spree::Role.model_name.human, admin_roles_path) %>
 <% end %>
 
+<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @role } %>
+
 <%= form_for [:admin, @role] do |f| %>
   <fieldset>
     <%= render partial: 'form', locals: { f: f } %>

--- a/backend/app/views/spree/admin/roles/new.html.erb
+++ b/backend/app/views/spree/admin/roles/new.html.erb
@@ -6,6 +6,8 @@
   <%= back_to_list_button(Spree::Role.model_name.human, admin_roles_path) %>
 <% end %>
 
+<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @role } %>
+
 <%= form_for [:admin, @role] do |f| %>
   <fieldset>
     <%= render partial: 'form', locals: { f: f } %>

--- a/backend/app/views/spree/admin/shared/named_types/_form.html.erb
+++ b/backend/app/views/spree/admin/shared/named_types/_form.html.erb
@@ -2,6 +2,7 @@
   <%= f.field_container :name, class: ['form-group'] do %>
     <%= f.label :name, Spree.t(:name) %> <span class="required">*</span>
     <%= f.text_field :name, class: 'form-control' %>
+    <%= error_message_on :object, :name %>
   <% end %>
   <div class="checkbox">
     <%= label_tag :active do %>

--- a/backend/app/views/spree/admin/shipping_categories/_form.html.erb
+++ b/backend/app/views/spree/admin/shipping_categories/_form.html.erb
@@ -1,6 +1,9 @@
 <div data-hook="admin_shipping_category_form_fields">
   <div data-hook="name" class="form-group">
-    <%= label_tag :shipping_category_name, Spree.t(:name) %><br>
-    <%= f.text_field :name, class: 'form-control' %>
+    <%= f.field_container :name, class: ["form-group"] do %>
+      <%= f.label :name, Spree.t(:name) %><br>
+      <%= f.text_field :name, class: 'form-control' %>
+      <%= error_message_on :shipping_category, :name %>
+    <% end %>
   </div>
 </div>

--- a/backend/app/views/spree/admin/states/_form.html.erb
+++ b/backend/app/views/spree/admin/states/_form.html.erb
@@ -3,6 +3,7 @@
     <%= f.field_container :name, class: ['form-group'] do %>
       <%= f.label :name, Spree.t(:name) %>
       <%= f.text_field :name, :class => 'form-control' %>
+      <%= error_message_on :state, :name %>
     <% end %>
   </div>
   <div class="col-md-6">

--- a/backend/app/views/spree/admin/stock_locations/_form.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/_form.html.erb
@@ -3,8 +3,9 @@
     <div class="col-md-9" data-hook="stock_location_names">
       <div data-hook="stock_location_name">
         <%= f.field_container :name, class: ['form-group']  do %>
-        <%= f.label :name, Spree.t(:name) %> <span class="required">*</span><br />
-        <%= f.text_field :name, class: 'form-control', required: true %>
+          <%= f.label :name, Spree.t(:name) %> <span class="required">*</span><br />
+          <%= f.text_field :name, class: 'form-control', required: true %>
+          <%= error_message_on :stock_location, :name %>
         <% end %>
       </div>
       <div data-hook="stock_location_admin_name">

--- a/backend/app/views/spree/admin/stock_locations/new.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/new.html.erb
@@ -6,7 +6,7 @@
   <%= link_to_with_icon 'arrow-left', Spree.t(:back_to_stock_locations_list), admin_stock_locations_path, :class => 'btn btn-primary' %>
 <% end %>
 
-<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @stock_locations } %>
+<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @stock_location } %>
 
 <%= form_for [:admin, @stock_location] do |f| %>
   <fieldset>

--- a/backend/app/views/spree/admin/tax_categories/_form.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/_form.html.erb
@@ -2,6 +2,7 @@
   <%= f.field_container :name, :class => ['form-group'] do %>
     <%= f.label :name, Spree.t(:name) %>
     <%= f.text_field :name, :class => 'form-control' %>
+    <%= error_message_on :tax_category, :name %>
   <% end %>
 
   <%= f.field_container :tax_code, :class => ['form-group'] do %>

--- a/backend/app/views/spree/admin/tax_rates/_form.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/_form.html.erb
@@ -13,10 +13,13 @@
           <%= f.text_field :name, :class => 'form-control' %>
         </div>
         <div data-hook="rate" class="form-group">
-          <%= f.label :amount, Spree.t(:rate) %>
-          <%= f.text_field :amount, :class => 'form-control' %>
+          <%= f.field_container :amount, class: ["form-group"] do %>
+            <%= f.label :amount, Spree.t(:rate) %>
+            <%= f.text_field :amount, :class => 'form-control' %>
+            <%= error_message_on :tax_rate, :amount %>
+          <% end %>
           <p class="help-block">
-            <%= Spree.t(:tax_rate_amount_explanation) %>
+          <%= Spree.t(:tax_rate_amount_explanation) %>
           </p>
         </div>
         <div data-hook="included" class="form-group">

--- a/backend/app/views/spree/admin/taxonomies/_form.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/_form.html.erb
@@ -1,7 +1,7 @@
 <div data-hook="admin_inside_taxonomy_form" class="form-group">
   <%= f.field_container :name, class: ['form-group'] do %>
     <%= f.label :name, Spree.t(:name) %> <span class="required">*</span>
+    <%= f.text_field :name, :class => 'form-control' %>
     <%= error_message_on :taxonomy, :name, :class => 'error-message' %>
-    <%= text_field :taxonomy, :name, :class => 'form-control' %>
   <% end %>
 </div>

--- a/backend/app/views/spree/admin/taxonomies/new.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/new.html.erb
@@ -1,6 +1,7 @@
 <% content_for :page_title do %>
   <%= Spree.t(:new_taxonomy) %>
 <% end %>
+<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @taxonomy } %>
 
 <% content_for :page_actions do %>
   <%= back_to_list_button(Spree::Taxonomy.model_name.human, admin_taxonomies_path) %>

--- a/backend/app/views/spree/admin/trackers/_form.html.erb
+++ b/backend/app/views/spree/admin/trackers/_form.html.erb
@@ -1,8 +1,11 @@
 <div data-hook="admin_tracker_form_fields" class="row">
   <div class="col-md-4">
     <div data-hook="analytics_id" class="form-group">
-      <%= label_tag nil, Spree.t(:google_analytics_id) %>
-      <%= text_field :tracker, :analytics_id, :class => 'form-control' %>
+      <%= f.field_container :analytics_id, class: ["form-group"] do %>
+        <%= f.label :analytics_id, Spree.t(:google_analytics_id) %>
+        <%= f.text_field :analytics_id, :class => 'form-control' %>
+        <%= error_message_on :tracker, :analytics_id %>
+      <% end %>
     </div>
   </div>
   <div class="col-md-4">
@@ -18,11 +21,11 @@
         <%= label_tag :tracker_active_false do %>
           <%= radio_button(:tracker, :active, false) %>
           <%= Spree.t(:say_no) %>
-        <% end %>        
+        <% end %>
       </div>
     </div>
   </div>
-  
+
   <div data-hook="additional_tracker_fields"></div>
 
 </div>

--- a/backend/app/views/spree/admin/trackers/edit.html.erb
+++ b/backend/app/views/spree/admin/trackers/edit.html.erb
@@ -5,6 +5,8 @@
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @tracker } %>
 
 <%= form_for [:admin, @tracker] do |f| %>
-  <%= render :partial => 'form', :locals => { :f => f } %>
-  <%= render :partial => 'spree/admin/shared/edit_resource_links' %>  
+  <fieldset>
+    <%= render :partial => 'form', :locals => { :f => f } %>
+    <%= render :partial => 'spree/admin/shared/edit_resource_links' %>
+  </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/zones/_form.html.erb
+++ b/backend/app/views/spree/admin/zones/_form.html.erb
@@ -9,6 +9,7 @@
         <%= zone_form.field_container :name, class: ['form-group'] do %>
           <%= zone_form.label :name, Spree.t(:name) %>
           <%= zone_form.text_field :name, :class => 'form-control' %>
+          <%= error_message_on :zone, :name %>
         <% end %>
 
         <%= zone_form.field_container :description, class: ['form-group'] do %>


### PR DESCRIPTION
In backend forms, errors are displayed in inline format with field in red colour and also field and label are marked with red colour. 
