### PR TITLE
Changed Product#default_variant behaviour

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -151,10 +151,28 @@ module Spree
       variants.any?
     end
 
+    # Returns default Variant for Product
+    # If `track_inventory_levels` is enabled it will try to find the first Variant
+    # in stock or backorderable, if there's none it will return first Variant sorted
+    # by `position` attribute
+    # If `track_inventory_levels` is disabled it will return first Variant sorted
+    # by `position` attribute
+    #
+    # @return [Spree::Variant]
     def default_variant
-      has_variants? ? variants.first : master
+      track_inventory = Spree::Config[:track_inventory_levels]
+
+      Rails.cache.fetch("spree/default-variant/#{cache_key_with_version}/#{track_inventory}") do
+        if track_inventory && variants.in_stock_or_backorderable.any?
+          variants.in_stock_or_backorderable.first
+        else
+          has_variants? ? variants.first : master
+        end
+      end
     end
 
+    # Returns default Variant ID for Product
+    # @return [Integer]
     def default_variant_id
       default_variant.id
     end

--- a/core/app/presenters/spree/variants/option_types_presenter.rb
+++ b/core/app/presenters/spree/variants/option_types_presenter.rb
@@ -55,7 +55,7 @@ module Spree
 
       def try_default_variant
         option_types.first.option_values.each do |option_value|
-          variant = option_value.variants.where(id: @product.default_variant_id).in_stock_or_backorderable.first
+          variant = option_value.variants.where(id: @product.default_variant_id).first
 
           return { variant: variant, option_value: option_value } if variant
         end

--- a/core/spec/presenters/spree/variants/option_types_presenter_spec.rb
+++ b/core/spec/presenters/spree/variants/option_types_presenter_spec.rb
@@ -58,7 +58,8 @@ describe Spree::Variants::OptionTypesPresenter do
 
     context 'with in-stock Variant' do
       before do
-        variant_0.stock_items.first.update(backorderable: false)
+        variant_0.stock_items.first.update(backorderable: false, count_on_hand: 0)
+        variant_1.stock_items.first.update(backorderable: false, count_on_hand: 0)
         variant_2.stock_items.first.adjust_count_on_hand(1)
       end
 


### PR DESCRIPTION
If inventory levels tracking is enabled it will try to return first in stock or backorderable Variant. This matches the actual behaviour of new Storefront and generally makes sense :)