### PR TITLE
taxonomy & taxon, includes translations to avoid n + 1 query

### DIFF
--- a/api/app/controllers/spree/api/v1/taxons_controller.rb
+++ b/api/app/controllers/spree/api/v1/taxons_controller.rb
@@ -74,7 +74,8 @@ module Spree
 
         def taxonomy
           if params[:taxonomy_id].present?
-            @taxonomy ||= Spree::Taxonomy.accessible_by(current_ability, :show).find(params[:taxonomy_id])
+            @taxonomy ||=
+              Spree::Taxonomy.includes(:translations, taxons: [:translations]).accessible_by(current_ability, :show).find(params[:taxonomy_id])
           end
         end
 

--- a/backend/app/controllers/spree/admin/taxons_controller.rb
+++ b/backend/app/controllers/spree/admin/taxons_controller.rb
@@ -77,7 +77,7 @@ module Spree
       end
 
       def load_taxonomy
-        @taxonomy = Taxonomy.find(params[:taxonomy_id])
+        @taxonomy = Taxonomy.includes(:translations, taxons: [:translations]).find(params[:taxonomy_id])
       end
 
       def set_position


### PR DESCRIPTION
Thank you for your great work! I'm using spree for my business and it runs as a multi-language e-commerce site. 

I found a n+1 query warning and fixed it. Please let me know is there anything else or what should I do to merge this pull request. Thank you.