### PR TITLE
fix error in creating extension using spree command, fixes #7237

### DIFF
--- a/cmd/lib/spree_cmd/extension.rb
+++ b/cmd/lib/spree_cmd/extension.rb
@@ -32,7 +32,7 @@ module SpreeCmd
       say %{
         #{'*' * 80}
 
-        Your extension has been generated with a gemspec dependency on Spree #{Spree.version}.
+        Your extension has been generated with a gemspec dependency on Spree #{spree_version}.
 
         For more information on the versioning of Spree.
         See https://guides.spreecommerce.com/developer/extensions_tutorial.html#versioning-your-extension
@@ -44,6 +44,10 @@ module SpreeCmd
     no_tasks do
       def class_name
         Thor::Util.camel_case file_name
+      end
+
+      def spree_version
+        Gem.loaded_specs['spree_cmd'].version.to_s
       end
 
       def use_prefix(prefix)

--- a/cmd/lib/spree_cmd/templates/extension/extension.gemspec
+++ b/cmd/lib/spree_cmd/templates/extension/extension.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = '<%= file_name %>'
-  s.version     = '<%= Spree.version %>'
+  s.version     = '<%= spree_version %>'
   s.summary     = 'TODO: Add gem summary here'
   s.description = 'TODO: Add (optional) gem description here'
   s.required_ruby_version = '>= 2.1.0'
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '~> <%= Spree.version %>'
+  s.add_dependency 'spree_core', '~> <%= spree_version %>'
 
   s.add_development_dependency 'capybara', '~> 2.6'
   s.add_development_dependency 'coffee-rails'


### PR DESCRIPTION
Do not use `Spree` for version as the class is not loaded while creating extension when spree is not pre-loaded.
Fixes #7237 
