### PR TITLE
Fix shipment issues and optimise shipment modules (3-1-stable)

### DIFF
--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -14,6 +14,7 @@ module Spree
 
     scope :backordered, -> { where state: 'backordered' }
     scope :on_hand, -> { where state: 'on_hand' }
+    scope :on_hand_or_backordered, -> { where state: ['backordered', 'on_hand'] }
     scope :shipped, -> { where state: 'shipped' }
     scope :returned, -> { where state: 'returned' }
     scope :backordered_per_variant, ->(stock_item) do

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -489,6 +489,11 @@ module Spree
     def create_proposed_shipments
       all_adjustments.shipping.delete_all
       shipments.destroy_all
+
+      # Inventory Units which are not associated to any shipment (unshippable)
+      # and are not returned or shipped should be deleted
+      inventory_units.on_hand_or_backordered.delete_all
+
       self.shipments = Spree::Stock::Coordinator.new(self).shipments
     end
 

--- a/core/app/models/spree/stock/adjuster.rb
+++ b/core/app/models/spree/stock/adjuster.rb
@@ -3,11 +3,12 @@
 module Spree
   module Stock
     class Adjuster
-      attr_accessor :inventory_unit, :status, :fulfilled
+      attr_accessor :inventory_unit, :status, :fulfilled, :package
 
-      def initialize(inventory_unit, status)
+      def initialize(inventory_unit, status, package=nil)
         @inventory_unit = inventory_unit
         @status = status
+        @package = package
         @fulfilled = false
       end
 
@@ -17,6 +18,12 @@ module Spree
         else
           self.fulfilled = true
         end
+      end
+
+      def reassign(status, package)
+        @fulfilled = false
+        @status = status
+        @package = package
       end
 
       def fulfilled?

--- a/core/app/models/spree/stock/coordinator.rb
+++ b/core/app/models/spree/stock/coordinator.rb
@@ -1,11 +1,12 @@
 module Spree
   module Stock
     class Coordinator
-      attr_reader :order, :inventory_units
+      attr_reader :order, :inventory_units, :allocated_inventory_units
 
       def initialize(order, inventory_units = nil)
         @order = order
         @inventory_units = inventory_units || InventoryUnitBuilder.new(order).units
+        @allocated_inventory_units = []
       end
 
       def shipments
@@ -22,7 +23,9 @@ module Spree
 
       def build_packages(packages = Array.new)
         stock_locations_with_requested_variants.each do |stock_location|
-          packages += build_packer(stock_location, inventory_units).packages
+          packer = build_packer(stock_location, unallocated_inventory_units)
+          packages += packer.packages
+          @allocated_inventory_units += packer.allocated_inventory_units
         end
 
         packages
@@ -30,9 +33,13 @@ module Spree
 
       private
 
+      def unallocated_inventory_units
+        inventory_units - allocated_inventory_units
+      end
+
       def stock_locations_with_requested_variants
         Spree::StockLocation.active.joins(:stock_items).
-          where(spree_stock_items: { variant_id: requested_variant_ids })
+          where(spree_stock_items: { variant_id: requested_variant_ids }).uniq
       end
 
       def requested_variant_ids

--- a/core/app/models/spree/stock/coordinator.rb
+++ b/core/app/models/spree/stock/coordinator.rb
@@ -47,7 +47,7 @@ module Spree
       end
 
       def prioritize_packages(packages)
-        prioritizer = Prioritizer.new(inventory_units, packages)
+        prioritizer = Prioritizer.new(packages)
         prioritizer.prioritized_packages
       end
 

--- a/core/app/models/spree/stock/inventory_unit_builder.rb
+++ b/core/app/models/spree/stock/inventory_unit_builder.rb
@@ -10,7 +10,7 @@ module Spree
           line_item.quantity.times.map do |i|
             @order.inventory_units.build(
               pending: true,
-              variant: line_item.variant,
+              variant_id: line_item.variant_id,
               line_item: line_item,
               order: @order
             )

