### PR TITLE
Remove binary collation config as alteration is already done in migration

### DIFF
--- a/core/config/initializers/acts_as_taggable_on.rb
+++ b/core/config/initializers/acts_as_taggable_on.rb
@@ -1,7 +1,4 @@
 require "acts-as-taggable-on"
-if ActsAsTaggableOn::Utils.using_mysql?
-  ActsAsTaggableOn.force_binary_collation = true
-end
 
 ActsAsTaggableOn::Tag.class_eval do
   self.table_name_prefix = "spree_"


### PR DESCRIPTION
Remove binary collation config for mysql as alteration is already done in migration [here](https://github.com/spree/spree/blob/master/core/db/migrate/20160511072249_change_collation_for_spree_tag_names.rb).
