### PR TITLE
[Rails 5] replace deprecated uniq with distinct on relation

### DIFF
--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -193,7 +193,7 @@ module Spree
     # Can't use add_search_scope for this as it needs a default argument
     def self.available(available_on = nil, currency = nil)
       available_on ||= Time.current
-      not_discontinued.joins(master: :prices).where("#{Product.quoted_table_name}.available_on <= ?", available_on).uniq
+      not_discontinued.joins(master: :prices).where("#{Product.quoted_table_name}.available_on <= ?", available_on).distinct
     end
     search_scopes << :available
 

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -31,7 +31,7 @@ module Spree
     scope :coupons, -> { where.not(code: nil) }
     scope :advertised, -> { where(advertise: true) }
     scope :applied, lambda {
-      joins(<<-SQL).uniq
+      joins(<<-SQL).distinct
         INNER JOIN spree_order_promotions
         ON spree_order_promotions.promotion_id = #{table_name}.id
       SQL

--- a/core/app/models/spree/promotion/rules/taxon.rb
+++ b/core/app/models/spree/promotion/rules/taxon.rb
@@ -44,7 +44,7 @@ module Spree
 
         # All taxons in an order
         def order_taxons(order)
-          Spree::Taxon.joins(products: {variants_including_master: :line_items}).where(spree_line_items: {order_id: order.id}).uniq
+          Spree::Taxon.joins(products: {variants_including_master: :line_items}).where(spree_line_items: {order_id: order.id}).distinct
         end
 
         # ids of taxons rules and taxons rules children

--- a/core/app/models/spree/stock/coordinator.rb
+++ b/core/app/models/spree/stock/coordinator.rb
@@ -39,7 +39,7 @@ module Spree
 
       def stock_locations_with_requested_variants
         Spree::StockLocation.active.joins(:stock_items).
-          where(spree_stock_items: { variant_id: requested_variant_ids }).uniq
+          where(spree_stock_items: { variant_id: requested_variant_ids }).distinct
       end
 
       def requested_variant_ids

--- a/core/app/models/spree/stock/package.rb
+++ b/core/app/models/spree/stock/package.rb
@@ -64,7 +64,7 @@ module Spree
 
       def shipping_categories
         Spree::ShippingCategory.joins(products: :variants_including_master).
-          where(spree_variants: { id: variant_ids }).uniq
+          where(spree_variants: { id: variant_ids }).distinct
       end
 
       def shipping_methods

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -69,7 +69,7 @@ module Spree
 
     scope :for_currency_and_available_price_amount, -> (currency) do
       currency ||= Spree::Config[:currency]
-      joins(:prices).where("spree_prices.currency = ?", currency).where("spree_prices.amount IS NOT NULL").uniq
+      joins(:prices).where("spree_prices.currency = ?", currency).where("spree_prices.amount IS NOT NULL").distinct
     end
 
     scope :active, -> (currency = nil) do

--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -33,7 +33,7 @@ module Spree
         # Match zones of the same kind with similar countries
         joins(countries: :zones).
           where("zone_members_spree_countries_join.zone_id = ?", zone.id).
-          uniq
+          distinct
       else
         # Match zones of the same kind with similar states in AND match zones
         # that have the states countries in
@@ -44,7 +44,7 @@ module Spree
             spree_zone_members.zoneable_id IN (?))",
           zone.state_ids,
           zone.states.pluck(:country_id)
-        ).uniq
+        ).distinct
       end
     end
 


### PR DESCRIPTION
In Rails 5 `uniq` method for relations is deprecated. This PR switches `uniq` to preferred `distinct`.
