### PR TITLE
inline errors for payment methods and create and cancel links also added

### DIFF
--- a/backend/app/views/spree/admin/payment_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/_form.html.erb
@@ -42,10 +42,12 @@
     </div>
 
     <div class="col-md-8">
-      <div data-hook="name" class="form-group">
-        <%= label_tag :payment_method_name, Spree.t(:name) %>
-        <%= text_field :payment_method, :name, :class => 'form-control' %>
-      </div>
+      <div data-hook="admin_payment_method_form_name_field" class="form-group">
+        <%= field_container :payment_method, :name, class: ['form-group'] do %>
+          <%= label_tag :payment_method_name, Spree.t(:name) %>
+          <%= text_field :payment_method, :name, :class => 'form-control' %>
+          <%= error_message_on :payment_method, :name %>
+        <% end %>
       <div data-hook="description" class="form-group">
         <%= label_tag :payment_method_description, Spree.t(:description) %>
         <%= text_area :payment_method, :description, { :cols => 60, :rows => 6, :class => 'form-control' } %>

--- a/backend/app/views/spree/admin/payment_methods/edit.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/edit.html.erb
@@ -11,8 +11,8 @@
 <%= form_for @payment_method, :url => admin_payment_method_path(@payment_method) do |f| %>
   <fieldset>
     <%= render :partial => 'form', :locals => { :f => f } %>
-    <div data-hook="buttons" class="actions">
-      <%= button Spree.t('actions.update'), 'save' %>
+    <div data-hook="admin_shipping_method_edit_form_buttons">
+      <%= render partial: 'spree/admin/shared/edit_resource_links' %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/payment_methods/new.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/new.html.erb
@@ -11,8 +11,8 @@
 <%= form_for @payment_method, :url => collection_url do |f| %>
   <fieldset>
     <%= render :partial => 'form', :locals => { :f => f } %>
-    <div data-hook="buttons" class="actions">
-      <%= button Spree.t(:create), 'save' %>
+    <div data-hook="admin_shipping_method_new_form_buttons">
+      <%= render partial: 'spree/admin/shared/new_resource_links' %>
     </div>
   </fieldset>
 <% end %>


### PR DESCRIPTION
In backend, payment methods now have inline errors with field and field and label are also marked with red colour.
Also, create and cancel links are also added like new spree syntax
