### PR TITLE
add info if product is backordered on product page

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -203,6 +203,11 @@ module Spree
       variants_including_master.any?(&:can_supply?)
     end
 
+    # determine if any variant (including master) is out of stock and backorderable
+    def backordered?
+      variants_including_master.any?(&:backordered?)
+    end
+
     # split variants list into hash which shows mapping of opt value onto matching variants
     # eg categorise_variants_from_option(color) => {"red" -> [...], "blue" -> [...]}
     def categorise_variants_from_option(opt_type)

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -273,6 +273,10 @@ module Spree
       !!discontinue_on && discontinue_on <= Time.current
     end
 
+    def backordered?
+      total_on_hand <= 0 && stock_items.exists?(backorderable: true)
+    end
+
     private
 
     def ensure_no_line_items

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1024,6 +1024,8 @@ en:
     order_updated: Order Updated
     orders: Orders
     out_of_stock: Out of Stock
+    backordered_info: Selected item is backordered so expect delays
+    backordered_confirm_info: Selected item is backordered so expect delays. Are you sure you want to order it?
     overview: Overview
     package_from: package from
     pagination:

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -608,6 +608,24 @@ describe Spree::Product, type: :model do
     end
   end
 
+  context '#backordered?' do
+    let!(:product) { create(:product) }
+
+    it 'returns true when out of stock and backorderable' do
+      expect(product.backordered?).to eq(true)
+    end
+
+    it 'returns false when out of stock and not backorderable' do
+      product.stock_items.first.update(backorderable: false)
+      expect(product.backordered?).to eq(false)
+    end
+
+    it 'returns false when there is available item in stock' do
+      product.stock_items.first.update(count_on_hand: 10)
+      expect(product.backordered?).to eq(false)
+    end
+  end
+
   describe '#ensure_no_line_items' do
     let(:product) { create(:product) }
     let!(:line_item) { create(:line_item, variant: product.master) }

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -885,6 +885,24 @@ describe Spree::Variant, type: :model do
     end
   end
 
+  context '#backordered?' do
+    let!(:variant) { create(:variant) }
+
+    it 'returns true when out of stock and backorderable' do
+      expect(variant.backordered?).to eq(true)
+    end
+
+    it 'returns false when out of stock and not backorderable' do
+      variant.stock_items.first.update(backorderable: false)
+      expect(variant.backordered?).to eq(false)
+    end
+
+    it 'returns false when there is available item in stock' do
+      variant.stock_items.first.update(count_on_hand: 10)
+      expect(variant.backordered?).to eq(false)
+    end
+  end
+
   describe '#ensure_no_line_items' do
     let!(:line_item) { create(:line_item, variant: variant) }
 

--- a/frontend/app/views/spree/products/_cart_form.html.erb
+++ b/frontend/app/views/spree/products/_cart_form.html.erb
@@ -8,7 +8,8 @@
             <li>
               <%= radio_button_tag "variant_id", variant.id, index == 0,
                   'data-price' => variant.price_in(current_currency).money,
-                  'data-in-stock' => variant.can_supply?
+                  'data-in-stock' => variant.can_supply?,
+                  'data-backordered' => variant.backordered?
               %>
               <%= label_tag "variant_id_#{ variant.id }" do %>
                 <span class="variant-description">
@@ -45,6 +46,11 @@
           <% elsif @product.variants.empty? %>
             <br />
             <span class="out-of-stock"><%= Spree.t(:out_of_stock) %></span>
+          <% end %>
+          <% if @product.backordered? %>
+            <div class="alert alert-warning" id="cart-backordered-info">
+              <%= Spree.t(:backordered_info) %>
+            </div>
           <% end %>
         </div>
 


### PR DESCRIPTION
This needs a little bit copy and some feedback if it's ok to show confirm modal when product is backordered
fixes #7752