### PR TITLE
bug/remove image.inheritance_column = nil

### DIFF
--- a/core/app/models/spree/image.rb
+++ b/core/app/models/spree/image.rb
@@ -2,13 +2,6 @@ module Spree
   class Image < Asset
     include Configuration::ActiveStorage
     include Rails.application.routes.url_helpers
-  
-    # In Rails 5.x class constants are being undefined/redefined during the code reloading process
-    # in a rails development environment, after which the actual ruby objects stored in those class constants
-    # are no longer equal (subclass == self) what causes error ActiveRecord::SubclassNotFound
-    # Invalid single-table inheritance type: Spree::Image is not a subclass of Spree::Image.
-    # The line below prevents the error.
-    self.inheritance_column = nil
 
     def styles
       self.class.styles.map do |_, size|


### PR DESCRIPTION
`self.inheritance_column = nil` in Spree::Image model prevented it from `ActiveRecord::SubclassNotFound` error in development environment, but causes randomly `SystemStackError: stack level too deep`