### PR TITLE
Active SKU and default.price

### DIFF
--- a/frontend/app/helpers/spree/structured_data_helper.rb
+++ b/frontend/app/helpers/spree/structured_data_helper.rb
@@ -23,7 +23,6 @@ module Spree
           image: structured_images(product),
           description: product.description,
           sku: structured_sku(product),
-          mpn: structured_sku(product),
           offers: {
             '@type': 'Offer',
             price: product.default_variant.price,

--- a/frontend/app/helpers/spree/structured_data_helper.rb
+++ b/frontend/app/helpers/spree/structured_data_helper.rb
@@ -17,6 +17,7 @@ module Spree
         {
           '@context': 'https://schema.org/',
           '@type': 'Product',
+          '@id': "#{spree.root_url}product_#{product.id}",
           url: spree.product_url(product),
           name: product.name,
           image: structured_images(product),

--- a/frontend/app/helpers/spree/structured_data_helper.rb
+++ b/frontend/app/helpers/spree/structured_data_helper.rb
@@ -26,7 +26,6 @@ module Spree
           offers: {
             '@type': 'Offer',
             price: product.default_variant.price,
-            priceValidUntil: product.discontinue_on ? product.discontinue_on.strftime('%F') : '',
             priceCurrency: current_currency,
             availability: product.in_stock? ? 'InStock' : 'OutOfStock',
             url: spree.product_url(product),

--- a/frontend/app/helpers/spree/structured_data_helper.rb
+++ b/frontend/app/helpers/spree/structured_data_helper.rb
@@ -17,15 +17,16 @@ module Spree
         {
           '@context': 'https://schema.org/',
           '@type': 'Product',
-          '@id': "#{spree.root_url}product_#{product.id}",
           url: spree.product_url(product),
           name: product.name,
           image: structured_images(product),
           description: product.description,
-          sku: product.sku,
+          sku: structured_sku(product),
+          mpn: structured_sku(product),
           offers: {
             '@type': 'Offer',
-            price: product.price_in(current_currency).amount,
+            price: product.default_variant.price,
+            priceValidUntil: product.discontinue_on ? product.discontinue_on.strftime('%F') : '',
             priceCurrency: current_currency,
             availability: product.in_stock? ? 'InStock' : 'OutOfStock',
             url: spree.product_url(product),
@@ -33,6 +34,10 @@ module Spree
           }
         }
       end
+    end
+
+    def structured_sku(product)
+      product.default_variant.sku? ? product.default_variant.sku : product.sku
     end
 
     def structured_images(product)


### PR DESCRIPTION
- Use default.variant for price, this seems to use the correct price if variants and options are available, or not.
- Create helper method that ensures an SKU is used, by using default.variant if there is one set else fallback to the master SKU.