### PR TITLE
We don't need to fire set_current_order before cart_link

### DIFF
--- a/frontend/app/controllers/spree/store_controller.rb
+++ b/frontend/app/controllers/spree/store_controller.rb
@@ -2,7 +2,6 @@ module Spree
   class StoreController < Spree::BaseController
     include Spree::Core::ControllerHelpers::Order
 
-    before_action :set_current_order, only: :cart_link
     skip_before_action :verify_authenticity_token, only: :ensure_cart, raise: false
 
     def forbidden


### PR DESCRIPTION
This will decrease the number of N+1 queries for this endpoint