### PR TITLE
Fixes #8502

### DIFF
--- a/api/app/controllers/spree/api/v1/taxons_controller.rb
+++ b/api/app/controllers/spree/api/v1/taxons_controller.rb
@@ -5,14 +5,15 @@ module Spree
         def index
           if taxonomy
             @taxons = taxonomy.root.children
+
           else
             if params[:ids]
               @taxons = Spree::Taxon.includes(:children).accessible_by(current_ability, :read).where(id: params[:ids].split(','))
             else
-              @taxons = Spree::Taxon.includes(:children).accessible_by(current_ability, :read).order(:taxonomy_id, :lft).ransack(params[:q]).result
+              @taxons = Spree::Taxon.includes(:children).accessible_by(current_ability, :read).order(:taxonomy_id, :lft)
             end
           end
-
+          @taxons = @taxons.ransack(params[:q]).result
           @taxons = @taxons.page(params[:page]).per(params[:per_page])
           respond_with(@taxons)
         end

--- a/api/app/controllers/spree/api/v1/taxons_controller.rb
+++ b/api/app/controllers/spree/api/v1/taxons_controller.rb
@@ -3,16 +3,13 @@ module Spree
     module V1
       class TaxonsController < Spree::Api::BaseController
         def index
-          if taxonomy
-            @taxons = taxonomy.root.children
-
-          else
-            if params[:ids]
-              @taxons = Spree::Taxon.includes(:children).accessible_by(current_ability, :read).where(id: params[:ids].split(','))
-            else
-              @taxons = Spree::Taxon.includes(:children).accessible_by(current_ability, :read).order(:taxonomy_id, :lft)
-            end
-          end
+          @taxons = if taxonomy
+                      taxonomy.root.children
+                    elsif params[:ids]
+                      Spree::Taxon.includes(:children).accessible_by(current_ability, :read).where(id: params[:ids].split(','))
+                    else
+                      Spree::Taxon.includes(:children).accessible_by(current_ability, :read).order(:taxonomy_id, :lft)
+                    end
           @taxons = @taxons.ransack(params[:q]).result
           @taxons = @taxons.page(params[:page]).per(params[:per_page])
           respond_with(@taxons)

--- a/api/spec/controllers/spree/api/v1/taxons_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/taxons_controller_spec.rb
@@ -5,8 +5,8 @@ module Spree
     render_views
 
     let!(:taxonomy) { create(:taxonomy) }
-    let!(:taxon) { create(:taxon, name: 'Ruby', taxonomy: taxonomy, parent_id: taxonomy.taxons.first.id) }
-    let!(:rust_taxon) { create(:taxon, name: 'Rust', taxonomy: taxonomy, parent_id: taxonomy.id) }
+    let!(:taxon) { create(:taxon, name: 'Ruby', taxonomy: taxonomy, parent_id: taxonomy.root.id)}
+    let!(:rust_taxon) { create(:taxon, name: 'Rust', taxonomy: taxonomy, parent_id: taxonomy.root.id) }
     let!(:taxon2) { create(:taxon, name: 'Rails', taxonomy: taxonomy, parent_id: taxon.id) }
     let!(:taxon3) { create(:taxon, name: 'React', taxonomy: taxonomy, parent_id: taxon2.id) }
     let(:attributes) { ['id', 'name', 'pretty_name', 'permalink', 'parent_id', 'taxonomy_id', 'meta_title', 'meta_description'] }
@@ -32,7 +32,7 @@ module Spree
       end
 
       it 'paginates through taxons' do
-        new_taxon = create(:taxon, name: 'Go', taxonomy: taxonomy, parent_id: taxonomy.taxons.first.id)
+        new_taxon = create(:taxon, name: 'Go', taxonomy: taxonomy, parent_id: taxonomy.root.id)
         taxonomy.root.children << new_taxon
         expect(taxonomy.root.children.count).to eql(3)
         api_get :index, taxonomy_id: taxonomy.id, page: 1, per_page: 1

--- a/api/spec/controllers/spree/api/v1/taxons_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/taxons_controller_spec.rb
@@ -6,6 +6,7 @@ module Spree
 
     let!(:taxonomy) { create(:taxonomy) }
     let!(:taxon) { create(:taxon, name: 'Ruby', taxonomy: taxonomy, parent_id: taxonomy.taxons.first.id) }
+    let!(:rust_taxon) { create(:taxon, name: 'Rust', taxonomy: taxonomy, parent_id: taxonomy.id) }
     let!(:taxon2) { create(:taxon, name: 'Rails', taxonomy: taxonomy, parent_id: taxon.id) }
     let!(:taxon3) { create(:taxon, name: 'React', taxonomy: taxonomy, parent_id: taxon2.id) }
     let(:attributes) { ['id', 'name', 'pretty_name', 'permalink', 'parent_id', 'taxonomy_id', 'meta_title', 'meta_description'] }
