### PR TITLE
Use system font in Spree Admin.

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/global/_variables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/global/_variables.scss
@@ -19,7 +19,7 @@
 /*------------------------------------------
   Fonts
   -----------------------------------------*/
-  $headings-font-family: "Segoe UI", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  $headings-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   $headings-font-weight: 300;
 
 /*------------------------------------------


### PR DESCRIPTION
Spree Admin currently uses the "Segoe UI" as its main font for headings, which is only available on Windows (Vista and up).

A better approach would be to use the system fonts for every device, to make Spree Admin look more native.

More info: https://css-tricks.com/snippets/css/system-font-stack/