### PR TITLE
Change API v2 content-type to application/vnd.api+json as it's requir…

### DIFF
--- a/api/app/controllers/spree/api/v2/base_controller.rb
+++ b/api/app/controllers/spree/api/v2/base_controller.rb
@@ -7,6 +7,10 @@ module Spree
         rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
         rescue_from CanCan::AccessDenied, with: :access_denied
 
+        def content_type
+          Spree::Api::Config[:api_v2_content_type]
+        end
+
         private
 
         def collection_paginator
@@ -14,16 +18,16 @@ module Spree
         end
 
         def render_serialized_payload(status = 200)
-          render json: yield, status: status
+          render json: yield, status: status, content_type: content_type
         rescue ArgumentError => exception
           render_error_payload(exception.message, 400)
         end
 
         def render_error_payload(error, status = 422)
           if error.is_a?(Struct)
-            render json: { error: error.to_s, errors: error.to_h }, status: status
+            render json: { error: error.to_s, errors: error.to_h }, status: status, content_type: content_type
           elsif error.is_a?(String)
-            render json: { error: error }, status: status
+            render json: { error: error }, status: status, content_type: content_type
           end
         end
 

--- a/api/app/models/spree/api_configuration.rb
+++ b/api/app/models/spree/api_configuration.rb
@@ -1,5 +1,6 @@
 module Spree
   class ApiConfiguration < Preferences::Configuration
     preference :requires_authentication, :boolean, default: true
+    preference :api_v2_content_type, :string, default: 'application/vnd.api+json'
   end
 end

--- a/api/config/initializers/json_api_mime_types.rb
+++ b/api/config/initializers/json_api_mime_types.rb
@@ -1,0 +1,8 @@
+api_mime_types = %w(
+  application/vnd.api+json
+  text/x-json
+  application/json
+)
+
+Mime::Type.unregister :json
+Mime::Type.register 'application/json', :json, api_mime_types

--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -34,7 +34,7 @@ paths:
         '200':
           description: ok
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/Account'
         '403':
@@ -53,7 +53,7 @@ paths:
         '200':
           description: Listing user credit cards.
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/CreditCardList'
         '403':
@@ -80,7 +80,7 @@ paths:
         '200':
           description: Listing user default credit card.
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/CreditCard'
         '403':
@@ -100,7 +100,7 @@ paths:
         '200':
           description: Listing user completed orders.
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/CartList'
         '403':
@@ -123,7 +123,7 @@ paths:
         '200':
           description: Listing user completed order.
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/Cart'
         '403':
@@ -150,7 +150,7 @@ paths:
         '201':
           description: Cart was successfully created
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/Cart'
       parameters:
@@ -165,7 +165,7 @@ paths:
         '200':
           description: Correct cart was returned
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/Cart'
         '404':
@@ -197,7 +197,7 @@ paths:
         '200':
           description: Item was added to the Cart successfully
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/Cart'
         '404':
@@ -211,7 +211,7 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          application/vnd.api+json:
             schema:
               type: object
               properties:
@@ -240,13 +240,13 @@ paths:
         '200':
           description: New quantity has been successfully set for a requested Line Item
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/Cart'
         '422':
           description: Stock quantity is not sufficient for this request to be fulfielled
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/Error'
       security:
@@ -258,7 +258,7 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          application/vnd.api+json:
             schema:
               type: object
               properties:
@@ -284,7 +284,7 @@ paths:
         '200':
           description: Requested Line Item has been removed from the Cart
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/Cart'
         '404':
@@ -303,7 +303,7 @@ paths:
         '200':
           description: Cart has been successfully emptied
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/Cart'
         '404':
@@ -325,13 +325,13 @@ paths:
         '200':
           description: Cuopon code was applied successfully
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/Cart'
         '422':
           description: Coupon code couldn't be applied
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/Error'
       security:
@@ -343,7 +343,7 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          application/vnd.api+json:
             schema:
               type: object
               properties:
@@ -371,13 +371,13 @@ paths:
         '200':
           description: Coupon code was removed successfully
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/Cart'
         '422':
           description: Coupon code couldn't be removed
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/Error'
       security:
@@ -496,13 +496,13 @@ paths:
         '200':
           description: Checkout was updated
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/Cart'
         '422':
           description: Checkout couldn't be updated
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/Error'
         '404':
@@ -515,7 +515,7 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          application/vnd.api+json:
             schema:
               type: object
               properties:
@@ -553,13 +553,13 @@ paths:
         '200':
           description: Checkout transitioned to the next step
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/Cart'
         '422':
           description: Checkout couldn't transition to the next step
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/Error'
         '404':
@@ -581,13 +581,13 @@ paths:
         '200':
           description: Checkout was advanced to the furthest step
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/Cart'
         '422':
           description: Checkout couldn't transition to the next step
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/Error'
         '404':
@@ -609,13 +609,13 @@ paths:
         '200':
           description: Checkout was completed
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/Cart'
         '422':
           description: Checkout couldn't be completed
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/Error'
         '404':
@@ -636,13 +636,13 @@ paths:
         '200':
           description: Store Credit payment created
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/Cart'
         '422':
           description: Store Credit couldn't be created
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/Error'
         '404':
@@ -671,13 +671,13 @@ paths:
         '200':
           description: Store Credit payment removed
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/Cart'
         '422':
           description: Store Credit payments weren't removed
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/Error'
         '404':
@@ -700,7 +700,7 @@ paths:
         '200':
           description: Returns a list of available Payment Methods
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/PaymentMethodsList'
         '404':
@@ -723,7 +723,7 @@ paths:
         '200':
           description: Returns a list of available Shipping Rates for Checkout
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/ShippingRatesList'
         '404':
@@ -788,7 +788,7 @@ paths:
         '200':
           description: Returns a list of Products
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/ProductsList'
   '/products/{id}':
@@ -810,7 +810,7 @@ paths:
         '200':
           description: Returns the requested Product
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/Product'
         '404':
@@ -852,7 +852,7 @@ paths:
         '200':
           description: Returns a list of Taxons
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/TaxonsList'
 
@@ -875,7 +875,7 @@ paths:
         '200':
           description: Returns the reqested Taxon
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/Taxon'
         '404':
@@ -892,7 +892,7 @@ paths:
         '200':
           description: Returns a list of all Countries
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/CountriesList'
 
@@ -915,7 +915,7 @@ paths:
         '200':
           description: Returns the requested Country
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/Country'
         '404':
@@ -936,7 +936,7 @@ paths:
         '200':
           description: Returns the default Country
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/Country'
 
@@ -2528,7 +2528,7 @@ components:
     404NotFound:
       description: Resource not found
       content:
-        application/json:
+        application/vnd.api+json:
           schema:
             properties:
               error:
@@ -2538,7 +2538,7 @@ components:
     403Forbidden:
       description: You are not authorized to access this page.
       content:
-        application/json:
+        application/vnd.api+json:
           schema:
             properties:
               error:


### PR DESCRIPTION
Rationale:
* `application/vnd.api+json` is required by JSON API spec https://jsonapi.org/format/#content-negotiation
* numerous libraries for interacting with JSON API (eg. https://github.com/orbitjs/orbit) require this as well
* still we can configure the API to use the standard `application/json`