### PR TITLE
[SD-961] As a Admin I can set the Checkout zone per Store

### DIFF
--- a/api/app/serializers/spree/v2/storefront/store_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/store_serializer.rb
@@ -7,6 +7,8 @@ module Spree
         attributes :name, :url, :meta_description, :meta_keywords, :seo_title, :default_currency, :default, :supported_currencies, :facebook,
                    :twitter, :instagram, :default_locale, :customer_support_email, :default_country_id, :description,
                    :address, :contact_phone, :contact_email
+
+        has_one :default_country, serializer: :country, record_type: :country, id_method_name: :default_country_id
       end
     end
   end

--- a/api/spec/requests/spree/api/v2/storefront/stores_controller_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/stores_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Storefront API v2 Stores spec', type: :request do
-  let!(:store) { create(:store) }
+  let!(:store) { create(:store, default_country: create(:country)) }
 
   describe 'stores#show' do
     context 'with code param' do
@@ -20,12 +20,13 @@ describe 'Storefront API v2 Stores spec', type: :request do
         expect(json_response['data']).to have_attribute(:twitter).with_value(store.twitter)
         expect(json_response['data']).to have_attribute(:instagram).with_value(store.instagram)
         expect(json_response['data']).to have_attribute(:default_locale).with_value(store.default_locale)
-        expect(json_response['data']).to have_attribute(:customer_support_email).with_value(store.customer_support_email)
-        expect(json_response['data']).to have_attribute(:default_country_id).with_value(store.default_country_id)
         expect(json_response['data']).to have_attribute(:description).with_value(store.description)
         expect(json_response['data']).to have_attribute(:address).with_value(store.address)
         expect(json_response['data']).to have_attribute(:contact_phone).with_value(store.contact_phone)
         expect(json_response['data']).to have_attribute(:contact_email).with_value(store.contact_email)
+
+        expect(json_response['data']).to have_relationship(:default_country)
+        expect(json_response['data']).to have_relationship(:default_country).with_data('id' => store.default_country_id.to_s, 'type' => 'country')
       end
     end
 

--- a/api/spec/requests/spree/api/v2/storefront/stores_controller_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/stores_controller_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe 'Storefront API v2 Stores spec', type: :request do
+  let!(:store) { create(:store) }
+
+  describe 'stores#show' do
+    context 'with code param' do
+      before { get "/api/v2/storefront/stores/#{store.code}" }
+
+      it 'return store with attributes' do
+        expect(json_response['data']).to have_attribute(:name).with_value(store.name)
+        expect(json_response['data']).to have_attribute(:url).with_value(store.url)
+        expect(json_response['data']).to have_attribute(:meta_description).with_value(store.meta_description)
+        expect(json_response['data']).to have_attribute(:meta_keywords).with_value(store.meta_keywords)
+        expect(json_response['data']).to have_attribute(:seo_title).with_value(store.seo_title)
+        expect(json_response['data']).to have_attribute(:default_currency).with_value(store.default_currency)
+        expect(json_response['data']).to have_attribute(:default).with_value(store.default)
+        expect(json_response['data']).to have_attribute(:supported_currencies).with_value(store.supported_currencies)
+        expect(json_response['data']).to have_attribute(:facebook).with_value(store.facebook)
+        expect(json_response['data']).to have_attribute(:twitter).with_value(store.twitter)
+        expect(json_response['data']).to have_attribute(:instagram).with_value(store.instagram)
+        expect(json_response['data']).to have_attribute(:default_locale).with_value(store.default_locale)
+        expect(json_response['data']).to have_attribute(:customer_support_email).with_value(store.customer_support_email)
+        expect(json_response['data']).to have_attribute(:default_country_id).with_value(store.default_country_id)
+        expect(json_response['data']).to have_attribute(:description).with_value(store.description)
+        expect(json_response['data']).to have_attribute(:address).with_value(store.address)
+        expect(json_response['data']).to have_attribute(:contact_phone).with_value(store.contact_phone)
+        expect(json_response['data']).to have_attribute(:contact_email).with_value(store.contact_email)
+      end
+    end
+
+    context 'with invalid code param' do
+      before { get '/api/v2/storefront/stores/XX' }
+
+      it 'return error' do
+        expect(json_response['error']).to eq('The resource you were looking for could not be found.')
+      end
+    end
+  end
+end

