### PR TITLE
Presence validation added on product_property's value

### DIFF
--- a/api/spec/controllers/spree/api/v1/product_properties_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/product_properties_controller_spec.rb
@@ -49,8 +49,8 @@ module Spree
     end
 
     it "can search for product properties" do
-      product.product_properties.create(property_name: "Shirt Size")
-      product.product_properties.create(property_name: "Shirt Weight")
+      product.product_properties.create(property_name: "Shirt Size", value: "M")
+      product.product_properties.create(property_name: "Shirt Weight", value: "H")
       api_get :index, q: { property_name_cont: "size" }
       expect(json_response["product_properties"].first['property_name']).to eq('Shirt Size')
       expect(json_response["product_properties"].first).to have_attributes(attributes)

--- a/core/app/models/spree/product_property.rb
+++ b/core/app/models/spree/product_property.rb
@@ -9,7 +9,7 @@ module Spree
 
     validates :property, presence: true
 
-    validates :value, db_maximum_length: true
+    validates :value, db_maximum_length: true, presence: true
 
     default_scope { order(:position) }
 

--- a/core/lib/spree/testing_support/factories/product_property_factory.rb
+++ b/core/lib/spree/testing_support/factories/product_property_factory.rb
@@ -2,5 +2,6 @@ FactoryGirl.define do
   factory :product_property, class: Spree::ProductProperty do
     product
     property
+    sequence(:value) { |n| "value_#{n}" }
   end
 end

--- a/core/spec/models/spree/product_property_spec.rb
+++ b/core/spec/models/spree/product_property_spec.rb
@@ -1,6 +1,16 @@
 require 'spec_helper'
 
 describe Spree::ProductProperty, type: :model do
+  context 'Associations' do
+    it { is_expected.to belong_to(:product).inverse_of(:product_properties).touch(true).class_name('Spree::Product') }
+    it { is_expected.to belong_to(:property).inverse_of(:product_properties).class_name('Spree::Property') }
+  end
+
+  context 'Validations' do
+    it { is_expected.to validate_presence_of(:property) }
+    it { is_expected.to validate_presence_of(:value) }
+  end
+
   context "touching" do
     it "should update product" do
       pp = create(:product_property)


### PR DESCRIPTION
## Issue
Admin can create a product property having no value.

## Steps to replicate
At **admin end**, go to products page.
Open properties section of any product.
Add a new property with a blank value.
Click on Update.

Now at **front end**, go to this product's show page.
Here the property name is displayed but without any value.
This looks quite odd to the user, because a property must be paired with its value.

## Fix
Add `presence validation` check on `value column of product_property` model.
   