### PR TITLE
Upgrade Capybara and usage

### DIFF
--- a/api/spec/support/database_cleaner.rb
+++ b/api/spec/support/database_cleaner.rb
@@ -8,7 +8,7 @@ RSpec.configure do |config|
     DatabaseCleaner.start
   end
 
-  config.after do
+  config.append_after do
     DatabaseCleaner.clean
   end
 end

--- a/backend/spec/features/admin/configuration/countries_spec.rb
+++ b/backend/spec/features/admin/configuration/countries_spec.rb
@@ -14,10 +14,10 @@ module Spree
       fill_in 'Iso3', with: 'BRL'
       click_button 'Create'
 
-      handle_js_confirm do
+      accept_confirm do
         click_icon :delete
-        wait_for_ajax
       end
+      wait_for_ajax
 
       expect { Country.find(country.id) }.to raise_error(StandardError)
     end

--- a/backend/spec/features/admin/configuration/countries_spec.rb
+++ b/backend/spec/features/admin/configuration/countries_spec.rb
@@ -17,7 +17,7 @@ module Spree
       accept_confirm do
         click_icon :delete
       end
-      wait_for_ajax
+      expect(page).to have_content('has been successfully removed!')
 
       expect { Country.find(country.id) }.to raise_error(StandardError)
     end

--- a/backend/spec/features/admin/configuration/payment_methods_spec.rb
+++ b/backend/spec/features/admin/configuration/payment_methods_spec.rb
@@ -10,7 +10,7 @@ describe 'Payment Methods', type: :feature do
   context 'admin visiting payment methods listing page' do
     it 'displays existing payment methods' do
       create(:check_payment_method)
-      visit current_path
+      refresh
 
       within('table#listing_payment_methods') do
         expect(all('th')[1].text).to eq('Name')
@@ -40,7 +40,7 @@ describe 'Payment Methods', type: :feature do
   context 'admin editing a payment method', js: true do
     before do
       create(:check_payment_method)
-      visit current_path
+      refresh
 
       within('table#listing_payment_methods') do
         click_icon(:edit)
@@ -51,7 +51,7 @@ describe 'Payment Methods', type: :feature do
       fill_in 'payment_method_name', with: 'Payment 99'
       click_button 'Update'
       expect(page).to have_content('successfully updated!')
-      expect(find_field('payment_method_name').value).to eq('Payment 99')
+      expect(page).to have_field('payment_method_name', with: 'Payment 99')
     end
 
     it 'displays validation errors' do

--- a/backend/spec/features/admin/configuration/shipping_methods_spec.rb
+++ b/backend/spec/features/admin/configuration/shipping_methods_spec.rb
@@ -10,7 +10,7 @@ describe 'Shipping Methods', type: :feature do
   end
 
   before do
-    Capybara.ignore_hidden_elements = false
+    # Capybara.ignore_hidden_elements = false
     # HACK: To work around no email prompting on check out
     allow_any_instance_of(Spree::Order).to receive_messages(require_email: false)
     create(:check_payment_method)
@@ -51,9 +51,9 @@ describe 'Shipping Methods', type: :feature do
         click_icon :edit
       end
 
-      expect(find(:css, '.calculator-settings-warning')).not_to be_visible
+      expect(page).to have_css('.calculator-settings-warning', visible: :hidden)
       select2_search('Flexible Rate', from: 'Calculator')
-      expect(find(:css, '.calculator-settings-warning')).to be_visible
+      expect(page).to have_css('.calculator-settings-warning')
 
       click_button 'Update'
       expect(page).not_to have_content('Shipping method is not found')

--- a/backend/spec/features/admin/configuration/shipping_methods_spec.rb
+++ b/backend/spec/features/admin/configuration/shipping_methods_spec.rb
@@ -5,12 +5,7 @@ describe 'Shipping Methods', type: :feature do
   let!(:zone) { create(:global_zone) }
   let!(:shipping_method) { create(:shipping_method, zones: [zone]) }
 
-  after do
-    Capybara.ignore_hidden_elements = true
-  end
-
   before do
-    # Capybara.ignore_hidden_elements = false
     # HACK: To work around no email prompting on check out
     allow_any_instance_of(Spree::Order).to receive_messages(require_email: false)
     create(:check_payment_method)

--- a/backend/spec/features/admin/configuration/shipping_methods_spec.rb
+++ b/backend/spec/features/admin/configuration/shipping_methods_spec.rb
@@ -30,7 +30,7 @@ describe 'Shipping Methods', type: :feature do
 
       fill_in 'shipping_method_name', with: 'bullock cart'
 
-      within('#shipping_method_categories_field') do
+      within('#shipping_method_categories_field', match: :first) do
         check first("input[type='checkbox']")['name']
       end
 

--- a/backend/spec/features/admin/configuration/states_spec.rb
+++ b/backend/spec/features/admin/configuration/states_spec.rb
@@ -27,7 +27,7 @@ describe 'States', type: :feature do
   context 'creating and editing states' do
     it 'allows an admin to edit existing states', js: true do
       go_to_states_page
-      set_select2_field('country', country.id)
+      choose_country(country.name)
 
       click_link 'new_state_link'
       fill_in 'state_name', with: 'Calgary'
@@ -39,10 +39,7 @@ describe 'States', type: :feature do
 
     it 'allows an admin to create states for non default countries', js: true do
       go_to_states_page
-      set_select2_field '#country', @hungary.id
-      # Just so the change event actually gets triggered in this spec
-      # It is definitely triggered in the "real world"
-      page.execute_script("$('#country').change();")
+      choose_country(@hungary.name)
 
       click_link 'new_state_link'
       fill_in 'state_name', with: 'Pest megye'
@@ -55,7 +52,7 @@ describe 'States', type: :feature do
 
     it 'shows validation errors', js: true do
       go_to_states_page
-      set_select2_field('country', country.id)
+      choose_country(country.name)
 
       click_link 'new_state_link'
 
@@ -63,6 +60,11 @@ describe 'States', type: :feature do
       fill_in 'Abbreviation', with: ''
       click_button 'Create'
       expect(page).to have_content("Name can't be blank")
+    end
+
+    def choose_country(country)
+      find('#s2id_country').click
+      find('ul.select2-results li', text: country).click
     end
   end
 end

--- a/backend/spec/features/admin/configuration/states_spec.rb
+++ b/backend/spec/features/admin/configuration/states_spec.rb
@@ -50,7 +50,7 @@ describe 'States', type: :feature do
       click_button 'Create'
       expect(page).to have_content('successfully created!')
       expect(page).to have_content('Pest megye')
-      expect(find('#s2id_country span').text).to eq('Hungary')
+      expect(page).to have_css('#s2id_country span', exact_text: 'Hungary')
     end
 
     it 'shows validation errors', js: true do

--- a/backend/spec/features/admin/configuration/stock_locations_spec.rb
+++ b/backend/spec/features/admin/configuration/stock_locations_spec.rb
@@ -19,20 +19,19 @@ describe 'Stock Locations', type: :feature do
   end
 
   it 'can delete an existing stock location', js: true do
-    visit current_path
-    expect(find('#listing_stock_locations')).to have_content(stock_location.name)
-    handle_js_confirm do
+    refresh
+    expect(page).to have_css('#listing_stock_locations', text: stock_location.name)
+    accept_confirm do
       click_icon :delete
-      # Wait for API request to complete.
-      wait_for_ajax
     end
-    visit current_path
+    wait_for_ajax
+    refresh
     wait_for { !page.has_text?('No Stock Locations found') }
     expect(page).to have_content('No Stock Locations found')
   end
 
   it 'can update an existing stock location', js: true do
-    visit current_path
+    refresh
 
     expect(page).to have_content(stock_location.name)
 

--- a/backend/spec/features/admin/configuration/stock_locations_spec.rb
+++ b/backend/spec/features/admin/configuration/stock_locations_spec.rb
@@ -24,7 +24,7 @@ describe 'Stock Locations', type: :feature do
     accept_confirm do
       click_icon :delete
     end
-    wait_for_ajax
+    expect(page).not_to have_css('#listing_stock_locations tbody tr')
     refresh
     wait_for { !page.has_text?('No Stock Locations found') }
     expect(page).to have_content('No Stock Locations found')

--- a/backend/spec/features/admin/configuration/stores_spec.rb
+++ b/backend/spec/features/admin/configuration/stores_spec.rb
@@ -10,7 +10,7 @@ describe 'Stores admin', type: :feature do
       visit spree.admin_stores_path
 
       store_table = page.find('table')
-      expect(store_table.all('tr').count).to eq 1
+      expect(store_table).to have_css('tr').once
       expect(store_table).to have_content(store.name)
       expect(store_table).to have_content(store.url)
     end
@@ -29,7 +29,7 @@ describe 'Stores admin', type: :feature do
 
       expect(page).to have_current_path spree.admin_stores_path
       store_table = page.find('table')
-      expect(store_table.all('tr').count).to eq 2
+      expect(store_table).to have_css('tr').twice
       expect(Spree::Store.count).to eq 2
     end
   end

--- a/backend/spec/features/admin/configuration/stores_spec.rb
+++ b/backend/spec/features/admin/configuration/stores_spec.rb
@@ -57,9 +57,8 @@ describe 'Stores admin', type: :feature do
     it 'updates store in lifetime stats' do
       visit spree.admin_stores_path
 
-      handle_js_confirm do
-        page.all('.icon-delete')[1].click
-        wait_for_ajax
+      accept_confirm do
+        page.all('.icon-delete', minimum: 2)[1].click
       end
       wait_for_ajax
 

--- a/backend/spec/features/admin/configuration/stores_spec.rb
+++ b/backend/spec/features/admin/configuration/stores_spec.rb
@@ -60,7 +60,7 @@ describe 'Stores admin', type: :feature do
       accept_confirm do
         page.all('.icon-delete', minimum: 2)[1].click
       end
-      wait_for_ajax
+      expect(page).to have_content('has been successfully removed!')
 
       expect(Spree::Store.find_by_id(second_store.id)).to be_nil
     end

--- a/backend/spec/features/admin/homepage_spec.rb
+++ b/backend/spec/features/admin/homepage_spec.rb
@@ -18,27 +18,27 @@ describe 'Homepage', type: :feature do
       end
 
       it 'has a link to orders' do
-        page.find_link('Orders')['/admin/orders']
+        expect(page).to have_link('Orders', href: '/admin/orders')
       end
 
       it 'has a link to products' do
-        page.find_link('Products')['/admin/products']
+        expect(page).to have_link('Products', href: '/admin/products')
       end
 
       it 'has a link to reports' do
-        page.find_link('Reports')['/admin/reports']
+        expect(page).to have_link('Reports', href: '/admin/reports')
       end
 
       it 'has a link to configuration' do
-        page.find_link('Configuration')['/admin/configurations']
+        expect(page).to have_link('Configuration', href: '#sidebar-configuration')
       end
 
       it 'has a link to return authorizations' do
-        within('.sidebar') { page.find_link('Return Authorizations')['/admin/return_authorizations'] }
+        within('.sidebar') { expect(page).to have_link('Return Authorizations', href: '/admin/return_authorizations') }
       end
 
       it 'has a link to customer returns' do
-        within('.sidebar') { page.find_link('Customer Returns')['/admin/customer_returns'] }
+        within('.sidebar') { expect(page).to have_link('Customer Returns', href: '/admin/customer_returns') }
       end
 
       context 'version number' do
@@ -63,19 +63,19 @@ describe 'Homepage', type: :feature do
       end
 
       it 'has a link to products' do
-        within('.sidebar') { page.find_link('Products')['/admin/products'] }
+        within('.sidebar') { expect(page).to have_link('Products', href: '/admin/products') }
       end
 
       it 'has a link to option types' do
-        within('.sidebar') { page.find_link('Option Types')['/admin/option_types'] }
+        within('.sidebar') { expect(page).to have_link('Option Types', href: '/admin/option_types') }
       end
 
       it 'has a link to properties' do
-        within('.sidebar') { page.find_link('Properties')['/admin/properties'] }
+        within('.sidebar') { expect(page).to have_link('Properties', href: '/admin/properties') }
       end
 
       it 'has a link to prototypes' do
-        within('.sidebar') { page.find_link('Prototypes')['/admin/prototypes'] }
+        within('.sidebar') { expect(page).to have_link('Prototypes', href: '/admin/prototypes') }
       end
     end
   end

--- a/backend/spec/features/admin/orders/adjustments_spec.rb
+++ b/backend/spec/features/admin/orders/adjustments_spec.rb
@@ -106,10 +106,9 @@ describe 'Adjustments', type: :feature do
 
   context 'deleting an adjustment' do
     it 'updates the total', js: true do
-      handle_js_confirm do
+      accept_confirm do
         within_row(2) do
           click_icon(:delete)
-          wait_for_ajax
         end
       end
 

--- a/backend/spec/features/admin/orders/cancelling_and_resuming_spec.rb
+++ b/backend/spec/features/admin/orders/cancelling_and_resuming_spec.rb
@@ -17,11 +17,7 @@ describe 'Cancelling + Resuming', type: :feature do
   it 'can cancel an order' do
     visit spree.edit_admin_order_path(order.number)
     click_button 'Cancel'
-    within('.additional-info') do
-      within('.state') do
-        expect(page).to have_content('canceled')
-      end
-    end
+    expect(page).to have_css('.additional-info .state', text: 'canceled')
   end
 
   context 'with a cancelled order' do
@@ -32,11 +28,7 @@ describe 'Cancelling + Resuming', type: :feature do
     it 'can resume an order' do
       visit spree.edit_admin_order_path(order.number)
       click_button 'Resume'
-      within('.additional-info') do
-        within('.state') do
-          expect(page).to have_content('resumed')
-        end
-      end
+      expect(page).to have_css('.additional-info .state', text: 'resumed')
     end
   end
 end

