### PR TITLE
Backport (3-3) Upgrade to Paperclip 5.2.0

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'highline', '~> 1.6.18' # Necessary for the install generator
   s.add_dependency 'kaminari', '~> 1.0.1'
   s.add_dependency 'monetize', '~> 1.1'
-  s.add_dependency 'paperclip', '~> 5.1.0'
+  s.add_dependency 'paperclip', '~> 5.2.0'
   s.add_dependency 'paranoia', '~> 2.3.0'
   s.add_dependency 'premailer-rails'
   s.add_dependency 'acts-as-taggable-on', '~> 5.0'


### PR DESCRIPTION
This addresses CVE-2017-0889

Paperclip ruby gem version 3.1.4 and later suffers from 
a Server-SIde Request Forgery (SSRF) vulnerability in 
the Paperclip::UriAdapter class. Attackers may be able 
to access information about internal network resources.

https://nvd.nist.gov/vuln/detail/CVE-2017-0889