--- a/core/app/models/spree/stock/packer.rb
+++ b/core/app/models/spree/stock/packer.rb
@@ -1,12 +1,13 @@
 module Spree
   module Stock
     class Packer
-      attr_reader :stock_location, :inventory_units, :splitters
+      attr_reader :stock_location, :inventory_units, :splitters, :allocated_inventory_units
 
       def initialize(stock_location, inventory_units, splitters=[Splitter::Base])
         @stock_location = stock_location
         @inventory_units = inventory_units
         @splitters = splitters
+        @allocated_inventory_units = []
       end
 
       def packages
@@ -19,23 +20,32 @@ module Spree
 
       def default_package
         package = Package.new(stock_location)
-        inventory_units.group_by(&:variant).each do |variant, variant_inventory_units|
+
+        # Group by variant_id as grouping by variant fires cached query.
+        inventory_units.group_by(&:variant_id).each do |variant_id, variant_inventory_units|
+          variant = Spree::Variant.find(variant_id)
           units = variant_inventory_units.clone
           if variant.should_track_inventory?
             next unless stock_location.stock_item(variant)
 
             on_hand, backordered = stock_location.fill_status(variant, units.size)
-            package.add_multiple units.slice!(0, on_hand), :on_hand if on_hand > 0
-            package.add_multiple units.slice!(0, backordered), :backordered if backordered > 0
+            on_hand_units, backordered_units = units.slice!(0, on_hand), units.slice!(0, backordered)
+
+            package.add_multiple on_hand_units, :on_hand if on_hand > 0
+            package.add_multiple backordered_units, :backordered if backordered > 0
+
+            @allocated_inventory_units += (on_hand_units + backordered_units)
           else
             package.add_multiple units
+            @allocated_inventory_units += units
           end
-
         end
+
         package
       end
 
       private
+
       def build_splitter
         splitter = nil
         splitters.reverse.each do |klass|

--- a/core/app/models/spree/stock/packer.rb
+++ b/core/app/models/spree/stock/packer.rb
@@ -24,10 +24,11 @@ module Spree
         # Group by variant_id as grouping by variant fires cached query.
         inventory_units.group_by(&:variant_id).each do |variant_id, variant_inventory_units|
           variant = Spree::Variant.find(variant_id)
-          units = variant_inventory_units.clone
-          if variant.should_track_inventory?
-            next unless stock_location.stock_item(variant)
+          next unless stock_location.stock_item(variant)
 
+          units = variant_inventory_units.clone
+
+          if variant.should_track_inventory?
             on_hand, backordered = stock_location.fill_status(variant, units.size)
             on_hand_units, backordered_units = units.slice!(0, on_hand), units.slice!(0, backordered)
 

--- a/core/app/models/spree/stock/splitter/shipping_category.rb
+++ b/core/app/models/spree/stock/splitter/shipping_category.rb
@@ -14,7 +14,7 @@ module Spree
         def split_by_category(package)
           categories = Hash.new { |hash, key| hash[key] = [] }
           package.contents.each do |item|
-            categories[item.variant.shipping_category_id] << item
+            categories[shipping_category_for(item)] << item
           end
           hash_to_packages(categories)
         end
@@ -25,6 +25,11 @@ module Spree
             packages << build_package(contents)
           end
           packages
+        end
+
+        def shipping_category_for(item)
+          @item_shipping_category ||= {}
+          @item_shipping_category[item.inventory_unit.variant_id] ||= item.variant.shipping_category_id
         end
       end
     end

--- a/core/spec/models/spree/inventory_unit_spec.rb
+++ b/core/spec/models/spree/inventory_unit_spec.rb
@@ -4,6 +4,33 @@ describe Spree::InventoryUnit, :type => :model do
   let(:stock_location) { create(:stock_location_with_items) }
   let(:stock_item) { stock_location.stock_items.order(:id).first }
 
