### PR TITLE
(3-6) Fix money to_html deprecation warnings 

### DIFF
--- a/core/lib/spree/money.rb
+++ b/core/lib/spree/money.rb
@@ -2,6 +2,8 @@
 
 require 'money'
 
+Money.locale_backend = :i18n
+
 module Spree
   class Money
     class <<self

--- a/core/lib/spree/money.rb
+++ b/core/lib/spree/money.rb
@@ -39,7 +39,7 @@ module Spree
       opts[:html_wrap] = opts[:html]
       opts.delete(:html)
 
-      output = money.format(options.merge(opts))
+      output = money.format(@options.merge(opts))
       if opts[:html_wrap]
         output.gsub!(/<\/?[^>]*>/, '') # we don't want wrap every element in span
         output = output.sub(' ', '&nbsp;').html_safe

--- a/core/lib/spree/money.rb
+++ b/core/lib/spree/money.rb
@@ -32,13 +32,19 @@ module Spree
       @money.format(@options)
     end
 
-    def to_html(options = { html: true })
-      output = @money.format(@options.merge(options))
-      if options[:html]
-        # 1) prevent blank, breaking spaces
-        # 2) prevent escaping of HTML character entities
+    # 1) prevent blank, breaking spaces
+    # 2) prevent escaping of HTML character entities
+    def to_html(opts = { html: true })
+      # html option is deprecated and we need to fallback to html_wrap
+      opts[:html_wrap] = opts[:html]
+      opts.delete(:html)
+
+      output = money.format(options.merge(opts))
+      if opts[:html_wrap]
+        output.gsub!(/<\/?[^>]*>/, '') # we don't want wrap every element in span
         output = output.sub(' ', '&nbsp;').html_safe
       end
+
       output
     end
 

--- a/core/spec/lib/spree/money_spec.rb
+++ b/core/spec/lib/spree/money_spec.rb
@@ -57,9 +57,9 @@ describe Spree::Money do
     end
   end
 
-  context 'symbol positioning' do
+  context 'format' do
     it 'passed in option' do
-      money = described_class.new(10, symbol_position: :after, html_wrap: false)
+      money = described_class.new(10, format: '%n %u', html_wrap: false)
       expect(money.to_s).to eq('10.00 $')
     end
   end
@@ -98,19 +98,19 @@ describe Spree::Money do
 
     # Regression test for #2634
     it 'formats as plain by default' do
-      money = described_class.new(10, symbol_position: :after)
+      money = described_class.new(10, format: '%n %u')
       expect(money.to_s).to eq('10.00 €')
     end
 
     # rubocop:disable Style/AsciiComments
     it 'formats as HTML if asked (nicely) to' do
-      money = described_class.new(10, symbol_position: :after)
+      money = described_class.new(10, format: '%n %u')
       # The HTML'ified version of "10.00 €"
       expect(money.to_html).to eq('10.00&nbsp;&#x20AC;')
     end
 
     it 'formats as HTML with currency' do
-      money = described_class.new(10, symbol_position: :after, with_currency: true)
+      money = described_class.new(10, format: '%n %u', with_currency: true)
       # The HTML'ified version of "10.00 €"
       expect(money.to_html).to eq('10.00&nbsp;&#x20AC; EUR')
     end

--- a/core/spec/lib/spree/money_spec.rb
+++ b/core/spec/lib/spree/money_spec.rb
@@ -24,7 +24,7 @@ describe Spree::Money do
 
   context 'with currency' do
     it 'passed in option' do
-      money = described_class.new(10, with_currency: true, html: false)
+      money = described_class.new(10, with_currency: true, html_wrap: false)
       expect(money.to_s).to eq('$10.00 USD')
     end
   end
@@ -44,14 +44,14 @@ describe Spree::Money do
   context 'currency parameter' do
     context 'when currency is specified in Canadian Dollars' do
       it 'uses the currency param over the global configuration' do
-        money = described_class.new(10, currency: 'CAD', with_currency: true, html: false)
+        money = described_class.new(10, currency: 'CAD', with_currency: true, html_wrap: false)
         expect(money.to_s).to eq('$10.00 CAD')
       end
     end
 
     context 'when currency is specified in Japanese Yen' do
       it 'uses the currency param over the global configuration' do
-        money = described_class.new(100, currency: 'JPY', html: false)
+        money = described_class.new(100, currency: 'JPY', html_wrap: false)
         expect(money.to_s).to eq('¥100')
       end
     end
@@ -59,7 +59,7 @@ describe Spree::Money do
 
   context 'symbol positioning' do
     it 'passed in option' do
-      money = described_class.new(10, symbol_position: :after, html: false)
+      money = described_class.new(10, symbol_position: :after, html_wrap: false)
       expect(money.to_s).to eq('10.00 $')
     end
   end
@@ -84,7 +84,7 @@ describe Spree::Money do
     end
 
     it 'formats correctly' do
-      money = described_class.new(1000, html: false)
+      money = described_class.new(1000, html_wrap: false)
       expect(money.to_s).to eq('¥1,000')
     end
   end
@@ -112,7 +112,7 @@ describe Spree::Money do
     it 'formats as HTML with currency' do
       money = described_class.new(10, symbol_position: :after, with_currency: true)
       # The HTML'ified version of "10.00 €"
-      expect(money.to_html).to eq('10.00&nbsp;&#x20AC; <span class="currency">EUR</span>')
+      expect(money.to_html).to eq('10.00&nbsp;&#x20AC; EUR')
     end
     # rubocop:enable Style/AsciiComments
   end

--- a/frontend/app/views/spree/checkout/_summary.html.erb
+++ b/frontend/app/views/spree/checkout/_summary.html.erb
@@ -60,7 +60,11 @@
 
     <tr data-hook="order_total">
       <td><strong><%= Spree.t(:order_total) %>:</strong></td>
-      <td><strong><span id='summary-order-total' class="lead text-primary" data-currency=<%= Money::Currency.find(order.currency).symbol %>><%= order.display_total.to_html %></span></strong></td>
+      <td>
+        <strong>
+          <span id='summary-order-total' class="lead text-primary" data-currency="<%= Money::Currency.find(order.currency).symbol %>"><%= order.display_total.to_html %></span>
+        </strong>
+      </td>
     </tr>
 
     <% if order.using_store_credit? %>

--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -254,7 +254,7 @@ describe 'Checkout', type: :feature, inaccessible: true, js: true do
       choose 'use_existing_card_no'
 
       fill_in 'Name on card', with: 'Spree Commerce'
-      fill_in 'Card Number', with: '4111111111111111'
+      fill_in 'Card Number', with: '1'
       fill_in 'card_expiry', with: '04 / 20'
       fill_in 'Card Code', with: '123'
 

--- a/guides/content/developer/customization/i18n.md
+++ b/guides/content/developer/customization/i18n.md
@@ -150,11 +150,9 @@ currency for your site, go to Admin, then Configuration, then General Settings.
 Changing the currency will only change the currency symbol across all prices of
 your store.
 
-There are three configuration options for currency:
+There are configuration options for currency:
 
 * `Spree::Config[:currency]`: 3-letter currency code representing the current currency.
-* `Spree::Config[:currency_symbol_position]`: Whether to include the symbol before or after the monetary amount.
-* `Spree::Config[:display_currency]`: Whether or not to display the currency with prices.
 
 ### Localizing Seed Data
 


### PR DESCRIPTION
I think that we should backport this at least to 3-6-stable so current users of stable version won't get deprecation messages and they won't be concerned about outdated dependencies