### PR TITLE
Bump rails dependency version to 4.2.6

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'paperclip', '~> 4.2.0'
   s.add_dependency 'paranoia', '~> 2.1.0'
   s.add_dependency 'premailer-rails'
-  s.add_dependency 'rails', '~> 4.2.5'
+  s.add_dependency 'rails', '~> 4.2.6'
   s.add_dependency 'ransack', '~> 1.4.1'
   s.add_dependency 'responders'
   s.add_dependency 'state_machines-activerecord', '~> 0.2'


### PR DESCRIPTION
There were some important security fixes after 4.2.5.1.
http://weblog.rubyonrails.org/2016/2/29/Rails-4-2-5-2-4-1-14-2-3-2-22-2-have-been-released/
