### PR TITLE
Fix and unify 'back to users list' button in users editing section

### DIFF
--- a/backend/app/views/spree/admin/store_credits/index.html.erb
+++ b/backend/app/views/spree/admin/store_credits/index.html.erb
@@ -5,7 +5,7 @@
 <%= render partial: 'spree/admin/users/sidebar', locals: { current: :store_credits } %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:back_to_users_list), spree.admin_users_path, class: 'btn-primary', icon: 'chevron-left' %>
+  <%= back_to_list_button(Spree.user_class.model_name.human, spree.admin_users_path) %>
   <%= button_link_to Spree.t(:add_store_credit), spree.new_admin_user_store_credit_path(@user), class: "btn-success", icon: 'add' %>
 <% end %>
 

--- a/backend/app/views/spree/admin/users/_user_page_actions.html.erb
+++ b/backend/app/views/spree/admin/users/_user_page_actions.html.erb
@@ -1,4 +1,4 @@
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:back_to_users_list), spree.admin_users_path, class: 'btn-primary', icon: 'chevron-left' %>
+  <%= back_to_list_button(Spree.user_class.model_name.human, spree.admin_users_path) %>
   <%= button_link_to Spree.t(:create_new_order), spree.new_admin_order_path(user_id: @user.id), class: "btn-success", icon: 'add' %>
 <% end %>

--- a/backend/app/views/spree/admin/users/edit.html.erb
+++ b/backend/app/views/spree/admin/users/edit.html.erb
@@ -2,10 +2,6 @@
   <%= Spree.t(:editing_user) %> <%= @user.email %>
 <% end %>
 
-<% content_for :page_actions do %>
-  <%= back_to_list_button(Spree.user_class.model_name.human, admin_users_path) %>
-<% end %>
-
 <%= render partial: 'spree/admin/users/sidebar', locals: { current: :account } %>
 <%= render partial: 'spree/admin/users/user_page_actions' %>
 

--- a/backend/spec/features/admin/users_spec.rb
+++ b/backend/spec/features/admin/users_spec.rb
@@ -38,7 +38,7 @@ describe 'Users', type: :feature do
     end
 
     it 'can go back to the users list' do
-      expect(page).to have_link Spree.t(:back_to_users_list), href: spree.admin_users_path
+      expect(page).to have_link Spree.user_class.model_name.human, href: spree.admin_users_path
     end
 
     it 'can navigate to the account page' do


### PR DESCRIPTION
Removes additional 'back to users list' button from Users edit admin page.
Unifies 'back to users list' buttons from Users edit section to fit rest of admin panel design. 
