### PR TITLE
Fix page title in admin/promotion_categories (master)

### DIFF
--- a/backend/app/views/spree/admin/promotion_categories/new.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= link_to Spree.t(:promotion_categories), spree.admin_promotion_categories_url %> /
+  <%= link_to plural_resource_name(Spree::PromotionCategory), spree.admin_promotion_categories_url %> /
   <%= Spree.t(:new_promotion_category) %>
 <% end %>
 


### PR DESCRIPTION
The title was using a nonexistent locale key, causing a translation missing error: "translation missing: en.spree.promotion_categories".

Fixed using the plural_resource_name helper.