### PR TITLE
Update CanCanCan to 3.0

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -133,12 +133,12 @@ module Spree
 
       def product_scope
         if @current_user_roles.include?('admin')
-          scope = Product.with_deleted.accessible_by(current_ability, :read).includes(*product_includes)
+          scope = Product.with_deleted.accessible_by(current_ability, :show).includes(*product_includes)
 
           scope = scope.not_deleted unless params[:show_deleted]
           scope = scope.not_discontinued unless params[:show_discontinued]
         else
-          scope = Product.accessible_by(current_ability, :read).active.includes(*product_includes)
+          scope = Product.accessible_by(current_ability, :show).active.includes(*product_includes)
         end
 
         scope
@@ -158,7 +158,7 @@ module Spree
 
       def authorize_for_order
         @order = Spree::Order.find_by(number: order_id)
-        authorize! :read, @order, order_token
+        authorize! :show, @order, order_token
       end
     end
   end

--- a/api/app/controllers/spree/api/v1/addresses_controller.rb
+++ b/api/app/controllers/spree/api/v1/addresses_controller.rb
@@ -5,7 +5,7 @@ module Spree
         before_action :find_order
 
         def show
-          authorize! :read, @order, order_token
+          authorize! :show, @order, order_token
           @address = find_address
           respond_with(@address)
         end

--- a/api/app/controllers/spree/api/v1/countries_controller.rb
+++ b/api/app/controllers/spree/api/v1/countries_controller.rb
@@ -5,7 +5,7 @@ module Spree
         skip_before_action :authenticate_user
 
         def index
-          @countries = Country.accessible_by(current_ability, :read).ransack(params[:q]).result.
+          @countries = Country.accessible_by(current_ability).ransack(params[:q]).result.
                        order('name ASC').
                        page(params[:page]).per(params[:per_page])
           country = Country.order('updated_at ASC').last
@@ -13,7 +13,7 @@ module Spree
         end
 
         def show
-          @country = Country.accessible_by(current_ability, :read).find(params[:id])
+          @country = Country.accessible_by(current_ability, :show).find(params[:id])
           respond_with(@country)
         end
       end

--- a/api/app/controllers/spree/api/v1/credit_cards_controller.rb
+++ b/api/app/controllers/spree/api/v1/credit_cards_controller.rb
@@ -7,7 +7,7 @@ module Spree
         def index
           @credit_cards = user.
                           credit_cards.
-                          accessible_by(current_ability, :read).
+                          accessible_by(current_ability).
                           with_payment_profile.
                           ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
           respond_with(@credit_cards)
@@ -17,7 +17,7 @@ module Spree
 
         def user
           if params[:user_id].present?
-            @user ||= Spree.user_class.accessible_by(current_ability, :read).find(params[:user_id])
+            @user ||= Spree.user_class.accessible_by(current_ability, :show).find(params[:user_id])
           end
         end
       end

--- a/api/app/controllers/spree/api/v1/images_controller.rb
+++ b/api/app/controllers/spree/api/v1/images_controller.rb
@@ -3,12 +3,12 @@ module Spree
     module V1
       class ImagesController < Spree::Api::BaseController
         def index
-          @images = scope.images.accessible_by(current_ability, :read)
+          @images = scope.images.accessible_by(current_ability)
           respond_with(@images)
         end
 
         def show
-          @image = Image.accessible_by(current_ability, :read).find(params[:id])
+          @image = Image.accessible_by(current_ability, :show).find(params[:id])
           respond_with(@image)
         end
 

--- a/api/app/controllers/spree/api/v1/inventory_units_controller.rb
+++ b/api/app/controllers/spree/api/v1/inventory_units_controller.rb
@@ -25,7 +25,7 @@ module Spree
         private
 
         def inventory_unit
-          @inventory_unit ||= InventoryUnit.accessible_by(current_ability, :read).find(params[:id])
+          @inventory_unit ||= InventoryUnit.accessible_by(current_ability, :show).find(params[:id])
         end
 
         def prepare_event

--- a/api/app/controllers/spree/api/v1/option_types_controller.rb
+++ b/api/app/controllers/spree/api/v1/option_types_controller.rb
@@ -6,19 +6,19 @@ module Spree
           @option_types =  if params[:ids]
                              Spree::OptionType.
                                includes(:option_values).
