### PR TITLE
Fix FrontendHelper#filtering_params_cache_key

### DIFF
--- a/frontend/app/helpers/spree/frontend_helper.rb
+++ b/frontend/app/helpers/spree/frontend_helper.rb
@@ -239,7 +239,7 @@ module Spree
     end
 
     def filtering_params_cache_key
-      @filtering_params_cache_key ||= params.permit(*filtering_params)&.reject { |_, v| v.blank? }&.to_s
+      @filtering_params_cache_key ||= params.permit(*filtering_params)&.reject { |_, v| v.blank? }&.to_param
     end
 
     def available_option_types_cache_key


### PR DESCRIPTION
It's better to store this cache key in a param format than a stringified hash