### PR TITLE
Use default_image_for_product_or_variant in StructuredDataHelper

### DIFF
--- a/frontend/app/helpers/spree/structured_data_helper.rb
+++ b/frontend/app/helpers/spree/structured_data_helper.rb
@@ -36,7 +36,7 @@ module Spree
     end
 
     def structured_images(product)
-      image = product.default_variant.images.first
+      image = default_image_for_product_or_variant(product)
 
       return '' unless image
 


### PR DESCRIPTION
Replace redundant method and re-use cached method to improve performance