### PR TITLE
add "turbolinks:load" listener to Spree.ready for Turbolinks 5

### DIFF
--- a/core/app/assets/javascripts/spree.js.coffee
+++ b/core/app/assets/javascripts/spree.js.coffee
@@ -4,7 +4,7 @@ class window.Spree
     jQuery(document).ready(callback)
 
     # fire ready callbacks also on turbolinks page change event
-    jQuery(document).on 'page:load', ->
+    jQuery(document).on 'page:load turbolinks:load', ->
       callback(jQuery)
 
   @mountedAt: ->


### PR DESCRIPTION
Turbolinks 5 replaced page:load with turbolinks:load