### PR TITLE
Default config locale should be nil

### DIFF
--- a/frontend/app/models/spree/frontend_configuration.rb
+++ b/frontend/app/models/spree/frontend_configuration.rb
@@ -2,7 +2,7 @@ module Spree
   class FrontendConfiguration < Preferences::Configuration
     preference :coupon_codes_enabled, :boolean, default: true # Determines if we show coupon code form at cart and checkout
     preference :http_cache_enabled, :boolean, default: true
-    preference :locale, :string, default: Rails.application.config.i18n.default_locale
+    preference :locale, :string, default: nil
     preference :products_filters, :array, default: %w(keywords price sort_by)
     preference :additional_filters_partials, :array, default: %w()
     preference :remember_me_enabled, :boolean, default: true


### PR DESCRIPTION
Starting with Spree 4.2 locale is Store-based not application wide set