### PR TITLE
Stock splitters refactoring

### DIFF
--- a/core/app/models/spree/stock/splitter/backordered.rb
+++ b/core/app/models/spree/stock/splitter/backordered.rb
@@ -4,16 +4,14 @@ module Spree
       class Backordered < Spree::Stock::Splitter::Base
         def split(packages)
           split_packages = []
-          packages.each do |package|
-            unless package.on_hand.empty?
-              split_packages << build_package(package.on_hand)
-            end
 
-            unless package.backordered.empty?
-              split_packages << build_package(package.backordered)
-            end
+          packages.each do |package|
+            split_packages << build_package(package.on_hand) unless package.on_hand.empty?
+
+            split_packages << build_package(package.backordered) unless package.backordered.empty?
           end
-          return_next split_packages
+
+          return_next(split_packages)
         end
       end
     end

--- a/core/app/models/spree/stock/splitter/base.rb
+++ b/core/app/models/spree/stock/splitter/base.rb
@@ -8,6 +8,7 @@ module Spree
           @packer = packer
           @next_splitter = next_splitter
         end
+
         delegate :stock_location, to: :packer
 
         def split(packages)

--- a/core/app/models/spree/stock/splitter/shipping_category.rb
+++ b/core/app/models/spree/stock/splitter/shipping_category.rb
@@ -3,31 +3,24 @@ module Spree
     module Splitter
       class ShippingCategory < Spree::Stock::Splitter::Base
         def split(packages)
-          split_packages = []
-          packages.each do |package|
-            split_packages += split_by_category(package)
-          end
-          return_next split_packages
+          split_packages = packages.flat_map(&method(:split_by_category))
+          return_next(split_packages)
         end
 
         private
 
         def split_by_category(package)
-          categories = Hash.new { |hash, key| hash[key] = [] }
-          package.contents.each do |item|
-            categories[shipping_category_for(item)] << item
-          end
-          hash_to_packages(categories)
+          # group package items by shipping category
+          grouped_packages = package.contents.group_by(&method(:shipping_category_for))
+          hash_to_packages(grouped_packages)
         end
 
-        def hash_to_packages(categories)
-          packages = []
-          categories.each do |_id, contents|
-            packages << build_package(contents)
-          end
-          packages
+        def hash_to_packages(grouped_packages)
+          # select values from packages grouped by shipping categories and build new packages
+          grouped_packages.values.map(&method(:build_package))
         end
 
+        # optimization: save variant -> shipping_category correspondence
         def shipping_category_for(item)
           @item_shipping_category ||= {}
           @item_shipping_category[item.inventory_unit.variant_id] ||= item.variant.shipping_category_id

--- a/core/app/models/spree/stock/splitter/weight.rb
+++ b/core/app/models/spree/stock/splitter/weight.rb
@@ -8,7 +8,8 @@ module Spree
 
         def split(packages)
           generated_packages = packages.flat_map(&method(:reduce))
-          return_next(generated_packages)
+          packages.push(*generated_packages)
+          return_next(packages)
         end
 
         private
@@ -32,7 +33,7 @@ module Spree
             package_to_use.contents << contents.shift
           end
 
-          split_packages
+          split_packages.drop(1)
         end
 
         def choose_package(generated_packages, content_to_add)
@@ -45,8 +46,8 @@ module Spree
           generated_packages.each do |generated_package|
             generated_package_weight = generated_package.weight
 
-            weight_exceed = generated_package_weight + content_to_add.weight > threshold
-            space_left = available_space >= threshold - generated_package_weight
+            weight_exceed = (generated_package_weight + content_to_add.weight) > threshold
+            space_left = available_space >= (threshold - generated_package_weight)
 
             next if weight_exceed || space_left
 

--- a/core/app/models/spree/stock/splitter/weight.rb
+++ b/core/app/models/spree/stock/splitter/weight.rb
@@ -4,17 +4,11 @@ module Spree
       class Weight < Spree::Stock::Splitter::Base
         attr_reader :packer, :next_splitter
 
-        cattr_accessor :threshold do
-          150
-        end
+        cattr_accessor(:threshold) { 150 }
 
         def split(packages)
