### PR TITLE
tackle I18n problem of 'state'

### DIFF
--- a/backend/app/views/spree/admin/adjustments/_adjustments_table.html.erb
+++ b/backend/app/views/spree/admin/adjustments/_adjustments_table.html.erb
@@ -8,7 +8,7 @@
       <th><%= Spree.t(:adjustable) %></th>
       <th><%= Spree.t(:description) %></th>
       <th class="text-center"><%= Spree.t(:amount) %></th>
-      <th class="text-center"><%= Spree.t(:state) %></th>
+      <th class="text-center"><%= Spree.t(:status) %></th>
       <th class="actions"></th>
     </tr>
   </thead>

--- a/backend/app/views/spree/admin/return_authorizations/_form.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/_form.html.erb
@@ -10,7 +10,7 @@
           <% end %>
         </th>
         <th><%= Spree.t(:product) %></th>
-        <th><%= Spree.t(:state) %></th>
+        <th><%= Spree.t(:status) %></th>
         <th><%= Spree.t(:charged) %></th>
         <th><%= Spree.t(:pre_tax_refund_amount) %></th>
         <th><%= Spree.t(:reimbursement_type) %></th>

--- a/backend/app/views/spree/admin/return_index/return_authorizations.html.erb
+++ b/backend/app/views/spree/admin/return_index/return_authorizations.html.erb
@@ -47,7 +47,7 @@
         <th><%= Spree.t(:created_at) %></th>
         <th><%= Spree.t(:number) %></th>
         <th><%= Spree.t(:order) %></th>
-        <th><%= Spree.t(:state) %></th>
+        <th><%= Spree.t(:status) %></th>
         <th></th>
       </tr>
     </thead>

--- a/backend/app/views/spree/admin/shared/named_types/_index.html.erb
+++ b/backend/app/views/spree/admin/shared/named_types/_index.html.erb
@@ -11,7 +11,7 @@
     <thead>
       <tr data-hook="named_types_header">
         <th><%= Spree.t(:name) %></th>
-        <th><%= Spree.t(:state) %></th>
+        <th><%= Spree.t(:status) %></th>
         <th></th>
       </tr>
     </thead>

--- a/backend/app/views/spree/admin/stock_locations/index.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/index.html.erb
@@ -11,7 +11,7 @@
     <thead>
       <tr data-hook="stock_locations_header">
         <th><%= Spree.t(:name) %></th>
-        <th><%= Spree.t(:state) %></th>
+        <th><%= Spree.t(:status) %></th>
         <th><%= Spree.t(:stock_movements) %></th>
         <th class="actions"></th>
       </tr>


### PR DESCRIPTION
it's about i18n of state, #7534

I noticed there is a _:status_, and _:state_ seems being used as _region/province_ rather than _status_ by many locales.
some example:

| locale | state | status |
| --- | --- | --- |
| :en | State | Status |
| :zh-CN | 省份 | 状态 |
| :ja | 都道府県（州） | 状況 |
| :fr | Province / Région / État | Statut |
| :de | Bundesland | Status |
| :ru | Регион/Область | Статус |
| :ko | -- | 상태 |
| :es | Provincia | Estatus |
| :it | Stato | Stato |

so I think it's better to change the miss-used status _:state_s to _:status_
