### PR TITLE
[Front End] Fix store-credit payment issue

### DIFF
--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -267,8 +267,7 @@ module Spree
       end
 
       def invalidate_old_payments
-        return if store_credit? # store credits shouldn't invalidate other payment types
-        order.payments.with_state('checkout').where("id != ?", self.id).each do |payment|
+        order.payments.with_state('checkout').where.not(id: id).each do |payment|
           payment.invalidate! unless payment.store_credit?
         end
       end


### PR DESCRIPTION
Issue - Selecting store credit payment method won't invalidate old payments.
Steps to replicate:
1. Create order from frontend.
2. Go to payment method.
3. Select credit card payment method.
4. From **Confirm** step, go back to **Payment** step.
5. Now select **Store Credit** Payment method and continue.
6. This time you will be redirected back to payment step.

Reason:
Old payments didn't get invalidated because the selected payment method was **store credit**
and the code snippet
``    def insufficient_payment?
      params[:state] == "confirm" &&
        @order.payment_required? &&
        @order.payments.valid.sum(:amount) != @order.total
    end``
 in ``checkout controller``, 
redirect order again to payment state as ``@order.payments.valid.sum(:amount) != @order.total`` returns true