### PR TITLE
Show sidebar menu in small screens

### DIFF
--- a/backend/app/views/spree/layouts/admin.html.erb
+++ b/backend/app/views/spree/layouts/admin.html.erb
@@ -30,7 +30,7 @@
         <%#-------------------------------------------------%>
         <%# Sidebar                                         %>
         <%#-------------------------------------------------%>
-        <div class="col-sm-3 col-md-2 hidden-xs sidebar" id="main-sidebar" data-hook="admin_tabs">
+        <div class="col-sm-3 col-md-2 sidebar" id="main-sidebar" data-hook="admin_tabs">
           <%= render partial: 'spree/admin/shared/main_menu' %>
         </div>
 


### PR DESCRIPTION
This PR makes possible to access sidebar menu in admin, using small devices like a smartphone.

Before:
![screenshot_20160601-121849](https://cloud.githubusercontent.com/assets/24940/15716977/3ff5c374-27fb-11e6-8d9f-6e1d87285af5.png)

After:
![screenshot_20160601-130448](https://cloud.githubusercontent.com/assets/24940/15716984/465614e4-27fb-11e6-859e-3f9974a11616.png)
