### PR TITLE
Removes money deprecation warning

### DIFF
--- a/core/lib/spree/money.rb
+++ b/core/lib/spree/money.rb
@@ -18,8 +18,8 @@ module Spree
     delegate    :cents, :currency, to: :money
 
     def initialize(amount, options = {})
-      set_default_currency(options)
-      set_default_rounding_mode
+      use_default_currency(options)
+      use_default_rounding_mode
 
       @money   = Monetize.parse([amount, (options[:currency] || Spree::Config[:currency])].join)
       @options = Spree::Money.default_formatting_rules.merge(options)
@@ -65,13 +65,13 @@ module Spree
       money == obj.money
     end
 
-    def set_default_currency(options)
+    def use_default_currency(options)
       currency = options[:currency] || Spree::Config[:currency]
-      ::Money.default_currency=(currency)
+      ::Money.default_currency = currency
     end
 
-    def set_default_rounding_mode
-      ::Money.rounding_mode=(BigDecimal::ROUND_HALF_UP)
+    def use_default_rounding_mode
+      ::Money.rounding_mode = BigDecimal::ROUND_HALF_UP
     end
 
     private

--- a/core/lib/spree/money.rb
+++ b/core/lib/spree/money.rb
@@ -18,6 +18,9 @@ module Spree
     delegate    :cents, :currency, to: :money
 
     def initialize(amount, options = {})
+      set_default_currency(options)
+      set_default_rounding_mode
+
       @money   = Monetize.parse([amount, (options[:currency] || Spree::Config[:currency])].join)
       @options = Spree::Money.default_formatting_rules.merge(options)
     end
@@ -60,6 +63,15 @@ module Spree
 
     def ==(obj)
       money == obj.money
+    end
+
+    def set_default_currency(options)
+      currency = options[:currency] || Spree::Config[:currency]
+      ::Money.default_currency=(currency)
+    end
+
+    def set_default_rounding_mode
+      ::Money.rounding_mode=(BigDecimal::ROUND_HALF_UP)
     end
 
     private

--- a/core/lib/spree/money.rb
+++ b/core/lib/spree/money.rb
@@ -1,6 +1,7 @@
 require 'money'
 
 Money.locale_backend = :i18n
+Money.rounding_mode = BigDecimal::ROUND_HALF_UP
 
 module Spree
   class Money
@@ -18,9 +19,7 @@ module Spree
     delegate    :cents, :currency, to: :money
 
     def initialize(amount, options = {})
-      use_default_currency(options)
-      use_default_rounding_mode
-
+      use_default_currency
       @money   = Monetize.parse([amount, (options[:currency] || Spree::Config[:currency])].join)
       @options = Spree::Money.default_formatting_rules.merge(options)
     end
@@ -65,13 +64,9 @@ module Spree
       money == obj.money
     end
 
-    def use_default_currency(options)
-      currency = options[:currency] || Spree::Config[:currency]
+    def use_default_currency
+      currency = Spree::Store.default.default_currency || Spree::Config[:currency]
       ::Money.default_currency = currency
-    end
-
-    def use_default_rounding_mode
-      ::Money.rounding_mode = BigDecimal::ROUND_HALF_UP
     end
 
     private


### PR DESCRIPTION
Removes money deprecation warning by setting default currency and default rounding mode. Fixes https://github.com/spree/spree/issues/9658