### PR TITLE
Fixed Zone#kind getter

### DIFF
--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -71,8 +71,8 @@ module Spree
     end
 
     def kind
-      if kind?
-        super
+      if self[:kind].present?
+        self[:kind]
       else
         not_nil_scope = members.where.not(zoneable_type: nil)
         zone_type = not_nil_scope.order('created_at ASC').pluck(:zoneable_type).last


### PR DESCRIPTION
Fixes runtime errors such as this:

```
NoMethodError (super: no superclass method `kind' for #<Spree::Zone:0x00007fd7c553f468>
```

https://spree-commerce.slack.com/archives/C0HUDSW5V/p1585689701090000