-          generated_packages = []
-          packages.each do |package|
-            generated_packages.push *reduce(package)
-          end
-          packages.push *generated_packages
-          return_next packages
+          generated_packages = packages.flat_map(&method(:reduce))
+          return_next(generated_packages)
         end
 
         private
@@ -25,20 +19,20 @@ module Spree
           # This also prevents an additional package if no fit is possible
           package.contents.clear
           package.contents << contents.shift
-          _split_packages = [package]
-          while contents.present?
+          split_packages = [package]
 
-            package_to_use = choose_package _split_packages, contents.first
+          while contents.present?
+            package_to_use = choose_package(split_packages, contents.first)
 
             if package_to_use.nil?
               package_to_use = build_package
-              _split_packages << package_to_use
+              split_packages << package_to_use
             end
 
             package_to_use.contents << contents.shift
           end
 
-          _split_packages.drop 1 # Drop the original package to ensure only generated packages are returned
+          split_packages
         end
 
         def choose_package(generated_packages, content_to_add)
@@ -50,11 +44,14 @@ module Spree
 
           generated_packages.each do |generated_package|
             generated_package_weight = generated_package.weight
-            if (generated_package_weight + content_to_add.weight <= threshold) &&
-                (available_space < threshold - generated_package_weight)
-              package_to_use = generated_package
-              available_space = threshold - generated_package_weight
-            end
+
+            weight_exceed = generated_package_weight + content_to_add.weight > threshold
+            space_left = available_space >= threshold - generated_package_weight
+
+            next if weight_exceed || space_left
+
+            package_to_use = generated_package
+            available_space = threshold - generated_package_weight
           end
 
           package_to_use
@@ -63,7 +60,7 @@ module Spree
         def split_package_contents_over_threshold(package)
           package.contents.flat_map do |content|
             if content.weight > threshold && content.splittable_by_weight?
-              split_content_item_over_threshold content
+              split_content_item_over_threshold(content)
             else
               content
             end

--- a/core/lib/spree/testing_support/factories/inventory_unit_factory.rb
+++ b/core/lib/spree/testing_support/factories/inventory_unit_factory.rb
@@ -6,5 +6,12 @@ FactoryBot.define do
     state 'on_hand'
     association(:shipment, factory: :shipment, state: 'pending')
     # return_authorization
+
+    # this trait usage increases build speed ~ 2x
+    trait :without_assoc do
+      shipment nil
+      order nil
+      line_item nil
+    end
   end
 end

--- a/core/spec/models/spree/stock/splitter/backordered_spec.rb
+++ b/core/spec/models/spree/stock/splitter/backordered_spec.rb
@@ -12,8 +12,8 @@ module Spree
         let(:package) { Package.new(packer.stock_location) }
 
         before do
-          4.times { package.add(build_stubbed(:inventory_unit, :without_assoc)) }
-          5.times { package.add(build_stubbed(:inventory_unit, :without_assoc), :backordered) }
+          package.add_multiple(build_stubbed_list(:inventory_unit, 4, :without_assoc))
+          package.add_multiple(build_stubbed_list(:inventory_unit, 5, :without_assoc), :backordered)
         end
 
         it 'splits packages by status' do

--- a/core/spec/models/spree/stock/splitter/backordered_spec.rb
+++ b/core/spec/models/spree/stock/splitter/backordered_spec.rb
@@ -11,14 +11,9 @@ module Spree
         let(:packer) { build(:stock_packer) }
         let(:package) { Package.new(packer.stock_location) }
 
-        # this inventory_unit method is working 2x faster than build_stubbed
-        def inventory_unit
-          InventoryUnit.new(variant: build_stubbed(:variant))
-        end
-
         before do
-          4.times { package.add(inventory_unit) }
-          5.times { package.add(inventory_unit, :backordered) }
+          4.times { package.add(build_stubbed(:inventory_unit, :without_assoc)) }
+          5.times { package.add(build_stubbed(:inventory_unit, :without_assoc), :backordered) }
         end
 
         it 'splits packages by status' do

