### PR TITLE
#discontinue! should change updated_at and invoke callbacks

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -159,7 +159,7 @@ module Spree
     end
 
     def discontinue!
-      update_column(:discontinue_on, Time.current)
+      update_attribute(:discontinue_on, Time.current)
     end
 
     def discontinued?

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -249,7 +249,7 @@ module Spree
     end
 
     def discontinue!
-      update_column(:discontinue_on, Time.current)
+      update_attribute(:discontinue_on, Time.current)
     end
 
     def discontinued?

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -521,6 +521,10 @@ describe Spree::Product, :type => :model do
       product.reload
       expect(product.discontinued?).to be(true)
     end
+
+    it "changes updated_at" do
+      expect { product.discontinue! }.to change { product.updated_at }
+    end
   end
 
   context "#discontinued?" do

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -643,6 +643,10 @@ describe Spree::Variant, :type => :model do
       variant.reload
       expect(variant.discontinued?).to be(true)
     end
+
+    it "changes updated_at" do
+      expect { variant.discontinue! }.to change { variant.updated_at }
+    end
   end
 
   context "#discontinued?" do


### PR DESCRIPTION
Changing `discontinuation_on` status should be visible on the frontend. Before it didn’t change the `updated_at` column so any cache keys for this product/variant weren’t invalidated and callbacks weren't invoked.
