### PR TITLE
Fixed errors with admin time helpers when nil values where supplied

### DIFF
--- a/backend/app/helpers/spree/admin/base_helper.rb
+++ b/backend/app/helpers/spree/admin/base_helper.rb
@@ -150,6 +150,8 @@ module Spree
       end
 
       def order_time(time)
+        return '' if time.blank?
+
         [I18n.l(time.to_date), time.strftime('%l:%M %p').strip].join(' ')
       end
 

--- a/backend/spec/helpers/spree/admin/base_helper_spec.rb
+++ b/backend/spec/helpers/spree/admin/base_helper_spec.rb
@@ -26,5 +26,9 @@ describe Spree::Admin::BaseHelper, type: :helper do
     it 'prints in a format' do
       expect(order_time(Time.new(2016, 5, 6, 13, 33))).to eq '2016-05-06 1:33 PM'
     end
+
+    it 'return empty stirng when nil is supplied' do
+      expect(order_time(nil)).to eq ''
+    end
   end
 end

--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -95,6 +95,8 @@ module Spree
     end
 
     def pretty_time(time)
+      return '' if time.blank?
+
       [I18n.l(time.to_date, format: :long), time.strftime('%l:%M %p')].join(' ')
     end
 

--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -127,6 +127,10 @@ describe Spree::BaseHelper, type: :helper do
     it 'prints in a format' do
       expect(pretty_time(Time.new(2012, 5, 6, 13, 33))).to eq 'May 06, 2012  1:33 PM'
     end
+
+    it 'return empty stirng when nil is supplied' do
+      expect(pretty_time(nil)).to eq ''
+    end
   end
 
   describe '#display_price' do


### PR DESCRIPTION
Somtimes records are missing `created_at` values especially when migrating from legacy systems. This adds a safeguard