### PR TITLE
Bump ransack to 2.3.0 for Rails 6 support

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'premailer-rails'
   s.add_dependency 'acts-as-taggable-on', '~> 6.0'
   s.add_dependency 'rails', '~> 5.2.1', '>= 5.2.1.1'
-  s.add_dependency 'ransack', '~> 2.1.1'
+  s.add_dependency 'ransack', '~> 2.3.0'
   s.add_dependency 'responders'
   s.add_dependency 'state_machines-activerecord', '~> 0.5'
   s.add_dependency 'stringex'


### PR DESCRIPTION
https://github.com/activerecord-hackery/ransack/releases/tag/v2.3.0