--- a/backend/app/controllers/spree/admin/stores_controller.rb
+++ b/backend/app/controllers/spree/admin/stores_controller.rb
@@ -7,6 +7,7 @@ module Spree
       before_action :normalize_supported_currencies, only: [:create, :update]
       before_action :set_default_country_id, only: :new
       before_action :load_all_countries, only: [:new, :edit, :update, :create]
+      before_action :load_all_zones, only: %i[new edit]
 
       if defined?(SpreeI18n)
         include SpreeI18n::LocaleHelper
@@ -112,6 +113,10 @@ module Spree
 
       def load_all_countries
         @countries = Spree::Country.all
+      end
+
+      def load_all_zones
+        @zones = Spree::Zone.all
       end
 
       def set_default_currency

--- a/backend/app/controllers/spree/admin/stores_controller.rb
+++ b/backend/app/controllers/spree/admin/stores_controller.rb
@@ -116,7 +116,7 @@ module Spree
       end
 
       def load_all_zones
-        @zones = Spree::Zone.all
+        @zones = Spree::Zone.pluck(:name, :id)
       end
 
       def set_default_currency

--- a/backend/app/helpers/spree/admin/stores_helper.rb
+++ b/backend/app/helpers/spree/admin/stores_helper.rb
@@ -1,0 +1,18 @@
+module Spree
+  module Admin
+    module StoresHelper
+      def selected_checkout_zone(store)
+        return store.checkout_zone_id unless store.checkout_zone_id.nil?
+        return checkout_zone('No Limits').id if Spree::Config[:checkout_zone].nil?
+
+        return checkout_zone(Spree::Config[:checkout_zone]).id unless Spree::Config[:checkout_zone].nil?
+      end
+
+      private
+
+      def checkout_zone(name)
+        Spree::Zone.find_by(name: name)
+      end
+    end
+  end
+end

--- a/backend/app/helpers/spree/admin/stores_helper.rb
+++ b/backend/app/helpers/spree/admin/stores_helper.rb
@@ -2,17 +2,9 @@ module Spree
   module Admin
     module StoresHelper
       def selected_checkout_zone(store)
-        return store.checkout_zone_id unless store.checkout_zone_id.nil?
-        return checkout_zone_id(Spree::Zone.new.default) if Spree::Config[:checkout_zone].nil?
+        return Spree::Zone.find_by(id: store.checkout_zone_id) unless store.checkout_zone_id.nil?
 
-        return checkout_zone_id(Spree::Config[:checkout_zone]) unless Spree::Config[:checkout_zone].nil?
-      end
-
-      private
-
-      def checkout_zone_id(name)
-        zone = Spree::Zone.find_by(name: name)
-        zone.nil? ? 0 : zone.id
+        Spree::Zone.default_checkout_zone
       end
     end
   end

--- a/backend/app/helpers/spree/admin/stores_helper.rb
+++ b/backend/app/helpers/spree/admin/stores_helper.rb
@@ -3,7 +3,7 @@ module Spree
     module StoresHelper
       def selected_checkout_zone(store)
         return store.checkout_zone_id unless store.checkout_zone_id.nil?
-        return checkout_zone_id('No Limits') if Spree::Config[:checkout_zone].nil?
+        return checkout_zone_id(Spree::Zone.new.default) if Spree::Config[:checkout_zone].nil?
 
         return checkout_zone_id(Spree::Config[:checkout_zone]) unless Spree::Config[:checkout_zone].nil?
       end

--- a/backend/app/helpers/spree/admin/stores_helper.rb
+++ b/backend/app/helpers/spree/admin/stores_helper.rb
@@ -2,9 +2,7 @@ module Spree
   module Admin
     module StoresHelper
       def selected_checkout_zone(store)
-        return Spree::Zone.find_by(id: store.checkout_zone_id) unless store.checkout_zone_id.nil?
-
-        Spree::Zone.default_checkout_zone
+        store&.checkout_zone || Spree::Zone.default_checkout_zone
       end
     end
   end

