### PR TITLE
Reduce n+1 queries for variant load associated with variant_images

### DIFF
--- a/frontend/app/controllers/spree/products_controller.rb
+++ b/frontend/app/controllers/spree/products_controller.rb
@@ -40,7 +40,7 @@ module Spree
         else
           @products = Product.active(current_currency)
         end
-        @product = @products.includes(:variants_including_master).friendly.find(params[:id])
+        @product = @products.includes(:variants_including_master, variant_images: :viewable).friendly.find(params[:id])
       end
 
       def load_taxon


### PR DESCRIPTION
Using association `variant_images: :viewable` in `includes` while finding the product will eager load `variant_images` associated with it and `viewable` which are `variants` in this case. These n+1 queries are fired on `spree/frontend/app/views/spree/products/_thumbnails.html.erb` this page
