### PR TITLE
Only include possible promotions when supported

### DIFF
--- a/frontend/app/controllers/spree/home_controller.rb
+++ b/frontend/app/controllers/spree/home_controller.rb
@@ -5,7 +5,8 @@ module Spree
 
     def index
       @searcher = build_searcher(params.merge(include_images: true))
-      @products = @searcher.retrieve_products.includes(:possible_promotions)
+      @products = @searcher.retrieve_products
+      @products = @products.includes(:possible_promotions) if @products.respond_to?(:includes)
       @taxonomies = Spree::Taxonomy.includes(root: :children)
     end
   end

--- a/frontend/app/controllers/spree/products_controller.rb
+++ b/frontend/app/controllers/spree/products_controller.rb
@@ -10,7 +10,8 @@ module Spree
 
     def index
       @searcher = build_searcher(params.merge(include_images: true))
-      @products = @searcher.retrieve_products.includes(:possible_promotions)
+      @products = @searcher.retrieve_products
+      @products = @products.includes(:possible_promotions) if @products.respond_to?(:includes)
       @taxonomies = Spree::Taxonomy.includes(root: :children)
     end
 

--- a/frontend/spec/controllers/spree/home_controller_spec.rb
+++ b/frontend/spec/controllers/spree/home_controller_spec.rb
@@ -24,4 +24,24 @@ describe Spree::HomeController, type: :controller do
       end
     end
   end
+
+  context "index products" do
+    it "calls includes when the retrieved_products object responds to it" do
+      searcher = double("Searcher")
+      allow(controller).to receive_messages build_searcher: searcher
+      expect(searcher).to receive_message_chain("retrieve_products.includes")
+
+      spree_get :index
+    end
+
+    it "does not call includes when it's not available" do
+      searcher = double("Searcher")
+      allow(controller).to receive_messages build_searcher: searcher
+      allow(searcher).to receive(:retrieve_products).and_return([])
+
+      spree_get :index
+
+      expect(assigns(:products)).to eq([])
+    end
+  end
 end

--- a/frontend/spec/controllers/spree/products_controller_spec.rb
+++ b/frontend/spec/controllers/spree/products_controller_spec.rb
@@ -64,4 +64,24 @@ describe Spree::ProductsController, type: :controller do
       expect(response.header["Location"]).to include("taxon_id=#{taxon.id}")
     end
   end
+
+  context "index products" do
+    it "calls includes when the retrieved_products object responds to it" do
+      searcher = double("Searcher")
+      allow(controller).to receive_messages build_searcher: searcher
+      expect(searcher).to receive_message_chain("retrieve_products.includes")
+
+      spree_get :index
+    end
+
+    it "does not call includes when it's not available" do
+      searcher = double("Searcher")
+      allow(controller).to receive_messages build_searcher: searcher
+      allow(searcher).to receive(:retrieve_products).and_return([])
+
+      spree_get :index
+
+      expect(assigns(:products)).to eq([])
+    end
+  end
 end


### PR DESCRIPTION
When using a different search class the response might not be an
Active Record object.

This was discovered as we were upgrading to Spree 3.1 with the Spree Searchkick extension installed, which in turn relies on ElasticSearch and works quite differently. By making this conditional, we're allowing the specific behavior of the search required for the base Active Record search as well as any other implementation.

Maybe there's a point in moving the includes into `retrieve_products` for the base search instead?
