### PR TITLE
[NUT-201] Refactor used_by? method for one_use_per_user rule

### DIFF
--- a/api/spec/controllers/spree/api/v1/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/orders_controller_spec.rb
@@ -765,7 +765,7 @@ module Spree
             create(:order_with_line_items, coupon_code: coupon_code, user: current_api_user).tap do |order|
               Spree::PromotionHandler::Coupon.new(order).apply
               order.update_column(:completed_at, Time.current)
-              order.update_column(:state, 'completed')
+              order.update_column(:state, 'complete')
             end
           end
 

--- a/api/spec/controllers/spree/api/v1/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/orders_controller_spec.rb
@@ -708,6 +708,82 @@ module Spree
       end
     end
 
+    describe '#apply_coupon_code' do
+      subject(:apply_coupon_code) do
+        api_put :apply_coupon_code, id: order.number,
+                                    order_token: order.token,
+                                    coupon_code: coupon_code
+      end
+
+      let(:order) { create(:order_with_line_items, user: current_api_user) }
+      let(:coupon_code) { 'coupon_code' }
+
+      context 'when coupon is not found' do
+        it 'returns coupon not found response' do
+          apply_coupon_code
+
+          expect(response.status).to eq 422
+          expect(json_response[:successful]).to eq false
+          expect(json_response[:status_code]).to eq 'coupon_code_not_found'
+          expect(json_response[:error]).to eq "The coupon code you entered doesn't exist. Please try again."
+          expect(json_response[:success]).to be_nil
+        end
+
+        it 'does not apply any promotion to order' do
+          apply_coupon_code
+
+          expect(order.promotions).to be_empty
+        end
+      end
+
+      context 'when coupon is found' do
+        let!(:promotion) { create(:promotion_with_one_use_per_user_rule, code: coupon_code) }
+
+        context 'when coupon is applied' do
+          it 'returns coupon applied response' do
+            apply_coupon_code
+
+            expect(response.status).to eq 200
+            expect(json_response[:successful]).to eq true
+            expect(json_response[:status_code]).to eq 'coupon_code_applied'
+            expect(json_response[:success]).to eq 'The coupon code was successfully applied to your order.'
+            expect(json_response[:error]).to be_nil
+          end
+
+          it 'applies specified promotion to order' do
+            expect(order.promotions).to be_empty
+
+            apply_coupon_code
+
+            expect(order.promotions.count).to eq 1
+            expect(order.promotions.first.code).to eq coupon_code
+          end
+        end
+
+        context 'when coupon can not be applied' do
+          let!(:order_with_line_item_promotion) do
+            create(:order_with_line_items, coupon_code: coupon_code, user: current_api_user).tap do |order|
+              Spree::PromotionHandler::Coupon.new(order).apply
+              order.update_column(:completed_at, Time.current)
+              order.update_column(:state, 'completed')
+            end
+          end
+
+          context 'when coupon was used by user already' do
+            it 'returns coupon was used already' do
+              apply_coupon_code
+
+              expect(response.status).to eq 422
+              expect(json_response[:successful]).to eq false
+              expect(json_response[:status_code]).to be_nil
+              expect(json_response[:error]).to eq 'This coupon code can only be used once per user.'
+              expect(json_response[:success]).to be_nil
+            end
+          end
+        end
+      end
+    end
+
     context 'PUT remove_coupon_code' do
       let(:order) { create(:order_with_line_items) }
 

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -194,7 +194,7 @@ module Spree
     end
 
     def used_by?(user, excluded_orders = [])
-      user.orders.complete.joins(:promotions).where.not(spree_orders: { id: excluded_orders.map(&:id) }).where(spree_promotions: { id: id }).any?
+      user.orders.complete.joins(:promotions).where.not(spree_orders: { id: excluded_orders.pluck(:id) }).where(spree_promotions: { id: id }).any?
     end
 
     private

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -194,21 +194,7 @@ module Spree
     end
 
     def used_by?(user, excluded_orders = [])
-      [
-        :adjustments,
-        :line_item_adjustments,
-        :shipment_adjustments
-      ].any? do |adjustment_type|
-        user.orders.complete.joins(adjustment_type).where(
-          spree_adjustments: {
-            source_type: 'Spree::PromotionAction',
-            source_id: actions.map(&:id),
-            eligible: true
-          }
-        ).where.not(
-          id: excluded_orders.map(&:id)
-        ).any?
-      end
+      user.orders.complete.joins(:promotions).where.not(spree_orders: { id: excluded_orders.map(&:id) }).where(spree_promotions: { id: id }).any?
     end
 
     private

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -194,7 +194,10 @@ module Spree
     end
 
     def used_by?(user, excluded_orders = [])
