### PR TITLE
Cheap Fix For #10218

### DIFF
--- a/frontend/app/views/spree/users/_address.html.erb
+++ b/frontend/app/views/spree/users/_address.html.erb
@@ -10,11 +10,13 @@
   </address>
   <div class="col-2">
     <div class="row">
-      <div class="col-5 offset-md-2 order-1">
-        <%= link_to spree.edit_address_path(address), method: :get, class: 'address-button', data: { hook: 'edit_address' } do %>
-          <%= inline_svg_tag 'edit.svg', class: "delete-address-img" %>
-        <% end %>
-      </div>
+      <% unless @body_id == 'checkout-page' %>
+        <div class="col-5 offset-md-2 order-1">
+          <%= link_to spree.edit_address_path(address), method: :get, class: 'address-button', data: { hook: 'edit_address' } do %>
+            <%= inline_svg_tag 'edit.svg', class: "delete-address-img" %>
+          <% end %>
+        </div>
+      <% end %>
       <div class="col-5 offset-2 offset-md-0 order-0">
         <div class="bg-transparent border-0 p-0 m-0 address-button delete-button js-delete-address-link" data-address="<%= spree.address_path(address) %>">
           <%= inline_svg_tag 'garbage_2.svg', class: "delete-address-img" %>


### PR DESCRIPTION
This is a fast fix for #10218

Is there really a need to go off and edit an address from checkout address stage? 
With **other address** option available right below? 

Could simply reserve the edit icon for the user accounts panel.

Also noticed that when edging an address from the checkout stage, there is no flash up message if the address does not update for some reason. An example would be an invalid post code, or missing required field, page just reloads, no indication as to why.

I expect this PR to fails spec tests as no doubt they will be looking for the now none existent edit address icon in the checkout stage.