### PR TITLE
fix/rounding reimbursement total down

### DIFF
--- a/core/app/models/spree/reimbursement.rb
+++ b/core/app/models/spree/reimbursement.rb
@@ -88,7 +88,7 @@ module Spree
     def calculated_total
       # rounding every return item individually to handle edge cases for consecutive partial
       # returns where rounding might cause us to try to reimburse more than was originally billed
-      return_items.map { |ri| ri.total.to_d.round(2) }.sum
+      return_items.map { |ri| ri.total.to_d.round(3) }.sum.round(2)
     end
 
     def paid_amount

--- a/core/spec/models/spree/reimbursement_spec.rb
+++ b/core/spec/models/spree/reimbursement_spec.rb
@@ -145,6 +145,19 @@ describe Spree::Reimbursement, type: :model do
       end
     end
 
+    context 'with return item amounts that should round down' do
+      let(:reimbursement) { create(:reimbursement, return_items_count: 3) }
+      let(:total) { (111.0000 + 5.84671) * 3 }
+
+      before do
+        reimbursement.return_items.each { |ri| ri.update_attributes(pre_tax_amount: 111.00, additional_tax_total: 5.84671) }
+      end
+
+      it 'rounds down' do
+        expect(reimbursement.calculated_total).to eq total.round(2)
+      end
+    end
+
     context 'with a return item amount that should round up' do
       let(:reimbursement) { Spree::Reimbursement.new }
 


### PR DESCRIPTION
- According to approximate numbers basics we should always use more digits than we would like to have in sum.