### PR TITLE
update product's stock after removing line item

### DIFF
--- a/core/app/models/spree/order_inventory.rb
+++ b/core/app/models/spree/order_inventory.rb
@@ -25,6 +25,8 @@ module Spree
 
           shipment = determine_target_shipment unless shipment
           add_to_shipment(shipment, quantity)
+        elsif inventory_units.size == line_item.quantity && !line_item.changed?
+          remove(inventory_units, shipment)
         elsif inventory_units.size > line_item.quantity
           remove(inventory_units, shipment)
         end
@@ -32,8 +34,9 @@ module Spree
     end
 
     private
+
       def remove(item_units, shipment = nil)
-        quantity = item_units.size - line_item.quantity
+        quantity = set_quantity_to_remove(item_units)
 
         if shipment.present?
           remove_from_shipment(shipment, quantity)
@@ -42,6 +45,14 @@ module Spree
             break if quantity == 0
             quantity -= remove_from_shipment(shipment, quantity)
           end
+        end
+      end
+
+      def set_quantity_to_remove(item_units)
+        if (item_units.size - line_item.quantity).zero?
+          line_item.quantity
+        else
+          item_units.size - line_item.quantity
         end
       end
 

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -87,9 +87,9 @@ describe Spree::LineItem, type: :model do
   end
 
   context "#destroy" do
+    let!(:line_item) { order.line_items.first }
     it "returns inventory when a line item is destroyed" do
-      expect_any_instance_of(Spree::OrderInventory).to receive(:verify)
-      line_item.destroy
+      is_expected.to callback(:verify_order_inventory).before(:destroy)
     end
 
     it "deletes inventory units" do

--- a/core/spec/models/spree/order_inventory_spec.rb
+++ b/core/spec/models/spree/order_inventory_spec.rb
@@ -93,6 +93,7 @@ describe Spree::OrderInventory, type: :model do
     let(:variant) { line_item.variant }
 
     before do
+      allow(line_item).to receive(:changed?).and_return(:true)
       subject.verify
 
       order.shipments.create(stock_location_id: stock_location.id, cost: 5)


### PR DESCRIPTION
This PR references issue #7375. After destroying a line item from the order, the product was not restocked due to a condition in callback always evaluating to false. This PR changes conditions under which verifying stock is called and the way the quantity of line item to remove is determined.
