### PR TITLE
Display variant compare_at price on PDP fix

### DIFF
--- a/frontend/app/assets/javascripts/spree/frontend/views/spree/products/cart_form.js
+++ b/frontend/app/assets/javascripts/spree/frontend/views/spree/products/cart_form.js
@@ -255,7 +255,7 @@ function CartForm($, $cartForm) {
 
     this.$price.html(variant.display_price)
 
-    var compareAtPriceContent = shouldDisplayCompareAtPrice ? '<span class="mr-3">' + variant.display_compare_at_price + '</span>' : ''
+    var compareAtPriceContent = shouldDisplayCompareAtPrice ? variant.display_compare_at_price : ''
     this.$compareAtPrice.html(compareAtPriceContent)
   }
 

--- a/frontend/app/views/spree/products/_cart_form.html.erb
+++ b/frontend/app/views/spree/products/_cart_form.html.erb
@@ -28,11 +28,9 @@
   <div id="inside-product-cart-form" data-hook="inside_product_cart_form">
     <% if is_product_available_in_currency %>
       <div id="product-price" class="mb-2 text-center text-md-left add-to-cart-form-price" data-hook="product_price">
-        <span class="compare-at-price">
-          <% if should_display_compare_at_price %>
-            <span class="mr-3"><%= display_compare_at_price(default_variant) %></span>
-          <% end %>
-        </span>
+        <% if should_display_compare_at_price %>
+          <span class="compare-at-price mr-3"><%= display_compare_at_price(default_variant) %></span>
+        <% end %>
         <span class="price selling" content="<%= @product_price.to_d %>">
           <%= display_price(default_variant) %>
         </span>


### PR DESCRIPTION
fixes #10590 

If admin applies visible discount using "compare at price" box in admin panel the PDP displays a strikethrough price (in grey) with an error. The strikethrough price appears to have a " - " character before the product actual price (in black). This may cause a misunderstanding, as it may be read as a negative price. 