### PR TITLE
replace string with array parameter

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/user_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/user_picker.js
@@ -10,7 +10,7 @@ $.fn.userAutocomplete = function () {
     multiple: true,
     initSelection: function (element, callback) {
       $.get(Spree.routes.users_api, {
-        ids: element.val().split(","),
+        ids: element.val().split(','),
         token: Spree.api_key
       }, function (data) {
         callback(data.users)

--- a/backend/app/assets/javascripts/spree/backend/user_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/user_picker.js
@@ -10,7 +10,7 @@ $.fn.userAutocomplete = function () {
     multiple: true,
     initSelection: function (element, callback) {
       $.get(Spree.routes.users_api, {
-        ids: element.val(),
+        ids: element.val().split(","),
         token: Spree.api_key
       }, function (data) {
         callback(data.users)


### PR DESCRIPTION
Without this change, the `GET` request looks like:

`http://localhost:3000/store/api/v1/users?ids=1,2,3&token=65593b40bb55f60ecb973e86865310234ffe3f237e9076a3`

It results with responding with the first user from the list (it's `User.where(id: params[:ids]`). The change fixes the URL:

`http://localhost:3000/store/api/v1/users?ids[]=1&ids[]=2&ids[]=3&token=65593b40bb55f60ecb973e86865310234ffe3f237e9076a3`

It seems to fix the select2 display.