### PR TITLE
API v2 Storefront Checkout finalize

### DIFF
--- a/api/app/controllers/spree/api/v2/storefront/checkout_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/checkout_controller.rb
@@ -116,14 +116,6 @@ module Spree
               params: { show_rates: true }
             ).serializable_hash
           end
-
-          def default_resource_includes
-            %i[
-              line_items
-              variants
-              promotions
-            ]
-          end
         end
       end
     end

--- a/api/app/controllers/spree/api/v2/storefront/checkout_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/checkout_controller.rb
@@ -60,6 +60,12 @@ module Spree
             render_order(result)
           end
 
+          def shipping_rates
+            result = dependencies[:shipping_rates_getter].call(order: spree_current_order)
+
+            render_serialized_payload { serialize_shipping_rates(result.value) }
+          end
+
           def payment_methods
             render_serialized_payload { serialize_payment_methods(spree_current_order.available_payment_methods) }
           end
@@ -80,6 +86,8 @@ module Spree
               updater: Spree::Checkout::Update,
               cart_serializer: Spree::V2::Storefront::CartSerializer,
               payment_methods_serializer: Spree::V2::Storefront::PaymentMethodSerializer,
+              shipping_rates_getter: Spree::Checkout::GetShippingRates,
+              shipping_rates_serializer: Spree::V2::Storefront::ShipmentSerializer,
               # defined in https://github.com/spree/spree/blob/master/core/lib/spree/core/controller_helpers/strong_parameters.rb#L19
               permitted_attributes: permitted_checkout_attributes
             }
@@ -99,6 +107,14 @@ module Spree
 
           def serialize_payment_methods(payment_methods)
             dependencies[:payment_methods_serializer].new(payment_methods).serializable_hash
+          end
+
+          def serialize_shipping_rates(shipments)
+            dependencies[:shipping_rates_serializer].new(
+              shipments,
+              include: [:shipping_rates],
+              params: { show_rates: true }
+            ).serializable_hash
           end
 
           def default_resource_includes

--- a/api/app/serializers/spree/v2/storefront/shipment_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/shipment_serializer.rb
@@ -6,6 +6,8 @@ module Spree
 
         attributes :tracking, :number, :cost, :display_cost, :discounted_cost, :display_discounted_cost,
                    :final_price, :display_final_price, :item_cost, :display_item_cost, :shipped_at
+
+        has_many :shipping_rates, if: proc { |_record, params| params&.dig(:show_rates) }
       end
     end
   end

--- a/api/app/serializers/spree/v2/storefront/shipment_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/shipment_serializer.rb
@@ -4,8 +4,10 @@ module Spree
       class ShipmentSerializer < BaseSerializer
         set_type :shipment
 
-        attributes :tracking, :number, :cost, :display_cost, :discounted_cost, :display_discounted_cost,
-                   :final_price, :display_final_price, :item_cost, :display_item_cost, :shipped_at
+        attributes :number, :final_price, :display_final_price,
+                   :state, :shipped_at, :tracking_url
+
+        attribute :free, &:free?
 
         has_many :shipping_rates, if: proc { |_record, params| params&.dig(:show_rates) }
       end

--- a/api/app/serializers/spree/v2/storefront/shipping_rate_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/shipping_rate_serializer.rb
@@ -7,9 +7,7 @@ module Spree
         attributes :name, :selected, :final_price, :display_final_price, :cost,
                    :display_cost, :tax_amount, :display_tax_amount, :shipping_method_id
 
-        attribute :free do |object|
-          object.free?
-        end
+        attribute :free, &:free?
       end
     end
   end

--- a/api/app/serializers/spree/v2/storefront/shipping_rate_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/shipping_rate_serializer.rb
@@ -1,0 +1,12 @@
+module Spree
+  module V2
+    module Storefront
+      class ShippingRateSerializer < BaseSerializer
+        set_type :shipping_rate
+
+        attributes :name, :cost, :selected, :display_cost, :tax_amount,
+                   :display_tax_amount, :shipping_method_id
+      end
+    end
+  end
+end

--- a/api/app/serializers/spree/v2/storefront/shipping_rate_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/shipping_rate_serializer.rb
@@ -4,8 +4,12 @@ module Spree
       class ShippingRateSerializer < BaseSerializer
         set_type :shipping_rate
 
-        attributes :name, :cost, :selected, :display_cost, :tax_amount,
-                   :display_tax_amount, :shipping_method_id
+        attributes :name, :selected, :final_price, :display_final_price, :cost,
+                   :display_cost, :tax_amount, :display_tax_amount, :shipping_method_id
+
+        attribute :free do |object|
+          object.free?
+        end
       end
     end
   end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -146,6 +146,7 @@ Spree::Core::Engine.add_routes do
           post :add_store_credit
           post :remove_store_credit
           get :payment_methods