-                               accessible_by(current_ability, :read).
+                               accessible_by(current_ability).
                                where(id: params[:ids].split(','))
                            else
                              Spree::OptionType.
                                includes(:option_values).
-                               accessible_by(current_ability, :read).
+                               accessible_by(current_ability).
                                load.ransack(params[:q]).result
                            end
           respond_with(@option_types)
         end
 
         def show
-          @option_type = Spree::OptionType.accessible_by(current_ability, :read).find(params[:id])
+          @option_type = Spree::OptionType.accessible_by(current_ability, :show).find(params[:id])
           respond_with(@option_type)
         end
 

--- a/api/app/controllers/spree/api/v1/option_values_controller.rb
+++ b/api/app/controllers/spree/api/v1/option_values_controller.rb
@@ -47,9 +47,9 @@ module Spree
 
         def scope
           @scope ||= if params[:option_type_id]
-                       Spree::OptionType.find(params[:option_type_id]).option_values.accessible_by(current_ability, :read)
+                       Spree::OptionType.find(params[:option_type_id]).option_values.accessible_by(current_ability, :show)
                      else
-                       Spree::OptionValue.accessible_by(current_ability, :read).load
+                       Spree::OptionValue.accessible_by(current_ability, :show).load
                      end
         end
 

--- a/api/app/controllers/spree/api/v1/payments_controller.rb
+++ b/api/app/controllers/spree/api/v1/payments_controller.rb
@@ -60,7 +60,7 @@ module Spree
 
         def find_order
           @order = Spree::Order.find_by!(number: order_id)
-          authorize! :read, @order, order_token
+          authorize! :show, @order, order_token
         end
 
         def find_payment

--- a/api/app/controllers/spree/api/v1/product_properties_controller.rb
+++ b/api/app/controllers/spree/api/v1/product_properties_controller.rb
@@ -6,7 +6,7 @@ module Spree
         before_action :product_property, only: [:show, :update, :destroy]
 
         def index
-          @product_properties = @product.product_properties.accessible_by(current_ability, :read).
+          @product_properties = @product.product_properties.accessible_by(current_ability).
                                 ransack(params[:q]).result.
                                 page(params[:page]).per(params[:per_page])
           respond_with(@product_properties)
@@ -51,7 +51,7 @@ module Spree
         end
 
         def authorize_product!
-          authorize! :read, @product
+          authorize! :show, @product
         end
 
         def product_property
@@ -60,7 +60,7 @@ module Spree
             @product_property ||= @product.product_properties.includes(:property).where(spree_properties: { name: params[:id] }).first
             raise ActiveRecord::RecordNotFound unless @product_property
 
-            authorize! :read, @product_property
+            authorize! :show, @product_property
           end
         end
 

--- a/api/app/controllers/spree/api/v1/properties_controller.rb
+++ b/api/app/controllers/spree/api/v1/properties_controller.rb
@@ -5,7 +5,7 @@ module Spree
         before_action :find_property, only: [:show, :update, :destroy]
 
         def index
-          @properties = Spree::Property.accessible_by(current_ability, :read)
+          @properties = Spree::Property.accessible_by(current_ability)
 
           @properties = if params[:ids]
                           @properties.where(id: params[:ids].split(',').flatten)
@@ -56,9 +56,9 @@ module Spree
         private
 
         def find_property
-          @property = Spree::Property.accessible_by(current_ability, :read).find(params[:id])
+          @property = Spree::Property.accessible_by(current_ability, :show).find(params[:id])
         rescue ActiveRecord::RecordNotFound
-          @property = Spree::Property.accessible_by(current_ability, :read).find_by!(name: params[:id])
+          @property = Spree::Property.accessible_by(current_ability, :show).find_by!(name: params[:id])
         end
 
         def property_params

--- a/api/app/controllers/spree/api/v1/return_authorizations_controller.rb
+++ b/api/app/controllers/spree/api/v1/return_authorizations_controller.rb
@@ -20,7 +20,7 @@ module Spree
 
         def index
           authorize! :admin, ReturnAuthorization
-          @return_authorizations = order.return_authorizations.accessible_by(current_ability, :read).
+          @return_authorizations = order.return_authorizations.accessible_by(current_ability).
                                    ransack(params[:q]).result.
                                    page(params[:page]).per(params[:per_page])
           respond_with(@return_authorizations)
