### PR TITLE
Fixes For Issues With Placeholders

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/spree-select2.js
+++ b/backend/app/assets/javascripts/spree/backend/spree-select2.js
@@ -11,13 +11,6 @@ document.addEventListener('DOMContentLoaded', function() {
     placeholder: Spree.translations.select_an_option,
     allowClear: true
   })
-
-  // Inititate a Select2 with the multiple set to true, on any select element with the class .select2-multiple
-  // Set include_blank: false in your ERB.
-  // Manually add a placeholder in the html or ERB as needed.
-  $('select.select2-multiple').select2({
-    multiple: true
-  })
 })
 
 $.fn.addSelect2Options = function (data) {

--- a/backend/app/assets/javascripts/spree/backend/spree-select2.js
+++ b/backend/app/assets/javascripts/spree/backend/spree-select2.js
@@ -1,8 +1,22 @@
 document.addEventListener('DOMContentLoaded', function() {
-  // Inititate Select2 on any select element with the class .select2
-  $('select.select2').select2({
-    allowClear: true,
-    placeholder: Spree.translations.select_an_option
+  // Inititate a standard Select2 on any select element with the class .select2
+  // Remember to add a place holder in the HTML as needed.
+  $('select.select2').select2()
+
+  // Inititate a Select2 with the option to clear, on any select element with the class .select2-clear
+  // Set: include_blank: true in your ERB.
+  // A placeholder is auto added here as it is required to clear the Select2
+  // If a custom placeholder is required, you will need to set up a custom instance.
+  $('select.select2-clear').select2({
+    placeholder: Spree.translations.select_an_option,
+    allowClear: true
+  })
+
+  // Inititate a Select2 with the multiple set to true, on any select element with the class .select2-multiple
+  // Set include_blank: false in your ERB.
+  // Manually add a placeholder in the html or ERB as needed.
+  $('select.select2-multiple').select2({
+    multiple: true
   })
 })
 

--- a/backend/app/assets/javascripts/spree/backend/spree-select2.js
+++ b/backend/app/assets/javascripts/spree/backend/spree-select2.js
@@ -1,12 +1,11 @@
 document.addEventListener('DOMContentLoaded', function() {
-  // Inititate a standard Select2 on any select element with the class .select2
+  // Initiate a standard Select2 on any select element with the class .select2
   // Remember to add a place holder in the HTML as needed.
   $('select.select2').select2()
 
-  // Inititate a Select2 with the option to clear, on any select element with the class .select2-clear
-  // Set: include_blank: true in your ERB.
-  // A placeholder is auto added here as it is required to clear the Select2
-  // If a custom placeholder is required, you will need to set up a custom instance.
+  // Initiate a Select2 with the option to clear, on any select element with the class .select2-clear
+  // Set: include_blank: true in the ERB.
+  // A placeholder is auto-added here as it is required to clear the Select2.
   $('select.select2-clear').select2({
     placeholder: Spree.translations.select_an_option,
     allowClear: true

--- a/backend/app/views/spree/admin/customer_returns/new.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/new.html.erb
@@ -24,7 +24,7 @@
 
         <%= f.field_container :stock_location, class: ['form-group'] do %>
           <%= f.label :stock_location, Spree.t(:stock_location) %> <span class="required">*</span>
-          <%= f.select :stock_location_id, Spree::StockLocation.order_default.active.to_a.collect{|l|[l.name.humanize, l.id]}, {include_blank: true}, {class: 'select2', "data-placeholder" => Spree.t(:select_a_stock_location)} %>
+          <%= f.select :stock_location_id, Spree::StockLocation.order_default.active.to_a.collect{|l|[l.name.humanize, l.id]}, {include_blank: true}, {class: 'select2-clear', "data-placeholder" => Spree.t(:select_a_stock_location)} %>
           <%= f.error_message_on :stock_location %>
         <% end %>
       </div>

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -67,21 +67,21 @@
           <%= f.select :state_eq,
             Spree::Order.state_machines[:state].states.map {|s| [Spree.t("order_state.#{s.name}"), s.value]},
             { include_blank: true },
-            class: 'select2 js-filterable' %>
+            class: 'select2-clear js-filterable' %>
         </div>
       </div>
 
       <div class="col-12 col-lg-4">
         <div class="form-group">
           <%= label_tag :q_payment_state_eq, Spree.t(:payment_state) %>
-          <%= f.select :payment_state_eq, Spree::Order::PAYMENT_STATES.map {|s| [Spree.t("payment_states.#{s}"), s]}, { include_blank: true }, class: 'select2 js-filterable' %>
+          <%= f.select :payment_state_eq, Spree::Order::PAYMENT_STATES.map {|s| [Spree.t("payment_states.#{s}"), s]}, { include_blank: true }, class: 'select2-clear js-filterable' %>
         </div>
       </div>
 
       <div class="col-12 col-lg-4">
         <div class="form-group">
           <%= label_tag :q_shipment_state_eq, Spree.t(:shipment_state) %>
-          <%= f.select :shipment_state_eq, Spree::Order::SHIPMENT_STATES.map {|s| [Spree.t("shipment_states.#{s}"), s]}, { include_blank: true }, class: 'select2 js-filterable' %>
+          <%= f.select :shipment_state_eq, Spree::Order::SHIPMENT_STATES.map {|s| [Spree.t("shipment_states.#{s}"), s]}, { include_blank: true }, class: 'select2-clear js-filterable' %>
         </div>
       </div>
 
@@ -124,21 +124,21 @@
       <div class="col-12 col-lg-4">
         <div class="form-group">
           <%= label_tag :q_promotions_id_in, Spree.t(:promotion) %>
-          <%= f.select :promotions_id_in, Spree::Promotion.applied.pluck(:name, :id), { include_blank: true }, class: 'select2 js-filterable' %>
+          <%= f.select :promotions_id_in, Spree::Promotion.applied.pluck(:name, :id), { include_blank: true }, class: 'select2-clear js-filterable' %>
         </div>
       </div>
 
       <div class="col-12 col-lg-4">
         <div class="form-group">
           <%= label_tag :q_store_id_in, Spree.t(:store) %>
-          <%= f.select :store_id_in, Spree::Store.order(:name).pluck(:name, :id), { include_blank: true }, class: 'select2 js-filterable' %>
+          <%= f.select :store_id_in, Spree::Store.order(:name).pluck(:name, :id), { include_blank: true }, class: 'select2-clear js-filterable' %>
         </div>
       </div>
 
       <div class="col-12 col-lg-4">
         <div class="form-group">
           <%= label_tag :q_channel_eq, Spree.t(:channel) %>
-          <%= f.select :channel_eq, Spree::Order.distinct.pluck(:channel), { include_blank: true }, class: 'select2 js-filterable' %>
+          <%= f.select :channel_eq, Spree::Order.distinct.pluck(:channel), { include_blank: true }, class: 'select2-clear js-filterable' %>
         </div>
       </div>
 

--- a/backend/app/views/spree/admin/payment_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/_form.html.erb
@@ -26,8 +26,10 @@
 
           <div data-hook="store" class="form-group">
             <%= label_tag :payment_method_store, Spree.t(:store) %>
-            <%= collection_select(:payment_method, :store_id, @stores, :id, :unique_name, { include_blank: true }, {id: 'store_id', class: 'select2'}) %>
+            <%= collection_select(:payment_method, :store_id, @stores, :id, :unique_name, { include_blank: true }, {id: 'store_id', class: 'select2-clear'}) %>
+            <small id="emailHelp" class="form-text text-muted"><%= Spree.t(:leave_blank_to_show_in_all_stores) %></small>
           </div>
+
           <div data-hook="display" class="form-group">
             <%= label_tag :payment_method_display_on, Spree.t(:display) %>
             <%= select(:payment_method, :display_on, Spree::PaymentMethod::DISPLAY.collect { |display| [Spree.t(display), display.to_s] }, {}, {class: 'select2'}) %>

--- a/backend/app/views/spree/admin/payment_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/_form.html.erb
@@ -27,7 +27,7 @@
           <div data-hook="store" class="form-group">
             <%= label_tag :payment_method_store, Spree.t(:store) %>
             <%= collection_select(:payment_method, :store_id, @stores, :id, :unique_name, { include_blank: true }, {id: 'store_id', class: 'select2-clear'}) %>
-            <small id="emailHelp" class="form-text text-muted"><%= Spree.t(:leave_blank_to_show_in_all_stores) %></small>
+            <small class="form-text text-muted"><%= Spree.t('payment_method_form.stores_help') %></small>
           </div>
 
           <div data-hook="display" class="form-group">

--- a/backend/app/views/spree/admin/products/new.html.erb
+++ b/backend/app/views/spree/admin/products/new.html.erb
@@ -27,7 +27,7 @@
       <div data-hook="new_product_prototype" class="col-12 col-md-4">
         <%= f.field_container :prototype, class: ['form-group'] do %>
           <%= f.label :prototype_id, Spree.t(:prototype) %>
-          <%= f.collection_select :prototype_id, Spree::Prototype.all, :id, :name, { include_blank: true }, { class: 'select2 w-100' } %>
+          <%= f.collection_select :prototype_id, Spree::Prototype.all, :id, :name, { include_blank: true }, { class: 'select2-clear w-100' } %>
         <% end %>
       </div>
 

--- a/backend/app/views/spree/admin/refunds/new.html.erb
+++ b/backend/app/views/spree/admin/refunds/new.html.erb
@@ -25,7 +25,7 @@
       <% end %>
       <%= f.field_container :reason, class: ['form-group'] do %>
         <%= f.label :refund_reason_id, Spree.t(:reason) %>
-        <%= f.collection_select(:refund_reason_id, refund_reasons, :id, :name, {include_blank: true}, {class: 'select2'}) %>
+        <%= f.collection_select(:refund_reason_id, refund_reasons, :id, :name, {include_blank: true}, {class: 'select2-clear'}) %>
         <%= f.error_message_on :reason %>
       <% end %>
     </div>

--- a/backend/app/views/spree/admin/reimbursements/edit.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/edit.html.erb
@@ -51,7 +51,7 @@
                 <% if return_item.exchange_processed? %>
                   <%= return_item.exchange_variant.exchange_name %>
                 <% else %>
-                  <%= item_fields.collection_select :exchange_variant_id, return_item.eligible_exchange_variants, :id, :exchange_name, { include_blank: true }, { class: "select2 return-item-exchange-selection" } %>
+                  <%= item_fields.collection_select :exchange_variant_id, return_item.eligible_exchange_variants, :id, :exchange_name, { include_blank: true }, { class: "select2-clear return-item-exchange-selection" } %>
                 <% end %>
               </td>
             </tr>

--- a/backend/app/views/spree/admin/return_authorizations/_form.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/_form.html.erb
@@ -61,7 +61,7 @@
           </td>
           <td>
             <% if editable %>
-              <%= item_fields.select :preferred_reimbursement_type_id, @reimbursement_types.collect{|r|[r.name.humanize, r.id]}, {include_blank: true}, {class: 'select2'} %>
+              <%= item_fields.select :preferred_reimbursement_type_id, @reimbursement_types.collect{|r|[r.name.humanize, r.id]}, {include_blank: true}, {class: 'select2-clear'} %>
             <% end %>
           </td>
           <td>
@@ -69,7 +69,7 @@
               <% if return_item.exchange_processed? %>
                 <%= return_item.exchange_variant.exchange_name %>
               <% else %>
-                <%= item_fields.collection_select :exchange_variant_id, return_item.eligible_exchange_variants, :id, :exchange_name, { include_blank: true }, { class: "select2 return-item-exchange-selection" } %>
+                <%= item_fields.collection_select :exchange_variant_id, return_item.eligible_exchange_variants, :id, :exchange_name, { include_blank: true }, { class: "select2-clear return-item-exchange-selection" } %>
               <% end %>
             <% end %>
           </td>
@@ -84,13 +84,13 @@
 
   <%= f.field_container :stock_location, class: ['form-group'] do %>
     <%= f.label :stock_location, Spree.t(:stock_location) %> <span class="required">*</span>
-    <%= f.select :stock_location_id, Spree::StockLocation.order_default.active.to_a.collect{|l|[l.name, l.id]}, {include_blank: true}, {class: 'select2', "data-placeholder" => Spree.t(:select_a_stock_location)} %>
+    <%= f.select :stock_location_id, Spree::StockLocation.order_default.active.to_a.collect{|l|[l.name, l.id]}, {include_blank: true}, {class: 'select2-clear', "data-placeholder" => Spree.t(:select_a_stock_location)} %>
     <%= f.error_message_on :stock_location %>
   <% end %>
 
   <%= f.field_container :reason, class: ['form-group'] do %>
     <%= f.label :reason, Spree.t(:reason) %> <span class="required">*</span>
-    <%= f.select :return_authorization_reason_id, @reasons.collect{|r|[r.name, r.id]}, {include_blank: true}, {class: 'select2', "data-placeholder" => Spree.t(:select_a_return_authorization_reason)} %>
+    <%= f.select :return_authorization_reason_id, @reasons.collect{|r|[r.name, r.id]}, {include_blank: true}, {class: 'select2-clear', "data-placeholder" => Spree.t(:select_a_return_authorization_reason)} %>
     <%= f.error_message_on :reason %>
   <% end %>
 

--- a/backend/app/views/spree/admin/return_index/return_authorizations.html.erb
+++ b/backend/app/views/spree/admin/return_index/return_authorizations.html.erb
@@ -33,7 +33,7 @@
         <div class="col-12 col-lg-6">
           <div class="form-group">
             <%= label_tag :q_state_eq, Spree.t(:status) %>
-            <%= f.select :state_eq, Spree::ReturnAuthorization.state_machines[:state].states.collect {|s| [Spree.t("return_authorization_states.#{s.name}"), s.value]}, {include_blank: true}, class: 'select2 js-filterable' %>
+            <%= f.select :state_eq, Spree::ReturnAuthorization.state_machines[:state].states.collect {|s| [Spree.t("return_authorization_states.#{s.name}"), s.value]}, {include_blank: true}, class: 'select2-clear js-filterable' %>
           </div>
         </div>
       </div>

--- a/backend/app/views/spree/admin/shipping_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/_form.html.erb
@@ -11,7 +11,7 @@
     <div data-hook="admin_shipping_method_form_display_field" class="col-12 col-lg-6">
       <%= f.field_container :display_on, class: ['form-group'] do %>
         <%= f.label :display_on, Spree.t(:display) %>
-        <%= select(:shipping_method, :display_on, Spree::ShippingMethod::DISPLAY.collect { |display| [Spree.t(display), display.to_s] }, { include_blank: true }, { class: 'select2' }) %>
+        <%= select(:shipping_method, :display_on, Spree::ShippingMethod::DISPLAY.collect { |display| [Spree.t(display), display.to_s] }, { include_blank: true }, { class: 'select2-clear' }) %>
         <%= f.error_message_on :display_on %>
       <% end %>
     </div>
@@ -110,7 +110,7 @@
 
       <div class="card-body">
         <%= f.field_container :categories, class: ['form-group'] do %>
-          <%= f.select :tax_category_id, @tax_categories.map { |tc| [tc.name, tc.id] }, { include_blank: true }, class: "select2" %>
+          <%= f.select :tax_category_id, @tax_categories.map { |tc| [tc.name, tc.id] }, { include_blank: true }, class: "select2-clear" %>
           <%= f.error_message_on :tax_category_id %>
         <% end %>
       </div>

--- a/backend/app/views/spree/admin/stock_locations/_form.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/_form.html.erb
@@ -80,7 +80,7 @@
       <%= f.label :state_id, Spree.t(:state) %>
       <span id="state" class="region">
         <%= f.text_field :state_name, style: "#{f.object.country.states.empty? ? '' : 'display: none;'}", disabled: !f.object.country.states.empty?, class: 'state_name form-control' %>
-        <%= f.collection_select :state_id, f.object.country.states.sort, :id, :name, { include_blank: true }, {class: 'select2', style: "#{f.object.country.states.empty? ? 'display: none;' : '' };", disabled: f.object.country.states.empty?} %>
+        <%= f.collection_select :state_id, f.object.country.states.sort, :id, :name, { include_blank: true }, {class: 'select2-clear', style: "#{f.object.country.states.empty? ? 'display: none;' : '' };", disabled: f.object.country.states.empty?} %>
       </span>
     <% end %>
   </div>

--- a/backend/app/views/spree/admin/stock_transfers/index.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/index.html.erb
@@ -23,7 +23,7 @@
             <%= f.label :source_location, Spree.t(:source) %>
             <%= f.select :source_location_id_eq,
                 options_from_collection_for_select(@stock_locations, :id, :name, @q.source_location_id_eq),
-                { include_blank: true }, class: 'select2 js-filterable' %>
+                { include_blank: true }, class: 'select2-clear js-filterable' %>
           </div>
         </div>
 
@@ -32,7 +32,7 @@
             <%= f.label :destination_location, Spree.t(:destination) %>
             <%= f.select :destination_location_id_eq,
                 options_from_collection_for_select(@stock_locations, :id, :name, @q.destination_location_id_eq),
-                { include_blank: true }, class: 'select2 js-filterable' %>
+                { include_blank: true }, class: 'select2-clear js-filterable' %>
           </div>
         </div>
       </div>

--- a/backend/app/views/spree/admin/variants/_form.html.erb
+++ b/backend/app/views/spree/admin/variants/_form.html.erb
@@ -6,10 +6,10 @@
           <%= label :new_variant, option_type.presentation %>
           <% if option_type.name == 'color' %>
             <%= f.collection_select 'option_value_ids', option_type.option_values, :id, :name,
-              { include_blank: true }, { name: 'variant[option_value_ids][]', class: 'select2', id: "option_value_ids-#{option_type.id}" } %>
+              { include_blank: true }, { name: 'variant[option_value_ids][]', class: 'select2-clear', id: "option_value_ids-#{option_type.id}" } %>
           <% else %>
             <%= f.collection_select 'option_value_ids', option_type.option_values, :id, :presentation,
-              { include_blank: true }, { name: 'variant[option_value_ids][]', class: 'select2', id: "option_value_ids-#{option_type.id}"  } %>
+              { include_blank: true }, { name: 'variant[option_value_ids][]', class: 'select2-clear', id: "option_value_ids-#{option_type.id}"  } %>
           <% end %>
         </div>
       <% end %>

--- a/backend/spec/features/admin/configuration/stores_spec.rb
+++ b/backend/spec/features/admin/configuration/stores_spec.rb
@@ -51,7 +51,7 @@ describe 'Stores admin', type: :feature, js: true do
         click_link 'New Store'
 
         expect(page).to have_current_path(spree.new_admin_store_path)
-        expect(page).to have_selector(:id, 'select2-store_checkout_zone_id-container', text: 'Select an option')
+        expect(page).to have_selector(:id, 'select2-store_checkout_zone_id-container', text: 'No Limits')
       end
     end
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1015,6 +1015,7 @@ en:
     lastname: Last Name
     last_name_begins_with: Last Name Begins With
     learn_more: Learn More
+    leave_blank_to_show_in_all_stores: Leave this option blank to show this payment method in all stores.
     lifetime_stats: Lifetime Stats
     limit_usage_to: Limit usage to
     line_item_adjustments: "Line item adjustments"

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1015,7 +1015,6 @@ en:
     lastname: Last Name
     last_name_begins_with: Last Name Begins With
     learn_more: Learn More
-    leave_blank_to_show_in_all_stores: Leave this option blank to show this payment method in all stores.
     lifetime_stats: Lifetime Stats
     limit_usage_to: Limit usage to
     line_item_adjustments: "Line item adjustments"
@@ -1250,6 +1249,8 @@ en:
     payment_identifier: Payment Identifier
     payment_information: Payment Information
     payment_method: Payment Method
+    payment_method_form:
+      stores_help: Leave blank to show this payment method in all stores.
     payment_methods: Payment Methods
     payment_method_not_supported: That payment method is unsupported. Please choose another one.
     payment_processing_failed: Payment could not be processed, please check the details you entered


### PR DESCRIPTION
### Select2 V4 Issue
Found a small issue with Select2 v4 if AllowClear is set to true, then a default option is discarded and replaced with the placeholder text.

Example: In the payment methods, the auto capture selector is supposed to have the option "Use App Default", but it is replaced with the placeholder text.

It might be best to remove AllowClear from the stranded select2, create a second option with its own class specifically for use when clear is wanted.

And then compare the views and add the appropriate select2-clear class depending on what type of selector is needed, based off what it was in Spree 4.1