### PR TITLE
Get attributes by flatten array in cart - compatibility issue

### DIFF
--- a/core/app/services/spree/cart/add_item.rb
+++ b/core/app/services/spree/cart/add_item.rb
@@ -18,7 +18,7 @@ module Spree
 
         line_item_created = line_item.nil?
         if line_item.nil?
-          opts = ::Spree::PermittedAttributes.line_item_attributes.each_with_object({}) do |attribute, result|
+          opts = ::Spree::PermittedAttributes.line_item_attributes.flatten.each_with_object({}) do |attribute, result|
             result[attribute] = options[attribute]
           end.merge(currency: order.currency).delete_if { |_key, value| value.nil? }
 


### PR DESCRIPTION
If someone wants to add permitted attributes, not overwrites them, its possible to have an array in array.
That was working in 3.1 (`ActionController::Parameters.new(options)`).