### PR TITLE
remove record from view only if it is successfully destroyed

### DIFF
--- a/backend/app/views/spree/admin/shared/_destroy.js.erb
+++ b/backend/app/views/spree/admin/shared/_destroy.js.erb
@@ -3,6 +3,7 @@
 <% end %>
 
 <% if error = flash.discard(:error) %>
+  $('#content').find('.alert-success').remove();
   show_flash('error', "<%= j error %>");
 <% end %>
 


### PR DESCRIPTION
Issue:
``<tr>`` entry for a record may get removed even if the record is not destroyed successfully.

Steps to Replicate:
1. Go to any index page, Let's say product index page at admin end.
2. Delete a valid record. 
3. Don't refresh the page and try to delete a product which can not be destroyed (For Ex. - A product for which line item exists)
4. Now you will see the flash that ``Product cannot be destroyed`` but the corresponding ``<tr>`` entry is removed from the table.

Reason:
During the first request when the record can be deleted a ``<div>`` with class ``alert-success`` is created.

` $('body').on('click', '.delete-resource', function() {
    var el = $(this);
    if (confirm(el.data("confirm"))) {
      $.ajax({
        type: 'POST',
        url: $(this).prop("href"),
        data: {
          _method: 'delete',
          authenticity_token: AUTH_TOKEN
        },
        dataType: 'script',
        success: function(response) {
          var $flash_element = $('.alert-success');
          if ($flash_element.length) {
            el.parents("tr").fadeOut('hide', function() {
              $(this).remove();
            });
          }
        },
        error: function(response, textStatus, errorThrown) {
          show_flash('error', response.responseText);
        }
      });
    }
    return false;
  });`

In the above, ajax success callback we are checking if any element with class ``alert-success`` is present then remove the row.
So we need to remove any previously created element having class ``alert-success`` in case a record is not deleted.