### PR TITLE
Add Customer Support Email Address

### DIFF
--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -161,8 +161,8 @@ module Spree
 
       @@store_attributes = [
         :id, :name, :url, :meta_description, :meta_keywords, :seo_title,
-        :mail_from_address, :default_currency, :code, :default,
-        :facebook, :twitter, :instagram
+        :mail_from_address, :customer_support_email, :default_currency,
+        :code, :default, :facebook, :twitter, :instagram
       ]
 
       @@tag_attributes = [:id, :name]

--- a/api/spec/controllers/spree/api/v1/stores_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/stores_controller_spec.rb
@@ -33,7 +33,8 @@ module Spree
               'meta_description' => nil,
               'meta_keywords' => nil,
               'seo_title' => nil,
-              'mail_from_address' => 'spree@example.org',
+              'mail_from_address' => 'no-reply@example.com',
+              'customer_support_email' => 'support@example.com',
               'default_currency' => 'USD',
               'code' => store.code,
               'default' => true,
@@ -48,7 +49,8 @@ module Spree
               'meta_description' => nil,
               'meta_keywords' => nil,
               'seo_title' => nil,
-              'mail_from_address' => 'spree@example.org',
+              'mail_from_address' => 'no-reply@example.com',
+              'customer_support_email' => 'support@example.com',
               'default_currency' => 'USD',
               'code' => non_default_store.code,
               'default' => false,
@@ -69,7 +71,8 @@ module Spree
           'meta_description' => nil,
           'meta_keywords' => nil,
           'seo_title' => nil,
-          'mail_from_address' => 'spree@example.org',
+          'mail_from_address' => 'no-reply@example.com',
+          'customer_support_email' => 'support@example.com',
           'default_currency' => 'USD',
           'code' => store.code,
           'default' => true,
@@ -85,6 +88,7 @@ module Spree
           name: 'Hack0rz',
           url: 'spree123.example.com',
           mail_from_address: 'me@example.com',
+          customer_support_email: 'sales@example.com',
           default_currency: 'USD'
         }
         api_post :create, store: store_hash
@@ -94,12 +98,14 @@ module Spree
       it 'I can update an existing store' do
         store_hash = {
           url: 'spree123.example.com',
-          mail_from_address: 'me@example.com'
+          mail_from_address: 'me@example.com',
+          customer_support_email: 'sales@example.com',
         }
         api_put :update, id: store.id, store: store_hash
         expect(response.status).to eq(200)
         expect(store.reload.url).to eql 'spree123.example.com'
         expect(store.reload.mail_from_address).to eql 'me@example.com'
+        expect(store.reload.customer_support_email).to eql 'sales@example.com'
       end
 
       context 'deleting a store' do

--- a/backend/app/views/spree/admin/stores/_form.html.erb
+++ b/backend/app/views/spree/admin/stores/_form.html.erb
@@ -3,7 +3,7 @@
   <div class="card">
     <div class="card-header">
       <h1 class="card-title mb-0 h5">
-        Basic Information
+        <%= Spree.t(:basic_information) %>
       </h1>
     </div>
     <div class="card-body">
@@ -13,7 +13,7 @@
         <%= f.error_message_on :name %>
       <% end %>
       <%= f.field_container :url, class: ['form-group'] do %>
-        <%= f.label :url, Spree.t(:url)  %>
+        <%= f.label :url, raw(Spree.t(:url) + required_span_tag)  %>
         <%= f.text_field :url, class: 'form-control', required: true %>
         <%= f.error_message_on :url %>
       <% end %>
@@ -25,12 +25,12 @@
   <div class="card">
     <div class="card-header">
       <h1 class="card-title mb-0 h5">
-        SEO
+        <%= Spree.t(:seo) %>
       </h1>
     </div>
     <div class="card-body">
       <%= f.field_container :seo_title, class: ['form-group'] do %>
-        <%= f.label :seo_title, Spree.t(:seo_title)  %>
+        <%= f.label :seo_title, Spree.t(:seo_title) %>
         <%= f.text_field :seo_title, class: 'form-control' %>
         <%= f.error_message_on :seo_title %>
       <% end %>
@@ -52,14 +52,20 @@
   <div class="card">
     <div class="card-header">
       <h1 class="card-title mb-0 h5">
