### PR TITLE
Email validator allows emails with longer domains

### DIFF
--- a/core/lib/spree/core/validators/email.rb
+++ b/core/lib/spree/core/validators/email.rb
@@ -4,7 +4,7 @@ class EmailValidator < ActiveModel::EachValidator
                           ([A-Za-z0-9]+\-+)|
                           ([A-Za-z0-9]+\.+)|
                           ([A-Za-z0-9]+\++))*[A-Za-z0-9_]+@((\w+\-+)|
-                          (\w+\.))*\w{1,63}\.[a-zA-Z]{2,6}\z}xi
+                          (\w+\.))*\w{1,63}\.[a-zA-Z]{2,15}\z}xi
       record.errors.add(attribute, :invalid, { value: value }.merge!(options))
     end
   end

--- a/core/spec/lib/spree/core/validators/email_spec.rb
+++ b/core/spec/lib/spree/core/validators/email_spec.rb
@@ -16,7 +16,8 @@ describe EmailValidator do
     'valid-email@email.com',
     'valid_email@email.com',
     'validemail_@email.com',
-    'valid.email@email.com'
+    'valid.email@email.com',
+    'valid.email@email.photography'
   ]}
   let(:invalid_emails) {[
     '',


### PR DESCRIPTION
Issue #7875 
Emails such as valid.email@email.photography will pass validation.