### PR TITLE
Create proper tags for tracking number after update

### DIFF
--- a/api/app/views/spree/api/v1/shipments/show.v1.rabl
+++ b/api/app/views/spree/api/v1/shipments/show.v1.rabl
@@ -13,7 +13,7 @@ child selected_shipping_rate: :selected_shipping_rate do
 end
 
 child shipping_methods: :shipping_methods do
-  attributes :id, :name
+  attributes :id, :name, :tracking_url
   child zones: :zones do
     attributes :id, :name, :description
   end

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -135,7 +135,7 @@ $(document).ready(function () {
       return '<a target="_blank" href="' + shipmentTrackingUrl + '">' + data.tracking + '<a>';
     }
 
-    return data.tracking
+    return data.tracking;
   }
 
   // handle tracking save

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -125,6 +125,19 @@ $(document).ready(function () {
   $('a.edit-tracking').click(toggleTrackingEdit);
   $('a.cancel-tracking').click(toggleTrackingEdit);
 
+  var createTrackingValueContent = function (data) {
+    var selected_shipping_method = data.shipping_methods.filter(function (method) {
+      return method.id === data.selected_shipping_rate.shipping_method_id;
+    })[0];
+
+    if (selected_shipping_method && selected_shipping_method.tracking_url) {
+      var shipmentTrackingUrl = selected_shipping_method.tracking_url.replace(/:tracking/, data.tracking);
+      return '<a target="_blank" href="' + shipmentTrackingUrl + '">' + data.tracking + '<a>';
+    }
+
+    return data.tracking
+  }
+
   // handle tracking save
   $('[data-hook=admin_shipment_form] a.save-tracking').on('click', function (event) {
     event.preventDefault();
@@ -148,7 +161,12 @@ $(document).ready(function () {
 
       var show = link.parents('tbody').find('tr.show-tracking');
       show.toggle();
-      show.find('.tracking-value').html($("<strong>").html(Spree.translations.tracking + ": ")).append(data.tracking);
+
+      if (data.tracking) {
+        show.find('.tracking-value').html($("<strong>").html(Spree.translations.tracking + ": ")).append(createTrackingValueContent(data));
+      } else {
+        show.find('.tracking-value').html(Spree.translations.no_tracking_present);
+      }
     });
   });
 });


### PR DESCRIPTION
Currently when updating the tracking number of a shipment, the tag that was previously an anchor becomes just text, so this changes that, creating either an anchor with the expected tracking url, or appending only the tracking number if the shipment's shipping method does not have a tracking url set.

#### Current behavior:
![current](https://cl.ly/25233M3z0G3H/Screen%20Recording%202017-11-27%20at%2009.02%20PM.gif)

#### New behavior:
![new](https://cl.ly/3F2M3V3o2l1A/Screen%20Recording%202017-11-27%20at%2009.05%20PM.gif)