### PR TITLE
Uniqueness validation added on Taxonomy's name and Taxon's permalink

### DIFF
--- a/backend/app/views/spree/admin/taxons/_form.html.erb
+++ b/backend/app/views/spree/admin/taxons/_form.html.erb
@@ -7,9 +7,9 @@
         <%= f.error_message_on :name, class: 'error-message' %>
       <% end %>
 
-      <%= f.field_container :permalink_part, class: ['form-group'] do %>
-        <%= f.label :permalink_part, Spree.t(:permalink) %> <span class="required">*</span>
-        <%= text_field_tag :permalink_part, @permalink_part, class: 'form-control' %>
+      <%= f.field_container :permalink, class: ['form-group'] do %>
+        <%= label_tag :permalink_part, Spree.t(:permalink) %> <span class="required">*</span>
+        <%= text_field_tag :permalink_part, @permalink_part, class: 'form-control', required: true %>
         <p class="help-block" id="permalink_part_display">
           <%= @taxon.permalink.split('/')[0...-1].join('/') + '/' %>
         </p>

--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -20,6 +20,7 @@ module Spree
     has_many :promotion_rules, through: :promotion_rule_taxons, class_name: 'Spree::PromotionRule'
 
     validates :name, presence: true
+    validates :permalink, uniqueness: { case_sensitive: false }
     with_options length: { maximum: 255 }, allow_blank: true do
       validates :meta_keywords
       validates :meta_description

--- a/core/app/models/spree/taxonomy.rb
+++ b/core/app/models/spree/taxonomy.rb
@@ -2,7 +2,7 @@ module Spree
   class Taxonomy < Spree::Base
     acts_as_list
 
-    validates :name, presence: true
+    validates :name, presence: true, uniqueness: { case_sensitive: false, allow_blank: true }
 
     has_many :taxons, inverse_of: :taxonomy
     has_one :root, -> { where parent_id: nil }, class_name: "Spree::Taxon", dependent: :destroy

--- a/core/lib/spree/testing_support/factories/taxon_factory.rb
+++ b/core/lib/spree/testing_support/factories/taxon_factory.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :taxon, class: Spree::Taxon do
-    name 'Ruby on Rails'
+    sequence(:name) { |n| "taxon_#{n}" }
     taxonomy
     parent_id nil
   end

--- a/core/lib/spree/testing_support/factories/taxonomy_factory.rb
+++ b/core/lib/spree/testing_support/factories/taxonomy_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
   factory :taxonomy, class: Spree::Taxonomy do
-    name 'Brand'
+    sequence(:name) { |n| "taxonomy_#{n}" }
   end
 end


### PR DESCRIPTION
Uniqueness validation constraint should be applied to **taxonomy's name** and **taxon's permalink**.

## Scenario
Under `Categories` root taxon, create two taxons with name `Test_1` and `Test_2` respectively.
Now edit the `Test_2` taxon.
Change the permalink field to `Test_1` and Update.
Taxon will be saved successfully and its permalink will become `categories/test-1`, which is same as `Test-1` taxon’s permalink.

## Issue
In front end, by clicking the link to `Test_2` taxon, products under `Test_1` taxon will appear.

## Fix
Add uniqueness validation on **taxon’s permalink**.
In taxon’s edit form, adding `required: true` in `:permalink_part` text_field_tag will also be helpful. It will ensure that the admin must fill out this field.

If we allow multiple taxonomies to have same name, then there root taxons will also have same name and permalink. To avoid this situation, uniqueness validation should also be added to **taxonomy's name**.
