### PR TITLE
Admin Panel breadcrumbs navigation

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_labels.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_labels.scss
@@ -8,7 +8,7 @@
 .label-active,
 .label-success,
 .label-sold,
-.label-open
+.label-open,
 .label-authorized
 {
   background-color: $brand-success;

--- a/backend/app/helpers/spree/admin/base_helper.rb
+++ b/backend/app/helpers/spree/admin/base_helper.rb
@@ -144,11 +144,6 @@ module Spree
         resource_class.model_name.human(count: I18N_PLURAL_MANY_COUNT)
       end
 
-      def back_to_list_button(resource, path)
-        button_text = Spree.t(:back_to_resource_list, resource: resource)
-        link_to_with_icon 'arrow-left', button_text, path, class: 'btn btn-default'
-      end
-
       def order_time(time)
         [I18n.l(time.to_date), time.strftime("%l:%M %p")].join('')
       end

--- a/backend/app/views/spree/admin/countries/edit.html.erb
+++ b/backend/app/views/spree/admin/countries/edit.html.erb
@@ -1,9 +1,6 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_resource, resource: Spree::Country.model_name.human) %>
-<% end %>
-
-<% content_for :page_actions do %>
-  <%= back_to_list_button(Spree::Country.model_name.human, admin_countries_path) %>
+  <%= link_to Spree.t(:countries), spree.admin_countries_url %> /
+  <%= @country.name %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @country } %>

--- a/backend/app/views/spree/admin/countries/new.html.erb
+++ b/backend/app/views/spree/admin/countries/new.html.erb
@@ -1,9 +1,6 @@
 <% content_for :page_title do %>
+  <%= link_to Spree.t(:countries), spree.admin_countries_url %> /
   <%= Spree.t(:new_country) %>
-<% end %>
-
-<% content_for :page_actions do %>
-  <%= back_to_list_button(Spree::Country.model_name.human, admin_countries_path) %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @country } %>

--- a/backend/app/views/spree/admin/option_types/edit.html.erb
+++ b/backend/app/views/spree/admin/option_types/edit.html.erb
@@ -1,13 +1,12 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_resource, resource: Spree::OptionType.model_name.human) %> <span class="green">"<%= @option_type.name %>"</span>
+  <%= link_to Spree.t(:option_types), spree.admin_option_types_url %> /
+  <%= @option_type.presentation %>
 <% end %>
 
 <% content_for :page_actions do %>
   <span id="new_add_option_value" data-hook>
     <%= button_link_to Spree.t(:add_option_value), "javascript:;", { :icon => 'add', :'data-target' => "tbody#option_values", :class => 'btn-success spree_add_fields' } %>
   </span>
-
-  <%= back_to_list_button(Spree::OptionType.model_name.human, admin_option_types_path) %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @option_type } %>

--- a/backend/app/views/spree/admin/option_types/edit.html.erb
+++ b/backend/app/views/spree/admin/option_types/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title do %>
   <%= link_to Spree.t(:option_types), spree.admin_option_types_url %> /
-  <%= @option_type.presentation %>
+  <%= @option_type.name %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/option_types/new.html.erb
+++ b/backend/app/views/spree/admin/option_types/new.html.erb
@@ -1,9 +1,6 @@
 <% content_for :page_title do %>
+  <%= link_to Spree.t(:option_types), spree.admin_option_types_url %> /
   <%= Spree.t(:new_option_type) %>
-<% end %>
-
-<% content_for :page_actions do %>
-  <%= back_to_list_button(Spree::OptionType.model_name.human, admin_option_types_path) %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @option_type } %>

--- a/backend/app/views/spree/admin/orders/cart.html.erb
+++ b/backend/app/views/spree/admin/orders/cart.html.erb
@@ -1,7 +1,4 @@
 <%= render 'order_actions', order: @order, events: @order_events %>
-<% content_for :page_actions do %>
-  <%= back_to_list_button(Spree::Order.model_name.human, admin_orders_path) %>
-<% end %>
 
 <%= render 'spree/admin/shared/order_tabs', current: :cart %>
 

--- a/backend/app/views/spree/admin/orders/edit.html.erb
+++ b/backend/app/views/spree/admin/orders/edit.html.erb
@@ -1,7 +1,4 @@
 <%= render 'order_actions', order: @order, events: @order_events %>
-<% content_for :page_actions do %>
-  <%= back_to_list_button(Spree::Order.model_name.human, admin_orders_path) %>
-<% end %>
 
 <%= render 'spree/admin/shared/order_tabs', current: :shipments %>
 

--- a/backend/app/views/spree/admin/payment_methods/edit.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/edit.html.erb
@@ -1,9 +1,6 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_resource, resource: Spree::PaymentMethod.model_name.human) %> / <%= @payment_method.name %>
-<% end %>
-
-<% content_for :page_actions do %>
-  <%= back_to_list_button(Spree::PaymentMethod.model_name.human, admin_payment_methods_path) %>
+  <%= link_to Spree.t(:payment_methods), admin_payment_methods_url %> /
+  <%= @payment_method.name %>
 <% end %>
 
 <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @payment_method } %>

--- a/backend/app/views/spree/admin/payment_methods/edit.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= link_to Spree.t(:payment_methods), admin_payment_methods_url %> /
+  <%= link_to Spree.t(:payment_methods), spree.admin_payment_methods_url %> /
   <%= @payment_method.name %>
 <% end %>
 

--- a/backend/app/views/spree/admin/payment_methods/new.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/new.html.erb
@@ -1,9 +1,6 @@
 <% content_for :page_title do %>
+  <%= link_to Spree.t(:payment_methods), admin_payment_methods_url %> /
   <%= Spree.t(:new_payment_method) %>
-<% end %>
-
-<% content_for :page_actions do %>
-  <%= back_to_list_button(Spree::PaymentMethod.model_name.human, admin_payment_methods_path) %>
 <% end %>
 
 <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @payment_method } %>

--- a/backend/app/views/spree/admin/payment_methods/new.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= link_to Spree.t(:payment_methods), admin_payment_methods_url %> /
+  <%= link_to Spree.t(:payment_methods), spree.admin_payment_methods_url %> /
   <%= Spree.t(:new_payment_method) %>
 <% end %>
 

--- a/backend/app/views/spree/admin/products/edit.html.erb
+++ b/backend/app/views/spree/admin/products/edit.html.erb
@@ -2,7 +2,6 @@
   <% if can?(:create, Spree::Product) %>
     <%= button_link_to Spree.t(:new_product), new_object_url, { class: "btn-success", icon: 'add', id: 'admin_new_product' } %>
   <% end %>
