### PR TITLE
Feature: added store credit removal feature on spree frontend 

### DIFF
--- a/core/app/models/spree/order/store_credit.rb
+++ b/core/app/models/spree/order/store_credit.rb
@@ -2,7 +2,7 @@ module Spree
   class Order < Spree::Base
     module StoreCredit
       def add_store_credit_payments
-        payments.store_credits.where(state: 'checkout').map(&:invalidate!)
+        payments.store_credits.where(state: :checkout).map(&:invalidate!)
 
         remaining_total = outstanding_balance
 
@@ -20,6 +20,10 @@ module Spree
           end
           payments.store_credits.checkout
         end
+      end
+
+      def remove_store_credit_payments
+        payments.checkout.store_credits.map(&:invalidate!) unless completed?
       end
 
       def covered_by_store_credit?

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1373,6 +1373,7 @@ en:
       captured: "Used"
       allocated: "Added"
       apply: Apply Store Credit
+      remove: Remove Store Credit
       applicable_amount: "%{amount} in store credit will be applied to this order."
       available_amount: "You have %{amount} in Store Credit available!"
       remaining_amount: "You have %{amount} remaining in your account's Store Credit."

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -62,6 +62,12 @@ FactoryGirl.define do
           end
         end
 
+        factory :completed_order_with_store_credit_payment do
+          after(:create) do |order|
+            create(:store_credit_payment, amount: order.total, order: order)
+          end
+        end
+
         factory :order_ready_to_ship do
           payment_state 'paid'
           shipment_state 'ready'

--- a/core/spec/models/spree/order/store_credit_spec.rb
+++ b/core/spec/models/spree/order/store_credit_spec.rb
@@ -117,6 +117,37 @@ describe 'Order' do
     end
   end
 
+  describe '#remove_store_credit_payments' do
+    let(:order_total) { 500.00 }
+    let(:order) { create(:order, user: store_credit.user, total: order_total) }
+
+    subject { order.remove_store_credit_payments }
+
+    context 'when order is not complete' do
+      let(:store_credit) { create(:store_credit, amount: order_total - 1) }
+
+      before do
+        create(:store_credit_payment_method)
+        order.add_store_credit_payments
+      end
+
+      it { expect { subject }.to change { order.payments.checkout.store_credits.count }.from(1).to(0) }
+      it { expect { subject }.to change { order.payments.with_state(:invalid).store_credits.count }.from(0).to(1) }
+    end
+
+    context 'when order is complete' do
+      let(:order) { create(:completed_order_with_store_credit_payment) }
+      let(:store_credit_payments) { order.payments.checkout.store_credits }
+
+      before do
+        subject
+        order.reload
+      end
+
+      it { expect(order.payments.checkout.store_credits).to eq store_credit_payments }
+    end
+  end
+
   describe '#covered_by_store_credit' do
     context "order doesn't have an associated user" do
       subject { create(:store_credits_order_without_user) }

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -17,7 +17,7 @@ module Spree
     before_action :check_authorization
 
     before_action :setup_for_current_state
-    before_action :add_store_credit_payments, only: [:update]
+    before_action :add_store_credit_payments, :remove_store_credit_payments, only: [:update]
 
     helper 'spree/orders'
 
@@ -176,6 +176,13 @@ module Spree
         if @order.payments.valid.sum(:amount) < @order.total
           redirect_to checkout_state_path(@order.state) and return
         end
+      end
+    end
+
+    def remove_store_credit_payments
+      if params.key?(:remove_store_credit)
+        @order.remove_store_credit_payments
+        redirect_to checkout_state_path(@order.state) and return
       end
     end
 

--- a/frontend/app/views/spree/checkout/_confirm.html.erb
+++ b/frontend/app/views/spree/checkout/_confirm.html.erb
@@ -8,6 +8,9 @@
 </div>
 
 <div class="well text-right form-buttons" data-hook="buttons">
+  <% if @order.using_store_credit? %>
+    <%= button_tag Spree.t('store_credit.remove'), name: 'remove_store_credit', class: 'continue btn' %>
+  <% end %>
   <%= submit_tag Spree.t(:place_order), class: 'btn btn-lg btn-success' %>
   <script>Spree.disableSaveOnClick();</script>
 </div>

--- a/frontend/app/views/spree/checkout/payment/_storecredit.html.erb
+++ b/frontend/app/views/spree/checkout/payment/_storecredit.html.erb
@@ -5,6 +5,7 @@
       <p><%= Spree.t('store_credit.remaining_amount', amount: @order.display_store_credit_remaining_after_capture) %></p>
     <% else %>
       <p><%= Spree.t('store_credit.additional_payment_needed', amount: @order.display_order_total_after_store_credit) %></p>
+      <%= button_tag Spree.t('store_credit.remove'), name: 'remove_store_credit', class: 'continue btn' %>
     <% end %>
   </div>
 

--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -673,6 +673,21 @@ describe 'Checkout', type: :feature, inaccessible: true, js: true do
         remaining_amount = Spree::Money.new(order.total - amount.money.to_f)
         expect(page).to have_content(Spree.t('store_credit.applicable_amount', amount: amount))
         expect(page).to have_content(Spree.t('store_credit.additional_payment_needed', amount: remaining_amount))
+        expect(page).to have_content(Spree.t('store_credit.remove'))
+      end
+
+      context 'remove store credits payments' do
+        before do
+          store_credit.update(amount: 5)
+          additional_store_credit.update(amount: 5)
+          click_button 'Apply Store Credit'
+        end
+        it 'remove store credits button should remove store_credits' do
+          click_button 'Remove Store Credit'
+          expect(current_path).to eq spree.checkout_state_path(:payment)
+          expect(page).to have_content(Spree.t('store_credit.available_amount', amount: order.display_total_available_store_credit))
+          expect(page).to have_selector('button[name="apply_store_credit"]')
+        end
       end
     end
 


### PR DESCRIPTION
Store credit removal feature on spree front-end  for partially paid order(with store credit payments).

Feature:
* When use has insufficient balance to pay from store credit, he can create a store credit payment but can not remove it even if he empties cart.
* This PR allow user to remove his store credit payments from front-end if order is not complete.