### PR TITLE
Fixes security issue with API v2 Order information

### DIFF
--- a/api/app/controllers/spree/api/v2/storefront/order_status_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/order_status_controller.rb
@@ -5,6 +5,8 @@ module Spree
         class OrderStatusController < ::Spree::Api::V2::BaseController
           include Spree::Api::V2::Storefront::OrderConcern
 
+          before_action :ensure_order_token
+
           def show
             render_serialized_payload { serialize_resource(resource) }
           end
@@ -24,6 +26,10 @@ module Spree
 
           def resource_serializer
             Spree::Api::Dependencies.storefront_cart_serializer.constantize
+          end
+
+          def ensure_order_token
+            raise ActiveRecord::RecordNotFound unless order_token
           end
         end
       end

--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -162,6 +162,8 @@ paths:
         - $ref: '#/components/parameters/OrderParam'
         - $ref: '#/components/parameters/CartIncludeParam'
         - $ref: '#/components/parameters/SparseFieldsParam'
+      security:
+        - orderToken: []
   '/cart':
     post:
       description: >-

--- a/api/spec/requests/spree/api/v2/storefront/order_status_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/order_status_spec.rb
@@ -6,16 +6,26 @@ describe 'Storefront API v2 OrderStatus spec', type: :request do
   include_context 'API v2 tokens'
 
   describe '#show' do
-    context 'as a guest user' do
-      before { get "/api/v2/storefront/order_status/#{order.number}" }
+    context 'with existing Order number' do
+      context 'as a guest user without token' do
+        before { get "/api/v2/storefront/order_status/#{order.number}" }
 
-      it_behaves_like 'returns valid cart JSON'
-    end
+        it_behaves_like 'returns 404 HTTP status'
+      end
 
-    context 'as a guest user with token' do
-      before { get "/api/v2/storefront/order_status/#{order.number}", headers: headers_order_token }
+      context 'as a guest user with invalid token' do
+        let(:headers_order_token) { { 'X-Spree-Order-Token' => 'WRONG' } }
 
-      it_behaves_like 'returns valid cart JSON'
+        before { get "/api/v2/storefront/order_status/#{order.number}", headers: headers_order_token }
+
+        it_behaves_like 'returns 404 HTTP status'
+      end
+
+      context 'as a guest user with valid token' do
+        before { get "/api/v2/storefront/order_status/#{order.number}", headers: headers_order_token }
+
+        it_behaves_like 'returns valid cart JSON'
+      end
     end
 
     context 'with non-existing Order number' do


### PR DESCRIPTION
Attacker could expose Order information using brute force to guess
Order numbers. This patch fixes it by requiring Order token to obtain
Order information from API v2 Order Status endpoint.