### PR TITLE
Removing unused JS code from admin.js

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -158,23 +158,6 @@ jQuery(function($) {
     }
   });
 
-  // Enable sidebar toggle
-  $("[data-toggle='offcanvas']").click(function(e) {
-    e.preventDefault();
-
-    // If window is small enough, enable sidebar push menu
-    if ($(window).width() <= 992) {
-      $('.row-offcanvas').toggleClass('active');
-      $('.left-side').removeClass("collapse-left");
-      $(".right-side").removeClass("strech");
-      $('.row-offcanvas').toggleClass("relative");
-    } else {
-      // Else, enable content streching
-      $('.left-side').toggleClass("collapse-left");
-      $(".right-side").toggleClass("strech");
-    }
-  });
-
   // Make flash messages disappear
   setTimeout('$(".alert-auto-disappear").slideUp()', 5000);
 


### PR DESCRIPTION
Sidebar toggle is controlled at
https://github.com/spree/spree/blob/master/backend/app/assets/javascripts/spree/backend/admin.js#L29 and this is useless.
