### PR TITLE
Always render cart indicator with 0

### DIFF
--- a/frontend/app/views/spree/shared/_nav_bar.html.erb
+++ b/frontend/app/views/spree/shared/_nav_bar.html.erb
@@ -39,15 +39,7 @@
     </li>
   <% end %>
   <li id="link-to-cart">
-    <span class="d-none d-xl-inline-block cart-icon--xl">
-      <%= icon(name: 'cart',
-               width: 41.8,
-               height: 36)  %>
-    </span>
-    <span class="d-xl-none">
-      <%= icon(name: 'cart',
-               width: 27.8,
-               height: 24)  %>
-    </span>
+    <%= render 'spree/shared/cart', class: 'd-none d-xl-inline-block cart-icon--xl', size: 36, item_count: 0 %>
+    <%= render 'spree/shared/cart', class: 'd-xl-none', size: 24, item_count: 0 %>
   </li>
 </ul>


### PR DESCRIPTION
This will remove cart indicator flickering when loading data from API