-  <%= back_to_list_button(Spree::Product.model_name.human, admin_products_path) %>
 <% end %>
 
 <%= render partial: 'spree/admin/shared/product_tabs', locals: {current: :details} %>

--- a/backend/app/views/spree/admin/products/new.html.erb
+++ b/backend/app/views/spree/admin/products/new.html.erb
@@ -1,11 +1,8 @@
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @product } %>
 
 <% content_for :page_title do %>
+  <%= link_to Spree.t(:products), spree.admin_products_url %> /
   <%= Spree.t(:new_product) %>
-<% end %>
-
-<% content_for :page_actions do %>
-  <%= back_to_list_button(Spree::Product.model_name.human, admin_products_path) %>
 <% end %>
 
 <%= form_for [:admin, @product], :html => { :multipart => true } do |f| %>

--- a/backend/app/views/spree/admin/promotion_categories/edit.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/edit.html.erb
@@ -1,9 +1,6 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_resource, resource: Spree::PromotionCategory.model_name.human) %>
-<% end %>
-
-<% content_for :page_actions do %>
-  <%= back_to_list_button(Spree::PromotionCategory.model_name.human, admin_promotion_categories_path) %>
+  <%= link_to Spree.t(:promotion_categories), spree.admin_promotion_categories_url %> /
+  <%= @promotion_category.name %>
 <% end %>
 
 <%= form_for @promotion_category, :url => object_url, :method => :put do |f| %>

--- a/backend/app/views/spree/admin/promotion_categories/new.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/new.html.erb
@@ -1,9 +1,6 @@
 <% content_for :page_title do %>
+  <%= link_to Spree.t(:promotion_categories), spree.admin_promotion_categories_url %> /
   <%= Spree.t(:new_promotion_category) %>
-<% end %>
-
-<% content_for :page_actions do %>
-  <%= back_to_list_button(Spree::PromotionCategory.model_name.human, admin_promotion_categories_path) %>
 <% end %>
 
 <%= form_for :promotion_category, :url => collection_url do |f| %>

--- a/backend/app/views/spree/admin/promotions/edit.html.erb
+++ b/backend/app/views/spree/admin/promotions/edit.html.erb
@@ -1,19 +1,16 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_resource, resource: Spree::Promotion.model_name.human) %>
-<% end %>
-
-<% content_for :page_actions do %>
-  <%= back_to_list_button(Spree::Promotion.model_name.human, admin_promotions_path) %>
+  <%= link_to Spree.t(:promotions), admin_promotions_url %> /
+  <%= @promotion.name %>
 <% end %>
 
 <%= form_for @promotion, :url => object_url, :method => :put do |f| %>
   <div class="row">
     <div class="col-md-12">
       <%= render :partial => 'form', :locals => { :f => f } %>
-      <%= render :partial => 'spree/admin/shared/edit_resource_links' %>  
-    </div>    
+      <%= render :partial => 'spree/admin/shared/edit_resource_links' %>
+    </div>
   </div>
-  
+
 <% end %>
 
 <div id="promotion-filters" class="row">

--- a/backend/app/views/spree/admin/promotions/new.html.erb
+++ b/backend/app/views/spree/admin/promotions/new.html.erb
@@ -1,14 +1,11 @@
 <% content_for :page_title do %>
+  <%= link_to Spree.t(:promotions), admin_promotions_url %> /
   <%= Spree.t(:new_promotion) %>
-<% end %>
-
-<% content_for :page_actions do %>
-  <%= back_to_list_button(Spree::Promotion.model_name.human, admin_promotions_path) %>
 <% end %>
 
 <%= form_for :promotion, :url => collection_url do |f| %>
   <%= render :partial => 'form', :locals => { :f => f } %>
   <div class="text-center">
-    <%= render :partial => 'spree/admin/shared/new_resource_links' %>  
+    <%= render :partial => 'spree/admin/shared/new_resource_links' %>
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/properties/edit.html.erb
+++ b/backend/app/views/spree/admin/properties/edit.html.erb
@@ -1,9 +1,6 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_resource, resource: Spree::Property.model_name.human) %>
-<% end %>
-
-<% content_for :page_actions do %>
-  <%= back_to_list_button(Spree::Property.model_name.human, admin_properties_path) %>
+  <%= link_to Spree.t(:properties), admin_properties_url %> /
+  <%= @property.presentation %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @property } %>

--- a/backend/app/views/spree/admin/properties/edit.html.erb
+++ b/backend/app/views/spree/admin/properties/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title do %>
   <%= link_to Spree.t(:properties), admin_properties_url %> /
-  <%= @property.presentation %>
+  <%= @property.name %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @property } %>

--- a/backend/app/views/spree/admin/properties/new.html.erb
+++ b/backend/app/views/spree/admin/properties/new.html.erb
@@ -1,11 +1,8 @@
 <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @property } %>
 
 <% content_for :page_title do %>
+  <%= link_to Spree.t(:properties), admin_properties_url %> /
   <%= Spree.t(:new_property) %>
-<% end %>
-
-<% content_for :page_actions do %>
-  <%= back_to_list_button(Spree::Property.model_name.human, admin_properties_path) %>
 <% end %>
 
 <%= form_for [:admin, @property] do |f| %>

--- a/backend/app/views/spree/admin/prototypes/edit.html.erb
+++ b/backend/app/views/spree/admin/prototypes/edit.html.erb
@@ -1,9 +1,6 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_resource, resource: Spree::Prototype.model_name.human) %>
-<% end %>
-
-<% content_for :page_actions do %>
-  <%= back_to_list_button(Spree::Prototype.model_name.human, admin_prototypes_path) %>
+  <%= link_to Spree.t(:prototypes), spree.admin_prototypes_url %> /
+  <%= @prototype.name %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @prototype } %>

--- a/backend/app/views/spree/admin/prototypes/new.html.erb
+++ b/backend/app/views/spree/admin/prototypes/new.html.erb
@@ -1,11 +1,8 @@
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @prototype } %>
 
 <% content_for :page_title do %>
+  <%= link_to Spree.t(:prototypes), spree.admin_prototypes_url %> /
   <%= Spree.t(:new_prototype) %>
-<% end %>
-
-<% content_for :page_actions do %>
-  <%= back_to_list_button(Spree::Prototype.model_name.human, admin_prototypes_path) %>
 <% end %>
 
 <%= form_for [:admin, @prototype] do |f| %>

