### PR TITLE
Guide: API: Update API line items docs

### DIFF
--- a/guides/content/api/line_items.md
+++ b/guides/content/api/line_items.md
@@ -29,7 +29,9 @@ This request will update the line item with the ID of 1 for the order, updating 
 ### Response
 
 <%= headers 200 %>
-<%= json(:line_item) %>
+<%= json(:line_item) do |h|
+  h.merge({ "quantity" => 1 })
+end %>
 
 ## Delete
 
@@ -40,4 +42,3 @@ To delete a line item, make a request like this:
 ### Response
 
 <%= headers 204 %>
-


### PR DESCRIPTION
Here the small fix was enough. Just to ensure that updated line item's quantity is the same as described in the perceding sentence.

