### PR TITLE
Suppress exception for skipped callback action

### DIFF
--- a/frontend/app/controllers/spree/store_controller.rb
+++ b/frontend/app/controllers/spree/store_controller.rb
@@ -3,7 +3,7 @@ module Spree
     include Spree::Core::ControllerHelpers::Order
 
     skip_before_action :set_current_order, only: :cart_link
-    skip_before_action :verify_authenticity_token, only: :ensure_cart
+    skip_before_action :verify_authenticity_token, only: :ensure_cart, raise: false
 
     def forbidden
       render 'spree/shared/forbidden', layout: Spree::Config[:layout], status: 403


### PR DESCRIPTION
To resolve issue #9545, we need to add

```ruby
raise: false
```
to
```ruby
skip_before_action :verify_authenticity_token, only: :ensure_cart
```
to suppress skipped callback which starts throwing exception in Rails 5.