### PR TITLE
changed flow: reset checkout flow instead of @order.next

### DIFF
--- a/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
+++ b/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
@@ -22,7 +22,8 @@ module Spree
         def update
           if @order.update_attributes(order_params)
             @order.associate_user!(@user, @order.email.blank?) unless guest_checkout?
-            @order.next if @order.address?
+
+            @order.restart_checkout_flow unless @order.complete?
             @order.refresh_shipment_rates(Spree::ShippingMethod::DISPLAY_ON_BACK_END)
 
             if @order.errors.empty?

--- a/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
@@ -43,7 +43,8 @@ describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
           before do
             allow(order).to receive_messages(update_attributes: true)
             allow(order).to receive_messages(next: false)
-            allow(order).to receive_messages(address?: false)
+            allow(order).to receive_messages(complete?: false)
+            allow(order).to receive(:restart_checkout_flow)
             allow(order).to receive_messages(refresh_shipment_rates: true)
           end
 
@@ -56,7 +57,8 @@ describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
           context 'with correct method flow' do
             it { expect(order).to receive(:update_attributes).with(ActionController::Parameters.new(attributes[:order]).permit(permitted_order_attributes)) }
             it { expect(order).to_not receive(:next) }
-            it { expect(order).to receive(:address?) }
+            it { expect(order).to receive(:complete?) }
+            it { expect(order).to receive(:restart_checkout_flow) }
             it 'does refresh the shipment rates with all shipping methods' do
               expect(order).to receive(:refresh_shipment_rates).
                 with(Spree::ShippingMethod::DISPLAY_ON_BACK_END)
@@ -97,7 +99,8 @@ describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
             allow(Spree.user_class).to receive(:find_by).and_return(user)
             allow(order).to receive_messages(update_attributes: true)
             allow(order).to receive_messages(next: false)
-            allow(order).to receive_messages(address?: false)
+            allow(order).to receive_messages(complete?: false)
+            allow(order).to receive(:restart_checkout_flow)
             allow(order).to receive_messages(refresh_shipment_rates: true)
             allow(order).to receive_messages(associate_user!: true)
             allow(controller).to receive(:guest_checkout?).and_return(false)
@@ -114,7 +117,8 @@ describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
             it { expect(order).to receive(:update_attributes).with(ActionController::Parameters.new(attributes[:order]).permit(permitted_order_attributes)) }
             it { expect(order).to receive(:associate_user!).with(user, order.email.blank?) }
             it { expect(order).to_not receive(:next) }
-            it { expect(order).to receive(:address?) }
+            it { expect(order).to receive(:complete?) }
+            it { expect(order).to receive(:restart_checkout_flow) }
             it 'does refresh the shipment rates with all shipping methods' do
               expect(order).to receive(:refresh_shipment_rates).
                 with(Spree::ShippingMethod::DISPLAY_ON_BACK_END)
@@ -152,7 +156,8 @@ describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
               allow(Spree.user_class).to receive(:find_by).and_return(user)
               allow(order).to receive_messages(update_attributes: true)
               allow(order).to receive_messages(next: false)
-              allow(order).to receive_messages(address?: false)
+              allow(order).to receive_messages(complete?: false)
+              allow(order).to receive(:restart_checkout_flow)
               allow(order).to receive_messages(refresh_shipment_rates: true)
               allow(order).to receive_messages(associate_user!: true)
               allow(controller).to receive(:guest_checkout?).and_return(false)

--- a/backend/spec/features/admin/orders/new_order_spec.rb
+++ b/backend/spec/features/admin/orders/new_order_spec.rb
@@ -163,7 +163,7 @@ describe "New Order", type: :feature do
       click_link "Customer"
       select_customer
       click_button "Update"
-      expect(Spree::Order.last.state).to eq 'delivery'
+      expect(Spree::Order.last.state).to eq 'address'
     end
   end
 


### PR DESCRIPTION
changed flow: use `reset_checkout_flow` instead of `@order.next`, in-case of updating customer details.

Scenario: The current ` @order.restart_checkout_flow unless @order.complete?` breaks if an spree-app does not uses address state, which may lead to unnecessary consequences.
Solution: updating it to wrapper method `reset_checkout_flow` which, i believe, is more ethical. 