### PR TITLE
fix for sassc segfaults on ruby 3.0.0 on macOS Big Sur

### DIFF
--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -65,6 +65,11 @@ end
 gem 'mini_racer'
 
 gem 'rack-cache'
+
+# temporary fix for sassc segfaults on ruby 3.0.0 on Mac OS Big Sur
+# this change fixes the issue:
+# https://github.com/sass/sassc-ruby/commit/04407faf6fbd400f1c9f72f752395e1dfa5865f7
+gem 'sassc', github: 'sass/sassc-ruby', branch: 'master'
 RUBY
 
 bundle install --gemfile Gemfile


### PR DESCRIPTION
required changes: https://github.com/sass/sassc-ruby/commit/04407faf6fbd400f1c9f72f752395e1dfa5865f7