### PR TITLE
Fixed: throw(:abort) cannot be called in after_ callbacks

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -341,7 +341,7 @@ module Spree
           price: master.price
         )
       end
-      throw(:abort) unless save
+      save
     end
 
     def ensure_master


### PR DESCRIPTION
https://github.com/rails/rails/issues/33192#issuecomment-399719506