### PR TITLE
Remove unnecessary images node

### DIFF
--- a/api/app/views/spree/api/v1/line_items/show.v1.rabl
+++ b/api/app/views/spree/api/v1/line_items/show.v1.rabl
@@ -7,7 +7,6 @@ node(:total) { |li| li.total }
 child :variant do
   extends "spree/api/v1/variants/small"
   attributes :product_id
-  child(images: :images) { extends "spree/api/v1/images/show" }
 end
 
 child adjustments: :adjustments do


### PR DESCRIPTION
This is redundant. [variants/small](https://github.com/spree/spree/blob/master/api/app/views/spree/api/v1/variants/small.v1.rabl) also includes the images. This is just a leftover from the refactor in 41b13310.