--- a/backend/app/views/spree/admin/refund_reasons/edit.html.erb
+++ b/backend/app/views/spree/admin/refund_reasons/edit.html.erb
@@ -1,4 +1,3 @@
 <%= render partial: 'spree/admin/shared/named_types/edit', locals: {
-  page_title: Spree.t(:editing_resource, resource: Spree::RefundReason.model_name.human),
-  back_button_text: Spree.t(:back_to_resource_list, resource: Spree::RefundReason.model_name.human)
+  collection_url_label: Spree.t(:refund_reasons)
 } %>

--- a/backend/app/views/spree/admin/refund_reasons/new.html.erb
+++ b/backend/app/views/spree/admin/refund_reasons/new.html.erb
@@ -1,4 +1,4 @@
 <%= render partial: 'spree/admin/shared/named_types/new', locals: {
-  page_title: Spree.t(:new_refund_reason),
-  back_button_text: Spree.t(:back_to_resource_list, resource: Spree::RefundReason.model_name.human)
+  collection_url_label: Spree.t(:refund_reasons),
+  page_title: Spree.t(:new_refund_reason)
 } %>

--- a/backend/app/views/spree/admin/refunds/edit.html.erb
+++ b/backend/app/views/spree/admin/refunds/edit.html.erb
@@ -1,8 +1,8 @@
 <%= render partial: 'spree/admin/shared/order_tabs', locals: { current: :payments } %>
 
 <% content_for :page_title do %>
-  / <%= link_to "#{Spree.t(:payment)} #{@refund.payment.id}", admin_order_payment_path(@refund.payment.order, @refund.payment) %>
-  / <%= Spree.t(:editing_resource, resource: Spree::Refund.model_name.human) %> <%= @refund.id %>
+  / <%= link_to "#{Spree.t(:payment)} #{@refund.payment.id}", spree.admin_order_payment_path(@refund.payment.order, @refund.payment) %>
+  / <%= Spree.t(:refund) %> <%= @refund.id %>
 <% end %>
 
 <%= form_for [:admin, @refund.payment.order, @refund.payment, @refund] do |f| %>

--- a/backend/app/views/spree/admin/refunds/new.html.erb
+++ b/backend/app/views/spree/admin/refunds/new.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: 'spree/admin/shared/order_tabs', locals: {current: :payments} %>
 
 <% content_for :page_title do %>
-  / <%= link_to "#{Spree.t(:payment)} #{@refund.payment.id}", admin_order_payment_path(@refund.payment.order, @refund.payment) %>
+  / <%= link_to "#{Spree.t(:payment)} #{@refund.payment.id}", spree.admin_order_payment_path(@refund.payment.order, @refund.payment) %>
   / <%= Spree.t(:new_refund) %>
 <% end %>
 

--- a/backend/app/views/spree/admin/reimbursements/edit.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: 'spree/admin/shared/order_tabs', locals: { current: :customer_returns } %>
 
 <% content_for :page_title do %>
-  / <%= Spree.t(:editing_resource, resource: Spree::Reimbursement.model_name.human) %> #<%= @reimbursement.number %>
+  / <%= Spree.t(:reimbursement) %> #<%= @reimbursement.number %>
 <% end %>
 
 <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @reimbursement } %>

--- a/backend/app/views/spree/admin/reports/sales_total.html.erb
+++ b/backend/app/views/spree/admin/reports/sales_total.html.erb
@@ -1,9 +1,6 @@
 <% content_for :page_title do %>
+  <%= link_to Spree.t(:reports), spree.admin_reports_url %> /
   <%= Spree.t(:sales_totals) %>
-<% end %>
-
-<% content_for :page_actions do %>
-  <%= back_to_list_button(Spree.t(:report), admin_reports_path) %>
 <% end %>
 
 <div class="well">

--- a/backend/app/views/spree/admin/return_authorization_reasons/edit.html.erb
+++ b/backend/app/views/spree/admin/return_authorization_reasons/edit.html.erb
@@ -1,4 +1,3 @@
 <%= render partial: 'spree/admin/shared/named_types/edit', locals: {
-  page_title: Spree.t(:editing_rma_reason),
-  back_button_text: Spree.t(:back_to_rma_reason_list)
+  collection_url_label: Spree.t(:return_authorization_reasons)
 } %>

--- a/backend/app/views/spree/admin/return_authorization_reasons/new.html.erb
+++ b/backend/app/views/spree/admin/return_authorization_reasons/new.html.erb
@@ -1,4 +1,4 @@
 <%= render partial: 'spree/admin/shared/named_types/new', locals: {
-  page_title: Spree.t(:new_rma_reason),
-  back_button_text: Spree.t(:back_to_rma_reason_list)
+  collection_url_label: Spree.t(:return_authorization_reasons),
+  page_title: Spree.t(:new_rma_reason)
 } %>

--- a/backend/app/views/spree/admin/return_authorizations/edit.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/edit.html.erb
@@ -2,13 +2,13 @@
   <% if @return_authorization.can_cancel? %>
     <%= button_link_to Spree.t('actions.cancel'), fire_admin_order_return_authorization_url(@order, @return_authorization, e: 'cancel'), method: :put, data: { confirm: Spree.t(:are_you_sure) }, icon: "delete" %>
   <% end %>
-  <%= button_link_to Spree.t(:back), spree.admin_order_return_authorizations_url(@order), icon: 'arrow-left' %>
 <% end %>
 
 <%= render partial: 'spree/admin/shared/order_tabs', locals: { current: :return_authorizations } %>
 
 <% content_for :page_title do %>
-  / <%= Spree.t(:return_authorization) %> <%= @return_authorization.number %> (<%= Spree.t(@return_authorization.state.downcase) %>)
+  / <%= link_to Spree.t(:return_authorizations), spree.admin_order_return_authorizations_url %>
+  / <%= @return_authorization.number %> (<%= Spree.t(@return_authorization.state.downcase) %>)
 <% end %>
 
 <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @return_authorization } %>

--- a/backend/app/views/spree/admin/return_authorizations/index.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/index.html.erb
@@ -25,7 +25,11 @@
       <% @return_authorizations.each do |return_authorization| %>
         <tr id="<%= spree_dom_id(return_authorization) %>" data-hook="rma_row">
           <td><%= return_authorization.number %></td>
-          <td><%= Spree.t(return_authorization.state.downcase) %></td>
+          <td>
+            <span class="label label-<%= return_authorization.state %>">
+              <%= Spree.t("return_authorization_states.#{return_authorization.state}") %>
+            </span>
+          </td>
           <td><%= return_authorization.display_pre_tax_total.to_html %></td>
           <td><%= pretty_time(return_authorization.created_at) %></td>
           <td class="actions actions-2">

