### PR TITLE
Set correct i18n locale based on different locales present in app

### DIFF
--- a/core/lib/spree/core/controller_helpers/common.rb
+++ b/core/lib/spree/core/controller_helpers/common.rb
@@ -51,9 +51,9 @@ module Spree
 
           def set_user_language
             locale = session[:locale]
-            locale ||= config_locale if respond_to?(:config_locale, true)
-            locale ||= Rails.application.config.i18n.default_locale
-            locale ||= I18n.default_locale unless I18n.available_locales.map(&:to_s).include?(locale)
+            locale = config_locale if respond_to?(:config_locale, true) && locale.blank?
+            locale = Rails.application.config.i18n.default_locale if locale.blank?
+            locale = I18n.default_locale unless I18n.available_locales.map(&:to_s).include?(locale.to_s)
             I18n.locale = locale
           end
 

--- a/frontend/spec/controllers/controller_helpers_spec.rb
+++ b/frontend/spec/controllers/controller_helpers_spec.rb
@@ -5,22 +5,118 @@ require 'spec_helper'
 # ProductsController is good.
 describe Spree::ProductsController, :type => :controller do
 
+  let!(:available_locales) { [:en, :de] }
+  let!(:available_locale) { :de }
+  let!(:unavailable_locale) { :ru }
+
   before do
     I18n.enforce_available_locales = false
-    expect(I18n).to receive(:available_locales).and_return([:en, :de])
-    Spree::Frontend::Config[:locale] = :de
+    expect(I18n).to receive(:available_locales).and_return(available_locales)
   end
 
   after do
     Spree::Frontend::Config[:locale] = :en
+    Rails.application.config.i18n.default_locale = :en
     I18n.locale = :en
     I18n.enforce_available_locales = true
   end
 
   # Regression test for #1184
-  it "sets the default locale based off Spree::Frontend::Config[:locale]" do
-    expect(I18n.locale).to eq(:en)
-    spree_get :index
-    expect(I18n.locale).to eq(:de)
+  context 'when session locale not set' do
+    before(:each) do
+      session[:locale] = nil
+    end
+
+    context 'when Spree::Frontend::Config[:locale] not present' do
+      before(:each) do
+        Spree::Frontend::Config[:locale] = nil
+      end
+
+      context 'when rails application default locale not set' do
+        before(:each) do
+          Rails.application.config.i18n.default_locale = nil
+        end
+
+        it "sets the I18n default locale" do
+          spree_get :index
+          expect(I18n.locale).to eq(I18n.default_locale)
+        end
+      end
+
+      context 'when rails application default locale is set' do
+        context 'and not in available_locales' do
+          before(:each) do
+            Rails.application.config.i18n.default_locale = unavailable_locale
+          end
+
+          it "sets the I18n default locale" do
+            spree_get :index
+            expect(I18n.locale).to eq(I18n.default_locale)
+          end
+        end
+
+        context 'and in available_locales' do
+          before(:each) do
+            Rails.application.config.i18n.default_locale = available_locale
+          end
+
+          it "sets the rails app locale" do
+            expect(I18n.locale).to eq(:en)
+            spree_get :index
+            expect(I18n.locale).to eq(available_locale)
+          end
+        end
+      end
+    end
+
+    context 'when Spree::Frontend::Config[:locale] is present' do
+      context 'and not in available_locales' do
+        before(:each) do
+          Spree::Frontend::Config[:locale] = unavailable_locale
+        end
+
+        it "sets the I18n default locale" do
+          spree_get :index
+          expect(I18n.locale).to eq(I18n.default_locale)
+        end
+      end
+
+      context 'and not in available_locales' do
+        before(:each) do
+          Spree::Frontend::Config[:locale] = available_locale
+        end
+
+        it "sets the default locale based on Spree::Frontend::Config[:locale]" do
+          expect(I18n.locale).to eq(:en)
+          spree_get :index
+          expect(I18n.locale).to eq(available_locale)
+        end
+      end
+    end
+  end
+
+  context 'when session locale is set' do
+    context 'and not in available_locales' do
+      before(:each) do
+        session[:locale] = unavailable_locale
+      end
+
+      it "sets the I18n default locale" do
+        spree_get :index
+        expect(I18n.locale).to eq(I18n.default_locale)
+      end
+    end
+
+    context 'and in available_locales' do
+      before(:each) do
+        session[:locale] = available_locale
+      end
+
+      it "sets the session locale" do
+        expect(I18n.locale).to eq(:en)
+        spree_get :index
+        expect(I18n.locale).to eq(available_locale)
+      end
+    end
   end
 end


### PR DESCRIPTION
- Set correct i18n locale based on different locales present in app.
- Add missing specs for each case.
