### PR TITLE
Change deprecated Address#same_as? to Address#==

### DIFF
--- a/backend/app/views/spree/admin/users/_addresses_form.html.erb
+++ b/backend/app/views/spree/admin/users/_addresses_form.html.erb
@@ -27,7 +27,7 @@
       <div class="panel-body">
           <p class="field checkbox" data-hook="use_billing">
             <%= label_tag :use_billing, id: 'use_billing' do %>
-              <% checked = @user.bill_address.nil? ? false : @user.bill_address.same_as?(@user.ship_address) %>
+              <% checked = @user.bill_address.nil? ? false : @user.bill_address == @user.ship_address %>
               <%= check_box_tag 'user[use_billing]', '1', checked %>
               <%= Spree.t(:use_billing_address) %>
             <% end %>

--- a/backend/spec/features/admin/users_spec.rb
+++ b/backend/spec/features/admin/users_spec.rb
@@ -187,7 +187,7 @@ describe 'Users', type: :feature do
         click_button 'Update'
       end
 
-      expect(user_a.reload.ship_address.same_as?(user_a.reload.bill_address)).to eq true
+      expect(user_a.reload.ship_address == user_a.reload.bill_address).to eq true
     end
 
     context 'no api key exists' do


### PR DESCRIPTION
Due to deprecation of method in Spree 4.0