### PR TITLE
Admin UX Suggestion

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -46,20 +46,6 @@ jQuery(function ($) {
   sidebarOpen.click(openMenu)
   sidebarClose.click(closeAllMenus)
 
-  // Contextual Sidebar Menu
-  var contextualSidebarMenuToggle = $('#contextual-menu-toggle')
-
-  function toggleContextualMenu() {
-    if (document.body.classList.contains('contextualSideMenu-open')) {
-      closeAllMenus()
-    } else {
-      closeAllMenus()
-      body.addClass('contextualSideMenu-open modal-open')
-      modalBackdrop.addClass('show')
-    }
-  }
-  contextualSidebarMenuToggle.click(toggleContextualMenu)
-
   // TODO: remove this js temp behaviour and fix this decent
   // Temp quick search
   // When there was a search term, copy it

--- a/backend/app/assets/stylesheets/spree/backend/components/_buttons.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_buttons.scss
@@ -10,7 +10,7 @@
 
 .btn {
   text-align: center;
-  margin:2.5px;
+  margin:2px;
 
   .ship {
     color: #fff;
@@ -26,10 +26,6 @@
   background-color: $green;
 }
 
-.btn-circle {
-  width: 50px;
-  height: 50px;
-  padding: 14px 10px;
-  border-radius: 25px;
-  text-align: center;
+.btn-group > .btn:not(:first-child), .btn-group > .btn-group:not(:first-child) {
+  margin-left: -3px;
 }

--- a/backend/app/assets/stylesheets/spree/backend/components/_sidebar.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_sidebar.scss
@@ -81,14 +81,6 @@ ul.nav-sidebar {
 }
 
 #contextual-menu-toggle {
-  position: fixed;
-  bottom: 15px;
-  right:15px;
-  border: none;
-  box-shadow: 0px 5px 5px -3px rgba(0, 0, 0, 0.2),
-              0px 8px 10px 1px rgba(0, 0, 0, 0.14),
-              0px 3px 14px 2px rgba(0,0,0,.12);
-
   & svg {
     transform:rotate(0deg);
     transition: .3s ease-in-out;
@@ -101,7 +93,6 @@ body.contextualSideMenu-open #contextualSideMenu {
 }
 
 body.contextualSideMenu-open #contextual-menu-toggle {
-  z-index: 1041;
   svg {
       transform:rotate(180deg);
       transition: .3s ease-in-out;
@@ -109,17 +100,24 @@ body.contextualSideMenu-open #contextual-menu-toggle {
 }
 
 .contextual-title {
-  font-size:1.25rem;
+  font-size:1rem;
 }
 
 
 @include media-breakpoint-up(sm) {
+  .contextual-title {
+    font-size: 1.25rem;
+  }
+
   aside#main-sidebar {
     width: 50%;
   }
 }
 
 @include media-breakpoint-up(md) {
+  .contextual-title {
+    font-size: 1.35rem;
+  }
   aside#main-sidebar {
     width: 30%;
   }

--- a/backend/app/assets/stylesheets/spree/backend/components/_sidebar.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_sidebar.scss
@@ -69,44 +69,14 @@ ul.nav-sidebar {
   }
 }
 
-#contextualSideMenu {
-  max-height: 85vh;
-  overflow-x: scroll;
-  background-color: white;
-  position: fixed;
-  left:0;
-  top: -100%;
-  z-index: 1041;
-  transition: .3s ease-in-out;
-}
-
-#contextual-menu-toggle {
-  & svg {
-    transform:rotate(0deg);
-    transition: .3s ease-in-out;
-  }
-}
-
-body.contextualSideMenu-open #contextualSideMenu {
-    top: 0;
-    transition: .3s ease-in-out;
-}
-
-body.contextualSideMenu-open #contextual-menu-toggle {
-  svg {
-      transform:rotate(180deg);
-      transition: .3s ease-in-out;
-  }
-}
-
 .contextual-title {
-  font-size:1rem;
+  font-size: 1.1rem;
 }
 
 
 @include media-breakpoint-up(sm) {
   .contextual-title {
-    font-size: 1.25rem;
+    font-size: 1.2rem;
   }
 
   aside#main-sidebar {
@@ -116,7 +86,7 @@ body.contextualSideMenu-open #contextual-menu-toggle {
 
 @include media-breakpoint-up(md) {
   .contextual-title {
-    font-size: 1.35rem;
+    font-size: 1.3rem;
   }
   aside#main-sidebar {
     width: 30%;
@@ -125,12 +95,6 @@ body.contextualSideMenu-open #contextual-menu-toggle {
 
 @include media-breakpoint-up(lg) {
 
-  #contextualSideMenu{
-    position: relative;
-    border: none;
-    height: auto;
-    z-index: 1000;
-  }
     aside#main-sidebar {
       left: 0;
       z-index: 999;
@@ -146,6 +110,6 @@ body.contextualSideMenu-open #contextual-menu-toggle {
   }
 
   .contextual-title {
-    font-size:1.5rem;
+    font-size:1.4rem;
   }
 }

