### PR TITLE
Remove unneeded char from en.yml

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1352,7 +1352,7 @@ en:
       apply: Apply Store Credit
       applicable_amount: "%{amount} in store credit will be applied to this order."
       available_amount: "You have %{amount} in Store Credit available!"
-      remaining_amount: "You have %{amount} remaining in your account\'s Store Credit."
+      remaining_amount: "You have %{amount} remaining in your account's Store Credit."
       additional_payment_needed: Select another payment method for the remaining %{amount}.
       errors:
         cannot_change_used_store_credit: You cannot change a store credit that has already been used


### PR DESCRIPTION
I don't think that we need this char there while using double quotes.
Also it's [breaking rake task](https://gist.github.com/zzk/44bd89a73d93ecba2a0027f666a3a175) (loading sample data) on jruby 9.1.1.0
