### PR TITLE
missing locale for `resend'

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1159,6 +1159,7 @@ en:
     report: Report
     reports: Reports
     resellable: Resellable
+    resend: Resend
     reset_password: Reset my password
     response_code: Response Code
     resume: resume


### PR DESCRIPTION
This PR add a missing translation for `resend' which is necessary to render emails properly, without any translation errors.
