### PR TITLE
upgrade paperclip version and resolve compatibility issues

### DIFF
--- a/api/lib/spree/api/testing_support/helpers.rb
+++ b/api/lib/spree/api/testing_support/helpers.rb
@@ -30,8 +30,8 @@ module Spree
           File.open(Spree::Api::Engine.root + "spec/fixtures" + filename)
         end
 
-        def upload_image(filename)
-          fixture_file_upload(image(filename).path)
+        def upload_image(filename, mime_type = 'image/jpg')
+          fixture_file_upload(image(filename).path, mime_type)
         end
       end
     end

--- a/core/app/models/spree/image.rb
+++ b/core/app/models/spree/image.rb
@@ -1,6 +1,5 @@
 module Spree
   class Image < Asset
-    validates_attachment_presence :attachment
     validate :no_attachment_errors
 
     has_attached_file :attachment,
@@ -9,6 +8,10 @@ module Spree
                       url: '/spree/products/:id/:style/:basename.:extension',
                       path: ':rails_root/public/spree/products/:id/:style/:basename.:extension',
                       convert_options: { all: '-strip -auto-orient -colorspace sRGB' }
+
+    validates_attachment :attachment,
+      :presence => true,
+      :content_type => { :content_type => %w(image/jpeg image/jpg image/png image/gif) }
 
     # save the w,h of the original image (from which others can be calculated)
     # we need to look at the write-queue for images which have not been saved yet

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'json', '~> 1.7'
   s.add_dependency 'kaminari', '~> 0.15.0'
   s.add_dependency 'monetize', '~> 1.1'
-  s.add_dependency 'paperclip', '~> 3.4.1'
+  s.add_dependency 'paperclip', '~> 4.2'
   s.add_dependency 'paranoia', '~> 2.0'
   s.add_dependency 'rails', '~> 4.0.12'
   s.add_dependency 'ransack', '~> 1.1.0'


### PR DESCRIPTION
ImageMagick recently had some severe vulnerabilities uncovered, as documented here: https://imagetragick.com/

Fortunately for us Spree folks, Paperclip has a number of protections in place that mitigate those issues, right?! Not so fast, 2.2 users...

This change upgrades Spree 2.2 to the latest paperclip, in order to obtain some [important file verification logic](https://github.com/thoughtbot/paperclip/blob/v4.3.6/lib/paperclip/content_type_detector.rb#L69-L72), amongst some other improvements.
