### PR TITLE
Add .reload in product_carousel method to prevent query errors

### DIFF
--- a/frontend/app/controllers/spree/taxons_controller.rb
+++ b/frontend/app/controllers/spree/taxons_controller.rb
@@ -16,7 +16,7 @@ module Spree
     def product_carousel
       if stale?(etag: carousel_etag, last_modified: last_modified, public: true)
         load_products
-        if @products.any?
+        if @products.reload.any?
           render template: 'spree/taxons/product_carousel', layout: false
         else
           head :no_content


### PR DESCRIPTION
It has been noticed that when the product carousels are being rendered on homepage, there's an issue with the fired query
**Error**

```
ActiveRecord::StatementInvalid: PG::InvalidColumnReference: ERROR:  for SELECT DISTINCT, ORDER BY expressions must appear in select list
LINE 1: ...e_products"."id" IN ($10, $11, $12, $13) ORDER BY "spree_pro...
```

**Before**
`SELECT DISTINCT "spree_products"."id" FROM "spree_products" INNER JOIN "spree_variants" ON "spree_variants"."deleted_at" IS NULL AND "spree_variants"."is_master" = $1 AND "spree_variants"."product_id" = "spree_products"."id" INNER JOIN "spree_prices" ON "spree_prices"."deleted_at" IS NULL AND "spree_prices"."variant_id" = "spree_variants"."id" INNER JOIN "spree_products_taxons" ON "spree_products_taxons"."product_id" = "spree_products"."id" LEFT OUTER JOIN "spree_assets" ON "spree_assets"."viewable_type" = $2 AND "spree_assets"."viewable_id" = "spree_variants"."id" LEFT OUTER JOIN "active_storage_attachments" ON "active_storage_attachments"."record_type" = $3 AND "active_storage_attachments"."name" = $4 AND "active_storage_attachments"."record_id" = "spree_assets"."id" LEFT OUTER JOIN "active_storage_blobs" ON "active_storage_blobs"."id" = "active_storage_attachments"."blob_id" LEFT OUTER JOIN "spree_assets" "images_spree_variants" ON "images_spree_variants"."viewable_type" = $5 AND "images_spree_variants"."viewable_id" = "spree_variants"."id" LEFT OUTER JOIN "active_storage_attachments" "attachment_attachments_spree_assets" ON "attachment_attachments_spree_assets"."record_type" = $6 AND "attachment_attachments_spree_assets"."name" = $7 AND "attachment_attachments_spree_assets"."record_id" = "images_spree_variants"."id" LEFT OUTER JOIN "active_storage_blobs" "blobs_active_storage_attachments" ON "blobs_active_storage_attachments"."id" = "attachment_attachments_spree_assets"."blob_id" LEFT OUTER JOIN "spree_tax_categories" ON "spree_tax_categories"."deleted_at" IS NULL AND "spree_tax_categories"."id" = "spree_products"."tax_category_id" WHERE "spree_products"."deleted_at" IS NULL AND ("spree_products".discontinue_on IS NULL or "spree_products".discontinue_on >= '2020-12-08 12:59:27.611900') AND ("spree_products".available_on <= '2020-12-08 12:59:27.611885') AND "spree_products_taxons"."taxon_id" = $8 AND ("spree_products".deleted_at IS NULL or "spree_products".deleted_at >= '2020-12-08 12:59:27.629550') AND ("spree_products".discontinue_on IS NULL or "spree_products".discontinue_on >= '2020-12-08 12:59:27.629775') AND ("spree_products".available_on <= '2020-12-08 12:59:27.629764') AND ("spree_products".discontinue_on IS NULL or "spree_products".discontinue_on >= '2020-12-08 12:59:27.630428') AND ("spree_products".available_on <= '2020-12-08 12:59:27.630410') AND (spree_prices.amount IS NOT NULL) AND "spree_prices"."currency" = $9 AND "spree_products"."id" IN ($10, $11, $12, $13) ORDER BY "spree_products_taxons"."position" ASC`

**After**
`SELECT DISTINCT spree_products.*, spree_products_taxons.position FROM "spree_products" INNER JOIN "spree_variants" ON "spree_variants"."deleted_at" IS NULL AND "spree_variants"."is_master" = $1 AND "spree_variants"."product_id" = "spree_products"."id" INNER JOIN "spree_prices" ON "spree_prices"."deleted_at" IS NULL AND "spree_prices"."variant_id" = "spree_variants"."id" INNER JOIN "spree_products_taxons" ON "spree_products_taxons"."product_id" = "spree_products"."id" WHERE "spree_products"."deleted_at" IS NULL AND ("spree_products".discontinue_on IS NULL or "spree_products".discontinue_on >= '2020-12-08 13:04:46.232487') AND ("spree_products".available_on <= '2020-12-08 13:04:46.232455') AND "spree_products_taxons"."taxon_id" = $2 AND ("spree_products".deleted_at IS NULL or "spree_products".deleted_at >= '2020-12-08 13:04:46.246110') AND ("spree_products".discontinue_on IS NULL or "spree_products".discontinue_on >= '2020-12-08 13:04:46.246290') AND ("spree_products".available_on <= '2020-12-08 13:04:46.246281') AND ("spree_products".discontinue_on IS NULL or "spree_products".discontinue_on >= '2020-12-08 13:04:46.246642') AND ("spree_products".available_on <= '2020-12-08 13:04:46.246634') AND (spree_prices.amount IS NOT NULL) AND "spree_prices"."currency" = $3 ORDER BY "spree_products_taxons"."position" ASC LIMIT $4 OFFSET $5`