### PR TITLE
Require Ruby 2.5.0

### DIFF
--- a/api/spree_api.gemspec
+++ b/api/spree_api.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.homepage      = 'http://spreecommerce.org'
   s.license       = 'BSD-3-Clause'
 
-  s.required_ruby_version = '>= 2.3.3'
+  s.required_ruby_version = '>= 2.5.0'
 
   s.files         = `git ls-files`.split($\).reject { |f| f.match(/^spec/) && !f.match(/^spec\/fixtures/) }
   s.executables   = s.files.grep(%r{^bin/}).map{ |f| File.basename(f) }

--- a/backend/spree_backend.gemspec
+++ b/backend/spree_backend.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.summary     = 'backend e-commerce functionality for the Spree project.'
   s.description = 'Required dependency for Spree'
 
-  s.required_ruby_version = '>= 2.3.3'
+  s.required_ruby_version = '>= 2.5.0'
 
   s.author      = 'Sean Schofield'
   s.email       = 'sean@spreecommerce.com'

--- a/cmd/lib/spree_cmd/templates/extension/extension.gemspec
+++ b/cmd/lib/spree_cmd/templates/extension/extension.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.version     = <%= class_name %>.version
   s.summary     = 'Add extension summary here'
   s.description = 'Add (optional) extension description here'
-  s.required_ruby_version = '>= 2.3.3'
+  s.required_ruby_version = '>= 2.5.0'
 
   s.author    = 'You'
   s.email     = 'you@example.com'

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = 'The bare bones necessary for Spree.'
   s.description = 'The bare bones necessary for Spree.'
 
-  s.required_ruby_version     = '>= 2.3.3'
+  s.required_ruby_version     = '>= 2.5.0'
   s.required_rubygems_version = '>= 1.8.23'
 
   s.author      = 'Sean Schofield'

--- a/frontend/spree_frontend.gemspec
+++ b/frontend/spree_frontend.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.summary     = 'Frontend e-commerce functionality for the Spree project.'
   s.description = s.summary
 
-  s.required_ruby_version = '>= 2.3.3'
+  s.required_ruby_version = '>= 2.5.0'
 
   s.author      = 'Sean Schofield'
   s.email       = 'sean@spreecommerce.com'

--- a/spree.gemspec
+++ b/spree.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.summary     = 'Full-stack e-commerce framework for Ruby on Rails.'
   s.description = 'Spree is an open source e-commerce framework for Ruby on Rails. Join us on http://slack.spreecommerce.org'
 
-  s.required_ruby_version = '>= 2.3.3'
+  s.required_ruby_version = '>= 2.5.0'
 
   s.files        = Dir['README.md', 'lib/**/*']
   s.require_path = 'lib'


### PR DESCRIPTION
To use Rails 6.0 we need to bump Ruby version to 2.5.0

Attached with #9170
- [x] require Ruby 2.5