### PR TITLE
ItemTotal Promotion Rule: max limit ineligibility error message fixed

### DIFF
--- a/core/app/models/spree/promotion/rules/item_total.rb
+++ b/core/app/models/spree/promotion/rules/item_total.rb
@@ -39,7 +39,7 @@ module Spree
         end
 
         def ineligible_message_max
-          if preferred_operator_max == 'gte'
+          if preferred_operator_max == 'lt'
             eligibility_error_message(:item_total_more_than_or_equal, amount: formatted_amount_max)
           else
             eligibility_error_message(:item_total_more_than, amount: formatted_amount_max)

--- a/core/spec/models/spree/promotion/rules/item_total_spec.rb
+++ b/core/spec/models/spree/promotion/rules/item_total_spec.rb
@@ -62,7 +62,7 @@ describe Spree::Promotion::Rules::ItemTotal, type: :model do
       it 'set an error message' do
         rule.eligible?(order)
         expect(rule.eligibility_errors.full_messages.first).
-          to eq "This coupon code can't be applied to orders higher than $60.00."
+          to eq "This coupon code can't be applied to orders higher than or equal to $60.00."
       end
     end
 
@@ -76,7 +76,7 @@ describe Spree::Promotion::Rules::ItemTotal, type: :model do
       it 'set an error message' do
         rule.eligible?(order)
         expect(rule.eligibility_errors.full_messages.first).
-          to eq "This coupon code can't be applied to orders higher than $60.00."
+          to eq "This coupon code can't be applied to orders higher than or equal to $60.00."
       end
     end
   end
@@ -194,7 +194,7 @@ describe Spree::Promotion::Rules::ItemTotal, type: :model do
       it 'set an error message' do
         rule.eligible?(order)
         expect(rule.eligibility_errors.full_messages.first).
-          to eq "This coupon code can't be applied to orders higher than $60.00."
+          to eq "This coupon code can't be applied to orders higher than or equal to $60.00."
       end
     end
 
@@ -208,7 +208,7 @@ describe Spree::Promotion::Rules::ItemTotal, type: :model do
       it 'set an error message' do
         rule.eligible?(order)
         expect(rule.eligibility_errors.full_messages.first).
-          to eq "This coupon code can't be applied to orders higher than $60.00."
+          to eq "This coupon code can't be applied to orders higher than or equal to $60.00."
       end
     end
   end


### PR DESCRIPTION
## Issue
The max limit ineligibility error message is not set properly in `Spree::Promotion::Rules::ItemTotal` promotion rule.

## Promotion Rule
<img width="354" alt="Item Total Promotion Rule" src="https://user-images.githubusercontent.com/21332195/57022826-f29a7080-6c4d-11e9-9f22-9a4a76a9f155.png">


## Current Behaviour
<img width="660" alt="Current Behaviour" src="https://user-images.githubusercontent.com/21332195/57022835-f928e800-6c4d-11e9-9543-bb04e36f8cea.png">

## Expected Behaviour
<img width="660" alt="Expected Behaviour" src="https://user-images.githubusercontent.com/21332195/57022839-fded9c00-6c4d-11e9-9bd4-437b5e8b86f2.png">
