### PR TITLE
Allow users to edit their Payment after getting to Confirm checkout step

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'json', '~> 1.7'
   s.add_dependency 'kaminari', '~> 0.15', '>= 0.15.1'
   s.add_dependency 'monetize', '~> 1.1'
-  s.add_dependency 'paperclip', '~> 4.2.0'
+  s.add_dependency 'paperclip'
   s.add_dependency 'paranoia', '~> 2.1.0'
   s.add_dependency 'premailer-rails'
   s.add_dependency 'rails', '~> 4.1.11'

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -153,7 +153,7 @@ module Spree
           # @order.reload sets @order.state back to "confirm," which we don't want.
           # Set the state back to payment so that the user can edit their payment after
           # getting to the confirm page (or on a failed payment attempt)
-          @order.state = 'payment'
+          @order.state = "payment"
         end
 
         if try_spree_current_user && try_spree_current_user.respond_to?(:payment_sources)

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -150,6 +150,10 @@ module Spree
           # As an intermediary step to optimize reloads out of high volume code path
           # the reload was lifted here and will be removed by later passes.
           @order.reload
+          # @order.reload sets @order.state back to "confirm," which we don't want.
+          # Set the state back to payment so that the user can edit their payment after
+          # getting to the confirm page (or on a failed payment attempt)
+          @order.state = 'payment'
         end
 
         if try_spree_current_user && try_spree_current_user.respond_to?(:payment_sources)


### PR DESCRIPTION
@order.reload sets @order.state back to "confirm," which we don't want. Set the state back to payment so that the user can edit their payment after getting to the confirm page (or on a failed payment attempt).

Without this, the user gets continually presented with the "confirm" step unless they go back to "address" and forward again from there.
