### PR TITLE
Fix: added condition to ensure add_to_line_item does not raise execption when options is a ActionController::Parameters object

### DIFF
--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -92,7 +92,8 @@ module Spree
         line_item.quantity += quantity.to_i
         line_item.currency = currency unless currency.nil?
       else
-        opts = ActionController::Parameters.new(options.to_h).
+        options_params = options.is_a?(ActionController::Parameters) ? options : ActionController::Parameters.new(options.to_h)
+        opts = options_params.
                permit(PermittedAttributes.line_item_attributes).to_h.
                merge( { currency: order.currency } )
 


### PR DESCRIPTION
added condition to ensure add_to_line_item does not raise exception when options is a ActionController::Parameters object with Rails5.