### PR TITLE
Missing braces crashing js file.

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/spree-select2.js
+++ b/backend/app/assets/javascripts/spree/backend/spree-select2.js
@@ -1,7 +1,7 @@
 document.addEventListener('DOMContentLoaded', function() {
   // Initiate a standard Select2 on any select element with the class .select2
   // Remember to add a place holder in the HTML as needed.
-  $('select.select2').select2()
+  $('select.select2').select2({})
 
   // Initiate a Select2 with the option to clear, on any select element with the class .select2-clear
   // Set: include_blank: true in the ERB.


### PR DESCRIPTION
{} Missing braces crash the whole select2.js file.