### PR TITLE
[SD-946] Add Spree::Config to initializer

### DIFF
--- a/core/lib/generators/spree/install/templates/config/initializers/spree.rb
+++ b/core/lib/generators/spree/install/templates/config/initializers/spree.rb
@@ -28,4 +28,8 @@ end
 
 # Spree::Api::Dependencies.storefront_cart_serializer = 'MyRailsApp::CartSerializer'
 
+Rails.application.config.after_initialize do
+  Spree::Config = Spree::AppConfiguration.new
+ends
+
 Spree.user_class = <%= (options[:user_class].blank? ? 'Spree::LegacyUser' : options[:user_class]).inspect %>

--- a/core/lib/generators/spree/install/templates/config/initializers/spree.rb
+++ b/core/lib/generators/spree/install/templates/config/initializers/spree.rb
@@ -28,8 +28,9 @@ end
 
 # Spree::Api::Dependencies.storefront_cart_serializer = 'MyRailsApp::CartSerializer'
 
-Rails.application.config.after_initialize do
-  Spree::Config = Spree::AppConfiguration.new
-ends
+# Uncomment if changes applied to Spree::Config are not visible
+# Rails.application.config.after_initialize do
+#   Spree::Config = Spree::AppConfiguration.new
+# end
 
 Spree.user_class = <%= (options[:user_class].blank? ? 'Spree::LegacyUser' : options[:user_class]).inspect %>


### PR DESCRIPTION
Issue: https://github.com/spree/spree/issues/10497

Spree::Config is required before the initialization process so it couldn't be moved/changed in the spree-core engine, however, the config can be recreated after Zeitwerk loads all files so any changes made to the AppConfiguration will be visible.

How to test:

Create AppConfigurationDecorator:

> module Spree
>   module AppConfigurationDecorator
>     def self.prepended(base)
>       base.preference :foo, :string, default: 'bar'
>     end
>   end
> end
> 
> Spree::AppConfiguration.prepend(Spree::AppConfigurationDecorator)
> 
> 

Open rails console and try to access `Spree::Config.foo`