### PR TITLE
Uniqueness validation added on promotion's code

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -21,7 +21,7 @@ module Spree
     validates_associated :rules
 
     validates :name, presence: true
-    validates :path, uniqueness: { allow_blank: true }
+    validates :path, :code, uniqueness: { case_sensitive: false, allow_blank: true }
     validates :usage_limit, numericality: { greater_than: 0, allow_nil: true }
     validates :description, length: { maximum: 255 }, allow_blank: true
     validate :expires_at_must_be_later_than_starts_at, if: -> { starts_at && expires_at }

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -8,6 +8,13 @@ describe Spree::Promotion, type: :model do
       @valid_promotion = Spree::Promotion.new name: "A promotion"
     end
 
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_uniqueness_of(:path).case_insensitive.allow_blank }
+    it { is_expected.to validate_uniqueness_of(:code).case_insensitive.allow_blank }
+    it { is_expected.to validate_numericality_of(:usage_limit).is_greater_than(0).allow_nil }
+    it { is_expected.to validate_length_of(:description).is_at_most(255) }
+    it { is_expected.to allow_values('', nil).for(:description) }
+
     it "valid_promotion is valid" do
       expect(@valid_promotion).to be_valid
     end
@@ -580,23 +587,11 @@ describe Spree::Promotion, type: :model do
       end
     end
 
-    context "and there are multiple coupons with the same code" do
-      context "and only one has any actions" do
-        let!(:promotion_without_actions) { create(:promotion, code: "MY-COUPON-123").actions.clear }
-        let!(:promotion) { create(:promotion, :with_order_adjustment, code: "MY-COUPON-123") }
+    context "when promotion has no actions" do
+      let!(:promotion_without_actions) { create(:promotion, code: "MY-COUPON-123").actions.clear }
 
-        it "then returns the one with an action" do
-          expect(Spree::Promotion.with_coupon_code("MY-COUPON-123").actions.exists?).to be
-        end
-      end
-
-      context "and all of them has actions" do
-        let!(:first_promotion) { create(:promotion, :with_order_adjustment, code: "MY-COUPON-123") }
-        let!(:second_promotion) { create(:promotion, :with_order_adjustment, code: "MY-COUPON-123") }
-
-        it "then returns the first one with an action" do
-          expect(Spree::Promotion.with_coupon_code("MY-COUPON-123").id).to eq(first_promotion.id)
-        end
+      it "then returns the one with an action" do
+        expect(Spree::Promotion.with_coupon_code("MY-COUPON-123")).to be_nil
       end
     end
   end


### PR DESCRIPTION
## Issue
Currently, Admin can create multiple **promotions** having **same promo code**.
Now, if we apply this promo code in an order, then the first promotion having this promo code will be applied to the order. The later promotions having same promo code will not be considered.

```
def self.with_coupon_code(coupon_code)
  where("lower(#{table_name}.code) = ?", coupon_code.strip.downcase)
    .includes(:promotion_actions).where.not(spree_promotion_actions: { id: nil })
    .first
end
```

## Fix
Uniqueness validation should be present on `promotion's code`, like it is present on `promotion's path`.
