### PR TITLE
fix for #6603

### DIFF
--- a/backend/spec/features/admin/orders/adjustments_spec.rb
+++ b/backend/spec/features/admin/orders/adjustments_spec.rb
@@ -62,7 +62,7 @@ describe "Adjustments", type: :feature do
         fill_in "adjustment_label", with: "rebate"
         click_button "Continue"
         expect(page).to have_content("successfully created!")
-        expect(page).to have_content("Total: $180.00")
+        expect(page).to have_content("Total: $80.00")
       end
     end
 
@@ -94,7 +94,7 @@ describe "Adjustments", type: :feature do
           expect(page).to have_content("$99.00")
         end
 
-        expect(page).to have_content("Total: $259.00")
+        expect(page).to have_content("Total: $159.00")
       end
     end
 

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -20,6 +20,7 @@ module Spree
         update_payment_state
         update_shipments
         update_shipment_state
+        update_shipment_total
       end
       run_hooks
       persist_totals

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -210,52 +210,56 @@ module Spree
     context "completed order" do
       before { allow(order).to receive_messages completed?: true }
 
-      it "updates payment state" do
-        expect(updater).to receive(:update_payment_state)
-        updater.update
+      describe "#update" do
+        it "updates payment state" do
+          expect(updater).to receive(:update_payment_state)
+          updater.update
+        end
+
+        it "updates shipment state" do
+          expect(updater).to receive(:update_shipment_state)
+          updater.update
+        end
+
+        it "updates shipments total again after updating shipments" do
+          expect(updater).to receive(:update_shipment_total).ordered
+          expect(updater).to receive(:update_shipments).ordered
+          expect(updater).to receive(:update_shipment_total).ordered
+          updater.update
+        end
       end
 
-      it "updates shipment state" do
-        expect(updater).to receive(:update_shipment_state)
-        updater.update
-      end
+      describe "#update_shipments" do
+        it "updates each shipment" do
+          shipment = stub_model(Spree::Shipment, order: order)
+          shipments = [shipment]
+          allow(order).to receive_messages shipments: shipments
+          allow(shipments).to receive_messages states: []
+          allow(shipments).to receive_messages ready: []
+          allow(shipments).to receive_messages pending: []
+          allow(shipments).to receive_messages shipped: []
 
-      it "updates shipments total again after updating shipments" do
-        expect(updater).to receive(:update_shipment_total).ordered
-        expect(updater).to receive(:update_shipments).ordered
-        expect(updater).to receive(:update_shipment_total).ordered
-        updater.update
-      end
+          expect(shipment).to receive(:update!).with(order)
+          updater.update_shipments
+        end
 
-      it "updates each shipment" do
-        shipment = stub_model(Spree::Shipment, order: order)
-        shipments = [shipment]
-        allow(order).to receive_messages shipments: shipments
-        allow(shipments).to receive_messages states: []
-        allow(shipments).to receive_messages ready: []
-        allow(shipments).to receive_messages pending: []
-        allow(shipments).to receive_messages shipped: []
+        it "refreshes shipment rates" do
+          shipment = stub_model(Spree::Shipment, order: order)
+          shipments = [shipment]
+          allow(order).to receive_messages shipments: shipments
 
-        expect(shipment).to receive(:update!).with(order)
-        updater.update_shipments
-      end
+          expect(shipment).to receive(:refresh_rates)
+          updater.update_shipments
+        end
 
-      it "refreshes shipment rates" do
-        shipment = stub_model(Spree::Shipment, order: order)
-        shipments = [shipment]
-        allow(order).to receive_messages shipments: shipments
+        it "updates the shipment amount" do
+          shipment = stub_model(Spree::Shipment, order: order)
+          shipments = [shipment]
+          allow(order).to receive_messages shipments: shipments
 
-        expect(shipment).to receive(:refresh_rates)
-        updater.update_shipments
-      end
-
-      it "updates the shipment amount" do
-        shipment = stub_model(Spree::Shipment, order: order)
-        shipments = [shipment]
-        allow(order).to receive_messages shipments: shipments
-
-        expect(shipment).to receive(:update_amounts)
-        updater.update_shipments
+          expect(shipment).to receive(:update_amounts)
+          updater.update_shipments
+        end
       end
     end
 

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -220,6 +220,13 @@ module Spree
         updater.update
       end
 
+      it "updates shipments total again after updating shipments" do
+        expect(updater).to receive(:update_shipment_total).ordered
+        expect(updater).to receive(:update_shipments).ordered
+        expect(updater).to receive(:update_shipment_total).ordered
+        updater.update
+      end
+
       it "updates each shipment" do
         shipment = stub_model(Spree::Shipment, order: order)
         shipments = [shipment]


### PR DESCRIPTION
This PR fixes issue #6603 by updating `shipment_total` attribute every time the order is updated.
