### PR TITLE
Admin Panel Forms validation & markup cleanup

### DIFF
--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -40,10 +40,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
     else
       invoke_callbacks(:update, :fails)
       respond_with(@object) do |format|
-        format.html do
-          flash.now[:error] = @object.errors.full_messages.join(", ")
-          render action: 'edit'
-        end
+        format.html { render action: :edit }
         format.js { render layout: false }
       end
     end
@@ -62,10 +59,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
     else
       invoke_callbacks(:create, :fails)
       respond_with(@object) do |format|
-        format.html do
-          flash.now[:error] = @object.errors.full_messages.join(", ")
-          render action: 'new'
-        end
+        format.html { render action: :new }
         format.js { render layout: false }
       end
     end

--- a/backend/app/views/spree/admin/countries/_form.html.erb
+++ b/backend/app/views/spree/admin/countries/_form.html.erb
@@ -1,12 +1,18 @@
 <div data-hook="admin_country_form_fields">
   <div data-hook="name" class="form-group">
-    <%= f.label :name, Spree.t(:name) %>
-    <%= f.text_field :name, :class => 'form-control' %>
+    <%= f.field_container :name, class: ["form-group"] do %>
+      <%= f.label :name, Spree.t(:name) %>
+      <%= f.text_field :name, :class => 'form-control' %>
+      <%= error_message_on :country, :name %>
+    <% end %>
   </div>
 
   <div data-hook="iso_name" class="form-group">
-    <%= f.label :iso_name, Spree.t(:iso_name) %>
-    <%= f.text_field :iso_name, :class => 'form-control' %>
+    <%= f.field_container :iso_name, class: ["form-group"] do %>
+      <%= f.label :iso_name, Spree.t(:iso_name) %>
+      <%= f.text_field :iso_name, :class => 'form-control' %>
+      <%= error_message_on :country, :iso_name %>
+    <% end %>
   </div>
 
   <div data-hook="states_required" class="checkbox">

--- a/backend/app/views/spree/admin/countries/_form.html.erb
+++ b/backend/app/views/spree/admin/countries/_form.html.erb
@@ -1,19 +1,15 @@
 <div data-hook="admin_country_form_fields">
-  <div data-hook="name" class="form-group">
-    <%= f.field_container :name, class: ["form-group"] do %>
-      <%= f.label :name, Spree.t(:name) %>
-      <%= f.text_field :name, :class => 'form-control' %>
-      <%= error_message_on :country, :name %>
-    <% end %>
-  </div>
+  <%= f.field_container :name, class: ['form-group'], 'data-hook' => 'name' do %>
+    <%= f.label :name, Spree.t(:name) %>
+    <%= f.text_field :name, :class => 'form-control' %>
+    <%= f.error_message_on :name %>
+  <% end %>
 
-  <div data-hook="iso_name" class="form-group">
-    <%= f.field_container :iso_name, class: ["form-group"] do %>
-      <%= f.label :iso_name, Spree.t(:iso_name) %>
-      <%= f.text_field :iso_name, :class => 'form-control' %>
-      <%= error_message_on :country, :iso_name %>
-    <% end %>
-  </div>
+  <%= f.field_container :iso_name, class: ['form-group'], 'data-hook' => 'iso_name' do %>
+    <%= f.label :iso_name, Spree.t(:iso_name) %>
+    <%= f.text_field :iso_name, :class => 'form-control' %>
+    <%= f.error_message_on :iso_name %>
+  <% end %>
 
   <div data-hook="states_required" class="checkbox">
     <label>

--- a/backend/app/views/spree/admin/countries/new.html.erb
+++ b/backend/app/views/spree/admin/countries/new.html.erb
@@ -6,7 +6,7 @@
   <%= back_to_list_button(Spree::Country.model_name.human, admin_countries_path) %>
 <% end %>
 
-<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @countries } %>
+<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @country } %>
 
 <%= form_for [:admin, @country] do |f| %>
   <fieldset>

--- a/backend/app/views/spree/admin/payment_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/_form.html.erb
@@ -42,14 +42,15 @@
     </div>
 
     <div class="col-md-8">
-      <div data-hook="name" class="form-group">
+      <%= field_container :payment_method, :name, class: ['form-group'], 'data-hook' => 'name' do %>
         <%= label_tag :payment_method_name, Spree.t(:name) %>
         <%= text_field :payment_method, :name, :class => 'form-control' %>
