### PR TITLE
Use class with namespace for payment methods to avoid Rails 5.2 caching problems

### DIFF
--- a/core/app/models/spree/payment_method/check.rb
+++ b/core/app/models/spree/payment_method/check.rb
@@ -1,5 +1,5 @@
 module Spree
-  class PaymentMethod::Check < PaymentMethod
+  class PaymentMethod::Check < ::Spree::PaymentMethod
     def actions
       %w{capture void}
     end

--- a/core/app/models/spree/payment_method/store_credit.rb
+++ b/core/app/models/spree/payment_method/store_credit.rb
@@ -1,5 +1,5 @@
 module Spree
-  class PaymentMethod::StoreCredit < PaymentMethod
+  class PaymentMethod::StoreCredit < ::Spree::PaymentMethod
     def payment_source_class
       ::Spree::StoreCredit
     end


### PR DESCRIPTION
With rails 5.2 after code-reload in dev environment this error occurs:
```
Invalid single-table inheritance type: Spree::PaymentMethod::Check is not a subclass of Spree::PaymentMethod
```