### PR TITLE
Use ActionController::API for API v1 controllers

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -2,9 +2,7 @@ require_dependency 'spree/api/controller_setup'
 
 module Spree
   module Api
-    class BaseController < ActionController::Base
-      protect_from_forgery unless: -> { request.format.json? || request.format.xml? }
-
+    class BaseController < ActionController::API
       include Spree::Api::ControllerSetup
       include Spree::Core::ControllerHelpers::Store
       include Spree::Core::ControllerHelpers::StrongParameters

--- a/api/app/controllers/spree/api/errors_controller.rb
+++ b/api/app/controllers/spree/api/errors_controller.rb
@@ -1,6 +1,6 @@
 module Spree
   module Api
-    class ErrorsController < ActionController::Base
+    class ErrorsController < ActionController::API
       def render_404
         render 'spree/api/errors/not_found', status: 404
       end

--- a/api/lib/spree/api/controller_setup.rb
+++ b/api/lib/spree/api/controller_setup.rb
@@ -6,7 +6,6 @@ module Spree
       def self.included(klass)
         klass.class_eval do
           include CanCan::ControllerAdditions
-          include Spree::Core::ControllerHelpers::Auth
 
           prepend_view_path Rails.root + 'app/views'
           append_view_path File.expand_path('../../../app/views', File.dirname(__FILE__))

--- a/guides/src/content/release_notes/4_2_0.md
+++ b/guides/src/content/release_notes/4_2_0.md
@@ -1,5 +1,5 @@
 ---
-title: Spree 4.1.0
+title: Spree 4.2.0
 section: release_notes
 order: 0
 hidden: true
@@ -61,8 +61,9 @@ rails g spree_gateway:install
 
 Please review each of the noteworthy changes to ensure your customizations or extensions are not affected. If you are affected by a change, and have any suggestions please submit a PR to help the next person!
 
-* `Spree::Variant` delegated fields `name` `description` and `slug` have been removed from the Storefront V2 serializer to cut down on response sizes and overfetching. If you need these three fields you can simply include the product in the request.
+* `Spree::Variant` delegated fields `name` `description` and `slug` have been removed from the Storefront API V2 serializer to cut down on response sizes and overfetching. If you need these three fields you can simply include the product in the request.
 
+* API v1 controllers now inherit from `ActionController::API` rather than `ActionController::Base`
 
 ## Full Changelog
 


### PR DESCRIPTION
```
API Controller is a lightweight version of ActionController::Base, created for applications that don't require all functionalities that a complete Rails controller provides, allowing you to create controllers with just the features that you need for API only applications.
```

At the time of API v1 creation ActionController::API wasn't around, hence Base was used. However, we shouldn't continue to do so nowadays.