### PR TITLE
Added caching to BaseHelper#default_image_for_product_or_variant

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -105,14 +105,16 @@ module Spree
     end
 
     def default_image_for_product_or_variant(product_or_variant)
-      if product_or_variant.images.empty?
-        if product_or_variant.is_a?(Spree::Product) && product_or_variant.variant_images.any?
-          product_or_variant.variant_images.first
-        elsif product_or_variant.is_a?(Spree::Variant) && product_or_variant.product.variant_images.any?
-          product_or_variant.product.variant_images.first
+      Rails.cache.fetch("spree/default-image/#{product_or_variant.cache_key_with_version}") do
+        if product_or_variant.images.empty?
+          if product_or_variant.is_a?(Spree::Product) && product_or_variant.variant_images.any?
+            product_or_variant.variant_images.first
+          elsif product_or_variant.is_a?(Spree::Variant) && product_or_variant.product.variant_images.any?
+            product_or_variant.product.variant_images.first
+          end
+        else
+          product_or_variant.images.first
         end
-      else
-        product_or_variant.images.first
       end
     end
 

--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -52,7 +52,7 @@ describe Spree::BaseHelper, type: :helper do
 
   # Regression test for #1436
   context 'defining custom image helpers' do
-    let(:product) { mock_model(Spree::Product, images: [], variant_images: []) }
+    let(:product) { build(:product) }
 
     before do
       Spree::Image.class_eval do


### PR DESCRIPTION
Besides Spree codebase it's also used in Spree Analytics Trackers and other extensions. So it makes sense to cache this