### PR TITLE
API v2 Storefront Checkout Apply Store Credits endpoint

### DIFF
--- a/api/app/controllers/spree/api/v2/storefront/checkout_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/checkout_controller.rb
@@ -8,7 +8,7 @@ module Spree
           def next
             spree_authorize! :update, spree_current_order, order_token
 
-            result = dependencies[:next_state_procceder].call(order: spree_current_order)
+            result = dependencies[:next_state_handler].call(order: spree_current_order)
 
             render_order(result)
           end
@@ -16,7 +16,7 @@ module Spree
           def advance
             spree_authorize! :update, spree_current_order, order_token
 
-            result = dependencies[:advance_proceeder].call(order: spree_current_order)
+            result = dependencies[:advance_handler].call(order: spree_current_order)
 
             render_order(result)
           end
@@ -42,6 +42,17 @@ module Spree
             render_order(result)
           end
 
+          def add_store_credit
+            spree_authorize! :update, spree_current_order, order_token
+
+            result = dependencies[:add_store_credit_handler].call(
+              order: spree_current_order,
+              amount: params[:amount].try(:to_f)
+            )
+
+            render_order(result)
+          end
+
           def payment_methods
             render_serialized_payload serialize_payment_methods(spree_current_order.available_payment_methods)
           end
@@ -54,8 +65,9 @@ module Spree
 
           def dependencies
             {
-              next_state_procceder: Spree::Checkout::Next,
-              advance_proceeder: Spree::Checkout::Advance,
+              next_state_handler: Spree::Checkout::Next,
+              advance_handler: Spree::Checkout::Advance,
+              add_store_credit_handler: Spree::Checkout::AddStoreCredit,
               completer: Spree::Checkout::Complete,
               updater: Spree::Checkout::Update,
               cart_serializer: Spree::V2::Storefront::CartSerializer,

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -143,6 +143,7 @@ Spree::Core::Engine.add_routes do
           patch :next
           patch :advance
           patch :complete
+          post :add_store_credit
           get :payment_methods
         end
 

--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -332,6 +332,40 @@ paths:
         parameters:
         - $ref: '#/components/parameters/CartIncludeParam'
 
+  '/checkout/add_store_credit':
+    post:
+      description: Adds StoreCredit payments if a user has any
+      tags:
+        - Checkout
+      responses:
+        '200':
+          description: StoreCredit payment created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Cart'
+        '422':
+          description: StoreCredit couldn't be created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+      security:
+        - orderToken: []
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: amount
+          description: >-
+            Amount of StoreCredit to use.
+            As much as possible StoreCredit will be applied if no amount is passed.
+          schema:
+            type: string
+          example: 100.0
+        - $ref: '#/components/parameters/CartIncludeParam'
+
   '/checkout/payment_methods':
     get:
       description: >-

--- a/api/spec/requests/spree/api/v2/storefront/checkout_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/checkout_spec.rb
@@ -395,6 +395,50 @@ describe 'API V2 Storefront Checkout Spec', type: :request do
     end
   end
 
+  describe 'checkout#add_store_credits' do
+    let(:order_total) { 500.00 }
+    let(:params) { { order_token: order.token } }
+    let(:execute) { post '/api/v2/storefront/checkout/add_store_credit', params: params, headers: headers }
+
+    before do
+      create(:store_credit_payment_method)
+      execute
+    end
+
+    context 'for guest or user without store credit' do
+      let!(:order) { create(:order, total: order_total) }
+
+      it_behaves_like 'returns 422 HTTP status'
+    end
+
+    context 'for user with store credits' do
+      let!(:store_credit) { create(:store_credit, amount: order_total) }
+      let!(:order) { create(:order, user: store_credit.user, total: order_total) }
+
+      shared_examples 'valid payload' do |amount|
+        it 'returns StoreCredit payment' do
+          expect(json_response['data']).to have_relationship(:payments)
+          payment = Spree::Payment.find(json_response['data']['relationships']['payments']['data'][0]['id'].to_i)
+          expect(payment.amount).to eq amount
+          expect(payment.payment_method.class).to eq Spree::PaymentMethod::StoreCredit
+        end
+      end
+
+      context 'with no amount param' do
+        it_behaves_like 'returns 200 HTTP status'
+        it_behaves_like 'valid payload', 500.0
+      end
+
+      context 'with amount params requested' do
+        let(:requested_amount) { 300.0 }
+        let(:params) { { order_token: order.token, amount: requested_amount } }
+
+        it_behaves_like 'returns 200 HTTP status'
+        it_behaves_like 'valid payload', 300.0
+      end
+    end
+  end
+
   describe 'checkout#payment_methods' do
     let(:execute) { get '/api/v2/storefront/checkout/payment_methods', headers: headers }
     let(:payment_methods) { order.available_payment_methods }

--- a/backend/app/controllers/spree/admin/payments_controller.rb
+++ b/backend/app/controllers/spree/admin/payments_controller.rb
@@ -27,7 +27,8 @@ module Spree
 
         begin
           if @payment_method.store_credit?
-            payments = @order.add_store_credit_payments
+            Spree::Checkout::AddStoreCredit.call(order: @order)
+            payments = @order.payments.store_credits.valid
           else
             @payment ||= @order.payments.build(object_params)
             if @payment.payment_method.source_required? && params[:card].present? && params[:card] != 'new'

--- a/core/app/models/spree/order/store_credit.rb
+++ b/core/app/models/spree/order/store_credit.rb
@@ -2,10 +2,10 @@ module Spree
   class Order < Spree::Base
     module StoreCredit
       def add_store_credit_payments(amount = nil)
-        ActiveSupport::Deprecation.warn(<<-EOS, caller)
+        ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
           Spree::Order#add_store_credit_payments method is deprecated and will be removed in Spree 4.0.
-          Please use Spree::Checkout::AddStoreCredit service to remove item from cart.
-        EOS
+          Please use Spree::Checkout::AddStoreCredit service to add Store Credit to Order.
+        DEPRECATION
 
         Spree::Checkout::AddStoreCredit.call(order: self, amount: amount)
       end

--- a/core/app/models/spree/order/store_credit.rb
+++ b/core/app/models/spree/order/store_credit.rb
@@ -1,25 +1,13 @@
 module Spree
   class Order < Spree::Base
     module StoreCredit
-      def add_store_credit_payments
-        payments.store_credits.where(state: :checkout).map(&:invalidate!)
+      def add_store_credit_payments(amount = nil)
+        ActiveSupport::Deprecation.warn(<<-EOS, caller)
+          Spree::Order#add_store_credit_payments method is deprecated and will be removed in Spree 4.0.
+          Please use Spree::Checkout::AddStoreCredit service to remove item from cart.
+        EOS
 
-        remaining_total = outstanding_balance
-
-        if user&.store_credits&.any?
-          payment_method = Spree::PaymentMethod::StoreCredit.available.first
-          raise 'Store credit payment method could not be found' unless payment_method
-
-          user.store_credits.order_by_priority.each do |credit|
-            break if remaining_total.zero?
-            next if credit.amount_remaining.zero?
-
-            amount_to_take = store_credit_amount(credit, remaining_total)
-            create_store_credit_payment(payment_method, credit, amount_to_take)
-            remaining_total -= amount_to_take
-          end
-          payments.store_credits.checkout
-        end
+        Spree::Checkout::AddStoreCredit.call(order: self, amount: amount)
       end
 
       def remove_store_credit_payments
@@ -81,22 +69,6 @@ module Spree
 
       def display_store_credit_remaining_after_capture
         Spree::Money.new(total_available_store_credit - total_applicable_store_credit, currency: currency)
-      end
-
-      private
-
-      def create_store_credit_payment(payment_method, credit, amount)
-        payments.create!(
-          source: credit,
-          payment_method: payment_method,
-          amount: amount,
-          state: 'checkout',
-          response_code: credit.generate_authorization_code
-        )
-      end
-
-      def store_credit_amount(credit, total)
-        [credit.amount_remaining, total].min
       end
     end
   end

--- a/core/app/services/spree/checkout/add_store_credit.rb
+++ b/core/app/services/spree/checkout/add_store_credit.rb
@@ -1,0 +1,49 @@
+module Spree
+  module Checkout
+    class AddStoreCredit
+      prepend Spree::ServiceModule::Base
+
+      def call(order:, amount: nil)
+        @order = order
+        return failed unless @order
+
+        @order.payments.store_credits.where(state: :checkout).map(&:invalidate!)
+        remaining_total = amount ? [amount, @order.outstanding_balance].min : @order.outstanding_balance
+
+        apply_store_credits(remaining_total) if @order.user&.store_credits&.any?
+
+        @order.reload.payments.store_credits.valid.any? ? success(@order) : failure(@order)
+      end
+
+      private
+
+      def apply_store_credits(remaining_total)
+        payment_method = Spree::PaymentMethod::StoreCredit.available.first
+        raise 'Store credit payment method could not be found' unless payment_method
+
+        @order.user.store_credits.order_by_priority.each do |credit|
+          break if remaining_total.zero?
+          next if credit.amount_remaining.zero?
+
+          amount_to_take = store_credit_amount(credit, remaining_total)
+          create_store_credit_payment(payment_method, credit, amount_to_take)
+          remaining_total -= amount_to_take
+        end
+      end
+
+      def create_store_credit_payment(payment_method, credit, amount)
+        @order.payments.create!(
+          source: credit,
+          payment_method: payment_method,
+          amount: amount,
+          state: 'checkout',
+          response_code: credit.generate_authorization_code
+        )
+      end
+
+      def store_credit_amount(credit, total)
+        [credit.amount_remaining, total].min
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/order/store_credit_spec.rb
+++ b/core/spec/models/spree/order/store_credit_spec.rb
@@ -25,98 +25,6 @@ shared_examples 'check total store credit from payments' do
 end
 
 describe 'Order' do
-  describe '#add_store_credit_payments' do
-    subject { order.add_store_credit_payments }
-
-    let(:order_total) { 500.00 }
-
-    before { create(:store_credit_payment_method) }
-
-    context 'there is no store credit' do
-      let(:order) { create(:store_credits_order_without_user, total: order_total) }
-
-      before do
-        # callbacks recalculate total based on line items
-        # this ensures the total is what we expect
-        order.update_column(:total, order_total)
-        subject
-        order.reload
-      end
-
-      it 'does not create a store credit payment' do
-        expect(order.payments.count).to eq 0
-      end
-    end
-
-    context 'there is enough store credit to pay for the entire order' do
-      let(:store_credit) { create(:store_credit, amount: order_total) }
-      let(:order) { create(:order, user: store_credit.user, total: order_total) }
-
-      before do
-        subject
-        order.reload
-      end
-
-      it 'creates a store credit payment for the full amount' do
-        expect(order.payments.count).to eq 1
-        expect(order.payments.first).to be_store_credit
-        expect(order.payments.first.amount).to eq order_total
-      end
-    end
-
-    context 'the available store credit is not enough to pay for the entire order' do
-      let(:expected_cc_total) { 100.0 }
-      let(:store_credit_total) { order_total - expected_cc_total }
-      let(:store_credit) { create(:store_credit, amount: store_credit_total) }
-      let(:order) { create(:order, user: store_credit.user, total: order_total) }
-
-      before do
-        # callbacks recalculate total based on line items
-        # this ensures the total is what we expect
-        order.update_column(:total, order_total)
-        subject
-        order.reload
-      end
-
-      it 'creates a store credit payment for the available amount' do
-        expect(order.payments.count).to eq 1
-        expect(order.payments.first).to be_store_credit
-        expect(order.payments.first.amount).to eq store_credit_total
-      end
-    end
-
-    context 'there are multiple store credits' do
-      context 'they have different credit type priorities' do
-        let(:amount_difference) { 100 }
-        let!(:primary_store_credit) { create(:store_credit, amount: (order_total - amount_difference)) }
-        let!(:secondary_store_credit) do
-          create(:store_credit, amount: order_total, user: primary_store_credit.user,
-                                credit_type: create(:secondary_credit_type))
-        end
-        let(:order) { create(:order, user: primary_store_credit.user, total: order_total) }
-
-        before do
-          Timecop.scale(3600)
-          subject
-          order.reload
-        end
-
-        after { Timecop.return }
-
-        it 'uses the primary store credit type over the secondary' do
-          primary_payment = order.payments.first
-          secondary_payment = order.payments.last
-
-          expect(order.payments.size).to eq 2
-          expect(primary_payment.source).to eq primary_store_credit
-          expect(secondary_payment.source).to eq secondary_store_credit
-          expect(primary_payment.amount).to eq(order_total - amount_difference)
-          expect(secondary_payment.amount).to eq(amount_difference)
-        end
-      end
-    end
-  end
-
   describe '#remove_store_credit_payments' do
     subject { order.remove_store_credit_payments }
 
@@ -128,7 +36,7 @@ describe 'Order' do
 
       before do
         create(:store_credit_payment_method)
-        order.add_store_credit_payments
+        Spree::Checkout::AddStoreCredit.call(order: order)
       end
 
       it { expect { subject }.to change { order.payments.checkout.store_credits.count }.from(1).to(0) }

--- a/core/spec/services/spree/checkout/add_store_credit_spec.rb
+++ b/core/spec/services/spree/checkout/add_store_credit_spec.rb
@@ -1,0 +1,112 @@
+require 'spec_helper'
+
+describe Spree::Checkout::AddStoreCredit, type: :service do
+
+  describe '#call' do
+    subject { described_class.call(order: order) }
+
+    let(:order_total) { 500.00 }
+
+    before { create(:store_credit_payment_method) }
+
+    context 'there is no store credit' do
+      let(:order) { create(:store_credits_order_without_user, total: order_total) }
+
+      before do
+        # callbacks recalculate total based on line items
+        # this ensures the total is what we expect
+        order.update_column(:total, order_total)
+        subject
+        order.reload
+      end
+
+      it 'does not create a store credit payment' do
+        expect(order.payments.count).to eq 0
+      end
+    end
+
+    context 'there is enough store credit to pay for the entire order' do
+      let(:store_credit) { create(:store_credit, amount: order_total) }
+      let(:order) { create(:order, user: store_credit.user, total: order_total) }
+
+      context 'with no amount specified' do
+        before do
+          subject
+          order.reload
+        end
+
+        it 'creates a store credit payment for the full amount' do
+          expect(order.payments.count).to eq 1
+          expect(order.payments.first).to be_store_credit
+          expect(order.payments.first.amount).to eq order_total
+        end
+      end
+
+      context 'with store credit amount specified' do
+        let(:requested_amount) { 300.0 }
+
+        before do
+          described_class.call(order: order, amount: requested_amount)
+        end
+
+        it 'creates a store credit payment for the specified amount' do
+          expect(order.payments.count).to eq 1
+          expect(order.payments.first).to be_store_credit
+          expect(order.payments.first.amount).to eq requested_amount
+        end
+      end
+    end
+
+    context 'the available store credit is not enough to pay for the entire order' do
+      let(:expected_cc_total) { 100.0 }
+      let(:store_credit_total) { order_total - expected_cc_total }
+      let(:store_credit) { create(:store_credit, amount: store_credit_total) }
+      let(:order) { create(:order, user: store_credit.user, total: order_total) }
+
+      before do
+        # callbacks recalculate total based on line items
+        # this ensures the total is what we expect
+        order.update_column(:total, order_total)
+        subject
+        order.reload
+      end
+
+      it 'creates a store credit payment for the available amount' do
+        expect(order.payments.count).to eq 1
+        expect(order.payments.first).to be_store_credit
+        expect(order.payments.first.amount).to eq store_credit_total
+      end
+    end
+
+    context 'there are multiple store credits' do
+      context 'they have different credit type priorities' do
+        let(:amount_difference) { 100 }
+        let!(:primary_store_credit) { create(:store_credit, amount: (order_total - amount_difference)) }
+        let!(:secondary_store_credit) do
+          create(:store_credit, amount: order_total, user: primary_store_credit.user,
+                 credit_type: create(:secondary_credit_type))
+        end
+        let(:order) { create(:order, user: primary_store_credit.user, total: order_total) }
+
+        before do
+          Timecop.scale(3600)
+          subject
+          order.reload
+        end
+
+        after { Timecop.return }
+
+        it 'uses the primary store credit type over the secondary' do
+          primary_payment = order.payments.first
+          secondary_payment = order.payments.last
+
+          expect(order.payments.size).to eq 2
+          expect(primary_payment.source).to eq primary_store_credit
+          expect(secondary_payment.source).to eq secondary_store_credit
+          expect(primary_payment.amount).to eq(order_total - amount_difference)
+          expect(secondary_payment.amount).to eq(amount_difference)
+        end
+      end
+    end
+  end
+end

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -162,7 +162,7 @@ module Spree
 
     def add_store_credit_payments
       if params.key?(:apply_store_credit)
-        @order.add_store_credit_payments
+        Spree::Checkout::AddStoreCredit.call(order: @order)
 
         # Remove other payment method parameters.
         params[:order].delete(:payments_attributes)

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -529,7 +529,7 @@ describe Spree::CheckoutController, type: :controller do
       before do
         create(:store_credit_payment_method)
         create(:store_credit, user: user, amount: credit_amount)
-        order.add_store_credit_payments
+        Spree::Checkout::AddStoreCredit.call(order: order)
       end
 
       def expect_invalid_store_credit_payment(order)

--- a/guides/content/release_notes/3_7_0.md
+++ b/guides/content/release_notes/3_7_0.md
@@ -178,6 +178,10 @@ of your own tips please submit a PR to help the next person!
 
   [Josh Powell](https://github.com/spree/spree/pull/9028)
 
+* Deprecated `Spree::Order#add_store_credit_payments` in favor of `Spree::Checkout::AddStoreCredit`
+
+  [Spark Solutions](https://github.com/spree/spree/pull/9146)
+
 ## Full Changelog
 
 You can view the full changes using [Github Compare](https://github.com/spree/spree/compare/3-6-stable...3-7-stable).


### PR DESCRIPTION
fixes https://github.com/spree/spree/issues/9143

- [x] `add_store_credit` endpoint
- [x] Move `Spree::Order#add_store_credit_payments` to a service
- [x] Update release notes with deprecation
- [x] Update Open API documentation
