### PR TITLE
Fix Over Scroll In Admin 

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_navbar.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_navbar.scss
@@ -7,6 +7,9 @@
     a:hover {
       text-decoration: none;
     }
+    svg{
+      margin-bottom: 0;
+    }
 
     .btn {
       &:hover,

--- a/backend/app/assets/stylesheets/spree/backend/components/_tables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_tables.scss
@@ -105,6 +105,10 @@ table.table {
 	}
 }
 
+div.table-responsive table.table-bordered {
+  border-top: 1px solid $input-border-color !important;
+}
+
 .sortable-drag-v {
   border: 1px solid $info;
   border-radius: 5px;

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -178,7 +178,6 @@
 
 <% if @orders.any? %>
 <div class="table-responsive">
-
   <table class="table" id="listing_orders" data-hook>
     <thead>
       <tr data-hook="admin_orders_index_headers">
@@ -261,7 +260,6 @@
     <% end %>
     </tbody>
   </table>
-
 </div>
 <% else %>
   <div class="alert alert-info no-objects-found">

--- a/backend/app/views/spree/admin/payment_methods/index.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/index.html.erb
@@ -7,6 +7,7 @@
 <% end if can? :create, Spree::PaymentMethod %>
 
 <% if @payment_methods.any? %>
+<div class="table-responsive">
   <table class="table sortable" id='listing_payment_methods' data-hook data-sortable-link="<%= update_positions_admin_payment_methods_url %>">
     <thead>
       <tr data-hook="admin_payment_methods_index_headers">
@@ -27,7 +28,7 @@
             <% end %>
           </td>
           <td><%= method.name %></td>
-          <td><%= method.type %></td>
+          <td><%= method.type.split('::', 3).last %></td>
           <td class="text-center"><%= Spree.t(method.display_on) %></td>
           <td class="text-center"><%= method.active ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>
           <td data-hook="admin_payment_methods_index_row_actions" class="actions actions-2 text-right">
@@ -38,6 +39,7 @@
       <% end %>
     </tbody>
   </table>
+  </div>
 <% else %>
   <div class="alert alert-info no-objects-found">
     <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::PaymentMethod)) %>,

--- a/backend/app/views/spree/admin/payments/index.html.erb
+++ b/backend/app/views/spree/admin/payments/index.html.erb
@@ -19,8 +19,7 @@
 <% end %>
 
 <% if @payments.any? %>
-
-  <div data-hook="payment_list" class="mb-3">
+  <div data-hook="payment_list" class="mb-3 table-responsive">
     <%= render partial: 'list', locals: { payments: @payments } %>
   </div>
 

--- a/backend/app/views/spree/admin/prices/_variant_prices.html.erb
+++ b/backend/app/views/spree/admin/prices/_variant_prices.html.erb
@@ -1,4 +1,4 @@
-<div class="panel-body no-padding-bottom panel-default">
+<div class="panel-body no-padding-bottom panel-default table-responsive">
   <div id="variant_prices-table-wrapper">
     <table class="table sortable">
       <colgroup>

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -49,6 +49,7 @@
 <% end %>
 
 <% if @collection.any? %>
+<div class="table-responsive">
   <table class="table" id="listing_products">
     <thead>
       <tr data-hook="admin_products_index_headers">
@@ -79,6 +80,7 @@
       <% end %>
     </tbody>
   </table>
+</div>
 <% else %>
   <div class="alert alert-info no-objects-found">
     <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::Product)) %>,

--- a/backend/app/views/spree/admin/products/stock.html.erb
+++ b/backend/app/views/spree/admin/products/stock.html.erb
@@ -7,8 +7,8 @@
   </div>
 <% end %>
 
-<div class="card mb-3">
-  <table class="table table-bordered" id="listing_product_stock">
+<div class="card mb-3 table-responsive">
+  <table class="table" id="listing_product_stock">
     <thead>
       <tr data-hook="admin_product_stock_management_index_headers">
         <th colspan="2"><%= Spree.t(:variant) %></th>

--- a/backend/app/views/spree/admin/promotions/index.html.erb
+++ b/backend/app/views/spree/admin/promotions/index.html.erb
@@ -45,6 +45,7 @@
 <%= paginate @promotions, theme: 'admin-twitter-bootstrap-4' %>
 
 <% if @promotions.any? %>
+<div class="table-responsive">
   <table class="table">
     <thead>
       <tr>
@@ -75,6 +76,7 @@
       <% end %>
     </tbody>
   </table>
+  </div>
 <% else %>
   <div class="alert alert-info no-objects-found">
     <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::Promotion)) %>,

--- a/backend/app/views/spree/admin/reimbursement_types/index.html.erb
+++ b/backend/app/views/spree/admin/reimbursement_types/index.html.erb
@@ -7,6 +7,7 @@
 <% end if can?(:create, Spree::ReimbursementType) %>
 
 <% if @reimbursement_types.any? %>
