### PR TITLE
 Add `constantize` parameter to `Spree.user_class`

### DIFF
--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -21,11 +21,11 @@ StateMachines::Machine.ignore_method_conflicts = true
 module Spree
   mattr_accessor :user_class
 
-  def self.user_class
+  def self.user_class(constantize: true)
     if @@user_class.is_a?(Class)
       raise 'Spree.user_class MUST be a String or Symbol object, not a Class object.'
     elsif @@user_class.is_a?(String) || @@user_class.is_a?(Symbol)
-      @@user_class.to_s.constantize
+      constantize ? @@user_class.to_s.constantize : @@user_class.to_s
     end
   end
 

--- a/core/spec/lib/spree/core_spec.rb
+++ b/core/spec/lib/spree/core_spec.rb
@@ -20,4 +20,35 @@ describe Spree do
       Spree.admin_path = original_admin_path
     end
   end
+
+  describe '.user_class' do
+    context 'when user_class is a Class instance' do
+      it 'raises an error' do
+        Spree.user_class = Spree::LegacyUser
+
+        expect { Spree.user_class }.to raise_error(RuntimeError)
+      end
+    end
+
+    context 'when user_class is a Symbol instance' do
+      it 'returns the user_class constant' do
+        Spree.user_class = :'Spree::LegacyUser'
+
+        expect(Spree.user_class).to eq(Spree::LegacyUser)
+      end
+    end
+
+    context 'when user_class is a String instance' do
+      it 'returns the user_class constant' do
+        Spree.user_class = 'Spree::LegacyUser'
+
+        expect(Spree.user_class).to eq(Spree::LegacyUser)
+      end
+    end
+
+    after do
+      Spree.user_class = 'Spree::LegacyUser'
+    end
+  end
+
 end

--- a/core/spec/lib/spree/core_spec.rb
+++ b/core/spec/lib/spree/core_spec.rb
@@ -46,9 +46,16 @@ describe Spree do
       end
     end
 
+    context 'when constantize is false' do
+      it 'returns the user_class as a String' do
+        Spree.user_class = 'Spree::LegacyUser'
+
+        expect(Spree.user_class(constantize: false)).to eq('Spree::LegacyUser')
+      end
+    end
+
     after do
       Spree.user_class = 'Spree::LegacyUser'
     end
   end
-
 end


### PR DESCRIPTION
Pull request for issue #8367

In some places we have to call `#to_s` on the result of `Spree.user_class`. Now we can pass a paramater `constantize: false` in order to get the string representation of the current user class.
I've also added specs for the previous scenarios of this method.
