### PR TITLE
don't save shipment when it was destroyed after transfer

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -349,7 +349,7 @@ module Spree
         order.update_with_updater!
 
         refresh_rates
-        save!
+        save! if persisted?
         new_shipment.save!
       end
     end
@@ -368,7 +368,7 @@ module Spree
         order.update_with_updater!
 
         refresh_rates
-        save!
+        save! if persisted?
         shipment_to_transfer_to.refresh_rates
         shipment_to_transfer_to.save!
       end


### PR DESCRIPTION
`save!` is changed a little bit in rails 5.2.0 and will fail if called on destroyed object, so we need to check if shipment is still persisted after transfer