### PR TITLE
Ensure Order guest_token uniqueness.

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -14,6 +14,7 @@ module Spree
     include Spree::Order::Payments
     include Spree::Order::StoreCredit
     include Spree::Core::NumberGenerator.new(prefix: 'R')
+    include Spree::Core::TokenGenerator
 
     extend Spree::DisplayMoney
     money_methods :outstanding_balance, :item_total,           :adjustment_total,
@@ -677,10 +678,7 @@ module Spree
     end
 
     def create_token
-      self.guest_token ||= loop do
-        random_token = SecureRandom.urlsafe_base64(nil, false)
-        break random_token unless self.class.exists?(guest_token: random_token)
-      end
+      self.guest_token ||= generate_guest_token
     end
   end
 end

--- a/core/db/migrate/20160308084101_add_unique_index_to_spree_orders_guest_token.rb
+++ b/core/db/migrate/20160308084101_add_unique_index_to_spree_orders_guest_token.rb
@@ -1,0 +1,19 @@
+class AddUniqueIndexToSpreeOrdersGuestToken < ActiveRecord::Migration
+  def up
+    # there should be no more than several duplicated tokens even for largest stores
+    Spree::Order.group(:guest_token).having('count(*) > 1').pluck(:guest_token).each do |token|
+      Spree::Order.where(guest_token: token).each do |order|
+        order.guest_token = nil
+        order.send(:create_token)
+      end
+    end
+    remove_index :spree_orders, :guest_token
+    add_index :spree_orders, :guest_token, unique: true
+  end
+
+  def down
+    remove_index :spree_orders, :guest_token
+    add_index :spree_orders, :guest_token
+  end
+end
+

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -62,6 +62,7 @@ module Spree
 
   module Core
     autoload :ProductFilters, "spree/core/product_filters"
+    autoload :TokenGenerator, "spree/core/token_generator"
 
     class GatewayError < RuntimeError; end
     class DestroyWithOrdersError < StandardError; end

--- a/core/lib/spree/core/controller_helpers/auth.rb
+++ b/core/lib/spree/core/controller_helpers/auth.rb
@@ -3,6 +3,7 @@ module Spree
     module ControllerHelpers
       module Auth
         extend ActiveSupport::Concern
+        include Spree::Core::TokenGenerator
 
         included do
           before_action :set_guest_token
@@ -24,8 +25,8 @@ module Spree
         end
 
         def set_guest_token
-          unless cookies.signed[:guest_token].present?
-            cookies.permanent.signed[:guest_token] = SecureRandom.urlsafe_base64(nil, false)
+          if cookies.signed[:guest_token].blank?
+            cookies.permanent.signed[:guest_token] = generate_guest_token
           end
         end
 

--- a/core/lib/spree/core/token_generator.rb
+++ b/core/lib/spree/core/token_generator.rb
@@ -1,0 +1,22 @@
+module Spree
+  module Core
+    module TokenGenerator
+      def generate_guest_token(model_class = Spree::Order)
+        loop do
+          token = "#{random_token}#{unique_ending}"
+          break token unless model_class.exists?(guest_token: token)
+        end
+      end
+
+      private
+
+      def random_token
+        SecureRandom.urlsafe_base64(nil, false)
+      end
+
+      def unique_ending
+        (Time.now.to_f * 1000).to_i
+      end
+    end
+  end
+end

--- a/core/spec/lib/spree/core/token_generator_spec.rb
+++ b/core/spec/lib/spree/core/token_generator_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe Spree::Core::TokenGenerator do
+  class DummyClass
+    include Spree::Core::TokenGenerator
+
+    attr_reader :created_at
+
+    def initialize
+      @created_at = Time.now.to_i
+    end
+  end
+
+  let(:dummy_class_instance) { DummyClass.new }
+
+  describe 'generate_guest_token' do
+    let(:generated_token) { dummy_class_instance.generate_guest_token }
+
+    it 'generates random token with timestamp' do
+      expect(generated_token.size).to eq 35
+      expect(generated_token).to include dummy_class_instance.created_at.to_s
+    end
+  end
+end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -98,15 +98,15 @@ describe Spree::Order, :type => :model do
     end
   end
 
-  context "#create" do
+  context '#create' do
     let(:order) { Spree::Order.create }
 
-    it "should assign an order number" do
+    it 'should assign an order number' do
       expect(order.number).not_to be_nil
     end
 
-    it 'should create a randomized 22 character token' do
-      expect(order.guest_token.size).to eq(22)
+    it 'should create a randomized 35 character token' do
+      expect(order.guest_token.size).to eq(35)
     end
   end
 


### PR DESCRIPTION
In cookies `guest_token` was not created as unique, which (in very rare occasions) led to users getting some other user's order.

This PR unifies token creation and ensures their uniqueness.

Spotted by @charlie-hadden - thanks!
