### PR TITLE
Lint Backend JS + Bug Fix

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,3 +25,4 @@ env:
 rules:
   space-before-function-paren: off
   semi: off
+  no-var: off

--- a/.eslintrc
+++ b/.eslintrc
@@ -23,4 +23,6 @@ env:
   jquery: true
 
 rules:
+  space-before-function-paren: off
+  semi: off
   no-var: off

--- a/.eslintrc
+++ b/.eslintrc
@@ -23,6 +23,4 @@ env:
   jquery: true
 
 rules:
-  space-before-function-paren: off
-  semi: off
   no-var: off

--- a/backend/app/assets/javascripts/spree/backend.js
+++ b/backend/app/assets/javascripts/spree/backend.js
@@ -7,6 +7,7 @@
 //= require bootstrap-sprockets
 //= require handlebars
 //= require cleave
+//= require card_formatting
 //= require js.cookie
 //= require jquery.jstree/jquery.jstree
 //= require jquery_ujs

--- a/backend/app/assets/javascripts/spree/backend/address_states.js
+++ b/backend/app/assets/javascripts/spree/backend/address_states.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line camelcase, no-unused-vars
-function update_state(region, done) {
+function update_state (region, done) {
   'use strict'
 
   var countryId = $('#' + region + 'country select').val()

--- a/backend/app/assets/javascripts/spree/backend/adjustments.js
+++ b/backend/app/assets/javascripts/spree/backend/adjustments.js
@@ -15,8 +15,8 @@ $(function () {
     }).done(function () {
       window.location.reload()
     }).fail(function (message) {
-      if (message.responseJSON['error']) {
-        show_flash('error', message.responseJSON['error'])
+      if (message.responseJSON.error) {
+        show_flash('error', message.responseJSON.error)
       } else {
         show_flash('error', 'There was a problem adding this coupon code.')
       }

--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -222,7 +222,7 @@ $.fn.radioControlsVisibilityOfElement = function (dependentElementSelector) {
   })
 }
 
-document.addEventListener('DOMContentLoaded', function () {
+document.addEventListener('DOMContentLoaded', function() {
   flatpickr.setDefaults({
     altInput: true,
     time_24hr: true,
@@ -231,13 +231,13 @@ document.addEventListener('DOMContentLoaded', function () {
   })
 
   var dateFrom = flatpickr('.datePickerFrom', {
-    onChange: function (selectedDates) {
+    onChange: function(selectedDates) {
       dateTo.set('minDate', selectedDates[0])
     }
   })
 
   var dateTo = flatpickr('.datePickerTo', {
-    onChange: function (selectedDates) {
+    onChange: function(selectedDates) {
       dateFrom.set('maxDate', selectedDates[0])
     }
   })

--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -120,7 +120,7 @@ jQuery(function ($) {
   $('.js-filterable').each(function () {
     var $this = $(this)
 
-    if ($this.val() !== null && $this.val() !== '' && $this.val().length !== 0 && $this.prop('readonly') !== true) {
+    if ($this.val() !== null && $this.val() !== '' && $this.val().length !== 0 && !$this.hasClass('flatpickr-alt-input')) {
       var ransackValue, filter
       var ransackFieldId = $this.attr('id')
       var label = $('label[for="' + ransackFieldId + '"]')
@@ -223,29 +223,26 @@ $.fn.radioControlsVisibilityOfElement = function (dependentElementSelector) {
 }
 
 document.addEventListener('DOMContentLoaded', function() {
+  flatpickr.setDefaults({
+      altInput: true,
+      time_24hr: true,
+      altInputClass: 'flatpickr-alt-input',
+      locale: Spree.translations.flatpickr_locale
+  })
+
   var dateFrom = flatpickr('.datePickerFrom', {
-    altInput: true,
-    time_24hr: true,
-    locale: Spree.translations.flatpickr_locale,
     onChange: function(selectedDates) {
       dateTo.set('minDate', selectedDates[0])
     }
   })
 
   var dateTo = flatpickr('.datePickerTo', {
-    locale: Spree.translations.flatpickr_locale,
-    time_24hr: true,
-    altInput: true,
     onChange: function(selectedDates) {
       dateFrom.set('maxDate', selectedDates[0])
     }
   })
 
-  flatpickr('.datepicker', {
-    locale: Spree.translations.flatpickr_locale,
-    time_24hr: true,
-    altInput: true
-  })
+  flatpickr('.datepicker', { })
 })
 
 $(document).ready(function() {

--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -224,10 +224,10 @@ $.fn.radioControlsVisibilityOfElement = function (dependentElementSelector) {
 
 document.addEventListener('DOMContentLoaded', function() {
   flatpickr.setDefaults({
-      altInput: true,
-      time_24hr: true,
-      altInputClass: 'flatpickr-alt-input',
-      locale: Spree.translations.flatpickr_locale
+    altInput: true,
+    time_24hr: true,
+    altInputClass: 'flatpickr-alt-input',
+    locale: Spree.translations.flatpickr_locale
   })
 
   var dateFrom = flatpickr('.datePickerFrom', {

--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -25,8 +25,8 @@ jQuery(function ($) {
   })
 
   // Responsive Menus
-  var body  = $('body')
-  var modalBackdrop  = $('#multi-backdrop')
+  var body = $('body')
+  var modalBackdrop = $('#multi-backdrop')
 
   // Fail safe on resize
   var resizeTimer;
@@ -48,9 +48,9 @@ jQuery(function ($) {
   modalBackdrop.click(closeAllMenus)
 
   // Main Menu Functionality
-  var sidebarOpen    = $('#sidebar-open')
-  var sidebarClose   = $('#sidebar-close')
-  var activeItem     = $('#main-sidebar').find('.selected')
+  var sidebarOpen = $('#sidebar-open')
+  var sidebarClose = $('#sidebar-close')
+  var activeItem = $('#main-sidebar').find('.selected')
 
   activeItem.closest('.nav-sidebar').addClass('active-option')
   activeItem.closest('.nav-pills').addClass('in show')
@@ -137,7 +137,7 @@ jQuery(function ($) {
       var cleanLabel = DOMPurify.sanitize(label)
 
       filter = '<span class="js-filter badge badge-secondary" data-ransack-field="' + ransackFieldId + '">' + cleanLabel + '<i class="icon icon-cancel ml-2 js-delete-filter"></i></span>'
-      $(".js-filters").append(filter).show()
+      $('.js-filters').append(filter).show()
     }
   })
 
@@ -185,7 +185,7 @@ $(document).ready(function () {
   }
 })
 
-$.fn.visible = function (cond) { this[ cond ? 'show' : 'hide' ]() }
+$.fn.visible = function (cond) { this[cond ? 'show' : 'hide']() }
 // Triggers alerts when requested by javascript.
 // eslint-disable-next-line camelcase
 function show_flash (type, message) {
@@ -247,7 +247,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
 $(document).ready(function() {
   $('.observe_field').on('change', function() {
-    target = $(this).data('update')
+    var target = $(this).data('update')
     $(target).hide()
     $.ajax({
       dataType: 'html',
@@ -295,8 +295,8 @@ $(document).ready(function() {
           el.blur()
         }
       }).done(function () {
-        var $flash_element = $('.alert-success')
-        if ($flash_element.length) {
+        var $flashElement = $('.alert-success')
+        if ($flashElement.length) {
           el.parents('tr').fadeOut('hide', function () {
             $(this).remove()
           })
@@ -311,7 +311,7 @@ $(document).ready(function() {
   })
 
   $('body').on('click', 'a.spree_remove_fields', function () {
-    el = $(this)
+    var el = $(this)
     el.prev('input[type=hidden]').val('1')
     el.closest('.fields').hide()
     if (el.prop('href').substr(-1) === '#') {
@@ -337,20 +337,20 @@ $(document).ready(function() {
 
   $('body').on('click', '.select_properties_from_prototype', function() {
     $('#busy_indicator').show()
-    var clicked_link = $(this)
+    var clickedLink = $(this)
     $.ajax({
       dataType: 'script',
-      url: clicked_link.prop('href'),
+      url: clickedLink.prop('href'),
       type: 'GET'
     }).done(function () {
-      clicked_link.parent('td').parent('tr').hide()
+      clickedLink.parent('td').parent('tr').hide()
       $('#busy_indicator').hide()
     })
     return false
   })
 
   // Sortable List Up-Down
-  var parentEl = document.getElementsByClassName("sortable")[0];
+  var parentEl = document.getElementsByClassName('sortable')[0];
   if (parentEl) {
     var element = parentEl.querySelector('tbody')
   }
@@ -360,7 +360,7 @@ $(document).ready(function() {
       handle: '.move-handle',
       animation: 550,
       ghostClass: 'bg-light',
-      dragClass: "sortable-drag-v",
+      dragClass: 'sortable-drag-v',
       easing: 'cubic-bezier(1, 0, 0, 1)',
       swapThreshold: 0.9,
       forceFallback: true,
@@ -368,8 +368,8 @@ $(document).ready(function() {
         var itemEl = evt.item
         var positions = { authenticity_token: AUTH_TOKEN }
         $.each($('tr', element), function(position, obj) {
-          reg = /spree_(\w+_?)+_(\d+)/
-          parts = reg.exec($(obj).prop('id'))
+          var reg = /spree_(\w+_?)+_(\d+)/
+          var parts = reg.exec($(obj).prop('id'))
           if (parts) {
             positions['positions[' + parts[2] + ']'] = position + 1
           }

--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -7,13 +7,13 @@ Hopefully, this will evolve into a propper class.
 /* global AUTH_TOKEN, order_number, Sortable, flatpickr, DOMPurify */
 jQuery(function ($) {
   // Add some tips
-  $('.with-tip').each(function() {
+  $('.with-tip').each(function () {
     $(this).tooltip({
       container: $(this)
     })
   })
 
-  $('.with-tip').on('show.bs.tooltip', function(event) {
+  $('.with-tip').on('show.bs.tooltip', function (event) {
     if (('ontouchstart' in window)) {
       event.preventDefault()
     }
@@ -29,17 +29,17 @@ jQuery(function ($) {
   var modalBackdrop = $('#multi-backdrop')
 
   // Fail safe on resize
-  var resizeTimer;
+  var resizeTimer
   window.addEventListener('resize', function () {
-    document.body.classList.remove('modal-open', 'sidebar-open', 'contextualSideMenu-open');
-    document.body.classList.add('resize-animation-stopper');
-    clearTimeout(resizeTimer);
+    document.body.classList.remove('modal-open', 'sidebar-open', 'contextualSideMenu-open')
+    document.body.classList.add('resize-animation-stopper')
+    clearTimeout(resizeTimer)
     resizeTimer = setTimeout(function () {
-      document.body.classList.remove('resize-animation-stopper');
-    }, 400);
-  });
+      document.body.classList.remove('resize-animation-stopper')
+    }, 400)
+  })
 
-  function closeAllMenus() {
+  function closeAllMenus () {
     body.removeClass()
     body.addClass('admin')
     modalBackdrop.removeClass('show')
@@ -55,7 +55,7 @@ jQuery(function ($) {
   activeItem.closest('.nav-sidebar').addClass('active-option')
   activeItem.closest('.nav-pills').addClass('in show')
 
-  function openMenu() {
+  function openMenu () {
     closeAllMenus()
     body.addClass('sidebar-open modal-open')
     modalBackdrop.addClass('show')
@@ -67,7 +67,7 @@ jQuery(function ($) {
   var contextualSidebarMenuToggle = $('#contextual-menu-toggle')
   var contextualSidebarMenuClose = $('#contextual-menu-close')
 
-  function toggleContextualMenu() {
+  function toggleContextualMenu () {
     if (document.body.classList.contains('contextualSideMenu-open')) {
       closeAllMenus()
     } else {
@@ -127,7 +127,7 @@ jQuery(function ($) {
 
       if ($this.is('select')) {
         ransackValue = $this.find('option:selected').toArray().map(function (option) {
-          return option.text;
+          return option.text
         }).join(', ')
       } else {
         ransackValue = $this.val()
@@ -222,7 +222,7 @@ $.fn.radioControlsVisibilityOfElement = function (dependentElementSelector) {
   })
 }
 
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', function () {
   flatpickr.setDefaults({
     altInput: true,
     time_24hr: true,
@@ -231,13 +231,13 @@ document.addEventListener('DOMContentLoaded', function() {
   })
 
   var dateFrom = flatpickr('.datePickerFrom', {
-    onChange: function(selectedDates) {
+    onChange: function (selectedDates) {
       dateTo.set('minDate', selectedDates[0])
     }
   })
 
   var dateTo = flatpickr('.datePickerTo', {
-    onChange: function(selectedDates) {
+    onChange: function (selectedDates) {
       dateFrom.set('maxDate', selectedDates[0])
     }
   })
@@ -245,8 +245,8 @@ document.addEventListener('DOMContentLoaded', function() {
   flatpickr('.datepicker', { })
 })
 
-$(document).ready(function() {
-  $('.observe_field').on('change', function() {
+$(document).ready(function () {
+  $('.observe_field').on('change', function () {
     var target = $(this).data('update')
     $(target).hide()
     $.ajax({
@@ -291,7 +291,7 @@ $(document).ready(function() {
           authenticity_token: AUTH_TOKEN
         },
         dataType: 'script',
-        complete: function() {
+        complete: function () {
           el.blur()
         }
       }).done(function () {
@@ -335,7 +335,7 @@ $(document).ready(function() {
     return false
   })
 
-  $('body').on('click', '.select_properties_from_prototype', function() {
+  $('body').on('click', '.select_properties_from_prototype', function () {
     $('#busy_indicator').show()
     var clickedLink = $(this)
     $.ajax({
@@ -350,7 +350,7 @@ $(document).ready(function() {
   })
 
   // Sortable List Up-Down
-  var parentEl = document.getElementsByClassName('sortable')[0];
+  var parentEl = document.getElementsByClassName('sortable')[0]
   if (parentEl) {
     var element = parentEl.querySelector('tbody')
   }
@@ -367,7 +367,7 @@ $(document).ready(function() {
       onEnd: function (evt) {
         var itemEl = evt.item
         var positions = { authenticity_token: AUTH_TOKEN }
-        $.each($('tr', element), function(position, obj) {
+        $.each($('tr', element), function (position, obj) {
           var reg = /spree_(\w+_?)+_(\d+)/
           var parts = reg.exec($(obj).prop('id'))
           if (parts) {
@@ -390,7 +390,7 @@ $(document).ready(function() {
   })
 
   // Utility
-  window.Spree.advanceOrder = function() {
+  window.Spree.advanceOrder = function () {
     $.ajax({
       type: 'PUT',
       async: false,
@@ -398,7 +398,7 @@ $(document).ready(function() {
         token: Spree.api_key
       },
       url: Spree.url(Spree.routes.checkouts_api + '/' + order_number + '/advance')
-    }).done(function() {
+    }).done(function () {
       window.location.reload()
     })
   }

--- a/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
+++ b/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
@@ -1,15 +1,15 @@
-function clearAddressFields(addressKinds) {
+function clearAddressFields (addressKinds) {
   if (addressKinds === undefined) {
     addressKinds = ['ship', 'bill']
   }
-  addressKinds.forEach(function(addressKind) {
-    ADDRESS_FIELDS.forEach(function(field) {
+  addressKinds.forEach(function (addressKind) {
+    ADDRESS_FIELDS.forEach(function (field) {
       $('#order_' + addressKind + '_address_attributes_' + field).val('')
     })
   })
 }
 
-function formatCustomerResult(customer) {
+function formatCustomerResult (customer) {
   var escapedResult = window.customerTemplate({
     customer: customer,
     bill_address: customer.bill_address,
@@ -18,7 +18,7 @@ function formatCustomerResult(customer) {
   return $(escapedResult)
 }
 
-function formatCustomerAddress(address, kind) {
+function formatCustomerAddress (address, kind) {
   $('#order_' + kind + '_address_attributes_firstname').val(address.firstname)
   $('#order_' + kind + '_address_attributes_lastname').val(address.lastname)
   $('#order_' + kind + '_address_attributes_address1').val(address.address1)
@@ -33,12 +33,12 @@ function formatCustomerAddress(address, kind) {
 
   var stateSelect = $('#order_' + kind + '_address_attributes_state_id')
 
-  update_state(kind.charAt(0), function() {
+  update_state(kind.charAt(0), function () {
     stateSelect.val(address.state_id).trigger('change')
   })
 }
 
-function formatCustomerSelection(customer) {
+function formatCustomerSelection (customer) {
   $('#order_email').val(customer.email)
   $('#order_user_id').val(customer.id)
   $('#guest_checkout_true').prop('checked', false)
@@ -63,7 +63,7 @@ function formatCustomerSelection(customer) {
   return customer.email
 }
 
-$.fn.customerAutocomplete = function() {
+$.fn.customerAutocomplete = function () {
   this.select2({
     minimumInputLength: 3,
     placeholder: Spree.translations.choose_a_customer,
@@ -89,12 +89,12 @@ $.fn.customerAutocomplete = function() {
     },
     templateResult: formatCustomerResult
   }).on('select2:select', function (e) {
-    var data = e.params.data;
+    var data = e.params.data
     formatCustomerSelection(data)
   })
 }
 
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', function () {
   $('#customer_search').customerAutocomplete()
 
   if ($('#customer_autocomplete_template').length > 0) {

--- a/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
+++ b/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
@@ -73,7 +73,7 @@ $.fn.customerAutocomplete = function() {
       data: function (params) {
         return {
           q: {
-            'm': 'or',
+            m: 'or',
             email_start: params.term,
             ship_address_firstname_start: params.term,
             ship_address_lastname_start: params.term,

--- a/backend/app/assets/javascripts/spree/backend/gateway.js
+++ b/backend/app/assets/javascripts/spree/backend/gateway.js
@@ -2,8 +2,7 @@ $(function () {
   var originalGtwyType = $('#gtwy-type').prop('value')
   $('div#gateway-settings-warning').hide()
   $('#gtwy-type').change(function () {
-    // eslint-disable-next-line
-    if ($('#gtwy-type').prop('value') == originalGtwyType) {
+    if ($('#gtwy-type').prop('value') === originalGtwyType) {
       $('div.gateway-settings').show()
       $('div#gateway-settings-warning').hide()
     } else {

--- a/backend/app/assets/javascripts/spree/backend/general_settings.js
+++ b/backend/app/assets/javascripts/spree/backend/general_settings.js
@@ -13,8 +13,8 @@ $(function () {
         show_flash('success', 'Cache was flushed.')
       })
         .fail(function (message) {
-          if (message.responseJSON['error']) {
-            show_flash('error', message.responseJSON['error'])
+          if (message.responseJSON.error) {
+            show_flash('error', message.responseJSON.error)
           } else {
             show_flash('error', 'There was a problem while flushing cache.')
           }

--- a/backend/app/assets/javascripts/spree/backend/handlebar_extensions.js
+++ b/backend/app/assets/javascripts/spree/backend/handlebar_extensions.js
@@ -5,9 +5,11 @@ Handlebars.registerHelper('t', function (key) {
     console.error('No translation found for ' + key + '. Does it exist within spree/admin/shared/_translations.html.erb?')
   }
 })
+
 Handlebars.registerHelper('edit_product_url', function (productId) {
   return Spree.routes.edit_product(productId)
 })
+
 Handlebars.registerHelper('name_or_presentation', function (optionValue) {
   if (optionValue.option_type_name === 'color') {
     return optionValue.name

--- a/backend/app/assets/javascripts/spree/backend/line_items_on_order_edit.js
+++ b/backend/app/assets/javascripts/spree/backend/line_items_on_order_edit.js
@@ -26,7 +26,7 @@ function addVariant () {
   return 1
 }
 
-var adjustLineItems = function(orderNumber, variantId, quantity) {
+var adjustLineItems = function (orderNumber, variantId, quantity) {
   var url = Spree.routes.orders_api + '/' + orderNumber + '/line_items'
 
   $.ajax({

--- a/backend/app/assets/javascripts/spree/backend/line_items_on_order_edit.js
+++ b/backend/app/assets/javascripts/spree/backend/line_items_on_order_edit.js
@@ -26,27 +26,27 @@ function addVariant () {
   return 1
 }
 
-adjustLineItems = function(order_number, variant_id, quantity){
-    var url = Spree.routes.orders_api + '/' + order_number + '/line_items'
+var adjustLineItems = function(orderNumber, variantId, quantity) {
+  var url = Spree.routes.orders_api + '/' + orderNumber + '/line_items'
 
-    $.ajax({
-      type: 'POST',
-      url: Spree.url(url),
-      data: {
-        line_item: {
-          variant_id: variant_id,
-          quantity: quantity
-        },
-        token: Spree.api_key
-      }
-    }).done(function () {
-        window.Spree.advanceOrder()
-        window.location.reload()
-    }).fail(function (msg) {
-      if (typeof msg.responseJSON.message != 'undefined') {
-        alert(msg.responseJSON.message)
-      } else {
-        alert(msg.responseJSON.exception)
-      }
-    })
+  $.ajax({
+    type: 'POST',
+    url: Spree.url(url),
+    data: {
+      line_item: {
+        variant_id: variantId,
+        quantity: quantity
+      },
+      token: Spree.api_key
+    }
+  }).done(function () {
+    window.Spree.advanceOrder()
+    window.location.reload()
+  }).fail(function (msg) {
+    if (typeof msg.responseJSON.message !== 'undefined') {
+      alert(msg.responseJSON.message)
+    } else {
+      alert(msg.responseJSON.exception)
+    }
+  })
 }

--- a/backend/app/assets/javascripts/spree/backend/option_value_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/option_value_picker.js
@@ -9,13 +9,13 @@ $.fn.optionValueAutocomplete = function (options) {
   var values = options.values
   var clearSelection = options.clearSelection
 
-  function formatOptionValueList(values) {
-    return values.map(function(obj) {
+  function formatOptionValueList (values) {
+    return values.map(function (obj) {
       return { id: obj.id, text: obj.name }
     })
   }
 
-  function addOptions(select, productId, values) {
+  function addOptions (select, productId, values) {
     $.ajax({
       type: 'GET',
       url: Spree.routes.option_values_api,
@@ -49,9 +49,9 @@ $.fn.optionValueAutocomplete = function (options) {
           token: Spree.api_key
         }
 
-        return query;
+        return query
       },
-      processResults: function(data) {
+      processResults: function (data) {
         var results = formatOptionValueList(data)
 
         return {

--- a/backend/app/assets/javascripts/spree/backend/payments/edit.js
+++ b/backend/app/assets/javascripts/spree/backend/payments/edit.js
@@ -96,7 +96,7 @@ jQuery(function ($) {
 
     PaymentView.prototype.$new_button = function (action) {
       return $('<a><i class="icon icon-' + action + '"></i></a>').attr({
-        'class': 'payment-action-' + action + ' btn btn-outline-secondary btn-sm no-filter',
+        class: 'payment-action-' + action + ' btn btn-outline-secondary btn-sm no-filter',
         title: Spree.translations[action]
       }).data({
         action: action

--- a/backend/app/assets/javascripts/spree/backend/payments/new.js
+++ b/backend/app/assets/javascripts/spree/backend/payments/new.js
@@ -1,43 +1,32 @@
 /* global Cleave */
 
-$(document).ready(function () {
-  var CARD_NUMBER_SELECT = '.cardNumber'
-  var CARD_CODE_SELECT = '.cardCode'
-  var CARD_EXPIRATION_SELECT = '.cardExpiry'
-
-  if ($(CARD_EXPIRATION_SELECT).length > 0 &&
-    $(CARD_CODE_SELECT).length > 0 &&
-    $(CARD_NUMBER_SELECT).length > 0) {
-    $(CARD_NUMBER_SELECT).each(function () {
-      var $this = $(this)
-      var cardNumberInputId = '#' + $this.attr('id')
-
+document.addEventListener('DOMContentLoaded', function () {
+  if (document.querySelector('.cardNumber')) {
+    document.querySelectorAll('.cardNumber').forEach(function (cardNumber) {
       // eslint-disable-next-line no-new
-      new Cleave(cardNumberInputId, {
+      new Cleave(cardNumber, {
         creditCard: true,
         onCreditCardTypeChanged: function (type) {
           $('.ccType').val(type)
         }
       })
     })
+  }
 
-    $(CARD_EXPIRATION_SELECT).each(function () {
-      var $this = $(this)
-      var cardExpiryInputId = '#' + $this.attr('id')
-
-      /* eslint-disable no-new */
-      new Cleave(cardExpiryInputId, {
+  if (document.querySelector('.cardExpiry')) {
+    document.querySelectorAll('.cardExpiry').forEach(function (cardExpiry) {
+      // eslint-disable-next-line no-new
+      new Cleave(cardExpiry, {
         date: true,
         datePattern: ['m', Spree.translations.card_expire_year_format]
       })
     })
+  }
 
-    $(CARD_CODE_SELECT).each(function () {
-      var $this = $(this)
-      var cardCodeInputId = '#' + $this.attr('id')
-
-      /* eslint-disable no-new */
-      new Cleave(cardCodeInputId, {
+  if (document.querySelector('.cardCode')) {
+    document.querySelectorAll('.cardCode').forEach(function (cardCode) {
+      // eslint-disable-next-line no-new
+      new Cleave(cardCode, {
         numericOnly: true,
         blocks: [3]
       })

--- a/backend/app/assets/javascripts/spree/backend/payments/new.js
+++ b/backend/app/assets/javascripts/spree/backend/payments/new.js
@@ -2,12 +2,12 @@
 
 $(document).ready(function () {
   var CARD_NUMBER_SELECTOR = '.cardNumber'
-  var CARD_EXPIRATION_SELECTOR = '.cardExpiry'
   var CARD_CODE_SELECTOR = '.cardCode'
+  var CARD_EXPIRATION_SELECTOR = '.cardExpiry'
 
-  if ($(CARD_NUMBER_SELECTOR).length > 0 &&
-    $(CARD_EXPIRATION_SELECTOR).length > 0 &&
-    $(CARD_CODE_SELECTOR).length > 0) {
+  if ($(CARD_EXPIRATION_SELECTOR).length > 0 &&
+    $(CARD_CODE_SELECTOR).length > 0 &&
+    $(CARD_NUMBER_SELECTOR).length > 0) {
     $(CARD_NUMBER_SELECTOR).each(function () {
       var $this = $(this)
       var cardNumberInputId = '#' + $this.attr('id')

--- a/backend/app/assets/javascripts/spree/backend/payments/new.js
+++ b/backend/app/assets/javascripts/spree/backend/payments/new.js
@@ -1,6 +1,6 @@
 /* global formatCardNumber, formatCardExpiry, formatCardCode */
 
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', function () {
   var cardPaymetnContainerEl = '.payment-gateway-fields'
 
   formatCardNumber(cardPaymetnContainerEl, '.cardNumber', '.ccType')

--- a/backend/app/assets/javascripts/spree/backend/payments/new.js
+++ b/backend/app/assets/javascripts/spree/backend/payments/new.js
@@ -2,8 +2,8 @@
 
 $(document).ready(function () {
   if ($('#new_payment').length) {
-    /* eslint-disable no-new */
-    new Cleave('.cardNumber', {
+    // eslint-disable-next-line no-unused-vars
+    var cleveCardNumber = new Cleave('.cardNumber', {
       creditCard: true,
       onCreditCardTypeChanged: function (type) {
         $('.ccType').val(type)

--- a/backend/app/assets/javascripts/spree/backend/payments/new.js
+++ b/backend/app/assets/javascripts/spree/backend/payments/new.js
@@ -28,7 +28,7 @@ $(document).ready(function () {
       /* eslint-disable no-new */
       new Cleave(cardExpiryInputId, {
         date: true,
-        datePattern: ['m', 'Y']
+        datePattern: ['m', Spree.translations.card_expire_year_format]
       })
     })
 

--- a/backend/app/assets/javascripts/spree/backend/payments/new.js
+++ b/backend/app/assets/javascripts/spree/backend/payments/new.js
@@ -2,22 +2,39 @@
 
 $(document).ready(function () {
   if ($('#new_payment').length) {
-    // eslint-disable-next-line no-unused-vars
-    var cleveCardNumber = new Cleave('.cardNumber', {
-      creditCard: true,
-      onCreditCardTypeChanged: function (type) {
-        $('.ccType').val(type)
-      }
+    $('.cardNumber').each(function () {
+      var $this = $(this)
+      var cardNumberInputId = '#' + $this.attr('id')
+
+      // eslint-disable-next-line no-new
+      new Cleave(cardNumberInputId, {
+        creditCard: true,
+        onCreditCardTypeChanged: function (type) {
+          $('.ccType').val(type)
+        }
+      })
     })
-    /* eslint-disable no-new */
-    new Cleave('.cardExpiry', {
-      date: true,
-      datePattern: ['m', 'Y']
+
+    $('.cardExpiry').each(function () {
+      var $this = $(this)
+      var cardExpiryInputId = '#' + $this.attr('id')
+
+      /* eslint-disable no-new */
+      new Cleave(cardExpiryInputId, {
+        date: true,
+        datePattern: ['m', 'Y']
+      })
     })
-    /* eslint-disable no-new */
-    new Cleave('.cardCode', {
-      numericOnly: true,
-      blocks: [3]
+
+    $('.cardCode').each(function () {
+      var $this = $(this)
+      var cardCodeInputId = '#' + $this.attr('id')
+
+      /* eslint-disable no-new */
+      new Cleave(cardCodeInputId, {
+        numericOnly: true,
+        blocks: [3]
+      })
     })
 
     $('.payment_methods_radios').click(

--- a/backend/app/assets/javascripts/spree/backend/payments/new.js
+++ b/backend/app/assets/javascripts/spree/backend/payments/new.js
@@ -21,7 +21,7 @@ $(document).ready(function () {
       })
     })
 
-    $(CARD_EXPIRATION_SELECTOR).each(function () {
+    $(CARD_EXPIRATION_SELECT).each(function () {
       var $this = $(this)
       var cardExpiryInputId = '#' + $this.attr('id')
 
@@ -32,7 +32,7 @@ $(document).ready(function () {
       })
     })
 
-    $(CARD_CODE_SELECTOR).each(function () {
+    $(CARD_CODE_SELECT).each(function () {
       var $this = $(this)
       var cardCodeInputId = '#' + $this.attr('id')
 

--- a/backend/app/assets/javascripts/spree/backend/payments/new.js
+++ b/backend/app/assets/javascripts/spree/backend/payments/new.js
@@ -1,8 +1,14 @@
 /* global Cleave */
 
 $(document).ready(function () {
-  if ($('#new_payment').length) {
-    $('.cardNumber').each(function () {
+  var CARD_NUMBER_SELECTOR = '.cardNumber'
+  var CARD_EXPIRATION_SELECTOR = '.cardExpiry'
+  var CARD_CODE_SELECTOR = '.cardCode'
+
+  if ($(CARD_NUMBER_SELECTOR).length > 0 &&
+    $(CARD_EXPIRATION_SELECTOR).length > 0 &&
+    $(CARD_CODE_SELECTOR).length > 0) {
+    $(CARD_NUMBER_SELECTOR).each(function () {
       var $this = $(this)
       var cardNumberInputId = '#' + $this.attr('id')
 
@@ -15,7 +21,7 @@ $(document).ready(function () {
       })
     })
 
-    $('.cardExpiry').each(function () {
+    $(CARD_EXPIRATION_SELECTOR).each(function () {
       var $this = $(this)
       var cardExpiryInputId = '#' + $this.attr('id')
 
@@ -26,7 +32,7 @@ $(document).ready(function () {
       })
     })
 
-    $('.cardCode').each(function () {
+    $(CARD_CODE_SELECTOR).each(function () {
       var $this = $(this)
       var cardCodeInputId = '#' + $this.attr('id')
 
@@ -36,32 +42,32 @@ $(document).ready(function () {
         blocks: [3]
       })
     })
-
-    $('.payment_methods_radios').click(
-      function () {
-        $('.payment-methods').hide()
-        $('.payment-methods :input').prop('disabled', true)
-        if (this.checked) {
-          $('#payment_method_' + this.value + ' :input').prop('disabled', false)
-          $('#payment_method_' + this.value).show()
-        }
-      }
-    )
-
-    $('.payment_methods_radios').each(
-      function () {
-        if (this.checked) {
-          $('#payment_method_' + this.value + ' :input').prop('disabled', false)
-          $('#payment_method_' + this.value).show()
-        } else {
-          $('#payment_method_' + this.value).hide()
-          $('#payment_method_' + this.value + ' :input').prop('disabled', true)
-        }
-
-        if ($('#card_new' + this.value).is('*')) {
-          $('#card_new' + this.value).radioControlsVisibilityOfElement('#card_form' + this.value)
-        }
-      }
-    )
   }
+
+  $('.payment_methods_radios').click(
+    function () {
+      $('.payment-methods').hide()
+      $('.payment-methods :input').prop('disabled', true)
+      if (this.checked) {
+        $('#payment_method_' + this.value + ' :input').prop('disabled', false)
+        $('#payment_method_' + this.value).show()
+      }
+    }
+  )
+
+  $('.payment_methods_radios').each(
+    function () {
+      if (this.checked) {
+        $('#payment_method_' + this.value + ' :input').prop('disabled', false)
+        $('#payment_method_' + this.value).show()
+      } else {
+        $('#payment_method_' + this.value).hide()
+        $('#payment_method_' + this.value + ' :input').prop('disabled', true)
+      }
+
+      if ($('#card_new' + this.value).is('*')) {
+        $('#card_new' + this.value).radioControlsVisibilityOfElement('#card_form' + this.value)
+      }
+    }
+  )
 })

--- a/backend/app/assets/javascripts/spree/backend/payments/new.js
+++ b/backend/app/assets/javascripts/spree/backend/payments/new.js
@@ -1,62 +1,38 @@
-/* global Cleave */
+/* global formatCardNumber, formatCardExpiry, formatCardCode */
 
-document.addEventListener('DOMContentLoaded', function () {
-  if (document.querySelector('.cardNumber')) {
-    document.querySelectorAll('.cardNumber').forEach(function (cardNumber) {
-      // eslint-disable-next-line no-new
-      new Cleave(cardNumber, {
-        creditCard: true,
-        onCreditCardTypeChanged: function (type) {
-          $('.ccType').val(type)
+document.addEventListener('DOMContentLoaded', function() {
+  var cardPaymetnContainerEl = '.payment-gateway-fields'
+
+  formatCardNumber(cardPaymetnContainerEl, '.cardNumber', '.ccType')
+  formatCardExpiry(cardPaymetnContainerEl, '.cardExpiry')
+  formatCardCode(cardPaymetnContainerEl, '.cardCode')
+
+  if ($('#new_payment').length) {
+    $('.payment_methods_radios').click(
+      function () {
+        $('.payment-methods').hide()
+        $('.payment-methods :input').prop('disabled', true)
+        if (this.checked) {
+          $('#payment_method_' + this.value + ' :input').prop('disabled', false)
+          $('#payment_method_' + this.value).show()
         }
-      })
-    })
-  }
-
-  if (document.querySelector('.cardExpiry')) {
-    document.querySelectorAll('.cardExpiry').forEach(function (cardExpiry) {
-      // eslint-disable-next-line no-new
-      new Cleave(cardExpiry, {
-        date: true,
-        datePattern: ['m', Spree.translations.card_expire_year_format]
-      })
-    })
-  }
-
-  if (document.querySelector('.cardCode')) {
-    document.querySelectorAll('.cardCode').forEach(function (cardCode) {
-      // eslint-disable-next-line no-new
-      new Cleave(cardCode, {
-        numericOnly: true,
-        blocks: [3]
-      })
-    })
-  }
-
-  $('.payment_methods_radios').click(
-    function () {
-      $('.payment-methods').hide()
-      $('.payment-methods :input').prop('disabled', true)
-      if (this.checked) {
-        $('#payment_method_' + this.value + ' :input').prop('disabled', false)
-        $('#payment_method_' + this.value).show()
       }
-    }
-  )
+    )
 
-  $('.payment_methods_radios').each(
-    function () {
-      if (this.checked) {
-        $('#payment_method_' + this.value + ' :input').prop('disabled', false)
-        $('#payment_method_' + this.value).show()
-      } else {
-        $('#payment_method_' + this.value).hide()
-        $('#payment_method_' + this.value + ' :input').prop('disabled', true)
-      }
+    $('.payment_methods_radios').each(
+      function () {
+        if (this.checked) {
+          $('#payment_method_' + this.value + ' :input').prop('disabled', false)
+          $('#payment_method_' + this.value).show()
+        } else {
+          $('#payment_method_' + this.value).hide()
+          $('#payment_method_' + this.value + ' :input').prop('disabled', true)
+        }
 
-      if ($('#card_new' + this.value).is('*')) {
-        $('#card_new' + this.value).radioControlsVisibilityOfElement('#card_form' + this.value)
+        if ($('#card_new' + this.value).is('*')) {
+          $('#card_new' + this.value).radioControlsVisibilityOfElement('#card_form' + this.value)
+        }
       }
-    }
-  )
+    )
+  }
 })

--- a/backend/app/assets/javascripts/spree/backend/payments/new.js
+++ b/backend/app/assets/javascripts/spree/backend/payments/new.js
@@ -1,14 +1,14 @@
 /* global Cleave */
 
 $(document).ready(function () {
-  var CARD_NUMBER_SELECTOR = '.cardNumber'
-  var CARD_CODE_SELECTOR = '.cardCode'
-  var CARD_EXPIRATION_SELECTOR = '.cardExpiry'
+  var CARD_NUMBER_SELECT = '.cardNumber'
+  var CARD_CODE_SELECT = '.cardCode'
+  var CARD_EXPIRATION_SELECT = '.cardExpiry'
 
-  if ($(CARD_EXPIRATION_SELECTOR).length > 0 &&
-    $(CARD_CODE_SELECTOR).length > 0 &&
-    $(CARD_NUMBER_SELECTOR).length > 0) {
-    $(CARD_NUMBER_SELECTOR).each(function () {
+  if ($(CARD_EXPIRATION_SELECT).length > 0 &&
+    $(CARD_CODE_SELECT).length > 0 &&
+    $(CARD_NUMBER_SELECT).length > 0) {
+    $(CARD_NUMBER_SELECT).each(function () {
       var $this = $(this)
       var cardNumberInputId = '#' + $this.attr('id')
 

--- a/backend/app/assets/javascripts/spree/backend/product_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/product_picker.js
@@ -6,13 +6,13 @@ $.fn.productAutocomplete = function (options) {
   var multiple = typeof (options.multiple) !== 'undefined' ? options.multiple : true
   var values = typeof (options.values) !== 'undefined' ? options.values : null
 
-  function formatProductList(products) {
-    return products.map(function(obj) {
+  function formatProductList (products) {
+    return products.map(function (obj) {
       return { id: obj.id, text: obj.name }
     })
   }
 
-  function addOptions(select, values) {
+  function addOptions (select, values) {
     $.ajax({
       url: Spree.routes.products_api,
       dataType: 'json',
@@ -42,7 +42,7 @@ $.fn.productAutocomplete = function (options) {
           token: Spree.api_key
         }
       },
-      processResults: function(data) {
+      processResults: function (data) {
         var products = data.products ? data.products : []
         var results = formatProductList(products)
 
@@ -51,7 +51,7 @@ $.fn.productAutocomplete = function (options) {
         }
       }
     },
-    templateSelection: function(data, _container) {
+    templateSelection: function (data, _container) {
       return data.text
     }
   })

--- a/backend/app/assets/javascripts/spree/backend/promotions.js
+++ b/backend/app/assets/javascripts/spree/backend/promotions.js
@@ -143,12 +143,12 @@ function initProductActions () {
     // Add line item to list
     $('.promotion_action.create_line_items button.add').off('click').click(function () {
       var $container = $(this).parents('.promotion_action')
-      var product_name = $container.find('input[name="add_product_name"]').val()
-      var variant_id = $container.find('input[name="add_variant_id"]').val()
+      var productName = $container.find('input[name="add_product_name"]').val()
+      var variantId = $container.find('input[name="add_variant_id"]').val()
       var quantity = $container.find('input[name="add_quantity"]').val()
-      if (variant_id) {
+      if (variantId) {
         // Add to the table
-        var newRow = '<tr><td>' + product_name + '</td><td>' + quantity + '</td><td><i class="icon icon-cancel"></i></td></tr>'
+        var newRow = '<tr><td>' + productName + '</td><td>' + quantity + '</td><td><i class="icon icon-cancel"></i></td></tr>'
         $container.find('table').append(newRow)
         // Add to serialized string in hidden text field
         var $hiddenField = $container.find('.line_items_string')
@@ -162,9 +162,9 @@ function initProductActions () {
 }
 
 $(document).ready(function () {
-  var promotion_form = $('form.edit_promotion')
+  var promotionForm = $('form.edit_promotion')
 
-  if (promotion_form.length) {
+  if (promotionForm.length) {
     initProductActions()
   }
 })

--- a/backend/app/assets/javascripts/spree/backend/promotions.js
+++ b/backend/app/assets/javascripts/spree/backend/promotions.js
@@ -49,7 +49,7 @@ function initProductActions () {
       var valuesSelect = optionValue.find('.js-promo-rule-option-value-option-values-select')
 
       productSelect.productAutocomplete({ multiple: false, values: productId })
-      productSelect.on('select2:select', function(e) {
+      productSelect.on('select2:select', function (e) {
         valuesSelect.attr('disabled', false).removeClass('d-none').addClass('d-block')
         valuesSelect.attr('name', optionValueSelectNameTemplate({ productId: productSelect.val() }).trim())
         valuesSelect.optionValueAutocomplete({
@@ -57,7 +57,7 @@ function initProductActions () {
           productSelect: productSelect,
           multiple: true,
           values: values,
-          clearSelection: productId != productSelect.val()
+          clearSelection: productId !== productSelect.val()
         })
       })
     }

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -115,7 +115,7 @@ $(document).ready(function () {
     })
   })
 
-  function toggleTrackingEdit(event) {
+  function toggleTrackingEdit (event) {
     event.preventDefault()
 
     var link = $(this)
@@ -127,7 +127,7 @@ $(document).ready(function () {
   $('a.edit-tracking').click(toggleTrackingEdit)
   $('a.cancel-tracking').click(toggleTrackingEdit)
 
-  function createTrackingValueContent(data) {
+  function createTrackingValueContent (data) {
     var selectedShippingMethod = data.shipping_methods.filter(function (method) {
       return method.id === data.selected_shipping_rate.shipping_method_id
     })[0]
@@ -173,7 +173,7 @@ $(document).ready(function () {
   })
 })
 
-function adjustShipmentItems(shipmentNumber, variantId, quantity) {
+function adjustShipmentItems (shipmentNumber, variantId, quantity) {
   var shipment = _.findWhere(shipments, { number: shipmentNumber + '' })
   var inventoryUnits = _.where(shipment.inventory_units, { variant_id: variantId })
   var url = Spree.routes.shipments_api + '/' + shipmentNumber
@@ -208,7 +208,7 @@ function adjustShipmentItems(shipmentNumber, variantId, quantity) {
   }
 }
 
-function toggleMethodEdit() {
+function toggleMethodEdit () {
   var link = $(this)
   link.parents('tbody').find('tr.edit-method').toggle()
   link.parents('tbody').find('tr.show-method').toggle()
@@ -216,7 +216,7 @@ function toggleMethodEdit() {
   return false
 }
 
-function toggleItemEdit() {
+function toggleItemEdit () {
   var link = $(this)
   var linkParent = link.parent()
   linkParent.find('a.edit-item').toggle()
@@ -230,7 +230,7 @@ function toggleItemEdit() {
   return false
 }
 
-function startItemSplit(event) {
+function startItemSplit (event) {
   event.preventDefault()
   $('.cancel-split').each(function () {
     $(this).click()
@@ -267,7 +267,7 @@ function startItemSplit(event) {
   $('#item_stock_location').select2({ width: 'resolve', placeholder: Spree.translations.item_stock_placeholder })
 }
 
-function completeItemSplit(event) {
+function completeItemSplit (event) {
   event.preventDefault()
 
   if ($('#item_stock_location').val() === '') {
@@ -320,7 +320,7 @@ function completeItemSplit(event) {
   }
 }
 
-function cancelItemSplit(event) {
+function cancelItemSplit (event) {
   event.preventDefault()
   var link = $(this)
   var prevRow = link.closest('tr').prev()
@@ -330,7 +330,7 @@ function cancelItemSplit(event) {
   prevRow.find('a.delete-item').toggle()
 }
 
-function addVariantFromStockLocation(event) {
+function addVariantFromStockLocation (event) {
   event.preventDefault()
 
   $('#stock_details').hide()

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -12,7 +12,6 @@ $(document).ready(function () {
 
     $('#stock_details').html(variantStockTemplate({ variant: variant }))
     $('#stock_details').show()
-
     $('button.add_variant').click(addVariantFromStockLocation)
   })
 

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -248,12 +248,12 @@ function startItemSplit(event) {
     url: Spree.url(Spree.routes.variants_api),
     data: {
       q: {
-        'id_eq': variantId
+        id_eq: variantId
       },
       token: Spree.api_key
     }
   }).done(function (data) {
-    variant = data['variants'][0]
+    variant = data.variants[0]
   }).fail(function (msg) {
     alert(msg.responseJSON.message || msg.responseJSON.exception)
   })

--- a/backend/app/assets/javascripts/spree/backend/spree-select2.js
+++ b/backend/app/assets/javascripts/spree/backend/spree-select2.js
@@ -1,4 +1,4 @@
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', function () {
   // Initiate a standard Select2 on any select element with the class .select2
   // Remember to add a place holder in the HTML as needed.
   $('select.select2').select2({})
@@ -15,13 +15,13 @@ document.addEventListener('DOMContentLoaded', function() {
 $.fn.addSelect2Options = function (data) {
   var select = this
 
-  function appendOption(select, data) {
+  function appendOption (select, data) {
     var option = new Option(data.name, data.id, true, true)
     select.append(option).trigger('change')
   }
 
   if (Array.isArray(data)) {
-    data.map(function(row) {
+    data.map(function (row) {
       return appendOption(select, row)
     })
   } else {

--- a/backend/app/assets/javascripts/spree/backend/spree-select2.js
+++ b/backend/app/assets/javascripts/spree/backend/spree-select2.js
@@ -22,7 +22,7 @@ $.fn.addSelect2Options = function (data) {
 
   if (Array.isArray(data)) {
     data.map(function(row) {
-      appendOption(select, row)
+      return appendOption(select, row)
     })
   } else {
     appendOption(select, data)

--- a/backend/app/assets/javascripts/spree/backend/stock_transfer.js
+++ b/backend/app/assets/javascripts/spree/backend/stock_transfer.js
@@ -127,11 +127,11 @@ $(function () {
     }
   }
 
-  function formattedVariantList(obj) {
+  function formattedVariantList (obj) {
     return { id: obj.id, text: obj.name, name: obj.name, sku: obj.sku, options_text: obj.options_text, variant: obj }
   }
 
-  function formattedStockItemsList(obj) {
+  function formattedStockItemsList (obj) {
     return { id: obj.variant.id, text: obj.variant.name, name: obj.variant.name, sku: obj.variant.sku, options_text: obj.variant.options_text, variant: obj.variant }
   }
 
@@ -163,7 +163,7 @@ $(function () {
           }
         }
       },
-      templateResult: function(variant) {
+      templateResult: function (variant) {
         if (variant.options_text !== '') {
           return variant.name + ' - ' + variant.sku + ' (' + variant.options_text + ')'
         } else {

--- a/backend/app/assets/javascripts/spree/backend/stock_transfer.js
+++ b/backend/app/assets/javascripts/spree/backend/stock_transfer.js
@@ -128,7 +128,7 @@ $(function () {
   }
 
   function formattedVariantList(obj) {
-   return { id: obj.id, text: obj.name, name: obj.name, sku: obj.sku, options_text: obj.options_text, variant: obj }
+    return { id: obj.id, text: obj.name, name: obj.name, sku: obj.sku, options_text: obj.options_text, variant: obj }
   }
 
   function formattedStockItemsList(obj) {
@@ -151,23 +151,20 @@ $(function () {
         },
         processResults: function (data) {
           var result = data.variants || data.stock_items
-          if (data.variants != null) {
-            var res = (result).map(function (variant) {
+          var res = (result).map(function (variant) {
+            if (data.variants != null) {
               return formattedVariantList(variant)
-            })
-          } else {
-            var res = (result).map(function (variant) {
+            } else {
               return formattedStockItemsList(variant)
-            })
-          }
-
+            }
+          })
           return {
             results: res
           }
         }
       },
       templateResult: function(variant) {
-        if (variant.options_text !== "") {
+        if (variant.options_text !== '') {
           return variant.name + ' - ' + variant.sku + ' (' + variant.options_text + ')'
         } else {
           return variant.name + ' - ' + variant.sku

--- a/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js
+++ b/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js
@@ -20,7 +20,7 @@ $.fn.taxonAutocomplete = function() {
       data: function (params) {
         return {
           q: {
-            name_cont: params.term,
+            name_cont: params.term
           },
           token: Spree.api_key
         }

--- a/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js
+++ b/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js
@@ -1,7 +1,7 @@
-$.fn.taxonAutocomplete = function() {
+$.fn.taxonAutocomplete = function () {
   'use strict'
 
-  function formatTaxonList(values) {
+  function formatTaxonList (values) {
     return values.map(function (obj) {
       return {
         id: obj.id,
@@ -25,7 +25,7 @@ $.fn.taxonAutocomplete = function() {
           token: Spree.api_key
         }
       },
-      processResults: function(data) {
+      processResults: function (data) {
         return {
           results: formatTaxonList(data.taxons)
         }

--- a/backend/app/assets/javascripts/spree/backend/taxonomy.js
+++ b/backend/app/assets/javascripts/spree/backend/taxonomy.js
@@ -101,7 +101,7 @@ var root = typeof exports !== 'undefined' && exports !== null ? exports : this
 
 root.setup_taxonomy_tree = function (taxonomyId) {
   var $taxonomyTree = $('#taxonomy_tree')
-  if (taxonomyId !== void 0) {
+  if (taxonomyId !== undefined) {
     // this is defined within admin/taxonomies/edit
     root.base_url = Spree.url(Spree.routes.taxonomy_taxons_path)
     $.ajax({

--- a/backend/app/assets/javascripts/spree/backend/taxons.js
+++ b/backend/app/assets/javascripts/spree/backend/taxons.js
@@ -72,31 +72,26 @@ $(function () {
       }).done(function (data) {
         var i, j, len, len1, product, ref, ref1, results, variant
         el.empty()
-        if (data.products.length === 0) {
-          return $('#taxon_products').html('<div class="alert alert-info">' + Spree.translations.no_results + '</div>')
-        } else {
-          ref = data.products
-          results = []
-          for (i = 0, len = ref.length; i < len; i++) {
-            product = ref[i]
-            if (product.master.images[0] !== undefined && product.master.images[0].small_url !== undefined) {
-              product.image = product.master.images[0].small_url
-            } else {
-              ref1 = product.variants
-              for (j = 0, len1 = ref1.length; j < len1; j++) {
-                variant = ref1[j]
-                if (variant.images[0] !== undefined && variant.images[0].small_url !== undefined) {
-                  product.image = variant.images[0].small_url
-                  break
-                }
+        if (data.products.length === 0) return $('#taxon_products').html('<div class="alert alert-info">' + Spree.translations.no_results + '</div>')
+        ref = data.products
+        results = []
+        for (i = 0, len = ref.length; i < len; i++) {
+          product = ref[i]
+          if (product.master.images[0] !== undefined && product.master.images[0].small_url !== undefined) {
+            product.image = product.master.images[0].small_url
+          } else {
+            ref1 = product.variants
+            for (j = 0, len1 = ref1.length; j < len1; j++) {
+              variant = ref1[j]
+              if (variant.images[0] !== undefined && variant.images[0].small_url !== undefined) {
+                product.image = variant.images[0].small_url
+                break
               }
             }
-            results.push(el.append(productTemplate({
-              product: product
-            })))
           }
-          return results
+          results.push(el.append(productTemplate({ product: product })))
         }
+        return results
       })
     })
   }

--- a/backend/app/assets/javascripts/spree/backend/taxons.js
+++ b/backend/app/assets/javascripts/spree/backend/taxons.js
@@ -79,13 +79,13 @@ $(function () {
           results = []
           for (i = 0, len = ref.length; i < len; i++) {
             product = ref[i]
-            if (product.master.images[0] !== void 0 && product.master.images[0].small_url !== void 0) {
+            if (product.master.images[0] !== undefined && product.master.images[0].small_url !== undefined) {
               product.image = product.master.images[0].small_url
             } else {
               ref1 = product.variants
               for (j = 0, len1 = ref1.length; j < len1; j++) {
                 variant = ref1[j]
-                if (variant.images[0] !== void 0 && variant.images[0].small_url !== void 0) {
+                if (variant.images[0] !== undefined && variant.images[0].small_url !== undefined) {
                   product.image = variant.images[0].small_url
                   break
                 }

--- a/backend/app/assets/javascripts/spree/backend/taxons.js
+++ b/backend/app/assets/javascripts/spree/backend/taxons.js
@@ -128,12 +128,12 @@ $(function () {
 
   function formatTaxon (taxon) {
     if (taxon.loading) {
-      return taxon.text;
+      return taxon.text
     }
     return taxon.pretty_name
   }
 
-  function formatTaxonList(values) {
+  function formatTaxonList (values) {
     return values.map(function (obj) {
       return {
         id: obj.id,

--- a/backend/app/assets/javascripts/spree/backend/user_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/user_picker.js
@@ -1,7 +1,7 @@
 $.fn.userAutocomplete = function () {
   'use strict'
 
-  function formatUserList(values) {
+  function formatUserList (values) {
     return values.map(function (obj) {
       return {
         id: obj.id,
@@ -24,7 +24,7 @@ $.fn.userAutocomplete = function () {
           token: Spree.api_key
         }
       },
-      processResults: function(data) {
+      processResults: function (data) {
         return {
           results: formatUserList(data.users)
         }

--- a/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js
+++ b/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js
@@ -39,7 +39,7 @@ $.fn.variantAutocomplete = function () {
           token: Spree.api_key
         }
 
-        return query;
+        return query
       },
       processResults: function (data) {
         window.variants = data.variants

--- a/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js
+++ b/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js
@@ -14,7 +14,7 @@ function formatVariantResult(variant) {
     return variant.text
   }
 
-  if (variant['images'][0] !== undefined && variant['images'][0].mini_url !== undefined) {
+  if (variant.images[0] !== undefined && variant.images[0].mini_url !== undefined) {
     variant.image = variant.images[0].mini_url
   }
   return $(variantTemplate({
@@ -23,7 +23,6 @@ function formatVariantResult(variant) {
 }
 
 $.fn.variantAutocomplete = function () {
-
   // deal with initSelection
   return this.select2({
     placeholder: Spree.translations.variant_placeholder,
@@ -43,7 +42,7 @@ $.fn.variantAutocomplete = function () {
         return query;
       },
       processResults: function(data) {
-        window.variants = data['variants']
+        window.variants = data.variants
         return {
           results: data.variants
         }
@@ -51,12 +50,11 @@ $.fn.variantAutocomplete = function () {
     },
     templateResult: formatVariantResult,
     templateSelection: function(variant) {
-      if (!!variant.options_text) {
+      if (variant.options_text) {
         return variant.name + '(' + variant.options_text + ')'
       } else {
         return variant.name
       }
     }
   })
-
 }

--- a/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js
+++ b/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js
@@ -9,7 +9,7 @@ $(function () {
   }
 })
 
-function formatVariantResult(variant) {
+function formatVariantResult (variant) {
   if (variant.loading) {
     return variant.text
   }
@@ -41,7 +41,7 @@ $.fn.variantAutocomplete = function () {
 
         return query;
       },
-      processResults: function(data) {
+      processResults: function (data) {
         window.variants = data.variants
         return {
           results: data.variants
@@ -49,7 +49,7 @@ $.fn.variantAutocomplete = function () {
       }
     },
     templateResult: formatVariantResult,
-    templateSelection: function(variant) {
+    templateSelection: function (variant) {
       if (variant.options_text) {
         return variant.name + '(' + variant.options_text + ')'
       } else {

--- a/backend/app/assets/javascripts/spree/backend/zone.js
+++ b/backend/app/assets/javascripts/spree/backend/zone.js
@@ -1,4 +1,4 @@
-document.addEventListener('DOMContentLoaded', function () {
+document.addEventListener('DOMContentLoaded', function ( ) {
   var typeRadioButtons = "input[name='zone[kind]']"
   var radioSelected = document.querySelector(typeRadioButtons + ':checked').value
   var shownZoneMembers = radioSelected + '_members'

--- a/backend/app/assets/javascripts/spree/backend/zone.js
+++ b/backend/app/assets/javascripts/spree/backend/zone.js
@@ -1,4 +1,4 @@
-document.addEventListener('DOMContentLoaded', function ( ) {
+document.addEventListener('DOMContentLoaded', function () {
   var typeRadioButtons = "input[name='zone[kind]']"
   var radioSelected = document.querySelector(typeRadioButtons + ':checked').value
   var shownZoneMembers = radioSelected + '_members'

--- a/backend/app/assets/javascripts/spree/backend/zone.js
+++ b/backend/app/assets/javascripts/spree/backend/zone.js
@@ -1,19 +1,19 @@
 $(function () {
   var countryBased = $('#country_based')
   var stateBased = $('#state_based')
-  countryBased.click(show_country)
-  stateBased.click(show_state)
+  countryBased.click(displayCountry)
+  stateBased.click(displayState)
   if (countryBased.is(':checked')) {
-    show_country()
+    displayCountry()
   } else if (stateBased.is(':checked')) {
-    show_state()
+    displayState()
   } else {
-    show_state()
+    displayState()
     stateBased.click()
   }
 })
-// eslint-disable-next-line camelcase
-function show_country () {
+
+function displayCountry () {
   $('#state_members :input').each(function () {
     $(this).prop('disabled', true)
   })
@@ -27,8 +27,8 @@ function show_country () {
   })
   $('#country_members').show()
 }
-// eslint-disable-next-line camelcase
-function show_state () {
+
+function displayState () {
   $('#country_members :input').each(function () {
     $(this).prop('disabled', true)
   })

--- a/backend/app/assets/javascripts/spree/backend/zone.js
+++ b/backend/app/assets/javascripts/spree/backend/zone.js
@@ -1,44 +1,39 @@
-$(function () {
-  var countryBased = $('#country_based')
-  var stateBased = $('#state_based')
-  countryBased.click(displayCountry)
-  stateBased.click(displayState)
-  if (countryBased.is(':checked')) {
-    displayCountry()
-  } else if (stateBased.is(':checked')) {
-    displayState()
-  } else {
-    displayState()
-    stateBased.click()
+document.addEventListener('DOMContentLoaded', function () {
+  var typeRadioButtons = "input[name='zone[kind]']"
+  var radioSelected = document.querySelector(typeRadioButtons + ':checked').value
+  var shownZoneMembers = radioSelected + '_members'
+  var zoneMembersContainer = 'div[data-hook=member]'
+  var activeInput = 'zone_' + radioSelected + '_ids_field'
+
+  toggleTypes(activeInput, zoneMembersContainer, shownZoneMembers)
+
+  if (document.querySelector(typeRadioButtons)) {
+    document.querySelectorAll(typeRadioButtons).forEach(function (elem) {
+      elem.addEventListener('change', function (event) {
+        var item = event.target.value
+        var toggledTypeMemebers = item + '_members'
+        var toggledaActiveInput = 'zone_' + item + '_ids_field'
+
+        toggleTypes(toggledaActiveInput, zoneMembersContainer, toggledTypeMemebers)
+      })
+    })
+  }
+
+  function toggleTypes (activeInput, membersContainer, shownType) {
+    document.getElementById('typeMembers')
+      .querySelectorAll('select, input').forEach(function (element) {
+        element.disabled = true
+      })
+
+    document.getElementById(activeInput)
+      .querySelectorAll('select, input').forEach(function (element) {
+        element.disabled = false
+      })
+
+    document.querySelectorAll(membersContainer).forEach(function (element) {
+      element.style.display = 'none'
+    })
+
+    document.getElementById(shownType).style.display = 'block'
   }
 })
-
-function displayCountry () {
-  $('#state_members :input').each(function () {
-    $(this).prop('disabled', true)
-  })
-  $('#state_members').hide()
-  $('#zone_members :input').each(function () {
-    $(this).prop('disabled', true)
-  })
-  $('#zone_members').hide()
-  $('#country_members :input').each(function () {
-    $(this).prop('disabled', false)
-  })
-  $('#country_members').show()
-}
-
-function displayState () {
-  $('#country_members :input').each(function () {
-    $(this).prop('disabled', true)
-  })
-  $('#country_members').hide()
-  $('#zone_members :input').each(function () {
-    $(this).prop('disabled', true)
-  })
-  $('#zone_members').hide()
-  $('#state_members :input').each(function () {
-    $(this).prop('disabled', false)
-  })
-  $('#state_members').show()
-}

--- a/backend/app/assets/javascripts/spree/backend/zone.js
+++ b/backend/app/assets/javascripts/spree/backend/zone.js
@@ -1,13 +1,14 @@
 document.addEventListener('DOMContentLoaded', function () {
   var typeRadioButtons = "input[name='zone[kind]']"
-  var radioSelected = document.querySelector(typeRadioButtons + ':checked').value
-  var shownZoneMembers = radioSelected + '_members'
-  var zoneMembersContainer = 'div[data-hook=member]'
-  var activeInput = 'zone_' + radioSelected + '_ids_field'
-
-  toggleTypes(activeInput, zoneMembersContainer, shownZoneMembers)
 
   if (document.querySelector(typeRadioButtons)) {
+    var radioSelected = document.querySelector(typeRadioButtons + ':checked').value
+    var shownZoneMembers = radioSelected + '_members'
+    var zoneMembersContainer = 'div[data-hook=member]'
+    var activeInput = 'zone_' + radioSelected + '_ids_field'
+
+    toggleTypes(activeInput, zoneMembersContainer, shownZoneMembers)
+
     document.querySelectorAll(typeRadioButtons).forEach(function (elem) {
       elem.addEventListener('change', function (event) {
         var item = event.target.value

--- a/backend/app/assets/stylesheets/spree/backend/global/_mixins.scss
+++ b/backend/app/assets/stylesheets/spree/backend/global/_mixins.scss
@@ -1,0 +1,19 @@
+// Mixin to prefix several properties at once
+
+// EXAMPLE
+// @include prefix((
+//   appearance: none,
+//   touch-callout: none,
+//   user-select: none
+// ), webkit moz ms khtml);
+
+@mixin prefix($declarations, $prefixes: ()) {
+  @each $property, $value in $declarations {
+    @each $prefix in $prefixes {
+      #{'-' + $prefix + '-' + $property}: $value;
+    }
+
+    // Output standard non-prefixed declaration
+    #{$property}: $value;
+  }
+}

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_flatpickr.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_flatpickr.scss
@@ -11,9 +11,10 @@
     }
 
     .flatpickr-monthDropdown-months {
-      -webkit-appearance: none;
-      -moz-appearance: none;
-      appearance: none;
+      @include prefix((
+        appearance: none
+      ), webkit moz ms khtml);
+
       padding: 0.2em;
       border-radius: $border-radius;
     }
@@ -58,7 +59,7 @@
   }
 }
 
-// Mixin Required for calendar toggle icon show/hide.
+// Mixin for calendar toggle icon show/hide.
 @mixin swith-appended-icon {
   &:placeholder-shown:not(:focus) + * {
       @content;
@@ -68,23 +69,18 @@
 .input-group.datePickerFrom,
 .input-group.datePickerTo,
 .input-group.datepicker {
-
   input.flatpickr-alt-input[readonly] {
     // Flatpickr alternate input is read-only,
     // style it as an active input field.
     background-color: white !important;
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    appearance: none;
 
     // Fix a bug where occasionally the whole screen will highlight
     // if you clicked the Flatpcikr input box while moving the cursor.
-    -webkit-touch-callout: none;
-    -webkit-user-select: none;
-    -khtml-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
+    @include prefix((
+      appearance: none,
+      touch-callout: none,
+      user-select: none
+    ), webkit moz ms khtml);
 
     @include swith-appended-icon  {
       opacity: 0;

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_flatpickr.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_flatpickr.scss
@@ -1,108 +1,117 @@
-// Adaptive icon from calendar to close.
+.flatpickr-calendar {
+  // Custom Flatpickr styling for Spree + BS4.
+  .flatpickr-current-month {
+    span.cur-month:hover {
+      background: transparent;
+    }
+      .numInputWrapper {
+      margin-left: 3px;
+      border-radius: $border-radius;
+      overflow: hidden;
+    }
+
+    .flatpickr-monthDropdown-months {
+      -webkit-appearance: none;
+      -moz-appearance: none;
+      appearance: none;
+      padding: 0.2em;
+      border-radius: $border-radius;
+    }
+  }
+
+  .numInputWrapper span.arrowUp {
+    border-color: transparent;
+    border-radius: 0;
+  }
+
+  .numInputWrapper span.arrowDown {
+    border-color: transparent;
+    border-radius: 0;
+  }
+
+  .flatpickr-day {
+    margin: 2px 0;
+    border-radius: $border-radius ;
+  }
+
+  .flatpickr-months .flatpickr-prev-month:hover svg,
+  .flatpickr-months .flatpickr-next-month:hover svg {
+    fill: $primary;
+  }
+
+  .flatpickr-time {
+    border-radius: 0 0 5px 5px;
+    &:after {
+      display: none;
+    }
+    .numInputWrapper {
+      span {
+        border-color: transparent;
+        border-radius: 0;
+      }
+    }
+  }
+
+  // Required to stop an opened cal showing above the nav bar.
+  &.open {
+    z-index: $zindex-dropdown;
+  }
+}
+
+// Mixin Required for calendar toggle icon show/hide.
 @mixin swith-appended-icon {
   &:placeholder-shown:not(:focus) + * {
       @content;
   }
 }
 
-input.flatpickr-alt-input {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: white !important;
-}
+.input-group.datePickerFrom,
+.input-group.datePickerTo,
+.input-group.datepicker {
 
-.flatpickr-current-month .numInputWrapper {
-  margin-left: 3px;
-  border-radius: $border-radius;
-  overflow: hidden;
-}
-.flatpickr-current-month span.cur-month:hover {
-  background: transparent;
-}
-.numInputWrapper span.arrowUp {
-  border-color: transparent;
-  border-radius: 0;
-}
-.numInputWrapper span.arrowDown {
-  border-color: transparent;
-  border-radius: 0;
-}
+  input.flatpickr-alt-input[readonly] {
+    // Flatpickr alternate input is read-only,
+    // style it as an active input field.
+    background-color: white !important;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
 
-.input-group {
-  input.flatpickr-alt-input {
+    // Fix a bug where occasionally the whole screen will highlight
+    // if you clicked the Flatpcikr input box while moving the cursor.
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+
     @include swith-appended-icon  {
       opacity: 0;
     }
   }
-}
 
-.append_under {
-  position: absolute;
-  right: 0;
-  top: 0;
-  z-index: 0;
-  height: 100%;
-}
-
-.flatpickr-day {
-  margin: 2px 0;
-  border-radius: $border-radius ;
-}
-
-// Fix Flatpickr bug where things jusy highlight for no reason.
-input.flatpickr-alt-input[readonly] {
-  -webkit-touch-callout: none; /* iOS Safari */
-    -webkit-user-select: none; /* Safari */
-     -khtml-user-select: none; /* Konqueror HTML */
-       -moz-user-select: none; /* Old versions of Firefox */
-        -ms-user-select: none; /* Internet Explorer/Edge */
-            user-select: none; /* Non-prefixed version, currently
-                                  supported by Chrome, Edge, Opera and Firefox */
-}
-
-
-.flatpickr-months .flatpickr-prev-month:hover svg,
-.flatpickr-months .flatpickr-next-month:hover svg {
-  fill: $primary;
-}
-
-// Force rounded corner for the toggle cal and close icons.
-.input-group >
-.input-group-append:not(:last-child) >
-.force-round {
-  z-index: 5;
-  border-top-right-radius: $border-radius !important;
-  border-bottom-right-radius: $border-radius !important;
-}
-
-.input-group >
-.form-control:not(:first-child), .input-group > .flatpickr-alt-input:not(:first-child) {
-  border-top-left-radius: $border-radius !important;
-  border-bottom-left-radius: $border-radius !important;
-}
-
-div.flatpickr-calendar.open {
-  z-index: $zindex-dropdown;
-}
-
-.flatpickr-time {
-  border-radius: 0 0 5px 5px;
-  &:after {
-    display: none;
+  // Required for calendar toggle icon show/hide.
+  .append_under {
+    position: absolute;
+    right: 0;
+    top: 0;
+    z-index: 0;
+    height: 100%;
   }
-  .numInputWrapper {
-    span {
-      border-color: transparent;
-      border-radius: 0;
-    }
-  }
-}
 
-.flatpickr-current-month .flatpickr-monthDropdown-months {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  padding: 0.2em;
-  border-radius: $border-radius;
+  // Styling for calendar toggle icon toggle
+  .input-group-append:not(:last-child) >
+  .force-round {
+    z-index: 5;
+    border-top-right-radius: $border-radius !important;
+    border-bottom-right-radius: $border-radius !important;
+  }
+
+  // Styling for calendar toggle icon toggle
+  .form-control:not(:first-child),
+  .input-group >.flatpickr-alt-input:not(:first-child) {
+    border-top-left-radius: $border-radius !important;
+    border-bottom-left-radius: $border-radius !important;
+  }
 }

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_flatpickr.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_flatpickr.scss
@@ -5,7 +5,7 @@
   }
 }
 
-input.input {
+input.flatpickr-alt-input {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -30,7 +30,7 @@ input.input {
 }
 
 .input-group {
-  input.input{
+  input.flatpickr-alt-input {
     @include swith-appended-icon  {
       opacity: 0;
     }
@@ -51,7 +51,7 @@ input.input {
 }
 
 // Fix Flatpickr bug where things jusy highlight for no reason.
-input.input[readonly] {
+input.flatpickr-alt-input[readonly] {
   -webkit-touch-callout: none; /* iOS Safari */
     -webkit-user-select: none; /* Safari */
      -khtml-user-select: none; /* Konqueror HTML */
@@ -77,7 +77,7 @@ input.input[readonly] {
 }
 
 .input-group >
-.form-control:not(:first-child), .input-group > .input:not(:first-child) {
+.form-control:not(:first-child), .input-group > .flatpickr-alt-input:not(:first-child) {
   border-top-left-radius: $border-radius !important;
   border-bottom-left-radius: $border-radius !important;
 }

--- a/backend/app/assets/stylesheets/spree/backend/spree_admin.css.scss
+++ b/backend/app/assets/stylesheets/spree/backend/spree_admin.css.scss
@@ -1,4 +1,5 @@
 @import 'global/variables';
+@import 'global/mixins';
 
 @import 'bootstrap';
 @import 'glyphicons';

--- a/backend/app/views/spree/admin/payments/source_forms/_gateway.html.erb
+++ b/backend/app/views/spree/admin/payments/source_forms/_gateway.html.erb
@@ -24,7 +24,7 @@
       </div>
   </div>
 <% end %>
-  <div id="card_form<%= payment_method.id %>" class="mt-3 row" data-hook>
+  <div id="card_form<%= payment_method.id %>" class="mt-3 row payment-gateway-fields" data-hook>
     <% param_prefix = "payment_source[#{payment_method.id}]" %>
 
     <div data-hook="card_number" class="form-group col-12">

--- a/backend/app/views/spree/admin/payments/source_forms/_gateway.html.erb
+++ b/backend/app/views/spree/admin/payments/source_forms/_gateway.html.erb
@@ -45,7 +45,7 @@
 
     <div data-hook="card_expiration" class="form-group col-6">
       <%= label_tag "card_expiry#{payment_method.id}", raw(Spree.t(:expiration) + required_span_tag) %><br>
-      <%= text_field_tag "#{param_prefix}[expiry]", '', id: "card_expiry#{payment_method.id}", class: "required cardExpiry form-control", placeholder: "MM/YYYY" %>
+      <%= text_field_tag "#{param_prefix}[expiry]", '', id: "card_expiry#{payment_method.id}", class: "required cardExpiry form-control", placeholder: Spree.t(:card_expire_human_readable) %>
     </div>
 
     <div data-hook="card_code" class="form-group col-6">

--- a/backend/app/views/spree/admin/shared/_translations.html.erb
+++ b/backend/app/views/spree/admin/shared/_translations.html.erb
@@ -6,6 +6,7 @@
     are_you_sure_delete:      Spree.t(:are_you_sure_delete),
     bill_address:             Spree.t(:bill_address),
     cancel:                   Spree.t(:cancel,  scope: :actions),
+    card_expire_year_format:  Spree.t(:card_expire_year_format),
     choose_a_customer:        Spree.t(:choose_a_customer),
     confirm_delete:           Spree.t(:confirm_delete),
     currency_separator:       I18n.t('number.currency.format.separator'),

--- a/backend/app/views/spree/admin/zones/_form.html.erb
+++ b/backend/app/views/spree/admin/zones/_form.html.erb
@@ -42,7 +42,7 @@
       </div>
     </div>
   </div>
-  <div class="col-12 col-lg-6">
+  <div id="typeMembers" class="col-12 col-lg-6">
     <%= render partial: 'state_members', locals: { zone_form: zone_form } %>
     <%= render partial: 'country_members', locals: { zone_form: zone_form } %>
   </div>

--- a/core/app/assets/javascripts/card_formatting.js
+++ b/core/app/assets/javascripts/card_formatting.js
@@ -15,9 +15,23 @@ function formatCardNumber (wrapperElement, cardNumberInput, cardTypeInput) {
       creditCard: true,
       onCreditCardTypeChanged: function (type) {
         targetCardType.value = type
+        showCardType(cardPaymentSet, type)
       }
     })
   })
+}
+
+var selectedCardIcon = null
+
+function showCardType (parent, type) {
+  if (!parent) return
+  if (!type) return
+
+  if (selectedCardIcon) selectedCardIcon.classList.remove('active')
+
+  selectedCardIcon = parent.querySelector(`.icon-${type}`)
+
+  if (selectedCardIcon) selectedCardIcon.classList.add('active')
 }
 
 /* eslint-disable no-unused-vars */

--- a/core/app/assets/javascripts/card_formatting.js
+++ b/core/app/assets/javascripts/card_formatting.js
@@ -1,0 +1,53 @@
+/* global Cleave */
+
+/* eslint-disable no-unused-vars */
+function formatCardNumber (wrapperElement, cardNumberInput, cardTypeInput) {
+  if (!document.querySelector(wrapperElement)) return
+  if (!cardNumberInput) return console.warn('Identify the card number input using the second function argument')
+  if (!cardTypeInput) return console.warn('Identify the card type input using the third function argument')
+
+  document.querySelectorAll(wrapperElement).forEach(function (cardPaymentSet) {
+    var targetNumberInput = cardPaymentSet.querySelector(cardNumberInput)
+    var targetCardType = cardPaymentSet.querySelector(cardTypeInput)
+
+    /* eslint-disable no-new */
+    new Cleave(targetNumberInput, {
+      creditCard: true,
+      onCreditCardTypeChanged: function (type) {
+        targetCardType.value = type
+      }
+    })
+  })
+}
+
+/* eslint-disable no-unused-vars */
+function formatCardExpiry (wrapperElement, cardExpiry) {
+  if (!document.querySelector(wrapperElement)) return
+  if (!cardExpiry) return console.warn('Identify the expiry input field using the second function argument')
+
+  document.querySelectorAll(wrapperElement).forEach(function (cardPaymentSet) {
+    var targetCardExpiry = cardPaymentSet.querySelector(cardExpiry)
+
+    /* eslint-disable no-new */
+    new Cleave(targetCardExpiry, {
+      date: true,
+      datePattern: ['m', Spree.translations.card_expire_year_format]
+    })
+  })
+}
+
+/* eslint-disable no-unused-vars */
+function formatCardCode (wrapperElement, cardCode) {
+  if (!document.querySelector(wrapperElement)) return
+  if (!cardCode) return console.warn('Identify the CVV code input field using the second function argument')
+
+  document.querySelectorAll(wrapperElement).forEach(function (cardPaymentSet) {
+    var targetCardCode = cardPaymentSet.querySelector(cardCode)
+
+    /* eslint-disable no-new */
+    new Cleave(targetCardCode, {
+      numericOnly: true,
+      blocks: [3]
+    })
+  })
+}

--- a/core/app/assets/javascripts/spree.js
+++ b/core/app/assets/javascripts/spree.js
@@ -2,7 +2,7 @@
 function Spree () {}
 
 Spree.ready = function (callback) {
-  return jQuery(document).on('page:load turbolinks:load', function () {
+  return window.addEventListener('turbolinks:load', function () {
     return callback(jQuery)
   })
 }

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -639,7 +639,7 @@ en:
     capture: Capture
     capture_events: Capture events
     card_code: Card Varification Code (CVC)
-    card_expire_year_format: 'Y' # Set y (lower case) for MM/YY
+    card_expire_year_format: 'y' # lower case y for MM/YY | upper case Y for MM/YYYY
     card_number: Card Number
     card_type: Brand
     card_type_is: Card type is

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -639,7 +639,8 @@ en:
     capture: Capture
     capture_events: Capture events
     card_code: Card Varification Code (CVC)
-    card_expire_year_format: 'y' # lower case y for MM/YY | upper case Y for MM/YYYY
+    card_expire_human_readable: 'MM/YYYY' # match the formatting as below
+    card_expire_year_format: 'Y' # upper case Y for MM/YYYY | lower case y for MM/YY
     card_number: Card Number
     card_type: Brand
     card_type_is: Card type is

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -639,6 +639,7 @@ en:
     capture: Capture
     capture_events: Capture events
     card_code: Card Varification Code (CVC)
+    card_expire_year_format: 'Y' # Set y (lower case) for MM/YY
     card_number: Card Number
     card_type: Brand
     card_type_is: Card type is

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -639,8 +639,8 @@ en:
     capture: Capture
     capture_events: Capture events
     card_code: Card Varification Code (CVC)
-    card_expire_human_readable: 'MM/YYYY' # match the formatting as below
-    card_expire_year_format: 'Y' # upper case Y for MM/YYYY | lower case y for MM/YY
+    card_expire_human_readable: 'MM/YYYY'  # Match for the formatting below
+    card_expire_year_format: 'Y'  # Y for MM/YYYY | y for MM/YY
     card_number: Card Number
     card_type: Brand
     card_type_is: Card type is

--- a/core/lib/spree/testing_support/flatpickr_capybara.rb
+++ b/core/lib/spree/testing_support/flatpickr_capybara.rb
@@ -49,7 +49,7 @@ module Spree
       def with_open_flatpickr(label_text)
         field_label = find_field(id: label_text, type: :hidden)
 
-        date_field = field_label.sibling('.input')
+        date_field = field_label.sibling('.flatpickr-alt-input')
         date_field.click # Open the widget
 
         yield(date_field)

--- a/core/vendor/assets/javascripts/cleave.js
+++ b/core/vendor/assets/javascripts/cleave.js
@@ -1,3 +1,4 @@
+// https://github.com/nosir/cleave.js/blob/v1.6.0/dist/cleave.js
 (function webpackUniversalModuleDefinition(root, factory) {
 	if(typeof exports === 'object' && typeof module === 'object')
 		module.exports = factory();

--- a/frontend/app/assets/javascripts/spree/frontend.js
+++ b/frontend/app/assets/javascripts/spree/frontend.js
@@ -5,6 +5,7 @@
 //= require jquery.payment
 //= require cleave
 //= require spree
+//= require card_formatting
 //= require polyfill.min
 //= require fetch.umd
 //= require spree/api/main

--- a/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js
@@ -4,7 +4,7 @@ var CARD_EXPIRATION_SELECTOR = '.cardExpiry'
 var CARD_CODE_SELECTOR = '.cardCode'
 
 //= require spree/frontend/coupon_manager
-window.addEventListener('turbolinks:load', function() {
+Spree.ready(function ($) {
   Spree.onPayment = function () {
     if ($('#checkout_form_payment').length) {
       if ($('#existing_cards').length) {

--- a/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js
@@ -1,9 +1,6 @@
-/* global Cleave */
-var CARD_NUMBER_SELECTOR = '.cardNumber'
-var CARD_EXPIRATION_SELECTOR = '.cardExpiry'
-var CARD_CODE_SELECTOR = '.cardCode'
-
+/* global formatCardNumber, formatCardExpiry, formatCardCode */
 //= require spree/frontend/coupon_manager
+
 Spree.ready(function ($) {
   Spree.onPayment = function () {
     if ($('#checkout_form_payment').length) {
@@ -24,45 +21,6 @@ Spree.ready(function ($) {
         })
       }
 
-      if ($(CARD_NUMBER_SELECTOR).length > 0 &&
-        $(CARD_EXPIRATION_SELECTOR).length > 0 &&
-        $(CARD_CODE_SELECTOR).length > 0) {
-        $(CARD_NUMBER_SELECTOR).each(function () {
-          var $this = $(this)
-          var cardNumberInputId = '#' + $this.attr('id')
-
-          // eslint-disable-next-line no-new
-          new Cleave(cardNumberInputId, {
-            creditCard: true,
-            onCreditCardTypeChanged: function (type) {
-              $('.ccType').val(type)
-            }
-          })
-        })
-
-        $(CARD_EXPIRATION_SELECTOR).each(function () {
-          var $this = $(this)
-          var cardExpiryInputId = '#' + $this.attr('id')
-
-          /* eslint-disable no-new */
-          new Cleave(cardExpiryInputId, {
-            date: true,
-            datePattern: ['m', Spree.translations.card_expire_year_format]
-          })
-        })
-
-        $(CARD_CODE_SELECTOR).each(function () {
-          var $this = $(this)
-          var cardCodeInputId = '#' + $this.attr('id')
-
-          /* eslint-disable no-new */
-          new Cleave(cardCodeInputId, {
-            numericOnly: true,
-            blocks: [3]
-          })
-        })
-      }
-
       $('input[type="radio"][name="order[payments_attributes][][payment_method_id]"]').click(function () {
         $('#payment-methods').hide()
         $('.payment-sources').hide()
@@ -70,18 +28,18 @@ Spree.ready(function ($) {
         if ($('#payment_method_' + this.value).find('fieldset').children().length !== 0) {
           if (this.closest('label').dataset.type === 'card') {
             if ($('#existing_cards').length) {
-              $('.existing-cc-radio').first().prop('checked', true)
+              $('.existing-cc-radio').first().prop('checked', true);
               $('#use_existing_card_no').prop('checked', false)
               $('#use_existing_card_yes').prop('checked', true)
-              $('#existing_cards').show()
-              $('#payment-methods').hide()
+              $('#existing_cards').show();
+              $('#payment-methods').hide();
               $('.payment-sources').show()
             }
           } else {
-            $('.existing-cc-radio').prop('checked', false)
-            $('#use_existing_card_no').prop('checked', false)
-            $('#existing_cards').hide()
-            $('#payment-methods').show()
+            $('.existing-cc-radio').prop('checked', false);
+            $('#use_existing_card_no').prop('checked', false);
+            $('#existing_cards').hide();
+            $('#payment-methods').show();
             $('.payment-sources').show()
           }
         }
@@ -116,4 +74,10 @@ Spree.ready(function ($) {
     }
   }
   Spree.onPayment()
+
+  var cardPaymetnContainerEl = '.payment-gateway-fields'
+
+  formatCardNumber(cardPaymetnContainerEl, '.cardNumber', '.ccType')
+  formatCardExpiry(cardPaymetnContainerEl, '.cardExpiry')
+  formatCardCode(cardPaymetnContainerEl, '.cardCode')
 })

--- a/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js
@@ -25,24 +25,41 @@ Spree.ready(function ($) {
       }
 
       if ($(CARD_NUMBER_SELECTOR).length > 0 &&
-          $(CARD_EXPIRATION_SELECTOR).length > 0 &&
-          $(CARD_CODE_SELECTOR).length > 0) {
-        /* eslint-disable no-new */
-        new Cleave(CARD_NUMBER_SELECTOR, {
-          creditCard: true,
-          onCreditCardTypeChanged: function (type) {
-            $('.ccType').val(type)
-          }
+        $(CARD_EXPIRATION_SELECTOR).length > 0 &&
+        $(CARD_CODE_SELECTOR).length > 0) {
+        $(CARD_NUMBER_SELECTOR).each(function () {
+          var $this = $(this)
+          var cardNumberInputId = '#' + $this.attr('id')
+
+          // eslint-disable-next-line no-new
+          new Cleave(cardNumberInputId, {
+            creditCard: true,
+            onCreditCardTypeChanged: function (type) {
+              $('.ccType').val(type)
+            }
+          })
         })
-        /* eslint-disable no-new */
-        new Cleave(CARD_EXPIRATION_SELECTOR, {
-          date: true,
-          datePattern: ['m', 'Y']
+
+        $(CARD_EXPIRATION_SELECTOR).each(function () {
+          var $this = $(this)
+          var cardExpiryInputId = '#' + $this.attr('id')
+
+          /* eslint-disable no-new */
+          new Cleave(cardExpiryInputId, {
+            date: true,
+            datePattern: ['m', 'Y']
+          })
         })
-        /* eslint-disable no-new */
-        new Cleave(CARD_CODE_SELECTOR, {
-          numericOnly: true,
-          blocks: [3]
+
+        $(CARD_CODE_SELECTOR).each(function () {
+          var $this = $(this)
+          var cardCodeInputId = '#' + $this.attr('id')
+
+          /* eslint-disable no-new */
+          new Cleave(cardCodeInputId, {
+            numericOnly: true,
+            blocks: [3]
+          })
         })
       }
 
@@ -53,18 +70,18 @@ Spree.ready(function ($) {
         if ($('#payment_method_' + this.value).find('fieldset').children().length !== 0) {
           if (this.closest('label').dataset.type === 'card') {
             if ($('#existing_cards').length) {
-              $('.existing-cc-radio').first().prop('checked', true);
+              $('.existing-cc-radio').first().prop('checked', true)
               $('#use_existing_card_no').prop('checked', false)
               $('#use_existing_card_yes').prop('checked', true)
-              $('#existing_cards').show();
-              $('#payment-methods').hide();
+              $('#existing_cards').show()
+              $('#payment-methods').hide()
               $('.payment-sources').show()
             }
           } else {
-            $('.existing-cc-radio').prop('checked', false);
-            $('#use_existing_card_no').prop('checked', false);
-            $('#existing_cards').hide();
-            $('#payment-methods').show();
+            $('.existing-cc-radio').prop('checked', false)
+            $('#use_existing_card_no').prop('checked', false)
+            $('#existing_cards').hide()
+            $('#payment-methods').show()
             $('.payment-sources').show()
           }
         }

--- a/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js
@@ -47,7 +47,7 @@ Spree.ready(function ($) {
           /* eslint-disable no-new */
           new Cleave(cardExpiryInputId, {
             date: true,
-            datePattern: ['m', 'Y']
+            datePattern: ['m', 'y']
           })
         })
 

--- a/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js
@@ -4,7 +4,7 @@ var CARD_EXPIRATION_SELECTOR = '.cardExpiry'
 var CARD_CODE_SELECTOR = '.cardCode'
 
 //= require spree/frontend/coupon_manager
-Spree.ready(function ($) {
+window.addEventListener('turbolinks:load', function() {
   Spree.onPayment = function () {
     if ($('#checkout_form_payment').length) {
       if ($('#existing_cards').length) {
@@ -47,7 +47,7 @@ Spree.ready(function ($) {
           /* eslint-disable no-new */
           new Cleave(cardExpiryInputId, {
             date: true,
-            datePattern: ['m', 'y']
+            datePattern: ['m', Spree.translations.card_expire_year_format]
           })
         })
 

--- a/frontend/app/assets/stylesheets/spree/frontend/views/spree/checkout/payment.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/views/spree/checkout/payment.scss
@@ -96,3 +96,15 @@
     }
   }
 }
+
+.cardIcon {
+  position: absolute;
+  top: 50%;
+  right: 4%;
+  transform: translate(0%, -50%);
+  display: none;
+}
+
+.cardIcon.active {
+  display: block;
+}

--- a/frontend/app/views/spree/checkout/payment/_gateway.html.erb
+++ b/frontend/app/views/spree/checkout/payment/_gateway.html.erb
@@ -11,11 +11,13 @@
       <% options_hash = Rails.env.production? ? {autocomplete: 'off'} : {} %>
       <%= text_field_tag "#{param_prefix}[number]", '', options_hash.merge(id: "card_number_#{payment_method.id}", class: 'spree-flat-input cardNumber', size: 19, maxlength: 19, autocomplete: "off", placeholder: Spree.t(:card_number)) %>
       <label><%= Spree.t(:card_number) %></label>
-      <span id="card_type" style="display:none;">
-        ( <span id="looks_like"><%= Spree.t(:card_type_is) %> <span id="type"></span></span>
-          <span id="unrecognized"><%= Spree.t(:unrecognized_card_type) %></span>
-        )
-      </span>
+
+      <span class="cardIcon icon-amex"><%= icon(name: 'credit_cards/icons/american_express', width: 65, height: 40) %></span>
+      <span class="cardIcon icon-diners"><%= icon(name: 'credit_cards/icons/diners_club', width: 65, height: 40) %></span>
+      <span class="cardIcon icon-mastercard"><%= icon(name: 'credit_cards/icons/master', width: 65, height: 40) %></span>
+      <span class="cardIcon icon-jcb"><%= icon(name: 'credit_cards/icons/jcb', width: 65, height: 40) %></span>
+      <span class="cardIcon icon-visa"><%= icon(name: 'credit_cards/icons/visa', width: 65, height: 40) %></span>
+      <span class="cardIcon icon-discover"><%= icon(name: 'credit_cards/icons/discover', width: 65, height: 40) %></span>
     </div>
 
     <div class="col-6 checkout-content-inner-field has-float-label" data-hook="card_expiration">

--- a/frontend/app/views/spree/checkout/payment/_gateway.html.erb
+++ b/frontend/app/views/spree/checkout/payment/_gateway.html.erb
@@ -3,13 +3,15 @@
   <% param_prefix = "payment_source[#{payment_method.id}]" %>
 
   <div class="payment-gateway-fields">
-    <div class="mb-4 payment-gateway-field checkout-content-inner-field">
+    <div class="mb-4 payment-gateway-field checkout-content-inner-field has-float-label">
       <%= text_field_tag "#{param_prefix}[name]", "#{@order.bill_address_firstname} #{@order.bill_address_lastname}", { id: "name_on_card_#{payment_method.id}", class: 'spree-flat-input', placeholder: Spree.t(:name_on_card)} %>
+      <label><%= Spree.t(:name_on_card) %></label>
     </div>
 
-    <div class="mb-4 payment-gateway-field checkout-content-inner-field" data-hook="card_number">
+    <div class="mb-4 payment-gateway-field checkout-content-inner-field has-float-label" data-hook="card_number">
       <% options_hash = Rails.env.production? ? {autocomplete: 'off'} : {} %>
       <%= text_field_tag "#{param_prefix}[number]", '', options_hash.merge(id: "card_number_#{payment_method.id}", class: 'spree-flat-input cardNumber', size: 19, maxlength: 19, autocomplete: "off", placeholder: Spree.t(:card_number)) %>
+      <label><%= Spree.t(:card_number) %></label>
       <span id="card_type" style="display:none;">
         ( <span id="looks_like"><%= Spree.t(:card_type_is) %> <span id="type"></span></span>
           <span id="unrecognized"><%= Spree.t(:unrecognized_card_type) %></span>
@@ -17,11 +19,13 @@
       </span>
     </div>
     <div class="payment-gateway-half-fields d-flex justify-content-between">
-      <div class="payment-gateway-field checkout-content-inner-field" data-hook="card_expiration">
+      <div class="payment-gateway-field checkout-content-inner-field has-float-label" data-hook="card_expiration">
         <%= text_field_tag "#{param_prefix}[expiry]", '', id: "card_expiry_#{payment_method.id}", class: 'spree-flat-input cardExpiry', placeholder: Spree.t(:card_expire_human_readable) %>
+        <label><%= Spree.t(:card_expire_human_readable) %></label>
       </div>
-      <div class="payment-gateway-field checkout-content-inner-field" data-hook="card_code">
+      <div class="payment-gateway-field checkout-content-inner-field has-float-label" data-hook="card_code">
         <%= text_field_tag "#{param_prefix}[verification_value]", '', options_hash.merge(id: "card_code_#{payment_method.id}", class: 'spree-flat-input cardCode', size: 5, placeholder: Spree.t(:cvv)) %>
+        <label><%= Spree.t(:cvv) %></label>
       </div>
     </div>
 

--- a/frontend/app/views/spree/checkout/payment/_gateway.html.erb
+++ b/frontend/app/views/spree/checkout/payment/_gateway.html.erb
@@ -1,14 +1,13 @@
 <div class="payment-gateway">
-
   <% param_prefix = "payment_source[#{payment_method.id}]" %>
 
-  <div class="payment-gateway-fields">
-    <div class="mb-4 payment-gateway-field checkout-content-inner-field has-float-label">
+  <div class="payment-gateway-fields row">
+    <div class="mb-4 col-12 checkout-content-inner-field has-float-label">
       <%= text_field_tag "#{param_prefix}[name]", "#{@order.bill_address_firstname} #{@order.bill_address_lastname}", { id: "name_on_card_#{payment_method.id}", class: 'spree-flat-input', placeholder: Spree.t(:name_on_card)} %>
       <label><%= Spree.t(:name_on_card) %></label>
     </div>
 
-    <div class="mb-4 payment-gateway-field checkout-content-inner-field has-float-label" data-hook="card_number">
+    <div class="mb-4 col-12 checkout-content-inner-field has-float-label" data-hook="card_number">
       <% options_hash = Rails.env.production? ? {autocomplete: 'off'} : {} %>
       <%= text_field_tag "#{param_prefix}[number]", '', options_hash.merge(id: "card_number_#{payment_method.id}", class: 'spree-flat-input cardNumber', size: 19, maxlength: 19, autocomplete: "off", placeholder: Spree.t(:card_number)) %>
       <label><%= Spree.t(:card_number) %></label>
@@ -18,15 +17,15 @@
         )
       </span>
     </div>
-    <div class="payment-gateway-half-fields d-flex justify-content-between">
-      <div class="payment-gateway-field checkout-content-inner-field has-float-label" data-hook="card_expiration">
-        <%= text_field_tag "#{param_prefix}[expiry]", '', id: "card_expiry_#{payment_method.id}", class: 'spree-flat-input cardExpiry', placeholder: Spree.t(:card_expire_human_readable) %>
-        <label><%= Spree.t(:card_expire_human_readable) %></label>
-      </div>
-      <div class="payment-gateway-field checkout-content-inner-field has-float-label" data-hook="card_code">
-        <%= text_field_tag "#{param_prefix}[verification_value]", '', options_hash.merge(id: "card_code_#{payment_method.id}", class: 'spree-flat-input cardCode', size: 5, placeholder: Spree.t(:cvv)) %>
-        <label><%= Spree.t(:cvv) %></label>
-      </div>
+
+    <div class="col-6 checkout-content-inner-field has-float-label" data-hook="card_expiration">
+      <%= text_field_tag "#{param_prefix}[expiry]", '', id: "card_expiry_#{payment_method.id}", class: 'spree-flat-input cardExpiry', placeholder: Spree.t(:card_expire_human_readable) %>
+      <label><%= Spree.t(:card_expire_human_readable) %></label>
+    </div>
+
+    <div class="col-6 checkout-content-inner-field has-float-label" data-hook="card_code">
+      <%= text_field_tag "#{param_prefix}[verification_value]", '', options_hash.merge(id: "card_code_#{payment_method.id}", class: 'spree-flat-input cardCode', size: 5, placeholder: Spree.t(:cvv)) %>
+      <label><%= Spree.t(:cvv) %></label>
     </div>
 
     <%= hidden_field_tag "#{param_prefix}[cc_type]", '', id: "cc_type", class: 'ccType' %>

--- a/frontend/app/views/spree/checkout/payment/_gateway.html.erb
+++ b/frontend/app/views/spree/checkout/payment/_gateway.html.erb
@@ -18,7 +18,7 @@
     </div>
     <div class="payment-gateway-half-fields d-flex justify-content-between">
       <div class="payment-gateway-field checkout-content-inner-field" data-hook="card_expiration">
-        <%= text_field_tag "#{param_prefix}[expiry]", '', id: "card_expiry_#{payment_method.id}", class: 'spree-flat-input cardExpiry', placeholder: "MM/YYYY" %>
+        <%= text_field_tag "#{param_prefix}[expiry]", '', id: "card_expiry_#{payment_method.id}", class: 'spree-flat-input cardExpiry', placeholder: Spree.t(:card_expire_human_readable) %>
       </div>
       <div class="payment-gateway-field checkout-content-inner-field" data-hook="card_code">
         <%= text_field_tag "#{param_prefix}[verification_value]", '', options_hash.merge(id: "card_code_#{payment_method.id}", class: 'spree-flat-input cardCode', size: 5, placeholder: Spree.t(:cvv)) %>

--- a/frontend/app/views/spree/checkout/payment/_gateway.html.erb
+++ b/frontend/app/views/spree/checkout/payment/_gateway.html.erb
@@ -4,12 +4,12 @@
 
   <div class="payment-gateway-fields">
     <div class="mb-4 payment-gateway-field checkout-content-inner-field">
-      <%= text_field_tag "#{param_prefix}[name]", "#{@order.bill_address_firstname} #{@order.bill_address_lastname}", { id: "name_on_card#{payment_method.id}", class: 'spree-flat-input', placeholder: Spree.t(:name_on_card)} %>
+      <%= text_field_tag "#{param_prefix}[name]", "#{@order.bill_address_firstname} #{@order.bill_address_lastname}", { id: "name_on_card_#{payment_method.id}", class: 'spree-flat-input', placeholder: Spree.t(:name_on_card)} %>
     </div>
 
     <div class="mb-4 payment-gateway-field checkout-content-inner-field" data-hook="card_number">
       <% options_hash = Rails.env.production? ? {autocomplete: 'off'} : {} %>
-      <%= text_field_tag "#{param_prefix}[number]", '', options_hash.merge(id: "card_number#{payment_method.id}", class: 'spree-flat-input cardNumber', size: 19, maxlength: 19, autocomplete: "off", placeholder: Spree.t(:card_number)) %>
+      <%= text_field_tag "#{param_prefix}[number]", '', options_hash.merge(id: "card_number_#{payment_method.id}", class: 'spree-flat-input cardNumber', size: 19, maxlength: 19, autocomplete: "off", placeholder: Spree.t(:card_number)) %>
       <span id="card_type" style="display:none;">
         ( <span id="looks_like"><%= Spree.t(:card_type_is) %> <span id="type"></span></span>
           <span id="unrecognized"><%= Spree.t(:unrecognized_card_type) %></span>
@@ -18,10 +18,10 @@
     </div>
     <div class="payment-gateway-half-fields d-flex justify-content-between">
       <div class="payment-gateway-field checkout-content-inner-field" data-hook="card_expiration">
-        <%= text_field_tag "#{param_prefix}[expiry]", '', id: "card_expiry#{payment_method.id}", class: 'spree-flat-input cardExpiry', placeholder: "MM/YYYY" %>
+        <%= text_field_tag "#{param_prefix}[expiry]", '', id: "card_expiry_#{payment_method.id}", class: 'spree-flat-input cardExpiry', placeholder: "MM/YYYY" %>
       </div>
       <div class="payment-gateway-field checkout-content-inner-field" data-hook="card_code">
-        <%= text_field_tag "#{param_prefix}[verification_value]", '', options_hash.merge(id: "card_code#{payment_method.id}", class: 'spree-flat-input cardCode', size: 5, placeholder: Spree.t(:cvv)) %>
+        <%= text_field_tag "#{param_prefix}[verification_value]", '', options_hash.merge(id: "card_code_#{payment_method.id}", class: 'spree-flat-input cardCode', size: 5, placeholder: Spree.t(:cvv)) %>
       </div>
     </div>
 

--- a/frontend/app/views/spree/checkout/payment/_gateway.html.erb
+++ b/frontend/app/views/spree/checkout/payment/_gateway.html.erb
@@ -4,12 +4,12 @@
 
   <div class="payment-gateway-fields">
     <div class="mb-4 payment-gateway-field checkout-content-inner-field">
-      <%= text_field_tag "#{param_prefix}[name]", "#{@order.bill_address_firstname} #{@order.bill_address_lastname}", { id: "name_on_card", class: 'spree-flat-input', placeholder: Spree.t(:name_on_card)} %>
+      <%= text_field_tag "#{param_prefix}[name]", "#{@order.bill_address_firstname} #{@order.bill_address_lastname}", { id: "name_on_card#{payment_method.id}", class: 'spree-flat-input', placeholder: Spree.t(:name_on_card)} %>
     </div>
 
     <div class="mb-4 payment-gateway-field checkout-content-inner-field" data-hook="card_number">
       <% options_hash = Rails.env.production? ? {autocomplete: 'off'} : {} %>
-      <%= text_field_tag "#{param_prefix}[number]", '', options_hash.merge(id: 'card_number', class: 'spree-flat-input cardNumber', size: 19, maxlength: 19, autocomplete: "off", placeholder: Spree.t(:card_number)) %>
+      <%= text_field_tag "#{param_prefix}[number]", '', options_hash.merge(id: "card_number#{payment_method.id}", class: 'spree-flat-input cardNumber', size: 19, maxlength: 19, autocomplete: "off", placeholder: Spree.t(:card_number)) %>
       <span id="card_type" style="display:none;">
         ( <span id="looks_like"><%= Spree.t(:card_type_is) %> <span id="type"></span></span>
           <span id="unrecognized"><%= Spree.t(:unrecognized_card_type) %></span>
@@ -18,10 +18,10 @@
     </div>
     <div class="payment-gateway-half-fields d-flex justify-content-between">
       <div class="payment-gateway-field checkout-content-inner-field" data-hook="card_expiration">
-        <%= text_field_tag "#{param_prefix}[expiry]", '', id: 'card_expiry', class: 'spree-flat-input cardExpiry', placeholder: "MM/YYYY" %>
+        <%= text_field_tag "#{param_prefix}[expiry]", '', id: "card_expiry#{payment_method.id}", class: 'spree-flat-input cardExpiry', placeholder: "MM/YYYY" %>
       </div>
       <div class="payment-gateway-field checkout-content-inner-field" data-hook="card_code">
-        <%= text_field_tag "#{param_prefix}[verification_value]", '', options_hash.merge(id: 'card_code', class: 'spree-flat-input cardCode', size: 5, placeholder: Spree.t(:cvv)) %>
+        <%= text_field_tag "#{param_prefix}[verification_value]", '', options_hash.merge(id: "card_code#{payment_method.id}", class: 'spree-flat-input cardCode', size: 5, placeholder: Spree.t(:cvv)) %>
       </div>
     </div>
 

--- a/frontend/app/views/spree/shared/_translations.html.erb
+++ b/frontend/app/views/spree/shared/_translations.html.erb
@@ -4,7 +4,8 @@
         {
           coupon_code_applied: Spree.t(:coupon_code_applied),
           coupon_code_removed: Spree.t(:coupon_code_removed),
-          coupon_code_error_icon: image_path('error.svg')
+          coupon_code_error_icon: image_path('error.svg'),
+          card_expire_year_format: Spree.t(:card_expire_year_format)
         }.to_json
                            %>
   });

--- a/frontend/spec/support/shared_contexts/checkout_address_book.rb
+++ b/frontend/spec/support/shared_contexts/checkout_address_book.rb
@@ -55,10 +55,10 @@ shared_context 'checkout address book' do
   end
 
   def fill_in_credit_card_info(address)
-    fill_in 'name_on_card', with: "#{address.firstname} #{address.lastname}"
-    fill_in 'card_number', with: '4111 1111 1111 1111'
-    fill_in 'card_expiry', with: '12 / 24'
-    fill_in 'card_code', with: '123'
+    fill_in Spree.t(:name_on_card), with: "#{address.firstname} #{address.lastname}"
+    fill_in Spree.t(:card_number), with: '4111 1111 1111 1111'
+    fill_in 'MM/YYYY', with: '12 / 24'
+    fill_in Spree.t(:cvv), with: '123'
   end
 
   def expected_address_format(address_title, address)

--- a/frontend/spec/support/shared_contexts/checkout_address_book.rb
+++ b/frontend/spec/support/shared_contexts/checkout_address_book.rb
@@ -57,7 +57,7 @@ shared_context 'checkout address book' do
   def fill_in_credit_card_info(address)
     fill_in Spree.t(:name_on_card), with: "#{address.firstname} #{address.lastname}"
     fill_in Spree.t(:card_number), with: '4111 1111 1111 1111'
-    fill_in 'MM/YYYY', with: '12 / 24'
+    fill_in Spree.t(:card_expire_human_readable), with: '12 / 24'
     fill_in Spree.t(:cvv), with: '123'
   end
 

--- a/frontend/spec/support/shared_contexts/checkout_setup.rb
+++ b/frontend/spec/support/shared_contexts/checkout_setup.rb
@@ -23,10 +23,10 @@ shared_context 'checkout setup' do
   end
 
   def fill_in_credit_card_info(invalid: false)
-    fill_in 'name_on_card', with: 'Spree Commerce'
-    fill_in 'card_number', with: invalid ? '123' : '4111 1111 1111 1111'
-    fill_in 'card_expiry', with: '12 / 24'
-    fill_in 'card_code', with: '123'
+    fill_in Spree.t(:name_on_card), with: 'Spree Commerce'
+    fill_in Spree.t(:card_number), with: invalid ? '123' : '4111 1111 1111 1111'
+    fill_in 'MM/YYYY', with: '12 / 24'
+    fill_in Spree.t(:cvv), with: '123'
   end
 
   def add_mug_to_cart

--- a/frontend/spec/support/shared_contexts/checkout_setup.rb
+++ b/frontend/spec/support/shared_contexts/checkout_setup.rb
@@ -25,7 +25,7 @@ shared_context 'checkout setup' do
   def fill_in_credit_card_info(invalid: false)
     fill_in Spree.t(:name_on_card), with: 'Spree Commerce'
     fill_in Spree.t(:card_number), with: invalid ? '123' : '4111 1111 1111 1111'
-    fill_in 'MM/YYYY', with: '12 / 24'
+    fill_in Spree.t(:card_expire_human_readable), with: '12 / 24'
     fill_in Spree.t(:cvv), with: '123'
   end
 


### PR DESCRIPTION
- Lint admin js
- Fix bug in Order/Payments where if you had multiple card payment options, only the first field would get Cleave Card formatting, the js now loops through each and targets by the unique ID.
- Add ability to set Cleave to formatting expire day year as MM/YYYY or MM/YY based on setting in translation file Y or y (Comment on change in payment.js) this can be matched with the place holder text.


Added floating labels to card input fields, helps confirm everything is in the correct place at a glance.
<img width="586" alt="Screenshot 2021-02-07 at 13 51 07" src="https://user-images.githubusercontent.com/1240766/107148569-ce53e380-694b-11eb-8df9-3ac2c3a4829c.png">
