### PR TITLE
Downgrade rake to version 10.5.0

### DIFF
--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -7,6 +7,7 @@ gem 'coffee-rails', '~> 4.0.0'
 gem 'sass-rails', '~> 5.0.0'
 gem 'sqlite3', platforms: [:ruby, :mingw, :mswin, :x64_mingw]
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
+gem 'rake', '~> 10.5.0' # downgraded because rspec-core on rubygems doesn’t support rake 11.x yet (https://github.com/rspec/rspec-core/commit/8e723fc805e901ac4fa5483837138b175d411d6e)
 
 platforms :jruby do
   gem 'jruby-openssl'


### PR DESCRIPTION
Downgraded because rspec-core on rubygems doesn’t support rake 11.x yet (https://github.com/rspec/rspec-core/commit/8e723fc805e901ac4fa5483837138b175d411d6e).