--- a/backend/app/helpers/spree/admin/stores_helper.rb
+++ b/backend/app/helpers/spree/admin/stores_helper.rb
@@ -3,15 +3,16 @@ module Spree
     module StoresHelper
       def selected_checkout_zone(store)
         return store.checkout_zone_id unless store.checkout_zone_id.nil?
-        return checkout_zone('No Limits').id if Spree::Config[:checkout_zone].nil?
+        return checkout_zone_id('No Limits') if Spree::Config[:checkout_zone].nil?
 
-        return checkout_zone(Spree::Config[:checkout_zone]).id unless Spree::Config[:checkout_zone].nil?
+        return checkout_zone_id(Spree::Config[:checkout_zone]) unless Spree::Config[:checkout_zone].nil?
       end
 
       private
 
-      def checkout_zone(name)
-        Spree::Zone.find_by(name: name)
+      def checkout_zone_id(name)
+        zone = Spree::Zone.find_by(name: name)
+        zone.nil? ? 0 : zone.id
       end
     end
   end

--- a/backend/app/views/spree/admin/stores/_form.html.erb
+++ b/backend/app/views/spree/admin/stores/_form.html.erb
@@ -118,7 +118,7 @@
     <% end %>
     <%= f.field_container :checkout_zone_id, class: ['form-group'] do %>
       <%= f.label :checkout_zone_id, Spree.t(:zone) %>
-      <%= f.select :checkout_zone_id, options_for_select(@zones, selected_checkout_zone(@store).id), {}, { class: 'select2' } %>
+      <%= f.select :checkout_zone_id, options_for_select(@zones, selected_checkout_zone(@store)&.id), { include_blank: Spree.t(:no_limits_zone) }, { class: 'select2' } %>
       <%= f.label :checkout_zone_id, Spree.t('i18n.checkout_zone_warning_html'), class: 'alert alert-warning col-12' %>
       <%= f.error_message_on :checkout_zone_id %>
     <% end %>

--- a/backend/app/views/spree/admin/stores/_form.html.erb
+++ b/backend/app/views/spree/admin/stores/_form.html.erb
@@ -118,7 +118,7 @@
     <% end %>
     <%= f.field_container :checkout_zone_id, class: ['form-group'] do %>
       <%= f.label :checkout_zone_id, Spree.t(:zone) %>
-      <%= f.select :checkout_zone_id, options_from_collection_for_select(@zones, :id, :name, selected_checkout_zone(@store)), {}, { class: 'select2' } %>
+      <%= f.select :checkout_zone_id, options_for_select(@zones, selected_checkout_zone(@store).id), {}, { class: 'select2' } %>
       <%= f.label :checkout_zone_id, Spree.t('i18n.checkout_zone_warning_html'), class: 'alert alert-warning col-12' %>
       <%= f.error_message_on :checkout_zone_id %>
     <% end %>

--- a/backend/app/views/spree/admin/stores/_form.html.erb
+++ b/backend/app/views/spree/admin/stores/_form.html.erb
@@ -116,6 +116,12 @@
       <%= f.select :supported_currencies, currency_options(@store.supported_currencies&.split(',')), { prompt: false }, { multiple: true, class: 'select2' } %>
       <%= f.error_message_on :supported_currencies %>
     <% end %>
+    <%= f.field_container :checkout_zone_id, class: ['form-group'] do %>
+      <%= f.label :checkout_zone_id, Spree.t('zone') %>
+      <%= f.select :checkout_zone_id, options_from_collection_for_select(@zones, :id, :name, selected_checkout_zone(@store)), {}, { class: 'select2' } %>
+      <%= f.label :checkout_zone_id, Spree.t('i18n.checkout_zone_warning_html'), class: 'alert alert-warning col-12' %>
+      <%= f.error_message_on :checkout_zone_id %>
+    <% end %>
     <%= f.field_container :default_locale, class: ['form-group'] do %>
       <%= f.label :default_locale, Spree.t('i18n.language') %>
       <%= f.select :default_locale, options_from_collection_for_select(all_locales_options, :last, :first, @store.default_locale), {}, { class: 'select2' } %>

