### PR TITLE
Display available countries on checkout address step with respect to the Spree::Store#default_zone

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -3,11 +3,7 @@ module Spree
     def available_countries
       checkout_zone = current_store.checkout_zone || Spree::Zone.default_checkout_zone
 
-      countries = if checkout_zone && checkout_zone.kind == 'country'
-                    checkout_zone.country_list
-                  else
-                    Spree::Country.all
-                  end
+      countries = checkout_zone ? checkout_zone.country_list : Spree::Country.all
 
       countries.collect do |country|
         country.name = Spree.t(country.iso, scope: 'country_names', default: country.name)

--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -51,15 +51,17 @@ describe Spree::BaseHelper, type: :helper do
       end
 
       context 'checkout zone is of type state' do
+        let(:state) { create(:state, country: country) }
+
         before do
           state_zone = create(:zone, name: 'StateZone')
-          state = create(:state, country: country)
           state_zone.members.create(zoneable: state)
+
           Spree::Config[:checkout_zone] = state_zone.name
         end
 
-        it 'return complete list of countries' do
-          expect(available_countries.count).to eq(Spree::Country.count)
+        it 'returns list of countries associated with states' do
+          expect(available_countries).to contain_exactly state.country
         end
       end
     end


### PR DESCRIPTION
`Spree::BaseHelper#available_countries` - added support for checkout zones of spree_stores assigned with zoneables of kind `Spree::State`