### PR TITLE
Prevent from raising errors when refunding CreditCard payment in StoreCredits

### DIFF
--- a/core/app/models/spree/reimbursement.rb
+++ b/core/app/models/spree/reimbursement.rb
@@ -42,7 +42,7 @@ module Spree
     #   Refund.total_amount_reimbursed_for(reimbursement)
     # See the `reimbursement_generator` property regarding the generation of custom reimbursements.
     class_attribute :reimbursement_models
-    self.reimbursement_models = [Refund]
+    self.reimbursement_models = [Refund, Credit]
 
     # The reimbursement_performer property should be set to an object that responds to the following methods:
     # - #perform

--- a/core/app/models/spree/reimbursement/reimbursement_type_engine.rb
+++ b/core/app/models/spree/reimbursement/reimbursement_type_engine.rb
@@ -22,7 +22,7 @@ module Spree
     def calculate_reimbursement_types
       @return_items.each do |return_item|
         reimbursement_type = calculate_reimbursement_type(return_item)
-        add_reimbursement_type(return_item, reimbursement_type)
+        @reimbursement_type_hash[reimbursement_type] << return_item if reimbursement_type
       end
 
       @reimbursement_type_hash
@@ -31,24 +31,13 @@ module Spree
     private
 
     def calculate_reimbursement_type(return_item)
-      if return_item.exchange_required?
-        exchange_reimbursement_type
-      elsif return_item.override_reimbursement_type.present?
-        return_item.override_reimbursement_type.class
-      elsif return_item.preferred_reimbursement_type.present?
-        if valid_preferred_reimbursement_type?(return_item)
-          return_item.preferred_reimbursement_type.class
-        end
-      elsif past_reimbursable_time_period?(return_item)
-        expired_reimbursement_type
-      else
-        default_reimbursement_type
+      return exchange_reimbursement_type if return_item.exchange_required?
+      return return_item.override_reimbursement_type.class if return_item.override_reimbursement_type.present?
+      if return_item.preferred_reimbursement_type.present?
+        return valid_preferred_reimbursement_type?(return_item) ? return_item.preferred_reimbursement_type.class : nil
       end
-    end
-
-    def add_reimbursement_type(return_item, reimbursement_type)
-      return unless reimbursement_type
-      @reimbursement_type_hash[reimbursement_type] << return_item
+      return expired_reimbursement_type if past_reimbursable_time_period?(return_item)
+      default_reimbursement_type
     end
   end
 end

--- a/core/app/models/spree/reimbursement_performer.rb
+++ b/core/app/models/spree/reimbursement_performer.rb
@@ -21,17 +21,13 @@ module Spree
       private
 
       def execute(reimbursement, simulate)
-        reimbursement_type_hash = calculate_reimbursement_types(reimbursement)
+        # Engine reimbursement_type_engine returns hash of preferred reimbursement types pointing at return items
+        # {Spree::ReimbursementType::OriginalPayment => [ReturnItem, ...], Spree::ReimbursementType::Exchange => [ReturnItem, ...]}
+        reimbursement_type_hash = reimbursement_type_engine.new(reimbursement.return_items).calculate_reimbursement_types
 
         reimbursement_type_hash.flat_map do |reimbursement_type, return_items|
           reimbursement_type.reimburse(reimbursement, return_items, simulate)
         end
-      end
-
-      def calculate_reimbursement_types(reimbursement)
-        # Engine returns hash of preferred reimbursement types pointing at return items
-        # {Spree::ReimbursementType::OriginalPayment => [ReturnItem, ...], Spree::ReimbursementType::Exchange => [ReturnItem, ...]}
-        reimbursement_type_engine.new(reimbursement.return_items).calculate_reimbursement_types
       end
     end
   end

--- a/core/app/models/spree/reimbursement_type/original_payment.rb
+++ b/core/app/models/spree/reimbursement_type/original_payment.rb
@@ -6,8 +6,8 @@ class Spree::ReimbursementType::OriginalPayment < Spree::ReimbursementType
       unpaid_amount = return_items.map { |ri| ri.total.to_d.round(2) }.sum
       payments = reimbursement.order.payments.completed
 
