### PR TITLE
Add variant association in ransack whitelist

### DIFF
--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -23,6 +23,7 @@ module Spree
     after_touch { variant.touch }
 
     self.whitelisted_ransackable_attributes = ['count_on_hand', 'stock_location_id']
+    self.whitelisted_ransackable_associations = ['variant']
 
     scope :with_active_stock_location, -> { joins(:stock_location).merge(Spree::StockLocation.active) }
 


### PR DESCRIPTION
Ransack uses variant association to search name and SKU related to the StockItem, for example, in Spree::Api::V1::StockItem ransack search.
Without this setting of whitelisted_ransackable_associations, the search form in Stock Transfers does not work.
