### PR TITLE
Splitted shipment has no taxes nor cost

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -217,10 +217,15 @@ module Spree
 
       if shipping_method
         selected_rate = shipping_rates.detect do |rate|
-          rate.shipping_method_id == original_shipping_method_id
+          if original_shipping_method_id
+            rate.shipping_method_id == original_shipping_method_id
+          else
+            rate.selected
+          end
         end
         save!
         self.selected_shipping_rate_id = selected_rate.id if selected_rate
+        reload
       end
 
       shipping_rates
@@ -340,6 +345,7 @@ module Spree
 
         order.contents.remove(variant, quantity, shipment: self)
         order.contents.add(variant, quantity, shipment: new_shipment)
+        order.create_tax_charge!
         order.update_with_updater!
 
         refresh_rates

--- a/core/spec/models/spree/order/payment_spec.rb
+++ b/core/spec/models/spree/order/payment_spec.rb
@@ -196,6 +196,11 @@ module Spree
 
       it 'should incorporate refunds' do
         order = create(:completed_order_with_totals)
+        calculator = order.shipments.first.shipping_method.calculator
+
+        calculator.set_preference(:amount, order.shipments.first.cost)
+        calculator.save!
+
         order.payments << create(:payment, state: :completed, order: order, amount: order.total)
 
         create(:refund, amount: 10, payment: order.payments.first)


### PR DESCRIPTION
Fixes #8571, check for complete issue/problem

Turned out the problem is in the `Shipment` model, it does not set a `ShippingRate` for the new shipment created in `#transfer_to_location` method, even when `Stock::Estimator` already calculated the proper one.

I also created some tests for `#transfer_to_shipment` since it did not have any

Here's a gif showing the new behavior:
![fixed](http://g.recordit.co/vOJPRFgRVQ.gif)

Although this fixes the problem, I'd like to create a context tests for `#transfer_to_location` when the shipping method has a tax rate available, but with my current knowledge of spree I don't know how to properly do them.