### PR TITLE
load only available payment_method in order/store_credit

### DIFF
--- a/core/app/models/spree/order/store_credit.rb
+++ b/core/app/models/spree/order/store_credit.rb
@@ -7,7 +7,7 @@ module Spree
         remaining_total = outstanding_balance
 
         if user && user.store_credits.any?
-          payment_method = Spree::PaymentMethod.find_by_type('Spree::PaymentMethod::StoreCredit')
+          payment_method = Spree::PaymentMethod::StoreCredit.available.first
           raise "Store credit payment method could not be found" unless payment_method
 
           user.store_credits.order_by_priority.each do |credit|


### PR DESCRIPTION
In order/store_credit, `add_store_credit_payments` method find store credit payment, but it should also check whether the payment method is available or not.
