### PR TITLE
Fixes displaying of version number in the admin panel

### DIFF
--- a/backend/app/views/spree/admin/shared/_main_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_main_menu.html.erb
@@ -40,7 +40,7 @@
   </ul>
 <% end %>
 
-<% if can? :admin, current_store && Spree::Config[:admin_show_version] %>
+<% if can?(:admin, current_store) && Spree::Config[:admin_show_version] %>
   <div class="spree-version hidden-xs hidden-sm">
     <%= Spree.version %>
   </div>

--- a/backend/spec/features/admin/homepage_spec.rb
+++ b/backend/spec/features/admin/homepage_spec.rb
@@ -17,7 +17,7 @@ describe "Homepage", type: :feature do
       it "has a link to overview" do
         within("header") { page.find(:xpath, "//a[@href='/admin']") }
       end
-        
+
       it "has a link to orders" do
         page.find_link("Orders")['/admin/orders']
       end
@@ -40,6 +40,21 @@ describe "Homepage", type: :feature do
 
       it "has a link to customer returns" do
         within('.sidebar') { page.find_link("Customer Returns")['/admin/customer_returns'] }
+      end
+
+      context 'version number' do
+        it 'is displayed' do
+          within('.sidebar') { expect(page).to have_content(Spree.version) }
+        end
+
+        context 'if turned off' do
+          before { Spree::Config[:admin_show_version] = false }
+
+          it 'is not displayed' do
+            visit spree.admin_path
+            within('.sidebar') { expect(page).to_not have_content(Spree.version) }
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Previous attempt (https://github.com/spree/spree/commit/2c520810a8830a0dee0f205e9513059c942e0c9f) always displayed the version number and didn't respect configuration