### PR TITLE
Prevent users from updating completed orders

### DIFF
--- a/api/app/controllers/spree/api/v1/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/v1/checkouts_controller.rb
@@ -25,6 +25,12 @@ module Spree
         end
 
         def update
+          # not authorized to update if order is already in the completed state
+          if @order.completed?
+            authorize! :read, @order, order_token
+            respond_with(@order, default_template: 'spree/api/v1/orders/show') and return
+          end
+
           authorize! :update, @order, order_token
 
           if @order.update_from_params(params, permitted_checkout_attributes, request.headers.env)

--- a/core/app/models/spree/ability.rb
+++ b/core/app/models/spree/ability.rb
@@ -43,8 +43,11 @@ module Spree
         can :display, OptionType
         can :display, OptionValue
         can :create, Order
-        can [:read, :update], Order do |order, token|
+        can [:read], Order do |order, token|
           order.user == user || order.guest_token && token == order.guest_token
+        end
+        can [:update], Order do |order, token|
+          !order.completed? && (order.user == user || order.guest_token && token == order.guest_token)
         end
         can :display, CreditCard, user_id: user.id
         can :display, Product

--- a/core/app/models/spree/ability.rb
+++ b/core/app/models/spree/ability.rb
@@ -43,12 +43,12 @@ module Spree
         can :display, OptionType
         can :display, OptionValue
         can :create, Order
-        can [:read], Order do |order, token|
+        can [:read, :update], Order do |order, token|
           order.user == user || order.guest_token && token == order.guest_token
         end
-        can [:update], Order do |order, token|
-          !order.completed? && (order.user == user || order.guest_token && token == order.guest_token)
-        end
+        #can [:update], Order do |order, token|
+        #  !order.completed? && (order.user == user || order.guest_token && token == order.guest_token)
+        #end
         can :display, CreditCard, user_id: user.id
         can :display, Product
         can :display, ProductProperty

--- a/core/app/models/spree/ability.rb
+++ b/core/app/models/spree/ability.rb
@@ -43,12 +43,12 @@ module Spree
         can :display, OptionType
         can :display, OptionValue
         can :create, Order
-        can [:read, :update], Order do |order, token|
+        can [:read], Order do |order, token|
           order.user == user || order.guest_token && token == order.guest_token
         end
-        #can [:update], Order do |order, token|
-        #  !order.completed? && (order.user == user || order.guest_token && token == order.guest_token)
-        #end
+        can [:update], Order do |order, token|
+          !order.completed? && (order.user == user || order.guest_token && token == order.guest_token)
+        end
         can :display, CreditCard, user_id: user.id
         can :display, Product
         can :display, ProductProperty


### PR DESCRIPTION
Fixes issue https://github.com/spree/spree/issues/7254

Straightforward fix to prevent users from updating orders that are in the completed state.
