### PR TITLE
refactor product and variant model for restrict destroy line items…

### DIFF
--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -47,10 +47,11 @@ module Spree
 
         begin
           # TODO: why is @product.destroy raising ActiveRecord::RecordNotDestroyed instead of failing with false result
+          # Issue found for above comment: https://github.com/rails/rails/issues/19761
           if @product.destroy
             flash[:success] = Spree.t('notice_messages.product_deleted')
           else
-            flash[:error] = Spree.t('notice_messages.product_not_deleted')
+            flash[:error] = @object.errors.full_messages.join(', ')
           end
         rescue ActiveRecord::RecordNotDestroyed => e
           flash[:error] = Spree.t('notice_messages.product_not_deleted')

--- a/backend/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/products_controller_spec.rb
@@ -62,10 +62,13 @@ describe Spree::Admin::ProductsController, type: :controller do
     end
 
     context 'will not successfully destroy product' do
+      let!(:error_message) { 'Test error' }
+
       before do
         allow(Spree::Product).to receive(:friendly).and_return(products)
         allow(products).to receive(:find).with(product.id.to_s).and_return(product)
         allow(product).to receive(:destroy).and_return(false)
+        allow(product).to receive_message_chain(:errors, :full_messages).and_return([error_message])
       end
 
       describe 'expects to receive' do
@@ -84,7 +87,7 @@ describe Spree::Admin::ProductsController, type: :controller do
       describe 'response' do
         before { send_request }
         it { expect(response).to have_http_status(:ok) }
-        it { expect(flash[:error]).to eq(Spree.t('notice_messages.product_not_deleted')) }
+        it { expect(flash[:error]).to eq(error_message) }
       end
     end
   end

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -87,7 +87,6 @@ module Spree
     after_save :run_touch_callbacks, if: :anything_changed?
     after_save :reset_nested_changes
     after_touch :touch_taxons
-    before_destroy :ensure_no_line_items
 
     before_validation :normalize_slug, on: :update
     before_validation :validate_master
@@ -354,13 +353,6 @@ module Spree
     def touch_taxons
       Spree::Taxon.where(id: taxon_and_ancestors.map(&:id)).update_all(updated_at: Time.current)
       Spree::Taxonomy.where(id: taxonomy_ids).update_all(updated_at: Time.current)
-    end
-
-    def ensure_no_line_items
-      if line_items.any?
-        errors.add(:base, Spree.t(:cannot_destroy_if_attached_to_line_items))
-        return false
-      end
     end
 
     def remove_taxon(taxon)

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -14,9 +14,10 @@ module Spree
 
     with_options inverse_of: :variant do
       has_many :inventory_units
-      has_many :line_items
       has_many :stock_items, dependent: :destroy
     end
+
+    has_many :line_items, dependent: :restrict_with_error
 
     has_many :orders, through: :line_items
     with_options through: :stock_items do
@@ -48,7 +49,6 @@ module Spree
 
     after_create :create_stock_items
     after_create :set_master_out_of_stock, unless: :is_master?
-    before_destroy :ensure_no_line_items
 
     after_touch :clear_in_stock_cache
 
@@ -257,13 +257,6 @@ module Spree
     end
 
     private
-
-    def ensure_no_line_items
-      if line_items.any?
-        errors.add(:base, Spree.t(:cannot_destroy_if_attached_to_line_items))
-        return false
-      end
-    end
 
     def quantifier
       Spree::Stock::Quantifier.new(self)

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -309,10 +309,6 @@ en:
           attributes:
             currency:
               must_match_order_currency: "Must match order currency"
-        spree/product:
-          attributes:
-            base:
-              cannot_destroy_if_attached_to_line_items: Cannot delete products once they are attached to line items.
         spree/refund:
           attributes:
             amount:
@@ -331,10 +327,6 @@ en:
           attributes:
             base:
               cannot_destroy_default_store: Cannot destroy the default Store.
-        spree/variant:
-          attributes:
-            base:
-              cannot_destroy_if_attached_to_line_items: Cannot delete variants once they are attached to line items.
         spree/shipping_method:
           attributes:
             base:


### PR DESCRIPTION
- `before_destroy :ensure_no_line_items` should not be present in product model as it is already verified by variant model.
- `before_destroy :ensure_no_line_items` can also be done using `dependent: :restrict_with_error`.
- Some refactors in products_controller
