### PR TITLE
[SDP-343] Fixes multiple occurences of a product on admin products list search

### DIFF
--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -14,8 +14,8 @@
       <div data-hook="admin_products_index_search" class="row">
         <div class="col-12 col-lg-6">
           <div class="form-group">
-            <%= f.label :name_cont, Spree.t(:name) %>
-            <%= f.text_field :name_cont, size: 15, class: "form-control js-quick-search-target js-filterable" %>
+            <%= f.label :search_by_name, Spree.t(:name) %>
+            <%= f.text_field :search_by_name, size: 15, class: "form-control js-quick-search-target js-filterable" %>
           </div>
         </div>
         <div class="col-12 col-lg-6">

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -91,7 +91,7 @@ describe 'Products', type: :feature do
         create(:product, name: 'zomg shirt')
 
         visit spree.admin_products_path
-        fill_in 'q_name_cont', with: 'ap'
+        fill_in 'q_search_by_name', with: 'ap'
         click_on 'Search'
 
         expect(page).to have_content('apache baseball cap')
@@ -426,7 +426,7 @@ describe 'Products', type: :feature do
         click_on 'Filter'
 
         within('#table-filter') do
-          fill_in 'q_name_cont', with: 'Backpack'
+          fill_in 'q_search_by_name', with: 'Backpack'
           fill_in 'q_variants_including_master_sku_cont', with: 'BAG-00001'
         end
 

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -113,7 +113,7 @@ module Spree
 
     self.whitelisted_ransackable_associations = %w[taxons stores variants_including_master master variants]
     self.whitelisted_ransackable_attributes = %w[description name slug discontinue_on]
-    self.whitelisted_ransackable_scopes = %w[not_discontinued]
+    self.whitelisted_ransackable_scopes = %w[not_discontinued search_by_name]
 
     [
       :sku, :price, :currency, :weight, :height, :width, :depth, :is_master,
@@ -250,6 +250,14 @@ module Spree
         arel_table[field].matches("%#{value}%")
       end
       where conditions.inject(:or)
+    end
+
+    def self.search_by_name(query)
+      if defined?(SpreeGlobalize)
+        joins(:translations).order(:name).where("LOWER(#{Product::Translation.table_name}.name) LIKE LOWER(:query)", query: "%#{query}%").distinct
+      else
+        where("LOWER(#{Product.table_name}.name) LIKE LOWER(:query)", query: "%#{query}%")
+      end
     end
 
     # Suitable for displaying only variants that has at least one option value.

--- a/core/spec/models/spree/product/scopes_spec.rb
+++ b/core/spec/models/spree/product/scopes_spec.rb
@@ -173,4 +173,28 @@ describe 'Product scopes', type: :model do
       end
     end
   end
+
+  context '#search_by_name' do
+    let!(:first_product) { create(:product, name: 'First product') }
+    let!(:second_product) { create(:product, name: 'Second product') }
+    let!(:third_product) { create(:product, name: 'Other second product') }
+
+    it 'shows product whose name contains phrase' do
+      result = Spree::Product.search_by_name('First').to_a
+      expect(result).to include(first_product)
+      expect(result.count).to eq(1)
+    end
+
+    it 'shows multiple products whose names contain phrase' do
+      result = Spree::Product.search_by_name('product').to_a
+      expect(result).to include(product, first_product, second_product, third_product)
+      expect(result.count).to eq(4)
+    end
+
+    it 'is case insensitive for search phrases' do
+      result = Spree::Product.search_by_name('Second').to_a
+      expect(result).to include(second_product, third_product)
+      expect(result.count).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
Appeared when using spree_globalize extension and with products that
have the same name in different translations (e.g. for US and UK)