### PR TITLE
Destroy a line_item from order association inorder to make sure order…

### DIFF
--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -19,8 +19,11 @@ module Spree
     end
 
     def remove_line_item(line_item, options = {})
-      line_item.destroy!
-      after_add_or_remove(line_item, options)
+      if order.line_items.destroy(line_item)
+        after_add_or_remove(line_item, options)
+      else
+        false
+      end
     end
 
     def update_cart(params)

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -208,6 +208,17 @@ describe Spree::OrderContents, :type => :model do
       expect(order.reload.line_items).to_not include(line_item)
     end
 
+    context 'should not remove line_item' do
+      let(:line_item) { subject.add(variant, 1) }
+
+      before do
+        allow(subject.order.line_items).to receive(:destroy).with(line_item).and_return(false)
+        subject.remove_line_item(line_item)
+      end
+
+      it { expect(order.reload.line_items).to include(line_item) }
+    end
+
     it "should update order totals" do
       expect(order.item_total.to_f).to eq(0.00)
       expect(order.total.to_f).to eq(0.00)


### PR DESCRIPTION
….line_items remain updated if used further instead of reloading order
- Destroy a line_item from order association in-order to make sure order.line_items(already loaded in memory) always remains consistent since few calculations are done on order.
- Handle failure exception in case of line_item_ destroy(Avoid raising exception)
