### PR TITLE
Chore/fix punctuation spacing

### DIFF
--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -41,7 +41,7 @@
   <div class="no-objects-found alert alert-info">
     <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::Variant)) %>
     <% if can?(:create, Spree::Variant) && !@product.empty_option_values? %>
-       - <%= link_to(Spree.t(:add_one), spree.new_admin_product_variant_path(@product)) %>!
+      - <%= link_to(Spree.t(:add_one), spree.new_admin_product_variant_path(@product)) %>!
     <% end %>
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -41,8 +41,8 @@
   <div class="no-objects-found alert alert-info">
     <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::Variant)) %>
     <% if can?(:create, Spree::Variant) && !@product.empty_option_values? %>
-       - <%= link_to(Spree.t(:add_one), spree.new_admin_product_variant_path(@product)) %>
-    <% end %>!
+       - <%= link_to(Spree.t(:add_one), spree.new_admin_product_variant_path(@product)) %>!
+    <% end %>
   </div>
 <% end %>
 


### PR DESCRIPTION
I noticed this small issue while playing around with the sandbox
project. I didn't find this pattern anywhere else, so this should be the
only instance of this mistake.

Before:
![4ace4edb-7dc9-4105-a8a1-71a15638a614](https://user-images.githubusercontent.com/11466782/48303629-fbe22600-e4d1-11e8-8e32-486bcafa3104.png)

After:
![d78ced5d-0c03-4c29-836d-068a021933d7](https://user-images.githubusercontent.com/11466782/48303621-dead5780-e4d1-11e8-9da9-c9d402691ad0.png)
