### PR TITLE
Allow title separator to be customized

### DIFF
--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -29,6 +29,7 @@ module Spree
     preference :alternative_shipping_phone, :boolean, default: false # Request extra phone for ship addr
     preference :always_include_confirm_step, :boolean, default: false # Ensures confirmation step is always in checkout_progress bar, but does not force a confirm step if your payment methods do not support it.
     preference :always_put_site_name_in_title, :boolean, default: true
+    preference :title_site_name_separator, :string, default: '-' # When always_put_site_name_in_title is true, insert a separator character before the site name in the title
     preference :auto_capture, :boolean, default: false # automatically capture the credit card (as opposed to just authorize and capture later)
     preference :auto_capture_on_dispatch, :boolean, default: false # Captures payment for each shipment in Shipment#after_ship callback, and makes Shipment.ready when payment authorized.
     preference :binary_inventory_cache, :boolean, default: false # only invalidate product cache when a stock item changes whether it is in_stock

--- a/core/lib/spree/core/controller_helpers/common.rb
+++ b/core/lib/spree/core/controller_helpers/common.rb
@@ -22,7 +22,7 @@ module Spree
             title_string = @title.present? ? @title : accurate_title
             if title_string.present?
               if Spree::Config[:always_put_site_name_in_title]
-                [title_string, default_title].join(' - ')
+                [title_string, default_title].join(" #{Spree::Config[:title_site_name_separator]} ")
               else
                 title_string
               end


### PR DESCRIPTION
Companies may wish to use other types of separators for their `<title>` tags for branding purposes. This pull request keeps the default `'-'`, however it allows others to be chosen through an initializer.

Examples
```
<title>Ruby on Rails Jr. Spaghetti - Site Name</title>
<title>Ruby on Rails Jr. Spaghetti | Site Name</title>
<title>Ruby on Rails Jr. Spaghetti at Site Name</title>
<title>Ruby on Rails Jr. Spaghetti @ Site Name</title>
```
Example overriding

```
# spree.rb
Spree.config do |config|
  config.title_site_name_separator = '|'
end
```