### PR TITLE
Move applicable? logic to Promotion::Rule super class

### DIFF
--- a/core/app/models/spree/promotion/rules/first_order.rb
+++ b/core/app/models/spree/promotion/rules/first_order.rb
@@ -4,10 +4,6 @@ module Spree
       class FirstOrder < PromotionRule
         attr_reader :user, :email
 
-        def applicable?(promotable)
-          promotable.is_a?(Spree::Order)
-        end
-
         def eligible?(order, options = {})
           @user = order.try(:user) || options[:user]
           @email = order.email

--- a/core/app/models/spree/promotion/rules/item_total.rb
+++ b/core/app/models/spree/promotion/rules/item_total.rb
@@ -13,10 +13,6 @@ module Spree
         OPERATORS_MIN = ['gt', 'gte']
         OPERATORS_MAX = ['lt','lte']
 
-        def applicable?(promotable)
-          promotable.is_a?(Spree::Order)
-        end
-
         def eligible?(order, options = {})
           item_total = order.item_total
 

--- a/core/app/models/spree/promotion/rules/one_use_per_user.rb
+++ b/core/app/models/spree/promotion/rules/one_use_per_user.rb
@@ -2,10 +2,6 @@ module Spree
   class Promotion
     module Rules
       class OneUsePerUser < PromotionRule
-        def applicable?(promotable)
-          promotable.is_a?(Spree::Order)
-        end
-
         def eligible?(order, options = {})
           if order.user.present?
             if promotion.used_by?(order.user, [order])

--- a/core/app/models/spree/promotion/rules/product.rb
+++ b/core/app/models/spree/promotion/rules/product.rb
@@ -15,10 +15,6 @@ module Spree
           products
         end
 
-        def applicable?(promotable)
-          promotable.is_a?(Spree::Order)
-        end
-
         def eligible?(order, options = {})
           return true if eligible_products.empty?
 

--- a/core/app/models/spree/promotion/rules/taxon.rb
+++ b/core/app/models/spree/promotion/rules/taxon.rb
@@ -7,10 +7,6 @@ module Spree
         MATCH_POLICIES = %w(any all)
         preference :match_policy, default: MATCH_POLICIES.first
 
-        def applicable?(promotable)
-          promotable.is_a?(Spree::Order)
-        end
-
         def eligible?(order, options = {})
           if preferred_match_policy == 'all'
             unless (taxons.to_a - taxons_in_order_including_parents(order)).empty?

--- a/core/app/models/spree/promotion/rules/user.rb
+++ b/core/app/models/spree/promotion/rules/user.rb
@@ -9,10 +9,6 @@ module Spree
           foreign_key: 'promotion_rule_id',
           association_foreign_key: :user_id
 
-        def applicable?(promotable)
-          promotable.is_a?(Spree::Order)
-        end
-
         def eligible?(order, options = {})
           users.include?(order.user)
         end

--- a/core/app/models/spree/promotion/rules/user_logged_in.rb
+++ b/core/app/models/spree/promotion/rules/user_logged_in.rb
@@ -2,10 +2,6 @@ module Spree
   class Promotion
     module Rules
       class UserLoggedIn < PromotionRule
-        def applicable?(promotable)
-          promotable.is_a?(Spree::Order)
-        end
-
         def eligible?(order, options = {})
           unless order.user.present?
             eligibility_errors.add(:base, eligibility_error_message(:no_user_specified))

--- a/core/app/models/spree/promotion_rule.rb
+++ b/core/app/models/spree/promotion_rule.rb
@@ -13,7 +13,7 @@ module Spree
     end
 
     def applicable?(promotable)
-      raise 'applicable? should be implemented in a sub-class of Spree::PromotionRule'
+      promotable.is_a?(Spree::Order)
     end
 
     def eligible?(promotable, options = {})


### PR DESCRIPTION
So I don't have to define the same method every time I define a new Promotion Rule.