+  describe 'scopes' do
+    let!(:inventory_unit_1) { create(:inventory_unit, state: 'on_hand') }
+    let!(:inventory_unit_2) { create(:inventory_unit, state: 'backordered') }
+    let!(:inventory_unit_3) { create(:inventory_unit, state: 'shipped') }
+    let!(:inventory_unit_4) { create(:inventory_unit, state: 'returned') }
+
+    describe '.backordered' do
+      it { expect(Spree::InventoryUnit.backordered).to eq([inventory_unit_2]) }
+    end
+
+    describe '.on_hand' do
+      it { expect(Spree::InventoryUnit.on_hand).to eq([inventory_unit_1]) }
+    end
+
+    describe '.on_hand_or_backordered' do
+      it { expect(Spree::InventoryUnit.on_hand_or_backordered).to eq([inventory_unit_1, inventory_unit_2]) }
+    end
+
+    describe '.shipped' do
+      it { expect(Spree::InventoryUnit.shipped).to eq([inventory_unit_3]) }
+    end
+
+    describe '.returned' do
+      it { expect(Spree::InventoryUnit.returned).to eq([inventory_unit_4]) }
+    end
+  end
+
   context "#backordered_for_stock_item" do
     let(:order) do
       order = create(:order, state: 'complete', ship_address: create(:ship_address))

--- a/core/spec/models/spree/stock/coordinator_spec.rb
+++ b/core/spec/models/spree/stock/coordinator_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module Spree
   module Stock
     describe Coordinator, :type => :model do
-      let!(:order) { create(:order_with_line_items) }
+      let(:order) { create(:order_with_line_items) }
 
       subject { Coordinator.new(order) }
 
@@ -34,8 +34,18 @@ module Spree
       end
 
       context "build packages" do
+        let!(:stock_location1) { create(:stock_location, backorderable_default: false) }
+        let!(:stock_location2) { create(:stock_location, backorderable_default: false) }
+        let!(:product) { create(:product) }
+
+        let!(:order) do
+          product.stock_items.map { |stock_item| stock_item.adjust_count_on_hand(1) }
+          line_item = create(:line_item, product: product, quantity: 2)
+          line_item.order
+        end
+
         it "builds a package for every stock location" do
-          subject.packages.count == StockLocation.count
+          expect(subject.build_packages.count).to eq(StockLocation.count)
         end
 
         context "missing stock items in stock location" do

--- a/core/spec/models/spree/stock/package_spec.rb
+++ b/core/spec/models/spree/stock/package_spec.rb
@@ -64,13 +64,11 @@ module Spree
         method2   = create(:shipping_method)
         method1.shipping_categories = [category1, category2]
         method2.shipping_categories = [category1]
-        variant1 = mock_model(Variant, shipping_category: category1)
-        variant2 = mock_model(Variant, shipping_category: category2)
-        variant3 = mock_model(Variant, shipping_category: nil)
-        contents = [ContentItem.new(build(:inventory_unit, variant: variant1)),
-                    ContentItem.new(build(:inventory_unit, variant: variant1)),
-                    ContentItem.new(build(:inventory_unit, variant: variant2)),
-                    ContentItem.new(build(:inventory_unit, variant: variant3))]
+        variant1 = create(:product, shipping_category: category1).master
+        variant2 = create(:product, shipping_category: category2).master
+        contents = [ContentItem.new(build(:inventory_unit, variant_id: variant1.id)),
+                    ContentItem.new(build(:inventory_unit, variant_id: variant1.id)),
+                    ContentItem.new(build(:inventory_unit, variant_id: variant2.id))]
 
         package = Package.new(stock_location, contents)
         expect(package.shipping_methods).to eq([method1])
@@ -104,16 +102,6 @@ module Spree
         expect(last_unit.state).to eq 'backordered'
 
         expect(shipment.shipping_method).to eq shipping_method
