### PR TITLE
fix bad link reference in frontend stylesheet

### DIFF
--- a/frontend/app/assets/stylesheets/spree/frontend/frontend_bootstrap.css.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/frontend_bootstrap.css.scss
@@ -1,4 +1,4 @@
-//Add your custom bootstrap variables here, see https://github.com/twbs/bootstrap-sass/blob/master/vendor/assets/stylesheets/bootstrap/_variables.scss for full list of variables.
+//Add your custom bootstrap variables here, see https://github.com/twbs/bootstrap-sass/blob/master/assets/stylesheets/bootstrap/_variables.scss for full list of variables.
 
 @import "bootstrap-sprockets";
 @import "variables";


### PR DESCRIPTION
replace reference link for bootstrap variables list (current URL at top of stylesheet is a 404)
