### PR TITLE
require acts_as_list ~> 0.7, >= 0.7.2 (3-1-stable)

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
 
   s.add_dependency 'activemerchant', '~> 1.59'
-  s.add_dependency 'acts_as_list', '0.7.2'
+  s.add_dependency 'acts_as_list', '~> 0.7', '>= 0.7.2'
   s.add_dependency 'awesome_nested_set', '~> 3.0.1'
   s.add_dependency 'carmen', '~> 1.0.0'
   s.add_dependency 'cancancan', '~> 1.10.1'


### PR DESCRIPTION
There is a lot of fixes in `acts_as_list`