### PR TITLE
Admin panel: "ship button" color fix + small linter fixes of _buttons.scss

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_buttons.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_buttons.scss
@@ -31,10 +31,11 @@
     padding-right: 3px;
   }
 
-  .action-void { @extend .btn-danger; }
-  .action-capture { @extend .btn-success; }
-  .payment-action-edit { @extend .btn-primary; }
   .ship { color: $btn-success-color; }
 }
 
 .btn-sm .glyphicon { padding: 0; }
+
+.btn.action-void { @extend .btn-danger; }
+.btn.action-capture { @extend .btn-success; }
+.btn.payment-action-edit { @extend .btn-primary; }

--- a/backend/app/assets/stylesheets/spree/backend/components/_buttons.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_buttons.scss
@@ -1,4 +1,5 @@
-.btn, .nav-pills > li > a {
+.btn,
+.nav-pills > li > a {
   letter-spacing: 1px;
   vertical-align: middle;
   transition: color 0.1s linear 0s,background-color 0.1s linear 0s,opacity 0.2s linear 0s !important;
@@ -9,29 +10,31 @@
   -webkit-font-feature-settings: "kern" 1;
   -moz-font-feature-settings: "kern" 1;
 }
+
 .btn {
   text-align: center;
 
   &:focus {
     outline: 0 !important;
   }
-  
+
   &:hover,
   &:focus,
   &:active,
   &.active,
   &.disabled,
   &[disabled] {
-      box-shadow: none;
+    box-shadow: none;
   }
 
   .glyphicon {
     padding-right: 3px;
   }
+
+  .action-void { @extend .btn-danger; }
+  .action-capture { @extend .btn-success; }
+  .payment-action-edit { @extend .btn-primary; }
+  .ship { color: $btn-success-color; }
 }
 
 .btn-sm .glyphicon { padding: 0; }
-
-.btn.action-void { @extend .btn-danger; }
-.btn.action-capture { @extend .btn-success; }
-.btn.payment-action-edit { @extend .btn-primary; }

--- a/backend/app/views/spree/admin/payments/_list.html.erb
+++ b/backend/app/views/spree/admin/payments/_list.html.erb
@@ -28,7 +28,7 @@
             <% if action == 'credit' %>
               <%= link_to_with_icon('refund', Spree.t(:refund), new_admin_order_payment_refund_path(@order, payment), no_text: true, class: "btn btn-default btn-sm") if can?(:create, Spree::Refund) %>
             <% else %>
-              <%= link_to_with_icon(action, Spree.t(action), fire_admin_order_payment_path(@order, payment, e: action), method: :put, no_text: true, data: { action: action }, class: "btn btn-danger btn-sm") if can?(action.to_sym, payment) %>
+              <%= link_to_with_icon(action, Spree.t(action), fire_admin_order_payment_path(@order, payment, e: action), method: :put, no_text: true, data: { action: action }, class: "btn btn-default btn-sm") if can?(action.to_sym, payment) %>
             <% end %>
           <% end %>
         </td>

--- a/backend/app/views/spree/admin/payments/_list.html.erb
+++ b/backend/app/views/spree/admin/payments/_list.html.erb
@@ -28,7 +28,7 @@
             <% if action == 'credit' %>
               <%= link_to_with_icon('refund', Spree.t(:refund), new_admin_order_payment_refund_path(@order, payment), no_text: true, class: "btn btn-default btn-sm") if can?(:create, Spree::Refund) %>
             <% else %>
-              <%= link_to_with_icon(action, Spree.t(action), fire_admin_order_payment_path(@order, payment, e: action), method: :put, no_text: true, data: { action: action }, class: "btn btn-default btn-sm") if can?(action.to_sym, payment) %>
+              <%= link_to_with_icon(action, Spree.t(action), fire_admin_order_payment_path(@order, payment, e: action), method: :put, no_text: true, data: { action: action }, class: "btn btn-danger btn-sm") if can?(action.to_sym, payment) %>
             <% end %>
           <% end %>
         </td>


### PR DESCRIPTION
Like all success buttons, this one should have the same color, but other CSS rule overrides it - so fixing it. Additionally some small linter fixes for the whole `_buttons.scss` file.
