### PR TITLE
fix factory shipped_order

### DIFF
--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -81,6 +81,7 @@ FactoryGirl.define do
                 shipment.inventory_units.update_all state: 'shipped'
                 shipment.update_column('state', 'shipped')
               end
+              order.update_column('shipment_state', 'shipped')
               order.reload
             end
           end


### PR DESCRIPTION
Now it factory create order with correct state of shipments, but order.shipped? returns false
