### PR TITLE
Add missing Spree namespace in LineItem and Variant models

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -20,7 +20,7 @@ module Spree
     validates :quantity, numericality: { only_integer: true, message: Spree.t('validation.must_be_int') }
     validates :price, numericality: true
 
-    validates_with Stock::AvailabilityValidator
+    validates_with Spree::Stock::AvailabilityValidator
     validate :ensure_proper_currency, if: -> { order.present? }
 
     before_destroy :verify_order_inventory_before_destroy, if: -> { order.has_checkout_step?('delivery') }
@@ -85,7 +85,7 @@ module Spree
     alias money display_total
 
     def sufficient_stock?
-      Stock::Quantifier.new(variant).can_supply? quantity
+      Spree::Stock::Quantifier.new(variant).can_supply? quantity
     end
 
     def insufficient_stock?
@@ -153,7 +153,7 @@ module Spree
     end
 
     def recalculate_adjustments
-      Adjustable::AdjustmentsUpdater.update(self)
+      Spree::Adjustable::AdjustmentsUpdater.update(self)
     end
 
     def update_tax_charge

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -81,7 +81,7 @@ module Spree
       )
     end
 
-    scope :not_deleted, -> { where("#{Variant.quoted_table_name}.deleted_at IS NULL") }
+    scope :not_deleted, -> { where("#{Spree::Variant.quoted_table_name}.deleted_at IS NULL") }
 
     scope :for_currency_and_available_price_amount, ->(currency = nil) do
       currency ||= Spree::Config[:currency]
@@ -112,7 +112,7 @@ module Spree
       if self[:tax_category_id].nil?
         product.tax_category
       else
-        TaxCategory.find(self[:tax_category_id])
+        Spree::TaxCategory.find(self[:tax_category_id])
       end
     end
 


### PR DESCRIPTION
Adding missing Spree namespaces in Variant and LineItem models.

This fixes `A copy of Spree::Variant has been removed from the module tree but is still active!` / `A copy of Spree::LineItem has been removed from the module tree but is still active!` errors that we've been having in development environment in a Spree 3.6.6 project.