--- a/backend/app/views/spree/admin/roles/edit.html.erb
+++ b/backend/app/views/spree/admin/roles/edit.html.erb
@@ -1,9 +1,6 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_resource, resource: Spree::Role.model_name.human) %>
-<% end %>
-
-<% content_for :page_actions do %>
-  <%= back_to_list_button(Spree::Role.model_name.human, admin_roles_path) %>
+  <%= link_to Spree.t(:roles), spree.admin_roles_url %> /
+  <%= @role.name.capitalize %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @role } %>

--- a/backend/app/views/spree/admin/roles/new.html.erb
+++ b/backend/app/views/spree/admin/roles/new.html.erb
@@ -1,9 +1,6 @@
 <% content_for :page_title do %>
+  <%= link_to Spree.t(:roles), spree.admin_roles_url %> /
   <%= Spree.t(:new_role) %>
-<% end %>
-
-<% content_for :page_actions do %>
-  <%= back_to_list_button(Spree::Role.model_name.human, admin_roles_path) %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @role } %>

--- a/backend/app/views/spree/admin/shared/named_types/_edit.html.erb
+++ b/backend/app/views/spree/admin/shared/named_types/_edit.html.erb
@@ -1,9 +1,6 @@
 <% content_for :page_title do %>
-  <%= page_title %> / <%= @object.name %>
-<% end %>
-
-<% content_for :page_actions do %>
-  <%= link_to_with_icon 'arrow-left', back_button_text, collection_url, class: 'btn btn-default' %>
+  <%= link_to collection_url_label, collection_url %> /
+  <%= @object.name %>
 <% end %>
 
 <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @object } %>

--- a/backend/app/views/spree/admin/shared/named_types/_new.html.erb
+++ b/backend/app/views/spree/admin/shared/named_types/_new.html.erb
@@ -1,9 +1,6 @@
 <% content_for :page_title do %>
+  <%= link_to collection_url_label, collection_url %> /
   <%= page_title %>
-<% end %>
-
-<% content_for :page_actions do %>
-  <%= link_to_with_icon 'arrow-left', back_button_text, collection_url, class: 'btn btn-default' %>
 <% end %>
 
 <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @object } %>

--- a/backend/app/views/spree/admin/shipping_categories/edit.html.erb
+++ b/backend/app/views/spree/admin/shipping_categories/edit.html.erb
@@ -1,9 +1,6 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_resource, resource: Spree::ShippingCategory.model_name.human) %>
-<% end %>
-
-<% content_for :page_actions do %>
-  <%= back_to_list_button(Spree::ShippingCategory.model_name.human, admin_shipping_categories_path) %>
+  <%= link_to Spree.t(:shipping_categories), spree.admin_shipping_categories_url %> /
+  <%= @shipping_category.name %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @shipping_category } %>

--- a/backend/app/views/spree/admin/shipping_categories/new.html.erb
+++ b/backend/app/views/spree/admin/shipping_categories/new.html.erb
@@ -1,9 +1,6 @@
 <% content_for :page_title do %>
+  <%= link_to Spree.t(:shipping_categories), spree.admin_shipping_categories_url %> /
   <%= Spree.t(:new_shipping_category) %>
-<% end %>
-
-<% content_for :page_actions do %>
-  <%= back_to_list_button(Spree::ShippingCategory.model_name.human, admin_shipping_categories_path) %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @shipping_category } %>

--- a/backend/app/views/spree/admin/shipping_methods/edit.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/edit.html.erb
@@ -1,5 +1,6 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_resource, resource: Spree::ShippingMethod.model_name.human) %>
+  <%= link_to Spree.t(:shipping_methods), spree.admin_shipping_methods_url %> /
+  <%= @shipping_method.name %>
 <% end %>
 
 <div data-hook="admin_shipping_method_edit_form_header">

--- a/backend/app/views/spree/admin/shipping_methods/new.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/new.html.erb
@@ -1,4 +1,5 @@
 <% content_for :page_title do %>
+  <%= link_to Spree.t(:shipping_methods), spree.admin_shipping_methods_url %> /
   <%= Spree.t(:new_shipping_method) %>
 <% end %>
 

--- a/backend/app/views/spree/admin/states/edit.html.erb
+++ b/backend/app/views/spree/admin/states/edit.html.erb
@@ -1,9 +1,6 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_resource, resource: Spree::State.model_name.human) %> / <%= @state.name %>
-<% end %>
-
-<% content_for :page_actions do %>
-  <%= back_to_list_button(Spree::State.model_name.human, admin_country_states_path(@country)) %>
+  <%= link_to Spree.t(:states), spree.admin_country_states_url(@country) %> /
+  <%= @state.name %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @state } %>

--- a/backend/app/views/spree/admin/states/new.html.erb
+++ b/backend/app/views/spree/admin/states/new.html.erb
@@ -1,11 +1,8 @@
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @state } %>
 
 <% content_for :page_title do %>
+  <%= link_to Spree.t(:states), spree.admin_country_states_url(@country) %> /
   <%= Spree.t(:new_state) %>
-<% end %>
-
-<% content_for :page_actions do %>
-  <%= back_to_list_button(Spree::State.model_name.human, admin_country_states_path(@country)) %>
 <% end %>
 
 <%= form_for [:admin, @country, @state] do |f| %>

--- a/backend/app/views/spree/admin/stock_locations/edit.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/edit.html.erb
@@ -1,10 +1,6 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_resource, resource: Spree::StockLocation.model_name.human) %> /
+  <%= link_to Spree.t(:stock_locations), spree.admin_stock_locations_url %> /
   <%= @stock_location.name %>
-<% end %>
-
-<% content_for :page_actions do %>
-  <%= back_to_list_button(Spree::StockLocation.model_name.human, admin_stock_locations_path) %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @stock_location } %>

--- a/backend/app/views/spree/admin/stock_locations/new.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/new.html.erb
@@ -1,9 +1,6 @@
 <% content_for :page_title do %>
+  <%= link_to Spree.t(:stock_locations), spree.admin_stock_locations_url %> /
   <%= Spree.t(:new_stock_location) %>
-<% end %>
-
-<% content_for :page_actions do %>
-  <%= link_to_with_icon 'arrow-left', Spree.t(:back_to_stock_locations_list), admin_stock_locations_path, :class => 'btn btn-primary' %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @stock_location } %>

--- a/backend/app/views/spree/admin/stock_movements/index.html.erb
+++ b/backend/app/views/spree/admin/stock_movements/index.html.erb
@@ -1,10 +1,10 @@
 <% content_for :page_title do %>
