### PR TITLE
Refine Flatpicker Admin Javascript

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -182,7 +182,6 @@ $.fn.radioControlsVisibilityOfElement = function (dependentElementSelector) {
 
 document.addEventListener('DOMContentLoaded', function() {
   var dateFrom = flatpickr('.datePickerFrom', {
-    wrap: true,
     monthSelectorType: 'static',
     time_24hr: true,
     dateFormat: Spree.translations.date_picker,
@@ -192,7 +191,6 @@ document.addEventListener('DOMContentLoaded', function() {
   })
 
   var dateTo = flatpickr('.datePickerTo', {
-    wrap: true,
     monthSelectorType: 'static',
     time_24hr: true,
     dateFormat: Spree.translations.date_picker,
@@ -206,7 +204,6 @@ document.addEventListener('DOMContentLoaded', function() {
     time_24hr: true,
     dateFormat: Spree.translations.date_picker,
   })
-  
 })
 
 $(document).ready(function() {

--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -182,6 +182,7 @@ $.fn.radioControlsVisibilityOfElement = function (dependentElementSelector) {
 
 document.addEventListener('DOMContentLoaded', function() {
   var dateFrom = flatpickr('.datePickerFrom', {
+    wrap: true,
     monthSelectorType: 'static',
     time_24hr: true,
     dateFormat: Spree.translations.date_picker,
@@ -191,6 +192,7 @@ document.addEventListener('DOMContentLoaded', function() {
   })
 
   var dateTo = flatpickr('.datePickerTo', {
+    wrap: true,
     monthSelectorType: 'static',
     time_24hr: true,
     dateFormat: Spree.translations.date_picker,
@@ -200,36 +202,11 @@ document.addEventListener('DOMContentLoaded', function() {
   })
 
   var fp = flatpickr('.datepicker', {
-    wrap: true,
     monthSelectorType: 'static',
     time_24hr: true,
     dateFormat: Spree.translations.date_picker,
   })
-
-  $(".data-clear").click(function() {
-    var input = this.previousElementSibling
-
-    if (input.classList.contains('datePickerFrom') ) {
-      dateFrom.clear()
-    } else if (input.classList.contains('datePickerTo')) {
-      dateTo.clear()
-    } else {
-      fp.clear()
-    }
-  })
-
-  $(".data-clear").click(function() {
-    var input = this.previousElementSibling
-
-    if (input.classList.contains('datePickerFrom') ) {
-      dateFrom.clear()
-    } else if (input.classList.contains('datePickerTo')) {
-      dateTo.clear()
-    } else {
-      fp.clear()
-    }
-  })
-
+  
 })
 
 $(document).ready(function() {

--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -181,33 +181,9 @@ $.fn.radioControlsVisibilityOfElement = function (dependentElementSelector) {
 }
 
 document.addEventListener('DOMContentLoaded', function() {
-  // This javascript needs re-writing to target paris of input fields
-  // within a div allowing you to have multiple instances of From To cals
-  // on a single page, and only the relevent cal is updated.
-  var target = document.querySelector('.datePickerFrom')
-  var targetTime = document.querySelector('.dateTimePickerFrom')
-
-  if (target) {
-    var targetDate = target.getElementsByTagName('input')[0].value
-  }
-
-  if (targetTime) {
-    var targetDateTime = targetTime.getElementsByTagName('input')[0].value
-  }
-
-  flatpickr('.datePickerSingle', {
-    wrap: true,
-    monthSelectorType: 'static',
-    ariaDateFormat: Spree.translations.date_picker,
-    disableMobile: true,
-    dateFormat: Spree.translations.date_picker
-  })
-
   var dateFrom = flatpickr('.datePickerFrom', {
-    wrap: true,
     monthSelectorType: 'static',
-    ariaDateFormat: Spree.translations.date_picker,
-    disableMobile: true,
+    time_24hr: true,
     dateFormat: Spree.translations.date_picker,
     onChange: function(selectedDates) {
       dateTo.set('minDate', selectedDates[0])
@@ -215,64 +191,45 @@ document.addEventListener('DOMContentLoaded', function() {
   })
 
   var dateTo = flatpickr('.datePickerTo', {
-    wrap: true,
     monthSelectorType: 'static',
-    ariaDateFormat: Spree.translations.date_picker,
-    disableMobile: true,
+    time_24hr: true,
     dateFormat: Spree.translations.date_picker,
-    minDate: targetDate,
-    onReady: function(selectedDates) {
-      dateFrom.set('maxDate', selectedDates[0])
-    },
     onChange: function(selectedDates) {
       dateFrom.set('maxDate', selectedDates[0])
     }
   })
 
-  flatpickr('.dateTimePickerSingle', {
+  var fp = flatpickr('.datepicker', {
     wrap: true,
-    enableTime: true,
-    dateFormat: Spree.translations.date_picker + " H:i",
-    time_24hr: true,
     monthSelectorType: 'static',
-    disableMobile: true
+    time_24hr: true,
+    dateFormat: Spree.translations.date_picker,
   })
 
-  var dateTimeFrom = flatpickr('.dateTimePickerFrom', {
-    wrap: true,
-    enableTime: true,
-    dateFormat: Spree.translations.date_picker + " - H:i",
-    time_24hr: true,
-    monthSelectorType: 'static',
-    disableMobile: true,
-    onChange: function(selectedDates) {
-      dateTimeTo.set('minDate', selectedDates[0])
+  $(".data-clear").click(function() {
+    var input = this.previousElementSibling
+
+    if (input.classList.contains('datePickerFrom') ) {
+      dateFrom.clear()
+    } else if (input.classList.contains('datePickerTo')) {
+      dateTo.clear()
+    } else {
+      fp.clear()
     }
   })
 
-  var dateTimeTo = flatpickr('.dateTimePickerTo', {
-    wrap: true,
-    enableTime: true,
-    monthSelectorType: 'static',
-    time_24hr: true,
-    disableMobile: true,
-    dateFormat: Spree.translations.date_picker + " - H:i",
-    minDate: targetDateTime,
-    onReady: function(selectedDates) {
-      dateTimeFrom.set('maxDate', selectedDates[0])
-    },
-    onChange: function(selectedDates) {
-      dateTimeFrom.set('maxDate', selectedDates[0])
+  $(".data-clear").click(function() {
+    var input = this.previousElementSibling
+
+    if (input.classList.contains('datePickerFrom') ) {
+      dateFrom.clear()
+    } else if (input.classList.contains('datePickerTo')) {
+      dateTo.clear()
+    } else {
+      fp.clear()
     }
   })
 
-  // For backwards compatability in extensions
-  flatpickr('.datepicker', {
-    monthSelectorType: 'static',
-    ariaDateFormat: Spree.translations.date_picker,
-    disableMobile: true,
-    dateFormat: Spree.translations.date_picker
-  })
 })
 
 $(document).ready(function() {

--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -182,9 +182,9 @@ $.fn.radioControlsVisibilityOfElement = function (dependentElementSelector) {
 
 document.addEventListener('DOMContentLoaded', function() {
   var dateFrom = flatpickr('.datePickerFrom', {
-    monthSelectorType: 'static',
     time_24hr: true,
     dateFormat: Spree.translations.date_picker,
+    monthSelectorType: 'static',
     onChange: function(selectedDates) {
       dateTo.set('minDate', selectedDates[0])
     }
@@ -199,10 +199,10 @@ document.addEventListener('DOMContentLoaded', function() {
     }
   })
 
-  var fp = flatpickr('.datepicker', {
+  flatpickr('.datepicker', {
     monthSelectorType: 'static',
     time_24hr: true,
-    dateFormat: Spree.translations.date_picker,
+    dateFormat: Spree.translations.date_picker
   })
 })
 

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_flatpickr.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_flatpickr.scss
@@ -23,7 +23,7 @@
 
 
 .flatpickr-day {
-  border-radius: 10px;
+  border-radius: 7px;
 }
 
 // Fix Flatpickr bug where things jusy highlight for no reason.
@@ -39,5 +39,5 @@ input.flatpickr-input[readonly] {
 
 .flatpickr-months .flatpickr-prev-month:hover svg,
 .flatpickr-months .flatpickr-next-month:hover svg {
-  fill: $success;
+  fill: $primary;
 }

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_flatpickr.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_flatpickr.scss
@@ -1,0 +1,43 @@
+// Adaptive icon from calendar to close.
+@mixin swith-appended-icon {
+  &:placeholder-shown:not(:focus) + * {
+      @content;
+  }
+}
+
+.input-group {
+  input.flatpickr-input{
+    @include swith-appended-icon  {
+      opacity: 0;
+    }
+  }
+}
+
+.append_under {
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 0;
+  height: 100%;
+}
+
+
+.flatpickr-day {
+  border-radius: 10px;
+}
+
+// Fix Flatpickr bug where things jusy highlight for no reason.
+input.flatpickr-input[readonly] {
+  -webkit-touch-callout: none; /* iOS Safari */
+    -webkit-user-select: none; /* Safari */
+     -khtml-user-select: none; /* Konqueror HTML */
+       -moz-user-select: none; /* Old versions of Firefox */
+        -ms-user-select: none; /* Internet Explorer/Edge */
+            user-select: none; /* Non-prefixed version, currently
+                                  supported by Chrome, Edge, Opera and Firefox */
+}
+
+.flatpickr-months .flatpickr-prev-month:hover svg,
+.flatpickr-months .flatpickr-next-month:hover svg {
+  fill: $success;
+}

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -12,21 +12,6 @@ span.or {
   padding: 0 10px;
 }
 
-// Adaptive icon from calendar to close.
-@mixin swith-appended-icon {
-  &:placeholder-shown:not(:focus) + * {
-      @content;
-  }
-}
-
-.input-group {
-  input.flatpickr-input{
-    @include swith-appended-icon  {
-      opacity: 0;
-    }
-  }
-}
-
 .form-group {
   &.withError {
     label, .formError, .required {
@@ -38,18 +23,6 @@ span.or {
       border-color: $danger;
     }
   }
-}
-
-// Fix Flatpickr bug where things jusy highlight for no reason.
-input.flatpickr-input[readonly],
-.numInputWrapper > * {
-  -webkit-touch-callout: none; /* iOS Safari */
-    -webkit-user-select: none; /* Safari */
-     -khtml-user-select: none; /* Konqueror HTML */
-       -moz-user-select: none; /* Old versions of Firefox */
-        -ms-user-select: none; /* Internet Explorer/Edge */
-            user-select: none; /* Non-prefixed version, currently
-                                  supported by Chrome, Edge, Opera and Firefox */
 }
 
 // Hide number toggler
@@ -71,12 +44,4 @@ input[type=number].hide-number-toggle {
   z-index: 5;
   border-top-right-radius: 2px !important;
   border-bottom-right-radius: 2px !important;
-}
-
-.append_under {
-  position: absolute;
-  right: 0;
-  top: 0;
-  z-index: 0;
-  height: 100%;
 }

--- a/backend/app/assets/stylesheets/spree/backend/spree_admin.css.scss
+++ b/backend/app/assets/stylesheets/spree/backend/spree_admin.css.scss
@@ -20,6 +20,7 @@
 
 @import 'plugins/select2';
 @import 'plugins/jquery_ui';
+@import 'plugins/flatpickr';
 
 @import 'shared/base';
 @import 'shared/forms';

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -22,6 +22,7 @@
           <div class="row pb-0">
             <div class="col-12 col-md-6 mb-3 mb-md-0">
               <div class="input-group datePickerFrom"
+                   data-wrap="true"
                    data-max-date="<%= params[:q][:created_at_lt] %>">
                 <%= f.text_field :created_at_gt,
                   class: 'form-control js-filterable shadow-none',
@@ -34,6 +35,7 @@
             </div>
             <div class="col-12 col-md-6 mt-3 mt-md-0">
               <div class="input-group datePickerTo"
+                   data-wrap="true"
                    data-min-date="<%= params[:q][:created_at_gt] %>">
 
                 <%= f.text_field :created_at_lt,

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -14,157 +14,159 @@
   <div data-hook="admin_orders_index_search">
 
     <%= search_form_for [:admin, @search] do |f| %>
-      <div class="row">
-        <div class="date-range-filter col-12 col-lg-8">
-          <div class="form-group">
-            <%= label_tag :q_created_at_gt, Spree.t(:date_range) %>
-            <div class="row pb-0">
+    <div class="row">
 
-              <div class="col-12 col-md-6 mb-3 mb-md-0">
-                <div class="input-group">
-                  <%= f.text_field :created_at_gt,
-                    class: 'form-control js-filterable shadow-none datePickerFrom',
-                      value: params[:q][:created_at_gt],
-                      placeholder: Spree.t(:starting_from),
-                      'data-max-date': params[:q][:created_at_lt] %>
+      <div class="date-range-filter col-12 col-lg-8">
+        <div class="form-group">
+          <%= label_tag :q_created_at_gt, Spree.t(:date_range) %>
+          <div class="row pb-0">
+            <div class="col-12 col-md-6 mb-3 mb-md-0">
+              <div class="input-group datePickerFrom"
+                   data-max-date="<%= params[:q][:created_at_lt] %>">
+                <%= f.text_field :created_at_gt,
+                  class: 'form-control js-filterable shadow-none',
+                    value: params[:q][:created_at_gt],
+                    placeholder: Spree.t(:starting_from),
+                    'data-input':'' %>
 
-                  <%= render partial: 'spree/admin/shared/cal_close' %>
+                <%= render partial: 'spree/admin/shared/cal_close' %>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 mt-3 mt-md-0">
+              <div class="input-group datePickerTo"
+                   data-min-date="<%= params[:q][:created_at_gt] %>">
+
+                <%= f.text_field :created_at_lt,
+                  class: 'form-control js-filterable shadow-none',
+                    value: params[:q][:created_at_lt],
+                    placeholder: Spree.t(:ending_at),
+                    'data-input':'' %>
+
+                <%= render partial: 'spree/admin/shared/cal_close' %>
                 </div>
-              </div>
-
-              <div class="col-12 col-md-6 mt-3 mt-md-0">
-                <div class="input-group">
-                  <%= f.text_field :created_at_lt,
-                    class: 'form-control js-filterable shadow-none datePickerTo',
-                      value: params[:q][:created_at_lt],
-                      placeholder: Spree.t(:ending_at),
-                      'data-min-date': params[:q][:created_at_gt] %>
-
-                  <%= render partial: 'spree/admin/shared/cal_close' %>
-                  </div>
-              </div>
-
-              </div>
-            </div>
-          </div>
-          <div class="col-12 col-lg-4">
-            <div class="form-group">
-              <%= label_tag :q_number_cont, Spree.t(:order_number, number: '') %>
-              <%= f.text_field :number_cont, class: 'form-control js-quick-search-target js-filterable' %>
             </div>
           </div>
         </div>
-
-      <div class="row">
-
-        <div class="col-12 col-lg-4">
-          <div class="form-group">
-            <%= label_tag :q_state_eq, Spree.t(:status) %>
-            <%= f.select :state_eq,
-              Spree::Order.state_machines[:state].states.map {|s| [Spree.t("order_state.#{s.name}"), s.value]},
-              { include_blank: true },
-              class: 'select2 js-filterable' %>
-          </div>
+      </div>
+      <div class="col-12 col-lg-4">
+        <div class="form-group">
+          <%= label_tag :q_number_cont, Spree.t(:order_number, number: '') %>
+          <%= f.text_field :number_cont, class: 'form-control js-quick-search-target js-filterable' %>
         </div>
-
-        <div class="col-12 col-lg-4">
-          <div class="form-group">
-            <%= label_tag :q_payment_state_eq, Spree.t(:payment_state) %>
-            <%= f.select :payment_state_eq, Spree::Order::PAYMENT_STATES.map {|s| [Spree.t("payment_states.#{s}"), s]}, { include_blank: true }, class: 'select2 js-filterable' %>
-          </div>
-        </div>
-
-        <div class="col-12 col-lg-4">
-          <div class="form-group">
-            <%= label_tag :q_shipment_state_eq, Spree.t(:shipment_state) %>
-            <%= f.select :shipment_state_eq, Spree::Order::SHIPMENT_STATES.map {|s| [Spree.t("shipment_states.#{s}"), s]}, { include_blank: true }, class: 'select2 js-filterable' %>
-          </div>
-        </div>
-
       </div>
 
-      <div class="row">
+    </div>
 
-        <div class="col-12 col-lg-4">
-          <div class="form-group">
-            <%= label_tag :q_bill_address_firstname_start, Spree.t(:first_name_begins_with) %>
-            <%= f.text_field :bill_address_firstname_start, class: 'form-control js-filterable' %>
-          </div>
+    <div class="row">
+
+      <div class="col-12 col-lg-4">
+        <div class="form-group">
+          <%= label_tag :q_state_eq, Spree.t(:status) %>
+          <%= f.select :state_eq,
+            Spree::Order.state_machines[:state].states.map {|s| [Spree.t("order_state.#{s.name}"), s.value]},
+            { include_blank: true },
+            class: 'select2 js-filterable' %>
         </div>
-
-        <div class="col-12 col-lg-4">
-          <div class="form-group">
-            <%= label_tag :q_bill_address_lastname_start, Spree.t(:last_name_begins_with) %>
-            <%= f.text_field :bill_address_lastname_start, class: 'form-control js-filterable' %>
-          </div>
-        </div>
-
-        <div class="col-12 col-lg-4">
-          <div class="form-group">
-            <%= label_tag :q_email_cont, Spree.t(:email) %>
-            <%= f.text_field :email_cont, class: 'form-control js-filterable' %>
-          </div>
-        </div>
-
       </div>
 
-      <div class="row">
-
-        <div class="col-12 col-lg-4">
-          <div class="form-group">
-            <%= label_tag :q_line_items_variant_sku_eq, Spree.t(:sku) %>
-            <%= f.text_field :line_items_variant_sku_eq, class: 'form-control js-filterable' %>
-          </div>
+      <div class="col-12 col-lg-4">
+        <div class="form-group">
+          <%= label_tag :q_payment_state_eq, Spree.t(:payment_state) %>
+          <%= f.select :payment_state_eq, Spree::Order::PAYMENT_STATES.map {|s| [Spree.t("payment_states.#{s}"), s]}, { include_blank: true }, class: 'select2 js-filterable' %>
         </div>
+      </div>
 
-        <div class="col-12 col-lg-4">
-          <div class="form-group">
-            <%= label_tag :q_promotions_id_in, Spree.t(:promotion) %>
-            <%= f.select :promotions_id_in, Spree::Promotion.applied.pluck(:name, :id), { include_blank: true }, class: 'select2 js-filterable' %>
-          </div>
+      <div class="col-12 col-lg-4">
+        <div class="form-group">
+          <%= label_tag :q_shipment_state_eq, Spree.t(:shipment_state) %>
+          <%= f.select :shipment_state_eq, Spree::Order::SHIPMENT_STATES.map {|s| [Spree.t("shipment_states.#{s}"), s]}, { include_blank: true }, class: 'select2 js-filterable' %>
         </div>
+      </div>
 
-        <div class="col-12 col-lg-4">
-          <div class="form-group">
-            <%= label_tag :q_store_id_in, Spree.t(:store) %>
-            <%= f.select :store_id_in, Spree::Store.order(:name).pluck(:name, :id), { include_blank: true }, class: 'select2 js-filterable' %>
-          </div>
+    </div>
+
+    <div class="row">
+
+      <div class="col-12 col-lg-4">
+        <div class="form-group">
+          <%= label_tag :q_bill_address_firstname_start, Spree.t(:first_name_begins_with) %>
+          <%= f.text_field :bill_address_firstname_start, class: 'form-control js-filterable' %>
         </div>
+      </div>
 
-        <div class="col-12 col-lg-4">
-          <div class="form-group">
-            <%= label_tag :q_channel_eq, Spree.t(:channel) %>
-            <%= f.select :channel_eq, Spree::Order.distinct.pluck(:channel), { include_blank: true }, class: 'select2 js-filterable' %>
-          </div>
+      <div class="col-12 col-lg-4">
+        <div class="form-group">
+          <%= label_tag :q_bill_address_lastname_start, Spree.t(:last_name_begins_with) %>
+          <%= f.text_field :bill_address_lastname_start, class: 'form-control js-filterable' %>
         </div>
+      </div>
 
-        <div class="col-12 col-lg-4">
+      <div class="col-12 col-lg-4">
+        <div class="form-group">
+          <%= label_tag :q_email_cont, Spree.t(:email) %>
+          <%= f.text_field :email_cont, class: 'form-control js-filterable' %>
+        </div>
+      </div>
 
-          <div class="form-group">
+    </div>
 
-            <div class="checkbox mt-2">
-              <%= label_tag 'q_completed_at_not_null' do %>
-                <%= f.check_box :completed_at_not_null, {checked: @show_only_completed}, '1', '0' %>
-                <%= Spree.t(:show_only_complete_orders) %>
-              <% end %>
-            </div>
+    <div class="row">
 
-            <div class="checkbox mt-2">
-              <%= label_tag 'q_considered_risky_eq' do %>
-                <%= f.check_box :considered_risky_eq, {checked: (params[:q][:considered_risky_eq] == '1')}, '1', '' %>
-                <%= Spree.t(:show_only_considered_risky) %>
-              <% end %>
-            </div>
+      <div class="col-12 col-lg-4">
+        <div class="form-group">
+          <%= label_tag :q_line_items_variant_sku_eq, Spree.t(:sku) %>
+          <%= f.text_field :line_items_variant_sku_eq, class: 'form-control js-filterable' %>
+        </div>
+      </div>
 
+      <div class="col-12 col-lg-4">
+        <div class="form-group">
+          <%= label_tag :q_promotions_id_in, Spree.t(:promotion) %>
+          <%= f.select :promotions_id_in, Spree::Promotion.applied.pluck(:name, :id), { include_blank: true }, class: 'select2 js-filterable' %>
+        </div>
+      </div>
+
+      <div class="col-12 col-lg-4">
+        <div class="form-group">
+          <%= label_tag :q_store_id_in, Spree.t(:store) %>
+          <%= f.select :store_id_in, Spree::Store.order(:name).pluck(:name, :id), { include_blank: true }, class: 'select2 js-filterable' %>
+        </div>
+      </div>
+
+      <div class="col-12 col-lg-4">
+        <div class="form-group">
+          <%= label_tag :q_channel_eq, Spree.t(:channel) %>
+          <%= f.select :channel_eq, Spree::Order.distinct.pluck(:channel), { include_blank: true }, class: 'select2 js-filterable' %>
+        </div>
+      </div>
+
+      <div class="col-12 col-lg-4">
+
+        <div class="form-group">
+
+          <div class="checkbox mt-2">
+            <%= label_tag 'q_completed_at_not_null' do %>
+              <%= f.check_box :completed_at_not_null, {checked: @show_only_completed}, '1', '0' %>
+              <%= Spree.t(:show_only_complete_orders) %>
+            <% end %>
+          </div>
+
+          <div class="checkbox mt-2">
+            <%= label_tag 'q_considered_risky_eq' do %>
+              <%= f.check_box :considered_risky_eq, {checked: (params[:q][:considered_risky_eq] == '1')}, '1', '' %>
+              <%= Spree.t(:show_only_considered_risky) %>
+            <% end %>
           </div>
 
         </div>
 
       </div>
 
-      <div data-hook="admin_orders_index_search_buttons" class="form-actions">
-        <%= button Spree.t(:filter_results), 'search.svg' %>
-      </div>
+    </div>
+
+    <div data-hook="admin_orders_index_search_buttons" class="form-actions">
+      <%= button Spree.t(:filter_results), 'search.svg' %>
+    </div>
 
     <% end %>
 

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -21,23 +21,25 @@
             <div class="row pb-0">
 
               <div class="col-12 col-md-6 mb-3 mb-md-0">
-                <div class="input-group datePickerFrom">
+                <div class="input-group">
                   <%= f.text_field :created_at_gt,
-                    class: 'form-control js-filterable shadow-none',
+                    class: 'form-control js-filterable shadow-none datePickerFrom',
                       value: params[:q][:created_at_gt],
                       placeholder: Spree.t(:starting_from),
-                      'data-input':'' %>
+                      'data-max-date': params[:q][:created_at_lt] %>
+
                   <%= render partial: 'spree/admin/shared/cal_close' %>
                 </div>
               </div>
 
               <div class="col-12 col-md-6 mt-3 mt-md-0">
-                <div class="input-group datePickerTo">
+                <div class="input-group">
                   <%= f.text_field :created_at_lt,
-                    class: 'form-control js-filterable shadow-none',
+                    class: 'form-control js-filterable shadow-none datePickerTo',
                       value: params[:q][:created_at_lt],
                       placeholder: Spree.t(:ending_at),
-                      'data-input':'' %>
+                      'data-min-date': params[:q][:created_at_gt] %>
+
                   <%= render partial: 'spree/admin/shared/cal_close' %>
                   </div>
               </div>

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -66,12 +66,14 @@
           <%= f.label :available_on, Spree.t(:available_on) %>
           <%= f.error_message_on :available_on %>
 
-          <div class="input-group">
+          <div class="input-group datePickerFrom"
+               data-max-date="<%= @product.discontinue_on %>" >
+
             <%= f.text_field :available_on,
                              value: datepicker_field_value(@product.available_on),
                              placeholder: Spree.t(:select_a_date),
-                             class: 'form-control shadow-none datePickerFrom',
-                            'data-max-date': @product.discontinue_on %>
+                             class: 'form-control shadow-none ',
+                             'data-input':'' %>
 
             <%= render partial: 'spree/admin/shared/cal_close' %>
           </div>
@@ -84,14 +86,15 @@
           <%= f.label :discontinue_on, Spree.t(:discontinue_on) %>
           <%= f.error_message_on :discontinue_on %>
 
-          <div class="input-group">
+          <div class="input-group datePickerTo"
+               data-min-date="<%= @product.available_on %>" >
 
             <%= f.text_field :discontinue_on,
                               value: datepicker_field_value(@product.discontinue_on),
                               placeholder: Spree.t(:select_a_date),
-                              class: 'form-control shadow-none datePickerTo',
-                              'data-min-date': @product.available_on %>
-                              
+                              class: 'form-control shadow-none ',
+                              'data-input':'' %>
+
             <%= render partial: 'spree/admin/shared/cal_close' %>
           </div>
         <% end %>

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -66,8 +66,13 @@
           <%= f.label :available_on, Spree.t(:available_on) %>
           <%= f.error_message_on :available_on %>
 
-          <div class="input-group datePickerFrom">
-            <%= f.text_field :available_on, value: datepicker_field_value(@product.available_on), placeholder: Spree.t(:select_a_date), class: 'form-control shadow-none', 'data-input':'' %>
+          <div class="input-group">
+            <%= f.text_field :available_on,
+                             value: datepicker_field_value(@product.available_on),
+                             placeholder: Spree.t(:select_a_date),
+                             class: 'form-control shadow-none datePickerFrom',
+                            'data-max-date': @product.discontinue_on %>
+
             <%= render partial: 'spree/admin/shared/cal_close' %>
           </div>
         <% end %>
@@ -79,8 +84,14 @@
           <%= f.label :discontinue_on, Spree.t(:discontinue_on) %>
           <%= f.error_message_on :discontinue_on %>
 
-          <div class="input-group datePickerTo">
-            <%= f.text_field :discontinue_on, value: datepicker_field_value(@product.discontinue_on), placeholder: Spree.t(:select_a_date), class: 'form-control shadow-none', 'data-input':'' %>
+          <div class="input-group">
+
+            <%= f.text_field :discontinue_on,
+                              value: datepicker_field_value(@product.discontinue_on),
+                              placeholder: Spree.t(:select_a_date),
+                              class: 'form-control shadow-none datePickerTo',
+                              'data-min-date': @product.available_on %>
+                              
             <%= render partial: 'spree/admin/shared/cal_close' %>
           </div>
         <% end %>

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -67,6 +67,7 @@
           <%= f.error_message_on :available_on %>
 
           <div class="input-group datePickerFrom"
+               data-wrap="true"
                data-max-date="<%= @product.discontinue_on %>" >
 
             <%= f.text_field :available_on,
@@ -87,6 +88,7 @@
           <%= f.error_message_on :discontinue_on %>
 
           <div class="input-group datePickerTo"
+               data-wrap="true"
                data-min-date="<%= @product.available_on %>" >
 
             <%= f.text_field :discontinue_on,

--- a/backend/app/views/spree/admin/products/new.html.erb
+++ b/backend/app/views/spree/admin/products/new.html.erb
@@ -44,8 +44,12 @@
           <%= f.label :available_on, Spree.t(:available_on) %>
           <%= f.error_message_on :available_on %>
 
-          <div class="input-group datePickerSingle">
-            <%= f.text_field :available_on, value: datepicker_field_value(@product.available_on), placeholder: Spree.t(:select_a_date), class: 'form-control shadow-none', 'data-input':'' %>
+          <div class="input-group">
+            <%= f.text_field :available_on,
+                             value: datepicker_field_value(@product.available_on),
+                             placeholder: Spree.t(:select_a_date),
+                             class: 'form-control shadow-none datepicker' %>
+                             
             <%= render partial: 'spree/admin/shared/cal_close' %>
           </div>
         <% end %>

--- a/backend/app/views/spree/admin/products/new.html.erb
+++ b/backend/app/views/spree/admin/products/new.html.erb
@@ -44,12 +44,13 @@
           <%= f.label :available_on, Spree.t(:available_on) %>
           <%= f.error_message_on :available_on %>
 
-          <div class="input-group">
+          <div class="input-group datepicker" data-wrap="true">
             <%= f.text_field :available_on,
                              value: datepicker_field_value(@product.available_on),
                              placeholder: Spree.t(:select_a_date),
-                             class: 'form-control shadow-none datepicker' %>
-                             
+                             class: 'form-control shadow-none',
+                             'data-input':'' %>
+
             <%= render partial: 'spree/admin/shared/cal_close' %>
           </div>
         <% end %>

--- a/backend/app/views/spree/admin/promotions/_form.html.erb
+++ b/backend/app/views/spree/admin/promotions/_form.html.erb
@@ -60,16 +60,28 @@
 
     <div id="starts_at_field" class="form-group">
       <%= f.label :starts_at %>
-      <div class="input-group dateTimePickerFrom">
-        <%= f.datetime_field :starts_at, class: 'form-control shadow-none', placeholder: Spree.t('starting_from'), 'data-input':'' %>
+      <div class="input-group">
+        <%= f.datetime_field :starts_at,
+                              class: 'form-control shadow-none datePickerFrom',
+                              placeholder: Spree.t('starting_from'),
+                              'data-enable-time': 'true',
+                              'data-date-format': Spree.t('js_date_time', scope: 'date_picker'),
+                              'data-max-date': @promotion.expires_at %>
+
         <%= render partial: 'spree/admin/shared/cal_close' %>
       </div>
     </div>
 
     <div id="expires_at_field" class="form-group">
       <%= f.label :expires_at %>
-      <div class="input-group dateTimePickerTo">
-        <%= f.datetime_field :expires_at, placeholder:Spree.t('ends_at'), class: 'form-control shadow-none', 'data-input':'' %>
+      <div class="input-group">
+        <%= f.datetime_field :expires_at,
+                              placeholder:Spree.t('ends_at'),
+                              class: 'form-control shadow-none datePickerTo',
+                              'data-enable-time': 'true',
+                              'data-date-format': Spree.t('js_date_time', scope: 'date_picker'),
+                              'data-min-date': @promotion.starts_at %>
+
         <%= render partial: 'spree/admin/shared/cal_close' %>
       </div>
     </div>

--- a/backend/app/views/spree/admin/promotions/_form.html.erb
+++ b/backend/app/views/spree/admin/promotions/_form.html.erb
@@ -61,6 +61,7 @@
     <div id="starts_at_field" class="form-group">
       <%= f.label :starts_at %>
       <div class="input-group datePickerFrom"
+           data-wrap="true"
            data-enable-time="true"
            data-date-format="<%= Spree.t('js_date_time', scope: 'date_picker') %>"
            data-max-date="<%= @promotion.expires_at %>" >
@@ -76,6 +77,7 @@
     <div id="expires_at_field" class="form-group">
       <%= f.label :expires_at %>
       <div class="input-group datePickerTo"
+           data-wrap="true"
            data-enable-time= 'true'
            data-date-format= "<%= Spree.t('js_date_time', scope: 'date_picker') %>"
            data-min-date="<%= @promotion.starts_at %>" >

--- a/backend/app/views/spree/admin/promotions/_form.html.erb
+++ b/backend/app/views/spree/admin/promotions/_form.html.erb
@@ -60,13 +60,14 @@
 
     <div id="starts_at_field" class="form-group">
       <%= f.label :starts_at %>
-      <div class="input-group">
+      <div class="input-group datePickerFrom"
+           data-enable-time="true"
+           data-date-format="<%= Spree.t('js_date_time', scope: 'date_picker') %>"
+           data-max-date="<%= @promotion.expires_at %>" >
         <%= f.datetime_field :starts_at,
-                              class: 'form-control shadow-none datePickerFrom',
-                              placeholder: Spree.t('starting_from'),
-                              'data-enable-time': 'true',
-                              'data-date-format': Spree.t('js_date_time', scope: 'date_picker'),
-                              'data-max-date': @promotion.expires_at %>
+                             class: 'form-control shadow-none',
+                             placeholder: Spree.t('starting_from'),
+                             'data-input':'' %>
 
         <%= render partial: 'spree/admin/shared/cal_close' %>
       </div>
@@ -74,13 +75,14 @@
 
     <div id="expires_at_field" class="form-group">
       <%= f.label :expires_at %>
-      <div class="input-group">
+      <div class="input-group datePickerTo"
+           data-enable-time= 'true'
+           data-date-format= "<%= Spree.t('js_date_time', scope: 'date_picker') %>"
+           data-min-date="<%= @promotion.starts_at %>" >
         <%= f.datetime_field :expires_at,
                               placeholder:Spree.t('ends_at'),
-                              class: 'form-control shadow-none datePickerTo',
-                              'data-enable-time': 'true',
-                              'data-date-format': Spree.t('js_date_time', scope: 'date_picker'),
-                              'data-min-date': @promotion.starts_at %>
+                              class: 'form-control shadow-none',
+                              'data-input':'' %>
 
         <%= render partial: 'spree/admin/shared/cal_close' %>
       </div>

--- a/backend/app/views/spree/admin/shared/_cal_close.html.erb
+++ b/backend/app/views/spree/admin/shared/_cal_close.html.erb
@@ -1,10 +1,10 @@
-<div class="input-group-append append_over">
-  <span class="input-group-text force-round" data-clear>
+<div class="input-group-append append_over data-clear" data-clear>
+  <span class="input-group-text force-round">
     <%= svg_icon name: "close.svg", width: '16', height: '16' %>
   </span>
 </div>
-<div class="input-group-append append_under">
-  <span class="input-group-text" data-toggle>
+<div class="input-group-append append_under data-toggle" data-toggle>
+  <span class="input-group-text">
     <%= svg_icon name: "calendar.svg", width: '16', height: '16' %>
   </span>
 </div>

--- a/backend/app/views/spree/admin/shared/_report_order_criteria.html.erb
+++ b/backend/app/views/spree/admin/shared/_report_order_criteria.html.erb
@@ -3,25 +3,27 @@
   <%= label_tag nil, Spree.t(:date_range) %>
   <div class="date-range-filter row">
     <div class="col-12 col-md-6 mb-3 mb-md-0">
-      <div class="input-group">
+      <div class="input-group datePickerFrom"
+           data-max-date="<%= params[:q][:completed_at_lt] %>" >
         <%= s.text_field :completed_at_gt,
-                         class: 'form-control shadow-none datePickerFrom',
+                         class: 'form-control shadow-none ',
                          placeholder: Spree.t(:starting_from),
                          value: datepicker_field_value(params[:q][:completed_at_gt]),
-                         'data-max-date': params[:q][:completed_at_lt] %>
+                         'data-input':'' %>
 
         <%= render partial: 'spree/admin/shared/cal_close' %>
       </div>
     </div>
 
     <div class="col-12 col-md-6 mt-3 mt-md-0">
-      <div class="input-group">
+      <div class="input-group datePickerTo"
+           data-min-date="<%= params[:q][:completed_at_gt] %>" >
+
         <%= s.text_field :completed_at_lt,
-                         class: 'form-control shadow-none datePickerTo',
+                         class: 'form-control shadow-none ',
                          placeholder: Spree.t(:ending_at),
                          value: datepicker_field_value(params[:q][:completed_at_lt]),
-                         'data-min-date': params[:q][:completed_at_gt] %>
-
+                         'data-input':'' %>
         <%= render partial: 'spree/admin/shared/cal_close' %>
       </div>
     </div>

--- a/backend/app/views/spree/admin/shared/_report_order_criteria.html.erb
+++ b/backend/app/views/spree/admin/shared/_report_order_criteria.html.erb
@@ -3,23 +3,25 @@
   <%= label_tag nil, Spree.t(:date_range) %>
   <div class="date-range-filter row">
     <div class="col-12 col-md-6 mb-3 mb-md-0">
-      <div class="input-group datePickerFrom">
+      <div class="input-group">
         <%= s.text_field :completed_at_gt,
-                         class: 'form-control shadow-none',
+                         class: 'form-control shadow-none datePickerFrom',
                          placeholder: Spree.t(:starting_from),
                          value: datepicker_field_value(params[:q][:completed_at_gt]),
-                         'data-input':'' %>
+                         'data-max-date': params[:q][:completed_at_lt] %>
+
         <%= render partial: 'spree/admin/shared/cal_close' %>
       </div>
     </div>
 
     <div class="col-12 col-md-6 mt-3 mt-md-0">
-      <div class="input-group datePickerTo">
+      <div class="input-group">
         <%= s.text_field :completed_at_lt,
-                         class: 'form-control shadow-none',
+                         class: 'form-control shadow-none datePickerTo',
                          placeholder: Spree.t(:ending_at),
                          value: datepicker_field_value(params[:q][:completed_at_lt]),
-                         'data-input':'' %>
+                         'data-min-date': params[:q][:completed_at_gt] %>
+
         <%= render partial: 'spree/admin/shared/cal_close' %>
       </div>
     </div>

--- a/backend/app/views/spree/admin/shared/_report_order_criteria.html.erb
+++ b/backend/app/views/spree/admin/shared/_report_order_criteria.html.erb
@@ -1,36 +1,38 @@
 <%= search_form_for @search, url: spree.sales_total_admin_reports_path  do |s| %>
-<div class="form-group date-range-filter">
-  <%= label_tag nil, Spree.t(:date_range) %>
-  <div class="date-range-filter row">
-    <div class="col-12 col-md-6 mb-3 mb-md-0">
-      <div class="input-group datePickerFrom"
-           data-max-date="<%= params[:q][:completed_at_lt] %>" >
-        <%= s.text_field :completed_at_gt,
-                         class: 'form-control shadow-none ',
-                         placeholder: Spree.t(:starting_from),
-                         value: datepicker_field_value(params[:q][:completed_at_gt]),
-                         'data-input':'' %>
+  <div class="form-group date-range-filter">
+    <%= label_tag nil, Spree.t(:date_range) %>
+    <div class="date-range-filter row">
+      <div class="col-12 col-md-6 mb-3 mb-md-0">
+        <div class="input-group datePickerFrom"
+             data-wrap="true"
+             data-max-date="<%= params[:q][:completed_at_lt] %>" >
+          <%= s.text_field :completed_at_gt,
+                           class: 'form-control shadow-none',
+                           placeholder: Spree.t(:starting_from),
+                           value: datepicker_field_value(params[:q][:completed_at_gt]),
+                           'data-input':'' %>
 
-        <%= render partial: 'spree/admin/shared/cal_close' %>
+          <%= render partial: 'spree/admin/shared/cal_close' %>
+        </div>
       </div>
-    </div>
 
-    <div class="col-12 col-md-6 mt-3 mt-md-0">
-      <div class="input-group datePickerTo"
-           data-min-date="<%= params[:q][:completed_at_gt] %>" >
+      <div class="col-12 col-md-6 mt-3 mt-md-0">
+        <div class="input-group datePickerTo"
+             data-wrap="true"
+             data-min-date="<%= params[:q][:completed_at_gt] %>" >
 
-        <%= s.text_field :completed_at_lt,
-                         class: 'form-control shadow-none ',
-                         placeholder: Spree.t(:ending_at),
-                         value: datepicker_field_value(params[:q][:completed_at_lt]),
-                         'data-input':'' %>
-        <%= render partial: 'spree/admin/shared/cal_close' %>
+          <%= s.text_field :completed_at_lt,
+                           class: 'form-control shadow-none',
+                           placeholder: Spree.t(:ending_at),
+                           value: datepicker_field_value(params[:q][:completed_at_lt]),
+                           'data-input':'' %>
+          <%= render partial: 'spree/admin/shared/cal_close' %>
+        </div>
       </div>
     </div>
   </div>
-</div>
 
-<div class="form-actions">
-  <%= button Spree.t(:search), 'search.svg' %>
-</div>
+  <div class="form-actions">
+    <%= button Spree.t(:search), 'search.svg' %>
+  </div>
 <% end %>

--- a/backend/app/views/spree/admin/variants/_form.html.erb
+++ b/backend/app/views/spree/admin/variants/_form.html.erb
@@ -42,9 +42,7 @@
       <div class="form-group" data-hook="discontinue_on">
           <%= f.label :discontinue_on, Spree.t(:discontinue_on) %>
           <%= f.error_message_on :discontinue_on %>
-          <div class="input-group datepicker"
-               data-date-format="Y-mm-d"
-                >
+          <div class="input-group datepicker" data-wrap="true" >
             <%= f.text_field :discontinue_on,
                              value: datepicker_field_value(@variant.discontinue_on),
                              placeholder: Spree.t(:select_a_date),

--- a/backend/app/views/spree/admin/variants/_form.html.erb
+++ b/backend/app/views/spree/admin/variants/_form.html.erb
@@ -42,8 +42,15 @@
       <div class="form-group" data-hook="discontinue_on">
           <%= f.label :discontinue_on, Spree.t(:discontinue_on) %>
           <%= f.error_message_on :discontinue_on %>
-          <div class="input-group datePickerSingle">
-            <%= f.text_field :discontinue_on, value: datepicker_field_value(@variant.discontinue_on), placeholder: Spree.t(:select_a_date), class: 'form-control shadow-none', 'data-input':'' %>
+          <div class="input-group datepicker"
+               data-date-format="Y-mm-d"
+                >
+            <%= f.text_field :discontinue_on,
+                             value: datepicker_field_value(@variant.discontinue_on),
+                             placeholder: Spree.t(:select_a_date),
+                             class: 'form-control shadow-none',
+                             'data-input':'' %>
+
             <%= render partial: 'spree/admin/shared/cal_close' %>
           </div>
       </div>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -762,6 +762,7 @@ en:
       format: ! '%Y/%m/%d'
       hourAriaLabel: 'Hour'
       js_format: Y/m/d
+      js_date_time: Y/m/d - H:i
       minuteAriaLabel: 'Minute'
       pm: 'PM'
       rangeSeparator: ' to '


### PR DESCRIPTION
- Reduced the complexity in the javascript for flatpickers, but also added flexibility of use on a per instant basis in the view files.
- Allows for the wrapped to/from date pickers with toggle open/close calendar icon plus the clear field button. Or use with the `datePickerTo` and `datePickerFrom` classes directly on the input fields for basic use.
-  Single date picker works for all fallbacks out of the box, but allows you to customise to wrap mode allowing you to create toggleable or the specific flat picker configs on a per instance basis.
- Added some basic styles to a plugin specific style sheet arrows now hover to the theme primary color.
- Use mobile native time and date pickers.