### PR TITLE
Override ActiveRecord belongs_to_required_by_default mattr_accessor

### DIFF
--- a/core/app/models/spree/base.rb
+++ b/core/app/models/spree/base.rb
@@ -18,7 +18,9 @@ class Spree::Base < ApplicationRecord
 
   self.abstract_class = true
 
-  self.belongs_to_required_by_default = false
+  mattr_accessor :belongs_to_required_by_default, instance_accessor: false do
+    false
+  end
 
   def self.spree_base_scopes
     where(nil)


### PR DESCRIPTION
This change stops spree from disabling the Rails 5 default belongs_to required validation on my non-spree "main app" models.

I'm not sure if there is a more idiomatic way of modifying the designed behavior of mattr_accessor so I did it this way. Another way I considered was just dropping in a method:

```ruby
def self.belongs_to_required_by_default
  false
end
```

I saw the guidelines require bug fix PR's to include tests which I did not write. Any suggestions on how to test this would be appreciated.