### PR TITLE
Missing translations fix

### DIFF
--- a/core/app/views/spree/order_mailer/cancel_email.text.erb
+++ b/core/app/views/spree/order_mailer/cancel_email.text.erb
@@ -9,8 +9,8 @@
   <%= item.variant.sku %> <%= raw(item.variant.product.name) %> <%= raw(item.variant.options_text) -%> (<%=item.quantity%>) <%= Spree.t('at_symbol') %> <%= item.single_money %> = <%= item.display_amount %>
 <% end %>
 ============================================================
-<%= Spree.t('order_mailer.cancel_email.subtotal') %> <%= @order.display_item_total %>
+<%= Spree.t('order_mailer.subtotal') %> <%= @order.display_item_total %>
 <% @order.adjustments.eligible.each do |adjustment| %>
   <%= raw(adjustment.label) %> <%= adjustment.display_amount %>
 <% end %>
-<%= Spree.t('order_mailer.cancel_email.total') %> <%= @order.display_total %>
+<%= Spree.t('order_mailer.total') %> <%= @order.display_total %>

--- a/core/app/views/spree/order_mailer/confirm_email.text.erb
+++ b/core/app/views/spree/order_mailer/confirm_email.text.erb
@@ -9,7 +9,7 @@
   <%= item.variant.sku %> <%= raw(item.variant.product.name) %> <%= raw(item.variant.options_text) -%> (<%=item.quantity%>) <%= Spree.t('at_symbol') %>  <%= item.single_money %> = <%= item.display_amount %>
 <% end %>
 ============================================================
-<%= Spree.t('order_mailer.confirm_email.subtotal') %> <%= @order.display_item_total %>
+<%= Spree.t('order_mailer.subtotal') %> <%= @order.display_item_total %>
 <% if @order.line_item_adjustments.exists? %>
   <% if @order.all_adjustments.promotion.eligible.exists? %>
     <% @order.all_adjustments.promotion.eligible.group_by(&:label).each do |label, adjustments| %>
@@ -33,6 +33,6 @@
 <%= adjustment.label %> <%= adjustment.display_amount %>
 <% end %>
 ============================================================
-<%= Spree.t('order_mailer.confirm_email.total') %> <%= @order.display_total %>
+<%= Spree.t('order_mailer.total') %> <%= @order.display_total %>
 
 <%= Spree.t('order_mailer.confirm_email.thanks') %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -716,6 +716,7 @@ en:
     error: error
     errors:
       messages:
+        blank: can't be blank
         could_not_create_taxon: Could not create taxon
         no_shipping_methods_available: No shipping methods available for selected location, please change your address and try again.
     errors_prohibited_this_record_from_being_saved:


### PR DESCRIPTION
Following translations are `missing`
```
Spree.t('order_mailer.cancel_email.subtotal')
Spree.t('order_mailer.cancel_email.total')
Spree.t('order_mailer.confirm_email.subtotal')
Spree.t('order_mailer.confirm_email.total')
Spree.t('errors.messages.blank')
```