### PR TITLE
Use the current sortable's context when selecting positions for sorting

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -327,9 +327,10 @@ $(document).ready(function(){
         helper: fixHelper,
         placeholder: 'ui-sortable-placeholder',
         update: function(event, ui) {
+          var tbody = this;
           $("#progress").show();
           positions = {};
-          $.each($('table.sortable tbody tr'), function(position, obj){
+          $.each($('tr', tbody), function(position, obj){
             reg = /spree_(\w+_?)+_(\d+)/;
             parts = reg.exec($(obj).prop('id'));
             if (parts) {


### PR DESCRIPTION
Allows for multiple sortables to work on a single page.
