### PR TITLE
Barcode & Structured Data

### DIFF
--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -84,6 +84,13 @@
         <% end %>
       </div>
 
+      <div data-hook="admin_product_form_barcode">
+        <%= f.field_container :barcode, class: ['form-group'] do %>
+          <%= f.label :barcode, Spree.t(:barcode) %>
+          <%= f.text_field :barcode, size: 16, class: 'form-control' %>
+        <% end %>
+      </div>
+
       <% if @product.has_variants? %>
         <div data-hook="admin_product_form_multiple_variants" class="card bg-light mb-3">
           <div class="card-body">

--- a/backend/app/views/spree/admin/variants/_form.html.erb
+++ b/backend/app/views/spree/admin/variants/_form.html.erb
@@ -14,11 +14,6 @@
         </div>
       <% end %>
 
-      <div class="form-group" data-hook="sku">
-        <%= f.label :sku, Spree.t(:sku) %>
-        <%= f.text_field :sku, class: 'form-control' %>
-      </div>
-
       <div class="form-group" data-hook="price">
         <%= f.label :price, Spree.t(:price) %>
         <%= f.text_field :price, value: number_to_currency(@variant.price, unit: ''), class: 'form-control' %>
@@ -50,5 +45,15 @@
         <%= f.text_field field, value: value, class: 'form-control' %>
       </div>
     <% end %>
+
+    <div class="form-group" data-hook="sku">
+      <%= f.label :sku, Spree.t(:sku) %>
+      <%= f.text_field :sku, class: 'form-control' %>
+    </div>
+
+    <div class="form-group" data-hook="barcode">
+      <%= f.label :barcode, Spree.t(:barcode) %>
+      <%= f.text_field :barcode, class: 'form-control' %>
+    </div>
   </div>
 </div>

--- a/backend/spec/features/admin/products/edit/products_spec.rb
+++ b/backend/spec/features/admin/products/edit/products_spec.rb
@@ -5,7 +5,7 @@ describe 'Product Details', type: :feature, js: true do
 
   context 'editing a product' do
     before do
