### PR TITLE
Fix not exited adjustables in AdjustmentsUpdater#update

### DIFF
--- a/core/app/models/spree/adjustable/adjustments_updater.rb
+++ b/core/app/models/spree/adjustable/adjustments_updater.rb
@@ -11,8 +11,7 @@ module Spree
       end
 
       def update
-        return unless @adjustable
-        return unless @adjustable.persisted?
+        return unless adjustable_still_exists?
 
         totals = {
           non_taxable_adjustment_total: 0,
@@ -42,6 +41,10 @@ module Spree
 
       def adjusters
         Rails.application.config.spree.adjusters
+      end
+
+      def adjustable_still_exists?
+        @adjustable && @adjustable.class.exists?(@adjustable.id)
       end
     end
   end


### PR DESCRIPTION
The problem with the previous solution using the `persisted?` method was that this method can help only in case of DB transactions / new object

But when we:
- Assign a record to a variable `@adjustable`
- Destroy the record in the DB (it can happen for example when orders got merged)
- Call `@adjustable.persisted?`
The result will be `true`

So here we do an additional DB call to make sure that the adjustable still exists