### PR TITLE
API v2 - rely on include parameter to decide what related resources should be return

### DIFF
--- a/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
@@ -136,14 +136,6 @@ module Spree
           def render_error_item_quantity
             render json: { error: I18n.t(:wrong_quantity, scope: 'spree.api.v2.cart') }, status: 422
           end
-
-          def default_resource_includes
-            %i[
-              line_items
-              variants
-              promotions
-            ]
-          end
         end
       end
     end

--- a/api/app/controllers/spree/api/v2/storefront/products_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/products_controller.rb
@@ -67,18 +67,6 @@ module Spree
             Spree::Product.includes(scope_includes)
           end
 
-          def default_resource_includes
-            %i[
-              variants
-              variants.images
-              default_variant
-              default_variant.images
-              option_types
-              option_types.option_values
-              product_properties
-            ]
-          end
-
           def scope_includes
             {
               classifications: :taxon,

--- a/api/app/controllers/spree/api/v2/storefront/products_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/products_controller.rb
@@ -59,24 +59,25 @@ module Spree
             {
               links: collection_links(collection),
               meta: collection_meta(collection),
-              include: collection_includes
+              include: resource_includes
             }
           end
 
           def scope
-            Spree::Product.includes(scope_includes)
+            Spree::Product.accessible_by(current_ability, :read).includes(scope_includes)
           end
 
           def scope_includes
             {
-              classifications: :taxon,
+              master: :default_price,
+              variants: [],
+              variant_images: [],
+              taxons: [],
               product_properties: :property,
               option_types: :option_values,
-              variants: %i[default_price option_values]
+              variants_including_master: %i[default_price option_values]
             }
           end
-
-          alias collection_includes resource_includes
         end
       end
     end

--- a/api/app/controllers/spree/api/v2/storefront/taxons_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/taxons_controller.rb
@@ -62,14 +62,6 @@ module Spree
             Spree::Taxon.includes(:parent, :children).accessible_by(current_ability, :read)
           end
 
-          def default_resource_includes
-            %i[
-              parent
-              taxonomy
-              children
-              products
-              image
-            ]
           end
 
           alias collection_includes resource_includes

--- a/api/app/controllers/spree/api/v2/storefront/taxons_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/taxons_controller.rb
@@ -42,7 +42,7 @@ module Spree
             {
               links: collection_links(collection),
               meta: collection_meta(collection),
-              include: collection_includes
+              include: resource_includes
             }
           end
 
@@ -59,12 +59,20 @@ module Spree
           end
 
           def scope
-            Spree::Taxon.includes(:parent, :children).accessible_by(current_ability, :read)
+            Spree::Taxon.accessible_by(current_ability, :read).includes(scope_includes)
           end
 
-          end
+          def scope_includes
+            node_includes = %i[icon products parent taxonomy]
 
-          alias collection_includes resource_includes
+            {
+              parent: node_includes,
+              children: node_includes,
+              taxonomy: [root: node_includes],
+              products: [],
+              icon: []
+            }
+          end
         end
       end
     end

--- a/api/app/serializers/spree/v2/storefront/product_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/product_serializer.rb
@@ -17,6 +17,13 @@ module Spree
         has_many :product_properties
         has_many :taxons
 
+        # all images from all variants
+        has_many :images,
+          object_method_name: :variant_images,
+          id_method_name: :variant_image_ids,
+          record_type: :image,
+          serializer: :image
+
         has_one  :default_variant,
           object_method_name: :default_variant,
           id_method_name: :default_variant_id,

--- a/api/app/serializers/spree/v2/storefront/product_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/product_serializer.rb
@@ -15,6 +15,7 @@ module Spree
         has_many :variants
         has_many :option_types
         has_many :product_properties
+        has_many :taxons
 
         has_one  :default_variant,
           object_method_name: :default_variant,

--- a/api/app/serializers/spree/v2/storefront/variant_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/variant_serializer.rb
@@ -12,7 +12,9 @@ module Spree
         attribute :in_stock,      &:in_stock?
         attribute :backorderable, &:backorderable?
 
+        belongs_to :product
         has_many :images
+        has_many :option_values
       end
     end
   end

--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -368,6 +368,7 @@ paths:
             Use <q>-</q> sign to set descenging sort, eg. <q>-updated_at</q>
         - $ref: '#/components/parameters/PageParam'
         - $ref: '#/components/parameters/PerPageParam'
+        - $ref: '#/components/parameters/ProductIncludeParam'
       responses:
         '200':
           description: ok
@@ -388,6 +389,7 @@ paths:
       operationId: index
       parameters:
         - $ref: '#/components/parameters/IdOrPermalink'
+        - $ref: '#/components/parameters/ProductIncludeParam'
       responses:
         '200':
           description: ok
@@ -1388,7 +1390,6 @@ components:
       description: >-
         <p>Specify what related resources (relationships) you would like to receive in the response body.</p>
         <p>You can also fetch relationships of relationships.</p>
-        <p>Passing empty string will result with none relationships being returned.</p>
         <p>
           Format:
           <ul>
@@ -1400,6 +1401,25 @@ components:
           <a href="https://jsonapi.org/format/#fetching-includes">https://jsonapi.org/format/#fetching-includes</a>
         </p>
       example: 'line_items,variants,variants.images,billing_address,shipping_address,user,payments,shipments,promotions'
+    ProductIncludeParam:
+      name: include
+      in: query
+      schema:
+        type: string
+      description: >-
+        <p>Specify what related resources (relationships) you would like to receive in the response body.</p>
+        <p>You can also fetch relationships of relationships.</p>
+        <p>
+          Format:
+          <ul>
+            <li>default_variant,variants,option_types,product_properties,taxons,images</li>
+            <li>variants,variants.images,variants.option_values</li>
+          </ul>
+        <p>
+          More information:
+          <a href="https://jsonapi.org/format/#fetching-includes">https://jsonapi.org/format/#fetching-includes</a>
+        </p>
+      example: 'default_variant,variants,option_types,product_properties,taxons,images'
   responses:
     404NotFound:
       description: Resource not found

--- a/api/spec/requests/spree/api/v2/resource_includes_spec.rb
+++ b/api/spec/requests/spree/api/v2/resource_includes_spec.rb
@@ -8,14 +8,6 @@ describe 'API v2 JSON API Resource Includes Spec', type: :request do
   let!(:option_value) { create(:option_value, option_type: product_option_type.option_type) }
   let(:default_variant) { product.master }
 
-  shared_examples 'default resources' do
-    it 'are returned' do
-      expect(json_response['included']).to be_present
-      expect(json_response['included']).to include(have_type('variant').and have_id(default_variant.id.to_s))
-      expect(json_response['included']).to include(have_type('option_type').and have_id(product.option_types.first.id.to_s))
-    end
-  end
-
   shared_examples 'requested resources' do
     it 'are returned' do
       expect(json_response['included']).to be_present
@@ -43,7 +35,7 @@ describe 'API v2 JSON API Resource Includes Spec', type: :request do
     context 'without include param' do
       before { get "/api/v2/storefront/products/#{product.id}" }
 
-      it_behaves_like 'default resources'
+      it_behaves_like 'requested no resources'
     end
 
     context 'with include param' do
@@ -73,7 +65,7 @@ describe 'API v2 JSON API Resource Includes Spec', type: :request do
     context 'without include param' do
       before { get '/api/v2/storefront/products' }
 
-      it_behaves_like 'default resources'
+      it_behaves_like 'requested no resources'
     end
 
     context 'with include param' do

--- a/api/spec/requests/spree/api/v2/storefront/cart_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/cart_spec.rb
@@ -80,7 +80,7 @@ describe 'API V2 Storefront Cart Spec', type: :request do
 
   describe 'cart#add_item' do
     let(:options) { {} }
-    let(:params) { { variant_id: variant.id, quantity: 5, options: options } }
+    let(:params) { { variant_id: variant.id, quantity: 5, options: options, include: 'variants' } }
     let(:execute) { post '/api/v2/storefront/cart/add_item', params: params, headers: headers }
 
     before do
@@ -364,7 +364,8 @@ describe 'API V2 Storefront Cart Spec', type: :request do
   describe 'cart#apply_coupon_code' do
     include_context 'coupon codes'
 
-    let(:execute) { patch '/api/v2/storefront/cart/apply_coupon_code', params: { coupon_code: coupon_code }, headers: headers }
+    let(:params) { { coupon_code: coupon_code, include: 'promotions' } }
+    let(:execute) { patch '/api/v2/storefront/cart/apply_coupon_code', params: params, headers: headers }
 
     shared_examples 'apply coupon code' do
       before { execute }
@@ -423,7 +424,8 @@ describe 'API V2 Storefront Cart Spec', type: :request do
   end
 
   describe 'cart#remove_coupon_code' do
-    let(:execute) { delete "/api/v2/storefront/cart/remove_coupon_code/#{coupon_code}", headers: headers }
+    let(:params) { { include: 'promotions' } }
+    let(:execute) { delete "/api/v2/storefront/cart/remove_coupon_code/#{coupon_code}", params: params, headers: headers }
 
     include_context 'coupon codes'
 

--- a/api/spec/requests/spree/api/v2/storefront/products_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/products_spec.rb
@@ -74,7 +74,7 @@ describe 'API V2 Storefront Products Spec', type: :request do
     end
 
     context 'with specified options' do
-      before { get "/api/v2/storefront/products?filter[options][#{option_type.name}]=#{option_value.name}" }
+      before { get "/api/v2/storefront/products?filter[options][#{option_type.name}]=#{option_value.name}&include=option_types,variants.option_values" }
 
       it_behaves_like 'returns proper status'
 

--- a/core/app/finders/spree/order/find_current.rb
+++ b/core/app/finders/spree/order/find_current.rb
@@ -15,7 +15,19 @@ module Spree
       private
 
       def incomplete_orders
-        Spree::Order.incomplete.includes(line_items: [variant: [:images, :option_values, :product]])
+        Spree::Order.incomplete.includes(scope_includes)
+      end
+
+      def scope_includes
+        {
+          line_items: [
+            variant: [
+              :images,
+              option_values: :option_type,
+              product: :product_properties,
+            ]
+          ]
+        }
       end
     end
   end

--- a/core/app/finders/spree/products/find.rb
+++ b/core/app/finders/spree/products/find.rb
@@ -72,7 +72,7 @@ module Spree
       def by_taxons(products)
         return products unless taxons?
 
-        products.where(spree_taxons: { id: taxons })
+        products.joins(:taxons).distinct.where(spree_taxons: { id: taxons })
       end
 
       def by_name(products)


### PR DESCRIPTION
Per JSON API spec:

```
If an endpoint supports the include parameter and a client supplies it, 
the server MUST NOT include unrequested resource objects in the  included 
section of the compound document.
```
https://jsonapi.org/format/#fetching-includes
