### PR TITLE
Search for current order using guest token only (3-1-stable)

### DIFF
--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -82,10 +82,11 @@ module Spree
 
           # Find any incomplete orders for the guest_token
           incomplete_orders = Spree::Order.incomplete.includes(line_items: [variant: [:images, :option_values, :product]])
+          guest_token_order_params = current_order_params.except(:user_id)
           order = if with_adjustments
-                    incomplete_orders.includes(:adjustments).lock(options[:lock]).find_by(current_order_params)
+                    incomplete_orders.includes(:adjustments).lock(options[:lock]).find_by(guest_token_order_params)
                   else
-                    incomplete_orders.lock(options[:lock]).find_by(current_order_params)
+                    incomplete_orders.lock(options[:lock]).find_by(guest_token_order_params)
                   end
 
           # Find any incomplete orders for the current user

--- a/core/spec/lib/spree/core/controller_helpers/order_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/order_spec.rb
@@ -45,6 +45,21 @@ describe Spree::Core::ControllerHelpers::Order, type: :controller do
         expect(Spree::Order.last.store_id).to eq store.id
       end
     end
+
+    context 'gets using the guest_token' do
+      let!(:order) { create :order, user: user }
+      let!(:guest_order) { create :order, user: nil, email: nil, guest_token: 'token' }
+
+      before do
+        expect(controller).to receive(:current_order_params).and_return(
+          currency: Spree::Config[:currency], guest_token: 'token', store_id: guest_order.store_id, user_id: user.id,
+        )
+      end
+
+      specify 'without the guest token being bound to any user yet' do
+        expect(controller.current_order).to eq guest_order
+      end
+    end
   end
 
   describe '#associate_user' do


### PR DESCRIPTION
This PR fixes a bug that loses your guest order when signing in and not visiting the cart.

Expected behavior:
1. Create a user
2. Add "Product 1" with a price of $10 to the cart
3. Sign out
4. Add "Product 2" with a price of $20 to the cart
5. Checkout
6. Sign in
7. Land on the `checkout/address` page
8. See that both "Product 1" and "Product 2" is in the cart (verifying that the cart total is $30)

What we see instead is that only "Product 1" is in the cart. This is happening because when searching for an order using the `guest_token` it doesn't find it unless it has already been bound to a user. Which only happens when the user stops on the cart page.

I'm not sure where to put in a feature test for this. But the feature test below test we're using on our Spree site for regression. (We've also developed it a bit further so that instead of merging the orders it continues through the flow with only the product the user added to cart before logging in. And if they go to the cart then we will do the merge.)

/@gaqzi and @lizanys, pairing

``` ruby
# Javascript is turned on to verify that no AJAX calls trigger a merge
RSpec.describe 'Cart restoration when logging in during checkout', js: true do
  let(:create_old_order) { create :order_with_totals, user: user }
  let(:product) { create :product, price: 50 }
  let(:user) { create :user }

  def do_request(user = nil)
    visit spree.product_path(product)
    click_on 'Add To Cart'

    click_on 'Checkout'

    visit '/login'
    fill_in 'spree_user[email]', with: user.email
    fill_in 'spree_user[password]', with: user.password
    click_on 'Login'
  end

  it 'continues through the checkout flow with the added product only' do
    create_old_order
    do_request(user)

    expect(page).to have_css('[data-hook="item_total"]',
                             text: 'Item Total: $50.00',
                             wait: 10)
  end

  it 'merges any unfinished orders with the current order when going to the cart' do
    create_old_order
    do_request(user)

    visit spree.cart_path

    expect(page).to have_css('.line-item', count: 2, wait: 10)
    expect(page).to have_css('.cart-total .lead', text: '$60.00', wait: 10)
  end
end
```
