### PR TITLE
Address Book (part 1)

### DIFF
--- a/backend/app/views/spree/admin/users/addresses.html.erb
+++ b/backend/app/views/spree/admin/users/addresses.html.erb
@@ -17,7 +17,7 @@
       <%= render partial: 'addresses_form', locals: { f: f } %>
 
       <div class="form-actions text-center card bg-light mb-3" data-hook="admin_user_edit_form_button">
-        <div class="card-body"> 
+        <div class="card-body">
           <%= render partial: 'spree/admin/shared/edit_resource_links', locals: { collection_url: spree.admin_users_url } %>
         </div>
       </div>

--- a/core/app/models/concerns/spree/user_address.rb
+++ b/core/app/models/concerns/spree/user_address.rb
@@ -13,6 +13,9 @@ module Spree
 
       accepts_nested_attributes_for :ship_address, :bill_address
 
+      has_many :addresses, -> { where(deleted_at: nil).order('updated_at DESC') },
+                           class_name: 'Spree::Address', foreign_key: :user_id
+
       def persist_order_address(order)
         b_address = bill_address || build_bill_address
         b_address.attributes = order.bill_address.value_attributes

--- a/core/app/models/spree/ability.rb
+++ b/core/app/models/spree/ability.rb
@@ -42,6 +42,12 @@ module Spree
         can :update, Order do |order, token|
           !order.completed? && (order.user == user || order.token && token == order.token)
         end
+        can :manage, Spree::Address do |address|
+          address.user == user
+        end
+        can :create, Spree::Address do |_address|
+          user.id.present?
+        end
         can :read, CreditCard, user_id: user.id
         can :read, Product
         can :read, ProductProperty

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -12,6 +12,7 @@ module Spree
 
     # we're not freezing this on purpose so developers can extend and manage
     # those attributes depending of the logic of their applications
+    ADDRESS_FIELDS = %w(firstname lastname company address1 address2 city state zipcode country phone)
     EXCLUDED_KEYS_FOR_COMPARISION = %w(id updated_at created_at deleted_at user_id)
 
     belongs_to :country, class_name: 'Spree::Country'

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -12,7 +12,7 @@ module Spree
 
     # we're not freezing this on purpose so developers can extend and manage
     # those attributes depending of the logic of their applications
-    EXCLUDED_KEYS_FOR_COMPARISION = %w(id updated_at created_at)
+    EXCLUDED_KEYS_FOR_COMPARISION = %w(id updated_at created_at deleted_at user_id)
 
     belongs_to :country, class_name: 'Spree::Country'
     belongs_to :state, class_name: 'Spree::State', optional: true

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -69,7 +69,14 @@ module Spree
     end
 
     def to_s
-      "#{full_name}: #{address1}"
+      [
+        full_name,
+        company,
+        address1,
+        address2,
+        "#{city}, #{state_text} #{zipcode}",
+        country.to_s
+      ].reject(&:blank?).map { |attribute| ERB::Util.html_escape(attribute) }.join('<br/>')
     end
 
     def clone

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -16,6 +16,7 @@ module Spree
 
     belongs_to :country, class_name: 'Spree::Country'
     belongs_to :state, class_name: 'Spree::State', optional: true
+    belongs_to :user, class_name: Spree.user_class.name, optional: true
 
     has_many :shipments, inverse_of: :address
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -9,6 +9,7 @@ module Spree
     include Spree::Order::CurrencyUpdater
     include Spree::Order::Payments
     include Spree::Order::StoreCredit
+    include Spree::Order::AddressBook
     include Spree::Core::NumberGenerator.new(prefix: 'R')
     include Spree::Core::TokenGenerator
 
@@ -228,15 +229,6 @@ module Spree
 
     def merger
       @merger ||= Spree::OrderMerger.new(self)
-    end
-
-    def clone_billing_address
-      if bill_address && ship_address.nil?
-        self.ship_address = bill_address.clone
-      else
-        ship_address.attributes = bill_address.attributes.except('id', 'updated_at', 'created_at')
-      end
-      true
     end
 
     def ensure_store_presence

--- a/core/app/models/spree/order/address_book.rb
+++ b/core/app/models/spree/order/address_book.rb
@@ -1,0 +1,86 @@
+# https://github.com/spree-contrib/spree_address_book/blob/master/app/models/spree/order_decorator.rb
+module Spree
+  class Order < Spree::Base
+    module AddressBook
+      extend ActiveSupport::Concern
+
+      def clone_shipping_address
+        if ship_address
+          self.bill_address = ship_address
+        end
+        true
+      end
+
+      def clone_billing_address
+        if bill_address
+          self.ship_address = bill_address
+        end
+        true
+      end
+
+      def bill_address_id=(id)
+        address = Spree::Address.find_by(id: id)
+        if address && address.user_id == user_id
+          self['bill_address_id'] = address.id
+          user.update_attribute(:bill_address_id, address.id)
+          bill_address.reload
+        else
+          self['bill_address_id'] = nil
+        end
+      end
+
+      def bill_address_attributes=(attributes)
+        self.bill_address = update_or_create_address(attributes)
+        user.bill_address = bill_address if user
+      end
+
+      def ship_address_id=(id)
+        address = Spree::Address.find_by(id: id)
+        if address && address.user_id == user_id
+          self['ship_address_id'] = address.id
+          user.update_attribute(:ship_address_id, address.id)
+          ship_address.reload
+        else
+          self['ship_address_id'] = nil
+        end
+      end
+
+      def ship_address_attributes=(attributes)
+        self.ship_address = update_or_create_address(attributes)
+        user.ship_address = ship_address if user
+      end
+
+      private
+
+      def update_or_create_address(attributes = {})
+        return if attributes.blank?
+
+        attributes = attributes.select { |_k, v| v.present? }
+
+        if user
+          address = user.addresses.build(attributes.except(:id)).check
+          return address if address.id
+        end
+
+        if attributes[:id]
+          address = Spree::Address.find(attributes[:id])
+          attributes.delete(:id)
+
+          if address&.editable?
+            address.update_attributes(attributes)
+            return address
+          else
+            attributes.delete(:id)
+          end
+        end
+
+        unless attributes[:id]
+          address = Spree::Address.new(attributes)
+          address.save
+        end
+
+        address
+      end
+    end
+  end
+end

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -94,7 +94,6 @@ module Spree
                 before_transition from: :address, do: :update_line_item_prices!
                 before_transition from: :address, do: :create_tax_charge!
                 before_transition to: :address, do: :assign_default_addresses!
-                before_transition from: :address, do: :persist_user_address!
               end
 
               if states[:delivery]
@@ -256,29 +255,11 @@ module Spree
 
           def assign_default_addresses!
             if user
-              clone_billing
+              self.bill_address = user.bill_address if !bill_address_id && user.bill_address&.valid?
               # Skip setting ship address if order doesn't have a delivery checkout step
               # to avoid triggering validations on shipping address
-              clone_shipping if checkout_steps.include?('delivery')
+              self.ship_address = user.ship_address if !ship_address_id && user.ship_address&.valid? && checkout_steps.include?('delivery')
             end