--- a/backend/app/views/spree/admin/images/index.html.erb
+++ b/backend/app/views/spree/admin/images/index.html.erb
@@ -1,9 +1,7 @@
 <%= render partial: 'spree/admin/shared/product_tabs', locals: { current: :images } %>
 
 <% content_for :page_actions do %>
-  <div class="page-actions col-6 pr-0" data-hook="toolbar">
     <%= yield :page_actions %>
-  </div>
   <%= product_preview_link(@product) %>
   <%= button_link_to(Spree.t(:new_image), spree.new_admin_product_image_url(@product), { class: "btn-success", icon: 'add.svg', id: 'new_image_link' }) if can? :create, Spree::Image %>
 <% end %>

--- a/backend/app/views/spree/admin/prices/index.html.erb
+++ b/backend/app/views/spree/admin/prices/index.html.erb
@@ -1,9 +1,7 @@
 <%= render partial: 'spree/admin/shared/product_tabs', locals: { current: :prices } %>
 
 <% content_for :page_actions do %>
-  <div class="page-actions col-6 pr-0" data-hook="toolbar">
     <%= yield :page_actions %>
-  </div>
   <%= product_preview_link(@product) %>
 <% end %>
 

--- a/backend/app/views/spree/admin/shared/_content_header.html.erb
+++ b/backend/app/views/spree/admin/shared/_content_header.html.erb
@@ -12,12 +12,9 @@
         <% end %>
 
         <% if content_for?(:page_actions) %>
-          <div class="page-actions pl-0 pr-0 d-none d-lg-flex" data-hook="toolbar">
-              <%= yield :page_actions %>
-          </div>
-        <% end %>
-
-        <% if content_for?(:page_actions) %>
+        <div class="page-actions pl-0 pr-0 d-none d-lg-flex" data-hook="toolbar">
+            <%= yield :page_actions %>
+        </div>
         <div class="d-flex d-lg-none justify-content-end m-0 p-0">
           <div class="btn-group" role="group" aria-label="Basic example">
             <% if content_for?(:page_actions) %>
@@ -27,7 +24,7 @@
                     class="btn btn-outline-secondary">
                     <%= svg_icon name: "items.svg", width: '16', height: '16' %>
                     <span class="d-none d-sm-inline">
-                      <%= Spree.t('action') %>
+                      <%= Spree.t('contextual_actions') %>
                     </span>
             </button>
             <% end %>
@@ -36,8 +33,7 @@
                     data-target="#optionsModal"
                     data-toggle="modal"
                     type="button"
-                    name="button"
-                    style="margin-left:-4px;">
+                    name="button">
                     <span class="d-none d-sm-inline"><%= Spree.t('options') %> </span>
                     <%= svg_icon name: "list.svg", width: '16', height: '16' %>
             </button>

--- a/backend/app/views/spree/admin/shared/_content_header.html.erb
+++ b/backend/app/views/spree/admin/shared/_content_header.html.erb
@@ -3,7 +3,7 @@
     <div id="contentHeader" class="content-header col <%= "with-page-tabs" if content_for?(:page_tabs) %> page-header">
       <div class="row align-items-center  <%= if content_for?(:page_tabs) then "pb-0" else "border-bottom" end %>">
         <% if content_for?(:page_title) %>
-          <h1 class="contextual-title pr-0 pl-0 mb-0 col-12 col-lg-<%= content_for?(:page_actions) ? '6' : '12'  %>">
+          <h1 class="contextual-title pr-0 pl-0 mb-0 col">
             <%= yield :page_title %>
             <% if content_for?(:page_title_small) %>
               <small><%= yield :page_title_small %></small>
