### PR TITLE
added unique index on spree_payment.number to avoid duplicate payment numbers

### DIFF
--- a/core/db/migrate/20160912100605_add_unique_index_on_payment_number.rb
+++ b/core/db/migrate/20160912100605_add_unique_index_on_payment_number.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexOnPaymentNumber < ActiveRecord::Migration
+  def change
+    add_index :spree_payments, :number, unique: true
+  end
+end


### PR DESCRIPTION
NumberGenerator validates uniqueness of the host model number. However, the rails uniqueness validation does not guarantee the number to be unique. We therefore ocasionally get duplicate payment numbers inserted into the database. When a model is updated, the uniqueness validator kicks in and the model will not be saved. By adding a unique index on the database, it becomes impossible to add duplicate numbers.
