### PR TITLE
Fix/9416 blank flash when deleting country

### DIFF
--- a/core/app/models/spree/country.rb
+++ b/core/app/models/spree/country.rb
@@ -4,8 +4,8 @@ module Spree
     # https://github.com/rails/rails/issues/3458
     before_destroy :ensure_not_default
 
-    has_many :states, dependent: :destroy
     has_many :addresses, dependent: :restrict_with_error
+    has_many :states, dependent: :destroy
     has_many :zone_members,
              -> { where(zoneable_type: 'Spree::Country') },
              class_name: 'Spree::ZoneMember',

--- a/core/spec/models/spree/country_spec.rb
+++ b/core/spec/models/spree/country_spec.rb
@@ -55,23 +55,25 @@ describe Spree::Country, type: :model do
     end
   end
 
-  describe 'ensure default country in not deleted' do
-    before { Spree::Config[:default_country_id] = america.id }
+  describe 'ensure proper country deletion' do
+    context 'when deleting default country' do
+      before { Spree::Config[:default_country_id] = america.id }
 
-    context 'will not destroy country if it is default' do
-      subject { america.destroy }
+      it 'does not destroy country' do
+        expect(america.destroy).to be_falsy
+      end
 
-      it { is_expected.to be_falsy }
+      it 'sets correct error message' do
+        america.destroy
 
-      context 'error should be default country cannot be deleted' do
-        before { subject }
-
-        it { expect(america.errors[:base]).to include(Spree.t(:default_country_cannot_be_deleted)) }
+        expect(america.errors[:base]).to include(Spree.t(:default_country_cannot_be_deleted))
       end
     end
 
-    context 'will destroy if it is not a default' do
-      it { expect(canada.destroy).to be_truthy }
+    context 'when deleting not a default country' do
+      it 'destroys country successfully' do
+        expect(canada.destroy).to be_truthy
+      end
     end
   end
 

--- a/core/spec/models/spree/country_spec.rb
+++ b/core/spec/models/spree/country_spec.rb
@@ -71,8 +71,26 @@ describe Spree::Country, type: :model do
     end
 
     context 'when deleting not a default country' do
-      it 'destroys country successfully' do
-        expect(canada.destroy).to be_truthy
+      context 'when country has no dependent addresses' do
+        it 'destroys country successfully' do
+          expect(canada.destroy).to be_truthy
+        end
+      end
+
+      context 'when country has dependent addresses' do
+        before do
+          create(:ship_address, country: canada, zipcode: 'l3l 4p4')
+        end
+
+        it 'does not destroy country' do
+          expect(canada.destroy).to be_falsy
+        end
+
+        it 'sets correct error message' do
+          canada.destroy
+
+          expect(canada.errors[:base]).to include('Cannot delete record because dependent addresses exist')
+        end
       end
     end
   end


### PR DESCRIPTION
This PR fixes blank error message when deleting a country with dependent addresses.

Issue: https://github.com/spree/spree/issues/9416

Solution based on: https://github.com/rails/rails/issues/24526#issuecomment-317361937