### PR TITLE
Normalize promotion code before validation

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -28,6 +28,8 @@ module Spree
 
     before_save :normalize_blank_values
 
+    before_validation :normalize_code
+
     scope :coupons, -> { where.not(code: nil) }
     scope :advertised, -> { where(advertise: true) }
     scope :applied, lambda {
@@ -225,6 +227,10 @@ module Spree
       [:code, :path].each do |column|
         self[column] = nil if self[column].blank?
       end
+    end
+
+    def normalize_code
+      self.code = code.strip if code.present?
     end
 
     def match_all?

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -25,6 +25,38 @@ describe Spree::Promotion, type: :model do
       expect(@valid_promotion).not_to be_valid
     end
 
+    describe 'code should be unique' do
+      let(:code) { 'code' }
+
+      context 'code is unique' do
+        before do
+          @valid_promotion.code = code
+        end
+
+        it { expect(@valid_promotion).to be_valid }
+      end
+
+      context 'code is not unique' do
+        let!(:promotion_with_code) { Spree::Promotion.create! name: 'test1', code: code }
+
+        context 'code is identical' do
+          before do
+            @valid_promotion.code = code
+          end
+
+          it { expect(@valid_promotion).not_to be_valid }
+        end
+
+        context 'code is identical with whitespace' do
+          before do
+            @valid_promotion.code = code + ' '
+          end
+
+          it { expect(@valid_promotion).not_to be_valid }
+        end
+      end
+    end
+
     describe 'expires_at_must_be_later_than_starts_at' do
       before do
         @valid_promotion.starts_at = Date.today


### PR DESCRIPTION
User can create 2 promotions with same code by adding whitespace.
For example:
1. Promotion with code 'promo'
2. Promotion with code 'promo '

Faced with this issue in production app. We had old promotion from 2017. Someone from admin users tried to create promotion with same code, but he saw validation error. So, this user added whitespace and this promotion was successfully created. Then there were questions, why this promotion would not apply. It showed that promotion was expired. So, spree applied promotion from 2017, not the recent one.

Ideally there should not be promotions with identical codes.

This PR includes changes that will not allow to create promotions with same code by adding whitespace.