### PR TITLE
remove states inclusion validation from Spree::Order

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -125,7 +125,6 @@ module Spree
     with_options presence: true do
       validates :number, length: { maximum: 32, allow_blank: true }, uniqueness: { allow_blank: true }
       validates :email, length: { maximum: 254, allow_blank: true }, email: { allow_blank: true }, if: :require_email
-      validates :state, inclusion: { in: state_machine.states.map { |state| state.name.to_s }, allow_blank: true }
       validates :item_count, numericality: { greater_than_or_equal_to: 0, less_than: 2**31, only_integer: true, allow_blank: true }
     end
     validates :payment_state,        inclusion:    { in: PAYMENT_STATES, allow_blank: true }

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -605,6 +605,10 @@ describe Spree::Order, :type => :model do
         order = Spree::Order.new
         expect(order.checkout_steps).to eq(%w(new_step before_address address delivery complete))
       end
+
+      it 'goes through checkout without raising error' do
+        expect{ OrderWalkthrough.up_to(:complete) }.to_not raise_error
+      end
     end
 
     context "after" do
@@ -617,6 +621,10 @@ describe Spree::Order, :type => :model do
       specify do
         order = Spree::Order.new
         expect(order.checkout_steps).to eq(%w(new_step address after_address delivery complete))
+      end
+
+      it 'goes through checkout without raising error' do
+        expect{ OrderWalkthrough.up_to(:complete) }.to_not raise_error
       end
     end
   end


### PR DESCRIPTION
This PR fixes issue #7337. Removing inclusion validation for order's states prevents validation error from occurring when someone tries to go to a custom checkout step.