--- a/backend/app/views/spree/admin/stores/_form.html.erb
+++ b/backend/app/views/spree/admin/stores/_form.html.erb
@@ -117,7 +117,7 @@
       <%= f.error_message_on :supported_currencies %>
     <% end %>
     <%= f.field_container :checkout_zone_id, class: ['form-group'] do %>
-      <%= f.label :checkout_zone_id, Spree.t('zone') %>
+      <%= f.label :checkout_zone_id, Spree.t(:zone) %>
       <%= f.select :checkout_zone_id, options_from_collection_for_select(@zones, :id, :name, selected_checkout_zone(@store)), {}, { class: 'select2' } %>
       <%= f.label :checkout_zone_id, Spree.t('i18n.checkout_zone_warning_html'), class: 'alert alert-warning col-12' %>
       <%= f.error_message_on :checkout_zone_id %>

--- a/backend/spec/features/admin/store_spec.rb
+++ b/backend/spec/features/admin/store_spec.rb
@@ -5,6 +5,8 @@ describe 'Stores', type: :feature, js: true do
 
   context 'creating new store' do
     before do
+      create(:zone, name: 'No Limits')
+
       visit spree.admin_path
 
       click_link 'Configurations'
@@ -54,8 +56,11 @@ describe 'Stores', type: :feature, js: true do
   end
 
   context 'editing existing store' do
+    let!(:updated_zone) { create(:zone, name: 'EU_VAT') }
+
     before do
-      create(:store, name: 'Some existing store')
+      @zone = create(:zone, name: 'No Limits')
+      create(:store, name: 'Some existing store', checkout_zone_id: @zone.id)
 
       visit spree.admin_path
 
@@ -74,6 +79,72 @@ describe 'Stores', type: :feature, js: true do
     it 'edits existing stores footer info' do
       within_row(1) { click_icon :edit }
       fill_in 'Description', with: 'Some edited description'
+      click_button 'Update'
+
+      expect(page).to have_content('successfully updated!')
+    end
+  end
+
+  context 'with checkout_zone preference set in spree config file' do
+    let!(:store) { create(:store, name: 'Some existing store') }
+    let!(:zone) { create(:zone, name: 'Asia') }
+
+    before do
+      Spree::Config[:checkout_zone] = 'Asia'
+
+      visit spree.admin_path
+
+      click_link 'Configurations'
+      click_link 'Stores'
+    end
+
+    it 'edits existing store' do
+      within_row(1) { click_icon :edit }
+      fill_in 'Mail from address', with: 'new_email@example.com'
+      click_button 'Update'
+
+      expect(page).to have_content('successfully updated!')
+    end
+  end
+
+  context 'with checkout_zone_id attribute set for store' do
+    let!(:store) { create(:store, name: 'Some existing store', checkout_zone_id: zone.id) }
+    let!(:zone) { create(:zone, name: 'Asia') }
+
+    before do
+      Spree::Config.preference_default(:checkout_zone)
+
+      visit spree.admin_path
+
+      click_link 'Configurations'
+      click_link 'Stores'
+    end
+
+    it 'edits existing store' do
+      within_row(1) { click_icon :edit }
+      fill_in 'Mail from address', with: 'some_email@example.com'
+      click_button 'Update'
+
+      expect(page).to have_content('successfully updated!')
+    end
+  end
+
+  context 'without checkout_zone_id attribute  and checkout_zone preference' do
+    let!(:store) { create(:store, name: 'Some existing store', checkout_zone_id: nil) }
+    let!(:zone) { create(:zone, name: 'No Limits') }
+
+    before do
+      Spree::Config.preference_default(:checkout_zone)
+
+      visit spree.admin_path
+
+      click_link 'Configurations'
+      click_link 'Stores'
+    end
+
+    it 'edits existing store' do
+      within_row(1) { click_icon :edit }
+      fill_in 'Mail from address', with: 'some_email@example.com'
       click_button 'Update'
 
       expect(page).to have_content('successfully updated!')

