### PR TITLE
Guide: API: Update stock items documentation

### DIFF
--- a/guides/content/api/stock_items.md
+++ b/guides/content/api/stock_items.md
@@ -26,8 +26,8 @@ per_page
 <%= json(:stock_item) do |h|
 { stock_items: [h],
   count: 25,
-  pages: 5,
-  current_page: 1 }
+  current_page: 1,
+  pages: 5 }
 end %>
 
 ## Search
@@ -49,8 +49,8 @@ The search results are paginated.
 <%= json(:stock_item) do |h|
  { stock_items: [h],
    count: 25,
-   pages: 5,
-   current_page: 1 }
+   current_page: 1,
+   pages: 5 }
 end %>
 
 ### Sorting results
@@ -114,9 +114,9 @@ For instance, a request to create a new stock item with a count_on_hand of 10 an
 
 <%= admin_only %>
 
-Note that using this endpoint, count_on_hand is APPENDED to its current value.
+Note that using this endpoint, count_on_hand <strong>IS APPENDED</strong> to its current value.
 
-Sending a request with a negative count_on_hand will subtract the current value.
+Sending a request with a negative count_on_hand <strong>WILL SUBSTRACT</strong> the current value.
 
 To force a value for count_on_hand, include force: true in your request, this will replace the current
 value as it's stored in the database.
@@ -144,7 +144,9 @@ Or alternatively with the force attribute to replace the current count_on_hand w
 ### Successful response
 
 <%= headers 201 %>
-<%= json(:stock_item) %>
+<%= json(:stock_item) do |h|
+  h.merge("count_on_hand" => 30)
+end %>
 
 ### Failed response
 

--- a/guides/content/api/stock_movements.md
+++ b/guides/content/api/stock_movements.md
@@ -26,8 +26,8 @@ per_page
 <%= json(:stock_movement) do |h|
 { stock_movements: [h],
   count: 25,
-  pages: 5,
-  current_page: 1 }
+  current_page: 1,
+  pages: 5 }
 end %>
 
 ## Search
@@ -49,8 +49,8 @@ The search results are paginated.
 <%= json(:stock_movement) do |h|
  { stock_movements: [h],
    count: 25,
-   pages: 5,
-   current_page: 1 }
+   current_page: 1,
+   pages: 5 }
 end %>
 
 ### Sorting results
@@ -129,7 +129,9 @@ For instance, to update a stock movement's quantity, send it through like this:
 ### Successful response
 
 <%= headers 201 %>
-<%= json(:stock_movement) %>
+<%= json(:stock_movement) do |h|
+  h.merge("quantity" => 30)
+end %>
 
 ### Failed response
 
@@ -139,16 +141,3 @@ For instance, to update a stock movement's quantity, send it through like this:
   errors: {
   }
 %>
-
-## Delete
-
-<%= admin_only %>
-
-To delete a stock movement, make this request:
-
-```text
-DELETE /api/v1/stock_locations/1/stock_movement/1```
-
-### Response
-
-<%= headers 204 %>

--- a/guides/layouts/api/_sidebar.html
+++ b/guides/layouts/api/_sidebar.html
@@ -519,10 +519,6 @@
             <i class="icon-dot"></i>
             <%= link_to "Update", 'stock_movements', 'update' %>
           </li>
-          <li>
-            <i class="icon-dot"></i>
-            <%= link_to "Delete", 'stock_movements', 'delete' %>
-          </li>
         </ul>
       </li>
       <li class='js-topic'>

--- a/guides/lib/resources.rb
+++ b/guides/lib/resources.rb
@@ -219,6 +219,7 @@ module Spree
           "slug"=>"ruby-on-rails-tote",
           "description"=>"A text description of the product.",
           "track_inventory"=>true,
+          "cost_price"=>nil,
           "option_values"=>[OPTION_VALUE],
           "images"=>[IMAGE],
           "display_price"=>"$15.99",
@@ -984,8 +985,8 @@ module Spree
       {
         "id"=>1,
         "quantity"=>10,
-        "action"=>"received",
-        "stock_item_id"=>1
+        "stock_item_id"=>1,
+        "stock_item"=>STOCK_ITEM
       }
 
     MESSAGE ||=

--- a/guides/lib/resources.rb
+++ b/guides/lib/resources.rb
@@ -205,16 +205,6 @@ module Spree
         "position" => 1
       }
 
-    STOCK_ITEM ||=
-      {
-        "id"=>1,
-        "count_on_hand"=>10,
-        "stock_location_id"=>1,
-        "backorderable"=>true,
-        "available"=>true,
-        "stock_location_name"=>"default"
-      }
-
     VARIANT ||=
        {
           "id"=>1,
@@ -239,6 +229,16 @@ module Spree
           "total_on_hand"=>10,
           "is_destroyed"=>false
        }
+
+    STOCK_ITEM ||=
+      {
+        "id"=>1,
+        "count_on_hand"=>10,
+        "backorderable"=>true,
+        "stock_location_id"=>1,
+        "variant_id"=>1,
+        "variant"=>VARIANT
+      }
 
     VARIANT_BIG ||= VARIANT.merge("stock_items"=>[STOCK_ITEM])
 


### PR DESCRIPTION
Next part of Spree Guides API documentation update works. This time I made following change:

- Updated JSON formatted ``Spree::StockItem`` resource response (+ pagination)