-      refund_list, unpaid_amount = create_refunds(reimbursement, payments, unpaid_amount, simulate)
-      refund_list
+      reimbursement_list, unpaid_amount = create_refunds(reimbursement, payments, unpaid_amount, simulate)
+      reimbursement_list
     end
   end
 end

--- a/core/app/models/spree/reimbursement_type/reimbursement_helpers.rb
+++ b/core/app/models/spree/reimbursement_type/reimbursement_helpers.rb
@@ -1,7 +1,7 @@
 module Spree
   module ReimbursementType::ReimbursementHelpers
     def create_refunds(reimbursement, payments, unpaid_amount, simulate, reimbursement_list = [])
-      payments.map do |payment|
+      payments.each do |payment|
         break if unpaid_amount <= 0
         next unless payment.can_credit?
 
@@ -37,15 +37,11 @@ module Spree
     # If you have multiple methods of crediting a customer, overwrite this method
     # Must return an array of objects the respond to #description, #display_amount
     def create_credit(reimbursement, unpaid_amount, simulate)
-      creditable = create_creditable(reimbursement, unpaid_amount)
+      category = Spree::StoreCreditCategory.default_reimbursement_category(category_options(reimbursement))
+      creditable = Spree::StoreCredit.new(store_credit_params(category, reimbursement, unpaid_amount))
       credit = reimbursement.credits.build(creditable: creditable, amount: unpaid_amount)
       simulate ? credit.readonly! : credit.save!
       credit
-    end
-
-    def create_creditable(reimbursement, unpaid_amount)
-      category = Spree::StoreCreditCategory.default_reimbursement_category(category_options(reimbursement))
-      Spree::StoreCredit.new(store_credit_params(category, reimbursement, unpaid_amount))
     end
 
     def store_credit_params(category, reimbursement, unpaid_amount)

--- a/core/app/models/spree/reimbursement_type/store_credit.rb
+++ b/core/app/models/spree/reimbursement_type/store_credit.rb
@@ -4,12 +4,10 @@ class Spree::ReimbursementType::StoreCredit < Spree::ReimbursementType
   class << self
     def reimburse(reimbursement, return_items, simulate)
       unpaid_amount = return_items.sum(&:total).to_d.round(2, :down)
-      payments = store_credit_payments(reimbursement)
-      reimbursement_list = []
+      payments = reimbursement.order.payments.completed.store_credits
 
       # Credit each store credit that was used on the order
-      reimbursement_list, unpaid_amount = create_refunds(reimbursement, payments, unpaid_amount,
-                                                         simulate, reimbursement_list)
+      reimbursement_list, unpaid_amount = create_refunds(reimbursement, payments, unpaid_amount, simulate)
 
       # If there is any amount left to pay out to the customer, then create credit with that amount
       if unpaid_amount > 0.0
@@ -17,12 +15,6 @@ class Spree::ReimbursementType::StoreCredit < Spree::ReimbursementType
       end
 
       reimbursement_list
-    end
-
-    private
-
-    def store_credit_payments(reimbursement)
-      reimbursement.order.payments.completed.store_credits
     end
   end
 end

--- a/core/spec/models/spree/reimbursement_performer_spec.rb
+++ b/core/spec/models/spree/reimbursement_performer_spec.rb
@@ -5,26 +5,23 @@ describe Spree::ReimbursementPerformer, type: :model do
   let(:return_item)             { reimbursement.return_items.first }
   let(:reimbursement_type)      { double('ReimbursementType') }
   let(:reimbursement_type_hash) { { reimbursement_type => [return_item] } }
+  let(:reimbursement_type_engine) { Spree::Reimbursement::ReimbursementTypeEngine }
 
   before do
-    expect(Spree::ReimbursementPerformer).to receive(:calculate_reimbursement_types).and_return(reimbursement_type_hash)
+    allow_any_instance_of(reimbursement_type_engine).to receive(:calculate_reimbursement_types).and_return(reimbursement_type_hash)
   end
 
   describe '.simulate' do
-    subject { Spree::ReimbursementPerformer.simulate(reimbursement) }
-
     it 'reimburses each calculated reimbursement types with the correct return items as a simulation' do
       expect(reimbursement_type).to receive(:reimburse).with(reimbursement, [return_item], true)
