### PR TITLE
Reduce n+1 queries for calculator, zone and zone_members

### DIFF
--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -28,7 +28,7 @@ module Spree
 
     def include?(address)
       return false unless address
-      zones.includes(:zone_members).any? do |zone|
+      zones.any? do |zone|
         zone.include?(address)
       end
     end

--- a/core/app/models/spree/stock/package.rb
+++ b/core/app/models/spree/stock/package.rb
@@ -63,7 +63,7 @@ module Spree
       end
 
       def shipping_categories
-        Spree::ShippingCategory.joins(products: :variants_including_master).
+        Spree::ShippingCategory.includes(products: :variants_including_master, shipping_methods: [:calculator, zones: :zone_members]).
           where(spree_variants: { id: variant_ids }).uniq
       end
 


### PR DESCRIPTION
When transitioning order from `address` to `delivery`. 3 sets of n+1 queries are fired for `calculator`, `zones`, `zone_members` for each `shipping_method` in the system. These queries can be prevented by eager_loading associations related to `shipping_method`
