### PR TITLE
order payment_methods in checkout and admin by their position

### DIFF
--- a/backend/app/controllers/spree/admin/payment_methods_controller.rb
+++ b/backend/app/controllers/spree/admin/payment_methods_controller.rb
@@ -52,6 +52,10 @@ module Spree
 
       private
 
+      def collection
+        @collection = super.order(position: :asc)
+      end
+      
       def load_data
         @providers = Gateway.providers.sort{|p1, p2| p1.name <=> p2.name }
       end

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -5,7 +5,7 @@ module Spree
 
     DISPLAY = [:both, :front_end, :back_end].freeze
 
-    scope :active,                 -> { where(active: true) }
+    scope :active,                 -> { where(active: true).order(position: :asc) }
     scope :available,              -> { active.where(display_on: [:front_end, :back_end, :both]) }
     scope :available_on_front_end, -> { active.where(display_on: [:front_end, :both]) }
     scope :available_on_back_end,  -> { active.where(display_on: [:back_end, :both]) }


### PR DESCRIPTION
Optimized https://github.com/spree/spree/pull/7516 . Use active Scope, also shows correct order in admin.
