### PR TITLE
Remove deprecated EmailValidator

### DIFF
--- a/core/lib/spree/core/validators/email.rb
+++ b/core/lib/spree/core/validators/email.rb
@@ -1,8 +1,0 @@
-class EmailValidator < ActiveModel::EachValidator
-  def validate_each(record, attribute, value)
-    warn "`EmailValidator` in 'lib/spree/core' is deprecated. Use `EmailValidator` in 'app/validators' instead."
-    unless value =~ /\A[^@\s]+@[^@\s]+\z/
-      record.errors.add(attribute, :invalid, { value: value }.merge!(options))
-    end
-  end
-end


### PR DESCRIPTION
This was moved to `app/validators` via https://github.com/spree/spree/commit/cf373814419d07beb4653910eefba9e9a208c24a