### PR TITLE
FIX: data inside rake db:migrate sometimes not accurate

### DIFF
--- a/core/db/default/spree/countries.rb
+++ b/core/db/default/spree/countries.rb
@@ -1,14 +1,29 @@
 require 'carmen'
 
-Carmen::Country.all.each do |country|
-  Spree::Country.where(
-    name: country.name,
-    iso3: country.alpha_3_code,
-    iso: country.alpha_2_code,
-    iso_name: country.name.upcase,
-    numcode: country.numeric_code,
-    states_required: country.subregions?
-  ).first_or_create
+# Carmen::Country.all.each do |country|
+#   Spree::Country.where(
+#     name: country.name,
+#     iso3: country.alpha_3_code,
+#     iso: country.alpha_2_code,
+#     iso_name: country.name.upcase,
+#     numcode: country.numeric_code,
+#     states_required: country.subregions?
+#   ).first_or_create
+# end
+
+if Spree::Country.all.blant?
+  # populate only blank DB
+  country_activerecord_hash = Carmen::Country.map{ |country|
+    {
+      name: country.name,
+      iso3: country.alpha_3_code,
+      iso: country.alpha_2_code,
+      iso_name: country.name.upcase,
+      numcode: country.numeric_code,
+      states_required: country.subregions?
+    }
+  }
+  Spree::Country.create(country_activerecord_hash)
 end
 
 Spree::Config[:default_country_id] = Spree::Country.find_by(iso: 'US').id

--- a/core/db/default/spree/countries.rb
+++ b/core/db/default/spree/countries.rb
@@ -3,7 +3,7 @@ require 'carmen'
 if Spree::Country.all.blant?
   # populate only blank DB
   Spree::Country.create(
-    Carmen::Country.all.map{ |country|
+    Carmen::Country.all.map do |country|
       {
         name: country.name,
         iso3: country.alpha_3_code,
@@ -12,7 +12,7 @@ if Spree::Country.all.blant?
         numcode: country.numeric_code,
         states_required: country.subregions?
       }
-    }
+    end
   )
 end
 

--- a/core/db/default/spree/countries.rb
+++ b/core/db/default/spree/countries.rb
@@ -1,29 +1,19 @@
 require 'carmen'
 
-# Carmen::Country.all.each do |country|
-#   Spree::Country.where(
-#     name: country.name,
-#     iso3: country.alpha_3_code,
-#     iso: country.alpha_2_code,
-#     iso_name: country.name.upcase,
-#     numcode: country.numeric_code,
-#     states_required: country.subregions?
-#   ).first_or_create
-# end
-
 if Spree::Country.all.blant?
   # populate only blank DB
-  country_activerecord_hash = Carmen::Country.map{ |country|
-    {
-      name: country.name,
-      iso3: country.alpha_3_code,
-      iso: country.alpha_2_code,
-      iso_name: country.name.upcase,
-      numcode: country.numeric_code,
-      states_required: country.subregions?
+  Spree::Country.create(
+    Carmen::Country.all.map{ |country|
+      {
+        name: country.name,
+        iso3: country.alpha_3_code,
+        iso: country.alpha_2_code,
+        iso_name: country.name.upcase,
+        numcode: country.numeric_code,
+        states_required: country.subregions?
+      }
     }
-  }
-  Spree::Country.create(country_activerecord_hash)
+  )
 end
 
 Spree::Config[:default_country_id] = Spree::Country.find_by(iso: 'US').id

--- a/core/db/default/spree/countries.rb
+++ b/core/db/default/spree/countries.rb
@@ -1,6 +1,6 @@
 require 'carmen'
 
-if Spree::Country.all.blant?
+if Spree::Country.all.blank?
   # populate only blank DB
   Spree::Country.create(
     Carmen::Country.all.map do |country|

--- a/core/db/default/spree/countries.rb
+++ b/core/db/default/spree/countries.rb
@@ -1,6 +1,6 @@
 require 'carmen'
 
-if Spree::Country.all.blant?
+if Spree::Country.all.blank?
   # populate only blank DB
   Spree::Country.create(
     Carmen::Country.all.map{ |country|


### PR DESCRIPTION
`.where` with `.first_or_create` inside `.map` sometime fails when create instance for multi-tenant use and main DB loaded and has increased network delay or etc.  
In this fix I create array of hashes and then create all records using one sql request.