### PR TITLE
Feature/exclude specs from gem builds

### DIFF
--- a/api/spree_api.gemspec
+++ b/api/spree_api.gemspec
@@ -11,9 +11,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.2.7'
 
-  s.files         = `git ls-files`.split($\)
+  s.files         = `git ls-files`.split($\).reject { |f| f.match(/^spec/) }
   s.executables   = s.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
-  s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.name          = "spree_api"
   s.require_paths = ["lib"]
   s.version       = Spree.version

--- a/backend/spree_backend.gemspec
+++ b/backend/spree_backend.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://spreecommerce.com'
   s.license     = 'BSD-3-Clause'
 
-  s.files        = `git ls-files`.split("\n")
+  s.files        = `git ls-files`.split("\n").reject { |f| f.match(/^spec/) }
   s.require_path = 'lib'
   s.requirements << 'none'
 

--- a/cmd/lib/spree_cmd/templates/extension/extension.gemspec
+++ b/cmd/lib/spree_cmd/templates/extension/extension.gemspec
@@ -17,8 +17,7 @@ Gem::Specification.new do |s|
   s.homepage  = 'https://github.com/your-github-handle/<%= file_name %>'
   s.license = 'BSD-3-Clause'
 
-  # s.files       = `git ls-files`.split("\n")
-  # s.test_files  = `git ls-files -- {test,spec,features}/*`.split("\n")
+  # s.files       = `git ls-files`.split("\n").reject { |f| f.match(/^spec/) }
   s.require_path = 'lib'
   s.requirements << 'none'
 

--- a/cmd/spree_cmd.gemspec
+++ b/cmd/spree_cmd.gemspec
@@ -12,8 +12,7 @@ Gem::Specification.new do |s|
   s.summary     = 'Spree Commerce command line utility'
   s.description = 'tools to create new Spree stores and extensions'
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split('\n')
+  s.files         = `git ls-files`.split("\n").reject { |f| f.match(/^spec/) }
   s.bindir        = 'bin'
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://spreecommerce.com'
   s.license     = 'BSD-3-Clause'
 
-  s.files        = `git ls-files`.split("\n")
+  s.files        = `git ls-files`.split("\n").reject { |f| f.match(/^spec/) }
   s.require_path = 'lib'
 
   s.add_dependency 'activemerchant', '~> 1.67'

--- a/frontend/spree_frontend.gemspec
+++ b/frontend/spree_frontend.gemspec
@@ -15,8 +15,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://spreecommerce.com'
   s.license     = 'BSD-3-Clause'
 
-  s.files        = `git ls-files`.split("\n")
-  s.test_files   = `git ls-files -- {test,spec,features}/*`.split("\n")
+  s.files        = `git ls-files`.split("\n").reject { |f| f.match(/^spec/) }
   s.require_path = 'lib'
   s.requirements << 'none'
 

--- a/sample/spree_sample.gemspec
+++ b/sample/spree_sample.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://spreecommerce.com'
   s.license     = 'BSD-3-Clause'
 
-  s.files        = `git ls-files`.split("\n")
+  s.files        = `git ls-files`.split("\n").reject { |f| f.match(/^spec/) }
   s.require_path = 'lib'
   s.requirements << 'none'
 


### PR DESCRIPTION
Build sizes:
API: `29 KB` vs `78 KB`
Backend: `268 KB` vs `326 KB`
Core: `245 KB` vs `406 KB`
Frontend: `139 KB` vs `237 KB`
Sample: `984 KB` vs `985 KB` (images)