### PR TITLE
Spree::UserMethods - added missing table name prefixes 

### DIFF
--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -31,7 +31,7 @@ module Spree
       self.whitelisted_ransackable_attributes = %w[id email]
 
       def self.with_email(query)
-        where('email LIKE ?', "%#{query}%")
+        where("#{table_name}.email LIKE ?", "%#{query}%")
       end
 
       def self.with_address(query, address = :ship_address)
@@ -42,7 +42,7 @@ module Spree
 
       def self.with_email_or_address(email, address)
         left_outer_joins(:addresses).
-          where("#{Spree::Address.table_name}.firstname LIKE ? or #{Spree::Address.table_name}.lastname LIKE ? or email LIKE ?",
+          where("#{Spree::Address.table_name}.firstname LIKE ? or #{Spree::Address.table_name}.lastname LIKE ? or #{table_name}.email LIKE ?",
                 "%#{address}%", "%#{address}%", "%#{email}%")
       end
     end


### PR DESCRIPTION
As in title, added some missing table prefixes to SQL queries composed within `Spree::UserMethods` scopes. This prevents ambiguity issues when 2 or more tables with the same column name requested are joined together.