### PR TITLE
Samples can be run multiple times

### DIFF
--- a/sample/db/samples/adjustments.rb
+++ b/sample/db/samples/adjustments.rb
@@ -3,18 +3,20 @@ Spree::Sample.load_sample("orders")
 first_order = Spree::Order.find_by_number!("R123456789")
 last_order = Spree::Order.find_by_number!("R987654321")
 
-first_order.adjustments.create!(
-  :amount => 0,
-  :source => Spree::TaxRate.find_by_name!("North America"),
-  :order  => first_order,
-  :label => "Tax",
-  :state => "open",
-  :mandatory => true)
+first_order.adjustments.where(
+  source: Spree::TaxRate.find_by_name!("North America"),
+  order: first_order,
+  label: "Tax",
+  state: "open",
+  mandatory: true).first_or_create! do |adj|
+    adj.amount = 0
+  end
 
-last_order.adjustments.create!(
-  :amount => 0,
-  :source => Spree::TaxRate.find_by_name!("North America"),
-  :order  => last_order,
-  :label => "Tax",
-  :state => "open",
-  :mandatory => true)
+last_order.adjustments.where(
+  source: Spree::TaxRate.find_by_name!("North America"),
+  order: last_order,
+  label: "Tax",
+  state: "open",
+  mandatory: true).first_or_create! do |adj|
+    adj.amount = 0
+  end

--- a/sample/db/samples/assets.rb
+++ b/sample/db/samples/assets.rb
@@ -2,7 +2,7 @@ Spree::Sample.load_sample("products")
 Spree::Sample.load_sample("variants")
 
 products = {}
-products[:ror_baseball_jersey] = Spree::Product.find_by_name!("Ruby on Rails Baseball Jersey") 
+products[:ror_baseball_jersey] = Spree::Product.find_by_name!("Ruby on Rails Baseball Jersey")
 products[:ror_tote] = Spree::Product.find_by_name!("Ruby on Rails Tote")
 products[:ror_bag] = Spree::Product.find_by_name!("Ruby on Rails Bag")
 products[:ror_jr_spaghetti] = Spree::Product.find_by_name!("Ruby on Rails Jr. Spaghetti")
@@ -19,141 +19,177 @@ products[:spree_bag] = Spree::Product.find_by_name!("Spree Bag")
 products[:ruby_baseball_jersey] = Spree::Product.find_by_name!("Ruby Baseball Jersey")
 products[:apache_baseball_jersey] = Spree::Product.find_by_name!("Apache Baseball Jersey")
 
-
-def image(name, type="jpeg")
+def image(name, type = "jpeg")
   images_path = Pathname.new(File.dirname(__FILE__)) + "images"
-  path = images_path + "#{name}.#{type}"
+  path = images_path + file_name(name, type)
   return false if !File.exist?(path)
   File.open(path)
+end
+
+def file_name(name, type = "jpeg")
+  "#{name}.#{type}"
 end
 
 images = {
   products[:ror_tote].master => [
     {
-      :attachment => image("ror_tote")
+      name: file_name("ror_tote"),
+      attachment: image("ror_tote")
     },
     {
-      :attachment => image("ror_tote_back") 
+      name: file_name("ror_tote_back"),
+      attachment: image("ror_tote_back")
     }
   ],
   products[:ror_bag].master => [
     {
-      :attachment => image("ror_bag")
+      name: file_name("ror_bag"),
+      attachment: image("ror_bag")
     }
   ],
   products[:ror_baseball_jersey].master => [
     {
-      :attachment => image("ror_baseball")
+      name: file_name("ror_baseball"),
+      attachment: image("ror_baseball")
     },
     {
-      :attachment => image("ror_baseball_back")
+      name: file_name("ror_baseball_back"),
+      attachment: image("ror_baseball_back")
     }
   ],
   products[:ror_jr_spaghetti].master => [
     {
-      :attachment => image("ror_jr_spaghetti")
+      name: file_name("ror_jr_spaghetti"),
+      attachment: image("ror_jr_spaghetti")
     }
   ],
   products[:ror_mug].master => [
     {
-      :attachment => image("ror_mug")
+      name: file_name("ror_mug"),
+      attachment: image("ror_mug")
     },
     {
-      :attachment => image("ror_mug_back")
+      name: file_name("ror_mug_back"),
+      attachment: image("ror_mug_back")
     }
   ],
   products[:ror_ringer].master => [
     {
-      :attachment => image("ror_ringer")
+      name: file_name("ror_ringer"),
+      attachment: image("ror_ringer")
     },
     {
-      :attachment => image("ror_ringer_back")
+      name: file_name("ror_ringer_back"),
+      attachment: image("ror_ringer_back")
     }
   ],
   products[:ror_stein].master => [
     {
-      :attachment => image("ror_stein")
+      name: file_name("ror_stein"),
+      attachment: image("ror_stein")
     },
     {
-      :attachment => image("ror_stein_back")
+      name: file_name("ror_stein_back"),
+      attachment: image("ror_stein_back")
     }
   ],
   products[:apache_baseball_jersey].master => [
     {
-      :attachment => image("apache_baseball", "png")
+      name: file_name("apache_baseball", "png"),
+      attachment: image("apache_baseball", "png")
     },
   ],
   products[:ruby_baseball_jersey].master => [
     {
-      :attachment => image("ruby_baseball", "png")
+      name: file_name("ruby_baseball", "png"),
+      attachment: image("ruby_baseball", "png")
     },
   ],
   products[:spree_bag].master => [
     {
-      :attachment => image("spree_bag")
+      name: file_name("spree_bag"),
+      attachment: image("spree_bag")
     },
   ],
   products[:spree_tote].master => [
     {
-      :attachment => image("spree_tote_front")
+      name: file_name("spree_tote_front"),
+      attachment: image("spree_tote_front")
     },
     {
-      :attachment => image("spree_tote_back") 
+      name: file_name("spree_tote_back"),
+      attachment: image("spree_tote_back")
     }
   ],
   products[:spree_ringer].master => [
     {
-      :attachment => image("spree_ringer_t")
+      name: file_name("spree_ringer_t"),
+      attachment: image("spree_ringer_t")
     },
     {
-      :attachment => image("spree_ringer_t_back") 
+      name: file_name("spree_ringer_t_back"),
+      attachment: image("spree_ringer_t_back")
     }
   ],
   products[:spree_jr_spaghetti].master => [
     {
-      :attachment => image("spree_spaghetti")
+      name: file_name("spree_spaghetti"),
+      attachment: image("spree_spaghetti")
     }
   ],
   products[:spree_baseball_jersey].master => [
     {
-      :attachment => image("spree_jersey")
+      name: file_name("spree_jersey"),
+      attachment: image("spree_jersey")
     },
     {
-      :attachment => image("spree_jersey_back") 
+      name: file_name("spree_jersey_back"),
+      attachment: image("spree_jersey_back")
     }
   ],
   products[:spree_stein].master => [
     {
-      :attachment => image("spree_stein")
+      name: file_name("spree_stein"),
+      attachment: image("spree_stein")
     },
     {
-      :attachment => image("spree_stein_back") 
+      name: file_name("spree_stein_back"),
+      attachment: image("spree_stein_back")
     }
   ],
   products[:spree_mug].master => [
     {
-      :attachment => image("spree_mug")
+      name: file_name("spree_mug"),
+      attachment: image("spree_mug")
     },
     {
-      :attachment => image("spree_mug_back") 
+      name: file_name("spree_mug_back"),
+      attachment: image("spree_mug_back")
     }
   ],
 }
 
 products[:ror_baseball_jersey].variants.each do |variant|
   color = variant.option_value("tshirt-color").downcase
