### PR TITLE
(Spree 3.2) ransack updated 1.4.1 -> 1.7.0

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'paranoia', '~> 2.1.0'
   s.add_dependency 'premailer-rails'
   s.add_dependency 'rails', '~> 4.2.6'
-  s.add_dependency 'ransack', '~> 1.4.1'
+  s.add_dependency 'ransack', '~> 1.7.0'
   s.add_dependency 'responders'
   s.add_dependency 'state_machines-activerecord', '~> 0.2'
   s.add_dependency 'stringex'


### PR DESCRIPTION
Ransack updated 1.4.1 -> 1.7.0, All specs passed successfully.
