### PR TITLE
Feature/remove rspec collection matchers

### DIFF
--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -24,7 +24,6 @@ group :test do
   gem 'email_spec'
   gem 'factory_bot_rails', '~> 4.8'
   gem 'rspec-activemodel-mocks', '~> 1.0'
-  gem 'rspec-collection_matchers'
   gem 'rspec-its'
   gem 'rspec-rails', '~> 3.7.2'
   gem 'rspec-retry'

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -83,7 +83,8 @@ describe Spree::CreditCard, type: :model do
 
     it 'validates name presence' do
       credit_card.valid?
-      expect(credit_card.error_on(:name).size).to eq(1)
+      expect(credit_card.errors).not_to be_empty
+      expect(credit_card.errors.messages[:name]).to be_present
     end
 
     it 'only validates on create' do

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -251,7 +251,7 @@ describe Spree::LineItem, type: :model do
         line_item.target_shipment = order.shipments.first
         line_item.valid?
 
-        expect(line_item.errors_on(:quantity).size).to eq(0)
+        expect(line_item.errors).to be_empty
       end
 
       it 'doesnt allow to increase item quantity' do
@@ -260,7 +260,8 @@ describe Spree::LineItem, type: :model do
         line_item.target_shipment = order.shipments.first
         line_item.valid?
 
-        expect(line_item.errors_on(:quantity).size).to eq(1)
+        expect(line_item.errors).not_to be_empty
+        expect(line_item.errors.messages[:quantity]).to be_present
       end
     end
 
@@ -279,7 +280,7 @@ describe Spree::LineItem, type: :model do
         line_item.target_shipment = order.shipments.first
         line_item.valid?
 
-        expect(line_item.errors_on(:quantity).size).to eq(0)
+        expect(line_item.errors).to be_empty
       end
 
       it 'doesnt allow to increase quantity over stock availability' do
@@ -288,7 +289,8 @@ describe Spree::LineItem, type: :model do
         line_item.target_shipment = order.shipments.first
         line_item.valid?
 
-        expect(line_item.errors_on(:quantity).size).to eq(1)
+        expect(line_item.errors).not_to be_empty
+        expect(line_item.errors.messages[:quantity]).to be_present
       end
     end
   end
@@ -299,7 +301,7 @@ describe Spree::LineItem, type: :model do
       line_item.currency = order.currency
       line_item.valid?
 
-      expect(line_item.error_on(:currency).size).to eq(0)
+      expect(line_item.errors).to be_empty
     end
   end
 
@@ -309,7 +311,8 @@ describe Spree::LineItem, type: :model do
       line_item.currency = 'no currency'
       line_item.valid?
 
-      expect(line_item.error_on(:currency).size).to eq(1)
+      expect(line_item.errors).not_to be_empty
+      expect(line_item.errors.messages[:currency]).to be_present
     end
   end
 

--- a/core/spec/models/spree/order/callbacks_spec.rb
+++ b/core/spec/models/spree/order/callbacks_spec.rb
@@ -13,7 +13,8 @@ describe Spree::Order, type: :model do
       it "o'brien@gmail.com is a valid email address" do
         order.state = 'address'
         order.email = "o'brien@gmail.com"
-        expect(order.error_on(:email).size).to eq(0)
+        order.valid?
+        expect(order.errors).to be_empty
       end
     end
   end
@@ -37,7 +38,8 @@ describe Spree::Order, type: :model do
     it 'does not validate email address' do
       order.state = 'cart'
       order.email = nil
-      expect(order.error_on(:email).size).to eq(0)
+      order.valid?
+      expect(order.errors).to be_empty
     end
   end
 end

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -534,7 +534,8 @@ describe Spree::Payment, type: :model do
       end
 
       it 'requires a payment method' do
-        expect(Spree::Payment.create(amount: 100, order: order)).to have(1).error_on(:payment_method)
+        expect(Spree::Payment.create(amount: 100, order: order).errors).not_to be_empty
+        expect(Spree::Payment.create(amount: 100, order: order).errors.messages[:payment_method]).to be_present
       end
     end
 
@@ -669,8 +670,9 @@ describe Spree::Payment, type: :model do
       payment = Spree::Payment.new(params)
       expect(payment).not_to be_valid
       expect(payment.source).not_to be_nil
-      expect(payment.source.error_on(:number).size).to eq(1)
-      expect(payment.source.error_on(:verification_value).size).to eq(1)
+      expect(payment.source.errors.messages[:name]).to be_present
+      expect(payment.source.errors).not_to be_empty
+      expect(payment.source.errors.messages[:verification_value]).to be_present
     end
 
     it 'does not build a new source when duplicating the model with source_attributes set' do

