### PR TITLE
Admin Panel list destroy fixes

### DIFF
--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -47,11 +47,10 @@ module Spree
 
         begin
           # TODO: why is @product.destroy raising ActiveRecord::RecordNotDestroyed instead of failing with false result
-          # Issue found for above comment: https://github.com/rails/rails/issues/19761
           if @product.destroy
             flash[:success] = Spree.t('notice_messages.product_deleted')
           else
-            flash[:error] = @object.errors.full_messages.join(', ')
+            flash[:error] = Spree.t('notice_messages.product_not_deleted')
           end
         rescue ActiveRecord::RecordNotDestroyed => e
           flash[:error] = Spree.t('notice_messages.product_not_deleted')

--- a/backend/app/controllers/spree/admin/variants_controller.rb
+++ b/backend/app/controllers/spree/admin/variants_controller.rb
@@ -12,12 +12,12 @@ module Spree
         if @variant.destroy
           flash[:success] = Spree.t('notice_messages.variant_deleted')
         else
-          flash[:success] = Spree.t('notice_messages.variant_not_deleted')
+          flash[:error] = Spree.t('notice_messages.variant_not_deleted')
         end
 
         respond_with(@variant) do |format|
           format.html { redirect_to admin_product_variants_url(params[:product_id]) }
-          format.js  { render_js_for_destroy }
+          format.js { render_js_for_destroy }
         end
       end
 

--- a/backend/app/views/spree/admin/shared/_destroy.js.erb
+++ b/backend/app/views/spree/admin/shared/_destroy.js.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% if error = flash.discard(:error) %>
-  show_flash('warning', "<%= j error %>");
+  show_flash('error', "<%= j error %>");
 <% end %>
 
 <%= render partial: '/spree/admin/shared/update_order_state' if @order %>

--- a/backend/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/products_controller_spec.rb
@@ -62,13 +62,10 @@ describe Spree::Admin::ProductsController, type: :controller do
     end
 
     context 'will not successfully destroy product' do
-      let!(:error_message) { 'Test error' }
-
       before do
         allow(Spree::Product).to receive(:friendly).and_return(products)
         allow(products).to receive(:find).with(product.id.to_s).and_return(product)
         allow(product).to receive(:destroy).and_return(false)
-        allow(product).to receive_message_chain(:errors, :full_messages).and_return([error_message])
       end
 
       describe 'expects to receive' do
@@ -87,7 +84,7 @@ describe Spree::Admin::ProductsController, type: :controller do
       describe 'response' do
         before { send_request }
         it { expect(response).to have_http_status(:ok) }
-        it { expect(flash[:error]).to eq(error_message) }
+        it { expect(flash[:error]).to eq(Spree.t('notice_messages.product_not_deleted')) }
       end
     end
   end

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -88,6 +88,7 @@ module Spree
     after_save :run_touch_callbacks, if: :anything_changed?
     after_save :reset_nested_changes
     after_touch :touch_taxons
+    before_destroy :ensure_no_line_items
 
     before_validation :normalize_slug, on: :update
     before_validation :validate_master
@@ -354,6 +355,13 @@ module Spree
     def touch_taxons
       Spree::Taxon.where(id: taxon_and_ancestors.map(&:id)).update_all(updated_at: Time.current)
       Spree::Taxonomy.where(id: taxonomy_ids).update_all(updated_at: Time.current)
+    end
+
+    def ensure_no_line_items
+      if line_items.any?
+        errors.add(:base, Spree.t(:cannot_destroy_if_attached_to_line_items))
+        return false
+      end
     end
 
     def remove_taxon(taxon)

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -26,6 +26,10 @@ module Spree
 
     acts_as_paranoid
 
+    # we need to have this callback before any dependent: :destroy associations
+    # https://github.com/rails/rails/issues/3458
+    before_destroy :ensure_no_line_items
+
     has_many :product_option_types, dependent: :destroy, inverse_of: :product
     has_many :option_types, through: :product_option_types
     has_many :product_properties, dependent: :destroy, inverse_of: :product
@@ -88,7 +92,6 @@ module Spree
     after_save :run_touch_callbacks, if: :anything_changed?
     after_save :reset_nested_changes
     after_touch :touch_taxons
-    before_destroy :ensure_no_line_items
 
     before_validation :normalize_slug, on: :update
     before_validation :validate_master

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -14,10 +14,9 @@ module Spree
 
     with_options inverse_of: :variant do
       has_many :inventory_units
+      has_many :line_items
       has_many :stock_items, dependent: :destroy
     end
-
-    has_many :line_items, dependent: :restrict_with_error
 
     has_many :orders, through: :line_items
     with_options through: :stock_items do
@@ -49,6 +48,7 @@ module Spree
 
     after_create :create_stock_items
     after_create :set_master_out_of_stock, unless: :is_master?
+    before_destroy :ensure_no_line_items
 
     after_touch :clear_in_stock_cache
 
@@ -257,6 +257,13 @@ module Spree
     end
 
     private
+
+    def ensure_no_line_items
+      if line_items.any?
+        errors.add(:base, Spree.t(:cannot_destroy_if_attached_to_line_items))
+        return false
+      end
+    end
 
     def quantifier
       Spree::Stock::Quantifier.new(self)

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -12,6 +12,10 @@ module Spree
                         :shipping_category_id, :meta_description, :meta_keywords,
                         :shipping_category
 
+    # we need to have this callback before any dependent: :destroy associations
+    # https://github.com/rails/rails/issues/3458
+    before_destroy :ensure_no_line_items
+
     with_options inverse_of: :variant do
       has_many :inventory_units
       has_many :line_items
@@ -48,7 +52,6 @@ module Spree
 
     after_create :create_stock_items
     after_create :set_master_out_of_stock, unless: :is_master?
-    before_destroy :ensure_no_line_items
 
     after_touch :clear_in_stock_cache
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -313,6 +313,10 @@ en:
           attributes:
             expires_at:
               invalid_date_range: must be later than start date
+        spree/product:
+          attributes:
+            base:
+              cannot_destroy_if_attached_to_line_items: Cannot delete products once they are attached to line items.
         spree/refund:
           attributes:
             amount:
@@ -343,6 +347,10 @@ en:
             amount_authorized:
               exceeds_total_credits: Exceeds total credits.
         spree/variant:
+          attributes:
+            base:
+              cannot_destroy_if_attached_to_line_items: Cannot delete variants once they are attached to line items.
+        spree/shipping_method:
           attributes:
             base:
               cannot_destroy_if_attached_to_line_items: Cannot delete variants once they are attached to line items.

--- a/core/spec/models/spree/order_merger_spec.rb
+++ b/core/spec/models/spree/order_merger_spec.rb
@@ -124,7 +124,9 @@ module Spree
       end
 
       it "should create errors with invalid line items" do
-        variant_2.destroy
+        # we cannot use .destroy here as it will be halted by
+        # :ensure_no_line_items callback
+        variant_2.really_destroy!
         subject.merge!(order_2)
         expect(order_1.errors.full_messages).not_to be_empty
       end


### PR DESCRIPTION
This PR:
- after unsuccessful variant deletion, we should display error flash, not success one
- errored record deletions should show error flash, not warning to be consistent with the rest of the project
- reverts https://github.com/spree/spree/commit/f2e3447c8d8bba2c63b6421a2e42dbb05bb57fdf as this breaks variants deletions
- fixes `dependent: :destroy` issues with associated models removed even if `Product` / `Variant` cannot be deleted (halted by `ensure_no_line_items` callback)
