### PR TITLE
Add promotion rule for shipping country

### DIFF
--- a/backend/app/views/spree/admin/promotions/_promotion_rule.html.erb
+++ b/backend/app/views/spree/admin/promotions/_promotion_rule.html.erb
@@ -7,5 +7,5 @@
   <% param_prefix = "promotion[promotion_rules_attributes][#{promotion_rule.id}]" %>
   <%= hidden_field_tag "#{param_prefix}[id]", promotion_rule.id %>
 
-  <%= render partial: "spree/admin/promotions/rules/#{type_name}", locals: { promotion_rule: promotion_rule, param_prefix: param_prefix } rescue nil %>
+  <%= render partial: "spree/admin/promotions/rules/#{type_name}", locals: { promotion_rule: promotion_rule, param_prefix: param_prefix } %>
 </div>

--- a/backend/app/views/spree/admin/promotions/rules/_country.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_country.html.erb
@@ -1,0 +1,6 @@
+<div class="panel-body">
+  <div class="form-group no-marginb">
+    <%= label_tag Spree.t('country_rule.label') %>
+    <%= select_tag("#{param_prefix}[preferred_country_id]", options_for_select(Spree::Country.pluck(:name, :id), promotion_rule.preferred_country_id), { class: 'select_product form-control' }) %>
+  </div>
+</div>

--- a/core/app/models/spree/promotion/rules/country.rb
+++ b/core/app/models/spree/promotion/rules/country.rb
@@ -1,0 +1,23 @@
+# A rule to limit a promotion based on shipment country.
+module Spree
+  class Promotion
+    module Rules
+      class Country < PromotionRule
+        preference :country_id, :integer
+
+        def applicable?(promotable)
+          promotable.is_a?(Spree::Order)
+        end
+
+        def eligible?(order, options = {})
+          country_id = options[:country_id] || order.ship_address.try(:country_id)
+          unless country_id.eql?(preferred_country_id || Spree::Country.default)
+            eligibility_errors.add(:base, eligibility_error_message(:wrong_country))
+          end
+
+          eligibility_errors.empty?
+        end
+      end
+    end
+  end
+end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -612,6 +612,8 @@ en:
       FRA: France
       ITA: Italy
       US: United States of America
+    country_rule:
+      label: Choose must be shipped to this country
     coupon: Coupon
     coupon_code: Coupon code
     coupon_code_already_applied: The coupon code has already been applied to this order
@@ -1098,6 +1100,9 @@ en:
     promotion_label: 'Promotion (%{name})'
     promotion_rule: Promotion Rule
     promotion_rule_types:
+      country:
+        description: Order is shipped to proper (or default) country
+        name: Country
       first_order:
         description: Must be the customer's first order
         name: First order

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -89,7 +89,8 @@ module Spree
           Spree::Promotion::Rules::UserLoggedIn,
           Spree::Promotion::Rules::OneUsePerUser,
           Spree::Promotion::Rules::Taxon,
-          Spree::Promotion::Rules::OptionValue
+          Spree::Promotion::Rules::OptionValue,
+          Spree::Promotion::Rules::Country
         ]
       end
 

--- a/core/spec/models/spree/promotion/rules/country_spec.rb
+++ b/core/spec/models/spree/promotion/rules/country_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe Spree::Promotion::Rules::Country, type: :model do
+  let(:rule) { Spree::Promotion::Rules::Country.new }
+  let(:order) { create(:order) }
+  let(:country) { create(:country) }
+  let(:other_country) { create(:country) }
+
+  before { allow(Spree::Country).to receive(:default) { other_country.id } }
+
+  context 'preferred country is set' do
+    before { rule.preferred_country_id = country.id }
+
+    it 'should be eligible for correct country' do
+      allow(order).to receive_message_chain(:ship_address, :country_id) { country.id }
+      expect(rule).to be_eligible(order)
+    end
+
+    it 'should not be eligible for incorrect country' do
+      allow(order).to receive_message_chain(:ship_address, :country_id) { other_country.id }
+      expect(rule).not_to be_eligible(order)
+    end
+  end
+
+  context 'preferred country is not set' do
+    it 'should be eligible for default country' do
+      allow(order).to receive_message_chain(:ship_address, :country_id) { other_country.id }
+      expect(rule).to be_eligible(order)
+    end
+
+    it 'should not be eligible for incorrect country' do
+      allow(order).to receive_message_chain(:ship_address, :country_id) { country.id }
+      expect(rule).not_to be_eligible(order)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds new Promotion Rule that checks if order is shipped to proper country. If no country is set, promotion rule will take `Spree::Country.default`.
