### PR TITLE
BugFix: StoreCredit payment when cart-items altered

### DIFF
--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -32,6 +32,7 @@ module Spree
         persist_totals
         PromotionHandler::Cart.new(order).activate
         order.ensure_updated_shipments
+        order.payments.store_credits.delete_all
         persist_totals
         true
       else
@@ -42,6 +43,7 @@ module Spree
     private
 
     def after_add_or_remove(line_item, options = {})
+      order.payments.store_credits.delete_all
       persist_totals
       shipment = options[:shipment]
       shipment.present? ? shipment.update_amounts : order.ensure_updated_shipments

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -32,7 +32,7 @@ module Spree
         persist_totals
         PromotionHandler::Cart.new(order).activate
         order.ensure_updated_shipments
-        order.payments.store_credits.delete_all
+        order.payments.store_credits.checkout.destroy_all
         persist_totals
         true
       else
@@ -43,7 +43,7 @@ module Spree
     private
 
     def after_add_or_remove(line_item, options = {})
-      order.payments.store_credits.delete_all
+      order.payments.store_credits.checkout.destroy_all
       persist_totals
       shipment = options[:shipment]
       shipment.present? ? shipment.update_amounts : order.ensure_updated_shipments

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -57,14 +57,7 @@ describe Spree::OrderContents, type: :model do
     context 'when store_credits payment' do
       let!(:payment) { create(:store_credit_payment, order: order) }
 
-      it 'is expected to have store_credit_payment' do
-        expect(order.payments.store_credits).to include(payment)
-      end
-
-      it "is expected to delete store_credits payment" do
-        subject.add(variant, 1)
-        expect(order.payments.store_credits.count).to eq(0)
-      end
+      it { expect { subject.add(variant, 1) }.to change { order.payments.store_credits.count }.by(-1) }
     end
 
     context "running promotions" do
@@ -180,14 +173,7 @@ describe Spree::OrderContents, type: :model do
         payment
       end
 
-      it 'is expected to have store_credit_payment' do
-        expect(order.payments.store_credits).to include(payment)
-      end
-
-      it "is expected to delete store_credits payment" do
-        subject.remove(variant, 1)
-        expect(order.payments.store_credits.count).to eq(0)
-      end
+      it { expect { subject.remove(variant, 1) }.to change { order.payments.store_credits.count }.by(-1) }
     end
 
     it 'should remove line_item if quantity matches line_item quantity' do
@@ -240,14 +226,7 @@ describe Spree::OrderContents, type: :model do
         payment
       end
 
-      it 'is expected to have store_credit_payment' do
-        expect(order.payments.store_credits).to include(payment)
-      end
-
-      it "is expected to delete store_credits payment" do
-        subject.remove_line_item(@line_item)
-        expect(order.payments.store_credits.count).to eq(0)
-      end
+      it { expect { subject.remove_line_item(@line_item) }.to change { order.payments.store_credits.count }.by(-1) }
     end
 
     it 'should remove line_item' do
@@ -295,14 +274,7 @@ describe Spree::OrderContents, type: :model do
     context 'when store_credits payment' do
       let!(:payment) { create(:store_credit_payment, order: order) }
 
-      it 'is expected to have store_credit_payment' do
-        expect(order.payments.store_credits).to include(payment)
-      end
-
-      it "is expected to delete store_credits payment" do
-        subject.update_cart params
-        expect(order.payments.store_credits.count).to eq(0)
-      end
+      it { expect { subject.update_cart params }.to change { order.payments.store_credits.count }.by(-1) }
     end
 
     context "submits item quantity 0" do

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -54,6 +54,19 @@ describe Spree::OrderContents, type: :model do
       expect(order.total.to_f).to eq(19.99)
     end
 
+    context 'when store_credits payment' do
+      let!(:payment) { create(:store_credit_payment, order: order) }
+
+      it 'is expected to have store_credit_payment' do
+        expect(order.payments.store_credits).to include(payment)
+      end
+
+      it "is expected to delete store_credits payment" do
+        subject.add(variant, 1)
+        expect(order.payments.store_credits.count).to eq(0)
+      end
+    end
+
     context "running promotions" do
       let(:promotion) { create(:promotion) }
       let(:calculator) { Spree::Calculator::FlatRate.new(preferred_amount: 10) }
@@ -159,6 +172,24 @@ describe Spree::OrderContents, type: :model do
       expect(line_item.quantity).to eq(2)
     end
 
+    context 'when store_credits payment' do
+      let(:payment) { create(:store_credit_payment, order: order) }
+
+      before do
+        subject.add(variant, 1)
+        payment
+      end
+
+      it 'is expected to have store_credit_payment' do
+        expect(order.payments.store_credits).to include(payment)
+      end
+
+      it "is expected to delete store_credits payment" do
+        subject.remove(variant, 1)
+        expect(order.payments.store_credits.count).to eq(0)
+      end
+    end
+
     it 'should remove line_item if quantity matches line_item quantity' do
       subject.add(variant, 1)
       removed_line_item = subject.remove(variant, 1)
@@ -198,6 +229,24 @@ describe Spree::OrderContents, type: :model do
         line_item = subject.add(variant, 1)
         expect(subject.order).to receive(:ensure_updated_shipments)
         subject.remove_line_item(line_item)
+      end
+    end
+
+    context 'when store_credits payment' do
+      let(:payment) { create(:store_credit_payment, order: order) }
+
+      before do
+        @line_item = subject.add(variant, 1)
+        payment
+      end
+
+      it 'is expected to have store_credit_payment' do
+        expect(order.payments.store_credits).to include(payment)
+      end
+
+      it "is expected to delete store_credits payment" do
+        subject.remove_line_item(@line_item)
+        expect(order.payments.store_credits.count).to eq(0)
       end
     end
 
@@ -241,6 +290,19 @@ describe Spree::OrderContents, type: :model do
       expect {
         subject.update_cart params
       }.to change { subject.order.total }
+    end
+
+    context 'when store_credits payment' do
+      let!(:payment) { create(:store_credit_payment, order: order) }
+
+      it 'is expected to have store_credit_payment' do
+        expect(order.payments.store_credits).to include(payment)
+      end
+
+      it "is expected to delete store_credits payment" do
+        subject.update_cart params
+        expect(order.payments.store_credits.count).to eq(0)
+      end
     end
 
     context "submits item quantity 0" do


### PR DESCRIPTION

When we add/remove cart-items the store credit payment fails compliance. This fix removes the store_credit payment if items are added or removed. Hence, order recreate the store_credit payment after reaching respective state.

Like for example, if order total is 100 currency, and you pay by StoreCredit, a payment(type: store_credit) is created; now go back to cart and remove an item(or add one), the StoreCredit payment doesn't changes.
In this case we can delete the StoreCredit payment, which can be created again while processing checkout.