### PR TITLE
Update API docs missing update special_instructions

### DIFF
--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -457,6 +457,7 @@ paths:
         <pre>
           order: {
             email: 'john@snow.org',
+            special_instructions: 'Please leave at door',
             bill_address_attributes: {
               firstname: 'John',
               lastname: 'Snow',
@@ -583,6 +584,9 @@ paths:
                     email:
                       type: string
                       example: 'john@snow.org'
+                    special_instructions:
+                      type: string
+                      example: 'Please leave at door'
                     bill_address_attributes:
                       $ref: '#/components/schemas/AddressPayload'
                     ship_address_attributes:


### PR DESCRIPTION
Currently not mentioned anywhere in API docs that you can update the special instructions using PATCH /checkout