### PR TITLE
Refund amount validation fix

### DIFF
--- a/backend/app/views/spree/admin/refunds/new.html.erb
+++ b/backend/app/views/spree/admin/refunds/new.html.erb
@@ -18,14 +18,16 @@
         <%= f.label :credit_allowed, Spree.t(:credit_allowed) %><br/>
         <%= @refund.payment.credit_allowed %>
       </div>
-      <div class="form-group">
+      <%= f.field_container :amount, class: ['form-group'] do %>
         <%= f.label :amount, Spree.t(:amount) %>
         <%= f.text_field :amount, class: 'form-control' %>
-      </div>
-      <div class="form-group">
+        <%= f.error_message_on :amount %>
+      <% end %>
+      <%= f.field_container :reason, class: ['form-group'] do %>
         <%= f.label :refund_reason_id, Spree.t(:reason) %>
         <%= f.collection_select(:refund_reason_id, refund_reasons, :id, :name, {include_blank: true}, {class: 'select2'}) %>
-      </div>
+        <%= f.error_message_on :reason %>
+      <% end %>
     </div>
 
     <div class="form-actions" data-hook="buttons">

--- a/core/app/models/spree/refund.rb
+++ b/core/app/models/spree/refund.rb
@@ -14,7 +14,7 @@ module Spree
       validates :transaction_id, on: :update
       validates :amount, numericality: { greater_than: 0, allow_nil: true }
     end
-    validate :amount_is_less_than_or_equal_to_allowed_amount, on: :create
+    validate :amount_is_less_than_or_equal_to_allowed_amount, on: :create, if: :amount
 
     after_create :perform!
     after_create :create_log_entry


### PR DESCRIPTION
## Issue
While creating a **Spree::Refund** object, if amount is `nil`, then `amount_is_less_than_or_equal_to_allowed_amount` method raises the following error:
`undefined method > for nil:NilClass`

## Fix
Validate `amount_is_less_than_or_equal_to_allowed_amount` only if `amount` is present.
This patch also shows the inline errors if validation fails while creating refund. 
