### PR TITLE
Fixes #9527 acts as taggable on migration fails when theres no acts as

### DIFF
--- a/core/db/migrate/20160511072249_change_collation_for_spree_tag_names.rb
+++ b/core/db/migrate/20160511072249_change_collation_for_spree_tag_names.rb
@@ -2,7 +2,7 @@
 # work properly
 class ChangeCollationForSpreeTagNames < ActiveRecord::Migration[4.2]
   def up
-    if ActsAsTaggableOn::Utils.using_mysql?
+    if defined?(ActsAsTaggableOn) && ActsAsTaggableOn::Utils.using_mysql?
       execute("ALTER TABLE spree_tags MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
     end
   end


### PR DESCRIPTION
taggable on gem installed

Tag support was removed in Spree 4.0, with this fix it will be easier to
migrate Spree 3.7 applications to 4.0