+  <%= link_to Spree.t(:stock_locations), spree.admin_stock_locations_path %> /
   <%= Spree.t(:stock_movements_for_stock_location, stock_location_name: @stock_location.name) %>
 <% end %>
 
 <% content_for :page_actions do %>
   <%= button_link_to Spree.t(:new_stock_movement), new_admin_stock_location_stock_movement_path(@stock_location), icon: 'add', class: 'btn-success', id: 'admin_new_stock_movement_link' %>
-  <%= back_to_list_button(Spree::StockLocation.model_name.human, admin_stock_locations_path) %>
 <% end %>
 
 <% if @stock_movements.any? %>

--- a/backend/app/views/spree/admin/stock_movements/new.html.erb
+++ b/backend/app/views/spree/admin/stock_movements/new.html.erb
@@ -1,9 +1,7 @@
 <% content_for :page_title do %>
+  <%= link_to Spree.t(:stock_locations), spree.admin_stock_locations_url %> /
+  <%= link_to Spree.t(:stock_movements), spree.admin_stock_location_stock_movements_path(stock_location) %> /
   <%= Spree.t(:new_stock_movement) %>
-<% end %>
-
-<% content_for :page_actions do %>
-  <%= back_to_list_button(Spree::StockMovement.model_name.human, admin_stock_location_stock_movements_path(stock_location)) %>
 <% end %>
 
 <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @stock_movement } %>

--- a/backend/app/views/spree/admin/stock_transfers/new.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/new.html.erb
@@ -1,4 +1,5 @@
 <% content_for :page_title do %>
+  <%= link_to Spree.t(:stock_transfers), spree.admin_stock_transfers_url %> /
   <%= Spree.t(:new_stock_transfer) %>
 <% end %>
 
@@ -48,7 +49,7 @@
           <%= label_tag :transfer_destination_location_id, Spree.t(:destination) %>
           <%= select_tag :transfer_destination_location_id, {}, class: 'select2' %>
         </div>
-      </div>  
+      </div>
     </div>
   </div>
 

--- a/backend/app/views/spree/admin/stock_transfers/show.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/show.html.erb
@@ -1,5 +1,6 @@
 <% content_for :page_title do %>
-  <%= plural_resource_name(Spree::StockTransfer) %> (<%= @stock_transfer.number %>)
+    <%= link_to Spree.t(:stock_transfers), spree.admin_stock_transfers_url %> /
+    <%= @stock_transfer.number %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/store_credit_categories/edit.html.erb
+++ b/backend/app/views/spree/admin/store_credit_categories/edit.html.erb
@@ -1,5 +1,6 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_resource, resource: Spree::StoreCreditCategory.model_name.human) %>
+  <%= link_to Spree.t(:store_credit_categories), spree.admin_store_credit_categories_url %> /
+  <%= @store_credit_category.name %>
 <% end %>
 
 <%= render 'spree/admin/shared/error_messages', target: @store_credit_category %>

--- a/backend/app/views/spree/admin/store_credit_categories/new.html.erb
+++ b/backend/app/views/spree/admin/store_credit_categories/new.html.erb
@@ -1,4 +1,5 @@
 <% content_for :page_title do %>
+  <%= link_to Spree.t(:store_credit_categories), spree.admin_store_credit_categories_url %> /
   <%= Spree.t(:new_store_credit_category) %>
 <% end %>
 

--- a/backend/app/views/spree/admin/store_credits/edit.html.erb
+++ b/backend/app/views/spree/admin/store_credits/edit.html.erb
@@ -1,8 +1,10 @@
-<% content_for :page_title do %>
-  <%= link_to "#{@user.email}", spree.edit_admin_user_url(@user) %> / <%= Spree.t(:editing_resource, resource: Spree::StoreCredit.model_name.human) %>
-<% end %>
-
 <%= render partial: 'spree/admin/users/sidebar', locals: { current: :store_credits } %>
+
+<% content_for :page_title do %>
+  <%= link_to @user.email, spree.edit_admin_user_url(@user) %> /
+  <%= link_to Spree.t(:store_credits), spree.admin_user_store_credits_path(@user) %> /
+  <%= Spree.t(:editing_resource, resource: Spree::StoreCredit.model_name.human) %>
+<% end %>
 
 <%= form_for @store_credit, url: spree.admin_user_store_credit_path(@user, @store_credit) do |f| %>
   <fieldset>

--- a/backend/app/views/spree/admin/store_credits/index.html.erb
+++ b/backend/app/views/spree/admin/store_credits/index.html.erb
@@ -1,11 +1,11 @@
-<% content_for :page_title do %>
-  <%= link_to "#{@user.email}", spree.edit_admin_user_url(@user) %> / <%= Spree.t(:"admin.user.store_credits") %>
-<% end %>
-
 <%= render partial: 'spree/admin/users/sidebar', locals: { current: :store_credits } %>
 
+<% content_for :page_title do %>
+  <%= link_to @user.email, spree.edit_admin_user_url(@user) %> /
+  <%= Spree.t(:"admin.user.store_credits") %>
+<% end %>
+
 <% content_for :page_actions do %>
-  <%= back_to_list_button(Spree.user_class.model_name.human, spree.admin_users_path) %>
   <%= button_link_to Spree.t(:add_store_credit), spree.new_admin_user_store_credit_path(@user), class: "btn-success", icon: 'add' %>
 <% end %>
 

--- a/backend/app/views/spree/admin/store_credits/new.html.erb
+++ b/backend/app/views/spree/admin/store_credits/new.html.erb
@@ -1,8 +1,10 @@
-<% content_for :page_title do %>
-  <%= link_to "#{@user.email}", spree.edit_admin_user_url(@user) %> / <%= Spree.t(:new_store_credit) %>
-<% end %>
-
 <%= render partial: 'spree/admin/users/sidebar', locals: { current: :store_credits } %>
+
+<% content_for :page_title do %>
+  <%= link_to @user.email, spree.edit_admin_user_url(@user) %> /
+  <%= link_to Spree.t(:store_credits), spree.admin_user_store_credits_path(@user) %> /
+  <%= Spree.t(:add_store_credit) %>
+<% end %>
 
 <%= form_for @store_credit, url: spree.admin_user_store_credits_path(@user, @store_credit) do |f| %>
   <fieldset>

--- a/backend/app/views/spree/admin/tax_categories/edit.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/edit.html.erb
@@ -1,9 +1,6 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_resource, resource: Spree::TaxCategory.model_name.human) %>
-<% end %>
-
-<% content_for :page_actions do %>
-  <%= back_to_list_button(Spree::TaxCategory.model_name.human, admin_tax_categories_path) %>
+  <%= link_to Spree.t(:tax_categories), spree.admin_tax_categories_url %> /
+  <%= @tax_category.name %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @tax_category } %>

