### PR TITLE
Eliminate existing card payment source when paying with store credit

### DIFF
--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -169,6 +169,7 @@ module Spree
 
         # Remove other payment method parameters.
         params[:order].delete(:payments_attributes)
+        params[:order].delete(:existing_card)
         params.delete(:payment_source)
 
         # Return to the Payments page if additional payment is needed.


### PR DESCRIPTION
Fixes #7732

Added three specs to cover partial payment with store credit, full payment w/ additional payment attrs, and full payment with existing card submission.