### PR TITLE
Add missing translations for `tags` and `addresses`

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -439,6 +439,7 @@ en:
     address: Address
     address1: Address
     address2: Address (contd.)
+    addresses: Addresses
     adjustable: Adjustable
     adjustment: Adjustment
     adjustment_amount: Amount
@@ -1393,6 +1394,8 @@ en:
     taxon: Taxon
     taxon_edit: Edit Taxon
     taxon_placeholder: Add a Taxon
+    tags: Tags
+    tags_placeholder: Add Tags
     taxon_rule:
       choose_taxons: Choose taxons
       label: Order must contain x amount of these taxons


### PR DESCRIPTION
This pull request adds missing translations for `spree/addresses` and `spree/tags`. It also fixes `Found missing translations` warnings appearing during specs run.
