### PR TITLE
[SD-1007] [BraintreeVZero] Add yield block in handle_payment_preconditions for payment methods with no source required

### DIFF
--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -113,6 +113,8 @@ module Spree
           else
             raise Core::GatewayError, Spree.t(:payment_processing_failed)
           end
+        else
+          yield
         end
       end
 


### PR DESCRIPTION
Related PRs:
https://github.com/spree-contrib/spree_braintree_vzero/pull/225
https://github.com/spree/spree_gateway/pull/370

During tests it has been noticed that when the payment method does not require source, during the payment processing the given block will be ignored what causes faulty payments with missing data.

I'm not sure about the proper implementation, what else would we like to include in the `else` block? Do we want it to be similar as the `if` block?

**How to test:**
- Using BraintreeVZero payment methods, try to place the order (as a User)
- Notice that when Spree::Payment::Processing is being fired, neither `process_authorization` nor `process_purchase` will be processed