@@ -32,7 +32,7 @@ module Spree
 
         def show
           authorize! :admin, ReturnAuthorization
-          @return_authorization = order.return_authorizations.accessible_by(current_ability, :read).find(params[:id])
+          @return_authorization = order.return_authorizations.accessible_by(current_ability, :show).find(params[:id])
           respond_with(@return_authorization)
         end
 
@@ -58,7 +58,7 @@ module Spree
 
         def order
           @order ||= Spree::Order.find_by!(number: order_id)
-          authorize! :read, @order
+          authorize! :show, @order
         end
 
         def return_authorization_params

--- a/api/app/controllers/spree/api/v1/shipments_controller.rb
+++ b/api/app/controllers/spree/api/v1/shipments_controller.rb
@@ -20,7 +20,7 @@ module Spree
 
         def create
           @order = Spree::Order.find_by!(number: params.fetch(:shipment).fetch(:order_id))
-          authorize! :read, @order
+          authorize! :show, @order
           authorize! :create, Shipment
           quantity = params[:quantity].to_i
           @shipment = @order.shipments.create(stock_location_id: params.fetch(:stock_location_id))
@@ -126,7 +126,7 @@ module Spree
           @original_shipment         = Spree::Shipment.find_by!(number: params[:original_shipment_number])
           @variant                   = Spree::Variant.find(params[:variant_id])
           @quantity                  = params[:quantity].to_i
-          authorize! :read, @original_shipment
+          authorize! :show, @original_shipment
           authorize! :create, Shipment
         end
 

--- a/api/app/controllers/spree/api/v1/states_controller.rb
+++ b/api/app/controllers/spree/api/v1/states_controller.rb
@@ -24,10 +24,10 @@ module Spree
 
         def scope
           if params[:country_id]
-            @country = Country.accessible_by(current_ability, :read).find(params[:country_id])
-            @country.states.accessible_by(current_ability, :read).order('name ASC')
+            @country = Country.accessible_by(current_ability, :show).find(params[:country_id])
+            @country.states.accessible_by(current_ability).order('name ASC')
           else
-            State.accessible_by(current_ability, :read).order('name ASC')
+            State.accessible_by(current_ability).order('name ASC')
           end
         end
       end

--- a/api/app/controllers/spree/api/v1/stock_items_controller.rb
+++ b/api/app/controllers/spree/api/v1/stock_items_controller.rb
@@ -65,12 +65,12 @@ module Spree
 
         def stock_location
           render 'spree/api/v1/shared/stock_location_required', status: 422 and return unless params[:stock_location_id]
-          @stock_location ||= StockLocation.accessible_by(current_ability, :read).find(params[:stock_location_id])
+          @stock_location ||= StockLocation.accessible_by(current_ability, :show).find(params[:stock_location_id])
         end
 
         def scope
           includes = { variant: [{ option_values: :option_type }, :product] }
-          @stock_location.stock_items.accessible_by(current_ability, :read).includes(includes)
+          @stock_location.stock_items.accessible_by(current_ability, :show).includes(includes)
         end
 
         def stock_item_params

--- a/api/app/controllers/spree/api/v1/stock_locations_controller.rb
+++ b/api/app/controllers/spree/api/v1/stock_locations_controller.rb
@@ -3,8 +3,9 @@ module Spree
     module V1
       class StockLocationsController < Spree::Api::BaseController
         def index
-          authorize! :read, StockLocation
-          @stock_locations = StockLocation.accessible_by(current_ability, :read).order('name ASC').ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
+          authorize! :index, StockLocation
+          @stock_locations = StockLocation.accessible_by(current_ability).order('name ASC').
+                             ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
           respond_with(@stock_locations)
         end
 
@@ -40,7 +41,7 @@ module Spree
         private
 
         def stock_location
-          @stock_location ||= StockLocation.accessible_by(current_ability, :read).find(params[:id])
+          @stock_location ||= StockLocation.accessible_by(current_ability, :show).find(params[:id])
         end
 
         def stock_location_params

--- a/api/app/controllers/spree/api/v1/stock_movements_controller.rb
+++ b/api/app/controllers/spree/api/v1/stock_movements_controller.rb
@@ -5,7 +5,7 @@ module Spree
         before_action :stock_location, except: [:update, :destroy]
 
         def index
