### PR TITLE
add id to each of menu item

### DIFF
--- a/backend/app/views/spree/admin/shared/_main_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_main_menu.html.erb
@@ -1,42 +1,42 @@
 <nav>
   <% if can? :admin, Spree::Order %>
-    <ul class="nav nav-sidebar border-bottom">
+    <ul class="nav nav-sidebar border-bottom" id="sidebar-order">
       <%= tab *Spree::BackendConfiguration::ORDER_TABS, icon: 'shopping-cart' %>
     </ul>
   <% end %>
 
   <% if can?(:admin, Spree::ReturnAuthorization) || can?(:admin, Spree::CustomerReturn) %>
-    <ul class="nav nav-sidebar border-bottom">
+    <ul class="nav nav-sidebar border-bottom" id="sidebar-return">
       <%= main_menu_tree Spree.t(:returns), icon: "transfer", sub_menu: "returns", url: "#sidebar-returns" %>
     </ul>
   <% end %>
 
   <% if can? :admin, Spree::Product %>
-    <ul class="nav nav-sidebar border-bottom">
+    <ul class="nav nav-sidebar border-bottom" id="sidebar-product">
       <%= main_menu_tree Spree.t(:products), icon: "th-large", sub_menu: "product", url: "#sidebar-product" %>
     </ul>
   <% end %>
 
   <% if can? :admin, Spree::Admin::ReportsController %>
-    <ul class="nav nav-sidebar border-bottom">
+    <ul class="nav nav-sidebar border-bottom" id="sidebar-report">
       <%= tab *Spree::BackendConfiguration::REPORT_TABS, icon: 'file'  %>
     </ul>
   <% end %>
 
   <% if can? :admin, Spree::Promotion %>
-    <ul class="nav nav-sidebar border-bottom">
+    <ul class="nav nav-sidebar border-bottom" id="sidebar-promotion">
       <%= main_menu_tree Spree.t(:promotions), icon: "gift", sub_menu: "promotion", url: "#sidebar-promotions" %>
     </ul>
   <% end %>
 
   <% if Spree.user_class && can?(:admin, Spree.user_class) %>
-    <ul class="nav nav-sidebar border-bottom">
+    <ul class="nav nav-sidebar border-bottom" id="sidebar-user">
       <%= tab *Spree::BackendConfiguration::USER_TABS, url: spree.admin_users_path, icon: 'user' %>
     </ul>
   <% end %>
 
   <% if can? :admin, current_store %>
-    <ul class="nav nav-sidebar border-bottom">
+    <ul class="nav nav-sidebar border-bottom" id="sidebar-configuration">
       <%= main_menu_tree Spree.t(:configurations), icon: "wrench", sub_menu: "configuration", url: "#sidebar-configuration" %>
     </ul>
   <% end %>


### PR DESCRIPTION
I want to propose adding the id attribute to each of the menu items in the admin side menu. 

The reason I want to add an id attribute is that it can help people who want to develop backend extension. The current implementation, if a new item is added to the menu by using deface, the item is usually be inserted to the bottom of the list. (It's okay to insert it to the top of the menu, but it is even wired.) Also, nowadays, it is common to see the configuration item at the bottom of the menu. Any new item placed after the configuration is quite against intuitive. 

If there are id attributes, the extension developer can insert the menu item to a proper position more flexible. 