### PR TITLE
Change seed data

### DIFF
--- a/sample/db/samples/taxons.rb
+++ b/sample/db/samples/taxons.rb
@@ -139,9 +139,10 @@ taxons = [
 taxons.each do |taxon_attrs|
   parent = Spree::Taxon.where(name: taxon_attrs[:parent]).first
   taxonomy = taxon_attrs[:taxonomy]
-  Spree::Taxon.where(name: taxon_attrs[:name]).first_or_create! do |taxon|
-    taxon.parent = parent
-    taxon.taxonomy = taxonomy
-    taxon.products = taxon_attrs[:products] if taxon_attrs[:products]
-  end
+
+  taxon = Spree::Taxon.where(name: taxon_attrs[:name]).first_or_create!
+  taxon.parent = parent
+  taxon.taxonomy = taxonomy
+  taxon.save
+  taxon.products = taxon_attrs[:products] if taxon_attrs[:products]
 end


### PR DESCRIPTION
This PR makes it possible to change seed data (in regards to products belonging to taxons) and have it updated in the database, without the need to do a full teardown-and-clean-seed.

Rationale: `first_or_create!` does not pass `attributes` and does not execute block when a record has been found, both are applied only when the create part gets ran.

It's branched out of the `3-4-stable` version, because the CircleCI tests fail on master.
Apparently CodeClimate has issues with `3-4-stable` though but the change introduced with this PR does not interfere with the files rejected by CodeClimate.