### PR TITLE
Remove unused Address#clear_state_entities private method

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -106,11 +106,6 @@ module Spree
 
     private
 
-    def clear_state_entities
-      clear_state
-      clear_state_name
-    end
-
     def clear_state
       self.state = nil
     end

--- a/core/spec/models/spree/address_spec.rb
+++ b/core/spec/models/spree/address_spec.rb
@@ -297,15 +297,6 @@ describe Spree::Address, type: :model do
     specify { expect(address.instance_eval { require_phone? }).to be true }
   end
 
-  context '#clear_state_entities' do
-    let (:address) { create(:address) }
-
-    before { address.state_name = 'maryland' }
-
-    it { expect { address.send(:clear_state_entities) }.to change(address, :state).to(nil).from(address.state) }
-    it { expect { address.send(:clear_state_entities) }.to change(address, :state_name).to(nil).from('maryland') }
-  end
-
   context '#clear_state' do
     let (:address) { create(:address) }
 


### PR DESCRIPTION
It was added by mistake. There is already one helper method for specs by this name