### PR TITLE
Add preview product button on products edit page in Admin 

### DIFF
--- a/backend/app/views/spree/admin/products/edit.html.erb
+++ b/backend/app/views/spree/admin/products/edit.html.erb
@@ -1,4 +1,7 @@
 <% content_for :page_actions do %>
+  <% if frontend_available? %>
+    <%= button_link_to Spree.t(:preview_product), product_url(@product), { class: "btn-default", icon: 'eye-open', id: 'admin_preview_product', target: :_blank } %>
+  <% end %>
   <% if can?(:create, Spree::Product) %>
     <%= button_link_to Spree.t(:new_product), new_object_url, { class: "btn-success", icon: 'add', id: 'admin_new_product' } %>
   <% end %>

--- a/backend/spec/features/admin/products/edit/products_spec.rb
+++ b/backend/spec/features/admin/products/edit/products_spec.rb
@@ -4,13 +4,15 @@ describe 'Product Details', type: :feature, js: true do
   stub_authorization!
 
   context 'editing a product' do
-    it 'lists the product details' do
+    before do
       create(:product, name: 'Bún thịt nướng', sku: 'A100',
                        description: 'lorem ipsum', available_on: '2013-08-14 01:02:03')
 
       visit spree.admin_products_path
       within_row(1) { click_icon :edit }
+    end
 
+    it 'lists the product details' do
       click_link 'Details'
 
       expect(find('.content-header h1').text.strip).to eq('Products / Bún thịt nướng')
@@ -24,17 +26,17 @@ describe 'Product Details', type: :feature, js: true do
     end
 
     it 'handles slug changes' do
-      create(:product, name: 'Bún thịt nướng', sku: 'A100',
-                       description: 'lorem ipsum', available_on: '2011-01-01 01:01:01')
-
-      visit spree.admin_products_path
-      within('table.table tbody tr:nth-child(1)') do
-        click_icon(:edit)
-      end
-
       fill_in 'product_slug', with: 'random-slug-value'
       click_button 'Update'
       expect(page).to have_content('successfully updated!')
+    end
+
+    it 'has a link to preview a product' do
+      allow(Spree::Core::Engine).to receive(:frontend_available?).and_return(true)
+      allow_any_instance_of(Spree::BaseHelper).to receive(:product_url).and_return('http://example.com/products/product-slug')
+      click_link 'Details'
+      expect(page).to have_css('#admin_preview_product')
+      expect(page).to have_link Spree.t(:preview_product), href: 'http://example.com/products/product-slug'
     end
   end
 end

--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -84,6 +84,10 @@ module Spree
       v.options_text
     end
 
+    def frontend_available?
+      Spree::Core::Engine.frontend_available?
+    end
+
     private
 
     def create_product_image_tag(image, product, options, style)

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1048,6 +1048,7 @@ en:
     pre_tax_total: Pre-Tax Total
     preferred_reimbursement_type: Preferred Reimbursement Type
     presentation: Presentation
+    preview_product: Preview Product
     previous: Previous
     previous_state_missing: "n/a"
     price: Price


### PR DESCRIPTION
The button is available under: `/admin/products/product-slug/edit`, right next to `+ New Product` button:

<img width="1440" alt="preview product button" src="https://user-images.githubusercontent.com/13647303/37455884-74a24ecc-283e-11e8-8989-524650abdc04.png">