### PR TITLE
[SDP-385] Fixes products carousel caching problem

### DIFF
--- a/frontend/app/views/spree/shared/_carousel_4_products.html.erb
+++ b/frontend/app/views/spree/shared/_carousel_4_products.html.erb
@@ -1,4 +1,4 @@
-<% cache [common_product_cache_keys, products&.maximum(:updated_at)&.to_i, id] do %>
+<% cache [common_product_cache_keys, products&.maximum(:updated_at)&.to_i, id, products&.ids&.join(',')] do %>
   <div id="<%= id %>-mobile" class="carousel slide d-md-none homepage-carousel" data-interval="false">
     <div class="carousel-inner">
       <% products.each_slice(2).with_index do |sliced_items, index| %>


### PR DESCRIPTION
The problem occurred on related products carousel on PDP. It was noticed that removing a product from related products list for product resulted in showing a product that was not present on the list of related products. This has happened after related
products were added using a script and multiple products in this list had the same `updated_at` dates.