### PR TITLE
Change `includes` to `preload` in Spree::Admin::ImagesController

### DIFF
--- a/backend/app/controllers/spree/admin/images_controller.rb
+++ b/backend/app/controllers/spree/admin/images_controller.rb
@@ -18,11 +18,11 @@ module Spree
       end
 
       def load_index_data
-        @product = Product.friendly.includes(*variant_index_includes).find(params[:product_id])
+        @product = Product.friendly.preload(*variant_index_includes).find(params[:product_id])
       end
 
       def load_edit_data
-        @product = Product.friendly.includes(*variant_edit_includes).find(params[:product_id])
+        @product = Product.friendly.preload(*variant_edit_includes).find(params[:product_id])
         @variants = @product.variants.map do |variant|
           [variant.sku_and_options_text, variant.id]
         end


### PR DESCRIPTION
Since `includes` will try to pick the best strategy for joining the
associated models, it will first try to use `eager_load` and it will fail
because `:viewable` is a polymorphic association. Therefore, we have to tell
rails to use preload as a strategy which can handle a polymorphic association.

[api documentation](https://api.rubyonrails.org/v6.1/classes/ActiveRecord/EagerLoadPolymorphicError.html)