### PR TITLE
Fix exception on creating stock_transfer

### DIFF
--- a/backend/app/controllers/spree/admin/stock_transfers_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_transfers_controller.rb
@@ -2,6 +2,7 @@ module Spree
   module Admin
     class StockTransfersController < Admin::BaseController
       before_action :load_stock_locations, only: :index
+      before_action :ensure_variants_exists, only: :create
 
       def index
         @q = StockTransfer.ransack(params[:q])
@@ -36,6 +37,13 @@ module Spree
       private
       def load_stock_locations
         @stock_locations = Spree::StockLocation.active.order_default
+      end
+
+      def ensure_variants_exists
+        if params[:variants].blank?
+          flash[:error] = Spree.t(:no_resource_found, resource: :variants)
+          redirect_to new_admin_stock_transfer_path
+        end
       end
 
       def source_location

--- a/backend/spec/features/admin/stock_transfer_spec.rb
+++ b/backend/spec/features/admin/stock_transfer_spec.rb
@@ -19,6 +19,15 @@ describe 'Stock Transfers', type: :feature, js: true do
     expect(page).to have_content(content)
   end
 
+  it 'show error message if no variant is added' do
+    visit spree.admin_stock_transfers_path
+    click_on 'New Stock Transfer'
+    click_button 'Transfer Stock'
+    fill_in 'reference', with: 'PO 666'
+
+    expect(page).to have_content('No Variants found')
+  end
+
   it 'transfer between 2 locations' do
     source_location = create(:stock_location_with_items, name: 'NY')
     destination_location = create(:stock_location, name: 'SF')


### PR DESCRIPTION
## Issue
While creating `stock transfer` from backend, the following exception arises.

<img width="1003" alt="stock transfer exception" src="https://user-images.githubusercontent.com/21332195/27011126-ec10b750-4ed2-11e7-81cd-448af31f9063.png">

## Steps to replicate
1. From backend, go to new stock transfer page.
2. Without adding any variant, submit the form.
3. An exception will arise `undefined method each_with_index for nil:NilClass`

## Fix
In `Admin::StockTransfersController`, a `before_action` can be used to ensure that variants are present, before creating the stock transfer object. 
