### PR TITLE
Fix Appearance of Action Buttons in The Contextual Menu

### DIFF
--- a/backend/app/views/spree/admin/shared/_sidebar.html.erb
+++ b/backend/app/views/spree/admin/shared/_sidebar.html.erb
@@ -1,6 +1,6 @@
 
 <% if content_for?(:page_actions) %>
-  <div class="page-actions d-lg-none col-12 px-0 <% if content_for?(:sidebar) %>pb-3<% end %> text-center" data-hook="toolbar">
+  <div class="page-actions d-flex justify-content-center flex-wrap d-lg-none col-12 px-0 <% if content_for?(:sidebar) %>pb-3<% end %> text-center" data-hook="toolbar">
     <%= yield :page_actions %>
   </div>
 <% end %>


### PR DESCRIPTION
If the buttons were in a `<from>` tag they would stack verses inline if there were in `<button>` or `<a>` tags in other parts of the UI, could of simply used `display:inline-block;` on the form tags, but it adds a weird margin on one item unless you start using floats.

BEFORE
<img width="851" alt="Screenshot 2020-07-13 at 21 33 55" src="https://user-images.githubusercontent.com/1240766/87351003-9e2c9980-c550-11ea-90e8-875e5656c61a.png">

AFTER:
<img width="766" alt="Screenshot 2020-07-13 at 21 33 37" src="https://user-images.githubusercontent.com/1240766/87351023-a7b60180-c550-11ea-8165-c2cf85a97763.png">

