### PR TITLE
We still need to use ES5 syntax in asets managed by asset pipeline

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -287,14 +287,14 @@ function completeItemSplit (event) {
   var selectedShipment = stockItemRow.find($('#item_stock_location').select2('data').element)
   var targetShipmentNumber = selectedShipment.data('shipment-number')
   var newShipment = selectedShipment.data('new-shipment')
-  // eslint-disable-next-line eqeqeq
+  // eslint-disable-next-line
   if (stockLocationId !== 'new_shipment') {
-    const splitItems = ({ url, data }) => {
+    var splitItems = function (opts) {
       $.ajax({
         type: 'POST',
         async: false,
-        url,
-        data
+        url: opts.url,
+        data: opts.data
       }).error(function (msg) {
         alert(msg.responseJSON.message || msg.responseJSON.exception)
       }).done(function () {


### PR DESCRIPTION
This bug was introduced in https://github.com/spree/spree/pull/9089 😱 