### PR TITLE
Fix JS of selected filters in admin's filters

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -126,9 +126,20 @@ jQuery(function($) {
         ransack_value = $this.val();
       }
 
-      label = label.text() + ': ' + ransack_value;
-      filter = '<span class="js-filter label label-default" data-ransack-field="' + ransack_field + '">' + label + '<span class="icon icon-delete js-delete-filter"></span></span>';
+      function ransackField(value) {
+        switch (value) {
+          case 'Date Range':
+            return 'Start';
+          case '':
+            return 'Stop';
+          default:
+            return value.trim();
+        }
+      }
 
+      label = ransackField(label.text()) + ': ' + ransack_value;
+
+      filter = '<span class="js-filter label label-default" data-ransack-field="' + ransack_field + '">' + label + '<span class="icon icon-delete js-delete-filter"></span></span>';
       $(".js-filters").append(filter).show();
     }
   });

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -17,7 +17,7 @@
             <div class="row no-padding-bottom">
               <div class="col-xs-12 col-md-6">
                 <div class="input-group">
-                  <%= f.text_field :created_at_gt, class: 'datepicker datepicker-from form-control', value: params[:q][:created_at_gt], placeholder: Spree.t(:start) %>
+                  <%= f.text_field :created_at_gt, class: 'datepicker datepicker-from form-control js-filterable', value: params[:q][:created_at_gt], placeholder: Spree.t(:start) %>
                   <span class="input-group-addon">
                     <i class="icon icon-calendar"></i>
                   </span>
@@ -26,7 +26,7 @@
               </div>
               <div class="col-xs-12 col-md-6">
                 <div class="input-group">
-                  <%= f.text_field :created_at_lt, class: 'datepicker datepicker-to form-control', value: params[:q][:created_at_lt], placeholder: Spree.t(:stop) %>
+                  <%= f.text_field :created_at_lt, class: 'datepicker datepicker-to form-control js-filterable', value: params[:q][:created_at_lt], placeholder: Spree.t(:stop) %>
                   <span class="input-group-addon">
                     <i class="icon icon-calendar"></i>
                   </span>
@@ -39,7 +39,7 @@
         <div class="col-xs-12 col-md-4">
           <div class="form-group">
             <%= label_tag :q_number_cont, Spree.t(:order_number, number: '') %>
-            <%= f.text_field :number_cont, class: 'form-control js-quick-search-target' %>
+            <%= f.text_field :number_cont, class: 'form-control js-quick-search-target js-filterable' %>
           </div>
         </div>
 
@@ -75,14 +75,14 @@
         <div class="col-xs-12 col-md-4">
           <div class="form-group">
             <%= label_tag :q_bill_address_firstname_start, Spree.t(:first_name_begins_with) %>
-            <%= f.text_field :bill_address_firstname_start, class: 'form-control' %>
+            <%= f.text_field :bill_address_firstname_start, class: 'form-control js-filterable' %>
           </div>
         </div>
 
         <div class="col-xs-12 col-md-4">
           <div class="form-group">
             <%= label_tag :q_bill_address_lastname_start, Spree.t(:last_name_begins_with) %>
-            <%= f.text_field :bill_address_lastname_start, class: 'form-control' %>
+            <%= f.text_field :bill_address_lastname_start, class: 'form-control js-filterable' %>
           </div>
         </div>
 
@@ -100,21 +100,21 @@
         <div class="col-xs-12 col-md-4">
           <div class="form-group">
             <%= label_tag :q_line_items_variant_sku_eq, Spree.t(:sku) %>
-            <%= f.text_field :line_items_variant_sku_eq, class: 'form-control' %>
+            <%= f.text_field :line_items_variant_sku_eq, class: 'form-control js-filterable' %>
           </div>
         </div>
 
         <div class="col-xs-12 col-md-4">
           <div class="form-group">
             <%= label_tag :q_promotions_id_in, Spree.t(:promotion) %>
-            <%= f.select :promotions_id_in, Spree::Promotion.applied.pluck(:name, :id), { include_blank: true }, class: 'select2' %>
+            <%= f.select :promotions_id_in, Spree::Promotion.applied.pluck(:name, :id), { include_blank: true }, class: 'select2 js-filterable' %>
           </div>
         </div>
 
         <div class="col-xs-12 col-md-4">
           <div class="form-group">
             <%= label_tag :q_store_id_in, Spree.t(:store) %>
