### PR TITLE
Do not apply user-coupled promotions to all carts

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -120,7 +120,12 @@ module Spree
     def eligible?(promotable)
       return false if expired? || usage_limit_exceeded?(promotable) || blacklisted?(promotable)
 
-      !!eligible_rules(promotable, {})
+      case promotable
+      when Spree::LineItem
+        !!eligible_rules(promotable, {}) && !!eligible_rules(promotable.order, {})
+      else
+        !!eligible_rules(promotable, {})
+      end
     end
 
     # eligible_rules returns an array of promotion rules where eligible? is true for the promotable

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -120,12 +120,11 @@ module Spree
     def eligible?(promotable)
       return false if expired? || usage_limit_exceeded?(promotable) || blacklisted?(promotable)
 
-      case promotable
-      when Spree::LineItem
-        !!eligible_rules(promotable, {}) && !!eligible_rules(promotable.order, {})
-      else
-        !!eligible_rules(promotable, {})
+      if promotable.is_a? Spree::LineItem
+        return false unless eligible_rules(promotable.order, {})
       end
+
+      !!eligible_rules(promotable, {})
     end
 
     # eligible_rules returns an array of promotion rules where eligible? is true for the promotable

--- a/core/spec/models/spree/adjustable/adjuster/promotion_spec.rb
+++ b/core/spec/models/spree/adjustable/adjuster/promotion_spec.rb
@@ -152,7 +152,7 @@ describe Spree::Adjustable::Adjuster::Promotion, type: :model do
             order.save
 
             order.reload
-            expect(order.all_adjustments.count).to eq(4)
+            expect(order.all_adjustments.count).to eq(2)
             expect(order.all_adjustments.eligible.count).to eq(2)
 
             order.all_adjustments.eligible.each do |adjustment|

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -710,4 +710,22 @@ describe Spree::Promotion, type: :model do
       end
     end
   end
+
+  describe 'a user-linked promotion without a code' do
+    let(:order) { create :order }
+    let(:promo) { create :promotion_with_order_adjustment, code: nil }
+    let(:variant) { create :variant }
+    let(:test_user) { create :user }
+
+    it 'is not applied to an order with a different user' do
+      user_rule = Spree::Promotion::Rules::User.create
+      user_rule.users << test_user
+      promo.promotion_rules << user_rule
+
+      Spree::Cart::AddItem.call(order: order, variant: variant,
+                                options: { currency: order.currency })
+
+      expect(order.all_adjustments.promotion).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
The code in the Cart promotion handler will first try if a promotion is eligible for the line item. However, Promotion#eligible? is implemented in such a way that it will consider itself eligible for a line item
if it is only applicable to orders.

Therefore, a user-related promotion without a promotion code, which is not applicable to line items, will be considered eligible for all orders. If there are many such promotions, this means each order will be burdened by a large number of inactive promotion adjustments.

This change fixes this problem by checking for eligibility with both line item and order.

Closes #7227.