### PR TITLE
fix(variant): Add unscoped method to activerecord query

### DIFF
--- a/core/db/migrate/20161014145148_add_created_at_to_variant.rb
+++ b/core/db/migrate/20161014145148_add_created_at_to_variant.rb
@@ -2,7 +2,7 @@ class AddCreatedAtToVariant < ActiveRecord::Migration[5.0]
   def change
     add_column :spree_variants, :created_at, :datetime
     Spree::Variant.reset_column_information
-    Spree::Variant.where.not(updated_at: nil).update_all('created_at = updated_at')
-    Spree::Variant.where(updated_at: nil).update_all(created_at: Time.current, updated_at: Time.current)
+    Spree::Variant.unscoped.where.not(updated_at: nil).update_all('created_at = updated_at')
+    Spree::Variant.unscoped.where(updated_at: nil).update_all(created_at: Time.current, updated_at: Time.current)
   end
 end


### PR DESCRIPTION
[Variants `act_as_paranoid`](https://github.com/spree/spree/blob/master/core/app/models/spree/variant.rb#L3). This fixes the issue of migration failure if the db has any variants where `deleted_at IS NOT NULL`.