### PR TITLE
[SD-1053] Add Seo Robots field to the Store in Admin Panel

### DIFF
--- a/backend/app/views/spree/admin/stores/_form.html.erb
+++ b/backend/app/views/spree/admin/stores/_form.html.erb
@@ -69,6 +69,11 @@
       <%= f.text_field :meta_keywords, class: 'form-control' %>
       <%= f.error_message_on :meta_keywords %>
     <% end %>
+    <%= f.field_container :seo_robots, class:['form-group']  do %>
+      <%= f.label :seo_robots, Spree.t(:seo_robots) %>
+      <%= f.text_field :seo_robots, class: 'form-control' %>
+      <%= f.error_message_on :seo_robots %>
+    <% end %>
   </div>
 </div>
 

--- a/backend/spec/features/admin/store_spec.rb
+++ b/backend/spec/features/admin/store_spec.rb
@@ -28,6 +28,13 @@ describe 'Stores', type: :feature, js: true do
       expect(page).to have_field(id: 'store_contact_email')
     end
 
+    it 'has seo fields' do
+      expect(page).to have_field(id: 'store_seo_title')
+      expect(page).to have_field(id: 'store_meta_description')
+      expect(page).to have_field(id: 'store_meta_keywords')
+      expect(page).to have_field(id: 'store_seo_robots')
+    end
+
     it 'creates a new store' do
       fill_in 'Name', with: 'Store name'
       fill_in 'Code', with: 'example_store'
@@ -39,7 +46,7 @@ describe 'Stores', type: :feature, js: true do
       expect(page).to have_content('successfully created!')
     end
 
-    it 'creates a new store with footer info' do
+    it 'creates a new store with footer and seo data' do
       fill_in 'Name', with: 'Store name'
       fill_in 'Code', with: 'example_store'
       fill_in 'URL', with: 'store.example.com'
@@ -48,6 +55,10 @@ describe 'Stores', type: :feature, js: true do
       fill_in 'Address', with: 'New store address 123, City 123'
       fill_in 'Contact phone', with: '123123123'
       fill_in 'Contact email', with: 'contact@example.com'
+      fill_in 'SEO Title', with: 'Spree Store meta title'
+      fill_in 'Meta Description', with: 'Spree Store meta description'
+      fill_in 'Meta Keywords', with: 'Spree, Store'
+      fill_in 'SEO Robots', with: 'noindex'
 
       click_button 'Create'
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -142,7 +142,8 @@ en:
         url: Site URL
         meta_description: Meta Description
         meta_keywords: Meta Keywords
-        seo_title: Seo Title
+        seo_robots: SEO Robots
+        seo_title: SEO Title
         name: Site Name
         mail_from_address: Mail From Address
       spree/store_credit:
@@ -1514,10 +1515,11 @@ en:
     select_a_store_credit_reason: Select a reason for the store credit
     select_stock: Select stock
     selected_quantity_not_available: ! 'selected of %{item} is not available.'
-    seo: SEO
     send_copy_of_all_mails_to: Send Copy of All Mails To
     send_mails_as: Send Mails As
-    seo_title: SEO title
+    seo: SEO
+    seo_robots: SEO Robots
+    seo_title: SEO Title
     server: Server
     server_error: The server returned an error
     settings: Settings

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -101,7 +101,7 @@ module Spree
                           :customer_support_email, :facebook, :twitter, :instagram,
                           :description, :address, :contact_email, :contact_phone,
                           :default_locale, :default_country_id, :supported_currencies,
-                          :new_order_notifications_email, :mailer_logo, :checkout_zone_id]
+                          :new_order_notifications_email, :mailer_logo, :checkout_zone_id, :seo_robots]
 
     @@store_credit_attributes = %i[amount currency category_id memo]
 


### PR DESCRIPTION
Adds SEO Robots field in Spree Store new/edit page. 

How to test:
1. Login as an Admin
2. Go to the admin panel and select Stores
3. Create new store and check if the new field is present in SEO section
4. After creating new Store, try to update it
5. On selected store's homepage check if the updated seo_robots value is present in the html head