### PR TITLE
Don't include webpacker and bootsnap in sandbox/dummy test applications

### DIFF
--- a/core/lib/generators/spree/dummy/dummy_generator.rb
+++ b/core/lib/generators/spree/dummy/dummy_generator.rb
@@ -38,6 +38,8 @@ module Spree
       opts[:skip_spring] = true
       opts[:skip_test] = true
       opts[:skip_yarn] = true
+      opts[:skip_javascript] = true
+      opts[:skip_bootsnap] = true
 
       puts 'Generating dummy Rails application...'
       invoke Rails::Generators::AppGenerator,

--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -27,8 +27,9 @@ bundle exec rails new sandbox --database="$RAILSDB" \
   --skip-rc \
   --skip-spring \
   --skip-test \
-  --skip-yarn \
-  --skip-coffee
+  --skip-coffee \
+  --skip-javascript \
+  --skip-bootsnap
 
 if [ ! -d "sandbox" ]; then
   echo 'sandbox rails application failed'


### PR DESCRIPTION
This will reduce the time required to generate those apps