### PR TITLE
Remove rspec-its gem from dependencies

### DIFF
--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -25,7 +25,6 @@ group :test do
   gem 'factory_bot_rails', '~> 4.8'
   gem 'rspec-activemodel-mocks', '~> 1.0'
   gem 'rspec-collection_matchers'
-  gem 'rspec-its'
   gem 'rspec-rails', '~> 3.7.2'
   gem 'rspec-retry'
   gem 'rspec_junit_formatter'

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -887,29 +887,25 @@ describe Spree::Payment, type: :model do
   end
 
   describe '#editable?' do
-    subject { payment }
-
-    before do
-      subject.state = state
-    end
+    before { payment.state = state }
 
     context "when the state is 'checkout'" do
       let(:state) { 'checkout' }
 
-      its(:editable?) { is_expected.to be(true) }
+      it { expect(payment.editable?).to eq(true) }
     end
 
     context "when the state is 'pending'" do
       let(:state) { 'pending' }
 
-      its(:editable?) { is_expected.to be(true) }
+      it { expect(payment.editable?).to eq(true) }
     end
 
     %w[processing completed failed void invalid].each do |state|
       context "when the state is '#{state}'" do
         let(:state) { state }
 
-        its(:editable?) { is_expected.to be(false) }
+        it { expect(payment.editable?).to eq(false) }
       end
     end
   end

--- a/core/spec/support/concerns/default_price.rb
+++ b/core/spec/support/concerns/default_price.rb
@@ -20,9 +20,8 @@ shared_examples_for 'default_price' do
   end
 
   describe '#default_price' do
-    subject { instance.default_price }
+    it { expect(instance.default_price.class).to eql Spree::Price }
 
-    its(:class) { is_expected.to eql Spree::Price }
     it 'delegates price' do
       expect(instance.default_price).to receive(:price)
       instance.price
@@ -34,5 +33,5 @@ shared_examples_for 'default_price' do
     end
   end
 
-  its(:has_default_price?) { is_expected.to be_truthy }
+  it { expect(instance.has_default_price?).to be_truthy }
 end

--- a/guides/src/content/release_notes/4_0_0.md
+++ b/guides/src/content/release_notes/4_0_0.md
@@ -72,6 +72,10 @@ Please review each of the noteworthy changes to ensure your customizations or ex
 
   [Janusz Kojro](https://github.com/spree/spree/pull/9285)
 
+- Droped rspec-its dependency
+
+  [Janusz Kojro](https://github.com/spree/spree/pull/9292)
+
 ## Full Changelog
 
 You can view the full changes using [Github Compare](https://github.com/spree/spree/compare/3-7-stable...master).


### PR DESCRIPTION
#9170

- [x] drop `rspec-its` dependency