### PR TITLE
RABL pagination fixes

### DIFF
--- a/api/app/views/spree/api/v1/countries/index.v1.rabl
+++ b/api/app/views/spree/api/v1/countries/index.v1.rabl
@@ -3,5 +3,5 @@ child(@countries => :countries) do
   attributes *country_attributes
 end
 node(:count) { @countries.count }
-node(:current_page) { params[:page] || 1 }
+node(:current_page) { params[:page].try(:to_i) || 1 }
 node(:pages) { @countries.total_pages }

--- a/api/app/views/spree/api/v1/credit_cards/index.v1.rabl
+++ b/api/app/views/spree/api/v1/credit_cards/index.v1.rabl
@@ -3,5 +3,5 @@ child(@credit_cards => :credit_cards) do
   extends "spree/api/v1/credit_cards/show"
 end
 node(:count) { @credit_cards.count }
-node(:current_page) { params[:page] || 1 }
+node(:current_page) { params[:page].try(:to_i) || 1 }
 node(:pages) { @credit_cards.total_pages }

--- a/api/app/views/spree/api/v1/orders/index.v1.rabl
+++ b/api/app/views/spree/api/v1/orders/index.v1.rabl
@@ -3,5 +3,5 @@ child(@orders => :orders) do
   extends "spree/api/v1/orders/order"
 end
 node(:count) { @orders.count }
-node(:current_page) { params[:page] || 1 }
+node(:current_page) { params[:page].try(:to_i) || 1 }
 node(:pages) { @orders.total_pages }

--- a/api/app/views/spree/api/v1/orders/mine.v1.rabl
+++ b/api/app/views/spree/api/v1/orders/mine.v1.rabl
@@ -5,5 +5,5 @@ child(@orders => :orders) do
 end
 
 node(:count) { @orders.count }
-node(:current_page) { params[:page] || 1 }
+node(:current_page) { params[:page].try(:to_i) || 1 }
 node(:pages) { @orders.total_pages }

--- a/api/app/views/spree/api/v1/payments/index.v1.rabl
+++ b/api/app/views/spree/api/v1/payments/index.v1.rabl
@@ -3,5 +3,5 @@ child(@payments => :payments) do
   attributes *payment_attributes
 end
 node(:count) { @payments.count }
-node(:current_page) { params[:page] || 1 }
+node(:current_page) { params[:page].try(:to_i) || 1 }
 node(:pages) { @payments.total_pages }

--- a/api/app/views/spree/api/v1/product_properties/index.v1.rabl
+++ b/api/app/views/spree/api/v1/product_properties/index.v1.rabl
@@ -3,5 +3,5 @@ child(@product_properties => :product_properties) do
   attributes *product_property_attributes 
 end
 node(:count) { @product_properties.count }
-node(:current_page) { params[:page] || 1 }
+node(:current_page) { params[:page].try(:to_i) || 1 }
 node(:pages) { @product_properties.total_pages }

--- a/api/app/views/spree/api/v1/products/index.v1.rabl
+++ b/api/app/views/spree/api/v1/products/index.v1.rabl
@@ -2,7 +2,7 @@ object false
 node(:count) { @products.count }
 node(:total_count) { @products.total_count }
 node(:current_page) { params[:page] ? params[:page].to_i : 1 }
-node(:per_page) { params[:per_page] || Kaminari.config.default_per_page }
+node(:per_page) { params[:per_page].try(:to_i) || Kaminari.config.default_per_page }
 node(:pages) { @products.total_pages }
 child(@products => :products) do
   extends "spree/api/v1/products/show"

--- a/api/app/views/spree/api/v1/properties/index.v1.rabl
+++ b/api/app/views/spree/api/v1/properties/index.v1.rabl
@@ -3,5 +3,5 @@ child(@properties => :properties) do
   attributes *property_attributes
 end
 node(:count) { @properties.count }
-node(:current_page) { params[:page] || 1 }
+node(:current_page) { params[:page].try(:to_i) || 1 }
 node(:pages) { @properties.total_pages }

--- a/api/app/views/spree/api/v1/return_authorizations/index.v1.rabl
+++ b/api/app/views/spree/api/v1/return_authorizations/index.v1.rabl
@@ -3,5 +3,5 @@ child(@return_authorizations => :return_authorizations) do
   attributes *return_authorization_attributes
 end
 node(:count) { @return_authorizations.count }
-node(:current_page) { params[:page] || 1 }
+node(:current_page) { params[:page].try(:to_i) || 1 }
 node(:pages) { @return_authorizations.total_pages }

--- a/api/app/views/spree/api/v1/shipments/mine.v1.rabl
+++ b/api/app/views/spree/api/v1/shipments/mine.v1.rabl
@@ -1,7 +1,7 @@
 object false
 
 node(:count) { @shipments.count }
