### PR TITLE
use include/extend directly for modules

### DIFF
--- a/core/lib/generators/spree/custom_user/templates/authentication_helpers.rb.tt
+++ b/core/lib/generators/spree/custom_user/templates/authentication_helpers.rb.tt
@@ -30,7 +30,7 @@ module Spree
   end
 end
 
-ApplicationController.send :include, Spree::AuthenticationHelpers
-ApplicationController.send :include, Spree::CurrentUserHelpers
+ApplicationController.include Spree::AuthenticationHelpers
+ApplicationController.include Spree::CurrentUserHelpers
 
-Spree::Api::BaseController.send :include, Spree::CurrentUserHelpers
+Spree::Api::BaseController.include Spree::CurrentUserHelpers

--- a/core/lib/spree/core/delegate_belongs_to.rb
+++ b/core/lib/spree/core/delegate_belongs_to.rb
@@ -92,4 +92,4 @@ module DelegateBelongsTo
   protected :delegator_for_setter
 end
 
-ActiveRecord::Base.send :include, DelegateBelongsTo
+ActiveRecord::Base.include DelegateBelongsTo

--- a/core/lib/spree/i18n/initializer.rb
+++ b/core/lib/spree/i18n/initializer.rb
@@ -1,1 +1,1 @@
-Spree::BaseController.send(:include, Spree::ViewContext)
+Spree::BaseController.include Spree::ViewContext

--- a/guides/content/developer/customization/authentication.markdown
+++ b/guides/content/developer/customization/authentication.markdown
@@ -120,9 +120,9 @@ module Spree
    end
 end
 
-Spree::BaseController.send      :include, Spree::AuthenticationHelpers
-Spree::Api::BaseController.send :include, Spree::AuthenticationHelpers
-ApplicationController.send      :include, Spree::AuthenticationHelpers
+Spree::BaseController.include Spree::AuthenticationHelpers
+Spree::Api::BaseController.include Spree::AuthenticationHelpers
+ApplicationController.include Spree::AuthenticationHelpers
 ```
 
 Each of the methods defined in this module return values that are the


### PR DESCRIPTION
since Ruby 2.1 `Module#include` became public, this PR takes advantage of this
