### PR TITLE
Fixes missing country picker flags

### DIFF
--- a/frontend/app/assets/stylesheets/spree/frontend/flags/_variables.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/flags/_variables.scss
@@ -1,2 +1,2 @@
-$flag-icon-css-path: '/assets/flags' !default;
+$flag-icon-css-path: 'flags' !default;
 $flag-icon-rect-path: '/4x3' !default;


### PR DESCRIPTION
Invalid path resulted in images not being found. Changing path resolved issue on spree-multi-store-demo project.