### PR TITLE
Rename tag migrations to spree

### DIFF
--- a/core/db/migrate/20160511071954_acts_as_taggable_on_spree_migration.rb
+++ b/core/db/migrate/20160511071954_acts_as_taggable_on_spree_migration.rb
@@ -1,4 +1,4 @@
-class ActsAsTaggableOnMigration < ActiveRecord::Migration
+class ActsAsTaggableOnSpreeMigration < ActiveRecord::Migration
   def self.up
     create_table :spree_tags do |t|
       t.string :name

--- a/core/db/migrate/20160511072249_change_collation_for_spree_tag_names.rb
+++ b/core/db/migrate/20160511072249_change_collation_for_spree_tag_names.rb
@@ -1,6 +1,6 @@
 # This migration is added to circumvent issue #623 and have special characters
 # work properly
-class ChangeCollationForTagNames < ActiveRecord::Migration
+class ChangeCollationForSpreeTagNames < ActiveRecord::Migration
   def up
     if ActsAsTaggableOn::Utils.using_mysql?
       execute("ALTER TABLE spree_tags MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")

--- a/core/db/migrate/20160511072335_add_missing_indexes_to_spree_taggings.rb
+++ b/core/db/migrate/20160511072335_add_missing_indexes_to_spree_taggings.rb
@@ -1,4 +1,4 @@
-class AddMissingIndexes < ActiveRecord::Migration
+class AddMissingIndexesToSpreeTaggings < ActiveRecord::Migration
   def change
     add_index :spree_taggings, :tag_id
     add_index :spree_taggings, :taggable_id


### PR DESCRIPTION
Avoid clashes for people who already have acts_as_taggable installed.
