### PR TITLE
Provide correct HTTP code with failed coupon code

### DIFF
--- a/api/app/controllers/spree/api/v1/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/v1/checkouts_controller.rb
@@ -69,7 +69,7 @@ module Spree
         end
 
         def raise_insufficient_quantity
-          respond_with(@order, default_template: 'spree/api/v1/orders/insufficient_quantity')
+          respond_with(@order, default_template: 'spree/api/v1/orders/insufficient_quantity', status: 422)
         end
 
         def state_callback(before_or_after = :before)
@@ -84,7 +84,7 @@ module Spree
 
             if handler.error.present?
               @coupon_message = handler.error
-              respond_with(@order, default_template: 'spree/api/v1/orders/could_not_apply_coupon')
+              respond_with(@order, default_template: 'spree/api/v1/orders/could_not_apply_coupon', status: 422)
               return true
             end
           end


### PR DESCRIPTION
When a coupon code fails it is responding with a HTTP 200 instead of a 422. 422 is used elsewhere in this file (for example on the could not transition error). Also the `apply_coupon_code` action in the Order api controller returns 422. This just makes this consistent.

I noticed above this that the insufficient quantity error has the same problem so went ahead and hit that one also.