### PR TITLE
Link fix for redirect from index.md in the user section

### DIFF
--- a/guides/src/content/user/index.md
+++ b/guides/src/content/user/index.md
@@ -7,4 +7,4 @@ Welcome to the Spree User Guides! This documentation is intended for business ow
 Should you find any errors in these guides, or topics you wish to see covered,
 please let us know by [creating an issue](https://github.com/spree/spree/issues/new) on GitHub.
 
-If you are a Spree developer, you may find the [Developer Guides](\developer/index) to be of benefit to you, though we strongly urge you to read through both sets of guides.
+If you are a Spree developer, you may find the [Developer Guides](/developer/index.html) to be of benefit to you, though we strongly urge you to read through both sets of guides.


### PR DESCRIPTION
Quick fix for now working link in the index.md file. I've missed this file previously.