### PR TITLE
reload associations explicitly

### DIFF
--- a/backend/spec/features/admin/promotions/option_value_rule_spec.rb
+++ b/backend/spec/features/admin/promotions/option_value_rule_spec.rb
@@ -34,7 +34,7 @@ feature 'Promotion with option value rule' do
 
     within('#rules_container') { click_button "Update" }
 
-    first_rule = promotion.rules(true).first
+    first_rule = promotion.rules.reload.first
     expect(first_rule.class).to eq Spree::Promotion::Rules::OptionValue
     expect(first_rule.preferred_eligible_values).to eq Hash[product.id => [option_value.id]]
   end
@@ -61,7 +61,7 @@ feature 'Promotion with option value rule' do
 
       within('#rule_fields') { click_button "Update" }
 
-      first_rule = promotion.rules(true).first
+      first_rule = promotion.rules.reload.first
       expect(first_rule.preferred_eligible_values).to eq(
         Hash[variant1.product_id => variant1.option_values.pluck(:id)]
       )

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -466,6 +466,7 @@ describe Spree::Product, type: :model do
         product.option_values_hash = option_values_hash
         product.prototype_id = nil
         product.save
+        product.reload
         expect(product.option_type_ids.length).to eq(1)
         expect(product.option_type_ids).to eq(prototype.option_type_ids)
         expect(product.variants.length).to eq(3)
@@ -533,7 +534,7 @@ describe Spree::Product, type: :model do
 
     it 'should return sum of stock items count_on_hand' do
       product.stock_items.first.set_count_on_hand 5
-      product.variants_including_master(true) # force load association
+      product.variants_including_master.reload # force load association
       expect(product.total_on_hand).to eql(5)
     end
 


### PR DESCRIPTION
In Rails 5 passing `true` argument while calling object's associations is deprecated. This PR changes the way relations are reloaded using `reload` method instead of deprecated behaviour.
