### PR TITLE
Product Page: when none Taxon selected, display breadcrumbs with the default one (first) for this Product

### DIFF
--- a/frontend/app/controllers/spree/products_controller.rb
+++ b/frontend/app/controllers/spree/products_controller.rb
@@ -20,7 +20,7 @@ module Spree
                            active(current_currency).
                            includes([:option_values, :images])
       @product_properties = @product.product_properties.includes(:property)
-      @taxon = Spree::Taxon.find(params[:taxon_id]) if params[:taxon_id]
+      @taxon = params[:taxon_id].present? ? Spree::Taxon.find(params[:taxon_id]) : @product.taxons.first
       redirect_if_legacy_path
     end
 

--- a/frontend/spec/features/products_spec.rb
+++ b/frontend/spec/features/products_spec.rb
@@ -224,6 +224,29 @@ describe "Visiting Products", type: :feature, inaccessible: true do
     end
   end
 
+  context 'product with taxons' do
+    let(:product) { Spree::Product.find_by_name("Ruby on Rails Tote") }
+    let(:taxon) { product.taxons.first }
+
+    it 'displays breadcrumbs for the default taxon when none selected' do
+      click_link product.name
+      within("#breadcrumbs") do
+        expect(page).to have_content taxon.name
+      end
+    end
+
+    it 'displays selected taxon in breadcrumbs' do
+      taxon = Spree::Taxon.last
+      product.taxons << taxon
+      product.save!
+      visit '/t/' + taxon.to_param
+      click_link product.name
+      within("#breadcrumbs") do
+        expect(page).to have_content taxon.name
+      end
+    end
+  end
+
   it "should be able to hide products without price" do
     expect(page.all('#products .product-list-item').size).to eq(9)
     Spree::Config.show_products_without_price = false


### PR DESCRIPTION
UX for the visitor is much better this way, site SEO also gains (breadcrumbs) and so on. Behaviour of hiding / showing breadcrumbs depending on URL was kinda funky.
