### PR TITLE
[#151944523] BUG: Global promotion is present in the adjustment tab even if order is not eligible for the created promotion

### DIFF
--- a/backend/app/controllers/spree/admin/adjustments_controller.rb
+++ b/backend/app/controllers/spree/admin/adjustments_controller.rb
@@ -12,7 +12,7 @@ module Spree
       before_action :find_adjustment, only: [:destroy, :edit, :update]
 
       def index
-        @adjustments = @order.all_adjustments.order(created_at: :asc)
+        @adjustments = @order.all_adjustments.eligible.order(created_at: :asc)
       end
 
       private

--- a/backend/spec/controllers/spree/admin/adjustments_controller_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/adjustments_controller_controller_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+module Spree
+  module Admin
+    describe AdjustmentsController, type: :controller do
+      stub_authorization!
+
+      describe '#index' do
+        let!(:order) { create(:order) }
+        let!(:adjustment_1) { create(:adjustment, order: order) }
+        let!(:adjustment_2) { create(:adjustment, order: order, eligible: false) }
+
+        subject do
+          spree_get :index, order_id: order.to_param
+        end
+
+        before { subject }
+
+        it 'returns 200 status' do
+          expect(response.status).to eq 200
+        end
+
+        it 'loads the order' do
+          expect(assigns(:order)).to eq order
+        end
+
+        it 'returns only eligible adjustments' do
+          expect(assigns(:adjustments)).to match_array([adjustment_1])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Description of the the bug that is being fixed:**

1. Create a global promotion with rules: More than 100 - less than 1000
2. Create order as a user that costs less than 100
3. Observe order review (there is no information about promotion added to your order)
4. Enter previously created order by admin
5. Open adjustment tab
6. Observe that there is adjustment added from the global promotion created in the first step

Please note that adjustment is not added to the total prize. It is only visible in adjustment but might cause problems when the user requests the invoice.