-      </div>
-      <div data-hook="description" class="form-group">
+        <%= error_message_on :payment_method, :name %>
+      <% end %>
+      <%= field_container :payment_method, :description, class: ['form-group'], 'data-hook' => 'description' do %>
         <%= label_tag :payment_method_description, Spree.t(:description) %>
         <%= text_area :payment_method, :description, { :cols => 60, :rows => 6, :class => 'form-control' } %>
-      </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/backend/app/views/spree/admin/promotion_categories/_form.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/_form.html.erb
@@ -1,8 +1,9 @@
-<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @promotion } %>
+<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @promotion_category } %>
 
 <%= f.field_container :name, class: ['form-group'] do %>
   <%= f.label :name %>
   <%= f.text_field :name, :class => 'form-control' %>
+  <%= error_message_on :promotion_category, :name %>
 <% end %>
 <%= f.field_container :code, class: ['form-group'] do %>
   <%= f.label :code %>

--- a/backend/app/views/spree/admin/promotion_categories/_form.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/_form.html.erb
@@ -3,7 +3,7 @@
 <%= f.field_container :name, class: ['form-group'] do %>
   <%= f.label :name %>
   <%= f.text_field :name, :class => 'form-control' %>
-  <%= error_message_on :promotion_category, :name %>
+  <%= f.error_message_on :name %>
 <% end %>
 <%= f.field_container :code, class: ['form-group'] do %>
   <%= f.label :code %>

--- a/backend/app/views/spree/admin/promotions/_form.html.erb
+++ b/backend/app/views/spree/admin/promotions/_form.html.erb
@@ -5,6 +5,7 @@
     <%= f.field_container :name, class: ['form-group'] do %>
       <%= f.label :name %>
       <%= f.text_field :name, :class => 'form-control' %>
+      <%= error_message_on :promotion, :name %>
     <% end %>
 
     <%= f.field_container :code, class: ['form-group'] do %>

--- a/backend/app/views/spree/admin/promotions/_form.html.erb
+++ b/backend/app/views/spree/admin/promotions/_form.html.erb
@@ -5,7 +5,7 @@
     <%= f.field_container :name, class: ['form-group'] do %>
       <%= f.label :name %>
       <%= f.text_field :name, :class => 'form-control' %>
-      <%= error_message_on :promotion, :name %>
+      <%= f.error_message_on :name %>
     <% end %>
 
     <%= f.field_container :code, class: ['form-group'] do %>

--- a/backend/app/views/spree/admin/roles/_form.html.erb
+++ b/backend/app/views/spree/admin/roles/_form.html.erb
@@ -1,7 +1,10 @@
 <div data-hook="admin_role_form_fields">
   <div data-hook="role_name" class="form-group">
-    <%= f.label :name, Spree.t(:name) %> <span class="required">*</span>
-    <%= f.text_field :name, class: 'form-control' %>
+    <%= f.field_container :name, class: ["form-group"] do %>
+      <%= f.label :name, Spree.t(:name) %> <span class="required">*</span>
+      <%= f.text_field :name, class: 'form-control' %>
+      <%= error_message_on :role, :name %>
+    <% end %>
   </div>
 
   <div data-hook="additional_role_fields"></div>

--- a/backend/app/views/spree/admin/roles/_form.html.erb
+++ b/backend/app/views/spree/admin/roles/_form.html.erb
@@ -1,11 +1,9 @@
 <div data-hook="admin_role_form_fields">
-  <div data-hook="role_name" class="form-group">
-    <%= f.field_container :name, class: ["form-group"] do %>
-      <%= f.label :name, Spree.t(:name) %> <span class="required">*</span>
-      <%= f.text_field :name, class: 'form-control' %>
-      <%= error_message_on :role, :name %>
-    <% end %>
-  </div>
+  <%= f.field_container :name, class: ["form-group"], 'data-hook' => "role_name" do %>
+    <%= f.label :name, Spree.t(:name) %> <span class="required">*</span>
+    <%= f.text_field :name, class: 'form-control' %>
+    <%= f.error_message_on :name %>
+  <% end %>
 
   <div data-hook="additional_role_fields"></div>
 </div>

--- a/backend/app/views/spree/admin/roles/edit.html.erb
+++ b/backend/app/views/spree/admin/roles/edit.html.erb
@@ -6,6 +6,8 @@
   <%= back_to_list_button(Spree::Role.model_name.human, admin_roles_path) %>
 <% end %>
 
