### PR TITLE
Prevent samples from increasing stock for master variants of products with variants

### DIFF
--- a/sample/db/samples/stock.rb
+++ b/sample/db/samples/stock.rb
@@ -11,6 +11,8 @@ location.active = true
 location.save!
 
 Spree::Variant.all.each do |variant|
+  next if variant.is_master? && variant.product.has_variants?
+
   variant.stock_items.each do |stock_item|
     Spree::StockMovement.create(quantity: 10, stock_item: stock_item)
   end


### PR DESCRIPTION
Normally, when a new variant is created for a product without any variants (only master), quantity of master variant's stock items is reduced to 0 by `after_create :set_master_out_of_stock` callback ([#](https://github.com/spree/spree/blob/master/core/app/models/spree/variant.rb#L54)) to prevent it from being purchased.
This doesn't happen in samples as `stock.rb` is run after variants are already created and sets positive quantities for every variant and master variant especially, whether it should or not.

This simple fix aims to make samples more compatible with real data as it's impossible to achieve the  same outcome using the admin backend.
