### PR TITLE
Backport removal of conditional logic for Calculator

### DIFF
--- a/core/app/models/spree/calculator.rb
+++ b/core/app/models/spree/calculator.rb
@@ -1,9 +1,6 @@
 module Spree
   class Calculator < Spree::Base
-    # Conditional check for backwards compatibilty since acts as paranoid was added late https://github.com/spree/spree/issues/5858
-    if connection.data_source_exists?(:spree_calculators) && connection.column_exists?(:spree_calculators, :deleted_at)
-      acts_as_paranoid
-    end
+    acts_as_paranoid
 
     belongs_to :calculable, polymorphic: true
 

--- a/core/app/models/spree/preferences/store.rb
+++ b/core/app/models/spree/preferences/store.rb
@@ -86,7 +86,11 @@ module Spree::Preferences
     end
 
     def should_persist?
-      @persistence and Spree::Preference.table_exists?
+      if ENV['DISABLE_DB_CONNECTION'].present?
+        false
+      else
+        @persistence and Spree::Preference.table_exists?
+      end
     end
 
   end

--- a/core/db/migrate/20140309023735_migrate_old_preferences.rb
+++ b/core/db/migrate/20140309023735_migrate_old_preferences.rb
@@ -1,6 +1,10 @@
 class MigrateOldPreferences < ActiveRecord::Migration[4.2]
   def up
-    migrate_preferences(Spree::Calculator)
+    if Spree::Calculator.respond_to?(:with_deleted)
+      migrate_preferences(Spree::Calculator.with_deleted)
+    else
+      migrate_preferences(Spree::Calculator)
+    end
     migrate_preferences(Spree::PaymentMethod)
     migrate_preferences(Spree::PromotionRule)
   end


### PR DESCRIPTION
This logic is causing havoc for using spree in docker, as every command line task requires a database connection.