### PR TITLE
Deprecate Variant#having_orders & Variant#on_backorder

### DIFF
--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -94,6 +94,7 @@ module Spree
     end
 
     def self.having_orders
+      warn "`Spree::Variant#having_orders` is deprecated and will be removed in Spree 3.4"
       joins(:line_items).distinct
     end
 

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -108,6 +108,7 @@ module Spree
 
     # returns number of units currently on backorder for this variant.
     def on_backorder
+      warn "`Spree::Variant#on_backorder` is deprecated and will be removed in Spree 3.4"
       inventory_units.with_state('backordered').size
     end
 

--- a/guides/content/release_notes/3_3_0.md
+++ b/guides/content/release_notes/3_3_0.md
@@ -269,3 +269,7 @@ You can view the full changes using [Github Compare](https://github.com/spree/sp
 * Deprecate `Shipment#editable_by?` & `Shipment#send_shipped_email`
 
   [Spark Solutions](https://github.com/spree/spree/pull/8106)
+
+* Deprecate `Variant#having_orders`
+
+  [Spark Solutions](https://github.com/spree/spree/pull/8225)

--- a/guides/content/release_notes/3_3_0.md
+++ b/guides/content/release_notes/3_3_0.md
@@ -270,6 +270,6 @@ You can view the full changes using [Github Compare](https://github.com/spree/sp
 
   [Spark Solutions](https://github.com/spree/spree/pull/8106)
 
-* Deprecate `Variant#having_orders`
+* Deprecate `Variant#having_orders` & `Variant#on_backorder`
 
   [Spark Solutions](https://github.com/spree/spree/pull/8225)


### PR DESCRIPTION
This scope became obsolete after
https://github.com/spree/spree/commit/6a33007ef211f43a08b0ec87c7dd355fc6d22457