### PR TITLE
Fix product thumbnail selected outline.

### DIFF
--- a/frontend/app/assets/stylesheets/spree/frontend/views/spree/shared/carousel/thumbnails.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/views/spree/shared/carousel/thumbnails.scss
@@ -11,21 +11,17 @@
       display: block;
     }
     &-single {
-      height: 0;
-      padding-bottom: $thumbnails-carousel-single-height;
+      height: auto;
       position: relative;
       display: none;
+      overflow: hidden;
 
       .modal-dialog--zoom & {
         padding-bottom: $thumbnails-carousel-single-height-zoom;
       }
 
       img {
-        position: absolute;
-        width: 100%;
-        height: 100%;
-        object-fit: contain;
-        border: 1px solid transparent;
+        border: 2px solid transparent;
         &.selected {
           border-color: $secondary-color;
         }
@@ -75,7 +71,7 @@
       &-single {
         &--visible {
           & ~ & {
-            margin-top: $single-gap-md;
+            margin-top: $single-gap-md * 3;
           }
 
           .modal-dialog--zoom & ~ & {

--- a/frontend/app/views/spree/shared/carousel/_thumbnails.html.erb
+++ b/frontend/app/views/spree/shared/carousel/_thumbnails.html.erb
@@ -13,7 +13,7 @@
       <% if image_index % per_page == 0 %>
         <div class="carousel-item product-thumbnails-carousel-item<%= ' active' if image_index == 0 %>">
         <div class="h-100 d-flex flex-column justify-content-center">
-            <div class="product-thumbnails-carousel-item-content">
+            <div class="product-thumbnails-carousel-item-content py-4">
       <% end %>
               <div
                 class="product-thumbnails-carousel-item-single product-thumbnails-carousel-item-single--visible"


### PR DESCRIPTION
Selected product image thumbnail had a strange gap on the border top and bottom.

- Set the border tight on the image. No matter if it is not a square image the border will now hug the image outline.
- Set surrounding div to hug tight around image for better targeting with mouse or touch. (Gaps between the thumbnail images are not be clickable space anymore).
- Add 1px to border to give better visual of selected image when border matched colour of image

** Needs testing on legacy / windows browsers, I have only tested in latest versions of Chrome, Safari, Edge, Opera and Firefox for Mac.

**BEFORE**
<img width="1280" alt="Screenshot 2020-02-09 at 12 39 36" src="https://user-images.githubusercontent.com/1240766/74102817-078e2380-4b3f-11ea-983c-beb5f1a6d8e0.png">

**AFTER**
<img width="1280" alt="Screenshot 2020-02-09 at 13 22 40" src="https://user-images.githubusercontent.com/1240766/74102859-46bc7480-4b3f-11ea-97a1-ede502bec131.png">



