### PR TITLE
render render_js_for_destroy when object is not destroyed

### DIFF
--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -88,17 +88,14 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
     if @object.destroy
       invoke_callbacks(:destroy, :after)
       flash[:success] = flash_message_for(@object, :successfully_removed)
-      respond_with(@object) do |format|
-        format.html { redirect_to location_after_destroy }
-        format.js   { render_js_for_destroy }
-      end
     else
       invoke_callbacks(:destroy, :fails)
       flash[:error] = @object.errors.full_messages.join(', ')
-      respond_with(@object) do |format|
-        format.html { redirect_to location_after_destroy }
-        format.js
-      end
+    end
+
+    respond_with(@object) do |format|
+      format.html { redirect_to location_after_destroy }
+      format.js   { render_js_for_destroy }
     end
   end
 

--- a/backend/app/views/spree/admin/shared/_destroy.js.erb
+++ b/backend/app/views/spree/admin/shared/_destroy.js.erb
@@ -1,9 +1,9 @@
 <% if success = flash.discard(:success) %>
-  show_flash('success', "<%= j success %>")
+  show_flash('success', "<%= j success %>");
 <% end %>
 
 <% if error = flash.discard(:error) %>
-show_flash('warning', "<%= j error %>")
+  show_flash('warning', "<%= j error %>");
 <% end %>
 
 <%= render :partial => '/spree/admin/shared/update_order_state' if @order %>


### PR DESCRIPTION
- Render render_js_for_destroy when object is not destroyed in resource controller.
- Fix indentation in admin/shared/_destroy.js.erb.
