### PR TITLE
Prevent stray text if guest checkout set to false.

### DIFF
--- a/frontend/app/views/spree/checkout/registration.html.erb
+++ b/frontend/app/views/spree/checkout/registration.html.erb
@@ -8,11 +8,11 @@
       <div class="col-lg-11 mx-auto">
         <% if defined?(spree_signup_path) %>
           <%= render partial: 'spree/shared/registration', locals: { registration_button: '' } %>
+        <% end %>
+        <% if Spree::Config[:allow_guest_checkout] %>
           <div class="checkout-registration-styled-or">
             <%= Spree.t(:or) %>
           </div>
-        <% end %>
-        <% if Spree::Config[:allow_guest_checkout] %>
           <% path = spree.respond_to?(:update_checkout_registration_path) ? spree.update_checkout_registration_path : spree_signup_path %>
 
           <%= form_for @order, url: path, method: :put, html: { id: 'checkout_form_registration' } do |f| %>


### PR DESCRIPTION
When guest checkout is set to false you get the text - or - with no option below it.

**BEFORE:**

<img width="1106" alt="Screenshot 2020-02-19 at 14 11 04" src="https://user-images.githubusercontent.com/1240766/74842391-3e73ee80-5322-11ea-90a0-8120873492ab.png">

**CHANGED TO:** 
<img width="1030" alt="Screenshot 2020-02-19 at 14 11 13" src="https://user-images.githubusercontent.com/1240766/74842416-4af84700-5322-11ea-9ccb-d2eaa778aedd.png">

