### PR TITLE
Fix small typo in address documentation

### DIFF
--- a/guides/src/content/developer/core/addresses.md
+++ b/guides/src/content/developer/core/addresses.md
@@ -24,7 +24,7 @@ Addresses can also link to countries and states. An address must always link to 
 
 ## Users
 
-As of Spree 4.0 `Spree::User` can have multiple addresses and can select them on the checkout and account page. Previously this feature was part of the [spree_address_book](https://github.com/spree-contrib/spree_address_book) extension. Each `Spree::Address` object has a `user_id` columnt which links to the User.
+As of Spree 4.0 `Spree::User` can have multiple addresses and can select them on the checkout and account page. Previously this feature was part of the [spree_address_book](https://github.com/spree-contrib/spree_address_book) extension. Each `Spree::Address` object has a `user_id` column which links to the User.
 
 Additionaly in the `Spree::User` model you have `ship_address_id` and `bill_address_id` columns which indicates default shipping and billing addresses.
 


### PR DESCRIPTION
I found a small typo in the documentation on addresses. This pull request changes the word `columnt` to `column`.