### PR TITLE
Fixes inline validation for Select2 elements

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -33,7 +33,8 @@ input.form-control {
       color: $brand-danger
     }
 
-    input {
+    input,
+    .select2-choice {
       border-color: $brand-danger;
     }
   }


### PR DESCRIPTION
Adds a standard red border around invalid `select2` elements

![screen shot 2016-04-19 at 7 01 04 pm](https://cloud.githubusercontent.com/assets/55154/14648213/71e7de78-0661-11e6-818d-dd8903153cc0.png)