+          get :shipping_rates
         end
 
         resource :account, controller: :account, only: %i[show]

--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -580,6 +580,28 @@ paths:
         - orderToken: []
         - bearerAuth: []
 
+  '/checkout/shipping_rates':
+    get:
+      description: >-
+        Returns a list of available Shipping Rates for Checkout.
+        Shipping Rates are grouped against Shipments.
+        Each checkout cna have multiple Shipments eg. some products are available
+        in stock and will be send out instantly and some needs to be backordered.
+      tags:
+        - Checkout
+      responses:
+        '200':
+          description: Returns a list of available Shipping Rates for Checkout
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ShippingRatesList'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+      security:
+        - orderToken: []
+        - bearerAuth: []
+
   '/products':
     get:
       description: >-
@@ -1900,6 +1922,133 @@ components:
             description:
               type: string
               example: 'Stripe Payments'
+    ShipmentAttributesWithoutRelationsips:
+      properties:
+        id:
+          type: string
+          example: '1'
+        type:
+          type: string
+          default: 'shipment'
+          example: 'shipment'
+        attributes:
+          $ref: '#/components/schemas/ShipmentAttributes'
+        relationships:
+          type: object
+    ShipmentAttributesAndRelationsips:
+      properties:
+        id:
+          type: string
+          example: '1'
+        type:
+          type: string
+          default: 'shipment'
+          example: 'shipment'
+        attributes:
+          $ref: '#/components/schemas/ShipmentAttributes'
+        relationships:
+          properties:
+            shipping_rates:
+              properties:
+                data:
+                  type: array
+                  items:
+                    oneOf:
+                      - $ref: '#/components/schemas/Relation'
+    ShipmentAttributes:
+      properties:
+        number:
+          type: string
+          example: 'H121354'
+          descriptipon: 'Unique Shipment identifier'
+        free:
+          type: boolean
+          example: true
+          description: 'Indicates if the Shipping Rate is free, eg. when Free shipping promo applied to Cart'
+        final_price:
+          type: string
+          example: '10.0'
+          description: 'Price to be presented for the Customer'
+        display_final_price:
+          type: string
+          example: '$10.00'
+        tracking_url:
+          type: string
+          example: 'https://tools.usps.com/go/TrackConfirmAction?tRef=fullpage&tLc=2&text28777=&tLabels=4123412434%2C'
+          description: 'Tracking URL to the service provider website'
+        state:
+          type: string
+          example: 'shipped'
+          description: >-
+            Status of the Shipment. For list of all available statuses please refer:
+            <a href="https://guides.spreecommerce.org/developer/shipments.html#overview" target="_blank" rel="noopener">
+              Shipment section in Spree Guides
+            </a>
+        shipped_at:
+          type: string
+          format: 'date-time'
+          example: '2019-01-02 13:42:12 UTC'
+          description: 'Date when Shipment was being sent from the warehouse'
+    ShippingRatesList:
+      required:
+        - data
+        - included
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/ShipmentAttributesAndRelationsips'
+        included:
+          type: array
+          items:
+            oneOf:
+              - $ref: '#/components/schemas/ShippingRate'
+    ShippingRate:
+      properties:
+        id:
+          type: string
+          example: '1'
+        type:
+          type: string
+          default: 'shipping_rate'
+          example: 'shipping_rate'
+        attributes:
+          type: object
+          properties:
+            name:
+              type: string
+              example: 'USPS Ground'
+            selected:
+              type: boolean
+              example: true
+            free:
+              type: boolean
+              example: true
+              description: 'Indicates if the Shipping Rate is free, eg. when Free shipping promo applied to Cart'
+            final_price:
+              type: string
+              example: '10.0'
+              description: 'Price to be presented for the Customer'
+            display_final_price:
+              type: string
+              example: '$10.00'
+            cost:
+              type: string
+              example: '10.0'
+              description: 'Price of the service without discounts applied'
+            display_cost:
+              type: string
+              example: '$10.00'
+            tax_amount:
+              type: string
+              example: '0.0'
+              description: 'Eligible tax for service (if any)'
+            display_tax_amount:
+              type: string
+              example: '$0.00'
+            shipping_method_id:
+              type: integer
+              example: 1
     Account:
       required:
         - data

--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -262,6 +262,164 @@ paths:
         - orderToken: []
         - bearerAuth: []
 