--- a/backend/spec/features/admin/orders/customer_details_spec.rb
+++ b/backend/spec/features/admin/orders/customer_details_spec.rb
@@ -20,9 +20,8 @@ describe 'Customer Details', type: :feature, js: true do
   # Value attribute is dynamically set via JS, so not observable via a CSS/XPath selector
   # As the browser might take time to make the values visible in the dom we need to
   # "intelligiently" wait for that event o prevent a race.
-  def expect_form_value(id, value)
-    node = page.find(id)
-    wait_for_condition { node.value.eql?(value) }
+  def expect_form_value(selector, value)
+    expect(page).to have_css(selector){ |n| n.value.eql?(value) }
   end
 
   context 'brand new order' do
@@ -81,7 +80,7 @@ describe 'Customer Details', type: :feature, js: true do
         end
 
         click_button 'Update'
-        expect(find_field('order_bill_address_attributes_state_name').value).to eq('Piaui')
+        expect(page).to have_field('order_bill_address_attributes_state_name', with: 'Piaui')
       end
     end
 
@@ -99,7 +98,7 @@ describe 'Customer Details', type: :feature, js: true do
       # Regression test for #2950 + #2433
       # This act should transition the state of the order as far as it will go too
       within('#order_tab_summary') do
-        expect(find('.state').text).to eq('complete')
+        expect(page).to have_css('.state', text: 'complete')
       end
     end
 

--- a/backend/spec/features/admin/orders/customer_details_spec.rb
+++ b/backend/spec/features/admin/orders/customer_details_spec.rb
@@ -33,11 +33,13 @@ describe 'Customer Details', type: :feature, js: true do
 
     it 'associates a user when not using guest checkout' do
       select2_search product.name, from: Spree.t(:name_or_sku)
+
       within('table.stock-levels') do
         fill_in 'variant_quantity', with: 1
         click_icon :add
       end
-      wait_for_ajax
+      expect(page).to have_css('.card', text: 'Order Line Items')
+
       click_link 'Customer'
       targetted_select2 'foobar@example.com', from: '#s2id_customer_search'
       # 5317 - Address prefills using user's default.

--- a/backend/spec/features/admin/orders/line_items_spec.rb
+++ b/backend/spec/features/admin/orders/line_items_spec.rb
@@ -40,9 +40,8 @@ describe 'Order Line Items', type: :feature, js: true do
 
     within('.line-items') do
       within_row(1) do
-        handle_js_confirm do
+        accept_confirm do
           find('.delete-line-item').click
-          wait_for_ajax
         end
       end
     end

--- a/backend/spec/features/admin/orders/listing_spec.rb
+++ b/backend/spec/features/admin/orders/listing_spec.rb
@@ -87,7 +87,7 @@ describe 'Orders Listing', type: :feature do
       click_on 'Filter Results'
 
       # Insure checkbox still checked
-      expect(find('#q_considered_risky_eq')).to be_checked
+      expect(page).to have_checked_field(id: 'q_considered_risky_eq')
       # Insure we have the risky order, R100
       within_row(1) do
         expect(page).to have_content('R100')
@@ -129,7 +129,7 @@ describe 'Orders Listing', type: :feature do
           click_link '2'
         end
         expect(page).to have_content('incomplete@example.com')
-        expect(find('#q_completed_at_not_null')).not_to be_checked
+        expect(page).to have_unchecked_field(id: 'q_completed_at_not_null')
       end
     end
 
@@ -195,13 +195,12 @@ describe 'Orders Listing', type: :feature do
     context 'per page dropdown', js: true do
       before do
         select '45', from: 'per_page'
-        wait_for_ajax
         expect(page).to have_select('per_page', selected: '45')
         expect(page).to have_selector(:css, 'select.per-page-selected-45')
       end
 
       it 'adds per_page parameter to url' do
-        expect(current_url).to match(/per_page\=45/)
+        expect(page).to have_current_path(/per_page\=45/)
       end
 
       it 'can be used with search filtering' do
@@ -210,15 +209,14 @@ describe 'Orders Listing', type: :feature do
         click_on 'Filter Results'
         expect(page).not_to have_content('R100')
         within_row(1) { expect(page).to have_content('R200') }
-        expect(current_url).to match(/per_page\=45/)
+        expect(page).to have_current_path(/per_page\=45/)
         expect(page).to have_select('per_page', selected: '45')
         select '60', from: 'per_page'
-        wait_for_ajax
+        expect(page).to have_current_path(/per_page\=60/)
         expect(page).to have_select('per_page', selected: '60')
         expect(page).to have_selector(:css, 'select.per-page-selected-60')
         expect(page).not_to have_content('R100')
         within_row(1) { expect(page).to have_content('R200') }
-        expect(current_url).to match(/per_page\=60/)
       end
     end
 

--- a/backend/spec/features/admin/orders/listing_spec.rb
+++ b/backend/spec/features/admin/orders/listing_spec.rb
@@ -125,7 +125,7 @@ describe 'Orders Listing', type: :feature do
         click_on 'Filter'
         uncheck 'q_completed_at_not_null'
         click_on 'Filter Results'
-        within('.pagination') do
+        within('.pagination', match: :first) do
           click_link '2'
         end
         expect(page).to have_content('incomplete@example.com')
@@ -194,7 +194,9 @@ describe 'Orders Listing', type: :feature do
     # regression tests for https://github.com/spree/spree/issues/6888
     context 'per page dropdown', js: true do
       before do
-        select '45', from: 'per_page'
+        within('div.index-pagination-row', match: :first) do
+          select '45', from: 'per_page'
+        end
         expect(page).to have_select('per_page', selected: '45')
         expect(page).to have_selector(:css, 'select.per-page-selected-45')
       end
@@ -211,7 +213,9 @@ describe 'Orders Listing', type: :feature do
         within_row(1) { expect(page).to have_content('R200') }
         expect(page).to have_current_path(/per_page\=45/)
         expect(page).to have_select('per_page', selected: '45')
-        select '60', from: 'per_page'
+        within('div.index-pagination-row', match: :first) do
+          select '60', from: 'per_page'
+        end
         expect(page).to have_current_path(/per_page\=60/)
         expect(page).to have_select('per_page', selected: '60')
         expect(page).to have_selector(:css, 'select.per-page-selected-60')
@@ -244,7 +248,7 @@ describe 'Orders Listing', type: :feature do
           fill_in 'q_email_cont', with: 'john_smith@example.com'
           fill_in 'q_line_items_variant_sku_eq', with: 'BAG-00001'
           select 'Promo', from: 'q_promotions_id_in'
-          select 'Spree Test Store', from: 'q_store_id_in'
+          select 'Spree Test Store', match: :first, from: 'q_store_id_in'
           select 'spree', from: 'q_channel_eq'
         end
 

--- a/backend/spec/features/admin/orders/log_entries_spec.rb
+++ b/backend/spec/features/admin/orders/log_entries_spec.rb
@@ -21,7 +21,7 @@ describe 'Log entries', type: :feature do
 
     it 'shows a successful attempt' do
       visit spree.admin_order_payments_path(payment.order)
-      find("#payment_#{payment.id} a").click
+      find("#payment_#{payment.id} a", text: payment.number).click
       click_link 'Logs'
       within('#listing_log_entries') do
         expect(page).to have_content('Transaction successful')
@@ -45,7 +45,7 @@ describe 'Log entries', type: :feature do
 
     it 'shows a failed attempt' do
       visit spree.admin_order_payments_path(payment.order)
-      find("#payment_#{payment.id} a").click
+      find("#payment_#{payment.id} a", text: payment.number).click
       click_link 'Logs'
       within('#listing_log_entries') do
         expect(page).to have_content('Transaction failed')

--- a/backend/spec/features/admin/orders/new_order_spec.rb
+++ b/backend/spec/features/admin/orders/new_order_spec.rb
@@ -141,9 +141,7 @@ describe 'New Order', type: :feature do
       click_on 'Payments'
       click_on 'Continue'
 
-      within('.additional-info .state') do
-        expect(page).to have_content('complete')
-      end
+      expect(page).to have_css('.additional-info .state', text: 'complete')
     end
   end
 

--- a/backend/spec/features/admin/orders/new_order_spec.rb
+++ b/backend/spec/features/admin/orders/new_order_spec.rb
@@ -24,8 +24,10 @@ describe 'New Order', type: :feature do
 
   it 'completes new order successfully without using the cart', js: true do
     select2_search product.name, from: Spree.t(:name_or_sku)
+
     click_icon :add
-    wait_for_ajax
+    expect(page).to have_css('.card', text: 'Order Line Items')
+
     click_on 'Customer'
     select_customer
 
@@ -134,7 +136,7 @@ describe 'New Order', type: :feature do
       click_on 'Shipments'
       select2_search product.name, from: Spree.t(:name_or_sku)
       click_icon :add
-      wait_for_ajax
+      expect(page).not_to have_content('Your order is empty')
 
       click_on 'Payments'
       click_on 'Continue'
@@ -154,11 +156,13 @@ describe 'New Order', type: :feature do
 
     it 'transitions to delivery not to complete' do
       select2_search product.name, from: Spree.t(:name_or_sku)
+
       within('table.stock-levels') do
         fill_in 'variant_quantity', with: 1
         click_icon :add
       end
-      wait_for_ajax
+      expect(page).not_to have_content('Your order is empty')
+
       click_link 'Customer'
       select_customer
       wait_for { !page.has_button?('Update') }

--- a/backend/spec/features/admin/orders/new_order_spec.rb
+++ b/backend/spec/features/admin/orders/new_order_spec.rb
@@ -41,7 +41,6 @@ describe 'New Order', type: :feature do
 
     click_on 'Shipments'
     click_on 'Ship'
-    wait_for_ajax
 
     expect(page).to have_content('shipped')
   end

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -74,9 +74,8 @@ describe 'Order Details', type: :feature, js: true do
         expect(page).to have_content('spree t-shirt')
 
         within_row(1) do
-          handle_js_confirm do
+          accept_confirm do
             click_icon :delete
-            wait_for_ajax
           end
         end
 
@@ -90,7 +89,7 @@ describe 'Order Details', type: :feature, js: true do
 
         within_row(1) do
           # Click "cancel" on confirmation dialog
-          dismiss_alert do
+          dismiss_confirm do
             click_icon :delete
           end
         end
@@ -361,10 +360,8 @@ describe 'Order Details', type: :feature, js: true do
               targetted_select2 stock_location2.name, from: '#s2id_item_stock_location'
               fill_in 'item_quantity', with: 2
 
-              spree_accept_alert do
-                click_icon :save
-                wait_for_ajax
-              end
+              click_icon :save
+              wait_for_ajax
 
               expect(order.shipments.count).to eq(1)
               expect(order.shipments.first.inventory_units_for(product.master).sum(&:quantity)).to eq(2)
@@ -511,19 +508,15 @@ describe 'Order Details', type: :feature, js: true do
             targetted_select2 @shipment2.number, from: '#s2id_item_stock_location'
             fill_in 'item_quantity', with: 1
 
-            spree_accept_alert do
-              click_icon :save
-              wait_for_ajax
-            end
+            click_icon :save
+            wait_for_ajax
 
             within_row(1) { click_icon 'split' }
             targetted_select2 @shipment2.number, from: '#s2id_item_stock_location'
             fill_in 'item_quantity', with: 200
 
-            spree_accept_alert do
-              click_icon :save
-              wait_for_ajax
-            end
+            click_icon :save
+            wait_for_ajax
 
             expect(order.shipments.count).to eq(2)
             expect(order.shipments.first.inventory_units_for(product.master).sum(&:quantity)).to eq(1)
@@ -697,10 +690,7 @@ describe 'Order Details', type: :feature, js: true do
       order.refresh_shipment_rates
       visit spree.edit_admin_order_path(order)
       click_on 'Ship'
-      wait_for_ajax
-      within '.shipment-state' do
-        expect(page).to have_content('shipped')
-      end
+      expect(page).to have_css('.shipment-state', text: 'shipped')
     end
   end
 end

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -235,10 +235,13 @@ describe 'Order Details', type: :feature, js: true do
 
       context 'splitting to location' do
         before { visit spree.edit_admin_order_path(order) }
-        # can not properly implement until poltergeist supports checking alert text
-        # see https://github.com/teampoltergeist/poltergeist/pull/516
 
-        it 'should warn you if you have not selected a location or shipment'
+        it 'should warn you if you have not selected a location or shipment' do
+          within_row(1) { click_icon :split }
+          accept_alert "Please select the split destination" do
+            click_icon :save
+          end
+        end
 
         context 'there is enough stock at the other location' do
           it 'allows me to make a split' do
@@ -419,8 +422,8 @@ describe 'Order Details', type: :feature, js: true do
 
             it 'adds variant to order just fine' do
               select2_search tote.name, from: Spree.t(:name_or_sku)
-              within('table.stock-levels') do
-                fill_in 'stock_item_quantity', with: 1
+              within('table.stock-levels tbody tr', match: :first) do
+                fill_in 'stock_item_quantity', match: :first, with: 1
                 click_icon :add
               end
 
@@ -445,7 +448,7 @@ describe 'Order Details', type: :feature, js: true do
             it 'adds variant to order just fine' do
               select2_search tote.name, from: Spree.t(:name_or_sku)
               within('table.stock-levels') do
-                fill_in 'stock_item_quantity', with: 1
+                fill_in 'stock_item_quantity', match: :first, with: 1
                 click_icon :add
               end
 
@@ -659,7 +662,7 @@ describe 'Order Details', type: :feature, js: true do
 
     it 'can add tracking information' do
       visit spree.edit_admin_order_path(order)
-      within('table.table tr:nth-child(5)') do
+      within('table.stock-contents tr:nth-child(5)', match: :first) do
         click_icon :edit
       end
       fill_in 'tracking', with: 'FOOBAR'

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -123,10 +123,7 @@ describe 'Payments', type: :feature, js: true do
           within_row(1) do
             click_icon(:edit)
 
