### PR TITLE
Fixed proper before action order

### DIFF
--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -1,7 +1,7 @@
 module Spree
   class OrdersController < Spree::StoreController
-    before_action :check_authorization
     before_action :set_current_order
+    before_action :check_authorization
 
     helper 'spree/products', 'spree/orders'
 


### PR DESCRIPTION
`set_current_order` assigns Order to User so it should be fired before authorization check