+  '/checkout':
+    patch:
+      description: >-
+        Updates the Checkout
+        <br />
+        <p>
+          You can run multiple Checkout updates with different data types.
+        </p>
+        <h3>1. Update the Customer information<h3>
+        <pre>PATCH /checkout</pre>
+        <br />
+        <pre>
+          order: {
+            email: 'john@snow.org',
+            bill_address_attributes: {
+              {
+                firstname: 'John',
+                lastname: 'Snow',
+                address1: '7735 Old Georgetown Road',
+                city: 'Bethesda',
+                phone: '3014445002',
+                zipcode: '20814',
+                state_name: 'MD',
+                country_id: 232
+              }
+            },
+            ship_address_attributes: {
+              {
+                firstname: 'John',
+                lastname: 'Snow',
+                address1: '7735 Old Georgetown Road',
+                city: 'Bethesda',
+                phone: '3014445002',
+                zipcode: '20814',
+                state_name: 'MD',
+                country_id: 232
+              }
+            }
+          }
+        </pre>
+        <h3>2. Fetch Shipping Rates</h3>
+        <pre>
+        GET /checkout/shipping_rates
+        </pre>
+        <br />
+        <p>
+          Order can have multiple Shipments, eg. some Items will be shipped right away,
+          and some needs to be backordered.
+        </p>
+        <p>
+          Each Shipment can have different Shipping Method/Rate selected.
+        </p>
+
+        <h3>3. Select shipping method(s)</h3>
+        <pre>PATCH /checkout</pre>
+        <br />
+        <pre>
+          order: {
+            shipments_attributes: {
+              '0' => { selected_shipping_rate_id: 1, id: 1}
+            }
+          }
+        </pre>
+        <br />
+        <p>
+          <code>selected_shipping_rate_id</code> is the ID of a Shipping Rate.
+          <code>id</code> is the ID of the Shipment itself. You can update multiple
+          Shipments at once.
+        </p>
+        <h3>4. Add Payment Source(s)</h3>
+        <pre>PATCH /checkout</pre>
+        <br />
+        <pre>
+          {
+            order: {
+              payments_attributes: [
+                {
+                  payment_method_id: 1
+                }
+              ]
+            },
+            payment_source: {
+              '1' => {
+                number: '4111111111111111',
+                month: '01',
+                year: '2022',
+                verification_value: '123',
+                name: 'John Doe'
+              }
+            }
+          }
+        </pre>
+        <br />
+        <p>
+          You can obtain <code>payment_method_id</code> by querying
+          <code>GET /checkout/payment_methods</code> endpoint.
+        </p>
+        <h3>5. Complete checkout</h3>
+        <pre>PATCH /checkout/complete</pre>
+        <br />
+        <p>
+          This will complete the Checout and will marke the Order as completed.
+          You cannot execute any operations on this Order anymore via Storefront API.
+          Further operations on the Order are possible via Platform API.
+        </p>
+      tags:
+        - Checkout
+      responses:
+        '200':
+          description: Checkout was updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Cart'
+        '422':
+          description: Checkout couldn't be updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+      security:
+        - orderToken: []
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/CartIncludeParam'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                order:
+                  type: object
+                  properties:
+                    email:
+                      type: string
+                      example: 'john@snow.org'
+                    bill_address_attributes:
+                      $ref: '#/components/schemas/AddressPayload'
+                    ship_address_attributes:
+                      $ref: '#/components/schemas/AddressPayload'
+                    payments_attributes:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          payment_method_id:
+                            type: number
+                            example: 1
+                            description: 'ID of selected payment method'
+                    shipments_attributes:
+                      type: object
+                payment_source:
+                  type: object
+
   '/checkout/next':
     patch:
       description: Goes to the next Checkout step
@@ -318,30 +476,29 @@ paths:
 
   '/checkout/complete':
     patch:
-        description: Completes the Checkout
-        tags:
-          - Checkout
-        responses:
-          '200':
-            description: Checkout was completed
-            content:
-              application/json:
-                schema:
-                  $ref: '#/components/schemas/Cart'
-          '422':
-            description: Checkout couldn't be completed
-            content:
-              application/json:
-                schema:
-                  $ref: '#/components/schemas/Error'
-          '404':
-            $ref: '#/components/responses/404NotFound'
-        security:
-          - orderToken: []
-          - bearerAuth: []
-        parameters:
-        - $ref: '#/components/parameters/CartIncludeParam'
-        - $ref: '#/components/parameters/SparseFieldsParam'
+      description: Completes the Checkout
+      tags:
+        - Checkout
+      responses:
+        '200':
+          description: Checkout was completed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Cart'
+        '422':
+          description: Checkout couldn't be completed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+      security:
+        - orderToken: []
+        - bearerAuth: []
+      parameters:
+      - $ref: '#/components/parameters/CartIncludeParam'
 
   '/checkout/add_store_credit':
     post:
@@ -1795,6 +1952,42 @@ components:
           $ref: '#/components/schemas/AccountAttributes'
         relationships:
           $ref: '#/components/schemas/AccountRelationships'
