### PR TITLE
Add customer returns and reimbursements to api #7770

### DIFF
--- a/api/app/controllers/spree/api/v1/customer_returns_controller.rb
+++ b/api/app/controllers/spree/api/v1/customer_returns_controller.rb
@@ -1,0 +1,27 @@
+module Spree
+  module Api
+    module V1
+      class CustomerReturnsController < Spree::Api::BaseController
+
+        def index
+          collection(Spree::CustomerReturn)
+          respond_with(@collection)
+        end
+
+        private
+
+        def collection(resource)
+          return @collection if @collection.present?
+          params[:q] ||= {}
+
+          @collection = resource.all
+          # @search needs to be defined as this is passed to search_form_for
+          @search = @collection.ransack(params[:q])
+          per_page = params[:per_page] || Spree::Config[:admin_customer_returns_per_page]
+          @collection = @search.result.order(created_at: :desc).page(params[:page]).per(per_page)
+        end
+
+      end
+    end
+  end
+end

--- a/api/app/controllers/spree/api/v1/customer_returns_controller.rb
+++ b/api/app/controllers/spree/api/v1/customer_returns_controller.rb
@@ -17,8 +17,7 @@ module Spree
           @collection = resource.all
           # @search needs to be defined as this is passed to search_form_for
           @search = @collection.ransack(params[:q])
-          per_page = params[:per_page] || Spree::Config[:admin_customer_returns_per_page]
-          @collection = @search.result.order(created_at: :desc).page(params[:page]).per(per_page)
+          @collection = @search.result.order(created_at: :desc).page(params[:page]).per(params[:per_page])
         end
 
       end

--- a/api/app/controllers/spree/api/v1/customer_returns_controller.rb
+++ b/api/app/controllers/spree/api/v1/customer_returns_controller.rb
@@ -2,7 +2,6 @@ module Spree
   module Api
     module V1
       class CustomerReturnsController < Spree::Api::BaseController
-
         def index
           collection(Spree::CustomerReturn)
           respond_with(@collection)
@@ -19,7 +18,6 @@ module Spree
           @search = @collection.ransack(params[:q])
           @collection = @search.result.order(created_at: :desc).page(params[:page]).per(params[:per_page])
         end
-
       end
     end
   end

--- a/api/app/controllers/spree/api/v1/reimbursements_controller.rb
+++ b/api/app/controllers/spree/api/v1/reimbursements_controller.rb
@@ -1,0 +1,27 @@
+module Spree
+  module Api
+    module V1
+      class ReimbursementsController < Spree::Api::BaseController
+
+        def index
+          collection(Spree::Reimbursement)
+          respond_with(@collection)
+        end
+
+        private
+        
+        def collection(resource)
+          return @collection if @collection.present?
+          params[:q] ||= {}
+
+          @collection = resource.all
+          # @search needs to be defined as this is passed to search_form_for
+          @search = @collection.ransack(params[:q])
+          per_page = params[:per_page] || Spree::Config[:admin_customer_returns_per_page]
+          @collection = @search.result.order(created_at: :desc).page(params[:page]).per(per_page)
+        end
+      end
+    end
+  end
+end
+

--- a/api/app/controllers/spree/api/v1/reimbursements_controller.rb
+++ b/api/app/controllers/spree/api/v1/reimbursements_controller.rb
@@ -17,8 +17,7 @@ module Spree
           @collection = resource.all
           # @search needs to be defined as this is passed to search_form_for
           @search = @collection.ransack(params[:q])
-          per_page = params[:per_page] || Spree::Config[:admin_customer_returns_per_page]
-          @collection = @search.result.order(created_at: :desc).page(params[:page]).per(per_page)
+          @collection = @search.result.order(created_at: :desc).page(params[:page]).per(params[:per_page])
         end
       end
     end

--- a/api/app/controllers/spree/api/v1/reimbursements_controller.rb
+++ b/api/app/controllers/spree/api/v1/reimbursements_controller.rb
@@ -2,14 +2,13 @@ module Spree
   module Api
     module V1
       class ReimbursementsController < Spree::Api::BaseController
-
         def index
           collection(Spree::Reimbursement)
           respond_with(@collection)
         end
 
         private
-        
+
         def collection(resource)
           return @collection if @collection.present?
           params[:q] ||= {}
@@ -23,4 +22,3 @@ module Spree
     end
   end
 end
-

--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -30,7 +30,8 @@ module Spree
         :stock_item_attributes,
         :promotion_attributes,
         :store_attributes,
