### PR TITLE
Admin Panel: unified order completion DateTime format - not with time actually

### DIFF
--- a/backend/app/helpers/spree/admin/base_helper.rb
+++ b/backend/app/helpers/spree/admin/base_helper.rb
@@ -149,6 +149,10 @@ module Spree
         link_to_with_icon 'arrow-left', button_text, path, class: 'btn btn-default'
       end
 
+      def order_time(time)
+        [I18n.l(time.to_date), time.strftime("%l:%M %p")].join('')
+      end
+
       private
         def attribute_name_for(field_name)
           field_name.gsub(' ', '_').downcase

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -171,7 +171,9 @@
     <tbody>
     <% @orders.each do |order| %>
       <tr data-hook="admin_orders_index_rows" class="state-<%= order.state.downcase %> <%= cycle('odd', 'even') %>">
-        <td><%= l (@show_only_completed ? order.completed_at : order.created_at).try!(:to_date) %></td>
+        <td>
+          <%= order_time(@show_only_completed ? order.completed_at : order.created_at) %>
+        </td>
         <td><%= link_to order.number, edit_admin_order_path(order) %></td>
         <td>
           <span class="label label-<%= order.considered_risky ? 'considered_risky' : 'considered_safe' %>">

--- a/backend/app/views/spree/admin/users/items.html.erb
+++ b/backend/app/views/spree/admin/users/items.html.erb
@@ -24,7 +24,7 @@
         <% @orders.each do |order| %>
           <% order.line_items.each do |item| %>
             <tr class="stock-item" data-item-quantity="<%= item.quantity %>">
-              <td class="order-completed-at"><%= l(order.completed_at.to_date) if order.completed_at %></td>
+              <td class="order-completed-at"><%= order_time(order.completed_at) if order.completed_at %></td>
               <td class="item-image">
                 <%= mini_image(item.variant) %>
               </td>

--- a/backend/app/views/spree/admin/users/orders.html.erb
+++ b/backend/app/views/spree/admin/users/orders.html.erb
@@ -22,7 +22,7 @@
       <tbody>
       <% @orders.each do |order| %>
         <tr data-hook="admin_orders_index_rows" class="state-<%= order.state.downcase %> <%= cycle('odd', 'even') %>">
-          <td class="order-completed-at"><%= l(order.completed_at.to_date) if order.completed_at %></td>
+          <td class="order-completed-at"><%= order_time(order.completed_at) if order.completed_at %></td>
           <td class="order-number"><%= link_to order.number, edit_admin_order_path(order) %></td>
           <td class="order-state">
             <div class="state <%= order.state.downcase %>"><%= Spree.t("order_state.#{order.state.downcase}") %></div>

--- a/backend/spec/features/admin/users_spec.rb
+++ b/backend/spec/features/admin/users_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe 'Users', type: :feature do
   stub_authorization!
+  include Spree::Admin::BaseHelper
 
   let!(:country) { create(:country) }
   let!(:user_a) { create(:user_with_addresses, email: 'a@example.com') }
@@ -219,8 +220,8 @@ describe 'Users', type: :feature do
 
     context "completed_at" do
       it_behaves_like "a sortable attribute" do
-        let(:text_match_1) { I18n.l(order.completed_at.to_date) }
-        let(:text_match_2) { I18n.l(order_2.completed_at.to_date) }
+        let(:text_match_1) { order_time(order.completed_at) }
+        let(:text_match_2) { order_time(order_2.completed_at) }
         let(:table_id) { "listing_orders" }
         let(:sort_link) { "orders_completed_at_title" }
       end
@@ -250,8 +251,8 @@ describe 'Users', type: :feature do
 
     context "completed_at" do
       it_behaves_like "a sortable attribute" do
-        let(:text_match_1) { I18n.l(order.completed_at.to_date) }
-        let(:text_match_2) { I18n.l(order_2.completed_at.to_date) }
+        let(:text_match_1) { order_time(order.completed_at) }
+        let(:text_match_2) { order_time(order_2.completed_at) }
         let(:table_id) { "listing_items" }
         let(:sort_link) { "orders_completed_at_title" }
       end

--- a/backend/spec/helpers/admin/base_helper_spec.rb
+++ b/backend/spec/helpers/admin/base_helper_spec.rb
@@ -21,4 +21,10 @@ describe Spree::Admin::BaseHelper, :type => :helper do
       expect(plural_resource_name(resource_class)).to eq("Products")
     end
   end
+
+  context "#order_time" do
+    it "prints in a format" do
+      expect(order_time(DateTime.new(2016, 5, 6, 13, 33))).to eq "2016-05-06 1:33 PM"
+    end
+  end
 end


### PR DESCRIPTION
Previously store owners to check the time of placing an order would have to visit the order page which wasn't a good user experience choice. Now it displays date and time in condensed format so it also doesn't cost a lot of screen space. For this, there is a new helper method called `order_time` used everywhere in the Admin Panel for displaying order completion date & time.

![screen shot 2016-03-13 at 9 56 07 am](https://cloud.githubusercontent.com/assets/55154/13727903/75679a12-e905-11e5-8a80-d767818795c8.png)
