### PR TITLE
Add ruby money dependency directly

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'friendly_id', '~> 5.2.1'
   s.add_dependency 'highline', '~> 1.6.18' # Necessary for the install generator
   s.add_dependency 'kaminari', '~> 1.0.1'
+  s.add_dependency 'money', '~> 6.13'
   s.add_dependency 'monetize', '~> 1.9'
   s.add_dependency 'paperclip', '~> 6.1.0'
   s.add_dependency 'paranoia', '~> 2.4.1'


### PR DESCRIPTION
We need money library at `6.13.0` at least, but the monetize gem also allows `6.12` which will break changes introduced in https://github.com/spree/spree/pull/9036