### PR TITLE
Eager load variant and product for finding insufficient stock items.

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -404,7 +404,7 @@ module Spree
     end
 
     def insufficient_stock_lines
-      line_items.select(&:insufficient_stock?)
+      line_items.includes(variant: :product).select(&:insufficient_stock?)
     end
 
     ##

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -222,8 +222,12 @@ describe Spree::Order, type: :model do
 
   context "insufficient_stock_lines" do
     let(:line_item) { mock_model Spree::LineItem, insufficient_stock?: true }
+    let(:line_items) { [line_item] }
 
-    before { allow(order).to receive_messages(line_items: [line_item]) }
+    before do
+      allow(order).to receive_messages(line_items: line_items)
+      allow(line_items).to receive_messages(includes: line_items)
+    end
 
     it "should return line_item that has insufficient stock on hand" do
       expect(order.insufficient_stock_lines.size).to eq(1)


### PR DESCRIPTION
```line_items.select(&:insufficient_stock?)``` loads the products and variants one by one when fetching data the first time.
It can be reduced by eager loading the product and variants initially with the downside that cached query will also load them which is not required in the former case. 

before change:
1. when cache is empty
```line_items.select(&:insufficient_stock?)
  Spree::LineItem Load (0.4ms)  SELECT "spree_line_items".* FROM "spree_line_items" WHERE "spree_line_items"."order_id" = ? ORDER BY "spree_line_items"."created_at" ASC  [["order_id", 4]]
  Spree::Variant Load (0.2ms)  SELECT  "spree_variants".* FROM "spree_variants" WHERE "spree_variants"."id" = ? LIMIT ?  [["id", 1], ["LIMIT", 1]]
  Spree::Product Load (0.2ms)  SELECT  "spree_products".* FROM "spree_products" WHERE "spree_products"."id" = ? LIMIT ?  [["id", 1], ["LIMIT", 1]]
  Spree::Preference Load (0.1ms)  SELECT  "spree_preferences".* FROM "spree_preferences" WHERE "spree_preferences"."key" = ? LIMIT ?  [["key", "spree/app_configuration/track_inventory_levels"], ["LIMIT", 1]]
   (0.2ms)  SELECT SUM("spree_stock_items"."count_on_hand") FROM "spree_stock_items" INNER JOIN "spree_stock_locations" ON "spree_stock_locations"."id" = "spree_stock_items"."stock_location_id" WHERE "spree_stock_items"."deleted_at" IS NULL AND "spree_stock_items"."variant_id" = ? AND "spree_stock_locations"."active" = ?  [["variant_id", 1], ["active", true]]
  Spree::Variant Load (0.1ms)  SELECT  "spree_variants".* FROM "spree_variants" WHERE "spree_variants"."id" = ? LIMIT ?  [["id", 2], ["LIMIT", 1]]
  Spree::Product Load (0.1ms)  SELECT  "spree_products".* FROM "spree_products" WHERE "spree_products"."id" = ? LIMIT ?  [["id", 2], ["LIMIT", 1]]
   (0.1ms)  SELECT SUM("spree_stock_items"."count_on_hand") FROM "spree_stock_items" INNER JOIN "spree_stock_locations" ON "spree_stock_locations"."id" = "spree_stock_items"."stock_location_id" WHERE "spree_stock_items"."deleted_at" IS NULL AND "spree_stock_items"."variant_id" = ? AND "spree_stock_locations"."active" = ?  [["variant_id", 2], ["active", true]]
```

2. when cached
```line_items.select(&:insufficient_stock?)
  CACHE (0.0ms)  SELECT SUM("spree_stock_items"."count_on_hand") FROM "spree_stock_items" INNER JOIN "spree_stock_locations" ON "spree_stock_locations"."id" = "spree_stock_items"."stock_location_id" WHERE "spree_stock_items"."deleted_at" IS NULL AND "spree_stock_items"."variant_id" = ? AND "spree_stock_locations"."active" = ?  [["variant_id", 1], ["active", true]]
  CACHE (0.0ms)  SELECT SUM("spree_stock_items"."count_on_hand") FROM "spree_stock_items" INNER JOIN "spree_stock_locations" ON "spree_stock_locations"."id" = "spree_stock_items"."stock_location_id" WHERE "spree_stock_items"."deleted_at" IS NULL AND "spree_stock_items"."variant_id" = ? AND "spree_stock_locations"."active" = ?  [["variant_id", 2], ["active", true]]
```

after change:
1. when cache is empty
```
  Spree::LineItem Load (0.3ms)  SELECT "spree_line_items".* FROM "spree_line_items" WHERE "spree_line_items"."order_id" = ? ORDER BY "spree_line_items"."created_at" ASC  [["order_id", 4]]
  Spree::Variant Load (0.2ms)  SELECT "spree_variants".* FROM "spree_variants" WHERE "spree_variants"."deleted_at" IS NULL AND "spree_variants"."id" IN (1, 2)
  Spree::Product Load (0.2ms)  SELECT "spree_products".* FROM "spree_products" WHERE "spree_products"."deleted_at" IS NULL AND "spree_products"."id" IN (1, 2)
   (0.1ms)  SELECT SUM("spree_stock_items"."count_on_hand") FROM "spree_stock_items" INNER JOIN "spree_stock_locations" ON "spree_stock_locations"."id" = "spree_stock_items"."stock_location_id" WHERE "spree_stock_items"."deleted_at" IS NULL AND "spree_stock_items"."variant_id" = ? AND "spree_stock_locations"."active" = ?  [["variant_id", 1], ["active", true]]
   (0.1ms)  SELECT SUM("spree_stock_items"."count_on_hand") FROM "spree_stock_items" INNER JOIN "spree_stock_locations" ON "spree_stock_locations"."id" = "spree_stock_items"."stock_location_id" WHERE "spree_stock_items"."deleted_at" IS NULL AND "spree_stock_items"."variant_id" = ? AND "spree_stock_locations"."active" = ?  [["variant_id", 2], ["active", true]]
```

2. when cached
```
 CACHE (0.0ms)  SELECT "spree_line_items".* FROM "spree_line_items" WHERE "spree_line_items"."order_id" = ? ORDER BY "spree_line_items"."created_at" ASC  [["order_id", 4]]
  CACHE (0.0ms)  SELECT "spree_variants".* FROM "spree_variants" WHERE "spree_variants"."deleted_at" IS NULL AND "spree_variants"."id" IN (1, 2)
  CACHE (0.0ms)  SELECT "spree_products".* FROM "spree_products" WHERE "spree_products"."deleted_at" IS NULL AND "spree_products"."id" IN (1, 2)
  CACHE (0.0ms)  SELECT SUM("spree_stock_items"."count_on_hand") FROM "spree_stock_items" INNER JOIN "spree_stock_locations" ON "spree_stock_locations"."id" = "spree_stock_items"."stock_location_id" WHERE "spree_stock_items"."deleted_at" IS NULL AND "spree_stock_items"."variant_id" = ? AND "spree_stock_locations"."active" = ?  [["variant_id", 1], ["active", true]]
  CACHE (0.0ms)  SELECT SUM("spree_stock_items"."count_on_hand") FROM "spree_stock_items" INNER JOIN "spree_stock_locations" ON "spree_stock_locations"."id" = "spree_stock_items"."stock_location_id" WHERE "spree_stock_items"."deleted_at" IS NULL AND "spree_stock_items"."variant_id" = ? AND "spree_stock_locations"."active" = ?  [["variant_id", 2], ["active", true]]
```
