### PR TITLE
Add error messages to notifications in admin panel

### DIFF
--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -50,7 +50,7 @@ module Spree
           if @product.destroy
             flash[:success] = Spree.t('notice_messages.product_deleted')
           else
-            flash[:error] = Spree.t('notice_messages.product_not_deleted', error: @product.errors.full_messages.join(', '))
+            flash[:error] = Spree.t('notice_messages.product_not_deleted', error: @product.errors.full_messages.to_sentence)
           end
         rescue ActiveRecord::RecordNotDestroyed => e
           flash[:error] = Spree.t('notice_messages.product_not_deleted', error: e.message)
@@ -69,12 +69,12 @@ module Spree
           flash[:success] = Spree.t('notice_messages.product_cloned')
           redirect_to edit_admin_product_url(@new)
         else
-          flash[:error] = Spree.t('notice_messages.product_not_cloned')
+          flash[:error] = Spree.t('notice_messages.product_not_cloned', error: @new.errors.full_messages.to_sentence)
           redirect_to admin_products_url
         end
-      rescue ActiveRecord::RecordInvalid
+      rescue ActiveRecord::RecordInvalid => e
         # Handle error on uniqueness validation on product fields
-        flash[:error] = Spree.t('notice_messages.product_not_cloned')
+        flash[:error] = Spree.t('notice_messages.product_not_cloned', error: e.message)
         redirect_to admin_products_url
       end
 

--- a/backend/app/controllers/spree/admin/promotions_controller.rb
+++ b/backend/app/controllers/spree/admin/promotions_controller.rb
@@ -15,7 +15,7 @@ module Spree
           flash[:success] = Spree.t('promotion_cloned')
           redirect_to edit_admin_promotion_url(@new_promo)
         else
-          flash[:error] = "#{Spree.t('promotion_not_cloned')}: #{@new_promo.errors.full_messages.join(', ')}"
+          flash[:error] = Spree.t('promotion_not_cloned', error: @new_promo.errors.full_messages.to_sentence)
           redirect_to admin_promotions_url(@new_promo)
         end
       end

--- a/backend/app/controllers/spree/admin/variants_controller.rb
+++ b/backend/app/controllers/spree/admin/variants_controller.rb
@@ -12,7 +12,7 @@ module Spree
         if @variant.destroy
           flash[:success] = Spree.t('notice_messages.variant_deleted')
         else
-          flash[:error] = Spree.t('notice_messages.variant_not_deleted')
+          flash[:error] = Spree.t('notice_messages.variant_not_deleted', error: @variant.errors.full_messages.to_sentence)
         end
 
         respond_with(@variant) do |format|

--- a/backend/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/products_controller_spec.rb
@@ -61,9 +61,12 @@ describe Spree::Admin::ProductsController, type: :controller do
     end
 
     context 'will not successfully destroy product' do
+      let(:error_msg) { 'Failed to delete' }
+
       before do
         allow(Spree::Product).to receive(:friendly).and_return(products)
         allow(products).to receive(:find).with(product.id.to_s).and_return(product)
+        allow(product).to receive_message_chain(:errors, :full_messages).and_return([error_msg])
         allow(product).to receive(:destroy).and_return(false)
       end
 
@@ -85,7 +88,7 @@ describe Spree::Admin::ProductsController, type: :controller do
         it { expect(response).to have_http_status(:ok) }
 
         it 'set flash error' do
-          expected_error = Spree.t('notice_messages.product_not_deleted', error: assigns(:product).errors.full_messages.to_sentence)
+          expected_error = Spree.t('notice_messages.product_not_deleted', error: error_msg)
           expect(flash[:error]).to eq(expected_error)
         end
       end

--- a/backend/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/products_controller_spec.rb
@@ -83,7 +83,11 @@ describe Spree::Admin::ProductsController, type: :controller do
       describe 'response' do
         before { send_request }
         it { expect(response).to have_http_status(:ok) }
-        it { expect(flash[:error]).to eq(Spree.t('notice_messages.product_not_deleted', error: product.errors.full_messages.join(', '))) }
+
+        it 'set flash error' do
+          expected_error = Spree.t('notice_messages.product_not_deleted', error: assigns(:product).errors.full_messages.to_sentence)
+          expect(flash[:error]).to eq(expected_error)
+        end
       end
     end
   end
@@ -91,11 +95,9 @@ describe Spree::Admin::ProductsController, type: :controller do
   describe '#clone' do
     let(:product) { create(:custom_product, name: 'MyProduct', sku: 'MySku') }
     let(:product2) { create(:custom_product, name: 'COPY OF MyProduct', sku: 'COPY OF MySku') }
-    let(:variant) do
-      create(:master_variant, name: 'COPY OF MyProduct', sku: 'COPY OF MySku', created_at: product.created_at - 1.day)
-    end
+    let(:variant) { create(:master_variant, name: 'COPY OF MyProduct', sku: 'COPY OF MySku', created_at: product.created_at - 1.day) }
 
-    def send_request
+    subject(:send_request) do
       spree_post :clone, id: product, format: :js
     end
 
@@ -121,7 +123,11 @@ describe Spree::Admin::ProductsController, type: :controller do
         before { send_request }
         it { expect(response).to have_http_status(:found) }
         it { expect(response).to be_redirect }