-          end
-
-          def clone_billing
-            return unless !bill_address_id && user.bill_address.try(:valid?)
-
-            self.bill_address = user.bill_address.try(:clone)
-          end
-
-          def clone_shipping
-            return unless !ship_address_id && user.ship_address.try(:valid?)
-
-            self.ship_address = user.ship_address.try(:clone)
-          end
-
-          def persist_user_address!
-            return unless !temporary_address && user && user.respond_to?(:persist_order_address) && bill_address_id
-
-            user.persist_order_address(self)
           end
 
           def persist_user_credit_card

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -478,6 +478,20 @@ en:
     address1: Address
     address2: Address (contd.)
     addresses: Addresses
+    address_book:
+      other_address: "Other address"
+      add_new_shipping_address: "Add new address"
+      new_shipping_address: "New Address"
+      edit_shipping_address: "Edit Address"
+      no_shipping_addresses_on_file: "No addresses on file"
+      shipping_addresses: "Addresses"
+      successfully_created: "Address has been successfully created."
+      successfully_removed: "Address has been successfully removed."
+      successfully_saved: "Saved successfully"
+      unsuccessfully_saved: "There was an error while trying to save your address."
+      successfully_updated: "Updated successfully"
+      unsuccessfully_updated: "There was an update while trying to update your address."
+      save: "Save"
     adjustable: Adjustable
     adjustment: Adjustment
     adjustment_amount: Amount

--- a/core/db/migrate/20190523092729_add_user_id_and_deleted_at_to_spree_addresses.rb
+++ b/core/db/migrate/20190523092729_add_user_id_and_deleted_at_to_spree_addresses.rb
@@ -1,0 +1,12 @@
+# this migration does the same as this two from SpreeAddressBook
+# https://github.com/spree-contrib/spree_address_book/blob/master/db/migrate/20110302102208_add_user_id_and_deleted_at_to_addresses.rb
+# https://github.com/spree-contrib/spree_address_book/blob/master/db/migrate/20170405133031_add_missing_indexes.rb
+class AddUserIdAndDeletedAtToSpreeAddresses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :spree_addresses, :user_id, :integer unless column_exists?(:spree_addresses, :user_id)
+    add_index :spree_addresses, :user_id unless index_exists?(:spree_addresses, :user_id)
+
+    add_column :spree_addresses, :deleted_at, :datetime unless column_exists?(:spree_addresses, :deleted_at)
+    add_index :spree_addresses, :deleted_at unless index_exists?(:spree_addresses, :deleted_at)
+  end
+end

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -33,12 +33,14 @@ module Spree
       :id, :firstname, :lastname, :first_name, :last_name,
       :address1, :address2, :city, :country_iso, :country_id, :state_id,
       :zipcode, :phone, :state_name, :alternative_phone, :company,
+      :user_id, :deleted_at,
       country: [:iso, :name, :iso3, :iso_name],
       state: [:name, :abbr]
     ]
 
     @@checkout_attributes = [
-      :coupon_code, :email, :shipping_method_id, :special_instructions, :use_billing, :user_id
+      :coupon_code, :email, :shipping_method_id, :special_instructions, :use_billing, 
+      :user_id, :bill_address_id, :ship_address_id
     ]
 
     @@customer_return_attributes = [:stock_location_id, return_items_attributes: [:id, :inventory_unit_id, :return_authorization_id, :returned, :pre_tax_amount, :acceptance_status, :exchange_variant_id, :resellable]]

--- a/core/spec/models/spree/address_spec.rb
+++ b/core/spec/models/spree/address_spec.rb
@@ -507,4 +507,24 @@ describe Spree::Address, type: :model do
       expect(Spree::Address.where(['id = (?)', address2.id])).to_not be_empty
     end
   end
+
+  describe '#to_s' do
+    let(:address) { create(:address) }
+
+    it 'is displayed as string' do
+      a = address
+      expect(address.to_s).to eq("#{a.full_name}<br/>#{a.company}<br/>#{a.address1}<br/>#{a.address2}<br/>#{a.city}, #{a.state_text} #{a.zipcode}<br/>#{a.country}")
+      address.company = nil
+      expect(address.to_s).to eq("#{a.full_name}<br/>#{a.address1}<br/>#{a.address2}<br/>#{a.city}, #{a.state_text} #{a.zipcode}<br/>#{a.country}")
+    end
+
+    context 'address contains HTML' do
+      it 'properly escapes HTML' do
+        dangerous_string = '<script>alert("BOOM!")</script>'
+        address = create(:address, first_name: dangerous_string)
+
+        expect(address.to_s).not_to include(dangerous_string)
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/address_spec.rb
+++ b/core/spec/models/spree/address_spec.rb
@@ -468,4 +468,43 @@ describe Spree::Address, type: :model do
 
     it { expect(_address.country).to eq(Spree::Country.default) }
   end
+
+  context 'editable & destroy' do
+    let(:address) { create(:address) }
+    let(:address2) { create(:address) }
+    let(:order) { create(:completed_order_with_totals) }
+    let(:user) { create(:user) }
+
+    before { order.update_attribute(:bill_address, address2) }
+
+    it 'has required attributes' do
+      expect(Spree::Address.required_fields).to eq([:firstname, :lastname, :address1, :city, :country, :zipcode, :phone])
+    end
+
+    it 'is editable' do
+      expect(address).to be_editable
+    end
+
+    it 'can be deleted' do
+      expect(address).to be_can_be_deleted
+    end
+
+    it "isn't editable when there is an associated order" do
+      expect(address2).to_not be_editable
+    end
+
+    it "can't be deleted when there is an associated order" do
+      expect(address2).to_not be_can_be_deleted
+    end
+
+    it 'is destroyed without saving used' do
+      address.destroy
+      expect(Spree::Address.where(['id = (?)', address.id])).to be_empty
+    end
+
+    it 'is destroyed deleted timestamp' do
+      address2.destroy
+      expect(Spree::Address.where(['id = (?)', address2.id])).to_not be_empty
+    end
+  end
 end

--- a/core/spec/models/spree/order/address_spec.rb
+++ b/core/spec/models/spree/order/address_spec.rb
@@ -47,4 +47,40 @@ describe Spree::Order, type: :model do
       end
     end
   end
+
+  context 'address book' do
+    let(:order) { create(:order) }
+    let(:address) { create(:address, user: order.user) }
+
+    describe 'mass attribute assignment for bill_address_id, ship_address_id' do
+      it 'is able to mass assign bill_address_id' do
+        params = { bill_address_id: address.id }
+        order.update_attributes(params)
+        expect(order.bill_address_id).to eq address.id
+      end
+
+      it 'is able to mass assign ship_address_id' do
+        params = { ship_address_id: address.id }
+        order.update_attributes(params)
+        expect(order.ship_address_id).to eq address.id
+      end
+    end
+
+    describe 'Create order with the same bill & ship addresses' do
+      it 'has equal ids when set ids' do
+        address = create(:address)
+        @order = create(:order, bill_address_id: address.id, ship_address_id: address.id)
+        expect(@bill_address_id).to eq @order.ship_address_id
+      end
+
+      it 'has equal ids when option use_billing is active' do
+        address = create(:address)
+        @order  = create(:order, use_billing: true,
+                                 bill_address_id: address.id,
+                                 ship_address_id: nil)
+        @order = @order.reload
+        expect(@order.bill_address_id).to eq @order.ship_address_id
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -223,40 +223,6 @@ describe Spree::Order, type: :model do
         expect(order.state).to eq('delivery')
       end
 
