### PR TITLE
feat: product finder filter[taxons] by permalink

### DIFF
--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -973,7 +973,7 @@ paths:
     get:
       description: >-
         To view the details for a single Country, make a request using that
-        Country's iso code:<br /> <code>GET /api/v2/storfront/countries/gb</code>
+        Country's iso code:<br /> <code>GET /api/v2/storefront/countries/gb</code>
         <br /><br />You may also query by the Country's iso3 code:<br /><code>GET
         /api/v2/storefront/coutries/gbr </code> <br /><br />Note that the API will attempt a
         iso lookup before an iso3 lookup.

--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -812,8 +812,8 @@ paths:
           name: filter[taxons]
           schema:
             type: string
-          example: 1,2,3,4,5,6,7,8,9,10,11
-          description: Filter Prodcuts based on taxons (IDs of categories, brands, etc)
+          example: 1,2,3,4,5,men,men/tshirts,women,women/tshirts
+          description: Filter Prodcuts based on taxons (IDs or Permalinks of categories, brands, etc)
         - in: query
           name: filter[name]
           schema:
@@ -973,7 +973,7 @@ paths:
     get:
       description: >-
         To view the details for a single Country, make a request using that
-        Country's iso code:<br /> <code>GET /api/v2/storefront/countries/gb</code>
+        Country's iso code:<br /> <code>GET /api/v2/stor/mefront/countries/gb</code>
         <br /><br />You may also query by the Country's iso3 code:<br /><code>GET
         /api/v2/storefront/coutries/gbr </code> <br /><br />Note that the API will attempt a
         iso lookup before an iso3 lookup.

--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -973,7 +973,7 @@ paths:
     get:
       description: >-
         To view the details for a single Country, make a request using that
-        Country's iso code:<br /> <code>GET /api/v2/stor/mefront/countries/gb</code>
+        Country's iso code:<br /> <code>GET /api/v2/storfront/countries/gb</code>
         <br /><br />You may also query by the Country's iso3 code:<br /><code>GET
         /api/v2/storefront/coutries/gbr </code> <br /><br />Note that the API will attempt a
         iso lookup before an iso3 lookup.

--- a/core/app/finders/spree/products/find.rb
+++ b/core/app/finders/spree/products/find.rb
@@ -99,7 +99,11 @@ module Spree
       def by_taxons(products)
         return products unless taxons?
 
-        products.joins(:taxons).where(spree_taxons: { id: taxons })
+        ids = taxons.select { |t| t =~ /^\d+$/ }
+        permalinks = taxons + ids - (taxons & ids)
+
+        products.joins(:taxons).where(spree_taxons: { id: ids }) if ids.count > 0
+        products.joins(:taxons).where(spree_taxons: { permalink: permalinks }) if permalinks.count > 0
       end
 
       def by_name(products)

--- a/core/app/finders/spree/products/find.rb
+++ b/core/app/finders/spree/products/find.rb
@@ -102,8 +102,12 @@ module Spree
         ids = taxons.select { |t| t =~ /^\d+$/ }
         permalinks = taxons + ids - (taxons & ids)
 
-        products.joins(:taxons).where(spree_taxons: { id: ids }) if ids.count > 0
-        products.joins(:taxons).where(spree_taxons: { permalink: permalinks }) if permalinks.count > 0
+        clause = ""
+        clause += Taxon.sanitize_sql_for_conditions(["\"spree_taxons\".\"id\" IN (?)", ids]) if ids.any?
+        clause += " OR " if ids.any? and permalinks.any?
+        clause += Taxon.sanitize_sql_for_conditions(["\"spree_taxons\".\"permalink\" IN (?)", permalinks]) if permalinks.any?
+
+        products.joins(:taxons).where(clause)
       end
 
       def by_name(products)

--- a/core/app/finders/spree/products/find.rb
+++ b/core/app/finders/spree/products/find.rb
@@ -102,10 +102,12 @@ module Spree
         ids = taxons.select { |t| t =~ /^\d+$/ }
         permalinks = taxons + ids - (taxons & ids)
 
+        c = Spree::Taxon.connection
+
         clause = ""
-        clause += Taxon.sanitize_sql_for_conditions(["\"spree_taxons\".\"id\" IN (?)", ids]) if ids.any?
+        clause += Spree::Taxon.sanitize_sql_for_conditions(["#{c.quote_table_name("spree_taxons")}.#{c.quote_column_name("id")} IN (?)", ids]) if ids.any?
         clause += " OR " if ids.any? and permalinks.any?
-        clause += Taxon.sanitize_sql_for_conditions(["\"spree_taxons\".\"permalink\" IN (?)", permalinks]) if permalinks.any?
+        clause += Spree::Taxon.sanitize_sql_for_conditions(["#{c.quote_table_name("spree_taxons")}.#{c.quote_column_name("permalink")} IN (?)", permalinks]) if permalinks.any?
 
         products.joins(:taxons).where(clause)
       end

--- a/core/app/finders/spree/products/find.rb
+++ b/core/app/finders/spree/products/find.rb
@@ -104,10 +104,10 @@ module Spree
 
         c = Spree::Taxon.connection
 
-        clause = ""
-        clause += Spree::Taxon.sanitize_sql_for_conditions(["#{c.quote_table_name("spree_taxons")}.#{c.quote_column_name("id")} IN (?)", ids]) if ids.any?
-        clause += " OR " if ids.any? and permalinks.any?
-        clause += Spree::Taxon.sanitize_sql_for_conditions(["#{c.quote_table_name("spree_taxons")}.#{c.quote_column_name("permalink")} IN (?)", permalinks]) if permalinks.any?
+        clause = ''
+        clause += Spree::Taxon.sanitize_sql_for_conditions(["#{c.quote_table_name('spree_taxons')}.#{c.quote_column_name('id')} IN (?)", ids]) if ids.any?
+        clause += ' OR ' if ids.any? && permalinks.any?
+        clause += Spree::Taxon.sanitize_sql_for_conditions(["#{c.quote_table_name('spree_taxons')}.#{c.quote_column_name('permalink')} IN (?)", permalinks]) if permalinks.any?
 
         products.joins(:taxons).where(clause)
       end


### PR DESCRIPTION
I work a lot with the API in a custom web environments and  I found it a pain working with taxon permalinks and fetching products. I need to fetch the taxon first before I can get products for a permalink since the product search API only accepts taxon ID’s.

This allows for permalinks to be passed into the talons filer like so: 
`/products?filter[taxons]=1,2,men,men/tshirts`