--- a/core/spec/models/spree/stock/splitter/backordered_spec.rb
+++ b/core/spec/models/spree/stock/splitter/backordered_spec.rb
@@ -4,24 +4,33 @@ module Spree
   module Stock
     module Splitter
       describe Backordered, type: :model do
-        let(:variant) { build(:variant) }
+        subject(:result) do
+          described_class.new(packer).split([package])
+        end
 
         let(:packer) { build(:stock_packer) }
+        let(:package) { Package.new(packer.stock_location) }
 
-        subject { Backordered.new(packer) }
+        # this inventory_unit method is working 2x faster than build_stubbed
+        def inventory_unit
+          InventoryUnit.new(variant: build_stubbed(:variant))
+        end
+
+        before do
+          4.times { package.add(inventory_unit) }
+          5.times { package.add(inventory_unit, :backordered) }
+        end
 
         it 'splits packages by status' do
-          package = Package.new(packer.stock_location)
-          4.times { package.add build(:inventory_unit, variant: variant) }
-          5.times { package.add build(:inventory_unit, variant: variant), :backordered }
+          expect(result.count).to eq 2
 
-          packages = subject.split([package])
-          expect(packages.count).to eq 2
-          expect(packages.first.quantity).to eq 4
-          expect(packages.first.on_hand.count).to eq 4
-          expect(packages.first.backordered.count).to eq 0
+          expect(result[0].quantity).to eq 4
+          expect(result[0].on_hand.count).to eq 4
+          expect(result[0].backordered.count).to eq 0
 
-          expect(packages[1].contents.count).to eq 5
+          expect(result[1].quantity).to eq 5
+          expect(result[1].on_hand.count).to eq 0
+          expect(result[1].backordered.count).to eq 5
         end
       end
     end

--- a/core/spec/models/spree/stock/splitter/base_spec.rb
+++ b/core/spec/models/spree/stock/splitter/base_spec.rb
@@ -4,15 +4,17 @@ module Spree
   module Stock
     module Splitter
       describe Base, type: :model do
+        let(:splitter1) { described_class.new(packer) }
+        let(:splitter2) { described_class.new(packer, splitter1) }
+
         let(:packer) { build(:stock_packer) }
 
-        it 'continues to splitter chain' do
-          splitter1 = Base.new(packer)
-          splitter2 = Base.new(packer, splitter1)
-          packages = []
+        let(:packages) { [] }
 
-          expect(splitter1).to receive(:split).with(packages)
-          splitter2.split(packages)
+        describe 'continues to splitter chain' do
+          it { expect(splitter1).to receive(:split).with(packages) }
+
+          after { splitter2.split(packages) }
         end
       end
     end

--- a/core/spec/models/spree/stock/splitter/shipping_category_spec.rb
+++ b/core/spec/models/spree/stock/splitter/shipping_category_spec.rb
@@ -4,41 +4,46 @@ module Spree
   module Stock
     module Splitter
       describe ShippingCategory, type: :model do
-        let(:variant1) { create(:variant) }
-        let(:variant2) { create(:variant) }
-        let(:shipping_category_1) { create(:shipping_category, name: 'A') }
-        let(:shipping_category_2) { create(:shipping_category, name: 'B') }
-
-        def inventory_unit1
-          InventoryUnit.new(variant: variant1).tap do |inventory_unit|
-            inventory_unit.variant.product.shipping_category = shipping_category_1
-          end
-        end
-
-        def inventory_unit2
-          InventoryUnit.new(variant: variant2).tap do |inventory_unit|
-            inventory_unit.variant.product.shipping_category = shipping_category_2
-          end
+        subject(:result) do
+          described_class.new(packer).split(packages)
         end
 
         let(:packer) { build(:stock_packer) }
 