-        it { expect(flash[:error]).to eq(Spree.t('notice_messages.product_not_cloned')) }
+
+        it 'set flash error' do
+          expected_error = Spree.t('notice_messages.product_not_cloned', error: 'Validation failed: Sku has already been taken')
+          expect(flash[:error]).to eq(expected_error)
+        end
       end
     end
   end

--- a/backend/spec/controllers/spree/admin/promotions_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/promotions_controller_spec.rb
@@ -72,6 +72,12 @@ describe Spree::Admin::PromotionsController, type: :controller do
       it 'doesnt create a copy of promotion' do
         expect { subject }.not_to(change { Spree::Promotion.count })
       end
+
+      it 'returns error' do
+        subject
+        expected_error = Spree.t('promotion_not_cloned', error: assigns(:new_promo).errors.full_messages.to_sentence)
+        expect(flash[:error]).to eq(expected_error)
+      end
     end
   end
 end

--- a/backend/spec/controllers/spree/admin/variants_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/variants_controller_spec.rb
@@ -20,10 +20,80 @@ module Spree
 
         context 'deleted is requested' do
           before { variant_2.destroy }
+
           it 'assigns only deleted variants for a requested product' do
             spree_get :index, product_id: product.slug, deleted: 'on'
             expect(assigns(:collection)).not_to include variant_1
             expect(assigns(:collection)).to include variant_2
+          end
+        end
+      end
+
+      describe '#destroy' do
+        let(:variant) { mock_model(Spree::Variant) }
+        let(:variants) { double(ActiveRecord::Relation) }
+        let(:product) { mock_model(Spree::Product) }
+        let(:products) { double(ActiveRecord::Relation) }
+
+        subject(:send_request) do
+          spree_delete :destroy, product_id: product, id: variant, format: :js
+        end
+
+        before do
+          allow(Spree::Product).to receive(:friendly).and_return(products)
+          allow(products).to receive(:find).with(product.id.to_s).and_return(product)
+          allow(product).to receive_message_chain(:variants, :find).with(variant.id.to_s).and_return(variants)
+
+          allow(Spree::Variant).to receive(:find).with(variant.id.to_s).and_return(variant)
+        end
+
+        describe 'expects to receive' do
+          after { send_request }
+          it { expect(Spree::Product).to receive(:friendly).and_return(products) }
+          it { expect(products).to receive(:find).with(product.id.to_s).and_return(product) }
+          it { expect(product).to receive_message_chain(:variants, :find).with(variant.id.to_s).and_return(variants) }
+          it { expect(Spree::Variant).to receive(:find).with(variant.id.to_s).and_return(variant) }
+        end
+
+        context 'will successfully destroy variant' do
+          before { allow(variant).to receive(:destroy).and_return(true) }
+
+          describe 'expects to receive' do
+            after { send_request }
+
+            it { expect(variant).to receive(:destroy).and_return(true) }
+          end
+
+          describe 'assigns' do
+            before { send_request }
+            it { expect(assigns(:variant)).to eq(variant) }
+          end
+
+          describe 'response' do
+            before { send_request }
+            it { expect(response).to have_http_status(:ok) }
+            it { expect(flash[:success]).to eq(Spree.t('notice_messages.variant_deleted')) }
+          end
+        end
+
+        context 'will not successfully destroy product' do
+          before { allow(variant).to receive(:destroy).and_return(false) }
+
+          describe 'expects to receive' do
+            after { send_request }
+
+            it { expect(variant).to receive(:destroy).and_return(false) }
+          end
+
+          describe 'assigns' do
+            before { send_request }
+            it { expect(assigns(:variant)).to eq(variant) }
+          end
+
+          describe 'response' do
+            before { send_request }
+            it { expect(response).to have_http_status(:ok) }
+            it { expect(flash[:error]).to eq(Spree.t('notice_messages.variant_not_deleted', error: variant.errors.full_messages.to_sentence)) }
           end
         end
       end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -936,10 +936,10 @@ en:
     notice_messages:
       product_cloned: Product has been cloned
       product_deleted: Product has been deleted
-      product_not_cloned: Product could not be cloned
-      product_not_deleted: Product could not be deleted
+      product_not_cloned: "Product could not be cloned. Reason: %{error}"
+      product_not_deleted: "Product could not be deleted. Reason: %{error}"
       variant_deleted: Variant has been deleted
-      variant_not_deleted: Variant could not be deleted
+      variant_not_deleted: "Variant could not be deleted. Reason: %{error}"
     num_orders: "# Orders"
     number: Number
     on_hand: On Hand
@@ -1072,7 +1072,7 @@ en:
     promotion: Promotion
     promotionable: Promotable
     promotion_cloned: Promotion has been cloned
-    promotion_not_cloned: Promotion has not been cloned
+    promotion_not_cloned: "Promotion has not been cloned. Reason: %{error}"
     promotion_action: Promotion Action
     promotion_action_types:
       create_adjustment:


### PR DESCRIPTION
Adds error reason to flash notifications when something is wrong in admin panel:
- product deletion
- product clone
- promotion clone
- variant deletion

Example:
![image](https://user-images.githubusercontent.com/9060346/35650319-b7803222-06ec-11e8-8830-c28db7670941.png)

Added specs