### PR TITLE
Replace the Model.model_name.human calls

### DIFF
--- a/backend/app/views/spree/admin/return_index/customer_returns.html.erb
+++ b/backend/app/views/spree/admin/return_index/customer_returns.html.erb
@@ -57,8 +57,7 @@
   </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: Spree::CustomerReturn.model_name.human(count: :many)) %>.
-  </div>
+    <%= Spree.t(:no_resource_found, resource: Spree::BaseHelper.plural_resource_name(Spree::CustomerReturn)) %>.  </div>
 <% end %>
 
 <%= render partial: 'spree/admin/shared/index_table_options', locals: { collection: @collection, per_page_action: :customer_returns } %>

--- a/backend/app/views/spree/admin/return_index/customer_returns.html.erb
+++ b/backend/app/views/spree/admin/return_index/customer_returns.html.erb
@@ -57,7 +57,7 @@
   </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: Spree::BaseHelper.plural_resource_name(Spree::CustomerReturn)) %>.  </div>
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::CustomerReturn)) %>.  </div>
 <% end %>
 
 <%= render partial: 'spree/admin/shared/index_table_options', locals: { collection: @collection, per_page_action: :customer_returns } %>

--- a/backend/app/views/spree/admin/return_index/return_authorizations.html.erb
+++ b/backend/app/views/spree/admin/return_index/return_authorizations.html.erb
@@ -69,7 +69,7 @@
   </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: Spree::ReturnAuthorization.model_name.human(count: :many)) %>.
+    <%= Spree.t(:no_resource_found, resource: Spree::BaseHelper.plural_resource_name(Spree::ReturnAuthorization)) %>.
   </div>
 <% end %>
 

--- a/backend/app/views/spree/admin/return_index/return_authorizations.html.erb
+++ b/backend/app/views/spree/admin/return_index/return_authorizations.html.erb
@@ -69,7 +69,7 @@
   </table>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: Spree::BaseHelper.plural_resource_name(Spree::ReturnAuthorization)) %>.
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::ReturnAuthorization)) %>.
   </div>
 <% end %>
 


### PR DESCRIPTION
Replace all calls to Model.model_name.human with
plural_resource_name(Model) instead

continue of https://github.com/solidusio/solidus/pull/1187/commits/cac2577de407f282e5dfe2fbe7c4a06fe340b4ee
