### PR TITLE
Update jQuery element exist checks to use `length` instead of `is('*')`

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/payments/new.js
+++ b/backend/app/assets/javascripts/spree/backend/payments/new.js
@@ -1,6 +1,6 @@
 //= require jquery.payment
 $(document).ready(function() {
-  if ($("#new_payment").is("*")) {
+  if ($("#new_payment").length) {
     $(".cardNumber").payment('formatCardNumber');
     $(".cardExpiry").payment('formatCardExpiry');
     $(".cardCode").payment('formatCardCVC');

--- a/frontend/app/assets/javascripts/spree/frontend/cart.js.coffee
+++ b/frontend/app/assets/javascripts/spree/frontend/cart.js.coffee
@@ -1,7 +1,7 @@
 #= require spree/frontend/coupon_manager
 
 Spree.ready ($) ->
-  if ($ 'form#update-cart').is('*')
+  if ($ 'form#update-cart').length
     ($ 'form#update-cart a.delete').show().one 'click', ->
       ($ this).parents('.line-item').first().find('input.line_item_quantity').val 0
       ($ this).parents('form').first().submit()

--- a/frontend/app/assets/javascripts/spree/frontend/checkout/address.js.coffee
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/address.js.coffee
@@ -1,6 +1,6 @@
 Spree.ready ($) ->
   Spree.onAddress = () ->
-    if ($ '#checkout_form_address').is('*')
+    if ($ '#checkout_form_address').length
       getCountryId = (region) ->
         $('#' + region + 'country select').val()
 

--- a/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js.coffee
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js.coffee
@@ -1,9 +1,9 @@
 #= require spree/frontend/coupon_manager
 Spree.ready ($) ->
   Spree.onPayment = () ->
-    if ($ '#checkout_form_payment').is('*')
+    if ($ '#checkout_form_payment').length
 
-      if ($ '#existing_cards').is('*')
+      if ($ '#existing_cards').length
         ($ '#payment-method-fields').hide()
         ($ '#payment-methods').hide()
 


### PR DESCRIPTION
This is the jQuery recommended way of testing whether an element exists:
https://learn.jquery.com/using-jquery-core/faq/how-do-i-test-whether-an-element-exists/

It's also about 55% faster to do it this way:
https://jsperf.com/jquery-is-vs-length-2