### PR TITLE
Fix undefined error.

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -230,6 +230,9 @@ toggleItemEdit = function(){
 
 startItemSplit = function(event){
   event.preventDefault();
+  $('.cancel-split').each(function(){
+    $(this).click()
+  })
   var link = $(this);
   link.parent().find('a.edit-item').toggle();
   link.parent().find('a.split-item').toggle();


### PR DESCRIPTION
It is a fix for #8441 

In there error is about not moving the previous ``item_stock_location`` block. There were two or more same dom_id and it's not possible in the rules. I check all dislay dom_id with item_stock_location and if it exists, it will be closed.
<img width="1273" alt="screen shot 2017-12-10 at 13 16 30" src="https://user-images.githubusercontent.com/447588/33805355-8a8398a6-ddc8-11e7-87b4-5a867825bd08.png">
<img width="790" alt="screen shot 2017-12-10 at 13 22 08" src="https://user-images.githubusercontent.com/447588/33805356-8abd754e-ddc8-11e7-82a2-bcfcb597d6bf.png">

As you see the images. There is no select2 css in the second one. 

![spree_bug](https://user-images.githubusercontent.com/447588/33805364-b2632076-ddc8-11e7-9085-bf969c35a54e.gif)

From the gif you can see how when the second item_stock_location opens the first or any open one is closing.
