### PR TITLE
Use a single button in the content header to trigger the dropdown.

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_buttons.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_buttons.scss
@@ -10,22 +10,39 @@
 
 .btn {
   text-align: center;
-  margin:2.5px;
-
+  margin: 2px;
   .ship {
     color: #fff;
   }
   svg {
-    margin-bottom: 3px;
+    margin-bottom: 3px !important;
   }
-
 }
 
-input#image_attachment input:matches([type="button"],
-                                     [type="submit"],
-                                     [type="reset"]),
-                                     input[type="file"]::-webkit-file-upload-button,
-                                     button {
-  @extend .btn ;
-  @extend .btn-outline-secondary ;
+input#image_attachment
+input:matches([type="button"],
+              [type="submit"],
+              [type="reset"]),
+              input[type="file"]::-webkit-file-upload-button,
+              button {
+  display: inline-block;
+  font-weight: 400;
+  color: $success;
+  text-align: center;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  background-color: transparent;
+  border: 1px solid transparent;
+  padding: 0.375rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  border-radius: 2px;
+  transition: color 0.15s ease-in-out,
+  background-color 0.15s ease-in-out,
+  border-color 0.15s ease-in-out,
+  box-shadow 0.15s ease-in-out;
+  @include button-variant($success, $success, $success );
 }

--- a/backend/app/assets/stylesheets/spree/backend/components/_buttons.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_buttons.scss
@@ -20,3 +20,12 @@
   }
 
 }
+
+input#image_attachment input:matches([type="button"],
+                                     [type="submit"],
+                                     [type="reset"]),
+                                     input[type="file"]::-webkit-file-upload-button,
+                                     button {
+  @extend .btn ;
+  @extend .btn-outline-secondary ;
+}

--- a/backend/app/assets/stylesheets/spree/backend/components/_buttons.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_buttons.scss
@@ -20,16 +20,3 @@
   }
 
 }
-.custom-control-input:checked ~ .custom-control-label::before {
-  color: $white;
-  border-color: $green;
-  background-color: $green;
-}
-
-.btn-circle {
-  width: 50px;
-  height: 50px;
-  padding: 14px 10px;
-  border-radius: 25px;
-  text-align: center;
-}

--- a/backend/app/assets/stylesheets/spree/backend/components/_buttons.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_buttons.scss
@@ -19,30 +19,17 @@
   }
 }
 
-input#image_attachment
-input:matches([type="button"],
-              [type="submit"],
-              [type="reset"]),
-              input[type="file"]::-webkit-file-upload-button,
-              button {
-  display: inline-block;
-  font-weight: 400;
-  color: $success;
-  text-align: center;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  background-color: transparent;
-  border: 1px solid transparent;
+input#image_attachment >
+input[type="button"],
+input[type="file"]::-webkit-file-upload-button {
+  @include border-radius();
+  border: 1px solid;
+  background-color: white;
+  color: $secondary;
+  border-color: $secondary;
   padding: 0.375rem 0.75rem;
-  font-size: 1rem;
-  line-height: 1.5;
-  border-radius: 2px;
-  transition: color 0.15s ease-in-out,
-  background-color 0.15s ease-in-out,
-  border-color 0.15s ease-in-out,
-  box-shadow 0.15s ease-in-out;
-  @include button-variant($success, $success, $success );
+  &:hover {
+    color: white;
+    background-color: $secondary;
+  }
 }

--- a/backend/app/assets/stylesheets/spree/backend/components/_buttons.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_buttons.scss
@@ -15,7 +15,7 @@
     color: #fff;
   }
   svg {
-    margin-bottom: 3px !important;
+    margin-bottom: 3px;
   }
 }
 

--- a/backend/app/assets/stylesheets/spree/backend/components/_filters.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_filters.scss
@@ -1,7 +1,5 @@
 #table-filter {
   display: none;
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
   margin-top: 20px;
 }
 

--- a/backend/app/assets/stylesheets/spree/backend/components/_navbar.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_navbar.scss
@@ -7,10 +7,6 @@
     a:hover {
       text-decoration: none;
     }
-    svg{
-      margin-bottom: 0;
-    }
-
     .btn {
       &:hover,
       &:focus {

--- a/backend/app/assets/stylesheets/spree/backend/components/_sidebar.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_sidebar.scss
@@ -129,11 +129,11 @@ body.contextualSideMenu-open #contextual-menu-toggle {
     z-index: 999;
     margin-top: 50px;
     height: calc(100% - 50px);
-    transition: 0;
+    transition: none;
     body.sidebar-open {
       aside#main-sidebar {
         left:0;
-        transition: 0;
+        transition: none;
       }
     }
   }

