### PR TITLE
Optimize inventory unit finalization by using update_all

### DIFF
--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -52,13 +52,8 @@ module Spree
       end
     end
 
-    def self.finalize_units!(inventory_units)
-      inventory_units.map do |iu|
-        iu.update_columns(
-          pending: false,
-          updated_at: Time.current,
-        )
-      end
+    def self.finalize_units!
+      update_all(pending: false, updated_at: Time.current)
     end
 
     def find_stock_item

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -137,7 +137,7 @@ module Spree
     end
 
     def finalize!
-      InventoryUnit.finalize_units!(inventory_units)
+      inventory_units.finalize_units!
       after_resume
     end
 

--- a/core/spec/models/spree/inventory_unit_spec.rb
+++ b/core/spec/models/spree/inventory_unit_spec.rb
@@ -105,14 +105,18 @@ describe Spree::InventoryUnit, :type => :model do
   context "#finalize_units!" do
     let!(:stock_location) { create(:stock_location) }
     let(:variant) { create(:variant) }
+    let (:shipment) { create(:shipment) }
     let(:inventory_units) { [
       create(:inventory_unit, variant: variant),
       create(:inventory_unit, variant: variant)
     ] }
+    before do
+      shipment.inventory_units = inventory_units
+    end
 
     it "should create a stock movement" do
-      Spree::InventoryUnit.finalize_units!(inventory_units)
-      expect(inventory_units.any?(&:pending)).to be false
+      expect { shipment.inventory_units.finalize_units! }.
+        to change { shipment.inventory_units.where(pending: false).count }.by 2
     end
   end
 


### PR DESCRIPTION
Optmized `InventoryUnit#finalize_units!` method by using `update_all` instead of `update_columns` in iteration. 
