### PR TITLE
Fixed checkout countries and states suggestions based on current_stor…

### DIFF
--- a/api/app/controllers/spree/api/v2/storefront/countries_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/countries_controller.rb
@@ -24,8 +24,15 @@ module Spree
               resource,
               include: resource_includes,
               fields: sparse_fields,
-              params: { include_states: true }
+              params: resource_serializer_params
             ).serializable_hash
+          end
+
+          def resource_serializer_params
+            default_params = { include_states: true }
+            default_params.merge!(current_store: current_store) if params[:include_checkout_zone_applicable_states]
+
+            default_params
           end
 
           def collection

--- a/api/app/controllers/spree/api/v2/storefront/countries_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/countries_controller.rb
@@ -29,10 +29,10 @@ module Spree
           end
 
           def resource_serializer_params
-            default_params = { include_states: true }
-            default_params.merge!(current_store: current_store) if params[:include_checkout_zone_applicable_states]
-
-            default_params
+            {
+              include_states: true,
+              current_store: current_store
+            }
           end
 
           def collection

--- a/api/app/serializers/spree/v2/storefront/country_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/country_serializer.rb
@@ -13,10 +13,10 @@ module Spree
 
         has_many :states, if: proc { |_record, params| params && params[:include_states] }
 
-        attribute :checkout_zone_applicable_states, if: proc { |_record, params| params && params[:current_store].present? } do |object, params|
-          current_store = params[:current_store]
-
-          current_store.states_available_for_checkout(object)
+        has_many :checkout_zone_applicable_states,
+                 serializer: ::Spree::V2::Storefront::StateSerializer,
+                 if: proc { |_record, params| params && params[:current_store].present? } do |object, params|
+          params[:current_store].states_available_for_checkout(object)
         end
       end
     end

--- a/api/app/serializers/spree/v2/storefront/country_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/country_serializer.rb
@@ -13,7 +13,7 @@ module Spree
 
         has_many :states, if: proc { |_record, params| params && params[:include_states] }
 
-        attribute :checkout_zone_applicable_states, if: proc { |_record, params| params && params[:current_store] } do |object, params|
+        attribute :checkout_zone_applicable_states, if: proc { |_record, params| params && params[:current_store].present? } do |object, params|
           current_store = params[:current_store]
 
           current_store.states_available_for_checkout(object)

--- a/api/app/serializers/spree/v2/storefront/country_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/country_serializer.rb
@@ -12,6 +12,12 @@ module Spree
         end
 
         has_many :states, if: proc { |_record, params| params && params[:include_states] }
+
+        attribute :checkout_zone_applicable_states, if: proc { |_record, params| params && params[:current_store] } do |object, params|
+          current_store = params[:current_store]
+
+          current_store.states_available_for_checkout(object)
+        end
       end
     end
   end

--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -1,9 +1,7 @@
 module Spree
   module BaseHelper
     def available_countries
-      checkout_zone = current_store.checkout_zone || Spree::Zone.default_checkout_zone
-
-      countries = checkout_zone ? checkout_zone.country_list : Spree::Country.all
+      countries = current_store.countries_available_for_checkout
 
       countries.collect do |country|
         country.name = Spree.t(country.iso, scope: 'country_names', default: country.name)

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -51,6 +51,18 @@ module Spree
       "#{name} (#{code})"
     end
 
+    def countries_available_for_checkout
+      checkout_zone_or_default.try(:country_list) || Spree::Country.all
+    end
+
+    def states_available_for_checkout(country)
+      checkout_zone_or_default.try(:state_list_for, country) || country.states
+    end
+
+    def checkout_zone_or_default
+      checkout_zone || Spree::Zone.default_checkout_zone
+    end
+
     private
 
     def ensure_default_exists_and_is_unique

--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -101,8 +101,6 @@ module Spree
           zone_member.zoneable_id == address.country_id
         when 'Spree::State'
           zone_member.zoneable_id == address.state_id
-        else
-          false
         end
       end
     end
@@ -114,8 +112,6 @@ module Spree
                        zoneables
                      when 'state' then
                        zoneables.collect(&:country)
-                     else
-                       []
                      end.flatten.compact.uniq
     end
 
@@ -169,6 +165,19 @@ module Spree
         return false if (target.states.pluck(:country_id) - countries.pluck(:id)).present?
       end
       true
