### PR TITLE
Split order products into shipments by stock location

### DIFF
--- a/api/config/locales/en.yml
+++ b/api/config/locales/en.yml
@@ -26,7 +26,7 @@ en:
         cannot_ready: "Cannot ready shipment."
       stock_location_required: "A stock_location_id parameter must be provided in order to retrieve stock movements."
       invalid_taxonomy_id: "Invalid taxonomy id."
-      shipment_transfer_errors_occured: "Following errors occured while attempting this action:"
+      shipment_transfer_errors_occurred: "Following errors occured while attempting this action:"
       negative_quantity: "quantity is negative"
       wrong_shipment_target: "target shipment is the same as original shipment"
 

--- a/api/spec/controllers/spree/api/v1/shipments_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/shipments_controller_spec.rb
@@ -81,7 +81,7 @@ describe Spree::Api::V1::ShipmentsController, type: :controller do
 
         it 'displays wrong target and negative quantity errors' do
           api_post :transfer_to_shipment, params
-          expect(json_response['exception']).to eq("#{Spree.t(:shipment_transfer_errors_occured, scope: 'api')} \n#{Spree.t(:negative_quantity, scope: 'api')}, \n#{Spree.t(:wrong_shipment_target, scope: 'api')}")
+          expect(json_response['exception']).to eq("#{Spree.t(:shipment_transfer_errors_occurred, scope: 'api')} \n#{Spree.t(:negative_quantity, scope: 'api')}, \n#{Spree.t(:wrong_shipment_target, scope: 'api')}")
         end
       end
 
@@ -92,7 +92,7 @@ describe Spree::Api::V1::ShipmentsController, type: :controller do
 
         it 'displays negative quantity error' do
           api_post :transfer_to_shipment, params
-          expect(json_response['exception']).to eq("#{Spree.t(:shipment_transfer_errors_occured, scope: 'api')} \n#{Spree.t(:negative_quantity, scope: 'api')}")
+          expect(json_response['exception']).to eq("#{Spree.t(:shipment_transfer_errors_occurred, scope: 'api')} \n#{Spree.t(:negative_quantity, scope: 'api')}")
         end
       end
 
@@ -103,7 +103,7 @@ describe Spree::Api::V1::ShipmentsController, type: :controller do
 
         it 'displays wrong target error' do
           api_post :transfer_to_shipment, params
