### PR TITLE
Updated test email template to show new name

### DIFF
--- a/core/app/views/spree/test_mailer/test_email.html.erb
+++ b/core/app/views/spree/test_mailer/test_email.html.erb
@@ -23,8 +23,8 @@
 
       <p>
         Please remember to configure all of the emails that Spree has provided to your needs.
-        Spree comes shipped with <a href="http://zurb.com/ink/" target="_blank"> Ink </a>
-        prepackaged, but you can use your own version. Ink is not placed in the asset pipeline.
+        Spree comes shipped with <a href="http://foundation.zurb.com/emails.html" target="_blank"> Foundation for Emails </a>
+        prepackaged, but you can use your own version. Foundation for Emails is not placed in the asset pipeline.
       </p>
 
       <p>


### PR DESCRIPTION
Ink has been renamed and http://zurb.com/ink/ redirects to foundation.zurb.com/emails.html now