### PR TITLE
Fixed :promotions association in Storefront::CartSerializer

### DIFF
--- a/api/app/serializers/spree/v2/storefront/cart_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/cart_serializer.rb
@@ -17,7 +17,7 @@ module Spree
           # sometimes Order can have multiple promotions but the promo engine
           # will only apply those that are more beneficial for the customer
           # TODO: we should probably move this code out of the serializer
-          promotion_ids = cart.all_adjustments.nonzero.promotion.map { |a| a.source.promotion_id }.uniq
+          promotion_ids = cart.all_adjustments.eligible.nonzero.promotion.map { |a| a.source.promotion_id }.uniq
 
           cart.order_promotions.where(promotion_id: promotion_ids).uniq(&:promotion_id)
         end

--- a/api/app/serializers/spree/v2/storefront/cart_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/cart_serializer.rb
@@ -12,8 +12,15 @@ module Spree
 
         has_many   :line_items
         has_many   :variants
-        has_many   :promotions, object_method_name: :order_promotions,
-                                id_method_name: :order_promotion_ids
+        has_many   :promotions, id_method_name: :promotion_id do |cart|
+          # we only want to display applied and valid promotions
+          # sometimes Order can have multiple promotions but the promo engine
+          # will only apply those that are more beneficial for the customer
+          # TODO: we should probably move this code out of the serializer
+          promotion_ids = cart.all_adjustments.nonzero.promotion.map { |a| a.source.promotion_id }.uniq
+
+          cart.order_promotions.where(promotion_id: promotion_ids).uniq(&:promotion_id)
+        end
         has_many   :payments do |cart|
           cart.payments.valid
         end

--- a/api/app/serializers/spree/v2/storefront/promotion_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/promotion_serializer.rb
@@ -2,6 +2,7 @@ module Spree
   module V2
     module Storefront
       class PromotionSerializer < BaseSerializer
+        set_id     :promotion_id
         set_type   :promotion
 
         attributes :name, :description, :amount, :display_amount, :code

--- a/api/spec/requests/spree/api/v2/storefront/cart_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/cart_spec.rb
@@ -373,7 +373,6 @@ describe 'API V2 Storefront Cart Spec', type: :request do
       context 'with coupon code for free shipping' do
         let(:adjustment_value) { -shipment.cost.to_f }
         let(:adjustment_value_in_money) { Spree::Money.new(adjustment_value, currency: order.currency) }
-        let(:order_promotion_id) { order.order_promotions.find_by(promotion: promotion).id.to_s }
 
         context 'applies coupon code correctly' do
           it_behaves_like 'returns 200 HTTP status'
@@ -385,7 +384,7 @@ describe 'API V2 Storefront Cart Spec', type: :request do
           end
 
           it 'includes the promotion in the response' do
-            expect(json_response['included']).to include(have_type('promotion').and(have_id(order_promotion_id)))
+            expect(json_response['included']).to include(have_type('promotion').and(have_id(promotion.id.to_s)))
             expect(json_response['included']).to include(have_type('promotion').and(have_attribute(:amount).with_value(adjustment_value.to_s)))
             expect(json_response['included']).to include(have_type('promotion').and(have_attribute(:display_amount).with_value(adjustment_value_in_money.to_s)))
             expect(json_response['included']).to include(have_type('promotion').and(have_attribute(:code).with_value(promotion.code)))


### PR DESCRIPTION
We always want to display unique promotions, also for the ID we should use promotion_id as a reference