### PR TITLE
double error messages fix for payment method

### DIFF
--- a/core/app/models/spree/gateway.rb
+++ b/core/app/models/spree/gateway.rb
@@ -4,7 +4,7 @@ module Spree
 
     delegate :authorize, :purchase, :capture, :void, :credit, to: :provider
 
-    validates :name, :type, presence: true
+    validates :type, presence: true
 
     preference :server, :string, default: 'test'
     preference :test_mode, :boolean, default: true


### PR DESCRIPTION
Removing presence validation for name from Gateway as its already present in its superclass PaymentMethod. This also fixes double error messages.
