### PR TITLE
Fix admin page template breaking after adding spree_globalize gem

### DIFF
--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -131,7 +131,7 @@
         <div class="col-12 col-lg-4">
           <div class="form-group">
             <%= label_tag :q_store_id_in, Spree.t(:store) %>
-            <%= f.select :store_id_in, Spree::Store.order("#{Spree::Store.table_name}.name").pluck(:name, :id), { include_blank: true }, class: 'select2 js-filterable' %>
+            <%= f.select :store_id_in, Spree::Store.order(:name).pluck(:name, :id), { include_blank: true }, class: 'select2 js-filterable' %>
           </div>
         </div>
 


### PR DESCRIPTION
Solves `ActiveRecord::StatementInvalid in Spree::Admin::Orders#index` thrown on admin page after installing spree_globalize.
Described in this issue: https://github.com/spree/spree/issues/9334

The problem was that the order statement specified store table name explicitly. Globalize gem replaces references to translated columns with joins to translations table.

If the table name in order clause was specified via string, it didn't get picked up by globalize and wasn't replaced with reference to translations table. This caused some databases (like postgresql) to raise an error (order column is not in select clause).