### PR TITLE
Move :selected_shipping_rate to association

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -20,6 +20,8 @@ module Spree
       has_many :state_changes, as: :stateful
     end
     has_many :shipping_methods, through: :shipping_rates
+    has_one :selected_shipping_rate, -> { where(selected: true).order(:cost) }, class_name: Spree::ShippingRate
+
 
     after_save :update_adjustments
 
@@ -227,10 +229,6 @@ module Spree
       end
 
       shipping_rates
-    end
-
-    def selected_shipping_rate
-      shipping_rates.where(selected: true).first
     end
 
     def selected_shipping_rate_id


### PR DESCRIPTION
This takes the existing `selected_shipping_rate` method and turns it into a `has_one` association. This enables eager loading, for instance `Spree::Shipment.includes(:selected_shipping_rate)`, which can speed up certain queries and avoid n-query issues in some cases.
