### PR TITLE
Prevent Spree::Base from overriding Rails 5 default belongs_to validation

### DIFF
--- a/core/app/models/spree/base.rb
+++ b/core/app/models/spree/base.rb
@@ -18,7 +18,7 @@ class Spree::Base < ApplicationRecord
 
   self.abstract_class = true
 
-  mattr_accessor :belongs_to_required_by_default, instance_accessor: false do
+  def self.belongs_to_required_by_default
     false
   end
 

--- a/core/lib/friendly_id/slug_rails5_patch.rb
+++ b/core/lib/friendly_id/slug_rails5_patch.rb
@@ -1,0 +1,11 @@
+# Temporary fix to FriendlyId in Rails5, so that we don't
+# encounter any validation errors when creating slugs via
+# FriendlyId::History on a paranoid model.
+# See: https://github.com/norman/friendly_id/issues/822
+if Rails::VERSION::STRING > '5.0'
+  module FriendlyId
+    class Slug < ActiveRecord::Base
+      belongs_to :sluggable, polymorphic: true, optional: true
+    end
+  end
+end

--- a/core/lib/spree_core.rb
+++ b/core/lib/spree_core.rb
@@ -1,1 +1,2 @@
+require 'friendly_id/slug_rails5_patch'
 require 'spree/core'

--- a/core/spec/models/spree/base_spec.rb
+++ b/core/spec/models/spree/base_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+module Test
+  class Parent < ActiveRecord::Base
+    self.table_name = 'test_parents'
+  end
+
+  class Child < ActiveRecord::Base
+    self.table_name = 'test_children'
+    belongs_to :parent, class_name: 'Test::Parent'
+  end
+end
+
+describe Spree::Base do
+  let(:connection) { ActiveRecord::Base.connection }
+  before(:each) do
+    connection.create_table :test_parents, force: true
+    connection.create_table :test_children, force: true do |t|
+      t.belongs_to :test_parent
+    end
+  end
+
+  after(:each) do
+    connection.drop_table 'test_parents', if_exists: true
+    connection.drop_table 'test_children', if_exists: true
+  end
+
+  it 'does not override Rails 5 default belongs_to_required_by_default' do
+    expect(Spree::Base.belongs_to_required_by_default).to eq(false)
+    expect(Spree::Product.belongs_to_required_by_default).to be(false)
+
+    expect(ApplicationRecord.belongs_to_required_by_default).to be(true)
+    expect(ActiveRecord::Base.belongs_to_required_by_default).to be(true)
+    expect(Test::Parent.belongs_to_required_by_default).to be(true)
+    expect(Test::Child.belongs_to_required_by_default).to be(true)
+  end
+
+  it 'does not disable non-spree, Rails 5 models to validate their associated belongs_to model' do
+    model_instance = Test::Child.new
+
+    expect(model_instance.save).to eq(false)
+    expect(model_instance.errors.messages).to include(:parent)
+    expect(model_instance.errors.messages[:parent]).to include('must exist')
+  end
+end


### PR DESCRIPTION
This is one way of fixing https://github.com/spree/spree/issues/8298.

Since Rails 5, belongs_to validates the presence of the associated
object, by default. The accompanying test ensures that non-spree models get the default behavior set by the Rails 5 main_app. In spree_core, we revert to the old belongs_to behaviour by setting a class method Spree::Base.belongs_to_required_by_default to always return `false`, instead of using `ActiveRecord::Base.mattr_accessor :belongs_to_required_by_default`, which can affect other ActiveRecord models outside of spree_core. Otherwise, it can be problematic when we try to add Rails-5-ready engines that rely on the new default (belongs_to_required_by_default set to true).

Unfortunately, since the class variable @@belongs_to_required_by_default has previously been set to false by Spree::Base before this commit, we've needed to also properly patch `FriendlyId::Slug.belongs_to :sluggable` to be `optional: true`, so that it conforms to new way of
setting optional belongs_to associations in Rails 5. Before this FriendlyId patch, some factories that use FriendlyId::History, with deleted_at (acts_as_paranoid) throws a validation error.

The FriendlyId part of this patch can be removed when the corresponding FriendlyId
issue has been resolved: norman/friendly_id#822
4806392

I will look into patching FriendlyId as well, but until then, I think this will suffice.