### PR TITLE
[SD-1072] Add unique ids to option types in variants edit form

### DIFF
--- a/backend/app/views/spree/admin/variants/_form.html.erb
+++ b/backend/app/views/spree/admin/variants/_form.html.erb
@@ -6,10 +6,10 @@
           <%= label :new_variant, option_type.presentation %>
           <% if option_type.name == 'color' %>
             <%= f.collection_select 'option_value_ids', option_type.option_values, :id, :name,
-              { include_blank: true }, { name: 'variant[option_value_ids][]', class: 'select2' } %>
+              { include_blank: true }, { name: 'variant[option_value_ids][]', class: 'select2', id: "option_value_ids-#{option_type.id}" } %>
           <% else %>
             <%= f.collection_select 'option_value_ids', option_type.option_values, :id, :presentation,
-              { include_blank: true }, { name: 'variant[option_value_ids][]', class: 'select2' } %>
+              { include_blank: true }, { name: 'variant[option_value_ids][]', class: 'select2', id: "option_value_ids-#{option_type.id}"  } %>
           <% end %>
         </div>
       <% end %>


### PR DESCRIPTION
Select fields had the same ids, because of that `select2` couldn't be applied properly to some fields.
![image](https://user-images.githubusercontent.com/30794294/104023798-77c77e00-51c2-11eb-937d-0de6b16a9487.png)
