### PR TITLE
At Users index page, show alert message if no result is found

### DIFF
--- a/backend/app/views/spree/admin/users/index.html.erb
+++ b/backend/app/views/spree/admin/users/index.html.erb
@@ -42,26 +42,33 @@
   </div>
 <% end %>
 
-<table class="table" id="listing_users" data-hook>
-  <thead>
-    <tr data-hook="admin_users_index_headers">
-      <th>
-        <%= sort_link @search,:email, Spree.t(:user), {}, {title: 'users_email_title'} %>
-      </th>
-      <th data-hook="admin_users_index_header_actions" class="actions"></th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @users.each do |user|%>
-      <tr id="<%= spree_dom_id user %>" data-hook="admin_users_index_rows">
-        <td class='user_email'><%=link_to user.email, edit_admin_user_url(user) %></td>
-        <td data-hook="admin_users_index_row_actions" class="actions actions-2 text-right">
-          <%= link_to_edit user, no_text: true %>
-          <%= link_to_delete user, no_text: true %>
-        </td>
+<% if @users.any? %>
+  <table class="table" id="listing_users" data-hook>
+    <thead>
+      <tr data-hook="admin_users_index_headers">
+        <th>
+          <%= sort_link @search,:email, Spree.t(:user), {}, {title: 'users_email_title'} %>
+        </th>
+        <th data-hook="admin_users_index_header_actions" class="actions"></th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      <% @users.each do |user|%>
+        <tr id="<%= spree_dom_id user %>" data-hook="admin_users_index_rows">
+          <td class='user_email'><%=link_to user.email, edit_admin_user_url(user) %></td>
+          <td data-hook="admin_users_index_row_actions" class="actions actions-2 text-right">
+            <%= link_to_edit user, no_text: true %>
+            <%= link_to_delete user, no_text: true %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <div class="alert alert-info no-objects-found">
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::User)) %>,
+    <%= link_to Spree.t(:add_one), new_object_url %>!
+  </div>
+<% end %>
 
 <%= paginate @users %>


### PR DESCRIPTION
On index pages at **admin end**, when ransack search yields no result, then `no resource found message` is displayed.
This patch does the same on `users index page`.
Currently at users index page, an `empty table is build` instead of no resource found message.
