### PR TITLE
Improve UX for setting up Payment Methods.

### DIFF
--- a/backend/app/views/spree/admin/payment_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/_form.html.erb
@@ -2,56 +2,77 @@
 
   <div data-hook="payment_method" class="row">
 
-    <div class="col-12 col-md-4">
-      <div id="preference-settings" data-hook class="form-group">
-        <div class="form-group">
-          <%= f.label :type, Spree.t(:provider) %>
-          <%= collection_select(:payment_method, :type, @providers, :to_s, :name, {}, {id: 'gtwy-type', class: 'select2'}) %>
+    <div class="col-12 col-md-6">
+      <div class="card mb-3">
+        <div class="card-header">
+          <h5 class="mb-0"><%= Spree.t(:settings) %></h5>
         </div>
-        <% unless @object.new_record? %>
-          <%= preference_fields(@object, f) %>
-
-          <% if @object.respond_to?(:preferences) %>
-            <div id="gateway-settings-warning" class="info warning"><%= Spree.t(:provider_settings_warning) %></div>
+        <div class="card-body">
+          <div class="form-group">
+            <%= f.label :type, Spree.t(:provider) %>
+            <%= collection_select(:payment_method, :type, @providers, :to_s, :name, {}, {id: 'gtwy-type', class: 'select2'}) %>
+          </div>
+          <hr class="my-4">
+          <%= field_container :payment_method, :name, class: ['form-group'], 'data-hook' => 'name' do %>
+            <%= label_tag :payment_method_name, Spree.t(:name) %>
+            <%= text_field :payment_method, :name, class: 'form-control' %>
+            <%= error_message_on :payment_method, :name %>
           <% end %>
-        <% end %>
-      </div>
-      <div data-hook="store" class="form-group">
-        <%= label_tag :payment_method_store, Spree.t(:store) %>
-        <%= collection_select(:payment_method, :store_id, @stores, :id, :unique_name, { include_blank: true }, {id: 'store_id', class: 'select2'}) %>
-      </div>
-      <div data-hook="display" class="form-group">
-        <%= label_tag :payment_method_display_on, Spree.t(:display) %>
-        <%= select(:payment_method, :display_on, Spree::PaymentMethod::DISPLAY.collect { |display| [Spree.t(display), display.to_s] }, {}, {class: 'select2'}) %>
-      </div>
-      <div data-hook="auto_capture" class="form-group">
-        <%= label_tag :payment_method_auto_capture, Spree.t(:auto_capture) %>
-        <%= select(:payment_method, :auto_capture, [["#{Spree.t(:use_app_default)} (#{Spree::Config[:auto_capture]})", ''], [Spree.t(:say_yes), true], [Spree.t(:say_no), false]], {}, {class: 'select2'}) %>
-      </div>
-      <div data-hook="active" class="form-group">
-        <strong><%= Spree.t(:active) %></strong>
-        <div class="radio my-2 form-check">
-          <%= radio_button :payment_method, :active, true, class: 'form-check-input' %>
-          <%= label_tag :payment_method_active_true, Spree.t(:say_yes), class: 'form-check-label' %>
-        </div>
 