+    AddressPayload:
+      properties:
+        firstname:
+          type: string
+        lastname:
+          type: string
+        address1:
+          type: string
+          description: 'Street address'
+        address2:
+          type: string
+          description: 'Additional address information, floor no etc'
+        city:
+          type: string
+          description: 'City, town'
+        phone:
+          type: string
+        zipcode:
+          type: string
+          description: 'Valid zipcode, will be validated against the selected Country'
+        state_name:
+          type: string
+          description: 'State/region/province 2 letter abbrevation'
+        country_id:
+          type: number
+          description: 'ID number of Country in the database'
+      example:
+        firstname: 'John'
+        lastname: 'Snow'
+        address1: '7735 Old Georgetown Road'
+        address2: '2nd Floor'
+        city: 'Bethesda'
+        phone: '3014445002'
+        zipcode: '20814'
+        state_name: 'MD'
+        country_id: 232
 
   parameters:
     IdOrPermalink:

--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -891,62 +891,53 @@ components:
       type: string
       example: '2018-05-25T11:22:57.214-04:00'
     Address:
-      required:
-        - data
       properties:
-        data:
+        id:
+          type: string
+          example: '1'
+        type:
+          type: string
+          default: 'address'
+          example: 'address'
+        attributes:
           type: object
-          required:
-            - id
-            - type
-            - attributes
           properties:
-            id:
+            firstname:
               type: string
-              example: '1'
-            type:
+              example: 'John'
+            lastname:
               type: string
-              default: 'address'
-              example: 'address'
-            attributes:
-              type: object
-              properties:
-                firstname:
-                  type: string
-                  example: 'John'
-                lastname:
-                  type: string
-                  example: 'Doe'
-                address1:
-                  type: string
-                  example: '1600 Amphitheatre Pkwy'
-                address2:
-                  type: string
-                  example: 'Suite 1'
-                city:
-                  type: string
-                  example: 'Mountain View'
-                zipcode:
-                  type: string
-                  example: '94043'
-                phone:
-                  type: string
-                  example: '(+1) 123 456 789'
-                state_name:
-                  type: string
-                  example: 'California'
-                state_code:
-                  type: string
-                  example: 'CA'
-                country_name:
-                  type: string
-                  example: 'United States of America'
-                country_iso3:
-                  type: string
-                  example: 'USA'
-                company:
-                  type: string
-                  example: 'Google Inc.'
+              example: 'Doe'
+            address1:
+              type: string
+              example: '1600 Amphitheatre Pkwy'
+            address2:
+              type: string
+              example: 'Suite 1'
+            city:
+              type: string
+              example: 'Mountain View'
+            zipcode:
+              type: string
+              example: '94043'
+            phone:
+              type: string
+              example: '(+1) 123 456 789'
+            state_name:
+              type: string
+              example: 'California'
+            state_code:
+              type: string
+              example: 'CA'
+            country_name:
+              type: string
+              example: 'United States of America'
+            country_iso3:
+              type: string
+              example: 'USA'
+            company:
+              type: string
+              example: 'Google Inc.'
     Cart:
       required:
         - data
@@ -962,8 +953,11 @@ components:
           properties:
             id:
               type: string
+              example: '1'
             type:
               type: string
+              example: 'cart'
+              default: 'cart'
             attributes:
               type: object
               properties:
@@ -1085,16 +1079,27 @@ components:
                   properties:
                     data:
                       $ref: '#/components/schemas/Relation'
+                payments:
+                  type: object
+                  properties:
+                    data:
+                      $ref: '#/components/schemas/Relation'
+                shipments:
+                  type: object
+                  properties:
+                    data:
+                      $ref: '#/components/schemas/Relation'
         included:
           type: array
           items:
             type: object
             oneOf:
-              - $ref: '#/components/schemas/Variant'
+              - $ref: '#/components/schemas/VariantAttributesAndRelationships'
               - $ref: '#/components/schemas/LineItem'
               - $ref: '#/components/schemas/Promotion'
               - $ref: '#/components/schemas/User'
               - $ref: '#/components/schemas/Address'
+              - $ref: '#/components/schemas/ShipmentAttributesWithoutRelationsips'
     Image:
       required:
         - data
@@ -1136,132 +1141,123 @@ components:
           example: 1080
           description: 'Actual height of image'
     User:
-      required:
-        - data
       properties:
-        data:
+        id:
+          type: string
+          example: 1
+        type:
+          type: string
+          default: 'user'
+          example: 'user'
+        attributes:
           type: object
           properties:
-            id:
+            email:
               type: string
-              example: 1
-            type:
-              type: string
-              default: 'user'
-              example: 'user'
-            attributes:
-              type: object
-              properties:
-                email:
-                  type: string
-                  example: 'spree@example.com'
+              example: 'spree@example.com'
     LineItem:
-      required:
-        - data
       properties:
-        data:
+        id:
+          type: string
+          example: '1'
+        type:
+          type: string
+          default: 'line_item'
+          example: 'line_item'
+        attributes:
           type: object
           properties:
