### PR TITLE
Relax dependency on deface from ~> 1.0.0 to 1.0

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'awesome_nested_set', '~> 3.0.1'
   s.add_dependency 'carmen', '~> 1.0.0'
   s.add_dependency 'cancancan', '~> 1.9.2'
-  s.add_dependency 'deface', '~> 1.0.0'
+  s.add_dependency 'deface', '~> 1.0'
   s.add_dependency 'ffaker', '~> 1.16'
   s.add_dependency 'font-awesome-rails', '~> 4.0'
   s.add_dependency 'friendly_id', '~> 5.0.4'


### PR DESCRIPTION
This change aims to allow us running Spree stores on the 2-4-stable branch, to upgrade to a more recent version of deface, in particular - deface version 1.2.0, that allows use of Nokogiri beyond version 1.6.0 (spree/deface#165).

The version of deface that Spree 2-4-stable seems to use, version 1.0.2 in https://github.com/DefaceCommunity/deface, has a travis.yml file that seems to be aimed at older version of Ruby, so not sure how feasible it would be to get these to work with a newer version of Nokogiri.

```
spree_core (~> 2.4.0) was resolved to 2.4.10, which depends on
  deface (~> 1.0.0) was resolved to 1.0.0, which depends on
    nokogiri (~> 1.6.0)
```