@@ -12,15 +12,38 @@
         <% end %>
 
         <% if content_for?(:page_actions) %>
-          <div class="page-actions pl-0 col-6 pr-0 d-none d-lg-block" data-hook="toolbar">
-            <%= yield :page_actions %>
+          <div class="page-actions pl-0 pr-0 d-none d-lg-flex" data-hook="toolbar">
+              <%= yield :page_actions %>
           </div>
         <% end %>
 
-        <% if content_for?(:page_tabs) %>
-          <ul class="nav nav-tabs w-100 mt-4">
-            <%= yield :page_tabs %>
-          </ul>
+        <% if content_for?(:page_actions) %>
+        <div class="d-flex d-lg-none justify-content-end m-0 p-0">
+          <div class="btn-group" role="group" aria-label="Basic example">
+            <% if content_for?(:page_actions) %>
+            <button type="button"
+                    data-target="#actionsModal"
+                    data-toggle="modal"
+                    class="btn btn-outline-secondary">
+                    <%= svg_icon name: "items.svg", width: '16', height: '16' %>
+                    <span class="d-none d-sm-inline">
+                      <%= Spree.t('action') %>
+                    </span>
+            </button>
+            <% end %>
+            <% if content_for?(:sidebar) %>
+            <button class="btn btn-outline-secondary"
+                    data-target="#optionsModal"
+                    data-toggle="modal"
+                    type="button"
+                    name="button"
+                    style="margin-left:-4px;">
+                    <span class="d-none d-sm-inline"><%= Spree.t('options') %> </span>
+                    <%= svg_icon name: "list.svg", width: '16', height: '16' %>
+            </button>
+            <% end %>
+          </div>
+        </div>
         <% end %>
       </div>
     </div>

--- a/backend/app/views/spree/admin/shared/_content_header.html.erb
+++ b/backend/app/views/spree/admin/shared/_content_header.html.erb
@@ -3,7 +3,7 @@
     <div id="contentHeader" class="content-header col <%= "with-page-tabs" if content_for?(:page_tabs) %> page-header">
       <div class="row align-items-center  <%= if content_for?(:page_tabs) then "pb-0" else "border-bottom" end %>">
         <% if content_for?(:page_title) %>
-          <h1 class="contextual-title pr-0 pl-0 mb-0 col">
+          <h1 class="contextual-title px-0 mb-0 col">
             <%= yield :page_title %>
             <% if content_for?(:page_title_small) %>
               <small><%= yield :page_title_small %></small>
@@ -12,36 +12,50 @@
         <% end %>
 
         <% if content_for?(:page_actions) %>
-        <div class="page-actions pl-0 pr-0 d-none d-lg-flex" data-hook="toolbar">
+          <div class="page-actions pl-0 pr-0 d-none d-lg-flex" data-hook="toolbar">
             <%= yield :page_actions %>
-        </div>
-        <div class="d-flex d-lg-none justify-content-end m-0 p-0">
-          <div class="btn-group" role="group" aria-label="Basic example">
-            <% if content_for?(:page_actions) %>
-            <button type="button"
-                    data-target="#actionsModal"
-                    data-toggle="modal"
-                    class="btn btn-outline-secondary">
-                    <%= svg_icon name: "items.svg", width: '16', height: '16' %>
-                    <span class="d-none d-sm-inline">
-                      <%= Spree.t('contextual_actions') %>
-                    </span>
-            </button>
-            <% end %>
-            <% if content_for?(:sidebar) %>
-            <button class="btn btn-outline-secondary"
-                    data-target="#optionsModal"
-                    data-toggle="modal"
-                    type="button"
-                    name="button">
-                    <span class="d-none d-sm-inline"><%= Spree.t('options') %> </span>
-                    <%= svg_icon name: "list.svg", width: '16', height: '16' %>
-            </button>
-            <% end %>
           </div>
