### PR TITLE
Store Credit Category fixes

### DIFF
--- a/backend/app/views/spree/admin/store_credits/_form.html.erb
+++ b/backend/app/views/spree/admin/store_credits/_form.html.erb
@@ -5,7 +5,7 @@
     <%= f.error_message_on :amount %>
   <% end %>
   <%= f.field_container :category, class: ['form-group'] do %>
-    <%= f.label :category, raw(Spree.t(:reason) + content_tag(:span, " *", class: "required")) %>
+    <%= f.label :category, raw(Spree.t(:category) + content_tag(:span, " *", class: "required")) %>
     <%= f.select :category_id, options_from_collection_for_select(@credit_categories, :id, :name, f.object.category.try(:id)),
         { include_blank: true }, { class: 'select2 fullwidth', placeholder: Spree.t(:select_a_store_credit_reason) } %>
     <%= f.error_message_on :category %>

--- a/backend/app/views/spree/admin/store_credits/index.html.erb
+++ b/backend/app/views/spree/admin/store_credits/index.html.erb
@@ -12,11 +12,11 @@
 <% if @store_credits.any? %>
   <table class="table">
     <thead>
-      <th><%= Spree.t("credited") %></th>
-      <th><%= Spree.t("used") %></th>
-      <th><%= Spree.t("type") %></th>
-      <th><%= Spree.t("created_by") %></th>
-      <th><%= Spree.t("issued_on") %></th>
+      <th><%= Spree.t(:credited) %></th>
+      <th><%= Spree.t(:used) %></th>
+      <th><%= Spree.t(:category) %></th>
+      <th><%= Spree.t(:created_by) %></th>
+      <th><%= Spree.t(:issued_on) %></th>
       <th data-hook="admin_store_credits_index_header_actions" class="actions"></th>
     <thead>
     <tbody>

--- a/sample/db/samples/store_credit_categories.rb
+++ b/sample/db/samples/store_credit_categories.rb
@@ -1,0 +1,1 @@
+Spree::StoreCreditCategory.find_or_create_by!(name: "Default")

--- a/sample/lib/spree_sample.rb
+++ b/sample/lib/spree_sample.rb
@@ -26,6 +26,7 @@ module SpreeSample
       Spree::Sample.load_sample("orders")
       Spree::Sample.load_sample("adjustments")
       Spree::Sample.load_sample("payments")
+      Spree::Sample.load_sample("store_credit_categories")
     end
   end
 end


### PR DESCRIPTION
1. `Default` Store Credit Category added to `spree_sample`
2. Unified naming - let's call category a category everywhere it's used for better UX
