### PR TITLE
Adds The Ability To Show / Not Show Specific Product Properties

### DIFF
--- a/backend/app/views/spree/admin/product_properties/_product_property_fields.html.erb
+++ b/backend/app/views/spree/admin/product_properties/_product_property_fields.html.erb
@@ -11,6 +11,9 @@
   <td class='value'>
     <%= f.text_field :value, class: 'form-control' %>
   </td>
+  <td class="show_property">
+    <%= f.check_box :show_property, class: 'form-control' %>
+  </td>
   <td class="actions actions-1">
     <% if f.object.persisted? && can?(:destroy, f.object) %>
       <%= link_to_delete f.object, no_text: true %>

--- a/backend/app/views/spree/admin/product_properties/index.html.erb
+++ b/backend/app/views/spree/admin/product_properties/index.html.erb
@@ -25,6 +25,7 @@
         <tr data-hook="product_properties_header">
           <th colspan="2"><%= Spree.t(:property) %></th>
           <th><%= Spree.t(:value) %></th>
+          <th><%= Spree.t(:show_property) %></th>
           <th class="actions"></th>
         </tr>
       </thead>

--- a/backend/spec/features/admin/products/edit/properties_spec.rb
+++ b/backend/spec/features/admin/products/edit/properties_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe 'Product Properties', type: :feature, js: true do
+  stub_authorization!
+
+  before do
+    create(:product)
+    visit spree.admin_products_path
+  end
+
+  context 'editing product properties' do
+    it 'allows admin to create a new property' do
+      within_row(1) { click_icon :edit }
+
+      within('#sidebar') { click_link 'Properties' }
+      fill_in 'product_product_properties_attributes_0_property_name', with: 'Material'
+      fill_in 'product_product_properties_attributes_0_value', with: 'Leather'
+      click_button 'Update'
+
+      within('#sidebar') { click_link 'Properties' }
+      expect(page).to have_content('Add Product Properties')
+      expect(page).to have_content('SHOW PROPERTY')
+      expect(page).to have_selector("input[value='Material']")
+      expect(page).to have_selector("input[value='Leather']")
+      expect(page).to have_field('product_product_properties_attributes_0_show_property', checked: true)
+    end
+
+    it 'allows admin to create a new property and not show the property on the storefront' do
+      within_row(1) { click_icon :edit }
+
+      within('#sidebar') { click_link 'Properties' }
+      fill_in 'product_product_properties_attributes_0_property_name', with: 'gtin'
+      fill_in 'product_product_properties_attributes_0_value', with: '9020188287332'
+      find(:css, "#product_product_properties_attributes_0_show_property").set(false)
+      click_button 'Update'
+
+      within('#sidebar') { click_link 'Properties' }
+      expect(page).to have_selector("input[value='gtin']")
+      expect(page).to have_selector("input[value='9020188287332']")
+      expect(page).to have_field('product_product_properties_attributes_0_show_property', checked: false)
+    end
+  end
+end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1505,6 +1505,7 @@ en:
     show_discontinued: Show Discontinued
     show_only_complete_orders: Only show complete orders
     show_only_considered_risky: Only show risky orders
+    show_property: Show Property
     show_rate_in_label: Show rate in label
     sign_up: Sign Up
     sku: SKU

--- a/core/db/migrate/20200513154939_add_show_property_to_spree_product_properties.rb
+++ b/core/db/migrate/20200513154939_add_show_property_to_spree_product_properties.rb
@@ -1,5 +1,5 @@
 class AddShowPropertyToSpreeProductProperties < ActiveRecord::Migration[6.0]
   def change
-      add_column :spree_product_properties, :show_property, :boolean, default: true
+    add_column :spree_product_properties, :show_property, :boolean, default: true unless column_exists?(:spree_product_properties, :show_property)
   end
 end

--- a/core/db/migrate/20200513154939_add_show_property_to_spree_product_properties.rb
+++ b/core/db/migrate/20200513154939_add_show_property_to_spree_product_properties.rb
@@ -1,0 +1,5 @@
+class AddShowPropertyToSpreeProductProperties < ActiveRecord::Migration[6.0]
+  def change
+      add_column :spree_product_properties, :show_property, :boolean, default: true
+  end
+end

--- a/frontend/app/views/spree/products/_properties.html.erb
+++ b/frontend/app/views/spree/products/_properties.html.erb
@@ -2,7 +2,7 @@
   <h3 class="pt-4 font-weight-bold text-uppercase product-details-subtitle"><%= Spree.t(:details) %></h3>
   <ul id="product-properties" class="m-0 list-unstyled product-properies" data-hook>
     <% @product_properties.each do |product_property| %>
-      <% if product_property.show_property %>
+      <% if product_property.show_property? %>
         <li>
           <span class="font-weight-bold text-break"><%= product_property.property.presentation %>:</span>
           <span class="text-break"><%= product_property.value %></span>

--- a/frontend/app/views/spree/products/_properties.html.erb
+++ b/frontend/app/views/spree/products/_properties.html.erb
@@ -2,10 +2,12 @@
   <h3 class="pt-4 font-weight-bold text-uppercase product-details-subtitle"><%= Spree.t(:details) %></h3>
   <ul id="product-properties" class="m-0 list-unstyled product-properies" data-hook>
     <% @product_properties.each do |product_property| %>
-      <li>
-        <span class="font-weight-bold text-break"><%= product_property.property.presentation %>:</span>
-        <span class="text-break"><%= product_property.value %></span>
-      </li>
+      <% if product_property.show_property %>
+        <li>
+          <span class="font-weight-bold text-break"><%= product_property.property.presentation %>:</span>
+          <span class="text-break"><%= product_property.value %></span>
+        </li>
+      <% end %>
     <% end %>
   </ul>
 <% end %>


### PR DESCRIPTION
This PR adds a simple checkbox to the product properties, allowing the Admin to decide what product properties should be displayed on the storefront.

Gives Product Properties power to be used in extensions for passing specific product properties as data in JSON, XML formats, information that you wouldn't otherwise want to be displayed on the product page.

<img width="2118" alt="Screenshot 2020-05-13 at 17 32 13" src="https://user-images.githubusercontent.com/1240766/81840821-68176d00-9541-11ea-8e92-cf7026bfd609.png">


<img width="1414" alt="Screenshot 2020-05-13 at 17 32 02" src="https://user-images.githubusercontent.com/1240766/81840836-6d74b780-9541-11ea-937f-b8e1ba0602d0.png">