+<div class="table-responsive">
   <table class="table" id='listing_reimbursement_types' data-hook>
     <thead>
       <tr data-hook="reimbursement_types_header">
@@ -22,7 +23,7 @@
             <%= reimbursement_type.name.humanize %>
           </td>
           <td>
-            <%= reimbursement_type.type %>
+            <%= reimbursement_type.type.split('::', 3).last %>
           </td>
           <td class="actions actions-2 text-right">
             <%= link_to_edit reimbursement_type, no_text: true, class: 'edit' if can?(:edit, reimbursement_type) %>
@@ -32,6 +33,7 @@
       <% end %>
     </tbody>
   </table>
+  </div>
 <% else %>
   <div class="alert alert-info no-objects-found">
     <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::ReimbursementType)) %>

--- a/backend/app/views/spree/admin/return_authorizations/_form.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/_form.html.erb
@@ -1,7 +1,8 @@
 <% allow_return_item_changes = !@return_authorization.customer_returned_items? %>
 
 <div data-hook="admin_return_authorization_form_fields">
-  <table class="table table-condensed table-bordered index return-items-table">
+<div class="table-responsive">
+  <table class="table table-condensed table-bordered return-items-table">
     <thead>
       <tr data-hook="rma_header">
         <th>
@@ -74,7 +75,7 @@
       <% end %>
     </tbody>
   </table>
-
+</div>
   <%= f.field_container :amount, class: ['alert alert-info'] do %>
     <%= Spree.t(:total_pre_tax_refund) %>: <span id="total_pre_tax_refund">0.00</span>
   <% end %>

--- a/backend/app/views/spree/admin/return_authorizations/edit.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_actions do %>
   <% if @return_authorization.can_cancel? %>
-    <%= button_link_to Spree.t('actions.cancel'), cancel_admin_order_return_authorization_url(@order, @return_authorization), method: :put, data: { confirm: Spree.t(:are_you_sure) }, icon: "delete" %>
+    <%= button_link_to Spree.t('actions.cancel'), cancel_admin_order_return_authorization_url(@order, @return_authorization), method: :put, data: { confirm: Spree.t(:are_you_sure) }, icon: "delete.svg" %>
   <% end %>
 <% end %>
 
@@ -18,9 +18,9 @@
     <%= render partial: 'form', locals: { f: f } %>
 
     <div class="form-actions" data-hook="buttons">
-      <%= button Spree.t('actions.update'), 'repeat' %>
+      <%= button Spree.t('actions.update'), 'save.svg' %>
       <span class="or"><%= Spree.t(:or) %></span>
-      <%= button_link_to Spree.t('actions.cancel'), spree.admin_order_return_authorizations_url(@order), icon: 'cancel' %>
+      <%= button_link_to Spree.t('actions.cancel'), spree.admin_order_return_authorizations_url(@order), icon: 'cancel.svg' %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/return_authorizations/index.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/index.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :page_actions do %>
   <% if @order.shipments.any?(&:shipped?) && can?(:create, Spree::ReturnAuthorization) %>
-    <%= button_link_to Spree.t(:new_return_authorization), new_admin_order_return_authorization_url(@order), class: "btn-success", icon: 'add' %>
+    <%= button_link_to Spree.t(:new_return_authorization), new_admin_order_return_authorization_url(@order), class: "btn-success", icon: 'add.svg' %>
   <% end %>
 <% end %>
 

--- a/backend/app/views/spree/admin/return_authorizations/new.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/new.html.erb
@@ -10,9 +10,9 @@
     <%= render partial: 'form', locals: { f: f } %>
 
     <div class="form-actions" data-hook="buttons">
-      <%= button Spree.t(:create), 'save' %>
+      <%= button Spree.t(:create), 'save.svg' %>
       <span class="or"><%= Spree.t(:or) %></span>
-      <%= button_link_to Spree.t('actions.cancel'), spree.admin_order_return_authorizations_url(@order), icon: 'cancel' %>
+      <%= button_link_to Spree.t('actions.cancel'), spree.admin_order_return_authorizations_url(@order), icon: 'cancel.svg' %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/return_index/return_authorizations.html.erb
+++ b/backend/app/views/spree/admin/return_index/return_authorizations.html.erb
@@ -45,6 +45,7 @@
 <% end %>
 
 <% if @collection.any? %>
+<div class="table-responsive">
   <table class="table">
     <thead>
       <tr data-hook="rate_header">
@@ -71,6 +72,7 @@
       <% end %>
     </tbody>
   </table>
+  </div>
 <% else %>
   <div class="alert alert-info no-objects-found">
     <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::ReturnAuthorization)) %>.

