### PR TITLE
Fix misspelling in the checkout customization docs

### DIFF
--- a/guides/src/content/developer/customization/checkout.md
+++ b/guides/src/content/developer/customization/checkout.md
@@ -139,7 +139,7 @@ add a new state, you will need to create a new partial for this state.
 
 The `update` action performs the following:
 
-* Updates the `current_order` with the paramaters passed in from the current
+* Updates the `current_order` with the parameters passed in from the current
   step.
 * Transitions the order state machine using the `next` event after successfully
   updating the order.


### PR DESCRIPTION
Another small documentation fix: `paramaters` -> `parameters`. Sorry for all the small pull requests, I'm just doing this through the GitHub UI.