### PR TITLE
respond with correct user list if params has ids query

### DIFF
--- a/api/app/controllers/spree/api/v1/users_controller.rb
+++ b/api/app/controllers/spree/api/v1/users_controller.rb
@@ -6,11 +6,15 @@ module Spree
         rescue_from Spree::Core::DestroyWithOrdersError, with: :error_during_processing
 
         def index
-          if params[:ids]
-            @users = Spree.user_class.accessible_by(current_ability,:read).ransack(id_in: params[:ids].split(',')).result.page(params[:page]).per(params[:per_page])
-          else
-            @users = Spree.user_class.accessible_by(current_ability,:read).ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
-          end
+          @users = Spree.user_class.accessible_by(current_ability, :read)
+
+          @users = if params[:ids]
+                     @users.ransack(id_in: params[:ids].split(','))
+                   else
+                     @users.ransack(params[:q])
+                   end
+
+          @users = @users.result.page(params[:page]).per(params[:per_page])
           expires_in 15.minutes, public: true
           headers['Surrogate-Control'] = "max-age=#{15.minutes}"
           respond_with(@users)

--- a/api/app/controllers/spree/api/v1/users_controller.rb
+++ b/api/app/controllers/spree/api/v1/users_controller.rb
@@ -6,7 +6,11 @@ module Spree
         rescue_from Spree::Core::DestroyWithOrdersError, with: :error_during_processing
 
         def index
-          @users = Spree.user_class.accessible_by(current_ability,:read).ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
+          if params[:ids]
+            @users = Spree.user_class.accessible_by(current_ability,:read).ransack(id_in: params[:ids].split(',')).result.page(params[:page]).per(params[:per_page])
+          else
+            @users = Spree.user_class.accessible_by(current_ability,:read).ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
+          end
           expires_in 15.minutes, public: true
           headers['Surrogate-Control'] = "max-age=#{15.minutes}"
           respond_with(@users)


### PR DESCRIPTION
On the Promotion User Rule view. The `initSelection` call in `user_picker.js` calls the Users api with `ids` as the query param, but the action does not look at that query params so we get a random list of users for that page. 

Adding conditional block to run a different query if ids query detected. (Similar code was in other API controllers)