### PR TITLE
STI fix needed for Image Decorator

### DIFF
--- a/guides/content/developer/customization/images.md
+++ b/guides/content/developer/customization/images.md
@@ -32,6 +32,7 @@ module YourApplication
       end
 
       def self.prepended(base)
+        base.inheritance_column = nil
         base.singleton_class.prepend ClassMethods
       end
     end


### PR DESCRIPTION
This is required to resolve random development errors:
```
Invalid single-table inheritance type: Spree::Image is not a subclass of Spree::Image
```