--- a/backend/spec/features/admin/store_spec.rb
+++ b/backend/spec/features/admin/store_spec.rb
@@ -129,9 +129,8 @@ describe 'Stores', type: :feature, js: true do
     end
   end
 
-  context 'without checkout_zone_id attribute  and checkout_zone preference' do
+  context 'without checkout_zone_id attribute and checkout_zone preference' do
     let!(:store) { create(:store, name: 'Some existing store', checkout_zone_id: nil) }
-    let!(:zone) { create(:zone, name: 'No Limits') }
 
     before do
       Spree::Config.preference_default(:checkout_zone)

--- a/backend/spec/helpers/spree/admin/stores_helper_spec.rb
+++ b/backend/spec/helpers/spree/admin/stores_helper_spec.rb
@@ -30,16 +30,14 @@ describe Spree::Admin::StoresHelper, type: :helper do
       end
     end
 
-    context 'return No Limits zone' do
+    context 'checkout_zone is not set via preference or store' do
       before do
         Spree::Config.preference_default(:checkout_zone)
         store.update(checkout_zone_id: nil)
-        country_zone.update(name: 'No Limits')
-        country_zone.members.create(zoneable: country)
       end
 
-      it 'return countries' do
-        expect(selected_checkout_zone(store)).to eq country_zone
+      it 'return nil' do
+        expect(selected_checkout_zone(store)).to eq nil
       end
     end
   end

--- a/backend/spec/helpers/spree/admin/stores_helper_spec.rb
+++ b/backend/spec/helpers/spree/admin/stores_helper_spec.rb
@@ -14,7 +14,7 @@ describe Spree::Admin::StoresHelper, type: :helper do
       end
 
       it 'return countries' do
-        expect(selected_checkout_zone(store)).to eq Spree::Zone.find_by(name: Spree::Config[:checkout_zone]).id
+        expect(selected_checkout_zone(store)).to eq Spree::Zone.find_by(name: Spree::Config[:checkout_zone])
       end
     end
 
@@ -26,7 +26,7 @@ describe Spree::Admin::StoresHelper, type: :helper do
       end
 
       it 'return countries' do
-        expect(selected_checkout_zone(store)).to eq country_zone.id
+        expect(selected_checkout_zone(store)).to eq country_zone
       end
     end
 
@@ -39,7 +39,7 @@ describe Spree::Admin::StoresHelper, type: :helper do
       end
 
       it 'return countries' do
-        expect(selected_checkout_zone(store)).to eq country_zone.id
+        expect(selected_checkout_zone(store)).to eq country_zone
       end
     end
   end

--- a/backend/spec/helpers/spree/admin/stores_helper_spec.rb
+++ b/backend/spec/helpers/spree/admin/stores_helper_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe Spree::Admin::StoresHelper, type: :helper do
+
+  describe '#selected_checkout_zone' do
+    let!(:store) { create(:store) }
+    let!(:country) { create(:country) }
+    let!(:country_zone) { create(:zone, name: 'CountryZone') }
+
+    context 'with set preference checkout_zone in spree config file' do
+      before do
+        country_zone.members.create(zoneable: country)
+        Spree::Config[:checkout_zone] = country_zone.name
+      end
+
+      it 'return countries' do
+        expect(selected_checkout_zone(store)).to eq Spree::Zone.find_by(name: Spree::Config[:checkout_zone]).id
+      end
+    end
+
+    context 'with checkout_zone_id set on store' do
+      before do
+        Spree::Config.preference_default(:checkout_zone)
+        country_zone.members.create(zoneable: country)
+        store.update(checkout_zone_id: country_zone.id)
+      end
+
+      it 'return countries' do
+        expect(selected_checkout_zone(store)).to eq country_zone.id
+      end
+    end
+
+    context 'return No Limits zone' do
+      before do
+        Spree::Config.preference_default(:checkout_zone)
+        store.update(checkout_zone_id: nil)
+        country_zone.update(name: 'No Limits')
+        country_zone.members.create(zoneable: country)
+      end
+
+      it 'return countries' do
+        expect(selected_checkout_zone(store)).to eq country_zone.id
+      end
+    end
+  end
+end

