### PR TITLE
Error while reverting migration AddDiscontinuedToProductsAndVariants

### DIFF
--- a/core/db/migrate/20150819154308_add_discontinued_to_products_and_variants.rb
+++ b/core/db/migrate/20150819154308_add_discontinued_to_products_and_variants.rb
@@ -59,8 +59,8 @@ We will print out a report of the data we are fixing now: "
   end
 
   def down
-    execute "UPDATE `spree_products` SET `deleted_at` = `discontinue_on` WHERE `deleted_at` IS NULL"
-    execute "UPDATE `spree_variants` SET `deleted_at` = `discontinue_on` WHERE `deleted_at` IS NULL"
+    execute "UPDATE spree_products SET deleted_at = discontinue_on WHERE deleted_at IS NULL"
+    execute "UPDATE spree_variants SET deleted_at = discontinue_on WHERE deleted_at IS NULL"
 
     remove_column :spree_products, :discontinue_on
     remove_column :spree_variants, :discontinue_on


### PR DESCRIPTION
Remove backticks from table name and column names

This resolves the following issue https://github.com/spree/spree/issues/7679