### PR TITLE
use SecureRandom for number generator

### DIFF
--- a/core/db/migrate/20170219132415_add_unique_index_to_number_fields.rb
+++ b/core/db/migrate/20170219132415_add_unique_index_to_number_fields.rb
@@ -1,14 +1,20 @@
-class AddUniqueIndexToNumberFields < ActiveRecord::Migration
+class AddUniqueIndexToNumberFields < ActiveRecord::Migration[5.0]
   def change
     remove_index :spree_orders, :number
     add_index :spree_orders, :number, :unique => true
-    remove_index :spree_payments, name: :index_spree_payments_on_number if index_name_exists?(:spree_payments, :index_spree_payments_on_number, nil)
+    if index_name_exists?(:spree_payments, :index_spree_payments_on_number, nil)
+      remove_index :spree_payments, name: :index_spree_payments_on_number
+    end
     add_index :spree_payments, :number, :unique => true
     add_index :spree_reimbursements, :number, :unique => true
     add_index :spree_return_authorizations, :number, :unique => true
-    remove_index :spree_shipments, name: :index_shipments_on_number if index_name_exists?(:spree_shipments, :index_shipments_on_number, nil)
+    if index_name_exists?(:spree_shipments, :index_shipments_on_number, nil)
+      remove_index :spree_shipments, name: :index_shipments_on_number
+    end
     add_index :spree_shipments, :number, :unique => true
-    remove_index :spree_stock_transfers, :number if index_exists?(:spree_stock_transfers, :number)
+    if index_exists?(:spree_stock_transfers, :number)
+      remove_index :spree_stock_transfers, :number
+    end
     add_index :spree_stock_transfers, :number, :unique => true
   end
 end

--- a/core/db/migrate/20170219132415_add_unique_index_to_number_fields.rb
+++ b/core/db/migrate/20170219132415_add_unique_index_to_number_fields.rb
@@ -1,13 +1,14 @@
 class AddUniqueIndexToNumberFields < ActiveRecord::Migration
   def change
     remove_index :spree_orders, :number
-    add_index :spree_orders, :number, unique: true
-    add_index :spree_payments, :number, unique: true
-    add_index :spree_reimbursements, :number, unique: true
-    add_index :spree_return_authorizations, :number, unique: true
-    remove_index :spree_shipments, name: :index_shipments_on_number
-    add_index :spree_shipments, :number, unique: true
-    remove_index :spree_stock_transfers, :number
-    add_index :spree_stock_transfers, :number, unique: true
+    add_index :spree_orders, :number, :unique => true
+    remove_index :spree_payments, name: :index_spree_payments_on_number if index_name_exists?(:spree_payments, :index_spree_payments_on_number, nil)
+    add_index :spree_payments, :number, :unique => true
+    add_index :spree_reimbursements, :number, :unique => true
+    add_index :spree_return_authorizations, :number, :unique => true
+    remove_index :spree_shipments, name: :index_shipments_on_number if index_name_exists?(:spree_shipments, :index_shipments_on_number, nil)
+    add_index :spree_shipments, :number, :unique => true
+    remove_index :spree_stock_transfers, :number if index_exists?(:spree_stock_transfers, :number)
+    add_index :spree_stock_transfers, :number, :unique => true
   end
 end

--- a/core/db/migrate/20170219132415_add_unique_index_to_number_fields.rb
+++ b/core/db/migrate/20170219132415_add_unique_index_to_number_fields.rb
@@ -1,6 +1,6 @@
 class AddUniqueIndexToNumberFields < ActiveRecord::Migration
   def change
-    remove_index spree_orders: :number
+    remove_index :spree_orders, :number
     add_index :spree_orders, :number, unique: true
     add_index :spree_payments, :number, unique: true
     add_index :spree_reimbursements, :number, unique: true

--- a/core/db/migrate/20170219132415_add_unique_index_to_number_fields.rb
+++ b/core/db/migrate/20170219132415_add_unique_index_to_number_fields.rb
@@ -1,13 +1,13 @@
 class AddUniqueIndexToNumberFields < ActiveRecord::Migration
   def change
-    remove_index :spree_orders, :number
-    add_index :spree_orders, :number, :unique => true
-    add_index :spree_payments, :number, :unique => true
-    add_index :spree_reimbursements, :number, :unique => true
-    add_index :spree_return_authorizations, :number, :unique => true
+    remove_index spree_orders: :number
+    add_index :spree_orders, :number, unique: true
+    add_index :spree_payments, :number, unique: true
+    add_index :spree_reimbursements, :number, unique: true
+    add_index :spree_return_authorizations, :number, unique: true
     remove_index :spree_shipments, name: :index_shipments_on_number
-    add_index :spree_shipments, :number, :unique => true
+    add_index :spree_shipments, :number, unique: true
     remove_index :spree_stock_transfers, :number
-    add_index :spree_stock_transfers, :number, :unique => true
+    add_index :spree_stock_transfers, :number, unique: true
   end
 end