--- a/backend/app/assets/stylesheets/spree/backend/components/_sidebar.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_sidebar.scss
@@ -65,9 +65,7 @@ ul.nav-sidebar {
     }
   }
 }
-#sidebar a svg {
-  margin-bottom: 3px;
-}
+
 #contextualSideMenu {
   max-height: 85vh;
   overflow-x: scroll;
@@ -96,6 +94,10 @@ body.contextualSideMenu-open #contextual-menu-toggle {
     transform:rotate(180deg);
     transition: transform .3s ease-in-out;
   }
+}
+
+#sidebar a svg {
+  margin-bottom: 3px;
 }
 
 .contextual-title {

--- a/backend/app/assets/stylesheets/spree/backend/components/_sidebar.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_sidebar.scss
@@ -84,6 +84,10 @@ ul.nav-sidebar {
   }
 }
 
+#sidebar a svg {
+  margin-bottom: 3px;
+}
+
 body.contextualSideMenu-open #contextualSideMenu {
   top: 0;
   transition: .3s ease-in-out;
@@ -96,9 +100,7 @@ body.contextualSideMenu-open #contextual-menu-toggle {
   }
 }
 
-#sidebar a svg {
-  margin-bottom: 3px;
-}
+
 
 .contextual-title {
   font-size:1.25rem;

--- a/backend/app/assets/stylesheets/spree/backend/components/_sidebar.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_sidebar.scss
@@ -65,7 +65,9 @@ ul.nav-sidebar {
     }
   }
 }
-
+#sidebar a svg {
+  margin-bottom: 3px;
+}
 #contextualSideMenu {
   max-height: 85vh;
   overflow-x: scroll;

--- a/backend/app/assets/stylesheets/spree/backend/components/_sidebar.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_sidebar.scss
@@ -100,12 +100,9 @@ body.contextualSideMenu-open #contextual-menu-toggle {
   }
 }
 
-
-
 .contextual-title {
   font-size:1.25rem;
 }
-
 
 @include media-breakpoint-up(sm) {
   aside#main-sidebar {

--- a/backend/app/assets/stylesheets/spree/backend/components/_sidebar.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_sidebar.scss
@@ -83,19 +83,19 @@ ul.nav-sidebar {
 #contextual-menu-toggle {
   & svg {
     transform:rotate(0deg);
-    transition: .3s ease-in-out;
+    transition: transform .3s ease-in-out;
   }
 }
 
 body.contextualSideMenu-open #contextualSideMenu {
-    top: 0;
-    transition: .3s ease-in-out;
+  top: 0;
+  transition: .3s ease-in-out;
 }
 
 body.contextualSideMenu-open #contextual-menu-toggle {
   svg {
-      transform:rotate(180deg);
-      transition: .3s ease-in-out;
+    transform:rotate(180deg);
+    transition: transform .3s ease-in-out;
   }
 }
 

--- a/backend/app/assets/stylesheets/spree/backend/components/_sidebar.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_sidebar.scss
@@ -62,9 +62,6 @@ ul.nav-sidebar {
           transition: .3s ease-in-out;
         }
       }
-      > svg {
-        margin-bottom: 0;
-      }
     }
   }
 }

--- a/backend/app/assets/stylesheets/spree/backend/components/_sidebar.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_sidebar.scss
@@ -81,14 +81,6 @@ ul.nav-sidebar {
 }
 
 #contextual-menu-toggle {
-  position: fixed;
-  bottom: 15px;
-  right:15px;
-  border: none;
-  box-shadow: 0px 5px 5px -3px rgba(0, 0, 0, 0.2),
-              0px 8px 10px 1px rgba(0, 0, 0, 0.14),
-              0px 3px 14px 2px rgba(0,0,0,.12);
-
   & svg {
     transform:rotate(0deg);
     transition: .3s ease-in-out;
@@ -101,7 +93,6 @@ body.contextualSideMenu-open #contextualSideMenu {
 }
 
 body.contextualSideMenu-open #contextual-menu-toggle {
