### PR TITLE
Avoid raising exception from return_processing_reason

### DIFF
--- a/core/app/models/spree/refund_reason.rb
+++ b/core/app/models/spree/refund_reason.rb
@@ -7,7 +7,7 @@ module Spree
     has_many :refunds, dependent: :restrict_with_error
 
     def self.return_processing_reason
-      find_by!(name: RETURN_PROCESSING_REASON, mutable: false)
+      find_by(name: RETURN_PROCESSING_REASON, mutable: false)
     end
   end
 end

--- a/core/spec/models/spree/refund_reason_spec.rb
+++ b/core/spec/models/spree/refund_reason_spec.rb
@@ -4,4 +4,17 @@ describe Spree::RefundReason do
   describe 'Associations' do
     it { is_expected.to have_many(:refunds).dependent(:restrict_with_error) }
   end
+
+  describe 'Class Methods' do
+    describe '.return_processing_reason' do
+      context 'default refund reason present' do
+        let!(:default_refund_reason) { create(:default_refund_reason) }
+        it { expect(described_class.return_processing_reason).to eq(default_refund_reason) }
+      end
+
+      context 'default refund reason not present' do
+        it { expect(described_class.return_processing_reason).to eq(nil) }
+      end
+    end
+  end
 end


### PR DESCRIPTION
- Avoid raising exception from return_processing_reason since it is already handled in reimbursement reason where we have a validation on reason. So no need to raise an exception.
