### PR TITLE
Backport (3-1) Stop re-appending spree locale paths in dev mode

### DIFF
--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -115,12 +115,13 @@ module Spree
       end
 
       config.to_prepare do
-        # Load spree locales before decorators
-        I18n.load_path += Dir.glob(
+        # Ensure spree locale paths are present before decorators
+        I18n.load_path.unshift(*(Dir.glob(
           File.join(
             File.dirname(__FILE__), '../../../config/locales', '*.{rb,yml}'
           )
-        )
+        ) - I18n.load_path))
+
         # Load application's model / class decorators
         Dir.glob(File.join(File.dirname(__FILE__), '../../../app/**/*_decorator*.rb')) do |c|
           Rails.configuration.cache_classes ? require(c) : load(c)


### PR DESCRIPTION
Spree appends I18n locale paths before the decorators are loaded.

It is necessary to ensure that the locale paths are only appended once
to avoid overriding customized locales.

Further more the spree locale paths are appended to the beginning of
I18n.load_path. This will ensure that locales that are loaded before
spree will not be overridden.

This issue was occurring in development mode when locales where changed
and the spree local paths where re-appended to I18n.load_path, thereby
prioritizing the spree locales over the overridden locals.

Only rails environments with "config.cache_classes = false" where
affected.