### PR TITLE
[EN-462] Fixes admin panel bug with stores field on product form

### DIFF
--- a/backend/app/controllers/spree/admin/stores_controller.rb
+++ b/backend/app/controllers/spree/admin/stores_controller.rb
@@ -15,7 +15,31 @@ module Spree
       helper_method :all_locales_options
 
       def index
-        @stores = Spree::Store.all
+        if params[:ids]
+          load_stores_by_ids
+        elsif params[:q]
+          load_stores_by_query
+        else
+          @stores = Spree::Store.all
+        end
+
+        respond_with(@stores) do |format|
+          format.json { render layout: false }
+        end
+      end
+
+      def load_stores_by_ids
+        ids = params[:ids].split(',')
+        @stores = Spree::Store.where(id: ids)
+      end
+
+      def load_stores_by_query
+        @stores = if defined?(SpreeGlobalize)
+                    Spree::Store.joins(:translations).where("LOWER(#{Store::Translation.table_name}.name) LIKE LOWER(:query)",
+                                                            query: "%#{params[:q]}%")
+                  else
+                    Spree::Store.where('LOWER(name) LIKE LOWER(:query)', query: params[:q].to_s)
+                  end
       end
 
       def create


### PR DESCRIPTION
Stores field on product form was not showing stores that product was assigned to, also it was not possible to search for a store because of `Loading failed` error.