-            # Can't use fill_in here, as under poltergeist that will unfocus (and
-            # thus submit) the field under poltergeist
-            find('td.amount input').click
-            page.execute_script("$('td.amount input').val('$1')")
+            find('td.amount input').send_keys([:backspace] * 6, '$1')
 
             click_icon(:cancel)
             expect(page).to have_selector('td.amount span', text: '$150.00')

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -20,10 +20,6 @@ describe 'Payments', type: :feature, js: true do
       click_link 'Payments'
     end
 
-    def refresh_page
-      visit current_path
-    end
-
     # Regression tests for #1453
     context 'with a check payment' do
       let(:order) { create(:completed_order_with_totals, number: 'R100') }
@@ -69,7 +65,7 @@ describe 'Payments', type: :feature, js: true do
       end
 
       click_icon :void
-      expect(find('#payment_status').text).to eq('balance due')
+      expect(page).to have_css('#payment_status', exact_text: 'balance due')
       expect(page).to have_content('Payment Updated')
 
       within_row(1) do
@@ -84,9 +80,8 @@ describe 'Payments', type: :feature, js: true do
       expect(page).to have_content('successfully created!')
 
       click_icon(:capture)
-      wait_for_ajax
-      expect(find('#payment_status').text).to eq('paid')
 
+      expect(page).to have_css('#payment_status', exact_text: 'paid')
       expect(page).not_to have_selector('#new_payment_section')
     end
 
@@ -204,7 +199,7 @@ describe 'Payments', type: :feature, js: true do
       before { visit spree.admin_order_payments_path(order) }
 
       it 'is able to reuse customer payment source', js: false do
-        expect(find("#card_#{cc.id}")).to be_checked
+        expect(page).to have_checked_field(id: "card_#{cc.id}")
         click_button 'Continue'
         expect(page).to have_content('Payment has been successfully created!')
       end

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -139,10 +139,11 @@ describe 'Payments', type: :feature, js: true do
             click_icon(:edit)
             fill_in('amount', with: 'invalid')
             click_icon(:save)
-            expect(find('td.amount input').value).to eq('invalid')
-            expect(payment.reload.amount).to eq(150.00)
           end
+
           expect(page).to have_selector('.alert-error', text: 'Invalid resource. Please fix errors and try again.')
+          expect(page).to have_field('amount', with: 'invalid')
+          expect(payment.reload.amount).to eq(150.00)
         end
       end
     end
@@ -174,8 +175,7 @@ describe 'Payments', type: :feature, js: true do
         fill_in 'Expiration', with: "09 / #{Time.current.year + 1}"
         fill_in 'Card Code', with: '007'
         # Regression test for #4277
-        sleep(1)
-        expect(find('.ccType', visible: false).value).to eq('visa')
+        expect(page).to have_field(class: 'ccType', type: :hidden, with: 'visa')
         click_button 'Continue'
         expect(page).to have_content('Payment has been successfully created!')
       end

--- a/backend/spec/features/admin/orders/shipments_spec.rb
+++ b/backend/spec/features/admin/orders/shipments_spec.rb
@@ -48,18 +48,17 @@ describe 'Shipments', type: :feature do
       expect(order.shipments.count).to eq(1)
 
       within_row(1) { click_icon :split }
-      wait_for_ajax
       targetted_select2 'LA', from: '#s2id_item_stock_location'
-
       click_icon :'save-split'
-      wait_for_ajax
 
+      expect(page).to have_css('#order-form-wrapper div', id: /^shipment_\d$/).exactly(2).times
       expect(page).to have_css("#shipment_#{order.shipments.first.id}")
 
       within_row(2) { click_icon :split }
       targetted_select2 "LA(#{order.reload.shipments.last.number})", from: '#s2id_item_stock_location'
       click_icon :save
       wait_for_ajax
+
       expect(page).to have_css("#shipment_#{order.reload.shipments.last.id}")
     end
   end

--- a/backend/spec/features/admin/orders/shipments_spec.rb
+++ b/backend/spec/features/admin/orders/shipments_spec.rb
@@ -29,9 +29,8 @@ describe 'Shipments', type: :feature do
 
     it 'can ship a completed order' do
       click_on 'Ship'
-      wait_for_ajax
 
-      expect(page).to have_content('shipped package')
+      expect(page).to have_content("shipped\npackage")
       expect(order.reload.shipment_state).to eq('shipped')
     end
   end
@@ -51,19 +50,17 @@ describe 'Shipments', type: :feature do
       within_row(1) { click_icon :split }
       wait_for_ajax
       targetted_select2 'LA', from: '#s2id_item_stock_location'
-      
-      handle_js_confirm do
-        click_icon :'save-split'
-        wait_for_ajax
-      end
 
-      expect(page.find("#shipment_#{order.shipments.first.id}")).to be_present
+      click_icon :'save-split'
+      wait_for_ajax
+
+      expect(page).to have_css("#shipment_#{order.shipments.first.id}")
 
       within_row(2) { click_icon :split }
       targetted_select2 "LA(#{order.reload.shipments.last.number})", from: '#s2id_item_stock_location'
       click_icon :save
       wait_for_ajax
-      expect(page.find("#shipment_#{order.reload.shipments.last.id}")).to be_present
+      expect(page).to have_css("#shipment_#{order.reload.shipments.last.id}")
     end
   end
 end

--- a/backend/spec/features/admin/products/edit/images_spec.rb
+++ b/backend/spec/features/admin/products/edit/images_spec.rb
@@ -34,7 +34,8 @@ describe 'Product Images', type: :feature, js: true do
       accept_confirm do
         click_icon :delete
       end
-      wait_for_ajax
+
+      expect(page).to have_content('successfully removed!')
       expect(page).not_to have_content('ruby on rails t-shirt')
     end
   end

--- a/backend/spec/features/admin/products/edit/images_spec.rb
+++ b/backend/spec/features/admin/products/edit/images_spec.rb
@@ -31,10 +31,10 @@ describe 'Product Images', type: :feature, js: true do
       expect(page).to have_content('successfully updated!')
       expect(page).to have_content('ruby on rails t-shirt')
 
-      handle_js_confirm do
+      accept_confirm do
         click_icon :delete
-        wait_for_ajax
       end
+      wait_for_ajax
       expect(page).not_to have_content('ruby on rails t-shirt')
     end
   end
@@ -54,7 +54,7 @@ describe 'Product Images', type: :feature, js: true do
 
       # ensure variant header is displayed
       within('thead') do
-        expect(page.body).to have_content('Variant')
+        expect(page).to have_content('Variant')
       end
 
       # ensure variant header is displayed

--- a/backend/spec/features/admin/products/edit/products_spec.rb
+++ b/backend/spec/features/admin/products/edit/products_spec.rb
@@ -16,13 +16,13 @@ describe 'Product Details', type: :feature, js: true do
       click_link 'Details'
 
       expect(find('.content-header h1').text.strip).to eq('Products / Bún thịt nướng')
-      expect(find('input#product_name').value).to eq('Bún thịt nướng')
-      expect(find('input#product_slug').value).to eq('bun-th-t-n-ng')
+      expect(page).to have_field(id: 'product_name', with: 'Bún thịt nướng')
+      expect(page).to have_field(id: 'product_slug', with: 'bun-th-t-n-ng')
       expect(find('textarea#product_description').text.strip).to eq('lorem ipsum')
-      expect(find('input#product_price').value).to eq('19.99')
-      expect(find('input#product_cost_price').value).to eq('17.00')
-      expect(find('input#product_available_on').value).to eq('2013/08/14')
-      expect(find('input#product_sku').value).to eq('A100')
+      expect(page).to have_field(id: 'product_price', with: '19.99')
+      expect(page).to have_field(id: 'product_cost_price', with: '17.00')
+      expect(page).to have_field(id: 'product_available_on', with: '2013/08/14')
+      expect(page).to have_field(id: 'product_sku', with: 'A100')
     end
 
     it 'handles slug changes' do
@@ -37,7 +37,7 @@ describe 'Product Details', type: :feature, js: true do
       wait_for { !page.has_button?('Update') }
       click_button 'Update'
       expect(page).to have_content('successfully updated!')
-      expect(find('#s2id_product_tag_list')).to have_content('example-tag')
+      expect(page).to have_css('#s2id_product_tag_list', text: 'example-tag')
     end
 
     it 'has a link to preview a product' do

--- a/backend/spec/features/admin/products/edit/products_spec.rb
+++ b/backend/spec/features/admin/products/edit/products_spec.rb
@@ -15,10 +15,10 @@ describe 'Product Details', type: :feature, js: true do
     it 'lists the product details' do
       click_link 'Details'
 
-      expect(find('.content-header h1').text.strip).to eq('Products / Bún thịt nướng')
+      expect(page).to have_css('.content-header h1', text: 'Products / Bún thịt nướng')
       expect(page).to have_field(id: 'product_name', with: 'Bún thịt nướng')
       expect(page).to have_field(id: 'product_slug', with: 'bun-th-t-n-ng')
-      expect(find('textarea#product_description').text.strip).to eq('lorem ipsum')
+      expect(page).to have_field(id: 'product_description', with: 'lorem ipsum')
       expect(page).to have_field(id: 'product_price', with: '19.99')
       expect(page).to have_field(id: 'product_cost_price', with: '17.00')
       expect(page).to have_field(id: 'product_available_on', with: '2013/08/14')

--- a/backend/spec/features/admin/products/edit/taxons_spec.rb
+++ b/backend/spec/features/admin/products/edit/taxons_spec.rb
@@ -25,10 +25,8 @@ describe 'Product Taxons', type: :feature, js: true do
       click_button 'Update'
       expect(selected_taxons).to match_array([taxon_1.id, taxon_2.id])
 
-      # Regression test for #2139
-      sleep(1)
       expect(page).to have_css('.select2-search-choice', text: taxon_1.name)
-      expect(page).to have_css('.select2-search-choice', text: taxon_2.name)
+                  .and have_css('.select2-search-choice', text: taxon_2.name)
     end
   end
 end

--- a/backend/spec/features/admin/products/edit/taxons_spec.rb
+++ b/backend/spec/features/admin/products/edit/taxons_spec.rb
@@ -8,12 +8,12 @@ describe 'Product Taxons', type: :feature, js: true do
   end
 
   before do
-    Capybara.ignore_hidden_elements = false
+    # Capybara.ignore_hidden_elements = false
   end
 
   context 'managing taxons' do
     def selected_taxons
-      find('#product_taxon_ids').value.split(',').map(&:to_i).uniq
+      find('#product_taxon_ids', visible: :hidden).value.split(',').map(&:to_i).uniq
     end
 
     it 'allows an admin to manage taxons' do
@@ -25,7 +25,7 @@ describe 'Product Taxons', type: :feature, js: true do
       visit spree.admin_products_path
       within_row(1) { click_icon :edit }
 
-      expect(find('.select2-search-choice').text).to eq("#{taxon_1.parent.name} -> #{taxon_1.name}")
+      expect(page).to have_css('.select2-search-choice', exact_text: "#{taxon_1.parent.name} -> #{taxon_1.name}")
       expect(selected_taxons).to match_array([taxon_1.id])
 
       select2_search 'Clothing', from: 'Taxons'
@@ -35,8 +35,8 @@ describe 'Product Taxons', type: :feature, js: true do
 
       # Regression test for #2139
       sleep(1)
-      expect(first('.select2-search-choice', text: taxon_1.name)).to be_present
-      expect(first('.select2-search-choice', text: taxon_2.name)).to be_present
+      expect(page).to have_css('.select2-search-choice', text: taxon_1.name)
+      expect(page).to have_css('.select2-search-choice', text: taxon_2.name)
     end
   end
 end

--- a/backend/spec/features/admin/products/edit/taxons_spec.rb
+++ b/backend/spec/features/admin/products/edit/taxons_spec.rb
@@ -3,14 +3,6 @@ require 'spec_helper'
 describe 'Product Taxons', type: :feature, js: true do
   stub_authorization!
 
-  after do
-    Capybara.ignore_hidden_elements = true
-  end
-
-  before do
-    # Capybara.ignore_hidden_elements = false
-  end
-
   context 'managing taxons' do
     def selected_taxons
       find('#product_taxon_ids', visible: :hidden).value.split(',').map(&:to_i).uniq

--- a/backend/spec/features/admin/products/option_types_spec.rb
+++ b/backend/spec/features/admin/products/option_types_spec.rb
@@ -59,7 +59,6 @@ describe 'Option Types', type: :feature, js: true do
     click_link 'Option Types'
     within('table#listing_option_types') { click_icon :edit }
 
-    wait_for_ajax
     expect(page).to have_css('tbody#option_values tr', count: 1)
 
     # Add a new option type

--- a/backend/spec/features/admin/products/option_types_spec.rb
+++ b/backend/spec/features/admin/products/option_types_spec.rb
@@ -60,30 +60,28 @@ describe 'Option Types', type: :feature, js: true do
     within('table#listing_option_types') { click_icon :edit }
 
     wait_for_ajax
-    page.find('tbody#option_values', visible: true)
-
-    expect(all('tbody#option_values tr').select(&:visible?).count).to eq(1)
+    expect(page).to have_css('tbody#option_values tr', count: 1)
 
     # Add a new option type
     click_link 'Add Option Value'
-    expect(all('tbody#option_values tr').select(&:visible?).count).to eq(2)
+    expect(page).to have_css('tbody#option_values tr', count: 2)
 
     # Remove default option type
     within('tbody#option_values') do
       click_icon :delete
     end
     # Check that there was no HTTP request
-    expect(all('div#progress[style]').count).to eq(0)
+    expect(page).not_to have_css('div#progress[style]')
     # Assert that the field is hidden automatically
-    expect(all('tbody#option_values tr').select(&:visible?).count).to eq(1)
+    expect(page).to have_css('tbody#option_values tr', count: 1)
 
     # Remove added option type
     within('tbody#option_values') do
       click_icon :delete
     end
     # Check that there was no HTTP request
