### PR TITLE
bump paranoia gem to 2.3 - prepare for Rails 5.1 support

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 require_relative 'lib/spree/core/version.rb'
 
 Gem::Specification.new do |s|
@@ -31,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'kaminari', '~> 1.0.1'
   s.add_dependency 'monetize', '~> 1.1'
   s.add_dependency 'paperclip', '~> 5.1.0'
-  s.add_dependency 'paranoia', '~> 2.2.0.pre'
+  s.add_dependency 'paranoia', '~> 2.3.0'
   s.add_dependency 'premailer-rails'
   s.add_dependency 'acts-as-taggable-on', '~> 4.0'
   s.add_dependency 'rails', '~> 5.0.0'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Bumping Paranoia to v2.3
<!--- Describe your changes in detail -->

## Motivation and Context
Paranoia added support for Rails 5.1 - https://github.com/rubysherpas/paranoia/releases/tag/v2.3.1
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.