--- a/backend/app/views/spree/admin/tax_categories/new.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/new.html.erb
@@ -1,9 +1,6 @@
 <% content_for :page_title do %>
+  <%= link_to Spree.t(:tax_categories), spree.admin_tax_categories_url %> /
   <%= Spree.t(:new_tax_category) %>
-<% end %>
-
-<% content_for :page_actions do %>
-  <%= back_to_list_button(Spree::TaxCategory.model_name.human, admin_tax_categories_path) %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @tax_category } %>

--- a/backend/app/views/spree/admin/tax_rates/edit.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/edit.html.erb
@@ -1,9 +1,6 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_resource, resource: Spree::TaxRate.model_name.human) %>
-<% end %>
-
-<% content_for :page_actions do %>
-  <%= back_to_list_button(Spree::TaxRate.model_name.human, admin_tax_rates_path) %>
+  <%= link_to Spree.t(:tax_rates), spree.admin_tax_rates_url %> /
+  <%= @tax_rate.name %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @tax_rate } %>

--- a/backend/app/views/spree/admin/tax_rates/new.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/new.html.erb
@@ -1,9 +1,6 @@
 <% content_for :page_title do %>
+  <%= link_to Spree.t(:tax_rates), spree.admin_tax_rates_url %> /
   <%= Spree.t(:new_tax_rate) %>
-<% end %>
-
-<% content_for :page_actions do %>
-  <%= back_to_list_button(Spree::TaxRate.model_name.human, admin_tax_rates_path) %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @tax_rate } %>

--- a/backend/app/views/spree/admin/taxonomies/edit.erb
+++ b/backend/app/views/spree/admin/taxonomies/edit.erb
@@ -1,11 +1,8 @@
 <%= render partial: 'js_head' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:taxonomy_edit) %>
-<% end %>
-
-<% content_for :page_actions do %>
-  <%= back_to_list_button(Spree::Taxonomy.model_name.human, admin_taxonomies_path) %>
+  <%= link_to Spree.t(:taxonomies), spree.admin_taxonomies_url %> /
+  <%= @taxonomy.name %>
 <% end %>
 
 <div id="ajax_error" class="errorExplanation" style="display:none;"></div>

--- a/backend/app/views/spree/admin/taxonomies/new.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/new.html.erb
@@ -1,11 +1,8 @@
 <% content_for :page_title do %>
+  <%= link_to Spree.t(:taxonomies), spree.admin_taxonomies_url %> /
   <%= Spree.t(:new_taxonomy) %>
 <% end %>
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @taxonomy } %>
-
-<% content_for :page_actions do %>
-  <%= back_to_list_button(Spree::Taxonomy.model_name.human, admin_taxonomies_path) %>
-<% end %>
 
 <%= form_for [:admin, @taxonomy] do |f| %>
   <fieldset>

--- a/backend/app/views/spree/admin/taxons/edit.html.erb
+++ b/backend/app/views/spree/admin/taxons/edit.html.erb
@@ -1,5 +1,7 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:taxon_edit) %>
+  <%= link_to Spree.t(:taxonomies), spree.admin_taxonomies_url %> /
+  <%= link_to @taxonomy.name, spree.edit_admin_taxonomy_url(@taxonomy) %> /
+  <%= @taxon.name %>
 <% end %>
 
 <%# Because otherwise the form would attempt to use to_param of @taxon %>

--- a/backend/app/views/spree/admin/trackers/edit.html.erb
+++ b/backend/app/views/spree/admin/trackers/edit.html.erb
@@ -1,5 +1,6 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_resource, resource: Spree::Tracker.model_name.human) %>
+  <%= link_to Spree.t(:analytics_trackers), spree.admin_trackers_url %> /
+  <%= @tracker.analytics_id %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @tracker } %>

--- a/backend/app/views/spree/admin/trackers/new.html.erb
+++ b/backend/app/views/spree/admin/trackers/new.html.erb
@@ -1,4 +1,5 @@
 <% content_for :page_title do %>
+  <%= link_to Spree.t(:analytics_trackers), spree.admin_trackers_url %> /
   <%= Spree.t(:new_tracker) %>
 <% end %>
 

--- a/backend/app/views/spree/admin/users/_sidebar.html.erb
+++ b/backend/app/views/spree/admin/users/_sidebar.html.erb
@@ -1,3 +1,7 @@
+<% content_for :page_title do %>
+  <%= link_to Spree.t(:users), spree.admin_users_path %> /
+<% end %>
+
 <% content_for :sidebar do %>
   <ul class="nav nav-pills nav-stacked" data-hook="admin_user_tab_options">
     <li<%== ' class="active"' if current == :account %>>

--- a/backend/app/views/spree/admin/users/_user_page_actions.html.erb
+++ b/backend/app/views/spree/admin/users/_user_page_actions.html.erb
@@ -1,4 +1,3 @@
 <% content_for :page_actions do %>
-  <%= back_to_list_button(Spree.user_class.model_name.human, spree.admin_users_path) %>
   <%= button_link_to Spree.t(:create_new_order), spree.new_admin_order_path(user_id: @user.id), class: "btn-success", icon: 'add' %>
 <% end %>

--- a/backend/app/views/spree/admin/users/addresses.html.erb
+++ b/backend/app/views/spree/admin/users/addresses.html.erb
@@ -1,9 +1,10 @@
-<% content_for :page_title do %>
-  <%= link_to "#{@user.email}", edit_admin_user_url(@user) %> / <%= Spree.t(:editing_resource, resource: plural_resource_name(Spree::Address)) %>
-<% end %>
-
 <%= render partial: 'spree/admin/users/sidebar', locals: { current: :address } %>
 <%= render partial: 'spree/admin/users/user_page_actions' %>
+
+<% content_for :page_title do %>
+  <%= link_to @user.email, spree.edit_admin_user_url(@user) %> /
+  <%= Spree.t(:addresses) %>
+<% end %>
 
 <div data-hook="admin_user_addresses" id="admin_user_edit_addresses">
   <div data-hook="admin_user_edit_form_header">

--- a/backend/app/views/spree/admin/users/edit.html.erb
+++ b/backend/app/views/spree/admin/users/edit.html.erb
@@ -1,9 +1,9 @@
-<% content_for :page_title do %>
-  <%= Spree.t(:editing_user) %> <%= @user.email %>
-<% end %>
-
 <%= render partial: 'spree/admin/users/sidebar', locals: { current: :account } %>
 <%= render partial: 'spree/admin/users/user_page_actions' %>
