### PR TITLE
Display proper value for 'display_on' on shipping methods

### DIFF
--- a/backend/app/views/spree/admin/shipping_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/_form.html.erb
@@ -11,7 +11,7 @@
     <div data-hook="admin_shipping_method_form_display_field" class="col-xs-12 col-md-6">
       <%= f.field_container :display_on, class: ['form-group'] do %>
         <%= f.label :display_on, Spree.t(:display) %>
-        <%= select(:shipping_method, :display_on, Spree::ShippingMethod::DISPLAY.collect { |display| [Spree.t(display), display.to_s] }, {}, { class: 'select2' }) %>
+        <%= select(:shipping_method, :display_on, Spree::ShippingMethod::DISPLAY.collect { |display| [Spree.t(display), display.to_s] }, { include_blank: true }, { class: 'select2' }) %>
         <%= f.error_message_on :display_on %>
       <% end %>
     </div>

--- a/backend/app/views/spree/admin/shipping_methods/index.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/index.html.erb
@@ -23,7 +23,7 @@
           <td><%= shipping_method.admin_name + ' / ' if shipping_method.admin_name.present? %><%= shipping_method.name %></td>
           <td><%= shipping_method.zones.collect(&:name).join(", ") if shipping_method.zones %></td>
           <td><%= shipping_method.calculator.description %></td>
-          <td class="text-center"><%= shipping_method.display_on.blank? ? Spree.t(:both) : Spree.t(shipping_method.display_on) %></td>
+          <td class="text-center"><%= shipping_method.display_on.blank? ? Spree.t(:none) : Spree.t(shipping_method.display_on) %></td>
           <td data-hook="admin_shipping_methods_index_row_actions" class="actions actions-2 text-right">
             <%= link_to_edit(shipping_method, no_text: true) if can? :edit, shipping_method %>
             <%= link_to_delete(shipping_method, no_text: true) if can? :delete, shipping_method %>


### PR DESCRIPTION
Currently the admin panel shows `Both` for the `display_on` attribute of any shipping method that does not have one already set in the `index` view and `_form` partial. This can cause a confusion to the user thinking that the shipping method does actually have that value set but failing when trying to create shipments for orders that have that shipping method associated.

Here's an example with the view in the panel and the value fetched from the console

In admin panel:
![index](https://gmkr.io/s/59f562e3192a10d00e84707f/0)
----
![_form](https://gmkr.io/s/59f5630d2ea08e260f861ff0/0)

In console:
![](https://cl.ly/1y0f1h3U3I0h/[164749fda272803a4e245de573b9d99f]_Image%25202017-10-29%2520at%252012.04.12%2520AM.png)

And with the proposed changes it will look like:
![index_proposed](https://gmkr.io/s/59f56352071965f01527b320/0)
----
![_form_proposed](https://gmkr.io/s/59f563795e287dbf0e76dc51/0)