### PR TITLE
Removing mutant dependency

### DIFF
--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -35,7 +35,6 @@ group :test do
   gem 'poltergeist', '~> 1.10'
   gem 'timecop'
   gem 'with_model'
-  gem 'mutant-rspec', '~> 0.8'
   gem 'shoulda-matchers', '~> 3.1'
   gem 'shoulda-callback-matchers', '~> 1.1'
   gem 'rails-controller-testing'


### PR DESCRIPTION
Per discussion https://github.com/mbj/mutant/pull/709 , moving forward without mutant for Rails 5.1 support