### PR TITLE
set @permalink_part in both edit and update action of taxons_controller at admin end

### DIFF
--- a/backend/app/controllers/spree/admin/taxons_controller.rb
+++ b/backend/app/controllers/spree/admin/taxons_controller.rb
@@ -4,6 +4,7 @@ module Spree
 
       before_action :load_taxonomy, only: [:create, :edit, :update]
       before_action :load_taxon, only: [:edit, :update]
+      before_action :set_permalink_part, only: [:edit, :update]
       respond_to :html, :js
 
       def index
@@ -24,7 +25,6 @@ module Spree
       end
 
       def edit
-        @permalink_part = @taxon.permalink.split("/").last
       end
 
       def update
@@ -66,6 +66,10 @@ module Spree
       end
 
       private
+
+      def set_permalink_part
+        @permalink_part = @taxon.permalink.split('/').last
+      end
 
       def taxon_params
         params.require(:taxon).permit(permitted_taxon_attributes)


### PR DESCRIPTION
``@permalink_part`` used in [taxon edit page](https://github.com/spree/spree/blob/master/backend/app/views/spree/admin/taxons/_form.html.erb#L12)  but not defined in taxons controller's update action.This results in the setting of an empty value in permalink field for a taxon if it fails to get save and edit page is rendered.