-  main_image = image("ror_baseball_jersey_#{color}", "png")
-  variant.images.create!(:attachment => main_image)
-  back_image = image("ror_baseball_jersey_back_#{color}", "png")
-  if back_image
-    variant.images.create!(:attachment => back_image)
+
+  if variant.images.where(attachment_file_name: file_name("ror_baseball_jersey_#{color}", "png")).none?
+    main_image = image("ror_baseball_jersey_#{color}", "png")
+    variant.images.create!(attachment: main_image)
+  end
+
+  if variant.images.where(attachment_file_name: file_name("ror_baseball_jersey_back_#{color}", "png")).none?
+    back_image = image("ror_baseball_jersey_back_#{color}", "png")
+    variant.images.create!(attachment: back_image)
   end
 end
 
 images.each do |variant, attachments|
   puts "Loading images for #{variant.product.name}"
-  attachments.each do |attachment|
-    variant.images.create!(attachment)
+  attachments.each do |attrs|
+    file_name = attrs.delete(:name)
+
+    if variant.images.where(attachment_file_name: file_name).none?
+      variant.images.create!(attrs)
+    end
   end
 end
-

--- a/sample/db/samples/option_types.rb
+++ b/sample/db/samples/option_types.rb
@@ -1,12 +1,16 @@
-Spree::OptionType.create!([
+option_types_attributes = [
   {
-    :name => "tshirt-size",
-    :presentation => "Size",
-    :position => 1
+    name: "tshirt-size",
+    presentation: "Size",
+    position: 1
   },
   {
-    :name => "tshirt-color",
-    :presentation => "Color",
-    :position => 2
+    name: "tshirt-color",
+    presentation: "Color",
+    position: 2
   }
-])
+]
+
+option_types_attributes.each do |attrs|
+  Spree::OptionType.where(attrs).first_or_create!
+end

--- a/sample/db/samples/option_values.rb
+++ b/sample/db/samples/option_values.rb
@@ -3,47 +3,51 @@ Spree::Sample.load_sample("option_types")
 size = Spree::OptionType.find_by_presentation!("Size")
 color = Spree::OptionType.find_by_presentation!("Color")
 
-Spree::OptionValue.create!([
+option_values_attributes = [
   {
-    :name => "Small",
-    :presentation => "S",
-    :position => 1,
-    :option_type => size
+    name: "Small",
+    presentation: "S",
+    position: 1,
+    option_type: size
   },
   {
-    :name => "Medium",
-    :presentation => "M",
-    :position => 2,
-    :option_type => size
+    name: "Medium",
+    presentation: "M",
+    position: 2,
+    option_type: size
   },
   {
-    :name => "Large",
-    :presentation => "L",
-    :position => 3,
-    :option_type => size
+    name: "Large",
+    presentation: "L",
+    position: 3,
+    option_type: size
   },
   {
-    :name => "Extra Large",
-    :presentation => "XL",
-    :position => 4,
-    :option_type => size
+    name: "Extra Large",
+    presentation: "XL",
+    position: 4,
+    option_type: size
   },
   {
-    :name => "Red",
-    :presentation => "Red",
-    :position => 1,
-    :option_type => color,
+    name: "Red",
+    presentation: "Red",
+    position: 1,
+    option_type: color,
   },
   {
-    :name => "Green",
-    :presentation => "Green",
-    :position => 2,
-    :option_type => color,
+    name: "Green",
+    presentation: "Green",
+    position: 2,
+    option_type: color,
   },
   {
-    :name => "Blue",
-    :presentation => "Blue",
-    :position => 3,
-    :option_type => color
+    name: "Blue",
+    presentation: "Blue",
+    position: 3,
+    option_type: color
   }
-])
+]
+
+option_values_attributes.each do |attrs|
+  Spree::OptionValue.where(attrs).first_or_create!
+end

