### PR TITLE
Add random string instead of 'new' in a duplicated promotion.

### DIFF
--- a/core/app/models/spree/promotion_handler/promotion_duplicator.rb
+++ b/core/app/models/spree/promotion_handler/promotion_duplicator.rb
@@ -7,9 +7,10 @@ module Spree
 
       def duplicate
         @new_promotion = @promotion.dup
-        @new_promotion.path = "#{@promotion.path}_new"
+        random_string = generate_random_string(4)
+        @new_promotion.path = "#{@promotion.path}_#{random_string}"
         @new_promotion.name = "New #{@promotion.name}"
-        @new_promotion.code = "#{@promotion.code}_new"
+        @new_promotion.code = "#{@promotion.code}_#{random_string}"
 
         ActiveRecord::Base.transaction do
           @new_promotion.save
@@ -31,6 +32,11 @@ module Spree
           new_rule.taxons = rule.taxons if rule.try(:taxons)
           new_rule.products = rule.products if rule.try(:products)
         end
+      end
+
+      def generate_random_string(number)
+        charset = Array('A'..'Z') + Array('a'..'z')
+        Array.new(number) { charset.sample }.join
       end
 
       def copy_actions

--- a/core/spec/models/spree/promotion_handler/promotion_duplicator_spec.rb
+++ b/core/spec/models/spree/promotion_handler/promotion_duplicator_spec.rb
@@ -30,9 +30,9 @@ describe Spree::PromotionHandler::PromotionDuplicator do
       let(:excluded_fields) { ['code', 'name', 'path', 'id', 'created_at', 'updated_at', 'deleted_at'] }
 
       it 'returns a duplicate of a promotion with the path, name and code fields changed' do
-        expect("#{promotion.path}_new").to eq new_promotion.path
         expect("New #{promotion.name}").to eq new_promotion.name
-        expect("#{promotion.code}_new").to eq new_promotion.code
+        expect(new_promotion.path).to match /#{promotion.path}_[a-zA-Z]{4}/
+        expect(new_promotion.code).to match /#{promotion.code}_[a-zA-Z]{4}/
       end
 
       it 'returns a duplicate of a promotion with all the fields (except the path, name and code fields) the same' do


### PR DESCRIPTION
This fix is needed because when you try to duplicate promotion with code 'code' and promotion 'code_new' exists, then it fails.