### PR TITLE
Localized fields for products/_form.html.erb to prevent incorrectly parsed decmial values

### DIFF
--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -111,28 +111,28 @@
           <div class="col-md-6">
             <div id="shipping_specs_weight_field" data-hook="admin_product_form_weight" class="form-group">
               <%= f.label :weight, Spree.t(:weight) %>
-              <%= f.text_field :weight, size: 4, class: 'form-control' %>
+              <%= f.text_field :weight, value: number_with_precision(@product.weight, precision: 2), size: 4, class: 'form-control' %>
             </div>
           </div>
 
           <div class="col-md-6">
             <div id="shipping_specs_height_field" data-hook="admin_product_form_height" class="form-group">
               <%= f.label :height, Spree.t(:height) %>
-              <%= f.text_field :height, size: 4, class: 'form-control' %>
+              <%= f.text_field :height, value: number_with_precision(@product.height, precision: 2), size: 4, class: 'form-control' %>
             </div>
           </div>
 
           <div class="col-md-6">
             <div id="shipping_specs_width_field" data-hook="admin_product_form_width" class="form-group">
               <%= f.label :width, Spree.t(:width) %>
-              <%= f.text_field :width, size: 4, class: 'form-control' %>
+              <%= f.text_field :width, value: number_with_precision(@product.width, precision: 2), size: 4, class: 'form-control' %>
             </div>
           </div>
 
           <div class="col-md-6">
             <div id="shipping_specs_depth_field" data-hook="admin_product_form_depth" class="form-group">
               <%= f.label :depth, Spree.t(:depth) %>
-              <%= f.text_field :depth, size: 4, class: 'form-control' %>
+              <%= f.text_field :depth, value: number_with_precision(@product.depth, precision: 2), size: 4, class: 'form-control' %>
             </div>
           </div>
         </div>

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -332,6 +332,55 @@ describe "Products", type: :feature do
           expect(first('input[type=text]').value).to eq('baseball_cap_color')
         end
       end
+
+      context "using a locale with a different decimal format" do
+        before do
+          # change English locale’s separator and delimiter to match 19,99 format
+          I18n.backend.store_translations(
+            :en,
+            number: {
+              currency: {
+                format: {
+                  separator: ",",
+                  delimiter: "."
+                }
+              },
+              format: {
+                separator: ",",
+                delimiter: "."
+              }
+            }
+          )
+        end
+
+        after do
+          # revert changes to English locale
+          I18n.backend.store_translations(
+            :en,
+            number: {
+              currency: {
+                format: {
+                  separator: ".",
+                  delimiter: ","
+                }
+              },
+              format: {
+                separator: ".",
+                delimiter: ","
+              }
+            }
+          )
+        end
+
+        it 'should parse correctly decimal values like weight' do
+          visit spree.admin_product_path(product)
+          fill_in 'product_weight', with: '1'
+          click_button 'Update'
+          weight_prev = find('#product_weight').value
+          click_button 'Update'
+          expect(find('#product_weight').value).to eq(weight_prev)
+        end
+      end
     end
 
     context 'deleting a product', :js => true do


### PR DESCRIPTION
Added number_with_precision helpers to width, height, depth and weight fields in products edit form. In the current version these fields default to the dot separator. The dot is then dropped by the localized parser which results in an increase by an order of magnitude for every update of the product edit form for each these fields that is non-zero.

This applies when the locale doesn't use the dot for decimal separator.

Test provided
