### PR TITLE
Payment 'processing' state missing label class added

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_labels.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_labels.scss
@@ -29,6 +29,7 @@
 }
 
 // Orange
+.label-processing,
 .label-pending,
 .label-awaiting_return,
 .label-returned,


### PR DESCRIPTION
Currently, if a `payment` is in `processing` state, then the state of this payment is not visible to the admin in the order's payment tab.
This patch adds the `label-processing` class to fix this.
