### PR TITLE
change default value of included to false in the argument list of create_adjustment method

### DIFF
--- a/core/app/models/concerns/spree/adjustment_source.rb
+++ b/core/app/models/concerns/spree/adjustment_source.rb
@@ -9,7 +9,7 @@ module Spree
 
     protected
 
-    def create_adjustment(order, adjustable, included = nil)
+    def create_adjustment(order, adjustable, included = false)
       amount = compute_amount(adjustable)
       return if amount == 0
       adjustments.new(order: order,


### PR DESCRIPTION
The default value of the column `included` in the `spree_adjustments` table is expected to be **false** as per the schema but the method `create_adjustment` in [adjustment_sources.rb](https://github.com/spree/spree/blob/master/core/app/models/concerns/spree/adjustment_source.rb#L12) defaults it to **nil** due to which adjustments with nil value of included are created which are not returned by either of the two scopes `is_included` or `additional` in the [adjustment.rb](https://github.com/spree/spree/blob/master/core/app/models/spree/adjustment.rb#L67). 

We should fix this ASAP as this may raise payment related issues, in PayPal payment in my case.