### PR TITLE
Issue-9231 include promotions into order taxes calculation

### DIFF
--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -93,6 +93,7 @@ module Spree
     end
 
     def prorata_corrected_tax_amount
+      return 1 unless line_items.sum(:included_tax_total) + line_items.sum(:additional_tax_total) > 0
       prorata_adjustments = line_items.sum do |item|
         tax_rate = (item.final_amount / item.pre_tax_amount - 1).round(2)
         item_prorata_discount = item.final_amount * adjustments.eligible.sum(:amount) * -1 / line_items.sum(&:final_amount)

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -94,7 +94,7 @@ module Spree
 
     def prorata_corrected_tax_amount
       return 1 unless line_items.sum(:included_tax_total) + line_items.sum(:additional_tax_total) > 0
-      
+
       prorata_adjustments = line_items.sum do |item|
         tax_rate = (item.final_amount / item.pre_tax_amount - 1).round(2)
         item_prorata_discount = item.final_amount * adjustments.eligible.sum(:amount) * -1 / line_items.sum(&:final_amount)

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -82,14 +82,23 @@ module Spree
       order.adjustment_total = line_items.sum(:adjustment_total) +
         shipments.sum(:adjustment_total) +
         adjustments.eligible.sum(:amount)
-      order.included_tax_total = line_items.sum(:included_tax_total) + shipments.sum(:included_tax_total)
-      order.additional_tax_total = line_items.sum(:additional_tax_total) + shipments.sum(:additional_tax_total)
+      order.included_tax_total = line_items.sum(:included_tax_total) * prorata_corrected_tax_amount + shipments.sum(:included_tax_total)
+      order.additional_tax_total = line_items.sum(:additional_tax_total) * prorata_corrected_tax_amount + shipments.sum(:additional_tax_total)
 
       order.promo_total = line_items.sum(:promo_total) +
         shipments.sum(:promo_total) +
         adjustments.promotion.eligible.sum(:amount)
 
       update_order_total
+    end
+
+    def prorata_corrected_tax_amount
+      prorata_adjustments = line_items.sum do |item|
+        tax_rate = (item.final_amount / item.pre_tax_amount - 1).round(2)
+        item_prorata_discount = item.final_amount * adjustments.eligible.sum(:amount) * -1 / line_items.sum(&:final_amount)
+        new_tax = (item.final_amount - item_prorata_discount) * tax_rate / ( 1 + tax_rate )
+      end
+      prorata_adjustments / (line_items.sum(:included_tax_total) + line_items.sum(:additional_tax_total))
     end
 
     def update_item_count

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -93,7 +93,7 @@ module Spree
     end
 
     def prorata_corrected_tax_amount
-      return 1 unless line_items.sum(:included_tax_total) > 0 && adjustments.eligible.sum(:amount) != 0
+      return 1 unless line_items.sum(:included_tax_total) > 0 && line_items.sum(:additional_tax_total) == 0 && adjustments.eligible.sum(:amount) != 0
 
       prorata_adjustments = line_items.sum do |item|
         tax_rate = (item.included_tax_total / (item.final_amount - item.included_tax_total)).round(2)

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -96,7 +96,7 @@ module Spree
       prorata_adjustments = line_items.sum do |item|
         tax_rate = (item.final_amount / item.pre_tax_amount - 1).round(2)
         item_prorata_discount = item.final_amount * adjustments.eligible.sum(:amount) * -1 / line_items.sum(&:final_amount)
-        new_tax = (item.final_amount - item_prorata_discount) * tax_rate / ( 1 + tax_rate )
+        (item.final_amount - item_prorata_discount) * tax_rate / (1 + tax_rate)
       end
       prorata_adjustments / (line_items.sum(:included_tax_total) + line_items.sum(:additional_tax_total))
     end

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -94,6 +94,7 @@ module Spree
 
     def prorata_corrected_tax_amount
       return 1 unless line_items.sum(:included_tax_total) + line_items.sum(:additional_tax_total) > 0
+      
       prorata_adjustments = line_items.sum do |item|
         tax_rate = (item.final_amount / item.pre_tax_amount - 1).round(2)
         item_prorata_discount = item.final_amount * adjustments.eligible.sum(:amount) * -1 / line_items.sum(&:final_amount)

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -93,7 +93,7 @@ module Spree
     end
 
     def prorata_corrected_tax_amount
-      return 1 unless line_items.sum(:included_tax_total) + line_items.sum(:additional_tax_total) > 0 && adjustments.eligible.sum(:amount) > 0
+      return 1 unless line_items.sum(:included_tax_total) + line_items.sum(:additional_tax_total) > 0 && adjustments.eligible.sum(:amount) != 0
 
       prorata_adjustments = line_items.sum do |item|
         item_tax = item.additional_tax_total + item.included_tax_total


### PR DESCRIPTION
See [Issue 9231](https://github.com/spree/spree/issues/9231)
This workaround will result into correct tax calculation at order level with order adjustments.