### PR TITLE
Removing Spree::StoreController#apply_coupon_code

### DIFF
--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -15,7 +15,6 @@ module Spree
 
     before_action :associate_user
     before_action :check_authorization
-    before_action :apply_coupon_code
 
     before_action :setup_for_current_state
     before_action :add_store_credit_payments, only: [:update]

--- a/frontend/app/controllers/spree/store_controller.rb
+++ b/frontend/app/controllers/spree/store_controller.rb
@@ -19,24 +19,6 @@ module Spree
 
     protected
 
-    # This method is placed here so that the CheckoutController
-    # and OrdersController can both reference it (or any other controller
-    # which needs it)
-    def apply_coupon_code
-      if params[:order] && params[:order][:coupon_code]
-        @order.coupon_code = params[:order][:coupon_code]
-
-        handler = PromotionHandler::Coupon.new(@order).apply
-
-        if handler.error.present?
-          flash.now[:error] = handler.error
-          respond_with(@order) { |format| format.html { render :edit } } and return
-        elsif handler.success
-          flash[:success] = handler.success
-        end
-      end
-    end
-
     def config_locale
       Spree::Frontend::Config[:locale]
     end


### PR DESCRIPTION
This method isn’t used anymore as frontend is applying coupon codes via API V1