+<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @role } %>
+
 <%= form_for [:admin, @role] do |f| %>
   <fieldset>
     <%= render partial: 'form', locals: { f: f } %>

--- a/backend/app/views/spree/admin/roles/new.html.erb
+++ b/backend/app/views/spree/admin/roles/new.html.erb
@@ -6,6 +6,8 @@
   <%= back_to_list_button(Spree::Role.model_name.human, admin_roles_path) %>
 <% end %>
 
+<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @role } %>
+
 <%= form_for [:admin, @role] do |f| %>
   <fieldset>
     <%= render partial: 'form', locals: { f: f } %>

--- a/backend/app/views/spree/admin/shared/named_types/_form.html.erb
+++ b/backend/app/views/spree/admin/shared/named_types/_form.html.erb
@@ -2,6 +2,7 @@
   <%= f.field_container :name, class: ['form-group'] do %>
     <%= f.label :name, Spree.t(:name) %> <span class="required">*</span>
     <%= f.text_field :name, class: 'form-control' %>
+    <%= error_message_on :object, :name %>
   <% end %>
   <div class="checkbox">
     <%= label_tag :active do %>

--- a/backend/app/views/spree/admin/shared/named_types/_form.html.erb
+++ b/backend/app/views/spree/admin/shared/named_types/_form.html.erb
@@ -2,7 +2,7 @@
   <%= f.field_container :name, class: ['form-group'] do %>
     <%= f.label :name, Spree.t(:name) %> <span class="required">*</span>
     <%= f.text_field :name, class: 'form-control' %>
-    <%= error_message_on :object, :name %>
+    <%= f.error_message_on :name %>
   <% end %>
   <div class="checkbox">
     <%= label_tag :active do %>

--- a/backend/app/views/spree/admin/shipping_categories/_form.html.erb
+++ b/backend/app/views/spree/admin/shipping_categories/_form.html.erb
@@ -1,6 +1,9 @@
 <div data-hook="admin_shipping_category_form_fields">
   <div data-hook="name" class="form-group">
-    <%= label_tag :shipping_category_name, Spree.t(:name) %><br>
-    <%= f.text_field :name, class: 'form-control' %>
+    <%= f.field_container :name, class: ["form-group"] do %>
+      <%= f.label :name, Spree.t(:name) %><br>
+      <%= f.text_field :name, class: 'form-control' %>
+      <%= error_message_on :shipping_category, :name %>
+    <% end %>
   </div>
 </div>

--- a/backend/app/views/spree/admin/shipping_categories/_form.html.erb
+++ b/backend/app/views/spree/admin/shipping_categories/_form.html.erb
@@ -3,7 +3,7 @@
     <%= f.field_container :name, class: ["form-group"] do %>
       <%= f.label :name, Spree.t(:name) %><br>
       <%= f.text_field :name, class: 'form-control' %>
-      <%= error_message_on :shipping_category, :name %>
+      <%= f.error_message_on :name %>
     <% end %>
   </div>
 </div>

--- a/backend/app/views/spree/admin/shipping_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/_form.html.erb
@@ -4,7 +4,7 @@
       <%= f.field_container :name, :class => ['form-group'] do %>
         <%= f.label :name, Spree.t(:name) %>
         <%= f.text_field :name, :class => 'form-control' %>
-        <%= error_message_on :shipping_method, :name %>
+        <%= f.error_message_on :name %>
       <% end %>
     </div>
 
@@ -12,7 +12,7 @@
       <%= f.field_container :display_on, :class => ['form-group'] do %>
         <%= f.label :display_on, Spree.t(:display) %>
         <%= select(:shipping_method, :display_on, Spree::ShippingMethod::DISPLAY.collect { |display| [Spree.t(display), display == :both ? nil : display.to_s] }, {}, { :class => 'select2' }) %>
-        <%= error_message_on :shipping_method, :display_on %>
+        <%= f.error_message_on :display_on %>
       <% end %>
     </div>
   </div>
@@ -22,7 +22,7 @@
       <%= f.field_container :admin_name, :class => ['form-group'] do %>
         <%= f.label :admin_name, Spree.t(:internal_name) %>
         <%= f.text_field :admin_name, :class => 'form-control', :label => false %>