--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -1,7 +1,7 @@
 module Spree
   module BaseHelper
     def available_countries
-      checkout_zone = Spree::Zone.find_by(name: Spree::Config[:checkout_zone])
+      checkout_zone = current_store.zone || Spree::Zone.find_by(name: Spree::Config[:checkout_zone])
 
       countries = if checkout_zone && checkout_zone.kind == 'country'
                     checkout_zone.country_list

--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -1,7 +1,7 @@
 module Spree
   module BaseHelper
     def available_countries
-      checkout_zone = current_store.zone || Spree::Zone.default_checkout_zone
+      checkout_zone = current_store.checkout_zone || Spree::Zone.default_checkout_zone
 
       countries = if checkout_zone && checkout_zone.kind == 'country'
                     checkout_zone.country_list
@@ -212,7 +212,7 @@ module Spree
     def meta_robots
       return unless current_store.respond_to?(:seo_robots)
       return if current_store.seo_robots.blank?
-      
+
       tag('meta', name: 'robots', content: current_store.seo_robots)
     end
   end

--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -1,7 +1,7 @@
 module Spree
   module BaseHelper
     def available_countries
-      checkout_zone = current_store.zone || Spree::Zone.find_by(name: Spree::Config[:checkout_zone])
+      checkout_zone = current_store.zone || Spree::Zone.default_checkout_zone
 
       countries = if checkout_zone && checkout_zone.kind == 'country'
                     checkout_zone.country_list

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -3,6 +3,7 @@ module Spree
     has_many :orders, class_name: 'Spree::Order'
     has_many :payment_methods, class_name: 'Spree::PaymentMethod'
     belongs_to :default_country, class_name: 'Spree::Country'
+    belongs_to :zone, class_name: 'Spree::Zone', foreign_key: 'checkout_zone_id'
 
     with_options presence: true do
       validates :name, :url, :mail_from_address, :default_currency, :code

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -3,7 +3,7 @@ module Spree
     has_many :orders, class_name: 'Spree::Order'
     has_many :payment_methods, class_name: 'Spree::PaymentMethod'
     belongs_to :default_country, class_name: 'Spree::Country'
-    belongs_to :zone, class_name: 'Spree::Zone', foreign_key: 'checkout_zone_id'
+    belongs_to :checkout_zone, class_name: 'Spree::Zone'
 
     with_options presence: true do
       validates :name, :url, :mail_from_address, :default_currency, :code

--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -71,7 +71,7 @@ module Spree
     end
 
     def self.default_checkout_zone
-      find_by(name: Spree::Config[:checkout_zone]) || find_by(name: Spree.t(:default_zone))
+      find_by(name: Spree::Config[:checkout_zone])
     end
 
     def kind

--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -1,7 +1,5 @@
 module Spree
   class Zone < Spree::Base
-    attribute :default, :string, default: Spree.t(:default_zone)
-
     with_options dependent: :destroy, inverse_of: :zone do
       has_many :zone_members, class_name: 'Spree::ZoneMember'
       has_many :tax_rates
@@ -70,6 +68,10 @@ module Spree
         end
       end
       matches.first
+    end
+
+    def self.default_checkout_zone
+      find_by(name: Spree::Config[:checkout_zone]) || find_by(name: Spree.t(:default_zone))
     end
 
     def kind

--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -1,5 +1,7 @@
 module Spree
   class Zone < Spree::Base
+    attribute :default, :string, default: Spree.t(:default_zone)
+
     with_options dependent: :destroy, inverse_of: :zone do
       has_many :zone_members, class_name: 'Spree::ZoneMember'
       has_many :tax_rates

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1812,4 +1812,4 @@ en:
     zipcode_required: Zip Code Required
     zone: Zone
     zones: Zones
-    default_zone: No Limits
+    no_limits_zone: No Limits

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1812,3 +1812,4 @@ en:
     zipcode_required: Zip Code Required
     zone: Zone
     zones: Zones
+    default_zone: No Limits

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -958,6 +958,8 @@ en:
       supported_locales: Supported Locales
       this_file_language: English (US)
       translations: Translations
