### PR TITLE
Lock sprockets gem at 3.7

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'state_machines-activemodel', '~> 0.7'
   s.add_dependency 'stringex'
   s.add_dependency 'twitter_cldr', '~> 4.3'
+  s.add_dependency 'sprockets', '~> 3.7'
   s.add_dependency 'sprockets-rails'
   s.add_dependency 'mini_magick', '~> 4.9.4'
   s.add_dependency 'image_processing', '~> 1.2'


### PR DESCRIPTION
4.0 has some serious issues and isn't stable enough for now