### PR TITLE
Remove spree extensions registry guide section

### DIFF
--- a/guides/content/developer/tutorials/extensions_tutorial.md
+++ b/guides/content/developer/tutorials/extensions_tutorial.md
@@ -11,10 +11,6 @@ This tutorial continues where we left off in the [Getting Started](getting_start
 
 Extensions are the primary mechanism for customizing a Spree site. They provide a convenient mechanism for Spree developers to share reusable code with one another. Even if you do not plan on sharing your extensions with the community, they can still be a useful way to reuse code within your organization. Extensions are also a convenient mechanism for organizing and isolating discrete chunks of functionality.
 
-### Finding Useful Spree Extensions in the Extension Registry
-
-The [Spree Extension Registry](http://spreecommerce.com/extensions) is a searchable collection of Spree Extensions written and maintained by members of the [Spree Community](http://spreecommerce.com/community). If you need to extend your Spree application's functionality, be sure to have a look in the Extension Registry first; you may find an extension that either implements what you need or provides a good starting point for your own implementation. If you write an extension and it might be useful to others, [publish it in the registry](http://spreecommerce.com/extensions/new) and people will be able to find it and contribute as well.
-
 ## Installing an Extension
 
 We are going to be adding the [spree_i18n](https://github.com/spree-contrib/spree_i18n) extension to our store. SpreeI18n is a extension containing community contributed translations of Spree & ability to supply different attribute values per language such as product names and descriptions. Extensions can also add models, controllers, and views to create new functionality.


### PR DESCRIPTION
The links in the guide were pointed to either `/storefront` or a 404 page on the spreecommerce.org website which ended up being confusing.