### PR TITLE
Improve Promotions UX

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -181,12 +181,21 @@ $.fn.radioControlsVisibilityOfElement = function (dependentElementSelector) {
 }
 
 document.addEventListener('DOMContentLoaded', function() {
-  var target = document.querySelector('.datepickerFrom');
+  // This javascript needs re-writing to target paris of input fields
+  // within a div allowing you to have multiple instances of From To cals
+  // on a single page, and only the relevent cal is updated.
+  var target = document.querySelector('.datePickerFrom')
+  var targetTime = document.querySelector('.dateTimePickerFrom')
+
   if (target) {
     var targetDate = target.getElementsByTagName('input')[0].value
   }
+  
+  if (targetTime) {
+    var targetDate = targetTime.getElementsByTagName('input')[0].value
+  }
 
-  flatpickr('.datepicker-single', {
+  flatpickr('.datePickerSingle', {
     wrap: true,
     monthSelectorType: 'static',
     ariaDateFormat: Spree.translations.date_picker,
@@ -194,7 +203,7 @@ document.addEventListener('DOMContentLoaded', function() {
     dateFormat: Spree.translations.date_picker
   })
 
-  var dateFrom = flatpickr('.datepickerFrom', {
+  var dateFrom = flatpickr('.datePickerFrom', {
     wrap: true,
     monthSelectorType: 'static',
     ariaDateFormat: Spree.translations.date_picker,
@@ -205,7 +214,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
   })
 
-  var dateTo = flatpickr('.datepickerTo', {
+  var dateTo = flatpickr('.datePickerTo', {
     wrap: true,
     monthSelectorType: 'static',
     ariaDateFormat: Spree.translations.date_picker,
@@ -217,6 +226,43 @@ document.addEventListener('DOMContentLoaded', function() {
     },
     onChange: function(selectedDates) {
       dateFrom.set('maxDate', selectedDates[0])
+    }
+  })
+
+  var dateTimeSingle = flatpickr('.dateTimePickerSingle', {
+    wrap: true,
+    enableTime: true,
+    dateFormat: Spree.translations.date_picker + " H:i",
+    time_24hr: true,
+    monthSelectorType: 'static',
+    disableMobile: true,
+  })
+
+  var dateTimeFrom = flatpickr('.dateTimePickerFrom', {
+    wrap: true,
+    enableTime: true,
+    dateFormat: Spree.translations.date_picker + " - H:i",
+    time_24hr: true,
+    monthSelectorType: 'static',
+    disableMobile: true,
+    onChange: function(selectedDates) {
+      dateTimeTo.set('minDate', selectedDates[0])
+    }
+  })
+
+  var dateTimeTo = flatpickr('.dateTimePickerTo', {
+    wrap: true,
+    enableTime: true,
+    monthSelectorType: 'static',
+    time_24hr: true,
+    disableMobile: true,
+    dateFormat: Spree.translations.date_picker + " - H:i",
+    minDate: targetDate,
+    onReady: function(selectedDates) {
+      dateTimeFrom.set('maxDate', selectedDates[0])
+    },
+    onChange: function(selectedDates) {
+      dateTimeFrom.set('maxDate', selectedDates[0])
     }
   })
 

--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -190,9 +190,9 @@ document.addEventListener('DOMContentLoaded', function() {
   if (target) {
     var targetDate = target.getElementsByTagName('input')[0].value
   }
-  
+
   if (targetTime) {
-    var targetDate = targetTime.getElementsByTagName('input')[0].value
+    var targetDateTime = targetTime.getElementsByTagName('input')[0].value
   }
 
   flatpickr('.datePickerSingle', {
@@ -229,13 +229,13 @@ document.addEventListener('DOMContentLoaded', function() {
     }
   })
 
-  var dateTimeSingle = flatpickr('.dateTimePickerSingle', {
+  flatpickr('.dateTimePickerSingle', {
     wrap: true,
     enableTime: true,
     dateFormat: Spree.translations.date_picker + " H:i",
     time_24hr: true,
     monthSelectorType: 'static',
-    disableMobile: true,
+    disableMobile: true
   })
 
   var dateTimeFrom = flatpickr('.dateTimePickerFrom', {
@@ -257,7 +257,7 @@ document.addEventListener('DOMContentLoaded', function() {
     time_24hr: true,
     disableMobile: true,
     dateFormat: Spree.translations.date_picker + " - H:i",
-    minDate: targetDate,
+    minDate: targetDateTime,
     onReady: function(selectedDates) {
       dateTimeFrom.set('maxDate', selectedDates[0])
     },

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
@@ -106,7 +106,9 @@
 
 .select2-container-multi {
   .select2-choices {
-    line-height: 1.8;
+    min-height: 38px;
+    border-radius: $border-radius;
+    line-height: 1;
     border-color: $input-border-color;
     background-image: none;
     background-color: $input-bg;

--- a/backend/app/assets/stylesheets/spree/backend/shared/_base.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_base.scss
@@ -15,3 +15,10 @@
 .alert-error {
   @extend .alert-danger;
 }
+
+.js-remove-promo-rule-option-value {
+  color: $primary !important;
+  &:hover {
+    color: darken($primary, 10) !important;
+  }
+}

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -19,11 +19,8 @@ span.or {
   }
 }
 
-.datepicker,
-.datepicker-single,
-.datepickerFrom,
-.datepickerTo {
-  input, textarea {
+.input-group {
+  input.flatpickr-input{
     @include swith-appended-icon  {
       opacity: 0;
     }
@@ -43,8 +40,9 @@ span.or {
   }
 }
 
-// Fix Flatpickr bug on select
-input.flatpickr-input[readonly] {
+// Fix Flatpickr bug where things jusy highlight for no reason.
+input.flatpickr-input[readonly],
+.numInputWrapper > * {
   -webkit-touch-callout: none; /* iOS Safari */
     -webkit-user-select: none; /* Safari */
      -khtml-user-select: none; /* Konqueror HTML */

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -43,6 +43,7 @@ span.or {
   }
 }
 
+// Fix Flatpickr bug on select
 input.flatpickr-input[readonly] {
   -webkit-touch-callout: none; /* iOS Safari */
     -webkit-user-select: none; /* Safari */
@@ -51,6 +52,19 @@ input.flatpickr-input[readonly] {
         -ms-user-select: none; /* Internet Explorer/Edge */
             user-select: none; /* Non-prefixed version, currently
                                   supported by Chrome, Edge, Opera and Firefox */
+}
+
+// Hide number toggler
+/* Chrome, Safari, Edge, Opera */
+input.hide-number-toggle::-webkit-outer-spin-button,
+input.hide-number-toggle::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+/* Firefox */
+input[type=number].hide-number-toggle {
+  -moz-appearance: textfield;
 }
 
 .input-group >

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -21,7 +21,7 @@
             <div class="row pb-0">
 
               <div class="col-12 col-md-6 mb-3 mb-md-0">
-                <div class="input-group datepickerFrom">
+                <div class="input-group datePickerFrom">
                   <%= f.text_field :created_at_gt,
                     class: 'form-control js-filterable shadow-none',
                       value: params[:q][:created_at_gt],
@@ -32,7 +32,7 @@
               </div>
 
               <div class="col-12 col-md-6 mt-3 mt-md-0">
-                <div class="input-group datepickerTo">
+                <div class="input-group datePickerTo">
                   <%= f.text_field :created_at_lt,
                     class: 'form-control js-filterable shadow-none',
                       value: params[:q][:created_at_lt],

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -66,7 +66,7 @@
           <%= f.label :available_on, Spree.t(:available_on) %>
           <%= f.error_message_on :available_on %>
 
-          <div class="input-group datepickerFrom">
+          <div class="input-group datePickerFrom">
             <%= f.text_field :available_on, value: datepicker_field_value(@product.available_on), placeholder: Spree.t(:select_a_date), class: 'form-control shadow-none', 'data-input':'' %>
             <%= render partial: 'spree/admin/shared/cal_close' %>
           </div>
@@ -79,7 +79,7 @@
           <%= f.label :discontinue_on, Spree.t(:discontinue_on) %>
           <%= f.error_message_on :discontinue_on %>
 
-          <div class="input-group datepickerTo">
+          <div class="input-group datePickerTo">
             <%= f.text_field :discontinue_on, value: datepicker_field_value(@product.discontinue_on), placeholder: Spree.t(:select_a_date), class: 'form-control shadow-none', 'data-input':'' %>
             <%= render partial: 'spree/admin/shared/cal_close' %>
           </div>

--- a/backend/app/views/spree/admin/products/new.html.erb
+++ b/backend/app/views/spree/admin/products/new.html.erb
@@ -44,7 +44,7 @@
           <%= f.label :available_on, Spree.t(:available_on) %>
           <%= f.error_message_on :available_on %>
 
-          <div class="input-group datepicker-single">
+          <div class="input-group datePickerSingle">
             <%= f.text_field :available_on, value: datepicker_field_value(@product.available_on), placeholder: Spree.t(:select_a_date), class: 'form-control shadow-none', 'data-input':'' %>
             <%= render partial: 'spree/admin/shared/cal_close' %>
           </div>

--- a/backend/app/views/spree/admin/promotions/_form.html.erb
+++ b/backend/app/views/spree/admin/promotions/_form.html.erb
@@ -8,17 +8,19 @@
       <%= f.error_message_on :name %>
     <% end %>
 
-    <%= f.field_container :code, class: ['form-group'] do %>
-      <%= f.label :code %>
-      <%= f.text_field :code, class: 'form-control' %>
-    <% end %>
-
-    <%= f.field_container :generate_code, class: ['checkbox'] do %>
-      <%= f.label :generate_code do %>
-        <%= f.check_box :generate_code %>
-        <%= Spree.t(:generate_code) %>
+    <div class="form-group">
+      <%= f.field_container :code do %>
+        <%= f.label :code %>
+        <%= f.text_field :code, class: 'form-control' %>
       <% end %>
-    <% end %>
+
+      <%= f.field_container :generate_code, class: ['checkbox'] do %>
+        <%= f.label :generate_code do %>
+          <%= f.check_box :generate_code %>
+          <%= Spree.t(:generate_code) %>
+        <% end %>
+      <% end %>
+    </div>
 
     <%= f.field_container :path, class: ['form-group'] do %>
       <%= f.label :path %>
@@ -48,22 +50,26 @@
   <div id="expiry_fields" class="col-12 col-md-3">
     <div class="form-group">
       <%= f.field_container :usage_limit do %>
-        <%= f.label :usage_limit, Spree.t(:current_promotion_usage, count: @promotion.credits_count) %>
+        <%= f.label :usage_limit, Spree.t('limit_usage_to') %>
         <%= f.number_field :usage_limit, min: 0, class: 'form-control hide-number-toggle' %>
       <% end %>
+      <small class="form-text text-muted">
+        <%= Spree.t(:current_promotion_usage, count: @promotion.credits_count) %>
+      </small>
     </div>
+
     <div id="starts_at_field" class="form-group">
       <%= f.label :starts_at %>
-      <div class="input-group datepickerFrom">
-        <%= f.text_field :starts_at, class: 'form-control shadow-none', placeholder: Spree.t('starting_from'), 'data-input':'' %>
+      <div class="input-group dateTimePickerFrom">
+        <%= f.datetime_field :starts_at, class: 'form-control shadow-none', placeholder: Spree.t('starting_from'), 'data-input':'' %>
         <%= render partial: 'spree/admin/shared/cal_close' %>
       </div>
     </div>
 
     <div id="expires_at_field" class="form-group">
       <%= f.label :expires_at %>
-      <div class="input-group datepickerTo">
-        <%= f.text_field :expires_at, placeholder:Spree.t('ends_at'), class: 'form-control shadow-none', 'data-input':'' %>
+      <div class="input-group dateTimePickerTo">
+        <%= f.datetime_field :expires_at, placeholder:Spree.t('ends_at'), class: 'form-control shadow-none', 'data-input':'' %>
         <%= render partial: 'spree/admin/shared/cal_close' %>
       </div>
     </div>

--- a/backend/app/views/spree/admin/promotions/_form.html.erb
+++ b/backend/app/views/spree/admin/promotions/_form.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @promotion } %>
 
 <div class="row" id="general_fields" >
-  <div class="col-6 col-md-3">
+  <div class="col-12 col-md-3">
     <%= f.field_container :name, class: ['form-group'] do %>
       <%= f.label :name %>
       <%= f.text_field :name, class: 'form-control' %>
@@ -45,19 +45,17 @@
     <% end %>
   </div>
 
-  <div id="expiry_fields" class="col-6 col-md-3">
-    <%= f.field_container :usage_limit do %>
-      <%= f.label :usage_limit %>
-      <%= f.number_field :usage_limit, min: 0, class: 'form-control' %>
-      <small class="form-text text-muted">
-        <%= Spree.t(:current_promotion_usage, count: @promotion.credits_count) %>
-      </small>
-    <% end %>
-
+  <div id="expiry_fields" class="col-12 col-md-3">
+    <div class="form-group">
+      <%= f.field_container :usage_limit do %>
+        <%= f.label :usage_limit, Spree.t(:current_promotion_usage, count: @promotion.credits_count) %>
+        <%= f.number_field :usage_limit, min: 0, class: 'form-control hide-number-toggle' %>
+      <% end %>
+    </div>
     <div id="starts_at_field" class="form-group">
       <%= f.label :starts_at %>
       <div class="input-group datepickerFrom">
-        <%= f.datetime_field :starts_at, class: 'form-control shadow-none', placeholder: Spree.t('starting_from'), 'data-input':'' %>
+        <%= f.text_field :starts_at, class: 'form-control shadow-none', placeholder: Spree.t('starting_from'), 'data-input':'' %>
         <%= render partial: 'spree/admin/shared/cal_close' %>
       </div>
     </div>
@@ -65,7 +63,7 @@
     <div id="expires_at_field" class="form-group">
       <%= f.label :expires_at %>
       <div class="input-group datepickerTo">
-        <%= f.datetime_field :expires_at, placeholder:Spree.t('ends_at'), class: 'form-control shadow-none', 'data-input':'' %>
+        <%= f.text_field :expires_at, placeholder:Spree.t('ends_at'), class: 'form-control shadow-none', 'data-input':'' %>
         <%= render partial: 'spree/admin/shared/cal_close' %>
       </div>
     </div>

--- a/backend/app/views/spree/admin/promotions/edit.html.erb
+++ b/backend/app/views/spree/admin/promotions/edit.html.erb
@@ -4,8 +4,8 @@
 <% end %>
 
 <%= form_for @promotion, url: object_url, method: :put do |f| %>
-  <div class="row">
-    <div class="col-12">
+<div class="card mb-4">
+  <div class="card-body">
       <%= render partial: 'form', locals: { f: f } %>
       <%= render partial: 'spree/admin/shared/edit_resource_links' %>
     </div>

--- a/backend/app/views/spree/admin/promotions/new.html.erb
+++ b/backend/app/views/spree/admin/promotions/new.html.erb
@@ -2,10 +2,11 @@
   <%= link_to Spree.t(:promotions), admin_promotions_url %> /
   <%= Spree.t(:new_promotion) %>
 <% end %>
-
-<%= form_for :promotion, url: collection_url do |f| %>
-  <%= render partial: 'form', locals: { f: f } %>
-  <div class="text-center">
-    <%= render partial: 'spree/admin/shared/new_resource_links' %>
+<div class="card">
+  <div class="card-body">
+    <%= form_for :promotion, url: collection_url do |f| %>
+      <%= render partial: 'form', locals: { f: f } %>
+      <%= render partial: 'spree/admin/shared/new_resource_links' %>
+    <% end %>
   </div>
-<% end %>
+</div>

--- a/backend/app/views/spree/admin/promotions/rules/_country.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_country.html.erb
@@ -1,6 +1,6 @@
 <div class="card-body">
   <div class="form-group mb-0">
     <%= label_tag Spree.t('country_rule.label') %>
-    <%= select_tag("#{param_prefix}[preferred_country_id]", options_for_select(Spree::Country.pluck(:name, :id), promotion_rule.preferred_country_id), { class: 'select_product form-control' }) %>
+    <%= select_tag("#{param_prefix}[preferred_country_id]", options_for_select(Spree::Country.pluck(:name, :id), promotion_rule.preferred_country_id), { class: 'select_product form-control custom-select' }) %>
   </div>
 </div>

--- a/backend/app/views/spree/admin/promotions/rules/_item_total.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_item_total.html.erb
@@ -1,11 +1,11 @@
 <div class="card-body">
   <div class="row mb-0">
-    <div class="form-group col-12 col-md-6 mb-0">
-      <%= select_tag "#{param_prefix}[preferred_operator_min]", options_for_select(Spree::Promotion::Rules::ItemTotal::OPERATORS_MIN.map{|o| [Spree.t("item_total_rule.operators.#{o}"),o]}, promotion_rule.preferred_operator_min), { class: 'select2 select_item_total marginb' } %>
+    <div class="form-group col-6 mb-3">
+      <%= select_tag "#{param_prefix}[preferred_operator_min]", options_for_select(Spree::Promotion::Rules::ItemTotal::OPERATORS_MIN.map{|o| [Spree.t("item_total_rule.operators.#{o}"),o]}, promotion_rule.preferred_operator_min), { class: 'select2 select_item_total mb-3' } %>
       <%= select_tag "#{param_prefix}[preferred_operator_max]", options_for_select(Spree::Promotion::Rules::ItemTotal::OPERATORS_MAX.map{|o| [Spree.t("item_total_rule.operators.#{o}"),o]}, promotion_rule.preferred_operator_max), { class: 'select2 select_item_total' } %>
     </div>
-    <div class="form-group col-12 col-md-6 mb-0">
-      <%= text_field_tag "#{param_prefix}[preferred_amount_min]", promotion_rule.preferred_amount_min, class: 'form-control marginb' %>
+    <div class="form-group col-6 mb-3">
+      <%= text_field_tag "#{param_prefix}[preferred_amount_min]", promotion_rule.preferred_amount_min, class: 'form-control mb-3' %>
       <%= text_field_tag "#{param_prefix}[preferred_amount_max]", promotion_rule.preferred_amount_max, class: 'form-control' %>
     </div>
   </div>

--- a/backend/app/views/spree/admin/promotions/rules/_option_value.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_option_value.html.erb
@@ -1,7 +1,6 @@
 <div class="card-body">
   <div class="promo-rule-option-values">
     <div class="js-promo-rule-option-values"></div>
-
     <button class="btn btn-primary btn-success js-add-promo-rule-option-value">
       <%= svg_icon name: "add.svg", width: '16', height: '16' %>
       <%= Spree.t(:add) %>
@@ -17,13 +16,12 @@
 </script>
 
 <script type="text/x-handlebars-template" id="promo-rule-option-value-template">
-  <div class="promo-rule-option-value panel  ">
-    <div class="card-header">
+  <div class="promo-rule-option-value panel card mb-3">
+    <div class="card-header d-flex justify-content-between">
+      <label><%= Spree.t(:product) %> <%= Spree.t(:option_values) %></label>
       <a class="js-remove-promo-rule-option-value delete pull-right">
         <%= svg_icon name: "delete.svg", width: '16', height: '16' %>
       </a>
-      <label><%= Spree.t(:product) %> <%= Spree.t(:option_values) %></label>
-      <div class="clearfix"></div>
     </div>
     <div class="card-body row p-3">
       <div class="col-12 col-md-6">

--- a/backend/app/views/spree/admin/promotions/rules/_product.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_product.html.erb
@@ -5,6 +5,6 @@
   </div>
   <div class="form-group mb-0">
     <%= label_tag Spree.t('product_rule.label') %>
-    <%= select_tag("#{param_prefix}[preferred_match_policy]", options_for_select(Spree::Promotion::Rules::Product::MATCH_POLICIES.map{|s| [Spree.t("product_rule.match_#{s}"),s] }, promotion_rule.preferred_match_policy), {class: 'select_product form-control'}) %>
+    <%= select_tag("#{param_prefix}[preferred_match_policy]", options_for_select(Spree::Promotion::Rules::Product::MATCH_POLICIES.map{|s| [Spree.t("product_rule.match_#{s}"),s] }, promotion_rule.preferred_match_policy), {class: 'select_product form-control custom-select'}) %>
   </div>
 </div>

--- a/backend/app/views/spree/admin/promotions/rules/_taxon.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_taxon.html.erb
@@ -5,6 +5,6 @@
   </div>
   <div class="form-group mb-0">
     <%= label_tag Spree.t('taxon_rule.label') %>
-    <%= select_tag("#{param_prefix}[preferred_match_policy]", options_for_select(Spree::Promotion::Rules::Taxon::MATCH_POLICIES.map{|s| [Spree.t("taxon_rule.match_#{s}"),s] }, promotion_rule.preferred_match_policy), {class: 'select_taxon form-control'}) %>
+    <%= select_tag("#{param_prefix}[preferred_match_policy]", options_for_select(Spree::Promotion::Rules::Taxon::MATCH_POLICIES.map{|s| [Spree.t("taxon_rule.match_#{s}"),s] }, promotion_rule.preferred_match_policy), {class: 'select_taxon form-control custom-select'}) %>
   </div>
 </div>

--- a/backend/app/views/spree/admin/shared/_report_order_criteria.html.erb
+++ b/backend/app/views/spree/admin/shared/_report_order_criteria.html.erb
@@ -3,7 +3,7 @@
   <%= label_tag nil, Spree.t(:date_range) %>
   <div class="date-range-filter row">
     <div class="col-12 col-md-6 mb-3 mb-md-0">
-      <div class="input-group datepickerFrom">
+      <div class="input-group datePickerFrom">
         <%= s.text_field :completed_at_gt,
                          class: 'form-control shadow-none',
                          placeholder: Spree.t(:starting_from),
@@ -14,7 +14,7 @@
     </div>
 
     <div class="col-12 col-md-6 mt-3 mt-md-0">
-      <div class="input-group datepickerTo">
+      <div class="input-group datePickerTo">
         <%= s.text_field :completed_at_lt,
                          class: 'form-control shadow-none',
                          placeholder: Spree.t(:ending_at),

--- a/backend/app/views/spree/admin/variants/_form.html.erb
+++ b/backend/app/views/spree/admin/variants/_form.html.erb
@@ -42,7 +42,7 @@
       <div class="form-group" data-hook="discontinue_on">
           <%= f.label :discontinue_on, Spree.t(:discontinue_on) %>
           <%= f.error_message_on :discontinue_on %>
-          <div class="input-group datepicker-single">
+          <div class="input-group datePickerSingle">
             <%= f.text_field :discontinue_on, value: datepicker_field_value(@variant.discontinue_on), placeholder: Spree.t(:select_a_date), class: 'form-control shadow-none', 'data-input':'' %>
             <%= render partial: 'spree/admin/shared/cal_close' %>
           </div>

--- a/backend/spec/features/admin/promotions/adjustments_spec.rb
+++ b/backend/spec/features/admin/promotions/adjustments_spec.rb
@@ -50,7 +50,7 @@ describe 'Promotion Adjustments', type: :feature, js: true do
 
     it 'allows an admin to create a single user coupon promo with flat rate discount' do
       fill_in 'Name', with: 'Promotion'
-      fill_in 'Usage Limit', with: '1'
+      fill_in 'Limit usage to', with: '1'
       fill_in 'Code', with: 'single_use'
       click_button 'Create'
       promotion = Spree::Promotion.find_by(name: 'Promotion')

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -740,7 +740,7 @@ en:
     currencies: Currencies
     currency_settings: Currency Settings
     current: Current
-    current_promotion_usage: ! 'Limit usage - (current usage: %{count})'
+    current_promotion_usage: ! 'current usage: %{count}'
     customer: Customer
     customer_details: Customer Details
     customer_details_updated: Customer Details Updated
@@ -1003,6 +1003,7 @@ en:
     last_name_begins_with: Last Name Begins With
     learn_more: Learn More
     lifetime_stats: Lifetime Stats
+    limit_usage_to: Limit usage to
     line_item_adjustments: "Line item adjustments"
     list: List
     loading: Loading

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -740,7 +740,7 @@ en:
     currencies: Currencies
     currency_settings: Currency Settings
     current: Current
-    current_promotion_usage: ! 'Current Usage: %{count}'
+    current_promotion_usage: ! 'Limit usage - (current usage: %{count})'
     customer: Customer
     customer_details: Customer Details
     customer_details_updated: Customer Details Updated


### PR DESCRIPTION
- Set layout to use full width for all fields in mobile.
- Set Select2 multiple choice fields to have same border radius, and height as other input fields, even when empty.
- Make panels more consistent looking for rules and actions.
- RULE: '_Order total meets these criteria_' now makes more sense on mobile size screens.
- Add date/time picker to promo start from / expires at.