### PR TITLE
Admin field_container now supports options like content_tag does

### DIFF
--- a/backend/app/helpers/spree/admin/base_helper.rb
+++ b/backend/app/helpers/spree/admin/base_helper.rb
@@ -21,7 +21,10 @@ module Spree
         if error_message_on(model, method).present?
           css_classes << 'withError'
         end
-        content_tag(:div, capture(&block), class: css_classes.join(' '), id: "#{model}_#{method}_field")
+        content_tag(
+          :div, capture(&block),
+          options.merge(class: css_classes.join(' '), id: "#{model}_#{method}_field")
+        )
       end
 
       def error_message_on(object, method, options = {})


### PR DESCRIPTION
In this way we can add, e.g., data attributes to field_container.

```erb
<%= field_container f.object, :company, class: ["form-group", "#{type}-row"], 'data-foo' => 'bar' do %>
...
<% end %
```