-        </div>
+        <% end %>
+
+        <% if content_for?(:page_actions) || content_for?(:sidebar) %>
+          <div class="d-flex d-lg-none justify-content-end m-0 p-0">
+            <div class="btn-group" role="group" aria-label="Basic example">
+              <% if content_for?(:page_actions) %>
+                <button type="button"
+                        data-target="#actionsModal"
+                        data-toggle="modal"
+                        class="btn btn-outline-secondary shadow-none">
+                        <%= svg_icon name: "items.svg", width: '16', height: '16' %>
+                        <span class="d-none d-sm-inline">
+                          <%= Spree.t('contextual_actions') %>
+                        </span>
+                </button>
+              <% end %>
+              <% if content_for?(:sidebar) %>
+                <button class="btn btn-outline-secondary shadow-none"
+                        data-target="#optionsModal"
+                        data-toggle="modal"
+                        type="button"
+                        name="button">
+                        <span class="d-none d-sm-inline">
+                          <%= Spree.t('options') %>
+                        </span>
+                        <%= svg_icon name: "list.svg", width: '16', height: '16' %>
+                </button>
+              <% end %>
+            </div>
+          </div>
         <% end %>
       </div>
+
+      <% if content_for?(:page_tabs) %>
+      <div class="row">
+         <ul class="nav nav-tabs w-100 mt-4 col px-0">
+           <%= yield :page_tabs %>
+         </ul>
+      </div>
+     <% end %>
+
     </div>
   <% end %>
 </div>

--- a/backend/app/views/spree/admin/shared/_modals.html.erb
+++ b/backend/app/views/spree/admin/shared/_modals.html.erb
@@ -1,39 +1,35 @@
-<!-- Contextual Buttons Modal -->
+<!-- Contextual Actions Modal -->
 <% if content_for?(:page_actions) %>
   <div class="modal fade" id="actionsModal" tabindex="-1" role="dialog" aria-labelledby="actionsModalCenterTitle" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered" role="document">
       <div class="modal-content">
           <div class="modal-header">
            <h5 class="modal-title" id="exampleModalLabel"><%= Spree.t('contextual_actions') %></h5>
-           <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-             <span aria-hidden="true">&times;</span>
+           <button type="button" class="close btn shadow-none" data-dismiss="modal" aria-label="Close">
+             <%= svg_icon name: "close.svg", width: '18', height: '18' %>
            </button>
          </div>
           <div class="modal-body">
-            <aside id="sidebar" class="main-right-sidebar" data-hook>
-              <%= yield :page_actions %>
-            </aside>
+            <%= yield :page_actions %>
           </div>
       </div>
     </div>
   </div>
 <% end %>
 
-<!-- Contextual Sidebar Modal -->
+<!-- Contextual Options Modal -->
 <% if content_for?(:sidebar) %>
   <div class="modal fade" id="optionsModal" tabindex="-1" role="dialog" aria-labelledby="optionsModalCenterTitle" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered" role="document">
       <div class="modal-content">
           <div class="modal-header">
            <h5 class="modal-title" id="exampleModalLabel"><%= Spree.t('options') %></h5>
-           <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-             <span aria-hidden="true">&times;</span>
+           <button type="button" class="close btn shadow-none" data-dismiss="modal" aria-label="Close">
+             <%= svg_icon name: "close.svg", width: '18', height: '18' %>
            </button>
          </div>
           <div class="modal-body">
-            <aside id="sidebar" class="main-right-sidebar" data-hook>
-              <%= yield :sidebar %>
-            </aside>
+            <%= yield :sidebar %>
           </div>
       </div>
     </div>

--- a/backend/app/views/spree/admin/shared/_modals.html.erb
+++ b/backend/app/views/spree/admin/shared/_modals.html.erb
@@ -4,7 +4,7 @@
     <div class="modal-dialog modal-dialog-centered" role="document">
       <div class="modal-content">
           <div class="modal-header">
-           <h5 class="modal-title" id="exampleModalLabel"><%= Spree.t('action') %></h5>
+           <h5 class="modal-title" id="exampleModalLabel"><%= Spree.t('contextual_actions') %></h5>
            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
              <span aria-hidden="true">&times;</span>
            </button>

