### PR TITLE
clone address instead of using same objects to stop overwriting them

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -268,8 +268,8 @@ module Spree
       self.user           = user
       self.email          = user.email if override_email
       self.created_by   ||= user
-      self.bill_address ||= user.bill_address
-      self.ship_address ||= user.ship_address
+      self.bill_address ||= user.bill_address.try(:clone)
+      self.ship_address ||= user.ship_address.try(:clone)
 
       changes = slice(:user_id, :email, :created_by_id, :bill_address_id, :ship_address_id)
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -618,11 +618,9 @@ describe Spree::Order, type: :model do
       expect(order.created_by).to eql(created_by)
       expect(order.created_by_id).to eql(created_by.id)
 
-      expect(order.bill_address).to eql(bill_address)
-      expect(order.bill_address_id).to eql(bill_address.id)
+      expect(order.bill_address.same_as?(bill_address)).to eql(true) if order.bill_address
 
-      expect(order.ship_address).to eql(ship_address)
-      expect(order.ship_address_id).to eql(ship_address.id)
+      expect(order.ship_address.same_as?(ship_address)).to eql(true) if order.ship_address
     end
 
     shared_examples_for '#associate_user!' do |persisted = false|


### PR DESCRIPTION
when user updates address with new order, old orders get address changed too. It's not expected to work like that