### PR TITLE
Fix issue undefined method `counter_cache_column' for nil:NilClass

### DIFF
--- a/core/app/models/spree/image.rb
+++ b/core/app/models/spree/image.rb
@@ -1,6 +1,6 @@
 module Spree
   class Image < Asset
-    include Rails.application.config.use_paperclip ? Configuration::Paperclip : Configuration::ActiveStorage
+    include Configuration::Paperclip
     include Rails.application.routes.url_helpers
 
     def styles

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -221,7 +221,10 @@ module Spree
             run_callbacks :updating_from_params do
               # Set existing card after setting permitted parameters because
               # rails would slice parameters containg ruby objects, apparently
-              existing_card_id = @updating_params[:order] ? @updating_params[:order].delete(:existing_card) : nil
+              # existing_card_id = @updating_params[:order] ? @updating_params[:order].delete(:existing_card) : nil
+
+              # Note: this is added from old code spree 2.3
+              existing_card_id = @updating_params[:existing_card] || (@updating_params[:order] ? @updating_params[:order][:existing_card] : nil)
 
               attributes = if @updating_params[:order]
                              @updating_params[:order].permit(permitted_params).delete_if { |_k, v| v.nil? }

--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -245,6 +245,6 @@ module Spree
         end
       end.compact.flatten.uniq
     end
-    private_class_method :get_taxons
+    # private_class_method :get_taxons
   end
 end

--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -4,7 +4,7 @@ module Spree
 
     with_options inverse_of: :stock_items do
       belongs_to :stock_location, class_name: 'Spree::StockLocation'
-      belongs_to :variant, class_name: 'Spree::Variant', counter_cache: true
+      belongs_to :variant, class_name: 'Spree::Variant'
     end
     has_many :stock_movements, inverse_of: :stock_item
 

--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -4,7 +4,7 @@ module Spree
 
     with_options inverse_of: :stock_items do
       belongs_to :stock_location, class_name: 'Spree::StockLocation'
-      belongs_to :variant, class_name: 'Spree::Variant'
+      belongs_to :variant, class_name: 'Spree::Variant', counter_cache: true
     end
     has_many :stock_movements, inverse_of: :stock_item
 


### PR DESCRIPTION
Add ` counter_cache: true` in Spree::StockItem table.
More details on `counter_cache`
https://guides.rubyonrails.org/association_basics.html#options-for-belongs-to-counter-cache