### PR TITLE
added unique index on spree_payment.number to avoid duplicate payment numbers

### DIFF
--- a/core/db/migrate/20160912100605_add_unique_index_on_payment_number.rb
+++ b/core/db/migrate/20160912100605_add_unique_index_on_payment_number.rb
@@ -1,4 +1,4 @@
-class AddUniqueIndexOnPaymentNumber < ActiveRecord::Migration
+class AddUniqueIndexOnPaymentNumber < ActiveRecord::Migration[4.2]
   def change
     non_unique_number_payments = Spree::Payment.all.group("number").having("count(*) > ?", 1)
     non_unique_numbers = []

--- a/core/db/migrate/20160912100605_add_unique_index_on_payment_number.rb
+++ b/core/db/migrate/20160912100605_add_unique_index_on_payment_number.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexOnPaymentNumber < ActiveRecord::Migration
+  def change
+    add_index :spree_payments, :number, unique: true
+  end
+end

--- a/core/db/migrate/20160912100605_add_unique_index_on_payment_number.rb
+++ b/core/db/migrate/20160912100605_add_unique_index_on_payment_number.rb
@@ -1,5 +1,18 @@
 class AddUniqueIndexOnPaymentNumber < ActiveRecord::Migration
   def change
+    non_unique_number_payments = Spree::Payment.all.group("number").having("count(*) > ?", 1)
+    non_unique_numbers = []
+    non_unique_number_payments.each do |p|
+      non_unique_numbers << p.number
+    end
+
+    payments_with_non_unique_numbers = Spree::Payment.where(number: non_unique_numbers)
+    payments_with_non_unique_numbers.count.times do |i|
+      p = payments_with_non_unique_numbers[i]
+      p.number += i.to_s
+      p.save
+    end
+
     add_index :spree_payments, :number, unique: true
   end
 end


### PR DESCRIPTION
Here we go again- NumberGenerator validates uniqueness of the host model number. However, the rails uniqueness validation does not guarantee the number to be unique. By adding a unique index on the database, the data integrity is guaranteed. This pull requests sets that index, and changes non-unique payment numbers to unique ones.
