### PR TITLE
Preload tax_category to omit N+1 queries

### DIFF
--- a/core/lib/spree/core/search/base.rb
+++ b/core/lib/spree/core/search/base.rb
@@ -57,6 +57,7 @@ module Spree
             # separate queries most of the time but opt for a join as soon as any
             # `where` constraints affecting joined tables are added to the search;
             # which is the case as soon as a taxon is added to the base scope.
+            scope = scope.preload(:tax_category)
             scope = scope.preload(master: :prices)
             scope = scope.preload(master: :images) if include_images
             scope


### PR DESCRIPTION
Because of `display_price_including_vat_for` method we had N+1 queries on `tax_category` on products retrevied with base `build_searcher`.

Before: [console logs](http://take.ms/9TXac)
After: [console logs](http://take.ms/Ta8sG)