### PR TITLE
Loosen active merchant dependency

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files        = `git ls-files`.split("\n")
   s.require_path = 'lib'
 
-  s.add_dependency 'activemerchant', '~> 1.49.0'
+  s.add_dependency 'activemerchant', '~> 1.49'
   s.add_dependency 'acts_as_list', '~> 0.7.4'
   s.add_dependency 'awesome_nested_set', '~> 3.1.1'
   s.add_dependency 'carmen', '~> 1.0.0'


### PR DESCRIPTION
This allows us to use any `1.x` version of `active merchant`
