### PR TITLE
:globe_with_meridians: (en) add missing translation shipment

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1563,6 +1563,7 @@ en:
       reimbursed: Reimbursed
       resumed: Resumed
       returned: Returned
+      shipment: Shipment
       shipped: Shipped
       void: Void
     states_required: States Required


### PR DESCRIPTION
As PR's title.