### PR TITLE
Fix shipping method display issue

### DIFF
--- a/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
+++ b/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
@@ -23,7 +23,7 @@ module Spree
           if @order.update_attributes(order_params)
             @order.associate_user!(@user, @order.email.blank?) unless guest_checkout?
             @order.next if @order.address?
-            @order.refresh_shipment_rates(Spree::ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END)
+            @order.refresh_shipment_rates(Spree::ShippingMethod::DISPLAY_ON_BACK_END)
 
             if @order.errors.empty?
               flash[:success] = Spree.t('customer_details_updated')

--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -56,7 +56,7 @@ module Spree
       def edit
         can_not_transition_without_customer_info
 
-        @order.refresh_shipment_rates(ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END)
+        @order.refresh_shipment_rates(ShippingMethod::DISPLAY_ON_BACK_END)
       end
 
       def cart

--- a/backend/app/views/spree/admin/shipping_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/_form.html.erb
@@ -11,7 +11,7 @@
     <div data-hook="admin_shipping_method_form_display_field" class="col-md-6">
       <%= f.field_container :display_on, class: ['form-group'] do %>
         <%= f.label :display_on, Spree.t(:display) %>
-        <%= select(:shipping_method, :display_on, Spree::ShippingMethod::DISPLAY.collect { |display| [Spree.t(display), display == :both ? nil : display.to_s] }, {}, { class: 'select2' }) %>
+        <%= select(:shipping_method, :display_on, Spree::ShippingMethod::DISPLAY.collect { |display| [Spree.t(display), display.to_s] }, {}, { class: 'select2' }) %>
         <%= f.error_message_on :display_on %>
       <% end %>
     </div>

--- a/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
@@ -59,7 +59,7 @@ describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
             it { expect(order).to receive(:address?) }
             it 'does refresh the shipment rates with all shipping methods' do
               expect(order).to receive(:refresh_shipment_rates).
-                with(Spree::ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END)
+                with(Spree::ShippingMethod::DISPLAY_ON_BACK_END)
             end
             it { expect(controller).to receive(:load_order).and_call_original }
             it { expect(controller).to receive(:guest_checkout?).twice.and_call_original }
@@ -117,7 +117,7 @@ describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
             it { expect(order).to receive(:address?) }
             it 'does refresh the shipment rates with all shipping methods' do
               expect(order).to receive(:refresh_shipment_rates).
-                with(Spree::ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END)
+                with(Spree::ShippingMethod::DISPLAY_ON_BACK_END)
             end
             it { expect(controller).to receive(:load_order).and_call_original }
             it { expect(controller).to receive(:guest_checkout?).twice.and_call_original }

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -84,7 +84,7 @@ describe Spree::Admin::OrdersController, type: :controller do
 
     # Regression test for #3684
     describe "#edit" do
-      let(:display_value) { Spree::ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END }
+      let(:display_value) { Spree::ShippingMethod::DISPLAY_ON_BACK_END }
 
       before do
         allow(controller).to receive(:can_not_transition_without_customer_info)

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -106,7 +106,7 @@ describe "Order Details", type: :feature, js: true do
         create(:shipping_method, name: "Backdoor", display_on: "back_end")
         order = create(
           :completed_order_with_totals,
-          shipping_method_filter: Spree::ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END
+          shipping_method_filter: Spree::ShippingMethod::DISPLAY_ON_BACK_END
         )
         visit spree.edit_admin_order_path(order)
         within("table tr.show-method") do

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -5,7 +5,6 @@ module Spree
     DISPLAY = [:both, :front_end, :back_end]
 
     # Used for #refresh_rates
-    DISPLAY_ON_FRONT_AND_BACK_END = 0
     DISPLAY_ON_FRONT_END = 1
     DISPLAY_ON_BACK_END = 2
 
@@ -43,22 +42,25 @@ module Spree
         .select { |c| c.to_s.constantize < Spree::ShippingCalculator }
     end
 
-    # Some shipping methods are only meant to be set via backend
-    def frontend?
-      self.display_on != "back_end"
-    end
-
     def tax_category
       Spree::TaxCategory.unscoped { super }
     end
 
-    def available_to_display(display_filter)
-      display_filter == DISPLAY_ON_FRONT_AND_BACK_END ||
+    def available_to_display?(display_filter)
       (frontend? && display_filter == DISPLAY_ON_FRONT_END) ||
