### PR TITLE
Fix Alignment & Logo

### DIFF
--- a/frontend/app/assets/stylesheets/spree/frontend/views/spree/shared/mobile_navigation.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/views/spree/shared/mobile_navigation.scss
@@ -99,9 +99,6 @@
 
 #mobile-navigation-back-button {
   opacity: 0;
-  padding-left: 17px;
-  padding-right: 17px;
-  margin-left: -17px;
   transition: basic-transition(opacity);
   appearance: none;
   border: none;

--- a/frontend/app/views/spree/products/_gallery_modal.html.erb
+++ b/frontend/app/views/spree/products/_gallery_modal.html.erb
@@ -3,7 +3,7 @@
     <div class="modal-dialog--zoom modal-dialog mw-100 vh-100 mt-0 mb-0" role="document">
       <div class="modal-content h-100">
         <div class="modal-body h-100">
-          <button type="button" class="close position-absolute" data-dismiss="modal" aria-label="Close">
+          <button type="button" class="close position-absolute mr-3" data-dismiss="modal" aria-label="Close">
             <span aria-hidden="true">
               <%= icon(name: 'close',
                        classes: 'd-block d-lg-none',

--- a/frontend/app/views/spree/shared/_change_store.html.erb
+++ b/frontend/app/views/spree/shared/_change_store.html.erb
@@ -7,7 +7,7 @@
                 width: 41,
                 height: 36)  %>
         <%= icon(name: 'arrow-down',
-                classes: 'd-none d-xl-inline-block',
+                classes: 'd-inline-block d-xl-none',
                 width: 15,
                 height: 15)  %>
       </button>

--- a/frontend/app/views/spree/shared/_checkout_header.html.erb
+++ b/frontend/app/views/spree/shared/_checkout_header.html.erb
@@ -20,7 +20,7 @@
       </div>
       <div class="d-flex flex-nowrap align-items-center justify-content-center">
         <figure class="logo flex-grow-0 flex-xl-grow-0 order-xl-0 header-spree-fluid-logo m-0">
-        <%= logo(Spree::Config[:logo], method: :get) %>
+          <%= logo %>
         </figure>
       </div>
     </div>

--- a/frontend/app/views/spree/shared/_mobile_navigation.html.erb
+++ b/frontend/app/views/spree/shared/_mobile_navigation.html.erb
@@ -2,12 +2,12 @@
   <div class="position-fixed text-uppercase d-xl-none mobile-navigation" role="navigation" aria-label="<%= Spree.t('nav_bar.mobile') %>">
     <div class="d-flex align-items-center header-spree" data-hook>
       <div class="container-fluid header-spree-fluid">
-        <div class="d-flex flex-row flex-nowrap align-items-center justify-content-between">
-          <button id="mobile-navigation-back-button" aria-label="<%= Spree.t('nav_bar.go_to_previous_menu') %>">
+        <div class="d-flex align-items-center justify-content-between">
+          <button class="pl-0" id="mobile-navigation-back-button" aria-label="<%= Spree.t('nav_bar.go_to_previous_menu') %>">
             <%= icon(name: 'arrow-right',
                     classes: 'd-inline spree-icon-arrow spree-icon-arrow-left',
-                    width: 17,
-                    height: 28) %>
+                    width: 26,
+                    height: 26) %>
           </button>
           <figure class="logo header-spree-fluid-logo" data-hook>
             <%= logo %>

--- a/frontend/app/views/spree/shared/_mobile_navigation.html.erb
+++ b/frontend/app/views/spree/shared/_mobile_navigation.html.erb
@@ -2,19 +2,17 @@
   <div class="position-fixed text-uppercase d-xl-none mobile-navigation" role="navigation" aria-label="<%= Spree.t('nav_bar.mobile') %>">
     <div class="d-flex align-items-center header-spree" data-hook>
       <div class="container-fluid header-spree-fluid">
