### PR TITLE
Fix Auto Generated Forms Fields Layouts

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -25,14 +25,6 @@ span.or {
   }
 }
 
-.form-check {
-  input[type=checkbox] {
-    position: absolute;
-    margin-top: .3rem;
-    margin-left: -1.25rem;
-  }
-}
-
 // Hide number toggler
   // Chrome, Safari, Edge, Opera
 input.hide-number-toggle::-webkit-outer-spin-button,

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -25,6 +25,14 @@ span.or {
   }
 }
 
+.form-check {
+  input[type=checkbox] {
+    position: absolute;
+    margin-top: .3rem;
+    margin-left: -1.25rem;
+  }
+}
+
 // Hide number toggler
   // Chrome, Safari, Edge, Opera
 input.hide-number-toggle::-webkit-outer-spin-button,

--- a/backend/app/helpers/spree/admin/base_helper.rb
+++ b/backend/app/helpers/spree/admin/base_helper.rb
@@ -131,16 +131,16 @@ module Spree
             when :currency
               content_tag(:div, form.label("preferred_#{key}", Spree.t(key) + ': ') +
                 (form.select "preferred_#{key}", currency_options(object.preferences[key]), {}, { class: 'form-control select2' }),
-                class: 'form-group')
+                          class: 'form-group')
             else
               if object.preference_type(key) == :boolean
                 content_tag(:div, preference_field_for(form, "preferred_#{key}", type: object.preference_type(key)) +
                   form.label("preferred_#{key}", Spree.t(key) + ': ', class: 'form-check-label'),
-                  class: 'form-group form-check')
+                            class: 'form-group form-check')
               else
                 content_tag(:div, form.label("preferred_#{key}", Spree.t(key) + ': ') +
                   preference_field_for(form, "preferred_#{key}", type: object.preference_type(key), class: 'form-control'),
-                  class: 'form-group')
+                            class: 'form-group')
               end
             end
           end

--- a/backend/app/helpers/spree/admin/base_helper.rb
+++ b/backend/app/helpers/spree/admin/base_helper.rb
@@ -131,16 +131,16 @@ module Spree
           if object.has_preference?(key)
             case key
             when :currency
-              content_tag(:div, form.label("preferred_#{key}", Spree.t(key) + ': ') +
+              content_tag(:div, form.label("preferred_#{key}", Spree.t(key)) +
                 (form.select "preferred_#{key}", currency_options(object.preferences[key]), {}, { class: 'form-control select2' }),
                           class: 'form-group')
             else
               if object.preference_type(key) == :boolean
                 content_tag(:div, preference_field_for(form, "preferred_#{key}", type: object.preference_type(key)) +
-                  form.label("preferred_#{key}", Spree.t(key) + ': ', class: 'form-check-label'),
+                  form.label("preferred_#{key}", Spree.t(key), class: 'form-check-label'),
                             class: 'form-group form-check')
               else
-                content_tag(:div, form.label("preferred_#{key}", Spree.t(key) + ': ') +
+                content_tag(:div, form.label("preferred_#{key}", Spree.t(key)) +
                   preference_field_for(form, "preferred_#{key}", type: object.preference_type(key)),
                             class: 'form-group')
               end

--- a/backend/app/helpers/spree/admin/base_helper.rb
+++ b/backend/app/helpers/spree/admin/base_helper.rb
@@ -93,7 +93,9 @@ module Spree
                             class: 'input_integer form-control'
                           }
                         when :boolean
-                          {}
+                          {
+                            class: 'form-check-input'
+                          }
                         when :string
                           {
                             size: 10,
@@ -139,7 +141,7 @@ module Spree
                             class: 'form-group form-check')
               else
                 content_tag(:div, form.label("preferred_#{key}", Spree.t(key) + ': ') +
-                  preference_field_for(form, "preferred_#{key}", type: object.preference_type(key), class: 'form-control'),
+                  preference_field_for(form, "preferred_#{key}", type: object.preference_type(key)),
                             class: 'form-group')
               end
             end

--- a/backend/app/helpers/spree/admin/base_helper.rb
+++ b/backend/app/helpers/spree/admin/base_helper.rb
@@ -129,15 +129,20 @@ module Spree
           if object.has_preference?(key)
             case key
             when :currency
-              form.label("preferred_#{key}", Spree.t(key) + ': ') +
-                (form.select "preferred_#{key}", currency_options(object.preferences[key]), {}, { class: 'form-control select2' })
+              content_tag(:div, form.label("preferred_#{key}", Spree.t(key) + ': ') +
+                (form.select "preferred_#{key}", currency_options(object.preferences[key]), {}, { class: 'form-control select2' }), class:'form-group')
             else
-              form.label("preferred_#{key}", Spree.t(key) + ': ') +
-                preference_field_for(form, "preferred_#{key}", type: object.preference_type(key))
+              if object.preference_type(key) == :boolean
+                content_tag(:div, preference_field_for(form, "preferred_#{key}", type: object.preference_type(key)) +
+                  form.label("preferred_#{key}", Spree.t(key) + ': ', class: 'form-check-label'), class:'form-group form-check')
+              else
+                content_tag(:div, form.label("preferred_#{key}", Spree.t(key) + ': ') +
+                  preference_field_for(form, "preferred_#{key}", type: object.preference_type(key), class: 'form-control'), class:'form-group')
+              end
             end
           end
         end
-        safe_join(fields, '<br />'.html_safe)
+        safe_join(fields)
       end
 
       # renders hidden field and link to remove record using nested_attributes

--- a/backend/app/helpers/spree/admin/base_helper.rb
+++ b/backend/app/helpers/spree/admin/base_helper.rb
@@ -130,14 +130,17 @@ module Spree
             case key
             when :currency
               content_tag(:div, form.label("preferred_#{key}", Spree.t(key) + ': ') +
-                (form.select "preferred_#{key}", currency_options(object.preferences[key]), {}, { class: 'form-control select2' }), class:'form-group')
+                (form.select "preferred_#{key}", currency_options(object.preferences[key]), {}, { class: 'form-control select2' }),
+                class: 'form-group')
             else
               if object.preference_type(key) == :boolean
                 content_tag(:div, preference_field_for(form, "preferred_#{key}", type: object.preference_type(key)) +
-                  form.label("preferred_#{key}", Spree.t(key) + ': ', class: 'form-check-label'), class:'form-group form-check')
+                  form.label("preferred_#{key}", Spree.t(key) + ': ', class: 'form-check-label'),
+                  class: 'form-group form-check')
               else
                 content_tag(:div, form.label("preferred_#{key}", Spree.t(key) + ': ') +
-                  preference_field_for(form, "preferred_#{key}", type: object.preference_type(key), class: 'form-control'), class:'form-group')
+                  preference_field_for(form, "preferred_#{key}", type: object.preference_type(key), class: 'form-control'),
+                  class: 'form-group')
               end
             end
           end

