### PR TITLE
Move Admin Panel account menu into Spree core and redesigned it

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/sections/_account.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_account.scss
@@ -5,12 +5,12 @@
   }
 
   .dropdown-menu {
-    padding: 20px;
-    min-width: 240px;
-    text-align: center;
+    width: 100%;
+    padding: 0 0;
 
     a {
       color: $dropdown-link-color !important;
+      padding: 15px;
     }
   }
 }

--- a/backend/app/assets/stylesheets/spree/backend/sections/_account.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_account.scss
@@ -8,6 +8,10 @@
     width: 100%;
     padding: 0 0;
 
+    hr {
+      margin: 0 0;
+    }
+
     a {
       color: $dropdown-link-color !important;
       padding: 15px;

--- a/backend/app/views/spree/admin/shared/_account_nav.html.erb
+++ b/backend/app/views/spree/admin/shared/_account_nav.html.erb
@@ -1,0 +1,37 @@
+<% if try_spree_current_user %>
+  <ul class="nav navbar-nav">
+    <li class="dropdown user user-menu">
+      <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+        <i class="glyphicon glyphicon-user"></i>
+        <span><%= try_spree_current_user.email %> <i class="caret"></i></span>
+      </a>
+      <ul class="dropdown-menu">
+        <% if spree.respond_to? :root_path %>
+          <li>
+            <%= link_to spree.root_path, target: :blank do %>
+              <i class="glyphicon glyphicon-new-window"></i>
+              &nbsp;
+              <%= Spree.t(:back_to_store) %>
+            <% end %>
+          </li>
+        <% end %>
+        <li>
+          <%= link_to spree.edit_admin_user_path(try_spree_current_user) do %>
+            <i class="glyphicon glyphicon-user"></i>
+            &nbsp;
+            <%= Spree.t(:account) %>
+          <% end %>
+        </li>
+        <% if spree.respond_to? :admin_logout_path %>
+          <li>
+            <%= link_to spree.admin_logout_path do %>
+              <i class="glyphicon glyphicon-log-out"></i>
+              &nbsp;
+              <%= Spree.t(:logout) %>
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
+    </li>
+  </ul>
+<% end %>

--- a/backend/app/views/spree/admin/shared/_account_nav.html.erb
+++ b/backend/app/views/spree/admin/shared/_account_nav.html.erb
@@ -31,6 +31,14 @@
             <% end %>
           </li>
         <% end %>
+        <hr />
+        <li>
+          <%= link_to 'http://guides.spreecommerce.org', target: :blank do %>
+            <i class="glyphicon glyphicon-info-sign"></i>
+            &nbsp;
+            <%= Spree.t(:help_center) %>
+          <% end %>
+        </li>
       </ul>
     </li>
   </ul>

--- a/backend/app/views/spree/admin/shared/_header.html.erb
+++ b/backend/app/views/spree/admin/shared/_header.html.erb
@@ -16,7 +16,9 @@
             </span>
         </div>
         <div class="col-xs-9 col-md-10">
-          <div class="navbar-right" data-hook="admin_login_navigation_bar"></div>
+          <div class="navbar-right">
+            <%= render partial: 'spree/admin/shared/account_nav' %>
+          </div>
         </div>
       </div>
     </div>

--- a/backend/spec/features/admin/orders/cancelling_and_resuming_spec.rb
+++ b/backend/spec/features/admin/orders/cancelling_and_resuming_spec.rb
@@ -4,7 +4,7 @@ describe "Cancelling + Resuming", type: :feature do
 
   stub_authorization!
 
-  let(:user) { double(id: 123, has_spree_role?: true, spree_api_key: 'fake') }
+  let(:user) { double(id: 123, has_spree_role?: true, spree_api_key: 'fake', email: 'spree@example.com') }
 
   before do
     allow_any_instance_of(Spree::Admin::BaseController).to receive(:try_spree_current_user).and_return(user)

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -540,7 +540,7 @@ en:
     back_to_resource_list: 'Back To %{resource} List'
     back_to_payment: Back To Payment
     back_to_rma_reason_list: Back To RMA Reason List
-    back_to_store: Go Back To Store
+    back_to_store: Back to Store
     back_to_users_list: Back To Users List
     backorderable: Backorderable
     backorderable_default: Backorderable default

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -779,6 +779,7 @@ en:
     has_no_shipped_units: has no shipped units
     height: Height
     home: Home
+    help_center: Help Center
     i18n:
       available_locales: Available Locales
       fields: Fields


### PR DESCRIPTION
For a long time this was part of the spree_auth_devise gem and forced
developers without auth_devise to create their own views.

Redesigning for modern UI

Account link links to backend user edit action

Before

<img width="248" alt="screen shot 2017-08-24 at 9 30 08 am" src="https://user-images.githubusercontent.com/55154/29654768-d95a7de2-88ae-11e7-96ab-07051aa21b31.png">

After

<img width="209" alt="screen shot 2017-08-23 at 10 26 38 pm" src="https://user-images.githubusercontent.com/55154/29654775-def4d810-88ae-11e7-8c34-9049a4a6ae03.png">
