### PR TITLE
Make option types in sample products and their variants consistent

### DIFF
--- a/sample/db/samples/products.rb
+++ b/sample/db/samples/products.rb
@@ -11,6 +11,7 @@ clothing_tax_category = Spree::TaxCategory.find_by!(name: 'Clothing')
 Spree::Config[:currency] = 'USD'
 
 color = Spree::OptionType.find_by!(name: 'color')
+length = Spree::OptionType.find_by!(name: 'length')
 size = Spree::OptionType.find_by!(name: 'size')
 
 PRODUCTS = CSV.read(File.join(__dir__, 'variants.csv')).map do |(parent_name, taxon_name, product_name, _color_name)|
@@ -24,7 +25,11 @@ PRODUCTS.each do |(parent_name, taxon_name, product_name)|
     product.price = rand(10...100) + 0.99
     product.description = FFaker::Lorem.paragraph
     product.available_on = Time.zone.now
-    product.option_types = [color, size]
+    if parent_name == 'Women' and %w[Dresses Skirts].include?(taxon_name)
+      product.option_types = [color, length, size]
+    else
+      product.option_types = [color, size]
+    end
     product.shipping_category = default_shipping_category
     product.tax_category = clothing_tax_category
     product.sku = [taxon_name.delete(' '), product_name.delete(' '), product.price].join('_')


### PR DESCRIPTION
Right now in sample data some variants have three option values (size, length, color) and some two (size, color). On the other hand, all sample products have only two option types. This discrepancy causes some unexpected behavior in code that looks up variant's option types based on its option values among its product's option types, like [Spree2VS](https://github.com/spark-solutions/spree2vuestorefront) connector when it performs data import to elasticsearch.

With this change the process of assigning option types to a product exactly follows the one used in variants case from `sample/db/samples/variants.rb`