-        <%= error_message_on :shipping_method, :admin_name %>
+        <%= f.error_message_on :admin_name %>
       <% end %>
     </div>
 
@@ -30,7 +30,7 @@
       <%= f.field_container :code, :class => ['form-group'] do %>
         <%= f.label :code, Spree.t(:code) %>
         <%= f.text_field :code, :class => 'form-control', :label => false %>
-        <%= error_message_on :shipping_method, :code %>
+        <%= f.error_message_on :code %>
       <% end %>
     </div>
 
@@ -38,7 +38,7 @@
       <%= f.field_container :tracking_url, :class => ['form-group'] do %>
         <%= f.label :tracking_url, Spree.t(:tracking_url) %>
         <%= f.text_field :tracking_url, :class => 'form-control', :placeholder => Spree.t(:tracking_url_placeholder) %>
-        <%= error_message_on :shipping_method, :tracking_url %>
+        <%= f.error_message_on :tracking_url %>
       <% end %>
     </div>
   </div>
@@ -63,7 +63,7 @@
               <% end %>
             </div>
           <% end %>
-          <%= error_message_on :shipping_method, :shipping_category_id %>
+          <%= f.error_message_on :shipping_category_id %>
         <% end %>
       </div>
     </div>
@@ -88,7 +88,7 @@
               <% end %>
             </div>
           <% end %>
-          <%= error_message_on :shipping_method, :zone_id %>
+          <%= f.error_message_on :zone_id %>
         <% end %>
       </div>
     </div>
@@ -111,7 +111,7 @@
       <div class="panel-body">
         <%= f.field_container :categories, :class => ['form-group'] do %>
           <%= f.select :tax_category_id, @tax_categories.map { |tc| [tc.name, tc.id] }, { include_blank: true }, class: "select2" %>
-          <%= error_message_on :shipping_method, :tax_category_id %>
+          <%= f.error_message_on :tax_category_id %>
         <% end %>
       </div>
     </div>

--- a/backend/app/views/spree/admin/states/_form.html.erb
+++ b/backend/app/views/spree/admin/states/_form.html.erb
@@ -3,6 +3,7 @@
     <%= f.field_container :name, class: ['form-group'] do %>
       <%= f.label :name, Spree.t(:name) %>
       <%= f.text_field :name, :class => 'form-control' %>
+      <%= error_message_on :state, :name %>
     <% end %>
   </div>
   <div class="col-md-6">

--- a/backend/app/views/spree/admin/states/_form.html.erb
+++ b/backend/app/views/spree/admin/states/_form.html.erb
@@ -3,7 +3,7 @@
     <%= f.field_container :name, class: ['form-group'] do %>
       <%= f.label :name, Spree.t(:name) %>
       <%= f.text_field :name, :class => 'form-control' %>
-      <%= error_message_on :state, :name %>
+      <%= f.error_message_on :name %>
     <% end %>
   </div>
   <div class="col-md-6">

--- a/backend/app/views/spree/admin/stock_locations/_form.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/_form.html.erb
@@ -3,8 +3,9 @@
     <div class="col-md-9" data-hook="stock_location_names">
       <div data-hook="stock_location_name">
         <%= f.field_container :name, class: ['form-group']  do %>
-        <%= f.label :name, Spree.t(:name) %> <span class="required">*</span><br />
-        <%= f.text_field :name, class: 'form-control', required: true %>
+          <%= f.label :name, Spree.t(:name) %> <span class="required">*</span><br />
+          <%= f.text_field :name, class: 'form-control', required: true %>
+          <%= error_message_on :stock_location, :name %>
         <% end %>
       </div>
       <div data-hook="stock_location_admin_name">

--- a/backend/app/views/spree/admin/stock_locations/_form.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/_form.html.erb
@@ -5,7 +5,7 @@
         <%= f.field_container :name, class: ['form-group']  do %>
           <%= f.label :name, Spree.t(:name) %> <span class="required">*</span><br />
           <%= f.text_field :name, class: 'form-control', required: true %>
-          <%= error_message_on :stock_location, :name %>
+          <%= f.error_message_on :name %>
         <% end %>
       </div>
       <div data-hook="stock_location_admin_name">

--- a/backend/app/views/spree/admin/stock_locations/new.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/new.html.erb
@@ -6,7 +6,7 @@
   <%= link_to_with_icon 'arrow-left', Spree.t(:back_to_stock_locations_list), admin_stock_locations_path, :class => 'btn btn-primary' %>
 <% end %>
 
