### PR TITLE
Fix API Docs - Add payment source

### DIFF
--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -519,18 +519,16 @@ paths:
             order: {
               payments_attributes: [
                 {
-                  payment_method_id: 1
+                  payment_method_id: 1,
+                  source_attributes: {
+                    number: '4111111111111111',
+                    month: '01',
+                    year: '2022',
+                    verification_value: '123',
+                    name: 'John Doe'
+                  }
                 }
               ]
-            },
-            payment_source: {
-              1: {
-                number: '4111111111111111',
-                month: '01',
-                year: '2022',
-                verification_value: '123',
-                name: 'John Doe'
-              }
             }
           }
         </pre>
@@ -596,10 +594,10 @@ paths:
                             type: number
                             example: 1
                             description: 'ID of selected payment method'
+                          source_attributes:
+                            $ref: '#/components/schemas/PaymentSource'
                     shipments_attributes:
                       type: object
-                payment_source:
-                  type: object
 
   '/checkout/next':
     patch:
@@ -2416,6 +2414,29 @@ components:
         zipcode: '20814'
         state_name: 'MD'
         country_iso: 'US'
+    PaymentSource:
+      properties:
+        number:
+          type: string
+          description: 'Credit card number'
+        month:
+          type: string
+        year:
+          type: string
+        verification_value:
+          type: string
+        cc_type:
+          type: string
+          description: 'Credit Card Brand'
+        name:
+          type: string
+      example:
+        number: '4111111111111111'
+        month: '01'
+        year: '2022'
+        verification_value: '123'
+        cc_type: 'visa'
+        name: 'John Doe'
 
   parameters:
     CreditCardIncludeParam:


### PR DESCRIPTION
Docs are completely wrong for how to add a payment source with PATCH /checkout

The source_attributes needs to be nested inside payments_attributes for it to work.
Current docs for API V2 show having separate payment_source which is possibly how it works for API V1 but not V2.