### PR TITLE
[rails 5] replace deprecated `render :text' with `render :plain'

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -89,7 +89,7 @@ module Spree
       end
 
       def unprocessable_entity(message)
-        render text: { exception: message }.to_json, status: 422
+        render plain: { exception: message }.to_json, status: 422
       end
 
       def gateway_error(exception)

--- a/api/app/controllers/spree/api/v1/inventory_units_controller.rb
+++ b/api/app/controllers/spree/api/v1/inventory_units_controller.rb
@@ -35,7 +35,7 @@ module Spree
 
           unless inventory_unit.respond_to?(can_event) &&
                  inventory_unit.send(can_event)
-            render text: { exception: "cannot transition to #{@event}" }.to_json,
+            render plain: { exception: "cannot transition to #{@event}" }.to_json,
                    status: 200
             false
           end

--- a/api/app/controllers/spree/api/v1/option_types_controller.rb
+++ b/api/app/controllers/spree/api/v1/option_types_controller.rb
@@ -47,7 +47,7 @@ module Spree
         def destroy
           @option_type = Spree::OptionType.accessible_by(current_ability, :destroy).find(params[:id])
           @option_type.destroy
-          render text: nil, status: 204
+          render plain: nil, status: 204
         end
 
         private

--- a/api/app/controllers/spree/api/v1/option_values_controller.rb
+++ b/api/app/controllers/spree/api/v1/option_values_controller.rb
@@ -41,7 +41,7 @@ module Spree
         def destroy
           @option_value = scope.accessible_by(current_ability, :destroy).find(params[:id])
           @option_value.destroy
-          render text: nil, status: 204
+          render plain: nil, status: 204
         end
 
         private

--- a/api/app/controllers/spree/api/v1/orders_controller.rb
+++ b/api/app/controllers/spree/api/v1/orders_controller.rb
@@ -47,7 +47,7 @@ module Spree
         def empty
           authorize! :update, @order, order_token
           @order.empty!
-          render text: nil, status: 204
+          render plain: nil, status: 204
         end
 
         def index

--- a/api/spec/controllers/spree/api/base_controller_spec.rb
+++ b/api/spec/controllers/spree/api/base_controller_spec.rb
@@ -7,7 +7,7 @@ describe Spree::Api::BaseController, type: :controller do
   render_views
   controller(Spree::Api::BaseController) do
     def index
-      render text: { "products" => [] }.to_json
+      render plain: { "products" => [] }.to_json
     end
   end
 

--- a/backend/app/controllers/spree/admin/option_types_controller.rb
+++ b/backend/app/controllers/spree/admin/option_types_controller.rb
@@ -12,7 +12,7 @@ module Spree
 
         respond_to do |format|
           format.html { redirect_to admin_product_variants_url(params[:product_id]) }
-          format.js { render text: 'Ok' }
+          format.js { render plain: 'Ok' }
         end
       end
 

--- a/backend/app/controllers/spree/admin/option_values_controller.rb
+++ b/backend/app/controllers/spree/admin/option_values_controller.rb
@@ -4,7 +4,7 @@ module Spree
       def destroy
         option_value = Spree::OptionValue.find(params[:id])
         option_value.destroy
-        render text: nil
+        render plain: nil
       end
     end
   end

--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -73,7 +73,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
     end
 
     respond_to do |format|
-      format.js { render text: 'Ok' }
+      format.js { render plain: 'Ok' }
     end
   end
 

--- a/backend/app/controllers/spree/admin/store_credits_controller.rb
+++ b/backend/app/controllers/spree/admin/store_credits_controller.rb
@@ -54,7 +54,7 @@ module Spree
             format.js { render_js_for_destroy }
           end
         else
-          render text: Spree.t('store_credit.errors.unable_to_delete'), status: :unprocessable_entity
+          render plain: Spree.t('store_credit.errors.unable_to_delete'), status: :unprocessable_entity
         end
       end
 

--- a/backend/spec/controllers/spree/admin/base_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/base_controller_spec.rb
@@ -7,7 +7,7 @@ describe Spree::Admin::BaseController, type: :controller do
   controller(Spree::Admin::BaseController) do
     def index
       authorize! :update, Spree::Order
-      render text: 'test'
+      render plain: 'test'
     end
   end
 

--- a/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
@@ -3,7 +3,7 @@ require 'spree/testing_support/url_helpers'
 
 class FakesController < ApplicationController
   include Spree::Core::ControllerHelpers::Auth
-  def index; render text: 'index'; end
+  def index; render plain: 'index'; end
 end
 
 describe Spree::Core::ControllerHelpers::Auth, type: :controller do
@@ -40,7 +40,7 @@ describe Spree::Core::ControllerHelpers::Auth, type: :controller do
     controller(FakesController) do
       def index
         set_guest_token
-        render text: 'index'
+        render plain: 'index'
       end
     end
     it 'sends cookie header' do

--- a/frontend/spec/controllers/controller_extension_spec.rb
+++ b/frontend/spec/controllers/controller_extension_spec.rb
@@ -6,7 +6,7 @@ require 'spec_helper'
 class Spree::CustomController < Spree::BaseController
   def index
     respond_with(Spree::Address.new) do |format|
-      format.html { render text: "neutral" }
+      format.html { render plain: "neutral" }
     end
   end
 
@@ -42,7 +42,7 @@ describe Spree::CustomController, type: :controller do
             private
 
             def success_method
-              render text: 'success!!!'
+              render plain: 'success!!!'
             end
           end
         end


### PR DESCRIPTION
In Rails 5 `render :text` will be deprecated. This PR switches from deprecated `:text` option to preferred `:plain`.