-            <%= f.select :store_id_in, Spree::Store.order("#{Spree::Store.table_name}.name").pluck(:name, :id), { include_blank: true }, class: 'select2' %>
+            <%= f.select :store_id_in, Spree::Store.order("#{Spree::Store.table_name}.name").pluck(:name, :id), { include_blank: true }, class: 'select2 js-filterable' %>
           </div>
         </div>
 

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -15,13 +15,13 @@
         <div class="col-xs-12 col-md-6">
           <div class="form-group">
             <%= f.label :name_cont, Spree.t(:name) %>
-            <%= f.text_field :name_cont, size: 15, class: "form-control js-quick-search-target" %>
+            <%= f.text_field :name_cont, size: 15, class: "form-control js-quick-search-target js-filterable" %>
           </div>
         </div>
         <div class="col-xs-12 col-md-6">
           <div class="form-group">
             <%= f.label :variants_including_master_sku_cont, Spree.t(:sku) %>
-            <%= f.text_field :variants_including_master_sku_cont, size: 15, class: "form-control" %>
+            <%= f.text_field :variants_including_master_sku_cont, size: 15, class: "form-control js-filterable" %>
           </div>
         </div>
         <div class="col-xs-12 col-md-12">

--- a/backend/app/views/spree/admin/promotions/index.html.erb
+++ b/backend/app/views/spree/admin/promotions/index.html.erb
@@ -13,24 +13,24 @@
         <div class="col-xs-12 col-md-6">
           <div class="form-group">
             <%= label_tag :q_name_cont, Spree.t(:name) %>
-            <%= f.text_field :name_cont, tabindex: 1, class: "form-control js-quick-search-target" %>
+            <%= f.text_field :name_cont, tabindex: 1, class: "form-control js-quick-search-target js-filterable" %>
           </div>
 
           <div class="form-group">
             <%= label_tag :q_code_cont, Spree.t(:code) %>
-            <%= f.text_field :code_cont, tabindex: 1, class: "form-control" %>
+            <%= f.text_field :code_cont, tabindex: 1, class: "form-control js-filterable" %>
           </div>
         </div>
 
         <div class="col-xs-12 col-md-6">
           <div class="form-group">
             <%= label_tag :q_path_cont, Spree.t(:path) %>
-            <%= f.text_field :path_cont, tabindex: 1, class: "form-control" %>
+            <%= f.text_field :path_cont, tabindex: 1, class: "form-control js-filterable" %>
           </div>
 
           <div class="form-group">
             <%= label_tag :q_promotion_category_id_eq, Spree.t(:promotion_category) %>
-            <%= f.collection_select(:promotion_category_id_eq, @promotion_categories, :id, :name, { include_blank: Spree.t('match_choices.all') }, { class: 'select2' }) %>
+            <%= f.collection_select(:promotion_category_id_eq, @promotion_categories, :id, :name, { include_blank: Spree.t('match_choices.all') }, { class: 'select2 js-filterable' }) %>
           </div>
         </div>
       </div>

--- a/backend/app/views/spree/admin/properties/index.html.erb
+++ b/backend/app/views/spree/admin/properties/index.html.erb
@@ -16,14 +16,14 @@
         <div class="col-xs-12 col-md-6">
           <div data-hook="admin_property_index_search" class="form-group">
             <%= f.label :name_cont, Spree.t(:name) %>
-            <%= f.text_field :name_cont, class: "form-control js-quick-search-target" %>
+            <%= f.text_field :name_cont, class: "form-control js-quick-search-target js-filterable" %>
           </div>
         </div>
 
         <div class="col-xs-12 col-md-6">
           <div class="form-group">
             <%= f.label :presentation_cont, Spree.t(:presentation) %>
-            <%= f.text_field :presentation_cont, class: "form-control" %>
+            <%= f.text_field :presentation_cont, class: "form-control js-filterable" %>
           </div>
         </div>
       </div>

--- a/backend/app/views/spree/admin/return_index/customer_returns.html.erb
+++ b/backend/app/views/spree/admin/return_index/customer_returns.html.erb
@@ -9,7 +9,7 @@
         <div class="col-xs-12">
           <div class="form-group">
             <%= f.label :number_cont, Spree.t(:number) %>
