### PR TITLE
use Spree namespace in admin

### DIFF
--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -34,7 +34,7 @@ module Spree
           params[:q][:completed_at_lt] = params[:q].delete(:created_at_lt)
         end
 
-        @search = Order.preload(:user).accessible_by(current_ability, :index).ransack(params[:q])
+        @search = Spree::Order.preload(:user).accessible_by(current_ability, :index).ransack(params[:q])
 
         # lazy loading other models here (via includes) may result in an invalid query
         # e.g. SELECT  DISTINCT DISTINCT "spree_orders".id, "spree_orders"."created_at" AS alias_0 FROM "spree_orders"
@@ -49,7 +49,7 @@ module Spree
       end
 
       def new
-        @order = Order.create(order_params)
+        @order = Spree::Order.create(order_params)
         redirect_to cart_admin_order_url(@order)
       end
 
@@ -130,7 +130,7 @@ module Spree
         end
 
         def load_order
-          @order = Order.includes(:adjustments).friendly.find(params[:id])
+          @order = Spree::Order.includes(:adjustments).friendly.find(params[:id])
           authorize! action, @order
         end
 


### PR DESCRIPTION
Without the spree namespace, unexpected bugs can happen. Another 'order' object might be used than is intended here.