### PR TITLE
Retain Zip Code Value When Optional

### DIFF
--- a/frontend/app/assets/javascripts/spree/frontend/checkout/address.js
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/address.js
@@ -42,7 +42,6 @@ Spree.ready(function ($) {
           zipcodeLabel.text(zipText)
           zipcodeInput.addClass('required')
         } else {
-          zipcodeInput.val('')
           zipcodeInput.prop('required', false).attr('placeholder', zipcodeLabelText)
           zipcodeLabel.text('')
           zipcodeLabel.text(zipcodeLabelText)

--- a/frontend/app/helpers/spree/addresses_helper.rb
+++ b/frontend/app/helpers/spree/addresses_helper.rb
@@ -34,7 +34,7 @@ module Spree
         form.label(:zipcode,
                    is_required ? "#{method_name} #{required}" : method_name,
                    class: 'text-uppercase',
-                   id: 'zipcode_label')
+                   id: _address_id + '_zipcode_label')
     end
 
     def address_state(form, country, _address_id = 'b')
@@ -55,7 +55,7 @@ module Spree
           form.label(Spree.t(:state).downcase,
                      raw(Spree.t(:state) + content_tag(:abbr, " #{Spree.t(:required)}")),
                      class: [have_states ? 'state-select-label' : nil, ' text-uppercase'].compact,
-                     id: 'state_label') +
+                     id: _address_id + '_state_label') +
           image_tag('arrow.svg',
                     class: [!have_states ? 'hidden' : nil, 'position-absolute spree-flat-select-arrow'].compact)
       ].join.tr('"', "'").delete("\n")

--- a/frontend/app/helpers/spree/addresses_helper.rb
+++ b/frontend/app/helpers/spree/addresses_helper.rb
@@ -21,7 +21,7 @@ module Spree
       end
     end
 
-    def address_zipcode(form, country, _address_id = 'b')
+    def address_zipcode(form, country, address_id = 'b')
       country ||= Spree::Country.default
       is_required = country.zipcode_required?
       method_name = Spree.t(:zipcode)
@@ -34,10 +34,10 @@ module Spree
         form.label(:zipcode,
                    is_required ? "#{method_name} #{required}" : method_name,
                    class: 'text-uppercase',
-                   id: _address_id + '_zipcode_label')
+                   id: address_id + '_zipcode_label')
     end
 
-    def address_state(form, country, _address_id = 'b')
+    def address_state(form, country, address_id = 'b')
       country ||= Spree::Country.find(Spree::Config[:default_country_id])
       have_states = country.states.any?
       state_elements = [
@@ -55,7 +55,7 @@ module Spree
           form.label(Spree.t(:state).downcase,
                      raw(Spree.t(:state) + content_tag(:abbr, " #{Spree.t(:required)}")),
                      class: [have_states ? 'state-select-label' : nil, ' text-uppercase'].compact,
-                     id: _address_id + '_state_label') +
+                     id: address_id + '_state_label') +
           image_tag('arrow.svg',
                     class: [!have_states ? 'hidden' : nil, 'position-absolute spree-flat-select-arrow'].compact)
       ].join.tr('"', "'").delete("\n")

--- a/frontend/app/helpers/spree/addresses_helper.rb
+++ b/frontend/app/helpers/spree/addresses_helper.rb
@@ -33,7 +33,8 @@ module Spree
                       aria: { label: Spree.t(:zipcode) }) +
         form.label(:zipcode,
                    is_required ? "#{method_name} #{required}" : method_name,
-                   class: 'text-uppercase')
+                   class: 'text-uppercase',
+                   id: 'zipcode_label')
     end
 
     def address_state(form, country, _address_id = 'b')
@@ -53,7 +54,8 @@ module Spree
                           placeholder: Spree.t(:state) + " #{Spree.t(:required)}") +
           form.label(Spree.t(:state).downcase,
                      raw(Spree.t(:state) + content_tag(:abbr, " #{Spree.t(:required)}")),
-                     class: [have_states ? 'state-select-label' : nil, ' text-uppercase'].compact) +
+                     class: [have_states ? 'state-select-label' : nil, ' text-uppercase'].compact,
+                       id: 'state_label') +
           image_tag('arrow.svg',
                     class: [!have_states ? 'hidden' : nil, 'position-absolute spree-flat-select-arrow'].compact)
       ].join.tr('"', "'").delete("\n")

