### PR TITLE
Fix exceptions on checkout workflow when going direct to link

### DIFF
--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -6,12 +6,12 @@ module Spree
   class CheckoutController < Spree::StoreController
     before_action :load_order_with_lock
     before_action :ensure_valid_state_lock_version, only: [:update]
+    before_action :ensure_valid_state
     before_action :set_state_if_present
 
     before_action :ensure_order_not_completed
     before_action :ensure_checkout_allowed
     before_action :ensure_sufficient_stock_lines
-    before_action :ensure_valid_state
 
     before_action :associate_user
     before_action :check_authorization
@@ -50,7 +50,7 @@ module Spree
 
     def unknown_state?
       (params[:state] && !@order.has_checkout_step?(params[:state])) ||
-        (!params[:state] && !@order.has_checkout_step?(@order.state))
+        (!@order.has_checkout_step?(@order.state))
     end
 
     def insufficient_payment?


### PR DESCRIPTION
As described by bug 7176, when a user goes directly to a checkout link
without going to the cart and clicking through the user interface, they
can get an exception. Reproduction instructions are available on the bug
comment at
https://github.com/spree/spree/issues/7176#issuecomment-196119351

This patch fixes the bug by moving the check for checking whether a
state is valid to BEFORE setting the order state from the user
parameters. In addition, the unknown_state? method is changed to test
the order state regardless of whether the user has supplied a state in
the parameters.

Fixes #7176
