### PR TITLE
Greatly decrease change for collisions when generating a random number

### DIFF
--- a/core/lib/spree/core/number_generator.rb
+++ b/core/lib/spree/core/number_generator.rb
@@ -45,6 +45,7 @@ module Spree
       end
 
       def new_candidate(length)
+        @candidates.shuffle!
         @prefix + length.times.map { @candidates.sample(random: @random) }.join
       end
     end # Permalink


### PR DESCRIPTION
We have been getting collisions on generated numbers (eg payment and shipment). After this fix this problem was gone. See issue #7822.