-            id:
+            name:
               type: string
-              example: '1'
-            type:
+              example: 'Sample product'
+            quantity:
+              type: integer
+              example: 1
+            slug:
               type: string
-              default: 'line_item'
-              example: 'line_item'
-            attributes:
-              type: object
-              properties:
-                name:
-                  type: string
-                  example: 'Sample product'
-                quantity:
-                  type: integer
-                  example: 1
-                slug:
-                  type: string
-                  example: 'sample-product'
-                options_text:
-                  type: string
-                  example: 'Size: small, Color: red'
-                price:
-                  type: string
-                  example: '125.0'
-                  description: Price of Product per quantity
-                currency:
-                  type: string
-                  example: 'USD'
-                display_price:
-                  type: string
-                  example: '$125.00'
-                  description: Price of Product per quantity
-                total:
-                  type: string
-                  example: '250.0'
-                  description: >-
-                    Total price of Line Item including adjastments, promotions
-                    and taxes
-                display_total:
-                  type: string
-                  example: '$250.00'
-                  description: >-
-                    Total price of Line Item including adjastments, promotions
-                    and taxes
-                adjustment_total:
-                  type: string
-                  example: '10.0'
-                  description: TBD
-                display_adjustment_total:
-                  type: string
-                  example: '$10.00'
-                  description: TBD
-                additional_tax_total:
-                  type: string
-                  example: '5.0'
-                display_additional_tax_total:
-                  type: string
-                  example: '$5.00'
-                promo_total:
-                  type: string
-                  example: '-5.0'
-                display_promo_total:
-                  type: string
-                included_tax_total:
-                  type: string
-                  example: '0.0'
-                  description: 'Taxes included in the price, eg. VAT'
-                display_inluded_tax_total:
-                  type: string
-                  example: '$0.00'
+              example: 'sample-product'
+            options_text:
+              type: string
+              example: 'Size: small, Color: red'
+            price:
+              type: string
+              example: '125.0'
+              description: Price of Product per quantity
+            currency:
+              type: string
+              example: 'USD'
+            display_price:
+              type: string
+              example: '$125.00'
+              description: Price of Product per quantity
+            total:
+              type: string
+              example: '250.0'
+              description: >-
+                Total price of Line Item including adjastments, promotions
+                and taxes
+            display_total:
+              type: string
+              example: '$250.00'
+              description: >-
+                Total price of Line Item including adjastments, promotions
+                and taxes
+            adjustment_total:
+              type: string
+              example: '10.0'
+              description: TBD
+            display_adjustment_total:
+              type: string
+              example: '$10.00'
+              description: TBD
+            additional_tax_total:
+              type: string
+              example: '5.0'
+            display_additional_tax_total:
+              type: string
+              example: '$5.00'
+            promo_total:
+              type: string
+              example: '-5.0'
+            display_promo_total:
+              type: string
+            included_tax_total:
+              type: string
+              example: '0.0'
+              description: 'Taxes included in the price, eg. VAT'
+            display_inluded_tax_total:
+              type: string
+              example: '$0.00'
+        relationships:
+          variant:
+            type: object
+            properties:
+              data:
+                $ref: '#/components/schemas/Relation'
     Promotion:
-      required:
-        - data
       properties:
-        data:
+        id:
+          type: string
+          example: '1'
+        type:
+          type: string
+          example: 'promotion'
+          default: 'promotion'
+        attributes:
           type: object
           properties:
-            id:
+            name:
               type: string
-              example: '1'
-            type:
+              example: '10% Discount'
+            descriptiom:
               type: string
-              example: 'promotion'
-              default: 'promotion'
-            attributes:
-              type: object
-              properties:
-                name:
-                  type: string
-                  example: '10% Discount'
-                descriptiom:
-                  type: string
-                  example: 'Super discount for you'
-                amount:
-                  type: string
-                  example: '-10.0'
-                display_amount:
-                  type: string
-                  example: '-$10.00'
+              example: 'Super discount for you'
+            amount:
+              type: string
+              example: '-10.0'
+            display_amount:
+              type: string
+              example: '-$10.00'
     Product:
       required:
         - data
@@ -2049,6 +2045,7 @@ components:
             shipping_method_id:
               type: integer
               example: 1
+              description: 'ID of a Shipping Method. You will need this for the Checkout Update action'
     Account:
       required:
         - data

--- a/api/spec/requests/spree/api/v2/storefront/checkout_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/checkout_spec.rb
@@ -495,6 +495,7 @@ describe 'API V2 Storefront Checkout Spec', type: :request do
 
   describe 'checkout#payment_methods' do
     let(:execute) { get '/api/v2/storefront/checkout/payment_methods', headers: headers }
+    let!(:payment_method) { create(:credit_card_payment_method) }
     let(:payment_methods) { order.available_payment_methods }
 
     shared_examples 'returns a list of available payment methods' do
