### PR TITLE
[SD-643] Remove right padding from bootstrap modal.

### DIFF
--- a/frontend/app/assets/stylesheets/spree/frontend/components-bootstrap/modal.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/components-bootstrap/modal.scss
@@ -1,3 +1,7 @@
 .modal-backdrop {
   background: adjust-color(theme-color-level('dark', -5), $alpha: -0.4);
 }
+
+.modal {
+  padding: 0 !important
+}


### PR DESCRIPTION
Override right padding, added by bootstrap script to make modal use full width.