### PR TITLE
ADMIN: Set .card overflow to hidden

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/shared/_base.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_base.scss
@@ -2,6 +2,10 @@
   padding: 0 0 15px 0;
 }
 
+.card {
+  overflow: hidden;
+}
+
 .is-hidden {
   display: none;
 }


### PR DESCRIPTION
Set .card overflow: hidden; stop tables showing over rounded corners.