### PR TITLE
Bump jquery-rails to 4.3 (3-2-stable)

### DIFF
--- a/backend/spree_backend.gemspec
+++ b/backend/spree_backend.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_core', s.version
 
   s.add_dependency 'bootstrap-sass',  '~> 3.3'
-  s.add_dependency 'jquery-rails',    '~> 4.1'
+  s.add_dependency 'jquery-rails',    '~> 4.3'
   s.add_dependency 'jquery-ui-rails', '~> 5.0'
   s.add_dependency 'select2-rails',   '3.5.9.1' # 3.5.9.2 breaks several specs
 end

--- a/frontend/spree_frontend.gemspec
+++ b/frontend/spree_frontend.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'bootstrap-sass',  '>= 3.3.5.1', '< 3.4'
   s.add_dependency 'canonical-rails', '~> 0.1.0'
-  s.add_dependency 'jquery-rails',    '~> 4.1'
+  s.add_dependency 'jquery-rails',    '~> 4.3'
 
   s.add_development_dependency 'capybara-accessible'
 end


### PR DESCRIPTION
`~> 4.1` caused sometimes problems with bundler and Rails 5.x