### PR TITLE
Improve omnichannel support

### DIFF
--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -119,6 +119,13 @@
         </div>
 
         <div class="col-xs-12 col-md-4">
+          <div class="form-group">
+            <%= label_tag :q_channel_eq, Spree.t(:channel) %>
+            <%= f.select :channel_eq, Spree::Order.pluck('DISTINCT channel'), { include_blank: true }, class: 'select2 js-filterable' %>
+          </div>
+        </div>
+
+        <div class="col-xs-12 col-md-4">
 
           <div class="form-group">
 

--- a/backend/app/views/spree/admin/shared/_order_summary.html.erb
+++ b/backend/app/views/spree/admin/shared/_order_summary.html.erb
@@ -16,6 +16,12 @@
         </td>
       </tr>
       <tr>
+        <td data-hook='admin_order_tab_channel_title'>
+          <strong><%= Spree.t(:channel) %>:</strong>
+        </td>
+        <td id='order_channel'><%= @order.channel %></td>
+      </tr>
+      <tr>
         <td data-hook='admin_order_tab_subtotal_title'>
           <strong><%= Spree.t(:subtotal) %>:</strong>
         </td>

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -590,6 +590,21 @@ describe 'Order Details', type: :feature, js: true do
           end
         end
       end
+
+      context 'display order summary' do
+        before do
+          visit spree.cart_admin_order_path(order)
+        end
+
+        it 'contains elements' do
+          within('.additional-info') do
+            expect(page).to have_content('complete')
+            expect(page).to have_content('spree')
+            expect(page).to have_content('backorder')
+            expect(page).to have_content('balance due')
+          end
+        end
+      end
     end
   end
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -75,7 +75,7 @@ module Spree
     end
 
     self.whitelisted_ransackable_associations = %w[shipments user promotions bill_address ship_address line_items store]
-    self.whitelisted_ransackable_attributes = %w[completed_at email number state payment_state shipment_state total considered_risky]
+    self.whitelisted_ransackable_attributes = %w[completed_at email number state payment_state shipment_state total considered_risky channel]
 
     attr_reader :coupon_code
     attr_accessor :temporary_address, :temporary_credit_card

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -596,6 +596,7 @@ en:
       other: 'Subtotal (%{count} items)'
     categories: Categories
     category: Category
+    channel: Channel
     charged: Charged
     checkout: Checkout
     choose_a_customer: Choose a customer


### PR DESCRIPTION
Improve omnichannel support by adding a filter on orders list and displaying in orders summary
Fix #8888

Filter on orders list page:
<img width="1132" alt="zrzut ekranu 2018-07-12 o 12 11 52" src="https://user-images.githubusercontent.com/13647303/42627487-7b439e42-85cd-11e8-9743-a66864ccbfb5.png">

Orders details page:
<img width="842" alt="zrzut ekranu 2018-07-12 o 12 12 05" src="https://user-images.githubusercontent.com/13647303/42627479-73841b46-85cd-11e8-8fa3-f712152fb7a8.png">