### PR TITLE
Use monetize 1.9 to enforce ruby-money 6.13

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'friendly_id', '~> 5.2.1'
   s.add_dependency 'highline', '~> 1.6.18' # Necessary for the install generator
   s.add_dependency 'kaminari', '~> 1.0.1'
-  s.add_dependency 'monetize', '~> 1.1'
+  s.add_dependency 'monetize', '~> 1.9'
   s.add_dependency 'paperclip', '~> 6.1.0'
   s.add_dependency 'paranoia', '~> 2.4.1'
   s.add_dependency 'premailer-rails'


### PR DESCRIPTION
We need to ensure we're using ruby-money 6.13 as we fixed the deprecations here: https://github.com/spree/spree/pull/9036