### PR TITLE
Avoid postgres distict order by issue with in_taxons

### DIFF
--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -244,7 +244,7 @@ module Spree
       # specifically avoid having an order for taxon search (conflicts with main order)
       def self.prepare_taxon_conditions(taxons)
         ids = taxons.map { |taxon| taxon.self_and_descendants.pluck(:id) }.flatten.uniq
-        joins(:classifications).where(Classification.table_name => { taxon_id: ids })
+        joins(:classifications).where(Spree::Classification.table_name => { taxon_id: ids })
       end
 
       # Produce an array of keywords for use in scopes.


### PR DESCRIPTION
## Description

If we use `in_taxons` method on taxon show page in postgres it throws error because at taxon page it also uses `in_taxon` scope and in this scope `order("spree_products_taxons.position ASC")` is used.