### PR TITLE
Admin has to confirm clear cache in Admin Panel

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/general_settings.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/general_settings.js.coffee
@@ -1,13 +1,15 @@
 $(@).ready( ->
   $('[data-hook=general_settings_clear_cache] #clear_cache').click ->
-    $.ajax
-      type: 'POST'
-      url: Spree.routes.clear_cache
-      success: ->
-        show_flash 'success', "Cache was flushed."
-      error: (msg) ->
-        if msg.responseJSON["error"]
-          show_flash 'error', msg.responseJSON["error"]
-        else
-          show_flash 'error', "There was a problem while flushing cache."
+    response = confirm(Spree.translations.are_you_sure)
+    if response
+      $.ajax
+        type: 'POST'
+        url: Spree.routes.clear_cache
+        success: ->
+          show_flash 'success', "Cache was flushed."
+        error: (msg) ->
+          if msg.responseJSON["error"]
+            show_flash 'error', msg.responseJSON["error"]
+          else
+            show_flash 'error', "There was a problem while flushing cache."
 )

--- a/backend/app/views/spree/admin/shared/_translations.html.erb
+++ b/backend/app/views/spree/admin/shared/_translations.html.erb
@@ -2,6 +2,7 @@
   Spree.translations = <%==
   { abbr_day_names:           I18n.t(:abbr_day_names, scope: :date),
     add:                      Spree.t(:add),
+    are_you_sure:             Spree.t(:are_you_sure),
     are_you_sure_delete:      Spree.t(:are_you_sure_delete),
     bill_address:             Spree.t(:bill_address),
     cancel:                   Spree.t(:cancel,  scope: :actions),

--- a/backend/spec/features/admin/configuration/general_settings_spec.rb
+++ b/backend/spec/features/admin/configuration/general_settings_spec.rb
@@ -36,7 +36,9 @@ describe "General Settings", type: :feature do
       expect(page).to_not have_content(Spree.t(:clear_cache_ok))
       expect(page).to have_content(Spree.t(:clear_cache_warning))
 
-      click_button "Clear Cache"
+      page.accept_confirm do
+        click_button "Clear Cache"
+      end
 
       expect(page).to have_content(Spree.t(:clear_cache_ok))
     end


### PR DESCRIPTION
This will allow us to avoid any accidental clicks leading to clearing the entire store cache