### PR TITLE
Remove spree4 deprecations

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -79,15 +79,6 @@ module Spree
       spree.nested_taxons_path(taxon.permalink)
     end
 
-    # human readable list of variant options
-    def variant_options(variant, _options = {})
-      ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
-        BaseHelper#variant_options is deprecated and will be removed in Spree 4.0.
-        Please use Variant#options_text or LineItem#options_text
-      DEPRECATION
-      variant.options_text
-    end
-
     def frontend_available?
       Spree::Core::Engine.frontend_available?
     end

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -61,22 +61,6 @@ module Spree
       state_name.present? ? state_name : state&.name
     end
 
-    def same_as?(other)
-      ActiveSupport::Deprecation.warn(<<-EOS, caller)
-        Address#same_as? is deprecated and will be removed in Spree 4.0. Please use Address#== instead"
-      EOS
-
-      self == other
-    end
-
-    def same_as(other)
-      ActiveSupport::Deprecation.warn(<<-EOS, caller)
-        Address#same_as is deprecated and will be removed in Spree 4.0. Please use Address#== instead"
-      EOS
-
-      self == other
-    end
-
     def to_s
       "#{full_name}: #{address1}"
     end

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -49,14 +49,6 @@ module Spree
       end
     end
 
-    def iso_name
-      ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
-    Address#iso_name is deprecated and will be removed in Spree 4.0.
-    Please use Address#country_iso_name instead
-      DEPRECATION
-      country_iso_name
-    end
-
     def full_name
       "#{firstname} #{lastname}".strip
     end

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -48,16 +48,6 @@ module Spree
 
     self.competing_promos_source_types = ['Spree::PromotionAction']
 
-    scope :open, -> {
-      ActiveSupport::Deprecation.warn 'Adjustment.open is deprecated. Please use Adjustment.not_finalized instead', caller
-      not_finalized
-    }
-
-    scope :closed, -> {
-      ActiveSupport::Deprecation.warn 'Adjustment.closed is deprecated. Please use Adjustment.finalized instead', caller
-      finalized
-    }
-
     scope :not_finalized, -> { where(state: 'open') }
     scope :finalized, -> { where(state: 'closed') }
     scope :tax, -> { where(source_type: 'Spree::TaxRate') }

--- a/core/app/models/spree/image.rb
+++ b/core/app/models/spree/image.rb
@@ -3,13 +3,6 @@ module Spree
     include Configuration::ActiveStorage
     include Rails.application.routes.url_helpers
 
-    # In Rails 5.x class constants are being undefined/redefined during the code reloading process
-    # in a rails development environment, after which the actual ruby objects stored in those class constants
-    # are no longer equal (subclass == self) what causes error ActiveRecord::SubclassNotFound
-    # Invalid single-table inheritance type: Spree::Image is not a subclass of Spree::Image.
-    # The line below prevents the error.
-    self.inheritance_column = nil
-
     def styles
       self.class.styles.map do |_, size|
         width, height = size[/(\d+)x(\d+)/].split('x')

--- a/core/app/models/spree/image.rb
+++ b/core/app/models/spree/image.rb
@@ -3,6 +3,13 @@ module Spree
     include Configuration::ActiveStorage
     include Rails.application.routes.url_helpers
 
+    # In Rails 5.x class constants are being undefined/redefined during the code reloading process
+    # in a rails development environment, after which the actual ruby objects stored in those class constants
+    # are no longer equal (subclass == self) what causes error ActiveRecord::SubclassNotFound
+    # Invalid single-table inheritance type: Spree::Image is not a subclass of Spree::Image.
+    # The line below prevents the error.
+    self.inheritance_column = nil
+
     def styles
       self.class.styles.map do |_, size|
         width, height = size[/(\d+)x(\d+)/].split('x')

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -280,27 +280,8 @@ module Spree
     def find_line_item_by_variant(variant, options = {})
       line_items.detect do |line_item|
         line_item.variant_id == variant.id &&
-          line_item_options_match(line_item, options)
+          Spree::Dependencies.cart_compare_line_items_service.constantize.new.call(order: self, line_item: line_item, options: options).value
       end
-    end
-
-    # This method enables extensions to participate in the
-    # "Are these line items equal" decision.
-    #
-    # When adding to cart, an extension would send something like:
-    # params[:product_customizations]={...}
-    #
-    # and would provide:
-    #
-    # def product_customizations_match
-    def line_item_options_match(line_item, options)
-      ActiveSupport::Deprecation.warn(<<-EOS, caller)
-        Order#line_item_options_match is deprecated and will be removed in Spree 4.0. Please use
-        Spree::Dependencies.cart_compare_line_items_service.constantize service instead.
-      EOS
-      return true unless options
-
-      Spree::Dependencies.cart_compare_line_items_service.constantize.new.call(order: self, line_item: line_item, options: options).value
     end
 
     # Creates new tax charges if there are any applicable rates. If prices already

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -22,30 +22,6 @@ module Spree
     alias display_ship_total display_shipment_total
     alias_attribute :ship_total, :shipment_total
 