-      (!frontend? && display_filter == DISPLAY_ON_BACK_END)
+      (backend? && display_filter == DISPLAY_ON_BACK_END)
     end
 
     private
+
+    # Some shipping methods are only meant to be set via backend
+    def frontend?
+      display_on.in?(['both', 'front_end'])
+    end
+
+    def backend?
+      display_on.in?(['both', 'back_end'])
+    end
 
     def at_least_one_shipping_category
       if shipping_categories.empty?

--- a/core/app/models/spree/stock/estimator.rb
+++ b/core/app/models/spree/stock/estimator.rb
@@ -58,7 +58,7 @@ module Spree
         package.shipping_methods.select do |ship_method|
           calculator = ship_method.calculator
 
-          ship_method.available_to_display(display_filter) &&
+          ship_method.available_to_display?(display_filter) &&
           ship_method.include?(order.ship_address) &&
           calculator.available?(package) &&
           (calculator.preferences[:currency].blank? ||

--- a/core/lib/spree/testing_support/factories/shipping_method_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipping_method_factory.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
     zones { |a| [Spree::Zone.global] }
     name 'UPS Ground'
     code 'UPS_GROUND'
+    display_on 'both'
 
     before(:create) do |shipping_method, evaluator|
       if shipping_method.shipping_categories.empty?

--- a/core/spec/models/spree/shipping_method_spec.rb
+++ b/core/spec/models/spree/shipping_method_spec.rb
@@ -5,6 +5,9 @@ end
 
 describe Spree::ShippingMethod, type: :model do
   let(:shipping_method){ create(:shipping_method) }
+  let(:frontend_shipping_method) { create :shipping_method, display_on: 'front_end' }
+  let(:backend_shipping_method) { create :shipping_method, display_on: 'back_end' }
+  let(:front_and_back_end_shipping_method) { create :shipping_method, display_on: 'both' }
 
   context 'calculators' do
     it "Should reject calculators that don't inherit from Spree::ShippingCalculator" do
@@ -92,4 +95,31 @@ describe Spree::ShippingMethod, type: :model do
       expect(shipping_method.deleted_at).not_to be_blank
     end
   end
+
+  describe '#available_to_display?' do
+    context 'when available on frontend' do
+      it { expect(frontend_shipping_method.available_to_display?(Spree::ShippingMethod::DISPLAY_ON_FRONT_END)).to be true }
+      it { expect(backend_shipping_method.available_to_display?(Spree::ShippingMethod::DISPLAY_ON_FRONT_END)).to be false }
+      it { expect(front_and_back_end_shipping_method.available_to_display?(Spree::ShippingMethod::DISPLAY_ON_FRONT_END)).to be true }
+    end
+
+    context 'when available on backend' do
+      it { expect(frontend_shipping_method.available_to_display?(Spree::ShippingMethod::DISPLAY_ON_BACK_END)).to be false }
+      it { expect(backend_shipping_method.available_to_display?(Spree::ShippingMethod::DISPLAY_ON_BACK_END)).to be true }
+      it { expect(front_and_back_end_shipping_method.available_to_display?(Spree::ShippingMethod::DISPLAY_ON_BACK_END)).to be true }
+    end
+  end
+
+  describe '#frontend?' do
+    it { expect(frontend_shipping_method.send(:frontend?)).to be true }
+    it { expect(backend_shipping_method.send(:frontend?)).to be false }
+    it { expect(front_and_back_end_shipping_method.send(:frontend?)).to be true }
+  end
+
+  describe '#backend?' do
+    it { expect(frontend_shipping_method.send(:backend?)).to be false }
+    it { expect(backend_shipping_method.send(:backend?)).to be true }
+    it { expect(front_and_back_end_shipping_method.send(:backend?)).to be true }
+  end
+
 end


### PR DESCRIPTION
Issue -
1. Wrong logic use in finding which shipping method should be displayed on frontend and backend
2. Method marked to be displayed on frontend only is also available on backend.
3. ``DISPLAY_ON_BACK_END`` constant is never being used.
4. Method that should be private were written as public method
5. avialble_to display should be a predicate method.

Fix.
1) Make separate method to check which Shipping Method should be available on frontend and backend.
2) Use ``DISPLAY_ON_BACK_END`` instead of ``DISPLAY_ON_FRONT_AND_BACK_END`` to ensure only shipping methods with display_on in [both, backend] are available on backend
3) Simplify logic of ``avialble_to display`` method and make it a predicate method.
