### PR TITLE
Add unique index on spree_promotions code column

### DIFF
--- a/core/db/migrate/20180222133746_add_unique_index_on_spree_promotions_code.rb
+++ b/core/db/migrate/20180222133746_add_unique_index_on_spree_promotions_code.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexOnSpreePromotionsCode < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :spree_promotions, :code
+    add_index :spree_promotions, :code, unique: true
+  end
+end


### PR DESCRIPTION
https://github.com/spree/spree/commit/4e0799a3021f975244942ba5e84dabb764d2ce16 introduced uniqueness validation for the code attribute but still, it's always recommended to have that also on the database level, hence this change