### PR TITLE
Removing previously deprecated Spree::Order#update! method

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -236,11 +236,6 @@ module Spree
       updater.update
     end
 
-    def update!
-      warn "`update!` is deprecated as it conflicts with update! method of rails. Use `update_with_updater!` instead."
-      update_with_updater!
-    end
-
     def merger
       @merger ||= Spree::OrderMerger.new(self)
     end


### PR DESCRIPTION
This was deprecated in `3.1` (https://github.com/spree/spree/pull/7144) so it's time to remove it completely. 
