### PR TITLE
Change Time.parse to strptime

### DIFF
--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -23,7 +23,7 @@ module Spree
 
         if params[:q][:created_at_gt].present?
           params[:q][:created_at_gt] = begin
-                                         Time.zone.parse(params[:q][:created_at_gt]).beginning_of_day
+                                         Time.zone.strptime(params[:q][:created_at_gt], Spree.t('date_picker.format')).beginning_of_day
                                        rescue StandardError
                                          ''
                                        end
@@ -31,7 +31,7 @@ module Spree
 
         if params[:q][:created_at_lt].present?
           params[:q][:created_at_lt] = begin
-                                         Time.zone.parse(params[:q][:created_at_lt]).end_of_day
+                                         Time.zone.strptime(params[:q][:created_at_lt], Spree.t('date_picker.format')).end_of_day
                                        rescue StandardError
                                          ''
                                        end

--- a/backend/app/controllers/spree/admin/reports_controller.rb
+++ b/backend/app/controllers/spree/admin/reports_controller.rb
@@ -32,7 +32,7 @@ module Spree
                                          Time.zone.now.beginning_of_month
                                        else
                                          begin
-                                           Time.zone.parse(params[:q][:completed_at_gt]).beginning_of_day
+                                           Time.zone.strptime(params[:q][:completed_at_gt], Spree.t('date_picker.format')).beginning_of_day
                                          rescue StandardError
                                            Time.zone.now.beginning_of_month
                                          end
@@ -40,7 +40,7 @@ module Spree
 
         if params[:q] && !params[:q][:completed_at_lt].blank?
           params[:q][:completed_at_lt] = begin
-                                           Time.zone.parse(params[:q][:completed_at_lt]).end_of_day
+                                           Time.zone.strptime(params[:q][:completed_at_lt], Spree.t('date_picker.format')).end_of_day
                                          rescue StandardError
                                            ''
                                          end


### PR DESCRIPTION
In en.yml I found these values:
https://github.com/spree/spree/blob/ed2b87e97fa5427bc5929dac04a4445229eabcd5/core/config/locales/en.yml#L742-L745

I tried changing the locale to print `mm-dd-yyyy` and they printed fine but executing the filter would not work correctly because `Time.zone.parse` in the controller was parsing the value as `dd-mm-yyyy`.

I replaced four instances of `Time.zone.parse` with `Time.zone.strptime` and passed in the formatter from the locale.