### PR TITLE
Avoid exceptions when parsing empty numeric fields in Ruby 2.4+

### DIFF
--- a/core/lib/spree/localized_number.rb
+++ b/core/lib/spree/localized_number.rb
@@ -19,6 +19,8 @@ module Spree
       return 0 unless number.present?
 
       number.to_d
+    rescue ArgumentError
+      0.to_d
     end
 
   end


### PR DESCRIPTION
Following the conversation from PR #7836, here is a change to avoid the exceptions raised by Ruby 2.4.0+ when trying to parse an invalid BigDecimal. 

In Ruby 2.3.x BigDecimal returned a default of 0, so:

    "".to_d => 0

In Ruby 2.4.x BigDecimal raises an ArgumentError instead:

    "".to_d => ArgumentError: invalid value for BigDecimal(): ""

With this change I'm just mimicking the previous default behaviour of the `BigDecimal#to_d` method so Spree doesn't crash when you leave an empty price field in the admin area.