### PR TITLE
API v2 Set order state to address if billing or shipping  address is updated

### DIFF
--- a/core/app/services/spree/checkout/update.rb
+++ b/core/app/services/spree/checkout/update.rb
@@ -4,8 +4,11 @@ module Spree
       prepend Spree::ServiceModule::Base
 
       def call(order:, params:, permitted_attributes:, request_env:)
-        params = replace_country_iso_with_id(params, 'ship') if address_with_country_iso_present?(params, 'ship')
-        params = replace_country_iso_with_id(params, 'bill') if address_with_country_iso_present?(params, 'bill')
+        ship_changed = address_with_country_iso_present?(params, 'ship')
+        bill_changed = address_with_country_iso_present?(params, 'bill')
+        params = replace_country_iso_with_id(params, 'ship') if ship_changed
+        params = replace_country_iso_with_id(params, 'bill') if bill_changed
+        order.state = 'address' if ship_changed || bill_changed
         return success(order) if order.update_from_params(params, permitted_attributes, request_env)
 
         failure(order)

--- a/core/app/services/spree/checkout/update.rb
+++ b/core/app/services/spree/checkout/update.rb
@@ -8,7 +8,7 @@ module Spree
         bill_changed = address_with_country_iso_present?(params, 'bill')
         params = replace_country_iso_with_id(params, 'ship') if ship_changed
         params = replace_country_iso_with_id(params, 'bill') if bill_changed
-        order.state = 'address' if (ship_changed || bill_changed) && @order.checkout_sptes.include?('address')
+        order.state = 'address' if (ship_changed || bill_changed) && order.checkout_steps.include?('address')
         return success(order) if order.update_from_params(params, permitted_attributes, request_env)
 
         failure(order)

--- a/core/app/services/spree/checkout/update.rb
+++ b/core/app/services/spree/checkout/update.rb
@@ -8,7 +8,7 @@ module Spree
         bill_changed = address_with_country_iso_present?(params, 'bill')
         params = replace_country_iso_with_id(params, 'ship') if ship_changed
         params = replace_country_iso_with_id(params, 'bill') if bill_changed
-        order.state = 'address' if ship_changed || bill_changed
+        order.state = 'address' if (ship_changed || bill_changed) && @order.checkout_sptes.include?('address')
         return success(order) if order.update_from_params(params, permitted_attributes, request_env)
 
         failure(order)

--- a/core/spec/services/spree/checkout/update_spec.rb
+++ b/core/spec/services/spree/checkout/update_spec.rb
@@ -60,4 +60,46 @@ describe Spree::Checkout::Update, type: :service do
       end
     end
   end
+
+  describe 'update address' do
+    let(:order) { create(:order_with_line_items) }
+    let(:state) { create(:state) }
+    let(:country) { state.country }
+    let(:update_service) { described_class.new }
+    let(:address) do
+      {
+        firstname: 'John',
+        lastname: 'Doe',
+        address1: '7735 Old Georgetown Road',
+        city: 'Bethesda',
+        phone: '3014445002',
+        zipcode: '20814',
+        state_id: state.id,
+        country_iso: country.iso
+      }
+    end
+    let(:order_params) do
+      ActionController::Parameters.new(
+        order: {
+          ship_address_attributes: address
+        }
+      )
+    end
+    let(:permitted_attributes) do
+      Spree::PermittedAttributes.checkout_attributes + [
+        bill_address_attributes: Spree::PermittedAttributes.address_attributes,
+        ship_address_attributes: Spree::PermittedAttributes.address_attributes
+      ]
+    end
+
+    it 'should set order back to address state' do
+      expect(order.state).not_to eq 'address'
+      expect(order.ship_address.state.id).not_to eq state.id
+
+      update_service.send(:call, order: order, params: order_params, permitted_attributes: permitted_attributes, request_env: nil)
+
+      expect(order.state).to eq 'address'
+      expect(order.ship_address.state.id).to eq state.id
+    end
+  end
 end


### PR DESCRIPTION
Fix #10276 

When updating the shipping or billing address for an order, we need to also reset the state to address so we can recalculate tax and shipping rates.