--- a/frontend/app/helpers/spree/addresses_helper.rb
+++ b/frontend/app/helpers/spree/addresses_helper.rb
@@ -55,7 +55,7 @@ module Spree
           form.label(Spree.t(:state).downcase,
                      raw(Spree.t(:state) + content_tag(:abbr, " #{Spree.t(:required)}")),
                      class: [have_states ? 'state-select-label' : nil, ' text-uppercase'].compact,
-                       id: 'state_label') +
+                     id: 'state_label') +
           image_tag('arrow.svg',
                     class: [!have_states ? 'hidden' : nil, 'position-absolute spree-flat-select-arrow'].compact)
       ].join.tr('"', "'").delete("\n")

--- a/frontend/spec/features/address_spec.rb
+++ b/frontend/spec/features/address_spec.rb
@@ -74,7 +74,6 @@ describe 'Address', type: :feature, inaccessible: true do
       it 'clears the state name' do
         select canada.name, from: @country_css
         page.find(@state_name_css).set('Toscana')
-
         select france.name, from: @country_css
         expect(page).to have_css(@state_name_css, filter_set: :field, disabled: true, with: '', visible: :hidden, class: ['!hidden', '!required'])
         expect(page).to have_css(@state_select_css, visible: :hidden, class: ['!required'])
@@ -113,7 +112,6 @@ describe 'Address', type: :feature, inaccessible: true do
     end
 
     it 'loads the page with the zipcode field showing required in the label and placeholder' do
-      expect(page).to have_css("input#{@zipcode_css}")
       expect(page).to have_css("label#zipcode_label", text: Spree.t(:required), visible: false)
       find("input[placeholder='#{Spree.t(:zipcode)} #{Spree.t(:required)}']").set "98378"
       expect(page).to have_css("label#zipcode_label", text: Spree.t(:required))
@@ -122,10 +120,8 @@ describe 'Address', type: :feature, inaccessible: true do
     context 'When the country is changed to one that does not require a zip code' do
       it 'the JS removes the required markers in the label and placeholder text' do
         select ug.name, from: @country_css
-
-        expect(page).to have_css("input#{@zipcode_css}")
-        find("input[placeholder='Zip Code']").set "98378"
-        expect(page).to have_css("label#zipcode_label", text: 'ZIP CODE')
+        find("input[placeholder='#{Spree.t(:zipcode)}']").set "98378"
+        expect(page).to have_css("label#zipcode_label", text: Spree.t(:zipcode).upcase)
       end
     end
   end
@@ -143,16 +139,13 @@ describe 'Address', type: :feature, inaccessible: true do
     end
 
     it 'loads the page without the zipcode field showing required in the label and placeholder' do
-      expect(page).to have_css("input#{@zipcode_css}")
       find("input[placeholder='#{Spree.t(:zipcode)}']").set "98378"
-      expect(page).to have_css("label#zipcode_label", text: 'ZIP CODE')
+      expect(page).to have_css("label#zipcode_label", text: Spree.t(:zipcode).upcase)
     end
 
     context 'When the country is changed to one that does require a zip code' do
       it 'the JS adds the required markers in the label and placeholder text' do
         select canada.name, from: @country_css
-
-        expect(page).to have_css("input#{@zipcode_css}")
         expect(page).to have_css("label#zipcode_label", text: Spree.t(:required), visible: false)
         find("input[placeholder='#{Spree.t(:zipcode)} #{Spree.t(:required)}']").set "98378"
         expect(page).to have_css("label#zipcode_label", text: Spree.t(:required))

