### PR TITLE
remove freeze from shipment & payment states

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -3,8 +3,8 @@ require 'spree/order/checkout'
 
 module Spree
   class Order < Spree::Base
-    PAYMENT_STATES = %w(balance_due credit_owed failed paid void).freeze
-    SHIPMENT_STATES = %w(backorder canceled partial pending ready shipped).freeze
+    PAYMENT_STATES = %w(balance_due credit_owed failed paid void)
+    SHIPMENT_STATES = %w(backorder canceled partial pending ready shipped)
 
     extend FriendlyId
     friendly_id :number, slug_column: :number, use: :slugged


### PR DESCRIPTION
This PR fixes #7352. Removing freeze from shipment and payment states will enable adding a new, custom state.