+    end
+
+    def state_list
+      case kind
+      when 'country'
+        zoneables.map(&:states)
+      when 'state'
+        zoneables
+      end.flatten.compact.uniq
+    end
+
+    def state_list_for(country)
+      state_list.select { |state| state.country == country }
     end
 
     private

--- a/core/db/migrate/20201127084048_add_default_country_kind_to_spree_zones.rb
+++ b/core/db/migrate/20201127084048_add_default_country_kind_to_spree_zones.rb
@@ -1,0 +1,5 @@
+class AddDefaultCountryKindToSpreeZones < ActiveRecord::Migration[6.0]
+  def change
+    change_column_default(:spree_zones, :kind, :state)
+  end
+end

--- a/core/lib/spree/testing_support/factories/zone_factory.rb
+++ b/core/lib/spree/testing_support/factories/zone_factory.rb
@@ -1,24 +1,27 @@
 FactoryBot.define do
-  factory :global_zone, class: Spree::Zone do
-    sequence(:name) { |n| "GlobalZone_#{n}" }
-    description { generate(:random_string) }
-    zone_members do |proxy|
-      zone = proxy.instance_eval { @instance }
-      Spree::Country.all.map do |c|
-        Spree::ZoneMember.create(zoneable: c, zone: zone)
-      end
-    end
-  end
-
   factory :zone, class: Spree::Zone do
     name        { generate(:random_string) }
     description { generate(:random_string) }
 
     factory :zone_with_country do
+      kind { :country }
+
       zone_members do |proxy|
         zone = proxy.instance_eval { @instance }
-        country = create(:country)
-        [Spree::ZoneMember.create(zoneable: country, zone: zone)]
+
+        [Spree::ZoneMember.create(zoneable: create(:country), zone: zone)]
+      end
+
+      factory :global_zone, class: Spree::Zone do
+        sequence(:name) { |n| "GlobalZone_#{n}" }
+
+        zone_members do |proxy|
+          zone = proxy.instance_eval { @instance }
+
+          Spree::Country.all.map do |country|
+            Spree::ZoneMember.where(zoneable: country, zone: zone).first_or_create
+          end
+        end
       end
     end
   end

--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -15,7 +15,7 @@ describe Spree::BaseHelper, type: :helper do
     context 'with checkout zone assigned to the store' do
       before do
         Spree::Config[:checkout_zone] = nil
-        @zone = create(:zone, name: 'No Limits')
+        @zone = create(:zone, name: 'No Limits', kind: 'country')
         @zone.members.create(zoneable: country)
         current_store.update(checkout_zone_id: @zone.id)
       end
@@ -40,7 +40,7 @@ describe Spree::BaseHelper, type: :helper do
     context 'with a checkout zone defined' do
       context 'checkout zone is of type country' do
         before do
-          @country_zone = create(:zone, name: 'CountryZone')
+          @country_zone = create(:zone, name: 'CountryZone', kind: 'country')
           @country_zone.members.create(zoneable: country)
           Spree::Config[:checkout_zone] = @country_zone.name
         end

--- a/core/spec/models/spree/tax_rate_spec.rb
+++ b/core/spec/models/spree/tax_rate_spec.rb
@@ -19,7 +19,7 @@ describe Spree::TaxRate, type: :model do
 
       context 'when there is no default tax zone' do
         before do
-          @zone = create(:zone, name: 'Country Zone', default_tax: false, zone_members: [])
+          @zone = create(:zone, name: 'Country Zone', kind: 'country', default_tax: false, zone_members: [])
           @zone.zone_members.create(zoneable: country)
         end
 
@@ -61,7 +61,7 @@ describe Spree::TaxRate, type: :model do
 
         context 'when the tax_zone is contained within a rate zone' do
           before do
