### PR TITLE
Add .cache class in general_settings/edit.html.erb

### DIFF
--- a/backend/app/views/spree/admin/general_settings/edit.html.erb
+++ b/backend/app/views/spree/admin/general_settings/edit.html.erb
@@ -37,7 +37,7 @@
           <%#-------------------------------------------------%>
           <%# Clear cache                                     %>
           <%#-------------------------------------------------%>
-          <div class="card mb-3 cache">
+          <div class="card mb-3" id="general-settings-cache" data-hook="general_settings_cache">
             <div class="card-header">
               <h1 class="card-title mb-0 h5"><%= Spree.t(:clear_cache)%></h1>
             </div>

--- a/backend/app/views/spree/admin/general_settings/edit.html.erb
+++ b/backend/app/views/spree/admin/general_settings/edit.html.erb
@@ -37,7 +37,7 @@
           <%#-------------------------------------------------%>
           <%# Clear cache                                     %>
           <%#-------------------------------------------------%>
-          <div class="card mb-3">
+          <div class="card mb-3 cache">
             <div class="card-header">
               <h1 class="card-title mb-0 h5"><%= Spree.t(:clear_cache)%></h1>
             </div>


### PR DESCRIPTION
### What

Add `.cache` class to clear cache card div in `general_settings/edit.html.erb`

### Why

Lately I wanted to create a deface override to clear cache card in `general_settings/edit.html.erb`, but noticed that didn't have a unique class to be used as css selector. I ended up using hacky css selector rule, but this would make it much easier.