### PR TITLE
Guide: API: Update zones documentation

### DIFF
--- a/guides/content/api/zones.md
+++ b/guides/content/api/zones.md
@@ -29,8 +29,8 @@ per_page
 <%= json(:zone) do |h|
 { zones: [h],
   count: 25,
-  pages: 5,
-  current_page: 1 }
+  current_page: 1,
+  pages: 5 }
 end %>
 
 ## Search
@@ -50,8 +50,8 @@ The search results are paginated.
 <%= json(:zone) do |h|
  { zones: [h],
    count: 25,
-   pages: 5,
-   current_page: 1 }
+   current_page: 1,
+   pages: 5 }
 end %>
 
 ### Sorting results
@@ -99,7 +99,9 @@ a zone member which is a `Spree::Country` record with the `id` attribute of 1, s
 ### Response
 
 <%= headers 201 %>
-<%= json(:zone) %>
+<%= json(:zone) do |h|
+  h.merge("name" => "North Pole")
+end %>
 
 ## Update
 
@@ -113,7 +115,6 @@ PUT /api/v1/zones/1```
 To update zone and zone member information, use parameters like this:
 
 <%= json \
-  id: 1,
   zone: {
     name: "North Pole",
     zone_members: [

--- a/guides/lib/resources.rb
+++ b/guides/lib/resources.rb
@@ -485,11 +485,19 @@ module Spree
         "name" => "Defaukt category"
       }
 
+    ZONE_MEMBER ||=
+      {
+        "id"=>1,
+        "zoneable_type"=>"Spree::Country",
+        "zoneable_id"=>1
+      }
+
     ZONE ||=
       {
         "id"=>1,
         "name"=>"America",
-        "description"=>"The US"
+        "description"=>"The US",
+        "zone_members"=>[ZONE_MEMBER]
       }
 
     SHIPPING_METHOD ||=
@@ -945,14 +953,6 @@ module Spree
         "id" => 1,
         "name" => "Brand",
         "root" => TAXON_WITHOUT_CHILDREN
-      }
-
-    ZONE_MEMBER ||=
-      {
-        "id"=>1,
-        "name"=>"United States",
-        "zoneable_type"=>"Spree::Country",
-        "zoneable_id"=>1,
       }
 
     RETURN_AUTHORIZATION ||=


### PR DESCRIPTION
Just as in case of my earlier documentation works, here are some rectifications to API docs, exactly to zones section. Changes made:

- Updated example JSON formatted Spree::Zone resource responded by the API.