-            sub_zone = create(:zone, name: 'State Zone', zone_members: [])
+            sub_zone = create(:zone, name: 'State Zone', kind: 'state', zone_members: [])
             sub_zone.zone_members.create(zoneable: create(:state, country: country))
             allow(order).to receive_messages tax_zone: sub_zone
             @rate = Spree::TaxRate.create(
@@ -82,7 +82,7 @@ describe Spree::TaxRate, type: :model do
         subject { Spree::TaxRate.match(order.tax_zone) }
 
         before do
-          @zone = create(:zone, name: 'Country Zone', default_tax: true, zone_members: [])
+          @zone = create(:zone, name: 'Country Zone', kind: 'country', default_tax: true, zone_members: [])
           @zone.zone_members.create(zoneable: country)
         end
 
@@ -113,7 +113,7 @@ describe Spree::TaxRate, type: :model do
 
         context 'when the order has a different tax zone' do
           before do
-            allow(order).to receive_messages tax_zone: create(:zone, name: 'Other Zone')
+            allow(order).to receive_messages tax_zone: create(:zone, kind: 'country', name: 'Other Zone')
           end
 
           context 'when the tax is a VAT' do
@@ -202,9 +202,9 @@ describe Spree::TaxRate, type: :model do
       let(:germany) { create :country, name: 'Germany' }
       let(:india) { create :country, name: 'India' }
       let(:france) { create :country, name: 'France' }
-      let(:france_zone) { create :zone_with_country, name: 'France Zone' }
-      let(:germany_zone) { create :zone_with_country, name: 'Germany Zone', default_tax: true }
-      let(:india_zone) { create :zone_with_country, name: 'India' }
+      let(:france_zone) { create :zone_with_country, kind: 'country', name: 'France Zone' }
+      let(:germany_zone) { create :zone_with_country, kind: 'country', name: 'Germany Zone', default_tax: true }
+      let(:india_zone) { create :zone_with_country, kind: 'country', name: 'India' }
       let(:moss_category) { Spree::TaxCategory.create(name: 'Digital Goods') }
       let(:normal_category) { Spree::TaxCategory.create(name: 'Analogue Goods') }
       let(:eu_zone) { create(:zone, name: 'EU') }
@@ -379,7 +379,7 @@ describe Spree::TaxRate, type: :model do
   describe '#adjust' do
     before do
       @country = create(:country)
-      @zone = create(:zone, name: 'Country Zone', default_tax: true, zone_members: [])
+      @zone = create(:zone, name: 'Country Zone', kind: 'country', default_tax: true, zone_members: [])
       @zone.zone_members.create(zoneable: @country)
       @category    = Spree::TaxCategory.create name: 'Taxable Foo'
       @category2   = Spree::TaxCategory.create(name: 'Non Taxable')

--- a/core/spec/models/spree/zone_spec.rb
+++ b/core/spec/models/spree/zone_spec.rb
@@ -54,7 +54,7 @@ describe Spree::Zone, type: :model do
 
     context 'when there are two qualified zones with same member type' do
       let(:address) { create(:address, country: country, state: state) }
-      let(:second_zone) { create(:zone, name: 'SecondZone') }
+      let(:second_zone) { create(:zone, name: 'SecondZone', kind: 'country') }
 
       before { second_zone.members.create(zoneable: country) }
 
@@ -172,165 +172,172 @@ describe Spree::Zone, type: :model do
     let(:state2) { create(:state) }
     let(:state3) { create(:state) }
 
-    before do
-      @source = create(:zone, name: 'source', zone_members: [])
-      @target = create(:zone, name: 'target', zone_members: [])
-    end
+    let(:source) { create(:zone, name: 'source', kind: 'country', zone_members: []) }
+    let(:target) { create(:zone, name: 'target', kind: 'country', zone_members: []) }
 
     context 'when the target has no members' do
-      before { @source.members.create(zoneable: country1) }
+      before { source.members.create(zoneable: country1) }
 
       it 'is false' do
-        expect(@source.contains?(@target)).to be false
+        expect(source.contains?(target)).to be false
       end
     end
 
     context 'when the source has no members' do
-      before { @target.members.create(zoneable: country1) }
+      before { target.members.create(zoneable: country1) }
 
       it 'is false' do
-        expect(@source.contains?(@target)).to be false
+        expect(source.contains?(target)).to be false
       end
     end
 
     context 'when both zones are the same zone' do
       before do
-        @source.members.create(zoneable: country1)
-        @target = @source
+        source.members.create(zoneable: country1)
+        target.members.create(zoneable: country1)
       end
 
       it 'is true' do
-        expect(@source.contains?(@target)).to be true
+        expect(source.contains?(target)).to be true
       end
     end
 
     context 'when checking countries against countries' do
       before do
-        @source.members.create(zoneable: country1)
-        @source.members.create(zoneable: country2)
+        source.members.create(zoneable: country1)
+        source.members.create(zoneable: country2)
       end
 
       context 'when all members are included in the zone we check against' do
         before do
-          @target.members.create(zoneable: country1)
-          @target.members.create(zoneable: country2)
+          target.members.create(zoneable: country1)
+          target.members.create(zoneable: country2)
         end
 
         it 'is true' do
-          expect(@source.contains?(@target)).to be true
+          expect(source.contains?(target)).to be true
         end
       end
 
       context 'when some members are included in the zone we check against' do
         before do
-          @target.members.create(zoneable: country1)
-          @target.members.create(zoneable: country2)
-          @target.members.create(zoneable: create(:country))
+          target.members.create(zoneable: country1)
+          target.members.create(zoneable: country2)
+          target.members.create(zoneable: create(:country))
         end
 
         it 'is false' do
-          expect(@source.contains?(@target)).to be false
+          expect(source.contains?(target)).to be false
         end
       end
 
       context 'when none of the members are included in the zone we check against' do
         before do
-          @target.members.create(zoneable: create(:country))
-          @target.members.create(zoneable: create(:country))
+          target.members.create(zoneable: create(:country))
+          target.members.create(zoneable: create(:country))
         end
 
         it 'is false' do
-          expect(@source.contains?(@target)).to be false
+          expect(source.contains?(target)).to be false
         end
       end
     end
 
     context 'when checking states against states' do
+      let(:source) { create(:zone, name: 'source', kind: 'state', zone_members: []) }
+      let(:target) { create(:zone, name: 'target', kind: 'state', zone_members: []) }
+
       before do
-        @source.members.create(zoneable: state1)
-        @source.members.create(zoneable: state2)
+        source.members.create(zoneable: state1)
+        source.members.create(zoneable: state2)
       end
 
       context 'when all members are included in the zone we check against' do
         before do
-          @target.members.create(zoneable: state1)
-          @target.members.create(zoneable: state2)
+          target.members.create(zoneable: state1)
+          target.members.create(zoneable: state2)
         end
 
         it 'is true' do
-          expect(@source.contains?(@target)).to be true
+          expect(source.contains?(target)).to be true
         end
       end
 
       context 'when some members are included in the zone we check against' do
         before do
-          @target.members.create(zoneable: state1)
-          @target.members.create(zoneable: state2)
-          @target.members.create(zoneable: create(:state))
+          target.members.create(zoneable: state1)
+          target.members.create(zoneable: state2)
+          target.members.create(zoneable: create(:state))
         end
 
         it 'is false' do
-          expect(@source.contains?(@target)).to be false
+          expect(source.contains?(target)).to be false
         end
       end
 
       context 'when none of the members are included in the zone we check against' do
         before do
-          @target.members.create(zoneable: create(:state))
-          @target.members.create(zoneable: create(:state))
+          target.members.create(zoneable: create(:state))
+          target.members.create(zoneable: create(:state))
         end
 
         it 'is false' do
-          expect(@source.contains?(@target)).to be false
+          expect(source.contains?(target)).to be false
         end
       end
     end
 
     context 'when checking country against state' do
+      let(:source) { create(:zone, name: 'source', kind: 'state', zone_members: []) }
+      let(:target) { create(:zone, name: 'target', kind: 'country', zone_members: []) }
+
       before do
-        @source.members.create(zoneable: create(:state))
-        @target.members.create(zoneable: country1)
+        source.members.create(zoneable: create(:state))
+        target.members.create(zoneable: country1)
       end
 
       it 'is false' do
-        expect(@source.contains?(@target)).to be false
+        expect(source.contains?(target)).to be false
       end
     end
 
     context 'when checking state against country' do
-      before { @source.members.create(zoneable: country1) }
+      let(:source) { create(:zone, name: 'source', kind: 'country', zone_members: []) }
+      let(:target) { create(:zone, name: 'target', kind: 'state', zone_members: []) }
+
+      before { source.members.create(zoneable: country1) }
 
       context 'when all states contained in one of the countries we check against' do
         before do
           state1 = create(:state, country: country1)
-          @target.members.create(zoneable: state1)
+          target.members.create(zoneable: state1)
         end
 
         it 'is true' do
-          expect(@source.contains?(@target)).to be true
+          expect(source.contains?(target)).to be true
         end
       end
 
       context 'when some states contained in one of the countries we check against' do
         before do
           state1 = create(:state, country: country1)
-          @target.members.create(zoneable: state1)
-          @target.members.create(zoneable: create(:state, country: country2))
+          target.members.create(zoneable: state1)
+          target.members.create(zoneable: create(:state, country: country2))
         end
 
         it 'is false' do
-          expect(@source.contains?(@target)).to be false
+          expect(source.contains?(target)).to be false
         end
       end
 
       context 'when none of the states contained in any of the countries we check against' do
         before do
-          @target.members.create(zoneable: create(:state, country: country2))
-          @target.members.create(zoneable: create(:state, country: country2))
+          target.members.create(zoneable: create(:state, country: country2))
+          target.members.create(zoneable: create(:state, country: country2))
         end
 
         it 'is false' do
-          expect(@source.contains?(@target)).to be false
+          expect(source.contains?(target)).to be false
         end
       end
     end
@@ -346,14 +353,17 @@ describe Spree::Zone, type: :model do
     end
 
     context 'when a zone member country is added to an existing zone consisting of state members' do
-      it 'removes existing state members' do
-        zone = create(:zone, name: 'foo', zone_members: [])
-        state = create(:state)
+      it 'removes existing country members' do
+        zone    = create(:zone, name: 'foo', kind: 'state', zone_members: [])
+        state   = create(:state)
         country = create(:country)
-        zone.members.create(zoneable: state)
-        country_member = zone.members.create(zoneable: country)
+
+        state_member    = zone.members.create(zoneable: state)
+        _country_member = zone.members.create(zoneable: country)
+
         zone.save
-        expect(zone.reload.members).to eq([country_member])
+
+        expect(zone.reload.members).to eq([state_member])
       end
     end
   end
@@ -365,13 +375,14 @@ describe Spree::Zone, type: :model do
     end
 
     context 'when the zone consists of country zone members' do
+      let(:zone) { create(:zone, name: 'country', kind: 'country', zone_members: []) }
+
       before do
-        @zone = create(:zone, name: 'country', zone_members: [])
-        @zone.members.create(zoneable: create(:country))
+        zone.members.create(zoneable: create(:country))
       end
 
       it 'returns the kind of zone member' do
-        expect(@zone.kind).to eq('country')
+        expect(zone.kind).to eq('country')
       end
     end
   end
@@ -386,24 +397,26 @@ describe Spree::Zone, type: :model do
 
     context 'finding potential matches for a country zone' do
       let!(:zone) do
-        create(:zone).tap do |z|
+        create(:zone, kind: 'country').tap do |z|
           z.members.create(zoneable: country)
           z.members.create(zoneable: country2)
           z.save!
         end
       end
       let!(:zone2) do
-        create(:zone).tap { |z| z.members.create(zoneable: country) && z.save! }
+        create(:zone, kind: 'country').tap do |zone|
+          zone.members.create(zoneable: country)
+        end
       end
+      let(:result) { Spree::Zone.potential_matching_zones(zone) }
 
-      before { @result = Spree::Zone.potential_matching_zones(zone) }
 
       it 'will find all zones with countries covered by the passed in zone' do
-        expect(@result).to include(zone, zone2)
+        expect(result).to include(zone, zone2)
       end
 
       it 'only returns each zone once' do
-        expect(@result.select { |z| z == zone }.size).to be 1
+        expect(result.select { |z| z == zone }.size).to be 1
       end
     end
 
@@ -484,6 +497,69 @@ describe Spree::Zone, type: :model do
 
       it 'return default checkout zone object' do
         expect(Spree::Zone.default_checkout_zone).to eq nil
+      end
+    end
+  end
+
+  describe '#state_list' do
+    let!(:country) { create(:country) }
+    let!(:state)   { create(:state, country: country) }
+
+    context 'has countries associated' do
+      let(:country_zone) do
+        create(:zone, kind: 'country').tap do |zone|
+          zone.members.create(zoneable: country)
+        end
+      end
+
+      it 'returns states associated to that countries' do
+        expect(country_zone.state_list).to contain_exactly(state)
+      end
+    end
+
+    context 'has states associated' do
+      let(:state_zone) do
+        create(:zone, kind: 'state').tap do |zone|
+          zone.members.create(zoneable: state)
+        end
+      end
+
+      it 'returns that states' do
+        expect(state_zone.state_list).to contain_exactly(state)
+      end
+    end
+  end
+
+  describe '#state_list_for' do
+    let!(:country1) { create(:country) }
+    let!(:country2) { create(:country) }
+
+    let!(:state1)   { create(:state, country: country1) }
+    let!(:state2)   { create(:state, country: country2) }
+
+    context 'has countries associated' do
+      let(:country_zone) do
+        create(:zone, kind: 'country').tap do |zone|
+          zone.members.create(zoneable: country1)
+          zone.members.create(zoneable: country2)
+        end
+      end
+
+      it 'returns states associated with the country' do
+        expect(country_zone.state_list_for(country1)).to contain_exactly(state1)
+      end
+    end
+
+    context 'has states associated' do
+      let(:state_zone) do
+        create(:zone, kind: 'state').tap do |zone|
+          zone.members.create(zoneable: state1)
+          zone.members.create(zoneable: state2)
+        end
+      end
+
+      it 'returns states associated with the country' do
+        expect(state_zone.state_list_for(country1)).to contain_exactly(state1)
       end
     end
   end

--- a/frontend/app/assets/javascripts/spree/frontend/checkout/address.js
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/address.js
@@ -6,11 +6,11 @@ Spree.ready(function ($) {
         if (countryId != null) {
           if (Spree.Checkout[countryId] == null) {
             $.ajax({
-              async: false, method: 'GET', url: Spree.pathFor('/api/v2/storefront/countries/' + countryId + '?include=states&include_checkout_zone_applicable_states=true'), dataType: 'json'
+              async: false, method: 'GET', url: Spree.pathFor('/api/v2/storefront/countries/' + countryId + '?include=checkout_zone_applicable_states'), dataType: 'json'
             }).done(function (data) {
-              var json = data.data.attributes.checkout_zone_applicable_states; var xStates = [];
+              var json = data.included; var xStates = [];
               for (var i = 0; i < json.length; i++) {
-                var obj = json[i]; xStates.push({ 'id': obj.id, 'name': obj.name })
+                var obj = json[i]; xStates.push({ 'id': obj.id, 'name': obj.attributes.name })
               }
               Spree.Checkout[countryId] = {
                 states: xStates,

--- a/frontend/app/assets/javascripts/spree/frontend/checkout/address.js
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/address.js
@@ -6,11 +6,11 @@ Spree.ready(function ($) {
         if (countryId != null) {
           if (Spree.Checkout[countryId] == null) {
             $.ajax({
-              async: false, method: 'GET', url: Spree.pathFor('/api/v2/storefront/countries/' + countryId + '?include=states'), dataType: 'json'
+              async: false, method: 'GET', url: Spree.pathFor('/api/v2/storefront/countries/' + countryId + '?include=states&include_checkout_zone_applicable_states=true'), dataType: 'json'
             }).done(function (data) {
-              var json = data.included; var xStates = []
+              var json = data.data.attributes.checkout_zone_applicable_states; var xStates = [];
               for (var i = 0; i < json.length; i++) {
-                var obj = json[i]; xStates.push({ 'id': obj.id, 'name': obj.attributes.name })
+                var obj = json[i]; xStates.push({ 'id': obj.id, 'name': obj.name })
               }
               Spree.Checkout[countryId] = {
                 states: xStates,

--- a/frontend/app/helpers/spree/addresses_helper.rb
+++ b/frontend/app/helpers/spree/addresses_helper.rb
@@ -41,7 +41,7 @@ module Spree
       country ||= Spree::Country.find(Spree::Config[:default_country_id])
       have_states = country.states.any?
       state_elements = [
-        form.collection_select(:state_id, country.states.order(:name),
+        form.collection_select(:state_id, checkout_zone_applicable_states_for(country).sort_by(&:name),
                               :id, :name,
                                { prompt: Spree.t(:state) },
                                class: [have_states ? 'required' : 'hidden', 'spree-flat-select'].compact,
@@ -68,6 +68,10 @@ module Spree
       return unless try_spree_current_user
 
       try_spree_current_user.addresses.where(country: available_countries)
+    end
+
+    def checkout_zone_applicable_states_for(country)
+      current_store.states_available_for_checkout(country)
     end
   end
 end


### PR DESCRIPTION
…e#checkout_zone

Previous changes on the issue: #10588 

This attempts to handle scenario where the checkout zone assigned to the store is of kind `state`. The expected result is to restrict the country result set that checkout user can pick only to those directly associated with zoneables.

 Apart from that, state address input field should not contain state records mixed up from multiple different countries, which is naturally expected behaviour I believe.