### PR TITLE
fix: taxon.name wildcard matching

### DIFF
--- a/core/app/finders/spree/taxons/find.rb
+++ b/core/app/finders/spree/taxons/find.rb
@@ -44,6 +44,10 @@ module Spree
         name.present?
       end
 
+      def name_matcher
+        Spree::Taxon.arel_table[:name].matches("%#{name}%")
+      end
+
       def by_ids(taxons)
         return taxons unless ids?
 
@@ -71,7 +75,7 @@ module Spree
       def by_name(taxons)
         return taxons unless name?
 
-        taxons.where(name: name)
+        taxons.where(name_matcher)
       end
     end
   end


### PR DESCRIPTION
The `GET /taxons` endpoint claims to match names by wild-card and partial-word match search however it does not. This uses the same name matcher as found in products.