### PR TITLE
Fix issues with decorators for CreditCard model

### DIFF
--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -2,8 +2,11 @@ module Spree
   class CreditCard < Spree::Base
     include ActiveMerchant::Billing::CreditCardMethods
 
+    # to migrate safely from older Spree versions that din't provide safe deletion for CCs
+    # we need to ensure that we have a connection to the DB and that the `deleted_at` column exists
     if !ENV['SPREE_DISABLE_DB_CONNECTION'] &&
-        connection.data_source_exists?(:spree_credit_cards) &&
+        connected? &&
+        table_exists? &&
         connection.column_exists?(:spree_credit_cards, :deleted_at)
       acts_as_paranoid
     end


### PR DESCRIPTION
Decorators were initialized before we established a connection to the DB, resulting with connection errors.