### PR TITLE
Backport (3-3) prioritize web over asset pipeline in premailer

### DIFF
--- a/core/config/initializers/premailer_rails.rb
+++ b/core/config/initializers/premailer_rails.rb
@@ -1,0 +1,3 @@
+if Gem.loaded_specs['premailer-rails'].version >= Gem::Version.create('1.10.0')
+  Premailer::Rails.config[:strategies] = [:filesystem, :network, :asset_pipeline]
+end


### PR DESCRIPTION
if asset pipeline tries to fetch asset from url on production, it raises
TypeError because of problem with sprockets

issue in premailer-rails: https://github.com/fphilipe/premailer-rails/pull/208