### PR TITLE
Fixed: don't destroy dependent associations if we cannot destroy the User

### DIFF
--- a/core/app/models/spree/legacy_user.rb
+++ b/core/app/models/spree/legacy_user.rb
@@ -7,15 +7,7 @@ module Spree
 
     self.table_name = 'spree_users'
 
-    before_destroy :check_completed_orders
-
     attr_accessor :password
     attr_accessor :password_confirmation
-
-    private
-
-      def check_completed_orders
-        raise Spree::Core::DestroyWithOrdersError if orders.complete.present?
-      end
   end
 end


### PR DESCRIPTION
Moved `check_completed_orders` to `UserMethods` module

Previously :check_completed_orders  callback could stop deleting the
User but associations (with dependent: :destroy) were
deleted whatsoever, as this is a rails bug (see
rails/rails#3458)
