### PR TITLE
Fixes bugs with js-filter badges

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -123,13 +123,13 @@ jQuery(function ($) {
   $('.js-filterable').each(function () {
     var $this = $(this)
 
-    if ($this.val()) {
+    if ($this.val() !== null && $this.val() !== '' && $this.val().length !== 0) {
       var ransackValue, filter
       var ransackFieldId = $this.attr('id')
       var label = $('label[for="' + ransackFieldId + '"]')
 
       if ($this.is('select')) {
-        ransackValue = $this.find('option:selected').text()
+        ransackValue = $this.find('option:selected').toArray().map(option => option.text).join(', ')
       } else {
         ransackValue = $this.val()
       }


### PR DESCRIPTION
Filter badge was showing up when no search filters were active:
<img width="446" alt="Screenshot 2020-10-02 at 16 13 26" src="https://user-images.githubusercontent.com/5177038/94935185-fe3a3880-04cc-11eb-970e-5422d29c7f72.png">

Fixed filters names joined together without spaces:
<img width="429" alt="Screenshot 2020-10-02 at 16 13 42" src="https://user-images.githubusercontent.com/5177038/94935249-18741680-04cd-11eb-8d3e-c18d4d6ee221.png">

Observed while working on https://github.com/spree-contrib/spree_multi_vendor/pull/136