### PR TITLE
Fixed: don't destroy dependent associations if we cannot destroy the Country

### DIFF
--- a/core/app/models/spree/country.rb
+++ b/core/app/models/spree/country.rb
@@ -3,6 +3,10 @@ module Spree
     has_many :states, dependent: :destroy
     has_many :addresses, dependent: :restrict_with_error
 
+    # we need to have this callback before any dependent: :destroy associations
+    # https://github.com/rails/rails/issues/3458
+    before_destroy :ensure_not_default
+
     has_many :zone_members,
              -> { where(zoneable_type: 'Spree::Country') },
              class_name: 'Spree::ZoneMember',
@@ -10,8 +14,6 @@ module Spree
              foreign_key: :zoneable_id
 
     has_many :zones, through: :zone_members, class_name: 'Spree::Zone'
-
-    before_destroy :ensure_not_default
 
     validates :name, :iso_name, presence: true, uniqueness: { case_sensitive: false, allow_blank: true }
 


### PR DESCRIPTION
Previously `ensure_not_default`  callback could stop deleting the `Country` but associations (with `dependent: :destroy`) were deleted whatsoever, as this is a rails bug (see rails/rails#3458)

Same issue as fixed in  https://github.com/spree/spree/commit/a140d564ae7b37476070c2435c6c39709ebe7b9e