-      it 'does not call persist_order_address if there is no address on the order' do
-        # otherwise, it will crash
-        allow(order).to receive_messages(ensure_available_shipping_rates: true)
-
-        order.user = FactoryBot.create(:user)
-        order.save!
-
-        expect(order.user).not_to receive(:persist_order_address).with(order)
-        order.next!
-      end
-
-      it "calls persist_order_address on the order's user" do
-        allow(order).to receive_messages(ensure_available_shipping_rates: true)
-
-        order.user = FactoryBot.create(:user)
-        order.ship_address = FactoryBot.create(:address)
-        order.bill_address = FactoryBot.create(:address)
-        order.save!
-
-        expect(order.user).to receive(:persist_order_address).with(order)
-        order.next!
-      end
-
-      it "does not call persist_order_address on the order's user for a temporary address" do
-        allow(order).to receive_messages(ensure_available_shipping_rates: true)
-
-        order.user = FactoryBot.create(:user)
-        order.temporary_address = true
-        order.save!
-
-        expect(order.user).not_to receive(:persist_order_address)
-        order.next!
-      end
-
       context 'cannot transition to delivery' do
         context 'with an existing shipment' do
           before do

--- a/core/spec/models/spree/user_spec.rb
+++ b/core/spec/models/spree/user_spec.rb
@@ -207,4 +207,21 @@ describe Spree.user_class, type: :model do
       end
     end
   end
+
+  context 'address book' do
+    let(:address) { create(:address) }
+    let(:address2) { create(:address) }
+
+    before do
+      address.user = subject
+      address.save
+      address2.user = subject
+      address2.save
+    end
+
+    it 'has many addresses' do
+      expect(subject).to respond_to(:addresses)
+      expect(subject.addresses).to eq [address2, address]
+    end
+  end
 end

--- a/frontend/app/assets/javascripts/spree/frontend.js
+++ b/frontend/app/assets/javascripts/spree/frontend.js
@@ -10,6 +10,7 @@
 //= require spree/frontend/cart
 //= require spree/frontend/checkout
 //= require spree/frontend/checkout/address
+//= require spree/frontend/checkout/address_book
 //= require spree/frontend/checkout/payment
 //= require spree/frontend/product
 

--- a/frontend/app/assets/javascripts/spree/frontend/checkout/address_book.js
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/address_book.js
@@ -1,0 +1,56 @@
+(function ($) {
+  $(document).ready(function () {
+    if ($('.select_address').length > 0) {
+      $('input#order_use_billing').unbind('change')
+
+      hide_address_form('billing')
+      hide_address_form('shipping')
+
+      if ($('input#order_use_billing').is(':checked')) {
+        $('#shipping .select_address').hide()
+      }
+
+      $('input#order_use_billing').click(function () {
+        if ($(this).is(':checked')) {
+          $('#shipping .select_address').hide()
+          hide_address_form('shipping')
+        } else {
+          $('#shipping .select_address').show()
+          if ($("input[name='order[ship_address_id]']:checked").val() == '0') {
+            show_address_form('shipping')
+          } else {
+            hide_address_form('shipping')
+          }
+        }
+      })
+
+      $("input[name='order[bill_address_id]']:radio").change(function () {
+        if ($("input[name='order[bill_address_id]']:checked").val() == '0') {
+          show_address_form('billing')
+        } else {
+          hide_address_form('billing')
+        }
+      })
+
+      $("input[name='order[ship_address_id]']:radio").change(function () {
+        if ($("input[name='order[ship_address_id]']:checked").val() == '0') {
+          show_address_form('shipping')
+        } else {
+          hide_address_form('shipping')
+        }
+      })
+    }
+  })
+
+  function hide_address_form (address_type) {
+    $('#' + address_type + ' .inner').hide()
+    $('#' + address_type + ' .inner input').prop('disabled', true)
+    $('#' + address_type + ' .inner select').prop('disabled', true)
+  }
+
+  function show_address_form (address_type) {
+    $('#' + address_type + ' .inner').show()
+    $('#' + address_type + ' .inner input').prop('disabled', false)
+    $('#' + address_type + ' .inner select').prop('disabled', false)
+  }
+})(jQuery)

--- a/frontend/app/assets/stylesheets/spree/frontend.css
+++ b/frontend/app/assets/stylesheets/spree/frontend.css
@@ -1,5 +1,6 @@
 /*
 * This is a manifest file that includes stylesheets for spree_frontend
  *= require spree/frontend/frontend_bootstrap
+ *= require spree/frontend/address_book
  *= require_self
 */

--- a/frontend/app/assets/stylesheets/spree/frontend/address_book.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/address_book.scss
@@ -1,0 +1,8 @@
+div#checkout #checkout_form_address {
+  #billing, #shipping {
+    .select_address label { float: none; }
+    input[type=radio] { width: auto; }
+  }
+}
+
+.hidden { display: none; }

--- a/frontend/app/controllers/concerns/spree/checkout/address_book.rb
+++ b/frontend/app/controllers/concerns/spree/checkout/address_book.rb
@@ -17,7 +17,7 @@ module Spree
         if params[:order][:ship_address_id].to_i > 0
           params[:order].delete(:ship_address_attributes)
 
-          Spree::Address.find(params[:order][:ship_address_id]).user_id != spree_current_user.id && raise('Frontend address forging')
+          Spree::Address.find(params[:order][:ship_address_id]).user_id != try_spree_current_user&.id && raise('Frontend address forging')
         else
           params[:order].delete(:ship_address_id)
         end
@@ -25,7 +25,7 @@ module Spree
         if params[:order][:bill_address_id].to_i > 0
           params[:order].delete(:bill_address_attributes)
 
-          Spree::Address.find(params[:order][:bill_address_id]).user_id != spree_current_user.id && raise('Frontend address forging')
+          Spree::Address.find(params[:order][:bill_address_id]).user_id != try_spree_current_user&.id && raise('Frontend address forging')
         else
           params[:order].delete(:bill_address_id)
         end

