### PR TITLE
Backport (3-1): Properly displays `or` on Taxon edit form in Admin Panel

### DIFF
--- a/backend/app/views/spree/admin/taxons/edit.html.erb
+++ b/backend/app/views/spree/admin/taxons/edit.html.erb
@@ -11,7 +11,7 @@
 
   <div class="form-actions" data-hook="buttons">
     <%= button Spree.t('actions.update'), 'save' %>
-    <%= Spree.t(:or) %>
+    <span class="or"><%= Spree.t(:or) %></span>
     <%= button_link_to Spree.t('actions.cancel'), edit_admin_taxonomy_url(@taxonomy), icon: "remove" %>
   </div>
 <% end %>


### PR DESCRIPTION
#7479