### PR TITLE
Dont allow expired tokens in api V2 base controller

### DIFF
--- a/api/app/controllers/spree/api/v2/base_controller.rb
+++ b/api/app/controllers/spree/api/v2/base_controller.rb
@@ -53,7 +53,12 @@ module Spree
         end
 
         def spree_current_user
-          @spree_current_user ||= Spree.user_class.find_by(id: doorkeeper_token.resource_owner_id) if doorkeeper_token
+          return nil unless doorkeeper_token
+          return @spree_current_user if @spree_current_user
+
+          doorkeeper_authorize!
+
+          @spree_current_user ||= Spree.user_class.find_by(id: doorkeeper_token.resource_owner_id)
         end
 
         def spree_authorize!(action, subject, *args)

--- a/api/lib/spree/api/testing_support/v2/base.rb
+++ b/api/lib/spree/api/testing_support/v2/base.rb
@@ -4,7 +4,7 @@ shared_context 'API v2 tokens' do
   let(:headers_order_token) { { 'X-Spree-Order-Token' => order.token } }
 end
 
-[200, 201, 400, 404, 403, 422].each do |status_code|
+[200, 201, 400, 401, 404, 403, 422].each do |status_code|
   shared_examples "returns #{status_code} HTTP status" do
     it "returns #{status_code}" do
       expect(response.status).to eq(status_code)

--- a/api/spec/requests/spree/api/v2/errors_spec.rb
+++ b/api/spec/requests/spree/api/v2/errors_spec.rb
@@ -29,4 +29,19 @@ describe 'API v2 Errors spec', type: :request do
       expect(json_response['error']).to eq('You are not authorized to access this page.')
     end
   end
+
+  context 'expired token failure' do
+    let(:user) { create(:user) }
+    let(:headers) { headers_bearer }
+
+    include_context 'API v2 tokens'
+
+    before do
+      token.expires_in = -1
+      token.save
+      get '/api/v2/storefront/account', headers: headers
+    end
+
+    it_behaves_like 'returns 401 HTTP status'
+  end
 end


### PR DESCRIPTION
`doorkeeper_authorize!` must be called when calling `doorkeeper_token` to ensure that the token is not expired.