### PR TITLE
[SD-905] Adds product_add_to_cart event triggering

### DIFF
--- a/frontend/app/assets/javascripts/spree/frontend/views/spree/products/cart_form.js
+++ b/frontend/app/assets/javascripts/spree/frontend/views/spree/products/cart_form.js
@@ -303,6 +303,12 @@ Spree.ready(function($) {
           Spree.showProductAddedModal(JSON.parse(
             $cartForm.attr('data-product-summary')
           ), Spree.variantById($cartForm, variantId))
+          $cartForm.trigger({
+            type: 'product_add_to_cart',
+            variant: Spree.variantById($cartForm, variantId),
+            quantity_increment: quantity,
+            cart: response.attributes
+          })
         },
         function(error) {
           if (typeof error === 'string' && error !== '') {


### PR DESCRIPTION
This event is needed by spree_analytics_trackers extension
to show up Product Added event in Segment and Google Analytics