-    def guest_token
-      ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
-        Order#guest_token is deprecated and will be removed in Spree 4.0. Please use Order#token instead
-      DEPRECATION
-
-      token
-    end
-
-    def guest_token?
-      ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
-        Order#guest_token? is deprecated and will be removed in Spree 4.0. Please use Order#token? instead
-      DEPRECATION
-
-      token?
-    end
-
-    def guest_token=(value)
-      ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
-        Order#guest_token= is deprecated and will be removed in Spree 4.0. Please use Order#token= instead
-      DEPRECATION
-
-      self.token = value
-    end
-
     MONEY_THRESHOLD  = 100_000_000
     MONEY_VALIDATION = {
       presence: true,

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -186,17 +186,6 @@ module Spree
       update_hooks.add(hook)
     end
 
-    # Use this method in other gems that wish to register their own custom logic
-    # that should be called when determining if two line items are equal.
-    def self.register_line_item_comparison_hook(hook)
-      ActiveSupport::Deprecation.warn(<<-EOS, caller)
-        Order.register_line_item_comparison_hook is deprecated and will be removed in Spree 4.0. Please use
-        `Rails.application.config.spree.line_item_comparison_hooks << hook` instead.
-      EOS
-
-      Rails.application.config.spree.line_item_comparison_hooks << hook
-    end
-
     # For compatiblity with Calculator::PriceSack
     def amount
       line_items.inject(0.0) { |sum, li| sum + li.amount }

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -729,14 +729,6 @@ module Spree
       self.currency ||= store.default_currency || Spree::Config[:currency]
     end
 
-    def set_currency
-      ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
-         Spree::Order#set_currency was renamed to Spree::Order#ensure_currency_presence
-         and will be removed in Spree 4.0. Please update your code to avoid problems after update
-      DEPRECATION
-      ensure_currency_presence
-    end
-
     def create_token
       self.token ||= generate_token
     end

--- a/core/app/models/spree/store_credit.rb
+++ b/core/app/models/spree/store_credit.rb
@@ -52,7 +52,6 @@ module Spree
       else
         authorization_code = generate_authorization_code
       end
-
       if validate_authorization(amount, order_currency)
         update_attributes!(
           action: AUTHORIZE_ACTION,

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -101,40 +101,7 @@ module Spree
         def self.create_line_items_from_params(line_items, order)
           return {} unless line_items
 
-          iterator = case line_items
-                     when Hash
-                       ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
-              Passing a hash is now deprecated and will be removed in Spree 4.0.
-              It is recommended that you pass it as an array instead.
-
-              New Syntax:
-
-              {
-                "order": {
-                  "line_items": [
-                    { "variant_id": 123, "quantity": 1 },
-                    { "variant_id": 456, "quantity": 1 }
-                  ]
-                }
-              }
-
-              Old Syntax:
-
-              {
-                "order": {
-                  "line_items": {
-                    "1": { "variant_id": 123, "quantity": 1 },
-                    "2": { "variant_id": 123, "quantity": 1 }
-                  }
-                }
-              }
-                       DEPRECATION
-                       :each_value
-                     when Array
-                       :each
-                     end
-
-          line_items.send(iterator) do |line_item|
+          line_items.each do |line_item|
             begin
               adjustments = line_item.delete(:adjustments_attributes)
               extra_params = line_item.except(:variant_id, :quantity, :sku)

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -573,12 +573,13 @@ describe Spree::Order, type: :model do
 
       it 'matches line item when options match' do
         allow(order).to receive(:foos_match).and_return(true)
-        expect(order.line_item_options_match(@line_items.first, foos: { bar: :zoo })).to be true
+        expect(Spree::Dependencies.cart_compare_line_items_service.constantize.new.call(order: order, line_item: @line_items.first, options: { foos: { bar: :zoo } }).value).to be true
+
       end
 
       it 'does not match line item without options' do
         allow(order).to receive(:foos_match).and_return(false)
-        expect(order.line_item_options_match(@line_items.first, {})).to be false
+        expect(Spree::Dependencies.cart_compare_line_items_service.constantize.new.call(order: order, line_item: @line_items.first, options: {}).value).to be false
       end
     end
   end

--- a/frontend/app/views/spree/products/_cart_form.html.erb
+++ b/frontend/app/views/spree/products/_cart_form.html.erb
@@ -15,7 +15,7 @@
                 %>
                 <%= label_tag "variant_id_#{ variant.id }", class: "form-check-label" do %>
                   <span class="variant-description">
-                    <%= variant_options variant %>
+                    <%= variant.options_text %>
                   </span>
                   <% if variant_price variant %>
                     <span class="price diff"><%= variant_price variant %></span>

--- a/guides/src/content/release_notes/4_0_0.md
+++ b/guides/src/content/release_notes/4_0_0.md
@@ -72,17 +72,41 @@ Please review each of the noteworthy changes to ensure your customizations or ex
 
   [Janusz Kojro](https://github.com/spree/spree/pull/9285)
 
-- Remove Address#iso_name
-- Remove Adjustment#open and Adjustment#closed
-- Remove BaseHelper#variant_options
-- Remove Order#set_currency
-- Remove Order#register_line_item_comparison_hook
-- Remove Order#guest_token
-- Remove Address#same_as
-- Remove hash case in Order#create_line_items_from_params
-- Remove Order#line_item_options_match
+- Removed Address#iso_name
 
-  [Janusz Kojro](https://github.com/spree/spree/pull/9285)
+  [Janusz Kojro](https://github.com/spree/spree/pull/9286/commits/17b629233be3f6d9facb8ecfb06a6f99a5ba3a4f)
+
+- Removed Adjustment#open and Adjustment#closed
+
+  [Janusz Kojro](https://github.com/spree/spree/pull/9286/commits/23568992c59f7249779037efb6ff0b6c6aea1b6a)
+
+- Removed BaseHelper#variant_options
+
+  [Janusz Kojro](https://github.com/spree/spree/pull/9286/commits/1483c27ba364a55067f464ec730e45153a8531a5)
+
+- Removed Order#set_currency
+
+  [Janusz Kojro](https://github.com/spree/spree/pull/9286/commits/e640891094e8f525243f1a507a231c2589c8c6dc)
+
+- Removed Order#register_line_item_comparison_hook
+
+  [Janusz Kojro](https://github.com/spree/spree/pull/9286/commits/81bbb534109225a9f7944f31d4507c733e5a6941)
+
+- Removed Order#guest_token
+
+  [Janusz Kojro](https://github.com/spree/spree/pull/9286/commits/103aa75139c9f3110a758e2cbcea2892d1519435)
+
+- Removed Address#same_as
+
+  [Janusz Kojro](https://github.com/spree/spree/pull/9286/commits/c7970720e531ac62b82f24280dc78748c04c0ec4)
+
+- Removed hash case in Order#create_line_items_from_params
+
+  [Janusz Kojro](https://github.com/spree/spree/pull/9286/commits/963f6f432a4d6f6f07d174d3ed4e6cf8227458db)
+
+- Removed Order#line_item_options_match
+
+  [Janusz Kojro](https://github.com/spree/spree/pull/9286/commits/2c3dcc72d594b891bb4749a36d30d8d49b675f4a)
 
 ## Full Changelog
 

--- a/guides/src/content/release_notes/4_0_0.md
+++ b/guides/src/content/release_notes/4_0_0.md
@@ -72,6 +72,18 @@ Please review each of the noteworthy changes to ensure your customizations or ex
 
   [Janusz Kojro](https://github.com/spree/spree/pull/9285)
 
+- Remove Address#iso_name
+- Remove Adjustment#open and Adjustment#closed
+- Remove BaseHelper#variant_options
+- Remove Order#set_currency
+- Remove Order#register_line_item_comparison_hook
+- Remove Order#guest_token
+- Remove Address#same_as
+- Remove hash case in Order#create_line_items_from_params
+- Remove Order#line_item_options_match
+
+  [Janusz Kojro](https://github.com/spree/spree/pull/9285)
+
 ## Full Changelog
 
 You can view the full changes using [Github Compare](https://github.com/spree/spree/compare/3-7-stable...master).


### PR DESCRIPTION
Fixes #9246 

> * [ ]  OrderContents
> * [ ]  Order#add_store_credit_payments
> * [ ]  Order#remove_store_credit_payments
> * [ ]  OrdersController#populate
> * [ ]  OrdersController#populate_redirect
> * [ ]  ControllerHelpers::RespondWith
> * [x]  Order#register_line_item_comparison_hook
> * [x]  Order#set_currency
> * [x]  Order#line_item_options_match
> * [x]  BaseHelper#variant_options
> * [x]  Address#iso_name
> * [x]  Adjustment#open
> * [x]  Adjustment#closed
> * [x]  Order#guest_token
> * [x]  Address#same_as
> * [x]  Order#line_item_options_match
