### PR TITLE
add scroll to tables incase their design starts breaking

### DIFF
--- a/backend/app/views/spree/admin/orders/_line_items.html.erb
+++ b/backend/app/views/spree/admin/orders/_line_items.html.erb
@@ -5,44 +5,46 @@
         <%= Spree.t(:order_line_items) %>
       </h1>
     </div>
-    <table class="table table-bordered line-items" data-hook="line-items">
-      <thead>
-        <tr>
-          <th colspan="2"><%= Spree.t(:name) %></th>
-          <th class="text-center"><%= Spree.t(:price) %></th>
-          <th class="text-center"><%= Spree.t(:quantity) %></th>
-          <th class="text-center"><%= Spree.t(:total_price) %></th>
-          <th class="orders-actions text-center" data-hook="admin_order_form_line_items_header_actions"></th>
-        </tr>
-      </thead>
-      <tbody>
-        <% order.line_items.each do |item| %>
-          <tr class="line-item" id="line-item-<%= item.id %>">
-            <td class="line-item-image image text-center">
-              <%= mini_image(item.variant) %>
-            </td>
-            <td class="line-item-name text-center">
-              <%= item.name %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>
-            </td>
-            <td class="line-item-price text-center"><%= item.single_money.to_html %></td>
-            <td class="line-item-qty-show text-center">
-              <%= item.quantity %>
-            </td>
-            <td class="line-item-qty-edit is-hidden">
-              <%= number_field_tag :quantity, item.quantity, min: 0, class: "line_item_quantity form-control", size: 5 %>
-            </td>
-            <td class="line-item-total text-center"><%= line_item_shipment_price(item, item.quantity) %></td>
-            <td class="cart-line-item-delete actions actions-4 text-center" data-hook="cart_line_item_delete">
-              <% if can? :update, item %>
-                <%= link_to_with_icon 'arrow-left', Spree.t('actions.cancel'), "#", class: 'cancel-line-item btn btn-default btn-sm', data: {action: 'cancel'}, title: Spree.t('actions.cancel'), style: 'display: none', no_text: true %>
-                <%= link_to_with_icon 'save', Spree.t('actions.save'), "#", class: 'save-line-item btn btn-success btn-sm', no_text: true, data: { :'line-item-id' => item.id, action: 'save'}, title: Spree.t('actions.save'), style: 'display: none' %>
-                <%= link_to_with_icon 'edit', Spree.t('edit'), "#", class: 'edit-line-item btn btn-primary btn-sm', data: {action: 'edit'}, title: Spree.t('edit'), no_text: true %>
-                <%= link_to_with_icon 'delete', Spree.t('delete'), "#", class: 'delete-line-item btn btn-danger btn-sm', data: { 'line-item-id' => item.id, action: 'remove'}, title: Spree.t('delete'), no_text: true %>
-              <% end %>
-            </td>
+    <div class="table-responsive">
+      <table class="table table-bordered line-items" data-hook="line-items">
+        <thead>
+          <tr>
+            <th colspan="2"><%= Spree.t(:name) %></th>
+            <th class="text-center"><%= Spree.t(:price) %></th>
+            <th class="text-center"><%= Spree.t(:quantity) %></th>
+            <th class="text-center"><%= Spree.t(:total_price) %></th>
+            <th class="orders-actions text-center" data-hook="admin_order_form_line_items_header_actions"></th>
           </tr>
-        <% end %>
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          <% order.line_items.each do |item| %>
+            <tr class="line-item" id="line-item-<%= item.id %>">
+              <td class="line-item-image image text-center">
+                <%= mini_image(item.variant) %>
+              </td>
+              <td class="line-item-name text-center">
+                <%= item.name %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>
+              </td>
+              <td class="line-item-price text-center"><%= item.single_money.to_html %></td>
+              <td class="line-item-qty-show text-center">
+                <%= item.quantity %>
+              </td>
+              <td class="line-item-qty-edit is-hidden">
+                <%= number_field_tag :quantity, item.quantity, min: 0, class: "line_item_quantity form-control", size: 5 %>
+              </td>
+              <td class="line-item-total text-center"><%= line_item_shipment_price(item, item.quantity) %></td>
+              <td class="cart-line-item-delete actions actions-4 text-center" data-hook="cart_line_item_delete">
+                <% if can? :update, item %>
+                  <%= link_to_with_icon 'arrow-left', Spree.t('actions.cancel'), "#", class: 'cancel-line-item btn btn-default btn-sm', data: {action: 'cancel'}, title: Spree.t('actions.cancel'), style: 'display: none', no_text: true %>
+                  <%= link_to_with_icon 'save', Spree.t('actions.save'), "#", class: 'save-line-item btn btn-success btn-sm', no_text: true, data: { :'line-item-id' => item.id, action: 'save'}, title: Spree.t('actions.save'), style: 'display: none' %>
+                  <%= link_to_with_icon 'edit', Spree.t('edit'), "#", class: 'edit-line-item btn btn-primary btn-sm', data: {action: 'edit'}, title: Spree.t('edit'), no_text: true %>
+                  <%= link_to_with_icon 'delete', Spree.t('delete'), "#", class: 'delete-line-item btn btn-danger btn-sm', data: { 'line-item-id' => item.id, action: 'remove'}, title: Spree.t('delete'), no_text: true %>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -16,95 +16,96 @@
     </h1>
   </div>
 
