### PR TITLE
Adds missing media tag to main stylesheet in admin panel

### DIFF
--- a/backend/app/views/spree/admin/shared/_head.html.erb
+++ b/backend/app/views/spree/admin/shared/_head.html.erb
@@ -13,7 +13,7 @@
   <% end %>
 </title>
 
-<%= stylesheet_link_tag 'spree/backend/all' %>
+<%= stylesheet_link_tag 'spree/backend/all', media: :all %>
 
 <%= javascript_include_tag 'spree/backend/all' %>
 <%= render "spree/admin/shared/translations" %>


### PR DESCRIPTION
Stylesheet was not being included when trying to print pages from the admin panel due to missing media: :all param.
