### PR TITLE
Update Stores Make Default Button

### DIFF
--- a/backend/app/views/spree/admin/stores/index.html.erb
+++ b/backend/app/views/spree/admin/stores/index.html.erb
@@ -28,9 +28,9 @@
 
             <% if can?(:edit, store) %>
               <% btn_url = store.default? ? '#' : spree.set_default_admin_store_path(store) %>
-              <% btn_class = store.default? ? 'inactive' : 'warning' %>
+              <% btn_class = store.default? ? 'outline-secondary disabled' : 'warning' %>
               <% btn_label = store.default? ? nil : Spree.t(:store_set_default_button) %>
-              <%= link_to_with_icon('save.svg', btn_label, btn_url, no_text: true, method: (store.default? ? nil : :put), class: "btn btn-#{btn_class} btn-sm with-tip") %>
+              <%= link_to_with_icon('save.svg', btn_label, btn_url, no_text: true, method: (store.default? ? nil : :put), class: "btn btn-#{btn_class} btn-sm with-tip", aria: {disabled: store.default?}) %>
             <% end %>
 
             <%= link_to_delete store, no_text: true, url: spree.admin_store_path(store) if can?(:destroy, store) %>


### PR DESCRIPTION
Add class `disabled` and `aria-disabled="true"` to the default store button so that it is not a clickable button if it is already the default store.


<img width="1053" alt="Screenshot 2021-01-17 at 21 28 54" src="https://user-images.githubusercontent.com/1240766/104856522-0ea2e180-590b-11eb-9ad8-1070fad5ce61.png">

This might fail a test or two if there are some looking for the message can't make default store default.

If no tests fail one could be written to check for disabled button or link.