### PR TITLE
Stop text string appearing for £ and €

### DIFF
--- a/frontend/app/assets/javascripts/spree/frontend/views/spree/products/cart_form.js
+++ b/frontend/app/assets/javascripts/spree/frontend/views/spree/products/cart_form.js
@@ -220,7 +220,7 @@ function CartForm($, $cartForm) {
 
     if (!variant) return
 
-    this.$price.text(variant.display_price)
+    this.$price.html(variant.display_price)
   }
 
   this.updateVariantId = function() {


### PR DESCRIPTION
Prevent £ and € symbols showing as a html string of characters with products in other currencies.