### PR TITLE
bump rails 5.1 dependencies - prep for Rails 5.1

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |s|
   s.files        = `git ls-files`.split("\n")
   s.require_path = 'lib'
 
-  s.add_dependency 'activemerchant', '~> 1.59'
+  s.add_dependency 'activemerchant', '~> 1.66.0'
   s.add_dependency 'acts_as_list', '~> 0.8'
-  s.add_dependency 'awesome_nested_set', '~> 3.1.1'
+  s.add_dependency 'awesome_nested_set', '~> 3.1.3'
   s.add_dependency 'carmen', '~> 1.0.0'
   s.add_dependency 'cancancan', '~> 1.10.1'
   s.add_dependency 'deface', '~> 1.0'
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '~> 5.0.0'
   s.add_dependency 'ransack', '~> 1.8.0'
   s.add_dependency 'responders'
-  s.add_dependency 'state_machines-activerecord', '~> 0.2'
+  s.add_dependency 'state_machines-activerecord', '~> 0.4.1'
   s.add_dependency 'stringex'
   s.add_dependency 'twitter_cldr', '~> 4.3'
   s.add_dependency 'sprockets-rails'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
bump the following: 
1. [ActiveMerchant](https://github.com/activemerchant/active_merchant/pull/2407) closes #7976 
2. [Awesome Nested Set](https://github.com/collectiveidea/awesome_nested_set/pull/372)
3. [State Machines-Activerecord](https://github.com/state-machines/state_machines-activerecord/pull/51)

<!--- Describe your changes in detail -->

## Motivation and Context
rails 5.1 dependencies need to support rails 5.1
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.