### PR TITLE
ADMIN: Select2 Styling Improvements

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_buttons.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_buttons.scss
@@ -38,13 +38,3 @@ input[type="file"]::-webkit-file-upload-button {
 .page-actions .btn {
   margin: 2px;
 }
-
-input.flatpickr-input {
-  /* Remove First */
--webkit-appearance: none;
--moz-appearance: none;
-appearance: none;
-
-  background-color: white !important;
-
-}

--- a/backend/app/assets/stylesheets/spree/backend/global/_variables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/global/_variables.scss
@@ -6,7 +6,6 @@
   $info:    #48B0F7;
   $warning: #F8D053;
   $danger:  #F55753;
-
   $input-border-color:  darken(#EDEDED, 5);
 
 /*------------------------------------------

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_flatpickr.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_flatpickr.scss
@@ -5,6 +5,13 @@
   }
 }
 
+input.flatpickr-input {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: white !important;
+}
+
 .input-group {
   input.flatpickr-input{
     @include swith-appended-icon  {
@@ -23,13 +30,6 @@
 
 .flatpickr-day {
   border-radius: 7px;
-}
-
-input.flatpickr-input {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: white !important;
 }
 
 // Fix Flatpickr bug where things jusy highlight for no reason.

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_flatpickr.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_flatpickr.scss
@@ -21,9 +21,15 @@
   height: 100%;
 }
 
-
 .flatpickr-day {
   border-radius: 7px;
+}
+
+input.flatpickr-input {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: white !important;
 }
 
 // Fix Flatpickr bug where things jusy highlight for no reason.

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_flatpickr.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_flatpickr.scss
@@ -41,3 +41,12 @@ input.flatpickr-input[readonly] {
 .flatpickr-months .flatpickr-next-month:hover svg {
   fill: $primary;
 }
+
+// Force rounded corner for the toggle cal and close icons.
+.input-group >
+.input-group-append:not(:last-child) >
+.force-round {
+  z-index: 5;
+  border-top-right-radius: $border-radius !important;
+  border-bottom-right-radius: $border-radius !important;
+}

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
@@ -82,7 +82,7 @@
   border-color: lighten($success, 20) !important;
   border-top: 0;
   border-radius: 0 0  $border-radius $border-radius;
-  margin-top: -8px;
+  margin-top: -6px;
 }
 
 .select2-drop.select2-drop-above.select2-drop-active {
@@ -90,7 +90,7 @@
   border-top: 1px solid lighten($success, 20);
 
   border-radius: $border-radius $border-radius 0 0;
-  margin-top: 8px;
+  margin-top: 6px;
 }
 
 div.select2-container-active.select2-drop-above {

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
@@ -7,6 +7,7 @@
     border-color: $input-border-color;
     background-image: none;
     background-color: $input-bg;
+    color: $gray-700;
 
     &,
     .select2-arrow {
@@ -32,7 +33,6 @@
     }
 
     .select2-chosen {
-      line-height: 36px;
       vertical-align: middle;
       display: inline;
     }
@@ -43,6 +43,10 @@
   }
 }
 
+.select2-container-multi .select2-choices .select2-search-field input {
+  color: $gray-700;
+}
+
 .select2-search input {
   border-color: $input-border-color;
   border-radius: $border-radius;
@@ -51,7 +55,7 @@
   vertical-align: middle !important;
   background-repeat: no-repeat !important;
   background-size: 1rem !important;
-  background-position: 98% !important;
+  background-position: 97% !important;
 }
 
 .select2-drop {
@@ -109,6 +113,7 @@ div.select2-container-active.select2-drop-above {
 
 .select2-results .select2-highlighted {
   background-color: $primary;
+  border-radius: $border-radius; 
 
   .select2-result-label {
     color: white;
@@ -146,7 +151,7 @@ div.select2-container-active.select2-drop-above {
       }
 
       div {
-        padding-left: 15px;
+        padding-left: 17px;
       }
     }
   }

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
@@ -68,8 +68,8 @@
 .select2-container-active {
   .select2-choice,
   .select2-choices {
-    border-color: lighten($success, 20);
-    border-bottom: 1px solid lighten($success, 20);
+    border-color: $input-focus-border-color;
+    border-bottom: 1px solid $input-focus-border-color;
   }
   &, & a {
     box-shadow: none !important;
@@ -83,15 +83,15 @@
 
 
 .select2-drop.select2-drop-active {
-  border-color: lighten($success, 20) !important;
+  border-color: $input-focus-border-color;
   border-top: 0;
   border-radius: 0 0  $border-radius $border-radius;
   margin-top: -6px;
 }
 
 .select2-drop.select2-drop-above.select2-drop-active {
-  border-color: lighten($success, 20);
-  border-top: 1px solid lighten($success, 20);
+  border-color: $input-focus-border-color;
+  border-top: 1px solid $input-focus-border-color;
 
   border-radius: $border-radius $border-radius 0 0;
   margin-top: 6px;
@@ -99,8 +99,8 @@
 
 div.select2-container-active.select2-drop-above {
   .select2-choice {
-    border-color: lighten($success, 20);
-    border-top: 1px solid lighten($success, 20);
+    border-color: $input-focus-border-color;
+    border-top: 1px solid $input-focus-border-color;
   }
 }
 
@@ -113,7 +113,7 @@ div.select2-container-active.select2-drop-above {
 
 .select2-results .select2-highlighted {
   background-color: $primary;
-  border-radius: $border-radius; 
+  border-radius: $border-radius;
 
   .select2-result-label {
     color: white;
@@ -159,7 +159,7 @@ div.select2-container-active.select2-drop-above {
   &.select2-container-active {
     .select2-choices {
       box-shadow: none;
-      border-color: lighten($success, 20);
+      border-color: $input-focus-border-color;
     }
   }
 }

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
@@ -82,13 +82,15 @@
   border-color: lighten($success, 20) !important;
   border-top: 0;
   border-radius: 0 0  $border-radius $border-radius;
+  margin-top: -8px;
 }
 
 .select2-drop.select2-drop-above.select2-drop-active {
   border-color: lighten($success, 20);
   border-top: 1px solid lighten($success, 20);
-  border-bottom: 0;
+
   border-radius: $border-radius $border-radius 0 0;
+  margin-top: 8px;
 }
 
 div.select2-container-active.select2-drop-above {

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
@@ -62,6 +62,11 @@
 }
 
 .select2-container-active {
+  .select2-choice,
+  .select2-choices {
+    border-color: lighten($success, 20);
+    border-bottom: 1px solid lighten($success, 20);
+  }
   &, & a {
     box-shadow: none !important;
   }
@@ -86,14 +91,6 @@
   border-radius: $border-radius $border-radius 0 0;
 }
 
-.select2-container-active {
-  .select2-choice,
-  .select2-choices {
-    border-color: lighten($success, 20);
-    border-bottom: 1px solid lighten($success, 20);
-  }
-}
-
 div.select2-container-active.select2-drop-above {
   .select2-choice {
     border-color: lighten($success, 20);
@@ -104,11 +101,6 @@ div.select2-container-active.select2-drop-above {
 .select2-container.select2-drop-above .select2-choice {
   border-radius: $border-radius;
 }
-
-.select2-container-multi.select2-container-active .select2-choices {
-  border-color: lighten($success, 20);
-}
-
 .select2-result-label {
   color: $gray-900;
 }
@@ -160,6 +152,7 @@ div.select2-container-active.select2-drop-above {
   &.select2-container-active {
     .select2-choices {
       box-shadow: none;
+      border-color: lighten($success, 20);
     }
   }
 }

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
@@ -21,7 +21,6 @@
       border-left-color: $input-border-color;
       width: 24px;
 
-
       b {
         background-image: url(asset-path("backend-chevron-down.svg")) !important;
         overflow: hidden !important;
@@ -73,24 +72,42 @@
   background-image: none;
 }
 
-.select2-dropdown-open.select2-drop-above .select2-choice {
-  border-radius: 0 0 $border-radius $border-radius;
-}
 
-.select2-drop-above,
-.select2-dropdown-open.select2-drop-above .select2-choice,
-.select2-dropdown-open .select2-choice {
-  border-color: lighten($success, 20);
-  border-bottom: none !important;
-  border-radius: $border-radius $border-radius 0 0 ;
-}
-
-.select2-drop.select2-drop-above.select2-drop-active,
 .select2-drop.select2-drop-active {
-  border-color: lighten($success, 20);
-  border-top: none;
+  border-color: lighten($success, 20) !important;
+  border-top: 0;
+  border-radius: 0 0  $border-radius $border-radius;
 }
 
+.select2-drop.select2-drop-above.select2-drop-active {
+  border-color: lighten($success, 20);
+  border-top: 1px solid lighten($success, 20);
+  border-bottom: 0;
+  border-radius: $border-radius $border-radius 0 0;
+}
+
+.select2-container-active {
+  .select2-choice,
+  .select2-choices {
+    border-color: lighten($success, 20);
+    border-bottom: 1px solid lighten($success, 20);
+  }
+}
+
+div.select2-container-active.select2-drop-above {
+  .select2-choice {
+    border-color: lighten($success, 20);
+    border-top: 1px solid lighten($success, 20);
+  }
+}
+
+.select2-container.select2-drop-above .select2-choice {
+  border-radius: $border-radius;
+}
+
+.select2-container-multi.select2-container-active .select2-choices {
+  border-color: lighten($success, 20);
+}
 
 .select2-result-label {
   color: $gray-900;
@@ -106,7 +123,7 @@
 
 .select2-container-multi {
   .select2-choices {
-    min-height: 38px;
+    min-height: $input-height;
     border-radius: $border-radius;
     line-height: 1;
     border-color: $input-border-color;
@@ -143,7 +160,6 @@
   &.select2-container-active {
     .select2-choices {
       box-shadow: none;
-
     }
   }
 }
@@ -162,7 +178,7 @@
   background-repeat: no-repeat !important;
   background-position: 50% !important;
   right:30px;
-  background-size: 0.7rem !important;
+  background-size: 0.8rem !important;
 }
 
 .select2-container-multi .select2-choices .select2-search-choice .select2-search-choice-close:hover {

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
@@ -21,7 +21,6 @@
       border-left-color: $input-border-color;
       width: 24px;
 
-
       b {
         background-image: url(asset-path("backend-chevron-down.svg")) !important;
         overflow: hidden !important;
@@ -73,24 +72,42 @@
   background-image: none;
 }
 
-.select2-dropdown-open.select2-drop-above .select2-choice {
-  border-radius: 0 0 $border-radius $border-radius;
-}
 
-.select2-drop-above,
-.select2-dropdown-open.select2-drop-above .select2-choice,
-.select2-dropdown-open .select2-choice {
-  border-color: lighten($success, 20);
-  border-bottom: none !important;
-  border-radius: $border-radius $border-radius 0 0 ;
-}
-
-.select2-drop.select2-drop-above.select2-drop-active,
 .select2-drop.select2-drop-active {
-  border-color: lighten($success, 20);
-  border-top: none;
+  border-color: lighten($success, 20) !important;
+  border-top: 0;
+  border-radius: 0 0  $border-radius $border-radius;
 }
 
+.select2-drop.select2-drop-above.select2-drop-active {
+  border-color: lighten($success, 20);
+  border-top: 1px solid lighten($success, 20);
+  border-bottom: 0;
+  border-radius: $border-radius $border-radius 0 0;
+}
+
+.select2-container-active {
+  .select2-choice,
+  .select2-choices {
+    border-color: lighten($success, 20);
+    border-bottom: 1px solid lighten($success, 20);
+  }
+}
+
+div.select2-container-active.select2-drop-above {
+  .select2-choice {
+    border-color: lighten($success, 20);
+    border-top: 1px solid lighten($success, 20);
+  }
+}
+
+.select2-container.select2-drop-above .select2-choice {
+  border-radius: $border-radius;
+}
+
+.select2-container-multi.select2-container-active .select2-choices {
+  border-color: lighten($success, 20);
+}
 
 .select2-result-label {
   color: $gray-900;
@@ -143,7 +160,6 @@
   &.select2-container-active {
     .select2-choices {
       box-shadow: none;
-
     }
   }
 }
@@ -162,7 +178,7 @@
   background-repeat: no-repeat !important;
   background-position: 50% !important;
   right:30px;
-  background-size: 0.7rem !important;
+  background-size: 0.8rem !important;
 }
 
 .select2-container-multi .select2-choices .select2-search-choice .select2-search-choice-close:hover {

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
@@ -51,7 +51,7 @@
   vertical-align: middle !important;
   background-repeat: no-repeat !important;
   background-size: 1rem !important;
-  background-position: 95% !important;
+  background-position: 98% !important;
 }
 
 .select2-drop {

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -26,22 +26,30 @@ span.or {
 }
 
 // Hide number toggler
-/* Chrome, Safari, Edge, Opera */
+  // Chrome, Safari, Edge, Opera
 input.hide-number-toggle::-webkit-outer-spin-button,
 input.hide-number-toggle::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
-
-/* Firefox */
+  // Firefox
 input[type=number].hide-number-toggle {
   -moz-appearance: textfield;
 }
 
-.input-group >
-.input-group-append:not(:last-child) >
-.force-round {
-  z-index: 5;
-  border-top-right-radius: 2px !important;
-  border-bottom-right-radius: 2px !important;
+
+// Remove the default 5px outlines and box-shadows
+// from all inputs on focus.
+.form-control:focus {
+  box-shadow: none !important;
+}
+
+*:focus {
+    outline: none;
+}
+
+:-webkit-direct-focus {
+  outline-color: transparent;
+  outline-style: auto;
+  outline-width: 0;
 }


### PR DESCRIPTION
- Consistent border styling when the Select2 pop-up appears above or below the input.
- Use `$input-height` to set the height rather than a set number of px.
- Can now take higher border radius values and still retain the proper look and feel when the select2 is open.
- Set the active/focus border color of a Select2 input to match that of other inputs.