### PR TITLE
Removing previously deprecated Spree::ProductsHelper::line_item_description

### DIFF
--- a/core/app/helpers/spree/products_helper.rb
+++ b/core/app/helpers/spree/products_helper.rb
@@ -38,12 +38,6 @@ module Spree
       description.blank? ? Spree.t(:product_has_no_description) : raw(description)
     end
 
-    def line_item_description(variant)
-      ActiveSupport::Deprecation.warn "line_item_description(variant) is deprecated and may be removed from future releases, use line_item_description_text(line_item.description) instead.", caller
-
-      line_item_description_text(variant.product.description)
-    end
-
     def line_item_description_text description_text
       if description_text.present?
         truncate(strip_tags(description_text.gsub('&nbsp;', ' ').squish), length: 100)

--- a/core/spec/helpers/products_helper_spec.rb
+++ b/core/spec/helpers/products_helper_spec.rb
@@ -183,13 +183,6 @@ THIS IS THE BEST PRODUCT EVER!
       end
     end
 
-    context "#line_item_description" do
-      let(:variant) { create(:variant, :product => product, description: description) }
-      subject { line_item_description_text(variant.product.description) }
-
-      it_should_behave_like "line item descriptions"
-    end
-
     context '#line_item_description_text' do
       subject { line_item_description_text description }
 


### PR DESCRIPTION
`Spree::ProductsHelper::line_item_description` was marked as deprecated via https://github.com/spree/spree/commit/d4b8b003e36e7a2c633f37225f5d609318fa8565 , so it's time to remove it completely :)
