### PR TITLE
Taxon rename AJAX was changing to PUT for some reason.

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/taxonomy.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/taxonomy.js.coffee
@@ -58,7 +58,6 @@ handle_rename = (e, data) ->
     dataType: "json",
     url: url.toString(),
     data: {
-      _method: "put",
       "taxon[name]": name,
       token: Spree.api_key
     },


### PR DESCRIPTION
The routes state that we should use POST. What was going on in that script filled with coffee was very confusing. Results was that name of taxon could not be changed.
Changed it back to use good old POST.