### PR TITLE
ADMIN: Valid HTML

### DIFF
--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -235,7 +235,7 @@ module Spree
             text = "#{icon} #{text}"
           end
 
-          link_to(text.html_safe, url, html_options)
+          link_to(text.html_safe, url, html_options.except(:icon))
         end
       end
 

--- a/backend/app/views/spree/admin/shared/_account_nav.html.erb
+++ b/backend/app/views/spree/admin/shared/_account_nav.html.erb
@@ -6,68 +6,54 @@
     </button>
 
     <div class="dropdown-menu dropdown-menu-right mt-2 p-0 mr-2">
-
       <div class="dropdown-item px-0 text-center bg-light">
         <span class="d-block text-dark py-2 px-4"><%= try_spree_current_user.email %></span>
       </div>
-
       <div class="dropdown-divider m-0"></div>
+
       <% if spree.respond_to? :root_path %>
-        <button class="dropdown-item px-0" type="button">
-          <%= link_to spree.root_path, target: :blank, class: 'd-block text-dark py-2 px-4' do %>
+          <%= link_to spree.root_path, target: :blank, class: 'd-block text-dark py-3 px-4 dropdown-item' do %>
             <%= svg_icon name: "store.svg", width: '18', height: '18' %>
             &nbsp;
             <%= Spree.t(:back_to_store) %>
           <% end %>
-        </button>
       <% end %>
 
       <% if can?(:manage, try_spree_current_user) %>
-        <button class="dropdown-item px-0" type="button">
-          <%= link_to spree.edit_admin_user_path(try_spree_current_user), class: 'd-block text-dark py-2 px-4' do %>
+          <%= link_to spree.edit_admin_user_path(try_spree_current_user), class: 'd-block text-dark py-3 px-4 dropdown-item' do %>
             <%= svg_icon name: "user.svg", width: '18', height: '18' %>
             &nbsp;
             <%= Spree.t(:account) %>
           <% end %>
-        </button>
       <% end %>
 
       <% if defined?(spree_logout_path) %>
-        <li class="dropdown-item p-0">
-          <%= link_to spree_logout_path, class: 'd-block text-dark py-2 px-4' do %>
+          <%= link_to spree_logout_path, class: 'd-block text-dark py-3 px-4 dropdown-item' do %>
             <%= svg_icon name: "exit.svg", width: '18', height: '18' %>
             &nbsp;
             <%= Spree.t(:logout) %>
           <% end %>
-        </li>
       <% end %>
 
       <div class="dropdown-divider m-0"></div>
 
-      <button class="dropdown-item px-0" type="button">
-        <%= link_to 'http://guides.spreecommerce.org', target: :blank, class: 'd-block text-dark py-2 px-4' do %>
+        <%= link_to 'http://guides.spreecommerce.org', target: :blank, class: 'd-block text-dark py-3 px-4 dropdown-item' do %>
         <%= svg_icon name: "info.svg", width: '18', height: '18' %>
           &nbsp;
           <%= Spree.t(:help_center) %>
         <% end %>
-      </button>
 
-      <button class="dropdown-item px-0" type="button">
-        <%= link_to 'http://slack.spreecommerce.org', target: :blank, class: 'd-block text-dark py-2 px-4' do %>
+        <%= link_to 'http://slack.spreecommerce.org', target: :blank, class: 'd-block text-dark py-3 px-4 dropdown-item' do %>
         <%= svg_icon name: "slack.svg", width: '18', height: '18' %>
           &nbsp;
           <%= Spree.t(:join_slack) %>
         <% end %>
-      </button>
 
-      <button class="dropdown-item px-0" type="button">
-        <%= link_to 'https://github.com/spree-contrib', target: :blank, class: 'd-block text-dark py-2 px-4' do %>
+        <%= link_to 'https://github.com/spree-contrib', target: :blank, class: 'd-block text-dark py-3 px-4 dropdown-item' do %>
         <%= svg_icon name: "extensions.svg", width: '18', height: '18' %>
           &nbsp;
           <%= Spree.t(:extensions_directory) %>
         <% end %>
-      </button>
-
     </div>
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/shared/_header.html.erb
+++ b/backend/app/views/spree/admin/shared/_header.html.erb
@@ -1,6 +1,6 @@
 <header class="header logged-in">
 
-  <nav class="navbar fixed-top navbar-dark align-items-middle" role="navigation">
+  <nav class="navbar fixed-top navbar-dark align-items-middle">
     <div class="col-3 col-sm-4 p-0 d-lg-none">
       <button
         id="sidebar-open"
@@ -13,7 +13,7 @@
     </div>
     <div class="col text-center text-lg-left">
       <%= link_to(
-        image_tag(Spree::Config[:admin_interface_logo], id: 'logo'),
+        image_tag(Spree::Config[:admin_interface_logo], id: 'logo', alt: current_store.name),
         spree.admin_path,
         class: "logo navbar-brand"
       ) %>

--- a/backend/app/views/spree/layouts/admin.html.erb
+++ b/backend/app/views/spree/layouts/admin.html.erb
@@ -45,7 +45,7 @@
         <%#-------------------------------------------------%>
         <%# Content                                         %>
         <%#-------------------------------------------------%>
-        <main class="col-12 col-lg-9 col-xl-10 offset-lg-3 offset-xl-2 main" id="main-part" role="main">
+        <main class="col-12 col-lg-9 col-xl-10 offset-lg-3 offset-xl-2 main" id="main-part">
           <div class="container">
 
             <%#-------------------------------------------------%>
@@ -81,7 +81,7 @@
         </main>
       </div>
     </div>
-    
+
     <%#-------------------------------------------------%>
     <%# Insert footer scripts here                      %>
     <%#-------------------------------------------------%>


### PR DESCRIPTION
- Account nav html was not valid, `<a>` tags inside `<button>` tags, and then one instance was a random `<li>` without the proper parent.
- role="navigation" & `role="main"` not needed on elements of the same type `<main role="main">`.
- Added alt text to spree logo (current store name).
- removed `icon="some_icon.svg"` form `<a>` tags generated via the navigation helper.