-      end
-
-      it 'does not add an inventory unit to a package twice' do
-        # since inventory units currently don't have a quantity
-        unit = build_inventory_unit
-        subject.add unit
-        subject.add unit
-        expect(subject.quantity).to eq 1
-        expect(subject.contents.first.inventory_unit).to eq unit
-        expect(subject.contents.first.quantity).to eq 1
       end
 
       describe "#add_multiple" do

--- a/core/spec/models/spree/stock/prioritizer_spec.rb
+++ b/core/spec/models/spree/stock/prioritizer_spec.rb
@@ -30,7 +30,7 @@ module Spree
         end
 
         packages = [package1]
-        prioritizer = Prioritizer.new(inventory_units, packages)
+        prioritizer = Prioritizer.new(packages)
         packages = prioritizer.prioritized_packages
         expect(packages.size).to eq 1
       end
@@ -47,7 +47,7 @@ module Spree
         end
 
         packages = [package1, package2]
-        prioritizer = Prioritizer.new(inventory_units, packages)
+        prioritizer = Prioritizer.new(packages)
         packages = prioritizer.prioritized_packages
         expect(packages.size).to eq 1
       end
@@ -61,7 +61,7 @@ module Spree
         end
 
         packages = [package1, package2]
-        prioritizer = Prioritizer.new(inventory_units, packages)
+        prioritizer = Prioritizer.new(packages)
         packages = prioritizer.prioritized_packages
         expect(packages.size).to eq 2
       end
@@ -77,7 +77,7 @@ module Spree
         end
 
         packages = [package1, package2]
-        prioritizer = Prioritizer.new(inventory_units, packages)
+        prioritizer = Prioritizer.new(packages)
         packages = prioritizer.prioritized_packages
         expect(packages.count).to eq 2
         expect(packages[0].quantity).to eq 2
@@ -95,7 +95,7 @@ module Spree
         end
 
         packages = [package1, package2]
-        prioritizer = Prioritizer.new(inventory_units, packages)
+        prioritizer = Prioritizer.new(packages)
         packages = prioritizer.prioritized_packages
 
         expect(packages[0].quantity(:backordered)).to eq 3
@@ -113,7 +113,7 @@ module Spree
         end
 
         packages = [package1, package2]
-        prioritizer = Prioritizer.new(inventory_units, packages)
+        prioritizer = Prioritizer.new(packages)
         packages = prioritizer.prioritized_packages
         expect(packages[0]).to eq package2
         expect(packages[1]).to be_nil

--- a/core/spec/models/spree/stock/splitter/shipping_category_spec.rb
+++ b/core/spec/models/spree/stock/splitter/shipping_category_spec.rb
@@ -5,8 +5,8 @@ module Spree
     module Splitter
       describe ShippingCategory, :type => :model do
 
-        let(:variant1) { build(:variant) }
-        let(:variant2) { build(:variant) }
+        let(:variant1) { create(:variant) }
+        let(:variant2) { create(:variant) }
         let(:shipping_category_1) { create(:shipping_category, name: 'A') }
         let(:shipping_category_2) { create(:shipping_category, name: 'B') }
 


### PR DESCRIPTION
Refer PR #7222 

Fixes 2 shipment issues, and optimises shipment modules like Coordinator, Prioritizer, Packer etc..

**Issue 1**
- Scenario: A product has 2 stock items for 2 stock locations. Each stock item has 1 quantity on hand and none is backorderable. User adds 2 quantity of that item in cart and moves to delivery step. Sees a shipment and an unshippable unit.
- Expected: User should see 2 shipments (no unshippable unit) each having 1 associated inventory unit.

**Issue 2**
- In `order#create_proposed_shipments`, inventory units are destroyed using shipments `has_many inventory_units, dependent: :delete_all` association but units which are not associated to any shipment (like unshippable units) are never destroyed.
