### PR TITLE
Fix email styling issues with order adjustments

### DIFF
--- a/core/app/views/spree/shared/_purchased_items_table.html.erb
+++ b/core/app/views/spree/shared/_purchased_items_table.html.erb
@@ -25,7 +25,7 @@
       <td></td>
       <td>
         <p class="f-fallback purchase_total purchase_total--label">
-          <%= Spree.t(:shipping) %><%= name %>:
+          <%= Spree.t(:shipping) %> <%= name %>:
         </p>
       </td>
       <td>
@@ -54,7 +54,7 @@
   <% end %>
   <% order.adjustments.eligible.each do |adjustment| %>
     <% next if (adjustment.source_type == 'Spree::TaxRate') || (adjustment.amount == 0) %>
-    <%= render 'spree/shared/purchased_items_table/adjustment', adjustment: adjustment %>
+    <%= render 'spree/shared/purchased_items_table/adjustment', adjustment: adjustment, order: order %>
   <% end %>
   <%= render 'spree/shared/purchased_items_table/total', order: order %>
 </table>

--- a/core/app/views/spree/shared/purchased_items_table/_adjustment.html.erb
+++ b/core/app/views/spree/shared/purchased_items_table/_adjustment.html.erb
@@ -1,12 +1,13 @@
 <tr>
-  <td class="purchase_footer" valign="middle">
+  <td></td>
+  <td>
     <p class="f-fallback purchase_total purchase_total--label">
       <%= raw(adjustment.label) %>:
     </p>
   </td>
-  <td class="purchase_footer" valign="middle">
+  <td>
     <p class="f-fallback purchase_total">
-      <%= adjustment.display_amount %>
+      <%= Spree::Money.new(adjustment.amount, currency: order.currency) %>
     </p>
   </td>
 </tr>


### PR DESCRIPTION
New emails from #10100 have some minor styling issues that needed fixing.

- Missing space on shipping adjustment label.
- Other order adjustments not styled correctly.

### Before:
![Screen Shot 2020-06-25 at 12 15 07 pm](https://user-images.githubusercontent.com/15181647/85646155-d160d300-b6de-11ea-9ead-8d8a55cb783e.png)

### After:
![Screen Shot 2020-06-25 at 12 15 18 pm](https://user-images.githubusercontent.com/15181647/85646152-cf970f80-b6de-11ea-9f63-e96fbafbd764.png)