### PR TITLE
Fix - error for blank "Master Price *" in product create/update

### DIFF
--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -156,6 +156,14 @@ module Spree
       def variant_stock_includes
         [:images, stock_items: :stock_location, option_values: :option_type]
       end
+
+      def permitted_resource_params
+        params[resource.object_name].present? ? permit_not_blank_params : ActionController::Parameters.new
+      end
+
+      def permit_not_blank_params
+        params.require(resource.object_name).reject { |_k, v| v.blank? }.permit!
+      end
     end
   end
 end

--- a/backend/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/products_controller_spec.rb
@@ -3,6 +3,16 @@ require 'spec_helper'
 describe Spree::Admin::ProductsController, type: :controller do
   stub_authorization!
 
+  context '#create' do
+    context 'when price is empty' do
+      let(:params) { { name: :sample_name, shipping_category_id: create(:shipping_category).id } }
+
+      it 'does not persist product' do
+        expect { spree_post :create, product: params }.not_to change { Spree::Product.count }
+      end
+    end
+  end
+
   context "#index" do
     let(:ability_user) { stub_model(Spree::LegacyUser, has_spree_role?: true) }
 


### PR DESCRIPTION
Pull request concerning issue [#7917](https://github.com/spree/spree/issues/7917)

**Actual behavior**
Master price error does not show up when the field is empty. 

**The reason:**

Not filled new product form submission passes control to ``Spree::Admin::ResourceController#create`` having all ``params[:product]`` hash values empty.

 Next,  below is executed, which assigns blank string into ``@object.price``
``@object.attributes = permitted_resource_params`` 

Internally ``@object``'s price value is set to ``BigDecimal.new('0')``, which results in not displaying master price validation error on the view.

In one sentence, product's price defaults 0 unless specified by the user.

**Obtained behavior**

My code rejects ``params[:product]`` keys with blank values, so that ``nil`` is assigned to ``@object.price`` and the validation error is displayed on the view.