--- a/frontend/app/controllers/concerns/spree/checkout/address_book.rb
+++ b/frontend/app/controllers/concerns/spree/checkout/address_book.rb
@@ -1,0 +1,53 @@
+# https://github.com/spree-contrib/spree_address_book/blob/master/app/controllers/spree/checkout_controller_decorator.rb
+module Spree
+  module Checkout
+    module AddressBook
+      extend ActiveSupport::Concern
+
+      included do
+        after_action :normalize_addresses, only: :update
+        before_action :set_addresses, only: :update
+      end
+
+      protected
+
+      def set_addresses
+        return unless params[:order] && params[:state] == 'address'
+
+        if params[:order][:ship_address_id].to_i > 0
+          params[:order].delete(:ship_address_attributes)
+
+          Spree::Address.find(params[:order][:ship_address_id]).user_id != spree_current_user.id && raise('Frontend address forging')
+        else
+          params[:order].delete(:ship_address_id)
+        end
+
+        if params[:order][:bill_address_id].to_i > 0
+          params[:order].delete(:bill_address_attributes)
+
+          Spree::Address.find(params[:order][:bill_address_id]).user_id != spree_current_user.id && raise('Frontend address forging')
+        else
+          params[:order].delete(:bill_address_id)
+        end
+      end
+
+      def normalize_addresses
+        return unless params[:state] == 'address' && @order.bill_address_id && @order.ship_address_id
+
+        # ensure that there is no validation errors and addresses were saved
+        return unless @order.bill_address && @order.ship_address
+
+        bill_address = @order.bill_address
+        ship_address = @order.ship_address
+        if @order.bill_address_id != @order.ship_address_id && bill_address == ship_address
+          @order.update_column(:bill_address_id, ship_address.id)
+          bill_address.destroy
+        else
+          bill_address.update_attribute(:user_id, try_spree_current_user&.id)
+        end
+
+        ship_address.update_attribute(:user_id, try_spree_current_user&.id)
+      end
+    end
+  end
+end

--- a/frontend/app/controllers/spree/addresses_controller.rb
+++ b/frontend/app/controllers/spree/addresses_controller.rb
@@ -1,0 +1,72 @@
+# https://github.com/spree-contrib/spree_address_book/blob/master/app/controllers/spree/addresses_controller.rb
+module Spree
+  class AddressesController < Spree::StoreController
+    helper Spree::AddressesHelper
+    load_and_authorize_resource class: Spree::Address
+
+    def index
+      @addresses = spree_current_user.addresses
+    end
+
+    def create
+      @address = spree_current_user.addresses.build(address_params)
+      if @address.save
+        flash[:notice] = Spree.t(:successfully_created, scope: :address_book)
+        redirect_to :index
+      else
+        render :new
+      end
+    end
+
+    def edit
+      session['spree_user_return_to'] = request.env['HTTP_REFERER']
+    end
+
+    def new
+      @address = Spree::Address.default
+    end
+
+    def update
+      if @address.editable?
+        if @address.update_attributes(address_params)
+          flash[:notice] = Spree.t(:successfully_updated, scope: :address_book)
+          redirect_back_or_default(addresses_path)
+        else
+          render :edit
+        end
+      else
+        new_address = @address.clone
+        new_address.attributes = address_params
+        @address.update_attribute(:deleted_at, Time.current)
+        if new_address.save
+          flash[:notice] = Spree.t(:successfully_updated, scope: :address_book)
+          redirect_back_or_default(addresses_path)
+        else
+          render :edit
+        end
+      end
+    end
+
+    def destroy
+      @address.destroy
+
+      flash[:notice] = Spree.t(:successfully_removed, scope: :address_book)
+      redirect_to(request.env['HTTP_REFERER'] || addresses_path) unless request.xhr?
+    end
+
+    private
+
+    def address_params
+      params[:address].permit(:address,
+                              :firstname,
+                              :lastname,
+                              :address1,
+                              :address2,
+                              :city,
+                              :state_id,
+                              :zipcode,
+                              :country_id,
+                              :phone)
+    end
+  end
+end

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -4,6 +4,8 @@ module Spree
   # checkout which has nothing to do with updating an order that this approach
   # is waranted.
   class CheckoutController < Spree::StoreController
+    include Spree::Checkout::AddressBook
+
     before_action :set_cache_header, only: [:edit]
     before_action :load_order_with_lock
     before_action :ensure_valid_state_lock_version, only: [:update]

--- a/frontend/app/helpers/spree/addresses_helper.rb
+++ b/frontend/app/helpers/spree/addresses_helper.rb
@@ -1,0 +1,36 @@
+# https://github.com/spree-contrib/spree_address_book/blob/master/app/helpers/spree/addresses_helper.rb
+module Spree
+  module AddressesHelper
+    def address_field(form, method, address_id = 'b', &handler)
+      content_tag :p, id: [address_id, method].join, class: 'form-group' do
+        if handler
+          yield
+        else
+          is_required = Spree::Address.required_fields.include?(method)
+          separator = is_required ? '<span class="required">*</span><br />' : '<br />'
+          form.label(method) + separator.html_safe +
+            form.text_field(method, class: [is_required ? 'required' : nil, 'form-control'].compact, required: is_required)
+        end
+      end
+    end
+
+    def address_state(form, country, _address_id = 'b')
+      country ||= Spree::Country.find(Spree::Config[:default_country_id])
+      have_states = country.states.any?
+      state_elements = [
+        form.collection_select(:state_id, country.states.order(:name),
+                              :id, :name,
+                              { include_blank: true },
+                               class: have_states ? 'required form-control' : 'hidden',
+                               disabled: !have_states) +
+          form.text_field(:state_name,
+                          class: !have_states ? 'required' : 'hidden',
+                          disabled: have_states)
+      ].join.tr('"', "'").delete("\n")
+
+      form.label(:state, Spree.t(:state)) + '<span class="req">*</span><br />'.html_safe +
+        content_tag(:noscript, form.text_field(:state_name, class: 'required')) +
+        javascript_tag("document.write(\"#{state_elements.html_safe}\");")
+    end
+  end
+end

--- a/frontend/app/views/spree/addresses/_form.html.erb
+++ b/frontend/app/views/spree/addresses/_form.html.erb
@@ -1,0 +1,18 @@
+<% address_id = address_type.chars.first %>
+
+<% Spree::Address::ADDRESS_FIELDS.each do |field| %>
+  <% if field == "country" %>
+    <p class="form-group" id="<%= "#{address_id}country" %>">
+      <%= address_form.label :country_id, Spree.t(:country) %><span class="required">*</span><br />
+      <span id="<%= "#{address_id}country-selection" %>">
+        <%= address_form.collection_select :country_id, available_countries, :id, :name, {}, {:class => 'required form-control'} %>
+      </span>
+    </p>
+  <% elsif field == "state" %>
+    <%= address_field(address_form, :state, address_id) { address_state(address_form, address.country, address_id) } if Spree::Config[:address_requires_state] %>
+  <% else %>
+    <% next if field == "company" && !Spree::Config[:company] %>
+    <% next if field == "alternative_#{address_id}_phone" && !Spree::Config["alternative_#{address_id}_phone"] %>
+    <%= address_field(address_form, field.to_sym, address_id) %>
+  <% end %>
+<% end %>

--- a/frontend/app/views/spree/addresses/destroy.js.erb
+++ b/frontend/app/views/spree/addresses/destroy.js.erb
@@ -1,0 +1,2 @@
+$("#billing_address_<%= @address.id %>").fadeOut();
+$("#shipping_address_<%= @address.id %>").fadeOut();

