### PR TITLE
remove product delegated fields from api-v2 variant serializer

### DIFF
--- a/api/app/serializers/spree/v2/storefront/variant_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/variant_serializer.rb
@@ -4,8 +4,8 @@ module Spree
       class VariantSerializer < BaseSerializer
         set_type :variant
 
-        attributes :name, :sku, :price, :currency, :display_price, :weight, :height,
-                   :width, :depth, :is_master, :options_text, :slug, :description
+        attributes :sku, :price, :currency, :display_price, :weight, :height,
+                   :width, :depth, :is_master, :options_text
 
         attribute :purchasable,   &:purchasable?
         attribute :in_stock,      &:in_stock?

--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -2003,10 +2003,6 @@ components:
     VariantAttributes:
       type: object
       properties:
-        name:
-          type: string
-          example: 'Example product'
-          description: 'Product name'
         sku:
           type: string
           example: 'SKU-1001'
@@ -2038,14 +2034,6 @@ components:
         options_text:
           type: string
           example: 'Size: small, Color: red'
-        slug:
-          type: string
-          example: 'example-product'
-          description: 'Product slug'
-        description:
-          type: string
-          example: 'Example description'
-          description: 'Product description'
         purchasable:
           type: boolean
           example: true

--- a/guides/src/content/release_notes/4_2_0.md
+++ b/guides/src/content/release_notes/4_2_0.md
@@ -61,6 +61,7 @@ rails g spree_gateway:install
 
 Please review each of the noteworthy changes to ensure your customizations or extensions are not affected. If you are affected by a change, and have any suggestions please submit a PR to help the next person!
 
+* `Spree::Variant` delegated fields `name` `description` and `slug` have been removed from the Storefront V2 serializer to cut down on response sizes and overfetching. If you need these three fields you can simply include the product in the request.
 
 
 ## Full Changelog


### PR DESCRIPTION
> When I retrieve my product with it’s 10 variants, I get 10 extra copies of the name and description (quite long in some cases) returned in the response. Add to this the many image variations and a single request for a product can bloat up quite a bit. And I don’t really see the use case for this personally. The only way I ever really get to a variant is through a product or through a line_item, both of which already have the name and if I do need the description for a line_item I can just include the product explicitly.

Per discussion with @damianlegawiec I created a PR to remove `name`, `description`, and `slug` from the v2 serializer to cut down on overfetching and response sizes.