### PR TITLE
Expose slug and options text in LineItem serializer for Storefront API v2

### DIFF
--- a/api/app/serializers/spree/v2/storefront/line_item_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/line_item_serializer.rb
@@ -4,11 +4,11 @@ module Spree
       class LineItemSerializer < BaseSerializer
         set_type   :line_item
 
-        attributes :name, :quantity, :price, :currency, :display_price, :total,
-                   :display_total, :adjustment_total, :display_adjustment_total,
-                   :additional_tax_total, :display_additional_tax_total,
-                   :promo_total, :display_promo_total, :included_tax_total,
-                   :display_included_tax_total
+        attributes :name, :quantity, :price, :slug, :options_text, :currency,
+                   :display_price, :total, :display_total, :adjustment_total,
+                   :display_adjustment_total, :additional_tax_total,
+                   :display_additional_tax_total, :promo_total, :display_promo_total,
+                   :included_tax_total, :display_included_tax_total
 
         belongs_to :variant
       end

--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -770,6 +770,12 @@ components:
                 quantity:
                   type: integer
                   example: 1
+                slug:
+                  type: string
+                  example: 'sample-product'
+                options_text:
+                  type: string
+                  example: 'Size: small, Color: red'
                 price:
                   type: string
                   example: '125.0'

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -32,7 +32,7 @@ module Spree
 
     after_create :update_tax_charge
 
-    delegate :name, :description, :sku, :should_track_inventory?, :product, :options_text, to: :variant
+    delegate :name, :description, :sku, :should_track_inventory?, :product, :options_text, :slug, to: :variant
     delegate :brand, :category, to: :product
     delegate :tax_zone, to: :order
 


### PR DESCRIPTION
Line items should be denormalized so we can limit the need to fetch additional resources