### PR TITLE
Skip zipcode validation for countries that do not use zipcodes

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -2,6 +2,14 @@ module Spree
   class Address < Spree::Base
     require 'twitter_cldr'
 
+    NO_ZIPCODE_ISO_CODES ||= [
+      'AO', 'AG', 'AW', 'BS', 'BZ', 'BJ', 'BM', 'BO', 'BW', 'BF', 'BI', 'CM', 'CF', 'KM', 'CG',
+      'CD', 'CK', 'CUW', 'CI', 'DJ', 'DM', 'GQ', 'ER', 'FJ', 'TF', 'GAB', 'GM', 'GH', 'GD', 'GN',
+      'GY', 'HK', 'IE', 'KI', 'KP', 'LY', 'MO', 'MW', 'ML', 'MR', 'NR', 'AN', 'NU', 'KP', 'PA',
+      'QA', 'RW', 'KN', 'LC', 'ST', 'SC', 'SL', 'SB', 'SO', 'SR', 'SY', 'TZ', 'TL', 'TK', 'TG',
+      'TO', 'TV', 'UG', 'AE', 'VU', 'YE', 'ZW'
+    ].freeze
+
     belongs_to :country, class_name: "Spree::Country"
     belongs_to :state, class_name: "Spree::State"
 
@@ -95,7 +103,7 @@ module Spree
     end
 
     def require_zipcode?
-      true
+      country ? country.zipcode_required? : true
     end
 
     private

--- a/core/db/default/spree/countries.rb
+++ b/core/db/default/spree/countries.rb
@@ -27,3 +27,7 @@ connection.execute <<-SQL
 SQL
 
 Spree::Config[:default_country_id] = Spree::Country.find_by(iso: "US").id
+
+# find countries that do not use postal codes (by iso) and set 'zipcode_required' to false for them.
+
+Spree::Country.where(iso: Spree::Address::NO_ZIPCODE_ISO_CODES).update_all(zipcode_required: false)

--- a/core/db/migrate/20160608090604_add_zipcode_required_to_spree_countries.rb
+++ b/core/db/migrate/20160608090604_add_zipcode_required_to_spree_countries.rb
@@ -1,0 +1,7 @@
+class AddZipcodeRequiredToSpreeCountries < ActiveRecord::Migration
+  def change
+    add_column :spree_countries, :zipcode_required, :boolean, default: true
+    Spree::Country.reset_column_information
+    Spree::Country.where(iso: Spree::Address::NO_ZIPCODE_ISO_CODES).update_all(zipcode_required: false)
+  end
+end

--- a/core/spec/models/spree/address_spec.rb
+++ b/core/spec/models/spree/address_spec.rb
@@ -65,7 +65,7 @@ describe Spree::Address, type: :model do
       end
     end
 
-    let(:country) { mock_model(Spree::Country, states: [state], states_required: true) }
+    let(:country) { stub_model(Spree::Country, states: [state], states_required: true) }
     let(:state) { stub_model(Spree::State, name: 'maryland', abbr: 'md') }
     let(:address) { build(:address, country: country) }
 
@@ -160,6 +160,12 @@ describe Spree::Address, type: :model do
       context 'does not validate' do
         it 'does not have a country' do
           address.country = nil
+          address.valid?
+          expect(address.errors['zipcode']).not_to include('is invalid')
+        end
+
+        it 'country does not requires zipcode' do
+          allow(address.country).to receive(:zipcode_required?).and_return(false)
           address.valid?
           expect(address.errors['zipcode']).not_to include('is invalid')
         end


### PR DESCRIPTION
This PR addresses issue #7389. The `zipcode_required` attribute is added to `Spree::Country` model which is now used to check whether zip code validation should be run or not.
