### PR TITLE
Add Store Filter to Payment method

### DIFF
--- a/backend/app/controllers/spree/admin/payment_methods_controller.rb
+++ b/backend/app/controllers/spree/admin/payment_methods_controller.rb
@@ -54,6 +54,7 @@ module Spree
       end
 
       def load_data
+        @stores = Spree::Store.all
         @providers = Gateway.providers.sort_by(&:name)
       end
 

--- a/backend/app/views/spree/admin/payment_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/_form.html.erb
@@ -15,6 +15,10 @@
           <% end %>
         <% end %>
       </div>
+      <div data-hook="store" class="form-group">
+        <%= label_tag :payment_method_store, Spree.t(:store) %>
+        <%= collection_select(:payment_method, :store_id, @stores, :id, :name, { include_blank: true }, {id: 'store_id', class: 'select2'}) %>
+      </div>
       <div data-hook="display" class="form-group">
         <%= label_tag :payment_method_display_on, Spree.t(:display) %>
         <%= select(:payment_method, :display_on, Spree::PaymentMethod::DISPLAY.collect { |display| [Spree.t(display), display.to_s] }, {}, {class: 'select2'}) %>

--- a/backend/spec/features/admin/configuration/payment_methods_spec.rb
+++ b/backend/spec/features/admin/configuration/payment_methods_spec.rb
@@ -4,6 +4,7 @@ describe 'Payment Methods', type: :feature do
   stub_authorization!
 
   before do
+    create(:store)
     visit spree.admin_payment_methods_path
   end
 
@@ -32,6 +33,7 @@ describe 'Payment Methods', type: :feature do
       fill_in 'payment_method_name', with: 'check90'
       fill_in 'payment_method_description', with: 'check90 desc'
       select 'PaymentMethod::Check', from: 'gtwy-type'
+      select 'Spree', from: 'store_id'
       click_button 'Create'
       expect(page).to have_content('successfully created!')
     end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -369,8 +369,8 @@ module Spree
       payment_state == 'paid' || payment_state == 'credit_owed'
     end
 
-    def available_payment_methods
-      @available_payment_methods ||= collect_payment_methods
+    def available_payment_methods(store = nil)
+      @available_payment_methods ||= collect_payment_methods(store)
     end
 
     def insufficient_stock_lines
@@ -683,8 +683,8 @@ module Spree
       self.token ||= generate_token
     end
 
-    def collect_payment_methods
-      PaymentMethod.available_on_front_end.select { |pm| pm.available_for_order?(self) }
+    def collect_payment_methods(store = nil)
+      PaymentMethod.available_on_front_end.select { |pm| pm.available_for_order?(self) && pm.available_for_store?(store) }
     end
 
     def credit_card_nil_payment?(attributes)

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -12,6 +12,8 @@ module Spree
 
     validates :name, presence: true
 
+    belongs_to :store
+
     with_options dependent: :restrict_with_error do
       has_many :payments, class_name: 'Spree::Payment', inverse_of: :payment_method
       has_many :credit_cards, class_name: 'Spree::CreditCard'
@@ -77,7 +79,7 @@ module Spree
     end
 
     def available_for_store?(store)
-      return true if store.blank?
+      return true if store.blank? || store_id.blank?
 
       store_id == store.id
     end

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -75,5 +75,11 @@ module Spree
     def available_for_order?(_order)
       true
     end
+
+    def available_for_store?(store)
+      return true if store.blank?
+
+      store_id == store.id
+    end
   end
 end

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -1,6 +1,7 @@
 module Spree
   class Store < Spree::Base
     has_many :orders, class_name: 'Spree::Order'
+    has_many :payment_methods, class_name: 'Spree::PaymentMethod'
 
     with_options presence: true do
       validates :code, uniqueness: { case_sensitive: false, allow_blank: true }

--- a/core/db/migrate/20191005121504_add_store_id_to_payment_methods.rb
+++ b/core/db/migrate/20191005121504_add_store_id_to_payment_methods.rb
@@ -1,0 +1,5 @@
+class AddStoreIdToPaymentMethods < ActiveRecord::Migration[5.2]
+  def change
+    add_column :spree_payment_methods, :store_id, :integer unless column_exists?(:spree_payment_methods, :store_id)
+  end
+end

--- a/core/db/migrate/20191005121504_add_store_id_to_payment_methods.rb
+++ b/core/db/migrate/20191005121504_add_store_id_to_payment_methods.rb
@@ -1,5 +1,7 @@
 class AddStoreIdToPaymentMethods < ActiveRecord::Migration[5.2]
   def change
-    add_column :spree_payment_methods, :store_id, :integer unless column_exists?(:spree_payment_methods, :store_id)
+    unless column_exists?(:spree_payment_methods, :store_id)
+      add_reference :spree_payment_methods, :store, references: :spree_stores, index: true
+    end
   end
 end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -492,8 +492,8 @@ describe Spree::Order, type: :model do
 
   # Regression test for #4199
   context '#available_payment_methods' do
