### PR TITLE
Return the fist coupon that has actions

### DIFF
--- a/api/spec/controllers/spree/api/v1/promotions_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/promotions_controller_spec.rb
@@ -22,7 +22,7 @@ module Spree
       stub_authentication!
     end
 
-    let(:promotion) { create :promotion, code: '10off' }
+    let(:promotion) { create :promotion, :with_order_adjustment, code: '10off' }
 
     describe 'GET #show' do
       subject { api_get :show, id: id }

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -40,7 +40,9 @@ module Spree
     self.whitelisted_ransackable_attributes = ['path', 'promotion_category_id', 'code']
 
     def self.with_coupon_code(coupon_code)
-      where("lower(#{table_name}.code) = ?", coupon_code.strip.downcase).first
+      where("lower(#{table_name}.code) = ?", coupon_code.strip.downcase)
+        .includes(:promotion_actions).where.not(spree_promotion_actions: { id: nil })
+        .first
     end
 
     def self.active

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -574,9 +574,29 @@ describe Spree::Promotion, type: :model do
   # Regression test for #4081
   describe "#with_coupon_code" do
     context "and code stored in uppercase" do
-      let!(:promotion) { create(:promotion, code: "MY-COUPON-123") }
+      let!(:promotion) { create(:promotion, :with_order_adjustment, code: "MY-COUPON-123") }
       it "finds the code with lowercase" do
         expect(Spree::Promotion.with_coupon_code("my-coupon-123")).to eql promotion
+      end
+    end
+
+    context "and there are multiple coupons with the same code" do
+      context "and only one has any actions" do
+        let!(:promotion_without_actions) { create(:promotion, code: "MY-COUPON-123").actions.clear }
+        let!(:promotion) { create(:promotion, :with_order_adjustment, code: "MY-COUPON-123") }
+
+        it "then returns the one with an action" do
+          expect(Spree::Promotion.with_coupon_code("MY-COUPON-123").actions.exists?).to be
+        end
+      end
+
+      context "and all of them has actions" do
+        let!(:first_promotion) { create(:promotion, :with_order_adjustment, code: "MY-COUPON-123") }
+        let!(:second_promotion) { create(:promotion, :with_order_adjustment, code: "MY-COUPON-123") }
+
+        it "then returns the first one with an action" do
+          expect(Spree::Promotion.with_coupon_code("MY-COUPON-123").id).to eq(first_promotion.id)
+        end
       end
     end
   end


### PR DESCRIPTION
If there are multiple active coupons with the same code Spree will
always pick the first one in primary key order. The returned promotion
may never be applicable because it doesn't have any actions. This will
filter out any coupons that doesn't have any actions.

I found because my client double-clicked when creating the promotion, and to try and mitigate any problems from that happening again.
