### PR TITLE
Replace sass with sassc

### DIFF
--- a/backend/spree_backend.gemspec
+++ b/backend/spree_backend.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_api', s.version
   s.add_dependency 'spree_core', s.version
 
-  s.add_dependency 'bootstrap-sass',  '~> 3.3'
+  s.add_dependency 'bootstrap-sass',  '~> 3.4'
   s.add_dependency 'jquery-rails',    '~> 4.3'
   s.add_dependency 'jquery-ui-rails', '~> 6.0.1'
   s.add_dependency 'select2-rails',   '3.5.9.1' # 3.5.9.2 breaks several specs

--- a/cmd/lib/spree_cmd/templates/extension/extension.gemspec
+++ b/cmd/lib/spree_cmd/templates/extension/extension.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'mysql2'
   s.add_development_dependency 'pg'
   s.add_development_dependency 'rspec-rails'
-  s.add_development_dependency 'sass-rails'
+  s.add_development_dependency 'sassc-rails'
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'

--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -3,8 +3,7 @@
 # the one component of Spree.
 source 'https://rubygems.org'
 
-gem 'sass-rails'
-gem 'sass', '~> 3.6.0' # https://github.com/sass/ruby-sass/issues/94
+gem 'sassc-rails'
 gem 'sqlite3', platforms: [:ruby, :mingw, :mswin, :x64_mingw]
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
 gem 'doorkeeper'

--- a/frontend/spree_frontend.gemspec
+++ b/frontend/spree_frontend.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_api', s.version
   s.add_dependency 'spree_core', s.version
 
-  s.add_dependency 'bootstrap-sass',  '>= 3.3.5.1', '< 3.4'
+  s.add_dependency 'bootstrap-sass',  '~> 3.4'
   s.add_dependency 'canonical-rails', '~> 0.2.3'
   s.add_dependency 'jquery-rails',    '~> 4.3'
 

--- a/guides/content/release_notes/3_7_0.md
+++ b/guides/content/release_notes/3_7_0.md
@@ -81,11 +81,15 @@ Also please review each of the noteworthy changes, and ensure your customization
 or extensions are not effected. If you are affected by a change, and have any
 of your own tips please submit a PR to help the next person!
 
+* Replaced `sass` with `sassc`
+
+  [joshRpowell](https://github.com/spree/spree/pull/9168)
+
 * Support multiple currencies for `Store Credits` management in Admin Panel
 
   [Spark Solutions](https://github.com/spree/spree/pull/8912)
 
-* Improve error handling for XHR requests in the Admin Panel
+* Improved error handling for XHR requests in the Admin Panel
 
   [Vernon de Goede](https://github.com/spree/spree/pull/9089)
 
@@ -97,7 +101,7 @@ of your own tips please submit a PR to help the next person!
 
   [Spark Solutions](https://github.com/spree/spree/pull/8927)
 
-* Make `CreditCard` deleted softly by default
+* Made `CreditCard` deleted softly by default
 
   [Spark Solutions](https://github.com/spree/spree/pull/9054)
 
@@ -169,14 +173,18 @@ of your own tips please submit a PR to help the next person!
 
   [Spark Solutions](https://github.com/spree/spree/pull/9121)
 
-* Bump `highline` dependency to `2.0.x`
+* Bumped `highline` dependency to `2.0.x`
 
   [Chamnap Chhorn
 ](https://github.com/spree/spree/pull/9079)
 
-* Bump `paperclip` dependency to `6.1.x`
+* Bumped `paperclip` dependency to `6.1.x`
 
   [Josh Powell](https://github.com/spree/spree/pull/9028)
+
+* Bumped `bootstrap-sass` to `3.4.x`
+
+  [Spark Solutions](https://github.com/spree/spree/pull/9168)
 
 * Deprecated `Order#add_store_credit_payments` in favor of `Checkout::AddStoreCredit`
 


### PR DESCRIPTION
Ruby Sass is deprecated and will be unmaintained as of 26 March 2019. 

We also had to bump `bootstrap-sass` to `3.4.x` because this version swapped `sass` for `sassc` in this commit:
https://github.com/twbs/bootstrap-sass/commit/dcdef9bfd81a9821d775417dbdab4c5df3553ba2