### PR TITLE
Fix/move order state to delivery before shipping method update

### DIFF
--- a/api/spec/requests/spree/api/v2/storefront/checkout_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/checkout_spec.rb
@@ -654,7 +654,7 @@ describe 'API V2 Storefront Checkout Spec', type: :request do
       {
         order: {
           shipments_attributes: {
-            '0' => { selected_shipping_rate_id: shipping_rate_id, id: shipment_id }
+            '0' => { selected_shipping_rate_id: new_selected_shipping_rate_id, id: shipment_id }
           }
         }
       }
@@ -664,6 +664,8 @@ describe 'API V2 Storefront Checkout Spec', type: :request do
       json_response['data'].first['relationships']['shipping_rates']['data'].first['id']
     end
     let(:shipment_id) { json_response['data'].first['id'] }
+    let!(:new_selected_shipping_method) { create(:shipping_method, name: 'Fedex') }
+    let(:new_selected_shipping_rate_id) { new_selected_shipping_method.shipping_rates.last.id }
 
     shared_examples 'transitions through checkout from start to finish' do
       before do
@@ -698,7 +700,7 @@ describe 'API V2 Storefront Checkout Spec', type: :request do
         expect(response.status).to eq(200)
         expect(order.reload.completed_at).not_to be_nil
         expect(order.state).to eq('complete')
-        expect(order.shipments.first.shipping_method).to eq(shipping_method)
+        expect(order.shipments.first.shipping_method).to eq(new_selected_shipping_method)
         expect(order.payments.valid.first.payment_method).to eq(payment_method)
       end
     end

--- a/core/app/services/spree/checkout/get_shipping_rates.rb
+++ b/core/app/services/spree/checkout/get_shipping_rates.rb
@@ -7,6 +7,7 @@ module Spree
         run :reload_order
         run :ensure_shipping_address
         run :ensure_line_items_present
+        run :move_order_to_delivery_state
         run :generate_shipping_rates
         run :return_shipments
       end
@@ -42,6 +43,12 @@ module Spree
 
       def return_shipments(order:)
         success(order.shipments.includes([shipping_rates: :shipping_method]))
+      end
+
+      def move_order_to_delivery_state(order:)
+        Spree::Dependencies.checkout_next_service.constantize.call(order: order) until order.state == 'delivery'
+
+        success(order: order)
       end
     end
   end


### PR DESCRIPTION
Order has to be in `delivery` state before requesting `/api/v2/storefront/checkout/shipping_rates` to prevent deleting already picked shipping method.