### PR TITLE
Deprecate Spree::Adjustable::PromotionAccumulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ in a single repository and documented in a single set of
 Getting Started
 ----------------------
 
+required rails `rails (~> 4.2.6)`
+
 Add Spree gems to your Gemfile:
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 * [2016 Development Roadmap](https://github.com/spree/spree/wiki/Spree-Commerce-development-roadmap-2016)
 * [Vote & comment on roadmap features](https://trello.com/b/ta4WU3AX/spree-roadmap)
 
-[![Circle CI](https://circleci.com/gh/spree/spree.svg?style=svg)](https://circleci.com/gh/spree/spree)
+[![Circle CI](https://circleci.com/gh/spree/spree.svg?style=svg)](https://circleci.com/gh/spree/spree/tree/master)
 [![Code Climate](https://codeclimate.com/github/spree/spree.png)](https://codeclimate.com/github/spree/spree)
 [![codebeat](https://codebeat.co/badges/16feb8a2-abf0-4fbb-a130-20b689efcfc0)](https://codebeat.co/projects/github-com-spree-spree)
 [![Slack Status](http://slack.spreecommerce.com/badge.svg)](http://slack.spreecommerce.com)

--- a/cmd/lib/spree_cmd/templates/extension/extension.gemspec
+++ b/cmd/lib/spree_cmd/templates/extension/extension.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'capybara', '~> 2.6'
   s.add_development_dependency 'coffee-rails'
   s.add_development_dependency 'database_cleaner'
-  s.add_development_dependency 'factory_girl', '~> 4.5'
+  s.add_development_dependency 'factory_girl', '~> 4.7'
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'rspec-rails', '~> 3.4'
   s.add_development_dependency 'sass-rails', '~> 5.0.0'

--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -23,7 +23,7 @@ group :test do
   gem 'capybara-screenshot', '~> 1.0.11'
   gem 'database_cleaner', '~> 1.3'
   gem 'email_spec'
-  gem 'factory_girl_rails', '~> 4.5.0'
+  gem 'factory_girl_rails', '~> 4.7.0'
   gem 'launchy'
   gem 'rspec-activemodel-mocks', '~> 1.0.2'
   gem 'rspec-collection_matchers'

--- a/core/app/models/spree/adjustable/promotion_accumulator.rb
+++ b/core/app/models/spree/adjustable/promotion_accumulator.rb
@@ -15,6 +15,7 @@ module Spree
       end
 
       def initialize(adjustable)
+        ActiveSupport::Deprecation.warn "PromotionAccumulator will be removed in Spree 3.3.0. Please use Adjusters (https://github.com/spree/spree/blob/master/guides/content/developer/core/adjustments.md#extending-adjustments)"
         @adjustable = adjustable
         @adjustments, @sources, @promotions = [], [], []
         all_adjustments.each { |a| add_adjustment(a) }

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
 
   s.add_dependency 'activemerchant', '~> 1.47.0'
-  s.add_dependency 'acts_as_list', '~> 0.6'
+  s.add_dependency 'acts_as_list', '0.7.2'
   s.add_dependency 'awesome_nested_set', '~> 3.0.1'
   s.add_dependency 'carmen', '~> 1.0.0'
   s.add_dependency 'cancancan', '~> 1.10.1'

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -15,7 +15,6 @@ module Spree
 
     before_action :associate_user
     before_action :check_authorization
-    before_action :apply_coupon_code
 
     before_action :setup_for_current_state
     before_action :add_store_credit_payments, only: [:update]

--- a/frontend/app/controllers/spree/store_controller.rb
+++ b/frontend/app/controllers/spree/store_controller.rb
@@ -19,24 +19,6 @@ module Spree
 
     protected
 
-    # This method is placed here so that the CheckoutController
-    # and OrdersController can both reference it (or any other controller
-    # which needs it)
-    def apply_coupon_code
-      if params[:order] && params[:order][:coupon_code]
-        @order.coupon_code = params[:order][:coupon_code]
-
-        handler = PromotionHandler::Coupon.new(@order).apply
-
-        if handler.error.present?
-          flash.now[:error] = handler.error
-          respond_with(@order) { |format| format.html { render :edit } } and return
-        elsif handler.success
-          flash[:success] = handler.success
-        end
-      end
-    end
-
     def config_locale
       Spree::Frontend::Config[:locale]
     end


### PR DESCRIPTION
Since adding Adjusters (https://github.com/spree/spree/commit/5fc79e57b8c3b387e5506cdc247192131b29b270) this class isn’t used anymore.

We should deprecate it in `3.2.0` and remove it in `3.3.0`.
