### PR TITLE
fixed store checkout zone user addresses suggestions

### DIFF
--- a/frontend/app/helpers/spree/addresses_helper.rb
+++ b/frontend/app/helpers/spree/addresses_helper.rb
@@ -65,9 +65,16 @@ module Spree
     end
 
     def user_available_addresses
-      return unless try_spree_current_user
+      @user_available_addresses ||= begin
+        return [] unless try_spree_current_user
 
-      try_spree_current_user.addresses.where(country: available_countries)
+        states = current_store.countries_available_for_checkout.each_with_object([]) do |country, memo|
+          memo << current_store.states_available_for_checkout(country)
+        end.flatten
+
+        try_spree_current_user.addresses.
+          where(id: states.pluck(:country_id).uniq)
+      end
     end
 
     def checkout_zone_applicable_states_for(country)

--- a/frontend/app/views/spree/checkout/_address.html.erb
+++ b/frontend/app/views/spree/checkout/_address.html.erb
@@ -1,5 +1,3 @@
-<% @addresses = try_spree_current_user ? user_available_addresses : [] %>
-
 <% if !try_spree_current_user || try_spree_current_user.email.blank? %>
   <div class="row">
     <div class="col-12 mb-4">
@@ -28,10 +26,10 @@
             <%= label_tag :order_use_billing, Spree.t(:use_billing_address), class: 'spree-checkbox-label' %>
           </div>
         <% end %>
-        <% if @addresses.present? %>
+        <% if user_available_addresses.present? %>
         <div class="select_address mb-5">
           <div class="form-group col">
-            <% @addresses.each_with_index do |address, idx| %>
+            <% user_available_addresses.each_with_index do |address, idx| %>
             <div class="row mb-3" id="<%= [address_type, dom_id(address)].join('_') %>">
               <label class="form-check-label spree-radio-label col-8">
                 <%= form.radio_button "#{address_name}_id", address.id, checked: (address.id == try_spree_current_user["#{address_name}_id"] || idx == 0) %>

--- a/frontend/spec/helpers/address_helper_spec.rb
+++ b/frontend/spec/helpers/address_helper_spec.rb
@@ -1,47 +1,65 @@
 require 'spec_helper'
 
 describe Spree::AddressesHelper, type: :helper do
+  class SampleClass
+    include Spree::AddressesHelper
+  end
+
   describe '#user_available_addresses' do
-    let!(:user) { create(:user) }
+    subject        { SampleClass.new.user_available_addresses }
 
-    let!(:united_states) { create(:country, name: 'United States') }
-    let!(:poland)        { create(:country, name: 'Poland') }
-    let!(:china)         { create(:country, name: 'China') }
-    let!(:ukraine)       { create(:country, name: 'Ukraine') }
+    let!(:user)    { create(:user) }
+    let!(:store)   { create(:store) }
 
-    let!(:address_1) { create(:address, country_id: united_states.id, state_id: united_states.states.first, user: user) }
-    let!(:address_2) { create(:address, country_id: poland.id, state_id: poland.states.first, user: user) }
-    let!(:address_3) { create(:address, country_id: china.id, state_id: china.states.first, user: user) }
-    
+    let(:new_york) { create(:state, name: 'New York') }
+
+    let!(:united_states) do
+      create(:country, name: 'United States').tap do |usa|
+        usa.states << new_york
+      end
+    end
+
+    let!(:address_1) do
+      create(:address,
+             country_id: united_states.id,
+             state_id: new_york.id,
+             user: user)
+    end
+
+    before do
+      allow_any_instance_of(described_class).to receive(:current_store)          { store }
+      allow_any_instance_of(described_class).to receive(:try_spree_current_user) { current_store }
+    end
+
+    context 'when user is not present' do
+      let(:current_store) { nil }
+
+      it 'returns an empty array' do
+        expect(subject).to match_array []
+      end
+    end
+
     context 'when user is present' do
-      subject { user_available_addresses }
+      let(:current_store) { user }
 
-      context 'when available countries do not includes user addresses countries' do
+      before do
+        store.update(checkout_zone: checkout_zone)
+      end
+
+      context 'when checkout zone does not include user addresses states' do
+        let(:checkout_zone) { create(:zone, kind: :country) } # zone with no attached zoneable
+
         it 'returns an empty array' do
-          allow_any_instance_of(Spree::AddressesHelper).to receive(:try_spree_current_user).and_return(user)
-          allow_any_instance_of(Spree::AddressesHelper).to receive(:available_countries).and_return([ukraine])
-
           expect(subject).to match_array []
         end
       end
 
-      context 'when available countries includes user addresses countries' do
+      context 'when checkout zone includes user addresses states' do # Global Zone including all countries
+        let(:checkout_zone) { create(:global_zone) }
+
         it 'returns that addresses' do
-          allow_any_instance_of(Spree::AddressesHelper).to receive(:try_spree_current_user).and_return(user)
-          allow_any_instance_of(Spree::AddressesHelper).to receive(:available_countries).and_return([poland, united_states])
-
-          expect(subject).to match_array [address_1, address_2]
+          expect(subject).to match_array address_1
         end
-      end
-    end
-
-    context 'when user is absent' do
-      subject { user_available_addresses }
-
-      it 'returns nil' do
-        allow_any_instance_of(Spree::AddressesHelper).to receive(:try_spree_current_user).and_return(nil)
-
-        expect(subject).to eq nil
       end
     end
   end


### PR DESCRIPTION
## Description ##

Modifed [Spree::AddressesHelper#user_available_addresses](https://github.com/spree/spree/blob/master/frontend/app/helpers/spree/addresses_helper.rb#L70) to suggest user addresses that exactly match the zone members of current store checkout zone.

Right now, selection is based on available countries, meaning that for example checkout zone of `kind: state` including Arizona state allows any United State user address to be rendered.