### PR TITLE
Add id to currency & security card divs

### DIFF
--- a/backend/app/views/spree/admin/general_settings/edit.html.erb
+++ b/backend/app/views/spree/admin/general_settings/edit.html.erb
@@ -13,7 +13,7 @@
           <%# Security settings                               %>
           <%#-------------------------------------------------%>
           <% if @preferences_security.any? %>
-            <div class="card mb-3 security">
+            <div class="card mb-3" id="general-settings-security" data-hook="general_settings_security">
               <div class="card-header">
                 <h1 class="card-title mb-0 h5">
                   <%= Spree.t(:security_settings) %>

--- a/backend/app/views/spree/admin/general_settings/edit.html.erb
+++ b/backend/app/views/spree/admin/general_settings/edit.html.erb
@@ -58,7 +58,7 @@
           <%#-------------------------------------------------%>
           <%# Currency Settings                               %>
           <%#-------------------------------------------------%>
-          <div class="card mb-3 currency">
+          <div class="card mb-3" id="general-settings-currency" data-hook="general_settings_currency">
             <div class="card-header">
               <h1 class="card-title mb-0 h5">
                 <%= Spree.t(:currency_settings)%>


### PR DESCRIPTION
Replaces `.security` and `.currency` classes with div specific ids in `backend/app/views/spree/admin/general_settings/edit.html.erb` similar to changes introduced in #9419 