### PR TITLE
Fix db:seed states nil carmen_country bug

### DIFF
--- a/core/db/default/spree/states.rb
+++ b/core/db/default/spree/states.rb
@@ -4,6 +4,7 @@ state_inserts = []
 state_values = -> do
   Spree::Country.where(states_required: true).each do |country|
     carmen_country = Carmen::Country.named(country.name)
+    next if !carmen_country
     carmen_country.subregions.each do |subregion|
       name       = connection.quote subregion.name
       abbr       = connection.quote subregion.code


### PR DESCRIPTION
When run `rails db:seed` throw nil:NilClass exception

> loading ruby /Users/GQiu/.rvm/gems/ruby-2.4.1/gems/spree_core-3.2.1/db/default/spree/countries.rb
loading ruby /Users/GQiu/.rvm/gems/ruby-2.4.1/gems/spree_core-3.2.1/db/default/spree/default_reimbursement_type.rb
loading ruby /Users/GQiu/.rvm/gems/ruby-2.4.1/gems/spree_core-3.2.1/db/default/spree/roles.rb
loading ruby /Users/GQiu/.rvm/gems/ruby-2.4.1/gems/spree_core-3.2.1/db/default/spree/states.rb
undefined method `subregions' for nil:NilClass
["/Users/GQiu/.rvm/gems/ruby-2.4.1/gems/spree_core-3.2.1/db/default/spree/states.rb:9:in `block (2 levels) in <top (required)>'"

## Possible Fix

> Found Venezuela have no subregions

Should goto next if found carmen_country is nil