### PR TITLE
[WIP] Fix: invalid value for BigDecimal() exception in Ruby 2.4.0

### DIFF
--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -113,13 +113,7 @@ module Spree
     alias display_amount money
 
     def amount=(amount)
-      self[:amount] =
-        case amount
-        when String
-          separator = I18n.t('number.currency.format.separator')
-          number    = amount.delete("^0-9-#{separator}\.").tr(separator, '.')
-          number.to_d if number.present?
-        end || amount
+      self[:amount] = Spree::LocalizedNumber.parse!(amount)
     end
 
     def offsets_total

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -113,7 +113,15 @@ module Spree
     alias display_amount money
 
     def amount=(amount)
-      self[:amount] = Spree::LocalizedNumber.parse!(amount)
+      self[:amount] =
+        case amount
+        when String
+          begin
+            Spree::LocalizedNumber.parse!(amount)
+          rescue ArgumentError
+            nil
+          end
+        end || amount
     end
 
     def offsets_total

--- a/core/lib/spree/localized_number.rb
+++ b/core/lib/spree/localized_number.rb
@@ -1,21 +1,29 @@
 module Spree
   class LocalizedNumber
 
-    # Strips all non-price-like characters from the number, taking into account locale settings.
-    def self.parse(number)
-      return number unless number.is_a?(String)
+    class << self
+      # Strips all non-price-like characters from the number, taking into account locale settings.
+      def parse!(number, default = nil)
+        return number unless number.is_a?(String)
 
-      separator, delimiter = I18n.t([:'number.currency.format.separator', :'number.currency.format.delimiter'])
-      non_number_characters = /[^0-9\-#{separator}]/
+        separator, delimiter = I18n.t([:'number.currency.format.separator', :'number.currency.format.delimiter'])
+        non_number_characters = /[^0-9\-#{separator}#{delimiter}]/
 
-      # work on a copy, prevent original argument modification
-      number = number.dup
-      # strip everything else first, including thousands delimiter
-      number.gsub!(non_number_characters, '')
-      # then replace the locale-specific decimal separator with the standard separator if necessary
-      number.gsub!(separator, '.') unless separator == '.'
+        # work on a copy, prevent original argument modification
+        number = number.dup
+        # strip everything else first, including thousands delimiter
+        number.gsub!(non_number_characters, '')
+        # then replace the locale-specific decimal separator with the standard separator if necessary
+        number.gsub!(separator, '.') unless separator == '.'
 
-      number.to_d
+        number.to_d
+      rescue ArgumentError
+        return default
+      end
+
+      def parse(string)
+        parse!(string, 0)
+      end
     end
 
   end

--- a/core/lib/spree/localized_number.rb
+++ b/core/lib/spree/localized_number.rb
@@ -2,12 +2,13 @@ module Spree
   class LocalizedNumber
 
     class << self
+
       # Strips all non-price-like characters from the number, taking into account locale settings.
-      def parse!(number, default = nil)
+      def parse!(number)
         return number unless number.is_a?(String)
 
-        separator, delimiter = I18n.t([:'number.currency.format.separator', :'number.currency.format.delimiter'])
-        non_number_characters = /[^0-9\-#{separator}#{delimiter}]/
+        separator = I18n.t(:'number.currency.format.separator')
+        non_number_characters = /[^0-9\-#{separator}]/
 
         # work on a copy, prevent original argument modification
         number = number.dup
@@ -17,13 +18,14 @@ module Spree
         number.gsub!(separator, '.') unless separator == '.'
 
         number.to_d
-      rescue ArgumentError
-        return default
       end
 
-      def parse(string)
-        parse!(string, 0)
+      def parse(number)
+        parse!(number)
+      rescue ArgumentError
+        return 0.0.to_d
       end
+
     end
 
   end

--- a/core/spec/lib/spree/localized_number_spec.rb
+++ b/core/spec/lib/spree/localized_number_spec.rb
@@ -14,6 +14,12 @@ describe Spree::LocalizedNumber do
       I18n.enforce_available_locales = true
     end
 
+    context "with an empty string" do
+      it "returns 0" do
+        expect(subject.class.parse("")).to eql 0
+      end
+    end
+
     context "with decimal point" do
       it "captures the proper amount for a formatted price" do
         expect(subject.class.parse('1,599.99')).to eql 1599.99


### PR DESCRIPTION
With the change in the BigDecimal library included in Ruby 2.4.0 explained [here](https://github.com/ruby/bigdecimal/issues/51), parsing of invalid prices raised `ArgumentError`s in Spree. This change updates `Spree::LocalizedNumber` class so it properly handles invalid numbers.

The previous implementation of BigDecimal defaulted to the value 0 on invalid strings, so the `parse` method will still return a 0 in those cases. I've added a `parse!` method that returns `nil` for the cases we don't want to do such assumption.

I've also updated the class Spree::Payment so it now uses the same parser for the amount than Spree::Product, which IMHO is more consistent.