### PR TITLE
Allow valid image types to be overridden without deleting validations

### DIFF
--- a/core/app/models/spree/image.rb
+++ b/core/app/models/spree/image.rb
@@ -2,6 +2,10 @@ module Spree
   class Image < Asset
     validate :no_attachment_errors
 
+    def self.accepted_image_types
+      %w(image/jpeg image/jpg image/png image/gif)
+    end
+
     has_attached_file :attachment,
                       styles: { mini: '48x48>', small: '100x100>', product: '240x240>', large: '600x600>' },
                       default_style: :product,
@@ -10,7 +14,7 @@ module Spree
                       convert_options: { all: '-strip -auto-orient -colorspace sRGB' }
     validates_attachment :attachment,
       presence: true,
-      content_type: { content_type: %w(image/jpeg image/jpg image/png image/gif) }
+      content_type: { content_type: accepted_image_types }
 
     # save the w,h of the original image (from which others can be calculated)
     # we need to look at the write-queue for images which have not been saved yet


### PR DESCRIPTION
Allows downstream users to define which types of images are accepted without having to modify the existing validations.