### PR TITLE
allow only backorderable and in stock variants in order creation from  admin end

### DIFF
--- a/api/app/views/spree/api/v1/variants/small.v1.rabl
+++ b/api/app/views/spree/api/v1/variants/small.v1.rabl
@@ -7,6 +7,7 @@ node(:options_text) { |v| v.options_text }
 node(:track_inventory) { |v| v.should_track_inventory? }
 node(:in_stock) { |v| v.in_stock? }
 node(:is_backorderable) { |v| v.is_backorderable? }
+node(:is_orderable) { |v| v.is_backorderable? || v.in_stock? }
 node(:total_on_hand) { |v| v.total_on_hand }
 node(:is_destroyed) { |v| v.destroyed? }
 

--- a/backend/app/views/spree/admin/variants/_autocomplete_line_items_stock.js.erb
+++ b/backend/app/views/spree/admin/variants/_autocomplete_line_items_stock.js.erb
@@ -13,7 +13,7 @@
       <tr>
         <td>{{variant.name}}</td>
         {{#if variant.track_inventory}}
-          {{#if variant.total_on_hand}}
+          {{#if variant.is_orderable}}
             <td class="text-center">
               {{variant.total_on_hand}}
             </td>


### PR DESCRIPTION
Currently if a variant's counts_on_hand is 0 it can't be added in order even if it is backorderable