@@ -503,13 +504,12 @@ describe 'API V2 Storefront Checkout Spec', type: :request do
       it_behaves_like 'returns 200 HTTP status'
 
       it 'returns valid payment methods JSON' do
-        payment_methods.each_with_index do |payment_method, index|
-          expect(json_response['data'][index]).to have_id(payment_method.id.to_s)
-          expect(json_response['data'][index]).to have_type('payment_method')
-          expect(json_response['data'][index]).to have_attribute(:name).with_value(payment_method.name)
-          expect(json_response['data'][index]).to have_attribute(:description).with_value(payment_method.description)
-          expect(json_response['data'][index]).to have_attribute(:type).with_value(payment_method.type)
-        end
+        expect(json_response['data']).not_to be_empty
+        expect(json_response['data'][0]).to have_id(payment_method.id.to_s)
+        expect(json_response['data'][0]).to have_type('payment_method')
+        expect(json_response['data'][0]).to have_attribute(:name).with_value(payment_method.name)
+        expect(json_response['data'][0]).to have_attribute(:description).with_value(payment_method.description)
+        expect(json_response['data'][0]).to have_attribute(:type).with_value(payment_method.type)
       end
     end
 

--- a/api/spec/requests/spree/api/v2/storefront/checkout_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/checkout_spec.rb
@@ -566,13 +566,16 @@ describe 'API V2 Storefront Checkout Spec', type: :request do
         expect(json_response['included'][0]).to have_id(shipping_rate.id.to_s)
         expect(json_response['included'][0]).to have_type('shipping_rate')
         expect(json_response['included'][0]).to have_attribute(:name).with_value(shipping_method.name)
+        expect(json_response['included'][0]).to have_attribute(:final_price).with_value(shipping_rate.final_price.to_s)
+        expect(json_response['included'][0]).to have_attribute(:display_final_price).with_value(shipping_rate.display_final_price.to_s)
         expect(json_response['included'][0]).to have_attribute(:cost).with_value(shipping_rate.cost.to_s)
         expect(json_response['included'][0]).to have_attribute(:display_cost).with_value(shipping_rate.display_cost.to_s)
         expect(json_response['included'][0]).to have_attribute(:display_cost).with_value(shipping_rate.display_cost.to_s)
         expect(json_response['included'][0]).to have_attribute(:tax_amount).with_value(shipping_rate.tax_amount.to_s)
         expect(json_response['included'][0]).to have_attribute(:display_tax_amount).with_value(shipping_rate.display_tax_amount.to_s)
         expect(json_response['included'][0]).to have_attribute(:shipping_method_id).with_value(shipping_method.id)
-        expect(json_response['included'][0]).to have_attribute(:selected).with_value(true)
+        expect(json_response['included'][0]).to have_attribute(:selected).with_value(shipping_rate.selected)
+        expect(json_response['included'][0]).to have_attribute(:free).with_value(shipping_rate.free?)
       end
     end
 

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -103,6 +103,7 @@ module Spree
       inventory_units.any?(&:backordered?)
     end
 
+    # TODO: delegate currency to Order, order.currency is mandatory
     def currency
       order ? order.currency : Spree::Config[:currency]
     end
@@ -132,6 +133,12 @@ module Spree
 
     def final_price_with_items
       item_cost + final_price
+    end
+
+    def free?
+      return true if final_price == BigDecimal(0)
+
+      adjustments.promotion.any? { |p| p.source.type == 'Spree::Promotion::Actions::FreeShipping' }
     end
 
     def finalize!

--- a/core/app/models/spree/shipping_rate.rb
+++ b/core/app/models/spree/shipping_rate.rb
@@ -6,9 +6,9 @@ module Spree
 
     extend Spree::DisplayMoney
 
-    money_methods :base_price, :tax_amount
+    money_methods :base_price, :final_price, :tax_amount
 
-    delegate :order, :currency, to: :shipment
+    delegate :order, :currency, :free?, to: :shipment
     delegate :name,             to: :shipping_method
     delegate :code,             to: :shipping_method, prefix: true
 
@@ -38,6 +38,22 @@ module Spree
 
     def tax_rate
       Spree::TaxRate.unscoped { super }
+    end
+
+    # returns base price - any available discounts for this Shipment
+    # useful when you want to present a list of available shipping rates
+    def final_price
+      if free? || cost < -discount_amount
+        BigDecimal(0)
+      else
+        cost + discount_amount
+      end
+    end
+
+    private
+
+    def discount_amount
+      shipment.adjustments.promotion.sum(:amount)
     end
   end
 end

--- a/core/app/models/spree/shipping_rate.rb
+++ b/core/app/models/spree/shipping_rate.rb
@@ -29,7 +29,7 @@ module Spree
     alias_attribute :base_price, :cost
 
     def tax_amount
