### PR TITLE
[Admin End] Refresh shipping rates only if order is incomplete

### DIFF
--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -56,13 +56,12 @@ module Spree
       def edit
         can_not_transition_without_customer_info
 
-        @order.refresh_shipment_rates(ShippingMethod::DISPLAY_ON_BACK_END)
+        @order.refresh_shipment_rates(ShippingMethod::DISPLAY_ON_BACK_END) unless @order.completed?
       end
 
       def cart
-        unless @order.completed?
-          @order.refresh_shipment_rates
-        end
+        @order.refresh_shipment_rates(ShippingMethod::DISPLAY_ON_BACK_END) unless @order.completed?
+
         if @order.shipments.shipped.count > 0
           redirect_to edit_admin_order_url(@order)
         end


### PR DESCRIPTION
`cart` action in **Spree::Admin::OrdersController** refreshes shipment rates only if order is incomplete. This patch applies the same condition in the `edit` action.
Also, since we are placing order from admin end, we should refresh shipping rates for shipping methods available only for admin end.