### PR TITLE
Core: Remove minimum length validation on product slug

### DIFF
--- a/backend/spec/features/admin/products/edit/products_spec.rb
+++ b/backend/spec/features/admin/products/edit/products_spec.rb
@@ -36,14 +36,6 @@ describe 'Product Details', type: :feature, js: true do
       fill_in "product_slug", with: 'random-slug-value'
       click_button "Update"
       expect(page).to have_content("successfully updated!")
-
-      fill_in "product_slug", with: 'a'
-      click_button "Update"
-      within('#product_slug_field') { expect(page).to have_content("is too short") }
-
-      fill_in "product_slug", with: 'another-random-slug-value'
-      click_button "Update"
-      expect(page).to have_content("successfully updated!")
     end
   end
 

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -105,7 +105,7 @@ module Spree
       validates :price, if: proc { Spree::Config[:require_master_price] }
     end
 
-    validates :slug, length: { minimum: 3 }, allow_blank: true, uniqueness: true
+    validates :slug, presence: true, uniqueness: { allow_blank: true }
     validate :discontinue_on_must_be_later_than_available_on, if: -> { available_on && discontinue_on }
 
     attr_accessor :option_values_hash


### PR DESCRIPTION
* There's no specific need to have this code in the core. Anyone willing
  to have this functionality, can easily add it to their own code.