+
+<% content_for :page_title do %>
+  <%= @user.email %>
+<% end %>
 
 <div data-hook="admin_user_edit_general_settings" class="panel panel-default">
   <div class="panel-heading">

--- a/backend/app/views/spree/admin/users/items.html.erb
+++ b/backend/app/views/spree/admin/users/items.html.erb
@@ -1,9 +1,10 @@
-<% content_for :page_title do %>
-  <%= link_to "#{@user.email}", edit_admin_user_url(@user) %> / <%= Spree.t(:"admin.user.items_purchased") %>
-<% end %>
-
 <%= render partial: 'spree/admin/users/sidebar', locals: { current: :items } %>
 <%= render partial: 'spree/admin/users/user_page_actions' %>
+
+<% content_for :page_title do %>
+  <%= link_to @user.email, spree.edit_admin_user_url(@user) %> /
+  <%= Spree.t(:"admin.user.items_purchased") %>
+<% end %>
 
 <fieldset data-hook="admin_user_items_purchased">
   <%= paginate @orders %>

--- a/backend/app/views/spree/admin/users/new.html.erb
+++ b/backend/app/views/spree/admin/users/new.html.erb
@@ -1,9 +1,6 @@
 <% content_for :page_title do %>
+  <%= link_to Spree.t(:users), spree.admin_users_url %>
   <%= Spree.t(:new_user) %>
-<% end %>
-
-<% content_for :page_actions do %>
-  <%= back_to_list_button(Spree.user_class.model_name.human, admin_users_path) %>
 <% end %>
 
 <div data-hook="admin_user_new_form_header">

--- a/backend/app/views/spree/admin/users/new.html.erb
+++ b/backend/app/views/spree/admin/users/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= link_to Spree.t(:users), spree.admin_users_url %>
+  <%= link_to Spree.t(:users), spree.admin_users_url %> /
   <%= Spree.t(:new_user) %>
 <% end %>
 

--- a/backend/app/views/spree/admin/users/orders.html.erb
+++ b/backend/app/views/spree/admin/users/orders.html.erb
@@ -1,9 +1,10 @@
-<% content_for :page_title do %>
-  <%= link_to "#{@user.email}", edit_admin_user_url(@user) %> / <%= Spree.t(:"admin.user.order_history") %>
-<% end %>
-
 <%= render partial: 'spree/admin/users/sidebar', locals: { current: :orders } %>
 <%= render partial: 'spree/admin/users/user_page_actions' %>
+
+<% content_for :page_title do %>
+  <%= link_to @user.email, spree.edit_admin_user_url(@user) %> /
+  <%= Spree.t(:"admin.user.order_history") %>
+<% end %>
 
 <fieldset data-hook="admin_user_order_history">
   <%= paginate @orders %>

--- a/backend/app/views/spree/admin/zones/edit.html.erb
+++ b/backend/app/views/spree/admin/zones/edit.html.erb
@@ -1,5 +1,6 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_resource, resource: Spree::Zone.model_name.human) %>
+  <%= link_to Spree.t(:zones), spree.admin_zones_url %> /
+  <%= @zone.name %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @zone } %>

--- a/backend/app/views/spree/admin/zones/new.html.erb
+++ b/backend/app/views/spree/admin/zones/new.html.erb
@@ -1,4 +1,5 @@
 <% content_for :page_title do %>
+  <%= link_to Spree.t(:zones), spree.admin_zones_url %> /
   <%= Spree.t(:new_zone) %>
 <% end %>
 

--- a/backend/spec/features/admin/products/option_types_spec.rb
+++ b/backend/spec/features/admin/products/option_types_spec.rb
@@ -55,10 +55,11 @@ describe "Option Types", type: :feature, js: true do
 
   # Regression test for #2277
   it "can remove an option value from an option type" do
-    create(:option_value)
+    option_type = create(:option_type)
+    create(:option_value, option_type: option_type)
     click_link "Option Types"
     within('table#listing_option_types') { click_icon :edit }
-    expect(page).to have_content("Editing Option Type")
+    expect(page).to have_content(option_type.presentation)
     expect(all("tbody#option_values tr").count).to eq(1)
     within("tbody#option_values") do
       find('.spree_remove_fields').click

--- a/backend/spec/features/admin/products/option_types_spec.rb
+++ b/backend/spec/features/admin/products/option_types_spec.rb
@@ -59,7 +59,7 @@ describe "Option Types", type: :feature, js: true do
     create(:option_value, option_type: option_type)
     click_link "Option Types"
     within('table#listing_option_types') { click_icon :edit }
-    expect(page).to have_content(option_type.presentation)
+    expect(page).to have_content(option_type.name)
     expect(all("tbody#option_values tr").count).to eq(1)
     within("tbody#option_values") do
       find('.spree_remove_fields').click

--- a/backend/spec/features/admin/promotions/adjustments_spec.rb
+++ b/backend/spec/features/admin/promotions/adjustments_spec.rb
@@ -13,7 +13,8 @@ describe "Promotion Adjustments", type: :feature, js: true do
       fill_in "Name", with: "Promotion"
       fill_in "Code", with: "order"
       click_button "Create"
-      expect(page).to have_content("Editing Promotion")
+      promotion = Spree::Promotion.find_by_name("Promotion")
+      expect(page).to have_content(promotion.name)
 
       select2 "Item total", from: "Add rule of type"
       within('#rule_fields') { click_button "Add" }
@@ -30,7 +31,6 @@ describe "Promotion Adjustments", type: :feature, js: true do
       within('.calculator-fields') { fill_in "Amount", with: 5 }
       within('#actions_container') { click_button "Update" }
 
-      promotion = Spree::Promotion.find_by_name("Promotion")
       expect(promotion.code).to eq("order")
 
       first_rule = promotion.rules.first
@@ -50,7 +50,8 @@ describe "Promotion Adjustments", type: :feature, js: true do
       fill_in "Usage Limit", with: "1"
       fill_in "Code", with: "single_use"
       click_button "Create"
-      expect(page).to have_content("Editing Promotion")
+      promotion = Spree::Promotion.find_by_name("Promotion")
+      expect(page).to have_content(promotion.name)
 
       select2 "Create whole-order adjustment", from: "Add action of type"
       within('#action_fields') { click_button "Add" }
@@ -59,7 +60,6 @@ describe "Promotion Adjustments", type: :feature, js: true do
       within('#action_fields') { fill_in "Amount", with: "5" }
       within('#actions_container') { click_button "Update" }
 
