### PR TITLE
Fix javascript related products url

### DIFF
--- a/frontend/app/assets/javascripts/spree/frontend.js
+++ b/frontend/app/assets/javascripts/spree/frontend.js
@@ -45,5 +45,5 @@ Spree.routes.ensure_cart = Spree.pathFor('ensure_cart')
 Spree.routes.api_v2_storefront_cart_apply_coupon_code = Spree.pathFor('api/v2/storefront/cart/apply_coupon_code')
 Spree.routes.api_v2_storefront_cart_remove_coupon_code = Spree.pathFor('api/v2/storefront/cart/remove_coupon_code')
 Spree.routes.product = function(id) { return Spree.pathFor('products/' + id) }
-Spree.routes.product_related = function(id) { return Spree.routes.product(id) + '/related' }
+Spree.routes.product_related = function(id) { return Spree.pathFor('products/' + id + '/related') }
 Spree.routes.product_carousel = function (taxonId) { return Spree.pathFor('product_carousel/' + taxonId) }

--- a/frontend/app/assets/javascripts/spree/frontend/views/spree/product/related.js
+++ b/frontend/app/assets/javascripts/spree/frontend/views/spree/product/related.js
@@ -1,6 +1,6 @@
 //= require spree/frontend/viewport
 
-Spree.fetchRelatedProductcs = function (id, htmlContainer) {
+Spree.fetchRelatedProducts = function (id, htmlContainer) {
   return $.ajax({
     url: Spree.routes.product_related(id)
   }).done(function (data) {
@@ -21,7 +21,7 @@ document.addEventListener('turbolinks:load', function () {
     if (!relatedProductsFetched && relatedProductsContainer.length && relatedProductsEnabled && relatedProductsEnabled === 'true' && productId !== '') {
       $(window).on('resize scroll', function () {
         if (!relatedProductsFetched && relatedProductsContainer.isInViewport()) {
-          Spree.fetchRelatedProductcs(productId, relatedProductsContainer)
+          Spree.fetchRelatedProducts(productId, relatedProductsContainer)
           relatedProductsFetched = true
         }
       })


### PR DESCRIPTION
When a query parameter is used (i.e. `?locale=en`), the related products URL is generated as `http://www.example.com/products/basic-t-shirt?locale=en/related`.
This change is fixing that, so this URL is generated as `http://www.example.com/products/basic-t-shirt/related?locale=en`