### PR TITLE
Remove old icon columns from taxon

### DIFF
--- a/core/db/migrate/20171004223836_remove_icon_from_taxons.rb
+++ b/core/db/migrate/20171004223836_remove_icon_from_taxons.rb
@@ -1,0 +1,8 @@
+class RemoveIconFromTaxons < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :spree_taxons, :icon_file_name
+    remove_column :spree_taxons, :icon_content_type
+    remove_column :spree_taxons, :icon_file_size
+    remove_column :spree_taxons, :icon_updated_at
+  end
+end


### PR DESCRIPTION
These columns are not being used anymore, icon is now a relation.

This resolves #8365. 