### PR TITLE
[ADMIN END] fix order guest checkout issue

### DIFF
--- a/api/spec/controllers/spree/api/v1/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/orders_controller_spec.rb
@@ -425,12 +425,12 @@ module Spree
         expect(json_response['errors']['ship_address.firstname'].first).to eq "can't be blank"
       end
 
-      it "cannot set the user_id for the order" do
+      it "can set the user_id for the order" do
         user = Spree.user_class.create
         original_id = order.user_id
         api_post :update, id: order.to_param, order: { user_id: user.id }
         expect(response.status).to eq 200
-        expect(json_response["user_id"]).to eq(original_id)
+        expect(json_response["user_id"]).to eq(user.id)
       end
 
       context "order has shipments" do

--- a/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
+++ b/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
@@ -33,7 +33,7 @@ $(document).ready(function() {
       formatResult: formatCustomerResult,
       formatSelection: function (customer) {
         $('#order_email').val(customer.email);
-        $('#user_id').val(customer.id);
+        $('#order_user_id').val(customer.id);
         $('#guest_checkout_true').prop('checked', false);
         $('#guest_checkout_false').prop('checked', true);
         $('#guest_checkout_false').prop('disabled', false);
@@ -77,7 +77,7 @@ $(document).ready(function() {
 
   $('#guest_checkout_true').change(function() {
     $('#customer_search').val('');
-    $('#user_id').val('');
+    $('#order_user_id').val('');
     $('#order_email').val('');
 
     var fields = ['firstname', 'lastname', 'company', 'address1', 'address2',

--- a/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
+++ b/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
@@ -40,8 +40,7 @@ module Spree
 
         def order_params
           params.require(:order).permit(
-            :email,
-            :use_billing,
+            :email, :user_id, :use_billing,
             bill_address_attributes: permitted_address_attributes,
             ship_address_attributes: permitted_address_attributes
           )
@@ -56,7 +55,7 @@ module Spree
         end
 
         def load_user
-          @user = (Spree.user_class.find_by(id: params[:user_id]) ||
+          @user = (Spree.user_class.find_by(id: order_params[:user_id]) ||
             Spree.user_class.find_by(email: order_params[:email]))
 
           unless @user

--- a/backend/app/views/spree/admin/orders/customer_details/_form.html.erb
+++ b/backend/app/views/spree/admin/orders/customer_details/_form.html.erb
@@ -45,7 +45,7 @@
                   <%= Spree.t(:say_no) %>
                 <% end %>
               </div>
-              <%= hidden_field_tag :user_id, @order.user_id %>
+              <%= f.hidden_field :user_id, value: @order.user_id %>
             <% end %>
           </div>
         </div>

--- a/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
@@ -7,6 +7,8 @@ describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
   context "with authorization" do
     stub_authorization!
 
+    let(:user) { mock_model(Spree.user_class) }
+
     let(:order) do
       mock_model(
         Spree::Order,
@@ -28,7 +30,8 @@ describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
             email: "",
             use_billing: "",
             bill_address_attributes: { firstname: 'john' },
-            ship_address_attributes: { firstname: 'john' }
+            ship_address_attributes: { firstname: 'john' },
+            user_id: user.id.to_s
           },
           guest_checkout: 'true'
         }
@@ -89,8 +92,7 @@ describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
       end
 
       context 'without using guest checkout' do
-        let(:user) { mock_model(Spree.user_class) }
-        let(:changed_attributes) { attributes.merge(guest_checkout: 'false', user_id: user.id) }
+        let(:changed_attributes) { attributes.merge(guest_checkout: 'false') }
 
         context 'having valid parameters' do
           before do

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -38,7 +38,7 @@ module Spree
     ]
 
     @@checkout_attributes = [
-      :coupon_code, :email, :shipping_method_id, :special_instructions, :use_billing
+      :coupon_code, :email, :shipping_method_id, :special_instructions, :use_billing, :user_id
     ]
 
     @@customer_return_attributes = [:stock_location_id, return_items_attributes: [:id, :inventory_unit_id, :return_authorization_id, :returned, :pre_tax_amount, :acceptance_status, :exchange_variant_id, :resellable]]


### PR DESCRIPTION
## Issue
Cannot guest checkout a order from admin end, if order is already associated with a user.

## Steps to replicate
* Create a order from admin end, say for user X. (Note: Do not complete the order at this stage)
* Now go back to order -> customer page
* Select guest checkout 'yes' option, fill address details and click Update.
* 'Customer Details Updated' is shown to the user.
* At this stage the user for this order should be nil, but user X is still associated with the order. (Note: This can be confirmed using rails console)

## Reason
When we select **guest checkout 'yes'** option, `params[:user_id]` field is set `nil` through javascript.
But while updating the order, the value `params[:user_id] = nil` does not show its effect, because it is not nested under order_params. Hence for proper results, we should use `params[:order][:user_id]`.
