### PR TITLE
Allow options to be sent to shipment transfer

### DIFF
--- a/api/app/controllers/spree/api/v1/shipments_controller.rb
+++ b/api/app/controllers/spree/api/v1/shipments_controller.rb
@@ -84,7 +84,7 @@ module Spree
             return
           end
 
-          @original_shipment.transfer_to_location(@variant, @quantity, @stock_location)
+          @original_shipment.transfer_to_location(@variant, @quantity, @stock_location, @options)
           render json: { success: true, message: Spree.t(:shipment_transfer_success) }, status: 201
         end
 
@@ -103,7 +103,7 @@ module Spree
           if error
             unprocessable_entity("#{Spree.t(:shipment_transfer_errors_occured, scope: 'api')} \n#{error}")
           else
-            @original_shipment.transfer_to_shipment(@variant, @quantity, @target_shipment)
+            @original_shipment.transfer_to_shipment(@variant, @quantity, @target_shipment, @options)
             render json: { success: true, message: Spree.t(:shipment_transfer_success) }, status: 201
           end
         end
@@ -114,6 +114,7 @@ module Spree
           @original_shipment         = Spree::Shipment.find_by!(number: params[:original_shipment_number])
           @variant                   = Spree::Variant.find(params[:variant_id])
           @quantity                  = params[:quantity].to_i
+          @options                   = params[:options] || {}
           authorize! :read, @original_shipment
           authorize! :create, Shipment
         end


### PR DESCRIPTION
Looking for some feedback here.  I can make this change to master too.  I had branched off the 3-6-stable branch so that is why it is going into that branch and master is a bit different but still has this issue.

This change makes it so you can pass an options hash to the ```transfer_to_shipment``` and ```transfer_to_location``` methods.

It seems weird that you can pass options when you are adding a product to an order but if you transfer the item to a different shipment location you lose any custom data you have on the LineItem object due to the fact that the LineItem is not moved but rather removed and added.

By allowing an options hash to be passed in you just mimic the front end functionality