### PR TITLE
Fix product's variant's images's alt attribute's value displayed on frontend

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -91,7 +91,7 @@ module Spree
     private
 
     def create_product_image_tag(image, product, options, style)
-      options.reverse_merge! alt: image.alt.blank? ? product.name : image.alt
+      options.merge! alt: image.alt.blank? ? product.name : image.alt
       image_tag main_app.url_for(image.url(style)), options
     end
 

--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -91,7 +91,7 @@ module Spree
     private
 
     def create_product_image_tag(image, product, options, style)
-      options.merge! alt: image.alt.blank? ? product.name : image.alt
+      options[:alt] = image.alt.blank? ? product.name : image.alt
       image_tag main_app.url_for(image.url(style)), options
     end
 

--- a/frontend/app/assets/javascripts/spree/frontend/product.js
+++ b/frontend/app/assets/javascripts/spree/frontend/product.js
@@ -9,6 +9,7 @@ Spree.ready(function ($) {
     thumbnails.find("a").on("click", function (event) {
       ($("#main-image")).data("selectedThumb", ($(event.currentTarget)).attr("href"));
       ($("#main-image")).data("selectedThumbId", ($(event.currentTarget)).parent().attr("id"));
+      ($("#main-image")).data("selectedThumbAlt", ($(event.currentTarget)).find("img").attr("alt"));
       thumbnails.find("li").removeClass("selected");
       ($(event.currentTarget)).parent("li").addClass("selected");
       return false;

--- a/frontend/app/assets/javascripts/spree/frontend/product.js
+++ b/frontend/app/assets/javascripts/spree/frontend/product.js
@@ -3,6 +3,7 @@ Spree.ready(function ($) {
   Spree.addImageHandlers = function () {
     var thumbnails = $("#product-images ul.thumbnails");
     ($("#main-image")).data("selectedThumb", ($("#main-image img")).attr("src"));
+    ($("#main-image")).data("selectedThumbAlt", ($("#main-image img")).attr("alt"));
     thumbnails.find("li").eq(0).addClass("selected");
 
     thumbnails.find("a").on("click", function (event) {
@@ -14,11 +15,11 @@ Spree.ready(function ($) {
     });
 
     thumbnails.find("li").on("mouseenter", function (event) {
-      return ($("#main-image img")).attr("src", ($(event.currentTarget)).find("a").attr("href"));
+      return ($("#main-image img")).attr({"src": ($(event.currentTarget)).find("a").attr("href"), "alt": ($(event.currentTarget)).find("img").attr("alt")});
     });
 
     return thumbnails.find("li").on("mouseleave", function (event) {
-      return ($("#main-image img")).attr("src", ($("#main-image")).data("selectedThumb"));
+      return ($("#main-image img")).attr({"src": ($("#main-image")).data("selectedThumb"), "alt": ($("#main-image")).data("selectedThumbAlt")});
     });
   };
 
@@ -34,11 +35,12 @@ Spree.ready(function ($) {
         thumb = $(($("#product-images ul.thumbnails li:visible")).eq(0));
       }
 
-      var newImg = thumb.find("a").attr("href");
+      var newImg = thumb.find("a").attr("href"),
+          newAlt = thumb.find('img').attr('alt');
       ($("#product-images ul.thumbnails li")).removeClass("selected");
       thumb.addClass("selected");
-      ($("#main-image img")).attr("src", newImg);
-      ($("#main-image")).data("selectedThumb", newImg);
+      ($("#main-image img")).attr({"src": newImg, "alt": newAlt});
+      ($("#main-image")).data({"selectedThumb": newImg, "selectedThumbAlt": newAlt});
       return ($("#main-image")).data("selectedThumbId", thumb.attr("id"));
     }
   };

--- a/frontend/app/assets/javascripts/spree/frontend/product.js
+++ b/frontend/app/assets/javascripts/spree/frontend/product.js
@@ -15,11 +15,13 @@ Spree.ready(function ($) {
     });
 
     thumbnails.find("li").on("mouseenter", function (event) {
-      return ($("#main-image img")).attr({"src": ($(event.currentTarget)).find("a").attr("href"), "alt": ($(event.currentTarget)).find("img").attr("alt")});
+      return ($("#main-image img"))
+        .attr({"src": ($(event.currentTarget)).find("a").attr("href"), "alt": ($(event.currentTarget)).find("img").attr("alt")});
     });
 
     return thumbnails.find("li").on("mouseleave", function (event) {
-      return ($("#main-image img")).attr({"src": ($("#main-image")).data("selectedThumb"), "alt": ($("#main-image")).data("selectedThumbAlt")});
+      return ($("#main-image img"))
+        .attr({"src": ($("#main-image")).data("selectedThumb"), "alt": ($("#main-image")).data("selectedThumbAlt")});
     });
   };
 
@@ -36,7 +38,7 @@ Spree.ready(function ($) {
       }
 
       var newImg = thumb.find("a").attr("href"),
-          newAlt = thumb.find('img').attr('alt');
+          newAlt = thumb.find("img").attr("alt");
       ($("#product-images ul.thumbnails li")).removeClass("selected");
       thumb.addClass("selected");
       ($("#main-image img")).attr({"src": newImg, "alt": newAlt});

--- a/frontend/app/helpers/spree/frontend_helper.rb
+++ b/frontend/app/helpers/spree/frontend_helper.rb
@@ -94,5 +94,9 @@ module Spree
         safe_join(taxons, "\n")
       end
     end
+
+    def set_image_alt(image, size)
+      image.alt.present? ? image.alt : image_alt(main_app.url_for(image.url(size)))
+    end
   end
 end

--- a/frontend/app/views/spree/products/_thumbnails.html.erb
+++ b/frontend/app/views/spree/products/_thumbnails.html.erb
@@ -3,7 +3,8 @@
   <ul id="product-thumbnails" class="thumbnails list-inline" data-hook>
     <% @product.images.each do |i| %>
       <li class='tmb-all tmb-<%= i.viewable.id %>'>
-        <%= link_to(image_tag(main_app.url_for(i.url(:mini)), class: "thumbnail"), main_app.url_for(i.url(:product))) %>
+        <% img_tag = i.alt.present? ? image_tag(main_app.url_for(i.url(:mini)), class: "thumbnail", alt: i.alt) : image_tag(main_app.url_for(i.url(:mini)), class: "thumbnail", alt: image_alt(main_app.url_for(i.url(:mini)))) %>
+        <%= link_to(img_tag, main_app.url_for(i.url(:product))) %>
       </li>
     <% end %>
 
@@ -11,7 +12,8 @@
       <% @product.variant_images.each do |i| %>
         <% next if @product.images.include?(i) %>
         <li class='vtmb tmb-<%= i.viewable.id %>'>
-          <%= link_to(image_tag(main_app.url_for(i.url(:mini)), class: "thumbnail"), main_app.url_for(i.url(:product))) %>
+          <% img_tag = i.alt.present? ? image_tag(main_app.url_for(i.url(:mini)), class: "thumbnail", alt: i.alt) : image_tag(main_app.url_for(i.url(:mini)), class: "thumbnail", alt: image_alt(main_app.url_for(i.url(:mini)))) %>
+          <%= link_to(img_tag, main_app.url_for(i.url(:product))) %>
         </li>
       <% end %>
     <% end %>

--- a/frontend/app/views/spree/products/_thumbnails.html.erb
+++ b/frontend/app/views/spree/products/_thumbnails.html.erb
@@ -3,7 +3,7 @@
   <ul id="product-thumbnails" class="thumbnails list-inline" data-hook>
     <% @product.images.each do |i| %>
       <li class='tmb-all tmb-<%= i.viewable.id %>'>
-        <% img_tag = i.alt.present? ? image_tag(main_app.url_for(i.url(:mini)), class: "thumbnail", alt: i.alt) : image_tag(main_app.url_for(i.url(:mini)), class: "thumbnail", alt: image_alt(main_app.url_for(i.url(:mini)))) %>
+        <% img_tag = image_tag(main_app.url_for(i.url(:mini)), class: "thumbnail", alt: set_image_alt(i, :mini)) %>
         <%= link_to(img_tag, main_app.url_for(i.url(:product))) %>
       </li>
     <% end %>
@@ -12,7 +12,7 @@
       <% @product.variant_images.each do |i| %>
         <% next if @product.images.include?(i) %>
         <li class='vtmb tmb-<%= i.viewable.id %>'>
-          <% img_tag = i.alt.present? ? image_tag(main_app.url_for(i.url(:mini)), class: "thumbnail", alt: i.alt) : image_tag(main_app.url_for(i.url(:mini)), class: "thumbnail", alt: image_alt(main_app.url_for(i.url(:mini)))) %>
+          <% img_tag = image_tag(main_app.url_for(i.url(:mini)), class: "thumbnail", alt: set_image_alt(i, :mini)) %>
           <%= link_to(img_tag, main_app.url_for(i.url(:product))) %>
         </li>
       <% end %>


### PR DESCRIPTION
Currently alt attribute's value being displayed in image tag for product and it's variant images is the product's master variant's image's name even if image's **alt** field is present.

So, in this fix if any product or it's variant's image's **alt** field is present then that will be used instead.