### PR TITLE
Fixes rails executable in generated extensions

### DIFF
--- a/cmd/lib/spree_cmd/extension.rb
+++ b/cmd/lib/spree_cmd/extension.rb
@@ -15,6 +15,7 @@ module SpreeCmd
       directory 'app', "#{file_name}/app"
       directory 'lib', "#{file_name}/lib"
       directory 'bin', "#{file_name}/bin"
+      chmod "#{file_name}/bin/rails", 0o755
 
       template 'extension.gemspec', "#{file_name}/#{file_name}.gemspec"
       template 'Gemfile', "#{file_name}/Gemfile"

--- a/cmd/lib/spree_cmd/templates/extension/bin/rails.tt
+++ b/cmd/lib/spree_cmd/templates/extension/bin/rails.tt
@@ -1,4 +1,5 @@
-# This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
+#!/usr/bin/env ruby
+# This command will automatically be run when you run "rails" from the root of your extension
 
 ENGINE_ROOT = File.expand_path('../..', __FILE__)
 ENGINE_PATH = File.expand_path('../../lib/<%= file_name -%>/engine', __FILE__)


### PR DESCRIPTION
I tried to use `rails` command in old generated extensions (and new) but it failed with this:

```ruby
rails_command:4: permission denied: bin/rails
```

after I made it executable I had this output:

```ruby
rails g migration AddNoteToVendors
bin/rails: line 3: syntax error near unexpected token `('
bin/rails: line 3: `ENGINE_ROOT = File.expand_path('../..', __FILE__)'
```

This fix adds env definition to generated rails bin and makes it executable