### PR TITLE
[Admin-End] fix shipment tax issue when a tax category is present on shipping method

### DIFF
--- a/backend/app/controllers/spree/admin/payments_controller.rb
+++ b/backend/app/controllers/spree/admin/payments_controller.rb
@@ -17,6 +17,8 @@ module Spree
       end
 
       def new
+        # Move order to payment state in order to capture tax generated on shipments
+        @order.next if @order.can_go_to_state?('payment')
         @payment = @order.payments.build
       end
 


### PR DESCRIPTION
**Issue**
When a tax category is present on shipping method and order is placed from admin end, then the shipment tax is calculated after the order gets completed.
This makes order's ``payment_state`` to ``balance_due``  even after capturing the payment.

**Steps to Replicate**
1. Add a tax category to any shipment method.
2. Create a new order from Admin End.
3. Now make the payment and complete the order.
4. Now capture the payment, you will still see order's payment state as ``balance_due``.

For ex. lets say
Order Total - $30
Shipment Total - $5
Tax Rate on shipment is 10%
So shipment tax would be $0.5
Now, this shipment tax is added to order's total only when the order gets completed and modify the Order Total to $30.5.
But the payment that was captured was of only $30.

**Reason**
When we move to payment tab from admin end, Order's state is still ``delivery`` and in Spree, tax amount on shipment is calculated when order moves to ``payment`` state.