### PR TITLE
Avoid duplicates when finding products by taxon and products have multiple taxons in same taxonomy

### DIFF
--- a/core/app/finders/spree/products/find.rb
+++ b/core/app/finders/spree/products/find.rb
@@ -166,7 +166,6 @@ module Spree
         when 'default'
           if taxons?
             products.
-              select("#{Product.table_name}.*, #{Classification.table_name}.position").
               order("#{Classification.table_name}.position" => :asc)
           else
             products

--- a/core/spec/finders/spree/products/find_spec.rb
+++ b/core/spec/finders/spree/products/find_spec.rb
@@ -275,6 +275,29 @@ module Spree
             expect(products).to match_array [product_2, product]
           end
         end
+
+        context 'when filtering by taxons and some products have multiple taxons in that taxonomy' do
+          let(:taxonomy) { create(:taxonomy) }
+          let(:child_taxon) { create(:taxon, taxonomy: taxonomy) }
+          let(:child_taxon_2) { create(:taxon, taxonomy: taxonomy) }
+
+          before do
+            product.taxons << child_taxon
+            product_2.taxons << child_taxon
+            product_2.taxons << child_taxon_2
+
+            # Fix products positions
+            product.classifications.find_by(taxon: child_taxon).update(position: 3)
+            product_2.classifications.find_by(taxon: child_taxon).update(position: 1)
+            product_2.classifications.find_by(taxon: child_taxon_2).update(position: 2)
+          end
+
+          let(:params) { { sort_by: 'default', filter: { taxons: taxonomy.root.id } } }
+
+          it 'returns products ordered by associated taxon position without duplicates' do
+            expect(products).to match_array [product_2, product]
+          end
+        end
       end
 
       it 'returns products in newest-first order' do


### PR DESCRIPTION
The following Products query was being generated for the show action on the taxons controller:

`SELECT DISTINCT spree_products.*, spree_products_taxons.position FROM "spree_products" INNER JOIN... ORDER BY "spree_products_taxons"."position" ASC LIMIT ? OFFSET ?`

This meant that any product having n>1 taxons on the same taxonomy would appear n times in the query result for the parent taxon (unless by chance it had the same position on every one of the n taxons).

Since it is not necessary to include the "spree_products_taxons.position" column in the query to be able to ORDER BY it, we can just remove the "select()" line so that it will generate this instead:

`SELECT DISTINCT spree_products.* FROM "spree_products" INNER JOIN... ORDER BY "spree_products_taxons"."position" ASC LIMIT ? OFFSET ?`

, thus avoiding duplicates.

This was a regression of bug https://github.com/spree/spree/issues/1917 .