--- a/backend/app/views/spree/admin/shared/_modals.html.erb
+++ b/backend/app/views/spree/admin/shared/_modals.html.erb
@@ -1,0 +1,41 @@
+<!-- Contextual Buttons Modal -->
+<% if content_for?(:page_actions) %>
+  <div class="modal fade" id="actionsModal" tabindex="-1" role="dialog" aria-labelledby="actionsModalCenterTitle" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+      <div class="modal-content">
+          <div class="modal-header">
+           <h5 class="modal-title" id="exampleModalLabel"><%= Spree.t('action') %></h5>
+           <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+             <span aria-hidden="true">&times;</span>
+           </button>
+         </div>
+          <div class="modal-body">
+            <aside id="sidebar" class="main-right-sidebar" data-hook>
+              <%= yield :page_actions %>
+            </aside>
+          </div>
+      </div>
+    </div>
+  </div>
+<% end %>
+
+<!-- Contextual Sidebar Modal -->
+<% if content_for?(:sidebar) %>
+  <div class="modal fade" id="optionsModal" tabindex="-1" role="dialog" aria-labelledby="optionsModalCenterTitle" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+      <div class="modal-content">
+          <div class="modal-header">
+           <h5 class="modal-title" id="exampleModalLabel"><%= Spree.t('options') %></h5>
+           <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+             <span aria-hidden="true">&times;</span>
+           </button>
+         </div>
+          <div class="modal-body">
+            <aside id="sidebar" class="main-right-sidebar" data-hook>
+              <%= yield :sidebar %>
+            </aside>
+          </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/backend/app/views/spree/admin/shared/_sidebar.html.erb
+++ b/backend/app/views/spree/admin/shared/_sidebar.html.erb
@@ -1,10 +1,3 @@
-
-<% if content_for?(:page_actions) %>
-  <div class="page-actions d-lg-none col-12 py-4 px-0 <% if content_for?(:sidebar) %>pb-3<% end %> text-center" data-hook="toolbar">
-    <%= yield :page_actions %>
-  </div>
-<% end %>
-
 <% if content_for?(:sidebar) %>
   <aside id="sidebar" class="main-right-sidebar px-2" data-hook>
     <%= yield :sidebar %>

--- a/backend/app/views/spree/layouts/admin.html.erb
+++ b/backend/app/views/spree/layouts/admin.html.erb
@@ -71,7 +71,7 @@
               <%# Inner aside                                     %>
               <%#-------------------------------------------------%>
               <% if content_for?(:sidebar) || content_for?(:page_actions) %>
-                <div class="col-12 col-lg-3 m-0 py-4 py-sm-0" id="contextualSideMenu">
+                <div class="col-12 col-lg-3 m-0 py-4 py-lg-0" id="contextualSideMenu">
                   <%= render partial: 'spree/admin/shared/sidebar' %>
                 </div>
               <% end %>

--- a/backend/app/views/spree/layouts/admin.html.erb
+++ b/backend/app/views/spree/layouts/admin.html.erb
@@ -24,10 +24,7 @@
     <%#-------------------------------------------------%>
     <%# Main content                                    %>
     <%#-------------------------------------------------%>
-    <div id="wrapper" class="container-fluid
-                            <% if content_for?(:sidebar) || content_for?(:page_actions) %>
-                             mb-4 mb-lg-0
-                            <% end %>">
+    <div id="wrapper" class="container-fluid mb-4 mb-lg-0">
       <div class="row">
 
         <%#-------------------------------------------------%>

--- a/backend/app/views/spree/layouts/admin.html.erb
+++ b/backend/app/views/spree/layouts/admin.html.erb
@@ -77,17 +77,16 @@
               <% end %>
             </div>
 
+            <%#-------------------------------------------------%>
+            <%# Modals for content on smaller screen sizes      %>
+            <%#-------------------------------------------------%>
+            <%= render partial: 'spree/admin/shared/modals' %>
+
           </div>
         </main>
       </div>
     </div>
-    <% if content_for?(:sidebar) || content_for?(:page_actions) %>
-      <button id="contextual-menu-toggle"
-              type="button"
-              class="btn btn-primary btn-circle d-lg-none">
-              <%= svg_icon name: "chevron-down.svg", width: '22', height: '22' %>
-      </button>
-    <% end %>
+
     <%#-------------------------------------------------%>
     <%# Insert footer scripts here                      %>
     <%#-------------------------------------------------%>

--- a/backend/app/views/spree/layouts/admin.html.erb
+++ b/backend/app/views/spree/layouts/admin.html.erb
@@ -70,8 +70,8 @@
               <%#-------------------------------------------------%>
               <%# Inner aside                                     %>
               <%#-------------------------------------------------%>
