### PR TITLE
Fix XSS vulnerability on products#show

### DIFF
--- a/core/app/helpers/spree/products_helper.rb
+++ b/core/app/helpers/spree/products_helper.rb
@@ -36,7 +36,7 @@ module Spree
                     else
                       product.description.to_s.gsub(/(.*?)\r?\n\r?\n/m, '<p>\1</p>')
                     end
-      description.blank? ? Spree.t(:product_has_no_description) : raw(description)
+      description.blank? ? Spree.t(:product_has_no_description) : description
     end
 
     def line_item_description_text(description_text)

--- a/frontend/app/views/spree/products/show.html.erb
+++ b/frontend/app/views/spree/products/show.html.erb
@@ -31,7 +31,7 @@
           <h1 class="product-title mt-2" itemprop="name"><%= @product.name %></h1>
 
           <div itemprop="description" data-hook="description">
-            <%= product_description(@product) %>
+            <%= sanitize product_description(@product) %>
           </div>
 
           <div id="cart-form" data-hook="cart_form">

--- a/frontend/lib/spree/frontend/engine.rb
+++ b/frontend/lib/spree/frontend/engine.rb
@@ -3,6 +3,10 @@ module Spree
     class Engine < ::Rails::Engine
       config.middleware.use 'Spree::Frontend::Middleware::SeoAssist'
 
+      # Prevent XSS but allow text formatting
+      config.action_view.sanitized_allowed_tags = %w(a b del em i ins mark p small strong sub sup)
+      config.action_view.sanitized_allowed_attributes = %w(href)
+
       # sets the manifests / assets to be precompiled, even when initialize_on_precompile is false
       initializer 'spree.assets.precompile', group: :all do |app|
         app.config.assets.precompile += %w[


### PR DESCRIPTION
## What

Fix #9390

As shown in screenshots, it preserves new line inserted in `products_helper.rb` as well as specific tags that I found in [this w3school page for text formatting](https://www.w3schools.com/html/html_formatting.asp)

Let me know if more tags / attributes should be added / removed

## Screenshots
 
#### /admin/products/:id/edit
![image](https://user-images.githubusercontent.com/9669739/59580175-15ec8280-910b-11e9-9f5d-11502367c74c.png)

#### /admin/products/:id/show
![image](https://user-images.githubusercontent.com/9669739/59580459-2c470e00-910c-11e9-8b42-9a27bf30074f.png)

#### HTML

![image](https://user-images.githubusercontent.com/9669739/59580469-35d07600-910c-11e9-9272-5852015408fb.png)

