### PR TITLE
Fix ransackable_attributes

### DIFF
--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -23,8 +23,8 @@ module Spree
       belongs_to :ship_address, class_name: 'Spree::Address', optional: true
       belongs_to :bill_address, class_name: 'Spree::Address', optional: true
 
-      self.whitelisted_ransackable_associations = %w[bill_address ship_address]
-      self.whitelisted_ransackable_attributes = %w[id email]
+      self.whitelisted_ransackable_associations += %w[bill_address ship_address]
+      self.whitelisted_ransackable_attributes += %w[id email]
     end
 
     # has_spree_role? simply needs to return true or false whether a user has a role or not.


### PR DESCRIPTION
Extend ransackable_attributes instead of override existing attributes from custom User-model.