### PR TITLE
2.3 Order guest token uniqueness

### DIFF
--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -26,7 +26,7 @@ group :test do
   gem 'rspec-activemodel-mocks'
   gem 'rspec-collection_matchers'
   gem 'rspec-its'
-  gem 'rspec-rails', '~> 3.1.0'
+  gem 'rspec-rails', '~> 3.4.2'
   gem 'simplecov'
   gem 'webmock', '1.8.11'
   gem 'poltergeist', '1.5.0'

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -5,6 +5,7 @@ module Spree
   class Order < Spree::Base
     include Spree::Order::Checkout
     include Spree::Order::CurrencyUpdater
+    include Spree::Core::TokenGenerator
 
     checkout_flow do
       go_to_state :address
@@ -678,10 +679,7 @@ module Spree
       end
 
       def create_token
-        self.guest_token ||= loop do
-          random_token = SecureRandom.urlsafe_base64(nil, false)
-          break random_token unless self.class.exists?(guest_token: random_token)
-        end
+        self.guest_token ||= generate_guest_token
       end
   end
 end

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -41,6 +41,7 @@ module Spree
 
   module Core
     autoload :ProductFilters, "spree/core/product_filters"
+    autoload :TokenGenerator, "spree/core/token_generator"
 
     class GatewayError < RuntimeError; end
     class DestroyWithOrdersError < StandardError; end

--- a/core/lib/spree/core/controller_helpers/auth.rb
+++ b/core/lib/spree/core/controller_helpers/auth.rb
@@ -3,6 +3,7 @@ module Spree
     module ControllerHelpers
       module Auth
         extend ActiveSupport::Concern
+        include Spree::Core::TokenGenerator
 
         included do
           before_filter :set_guest_token
@@ -24,8 +25,8 @@ module Spree
         end
 
         def set_guest_token
-          unless cookies.signed[:guest_token].present?
-            cookies.permanent.signed[:guest_token] = SecureRandom.urlsafe_base64(nil, false)
+          if cookies.signed[:guest_token].blank?
+            cookies.permanent.signed[:guest_token] = generate_guest_token
           end
         end
 

--- a/core/lib/spree/core/token_generator.rb
+++ b/core/lib/spree/core/token_generator.rb
@@ -1,0 +1,22 @@
+module Spree
+  module Core
+    module TokenGenerator
+      def generate_guest_token(model_class = Spree::Order)
+        loop do
+          token = "#{random_token}#{unique_ending}"
+          break token unless model_class.exists?(guest_token: token)
+        end
+      end
+
+      private
+
+      def random_token
+        SecureRandom.urlsafe_base64(nil, false)
+      end
+
+      def unique_ending
+        (Time.now.to_f * 1000).to_i
+      end
+    end
+  end
+end

--- a/core/spec/lib/spree/core/token_generator_spec.rb
+++ b/core/spec/lib/spree/core/token_generator_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe Spree::Core::TokenGenerator do
+  class DummyClass
+    include Spree::Core::TokenGenerator
+
+    attr_reader :created_at
+
+    def initialize
+      @created_at = Time.now.to_i
+    end
+  end
+
+  let(:dummy_class_instance) { DummyClass.new }
+
+  describe 'generate_guest_token' do
+    let(:generated_token) { dummy_class_instance.generate_guest_token }
+
+    it 'generates random token with timestamp' do
+      expect(generated_token.size).to eq 35
+      expect(generated_token).to include dummy_class_instance.created_at.to_s
+    end
+  end
+end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -23,8 +23,8 @@ describe Spree::Order, :type => :model do
       expect(order.number).not_to be_nil
     end
 
-    it 'should create a randomized 22 character token' do
-      expect(order.guest_token.size).to eq(22)
+    it "should create a randomized 35 character token" do
+      expect(order.guest_token.size).to eq(35)
     end
   end
 


### PR DESCRIPTION
Also upgrades rspec-rails to 3.4.2, because previous version doesn’t support rake 11.x (rspec/rspec-core@8e723fc)