--- a/frontend/app/views/spree/addresses/edit.html.erb
+++ b/frontend/app/views/spree/addresses/edit.html.erb
@@ -1,0 +1,23 @@
+<div class="col-lg-6 offset-lg-3">
+  <div class="card mb-3">
+    <div class="card-header">
+      <h3 class="card-title mb-0 h5"><%= t(:edit_shipping_address, scope: :address_book) %></h3>
+    </div>
+    <div class="card-body">
+      <%= render 'spree/shared/error_messages', target: @address %>
+      <%= form_for @address, html: { id: 'checkout_form_address' } do |f| %>
+        <fieldset>
+          <div class="inner">
+            <%= render 'spree/addresses/form',
+              address_name: 'address',
+              address_form: f,
+              address_type: 'shipping',
+              address: @address
+            %>
+          </div>
+          <%= f.submit Spree.t(:update), class: 'btn btn-primary' %>
+        </fieldset>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/frontend/app/views/spree/addresses/new.html.erb
+++ b/frontend/app/views/spree/addresses/new.html.erb
@@ -1,0 +1,23 @@
+<div class="col-lg-6 offset-lg-3">
+  <div class="card mb-3">
+    <div class="card-header">
+      <h3 class="card-title h5 mb-0"><%= t(:new_shipping_address, scope: :address_book) %></h3>
+    </div>
+    <div class="card-body">
+      <%= render 'spree/shared/error_messages', target: @address %>
+      <%= form_for @address, html: { id: 'checkout_form_address' } do |f| %>
+        <fieldset>
+          <div class="inner">
+            <%= render 'spree/addresses/form',
+              address_name: 'address',
+              address_form: f,
+              address_type: 'shipping',
+              address: @address
+            %>
+          </div>
+          <%= f.submit t(:save, scope: :address_book), class: 'btn btn-primary' %>
+        </fieldset>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/frontend/app/views/spree/checkout/_address.html.erb
+++ b/frontend/app/views/spree/checkout/_address.html.erb
@@ -1,39 +1,56 @@
-<div class="row">
-  <div class="col-12 col-md-6 mb-4" data-hook="billing_fieldset_wrapper">
-    <div class="card card-default" id="billing" data-hook>
-      <%= form.fields_for :bill_address do |bill_form| %>
-        <div class="card-header">
-          <h5 class="mb-0">
-            <%= Spree.t(:billing_address) %>
-          </h5>
-        </div>
-        <div class="card-body">
-          <%= render partial: 'spree/address/form', locals: { form: bill_form, address_type: 'billing', address: @order.bill_address } %>
-        </div>
-      <% end %>
-    </div>
-  </div>
+<% @addresses = try_spree_current_user ? try_spree_current_user.addresses : [] %>
 
-  <div class="col-12 col-md-6" data-hook="shipping_fieldset_wrapper">
-    <div class="card card-default" id="shipping" data-hook>
-      <%= form.fields_for :ship_address do |ship_form| %>
+<div class="row">
+  <% ['billing', 'shipping'].each do |address_type|
+    address_name = "#{address_type[0...4]}_address" %>
+    <div class="col-12 col-md-6 mb-4" data-hook="<%= address_type %>_fieldset_wrapper">
+      <div class="card card-default" id="<%= address_type %>" data-hook>
         <div class="card-header">
           <h5 class="mb-0">
-            <%= Spree.t(:shipping_address) %>
+            <%= Spree.t(address_type + '_address') %>
           </h5>
         </div>
         <div class="card-body">
-          <p class="field checkbox" data-hook="use_billing">
-            <%= label_tag :order_use_billing, id: 'use_billing' do %>
-              <%= check_box_tag 'order[use_billing]', '1', @order.shipping_eq_billing_address? %>
-              <%= Spree.t(:use_billing_address) %>
-            <% end %>
-          </p>
-          <%= render partial: 'spree/address/form', locals: { form: ship_form, address_type: 'shipping', address: @order.ship_address } %>
+          <% if address_type == 'shipping' %>
+            <p class="mb-0 form-check" data-hook="use_billing">
+              <%= label_tag :order_use_billing, id: 'use_billing' do %>
+                <%= check_box_tag 'order[use_billing]', '1', @order.shipping_eq_billing_address?, { class: 'form-check-input'} %>
+                <%= Spree.t(:use_billing_address) %>
+              <% end %>
+            </p>
+          <% end %>
+          <% if @addresses.present? %>
+          <div class="select_address">
+            <p class="form-group">
+              <% @addresses.each_with_index do |address, idx| %>
+              <span class="d-block mb-2" id="<%= [address_type, dom_id(address)].join('_') %>">
+                <label class="form-check-label">
+                  <%= form.radio_button "#{address_name}_id", address.id, checked: (address.id == try_spree_current_user["#{address_name}_id"] || idx == 0) %> <%= address.to_s.html_safe %>
+                </label>
+              </span>
+              <% end %>
+              <div class="form-check">
+                <label class="form-check-label">
+                  <%= form.radio_button "#{address_name}_id", 0, class: 'form-check-input' %> <%= Spree.t('address_book.other_address') %>
+                </label>
+              </div>
+            </p>
+          </div>
+          <% end %>
+          <%= form.fields_for address_name do |address_form| %>
+            <div class="inner" data-hook=<%="#{address_type}_inner" %>>
+              <%= render partial: 'spree/addresses/form', locals: {
+                address_name: address_name,
+                address_form: address_form,
+                address_type: address_type,
+                address: Spree::Address.default
+              } %>
+            </div>
+          <% end %>
         </div>
-      <% end %>
+      </div>
     </div>
-  </div>
+  <% end %>
 </div>
 
 <div class="card text-right form-buttons my-4" data-hook="buttons">

--- a/frontend/app/views/spree/checkout/_address.html.erb
+++ b/frontend/app/views/spree/checkout/_address.html.erb
@@ -27,6 +27,7 @@
                 <label class="form-check-label">
                   <%= form.radio_button "#{address_name}_id", address.id, checked: (address.id == try_spree_current_user["#{address_name}_id"] || idx == 0) %> <%= address.to_s.html_safe %>
                 </label>
+                <a class="mb-3" href="<%= edit_address_path(address) %>" data-hook="edit_address"><%= Spree.t(:edit) %></a>
               </span>
               <% end %>
               <div class="form-check">

--- a/frontend/config/routes.rb
+++ b/frontend/config/routes.rb
@@ -16,6 +16,8 @@ Spree::Core::Engine.add_routes do
     post :populate, on: :collection
   end
 
+  resources :addresses, except: [:show]
+
   get '/cart', to: 'orders#edit', as: :cart
   patch '/cart', to: 'orders#update', as: :update_cart
   put '/cart/empty', to: 'orders#empty', as: :empty_cart

--- a/frontend/spec/features/checkout_address_selection_spec.rb
+++ b/frontend/spec/features/checkout_address_selection_spec.rb
@@ -4,20 +4,6 @@ describe 'Address selection during checkout', type: :feature, js: true do
   let!(:store) { create(:store, default: true) }
   let(:state) { Spree::State.all.first || create(:state) }
 
-  before do
-    taxonomy = create(:taxonomy, name: 'Categories')
-    root = taxonomy.root
-    # create(:shipping_method)
-    clothing_taxon = create(:taxon, name: 'Clothing', parent_id: root.id)
-    bags_taxon = create(:taxon, name: 'Bags', parent_id: root.id)
-    mugs_taxon = create(:taxon, name: 'Mugs', parent_id: root.id)
-
-    create(:product_in_stock, name: 'Ruby on Rails Ringer T-Shirt',
-                              price: 17.99, taxons: [clothing_taxon])
-    create(:product_in_stock, name: 'Ruby on Rails Mug', price: 13.99,
-                              taxons: [mugs_taxon])
-  end
-
   describe 'guest user' do
     include_context 'checkout address book'
     before do
