### PR TITLE
Fixed #8207 PG::InvalidColumnReference: ERROR:  for SELECT DISTINCT, …

### DIFF
--- a/api/app/controllers/spree/api/v1/products_controller.rb
+++ b/api/app/controllers/spree/api/v1/products_controller.rb
@@ -7,10 +7,10 @@ module Spree
           if params[:ids]
             @products = product_scope.where(id: params[:ids].split(",").flatten)
           else
-            @products = product_scope.ransack(params[:q]).result
+            @products = product_scope.ransack(params[:q]).result(distinct: true).select("#{Spree::Product.table_name}.id AS count_column, #{Spree::Product.table_name}.*")
           end
 
-          @products = @products.distinct.page(params[:page]).per(params[:per_page])
+          @products = @products.page(params[:page]).per(params[:per_page])
           expires_in 15.minutes, public: true
           headers['Surrogate-Control'] = "max-age=#{15.minutes}"
           respond_with(@products)

--- a/api/spec/controllers/spree/api/v1/products_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/products_controller_spec.rb
@@ -124,6 +124,14 @@ module Spree
         expect(json_response["count"]).to eq(1)
       end
 
+      # regression test for https://github.com/spree/spree/issues/8207
+      it "can sort products by date" do
+        first_product = create(:product, created_at: Time.current - 1.month)
+        second_product = create(:product, created_at: Time.current)
+        api_get :index, q: { s: "created_at asc" }
+        expect(json_response["products"].first['id']).to eq(first_product.id)
+      end
+
       it "gets a single product" do
         product.master.images.create!(attachment: image("thinking-cat.jpg"))
         create(:variant, product: product)


### PR DESCRIPTION
…ORDER BY expressions must appear in select list

This is a temporary fix until Rails 5.1.4 release containing a fix
provided via https://github.com/rails/rails/pull/29848

See also
https://github.com/activerecord-hackery/ransack#problem-with-distinct-se
lects