### PR TITLE
Use scope to select payment states

### DIFF
--- a/core/app/models/spree/order/payments.rb
+++ b/core/app/models/spree/order/payments.rb
@@ -32,11 +32,11 @@ module Spree
         end
 
         def pending_payments
-          payments.select(&:pending?)
+          payments.pending
         end
 
         def unprocessed_payments
-          payments.select(&:checkout?)
+          payments.checkout
         end
 
         private

--- a/core/app/models/spree/order/payments.rb
+++ b/core/app/models/spree/order/payments.rb
@@ -36,7 +36,7 @@ module Spree
         end
 
         def unprocessed_payments
-          payments.checkout
+          payments.select(&:checkout?)
         end
 
         private


### PR DESCRIPTION
The current behaviour loops over the payments object and calls checkout scope method or the pending scope method multiple times. This commit removes the loop and uses the scope directly, optimizing the current behaviour.