### PR TITLE
[bump] versioncake to 3.3; ruby 2.4 deprecation warning

### DIFF
--- a/api/spree_api.gemspec
+++ b/api/spree_api.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'spree_core', s.version
   s.add_dependency 'rabl', '~> 0.13.1'
-  s.add_dependency 'versioncake', '~> 3.2.0'
+  s.add_dependency 'versioncake', '~> 3.3.0'
 end


### PR DESCRIPTION
see: https://github.com/bwillis/versioncake/pull/62