### PR TITLE
[WCAG-11] Wrap checkout footer content with footer tags

### DIFF
--- a/frontend/app/views/spree/layouts/checkout.html.erb
+++ b/frontend/app/views/spree/layouts/checkout.html.erb
@@ -20,7 +20,9 @@
       <%= yield :templates %>
     </div>
 
-    <%= render 'spree/shared/copyright' %>
+    <footer>
+      <%= render 'spree/shared/copyright' %>
+    </footer>
     <%= render 'spree/shared/translations' %>
   </body>
 </html>


### PR DESCRIPTION
Fix for `All page content must be contained by landmarks` issue.