### PR TITLE
enforce has_many through sequence - prepare for Rails 5.1 support

### DIFF
--- a/core/app/models/spree/customer_return.rb
+++ b/core/app/models/spree/customer_return.rb
@@ -4,8 +4,8 @@ module Spree
     belongs_to :stock_location
 
     has_many :reimbursements, inverse_of: :customer_return
-    has_many :return_authorizations, through: :return_items
     has_many :return_items, inverse_of: :customer_return
+    has_many :return_authorizations, through: :return_items
 
     after_create :process_return!
 
@@ -36,7 +36,6 @@ module Spree
       return nil if return_items.blank?
       return_items.first.inventory_unit.order
     end
-
 
     def pre_tax_total
       return_items.sum(:pre_tax_amount)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
move relationships to enforce sequencing noted below
<!--- Describe your changes in detail -->

## Motivation and Context
rails 5.1 deprecation warning: https://github.com/rails/rails/pull/27485
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.