### PR TITLE
Lock acts-as-taggable-on on 6.0.x

### DIFF
--- a/core/lib/spree/core/version.rb
+++ b/core/lib/spree/core/version.rb
@@ -1,5 +1,5 @@
 module Spree
   def self.version
-    '3.7.7'
+    '3.7.8'
   end
 end

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'paperclip', '~> 6.1.0'
   s.add_dependency 'paranoia', '~> 2.4.1'
   s.add_dependency 'premailer-rails'
-  s.add_dependency 'acts-as-taggable-on', '~> 6.0'
+  s.add_dependency 'acts-as-taggable-on', '~> 6.0.0'
   s.add_dependency 'rails', '~> 5.2.1', '>= 5.2.1.1'
   s.add_dependency 'ransack', '~> 2.1.1'
   s.add_dependency 'responders'


### PR DESCRIPTION
6.5.0 doesn't play nicely with Rails 5.2