### PR TITLE
Proper spree version dependency in extension generator

### DIFF
--- a/cmd/lib/spree_cmd/templates/extension/extension.gemspec
+++ b/cmd/lib/spree_cmd/templates/extension/extension.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '~> <%= spree_version %>'
+  s.add_dependency 'spree_core', '>= <%= spree_version %>', '< 4.0'
 
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'coffee-rails'


### PR DESCRIPTION
We're changing how extensions dependencies work. Previously you had to match extension branch to Spree branch. Starting from now master branch of all `spree-contrib` extensions should work with Spree >= `3.1` and <`4.0`. More at https://github.com/spree/spree/blob/master/guides/content/release_notes/3_2_0.md