-<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @stock_locations } %>
+<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @stock_location } %>
 
 <%= form_for [:admin, @stock_location] do |f| %>
   <fieldset>

--- a/backend/app/views/spree/admin/store_credit_categories/_form.html.erb
+++ b/backend/app/views/spree/admin/store_credit_categories/_form.html.erb
@@ -1,8 +1,9 @@
 <div data-hook="admin_store_credit_category_form_fields">
-  <div data-hook="store_credit_category_name" class="form-group">
+  <%= f.field_container :name, class: ['form-group'], 'data-hook' => 'store_credit_category_name' do %>
     <%= f.label :name, Spree.t(:name) %> <span class="required">*</span>
     <%= f.text_field :name, class: 'form-control' %>
-  </div>
+    <%= f.error_message_on :name %>
+  <% end %>
 
   <div data-hook="additional_store_credit_category_fields"></div>
 </div>

--- a/backend/app/views/spree/admin/store_credit_categories/edit.html.erb
+++ b/backend/app/views/spree/admin/store_credit_categories/edit.html.erb
@@ -2,6 +2,8 @@
   <%= Spree.t(:editing_resource, resource: Spree::StoreCreditCategory.model_name.human) %>
 <% end %>
 
+<%= render 'spree/admin/shared/error_messages', target: @store_credit_category %>
+
 <%= form_for [:admin, @store_credit_category] do |f| %>
   <fieldset>
     <%= render partial: 'form', locals: { f: f } %>

--- a/backend/app/views/spree/admin/store_credit_categories/new.html.erb
+++ b/backend/app/views/spree/admin/store_credit_categories/new.html.erb
@@ -2,6 +2,8 @@
   <%= Spree.t(:new_store_credit_category) %>
 <% end %>
 
+<%= render 'spree/admin/shared/error_messages', target: @store_credit_category %>
+
 <%= form_for [:admin, @store_credit_category] do |f| %>
   <fieldset>
     <%= render partial: 'form', locals: { f: f } %>

--- a/backend/app/views/spree/admin/tax_categories/_form.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/_form.html.erb
@@ -2,6 +2,7 @@
   <%= f.field_container :name, :class => ['form-group'] do %>
     <%= f.label :name, Spree.t(:name) %>
     <%= f.text_field :name, :class => 'form-control' %>
+    <%= error_message_on :tax_category, :name %>
   <% end %>
 
   <%= f.field_container :tax_code, :class => ['form-group'] do %>

--- a/backend/app/views/spree/admin/tax_categories/_form.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/_form.html.erb
@@ -2,7 +2,7 @@
   <%= f.field_container :name, :class => ['form-group'] do %>
     <%= f.label :name, Spree.t(:name) %>
     <%= f.text_field :name, :class => 'form-control' %>
-    <%= error_message_on :tax_category, :name %>
+    <%= f.error_message_on :name %>
   <% end %>
 
   <%= f.field_container :tax_code, :class => ['form-group'] do %>

--- a/backend/app/views/spree/admin/tax_rates/_form.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/_form.html.erb
@@ -13,10 +13,13 @@
           <%= f.text_field :name, :class => 'form-control' %>
         </div>
         <div data-hook="rate" class="form-group">
-          <%= f.label :amount, Spree.t(:rate) %>
-          <%= f.text_field :amount, :class => 'form-control' %>
+          <%= f.field_container :amount, class: ["form-group"] do %>
+            <%= f.label :amount, Spree.t(:rate) %>
+            <%= f.text_field :amount, :class => 'form-control' %>
+            <%= error_message_on :tax_rate, :amount %>
+          <% end %>
           <p class="help-block">
-            <%= Spree.t(:tax_rate_amount_explanation) %>
+          <%= Spree.t(:tax_rate_amount_explanation) %>
           </p>
         </div>
         <div data-hook="included" class="form-group">

--- a/backend/app/views/spree/admin/tax_rates/_form.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/_form.html.erb
@@ -16,10 +16,10 @@
           <%= f.field_container :amount, class: ["form-group"] do %>
             <%= f.label :amount, Spree.t(:rate) %>
             <%= f.text_field :amount, :class => 'form-control' %>
-            <%= error_message_on :tax_rate, :amount %>
+            <%= f.error_message_on :amount %>
           <% end %>
           <p class="help-block">
