### PR TITLE
Admin Panel: "security settings" panel hidden if no security settings present

### DIFF
--- a/backend/app/views/spree/admin/general_settings/edit.html.erb
+++ b/backend/app/views/spree/admin/general_settings/edit.html.erb
@@ -59,29 +59,30 @@
 
       <div class="row">
         <div class="col-md-6">
-
           <%#-------------------------------------------------%>
           <%# Security settings                               %>
           <%#-------------------------------------------------%>
-          <div class="panel panel-default security">
-            <div class="panel-heading">
-              <h1 class="panel-title">
-                <%= Spree.t(:security_settings)%>
-              </h1>
-            </div>
+          <% if @preferences_security.any? %>
+            <div class="panel panel-default security">
+              <div class="panel-heading">
+                <h1 class="panel-title">
+                  <%= Spree.t(:security_settings) %>
+                </h1>
+              </div>
 
-            <div class="panel-body">
-              <% @preferences_security.each do |key|
-                  type = Spree::Config.preference_type(key) %>
-                  <div class="checkbox">
-                    <%= label_tag key do %>
-                      <%= preference_field_tag(key, Spree::Config[key], type: type) %>
-                      <%= Spree.t(key) %>
-                    <% end %>
-                  </div>
-              <% end %>
+              <div class="panel-body">
+                <% @preferences_security.each do |key|
+                    type = Spree::Config.preference_type(key) %>
+                    <div class="checkbox">
+                      <%= label_tag key do %>
+                        <%= preference_field_tag(key, Spree::Config[key], type: type) %>
+                        <%= Spree.t(key) %>
+                      <% end %>
+                    </div>
+                <% end %>
+              </div>
             </div>
-          </div>
+          <% end %>
 
           <%#-------------------------------------------------%>
           <%# Clear cache                                     %>

--- a/backend/spec/features/admin/configuration/general_settings_spec.rb
+++ b/backend/spec/features/admin/configuration/general_settings_spec.rb
@@ -15,6 +15,7 @@ describe "General Settings", type: :feature do
       expect(find("#store_name").value).to eq("Test Store")
       expect(find("#store_url").value).to eq("test.example.org")
       expect(find("#store_mail_from_address").value).to eq("test@example.org")
+      expect(page).to_not have_content(Spree.t(:security_settings))
     end
   end
 


### PR DESCRIPTION
Since `Spree::Alert` has been removed (https://github.com/spree/spree/commit/ccd5638a91db5a5ac3992a322cf546cdad9a7720) this was always displaying empty section in `Admin Panel / Configuration / General Settings` - so let’s hide it. If someone has some custom security settings it will be visible, though.
