### PR TITLE
Sandbox gemfile should include current branch for spree version

### DIFF
--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -11,8 +11,9 @@ fi
 cd ./sandbox
 
 cat <<RUBY >> Gemfile
-gem 'spree', path: '..'
-gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: 'master'
+current_branch = '$(git symbolic-ref --short -q HEAD)'
+gem 'spree', path: '..', branch: current_branch
+gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: current_branch
 
 group :test, :development do
   gem 'bullet'


### PR DESCRIPTION
### Problem

Current sandbox application doesn't include current branch in gemfile.
### Solution

Added current git branch in gemfile
