### PR TITLE
Circle CI build fixes

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,6 +11,9 @@ dependencies:
     - bundle check --path=vendor/bundle || bundle install --path=vendor/bundle
     - bundle update
     - ./build-ci.rb install
+  pre:
+    - gem uninstall bundler -x -a
+    - gem install bundler -v 1.14.6
 test:
   override:
     - './build-ci.rb test':

--- a/circle.yml
+++ b/circle.yml
@@ -6,8 +6,6 @@ machine:
     - postgresql
   ruby:
     version: 2.3.1
-  pre:
-    - sudo curl --output /usr/local/bin/phantomjs https://s3.amazonaws.com/circle-downloads/phantomjs-2.1.1
 dependencies:
   override:
     - bundle check --path=vendor/bundle || bundle install --path=vendor/bundle


### PR DESCRIPTION
- [X] Circle Ci already uses phantomjs 2.1.1 so no need for manual install
- [X] setting bundler to 1.14.6