### PR TITLE
Engine: Routes: Use `add_routes` to prevent routes being drawn twice

### DIFF
--- a/cmd/lib/spree_cmd/templates/extension/config/routes.rb
+++ b/cmd/lib/spree_cmd/templates/extension/config/routes.rb
@@ -1,3 +1,3 @@
-Spree::Core::Engine.routes.draw do
+Spree::Core::Engine.add_routes do
   # Add your extension routes here
 end


### PR DESCRIPTION
For more details why `add_routes` is needed, please refer to:
`spree/core/lib/spree/core/routes.rb`