### PR TITLE
show flash message and remove store-credit row from the table on deletion

### DIFF
--- a/backend/app/controllers/spree/admin/store_credits_controller.rb
+++ b/backend/app/controllers/spree/admin/store_credits_controller.rb
@@ -49,6 +49,7 @@ module Spree
         ensure_unused_store_credit
 
         if @store_credit.destroy
+          flash[:success] = flash_message_for(@store_credit, :successfully_removed)
           respond_with(@store_credit) do |format|
             format.html { redirect_to admin_user_store_credits_path(@user) }
             format.js { render_js_for_destroy }


### PR DESCRIPTION
Issue:
Currently, on removing a store-credit entry for a user from admin end does not remove the corresponding row from the table after a successful deletion.

Reason.
According to the logic in [admin.js](https://github.com/spree/spree/blob/master/backend/app/assets/javascripts/spree/backend/admin.js#L250l) table row is only deleted if a flash[:success] if present.

This PR set the flash message and remove the store credit entry from admin end on successful deletion.

