### PR TITLE
[WIP] Fix/avoid postgres distinct order by issue tests

### DIFF
--- a/backend/spec/features/admin/taxons_spec.rb
+++ b/backend/spec/features/admin/taxons_spec.rb
@@ -2,17 +2,11 @@ require 'spec_helper'
 
 feature "Taxonomies and taxons" do
   stub_authorization!
-  before(:all) do
-    visit spree.new_admin_taxonomy_path
 
-    fill_in "Name", with: "Hello"
-    click_button "Create"
-
-    @taxonomy = Spree::Taxonomy.last
-  end
+  let(:taxonomy) { create(:taxonomy, name: 'Hello') }
 
   scenario "admin should be able to edit taxon" do
-    visit spree.edit_admin_taxonomy_taxon_path(@taxonomy, @taxonomy.root.id)
+    visit spree.edit_admin_taxonomy_taxon_path(taxonomy, taxonomy.root.id)
 
     fill_in "taxon_name", with: "Shirt"
     fill_in "taxon_description", with: "Discover our new rails shirts"
@@ -23,7 +17,7 @@ feature "Taxonomies and taxons" do
   end
 
   scenario "taxon without name should not be updated" do
-    visit spree.edit_admin_taxonomy_taxon_path(@taxonomy, @taxonomy.root.id)
+    visit spree.edit_admin_taxonomy_taxon_path(taxonomy, taxonomy.root.id)
 
     fill_in "taxon_name", with: ""
     fill_in "taxon_description", with: "Discover our new rails shirts"

--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -244,7 +244,7 @@ module Spree
       # specifically avoid having an order for taxon search (conflicts with main order)
       def self.prepare_taxon_conditions(taxons)
         ids = taxons.map { |taxon| taxon.self_and_descendants.pluck(:id) }.flatten.uniq
-        joins(:taxons).where("#{Taxon.table_name}.id" => ids)
+        joins(:classifications).where(Classification.table_name => { taxon_id: ids })
       end
 
       # Produce an array of keywords for use in scopes.

--- a/core/lib/generators/spree/install/install_generator.rb
+++ b/core/lib/generators/spree/install/install_generator.rb
@@ -2,6 +2,7 @@ require 'rails/generators'
 require 'highline/import'
 require 'bundler'
 require 'bundler/cli'
+require 'active_support/core_ext/string/indent'
 
 module Spree
   class InstallGenerator < Rails::Generators::Base


### PR DESCRIPTION
I tried to fix broken specs of #7950

**Done:**
1. Changed ```Spree::Classification``` to ```Classification``` ('where' method)
2. Required the active support file responsible supplying ```String```class with ```#indent! ``` (see https://github.com/spree/spree/commit/a89eede9a0e2107c7c13825f17704f389bda0b9d).
Now it breaks on building sample test_app even on development.

```
 cd sample && bundle exec rake test_app
```

```
Generating dummy Rails application...
rake aborted!
NoMethodError: undefined method `indent!' for #<String:0x007fdbe1ad8490>
Did you mean?  index
/Users/nati/Projects/spree/core/lib/generators/spree/install/install_generator.rb:78:in `configure_application'
/Users/nati/.rvm/gems/ruby-2.3.1@hingeto/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
/Users/nati/.rvm/gems/ruby-2.3.1@hingeto/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
/Users/nati/.rvm/gems/ruby-2.3.1@hingeto/gems/thor-0.19.4/lib/thor/invocation.rb:133:in `block in invoke_all'
/Users/nati/.rvm/gems/ruby-2.3.1@hingeto/gems/thor-0.19.4/lib/thor/invocation.rb:133:in `each'
/Users/nati/.rvm/gems/ruby-2.3.1@hingeto/gems/thor-0.19.4/lib/thor/invocation.rb:133:in `map'
/Users/nati/.rvm/gems/ruby-2.3.1@hingeto/gems/thor-0.19.4/lib/thor/invocation.rb:133:in `invoke_all'
/Users/nati/.rvm/gems/ruby-2.3.1@hingeto/gems/thor-0.19.4/lib/thor/group.rb:232:in `dispatch'
/Users/nati/.rvm/gems/ruby-2.3.1@hingeto/gems/thor-0.19.4/lib/thor/base.rb:444:in `start'
/Users/nati/Projects/spree/core/lib/spree/testing_support/common_rake.rb:16:in `block (2 levels) in <top (required)>'
/Users/nati/Projects/spree/sample/Rakefile:14:in `block in <top (required)>'
/Users/nati/.rvm/gems/ruby-2.3.1@hingeto/gems/rake-12.0.0/exe/rake:27:in `<top (required)>'
/Users/nati/.rvm/gems/ruby-2.3.1@hingeto/gems/bundler-1.14.6/lib/bundler/cli/exec.rb:74:in `load'
/Users/nati/.rvm/gems/ruby-2.3.1@hingeto/gems/bundler-1.14.6/lib/bundler/cli/exec.rb:74:in `kernel_load'
/Users/nati/.rvm/gems/ruby-2.3.1@hingeto/gems/bundler-1.14.6/lib/bundler/cli/exec.rb:27:in `run'
/Users/nati/.rvm/gems/ruby-2.3.1@hingeto/gems/bundler-1.14.6/lib/bundler/cli.rb:335:in `exec'
/Users/nati/.rvm/gems/ruby-2.3.1@hingeto/gems/bundler-1.14.6/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/Users/nati/.rvm/gems/ruby-2.3.1@hingeto/gems/bundler-1.14.6/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/Users/nati/.rvm/gems/ruby-2.3.1@hingeto/gems/bundler-1.14.6/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'
/Users/nati/.rvm/gems/ruby-2.3.1@hingeto/gems/bundler-1.14.6/lib/bundler/cli.rb:20:in `dispatch'
/Users/nati/.rvm/gems/ruby-2.3.1@hingeto/gems/bundler-1.14.6/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'
/Users/nati/.rvm/gems/ruby-2.3.1@hingeto/gems/bundler-1.14.6/lib/bundler/cli.rb:11:in `start'
/Users/nati/.rvm/gems/ruby-2.3.1@hingeto/gems/bundler-1.14.6/exe/bundle:32:in `block in <top (required)>'
/Users/nati/.rvm/gems/ruby-2.3.1@hingeto/gems/bundler-1.14.6/lib/bundler/friendly_errors.rb:121:in `with_friendly_errors'
/Users/nati/.rvm/gems/ruby-2.3.1@hingeto/gems/bundler-1.14.6/exe/bundle:24:in `<top (required)>'
/Users/nati/.rvm/gems/ruby-2.3.1@hingeto/bin/bundle:23:in `load'
/Users/nati/.rvm/gems/ruby-2.3.1@hingeto/bin/bundle:23:in `<main>'
```
3. Taxon feature spec fixed. Replaced before(:all) block with classic let, which might help resolving timeouts on Circle CI.
 
All in all, this did not cause Circle CI build successful - it mysteriously timed out. However, errors from #7950 build disappeared. 

Any ideas what could be the exact issue here?