### PR TITLE
Arrange configurations options alphabetically #8313

### DIFF
--- a/backend/app/views/spree/admin/shared/sub_menu/_configuration.html.erb
+++ b/backend/app/views/spree/admin/shared/sub_menu/_configuration.html.erb
@@ -1,22 +1,20 @@
 <ul data-hook="admin_configurations_sidebar_menu" class="collapse nav nav-pills nav-stacked" id="sidebar-configuration">
-  <%= configurations_sidebar_menu_item(Spree.t(:general_settings), spree.edit_admin_general_settings_path) if can? :manage, Spree::Config %>
-  <%= configurations_sidebar_menu_item(Spree.t(:tax_categories), spree.admin_tax_categories_path) if can? :manage, Spree::TaxCategory %>
-  <%= configurations_sidebar_menu_item(Spree.t(:tax_rates), spree.admin_tax_rates_path) if can? :manage, Spree::TaxRate %>
-  <%= configurations_sidebar_menu_item(Spree.t(:zones), spree.admin_zones_path) if can? :manage, Spree::Zone %>
   <%= configurations_sidebar_menu_item(Spree.t(:countries), spree.admin_countries_path) if can? :manage, Spree::Country %>
-
-  <% if country = Spree::Country.find_by(id: Spree::Config[:default_country_id]) || Spree::Country.first %>
-    <%= configurations_sidebar_menu_item(Spree.t(:states), spree.admin_country_states_path(country)) if can? :manage, Spree::Country %>
-  <% end %>
-
+  <%= configurations_sidebar_menu_item(Spree.t(:general_settings), spree.edit_admin_general_settings_path) if can? :manage, Spree::Config %>
   <%= configurations_sidebar_menu_item(Spree.t(:payment_methods), spree.admin_payment_methods_path) if can? :manage, Spree::PaymentMethod %>
-  <%= configurations_sidebar_menu_item(Spree.t(:shipping_methods), spree.admin_shipping_methods_path) if can? :manage, Spree::ShippingMethod %>
-  <%= configurations_sidebar_menu_item(Spree.t(:shipping_categories), spree.admin_shipping_categories_path) if can? :manage, Spree::ShippingCategory %>
-  <%= configurations_sidebar_menu_item(Spree.t(:stock_transfers), spree.admin_stock_transfers_path) if can? :manage, Spree::StockTransfer %>
-  <%= configurations_sidebar_menu_item(Spree.t(:stock_locations), spree.admin_stock_locations_path) if can? :manage, Spree::StockLocation %>
-  <%= configurations_sidebar_menu_item(Spree.t(:store_credit_categories), spree.admin_store_credit_categories_path) if can? :manage, Spree::StoreCreditCategory %>
   <%= configurations_sidebar_menu_item(Spree.t(:refund_reasons), spree.admin_refund_reasons_path) if can? :manage, Spree::RefundReason %>
   <%= configurations_sidebar_menu_item(Spree.t(:reimbursement_types), spree.admin_reimbursement_types_path) if can? :manage, Spree::ReimbursementType %>
   <%= configurations_sidebar_menu_item(Spree.t(:return_authorization_reasons), spree.admin_return_authorization_reasons_path) if can? :manage, Spree::ReturnAuthorizationReason %>
   <%= configurations_sidebar_menu_item(Spree.t(:roles), spree.admin_roles_path) if can? :manage, Spree::Role %>
+  <%= configurations_sidebar_menu_item(Spree.t(:shipping_categories), spree.admin_shipping_categories_path) if can? :manage, Spree::ShippingCategory %>
+  <%= configurations_sidebar_menu_item(Spree.t(:shipping_methods), spree.admin_shipping_methods_path) if can? :manage, Spree::ShippingMethod %>
+  <% if country = Spree::Country.find_by(id: Spree::Config[:default_country_id]) || Spree::Country.first %>
+    <%= configurations_sidebar_menu_item(Spree.t(:states), spree.admin_country_states_path(country)) if can? :manage, Spree::Country %>
+  <% end %>
+  <%= configurations_sidebar_menu_item(Spree.t(:stock_locations), spree.admin_stock_locations_path) if can? :manage, Spree::StockLocation %>
+  <%= configurations_sidebar_menu_item(Spree.t(:stock_transfers), spree.admin_stock_transfers_path) if can? :manage, Spree::StockTransfer %>
+  <%= configurations_sidebar_menu_item(Spree.t(:store_credit_categories), spree.admin_store_credit_categories_path) if can? :manage, Spree::StoreCreditCategory %>
+  <%= configurations_sidebar_menu_item(Spree.t(:tax_categories), spree.admin_tax_categories_path) if can? :manage, Spree::TaxCategory %>
+  <%= configurations_sidebar_menu_item(Spree.t(:tax_rates), spree.admin_tax_rates_path) if can? :manage, Spree::TaxRate %>
+  <%= configurations_sidebar_menu_item(Spree.t(:zones), spree.admin_zones_path) if can? :manage, Spree::Zone %>
 </ul>

--- a/backend/spec/features/admin/configuration/store_credit_categories_spec.rb
+++ b/backend/spec/features/admin/configuration/store_credit_categories_spec.rb
@@ -39,6 +39,8 @@ describe 'Store Credit Categories', type: :feature, js: true do
   context 'admin editing a store credit category' do
     it 'should be able to update an existing store credit category' do
       create(:store_credit_category)
+      # Workaround for animation to finish expanding
+      sleep 1
       click_link 'Store Credit Categories'
       within_row(1) { click_icon :edit }
       fill_in 'store_credit_category_name', with: 'Return'

--- a/backend/spec/features/admin/configuration/tax_categories_spec.rb
+++ b/backend/spec/features/admin/configuration/tax_categories_spec.rb
@@ -45,6 +45,8 @@ describe 'Tax Categories', type: :feature do
   context 'admin editing a tax category' do
     it 'should be able to update an existing tax category', js: true do
       create(:tax_category)
+      # Workaround for animation to finish expanding
+      sleep 1
       click_link 'Tax Categories'
       within_row(1) { click_icon :edit }
       fill_in 'tax_category_description', with: 'desc 99'


### PR DESCRIPTION
Configurations section is quite cluttered and confusing. Atleast we should arrange them alphabetically.