### PR TITLE
Fix exception on cloning deleted product

### DIFF
--- a/core/lib/spree/core/product_duplicator.rb
+++ b/core/lib/spree/core/product_duplicator.rb
@@ -72,7 +72,7 @@ module Spree
     end
 
     def sku_generator(sku)
-      "COPY OF #{Variant.where('sku like ?', "%#{sku}").order(:created_at).last.sku}"
+      "COPY OF #{Variant.unscoped.where('sku like ?', "%#{sku}").order(:created_at).last.sku}"
     end
   end
 end


### PR DESCRIPTION
## Issue
While cloning a deleted product from backend, the following exception arises.

<img width="1022" alt="screen shot 2017-06-03 at 8 57 47 pm" src="https://cloud.githubusercontent.com/assets/21332195/26754820/65cadb5a-489f-11e7-82bf-e3a1d9b751c0.png">

## Steps to reproduce
1. Delete a product from admin end.
2. Clone this deleted product.
3. An exception will arise `undefined method sku for nil:NilClass`

## Fix
This patch fixes the bug by adding acts_as_paranoid's **with_deleted** scope in **sku_generator** method of **ProductDuplicator**.