### PR TITLE
Added multi store support to Spree core emails

### DIFF
--- a/core/app/mailers/spree/base_mailer.rb
+++ b/core/app/mailers/spree/base_mailer.rb
@@ -2,11 +2,17 @@ module Spree
   class BaseMailer < ActionMailer::Base
     add_template_helper(MailHelper)
 
+    def current_store
+      @current_store ||= Spree::Store.current
+    end
+    helper_method :current_store
+
     def from_address
-      Spree::Store.current.mail_from_address
+      current_store.mail_from_address
     end
 
-    def money(amount, currency = Spree::Config[:currency])
+    def money(amount, currency = nil)
+      currency ||= current_store.default_currency
       Spree::Money.new(amount, currency: currency).to_s
     end
     helper_method :money
@@ -28,7 +34,7 @@ module Spree
     # http://guides.rubyonrails.org/action_mailer_basics.html#generating-urls-in-action-mailer-views
     def ensure_default_action_mailer_url_host
       ActionMailer::Base.default_url_options ||= {}
-      ActionMailer::Base.default_url_options[:host] ||= Spree::Store.current.url
+      ActionMailer::Base.default_url_options[:host] ||= current_store.url
     end
   end
 end

--- a/core/app/mailers/spree/order_mailer.rb
+++ b/core/app/mailers/spree/order_mailer.rb
@@ -2,15 +2,17 @@ module Spree
   class OrderMailer < BaseMailer
     def confirm_email(order, resend = false)
       @order = order.respond_to?(:id) ? order : Spree::Order.find(order)
+      current_store = @order.store
       subject = (resend ? "[#{Spree.t(:resend).upcase}] " : '')
-      subject += "#{Spree::Store.current.name} #{Spree.t('order_mailer.confirm_email.subject')} ##{@order.number}"
+      subject += "#{current_store.name} #{Spree.t('order_mailer.confirm_email.subject')} ##{@order.number}"
       mail(to: @order.email, from: from_address, subject: subject)
     end
 
     def cancel_email(order, resend = false)
       @order = order.respond_to?(:id) ? order : Spree::Order.find(order)
+      current_store = @order.store
       subject = (resend ? "[#{Spree.t(:resend).upcase}] " : '')
-      subject += "#{Spree::Store.current.name} #{Spree.t('order_mailer.cancel_email.subject')} ##{@order.number}"
+      subject += "#{current_store.name} #{Spree.t('order_mailer.cancel_email.subject')} ##{@order.number}"
       mail(to: @order.email, from: from_address, subject: subject)
     end
   end

--- a/core/app/mailers/spree/reimbursement_mailer.rb
+++ b/core/app/mailers/spree/reimbursement_mailer.rb
@@ -2,9 +2,11 @@ module Spree
   class ReimbursementMailer < BaseMailer
     def reimbursement_email(reimbursement, resend = false)
       @reimbursement = reimbursement.respond_to?(:id) ? reimbursement : Spree::Reimbursement.find(reimbursement)
+      @order = @reimbursement.order
+      current_store = @reimbursement.store
       subject = (resend ? "[#{Spree.t(:resend).upcase}] " : '')
-      subject += "#{Spree::Store.current.name} #{Spree.t('reimbursement_mailer.reimbursement_email.subject')} ##{@reimbursement.order.number}"
-      mail(to: @reimbursement.order.email, from: from_address, subject: subject)
+      subject += "#{current_store.name} #{Spree.t('reimbursement_mailer.reimbursement_email.subject')} ##{@order.number}"
+      mail(to: @order.email, from: from_address, subject: subject)
     end
   end
 end

--- a/core/app/mailers/spree/shipment_mailer.rb
+++ b/core/app/mailers/spree/shipment_mailer.rb
@@ -2,9 +2,11 @@ module Spree
   class ShipmentMailer < BaseMailer
     def shipped_email(shipment, resend = false)
       @shipment = shipment.respond_to?(:id) ? shipment : Spree::Shipment.find(shipment)
+      @order = @shipment.order
+      current_store = @shipment.store
       subject = (resend ? "[#{Spree.t(:resend).upcase}] " : '')
-      subject += "#{Spree::Store.current.name} #{Spree.t('shipment_mailer.shipped_email.subject')} ##{@shipment.order.number}"
-      mail(to: @shipment.order.email, from: from_address, subject: subject)
+      subject += "#{current_store.name} #{Spree.t('shipment_mailer.shipped_email.subject')} ##{@order.number}"
+      mail(to: @order.email, from: from_address, subject: subject)
     end
   end
 end

--- a/core/app/models/spree/reimbursement.rb
+++ b/core/app/models/spree/reimbursement.rb
@@ -60,6 +60,8 @@ module Spree
     class_attribute :reimbursement_failure_hooks
     self.reimbursement_failure_hooks = []
 
+    delegate :store, :currency, to: :order
+
     state_machine :reimbursement_status, initial: :pending do
       event :errored do
         transition to: :errored, from: :pending

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -42,6 +42,8 @@ module Spree
     scope :reverse_chronological, -> { order(Arel.sql('coalesce(spree_shipments.shipped_at, spree_shipments.created_at) desc'), id: :desc) }
     scope :valid, -> { where.not(state: :canceled) }
 
