### PR TITLE
Bump ruby 2.2 required version to 2.2.7

### DIFF
--- a/api/spree_api.gemspec
+++ b/api/spree_api.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.homepage      = 'https://spreecommerce.com'
   s.license       = 'BSD-3-Clause'
 
-  s.required_ruby_version = '>= 2.2.2'
+  s.required_ruby_version = '>= 2.2.7'
 
   s.files         = `git ls-files`.split($\)
   s.executables   = s.files.grep(%r{^bin/}).map{ |f| File.basename(f) }

--- a/backend/spree_backend.gemspec
+++ b/backend/spree_backend.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.summary     = 'backend e-commerce functionality for the Spree project.'
   s.description = 'Required dependency for Spree'
 
-  s.required_ruby_version = '>= 2.2.2'
+  s.required_ruby_version = '>= 2.2.7'
 
   s.author      = 'Sean Schofield'
   s.email       = 'sean@spreecommerce.com'

--- a/cmd/lib/spree_cmd/templates/extension/extension.gemspec
+++ b/cmd/lib/spree_cmd/templates/extension/extension.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.version     = <%= class_name %>.version
   s.summary     = 'Add extension summary here'
   s.description = 'Add (optional) extension description here'
-  s.required_ruby_version = '>= 2.2.2'
+  s.required_ruby_version = '>= 2.2.7'
 
   s.author    = 'You'
   s.email     = 'you@example.com'

--- a/cmd/lib/spree_cmd/templates/extension/travis.yml
+++ b/cmd/lib/spree_cmd/templates/extension/travis.yml
@@ -18,7 +18,7 @@ script:
 
 rvm:
   - 2.3.1
-  - 2.2.5
+  - 2.2.7
 
 addons:
   apt:

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = 'The bare bones necessary for Spree.'
   s.description = 'The bare bones necessary for Spree.'
 
-  s.required_ruby_version     = '>= 2.2.2'
+  s.required_ruby_version     = '>= 2.2.7'
   s.required_rubygems_version = '>= 1.8.23'
 
   s.author      = 'Sean Schofield'

--- a/frontend/spree_frontend.gemspec
+++ b/frontend/spree_frontend.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.summary     = 'Frontend e-commerce functionality for the Spree project.'
   s.description = s.summary
 
-  s.required_ruby_version = '>= 2.2.2'
+  s.required_ruby_version = '>= 2.2.7'
 
   s.author      = 'Sean Schofield'
   s.email       = 'sean@spreecommerce.com'

--- a/spree.gemspec
+++ b/spree.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.summary     = 'Full-stack e-commerce framework for Ruby on Rails.'
   s.description = 'Spree is an open source e-commerce framework for Ruby on Rails. Join us on http://slack.spreecommerce.com'
 
-  s.required_ruby_version = '>= 2.2.2'
+  s.required_ruby_version = '>= 2.2.7'
 
   s.files        = Dir['README.md', 'lib/**/*']
   s.require_path = 'lib'


### PR DESCRIPTION
`acts-as-taggable-on` 5.0 dropped support for ruby prior 2.2.7 via https://github.com/mbleigh/acts-as-taggable-on/commit/f5222d8afaec1337a9d76b27fcc503a9125fc85d