+      checkout_zone_warning_html: "Selecting a Zone will limit customers on Checkout to Addresses in Countries in that Zone. <br />
+      Please see documentation: <a href='https://guides.spreecommerce.org/user/configuration/configuring_geography.html#zones' target='_blank' class='alert-link'>https://guides.spreecommerce.org/user/configuration/configuring_geography.html#zones</a>"
     icon: Icon
     image: Image
     images: Images

--- a/core/db/default/spree/zones.rb
+++ b/core/db/default/spree/zones.rb
@@ -3,6 +3,9 @@ north_america = Spree::Zone.where(name: 'North America', description: 'USA + Can
 south_america = Spree::Zone.where(name: 'South America', description: 'South America', kind: 'country').first_or_create!
 middle_east = Spree::Zone.where(name: 'Middle East', description: 'Middle East', kind: 'country').first_or_create!
 asia = Spree::Zone.where(name: 'Asia', description: 'Asia', kind: 'country').first_or_create!
+no_limits = Spree::Zone.where(name: 'No Limits', description: 'Includes all the countries of the world!', kind: 'country').first_or_create!
+
+Spree::Country.pluck(:iso).each { |iso| no_limits.zone_members.where(zoneable: Spree::Country.find_by!(iso: iso)).first_or_create! }
 
 %w(PL FI PT RO DE FR SK HU SI IE AT ES IT BE SE LV BG GB LT CY LU MT DK NL EE HR CZ GR).each do |name|
   eu_vat.zone_members.where(zoneable: Spree::Country.find_by!(iso: name)).first_or_create!

--- a/core/db/default/spree/zones.rb
+++ b/core/db/default/spree/zones.rb
@@ -3,9 +3,6 @@ north_america = Spree::Zone.where(name: 'North America', description: 'USA + Can
 south_america = Spree::Zone.where(name: 'South America', description: 'South America', kind: 'country').first_or_create!
 middle_east = Spree::Zone.where(name: 'Middle East', description: 'Middle East', kind: 'country').first_or_create!
 asia = Spree::Zone.where(name: 'Asia', description: 'Asia', kind: 'country').first_or_create!
-no_limits = Spree::Zone.where(name: 'No Limits', description: 'Includes all the countries of the world!', kind: 'country').first_or_create!
-
-Spree::Country.pluck(:iso).each { |iso| no_limits.zone_members.where(zoneable: Spree::Country.find_by!(iso: iso)).first_or_create! }
 
 %w(PL FI PT RO DE FR SK HU SI IE AT ES IT BE SE LV BG GB LT CY LU MT DK NL EE HR CZ GR).each do |name|
   eu_vat.zone_members.where(zoneable: Spree::Country.find_by!(iso: name)).first_or_create!

--- a/core/db/migrate/20201006110150_add_checkout_zone_field_to_store.rb
+++ b/core/db/migrate/20201006110150_add_checkout_zone_field_to_store.rb
@@ -1,0 +1,10 @@
+class AddCheckoutZoneFieldToStore < ActiveRecord::Migration[6.0]
+  def change
+    unless column_exists?(:spree_stores, :checkout_zone_id)
+      add_reference :spree_stores, :checkout_zone, { references: :spree_zones, index: true }
+
+      Spree::Store.reset_column_information
+      Spree::Store.update_all(checkout_zone_id: Spree::Zone.find_by(name: Spree::Config[:checkout_zone])&.id)
+    end
+  end
+end

--- a/core/db/migrate/20201006110150_add_checkout_zone_field_to_store.rb
+++ b/core/db/migrate/20201006110150_add_checkout_zone_field_to_store.rb
@@ -1,10 +1,12 @@
 class AddCheckoutZoneFieldToStore < ActiveRecord::Migration[6.0]
   def change
     unless column_exists?(:spree_stores, :checkout_zone_id)
-      add_reference :spree_stores, :checkout_zone, { references: :spree_zones, index: true }
+      add_column :spree_stores, :checkout_zone_id, :integer
 
       Spree::Store.reset_column_information
-      Spree::Store.update_all(checkout_zone_id: Spree::Zone.find_by(name: Spree::Config[:checkout_zone])&.id)
+
+      default_zone = Spree::Zone.default_checkout_zone
+      Spree::Store.update_all(checkout_zone_id: default_zone.id) if default_zone.present?
     end
   end
 end

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -101,7 +101,7 @@ module Spree
                           :customer_support_email, :facebook, :twitter, :instagram,
                           :description, :address, :contact_email, :contact_phone,
                           :default_locale, :default_country_id, :supported_currencies,
-                          :new_order_notifications_email, :mailer_logo]
+                          :new_order_notifications_email, :mailer_logo, :checkout_zone_id]
 
     @@store_credit_attributes = %i[amount currency category_id memo]
 