-        :tag_attributes
+        :tag_attributes,
+        :customer_return_attributes
       ]
 
       mattr_reader *ATTRIBUTES
@@ -163,6 +164,8 @@ module Spree
       ]
 
       @@tag_attributes = [:id, :name]
+
+      @@customer_return_attributes = [:id, :number, :order_id, :fully_reimbursed?, :pre_tax_total, :created_at, :updated_at]
 
       def variant_attributes
         if @current_user_roles && @current_user_roles.include?("admin")

--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -31,7 +31,8 @@ module Spree
         :promotion_attributes,
         :store_attributes,
         :tag_attributes,
-        :customer_return_attributes
+        :customer_return_attributes,
+        :reimbursement_attributes
       ]
 
       mattr_reader *ATTRIBUTES
@@ -165,7 +166,15 @@ module Spree
 
       @@tag_attributes = [:id, :name]
 
-      @@customer_return_attributes = [:id, :number, :order_id, :fully_reimbursed?, :pre_tax_total, :created_at, :updated_at]
+      @@customer_return_attributes = [
+        :id, :number, :order_id, :fully_reimbursed?, :pre_tax_total,
+        :created_at, :updated_at
+      ]
+
+      @@reimbursement_attributes = [
+        :id, :reimbursement_status, :customer_return_id, :order_id,
+        :number, :total, :created_at, :updated_at
+      ]
 
       def variant_attributes
         if @current_user_roles && @current_user_roles.include?("admin")

--- a/api/app/views/spree/api/v1/customer_returns/index.v1.rabl
+++ b/api/app/views/spree/api/v1/customer_returns/index.v1.rabl
@@ -1,0 +1,7 @@
+object false
+child(@collection => :customer_returns) do
+  attributes *customer_return_attributes
+end
+node(:count) { @collection.count }
+node(:current_page) { params[:page].try(:to_i) || 1 }
+node(:pages) { @collection.total_pages }

--- a/api/app/views/spree/api/v1/reimbursements/index.v1.rabl
+++ b/api/app/views/spree/api/v1/reimbursements/index.v1.rabl
@@ -1,0 +1,7 @@
+object false
+child(@collection => :reimbursements) do
+  attributes *reimbursement_attributes
+end
+node(:count) { @collection.count }
+node(:current_page) { params[:page].try(:to_i) || 1 }
+node(:pages) { @collection.total_pages }

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -3,6 +3,8 @@ Spree::Core::Engine.add_routes do
     namespace :v1 do
       resources :promotions, only: [:show]
 
+      resources :customer_returns, only: [:index]
+
       resources :products do
         resources :images
         resources :variants

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -4,6 +4,7 @@ Spree::Core::Engine.add_routes do
       resources :promotions, only: [:show]
 
       resources :customer_returns, only: [:index]
+      resources :reimbursements, only: [:index]
 
       resources :products do
         resources :images

--- a/api/spec/controllers/spree/api/v1/customer_returns_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/customer_returns_controller_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+module Spree
+  describe Api::V1::CustomerReturnsController, type: :controller do
+    render_views
+
+    before do
+      stub_authentication!
+      @customer_return = create(:customer_return)
+    end
+
+    describe '#index' do
+      let(:order)           { customer_return.order }
+      let(:customer_return) { create(:customer_return) }
+
+      before do
+        api_get :index
+      end
+ 
+      it 'loads customer returns' do
+        expect(response.status).to eq(200)
+        expect(json_response['count']).to eq(1)
+      end
+    end
+  end
+end
+

--- a/api/spec/controllers/spree/api/v1/reimbursements_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/reimbursements_controller_spec.rb
@@ -22,4 +22,3 @@ module Spree
     end
   end
 end
-

--- a/api/spec/controllers/spree/api/v1/reimbursements_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/reimbursements_controller_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+module Spree
+  describe Api::V1::ReimbursementsController, type: :controller do
+    render_views
+
+    before do
+      stub_authentication!
+    end
+
+    describe '#index' do
+      let!(:reimbursement)   { create(:reimbursement) }
+
+      before do
+        api_get :index
+      end
+ 
+      it 'loads reimbursements' do
+        expect(response.status).to eq(200)
+        expect(json_response['count']).to eq(1)
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
Reimbursements are available with **/api/v1/reimbursements** path.
Customer Returns are available with **/api/v1/customer_returns** path.

Also all ransack queries are acceptable.

#7770