### PR TITLE
add missing backorderable conditional in admin cart

### DIFF
--- a/backend/app/views/spree/admin/variants/_autocomplete_line_items_stock.js.erb
+++ b/backend/app/views/spree/admin/variants/_autocomplete_line_items_stock.js.erb
@@ -15,7 +15,7 @@
         {{#if variant.track_inventory}}
           {{#if variant.total_on_hand}}
             <td class="text-center">
-                {{variant.total_on_hand}}
+              {{variant.total_on_hand}}
             </td>
 
             <td class="text-center">
@@ -24,14 +24,12 @@
             <td class="actions actions-1 text-center">
               <button class="btn btn-sm btn-success add_variant with-tip" data-variant-id="{{variant.id}}" title="<%= Spree.t(:add) %>" data-action="add">
                 <span class="icon icon-add"></span>
-                </button>
+              </button>
             </td>
           {{else}}
-
             {{#if variant.is_backorderable}}
               <td class="text-center">
-                  {{variant.total_on_hand}}
-                  (<%= Spree.t(:backorders_allowed) %>)
+                {{variant.total_on_hand}} (<%= Spree.t(:backorders_allowed) %>)
               </td>
 
               <td class="text-center">
@@ -40,7 +38,7 @@
               <td class="actions actions-1 text-center">
                 <button class="btn btn-sm btn-success add_variant with-tip" data-variant-id="{{variant.id}}" title="<%= Spree.t(:add) %>" data-action="add">
                   <span class="icon icon-add"></span>
-                  </button>
+                </button>
               </td>
             {{else}}
               <td class="text-center"><%= Spree.t(:out_of_stock) %></td>
@@ -64,4 +62,3 @@
     </tbody>
   </table>
 </script>
-

--- a/backend/app/views/spree/admin/variants/_autocomplete_line_items_stock.js.erb
+++ b/backend/app/views/spree/admin/variants/_autocomplete_line_items_stock.js.erb
@@ -14,7 +14,10 @@
         <td>{{variant.name}}</td>
         {{#if variant.track_inventory}}
           {{#if variant.total_on_hand}}
-            <td class="text-center">{{variant.total_on_hand}}</td>
+            <td class="text-center">
+                {{variant.total_on_hand}}
+            </td>
+
             <td class="text-center">
               <input class="quantity form-control" id="variant_quantity" data-variant-id="{{variant.id}}" type="number" min="1" value="1">
             </td>
@@ -24,10 +27,27 @@
                 </button>
             </td>
           {{else}}
-            <td class="text-center"><%= Spree.t(:out_of_stock) %></td>
-            <td class="text-center">0</td>
-            <td></td>
-            <td></td>
+
+            {{#if variant.is_backorderable}}
+              <td class="text-center">
+                  {{variant.total_on_hand}}
+                  (<%= Spree.t(:backorders_allowed) %>)
+              </td>
+
+              <td class="text-center">
+                <input class="quantity form-control" id="variant_quantity" data-variant-id="{{variant.id}}" type="number" min="1" value="1">
+              </td>
+              <td class="actions actions-1 text-center">
+                <button class="btn btn-sm btn-success add_variant with-tip" data-variant-id="{{variant.id}}" title="<%= Spree.t(:add) %>" data-action="add">
+                  <span class="icon icon-add"></span>
+                  </button>
+              </td>
+            {{else}}
+              <td class="text-center"><%= Spree.t(:out_of_stock) %></td>
+              <td class="text-center">0</td>
+              <td></td>
+              <td></td>
+            {{/if}}
           {{/if}}
         {{else}}
           <td class="text-center"><%= Spree.t(:doesnt_track_inventory) %></td>
@@ -44,3 +64,4 @@
     </tbody>
   </table>
 </script>
+


### PR DESCRIPTION
This autocomplete template wasn't checking backorderable variants at cart level, so it wasn't able to be added to the cart.