-  z-index: 1041;
   svg {
       transform:rotate(180deg);
       transition: .3s ease-in-out;
@@ -127,24 +118,24 @@ body.contextualSideMenu-open #contextual-menu-toggle {
 
 @include media-breakpoint-up(lg) {
 
-  #contextualSideMenu{
+  #contextualSideMenu {
     position: relative;
     border: none;
     height: auto;
     z-index: 1000;
   }
-    aside#main-sidebar {
-      left: 0;
-      z-index: 999;
-      margin-top: 50px;
-      height: calc(100% - 50px);
-      transition: 0;
-      body.sidebar-open {
-        aside#main-sidebar {
-          left:0;
-          transition: 0;
-        }
+  aside#main-sidebar {
+    left: 0;
+    z-index: 999;
+    margin-top: 50px;
+    height: calc(100% - 50px);
+    transition: 0;
+    body.sidebar-open {
+      aside#main-sidebar {
+        left:0;
+        transition: 0;
       }
+    }
   }
 
   .contextual-title {

--- a/backend/app/assets/stylesheets/spree/backend/components/_taxon_products_view.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_taxon_products_view.scss
@@ -13,6 +13,7 @@
     }
   }
 }
+
 ul#taxon_products, tbody#sortVert {
   -webkit-user-select: none;
   -moz-user-select: none;

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_jquery_ui.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_jquery_ui.scss
@@ -11,6 +11,7 @@
   border-color: $input-border-color;
   width: auto;
   padding: 20px;
+  z-index: 1041 !important;
 
   &.ui-corner-all {
     border-radius: $border-radius;

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
@@ -175,3 +175,8 @@ select.select2[required="required"] {
   opacity:0;
   filter:alpha(opacity=0);
 }
+
+i.js-delete-filter {
+  width: 0.9rem;
+  height: 0.9rem;
+}

--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -247,7 +247,7 @@ module Spree
         options[:class] = 'sidebar-menu-item d-block w-100'
         options[:class] << ' selected' if is_selected
         content_tag(:li, options) do
-          link_to(link_text, url, class: "#{'text-success' if is_selected} py-1 px-3 d-block sidebar-submenu-item")
+          link_to(link_text, url, class: "#{'text-success' if is_selected} sidebar-submenu-item w-100 py-2 py-md-1 pl-3 d-block")
         end
       end
 

--- a/backend/app/helpers/spree/admin/orders_helper.rb
+++ b/backend/app/helpers/spree/admin/orders_helper.rb
@@ -16,7 +16,7 @@ module Spree
             data: { confirm: Spree.t(:order_sure_want_to, event: label) }
           )
         end
-        safe_join(links, '&nbsp;'.html_safe)
+        safe_join(links, ''.html_safe)
       end
 
       def line_item_shipment_price(line_item, quantity)

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -19,7 +19,7 @@
           <div class="form-group">
             <%= label_tag :q_created_at_gt, Spree.t(:date_range) %>
             <div class="row pb-0">
-              <div class="col-6">
+              <div class="col-6 pr-1 pr-md-3">
                 <div class="input-group">
                   <%= f.text_field :created_at_gt,
                     class: 'datepicker datepicker-from form-control js-filterable',
@@ -33,7 +33,7 @@
                 </div>
 
               </div>
-              <div class="col-6">
+              <div class="col-6 pl-1 pl-md-3">
                 <div class="input-group">
                   <%= f.text_field :created_at_lt,
                     class: 'datepicker datepicker-to form-control js-filterable',

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -19,7 +19,7 @@
           <div class="form-group">
             <%= label_tag :q_created_at_gt, Spree.t(:date_range) %>
             <div class="row pb-0">
-              <div class="col-12 col-lg-6">
+              <div class="col-6">
                 <div class="input-group">
                   <%= f.text_field :created_at_gt,
                     class: 'datepicker datepicker-from form-control js-filterable',
@@ -33,7 +33,7 @@
                 </div>
 
               </div>
-              <div class="col-12 col-lg-6">
+              <div class="col-6">
                 <div class="input-group">
                   <%= f.text_field :created_at_lt,
                     class: 'datepicker datepicker-to form-control js-filterable',

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -19,7 +19,7 @@
           <div class="form-group">
             <%= label_tag :q_created_at_gt, Spree.t(:date_range) %>
             <div class="row pb-0">
-              <div class="col-6 pr-1 pr-md-3">
+              <div class="col-12 col-md-6 mb-3 mb-md-0">
                 <div class="input-group">
                   <%= f.text_field :created_at_gt,
                     class: 'datepicker datepicker-from form-control js-filterable',
@@ -33,7 +33,7 @@
                 </div>
 
               </div>
-              <div class="col-6 pl-1 pl-md-3">
+              <div class="col-12 col-md-6 mt-3 mt-md-0">
                 <div class="input-group">
                   <%= f.text_field :created_at_lt,
                     class: 'datepicker datepicker-to form-control js-filterable',

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -65,7 +65,14 @@
         <%= f.field_container :available_on, class: ['form-group'] do %>
           <%= f.label :available_on, Spree.t(:available_on) %>
           <%= f.error_message_on :available_on %>
