### PR TITLE
Spree 3.1.0.rc1 rubygems installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Getting Started
 Add Spree gems to your Gemfile:
 
 ```ruby
-gem 'spree', '~> 3.0.7'
-gem 'spree_auth_devise', '~> 3.0.5'
-gem 'spree_gateway', '~> 3.0.0'
+gem 'spree', '~> 3.1.0.rc1'
+gem 'spree_auth_devise', '~> 3.1.0.rc1'
+gem 'spree_gateway', '~> 3.1.0.rc1'
 ```
 
 Run `bundle install`

--- a/guides/content/developer/upgrades/three-dot-oh-to-three-dot-one.md
+++ b/guides/content/developer/upgrades/three-dot-oh-to-three-dot-one.md
@@ -25,7 +25,7 @@ gem 'rails', '~> 4.2.6'
 For best results, use the spree gem in version 3.1.x:
 
 ```ruby
-gem 'spree', '~> 3.1.0'
+gem 'spree', '~> 3.1.0.rc1'
 ```
 
 Run `bundle update spree`.
@@ -43,8 +43,8 @@ these commands:
 If you are using Spree Gateway and/or Spree Auth Devise you should also upgrade them:
 
 ```ruby
-gem 'spree_auth_devise', '~> 3.1.0'
-gem 'spree_gateway', '~> 3.1.0'
+gem 'spree_auth_devise', '~> 3.1.0.rc1'
+gem 'spree_gateway', '~> 3.1.0.rc1'
 ```
 
 For Spree Auth Devise run installer:


### PR DESCRIPTION
Updated:
1. README.md standard installation process
2. `3.0` to `3.1` upgrade instructions
