### PR TITLE
Fix - error for blank string to LocalizedNumber.parse

### DIFF
--- a/backend/app/views/spree/admin/products/new.html.erb
+++ b/backend/app/views/spree/admin/products/new.html.erb
@@ -9,7 +9,7 @@
   <fieldset data-hook="new_product">
     <%= f.field_container :name, class: ['form-group'] do %>
       <%= f.label :name, Spree.t(:name) %> <span class="required">*</span>
-      <%= f.text_field :name, class: 'form-control title' %>
+      <%= f.text_field :name, class: 'form-control title', required: :required %>
       <%= f.error_message_on :name %>
     <% end %>
 
@@ -34,7 +34,7 @@
       <div data-hook="new_product_price" class="col-md-4">
         <%= f.field_container :price, class: ['form-group'] do %>
           <%= f.label :price, Spree.t(:master_price) %> <span class="required">*</span>
-          <%= f.text_field :price, value: number_to_currency(@product.price, unit: ''), class: 'form-control' %>
+          <%= f.text_field :price, value: number_to_currency(@product.price, unit: ''), class: 'form-control', required: :required %>
           <%= f.error_message_on :price %>
         <% end %>
       </div>
@@ -50,7 +50,7 @@
       <div data-hook="new_product_shipping_category" class="col-md-4">
         <%= f.field_container :shipping_category, class: ['form-group'] do %>
           <%= f.label :shipping_category_id, Spree.t(:shipping_categories) %><span class="required">*</span>
-          <%= f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { include_blank: Spree.t('match_choices.none') }, { class: 'select2' }) %>
+          <%= f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { include_blank: Spree.t('match_choices.none') }, { class: 'select2', required: :required }) %>
           <%= f.error_message_on :shipping_category_id %>
         <% end %>
       </div>

--- a/core/lib/spree/localized_number.rb
+++ b/core/lib/spree/localized_number.rb
@@ -15,6 +15,9 @@ module Spree
       # then replace the locale-specific decimal separator with the standard separator if necessary
       number.gsub!(separator, '.') unless separator == '.'
 
+      # Returns 0 to avoid ArgumentError: invalid value for BigDecimal(): "" for empty string
+      return 0 unless number.present?
+
       number.to_d
     end
 

--- a/core/spec/lib/spree/localized_number_spec.rb
+++ b/core/spec/lib/spree/localized_number_spec.rb
@@ -43,6 +43,12 @@ describe Spree::LocalizedNumber do
         expect(number).to eql(number_bak)
       end
     end
+
+    context "with empty string" do
+      it "should return 0" do
+        expect(subject.class.parse('')).to eql 0
+      end
+    end
   end
 
 end


### PR DESCRIPTION
Resolve #7917

Added client side validation check for product new.
Returns 0 from `LocalizedNumber.parse` for empty strings as this issue can be reproduce with other models as well wherever we used `LocalizedNumber.parse`.

This issue is handled in next ruby versions.
https://github.com/ruby/ruby/blob/trunk/ext/bigdecimal/lib/bigdecimal/util.rb#L67

