### PR TITLE
Remove Paperclip::Shoulda::Matchers

### DIFF
--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -44,8 +44,6 @@ require 'spree/testing_support/capybara_ext'
 
 require 'spree/core/controller_helpers/strong_parameters'
 
-require 'paperclip/matchers'
-
 require 'capybara-screenshot/rspec'
 Capybara.save_path = ENV['CIRCLE_ARTIFACTS'] if ENV['CIRCLE_ARTIFACTS']
 
@@ -118,8 +116,6 @@ RSpec.configure do |config|
   config.include Spree::TestingSupport::Flash
 
   config.include Spree::Core::ControllerHelpers::StrongParameters, type: :controller
-
-  config.include Paperclip::Shoulda::Matchers
 
   config.extend WithModel
 

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -44,8 +44,6 @@ require 'spree/testing_support/url_helpers'
 require 'spree/testing_support/order_walkthrough'
 require 'spree/testing_support/caching'
 
-require 'paperclip/matchers'
-
 require 'capybara-screenshot/rspec'
 Capybara.save_path = ENV['CIRCLE_ARTIFACTS'] if ENV['CIRCLE_ARTIFACTS']
 
@@ -117,8 +115,6 @@ RSpec.configure do |config|
   config.include Spree::TestingSupport::UrlHelpers
   config.include Spree::TestingSupport::ControllerRequests, type: :controller
   config.include Spree::TestingSupport::Flash
-
-  config.include Paperclip::Shoulda::Matchers
 
   config.order = :random
   Kernel.srand config.seed


### PR DESCRIPTION
We’re not using this at all so no need to require it in spec helpers