### PR TITLE
Add ship to address on "Choose Delivery Method" page.

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1452,6 +1452,7 @@ en:
     server_error: The server returned an error
     settings: Settings
     ship: Ship
+    ship_to: "Shipping to:"
     ship_address: Ship Address
     ship_total: Ship Total
     shipment: Shipment

--- a/frontend/app/assets/stylesheets/spree/frontend/application.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/application.scss
@@ -38,6 +38,7 @@
 @import "spree/frontend/components-custom/headers";
 @import "spree/frontend/components-custom/inputs";
 @import "spree/frontend/views/spree/checkout/registration";
+@import "spree/frontend/views/spree/checkout/delivery";
 @import "spree/frontend/views/spree/checkout/confirm";
 @import "spree/frontend/views/spree/checkout/payment";
 @import "spree/frontend/views/spree/orders/edit";

--- a/frontend/app/assets/stylesheets/spree/frontend/views/spree/checkout/delivery.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/views/spree/checkout/delivery.scss
@@ -1,0 +1,6 @@
+#shipToLocation {
+  font-size: font-px-to-rem(10px);
+  @include media-breakpoint-up(md) {
+    font-size: font-px-to-rem(14px);
+  }
+}

--- a/frontend/app/views/spree/checkout/_delivery.html.erb
+++ b/frontend/app/views/spree/checkout/_delivery.html.erb
@@ -3,9 +3,17 @@
     <div id="methods">
       <%= form.fields_for :shipments do |ship_form| %>
         <div class="shipment">
-          <h4 class="text-uppercase checkout-content-header checkout-content-shipping-methods-header">
+          <h4 class="text-uppercase checkout-content-header checkout-content-shipping-methods-header mb-1">
             <%= Spree.t('checkout_page.delivery_method') %>
           </h4>
+          <div id="shipToLocation" class="mb-4 text-uppercase">
+            <h6 class="small">
+              <%= Spree.t(:ship_to) %>
+              <span class="text-muted"><%= @order.shipping_address.address1 %></span> -
+                <% if @order.shipping_address.zipcode.present? %> <span class="text-muted"><%= @order.shipping_address.zipcode %></span> - <% end %>
+              <span class="text-muted"><%= @order.shipping_address.country.iso %></span>
+            </h6>
+          </div>
 
           <ul class="checkout-content-shipping-methods-list">
             <% ship_form.object.shipping_rates.each do |rate| %>
@@ -28,13 +36,14 @@
         </div>
       <% end %>
     </div>
+
     <% if Spree::Config[:shipping_instructions] %>
-      <p id="minstrs" data-hook>
+      <div id="minstrs" data-hook>
         <h4 class="h5">
           <%= Spree.t(:shipping_instructions) %>
         </h4>
         <%= form.text_area :special_instructions, cols: 40, rows: 4, class: "form-control" %>
-      </p>
+      </div>
     <% end %>
   </div>
 </div>

--- a/frontend/app/views/spree/checkout/_delivery.html.erb
+++ b/frontend/app/views/spree/checkout/_delivery.html.erb
@@ -7,12 +7,10 @@
             <%= Spree.t('checkout_page.delivery_method') %>
           </h4>
           <div id="shipToLocation" class="mb-4 text-uppercase">
-            <h6 class="small">
-              <%= Spree.t(:ship_to) %>
-              <span class="text-muted"><%= @order.shipping_address.address1 %></span> -
-                <% if @order.shipping_address.zipcode.present? %> <span class="text-muted"><%= @order.shipping_address.zipcode %></span> - <% end %>
-              <span class="text-muted"><%= @order.shipping_address.country.iso %></span>
-            </h6>
+            <%= Spree.t(:ship_to) %>
+            <span class="text-muted"><%= @order.shipping_address.address1 %></span> -
+              <% if @order.shipping_address.zipcode.present? %> <span class="text-muted"><%= @order.shipping_address.zipcode %></span> - <% end %>
+            <span class="text-muted"><%= @order.shipping_address.country.iso %></span>
           </div>
 
           <ul class="checkout-content-shipping-methods-list">

--- a/frontend/app/views/spree/checkout/_delivery.html.erb
+++ b/frontend/app/views/spree/checkout/_delivery.html.erb
@@ -10,7 +10,7 @@
             <%= Spree.t(:ship_to) %>
             <span class="text-muted"><%= @order.shipping_address.address1 %></span> -
               <% if @order.shipping_address.zipcode.present? %> <span class="text-muted"><%= @order.shipping_address.zipcode %></span> - <% end %>
