### PR TITLE
Update form to allow input & edit of iso and iso3

### DIFF
--- a/backend/app/views/spree/admin/countries/_form.html.erb
+++ b/backend/app/views/spree/admin/countries/_form.html.erb
@@ -10,6 +10,18 @@
     <%= f.text_field :iso_name, class: 'form-control' %>
     <%= f.error_message_on :iso_name %>
   <% end %>
+  
+  <%= f.field_container :iso, class: ['form-group'], 'data-hook' => 'iso' do %>
+    <%= f.label :iso, Spree.t(:iso) %>
+    <%= f.text_field :iso, class: 'form-control' %>
+    <%= f.error_message_on :iso %>
+  <% end %>
+
+  <%= f.field_container :iso3, class: ['form-group'], 'data-hook' => 'iso3' do %>
+    <%= f.label :iso3, Spree.t(:iso3) %>
+    <%= f.text_field :iso3, class: 'form-control' %>
+    <%= f.error_message_on :iso3 %>
+  <% end %>
 
   <div data-hook="states_required" class="form-group checkbox">
     <label>

--- a/backend/spec/features/admin/configuration/countries_spec.rb
+++ b/backend/spec/features/admin/configuration/countries_spec.rb
@@ -10,6 +10,8 @@ module Spree
 
       fill_in 'Name', with: 'Brazil'
       fill_in 'Iso Name', with: 'BRL'
+      fill_in 'Iso', with: 'BR'
+      fill_in 'Iso3', with: 'BRL'
       click_button 'Create'
 
       spree_accept_alert do


### PR DESCRIPTION
Simple update to allow admins to manually enter, or edit iso and iso3 in countries form.