-    expect(all('div#progress[style]').count).to eq(0)
+    expect(page).not_to have_css('div#progress[style]')
     # Assert that the field is hidden automatically
-    expect(all('tbody#option_values tr').select(&:visible?).count).to eq(0)
+    expect(page).not_to have_css('tbody#option_values tr')
   end
 end

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -179,11 +179,12 @@ describe 'Products', type: :feature do
           check 'Large'
           click_button 'Create'
 
-          message = page.find('#product_shipping_category_id').native.attribute('validationMessage')
-          expect(message).to eq('Please select an item in the list.')
-          expect(field_labeled('Size')).to be_checked
-          expect(field_labeled('Large')).to be_checked
-          expect(field_labeled('Small')).not_to be_checked
+          expect(page).to have_css('#product_shipping_category_id') do |el|
+            el['validationMessage'] == 'Please select an item in the list.'
+          end
+          expect(page).to have_checked_field('Size')
+          expect(page).to have_checked_field('Large')
+          expect(page).to have_unchecked_field('Small')
         end
       end
 
@@ -198,9 +199,9 @@ describe 'Products', type: :feature do
           check 'Large'
           click_button 'Create'
           expect(page).to have_content("Shipping Category can't be blank")
-          expect(field_labeled('Size')).to be_checked
-          expect(field_labeled('Large')).to be_checked
-          expect(field_labeled('Small')).not_to be_checked
+          expect(page).to have_checked_field('Size')
+          expect(page).to have_checked_field('Large')
+          expect(page).to have_unchecked_field('Small')
         end
       end
     end
@@ -265,7 +266,7 @@ describe 'Products', type: :feature do
         it 'shows localized price value on validation errors', js: true do
           fill_in 'product_price', with: '19,99'
           click_button 'Create'
-          expect(find('input#product_price').value).to eq('19,99')
+          expect(page).to have_field(id: 'product_price', with: '19,99')
         end
       end
 
@@ -396,7 +397,7 @@ describe 'Products', type: :feature do
           click_button 'Update'
           weight_prev = find('#product_weight').value
           click_button 'Update'
-          expect(find('#product_weight').value).to eq(weight_prev)
+          expect(page).to have_field(id: 'product_weight', with: weight_prev)
         end
       end
     end
@@ -406,16 +407,19 @@ describe 'Products', type: :feature do
 
       it 'is still viewable' do
         visit spree.admin_products_path
-        handle_js_confirm do
+        accept_confirm do
           click_icon :delete
-          wait_for_ajax
         end
+        wait_for_ajax
+
         click_on 'Filter'
         # This will show our deleted product
         check 'Show Deleted'
         click_on 'Search'
         click_link product.name
-        expect(find('#product_price').value.to_f).to eq(product.price.to_f)
+        expect(page).to have_field(id: 'product_price') do |field|
+          field.value.to_f == product.price.to_f
+        end
       end
     end
 

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -348,7 +348,7 @@ describe 'Products', type: :feature do
         end
 
         within(:css, 'tr.product_property:first-child') do
-          expect(first('input[type=text]').value).to eq('baseball_cap_color')
+          expect(page).to have_field(id: /property_name$/, with: 'baseball_cap_color')
         end
       end
 

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -150,10 +150,8 @@ describe 'Products', type: :feature do
         fill_in 'product_sku', with: 'B100'
         fill_in 'product_price', with: '100'
         fill_in 'product_available_on', with: '2012/01/24'
-        # Just so the datepicker gets out of poltergeists way.
-        page.execute_script("$('#ui-datepicker-div').hide();")
+        find('#product_available_on').send_keys(:tab)
         select 'Size', from: 'Prototype'
-        wait_for_ajax
         check 'Large'
         select @shipping_category.name, from: 'product_shipping_category_id'
         click_button 'Create'
@@ -175,7 +173,6 @@ describe 'Products', type: :feature do
           fill_in 'product_sku', with: 'B100'
           fill_in 'product_price', with: '100'
           select 'Size', from: 'Prototype'
-          wait_for_ajax
           check 'Large'
           click_button 'Create'
 
@@ -195,7 +192,6 @@ describe 'Products', type: :feature do
           fill_in 'product_sku', with: 'B100'
           fill_in 'product_price', with: '100'
           select 'Size', from: 'Prototype'
-          wait_for_ajax
           check 'Large'
           click_button 'Create'
           expect(page).to have_content("Shipping Category can't be blank")
@@ -344,7 +340,6 @@ describe 'Products', type: :feature do
 
         within("#prototypes tr#row_#{prototype.id}") do
           click_link 'Select'
-          wait_for_ajax
         end
 
         within(:css, 'tr.product_property:first-child') do
@@ -410,7 +405,7 @@ describe 'Products', type: :feature do
         accept_confirm do
           click_icon :delete
         end
-        wait_for_ajax
+        expect(page).to have_content('Product has been deleted')
 
         click_on 'Filter'
         # This will show our deleted product

--- a/backend/spec/features/admin/products/properties_spec.rb
+++ b/backend/spec/features/admin/products/properties_spec.rb
@@ -145,7 +145,8 @@ describe 'Properties', type: :feature, js: true do
       accept_confirm do
         click_icon :delete
       end
-      wait_for_ajax
+      expect(page.document).to have_content('successfully removed!')
+                           .or have_content('Cannot delete record')
     end
 
     def check_property_row_count(expected_row_count)

--- a/backend/spec/features/admin/products/properties_spec.rb
+++ b/backend/spec/features/admin/products/properties_spec.rb
@@ -143,18 +143,17 @@ describe 'Properties', type: :feature, js: true do
     end
 
     def delete_product_property
-      handle_js_confirm do
+      accept_confirm do
         click_icon :delete
-        wait_for_ajax
       end
+      wait_for_ajax
     end
 
     def check_property_row_count(expected_row_count)
       within('#sidebar') do
         click_link 'Properties'
       end
-      expect(page).to have_css('tbody#product_properties')
-      expect(all('tbody#product_properties tr').count).to eq(expected_row_count)
+      expect(page).to have_css('tbody#product_properties tr', count: expected_row_count)
     end
   end
 end

--- a/backend/spec/features/admin/products/properties_spec.rb
+++ b/backend/spec/features/admin/products/properties_spec.rb
@@ -103,10 +103,9 @@ describe 'Properties', type: :feature, js: true do
     # Regression test for #2279
     it 'successfully create and then remove product property' do
       fill_in_property
-      # Sometimes the page doesn't load before the all check is done
-      # lazily finding the element gives the page 10 seconds
+
       expect(page).to have_css('tbody#product_properties tr:nth-child(2)')
-      expect(all('tbody#product_properties tr').count).to eq(2)
+      expect(page).to have_css('tbody#product_properties tr').twice
 
       delete_product_property
 

--- a/backend/spec/features/admin/products/prototypes_spec.rb
+++ b/backend/spec/features/admin/products/prototypes_spec.rb
@@ -89,7 +89,9 @@ describe 'Prototypes', type: :feature, js: true do
 
       click_icon :edit
 
-      expect(find_field('prototype_property_ids').value).to be_empty
+      expect(page).to have_field('prototype_property_ids') do |field|
+        field.empty?
+      end
     end
   end
 
@@ -101,13 +103,11 @@ describe 'Prototypes', type: :feature, js: true do
     click_link 'Products'
     click_link 'Prototypes'
 
-    handle_js_confirm do
+    accept_confirm do
       within("#spree_prototype_#{shirt_prototype.id}") do
         page.find('.delete-resource').click
       end
-      wait_for_ajax
-
-      expect(page).to have_content("Prototype \"#{shirt_prototype.name}\" has been successfully removed!")
     end
+    expect(page).to have_content("Prototype \"#{shirt_prototype.name}\" has been successfully removed!")
   end
 end

--- a/backend/spec/features/admin/products/stock_management_spec.rb
+++ b/backend/spec/features/admin/products/stock_management_spec.rb
@@ -14,11 +14,11 @@ describe 'Stock Management', type: :feature, js: true do
     end
 
     context "toggle backorderable for a variant's stock item" do
-      let(:backorderable) { find '.stock_item_backorderable' }
+      let(:backorderable) { find_field(class: 'stock_item_backorderable') }
 
       before do
         expect(backorderable).to be_checked
-        backorderable.set(false)
+        backorderable.uncheck
         wait_for_ajax
       end
 
@@ -29,11 +29,11 @@ describe 'Stock Management', type: :feature, js: true do
     end
 
     context "toggle track inventory for a variant's stock item" do
-      let(:track_inventory) { find '.track_inventory_checkbox' }
+      let(:track_inventory) { find_field(class: 'track_inventory_checkbox') }
 
       before do
         expect(track_inventory).to be_checked
-        track_inventory.set(false)
+        track_inventory.uncheck
         wait_for_ajax
       end
 
@@ -51,8 +51,8 @@ describe 'Stock Management', type: :feature, js: true do
       new_location = create(:stock_location, name: 'Another Location')
       refresh
 
-      new_location_backorderable = find "#stock_item_backorderable_#{new_location.id}"
-      new_location_backorderable.set(false)
+      new_location_backorderable = find_field(id: "stock_item_backorderable_#{new_location.id}", checked: true)
+      new_location_backorderable.uncheck
       wait_for_ajax
 
       expect(page).to have_current_path(%r{/admin/products})

--- a/backend/spec/features/admin/products/stock_management_spec.rb
+++ b/backend/spec/features/admin/products/stock_management_spec.rb
@@ -23,7 +23,7 @@ describe 'Stock Management', type: :feature, js: true do
       end
 
       it 'persists the value when page reload' do
-        visit current_path
+        refresh
         expect(backorderable).not_to be_checked
       end
     end
@@ -38,7 +38,7 @@ describe 'Stock Management', type: :feature, js: true do
       end
 
       it 'persists the value when page reloaded' do
-        visit current_path
+        refresh
         expect(track_inventory).not_to be_checked
       end
     end
@@ -49,13 +49,13 @@ describe 'Stock Management', type: :feature, js: true do
     # assert that the redirect is *not* happening.
     it 'can toggle backorderable for the second variant stock item' do
       new_location = create(:stock_location, name: 'Another Location')
-      visit current_url
+      refresh
 
       new_location_backorderable = find "#stock_item_backorderable_#{new_location.id}"
       new_location_backorderable.set(false)
       wait_for_ajax
 
-      expect(page.current_url).to include('/admin/products')
+      expect(page).to have_current_path(%r{/admin/products})
     end
 
     it 'can create a new stock movement' do
@@ -87,7 +87,7 @@ describe 'Stock Management', type: :feature, js: true do
 
       before do
         variant.stock_items.first.update_column(:count_on_hand, 30)
-        visit current_url
+        refresh
       end
 
       it 'can create a new stock movement for the specified variant' do
@@ -118,7 +118,7 @@ describe 'Stock Management', type: :feature, js: true do
 
       it 'redirects to stock locations page', js: false do
         expect(page).to have_content(Spree.t(:stock_management_requires_a_stock_location))
-        expect(page.current_url).to include('admin/stock_locations')
+        expect(page).to have_current_path(%r{admin/stock_locations})
       end
     end
   end

--- a/backend/spec/features/admin/products/variant_spec.rb
+++ b/backend/spec/features/admin/products/variant_spec.rb
@@ -15,12 +15,12 @@ describe 'Variants', type: :feature do
       within_row(1) { click_icon :edit }
       click_link 'Variants'
       click_on 'Add One'
-      expect(find('input#variant_price').value).to eq('1.99')
-      expect(find('input#variant_cost_price').value).to eq('1.00')
-      expect(find('input#variant_weight').value).to eq('2.50')
-      expect(find('input#variant_height').value).to eq('3.00')
-      expect(find('input#variant_width').value).to eq('1.00')
-      expect(find('input#variant_depth').value).to eq('1.50')
+      expect(page).to have_field(id: 'variant_price', with: '1.99')
+      expect(page).to have_field(id: 'variant_cost_price', with: '1.00')
+      expect(page).to have_field(id: 'variant_weight', with: '2.50')
+      expect(page).to have_field(id: 'variant_height', with: '3.00')
+      expect(page).to have_field(id: 'variant_width', with: '1.00')
+      expect(page).to have_field(id: 'variant_depth', with: '1.50')
       expect(page).to have_select('variant[tax_category_id]')
     end
   end

--- a/backend/spec/features/admin/promotions/adjustments_spec.rb
+++ b/backend/spec/features/admin/promotions/adjustments_spec.rb
@@ -19,8 +19,8 @@ describe 'Promotion Adjustments', type: :feature, js: true do
       select2 'Item total', from: 'Add rule of type'
       within('#rule_fields') { click_button 'Add' }
 
-      eventually_fill_in "promotion_promotion_rules_attributes_#{Spree::Promotion.count}_preferred_amount_min", with: 30
-      eventually_fill_in "promotion_promotion_rules_attributes_#{Spree::Promotion.count}_preferred_amount_max", with: 60
+      fill_in id: "promotion_promotion_rules_attributes_#{Spree::Promotion.count}_preferred_amount_min", with: 30
+      fill_in id: "promotion_promotion_rules_attributes_#{Spree::Promotion.count}_preferred_amount_max", with: 60
       wait_for { !page.has_button?('Update') }
       within('#rule_fields') { click_button 'Update' }
 
@@ -85,8 +85,8 @@ describe 'Promotion Adjustments', type: :feature, js: true do
       select2 'Item total', from: 'Add rule of type'
       within('#rule_fields') { click_button 'Add' }
 
-      eventually_fill_in 'promotion_promotion_rules_attributes_1_preferred_amount_min', with: 30
-      eventually_fill_in 'promotion_promotion_rules_attributes_1_preferred_amount_max', with: 60
+      fill_in id: 'promotion_promotion_rules_attributes_1_preferred_amount_min', with: 30
+      fill_in id: 'promotion_promotion_rules_attributes_1_preferred_amount_max', with: 60
       wait_for { !page.has_button?('Update') }
       within('#rule_fields') { click_button 'Update' }
 
