### PR TITLE
Bumping rails version 4.2.6 to 4.2.7.1 security patch  against master

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'paranoia', '~> 2.1.0'
   s.add_dependency 'premailer-rails'
   s.add_dependency 'acts-as-taggable-on', '~> 3.4'
-  s.add_dependency 'rails', '~> 4.2.6'
+  s.add_dependency 'rails', '~> 4.2.7.1'
   s.add_dependency 'ransack', '~> 1.8.0'
   s.add_dependency 'responders'
   s.add_dependency 'state_machines-activerecord', '~> 0.2'


### PR DESCRIPTION
[CVE-2016-6317] Unsafe Query Generation Risk in Active Record

There is a vulnerability when Active Record is used in conjunction with JSON 
parameter parsing. This vulnerability has been assigned the CVE identifier 
CVE-2016-6317.  This vulnerability is similar to CVE-2012-2660, CVE-2012-2694 
and CVE-2013-0155. 
refer https://groups.google.com/forum/#!msg/rubyonrails-security/rgO20zYW33s/gmamLa-wDAAJ
https://github.com/rails/rails/commit/93ab8c2638a5a3aa3e63915a4c646effefbae0ba
