### PR TITLE
Guides - Developer - Getting help page updated

### DIFF
--- a/guides/content/developer/source/getting_help.md
+++ b/guides/content/developer/source/getting_help.md
@@ -9,36 +9,9 @@ There may be times when using Spree that the documentation doesn't answer all
 the questions you may have. There are several other places on the internet where
 you can go to ask Spree questions, and they are covered in this guide.
 
-## Mailing List
+## Slack
 
-The first of these places is our [Google Groups mailing
-list](http://groups.google.com/group/spree-user). On this list, any user may ask
-any question about Spree and it's up to the community to answer it, or in some
-cases, a Spree employee may answer the question.
-
-This list is perfect for *general* questions about Spree. If you think you have
-discovered a bug in Spree, please [file an issue on GitHub](#github-issues).
-
-Questions on this list may take some time to answer, so please be patient when
-asking them.
-
-## Gitter
-
-Spree has a [Gitter chat room](https://gitter.im/spree/spree) similar to IRC that
-can be used to discuss Spree in real-time. We prefer using Gitter over IRC for the chat logs, notifications, and other features.
-
-## IRC Channel
-
-The IRC channel for Spree is at #spree on irc.freenode.net. Here you can talk to
-other users of Spree in real-time. Spree employees are represented in the channel with a `@` before their name on most clients.
-
-If you do not have an IRC client and still want to join the discussion, Freenode offers a webchat solution for their network. [Simply visit this link, enter your username and connect!](http://webchat.freenode.net/?channels=#spree)
-
-It is recommended that for people using IRC often, or on multiple networks that they download an IRC client. Popular IRC clients include: [Quassel (all platforms)](http://quassel-irc.org/), [XChat (windows and linux)](http://xchat.org/) and [mIRC (windows only)](http://www.mirc.com/).
-
-!!!
-We prefer using Gitter over IRC for the chat logs, notifications, and other features.
-!!!
+Spree has a [Slack chat room ](http://slack.spreecommerce.com/) that can be used to discuss Spree in real-time.
 
 ## GitHub Issues
 


### PR DESCRIPTION
In a response to [#7931](https://github.com/spree/spree/issues/7931).

All of the listed are no longer supported: Mailing List, Gitter & IRC channel.
Slack and Github Issues are still used means of communiaction.