### PR TITLE
Admin Panel: pretty_time used in user lifetime stats and order state changes

### DIFF
--- a/backend/app/views/spree/admin/state_changes/index.html.erb
+++ b/backend/app/views/spree/admin/state_changes/index.html.erb
@@ -26,9 +26,9 @@
             <%= link_to state_change.user.login, spree.admin_user_path(state_change.user) if state_change.user %>
           </td>
           <td>
-            <%= l(state_change.created_at) %>
+            <%= pretty_time(state_change.created_at) %>
             <% if state_change.created_at != state_change.updated_at %>
-              <small><%= Spree::StateChange.human_attribute_name(:updated)%>: <%= l(state_change.updated_at) %></small>
+              <small><%= Spree::StateChange.human_attribute_name(:updated) %>: <%= pretty_time(state_change.updated_at) %></small>
             <% end %>
           </td>
         </tr>

--- a/backend/app/views/spree/admin/users/_lifetime_stats.html.erb
+++ b/backend/app/views/spree/admin/users/_lifetime_stats.html.erb
@@ -4,7 +4,7 @@
       <%= Spree.t(:lifetime_stats) %>
     </h1>
   </div>
-  
+
   <table class="table" id="user-lifetime-stats" data-hook>
     <tr>
       <td width="30%"><%= Spree.t(:total_sales) %>:</td>
@@ -24,7 +24,7 @@
     </tr>
     <tr>
       <td><%= Spree.t(:member_since) %>:</td>
-      <td><%= l @user.created_at.to_date %></td>
+      <td><%= pretty_time(@user.created_at) %></td>
     </tr>
   </table>
 </div>

--- a/backend/spec/features/admin/users_spec.rb
+++ b/backend/spec/features/admin/users_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe 'Users', type: :feature do
+  include Spree::BaseHelper
   stub_authorization!
 
   let!(:country) { create(:country) }
@@ -33,7 +34,7 @@ describe 'Users', type: :feature do
         expect(page).to have_content (order.total + order_2.total)
         expect(page).to have_content orders.count
         expect(page).to have_content (orders.sum(&:total) / orders.count)
-        expect(page).to have_content I18n.l(user_a.created_at.to_date)
+        expect(page).to have_content pretty_time(user_a.created_at)
       end
     end
 


### PR DESCRIPTION
1. `pretty_time` used for displaying user registration date in lifetime stats section
2. `pretty_time` used for displaying dates in order state changes
