### PR TITLE
Disable Style/FrozenStringLiteralComment within rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -93,6 +93,9 @@ FlipFlop:
 FormatString:
   Enabled: false
 
+FrozenStringLiteralComment:
+  Enabled: false
+
 GlobalVars:
   Enabled: false
 


### PR DESCRIPTION
Tell the hound not to care about that violation :)
http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/FrozenStringLiteralComment