### PR TITLE
Require Ruby 2.3.3 on Travis for running Spree 3.7 tests

### DIFF
--- a/cmd/lib/spree_cmd/templates/extension/travis.yml
+++ b/cmd/lib/spree_cmd/templates/extension/travis.yml
@@ -20,7 +20,7 @@ script:
 rvm:
   - 2.5.1
   - 2.4.2
-  - 2.3.1
+  - 2.3.3
 
 matrix:
   allow_failures:


### PR DESCRIPTION
https://github.com/spree/spree/commit/785af0d6df691e016a746149d072cd7432c90bf6#diff-89479d84836feec76ada6e7343ba1be8