### PR TITLE
Fix 500 on product clone

### DIFF
--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -72,6 +72,11 @@ module Spree
         end
 
         redirect_to edit_admin_product_url(@new)
+
+      rescue ActiveRecord::RecordInvalid
+        # Handle error on uniqueness validation on product fields
+        flash[:error] = Spree.t('notice_messages.product_not_cloned')
+        redirect_to admin_products_url
       end
 
       def stock

--- a/core/lib/spree/core/product_duplicator.rb
+++ b/core/lib/spree/core/product_duplicator.rb
@@ -40,7 +40,7 @@ module Spree
     def duplicate_master
       master = product.master
       master.dup.tap do |new_master|
-        new_master.sku = "COPY OF #{master.sku}"
+        new_master.sku = sku_generator(master.sku)
         new_master.deleted_at = nil
         new_master.images = master.images.map { |image| duplicate_image image } if @include_images
         new_master.price = master.price
@@ -50,9 +50,9 @@ module Spree
 
     def duplicate_variant(variant)
       new_variant = variant.dup
-      new_variant.sku = "COPY OF #{new_variant.sku}"
+      new_variant.sku = sku_generator(new_variant.sku)
       new_variant.deleted_at = nil
-      new_variant.option_values = variant.option_values.map { |option_value| option_value}
+      new_variant.option_values = variant.option_values.map { |option_value| option_value }
       new_variant
     end
 
@@ -69,6 +69,10 @@ module Spree
           new_prop.updated_at = nil
         end
       end
+    end
+
+    def sku_generator(sku)
+      "COPY OF #{Variant.where('sku like ?', "%#{sku}").order(:created_at).last.sku}"
     end
   end
 end

--- a/core/spec/models/spree/product_duplicator_spec.rb
+++ b/core/spec/models/spree/product_duplicator_spec.rb
@@ -1,53 +1,55 @@
-require 'spec_helper'
+require "spec_helper"
 
 module Spree
-
   describe Spree::ProductDuplicator, type: :model do
+    let(:product) { create(:product, properties: [create(:property, name: "MyProperty")]) }
+    let!(:duplicator) { Spree::ProductDuplicator.new(product) }
 
-    let(:product) { create(:product, properties: [create(:property, name: "MyProperty")])}
-    let!(:duplicator) { Spree::ProductDuplicator.new(product)}
-
-    let(:image) { File.open(File.expand_path('../../../fixtures/thinking-cat.jpg', __FILE__)) }
-    let(:params) { {viewable_id: product.master.id, viewable_type: 'Spree::Variant', attachment: image, alt: "position 1", position: 1} }
+    let(:image) { File.open(File.expand_path("../../../fixtures/thinking-cat.jpg", __FILE__)) }
+    let(:params) do
+      {
+        viewable_id: product.master.id,
+        viewable_type: "Spree::Variant",
+        attachment: image,
+        alt: "position 1",
+        position: 1,
+      }
+    end
 
     before do
       Spree::Image.create(params)
     end
 
     it "will duplicate the product" do
-      expect{duplicator.duplicate}.to change{Spree::Product.count}.by(1)
+      expect { duplicator.duplicate }.to change { Spree::Product.count }.by(1)
     end
 
-    context 'when image duplication enabled' do
+    it "will duplicate already duplicated product" do
+      expect { 3.times { duplicator.duplicate } }.to change { Spree::Product.count }.by(3)
+    end
 
+    context "when image duplication enabled" do
       it "will duplicate the product images" do
-        expect{duplicator.duplicate}.to change{Spree::Image.count}.by(1)
+        expect { duplicator.duplicate }.to change { Spree::Image.count }.by(1)
       end
-
     end
 
-    context 'when image duplication disabled' do
-
+    context "when image duplication disabled" do
       let!(:duplicator) { Spree::ProductDuplicator.new(product, false) }
 
       it "will not duplicate the product images" do
-        expect{duplicator.duplicate}.to change{Spree::Image.count}.by(0)
+        expect { duplicator.duplicate }.to change { Spree::Image.count }.by(0)
       end
-
     end
 
-    context 'image duplication default' do
-
-      context 'when default is set to true' do
-
-        it 'clones images if no flag passed to initializer' do
-          expect{duplicator.duplicate}.to change{Spree::Image.count}.by(1)
+    context "image duplication default" do
+      context "when default is set to true" do
+        it "clones images if no flag passed to initializer" do
+          expect { duplicator.duplicate }.to change { Spree::Image.count }.by(1)
         end
-
       end
 
-      context 'when default is set to false' do
-
+      context "when default is set to false" do
         before do
           ProductDuplicator.clone_images_default = false
         end
@@ -56,16 +58,14 @@ module Spree
           ProductDuplicator.clone_images_default = true
         end
 
-        it 'does not clone images if no flag passed to initializer' do
-          expect{ProductDuplicator.new(product).duplicate}.to change{Spree::Image.count}.by(0)
+        it "does not clone images if no flag passed to initializer" do
+          expect { ProductDuplicator.new(product).duplicate }.to change { Spree::Image.count }.by(0)
         end
-
       end
-
     end
 
     context "product attributes" do
-      let!(:new_product) {duplicator.duplicate}
+      let!(:new_product) { duplicator.duplicate }
 
       it "will set an unique name" do
         expect(new_product.name).to eql "COPY OF #{product.name}"
@@ -82,22 +82,21 @@ module Spree
     end
 
     context "with variants" do
-      let(:option_type) { create(:option_type, name: "MyOptionType")}
-      let(:option_value1) { create(:option_value, name: "OptionValue1", option_type: option_type)}
-      let(:option_value2) { create(:option_value, name: "OptionValue2", option_type: option_type)}
+      let(:option_type) { create(:option_type, name: "MyOptionType") }
+      let(:option_value1) { create(:option_value, name: "OptionValue1", option_type: option_type) }
+      let(:option_value2) { create(:option_value, name: "OptionValue2", option_type: option_type) }
 
       let!(:variant1) { create(:variant, product: product, option_values: [option_value1]) }
       let!(:variant2) { create(:variant, product: product, option_values: [option_value2]) }
 
-      it  "will duplciate the variants" do
+      it "will duplciate the variants" do
         # will change the count by 3, since there will be a master variant as well
-        expect{duplicator.duplicate}.to change{Spree::Variant.count}.by(3)
+        expect { duplicator.duplicate }.to change { Spree::Variant.count }.by(3)
       end
 
       it "will not duplicate the option values" do
-        expect{duplicator.duplicate}.to change{Spree::OptionValue.count}.by(0)
+        expect { duplicator.duplicate }.to change { Spree::OptionValue.count }.by(0)
       end
-
     end
   end
 end


### PR DESCRIPTION
Before:
Cloning for another time a product throws `Validation failed: Sku has already been taken`

After:
Cloning for another time a product add to it another `COPY OF`. However, there can be edge case if we name `COPY OF ...` older product. Because of that, we handle 500 by showing user error flash message instead of a unhandled exception.

There was a lack of tests for clone action for product controller. I have added some.