### PR TITLE
Fix reference to Stock Locations Guide

### DIFF
--- a/guides/content/user/orders/returning_orders.md
+++ b/guides/content/user/orders/returning_orders.md
@@ -18,7 +18,7 @@ To create an RMA for a shipped order, click the order's "Return Authorizations" 
 
 To use it, just select each line item to be returned, either a reimbursement type or exchange item. Select Quantity of the items(s), its set to "1" by default. For example, customer wants to return a damaged item. Selecting the "Original" reimbursement type will refund a user back to their original payment method when the items are returned and approved.  Selecting an exchange item will create a new shipment to ship the exchange item to the customer.  The form will automatically calculate the RMA value based on the sale price of the item(s), but you will have to confirm the amount when the reimbursement is issued. This gives you a chance to adjust for handling fees, restocking fees, damages, etc.
 
-Input the reason and any memo notes for the return, and select the [Stock Location](stock_locations) the item is coming back to. Click the "Create" button.
+Input the reason and any memo notes for the return, and select the [Stock Location](configuring_inventory) the item is coming back to. Click the "Create" button.
 
 Now, you just need to wait for the package to be received at your location.
 
@@ -38,7 +38,7 @@ Once you receive a return package, you need to create a "Customer Return". To do
 
 ![Receive RMA Button](/images/user/orders/customer_return_link.jpg)
 
-Select which of the authorized return items were received or mark all of them by simply clicking next to product on the left side checkbox, and to which [Stock Location](stock_locations). You can also set if the item that has been returned by the User is still **Resellable** or not. Once you are done, click the "Create" button.
+Select which of the authorized return items were received or mark all of them by simply clicking next to product on the left side checkbox, and to which [Stock Location](creating_products). You can also set if the item that has been returned by the User is still **Resellable** or not. Once you are done, click the "Create" button.
 
 ![Receive RMA Button](/images/user/orders/customer_return_form.jpg)
 

--- a/guides/content/user/products/creating_products.md
+++ b/guides/content/user/products/creating_products.md
@@ -111,9 +111,9 @@ You can read much more in-depth information about this feature in the [Product P
 
 ## Stock Management
 
-As of version 2.0 of Spree, you now have much more granular control over how inventory is tracked through your store. You will learn more about stock locations in the [Stock Locations Guide](stock_locations), but for now it's enough to understand that you enter the number of each product variant that you have at each of your individual stock locations.
+As of version 2.0 of Spree, you now have much more granular control over how inventory is tracked through your store. You will learn more about stock locations in the [Stock Locations Guide](configuring_inventory), but for now it's enough to understand that you enter the number of each product variant that you have at each of your individual stock locations.
 
-Let's assume that you have two stock locations - your main New York warehouse and your satellite Detroit warehouse. Refer to the instructions on creating stock locations in the [Stock Locations Guide](stock_locations#create-a-new-stock-location) to add your warehouses.
+Let's assume that you have two stock locations - your main New York warehouse and your satellite Detroit warehouse. Refer to the instructions on creating stock locations in the [Stock Locations Guide](configuring_inventory#create-a-new-stock-location) to add your warehouses.
 
 Now, go back to the Tumblers product page, and click the "Stock Management" link.
 

--- a/guides/content/user/shipments/shipping_methods.md
+++ b/guides/content/user/shipments/shipping_methods.md
@@ -40,7 +40,7 @@ If a shipping method is available only on backend, then only your store's admini
 
 #### Tracking URL
 
-You can optionally input a tracking URL for your new shipping method. This allows customers to track the progress of their package from your [Stock Location](stock_locations) to the order's shipping address. The string ":tracking" will be replaced with the tracking number you input once you actually process the order.
+You can optionally input a tracking URL for your new shipping method. This allows customers to track the progress of their package from your [Stock Location](configuring_inventory) to the order's shipping address. The string ":tracking" will be replaced with the tracking number you input once you actually process the order.
 
 You may need to check with the shipping carrier to see if they have a Shipping Confirmation URL that customers can use for this service. Some [commonly-used tracking URLs](http://verysimple.com/2011/07/06/ups-tracking-url/) are available online.
 


### PR DESCRIPTION
Going through the User Guides I found that two links on [this section](https://guides.spreecommerce.org/user/creating_products.html#stock-management) were taking me to a `403` page.

Did a quick search and replace throughout the guides and I believe this tiny change should fix the link error (by referencing to the the actual Stock Locations Guide).

Cheers.