### PR TITLE
fix: nested permalink not matched for taxon lookup

### DIFF
--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -160,7 +160,7 @@ Spree::Core::Engine.add_routes do
         get '/countries/:iso', to: 'countries#show', as: :country
         get '/order_status/:number', to: 'order_status#show', as: :order_status
         resources :products, only: %i[index show]
-        resources :taxons,   only: %i[index show]
+        resources :taxons,   only: %i[index show], id: /.+/
       end
     end
 


### PR DESCRIPTION
Fixes issue where API v2 could not lookup nested permalinks because the route never matched.

Now both work as expected.
`GET /api/v2/storefront/taxons/t-shirts`
`GET /api/v2/storefront/taxons/t-shirts/crew-cut`

Discussion: https://spree-commerce.slack.com/archives/C0JCDUK0D/p1580509050021500