### PR TITLE
Fix for issue #6603

### DIFF
--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -20,6 +20,7 @@ module Spree
         update_payment_state
         update_shipments
         update_shipment_state
+        update_shipment_total
       end
       run_hooks
       persist_totals

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -210,52 +210,56 @@ module Spree
     context "completed order" do
       before { allow(order).to receive_messages completed?: true }
 
-      it "updates payment state" do
-        expect(updater).to receive(:update_payment_state)
-        updater.update
+      describe "#update" do
+        it "updates payment state" do
+          expect(updater).to receive(:update_payment_state)
+          updater.update
+        end
+
+        it "updates shipment state" do
+          expect(updater).to receive(:update_shipment_state)
+          updater.update
+        end
+
+        it "updates shipments total again after updating shipments" do
+          expect(updater).to receive(:update_shipment_total).ordered
+          expect(updater).to receive(:update_shipments).ordered
+          expect(updater).to receive(:update_shipment_total).ordered
+          updater.update
+        end
       end
 
-      it "updates shipment state" do
-        expect(updater).to receive(:update_shipment_state)
-        updater.update
-      end
+      describe "#update_shipments" do
+        it "updates each shipment" do
+          shipment = stub_model(Spree::Shipment, order: order)
+          shipments = [shipment]
+          allow(order).to receive_messages shipments: shipments
+          allow(shipments).to receive_messages states: []
+          allow(shipments).to receive_messages ready: []
+          allow(shipments).to receive_messages pending: []
+          allow(shipments).to receive_messages shipped: []
 
-      it "updates shipments total again after updating shipments" do
-        expect(updater).to receive(:update_shipment_total).ordered
-        expect(updater).to receive(:update_shipments).ordered
-        expect(updater).to receive(:update_shipment_total).ordered
-        updater.update
-      end
+          expect(shipment).to receive(:update!).with(order)
+          updater.update_shipments
+        end
 
-      it "updates each shipment" do
-        shipment = stub_model(Spree::Shipment, order: order)
-        shipments = [shipment]
-        allow(order).to receive_messages shipments: shipments
-        allow(shipments).to receive_messages states: []
-        allow(shipments).to receive_messages ready: []
-        allow(shipments).to receive_messages pending: []
-        allow(shipments).to receive_messages shipped: []
+        it "refreshes shipment rates" do
+          shipment = stub_model(Spree::Shipment, order: order)
+          shipments = [shipment]
+          allow(order).to receive_messages shipments: shipments
 
-        expect(shipment).to receive(:update!).with(order)
-        updater.update_shipments
-      end
+          expect(shipment).to receive(:refresh_rates)
+          updater.update_shipments
+        end
 
-      it "refreshes shipment rates" do
-        shipment = stub_model(Spree::Shipment, order: order)
-        shipments = [shipment]
-        allow(order).to receive_messages shipments: shipments
+        it "updates the shipment amount" do
+          shipment = stub_model(Spree::Shipment, order: order)
+          shipments = [shipment]
+          allow(order).to receive_messages shipments: shipments
 
-        expect(shipment).to receive(:refresh_rates)
-        updater.update_shipments
-      end
-
-      it "updates the shipment amount" do
-        shipment = stub_model(Spree::Shipment, order: order)
-        shipments = [shipment]
-        allow(order).to receive_messages shipments: shipments
-
-        expect(shipment).to receive(:update_amounts)
-        updater.update_shipments
+          expect(shipment).to receive(:update_amounts)
+          updater.update_shipments
+        end
       end
     end
 

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -220,6 +220,13 @@ module Spree
         updater.update
       end
 
+      it "updates shipments total again after updating shipments" do
+        expect(updater).to receive(:update_shipment_total).ordered
+        expect(updater).to receive(:update_shipments).ordered
+        expect(updater).to receive(:update_shipment_total).ordered
+        updater.update
+      end
+
       it "updates each shipment" do
         shipment = stub_model(Spree::Shipment, order: order)
         shipments = [shipment]


### PR DESCRIPTION
These changes fix issue #6603. I only added unit tests for the change but I manually verified that it works by using a custom ShipmentCalculator as described in the issue.
The fix is to recalculate total costs again after calculating shipment costs, so that the total is always up-to-date. In the scenario described in the issue, it will now show 0 shipping cost in each split shipment and 0 as the total shipment cost.
