### PR TITLE
Admin Panel: inline validation for Address forms

### DIFF
--- a/backend/app/views/spree/admin/shared/_address_form.html.erb
+++ b/backend/app/views/spree/admin/shared/_address_form.html.erb
@@ -1,42 +1,49 @@
 <% s_or_b = type.chars.first %>
 
 <div id="<%= type %>" data-hook="address_fields">
-  <div class="form-group <%= "#{type}-row" %>">
+  <%= field_container f.object, :firstname, class: ["form-group", "#{type}-row"] do %>
     <%= f.label :firstname, Spree.t(:first_name) %>
     <%= f.text_field :firstname, class: 'form-control' %>
-  </div>
-
-  <div class="form-group <%= "#{type}-row" %>">
-    <%= f.label :lastname, Spree.t(:last_name) %>
-    <%= f.text_field :lastname, class: 'form-control' %>
-  </div>
-
-  <% if Spree::Config[:company] %>
-    <div class="form-group <%= "#{type}-row" %>">
-      <%= f.label :company, Spree.t(:company) %>
-      <%= f.text_field :company, class: 'form-control' %>
-    </div>
+    <%= error_message_on f.object, :firstname %>
   <% end %>
 
-  <div class="form-group <%= "#{type}-row" %>">
+  <%= field_container f.object, :lastname, class: ["form-group", "#{type}-row"] do %>
+    <%= f.label :lastname, Spree.t(:last_name) %>
+    <%= f.text_field :lastname, class: 'form-control' %>
+    <%= error_message_on f.object, :lastname %>
+  <% end %>
+
+  <% if Spree::Config[:company] %>
+    <%= field_container f.object, :company, class: ["form-group", "#{type}-row"] do %>
+      <%= f.label :company, Spree.t(:company) %>
+      <%= f.text_field :company, class: 'form-control' %>
+      <%= error_message_on f.object, :company %>
+    <% end %>
+  <% end %>
+
+  <%= field_container f.object, :address1, class: ["form-group", "#{type}-row"] do %>
     <%= f.label :address1, Spree.t(:street_address) %>
     <%= f.text_field :address1, class: 'form-control' %>
-  </div>
+    <%= error_message_on f.object, :address1 %>
+  <% end %>
 
-  <div class="form-group <%= "#{type}-row" %>">
+  <%= field_container f.object, :address2, class: ["form-group", "#{type}-row"] do %>
     <%= f.label :address2, Spree.t(:street_address_2) %>
     <%= f.text_field :address2, class: 'form-control' %>
-  </div>
+    <%= error_message_on f.object, :address2 %>
+  <% end %>
 
-  <div class="form-group <%= "#{type}-row" %>">
+  <%= field_container f.object, :city, class: ["form-group", "#{type}-row"] do %>
     <%= f.label :city, Spree.t(:city) %>
     <%= f.text_field :city, class: 'form-control' %>
-  </div>
+    <%= error_message_on f.object, :city %>
+  <% end %>
 
-  <div class="form-group <%= "#{type}-row" %>">
+  <%= field_container f.object, :zipcode, class: ["form-group", "#{type}-row"] do %>
     <%= f.label :zipcode, Spree.t(:zip) %>
     <%= f.text_field :zipcode, class: 'form-control' %>
-  </div>
+    <%= error_message_on f.object, :zipcode %>
+  <% end %>
 
   <div class="form-group <%= "#{type}-row" %>">
     <%= f.label :country_id, Spree.t(:country) %>
@@ -55,10 +62,11 @@
     </span>
   </div>
 
-  <div class="form-group <%= "#{type}-row" %>">
+  <%= field_container f.object, :phone, class: ["form-group", "#{type}-row"] do %>
     <%= f.label :phone, Spree.t(:phone) %>
     <%= f.phone_field :phone, class: 'form-control' %>
-  </div>
+    <%= error_message_on f.object, :phone %>
+  <% end %>
 </div>
 
 <% content_for :head do %>


### PR DESCRIPTION
Previously there weren't any validation on Address forms hence this PR :) Achieved with standard `error_message_on` and `field_container` helper methods.

Address forms are used in `Order -> Customer` and `User -> Addresses`
