### PR TITLE
Frontend performance optimization

### DIFF
--- a/api/app/controllers/spree/api/v1/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/v1/checkouts_controller.rb
@@ -2,13 +2,7 @@ module Spree
   module Api
     module V1
       class CheckoutsController < Spree::Api::BaseController
-        before_action :associate_user, only: :update
         before_action :load_order_with_lock, only: [:next, :advance, :update]
-
-        include Spree::Core::ControllerHelpers::Auth
-        include Spree::Core::ControllerHelpers::Order
-        # This before_action comes from Spree::Core::ControllerHelpers::Order
-        skip_before_action :set_current_order
 
         def next
           authorize! :update, @order, order_token

--- a/core/app/helpers/spree/products_helper.rb
+++ b/core/app/helpers/spree/products_helper.rb
@@ -1,5 +1,7 @@
 module Spree
   module ProductsHelper
+    include BaseHelper
+
     # returns the formatted price for the specified variant as a full price or a difference depending on configuration
     def variant_price(variant)
       if Spree::Config[:show_variant_full_price]
@@ -55,11 +57,11 @@ module Spree
       end
     end
 
-    def cache_key_for_products(products = @products, additional_cache_key = '')
+    def cache_key_for_products(products = @products)
       count = products.count
       max_updated_at = (products.maximum(:updated_at) || Date.today).to_s(:number)
-      products_cache_keys = "spree/products/all-#{params[:page]}-#{max_updated_at}-#{count}"
-      (common_product_cache_keys + [products_cache_keys] + [additional_cache_key]).compact.join('/')
+      products_cache_keys = "spree/products/all-#{params[:page]}-#{max_updated_at}-#{count}-#{@taxon&.id}"
+      (common_product_cache_keys + [products_cache_keys]).compact.join('/')
     end
 
     def cache_key_for_product(product = @product)
@@ -120,8 +122,7 @@ module Spree
                                  images: { attachment_attachment: :blob }
                                ]
                              ).
-                             limit(Spree::Config[:products_per_page]).
-                             to_a
+                             limit(Spree::Config[:products_per_page])
     end
 
     def common_product_cache_keys

--- a/core/app/helpers/spree/products_helper.rb
+++ b/core/app/helpers/spree/products_helper.rb
@@ -55,11 +55,11 @@ module Spree
       end
     end
 
-    def cache_key_for_products
-      count = @products.count
-      max_updated_at = (@products.maximum(:updated_at) || Date.today).to_s(:number)
+    def cache_key_for_products(products = @products, additional_cache_key = '')
+      count = products.count
+      max_updated_at = (products.maximum(:updated_at) || Date.today).to_s(:number)
       products_cache_keys = "spree/products/all-#{params[:page]}-#{max_updated_at}-#{count}"
-      (common_product_cache_keys + [products_cache_keys]).compact.join('/')
+      (common_product_cache_keys + [products_cache_keys] + [additional_cache_key]).compact.join('/')
     end
 
     def cache_key_for_product(product = @product)

--- a/core/app/helpers/spree/products_helper.rb
+++ b/core/app/helpers/spree/products_helper.rb
@@ -124,11 +124,11 @@ module Spree
                              to_a
     end
 
-    private
-
     def common_product_cache_keys
-      [I18n.locale, current_currency] + price_options_cache_key
+      base_cache_key + price_options_cache_key
     end
+
+    private
 
     def price_options_cache_key
       current_price_options.sort.map(&:last).map do |value|

--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -47,9 +47,9 @@ module Spree
       spree_roles.any? { |role| role.name == role_in_question.to_s }
     end
 
-    def last_incomplete_spree_order(store)
+    def last_incomplete_spree_order(store, options = {})
       orders.where(store: store).incomplete.
-        includes(line_items: [variant: [:images, :option_values, :product]]).
+        includes(options[:includes]).
         order('created_at DESC').
         first
     end

--- a/core/lib/generators/spree/install/install_generator.rb
+++ b/core/lib/generators/spree/install/install_generator.rb
@@ -54,6 +54,9 @@ module Spree
         Disallow: /account
         Disallow: /api
         Disallow: /password
+        Disallow: /api_tokens
+        Disallow: /cart_link
+        Disallow: /account_link
       ROBOTS
     end
 

--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -5,8 +5,6 @@ module Spree
         extend ActiveSupport::Concern
 
         included do
-          before_action :set_current_order
-
           helper_method :current_order
           helper_method :simple_current_order
         end

--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -26,6 +26,7 @@ module Spree
         # The current incomplete order from the token for use in cart and during checkout
         def current_order(options = {})
           options[:create_order_if_necessary] ||= false
+          options[:includes] ||= true
 
           if @current_order
             @current_order.last_ip_address = ip_address
@@ -64,8 +65,8 @@ module Spree
 
         private
 
-        def last_incomplete_order
-          @last_incomplete_order ||= try_spree_current_user.last_incomplete_spree_order(current_store)
+        def last_incomplete_order(includes = {})
+          @last_incomplete_order ||= try_spree_current_user.last_incomplete_spree_order(current_store, includes: includes)
         end
 
         def current_order_params
@@ -75,8 +76,15 @@ module Spree
         def find_order_by_token_or_user(options = {}, with_adjustments = false)
           options[:lock] ||= false
 
+          includes = if options[:includes]
+                       { line_items: [variant: [:images, :option_values, :product]] }
+                     else
+                       {}
+                     end
+
           # Find any incomplete orders for the token
-          incomplete_orders = Spree::Order.incomplete.includes(line_items: [variant: [:images, :option_values, :product]])
+          incomplete_orders = Spree::Order.incomplete.includes(includes)
+
           token_order_params = current_order_params.except(:user_id)
           order = if with_adjustments
                     incomplete_orders.includes(:adjustments).lock(options[:lock]).find_by(token_order_params)
@@ -85,7 +93,7 @@ module Spree
                   end
 
           # Find any incomplete orders for the current user
-          order = last_incomplete_order if order.nil? && try_spree_current_user
+          order = last_incomplete_order(includes) if order.nil? && try_spree_current_user
 
           order
         end

--- a/core/lib/spree/core/controller_helpers/store.rb
+++ b/core/lib/spree/core/controller_helpers/store.rb
@@ -43,7 +43,7 @@ module Spree
         private
 
         def current_tax_zone
-          @current_tax_zone ||= current_order.try(:tax_zone) || Spree::Zone.default_tax
+          @current_tax_zone ||= @current_order&.tax_zone || Spree::Zone.default_tax
         end
       end
     end

--- a/core/spec/helpers/products_helper_spec.rb
+++ b/core/spec/helpers/products_helper_spec.rb
@@ -214,7 +214,7 @@ THIS IS THE BEST PRODUCT EVER!
           allow(@products).to receive(:maximum).with(:updated_at) { updated_at }
         end
 
