### PR TITLE
Fixes invalid ES5 syntax error

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
+++ b/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
@@ -1,7 +1,10 @@
-function clearAddressFields(kinds = ['ship', 'bill']) {
-  kinds.forEach(function(kind) {
+function clearAddressFields(addressKinds) {
+  if (addressKinds === undefined) {
+    addressKinds = ['ship', 'bill']
+  }
+  addressKinds.forEach(function(addressKind) {
     ADDRESS_FIELDS.forEach(function(field) {
-      $('#order_' + kind + '_address_attributes_' + field).val('')
+      $('#order_' + addressKind + '_address_attributes_' + field).val('')
     })
   })
 }


### PR DESCRIPTION
This code was giving an ES5 syntax error on `spree-designs` project because the default parameter values were introduced in ES6:
```
Uglifier::Error: Unexpected token operator «=», expected punc «,». To use ES6 syntax, harmony mode must be enabled with Uglifier.new(:harmony => true).
       --
        51782     } else {
        51783       $('div.calculator-settings').hide()
        51784       $('.calculator-settings-warning').show()
        51785       $('.calculator-settings').find('input, textarea').prop('disabled', true)
        51786     }
        51787   })
        51788 })
        51789 ;
           => function clearAddressFields(kinds = ['ship', 'bill']) {
        51791   kinds.forEach(function(kind) {
        51792     ADDRESS_FIELDS.forEach(function(field) {
        51793       $('#order_' + kind + '_address_attributes_' + field).val('')
        51794     })
        51795   })
        51796 }
        51797 
        51798 function formatCustomerResult(customer) {
       ==
```