### PR TITLE
Typo fix

### DIFF
--- a/guides/src/content/developer/customization/view.md
+++ b/guides/src/content/developer/customization/view.md
@@ -7,7 +7,7 @@ order: 0
 ## Overview
 
 View customization allows you to extend or replace any view within a
-Spree application bot for the Customer Storefront (Frontend) and Admin Panel (Backend).
+Spree application both for the Customer Storefront (Frontend) and Admin Panel (Backend).
 
 ## Template replacement
 


### PR DESCRIPTION
This fixes a typo in the documentation - replacing `bot` with `both` so the sentence now reads 

```
View customization allows you to extend or replace any view within a Spree 
application both for the Customer Storefront (Frontend) and Admin Panel (Backend).
```