### PR TITLE
Fixed checks for login helper paths

### DIFF
--- a/frontend/app/views/spree/checkout/registration.html.erb
+++ b/frontend/app/views/spree/checkout/registration.html.erb
@@ -2,17 +2,19 @@
 <div class="checkout-registration container">
   <div class="row col-xs-12 col-lg-11 mx-auto">
     <div class="col-xs-12 col-lg-6">
-      <%= render partial: 'spree/shared/login' %>
+      <%= render partial: 'spree/shared/login' if defined?(spree_login_path) %>
     </div>
     <div class="col-xs-12 col-lg-6">
       <div class="col-lg-11 mx-auto pt-lg-2">
-        <h3 class="spree-header header-sm spree-mt-large mb-3 mb-sm-4 mb-xl-4"><%= Spree.t('dont_have_account') %></h3>
-        <%= link_to Spree.t(:sign_up), spree.signup_path, class: 'btn btn-block btn-outline-primary spree-btn' %>
-        <div class="checkout-registration-styled-or">
-          <%= Spree.t(:or) %>
-        </div>
+        <% if defined?(spree_signup_path) %>
+          <h3 class="spree-header header-sm spree-mt-large mb-3 mb-sm-4 mb-xl-4"><%= Spree.t('dont_have_account') %></h3>
+          <%= link_to Spree.t(:sign_up), spree_signup_path, class: 'btn btn-block btn-outline-primary spree-btn' %>
+          <div class="checkout-registration-styled-or">
+            <%= Spree.t(:or) %>
+          </div>
+        <% end %>
         <% if Spree::Config[:allow_guest_checkout] %>
-          <% path = spree.respond_to?(:update_checkout_registration_path) ? spree.update_checkout_registration_path : spree.signup_path %>
+          <% path = spree.respond_to?(:update_checkout_registration_path) ? spree.update_checkout_registration_path : spree_signup_path %>
 
           <%= form_for @order, url: path, method: :put, html: { id: 'checkout_form_registration' } do |f| %>
             <div class="form-group">

--- a/frontend/app/views/spree/shared/_link_to_account.html.erb
+++ b/frontend/app/views/spree/shared/_link_to_account.html.erb
@@ -1,7 +1,7 @@
 <% if try_spree_current_user %>
   <%= link_to Spree.t('nav_bar.my_account'), spree.account_path, class: 'dropdown-item' if spree.respond_to?(:account_path) %>
-  <%= link_to Spree.t('nav_bar.log_out'), spree.logout_path, class: 'dropdown-item', method: :get if spree.respond_to?(:logout_path) %>
+  <%= link_to Spree.t('nav_bar.log_out'), spree_logout_path, class: 'dropdown-item', method: :get if defined?(spree_logout_path) %>
 <% else %>
-  <%= link_to Spree.t('nav_bar.log_in'), spree.login_path, class: 'dropdown-item' if spree.respond_to?(:login_path) %>
-  <%= link_to Spree.t('nav_bar.sign_up'), spree.signup_path, class: 'dropdown-item' if spree.respond_to?(:signup_path) %>
+  <%= link_to Spree.t('nav_bar.log_in'), spree_login_path, class: 'dropdown-item' if defined?(spree_login_path) %>
+  <%= link_to Spree.t('nav_bar.sign_up'), spree_signup_path, class: 'dropdown-item' if defined?(spree_signup_path) %>
 <% end %>


### PR DESCRIPTION
This will allow using Spree 4.1 with non-spree_auth_devise setups