### PR TITLE
add rake task `test_app` for cmd gem

### DIFF
--- a/cmd/Rakefile
+++ b/cmd/Rakefile
@@ -3,3 +3,7 @@ require "bundler/gem_tasks"
 desc 'alias for :build to work with other spree gems'
 task gem: :build do
 end
+
+desc 'alias for :test_app to work with other spree gems'
+task :test_app do
+end


### PR DESCRIPTION
If you try to run the main Spree rake task `rake test_app` it fails when trying to generate the test_app for the cmd gem.

This is because there is no `rake test_app` rake task in the cmd gem.  However the main Spree `rake test_app` task iterates through all gem components including the cmd gem, causing this error.