-        subject { ShippingCategory.new(packer) }
+        let(:packages) { [package1, package2] }
+        let(:package1) { Spree::Stock::Package.new(packer.stock_location) }
+        let(:package2) { Spree::Stock::Package.new(packer.stock_location) }
+
+        let(:variant1) { build_stubbed(:variant, product: product1) }
+        let(:product1) { build_stubbed(:product, shipping_category: shipping_category_1) }
+        let(:variant2) { build_stubbed(:variant, product: product2) }
+        let(:product2) { build_stubbed(:product, shipping_category: shipping_category_2) }
+
+        let(:shipping_category_1) { build_stubbed(:shipping_category, name: 'A') }
+        let(:shipping_category_2) { build_stubbed(:shipping_category, name: 'B') }
+
+        # these inventory_unit methods are working 2x faster than build_stubbed
+        def inventory_unit1
+          InventoryUnit.new(variant: variant1)
+        end
+
+        def inventory_unit2
+          InventoryUnit.new(variant: variant2)
+        end
+
+        before do
+          4.times { package1.add(inventory_unit1) }
+          8.times { package1.add(inventory_unit2) }
+
+          6.times { package2.add(inventory_unit1) }
+          9.times { package2.add(inventory_unit2, :backordered) }
+        end
 
         it 'splits each package by shipping category' do
-          package1 = Package.new(packer.stock_location)
-          4.times { package1.add inventory_unit1 }
-          8.times { package1.add inventory_unit2 }
-
-          package2 = Package.new(packer.stock_location)
-          6.times { package2.add inventory_unit1 }
-          9.times { package2.add inventory_unit2, :backordered }
-
-          packages = subject.split([package1, package2])
-          expect(packages[0].quantity).to eq 4
-          expect(packages[1].quantity).to eq 8
-          expect(packages[2].quantity).to eq 6
-          expect(packages[3].quantity).to eq 9
+          expect(result[0].quantity).to eq 4
+          expect(result[1].quantity).to eq 8
+          expect(result[2].quantity).to eq 6
+          expect(result[3].quantity).to eq 9
         end
       end
     end

--- a/core/spec/models/spree/stock/splitter/shipping_category_spec.rb
+++ b/core/spec/models/spree/stock/splitter/shipping_category_spec.rb
@@ -22,21 +22,12 @@ module Spree
         let(:shipping_category_1) { build_stubbed(:shipping_category, name: 'A') }
         let(:shipping_category_2) { build_stubbed(:shipping_category, name: 'B') }
 
-        # these inventory_unit methods are working 2x faster than build_stubbed
-        def inventory_unit1
-          InventoryUnit.new(variant: variant1)
-        end
-
-        def inventory_unit2
-          InventoryUnit.new(variant: variant2)
-        end
-
         before do
-          4.times { package1.add(inventory_unit1) }
-          8.times { package1.add(inventory_unit2) }
+          4.times { package1.add(build_stubbed(:inventory_unit, :without_assoc, variant: variant1)) }
+          8.times { package1.add(build_stubbed(:inventory_unit, :without_assoc, variant: variant2)) }
 
-          6.times { package2.add(inventory_unit1) }
-          9.times { package2.add(inventory_unit2, :backordered) }
+          6.times { package2.add(build_stubbed(:inventory_unit, :without_assoc, variant: variant1)) }
+          9.times { package2.add(build_stubbed(:inventory_unit, :without_assoc, variant: variant2), :backordered) }
         end
 
         it 'splits each package by shipping category' do

--- a/core/spec/models/spree/stock/splitter/shipping_category_spec.rb
+++ b/core/spec/models/spree/stock/splitter/shipping_category_spec.rb
@@ -23,11 +23,11 @@ module Spree
         let(:shipping_category_2) { build_stubbed(:shipping_category, name: 'B') }
 
         before do
-          4.times { package1.add(build_stubbed(:inventory_unit, :without_assoc, variant: variant1)) }
-          8.times { package1.add(build_stubbed(:inventory_unit, :without_assoc, variant: variant2)) }
+          package1.add_multiple(build_stubbed_list(:inventory_unit, 4, :without_assoc, variant: variant1))
+          package1.add_multiple(build_stubbed_list(:inventory_unit, 8, :without_assoc, variant: variant2))
 
-          6.times { package2.add(build_stubbed(:inventory_unit, :without_assoc, variant: variant1)) }
-          9.times { package2.add(build_stubbed(:inventory_unit, :without_assoc, variant: variant2), :backordered) }
+          package2.add_multiple(build_stubbed_list(:inventory_unit, 6, :without_assoc, variant: variant1))
+          package2.add_multiple(build_stubbed_list(:inventory_unit, 9, :without_assoc, variant: variant2), :backordered)
         end
 
         it 'splits each package by shipping category' do

