### PR TITLE
Centralise Logo Vertically on large screens + Correct Price Display...

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -635,7 +635,7 @@ en:
     cart_page:
       add_promo_code: ADD PROMO CODE
       checkout: checkout
-      empty_info: 'Your cart is empty.<br />There are no items in your cart.'
+      empty_info: 'Your cart is empty.'
       header: Your shopping bag
       product: product
       quantity: quantity

--- a/frontend/app/assets/javascripts/spree/frontend/views/spree/shared/product_added_modal.js
+++ b/frontend/app/assets/javascripts/spree/frontend/views/spree/shared/product_added_modal.js
@@ -12,7 +12,7 @@ Spree.showProductAddedModal = function(product, variant) {
   var $modal = $(modalSelector)
 
   $modal.find(nameSelector).text(name)
-  $modal.find(priceSelector).text(price)
+  $modal.find(priceSelector).html(price)
 
   if (leadImage !== null) {
     $modal

--- a/frontend/app/assets/stylesheets/spree/frontend/views/spree/shared/main_nav_bar.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/views/spree/shared/main_nav_bar.scss
@@ -67,6 +67,7 @@
       display: none;
       background: $meganav-background;
       background-clip: padding-box;
+      border-top: 1px solid $global-border-style;
 
       form {
         input#keywords {
@@ -92,7 +93,7 @@
       }
 
       @include media-breakpoint-up(xl) {
-        top: $spree-header-desktop-height;
+        top: $spree-header-desktop-height - 1px;
       }
     }
   }

--- a/frontend/app/views/spree/products/_filters_desktop.html.erb
+++ b/frontend/app/views/spree/products/_filters_desktop.html.erb
@@ -1,7 +1,7 @@
 <% cache base_cache_key + [available_option_types, permitted_params, @taxon] do %>
   <div id="plp-filters-accordion" class="d-none d-lg-block col-lg-3 pr-5 position-sticky h-100 plp-filters" data-hook="taxon_sidebar_navigation">
     <% @available_option_types.each do |option_type| %>
-      <div class="w-100 py-2 card plp-filters-card">
+      <div class="w-100 card plp-filters-card">
         <% ot_downcase_name = option_type.filter_param %>
         <% option_type_name = ot_downcase_name.titleize %>
 
@@ -29,7 +29,7 @@
       </div>
     <% end %>
 
-    <div class="w-100 py-2 card plp-filters-card">
+    <div class="w-100 card plp-filters-card">
       <div class="card-header <%= 'collapsed' if params[:price].blank? %> px-1 plp-filters-card-header" id="filtersPrice" data-toggle="collapse" data-target="#collapseFilterPrice" aria-expanded="false" aria-controls="collapseFilterPrice" role="heading" aria-level="2">
         <%= Spree.t('plp.price') %>
         <%= icon(name: 'plus',

--- a/frontend/app/views/spree/shared/_checkout_header.html.erb
+++ b/frontend/app/views/spree/shared/_checkout_header.html.erb
@@ -10,7 +10,7 @@
         <%= link_to Spree.t('back'), spree.cart_path, class: "d-sm-none text-uppercase", method: :get %>
       </div>
       <div class="d-flex flex-nowrap align-items-center justify-content-center">
-        <figure class="logo flex-grow-0 flex-xl-grow-0 order-xl-0 header-spree-fluid-logo">
+        <figure class="logo flex-grow-0 flex-xl-grow-0 order-xl-0 header-spree-fluid-logo m-0">
         <%= logo(Spree::Config[:logo], method: :get) %>
         </figure>
       </div>

--- a/frontend/app/views/spree/shared/_header.html.erb
+++ b/frontend/app/views/spree/shared/_header.html.erb
@@ -11,7 +11,7 @@
                       height: 16)  %>
             </button>
           </div>
-          <figure class="logo flex-grow-0 flex-xl-grow-1 order-xl-0 header-spree-fluid-logo">
+          <figure class="logo flex-grow-0 flex-xl-grow-1 order-xl-0 header-spree-fluid-logo m-0">
             <%= logo %>
           </figure>
           <div id="main-nav-bar" class="flex-grow-0 d-none d-xl-block h-100 header-spree-fluid-primary-navigation">


### PR DESCRIPTION
- Centralise Spree logo vertically on large screens.
- Correct price display in the added to cart modal when the currency is not dollars.
- The empty cart info said the same thing two different ways with a line break between.
- Move categories menu up 1px and add 1px border to the top of the categories div matching the nav bar border. This stops the categories menu from closing if you're not quick enough moving the mouse down into the menu, looks seamless.

<img width="821" alt="Screenshot 2020-02-08 at 14 16 27" src="https://user-images.githubusercontent.com/1240766/74086758-0812b580-4a7e-11ea-8e01-a375f8f5cce2.png">


Vertically centre Product filters.
Before:

<img width="280" alt="Screenshot 2020-02-08 at 15 43 53" src="https://user-images.githubusercontent.com/1240766/74088124-bae91080-4a8a-11ea-8bf8-1565dfcc6ff5.png">

After:
<img width="293" alt="Screenshot 2020-02-08 at 15 47 38" src="https://user-images.githubusercontent.com/1240766/74088134-ca685980-4a8a-11ea-9bac-d108bf1a81ea.png">

Is there a reason PRICE is in upper case?
