### PR TITLE
Remove disqus embed from Spree Guides

### DIFF
--- a/guides/package.json
+++ b/guides/package.json
@@ -5,7 +5,6 @@
   "author": "Spark Solutions <we@sparksolutions.co>",
   "dependencies": {
     "@emotion/core": "^10.0.2",
-    "disqus-react": "^1.0.6",
     "emotion": "^10.0.0",
     "emotion-server": "^10.0.9",
     "gatsby": "^2.0.19",

--- a/guides/src/templates/guide.js
+++ b/guides/src/templates/guide.js
@@ -3,7 +3,6 @@ import * as React from 'react'
 import PropTypes from 'prop-types'
 import { graphql } from 'gatsby'
 import RehypeReact from 'rehype-react'
-import { DiscussionEmbed } from 'disqus-react'
 
 // --- Components
 import Layout from '../components/Layout'
@@ -50,11 +49,6 @@ const renderAst = new RehypeReact({
 
 export default function Template({ data }) {
   const { guide } = data
-  const disqusShortname = 'spree-guides'
-  const disqusConfig = {
-    identifier: data.id,
-    title: guide.frontmatter.title
-  }
 
   let pageTitle = guide.frontmatter.title
   if (guide.fields.rootSection) {
@@ -78,9 +72,6 @@ export default function Template({ data }) {
       <article className="mt2">
         <H1>{guide.frontmatter.title}</H1>
         {renderAst(guide.htmlAst)}
-        {!guide.fields.isIndex &&
-          <DiscussionEmbed shortname={disqusShortname} config={disqusConfig} />
-        }
       </article>
     </Layout>
   )

--- a/guides/yarn.lock
+++ b/guides/yarn.lock
@@ -4158,11 +4158,6 @@ dir-glob@^2.0.0:
     arrify "^1.0.1"
     path-type "^3.0.0"
 
-disqus-react@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/disqus-react/-/disqus-react-1.0.6.tgz#35540425cf105075e9f2cc1f18e7b03f63a55879"
-  integrity sha512-rH3oq0FsjX4lIfRu2AmannoLVEv4n7tlwrwQ/aCnFD/j7ClVogpU72WOuj8OwtdQYX8cEYUbaurdwTqSTD2SFg==
-
 dns-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/dns-equal/-/dns-equal-1.0.0.tgz#b39e7f1da6eb0a75ba9c17324b34753c47e0654d"


### PR DESCRIPTION
Rather than comment discussions we should promote updating and extending documentation