### PR TITLE
use absolute path instead of relative in main menu links

### DIFF
--- a/guides/layouts/_main_menu_home.html
+++ b/guides/layouts/_main_menu_home.html
@@ -1,9 +1,9 @@
 <nav id="main-menu" class="eleven columns">
   <ul class="inline">
-    <li><a href="api/">API</a></li>
-    <li><a href="developer/">Developer</a></li>
-    <li><a href="user/">User</a></li>
-    <li><a href="release_notes/">Release Notes</a></li>
+    <li><a href="/api/">API</a></li>
+    <li><a href="/developer/">Developer</a></li>
+    <li><a href="/user/">User</a></li>
+    <li><a href="/release_notes/">Release Notes</a></li>
     <li>
       <a href="http://slack.spreecommerce.org" target="_blank" rel="nofollow">Slack</a>
     </li>


### PR DESCRIPTION
fixes links in main menu because they're relative instead of absolute (when you're in `/api/` and you click `Developer` you'll be redirected to `/api/developer/` which is invalid