### PR TITLE
Issue #8152 Spree header takes far too much room on mobile

### DIFF
--- a/frontend/app/assets/stylesheets/spree/frontend/frontend_bootstrap.css.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/frontend_bootstrap.css.scss
@@ -8,6 +8,7 @@
 #spree-header {
   background-color: $brand-primary;
   margin-bottom: $line-height-computed;
+  padding-top: 0.25em;
 
   #header {
     background: rgba($gray-darker, 0.4);
@@ -19,8 +20,14 @@
 
     img {
       max-width: 100%;
-      max-height: 50px;
+      max-height: 5.5vmax;
     }
+  }
+
+  .navbar-nav > li > a {
+    padding-top: 0;
+    padding-bottom: 10px;
+    line-height: $line-height-computed;
   }
 
   .nav a {


### PR DESCRIPTION
Add styling to app/assests/stylesheets/frontend/frontend_bootstrap to resize header
  @mimilettd