### PR TITLE
Fix payment methods display when payment_sources are available

### DIFF
--- a/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js
@@ -8,20 +8,7 @@ Spree.ready(function ($) {
   Spree.onPayment = function () {
     if ($('#checkout_form_payment').length) {
       if ($('#existing_cards').length) {
-        $('#existing_cards').hide()
         $('#payment-methods').hide()
-        $("#payment-method-fields label[data-type='card']").click(function() {
-          $('#existing_cards').show()
-          $('.payment-sources').show()
-          $('.existing-cc-radio').first().prop('checked', true)
-        })
-        $("#payment-method-fields label:not([data-type='card'])").click(function() {
-          $('#existing_cards').hide()
-          $('#payment-methods').hide()
-          $('.payment-sources').hide()
-          $('.existing-cc-radio').prop('checked', false)
-          $('#use_existing_card_no').prop('checked', false)
-        })
         $('.existing-cc-radio').click(function () {
           $(this).prop('checked', true)
           $('#use_existing_card_no').prop('checked', false)
@@ -60,11 +47,26 @@ Spree.ready(function ($) {
       }
 
       $('input[type="radio"][name="order[payments_attributes][][payment_method_id]"]').click(function () {
+        $('#payment-methods').hide()
+        $('.payment-sources').hide()
         Spree.enableSave()
-        if ($('#payment_method_' + this.value).find('fieldset').children().length == 0) {
-          $('.payment-sources').hide()
-        } else {
-          $('.payment-sources').show()
+        if ($('#payment_method_' + this.value).find('fieldset').children().length !== 0) {
+          if (this.closest('label').dataset.type === 'card') {
+            if ($('#existing_cards').length) {
+              $('.existing-cc-radio').first().prop('checked', true);
+              $('#use_existing_card_no').prop('checked', false)
+              $('#use_existing_card_yes').prop('checked', true)
+              $('#existing_cards').show();
+              $('#payment-methods').hide();
+              $('.payment-sources').show()
+            }
+          } else {
+            $('.existing-cc-radio').prop('checked', false);
+            $('#use_existing_card_no').prop('checked', false);
+            $('#existing_cards').hide();
+            $('#payment-methods').show();
+            $('.payment-sources').show()
+          }
         }
         $('#payment-methods li').hide()
         if (this.checked) {

--- a/frontend/app/views/spree/checkout/_payment.html.erb
+++ b/frontend/app/views/spree/checkout/_payment.html.erb
@@ -21,7 +21,7 @@
     </ul>
 
     <div class="payment-sources">
-      <%= render partial: 'payment_sources' %>
+      <%= render partial: 'payment_sources' if @payment_sources.present? %>
 
       <ul id="payment-methods" class="list-unstyled position-relative mb-0 payment-sources-add-form" data-hook>
         <% checkout_available_payment_methods.each do |method| %>

--- a/frontend/app/views/spree/checkout/_payment.html.erb
+++ b/frontend/app/views/spree/checkout/_payment.html.erb
@@ -4,7 +4,6 @@
   </p>
 
   <div data-hook="checkout_payment_step">
-
     <%= render partial: 'spree/checkout/payment/storecredit' %>
 
     <ul id="payment-method-fields" class="list-unstyled position-relative" data-hook>
@@ -22,25 +21,7 @@
     </ul>
 
     <div class="payment-sources">
-      <% if @payment_sources.present? %>
-        <div id="existing_cards" class="payment-sources-existing-cards">
-          <%= radio_button_tag 'use_existing_card', 'yes', true, class: 'd-none' %>
-          <div class="form-group" data-hook="existing_cards">
-            <div class="d-flex flex-column payment-sources-list">
-              <% @payment_sources.each do |card| %>
-                <%= render partial: 'credit_card', locals: { card: card } %>
-              <% end %>
-              <div>
-                <label class="form-check-label spree-radio-label col-6 mb-2">
-                  <%= radio_button_tag 'use_existing_card', 'no' %>
-                  <span class="spree-radio-label-custom-input"></span>
-                  <span><%= Spree.t(:add_new_credit_card) %></span>
-                </label>
-              </div>
-            </div>
-          </div>
-        </div>
-      <% end %>
+      <%= render partial: 'payment_sources' %>
 
       <ul id="payment-methods" class="list-unstyled position-relative mb-0 payment-sources-add-form" data-hook>
         <% checkout_available_payment_methods.each do |method| %>

--- a/frontend/app/views/spree/checkout/_payment_sources.html.erb
+++ b/frontend/app/views/spree/checkout/_payment_sources.html.erb
@@ -1,0 +1,19 @@
+<% if @payment_sources.present? %>
+  <div id="existing_cards" class="payment-sources-existing-cards" style="display:none;">
+    <%= radio_button_tag 'use_existing_card', 'yes', true, class: 'd-none' %>
+    <div class="form-group" data-hook="existing_cards">
+      <div class="d-flex flex-column payment-sources-list">
+        <% @payment_sources.each do |card| %>
+          <%= render partial: 'credit_card', locals: { card: card } %>
+        <% end %>
+        <div>
+          <label class="form-check-label spree-radio-label col-6 mb-2">
+            <%= radio_button_tag 'use_existing_card', 'no' %>
+            <span class="spree-radio-label-custom-input"></span>
+            <span><%= Spree.t(:add_new_credit_card) %></span>
+          </label>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/frontend/app/views/spree/checkout/_payment_sources.html.erb
+++ b/frontend/app/views/spree/checkout/_payment_sources.html.erb
@@ -1,19 +1,17 @@
-<% if @payment_sources.present? %>
-  <div id="existing_cards" class="payment-sources-existing-cards" style="display:none;">
-    <%= radio_button_tag 'use_existing_card', 'yes', true, class: 'd-none' %>
-    <div class="form-group" data-hook="existing_cards">
-      <div class="d-flex flex-column payment-sources-list">
-        <% @payment_sources.each do |card| %>
-          <%= render partial: 'credit_card', locals: { card: card } %>
-        <% end %>
-        <div>
-          <label class="form-check-label spree-radio-label col-6 mb-2">
-            <%= radio_button_tag 'use_existing_card', 'no' %>
-            <span class="spree-radio-label-custom-input"></span>
-            <span><%= Spree.t(:add_new_credit_card) %></span>
-          </label>
-        </div>
+<div id="existing_cards" class="payment-sources-existing-cards" style="display:none;">
+  <%= radio_button_tag 'use_existing_card', 'yes', true, class: 'd-none' %>
+  <div class="form-group" data-hook="existing_cards">
+    <div class="d-flex flex-column payment-sources-list">
+      <% @payment_sources.each do |card| %>
+        <%= render partial: 'credit_card', locals: { card: card } %>
+      <% end %>
+      <div>
+        <label class="form-check-label spree-radio-label col-6 mb-2">
+          <%= radio_button_tag 'use_existing_card', 'no' %>
+          <span class="spree-radio-label-custom-input"></span>
+          <span><%= Spree.t(:add_new_credit_card) %></span>
+        </label>
       </div>
     </div>
   </div>
-<% end %>
+</div>

--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -202,17 +202,35 @@ describe 'Checkout', type: :feature, inaccessible: true, js: true do
     it 'only returns supported payment method of current store' do
       expect(page).not_to have_css("#payment_method_#{unsupported_payment.id}", visible: :hidden)
     end
+
+    it 'shows proper fields when changing payment method' do
+      expect(page).to have_css("#payment_method_#{credit_card_payment.id}")
+      expect(page).to have_css("#payment_method_#{check_payment.id}", visible: :hidden)
+
+      within('#payment-method-fields') do
+        find('label', text: 'Check').click
+      end
+      expect(page).not_to have_css("#payment_method_#{check_payment.id}")
+      expect(page).to have_css("#payment_method_#{credit_card_payment.id}", visible: :hidden)
+
+      within('#payment-method-fields') do
+        find('label', text: 'Credit Card').click
+      end
+      expect(page).to have_css("#payment_method_#{credit_card_payment.id}")
+      expect(page).to have_css("#payment_method_#{check_payment.id}", visible: :hidden)
+    end
   end
 
   context 'user has payment sources', js: true do
     let(:bogus) { create(:credit_card_payment_method) }
+    let(:check) { create(:check_payment_method) }
     let(:user) { create(:user) }
 
     before do
       create(:credit_card, user_id: user.id, payment_method: bogus, gateway_customer_profile_id: 'BGS-WEFWF')
 
       order = OrderWalkthrough.up_to(:payment)
-      allow(order).to receive_messages(available_payment_methods: [bogus])
+      allow(order).to receive_messages(available_payment_methods: [bogus, check])
 
       allow_any_instance_of(Spree::CheckoutController).to receive_messages(current_order: order)
       allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: user)
@@ -232,6 +250,40 @@ describe 'Checkout', type: :feature, inaccessible: true, js: true do
 
       expect(page).to have_content(Spree.t(:order_success).gsub(/[[:space:]]+/, ' '))
       expect(page).to have_current_path(spree.order_path(Spree::Order.last))
+    end
+
+    it 'shows proper fields when changing payment method' do
+      # Check if credit card fields with existing card option are visible.
+      within('#existing_cards') do
+        expect(page).to have_content('****1111,  Spree Commerce')
+        expect(page).to have_content('Add a new card')
+      end
+
+      expect(page).to have_css("#payment_method_#{bogus.id}", visible: :hidden)
+      find('span', text: 'Add a new card').click
+      expect(page).to have_css("#payment_method_#{bogus.id}")
+
+      # Choose 'Check' and see if credit card fields are hidden.
+      within('#payment-method-fields') do
+        find('label', text: 'Check').click
+      end
+
+      expect(page).to have_css("#payment_method_#{bogus.id}", visible: :hidden)
+      expect(page).to have_css("#existing_cards", visible: :hidden)
+
+      # Choose 'Credit Card' and see if credit card fields with existing card option are visible again.
+      within('#payment-method-fields') do
+        find('label', text: 'Credit Card').click
+      end
+
+      within('#existing_cards') do
+        expect(page).to have_content('****1111,  Spree Commerce')
+        expect(page).to have_content('Add a new card')
+      end
+
+      expect(page).to have_css("#payment_method_#{bogus.id}", visible: :hidden)
+      find('span', text: 'Add a new card').click
+      expect(page).to have_css("#payment_method_#{bogus.id}")
     end
   end
 

--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -269,7 +269,7 @@ describe 'Checkout', type: :feature, inaccessible: true, js: true do
       end
 
       expect(page).to have_css("#payment_method_#{bogus.id}", visible: :hidden)
-      expect(page).to have_css("#existing_cards", visible: :hidden)
+      expect(page).to have_css('#existing_cards', visible: :hidden)
 
       # Choose 'Credit Card' and see if credit card fields with existing card option are visible again.
       within('#payment-method-fields') do


### PR DESCRIPTION
The JS code responsible for showing/hiding payment method fields does not work properly when there are payment sources available and therefore `#existing_cards` element is rendered.