### PR TITLE
Fixed store checkout zone user addresses suggestions

### DIFF
--- a/frontend/app/helpers/spree/addresses_helper.rb
+++ b/frontend/app/helpers/spree/addresses_helper.rb
@@ -65,9 +65,14 @@ module Spree
     end
 
     def user_available_addresses
-      return unless try_spree_current_user
+      return [] unless try_spree_current_user
 
-      try_spree_current_user.addresses.where(country: available_countries)
+      states = current_store.countries_available_for_checkout.each_with_object([]) do |country, memo|
+        memo << current_store.states_available_for_checkout(country)
+      end.flatten
+
+      try_spree_current_user.addresses.
+        where(id: states.pluck(:country_id).uniq)
     end
 
     def checkout_zone_applicable_states_for(country)

--- a/frontend/spec/helpers/address_helper_spec.rb
+++ b/frontend/spec/helpers/address_helper_spec.rb
@@ -2,46 +2,60 @@ require 'spec_helper'
 
 describe Spree::AddressesHelper, type: :helper do
   describe '#user_available_addresses' do
-    let!(:user) { create(:user) }
+    subject { user_available_addresses }
+
+    let!(:store)  { create(:store) }
+    let!(:user)   { create(:user) }
 
     let!(:united_states) { create(:country, name: 'United States') }
     let!(:poland)        { create(:country, name: 'Poland') }
     let!(:china)         { create(:country, name: 'China') }
     let!(:ukraine)       { create(:country, name: 'Ukraine') }
 
-    let!(:address_1) { create(:address, country_id: united_states.id, state_id: united_states.states.first, user: user) }
-    let!(:address_2) { create(:address, country_id: poland.id, state_id: poland.states.first, user: user) }
-    let!(:address_3) { create(:address, country_id: china.id, state_id: china.states.first, user: user) }
-    
+    let!(:address_1) { create(:address, country_id: united_states.id, user: user) }
+    let!(:address_2) { create(:address, country_id: poland.id, user: user) }
+    let!(:address_3) { create(:address, country_id: china.id, user: user) }
+
+    before do
+      allow_any_instance_of(described_class).to receive(:current_store).and_return(store)
+    end
+
     context 'when user is present' do
-      subject { user_available_addresses }
+      before do
+        allow_any_instance_of(described_class).to receive(:try_spree_current_user).and_return(user)
+      end
 
-      context 'when available countries do not includes user addresses countries' do
+      context 'when checkout zone do not includes user addresses states' do
+        before do
+          store.update(checkout_zone: create(:zone))
+        end
+
         it 'returns an empty array' do
-          allow_any_instance_of(Spree::AddressesHelper).to receive(:try_spree_current_user).and_return(user)
-          allow_any_instance_of(Spree::AddressesHelper).to receive(:available_countries).and_return([ukraine])
-
           expect(subject).to match_array []
         end
       end
 
-      context 'when available countries includes user addresses countries' do
-        it 'returns that addresses' do
-          allow_any_instance_of(Spree::AddressesHelper).to receive(:try_spree_current_user).and_return(user)
-          allow_any_instance_of(Spree::AddressesHelper).to receive(:available_countries).and_return([poland, united_states])
+      context 'when checkout zone includes user addresses states' do # Global Zone
+        before do
+          state = create(:state, name: 'New York')
 
-          expect(subject).to match_array [address_1, address_2]
+          united_states.states << state
+          address_1.update(state: state)
+        end
+
+        it 'returns that addresses' do
+          expect(subject).to match_array address_1
         end
       end
     end
 
     context 'when user is absent' do
-      subject { user_available_addresses }
+      before do
+        allow_any_instance_of(described_class).to receive(:try_spree_current_user).and_return(nil)
+      end
 
-      it 'returns nil' do
-        allow_any_instance_of(Spree::AddressesHelper).to receive(:try_spree_current_user).and_return(nil)
-
-        expect(subject).to eq nil
+      it 'returns an empty array' do
+        expect(subject).to match_array []
       end
     end
   end


### PR DESCRIPTION
## Description ##

Modifed [Spree::AddressesHelper#user_available_addresses](https://github.com/spree/spree/blob/master/frontend/app/helpers/spree/addresses_helper.rb#L70) to suggest user addresses that exactly match the zone members of current store checkout zone.

Right now, selection is based on available countries, meaning that for example checkout zone of `kind: state` including Arizona state allows any United State user address to be rendered.