### PR TITLE
Add id attribute to parent div in preferences.

### DIFF
--- a/backend/app/helpers/spree/admin/base_helper.rb
+++ b/backend/app/helpers/spree/admin/base_helper.rb
@@ -133,16 +133,16 @@ module Spree
             when :currency
               content_tag(:div, form.label("preferred_#{key}", Spree.t(key)) +
                 (form.select "preferred_#{key}", currency_options(object.preferences[key]), {}, { class: 'form-control select2' }),
-                          class: 'form-group', id: key)
+                          class: 'form-group', id: [object.class.to_s.parameterize, 'preference', key].join('-'))
             else
               if object.preference_type(key) == :boolean
                 content_tag(:div, preference_field_for(form, "preferred_#{key}", type: object.preference_type(key)) +
                   form.label("preferred_#{key}", Spree.t(key), class: 'form-check-label'),
-                            class: 'form-group form-check', id: key)
+                            class: 'form-group form-check', id: [object.class.to_s.parameterize, 'preference', key].join('-'))
               else
                 content_tag(:div, form.label("preferred_#{key}", Spree.t(key)) +
                   preference_field_for(form, "preferred_#{key}", type: object.preference_type(key)),
-                            class: 'form-group', id: key)
+                            class: 'form-group', id: [object.class.to_s.parameterize, 'preference', key].join('-'))
               end
             end
           end

--- a/backend/app/helpers/spree/admin/base_helper.rb
+++ b/backend/app/helpers/spree/admin/base_helper.rb
@@ -133,16 +133,16 @@ module Spree
             when :currency
               content_tag(:div, form.label("preferred_#{key}", Spree.t(key)) +
                 (form.select "preferred_#{key}", currency_options(object.preferences[key]), {}, { class: 'form-control select2' }),
-                          class: 'form-group')
+                          class: 'form-group', id: key)
             else
               if object.preference_type(key) == :boolean
                 content_tag(:div, preference_field_for(form, "preferred_#{key}", type: object.preference_type(key)) +
                   form.label("preferred_#{key}", Spree.t(key), class: 'form-check-label'),
-                            class: 'form-group form-check')
+                            class: 'form-group form-check', id: key)
               else
                 content_tag(:div, form.label("preferred_#{key}", Spree.t(key)) +
                   preference_field_for(form, "preferred_#{key}", type: object.preference_type(key)),
-                            class: 'form-group')
+                            class: 'form-group', id: key)
               end
             end
           end


### PR DESCRIPTION
Looking through other payment method extensions, it seems required to inherit from `Spree::Gateway`, this pulls in 2 default preferences, that appear to not always be used.

A safe and easy way to tidy this up, if you are not using these default preferences, would be to add a little CSS to your extension to hide one or both by targeting the parent element ID's.

Might be useful.