### PR TITLE
:bug: (variant) fix variant searching issue

### DIFF
--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -105,12 +105,13 @@ module Spree
     self.whitelisted_ransackable_scopes = %i(product_name_or_sku_cont search_by_product_name_or_sku)
 
     def self.product_name_or_sku_cont(query)
-      joins(:product).where("#{Product.table_name}.name LIKE :query OR sku LIKE :query", query: "%#{query}%")
+      joins(:product).where("LOWER(#{Product.table_name}.name) LIKE LOWER(:query) OR LOWER(sku) LIKE LOWER(:query)", query: "%#{query}%")
     end
 
     def self.search_by_product_name_or_sku(query)
       if defined?(SpreeGlobalize)
-        joins(product: :translations).where("#{Product::Translation.table_name}.name LIKE :query OR sku LIKE :query", query: "%#{query}%")
+        joins(product: :translations).where("LOWER(#{Product::Translation.table_name}.name) LIKE LOWER(:query) OR LOWER(sku) LIKE LOWER(:query)",
+                                            query: "%#{query}%")
       else
         product_name_or_sku_cont(query)
       end


### PR DESCRIPTION
Related to #9216

Adding a product to an existing order fails with 'Loading failed' when using the 'Choose a variant'
search bar in the admin/orders section.