+    delegate :store, :currency, to: :order
+
     # shipment state machine (see http://github.com/pluginaweek/state_machine/tree/master for details)
     state_machine initial: :pending, use_transactions: false do
       event :ready do
@@ -102,11 +104,6 @@ module Spree
 
     def backordered?
       inventory_units.any?(&:backordered?)
-    end
-
-    # TODO: delegate currency to Order, order.currency is mandatory
-    def currency
-      order ? order.currency : Spree::Config[:currency]
     end
 
     # Determines the appropriate +state+ according to the following logic:

--- a/core/app/views/spree/reimbursement_mailer/reimbursement_email.html.erb
+++ b/core/app/views/spree/reimbursement_mailer/reimbursement_email.html.erb
@@ -1,5 +1,5 @@
 <h1>
-  <%= Spree.t('reimbursement_mailer.reimbursement_email.dear_customer', name: name_for(@reimbursement.order)) %>
+  <%= Spree.t('reimbursement_mailer.reimbursement_email.dear_customer', name: name_for(@order)) %>
 </h1>
 <p>
   <%= Spree.t('reimbursement_mailer.reimbursement_email.instructions') %>

--- a/core/app/views/spree/shared/_base_mailer_header.html.erb
+++ b/core/app/views/spree/shared/_base_mailer_header.html.erb
@@ -3,10 +3,10 @@
   <td class="email-masthead">
     <% if frontend_available? %>
       <%= link_to spree.root_url, class: 'template-label' do %>
-        <%= image_tag Spree::Config.logo, class: 'logo', alt: Spree::Store.current.name, title: Spree::Store.current.name %>
+        <%= image_tag Spree::Config.logo, class: 'logo', alt: current_store.name, title: current_store.name %>
       <% end %>
     <% else %>
-      <%= image_tag Spree::Config.logo, class: 'logo', alt: Spree::Store.current.name, title: Spree::Store.current.name %>
+      <%= image_tag Spree::Config.logo, class: 'logo', alt: current_store.name, title: current_store.name %>
     <% end %>
   </td>
 </tr>

--- a/core/spec/mailers/order_mailer_spec.rb
+++ b/core/spec/mailers/order_mailer_spec.rb
@@ -12,10 +12,12 @@ describe Spree::OrderMailer, type: :mailer do
     product = stub_model(Spree::Product, name: %{The "BEST" product})
     variant = stub_model(Spree::Variant, product: product)
     price = stub_model(Spree::Price, variant: variant, amount: 5.00)
+    store = build(:store)
     line_item = stub_model(Spree::LineItem, variant: variant, order: order, quantity: 1, price: 4.99)
     allow(product).to receive_messages(default_variant: variant)
     allow(variant).to receive_messages(default_price: price)
     allow(order).to receive_messages(line_items: [line_item])
+    allow(order).to receive_messages(store: store)
     order
   end
 

--- a/core/spec/mailers/shipment_mailer_spec.rb
+++ b/core/spec/mailers/shipment_mailer_spec.rb
@@ -5,9 +5,9 @@ describe Spree::ShipmentMailer, type: :mailer do
   include EmailSpec::Helpers
   include EmailSpec::Matchers
 
-  before { create(:store) }
+  let!(:store) { create(:store) }
 
-  let(:order) { stub_model(Spree::Order, number: 'R12345') }
+  let(:order) { stub_model(Spree::Order, number: 'R12345', store: store) }
   let(:shipping_method) { stub_model(Spree::ShippingMethod, name: 'USPS') }
   let(:product) { stub_model(Spree::Product, name: %{The "BEST" product}, sku: 'SKU0001') }
   let(:variant) { stub_model(Spree::Variant, product: product) }

--- a/core/spec/models/spree/reimbursement_spec.rb
+++ b/core/spec/models/spree/reimbursement_spec.rb
@@ -18,6 +18,20 @@ describe Spree::Reimbursement, type: :model do
     end
   end
 
+  describe '#store' do
+    subject { reimbursement.store }
+
+    let(:total)         { 100.50 }
+    let(:currency)      { 'USD' }
+    let(:store)         { create(:store) }
+    let(:order)         { Spree::Order.new(currency: currency, store: store) }
+    let(:reimbursement) { Spree::Reimbursement.new(total: total, order: order) }
+
+    it 'returns order store' do
+      expect(subject).to eq(store)
+    end
+  end
+
   describe '#perform!' do
     subject { reimbursement.perform! }
 

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -187,6 +187,25 @@ describe Spree::Shipment, type: :model do
     end
   end
 
+  context '#store' do
+    let(:store) { create(:store) }
+    let!(:order) { create(:order, store: store) }
+    let!(:shipment) { create(:shipment, cost: 10, order: order) }
+
+    it 'return order store' do
+      expect(shipment.store).to eq(store)
+    end
+  end
+
+  context '#currency' do
+    let!(:order) { create(:order, currency: 'EUR') }
+    let!(:shipment) { create(:shipment, cost: 10, order: order) }
+
+    it 'return order currency' do
+      expect(shipment.currency).to eq('EUR')
+    end
+  end
+
   context 'manifest' do
     let(:order) { Spree::Order.create }
     let(:variant) { create(:variant) }


### PR DESCRIPTION
Emails are now personalized based on the Store they are sent from.

Emails aren't always sent from controllers (eg. background job) so `Spree::Store.curent` won't work.