-      @tax_amount ||= tax_rate.calculator.compute_shipping_rate(self)
+      @tax_amount ||= tax_rate&.calculator&.compute_shipping_rate(self) || BigDecimal(0)
     end
 
     def shipping_method

--- a/core/app/services/spree/checkout/get_shipping_rates.rb
+++ b/core/app/services/spree/checkout/get_shipping_rates.rb
@@ -1,0 +1,48 @@
+module Spree
+  module Checkout
+    class GetShippingRates
+      prepend Spree::ServiceModule::Base
+
+      def call(order:)
+        run :reload_order
+        run :ensure_shipping_address
+        run :ensure_line_items_present
+        run :generate_shipping_rates
+        run :return_shipments
+      end
+
+      private
+
+      # we need to reload order to fetch the most up-to-date version of it
+      def reload_order(order:)
+        success(order: order.reload)
+      end
+
+      def ensure_shipping_address(order:)
+        return failure([], Spree.t('errors.services.get_shipping_rates.no_shipping_address')) if order.ship_address.blank?
+
+        success(order: order)
+      end
+
+      def ensure_line_items_present(order:)
+        return failure([], Spree.t('errors.services.get_shipping_rates.no_line_items')) if order.line_items.empty?
+
+        success(order: order)
+      end
+
+      def generate_shipping_rates(order:)
+        ApplicationRecord.transaction do
+          order.create_proposed_shipments
+          order.create_shipment_tax_charge!
+          order.set_shipments_cost
+          order.apply_free_shipping_promotions
+        end
+        success(order: order.reload)
+      end
+
+      def return_shipments(order:)
+        success(order.shipments.includes([shipping_rates: :shipping_method]))
+      end
+    end
+  end
+end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -732,6 +732,10 @@ en:
         blank: can't be blank
         could_not_create_taxon: Could not create taxon
         no_shipping_methods_available: No shipping methods available for selected location, please change your address and try again.
+      services:
+        get_shipping_rates:
+          no_shipping_address: To generate Shipping Rates Order needs to have a Shipping Address
+          no_line_items: To generate Shipping Rates you need to add some Line Items to Order
     errors_prohibited_this_record_from_being_saved:
       one: 1 error prohibited this record from being saved
       other: ! '%{count} errors prohibited this record from being saved'

--- a/core/lib/spree/testing_support/factories/promotion_factory.rb
+++ b/core/lib/spree/testing_support/factories/promotion_factory.rb
@@ -48,4 +48,14 @@ FactoryBot.define do
     end
     factory :promotion_with_item_total_rule, traits: [:with_item_total_rule]
   end
+
+  factory :free_shipping_promotion, class: Spree::Promotion do
+    name { 'Free Shipping Promotion' }
+
+    after(:create) do |promotion|
+      action = Spree::Promotion::Actions::FreeShipping.new
+      action.promotion = promotion
+      action.save
+    end
+  end
 end

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -170,6 +170,24 @@ describe Spree::Shipment, type: :model do
     expect(shipment.final_price).to eq(8)
   end
 
+  context '#free?' do
+    let!(:order) { create(:order) }
+    let!(:shipment) { create(:shipment, cost: 10, order: order) }
+    let(:free_shipping_promotion) { create(:free_shipping_promotion, code: 'freeship') }
+
+    it 'returns true if final_price is equal to 0' do
+      shipment.adjustment_total = -10
+      expect(shipment.free?).to eq(true)
+    end
+
+    it 'returns when Free Shipping promotion is applied' do
+      order.coupon_code = free_shipping_promotion.code
+      Spree::PromotionHandler::Coupon.new(order).apply
+      expect(order.promotions).to include(free_shipping_promotion)
+      expect(shipment.free?).to eq(true)
+    end
+  end
+
   context 'manifest' do
     let(:order) { Spree::Order.create }
     let(:variant) { create(:variant) }

--- a/core/spec/models/spree/shipping_rate_spec.rb
+++ b/core/spec/models/spree/shipping_rate_spec.rb
@@ -141,4 +141,26 @@ describe Spree::ShippingRate, type: :model do
       end
     end
   end
+
+  context '#final_price' do
+    let(:free_shipping_promotion) { create(:free_shipping_promotion, code: 'freeship') }
+    let(:order) { shipment.order }
+
+    it 'returns 0 if free shipping promotion is applied' do
+      order.coupon_code = free_shipping_promotion.code
+      Spree::PromotionHandler::Coupon.new(order).apply
+      expect(order.promotions).to include(free_shipping_promotion)
+      expect(shipping_rate.final_price).to eq(0.0)
+    end
+
+    it 'returns 0 if cost is lesser than the discount amount' do
+      allow_any_instance_of(Spree::ShippingRate).to receive_messages(discount_amount: -20.0)
+      expect(shipping_rate.final_price).to eq(0.0)
+    end
+
+    it 'returns cost minus discount amount' do
+      allow_any_instance_of(Spree::ShippingRate).to receive_messages(discount_amount: -5.0)
+      expect(shipping_rate.final_price).to eq(5.0)
+    end
+  end
 end

