### PR TITLE
[SDP-352] Fixes for mailer issues related to stores

### DIFF
--- a/core/app/mailers/spree/base_mailer.rb
+++ b/core/app/mailers/spree/base_mailer.rb
@@ -24,6 +24,7 @@ module Spree
 
     def mail(headers = {}, &block)
       ensure_default_action_mailer_url_host
+      set_email_locale
       super if Spree::Config[:send_core_emails]
     end
 
@@ -35,6 +36,11 @@ module Spree
     def ensure_default_action_mailer_url_host
       ActionMailer::Base.default_url_options ||= {}
       ActionMailer::Base.default_url_options[:host] ||= current_store.url
+    end
+
+    def set_email_locale
+      locale = @order&.store&.default_locale || current_store&.default_locale
+      I18n.locale = locale if locale.present?
     end
   end
 end

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -49,6 +49,7 @@ module Spree
     preference :expedited_exchanges_days_window, :integer, default: 14 # the amount of days the customer has to return their item after the expedited exchange is shipped in order to avoid being charged
     preference :layout, :string, default: 'spree/layouts/spree_application'
     preference :logo, :string, default: 'logo/spree_50.png'
+    preference :mailer_logo, :string, default: 'logo/spree_50.png'
     preference :max_level_in_taxons_menu, :integer, default: 1 # maximum nesting level in taxons menu
     preference :products_per_page, :integer, default: 12
     preference :require_master_price, :boolean, default: true

--- a/core/app/views/spree/shared/_base_mailer_header.html.erb
+++ b/core/app/views/spree/shared/_base_mailer_header.html.erb
@@ -1,13 +1,14 @@
 <!-- You can override this template to design your own header. -->
 <% store_name = @order&.store&.name || current_store.name %>
+<% logo = Spree::Config.mailer_logo || Spree::Config.logo %>
 <tr>
   <td class="email-masthead">
     <% if frontend_available? %>
       <%= link_to spree.root_url, class: 'template-label' do %>
-        <%= image_tag Spree::Config.logo, class: 'logo', alt: store_name, title: store_name %>
+        <%= image_tag logo, class: 'logo', alt: store_name, title: store_name %>
       <% end %>
     <% else %>
-      <%= image_tag Spree::Config.logo, class: 'logo', alt: store_name, title: store_name %>
+      <%= image_tag logo, class: 'logo', alt: store_name, title: store_name %>
     <% end %>
   </td>
 </tr>

--- a/core/app/views/spree/shared/_base_mailer_header.html.erb
+++ b/core/app/views/spree/shared/_base_mailer_header.html.erb
@@ -1,12 +1,13 @@
 <!-- You can override this template to design your own header. -->
+<% store_name = @order&.store&.name || current_store.name %>
 <tr>
   <td class="email-masthead">
     <% if frontend_available? %>
       <%= link_to spree.root_url, class: 'template-label' do %>
-        <%= image_tag Spree::Config.logo, class: 'logo', alt: current_store.name, title: current_store.name %>
+        <%= image_tag Spree::Config.logo, class: 'logo', alt: store_name, title: store_name %>
       <% end %>
     <% else %>
-      <%= image_tag Spree::Config.logo, class: 'logo', alt: current_store.name, title: current_store.name %>
+      <%= image_tag Spree::Config.logo, class: 'logo', alt: store_name, title: store_name %>
     <% end %>
   </td>
 </tr>


### PR DESCRIPTION
- email logo image alt and title attributes changed to the name of the store in which the order has been made
- email logo image changed to png file for better compatibility with mail readers (SVG files are not displayed in Gmail)
- setting email locale based on orders store default locale