-            <span class="text-muted"><%= @order.shipping_address.country.iso %></span>
+            <span class="text-muted"><%= @order.shipping_address.country_iso %></span>
           </div>
 
           <ul class="checkout-content-shipping-methods-list">

--- a/frontend/spec/features/delivery_spec.rb
+++ b/frontend/spec/features/delivery_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'Delivery', type: :feature, inaccessible: true, js: true do
   include_context 'checkout setup'
 
-  let(:country) { create(:country, name: 'United States of America', iso_name: 'UNITED STATES') }
+  let(:country) { create(:country, name: 'United States of America', iso_name: 'UNITED STATES', iso: 'US') }
   let(:state) { create(:state, name: 'Alabama', abbr: 'AL', country: country) }
   let(:user) { create(:user) }
   let!(:shipping_method2) do
@@ -36,15 +36,24 @@ describe 'Delivery', type: :feature, inaccessible: true, js: true do
     end
 
     it 'contains the shipping total' do
-      page.has_text? 'SHIPPING: $10.00'
+      expect(page).to have_css(".checkout-content-summary-table", text: '$10.00')
     end
 
     context 'shipping method is changed' do
       before { find('label', text: shipping_method2.name).click }
+        it 'shipping total and order total both are updates' do
+          expect(page).to have_css(".checkout-content-summary-table", text: '$20.00')
+        end
+    end
+  end
 
-      it 'shipping total and order total both are updates' do
-        page.has_text? 'SHIPPING: $20.00'
-      end
+  describe 'shipping address is displayed on delivery page' do
+    before do
+      add_mug_and_navigate_to_delivery_page
+    end
+
+    it 'contains the correct address' do
+      expect(page).to have_text 'SHIPPING TO: ' + @street.upcase + ' - ' + @zipcode.upcase + ' - US'
     end
   end
 
@@ -64,23 +73,25 @@ describe 'Delivery', type: :feature, inaccessible: true, js: true do
     end
 
     it 'calculates shipping total correctly with different currency marker' do
-      page.has_text? 'SHIPPING: $20,00'
+      expect(page).to have_css(".checkout-content-summary-table", text: '$20,00')
     end
 
     it 'calculates order total correctly with different currency marker' do
-      page.has_text? 'ORDER TOTAL: $39,99'
+      expect(page).to have_css(".checkout-content-summary-table", text: '$39,99')
     end
   end
 
   def fill_in_address
+    @street = FFaker::Address.street_address
+    @zipcode = FFaker::AddressUS.zip_code
     address = 'order_bill_address_attributes'
     fill_in "#{address}_firstname", with: FFaker::Name.first_name
     fill_in "#{address}_lastname", with: FFaker::Name.last_name
-    fill_in "#{address}_address1", with: FFaker::Address.street_address
+    fill_in "#{address}_address1", with: @street
     fill_in "#{address}_city", with: FFaker::Address.city
     select country.name, from: "#{address}_country_id"
     select state.name, from: "#{address}_state_id"
-    fill_in "#{address}_zipcode", with: FFaker::AddressUS.zip_code
+    fill_in "#{address}_zipcode", with: @zipcode
     fill_in "#{address}_phone", with: FFaker::PhoneNumber.phone_number
   end
 end


### PR DESCRIPTION
Adds a little reminder what delivery address you are using while choosing the delivery method. 

This is useful if you start a checkout, and then come back later. Often the checkout takes you straight to choosing a delivery method if you have an address saved from already started order, it's nice to see the shipping address if this happens.

**Mobile**
<img width="412" alt="Screenshot 2020-06-05 at 16 54 54" src="https://user-images.githubusercontent.com/1240766/83897319-5f374700-a74d-11ea-898f-80e069ec52b0.png">


**Desktop**
<img width="1209" alt="Screenshot 2020-06-05 at 16 55 07" src="https://user-images.githubusercontent.com/1240766/83897347-66f6eb80-a74d-11ea-9b2e-021d542c23d8.png">

- If you add the ability to name saved addresses in Spree (Work, Home..) you could have the address name replace the street name zip code and country, **SHIPPING TO: WORK**.
- Found some tests in delivery_spec.rb were not looking for any specific text, fixed those.


