### PR TITLE
Fixed EnsurePaymentsHaveNumbers migration

### DIFF
--- a/core/db/migrate/20150309161154_ensure_payments_have_numbers.rb
+++ b/core/db/migrate/20150309161154_ensure_payments_have_numbers.rb
@@ -2,8 +2,10 @@ class EnsurePaymentsHaveNumbers < ActiveRecord::Migration[4.2]
   def change
     add_index :spree_payments, :number unless index_exists?(:spree_payments, :number)
     Spree::Payment.where(number: nil).find_each do |payment|
-      payment.generate_number
-      payment.update_columns(number: payment.number)
+      payment.save! # to generate a new number we need to save the record
+    rescue ActiveRecord::RecordNotSaved
+      Rails.logger.error("Payment with ID = #{payment.id} couldn't be saved")
+      Rails.logger.error(payment.errors.full_messages.to_sentence)
     end
   end
 end


### PR DESCRIPTION
Since https://github.com/spree/spree/commit/d2105ea1a767ec0649867c33462dc0291f6cd12d there's no explicit `generate_number` method.

We need to save the record to generate a new number in the process.

Some more context: https://spree-commerce.slack.com/archives/C0JCDUK0D/p1543324683155500