### PR TITLE
Improve Carmen Data Import

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -10,6 +10,12 @@ module Spree
       'TO', 'TV', 'UG', 'AE', 'VU', 'YE', 'ZW'
     ].freeze
 
+    # The Information for this matches that used by PayPal, Stripe, and Shopify.
+    STATES_REQUIRED = [
+      'AU', 'AE', 'BR', 'CA', 'CN', 'ES', 'HK', 'IE', 'IN', 'IT', 'MY', 'MX', 'NZ', 'PT', 'RO',
+      'TH', 'US', 'ZA'
+    ].freeze
+
     # we're not freezing this on purpose so developers can extend and manage
     # those attributes depending of the logic of their applications
     ADDRESS_FIELDS = %w(firstname lastname company address1 address2 city state zipcode country phone)

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -10,10 +10,10 @@ module Spree
       'TO', 'TV', 'UG', 'AE', 'VU', 'YE', 'ZW'
     ].freeze
 
-    # The Information for this matches that used by PayPal, Stripe, and Shopify.
+    # The required states listed below match those used by PayPal and Shopify.
     STATES_REQUIRED = [
-      'AU', 'AE', 'BR', 'CA', 'CN', 'ES', 'HK', 'IE', 'IN', 'IT', 'MY', 'MX', 'NZ', 'PT', 'RO',
-      'TH', 'US', 'ZA'
+      'AU', 'AE', 'BR', 'CA', 'CN', 'ES', 'HK', 'IE', 'IN',
+      'IT', 'MY', 'MX', 'NZ', 'PT', 'RO', 'TH', 'US', 'ZA'
     ].freeze
 
     # we're not freezing this on purpose so developers can extend and manage

--- a/core/db/default/spree/countries.rb
+++ b/core/db/default/spree/countries.rb
@@ -6,13 +6,14 @@ Carmen::Country.all.each do |country|
     iso3: country.alpha_3_code,
     iso: country.alpha_2_code,
     iso_name: country.name.upcase,
-    numcode: country.numeric_code,
-    states_required: country.subregions?
+    numcode: country.numeric_code
   ).first_or_create
 end
 
 Spree::Config[:default_country_id] = Spree::Country.find_by(iso: 'US').id
 
-# find countries that do not use postal codes (by iso) and set 'zipcode_required' to false for them.
-
+# Find countries that do not use postal codes (by iso) and set 'zipcode_required' to false for them.
 Spree::Country.where(iso: Spree::Address::NO_ZIPCODE_ISO_CODES).update_all(zipcode_required: false)
+
+# Find all countries that require a state (province) at checkout and set 'states_required' to true.
+Spree::Country.where(iso: Spree::Address::STATES_REQUIRED).update_all(states_required: true)

--- a/core/db/default/spree/countries.rb
+++ b/core/db/default/spree/countries.rb
@@ -1,6 +1,11 @@
 require 'carmen'
 
+EXCLUDED_COUNTRIES = ['AQ', 'AX', 'GS', 'UM', 'HM', 'IO', 'EH', 'BV', 'TF'].freeze
+
 Carmen::Country.all.each do |country|
