### PR TITLE
Delete unused spree/api/v1/config directory

### DIFF
--- a/api/app/views/spree/api/v1/config/money.v1.rabl
+++ b/api/app/views/spree/api/v1/config/money.v1.rabl
@@ -1,2 +1,0 @@
-object false
-node(:symbol) { ::Money.new(1, Spree::Config[:currency]).symbol }

--- a/api/app/views/spree/api/v1/config/show.v1.rabl
+++ b/api/app/views/spree/api/v1/config/show.v1.rabl
@@ -1,2 +1,0 @@
-object false
-node(:default_country_id) { Spree::Config[:default_country_id] }


### PR DESCRIPTION
According to [commit](https://github.com/spree/spree/commit/7c031344bae3037aa9a0ea48180be489c70c78ae) ```Spree::Api::ConfigController``` has been deprecated in Spree 3.0.0 and was removed.

Related rabl templates are still present, so it's time to get rid of them.