### PR TITLE
[SD-1070] add select dropdown for currency field

### DIFF
--- a/backend/app/controllers/spree/admin/shipping_methods_controller.rb
+++ b/backend/app/controllers/spree/admin/shipping_methods_controller.rb
@@ -16,12 +16,10 @@ module Spree
         end
       end
 
+      protected
+
       def permitted_resource_params
-        if params[resource.object_name].present?
-          params.require(resource.object_name).permit([:name, :display_on, :admin_name, :code, :tracking_url, :calculator_type, :tax_category_id])
-        else
-          ActionController::Parameters.new
-        end
+        params.require(resource.object_name).permit(permitted_shipping_method_attributes)
       end
 
       private

--- a/backend/app/controllers/spree/admin/shipping_methods_controller.rb
+++ b/backend/app/controllers/spree/admin/shipping_methods_controller.rb
@@ -16,6 +16,14 @@ module Spree
         end
       end
 
+      def permitted_resource_params
+        if params[resource.object_name].present?
+          params.require(resource.object_name).permit([:name, :display_on, :admin_name, :code, :tracking_url, :calculator_type, :tax_category_id])
+        else
+          ActionController::Parameters.new
+        end
+      end
+
       private
 
       def set_shipping_category

--- a/backend/app/helpers/spree/admin/base_helper.rb
+++ b/backend/app/helpers/spree/admin/base_helper.rb
@@ -127,8 +127,14 @@ module Spree
 
         fields = object.preferences.keys.map do |key|
           if object.has_preference?(key)
-            form.label("preferred_#{key}", Spree.t(key) + ': ') +
-              preference_field_for(form, "preferred_#{key}", type: object.preference_type(key))
+            case key
+            when :currency
+              form.label("preferred_#{key}", Spree.t(key) + ': ') +
+                (form.select "preferred_#{key}", currency_options(current_store.default_currency), {}, { class: 'form-control select2' })
+            else
+              form.label("preferred_#{key}", Spree.t(key) + ': ') +
+                preference_field_for(form, "preferred_#{key}", type: object.preference_type(key))
+            end
           end
         end
         safe_join(fields, '<br />'.html_safe)

--- a/backend/app/helpers/spree/admin/base_helper.rb
+++ b/backend/app/helpers/spree/admin/base_helper.rb
@@ -130,7 +130,7 @@ module Spree
             case key
             when :currency
               form.label("preferred_#{key}", Spree.t(key) + ': ') +
-                (form.select "preferred_#{key}", currency_options(current_store.default_currency), {}, { class: 'form-control select2' })
+                (form.select "preferred_#{key}", currency_options(object.preferences[key]), {}, { class: 'form-control select2' })
             else
               form.label("preferred_#{key}", Spree.t(key) + ': ') +
                 preference_field_for(form, "preferred_#{key}", type: object.preference_type(key))

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -24,7 +24,8 @@ module Spree
       :taxon_attributes,
       :taxonomy_attributes,
       :user_attributes,
-      :variant_attributes
+      :variant_attributes,
+      :shipping_method_attributes
     ]
 
     mattr_reader *ATTRIBUTES
@@ -122,5 +123,7 @@ module Spree
       :weight, :height, :width, :depth, :sku, :cost_currency,
       options: [:name, :value], option_value_ids: []
     ]
+
+    @@shipping_method_attributes = [:name, :display_on, :admin_name, :code, :tracking_url, :calculator_type, :tax_category_id]
   end
 end


### PR DESCRIPTION
Task: https://spark-solutions.atlassian.net/browse/SD-1070

Calculator is called here: https://github.com/spree/spree/blob/ae2fc4a3fa88957fc328464aa3deb28abc19de02/backend/app/views/spree/admin/shipping_methods/_form.html.erb#L100

and calculator uses `preference_fields` here: https://github.com/spree/spree/blob/ae2fc4a3fa88957fc328464aa3deb28abc19de02/backend/app/views/spree/admin/shared/_calculator_fields.html.erb#L18

I extended this method by dropdown selector for currencies.
I used paranthesis in `form.select` because in other way it throws errors.