### PR TITLE
Search term should be contained as a ransack prefix in params

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/user_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/user_picker.js
@@ -21,7 +21,9 @@ $.fn.userAutocomplete = function () {
       datatype: 'json',
       data: function (term) {
         return {
-          q: term,
+          q: {
+            email_cont: term
+          },
           token: Spree.api_key
         };
       },


### PR DESCRIPTION
The user_picker is used in the User promotion rule. the controller always returns all users as it's expecting a ransack query whereas the js sends a string.