### PR TITLE
Fix security issue in order status endpoint

### DIFF
--- a/api/app/controllers/spree/api/v2/storefront/order_status_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/order_status_controller.rb
@@ -29,7 +29,7 @@ module Spree
           end
 
           def ensure_order_token
-            raise ActiveRecord::RecordNotFound unless order_token
+            raise ActiveRecord::RecordNotFound unless order_token.present?
           end
         end
       end

--- a/api/spec/requests/spree/api/v2/storefront/order_status_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/order_status_spec.rb
@@ -13,6 +13,14 @@ describe 'Storefront API v2 OrderStatus spec', type: :request do
         it_behaves_like 'returns 404 HTTP status'
       end
 
+      context 'as a guest user with blank token' do
+        let(:headers_order_token) { { 'X-Spree-Order-Token' => '' } }
+
+        before { get "/api/v2/storefront/order_status/#{order.number}", headers: headers_order_token }
+
+        it_behaves_like 'returns 404 HTTP status'
+      end
+
       context 'as a guest user with invalid token' do
         let(:headers_order_token) { { 'X-Spree-Order-Token' => 'WRONG' } }
 


### PR DESCRIPTION
## Issue
`ensure_order_token` in `OrderStatusController` ([permalink](https://github.com/spree/spree/blob/6495f2d1b9a20dc35016c1e8267400792327e9af/api/app/controllers/spree/api/v2/storefront/order_status_controller.rb#L31-L33)) checks if `order_token` is truthy instead of checking if it's `present?`.

## Outcome
Passing an empty string `''` as the token allows to query any complete order without knowing it's token.

## Description
Searching for complete orders forms a pipeline where the last step should filter out every order whose token doesn't match the token provided by the client: https://github.com/spree/spree/blob/4cc2c2967352d3fe7652bd873e492c074ffcc3da/core/app/finders/spree/orders/find_complete.rb#L12-L18

`by_token` first checks whether token is present:

https://github.com/spree/spree/blob/4cc2c2967352d3fe7652bd873e492c074ffcc3da/core/app/finders/spree/orders/find_complete.rb#L34-L36

https://github.com/spree/spree/blob/4cc2c2967352d3fe7652bd873e492c074ffcc3da/core/app/finders/spree/orders/find_complete.rb#L50-L54

This completely skips filtering by token when the token is blank. In particular, it skips it when the token is an empty string `''`.  Since empty string evaluates to `true`, `ensure_order_token` would accept it as valid input. This makes it possible to query for any complete order without knowing it's token.

## Steps to reproduce

1. Complete an order `<order_number>`.
2. Set the `X-Spree-Order-Token` header to an empty string `''`.
3. Query `/api/v2/storefront/order_status/<order_number>`.

You should now see the order's details.