-        it { is_expected.to eq('en/USD/spree/zones/new/spree/products/all-10-20111213-5') }
+        it { is_expected.to eq('en/USD/spree/zones/new/spree/products/all-10-20111213-5-') }
       end
 
       context 'when there is no considered maximum updated date' do
@@ -226,7 +226,19 @@ THIS IS THE BEST PRODUCT EVER!
           allow(Date).to receive(:today) { today }
         end
 
-        it { is_expected.to eq('en/USD/spree/zones/new/spree/products/all-10-20131211-1234567') }
+        it { is_expected.to eq('en/USD/spree/zones/new/spree/products/all-10-20131211-1234567-') }
+      end
+
+      context 'with Taxon ID present' do
+        let(:updated_at) { Date.new(2011, 12, 13) }
+
+        before do
+          @taxon = create(:taxon)
+          allow(@products).to receive(:count).and_return(5)
+          allow(@products).to receive(:maximum).with(:updated_at) { updated_at }
+        end
+
+        it { is_expected.to eq("en/USD/spree/zones/new/spree/products/all-10-20111213-5-#{@taxon.id}") }
       end
     end
 

--- a/core/spec/lib/spree/core/controller_helpers/store_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/store_spec.rb
@@ -4,6 +4,8 @@ class FakesController < ApplicationController
   include Spree::Core::ControllerHelpers::Auth
   include Spree::Core::ControllerHelpers::Order
   include Spree::Core::ControllerHelpers::Store
+
+  before_action :set_current_order
 end
 
 describe Spree::Core::ControllerHelpers::Store, type: :controller do
@@ -48,6 +50,7 @@ describe Spree::Core::ControllerHelpers::Store, type: :controller do
         before do
           allow(current_order).to receive(:tax_zone).and_return(other_zone)
           allow(controller).to receive(:current_order).and_return(current_order)
+          controller.instance_variable_set(:@current_order, current_order)
         end
 
         it { is_expected.to include(tax_zone: other_zone) }
@@ -72,6 +75,7 @@ describe Spree::Core::ControllerHelpers::Store, type: :controller do
         before do
           allow(current_order).to receive(:tax_zone).and_return(other_zone)
           allow(controller).to receive(:current_order).and_return(current_order)
+          controller.instance_variable_set(:@current_order, current_order)
         end
 
         it { is_expected.to include(tax_zone: other_zone) }

--- a/frontend/app/assets/javascripts/spree/frontend/account.js
+++ b/frontend/app/assets/javascripts/spree/frontend/account.js
@@ -1,0 +1,9 @@
+Spree.fetchAccount = function () {
+  return $.ajax({
+    url: Spree.pathFor('account_link')
+  }).done(function (data) {
+    return $('#link-to-account').html(data)
+  })
+}
+
+Spree.ready(function () { Spree.fetchAccount() })

--- a/frontend/app/assets/javascripts/spree/frontend/account.js
+++ b/frontend/app/assets/javascripts/spree/frontend/account.js
@@ -2,8 +2,11 @@ Spree.fetchAccount = function () {
   return $.ajax({
     url: Spree.pathFor('account_link')
   }).done(function (data) {
+    Spree.accountFetched = true
     return $('#link-to-account').html(data)
   })
 }
 
-Spree.ready(function () { Spree.fetchAccount() })
+Spree.ready(function () {
+  if (!Spree.accountFetched) Spree.fetchAccount()
+})

--- a/frontend/app/assets/javascripts/spree/frontend/api_tokens.js
+++ b/frontend/app/assets/javascripts/spree/frontend/api_tokens.js
@@ -8,10 +8,13 @@ Spree.fetchApiTokens = function () {
         response.json().then(function (json) {
           SpreeAPI.orderToken = json.order_token
           SpreeAPI.oauthToken = json.oauth_token
+          Spree.apiTokensFetched = true
         })
         break
     }
   })
 }
 
-Spree.ready(function () { Spree.fetchApiTokens() })
+Spree.ready(function () {
+  if (!Spree.apiTokensFetched) Spree.fetchApiTokens()
+})

