### PR TITLE
Falllback to order.currency if there's no currency set for Adjustment

### DIFF
--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -88,7 +88,7 @@ module Spree
     end
 
     def currency
-      adjustable ? adjustable.currency : Spree::Config[:currency]
+      adjustable ? adjustable.currency : order.currency
     end
 
     def promotion?

--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -135,8 +135,10 @@ describe Spree::Adjustment, type: :model do
   end
 
   context '#currency' do
-    it 'returns the globally configured currency' do
-      expect(adjustment.currency).to eq 'USD'
+    let(:order) { Spree::Order.new(currency: 'EUR') }
+
+    it 'returns the order currency' do
+      expect(adjustment.currency).to eq 'EUR'
     end
   end
 


### PR DESCRIPTION
Order currency is mandatory and we should reuse. We should move away from the global `Spree::Config[:currency]`