--- a/core/db/migrate/20170219132415_add_unique_index_to_number_fields.rb
+++ b/core/db/migrate/20170219132415_add_unique_index_to_number_fields.rb
@@ -1,0 +1,13 @@
+class AddUniqueIndexToNumberFields < ActiveRecord::Migration
+  def change
+    remove_index :spree_orders, :number
+    add_index :spree_orders, :number, :unique => true
+    add_index :spree_payments, :number, :unique => true
+    add_index :spree_reimbursements, :number, :unique => true
+    add_index :spree_return_authorizations, :number, :unique => true
+    remove_index :spree_shipments, name: :index_shipments_on_number
+    add_index :spree_shipments, :number, :unique => true
+    remove_index :spree_stock_transfers, :number
+    add_index :spree_stock_transfers, :number, :unique => true
+  end
+end

--- a/core/lib/spree/core/number_generator.rb
+++ b/core/lib/spree/core/number_generator.rb
@@ -1,18 +1,13 @@
 module Spree
   module Core
     class NumberGenerator < Module
-      BASE           = 10
       DEFAULT_LENGTH = 9
-      NUMBERS        = (0..9).to_a.freeze
-      LETTERS        = ('A'..'Z').to_a.freeze
-
-      attr_accessor :prefix, :length
 
       def initialize(options)
         @random     = Random.new
         @prefix     = options.fetch(:prefix)
         @length     = options.fetch(:length, DEFAULT_LENGTH)
-        @candidates = NUMBERS + (options[:letters] ? LETTERS : [])
+        @letters    = options[:letters]
       end
 
       def included(host)
@@ -35,17 +30,13 @@ module Spree
       def generate_permalink(host)
         length = @length
 
-        loop do
-          candidate = new_candidate(length)
-          return candidate unless host.exists?(number: candidate)
-
-          # If over half of all possible options are taken add another digit.
-          length += 1 if host.count > Rational(BASE**length, 2)
+        candidate = @letters ? 36 : 10
+        number = loop do
+          random_token = SecureRandom.random_number(candidate**length).to_s(candidate).rjust(length, "0")
+          break random_token unless host.exists?(number: random_token)
         end
-      end
 
-      def new_candidate(length)
-        @prefix + length.times.map { @candidates.sample(random: @random) }.join
+        return @prefix + number
       end
     end # Permalink
   end # Core

--- a/core/lib/spree/core/number_generator.rb
+++ b/core/lib/spree/core/number_generator.rb
@@ -32,7 +32,7 @@ module Spree
 
         candidate = @letters ? 36 : 10
         number = loop do
-          random_token = SecureRandom.random_number(candidate**length).to_s(candidate).rjust(length, "0")
+          random_token = SecureRandom.random_number(candidate**length).to_s(candidate).rjust(length, '0')
           break random_token unless host.exists?(number: random_token)
         end
 

--- a/core/lib/spree/core/number_generator.rb
+++ b/core/lib/spree/core/number_generator.rb
@@ -36,7 +36,7 @@ module Spree
           break random_token unless host.exists?(number: random_token)
         end
 
-        return @prefix + number
+        @prefix + number
       end
     end # Permalink
   end # Core

--- a/core/lib/spree/core/number_generator.rb
+++ b/core/lib/spree/core/number_generator.rb
@@ -1,7 +1,11 @@
+
 module Spree
   module Core
     class NumberGenerator < Module
+      BASE           = 10      
       DEFAULT_LENGTH = 9
+
+      attr_accessor :prefix, :length
 
       def initialize(options)
         @random     = Random.new
@@ -30,14 +34,20 @@ module Spree
       def generate_permalink(host)
         length = @length
 
-        candidate = @letters ? 36 : 10
-        number = loop do
-          random_token = SecureRandom.random_number(candidate**length).to_s(candidate).rjust(length, '0')
-          break random_token unless host.exists?(number: random_token)
+        loop do
+          candidate = new_candidate(length)
+          return candidate unless host.exists?(number: candidate)
+          
+          # If over half of all possible options are taken add another digit.
+          length += 1 if host.count > Rational(BASE**length, 2)
         end
 
-        @prefix + number
       end
+
+      def new_candidate(length)
+        characters = @letters ? 36 : 10
+        @prefix + SecureRandom.random_number(characters**length).to_s(characters).rjust(length, '0')
+      end      
     end # Permalink
   end # Core
 end # Spree


### PR DESCRIPTION
I encounter this issue last week.
https://github.com/spree/spree/issues/6719

There are two things should be fixed.

using sample() with random seed may get into concurrency issue when two threads create number at the same time (at exactly the same millisecond may have the same random seed).
It would be better to use SecureRandom instead.

Also, according to this article https://makandracards.com/makandra/13901-understand-and-fix-race-conditions-with-duplicate-unique-keys-in-rails-mysql  
 I believe it's mandatory to add unique index to all "number" fields. 