--- a/frontend/spec/features/address_spec.rb
+++ b/frontend/spec/features/address_spec.rb
@@ -12,6 +12,8 @@ describe 'Address', type: :feature, inaccessible: true do
     @country_css = "#{address}_country_id"
     @state_select_css = "##{address}_state_id"
     @state_name_css = "##{address}_state_name"
+    @state_label_css = '#b_state_label'
+    @zipcode_label_css = '#b_zipcode_label'
   end
 
   context 'country requires state', js: true do
@@ -37,7 +39,7 @@ describe 'Address', type: :feature, inaccessible: true do
       it 'shows placeholder and label text indicating a required field' do
         select canada.name, from: @country_css
         find("input[placeholder='#{Spree.t(:state)} #{ Spree.t(:required)}']").set "Ontario"
-        expect(page).to have_css("label#state_label", text: Spree.t(:required))
+        expect(page).to have_css("label#{@state_label_css}", text: Spree.t(:required))
       end
     end
 
@@ -58,7 +60,7 @@ describe 'Address', type: :feature, inaccessible: true do
 
       it 'shows the state required indicator in the label' do
         select canada.name, from: @country_css
-        expect(page).to have_css("label#state_label", text: Spree.t(:required))
+        expect(page).to have_css("label#{@state_label_css}", text: Spree.t(:required))
       end
     end
 
@@ -112,16 +114,16 @@ describe 'Address', type: :feature, inaccessible: true do
     end
 
     it 'loads the page with the zipcode field showing required in the label and placeholder' do
-      expect(page).to have_css("label#zipcode_label", text: Spree.t(:required), visible: false)
+      expect(page).to have_css("label#{@zipcode_label_css}", text: Spree.t(:required), visible: false)
       find("input[placeholder='#{Spree.t(:zipcode)} #{Spree.t(:required)}']").set "98378"
-      expect(page).to have_css("label#zipcode_label", text: Spree.t(:required))
+      expect(page).to have_css("label#{@zipcode_label_css}", text: Spree.t(:required))
     end
 
     context 'When the country is changed to one that does not require a zip code' do
       it 'the JS removes the required markers in the label and placeholder text' do
         select ug.name, from: @country_css
         find("input[placeholder='#{Spree.t(:zipcode)}']").set "98378"
-        expect(page).to have_css("label#zipcode_label", text: Spree.t(:zipcode).upcase)
+        expect(page).to have_css("label#{@zipcode_label_css}", text: Spree.t(:zipcode).upcase)
       end
     end
   end
@@ -140,15 +142,15 @@ describe 'Address', type: :feature, inaccessible: true do
 
     it 'loads the page without the zipcode field showing required in the label and placeholder' do
       find("input[placeholder='#{Spree.t(:zipcode)}']").set "98378"
-      expect(page).to have_css("label#zipcode_label", text: Spree.t(:zipcode).upcase)
+      expect(page).to have_css("label#{@zipcode_label_css}", text: Spree.t(:zipcode).upcase)
     end
 
     context 'When the country is changed to one that does require a zip code' do
       it 'the JS adds the required markers in the label and placeholder text' do
         select canada.name, from: @country_css
-        expect(page).to have_css("label#zipcode_label", text: Spree.t(:required), visible: false)
+        expect(page).to have_css("label#{@zipcode_label_css}", text: Spree.t(:required), visible: false)
         find("input[placeholder='#{Spree.t(:zipcode)} #{Spree.t(:required)}']").set "98378"
-        expect(page).to have_css("label#zipcode_label", text: Spree.t(:required))
+        expect(page).to have_css("label#{@zipcode_label_css}", text: Spree.t(:required))
       end
     end
   end

--- a/frontend/spec/features/address_spec.rb
+++ b/frontend/spec/features/address_spec.rb
@@ -12,7 +12,6 @@ describe 'Address', type: :feature, inaccessible: true do
     @country_css = "#{address}_country_id"
     @state_select_css = "##{address}_state_id"
     @state_name_css = "##{address}_state_name"
-    @zipcode_css = "##{address}_zipcode"
   end
 
   context 'country requires state', js: true do
