### PR TITLE
Guides: Make API collection pagination clearer

### DIFF
--- a/guides/content/api/summary.md
+++ b/guides/content/api/summary.md
@@ -58,8 +58,10 @@ The following are some simple rules that all Spree API endpoints comply with.
 3. Both create and update requests will return Spree\'s representation of the data upon success.
 4. If a create or update request fails, a status code of 422 will be returned, with a hash containing an \"error\" key, and an \"errors\" key. The errors value will contain all ActiveRecord validation errors encountered when saving this record.
 5. Delete requests will return status of 200, and no content.
-6. Requests that list collections, such as /api/v1/products are paginated and will return 25 records per page.
-7. Requests that list collections can be paginated through by passing a 0-based page parameter (page=0 will return first 25 products).
+6. Requests that list collections, such as `/api/v1/products` are paginated and
+   will return 25 records per page. You can speficy your own `per_page` value.
+7. Requests that list collections can be paginated through by passing a 0-based
+   `page` parameter (`page=0` will return first 25 products).
 8. If a resource can not be found, the API will return a status of 404.
 9. Unauthorized requests will be met with a 401 response.
 

--- a/guides/content/api/summary.md
+++ b/guides/content/api/summary.md
@@ -60,8 +60,8 @@ The following are some simple rules that all Spree API endpoints comply with.
 5. Delete requests will return status of 200, and no content.
 6. Requests that list collections, such as `/api/v1/products` are paginated and
    will return 25 records per page. You can speficy your own `per_page` value.
-7. Requests that list collections can be paginated through by passing a 0-based
-   `page` parameter (`page=0` will return first 25 products).
+7. Requests that list collections can be paginated through by passing a `page`
+   parameter, `page=1` being the first page.
 8. If a resource can not be found, the API will return a status of 404.
 9. Unauthorized requests will be met with a 401 response.
 

--- a/guides/content/api/summary.md
+++ b/guides/content/api/summary.md
@@ -58,8 +58,8 @@ The following are some simple rules that all Spree API endpoints comply with.
 3. Both create and update requests will return Spree\'s representation of the data upon success.
 4. If a create or update request fails, a status code of 422 will be returned, with a hash containing an \"error\" key, and an \"errors\" key. The errors value will contain all ActiveRecord validation errors encountered when saving this record.
 5. Delete requests will return status of 200, and no content.
-6. Requests that list collections, such as /api/v1/products will return a limited result set back.
-7. Requests that list collections can be paginated through by passing a page parameter that is a number greater than 0.
+6. Requests that list collections, such as /api/v1/products are paginated and will return 25 records per page.
+7. Requests that list collections can be paginated through by passing a 0-based page parameter (page=0 will return first 25 products).
 8. If a resource can not be found, the API will return a status of 404.
 9. Unauthorized requests will be met with a 401 response.
 


### PR DESCRIPTION
* The docs didn't mention how many records are shown per page
* The docs stated that specific page number should be higher than zero.
   I updated the docs to say that `page=1` is the first page.