### PR TITLE
set precision to 6 for datetime columns

### DIFF
--- a/core/db/migrate/20160720180802_increase_timestamp_precision.rb
+++ b/core/db/migrate/20160720180802_increase_timestamp_precision.rb
@@ -1,0 +1,12 @@
+class IncreaseTimestampPrecision < ActiveRecord::Migration
+  def change
+    ActiveRecord::Base.connection.tables.each do |table_name|
+      columns = ActiveRecord::Base.connection.columns(table_name)
+
+      # set the precision to microseconds for each datetime column on the table
+      columns.select { |col| col.type == :datetime }.each do |column|
+        change_column table_name, column.name, :datetime, limit: 6
+      end
+    end
+  end
+end


### PR DESCRIPTION
Default precision could be 0, so milliseconds are lost