-  <table class="table table-bordered stock-contents" data-hook="stock-contents">
-    <thead>
-      <tr>
-        <th colspan="2"><%= Spree.t(:item_description) %></th>
-        <th width="15%" class="text-center"><%= Spree.t(:price) %></th>
-        <th width="15%" class="text-center"><%= Spree.t(:quantity) %></th>
-        <th width="15%" class="text-center"><%= Spree.t(:total) %></th>
-        <th class="orders-actions actions text-center" data-hook="admin_order_form_line_items_header_actions"></th>
-      </tr>
-    </thead>
+  <div class="table-responsive">
+    <table class="table table-bordered stock-contents" data-hook="stock-contents">
+      <thead>
+        <tr>
+          <th colspan="2"><%= Spree.t(:item_description) %></th>
+          <th width="15%" class="text-center"><%= Spree.t(:price) %></th>
+          <th width="15%" class="text-center"><%= Spree.t(:quantity) %></th>
+          <th width="15%" class="text-center"><%= Spree.t(:total) %></th>
+          <th class="orders-actions actions text-center" data-hook="admin_order_form_line_items_header_actions"></th>
+        </tr>
+      </thead>
 
-    <tbody data-shipment-number="<%= shipment.number %>" data-order-number="<%= order.number %>">
-      <%= render 'spree/admin/orders/shipment_manifest', shipment: shipment %>
+      <tbody data-shipment-number="<%= shipment.number %>" data-order-number="<%= order.number %>">
+        <%= render 'spree/admin/orders/shipment_manifest', shipment: shipment %>
 
-      <% unless shipment.shipped? %>
-        <tr class="edit-method is-hidden total">
+        <% unless shipment.shipped? %>
+          <tr class="edit-method is-hidden total">
+            <td colspan="5">
+              <div class="field alpha five columns">
+                <%= label_tag 'selected_shipping_rate_id', Spree.t(:shipping_method) %>
+                <%= select_tag :selected_shipping_rate_id,
+                      options_for_select(shipment.shipping_rates.map {|sr| ["#{sr.name} #{sr.display_price}", sr.id] }, shipment.selected_shipping_rate_id),
+                      { class: 'select2', data: {'shipment-number' => shipment.number } } %>
+              </div>
+            </td>
+            <td class="actions text-center">
+              <% if can? :update, shipment %>
+                <%= link_to_with_icon 'cancel', Spree.t('actions.cancel'), "#", class: 'cancel-method btn btn-primary btn-sm', data: {action: 'cancel'}, title: Spree.t('actions.cancel'), no_text: true %>
+                <%= link_to_with_icon 'save', Spree.t('actions.save'), "#", class: 'save-method btn btn-success btn-sm', data: {'shipment-number' => shipment.number, action: 'save'}, title: Spree.t('actions.save'), no_text: true %>
+              <% end %>
+            </td>
+          </tr>
+          <% end %>
+
+          <tr class="show-method total">
+            <% if rate = shipment.selected_shipping_rate %>
+              <td colspan="4">
+                <strong><%= rate.name %></strong>
+              </td>
+              <td class="total text-center">
+                <%= shipment.display_cost %>
+              </td>
+            <% else %>
+              <td colspan='5'><%= Spree.t(:no_shipping_method_selected) %></td>
+            <% end %>
+
+            <td class="actions text-center">
+              <% if( (can? :update, shipment) and !shipment.shipped?) %>
+                <%= link_to_with_icon 'edit', Spree.t('edit'), "javascript:;", class: 'edit-method with-tip btn btn-sm btn-primary', data: {action: 'edit'}, no_text: true %>
+              <% end %>
+            </td>
+          </tr>
+
+
+        <tr class="edit-tracking is-hidden total">
           <td colspan="5">
