### PR TITLE
stop Number Generation producing collisions

### DIFF
--- a/core/lib/spree/core/number_generator.rb
+++ b/core/lib/spree/core/number_generator.rb
@@ -45,6 +45,7 @@ module Spree
       end
 
       def new_candidate(length)
+        @candidates.shuffle!
         @prefix + length.times.map { @candidates.sample(random: @random) }.join
       end
     end # Permalink

--- a/core/spec/lib/spree/core/number_generator_spec.rb
+++ b/core/spec/lib/spree/core/number_generator_spec.rb
@@ -44,6 +44,7 @@ describe Spree::Core::NumberGenerator do
 
   shared_examples_for 'duplicate without length increment' do
     before do
+      allow_any_instance_of(Array).to receive(:shuffle!).and_return(self)
       expect(random).to receive(:rand).
         with(expected_rand_limit).
         and_return(next_candidate_index).
@@ -59,6 +60,7 @@ describe Spree::Core::NumberGenerator do
     let(:resource) { model.new }
 
     before do
+      allow_any_instance_of(Array).to receive(:shuffle!).and_return(self)
       expect(random).to receive(:rand).
         with(expected_rand_limit).
         and_return(first_candidate_index).
@@ -101,6 +103,7 @@ describe Spree::Core::NumberGenerator do
         let(:next_candidate) { next_candidate_high           }
 
         before do
+          allow_any_instance_of(Array).to receive(:shuffle!).and_return(self)
           expect(random).to receive(:rand).
             with(expected_rand_limit).
             and_return(next_candidate_index).


### PR DESCRIPTION
The problem was reported in #7822; the number generator sometimes creates nummers that collide. After this fix we have not experienced this problem again.

As discussed in #7824, i'm going for an Array.shuffle! as it maintains continuity to the existing structure. I have also not included migrations to make the database fields for number unique (as was included in #7815) as that might not be backwards compatible for users that update their spree version. I'm not sure how to solve that, as that migration would have to change numbers from existing collisions, but at the same time it is not desirable to change the identifier of order/payments/shipments.