### PR TITLE
[SDP-295] Fixes error on product search in admin panel when spree_globalize is used

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js
+++ b/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js
@@ -36,7 +36,7 @@ $.fn.variantAutocomplete = function () {
       data: function (term) {
         return {
           q: {
-            product_name_or_sku_cont: term
+            search_by_product_name_or_sku: term
           },
           token: Spree.api_key
         }

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -102,10 +102,18 @@ module Spree
 
     self.whitelisted_ransackable_associations = %w[option_values product prices default_price]
     self.whitelisted_ransackable_attributes = %w[weight sku]
-    self.whitelisted_ransackable_scopes = %i(product_name_or_sku_cont)
+    self.whitelisted_ransackable_scopes = %i(product_name_or_sku_cont search_by_product_name_or_sku)
 
     def self.product_name_or_sku_cont(query)
       joins(:product).where("#{Product.table_name}.name LIKE :query OR sku LIKE :query", query: "%#{query}%")
+    end
+
+    def self.search_by_product_name_or_sku(query)
+      if defined?(SpreeGlobalize)
+        joins(product: :translations).where("#{Product::Translation.table_name}.name LIKE :query OR sku LIKE :query", query: "%#{query}%")
+      else
+        product_name_or_sku_cont(query)
+      end
     end
 
     def available?

--- a/core/spec/models/spree/variant/scopes_spec.rb
+++ b/core/spec/models/spree/variant/scopes_spec.rb
@@ -46,4 +46,42 @@ describe 'Variant scopes', type: :model do
       expect(variants.count).to eq(0)
     end
   end
+
+  describe '#search_by_product_name_or_sku' do
+    it 'returns variants based on products name' do
+      expect(Spree::Variant.search_by_product_name_or_sku('Second')).to include(variant_2)
+    end
+
+    it 'returns variants based on variant sku' do
+      expect(Spree::Variant.search_by_product_name_or_sku('blue')).to include(variant_3)
+    end
+
+    it 'does not return variants of products that do not match name' do
+      expect(Spree::Variant.search_by_product_name_or_sku('First')).not_to include(variant_2, variant_3)
+    end
+
+    it 'does not return variants with not matching skus' do
+      expect(Spree::Variant.search_by_product_name_or_sku('green')).not_to include(variant_1, variant_3)
+    end
+
+    it 'returns multiple variants based on products name' do
+      expect(Spree::Variant.search_by_product_name_or_sku('product')).to include(variant_1, variant_2, variant_3)
+    end
+
+    it 'return multiple variants based on variants sku' do
+      expect(Spree::Variant.search_by_product_name_or_sku('variant')).to include(variant_1, variant_2, variant_3)
+    end
+
+    it 'returns no variants when products name does not match any' do
+      variants = Spree::Variant.search_by_product_name_or_sku('White dress')
+      expect(variants).not_to include(variant_1, variant_2, variant_3)
+      expect(variants.count).to eq(0)
+    end
+
+    it 'returns no variants when variants sku does not match any' do
+      variants = Spree::Variant.search_by_product_name_or_sku('variant_white')
+      expect(variants).not_to include(variant_1, variant_2, variant_3)
+      expect(variants.count).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
When spree_globalize gem is being used the search should be made using translations table.
Added a new method as `self.product_name_or_sku_cont` was being ignored and a standard Ransack matcher was used.