### PR TITLE
Fixes #8292 use Rails 5.1.4 to fix distinct issues with Postgres

### DIFF
--- a/api/app/controllers/spree/api/v1/products_controller.rb
+++ b/api/app/controllers/spree/api/v1/products_controller.rb
@@ -6,10 +6,10 @@ module Spree
           if params[:ids]
             @products = product_scope.where(id: params[:ids].split(',').flatten)
           else
-            @products = product_scope.ransack(params[:q]).result(distinct: true).select("#{Spree::Product.table_name}.id AS count_column, #{Spree::Product.table_name}.*")
+            @products = product_scope.ransack(params[:q]).result
           end
 
-          @products = @products.page(params[:page]).per(params[:per_page])
+          @products = @products.distinct.page(params[:page]).per(params[:per_page])
           expires_in 15.minutes, public: true
           headers['Surrogate-Control'] = "max-age=#{15.minutes}"
           respond_with(@products)

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'paranoia', '~> 2.3.0'
   s.add_dependency 'premailer-rails'
   s.add_dependency 'acts-as-taggable-on', '~> 5.0'
-  s.add_dependency 'rails', '~> 5.1.1'
+  s.add_dependency 'rails', '~> 5.1.4'
   s.add_dependency 'ransack', '~> 1.8.0'
   s.add_dependency 'responders'
   s.add_dependency 'state_machines-activerecord', '~> 0.5'


### PR DESCRIPTION
Rails 5.1.4 contains `Fix COUNT(DISTINCT ...) with ORDER BY and LIMIT
to keep the existing select list.` (https://github.com/rails/rails/blob/v5.1.4/activerecord/CHANGELOG.md#rails-514rc1-august-24-2017) so we don’t need this ugly hack anymore