### PR TITLE
Rewrote Order#shipping_eq_billing_address? with specs added

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -55,11 +55,20 @@ module Spree
     end
 
     def same_as?(other)
-      return false if other.nil?
-      attributes.except(*EXCLUDED_KEYS_FOR_COMPARISION) == other.attributes.except(*EXCLUDED_KEYS_FOR_COMPARISION)
+      ActiveSupport::Deprecation.warn(<<-EOS, caller)
+        Address#same_as? is deprecated and will be removed in Spree 4.0. Please use Address#== instead"
+      EOS
+
+      self == other
     end
 
-    alias same_as same_as?
+    def same_as(other)
+      ActiveSupport::Deprecation.warn(<<-EOS, caller)
+        Address#same_as is deprecated and will be removed in Spree 4.0. Please use Address#== instead"
+      EOS
+
+      self == other
+    end
 
     def to_s
       "#{full_name}: #{address1}"
@@ -69,13 +78,14 @@ module Spree
       self.class.new(attributes.except('id', 'updated_at', 'created_at'))
     end
 
-    def ==(other_address)
-      self_attrs = attributes
-      other_attrs = other_address.respond_to?(:attributes) ? other_address.attributes : {}
+    def ==(other)
+      return false unless other && other.respond_to?(:value_attributes)
 
-      [self_attrs, other_attrs].each { |attrs| attrs.except!('id', 'created_at', 'updated_at') }
+      value_attributes == other.value_attributes
+    end
 
-      self_attrs == other_attrs
+    def value_attributes
+      attributes.except(*EXCLUDED_KEYS_FOR_COMPARISION)
     end
 
     def empty?

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -565,7 +565,10 @@ module Spree
     end
 
     def shipping_eq_billing_address?
-      (bill_address.empty? && ship_address.empty?) || bill_address.same_as?(ship_address)
+      return false if !bill_address || !ship_address
+      return true if bill_address.empty? && ship_address.empty?
+
+      bill_address.same_as?(ship_address)
     end
 
     def set_shipments_cost

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -565,11 +565,7 @@ module Spree
     end
 
     def shipping_eq_billing_address?
-      return true if bill_address == ship_address
-      return false if !bill_address || !ship_address
-      return true if bill_address.empty? && ship_address.empty?
-
-      bill_address.same_as?(ship_address)
+      bill_address == ship_address
     end
 
     def set_shipments_cost

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -565,6 +565,7 @@ module Spree
     end
 
     def shipping_eq_billing_address?
+      return true if bill_address == ship_address
       return false if !bill_address || !ship_address
       return true if bill_address.empty? && ship_address.empty?
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1122,4 +1122,28 @@ describe Spree::Order, type: :model do
       it { expect(order).to receive_message_chain(:shipments, :any?).and_return(false) }
     end
   end
+
+  describe '#shipping_eq_billing_address' do
+    let!(:order) { create(:order) }
+
+    context 'with only bill address' do
+      it { expect(order.shipping_eq_billing_address?).to eq(false) }
+    end
+
+    context 'blank addresses' do
+      before do
+        order.bill_address = Spree::Address.new
+        order.ship_address = Spree::Address.new
+      end
+      it { expect(order.shipping_eq_billing_address?).to eq(true) }
+    end
+
+    context 'no addresses' do
+      before do
+        order.bill_address = nil
+        order.ship_address = nil
+      end
+      it { expect(order.shipping_eq_billing_address?).to eq(true) }
+    end
+  end
 end

--- a/guides/content/release_notes/3_7_0.md
+++ b/guides/content/release_notes/3_7_0.md
@@ -66,6 +66,10 @@ of your own tips please submit a PR to help the next person!
 
   [Spark Solutions](https://github.com/spree/spree/pull/8782)
 
+* Deprecated `Address#same_as?` in favour of `Address#==`
+
+  [Spark Solutions](https://github.com/spree/spree/pull/8386)
+
 ## Full Changelog
 
 You can view the full changes using [Github Compare](https://github.com/spree/spree/compare/3-6-stable...3-7-stable).


### PR DESCRIPTION
This is really helpful if you’re building custom mobile/javascripts frontends that speak to the API

Also rewrote `Order#shipping_eq_billing_address?` with specs added (there weren't any before)