### PR TITLE
Allow backend shipping rates for completed orders in :update_shipments

### DIFF
--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -53,11 +53,13 @@ module Spree
 
     # give each of the shipments a chance to update themselves
     def update_shipments
+      shipping_method_filter = order.completed? ? ShippingMethod::DISPLAY_ON_BACK_END : ShippingMethod::DISPLAY_ON_FRONT_END
+
       shipments.each do |shipment|
         next unless shipment.persisted?
 
         shipment.update!(order)
-        shipment.refresh_rates
+        shipment.refresh_rates(shipping_method_filter)
         shipment.update_amounts
       end
     end

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spree/testing_support/order_walkthrough'
 
 module Spree
   describe OrderUpdater, type: :model do
@@ -207,8 +208,15 @@ module Spree
       order.state_changed('shipment')
     end
 
+    shared_context 'with original shipping method gone backend only' do
+      before do
+        order.shipments.first.shipping_method.update(display_on: :back_end)
+        create(:shipping_method) # create frontend available shipping method
+      end
+    end
+
     context 'completed order' do
-      before { allow(order).to receive_messages completed?: true }
+      before { order.update(completed_at: Time.current) }
 
       describe '#update' do
         it 'updates payment state' do
@@ -260,12 +268,19 @@ module Spree
           expect(shipment).to receive(:update_amounts)
           updater.update_shipments
         end
+
+        context 'refresh rates' do
+          include_context 'with original shipping method gone backend only'
+          let(:order) { create(:completed_order_with_totals) }
+
+          it 'keeps the original shipping method' do
+            expect { updater.update_shipments }.not_to change { order.shipments.first.shipping_method }
+          end
+        end
       end
     end
 
-    context 'incompleted order' do
-      before { allow(order).to receive_messages completed?: false }
-
+    context 'incomplete order' do
       it 'doesnt update payment state' do
         expect(updater).not_to receive(:update_payment_state)
         updater.update
@@ -288,6 +303,16 @@ module Spree
         allow(updater).to receive(:update_totals) # Otherwise this gets called and causes a scene
         expect(updater).not_to receive(:update_shipments).with(order)
         updater.update
+      end
+
+      describe '#update_shipments' do
+        include_context 'with original shipping method gone backend only'
+        let(:order) { ::OrderWalkthrough.up_to(:delivery) }
+
+        it 'resets shipping method to frontend-available' do
+          order.updater.update_shipments
+          expect(order.shipments.first.shipping_method).to eq Spree::ShippingMethod.find_by(display_on: 'both')
+        end
       end
     end
   end


### PR DESCRIPTION
If an order placed with a shipping method that later moved to backend-only
events like _payment capture_ should not change it back