### PR TITLE
Show Spree version in Admin Panel

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_sidebar.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_sidebar.scss
@@ -71,6 +71,13 @@
       }
     }
   }
+
+  .spree-version {
+    position: absolute;
+    z-index: -1;
+    left: 15px;
+    bottom: 15px;
+  }
 }
 
 #wrapper.sidebar-minimized #main-sidebar {

--- a/backend/app/views/spree/admin/shared/_main_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_main_menu.html.erb
@@ -39,3 +39,9 @@
     <%= main_menu_tree Spree.t(:configurations), icon: "wrench", sub_menu: "configuration", url: "#sidebar-configuration" %>
   </ul>
 <% end %>
+
+<% if can? :admin, current_store && Spree::Config[:admin_show_version] %>
+  <div class="spree-version hidden-xs hidden-sm">
+    <%= Spree.version %>
+  </div>
+<% end %>

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -24,6 +24,7 @@ module Spree
     preference :admin_interface_logo, :string, default: 'logo/spree_50.png'
     preference :admin_path, :string, default: '/admin'
     preference :admin_products_per_page, :integer, default: 10
+    preference :admin_show_version, :boolean, default: true
     preference :allow_checkout_on_gateway_error, :boolean, default: false
     preference :allow_guest_checkout, :boolean, default: true
     preference :alternative_shipping_phone, :boolean, default: false # Request extra phone for ship addr

--- a/guides/content/release_notes/3_2_0.md
+++ b/guides/content/release_notes/3_2_0.md
@@ -118,3 +118,14 @@ You can view the full changes using [Github Compare](https://github.com/spree/sp
 * Fixed API pagination `per_page` and `current_page` values (now always returned as integer)
 
     [Spark Solutions](https://github.com/spree/spree/pull/7550)
+
+* Display Spree version in Admin Panel
+
+    [Spark Solutions](https://github.com/spree/spree/pull/7685)
+
+    By default, it's displayed only for Admin users who can manage the current Store, but can be disabled altogether by changing preferences:
+
+    ```
+    Spree::Config[:admin_show_version] = false
+    ```
+    in `config/initializers/spree.rb`


### PR DESCRIPTION
Can be easily turned off, visible only for admin users who can manage Store

<img width="694" alt="screen shot 2016-11-16 at 3 36 07 pm" src="https://cloud.githubusercontent.com/assets/55154/20351267/6e6354f6-ac12-11e6-8427-c97292ecb9f3.png">
