### PR TITLE
Don't use Spree::Order.register_line_item_comparison_hook in specs

### DIFF
--- a/core/spec/models/spree/order_merger_spec.rb
+++ b/core/spec/models/spree/order_merger_spec.rb
@@ -44,7 +44,7 @@ module Spree
 
     context 'merging using extension-specific line_item_comparison_hooks' do
       before do
-        Spree::Order.register_line_item_comparison_hook(:foos_match)
+        Rails.application.config.spree.line_item_comparison_hooks << :foos_match
         allow(Spree::Variant).to receive(:price_modifier_amount).and_return(0.00)
       end
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -559,7 +559,7 @@ describe Spree::Order, type: :model do
 
     context 'match line item with options' do
       before do
-        Spree::Order.register_line_item_comparison_hook(:foos_match)
+        Rails.application.config.spree.line_item_comparison_hooks << :foos_match
       end
 
       after do


### PR DESCRIPTION
This was deprecated via https://github.com/spree/spree/commit/0a525ccab9ea0bc52cc4e249d53b38df6f231691