+  # Skip the creation of some territories, uninhabited islands and the Antarctic.
+  next if EXCLUDED_COUNTRIES.include?(country.alpha_2_code)
+
   Spree::Country.where(
     name: country.name,
     iso3: country.alpha_3_code,

--- a/core/db/default/spree/states.rb
+++ b/core/db/default/spree/states.rb
@@ -1,22 +1,49 @@
+# frozen_string_literal: true
+
+EXCLUDED_US_STATES = ['UM', 'AS', 'MP', 'VI', 'PR', 'GU'].freeze
+EXCLUDED_CN_STATES = ['HK', 'MO', 'TW'].freeze
+
+def state_level(country, subregion)
+  country.states.where(
+    name: subregion.name,
+    abbr: subregion.code
+  ).first_or_create
+end
+
+def province_level(country, subregion)
+  subregion.subregions.each do |province|
+    country.states.where(
+      name: province.name,
+      abbr: province.code
+    ).first_or_create
+  end
+end
+
 Spree::Country.where(states_required: true).each do |country|
   carmen_country = Carmen::Country.named(country.name)
   next unless carmen_country
 
   carmen_country.subregions.each do |subregion|
-    if subregion.subregions?
-      subregion.subregions.each do |province|
-        country.states.where(
-          name: province.name,
-          abbr: province.code,
-          country_id: country.id
-        ).first_or_create
-      end
+    if carmen_country.alpha_2_code == 'US'
+      # Produces 50 states, one postal district (Washington DC)
+      # and 3 APO's as you would expect to see on any good U.S. states list.
+      next if EXCLUDED_US_STATES.include?(subregion.code)
+
+      state_level(country, subregion)
+    elsif carmen_country.alpha_2_code == 'CA' || carmen_country.alpha_2_code == 'MX'
+      # Force Canada and Mexico to use state-level data import from Carmen Gem
+      # else we pull in a subset of provinces that are not common at checkout.
+      state_level(country, subregion)
+    elsif carmen_country.alpha_2_code == 'CN'
+      # Removes 3 "States" from that list that are also listed as Countries,
+      # Hong Kong, Taiwan and Macao
+      next if EXCLUDED_CN_STATES.include?(subregion.code)
+
+      state_level(country, subregion)
+    elsif subregion.subregions?
+      province_level(country, subregion)
     else
-      country.states.where(
-        name: subregion.name,
-        abbr: subregion.code,
-        country_id: country.id
-      ).first_or_create
+      state_level(country, subregion)
     end
   end
 end

--- a/core/db/default/spree/states.rb
+++ b/core/db/default/spree/states.rb
@@ -3,10 +3,20 @@ Spree::Country.where(states_required: true).each do |country|
   next unless carmen_country
 
   carmen_country.subregions.each do |subregion|
-    country.states.where(
-      name: subregion.name,
-      abbr: subregion.code,
-      country_id: country.id
-    ).first_or_create
+    if subregion.subregions?
+      subregion.subregions.each do |province|
+        country.states.where(
+          name: province.name,
+          abbr: province.code,
+          country_id: country.id
+        ).first_or_create
+      end
+    else
+      country.states.where(
+        name: subregion.name,
+        abbr: subregion.code,
+        country_id: country.id
+      ).first_or_create
+    end
   end
 end

--- a/core/db/default/spree/zones.rb
+++ b/core/db/default/spree/zones.rb
@@ -16,7 +16,7 @@ end
   middle_east.zone_members.where(zoneable: Spree::Country.find_by!(iso: name)).first_or_create!
 end
 
-%w(AF AM AZ BH BD BT BN KH CN CX CC IO GE HK IN ID IR IQ IL JP JO KZ KW KG LA LB MO MY MV MN MM NP
+%w(AF AM AZ BH BD BT BN KH CN CX CC GE HK IN ID IR IQ IL JP JO KZ KW KG LA LB MO MY MV MN MM NP
   KP OM PK PS PH QA SA SG KR LK SY TW TJ TH TR TM AE UZ VN YE).each do |name|
   asia.zone_members.where(zoneable: Spree::Country.find_by!(iso: name)).first_or_create!
 end


### PR DESCRIPTION
This PR improves how the data is pulled from the Carmen Gem into Spree, as far as I can tell, Carmen is set up strictly to follow ISO standards and has the following setups depending on the country.

## US, AU examples
```
--country
  --state

```
## Italy, Spain examples 
```
--country
  --region
    --province 
```
---

For this PR I am referencing what Shopify use on their checkout systems, and PayPal Checkout to match what Countries require States, and what states are pulled in from the Carmen gem.

---
## 17 Countries Require States at checkout.
- A ticked checkbox below means the states have been cross referenced against Shopify and PayPal Checkouts and they list the correct states in Spree.

- [x] Australia -- (8 States)

- [x] Brazil -- (27 states)

- [x] Canada -- (13 States)

- [x] China -- (31 States)

- [x] India -- (36 States)

- [x] Ireland -- (26 States)

- [x] Italy -- (110 Provinces)

- [x] Malaysia -- (16 States)

- [x] Mexico -- (32 States)

- [x] New Zealand -- (17 States)

- [x] Portugal -- (20 States)

- [x] Romania -- (42 States)

- [x] South Africa -- (9 States)

- [x] Spain -- (52 States)

- [x] Thailand -- (77 States)

- [x] United Arab Emirates -- (7 Emirates)

- [x] United States -- (50 states, one postal district DC, and 3 APO's -- 54 total) 



---
## Sorting Valid Countries From Disputed Territories and Uninhabited Islands
There are 195 official countries in the world as of writing in 2020, but the ISO standards have 249 country codes taking into account some random territories and uninhabited islands.

Most shippers will list around 234 (DHL) to 238(Fedex)

Somewhere in amongst these country lists lay some sensible setup for a checkout system, after viewing Shopify it appears they are also using a modified version of the Carmen gem for their list of countries, and list uninhabited islands at checkout, the intention is now to do better than Shopify at producing a valid list of countries for a checkout system.

- Antarctica (not a shippable location).
- South Georgia and the South Sandwich Islands (inhospitable islands)
- United States Minor Outlying Islands (all listed islands are uninhabited)
- Åland Islands (Cant seem to find it on a DHL list or any other respectable shipping list.)
- Heard Island and McDonald Islands (Un-shippable location)
- British Indian Ocean Territory (Un-shippable location)
- Western Sahara (disputed territory, not on any known shipping lists)
- Bouvet Island (Small island in the middle of the Atlantic, population 0)
- French Southern Territories (Arctic islands no shipping)