### PR TITLE
We don't need rabl in the gemfile, it's in gemspecs

### DIFF
--- a/api/Gemfile
+++ b/api/Gemfile
@@ -2,6 +2,4 @@ eval(File.read(File.dirname(__FILE__) + '/../common_spree_dependencies.rb'))
 
 gem 'spree_core', path: '../core'
 
-gem 'rabl'
-
 gemspec


### PR DESCRIPTION
It was only required when we used rabl from github for rails 5 support
https://github.com/spree/spree/commit/13bea766d6ed57771da875279d57785b225ed82e