### PR TITLE
Update documentation for 4.1 release

### DIFF
--- a/guides/src/content/developer/upgrades/four-dot-oh-to-four-dot-one.md
+++ b/guides/src/content/developer/upgrades/four-dot-oh-to-four-dot-one.md
@@ -2,7 +2,6 @@
 title: Upgrading Spree 4.0 to 4.1
 section: upgrades
 order: 0
-hidden: true
 ---
 
 This guide covers upgrading a **4.0 Spree application** to **Spree 4.1**.

--- a/guides/src/content/developer/upgrades/one-dot-oh-to-one-dot-one.md
+++ b/guides/src/content/developer/upgrades/one-dot-oh-to-one-dot-one.md
@@ -2,7 +2,7 @@
 title: Upgrading Spree from 1.0.x to 1.1.x
 section: upgrades
 hidden: false
-order: 14
+order: 16
 ---
 
 ## Overview

--- a/guides/src/content/developer/upgrades/one-dot-one-to-one-dot-two.md
+++ b/guides/src/content/developer/upgrades/one-dot-one-to-one-dot-two.md
@@ -1,7 +1,7 @@
 ---
 title: Upgrading Spree from 1.1.x to 1.2.x
 section: upgrades
-order: 13
+order: 15
 ---
 
 ## Overview

--- a/guides/src/content/developer/upgrades/one-dot-three-to-two-dot-oh.md
+++ b/guides/src/content/developer/upgrades/one-dot-three-to-two-dot-oh.md
@@ -1,7 +1,7 @@
 ---
 title: Upgrading Spree from 1.3.x to 2.0.x
 section: upgrades
-order: 11
+order: 13
 ---
 
 ## Overview

--- a/guides/src/content/developer/upgrades/one-dot-two-to-one-dot-three.md
+++ b/guides/src/content/developer/upgrades/one-dot-two-to-one-dot-three.md
@@ -1,7 +1,7 @@
 ---
 title: Upgrading Spree from 1.2.x to 1.3.x
 section: upgrades
-order: 12
+order: 14
 ---
 
 ## Overview

--- a/guides/src/content/developer/upgrades/point-seventy-to-one-dot-oh.md
+++ b/guides/src/content/developer/upgrades/point-seventy-to-one-dot-oh.md
@@ -1,7 +1,7 @@
 ---
 title: Upgrading Spree from 0.70.x to 1.0.x
 section: upgrades
-order: 15
+order: 17
 ---
 
 ## Overview

--- a/guides/src/content/developer/upgrades/point-sixty-to-point-seventy.md
+++ b/guides/src/content/developer/upgrades/point-sixty-to-point-seventy.md
@@ -1,7 +1,7 @@
 ---
 title: Upgrading Spree from 0.60.x to 0.70.x
 section: upgrades
-order: 16
+order: 18
 ---
 
 ## Overview

--- a/guides/src/content/developer/upgrades/three-dot-five-to-three-dot-six.md
+++ b/guides/src/content/developer/upgrades/three-dot-five-to-three-dot-six.md
@@ -1,7 +1,7 @@
 ---
 title: Upgrading Spree from 3.5.x to 3.6.x
 section: upgrades
-order: 1
+order: 3
 ---
 
 This guide covers upgrading a 3.5 Spree application, to a 3.6 application.

--- a/guides/src/content/developer/upgrades/three-dot-four-to-three-dot-five.md
+++ b/guides/src/content/developer/upgrades/three-dot-four-to-three-dot-five.md
@@ -1,7 +1,7 @@
 ---
 title: Upgrading Spree from 3.4.x to 3.5.x
 section: upgrades
-order: 2
+order: 4
 ---
 
 This guide covers upgrading a 3.4 Spree store, to a 3.5 store.

--- a/guides/src/content/developer/upgrades/three-dot-oh-to-three-dot-one.md
+++ b/guides/src/content/developer/upgrades/three-dot-oh-to-three-dot-one.md
@@ -1,7 +1,7 @@
 ---
 title: Upgrading Spree from 3.0.x to 3.1.x
 section: upgrades
-order: 6
+order: 8
 ---
 
 This guide covers upgrading a 3.0.x Spree store, to a 3.1.x store. This

