### PR TITLE
Removing unused registration_error css class

### DIFF
--- a/frontend/app/assets/stylesheets/spree/frontend/frontend_bootstrap.css.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/frontend_bootstrap.css.scss
@@ -47,7 +47,7 @@
 // -- Spree Layout Custom Rules -------------------------
 
 .alert-notice { @extend .alert-success; }
-.alert-error, .alert-registration_error { @extend .alert-danger; }
+.alert-error { @extend .alert-danger; }
 .alert-alert { @extend .alert-info; }
 
 .product-body {


### PR DESCRIPTION
This was removed via https://github.com/spree/spree_auth_devise/pull/361