### PR TITLE
Add metadata to gemspecs

### DIFF
--- a/api/spree_api.gemspec
+++ b/api/spree_api.gemspec
@@ -2,20 +2,27 @@
 require_relative '../core/lib/spree/core/version.rb'
 
 Gem::Specification.new do |s|
+  s.name          = "spree_api"
+  s.version       = Spree.version
   s.authors       = ["Ryan Bigg"]
   s.email         = ["ryan@spreecommerce.com"]
-  s.description   = %q{Spree's API}
   s.summary       = %q{Spree's API}
+  s.description   = %q{Spree's API}
   s.homepage      = 'http://spreecommerce.org'
   s.license       = 'BSD-3-Clause'
+
+  s.metadata = {
+    "bug_tracker_uri"   => "https://github.com/spree/spree/issues",
+    "changelog_uri"     => "https://github.com/spree/spree/releases/tag/v#{s.version}",
+    "documentation_uri" => "https://guides.spreecommerce.org/",
+    "source_code_uri"   => "https://github.com/spree/spree/tree/v#{s.version}",
+  }
 
   s.required_ruby_version = '>= 2.5.0'
 
   s.files         = `git ls-files`.split($\).reject { |f| f.match(/^spec/) && !f.match(/^spec\/fixtures/) }
   s.executables   = s.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
-  s.name          = "spree_api"
   s.require_paths = ["lib"]
-  s.version       = Spree.version
 
   s.add_development_dependency 'jsonapi-rspec'
 

--- a/backend/spree_backend.gemspec
+++ b/backend/spree_backend.gemspec
@@ -5,15 +5,21 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_backend'
   s.version     = Spree.version
-  s.summary     = 'backend e-commerce functionality for the Spree project.'
-  s.description = 'Required dependency for Spree'
-
-  s.required_ruby_version = '>= 2.5.0'
-
   s.author      = 'Sean Schofield'
   s.email       = 'sean@spreecommerce.com'
+  s.summary     = 'backend e-commerce functionality for the Spree project.'
+  s.description = 'Required dependency for Spree'
   s.homepage    = 'http://spreecommerce.org'
   s.license     = 'BSD-3-Clause'
+
+  s.metadata = {
+    "bug_tracker_uri"   => "https://github.com/spree/spree/issues",
+    "changelog_uri"     => "https://github.com/spree/spree/releases/tag/v#{s.version}",
+    "documentation_uri" => "https://guides.spreecommerce.org/",
+    "source_code_uri"   => "https://github.com/spree/spree/tree/v#{s.version}",
+  }
+
+  s.required_ruby_version = '>= 2.5.0'
 
   s.files        = `git ls-files`.split("\n").reject { |f| f.match(/^spec/) && !f.match(/^spec\/fixtures/) }
   s.require_path = 'lib'

--- a/cmd/spree_cmd.gemspec
+++ b/cmd/spree_cmd.gemspec
@@ -7,10 +7,17 @@ Gem::Specification.new do |s|
   s.version     = Spree.version
   s.authors     = ['Chris Mar']
   s.email       = ['chris@spreecommerce.com']
-  s.homepage    = 'http://spreecommerce.org'
-  s.license     = 'BSD-3-Clause'
   s.summary     = 'Spree Commerce command line utility'
   s.description = 'tools to create new Spree stores and extensions'
+  s.homepage    = 'http://spreecommerce.org'
+  s.license     = 'BSD-3-Clause'
+
+  s.metadata = {
+    "bug_tracker_uri"   => "https://github.com/spree/spree/issues",
+    "changelog_uri"     => "https://github.com/spree/spree/releases/tag/v#{s.version}",
+    "documentation_uri" => "https://guides.spreecommerce.org/",
+    "source_code_uri"   => "https://github.com/spree/spree/tree/v#{s.version}",
+  }
 
   s.files         = `git ls-files`.split("\n").reject { |f| f.match(/^spec/) && !f.match(/^spec\/fixtures/) }
   s.bindir        = 'bin'

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -6,16 +6,22 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_core'
   s.version     = Spree.version
+  s.author      = 'Sean Schofield'
+  s.email       = 'sean@spreecommerce.com'
   s.summary     = 'The bare bones necessary for Spree.'
   s.description = 'The bare bones necessary for Spree.'
+  s.homepage    = 'http://spreecommerce.org'
+  s.license     = 'BSD-3-Clause'
+
+  s.metadata = {
+    "bug_tracker_uri"   => "https://github.com/spree/spree/issues",
+    "changelog_uri"     => "https://github.com/spree/spree/releases/tag/v#{s.version}",
+    "documentation_uri" => "https://guides.spreecommerce.org/",
+    "source_code_uri"   => "https://github.com/spree/spree/tree/v#{s.version}",
+  }
 
   s.required_ruby_version     = '>= 2.5.0'
   s.required_rubygems_version = '>= 1.8.23'
-
-  s.author      = 'Sean Schofield'
-  s.email       = 'sean@spreecommerce.com'
-  s.homepage    = 'http://spreecommerce.org'
-  s.license     = 'BSD-3-Clause'
 
   s.files        = `git ls-files`.split("\n").reject { |f| f.match(/^spec/) && !f.match(/^spec\/fixtures/) }
   s.require_path = 'lib'

--- a/frontend/spree_frontend.gemspec
+++ b/frontend/spree_frontend.gemspec
@@ -5,15 +5,21 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_frontend'
   s.version     = Spree.version
-  s.summary     = 'Frontend e-commerce functionality for the Spree project.'
-  s.description = s.summary
-
-  s.required_ruby_version = '>= 2.5.0'
-
   s.author      = 'Sean Schofield'
   s.email       = 'sean@spreecommerce.com'
+  s.summary     = 'Frontend e-commerce functionality for the Spree project.'
+  s.description = s.summary
   s.homepage    = 'http://spreecommerce.org'
   s.license     = 'BSD-3-Clause'
+
+  s.metadata = {
+    "bug_tracker_uri"   => "https://github.com/spree/spree/issues",
+    "changelog_uri"     => "https://github.com/spree/spree/releases/tag/v#{s.version}",
+    "documentation_uri" => "https://guides.spreecommerce.org/",
+    "source_code_uri"   => "https://github.com/spree/spree/tree/v#{s.version}",
+  }
+
+  s.required_ruby_version = '>= 2.5.0'
 
   s.files        = `git ls-files`.split("\n").reject { |f| f.match(/^spec/) && !f.match(/^spec\/fixtures/) }
   s.require_path = 'lib'

--- a/sample/spree_sample.gemspec
+++ b/sample/spree_sample.gemspec
@@ -5,13 +5,19 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_sample'
   s.version     = Spree.version
-  s.summary     = 'Sample data (including images) for use with Spree.'
-  s.description = 'Required dependency for Spree'
-
   s.author      = 'Sean Schofield'
   s.email       = 'sean@spreecommerce.com'
+  s.summary     = 'Sample data (including images) for use with Spree.'
+  s.description = 'Required dependency for Spree'
   s.homepage    = 'http://spreecommerce.org'
   s.license     = 'BSD-3-Clause'
+
+  s.metadata = {
+    "bug_tracker_uri"   => "https://github.com/spree/spree/issues",
+    "changelog_uri"     => "https://github.com/spree/spree/releases/tag/v#{s.version}",
+    "documentation_uri" => "https://guides.spreecommerce.org/",
+    "source_code_uri"   => "https://github.com/spree/spree/tree/v#{s.version}",
+  }
 
   s.files        = `git ls-files`.split("\n").reject { |f| f.match(/^spec/) && !f.match(/^spec\/fixtures/) }
   s.require_path = 'lib'

--- a/spree.gemspec
+++ b/spree.gemspec
@@ -5,19 +5,25 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree'
   s.version     = Spree.version
+  s.author      = 'Sean Schofield'
+  s.email       = 'sean@spreecommerce.com'
   s.summary     = 'Full-stack e-commerce framework for Ruby on Rails.'
   s.description = 'Spree is an open source e-commerce framework for Ruby on Rails. Join us on http://slack.spreecommerce.org'
+  s.homepage    = 'http://spreecommerce.org'
+  s.license     = 'BSD-3-Clause'
+
+  s.metadata = {
+    "bug_tracker_uri"   => "https://github.com/spree/spree/issues",
+    "changelog_uri"     => "https://github.com/spree/spree/releases/tag/v#{s.version}",
+    "documentation_uri" => "https://guides.spreecommerce.org/",
+    "source_code_uri"   => "https://github.com/spree/spree/tree/v#{s.version}",
+  }
 
   s.required_ruby_version = '>= 2.5.0'
 
   s.files        = Dir['README.md', 'lib/**/*']
   s.require_path = 'lib'
   s.requirements << 'none'
-
-  s.author       = 'Sean Schofield'
-  s.email        = 'sean@spreecommerce.com'
-  s.homepage     = 'http://spreecommerce.org'
-  s.license      = 'BSD-3-Clause'
 
   s.add_dependency 'spree_core', s.version
   s.add_dependency 'spree_api', s.version


### PR DESCRIPTION
Benefits of adding metadata:
- Extra links added to each gem's Rubygems.org page.
- Adds extra info to PRs created by automatic tools like dependabot. Currently missing release notes, changelog and commits on the individual gems. Only works currently on main spree gem.

I have also moved some of the attributes around so they are the same order in all of them.

This is what a dependabot PR for spree_api gem currently looks like:
![Screen Shot 2020-06-25 at 7 48 17 pm](https://user-images.githubusercontent.com/15181647/85697269-fb38ea80-b71c-11ea-92f2-5247e7679689.png)

Should look like this:
![Screen Shot 2020-06-25 at 7 47 45 pm](https://user-images.githubusercontent.com/15181647/85697280-fd9b4480-b71c-11ea-9344-98279d528e24.png)

