### PR TITLE
handle alerts in way respected by chromedriver

### DIFF
--- a/backend/spec/features/admin/configuration/countries_spec.rb
+++ b/backend/spec/features/admin/configuration/countries_spec.rb
@@ -12,11 +12,10 @@ module Spree
       fill_in 'Iso Name', with: 'BRL'
       click_button 'Create'
 
-      accept_alert do
+      spree_accept_alert do
         click_icon :delete
+        wait_for_ajax
       end
-
-      wait_for_ajax
 
       expect { Country.find(country.id) }.to raise_error(StandardError)
     end

--- a/backend/spec/features/admin/configuration/stock_locations_spec.rb
+++ b/backend/spec/features/admin/configuration/stock_locations_spec.rb
@@ -23,11 +23,11 @@ describe 'Stock Locations', type: :feature do
     visit current_path
 
     expect(find('#listing_stock_locations')).to have_content('NY Warehouse')
-    accept_alert do
+    spree_accept_alert do
       click_icon :delete
+      # Wait for API request to complete.
+      wait_for_ajax
     end
-    # Wait for API request to complete.
-    wait_for_ajax
     visit current_path
     expect(page).to have_content('No Stock Locations found')
   end

--- a/backend/spec/features/admin/orders/adjustments_spec.rb
+++ b/backend/spec/features/admin/orders/adjustments_spec.rb
@@ -110,13 +110,13 @@ describe 'Adjustments', type: :feature do
 
   context 'deleting an adjustment' do
     it 'should update the total', js: true do
-      accept_alert do
+      spree_accept_alert do
         within_row(2) do
           click_icon(:delete)
+          wait_for_ajax
         end
       end
 
-      wait_for_ajax
       expect(page).to have_content(/Total: ?\$170\.00/)
     end
   end

--- a/backend/spec/features/admin/orders/line_items_spec.rb
+++ b/backend/spec/features/admin/orders/line_items_spec.rb
@@ -40,8 +40,9 @@ describe 'Order Line Items', type: :feature, js: true do
 
     within('.line-items') do
       within_row(1) do
-        accept_alert do
+        spree_accept_alert do
           find('.delete-line-item').click
+          wait_for_ajax
         end
       end
     end

--- a/backend/spec/features/admin/orders/new_order_spec.rb
+++ b/backend/spec/features/admin/orders/new_order_spec.rb
@@ -87,7 +87,7 @@ describe 'New Order', type: :feature do
 
     context 'on increase in quantity the product should be removed from order', js: true do
       before do
-        accept_alert do
+        spree_accept_alert do
           within('table.stock-levels') do
             fill_in 'variant_quantity', with: 2
             click_icon :add

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -54,8 +54,9 @@ describe 'Order Details', type: :feature, js: true do
         expect(page).to have_content('spree t-shirt')
 
         within_row(1) do
-          accept_alert do
+          spree_accept_alert do
             click_icon :delete
+            wait_for_ajax
           end
         end
 
@@ -279,7 +280,7 @@ describe 'Order Details', type: :feature, js: true do
             targetted_select2 stock_location2.name, from: '#s2id_item_stock_location'
             fill_in 'item_quantity', with: 'ff'
 
-            accept_alert do
+            spree_accept_alert do
               click_icon :save
               wait_for_ajax
             end
@@ -296,7 +297,7 @@ describe 'Order Details', type: :feature, js: true do
             targetted_select2 stock_location2.name, from: '#s2id_item_stock_location'
             fill_in 'item_quantity', with: 0
 
-            accept_alert do
+            spree_accept_alert do
               click_icon :save
               wait_for_ajax
             end
@@ -307,7 +308,7 @@ describe 'Order Details', type: :feature, js: true do
 
             fill_in 'item_quantity', with: -1
 
-            accept_alert do
+            spree_accept_alert do
               click_icon :save
               wait_for_ajax
             end
@@ -340,7 +341,7 @@ describe 'Order Details', type: :feature, js: true do
               targetted_select2 stock_location2.name, from: '#s2id_item_stock_location'
               fill_in 'item_quantity', with: 2
 
-              accept_alert do
+              spree_accept_alert do
                 click_icon :save
                 wait_for_ajax
               end
@@ -490,7 +491,7 @@ describe 'Order Details', type: :feature, js: true do
             targetted_select2 @shipment2.number, from: '#s2id_item_stock_location'
             fill_in 'item_quantity', with: 1
 
-            accept_alert do
+            spree_accept_alert do
               click_icon :save
               wait_for_ajax
             end
@@ -499,7 +500,7 @@ describe 'Order Details', type: :feature, js: true do
             targetted_select2 @shipment2.number, from: '#s2id_item_stock_location'
             fill_in 'item_quantity', with: 200
 
