### PR TITLE
Remove coupon box from payment page

### DIFF
--- a/frontend/app/views/spree/checkout/_payment.html.erb
+++ b/frontend/app/views/spree/checkout/_payment.html.erb
@@ -58,13 +58,6 @@
       <% end %>
     </ul>
 
-
-    <% if Spree::Frontend::Config[:coupon_codes_enabled] %>
-      <p class='field' data-hook='coupon_code'>
-        <%= form.label :coupon_code %>
-        <%= form.text_field :coupon_code, class: 'form-control' %>
-      </p>
-    <% end %>
   </div>
 </div>
 


### PR DESCRIPTION
There is already a coupon box on the orders edit page. There is also a problem with the payments one because it has no button to confirm the code if you get the code wrong the order goes through without the coupon code being applied.