### PR TITLE
Added ability to prevent normal user from updating completed order

### DIFF
--- a/api/spec/controllers/spree/api/v1/checkouts_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/checkouts_controller_spec.rb
@@ -248,11 +248,10 @@ module Spree
         expect(response.status).to eq(200)
       end
 
-      it "returns the order if the order is already complete" do
+      it "prevent normal user from updating completed order" do
         order.update_columns(completed_at: Time.current, state: 'complete')
         api_put :update, id: order.to_param, order_token: order.guest_token
-        expect(json_response['number']).to eq(order.number)
-        expect(response.status).to eq(200)
+        assert_unauthorized!
       end
 
       # Regression test for #3784

--- a/api/spec/controllers/spree/api/v1/line_items_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/line_items_controller_spec.rb
@@ -20,6 +20,7 @@ module Spree
     let(:product) { create(:product) }
     let(:attributes) { [:id, :quantity, :price, :variant, :total, :display_amount, :single_display_amount] }
     let(:resource_scoping) { { order_id: order.to_param } }
+    let(:admin_role) { create(:admin_role) }
 
     before do
       stub_authentication!
@@ -143,6 +144,7 @@ module Spree
 
         context "order is completed" do
           before do
+            current_api_user.spree_roles << admin_role
             order.reload
             allow(order).to receive_messages completed?: true
             allow(Order).to receive_message_chain :includes, find_by!: order

--- a/core/app/models/spree/ability.rb
+++ b/core/app/models/spree/ability.rb
@@ -43,8 +43,11 @@ module Spree
         can :display, OptionType
         can :display, OptionValue
         can :create, Order
-        can [:read, :update], Order do |order, token|
+        can :read, Order do |order, token|
           order.user == user || order.guest_token && token == order.guest_token
+        end
+        can :update, Order do |order, token|
+          !order.completed? && (order.user == user || order.guest_token && token == order.guest_token)
         end
         can :display, CreditCard, user_id: user.id
         can :display, Product

--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -82,6 +82,8 @@ module Spree
       redirect_to spree.cart_path
     end
 
+    private
+
     def accurate_title
       if @order && @order.completed?
         Spree.t(:order_number, number: @order.number)
@@ -94,29 +96,29 @@ module Spree
       order = Spree::Order.find_by(number: params[:id]) if params[:id].present?
       order = current_order unless order
 
-      if order
+      if order && action_name.to_sym == :show
+        authorize! :show, order, cookies.signed[:guest_token]
+      elsif order
         authorize! :edit, order, cookies.signed[:guest_token]
       else
         authorize! :create, Spree::Order
       end
     end
 
-    private
-
-      def order_params
-        if params[:order]
-          params[:order].permit(*permitted_order_attributes)
-        else
-          {}
-        end
+    def order_params
+      if params[:order]
+        params[:order].permit(*permitted_order_attributes)
+      else
+        {}
       end
+    end
 
-      def assign_order_with_lock
-        @order = current_order(lock: true)
-        unless @order
-          flash[:error] = Spree.t(:order_not_found)
-          redirect_to root_path and return
-        end
+    def assign_order_with_lock
+      @order = current_order(lock: true)
+      unless @order
+        flash[:error] = Spree.t(:order_not_found)
+        redirect_to root_path and return
       end
+    end
   end
 end

--- a/frontend/spec/controllers/spree/orders_controller_ability_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_ability_spec.rb
@@ -64,7 +64,7 @@ module Spree
 
       context "#show" do
         it "should check against the specified order" do
-          expect(controller).to receive(:authorize!).with(:edit, specified_order, token)
+          expect(controller).to receive(:authorize!).with(:show, specified_order, token)
           spree_get :show, id: specified_order.number
         end
       end
@@ -78,7 +78,7 @@ module Spree
           before { cookies.signed[:guest_token] = order.guest_token }
 
           it 'displays the page' do
-            expect(controller).to receive(:authorize!).with(:edit, order, order.guest_token)
+            expect(controller).to receive(:authorize!).with(:show, order, order.guest_token)
             spree_get :show, { id: 'R123' }
             expect(response.code).to eq('200')
           end


### PR DESCRIPTION
This patch adds the ability to prevent **normal user** from updating **completed order**.
Also, marked the `accurate_title` and `check_authorization` methods of `Spree::OrderController` as **private**.