-            <%= f.text_field :number_cont, class: "form-control js-quick-search-target" %>
+            <%= f.text_field :number_cont, class: "form-control js-quick-search-target js-filterable" %>
           </div>
         </div>
       </div>

--- a/backend/app/views/spree/admin/return_index/return_authorizations.html.erb
+++ b/backend/app/views/spree/admin/return_index/return_authorizations.html.erb
@@ -21,13 +21,13 @@
         <div class="col-xs-12 col-md-6">
           <div class="form-group">
             <%= f.label :number_cont, Spree.t(:number) %>
-            <%= f.text_field :number_cont, class: "form-control js-quick-search-target" %>
+            <%= f.text_field :number_cont, class: "form-control js-quick-search-target js-filterable" %>
           </div>
         </div>
         <div class="col-xs-12 col-md-6">
           <div class="form-group">
             <%= label_tag :q_state_eq, Spree.t(:status) %>
-            <%= f.select :state_eq, Spree::ReturnAuthorization.state_machines[:state].states.collect {|s| [Spree.t("return_authorization_states.#{s.name}"), s.value]}, {include_blank: true}, class: 'select2' %>
+            <%= f.select :state_eq, Spree::ReturnAuthorization.state_machines[:state].states.collect {|s| [Spree.t("return_authorization_states.#{s.name}"), s.value]}, {include_blank: true}, class: 'select2 js-filterable' %>
           </div>
         </div>
       </div>

--- a/backend/app/views/spree/admin/users/index.html.erb
+++ b/backend/app/views/spree/admin/users/index.html.erb
@@ -14,26 +14,26 @@
   <div data-hook="admin_users_index_search">
     <%= search_form_for [:admin, @search], url: spree.admin_users_url do |f| %>
       <div class="form-group">
-        <%= f.label Spree.t(:email) %>
-        <%= f.text_field :email_cont, class: "form-control js-quick-search-target" %>
+        <%= f.label :email_cont, Spree.t(:email) %>
+        <%= f.text_field :email_cont, class: "form-control js-quick-search-target js-filterable" %>
       </div>
       <div class="row">
         <div class="col-xs-12 col-md-6">
           <div class="form-group">
-            <%= f.label Spree.t(:first_name) %>
-            <%= f.text_field :bill_address_firstname_cont, class: 'form-control' %>
+            <%= f.label :bill_address_firstname_cont, Spree.t(:first_name) %>
+            <%= f.text_field :bill_address_firstname_cont, class: 'form-control js-filterable' %>
           </div>
         </div>
         <div class="col-xs-12 col-md-6">
           <div class="form-group">
-            <%= f.label Spree.t(:last_name) %>
-            <%= f.text_field :bill_address_lastname_cont, class: 'form-control' %>
+            <%= f.label :bill_address_lastname_cont, Spree.t(:last_name) %>
+            <%= f.text_field :bill_address_lastname_cont, class: 'form-control js-filterable' %>
           </div>
         </div>
       </div>
       <div class="form-group">
-        <%= f.label Spree.t(:company) %>
-        <%= f.text_field :bill_address_company_cont, class: 'form-control' %>
+        <%= f.label :bill_address_company_cont, Spree.t(:company) %>
+        <%= f.text_field :bill_address_company_cont, class: 'form-control js-filterable' %>
       </div>
       <div data-hook="admin_users_index_search_buttons" class="form-actions">
         <%= button Spree.t(:search), 'search' %>

--- a/backend/spec/features/admin/orders/listing_spec.rb
+++ b/backend/spec/features/admin/orders/listing_spec.rb
@@ -221,5 +221,53 @@ describe 'Orders Listing', type: :feature do
         expect(current_url).to match(/per_page\=60/)
       end
     end
