### PR TITLE
Do not show payment sources on payment step page load

### DIFF
--- a/frontend/app/views/spree/checkout/_payment.html.erb
+++ b/frontend/app/views/spree/checkout/_payment.html.erb
@@ -21,7 +21,7 @@
       <% end %>
     </ul>
 
-    <div class="payment-sources">
+    <div class="payment-sources" style="display:none;">
       <% if @payment_sources.present? %>
         <div id="existing_cards" class="payment-sources-existing-cards">
           <%= radio_button_tag 'use_existing_card', 'yes', true, class: 'd-none' %>


### PR DESCRIPTION
Fixes issue when `payment sources` on the `payment checkout step page` can be visible for a moment on page load before they are hidden by javascript script.