### PR TITLE
Move Doorkeeper decorators to initializer

### DIFF
--- a/api/app/models/doorkeeper/access_grant_decorator.rb
+++ b/api/app/models/doorkeeper/access_grant_decorator.rb
@@ -1,3 +1,0 @@
-Doorkeeper::AccessGrant.class_eval do
-  self.table_name = 'spree_oauth_access_grants'
-end

--- a/api/app/models/doorkeeper/access_token_decorator.rb
+++ b/api/app/models/doorkeeper/access_token_decorator.rb
@@ -1,3 +1,0 @@
-Doorkeeper::AccessToken.class_eval do
-  self.table_name = 'spree_oauth_access_tokens'
-end

--- a/api/app/models/doorkeeper/application_decorator.rb
+++ b/api/app/models/doorkeeper/application_decorator.rb
@@ -1,3 +1,0 @@
-Doorkeeper::Application.class_eval do
-  self.table_name = 'spree_oauth_applications'
-end

--- a/api/config/initializers/doorkeeper.rb
+++ b/api/config/initializers/doorkeeper.rb
@@ -18,3 +18,15 @@ Doorkeeper.configure do
 
   access_token_methods :from_bearer_authorization, :from_access_token_param
 end
+
+Doorkeeper::AccessGrant.class_eval do
+  self.table_name = 'spree_oauth_access_grants'
+end
+
+Doorkeeper::AccessToken.class_eval do
+  self.table_name = 'spree_oauth_access_tokens'
+end
+
+Doorkeeper::Application.class_eval do
+  self.table_name = 'spree_oauth_applications'
+end

--- a/api/lib/spree/api/engine.rb
+++ b/api/lib/spree/api/engine.rb
@@ -32,13 +32,6 @@ module Spree
         Migrations.new(config, engine_name).check
       end
 
-      def self.activate
-        Dir.glob(File.join(File.dirname(__FILE__), '../../../app/**/*_decorator*.rb')) do |c|
-          Rails.configuration.cache_classes ? require(c) : load(c)
-        end
-      end
-      config.to_prepare &method(:activate).to_proc
-
       def self.root
         @root ||= Pathname.new(File.expand_path('../../..', __dir__))
       end


### PR DESCRIPTION
We need to keep those decorators as class_evals because of issues with dev environments described in https://github.com/spree/spree/commit/1573ffa4d5103e819c6c226565ccb32fa9984736

This will also fix issues with Zeitwerk autoloader in Rails 6+