### PR TITLE
Fix DB_EXCEPTIONS Warning

### DIFF
--- a/core/app/models/spree/preferences/store.rb
+++ b/core/app/models/spree/preferences/store.rb
@@ -6,7 +6,7 @@
 
 require 'singleton'
 
-DB_EXCEPTIONS = if defined? PG
+DB_EXCEPTIONS ||= if defined? PG
                   [PG::ConnectionBad, ActiveRecord::NoDatabaseError]
                 elsif defined? Mysql2
                   [Mysql2::Error::ConnectionError, ActiveRecord::NoDatabaseError]


### PR DESCRIPTION
I couldn't find place where `DB_EXCEPTIONS` was already initialized resulting this warning, but this solved the warning.
Before:
<img width="1680" alt="Screen Shot 2020-09-19 at 9 09 37 AM" src="https://user-images.githubusercontent.com/6129641/93658167-dffa2480-fa58-11ea-94b4-596aa2b05629.png">
After:
<img width="1676" alt="Screen Shot 2020-09-19 at 9 09 50 AM" src="https://user-images.githubusercontent.com/6129641/93658170-e6889c00-fa58-11ea-9f06-93ac83bf2009.png">
