### PR TITLE
CreateAdjustment promotion action should not remove shipment tax

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -184,7 +184,7 @@ module Spree
     end
 
     def shipping_discount
-      shipment_adjustments.eligible.sum(:amount) * - 1
+      shipment_adjustments.non_tax.eligible.sum(:amount) * - 1
     end
 
     def completed?


### PR DESCRIPTION
## Issue
Currently, the `CreateAdjustment` promotion action `do not remove product tax`, but it `removes shipment tax`.

## Steps to replicate
1. Create a promotion from admin end, with a promo code and whole-order adjustment of flat $100.
2. Now create an order from frontend.
3. Add 1 quantity of a product whose price is $80, plus $8 tax on it.
4. At delivery step, choose the shipping method with $15 cost, plus $1.5 of tax on it.
5. Now at payment step, select any payment method and apply the above mentioned coupon code promotion.
6. Order completed successfully.

**Order summary**
Subtotal: $80
Shipping: $15
Tax (Product): $8
Tax (Shipment): $1.5
Promotion ($100_off): -$96.5
Order total: $8

The promotion `did not remove the product's tax`, but it `removed the shipment's tax`.

## Fix
In the following code snippet from `CreateAdjustment` promotion action, the `order.shipping_discount` method call **should not** consider the tax adjustments on shipment.

```
def compute_amount(order)
  [(order.item_total + order.ship_total - order.shipping_discount), compute(order)].min * -1
end
```