### PR TITLE
Rewrite FriendlyId::SlugDecorator to Module.prepend

### DIFF
--- a/core/app/models/friendly_id/slug_decorator.rb
+++ b/core/app/models/friendly_id/slug_decorator.rb
@@ -1,3 +1,9 @@
-FriendlyId::Slug.class_eval do
-  acts_as_paranoid
+module FriendlyId
+  module SlugDecorator
+    def self.prepended(base)
+      base.acts_as_paranoid
+    end
+  end
 end
+
+FriendlyId::Slug.prepend FriendlyId::SlugDecorator


### PR DESCRIPTION
This fixes autoloading issues with Rails 6 and Zeitwerk trying to autoload `FriendlyId::SlugDecorator` constant