### PR TITLE
Add query_track to find slow SQL queries

### DIFF
--- a/core/config/initializers/query_track.rb
+++ b/core/config/initializers/query_track.rb
@@ -1,0 +1,4 @@
+QueryTrack::Settings.configure do |config|
+  config.duration = 1
+  config.logs = true
+end

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -13,6 +13,7 @@ require 'premailer/rails'
 require 'ransack'
 require 'responders'
 require 'state_machines-activerecord'
+require 'query_track'
 
 # This is required because ActiveModel::Validations#invalid? conflicts with the
 # invalid state of a Payment. In the future this should be removed.

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'monetize', '~> 1.9'
   s.add_dependency 'paranoia', '~> 2.4.2'
   s.add_dependency 'premailer-rails'
+  s.add_dependency 'query_track', '~> 0.0.7'
   s.add_dependency 'acts-as-taggable-on', '~> 6.0'
   s.add_dependency 'rails', '~> 5.2.1', '>= 5.2.1.1'
   s.add_dependency 'ransack', '~> 2.1.1'


### PR DESCRIPTION
I suggest adding a gem query_track which will be show in the console info about SQL queries which slower than 1s (for example, this is configurable). It helps for developers will be easier to profile the database and improve performance.

Example of log (from another project):
![console](https://user-images.githubusercontent.com/5091851/62291900-c02b2a00-b46d-11e9-95de-c2d5eb98de21.jpg)
