### PR TITLE
Remove conditional logic around acts_as_paranoid for calculators

### DIFF
--- a/core/app/models/spree/calculator.rb
+++ b/core/app/models/spree/calculator.rb
@@ -1,9 +1,6 @@
 module Spree
   class Calculator < Spree::Base
-    # Conditional check for backwards compatibilty since acts as paranoid was added late https://github.com/spree/spree/issues/5858
-    if ActiveRecord::Base.connected? && connection.data_source_exists?(:spree_calculators) && connection.column_exists?(:spree_calculators, :deleted_at)
-      acts_as_paranoid
-    end
+    acts_as_paranoid
 
     belongs_to :calculable, polymorphic: true, optional: true
 

--- a/core/db/migrate/20140309023735_migrate_old_preferences.rb
+++ b/core/db/migrate/20140309023735_migrate_old_preferences.rb
@@ -1,6 +1,10 @@
 class MigrateOldPreferences < ActiveRecord::Migration[4.2]
   def up
-    migrate_preferences(Spree::Calculator)
+    if Spree::Calculator.respond_to?(:with_deleted)
+      migrate_preferences(Spree::Calculator.with_deleted)
+    else
+      migrate_preferences(Spree::Calculator)
+    end
     migrate_preferences(Spree::PaymentMethod)
     migrate_preferences(Spree::PromotionRule)
   end


### PR DESCRIPTION
Fixes #8958 

I'd recommend backporting this to 3.1+

In order to make tests pass a check was required in a migration that migrated old Spree::Calculator preferences. Paranoia queries by where deleted_at is null in that migration otherwise, and the deleted_at column has actually not been added at that point in the migration process. 

Removing the conditional check for whether acts_as_paranoid is included makes sense here because all spree 3.1+ sites have the deleted_at column on the calculator table. This conditional initialization was not working on my site. I would like to hear from other store owners if they are able to reproduce the issue. I am able to reproduce the issue on the dummy app in core. 