### PR TITLE
fix frontend product partial nil price ternary operator bug

### DIFF
--- a/frontend/app/views/spree/products/_product.html.erb
+++ b/frontend/app/views/spree/products/_product.html.erb
@@ -10,7 +10,7 @@
         <% end %>
       </div>
       <div class="card-footer text-center">
-        <span class="price selling lead" content="<%= price.nil? 0 : price.to_d %>">
+        <span class="price selling lead" content="<%= price.nil? ? 0 : price.to_d %>">
           <%= display_price(product) %>
         </span>
         <span content="<%= current_currency %>"></span>


### PR DESCRIPTION
Fix ternary operator bug when frontend product partial price is nil. https://github.com/spree/spree/blob/master/frontend/app/views/spree/products/_product.html.erb#L13