### PR TITLE
Display Master SKU even if variants are present

### DIFF
--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -77,6 +77,13 @@
         <% end %>
       </div>
 
+      <div data-hook="admin_product_form_sku">
+        <%= f.field_container :master_sku, class: ['form-group'] do %>
+          <%= f.label :master_sku, Spree.t(:master_sku) %>
+          <%= f.text_field :sku, size: 16, class: 'form-control' %>
+        <% end %>
+      </div>
+
       <% if @product.has_variants? %>
         <div data-hook="admin_product_form_multiple_variants" class="well">
           <%= f.label :skus, Spree.t(:sku).pluralize %>
@@ -100,13 +107,6 @@
           </div>
         </div>
       <% else %>
-        <div data-hook="admin_product_form_sku">
-          <%= f.field_container :sku, class: ['form-group'] do %>
-            <%= f.label :sku, Spree.t(:sku) %>
-            <%= f.text_field :sku, size: 16, class: 'form-control' %>
-          <% end %>
-        </div>
-
         <div id="shipping_specs" class="row">
           <div class="col-xs-12 col-md-6">
             <div id="shipping_specs_weight_field" data-hook="admin_product_form_weight" class="form-group">

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -851,6 +851,7 @@ en:
     manual_intervention_required: Manual intervention required
     manage_variants: Manage Variants
     master_price: Master Price
+    master_sku: Master SKU
     match_choices:
       all: All
       none: None


### PR DESCRIPTION
Fixes #8639 
Pull Request to the following issue `Could not edit SKU of product master #8639`: https://github.com/spree/spree/issues/8639
To make it possible to edit Master SKU even if variants are present, I'm just displaying it regardless of variants presence! Visible as followed:
<img width="333" alt="master sku" src="https://user-images.githubusercontent.com/13647303/37893264-c2f2ac94-30da-11e8-9622-fbf9e57db530.png">
