### PR TITLE
[Admin End] Add missing translations for order state changes

### DIFF
--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -50,7 +50,7 @@
         <div class="col-md-4">
           <div class="form-group">
             <%= label_tag :q_state_eq, Spree.t(:status) %>
-            <%= f.select :state_eq, Spree::Order.state_machines[:state].states.map {|s| [Spree.t("order_state.#{s.name}"), s.value]}, {include_blank: true}, class: 'select2 js-filterable' %>
+            <%= f.select :state_eq, Spree::Order.state_machines[:state].states.map {|s| [Spree.t("order_states.#{s.name}"), s.value]}, {include_blank: true}, class: 'select2 js-filterable' %>
           </div>
         </div>
 
@@ -181,7 +181,7 @@
           </span>
         </td>
         <td>
-          <span class="label label-<%= order.state.downcase %>"><%= Spree.t("order_state.#{order.state.downcase}") %></span>
+          <span class="label label-<%= order.state.downcase %>"><%= Spree.t("order_states.#{order.state.downcase}") %></span>
           <span class="icon icon-filter filterable js-add-filter" data-ransack-field="q_state_eq" data-ransack-value="<%= order.state %>"></span>
         </td>
         <td>

--- a/backend/app/views/spree/admin/shared/_order_summary.html.erb
+++ b/backend/app/views/spree/admin/shared/_order_summary.html.erb
@@ -11,7 +11,7 @@
         </td>
         <td>
           <span class="state label label-<%= @order.state %>">
-            <%= Spree.t(@order.state, scope: :order_state) %>
+            <%= Spree.t(@order.state, scope: :order_states) %>
           </span>
         </td>
       </tr>

--- a/backend/app/views/spree/admin/shared/_update_order_state.js.erb
+++ b/backend/app/views/spree/admin/shared/_update_order_state.js.erb
@@ -1,4 +1,4 @@
-$('#order_tab_summary h5#order_status').html('<%= j Spree.t(:status) %>: <%= j Spree.t(@order.state, scope: :order_state) %>');
+$('#order_tab_summary h5#order_status').html('<%= j Spree.t(:status) %>: <%= j Spree.t(@order.state, scope: :order_states) %>');
 $('#order_tab_summary h5#order_total').html('<%= j Spree.t(:total) %>: <%= j @order.display_total.to_html %>');
 
 <% if @order.completed? %>

--- a/backend/app/views/spree/admin/state_changes/index.html.erb
+++ b/backend/app/views/spree/admin/state_changes/index.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: 'spree/admin/shared/order_tabs', locals: { current: :state_changes } %>
 
-<% content_for :page_title do %>  
+<% content_for :page_title do %>
   / <%= plural_resource_name(Spree::StateChange) %>
   / <%= Spree::StateChange.human_attribute_name(:state_changes) %>
 <% end %>
@@ -21,8 +21,8 @@
       <% @state_changes.each do |state_change| %>
         <tr>
           <td><%= Spree.t("state_machine_states.#{state_change.name}") %></td>
-          <td><%= state_change.previous_state ? Spree.t(state_change.previous_state) : Spree.t(:previous_state_missing) %></td>
-          <td><%= Spree.t(state_change.next_state) %></td>
+          <td><%= state_change.previous_state ? Spree.t(state_change.previous_state, scope: "#{ state_change.name }_states") : Spree.t(:previous_state_missing) %></td>
+          <td><%= Spree.t(state_change.next_state, scope: "#{ state_change.name}_states") %></td>
           <td>
             <% if state_change.user %>
               <% user_login = state_change.user.try(:login) || state_change.user.try(:email) %>

--- a/backend/app/views/spree/admin/users/items.html.erb
+++ b/backend/app/views/spree/admin/users/items.html.erb
@@ -39,7 +39,7 @@
               <td class="item-quantity"><%= item.quantity %></td>
               <td class="item-total"><%= item.money.to_html %></td>
               <td class="order-state">
-                <div class="state <%= order.state.downcase %>"><%= Spree.t("order_state.#{order.state.downcase}") %></div>
+                <div class="state <%= order.state.downcase %>"><%= Spree.t("order_states.#{order.state.downcase}") %></div>
                 <% if order.payment_state %>
                   <div class="state <%= order.payment_state %>"><%= link_to Spree.t("payment_states.#{order.payment_state}"), admin_order_payments_path(order) %></div>
                 <% end %>

--- a/backend/app/views/spree/admin/users/orders.html.erb
+++ b/backend/app/views/spree/admin/users/orders.html.erb
@@ -26,7 +26,7 @@
           <td class="order-completed-at"><%= order_time(order.completed_at) if order.completed_at %></td>
           <td class="order-number"><%= link_to order.number, edit_admin_order_path(order) %></td>
           <td class="order-state">
-            <div class="state <%= order.state.downcase %>"><%= Spree.t("order_state.#{order.state.downcase}") %></div>
+            <div class="state <%= order.state.downcase %>"><%= Spree.t("order_states.#{order.state.downcase}") %></div>
             <% if order.payment_state %>
               <div class="state <%= order.payment_state %>"><%= link_to Spree.t("payment_states.#{order.payment_state}"), admin_order_payments_path(order) %></div>
             <% end %>

--- a/backend/spec/features/admin/orders/state_changes_spec.rb
+++ b/backend/spec/features/admin/orders/state_changes_spec.rb
@@ -13,8 +13,8 @@ describe "Order - State Changes", type: :feature do
     it 'are viewable' do
       within_row(1) do
         within('td:nth-child(1)') { expect(page).to have_content('Order') }
-        within('td:nth-child(2)') { expect(page).to have_content('Cart') }
-        within('td:nth-child(3)') { expect(page).to have_content('Address') }
+        within('td:nth-child(2)') { expect(page).to have_content('cart') }
+        within('td:nth-child(3)') { expect(page).to have_content('address') }
       end
     end
   end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -990,7 +990,7 @@ en:
     order_number: Order %{number}
     order_processed_successfully: Your order has been processed successfully
     order_resumed: Order resumed
-    order_state:
+    order_states:
       address: address
       awaiting_return: awaiting return
       canceled: canceled

--- a/frontend/app/helpers/spree/frontend_helper.rb
+++ b/frontend/app/helpers/spree/frontend_helper.rb
@@ -23,7 +23,7 @@ module Spree
     def checkout_progress(numbers: false)
       states = @order.checkout_steps
       items = states.each_with_index.map do |state, i|
-        text = Spree.t("order_state.#{state}").titleize
+        text = Spree.t("order_states.#{state}").titleize
         text.prepend("#{i.succ}. ") if numbers
 
         css_classes = []


### PR DESCRIPTION
Some translations were missing for order state changes when we go to state changes tab for a particular order.