### PR TITLE
Fix #10569 : Set `user_id` to new address in `PATCH /addresses/:id`

### DIFF
--- a/frontend/app/controllers/spree/addresses_controller.rb
+++ b/frontend/app/controllers/spree/addresses_controller.rb
@@ -37,6 +37,7 @@ module Spree
       else
         new_address = @address.clone
         new_address.attributes = address_params
+        new_address.user_id = @address.user_id
         @address.update_attribute(:deleted_at, Time.current)
         if new_address.save
           flash[:notice] = Spree.t(:successfully_updated, scope: :address_book)


### PR DESCRIPTION
Because Spree::Address#clone does not copy `user_id` by default now.

Fixes https://github.com/spree/spree/issues/10569