### PR TITLE
API v2 Set order state to delivery if selected shipping rate is changed

### DIFF
--- a/api/spec/requests/spree/api/v2/storefront/checkout_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/checkout_spec.rb
@@ -276,9 +276,9 @@ describe 'API V2 Storefront Checkout Spec', type: :request do
         let(:params) do
           {
             order: {
-              shipments_attributes: {
-                '0' => { selected_shipping_rate_id: new_selected_shipping_rate_id, id: shipment.id }
-              }
+              shipments_attributes: [
+                { selected_shipping_rate_id: new_selected_shipping_rate_id, id: shipment.id }
+              ]
             }
           }
         end
@@ -664,9 +664,9 @@ describe 'API V2 Storefront Checkout Spec', type: :request do
     let(:shipment_params) do
       {
         order: {
-          shipments_attributes: {
-            '0' => { selected_shipping_rate_id: shipping_rate_id, id: shipment_id }
-          }
+          shipments_attributes: [
+            { selected_shipping_rate_id: shipping_rate_id, id: shipment_id }
+          ]
         }
       }
     end

--- a/core/app/services/spree/checkout/update.rb
+++ b/core/app/services/spree/checkout/update.rb
@@ -8,7 +8,8 @@ module Spree
         bill_changed = address_with_country_iso_present?(params, 'bill')
         params = replace_country_iso_with_id(params, 'ship') if ship_changed
         params = replace_country_iso_with_id(params, 'bill') if bill_changed
-        order.state = 'address' if (ship_changed || bill_changed) && order.checkout_steps.include?('address')
+        order.state = 'address' if (ship_changed || bill_changed) && order.has_checkout_step?('address')
+        order.state = 'delivery' if selected_shipping_rate_present?(params) && order.has_checkout_step?('delivery')
         return success(order) if order.update_from_params(params, permitted_attributes, request_env)
 
         failure(order)
@@ -21,6 +22,13 @@ module Spree
         return false if params.dig(:order, "#{address_kind}_address_attributes".to_sym, :country_id)
 
         true
+      end
+
+      def selected_shipping_rate_present?(params)
+        shipments_attributes = params.dig(:order, :shipments_attributes)
+        return false unless shipments_attributes
+
+        shipments_attributes.any? { |s| s.dig(:selected_shipping_rate_id) }
       end
 
       def replace_country_iso_with_id(params, address_kind = 'ship')

--- a/core/spec/services/spree/checkout/update_spec.rb
+++ b/core/spec/services/spree/checkout/update_spec.rb
@@ -102,4 +102,34 @@ describe Spree::Checkout::Update, type: :service do
       expect(order.ship_address.state.id).to eq state.id
     end
   end
+
+  describe 'update selected shipping rate' do
+    let(:update_service) { described_class.new }
+    let(:order) { create(:order_with_line_items) }
+    let(:order_params) do
+      ActionController::Parameters.new(
+        order: {
+          shipments_attributes: [
+            {
+              id: order.shipments.first.id,
+              selected_shipping_rate_id: order.shipments.first.shipping_rates.first.id
+            }
+          ]
+        }
+      )
+    end
+    let(:permitted_attributes) do
+      Spree::PermittedAttributes.checkout_attributes + [
+        shipments_attributes: Spree::PermittedAttributes.shipment_attributes
+      ]
+    end
+
+    it 'should set order back to delivery state' do
+      expect(order.state).not_to eq 'delivery'
+
+      update_service.send(:call, order: order, params: order_params, permitted_attributes: permitted_attributes, request_env: nil)
+
+      expect(order.state).to eq 'delivery'
+    end
+  end
 end


### PR DESCRIPTION
Similar to the changes made in #10476, we need a special logic for the delivery step. If a customer decides to change the selected shipping rate, the order needs to go back to delivery state to recalculate the tax amount on the shipping cost, and adjust any "free shipping" promotion if needed.