### PR TITLE
Load FriendlyId::Slug patch for when Rails is exactly 5.0

### DIFF
--- a/core/lib/friendly_id/slug_rails5_patch.rb
+++ b/core/lib/friendly_id/slug_rails5_patch.rb
@@ -2,7 +2,7 @@
 # encounter any validation errors when creating slugs via
 # FriendlyId::History on a paranoid model.
 # See: https://github.com/norman/friendly_id/issues/822
-if Rails::VERSION::STRING > '5.0'
+if Rails::VERSION::STRING >= '5.0'
   module FriendlyId
     class Slug < ActiveRecord::Base
       belongs_to :sluggable, polymorphic: true, optional: true


### PR DESCRIPTION
This extends https://github.com/spree/spree/pull/8355 when Rails is exactly 5.0

Totally forgot about this one character since I was previously testing
for Rails 5.1.4. But I intended to patch 5.0 as well.

See Rails 5.0's CHANGELOG:
https://github.com/rails/rails/blob/5-0-stable/activerecord/CHANGELOG.md

