### PR TITLE
Locking acts_as_lists at 0.7.2, 0.7.3 breaks spec suite (3-0-stable)

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
 
   s.add_dependency 'activemerchant', '~> 1.47.0'
-  s.add_dependency 'acts_as_list', '~> 0.6'
+  s.add_dependency 'acts_as_list', '0.7.2'
   s.add_dependency 'awesome_nested_set', '~> 3.0.1'
   s.add_dependency 'carmen', '~> 1.0.0'
   s.add_dependency 'cancancan', '~> 1.10.1'


### PR DESCRIPTION
Although `acts_as_list 0.7.4` fixes it (https://github.com/swanandp/acts_as_list/issues/199) but for `3-0-stable` let's lock it. 

Fixes https://github.com/spree/spree/issues/7294
