### PR TITLE
Place radio buttons before credit cards, not after, on Payment step in Checkout

### DIFF
--- a/frontend/app/views/spree/checkout/_payment.html.erb
+++ b/frontend/app/views/spree/checkout/_payment.html.erb
@@ -21,12 +21,12 @@
             <tbody>
               <% @payment_sources.each do |card| %>
                 <tr id="<%= dom_id(card,'spree')%>" class="<%= cycle('even', 'odd') %>">
-                  <td><%= card.name %></td>
-                  <td><%= card.display_number %></td>
-                  <td><%= card.month %> / <%= card.year %></td>
                   <td>
                     <%= radio_button_tag "order[existing_card]", card.id, (card == @payment_sources.first), { class: "existing-cc-radio" }  %>
                   </td>
+                  <td><%= card.name %></td>
+                  <td><%= card.display_number %></td>
+                  <td><%= card.month %> / <%= card.year %></td>
                 </tr>
               <% end %>
             </tbody>


### PR DESCRIPTION
Fix #8890

<img width="866" alt="zrzut ekranu 2018-07-20 o 13 59 08" src="https://user-images.githubusercontent.com/13647303/43001341-3206a7e8-8c25-11e8-8fbf-b5987c2d781d.png">
