### PR TITLE
use `_path' instead of `_url' on `products' partial

### DIFF
--- a/frontend/app/views/spree/shared/_products.html.erb
+++ b/frontend/app/views/spree/shared/_products.html.erb
@@ -24,7 +24,7 @@
 <% if products.any? %>
 <ul id="products" class="inline product-listing" data-hook>
   <% products.each do |product| %>
-    <% url = product_url(product, :taxon_id => @taxon.try(:id)) %>
+    <% url = product_path(product, :taxon_id => @taxon.try(:id)) %>
     <li id="product_<%= product.id %>" class="columns three <%= cycle("alpha", "secondary", "", "omega secondary", :name => "classes") %>" data-hook="products_list_item" itemscope itemtype="http://schema.org/Product">
       <% cache(@taxon.present? ? [I18n.locale, current_currency, @taxon, product] : [I18n.locale, current_currency, product]) do %>
         <div class="product-image">


### PR DESCRIPTION
This PR changes the `_products` partial so it uses `_path` helper instead of `_url` when generating links for products.

As reported by @dangerdogz: products link are generated using *_url helper and the helper uses the HTTP Host to generate the link. It's fairly common with nginx/apache to serve every host and not validate the domain (cloud66 does it by default so that's good chunk of insecure servers) so an attacker can make curl requests with a spoofed header until it gets cache and then every visitor will have the "poisoned" link and after that it's trivial to do XSS or redirect to malicious url
