### PR TITLE
allow order to transit from resumed state to returned state

### DIFF
--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -62,7 +62,7 @@ module Spree
 
               event :return do
                 transition to: :returned,
-                           from: [:complete, :awaiting_return, :canceled],
+                           from: [:complete, :awaiting_return, :canceled, :resumed],
                            if: :all_inventory_units_returned?
               end
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1023,4 +1023,24 @@ describe Spree::Order, type: :model do
       it { expect(order.fully_discounted?).to eq false }
     end
   end
+
+  describe 'order transit to returned state from resumed state' do
+    let!(:resumed_order) { create(:order_with_line_items, line_items_count: 3, state: :resumed) }
+
+    context 'when all inventory_units returned' do
+      before do
+        resumed_order.inventory_units.update_all(state: 'returned')
+        resumed_order.return
+      end
+      it { expect(resumed_order).to be_returned }
+    end
+
+    context 'when some inventory_units returned' do
+      before do
+        resumed_order.inventory_units.first.update_attribute(:state, 'returned')
+        resumed_order.return
+      end
+      it { expect(resumed_order).to be_resumed }
+    end
+  end
 end


### PR DESCRIPTION
Currently, if you resume an cancel order and try to return that order it will raise an exception because transition from resumed state to returned state is not possible
