### PR TITLE
set taxon permalink in before_validation instead on before_create to ensure its uniqueness

### DIFF
--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -5,7 +5,7 @@ module Spree
   class Taxon < Spree::Base
     extend FriendlyId
     friendly_id :permalink, slug_column: :permalink, use: :history
-    before_validation :set_permalink, on: :create
+    before_validation :set_permalink, on: :create, if: :name
 
     acts_as_nested_set dependent: :destroy
 
@@ -19,7 +19,7 @@ module Spree
     has_many :promotion_rule_taxons, class_name: 'Spree::PromotionRuleTaxon', dependent: :destroy
     has_many :promotion_rules, through: :promotion_rule_taxons, class_name: 'Spree::PromotionRule'
 
-    validates :name, presence: true
+    validates :name, presence: true, uniqueness: { scope: [:parent_id, :taxonomy_id], allow_blank: true }
     validates :permalink, uniqueness: { case_sensitive: false }
     with_options length: { maximum: 255 }, allow_blank: true do
       validates :meta_keywords

--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -5,7 +5,7 @@ module Spree
   class Taxon < Spree::Base
     extend FriendlyId
     friendly_id :permalink, slug_column: :permalink, use: :history
-    before_create :set_permalink
+    before_validation :set_permalink, on: :create
 
     acts_as_nested_set dependent: :destroy
 

--- a/core/spec/models/spree/taxon_spec.rb
+++ b/core/spec/models/spree/taxon_spec.rb
@@ -84,5 +84,10 @@ describe Spree::Taxon, type: :model do
     it { expect(described_class.whitelisted_ransackable_associations).to include('taxonomy') }
   end
 
-  it { expect(taxon).to callback(:set_permalink).before(:validation).on(:create) }
+  it { expect(taxon).to callback(:set_permalink).before(:validation).on(:create).if(:name) }
+  describe 'validation' do
+    subject { taxon }
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_uniqueness_of(:name).scoped_to([:parent_id, :taxonomy_id]).allow_blank }
+  end
 end

--- a/core/spec/models/spree/taxon_spec.rb
+++ b/core/spec/models/spree/taxon_spec.rb
@@ -83,4 +83,6 @@ describe Spree::Taxon, type: :model do
   context 'ransackable_associations' do
     it { expect(described_class.whitelisted_ransackable_associations).to include('taxonomy') }
   end
+
+  it { expect(taxon).to callback(:set_permalink).before(:validation).on(:create) }
 end


### PR DESCRIPTION
permalink should be validated in before_validation callback as permalink uniqueness validation won't be checked in before_create.
Also, ensure two taxons under the same parent should not have the same name.