### PR TITLE
Order 'resumed' state missing label class added

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_labels.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_labels.scss
@@ -1,6 +1,7 @@
 // Green
 .label-completed,
 .label-complete,
+.label-resumed,
 .label-considered_safe,
 .label-paid,
 .label-shipped,


### PR DESCRIPTION
## Issue
Currently if an order is in `resumed` state, then the `state` of this order is not visible to the admin.

### Order index page
<img width="1141" alt="screen shot 2017-07-29 at 10 10 32 pm" src="https://user-images.githubusercontent.com/21332195/28746518-acd1c17a-74ab-11e7-8277-f83f6a33e91b.png">

### Order summary
<img width="1152" alt="screen shot 2017-07-29 at 10 16 37 pm" src="https://user-images.githubusercontent.com/21332195/28746519-aeb7f84c-74ab-11e7-9585-20fc5ba8f703.png">
