### PR TITLE
7450 move forward checkout steps when free order

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -46,7 +46,7 @@ module Spree
     checkout_flow do
       go_to_state :address
       go_to_state :delivery
-      go_to_state :payment, if: ->(order) { order.payment_required? }
+      go_to_state :payment, if: ->(order) { order.payment? || order.payment_required? }
       go_to_state :confirm, if: ->(order) { order.confirmation_required? }
       go_to_state :complete
       remove_transition from: :delivery, to: :confirm


### PR DESCRIPTION
Fix for https://github.com/spree/spree/issues/7450

Because of the feature with promo code input in the cart view, it deletes **payment** step if order total downgrade to 0.0 (it would be silly to require payment details for free order).

The issue was with the input on **payment** checkout step. Downgrading order total to 0.0 was deleting **payment** checkout step. Leaving **payment** checkout step it was sure we are on `unknown_state` so it was redirecting us to **very first** checkout step.

This fix allows us to move out the **payment** checkout step even if it's already deleted when we are leaving.