### PR TITLE
Store: add default to permitted attributes

### DIFF
--- a/backend/app/views/spree/admin/stores/_form.html.erb
+++ b/backend/app/views/spree/admin/stores/_form.html.erb
@@ -40,9 +40,4 @@
     <%= f.text_field :code, class: 'form-control', required: true %>
     <%= f.error_message_on :code %>
   <% end %>
-  <%= f.field_container :default, class: ['form-group'] do %>
-    <%= f.label :default, Spree.t(:default)  %>
-    <%= f.check_box :default %>
-    <%= f.error_message_on :default %>
-  <% end %>
 </div>


### PR DESCRIPTION
This patch fixes `ActionController::UnpermittedParameters: found unpermitted parameter: :default` when updating here `/store/admin/stores/1/edit`: 
![slack - nasb-milner 2018-05-07 10-38-20](https://user-images.githubusercontent.com/6732638/39707583-d5d2bb1e-51e2-11e8-8948-dc7458c00752.png)
