### PR TITLE
Fix trailing whitespace in labels

### DIFF
--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -191,8 +191,8 @@ module Spree
 
       def create_label
         label = ""
-        label << (name.present? ? name : tax_category.name) + " "
-        label << (show_rate_in_label? ? "#{amount * 100}%" : "")
+        label << (name.present? ? name : tax_category.name)
+        label << (show_rate_in_label? ? " #{amount * 100}%" : "")
         label << " (#{Spree.t(:included_in_price)})" if included_in_price?
         label
       end


### PR DESCRIPTION
The label logic in 2-4-stable would append a space whether or not it displayed the amount. This corrects that behavior to only include the space if we are going to be showing the amount.