### PR TITLE
Speed up Migrations

### DIFF
--- a/core/db/migrate/20130807024301_upgrade_adjustments.rb
+++ b/core/db/migrate/20130807024301_upgrade_adjustments.rb
@@ -1,8 +1,8 @@
 class UpgradeAdjustments < ActiveRecord::Migration[4.2]
   def up
-    #Add Temporary index
+    # Add Temporary index
     add_index :spree_adjustments, :originator_type unless index_exists?(:spree_adjustments, :originator_type)
-    
+
     # Temporarily make originator association available
     Spree::Adjustment.class_eval do
       belongs_to :originator, polymorphic: true
@@ -39,8 +39,8 @@ class UpgradeAdjustments < ActiveRecord::Migration[4.2]
 
       adjustment.save!
     end
-    
-    #Remove Temporary index
+
+    # Remove Temporary index
     remove_index :spree_adjustments, :originator_type if index_exists?(:spree_adjustments, :originator_type)
   end
 end

--- a/core/db/migrate/20130807024301_upgrade_adjustments.rb
+++ b/core/db/migrate/20130807024301_upgrade_adjustments.rb
@@ -1,5 +1,8 @@
 class UpgradeAdjustments < ActiveRecord::Migration[4.2]
   def up
+    #Add Temporary index
+    add_index :spree_adjustments, :originator_type unless index_exists?(:spree_adjustments, :originator_type)
+    
     # Temporarily make originator association available
     Spree::Adjustment.class_eval do
       belongs_to :originator, polymorphic: true
@@ -36,5 +39,8 @@ class UpgradeAdjustments < ActiveRecord::Migration[4.2]
 
       adjustment.save!
     end
+    
+    #Remove Temporary index
+    remove_index :spree_adjustments, :originator_type if index_exists?(:spree_adjustments, :originator_type)
   end
 end

--- a/core/db/migrate/20130807024302_rename_adjustment_fields.rb
+++ b/core/db/migrate/20130807024302_rename_adjustment_fields.rb
@@ -1,5 +1,8 @@
 class RenameAdjustmentFields < ActiveRecord::Migration[4.2]
   def up
+    #Add Temporary index
+    add_index :spree_adjustments, :adjustable_type unless index_exists?(:spree_adjustments, :adjustable_type)
+    
     remove_column :spree_adjustments, :originator_id
     remove_column :spree_adjustments, :originator_type
 
@@ -10,5 +13,8 @@ class RenameAdjustmentFields < ActiveRecord::Migration[4.2]
     Spree::Adjustment.where(adjustable_type: "Spree::Order").find_each do |adjustment|
       adjustment.update_column(:order_id, adjustment.adjustable_id)
     end
+    
+    #Remove Temporary index
+    remove_index :spree_adjustments, :adjustable_type if index_exists?(:spree_adjustments, :adjustable_type)
   end
 end

--- a/core/db/migrate/20130807024302_rename_adjustment_fields.rb
+++ b/core/db/migrate/20130807024302_rename_adjustment_fields.rb
@@ -1,8 +1,8 @@
 class RenameAdjustmentFields < ActiveRecord::Migration[4.2]
   def up
-    #Add Temporary index
+    # Add Temporary index
     add_index :spree_adjustments, :adjustable_type unless index_exists?(:spree_adjustments, :adjustable_type)
-    
+
     remove_column :spree_adjustments, :originator_id
     remove_column :spree_adjustments, :originator_type
 
@@ -13,8 +13,8 @@ class RenameAdjustmentFields < ActiveRecord::Migration[4.2]
     Spree::Adjustment.where(adjustable_type: "Spree::Order").find_each do |adjustment|
       adjustment.update_column(:order_id, adjustment.adjustable_id)
     end
-    
-    #Remove Temporary index
+
+    # Remove Temporary index
     remove_index :spree_adjustments, :adjustable_type if index_exists?(:spree_adjustments, :adjustable_type)
   end
 end


### PR DESCRIPTION
I've found that @brchristian's recommendation (#6726) of adding temporary indexes in slow running migrations really speeds them up when dealing with really large databases. I hope these could be incorporated.