### PR TITLE
Change Capybara save_and_open_page_path to save_path

### DIFF
--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -45,7 +45,7 @@ require 'spree/testing_support/shoulda_matcher_configuration'
 require 'paperclip/matchers'
 
 require 'capybara-screenshot/rspec'
-Capybara.save_and_open_page_path = ENV['CIRCLE_ARTIFACTS'] if ENV['CIRCLE_ARTIFACTS']
+Capybara.save_path = ENV['CIRCLE_ARTIFACTS'] if ENV['CIRCLE_ARTIFACTS']
 
 require 'capybara/poltergeist'
 Capybara.javascript_driver = :poltergeist

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -50,7 +50,7 @@ require 'spree/testing_support/microdata'
 require 'paperclip/matchers'
 
 require 'capybara-screenshot/rspec'
-Capybara.save_and_open_page_path = ENV['CIRCLE_ARTIFACTS'] if ENV['CIRCLE_ARTIFACTS']
+Capybara.save_path = ENV['CIRCLE_ARTIFACTS'] if ENV['CIRCLE_ARTIFACTS']
 
 if ENV['WEBDRIVER'] == 'accessible'
   require 'capybara/accessible'


### PR DESCRIPTION
`save_and_open_page_path` is deprecated, we should use `save_path` instead (https://github.com/jnicklas/capybara/pull/1676 )