--- a/guides/src/content/developer/upgrades/three-dot-one-to-three-dot-two.md
+++ b/guides/src/content/developer/upgrades/three-dot-one-to-three-dot-two.md
@@ -1,7 +1,7 @@
 ---
 title: Upgrading Spree from 3.1.x to 3.2.x
 section: upgrades
-order: 5
+order: 7
 ---
 
 This guide covers upgrading a 3.1.x Spree store, to a 3.2.x store.

--- a/guides/src/content/developer/upgrades/three-dot-seven-to-four-dot-oh.md
+++ b/guides/src/content/developer/upgrades/three-dot-seven-to-four-dot-oh.md
@@ -1,7 +1,7 @@
 ---
 title: Upgrading Spree 3.7 to 4.0
 section: upgrades
-order: 0
+order: 1
 ---
 
 This guide covers upgrading a **3.7 Spree application** to **Spree 4.0**. 

--- a/guides/src/content/developer/upgrades/three-dot-six-to-three-dot-seven.md
+++ b/guides/src/content/developer/upgrades/three-dot-six-to-three-dot-seven.md
@@ -1,7 +1,7 @@
 ---
 title: Upgrading Spree from 3.6 to 3.7
 section: upgrades
-order: 0
+order: 2
 ---
 
 This guide covers upgrading a 3.6 Spree application, to version 3.7.

--- a/guides/src/content/developer/upgrades/three-dot-three-to-three-dot-four.md
+++ b/guides/src/content/developer/upgrades/three-dot-three-to-three-dot-four.md
@@ -1,7 +1,7 @@
 ---
 title: Upgrading Spree from 3.3.x to 3.4.x
 section: upgrades
-order: 3
+order: 5
 ---
 
 This guide covers upgrading a 3.3 Spree store, to a 3.4 store.

--- a/guides/src/content/developer/upgrades/three-dot-two-to-three-dot-three.md
+++ b/guides/src/content/developer/upgrades/three-dot-two-to-three-dot-three.md
@@ -1,7 +1,7 @@
 ---
 title: Upgrading Spree from 3.2.x to 3.3.x
 section: upgrades
-order: 4
+order: 6
 ---
 
 This guide covers upgrading a 3.2.x Spree store, to a 3.3.x store.

--- a/guides/src/content/developer/upgrades/two-dot-oh-to-two-dot-one.md
+++ b/guides/src/content/developer/upgrades/two-dot-oh-to-two-dot-one.md
@@ -1,7 +1,7 @@
 ---
 title: Upgrading Spree from 2.0.x to 2.1.x
 section: upgrades
-order: 10
+order: 12
 ---
 
 ## Overview

--- a/guides/src/content/developer/upgrades/two-dot-one-to-two-dot-two.md
+++ b/guides/src/content/developer/upgrades/two-dot-one-to-two-dot-two.md
@@ -1,7 +1,7 @@
 ---
 title: Upgrading Spree from 2.1.x to 2.2.x
 section: upgrades
-order: 9
+order: 11
 ---
 
 ## Overview

--- a/guides/src/content/developer/upgrades/two-dot-three-to-two-dot-four.md
+++ b/guides/src/content/developer/upgrades/two-dot-three-to-two-dot-four.md
@@ -1,7 +1,7 @@
 ---
 title: Upgrading Spree from 2.3.x to 2.4.x
 section: upgrades
-order: 7
+order: 9
 ---
 
 This guide covers upgrading a 2.3.x Spree store, to a 2.4.x store. This

--- a/guides/src/content/developer/upgrades/two-dot-two-to-two-dot-three.md
+++ b/guides/src/content/developer/upgrades/two-dot-two-to-two-dot-three.md
@@ -1,7 +1,7 @@
 ---
 title: Upgrading Spree from 2.2.x to 2.3.x
 section: upgrades
-order: 8
+order: 10
 ---
 
 ## Overview

