### PR TITLE
Store Credits: store credit duplicate translation key fix

### DIFF
--- a/backend/app/views/spree/admin/payments/source_views/_storecredit.html.erb
+++ b/backend/app/views/spree/admin/payments/source_views/_storecredit.html.erb
@@ -1,5 +1,5 @@
 <fieldset data-hook="store_credit">
-  <legend><%= Spree.t(:store_credit) %></legend>
+  <legend><%= Spree.t(:store_credit_name) %></legend>
   <table class="table table-condensed table-bordered">
     <tr>
       <th width="20%"><%= Spree.t(:used) %>:</th>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1339,7 +1339,7 @@ en:
     stock_transfers: Stock Transfers
     stop: Stop
     store: Store
-    store_credit: Store Credit
+    store_credit_name: Store Credit
     store_credit:
       credit: "Credit"
       authorized: "Authorized"

--- a/frontend/app/views/spree/checkout/_summary.html.erb
+++ b/frontend/app/views/spree/checkout/_summary.html.erb
@@ -64,7 +64,7 @@
 
     <% if order.using_store_credit? %>
       <tr data-hook="order_details_store_credit">
-        <td><%= Spree.t(:store_credit) %>:</strong></td>
+        <td><%= Spree.t(:store_credit_name) %>:</strong></td>
         <td><span id='summary-store-credit'><%= order.display_total_applied_store_credit.to_html %></span></td>
       </tr>
     <% end %>


### PR DESCRIPTION
There were 2 `store_credit` translation keys which obviously was a bug. This PR fixes it. 
