### PR TITLE
show only available payment methods on backend on payment step

### DIFF
--- a/backend/app/controllers/spree/admin/payments_controller.rb
+++ b/backend/app/controllers/spree/admin/payments_controller.rb
@@ -89,11 +89,11 @@ module Spree
 
       def load_data
         @amount = params[:amount] || load_order.total
-        @payment_methods = PaymentMethod.available_on_back_end
+        @payment_methods = @order.collect_backend_payment_methods
         if @payment and @payment.payment_method
           @payment_method = @payment.payment_method
         else
-          @payment_method = @payment_methods.find_by(id: params[:payment][:payment_method_id]) if params[:payment]
+          @payment_method = @payment_methods.find { |payment_method| payment_method.id == params[:payment][:payment_method_id].to_i } if params[:payment]
           @payment_method ||= @payment_methods.first
         end
       end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -12,7 +12,7 @@ module Spree
     include Spree::Order::StoreCredit
     include Spree::Core::NumberGenerator.new(prefix: 'R')
     include Spree::Core::TokenGenerator
-    
+
     include NumberAsParam
 
     extend Spree::DisplayMoney
@@ -605,6 +605,10 @@ module Spree
     def has_non_reimbursement_related_refunds?
       refunds.non_reimbursement.exists? ||
         payments.offset_payment.exists? # how old versions of spree stored refunds
+    end
+
+    def collect_backend_payment_methods
+      PaymentMethod.available_on_back_end.select { |pm| pm.available_for_order?(self) }
     end
 
     # determines whether the inventory is fully discounted

--- a/core/app/models/spree/payment_method/store_credit.rb
+++ b/core/app/models/spree/payment_method/store_credit.rb
@@ -93,6 +93,10 @@ module Spree
       true
     end
 
+    def available_for_order?(order)
+      order.could_use_store_credit?
+    end
+
     private
 
     def handle_action_call(store_credit, action, action_name, auth_code = nil)

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1064,4 +1064,13 @@ describe Spree::Order, type: :model do
       end
     end
   end
+
+  describe '#collect_backend_payment_methods' do
+    let!(:order) { create(:order_with_line_items, line_items_count: 2) }
+    let!(:credit_card_payment_method) { create(:simple_credit_card_payment_method, display_on: 'both') }
+    let!(:store_credit_payment_method) { create(:store_credit_payment_method, display_on: 'both') }
+    it { expect(order.collect_backend_payment_methods).to include(credit_card_payment_method) }
+    it { expect(order.collect_backend_payment_methods).to_not include(store_credit_payment_method) }
+  end
+
 end

--- a/core/spec/models/spree/payment_method/store_credit_spec.rb
+++ b/core/spec/models/spree/payment_method/store_credit_spec.rb
@@ -288,4 +288,21 @@ describe Spree::PaymentMethod::StoreCredit do
       end
     end
   end
+
+  describe '#available_for_order?' do
+    let!(:store_credit_payment_method) { create(:store_credit_payment_method, display_on: 'both') }
+
+    context 'when user have store credits' do
+      let!(:user_with_store_credits) { create(:user) }
+      let!(:store_credit) { create(:store_credit, user: user_with_store_credits) }
+      let!(:order_with_store_credit) { create(:order, user: user_with_store_credits) }
+      it { expect(store_credit_payment_method.available_for_order?(order_with_store_credit)).to be true }
+    end
+
+    context "when user don't store credits" do
+      let!(:user_without_store_credits) { create(:user) }
+      let!(:order_without_store_credit) { create(:order, user: user_without_store_credits) }
+      it { expect(store_credit_payment_method.available_for_order?(order_without_store_credit)).to be false }
+    end
+  end
 end


### PR DESCRIPTION
## Issue
Store Credit Payment method is available on the backend for those users who don't have any store credits.

## Steps to Replicate

1. Create an Order from backend
2. Select a user who doesn't have any store credit in his/her account.
3. Go to payment method. Yo will see store credit payment method option.
4. Select this option and continue. An exception will be raised.

## Fix
Show only valid payment method for the orders.

## Screenshot
<img width="1440" alt="screen shot 2017-05-06 at 12 43 18 pm" src="https://cloud.githubusercontent.com/assets/13478899/25770706/53640db6-325a-11e7-94cd-371145eb872a.png">