+
+    context 'filtering orders', js: true do
+      let(:promotion) { create(:promotion_with_item_adjustment) }
+
+      before do
+        order1.promotions << promotion
+        order1.save
+        visit spree.admin_orders_path
+      end
+
+      it 'renders selected filters' do
+        click_on 'Filter'
+
+        within('#table-filter') do
+          fill_in 'q_created_at_gt', with: '2018/01/01'
+          fill_in 'q_created_at_lt', with: '2018/06/30'
+          fill_in 'q_number_cont', with: 'R100'
+          select 'cart', from: 'q_state_eq'
+          select 'paid', from: 'q_payment_state_eq'
+          select 'pending', from: 'q_shipment_state_eq'
+          fill_in 'q_bill_address_firstname_start', with: 'John'
+          fill_in 'q_bill_address_lastname_start', with: 'Smith'
+          fill_in 'q_email_cont', with: 'john_smith@example.com'
+          fill_in 'q_line_items_variant_sku_eq', with: 'BAG-00001'
+          select 'Promo', from: 'q_promotions_id_in'
+          select 'Spree Test Store', from: 'q_store_id_in'
+          select 'spree', from: 'q_channel_eq'
+        end
+
+        click_on 'Filter Results'
+
+        within('.table-active-filters') do
+          expect(page).to have_content('Start: 2018/01/01')
+          expect(page).to have_content('Stop: 2018/06/30')
+          expect(page).to have_content('Order: R100')
+          expect(page).to have_content('Status: cart')
+          expect(page).to have_content('Payment State: paid')
+          expect(page).to have_content('Shipment State: pending')
+          expect(page).to have_content('First Name Begins With: John')
+          expect(page).to have_content('Last Name Begins With: Smith')
+          expect(page).to have_content('Email: john_smith@example.com')
+          expect(page).to have_content('SKU: BAG-00001')
+          expect(page).to have_content('Promotion: Promo')
+          expect(page).to have_content('Store: Spree Test Store')
+          expect(page).to have_content('Channel: spree')
+        end
+      end
+    end
   end
 end

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -418,6 +418,26 @@ describe 'Products', type: :feature do
         expect(find('#product_price').value.to_f).to eq(product.price.to_f)
       end
     end
+
+    context 'filtering products', js: true do
+      it 'renders selected filters' do
+        visit spree.admin_products_path
+
+        click_on 'Filter'
+
+        within('#table-filter') do
+          fill_in 'q_name_cont', with: 'Backpack'
+          fill_in 'q_variants_including_master_sku_cont', with: 'BAG-00001'
+        end
+
+        click_on 'Search'
+
+        within('.table-active-filters') do
+          expect(page).to have_content('Name: Backpack')
+          expect(page).to have_content('SKU: BAG-00001')
+        end
+      end
+    end
   end
 
   context 'with only product permissions' do

--- a/backend/spec/features/admin/products/properties_spec.rb
+++ b/backend/spec/features/admin/products/properties_spec.rb
@@ -37,6 +37,22 @@ describe 'Properties', type: :feature, js: true do
         expect(page).to have_content('shirt size')
         expect(page).not_to have_content('shirt fit')
       end
+
+      it 'renders selected filters' do
+        click_on 'Filter'
+
+        within('#table-filter') do
+          fill_in 'q_name_cont', with: 'color'
+          fill_in 'q_presentation_cont', with: 'shade'
+        end
+
+        click_on 'Search'
+
+        within('.table-active-filters') do
+          expect(page).to have_content('Name: color')
+          expect(page).to have_content('Presentation: shade')
+        end
+      end
     end
   end
 

--- a/backend/spec/features/admin/promotions/adjustments_spec.rb
+++ b/backend/spec/features/admin/promotions/adjustments_spec.rb
@@ -255,4 +255,30 @@ describe 'Promotion Adjustments', type: :feature, js: true do
       expect(first_action.calculator.preferred_amount).to eq(5)
     end
   end
+
+  context 'filtering promotions' do
+    let!(:promotion_category) { create(:promotion_category, name: 'Welcome Category') }
+
+    it 'renders selected filters' do
+      visit spree.admin_promotions_path
+
+      click_on 'Filter'
+
+      within('#table-filter') do
+        fill_in 'q_name_cont', with: 'welcome'
+        fill_in 'q_code_cont', with: 'rx01welcome'
+        fill_in 'q_path_cont', with: 'path_promo'
+        select 'Welcome Category', from: 'q_promotion_category_id_eq'
+      end
+
+      click_on 'Filter Results'
+
+      within('.table-active-filters') do
+        expect(page).to have_content('Name: welcome')
+        expect(page).to have_content('Code: rx01welcome')
+        expect(page).to have_content('Path: path_promo')
+        expect(page).to have_content('Promotion Category: Welcome Category')
+      end
+    end
+  end
 end

