### PR TITLE
Show promotionable checkbox in product form even if it has variants

### DIFF
--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -69,6 +69,14 @@
         <% end %>
       </div>
 
+      <div data-hook="admin_product_form_promotionable">
+        <%= f.field_container :promotionable, class: ['form-group'] do %>
+          <%= f.label :promotionable, Spree.t(:promotionable) %>
+          <%= f.error_message_on :promotionable %>
+          <%= f.check_box :promotionable, class: 'form-control' %>
+        <% end %>
+      </div>
+
       <% if @product.has_variants? %>
         <div data-hook="admin_product_form_multiple_variants" class="well">
           <%= f.label :skus, Spree.t(:sku).pluralize %>
@@ -96,14 +104,6 @@
           <%= f.field_container :sku, class: ['form-group'] do %>
             <%= f.label :sku, Spree.t(:sku) %>
             <%= f.text_field :sku, size: 16, class: 'form-control' %>
-          <% end %>
-        </div>
-
-        <div data-hook="admin_product_form_promotionable">
-          <%= f.field_container :promotionable, class: ['form-group'] do %>
-              <%= f.label :promotionable, Spree.t(:promotionable) %>
-              <%= f.error_message_on :promotionable %>
-              <%= f.check_box :promotionable, class: 'form-control' %>
           <% end %>
         </div>
 


### PR DESCRIPTION
Currently, on **admin end**, if we go to the edit page of a **product** which also have variants, then the **promotionable** checkbox is not shown in the form.
This patch fixes this, so that admin can update product's promotionable field even if it has variants.
