### PR TITLE
restore errors for order before transition to complete

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -412,8 +412,8 @@ module Spree
     # If so add error and restart checkout.
     def ensure_line_item_variants_are_not_discontinued
       if line_items.any?{ |li| !li.variant || li.variant.discontinued? }
-        errors.add(:base, Spree.t(:discontinued_variants_present))
         restart_checkout_flow
+        errors.add(:base, Spree.t(:discontinued_variants_present))
         false
       else
         true
@@ -422,8 +422,8 @@ module Spree
 
     def ensure_line_items_are_in_stock
       if insufficient_stock_lines.present?
-        errors.add(:base, Spree.t(:insufficient_stock_lines_present))
         restart_checkout_flow
+        errors.add(:base, Spree.t(:insufficient_stock_lines_present))
         false
       else
         true

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -238,7 +238,6 @@ describe Spree::Order, type: :model do
 
     context 'when variant is destroyed' do
       before do
-        allow(order).to receive(:restart_checkout_flow)
         order.line_items.first.variant.discontinue!
       end
 
@@ -272,14 +271,14 @@ describe Spree::Order, type: :model do
   describe '#ensure_line_items_are_in_stock' do
     subject { order.ensure_line_items_are_in_stock }
 
-    let(:line_item) { mock_model Spree::LineItem, insufficient_stock?: true }
+    let(:line_item) { create(:line_item, order: order) }
 
     before do
-      allow(order).to receive(:restart_checkout_flow)
-      allow(order).to receive_messages(line_items: [line_item])
+      allow(order).to receive(:insufficient_stock_lines).and_return([true])
     end
 
     it 'should restart checkout flow' do
+      allow(order).to receive(:restart_checkout_flow)
       expect(order).to receive(:restart_checkout_flow).once
       subject
     end
@@ -290,6 +289,7 @@ describe Spree::Order, type: :model do
     end
 
     it 'should be false' do
+      allow(order).to receive(:restart_checkout_flow)
       expect(subject).to be_falsey
     end
   end


### PR DESCRIPTION
Before an order is transited to complete state, `:ensure_line_item_variants_are_not_discontinue` and `ensure_line_items_are_in_stock` methods are triggered, which restart checkout flow for the currently processed order. Any error concerning the order is wiped out by the `:restart_checkout_flow` method. This PR addresses this issue by assigning errors to the order after `:restart_checkout_flow` is called.
