### PR TITLE
Return guest_token in cookies for spree_auth dependency

### DIFF
--- a/core/lib/spree/core/controller_helpers/auth.rb
+++ b/core/lib/spree/core/controller_helpers/auth.rb
@@ -25,11 +25,11 @@ module Spree
         end
 
         def set_token
-          cookies.permanent.signed[:token] ||= cookies.delete(:guest_token)
           cookies.permanent.signed[:token] ||= {
             value:    generate_token,
             httponly: true
           }
+          cookies.permanent.signed[:guest_token] ||= cookies.permanent.signed[:token]
         end
 
         def store_location


### PR DESCRIPTION
Fix the problem with guest checkout after migrating from `guest_token` to `token`

Need to be merged with https://github.com/spree/spree_auth_devise/pull/438