### PR TITLE
Lower z-index on flatpickr, select2 & tooltips

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/plugins/_flatpickr.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_flatpickr.scss
@@ -56,3 +56,7 @@ input.flatpickr-input[readonly] {
   border-top-right-radius: $border-radius !important;
   border-bottom-right-radius: $border-radius !important;
 }
+
+div.flatpickr-calendar.open {
+  z-index: $zindex-dropdown;
+}

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
@@ -59,6 +59,7 @@
 }
 
 .select2-drop {
+  z-index: $zindex-dropdown;
   &, &.select2-drop-above {
     border-radius: $border-radius;
     box-shadow: none;

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
@@ -59,7 +59,6 @@
 }
 
 .select2-drop {
-  z-index: $zindex-dropdown;
   &, &.select2-drop-above {
     border-radius: $border-radius;
     box-shadow: none;

--- a/backend/app/assets/stylesheets/spree/backend/shared/_base.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_base.scss
@@ -10,6 +10,10 @@
   display: none;
 }
 
+.tooltip{
+  z-index: $zindex-dropdown;
+}
+
 // No-margin and no-padding helper classes
 @each $side in top bottom left right {
   .no-margin-#{$side}  { margin-#{side}: 0; }


### PR DESCRIPTION
- Lower z-index on flatpickr, Select2 and tooltips using the bootstrap variable to stop them showing above the main nav bar.
I could of just raised the z-index of the nav bar, but then it would show over modal backdrops and the slide out nav draws.

<img width="1280" alt="Screenshot 2020-07-14 at 21 55 25" src="https://user-images.githubusercontent.com/1240766/87475517-d8636d00-c61c-11ea-9c66-9e24dc5fede2.png">
<img width="718" alt="Screenshot 2020-07-14 at 21 55 35" src="https://user-images.githubusercontent.com/1240766/87475520-d9949a00-c61c-11ea-93be-0dd5d793f237.png">
<img width="961" alt="Screenshot 2020-07-14 at 21 56 03" src="https://user-images.githubusercontent.com/1240766/87475522-d9949a00-c61c-11ea-8df7-1264aea79758.png">
