### PR TITLE
Backport: added validation for discontinue_on and available_on in product.rb and specs for the it (3-1)

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -105,6 +105,7 @@ module Spree
     end
 
     validates :slug, length: { minimum: 3 }, allow_blank: true, uniqueness: true
+    validate :discontinue_on_must_be_later_than_available_on, if: -> { available_on && discontinue_on }
 
     attr_accessor :option_values_hash
 
@@ -370,6 +371,12 @@ module Spree
     def remove_taxon(taxon)
       removed_classifications = classifications.where(taxon: taxon)
       removed_classifications.each &:remove_from_list
+    end
+
+    def discontinue_on_must_be_later_than_available_on
+      if discontinue_on < available_on
+        errors.add(:discontinue_on, :invalid_date_range)
+      end
     end
   end
 end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -315,6 +315,8 @@ en:
               invalid_date_range: must be later than start date
         spree/product:
           attributes:
+            discontinue_on:
+              invalid_date_range: must be later than available date
             base:
               cannot_destroy_if_attached_to_line_items: Cannot delete products once they are attached to line items.
         spree/refund:

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -268,6 +268,40 @@ describe Spree::Product, :type => :model do
       end
     end
 
+    describe "#discontinue_on_must_be_later_than_available_on" do
+      before { product.available_on = Date.today }
+
+      context "available_on is a date earlier than discontinue_on" do
+        before { product.discontinue_on = 5.days.from_now }
+
+        it "is valid" do
+          expect(product).to be_valid
+        end
+      end
+
+      context "available_on is a date earlier than discontinue_on" do
+        before { product.discontinue_on = 5.days.ago }
+
+        context "is not valid" do
+          before { product.valid? }
+
+          it { expect(product).not_to be_valid }
+          it { expect(product.errors[:discontinue_on]).to include(I18n.t(:invalid_date_range, scope: 'activerecord.errors.models.spree/product.attributes.discontinue_on')) }
+        end
+      end
+
+      context "available_on and discontinue_on are nil" do
+        before do
+          product.discontinue_on = nil
+          product.available_on = nil
+        end
+
+        it "is valid" do
+          expect(product).to be_valid
+        end
+      end
+    end
+
     context "hard deletion" do
       it "doesnt raise ActiveRecordError error" do
         expect { product.really_destroy! }.to_not raise_error


### PR DESCRIPTION
#7468 