### PR TITLE
Refactor admin ReturnAuthorizations controller to not use unsafe :send

### DIFF
--- a/backend/app/controllers/spree/admin/return_authorizations_controller.rb
+++ b/backend/app/controllers/spree/admin/return_authorizations_controller.rb
@@ -7,9 +7,9 @@ module Spree
       create.fails  :load_form_data
       update.fails  :load_form_data
 
-      def fire
-        @return_authorization.send("#{params[:e]}!")
-        flash[:success] = Spree.t(:return_authorization_updated)
+      def cancel
+        @return_authorization.cancel!
+        flash[:success] = Spree.t(:return_authorization_canceled)
         redirect_back fallback_location: spree.edit_admin_order_return_authorization_path(@order, @return_authorization)
       end
 

--- a/backend/app/views/spree/admin/return_authorizations/edit.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_actions do %>
   <% if @return_authorization.can_cancel? %>
-    <%= button_link_to Spree.t('actions.cancel'), fire_admin_order_return_authorization_url(@order, @return_authorization, e: 'cancel'), method: :put, data: { confirm: Spree.t(:are_you_sure) }, icon: "delete" %>
+    <%= button_link_to Spree.t('actions.cancel'), cancel_admin_order_return_authorization_url(@order, @return_authorization), method: :put, data: { confirm: Spree.t(:are_you_sure) }, icon: "delete" %>
   <% end %>
 <% end %>
 

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -99,7 +99,7 @@ Spree::Core::Engine.add_routes do
       resources :adjustments
       resources :return_authorizations do
         member do
-          put :fire
+          put :cancel
         end
       end
       resources :payments do

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1367,6 +1367,7 @@ en:
       authorized: Authorized
       canceled: Canceled
     return_authorization_updated: Return authorization updated
+    return_authorization_canceled: Return authorization canceled
     return_authorizations: Return Authorizations
     return_item_inventory_unit_ineligible: Return item's inventory unit must be shipped
     return_item_inventory_unit_reimbursed: Return item's inventory unit is already reimbursed


### PR DESCRIPTION
Using :send with user-input is not safe even having a `!` added in the end.
Read more here: https://ruby-doc.org/core-2.6.5/doc/security_rdoc.html#label-send