### PR TITLE
Deprecate BaseHelper#variant_options

### DIFF
--- a/backend/app/views/spree/admin/orders/_line_items.html.erb
+++ b/backend/app/views/spree/admin/orders/_line_items.html.erb
@@ -23,7 +23,9 @@
                 <%= mini_image(item.variant) %>
               </td>
               <td class="line-item-name text-center">
-                <%= item.name %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>
+                <%= item.name %>
+                <br />
+                <%= "(#{item.options_text})" if item.options_text.present? %>
               </td>
               <td class="line-item-price text-center"><%= item.single_money.to_html %></td>
               <td class="line-item-qty-show text-center">

--- a/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
@@ -5,7 +5,9 @@
     </td>
 
     <td class="item-name">
-      <%= item.variant.product.name %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>
+      <%= item.variant.product.name %>
+      <br />
+      <%= "(#{item.variant.options_text})" if item.variant.options_text.present? %>
       <% if item.variant.sku.present? %>
         <strong><%= Spree.t(:sku) %>:</strong> <%= item.variant.sku %>
       <% end %>

--- a/backend/app/views/spree/admin/users/items.html.erb
+++ b/backend/app/views/spree/admin/users/items.html.erb
@@ -30,7 +30,9 @@
                 <%= mini_image(item.variant) %>
               </td>
               <td class="item-name">
-                <%= item.name %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>
+                <%= item.name %>
+                <br />
+                <%= "(#{item.options_text})" if item.options_text.present? %>
                 <% if item.sku.present? %>
                   <strong><%= Spree.t(:sku) %>:</strong> <%= item.variant.sku %>
                 <% end %>

--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -81,6 +81,10 @@ module Spree
 
     # human readable list of variant options
     def variant_options(variant, _options = {})
+      ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+        BaseHelper#variant_options is deprecated and will be removed in Spree 4.0.
+        Please use Variant#options_text or LineItem#options_text
+      DEPRECATION
       variant.options_text
     end
 

--- a/frontend/app/views/spree/products/_cart_form.html.erb
+++ b/frontend/app/views/spree/products/_cart_form.html.erb
@@ -13,7 +13,7 @@
               %>
               <%= label_tag "variant_id_#{ variant.id }" do %>
                 <span class="variant-description">
-                  <%= variant_options variant %>
+                  <%= variant.options_text %>
                 </span>
                 <% if variant_price variant %>
                   <span class="price diff"><%= variant_price variant %></span>

--- a/guides/content/release_notes/3_7_0.md
+++ b/guides/content/release_notes/3_7_0.md
@@ -101,6 +101,10 @@ of your own tips please submit a PR to help the next person!
 
   [Spark Solutions](https://github.com/spree/spree/pull/9081)
 
+* Deprecated `BaseHelper#variant_options`
+
+  [Spark Solutions](https://github.com/spree/spree/pull/9105)
+
 * Renamed `Admin::GeneralSettingsHelper` to `Admin::CurrencyHelper`
 
   [Spark Solutuons](https://github.com/spree/spree/pull/8912)


### PR DESCRIPTION
This is already available via `Variant#options_text` and `LineItem#options_text` so no need for another layer of abstraction.