### PR TITLE
added method to set options to pass to api while adding products to cart

### DIFF
--- a/frontend/app/assets/javascripts/spree/frontend/views/spree/products/cart_form.js
+++ b/frontend/app/assets/javascripts/spree/frontend/views/spree/products/cart_form.js
@@ -243,21 +243,24 @@ Spree.ready(function($) {
     )
   }
 
+  Spree.addToCartFormSubmissionOptions = function() {
+    return {};
+  }
+
   $('#product-details').on('submit', ADD_TO_CART_FORM_SELECTOR, function(event) {
-    var variantId
-    var quantity
-    var $cartForm = $(event.currentTarget)
-    var $addToCart = $cartForm.find(ADD_TO_CART_SELECTOR)
+    let $cartForm = $(event.currentTarget);
+    let $addToCart = $cartForm.find(ADD_TO_CART_SELECTOR);
+    let variantId = $cartForm.find(VARIANT_ID_SELECTOR).val();
+    let quantity = parseInt($cartForm.find('[name="quantity"]').val());
+    let options = Spree.addToCartFormSubmissionOptions();
 
     event.preventDefault()
-    $addToCart.prop('disabled', true)
-    variantId = $cartForm.find(VARIANT_ID_SELECTOR).val()
-    quantity = parseInt($cartForm.find('[name="quantity"]').val())
+    $addToCart.prop('disabled', true);
     Spree.ensureCart(function() {
       SpreeAPI.Storefront.addToCart(
         variantId,
         quantity,
-        {}, // options hash - you can pass additional parameters here, your backend
+        options, // options hash - you can pass additional parameters here, your backend
         // needs to be aware of those, see API docs:
         // https://github.com/spree/spree/blob/master/api/docs/v2/storefront/index.yaml#L42
         function(response) {

--- a/frontend/app/assets/javascripts/spree/frontend/views/spree/products/cart_form.js
+++ b/frontend/app/assets/javascripts/spree/frontend/views/spree/products/cart_form.js
@@ -248,11 +248,11 @@ Spree.ready(function($) {
   }
 
   $('#product-details').on('submit', ADD_TO_CART_FORM_SELECTOR, function(event) {
-    let $cartForm = $(event.currentTarget);
-    let $addToCart = $cartForm.find(ADD_TO_CART_SELECTOR);
-    let variantId = $cartForm.find(VARIANT_ID_SELECTOR).val();
-    let quantity = parseInt($cartForm.find('[name="quantity"]').val());
-    let options = Spree.addToCartFormSubmissionOptions();
+    var $cartForm = $(event.currentTarget);
+    var $addToCart = $cartForm.find(ADD_TO_CART_SELECTOR);
+    var variantId = $cartForm.find(VARIANT_ID_SELECTOR).val();
+    var quantity = parseInt($cartForm.find('[name="quantity"]').val());
+    var options = Spree.addToCartFormSubmissionOptions();
 
     event.preventDefault()
     $addToCart.prop('disabled', true);


### PR DESCRIPTION
Added a method which can be overridden to set options hash which can be passed as additional options to api when adding a product to the cart. This method is added in cart_form.js. Commit file for this is at https://github.com/spree/spree/commit/a2e62396fcbe63c4f81986237fc642af70b44bcd