### PR TITLE
Fix math in payments.rb (#8148)

### DIFF
--- a/core/app/models/spree/order/payments.rb
+++ b/core/app/models/spree/order/payments.rb
@@ -52,7 +52,9 @@ module Spree
 
             payment.public_send(method)
 
-            if payment.completed? && payment_total != total
+            # Payment updates the order total if capture_on_dispatch is *not* set; don't do this twice
+            # See: https://github.com/spree/spree/issues/8148
+            if payment.completed? && payment.capture_on_dispatch
               self.payment_total += payment.amount
             end
           end


### PR DESCRIPTION
`payment_total` was being updated twice.

the comparison here can be wrong regardless of whether payment total is less than or greater than the total. if it's $1499 and the total is $1500 you shouldn't double the payment total, and vice versa.

#8148 was resulting in `credit_owed` order states due to payment totals what were double what the user actually paid.