### PR TITLE
[SD-1129] Fixes error after setting certain languages for a store

### DIFF
--- a/backend/app/views/spree/admin/shared/_translations.html.erb
+++ b/backend/app/views/spree/admin/shared/_translations.html.erb
@@ -77,6 +77,9 @@
 %>
 </script>
 
-<% if I18n.locale != :en %>
+<% stripped_locale = I18n.locale.to_s.split('-').first %>
+<% if ['zh-CN', 'zh-TW', 'sr-Cyrl', 'pt-BR'].include?(I18n.locale.to_s) %>
   <%= javascript_include_tag "select2_locale_#{I18n.locale}" %>
+<% else %>
+  <%= javascript_include_tag "select2_locale_#{stripped_locale}" %>
 <% end %>


### PR DESCRIPTION
Select2 supports only those four (`zh-CN`, `zh-TW`, `sr-Cyrl`, `pt-BR`) language variants.