### PR TITLE
Introduce concat taxons filter

### DIFF
--- a/core/app/finders/spree/products/find.rb
+++ b/core/app/finders/spree/products/find.rb
@@ -9,6 +9,7 @@ module Spree
         @price            = String(params.dig(:filter, :price)).split(',').map(&:to_f)
         @currency         = params[:currency] || current_currency
         @taxons           = taxon_ids(params.dig(:filter, :taxons))
+        @concat_taxons    = taxon_ids(params.dig(:filter, :concat_taxons))
         @name             = params.dig(:filter, :name)
         @options          = params.dig(:filter, :options).try(:to_unsafe_hash)
         @option_value_ids = params.dig(:filter, :option_value_ids)
@@ -22,6 +23,7 @@ module Spree
         products = by_skus(products)
         products = by_price(products)
         products = by_taxons(products)
+        products = by_concat_taxons(products)
         products = by_name(products)
         products = by_options(products)
         products = by_option_value_ids(products)
@@ -30,11 +32,12 @@ module Spree
         products = ordered(products)
 
         products.distinct
+
       end
 
       private
 
-      attr_reader :ids, :skus, :price, :currency, :taxons, :name, :options, :option_value_ids, :scope, :sort_by, :deleted, :discontinued
+      attr_reader :ids, :skus, :price, :currency, :taxons, :concat_taxons, :name, :options, :option_value_ids, :scope, :sort_by, :deleted, :discontinued
 
       def ids?
         ids.present?
@@ -50,6 +53,10 @@ module Spree
 
       def taxons?
         taxons.present?
+      end
+
+      def concat_taxons?
+        concat_taxons.present?
       end
 
       def name?
@@ -100,6 +107,19 @@ module Spree
         return products unless taxons?
 
         products.joins(:classifications).where(Classification.table_name => { taxon_id: taxons })
+      end
+
+      def by_concat_taxons(products)
+        return products unless concat_taxons?
+
+        product_ids = Spree::Product.
+                      joins(:classifications).
+                      where(Classification.table_name => { taxon_id: concat_taxons }).
+                      group("#{Spree::Product.table_name}.id").
+                      having("COUNT(#{Spree::Product.table_name}.id) = ?", concat_taxons.length).
+                      ids
+
+        products.where(id: product_ids)
       end
 
       def by_name(products)

--- a/core/app/finders/spree/products/find.rb
+++ b/core/app/finders/spree/products/find.rb
@@ -32,12 +32,12 @@ module Spree
         products = ordered(products)
 
         products.distinct
-
       end
 
       private
 
-      attr_reader :ids, :skus, :price, :currency, :taxons, :concat_taxons, :name, :options, :option_value_ids, :scope, :sort_by, :deleted, :discontinued
+      attr_reader :ids, :skus, :price, :currency, :taxons, :concat_taxons, :name, :options,
+                  :option_value_ids, :scope, :sort_by, :deleted, :discontinued
 
       def ids?
         ids.present?

--- a/core/spec/finders/spree/products/find_spec.rb
+++ b/core/spec/finders/spree/products/find_spec.rb
@@ -18,6 +18,7 @@ module Spree
             price: '',
             currency: false,
             taxons: '',
+            concat_taxons: '',
             name: false,
             options: false,
             show_deleted: false,
@@ -46,6 +47,7 @@ module Spree
             price: '',
             currency: false,
             taxons: '',
+            concat_taxons: '',
             name: false,
             options: false,
             show_deleted: true,
@@ -72,6 +74,7 @@ module Spree
             price: '',
             currency: false,
             taxons: '',
+            concat_taxons: '',
             name: false,
             options: false,
             show_deleted: false,
@@ -184,6 +187,54 @@ module Spree
         end
 
         it { expect(products).to match_array [product, product_2] }
+      end
+
+      context 'multiple taxons + 1 concat_taxons are requested' do
+        let(:params) { { filter: { taxons: "#{taxon.id},#{taxon_2.id}", concat_taxons: "#{taxon_3.id}" } } }
+        let(:taxon) { create(:taxon) }
+        let(:taxon_2) { create(:taxon) }
+        let(:taxon_3) { create(:taxon) }
+
+        before do
+          taxon.products << product
+          taxon_2.products << product_2
+          taxon_3.products << product_2
+          taxon_3.products << product_3
+        end
+
+        it { expect(products).to match_array [product_2] }
+      end
+
+      context 'only multiple concat_taxons are requested' do
+        let(:params) { { filter: {concat_taxons: "#{taxon_2.id},#{taxon_3.id}" } } }
+        let(:taxon) { create(:taxon) }
+        let(:taxon_2) { create(:taxon) }
+        let(:taxon_3) { create(:taxon) }
+
+        before do
+          taxon.products << product
+          taxon_2.products << product_2
+          taxon_3.products << product_2
+          taxon_3.products << product_3
+        end
+
+        it { expect(products).to match_array [product_2] }
+      end
+
+      context 'only one concat_taxons is requested' do
+        let(:params) { { filter: {concat_taxons: "#{taxon_3.id}" } } }
+        let(:taxon) { create(:taxon) }
+        let(:taxon_2) { create(:taxon) }
+        let(:taxon_3) { create(:taxon) }
+
+        before do
+          taxon.products << product
+          taxon_2.products << product_2
+          taxon_3.products << product_2
+          taxon_3.products << product_3
+        end
+
+        it { expect(products).to match_array [product_2,product_3] }
       end
     end
 


### PR DESCRIPTION
If you want to filter products to include the exact set of taxons, you can now use the concat_filter.
It also works for combinations with the normal taxon filters.

**Example on Taxonomies**
- Category (1) -> Cars (2)
- Category (1) -> Bikes (8)
- Category (1) -> Skateboards (9)
- Brand (3) -> Awesome Designer (4)
- Design Style (5) -> Modern (6)
- Design Style (5) -> Antique (7)

`filter[concat_taxon]=2,4`
Returns all items that have Care (2) and Awesome Designer (4) as Taxon

`filter[concat_taxon]=4,7`
Returns all items that have Awesome Designer (4) and Antique (7) as Taxon

`filter[taxon]=2,8&filter[concat_taxon]=4,7`
Returns all items Cars(2) and Bikes (8) that have Awesome Designer (4) and Antique (7) as Taxon