### PR TITLE
Use 3-1-stable branch for spree instead of master as master is on Spr…

### DIFF
--- a/cmd/lib/spree_cmd/templates/extension/Gemfile
+++ b/cmd/lib/spree_cmd/templates/extension/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'spree', github: 'spree/spree', branch: 'master'
+gem 'spree', github: 'spree/spree', branch: '3-1-stable'
 # Provides basic authentication functionality for testing parts of your engine
-gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: 'master'
+gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: '3-1-stable'
 
 gemspec


### PR DESCRIPTION
…ee 3.2 which causes dependency issues

Use 3-1-stable branch instead of the master branch for the creation of extensions using Spree 3.1 as master branch is on a different version(3.2.0.beta) now.
Fixes dependency issues for Spree 3.1 extensions #7633 
