### PR TITLE
Fix product thumbnail selected outline Smaller margin.

### DIFF
--- a/frontend/app/assets/stylesheets/spree/frontend/views/spree/shared/carousel/thumbnails.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/views/spree/shared/carousel/thumbnails.scss
@@ -11,21 +11,16 @@
       display: block;
     }
     &-single {
-      height: 0;
-      padding-bottom: $thumbnails-carousel-single-height;
       position: relative;
       display: none;
+      overflow: hidden;
 
       .modal-dialog--zoom & {
         padding-bottom: $thumbnails-carousel-single-height-zoom;
       }
 
       img {
-        position: absolute;
-        width: 100%;
-        height: 100%;
-        object-fit: contain;
-        border: 1px solid transparent;
+        border: 2px solid transparent;
         &.selected {
           border-color: $secondary-color;
         }
@@ -75,7 +70,7 @@
       &-single {
         &--visible {
           & ~ & {
-            margin-top: $single-gap-md;
+            margin-top: $single-gap-md / 2;
           }
 
           .modal-dialog--zoom & ~ & {

--- a/frontend/app/assets/stylesheets/spree/frontend/views/spree/shared/carousel/thumbnails.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/views/spree/shared/carousel/thumbnails.scss
@@ -15,10 +15,6 @@
       display: none;
       overflow: hidden;
 
-      .modal-dialog--zoom & {
-        padding-bottom: $thumbnails-carousel-single-height-zoom;
-      }
-
       img {
         border: 2px solid transparent;
         &.selected {

--- a/frontend/app/views/spree/shared/carousel/_thumbnails.html.erb
+++ b/frontend/app/views/spree/shared/carousel/_thumbnails.html.erb
@@ -13,7 +13,7 @@
       <% if image_index % per_page == 0 %>
         <div class="carousel-item product-thumbnails-carousel-item<%= ' active' if image_index == 0 %>">
         <div class="h-100 d-flex flex-column justify-content-center">
-            <div class="product-thumbnails-carousel-item-content">
+            <div class="product-thumbnails-carousel-item-content py-1">
       <% end %>
               <div
                 class="product-thumbnails-carousel-item-single product-thumbnails-carousel-item-single--visible"


### PR DESCRIPTION
Same as previous pull request with margins reduced so that thumbnail selector is not larger than the image even when using portrait images.

<img width="1280" alt="Screenshot 2020-02-09 at 17 47 12" src="https://user-images.githubusercontent.com/1240766/74107161-3dde9980-4b65-11ea-8e79-b8ccf5f53349.png">