--- a/core/spec/models/spree/stock/splitter/weight_spec.rb
+++ b/core/spec/models/spree/stock/splitter/weight_spec.rb
@@ -4,27 +4,62 @@ module Spree
   module Stock
     module Splitter
       describe Weight, type: :model do
-        let(:packer) { build(:stock_packer) }
-        let(:heavy_variant) { build(:base_variant, weight: 100) }
-        let(:variant) { build(:base_variant, weight: 49) }
-
-        subject { Weight.new(packer) }
-
-        it 'splits and keeps splitting until all packages are underweight' do
-          package = Package.new(packer.stock_location)
-          2.times { package.add build(:inventory_unit, variant: heavy_variant) }
-          4.times { package.add build(:inventory_unit, variant: variant) }
-          2.times { package.add build(:inventory_unit, variant: heavy_variant) }
-          packages = subject.split([package])
-          expect(packages.size).to eq 4
+        subject(:result) do
+          described_class.new(packer).split(packages)
         end
 
-        it 'handles packages that can not be reduced' do
-          package = Package.new(packer.stock_location)
-          allow(variant).to receive_messages(weight: 200)
-          2.times { package.add build(:inventory_unit, variant: variant) }
-          packages = subject.split([package])
-          expect(packages.size).to eq 2
+        let(:packer) { build(:stock_packer) }
+        let(:packages) { [package] }
+        let(:package) { Package.new(packer.stock_location) }
+
+        let(:heavy_variant) { build_stubbed(:base_variant, weight: 100) }
+        let(:variant) { build_stubbed(:base_variant, weight: 49) }
+
+        context 'with packages that can be reduced' do
+          before do
+            2.times { package.add(build_stubbed(:inventory_unit, :without_assoc, variant: heavy_variant)) }
+            4.times { package.add(build_stubbed(:inventory_unit, :without_assoc, variant: variant)) }
+            2.times { package.add(build_stubbed(:inventory_unit, :without_assoc, variant: heavy_variant)) }
+          end
+
+          it 'splits and keeps splitting until all packages are underweight' do
+            expect(result.size).to eq 4
+
+            result.each do |pack|
+              expect(pack.weight).to be <= described_class.threshold
+            end
+          end
+        end
+
+        context 'with packages that can not be reduced' do
+          let(:variant) { build_stubbed(:base_variant, weight: 200) }
+
+          before do
+            2.times { package.add(build_stubbed(:inventory_unit, :without_assoc, variant: variant)) }
+          end
+
+          it 'handles packages that can not be reduced' do
+            # formula: (2*200) / 150
+            expect(result.size).to eq 2
+          end
+        end
+
+        xcontext 'with multiple packages' do
+          let(:packages) { [package, package1] }
+          let(:package1) { Package.new(packer.stock_location) }
+
+          before do
+            2.times { package.add(build_stubbed(:inventory_unit, :without_assoc, variant: heavy_variant)) }
+            4.times { package.add(build_stubbed(:inventory_unit, :without_assoc, variant: variant)) }
+
+            2.times { package1.add(build_stubbed(:inventory_unit, :without_assoc, variant: variant)) }
+            4.times { package1.add(build_stubbed(:inventory_unit, :without_assoc, variant: heavy_variant)) }
+          end
+
+          it 'splits and keeps splitting until all packages are underweight' do
+            # formula: (2*100 + 4*49 + 2*49 + 4*100) / 150
+            expect(result.size).to eq 6
+          end
         end
       end
     end


### PR DESCRIPTION
I did small refactoring of stock splitter

One thing I didn't understand in code: 
https://github.com/spree/spree/compare/master...public-market:stock-splitters-refactor?expand=1#diff-ed14b03a07655a02917dc2e8f4c90080L16

Why original packages are merged with generated ones, but original removed from generated before

I guess it was implemented like this intentionally, maybe I miss something here.