-          authorize! :read, StockMovement
+          authorize! :index, StockMovement
           @stock_movements = scope.ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
           respond_with(@stock_movements)
         end
@@ -29,11 +29,11 @@ module Spree
 
         def stock_location
           render 'spree/api/v1/shared/stock_location_required', status: 422 and return unless params[:stock_location_id]
-          @stock_location ||= StockLocation.accessible_by(current_ability, :read).find(params[:stock_location_id])
+          @stock_location ||= StockLocation.accessible_by(current_ability, :show).find(params[:stock_location_id])
         end
 
         def scope
-          @stock_location.stock_movements.accessible_by(current_ability, :read)
+          @stock_location.stock_movements.accessible_by(current_ability, :show)
         end
 
         def stock_movement_params

--- a/api/app/controllers/spree/api/v1/stores_controller.rb
+++ b/api/app/controllers/spree/api/v1/stores_controller.rb
@@ -5,8 +5,8 @@ module Spree
         before_action :get_store, except: [:index, :create]
 
         def index
-          authorize! :read, Store
-          @stores = Store.accessible_by(current_ability, :read).all
+          authorize! :index, Store
+          @stores = Store.accessible_by(current_ability).all
           respond_with(@stores)
         end
 
@@ -31,7 +31,7 @@ module Spree
         end
 
         def show
-          authorize! :read, @store
+          authorize! :show, @store
           respond_with(@store)
         end
 

--- a/api/app/controllers/spree/api/v1/taxonomies_controller.rb
+++ b/api/app/controllers/spree/api/v1/taxonomies_controller.rb
@@ -45,13 +45,13 @@ module Spree
         private
 
         def taxonomies
-          @taxonomies = Taxonomy.accessible_by(current_ability, :read).order('name').includes(root: :children).
+          @taxonomies = Taxonomy.accessible_by(current_ability).order('name').includes(root: :children).
                         ransack(params[:q]).result.
                         page(params[:page]).per(params[:per_page])
         end
 
         def taxonomy
-          @taxonomy ||= Taxonomy.accessible_by(current_ability, :read).find(params[:id])
+          @taxonomy ||= Taxonomy.accessible_by(current_ability, :show).find(params[:id])
         end
 
         def taxonomy_params

--- a/api/app/controllers/spree/api/v1/taxons_controller.rb
+++ b/api/app/controllers/spree/api/v1/taxons_controller.rb
@@ -6,9 +6,9 @@ module Spree
           @taxons = if taxonomy
                       taxonomy.root.children
                     elsif params[:ids]
-                      Spree::Taxon.includes(:children).accessible_by(current_ability, :read).where(id: params[:ids].split(','))
+                      Spree::Taxon.includes(:children).accessible_by(current_ability).where(id: params[:ids].split(','))
                     else
-                      Spree::Taxon.includes(:children).accessible_by(current_ability, :read).order(:taxonomy_id, :lft)
+                      Spree::Taxon.includes(:children).accessible_by(current_ability).order(:taxonomy_id, :lft)
                     end
           @taxons = @taxons.ransack(params[:q]).result
           @taxons = @taxons.page(params[:page]).per(params[:per_page])
@@ -74,12 +74,12 @@ module Spree
 
         def taxonomy
           if params[:taxonomy_id].present?
-            @taxonomy ||= Spree::Taxonomy.accessible_by(current_ability, :read).find(params[:taxonomy_id])
+            @taxonomy ||= Spree::Taxonomy.accessible_by(current_ability, :show).find(params[:taxonomy_id])
           end
         end
 
         def taxon
-          @taxon ||= taxonomy.taxons.accessible_by(current_ability, :read).find(params[:id])
+          @taxon ||= taxonomy.taxons.accessible_by(current_ability, :show).find(params[:id])
         end
 
         def taxon_params

--- a/api/app/controllers/spree/api/v1/users_controller.rb
+++ b/api/app/controllers/spree/api/v1/users_controller.rb
@@ -5,7 +5,7 @@ module Spree
         rescue_from Spree::Core::DestroyWithOrdersError, with: :error_during_processing
 
         def index