--- a/core/lib/spree/testing_support/factories/zone_factory.rb
+++ b/core/lib/spree/testing_support/factories/zone_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :global_zone, class: Spree::Zone do
-    name        { 'GlobalZone' }
+    sequence(:name) { |n| "GlobalZone_#{n}" }
     description { generate(:random_string) }
     zone_members do |proxy|
       zone = proxy.instance_eval { @instance }

--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -12,9 +12,24 @@ describe Spree::BaseHelper, type: :helper do
       create_list(:country, 3)
     end
 
+    context 'with checkout zone assigned to the store' do
+      before do
+        Spree::Config[:checkout_zone] = nil
+        @zone = create(:zone, name: 'No Limits')
+        @zone.members.create(zoneable: country)
+        current_store.update(checkout_zone_id: @zone.id)
+      end
+
+      it 'return only the countries defined by the checkout_zone_id' do
+        expect(available_countries).to eq([country])
+        expect(current_store.checkout_zone_id).to eq @zone.id
+      end
+    end
+
     context 'with no checkout zone defined' do
       before do
         Spree::Config[:checkout_zone] = nil
+        current_store.update(checkout_zone_id: nil)
       end
 
       it 'return complete list of countries' do

--- a/core/spec/models/spree/zone_spec.rb
+++ b/core/spec/models/spree/zone_spec.rb
@@ -483,7 +483,7 @@ describe Spree::Zone, type: :model do
       before { Spree::Config[:checkout_zone] = nil }
 
       it 'return default checkout zone object' do
-        expect(Spree::Zone.default_checkout_zone).to eq default_zone
+        expect(Spree::Zone.default_checkout_zone).to eq nil
       end
     end
   end

--- a/core/spec/models/spree/zone_spec.rb
+++ b/core/spec/models/spree/zone_spec.rb
@@ -465,4 +465,12 @@ describe Spree::Zone, type: :model do
       end
     end
   end
+
+  context '.default' do
+    let!(:default_zone) { create(:zone, name: 'No Limits') }
+
+    it 'return name of default zone' do
+      expect(Spree::Zone.new.default).to eq('No Limits')
+    end
+  end
 end

--- a/core/spec/models/spree/zone_spec.rb
+++ b/core/spec/models/spree/zone_spec.rb
@@ -466,11 +466,25 @@ describe Spree::Zone, type: :model do
     end
   end
 
-  context '.default' do
+  describe '#default_checkout_zone' do
+    let!(:country) { create(:country) }
+    let!(:zone) { create(:zone, name: 'Asia') }
     let!(:default_zone) { create(:zone, name: 'No Limits') }
 
-    it 'return name of default zone' do
-      expect(Spree::Zone.new.default).to eq('No Limits')
+    context 'when checkout_zone is set by config file' do
+      before { Spree::Config[:checkout_zone] = zone.name }
+
+      it 'return default checkout zone object' do
+        expect(Spree::Zone.default_checkout_zone).to eq zone
+      end
+    end
+
+    context 'when checkout_zone is not set in config file' do
+      before { Spree::Config[:checkout_zone] = nil }
+
+      it 'return default checkout zone object' do
+        expect(Spree::Zone.default_checkout_zone).to eq default_zone
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adding option to assign specific [zone](https://guides.spreecommerce.org/user/configuration/configuring_geography.html#zones) to the store. 

more details: https://spark-solutions.atlassian.net/browse/SD-961