### PR TITLE
Use correct Bootstrap class for input[type="radio"] in payment method selection screen.

### DIFF
--- a/frontend/app/views/spree/checkout/_payment.html.erb
+++ b/frontend/app/views/spree/checkout/_payment.html.erb
@@ -39,7 +39,7 @@
 
     <ul class="list-group" id="payment-method-fields" data-hook>
       <% @order.available_payment_methods.each do |method| %>
-        <li class="list-group-item">
+        <li class="list-group-item radio">
           <label>
             <%= radio_button_tag "order[payments_attributes][][payment_method_id]", method.id, method == @order.available_payment_methods.first %>
             <%= Spree.t(method.name, scope: :payment_methods, default: method.name) %>


### PR DESCRIPTION
There's currently no margin between the radio buttons in the checkout and the text. This is because there's a Bootstrap form class missing.

Before:
![image](https://user-images.githubusercontent.com/2484832/36174503-cf353dc0-110c-11e8-85f4-afc58450263e.png)


After:
![image](https://user-images.githubusercontent.com/2484832/36174479-bdeb8c40-110c-11e8-817d-06ca3d082f4c.png)