@@ -45,12 +31,6 @@ describe 'Address selection during checkout', type: :feature, js: true do
   describe 'as authenticated user with saved addresses' do
     include_context 'checkout address book'
 
-    let(:billing) { build(:address, state: state) }
-    let(:shipping) do
-      build(:address, address1: FFaker::Address.street_address, state: state)
-    end
-    let(:user) { @user }
-
     before do
       @user = create(:user)
       @user.addresses << create(:address, address1: FFaker::Address.street_address, state: state, alternative_phone: nil)
@@ -60,10 +40,13 @@ describe 'Address selection during checkout', type: :feature, js: true do
       allow_any_instance_of(Spree::CheckoutController).to receive_messages(skip_state_validation?: true)
 
       click_button 'Checkout'
-
-      find('#link-to-cart a').click
-      click_button 'Checkout'
     end
+
+    let(:billing) { build(:address, state: state) }
+    let(:shipping) do
+      build(:address, address1: FFaker::Address.street_address, state: state)
+    end
+    let(:user) { @user }
 
     it 'does not see billing or shipping address form' do
       expect(find('#billing .inner', visible: false)).not_to be_visible

--- a/frontend/spec/features/checkout_address_selection_spec.rb
+++ b/frontend/spec/features/checkout_address_selection_spec.rb
@@ -1,0 +1,331 @@
+require 'spec_helper'
+
+describe 'Address selection during checkout', type: :feature, js: true do
+  let!(:store) { create(:store, default: true) }
+  let(:state) { Spree::State.all.first || create(:state) }
+
+  before do
+    taxonomy = create(:taxonomy, name: 'Categories')
+    root = taxonomy.root
+    # create(:shipping_method)
+    clothing_taxon = create(:taxon, name: 'Clothing', parent_id: root.id)
+    bags_taxon = create(:taxon, name: 'Bags', parent_id: root.id)
+    mugs_taxon = create(:taxon, name: 'Mugs', parent_id: root.id)
+
+    create(:product_in_stock, name: 'Ruby on Rails Ringer T-Shirt',
+                              price: 17.99, taxons: [clothing_taxon])
+    create(:product_in_stock, name: 'Ruby on Rails Mug', price: 13.99,
+                              taxons: [mugs_taxon])
+  end
+
+  describe 'guest user' do
+    include_context 'checkout address book'
+    before do
+      click_button 'Checkout'
+      fill_in 'order_email', with: 'guest@example.com'
+      click_button 'Continue'
+    end
+
+    it 'sees billing address form' do
+      within('#billing') do
+        should_have_address_fields
+        expect(page).not_to have_selector('.select_address')
+      end
+    end
+
+    it 'sees shipping address form' do
+      within('#shipping') do
+        uncheck 'order_use_billing'
+        should_have_address_fields
+        expect(page).not_to have_selector('.select_address')
+      end
+    end
+  end
+
+  describe 'as authenticated user with saved addresses' do
+    include_context 'checkout address book'
+
+    let(:billing) { build(:address, state: state) }
+    let(:shipping) do
+      build(:address, address1: FFaker::Address.street_address, state: state)
+    end
+    let(:user) { @user }
+
+    before do
+      @user = create(:user)
+      @user.addresses << create(:address, address1: FFaker::Address.street_address, state: state, alternative_phone: nil)
+      @user.save
+
+      allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: @user)
+      allow_any_instance_of(Spree::CheckoutController).to receive_messages(skip_state_validation?: true)
+
+      click_button 'Checkout'
+
+      find('#link-to-cart a').click
+      click_button 'Checkout'
+    end
+
+    it 'does not see billing or shipping address form' do
+      expect(find('#billing .inner', visible: false)).not_to be_visible
+      expect(find('#shipping .inner', visible: false)).not_to be_visible
+    end
+
+    it 'lists saved addresses for billing and shipping' do
+      within('#billing .select_address') do
+        user.addresses.each do |a|
+          expect(page).to have_field("order_bill_address_id_#{a.id}")
+        end
+      end
+      within('#shipping .select_address', visible: false) do
+        user.addresses.each do |a|
+          expect(page).to have_field("order_ship_address_id_#{a.id}", visible: false)
+        end
+      end
+    end
+
+    it 'saves 2 addresses for user if they are different', js: true do
+      expect do
+        within('#billing') do
+          choose Spree.t('address_book.other_address')
+          fill_in_address(billing)
+        end
+        within('#shipping') do
+          uncheck 'order_use_billing'
+          choose Spree.t('address_book.other_address')
+          fill_in_address(shipping, :ship)
+        end
+        complete_checkout
+      end.to change { user.addresses.count }.by(2)
+    end
+
+    it 'saves 1 address for user if they are the same' do
+      expect do
+        within('#billing') do
+          choose Spree.t('address_book.other_address')
+          fill_in_address(billing)
+        end
+        within('#shipping') do
+          uncheck 'order_use_billing'
+          choose Spree.t('address_book.other_address')
+          fill_in_address(billing, :ship)
+        end
+        complete_checkout
+      end.to change { user.addresses.count }.by(1)
+    end
+
+    describe 'when invalid address is entered', js: true do
+      let(:address) do
+        build(:address, firstname: nil, state: state)
+      end
+
+      # TODO: the JS error reporting isn't working with our current iteration
+      # this is what this piece of code ('field is required') tests
+      it 'shows address form with error' do
+        allow(Capybara).to receive(:ignore_hidden_elements).and_return(false)
+        within('#billing') do
+          choose Spree.t('address_book.other_address')
+          fill_in_address(address)
+        end
+        within('#shipping') do
+          uncheck 'order_use_billing'
+          choose Spree.t('address_book.other_address')
+          fill_in_address(address, :ship)
+        end
+        click_button 'Save and Continue'
+
+        bfirstname_message = page.find('#order_bill_address_attributes_firstname').native.attribute('validationMessage')
+        sfirstname_message = page.find('#order_ship_address_attributes_firstname').native.attribute('validationMessage')
+
+        expect(bfirstname_message).to eq('Please fill out this field.')
+        expect(sfirstname_message).to eq('Please fill out this field.')
+      end
+    end
+
+    describe 'entering 2 new addresses', js: true do
+      it 'assigns 2 new addresses to order' do
+        allow(Capybara).to receive(:ignore_hidden_elements).and_return(false)
+        within('#billing') do
+          choose Spree.t('address_book.other_address')
+          fill_in_address(billing)
+        end
+        within('#shipping') do
+          uncheck 'order_use_billing'
+          choose Spree.t('address_book.other_address')
+          fill_in_address(shipping, :ship)
+        end
+        complete_checkout
+        expect(page).to have_content('processed successfully')
+        within('#order > div.row.steps-data > div:nth-child(1)') do
+          expect(page).to have_content('Billing Address')
+          expect(page).to have_content(expected_address_format(billing))
+        end
+        within('#order > div.row.steps-data > div:nth-child(2)') do
+          expect(page).to have_content('Shipping Address')
+          expect(page).to have_content(expected_address_format(shipping))
+        end
+      end
+    end
+
+    describe 'using saved address for bill and new ship address', js: true do
+      let(:shipping) do
+        build(:address, address1: FFaker::Address.street_address,
+                        state: state)
+      end
+
+      it 'saves 1 new address for user' do
+        expect do
+          address = user.addresses.first
+          choose "order_bill_address_id_#{address.id}"
+          within('#shipping') do
+            uncheck 'order_use_billing'
+            choose Spree.t('address_book.other_address')
+            fill_in_address(shipping, :ship)
+          end
+          complete_checkout
+        end.to change { user.addresses.count }.by(1)
+      end
+
+      it 'assigns addresses to orders' do
+        allow(Capybara).to receive(:ignore_hidden_elements).and_return(false)
+        address = user.addresses.first
+        choose "order_bill_address_id_#{address.id}"
+        within('#shipping') do
+          uncheck 'order_use_billing'
+          choose Spree.t('address_book.other_address')
+          fill_in_address(shipping, :ship)
+        end
+        complete_checkout
+        expect(page).to have_content('processed successfully')
+        within('#order > div.row.steps-data > div:nth-child(1)') do
+          expect(page).to have_content('Billing Address')
+          expect(page).to have_content(expected_address_format(address))
+        end
+        within('#order > div.row.steps-data > div:nth-child(2)') do
+          expect(page).to have_content('Shipping Address')
+          expect(page).to have_content(expected_address_format(shipping))
+        end
+      end
+
+      it 'sees form when new shipping address invalid' do
+        address = user.addresses.first
+        shipping = build(:address, address1: nil, state: state)
+        choose "order_bill_address_id_#{address.id}"
+        within('#shipping') do
+          uncheck 'order_use_billing'
+          choose Spree.t('address_book.other_address')
+          fill_in_address(shipping, :ship)
+        end
+        click_button 'Save and Continue'
+
+        saddress1_message = page.find('#order_ship_address_attributes_address1').native.attribute('validationMessage')
+        expect(saddress1_message).to eq('Please fill out this field.')
+
+        within('#billing') do
+          expect(find("#order_bill_address_id_#{address.id}")).to be_checked
+        end
+      end
+    end
+
+    describe 'using saved address for billing and shipping', js: true do
+      it 'addresseses to order' do
+        allow(Capybara).to receive(:ignore_hidden_elements).and_return(false)
+        address = user.addresses.first
+        choose "order_bill_address_id_#{address.id}"
+        check 'Use Billing Address'
+        complete_checkout
+        within('#order > div.row.steps-data > div:nth-child(1)') do
+          expect(page).to have_content('Billing Address')
+          expect(page).to have_content(expected_address_format(address))
+        end
+        within('#order > div.row.steps-data > div:nth-child(2)') do
+          expect(page).to have_content('Shipping Address')
+          expect(page).to have_content(expected_address_format(address))
+        end
+      end
+
+      it 'does not add addresses to user' do
+        expect do
+          address = user.addresses.first
+          choose "order_bill_address_id_#{address.id}"
+          check 'Use Billing Address'
+          complete_checkout
+        end.not_to change { user.addresses.count }
+      end
+    end
+
+    describe 'using saved address for ship and new bill address', js: true do
+      let(:billing) do
+        build(:address, address1: FFaker::Address.street_address, state: state, zipcode: '90210')
+      end
+
+      it 'saves 1 new address for user' do
+        expect do
+          address = user.addresses.first
+          uncheck 'order_use_billing'
+          choose "order_ship_address_id_#{address.id}"
+          within('#billing') do
+            choose Spree.t('address_book.other_address')
+            fill_in_address(billing)
+          end
+          complete_checkout
+        end.to change { user.addresses.count }.by(1)
+      end
+
+      it 'assigns addresses to orders' do
+        allow(Capybara).to receive(:ignore_hidden_elements).and_return(false)
+        address = user.addresses.first
+        uncheck 'order_use_billing'
+        choose "order_ship_address_id_#{address.id}"
+        within('#billing') do
+          choose Spree.t('address_book.other_address')
+          fill_in_address(billing)
+        end
+        complete_checkout
+        expect(page).to have_content('processed successfully')
+        within('#order > div.row.steps-data > div:nth-child(1)') do
+          expect(page).to have_content('Billing Address')
+          expect(page).to have_content(expected_address_format(billing))
+        end
+        within('#order > div.row.steps-data > div:nth-child(2)') do
+          expect(page).to have_content('Shipping Address')
+          expect(page).to have_content(expected_address_format(address))
+        end
+      end
+
+      # TODO: not passing because inline JS validation not working
+      it 'sees form when new billing address invalid' do
+        address = user.addresses.first
+        billing = build(:address, address1: nil, state: state)
+        uncheck 'order_use_billing'
+        choose "order_ship_address_id_#{address.id}"
+        within('#billing') do
+          choose Spree.t('address_book.other_address')
+          fill_in_address(billing)
+        end
+        click_button 'Save and Continue'
+
+        baddress1_message = page.find('#order_bill_address_attributes_address1').native.attribute('validationMessage')
+        expect(baddress1_message).to eq('Please fill out this field.')
+
+        within('#shipping') do
+          expect(find("#order_ship_address_id_#{address.id}")).to be_checked
+        end
+      end
+    end
+
+    describe 'entering address that is already saved', js: true do
+      it 'does not save address for user' do
+        expect do
+          address = user.addresses.first
+          uncheck 'order_use_billing'
+          choose "order_ship_address_id_#{address.id}"
+          within('#billing') do
+            choose Spree.t('address_book.other_address')
+            fill_in_address(address)
+          end
+          complete_checkout
+        end.not_to change { user.addresses.count }
+      end
+    end
+  end
+end