--- a/frontend/app/assets/javascripts/spree/frontend/cart.js
+++ b/frontend/app/assets/javascripts/spree/frontend/cart.js
@@ -2,6 +2,7 @@
 
 Spree.ready(function ($) {
   var formUpdateCart = $('form#update-cart')
+
   if (formUpdateCart.length) {
     $('form#update-cart a.delete').show().one('click', function () {
       $(this).parents('.shopping-cart-item').first().find('input.shopping-cart-item-quantity-input').val(0)
@@ -16,7 +17,7 @@ Spree.ready(function ($) {
       $(targetInputs).val(newValue)
     })
     $('form#update-cart input.shopping-cart-item-quantity-input').on('change', function(e) {
-      $('#update-cart').submit()
+      formUpdateCart.submit()
     })
     $('form#update-cart button.shopping-cart-item-quantity-decrease-btn').off('click').on('click', function() {
       var itemId = $(this).attr('data-id')
@@ -25,7 +26,7 @@ Spree.ready(function ($) {
 
       if (inputValue > 1) {
         $(input).val(inputValue - 1)
-        $('#update-cart').submit()
+        formUpdateCart.submit()
       }
     })
     $('form#update-cart button.shopping-cart-item-quantity-increase-btn').off('click').on('click', function() {
@@ -34,7 +35,7 @@ Spree.ready(function ($) {
       var inputValue = parseInt($(input).val(), 10)
 
       $(input).val(inputValue + 1)
-      $('#update-cart').submit()
+      formUpdateCart.submit()
     })
     $('form#update-cart button#shopping-cart-coupon-code-button').off('click').on('click', function(event) {
       var couponCodeField = $('#order_coupon_code');
@@ -83,13 +84,14 @@ Spree.ready(function ($) {
     }
   })
 
-  Spree.fetchCart()
+  if (!Spree.cartFetched) Spree.fetchCart()
 })
 
 Spree.fetchCart = function () {
   return $.ajax({
     url: Spree.pathFor('cart_link')
   }).done(function (data) {
+    Spree.cartFetched = true
     return $('#link-to-cart').html(data)
   })
 }

--- a/frontend/app/assets/javascripts/spree/frontend/cart.js
+++ b/frontend/app/assets/javascripts/spree/frontend/cart.js
@@ -82,9 +82,11 @@ Spree.ready(function ($) {
       }
     }
   })
+
+  Spree.fetchCart()
 })
 
-Spree.fetch_cart = function () {
+Spree.fetchCart = function () {
   return $.ajax({
     url: Spree.pathFor('cart_link')
   }).done(function (data) {

--- a/frontend/app/assets/javascripts/spree/frontend/views/spree/products/cart_form.js
+++ b/frontend/app/assets/javascripts/spree/frontend/views/spree/products/cart_form.js
@@ -263,6 +263,7 @@ Spree.ready(function($) {
             quantity_increment: quantity,
             cart: response.attributes
           })
+          Spree.fetchCart()
         },
         function(_error) {
           document.getElementById('overlay').classList.add('shown')

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -7,6 +7,7 @@ module Spree
     include Spree::Checkout::AddressBook
 
     before_action :set_cache_header, only: [:edit]
+    before_action :set_current_order
     before_action :load_order_with_lock
     before_action :ensure_valid_state_lock_version, only: [:update]
     before_action :set_state_if_present

--- a/frontend/app/controllers/spree/home_controller.rb
+++ b/frontend/app/controllers/spree/home_controller.rb
@@ -6,8 +6,6 @@ module Spree
     def index
       @bestsellers_products = load_taxon_products('Bestsellers')
       @trending_products = load_taxon_products('Trending')
-
-      @combined_products = [@bestsellers_products, @trending_products].flatten.uniq
     end
 
     private

--- a/frontend/app/controllers/spree/home_controller.rb
+++ b/frontend/app/controllers/spree/home_controller.rb
@@ -6,6 +6,8 @@ module Spree
     def index
       @bestsellers_products = load_taxon_products('Bestsellers')
       @trending_products = load_taxon_products('Trending')
+
+      fresh_when etag: etag, last_modified: last_modified, public: true
     end
 
     private
@@ -23,6 +25,30 @@ module Spree
         available.
         order('spree_products_taxons.position').
         limit(12)
+    end
+
+    def products_updated_at
+      @products_updated_at ||= [
+        @bestsellers_products&.maximum(:updated_at),
+        @trending_products&.maximum(:updated_at)
+      ].compact
+      @products_updated_at
+    end
+
+    def etag
+      [
+        store_etag,
+        products_updated_at,
+        additional_cache_key
+      ]
+    end
+
+    def last_modified
+      (products_updated_at + [current_store.updated_at]).max.utc
+    end
+
+    def additional_cache_key
+      # add your own project specific cache key here
     end
   end
 end

--- a/frontend/app/controllers/spree/home_controller.rb
+++ b/frontend/app/controllers/spree/home_controller.rb
@@ -13,7 +13,7 @@ module Spree
     def load_taxon_products(taxon_name)
       Spree::Product.joins(:taxons).
         where(spree_taxons: { name: taxon_name }).
-        eager_load(
+        includes(
           :variants_including_master,
                       master: [
                         :default_price,
@@ -21,8 +21,7 @@ module Spree
                       ]
                     ).
         available.
-        limit(12).
-        to_a
+        limit(12)
     end
   end
 end

--- a/frontend/app/controllers/spree/home_controller.rb
+++ b/frontend/app/controllers/spree/home_controller.rb
@@ -21,6 +21,7 @@ module Spree
                       ]
                     ).
         available.
+        order('spree_products_taxons.position').
         limit(12)
     end
   end

--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -1,6 +1,8 @@
 module Spree
   class OrdersController < Spree::StoreController
     before_action :check_authorization
+    before_action :set_current_order
+
     helper 'spree/products', 'spree/orders'
 
     respond_to :html

--- a/frontend/app/controllers/spree/products_controller.rb
+++ b/frontend/app/controllers/spree/products_controller.rb
@@ -11,7 +11,6 @@ module Spree
       @searcher = build_searcher(params.merge(include_images: true))
       @products = @searcher.retrieve_products
       @products = @products.includes(:possible_promotions) if @products.respond_to?(:includes)
-      @option_types = load_options
     end
 
     def show
@@ -31,10 +30,6 @@ module Spree
       else
         super
       end
-    end
-
-    def load_options
-      Spree::OptionType.includes(:option_values)
     end
 
     def load_product

--- a/frontend/app/controllers/spree/store_controller.rb
+++ b/frontend/app/controllers/spree/store_controller.rb
@@ -20,7 +20,7 @@ module Spree
 
     def api_tokens
       render json: {
-        order_token: current_order&.token,
+        order_token: simple_current_order&.token,
         oauth_token: current_oauth_token&.token
       }
     end

--- a/frontend/app/controllers/spree/store_controller.rb
+++ b/frontend/app/controllers/spree/store_controller.rb
@@ -2,7 +2,7 @@ module Spree
   class StoreController < Spree::BaseController
     include Spree::Core::ControllerHelpers::Order
 
-    skip_before_action :set_current_order, only: :cart_link
+    before_action :set_current_order, only: :cart_link
     skip_before_action :verify_authenticity_token, only: :ensure_cart, raise: false
 
     def forbidden

--- a/frontend/app/controllers/spree/store_controller.rb
+++ b/frontend/app/controllers/spree/store_controller.rb
@@ -13,6 +13,11 @@ module Spree
       render 'spree/shared/unauthorized', layout: Spree::Config[:layout], status: 401
     end
 
+    def account_link
+      render partial: 'spree/shared/link_to_account'
+      fresh_when(try_spree_current_user)
+    end
+
     def cart_link
       render partial: 'spree/shared/link_to_cart'
       fresh_when(simple_current_order)
@@ -33,6 +38,14 @@ module Spree
 
     def config_locale
       Spree::Frontend::Config[:locale]
+    end
+
+    def store_etag
+      [
+        current_store,
+        current_currency,
+        config_locale
+      ]
     end
   end
 end

--- a/frontend/app/controllers/spree/taxons_controller.rb
+++ b/frontend/app/controllers/spree/taxons_controller.rb
@@ -9,7 +9,6 @@ module Spree
 
       @searcher = build_searcher(params.merge(taxon: @taxon.id, include_images: true))
       @products = @searcher.retrieve_products
-      @option_types = Spree::OptionType.includes(:option_values)
     end
 
     private

--- a/frontend/app/helpers/spree/frontend_helper.rb
+++ b/frontend/app/helpers/spree/frontend_helper.rb
@@ -147,7 +147,7 @@ module Spree
     end
 
     def permitted_product_params
-      product_filters = Rails.cache.fetch('spree/product-filters', expires_in: 5.minutes) { Spree::OptionType.pluck(:name) }
+      product_filters = available_option_types.map(&:name)
       params.permit(product_filters << :sort_by)
     end
 
@@ -214,7 +214,14 @@ module Spree
     def filtering_params
       static_filters = %w(keywords price sort_by)
 
-      @option_types.map(&:filter_param).concat(static_filters)
+      available_option_types.map(&:filter_param).concat(static_filters)
+    end
+
+    def available_option_types
+      @available_option_types ||= Rails.cache.fetch('available-option-types', expires_in: 3.minutes) do
+        Spree::OptionType.includes(:option_values).to_a
+      end
+      @available_option_types
     end
 
     private

--- a/frontend/app/helpers/spree/structured_data_helper.rb
+++ b/frontend/app/helpers/spree/structured_data_helper.rb
@@ -13,7 +13,7 @@ module Spree
     private
 
     def structured_product_hash(product)
-      Rails.cache.fetch("spree/structured-data/#{product.cache_key}") do
+      Rails.cache.fetch(common_product_cache_keys + ["spree/structured-data/#{product.cache_key}"]) do
         {
           '@context': 'https://schema.org/',
           '@type': 'Product',

--- a/frontend/app/helpers/spree/structured_data_helper.rb
+++ b/frontend/app/helpers/spree/structured_data_helper.rb
@@ -13,7 +13,7 @@ module Spree
     private
 
     def structured_product_hash(product)
-      Rails.cache.fetch(common_product_cache_keys + ["spree/structured-data/#{product.cache_key}"]) do
+      Rails.cache.fetch(common_product_cache_keys + ["spree/structured-data/#{product.cache_key_with_version}"]) do
         {
           '@context': 'https://schema.org/',
           '@type': 'Product',

--- a/frontend/app/views/spree/home/_carousel.html.erb
+++ b/frontend/app/views/spree/home/_carousel.html.erb
@@ -23,9 +23,7 @@
                   </a>
                 <% end %>
 
-                <% cache(item) do %>
-                  <%= render 'spree/shared/carousel_product', product: item, image_class: 'w-100' %>
-                <% end %>
+                <%= render 'spree/shared/product', product: item, image_class: 'w-100' %>
 
                 <% if idx == sliced_items.count - 1 %>
                   <a
@@ -79,9 +77,7 @@
                   </a>
                 <% end %>
 
-                <% cache(item) do %>
-                  <%= render 'spree/shared/carousel_product', product: item, image_class: 'w-100' %>
-                <% end %>
+              <%= render 'spree/shared/product', product: item, image_class: 'w-100' %>
 
                 <% if idx == sliced_items.count - 1 %>
                   <a

--- a/frontend/app/views/spree/home/_carousel.html.erb
+++ b/frontend/app/views/spree/home/_carousel.html.erb
@@ -1,106 +1,108 @@
-<div id="<%= id %>-mobile" class="carousel slide d-md-none homepage-carousel" data-interval="false">
-  <div class="carousel-inner">
-    <% products.each_slice(2).with_index do |sliced_items, index| %>
-      <div class="carousel-item <%= 'active' if index == 0 %>">
-        <div class="container">
-          <div class="row">
-            <% sliced_items.each_with_index do |item, idx| %>
-              <div class="col-6">
-                <% if idx == 0 %>
-                  <a
-                    class="d-flex position-absolute justify-content-center align-items-center carousel-icon-control carousel-icon-control--previous"
-                    href="#<%= id %>-mobile"
-                    role="button"
-                    data-slide="prev"
-                  >
-                    <span class="d-flex justify-content-center align-items-center carousel-icon-control-rounded" aria-hidden="true">
-                      <%= icon(name: 'arrow-right',
-                               classes: 'spree-icon-arrow spree-icon-arrow-left',
-                               width: 20,
-                               height: 20) %>
-                    </span>
-                    <span class="sr-only"><%= Spree.t(:previous) %></span>
-                  </a>
-                <% end %>
+<% cache [common_product_cache_keys, products&.maximum(:updated_at)&.to_i, id] do %>
+  <div id="<%= id %>-mobile" class="carousel slide d-md-none homepage-carousel" data-interval="false">
+    <div class="carousel-inner">
+      <% products.each_slice(2).with_index do |sliced_items, index| %>
+        <div class="carousel-item <%= 'active' if index == 0 %>">
+          <div class="container">
+            <div class="row">
+              <% sliced_items.each_with_index do |item, idx| %>
+                <div class="col-6">
+                  <% if idx == 0 %>
+                    <a
+                      class="d-flex position-absolute justify-content-center align-items-center carousel-icon-control carousel-icon-control--previous"
+                      href="#<%= id %>-mobile"
+                      role="button"
+                      data-slide="prev"
+                    >
+                      <span class="d-flex justify-content-center align-items-center carousel-icon-control-rounded" aria-hidden="true">
+                        <%= icon(name: 'arrow-right',
+                                classes: 'spree-icon-arrow spree-icon-arrow-left',
+                                width: 20,
+                                height: 20) %>
+                      </span>
+                      <span class="sr-only"><%= Spree.t(:previous) %></span>
+                    </a>
+                  <% end %>
+
+                  <%= render 'spree/shared/product', product: item, image_class: 'w-100' %>
+
+                  <% if idx == sliced_items.count - 1 %>
+                    <a
+                      class="d-flex position-absolute justify-content-center align-items-center carousel-icon-control carousel-icon-control--next"
+                      href="#<%= id %>-mobile"
+                      role="button"
+                      data-slide="next"
+                    >
+                      <span class="d-flex justify-content-center align-items-center carousel-icon-control-rounded" aria-hidden="true">
+                        <%= icon(name: 'arrow-right',
+                                classes: 'spree-icon-arrow spree-icon-arrow-right',
+                                width: 20,
+                                height: 20) %>
+                      </span>
+                      <span class="sr-only"><%= Spree.t(:next) %></span>
+                    </a>
+                  <% end %>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <div id="<%= id %>-desktop" class="carousel slide d-none d-md-block homepage-carousel" data-interval="false">
+    <div class="carousel-inner">
+      <% products.each_slice(4).with_index do |sliced_items, index| %>
+        <div class="carousel-item <%= 'active' if index == 0 %>">
+          <div class="container position-relative">
+
+            <div class="row">
+              <% sliced_items.each_with_index do |item, idx| %>
+                <div class="col-3">
+                  <% if idx == 0 %>
+                    <a
+                      class="d-md-flex position-absolute justify-content-center align-items-center carousel-icon-control carousel-icon-control--previous"
+                      href="#<%= id %>-desktop"
+                      role="button"
+                      data-slide="prev"
+                    >
+                      <span class="d-flex justify-content-center align-items-center carousel-icon-control-rounded" aria-hidden="true">
+                        <%= icon(name: 'arrow-right',
+                                classes: 'spree-icon-arrow spree-icon-arrow-left',
+                                width: 20,
+                                height: 20)
+                        %>
+                      </span>
+                      <span class="sr-only"><%= Spree.t(:previous) %></span>
+                    </a>
+                  <% end %>
 
                 <%= render 'spree/shared/product', product: item, image_class: 'w-100' %>
 
-                <% if idx == sliced_items.count - 1 %>
-                  <a
-                    class="d-flex position-absolute justify-content-center align-items-center carousel-icon-control carousel-icon-control--next"
-                    href="#<%= id %>-mobile"
-                    role="button"
-                    data-slide="next"
-                  >
-                    <span class="d-flex justify-content-center align-items-center carousel-icon-control-rounded" aria-hidden="true">
-                      <%= icon(name: 'arrow-right',
-                               classes: 'spree-icon-arrow spree-icon-arrow-right',
-                               width: 20,
-                               height: 20) %>
-                    </span>
-                    <span class="sr-only"><%= Spree.t(:next) %></span>
-                  </a>
-                <% end %>
-              </div>
-            <% end %>
+                  <% if idx == sliced_items.count - 1 %>
+                    <a
+                      class="d-md-flex position-absolute justify-content-center align-items-center carousel-icon-control carousel-icon-control--next"
+                      href="#<%= id %>-desktop"
+                      role="button"
+                      data-slide="next"
+                    >
+                      <span class="d-flex justify-content-center align-items-center carousel-icon-control-rounded" aria-hidden="true">
+                        <%= icon(name: 'arrow-right',
+                                classes: 'spree-icon-arrow spree-icon-arrow-right',
+                                width: 20,
+                                height: 20)
+                        %>
+                      </span>
+                      <span class="sr-only"><%= Spree.t(:next) %></span>
+                    </a>
+                  <% end %>
+                </div>
+              <% end %>
+            </div>
           </div>
         </div>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
   </div>
-</div>
-
-<div id="<%= id %>-desktop" class="carousel slide d-none d-md-block homepage-carousel" data-interval="false">
-  <div class="carousel-inner">
-    <% products.each_slice(4).with_index do |sliced_items, index| %>
-      <div class="carousel-item <%= 'active' if index == 0 %>">
-        <div class="container position-relative">
-
-          <div class="row">
-            <% sliced_items.each_with_index do |item, idx| %>
-              <div class="col-3">
-                <% if idx == 0 %>
-                  <a
-                    class="d-md-flex position-absolute justify-content-center align-items-center carousel-icon-control carousel-icon-control--previous"
-                    href="#<%= id %>-desktop"
-                    role="button"
-                    data-slide="prev"
-                  >
-                    <span class="d-flex justify-content-center align-items-center carousel-icon-control-rounded" aria-hidden="true">
-                      <%= icon(name: 'arrow-right',
-                               classes: 'spree-icon-arrow spree-icon-arrow-left',
-                               width: 20,
-                               height: 20)
-                      %>
-                    </span>
-                    <span class="sr-only"><%= Spree.t(:previous) %></span>
-                  </a>
-                <% end %>
-
-              <%= render 'spree/shared/product', product: item, image_class: 'w-100' %>
-
-                <% if idx == sliced_items.count - 1 %>
-                  <a
-                    class="d-md-flex position-absolute justify-content-center align-items-center carousel-icon-control carousel-icon-control--next"
-                    href="#<%= id %>-desktop"
-                    role="button"
-                    data-slide="next"
-                  >
-                    <span class="d-flex justify-content-center align-items-center carousel-icon-control-rounded" aria-hidden="true">
-                      <%= icon(name: 'arrow-right',
-                               classes: 'spree-icon-arrow spree-icon-arrow-right',
-                               width: 20,
-                               height: 20)
-                      %>
-                    </span>
-                    <span class="sr-only"><%= Spree.t(:next) %></span>
-                  </a>
-                <% end %>
-              </div>
-            <% end %>
-          </div>
-        </div>
-      </div>
-    <% end %>
-  </div>
-</div>
+<% end %>

--- a/frontend/app/views/spree/home/index.html.erb
+++ b/frontend/app/views/spree/home/index.html.erb
@@ -136,4 +136,4 @@
   </div>
 </div>
 
-<%= products_structured_data(@combined_products) %>
+<%= products_structured_data((@bestsellers_products.to_a + @trending_products.to_a).uniq.compact) %>

--- a/frontend/app/views/spree/products/_carousel.html.erb
+++ b/frontend/app/views/spree/products/_carousel.html.erb
@@ -1,91 +1,93 @@
-<div id="<%= id %>-mobile" class="carousel slide d-md-none product-details-carousel" data-interval="false">
-  <div class="carousel-inner">
-    <% products.each_slice(2).with_index do |sliced_items, index| %>
-      <div class="carousel-item <%= 'active' if index == 0 %>">
-        <div class="container">
-          <div class="row">
-            <% sliced_items.each do |item| %>
-              <div class="col-6">
-                <%= render 'spree/shared/product', product: item, image_class: 'w-100' %>
-              </div>
-            <% end %>
+<% cache [common_product_cache_keys, products&.maximum(:updated_at)&.to_i, id] do %>
+  <div id="<%= id %>-mobile" class="carousel slide d-md-none product-details-carousel" data-interval="false">
+    <div class="carousel-inner">
+      <% products.each_slice(2).with_index do |sliced_items, index| %>
+        <div class="carousel-item <%= 'active' if index == 0 %>">
+          <div class="container">
+            <div class="row">
+              <% sliced_items.each do |item| %>
+                <div class="col-6">
+                  <%= render 'spree/shared/product', product: item, image_class: 'w-100' %>
+                </div>
+              <% end %>
+            </div>
           </div>
         </div>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
+    <a
+      class="d-flex h-100 position-absolute justify-content-center align-items-center carousel-icon-control carousel-icon-control--previous"
+      href="#<%= id %>-mobile"
+      role="button"
+      data-slide="prev"
+    >
+      <span class="d-flex justify-content-center align-items-center carousel-icon-control-rounded" aria-hidden="true">
+        <%= icon(name: 'arrow-right',
+                classes: 'spree-icon-arrow spree-icon-arrow-left',
+                width: 20,
+                height: 20) %>
+      </span>
+      <span class="sr-only"><%= Spree.t(:previous) %></span>
+    </a>
+    <a
+      class="d-flex h-100 position-absolute justify-content-center align-items-center carousel-icon-control carousel-icon-control--next"
+      href="#<%= id %>-mobile"
+      role="button"
+      data-slide="next"
+    >
+      <span class="d-flex justify-content-center align-items-center carousel-icon-control-rounded" aria-hidden="true">
+        <%= icon(name: 'arrow-right',
+                classes: 'spree-icon-arrow spree-icon-arrow-right',
+                width: 20,
+                height: 20) %>
+      </span>
+      <span class="sr-only"><%= Spree.t(:next) %></span>
+    </a>
   </div>
-  <a
-    class="d-flex h-100 position-absolute justify-content-center align-items-center carousel-icon-control carousel-icon-control--previous"
-    href="#<%= id %>-mobile"
-    role="button"
-    data-slide="prev"
-  >
-    <span class="d-flex justify-content-center align-items-center carousel-icon-control-rounded" aria-hidden="true">
-      <%= icon(name: 'arrow-right',
-               classes: 'spree-icon-arrow spree-icon-arrow-left',
-               width: 20,
-               height: 20) %>
-    </span>
-    <span class="sr-only"><%= Spree.t(:previous) %></span>
-  </a>
-  <a
-    class="d-flex h-100 position-absolute justify-content-center align-items-center carousel-icon-control carousel-icon-control--next"
-    href="#<%= id %>-mobile"
-    role="button"
-    data-slide="next"
-  >
-    <span class="d-flex justify-content-center align-items-center carousel-icon-control-rounded" aria-hidden="true">
-      <%= icon(name: 'arrow-right',
-               classes: 'spree-icon-arrow spree-icon-arrow-right',
-               width: 20,
-               height: 20) %>
-    </span>
-    <span class="sr-only"><%= Spree.t(:next) %></span>
-  </a>
-</div>
 
-<div id="<%= id %>-desktop" class="carousel slide d-none d-md-block product-details-carousel" data-interval="false">
-  <div class="carousel-inner">
-    <% products.each_slice(4).with_index do |sliced_items, index| %>
-      <div class="carousel-item <%= 'active' if index == 0 %>">
-        <div class="container">
-          <div class="row">
-            <% sliced_items.each do |item| %>
-              <div class="col-3">
-                <%= render 'spree/shared/product', product: item, image_class: 'w-100' %>
-              </div>
-            <% end %>
+  <div id="<%= id %>-desktop" class="carousel slide d-none d-md-block product-details-carousel" data-interval="false">
+    <div class="carousel-inner">
+      <% products.each_slice(4).with_index do |sliced_items, index| %>
+        <div class="carousel-item <%= 'active' if index == 0 %>">
+          <div class="container">
+            <div class="row">
+              <% sliced_items.each do |item| %>
+                <div class="col-3">
+                  <%= render 'spree/shared/product', product: item, image_class: 'w-100' %>
+                </div>
+              <% end %>
+            </div>
           </div>
         </div>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
+    <a
+      class="d-md-flex h-100 position-absolute justify-content-center align-items-center carousel-icon-control carousel-icon-control--previous"
+      href="#<%= id %>-desktop"
+      role="button"
+      data-slide="prev"
+    >
+      <span class="d-flex justify-content-center align-items-center carousel-icon-control-rounded" aria-hidden="true">
+        <%= icon(name: 'arrow-right',
+                classes: 'spree-icon-arrow spree-icon-arrow-left',
+                width: 20,
+                height: 20) %>
+      </span>
+      <span class="sr-only"><%= Spree.t(:previous) %></span>
+    </a>
+    <a
+      class="d-md-flex h-100 position-absolute justify-content-center align-items-center carousel-icon-control carousel-icon-control--next"
+      href="#<%= id %>-desktop"
+      role="button"
+      data-slide="next"
+    >
+      <span class="d-flex justify-content-center align-items-center carousel-icon-control-rounded" aria-hidden="true">
+        <%= icon(name: 'arrow-right',
+                classes: 'spree-icon-arrow spree-icon-arrow-right',
+                width: 20,
+                height: 20) %>
+      </span>
+      <span class="sr-only"><%= Spree.t(:next) %></span>
+    </a>
   </div>
-  <a
-    class="d-md-flex h-100 position-absolute justify-content-center align-items-center carousel-icon-control carousel-icon-control--previous"
-    href="#<%= id %>-desktop"
-    role="button"
-    data-slide="prev"
-  >
-    <span class="d-flex justify-content-center align-items-center carousel-icon-control-rounded" aria-hidden="true">
-      <%= icon(name: 'arrow-right',
-               classes: 'spree-icon-arrow spree-icon-arrow-left',
-               width: 20,
-               height: 20) %>
-    </span>
-    <span class="sr-only"><%= Spree.t(:previous) %></span>
-  </a>
-  <a
-    class="d-md-flex h-100 position-absolute justify-content-center align-items-center carousel-icon-control carousel-icon-control--next"
-    href="#<%= id %>-desktop"
-    role="button"
-    data-slide="next"
-  >
-    <span class="d-flex justify-content-center align-items-center carousel-icon-control-rounded" aria-hidden="true">
-      <%= icon(name: 'arrow-right',
-               classes: 'spree-icon-arrow spree-icon-arrow-right',
-               width: 20,
-               height: 20) %>
-    </span>
-    <span class="sr-only"><%= Spree.t(:next) %></span>
-  </a>
-</div>
+<% end %>

--- a/frontend/app/views/spree/products/_filters_desktop.html.erb
+++ b/frontend/app/views/spree/products/_filters_desktop.html.erb
@@ -1,6 +1,6 @@
-<% cache base_cache_key + [@option_types, permitted_params, @taxon] do %>
+<% cache base_cache_key + [available_option_types, permitted_params, @taxon] do %>
   <div id="plp-filters-accordion" class="d-none d-lg-block col-lg-3 pr-5 position-sticky h-100 plp-filters" data-hook="taxon_sidebar_navigation">
-    <% @option_types.each do |option_type| %>
+    <% @available_option_types.each do |option_type| %>
       <div class="w-100 py-2 card plp-filters-card">
         <% ot_downcase_name = option_type.filter_param %>
         <% option_type_name = ot_downcase_name.titleize %>

--- a/frontend/app/views/spree/products/_filters_mobile.html.erb
+++ b/frontend/app/views/spree/products/_filters_mobile.html.erb
@@ -1,6 +1,6 @@
 <% is_visible = params[:menu_open] ? 'block' : 'none' %>
 
-<% cache base_cache_key + [@option_types, permitted_params, @taxon, is_visible] do %>
+<% cache base_cache_key + [available_option_types, permitted_params, @taxon, is_visible] do %>
   <div id="filter-by-overlay" class="d-lg-none plp-overlay" style="display: <%= is_visible %>;">
     <div class="plp-scroll">
       <div class="container">
@@ -10,7 +10,7 @@
         </div>
       </div>
       <div id="filters-accordion">
-        <% @option_types.each do |option_type| %>
+        <% available_option_types.each do |option_type| %>
           <% option_type_name = option_type.presentation.titleize.gsub(' ', '') %>
           <% ot_downcase_name = option_type_name.downcase %>
 

--- a/frontend/app/views/spree/products/index.html.erb
+++ b/frontend/app/views/spree/products/index.html.erb
@@ -32,29 +32,7 @@
     <%= render 'spree/products/sort_desktop', permitted_params: permitted_params %>
     <div class="container mb-3 d-md-flex">
       <%= render 'spree/products/filters_desktop', permitted_params: permitted_params %>
-      <div class="col-md-12 col-lg-9" data-hook="homepage_products">
-        <div class="row">
-          <% cache(params.permit!.merge(current_currency: current_currency)) do %>
-            <% @products.each_with_index do |product, index| %>
-              <div id="product_<%= product.id %>" class="col-sm-4 col-6 mb-3 mb-md-4 pr-sm-0 pr-md-0 pl-md-4 pl-sm-4 <%= index&1 == 0 ? 'pl-0 pr-2' : 'pr-0 pl-2' %>">
-                <%= render 'spree/shared/product', product: product, image_class: 'product-component-plp-image' %>
-              </div>
-            <% end %>
-          <% end %>
-        </div>
-
-        <div class="row pl-md-4 pl-sm-4">
-          <div class="col-12">
-            <div class="plp-pagination d-none d-lg-flex">
-              <%= paginate @products, window: 2, theme: 'twitter-bootstrap-4' %>
-            </div>
-
-            <div class="plp-pagination d-lg-none">
-              <%= paginate @products, window: 1, theme: 'twitter-bootstrap-4' %>
-            </div>
-          </div>
-        </div>
-      </div>
+      <%= render 'spree/shared/products', products: @products %>
     </div>
   <% end %>
 </div>

--- a/frontend/app/views/spree/shared/_carousel_product.html.erb
+++ b/frontend/app/views/spree/shared/_carousel_product.html.erb
@@ -1,8 +1,0 @@
-<%= link_to spree.product_path(product, taxon_id: @taxon&.id), class: 'h-100 d-flex flex-column justify-content-between' do %>
-  <%= plp_and_carousel_image(product, image_class) %>
-
-  <div>
-    <div class="product-component-name" title="<%= product.name %>"><%= product.name %></div>
-    <div class="product-component-price"><%= display_price(product) %></div>
-  </div>
-<% end %>

--- a/frontend/app/views/spree/shared/_cart.html.erb
+++ b/frontend/app/views/spree/shared/_cart.html.erb
@@ -1,4 +1,4 @@
-<% item_count = current_order&.item_count || 0 %>
+<% item_count = simple_current_order&.item_count || 0 %>
 
 <%= link_to spree.cart_path,
   class: "cart-icon #{'cart-icon--visible-count' if item_count > 0} #{local_assigns[:class]}",

--- a/frontend/app/views/spree/shared/_link_to_account.html.erb
+++ b/frontend/app/views/spree/shared/_link_to_account.html.erb
@@ -1,6 +1,6 @@
 <% if try_spree_current_user %>
   <%= link_to Spree.t('nav_bar.my_account'), spree.account_path, class: 'dropdown-item' if spree.respond_to?(:account_path) %>
-  <%= link_to Spree.t('nav_bar.log_out'), spree.logout_path, class: 'dropdown-item' if spree.respond_to?(:logout_path) %>
+  <%= link_to Spree.t('nav_bar.log_out'), spree.logout_path, class: 'dropdown-item', method: :get if spree.respond_to?(:logout_path) %>
 <% else %>
   <%= link_to Spree.t('nav_bar.log_in'), spree.login_path, class: 'dropdown-item' if spree.respond_to?(:login_path) %>
   <%= link_to Spree.t('nav_bar.sign_up'), spree.signup_path, class: 'dropdown-item' if spree.respond_to?(:signup_path) %>

--- a/frontend/app/views/spree/shared/_login_bar.html.erb
+++ b/frontend/app/views/spree/shared/_login_bar.html.erb
@@ -1,5 +1,0 @@
-<script>
-  window.addEventListener('DOMContentLoaded', function() {
-    if(typeof Spree.fetch_account !== 'undefined') Spree.fetch_account()
-  })
-</script>

--- a/frontend/app/views/spree/shared/_nav_bar.html.erb
+++ b/frontend/app/views/spree/shared/_nav_bar.html.erb
@@ -33,7 +33,7 @@
                   height: 24)  %>
         </button>
 
-        <div id="link-to-account" class="dropdown-menu dropdown-menu-right text-right">
+        <div id="link-to-account" class="dropdown-menu dropdown-menu-right text-right" data-turbolinks-permanent>
         </div>
       </div>
     </li>

--- a/frontend/app/views/spree/shared/_nav_bar.html.erb
+++ b/frontend/app/views/spree/shared/_nav_bar.html.erb
@@ -35,17 +35,6 @@
 
         <div id="link-to-account" class="dropdown-menu dropdown-menu-right text-right">
         </div>
-        <%# TODO: fix me in spree_auth_devise %>
-        <script>
-          window.addEventListener('turbolinks:load', function() {
-            $.ajax({
-              url: Spree.pathFor("account_link"),
-              success: function(data) {
-                return $('#link-to-account').html(data)
-              }
-            })
-          })
-        </script>
       </div>
     </li>
   <% end %>
@@ -61,9 +50,4 @@
                height: 24)  %>
     </span>
   </li>
-  <script>
-    window.addEventListener('turbolinks:load', function() {
-      Spree.fetch_cart()
-    })
-  </script>
 </ul>

--- a/frontend/app/views/spree/shared/_nav_bar.html.erb
+++ b/frontend/app/views/spree/shared/_nav_bar.html.erb
@@ -38,7 +38,7 @@
       </div>
     </li>
   <% end %>
-  <li id="link-to-cart" data-hook>
+  <li id="link-to-cart" data-turbolinks-permanent>
     <span class="d-none d-xl-inline-block cart-icon--xl">
       <%= icon(name: 'bag',
                width: 41.8,

--- a/frontend/app/views/spree/shared/_product.html.erb
+++ b/frontend/app/views/spree/shared/_product.html.erb
@@ -1,7 +1,9 @@
-<%= link_to spree.product_path(product, taxon_id: @taxon&.id), class: 'h-100 d-flex flex-column justify-content-between' do %>
-  <%= plp_and_carousel_image(product, image_class) %>
-  <div>
-    <div class="product-component-name" title="<%= product.name %>"><%= product.name %></div>
-    <div class="product-component-price"><%= display_price(product) %></div>
-  </div>
+<% cache [common_product_cache_keys, product, @taxon&.id] do %>
+  <%= link_to spree.product_path(product, taxon_id: @taxon&.id), class: 'h-100 d-flex flex-column justify-content-between' do %>
+    <%= plp_and_carousel_image(product, image_class) %>
+    <div>
+      <div class="product-component-name" title="<%= product.name %>"><%= product.name %></div>
+      <div class="product-component-price"><%= display_price(product) %></div>
+    </div>
+  <% end %>
 <% end %>

--- a/frontend/app/views/spree/shared/_products.html.erb
+++ b/frontend/app/views/spree/shared/_products.html.erb
@@ -4,29 +4,28 @@
   <% end %>
 <% end %>
 
-<div data-hook="products_search_results_heading">
-  <% if products.empty? %>
-    <div data-hook="products_search_results_heading_no_results_found">
-      <%= Spree.t(:no_products_found) %>
-    </div>
-  <% elsif params.key?(:keywords) %>
-    <div data-hook="products_search_results_heading_results_found">
-      <h6 class="search-results-title"><%= Spree.t(:search_results, keywords: h(params[:keywords])) %></h6>
+<div class="col-md-12 col-lg-9" data-hook="homepage_products">
+  <div class="row">
+    <% cache cache_key_for_products(products) do %>
+      <% products.each_with_index do |product, index| %>
+        <div id="product_<%= product.id %>" class="col-sm-4 col-6 mb-3 mb-md-4 pr-sm-0 pr-md-0 pl-md-4 pl-sm-4 <%= index&1 == 0 ? 'pl-0 pr-2' : 'pr-0 pl-2' %>">
+          <%= render 'spree/shared/product', product: product, image_class: 'product-component-plp-image' %>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+
+  <% if products.respond_to?(:total_pages) %>
+    <div class="row pl-md-4 pl-sm-4">
+      <div class="col-12">
+        <div class="plp-pagination d-none d-lg-flex">
+          <%= paginate products, window: 2, theme: 'twitter-bootstrap-4' %>
+        </div>
+
+        <div class="plp-pagination d-lg-none">
+          <%= paginate products, window: 1, theme: 'twitter-bootstrap-4' %>
+        </div>
+      </div>
     </div>
   <% end %>
 </div>
-
-<% if products.any? %>
-  <div id="products" class="row d-flex" data-hook>
-    <%= render partial: 'spree/products/product', collection: products, locals: { taxon: @taxon } %>
-  </div>
-<% end %>
-
-<% if products.respond_to?(:total_pages) %>
-  <div class="d-none d-lg-flex">
-    <%= paginate products, window: 2, theme: 'twitter-bootstrap-4' %>
-  </div>
-  <div class="d-lg-none">
-    <%= paginate products, window: 1, theme: 'twitter-bootstrap-4' %>
-  </div>
-<% end %>

--- a/frontend/app/views/spree/taxons/_subcategories.html.erb
+++ b/frontend/app/views/spree/taxons/_subcategories.html.erb
@@ -1,24 +1,26 @@
-<% [taxon.parent, taxon].each do |current_taxon| %>
-  <% child_taxons = [current_taxon, *current_taxon.children] %>
+<% cache([base_cache_key, taxon, 'subcategories', permitted_product_params]) do %>
+  <% [taxon.parent, taxon].each do |current_taxon| %>
+    <% child_taxons = [current_taxon, *current_taxon.children] %>
 
-  <% if current_taxon.level > 0 && child_taxons.size > 1 %>
-    <div class="d-flex justify-content-center position-sticky sticky-top-90px taxon-subcategories-wrapper">
-      <div class="py-1 text-uppercase d-none d-xl-flex overflow-x taxon-subcategories">
-        <% child_taxons.each_with_index.map do |subcategory, index| %>
-          <%=
-            link_to_unless subcategory == taxon,
-                          index.zero? ? Spree.t(:all) : subcategory.name,
-                          spree.nested_taxons_path(subcategory, params: permitted_product_params),
-                          class: "pt-4 pb-2 mb-2 #{index.zero? ? '' : 'pl-4 pt-4 pb-2'}" do
-          %>
-            <div class="pt-4 mb-2 <%= index.zero? ? '' : 'pl-4' %>">
-              <span class="pb-2 taxon-subcategories-selected">
-                <%= index.zero? ? Spree.t(:all) : subcategory.name %>
-              </span>
-            </div>
+    <% if current_taxon.level > 0 && child_taxons.size > 1 %>
+      <div class="d-flex justify-content-center position-sticky sticky-top-90px taxon-subcategories-wrapper">
+        <div class="py-1 text-uppercase d-none d-xl-flex overflow-x taxon-subcategories">
+          <% child_taxons.each_with_index.map do |subcategory, index| %>
+            <%=
+              link_to_unless subcategory == taxon,
+                            index.zero? ? Spree.t(:all) : subcategory.name,
+                            spree.nested_taxons_path(subcategory, params: permitted_product_params),
+                            class: "pt-4 pb-2 mb-2 #{index.zero? ? '' : 'pl-4 pt-4 pb-2'}" do
+            %>
+              <div class="pt-4 mb-2 <%= index.zero? ? '' : 'pl-4' %>">
+                <span class="pb-2 taxon-subcategories-selected">
+                  <%= index.zero? ? Spree.t(:all) : subcategory.name %>
+                </span>
+              </div>
+            <% end %>
           <% end %>
-        <% end %>
+        </div>
       </div>
-    </div>
+    <% end %>
   <% end %>
 <% end %>

--- a/frontend/config/routes.rb
+++ b/frontend/config/routes.rb
@@ -29,6 +29,7 @@ Spree::Core::Engine.add_routes do
   get '/content/cvv', to: 'content#cvv', as: :cvv
   get '/content/test', to: 'content#test'
   get '/cart_link', to: 'store#cart_link', as: :cart_link
+  get '/account_link', to: 'store#account_link', as: :account_link
 
   get '/api_tokens', to: 'store#api_tokens'
   post '/ensure_cart', to: 'store#ensure_cart'

--- a/frontend/spec/requests/api_tokens_spec.rb
+++ b/frontend/spec/requests/api_tokens_spec.rb
@@ -20,7 +20,7 @@ describe 'API Tokens Spec', type: :request do
       let(:order) { create(:order, user: nil, email: 'dummy@example.com') }
 
       before do
-        allow_any_instance_of(Spree::StoreController).to receive_messages(current_order: order)
+        allow_any_instance_of(Spree::StoreController).to receive_messages(simple_current_order: order)
         get '/api_tokens'
       end
 
@@ -59,7 +59,7 @@ describe 'API Tokens Spec', type: :request do
       let(:order) { create(:order, user: user) }
 
       before do
-        allow_any_instance_of(Spree::StoreController).to receive_messages(current_order: order)
+        allow_any_instance_of(Spree::StoreController).to receive_messages(simple_current_order: order)
         get '/api_tokens'
       end
 

--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -61,6 +61,8 @@ group :test, :development do
   gem 'rack-mini-profiler'
   gem 'awesome_print'
 end
+
+gem 'rack-cache'
 RUBY
 
 bundle install --gemfile Gemfile


### PR DESCRIPTION
- [X] added fragment caching for products 
- [X] added fragment caching for carousels
- [X] added full page caching for PDP
- [X] added full page caching for the home page
- [X] fixed `set_current_order` behaviour
- [X] fixed turbolinks firing fetch cart/account multiple times
- [X] moved `account_link` endpoint from Auth Devise to Spree
- [X] fetch Account/Cart/API tokens only when necessary