### PR TITLE
Remove frontend routes from core

### DIFF
--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -255,12 +255,12 @@ describe Spree::Admin::OrdersController, type: :controller do
 
       context 'when referer' do
         before(:each) do
-          request.env['HTTP_REFERER'] = root_url
+          request.env['HTTP_REFERER'] = '/'
         end
 
         it "redirects back" do
           spree_post :open_adjustments, id: order.number
-          expect(response).to redirect_to(root_url)
+          expect(response).to redirect_to('/')
         end
       end
 
@@ -297,12 +297,12 @@ describe Spree::Admin::OrdersController, type: :controller do
 
       context 'when referer' do
         before(:each) do
-          request.env['HTTP_REFERER'] = root_url
+          request.env['HTTP_REFERER'] = '/'
         end
 
         it "redirects back" do
           spree_post :close_adjustments, id: order.number
-          expect(response).to redirect_to(root_url)
+          expect(response).to redirect_to('/')
         end
       end
 
@@ -370,7 +370,7 @@ describe Spree::Admin::OrdersController, type: :controller do
     it 'should deny access to not signed in users' do
       allow(controller).to receive_messages spree_current_user: nil
       spree_get :index
-      expect(response).to redirect_to(spree.root_path)
+      expect(response).to redirect_to('/')
     end
 
     it 'should restrict returned order(s) on index when using OrderSpecificAbility' do

--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -34,7 +34,7 @@ module Spree
     end
 
     def logo(image_path=Spree::Config[:logo])
-      link_to image_tag(image_path), spree.root_path
+      link_to image_tag(image_path), spree.respond_to?(:root_path) ? spree.root_path : main_app.root_path
     end
 
     def meta_data

--- a/core/app/mailers/spree/base_mailer.rb
+++ b/core/app/mailers/spree/base_mailer.rb
@@ -9,6 +9,11 @@ module Spree
     end
     helper_method :money
 
+    def frontend_available?
+      Spree::Core::Engine.frontend_available?
+    end
+    helper_method :frontend_available?
+
     def mail(headers = {}, &block)
       ensure_default_action_mailer_url_host
       super if Spree::Config[:send_core_emails]

--- a/core/app/views/spree/shared/_base_mailer_header.html.erb
+++ b/core/app/views/spree/shared/_base_mailer_header.html.erb
@@ -11,7 +11,11 @@
               <table class="twelve columns">
                 <tr>
                   <td class="twelve sub-columns last">
-                    <%= link_to spree.root_url, class: 'template-label' do %>
+                    <% if frontend_available? %>
+                      <%= link_to spree.root_url, class: 'template-label' do %>
+                        <%= image_tag Spree::Config.logo, class: 'logo', alt: Spree::Store.current.name, title: Spree::Store.current.name %>
+                      <% end %>
+                    <% else %>
                       <%= image_tag Spree::Config.logo, class: 'logo', alt: Spree::Store.current.name, title: Spree::Store.current.name %>
                     <% end %>
                   </td>

--- a/core/app/views/spree/shared/_mailer_line_item.html.erb
+++ b/core/app/views/spree/shared/_mailer_line_item.html.erb
@@ -1,7 +1,11 @@
 <tr>
   <td class="six sub-columns">
     <strong>
-      <%= link_to raw(line_item.variant.product.name), spree.product_url(line_item.variant.product) %>
+      <% if frontend_available? %>
+        <%= link_to raw(line_item.variant.product.name), spree.product_url(line_item.variant.product) %>
+      <% else %>
+        <%= raw(line_item.variant.product.name) %>
+      <% end %>
     </strong>
     <%= raw(line_item.variant.options_text) -%>
     (<%= line_item.variant.sku %>)

--- a/core/config/routes.rb
+++ b/core/config/routes.rb
@@ -1,8 +1,5 @@
 Spree::Core::Engine.add_routes do
   get '/forbidden', to: 'home#forbidden', as: :forbidden
-  # those routes are needed for mailers
-  root to: 'home#index'
-  resources :products, only: [:index, :show]
 end
 
 Spree::Core::Engine.draw_routes

--- a/core/lib/spree/core/components.rb
+++ b/core/lib/spree/core/components.rb
@@ -1,0 +1,17 @@
+module Spree
+  module Core
+    class Engine < ::Rails::Engine
+      def self.api_available?
+        @@api_available ||= ::Rails::Engine.subclasses.map(&:instance).map{ |e| e.class.to_s }.include?('Spree::Api::Engine')
+      end
+
+      def self.backend_available?
+        @@backend_available ||= ::Rails::Engine.subclasses.map(&:instance).map{ |e| e.class.to_s }.include?('Spree::Backend::Engine')
+      end
+
+      def self.frontend_available?
+        @@frontend_available ||= ::Rails::Engine.subclasses.map(&:instance).map{ |e| e.class.to_s }.include?('Spree::Frontend::Engine')
+      end
+    end
+  end
+end

--- a/core/lib/spree/core/controller_helpers/auth.rb
+++ b/core/lib/spree/core/controller_helpers/auth.rb
@@ -72,8 +72,10 @@ module Spree
             store_location
             if respond_to?(:spree_login_path)
               redirect_to spree_login_path
+            elsif spree.respond_to?(:root_path)
+              redirect_to spree.root_path
             else
-              redirect_to spree.respond_to?(:root_path) ? spree.root_path : main_app.root_path
+              redirect_to main_app.respond_to?(:root_path) ? main_app.root_path : '/'
             end
           end
         end

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -133,3 +133,4 @@ module Spree
 end
 
 require 'spree/core/routes'
+require 'spree/core/components'

--- a/frontend/config/routes.rb
+++ b/frontend/config/routes.rb
@@ -1,5 +1,9 @@
 Spree::Core::Engine.add_routes do
 
+  root to: 'home#index'
+
+  resources :products, only: [:index, :show]
+
   get '/locale/set', to: 'locale#set'
 
   # non-restful checkout stuff


### PR DESCRIPTION
Frontend-specific routes should be part of the `spree_frontend` to not clash with any developer-defined routes when frontend isn't used. 

This was introduced in https://github.com/spree/spree/commit/f9c40b7743470a88449914ea3f8582d13f5092c0 .

Also adding `Spree::Core::Engine` component specific chekers like `frontend_available?`, `backend_available?`, `api_available?`