-      subject
+      Spree::ReimbursementPerformer.simulate(reimbursement)
     end
   end
 
   describe '.perform' do
-    subject { Spree::ReimbursementPerformer.perform(reimbursement) }
-
-    it 'reimburses each calculated reimbursement types with the correct return items as a simulation' do
+    it 'reimburses each calculated reimbursement types with the correct return items as a performance' do
       expect(reimbursement_type).to receive(:reimburse).with(reimbursement, [return_item], false)
-      subject
+      Spree::ReimbursementPerformer.perform(reimbursement)
     end
   end
 end

--- a/core/spec/models/spree/reimbursement_spec.rb
+++ b/core/spec/models/spree/reimbursement_spec.rb
@@ -39,6 +39,8 @@ describe Spree::Reimbursement, type: :model do
 
     let(:reimbursement) { create(:reimbursement, customer_return: customer_return, order: order, return_items: [return_item]) }
 
+    let(:store_credit_reimbursement_type) { create(:reimbursement_type, name: 'StoreCredit', type: 'Spree::ReimbursementType::StoreCredit') }
+
     before do
       order.shipments.each do |shipment|
         shipment.inventory_units.update_all state: 'shipped'
@@ -102,6 +104,13 @@ describe Spree::Reimbursement, type: :model do
 
       it 'raises IncompleteReimbursement error' do
         expect { subject }.to raise_error(Spree::Reimbursement::IncompleteReimbursementError)
+      end
+    end
+
+    context 'when reimbursement is performed using store credits' do
+      it 'succeeds' do
+        reimbursement.return_items.last.update(preferred_reimbursement_type_id: store_credit_reimbursement_type.id)
+        expect { subject }.not_to raise_error(Spree::Reimbursement::IncompleteReimbursementError)
       end
     end
 

--- a/core/spec/models/spree/reimbursement_type/credit_spec.rb
+++ b/core/spec/models/spree/reimbursement_type/credit_spec.rb
@@ -18,7 +18,7 @@ module Spree
 
     before do
       reimbursement.update!(total: reimbursement.calculated_total)
-      allow(Spree::ReimbursementType::Credit).to receive(:create_creditable).and_return(creditable)
+      allow(Spree::StoreCredit).to receive(:new).and_return(creditable)
     end
 
     describe '.reimburse' do

--- a/core/spec/models/spree/reimbursement_type/store_credit_spec.rb
+++ b/core/spec/models/spree/reimbursement_type/store_credit_spec.rb
@@ -29,7 +29,7 @@ module Spree
 
         context 'for store credits that the customer used' do
           before do
-            allow(Spree::ReimbursementType::StoreCredit).to receive(:store_credit_payments).and_return([payment])
+            allow(reimbursement).to receive_message_chain('order.payments.completed.store_credits').and_return([payment])
           end
 
           it 'creates readonly refunds for all store credit payments' do
@@ -43,10 +43,6 @@ module Spree
         end
 
         context 'for return items that were not paid for with store credit' do
-          before do
-            allow(Spree::ReimbursementType::StoreCredit).to receive(:store_credit_payments).and_return([])
-          end
-
           context 'creates one readonly lump credit for all outstanding balance payable to the customer' do
             it 'creates a credit that is read only' do
               expect(subject.map(&:class)).to eq [Spree::Reimbursement::Credit]
@@ -71,7 +67,7 @@ module Spree
 
         context 'for store credits that the customer used' do
           before do
-            allow(Spree::ReimbursementType::StoreCredit).to receive(:store_credit_payments).and_return([payment])
+            allow(reimbursement).to receive_message_chain('order.payments.completed.store_credits').and_return([payment])
           end
 
           it 'performs refunds for all store credit payments' do


### PR DESCRIPTION
Fixes #8614 
When checking `paid_amount` in `core/app/models/spree/reimbursement.rb`, it did not take into consideration created StoreCredits, so `IncompleteReimbursementError` is raised. Therefore the solution that author of an issue proposed (`self.reimbursement_models = [Refund, Credit]`) makes sense. In my opinion, other solutions could be much more complicated and would require changes to the logic of how Refunds/ Reimbursements are created. That's why, after consulting it with @bbonislawski, I've picked simpler solution for that. Also I've added some refactor. But feel free to let me know if you have any comments or questions.