### PR TITLE
Fix firefox bug for incorrect input width with display flex property

### DIFF
--- a/frontend/app/assets/stylesheets/spree/frontend/views/spree/shared/quantity_select.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/views/spree/shared/quantity_select.scss
@@ -1,42 +1,39 @@
 .quantity-select {
-  width: 136px;
-  height: 45px;
-  @include media-breakpoint-up(sm) {
-    width: 174px;
-    height: 58px;
-  }
-  @include media-breakpoint-up(md) {
-    width: 136px;
-    height: 45px;
-  }
   &-decrease, &-increase {
+    width: 45px;
     border-radius: 0;
     font-size: font-px-to-rem(20px);
     font-weight: 500;
     background-color: theme-color("light-background");
     border: 1px solid theme-color("borders");
     @include media-breakpoint-up(sm) {
+      width: 58px;
       font-size: font-px-to-rem(30px);
       border: 2px solid theme-color("borders");
     }
     @include media-breakpoint-up(md) {
+      width: 45px;
       font-size: font-px-to-rem(20px);
       border: 1px solid theme-color("borders");
     }
   }
   &-value {
-    width: 100%;
+    width: 46px;
+    height: 45px;
     font-size: font-px-to-rem(20px);
     font-weight: 500;
     border-radius: 0;
     border: 1px solid theme-color('borders');
-    height: auto;
     z-index: 1;
     @include media-breakpoint-up(sm) {
+      width: 58px;
+      height: 58px;
       font-size: font-px-to-rem(28px);
       border: 2px solid theme-color("borders");
     }
     @include media-breakpoint-up(md) {
+      width: 46px;
+      height: 45px;
       font-size: font-px-to-rem(20px);
       border: 1px solid theme-color("borders");
     }

--- a/frontend/app/views/spree/products/_cart_form.html.erb
+++ b/frontend/app/views/spree/products/_cart_form.html.erb
@@ -73,7 +73,7 @@
 
       <hr>
       <div>
-        <div class="mb-5 mt-4">
+        <div class="mb-5 mt-4 text-center text-md-left">
           <%= render 'spree/shared/quantity_select', input_name: :quantity %>
         </div>
 

--- a/frontend/app/views/spree/shared/_quantity_select.html.erb
+++ b/frontend/app/views/spree/shared/_quantity_select.html.erb
@@ -1,5 +1,5 @@
 <%# TODO: Use in cart %>
-<div class="d-flex quantity-select mx-auto mx-md-0">
+<div class="d-inline-flex quantity-select">
   <%= button_tag '-', type: 'button', class: "border-right-0 flex-grow-0 flex-shrink-0 py-0 px-3 quantity-select-decrease" %>
   <%= number_field_tag input_name, 1, min: 1, max: maximum_quantity, class: "p-0 flex-grow-1 flex-shrink-1 text-center form-control border-left-0 border-right-0 quantity-select-value", 'aria-label': Spree.t('pdp.quantity') %>
   <%= button_tag '+', type: 'button', class: "border-left-0  flex-grow-0 flex-shrink-0 py-0 px-3 quantity-select-increase" %>


### PR DESCRIPTION
BEFORE:

<img width="488" alt="Zrzut ekranu 2020-06-24 o 16 14 13" src="https://user-images.githubusercontent.com/26117538/85573169-f1888780-b635-11ea-9d71-11a2bb30db52.png">

<img width="650" alt="Zrzut ekranu 2020-06-24 o 16 14 29" src="https://user-images.githubusercontent.com/26117538/85573200-f8af9580-b635-11ea-8c36-ca5088d18054.png">

NOW:

<img width="532" alt="Zrzut ekranu 2020-06-24 o 16 12 59" src="https://user-images.githubusercontent.com/26117538/85573271-06fdb180-b636-11ea-87b6-5dedf8af3bea.png">

<img width="638" alt="Zrzut ekranu 2020-06-24 o 16 13 26" src="https://user-images.githubusercontent.com/26117538/85573305-0f55ec80-b636-11ea-923a-40e4e749502e.png">
