### PR TITLE
Small Select2 v4 Updates

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/spree-select2.js
+++ b/backend/app/assets/javascripts/spree/backend/spree-select2.js
@@ -8,21 +8,6 @@ document.addEventListener('DOMContentLoaded', function() {
       text: 'Select an option'
     }
   })
-
-  // BELOW: z-index fix for Select2 v3.x to lower the z-index of an opened Select2.
-  // The javascript below is not needed if Spree is updated to use Select2 v4.x
-  window.addEventListener('click', function(e) {
-    var select2Drop = document.getElementById('select2-drop')
-
-    if (select2Drop) {
-      if (select2Drop.contains(e.target)) {
-        // Clicking inside the Select2 dropdown does nothing...
-      } else {
-        // Clicking outside the Select2 dropdown close all open Select2 dropdowns.
-        $('*').select2('close')
-      }
-    }
-  })
 })
 
 $.fn.addSelect2Options = function (data) {
@@ -48,4 +33,6 @@ $.fn.addSelect2Options = function (data) {
   })
 }
 
+$.fn.select2.defaults.set("width", "style")
+$.fn.select2.defaults.set("dropdownAutoWidth", false)
 $.fn.select2.defaults.set('theme', 'bootstrap4')

--- a/backend/app/assets/javascripts/spree/backend/spree-select2.js
+++ b/backend/app/assets/javascripts/spree/backend/spree-select2.js
@@ -33,6 +33,6 @@ $.fn.addSelect2Options = function (data) {
   })
 }
 
-$.fn.select2.defaults.set("width", "style")
-$.fn.select2.defaults.set("dropdownAutoWidth", false)
+$.fn.select2.defaults.set('width', 'style')
+$.fn.select2.defaults.set('dropdownAutoWidth', false)
 $.fn.select2.defaults.set('theme', 'bootstrap4')

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_select2_custom.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_select2_custom.scss
@@ -9,8 +9,7 @@
   z-index: 1028;
 }
 
-// Hides strange empty <li> tag highligted in open select2-dropdown
-// Comment out below and see orders/filter Shipment State
+// Hides the empty <li> tag highligted in open select2-dropdown.
 ul.select2-results__options {
   li:empty  {
     display: none;

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_select2_custom.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_select2_custom.scss
@@ -1,0 +1,18 @@
+// style display:none on html attribute dosen't work,
+// find more proper place for that style class
+.select2-container--disabled {
+  display: none;
+}
+
+// Stop an open select2-dropdown from appearing over fixed nav bar.
+.select2-dropdown {
+  z-index: 1028;
+}
+
+// Hides strange empty <li> tag highligted in open select2-dropdown
+// Comment out below and see orders/filter Shipment State
+ul.select2-results__options {
+  li:empty  {
+    display: none;
+  }
+}

--- a/backend/app/assets/stylesheets/spree/backend/shared/_base.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_base.scss
@@ -15,11 +15,6 @@
   z-index: $zindex-dropdown;
 }
 
-// style display:none on html attribute dosen't work, find more proper place for that style class
-.select2-container--disabled {
-  display: none;
-}
-
 // No-margin and no-padding helper classes
 @each $side in top bottom left right {
   .no-margin-#{$side}  { margin-#{side}: 0; }

--- a/backend/app/assets/stylesheets/spree/backend/spree_admin.css.scss
+++ b/backend/app/assets/stylesheets/spree/backend/spree_admin.css.scss
@@ -22,8 +22,6 @@
 @import 'plugins/flatpickr';
 @import 'plugins/select2_custom';
 
-
-
 @import 'shared/base';
 @import 'shared/forms';
 

--- a/backend/app/assets/stylesheets/spree/backend/spree_admin.css.scss
+++ b/backend/app/assets/stylesheets/spree/backend/spree_admin.css.scss
@@ -20,6 +20,9 @@
 
 @import 'plugins/jquery_ui';
 @import 'plugins/flatpickr';
+@import 'plugins/select2_custom';
+
+
 
 @import 'shared/base';
 @import 'shared/forms';


### PR DESCRIPTION
Javascript Changes
- Fix the width of a Select2 v4 dropdown not being wide enough. (see edit product, selector for shipping and tax category).
- Remove some JS hack I used for clicking elsewhere on screen to close a Select2 pre v4. - (V4 has this built in and better).

CSS Changes
- Move Select2 CSS bug fixes into their own custom file.
- Stop an open Select2 dropdown from showing above the fixed Nav bar
- Stop weird empty `<li>` from being shown in select2 options list.

Are you interested in some CSS styling to match the UI icons?