### PR TITLE
adds error message to clarify product not delete reason

### DIFF
--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -50,10 +50,10 @@ module Spree
           if @product.destroy
             flash[:success] = Spree.t('notice_messages.product_deleted')
           else
-            flash[:error] = Spree.t('notice_messages.product_not_deleted')
+            flash[:error] = Spree.t('notice_messages.product_not_deleted', error: @product.errors.full_messages.join(', '))
           end
         rescue ActiveRecord::RecordNotDestroyed => e
-          flash[:error] = Spree.t('notice_messages.product_not_deleted')
+          flash[:error] = Spree.t('notice_messages.product_not_deleted', error: e.message)
         end
 
         respond_with(@product) do |format|

--- a/backend/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/products_controller_spec.rb
@@ -83,7 +83,7 @@ describe Spree::Admin::ProductsController, type: :controller do
       describe 'response' do
         before { send_request }
         it { expect(response).to have_http_status(:ok) }
-        it { expect(flash[:error]).to eq(Spree.t('notice_messages.product_not_deleted')) }
+        it { expect(flash[:error]).to eq(Spree.t('notice_messages.product_not_deleted', error: product.errors.full_messages.join(', '))) }
       end
     end
   end


### PR DESCRIPTION
Issue #8141
This adds error message to clarify why a product cannot be deleted. 