### PR TITLE
Enable to set time parts of a promotion period

### DIFF
--- a/backend/app/views/spree/admin/promotions/_form.html.erb
+++ b/backend/app/views/spree/admin/promotions/_form.html.erb
@@ -56,12 +56,12 @@
 
     <div id="starts_at_field" class="form-group">
       <%= f.label :starts_at %>
-      <%= f.text_field :starts_at, value: datepicker_field_value(@promotion.starts_at), class: 'datepicker datepicker-from form-control' %>
+      <%= f.datetime_field :starts_at, class: 'form-control' %>
     </div>
 
     <div id="expires_at_field" class="form-group">
       <%= f.label :expires_at %>
-      <%= f.text_field :expires_at, value: datepicker_field_value(@promotion.expires_at), class: 'datepicker datepicker-to form-control' %>
+      <%= f.datetime_field :expires_at, class: 'form-control' %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
The type of the fields is `datetime`, however their time parts cannot be set with datepicker. So, it uses `datetime_field` instead.

![image](https://user-images.githubusercontent.com/3321320/62404227-9852d800-b5cd-11e9-9601-7eca3a4d1f64.png)