### PR TITLE
Backport: reduces n+1 queries for variant load associated with variant_images (3-1)

### DIFF
--- a/frontend/app/controllers/spree/products_controller.rb
+++ b/frontend/app/controllers/spree/products_controller.rb
@@ -41,7 +41,7 @@ module Spree
         else
           @products = Product.active(current_currency)
         end
-        @product = @products.includes(:variants_including_master).friendly.find(params[:id])
+        @product = @products.includes(:variants_including_master, variant_images: :viewable).friendly.find(params[:id])
       end
 
       def load_taxon


### PR DESCRIPTION
#7456