### PR TITLE
fix activerecord typo in spree/preferences/store model

### DIFF
--- a/core/app/models/spree/preferences/store.rb
+++ b/core/app/models/spree/preferences/store.rb
@@ -86,7 +86,7 @@ module Spree::Preferences
 
     def should_persist?
       @persistence && Spree::Preference.table_exists?
-    rescue PG::ConnectionBad, Activerecord::NoDatabaseError # this is fix to make Deploy To Heroku button work
+    rescue PG::ConnectionBad, ActiveRecord::NoDatabaseError # this is fix to make Deploy To Heroku button work
       false
     end
   end


### PR DESCRIPTION
I've made a typo and didn't notice it because we run tests only on postgres