### PR TITLE
Fixes for discontinue_on in admin product index.

### DIFF
--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -105,6 +105,7 @@ module Spree
         return @collection if @collection.present?
         params[:q] ||= {}
         params[:q][:deleted_at_null] ||= "1"
+        params[:q][:discontinue_on_null] ||= "1"
 
         params[:q][:s] ||= "name asc"
         @collection = super

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -115,7 +115,7 @@ module Spree
     alias :options :product_option_types
 
     self.whitelisted_ransackable_associations = %w[stores variants_including_master master variants]
-    self.whitelisted_ransackable_attributes = %w[description name slug]
+    self.whitelisted_ransackable_attributes = %w[description name slug discontinue_on]
 
     # the master variant is not a member of the variants array
     def has_variants?


### PR DESCRIPTION
- Fixes an issue where admin index is not filtering by whether a product is discontinued.
- Fixes an issue where the admin product index isn't filtering out discontinued products by default.

Issue: https://github.com/spree/spree/issues/7365#issuecomment-259929611
Request for PR: https://github.com/spree/spree/pull/7683#issuecomment-260943729