### PR TITLE
Fix cart quantity edge case when inventory units already created

### DIFF
--- a/core/app/models/spree/stock/availability_validator.rb
+++ b/core/app/models/spree/stock/availability_validator.rb
@@ -2,7 +2,7 @@ module Spree
   module Stock
     class AvailabilityValidator < ActiveModel::Validator
       def validate(line_item)
-        unit_count = line_item.inventory_units.sum(&:quantity)
+        unit_count = line_item.inventory_units.reject(&:pending?).sum(&:quantity)
         return if unit_count >= line_item.quantity
 
         quantity = line_item.quantity - unit_count

--- a/core/spec/models/spree/stock/availability_validator_spec.rb
+++ b/core/spec/models/spree/stock/availability_validator_spec.rb
@@ -10,6 +10,7 @@ module Spree
       subject { described_class.new }
 
       before do
+        allow(inventory_unit).to receive_messages(pending?: false)
         allow(inventory_unit).to receive_messages(quantity: 5)
       end
 


### PR DESCRIPTION
Steps to Replicate:
1. Add an item to the cart which has only one quantity remaining, further adding this item will give error.
2. Proceed to checkout till payment screen.
3. Go back to home screen and add this item again, it gets added to the cart as the inventory units already created.

