### PR TITLE
Add `region` parameter to Paperclip S3 config

### DIFF
--- a/guides/content/developer/customization/s3_storage.md
+++ b/guides/content/developer/customization/s3_storage.md
@@ -24,6 +24,7 @@ attachment_config = {
   },
 
   storage:        :s3,
+  s3_region:      ENV['S3_REGION'],
   s3_headers:     { "Cache-Control" => "max-age=31557600" },
   s3_protocol:    "https",
   bucket:         ENV['S3_BUCKET_NAME'],


### PR DESCRIPTION
`region` is now required with `aws-sdk` version >= 2