### PR TITLE
When trying to exchange the SameProduct, in dropdown display also backorderable items, not only in_stock.

### DIFF
--- a/core/app/models/spree/return_item/exchange_variant_eligibility/same_product.rb
+++ b/core/app/models/spree/return_item/exchange_variant_eligibility/same_product.rb
@@ -2,7 +2,7 @@ module Spree
   module ReturnItem::ExchangeVariantEligibility
     class SameProduct
       def self.eligible_variants(variant)
-        Spree::Variant.where(product_id: variant.product_id, is_master: variant.is_master?).in_stock
+        Spree::Variant.where(product_id: variant.product_id, is_master: variant.is_master?).in_stock_or_backorderable
       end
     end
   end

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -56,6 +56,8 @@ module Spree
     after_touch :clear_in_stock_cache
 
     scope :in_stock, -> { joins(:stock_items).where('count_on_hand > ? OR track_inventory = ?', 0, false) }
+    scope :backorderable, -> { joins(:stock_items).where(spree_stock_items: { backorderable: true }) }
+    scope :in_stock_or_backorderable, -> { in_stock.or(backorderable) }
 
     scope :eligible, -> {
       where(is_master: false).or(

--- a/core/spec/models/spree/return_item/exchange_variant_eligibility/same_product_spec.rb
+++ b/core/spec/models/spree/return_item/exchange_variant_eligibility/same_product_spec.rb
@@ -28,12 +28,16 @@ module Spree
           expect(SameProduct.eligible_variants(variant)).not_to include other_product_variant
         end
 
-        it 'only returns variants that are on hand' do
-          product = create(:product, variants: Array.new(2) { create(:variant) })
+        it 'only returns variants that are on hand or backorderable' do
+          product = create(:product, variants: Array.new(3) { create(:variant) })
           in_stock_variant = product.variants.first
+          backorderable_variant = product.variants.second
+          not_backorderable_variant = product.variants.third
 
           in_stock_variant.stock_items.first.update_column(:count_on_hand, 10)
-          expect(SameProduct.eligible_variants(in_stock_variant)).to eq [in_stock_variant]
+          not_backorderable_variant.stock_items.first.update_column(:backorderable, false)
+
+          expect(SameProduct.eligible_variants(in_stock_variant)).to eq [in_stock_variant, backorderable_variant]
         end
       end
     end

--- a/core/spec/models/spree/return_item_spec.rb
+++ b/core/spec/models/spree/return_item_spec.rb
@@ -619,7 +619,12 @@ describe Spree::ReturnItem, type: :model do
           let(:return_item)      { build(:return_item) }
           let(:exchange_variant) { create(:variant, product: return_item.inventory_unit.variant.product) }
 
-          before { return_item.exchange_variant = exchange_variant }
+          before do
+            exchange_variant.stock_items.each do |item|
+              item.update_column(:backorderable, false)
+            end
+            return_item.exchange_variant = exchange_variant
+          end
 
           it 'is invalid' do
             expect(subject).not_to be_valid


### PR DESCRIPTION
Fix #6575