### PR TITLE
loosen activemerchant dependency

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.files        = `git ls-files`.split("\n")
   s.require_path = 'lib'
 
-  s.add_dependency 'activemerchant', '~> 1.66.0'
+  s.add_dependency 'activemerchant', '~> 1.67'
   s.add_dependency 'acts_as_list', '~> 0.8'
   s.add_dependency 'awesome_nested_set', '~> 3.1.3'
   s.add_dependency 'carmen', '~> 1.0.0'


### PR DESCRIPTION
dependency on activemerchant was made too strict in 5b260f3223eb8981104eaf0c426249f9990ee371

Since activemerchant does not (rarely) version to the patch level the dependency was essentially locked at 1.66.0

Prior to that commit activemerchant was twiddle-waka'd to the minor version level as is this commit.

I noticed this when trying developing a new gateway integration for activemerchant / spree and I couldn't update activemerchant without updating the spree gemspec.