-      user.orders.complete.joins(:promotions).where.not(spree_orders: { id: excluded_orders.pluck(:id) }).where(spree_promotions: { id: id }).any?
+      user.orders.complete.joins(:promotions).joins(:all_adjustments).
+        where.not(spree_orders: { id: excluded_orders.map(&:id) }).
+        where(spree_promotions: { id: id }).
+        where(spree_adjustments: { source_type: 'Spree::PromotionAction', eligible: true }).any?
     end
 
     private

--- a/core/lib/spree/testing_support/factories/promotion_factory.rb
+++ b/core/lib/spree/testing_support/factories/promotion_factory.rb
@@ -13,7 +13,17 @@ FactoryBot.define do
         Spree::Promotion::Actions::CreateItemAdjustments.create!(calculator: calculator, promotion: promotion)
       end
     end
+
+    trait :with_one_use_per_user_rule do
+      after(:create) do |promotion|
+        rule = Spree::Promotion::Rules::OneUsePerUser.create!
+        promotion.rules << rule
+        promotion.save!
+      end
+    end
+
     factory :promotion_with_item_adjustment, traits: [:with_line_item_adjustment]
+    factory :promotion_with_one_use_per_user_rule, traits: [:with_line_item_adjustment, :with_one_use_per_user_rule]
 
     trait :with_order_adjustment do
       transient do

--- a/core/lib/spree/testing_support/factories/promotion_factory.rb
+++ b/core/lib/spree/testing_support/factories/promotion_factory.rb
@@ -18,7 +18,6 @@ FactoryBot.define do
       after(:create) do |promotion|
         rule = Spree::Promotion::Rules::OneUsePerUser.create!
         promotion.rules << rule
-        promotion.save!
       end
     end
 

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -672,6 +672,17 @@ describe Spree::Promotion, type: :model do
       context 'when the order is complete' do
         it { is_expected.to be true }
 
+        context 'when the promotion is not eligible' do
+          let(:adjustment) { order.adjustments.first }
+
+          before do
+            adjustment.eligible = false
+            adjustment.save!
+          end
+
+          it { is_expected.to be false }
+        end
+
         context 'when the only matching order is the excluded order' do
           let(:excluded_order) { order }
 

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -672,17 +672,6 @@ describe Spree::Promotion, type: :model do
       context 'when the order is complete' do
         it { is_expected.to be true }
 
-        context 'when the promotion was not eligible' do
-          let(:adjustment) { order.adjustments.first }
-
-          before do
-            adjustment.eligible = false
-            adjustment.save!
-          end
-
-          it { is_expected.to be false }
-        end
-
         context 'when the only matching order is the excluded order' do
           let(:excluded_order) { order }
 


### PR DESCRIPTION
This branch is created because of https://spark-solutions.atlassian.net/browse/NUT-201 task.
User can use one_use_per_user promotion many times.
This was tested, but in production user somehow can use the promotion many times.

### Actual Behavior
So far condition was checked by looking for same PromotionAction through adjustments:
https://github.com/spree/spree/blob/849f985e9b9a0c79052014a395811b1cdec247c7/core/app/models/spree/promotion.rb#L196
Although in tests PromotionActions are associated with adjustments as source, in production it occurs that it does not always happen:
`irb(main):004:0> user.orders.complete.first.all_adjustments.where(source_type: "Spree::PromotionAction").pluck(:source_id)
=> [nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil]
irb(main):005:0> user.orders.complete.second.all_adjustments.where(source_type: "Spree::PromotionAction").pluck(:source_id)
=> [nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil]
irb(main):006:0> user.orders.complete.third.all_adjustments.where(source_type: "Spree::PromotionAction").pluck(:source_id)
=> []`
However, order is always associated:
`irb(main):009:0> user.orders.complete.first.promotions.pluck(:id)
=> [33, 33, 33, 33, 33, 33, 33]
irb(main):010:0> user.orders.complete.second.promotions.pluck(:id)
=> [33]
irb(main):011:0> user.orders.complete.third.promotions.pluck(:id)
=> [33, 33, 33, 33]`

### Expected behavior
User can use promo code only once

### Possible fix
Use promotion to check if it was already used (simpler and based on production data it works).