### PR TITLE
Ability to reject payment method based on order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ test_app
 */.sass-cache
 .localeapp
 .ruby-gemset
+vendor/bundle
+*/vendor/bundle

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -406,7 +406,7 @@ module Spree
     end
 
     def available_payment_methods
-      @available_payment_methods ||= PaymentMethod.available_on_front_end
+      @available_payment_methods ||= collect_payment_methods
     end
 
     def insufficient_stock_lines
@@ -481,7 +481,6 @@ module Spree
     def can_add_coupon?
       Spree::Promotion.order_activatable?(self)
     end
-
 
     def shipped?
       %w(partial shipped).include?(shipment_state)
@@ -679,6 +678,10 @@ module Spree
 
     def create_token
       self.guest_token ||= generate_guest_token
+    end
+
+    def collect_payment_methods
+      PaymentMethod.available_on_front_end.select { |pm| pm.available_for_order?(self) }
     end
   end
 end

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -67,5 +67,11 @@ module Spree
     def store_credit?
       self.class == Spree::PaymentMethod::StoreCredit
     end
+
+    # Custom PaymentMethod/Gateway can redefine this method to check method
+    # availability for concrete order.
+    def available_for_order?(_order)
+      true
+    end
   end
 end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -531,6 +531,15 @@ describe Spree::Order, :type => :model do
       expect(order.available_payment_methods.count).to eq(1)
       expect(order.available_payment_methods).to include(payment_method)
     end
+
+    let(:ok_method) { double :payment_method, available_for_order?: true }
+    let(:no_method) { double :payment_method, available_for_order?: false }
+    let(:methods) { [ok_method, no_method] }
+
+    it "does not include a payment method that is not suitable for this order" do
+      allow(Spree::PaymentMethod).to receive(:available_on_front_end).and_return(methods)
+      expect(order.available_payment_methods).to match_array [ok_method]
+    end
   end
 
   context "#apply_free_shipping_promotions" do
@@ -960,8 +969,6 @@ describe Spree::Order, :type => :model do
       end
 
       it { expect(order.fully_discounted?).to eq false }
-
     end
   end
-
 end


### PR DESCRIPTION
For example: some payment method can be available for logged in user only (can be check via `order.user`) or payment method availability can depends on some user flags (as we have to do).
