### PR TITLE
Add presence validation to display_on of ShippingMethod

### DIFF
--- a/backend/spec/features/admin/configuration/shipping_methods_spec.rb
+++ b/backend/spec/features/admin/configuration/shipping_methods_spec.rb
@@ -29,6 +29,7 @@ describe 'Shipping Methods', type: :feature do
       click_link 'New Shipping Method'
 
       fill_in 'shipping_method_name', with: 'bullock cart'
+      select 'Both', from: 'Display'
 
       within('#shipping_method_categories_field', match: :first) do
         check first("input[type='checkbox']")['name']

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -21,7 +21,7 @@ module Spree
 
     belongs_to :tax_category, class_name: 'Spree::TaxCategory', optional: true
 
-    validates :name, presence: true
+    validates :name, :display_on, presence: true
 
     validate :at_least_one_shipping_category
 

--- a/core/spec/models/spree/shipping_method_spec.rb
+++ b/core/spec/models/spree/shipping_method_spec.rb
@@ -43,6 +43,11 @@ describe Spree::ShippingMethod, type: :model do
       expect(subject.errors.messages[:name].size).to eq(1)
     end
 
+    it 'validates presence of display_on' do
+      subject.valid?
+      expect(subject.errors.messages[:display_on].size).to eq(1)
+    end
+
     context 'shipping category' do
       context 'is required' do
         before { subject.valid? }


### PR DESCRIPTION
* Why was this change necessary?
Resolved #9211 

ShippingMethod will be picked up for calculating pricing for an order. So if it doesn't have value on display_on, it leads us to get some misleading error message (https://github.com/spree/spree/issues/9211). So this pr, we attempt to fix this error by adding a presence validation for it. To void conflicting with this PR as well https://github.com/spree/spree/pull/8430

* How does it address the problem?
By adding a presence validation for display_on, we will make sure that, the old shipping method won't be affected, it will still shown as None value in DisplayOn.

But this PR will force the admin, they have to pick up a suitable display on method for shipping method instead of leave it blank

## Still keep the old behavior for exiting shipping methods (Show NONE for empty displayon)
<img width="1170" alt="Screenshot 2019-09-02 12 02 06" src="https://user-images.githubusercontent.com/1973623/64091304-bdc43480-cd79-11e9-9ea0-9856bbf967eb.png">

## but we admin want to update an existing shipping method which is none display on
<img width="1178" alt="Screenshot 2019-09-02 12 01 57" src="https://user-images.githubusercontent.com/1973623/64091301-bb61da80-cd79-11e9-8d02-92c02ca0409e.png">


# Checklists
- [x] Check db sample of Shipping Method
- [x] Add validation to model
- [x] Update specs
