### PR TITLE
Added preference to toggle HTTP caching for Storefrront

### DIFF
--- a/frontend/app/controllers/spree/home_controller.rb
+++ b/frontend/app/controllers/spree/home_controller.rb
@@ -3,7 +3,9 @@ module Spree
     respond_to :html
 
     def index
-      fresh_when etag: store_etag, last_modified: store_last_modified, public: true
+      if Spree::Frontend::Config[:http_cache_enabled]
+        fresh_when etag: store_etag, last_modified: store_last_modified, public: true
+      end
     end
   end
 end

--- a/frontend/app/controllers/spree/taxons_controller.rb
+++ b/frontend/app/controllers/spree/taxons_controller.rb
@@ -8,13 +8,13 @@ module Spree
     respond_to :html
 
     def show
-      if stale?(etag: etag, last_modified: last_modified, public: true)
+      if !Spree::Frontend::Config[:http_cache_enabled] || stale?(etag: etag, last_modified: last_modified, public: true)
         load_products
       end
     end
 
     def product_carousel
-      if stale?(etag: carousel_etag, last_modified: last_modified, public: true)
+      if !Spree::Frontend::Config[:http_cache_enabled] || stale?(etag: carousel_etag, last_modified: last_modified, public: true)
         load_products
         if @products.any?
           render template: 'spree/taxons/product_carousel', layout: false

--- a/frontend/app/models/spree/frontend_configuration.rb
+++ b/frontend/app/models/spree/frontend_configuration.rb
@@ -1,6 +1,7 @@
 module Spree
   class FrontendConfiguration < Preferences::Configuration
     preference :coupon_codes_enabled, :boolean, default: true # Determines if we show coupon code form at cart and checkout
+    preference :http_cache_enabled, :boolean, default: true
     preference :locale, :string, default: Rails.application.config.i18n.default_locale
     preference :products_filters, :array, default: %w(keywords price sort_by)
     preference :additional_filters_partials, :array, default: %w()


### PR DESCRIPTION
`Spree::Frontend::Config[:http_cache_enabled]` is now used to determine if we should cache Home page, Product page, Product list & Taxon page. By default, it's enabled. For flexibility,  you can now disable this altogether. Useful for private/internal websites.