### PR TITLE
move Shipment.shipping_method to association

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -21,7 +21,7 @@ module Spree
     end
     has_many :shipping_methods, through: :shipping_rates
     has_one :selected_shipping_rate, -> { where(selected: true).order(:cost) }, class_name: Spree::ShippingRate
-    has_one :shipping_method, through: :selected_shipping_rate, source: :shipping_method
+    has_one :shipping_method, through: :selected_shipping_rate
 
 
     after_save :update_adjustments

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -21,6 +21,7 @@ module Spree
     end
     has_many :shipping_methods, through: :shipping_rates
     has_one :selected_shipping_rate, -> { where(selected: true).order(:cost) }, class_name: Spree::ShippingRate
+    has_one :shipping_method, through: :selected_shipping_rate, source: :shipping_method
 
 
     after_save :update_adjustments
@@ -253,10 +254,6 @@ module Spree
     def shipped=(value)
       return unless value == '1' && shipped_at.nil?
       self.shipped_at = Time.current
-    end
-
-    def shipping_method
-      selected_shipping_rate.try(:shipping_method) || shipping_rates.first.try(:shipping_method)
     end
 
     def tax_category


### PR DESCRIPTION
Following in the vein of https://github.com/spree/spree/pull/7511, this PR suggests moving Shipment.shipping_method into a model association rather than a method.

This enables handy queries like `Shipment.all.includes(:shipping_method)`, which avoids the _n_-queries problem in some use cases.

Note that the behavior here is not _exactly_ the same, as the method falls back to `shipping_rates.first.try(:shipping_method)` if `selected_shipping_rate.try(:shipping_method)` is nil.

(IMO, this is a slightly cleaner implementation, because if there’s no selected shipping rate, how can there be a selected shipping method?)