-          <%= Spree.t(:tax_rate_amount_explanation) %>
+            <%= Spree.t(:tax_rate_amount_explanation) %>
           </p>
         </div>
         <div data-hook="included" class="form-group">

--- a/backend/app/views/spree/admin/taxonomies/_form.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/_form.html.erb
@@ -1,7 +1,7 @@
 <div data-hook="admin_inside_taxonomy_form" class="form-group">
   <%= f.field_container :name, class: ['form-group'] do %>
     <%= f.label :name, Spree.t(:name) %> <span class="required">*</span>
+    <%= f.text_field :name, :class => 'form-control' %>
     <%= error_message_on :taxonomy, :name, :class => 'error-message' %>
-    <%= text_field :taxonomy, :name, :class => 'form-control' %>
   <% end %>
 </div>

--- a/backend/app/views/spree/admin/taxonomies/_form.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/_form.html.erb
@@ -2,6 +2,6 @@
   <%= f.field_container :name, class: ['form-group'] do %>
     <%= f.label :name, Spree.t(:name) %> <span class="required">*</span>
     <%= f.text_field :name, :class => 'form-control' %>
-    <%= error_message_on :taxonomy, :name, :class => 'error-message' %>
+    <%= f.error_message_on :name, :class => 'error-message' %>
   <% end %>
 </div>

--- a/backend/app/views/spree/admin/taxonomies/new.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/new.html.erb
@@ -1,6 +1,7 @@
 <% content_for :page_title do %>
   <%= Spree.t(:new_taxonomy) %>
 <% end %>
+<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @taxonomy } %>
 
 <% content_for :page_actions do %>
   <%= back_to_list_button(Spree::Taxonomy.model_name.human, admin_taxonomies_path) %>

--- a/backend/app/views/spree/admin/taxons/_form.html.erb
+++ b/backend/app/views/spree/admin/taxons/_form.html.erb
@@ -4,7 +4,7 @@
       <%= f.field_container :name, class: ['form-group'] do %>
         <%= f.label :name, Spree.t(:name) %> <span class="required">*</span>
         <%= text_field :taxon, :name, :class => 'form-control' %>
-        <%= error_message_on :taxon, :name, :class => 'error-message' %>
+        <%= f.error_message_on :name, :class => 'error-message' %>
       <% end %>
 
       <%= f.field_container :permalink_part, class: ['form-group'] do %>

--- a/backend/app/views/spree/admin/trackers/_form.html.erb
+++ b/backend/app/views/spree/admin/trackers/_form.html.erb
@@ -1,8 +1,11 @@
 <div data-hook="admin_tracker_form_fields" class="row">
   <div class="col-md-4">
     <div data-hook="analytics_id" class="form-group">
-      <%= label_tag nil, Spree.t(:google_analytics_id) %>
-      <%= text_field :tracker, :analytics_id, :class => 'form-control' %>
+      <%= f.field_container :analytics_id, class: ["form-group"] do %>
+        <%= f.label :analytics_id, Spree.t(:google_analytics_id) %>
+        <%= f.text_field :analytics_id, :class => 'form-control' %>
+        <%= error_message_on :tracker, :analytics_id %>
+      <% end %>
     </div>
   </div>
   <div class="col-md-4">
@@ -18,11 +21,11 @@
         <%= label_tag :tracker_active_false do %>
           <%= radio_button(:tracker, :active, false) %>
           <%= Spree.t(:say_no) %>
-        <% end %>        
+        <% end %>
       </div>
     </div>
   </div>
-  
+
   <div data-hook="additional_tracker_fields"></div>
 
 </div>

--- a/backend/app/views/spree/admin/trackers/_form.html.erb
+++ b/backend/app/views/spree/admin/trackers/_form.html.erb
@@ -1,12 +1,10 @@
 <div data-hook="admin_tracker_form_fields" class="row">
-  <div class="col-md-4">
-    <div data-hook="analytics_id" class="form-group">
-      <%= f.field_container :analytics_id, class: ["form-group"] do %>
-        <%= f.label :analytics_id, Spree.t(:google_analytics_id) %>
-        <%= f.text_field :analytics_id, :class => 'form-control' %>
-        <%= error_message_on :tracker, :analytics_id %>
-      <% end %>
-    </div>
+  <div class="col-md-4" data-hook="analytics_id">
+    <%= f.field_container :analytics_id, class: ["form-group"], "data-hook" => "analytics_id" do %>
+      <%= f.label :analytics_id, Spree.t(:google_analytics_id) %>
+      <%= f.text_field :analytics_id, :class => 'form-control' %>
+      <%= f.error_message_on :analytics_id %>
+    <% end %>
   </div>
   <div class="col-md-4">
     <div data-hook="active" class="form-group">

