### PR TITLE
Fixed admin logout link for non spree auth devise installs

### DIFF
--- a/backend/app/views/spree/admin/shared/_account_nav.html.erb
+++ b/backend/app/views/spree/admin/shared/_account_nav.html.erb
@@ -30,9 +30,9 @@
             </li>
           <% end %>
 
-          <% if spree.respond_to? :admin_logout_path %>
+          <% if defined?(spree_logout_path) %>
             <li class="dropdown-item p-0">
-              <%= link_to spree.admin_logout_path, class: 'd-block text-dark py-2 px-4' do %>
+              <%= link_to spree_logout_path, class: 'd-block text-dark py-2 px-4' do %>
                 <i class="glyphicon glyphicon-log-out"></i>
                 &nbsp;
                 <%= Spree.t(:logout) %>


### PR DESCRIPTION
Also this streamlines any future developments with one single logout endpoint