### PR TITLE
Admin: Fix sidebar minimized cookie logic

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -44,9 +44,9 @@ jQuery(function($) {
       .toggleClass(mainWrapperExpandedClasses);
 
     if (wrapper.hasClass('sidebar-minimized')) {
-      $.cookie('sidebar-minimized', 'false', { path: '/admin' });
-    } else {
       $.cookie('sidebar-minimized', 'true', { path: '/admin' });
+    } else {
+      $.cookie('sidebar-minimized', 'false', { path: '/admin' });
     }
   });
 


### PR DESCRIPTION
Why:

* The if-statement was wrongly storing the opposite value: when sidebar
  was minimized, it was storing 'sidebar-minimized': 'false', and when
  sidebar was expanded, it was storing 'sidebar-minimized': 'true'
* This happened because before it was checking if wrapper had
  'sidebar-minimized' class before changing the value due to the user
  click. The recent change (514f25e43857f917236efe8e7b56fe23d3af3242)
  is first toggling the class, and then checking for its presence

How:

* Swap the cookie setting order in if-else statement