### PR TITLE
Always display default Variant image on PLP when present

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -104,16 +104,26 @@ module Spree
       Spree::Core::Engine.frontend_available?
     end
 
+    # we should always try to render image of the default variant
+    # same as it's done on PDP
+    def default_image_for_product(product)
+      if product.default_variant.images.any?
+        product.default_variant.images.first
+      elsif product.variant_images.any?
+        product.variant_images.first
+      end
+    end
+
     def default_image_for_product_or_variant(product_or_variant)
       Rails.cache.fetch("spree/default-image/#{product_or_variant.cache_key_with_version}") do
-        if product_or_variant.images.empty?
-          if product_or_variant.is_a?(Spree::Product) && product_or_variant.variant_images.any?
-            product_or_variant.variant_images.first
-          elsif product_or_variant.is_a?(Spree::Variant) && product_or_variant.product.variant_images.any?
-            product_or_variant.product.variant_images.first
+        if product_or_variant.is_a?(Spree::Product)
+          default_image_for_product(product_or_variant)
+        elsif product_or_variant.is_a?(Spree::Variant)
+          if product_or_variant.images.any?
+            product_or_variant.images.first
+          else
+            default_image_for_product(product_or_variant.product)
           end
-        else
-          product_or_variant.images.first
         end
       end
     end

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -75,6 +75,7 @@ module Spree
     has_many :orders, through: :line_items
 
     has_many :variant_images, -> { order(:position) }, source: :images, through: :variants_including_master
+    has_many :variant_images_without_master, -> { order(:position) }, source: :images, through: :variants
 
     after_create :add_associations_from_prototype
     after_create :build_variants_from_option_values_hash, if: :option_values_hash

--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -203,14 +203,16 @@ describe Spree::BaseHelper, type: :helper do
 
       it { is_expected.to eq(nil) }
 
-      context 'and Variant has images' do
-        let!(:image_1) { create :image, viewable: variant }
-        let!(:image_2) { create :image, viewable: variant }
+      context 'with variants' do
+        let!(:image_1) { create :image, viewable: product.master }
+        let!(:image_2) { create :image, viewable: product.master }
+        let!(:image_3) { create :image, viewable: variant }
+        let!(:image_4) { create :image, viewable: variant }
 
-        it { is_expected.to eq(image_1) }
+        it { is_expected.to eq(image_3) }
       end
 
-      context 'and master Variant has images' do
+      context 'only with master' do
         let!(:image_1) { create :image, viewable: product.master }
         let!(:image_2) { create :image, viewable: product.master }
 


### PR DESCRIPTION
This will align PLP behaviour with PDP. Previously you could see different thumbnail on PLP and a different image on PDP when entered.