### PR TITLE
[ADMIN END] fix shipment rate calculation issue

### DIFF
--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -46,7 +46,16 @@ module Spree
       order.payments.store_credits.checkout.destroy_all
       persist_totals
       shipment = options[:shipment]
-      shipment.present? ? shipment.update_amounts : order.ensure_updated_shipments
+      if shipment.present?
+        # ADMIN END SHIPMENT RATE FIX
+        # refresh shipments to ensure correct shipment amount is calculated when using price sack calculator
+        # for calculating shipment rates.
+        # Currently shipment rate is calculated on previous order total instead of current order total when updating a shipment from admin end.
+        order.refresh_shipment_rates(ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END)
+        shipment.update_amounts
+      else
+        order.ensure_updated_shipments
+      end
       PromotionHandler::Cart.new(order, line_item).activate
       Adjustable::AdjustmentsUpdater.update(line_item)
       TaxRate.adjust(order, [line_item]) if options[:line_item_created]

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -51,7 +51,7 @@ module Spree
         # refresh shipments to ensure correct shipment amount is calculated when using price sack calculator
         # for calculating shipment rates.
         # Currently shipment rate is calculated on previous order total instead of current order total when updating a shipment from admin end.
-        order.refresh_shipment_rates(ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END)
+        order.refresh_shipment_rates(ShippingMethod::DISPLAY_ON_BACK_END)
         shipment.update_amounts
       else
         order.ensure_updated_shipments

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -19,7 +19,7 @@ describe Spree::OrderContents, type: :model do
       it "ensure shipment calls update_amounts instead of order calling ensure_updated_shipments" do
         shipment = create(:shipment)
         expect(subject.order).to_not receive(:ensure_updated_shipments)
-        expect(subject.order).to receive(:refresh_shipment_rates).with(Spree::ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END)
+        expect(subject.order).to receive(:refresh_shipment_rates).with(Spree::ShippingMethod::DISPLAY_ON_BACK_END)
         expect(shipment).to receive(:update_amounts)
         subject.add(variant, 1, shipment: shipment)
       end

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -19,6 +19,7 @@ describe Spree::OrderContents, type: :model do
       it "ensure shipment calls update_amounts instead of order calling ensure_updated_shipments" do
         shipment = create(:shipment)
         expect(subject.order).to_not receive(:ensure_updated_shipments)
+        expect(subject.order).to receive(:refresh_shipment_rates).with(Spree::ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END)
         expect(shipment).to receive(:update_amounts)
         subject.add(variant, 1, shipment: shipment)
       end


### PR DESCRIPTION
Issue - Currently shipment rate is calculated on previous order total instead of current order total when updating a shipment from admin end and using price sack calculator.

Steps to reproduce:
1. Go to shipment methods and use price sack calculator for a shipment method.
2. Set **minimum order total** to let say '**$50**', **normal amount** to **$10**, **Discounted amount** to **$0**.
2. Create an order from admin end.
3. Add a product which is of less than $50 with a single quantity.
4. Go to shipment tab, you will shipment charges are being applied to the order.
5. Now, increase the quantity of product to make order subtotal greater than $50.
6. Technically now shipment cost should become 0 as order total is greater than $50. But you will still see a charge of $10 as the shipment rate is being calculated on previous order total instead of current order total.
7. Now, Order total is greater than $50. Edit the shipment again to make the order total to become less than $50.
8.  Technically now shipment cost should become $10 as order total is less than $50. But you will see a charge of $0 as the shipment rate is being calculated on previous order which was greater than $50