### PR TITLE
acts_as_list index starts from 1

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -334,7 +334,7 @@ $(document).ready(function(){
             reg = /spree_(\w+_?)+_(\d+)/;
             parts = reg.exec($(obj).prop('id'));
             if (parts) {
-              positions['positions['+parts[2]+']'] = position;
+              positions['positions['+parts[2]+']'] = position+1;
             }
           });
           $.ajax({


### PR DESCRIPTION
(Identified in older version of spree . Fix made to solidus fork at https://github.com/solidusio/solidus/commit/ad403748a4a9167f5b13d99134fbd7baebe1b2b9 )
Javascript is sending indices starting from 0. 

acts_as_list has top_of_list defaulted as 1 - Source: https://github.com/swanandp/acts_as_list/blob/master/lib/acts_as_list/active_record/acts/list.rb#L38

Steps to reproduce the Issue: 
1. Go to images under product. 
2. Take any element after the 1st one to the top. 
3. Edit the one at the top (that was just dragged)
4. Coming back to the index page shows it in the 2nd position. 

What is happening in the frontend?
1. Javascript sends the indices starting 0. 
2. The update_positions method in resource_controller just sets the positions as they were sent (with more stuff going on)
3. When element in the 0th position is modified. acts_as_list figures 1 is the top of the list and sets the value to 1 along with setting anything which is already in position 1 to 0. 

This fix will not modify existing positions, but will only fix those resources for new updates.

Another solution could be to set the configuration for all models which use acts_as_list to top_of_list: 0 which could be an alternative solution which fixes this issue from re-occurring in the first place.