-        <div class="d-flex flex-nowrap align-items-center">
-          <div class="d-xl-none flex-grow-1">
-            <button id="mobile-navigation-back-button" aria-label="<%= Spree.t('nav_bar.go_to_previous_menu') %>">
-              <%= icon(name: 'arrow-right',
-                      classes: 'd-inline spree-icon-arrow spree-icon-arrow-left',
-                      width: 17,
-                      height: 28) %>
-            </button>
-          </div>
-          <figure class="logo flex-grow-0 flex-xl-grow-1 order-xl-0 header-spree-fluid-logo" data-hook>
+        <div class="d-flex flex-row flex-nowrap align-items-center justify-content-between">
+          <button id="mobile-navigation-back-button" aria-label="<%= Spree.t('nav_bar.go_to_previous_menu') %>">
+            <%= icon(name: 'arrow-right',
+                    classes: 'd-inline spree-icon-arrow spree-icon-arrow-left',
+                    width: 17,
+                    height: 28) %>
+          </button>
+          <figure class="logo header-spree-fluid-logo" data-hook>
             <%= logo %>
           </figure>
-          <div id="top-nav-bar-mobile" class="text-right flex-grow-1 header-spree-fluid-secondary-navigation" data-hook>
+          <div id="top-nav-bar-mobile" class="header-spree-fluid-secondary-navigation" data-hook>
             <button id="mobile-navigation-close-button" aria-label="<%= Spree.t('nav_bar.close_menu') %>">
               <%= icon(name: 'close',
                       classes: 'd-inline',

--- a/frontend/app/views/spree/shared/_mobile_navigation.html.erb
+++ b/frontend/app/views/spree/shared/_mobile_navigation.html.erb
@@ -1,26 +1,22 @@
 <% if spree_navigation_data.any? %>
   <div class="position-fixed text-uppercase d-xl-none mobile-navigation" role="navigation" aria-label="<%= Spree.t('nav_bar.mobile') %>">
-    <div class="d-flex align-items-center header-spree" data-hook>
-      <div class="container-fluid header-spree-fluid">
-        <div class="d-flex align-items-center justify-content-between">
-          <button class="pl-0" id="mobile-navigation-back-button" aria-label="<%= Spree.t('nav_bar.go_to_previous_menu') %>">
-            <%= icon(name: 'arrow-right',
-                    classes: 'd-inline spree-icon-arrow spree-icon-arrow-left',
-                    width: 26,
-                    height: 26) %>
-          </button>
-          <figure class="logo header-spree-fluid-logo" data-hook>
-            <%= logo %>
-          </figure>
-          <div id="top-nav-bar-mobile" class="header-spree-fluid-secondary-navigation" data-hook>
-            <button id="mobile-navigation-close-button" aria-label="<%= Spree.t('nav_bar.close_menu') %>">
-              <%= icon(name: 'close',
-                      classes: 'd-inline',
-                      width: 26,
-                      height: 26) %>
-            </button>
-          </div>
-        </div>
+    <div class="d-flex align-items-center justify-content-between header-spree" data-hook>
+      <button class="ml-2" id="mobile-navigation-back-button" aria-label="<%= Spree.t('nav_bar.go_to_previous_menu') %>">
+        <%= icon(name: 'arrow-right',
+                classes: 'd-inline spree-icon-arrow spree-icon-arrow-left',
+                width: 26,
+                height: 26) %>
+      </button>
+      <figure class="logo header-spree-fluid-logo" data-hook>
+        <%= logo %>
+      </figure>
+      <div id="top-nav-bar-mobile" class="mr-3 header-spree-fluid-secondary-navigation" data-hook>
+        <button id="mobile-navigation-close-button" aria-label="<%= Spree.t('nav_bar.close_menu') %>">
+          <%= icon(name: 'close',
+                  classes: 'd-inline',
+                  width: 26,
+                  height: 26) %>
+        </button>
       </div>
     </div>
 

--- a/frontend/app/views/spree/shared/_nav_bar.html.erb
+++ b/frontend/app/views/spree/shared/_nav_bar.html.erb
@@ -1,4 +1,4 @@
-<ul id="nav-bar" class="nav align-items-center d-flex justify-content-end navbar-right">
+<ul id="nav-bar" class="nav align-items-center d-flex flex-nowrap justify-content-end navbar-right">
   <li>
     <div class="navbar-right-search-menu">
       <button type="button" class="navbar-right-dropdown-toggle search-icons" aria-label="<%= Spree.t('nav_bar.show_search')%>">


### PR DESCRIPTION
- Fix alignment of logo in mobile menu on very narrow screens.
- Add mr-3 to picture modal close button to bring it off the edge of the screen.
- Set logo to use new method in checkout area, same as main area.
- Main nav bar, set right hand icons to no wrap
- The little arrow down for multi store was set to display none for small, I think it was supposed to be swapped out below xl