-    let(:ok_method) { double :payment_method, available_for_order?: true }
-    let(:no_method) { double :payment_method, available_for_order?: false }
+    let(:ok_method) { double :payment_method, available_for_order?: true, available_for_store?: true }
+    let(:no_method) { double :payment_method, available_for_order?: false, available_for_store?: true }
     let(:methods) { [ok_method, no_method] }
 
     it 'includes frontend payment methods' do
@@ -520,6 +520,7 @@ describe Spree::Order, type: :model do
 
     it 'does not include a payment method that is not suitable for this order' do
       allow(Spree::PaymentMethod).to receive(:available_on_front_end).and_return(methods)
+
       expect(order.available_payment_methods).to match_array [ok_method]
     end
   end

--- a/frontend/app/views/spree/checkout/_payment.html.erb
+++ b/frontend/app/views/spree/checkout/_payment.html.erb
@@ -41,7 +41,7 @@
     <%= render partial: 'spree/checkout/payment/storecredit' %>
 
     <ul class="list-group" id="payment-method-fields" data-hook>
-      <% @order.available_payment_methods.each do |method| %>
+      <% @order.available_payment_methods(current_store).each do |method| %>
         <li class="list-group-item radio">
           <label>
             <%= radio_button_tag "order[payments_attributes][][payment_method_id]", method.id, method == @order.available_payment_methods.first %>

--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -190,8 +190,10 @@ describe 'Checkout', type: :feature, inaccessible: true, js: true do
   end
 
   context 'when several payment methods are available', js: true do
-    let(:credit_cart_payment) { create(:credit_card_payment_method) }
-    let(:check_payment) { create(:check_payment_method) }
+    let(:store) { create(:store) }
+    let(:credit_cart_payment) { create(:credit_card_payment_method, store: store) }
+    let(:check_payment) { create(:check_payment_method, store: store) }
+    let(:unsupported_payment_method) { create(:payment_method) }
 
     before do
       order = OrderWalkthrough.up_to(:payment)
@@ -215,6 +217,10 @@ describe 'Checkout', type: :feature, inaccessible: true, js: true do
       payment_method_css = '#payment_method_'
       expect(page).to have_css("#{payment_method_css}#{check_payment.id}", visible: true)
       expect(page).to have_css("#{payment_method_css}#{credit_cart_payment.id}", visible: :hidden)
+    end
+
+    it 'only returns supported payment method of current store' do
+      expect(page).to have_css("#payment_method_#{unsupported_payment_method.id}", visible: :hidden)
     end
   end
 

--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -190,14 +190,14 @@ describe 'Checkout', type: :feature, inaccessible: true, js: true do
   end
 
   context 'when several payment methods are available', js: true do
-    let(:store) { create(:store) }
-    let(:credit_cart_payment) { create(:credit_card_payment_method, store: store) }
-    let(:check_payment) { create(:check_payment_method, store: store) }
-    let(:unsupported_payment_method) { create(:payment_method) }
+    let!(:current_store) { create(:store, default: true) }
+    let(:credit_cart_payment) { create(:credit_card_payment_method) }
+    let(:check_payment) { create(:check_payment_method) }
+    let(:unsupported_payment) { create(:check_payment_method, store: create(:store)) }
 
     before do
       order = OrderWalkthrough.up_to(:payment)
-      allow(order).to receive_messages(available_payment_methods: [check_payment, credit_cart_payment])
+      allow(order).to receive_messages(available_payment_methods: [check_payment, credit_cart_payment, unsupported_payment])
       order.user = create(:user)
       order.update_with_updater!
 
@@ -220,7 +220,7 @@ describe 'Checkout', type: :feature, inaccessible: true, js: true do
     end
 
     it 'only returns supported payment method of current store' do
-      expect(page).to have_css("#payment_method_#{unsupported_payment_method.id}", visible: :hidden)
+      expect(page).to have_css("#payment_method_#{unsupported_payment.id}", visible: :hidden)
     end
   end
 


### PR DESCRIPTION
# Why was this change necessary?
Resolved https://github.com/spree/spree/issues/9401

# How does it address the problem?

Added a new association to PaymentMethod to link to Store. We also update the admin UI to allow Admin to update store for each payment method.

Finally, we added store filter to payment source in Payment steps of checkout flow

### Admin UI
![Screenshot from 2019-10-06 00-49-10](https://user-images.githubusercontent.com/1973623/66258750-37b16880-e7d3-11e9-9f76-a21624622f8d.png)

### FE UI
![Screenshot from 2019-10-06 13-03-15](https://user-images.githubusercontent.com/1973623/66265031-b640f100-e839-11e9-983d-93e4d980259f.png)

