### PR TITLE
Cmd/ Remove comment in gemspec

### DIFF
--- a/cmd/spree_cmd.gemspec
+++ b/cmd/spree_cmd.gemspec
@@ -25,6 +25,5 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_development_dependency 'rspec'
-  # Temporary hack until https://github.com/wycats/thor/issues/234 is fixed
   s.add_dependency 'thor', '~> 1.0'
 end


### PR DESCRIPTION
Very small change of removing comment following the discussion: https://github.com/spree/spree/pull/10613#discussion_r549660446

Tasks
---

- Remove thor link comment in gemspec: cmd/spree_cmd.gemspec