### PR TITLE
Small Admin Fixes

### DIFF
--- a/backend/app/views/spree/admin/images/index.html.erb
+++ b/backend/app/views/spree/admin/images/index.html.erb
@@ -1,9 +1,7 @@
 <%= render partial: 'spree/admin/shared/product_tabs', locals: { current: :images } %>
 
 <% content_for :page_actions do %>
-  <div class="page-actions col-6 pr-0" data-hook="toolbar">
-    <%= yield :page_actions %>
-  </div>
+  <%= yield :page_actions %>
   <%= product_preview_link(@product) %>
   <%= button_link_to(Spree.t(:new_image), spree.new_admin_product_image_url(@product), { class: "btn-success", icon: 'add.svg', id: 'new_image_link' }) if can? :create, Spree::Image %>
 <% end %>

--- a/backend/app/views/spree/admin/prices/index.html.erb
+++ b/backend/app/views/spree/admin/prices/index.html.erb
@@ -1,9 +1,7 @@
 <%= render partial: 'spree/admin/shared/product_tabs', locals: { current: :prices } %>
 
 <% content_for :page_actions do %>
-  <div class="page-actions col-6 pr-0" data-hook="toolbar">
-    <%= yield :page_actions %>
-  </div>
+  <%= yield :page_actions %>
   <%= product_preview_link(@product) %>
 <% end %>
 

--- a/backend/app/views/spree/admin/shared/_content_header.html.erb
+++ b/backend/app/views/spree/admin/shared/_content_header.html.erb
@@ -3,7 +3,7 @@
     <div id="contentHeader" class="content-header col <%= "with-page-tabs" if content_for?(:page_tabs) %> page-header">
       <div class="row align-items-center  <%= if content_for?(:page_tabs) then "pb-0" else "border-bottom" end %>">
         <% if content_for?(:page_title) %>
-          <h1 class="contextual-title pr-0 pl-0 mb-0 col-12 col-lg-<%= content_for?(:page_actions) ? '6' : '12'  %>">
+          <h1 class="contextual-title px-0 mb-0 col">
             <%= yield :page_title %>
             <% if content_for?(:page_title_small) %>
               <small><%= yield :page_title_small %></small>
@@ -12,17 +12,19 @@
         <% end %>
 
         <% if content_for?(:page_actions) %>
-          <div class="page-actions pl-0 col-6 pr-0 d-none d-lg-block" data-hook="toolbar">
+          <div class="page-actions pl-0 pr-0 d-none d-lg-flex" data-hook="toolbar">
             <%= yield :page_actions %>
           </div>
         <% end %>
-
-        <% if content_for?(:page_tabs) %>
-          <ul class="nav nav-tabs w-100 mt-4">
+      </div>
+      
+      <% if content_for?(:page_tabs) %>
+        <div class="row">
+          <ul class="nav nav-tabs w-100 mt-4 px-0">
             <%= yield :page_tabs %>
           </ul>
-        <% end %>
-      </div>
+        </div>
+      <% end %>
     </div>
   <% end %>
 </div>

--- a/backend/app/views/spree/admin/shared/_sidebar.html.erb
+++ b/backend/app/views/spree/admin/shared/_sidebar.html.erb
@@ -1,6 +1,6 @@
 
 <% if content_for?(:page_actions) %>
-  <div class="page-actions d-lg-none col-12 py-4 px-0 <% if content_for?(:sidebar) %>pb-3<% end %> text-center" data-hook="toolbar">
+  <div class="page-actions d-lg-none col-12 px-0 <% if content_for?(:sidebar) %>pb-3<% end %> text-center" data-hook="toolbar">
     <%= yield :page_actions %>
   </div>
 <% end %>

--- a/backend/app/views/spree/layouts/admin.html.erb
+++ b/backend/app/views/spree/layouts/admin.html.erb
@@ -71,7 +71,7 @@
               <%# Inner aside                                     %>
               <%#-------------------------------------------------%>
               <% if content_for?(:sidebar) || content_for?(:page_actions) %>
-                <div class="col-12 col-lg-3 m-0 p-4" id="contextualSideMenu">
+                <div class="col-12 col-lg-3 m-0 p-4 p-lg-0" id="contextualSideMenu">
                   <%= render partial: 'spree/admin/shared/sidebar' %>
                 </div>
               <% end %>

--- a/backend/app/views/spree/layouts/admin.html.erb
+++ b/backend/app/views/spree/layouts/admin.html.erb
@@ -71,7 +71,7 @@
               <%# Inner aside                                     %>
               <%#-------------------------------------------------%>
               <% if content_for?(:sidebar) || content_for?(:page_actions) %>
-                <div class="col-12 col-lg-3 m-0 py-4 py-sm-0" id="contextualSideMenu">
+                <div class="col-12 col-lg-3 m-0 p-4" id="contextualSideMenu">
                   <%= render partial: 'spree/admin/shared/sidebar' %>
                 </div>
               <% end %>


### PR DESCRIPTION
- In Content Header use class `col` on the h1 tag and `d-lg-flex` on the page actions container, this makes better use of screen real estate for the buttons and the h1 text.
- Fix no bottom padding on contextual options menu.
- Fix nesting of duplicate `  <div class="page-actions pl-0 pr-0 d-none d-lg-flex" data-hook="toolbar">` found in other files getting need inside itself.