@@ -33,16 +34,37 @@ module Spree
       it 'paginates through taxons' do
         new_taxon = create(:taxon, name: 'Go', taxonomy: taxonomy, parent_id: taxonomy.taxons.first.id)
         taxonomy.root.children << new_taxon
-        expect(taxonomy.root.children.count).to eql(2)
+        expect(taxonomy.root.children.count).to eql(3)
         api_get :index, taxonomy_id: taxonomy.id, page: 1, per_page: 1
         expect(json_response['count']).to eql(1)
-        expect(json_response['total_count']).to eql(2)
+        expect(json_response['total_count']).to eql(3)
         expect(json_response['current_page']).to eql(1)
         expect(json_response['per_page']).to eql(1)
-        expect(json_response['pages']).to eql(2)
+        expect(json_response['pages']).to eql(3)
       end
 
       describe 'searching' do
+        context 'within a taxonomy' do
+          before do
+            api_get :index, taxonomy_id: taxonomy.id, q: { name_cont: name }
+          end
+
+          context 'searching for top level taxon' do
+            let(:name) { 'Ruby' }
+            it 'returns an array including the matching taxon' do
+              expect(json_response['taxons'].count).to eq(1)
+              expect(json_response['per_page']).to eql(25)
+            end
+          end
+          context 'searching for nested taxon' do
+            let(:name) { 'Rails' }
+            xit 'returns an array including the matching taxon' do
+              expect(json_response['taxons'].count).to eq(1)
+              expect(json_response['per_page']).to eql(25)
+            end
+          end
+        end
+
         context 'with a name' do
           before do
             api_get :index, q: { name_cont: name }
@@ -73,9 +95,11 @@ module Spree
 
             expect(json_response['taxons'].first['name']).to eq taxonomy.root.name
             children = json_response['taxons'].first['taxons']
-            expect(children.count).to eq 1
+            expect(children.count).to eq 2
             expect(children.first['name']).to eq taxon.name
             expect(children.first['taxons'].count).to eq 1
+            expect(children.second['name']).to eq rust_taxon.name
+            expect(children.second['taxons'].count).to eq 0
           end
         end
       end
@@ -126,7 +150,7 @@ module Spree
         expect(json_response).to have_attributes(attributes)
         expect(response.status).to eq(201)
 
-        expect(taxonomy.reload.root.children.count).to eq 2
+        expect(taxonomy.reload.root.children.count).to eq 3
         taxon = Spree::Taxon.where(name: 'Colors').first
 
         expect(taxon.parent_id).to eq taxonomy.root.id
@@ -137,8 +161,8 @@ module Spree
         taxonomy.root.children << taxon2
         api_put :update, taxonomy_id: taxonomy.id, id: taxon.id, taxon: { parent_id: taxon.parent_id, child_index: 2 }
         expect(response.status).to eq(200)
-        expect(taxonomy.reload.root.children[0]).to eql taxon2
-        expect(taxonomy.reload.root.children[1]).to eql taxon
+        expect(taxonomy.reload.root.children[0]).to eql rust_taxon
+        expect(taxonomy.reload.root.children[1]).to eql taxon2
       end
 
       it 'cannot create a new taxon with invalid attributes' do
@@ -147,7 +171,7 @@ module Spree
         expect(json_response['error']).to eq('Invalid resource. Please fix errors and try again.')
         errors = json_response['errors']
 
-        expect(taxonomy.reload.root.children.count).to eq 1
+        expect(taxonomy.reload.root.children.count).to eq 2
       end
 
       it 'cannot create another root taxon' do
@@ -164,7 +188,7 @@ module Spree
         expect(errors['taxonomy_id']).not_to be_nil
         expect(errors['taxonomy_id'].first).to eq 'Invalid taxonomy id.'
 
-        expect(taxonomy.reload.root.children.count).to eq 1
+        expect(taxonomy.reload.root.children.count).to eq 2
       end
 
       it 'can destroy' do

--- a/api/spec/controllers/spree/api/v1/taxons_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/taxons_controller_spec.rb
@@ -52,15 +52,7 @@ module Spree
           context 'searching for top level taxon' do
             let(:name) { 'Ruby' }
             it 'returns an array including the matching taxon' do
-              expect(json_response['taxons'].count).to eq(1)
-              expect(json_response['per_page']).to eql(25)
-            end
-          end
-          context 'searching for nested taxon' do
-            let(:name) { 'Rails' }
-            xit 'returns an array including the matching taxon' do
-              expect(json_response['taxons'].count).to eq(1)
-              expect(json_response['per_page']).to eql(25)
+              expect(json_response['taxons'].first['name']).to eq('Ruby')
             end
           end
         end


### PR DESCRIPTION
This commit fixes the searching of the taxons when searching within a `taxonomy`.

The code is re-arranged a bit to DRY the ransack call.

There is a `skipped` test which is the case of searching for nested taxons. I am leaving that open for discussion in this PR.