### PR TITLE
Fix unnecessary order query in check_authorization.

### DIFF
--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -91,7 +91,8 @@ module Spree
     end
 
     def check_authorization
-      order = Spree::Order.find_by_number(params[:id]) || current_order
+      order = Spree::Order.find_by_number(params[:id]) if params[:id].present?
+      order = current_order unless order
 
       if order
         authorize! :edit, order, cookies.signed[:guest_token]


### PR DESCRIPTION
When the `check_authorization` method in the orders_controller is called it always does an query.
Even when there is no id present. 

This PR removes that query when it's not needed. And also prevents finding 'rogue' orders (order where there is no number present) so it does not keep redirecting to the login page.