### PR TITLE
Outstanding balance uses reimbursement

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -297,13 +297,13 @@ module Spree
     def outstanding_balance
       if canceled?
         -1 * payment_total
-      elsif refunds.exists?
-        # If refund has happened add it back to total to prevent balance_due payment state
-        # See: https://github.com/spree/spree/issues/6229 & https://github.com/spree/spree/issues/8136
-        total - (payment_total + refunds.sum(:amount))
       else
-        total - payment_total
+        total - (payment_total + reimbursement_paid_total)
       end
+    end
+
+    def reimbursement_paid_total
+      reimbursements.sum(&:paid_amount)
     end
 
     def outstanding_balance?

--- a/core/spec/models/spree/order/payment_spec.rb
+++ b/core/spec/models/spree/order/payment_spec.rb
@@ -178,11 +178,13 @@ module Spree
         order.total = 30.30
         expect(order.outstanding_balance).to eq(10.10)
       end
+
       it 'returns negative amount when payment_total is greater than total' do
         order.total = 8.20
         order.payment_total = 10.20
         expect(order.outstanding_balance).to be_within(0.001).of(-2.00)
       end
+
       it 'incorporates refund reimbursements' do
         # Creates an order w/total 10
         reimbursement = create :reimbursement
@@ -200,7 +202,7 @@ module Spree
         expect(order.outstanding_balance).to eq 0
       end
 
-      it 'incorporates refunds' do
+      it 'does not incorporate refunds without a reimbursement' do
         order = create(:completed_order_with_totals)
         calculator = order.shipments.first.shipping_method.calculator
 
@@ -211,8 +213,9 @@ module Spree
 
         create(:refund, amount: 10, payment: order.payments.first)
         order.update_with_updater!
-
-        expect(order.outstanding_balance).to eq 0
+        # Order Total - (Payment Total + Reimbursed)
+        # 10 - (0 + 0) = 0
+        expect(order.outstanding_balance).to eq 10
       end
     end
 


### PR DESCRIPTION
This updates outstanding_balance to use the value of "reimbursements" when determining the payment total.

Currently `outstanding_balance` (when a refund exists) is defined as
```
total - (payment_total + refunds.sum(:amount))
```
Because refunds are included in the `payment_total` [here](https://github.com/spree/spree/blob/4cc2c2967352d3fe7652bd873e492c074ffcc3da/core/app/models/spree/order_updater.rb#L68) the outstanding balance ends up equalling the "order total minus your completed payment total, regardless of whether those payments have been refunded or not".

In a couple scenarios this does not work as expected:
- User places an order with one payment method
- They reach out and request to switch payment methods
- Admin refunds payment and submits a new payment
In this case the payment total will be double the order total and the order will show as refund owed.

In any scenario where the order is modified after payment is complete:
- User accidentally orders Product A (price $100) instead of Product B (price $10)
- Before Product A is shipped, user requests a switch to Product B
- Admin removes Product A, adds Product B, and refunds $90




