### PR TITLE
Add missing attribute for taxon

### DIFF
--- a/api/app/serializers/spree/v2/storefront/taxon_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/taxon_serializer.rb
@@ -4,7 +4,7 @@ module Spree
       class TaxonSerializer < BaseSerializer
         set_type   :taxon
 
-        attributes :name, :pretty_name, :permalink, :seo_title, :meta_title, :meta_description,
+        attributes :name, :pretty_name, :permalink, :seo_title, :description, :meta_title, :meta_description,
                    :meta_keywords, :left, :right, :position, :depth, :updated_at
 
         attribute :is_root,  &:root?


### PR DESCRIPTION
description was missing in attribute for api v2 calls.