--- a/backend/app/views/spree/admin/roles/index.html.erb
+++ b/backend/app/views/spree/admin/roles/index.html.erb
@@ -7,25 +7,27 @@
 <% end if can? :create, Spree::Role %>
 
 <% if @roles.any? %>
-  <table class="table">
-    <thead>
-      <tr data-hook="admin_roles_index_headers">
-        <th><%= Spree.t(:role_id) %></th>
-        <th class="actions"></th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @roles.each do |role|%>
-        <tr id="<%= spree_dom_id role %>" data-hook="admin_roles_index_rows">
-          <td><%= role.name %></td>
-          <td class="actions text-right">
-            <%= link_to_edit(role, no_text: true) if can? :edit, role %>
-            <%= link_to_delete(role, no_text: true) if can? :destroy, role %>
-          </td>
+  <div class="table-responsive">
+    <table class="table">
+      <thead>
+        <tr data-hook="admin_roles_index_headers">
+          <th><%= Spree.t(:role_id) %></th>
+          <th class="actions"></th>
         </tr>
-      <% end %>
-    </tbody>
-  </table>
+      </thead>
+      <tbody>
+        <% @roles.each do |role|%>
+          <tr id="<%= spree_dom_id role %>" data-hook="admin_roles_index_rows">
+            <td><%= role.name %></td>
+            <td class="actions text-right">
+              <%= link_to_edit(role, no_text: true) if can? :edit, role %>
+              <%= link_to_delete(role, no_text: true) if can? :destroy, role %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
 <% else %>
   <div class="alert alert-warning">
     <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::Role)) %>,

--- a/backend/app/views/spree/admin/state_changes/index.html.erb
+++ b/backend/app/views/spree/admin/state_changes/index.html.erb
@@ -5,6 +5,7 @@
 <% end %>
 
 <% if @state_changes.any? %>
+<div class="table-responsive">
   <table class="table" id="listing_order_state_changes" data-hook>
     <thead>
       <tr data-hook="admin_orders_state_changes_headers">
@@ -38,6 +39,7 @@
       <% end %>
     </tbody>
   </table>
+</div>
 <% else %>
   <div class="alert alert-info no-objects-found">
     <%= Spree.t(:no_state_changes) %>

--- a/backend/app/views/spree/admin/stores/index.html.erb
+++ b/backend/app/views/spree/admin/stores/index.html.erb
@@ -7,6 +7,7 @@
 <% end %>
 
 <% if @stores.any? %>
+<div class="table-responsive">
   <table class="table">
     <thead>
       <th><%= Spree.t(:name) %></th>
@@ -33,6 +34,7 @@
       <% end %>
     </tbody>
   </table>
+</div>  
 <% else %>
   <div class="alert alert-info no-objects-found">
     <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::StoreCredit)) %>

--- a/backend/app/views/spree/admin/tax_rates/index.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/index.html.erb
@@ -7,6 +7,7 @@
 <% end if can? :create, Spree::TaxRate %>
 
 <% if @tax_rates.any? %>
+<div class="table-responsive">
   <table class="table">
     <thead>
       <tr data-hook="rate_header">
@@ -38,6 +39,7 @@
       <% end %>
     </tbody>
   </table>
+</div>
 <% else %>
   <div class="alert alert-info no-objects-found">
     <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::TaxRate)) %>,

--- a/backend/spec/features/admin/configuration/payment_methods_spec.rb
+++ b/backend/spec/features/admin/configuration/payment_methods_spec.rb
@@ -21,7 +21,7 @@ describe 'Payment Methods', type: :feature do
       end
 
       within('table#listing_payment_methods') do
-        expect(page).to have_content('Spree::PaymentMethod::Check')
+        expect(page).to have_content('Check')
       end
     end
   end
@@ -31,7 +31,7 @@ describe 'Payment Methods', type: :feature do
       within find('#contentHeader') do
         click_link 'admin_new_payment_methods_link'
       end
-      
+
       expect(page).to have_content('New Payment Method')
       fill_in 'payment_method_name', with: 'check90'
       fill_in 'payment_method_description', with: 'check90 desc'


### PR DESCRIPTION
- Fix side over-scroll.
- Update a few more icons.
- Make type/provider more user friendly on Configurations/Payment Methods and Configurations/Reimbursement Types

Just check that the type is useable this way, is there a need for the Spree::PaymentMethod:: being visible to  the user?

From:
<img width="210" alt="Screenshot 2020-06-25 at 21 27 08" src="https://user-images.githubusercontent.com/1240766/85792126-e4999000-b72a-11ea-832d-4ad2968b8086.png">

To:
<img width="209" alt="Screenshot 2020-06-25 at 21 27 25" src="https://user-images.githubusercontent.com/1240766/85792135-ebc09e00-b72a-11ea-9d22-0b85d3819f39.png">

