### PR TITLE
use proper association between product and shipping_category in product form at admin end

### DIFF
--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -139,8 +139,8 @@
       <% end %>
 
       <div data-hook="admin_product_form_shipping_categories">
-        <%= f.field_container :shipping_categories, class: ['form-group'] do %>
-          <%= f.label :shipping_category_id, Spree.t(:shipping_categories) %>
+        <%= f.field_container :shipping_category, class: ['form-group'] do %>
+          <%= f.label :shipping_category_id, Spree.t(:shipping_category) %>
           <%= f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { include_blank: Spree.t('match_choices.none') }, { class: 'select2' }) %>
           <%= f.error_message_on :shipping_category %>
         <% end %>


### PR DESCRIPTION
Association between product and shipping_category is
``belongs_to :shipping_category, class_name: 'Spree::ShippingCategory', inverse_of: :products``

whereas in product form we were using wrong association ``shipping_categories`` due to which if shipping_category validation is failed the that are won't get highlighted.