### PR TITLE
Update version of fast_jsonapi gem

### DIFF
--- a/api/app/serializers/spree/v2/storefront/product_property_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/product_property_serializer.rb
@@ -6,13 +6,8 @@ module Spree
 
         attribute :value
 
-        attribute :name do |product_property|
-          product_property.property_name
-        end
-
-        attribute :description do |product_property|
-          product_property.property_presentation
-        end
+        attribute :name,        &:property_name
+        attribute :description, &:property_presentation
       end
     end
   end

--- a/api/app/serializers/spree/v2/storefront/product_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/product_serializer.rb
@@ -8,17 +8,9 @@ module Spree
                    :available_on, :slug, :meta_description, :meta_keywords,
                    :updated_at
 
-        attribute :purchasable do |product|
-          product.purchasable?
-        end
-
-        attribute :in_stock do |product|
-          product.in_stock?
-        end
-
-        attribute :backorderable do |product|
-          product.backorderable?
-        end
+        attribute :purchasable,   &:purchasable?
+        attribute :in_stock,      &:in_stock?
+        attribute :backorderable, &:backorderable?
 
         has_many :variants
         has_many :option_types

--- a/api/app/serializers/spree/v2/storefront/taxon_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/taxon_serializer.rb
@@ -7,17 +7,9 @@ module Spree
         attributes :name, :pretty_name, :permalink, :seo_title, :meta_title, :meta_description,
                    :meta_keywords, :left, :right, :position, :depth, :updated_at
 
-        attribute :is_root do |taxon|
-          taxon.root?
-        end
-
-        attribute :is_child do |taxon|
-          taxon.child?
-        end
-
-        attribute :is_leaf do |taxon|
-          taxon.leaf?
-        end
+        attribute :is_root,  &:root?
+        attribute :is_child, &:child?
+        attribute :is_leaf,  &:leaf?
 
         belongs_to :parent,   record_type: :taxon, serializer: :taxon
         belongs_to :taxonomy, record_type: :taxonomy

--- a/api/app/serializers/spree/v2/storefront/variant_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/variant_serializer.rb
@@ -8,17 +8,9 @@ module Spree
                    :width, :depth, :is_master, :options_text, :slug, :description,
                    :track_inventory
 
-        attribute :purchasable do |variant|
-          variant.purchasable?
-        end
-
-        attribute :in_stock do |variant|
-          variant.in_stock?
-        end
-
-        attribute :backorderable do |variant|
-          variant.backorderable?
-        end
+        attribute :purchasable,   &:purchasable?
+        attribute :in_stock,      &:in_stock?
+        attribute :backorderable, &:backorderable?
 
         has_many :images
       end

--- a/api/spree_api.gemspec
+++ b/api/spree_api.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_core', s.version
   s.add_dependency 'rabl', '~> 0.13.1'
   s.add_dependency 'versioncake', '~> 3.4.0'
-  s.add_dependency 'fast_jsonapi', '~> 1.2.0'
+  s.add_dependency 'fast_jsonapi', '~> 1.3.0'
   s.add_dependency 'doorkeeper'
 end


### PR DESCRIPTION
Update version of fast_jsonapi gem from '1.2' to '1.3'. Change syntax due to new version.