-          @users = Spree.user_class.accessible_by(current_ability, :read)
+          @users = Spree.user_class.accessible_by(current_ability, :show)
 
           @users = if params[:ids]
                      @users.ransack(id_in: params[:ids].split(','))
@@ -53,7 +53,7 @@ module Spree
         private
 
         def user
-          @user ||= Spree.user_class.accessible_by(current_ability, :read).find(params[:id])
+          @user ||= Spree.user_class.accessible_by(current_ability, :show).find(params[:id])
         end
 
         def user_params

--- a/api/app/controllers/spree/api/v1/variants_controller.rb
+++ b/api/app/controllers/spree/api/v1/variants_controller.rb
@@ -49,7 +49,7 @@ module Spree
 
         def product
           if params[:product_id]
-            @product ||= Spree::Product.accessible_by(current_ability, :read).
+            @product ||= Spree::Product.accessible_by(current_ability, :show).
                          friendly.find(params[:product_id])
           end
         end
@@ -65,7 +65,7 @@ module Spree
             variants = variants.with_deleted
           end
 
-          variants.eligible.accessible_by(current_ability, :read)
+          variants.eligible.accessible_by(current_ability)
         end
 
         def variant_params

--- a/api/app/controllers/spree/api/v1/zones_controller.rb
+++ b/api/app/controllers/spree/api/v1/zones_controller.rb
@@ -19,7 +19,7 @@ module Spree
         end
 
         def index
-          @zones = Zone.accessible_by(current_ability, :read).order('name ASC').ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
+          @zones = Zone.accessible_by(current_ability).order('name ASC').ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
           respond_with(@zones)
         end
 
@@ -47,7 +47,7 @@ module Spree
         end
 
         def zone
-          @zone ||= Spree::Zone.accessible_by(current_ability, :read).find(params[:id])
+          @zone ||= Spree::Zone.accessible_by(current_ability, :show).find(params[:id])
         end
       end
     end

--- a/api/app/controllers/spree/api/v2/storefront/account/credit_cards_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/account/credit_cards_controller.rb
@@ -41,7 +41,7 @@ module Spree
             end
 
             def scope
-              spree_current_user.credit_cards.accessible_by(current_ability, :read)
+              spree_current_user.credit_cards.accessible_by(current_ability, :show)
             end
           end
         end

--- a/api/app/controllers/spree/api/v2/storefront/countries_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/countries_controller.rb
@@ -52,7 +52,7 @@ module Spree
           end
 
           def scope
-            Spree::Country.accessible_by(current_ability, :read)
+            Spree::Country.accessible_by(current_ability, :show)
           end
         end
       end

--- a/api/app/controllers/spree/api/v2/storefront/products_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/products_controller.rb
@@ -44,7 +44,7 @@ module Spree
           end
 
           def scope
-            Spree::Product.accessible_by(current_ability, :read).includes(scope_includes)
+            Spree::Product.accessible_by(current_ability, :show).includes(scope_includes)
           end
 
           def scope_includes

--- a/api/app/controllers/spree/api/v2/storefront/taxons_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/taxons_controller.rb
@@ -40,7 +40,7 @@ module Spree
           end
 
           def scope
-            Spree::Taxon.accessible_by(current_ability, :read).includes(scope_includes)
+            Spree::Taxon.accessible_by(current_ability, :show).includes(scope_includes)
           end
 
           def scope_includes

--- a/backend/app/controllers/spree/admin/customer_returns_controller.rb
+++ b/backend/app/controllers/spree/admin/customer_returns_controller.rb
@@ -31,13 +31,13 @@ module Spree
       end
 
       def find_resource
-        Spree::CustomerReturn.accessible_by(current_ability, :read).find(params[:id])
+        Spree::CustomerReturn.accessible_by(current_ability, :show).find(params[:id])
       end
 
       def collection
         parent # trigger loading the order
         @collection ||= Spree::ReturnItem.
-                        accessible_by(current_ability, :read).
+                        accessible_by(current_ability).
                         where(inventory_unit_id: @order.inventory_units.pluck(:id)).
                         map(&:customer_return).uniq.compact
         @customer_returns = @collection

--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -81,7 +81,7 @@ module Spree
       def stock
         @variants = @product.variants.includes(*variant_stock_includes)
         @variants = [@product.master] if @variants.empty?
