### PR TITLE
add uniqueness validation on name and presentation and name field in Property model

### DIFF
--- a/core/app/models/spree/property.rb
+++ b/core/app/models/spree/property.rb
@@ -6,7 +6,7 @@ module Spree
     has_many :product_properties, dependent: :delete_all, inverse_of: :property
     has_many :products, through: :product_properties
 
-    validates :name, :presentation, presence: true
+    validates :name, :presentation, presence: true, uniqueness: { case_sensitive: false, allow_blank: true }
 
     scope :sorted, -> { order(:name) }
 

--- a/core/spec/models/spree/property_spec.rb
+++ b/core/spec/models/spree/property_spec.rb
@@ -1,5 +1,11 @@
 require 'spec_helper'
 
 describe Spree::Property, type: :model do
-
+  describe 'Validations' do
+    subject { Spree::Property.new(name: "brand", presentation: "brand") }
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:presentation) }
+    it { is_expected.to validate_uniqueness_of(:name).case_insensitive }
+    it { is_expected.to validate_uniqueness_of(:presentation).case_insensitive }
+  end
 end


### PR DESCRIPTION
Currently, there is no validation on the uniqueness of Property name and presentation due to which we can create multiple records with same ``name`` and ``presentation`` value.