-            <div class="field alpha five columns">
-              <%= label_tag 'selected_shipping_rate_id', Spree.t(:shipping_method) %>
-              <%= select_tag :selected_shipping_rate_id,
-                    options_for_select(shipment.shipping_rates.map {|sr| ["#{sr.name} #{sr.display_price}", sr.id] }, shipment.selected_shipping_rate_id),
-                    { class: 'select2', data: {'shipment-number' => shipment.number } } %>
-            </div>
+            <label><%= Spree.t(:tracking_number) %>:</label>
+            <%= text_field_tag :tracking, shipment.tracking, class: "form-control" %>
+          </td>
+          <td class="actions">
+            <% if can? :update, shipment %>
+              <%= link_to_with_icon 'cancel', Spree.t('actions.cancel'), "#", class: 'cancel-tracking btn btn-primary btn-sm', data: {action: 'cancel'}, title: Spree.t('actions.cancel'), no_text: true %>
+              <%= link_to_with_icon 'save', Spree.t('actions.save'), "#", class: 'save-tracking btn btn-success btn-sm', data: {'shipment-number' => shipment.number, action: 'save'}, title: Spree.t('actions.save'), no_text: true %>
+            <% end %>
+          </td>
+        </tr>
+
+        <% if order.special_instructions.present? %>
+          <tr class='special_instructions'>
+            <td colspan="5">
+              <strong><%= Spree.t(:special_instructions) %>:&nbsp;</strong><%= order.special_instructions %>
+            </td>
+          </tr>
+        <% end %>
+
+        <tr class="show-tracking total">
+          <td colspan="5" class="tracking-value">
+            <% if shipment.tracking.present? %>
+              <strong><%= Spree.t(:tracking) %>:</strong> <%= link_to_tracking(shipment, target: '_blank') %>
+            <% else %>
+              <%= Spree.t(:no_tracking_present) %>
+            <% end %>
           </td>
           <td class="actions text-center">
             <% if can? :update, shipment %>
-              <%= link_to_with_icon 'cancel', Spree.t('actions.cancel'), "#", class: 'cancel-method btn btn-primary btn-sm', data: {action: 'cancel'}, title: Spree.t('actions.cancel'), no_text: true %>
-              <%= link_to_with_icon 'save', Spree.t('actions.save'), "#", class: 'save-method btn btn-success btn-sm', data: {'shipment-number' => shipment.number, action: 'save'}, title: Spree.t('actions.save'), no_text: true %>
+              <%= link_to_with_icon 'edit', Spree.t('edit'), "#", class: 'edit-tracking btn btn-primary btn-sm', data: {action: 'edit'}, title: Spree.t('edit'), no_text: true %>
             <% end %>
           </td>
         </tr>
-        <% end %>
-
-        <tr class="show-method total">
-          <% if rate = shipment.selected_shipping_rate %>
-            <td colspan="4">
-              <strong><%= rate.name %></strong>
-            </td>
-            <td class="total text-center">
-              <%= shipment.display_cost %>
-            </td>
-          <% else %>
-            <td colspan='5'><%= Spree.t(:no_shipping_method_selected) %></td>
-          <% end %>
-
-          <td class="actions text-center">
-            <% if( (can? :update, shipment) and !shipment.shipped?) %>
-              <%= link_to_with_icon 'edit', Spree.t('edit'), "javascript:;", class: 'edit-method with-tip btn btn-sm btn-primary', data: {action: 'edit'}, no_text: true %>
-            <% end %>
-          </td>
-        </tr>
-
-
-      <tr class="edit-tracking is-hidden total">
-        <td colspan="5">
-          <label><%= Spree.t(:tracking_number) %>:</label>
-          <%= text_field_tag :tracking, shipment.tracking, class: "form-control" %>
-        </td>
-        <td class="actions">
-          <% if can? :update, shipment %>
-            <%= link_to_with_icon 'cancel', Spree.t('actions.cancel'), "#", class: 'cancel-tracking btn btn-primary btn-sm', data: {action: 'cancel'}, title: Spree.t('actions.cancel'), no_text: true %>
-            <%= link_to_with_icon 'save', Spree.t('actions.save'), "#", class: 'save-tracking btn btn-success btn-sm', data: {'shipment-number' => shipment.number, action: 'save'}, title: Spree.t('actions.save'), no_text: true %>
-          <% end %>
-        </td>
-      </tr>
-
-      <% if order.special_instructions.present? %>
-        <tr class='special_instructions'>
-          <td colspan="5">
-            <strong><%= Spree.t(:special_instructions) %>:&nbsp;</strong><%= order.special_instructions %>
-          </td>
-        </tr>
-      <% end %>
-
-      <tr class="show-tracking total">
-        <td colspan="5" class="tracking-value">
-          <% if shipment.tracking.present? %>
-            <strong><%= Spree.t(:tracking) %>:</strong> <%= link_to_tracking(shipment, target: '_blank') %>
-          <% else %>
-            <%= Spree.t(:no_tracking_present) %>
-          <% end %>
-        </td>
-        <td class="actions text-center">
-          <% if can? :update, shipment %>
-            <%= link_to_with_icon 'edit', Spree.t('edit'), "#", class: 'edit-tracking btn btn-primary btn-sm', data: {action: 'edit'}, title: Spree.t('edit'), no_text: true %>
-          <% end %>
-        </td>
-      </tr>
-    </tbody>
-  </table>
-
+      </tbody>
+    </table>
+  </div>
 </div>


### PR DESCRIPTION
Issue -
If there is a product with a very large name then there is a possibility that the design of table may break.
This fix will ensure that there is a scroll on the table whenever the table cannot handle the large data.