### PR TITLE
Added missing specs for Address#same_as method and Address#EXCLUDED_KEYS_FOR_COMPARISION

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -10,6 +10,10 @@ module Spree
       'TO', 'TV', 'UG', 'AE', 'VU', 'YE', 'ZW'
     ].freeze
 
+    # we're not freezing this on purpose so developers can extend and manage
+    # those attributes depending of the logic of their applications
+    EXCLUDED_KEYS_FOR_COMPARISION = %w(id updated_at created_at)
+
     belongs_to :country, class_name: 'Spree::Country'
     belongs_to :state, class_name: 'Spree::State', optional: true
 
@@ -62,7 +66,7 @@ module Spree
 
     def same_as?(other)
       return false if other.nil?
-      attributes.except('id', 'updated_at', 'created_at') == other.attributes.except('id', 'updated_at', 'created_at')
+      attributes.except(*EXCLUDED_KEYS_FOR_COMPARISION) == other.attributes.except(*EXCLUDED_KEYS_FOR_COMPARISION)
     end
 
     alias same_as same_as?

--- a/core/spec/models/spree/address_spec.rb
+++ b/core/spec/models/spree/address_spec.rb
@@ -393,4 +393,18 @@ describe Spree::Address, type: :model do
       end
     end
   end
+
+  context '#same_as' do
+    let(:address) { create(:address) }
+    let(:address2) { address.clone }
+
+    context 'same addresses' do
+      it { expect(address.same_as?(address2)).to eq(true) }
+    end
+
+    context 'different addresses' do
+      before { address2.first_name = 'Someone Else' }
+      it { expect(address.same_as?(address2)).to eq(false) }
+    end
+  end
 end

--- a/guides/content/release_notes/3_5_0.md
+++ b/guides/content/release_notes/3_5_0.md
@@ -47,3 +47,7 @@ of your own tips please submit a PR to help the next person!
 You can view the full changes using [Github Compare](https://github.com/spree/spree/compare/3-4-stable...master).
 
 ## Noteworthy Changes
+
+* Added `Address#EXCLUDED_KEYS_FOR_COMPARISION` o developers won't need to rewrite `Address#same_as`
+
+  [Spark Solutions](https://github.com/spree/spree/pull/8387)


### PR DESCRIPTION
Before everyone who added some custom column to the Address model you had to rewrite the `same_as` method. Now it’s just a matter of changing `EXCLUDED_KEYS_FOR_COMPARISION`