### PR TITLE
Change IF Statement to render shipments

### DIFF
--- a/backend/app/views/spree/admin/orders/_form.html.erb
+++ b/backend/app/views/spree/admin/orders/_form.html.erb
@@ -3,7 +3,7 @@
     <%= render 'spree/admin/shared/error_messages', target: @line_item %>
   <% end %>
 
-  <% if Spree::Order.checkout_step_names.include?(:delivery) %>
+  <% if @order.shipments.present? %>
     <%= render partial: "spree/admin/orders/shipment", collection: @order.shipments.order(:created_at), locals: {order: order} %>
   <% else %>
     <%= render "spree/admin/orders/line_items", order: order %>


### PR DESCRIPTION
Sometimes we do have a delivery step - but the particular order doesn't have any shippings (for various reasons).

Sometimes we don't have a delivery step, because it's either done programaticaly or the _shipping_ isn't physical, yet we might need the shipment rendered.

Instead of checking against the checkout_step we should check against any shipments that are available.