+          <div class="input-group">
           <%= f.text_field :available_on, value: datepicker_field_value(@product.available_on), class: 'datepicker form-control' %>
+          <div class="input-group-append">
+            <span class="input-group-text">
+              <%= svg_icon name: "calendar.svg", width: '18', height: '18' %>
+            </span>
+          </div>
+        </div>
         <% end %>
       </div>
 
@@ -73,7 +80,14 @@
         <%= f.field_container :discontinue_on, class: ['form-group'] do %>
           <%= f.label :discontinue_on, Spree.t(:discontinue_on) %>
           <%= f.error_message_on :discontinue_on %>
+          <div class="input-group">
           <%= f.text_field :discontinue_on, value: datepicker_field_value(@product.discontinue_on), class: 'datepicker form-control' %>
+          <div class="input-group-append">
+            <span class="input-group-text">
+              <%= svg_icon name: "calendar.svg", width: '18', height: '18' %>
+            </span>
+          </div>
+        </div>
         <% end %>
       </div>
 

--- a/backend/app/views/spree/admin/products/new.html.erb
+++ b/backend/app/views/spree/admin/products/new.html.erb
@@ -43,7 +43,14 @@
         <%= f.field_container :available_on, class: ['form-group'] do %>
           <%= f.label :available_on, Spree.t(:available_on) %>
           <%= f.error_message_on :available_on %>
+          <div class="input-group">
           <%= f.text_field :available_on, class: 'datepicker form-control' %>
+          <div class="input-group-append">
+            <span class="input-group-text">
+              <%= svg_icon name: "calendar.svg", width: '18', height: '18' %>
+            </span>
+          </div>
+        </div>
         <% end %>
       </div>
 

--- a/backend/app/views/spree/admin/shared/_content_header.html.erb
+++ b/backend/app/views/spree/admin/shared/_content_header.html.erb
@@ -2,6 +2,7 @@
   <% if content_for?(:page_title) || content_for?(:page_actions) %>
     <div id="contentHeader" class="content-header col <%= "with-page-tabs" if content_for?(:page_tabs) %> page-header">
       <div class="row align-items-center  <%= if content_for?(:page_tabs) then "pb-0" else "border-bottom" end %>">
+
         <% if content_for?(:page_title) %>
           <h1 class="contextual-title px-0 mb-0 col">
             <%= yield :page_title %>
@@ -16,8 +17,21 @@
             <%= yield :page_actions %>
           </div>
         <% end %>
+
+        <% if content_for?(:page_actions) || content_for?(:sidebar) %>
+          <div class="d-flex d-lg-none justify-content-end m-0 p-0">
+            <button type="button"
+                    id="contextual-menu-toggle"
+                    class="btn btn-outline-secondary shadow-none">
+                    <span class="d-none d-sm-inline">
+                      <%= Spree.t('more') %>
+                    </span>
+                    <%= svg_icon name: "chevron-down.svg", width: '16', height: '16' %>
+            </button>
+          </div>
+        <% end %>
       </div>
-      
+
       <% if content_for?(:page_tabs) %>
         <div class="row">
           <ul class="nav nav-tabs w-100 mt-4 px-0">
@@ -25,6 +39,7 @@
           </ul>
         </div>
       <% end %>
+
     </div>
   <% end %>
 </div>

--- a/backend/app/views/spree/admin/shared/_report_order_criteria.html.erb
+++ b/backend/app/views/spree/admin/shared/_report_order_criteria.html.erb
@@ -2,11 +2,25 @@
   <div class="form-group date-range-filter">
     <%= label_tag nil, Spree.t(:date_range) %>
     <div class="date-range-filter row">
-      <div class="col-md-6">
-        <%= s.text_field :completed_at_gt, class: 'datepicker datepicker-from form-control', value: datepicker_field_value(params[:q][:completed_at_gt]) %>
+      <div class="col-6">
+        <div class="input-group">
+          <%= s.text_field :completed_at_gt, class: 'datepicker datepicker-from form-control', value: datepicker_field_value(params[:q][:completed_at_gt]) %>
+          <div class="input-group-append">
+            <span class="input-group-text">
+               <%= svg_icon name: "calendar.svg", width: '18', height: '18' %>
+            </span>
+          </div>
+        </div>
       </div>
-      <div class="col-md-6">
+      <div class="col-6">
+        <div class="input-group">
         <%= s.text_field :completed_at_lt, class: 'datepicker datepicker-to form-control', value: datepicker_field_value(params[:q][:completed_at_lt]) %>