-      create(:product, name: 'Bún thịt nướng', sku: 'A100',
+      create(:product, name: 'Bún thịt nướng', sku: 'A100', barcode: '5260364685169',
                        description: 'lorem ipsum', available_on: '2013-08-14 01:02:03')
 
       visit spree.admin_products_path
@@ -23,6 +23,7 @@ describe 'Product Details', type: :feature, js: true do
       expect(page).to have_field(id: 'product_cost_price', with: '17.00')
       expect(page).to have_field(id: 'product_available_on', with: '2013/08/14')
       expect(page).to have_field(id: 'product_sku', with: 'A100')
+      expect(page).to have_field(id: 'product_barcode', with: '5260364685169')
     end
 
     it 'handles slug changes' do

--- a/backend/spec/features/admin/products/edit/variants_spec.rb
+++ b/backend/spec/features/admin/products/edit/variants_spec.rb
@@ -45,6 +45,7 @@ describe 'Product Variants', type: :feature, js: true do
 
       select2 'black', from: 'Colors'
       fill_in 'variant_sku', with: 'A100'
+      fill_in 'variant_barcode', with: '5260364685171'
       click_button 'Create'
       expect(page).to have_content('successfully created!')
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -605,6 +605,7 @@ en:
     backorderable_default: Backorderable default
     backorders_allowed: backorders allowed
     balance_due: Balance Due
+    barcode: Barcode (ISBN, UPC, GTIN, etc.)
     base_amount: Base Amount
     base_percent: Base Percent
     basic_information: Basic Information

--- a/core/db/migrate/20200427165008_add_barcode_to_spree_variants_and_spree_products.rb
+++ b/core/db/migrate/20200427165008_add_barcode_to_spree_variants_and_spree_products.rb
@@ -1,0 +1,6 @@
+class AddBarcodeToSpreeVariantsAndSpreeProducts < ActiveRecord::Migration[6.0]
+  def change
+    add_column :spree_variants, :barcode, :string
+    add_column :spree_products, :barcode, :string
+  end
+end

--- a/frontend/app/helpers/spree/structured_data_helper.rb
+++ b/frontend/app/helpers/spree/structured_data_helper.rb
@@ -28,7 +28,6 @@ module Spree
           offers: {
             '@type': 'Offer',
             price: product.default_variant.price_in(current_currency).amount,
-            priceValidUntil: product.discontinue_on ? product.discontinue_on.strftime('%F') : DateTime.now.next_year(10).to_time.strftime('%F'),
             priceCurrency: current_currency,
             availability: product.in_stock? ? 'InStock' : 'OutOfStock',
             url: spree.product_url(product),
@@ -42,16 +41,16 @@ module Spree
       product.default_variant.sku? ? product.default_variant.sku : product.sku
     end
 
+    def structured_barcode(product)
+      product.default_variant.barcode? ? product.default_variant.barcode : product.barcode
+    end
+
     def structured_brand(product)
       if product.property('brand').present?
         return product.property('brand')
       else
-        return ''
+        return 'Generic'
       end
-    end
-
-    def structured_barcode(product)
-      product.default_variant.barcode? ? product.default_variant.barcode : product.barcode
     end
 
     def structured_images(product)

--- a/frontend/app/helpers/spree/structured_data_helper.rb
+++ b/frontend/app/helpers/spree/structured_data_helper.rb
@@ -46,11 +46,9 @@ module Spree
     end
 
     def structured_brand(product)
-      if product.property('brand').present?
-        return product.property('brand')
-      else
-        return ''
-      end
+      return '' unless product.property('brand').present?
+      
+      product.property('brand')
     end
 
     def structured_images(product)

--- a/frontend/app/helpers/spree/structured_data_helper.rb
+++ b/frontend/app/helpers/spree/structured_data_helper.rb
@@ -47,7 +47,7 @@ module Spree
 
     def structured_brand(product)
       return '' unless product.property('brand').present?
-      
+
       product.property('brand')
     end
 

--- a/frontend/app/helpers/spree/structured_data_helper.rb
+++ b/frontend/app/helpers/spree/structured_data_helper.rb
@@ -28,7 +28,7 @@ module Spree
           offers: {
             '@type': 'Offer',
             price: product.default_variant.price_in(current_currency).amount,
-            priceValidUntil: product.discontinue_on ? product.discontinue_on.strftime('%F') : '',
+            priceValidUntil: product.discontinue_on ? product.discontinue_on.strftime('%F') : DateTime.now.next_year(10).to_time.strftime('%F'),
             priceCurrency: current_currency,
             availability: product.in_stock? ? 'InStock' : 'OutOfStock',
             url: spree.product_url(product),

--- a/frontend/app/helpers/spree/structured_data_helper.rb
+++ b/frontend/app/helpers/spree/structured_data_helper.rb
@@ -24,7 +24,7 @@ module Spree
           description: product.description,
           brand: structured_brand(product),
           sku: structured_sku(product),
-          gtin: structured_barcode(product),
+          gtin13: structured_barcode(product),
           offers: {
             '@type': 'Offer',
             price: product.default_variant.price_in(current_currency).amount,

--- a/frontend/app/helpers/spree/structured_data_helper.rb
+++ b/frontend/app/helpers/spree/structured_data_helper.rb
@@ -49,7 +49,7 @@ module Spree
       if product.property('brand').present?
         return product.property('brand')
       else
-        return 'Generic'
+        return ''
       end
     end
 

--- a/frontend/app/helpers/spree/structured_data_helper.rb
+++ b/frontend/app/helpers/spree/structured_data_helper.rb
@@ -22,10 +22,13 @@ module Spree
           name: product.name,
           image: structured_images(product),
           description: product.description,
-          sku: product.sku,
+          brand: structured_brand(product),
+          sku: structured_sku(product),
+          gtin: structured_barcode(product),
           offers: {
             '@type': 'Offer',
-            price: product.price_in(current_currency).amount,
+            price: product.default_variant.price_in(current_currency).amount,
+            priceValidUntil: product.discontinue_on ? product.discontinue_on.strftime('%F') : '',
             priceCurrency: current_currency,
             availability: product.in_stock? ? 'InStock' : 'OutOfStock',
             url: spree.product_url(product),
@@ -33,6 +36,22 @@ module Spree
           }
         }
       end
+    end
+
+    def structured_sku(product)
+      product.default_variant.sku? ? product.default_variant.sku : product.sku
+    end
+
+    def structured_brand(product)
+      if product.property('brand').present?
+        return product.property('brand')
+      else
+        return ''
+      end
+    end
+
+    def structured_barcode(product)
+      product.default_variant.barcode? ? product.default_variant.barcode : product.barcode
     end
 
     def structured_images(product)

--- a/frontend/spec/features/json_ld_spec.rb
+++ b/frontend/spec/features/json_ld_spec.rb
@@ -21,7 +21,7 @@ describe 'JSON-LD hashes', type: :feature, inaccessible: true do
         expect(serialized_product['url']).to eq "http://www.example.com/products/#{product.slug}"
         expect(serialized_product['image']).to eq ''
         expect(serialized_product['description']).to eq product.description
-        expect(serialized_product['brand']).to eq 'Generic'
+        expect(serialized_product['brand']).to eq ''
         expect(serialized_product['sku']).to eq product.sku
         expect(serialized_product['gtin13']).to eq product.barcode
 

--- a/frontend/spec/features/json_ld_spec.rb
+++ b/frontend/spec/features/json_ld_spec.rb
@@ -22,6 +22,7 @@ describe 'JSON-LD hashes', type: :feature, inaccessible: true do
         expect(serialized_product['image']).to eq ''
         expect(serialized_product['description']).to eq product.description
         expect(serialized_product['sku']).to eq product.sku
+        expect(serialized_product['gtin']).to eq product.barcode
 
         offer = serialized_product['offers']
         expect(offer['@type']).to eq 'Offer'

--- a/frontend/spec/features/json_ld_spec.rb
+++ b/frontend/spec/features/json_ld_spec.rb
@@ -21,8 +21,9 @@ describe 'JSON-LD hashes', type: :feature, inaccessible: true do
         expect(serialized_product['url']).to eq "http://www.example.com/products/#{product.slug}"
         expect(serialized_product['image']).to eq ''
         expect(serialized_product['description']).to eq product.description
+        expect(serialized_product['brand']).to eq 'Generic'
         expect(serialized_product['sku']).to eq product.sku
-        expect(serialized_product['gtin']).to eq product.barcode
+        expect(serialized_product['gtin13']).to eq product.barcode
 
         offer = serialized_product['offers']
         expect(offer['@type']).to eq 'Offer'


### PR DESCRIPTION
- Added barcode to product and product variants, and used this in the structured data.
- Added methods to the structure data helper to provide a barcode and SKU if at all possible.
- Set structure data to match the displayed price on page load.
- Added tests for new barcode field. 
