### PR TITLE
Coupon code applied message on frontend is now fetched dynamically from selected translation

### DIFF
--- a/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js.coffee
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js.coffee
@@ -69,7 +69,7 @@ Spree.ready ($) ->
             url: url,
             success: (data) =>
               coupon_code_field.val('')
-              coupon_status.addClass("alert-success").html("Coupon code applied successfully.")
+              coupon_status.addClass("alert-success").html(Spree.translations.coupon_code_applied)
               coupon_applied = true
             error: (xhr) ->
               handler = JSON.parse(xhr.responseText)

--- a/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js.coffee
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js.coffee
@@ -67,7 +67,7 @@ Spree.ready ($) ->
             async: false,
             method: "PUT",
             url: url,
-            success: (data) =>
+            success: (data) ->
               coupon_code_field.val('')
               coupon_status.addClass("alert-success").html(Spree.translations.coupon_code_applied)
               coupon_applied = true

--- a/frontend/app/views/spree/shared/_head.html.erb
+++ b/frontend/app/views/spree/shared/_head.html.erb
@@ -12,3 +12,4 @@
   <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.6/html5shiv.min.js"></script>
 <![endif]-->
 <%= yield :head %>
+<%= render 'spree/shared/translations' %>

--- a/frontend/app/views/spree/shared/_translations.html.erb
+++ b/frontend/app/views/spree/shared/_translations.html.erb
@@ -1,0 +1,7 @@
+<script>
+  Spree.translations = <%==
+  {
+    coupon_code_applied: Spree.t(:coupon_code_applied)
+  }.to_json
+%>
+</script>


### PR DESCRIPTION
Also added a starting point file (`spree/shared/translations`) for other future JavaScript translations on the frontend in a similar fashion as it’s already implemented in the Admin Panel.
