### PR TITLE
force specific sqlite version on sandbox application.

### DIFF
--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -62,6 +62,7 @@ group :test, :development do
 end
 RUBY
 
+sed -i '' "/^gem.*sqlite3/ s/$/, '1.3.6'/" Gemfile 
 bundle install --gemfile Gemfile
 bundle exec rails db:drop || true
 bundle exec rails db:create


### PR DESCRIPTION
Closes #9240
Forces sqlite gem to version 1.3.6 in the sandbox development app.
#9233 ref