### PR TITLE
Makes coupon code safer (if, e.g., coupon code is removed)

### DIFF
--- a/frontend/app/assets/javascripts/spree/frontend/cart.js.coffee
+++ b/frontend/app/assets/javascripts/spree/frontend/cart.js.coffee
@@ -12,7 +12,7 @@ Spree.ready ($) ->
     input =
       couponCodeField: $('#order_coupon_code')
       couponStatus: $('#coupon_status')
-    if input.couponCodeField.val().trim().length > 0
+    if $.trim(input.couponCodeField.val()).length > 0
       if new CouponManager(input).applyCoupon()
         @submit()
         return true

--- a/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js.coffee
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js.coffee
@@ -45,7 +45,7 @@ Spree.ready ($) ->
         input =
           couponCodeField: $('#order_coupon_code')
           couponStatus: $('#coupon_status')
-        if input.couponCodeField.val().trim().length > 0
+        if $.trim(input.couponCodeField.val()).length > 0
           if new CouponManager(input).applyCoupon()
             @submit()
             return true


### PR DESCRIPTION
We upgraded to Spree 3.3.1 at my company, which introduced a slight js bug - `Cannot read property 'trim' of undefined` - which was caused by the modification of the coupon code in `payment.js` and the fact that we had removed the coupon code field from the affected page.

This change prefers the style found in `coupon_manager.js`: https://github.com/spree/spree/blob/8b9d1467721a469b715e3f82e97b8a28039dee9b/frontend/app/assets/javascripts/spree/frontend/coupon_manager.js.coffee#L8

`jQuery.trim` returns empty string when given `undefined` or `null`.

Any advice on how to test this or additional requirements would be appreciated. Thanks, maintainers!