-        @stock_locations = StockLocation.accessible_by(current_ability, :read)
+        @stock_locations = StockLocation.accessible_by(current_ability)
         if @stock_locations.empty?
           flash[:error] = Spree.t(:stock_management_requires_a_stock_location)
           redirect_to admin_stock_locations_path

--- a/backend/app/controllers/spree/admin/return_authorizations_controller.rb
+++ b/backend/app/controllers/spree/admin/return_authorizations_controller.rb
@@ -36,7 +36,7 @@ module Spree
       end
 
       def load_reimbursement_types
-        @reimbursement_types = Spree::ReimbursementType.accessible_by(current_ability, :read).active
+        @reimbursement_types = Spree::ReimbursementType.accessible_by(current_ability).active
       end
 
       def load_return_authorization_reasons

--- a/backend/app/helpers/spree/admin/customer_returns_helper.rb
+++ b/backend/app/helpers/spree/admin/customer_returns_helper.rb
@@ -2,7 +2,7 @@ module Spree
   module Admin
     module CustomerReturnsHelper
       def reimbursement_types
-        @reimbursement_types ||= Spree::ReimbursementType.accessible_by(current_ability, :read).active
+        @reimbursement_types ||= Spree::ReimbursementType.accessible_by(current_ability).active
       end
     end
   end

--- a/backend/app/views/spree/admin/shared/_order_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_order_tabs.html.erb
@@ -14,7 +14,7 @@
       </li>
     <% end %>
 
-    <% if ((can?(:update, @order) && can?(:display, Spree::Store)) && (@order.shipments.size.zero? || @order.shipments.shipped.size.zero?)) %>
+    <% if ((can?(:update, @order) && can?(:read, Spree::Store)) && (@order.shipments.size.zero? || @order.shipments.shipped.size.zero?)) %>
       <li data-hook='admin_order_tabs_store_details'>
         <%= link_to_with_icon 'home',
           Spree.t(:store),

--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -51,7 +51,7 @@
     <p class='first_add_option_types no-objects-found' data-hook="first_add_option_types">
       <%= Spree.t(:to_add_variants_you_must_first_define) %>
       <%= link_to(Spree.t(:option_types), spree.admin_product_url(@product)) %>
-      <% if can?(:display, Spree::OptionType) && can?([:create, :display], Spree::OptionValue) %>
+      <% if can?(:read, Spree::OptionType) && can?([:create, :read], Spree::OptionValue) %>
         <%= Spree.t(:and) %>
         <%= link_to Spree.t(:option_values), spree.admin_option_types_url %>
       <% end %>

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -446,7 +446,7 @@ describe 'Products', type: :feature do
     end
 
     custom_authorization! do |_user|
-      can [:admin, :update, :index, :read], Spree::Product
+      can [:admin, :update, :read], Spree::Product
     end
     let!(:product) { create(:product) }
 

--- a/core/app/models/spree/ability.rb
+++ b/core/app/models/spree/ability.rb
@@ -23,15 +23,8 @@ module Spree
     end
 
     def initialize(user)
-      clear_aliased_actions
-
-      # override cancan default aliasing (we don't want to differentiate between read and index)
+      # add cancancan aliasing
       alias_action :delete, to: :destroy
-      alias_action :edit, to: :update
-      alias_action :new, to: :create
-      alias_action :new_action, to: :create
-      alias_action :show, to: :read
-      alias_action :index, :read, to: :display
       alias_action :create, :update, :destroy, to: :modify
 
       user ||= Spree.user_class.new
@@ -39,27 +32,27 @@ module Spree
       if user.respond_to?(:has_spree_role?) && user.has_spree_role?('admin')
         can :manage, :all
       else
-        can :display, Country
-        can :display, OptionType
-        can :display, OptionValue
+        can :read, Country
+        can :read, OptionType
+        can :read, OptionValue
         can :create, Order
-        can :read, Order do |order, token|
+        can :show, Order do |order, token|
           order.user == user || order.token && token == order.token
         end
         can :update, Order do |order, token|
           !order.completed? && (order.user == user || order.token && token == order.token)
         end
-        can :display, CreditCard, user_id: user.id
-        can :display, Product
-        can :display, ProductProperty
-        can :display, Property
+        can :read, CreditCard, user_id: user.id
+        can :read, Product
+        can :read, ProductProperty
+        can :read, Property
         can :create, Spree.user_class
