### PR TITLE
Loosen our dependency on FriendlyId

### DIFF
--- a/api/app/controllers/spree/api/v1/orders_controller.rb
+++ b/api/app/controllers/spree/api/v1/orders_controller.rb
@@ -121,7 +121,7 @@ module Spree
           end
 
           def find_order(lock = false)
-            @order = Spree::Order.lock(lock).friendly.find(params[:id])
+            @order = Spree::Order.lock(lock).find_by!(number: params[:id])
           end
 
           def find_current_order

--- a/api/app/controllers/spree/api/v1/payments_controller.rb
+++ b/api/app/controllers/spree/api/v1/payments_controller.rb
@@ -59,12 +59,12 @@ module Spree
         private
 
           def find_order
-            @order = Spree::Order.friendly.find(order_id)
+            @order = Spree::Order.find_by!(number: order_id)
             authorize! :read, @order, order_token
           end
 
           def find_payment
-            @payment = @order.payments.friendly.find(params[:id])
+            @payment = @order.payments.find_by!(number: params[:id])
           end
 
           def perform_payment_action(action, *args)

--- a/api/app/controllers/spree/api/v1/shipments_controller.rb
+++ b/api/app/controllers/spree/api/v1/shipments_controller.rb
@@ -33,7 +33,7 @@ module Spree
         end
 
         def update
-          @shipment = Spree::Shipment.accessible_by(current_ability, :update).readonly(false).friendly.find(params[:id])
+          @shipment = Spree::Shipment.accessible_by(current_ability, :update).readonly(false).find_by!(number: params[:id])
           @shipment.update_attributes_and_order(shipment_params)
 
           respond_with(@shipment.reload, default_template: :show)
@@ -86,7 +86,7 @@ module Spree
         end
 
         def transfer_to_shipment
-          @target_shipment  = Spree::Shipment.friendly.find(params[:target_shipment_number])
+          @target_shipment = Spree::Shipment.find_by!(number: params[:target_shipment_number])
 
           if @quantity < 0 || @target_shipment == @original_shipment
             unprocessable_entity('ArgumentError')
@@ -100,7 +100,7 @@ module Spree
         private
 
         def load_transfer_params
-          @original_shipment         = Spree::Shipment.friendly.find(params[:original_shipment_number])
+          @original_shipment         = Spree::Shipment.find_by!(number: params[:original_shipment_number])
           @variant                   = Spree::Variant.find(params[:variant_id])
           @quantity                  = params[:quantity].to_i
           authorize! :read, @original_shipment
@@ -108,7 +108,7 @@ module Spree
         end
 
         def find_and_update_shipment
-          @shipment = Spree::Shipment.accessible_by(current_ability, :update).readonly(false).friendly.find(params[:id])
+          @shipment = Spree::Shipment.accessible_by(current_ability, :update).readonly(false).find_by!(number: params[:id])
           @shipment.update_attributes(shipment_params)
           @shipment.reload
         end

--- a/backend/app/assets/javascripts/spree/backend/payments/edit.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/payments/edit.js.coffee
@@ -2,8 +2,8 @@ jQuery ($) ->
   # Payment model
   order_id = $('#payments').data('order-id')
   class Payment
-    constructor: (id) ->
-      @url  = Spree.url("#{Spree.routes.payments_api(order_id)}/#{id}.json" + '?token=' + Spree.api_key)
+    constructor: (number) ->
+      @url  = Spree.url("#{Spree.routes.payments_api(order_id)}/#{number}.json" + '?token=' + Spree.api_key)
       @json = $.getJSON @url.toString(), (data) =>
         @data = data
       @updating = false
@@ -141,5 +141,5 @@ jQuery ($) ->
   # Attach ShowPaymentView to each editable payment in the table
   $('.admin tr[data-hook=payments_row]').each ->
     $el = $(@)
-    payment = new Payment($el.prop('id').match(/\d+$/))
+    payment = new Payment($el.attr('data-number'))
     payment.if_editable -> new ShowPaymentView($el, payment)

--- a/backend/app/controllers/spree/admin/log_entries_controller.rb
+++ b/backend/app/controllers/spree/admin/log_entries_controller.rb
@@ -11,8 +11,8 @@ module Spree
       private
 
       def find_order_and_payment
-        @order = Spree::Order.friendly.find(params[:order_id])
-        @payment = @order.payments.friendly.find(params[:payment_id])
+        @order = Spree::Order.find_by!(number: params[:order_id])
+        @payment = @order.payments.find_by!(number: params[:payment_id])
       end
     end
   end

--- a/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
+++ b/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
@@ -47,7 +47,7 @@ module Spree
         end
 
         def load_order
-          @order = Order.includes(:adjustments).friendly.find(params[:order_id])
+          @order = Order.includes(:adjustments).find_by!(number: params[:order_id])
         end
 
         def model_class

--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -130,7 +130,7 @@ module Spree
         end
 
         def load_order
