### PR TITLE
[Rails 5] replace deliver and deliver! from deliver_now or deliver_later

### DIFF
--- a/core/spec/models/spree/order/state_machine_spec.rb
+++ b/core/spec/models/spree/order/state_machine_spec.rb
@@ -142,7 +142,7 @@ describe Spree::Order, type: :model do
         allow(shipment).to receive(:ensure_correct_adjustment)
         allow(shipment).to receive(:update_order)
         allow(Spree::OrderMailer).to receive(:cancel_email).and_return(mail_message = double)
-        allow(mail_message).to receive :deliver
+        allow(mail_message).to receive :deliver_later
 
       end
     end


### PR DESCRIPTION
This PR replaces all usages of `deliver` (which will be deprecated since Rails 5) to `deliver_later`.
