### PR TITLE
Lock factory_bot at 4.x for extension generator

### DIFF
--- a/cmd/lib/spree_cmd/templates/extension/extension.gemspec
+++ b/cmd/lib/spree_cmd/templates/extension/extension.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'capybara-screenshot'
   s.add_development_dependency 'coffee-rails'
   s.add_development_dependency 'database_cleaner'
-  s.add_development_dependency 'factory_bot'
+  s.add_development_dependency 'factory_bot', '~> 4.7'
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'mysql2'
   s.add_development_dependency 'pg'


### PR DESCRIPTION
5.0 includes breaking changes that older versions of Spree won't be able to fix easily.

https://github.com/thoughtbot/factory_bot/issues/1255