### PR TITLE
Fix randomly failing variants spec

### DIFF
--- a/backend/spec/features/admin/products/edit/variants_spec.rb
+++ b/backend/spec/features/admin/products/edit/variants_spec.rb
@@ -17,7 +17,6 @@ describe 'Product Variants', type: :feature, js: true do
     end
 
     it 'allows admin to create a variant if there are option types' do
-      click_link 'Products'
       click_link 'Option Types'
       click_link 'new_option_type_link'
       fill_in 'option_type_name', with: 'shirt colors'


### PR DESCRIPTION
I have removed `click_link 'Products'` because it was closing the Products dropdown in the navbar. Next `click_link` was executed in time of the closing animation and thus it would not always be executed on time causing random failures. 