### PR TITLE
Store Credits: lighter association :store_credits in UserMethods & optimisations of StoreCreditsController#index

### DIFF
--- a/backend/app/controllers/spree/admin/store_credits_controller.rb
+++ b/backend/app/controllers/spree/admin/store_credits_controller.rb
@@ -9,7 +9,7 @@ module Spree
       before_action :ensure_unused_store_credit, only: [:update]
 
       def index
-        @store_credits = @user.store_credits.reverse_order
+        @store_credits = @user.store_credits.includes(:credit_type, :category).reverse_order
       end
 
       def create

--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -15,7 +15,7 @@ module Spree
       has_many :promotion_rules, through: :promotion_rule_users, class_name: 'Spree::PromotionRule'
 
       has_many :orders, foreign_key: :user_id, class_name: "Spree::Order"
-      has_many :store_credits, -> { includes(:credit_type) }, foreign_key: "user_id", class_name: "Spree::StoreCredit"
+      has_many :store_credits, foreign_key: :user_id, class_name: 'Spree::StoreCredit'
 
       belongs_to :ship_address, class_name: 'Spree::Address'
       belongs_to :bill_address, class_name: 'Spree::Address'


### PR DESCRIPTION
These includes are required only in `Spree::Admin::StoreCreditsController`, so why force it globally. Also adding `Spree::StoreCreditCategory` to includes for fewer SQL queries.
