### PR TITLE
Promotion.eligible? is true even though PromotionAction.applicable? is false

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -129,6 +129,7 @@ module Spree
       # Promotions without rules are eligible by default.
       return [] if rules.none?
       specific_rules = rules.select { |rule| rule.applicable?(promotable) }
+      # Promotions with no appliable rules are not eligible.
       return nil if specific_rules.none?
 
       rule_eligibility = Hash[specific_rules.map do |rule|

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -129,7 +129,7 @@ module Spree
       # Promotions without rules are eligible by default.
       return [] if rules.none?
       specific_rules = rules.select { |rule| rule.applicable?(promotable) }
-      # Promotions with no appliable rules are not eligible.
+      # Promotions without applicable rules are not eligible.
       return nil if specific_rules.none?
 
       rule_eligibility = Hash[specific_rules.map do |rule|

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -129,7 +129,7 @@ module Spree
       # Promotions without rules are eligible by default.
       return [] if rules.none?
       specific_rules = rules.select { |rule| rule.applicable?(promotable) }
-      return [] if specific_rules.none?
+      return nil if specific_rules.none?
 
       rule_eligibility = Hash[specific_rules.map do |rule|
         [rule, rule.eligible?(promotable, options)]

--- a/core/spec/models/spree/promotion_handler/custom_promotion_spec.rb
+++ b/core/spec/models/spree/promotion_handler/custom_promotion_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+class CustomPromotionRule < Spree::PromotionRule
+  def applicable?(promotable)
+    false
+  end
+end
+
+module Spree
+  module PromotionHandler
+    describe Cart, type: :model do
+      let(:promotion) { Promotion.create(name: 'At line items') }
+      let(:line_item) { create(:line_item) }
+      let(:order) { line_item.order }
+      let(:rule) { CustomPromotionRule.create(promotion: promotion) }
+
+      it 'should not be eligible' do
+        promotion.promotion_rules << rule
+        expect(promotion.eligible?(order)).to be false
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/promotion_handler/custom_promotion_spec.rb
+++ b/core/spec/models/spree/promotion_handler/custom_promotion_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 class CustomPromotionRule < Spree::PromotionRule
-  def applicable?(promotable)
+  def applicable?(_promotable)
     false
   end
 end
@@ -14,7 +14,7 @@ module Spree
       let(:order) { line_item.order }
       let(:rule) { CustomPromotionRule.create(promotion: promotion) }
 
-      it 'should not be eligible' do
+      it 'is not eligible' do
         promotion.promotion_rules << rule
         expect(promotion.eligible?(order)).to be false
       end


### PR DESCRIPTION
The problem is with the Promotion's `eligible?` method:

```
def eligible?(promotable)
  return false if expired? || usage_limit_exceeded?(promotable) || blacklisted?(promotable)
  !!eligible_rules(promotable, {})
end

def eligible_rules(promotable, options = {})
  # Promotions without rules are eligible by default.
  return [] if rules.none?
  specific_rules = rules.select { |rule| rule.applicable?(promotable) }
  return [] if specific_rules.none?
...
```

`eligible?` is returning `true` because `eligible_rules` is returning `[]` and `!![] == true`

It should be `nil` instead: `return nil if specific_rules.none?`
