### PR TITLE
Fix RSpec configuration

### DIFF
--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -45,9 +45,10 @@ RSpec.configure do |config|
 
   # Config for running specs while have transition period from Paperclip to ActiveStorage
   if Rails.application.config.use_paperclip
-    config.filter_run_excluding active_storage: true
+    config.filter_run_excluding :active_storage
   else
-    config.filter_run_including active_storage: true
+    config.filter_run_including :active_storage
+    config.run_all_when_everything_filtered = true
   end
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your


### PR DESCRIPTION
This PR introduces a fix to RSpec configuration with ActiveStorage adapter.
Previously we've ran only tests that include `active_storage:true` which makes no sense since there are only 2 of 'em. 