### PR TITLE
Use `_path' instead of `_url' on `products' partial

### DIFF
--- a/frontend/app/views/spree/shared/_products.html.erb
+++ b/frontend/app/views/spree/shared/_products.html.erb
@@ -19,7 +19,7 @@
 <% if products.any? %>
   <div id="products" class="row" data-hook>
     <% products.each do |product| %>
-      <% url = spree.product_url(product, taxon_id: @taxon.try(:id)) %>
+      <% url = spree.product_path(product, taxon_id: @taxon.try(:id)) %>
       <div id="product_<%= product.id %>" class="col-md-3 col-sm-6 col-xs-6 product-list-item" data-hook="products_list_item" itemscope itemtype="https://schema.org/Product">
         <div class="panel panel-default">
           <% cache(@taxon.present? ? [I18n.locale, current_currency, @taxon, product] : cache_key_for_product(product)) do %>

--- a/frontend/spec/features/products_spec.rb
+++ b/frontend/spec/features/products_spec.rb
@@ -33,7 +33,7 @@ describe "Visiting Products", type: :feature, inaccessible: true do
     end
 
     it "correctly displays the product url via microdata" do
-      expect(ringer.properties["url"]).to eq ["http://www.example.com/products/ruby-on-rails-ringer-t-shirt"]
+      expect(ringer.properties["url"]).to eq ["/products/ruby-on-rails-ringer-t-shirt"]
     end
   end
 


### PR DESCRIPTION
This PR changes the `_products` partial so it uses `_path` helper instead of `_url` when generating links for products.

As reported by @dangerdogz: products link are generated using *_url helper and the helper uses the HTTP Host to generate the link. It's fairly common with nginx/apache to serve every host and not validate the domain (cloud66 does it by default so that's good chunk of insecure servers) so an attacker can make curl requests with a spoofed header until it gets cache and then every visitor will have the "poisoned" link and after that it's trivial to do XSS or redirect to malicious url
