### PR TITLE
Admin controllers/helpers cleanup

### DIFF
--- a/backend/app/controllers/spree/admin/option_types_controller.rb
+++ b/backend/app/controllers/spree/admin/option_types_controller.rb
@@ -35,14 +35,6 @@ module Spree
         def setup_new_option_value
           @option_type.option_values.build if @option_type.option_values.empty?
         end
-
-        def set_available_option_types
-          @available_option_types = if @product.option_type_ids.any?
-            OptionType.where.not(id: @product.option_type_ids)
-          else
-            OptionType.all
-          end
-        end
     end
   end
 end

--- a/backend/app/controllers/spree/admin/option_types_controller.rb
+++ b/backend/app/controllers/spree/admin/option_types_controller.rb
@@ -28,10 +28,6 @@ module Spree
 
 
       private
-        def load_product
-          @product = Product.friendly.find(params[:product_id])
-        end
-
         def setup_new_option_value
           @option_type.option_values.build if @option_type.option_values.empty?
         end

--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -121,12 +121,6 @@ module Spree
         button_link_to '', clone_object_url(resource), options
       end
 
-      def link_to_new(resource)
-        options[:data] = { action: 'new' }
-        options[:class] = "btn btn-success btn-sm"
-        link_to_with_icon('plus', Spree.t(:new), edit_object_url(resource))
-      end
-
       def link_to_edit(resource, options={})
         url = options[:url] || edit_object_url(resource)
         options[:data] = { action: 'edit' }


### PR DESCRIPTION
Another portion of deadweight removed:
- `Spree::Admin::OptionTypesController#set_available_option_types`
- `Spree::Admin::NavigationHelper#link_to_new`
- `Spree::Admin::OptionTypesController#load_product`
