### PR TITLE
Make `discontinued_at` scope bit cleaner

### DIFF
--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -58,8 +58,11 @@ module Spree
     scope :in_stock, -> { joins(:stock_items).where('count_on_hand > ? OR track_inventory = ?', 0, false) }
 
     scope :not_discontinued, -> do
-      variant_table_name = Variant.quoted_table_name
-      where("#{variant_table_name}.discontinue_on IS NULL OR #{variant_table_name}.discontinue_on >= ?", Time.current)
+      where(
+        arel_table[:discontinue_on].eq(nil).or(
+          arel_table[:discontinue_on].gte(Time.current)
+        )
+      )
     end
 
     scope :not_deleted, -> { where("#{Variant.quoted_table_name}.deleted_at IS NULL") }

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -60,7 +60,7 @@ module Spree
     scope :not_discontinued, -> do
       where(
         arel_table[:discontinue_on].eq(nil).or(
-          arel_table[:discontinue_on].gte(Time.current)
+          arel_table[:discontinue_on].gteq(Time.current)
         )
       )
     end


### PR DESCRIPTION
When refactoring code to switch from `deleted_at` to `discontinued_at` I have noticed output generated by this scope (and some others) is inconsistent a tiny bit (missing backticks in table name). While adding backticks in query would also work, I thought to try to improve a bit on it.

To me this looks like a cleaner solution. With that in mind, I would like to propose a change where queries written in similar manner would be replaced by ruby code where it makes sense (or, greater than, less than... queries).
