### PR TITLE
Displayed paymentmethods in frontend are ordered correctly

### DIFF
--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -7,7 +7,7 @@ module Spree
 
     scope :active,                 -> { where(active: true) }
     scope :available,              -> { active.where(display_on: [:front_end, :back_end, :both]) }
-    scope :available_on_front_end, -> { active.where(display_on: [:front_end, :both]) }
+    scope :available_on_front_end, -> { active.where(display_on: [:front_end, :both]).order(position: :asc) }
     scope :available_on_back_end,  -> { active.where(display_on: [:back_end, :both]) }
 
     validates :name, presence: true


### PR DESCRIPTION
https://github.com/spree/spree/issues/7515
