### PR TITLE
reduce n-1 queries for inventory units update function

### DIFF
--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -53,12 +53,7 @@ module Spree
     end
 
     def self.finalize_units!(inventory_units)
-      inventory_units.map do |iu|
-        iu.update_columns(
-          pending: false,
-          updated_at: Time.current,
-        )
-      end
+      inventory_units.update_all(pending: false, updated_at: Time.current)
     end
 
     def find_stock_item


### PR DESCRIPTION
In `finalize_units!` method in `Spree::InventoryUnit` class, `update_columns` is used on every single inventory_unit.
Using `update_all` instead on all inventory_units objects to fire one update query instead of n queries.
