### PR TITLE
fix: Replace all spaces to non-breaking onces

### DIFF
--- a/core/lib/spree/money.rb
+++ b/core/lib/spree/money.rb
@@ -34,9 +34,7 @@ module Spree
     # 2) prevent escaping of HTML character entities
     def to_html(opts = { html: true })
       output = money.format(options.merge(opts))
-      output = output.sub(' ', '&nbsp;').html_safe if opts[:html]
-
-      output
+      output.gsub(' ', '&nbsp;').html_safe if opts[:html]
     end
 
     def as_json(*)


### PR DESCRIPTION
It allows us to fix the problem with breaking an amount with currency name

Before:
```
10 000,00
Kč
```
After:
```
10 000,00 Kč
```