### PR TITLE
add dependent delete_all option

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -17,9 +17,9 @@ module Spree
       has_many :adjustments, as: :adjustable
       has_many :inventory_units, inverse_of: :shipment
       has_many :shipping_rates, -> { order(:cost) }
+      has_many :state_changes, as: :stateful
     end
     has_many :shipping_methods, through: :shipping_rates
-    has_many :state_changes, as: :stateful
 
     after_save :update_adjustments
 


### PR DESCRIPTION
state_changes should be destroyed as same as order.
https://github.com/spree/spree/blob/master/core/app/models/spree/order.rb#L82

Spree::Order add `dependent: destroy` option, but it seems no problem to use `dependent: delete_all` option
