### PR TITLE
Change render_serialized_payload to accept payload as block

### DIFF
--- a/api/app/controllers/spree/api/v2/base_controller.rb
+++ b/api/app/controllers/spree/api/v2/base_controller.rb
@@ -9,8 +9,8 @@ module Spree
 
         private
 
-        def render_serialized_payload(payload, status = 200)
-          render json: payload, status: status
+        def render_serialized_payload(status = 200)
+          render json: yield, status: status
         rescue ArgumentError => exception
           render_error_payload(exception.message, 400)
         end

--- a/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
@@ -17,7 +17,7 @@ module Spree
             order   = spree_current_order if spree_current_order.present?
             order ||= dependencies[:create_cart].call(order_params).value
 
-            render_serialized_payload serialize_order(order), 201
+            render_serialized_payload(201) { serialize_order(order) }
           end
 
           def add_item
@@ -34,7 +34,7 @@ module Spree
             )
 
             if result.success?
-              render_serialized_payload serialized_current_order
+              render_serialized_payload { serialized_current_order }
             else
               render_error_payload(result.error)
             end
@@ -48,7 +48,7 @@ module Spree
               line_item: line_item
             )
 
-            render_serialized_payload serialized_current_order
+            render_serialized_payload { serialized_current_order }
           end
 
           def empty
@@ -56,7 +56,7 @@ module Spree
 
             spree_current_order.empty!
 
-            render_serialized_payload serialized_current_order
+            render_serialized_payload { serialized_current_order }
           end
 
           def set_quantity
@@ -67,7 +67,7 @@ module Spree
             result = dependencies[:set_item_quantity].call(order: spree_current_order, line_item: line_item, quantity: params[:quantity])
 
             if result.success?
-              render_serialized_payload serialized_current_order
+              render_serialized_payload { serialized_current_order }
             else
               render_error_payload(result.error)
             end
@@ -76,7 +76,7 @@ module Spree
           def show
             spree_authorize! :show, spree_current_order, order_token
 
-            render_serialized_payload serialized_current_order
+            render_serialized_payload { serialized_current_order }
           end
 
           def apply_coupon_code
@@ -86,7 +86,7 @@ module Spree
             result = dependencies[:coupon_handler].new(spree_current_order).apply
 
             if result.error.blank?
-              render_serialized_payload serialized_current_order
+              render_serialized_payload { serialized_current_order }
             else
               render_error_payload(result.error)
             end
@@ -98,7 +98,7 @@ module Spree
             result = dependencies[:coupon_handler].new(spree_current_order).remove(params[:coupon_code])
 
             if result.error.blank?
-              render_serialized_payload serialized_current_order
+              render_serialized_payload { serialized_current_order }
             else
               render_error_payload(result.error)
             end

--- a/api/app/controllers/spree/api/v2/storefront/checkout_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/checkout_controller.rb
@@ -43,7 +43,7 @@ module Spree
           end
 
           def payment_methods
-            render_serialized_payload serialize_payment_methods(spree_current_order.available_payment_methods)
+            render_serialized_payload { serialize_payment_methods(spree_current_order.available_payment_methods) }
           end
 
           private
@@ -67,7 +67,7 @@ module Spree
 
           def render_order(result)
             if result.success?
-              render_serialized_payload serialize_order(result.value)
+              render_serialized_payload { serialize_order(result.value) }
             else
               render_error_payload(result.error)
             end

--- a/api/app/controllers/spree/api/v2/storefront/countries_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/countries_controller.rb
@@ -6,11 +6,11 @@ module Spree
           include Spree::Api::V2::CollectionOptionsHelpers
 
           def index
-            render_serialized_payload serialize_collection(collection)
+            render_serialized_payload { serialize_collection(collection) }
           end
 
           def show
-            render_serialized_payload serialize_resource(resource)
+            render_serialized_payload { serialize_resource(resource) }
           end
 
           private

--- a/api/app/controllers/spree/api/v2/storefront/products_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/products_controller.rb
@@ -6,11 +6,11 @@ module Spree
           include Spree::Api::V2::CollectionOptionsHelpers
 
           def index
-            render_serialized_payload serialize_collection(paginated_collection)
+            render_serialized_payload { serialize_collection(paginated_collection) }
           end
 
           def show
-            render_serialized_payload serialize_resource(resource)
+            render_serialized_payload { serialize_resource(resource) }
           end
 
           private

--- a/api/app/controllers/spree/api/v2/storefront/taxons_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/taxons_controller.rb
@@ -6,11 +6,11 @@ module Spree
           include Spree::Api::V2::CollectionOptionsHelpers
 
           def index
-            render_serialized_payload serialize_collection(paginated_collection)
+            render_serialized_payload { serialize_collection(paginated_collection) }
           end
 
           def show
-            render_serialized_payload serialize_resource(resource)
+            render_serialized_payload { serialize_resource(resource) }
           end
 
           private

--- a/api/spec/requests/spree/api/v2/resource_includes_spec.rb
+++ b/api/spec/requests/spree/api/v2/resource_includes_spec.rb
@@ -45,6 +45,12 @@ describe 'API v2 JSON API Resource Includes Spec', type: :request do
         it_behaves_like 'requested no resources'
       end
 
+      context 'with non-existing relation requested' do
+        before { get "/api/v2/storefront/products/#{product.id}?include=does_not_exist" }
+
+        it_behaves_like 'returns 400 HTTP status'
+      end
+
       context 'present param' do
         context 'without nested resources' do
           before { get "/api/v2/storefront/products/#{product.id}?include=default_variant" }

--- a/api/spec/shared_examples/api_v2/base.rb
+++ b/api/spec/shared_examples/api_v2/base.rb
@@ -4,7 +4,7 @@ shared_context 'API v2 tokens' do
   let(:headers_order_token) { { 'X-Spree-Order-Token' => order.token } }
 end
 
-[200, 201, 404, 403, 422].each do |status_code|
+[200, 201, 400, 404, 403, 422].each do |status_code|
   shared_examples "returns #{status_code} HTTP status" do
     it "returns #{status_code}" do
       expect(response.status).to eq(status_code)


### PR DESCRIPTION
This change will allow render_serialized_payload to handle serialization errors
Such as non-existing relation requested via `include` param

400 response, in this case, is requested by [JSON:API specification](https://jsonapi.org/format/#fetching-includes)