-              <% if content_for?(:sidebar) || content_for?(:page_actions) %>
-                <div class="col-12 col-lg-3 m-0 py-4 py-lg-0" id="contextualSideMenu">
+              <% if content_for?(:sidebar) %>
+                <div class="d-none d-lg-block col-lg-3 m-0 py-0">
                   <%= render partial: 'spree/admin/shared/sidebar' %>
                 </div>
               <% end %>

--- a/backend/spec/features/admin/orders/adjustments_spec.rb
+++ b/backend/spec/features/admin/orders/adjustments_spec.rb
@@ -27,7 +27,8 @@ describe 'Adjustments', type: :feature do
 
     visit spree.admin_orders_path
     within_row(1) { click_on order.number }
-    click_on 'Adjustments'
+
+    within('#sidebar') { click_on 'Adjustments'}  
   end
 
   after do

--- a/backend/spec/features/admin/orders/new_order_spec.rb
+++ b/backend/spec/features/admin/orders/new_order_spec.rb
@@ -17,7 +17,7 @@ describe 'New Order', type: :feature do
   end
 
   it 'does check if you have a billing address before letting you add shipments' do
-    click_on 'Shipments'
+    within('#sidebar') { click_on 'Shipments' }
     expect(page).to have_content 'Please fill in customer info'
     expect(page).to have_current_path(spree.edit_admin_order_customer_path(Spree::Order.last))
   end
@@ -40,8 +40,8 @@ describe 'New Order', type: :feature do
 
     expect(page).to have_current_path(spree.admin_order_payments_path(Spree::Order.last))
     click_icon 'capture'
+    within('#sidebar') { click_on 'Shipments' }
 
-    click_on 'Shipments'
     click_on 'Ship'
 
     expect(page).to have_content('shipped')
@@ -67,7 +67,7 @@ describe 'New Order', type: :feature do
       fill_in_address
       click_on 'Update'
 
-      click_on 'Shipments'
+      within('#sidebar') { click_on 'Shipments' }
 
       within('.stock-contents') do
         expect(page).to have_content(product.name)
@@ -133,7 +133,7 @@ describe 'New Order', type: :feature do
       fill_in_address
       click_on 'Update'
 
-      click_on 'Shipments'
+      within('#sidebar') { click_on 'Shipments' }
       select2 product.name, from: Spree.t(:name_or_sku), search: true
       click_icon :add
       expect(page).not_to have_content('Your order is empty')

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -17,7 +17,7 @@ describe 'Payments', type: :feature, js: true do
 
     before do
       visit spree.edit_admin_order_path(order)
-      click_link 'Payments'
+      within('#sidebar') { click_on 'Payments' }
     end
 
     # Regression tests for #1453
@@ -93,7 +93,7 @@ describe 'Payments', type: :feature, js: true do
       within find('#contentHeader') do
         click_on 'New Payment'
       end
-      
+
       expect(page).to have_content('You cannot create a payment for an order without any payment methods defined.')
       expect(page).to have_content('Please define some payment methods first.')
     end

--- a/backend/spec/features/admin/products/edit/properties_spec.rb
+++ b/backend/spec/features/admin/products/edit/properties_spec.rb
@@ -18,7 +18,7 @@ describe 'Product Properties', type: :feature, js: true do
       click_button 'Update'
 
       within('#sidebar') { click_link 'Properties' }
-      expect(page).to have_content('Add Product Properties')
+      expect(page).to have_content('Add Properties')
       expect(page).to have_content('SHOW PROPERTY')
       expect(page).to have_selector("input[value='Material']")
       expect(page).to have_selector("input[value='Leather']")

--- a/backend/spec/features/admin/store_credits_spec.rb
+++ b/backend/spec/features/admin/store_credits_spec.rb
@@ -18,7 +18,7 @@ describe 'Store credits admin', type: :feature do
 
     it 'is on the store credits page' do
       click_link store_credit.user.email
-      click_link 'Store Credits'
+      within('#sidebar') { click_on 'Store Credits' }
       expect(page).to have_current_path(spree.admin_user_store_credits_path(store_credit.user))
 
       store_credit_table = page.find('table', match: :first)
@@ -35,7 +35,7 @@ describe 'Store credits admin', type: :feature do
       visit spree.admin_path
       click_link 'Users'
       click_link store_credit.user.email
-      click_link 'Store Credits'
+      within('#sidebar') { click_on 'Store Credits' }
       allow_any_instance_of(Spree::Admin::StoreCreditsController).to receive(:try_spree_current_user).and_return(admin_user)
     end
 
