### PR TITLE
Remove shipping adjustment with free shipping

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -540,6 +540,7 @@ module Spree
     def apply_free_shipping_promotions
       Spree::PromotionHandler::FreeShipping.new(self).activate
       shipments.each { |shipment| Spree::Adjustable::AdjustmentsUpdater.update(shipment) }
+      create_shipment_tax_charge!
       update_with_updater!
     end
 

--- a/core/spec/models/spree/order/adjustments_spec.rb
+++ b/core/spec/models/spree/order/adjustments_spec.rb
@@ -26,4 +26,53 @@ describe Spree::Order do
       expect(persisted_order.state).to eq('payment')
     end
   end
+
+  context 'when an order has an taxed shipment with tax included_in_price and apply free_shipping_promotion' do
+    let!(:order) { create(:order) }
+    let!(:line_item) { create(:line_item) }
+
+    let!(:country) { create(:country) }
+    let!(:zone) { create(:zone) }
+    let!(:zone_member) { create(:zone_member, zone: zone, zoneable: country) }
+    let(:address) { create(:address, country: country) }
+
+    let!(:tax_category) { create(:tax_category) }
+    let!(:tax_rate) {
+      create(:tax_rate,
+        amount: 0.2,
+        included_in_price: true,
+        tax_category: tax_category,
+        zone: zone
+      )
+    }
+    let!(:shipping_method) do
+      sm = create(:shipping_method, tax_category: tax_category)
+      sm.calculator.preferred_amount = 10
+      sm.zones = [zone]
+      sm.save
+      sm
+    end
+
+    let!(:free_shipping_promotion) {
+      create(:free_shipping_promotion, code: 'freeship')
+    }
+
+    before do
+      order.line_items << line_item
+      order.ship_address = address
+      order.create_proposed_shipments
+      order.send :ensure_available_shipping_rates
+      order.set_shipments_cost
+      order.create_shipment_tax_charge!
+    end
+
+    it 'removes the shipment tax adjustment' do
+      order.coupon_code = free_shipping_promotion.code
+      Spree::PromotionHandler::Coupon.new(order).apply
+      order.apply_free_shipping_promotions
+
+      shipment_tax_adjustments = order.shipment_adjustments.where(source_type: "Spree::TaxRate")
+      expect(shipment_tax_adjustments.blank?).to be true
+    end
+  end
 end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -533,6 +533,8 @@ describe Spree::Order, type: :model do
 
       expect(Spree::Adjustable::AdjustmentsUpdater).to receive(:update).with(shipment)
 
+      expect(Spree::TaxRate).to receive(:adjust).with(order, [shipment])
+
       expect(order.updater).to receive(:update)
       order.apply_free_shipping_promotions
     end


### PR DESCRIPTION
Shipments with tax included_in_price did not delete the tax adjustment after free_shipping_promotion was applied to the order. This PR fixed that.

This is my first rspec example I wrote. :) I use Rails default minitest in my projects. I hope it meets the requirements. Feedback is welcome!