--- a/backend/app/views/spree/admin/trackers/edit.html.erb
+++ b/backend/app/views/spree/admin/trackers/edit.html.erb
@@ -5,6 +5,8 @@
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @tracker } %>
 
 <%= form_for [:admin, @tracker] do |f| %>
-  <%= render :partial => 'form', :locals => { :f => f } %>
-  <%= render :partial => 'spree/admin/shared/edit_resource_links' %>  
+  <fieldset>
+    <%= render :partial => 'form', :locals => { :f => f } %>
+    <%= render :partial => 'spree/admin/shared/edit_resource_links' %>
+  </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/users/_form.html.erb
+++ b/backend/app/views/spree/admin/users/_form.html.erb
@@ -3,7 +3,7 @@
     <%= f.field_container :email, class: ['form-group'] do %>
       <%= f.label :email, Spree.t(:email) %>
       <%= f.email_field :email, :class => 'form-control' %>
-      <%= error_message_on :user, :email %>
+      <%= f.error_message_on :email %>
     <% end %>
 
     <div data-hook="admin_user_form_roles" class="form-group">

--- a/backend/app/views/spree/admin/zones/_form.html.erb
+++ b/backend/app/views/spree/admin/zones/_form.html.erb
@@ -9,6 +9,7 @@
         <%= zone_form.field_container :name, class: ['form-group'] do %>
           <%= zone_form.label :name, Spree.t(:name) %>
           <%= zone_form.text_field :name, :class => 'form-control' %>
+          <%= error_message_on :zone, :name %>
         <% end %>
 
         <%= zone_form.field_container :description, class: ['form-group'] do %>

--- a/backend/app/views/spree/admin/zones/_form.html.erb
+++ b/backend/app/views/spree/admin/zones/_form.html.erb
@@ -9,7 +9,7 @@
         <%= zone_form.field_container :name, class: ['form-group'] do %>
           <%= zone_form.label :name, Spree.t(:name) %>
           <%= zone_form.text_field :name, :class => 'form-control' %>
-          <%= error_message_on :zone, :name %>
+          <%= zone_form.error_message_on :name %>
         <% end %>
 
         <%= zone_form.field_container :description, class: ['form-group'] do %>

--- a/backend/spec/controllers/spree/admin/resource_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/resource_controller_spec.rb
@@ -79,17 +79,6 @@ describe Spree::Admin::WidgetsController, :type => :controller do
       expect { subject }.to change { Widget.count }.by(1)
     end
 
-    context 'failure' do
-      let(:params) do
-        {widget: {name: ''}} # blank name generates an error
-      end
-
-      it 'sets a flash error' do
-        subject
-        expect(flash[:error]).to eq assigns(:widget).errors.full_messages.join(', ')
-      end
-    end
-
     context 'without any parameters' do
       let(:params) { {} }
 
@@ -117,20 +106,6 @@ describe Spree::Admin::WidgetsController, :type => :controller do
 
     it 'updates the resource' do
       expect { subject }.to change { widget.reload.name }.from('a widget').to('widget renamed')
-    end
-
-    context 'failure' do
-      let(:params) do
-        {
-          id: widget.to_param,
-          widget: {name: ''}, # a blank name will trigger a validation error
-        }
-      end
-
-      it 'sets a flash error' do
-        subject
-        expect(flash[:error]).to eq assigns(:widget).errors.full_messages.join(', ')
-      end
     end
   end
 
@@ -273,4 +248,3 @@ describe Spree::Admin::Submodule::PostsController, type: :controller do
     end
   end
 end
-


### PR DESCRIPTION
This PR:
- unifies validation error handling across all Admin Panel forms
- adds missing inline validation errors to Admin Panel forms  (via `error_message_on`)
- fixes double validation errors - validation errors were rendered via `admin/shared/error_messages` partial and flashes, which wasn't a good UX solution
- unifies Admin Panel forms with the usage of `field_container` method
- fixes double `form-group` divs markup errors  
