### PR TITLE
Bump state_machines-activerecord to 0.5

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '~> 5.0.0'
   s.add_dependency 'ransack', '~> 1.8.0'
   s.add_dependency 'responders'
-  s.add_dependency 'state_machines-activerecord', '~> 0.4.1'
+  s.add_dependency 'state_machines-activerecord', '~> 0.5'
   s.add_dependency 'stringex'
   s.add_dependency 'twitter_cldr', '~> 4.3'
   s.add_dependency 'sprockets-rails'


### PR DESCRIPTION
There was a dependency problem where `state_machines` was at `0.5.0` and `state_machines-activerecord` was still `0.4.1` resulting in errors. Now both of those gems are on the same version.