-        can [:read, :update, :destroy], Spree.user_class, id: user.id
-        can :display, State
-        can :display, Taxon
-        can :display, Taxonomy
-        can :display, Variant
-        can :display, Zone
+        can [:show, :update, :destroy], Spree.user_class, id: user.id
+        can :read, State
+        can :read, Taxon
+        can :read, Taxonomy
+        can :read, Variant
+        can :read, Zone
       end
 
       # Include any abilities registered by extensions, etc.

--- a/core/lib/spree/testing_support/ability_helpers.rb
+++ b/core/lib/spree/testing_support/ability_helpers.rb
@@ -1,7 +1,7 @@
 shared_examples_for 'access granted' do
-  it 'should allow read' do
-    expect(ability).to be_able_to(:read, resource, token) if token
-    expect(ability).to be_able_to(:read, resource) unless token
+  it 'should allow show' do
+    expect(ability).to be_able_to(:show, resource, token) if token
+    expect(ability).to be_able_to(:show, resource) unless token
   end
 
   it 'should allow create' do
@@ -66,10 +66,6 @@ shared_examples_for 'create only' do
   it 'should not allow update' do
     expect(ability).to_not be_able_to(:update, resource)
   end
-
-  it 'should not allow index' do
-    expect(ability).to_not be_able_to(:index, resource)
-  end
 end
 
 shared_examples_for 'read only' do
@@ -97,9 +93,5 @@ shared_examples_for 'update only' do
 
   it 'should allow update' do
     expect(ability).to be_able_to(:update, resource)
-  end
-
-  it 'should not allow index' do
-    expect(ability).to_not be_able_to(:index, resource)
   end
 end

--- a/core/spec/models/spree/ability_spec.rb
+++ b/core/spec/models/spree/ability_spec.rb
@@ -111,6 +111,7 @@ describe Spree::Ability, type: :model do
         expect(ability).to be_able_to :update, user
         # ability.should_not be_able_to :create, resource_user # Fails
         # It can create new users if is has access to the :admin, User!!
+        expect(ability).to be_able_to :create, user
 
         # TODO: change the Ability class so only users and customers get the extra premissions?
 

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'acts_as_list', '~> 0.8'
   s.add_dependency 'awesome_nested_set', '~> 3.1.4'
   s.add_dependency 'carmen', '>= 1.0', '< 1.2'
-  s.add_dependency 'cancancan', '~> 2.0'
+  s.add_dependency 'cancancan', '~> 3.0'
   s.add_dependency 'deface', '~> 1.0'
   s.add_dependency 'ffaker', '~> 2.9'
   s.add_dependency 'friendly_id', '~> 5.2.1'

--- a/guides/src/content/release_notes/4_0_0.md
+++ b/guides/src/content/release_notes/4_0_0.md
@@ -116,6 +116,9 @@ Please review each of the noteworthy changes to ensure your customizations or ex
 
   [Janusz Kojro](https://github.com/spree/spree/pull/9292)
 
+- Updated 'cancancan' to '3.0'
+  [Spark Solutions](https://github.com/spree/spree/pull/9307)
+
 ## Full Changelog
 
 You can view the full changes using [Github Compare](https://github.com/spree/spree/compare/3-7-stable...master).


### PR DESCRIPTION
According to "Remove cancancan customizations" #3148

Changes provided:
`:read` replaced with `:show`
`:display` :replaced with `:read`
removed `:new_action`

In cancancan 3.0.0 when two abilities are merged, also the aliased_actions are merged.
for custom rules:
```
{
:destroy=>[:delete], 
:update=>[:edit], 
:create=>[:new, :new_action], 
:read=>[:show], 
:display=>[:index, :read]
}
```
base ability is the merged with other abilities where the default aliases are defined. The following:
```
{
  :read => [:index, :show],
  :create => [:new],
  :update => [:edit]
}
```
with the following aliases as a result:
```
{
:destroy=>[:delete], 
:update=>[:edit], 
:create=>[:new], 
:read=>[:index, :show], 
:display=>[:index, :read]
}
```
which makes confusions, because `:read` is an alias for `:index` and is also aliased by `:display`