### PR TITLE
lock version of rspec-rails since new version breaks specs

### DIFF
--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -28,7 +28,7 @@ group :test do
   gem 'rspec-activemodel-mocks', '~> 1.0'
   gem 'rspec-collection_matchers'
   gem 'rspec-its'
-  gem 'rspec-rails', '~> 3.6'
+  gem 'rspec-rails', '~> 3.6.1'
   gem 'rspec_junit_formatter'
   gem 'simplecov'
   gem 'webmock', '~> 3.0.1'


### PR DESCRIPTION
We'll lock version and see how rspec will handle this issue
rspec/rspec-rails#1882