### PR TITLE
[SD-872] Removes required attribute from Shipping Categories dropdown

### DIFF
--- a/backend/app/views/spree/admin/products/new.html.erb
+++ b/backend/app/views/spree/admin/products/new.html.erb
@@ -50,7 +50,7 @@
       <div data-hook="new_product_shipping_category" class="col-12 col-md-4">
         <%= f.field_container :shipping_category, class: ['form-group'] do %>
           <%= f.label :shipping_category_id, Spree.t(:shipping_categories) %><span class="required">*</span>
-          <%= f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { include_blank: Spree.t('match_choices.none') }, { class: 'select2', required: :required }) %>
+          <%= f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { include_blank: Spree.t('match_choices.none') }, { class: 'select2' }) %>
           <%= f.error_message_on :shipping_category_id %>
         <% end %>
       </div>


### PR DESCRIPTION
There was a problem with select2 dropdown and HTML validation on iOS
devices. Validation messages were not styled and sometimes didn't show
up at all. Validation is still performed by backend and proper error
messages are being shown.

Examples of incorrect behavior:
see movies on https://spark-solutions.atlassian.net/browse/SD-872

