### PR TITLE
Backport: added created_at and updated_at globally to ransack search. (3-1)

### DIFF
--- a/core/app/models/concerns/spree/ransackable_attributes.rb
+++ b/core/app/models/concerns/spree/ransackable_attributes.rb
@@ -6,7 +6,7 @@ module Spree::RansackableAttributes
     class_attribute :whitelisted_ransackable_scopes
 
     class_attribute :default_ransackable_attributes
-    self.default_ransackable_attributes = %w[id name]
+    self.default_ransackable_attributes = %w[id name updated_at created_at]
 
     def self.ransackable_associations(*args)
       self.whitelisted_ransackable_associations || []

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -53,7 +53,7 @@ module Spree
     end
 
     self.whitelisted_ransackable_associations = %w[shipments user promotions bill_address ship_address line_items]
-    self.whitelisted_ransackable_attributes =  %w[completed_at created_at email number state payment_state shipment_state total considered_risky]
+    self.whitelisted_ransackable_attributes = %w[completed_at email number state payment_state shipment_state total considered_risky]
 
     attr_reader :coupon_code
     attr_accessor :temporary_address, :temporary_credit_card

--- a/core/app/models/spree/stock_transfer.rb
+++ b/core/app/models/spree/stock_transfer.rb
@@ -10,7 +10,7 @@ module Spree
     belongs_to :source_location, class_name: 'StockLocation'
     belongs_to :destination_location, class_name: 'StockLocation'
 
-    self.whitelisted_ransackable_attributes = %w[reference source_location_id destination_location_id created_at number]
+    self.whitelisted_ransackable_attributes = %w[reference source_location_id destination_location_id number]
 
     def to_param
       number


### PR DESCRIPTION
#7452 