--- a/guides/src/content/developer/upgrades/upgrade_guides.md
+++ b/guides/src/content/developer/upgrades/upgrade_guides.md
@@ -9,6 +9,9 @@ We strongly advise upgrading Spree incrementally, rather than in one big go. For
 
 If there are any issues with these guides, please let us know by [filing an issue](https://github.com/spree/spree/issues/new).
 
+* [4.0 to 4.1](/developer/four-dot-oh-to-four-dot-one)
+* [3.7 to 4.0](/developer/three-dot-seven-to-four-dot-oh)
+* [3.6 to 3.7](/developer/three-dot-six-to-three-dot-seven)
 * [3.5.x to 3.6.x](/developer/three-dot-five-to-three-dot-six)
 * [3.4.x to 3.5.x](/developer/three-dot-four-to-three-dot-five)
 * [3.3.x to 3.4.x](/developer/three-dot-three-to-three-dot-four)

--- a/guides/src/content/release_notes/0_10_0.md
+++ b/guides/src/content/release_notes/0_10_0.md
@@ -1,7 +1,7 @@
 ---
 title: Spree 0.10.0
 section: release_notes
-order: 25
+order: 26
 ---
 
 # Upgrade Notes

--- a/guides/src/content/release_notes/0_30_0.md
+++ b/guides/src/content/release_notes/0_30_0.md
@@ -1,7 +1,7 @@
 ---
 title: Spree 0.30.0
 section: release_notes
-order: 24
+order: 25
 ---
 
 # Summary

--- a/guides/src/content/release_notes/0_40_0.md
+++ b/guides/src/content/release_notes/0_40_0.md
@@ -1,7 +1,7 @@
 ---
 title: Spree 0.40.0
 section: release_notes
-order: 23
+order: 24
 ---
 
 # Summary

--- a/guides/src/content/release_notes/0_50_0.md
+++ b/guides/src/content/release_notes/0_50_0.md
@@ -1,7 +1,7 @@
 ---
 title: Spree 0.50.0
 section: release_notes
-order: 22
+order: 23
 ---
 
 # Summary

--- a/guides/src/content/release_notes/0_60_0.md
+++ b/guides/src/content/release_notes/0_60_0.md
@@ -1,7 +1,7 @@
 ---
 title: Spree 0.60.0
 section: release_notes
-order: 21
+order: 22
 ---
 
 # Summary

--- a/guides/src/content/release_notes/0_70_0.md
+++ b/guides/src/content/release_notes/0_70_0.md
@@ -1,7 +1,7 @@
 ---
 title: Spree 0.70.0
 section: release_notes
-order: 20
+order: 21
 ---
 
 # Summary

--- a/guides/src/content/release_notes/0_9_0.md
+++ b/guides/src/content/release_notes/0_9_0.md
@@ -1,7 +1,7 @@
 ---
 title: Spree 0.9.0
 section: release_notes
-order: 26
+order: 27
 ---
 
 !!!

--- a/guides/src/content/release_notes/1_0_0.md
+++ b/guides/src/content/release_notes/1_0_0.md
@@ -1,7 +1,7 @@
 ---
 title: Spree 1.0.0
 section: release_notes
-order: 19
+order: 20
 ---
 
 # Summary

--- a/guides/src/content/release_notes/1_1_0.md
+++ b/guides/src/content/release_notes/1_1_0.md
@@ -1,7 +1,7 @@
 ---
 title: Spree 1.1.0
 section: release_notes
-order: 18
+order: 19
 ---
 
 # Summary

--- a/guides/src/content/release_notes/1_1_4.md
+++ b/guides/src/content/release_notes/1_1_4.md
@@ -1,7 +1,7 @@
 ---
 title: Spree 1.1.4
 section: release_notes
-order: 17
+order: 18
 ---
 
 # Summary

--- a/guides/src/content/release_notes/1_2_0.md
+++ b/guides/src/content/release_notes/1_2_0.md
@@ -1,7 +1,7 @@
 ---
 title: Spree 1.2.0
 section: release_notes
-order: 16
+order: 17
 ---
 
 Spree 1.2.0 introduces some fairly major changes in the basic

--- a/guides/src/content/release_notes/1_2_2.md
+++ b/guides/src/content/release_notes/1_2_2.md
@@ -1,7 +1,7 @@
 ---
 title: Spree 1.2.2
 section: release_notes
-order: 15
+order: 16
 ---
 
 Spree 1.2.2 is the latest Spree release in the 1.2.x branch. This

--- a/guides/src/content/release_notes/1_3_0.md
+++ b/guides/src/content/release_notes/1_3_0.md
@@ -1,7 +1,7 @@
 ---
 title: Spree 1.3.0
 section: release_notes
-order: 14
+order: 15
 ---
 
 Spree 1.3.0 is the first release of the 1.3.x branch of Spree. This release contains some major non-breaking changes, which are covered in the release notes below.

--- a/guides/src/content/release_notes/2_0_0.md
+++ b/guides/src/content/release_notes/2_0_0.md
@@ -1,7 +1,7 @@
 ---
 title: Spree 2.0.0
 section: release_notes
-order: 13
+order: 14
 ---
 
 ## Major/new features

--- a/guides/src/content/release_notes/2_1_0.md
+++ b/guides/src/content/release_notes/2_1_0.md
@@ -1,7 +1,7 @@
 ---
 title: Spree 2.1.0
 section: release_notes
-order: 12
+order: 13
 ---
 
 ## Major/new features

--- a/guides/src/content/release_notes/2_2_0.md
+++ b/guides/src/content/release_notes/2_2_0.md
@@ -1,7 +1,7 @@
 ---
 title: Spree 2.2.0
 section: release_notes
-order: 11
+order: 12
 ---
 
 ## Major/new features

--- a/guides/src/content/release_notes/2_3_0.md
+++ b/guides/src/content/release_notes/2_3_0.md
@@ -1,7 +1,7 @@
 ---
 title: Spree 2.3.0
 section: release_notes
-order: 10
+order: 11
 ---
 
 ## Major/new features

--- a/guides/src/content/release_notes/2_4_0.md
+++ b/guides/src/content/release_notes/2_4_0.md
@@ -1,7 +1,7 @@
 ---
 title: Spree 2.4.0
 section: release_notes
-order: 9
+order: 10
 ---
 
 ## Major/new features

--- a/guides/src/content/release_notes/3_0_0.md
+++ b/guides/src/content/release_notes/3_0_0.md
@@ -1,7 +1,7 @@
 ---
 title: Spree 3.0.0
 section: release_notes
-order: 8
+order: 9
 ---
 
 ## Major/New Features

--- a/guides/src/content/release_notes/3_1_0.md
+++ b/guides/src/content/release_notes/3_1_0.md
@@ -1,7 +1,7 @@
 ---
 title: Spree 3.1.0
 section: release_notes
-order: 7
+order: 8
 ---
 
 ## Major/New Features

--- a/guides/src/content/release_notes/3_2_0.md
+++ b/guides/src/content/release_notes/3_2_0.md
@@ -1,7 +1,7 @@
 ---
 title: Spree 3.2.0
 section: release_notes
-order: 6
+order: 7
 ---
 
 ## Major/New Features

--- a/guides/src/content/release_notes/3_3_0.md
+++ b/guides/src/content/release_notes/3_3_0.md
@@ -1,7 +1,7 @@
 ---
 title: Spree 3.3.0
 section: release_notes
-order: 5
+order: 6
 ---
 
 ## Major/New Features

--- a/guides/src/content/release_notes/3_4_0.md
+++ b/guides/src/content/release_notes/3_4_0.md
@@ -1,7 +1,7 @@
 ---
 title: Spree 3.4.0
 section: release_notes
-order: 4
+order: 5
 ---
 
 ## Major/New Features

--- a/guides/src/content/release_notes/3_5_0.md
+++ b/guides/src/content/release_notes/3_5_0.md
@@ -1,7 +1,7 @@
 ---
 title: Spree 3.5.0
 section: release_notes
-order: 3
+order: 4
 ---
 
 ## Major/New Features

--- a/guides/src/content/release_notes/3_6_0.md
+++ b/guides/src/content/release_notes/3_6_0.md
@@ -1,7 +1,7 @@
 ---
 title: Spree 3.6.0
 section: release_notes
-order: 2
+order: 3
 ---
 
 ## Major/New Features

--- a/guides/src/content/release_notes/3_7_0.md
+++ b/guides/src/content/release_notes/3_7_0.md
@@ -1,7 +1,7 @@
 ---
 title: Spree 3.7.0
 section: release_notes
-order: 1
+order: 2
 ---
 
 ## Major/New Features

--- a/guides/src/content/release_notes/4_0_0.md
+++ b/guides/src/content/release_notes/4_0_0.md
@@ -1,7 +1,7 @@
 ---
 title: Spree 4.0.0
 section: release_notes
-order: 0
+order: 1
 ---
 
 <a href="https://spreecommerce.org/contact/" target="_blank" rel="nofollow"><img src="https://spreecommerce.org/wp-content/uploads/2019/10/spree_commerce_new_ux_template.jpg" /></a>


### PR DESCRIPTION
Add missing links to documentation for 4.1 release and fix ordering.
This applies to upgrade guides and release notes.