### PR TITLE
Remove not used typography.scss file from backend

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/shared/_typography.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_typography.scss
@@ -1,5 +1,0 @@
-h1, h2, h3, h4, h5, h6 {
-  -webkit-font-smoothing: antialiased;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-}


### PR DESCRIPTION
Fixes #7291 

This pull request removes one small scss file, that is not used anywhere anymore. Looks like this is something that was left after we migrated to bootstrap. I tested locally and it's safe to remove it now.