-        <div class="radio my-2 form-check">
-          <%= radio_button :payment_method, :active, false, class: 'form-check-input' %>
-          <%= label_tag :payment_method_active_false, Spree.t(:say_no), class: 'form-check-label' %>
+          <%= field_container :payment_method, :description, class: ['form-group'], 'data-hook' => 'description' do %>
+            <%= label_tag :payment_method_description, Spree.t(:description) %>
+            <%= text_area :payment_method, :description, { cols: 60, rows: 6, class: 'form-control' } %>
+          <% end %>
+
+          <div data-hook="store" class="form-group">
+            <%= label_tag :payment_method_store, Spree.t(:store) %>
+            <%= collection_select(:payment_method, :store_id, @stores, :id, :unique_name, { include_blank: true }, {id: 'store_id', class: 'select2'}) %>
+          </div>
+          <div data-hook="display" class="form-group">
+            <%= label_tag :payment_method_display_on, Spree.t(:display) %>
+            <%= select(:payment_method, :display_on, Spree::PaymentMethod::DISPLAY.collect { |display| [Spree.t(display), display.to_s] }, {}, {class: 'select2'}) %>
+          </div>
+          <div data-hook="auto_capture" class="form-group">
+            <%= label_tag :payment_method_auto_capture, Spree.t(:auto_capture) %>
+            <%= select(:payment_method, :auto_capture, [["#{Spree.t(:use_app_default)} (#{Spree::Config[:auto_capture]})", ''], [Spree.t(:say_yes), true], [Spree.t(:say_no), false]], {}, {class: 'select2'}) %>
+          </div>
+
+          <div data-hook="active" class="form-group">
+            <strong><%= Spree.t(:active) %></strong>
+            <div class="radio my-2 form-check">
+              <%= radio_button :payment_method, :active, true, class: 'form-check-input' %>
+              <%= label_tag :payment_method_active_true, Spree.t(:say_yes), class: 'form-check-label' %>
+            </div>
+
+            <div class="radio my-2 form-check">
+              <%= radio_button :payment_method, :active, false, class: 'form-check-input' %>
+              <%= label_tag :payment_method_active_false, Spree.t(:say_no), class: 'form-check-label' %>
+            </div>
+          </div>
         </div>
       </div>
     </div>
 
-    <div class="col-12 col-md-8">
-      <%= field_container :payment_method, :name, class: ['form-group'], 'data-hook' => 'name' do %>
-        <%= label_tag :payment_method_name, Spree.t(:name) %>
-        <%= text_field :payment_method, :name, class: 'form-control' %>
-        <%= error_message_on :payment_method, :name %>
-      <% end %>
-      <%= field_container :payment_method, :description, class: ['form-group'], 'data-hook' => 'description' do %>
-        <%= label_tag :payment_method_description, Spree.t(:description) %>
-        <%= text_area :payment_method, :description, { cols: 60, rows: 6, class: 'form-control' } %>
-      <% end %>
+    <div class="col-12 col-md-6">
+      <div class="card mb-3">
+        <div class="card-header">
+          <h5 class="mb-0"><%= Spree.t(:payment_provider_settings) %></h5>
+        </div>
+        <div class="card-body">
+          <div id="preference-settings" data-hook class="form-group">
+            <% unless @object.new_record? %>
+            <% if preference_fields(@object, f).empty? %>
+              <%= Spree.t('no_payment_provider_settings_message') %>
+            <% end %>
+              <%= preference_fields(@object, f) %>
+
+              <% if @object.respond_to?(:preferences) %>
+                <div id="gateway-settings-warning" class="info warning"><%= Spree.t(:provider_settings_warning) %></div>
+              <% end %>
+            <% end %>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1130,6 +1130,7 @@ en:
     no_available_date_set: No available date set
     no_country: No country set
     no_payment_found: No payment found
+    no_payment_provider_settings_message: This payment provider has no custom settings available
     no_pending_payments: No pending payments
     no_product_available:
       for_this_quantity: Sorry, it looks like some products are not available in selected quantity.
@@ -1253,6 +1254,7 @@ en:
     payment_processing_failed: Payment could not be processed, please check the details you entered
     payment_processor_choose_banner_text: If you need help choosing a payment processor, please visit
     payment_processor_choose_link: our payments page
+    payment_provider_settings: Payment Provider Settings
     payment_state: Payment State
     payment_states:
       balance_due: balance due


### PR DESCRIPTION
Moved Payment Provider setting into separate cards (similar to shipping method settings)

One  card for the default settings that come with every payment method, and a card  for payment provider specific settings. This allows users to become familiar with the standard settings and instantly recognise custom fields as they are provided.

**Reason for PR:**
Personally I found when switching payment providers it was sometimes a spot-the-difference moment when you updated the provider to see what fields had just been inserted amongst the regular fields.

**No Preferences needed:**
If no settings are available a message is displayed.
<img width="1069" alt="Screenshot 2021-01-13 at 11 05 01" src="https://user-images.githubusercontent.com/1240766/104444151-4fa79880-558f-11eb-9e1d-9b989847002b.png">

**Custom Preferences offered:**
<img width="1067" alt="Screenshot 2021-01-13 at 11 05 29" src="https://user-images.githubusercontent.com/1240766/104444170-5504e300-558f-11eb-9601-60bb13ce22f2.png">
