### PR TITLE
Convert ES6 code to ES5

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -129,7 +129,9 @@ jQuery(function ($) {
       var label = $('label[for="' + ransackFieldId + '"]')
 
       if ($this.is('select')) {
-        ransackValue = $this.find('option:selected').toArray().map(option => option.text).join(', ')
+        ransackValue = $this.find('option:selected').toArray().map(function (option) {
+          return option.text;
+        }).join(', ')
       } else {
         ransackValue = $this.val()
       }


### PR DESCRIPTION
To avoid compilation problems with asset pipeline when harmony is set to false