### PR TITLE
It's fixes Fixes CVE-2019-13574 to version 3.7

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'stringex'
   s.add_dependency 'twitter_cldr', '~> 4.3'
   s.add_dependency 'sprockets-rails'
-  s.add_dependency 'mini_magick', '~> 4.8.0'
+  s.add_dependency 'mini_magick', '~> 4.9.4'
 
   s.add_development_dependency 'email_spec', '~> 1.6'
 end


### PR DESCRIPTION
[#9443 ](https://github.com/spree/spree/issues/9443)

In lib/mini_magick/image.rb in MiniMagick before 4.9.4, a fetched remote image filename could cause remote command execution because Image.open input is directly passed to Kernel#open, which accepts a '|' character followed by a command.

https://nvd.nist.gov/vuln/detail/CVE-2019-13574