### PR TITLE
Fixes JS error when there's no `new state` button in Admin Panel country dropdowns

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/states.js
+++ b/backend/app/assets/javascripts/spree/backend/states.js
@@ -1,11 +1,13 @@
 $(document).ready(function () {
   'use strict';
 
-  $('#country').on('change', function () {
-    var new_state_link_href = $('#new_state_link').prop('href');
-    var selected_country_id = $('#country option:selected').prop('value');
-    var new_link = new_state_link_href.replace(/countries\/(\d+)/,
-      'countries/' + selected_country_id);
-    $('#new_state_link').attr('href', new_link);
-  });
+  if ($('#new_state_link').length) {
+    $('#country').on('change', function () {
+      var new_state_link_href = $('#new_state_link').prop('href');
+      var selected_country_id = $('#country option:selected').prop('value');
+      var new_link = new_state_link_href.replace(/countries\/(\d+)/,
+        'countries/' + selected_country_id);
+      $('#new_state_link').attr('href', new_link);
+    });
+  };
 });


### PR DESCRIPTION
Eg. `stock location` form was a source of JS errors when someone wanted to change the country.
