### PR TITLE
Upgrade paperclip dependency to incorporate upstream security fix.

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'json', '~> 1.7'
   s.add_dependency 'kaminari', '~> 0.15', '>= 0.15.1'
   s.add_dependency 'monetize', '~> 1.1'
-  s.add_dependency 'paperclip', '~> 4.2.0'
+  s.add_dependency 'paperclip', '~> 4.3.0'
   s.add_dependency 'paranoia', '~> 2.1.0'
   s.add_dependency 'premailer-rails'
   s.add_dependency 'rails', '~> 4.2.2'


### PR DESCRIPTION
"It's possible to cause a DoS by uploading files with a spoofed media
type, because it causes megabytes of logging to be written."

See https://github.com/thoughtbot/paperclip/pull/2017 and
https://github.com/thoughtbot/paperclip/pull/2126
