### PR TITLE
Bug Fix on Address Form + Use div for form container elements, not p tags

### DIFF
--- a/frontend/app/assets/javascripts/spree/frontend/checkout/address.js
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/address.js
@@ -53,6 +53,7 @@ Spree.ready(function ($) {
         var states = data.states
         var statePara = $('#' + region + 'state')
         var stateSelect = statePara.find('select')
+        var stateSelectImg = statePara.find('img')
         var stateInput = statePara.find('input')
         var stateSpanRequired = statePara.find('abbr')
 
@@ -70,11 +71,12 @@ Spree.ready(function ($) {
           stateSelect.prop('disabled', false).show()
           stateInput.hide().prop('disabled', true)
           statePara.show()
+          stateSelectImg.show()
           stateSpanRequired.hide()
           stateSelect.removeClass('required')
 
           if (statesRequired) {
-            stateSelect.addClass('required form-control spree-flat-select')
+            stateSelect.addClass('required')
             stateSpanRequired.show()
             stateSelect.prop('required', true)
           }
@@ -82,6 +84,7 @@ Spree.ready(function ($) {
           stateInput.removeClass('required')
         } else {
           stateSelect.hide().prop('disabled', true)
+          stateSelectImg.hide()
           stateInput.show()
           if (statesRequired) {
             stateSpanRequired.show()

--- a/frontend/app/assets/javascripts/spree/frontend/checkout/address.js
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/address.js
@@ -74,7 +74,7 @@ Spree.ready(function ($) {
           stateSelect.removeClass('required')
 
           if (statesRequired) {
-            stateSelect.addClass('required')
+            stateSelect.addClass('required form-control spree-flat-select')
             stateSpanRequired.show()
             stateSelect.prop('required', true)
           }

--- a/frontend/app/helpers/spree/addresses_helper.rb
+++ b/frontend/app/helpers/spree/addresses_helper.rb
@@ -25,11 +25,15 @@ module Spree
         form.collection_select(:state_id, country.states.order(:name),
                               :id, :name,
                                { prompt: Spree.t(:state).upcase },
-                               class: have_states ? 'required form-control spree-flat-select' : 'hidden',
+                               class: have_states ? 'required form-control spree-flat-select' : 'hidden form-control spree-flat-select',
                                aria: { label: Spree.t(:state) },
                                disabled: !have_states) +
-          form.text_field(:state_name, class: !have_states ? 'required' : 'hidden', disabled: have_states) +
-          image_tag('arrow.svg', class: 'position-absolute spree-flat-select-arrow')
+          form.text_field(:state_name,
+                          class: !have_states ? 'required spree-flat-input' : 'hidden spree-flat-input',
+                          disabled: have_states,
+                          placeholder: Spree.t(:state) + ' *') +
+          image_tag('arrow.svg',
+                    class: !have_states ? 'hidden position-absolute spree-flat-select-arrow' : 'position-absolute spree-flat-select-arrow')
       ].join.tr('"', "'").delete("\n")
 
       content_tag(:noscript, form.text_field(:state_name, class: 'required')) +

--- a/frontend/app/helpers/spree/addresses_helper.rb
+++ b/frontend/app/helpers/spree/addresses_helper.rb
@@ -2,7 +2,7 @@
 module Spree
   module AddressesHelper
     def address_field(form, method, address_id = 'b', &handler)
-      content_tag :p, id: [address_id, method].join, class: 'form-group checkout-content-inner-field' do
+      content_tag :div, id: [address_id, method].join, class: 'form-group checkout-content-inner-field' do
         if handler
           yield
         else

--- a/frontend/app/views/spree/address/_form.html.erb
+++ b/frontend/app/views/spree/address/_form.html.erb
@@ -1,51 +1,51 @@
 <% address_id = address_type.chars.first %>
 
 <div class="inner" data-hook=<%="#{address_type}_inner" %>>
-  <p class="form-group" id=<%="#{address_id}firstname" %>>
+  <div class="form-group" id=<%="#{address_id}firstname" %>>
     <%= form.label :firstname do %>
       <%= Spree.t(:first_name) %><abbr class="required" title="required">*</abbr>
     <% end %>
     <%= form.text_field :firstname, class: 'form-control', required: true %>
-  </p>
-  <p class="form-group" id=<%="#{address_id}lastname" %>>
+  </div>
+  <div class="form-group" id=<%="#{address_id}lastname" %>>
     <%= form.label :lastname do %>
       <%= Spree.t(:last_name) %><abbr class="required" title="required">*</abbr>
     <% end %>
     <%= form.text_field :lastname, class: 'form-control', required: true %>
-  </p>
+  </div>
   <% if Spree::Config[:company] %>
-    <p class="form-group" id=<%="#{address_id}company" %>>
+    <div class="form-group" id=<%="#{address_id}company" %>>
       <%= form.label :company, Spree.t(:company) %>
       <%= form.text_field :company, class: 'form-control' %>
-    </p>
+    </div>
   <% end %>
-  <p class="form-group" id=<%="#{address_id}address1" %>>
+  <div class="form-group" id=<%="#{address_id}address1" %>>
     <%= form.label :address1 do %>
       <%= Spree.t(:street_address) %><abbr class="required" title="required">*</abbr>
     <% end %>
     <%= form.text_field :address1, class: 'form-control required' %>
-  </p>
-  <p class="form-group" id=<%="#{address_id}address2" %>>
+  </div>
+  <div class="form-group" id=<%="#{address_id}address2" %>>
     <%= form.label :address2, Spree.t(:street_address_2) %>
     <%= form.text_field :address2, class: 'form-control' %>
-  </p>
-  <p class="form-group" id=<%="#{address_id}city" %>>
+  </div>
+  <div class="form-group" id=<%="#{address_id}city" %>>
     <%= form.label :city do %>
       <%= Spree.t(:city) %><abbr class="required" title="required">*</abbr>
     <% end %>
     <%= form.text_field :city, class: 'form-control', required: true %>
-  </p>
-  <p class="form-group" id=<%="#{address_id}country" %>>
+  </div>
+  <div class="form-group" id=<%="#{address_id}country" %>>
     <%= form.label :country_id do %>
       <%= Spree.t(:country) %><abbr class="required" title="required">*</abbr>
     <% end %>
     <span id=<%="#{address_id}country-selection" %>>
       <%= form.collection_select :country_id, available_countries, :id, :name, {}, { class: 'form-control', required: true } %>
     </span>
-  </p>
+  </div>
 
   <% if Spree::Config[:address_requires_state] %>
-    <p class="form-group" id=<%="#{address_id}state" %>>
+    <div class="form-group" id=<%="#{address_id}state" %>>
       <% have_states = !address.country.states.empty? %>
       <%= form.label :state do %>
         <%= Spree.t(:state) %><abbr class='required' title="required" id=<%="#{address_id}state-required"%>>*</abbr>
@@ -64,28 +64,28 @@
                             disabled: have_states)
          ].join.gsub('"', "'").gsub("\n", "")
       %>
-    </p>
+    </div>
       <noscript>
         <%= form.text_field :state_name, class: 'form-control', required: true %>
       </noscript>
   <% end %>
 
-  <p class="form-group" id=<%="#{address_id}zipcode" %>>
+  <div class="form-group" id=<%="#{address_id}zipcode" %>>
     <%= form.label :zipcode do %>
       <%= Spree.t(:zip) %><% if address.require_zipcode? %><abbr class="required" title="required">*</abbr><% end %>
     <% end %>
     <%= form.text_field :zipcode, class: 'form-control', required: address.require_zipcode? %>
-  </p>
-  <p class="form-group" id=<%="#{address_id}phone" %>>
+  </div>
+  <div class="form-group" id=<%="#{address_id}phone" %>>
     <%= form.label :phone do %>
       <%= Spree.t(:phone) %><% if address.require_phone? %><abbr class="required" title="required">*</abbr><% end %>
     <% end %>
     <%= form.phone_field :phone, class: 'form-control', required: address.require_phone? %>
-  </p>
+  </div>
   <% if Spree::Config[:alternative_shipping_phone] %>
-    <p class="form-group" id=<%="#{address_id}altphone" %>>
+    <div class="form-group" id=<%="#{address_id}altphone" %>>
       <%= form.label :alternative_phone, Spree.t(:alternative_phone) %>
       <%= form.phone_field :alternative_phone, class: 'form-control' %>
-    </p>
+    </div>
   <% end %>
 </div>

--- a/frontend/app/views/spree/addresses/_form.html.erb
+++ b/frontend/app/views/spree/addresses/_form.html.erb
@@ -2,7 +2,7 @@
 
 <% Spree::Address::ADDRESS_FIELDS.each do |field| %>
   <% if field == "country" %>
-    <p class="form-group checkout-content-inner-field" id="<%= "#{address_id}country" %>">
+    <div class="form-group checkout-content-inner-field" id="<%= "#{address_id}country" %>">
       <span id="<%= "#{address_id}country-selection" %>" class="d-block position-relative">
         <%= address_form.collection_select :country_id, available_countries, :id, :name,
                                            { prompt: Spree.t(:country).upcase },
@@ -10,7 +10,7 @@
                                              aria: { label: Spree.t(:country) } } %>
         <%= image_tag 'arrow.svg', class: 'position-absolute spree-flat-select-arrow' %>
       </span>
-    </p>
+    </div>
   <% elsif field == "state" %>
     <div class="form-group mb-4">
       <%= address_field(address_form, :state, address_id) { address_state(address_form, address.country, address_id) } if Spree::Config[:address_requires_state] %>

--- a/frontend/app/views/spree/checkout/_address.html.erb
+++ b/frontend/app/views/spree/checkout/_address.html.erb
@@ -3,12 +3,12 @@
 <% if !try_spree_current_user || try_spree_current_user.email.blank? %>
   <div class="row">
     <div class="col-12 mb-4">
-      <p class="form-group checkout-content-inner-field">
+      <div class="form-group checkout-content-inner-field">
         <%= form.label :email, class: 'text-uppercase' %>
         <span class="required">*</span>
         <br />
         <%= form.email_field :email, class: 'required spree-flat-input', required: true %>
-      </p>
+      </div>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
There was a bug on the address form, where by, if you had an address saved that did not require a state, then you click edit, and changed to a country that does require a state, the state select element was placed in the dom without the spree flat styling.

Second change is to swap out the p tags for div tags for wrapping form elements.