-          @order = Spree::Order.includes(:adjustments).friendly.find(params[:id])
+          @order = Spree::Order.includes(:adjustments).find_by!(number: params[:id])
           authorize! action, @order
         end
 

--- a/backend/app/controllers/spree/admin/payments_controller.rb
+++ b/backend/app/controllers/spree/admin/payments_controller.rb
@@ -99,13 +99,13 @@ module Spree
       end
 
       def load_order
-        @order = Order.friendly.find(params[:order_id])
+        @order = Order.find_by!(number: params[:order_id])
         authorize! action, @order
         @order
       end
 
       def load_payment
-        @payment = Payment.friendly.find(params[:id])
+        @payment = Payment.find_by!(number: params[:id])
       end
 
       def model_class

--- a/backend/app/controllers/spree/admin/stock_transfers_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_transfers_controller.rb
@@ -13,7 +13,7 @@ module Spree
       end
 
       def show
-        @stock_transfer = StockTransfer.friendly.find(params[:id])
+        @stock_transfer = StockTransfer.find_by!(number: params[:id])
       end
 
       def new; end

--- a/backend/app/views/spree/admin/payments/_list.html.erb
+++ b/backend/app/views/spree/admin/payments/_list.html.erb
@@ -12,7 +12,7 @@
   </thead>
   <tbody>
     <% payments.each do |payment| %>
-      <tr id="<%= dom_id(payment) %>" data-hook="payments_row">
+      <tr id="<%= dom_id(payment) %>" data-hook="payments_row" data-number="<%= payment.number %>">
         <td><%= link_to payment.number, spree.admin_order_payment_path(@order, payment) %></td>
         <td><%= pretty_time(payment.created_at) %></td>
         <td class="amount text-center"><%= payment.display_amount %></td>

--- a/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
@@ -19,7 +19,7 @@ describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
     end
 
     before do
-      allow(Spree::Order).to receive_message_chain(:friendly, :find).and_return(order)
+      allow(Spree::Order).to receive_message_chain(:includes, find_by!: order)
     end
 
     describe '#update' do

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -39,7 +39,7 @@ describe Spree::Admin::OrdersController, type: :controller do
     let(:adjustments) { double('adjustments') }
 
     before do
-      allow(Spree::Order).to receive_message_chain(:friendly, :find).and_return(order)
+      allow(Spree::Order).to receive_message_chain(:includes, find_by!: order)
     end
 
     context "#approve" do

--- a/core/app/models/concerns/spree/number_as_param.rb
+++ b/core/app/models/concerns/spree/number_as_param.rb
@@ -1,0 +1,9 @@
+module Spree
+  module NumberAsParam
+    extend ActiveSupport::Concern
+
+    def to_param
+      number.presence.to_s
+    end
+  end
+end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -6,9 +6,6 @@ module Spree
     PAYMENT_STATES = %w(balance_due credit_owed failed paid void)
     SHIPMENT_STATES = %w(backorder canceled partial pending ready shipped)
 
-    extend FriendlyId
-    friendly_id :number, slug_column: :number, use: :slugged
-
     include Spree::Order::Checkout
     include Spree::Order::CurrencyUpdater
     include Spree::Order::Payments
@@ -166,6 +163,10 @@ module Spree
     # that should be called when determining if two line items are equal.
     def self.register_line_item_comparison_hook(hook)
       line_item_comparison_hooks.add(hook)
+    end
+
+    def to_param
+      number.to_s
     end
 
     # For compatiblity with Calculator::PriceSack

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -12,6 +12,8 @@ module Spree
     include Spree::Order::StoreCredit
     include Spree::Core::NumberGenerator.new(prefix: 'R')
     include Spree::Core::TokenGenerator
+    
+    include NumberAsParam
 
     extend Spree::DisplayMoney
     money_methods :outstanding_balance, :item_total,           :adjustment_total,
@@ -163,10 +165,6 @@ module Spree
     # that should be called when determining if two line items are equal.
     def self.register_line_item_comparison_hook(hook)
       line_item_comparison_hooks.add(hook)
-    end
-
-    def to_param
-      number.to_s
     end
 
     # For compatiblity with Calculator::PriceSack

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -2,9 +2,6 @@ module Spree
   class Payment < Spree::Base
     include Spree::Core::NumberGenerator.new(prefix: 'P', letters: true, length: 7)
 
-    extend FriendlyId
-    friendly_id :number, slug_column: :number, use: :slugged
-
     include Spree::Payment::Processing
 
     NON_RISKY_AVS_CODES = ['B', 'D', 'H', 'J', 'M', 'Q', 'T', 'V', 'X', 'Y'].freeze
@@ -62,6 +59,10 @@ module Spree
 
     scope :store_credits, -> { where(source_type: Spree::StoreCredit.to_s) }
     scope :not_store_credits, -> { where(arel_table[:source_type].not_eq(Spree::StoreCredit.to_s).or(arel_table[:source_type].eq(nil))) }
