### PR TITLE
Check for persistence of cloned object instead of saving it

### DIFF
--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -65,13 +65,13 @@ module Spree
       def clone
         @new = @product.duplicate
 
-        if @new.save
+        if @new.persisted?
           flash[:success] = Spree.t('notice_messages.product_cloned')
+          redirect_to edit_admin_product_url(@new)
         else
           flash[:error] = Spree.t('notice_messages.product_not_cloned')
+          redirect_to admin_products_url
         end
-
-        redirect_to edit_admin_product_url(@new)
 
       rescue ActiveRecord::RecordInvalid
         # Handle error on uniqueness validation on product fields


### PR DESCRIPTION
Hi! I'm first-time Spree contributor and I really glad to do that. But anyway let me know if anything I can do better this or next time.

So, I noticed that after we duplicate a product from admin panel, we trying to save the cloned product once again, even though we do saving it in [here](https://github.com/spree/spree/blob/master/core/lib/spree/core/product_duplicator.rb#L21)

Quickly running a benchmark and it seems like we can replace it with `persisted?` instead.
```ruby
require 'benchmark/ips'

ActiveRecord::Base.logger.level = 1
product = Spree::Product.first

puts 'With dynamic product calling'
puts '===================================================='
Benchmark.ips do |benchmark|
  benchmark.report('save') { Spree::Product.first.save }
  benchmark.report('persisted?')  { Spree::Product.first.persisted? }
  benchmark.compare!
end
puts '--------------------------------------------------'

puts 'With predefined product'
puts '===================================================='
Benchmark.ips do |benchmark|
  benchmark.report('save') { product.save }
  benchmark.report('persisted?') { product.persisted? }
  benchmark.compare!
end
puts '--------------------------------------------------'
```

And the output:
```ruby
With dynamic calling
====================================================
Warming up --------------------------------------
                save     5.000  i/100ms
          persisted?   108.000  i/100ms
Calculating -------------------------------------
                save     67.537  (±10.4%) i/s -    335.000  in   5.031552s
          persisted?      1.027k (±14.4%) i/s -      5.076k in   5.085161s

Comparison:
          persisted?:     1026.8 i/s
                save:       67.5 i/s - 15.20x  slower
--------------------------------------------------

With predefined product
====================================================
Warming up --------------------------------------
                save    15.000  i/100ms
          persisted?    51.471k i/100ms
Calculating -------------------------------------
                save    149.331  (±14.7%) i/s -    735.000  in   5.059768s
          persisted?    651.744k (±16.1%) i/s -      3.140M in   5.005903s

Comparison:
          persisted?:   651743.6 i/s
                save:      149.3 i/s - 4364.42x  slower
--------------------------------------------------
```

I know, that the difference is not that ~ big ~ in the real-world, but I thought it may be a good start for me to make Spree better and greater :)
Thank you in advance.