### PR TITLE
Fix for #7801: added ransackable_association for product_property

### DIFF
--- a/api/spec/controllers/spree/api/v1/product_properties_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/product_properties_controller_spec.rb
@@ -48,6 +48,15 @@ module Spree
       expect(json_response['product_properties'].first['value']).to eq property.value
     end
 
+    it "can search for product properties" do
+      product.product_properties.create(property_name: "Shirt Size")
+      product.product_properties.create(property_name: "Shirt Weight")
+      api_get :index, q: { property_name_cont: "size" }
+      expect(json_response["product_properties"].first['property_name']).to eq('Shirt Size')
+      expect(json_response["product_properties"].first).to have_attributes(attributes)
+      expect(json_response["count"]).to eq(1)
+    end
+
     it "can see a single product_property" do
       api_get :show, id: property_1.property_name
       expect(json_response).to have_attributes(attributes)

--- a/core/app/models/spree/product_property.rb
+++ b/core/app/models/spree/product_property.rb
@@ -14,6 +14,7 @@ module Spree
     default_scope { order(:position) }
 
     self.whitelisted_ransackable_attributes = ['value']
+    self.whitelisted_ransackable_associations = ['property']
 
     # virtual attributes for use with AJAX completion stuff
     delegate :name, to: :property, prefix: true, allow_nil: true

--- a/core/spec/models/spree/product_property_spec.rb
+++ b/core/spec/models/spree/product_property_spec.rb
@@ -19,4 +19,8 @@ describe Spree::ProductProperty, type: :model do
       expect(@pp.property.name).to eq('Size')
     end
   end
+
+  context 'ransackable_associations' do
+    it { expect(Spree::ProductProperty.whitelisted_ransackable_associations).to include('property') }
+  end
 end


### PR DESCRIPTION
#7801 
Whitelisted property associations on product_property for ransack search, allows product.product_properties.ransack to return the valid result.