+        <div class="input-group-append">
+          <span class="input-group-text">
+             <%= svg_icon name: "calendar.svg", width: '18', height: '18' %>
+          </span>
+        </div>
+      </div>
     </div>
     </div>
   </div>

--- a/backend/app/views/spree/admin/shared/_report_order_criteria.html.erb
+++ b/backend/app/views/spree/admin/shared/_report_order_criteria.html.erb
@@ -2,7 +2,7 @@
   <div class="form-group date-range-filter">
     <%= label_tag nil, Spree.t(:date_range) %>
     <div class="date-range-filter row">
-      <div class="col-6 pr-1 pr-md-3">
+      <div class="col-12 col-md-6 mb-3 mb-md-0">
         <div class="input-group">
           <%= s.text_field :completed_at_gt, class: 'datepicker datepicker-from form-control', value: datepicker_field_value(params[:q][:completed_at_gt]) %>
           <div class="input-group-append">
@@ -12,7 +12,7 @@
           </div>
         </div>
       </div>
-      <div class="col-6 pl-1 pl-md-3">
+      <div class="col-12 col-md-6 mt-3 mt-md-0">
         <div class="input-group">
         <%= s.text_field :completed_at_lt, class: 'datepicker datepicker-to form-control', value: datepicker_field_value(params[:q][:completed_at_lt]) %>
         <div class="input-group-append">

--- a/backend/app/views/spree/admin/shared/_report_order_criteria.html.erb
+++ b/backend/app/views/spree/admin/shared/_report_order_criteria.html.erb
@@ -2,7 +2,7 @@
   <div class="form-group date-range-filter">
     <%= label_tag nil, Spree.t(:date_range) %>
     <div class="date-range-filter row">
-      <div class="col-6">
+      <div class="col-6 pr-1 pr-md-3">
         <div class="input-group">
           <%= s.text_field :completed_at_gt, class: 'datepicker datepicker-from form-control', value: datepicker_field_value(params[:q][:completed_at_gt]) %>
           <div class="input-group-append">
@@ -12,7 +12,7 @@
           </div>
         </div>
       </div>
-      <div class="col-6">
+      <div class="col-6 pl-1 pl-md-3">
         <div class="input-group">
         <%= s.text_field :completed_at_lt, class: 'datepicker datepicker-to form-control', value: datepicker_field_value(params[:q][:completed_at_lt]) %>
         <div class="input-group-append">

--- a/backend/app/views/spree/admin/variants/_form.html.erb
+++ b/backend/app/views/spree/admin/variants/_form.html.erb
@@ -40,10 +40,16 @@
       </div>
 
       <div class="form-group" data-hook="discontinue_on">
-
           <%= f.label :discontinue_on, Spree.t(:discontinue_on) %>
           <%= f.error_message_on :discontinue_on %>
+          <div class="input-group-append">
           <%= f.text_field :discontinue_on, value: datepicker_field_value(@variant.discontinue_on), class: 'datepicker form-control' %>
+          <div class="input-group-append">
+            <span class="input-group-text">
+              <%= svg_icon name: "calendar.svg", width: '18', height: '18' %>
+            </span>
+          </div>
+          </div>
       </div>
     </div>
   </div>

--- a/backend/app/views/spree/layouts/admin.html.erb
+++ b/backend/app/views/spree/layouts/admin.html.erb
@@ -81,13 +81,7 @@
         </main>
       </div>
     </div>
-    <% if content_for?(:sidebar) || content_for?(:page_actions) %>
-      <button id="contextual-menu-toggle"
-              type="button"
-              class="btn btn-primary btn-circle d-lg-none">
-              <%= svg_icon name: "chevron-down.svg", width: '22', height: '22' %>
-      </button>
-    <% end %>
+    
     <%#-------------------------------------------------%>
     <%# Insert footer scripts here                      %>
     <%#-------------------------------------------------%>


### PR DESCRIPTION
- Uses a singe responsive button in content header to trigger the contextual options dropdown.
- Stop the slow transition happening for main menu when the screen is resized from MD to LG.
- Remove sharp top corners from expanded filter panel.
- Set the Select2 tag close icon slightly smaller to match adjacent text size.
- Style the product image upload button to match rest of the UI (WebKit browsers).
- Fix the smaller padding issue on the configurations sub menu in mobile view, vs the other sub menus (Products, Promotions...)
- Add cal icon to all date picker fields, add responsive margins to tidy up view on small.