--- a/sample/db/samples/orders.rb
+++ b/sample/db/samples/orders.rb
@@ -1,33 +1,33 @@
 Spree::Sample.load_sample("addresses")
 
 orders = []
-orders << Spree::Order.create!(
-  :number => "R123456789",
-  :email => "spree@example.com",
-  :item_total => 150.95,
-  :adjustment_total => 150.95,
-  :total => 301.90,
-  :shipping_address => Spree::Address.first,
-  :billing_address => Spree::Address.last)
+orders << Spree::Order.where(
+  number: "R123456789",
+  email: "spree@example.com").first_or_create! do |order|
+    order.item_total = 150.95
+    order.adjustment_total = 150.95
+    order.total = 301.90
+  end
 
-orders << Spree::Order.create!(
-  :number => "R987654321",
-  :email => "spree@example.com",
-  :item_total => 15.95,
-  :adjustment_total => 15.95,
-  :total => 31.90,
-  :shipping_address => Spree::Address.first,
-  :billing_address => Spree::Address.last)
+orders << Spree::Order.where(
+  number: "R987654321",
+  email: "spree@example.com").first_or_create! do |order|
+    order.item_total = 15.95
+    order.adjustment_total = 15.95
+    order.total = 31.90
+    order.shipping_address = Spree::Address.first
+    order.billing_address = Spree::Address.last
+  end
 
-orders[0].line_items.create!(
-  :variant => Spree::Product.find_by_name!("Ruby on Rails Tote").master,
-  :quantity => 1,
-  :price => 15.99)
+orders[0].line_items.where(
+  variant: Spree::Product.find_by_name!("Ruby on Rails Tote").master,
+  quantity: 1,
+  price: 15.99).first_or_create!
 
-orders[1].line_items.create!(
-  :variant => Spree::Product.find_by_name!("Ruby on Rails Bag").master,
-  :quantity => 1,
-  :price => 22.99)
+orders[1].line_items.where(
+  variant: Spree::Product.find_by_name!("Ruby on Rails Bag").master,
+  quantity: 1,
+  price: 22.99).first_or_create!
 
 orders.each(&:create_proposed_shipments)
 

--- a/sample/db/samples/payment_methods.rb
+++ b/sample/db/samples/payment_methods.rb
@@ -1,15 +1,11 @@
-Spree::Gateway::Bogus.create!(
-  {
-    name: "Credit Card",
-    description: "Bogus payment gateway.",
-    active: true
-  }
-)
+Spree::Gateway::Bogus.where(
+  name: "Credit Card",
+  description: "Bogus payment gateway.",
+  active: true
+).first_or_create!
 
-Spree::PaymentMethod::Check.create!(
-  {
-    name: "Check",
-    description: "Pay by check.",
-    active: true
-  }
-)
+Spree::PaymentMethod::Check.where(
+  name: "Check",
+  description: "Pay by check.",
+  active: true
+).first_or_create!

--- a/sample/db/samples/payments.rb
+++ b/sample/db/samples/payments.rb
@@ -1,5 +1,5 @@
 # create payments based on the totals since they can't be known in YAML (quantities are random)
-method = Spree::PaymentMethod.where(:name => 'Credit Card', :active => true).first
+method = Spree::PaymentMethod.where(name: 'Credit Card', active: true).first
 
 # Hack the current method so we're able to return a gateway without a RAILS_ENV
 Spree::Gateway.class_eval do
@@ -12,11 +12,18 @@ end
 # reference it as such. Make it explicit here that this table has been renamed.
 Spree::CreditCard.table_name = 'spree_credit_cards'
 
-creditcard = Spree::CreditCard.create(:cc_type => 'visa', :month => 12, :year => 2.years.from_now.year, :last_digits => '1111',
-                                      :name => 'Sean Schofield', :gateway_customer_profile_id => 'BGS-1234')
+credit_card = Spree::CreditCard.where(cc_type: 'visa',
+                                      month: 12,
+                                      year: 2.years.from_now.year,
+                                      last_digits: '1111',
+                                      name: 'Sean Schofield',
+                                      gateway_customer_profile_id: 'BGS-1234').first_or_create!
 
-Spree::Order.all.each_with_index do |order, index|
+Spree::Order.all.each_with_index do |order, _index|
   order.update_with_updater!
-  payment = order.payments.create!(:amount => order.total, :source => creditcard.clone, :payment_method => method)
-  payment.update_columns(:state => 'pending', :response_code => '12345')
+  payment = order.payments.where(amount: BigDecimal(order.total, 4),
+                                 source: credit_card.clone,
+                                 payment_method: method).first_or_create!
+
+  payment.update_columns(state: 'pending', response_code: '12345')
 end

--- a/sample/db/samples/product_properties.rb
+++ b/sample/db/samples/product_properties.rb
@@ -1,7 +1,7 @@
 products =