--- a/backend/app/views/spree/admin/payment_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/_form.html.erb
@@ -4,9 +4,10 @@
 
     <div class="col-12 col-md-4">
       <div id="preference-settings" data-hook class="form-group">
-        <%= f.label :type, Spree.t(:provider) %>
-        <%= collection_select(:payment_method, :type, @providers, :to_s, :name, {}, {id: 'gtwy-type', class: 'select2'}) %>
-
+        <div class="form-group">
+          <%= f.label :type, Spree.t(:provider) %>
+          <%= collection_select(:payment_method, :type, @providers, :to_s, :name, {}, {id: 'gtwy-type', class: 'select2'}) %>
+        </div>
         <% unless @object.new_record? %>
           <%= preference_fields(@object, f) %>
 

--- a/backend/app/views/spree/admin/payment_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/_form.html.erb
@@ -30,18 +30,14 @@
       </div>
       <div data-hook="active" class="form-group">
         <strong><%= Spree.t(:active) %></strong>
-        <div class="radio my-2">
-          <%= label_tag :payment_method_active_true do %>
-            <%= radio_button :payment_method, :active, true %>
-            <%= Spree.t(:say_yes) %>
-          <% end %>
+        <div class="radio my-2 form-check">
+          <%= radio_button :payment_method, :active, true, class: 'form-check-input' %>
+          <%= label_tag :payment_method_active_true, Spree.t(:say_yes), class: 'form-check-label' %>
         </div>
 
-        <div class="radio my-2">
-          <%= label_tag :payment_method_active_false do %>
-            <%= radio_button :payment_method, :active, false %>
-            <%= Spree.t(:say_no) %>
-          <% end %>
+        <div class="radio my-2 form-check">
+          <%= radio_button :payment_method, :active, false, class: 'form-check-input' %>
+          <%= label_tag :payment_method_active_false, Spree.t(:say_no), class: 'form-check-label' %>
         </div>
       </div>
     </div>

--- a/backend/app/views/spree/admin/shared/_account_nav.html.erb
+++ b/backend/app/views/spree/admin/shared/_account_nav.html.erb
@@ -5,7 +5,7 @@
       <%= svg_icon name: "user.svg", width: '24', height: '24' %>
     </button>
 
-    <div class="dropdown-menu dropdown-menu-right mt-2 p-0 mr-2">
+    <div class="dropdown-menu dropdown-menu-right overflow-hidden mt-2 p-0 mr-2">
       <div class="dropdown-item px-0 text-center bg-light">
         <span class="d-block text-dark py-2 px-4"><%= try_spree_current_user.email %></span>
       </div>


### PR DESCRIPTION
- CSS fix so the contents of the Accounts menu don't overflow the rounded corners.
-  Improve the layout of form elements generated by the` preference_field_for` helper.