-          expect(json_response['exception']).to eq("#{Spree.t(:shipment_transfer_errors_occured, scope: 'api')} \n#{Spree.t(:wrong_shipment_target, scope: 'api')}")
+          expect(json_response['exception']).to eq("#{Spree.t(:shipment_transfer_errors_occurred, scope: 'api')} \n#{Spree.t(:wrong_shipment_target, scope: 'api')}")
         end
       end
     end

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -289,14 +289,14 @@ function completeItemSplit(event) {
   var newShipment = selectedShipment.data('new-shipment')
   // eslint-disable-next-line eqeqeq
   if (stockLocationId != 'new_shipment') {
-    var url, additionalData
+    var path, additionalData
     if (newShipment !== undefined) {
       // transfer to a new location data
-      url = Spree.url(Spree.routes.shipments_api + '/transfer_to_location')
+      path = '/transfer_to_location'
       additionalData = { stock_location_id: stockLocationId }
     } else {
       // transfer to an existing shipment data
-      url = Spree.url(Spree.routes.shipments_api + '/transfer_to_shipment')
+      path = '/transfer_to_shipment'
       additionalData = { target_shipment_number: targetShipmentNumber }
     }
 
@@ -310,7 +310,7 @@ function completeItemSplit(event) {
     $.ajax({
       type: 'POST',
       async: false,
-      url: url,
+      url: Spree.url(Spree.routes.shipments_api + path),
       data: $.extend(data, additionalData)
     }).fail(function (msg) {
       alert(msg.responseJSON.message || msg.responseJSON.exception)

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -290,42 +290,32 @@ function completeItemSplit(event) {
   // eslint-disable-next-line eqeqeq
   if (stockLocationId != 'new_shipment') {
     if (newShipment !== undefined) {
-      // TRANSFER TO A NEW LOCATION
-      $.ajax({
-        type: 'POST',
-        async: false,
-        url: Spree.url(Spree.routes.shipments_api + '/transfer_to_location'),
-        data: {
-          original_shipment_number: originalShipmentNumber,
-          variant_id: variantId,
-          quantity: quantity,
-          stock_location_id: stockLocationId,
-          token: Spree.api_key
-        }
-      }).fail(function (msg) {
-        alert(msg.responseJSON.message || msg.responseJSON.exception)
-      }).done(function (msg) {
-        window.location.reload()
-      })
+      // transfer to a new location data
+      var url = Spree.url(Spree.routes.shipments_api + '/transfer_to_location')
+      var additional_data = { stock_location_id: stockLocationId }
     } else {
-      // TRANSFER TO AN EXISTING SHIPMENT
-      $.ajax({
-        type: 'POST',
-        async: false,
-        url: Spree.url(Spree.routes.shipments_api + '/transfer_to_shipment'),
-        data: {
-          original_shipment_number: originalShipmentNumber,
-          target_shipment_number: targetShipmentNumber,
-          variant_id: variantId,
-          quantity: quantity,
-          token: Spree.api_key
-        }
-      }).fail(function (msg) {
-        alert(msg.responseJSON.message || msg.responseJSON.exception)
-      }).done(function (msg) {
-        window.location.reload()
-      })
+      // transfer to an existing shipment data
+      var url = Spree.url(Spree.routes.shipments_api + '/transfer_to_shipment')
+      var additional_data = { target_shipment_number: targetShipmentNumber }
     }
+
+    data = {
+      original_shipment_number: originalShipmentNumber,
+      variant_id: variantId,
+      quantity: quantity,
+      token: Spree.api_key
+    }
+
+    $.ajax({
+      type: 'POST',
+      async: false,
+      url: url,
+      data: $.extend(data, additional_data)
+    }).fail(function (msg) {
+      alert(msg.responseJSON.message || msg.responseJSON.exception)
+    }).done(function (msg) {
+      window.location.reload()
+    })
   }
 }
 

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -289,17 +289,18 @@ function completeItemSplit(event) {
   var newShipment = selectedShipment.data('new-shipment')
   // eslint-disable-next-line eqeqeq
   if (stockLocationId != 'new_shipment') {
+    var url, additionalData
     if (newShipment !== undefined) {
       // transfer to a new location data
-      var url = Spree.url(Spree.routes.shipments_api + '/transfer_to_location')
-      var additional_data = { stock_location_id: stockLocationId }
+      url = Spree.url(Spree.routes.shipments_api + '/transfer_to_location')
+      additionalData = { stock_location_id: stockLocationId }
     } else {
       // transfer to an existing shipment data
-      var url = Spree.url(Spree.routes.shipments_api + '/transfer_to_shipment')
-      var additional_data = { target_shipment_number: targetShipmentNumber }
+      url = Spree.url(Spree.routes.shipments_api + '/transfer_to_shipment')
+      additionalData = { target_shipment_number: targetShipmentNumber }
     }
 
-    data = {
+    var data = {
       original_shipment_number: originalShipmentNumber,
       variant_id: variantId,
       quantity: quantity,
@@ -310,7 +311,7 @@ function completeItemSplit(event) {
       type: 'POST',
       async: false,
       url: url,
-      data: $.extend(data, additional_data)
+      data: $.extend(data, additionalData)
     }).fail(function (msg) {
       alert(msg.responseJSON.message || msg.responseJSON.exception)
     }).done(function (msg) {

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -362,7 +362,9 @@ describe 'Order Details', type: :feature, js: true do
               fill_in 'item_quantity', with: 2
 
               click_icon :save
-              expect(page).not_to have_css('tr.stock-item-split')
+              alert_text = page.driver.browser.switch_to.alert.text
+              expect(alert_text).to eq('Desired shipment has not enough stock in desired stock location')
+              accept_alert { order.reload }
 
               expect(order.shipments.count).to eq(1)
               expect(order.shipments.first.inventory_units_for(product.master).sum(&:quantity)).to eq(2)
@@ -514,8 +516,9 @@ describe 'Order Details', type: :feature, js: true do
             fill_in 'item_quantity', with: 200
 
             click_icon :save
-            expect(page).not_to have_css('tr.stock-item-split')
-            order.reload
+            alert_text = page.driver.browser.switch_to.alert.text
+            expect(alert_text).to eq('Desired shipment has not enough stock in desired stock location')
+            accept_alert { order.reload }
 
             expect(order.shipments.count).to eq(2)
             expect(order.shipments.first.inventory_units_for(product.master).sum(&:quantity)).to eq(1)

--- a/backend/spec/features/admin/orders/shipments_spec.rb
+++ b/backend/spec/features/admin/orders/shipments_spec.rb
@@ -47,13 +47,16 @@ describe 'Shipments', type: :feature do
     it 'can move a variant to a new and to an existing shipment' do
       expect(order.shipments.count).to eq(1)
 
+      # Non existing shipment
       within_row(1) { click_icon :split }
       select2 'LA', css: '.stock-item-split', search: true, match: :first
-      click_icon :'save-split'
+      click_icon :save
+      wait_for_ajax
 
       expect(page).to have_css('#order-form-wrapper div', id: /^shipment_\d$/).exactly(2).times
       expect(page).to have_css("#shipment_#{order.shipments.first.id}")
 
+      # Existing shipment
       within_row(2) { click_icon :split }
       select2 "LA(#{order.reload.shipments.last.number})", css: '.stock-item-split', search: true, match: :first
       click_icon :save

--- a/backend/spec/features/admin/orders/shipments_spec.rb
+++ b/backend/spec/features/admin/orders/shipments_spec.rb
@@ -30,7 +30,7 @@ describe 'Shipments', type: :feature do
     it 'can ship a completed order' do
       click_on 'Ship'
 
-      expect(page).to have_content("shipped package")
+      expect(page).to have_content('shipped package')
       expect(order.reload.shipment_state).to eq('shipped')
     end
   end

--- a/core/app/models/spree/fulfilment_changer.rb
+++ b/core/app/models/spree/fulfilment_changer.rb
@@ -93,7 +93,7 @@ module Spree
 
     def get_desired_shipment_inventory_unit(state)
       desired_shipment.inventory_units.find_or_create_by(state: state) do |unit|
-        current_shipment_unit = current_shipment.inventory_units.first
+        current_shipment_unit = current_shipment_units.first
         unit.variant_id = current_shipment_unit.variant_id
         unit.order_id = current_shipment_unit.order_id
         unit.line_item_id = current_shipment_unit.line_item_id

--- a/core/app/models/spree/fulfilment_changer.rb
+++ b/core/app/models/spree/fulfilment_changer.rb
@@ -9,8 +9,6 @@ module Spree
     validate  :enough_stock_at_desired_location, if: :handle_stock_counts?
 
     def initialize(params = {})
-      # TODO: Check if stocks' count_on_hand is correct after split (admin/products/checked-shirt/stock)
-      # TODO: Is there a case when shipment has more than one on_hand inventory unit?
       @current_stock_location = params[:current_stock_location]
       @desired_stock_location = params[:desired_stock_location]
       @current_shipment       = params[:current_shipment]
@@ -57,7 +55,7 @@ module Spree
     end
 
     def current_shipment_units
-      current_shipment.inventory_units.where(variant_id: variant.id)
+      current_shipment.inventory_units.on_hand_or_backordered.where(variant_id: variant.id)
     end
 
     def update_desired_shipment_inventory_units

--- a/core/app/models/spree/fulfilment_changer.rb
+++ b/core/app/models/spree/fulfilment_changer.rb
@@ -62,7 +62,7 @@ module Spree
       on_hand_unit = get_desired_shipment_inventory_unit(:on_hand)
       on_hand_unit.update(quantity: on_hand_unit.quantity + new_on_hand_quantity)
 
-      new_backorder_quantity = quantity - new_on_hand_quantity
+      new_backorder_quantity = current_on_hand_quantity - new_on_hand_quantity
       if new_backorder_quantity > 0
         backordered_unit = get_desired_shipment_inventory_unit(:backordered)
         backordered_unit.update(quantity: backordered_unit.quantity + new_backorder_quantity)
@@ -70,9 +70,9 @@ module Spree
     end
 
     def update_current_shipment_inventory_units
-      reduced_quantity = quantity
+      reduced_quantity = current_on_hand_quantity
 
-      # Reduce quantities from all backordered units in case there is more than one.
+      # Reduce quantities from all backordered units first in case there is more than one.
       backorder_units = current_shipment_units.backordered
       reduced_quantity = reduce_units_quantities(reduced_quantity, backorder_units) if backorder_units.any?
 
@@ -115,7 +115,7 @@ module Spree
     end
 
     def new_on_hand_quantity
-      [available_quantity, quantity].min
+      [available_quantity, current_on_hand_quantity].min
     end
 
     def unstock_quantity

--- a/core/app/models/spree/fulfilment_changer.rb
+++ b/core/app/models/spree/fulfilment_changer.rb
@@ -72,11 +72,15 @@ module Spree
 
     def update_current_shipment_inventory_units
       on_hand_quantity = quantity
-      backordered_units = current_shipment_units.find_by(state: :backordered)
-
-      if backordered_units.present? && backordered_units.quantity > 0
-        backordered_units.update(quantity: 0)
-        on_hand_quantity -= backordered_units.quantity
+      backordered_unit = current_shipment_units.find_by(state: :backordered)
+      if backordered_unit.present?
+        if backordered_unit.quantity > on_hand_quantity
+          backordered_unit.decrease!(:quantity, on_hand_quantity)
+          on_hand_quantity = 0
+        else
+          on_hand_quantity -= backordered_unit.quantity
+          backordered_unit.update(quantity: 0)
+        end
       end
       current_shipment_units.find_by(state: :on_hand).decrement!(:quantity, on_hand_quantity) if on_hand_quantity > 0
     end

--- a/core/app/models/spree/fulfilment_changer.rb
+++ b/core/app/models/spree/fulfilment_changer.rb
@@ -55,7 +55,7 @@ module Spree
     end
 
     def current_shipment_units
-      current_shipment.inventory_units.on_hand_or_backordered.where(variant_id: variant.id)
+      @current_shipment_units ||= current_shipment.inventory_units.on_hand_or_backordered.where(variant_id: variant.id)
     end
 
     def update_desired_shipment_inventory_units

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -362,7 +362,7 @@ module Spree
         desired_shipment: shipment_to_transfer_to,
         variant: variant,
         quantity: quantity
-      ).run!
+      )
     end
 
     private

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -6,7 +6,7 @@ en:
           attributes:
             desired_shipment:
               can_not_transfer_within_same_shipment: can not be same as current shipment
-              not_enough_stock_at_desired_location: not enough stock in desired stock location
+              has_not_enough_stock_at_desired_location: has not enough stock in desired stock location
             current_shipment:
               has_already_been_shipped: has already been shipped
               can_not_have_backordered_inventory_units: has backordered inventory units

--- a/core/lib/spree/testing_support/factories/shipment_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipment_factory.rb
@@ -8,15 +8,13 @@ FactoryBot.define do
 
     after(:create) do |shipment, _evalulator|
       shipment.add_shipping_method(create(:shipping_method), true)
-
-      shipment.order.line_items.each do |line_item|
-        line_item.quantity.times do
-          shipment.inventory_units.create(
-            order_id: shipment.order_id,
-            variant_id: line_item.variant_id,
-            line_item_id: line_item.id
-          )
-        end
+      shipment.order.line_items.map do |line_item|
+        shipment.inventory_units.create(
+          order_id: shipment.order_id,
+          variant_id: line_item.variant_id,
+          line_item_id: line_item.id,
+          quantity: line_item.quantity
+        )
       end
     end
   end

--- a/core/spec/models/spree/fulfilment_changer_spec.rb
+++ b/core/spec/models/spree/fulfilment_changer_spec.rb
@@ -43,6 +43,7 @@ describe Spree::FulfilmentChanger do
     let(:quantity) { 1 }
 
     it 'adds the desired inventory units to the desired shipment' do
+      # TODO: Check inventory_unit quantity, not length.
       expect { subject }.to change { desired_shipment.inventory_units.length }.by(quantity)
     end
 

--- a/core/spec/models/spree/fulfilment_changer_spec.rb
+++ b/core/spec/models/spree/fulfilment_changer_spec.rb
@@ -147,7 +147,7 @@ describe Spree::FulfilmentChanger do
 
         context 'when the original shipment has on hand and backordered units' do
           before do
-            expect_any_instance_of(Spree::FulfilmentChanger).to receive(:handle_stock_counts?).at_least(:once).and_return(false)
+            expect_any_instance_of(described_class).to receive(:handle_stock_counts?).at_least(:once).and_return(false)
             backordered_unit = current_shipment.inventory_units.on_hand.first.dup
             backordered_unit.update(state: :backordered, quantity: 5)
           end

--- a/core/spec/models/spree/fulfilment_changer_spec.rb
+++ b/core/spec/models/spree/fulfilment_changer_spec.rb
@@ -298,6 +298,19 @@ describe Spree::FulfilmentChanger do
     end
   end
 
+  context 'when the current shipment has not enough inventory units' do
+    let(:current_shipment_inventory_unit_count) { 3 }
+    let(:quantity) { 5 }
+
+    it 'adds the desired inventory units to the desired shipment' do
+      expect { subject }.to change { desired_shipment.inventory_units.sum(:quantity) }.by(current_shipment_inventory_unit_count)
+    end
+
+    it 'removes the desired inventory units from the current shipment' do
+      expect { subject }.to change { current_shipment.inventory_units.sum(:quantity) }.by(-current_shipment_inventory_unit_count)
+    end
+  end
+
   context 'when the current shipment is emptied out by the transfer' do
     let(:current_shipment_inventory_unit_count) { 30 }
     let(:quantity) { 30 }

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -767,13 +767,13 @@ describe Spree::Shipment, type: :model do
     it 'creates new shipment for same order' do
       shipment = order.shipments.first
 
-      expect { shipment.transfer_to_location(variant, 1, stock_location) }.
+      expect { shipment.transfer_to_location(variant, 1, stock_location).run! }.
         to change { order.reload.shipments.size }.from(1).to(2)
     end
 
     it 'sets the given stock location for new shipment' do
       shipment = order.shipments.first
-      shipment.transfer_to_location(variant, 1, stock_location)
+      shipment.transfer_to_location(variant, 1, stock_location).run!
 
       new_shipment = order.reload.shipments.last
 


### PR DESCRIPTION
Fixes splitting order products into shipments.
The current mechanism was based on the changes from 2014, which assumed that an inventory unit was created for every single product. I.e: For 10 same products 10 inventory units with quantity 1 were created. Now it is one inventory unit with quantity 10.
That's why when trying to split products into another shipment, whole quantity was moved.
Added here: https://github.com/spark-solutions/spree/commit/974cad4c65596d4acaf405287f47e2c37a336d05#diff-96bc2df1fa18d13254585e406764bc91bdd6c261c7b4efe678b7fc374ecd3887R10
Changed to current here: https://github.com/spark-solutions/spree/commit/0beb977b31e02adb34646afbb216ae6525f68f05#diff-96bc2df1fa18d13254585e406764bc91bdd6c261c7b4efe678b7fc374ecd3887R9