-        Emails
+        <%= Spree.t(:email).pluralize %>
       </h1>
     </div>
     <div class="card-body">
       <%= f.field_container :mail_from_address, class: ['form-group'] do %>
-        <%= f.label :mail_from_address, Spree.t(:mail_from_address)  %>
+        <%= f.label :mail_from_address, raw(Spree.t(:mail_from_address)  + required_span_tag) %>
         <%= f.text_field :mail_from_address, class: 'form-control', required: true %>
         <%= f.error_message_on :mail_from_address %>
+      <% end %>
+
+      <%= f.field_container :customer_support_email, class: ['form-group'] do %>
+        <%= f.label :customer_support_email, Spree.t(:customer_support_email) %>
+        <%= f.text_field :customer_support_email, class: 'form-control' %>
+        <%= f.error_message_on :customer_support_email %>
       <% end %>
     </div>
   </div>
@@ -69,7 +75,7 @@
 <div class="card">
   <div class="card-header">
     <h1 class="card-title mb-0 h5">
-      Internationalization
+      <%= Spree.t(:internationalization) %>
     </h1>
   </div>
   <div class="card-body">
@@ -91,7 +97,7 @@
 <div class="card">
   <div class="card-header">
     <h1 class="card-title mb-0 h5">
-      Social
+      <%= Spree.t(:social) %>
     </h1>
   </div>
   <div class="card-body">

--- a/backend/spec/features/admin/configuration/general_settings_spec.rb
+++ b/backend/spec/features/admin/configuration/general_settings_spec.rb
@@ -4,7 +4,7 @@ describe 'General Settings', type: :feature do
   stub_authorization!
 
   before do
-    create(:store, name: 'Test Store', url: 'test.example.org', mail_from_address: 'test@example.org')
+    create(:store, name: 'Test Store', url: 'test.example.com', mail_from_address: 'test@example.com')
     visit spree.edit_admin_general_settings_path
   end
 

--- a/backend/spec/features/admin/configuration/stores_spec.rb
+++ b/backend/spec/features/admin/configuration/stores_spec.rb
@@ -34,7 +34,8 @@ describe 'Stores admin', type: :feature, js: true do
       click_link 'New Store'
       page.fill_in 'store_name', with: 'Spree Example Test'
       page.fill_in 'store_url', with: 'test.localhost'
-      page.fill_in 'store_mail_from_address', with: 'spree@example.com'
+      page.fill_in 'store_mail_from_address', with: 'no-reply@example.com'
+      page.fill_in 'store_customer_support_email', with: 'support@example.com'
       select2 'EUR', from: 'Currency'
       click_button 'Create'
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -607,6 +607,7 @@ en:
     balance_due: Balance Due
     base_amount: Base Amount
     base_percent: Base Percent
+    basic_information: Basic Information
     bill_address: Bill Address
     billing: Billing
     billing_address: Billing Address
@@ -734,6 +735,7 @@ en:
     customer_return: Customer Return
     customer_returns: Customer Returns
     customer_search: Customer Search
+    customer_support_email: Customer Support Email
     cut: Cut
     cvv: CVV
     cvv_response: CVV Response
@@ -831,6 +833,7 @@ en:
     extension: Extension
     extensions_directory: Extensions Directory
     existing_shipments: Existing shipments
+    facebook: Facebook
     failed_payment_attempts: Failed Payment Attempts
     filename: Filename
     fill_in_customer_info: Please fill in customer info
@@ -912,6 +915,7 @@ en:
     info_number_of_skus_not_shown:
       one: "and one other"
       other: "and %{count} others"
+    instagram: Instagram
     instructions_to_reset_password: Please enter your email on the form below
     insufficient_stock: Insufficient stock available, only %{on_hand} remaining
     insufficient_stock_item_quantity: Insufficient stock quantity available
@@ -919,6 +923,7 @@ en:
     intercept_email_address: Intercept Email Address
     intercept_email_instructions: Override email recipient and replace with this address.
     internal_name: Internal Name
+    internationalization: Internationalization
     invalid_credit_card: Invalid credit card.
     invalid_exchange_variant: Invalid exchange variant.
     invalid_payment_provider: Invalid payment provider.
@@ -1422,6 +1427,7 @@ en:
     select_a_store_credit_reason: Select a reason for the store credit
     select_stock: Select stock
     selected_quantity_not_available: ! 'selected of %{item} is not available.'
