### PR TITLE
Don't run Rails 6 builds on Ruby 2.3/2.4, run tests against Ruby 2.6

### DIFF
--- a/cmd/lib/spree_cmd/templates/extension/travis.yml
+++ b/cmd/lib/spree_cmd/templates/extension/travis.yml
@@ -18,13 +18,19 @@ script:
   - bundle exec rake spec
 
 rvm:
+  - 2.6.3
   - 2.5.1
   - 2.4.2
-  - 2.3.3
+  - 2.3.8
 
 matrix:
   allow_failures:
     - gemfile: gemfiles/spree_master.gemfile
+  exclude:
+  - rvm: 2.3.8
+    gemfile: gemfiles/spree_master.gemfile
+  - rvm: 2.4.2
+    gemfile: gemfiles/spree_master.gemfile
 
 before_install:
   - mysql -u root -e "GRANT ALL ON *.* TO 'travis'@'%';"


### PR DESCRIPTION
Require Ruby 2.3.8 as this is the minimal version required by Spree 3.7