### PR TITLE
Fix i18n issue in Store Credits heading

### DIFF
--- a/backend/app/views/spree/admin/store_credits/edit.html.erb
+++ b/backend/app/views/spree/admin/store_credits/edit.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :page_title do %>
   <%= link_to @user.email, spree.edit_admin_user_url(@user) %> /
-  <%= link_to Spree.t(:store_credits), spree.admin_user_store_credits_path(@user) %> /
+  <%= link_to Spree.t(:'admin.user.store_credits'), spree.admin_user_store_credits_path(@user) %> /
   <%= Spree.t(:editing_resource, resource: Spree::StoreCredit.model_name.human) %>
 <% end %>
 

--- a/backend/app/views/spree/admin/store_credits/new.html.erb
+++ b/backend/app/views/spree/admin/store_credits/new.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :page_title do %>
   <%= link_to @user.email, spree.edit_admin_user_url(@user) %> /
-  <%= link_to Spree.t(:store_credits), spree.admin_user_store_credits_path(@user) %> /
+  <%= link_to Spree.t(:'admin.user.store_credits'), spree.admin_user_store_credits_path(@user) %> /
   <%= Spree.t(:add_store_credit) %>
 <% end %>
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/581569/49736519-b65c7880-fc8a-11e8-8535-c5ad44a5068a.png)

It targets both `new` and `edit` actions for user store credits.