### PR TITLE
Use disable with to enable only one request if clicked multiple times

### DIFF
--- a/backend/app/views/spree/admin/shared/_edit_resource_links.html.erb
+++ b/backend/app/views/spree/admin/shared/_edit_resource_links.html.erb
@@ -1,5 +1,5 @@
 <div class="form-actions" data-hook="buttons">
-  <%= button Spree.t('actions.update'), 'refresh', 'submit', {class: 'btn-success', data: { :'disable_with' => "Updating..." }} %>
+  <%= button Spree.t('actions.update'), 'refresh', 'submit', {class: 'btn-success', data: { :'disable_with' => "#{ Spree.t(:updating) }..." }} %>
   <span class="or"><%= Spree.t(:or) %></span>
   <%= button_link_to Spree.t('actions.cancel'), collection_url, icon: 'delete' %>
 </div>

--- a/backend/app/views/spree/admin/shared/_edit_resource_links.html.erb
+++ b/backend/app/views/spree/admin/shared/_edit_resource_links.html.erb
@@ -1,5 +1,5 @@
 <div class="form-actions" data-hook="buttons">
-  <%= button Spree.t('actions.update'), 'refresh', 'submit', {class: 'btn-success'} %>
+  <%= button Spree.t('actions.update'), 'refresh', 'submit', {class: 'btn-success', data: { :'disable_with' => "Updating..." }} %>
   <span class="or"><%= Spree.t(:or) %></span>
   <%= button_link_to Spree.t('actions.cancel'), collection_url, icon: 'delete' %>
 </div>

--- a/backend/app/views/spree/admin/shared/_edit_resource_links.html.erb
+++ b/backend/app/views/spree/admin/shared/_edit_resource_links.html.erb
@@ -1,5 +1,5 @@
 <div class="form-actions" data-hook="buttons">
-  <%= button Spree.t('actions.update'), 'refresh', 'submit', {class: 'btn-success', data: { :'disable_with' => "#{ Spree.t(:updating) }..." }} %>
+  <%= button Spree.t('actions.update'), 'refresh', 'submit', {class: 'btn-success', data: { disable_with: "#{ Spree.t(:saving) }..." }} %>
   <span class="or"><%= Spree.t(:or) %></span>
   <%= button_link_to Spree.t('actions.cancel'), collection_url, icon: 'delete' %>
 </div>

--- a/backend/app/views/spree/admin/shared/_new_resource_links.html.erb
+++ b/backend/app/views/spree/admin/shared/_new_resource_links.html.erb
@@ -1,5 +1,5 @@
 <div class="form-actions" data-hook="buttons">
-  <%= button Spree.t('actions.create'), 'ok', 'submit', {class: 'btn-success', data: { :'disable_with' => "#{ Spree.t(:creating) }..." }} %>
+  <%= button Spree.t('actions.create'), 'ok', 'submit', {class: 'btn-success', data: { disable_with: "#{ Spree.t(:saving) }..." }} %>
   <span class="or"><%= Spree.t(:or) %></span>
   <%= button_link_to Spree.t('actions.cancel'), collection_url, icon: 'remove' %>
 </div>

--- a/backend/app/views/spree/admin/shared/_new_resource_links.html.erb
+++ b/backend/app/views/spree/admin/shared/_new_resource_links.html.erb
@@ -1,5 +1,5 @@
 <div class="form-actions" data-hook="buttons">
-  <%= button Spree.t('actions.create'), 'ok', 'submit', {class: 'btn-success'} %>
+  <%= button Spree.t('actions.create'), 'ok', 'submit', {class: 'btn-success', data: { :'disable_with' => "Creating..." }} %>
   <span class="or"><%= Spree.t(:or) %></span>
   <%= button_link_to Spree.t('actions.cancel'), collection_url, icon: 'remove' %>
 </div>

--- a/backend/app/views/spree/admin/shared/_new_resource_links.html.erb
+++ b/backend/app/views/spree/admin/shared/_new_resource_links.html.erb
@@ -1,5 +1,5 @@
 <div class="form-actions" data-hook="buttons">
-  <%= button Spree.t('actions.create'), 'ok', 'submit', {class: 'btn-success', data: { :'disable_with' => "Creating..." }} %>
+  <%= button Spree.t('actions.create'), 'ok', 'submit', {class: 'btn-success', data: { :'disable_with' => "#{ Spree.t(:creating) }..." }} %>
   <span class="or"><%= Spree.t(:or) %></span>
   <%= button_link_to Spree.t('actions.cancel'), collection_url, icon: 'remove' %>
 </div>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -630,7 +630,6 @@ en:
     create_reimbursement: Create reimbursement
     created_at: Created At
     created_by: Created By
-    creating: Creating
     credit: Credit
     credit_card: Credit Card
     credit_cards: Credit Cards
@@ -1225,6 +1224,7 @@ en:
     sales_totals: Sales Totals
     save_and_continue: Save and Continue
     save_my_address: Save my address
+    saving: Saving
     say_no: 'No'
     say_yes: 'Yes'
     scope: Scope

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -630,6 +630,7 @@ en:
     create_reimbursement: Create reimbursement
     created_at: Created At
     created_by: Created By
+    creating: Creating
     credit: Credit
     credit_card: Credit Card
     credit_cards: Credit Cards


### PR DESCRIPTION
On Admin End, `new resource links` and `edit resource links` have submit buttons which submits multiple requests when clicked multiple times which results in creation of multiple objects if no validation fails for create request and similarily for update request.
Using `data-disable-with` disables button after first click so only single request is sent.
