### PR TITLE
text formatting update storefront.md

### DIFF
--- a/guides/src/content/developer/customization/storefront.md
+++ b/guides/src/content/developer/customization/storefront.md
@@ -24,8 +24,7 @@ All the Sass variables needed for customizing the new Spree UX are in the variab
 - Color name - example: Blue
 
 To make those changes live you need to update
-`[app/assets/stylesheets/spree/frontend/variables/variables.scss]`
-(https://github.com/spree/spree/blob/master/frontend/app/assets/stylesheets/spree/frontend/variables/variables.scss) 
+[app/assets/stylesheets/spree/frontend/variables/variables.scss](https://github.com/spree/spree/blob/master/frontend/app/assets/stylesheets/spree/frontend/variables/variables.scss) 
 in your project directory with your values and then commit those changes to your project code repository.
 
 ### Header

--- a/guides/src/content/developer/customization/storefront.md
+++ b/guides/src/content/developer/customization/storefront.md
@@ -23,7 +23,10 @@ All the Sass variables needed for customizing the new Spree UX are in the variab
 - HSL-A - example: 211 100% 50% 1
 - Color name - example: Blue
 
-``To make those changes live you need to update [app/assets/stylesheets/spree/frontend/variables/variables.scss](https://github.com/spree/spree/blob/master/frontend/app/assets/stylesheets/spree/frontend/variables/variables.scss) in your project directory with your values and then commit those changes to your project code repository.``
+To make those changes live you need to update
+`[app/assets/stylesheets/spree/frontend/variables/variables.scss]`
+(https://github.com/spree/spree/blob/master/frontend/app/assets/stylesheets/spree/frontend/variables/variables.scss) 
+in your project directory with your values and then commit those changes to your project code repository.
 
 ### Header
 


### PR DESCRIPTION

![Zrzut ekranu 2020-04-07 o 22 31 18](https://user-images.githubusercontent.com/53864665/78718727-1ae12380-7923-11ea-827d-7b3a40786bb3.png)

In the Styling with SASS variables section, info on where to make changes live (last paragraph) the text, file location & GH link were put between  "``", which made information unreadable and link to GH not redirected anywhere.