### PR TITLE
When applying a promo code for the whole order, it consideres only promotionable items

### DIFF
--- a/core/app/models/spree/calculator/flat_percent_item_total.rb
+++ b/core/app/models/spree/calculator/flat_percent_item_total.rb
@@ -9,11 +9,12 @@ module Spree
     end
 
     def compute(object)
-      computed_amount = (object.amount * preferred_flat_percent / 100).round(2)
+      amount = object.promotionable_amount
+      computed_amount = (amount * preferred_flat_percent / 100).round(2)
 
       # We don't want to cause the promotion adjustments to push the order into a negative total.
-      if computed_amount > object.amount
-        object.amount
+      if computed_amount > amount
+        amount
       else
         computed_amount
       end

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -36,6 +36,8 @@ module Spree
     delegate :brand, :category, to: :product
     delegate :tax_zone, to: :order
 
+    scope :promotionable, -> { joins(:product).where(spree_products: { promotionable: true }) }
+
     attr_accessor :target_shipment
 
     self.whitelisted_ransackable_associations = ['variant']
@@ -67,6 +69,7 @@ module Spree
       price * quantity
     end
 
+    alias promotionable_amount amount
     alias subtotal amount
 
     def taxable_amount

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -173,6 +173,10 @@ module Spree
       line_items.inject(0.0) { |sum, li| sum + li.amount }
     end
 
+    def promotionable_amount
+      line_items.promotionable.map(&:amount).sum
+    end
+
     # Sum of all line item amounts pre-tax
     def pre_tax_item_amount
       line_items.to_a.sum(&:pre_tax_amount)

--- a/core/spec/models/spree/calculator/flat_percent_item_total_spec.rb
+++ b/core/spec/models/spree/calculator/flat_percent_item_total_spec.rb
@@ -3,23 +3,31 @@ require 'spec_helper'
 describe Spree::Calculator::FlatPercentItemTotal, type: :model do
   let(:calculator) { Spree::Calculator::FlatPercentItemTotal.new }
   let(:line_item) { mock_model Spree::LineItem }
+  let(:order) { create(:order_with_line_items, line_items_count: 2) }
 
   before { allow(calculator).to receive_messages preferred_flat_percent: 10 }
 
   context 'compute' do
     it 'rounds result correctly' do
-      allow(line_item).to receive_messages amount: 31.08
+      allow(line_item).to receive_messages promotionable_amount: 31.08
       expect(calculator.compute(line_item)).to eq 3.11
 
-      allow(line_item).to receive_messages amount: 31.00
+      allow(line_item).to receive_messages promotionable_amount: 31.00
       expect(calculator.compute(line_item)).to eq 3.10
     end
 
-    it 'returns object.amount if computed amount is greater' do
+    it 'returns object.promotionable_items_amount if computed amount is greater' do
       allow(calculator).to receive_messages preferred_flat_percent: 110
-      allow(line_item).to receive_messages amount: 30.00
+      allow(line_item).to receive_messages promotionable_amount: 30.00
 
       expect(calculator.compute(line_item)).to eq 30.0
+    end
+
+    it 'calculates only for promotionable items' do
+      order.products.first.update_column(:promotionable, false)
+      allow(calculator).to receive_messages preferred_flat_percent: 50
+
+      expect(calculator.compute(order)).to eq 5
     end
   end
 end


### PR DESCRIPTION
Fix #6476