### PR TITLE
Restrict deletion of payment method if associated with payments or credit cards

### DIFF
--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -12,8 +12,10 @@ module Spree
 
     validates :name, presence: true
 
-    has_many :payments, class_name: "Spree::Payment", inverse_of: :payment_method
-    has_many :credit_cards, class_name: "Spree::CreditCard"
+    with_options dependent: :restrict_with_error do
+      has_many :payments, class_name: "Spree::Payment", inverse_of: :payment_method
+      has_many :credit_cards, class_name: "Spree::CreditCard"
+    end
 
     def self.providers
       Rails.application.config.spree.payment_methods

--- a/core/spec/models/spree/payment_method_spec.rb
+++ b/core/spec/models/spree/payment_method_spec.rb
@@ -1,6 +1,11 @@
 require 'spec_helper'
 
 describe Spree::PaymentMethod, type: :model do
+  describe "Associations" do
+    it { is_expected.to have_many(:payments).class_name("Spree::Payment").inverse_of(:payment_method).dependent(:restrict_with_error) }
+    it { is_expected.to have_many(:credit_cards).class_name("Spree::CreditCard").dependent(:restrict_with_error) }
+  end
+
   context "visibility scopes" do
     before do
       [nil, '', 'both', 'front_end', 'back_end'].each do |display_on|


### PR DESCRIPTION
## Issue
Admin can delete a payment method which has associated payments or credit cards.
This removes the `:payment_method_id` from the existing payments and credit cards objects, which leads to inconsistencies.

## Fix
`dependent: :restrict_with_error` option should be used in the associations.
