### PR TITLE
Hotfix/product property api fixes

### DIFF
--- a/api/app/controllers/spree/api/v1/product_properties_controller.rb
+++ b/api/app/controllers/spree/api/v1/product_properties_controller.rb
@@ -30,23 +30,19 @@ module Spree
         end
 
         def update
-          if @product_property
-            authorize! :update, @product_property
-            @product_property.update_attributes(product_property_params)
-            respond_with(@product_property, status: 200, default_template: :show)
-          else
-            invalid_resource!(@product_property)
-          end
+          fail ActiveRecord::RecordNotFound unless @product_property
+
+          authorize! :update, @product_property
+          @product_property.update_attributes(product_property_params)
+          respond_with(@product_property, status: 200, default_template: :show)
         end
 
         def destroy
-          if @product_property
-            authorize! :destroy, @product_property
-            @product_property.destroy
-            respond_with(@product_property, status: 204)
-          else
-            invalid_resource!(@product_property)
-          end
+          fail ActiveRecord::RecordNotFound unless @product_property
+
+          authorize! :destroy, @product_property
+          @product_property.destroy
+          respond_with(@product_property, status: 204)
         end
 
         private

--- a/api/app/controllers/spree/api/v1/product_properties_controller.rb
+++ b/api/app/controllers/spree/api/v1/product_properties_controller.rb
@@ -30,16 +30,16 @@ module Spree
         end
 
         def update
-          fail ActiveRecord::RecordNotFound unless @product_property
-
           authorize! :update, @product_property
-          @product_property.update_attributes(product_property_params)
-          respond_with(@product_property, status: 200, default_template: :show)
+
+          if @product_property.update_attributes(product_property_params)
+            respond_with(@product_property, status: 200, default_template: :show)
+          else
+            invalid_resource!(@product_property)
+          end
         end
 
         def destroy
-          fail ActiveRecord::RecordNotFound unless @product_property
-
           authorize! :destroy, @product_property
           @product_property.destroy
           respond_with(@product_property, status: 204)
@@ -56,6 +56,7 @@ module Spree
           if @product
             @product_property ||= @product.product_properties.find_by(id: params[:id])
             @product_property ||= @product.product_properties.includes(:property).where(spree_properties: { name: params[:id] }).first
+            fail ActiveRecord::RecordNotFound unless @product_property
             authorize! :read, @product_property
           end
         end

--- a/api/spec/controllers/spree/api/v1/product_properties_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/product_properties_controller_spec.rb
@@ -94,9 +94,22 @@ module Spree
       end
 
       context 'when product property exists' do
-        it "can update a product property" do
-          api_put :update, id: property_1.property_name, product_property: { value: "my value 456" }
-          expect(response.status).to eq(200)
+        context 'when product property is valid' do
+          it 'responds 200' do
+            api_put :update, id: property_1.property_name, product_property: { value: "my value 456" }
+            expect(response.status).to eq(200)
+          end
+        end
+
+        context 'when product property is invalid' do
+          before(:each) do
+            expect_any_instance_of(Spree::ProductProperty).to receive(:update_attributes).and_return false
+          end
+
+          it 'responds 422' do
+            api_put :update, id: property_1.property_name, product_property: { value: 'hello' }
+            expect(response.status).to eq(422)
+          end
         end
       end
 

--- a/api/spec/controllers/spree/api/v1/product_properties_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/product_properties_controller_spec.rb
@@ -86,15 +86,33 @@ module Spree
         expect(response.status).to eq(201)
       end
 
-      it "can update a product property" do
-        api_put :update, id: property_1.property_name, product_property: { value: "my value 456" }
-        expect(response.status).to eq(200)
+      context 'when product property does not exist' do
+        it 'cannot update product property and responds 404' do
+          api_put :update, id: 'does not exist', product_property: { value: 'new value' }
+          expect(response.status).to eq(404)
+        end
       end
 
-      it "can delete a product property" do
-        api_delete :destroy, id: property_1.property_name
-        expect(response.status).to eq(204)
-        expect { property_1.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      context 'when product property exists' do
+        it "can update a product property" do
+          api_put :update, id: property_1.property_name, product_property: { value: "my value 456" }
+          expect(response.status).to eq(200)
+        end
+      end
+
+      context 'when product property does not exist' do
+        it 'cannot delete product property and responds 404' do
+          api_delete :destroy, id: 'does not exist'
+          expect(response.status).to eq(404)
+        end
+      end
+
+      context 'when product property exists' do
+        it "can delete a product property" do
+          api_delete :destroy, id: property_1.property_name
+          expect(response.status).to eq(204)
+          expect { property_1.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        end
       end
     end
 


### PR DESCRIPTION
When product property id does not exist, both `PUT /products/:product_id/product_properties/:id` and `DELETE /products/:product_id/product_properties/:id` will raise exception and respond 500.

It is better to respond 404 than to raise exception.
