### PR TITLE
Set Common Flatpickr Defaults.

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -120,7 +120,7 @@ jQuery(function ($) {
   $('.js-filterable').each(function () {
     var $this = $(this)
 
-    if ($this.val() !== null && $this.val() !== '' && $this.val().length !== 0 && $this.prop('readonly') !== true) {
+    if ($this.val() !== null && $this.val() !== '' && $this.val().length !== 0 && !$this.hasClass('flatpickr-alt-input')) {
       var ransackValue, filter
       var ransackFieldId = $this.attr('id')
       var label = $('label[for="' + ransackFieldId + '"]')
@@ -223,29 +223,26 @@ $.fn.radioControlsVisibilityOfElement = function (dependentElementSelector) {
 }
 
 document.addEventListener('DOMContentLoaded', function() {
+  flatpickr.setDefaults({
+      altInput: true,
+      time_24hr: true,
+      altInputClass: 'flatpickr-alt-input',
+      locale: Spree.translations.flatpickr_locale
+  })
+
   var dateFrom = flatpickr('.datePickerFrom', {
-    altInput: true,
-    time_24hr: true,
-    locale: Spree.translations.flatpickr_locale,
     onChange: function(selectedDates) {
       dateTo.set('minDate', selectedDates[0])
     }
   })
 
   var dateTo = flatpickr('.datePickerTo', {
-    locale: Spree.translations.flatpickr_locale,
-    time_24hr: true,
-    altInput: true,
     onChange: function(selectedDates) {
       dateFrom.set('maxDate', selectedDates[0])
     }
   })
 
-  flatpickr('.datepicker', {
-    locale: Spree.translations.flatpickr_locale,
-    time_24hr: true,
-    altInput: true
-  })
+  flatpickr('.datepicker', { })
 })
 
 $(document).ready(function() {

--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -224,10 +224,10 @@ $.fn.radioControlsVisibilityOfElement = function (dependentElementSelector) {
 
 document.addEventListener('DOMContentLoaded', function() {
   flatpickr.setDefaults({
-      altInput: true,
-      time_24hr: true,
-      altInputClass: 'flatpickr-alt-input',
-      locale: Spree.translations.flatpickr_locale
+    altInput: true,
+    time_24hr: true,
+    altInputClass: 'flatpickr-alt-input',
+    locale: Spree.translations.flatpickr_locale
   })
 
   var dateFrom = flatpickr('.datePickerFrom', {

--- a/backend/app/assets/stylesheets/spree/backend/global/_mixins.scss
+++ b/backend/app/assets/stylesheets/spree/backend/global/_mixins.scss
@@ -1,0 +1,19 @@
+// Mixin to prefix several properties at once
+
+// EXAMPLE
+// @include prefix((
+//   appearance: none,
+//   touch-callout: none,
+//   user-select: none
+// ), webkit moz ms khtml);
+
+@mixin prefix($declarations, $prefixes: ()) {
+  @each $property, $value in $declarations {
+    @each $prefix in $prefixes {
+      #{'-' + $prefix + '-' + $property}: $value;
+    }
+
+    // Output standard non-prefixed declaration
+    #{$property}: $value;
+  }
+}

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_flatpickr.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_flatpickr.scss
@@ -11,9 +11,10 @@
     }
 
     .flatpickr-monthDropdown-months {
-      -webkit-appearance: none;
-      -moz-appearance: none;
-      appearance: none;
+      @include prefix((
+        appearance: none
+      ), webkit moz ms khtml);
+
       padding: 0.2em;
       border-radius: $border-radius;
     }
@@ -58,7 +59,7 @@
   }
 }
 
-// Mixin Required for calendar toggle icon show/hide.
+// Mixin for calendar toggle icon show/hide.
 @mixin swith-appended-icon {
   &:placeholder-shown:not(:focus) + * {
       @content;
@@ -68,23 +69,18 @@
 .input-group.datePickerFrom,
 .input-group.datePickerTo,
 .input-group.datepicker {
-
   input.flatpickr-alt-input[readonly] {
     // Flatpickr alternate input is read-only,
     // style it as an active input field.
     background-color: white !important;
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    appearance: none;
 
     // Fix a bug where occasionally the whole screen will highlight
     // if you clicked the Flatpcikr input box while moving the cursor.
-    -webkit-touch-callout: none;
-    -webkit-user-select: none;
-    -khtml-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
+    @include prefix((
+      appearance: none,
+      touch-callout: none,
+      user-select: none
+    ), webkit moz ms khtml);
 
     @include swith-appended-icon  {
       opacity: 0;

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_flatpickr.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_flatpickr.scss
@@ -1,108 +1,117 @@
-// Adaptive icon from calendar to close.
+.flatpickr-calendar {
+  // Custom Flatpickr styling for Spree + BS4.
+  .flatpickr-current-month {
+    span.cur-month:hover {
+      background: transparent;
+    }
+      .numInputWrapper {
+      margin-left: 3px;
+      border-radius: $border-radius;
+      overflow: hidden;
+    }
+
+    .flatpickr-monthDropdown-months {
+      -webkit-appearance: none;
+      -moz-appearance: none;
+      appearance: none;
+      padding: 0.2em;
+      border-radius: $border-radius;
+    }
+  }
+
+  .numInputWrapper span.arrowUp {
+    border-color: transparent;
+    border-radius: 0;
+  }
+
+  .numInputWrapper span.arrowDown {
+    border-color: transparent;
+    border-radius: 0;
+  }
+
+  .flatpickr-day {
+    margin: 2px 0;
+    border-radius: $border-radius ;
+  }
+
+  .flatpickr-months .flatpickr-prev-month:hover svg,
+  .flatpickr-months .flatpickr-next-month:hover svg {
+    fill: $primary;
+  }
+
+  .flatpickr-time {
+    border-radius: 0 0 5px 5px;
+    &:after {
+      display: none;
+    }
+    .numInputWrapper {
+      span {
+        border-color: transparent;
+        border-radius: 0;
+      }
+    }
+  }
+
+  // Required to stop an opened cal showing above the nav bar.
+  &.open {
+    z-index: $zindex-dropdown;
+  }
+}
+
+// Mixin Required for calendar toggle icon show/hide.
 @mixin swith-appended-icon {
   &:placeholder-shown:not(:focus) + * {
       @content;
   }
 }
 
-input.flatpickr-alt-input {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: white !important;
-}
+.input-group.datePickerFrom,
+.input-group.datePickerTo,
+.input-group.datepicker {
 
-.flatpickr-current-month .numInputWrapper {
-  margin-left: 3px;
-  border-radius: $border-radius;
-  overflow: hidden;
-}
-.flatpickr-current-month span.cur-month:hover {
-  background: transparent;
-}
-.numInputWrapper span.arrowUp {
-  border-color: transparent;
-  border-radius: 0;
-}
-.numInputWrapper span.arrowDown {
-  border-color: transparent;
-  border-radius: 0;
-}
+  input.flatpickr-alt-input[readonly] {
+    // Flatpickr alternate input is read-only,
+    // style it as an active input field.
+    background-color: white !important;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
 
-.input-group {
-  input.flatpickr-alt-input {
+    // Fix a bug where occasionally the whole screen will highlight
+    // if you clicked the Flatpcikr input box while moving the cursor.
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+
     @include swith-appended-icon  {
       opacity: 0;
     }
   }
-}
 
-.append_under {
-  position: absolute;
-  right: 0;
-  top: 0;
-  z-index: 0;
-  height: 100%;
-}
-
-.flatpickr-day {
-  margin: 2px 0;
-  border-radius: $border-radius ;
-}
-
-// Fix Flatpickr bug where things jusy highlight for no reason.
-input.flatpickr-alt-input[readonly] {
-  -webkit-touch-callout: none; /* iOS Safari */
-    -webkit-user-select: none; /* Safari */
-     -khtml-user-select: none; /* Konqueror HTML */
-       -moz-user-select: none; /* Old versions of Firefox */
-        -ms-user-select: none; /* Internet Explorer/Edge */
-            user-select: none; /* Non-prefixed version, currently
-                                  supported by Chrome, Edge, Opera and Firefox */
-}
-
-
-.flatpickr-months .flatpickr-prev-month:hover svg,
-.flatpickr-months .flatpickr-next-month:hover svg {
-  fill: $primary;
-}
-
-// Force rounded corner for the toggle cal and close icons.
-.input-group >
-.input-group-append:not(:last-child) >
-.force-round {
-  z-index: 5;
-  border-top-right-radius: $border-radius !important;
-  border-bottom-right-radius: $border-radius !important;
-}
-
-.input-group >
-.form-control:not(:first-child), .input-group > .flatpickr-alt-input:not(:first-child) {
-  border-top-left-radius: $border-radius !important;
-  border-bottom-left-radius: $border-radius !important;
-}
-
-div.flatpickr-calendar.open {
-  z-index: $zindex-dropdown;
-}
-
-.flatpickr-time {
-  border-radius: 0 0 5px 5px;
-  &:after {
-    display: none;
+  // Required for calendar toggle icon show/hide.
+  .append_under {
+    position: absolute;
+    right: 0;
+    top: 0;
+    z-index: 0;
+    height: 100%;
   }
-  .numInputWrapper {
-    span {
-      border-color: transparent;
-      border-radius: 0;
-    }
-  }
-}
 
-.flatpickr-current-month .flatpickr-monthDropdown-months {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  padding: 0.2em;
-  border-radius: $border-radius;
+  // Styling for calendar toggle icon toggle
+  .input-group-append:not(:last-child) >
+  .force-round {
+    z-index: 5;
+    border-top-right-radius: $border-radius !important;
+    border-bottom-right-radius: $border-radius !important;
+  }
+
+  // Styling for calendar toggle icon toggle
+  .form-control:not(:first-child),
+  .input-group >.flatpickr-alt-input:not(:first-child) {
+    border-top-left-radius: $border-radius !important;
+    border-bottom-left-radius: $border-radius !important;
+  }
 }

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_flatpickr.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_flatpickr.scss
@@ -5,7 +5,7 @@
   }
 }
 
-input.input {
+input.flatpickr-alt-input {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -30,7 +30,7 @@ input.input {
 }
 
 .input-group {
-  input.input{
+  input.flatpickr-alt-input {
     @include swith-appended-icon  {
       opacity: 0;
     }
@@ -51,7 +51,7 @@ input.input {
 }
 
 // Fix Flatpickr bug where things jusy highlight for no reason.
-input.input[readonly] {
+input.flatpickr-alt-input[readonly] {
   -webkit-touch-callout: none; /* iOS Safari */
     -webkit-user-select: none; /* Safari */
      -khtml-user-select: none; /* Konqueror HTML */
@@ -77,7 +77,7 @@ input.input[readonly] {
 }
 
 .input-group >
-.form-control:not(:first-child), .input-group > .input:not(:first-child) {
+.form-control:not(:first-child), .input-group > .flatpickr-alt-input:not(:first-child) {
   border-top-left-radius: $border-radius !important;
   border-bottom-left-radius: $border-radius !important;
 }

--- a/backend/app/assets/stylesheets/spree/backend/spree_admin.css.scss
+++ b/backend/app/assets/stylesheets/spree/backend/spree_admin.css.scss
@@ -1,4 +1,5 @@
 @import 'global/variables';
+@import 'global/mixins';
 
 @import 'bootstrap';
 @import 'glyphicons';

--- a/core/lib/spree/testing_support/flatpickr_capybara.rb
+++ b/core/lib/spree/testing_support/flatpickr_capybara.rb
@@ -49,7 +49,7 @@ module Spree
       def with_open_flatpickr(label_text)
         field_label = find_field(id: label_text, type: :hidden)
 
-        date_field = field_label.sibling('.input')
+        date_field = field_label.sibling('.flatpickr-alt-input')
         date_field.click # Open the widget
 
         yield(date_field)


### PR DESCRIPTION
### Improve Flatpickr SCSS
- Add a useful vendor prefix SCSS Mixin
- Clean up Flatpicker SCSS

### Improve Flatpickr Javascript
- Set global defaults that are common to all instances of Flatpicker.
- Set a specific class for alt input
- Target that class with tests and other js
