### PR TITLE
Fix syntax error, unexpected keyword_rescue, expecting keyword_end.

### DIFF
--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -57,9 +57,11 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
 
   config.before do
-    Rails.cache.clear
-    reset_spree_preferences
-  rescue Errno::ENOTEMPTY
+    begin
+      Rails.cache.clear
+      reset_spree_preferences
+    rescue Errno::ENOTEMPTY
+    end
   end
 
   config.include FactoryBot::Syntax::Methods


### PR DESCRIPTION
core/spec/spec_helper.rb:62

Step to reproduce:

```Ruby
git clone git@github.com:spree/spree.git
cd spree/
bundle install
cd core
BUNDLE_GEMFILE=../Gemfile bundle exec rake test_app
bundle exec rspec spec
```

```
An error occurred while loading ./spec/helpers/base_helper_spec.rb.
Failure/Error: load file

SyntaxError:
  /home/none/Documents/dev/hub/spree/core/spec/spec_helper.rb:62: syntax error, unexpected keyword_rescue, expecting keyword_end
    rescue Errno::ENOTEMPTY
          ^
# /home/none/.rvm/gems/ruby-2.3.0/gems/rspec-core-3.7.1/lib/rspec/core/configuration.rb:1954:in `load'
# /home/none/.rvm/gems/ruby-2.3.0/gems/rspec-core-3.7.1/lib/rspec/core/configuration.rb:1954:in `load_spec_file_handling_errors'
# /home/none/.rvm/gems/ruby-2.3.0/gems/rspec-core-3.7.1/lib/rspec/core/configuration.rb:1496:in `block in load_spec_files'
# /home/none/.rvm/gems/ruby-2.3.0/gems/rspec-core-3.7.1/lib/rspec/core/configuration.rb:1494:in `each'
# /home/none/.rvm/gems/ruby-2.3.0/gems/rspec-core-3.7.1/lib/rspec/core/configuration.rb:1494:in `load_spec_files'
# /home/none/.rvm/gems/ruby-2.3.0/gems/rspec-core-3.7.1/lib/rspec/core/runner.rb:100:in `setup'
# /home/none/.rvm/gems/ruby-2.3.0/gems/rspec-core-3.7.1/lib/rspec/core/runner.rb:86:in `run'
# /home/none/.rvm/gems/ruby-2.3.0/gems/rspec-core-3.7.1/lib/rspec/core/runner.rb:71:in `run'
# /home/none/.rvm/gems/ruby-2.3.0/gems/rspec-core-3.7.1/lib/rspec/core/runner.rb:45:in `invoke'
# /home/none/.rvm/gems/ruby-2.3.0/gems/rspec-core-3.7.1/exe/rspec:4:in `<top (required)>'
# /home/none/.rvm/gems/ruby-2.3.0/bin/rspec:23:in `load'
# /home/none/.rvm/gems/ruby-2.3.0/bin/rspec:23:in `<main>'
# /home/none/.rvm/gems/ruby-2.3.0/bin/ruby_executable_hooks:15:in `eval'
# /home/none/.rvm/gems/ruby-2.3.0/bin/ruby_executable_hooks:15:in `<main>'
# 
#   Showing full backtrace because every line was filtered out.
#   See docs for RSpec::Configuration#backtrace_exclusion_patterns and
#   RSpec::Configuration#backtrace_inclusion_patterns for more information.
...
```
