### PR TITLE
UX Change - Move clickable items to the first column (products & orders)

### DIFF
--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -181,12 +181,12 @@
   <table class="table" id="listing_orders" data-hook>
     <thead>
       <tr data-hook="admin_orders_index_headers">
+        <th><%= sort_link @search, :number,           I18n.t(:number, scope: 'activerecord.attributes.spree/order') %></th>
         <% if @show_only_completed %>
           <th><%= sort_link @search, :completed_at,   I18n.t(:completed_at, scope: 'activerecord.attributes.spree/order') %></th>
         <% else %>
           <th><%= sort_link @search, :created_at,     I18n.t(:created_at, scope: 'activerecord.attributes.spree/order') %></th>
         <% end %>
-        <th><%= sort_link @search, :number,           I18n.t(:number, scope: 'activerecord.attributes.spree/order') %></th>
         <th><%= sort_link @search, :considered_risky, I18n.t(:considered_risky, scope: 'activerecord.attributes.spree/order') %></th>
         <th><%= sort_link @search, :state,            I18n.t(:state, scope: 'activerecord.attributes.spree/order') %></th>
         <th><%= sort_link @search, :payment_state,    I18n.t(:payment_state, scope: 'activerecord.attributes.spree/order') %></th>
@@ -201,10 +201,10 @@
     <tbody>
     <% @orders.each do |order| %>
       <tr data-hook="admin_orders_index_rows" class="state-<%= order.state.downcase %> <%= cycle('odd', 'even') %>">
+        <td><%= link_to order.number, edit_admin_order_path(order) %></td>
         <td>
           <%= order_time(@show_only_completed ? order.completed_at : order.created_at) %>
         </td>
-        <td><%= link_to order.number, edit_admin_order_path(order) %></td>
         <td>
           <span class="badge badge-<%= order.considered_risky ? 'considered_risky' : 'considered_safe' %>">
             <%= order.considered_risky ? Spree.t("risky") : Spree.t("safe") %>

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -53,10 +53,9 @@
   <table class="table" id="listing_products">
     <thead>
       <tr data-hook="admin_products_index_headers">
+          <th colspan="2"><%= sort_link @search,:name, Spree.t(:name), { default_order: "desc" }, {title: 'admin_products_listing_name_title'} %></th>
         <th><%= Spree.t(:sku) %></th>
         <th><%= Spree.t(:status) %></th>
-
-        <th colspan="2"><%= sort_link @search,:name, Spree.t(:name), { default_order: "desc" }, {title: 'admin_products_listing_name_title'} %></th>
         <th class="text-center">
           <%= sort_link @search, :master_default_price_amount, Spree.t(:master_price), {}, {title: 'admin_products_listing_price_title'} %>
         </th>
@@ -66,10 +65,14 @@
     <tbody>
       <% @collection.each do |product| %>
           <tr <%== "style='color: red;'" if product.deleted? %> id="<%= spree_dom_id product %>" data-hook="admin_products_index_rows" class="<%= cycle('odd', 'even') %>">
+            <td class="image">
+              <%= link_to edit_admin_product_path(product) do %>
+                <%= mini_image product %>
+              <% end %>
+            </td>
+            <td><%= link_to product.try(:name), edit_admin_product_path(product) %></td>
             <td class="sku"><%= product.sku rescue '' %></td>
             <td class="status"><%= available_status(product) %> </td>
-            <td class="image"><%= mini_image product %></td>
-            <td><%= link_to product.try(:name), edit_admin_product_path(product) %></td>
             <td class="text-center"><%= display_price(product) %></td>
             <td class="actions actions-3 text-right" data-hook="admin_products_index_row_actions">
               <%= link_to_edit product, no_text: true, class: 'edit' if can?(:edit, product) && !product.deleted? %>

--- a/backend/spec/features/admin/orders/listing_spec.rb
+++ b/backend/spec/features/admin/orders/listing_spec.rb
@@ -35,7 +35,7 @@ describe 'Orders Listing', type: :feature do
       end
 
       within_row(2) do
-        expect(column_text(2)).to eq 'R200'
+        expect(column_text(1)).to eq 'R200'
         expect(find('td:nth-child(3)')).to have_css '.badge-considered_safe'
       end
     end

--- a/backend/spec/features/admin/orders/listing_spec.rb
+++ b/backend/spec/features/admin/orders/listing_spec.rb
@@ -29,7 +29,7 @@ describe 'Orders Listing', type: :feature do
   describe 'listing orders' do
     it 'lists existing orders' do
       within_row(1) do
-        expect(column_text(2)).to eq 'R100'
+        expect(column_text(1)).to eq 'R100'
         expect(find('td:nth-child(3)')).to have_css '.badge-considered_risky'
         expect(column_text(4)).to eq 'cart'
       end

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -418,9 +418,7 @@ describe 'Products', type: :feature do
         # This will show our deleted product
         check 'Show Deleted'
         click_on 'Search'
-        within_column(2) do
-          click_link product.name
-        end
+        click_link(product.name, match: :first)
         expect(page).to have_field(id: 'product_price') do |field|
           field.value.to_f == product.price.to_f
         end

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -418,7 +418,9 @@ describe 'Products', type: :feature do
         # This will show our deleted product
         check 'Show Deleted'
         click_on 'Search'
-        click_link product.name
+        within_column(2) do
+          click_link product.name
+        end
         expect(page).to have_field(id: 'product_price') do |field|
           field.value.to_f == product.price.to_f
         end


### PR DESCRIPTION
Suggestion: For usability move the clickable link in the orders and products tables to the first column.