### PR TITLE
Admin store credit payment

### DIFF
--- a/backend/app/controllers/spree/admin/payments_controller.rb
+++ b/backend/app/controllers/spree/admin/payments_controller.rb
@@ -42,7 +42,8 @@ module Spree
             while @order.next; end
             # If "@order.next" didn't trigger payment processing already (e.g. if the order was
             # already complete) then trigger it manually now
-            saved_payments.checkout.map &:process! if(@order.completed?)
+
+            saved_payments.each { |payment| payment.process! if payment.reload.checkout? && @order.complete? }
             flash[:success] = flash_message_for(saved_payments.first , :successfully_created)
             redirect_to admin_order_payments_path(@order)
           else

--- a/backend/app/controllers/spree/admin/payments_controller.rb
+++ b/backend/app/controllers/spree/admin/payments_controller.rb
@@ -22,20 +22,28 @@ module Spree
 
       def create
         invoke_callbacks(:create, :before)
-        @payment ||= @order.payments.build(object_params)
-        if @payment.payment_method.source_required? && params[:card].present? and params[:card] != 'new'
-          @payment.source = @payment.payment_method.payment_source_class.find_by_id(params[:card])
-        end
 
         begin
-          if @payment.save
+          if @payment_method.store_credit?
+            payments = @order.add_store_credit_payments
+          else
+            @payment ||= @order.payments.build(object_params)
+            if @payment.payment_method.source_required? && params[:card].present? and params[:card] != 'new'
+              @payment.source = @payment.payment_method.payment_source_class.find_by_id(params[:card])
+            end
+            @payment.save
+            payments = [@payment]
+          end
+
+          if (saved_payments = payments.select &:persisted?).any?
             invoke_callbacks(:create, :after)
+
             # Transition order as far as it will go.
             while @order.next; end
             # If "@order.next" didn't trigger payment processing already (e.g. if the order was
             # already complete) then trigger it manually now
-            @payment.process! if @order.completed? && @payment.checkout?
-            flash[:success] = flash_message_for(@payment, :successfully_created)
+            saved_payments.checkout.map &:process! if(@order.completed?)
+            flash[:success] = flash_message_for(saved_payments.first , :successfully_created)
             redirect_to admin_order_payments_path(@order)
           else
             invoke_callbacks(:create, :fails)
@@ -81,7 +89,8 @@ module Spree
         if @payment and @payment.payment_method
           @payment_method = @payment.payment_method
         else
-          @payment_method = @payment_methods.first
+          @payment_method = @payment_methods.find_by(id: params[:payment][:payment_method_id]) if params[:payment]
+          @payment_method ||= @payment_methods.first
         end
       end
 

--- a/backend/app/controllers/spree/admin/payments_controller.rb
+++ b/backend/app/controllers/spree/admin/payments_controller.rb
@@ -28,7 +28,7 @@ module Spree
             payments = @order.add_store_credit_payments
           else
             @payment ||= @order.payments.build(object_params)
-            if @payment.payment_method.source_required? && params[:card].present? and params[:card] != 'new'
+            if @payment.payment_method.source_required? && params[:card].present? && params[:card] != 'new'
               @payment.source = @payment.payment_method.payment_source_class.find_by_id(params[:card])
             end
             @payment.save
@@ -44,7 +44,7 @@ module Spree
             # already complete) then trigger it manually now
 
             saved_payments.each { |payment| payment.process! if payment.reload.checkout? && @order.complete? }
-            flash[:success] = flash_message_for(saved_payments.first , :successfully_created)
+            flash[:success] = flash_message_for(saved_payments.first, :successfully_created)
             redirect_to admin_order_payments_path(@order)
           else
             invoke_callbacks(:create, :fails)

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -227,5 +227,19 @@ describe 'Payments', type: :feature, js: true do
         expect(page).to have_content("Payment Updated")
       end
     end
+
+    context 'store_credit payment' do
+      let!(:payment_method) { create(:store_credit_payment_method) }
+      let!(:category) { create(:store_credit_category, name: 'Default') }
+      let!(:store_credit) { create(:store_credit, user: order.user, category: category, amount: 500) }
+
+      before do
+        visit spree.new_admin_order_payment_path(order.reload)
+        choose("payment_payment_method_id_#{ payment_method.id }")
+        click_button 'Continue'
+      end
+
+      it { expect(page).to have_content('successfully created') }
+    end
   end
 end

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -235,7 +235,7 @@ describe 'Payments', type: :feature, js: true do
 
       before do
         visit spree.new_admin_order_payment_path(order.reload)
-        choose("payment_payment_method_id_#{ payment_method.id }")
+        choose("payment_payment_method_id_#{payment_method.id}")
         click_button 'Continue'
       end
 

--- a/core/app/models/spree/order/store_credit.rb
+++ b/core/app/models/spree/order/store_credit.rb
@@ -16,6 +16,7 @@ module Spree
 
             amount_to_take = store_credit_amount(credit, remaining_total)
             create_store_credit_payment(payment_method, credit, amount_to_take)
+            remaining_total -= amount_to_take
           end
           payments.store_credits.checkout
         end

--- a/core/app/models/spree/order/store_credit.rb
+++ b/core/app/models/spree/order/store_credit.rb
@@ -16,8 +16,8 @@ module Spree
 
             amount_to_take = store_credit_amount(credit, remaining_total)
             create_store_credit_payment(payment_method, credit, amount_to_take)
-            remaining_total -= amount_to_take
           end
+          payments.store_credits.checkout
         end
       end
 


### PR DESCRIPTION
Enable Admin to add StoreCredit payment form admin-end.
Admin::PaymentController#create was written to accommodate CreditCard/Cheque. When admin try to add StoreCredit payment it ends up in showing error.
This PR rewrites #create to accommodate StoreCredit(single as well as multiple payments) payments.