### PR TITLE
Admin Country Updates

### DIFF
--- a/backend/app/views/spree/admin/countries/_form.html.erb
+++ b/backend/app/views/spree/admin/countries/_form.html.erb
@@ -24,9 +24,14 @@
   <% end %>
 
   <div data-hook="states_required" class="form-group checkbox">
-    <label>
-      <%= f.check_box :states_required %>
-      <%= Spree.t(:states_required) %>
-    </label>
+    <%= f.check_box :states_required %>
+    <%= f.label :states_required, Spree.t(:states_required) %>
+    <%= f.error_message_on :states_required %>
+  </div>
+
+  <div data-hook="zipcode_required" class="form-group checkbox">
+    <%= f.check_box :zipcode_required %>
+    <%= f.label :zipcode_required, Spree.t(:zipcode_required) %>
+    <%= f.error_message_on :zipcode_required %>
   </div>
 </div>

--- a/backend/app/views/spree/admin/countries/index.html.erb
+++ b/backend/app/views/spree/admin/countries/index.html.erb
@@ -10,8 +10,9 @@
     <thead>
       <tr data-hook="tax_header">
         <th><%= Spree.t(:country_name) %></th>
-        <th><%= Spree.t(:iso_name) %></th>
+        <th><%= Spree.t(:iso3) %></th>
         <th><%= Spree.t(:states_required) %></th>
+        <th><%= Spree.t(:zipcode_required) %></th>
         <th class="actions"></th>
       </tr>
     </thead>
@@ -19,8 +20,9 @@
       <% @countries.each do |country| %>
         <tr id="<%= spree_dom_id country %>" data-hook="country_row">
           <td><%= country.name %></td>
-          <td><%= country.iso_name %></td>
+          <td><%= country.iso3 %></td>
           <td class="text-center"><%= country.states_required? ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>
+          <td class="text-center"><%= country.zipcode_required? ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>
           <td class="actions actions-2 text-right">
             <%= link_to_edit(country, no_text: true) if can? :edit, country %>
             <%= link_to_delete(country, no_text: true) if can? :delete, country %>

--- a/backend/spec/features/admin/configuration/countries_spec.rb
+++ b/backend/spec/features/admin/configuration/countries_spec.rb
@@ -9,10 +9,18 @@ module Spree
       click_link 'New Country'
 
       fill_in 'Name', with: 'Brazil'
-      fill_in 'Iso Name', with: 'BRL'
-      fill_in 'Iso', with: 'BR'
-      fill_in 'Iso3', with: 'BRL'
+      fill_in 'ISO Name', with: 'BRAZIL'
+      fill_in 'ISO Alpha-2', with: 'BR'
+      fill_in 'ISO Alpha-3', with: 'BRL'
+      check 'States Required'
+      uncheck 'Zip Code Required'
+
       click_button 'Create'
+
+      expect(page).to have_content('Brazil')
+      expect(page).to have_content('BRL')
+      expect(page).to have_content('Yes')
+      expect(page).to have_content('No')
 
       accept_confirm do
         click_icon :delete

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -986,8 +986,8 @@ en:
     inventory_error_flash_for_insufficient_quantity: An item in your cart has become unavailable.
     inventory_state: Inventory State
     is_not_available_to_shipment_address: is not available to shipment address
-    iso: ISO Alpha-2 Code
-    iso3: ISO Alpha-3 Code
+    iso: ISO Alpha-2
+    iso3: ISO Alpha-3
     iso_name: ISO Name
     issued_on: Issued On
     item: Item

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -986,7 +986,9 @@ en:
     inventory_error_flash_for_insufficient_quantity: An item in your cart has become unavailable.
     inventory_state: Inventory State
     is_not_available_to_shipment_address: is not available to shipment address
-    iso_name: Iso Name
+    iso: ISO Alpha-2 Code
+    iso3: ISO Alpha-3 Code
+    iso_name: ISO Name
     issued_on: Issued On
     item: Item
     item_description: Item Description
@@ -1792,5 +1794,6 @@ en:
     your_order_is_empty_add_product: Your order is empty, please search for and add a product above
     zip: Zip
     zipcode: Zip Code
+    zipcode_required: Zip Code Required
     zone: Zone
     zones: Zones


### PR DESCRIPTION
- Allow admin user to set zip code required checkbox.
- Display Zip Code Required Yes / No on countries index
- Swap country ISO Name for ISO Alpha-3 in country index, Reason: (ISO Name is just the same as Country Name but in all caps, where as the ISO 3 seems more useful).
- Strengthen tests slightly to check that all fields saved and checkboxes were saved.
- Add in local translations for the zip code required, and some missing ones for the ISO alpha-3 and 2