### PR TITLE
ADMIN: Fix Bad ID on address form + Select2 styling.

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -190,7 +190,7 @@ function show_flash (type, message) {
   var flashDiv = $('.alert-' + type)
   if (flashDiv.length === 0) {
     flashDiv = $('<div class="d-flex justify-content-center position-fixed flash-alert">' +
-                 '<div class="alert alert-' + type + '">' + cleanMessage + '</div></div>')
+                 '<div class="alert alert-' + type + ' mx-2">' + cleanMessage + '</div></div>')
 
     $('body').append(flashDiv)
 

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
@@ -83,28 +83,18 @@
 
 
 .select2-drop.select2-drop-active {
-  border-color: $input-focus-border-color;
-  border-top: 0;
-  border-radius: 0 0  $border-radius $border-radius;
-  margin-top: -6px;
+  border-color: $input-focus-border-color !important;
+  border-top: 1px solid $input-focus-border-color;
+  border-bottom: 1px solid $input-focus-border-color;
+  margin-top: 2px;
 }
 
 .select2-drop.select2-drop-above.select2-drop-active {
-  border-color: $input-focus-border-color;
-  border-top: 1px solid $input-focus-border-color;
-
-  border-radius: $border-radius $border-radius 0 0;
-  margin-top: 6px;
-}
-
-div.select2-container-active.select2-drop-above {
-  .select2-choice {
-    border-color: $input-focus-border-color;
-    border-top: 1px solid $input-focus-border-color;
-  }
+  margin-top: -2px;
 }
 
 .select2-container.select2-drop-above .select2-choice {
+  border-color: $input-focus-border-color !important;
   border-radius: $border-radius;
 }
 .select2-result-label {

--- a/backend/app/helpers/spree/admin/base_helper.rb
+++ b/backend/app/helpers/spree/admin/base_helper.rb
@@ -7,7 +7,7 @@ module Spree
           flash_class = 'danger' if flash[:error]
           flash_class = 'info' if flash[:notice]
           flash_class = 'success' if flash[:success]
-          flash_div = content_tag(:div, message, class: "alert alert-#{flash_class} mx-4")
+          flash_div = content_tag(:div, message, class: "alert alert-#{flash_class} mx-2")
           content_tag(:div, flash_div,
                       class: 'd-flex justify-content-center position-fixed flash-alert ')
         end

--- a/backend/app/views/spree/admin/shared/_address_form.html.erb
+++ b/backend/app/views/spree/admin/shared/_address_form.html.erb
@@ -1,38 +1,38 @@
 <% s_or_b = type.chars.first %>
 <div id="<%= type %>" data-hook="address_fields">
-<% Spree::Address::ADDRESS_FIELDS.each do |field| %>
-  <% if field == "country" %>
-    <div id="<%= type + '_' + field %>" class="form-group <%= "#{type}-row" %>">
-      <%= f.label :country_id, Spree.t(:country) %>
-      <span id="<%= s_or_b %>country">
-        <%= f.collection_select :country_id, available_countries, :id, :name, {}, { class: 'select2' } %>
-      </span>
-    </div>
-  <% elsif field == "state" %>
-    <%= field_container (type + '_' + field), :state, class: ["form-group", "#{type}-row"] do %>
-      <%= f.label :state_id, Spree.t(:state) %>
-      <span id="<%= s_or_b %>state">
-        <% if f.object.country.try(:states) %>
-          <%= f.text_field :state_name,
-                           style: "display: #{f.object.country.try(:states) && f.object.country.states.empty? ? 'block' : 'none' };",
-                           disabled: !(f.object.country.try(:states) && f.object.country.states.empty?), class: 'form-control state_name' %>
-          <%= f.collection_select :state_id, f.object.country.states.sort, :id, :name, { include_blank: true }, { class: 'select2', style: "display: #{ f.object.country.states.empty? ? 'none' : 'block' };", disabled: f.object.country.states.empty? } %>
-        <% else %>
-          <div>
-            <em><%= Spree.t(:no_country) %></em>
-          </div>
-        <% end %>
-      </span>
-      <%= error_message_on f.object, :state_id %>
-    <% end %>
-  <% else %>
-    <%= field_container (type + '_' + field), field, class: ["form-group", "#{type}-row"] do %>
-      <%= f.label field, Spree.t(field) %>
-      <%= f.text_field field, class: 'form-control' %>
-      <%= error_message_on f.object, field %>
+  <% Spree::Address::ADDRESS_FIELDS.each do |field| %>
+    <% if field == "country" %>
+      <%= field_container (s_or_b + '_' + field), nil, class: ["form-group", "#{type}-row"] do %>
+        <%= f.label :country_id, Spree.t(:country) %>
+        <span id="<%= s_or_b %>country">
+          <%= f.collection_select :country_id, available_countries, :id, :name, {}, { class: 'select2' } %>
+        </span>
+      <% end %>
+    <% elsif field == "state" %>
+      <%= field_container (s_or_b + '_' + field), :state, class: ["form-group", "#{type}-row"] do %>
+        <%= f.label :state_id, Spree.t(:state) %>
+        <span id="<%= s_or_b %>state">
+          <% if f.object.country.try(:states) %>
+            <%= f.text_field :state_name,
+                             style: "display: #{f.object.country.try(:states) && f.object.country.states.empty? ? 'block' : 'none' };",
+                             disabled: !(f.object.country.try(:states) && f.object.country.states.empty?), class: 'form-control state_name' %>
+            <%= f.collection_select :state_id, f.object.country.states.sort, :id, :name, { include_blank: true }, { class: 'select2', style: "display: #{ f.object.country.states.empty? ? 'none' : 'block' };", disabled: f.object.country.states.empty? } %>
+          <% else %>
+            <div>
+              <em><%= Spree.t(:no_country) %></em>
+            </div>
+          <% end %>
+        </span>
+        <%= error_message_on f.object, :state_id %>
+      <% end %>
+    <% else %>
+      <%= field_container (s_or_b + '_' + field), nil, class: ["form-group", "#{type}-row"] do %>
+        <%= f.label field, Spree.t(field) %>
+        <%= f.text_field field, class: 'form-control' %>
+        <%= error_message_on f.object, field %>
+      <% end %>
     <% end %>
   <% end %>
-<% end %>
 </div>
 
 <% content_for :head do %>

--- a/backend/app/views/spree/admin/shared/_address_form.html.erb
+++ b/backend/app/views/spree/admin/shared/_address_form.html.erb
@@ -2,14 +2,14 @@
 <div id="<%= type %>" data-hook="address_fields">
 <% Spree::Address::ADDRESS_FIELDS.each do |field| %>
   <% if field == "country" %>
-    <div class="form-group <%= "#{type}-row" %>">
+    <div id="<%= type + '_' + field %>" class="form-group <%= "#{type}-row" %>">
       <%= f.label :country_id, Spree.t(:country) %>
       <span id="<%= s_or_b %>country">
         <%= f.collection_select :country_id, available_countries, :id, :name, {}, { class: 'select2' } %>
       </span>
     </div>
   <% elsif field == "state" %>
-    <%= field_container f.object, :state, class: ["form-group", "#{type}-row"] do %>
+    <%= field_container (type + '_' + field), :state, class: ["form-group", "#{type}-row"] do %>
       <%= f.label :state_id, Spree.t(:state) %>
       <span id="<%= s_or_b %>state">
         <% if f.object.country.try(:states) %>
@@ -26,7 +26,7 @@
       <%= error_message_on f.object, :state_id %>
     <% end %>
   <% else %>
-    <%= field_container f.object, field, class: ["form-group", "#{type}-row"] do %>
+    <%= field_container (type + '_' + field), field, class: ["form-group", "#{type}-row"] do %>
       <%= f.label field, Spree.t(field) %>
       <%= f.text_field field, class: 'form-control' %>
       <%= error_message_on f.object, field %>


### PR DESCRIPTION
Address form continuers used bad ID's

BEFORE:
<img width="1132" alt="Screenshot 2020-07-14 at 15 07 51" src="https://user-images.githubusercontent.com/1240766/87444745-177ac980-c5ef-11ea-8c1f-35be417311ba.png">

AFTER:
<img width="800" alt="Screenshot 2020-07-14 at 16 41 10" src="https://user-images.githubusercontent.com/1240766/87446159-d7b4e180-c5f0-11ea-82b9-b05db6b4028a.png">

Had to re-style Select2 slightly. The width on the Select2 dropdown div is set by javascript based on the width of the largest child item, or the width of the containing item what ever is greater, causing a bad look if the content is wider than the container.

BEFORE:
<img width="579" alt="Screenshot 2020-07-14 at 16 45 18" src="https://user-images.githubusercontent.com/1240766/87446625-6d507100-c5f1-11ea-9892-216a0c9aba40.png">


AFTER:
<img width="1090" alt="Screenshot 2020-07-14 at 16 26 30" src="https://user-images.githubusercontent.com/1240766/87446452-38dcb500-c5f1-11ea-9a50-7469600685aa.png">




