### PR TITLE
Ensure payment source persistence

### DIFF
--- a/api/spec/controllers/spree/api/v1/checkouts_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/checkouts_controller_spec.rb
@@ -184,6 +184,7 @@ module Spree
       end
 
       it 'can update payment method and transition from payment to confirm' do
+        allow_any_instance_of(Spree::PaymentMethod).to receive(:source_required?).and_return(false)
         order.update_column(:state, 'payment')
         api_put :update, id: order.to_param, order_token: order.token,
                          order: { payments_attributes: [{ payment_method_id: @payment_method.id }] }
@@ -204,8 +205,7 @@ module Spree
         }
 
         api_put :update, id: order.to_param, order_token: order.token,
-                         order: { payments_attributes: [{ payment_method_id: @payment_method.id.to_s }],
-                                  payment_source: { @payment_method.id.to_s => source_attributes } }
+                         order: { payments_attributes: [{ payment_method_id: @payment_method.id.to_s, source_attributes: source_attributes }] }
         expect(json_response['payments'][0]['payment_method']['name']).to eq(@payment_method.name)
         expect(json_response['payments'][0]['amount']).to eq(order.total.to_s)
         expect(response.status).to eq(200)

--- a/api/spec/controllers/spree/api/v1/payments_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/payments_controller_spec.rb
@@ -36,6 +36,7 @@ module Spree
         end
 
         it 'can create a new payment' do
+          allow_any_instance_of(Spree::PaymentMethod).to receive(:source_required?).and_return(false)
           api_post :create, payment: { payment_method_id: PaymentMethod.first.id, amount: 50 }
           expect(response.status).to eq(201)
           expect(json_response).to have_attributes(attributes)

--- a/api/spec/requests/spree/api/v2/storefront/checkout_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/checkout_spec.rb
@@ -105,6 +105,7 @@ describe 'API V2 Storefront Checkout Spec', type: :request do
     let!(:payment_method)  { create(:credit_card_payment_method) }
 
     before do
+      allow_any_instance_of(Spree::PaymentMethod).to receive(:source_required?).and_return(false)
       allow_any_instance_of(Spree::Order).to receive_messages(confirmation_required?: true)
       allow_any_instance_of(Spree::Order).to receive_messages(payment_required?: true)
       put '/api/v2/storefront/checkout', params: params, headers: headers

--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -2,7 +2,11 @@ module Spree
   class CreditCard < Spree::Base
     include ActiveMerchant::Billing::CreditCardMethods
 
-    acts_as_paranoid
+    if !ENV['SPREE_DISABLE_DB_CONNECTION'] &&
+        connection.data_source_exists?(:spree_credit_cards) &&
+        connection.column_exists?(:spree_credit_cards, :deleted_at)
+      acts_as_paranoid
+    end
 
     belongs_to :payment_method
     belongs_to :user, class_name: Spree.user_class.to_s, foreign_key: 'user_id',

--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -2,6 +2,8 @@ module Spree
   class CreditCard < Spree::Base
     include ActiveMerchant::Billing::CreditCardMethods
 
+    acts_as_paranoid
+
     belongs_to :payment_method
     belongs_to :user, class_name: Spree.user_class.to_s, foreign_key: 'user_id',
                       optional: true

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -24,6 +24,7 @@ module Spree
 
     validates :payment_method, presence: true
     validates :number, uniqueness: true
+    validates :source, presence: true, if: -> { payment_method&.source_required? }
 
     before_validation :validate_source
 

--- a/core/db/migrate/20181024100754_add_deleted_at_to_spree_credit_cards.rb
+++ b/core/db/migrate/20181024100754_add_deleted_at_to_spree_credit_cards.rb
@@ -1,0 +1,6 @@
+class AddDeletedAtToSpreeCreditCards < ActiveRecord::Migration[5.2]
+  def change
+    add_column :spree_credit_cards, :deleted_at, :datetime
+    add_index :spree_credit_cards, :deleted_at
+  end
+end

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -119,7 +119,7 @@ describe Spree::Payment, type: :model do
   context 'validations' do
     context 'when payment source is not required' do
       it 'do not validate source presence' do
-        allow(gateway).to receive_messages source_required: false
+        allow_any_instance_of(Spree::PaymentMethod).to receive(:source_required?).and_return(false)
 
         payment.source = nil
         expect(payment).to be_valid
@@ -559,7 +559,7 @@ describe Spree::Payment, type: :model do
       it 'updates payment_state and shipments' do
         expect(order.updater).to receive(:update_payment_state)
         expect(order.updater).to receive(:update_shipment_state)
-        Spree::Payment.create(amount: 100, order: order, payment_method: gateway)
+        Spree::Payment.create(amount: 100, order: order, payment_method: gateway, source: card)
       end
     end
 

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -117,6 +117,22 @@ describe Spree::Payment, type: :model do
   end
 
   context 'validations' do
+    context 'when payment source is not required' do
+      it 'do not validate source presence' do
+        allow(gateway).to receive_messages source_required: false
+
+        payment.source = nil
+        expect(payment).to be_valid
+      end
+    end
+
+    context 'with payment source required' do
+      it 'validate source presence' do
+        payment.source = nil
+        expect(payment).not_to be_valid
+      end
+    end
+
     it 'returns useful error messages when source is invalid' do
       payment.source = Spree::CreditCard.new
       expect(payment).not_to be_valid


### PR DESCRIPTION
- Make Spree::CreditCard `acts_as_paranoid`
- Add payment source presence validation