-  { 
-    "Ruby on Rails Baseball Jersey" => 
-    { 
+  {
+    "Ruby on Rails Baseball Jersey" =>
+    {
       "Manufacturer" => "Wilson",
       "Brand" => "Wannabe Sports",
       "Model" => "JK1002",
@@ -36,44 +36,44 @@ products =
     "Ruby on Rails Tote" =>
     {
       "Type" => "Tote",
-      "Size" => %Q{15" x 18" x 6"},
+      "Size" => %{15" x 18" x 6"},
       "Material" => "Canvas"
     },
     "Ruby on Rails Bag" =>
     {
       "Type" => "Messenger",
-      "Size" => %Q{14 1/2" x 12" x 5"},
+      "Size" => %{14 1/2" x 12" x 5"},
       "Material" => "600 Denier Polyester"
     },
-    "Ruby on Rails Mug" => 
+    "Ruby on Rails Mug" =>
     {
       "Type" => "Mug",
-      "Size" => %Q{4.5" tall, 3.25" dia.}
+      "Size" => %{4.5" tall, 3.25" dia.}
     },
     "Ruby on Rails Stein" =>
     {
       "Type" => "Stein",
-      "Size" => %Q{6.75" tall, 3.75" dia. base, 3" dia. rim}
+      "Size" => %{6.75" tall, 3.75" dia. base, 3" dia. rim}
     },
     "Spree Stein" =>
     {
       "Type" => "Stein",
-      "Size" => %Q{6.75" tall, 3.75" dia. base, 3" dia. rim}
+      "Size" => %{6.75" tall, 3.75" dia. base, 3" dia. rim}
     },
-    "Spree Mug" => 
+    "Spree Mug" =>
     {
       "Type" => "Mug",
-      "Size" => %Q{4.5" tall, 3.25" dia.}
+      "Size" => %{4.5" tall, 3.25" dia.}
     },
-    "Spree Tote" => 
+    "Spree Tote" =>
     {
       "Type" => "Tote",
-      "Size" => %Q{15" x 18" x 6"}
+      "Size" => %{15" x 18" x 6"}
     },
-    "Spree Bag" => 
+    "Spree Bag" =>
     {
       "Type" => "Messenger",
-      "Size" => %Q{14 1/2" x 12" x 5"}
+      "Size" => %{14 1/2" x 12" x 5"}
     },
     "Spree Baseball Jersey" =>
     {

--- a/sample/db/samples/products.rb
+++ b/sample/db/samples/products.rb
@@ -2,136 +2,123 @@ Spree::Sample.load_sample("tax_categories")
 Spree::Sample.load_sample("shipping_categories")
 
 clothing = Spree::TaxCategory.find_by_name!("Clothing")
-shipping_category = Spree::ShippingCategory.find_by_name!("Default")
-
-default_attrs = {
-  description: FFaker::Lorem.paragraph,
-  available_on: Time.zone.now
-}
 
 products = [
   {
-    :name => "Ruby on Rails Tote",
-    :tax_category => clothing,
-    :shipping_category => shipping_category,
-    :price => 15.99,
-    :eur_price => 14,
+    name: "Ruby on Rails Tote",
+    tax_category: clothing,
+    price: 15.99,
+    eur_price: 14,
   },
   {
-    :name => "Ruby on Rails Bag",
-    :tax_category => clothing,
-    :shipping_category => shipping_category,
-    :price => 22.99,
-    :eur_price => 19,
+    name: "Ruby on Rails Bag",
+    tax_category: clothing,
+    price: 22.99,
+    eur_price: 19,
   },
   {
-    :name => "Ruby on Rails Baseball Jersey",
-    :tax_category => clothing,
-    :shipping_category => shipping_category,
-    :price => 19.99,
-    :eur_price => 16
+    name: "Ruby on Rails Baseball Jersey",
+    tax_category: clothing,
+    price: 19.99,
+    eur_price: 16
   },
   {
-    :name => "Ruby on Rails Jr. Spaghetti",
-    :tax_category => clothing,
-    :shipping_category => shipping_category,
-    :price => 19.99,
-    :eur_price => 16
+    name: "Ruby on Rails Jr. Spaghetti",
+    tax_category: clothing,
+    price: 19.99,
+    eur_price: 16
 
   },
   {
-    :name => "Ruby on Rails Ringer T-Shirt",
-    :shipping_category => shipping_category,
-    :tax_category => clothing,
-    :price => 19.99,
-    :eur_price => 16
+    name: "Ruby on Rails Ringer T-Shirt",
+    tax_category: clothing,
+    price: 19.99,
+    eur_price: 16
   },
   {
-    :name => "Ruby Baseball Jersey",
-    :tax_category => clothing,
-    :shipping_category => shipping_category,
-    :price => 19.99,
-    :eur_price => 16
+    name: "Ruby Baseball Jersey",
+    tax_category: clothing,
+    price: 19.99,
+    eur_price: 16
   },
   {
-    :name => "Apache Baseball Jersey",
-    :tax_category => clothing,
-    :shipping_category => shipping_category,
-    :price => 19.99,
-    :eur_price => 16
+    name: "Apache Baseball Jersey",
+    tax_category: clothing,
+    price: 19.99,
+    eur_price: 16
   },
   {
-    :name => "Spree Baseball Jersey",
-    :tax_category => clothing,
-    :shipping_category => shipping_category,
-    :price => 19.99,
-    :eur_price => 16
+    name: "Spree Baseball Jersey",
+    tax_category: clothing,
+    price: 19.99,
+    eur_price: 16
   },
   {
-    :name => "Spree Jr. Spaghetti",
-    :tax_category => clothing,
-    :shipping_category => shipping_category,
-    :price => 19.99,
-    :eur_price => 16
+    name: "Spree Jr. Spaghetti",
+    tax_category: clothing,
+    price: 19.99,
+    eur_price: 16
   },
   {
-    :name => "Spree Ringer T-Shirt",
-    :tax_category => clothing,
-    :shipping_category => shipping_category,
-    :price => 19.99,
-    :eur_price => 16
+    name: "Spree Ringer T-Shirt",
+    tax_category: clothing,
+    price: 19.99,
+    eur_price: 16
   },
   {
-    :name => "Spree Tote",
-    :tax_category => clothing,
-    :shipping_category => shipping_category,
-    :price => 15.99,
-    :eur_price => 14,
+    name: "Spree Tote",
+    tax_category: clothing,
+    price: 15.99,
+    eur_price: 14,
   },
   {
-    :name => "Spree Bag",
-    :tax_category => clothing,
-    :shipping_category => shipping_category,
-    :price => 22.99,
-    :eur_price => 19
+    name: "Spree Bag",
+    tax_category: clothing,
+    price: 22.99,
+    eur_price: 19
   },
   {
-    :name => "Ruby on Rails Mug",
-    :shipping_category => shipping_category,
-    :price => 13.99,
-    :eur_price => 12
+    name: "Ruby on Rails Mug",
+    price: 13.99,
+    eur_price: 12
   },
   {
-    :name => "Ruby on Rails Stein",
-    :shipping_category => shipping_category,
-    :price => 16.99,
-    :eur_price => 14
+    name: "Ruby on Rails Stein",
+    price: 16.99,
+    eur_price: 14
   },
   {
-    :name => "Spree Stein",
-    :shipping_category => shipping_category,
-    :price => 16.99,
-    :eur_price => 14,
+    name: "Spree Stein",
+    price: 16.99,
+    eur_price: 14,
   },
   {
-    :name => "Spree Mug",
-    :shipping_category => shipping_category,
-    :price => 13.99,
-    :eur_price => 12
+    name: "Spree Mug",
+    price: 13.99,
+    eur_price: 12
   }
 ]
 
-products.each do |product_attrs|
-  eur_price = product_attrs.delete(:eur_price)
-  Spree::Config[:currency] = "USD"
+default_shipping_category = Spree::ShippingCategory.find_by_name!("Default")
 
-  default_shipping_category = Spree::ShippingCategory.find_by_name!("Default")
-  product = Spree::Product.create!(default_attrs.merge(product_attrs))
-  Spree::Config[:currency] = "EUR"
-  product.reload
-  product.price = eur_price
-  product.shipping_category = default_shipping_category
-  product.save!
+products.each do |product_attrs|
+  Spree::Config[:currency] = "USD"
+  eur_price = product_attrs.delete(:eur_price)
+
+  new_product = Spree::Product.where(name: product_attrs[:name],
+                                     tax_category: product_attrs[:tax_category]).first_or_create! do |product|
+    product.price = product_attrs[:price]
+    product.description = FFaker::Lorem.paragraph
+    product.available_on = Time.zone.now
+    product.shipping_category = default_shipping_category
+  end
+
+  if new_product
+    Spree::Config[:currency] = "EUR"
+    new_product.reload
+    new_product.price = eur_price
+    new_product.save
+  end
 end
 
 Spree::Config[:currency] = "USD"

--- a/sample/db/samples/prototypes.rb
+++ b/sample/db/samples/prototypes.rb
@@ -1,21 +1,22 @@
 prototypes = [
   {
-    :name => "Shirt",
-    :properties => ["Manufacturer", "Brand", "Model", "Shirt Type", "Sleeve Type", "Material", "Fit", "Gender"]
+    name: "Shirt",
+    properties: ["Manufacturer", "Brand", "Model", "Shirt Type", "Sleeve Type", "Material", "Fit", "Gender"]
   },
   {
-    :name => "Bag",
-    :properties => ["Type", "Size", "Material"]
+    name: "Bag",
+    properties: ["Type", "Size", "Material"]
   },
   {
-    :name => "Mugs",
-    :properties => ["Size", "Type"]
+    name: "Mugs",
+    properties: ["Size", "Type"]
   }
 ]
 
 prototypes.each do |prototype_attrs|
-  prototype = Spree::Prototype.create!(:name => prototype_attrs[:name])
-  prototype_attrs[:properties].each do |property|
-    prototype.properties << Spree::Property.where(name: property).first
+  prototype = Spree::Prototype.where(name: prototype_attrs[:name]).first_or_create!
+  prototype_attrs[:properties].each do |property_name|
+    property = Spree::Property.where(name: property_name).first
+    prototype.properties << property unless prototype.properties.include?(property)
   end
 end

--- a/sample/db/samples/shipping_categories.rb
+++ b/sample/db/samples/shipping_categories.rb
@@ -1,1 +1,1 @@
-Spree::ShippingCategory.find_or_create_by!(:name => "Default")
+Spree::ShippingCategory.find_or_create_by!(name: 'Default')

--- a/sample/db/samples/shipping_methods.rb
+++ b/sample/db/samples/shipping_methods.rb
@@ -1,5 +1,5 @@
 begin
-north_america = Spree::Zone.find_by_name!("North America")
+  north_america = Spree::Zone.find_by_name!("North America")
 rescue ActiveRecord::RecordNotFound
   puts "Couldn't find 'North America' zone. Did you run `rake db:seed` first?"
   puts "That task will set up the countries, states and zones required for Spree."
@@ -9,38 +9,41 @@ end
 europe_vat = Spree::Zone.find_by_name!("EU_VAT")
 shipping_category = Spree::ShippingCategory.find_or_create_by!(name: 'Default')
 
-Spree::ShippingMethod.create!([
+shipping_methods = [
   {
-    :name => "UPS Ground (USD)",
-    :zones => [north_america],
-    :calculator => Spree::Calculator::Shipping::FlatRate.create!,
-    :shipping_categories => [shipping_category]
+    name: "UPS Ground (USD)",
+    zones: [north_america],
+    shipping_categories: [shipping_category]
   },
   {
-    :name => "UPS Two Day (USD)",
-    :zones => [north_america],
-    :calculator => Spree::Calculator::Shipping::FlatRate.create!,
-    :shipping_categories => [shipping_category]
+    name: "UPS Two Day (USD)",
+    zones: [north_america],
+    shipping_categories: [shipping_category]
   },
   {
-    :name => "UPS One Day (USD)",
-    :zones => [north_america],
-    :calculator => Spree::Calculator::Shipping::FlatRate.create!,
-    :shipping_categories => [shipping_category]
+    name: "UPS One Day (USD)",
+    zones: [north_america],
+    shipping_categories: [shipping_category]
   },
   {
-    :name => "UPS Ground (EU)",
-    :zones => [europe_vat],
-    :calculator => Spree::Calculator::Shipping::FlatRate.create!,
-    :shipping_categories => [shipping_category]
+    name: "UPS Ground (EU)",
+    zones: [europe_vat],
+    shipping_categories: [shipping_category]
   },
   {
-    :name => "UPS Ground (EUR)",
-    :zones => [europe_vat],
-    :calculator => Spree::Calculator::Shipping::FlatRate.create!,
-    :shipping_categories => [shipping_category]
+    name: "UPS Ground (EUR)",
+    zones: [europe_vat],
+    shipping_categories: [shipping_category]
   }
-])
+]
+
+shipping_methods.each do |attributes|
+  Spree::ShippingMethod.where(name: attributes[:name]).first_or_create! do |shipping_method|
+    shipping_method.calculator = Spree::Calculator::Shipping::FlatRate.create!
+    shipping_method.zones = attributes[:zones]
+    shipping_method.shipping_categories = attributes[:shipping_categories]
+  end
+end
 
 {
   "UPS Ground (USD)" => [5, "USD"],
@@ -57,4 +60,3 @@ Spree::ShippingMethod.create!([
   shipping_method.calculator.save!
   shipping_method.save!
 end
-

--- a/sample/db/samples/stock.rb
+++ b/sample/db/samples/stock.rb
@@ -1,12 +1,17 @@
 Spree::Sample.load_sample("variants")
 
 country =  Spree::Country.find_by(iso: 'US')
-location = Spree::StockLocation.first_or_create! name: 'default', address1: 'Example Street', city: 'City', zipcode: '12345', country: country, state: country.states.first
+location = Spree::StockLocation.first_or_create!(name: 'default',
+                                                 address1: 'Example Street',
+                                                 city: 'City',
+                                                 zipcode: '12345',
+                                                 country: country,
+                                                 state: country.states.first)
 location.active = true
 location.save!
 
 Spree::Variant.all.each do |variant|
   variant.stock_items.each do |stock_item|
-    Spree::StockMovement.create(:quantity => 10, :stock_item => stock_item)
+    Spree::StockMovement.create(quantity: 10, stock_item: stock_item)
   end
 end

--- a/sample/db/samples/tax_categories.rb
+++ b/sample/db/samples/tax_categories.rb
@@ -1,2 +1,2 @@
-Spree::TaxCategory.create!(:name => "Clothing")
-Spree::TaxCategory.create!(:name => "Food")
+Spree::TaxCategory.where(name: 'Clothing').first_or_create!
+Spree::TaxCategory.where(name: 'Food').first_or_create!

--- a/sample/db/samples/tax_rates.rb
+++ b/sample/db/samples/tax_rates.rb
@@ -1,9 +1,10 @@
 north_america = Spree::Zone.find_by_name!("North America")
 clothing = Spree::TaxCategory.find_by_name!("Clothing")
-tax_rate = Spree::TaxRate.create(
-  :name => "North America",
-  :zone => north_america, 
-  :amount => 0.05,
-  :tax_category => clothing)
-tax_rate.calculator = Spree::Calculator::DefaultTax.create!
-tax_rate.save!
+
+Spree::TaxRate.where(
+  name: "North America",
+  zone: north_america,
+  amount: 0.05,
+  tax_category: clothing).first_or_create! do |tax_rate|
+  tax_rate.calculator = Spree::Calculator::DefaultTax.create!
+end

--- a/sample/db/samples/taxonomies.rb
+++ b/sample/db/samples/taxonomies.rb
@@ -4,5 +4,5 @@ taxonomies = [
 ]
 
 taxonomies.each do |taxonomy_attrs|
-  Spree::Taxonomy.create!(taxonomy_attrs)
+  Spree::Taxonomy.where(taxonomy_attrs).first_or_create!
 end

--- a/sample/db/samples/taxons.rb
+++ b/sample/db/samples/taxons.rb
@@ -4,25 +4,24 @@ Spree::Sample.load_sample("products")
 categories = Spree::Taxonomy.find_by_name!("Categories")
 brands = Spree::Taxonomy.find_by_name!("Brand")
 
-products = { 
-  :ror_tote => "Ruby on Rails Tote",
-  :ror_bag => "Ruby on Rails Bag",
-  :ror_mug => "Ruby on Rails Mug",
-  :ror_stein => "Ruby on Rails Stein",
-  :ror_baseball_jersey => "Ruby on Rails Baseball Jersey",
-  :ror_jr_spaghetti => "Ruby on Rails Jr. Spaghetti",
-  :ror_ringer => "Ruby on Rails Ringer T-Shirt",
-  :spree_stein => "Spree Stein",
-  :spree_mug => "Spree Mug",
-  :spree_ringer => "Spree Ringer T-Shirt",
-  :spree_baseball_jersey =>  "Spree Baseball Jersey",
-  :spree_tote => "Spree Tote",
-  :spree_bag => "Spree Bag",
-  :spree_jr_spaghetti => "Spree Jr. Spaghetti",
-  :apache_baseball_jersey => "Apache Baseball Jersey",
-  :ruby_baseball_jersey => "Ruby Baseball Jersey",
+products = {
+  ror_tote: "Ruby on Rails Tote",
+  ror_bag: "Ruby on Rails Bag",
+  ror_mug: "Ruby on Rails Mug",
+  ror_stein: "Ruby on Rails Stein",
+  ror_baseball_jersey: "Ruby on Rails Baseball Jersey",
+  ror_jr_spaghetti: "Ruby on Rails Jr. Spaghetti",
+  ror_ringer: "Ruby on Rails Ringer T-Shirt",
+  spree_stein: "Spree Stein",
+  spree_mug: "Spree Mug",
+  spree_ringer: "Spree Ringer T-Shirt",
+  spree_baseball_jersey: "Spree Baseball Jersey",
+  spree_tote: "Spree Tote",
+  spree_bag: "Spree Bag",
+  spree_jr_spaghetti: "Spree Jr. Spaghetti",
+  apache_baseball_jersey: "Apache Baseball Jersey",
+  ruby_baseball_jersey: "Ruby Baseball Jersey",
 }
-
 
 products.each do |key, name|
   products[key] = Spree::Product.find_by_name!(name)
@@ -30,16 +29,16 @@ end
 
 taxons = [
   {
-    :name => "Categories",
-    :taxonomy => categories,
-    :position => 0
+    name: "Categories",
+    taxonomy: categories,
+    position: 0
   },
   {
-    :name => "Bags",
-    :taxonomy => categories,
-    :parent => "Categories",
-    :position => 1,
-    :products => [
+    name: "Bags",
+    taxonomy: categories,
+    parent: "Categories",
+    position: 1,
+    products: [
       products[:ror_tote],
       products[:ror_bag],
       products[:spree_tote],
@@ -47,11 +46,11 @@ taxons = [
     ]
   },
   {
-    :name => "Mugs",
-    :taxonomy => categories,
-    :parent => "Categories",
-    :position => 2,
-    :products => [
+    name: "Mugs",
+    taxonomy: categories,
+    parent: "Categories",
+    position: 2,
+    products: [
       products[:ror_mug],
       products[:ror_stein],
       products[:spree_stein],
@@ -59,25 +58,25 @@ taxons = [
     ]
   },
   {
-    :name => "Clothing",
-    :taxonomy => categories,
-    :parent => "Categories" 
+    name: "Clothing",
+    taxonomy: categories,
+    parent: "Categories"
   },
   {
-    :name => "Shirts",
-    :taxonomy => categories,
-    :parent => "Clothing",
-    :position => 0,
-    :products => [
+    name: "Shirts",
+    taxonomy: categories,
+    parent: "Clothing",
+    position: 0,
+    products: [
       products[:ror_jr_spaghetti],
       products[:spree_jr_spaghetti]
     ]
   },
   {
-    :name => "T-Shirts",
-    :taxonomy => categories,
-    :parent => "Clothing" ,
-    :products => [
+    name: "T-Shirts",
+    taxonomy: categories,
+    parent: "Clothing",
+    products: [
       products[:ror_baseball_jersey],
       products[:ror_ringer],
       products[:apache_baseball_jersey],
@@ -85,33 +84,33 @@ taxons = [
       products[:spree_baseball_jersey],
       products[:spree_ringer]
     ],
-    :position => 0
+    position: 0
   },
   {
-    :name => "Brands",
-    :taxonomy => brands
+    name: "Brands",
+    taxonomy: brands
   },
   {
-    :name => "Ruby",
-    :taxonomy => brands,
-    :parent => "Brand",
-    :products => [
+    name: "Ruby",
+    taxonomy: brands,
+    parent: "Brands",
+    products: [
       products[:ruby_baseball_jersey]
     ]
   },
   {
-    :name => "Apache",
-    :taxonomy => brands,
-    :parent => "Brand",
-    :products => [
+    name: "Apache",
+    taxonomy: brands,
+    parent: "Brands",
+    products: [
       products[:apache_baseball_jersey]
     ]
   },
   {
-    :name => "Spree",
-    :taxonomy => brands,
-    :parent => "Brand",
-    :products => [
+    name: "Spree",
+    taxonomy: brands,
+    parent: "Brands",
+    products: [
       products[:spree_stein],
       products[:spree_mug],
       products[:spree_ringer],
@@ -122,10 +121,10 @@ taxons = [
     ]
   },
   {
-    :name => "Rails",
-    :taxonomy => brands,
-    :parent => "Brand",
-    :products => [
+    name: "Rails",
+    taxonomy: brands,
+    parent: "Brands",
+    products: [
       products[:ror_tote],
       products[:ror_bag],
       products[:ror_mug],
@@ -138,8 +137,9 @@ taxons = [
 ]
 
 taxons.each do |taxon_attrs|
-  if taxon_attrs[:parent]
-    taxon_attrs[:parent] = Spree::Taxon.where(name: taxon_attrs[:parent]).first
-    Spree::Taxon.create!(taxon_attrs)
+  parent = Spree::Taxon.where(name: taxon_attrs[:parent]).first
+  Spree::Taxon.where(name: taxon_attrs[:name]).first_or_create! do |taxon|
+    taxon.parent = parent
+    taxon.products = taxon_attrs[:products] if taxon_attrs[:products]
   end
 end

--- a/sample/db/samples/variants.rb
+++ b/sample/db/samples/variants.rb
@@ -29,135 +29,139 @@ green = Spree::OptionValue.where(name: "Green").first
 
 variants = [
   {
-    :product => ror_baseball_jersey,
-    :option_values => [small, red],
-    :sku => "ROR-00001",
-    :cost_price => 17
+    product: ror_baseball_jersey,
+    option_values: [small, red],
+    sku: "ROR-00001",
+    cost_price: 17
   },
   {
-    :product => ror_baseball_jersey,
-    :option_values => [small, blue],
-    :sku => "ROR-00002",
-    :cost_price => 17
+    product: ror_baseball_jersey,
+    option_values: [small, blue],
+    sku: "ROR-00002",
+    cost_price: 17
   },
   {
-    :product => ror_baseball_jersey,
-    :option_values => [small, green],
-    :sku => "ROR-00003",
-    :cost_price => 17
+    product: ror_baseball_jersey,
+    option_values: [small, green],
+    sku: "ROR-00003",
+    cost_price: 17
   },
   {
-    :product => ror_baseball_jersey,
-    :option_values => [medium, red],
-    :sku => "ROR-00004",
-    :cost_price => 17
+    product: ror_baseball_jersey,
+    option_values: [medium, red],
+    sku: "ROR-00004",
+    cost_price: 17
   },
   {
-    :product => ror_baseball_jersey,
-    :option_values => [medium, blue],
-    :sku => "ROR-00005",
-    :cost_price => 17
+    product: ror_baseball_jersey,
+    option_values: [medium, blue],
+    sku: "ROR-00005",
+    cost_price: 17
   },
   {
-    :product => ror_baseball_jersey,
-    :option_values => [medium, green],
-    :sku => "ROR-00006",
-    :cost_price => 17
+    product: ror_baseball_jersey,
+    option_values: [medium, green],
+    sku: "ROR-00006",
+    cost_price: 17
   },
   {
-    :product => ror_baseball_jersey,
-    :option_values => [large, red],
-    :sku => "ROR-00007",
-    :cost_price => 17
+    product: ror_baseball_jersey,
+    option_values: [large, red],
+    sku: "ROR-00007",
+    cost_price: 17
   },
   {
-    :product => ror_baseball_jersey,
-    :option_values => [large, blue],
-    :sku => "ROR-00008",
-    :cost_price => 17
+    product: ror_baseball_jersey,
+    option_values: [large, blue],
+    sku: "ROR-00008",
+    cost_price: 17
   },
   {
-    :product => ror_baseball_jersey,
-    :option_values => [large, green],
-    :sku => "ROR-00009",
-    :cost_price => 17
+    product: ror_baseball_jersey,
+    option_values: [large, green],
+    sku: "ROR-00009",
+    cost_price: 17
   },
   {
-    :product => ror_baseball_jersey,
-    :option_values => [extra_large, green],
-    :sku => "ROR-00010",
-    :cost_price => 17
+    product: ror_baseball_jersey,
+    option_values: [extra_large, green],
+    sku: "ROR-00010",
+    cost_price: 17
   },
 ]
 
 masters = {
   ror_baseball_jersey => {
-    :sku => "ROR-001",
-    :cost_price => 17,
+    sku: "ROR-001",
+    cost_price: 17,
   },
   ror_tote => {
-    :sku => "ROR-00011",
-    :cost_price => 17
+    sku: "ROR-00011",
+    cost_price: 17
   },
   ror_bag => {
-    :sku => "ROR-00012",
-    :cost_price => 21
+    sku: "ROR-00012",
+    cost_price: 21
   },
   ror_jr_spaghetti => {
-    :sku => "ROR-00013",
-    :cost_price => 17
+    sku: "ROR-00013",
+    cost_price: 17
   },
   ror_mug => {
-    :sku => "ROR-00014",
-    :cost_price => 11
+    sku: "ROR-00014",
+    cost_price: 11
   },
   ror_ringer => {
-    :sku => "ROR-00015",
-    :cost_price => 17
+    sku: "ROR-00015",
+    cost_price: 17
   },
   ror_stein => {
-    :sku => "ROR-00016",
-    :cost_price => 15
+    sku: "ROR-00016",
+    cost_price: 15
   },
   apache_baseball_jersey => {
-    :sku => "APC-00001",
-    :cost_price => 17
+    sku: "APC-00001",
+    cost_price: 17
   },
   ruby_baseball_jersey => {
-    :sku => "RUB-00001",
-    :cost_price => 17
+    sku: "RUB-00001",
+    cost_price: 17
   },
   spree_baseball_jersey => {
-    :sku => "SPR-00001",
-    :cost_price => 17
+    sku: "SPR-00001",
+    cost_price: 17
   },
   spree_stein => {
-    :sku => "SPR-00016",
-    :cost_price => 15
+    sku: "SPR-00016",
+    cost_price: 15
   },
   spree_jr_spaghetti => {
-    :sku => "SPR-00013",
-    :cost_price => 17
+    sku: "SPR-00013",
+    cost_price: 17
   },
   spree_mug => {
-    :sku => "SPR-00014",
-    :cost_price => 11
+    sku: "SPR-00014",
+    cost_price: 11
   },
   spree_ringer => {
-    :sku => "SPR-00015",
-    :cost_price => 17
+    sku: "SPR-00015",
+    cost_price: 17
   },
   spree_tote => {
-    :sku => "SPR-00011",
-    :cost_price => 13
+    sku: "SPR-00011",
+    cost_price: 13
   },
   spree_bag => {
-    :sku => "SPR-00012",
-    :cost_price => 21
+    sku: "SPR-00012",
+    cost_price: 21
   }
 }
 
-Spree::Variant.create!(variants)
+variants.each do |attrs|
+  if Spree::Variant.where(product_id: attrs[:product].id, sku: attrs[:sku]).none?
+    Spree::Variant.create!(attrs)
+  end
+end
 
 masters.each do |product, variant_attrs|
   product.master.update_attributes!(variant_attrs)


### PR DESCRIPTION
This PR enables running `rake spree_sample:load` multiple times without any validation errors because any existing records will be only updated and it will not create duplicates. Also updated syntax to 1.9+.