@@ -62,7 +62,7 @@ describe 'Store credits admin', type: :feature do
         within find('#contentHeader') do
           click_link 'Add Store Credit'
         end
-        
+
         page.fill_in 'store_credit_amount', with: '100.00'
         select 'EUR', from: 'store_credit_currency'
         select 'Exchange', from: 'store_credit_category_id'
@@ -86,7 +86,7 @@ describe 'Store credits admin', type: :feature do
       visit spree.admin_path
       click_link 'Users'
       click_link store_credit.user.email
-      click_link 'Store Credits'
+      within('#sidebar') { click_on 'Store Credits' }
       allow_any_instance_of(Spree::Admin::StoreCreditsController).to receive(:try_spree_current_user).and_return(admin_user)
     end
 
@@ -107,7 +107,7 @@ describe 'Store credits admin', type: :feature do
       visit spree.admin_path
       click_link 'Users'
       click_link store_credit.user.email
-      click_link 'Store Credits'
+      within('#sidebar') { click_on 'Store Credits' }
       allow_any_instance_of(Spree::Admin::StoreCreditsController).to receive(:try_spree_current_user).and_return(admin_user)
     end
 
@@ -126,7 +126,7 @@ describe 'Store credits admin', type: :feature do
       click_link store_credit.user.email
       store_credit.user.destroy
       allow(Spree.user_class).to receive(:find_by).and_return(nil)
-      click_link 'Store Credits'
+      within('#sidebar') { click_on 'Store Credits' }
       allow_any_instance_of(Spree::Admin::StoreCreditsController).to receive(:try_spree_current_user).and_return(admin_user)
     end
 

--- a/backend/spec/features/admin/users_spec.rb
+++ b/backend/spec/features/admin/users_spec.rb
@@ -157,7 +157,7 @@ describe 'Users', type: :feature do
     end
 
     it 'can edit user shipping address' do
-      click_link 'Addresses'
+      within('#sidebar') { click_link 'Addresses' }
 
       within('#admin_user_edit_addresses') do
         fill_in 'user_ship_address_attributes_address1', with: '1313 Mockingbird Ln'
@@ -169,7 +169,7 @@ describe 'Users', type: :feature do
     end
 
     it 'can edit user billing address' do
-      click_link 'Addresses'
+      within('#sidebar') { click_link 'Addresses' }
 
       within('#admin_user_edit_addresses') do
         fill_in 'user_bill_address_attributes_address1', with: '1313 Mockingbird Ln'
@@ -181,8 +181,8 @@ describe 'Users', type: :feature do
     end
 
     it 'can set shipping address to be the same as billing address' do
-      click_link 'Addresses'
-
+      within('#sidebar') { click_link 'Addresses' }
+      
       within('#admin_user_edit_addresses') do
         find('#user_use_billing').click
         click_button 'Update'

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -701,6 +701,7 @@ en:
     could_not_create_customer_return: Could not create customer return
     could_not_create_stock_movement: There was a problem saving this stock movement. Please try again.
     count_on_hand: Count On Hand
+    contextual_actions: Actions
     countries: Countries
     country: Country
     country_based: Country Based

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -481,7 +481,7 @@ en:
     add_one: Add One
     add_option_value: Add Option Value
     add_product: Add Product
-    add_product_properties: Add Product Properties
+    add_product_properties: Add Properties
     add_rule_of_type: Add rule of type
     add_state: Add State
     add_stock: Add Stock


### PR DESCRIPTION
Hi @damianlegawiec 

Just an idea to use a more bootstrap style setup.

Rather than using the round floating button to trigger a dropdown menu, you could use responsive buttons in the content header that trigger modals?

Any preferences? If you're not interested in this PR I'll shelve it, but thought it worth considering, if you like this version I’m happy to go ahead and fix the tests and work on this some more.

<img width="405" alt="Screenshot 2020-06-30 at 21 17 34" src="https://user-images.githubusercontent.com/1240766/86173456-ec38aa80-bb17-11ea-928a-af403bf15873.png">

<img width="640" alt="Screenshot 2020-06-30 at 21 17 08" src="https://user-images.githubusercontent.com/1240766/86173445-e5aa3300-bb17-11ea-88cd-cd0730dc91ad.png">