### PR TITLE
deprecate overriding 404 handling by rails

### DIFF
--- a/core/lib/spree/core/controller_helpers/common.rb
+++ b/core/lib/spree/core/controller_helpers/common.rb
@@ -41,6 +41,10 @@ module Spree
           end
 
           def render_404(_exception = nil)
+            ActiveSupport::Deprecation.warn(<<-EOS, caller)
+              #render_404 will be removed in Spree 3.6
+              You should switch to 404 handled by rails
+            EOS
             respond_to do |type|
               type.html { render status: :not_found, file: "#{::Rails.root}/public/404", formats: [:html], layout: nil }
               type.all  { head :not_found }

--- a/frontend/app/controllers/spree/content_controller.rb
+++ b/frontend/app/controllers/spree/content_controller.rb
@@ -1,10 +1,7 @@
 module Spree
   class ContentController < Spree::StoreController
     # Don't serve local files or static assets
-    before_action { render_404 if params[:path] =~ /(\.|\\)/ }
     after_action :fire_visited_path, except: :cvv
-
-    rescue_from ActionView::MissingTemplate, with: :render_404
 
     respond_to :html
 

--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -1,7 +1,6 @@
 module Spree
   class OrdersController < Spree::StoreController
     before_action :check_authorization
-    rescue_from ActiveRecord::RecordNotFound, with: :render_404
     helper 'spree/products', 'spree/orders'
 
     respond_to :html

--- a/frontend/app/controllers/spree/products_controller.rb
+++ b/frontend/app/controllers/spree/products_controller.rb
@@ -3,7 +3,6 @@ module Spree
     before_action :load_product, only: :show
     before_action :load_taxon, only: :index
 
-    rescue_from ActiveRecord::RecordNotFound, with: :render_404
     helper 'spree/taxons'
 
     respond_to :html

--- a/frontend/app/controllers/spree/taxons_controller.rb
+++ b/frontend/app/controllers/spree/taxons_controller.rb
@@ -1,6 +1,5 @@
 module Spree
   class TaxonsController < Spree::StoreController
-    rescue_from ActiveRecord::RecordNotFound, with: :render_404
     helper 'spree/products'
 
     respond_to :html

--- a/frontend/spec/controllers/spree/orders_controller_ability_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_ability_spec.rb
@@ -9,6 +9,7 @@ module Spree
     context 'when an order exists in the cookies.signed' do
       let(:token) { 'some_token' }
       let(:specified_order) { create(:order) }
+      let!(:variant) { create(:variant) }
 
       before do
         cookies.signed[:guest_token] = token
@@ -19,11 +20,11 @@ module Spree
       context '#populate' do
         it 'should check if user is authorized for :edit' do
           expect(controller).to receive(:authorize!).with(:edit, order, token)
-          spree_post :populate
+          spree_post :populate, variant_id: variant.id
         end
         it 'should check against the specified order' do
           expect(controller).to receive(:authorize!).with(:edit, specified_order, token)
-          spree_post :populate, id: specified_order.number
+          spree_post :populate, id: specified_order.number, variant_id: variant.id
         end
       end
 
@@ -85,9 +86,8 @@ module Spree
         end
 
         context 'when guest_token not present' do
-          it 'should respond with 404' do
-            spree_get :show, id: 'R123'
-            expect(response.code).to eq('404')
+          it 'should raise ActiveRecord::RecordNotFound' do
+            expect { spree_get :show, id: 'R123' }.to raise_error(ActiveRecord::RecordNotFound)
           end
         end
       end

--- a/frontend/spec/controllers/spree/orders_controller_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_spec.rb
@@ -15,7 +15,7 @@ describe Spree::OrdersController, type: :controller do
 
     context '#populate' do
       it 'should create a new order when none specified' do
-        spree_post :populate, {}, {}
+        spree_post :populate, variant_id: variant.id
         expect(cookies.signed[:guest_token]).not_to be_blank
         expect(Spree::Order.find_by(guest_token: cookies.signed[:guest_token])).to be_persisted
       end

--- a/frontend/spec/controllers/spree/products_controller_spec.rb
+++ b/frontend/spec/controllers/spree/products_controller_spec.rb
@@ -12,8 +12,7 @@ describe Spree::ProductsController, type: :controller do
   end
 
   it 'cannot view non-active products' do
-    spree_get :show, id: product.to_param
-    expect(response.status).to eq(404)
+    expect { spree_get :show, id: product.to_param }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
   it 'should provide the current user to the searcher class' do

--- a/guides/content/release_notes/3_5_0.md
+++ b/guides/content/release_notes/3_5_0.md
@@ -57,6 +57,10 @@ You can view the full changes using [Github Compare](https://github.com/spree/sp
 
   [Spark Solutions](https://github.com/spree/spree/pull/8445)
 
-* Deprecate `EnvironmentExtension`
+* Deprecated `EnvironmentExtension`
 
   [Spark Solutions](https://github.com/spree/spree/pull/8459)
+
+* Deprecated `render_404`
+
+  [Spark Solutions](https://github.com/spree/spree/pull/8465)


### PR DESCRIPTION
Rails is handling 404 pretty well, we don't need to override it