### PR TITLE
Even Out: Allow admin to remove store credit for partial store credit payment for order 

### DIFF
--- a/core/app/models/spree/store_credit.rb
+++ b/core/app/models/spree/store_credit.rb
@@ -153,7 +153,7 @@ module Spree
     end
 
     def can_void?(payment)
-      payment.pending?
+      payment.pending? || (payment.checkout? && !payment.order.completed?)
     end
 
     def can_credit?(payment)

--- a/core/spec/models/spree/store_credit_spec.rb
+++ b/core/spec/models/spree/store_credit_spec.rb
@@ -663,11 +663,23 @@ describe 'StoreCredit' do
       end
     end
 
-    context 'checkout payment' do
-      let(:payment_state) { 'checkout' }
+    context 'remove store credits' do
+      let(:payment_state) { :checkout }
 
-      it 'returns false' do
-        expect(subject).to be false
+      context 'when payment is in checkout and order is not completed' do
+        it { is_expected.to be true }
+      end
+
+      context 'when order is completed' do
+        before { payment.order.update_column(:completed_at, Time.current) }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when payment is completed' do
+        before { payment.update_column(:state, :completed) }
+
+        it { is_expected.to be false }
       end
     end
 


### PR DESCRIPTION
User can remove its store credit payment if additional payment is required. (ref: #8023) 
This PR allows admin to do the same from back-end.