-node(:current_page) { params[:page] || 1 }
+node(:current_page) { params[:page].try(:to_i) || 1 }
 node(:pages) { @shipments.total_pages }
 
 child(@shipments => :shipments) do

--- a/api/app/views/spree/api/v1/states/index.v1.rabl
+++ b/api/app/views/spree/api/v1/states/index.v1.rabl
@@ -9,6 +9,6 @@ end
 
 if @states.respond_to?(:total_pages)
   node(:count) { @states.count }
-  node(:current_page) { params[:page] || 1 }
+  node(:current_page) { params[:page].try(:to_i) || 1 }
   node(:pages) { @states.total_pages }
 end

--- a/api/app/views/spree/api/v1/stock_items/index.v1.rabl
+++ b/api/app/views/spree/api/v1/stock_items/index.v1.rabl
@@ -3,5 +3,5 @@ child(@stock_items => :stock_items) do
   extends 'spree/api/v1/stock_items/show'
 end
 node(:count) { @stock_items.count }
-node(:current_page) { params[:page] || 1 }
+node(:current_page) { params[:page].try(:to_i) || 1 }
 node(:pages) { @stock_items.total_pages }

--- a/api/app/views/spree/api/v1/stock_locations/index.v1.rabl
+++ b/api/app/views/spree/api/v1/stock_locations/index.v1.rabl
@@ -3,5 +3,5 @@ child(@stock_locations => :stock_locations) do
   extends 'spree/api/v1/stock_locations/show'
 end
 node(:count) { @stock_locations.count }
-node(:current_page) { params[:page] || 1 }
+node(:current_page) { params[:page].try(:to_i) || 1 }
 node(:pages) { @stock_locations.total_pages }

--- a/api/app/views/spree/api/v1/stock_movements/index.v1.rabl
+++ b/api/app/views/spree/api/v1/stock_movements/index.v1.rabl
@@ -3,5 +3,5 @@ child(@stock_movements => :stock_movements) do
   extends 'spree/api/v1/stock_movements/show'
 end
 node(:count) { @stock_movements.count }
-node(:current_page) { params[:page] || 1 }
+node(:current_page) { params[:page].try(:to_i) || 1 }
 node(:pages) { @stock_movements.total_pages }

--- a/api/app/views/spree/api/v1/taxonomies/index.v1.rabl
+++ b/api/app/views/spree/api/v1/taxonomies/index.v1.rabl
@@ -3,5 +3,5 @@ child(@taxonomies => :taxonomies) do
   extends "spree/api/v1/taxonomies/show"
 end
 node(:count) { @taxonomies.count }
-node(:current_page) { params[:page] || 1 }
+node(:current_page) { params[:page].try(:to_i) || 1 }
 node(:pages) { @taxonomies.total_pages }

--- a/api/app/views/spree/api/v1/taxons/index.v1.rabl
+++ b/api/app/views/spree/api/v1/taxons/index.v1.rabl
@@ -2,7 +2,7 @@ object false
 node(:count) { @taxons.count }
 node(:total_count) { @taxons.total_count }
 node(:current_page) { params[:page] ? params[:page].to_i : 1 }
-node(:per_page) { params[:per_page] || Kaminari.config.default_per_page }
+node(:per_page) { params[:per_page].try(:to_i) || Kaminari.config.default_per_page }
 node(:pages) { @taxons.total_pages }
 child @taxons => :taxons do
   attributes *taxon_attributes

--- a/api/app/views/spree/api/v1/users/index.v1.rabl
+++ b/api/app/views/spree/api/v1/users/index.v1.rabl
@@ -3,5 +3,5 @@ child(@users => :users) do
   extends "spree/api/v1/users/show"
 end
 node(:count) { @users.count }
-node(:current_page) { params[:page] || 1 }
+node(:current_page) { params[:page].try(:to_i) || 1 }
 node(:pages) { @users.total_pages }

--- a/api/app/views/spree/api/v1/zones/index.v1.rabl
+++ b/api/app/views/spree/api/v1/zones/index.v1.rabl
@@ -3,5 +3,5 @@ child(@zones => :zones) do
   extends 'spree/api/v1/zones/show'
 end
 node(:count) { @zones.count }
-node(:current_page) { params[:page] || 1 }
+node(:current_page) { params[:page].try(:to_i) || 1 }
 node(:pages) { @zones.total_pages }


### PR DESCRIPTION
Extracted from work on getting Spree ready for Rails 5:
- value of `per_page` node in RABL should always be returned as Integer
- value of `current_page` node in RABL should always be returned as Integer