@@ -37,8 +36,8 @@ describe 'Address', type: :feature, inaccessible: true do
 
       it 'shows placeholder and label text indicating a required field' do
         select canada.name, from: @country_css
-        find("input[placeholder='State *']").set "Ontario"
-        expect(page).to have_css("label#state_label", text: '*')
+        find("input[placeholder='#{Spree.t(:state)} #{ Spree.t(:required)}']").set "Ontario"
+        expect(page).to have_css("label#state_label", text: Spree.t(:required))
       end
     end
 
@@ -59,7 +58,7 @@ describe 'Address', type: :feature, inaccessible: true do
 
       it 'shows the state required indicator in the label' do
         select canada.name, from: @country_css
-        expect(page).to have_css("label#state_label", text: '*')
+        expect(page).to have_css("label#state_label", text: Spree.t(:required))
       end
     end
 
@@ -115,9 +114,9 @@ describe 'Address', type: :feature, inaccessible: true do
 
     it 'loads the page with the zipcode field showing required in the label and placeholder' do
       expect(page).to have_css("input#{@zipcode_css}")
-      expect(page).to have_css("label#zipcode_label", text: '*', visible: false)
-      find("input[placeholder='Zip Code *']").set "98378"
-      expect(page).to have_css("label#zipcode_label", text: '*')
+      expect(page).to have_css("label#zipcode_label", text: Spree.t(:required), visible: false)
+      find("input[placeholder='#{Spree.t(:zipcode)} #{Spree.t(:required)}']").set "98378"
+      expect(page).to have_css("label#zipcode_label", text: Spree.t(:required))
     end
 
     context 'When the country is changed to one that does not require a zip code' do
@@ -145,7 +144,7 @@ describe 'Address', type: :feature, inaccessible: true do
 
     it 'loads the page without the zipcode field showing required in the label and placeholder' do
       expect(page).to have_css("input#{@zipcode_css}")
-      find("input[placeholder='Zip Code']").set "98378"
+      find("input[placeholder='#{Spree.t(:zipcode)}']").set "98378"
       expect(page).to have_css("label#zipcode_label", text: 'ZIP CODE')
     end
 
@@ -154,9 +153,9 @@ describe 'Address', type: :feature, inaccessible: true do
         select canada.name, from: @country_css
 
         expect(page).to have_css("input#{@zipcode_css}")
-        expect(page).to have_css("label#zipcode_label", text: '*', visible: false)
-        find("input[placeholder='Zip Code *']").set "98378"
-        expect(page).to have_css("label#zipcode_label", text: '*')
+        expect(page).to have_css("label#zipcode_label", text: Spree.t(:required), visible: false)
+        find("input[placeholder='#{Spree.t(:zipcode)} #{Spree.t(:required)}']").set "98378"
+        expect(page).to have_css("label#zipcode_label", text: Spree.t(:required))
       end
     end
   end

--- a/frontend/spec/features/address_spec.rb
+++ b/frontend/spec/features/address_spec.rb
@@ -12,15 +12,16 @@ describe 'Address', type: :feature, inaccessible: true do
     @country_css = "#{address}_country_id"
     @state_select_css = "##{address}_state_id"
     @state_name_css = "##{address}_state_name"
+    @zipcode_css = "##{address}_zipcode"
   end
 
   context 'country requires state', js: true do
-    let!(:canada) { create(:country, name: 'Canada', states_required: true, iso: 'CA') }
-    let!(:uk) { create(:country, name: 'United Kingdom', states_required: true, iso: 'UK') }
+    let!(:canada) { create(:country, name: 'Canada', states_required: true, iso: 'CA', zipcode_required: true) }
+    let!(:uk) { create(:country, name: 'United Kingdom', states_required: false, iso: 'UK', zipcode_required: true) }
 
     before { Spree::Config[:default_country_id] = uk.id }
 
-    context 'but has no state' do
+    context 'but has no states in the database' do
       before do
         add_to_cart(mug) do
           click_link 'Checkout'
