### PR TITLE
Refactored product active scope

### DIFF
--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -198,7 +198,7 @@ module Spree
     search_scopes << :available
 
     def self.active(currency = nil)
-      not_discontinued.available(nil, currency)
+      available(nil, currency)
     end
     search_scopes << :active
 


### PR DESCRIPTION
not_discontinued is already used by available.
