### PR TITLE
BugFix: Issue with  StoreCredit payment

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -110,7 +110,7 @@ module Spree
     accepts_nested_attributes_for :line_items
     accepts_nested_attributes_for :bill_address
     accepts_nested_attributes_for :ship_address
-    accepts_nested_attributes_for :payments
+    accepts_nested_attributes_for :payments, reject_if: :credit_card_nil_payment
     accepts_nested_attributes_for :shipments
 
     # Needs to happen before save_permalink is called
@@ -672,6 +672,10 @@ module Spree
 
     def collect_payment_methods
       PaymentMethod.available_on_front_end.select { |pm| pm.available_for_order?(self) }
+    end
+
+    def credit_card_nil_payment(attributes)
+      payments.store_credits.present? && (attributes[:amount].try :zero?)
     end
   end
 end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -110,7 +110,7 @@ module Spree
     accepts_nested_attributes_for :line_items
     accepts_nested_attributes_for :bill_address
     accepts_nested_attributes_for :ship_address
-    accepts_nested_attributes_for :payments, reject_if: :credit_card_nil_payment
+    accepts_nested_attributes_for :payments, reject_if: :credit_card_nil_payment?
     accepts_nested_attributes_for :shipments
 
     # Needs to happen before save_permalink is called
@@ -674,8 +674,8 @@ module Spree
       PaymentMethod.available_on_front_end.select { |pm| pm.available_for_order?(self) }
     end
 
-    def credit_card_nil_payment(attributes)
-      payments.store_credits.present? && (attributes[:amount].try :zero?)
+    def credit_card_nil_payment?(attributes)
+      payments.store_credits.present? && (attributes[:amount].to_f.zero?)
     end
   end
 end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1043,4 +1043,25 @@ describe Spree::Order, type: :model do
       it { expect(resumed_order).to be_resumed }
     end
   end
+
+  describe 'credit_card_nil_payment' do
+    let!(:order) { create(:order_with_line_items, line_items_count: 2) }
+    let!(:credit_card_payment_method) { create(:simple_credit_card_payment_method) }
+    let!(:store_credits) { create(:store_credit_payment, order: order) }
+
+    def attributes(amount = 0)
+      { payments_attributes: [{ amount: amount, payment_method_id: credit_card_payment_method.id }] }
+    end
+    context 'when zero amount credit-card payment' do
+      it 'expect not to build a new payment' do
+        expect { order.assign_attributes(attributes) }.to change { order.payments.size }.by(0)
+      end
+    end
+
+    context 'when valid-amount(>0) creditcard payment' do
+      it 'expect not to build a new payment' do
+        expect { order.assign_attributes(attributes(10)) }.to change { order.payments.size }.by(1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
#7873 
If user has 'existing credit card' and pays with StoreCredit, a 'zero amount' payment with credit card is also created. 
Resolution: Reject the params if order has store-credits and pament of zero amount is being created.