### PR TITLE
Stop re-appending spree locale paths in dev mode

### DIFF
--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -116,12 +116,12 @@ module Spree
       end
 
       config.to_prepare do
-        # Load spree locales before decorators
-        I18n.load_path += Dir.glob(
+        # Ensure spree locale paths are present before decorators
+        I18n.load_path.unshift(*(Dir.glob(
           File.join(
             File.dirname(__FILE__), '../../../config/locales', '*.{rb,yml}'
           )
-        )
+        ) - I18n.load_path))
 
         # Load application's model / class decorators
         Dir.glob(File.join(File.dirname(__FILE__), '../../../app/**/*_decorator*.rb')) do |c|


### PR DESCRIPTION
Spree appends I18n locale paths before the decorators are loaded.

It is necessary to ensure that the locale paths are only appended once
to avoid overriding customized locales.

This issue was occurring in development mode when locales where changed
and the spree local paths where re-appended to I18n.load_path, thereby
prioritizing the spree locales over the overridden locals.

Only rails environments with "config.cache_classes = false" where
affected.

### Reprduction of this issue:
For simple reproduction of this issue I added a sample app that uses docker. I have added an override:

https://github.com/arkirchner/spree_locales_test

```
en:
  spree:
    home: My Home
```

Please start the app with:
```
bin/setup
docker-compose up
```

Look at `localhost:9292` to see the header `My home`. Change the locale without restarting the app. Reload the page and you will see "Home" instead of your adjustment.

To test my change please go in the Gemfile and replace spree with my git version. I added the necessary line as a commend at the end of the Gemfile.

Please run this to install the gem and build the docker image:
```
docker-compose run app bundle install
docker-compose build
```

Start the app (`docker-compose up`) again. Now the local can be changed without reverting to the spree defaults. 

This issue is related to the issues I have opened:
https://github.com/spree/spree/issues/8783