### PR TITLE
Fix: Admin Store Credit I18n Bug

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1378,6 +1378,7 @@ en:
         unable_to_delete: Unable to delete store credit
         unable_to_fund: Unable to pay for order using store credits
         unable_to_update: Unable to update store credit
+    store_credits: Store Credits
     store_credit_categories: Store Credit Categories
     store_credit_payment_method:
       unable_to_void: "Unable to void code: %{auth_code}"


### PR DESCRIPTION
While adding/editing store credits from admin panel, there is a i18n error which renders the link and the page title incorrectly.
Currently, page looks like this
<img width="1438" alt="screen shot 2018-04-06 at 7 30 44 pm" src="https://user-images.githubusercontent.com/8337530/38425373-562dbbb2-39d1-11e8-83a7-77f9a1e211a3.png">
After adding the translation, the page looks like this-
<img width="1440" alt="screen shot 2018-04-06 at 7 31 05 pm" src="https://user-images.githubusercontent.com/8337530/38425388-65cc1d2a-39d1-11e8-8a9a-d645dc43a602.png">