--- a/core/spec/models/spree/price_spec.rb
+++ b/core/spec/models/spree/price_spec.rb
@@ -42,24 +42,24 @@ describe Spree::Price, type: :model do
 
     context 'when the amount is less than 0' do
       let(:amount) { -1 }
+      before { subject.valid? }
 
-      it 'has 1 error_on' do
-        expect(subject.error_on(:amount).size).to eq(1)
+      it 'has 1 error on amount' do
+        expect(subject.errors.messages[:amount].size).to eq(1)
       end
       it 'populates errors' do
-        subject.valid?
         expect(subject.errors.messages[:amount].first).to eq 'must be greater than or equal to 0'
       end
     end
 
     context 'when the amount is greater than maximum amount' do
       let(:amount) { Spree::Price::MAXIMUM_AMOUNT + 1 }
+      before { subject.valid? }
 
-      it 'has 1 error_on' do
-        expect(subject.error_on(:amount).size).to eq(1)
+      it 'has 1 error on amount' do
+        expect(subject.errors.messages[:amount].size).to eq(1)
       end
       it 'populates errors' do
-        subject.valid?
         expect(subject.errors.messages[:amount].first).to eq "must be less than or equal to #{Spree::Price::MAXIMUM_AMOUNT}"
       end
     end

--- a/core/spec/models/spree/shipping_method_spec.rb
+++ b/core/spec/models/spree/shipping_method_spec.rb
@@ -38,17 +38,18 @@ describe Spree::ShippingMethod, type: :model do
   end
 
   context 'validations' do
-    before { subject.valid? }
-
     it 'validates presence of name' do
-      expect(subject.error_on(:name).size).to eq(1)
+      subject.valid?
+      expect(subject.errors.messages[:name].size).to eq(1)
     end
 
     context 'shipping category' do
       context 'is required' do
-        it { expect(subject.error_on(:base).size).to eq(1) }
+        before { subject.valid? }
+
+        it { expect(subject.errors.messages[:base].size).to eq(1) }
         it 'adds error to base' do
-          expect(subject.error_on(:base)).to include(I18n.t(:required_shipping_category,
+          expect(subject.errors.messages[:base]).to include(I18n.t(:required_shipping_category,
                                                             scope: [
                                                               :activerecord, :errors, :models,
                                                               'spree/shipping_method', :attributes, :base
@@ -57,9 +58,9 @@ describe Spree::ShippingMethod, type: :model do
       end
 
       context 'one associated' do
-        before { subject.shipping_categories.push create(:shipping_category) }
+        before { subject.shipping_categories.push(create(:shipping_category)) }
 
-        it { expect(subject.error_on(:base).size).to eq(0) }
+        it { expect(subject.errors.messages[:base]).to be_empty }
       end
     end
   end

--- a/core/spec/models/spree/stock_item_spec.rb
+++ b/core/spec/models/spree/stock_item_spec.rb
@@ -292,7 +292,7 @@ describe Spree::StockItem, type: :model do
           subject.save
         end
 
-        it 'has 1 error_on' do
+        it 'has 1 error on count_on_hand' do
           expect(subject.errors).not_to be_empty
           expect(subject.errors.messages[:count_on_hand]).to be_present
         end

--- a/core/spec/models/spree/stock_item_spec.rb
+++ b/core/spec/models/spree/stock_item_spec.rb
@@ -283,7 +283,7 @@ describe Spree::StockItem, type: :model do
         end
 
         it 'has :no errors_on' do
-          expect(subject.errors_on(:count_on_hand).size).to eq(0)
+          expect(subject.errors).to be_empty
         end
       end
 
@@ -293,7 +293,8 @@ describe Spree::StockItem, type: :model do
         end
 
         it 'has 1 error_on' do
-          expect(subject.error_on(:count_on_hand).size).to eq(1)
+          expect(subject.errors).not_to be_empty
+          expect(subject.errors.messages[:count_on_hand]).to be_present
         end
         it { expect(subject.errors[:count_on_hand]).to include 'must be greater than or equal to 0' }
       end

--- a/guides/src/content/release_notes/4_0_0.md
+++ b/guides/src/content/release_notes/4_0_0.md
@@ -72,6 +72,10 @@ Please review each of the noteworthy changes to ensure your customizations or ex
 
   [Janusz Kojro](https://github.com/spree/spree/pull/9285)
 
+- Removed rspec-collection_matchers dependency
+
+  [Janusz Kojro](https://github.com/spree/spree/pull/9295)
+
 ## Full Changelog
 
 You can view the full changes using [Github Compare](https://github.com/spree/spree/compare/3-7-stable...master).


### PR DESCRIPTION
Related to #9170

- [x] drop `rspec-collection_matchers` dependency