--- a/backend/spec/features/admin/returns/customer_returns_spec.rb
+++ b/backend/spec/features/admin/returns/customer_returns_spec.rb
@@ -40,9 +40,11 @@ describe 'Customer Returns', type: :feature do
   describe 'searching' do
     let!(:customer_return_2) { create(:customer_return) }
 
-    it 'searches on number' do
+    before do
       visit spree.admin_customer_returns_path
+    end
 
+    it 'searches on number' do
       click_on 'Filter'
       fill_in 'q_number_cont', with: customer_return.number
       click_on 'Search'
@@ -56,6 +58,20 @@ describe 'Customer Returns', type: :feature do
 
       expect(page).to have_content(customer_return_2.number)
       expect(page).not_to have_content(customer_return.number)
+    end
+
+    it 'renders selected filters', js: true do
+      click_on 'Filter'
+
+      within('#table-filter') do
+        fill_in 'q_number_cont', with: 'RX001-01'
+      end
+
+      click_on 'Search'
+
+      within('.table-active-filters') do
+        expect(page).to have_content('Number: RX001-01')
+      end
     end
   end
 

--- a/backend/spec/features/admin/returns/return_authorizations_spec.rb
+++ b/backend/spec/features/admin/returns/return_authorizations_spec.rb
@@ -38,9 +38,11 @@ describe 'Return Authorizations', type: :feature do
     let!(:return_authorization) { create(:return_authorization, state: 'authorized') }
     let!(:return_authorization_2) { create(:return_authorization, state: 'canceled') }
 
-    it 'searches on number' do
+    before do
       visit spree.admin_return_authorizations_path
+    end
 
+    it 'searches on number' do
       click_on 'Filter'
       fill_in 'q_number_cont', with: return_authorization.number
       click_on 'Search'
@@ -57,8 +59,6 @@ describe 'Return Authorizations', type: :feature do
     end
 
     it 'searches on status' do
-      visit spree.admin_return_authorizations_path
-
       click_on 'Filter'
       select Spree.t("return_authorization_states.#{return_authorization.state}"), from: 'Status'
       click_on 'Search'
@@ -72,6 +72,22 @@ describe 'Return Authorizations', type: :feature do
 
       expect(page).to have_content(return_authorization_2.number)
       expect(page).not_to have_content(return_authorization.number)
+    end
+
+    it 'renders selected filters', js: true do
+      click_on 'Filter'
+
+      within('#table-filter') do
+        fill_in 'q_number_cont', with: 'RX001-01'
+        select 'Authorized', from: 'q_state_eq'
+      end
+
+      click_on 'Search'
+
+      within('.table-active-filters') do
+        expect(page).to have_content('Number: RX001-01')
+        expect(page).to have_content('Status: Authorized')
+      end
     end
   end
 

--- a/backend/spec/features/admin/users_spec.rb
+++ b/backend/spec/features/admin/users_spec.rb
@@ -98,6 +98,28 @@ describe 'Users', type: :feature do
         expect(page).not_to have_text user_b.email
       end
     end
+
+    context 'filtering users', js: true do
+      it 'renders selected filters' do
+        click_on 'Filter'
+
+        within('#table-filter') do
+          fill_in 'q_email_cont', with: 'a@example.com'
+          fill_in 'q_bill_address_firstname_cont', with: 'John'
+          fill_in 'q_bill_address_lastname_cont', with: 'Doe'
+          fill_in 'q_bill_address_company_cont', with: 'Company'
+        end
+
+        click_on 'Search'
+
+        within('.table-active-filters') do
+          expect(page).to have_content('Email: a@example.com')
+          expect(page).to have_content('First Name: John')
+          expect(page).to have_content('Last Name: Doe')
+          expect(page).to have_content('Company: Company')
+        end
+      end
+    end
   end
 
   context 'editing users' do


### PR DESCRIPTION
Found the issue when working on this: https://github.com/spree/spree/pull/8892
Fix includes all filters across admin panel. All applied filters should look like that:
<img width="1148" alt="zrzut ekranu 2018-07-16 o 15 47 33" src="https://user-images.githubusercontent.com/13647303/42762244-1464d0ec-8910-11e8-842a-df870424d37b.png">
