### PR TITLE
Cache-Control: no-store

### DIFF
--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -4,7 +4,7 @@ module Spree
   # checkout which has nothing to do with updating an order that this approach
   # is waranted.
   class CheckoutController < Spree::StoreController
-    before_action :expires_now, only: [:edit]
+    before_action :set_cache_header, only: [:edit]
     before_action :load_order_with_lock
     before_action :ensure_valid_state_lock_version, only: [:update]
     before_action :set_state_if_present
@@ -189,6 +189,10 @@ module Spree
 
     def check_authorization
       authorize!(:edit, current_order, cookies.signed[:token])
+    end
+
+    def set_cache_header
+      response.headers["Cache-Control"] = "no-store"
     end
   end
 end

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -192,7 +192,7 @@ module Spree
     end
 
     def set_cache_header
-      response.headers["Cache-Control"] = "no-store"
+      response.headers['Cache-Control'] = 'no-store'
     end
   end
 end


### PR DESCRIPTION
Fixes #9188 

Use `Cache-Control: no-store` instead of Rails' `expires_now()` method that
uses `Cache-Control: no-cache`.

https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching