### PR TITLE
fix checkout address issue at admin end

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
+++ b/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
@@ -1,4 +1,14 @@
 //= require_self
+
+var clear_address_fields = function() {
+  var fields = ['firstname', 'lastname', 'company', 'address1', 'address2',
+            'city', 'zipcode', 'state_id', 'country_id', 'phone'];
+  $.each(fields, function(i, field) {
+    $('#order_bill_address_attributes_' + field).val('');
+    $('#order_ship_address_attributes_' + field).val('');
+  });
+};
+
 $(document).ready(function() {
   if ($('#customer_autocomplete_template').length > 0) {
     window.customerTemplate = Handlebars.compile($('#customer_autocomplete_template').text());
@@ -53,6 +63,8 @@ $(document).ready(function() {
               $('#order_bill_address_attributes_state_id').select2('val', billAddress.state_id);
             });
           });
+        } else {
+          clear_address_fields();
         }
         return Select2.util.escapeMarkup(customer.email);
       }
@@ -79,12 +91,6 @@ $(document).ready(function() {
     $('#customer_search').val('');
     $('#order_user_id').val('');
     $('#order_email').val('');
-
-    var fields = ['firstname', 'lastname', 'company', 'address1', 'address2',
-              'city', 'zipcode', 'state_id', 'country_id', 'phone']
-    $.each(fields, function(i, field) {
-      $('#order_bill_address_attributes_' + field).val('');
-      $('#order_ship_address_attributes_' + field).val('');
-    })
+    clear_address_fields();
   });
 });


### PR DESCRIPTION
**Issue** :
Checkout address issue at admin end

**Description**:
When we are at customer details page at admin end and select a user for which shipping and billing address is already available then the address fields get setup accordingly.
But now when we select another user for whom shipping and billing address is not built yet then the value of address fields would remain same that was there for the previous user.

**Steps to replicate**:

1. Create an order from admin end.
2. Checkout to address page.
3. Select a user for whom shipping and billing address is already present.
4. Now you may see his address details in corresponding address fields.
5. Now, Select another user for whom shipping and billing address is not built yet.
6. Address fields won't get cleared and will show the data of the previous user.

**Fix**:
Clear address fields when ``billing_address`` is not present