### PR TITLE
Updates order shipment state

### DIFF
--- a/core/app/models/spree/exchange.rb
+++ b/core/app/models/spree/exchange.rb
@@ -27,6 +27,7 @@ module Spree
       end
 
       @order.shipments += shipments
+      @order.shipment_state = Spree::OrderUpdater.new(@order).update_shipment_state
       @order.save!
 
       shipments.each do |shipment|


### PR DESCRIPTION
I believe that when an exchange is made and the order has a new shipment, it's shipment status should also be updated ( It will become partial most of the times according to the updater )