### PR TITLE
Fixed: don't destroy dependent associations if we cannot destroy the Country

### DIFF
--- a/core/app/models/spree/country.rb
+++ b/core/app/models/spree/country.rb
@@ -1,12 +1,11 @@
 module Spree
   class Country < Spree::Base
-    has_many :states, dependent: :destroy
-    has_many :addresses, dependent: :restrict_with_error
-
     # we need to have this callback before any dependent: :destroy associations
     # https://github.com/rails/rails/issues/3458
     before_destroy :ensure_not_default
 
+    has_many :states, dependent: :destroy
+    has_many :addresses, dependent: :restrict_with_error
     has_many :zone_members,
              -> { where(zoneable_type: 'Spree::Country') },
              class_name: 'Spree::ZoneMember',


### PR DESCRIPTION
corrected place of before_destroy callback from PR https://github.com/spree/spree/pull/7428
