### PR TITLE
Updating Zones Guide enabling user to be redirected to the guide.

### DIFF
--- a/guides/src/content/user/configuration/configuring_taxes.md
+++ b/guides/src/content/user/configuration/configuring_taxes.md
@@ -40,7 +40,7 @@ Each product in your store will need a tax category assigned to it to accurately
 
 ## Zones
 
-In addition to a product's tax category, the zone an order is being shipped to will play a role in determining the tax amount. You can read more about how zones work in the [Zones guide](#zones).
+In addition to a product's tax category, the zone an order is being shipped to will play a role in determining the tax amount. You can read more about how zones work in the [Zones guide](https://guides.spreecommerce.org/user/shipments/zones.html).
 
 ## Tax Rates
 


### PR DESCRIPTION
The link to Zone Guide was not redirecting to Zones Guide. As for other links it makes sense for the user not to be redirected from this page, the Zone Guide suggests reaching it in order to read more on Zones.