### PR TITLE
Add and remove extra td to sort out correct table for desgin fix

### DIFF
--- a/backend/app/views/spree/admin/variants/_autocomplete_line_items_stock.js.erb
+++ b/backend/app/views/spree/admin/variants/_autocomplete_line_items_stock.js.erb
@@ -44,7 +44,6 @@
               <td class="text-center"><%= Spree.t(:out_of_stock) %></td>
               <td class="text-center">0</td>
               <td></td>
-              <td></td>
             {{/if}}
           {{/if}}
         {{else}}

--- a/backend/app/views/spree/admin/variants/_autocomplete_stock.js.erb
+++ b/backend/app/views/spree/admin/variants/_autocomplete_stock.js.erb
@@ -39,6 +39,7 @@
             {{else}}
               <td><%= Spree.t(:out_of_stock) %></td>
               <td>0</td>
+              <td></td>
             {{/if}}
           {{/unless}}
         </tr>


### PR DESCRIPTION
Remove extra `<td>` from `_autocomplete_line_items_stock.js.erb`
Add extra `<td>` in `_autocomplete_stock.js.erb`
To completed `<td>`s required for table headers
