### PR TITLE
Admin UI & UX Improvements

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -32,7 +32,15 @@ jQuery(function ($) {
   var modalBackdrop  = $('#multi-backdrop')
 
   // Fail safe on resize
-  document.getElementsByTagName("BODY")[0].onresize = function() { closeAllMenus() }
+  var resizeTimer;
+  window.addEventListener('resize', function () {
+    document.body.classList.remove('modal-open', 'sidebar-open', 'contextualSideMenu-open');
+    document.body.classList.add('resize-animation-stopper');
+    clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(function () {
+      document.body.classList.remove('resize-animation-stopper');
+    }, 400);
+  });
 
   function closeAllMenus() {
     body.removeClass()

--- a/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
+++ b/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
@@ -59,6 +59,7 @@ $(document).ready(function () {
         if (billAddress) {
           $('#order_bill_address_attributes_firstname').val(billAddress.firstname)
           $('#order_bill_address_attributes_lastname').val(billAddress.lastname)
+          $('#order_bill_address_attributes_company').val(billAddress.company)
           $('#order_bill_address_attributes_address1').val(billAddress.address1)
           $('#order_bill_address_attributes_address2').val(billAddress.address2)
           $('#order_bill_address_attributes_city').val(billAddress.city)

--- a/backend/app/assets/javascripts/spree/backend/spree-select2.js
+++ b/backend/app/assets/javascripts/spree/backend/spree-select2.js
@@ -1,7 +1,26 @@
-jQuery(function ($) {
-  // Make select beautiful
+document.addEventListener('DOMContentLoaded', function() {
+  // Custom Select2
+
+  // Fix for Select2 v3.x using overlay mask to close any opened Select2 instances
+  // The overlay mask stops you lowering the z-index of the opend Select2 instance
+  // This is not needed if upgraded to Select2 v4.x
+  window.addEventListener('click', function(e) {
+    var select2Mask = document.getElementById('select2-drop-mask')
+    var select2Drop = document.getElementById('select2-drop')
+
+    if (select2Drop) {
+      if (select2Drop.contains(e.target)) {
+        // Click in the Select2 dropdown and do nothing...
+      } else {
+        if (select2Mask) {
+          $(select2Mask).click()
+        }
+      }
+    }
+  })
+
+  // Inititate Select2 on any select element with the class .select2
   $('select.select2').select2({
-    allowClear: true,
-    dropdownAutoWidth: false
+    allowClear: true
   })
 })

--- a/backend/app/assets/javascripts/spree/backend/spree-select2.js
+++ b/backend/app/assets/javascripts/spree/backend/spree-select2.js
@@ -2,6 +2,6 @@ jQuery(function ($) {
   // Make select beautiful
   $('select.select2').select2({
     allowClear: true,
-    dropdownAutoWidth: true
+    dropdownAutoWidth: false
   })
 })

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
@@ -1,3 +1,7 @@
+div.select2-drop-mask {
+  position: absolute;
+  display: none !important;
+}
 .select2-container {
   display: block;
 
@@ -59,6 +63,7 @@
 }
 
 .select2-drop {
+  z-index: $zindex-dropdown;
   &, &.select2-drop-above {
     border-radius: $border-radius;
     box-shadow: none;

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
@@ -83,14 +83,17 @@
 
 
 .select2-drop.select2-drop-active {
-  border-color: $input-focus-border-color !important;
-  border-top: 1px solid $input-focus-border-color;
-  border-bottom: 1px solid $input-focus-border-color;
-  margin-top: 2px;
+  border-color: $input-focus-border-color;
+  border-top: 0;
+  border-radius: 0 0  $border-radius $border-radius;
+  margin-top: -6px;
 }
 
 .select2-drop.select2-drop-above.select2-drop-active {
-  margin-top: -2px;
+  border-color: $input-focus-border-color;
+  border-top: 1px solid $input-focus-border-color;
+  border-radius: $border-radius $border-radius 0 0;
+  margin-top: 6px;
 }
 
 .select2-container.select2-drop-above .select2-choice {

--- a/backend/app/assets/stylesheets/spree/backend/shared/_base.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_base.scss
@@ -11,6 +11,7 @@
 }
 
 .tooltip{
+  pointer-events: none;
   z-index: $zindex-dropdown;
 }
 
@@ -49,4 +50,9 @@
 .flash-alert.animate__animated {
   opacity: 1;
   bottom: 30px;
+}
+
+.resize-animation-stopper * {
+  animation: none !important;
+  transition: none !important;
 }

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -55,7 +55,7 @@ input[type=number].hide-number-toggle {
 }
 
 .custom-select {
-  background: #fff url(asset-path("backend-chevron-down.svg")) no-repeat right 0.5rem center/8px 10px;
+  background: $input-bg url(asset-path("backend-chevron-down.svg")) no-repeat right 0.5rem center/8px 10px;
   background-size: 0.7em;
   &:focus{
     outline: none;

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -53,3 +53,12 @@ input[type=number].hide-number-toggle {
   outline-style: auto;
   outline-width: 0;
 }
+
+.custom-select {
+  background: #fff url(asset-path("backend-chevron-down.svg")) no-repeat right 0.5rem center/8px 10px;
+  background-size: 0.7em;
+  &:focus{
+    outline: none;
+    box-shadow: none;
+  }
+}

--- a/backend/app/views/spree/admin/promotions/rules/_item_total.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_item_total.html.erb
@@ -1,8 +1,8 @@
 <div class="card-body">
   <div class="row mb-0">
     <div class="form-group col-6 mb-3">
-      <%= select_tag "#{param_prefix}[preferred_operator_min]", options_for_select(Spree::Promotion::Rules::ItemTotal::OPERATORS_MIN.map{|o| [Spree.t("item_total_rule.operators.#{o}"),o]}, promotion_rule.preferred_operator_min), { class: 'select2 select_item_total mb-3' } %>
-      <%= select_tag "#{param_prefix}[preferred_operator_max]", options_for_select(Spree::Promotion::Rules::ItemTotal::OPERATORS_MAX.map{|o| [Spree.t("item_total_rule.operators.#{o}"),o]}, promotion_rule.preferred_operator_max), { class: 'select2 select_item_total' } %>
+      <%= select_tag "#{param_prefix}[preferred_operator_min]", options_for_select(Spree::Promotion::Rules::ItemTotal::OPERATORS_MIN.map{|o| [Spree.t("item_total_rule.operators.#{o}"),o]}, promotion_rule.preferred_operator_min), { class: 'custom-select select_item_total mb-3' } %>
+      <%= select_tag "#{param_prefix}[preferred_operator_max]", options_for_select(Spree::Promotion::Rules::ItemTotal::OPERATORS_MAX.map{|o| [Spree.t("item_total_rule.operators.#{o}"),o]}, promotion_rule.preferred_operator_max), { class: 'custom-select select_item_total' } %>
     </div>
     <div class="form-group col-6 mb-3">
       <%= text_field_tag "#{param_prefix}[preferred_amount_min]", promotion_rule.preferred_amount_min, class: 'form-control mb-3' %>

--- a/backend/app/views/spree/admin/stores/_form.html.erb
+++ b/backend/app/views/spree/admin/stores/_form.html.erb
@@ -81,22 +81,22 @@
   <div class="card-body">
     <%= f.field_container :default_currency, class: ['form-group'] do %>
       <%= f.label :default_currency, Spree.t(:currency) %>
-      <%= f.select :default_currency, currency_options(@store.default_currency) %>
+      <%= f.select :default_currency, currency_options(@store.default_currency), {}, { class: 'select2' } %>
       <%= f.error_message_on :default_currency %>
     <% end %>
     <%= f.field_container :supported_currencies, class: ['form-group'] do %>
       <%= f.label :supported_currencies, Spree.t(:supported_currencies) %>
-      <%= f.select :supported_currencies, currency_options(@store.supported_currencies&.split(',')), { prompt: false }, { multiple: true } %>
+      <%= f.select :supported_currencies, currency_options(@store.supported_currencies&.split(',')), { prompt: false }, { multiple: true, class: 'select2' } %>
       <%= f.error_message_on :supported_currencies %>
     <% end %>
     <%= f.field_container :default_locale, class: ['form-group'] do %>
       <%= f.label :default_locale, Spree.t('i18n.language') %>
-      <%= f.select :default_locale, options_from_collection_for_select(all_locales_options, :last, :first, @store.default_locale) %>
+      <%= f.select :default_locale, options_from_collection_for_select(all_locales_options, :last, :first, @store.default_locale), {}, { class: 'select2' } %>
       <%= f.error_message_on :default_locale %>
     <% end %>
     <%= f.field_container :default_country_id, class: ['form-group'] do %>
       <%= f.label :default_country_id, Spree.t('i18n.country') %>
-      <%= f.select :default_country_id, options_from_collection_for_select(@countries, :id, :name, @store.default_country_id) %>
+      <%= f.select :default_country_id, options_from_collection_for_select(@countries, :id, :name, @store.default_country_id), {}, { class: 'select2' } %>
       <%= f.error_message_on :default_country_id %>
     <% end %>
   </div>
@@ -156,10 +156,3 @@
     <% end %>
   </div>
 </div>
-
-<script>
-  $('#store_default_currency').select2();
-  $('#store_supported_currencies').select2();
-  $('#store_default_locale').select2();
-  $('#store_default_country_id').select2();
-</script>


### PR DESCRIPTION
- Fix Select2 blowing out of the parent container and revert styling to match the nice look from before.
- Add tooltip `pointer-events: none;` to stop the tooltips acting like a buttons, and blocking other buttons.
- Block CSS animations while re-sizing the viewport to stop the user seeing the menu states changing when resizing the screen.
- Add in company to the checkout edit.js so that  a users company field is populated if they have one.
- Use bootstrap custom select on promotion lesser than greater than selector.
- Style Bootstrap Custom Select to match Spree theme icon.
- Use Indirect click on select2 overlay mask to close Select2 drop downs, allowing a lower z-index on open select2 drop boxes.