### PR TITLE
concat(prepend) icon with html input labels correctly

### DIFF
--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -163,7 +163,7 @@ module Spree
         options.delete(:no_text)
         if icon_name
           icon = content_tag(:span, '', class: "#{'mr-2' unless text.empty?} icon icon-#{icon_name}")
-          text.insert(0, icon + ' ')
+          text = "#{icon} #{text}"
         end
         link_to(text.html_safe, url, options)
       end
@@ -176,7 +176,7 @@ module Spree
       def button(text, icon_name = nil, button_type = 'submit', options = {})
         if icon_name
           icon = content_tag(:span, '', class: "icon icon-#{icon_name}")
-          text.insert(0, icon + ' ')
+          text = "#{icon} #{text}"
         end
         button_tag(
           text.html_safe,
@@ -207,7 +207,7 @@ module Spree
 
           if html_options[:icon]
             icon = content_tag(:span, '', class: "icon icon-#{html_options[:icon]}")
-            text.insert(0, icon + ' ')
+            text = "#{icon} #{text}"
           end
 
           link_to(text.html_safe, url, html_options)


### PR DESCRIPTION
when i18n cache is enabled, String#insert is modifying the cache entry which in turn prepends icons everytime we fetch text from i18n

To reproduce the issue, add these following lines in one of the initializers
```
I18n::Backend::Simple.send(:include, I18n::Backend::Cache)
I18n.cache_store = ActiveSupport::Cache.lookup_store(:memory_store)
```
As you can see in the screenshot below, Everytime I refresh the page, icon is being prepended. 

![image](https://user-images.githubusercontent.com/3734270/62427278-50879a00-b70e-11e9-81fd-75630bcf8d84.png)
