### PR TITLE
Fix exception on cancelling Return Authorization

### DIFF
--- a/backend/app/controllers/spree/admin/return_authorizations_controller.rb
+++ b/backend/app/controllers/spree/admin/return_authorizations_controller.rb
@@ -10,7 +10,7 @@ module Spree
       def fire
         @return_authorization.send("#{params[:e]}!")
         flash[:success] = Spree.t(:return_authorization_updated)
-        redirect_back fallback_location: spree.admin_return_authorization_url(@return_authorization)
+        redirect_to :back
       end
 
       private


### PR DESCRIPTION
## Issue
While cancelling a `Return Authorization` from **admin end**, the following exception arises.

<img width="1245" alt="returnauth exception" src="https://user-images.githubusercontent.com/21332195/27113742-6aa0e83c-50dc-11e7-9267-d2afb4d96acf.png">

## Steps to replicate
1. Create a new return authorization for a completed order, having shipped inventory units.
2. To cancel this return authorization, go to its edit page and click on `Cancel`.
3. An exception will arise.

## Fix
In the `fire` action of `Admin::ReturnAuthorizationsController`, the `invalid routing helper` should be replaced by `redirect_to :back`.
