### PR TITLE
Fix Customer Search when creating new Order 

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
+++ b/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
@@ -31,7 +31,14 @@ $(document).ready(function() {
         cache: true,
         data: function(term, page) {
           return {
-            q: term,
+            q: {
+              'm': 'or',
+              'email_start': term,
+              'ship_address_firstname_start': term,
+              'ship_address_lastname_start': term,
+              'bill_address_firstname_start': term,
+              'bill_address_lastname_start': term
+            },
             token: Spree.api_key
           }
         },


### PR DESCRIPTION
There's some changes in the way the customers are searched since #7444. 
Everything works fine except the search box in admin panel returns all results.

The users controller (now managing the customer search) doesn't parse the search terms that comes from the select2 ( like the old search controller was able to do spree/backend/app/controllers/spree/admin/search_controller.rb ).
so I added these same customer query fields directly in the **ajax** call for customer search. 