### PR TITLE
Fix error message for shipping method 3-1-stable

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -350,10 +350,6 @@ en:
           attributes:
             base:
               cannot_destroy_if_attached_to_line_items: Cannot delete variants once they are attached to line items.
-        spree/shipping_method:
-          attributes:
-            base:
-              cannot_destroy_if_attached_to_line_items: Cannot delete variants once they are attached to line items.
 
   devise:
     confirmations:


### PR DESCRIPTION
If you try to create a shipping method with no shipping category, the error message shows missing translation.
![screen shot 2016-07-15 at 4 01 12 pm](https://cloud.githubusercontent.com/assets/24940/16887812/b6207aa6-4ab2-11e6-8171-2ef098c8a8c0.png)

The fact is the locale key is there -> https://github.com/spree/spree/blob/3-1-stable/core/config/locales/en.yml#L334-L337

But some lines below, it is overwritten by duplicate node -> https://github.com/spree/spree/blob/3-1-stable/core/config/locales/en.yml#L353-L356

This PR removes the duplicate node and also the locale key nested in it, because it seems to be there by mistake.
