### PR TITLE
Fix/replace render file: with render trmplate: because of security vulnerability

### DIFF
--- a/backend/app/views/spree/admin/products/new.html.erb
+++ b/backend/app/views/spree/admin/products/new.html.erb
@@ -58,7 +58,7 @@
     </div>
 
     <div data-hook="product-from-prototype" id="product-from-prototype">
-      <%= render file: 'spree/admin/prototypes/show' if @prototype %>
+      <%= render template: 'spree/admin/prototypes/show' if @prototype %>
     </div>
 
     <%= render partial: 'spree/admin/shared/new_resource_links' %>


### PR DESCRIPTION
According to https://github.com/mpgn/CVE-2019-5418#cve-2019-5418---file-content-disclosure-on-rails
https://news.ycombinator.com/item?id=19456213
This was fixed in 6.0.0.beta3, 5.2.2.1, 5.1.6.2, 5.0.7.2, 4.2.11.1
https://weblog.rubyonrails.org/2019/3/13/Rails-4-2-5-1-5-1-6-2-have-been-released/