-            accept_alert do
+            spree_accept_alert do
               click_icon :save
               wait_for_ajax
             end
@@ -514,7 +515,7 @@ describe 'Order Details', type: :feature, js: true do
             targetted_select2 order.shipments.first.number, from: '#s2id_item_stock_location'
             fill_in 'item_quantity', with: 1
 
-            accept_alert do
+            spree_accept_alert do
               click_icon :save
               wait_for_ajax
             end

--- a/backend/spec/features/admin/products/edit/images_spec.rb
+++ b/backend/spec/features/admin/products/edit/images_spec.rb
@@ -32,8 +32,9 @@ describe 'Product Images', type: :feature, js: true do
       expect(page).to have_content('successfully updated!')
       expect(page).to have_content('ruby on rails t-shirt')
 
-      accept_alert do
+      spree_accept_alert do
         click_icon :delete
+        wait_for_ajax
       end
       expect(page).not_to have_content('ruby on rails t-shirt')
     end

--- a/backend/spec/features/admin/products/edit/products_spec.rb
+++ b/backend/spec/features/admin/products/edit/products_spec.rb
@@ -47,11 +47,11 @@ describe 'Product Details', type: :feature, js: true do
 
       visit spree.admin_products_path
       within_row(1) do
-        accept_alert do
+        spree_accept_alert do
           click_icon :delete
+          wait_for_ajax
         end
       end
-      wait_for_ajax
     end
   end
 end

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -391,7 +391,7 @@ describe 'Products', type: :feature do
 
       it 'is still viewable' do
         visit spree.admin_products_path
-        accept_alert do
+        spree_accept_alert do
           click_icon :delete
           wait_for_ajax
         end

--- a/backend/spec/features/admin/products/properties_spec.rb
+++ b/backend/spec/features/admin/products/properties_spec.rb
@@ -128,8 +128,9 @@ describe 'Properties', type: :feature, js: true do
     end
 
     def delete_product_property
-      accept_alert do
+      spree_accept_alert do
         click_icon :delete
+        wait_for_ajax
       end
     end
 

--- a/backend/spec/features/admin/products/prototypes_spec.rb
+++ b/backend/spec/features/admin/products/prototypes_spec.rb
@@ -101,10 +101,11 @@ describe 'Prototypes', type: :feature, js: true do
     click_link 'Products'
     click_link 'Prototypes'
 
-    accept_alert do
+    spree_accept_alert do
       within("#spree_prototype_#{shirt_prototype.id}") do
         page.find('.delete-resource').click
       end
+      wait_for_ajax
 
       expect(page).to have_content("Prototype \"#{shirt_prototype.name}\" has been successfully removed!")
     end

--- a/backend/spec/features/admin/refund_reasons/refund_reasons_spec.rb
+++ b/backend/spec/features/admin/refund_reasons/refund_reasons_spec.rb
@@ -50,10 +50,11 @@ describe 'RefundReason', type: :feature, js: true do
     end
 
     def delete_product_property
-      accept_alert do
+      spree_accept_alert do
         click_icon :delete
         wait_for_ajax
       end
+      wait_for_ajax
     end
   end
 end

--- a/backend/spec/features/admin/return_authorization_reasons/return_authorization_reasons_spec.rb
+++ b/backend/spec/features/admin/return_authorization_reasons/return_authorization_reasons_spec.rb
@@ -56,10 +56,11 @@ describe 'ReturnAuthorizationReason', type: :feature, js: true do
     end
 
     def delete_product_property
-      accept_alert do
+      spree_accept_alert do
         click_icon :delete
         wait_for_ajax
       end
+      wait_for_ajax
     end
   end
 end

--- a/backend/spec/features/admin/store_credits_spec.rb
+++ b/backend/spec/features/admin/store_credits_spec.rb
@@ -85,7 +85,7 @@ describe 'Store credits admin', type: :feature do
     end
 
     it 'should update store credit in lifetime stats' do
-      accept_alert do
+      spree_accept_alert do
         click_icon :delete
         wait_for_ajax
       end

--- a/core/lib/spree/testing_support/capybara_ext.rb
+++ b/core/lib/spree/testing_support/capybara_ext.rb
@@ -129,6 +129,12 @@ module CapybaraExt
     page.evaluate_script('window.confirm = function() { return true; }')
   end
 
+  def spree_accept_alert
+    yield
+  rescue Selenium::WebDriver::Error::UnhandledAlertError
+    page.driver.browser.switch_to.alert.accept
+  end
+
   def disable_html5_validation
     page.execute_script('for(var f=document.forms,i=f.length;i--;)f[i].setAttribute("novalidate",i)')
   end


### PR DESCRIPTION
I've named method `spree_accept_alert` to make original `accept_alert` still available if someone wants to use it