--- a/core/spec/models/spree/shipping_rate_spec.rb
+++ b/core/spec/models/spree/shipping_rate_spec.rb
@@ -133,4 +133,12 @@ describe Spree::ShippingRate, type: :model do
       expect(shipping_rate.tax_rate).to eq(tax_rate)
     end
   end
+
+  context '#tax_amount' do
+    context 'without tax rate' do
+      it 'returns 0.0' do
+        expect(shipping_rate.tax_amount).to eq(0.0)
+      end
+    end
+  end
 end

--- a/core/spec/services/spree/checkout/get_shipping_rates_spec.rb
+++ b/core/spec/services/spree/checkout/get_shipping_rates_spec.rb
@@ -1,0 +1,127 @@
+require 'spec_helper'
+
+module Spree
+  describe Checkout::GetShippingRates do
+    subject { described_class }
+
+    let(:order) { create(:order) }
+    let(:line_item) { create(:line_item, order: order) }
+    let(:shipment) { order.reload.shipments.first }
+
+    let(:execute) { subject.call(order: order) }
+    let(:value) { execute.value }
+    let(:error) { execute.error.to_s }
+
+    let!(:country) { create(:country) }
+    let!(:shipping_method) do
+      create(:shipping_method).tap do |shipping_method|
+        shipping_method.calculator.preferred_amount = 10
+        shipping_method.calculator.save
+        shipping_method.zones = [zone]
+      end
+    end
+    let!(:zone) { create(:zone) }
+    let!(:zone_member) { create(:zone_member, zone: zone, zoneable: country) }
+    let(:address) { create(:address, country: country) }
+
+    let(:free_shipping_promotion) { create(:free_shipping_promotion) }
+
+    shared_examples 'generates shipping rates' do
+      it 'returns shipping rates' do
+        expect(execute.success?).to eq(true)
+        expect(value).not_to be_empty
+        expect(value).to eq(order.reload.shipments)
+        expect(shipment.shipping_method).to eq(shipping_method)
+      end
+
+      it "doesn't update checkout state" do
+        expect { execute }.not_to change {
+          order.state
+          order.completed_at
+        }
+      end
+    end
+
+    shared_examples 'applies standard shipping costs' do
+      before { execute }
+
+      it 'for shipment' do
+        expect(shipment.final_price).to eq(10.0)
+      end
+
+      it 'updates shipment total' do
+        expect(order.reload.shipment_total).to eq(10.0)
+      end
+    end
+
+    shared_examples 'failure' do
+      it 'returns error' do
+        expect(execute.success?).to eq(false)
+        expect(value).to be_empty
+        expect(error).to eq(error_message)
+      end
+
+      it "doesn't generate shipping rates" do
+        expect { execute }.not_to change {
+          Spree::ShippingRate.count
+          order.shipments
+          order.state
+          order.completed_at
+        }
+      end
+    end
+
+    context 'without shipping address' do
+      let(:error_message) { 'To generate Shipping Rates Order needs to have a Shipping Address' }
+
+      it_behaves_like 'failure'
+    end
+
+    context 'without line items' do
+      let(:error_message) { 'To generate Shipping Rates you need to add some Line Items to Order' }
+
+      before do
+        order.ship_address = address
+        order.save!
+      end
+
+      it_behaves_like 'failure'
+    end
+
+    context 'with line items and shipping address' do
+      before do
+        line_item
+        order.ship_address = address
+        order.save!
+      end
+
+      context 'without shipments' do
+        before { order.shipments.destroy_all }
+
+        it_behaves_like 'generates shipping rates'
+        it_behaves_like 'applies standard shipping costs'
+      end
+
+      context 'with already present shipments' do
+        it_behaves_like 'generates shipping rates'
+        it_behaves_like 'applies standard shipping costs'
+
+        it 'replaces current shipments with new ones' do
+          expect { execute }.to change { order.shipments.pluck(:number) }
+        end
+      end
+
+      context 'with free shipping promotion' do
+        before do
+          free_shipping_promotion
+          execute
+        end
+
+        it 'applies promotion' do
+          expect(order.promotions).to include(free_shipping_promotion)
+          expect(shipment.final_price).to eq(0.0)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
 - [X] Added Checkout Shipping Rates endpoint (`/checkout/shipping_ratea`)
- [X] Fixed `ShippingRate#tax_amount` method if no tax is applied
- [X] Added specs for selecting Shipping Rates
- [X] Added request specs for full checkout flow
- [X] Updated Checkout OpenAPI docs