@@ -159,8 +159,8 @@ describe 'Promotion Adjustments', type: :feature, js: true do
 
       select2 'Item total', from: 'Add rule of type'
       within('#rule_fields') { click_button 'Add' }
-      eventually_fill_in 'promotion_promotion_rules_attributes_1_preferred_amount_min', with: '50'
-      eventually_fill_in 'promotion_promotion_rules_attributes_1_preferred_amount_max', with: '150'
+      fill_in id: 'promotion_promotion_rules_attributes_1_preferred_amount_min', with: '50'
+      fill_in id: 'promotion_promotion_rules_attributes_1_preferred_amount_max', with: '150'
       wait_for { !page.has_button?('Update') }
       within('#rule_fields') { click_button 'Update' }
 
@@ -250,8 +250,8 @@ describe 'Promotion Adjustments', type: :feature, js: true do
 
       select2 'Item total', from: 'Add rule of type'
       within('#rule_fields') { click_button 'Add' }
-      eventually_fill_in 'promotion_promotion_rules_attributes_1_preferred_amount_min', with: '50'
-      eventually_fill_in 'promotion_promotion_rules_attributes_1_preferred_amount_max', with: '150'
+      fill_in id: 'promotion_promotion_rules_attributes_1_preferred_amount_min', with: '50'
+      fill_in id: 'promotion_promotion_rules_attributes_1_preferred_amount_max', with: '150'
       wait_for { !page.has_button?('Update') }
       within('#rule_fields') { click_button 'Update' }
 

--- a/backend/spec/features/admin/promotions/option_value_rule_spec.rb
+++ b/backend/spec/features/admin/promotions/option_value_rule_spec.rb
@@ -20,8 +20,8 @@ describe 'Promotion with option value rule', type: :feature do
     within('#rules .promotion-block') do
       click_button 'Add'
 
-      expect(page.body).to have_content('Product')
-      expect(page.body).to have_content('Option Values')
+      expect(page).to have_content('Product')
+      expect(page).to have_content('Option Values')
     end
 
     within('.promo-rule-option-value') do

--- a/backend/spec/features/admin/promotions/tiered_calculator_spec.rb
+++ b/backend/spec/features/admin/promotions/tiered_calculator_spec.rb
@@ -17,8 +17,8 @@ describe 'Tiered Calculator Promotions' do
     within('#actions_container') { click_button 'Update' }
 
     within('#actions_container .settings') do
-      expect(page.body).to have_content('Base Percent')
-      expect(page.body).to have_content('Tiers')
+      expect(page).to have_content('Base Percent')
+      expect(page).to have_content('Tiers')
 
       click_button 'Add'
     end

--- a/backend/spec/features/admin/promotions/tiered_calculator_spec.rb
+++ b/backend/spec/features/admin/promotions/tiered_calculator_spec.rb
@@ -26,10 +26,8 @@ describe 'Tiered Calculator Promotions' do
     fill_in 'Base Percent', with: 5
 
     within('.tier') do
-      find('.js-base-input').set(100)
-      page.execute_script("$('.js-base-input').change();")
-      find('.js-value-input').set(10)
-      page.execute_script("$('.js-value-input').change();")
+      fill_in(class: 'js-base-input', with: '100')
+      fill_in(class: 'js-value-input', with: '10')
     end
     within('#actions_container') { click_button 'Update' }
 

--- a/backend/spec/features/admin/refund_reasons/refund_reasons_spec.rb
+++ b/backend/spec/features/admin/refund_reasons/refund_reasons_spec.rb
@@ -55,7 +55,8 @@ describe 'RefundReason', type: :feature, js: true do
       accept_confirm do
         click_icon :delete
       end
-      wait_for_ajax
+      expect(page.document).to have_content('successfully removed!')
+                           .or have_content('Cannot delete record')
     end
   end
 end

--- a/backend/spec/features/admin/refund_reasons/refund_reasons_spec.rb
+++ b/backend/spec/features/admin/refund_reasons/refund_reasons_spec.rb
@@ -52,9 +52,8 @@ describe 'RefundReason', type: :feature, js: true do
     end
 
     def delete_product_property
-      handle_js_confirm do
+      accept_confirm do
         click_icon :delete
-        wait_for_ajax
       end
       wait_for_ajax
     end

--- a/backend/spec/features/admin/return_authorization_reasons/return_authorization_reasons_spec.rb
+++ b/backend/spec/features/admin/return_authorization_reasons/return_authorization_reasons_spec.rb
@@ -59,7 +59,8 @@ describe 'ReturnAuthorizationReason', type: :feature, js: true do
       accept_confirm do
         click_icon :delete
       end
-      wait_for_ajax
+      expect(page.document).to have_content('successfully removed!')
+                           .or have_content('Cannot delete record')
     end
   end
 end

--- a/backend/spec/features/admin/return_authorization_reasons/return_authorization_reasons_spec.rb
+++ b/backend/spec/features/admin/return_authorization_reasons/return_authorization_reasons_spec.rb
@@ -56,9 +56,8 @@ describe 'ReturnAuthorizationReason', type: :feature, js: true do
     end
 
     def delete_product_property
-      handle_js_confirm do
+      accept_confirm do
         click_icon :delete
-        wait_for_ajax
       end
       wait_for_ajax
     end

--- a/backend/spec/features/admin/store_credits_spec.rb
+++ b/backend/spec/features/admin/store_credits_spec.rb
@@ -22,7 +22,7 @@ describe 'Store credits admin', type: :feature do
       expect(page).to have_current_path(spree.admin_user_store_credits_path(store_credit.user))
 
       store_credit_table = page.find('table')
-      expect(store_credit_table.all('tr').count).to eq 1
+      expect(store_credit_table).to have_css('tr').once
       expect(store_credit_table).to have_content(Spree::Money.new(store_credit.amount, currency: store_credit.currency).to_s)
       expect(store_credit_table).to have_content(Spree::Money.new(store_credit.amount_used, currency: store_credit.currency).to_s)
       expect(store_credit_table).to have_content(store_credit.category_name)
@@ -49,7 +49,7 @@ describe 'Store credits admin', type: :feature do
         expect(page).to have_current_path(spree.admin_user_store_credits_path(store_credit.user))
 
         store_credit_table = page.find('table')
-        expect(store_credit_table.all('tr').count).to eq 2
+        expect(store_credit_table).to have_css('tr').twice
         expect(Spree::StoreCredit.count).to eq 2
       end
     end
@@ -65,7 +65,7 @@ describe 'Store credits admin', type: :feature do
         expect(page).to have_current_path(spree.admin_user_store_credits_path(store_credit.user))
 
         store_credit_table = page.find('table')
-        expect(store_credit_table.all('tr').count).to eq 2
+        expect(store_credit_table).to have_css('tr').twice
         expect(Spree::StoreCredit.count).to eq 2
         expect(Spree::StoreCredit.last.currency).to eq 'EUR'
         expect(store_credit_table).to have_content('€100.00')

--- a/backend/spec/features/admin/store_credits_spec.rb
+++ b/backend/spec/features/admin/store_credits_spec.rb
@@ -21,7 +21,7 @@ describe 'Store credits admin', type: :feature do
       click_link 'Store Credits'
       expect(page).to have_current_path(spree.admin_user_store_credits_path(store_credit.user))
 
-      store_credit_table = page.find('table')
+      store_credit_table = page.find('table', match: :first)
       expect(store_credit_table).to have_css('tr').once
       expect(store_credit_table).to have_content(Spree::Money.new(store_credit.amount, currency: store_credit.currency).to_s)
       expect(store_credit_table).to have_content(Spree::Money.new(store_credit.amount_used, currency: store_credit.currency).to_s)
@@ -48,7 +48,7 @@ describe 'Store credits admin', type: :feature do
 
         expect(page).to have_current_path(spree.admin_user_store_credits_path(store_credit.user))
 
-        store_credit_table = page.find('table')
+        store_credit_table = page.find('table', match: :first)
         expect(store_credit_table).to have_css('tr').twice
         expect(Spree::StoreCredit.count).to eq 2
       end
@@ -64,7 +64,7 @@ describe 'Store credits admin', type: :feature do
 
         expect(page).to have_current_path(spree.admin_user_store_credits_path(store_credit.user))
 
-        store_credit_table = page.find('table')
+        store_credit_table = page.find('table', match: :first)
         expect(store_credit_table).to have_css('tr').twice
         expect(Spree::StoreCredit.count).to eq 2
         expect(Spree::StoreCredit.last.currency).to eq 'EUR'
@@ -90,7 +90,7 @@ describe 'Store credits admin', type: :feature do
       click_button 'Update'
 
       expect(page).to have_current_path(spree.admin_user_store_credits_path(store_credit.user))
-      store_credit_table = page.find('table')
+      store_credit_table = page.first('table')
       expect(store_credit_table).to have_content(Spree::Money.new(updated_amount, currency: store_credit.currency).to_s)
       expect(store_credit.reload.amount.to_f).to eq updated_amount.to_f
     end

--- a/backend/spec/features/admin/store_credits_spec.rb
+++ b/backend/spec/features/admin/store_credits_spec.rb
@@ -106,12 +106,10 @@ describe 'Store credits admin', type: :feature do
     end
 
     it 'updates store credit in lifetime stats' do
-      handle_js_confirm do
+      accept_confirm do
         click_icon :delete
-        wait_for_ajax
       end
-      store_credit = page.find('#user-lifetime-stats #store_credit')
-      expect(store_credit.text).to eq(Spree::Money.new(0).to_s)
+      expect(page).to have_css('#user-lifetime-stats #store_credit', text: Spree::Money.new(0).to_s)
     end
   end
 

--- a/backend/spec/features/admin/taxons_spec.rb
+++ b/backend/spec/features/admin/taxons_spec.rb
@@ -40,7 +40,7 @@ describe 'Taxonomies and taxons', type: :feature do
     click_link 'Delete From Taxon'
     wait_for_ajax
 
-    visit current_path
+    refresh
     select_clothing_from_select2
 
     expect(page).to have_content('No results')

--- a/backend/spec/features/admin/taxons_spec.rb
+++ b/backend/spec/features/admin/taxons_spec.rb
@@ -37,8 +37,10 @@ describe 'Taxonomies and taxons', type: :feature do
 
     find('.product').hover
     find('.product .dropdown-toggle').click
+
     click_link 'Delete From Taxon'
-    wait_for_ajax
+
+    expect(page).not_to have_css('.product')
 
     refresh
     select_clothing_from_select2

--- a/backend/spec/features/admin/users_spec.rb
+++ b/backend/spec/features/admin/users_spec.rb
@@ -146,7 +146,7 @@ describe 'Users', type: :feature do
 
     it 'can edit user roles' do
       Spree::Role.create name: 'admin'
-      click_link 'Users'
+      click_link 'Users', match: :first
       click_link user_a.email
 
       check 'user_spree_role_admin'

--- a/backend/spec/features/admin/users_spec.rb
+++ b/backend/spec/features/admin/users_spec.rb
@@ -22,7 +22,7 @@ describe 'Users', type: :feature do
   shared_examples_for 'a user page' do
     it 'has lifetime stats' do
       orders
-      visit current_url # need to refresh after creating the orders for specs that did not require orders
+      refresh # need to refresh after creating the orders for specs that did not require orders
       within('#user-lifetime-stats') do
         [:total_sales, :num_orders, :average_order_value, :member_since].each do |stat_name|
           expect(page).to have_content Spree.t(stat_name)
@@ -30,7 +30,7 @@ describe 'Users', type: :feature do
         expect(page).to have_content (order.total + order_2.total)
         expect(page).to have_content orders.count
         expect(page).to have_content (orders.sum(&:total) / orders.count)
-        expect(page).to have_content pretty_time(user_a.created_at)
+        expect(page).to have_content pretty_time(user_a.created_at).gsub(/[[:space:]]+/, ' ')
       end
     end
 
@@ -133,7 +133,7 @@ describe 'Users', type: :feature do
 
       expect(user_a.reload.email).to eq 'a@example.com99'
       expect(page).to have_text 'Account updated'
-      expect(find_field('user_email').value).to eq 'a@example.com99'
+      expect(page).to have_field('user_email', with: 'a@example.com99')
     end
 
     it 'can edit the user password' do
@@ -152,7 +152,7 @@ describe 'Users', type: :feature do
       check 'user_spree_role_admin'
       click_button 'Update'
       expect(page).to have_text 'Account updated'
-      expect(find_field('user_spree_role_admin')['checked']).to be true
+      expect(page).to have_checked_field('user_spree_role_admin')
     end
 
     it 'can edit user shipping address' do
@@ -161,7 +161,7 @@ describe 'Users', type: :feature do
       within('#admin_user_edit_addresses') do
         fill_in 'user_ship_address_attributes_address1', with: '1313 Mockingbird Ln'
         click_button 'Update'
-        expect(find_field('user_ship_address_attributes_address1').value).to eq '1313 Mockingbird Ln'
+        expect(page).to have_field('user_ship_address_attributes_address1', with: '1313 Mockingbird Ln')
       end
 
       expect(user_a.reload.ship_address.address1).to eq '1313 Mockingbird Ln'
@@ -173,7 +173,7 @@ describe 'Users', type: :feature do
       within('#admin_user_edit_addresses') do
         fill_in 'user_bill_address_attributes_address1', with: '1313 Mockingbird Ln'
         click_button 'Update'
-        expect(find_field('user_bill_address_attributes_address1').value).to eq '1313 Mockingbird Ln'
+        expect(page).to have_field('user_bill_address_attributes_address1', with: '1313 Mockingbird Ln')
       end
 
       expect(user_a.reload.bill_address.address1).to eq '1313 Mockingbird Ln'
@@ -200,7 +200,7 @@ describe 'Users', type: :feature do
         expect(user_a.reload.spree_api_key).to be_present
 
         within('#admin_user_edit_api_key') do