--- a/frontend/spec/features/checkout_edit_address_spec.rb
+++ b/frontend/spec/features/checkout_edit_address_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe 'User editing saved address during checkout', type: :feature, js: true do
+  include_context 'checkout address book'
+  include_context 'user with address'
+
+  before { click_button 'Checkout' }
+
+  it 'can update billing address' do
+    within("#billing #billing_address_#{address.id}") do
+      click_link 'Edit'
+    end
+    expect(page).to have_current_path spree.edit_address_path(address)
+    new_street = FFaker::Address.street_address
+    fill_in I18n.t('activerecord.attributes.spree/address.address1'), with: new_street
+    click_button 'Update'
+    user.reload
+    page.driver.browser.navigate.refresh
+    expect(page).to have_current_path spree.checkout_state_path('address')
+    within('h1') { expect(page).to have_content('Checkout') }
+    within('#billing') do
+      expect(page).to have_content(new_street)
+    end
+  end
+
+  it 'can update shipping address' do
+    uncheck 'order_use_billing'
+    within("#shipping #shipping_address_#{address.id}") do
+      click_link 'Edit'
+    end
+    expect(page).to have_current_path spree.edit_address_path(address)
+    new_street = FFaker::Address.street_address
+    fill_in I18n.t('activerecord.attributes.spree/address.address1'), with: new_street
+    click_button 'Update'
+    user.reload
+    page.driver.browser.navigate.refresh
+    expect(page).to have_current_path spree.checkout_state_path('address')
+    within('h1') { expect(page).to have_content('Checkout') }
+    find('#order_use_billing').click # checking hidden elements in capybara is funky
+    within('#shipping') do
+      expect(page).to have_content(new_street)
+    end
+  end
+end