-      promotion = Spree::Promotion.find_by_name("Promotion")
       expect(promotion.usage_limit).to eq(1)
       expect(promotion.code).to eq("single_use")
 
@@ -73,7 +73,9 @@ describe "Promotion Adjustments", type: :feature, js: true do
     it "should allow an admin to create an automatic promo with flat percent discount" do
       fill_in "Name", with: "Promotion"
       click_button "Create"
-      expect(page).to have_content("Editing Promotion")
+      promotion = Spree::Promotion.find_by_name("Promotion")
+
+      expect(page).to have_content(promotion.name)
 
       select2 "Item total", from: "Add rule of type"
       within('#rule_fields') { click_button "Add" }
@@ -89,7 +91,6 @@ describe "Promotion Adjustments", type: :feature, js: true do
       within('.calculator-fields') { fill_in "Flat Percent", with: "10" }
       within('#actions_container') { click_button "Update" }
 
-      promotion = Spree::Promotion.find_by_name("Promotion")
       expect(promotion.code).to be_blank
 
       first_rule = promotion.rules.first
@@ -109,7 +110,9 @@ describe "Promotion Adjustments", type: :feature, js: true do
 
       fill_in "Name", with: "Promotion"
       click_button "Create"
-      expect(page).to have_content("Editing Promotion")
+      promotion = Spree::Promotion.find_by_name("Promotion")
+
+      expect(page).to have_content(promotion.name)
 
       select2 "Product(s)", from: "Add rule of type"
       within("#rule_fields") { click_button "Add" }
@@ -123,7 +126,6 @@ describe "Promotion Adjustments", type: :feature, js: true do
       within('.calculator-fields') { fill_in "Percent", with: "10" }
       within('#actions_container') { click_button "Update" }
 
-      promotion = Spree::Promotion.find_by_name("Promotion")
       expect(promotion.code).to be_blank
 
       first_rule = promotion.rules.first
@@ -168,7 +170,9 @@ describe "Promotion Adjustments", type: :feature, js: true do
       fill_in "Name", with: "Promotion"
       fill_in "Path", with: "content/cvv"
       click_button "Create"
-      expect(page).to have_content("Editing Promotion")
+      promotion = Spree::Promotion.find_by_name("Promotion")
+
+      expect(page).to have_content(promotion.name)
 
       select2 "Create whole-order adjustment", from: "Add action of type"
       within('#action_fields') { click_button "Add" }
@@ -177,7 +181,6 @@ describe "Promotion Adjustments", type: :feature, js: true do
       within('.calculator-fields') { fill_in "Amount", with: "4" }
       within('#actions_container') { click_button "Update" }
 
-      promotion = Spree::Promotion.find_by_name("Promotion")
       expect(promotion.path).to eq("content/cvv")
       expect(promotion.code).to be_blank
       expect(promotion.rules).to be_blank
@@ -194,7 +197,9 @@ describe "Promotion Adjustments", type: :feature, js: true do
       fill_in "Name", with: "Promotion"
       fill_in "Code", with: "complex"
       click_button "Create"
-      expect(page).to have_content("Editing Promotion")
+      promotion = Spree::Promotion.find_by_name("Promotion")
+
+      expect(page).to have_content(promotion.name)
 
       select2 "Create line items", from: "Add action of type"
 
@@ -213,7 +218,6 @@ describe "Promotion Adjustments", type: :feature, js: true do
       within('.create_adjustment .calculator-fields') { fill_in "Amount", with: "40.00" }
       within('#actions_container') { click_button "Update" }
 
-      promotion = Spree::Promotion.find_by_name("Promotion")
       expect(promotion.code).to eq("complex")
 
       first_action = promotion.actions.first
@@ -224,7 +228,9 @@ describe "Promotion Adjustments", type: :feature, js: true do
     it "ceasing to be eligible for a promotion with item total rule then becoming eligible again" do
       fill_in "Name", with: "Promotion"
       click_button "Create"
-      expect(page).to have_content("Editing Promotion")
+      promotion = Spree::Promotion.find_by_name("Promotion")
+
+      expect(page).to have_content(promotion.name)
 
       select2 "Item total", from: "Add rule of type"
       within('#rule_fields') { click_button "Add" }
@@ -238,8 +244,6 @@ describe "Promotion Adjustments", type: :feature, js: true do
       within('#actions_container') { click_button "Update" }
       within('.calculator-fields') { fill_in "Amount", with: "5" }
       within('#actions_container') { click_button "Update" }
-
-      promotion = Spree::Promotion.find_by_name("Promotion")
 
       first_rule = promotion.rules.first
       expect(first_rule.class).to eq(Spree::Promotion::Rules::ItemTotal)

--- a/backend/spec/features/admin/returns/return_authorizations_spec.rb
+++ b/backend/spec/features/admin/returns/return_authorizations_spec.rb
@@ -91,7 +91,7 @@ describe "Return Authorizations", type: :feature do
       it 'opens return authorization edit page' do
         visit spree.admin_return_authorizations_path
         click_link return_authorization.number
-        expect(page).to have_content("Return Authorization #{return_authorization.number}")
+        expect(page).to have_content(return_authorization.number)
       end
     end
 

--- a/backend/spec/features/admin/users_spec.rb
+++ b/backend/spec/features/admin/users_spec.rb
@@ -40,7 +40,7 @@ describe 'Users', type: :feature do
     end
 
     it 'can go back to the users list' do
-      expect(page).to have_link Spree.user_class.model_name.human, href: spree.admin_users_path
+      expect(page).to have_link Spree.t(:users), href: spree.admin_users_path
     end
 
     it 'can navigate to the account page' do


### PR DESCRIPTION
With the `3.0` release and move to bootstrap, we started using breadcrumbs for navigation in Admin Panel eg.

![screen shot 2016-04-23 at 5 12 51 pm](https://cloud.githubusercontent.com/assets/55154/14762275/aa034708-0976-11e6-883a-6f6382534db4.png)

This PR finishes this work for every Admin Panel section, that is:
- Orders
- Users
- Zones 
- Store Credits
- Store Credit Categories
- Trackers
- Taxons
- Taxonomies
- Tax Rates
- Tax Categories
- Countries
- Option Types
- Payment Methods
- Products
- Promotions
- Promotion Categories
- Properties
- Prototypes
- Refunds
- Refund Reasons
- Return Authorizations
- Roles
- Reimbursements
- Stock Transfers
- Shipping Methods
- Shipping Categories
- States
- Stock Locations
- Stock Movements
- Reports

Also:
- removes now unused `bac to list` buttons
- fixes return authorizations state labels on lists
