### PR TITLE
Admin Panel: new Stock Movement page moved to the new modern look & feel

### DIFF
--- a/backend/app/views/spree/admin/stock_movements/_form.html.erb
+++ b/backend/app/views/spree/admin/stock_movements/_form.html.erb
@@ -1,12 +1,12 @@
 <div data-hook="admin_stock_movements_form_fields">
   <%= f.field_container :quantity, class: ['form-group'] do %>
     <%= f.label :quantity, Spree.t(:quantity) %>
-    <%= f.text_field :quantity %>
+    <%= f.text_field :quantity, class: 'form-control' %>
   <% end %>
   <%= f.field_container :stock_item_id, class: ['form-group'] do %>
     <%= f.label :stock_item_id, Spree.t(:stock_item_id) %>
-    <%= f.text_field 'stock_item_id', :class => 'form-control', :'data-stock-location-id' => params[:stock_location_id] %>
+    <%= f.text_field 'stock_item_id', :'data-stock-location-id' => params[:stock_location_id] %>
   <% end %>
 </div>
 
-<%= render :partial => "spree/admin/variants/autocomplete", :formats => :js %>
+<%= render partial: "spree/admin/variants/autocomplete", formats: :js %>

--- a/backend/app/views/spree/admin/stock_movements/index.html.erb
+++ b/backend/app/views/spree/admin/stock_movements/index.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:new_stock_movement), new_admin_stock_location_stock_movement_path(@stock_location), icon: 'plus', id: 'admin_new_stock_movement_link' %>
+  <%= button_link_to Spree.t(:new_stock_movement), new_admin_stock_location_stock_movement_path(@stock_location), icon: 'add', class: 'btn-success', id: 'admin_new_stock_movement_link' %>
   <%= back_to_list_button(Spree::StockLocation.model_name.human, admin_stock_locations_path) %>
 <% end %>
 

--- a/backend/app/views/spree/admin/stock_movements/new.html.erb
+++ b/backend/app/views/spree/admin/stock_movements/new.html.erb
@@ -3,14 +3,14 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <li><%= link_to_with_icon 'arrow-left', Spree.t(:back_to_stock_movements_list), admin_stock_location_stock_movements_path(stock_location), :class => 'btn btn-default' %></li>
+  <%= back_to_list_button(Spree::StockMovement.model_name.human, admin_stock_location_stock_movements_path(stock_location)) %>
 <% end %>
 
-<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @stock_movement } %>
+<%= render partial: 'spree/admin/shared/error_messages', locals: { target: @stock_movement } %>
 
 <%= form_for [:admin, stock_location, @stock_movement] do |f| %>
   <fieldset>
-    <%= render :partial => 'form', :locals => { :f => f } %>
-    <%= render :partial => 'spree/admin/shared/new_resource_links', locals: { collection_url: admin_stock_location_stock_movements_path(stock_location) } %>
+    <%= render partial: 'form', locals: { :f => f } %>
+    <%= render partial: 'spree/admin/shared/new_resource_links', locals: { collection_url: admin_stock_location_stock_movements_path(stock_location) } %>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/stock_movements/new.html.erb
+++ b/backend/app/views/spree/admin/stock_movements/new.html.erb
@@ -10,7 +10,7 @@
 
 <%= form_for [:admin, stock_location, @stock_movement] do |f| %>
   <fieldset>
-    <%= render partial: 'form', locals: { :f => f } %>
+    <%= render partial: 'form', locals: { f: f } %>
     <%= render partial: 'spree/admin/shared/new_resource_links', locals: { collection_url: admin_stock_location_stock_movements_path(stock_location) } %>
   </fieldset>
 <% end %>


### PR DESCRIPTION
This page was still in the era of old Spree 2.x admin panel merged with some Spree 3.x goodies. Moved it completely to the new modern look. Also Admin Panel: Stock Movements page - new Stock Movement button had old CSS class.
### Old

![screen shot 2016-03-13 at 10 24 25 am](https://cloud.githubusercontent.com/assets/55154/13728025/b5f5fd9a-e909-11e5-87e3-1979c4491092.png)
### New

![screen shot 2016-03-13 at 10 24 40 am](https://cloud.githubusercontent.com/assets/55154/13728026/bbe02532-e909-11e5-8611-2d1b73b4ed6d.png)
