### PR TITLE
State change's spree scope mistake

### DIFF
--- a/backend/app/views/spree/admin/state_changes/index.html.erb
+++ b/backend/app/views/spree/admin/state_changes/index.html.erb
@@ -21,8 +21,8 @@
       <% @state_changes.each do |state_change| %>
         <tr>
           <td><%= Spree.t("state_machine_states.#{state_change.name}") %></td>
-          <td><%= state_change.previous_state ? Spree.t(state_change.previous_state, scope: "#{ state_change.name }_state") : Spree.t(:previous_state_missing) %></td>
-          <td><%= Spree.t(state_change.next_state, scope: "#{ state_change.name }_state") %></td>
+          <td><%= state_change.previous_state ? Spree.t(state_change.previous_state, scope: "#{ state_change.name }_states") : Spree.t(:previous_state_missing) %></td>
+          <td><%= Spree.t(state_change.next_state, scope: "#{ state_change.name }_states") %></td>
           <td>
             <% if state_change.user %>
               <% user_login = state_change.user.try(:login) || state_change.user.try(:email) %>


### PR DESCRIPTION
It should be `scope: "#{ state_change.name }_states")`  
not `scope: "#{ state_change.name }_state")`
<img width="250" alt="default" src="https://user-images.githubusercontent.com/22900392/44651079-f1f46f00-aa1a-11e8-820d-2db885e7c946.png">
<img width="272" alt="default" src="https://user-images.githubusercontent.com/22900392/44651096-00db2180-aa1b-11e8-98e8-44f956309e97.png">
