### PR TITLE
Fix mismatched tags in default frontend

### DIFF
--- a/frontend/app/views/spree/shared/_main_nav_bar.html.erb
+++ b/frontend/app/views/spree/shared/_main_nav_bar.html.erb
@@ -11,8 +11,8 @@
           <% if has_dropdown %>
             <div class="dropdown-menu w-100 shadow main-nav-bar-category-dropdown">
               <div class="container p-0 d-flex justify-content-xl-around mx-auto">
-                <% if root[:items].present? %>
-                  <div class="row">
+                <div class="row">
+                  <% if root[:items].present? %>
                     <div class="category-links">
                       <% if root[:subtitle].present? %>
                         <div class="category-links-header text-uppercase">


### PR DESCRIPTION
The default frontend had a div tag opened within a condition and the corresponding closing tag outside of that condition, causing a mismatch if the condition was not met (i.e. no items were present in that root menu item).