--- a/frontend/spec/support/shared_contexts/checkout_address_book.rb
+++ b/frontend/spec/support/shared_contexts/checkout_address_book.rb
@@ -1,0 +1,72 @@
+shared_context 'checkout address book' do
+  before do
+    @store = Spree::Store.current || create(:store)
+    @state = Spree::State.all.first || create(:state)
+    @zone = Spree::Zone.global || create(:global_zone)
+    @zone.countries << Spree::Country.all
+    @tax_category = Spree::TaxCategory.first || create(:tax_category)
+    @shipping = Spree::ShippingMethod.find_by_name('UPS Ground') || create(:shipping_method, tax_category: @tax_category)
+    @product = Spree::Product.find_by_name('Ruby on Rails Mug')
+
+    create(:check_payment_method)
+    reset_spree_preferences do |config|
+      config.company = true
+      config.alternative_shipping_phone = false
+    end
+
+    visit spree.root_path
+    click_link 'Ruby on Rails Mug'
+    wait_for_condition do
+      expect(page.find('#add-to-cart-button').disabled?).to eq(false)
+    end
+    click_button 'add-to-cart-button'
+    wait_for_condition do
+      expect(page).to have_content(Spree.t(:shopping_cart))
+    end
+  end
+
+  let(:state) { @state }
+
+  private
+
+  def should_have_address_fields
+    expect(page).to have_field('First Name')
+    expect(page).to have_field('Last Name')
+    expect(page).to have_field(I18n.t('activerecord.attributes.spree/address.address1'))
+    expect(page).to have_field('City')
+    expect(page).to have_field('Country')
+    expect(page).to have_field(I18n.t('activerecord.attributes.spree/address.zipcode'))
+    expect(page).to have_field(I18n.t('activerecord.attributes.spree/address.phone'))
+  end
+
+  def complete_checkout
+    click_button Spree.t(:save_and_continue)
+    choose 'UPS Ground'
+    click_button Spree.t(:save_and_continue)
+    choose 'Check'
+    click_button Spree.t(:save_and_continue)
+  end
+
+  def fill_in_address(address, type = :bill)
+    fill_in 'First Name', with: address.firstname
+    fill_in 'Last Name', with: address.lastname
+    fill_in 'Company', with: address.company if Spree::Config[:company]
+    fill_in I18n.t('activerecord.attributes.spree/address.address1'), with: address.address1
+    fill_in I18n.t('activerecord.attributes.spree/address.address2'), with: address.address2
+    select address.state.name, from: "order_#{type}_address_attributes_state_id"
+    fill_in 'City', with: address.city
+    fill_in I18n.t('activerecord.attributes.spree/address.zipcode'), with: address.zipcode
+    fill_in I18n.t('activerecord.attributes.spree/address.phone'), with: address.phone
+  end
+
+  def expected_address_format(address)
+    [
+      "#{address.firstname} #{address.lastname}",
+      address.company.to_s,
+      address.address1.to_s,
+      address.address2.to_s,
+      "#{address.city} #{address.state ? address.state.abbr : address.state_name} #{address.zipcode}",
+      address.country.to_s
+    ].reject(&:empty?).join(' ')
+  end
+end

--- a/frontend/spec/support/shared_contexts/checkout_address_book.rb
+++ b/frontend/spec/support/shared_contexts/checkout_address_book.rb
@@ -6,7 +6,6 @@ shared_context 'checkout address book' do
     @zone.countries << Spree::Country.all
     @tax_category = Spree::TaxCategory.first || create(:tax_category)
     @shipping = Spree::ShippingMethod.find_by_name('UPS Ground') || create(:shipping_method, tax_category: @tax_category)
-    @product = Spree::Product.find_by_name('Ruby on Rails Mug')
 
     create(:check_payment_method)
     reset_spree_preferences do |config|
@@ -14,15 +13,9 @@ shared_context 'checkout address book' do
       config.alternative_shipping_phone = false
     end
 
-    visit spree.root_path
-    click_link 'Ruby on Rails Mug'
-    wait_for_condition do
-      expect(page.find('#add-to-cart-button').disabled?).to eq(false)
-    end
-    click_button 'add-to-cart-button'
-    wait_for_condition do
-      expect(page).to have_content(Spree.t(:shopping_cart))
-    end
+    create(:product_in_stock, name: 'Ruby on Rails Mug', price: 13.99)
+
+    add_to_cart('Ruby on Rails Mug')
   end
 
   let(:state) { @state }

--- a/frontend/spec/support/shared_contexts/checkout_setup.rb
+++ b/frontend/spec/support/shared_contexts/checkout_setup.rb
@@ -16,7 +16,7 @@ shared_context 'proceed to payment step' do
     fill_in 'order_email', with: 'spree@example.com'
     fill_in 'First Name', with: 'John'
     fill_in 'Last Name', with: 'Smith'
-    fill_in 'Street Address', with: '1 John Street'
+    fill_in 'Address', with: '1 John Street'
     fill_in 'City', with: 'City of John'
     fill_in 'Zip', with: '01337'
     select country.name, from: 'Country'

--- a/frontend/spec/support/shared_contexts/user_with_address.rb
+++ b/frontend/spec/support/shared_contexts/user_with_address.rb
@@ -1,0 +1,19 @@
+shared_context 'user with address' do
+  let(:state) { Spree::State.all.first || create(:state) }
+
+  let(:address) do
+    create(:address, address1: FFaker::Address.street_address, state: state)
+  end
+
+  let(:billing) { build(:address, state: state) }
+  let(:shipping) do
+    build(:address, address1: FFaker::Address.street_address, state: state)
+  end
+
+  let(:user) do
+    u = create(:user)
+    u.addresses << address
+    u.save
+    u
+  end
+end

--- a/frontend/spec/support/shared_contexts/user_with_address.rb
+++ b/frontend/spec/support/shared_contexts/user_with_address.rb
@@ -10,10 +10,15 @@ shared_context 'user with address' do
     build(:address, address1: FFaker::Address.street_address, state: state)
   end
 
-  let(:user) do
+  let!(:user) do
     u = create(:user)
     u.addresses << address
     u.save
     u
+  end
+
+  before do
+    allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: user)
+    allow_any_instance_of(Spree::AddressesController).to receive_messages(try_spree_current_user: user)
   end
 end


### PR DESCRIPTION
<img width="1123" alt="Screen Shot 2019-05-31 at 10 45 27 AM" src="https://user-images.githubusercontent.com/55154/58693574-5caf4e00-8391-11e9-8c0e-4f55ae64e7c8.png">

ref https://github.com/spree/spree/issues/6942

This adds the backend logic of handling multiple Addresses per User plus UI for the Frontend part to handle Addresses selection / creation / editing on Checkout.

The code was moved from the [Spree Address Book](https://github.com/spree-contrib/spree_address_book) extension and later improved & fixed for Spree 4.0

Next steps:
- [ ] support Address Book in API v2
- [ ] support Address Book in the Admin Panel