### PR TITLE
Fix `item.name` in `_create_line_items.html.erb`

### DIFF
--- a/backend/app/views/spree/admin/promotions/actions/_create_line_items.html.erb
+++ b/backend/app/views/spree/admin/promotions/actions/_create_line_items.html.erb
@@ -1,7 +1,9 @@
 <div class="panel-body calculator-fields">
   <% promotion_action.promotion_action_line_items.each do |item| %>
-    <strong><%= item.quantity %> x <%= item.name %></strong>
-    <%= item.variant.options_text %>
+    <% variant = item.variant %>
+
+    <strong><%= item.quantity %> x <%= variant.name %></strong>
+    <%= variant.options_text %>
   <% end %>
 
   <% if promotion_action.promotion_action_line_items.empty? %>


### PR DESCRIPTION
There is no `name` method for `PromotionActionLineItem`. The `rescue nil` on rendering the promotion action hides this error.