### PR TITLE
Sets HttpOnly flag to the guest_token cookie. 

### DIFF
--- a/core/lib/spree/core/controller_helpers/auth.rb
+++ b/core/lib/spree/core/controller_helpers/auth.rb
@@ -26,7 +26,7 @@ module Spree
 
         def set_guest_token
           if cookies.signed[:guest_token].blank?
-            cookies.permanent.signed[:guest_token] = generate_guest_token
+            cookies.permanent.signed[:guest_token] = { value: generate_guest_token, httponly: true }
           end
         end
 

--- a/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
@@ -51,6 +51,10 @@ describe Spree::Core::ControllerHelpers::Auth, type: :controller do
       get :index
       expect(response.cookies['guest_token']).not_to be_nil
     end
+    it 'sets httponly flag' do
+      get :index
+      expect(response['Set-Cookie']).to include('HttpOnly')
+    end
   end
 
   describe '#store_location' do


### PR DESCRIPTION
It instructs the browser that the cookie can only be accessed by the server for additional security