### PR TITLE
Locking acts_as_list at 0.7.2 & bumping FactoryGirl to 4.7.0

### DIFF
--- a/cmd/lib/spree_cmd/templates/extension/extension.gemspec
+++ b/cmd/lib/spree_cmd/templates/extension/extension.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'capybara', '~> 2.6'
   s.add_development_dependency 'coffee-rails'
   s.add_development_dependency 'database_cleaner'
-  s.add_development_dependency 'factory_girl', '~> 4.5'
+  s.add_development_dependency 'factory_girl', '~> 4.7'
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'rspec-rails', '~> 3.4'
   s.add_development_dependency 'sass-rails', '~> 5.0.0'

--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -23,7 +23,7 @@ group :test do
   gem 'capybara-screenshot', '~> 1.0.11'
   gem 'database_cleaner', '~> 1.3'
   gem 'email_spec'
-  gem 'factory_girl_rails', '~> 4.5.0'
+  gem 'factory_girl_rails', '~> 4.7.0'
   gem 'launchy'
   gem 'rspec-activemodel-mocks', '~> 1.0.2'
   gem 'rspec-collection_matchers'

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
 
   s.add_dependency 'activemerchant', '~> 1.47.0'
-  s.add_dependency 'acts_as_list', '~> 0.6'
+  s.add_dependency 'acts_as_list', '0.7.2'
   s.add_dependency 'awesome_nested_set', '~> 3.0.1'
   s.add_dependency 'carmen', '~> 1.0.0'
   s.add_dependency 'cancancan', '~> 1.10.1'


### PR DESCRIPTION
`acts_as_list 0.7.3` is broken