-          expect(find('#current-api-key').text).to match(/Key: #{user_a.spree_api_key}/)
+          expect(page).to have_css('#current-api-key', text: /Key: #{user_a.spree_api_key}/)
         end
       end
     end
@@ -209,7 +209,7 @@ describe 'Users', type: :feature do
       before do
         user_a.generate_spree_api_key!
         expect(user_a.reload.spree_api_key).to be_present
-        visit current_path
+        refresh
       end
 
       it 'can clear an api key' do
@@ -218,7 +218,7 @@ describe 'Users', type: :feature do
         end
 
         expect(user_a.reload.spree_api_key).to be_blank
-        expect { find('#current-api-key') }.to raise_error Capybara::ElementNotFound
+        expect(page).not_to have_css('#current-api-key')
       end
 
       it 'can regenerate an api key' do
@@ -232,7 +232,7 @@ describe 'Users', type: :feature do
         expect(user_a.reload.spree_api_key).not_to eq old_key
 
         within('#admin_user_edit_api_key') do
-          expect(find('#current-api-key').text).to match(/Key: #{user_a.spree_api_key}/)
+          expect(page).to have_css('#current-api-key', text: /Key: #{user_a.spree_api_key}/)
         end
       end
     end

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -83,20 +83,16 @@ RSpec.configure do |config|
     reset_spree_preferences
   end
 
-  config.after do
-    # wait_for_ajax sometimes fails so we should clean db first to get rid of false failed specs
-    DatabaseCleaner.clean
-
-    # Ensure js requests finish processing before advancing to the next test
-    wait_for_ajax if RSpec.current_example.metadata[:js]
-  end
-
   config.after(:each, type: :feature) do |example|
     missing_translations = page.body.scan(/translation missing: #{I18n.locale}\.(.*?)[\s<\"&]/)
     if missing_translations.any?
       puts "Found missing translations: #{missing_translations.inspect}"
       puts "In spec: #{example.location}"
     end
+  end
+
+  config.append_after do
+    DatabaseCleaner.clean
   end
 
   config.include FactoryBot::Syntax::Methods

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -63,7 +63,7 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = false
 
   config.before :suite do
-    Capybara.match = :prefer_exact
+    Capybara.match = :smart
     DatabaseCleaner.clean_with :truncation
   end
 
@@ -114,6 +114,9 @@ RSpec.configure do |config|
 
   config.order = :random
   Kernel.srand config.seed
+
+  config.filter_run_including focus: true unless ENV['CI']
+  config.run_all_when_everything_filtered = true
 end
 
 module Spree

--- a/cmd/lib/spree_cmd/templates/extension/spec/support/database_cleaner.rb
+++ b/cmd/lib/spree_cmd/templates/extension/spec/support/database_cleaner.rb
@@ -19,7 +19,7 @@ RSpec.configure do |config|
   end
 
   # After each spec clean the database.
-  config.after do
+  config.append_after do
     DatabaseCleaner.clean
   end
 end

--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -18,7 +18,7 @@ platforms :ruby do
 end
 
 group :test do
-  gem 'capybara', '~> 2.16'
+  gem 'capybara', '~> 3.24'
   gem 'capybara-screenshot', '~> 1.0'
   gem 'database_cleaner', '~> 1.3'
   gem 'email_spec'

--- a/core/lib/spree/testing_support/capybara_config.rb
+++ b/core/lib/spree/testing_support/capybara_config.rb
@@ -12,7 +12,7 @@ else
     Capybara::Selenium::Driver.new app,
       browser: :chrome,
       options: Selenium::WebDriver::Chrome::Options.new(
-        args: %w[no-sandbox disable-dev-shm-usage disable-popup-blocking headless disable-gpu window-size=1920,1080 --enable-features=NetworkService,NetworkServiceInProcess --disable-features=VizDisplayCompositor],
+        args: %w[no-sandbox disable-dev-shm-usage disable-popup-blocking headless disable-gpu window-size=1920,1080 --enable-features=NetworkService,NetworkServiceInProcess--disable-features=VizDisplayCompositor],
         log_level: :error
       )
   end
@@ -23,3 +23,4 @@ else
   end
 end
 Capybara.default_max_wait_time = 45
+Capybara.server = :webrick

--- a/core/lib/spree/testing_support/capybara_config.rb
+++ b/core/lib/spree/testing_support/capybara_config.rb
@@ -12,7 +12,7 @@ else
     Capybara::Selenium::Driver.new app,
       browser: :chrome,
       options: Selenium::WebDriver::Chrome::Options.new(
-        args: %w[no-sandbox disable-dev-shm-usage disable-popup-blocking headless disable-gpu window-size=1920,1080 --enable-features=NetworkService,NetworkServiceInProcess--disable-features=VizDisplayCompositor],
+        args: %w[no-sandbox disable-dev-shm-usage disable-popup-blocking headless disable-gpu window-size=1920,1080--enable-features=NetworkService,NetworkServiceInProcess--disable-features=VizDisplayCompositor],
         log_level: :error
       )
   end

--- a/core/lib/spree/testing_support/capybara_config.rb
+++ b/core/lib/spree/testing_support/capybara_config.rb
@@ -12,7 +12,7 @@ else
     Capybara::Selenium::Driver.new app,
       browser: :chrome,
       options: Selenium::WebDriver::Chrome::Options.new(
-        args: %w[no-sandbox disable-dev-shm-usage disable-popup-blocking headless disable-gpu window-size=1920,1080--enable-features=NetworkService,NetworkServiceInProcess--disable-features=VizDisplayCompositor],
+        args: %w[no-sandbox disable-dev-shm-usage disable-popup-blocking headless disable-gpu window-size=1920,1080 --enable-features=NetworkService,NetworkServiceInProcess --disable-features=VizDisplayCompositor],
         log_level: :error
       )
   end

--- a/core/lib/spree/testing_support/capybara_ext.rb
+++ b/core/lib/spree/testing_support/capybara_ext.rb
@@ -142,21 +142,6 @@ RSpec::Matchers.define :have_meta do |name, expected|
   end
 end
 
-RSpec::Matchers.define :have_title do |expected|
-  match do |_actual|
-    has_css?('title', text: expected, visible: false)
-  end
-
-  failure_message do |actual|
-    actual = first('title')
-    if actual
-      "expected that title would have been '#{expected}' but was '#{actual.text}'"
-    else
-      "expected that title would exist with '#{expected}'"
-    end
-  end
-end
-
 RSpec.configure do |c|
   c.include CapybaraExt
 end

--- a/core/lib/spree/testing_support/capybara_ext.rb
+++ b/core/lib/spree/testing_support/capybara_ext.rb
@@ -45,7 +45,8 @@ module CapybaraExt
   end
 
   def targetted_select2_search(value, options)
-    page.execute_script %Q{$('#{options[:from]}').select2('open')}
+    select2_el = find(:css, options[:from])
+    page.execute_script "$(arguments[0]).select2('open')", select2_el
     page.execute_script "$('#{options[:dropdown_css]} input.select2-input').val('#{value}').trigger('keyup-change');"
     select_select2_result(value)
   end

--- a/core/lib/spree/testing_support/capybara_ext.rb
+++ b/core/lib/spree/testing_support/capybara_ext.rb
@@ -13,14 +13,14 @@ module CapybaraExt
   end
 
   def click_icon(type)
-    find(".icon-#{type}").click
+    first(".icon-#{type}").click
   end
 
   def within_row(num, &block)
     if RSpec.current_example.metadata[:js]
-      within("table.table tbody tr:nth-child(#{num})", &block)
+      within("table.table tbody tr:nth-child(#{num})", match: :first, &block)
     else
-      within(:xpath, all('table.table tbody tr')[num - 1].path, &block)
+      within(all('table.table tbody tr')[num - 1], &block)
     end
   end
 
@@ -74,7 +74,7 @@ module CapybaraExt
 
   def select_select2_result(value)
     # results are in a div appended to the end of the document
-    page.document.find('div.select2-result-label', text: %r{#{Regexp.escape(value)}}i).click
+    page.document.find('div.select2-result-label', match: :first, text: %r{#{Regexp.escape(value)}}i).click
   end
 
   # arg delay in seconds
@@ -99,7 +99,7 @@ rescue Selenium::WebDriver::Error::TimeOutError
 end
 
 Capybara.configure do |config|
-  config.match = :prefer_exact
+  config.match = :smart
   config.ignore_hidden_elements = true
 end
 

--- a/frontend/spec/features/address_spec.rb
+++ b/frontend/spec/features/address_spec.rb
@@ -46,21 +46,17 @@ describe 'Address', type: :feature, inaccessible: true do
       end
     end
 
-    context 'user changes to country without states required' do
+    context 'user changes to country without states required', :focus do
       let!(:france) { create(:country, name: 'France', states_required: false, iso: 'FRA') }
 
       it 'clears the state name' do
-        skip 'This is failing on the CI server, but not when you run the tests manually... It also does not fail locally on a machine.'
         click_button 'Checkout'
         select canada.name, from: @country_css
         page.find(@state_name_css).set('Toscana')
 
         select france.name, from: @country_css
-        expect(page).to have_css(@state_name_css, exact_text: '')
-        until page.evaluate_script('$.active').to_i.zero?
-          expect(page).to have_css(@state_name_css, class: ['!hidden', '!required'])
-          expect(page).to have_css(@state_select_css, class: ['!required'])
-        end
+        expect(page).to have_css(@state_name_css, filter_set: :field, disabled: true, with: '', visible: :hidden, class: ['!hidden', '!required'])
+        expect(page).to have_css(@state_select_css, visible: :hidden, class: ['!required'])
       end
     end
   end

--- a/frontend/spec/features/address_spec.rb
+++ b/frontend/spec/features/address_spec.rb
@@ -46,7 +46,7 @@ describe 'Address', type: :feature, inaccessible: true do
       end
     end
 
-    context 'user changes to country without states required', :focus do
+    context 'user changes to country without states required' do
       let!(:france) { create(:country, name: 'France', states_required: false, iso: 'FRA') }
 
       it 'clears the state name' do

--- a/frontend/spec/features/address_spec.rb
+++ b/frontend/spec/features/address_spec.rb
@@ -3,15 +3,9 @@ require 'spec_helper'
 describe 'Address', type: :feature, inaccessible: true do
   stub_authorization!
 
-  after do
-    Capybara.ignore_hidden_elements = true
-  end
-
   before do
     create(:product, name: 'RoR Mug')
     create(:order_with_totals, state: 'cart')
-
-    Capybara.ignore_hidden_elements = false
 
     visit spree.root_path
 
@@ -34,12 +28,9 @@ describe 'Address', type: :feature, inaccessible: true do
         click_button 'Checkout'
 
         select canada.name, from: @country_css
-        expect(page).to have_selector(@state_select_css, visible: :hidden)
-        expect(page).to have_selector(@state_name_css, visible: true)
-        expect(page).to have_css(@state_name_css, class: ['!hidden'])
-        expect(page).to have_css(@state_name_css, class: ['required'])
-        expect(page).to have_css(@state_select_css, class: ['!required'])
-        expect(page).not_to have_selector("input#{@state_name_css}[disabled]")
+        expect(page).to have_css(@state_select_css, visible: :hidden, class: ['!required'])
+        expect(page).to have_css(@state_name_css, visible: true, class: ['!hidden', 'required'])
+        expect(page).not_to have_css("input#{@state_name_css}[disabled]")
       end
     end
 
@@ -50,11 +41,8 @@ describe 'Address', type: :feature, inaccessible: true do
         click_button 'Checkout'
 
         select canada.name, from: @country_css
-        expect(page).to have_selector(@state_select_css, visible: true)
-        expect(page).to have_selector(@state_name_css, visible: :hidden)
-        expect(page).to have_css(@state_select_css, class: ['required'])
-        expect(page).to have_css(@state_select_css, class: ['!hidden'])
-        expect(page).to have_css(@state_name_css, class: ['!required'])
+        expect(page).to have_css(@state_select_css, visible: true, class: ['!hidden', 'required'])
+        expect(page).to have_css(@state_name_css, visible: :hidden, class: ['!required'])
       end
     end
 
@@ -70,8 +58,7 @@ describe 'Address', type: :feature, inaccessible: true do
         select france.name, from: @country_css
         expect(page).to have_css(@state_name_css, exact_text: '')
         until page.evaluate_script('$.active').to_i.zero?
-          expect(page).to have_css(@state_name_css, class: ['!hidden'])
-          expect(page).to have_css(@state_name_css, class: ['!required'])
+          expect(page).to have_css(@state_name_css, class: ['!hidden', '!required'])
           expect(page).to have_css(@state_select_css, class: ['!required'])
         end
       end

--- a/frontend/spec/features/address_spec.rb
+++ b/frontend/spec/features/address_spec.rb
@@ -34,11 +34,11 @@ describe 'Address', type: :feature, inaccessible: true do
         click_button 'Checkout'
 
         select canada.name, from: @country_css
-        expect(page).to have_selector(@state_select_css, visible: false)
+        expect(page).to have_selector(@state_select_css, visible: :hidden)
         expect(page).to have_selector(@state_name_css, visible: true)
-        expect(find(@state_name_css)['class']).not_to match(/hidden/)
-        expect(find(@state_name_css)['class']).to match(/required/)
-        expect(find(@state_select_css)['class']).not_to match(/required/)
+        expect(page).to have_css(@state_name_css, class: ['!hidden'])
+        expect(page).to have_css(@state_name_css, class: ['required'])
+        expect(page).to have_css(@state_select_css, class: ['!required'])
         expect(page).not_to have_selector("input#{@state_name_css}[disabled]")
       end
     end
@@ -51,10 +51,10 @@ describe 'Address', type: :feature, inaccessible: true do
 
         select canada.name, from: @country_css
         expect(page).to have_selector(@state_select_css, visible: true)
-        expect(page).to have_selector(@state_name_css, visible: false)
-        expect(find(@state_select_css)['class']).to match(/required/)
-        expect(find(@state_select_css)['class']).not_to match(/hidden/)
-        expect(find(@state_name_css)['class']).not_to match(/required/)
+        expect(page).to have_selector(@state_name_css, visible: :hidden)
+        expect(page).to have_css(@state_select_css, class: ['required'])
+        expect(page).to have_css(@state_select_css, class: ['!hidden'])
+        expect(page).to have_css(@state_name_css, class: ['!required'])
       end
     end
 
@@ -68,11 +68,11 @@ describe 'Address', type: :feature, inaccessible: true do
         page.find(@state_name_css).set('Toscana')
 
         select france.name, from: @country_css
-        expect(page.find(@state_name_css)).to have_content('')
+        expect(page).to have_css(@state_name_css, exact_text: '')
         until page.evaluate_script('$.active').to_i.zero?
-          expect(find(@state_name_css)['class']).not_to match(/hidden/)
-          expect(find(@state_name_css)['class']).not_to match(/required/)
-          expect(find(@state_select_css)['class']).not_to match(/required/)
+          expect(page).to have_css(@state_name_css, class: ['!hidden'])
+          expect(page).to have_css(@state_name_css, class: ['!required'])
+          expect(page).to have_css(@state_select_css, class: ['!required'])
         end
       end
     end
@@ -85,8 +85,8 @@ describe 'Address', type: :feature, inaccessible: true do
       click_button 'Checkout'
 
       select france.name, from: @country_css
-      expect(page).to have_selector(@state_select_css, visible: false)
-      expect(page).to have_selector(@state_name_css, visible: false)
+      expect(page).to have_selector(@state_select_css, visible: :hidden)
+      expect(page).to have_selector(@state_name_css, visible: :hidden)
     end
   end
 end

--- a/frontend/spec/features/automatic_promotion_adjustments_spec.rb
+++ b/frontend/spec/features/automatic_promotion_adjustments_spec.rb
@@ -36,10 +36,10 @@ describe 'Automatic promotions', type: :feature, js: true do
     it 'automatically applies the promotion once the order crosses the threshold' do
       fill_in 'order_line_items_attributes_0_quantity', with: 10
       click_button 'Update'
-      expect(page).to have_content('Promotion ($10 off when you spend more than $100) -$10.00')
+      expect(page).to have_content("Promotion ($10 off when you spend more than $100)\n-$10.00")
       fill_in 'order_line_items_attributes_0_quantity', with: 1
       click_button 'Update'
-      expect(page).not_to have_content('Promotion ($10 off when you spend more than $100) -$10.00')
+      expect(page).not_to have_content('Promotion ($10 off when you spend more than $100) -$10.00', normalize_ws: true)
     end
   end
 end

--- a/frontend/spec/features/cart_spec.rb
+++ b/frontend/spec/features/cart_spec.rb
@@ -20,7 +20,7 @@ describe 'Cart', type: :feature, inaccessible: true, js: true do
   it 'prevents double clicking the remove button on cart' do
     add_mug_to_cart
     # prevent form submit to verify button is disabled
-    page.execute_script("$('#update-cart').submit(function(){return false;})")
+    find('#update-cart').execute_script('$(this).submit(function(){return false;})')
 
     expect(page).not_to have_selector('button#update-button[disabled]')
     page.find(:css, '.delete span').click

--- a/frontend/spec/features/checkout_address_selection_spec.rb
+++ b/frontend/spec/features/checkout_address_selection_spec.rb
@@ -49,8 +49,8 @@ describe 'Address selection during checkout', type: :feature, js: true do
     let(:user) { @user }
 
     it 'does not see billing or shipping address form' do
-      expect(find('#billing .inner', visible: false)).not_to be_visible
-      expect(find('#shipping .inner', visible: false)).not_to be_visible
+      expect(page).to have_css('#billing .inner', visible: :hidden)
+      expect(page).to have_css('#shipping .inner', visible: :hidden)
     end
 
     it 'lists saved addresses for billing and shipping' do
@@ -104,7 +104,7 @@ describe 'Address selection during checkout', type: :feature, js: true do
       # TODO: the JS error reporting isn't working with our current iteration
       # this is what this piece of code ('field is required') tests
       it 'shows address form with error' do
-        allow(Capybara).to receive(:ignore_hidden_elements).and_return(false)
+        # allow(Capybara).to receive(:ignore_hidden_elements).and_return(false)
         within('#billing') do
           choose Spree.t('address_book.other_address')
           fill_in_address(address)
@@ -126,7 +126,7 @@ describe 'Address selection during checkout', type: :feature, js: true do
 
     describe 'entering 2 new addresses', js: true do
       it 'assigns 2 new addresses to order' do
-        allow(Capybara).to receive(:ignore_hidden_elements).and_return(false)
+        # allow(Capybara).to receive(:ignore_hidden_elements).and_return(false)
         within('#billing') do
           choose Spree.t('address_book.other_address')
           fill_in_address(billing)
@@ -169,7 +169,7 @@ describe 'Address selection during checkout', type: :feature, js: true do
       end
 
       it 'assigns addresses to orders' do
-        allow(Capybara).to receive(:ignore_hidden_elements).and_return(false)
+        # allow(Capybara).to receive(:ignore_hidden_elements).and_return(false)
         address = user.addresses.first
         choose "order_bill_address_id_#{address.id}"
         within('#shipping') do
@@ -204,14 +204,14 @@ describe 'Address selection during checkout', type: :feature, js: true do
         expect(saddress1_message).to eq('Please fill out this field.')
 
         within('#billing') do
-          expect(find("#order_bill_address_id_#{address.id}")).to be_checked
+          expect(page).to have_checked_field(id: "order_bill_address_id_#{address.id}")
         end
       end
     end
 
     describe 'using saved address for billing and shipping', js: true do
       it 'addresseses to order' do
-        allow(Capybara).to receive(:ignore_hidden_elements).and_return(false)
+        # allow(Capybara).to receive(:ignore_hidden_elements).and_return(false)
         address = user.addresses.first
         choose "order_bill_address_id_#{address.id}"
         check 'Use Billing Address'
@@ -255,7 +255,7 @@ describe 'Address selection during checkout', type: :feature, js: true do
       end
 
       it 'assigns addresses to orders' do
-        allow(Capybara).to receive(:ignore_hidden_elements).and_return(false)
+        # allow(Capybara).to receive(:ignore_hidden_elements).and_return(false)
         address = user.addresses.first
         uncheck 'order_use_billing'
         choose "order_ship_address_id_#{address.id}"
@@ -291,7 +291,7 @@ describe 'Address selection during checkout', type: :feature, js: true do
         expect(baddress1_message).to eq('Please fill out this field.')
 
         within('#shipping') do
-          expect(find("#order_ship_address_id_#{address.id}")).to be_checked
+          expect(page).to have_checked_field(id: "order_ship_address_id_#{address.id}")
         end
       end
     end

--- a/frontend/spec/features/checkout_address_selection_spec.rb
+++ b/frontend/spec/features/checkout_address_selection_spec.rb
@@ -104,7 +104,6 @@ describe 'Address selection during checkout', type: :feature, js: true do
       # TODO: the JS error reporting isn't working with our current iteration
       # this is what this piece of code ('field is required') tests
       it 'shows address form with error' do
-        # allow(Capybara).to receive(:ignore_hidden_elements).and_return(false)
         within('#billing') do
           choose Spree.t('address_book.other_address')
           fill_in_address(address)
@@ -126,7 +125,6 @@ describe 'Address selection during checkout', type: :feature, js: true do
 
     describe 'entering 2 new addresses', js: true do
       it 'assigns 2 new addresses to order' do
-        # allow(Capybara).to receive(:ignore_hidden_elements).and_return(false)
         within('#billing') do
           choose Spree.t('address_book.other_address')
           fill_in_address(billing)
@@ -169,7 +167,6 @@ describe 'Address selection during checkout', type: :feature, js: true do
       end
 
       it 'assigns addresses to orders' do
-        # allow(Capybara).to receive(:ignore_hidden_elements).and_return(false)
         address = user.addresses.first
         choose "order_bill_address_id_#{address.id}"
         within('#shipping') do
@@ -211,7 +208,6 @@ describe 'Address selection during checkout', type: :feature, js: true do
 
     describe 'using saved address for billing and shipping', js: true do
       it 'addresseses to order' do
-        # allow(Capybara).to receive(:ignore_hidden_elements).and_return(false)
         address = user.addresses.first
         choose "order_bill_address_id_#{address.id}"
         check 'Use Billing Address'
@@ -255,7 +251,6 @@ describe 'Address selection during checkout', type: :feature, js: true do
       end
 
       it 'assigns addresses to orders' do
-        # allow(Capybara).to receive(:ignore_hidden_elements).and_return(false)
         address = user.addresses.first
         uncheck 'order_use_billing'
         choose "order_ship_address_id_#{address.id}"

--- a/frontend/spec/features/checkout_edit_address_spec.rb
+++ b/frontend/spec/features/checkout_edit_address_spec.rb
@@ -15,7 +15,7 @@ describe 'User editing saved address during checkout', type: :feature, js: true 
     fill_in I18n.t('activerecord.attributes.spree/address.address1'), with: new_street
     click_button 'Update'
     user.reload
-    page.driver.browser.navigate.refresh
+    refresh
     expect(page).to have_current_path spree.checkout_state_path('address')
     within('h1') { expect(page).to have_content('Checkout') }
     within('#billing') do
@@ -33,7 +33,7 @@ describe 'User editing saved address during checkout', type: :feature, js: true 
     fill_in I18n.t('activerecord.attributes.spree/address.address1'), with: new_street
     click_button 'Update'
     user.reload
-    page.driver.browser.navigate.refresh
+    refresh
     expect(page).to have_current_path spree.checkout_state_path('address')
     within('h1') { expect(page).to have_content('Checkout') }
     find('#order_use_billing').click # checking hidden elements in capybara is funky

--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -142,8 +142,7 @@ describe 'Checkout', type: :feature, inaccessible: true, js: true do
       click_button 'Save and Continue'
       click_button 'Save and Continue'
 
-      continue_button = find('#checkout .btn-success')
-      expect(continue_button.value).to eq 'Place Order'
+      expect(find('#checkout')).to have_button(class: 'btn-success', value: 'Place Order')
     end
   end
 

--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -194,12 +194,7 @@ describe 'Checkout', type: :feature, inaccessible: true, js: true do
     let(:credit_cart_payment) { create(:credit_card_payment_method) }
     let(:check_payment) { create(:check_payment_method) }
 
-    after do
-      Capybara.ignore_hidden_elements = true
-    end
-
     before do
-      # Capybara.ignore_hidden_elements = false
       order = OrderWalkthrough.up_to(:payment)
       allow(order).to receive_messages(available_payment_methods: [check_payment, credit_cart_payment])
       order.user = create(:user)

--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -169,7 +169,7 @@ describe 'Checkout', type: :feature, inaccessible: true, js: true do
       visit spree.checkout_state_path(:payment)
 
       # prevent form submit to verify button is disabled
-      page.execute_script("$('#checkout_form_payment').submit(function(){return false;})")
+      find('#checkout_form_payment').execute_script('$(this).submit(function(){return false;})')
 
       expect(page).not_to have_selector('input.btn.disabled')
       click_button 'Save and Continue'
@@ -181,7 +181,7 @@ describe 'Checkout', type: :feature, inaccessible: true, js: true do
       visit spree.checkout_state_path(:confirm)
 
       # prevent form submit to verify button is disabled
-      page.execute_script("$('#checkout_form_confirm').submit(function(){return false;})")
+      find('#checkout_form_confirm').execute_script('$(this).submit(function(){return false;})')
 
       expect(page).not_to have_selector('input.btn.disabled')
       click_button 'Place Order'

--- a/frontend/spec/features/coupon_code_spec.rb
+++ b/frontend/spec/features/coupon_code_spec.rb
@@ -57,14 +57,14 @@ describe 'Coupon code promotions', type: :feature, js: true do
         expect(page).to have_content(Spree.t(:coupon_code_not_found))
         fill_in 'order_coupon_code', with: 'onetwo'
         click_button 'Save and Continue'
-        expect(page).to have_content('Promotion (Onetwo)   -$10.00')
+        expect(page).to have_content('Promotion (Onetwo) -$10.00')
       end
 
       context 'with a promotion' do
         it 'applies a promotion to an order' do
           fill_in 'order_coupon_code', with: 'onetwo'
           click_button 'Save and Continue'
-          expect(page).to have_content('Promotion (Onetwo)   -$10.00')
+          expect(page).to have_content('Promotion (Onetwo) -$10.00')
         end
       end
     end

--- a/frontend/spec/features/free_shipping_promotions_spec.rb
+++ b/frontend/spec/features/free_shipping_promotions_spec.rb
@@ -30,7 +30,7 @@ describe 'Free shipping promotions', type: :feature, js: true do
     # Regression test for #4428
     it 'applies the free shipping promotion' do
       within('#checkout-summary') do
-        expect(page).to have_content('Shipping total:  $10.00')
+        expect(page).to have_content('Shipping total: $10.00')
         expect(page).to have_content('Promotion (Free Shipping): -$10.00')
       end
     end

--- a/frontend/spec/features/locale_spec.rb
+++ b/frontend/spec/features/locale_spec.rb
@@ -40,7 +40,7 @@ describe 'setting locale', type: :feature do
 
     def check_error_text(text)
       %w(firstname lastname address1 city).each do |attr|
-        expect(find("#b#{attr} label.error").text).to eq(text)
+        expect(page).to have_css("#b#{attr} label.error", exact_text: text)
       end
     end
   end

--- a/frontend/spec/features/order_spec.rb
+++ b/frontend/spec/features/order_spec.rb
@@ -59,7 +59,7 @@ describe 'orders', type: :feature do
     specify do
       visit spree.order_path(order)
       within '.payment-info' do
-        expect { find('img') }.to raise_error(Capybara::ElementNotFound)
+        expect(page).not_to have_selector('img')
       end
     end
   end

--- a/frontend/spec/features/page_promotions_spec.rb
+++ b/frontend/spec/features/page_promotions_spec.rb
@@ -19,17 +19,17 @@ describe 'page promotions', type: :feature, js: true do
   end
 
   it 'automatically applies a page promotion upon visiting' do
-    expect(page).not_to have_content('Promotion ($10 off) -$10.00')
+    expect(page).not_to have_content('Promotion ($10 off) -$10.00', normalize_ws: true)
     visit '/content/test'
     visit '/cart'
-    expect(page).to have_content('Promotion ($10 off) -$10.00')
-    expect(page).to have_content('Subtotal (1 item) $20.00')
+    expect(page).to have_content("Promotion ($10 off)\n-$10.00")
+    expect(page).to have_content("Subtotal (1 item)\n$20.00")
   end
 
   it "does not activate an adjustment for a path that doesn't have a promotion" do
-    expect(page).not_to have_content('Promotion ($10 off) -$10.00')
+    expect(page).not_to have_content('Promotion ($10 off) -$10.00', normalize_ws: true)
     visit '/content/cvv'
     visit '/cart'
-    expect(page).not_to have_content('Promotion ($10 off) -$10.00')
+    expect(page).not_to have_content('Promotion ($10 off) -$10.00', normalize_ws: true)
   end
 end

--- a/frontend/spec/features/products_spec.rb
+++ b/frontend/spec/features/products_spec.rb
@@ -17,14 +17,9 @@ describe 'Visiting Products', type: :feature, inaccessible: true do
     expect(page).to have_content('$19.99')
 
     expect(page).to have_selector('form#add-to-cart-form')
-    expect(page).to have_selector('button#add-to-cart-button')
-    wait_for_condition do
-      expect(page.find('#add-to-cart-button').disabled?).to eq(false)
-    end
+    expect(page).to have_selector(:button, id: 'add-to-cart-button', disabled: false)
     click_button 'add-to-cart-button'
-    wait_for_condition do
-      expect(page).to have_content(Spree.t(:shopping_cart))
-    end
+    expect(page).to have_content(Spree.t(:shopping_cart))
   end
 
   describe 'correct displaying of microdata' do
@@ -153,7 +148,7 @@ describe 'Visiting Products', type: :feature, inaccessible: true do
     fill_in 'keywords', with: 'shirt'
     click_button 'Search'
 
-    expect(page.all('#products .product-list-item').size).to eq(1)
+    expect(page).to have_css('#products .product-list-item').once
   end
 
   context 'a product with variants' do
@@ -263,11 +258,11 @@ describe 'Visiting Products', type: :feature, inaccessible: true do
   end
 
   it 'is able to hide products without price' do
-    expect(page.all('#products .product-list-item').size).to eq(9)
+    expect(page).to have_css('#products .product-list-item').exactly(9).times
     Spree::Config.show_products_without_price = false
     Spree::Config.currency = 'CAN'
     visit spree.root_path
-    expect(page.all('#products .product-list-item').size).to eq(0)
+    expect(page).not_to have_css('#products .product-list-item')
   end
 
   it 'is able to display products priced under 10 dollars' do
@@ -282,7 +277,7 @@ describe 'Visiting Products', type: :feature, inaccessible: true do
     check 'Price_Range_$15.00_-_$18.00'
     within(:css, '#sidebar_products_search') { click_button 'Search' }
 
-    expect(page.all('#products .product-list-item').size).to eq(3)
+    expect(page).to have_css('#products .product-list-item').exactly(3).times
     tmp = page.all('#products .product-list-item a').map(&:text).flatten.compact
     tmp.delete('')
     expect(tmp.sort!).to eq(['Ruby on Rails Mug', 'Ruby on Rails Stein', 'Ruby on Rails Tote'])
@@ -294,13 +289,11 @@ describe 'Visiting Products', type: :feature, inaccessible: true do
     check 'Price_Range_$15.00_-_$18.00'
     within(:css, '#sidebar_products_search') { click_button 'Search' }
 
-    expect(page.all('#products .product-list-item').size).to eq(2)
-    products = page.all('#products .product-list-item span[itemprop=name]')
-    expect(products.count).to eq(2)
+    expect(page).to have_css('#products .product-list-item').twice
+    expect(page).to have_css('#products .product-list-item span[itemprop=name]').twice
 
     find('.pagination .next a').click
-    products = page.all('#products .product-list-item span[itemprop=name]')
-    expect(products.count).to eq(1)
+    expect(page).to have_css('#products .product-list-item span[itemprop=name]').once
   end
 
   it 'is able to display products priced 18 dollars and above' do
@@ -309,7 +302,7 @@ describe 'Visiting Products', type: :feature, inaccessible: true do
     check 'Price_Range_$20.00_or_over'
     within(:css, '#sidebar_products_search') { click_button 'Search' }
 
-    expect(page.all('#products .product-list-item').size).to eq(4)
+    expect(page).to have_css('#products .product-list-item').exactly(4).times
     tmp = page.all('#products .product-list-item a').map(&:text).flatten.compact
     tmp.delete('')
     expect(tmp.sort!).to eq(['Ruby on Rails Bag',
@@ -322,15 +315,10 @@ describe 'Visiting Products', type: :feature, inaccessible: true do
     product = FactoryBot.create(:base_product, description: nil, name: 'Sample', price: '19.99')
     visit spree.product_path(product)
     expect(page).to have_selector('form#add-to-cart-form')
-    expect(page).to have_selector('button#add-to-cart-button')
+    expect(page).to have_button(id: 'add-to-cart-button', disabled: false)
     expect(page).to have_content 'This product has no description'
-    wait_for_condition do
-      expect(page.find('#add-to-cart-button').disabled?).to eq(false)
-    end
     click_button 'add-to-cart-button'
-    wait_for_condition do
-      expect(page).to have_content(Spree.t(:shopping_cart))
-    end
+    expect(page).to have_content(Spree.t(:shopping_cart))
     expect(page).to have_content 'This product has no description'
   end
 

--- a/frontend/spec/features/products_spec.rb
+++ b/frontend/spec/features/products_spec.rb
@@ -341,19 +341,17 @@ describe 'Visiting Products', type: :feature, inaccessible: true do
       end
     end
   end
-  
+
   context 'when rendering the product description' do
     context 'when <script> tag exists' do
       it 'prevents the script from running', js: true do
         description = '<script>window.alert("Message")</script>'
         product = FactoryBot.create(:base_product, description: description, name: 'Sample', price: '19.99')
-        visit spree.product_path(product)
 
-        begin
-          page.driver.browser.switch_to.alert
-          fail "XSS alert exists"
-        rescue Selenium::WebDriver::Error::NoSuchAlertError
-        end
+        accept_alert(wait: 1) { visit spree.product_path(product) }
+        fail "XSS alert exists"
+
+      rescue Capybara::ModalNotFound
       end
 
       it 'returns sanitized js text in html' do

--- a/frontend/spec/features/taxons_spec.rb
+++ b/frontend/spec/features/taxons_spec.rb
@@ -83,7 +83,7 @@ describe 'viewing products', type: :feature, inaccessible: true do
     it 'is able to visit brand Ruby on Rails' do
       within(:css, '#taxonomies') { click_link 'Ruby on Rails' }
 
-      expect(page.all('#products .product-list-item').size).to eq(7)
+      expect(page).to have_css('#products .product-list-item').exactly(7).times
       tmp = page.all('#products .product-list-item a').map(&:text).flatten.compact
       tmp.delete('')
       array = ['Ruby on Rails Bag',
@@ -99,7 +99,7 @@ describe 'viewing products', type: :feature, inaccessible: true do
     it 'is able to visit brand Ruby' do
       within(:css, '#taxonomies') { click_link 'Ruby' }
 
-      expect(page.all('#products .product-list-item').size).to eq(1)
+      expect(page).to have_css('#products .product-list-item').once
       tmp = page.all('#products .product-list-item a').map(&:text).flatten.compact
       tmp.delete('')
       expect(tmp.sort!).to eq(['Ruby Baseball Jersey'])
@@ -108,7 +108,7 @@ describe 'viewing products', type: :feature, inaccessible: true do
     it 'is able to visit brand Apache' do
       within(:css, '#taxonomies') { click_link 'Apache' }
 
-      expect(page.all('#products .product-list-item').size).to eq(1)
+      expect(page).to have_css('#products .product-list-item').once
       tmp = page.all('#products .product-list-item a').map(&:text).flatten.compact
       tmp.delete('')
       expect(tmp.sort!).to eq(['Apache Baseball Jersey'])
@@ -117,7 +117,7 @@ describe 'viewing products', type: :feature, inaccessible: true do
     it 'is able to visit category Clothing' do
       click_link 'Clothing'
 
-      expect(page.all('#products .product-list-item').size).to eq(5)
+      expect(page).to have_css('#products .product-list-item').exactly(5).times
       tmp = page.all('#products .product-list-item a').map(&:text).flatten.compact
       tmp.delete('')
       expect(tmp.sort!).to eq(['Apache Baseball Jersey',
@@ -130,7 +130,7 @@ describe 'viewing products', type: :feature, inaccessible: true do
     it 'is able to visit category Mugs' do
       click_link 'Mugs'
 
-      expect(page.all('#products .product-list-item').size).to eq(2)
+      expect(page).to have_css('#products .product-list-item').twice
       tmp = page.all('#products .product-list-item a').map(&:text).flatten.compact
       tmp.delete('')
       expect(tmp.sort!).to eq(['Ruby on Rails Mug', 'Ruby on Rails Stein'])
@@ -139,7 +139,7 @@ describe 'viewing products', type: :feature, inaccessible: true do
     it 'is able to visit category Bags' do
       click_link 'Bags'
 
-      expect(page.all('#products .product-list-item').size).to eq(2)
+      expect(page).to have_css('#products .product-list-item').twice
       tmp = page.all('#products .product-list-item a').map(&:text).flatten.compact
       tmp.delete('')
       expect(tmp.sort!).to eq(['Ruby on Rails Bag', 'Ruby on Rails Tote'])

--- a/frontend/spec/features/template_rendering_spec.rb
+++ b/frontend/spec/features/template_rendering_spec.rb
@@ -1,14 +1,6 @@
 require 'spec_helper'
 
 describe 'Template rendering', type: :feature do
-  after do
-    Capybara.ignore_hidden_elements = true
-  end
-
-  before do
-    # Capybara.ignore_hidden_elements = false
-  end
-
   it 'layout should have canonical tag referencing site url' do
     Spree::Store.create!(code: 'spree', name: 'My Spree Store', url: 'spreestore.example.com', mail_from_address: 'test@example.com')
 

--- a/frontend/spec/features/template_rendering_spec.rb
+++ b/frontend/spec/features/template_rendering_spec.rb
@@ -6,13 +6,13 @@ describe 'Template rendering', type: :feature do
   end
 
   before do
-    Capybara.ignore_hidden_elements = false
+    # Capybara.ignore_hidden_elements = false
   end
 
   it 'layout should have canonical tag referencing site url' do
     Spree::Store.create!(code: 'spree', name: 'My Spree Store', url: 'spreestore.example.com', mail_from_address: 'test@example.com')
 
     visit spree.root_path
-    expect(find('link[rel=canonical]')[:href]).to eql('http://spreestore.example.com/')
+    expect(find('link[rel=canonical]', visible: false)[:href]).to eql('http://spreestore.example.com/')
   end
 end

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -90,16 +90,16 @@ RSpec.configure do |config|
     reset_spree_preferences
   end
 
-  config.after do
-    DatabaseCleaner.clean
-  end
-
   config.after(:each, type: :feature) do |example|
     missing_translations = page.body.scan(/translation missing: #{I18n.locale}\.(.*?)[\s<\"&]/)
     if missing_translations.any?
       puts "Found missing translations: #{missing_translations.inspect}"
       puts "In spec: #{example.location}"
     end
+  end
+
+  config.append_after do
+    DatabaseCleaner.clean
   end
 
   config.include FactoryBot::Syntax::Methods

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -119,4 +119,7 @@ RSpec.configure do |config|
   config.around :each, type: :feature do |ex|
     ex.run_with_retry retry: 3
   end
+
+  config.filter_run_including focus: true unless ENV['CI']
+  config.run_all_when_everything_filtered = true
 end

--- a/frontend/spec/support/add_to_cart.rb
+++ b/frontend/spec/support/add_to_cart.rb
@@ -2,12 +2,7 @@ def add_to_cart(product_name)
   visit spree.root_path
   click_link product_name
   expect(page).to have_selector('form#add-to-cart-form')
-  expect(page).to have_selector('button#add-to-cart-button')
-  wait_for_condition do
-    expect(page.find('#add-to-cart-button').disabled?).to eq(false)
-  end
+  expect(page).to have_selector(:button, id: 'add-to-cart-button', disabled: false)
   click_button 'add-to-cart-button'
-  wait_for_condition do
-    expect(page).to have_content(Spree.t(:shopping_cart))
-  end
+  expect(page).to have_content(Spree.t(:shopping_cart))
 end

--- a/frontend/spec/support/shared_contexts/checkout_address_book.rb
+++ b/frontend/spec/support/shared_contexts/checkout_address_book.rb
@@ -60,6 +60,6 @@ shared_context 'checkout address book' do
       address.address2.to_s,
       "#{address.city} #{address.state ? address.state.abbr : address.state_name} #{address.zipcode}",
       address.country.to_s
-    ].reject(&:empty?).join(' ')
+    ].reject(&:empty?).join("\n")
   end
 end


### PR DESCRIPTION
This updates Capybara to a current release and fixes relevant tests and Capybara usage.  It also shows a test which I believe is now correctly failing, but was previously being hidden by the non-waiting behavior of `all` in Capybara 2.x.  There are other Capybara related updates/improvements that could be done (`wait_for_ajax` really shouldn't be necessary) but will require more study of the expected behavior.  I'll try and work on those later if there is interest.