### PR TITLE
Promotion rule 'missing partial' exception fix

### DIFF
--- a/backend/app/views/spree/admin/promotions/_promotion_rule.html.erb
+++ b/backend/app/views/spree/admin/promotions/_promotion_rule.html.erb
@@ -7,5 +7,5 @@
   <% param_prefix = "promotion[promotion_rules_attributes][#{promotion_rule.id}]" %>
   <%= hidden_field_tag "#{param_prefix}[id]", promotion_rule.id %>
 
-  <%= render partial: "spree/admin/promotions/rules/#{type_name}", locals: { promotion_rule: promotion_rule, param_prefix: param_prefix } %>
+  <%= render partial: "spree/admin/promotions/rules/#{type_name}", locals: { promotion_rule: promotion_rule, param_prefix: param_prefix } rescue nil %>
 </div>


### PR DESCRIPTION
## Issue
At admin end, `ActionView::MissingTemplate` exception is arising when we add any of the following promotion rule in a promotion:
1. First order
2. User logged in
3. One use per user

<img width="1388" alt="screen shot 2017-06-12 at 10 03 14 pm" src="https://user-images.githubusercontent.com/21332195/27044382-00d75174-4fbb-11e7-9bdb-70dde718db74.png">
