### PR TITLE
dont require activerecord base connected on saving preferences

### DIFF
--- a/core/app/models/spree/preferences/store.rb
+++ b/core/app/models/spree/preferences/store.rb
@@ -85,7 +85,7 @@ module Spree::Preferences
     end
 
     def should_persist?
-      @persistence && ActiveRecord::Base.connected? && Spree::Preference.table_exists?
+      @persistence && Spree::Preference.table_exists?
     end
   end
 


### PR DESCRIPTION
This somehow doesn't work outside of test environment. 