### PR TITLE
Fixes problem with color picker when OptionType name has been translated

### DIFF
--- a/core/app/models/spree/option_type.rb
+++ b/core/app/models/spree/option_type.rb
@@ -27,6 +27,10 @@ module Spree
       presentation.titleize.delete(' ').downcase
     end
 
+    def self.color
+      find_by(name: 'color')
+    end
+
     private
 
     def touch_all_products

--- a/core/spec/models/spree/option_type_spec.rb
+++ b/core/spec/models/spree/option_type_spec.rb
@@ -11,4 +11,22 @@ describe Spree::OptionType, type: :model do
       expect(product.reload.updated_at).to be_within(3.seconds).of(Time.current)
     end
   end
+
+  context '#filter_param' do
+    let!(:option_type) { create(:option_type, name: 'color', presentation: 'Color') }
+    let!(:other_option_type) { create(:option_type, name: 'secondary_color', presentation: 'Secondary Color') }
+
+    it 'returns filtered presentation param' do
+      expect(option_type.filter_param).to eq('color')
+      expect(other_option_type.filter_param).to eq('secondarycolor')
+    end
+  end
+
+  context '#self.color' do
+    let!(:option_type) { create(:option_type, name: 'color', presentation: 'Color') }
+
+    it 'finds color option type' do
+      Spree::OptionType.color.id == option_type.id
+    end
+  end
 end

--- a/frontend/app/views/spree/products/_cart_form.html.erb
+++ b/frontend/app/views/spree/products/_cart_form.html.erb
@@ -58,7 +58,7 @@
       <ul id="product-variants" class="product-variants">
         <% used_variants_options(@variants, @product).each_with_index do |option_type, index| %>
           <li>
-            <% if option_type[:name] == "color" %>
+            <% if Spree::OptionType.color&.name == option_type[:name] %>
               <%= render "color_option_type", option_type: option_type, index: index %>
             <% else %>
               <%= render "option_type", option_type: option_type, index: index %>


### PR DESCRIPTION
When used with `spree_globalize` gem this caused incorrect color picker
view with rectangular color codes instead of colorful circles.
This was because of check with the hardcoded English name for 'color' which was
needed to show the correct picker for colors.