+
+    def to_param
+      number.to_s
+    end
 
     # transaction_id is much easier to understand
     def transaction_id

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -4,6 +4,8 @@ module Spree
 
     include Spree::Payment::Processing
 
+    include NumberAsParam
+
     NON_RISKY_AVS_CODES = ['B', 'D', 'H', 'J', 'M', 'Q', 'T', 'V', 'X', 'Y'].freeze
     RISKY_AVS_CODES     = ['A', 'C', 'E', 'F', 'G', 'I', 'K', 'L', 'N', 'O', 'P', 'R', 'S', 'U', 'W', 'Z'].freeze
     INVALID_STATES      = %w(failed invalid).freeze
@@ -59,10 +61,6 @@ module Spree
 
     scope :store_credits, -> { where(source_type: Spree::StoreCredit.to_s) }
     scope :not_store_credits, -> { where(arel_table[:source_type].not_eq(Spree::StoreCredit.to_s).or(arel_table[:source_type].eq(nil))) }
-
-    def to_param
-      number.to_s
-    end
 
     # transaction_id is much easier to understand
     def transaction_id

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -4,6 +4,8 @@ module Spree
   class Shipment < Spree::Base
     include Spree::Core::NumberGenerator.new(prefix: 'H', length: 11)
 
+    include NumberAsParam
+
     with_options inverse_of: :shipments do
       belongs_to :address, class_name: 'Spree::Address'
       belongs_to :order, class_name: 'Spree::Order', touch: true
@@ -84,10 +86,6 @@ module Spree
     extend DisplayMoney
     money_methods :cost, :discounted_cost, :final_price, :item_cost
     alias display_amount display_cost
-
-    def to_param
-      number.to_s
-    end
 
     def add_shipping_method(shipping_method, selected = false)
       shipping_rates.create(shipping_method: shipping_method, selected: selected, cost: cost)

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -4,9 +4,6 @@ module Spree
   class Shipment < Spree::Base
     include Spree::Core::NumberGenerator.new(prefix: 'H', length: 11)
 
-    extend FriendlyId
-    friendly_id :number, slug_column: :number, use: :slugged
-
     with_options inverse_of: :shipments do
       belongs_to :address, class_name: 'Spree::Address'
       belongs_to :order, class_name: 'Spree::Order', touch: true
@@ -87,6 +84,10 @@ module Spree
     extend DisplayMoney
     money_methods :cost, :discounted_cost, :final_price, :item_cost
     alias display_amount display_cost
+
+    def to_param
+      number.to_s
+    end
 
     def add_shipping_method(shipping_method, selected = false)
       shipping_rates.create(shipping_method: shipping_method, selected: selected, cost: cost)

--- a/core/app/models/spree/stock_transfer.rb
+++ b/core/app/models/spree/stock_transfer.rb
@@ -2,9 +2,6 @@ module Spree
   class StockTransfer < Spree::Base
     include Spree::Core::NumberGenerator.new(prefix: 'T')
 
-    extend FriendlyId
-    friendly_id :number, slug_column: :number, use: :slugged
-
     has_many :stock_movements, as: :originator
 
     belongs_to :source_location, class_name: 'StockLocation'

--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -91,7 +91,7 @@ module Spree
     end
 
     def check_authorization
-      order = Spree::Order.find_by_number(params[:id]) if params[:id].present?
+      order = Spree::Order.find_by(number: params[:id]) if params[:id].present?
       order = current_order unless order
 
       if order

--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -10,7 +10,7 @@ module Spree
     skip_before_action :verify_authenticity_token, only: [:populate]
 
     def show
-      @order = Order.includes(line_items: [variant: [:option_values, :images, :product]], bill_address: :state, ship_address: :state).find_by_number!(params[:id])
+      @order = Order.includes(line_items: [variant: [:option_values, :images, :product]], bill_address: :state, ship_address: :state).find_by!(number: params[:id])
     end
 
     def update

--- a/sample/db/samples/adjustments.rb
+++ b/sample/db/samples/adjustments.rb
@@ -1,7 +1,7 @@
 Spree::Sample.load_sample("orders")
 
-first_order = Spree::Order.find_by_number!("R123456789")
-last_order = Spree::Order.find_by_number!("R987654321")
+first_order = Spree::Order.find_by!(number: "R123456789")
+last_order = Spree::Order.find_by!(number: "R987654321")
 
 first_order.adjustments.where(
   source: Spree::TaxRate.find_by_name!("North America"),


### PR DESCRIPTION
FriendlyId should be used only for SEO purposes (product URLs, taxon permalinks) not for models like Order/Shipment/Payment which uses NumberGenerator. Switching back to standard rails finders. 

Basically, reverts https://github.com/spree/spree/commit/259c6b3aeec894f93f19d0220011c23496889f14