### PR TITLE
Add Customer Returns API v1 docs

### DIFF
--- a/guides/src/content/api/customer_returns.md
+++ b/guides/src/content/api/customer_returns.md
@@ -1,0 +1,60 @@
+---
+title: Customer Returns
+description: Use the Spree Commerce storefront API to access Customer Returns data.
+---
+
+## Index
+
+Retrieve a list of customer returns by making this request:
+
+```text
+GET /api/v1/customer_returns
+```
+
+Customer returns are paginated and can be iterated through by passing along a `page` parameter:
+
+```text
+GET /api/v1/customer_returns?page=2
+```
+
+### Parameters
+
+<params params='[
+  {
+    "name": "page",
+    "description": "The page number of customer return to display."
+  }, {
+    "name": "per_page",
+    "description": "The number of customer returns to return per page"
+  }
+]'></params>
+
+### Response
+
+<status code="200"></status>
+<json sample="customer_returns"></json>
+
+## Search
+
+To search for a particular customer return, make a request like this:
+
+```text
+GET /api/v1/customer_returns?q[number_cont]=CR972477438
+```
+
+The searching API is provided through the Ransack gem which Spree depends on. The `number_cont` here is called a predicate, and you can learn more about them by reading about [Predicates on the Ransack wiki](https://github.com/ernie/ransack/wiki/Basic-Searching).
+
+The search results are paginated.
+
+### Response
+
+<status code="200"></status>
+<json sample="customer_returns"></json>
+
+### Sorting results
+
+Results can be returned in a specific order by specifying which field to sort by when making a request.
+
+```text
+GET /api/v1/customer_returns?q[s]=updated_at%20desc
+```

--- a/guides/src/data/customer_return.js
+++ b/guides/src/data/customer_return.js
@@ -1,0 +1,9 @@
+export default {
+  id: 1,
+  number: 'CR972477438',
+  order_id: 1,
+  fully_reimbursed: false,
+  pre_tax_total: '100.0',
+  created_at: '2020-05-12T05:52:46.268Z',
+  updated_at: '2020-05-12T05:52:46.268Z'
+}

--- a/guides/src/data/customer_returns.js
+++ b/guides/src/data/customer_returns.js
@@ -1,0 +1,8 @@
+import CUSTOMER_RETURN from './customer_return'
+
+export default {
+  customer_returns: [CUSTOMER_RETURN],
+  count: 25,
+  current_page: 1,
+  pages: 5
+}

--- a/guides/src/data/index.js
+++ b/guides/src/data/index.js
@@ -35,6 +35,8 @@ import SHIPMENT_SMALL from './shipment_small'
 import SHIPMENTS from './shipments'
 import RETURN_AUTHORIZATION from './return_authorization'
 import RETURN_AUTHORIZATIONS from './return_authorizations'
+import CUSTOMER_RETURN from './customer_return'
+import CUSTOMER_RETURNS from './customer_returns'
 import PRODUCT from './product'
 import PRODUCTS from './products'
 import PRODUCT_PROPERTY from './product_property'
@@ -86,6 +88,8 @@ export default {
   shipments: SHIPMENTS,
   return_authorization: RETURN_AUTHORIZATION,
   return_authorizations: RETURN_AUTHORIZATIONS,
+  customer_return: CUSTOMER_RETURN,
+  customer_returns: CUSTOMER_RETURNS,
   product: PRODUCT,
   products: PRODUCTS,
   product_property: PRODUCT_PROPERTY,

--- a/guides/src/data/orders.js
+++ b/guides/src/data/orders.js
@@ -1,4 +1,4 @@
-import ORDER from './orders'
+import ORDER from './order'
 
 export default {
   orders: [ORDER],

--- a/guides/src/data/payments.js
+++ b/guides/src/data/payments.js
@@ -1,3 +1,3 @@
-import PAYMENT from './payments'
+import PAYMENT from './payment'
 
 export default { payments: [PAYMENT], count: 2, current_page: 1, pages: 2 }


### PR DESCRIPTION
(I'm not sure that the API v1 is still supported, but till there's no replacements on v2..)

The CustomerReturn index endpoint is not described in the docs. I thought it's useful to have it documented, since someone can start to implement it as I did :D 

+ Fixed a wrong path for the import of some objects