@@ -33,9 +34,15 @@ describe 'Address', type: :feature, inaccessible: true do
         expect(page).to have_css(@state_name_css, visible: true, class: ['!hidden', 'required'])
         expect(page).not_to have_css("input#{@state_name_css}[disabled]")
       end
+
+      it 'shows placeholder and label text indicating a required field' do
+        select canada.name, from: @country_css
+        find("input[placeholder='State *']").set "Ontario"
+        expect(page).to have_css("label#state_label", text: '*')
+      end
     end
 
-    context 'and has state' do
+    context 'and has states in database' do
       before do
         create(:state, name: 'Ontario', country: canada)
 
@@ -48,6 +55,11 @@ describe 'Address', type: :feature, inaccessible: true do
         select canada.name, from: @country_css
         expect(page).to have_css(@state_select_css, visible: true, class: ['!hidden', 'required'])
         expect(page).to have_css(@state_name_css, visible: :hidden, class: ['!required'])
+      end
+
+      it 'shows the state required indicator in the label' do
+        select canada.name, from: @country_css
+        expect(page).to have_css("label#state_label", text: '*')
       end
     end
 
@@ -84,6 +96,68 @@ describe 'Address', type: :feature, inaccessible: true do
       select france.name, from: @country_css
       expect(page).to have_selector(@state_select_css, visible: :hidden)
       expect(page).to have_selector(@state_name_css, visible: :hidden)
+    end
+  end
+
+
+
+  context 'country that requires zipcode', js: true do
+    let!(:canada) { create(:country, name: 'Canada', states_required: true, iso: 'CA', zipcode_required: true) }
+    let!(:ug) { create(:country, name: 'Uganda', states_required: false, iso: 'UG', zipcode_required: false) }
+
+    before { Spree::Config[:default_country_id] = canada.id }
+
+    before do
+      add_to_cart(mug) do
+        click_link 'Checkout'
+      end
+    end
+
+    it 'loads the page with the zipcode field showing required in the label and placeholder' do
+      expect(page).to have_css("input#{@zipcode_css}")
+      expect(page).to have_css("label#zipcode_label", text: '*', visible: false)
+      find("input[placeholder='Zip Code *']").set "98378"
+      expect(page).to have_css("label#zipcode_label", text: '*')
+    end
+
+    context 'When the country is changed to one that does not require a zip code' do
+      it 'the JS removes the required markers in the label and placeholder text' do
+        select ug.name, from: @country_css
+
+        expect(page).to have_css("input#{@zipcode_css}")
+        find("input[placeholder='Zip Code']").set "98378"
+        expect(page).to have_css("label#zipcode_label", text: 'ZIP CODE')
+      end
+    end
+  end
+
+  context 'country that does not require zipcode', js: true do
+    let!(:canada) { create(:country, name: 'Canada', states_required: true, iso: 'CA', zipcode_required: true) }
+    let!(:ug) { create(:country, name: 'Uganda', states_required: false, iso: 'UG', zipcode_required: false) }
+
+    before { Spree::Config[:default_country_id] = ug.id }
+
+    before do
+      add_to_cart(mug) do
+        click_link 'Checkout'
+      end
+    end
+
+    it 'loads the page without the zipcode field showing required in the label and placeholder' do
+      expect(page).to have_css("input#{@zipcode_css}")
+      find("input[placeholder='Zip Code']").set "98378"
+      expect(page).to have_css("label#zipcode_label", text: 'ZIP CODE')
+    end
+
+    context 'When the country is changed to one that does require a zip code' do
+      it 'the JS adds the required markers in the label and placeholder text' do
+        select canada.name, from: @country_css
+
+        expect(page).to have_css("input#{@zipcode_css}")
+        expect(page).to have_css("label#zipcode_label", text: '*', visible: false)
+        find("input[placeholder='Zip Code *']").set "98378"
+        expect(page).to have_css("label#zipcode_label", text: '*')
+      end
     end
   end
 end


### PR DESCRIPTION
This PR fixes a small bug where the zip code field value is emptied on page load if the country that is set in the address form has zipcode_required = false.

Also adds some tests to check the zip code placeholder and label are set indicating required or not required appropriately.