### PR TITLE
Move copy views in install generator as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,11 @@ state. It is unwise to use this branch in a production system you care deeply
 about.**
 
 By default, the installation generator (`rails g spree:install`) will run
-migrations as well as adding seed and sample data. This can be disabled using
+migrations as well as adding seed and sample data and will copy frontend views
+for easy customization (if spree_frontend available). This can be disabled using
 
 ```shell
-rails g spree:install --migrate=false --sample=false --seed=false
+rails g spree:install --migrate=false --sample=false --seed=false --copy_views=false
 ```
 
 You can always perform any of these steps later by using these commands.

--- a/core/lib/generators/spree/install/install_generator.rb
+++ b/core/lib/generators/spree/install/install_generator.rb
@@ -10,6 +10,7 @@ module Spree
     class_option :migrate, type: :boolean, default: true, banner: 'Run Spree migrations'
     class_option :seed, type: :boolean, default: true, banner: 'load seed data (migrations must be run)'
     class_option :sample, type: :boolean, default: true, banner: 'load sample data (migrations must be run)'
+    class_option :copy_views, type: :boolean, default: true, banner: 'copy frontend views from spree to your application for easy customization'
     class_option :auto_accept, type: :boolean
     class_option :user_class, type: :string
     class_option :admin_email, type: :string
@@ -29,6 +30,7 @@ module Spree
       @run_migrations = options[:migrate]
       @load_seed_data = options[:seed]
       @load_sample_data = options[:sample]
+      @copy_views = options[:copy_views]
 
       unless @run_migrations
          @load_seed_data = false
@@ -81,10 +83,8 @@ module Spree
     end
 
     def copy_views
-      if Spree::Core::Engine.frontend_available? && !options[:quiet]
-        if yes?('Do you want to copy views from spree to your application for easy customization? y/n')
-          generate 'spree:frontend:copy_views'
-        end
+      if @copy_views && Spree::Core::Engine.frontend_available?
+        generate 'spree:frontend:copy_views'
       end
     end
 

--- a/core/lib/spree/testing_support/common_rake.rb
+++ b/core/lib/spree/testing_support/common_rake.rb
@@ -13,7 +13,7 @@ namespace :common do
     ENV['RAILS_ENV'] = 'test'
 
     Spree::DummyGenerator.start ["--lib_name=#{ENV['LIB_NAME']}", "--quiet"]
-    Spree::InstallGenerator.start ["--lib_name=#{ENV['LIB_NAME']}", "--auto-accept", "--migrate=false", "--seed=false", "--sample=false", "--quiet", "--user_class=#{args[:user_class]}"]
+    Spree::InstallGenerator.start ["--lib_name=#{ENV['LIB_NAME']}", "--auto-accept", "--migrate=false", "--seed=false", "--sample=false", "--quiet", "--copy_views=false", "--user_class=#{args[:user_class]}"]
 
     puts "Setting up dummy database..."
     system("bundle exec rake db:drop db:create db:migrate > #{File::NULL}")

--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -50,5 +50,5 @@ RUBY
 bundle install --gemfile Gemfile
 bundle exec rails db:drop || true
 bundle exec rails db:create
-bundle exec rails g spree:install --auto-accept --user_class=Spree::User --enforce_available_locales=true
+bundle exec rails g spree:install --auto-accept --user_class=Spree::User --enforce_available_locales=true --copy_views=false
 bundle exec rails g spree:auth:install


### PR DESCRIPTION
Continuation of work began in from https://github.com/spree/spree/pull/8273

This way we can control this option in a better way, also in the sandbox app, we won’t have copied views.

Related to https://github.com/spree/spree/issues/8265