### PR TITLE
use html way of data-disable-with instead of rails way

### DIFF
--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -167,7 +167,7 @@ module Spree
           icon = content_tag(:span, '', class: "icon icon-#{icon_name}")
           text.insert(0, icon + ' ')
         end
-        button_tag(text.html_safe, options.merge(type: button_type, class: "btn btn-primary #{options[:class]}", data: { disable_with: "#{ Spree.t(:saving) }..." }))
+        button_tag(text.html_safe, options.merge(type: button_type, class: "btn btn-primary #{options[:class]}", 'data-disable-with' => "#{ Spree.t(:saving) }..."))
       end
 
       def button_link_to(text, url, html_options = {})


### PR DESCRIPTION
the current implementation will override any ``data: { key: :value}`` hash pass in `` button_link_to``  helper method.
So it's better to use HTML way so that we can still pass our own data attributes