### PR TITLE
Installer uses new ruby syntax for adding Spree root mount point

### DIFF
--- a/core/lib/generators/spree/install/install_generator.rb
+++ b/core/lib/generators/spree/install/install_generator.rb
@@ -167,7 +167,7 @@ Spree::Auth::Engine.load_seed if defined?(Spree::Auth)
   # If you would like to change where this engine is mounted, simply change the :at option to something different.
   #
   # We ask that you don't use the :as option here, as Spree relies on it being the default of "spree"
-  mount Spree::Core::Engine, :at => '/'
+  mount Spree::Core::Engine, at: '/'
         }
       end
 
@@ -175,7 +175,7 @@ Spree::Auth::Engine.load_seed if defined?(Spree::Auth)
         puts "*" * 50
         puts "We added the following line to your application's config/routes.rb file:"
         puts " "
-        puts "    mount Spree::Core::Engine, :at => '/'"
+        puts "    mount Spree::Core::Engine, at: '/'"
       end
     end
 


### PR DESCRIPTION
Not changing other syntax stuff in this file on purpose - will do it later in a bigger commit focused only on linter fixes. 
