### PR TITLE
Incorrect I18n scopes used in admin/state_changes/index.html.erb

### DIFF
--- a/backend/app/views/spree/admin/state_changes/index.html.erb
+++ b/backend/app/views/spree/admin/state_changes/index.html.erb
@@ -19,10 +19,11 @@
 
     <tbody>
       <% @state_changes.each do |state_change| %>
+        <% scope = state_change.name == 'order'  ? "#{ state_change.name }_state" : "#{ state_change.name }_states" -%>
         <tr>
           <td><%= Spree.t("state_machine_states.#{state_change.name}") %></td>
-          <td><%= state_change.previous_state ? Spree.t(state_change.previous_state, scope: "#{ state_change.name }_state") : Spree.t(:previous_state_missing) %></td>
-          <td><%= Spree.t(state_change.next_state, scope: "#{ state_change.name }_state") %></td>
+          <td><%= state_change.previous_state ? Spree.t(state_change.previous_state, scope: scope) : Spree.t(:previous_state_missing) %></td>
+          <td><%= Spree.t(state_change.next_state, scope: scope) %></td>
           <td>
             <% if state_change.user %>
               <% user_login = state_change.user.try(:login) || state_change.user.try(:email) %>


### PR DESCRIPTION
Fixes an issue that the I18n scope names are not named consistent. (Which result in a crash in you enable config.action_view.raise_on_missing_translations)
Order states are named 'en.spree.order_state'. (without S)
Shipment states are named 'en.spree.shipment_states' (with S)
Payment states are named 'en.spree.payment_states' (with S)