### PR TITLE
Fix N+1 queries on /api/v2/storefront/taxons

### DIFF
--- a/api/app/controllers/spree/api/v2/storefront/taxons_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/taxons_controller.rb
@@ -51,7 +51,7 @@ module Spree
               children: node_includes,
               taxonomy: [root: node_includes],
               products: [],
-              icon: []
+              icon: [attachment_attachment: :blob]
             }
           end
         end


### PR DESCRIPTION
Related to the issue https://github.com/spree/spree/issues/10285
There was N+1 queries on ActiveStorage::Attachment and ActiveStorage::Blob fetch by every taxon
Including it in the query seems to fix it