### PR TITLE
Ensure default_url_options is empty for spec

### DIFF
--- a/core/spec/mailers/test_mailer_spec.rb
+++ b/core/spec/mailers/test_mailer_spec.rb
@@ -24,13 +24,14 @@ describe Spree::TestMailer, :type => :mailer do
 
   context "action mailer host" do
     it "falls back to spree store url" do
-      Spree::TestMailer.test_email('test@example.com')
+      ActionMailer::Base.default_url_options = {}
+      Spree::TestMailer.test_email('test@example.com').deliver_now
       expect(ActionMailer::Base.default_url_options[:host]).to eq(Spree::Store.current.url)
     end
 
     it "uses developer set host" do
       ActionMailer::Base.default_url_options[:host] = 'test.test'
-      Spree::TestMailer.test_email('test@example.com')
+      Spree::TestMailer.test_email('test@example.com').deliver_now
       expect(ActionMailer::Base.default_url_options[:host]).to eq('test.test')
     end
   end


### PR DESCRIPTION
Fixes failing specs on CI caused by https://github.com/spree/spree/pull/7165
