### PR TITLE
Indicate how to generate a new admin account.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Browse Admin Interface
 
 http://localhost:3000/admin
 
-You can generate a new admin account by running `rake spree_auth:admin:create`.
+If you have `spree_auth_devise` installed, you can generate a new admin user by running `rake spree_auth:admin:create`.
 
 Extensions
 ----------------------

--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ Browse Admin Interface
 
 http://localhost:3000/admin
 
+You can generate a new admin account by running `rake spree_auth:admin:create`.
+
 Extensions
 ----------------------
 


### PR DESCRIPTION
The "Getting started" guide indicates there's already an admin account generated, which does not seem to be the case (this is a good thing because of security).

We should indicate how to generate a new admin account.