### PR TITLE
Remove previously deprecated LineItem#invalid_quantity_check

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -85,11 +85,6 @@ module Spree
     alias total final_amount
     alias money display_total
 
-    def invalid_quantity_check
-      warn "`invalid_quantity_check` is deprecated. Use private `ensure_valid_quantity` instead."
-      ensure_valid_quantity
-    end
-
     def sufficient_stock?
       Stock::Quantifier.new(variant).can_supply? quantity
     end


### PR DESCRIPTION
This was deprecated around Spree 3.1 release via https://github.com/spree/spree/pull/6955/commits/ac2a6980d629af355b3c2ef7b580617bb006653e