### PR TITLE
[WIP] Fix an issue with promotion application #7227

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -129,7 +129,7 @@ module Spree
       # Promotions without rules are eligible by default.
       return [] if rules.none?
       specific_rules = rules.select { |rule| rule.applicable?(promotable) }
-      return [] if specific_rules.none?
+      return if specific_rules.none?
 
       rule_eligibility = Hash[specific_rules.map do |rule|
         [rule, rule.eligible?(promotable, options)]

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -434,10 +434,10 @@ describe Spree::Promotion, type: :model do
       expect(promotion.eligible_rules(promotable)).to eq []
     end
 
-    it 'true if there are no applicable rules' do
+    it 'nil if there are no applicable rules' do
       promotion.promotion_rules = [stub_model(Spree::PromotionRule, eligible?: true, applicable?: false)]
-      allow(promotion.promotion_rules).to receive(:for).and_return([])
-      expect(promotion.eligible_rules(promotable)).to eq []
+      allow(promotion.promotion_rules).to receive(:for).and_return(nil)
+      expect(promotion.eligible_rules(promotable)).to eq nil
     end
 
     context "with 'all' match policy" do


### PR DESCRIPTION
https://github.com/spree/spree/issues/7227

Thoughts?
I don't see a point of returning an empty array whenever there are no applicable specific rules. 
Such scenario indicates that promotable object is not eligible for promotion therefore we shouldn't apply any promotion actions.