### PR TITLE
Add type while removing column to enable rollback

### DIFF
--- a/core/db/migrate/20130917024658_remove_promotions_event_name_field.rb
+++ b/core/db/migrate/20130917024658_remove_promotions_event_name_field.rb
@@ -1,5 +1,5 @@
 class RemovePromotionsEventNameField < ActiveRecord::Migration[4.2]
   def change
-    remove_column :spree_promotions, :event_name
+    remove_column :spree_promotions, :event_name, :string
   end
 end


### PR DESCRIPTION
Add type while removing the column to avoid the following error

> remove_column is only reversible if given a type.