### PR TITLE
set test environment for install generator in rake test_app

### DIFF
--- a/core/lib/spree/testing_support/common_rake.rb
+++ b/core/lib/spree/testing_support/common_rake.rb
@@ -11,6 +11,7 @@ namespace :common do
     require ENV['LIB_NAME'].to_s
 
     ENV['RAILS_ENV'] = 'test'
+    Rails.env = 'test'
 
     Spree::DummyGenerator.start ["--lib_name=#{ENV['LIB_NAME']}", '--quiet']
     Spree::InstallGenerator.start ["--lib_name=#{ENV['LIB_NAME']}", '--auto-accept', '--migrate=false', '--seed=false', '--sample=false', '--quiet', '--copy_views=false', "--user_class=#{args[:user_class]}"]


### PR DESCRIPTION
`ENV['RAILS_ENV'] = 'test'` doesn't set environment for generators so we need `Rails.env = 'test'` too