### PR TITLE
Add missing error messages in store_credit model

### DIFF
--- a/core/app/models/spree/store_credit.rb
+++ b/core/app/models/spree/store_credit.rb
@@ -223,21 +223,21 @@ module Spree
       return true if amount_used.nil?
 
       if amount_used > amount
-        errors.add(:amount_used, Spree.t('admin.store_credits.errors.amount_used_cannot_be_greater'))
+        errors.add(:amount_used, :cannot_be_greater_than_amount)
         false
       end
     end
 
     def amount_authorized_less_than_or_equal_to_amount
       if (amount_used + amount_authorized) > amount
-        errors.add(:amount_authorized, Spree.t('admin.store_credits.errors.amount_authorized_exceeds_total_credit'))
+        errors.add(:amount_authorized, :exceeds_total_credits)
         false
       end
     end
 
     def validate_no_amount_used
       if amount_used > 0
-        errors.add(:amount_used, 'is greater than zero. Can not delete store credit')
+        errors.add(:amount_used, :greater_than_zero_restrict_delete)
         false
       end
     end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -323,14 +323,25 @@ en:
               cannot_be_associated_unless_accepted: cannot be associated to a return item that is not accepted.
             inventory_unit:
               other_completed_return_item_exists: "%{inventory_unit_id} has already been taken by return item %{return_item_id}"
-        spree/store:
-          attributes:
-            base:
-              cannot_destroy_default_store: Cannot destroy the default Store.
         spree/shipping_method:
           attributes:
             base:
               required_shipping_category: "You must select at least one shipping category"
+        spree/store:
+          attributes:
+            base:
+              cannot_destroy_default_store: Cannot destroy the default Store.
+        spree/store_credit:
+          attributes:
+            amount_used:
+              cannot_be_greater_than_amount: Cannot be greater than amount.
+              greater_than_zero_restrict_delete: is greater than zero. Can not delete store credit.
+            amount_authorized:
+              exceeds_total_credits: Exceeds total credits.
+        spree/variant:
+          attributes:
+            base:
+              cannot_destroy_if_attached_to_line_items: Cannot delete variants once they are attached to line items.
 
   devise:
     confirmations:

--- a/core/spec/models/spree/store_credit_spec.rb
+++ b/core/spec/models/spree/store_credit_spec.rb
@@ -10,12 +10,13 @@ describe 'StoreCredit' do
 
     context 'amount used is greater than zero' do
       let(:store_credit) { create(:store_credit, amount: 100, amount_used: 1) }
+      let(:validation_message) { I18n.t('activerecord.errors.models.spree/store_credit.attributes.amount_used.greater_than_zero_restrict_delete') }
       subject { store_credit.destroy }
 
       it 'can not delete the store credit' do
         subject
         expect(store_credit.reload).to eq store_credit
-        expect(store_credit.errors[:amount_used]).to include('is greater than zero. Can not delete store credit')
+        expect(store_credit.errors[:amount_used]).to include(validation_message)
       end
     end
 
@@ -62,7 +63,7 @@ describe 'StoreCredit' do
         it 'should set the correct error message' do
           invalid_store_credit.valid?
           attribute_name = I18n.t('activerecord.attributes.spree/store_credit.amount_used')
-          validation_message = Spree.t('admin.store_credits.errors.amount_used_cannot_be_greater')
+          validation_message = I18n.t('activerecord.errors.models.spree/store_credit.attributes.amount_used.cannot_be_greater_than_amount')
           expected_error_message = "#{attribute_name} #{validation_message}"
           expect(invalid_store_credit.errors.full_messages).to include(expected_error_message)
         end
@@ -86,7 +87,7 @@ describe 'StoreCredit' do
 
       it 'adds an error message about the invalid amount used' do
         subject.valid?
-        text = Spree.t('admin.store_credits.errors.amount_used_cannot_be_greater')
+        text = I18n.t('activerecord.errors.models.spree/store_credit.attributes.amount_used.cannot_be_greater_than_amount')
         expect(subject.errors[:amount_used]).to include(text)
       end
     end
@@ -100,7 +101,7 @@ describe 'StoreCredit' do
 
       it 'adds an error message about the invalid authorized amount' do
         subject.valid?
-        text = Spree.t('admin.store_credits.errors.amount_authorized_exceeds_total_credit')
+        text = I18n.t('activerecord.errors.models.spree/store_credit.attributes.amount_authorized.exceeds_total_credits')
         expect(subject.errors[:amount_authorized]).to include(text)
       end
     end


### PR DESCRIPTION
Error messages are not present in en.yml for store credit model.

Done with little bit refactoring.