+    seo: SEO
     send_copy_of_all_mails_to: Send Copy of All Mails To
     send_mails_as: Send Mails As
     seo_title: SEO title
@@ -1486,6 +1492,7 @@ en:
     skus: SKUs
     slug: Slug
     source: Source
+    social: Social
     special_instructions: Special Instructions
     split: Split
     spree_gateway_error_flash_for_checkout: There was a problem with your payment information. Please check your information and try again.
@@ -1657,6 +1664,7 @@ en:
     tree: Tree
     type: Type
     type_to_search: Type to search
+    twitter: Twitter
     unable_to_connect_to_gateway: Unable to connect to gateway.
     unable_to_create_reimbursements: Unable to create reimbursements because there are items pending manual intervention.
     under_price: Under %{price}

--- a/core/db/default/spree/stores.rb
+++ b/core/db/default/spree/stores.rb
@@ -1,15 +1,16 @@
 # Possibly already created by a migration.
 unless Spree::Store.default.persisted?
   Spree::Store.new do |s|
-    s.name              = 'Spree Demo Site'
-    s.code              = 'spree'
-    s.url               = Rails.application.routes.default_url_options[:host] || 'demo.spreecommerce.org'
-    s.mail_from_address = 'spree@example.com'
-    s.default_currency  = 'USD'
-    s.seo_title         = 'Spree Commerce Demo Shop'
-    s.meta_description  = 'Spree Commerce is an open source Ecommerce framework decision makers want, developers enjoy.'
-    s.facebook          = 'spreecommerce'
-    s.twitter           = 'spreecommerce'
-    s.instagram         = 'spreecommerce'
+    s.name                   = 'Spree Demo Site'
+    s.code                   = 'spree'
+    s.url                    = Rails.application.routes.default_url_options[:host] || 'demo.spreecommerce.org'
+    s.mail_from_address      = 'no-reply@example.com'
+    s.customer_support_email = 'support@example.com'
+    s.default_currency       = 'USD'
+    s.seo_title              = 'Spree Commerce Demo Shop'
+    s.meta_description       = 'Spree Commerce is an open source Ecommerce framework decision makers want, developers enjoy.'
+    s.facebook               = 'spreecommerce'
+    s.twitter                = 'spreecommerce'
+    s.instagram              = 'spreecommerce'
   end.save!
 end

--- a/core/db/migrate/20200310145140_add_customer_support_email_to_spree_store.rb
+++ b/core/db/migrate/20200310145140_add_customer_support_email_to_spree_store.rb
@@ -1,0 +1,7 @@
+class AddCustomerSupportEmailToSpreeStore < ActiveRecord::Migration[6.0]
+  def change
+    unless column_exists?(:spree_stores, :customer_support_email)
+      add_column :spree_stores, :customer_support_email, :string
+    end
+  end
+end

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -98,7 +98,7 @@ module Spree
 
     @@store_attributes = [:name, :url, :seo_title, :code, :meta_keywords,
                           :meta_description, :default_currency, :mail_from_address,
-                          :facebook, :twitter, :instagram, :default_locale]
+                          :customer_support_email, :facebook, :twitter, :instagram, :default_locale]
 
     @@store_credit_attributes = %i[amount currency category_id memo]
 

--- a/core/lib/spree/testing_support/factories/store_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_factory.rb
@@ -1,12 +1,13 @@
 FactoryBot.define do
   factory :store, class: Spree::Store do
-    sequence(:code)   { |i| "spree_#{i}" }
-    name              { 'Spree Test Store' }
-    url               { 'www.example.com' }
-    mail_from_address { 'spree@example.org' }
-    default_currency  { 'USD' }
-    facebook          { 'spreecommerce' }
-    twitter           { 'spreecommerce' }
-    instagram         { 'spreecommerce' }
+    sequence(:code)        { |i| "spree_#{i}" }
+    name                   { 'Spree Test Store' }
+    url                    { 'www.example.com' }
+    mail_from_address      { 'no-reply@example.com' }
+    customer_support_email { 'support@example.com' }
+    default_currency       { 'USD' }
+    facebook               { 'spreecommerce' }
+    twitter                { 'spreecommerce' }
+    instagram              { 'spreecommerce' }
   end
 end


### PR DESCRIPTION
Add a customer support email to allow the option of using one email address for sending out and another for display on the store front for customers to email in.