### PR TITLE
Guide: API: Update shipments docs

### DIFF
--- a/guides/content/api/shipments.md
+++ b/guides/content/api/shipments.md
@@ -29,10 +29,12 @@ per_page
 
 <%= headers 200 %>
 <%= json(:shipment) do |h|
-{ count: 25,
+{
+  shipments: [h],
+  count: 25,
   current_page: 1,
-  pages: 5,
-  shipments: [h] }
+  pages: 5
+}
 end %>
 
 ## Create
@@ -48,7 +50,7 @@ The following attributes are required when creating a shipment:
 To create a shipment, make a request like this:
 
 ```text
-POST /api/v1/shipments?shipment[order_id]=R1234567```
+POST /api/v1/shipments?shipment[order_id]=R123456789```
 
 The `order_id` is the number of the order to create a shipment for and is provided as part of the URL string as shown above. The shipment will be created at the selected stock location and include the variant selected.
 
@@ -58,12 +60,12 @@ Assuming in this instance that you want to create a shipment with a stock_locati
   order_id: 123456,
   stock_location_id: 1,
   variant_id: 10
- %>
+%>
 
 ### Response
 
 <%= headers 200 %>
-<%= json(:shipment) %>
+<%= json(:shipment_small) %>
 
 ## Update
 
@@ -74,19 +76,14 @@ To update shipment information, make a request like this:
 ```text
 PUT /api/v1/shipments/H123456789?shipment[tracking]=TRK9000```
 
-### Parameters
-
-unlock
-: When set to `yes`, the shipment's adjustment will be recalculated.
-
 To update order ship method inspect order/shipments/shipping_rates for available shipping_rate_id values and use following api call:
 
-    PUT /api/v1/shipments/H123456789?shipment[selected_shipping_rate_id]=162&shipment[unlock]=yes
+    PUT /api/v1/shipments/H123456789?shipment[selected_shipping_rate_id]=1
 
 ### Response
 
 <%= headers 200 %>
-<%= json(:shipment) %>
+<%= json(:shipment_small) %>
 
 ## Ready
 
@@ -103,7 +100,9 @@ You may choose to update shipment attributes with this request as well:
 ### Response
 
 <%= headers 200 %>
-<%= json(:shipment) %>
+<%= json(:shipment_small) do |h|
+  h.merge("state" => "ready")
+end %>
 
 ## Ship
 
@@ -120,7 +119,9 @@ You may choose to update shipment attributes with this request as well:
 ### Response
 
 <%= headers 200 %>
-<%= json(:shipment_shipped) %>
+<%= json(:shipment_small) do |h|
+  h.merge("state" => "shipped")
+end %>
 
 ## Add Variant
 
@@ -128,12 +129,20 @@ You may choose to update shipment attributes with this request as well:
 
 To add a variant to a shipment, make a request like this:
 
-    PUT /api/v1/shipments/H123456789/add?variant_id=1&quantity=1
+    PUT /api/v1/shipments/H123456789/add
+
+<%= json \
+  order_id: 123456,
+  stock_location_id: 1,
+  variant_id: 10
+%>
+
+
 
 ### Response
 
 <%= headers 200 %>
-<%= json(:shipment) %>
+<%= json(:shipment_small) %>
 
 ## Remove Variant
 
@@ -146,4 +155,4 @@ To remove a variant from a shipment, make a request like this:
 ### Response
 
 <%= headers 200 %>
-<%= json(:shipment) %>
+<%= json(:shipment_small) %>

--- a/guides/lib/resources.rb
+++ b/guides/lib/resources.rb
@@ -217,7 +217,7 @@ module Spree
 
     VARIANT ||=
        {
-         "id"=>1,
+          "id"=>1,
           "name"=>"Ruby on Rails Tote",
           "sku"=>"ROR-00011",
           "price"=>"15.99",
@@ -501,6 +501,8 @@ module Spree
         "shipping_categories" => [SHIPPING_CATEGORY]
       }
 
+    SHIPPING_METHOD_SMALL ||= SHIPPING_METHOD.select{ |k| %w(id name zones shipping_categories).include?(k)}
+
     SHIPPING_RATE ||=
       {
         "id"=>1,
@@ -512,22 +514,95 @@ module Spree
         "display_cost"=>"$5.00"
       }
 
-    MANIFEST ||=
-      {
-        "variant_id"=>1,
-        "quantity"=>1,
-        "states"=>{"on_hand"=>1}
-      }
-
     INVENTORY_UNIT ||=
       {
         "id"=>1,
-        "lock_version"=>1,
         "state"=>"on_hand",
-        "variant_id"=>10,
+        "variant_id"=>1,
         "shipment_id"=>1,
-        "return_authorization_id"=>nil
+        "variant"=>VARIANT,
+        "line_item"=>LINE_ITEM.reject{ |k| %w(variant adjustments).include?(k) }
       }
+
+  CHECKOUT_STEPS ||= ["address,", "delivery", "complete"]
+
+  ORDER ||=
+    {
+      "id"=>1,
+      "number"=>"R335381310",
+      "item_total"=>"100.0",
+      "total"=>"100.0",
+      "ship_total"=>"0.0",
+      "state"=>"cart",
+      "adjustment_total"=>"-12.0",
+      "user_id"=>nil,
+      "created_at"=>"2012-10-24T01:02:25Z",
+      "updated_at"=>"2012-10-24T01:02:25Z",
+      "completed_at"=>nil,
+      "payment_total"=>"0.0",
+      "shipment_state"=>nil,
+      "payment_state"=>nil,
+      "email"=>nil,
+      "special_instructions"=>nil,
+      "channel"=>"spree",
+      "included_tax_total"=>"0.0",
+      "additional_tax_total"=>"0.0",
+      "display_included_tax_total"=>"$0.0",
+      "display_additional_tax_total"=>"$0.0",
+      "tax_total"=>"0.0",
+      "currency"=>"USD",
+      "considered_risky"=>false,
+      "canceler_id"=>nil,
+      "display_item_total"=>"$100.00",
+      "total_quantity"=>1,
+      "display_total"=>"$100.00",
+      "display_ship_total"=>"$0.00",
+      "display_tax_total"=>"$0.00",
+      "display_adjustment_total": "$0.00",
+      "token"=> "abcdef123456",
+      "checkout_steps"=> CHECKOUT_STEPS
+    }
+
+    ADDRESS_COUNTRY ||=
+      {
+        "id"=>1,
+        "iso_name"=>"UNITED STATES",
+        "iso"=>"US",
+        "iso3"=>"USA",
+        "name"=>"United States",
+        "numcode"=>1
+      }
+
+    ADDRESS_STATE ||=
+      {
+        "id"=>1,
+        "name"=>"New York",
+        "abbr"=>"NY",
+        "country_id"=>1
+      }
+
+    ADDRESS ||=
+      {
+        "id"=>1,
+        "firstname"=>"Spree",
+        "lastname"=>"Commerce",
+        "full_name"=>"Spree Commerce",
+        "address1"=>"1 Someplace Lane",
+        "address2"=>"Suite 1",
+        "city"=>"Bethesda",
+        "zipcode"=>"16804",
+        "phone"=>"123.4567.890",
+        "company"=>nil,
+        "alternative_phone"=>nil,
+        "country_id"=>1,
+        "state_id"=>1,
+        "state_name"=>nil,
+        "state_text"=>"NY",
+        "country"=> ADDRESS_COUNTRY,
+        "state" => ADDRESS_STATE
+      }
+
+    COUNTRY_STATE ||= { "state"=> ADDRESS_STATE }
 
     SHIPMENT ||=
       {
@@ -537,13 +612,38 @@ module Spree
         "cost"=>"5.0",
         "shipped_at"=>nil,
         "state"=>"pending",
-        "shipping_rates"=>[SHIPPING_RATE],
         "selected_shipping_rate"=>SHIPPING_RATE,
-        "shipping_methods"=> [SHIPPING_METHOD],
-        "manifest"=>[MANIFEST],
-        "adjustments"=>[],
-        "order_id"=>"R1234567",
-        "stock_location_name"=>"NY Warehouse"
+        "inventory_units"=>[INVENTORY_UNIT],
+        "order"=>ORDER.merge({
+                               "state"=>"payment",
+                               "bill_address"=>ADDRESS,
+                               "ship_address"=>ADDRESS,
+                               "adjustments"=>[],
+                               "payments"=>[PAYMENT]
+                            })
+      }
+
+    MANIFEST ||=
+      {
+        "variant"=> VARIANT,
+        "quantity"=>1,
+        "states"=>{"on_hand"=>1}
+      }
+
+    SHIPMENT_SMALL ||=
+      {
+        "id"=>1,
+        "tracking"=>nil,
+        "number"=>"H71047039332",
+        "cost"=>"5.0",
+        "shipped_at"=>nil,
+        "state"=>"pending",
+        "shipping_rates"=>[SHIPPING_RATE],
+        "selected_shipping_rate"=>[SHIPPING_RATE],
+        "shipping_methods"=>[SHIPPING_METHOD],
+        "manifest"=> [MANIFEST],
+        "order_id"=> 1,
+        "stock_location_name"=>"default"
       }
 
     SHIPMENT_SHIPPED ||=
@@ -559,45 +659,6 @@ module Spree
         "shipping_rates"=>[SHIPPING_RATE],
         "shipping_method"=> SHIPPING_METHOD,
         "manifest"=>[MANIFEST]
-      }
-
-    CHECKOUT_STEPS ||= ["address,", "delivery", "complete"]
-
-    ORDER ||=
-      {
-        "id"=>1,
-        "number"=>"R335381310",
-        "item_total"=>"100.0",
-        "total"=>"100.0",
-        "ship_total"=>"0.0",
-        "state"=>"cart",
-        "adjustment_total"=>"-12.0",
-        "user_id"=>nil,
-        "created_at"=>"2012-10-24T01:02:25Z",
-        "updated_at"=>"2012-10-24T01:02:25Z",
-        "completed_at"=>nil,
-        "payment_total"=>"0.0",
-        "shipment_state"=>nil,
-        "payment_state"=>nil,
-        "email"=>nil,
-        "special_instructions"=>nil,
-        "channel"=>"spree",
-        "included_tax_total"=>"0.0",
-        "additional_tax_total"=>"0.0",
-        "display_included_tax_total"=>"$0.0",
-        "display_additional_tax_total"=>"$0.0",
-        "tax_total"=>"0.0",
-        "currency"=>"USD",
-        "considered_risky"=>false,
-        "canceler_id"=>nil,
-        "display_item_total"=>"$100.00",
-        "total_quantity"=>1,
-        "display_total"=>"$100.00",
-        "display_ship_total"=>"$0.00",
-        "display_tax_total"=>"$0.00",
-        "display_adjustment_total": "$0.00",
-        "token"=> "abcdef123456",
-        "checkout_steps"=> CHECKOUT_STEPS
       }
 
     NEW_ORDER ||= {
@@ -821,45 +882,6 @@ module Spree
     ORDER_SHOW_COMPLETE_STATE ||= ORDER.merge({
       "state" => "complete"
     })
-
-    ADDRESS_COUNTRY ||=
-      {
-        "id"=>1,
-        "iso_name"=>"UNITED STATES",
-        "iso"=>"US",
-        "iso3"=>"USA",
-        "name"=>"United States",
-        "numcode"=>1
-      }
-
-    ADDRESS_STATE ||=
-      {
-        "abbr"=>"NY",
-        "country_id"=>1,
-        "id"=>1,
-        "name"=>"New York"
-      }
-
-    ADDRESS ||=
-      {
-        "id"=>1,
-        "firstname"=>"Spree",
-        "lastname"=>"Commerce",
-        "address1"=>"1 Someplace Lane",
-        "address2"=>"Suite 1",
-        "city"=>"Bethesda",
-        "zipcode"=>"16804",
-        "phone"=>"123.4567.890",
-        "company"=>nil,
-        "alternative_phone"=>nil,
-        "country_id"=>1,
-        "state_id"=>1,
-        "state_name"=>nil,
-        "country"=> ADDRESS_COUNTRY,
-        "state" => ADDRESS_STATE
-      }
-
-    COUNTRY_STATE ||= { "state"=> ADDRESS_STATE }
 
     COUNTRY ||=
       {


### PR DESCRIPTION
Shipments API documentation has been updated by this commit. Introduced changes:

- 'Update' section - removed ``shipment[:unlocked]`` param description (I cannot see the code that uses it)
- Introduced ``SHIPMENT_SMALL`` and ``SHIPPING_METHOD_SMALL`` resource constants to better imitate ``Spree::Api::V1::ShipmentsController``'s actions' responses structure
- Some pagination corrections