### PR TITLE
Add rails_test_params_backport for Spree 3.1/Rails 4.2 in extension generator

### DIFF
--- a/cmd/lib/spree_cmd/templates/extension/Appraisals
+++ b/cmd/lib/spree_cmd/templates/extension/Appraisals
@@ -1,6 +1,7 @@
 appraise 'spree-3-1' do
   gem 'spree', '~> 3.1.0'
   gem 'spree_auth_devise', '~> 3.1.0'
+  gem 'rails_test_params_backport', group: :test
 end
 
 appraise 'spree-3-2' do

--- a/cmd/lib/spree_cmd/templates/extension/gemfiles/spree_3_1.gemfile
+++ b/cmd/lib/spree_cmd/templates/extension/gemfiles/spree_3_1.gemfile
@@ -4,5 +4,6 @@ source "https://rubygems.org"
 
 gem "spree", "~> 3.1.0"
 gem "spree_auth_devise", "~> 3.1.0"
+gem "rails_test_params_backport", group: :test
 
 gemspec :path => "../"


### PR DESCRIPTION
This will allow to write universal controller specs with Rails 5.0+ params even on Rails 4.2