### PR TITLE
Fix association between InventoryUnit and ReturnAuthorization

### DIFF
--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -4,11 +4,11 @@ module Spree
       belongs_to :variant, class_name: 'Spree::Variant'
       belongs_to :order, class_name: 'Spree::Order'
       belongs_to :shipment, class_name: 'Spree::Shipment', touch: true, optional: true
-      belongs_to :return_authorization, class_name: 'Spree::ReturnAuthorization'
+      has_many :return_items
+      has_many :return_authorizations, class_name: 'Spree::ReturnAuthorization', through: :return_items
       belongs_to :line_item, class_name: 'Spree::LineItem'
     end
 
-    has_many :return_items, inverse_of: :inventory_unit
     belongs_to :original_return_item, class_name: 'Spree::ReturnItem'
 
     scope :backordered, -> { where state: 'backordered' }

--- a/core/spec/models/spree/inventory_unit_spec.rb
+++ b/core/spec/models/spree/inventory_unit_spec.rb
@@ -164,6 +164,10 @@ describe Spree::InventoryUnit, type: :model do
       it "returns it's associated return_item" do
         expect(subject).to eq return_item
       end
+
+      it 'connects return_authorizations' do
+        expect(inventory_unit.return_authorizations).to eq [return_item.return_authorization]
+      end 
     end
 
     context 'no associated return item' do


### PR DESCRIPTION
Since ReturnAuthorization associates InventoryUnit with a has_many through: :return_items
And on the other side InventoryUnit associate it with belongs_to, if you try to reach the return_authorization of an InventoryUnit, the result were always nil. I created a fix to this problem, and included a test, which fails without my modification.