### PR TITLE
Fix documentation for hiding spree version number

### DIFF
--- a/guides/src/content/developer/customization/view.md
+++ b/guides/src/content/developer/customization/view.md
@@ -77,7 +77,7 @@ You need to set a preference in `config/initializers/spree.rb` file, eg.
 
 ```ruby
 Spree.config do |config|
-  config.admin_show_version = 'my_new_admin_logo.png'
+  config.admin_show_version = false
 end
 ```
 


### PR DESCRIPTION
This pull request fixes another documentation issue I found. I'm not 100% positive that this is correct, but what was there already definitely wasn't. Let me know if this needs to be changed.