### PR TITLE
Use pluck instead of map

### DIFF
--- a/api/spec/controllers/spree/api/v1/products_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/products_controller_spec.rb
@@ -69,7 +69,7 @@ module Spree
 
         it 'returns distinct products only' do
           api_get :index
-          expect(assigns(:products).map(&:id).uniq).to eq assigns(:products).map(&:id)
+          expect(assigns(:products).ids.uniq).to eq assigns(:products).ids
         end
       end
 

--- a/api/spec/controllers/spree/api/v1/shipments_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/shipments_controller_spec.rb
@@ -214,7 +214,7 @@ describe Spree::Api::V1::ShipmentsController, type: :controller do
           end
 
           it 'filters' do
-            expect(assigns(:shipments).map(&:id)).to match_array current_api_user.orders.complete.flat_map(&:shipments).map(&:id)
+            expect(assigns(:shipments).ids).to match_array current_api_user.orders.complete.flat_map(&:shipments).ids
           end
         end
       end

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -225,7 +225,7 @@ describe Spree::Admin::OrdersController, type: :controller do
 
       def send_request
         spree_get :index, q: {
-          line_items_variant_id_in: Spree::Order.first.variants.map(&:id)
+          line_items_variant_id_in: Spree::Order.first.variants.ids
         }
       end
 

--- a/backend/spec/features/admin/promotions/adjustments_spec.rb
+++ b/backend/spec/features/admin/promotions/adjustments_spec.rb
@@ -130,7 +130,7 @@ describe 'Promotion Adjustments', type: :feature, js: true do
 
       first_rule = promotion.rules.first
       expect(first_rule.class).to eq(Spree::Promotion::Rules::Product)
-      expect(first_rule.products.map(&:name)).to include('RoR Mug')
+      expect(first_rule.products.pluck(:name)).to include('RoR Mug')
 
       first_action = promotion.actions.first
       expect(first_action.class).to eq(Spree::Promotion::Actions::CreateItemAdjustments)

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -488,7 +488,7 @@ module Spree
     def create_proposed_shipments
       all_adjustments.shipping.delete_all
 
-      shipment_ids = shipments.map(&:id)
+      shipment_ids = shipments.ids
       StateChange.where(stateful_type: 'Spree::Shipment', stateful_id: shipment_ids).delete_all
       ShippingRate.where(shipment_id: shipment_ids).delete_all
 

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -164,11 +164,11 @@ module Spree
 
     def adjusted_credits_count(promotable)
       adjustments = promotable.is_a?(Order) ? promotable.all_adjustments : promotable.adjustments
-      credits_count - adjustments.promotion.where(source_id: actions.pluck(:id)).size
+      credits_count - adjustments.promotion.where(source_id: actions.ids).size
     end
 
     def credits
-      Adjustment.eligible.promotion.where(source_id: actions.map(&:id))
+      Adjustment.eligible.promotion.where(source_id: actions.ids)
     end
 
     def credits_count
@@ -199,7 +199,7 @@ module Spree
         user.orders.complete.joins(adjustment_type).where(
           spree_adjustments: {
             source_type: 'Spree::PromotionAction',
-            source_id: actions.map(&:id),
+            source_id: actions.pluck(:id),
             eligible: true
           }
         ).where.not(

--- a/core/app/models/spree/stock/coordinator.rb
+++ b/core/app/models/spree/stock/coordinator.rb
@@ -38,7 +38,7 @@ module Spree
       end
 
       def requested_variant_ids
-        inventory_units.map(&:variant_id).uniq
+        inventory_units.pluck(:variant_id).uniq
       end
 
       def prioritize_packages(packages)

--- a/core/spec/models/spree/classification_spec.rb
+++ b/core/spec/models/spree/classification_spec.rb
@@ -21,7 +21,7 @@ module Spree
     end
 
     def positions_to_be_valid(taxon)
-      positions = taxon.reload.classifications.map(&:position)
+      positions = taxon.reload.classifications.pluck(:position)
       expect(positions).to eq((1..taxon.classifications.count).to_a)
     end
 

--- a/core/spec/models/spree/stock/inventory_unit_builder_spec.rb
+++ b/core/spec/models/spree/stock/inventory_unit_builder_spec.rb
@@ -27,7 +27,7 @@ module Spree
         end
 
         it 'sets the order_id on inventory units' do
-          expect(subject.units.map(&:order_id).uniq).to eq [order.id]
+          expect(subject.units.pluck(:order_id).uniq).to eq [order.id]
         end
       end
     end


### PR DESCRIPTION
Pluck is much faster as it returns an array rather than entire collection of AR objects

https://collectiveidea.com/blog/archives/2015/03/05/optimizing-rails-for-memory-usage-part-3-pluck-and-database-laziness