### PR TITLE
Fix Card Input Formatting Bug + Other Improvements

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,3 +21,7 @@ globals:
 env:
   browser: true
   jquery: true
+
+rules:
+  space-before-function-paren: off
+  semi: off

--- a/.eslintrc
+++ b/.eslintrc
@@ -21,7 +21,3 @@ globals:
 env:
   browser: true
   jquery: true
-
-rules:
-  space-before-function-paren: off
-  semi: off

--- a/backend/app/assets/javascripts/spree/backend.js
+++ b/backend/app/assets/javascripts/spree/backend.js
@@ -7,6 +7,7 @@
 //= require bootstrap-sprockets
 //= require handlebars
 //= require cleave
+//= require card_formatting
 //= require js.cookie
 //= require jquery.jstree/jquery.jstree
 //= require jquery_ujs

--- a/backend/app/assets/javascripts/spree/backend/payments/new.js
+++ b/backend/app/assets/javascripts/spree/backend/payments/new.js
@@ -1,6 +1,6 @@
-/* global formattAllCardInputFields */
+/* global formatAllCardInputFields */
 $(document).ready(function () {
-  formattAllCardInputFields()
+  formatAllCardInputFields()
   if ($('#new_payment').length) {
     $('.payment_methods_radios').click(
       function () {

--- a/backend/app/assets/javascripts/spree/backend/payments/new.js
+++ b/backend/app/assets/javascripts/spree/backend/payments/new.js
@@ -1,3 +1,4 @@
+/* global validateCardElements */
 $(document).ready(function () {
   validateCardElements()
   if ($('#new_payment').length) {

--- a/backend/app/assets/javascripts/spree/backend/payments/new.js
+++ b/backend/app/assets/javascripts/spree/backend/payments/new.js
@@ -1,6 +1,11 @@
 /* global formatAllCardInputFields */
-$(document).ready(function () {
-  formatAllCardInputFields()
+document.addEventListener('DOMContentLoaded', function() {
+  var cardPaymetnContainerEl = '.payment-gateway-fields'
+
+  formatCardNumber(cardPaymetnContainerEl, '.cardNumber', '.ccType')
+  formatCardExpiry (cardPaymetnContainerEl, '.cardExpiry')
+  formatCardCode (cardPaymetnContainerEl, '.cardCode')
+
   if ($('#new_payment').length) {
     $('.payment_methods_radios').click(
       function () {

--- a/backend/app/assets/javascripts/spree/backend/payments/new.js
+++ b/backend/app/assets/javascripts/spree/backend/payments/new.js
@@ -1,25 +1,6 @@
-/* global Cleave */
-
 $(document).ready(function () {
+  validateCardElements()
   if ($('#new_payment').length) {
-    /* eslint-disable no-new */
-    new Cleave('.cardNumber', {
-      creditCard: true,
-      onCreditCardTypeChanged: function (type) {
-        $('.ccType').val(type)
-      }
-    })
-    /* eslint-disable no-new */
-    new Cleave('.cardExpiry', {
-      date: true,
-      datePattern: ['m', 'Y']
-    })
-    /* eslint-disable no-new */
-    new Cleave('.cardCode', {
-      numericOnly: true,
-      blocks: [3]
-    })
-
     $('.payment_methods_radios').click(
       function () {
         $('.payment-methods').hide()

--- a/backend/app/assets/javascripts/spree/backend/payments/new.js
+++ b/backend/app/assets/javascripts/spree/backend/payments/new.js
@@ -1,10 +1,11 @@
-/* global formatAllCardInputFields */
+/* global formatCardNumber, formatCardExpiry, formatCardCode */
+
 document.addEventListener('DOMContentLoaded', function() {
   var cardPaymetnContainerEl = '.payment-gateway-fields'
 
   formatCardNumber(cardPaymetnContainerEl, '.cardNumber', '.ccType')
-  formatCardExpiry (cardPaymetnContainerEl, '.cardExpiry')
-  formatCardCode (cardPaymetnContainerEl, '.cardCode')
+  formatCardExpiry(cardPaymetnContainerEl, '.cardExpiry')
+  formatCardCode(cardPaymetnContainerEl, '.cardCode')
 
   if ($('#new_payment').length) {
     $('.payment_methods_radios').click(

--- a/backend/app/assets/javascripts/spree/backend/payments/new.js
+++ b/backend/app/assets/javascripts/spree/backend/payments/new.js
@@ -1,6 +1,6 @@
-/* global validateCardElements */
+/* global formattAllCardInputFields */
 $(document).ready(function () {
-  validateCardElements()
+  formattAllCardInputFields()
   if ($('#new_payment').length) {
     $('.payment_methods_radios').click(
       function () {

--- a/backend/app/views/spree/admin/payments/source_forms/_gateway.html.erb
+++ b/backend/app/views/spree/admin/payments/source_forms/_gateway.html.erb
@@ -23,7 +23,7 @@
       </div>
   </div>
 <% end %>
-  <div id="card_form<%= payment_method.id %>" class="mt-3 row" data-hook>
+  <div id="card_form<%= payment_method.id %>" class="mt-3 row payment-gateway-fields" data-hook>
     <% param_prefix = "payment_source[#{payment_method.id}]" %>
 
     <div data-hook="card_number" class="form-group col-12">

--- a/backend/app/views/spree/admin/shared/_translations.html.erb
+++ b/backend/app/views/spree/admin/shared/_translations.html.erb
@@ -6,6 +6,7 @@
     are_you_sure_delete:      Spree.t(:are_you_sure_delete),
     bill_address:             Spree.t(:bill_address),
     cancel:                   Spree.t(:cancel,  scope: :actions),
+    card_expire_year_format:  Spree.t(:card_expire_year_format),
     choose_a_customer:        Spree.t(:choose_a_customer),
     confirm_delete:           Spree.t(:confirm_delete),
     currency_separator:       I18n.t('number.currency.format.separator'),

--- a/core/app/assets/javascripts/card_formatting.js
+++ b/core/app/assets/javascripts/card_formatting.js
@@ -1,6 +1,6 @@
 /* global Cleave */
-/* exported validateCardElements */
 
+/* eslint-disable no-unused-vars */
 function validateCardElements () {
   if (document.querySelector('.cardNumber')) {
     document.querySelectorAll('.cardNumber').forEach(function (cardNumber) {

--- a/core/app/assets/javascripts/card_formatting.js
+++ b/core/app/assets/javascripts/card_formatting.js
@@ -1,46 +1,80 @@
 /* global Cleave */
 
 /* eslint-disable no-unused-vars */
-function formatAllCardInputFields () {
-  formatCardnumber()
-  formatCardExpiry()
-  formatCardCode()
-}
+function formatCardNumber (wrapperElement, cardNumberInput, cardTypeInput) {
+  if (document.querySelector(wrapperElement)) {
+      document.querySelectorAll(wrapperElement).forEach(function (cardPaymentSet) {
 
-function formatCardnumber () {
-  if (document.querySelector('.cardNumber')) {
-    document.querySelectorAll('.cardNumber').forEach(function (cardNumber) {
-      /* eslint-disable no-new */
-      new Cleave(cardNumber, {
-        creditCard: true,
-        onCreditCardTypeChanged: function (type) {
-          $('.ccType').val(type)
-        }
-      })
+      if (cardNumberInput) {
+        var targetNumberInput = cardPaymentSet.querySelector(cardNumberInput)
+      } else {
+        console.warn('Please identify your card number input using the second function argument')
+      }
+
+      if (cardTypeInput) {
+        var targetCardType = cardPaymentSet.querySelector(cardTypeInput)
+      } else {
+        console.warn('Please identify your card type input using the third function argument')
+      }
+
+      if (cardNumberInput && cardTypeInput) {
+        /* eslint-disable no-new */
+        new Cleave(targetNumberInput, {
+          creditCard: true,
+          onCreditCardTypeChanged: function (type) {
+            if (true) {}
+            targetCardType.value = type
+          }
+        })
+      }
     })
+  } else {
+    console.warn('Please identify the container element for the card input fields using the first function argument')
   }
 }
 
-function formatCardExpiry () {
-  if (document.querySelector('.cardExpiry')) {
-    document.querySelectorAll('.cardExpiry').forEach(function (cardExpiry) {
-      /* eslint-disable no-new */
-      new Cleave(cardExpiry, {
-        date: true,
-        datePattern: ['m', Spree.translations.card_expire_year_format]
-      })
+/* eslint-disable no-unused-vars */
+function formatCardExpiry (wrapperElement, cardExpiry) {
+  if (document.querySelector(wrapperElement)) {
+      document.querySelectorAll(wrapperElement).forEach(function (cardPaymentSet) {
+
+      if (cardExpiry) {
+        var targetCardExpiry = cardPaymentSet.querySelector(cardExpiry)
+      } else {
+        console.warn('Please identify your card expiry input field using the second argument in this function')
+      }
+
+      if (targetCardExpiry) {
+        /* eslint-disable no-new */
+        new Cleave(targetCardExpiry, {
+          date: true,
+          datePattern: ['m', Spree.translations.card_expire_year_format]
+        })
+      }
     })
+  } else {
+    console.warn('Please identify the container element for the card input fields using the first function argument')
   }
 }
 
-function formatCardCode () {
-  if (document.querySelector('.cardCode')) {
-    document.querySelectorAll('.cardCode').forEach(function (cardCode) {
+/* eslint-disable no-unused-vars */
+function formatCardCode (wrapperElement, cardCode) {
+  if (document.querySelector(wrapperElement)) {
+      document.querySelectorAll(wrapperElement).forEach(function (cardPaymentSet) {
+
+      if (cardCode) {
+        var targetCardCode = cardPaymentSet.querySelector(cardCode)
+      } else {
+        console.warn('Please identify your card CVV code input field')
+      }
+
       /* eslint-disable no-new */
-      new Cleave(cardCode, {
+      new Cleave(targetCardCode, {
         numericOnly: true,
         blocks: [3]
       })
     })
+  } else {
+    console.warn('Please identify the container element for the card input fields using the first function argument.')
   }
 }

--- a/core/app/assets/javascripts/card_formatting.js
+++ b/core/app/assets/javascripts/card_formatting.js
@@ -1,35 +1,25 @@
-/* global Cleave, validateCardElements */
+/* global Cleave */
+/* exported validateCardElements */
 
 function validateCardElements () {
   if (document.querySelector('.cardNumber')) {
     document.querySelectorAll('.cardNumber').forEach(function (cardNumber) {
       /* eslint-disable no-new */
-      new Cleave(cardNumber, {
-        creditCard: true,
-        onCreditCardTypeChanged: function (type) {
-          $('.ccType').val(type)
-        }
-      })
+      new Cleave(cardNumber, { creditCard: true, onCreditCardTypeChanged: function (type) { $('.ccType').val(type) } })
     })
   }
 
   if (document.querySelector('.cardExpiry')) {
     document.querySelectorAll('.cardExpiry').forEach(function (cardExpiry) {
       /* eslint-disable no-new */
-      new Cleave(cardExpiry, {
-        date: true,
-        datePattern: ['m', Spree.translations.card_expire_year_format]
-      })
+      new Cleave(cardExpiry, { date: true, datePattern: ['m', Spree.translations.card_expire_year_format] })
     })
   }
 
   if (document.querySelector('.cardCode')) {
     document.querySelectorAll('.cardCode').forEach(function (cardCode) {
       /* eslint-disable no-new */
-      new Cleave(cardCode, {
-        numericOnly: true,
-        blocks: [3]
-      })
+      new Cleave(cardCode, { numericOnly: true, blocks: [3] })
     })
   }
 }

--- a/core/app/assets/javascripts/card_formatting.js
+++ b/core/app/assets/javascripts/card_formatting.js
@@ -2,69 +2,52 @@
 
 /* eslint-disable no-unused-vars */
 function formatCardNumber (wrapperElement, cardNumberInput, cardTypeInput) {
-  if (document.querySelector(wrapperElement)) {
-    document.querySelectorAll(wrapperElement).forEach(function (cardPaymentSet) {
-      if (cardNumberInput) {
-        var targetNumberInput = cardPaymentSet.querySelector(cardNumberInput)
-      } else {
-        console.warn('Please identify your card number input using the second function argument')
-      }
+  if (!document.querySelector(wrapperElement)) return
+  if (!cardNumberInput) return console.warn('Identify the card number input using the second function argument')
+  if (!cardTypeInput) return console.warn('Identify the card type input using the third function argument')
 
-      if (cardTypeInput) {
-        var targetCardType = cardPaymentSet.querySelector(cardTypeInput)
-      } else {
-        console.warn('Please identify your card type input using the third function argument')
-      }
+  document.querySelectorAll(wrapperElement).forEach(function (cardPaymentSet) {
+    var targetNumberInput = cardPaymentSet.querySelector(cardNumberInput)
+    var targetCardType = cardPaymentSet.querySelector(cardTypeInput)
 
-      if (cardNumberInput && cardTypeInput) {
-        /* eslint-disable no-new */
-        new Cleave(targetNumberInput, {
-          creditCard: true,
-          onCreditCardTypeChanged: function (type) {
-            targetCardType.value = type
-          }
-        })
+    /* eslint-disable no-new */
+    new Cleave(targetNumberInput, {
+      creditCard: true,
+      onCreditCardTypeChanged: function (type) {
+        targetCardType.value = type
       }
     })
-  }
+  })
 }
 
 /* eslint-disable no-unused-vars */
 function formatCardExpiry (wrapperElement, cardExpiry) {
-  if (document.querySelector(wrapperElement)) {
-    document.querySelectorAll(wrapperElement).forEach(function (cardPaymentSet) {
-      if (cardExpiry) {
-        var targetCardExpiry = cardPaymentSet.querySelector(cardExpiry)
-      } else {
-        console.warn('Please identify your card expiry input field using the second argument in this function')
-      }
+  if (!document.querySelector(wrapperElement)) return
+  if (!cardExpiry) return console.warn('Identify the expiry input field using the second function argument')
 
-      if (targetCardExpiry) {
-        /* eslint-disable no-new */
-        new Cleave(targetCardExpiry, {
-          date: true,
-          datePattern: ['m', Spree.translations.card_expire_year_format]
-        })
-      }
+  document.querySelectorAll(wrapperElement).forEach(function (cardPaymentSet) {
+    var targetCardExpiry = cardPaymentSet.querySelector(cardExpiry)
+
+    /* eslint-disable no-new */
+    new Cleave(targetCardExpiry, {
+      date: true,
+      datePattern: ['m', Spree.translations.card_expire_year_format]
     })
-  }
+  })
 }
 
 /* eslint-disable no-unused-vars */
 function formatCardCode (wrapperElement, cardCode) {
-  if (document.querySelector(wrapperElement)) {
-    document.querySelectorAll(wrapperElement).forEach(function (cardPaymentSet) {
-      if (cardCode) {
-        var targetCardCode = cardPaymentSet.querySelector(cardCode)
-      } else {
-        console.warn('Please identify your card CVV code input field')
-      }
+  if (!document.querySelector(wrapperElement)) return
+  if (!cardCode) return console.warn('Identify the CVV code input field using the second function argument')
 
-      /* eslint-disable no-new */
-      new Cleave(targetCardCode, {
-        numericOnly: true,
-        blocks: [3]
-      })
+  document.querySelectorAll(wrapperElement).forEach(function (cardPaymentSet) {
+    var targetCardCode = cardPaymentSet.querySelector(cardCode)
+
+    /* eslint-disable no-new */
+    new Cleave(targetCardCode, {
+      numericOnly: true,
+      blocks: [3]
     })
-  }
+  })
 }

--- a/core/app/assets/javascripts/card_formatting.js
+++ b/core/app/assets/javascripts/card_formatting.js
@@ -3,8 +3,7 @@
 /* eslint-disable no-unused-vars */
 function formatCardNumber (wrapperElement, cardNumberInput, cardTypeInput) {
   if (document.querySelector(wrapperElement)) {
-      document.querySelectorAll(wrapperElement).forEach(function (cardPaymentSet) {
-
+    document.querySelectorAll(wrapperElement).forEach(function (cardPaymentSet) {
       if (cardNumberInput) {
         var targetNumberInput = cardPaymentSet.querySelector(cardNumberInput)
       } else {
@@ -22,7 +21,6 @@ function formatCardNumber (wrapperElement, cardNumberInput, cardTypeInput) {
         new Cleave(targetNumberInput, {
           creditCard: true,
           onCreditCardTypeChanged: function (type) {
-            if (true) {}
             targetCardType.value = type
           }
         })
@@ -36,8 +34,7 @@ function formatCardNumber (wrapperElement, cardNumberInput, cardTypeInput) {
 /* eslint-disable no-unused-vars */
 function formatCardExpiry (wrapperElement, cardExpiry) {
   if (document.querySelector(wrapperElement)) {
-      document.querySelectorAll(wrapperElement).forEach(function (cardPaymentSet) {
-
+    document.querySelectorAll(wrapperElement).forEach(function (cardPaymentSet) {
       if (cardExpiry) {
         var targetCardExpiry = cardPaymentSet.querySelector(cardExpiry)
       } else {
@@ -60,8 +57,7 @@ function formatCardExpiry (wrapperElement, cardExpiry) {
 /* eslint-disable no-unused-vars */
 function formatCardCode (wrapperElement, cardCode) {
   if (document.querySelector(wrapperElement)) {
-      document.querySelectorAll(wrapperElement).forEach(function (cardPaymentSet) {
-
+    document.querySelectorAll(wrapperElement).forEach(function (cardPaymentSet) {
       if (cardCode) {
         var targetCardCode = cardPaymentSet.querySelector(cardCode)
       } else {

--- a/core/app/assets/javascripts/card_formatting.js
+++ b/core/app/assets/javascripts/card_formatting.js
@@ -26,8 +26,6 @@ function formatCardNumber (wrapperElement, cardNumberInput, cardTypeInput) {
         })
       }
     })
-  } else {
-    console.warn('Please identify the container element for the card input fields using the first function argument')
   }
 }
 
@@ -49,8 +47,6 @@ function formatCardExpiry (wrapperElement, cardExpiry) {
         })
       }
     })
-  } else {
-    console.warn('Please identify the container element for the card input fields using the first function argument')
   }
 }
 
@@ -70,7 +66,5 @@ function formatCardCode (wrapperElement, cardCode) {
         blocks: [3]
       })
     })
-  } else {
-    console.warn('Please identify the container element for the card input fields using the first function argument.')
   }
 }

--- a/core/app/assets/javascripts/card_formatting.js
+++ b/core/app/assets/javascripts/card_formatting.js
@@ -1,8 +1,9 @@
-function validateCardElements () {
+/* global Cleave, validateCardElements */
 
-    // Formats card input
-    if (document.querySelector('.cardNumber')) {
+function validateCardElements () {
+  if (document.querySelector('.cardNumber')) {
     document.querySelectorAll('.cardNumber').forEach(function (cardNumber) {
+      /* eslint-disable no-new */
       new Cleave(cardNumber, {
         creditCard: true,
         onCreditCardTypeChanged: function (type) {
@@ -12,9 +13,9 @@ function validateCardElements () {
     })
   }
 
-  // Formats card expiry date
   if (document.querySelector('.cardExpiry')) {
     document.querySelectorAll('.cardExpiry').forEach(function (cardExpiry) {
+      /* eslint-disable no-new */
       new Cleave(cardExpiry, {
         date: true,
         datePattern: ['m', Spree.translations.card_expire_year_format]
@@ -22,9 +23,9 @@ function validateCardElements () {
     })
   }
 
-  // Formats card CVV code
   if (document.querySelector('.cardCode')) {
     document.querySelectorAll('.cardCode').forEach(function (cardCode) {
+      /* eslint-disable no-new */
       new Cleave(cardCode, {
         numericOnly: true,
         blocks: [3]

--- a/core/app/assets/javascripts/card_formatting.js
+++ b/core/app/assets/javascripts/card_formatting.js
@@ -1,0 +1,34 @@
+function validateCardElements () {
+
+    // Formats card input
+    if (document.querySelector('.cardNumber')) {
+    document.querySelectorAll('.cardNumber').forEach(function (cardNumber) {
+      new Cleave(cardNumber, {
+        creditCard: true,
+        onCreditCardTypeChanged: function (type) {
+          $('.ccType').val(type)
+        }
+      })
+    })
+  }
+
+  // Formats card expiry date
+  if (document.querySelector('.cardExpiry')) {
+    document.querySelectorAll('.cardExpiry').forEach(function (cardExpiry) {
+      new Cleave(cardExpiry, {
+        date: true,
+        datePattern: ['m', Spree.translations.card_expire_year_format]
+      })
+    })
+  }
+
+  // Formats card CVV code
+  if (document.querySelector('.cardCode')) {
+    document.querySelectorAll('.cardCode').forEach(function (cardCode) {
+      new Cleave(cardCode, {
+        numericOnly: true,
+        blocks: [3]
+      })
+    })
+  }
+}

--- a/core/app/assets/javascripts/card_formatting.js
+++ b/core/app/assets/javascripts/card_formatting.js
@@ -1,7 +1,7 @@
 /* global Cleave */
 
 /* eslint-disable no-unused-vars */
-function formattAllCardInputFields () {
+function formatAllCardInputFields () {
   formatCardnumber()
   formatCardExpiry()
   formatCardCode()

--- a/core/app/assets/javascripts/card_formatting.js
+++ b/core/app/assets/javascripts/card_formatting.js
@@ -1,25 +1,46 @@
 /* global Cleave */
 
 /* eslint-disable no-unused-vars */
-function validateCardElements () {
+function formattAllCardInputFields () {
+  formatCardnumber()
+  formatCardExpiry()
+  formatCardCode()
+}
+
+function formatCardnumber () {
   if (document.querySelector('.cardNumber')) {
     document.querySelectorAll('.cardNumber').forEach(function (cardNumber) {
       /* eslint-disable no-new */
-      new Cleave(cardNumber, { creditCard: true, onCreditCardTypeChanged: function (type) { $('.ccType').val(type) } })
+      new Cleave(cardNumber, {
+        creditCard: true,
+        onCreditCardTypeChanged: function (type) {
+          $('.ccType').val(type)
+        }
+      })
     })
   }
+}
 
+function formatCardExpiry () {
   if (document.querySelector('.cardExpiry')) {
     document.querySelectorAll('.cardExpiry').forEach(function (cardExpiry) {
       /* eslint-disable no-new */
-      new Cleave(cardExpiry, { date: true, datePattern: ['m', Spree.translations.card_expire_year_format] })
+      new Cleave(cardExpiry, {
+        date: true,
+        datePattern: ['m', Spree.translations.card_expire_year_format]
+      })
     })
   }
+}
 
+function formatCardCode () {
   if (document.querySelector('.cardCode')) {
     document.querySelectorAll('.cardCode').forEach(function (cardCode) {
       /* eslint-disable no-new */
-      new Cleave(cardCode, { numericOnly: true, blocks: [3] })
+      new Cleave(cardCode, {
+        numericOnly: true,
+        blocks: [3]
+      })
     })
   }
 }

--- a/core/app/assets/javascripts/spree.js
+++ b/core/app/assets/javascripts/spree.js
@@ -2,7 +2,7 @@
 function Spree () {}
 
 Spree.ready = function (callback) {
-  return jQuery(document).on('page:load turbolinks:load', function () {
+  return window.addEventListener('turbolinks:load', function () {
     return callback(jQuery)
   })
 }

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -639,6 +639,8 @@ en:
     capture: Capture
     capture_events: Capture events
     card_code: Card Varification Code (CVC)
+    card_expire_human_readable: 'MM/YYYY'  # Match for the formatting below
+    card_expire_year_format: 'Y'  # Y for MM/YYYY | y for MM/YY
     card_number: Card Number
     card_type: Brand
     card_type_is: Card type is

--- a/frontend/app/assets/javascripts/spree/frontend.js
+++ b/frontend/app/assets/javascripts/spree/frontend.js
@@ -5,6 +5,7 @@
 //= require jquery.payment
 //= require cleave
 //= require spree
+//= require card_formatting
 //= require polyfill.min
 //= require fetch.umd
 //= require spree/api/main

--- a/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js
@@ -1,4 +1,4 @@
-/* global formattAllCardInputFields */
+/* global formatAllCardInputFields */
 //= require spree/frontend/coupon_manager
 
 Spree.ready(function ($) {
@@ -74,5 +74,5 @@ Spree.ready(function ($) {
     }
   }
   Spree.onPayment()
-  formattAllCardInputFields()
+  formatAllCardInputFields()
 })

--- a/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js
@@ -1,4 +1,4 @@
-/* global formatAllCardInputFields */
+/* global formatCardNumber, formatCardExpiry, formatCardCode */
 //= require spree/frontend/coupon_manager
 
 Spree.ready(function ($) {
@@ -78,6 +78,6 @@ Spree.ready(function ($) {
   var cardPaymetnContainerEl = '.payment-gateway-fields'
 
   formatCardNumber(cardPaymetnContainerEl, '.cardNumber', '.ccType')
-  formatCardExpiry (cardPaymetnContainerEl, '.cardExpiry')
-  formatCardCode (cardPaymetnContainerEl, '.cardCode')
+  formatCardExpiry(cardPaymetnContainerEl, '.cardExpiry')
+  formatCardCode(cardPaymetnContainerEl, '.cardCode')
 })

--- a/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js
@@ -1,3 +1,4 @@
+/* global validateCardElements */
 //= require spree/frontend/coupon_manager
 
 Spree.ready(function ($) {

--- a/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js
@@ -1,9 +1,5 @@
-/* global Cleave */
-var CARD_NUMBER_SELECTOR = '.cardNumber'
-var CARD_EXPIRATION_SELECTOR = '.cardExpiry'
-var CARD_CODE_SELECTOR = '.cardCode'
-
 //= require spree/frontend/coupon_manager
+
 Spree.ready(function ($) {
   Spree.onPayment = function () {
     if ($('#checkout_form_payment').length) {
@@ -21,28 +17,6 @@ Spree.ready(function ($) {
           $('.existing-cc-radio').prop('checked', false)
           $('#use_existing_card_yes').prop('checked', false)
           Spree.enableSave()
-        })
-      }
-
-      if ($(CARD_NUMBER_SELECTOR).length > 0 &&
-          $(CARD_EXPIRATION_SELECTOR).length > 0 &&
-          $(CARD_CODE_SELECTOR).length > 0) {
-        /* eslint-disable no-new */
-        new Cleave(CARD_NUMBER_SELECTOR, {
-          creditCard: true,
-          onCreditCardTypeChanged: function (type) {
-            $('.ccType').val(type)
-          }
-        })
-        /* eslint-disable no-new */
-        new Cleave(CARD_EXPIRATION_SELECTOR, {
-          date: true,
-          datePattern: ['m', 'Y']
-        })
-        /* eslint-disable no-new */
-        new Cleave(CARD_CODE_SELECTOR, {
-          numericOnly: true,
-          blocks: [3]
         })
       }
 
@@ -99,4 +73,5 @@ Spree.ready(function ($) {
     }
   }
   Spree.onPayment()
+  validateCardElements()
 })

--- a/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js
@@ -1,4 +1,4 @@
-/* global validateCardElements */
+/* global formattAllCardInputFields */
 //= require spree/frontend/coupon_manager
 
 Spree.ready(function ($) {
@@ -74,5 +74,5 @@ Spree.ready(function ($) {
     }
   }
   Spree.onPayment()
-  validateCardElements()
+  formattAllCardInputFields()
 })

--- a/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js
@@ -74,5 +74,10 @@ Spree.ready(function ($) {
     }
   }
   Spree.onPayment()
-  formatAllCardInputFields()
+
+  var cardPaymetnContainerEl = '.payment-gateway-fields'
+
+  formatCardNumber(cardPaymetnContainerEl, '.cardNumber', '.ccType')
+  formatCardExpiry (cardPaymetnContainerEl, '.cardExpiry')
+  formatCardCode (cardPaymetnContainerEl, '.cardCode')
 })

--- a/frontend/app/views/spree/checkout/payment/_gateway.html.erb
+++ b/frontend/app/views/spree/checkout/payment/_gateway.html.erb
@@ -3,13 +3,15 @@
   <% param_prefix = "payment_source[#{payment_method.id}]" %>
 
   <div class="payment-gateway-fields">
-    <div class="mb-4 payment-gateway-field checkout-content-inner-field">
-      <%= text_field_tag "#{param_prefix}[name]", "#{@order.bill_address_firstname} #{@order.bill_address_lastname}", { id: "name_on_card", class: 'spree-flat-input', placeholder: Spree.t(:name_on_card)} %>
+    <div class="mb-4 payment-gateway-field checkout-content-inner-field has-float-label">
+      <%= text_field_tag "#{param_prefix}[name]", "#{@order.bill_address_firstname} #{@order.bill_address_lastname}", { id: "name_on_card_#{payment_method.id}", class: 'spree-flat-input', placeholder: Spree.t(:name_on_card)} %>
+      <label><%= Spree.t(:name_on_card) %></label>
     </div>
 
-    <div class="mb-4 payment-gateway-field checkout-content-inner-field" data-hook="card_number">
+    <div class="mb-4 payment-gateway-field checkout-content-inner-field has-float-label" data-hook="card_number">
       <% options_hash = Rails.env.production? ? {autocomplete: 'off'} : {} %>
-      <%= text_field_tag "#{param_prefix}[number]", '', options_hash.merge(id: 'card_number', class: 'spree-flat-input cardNumber', size: 19, maxlength: 19, autocomplete: "off", placeholder: Spree.t(:card_number)) %>
+      <%= text_field_tag "#{param_prefix}[number]", '', options_hash.merge(id: "card_number_#{payment_method.id}", class: 'spree-flat-input cardNumber', size: 19, maxlength: 19, autocomplete: "off", placeholder: Spree.t(:card_number)) %>
+      <label><%= Spree.t(:card_number) %></label>
       <span id="card_type" style="display:none;">
         ( <span id="looks_like"><%= Spree.t(:card_type_is) %> <span id="type"></span></span>
           <span id="unrecognized"><%= Spree.t(:unrecognized_card_type) %></span>
@@ -17,11 +19,13 @@
       </span>
     </div>
     <div class="payment-gateway-half-fields d-flex justify-content-between">
-      <div class="payment-gateway-field checkout-content-inner-field" data-hook="card_expiration">
-        <%= text_field_tag "#{param_prefix}[expiry]", '', id: 'card_expiry', class: 'spree-flat-input cardExpiry', placeholder: "MM/YYYY" %>
+      <div class="payment-gateway-field checkout-content-inner-field has-float-label" data-hook="card_expiration">
+        <%= text_field_tag "#{param_prefix}[expiry]", '', id: "card_expiry_#{payment_method.id}", class: 'spree-flat-input cardExpiry', placeholder: Spree.t(:card_expire_human_readable) %>
+        <label><%= Spree.t(:card_expire_human_readable) %></label>
       </div>
-      <div class="payment-gateway-field checkout-content-inner-field" data-hook="card_code">
-        <%= text_field_tag "#{param_prefix}[verification_value]", '', options_hash.merge(id: 'card_code', class: 'spree-flat-input cardCode', size: 5, placeholder: Spree.t(:cvv)) %>
+      <div class="payment-gateway-field checkout-content-inner-field has-float-label" data-hook="card_code">
+        <%= text_field_tag "#{param_prefix}[verification_value]", '', options_hash.merge(id: "card_code_#{payment_method.id}", class: 'spree-flat-input cardCode', size: 5, placeholder: Spree.t(:cvv)) %>
+        <label><%= Spree.t(:cvv) %></label>
       </div>
     </div>
 

--- a/frontend/app/views/spree/shared/_translations.html.erb
+++ b/frontend/app/views/spree/shared/_translations.html.erb
@@ -4,7 +4,8 @@
         {
           coupon_code_applied: Spree.t(:coupon_code_applied),
           coupon_code_removed: Spree.t(:coupon_code_removed),
-          coupon_code_error_icon: image_path('error.svg')
+          coupon_code_error_icon: image_path('error.svg'),
+          card_expire_year_format: Spree.t(:card_expire_year_format)
         }.to_json
                            %>
   });

--- a/frontend/spec/support/shared_contexts/checkout_address_book.rb
+++ b/frontend/spec/support/shared_contexts/checkout_address_book.rb
@@ -55,10 +55,10 @@ shared_context 'checkout address book' do
   end
 
   def fill_in_credit_card_info(address)
-    fill_in 'name_on_card', with: "#{address.firstname} #{address.lastname}"
-    fill_in 'card_number', with: '4111 1111 1111 1111'
-    fill_in 'card_expiry', with: '12 / 24'
-    fill_in 'card_code', with: '123'
+    fill_in Spree.t(:name_on_card), with: "#{address.firstname} #{address.lastname}"
+    fill_in Spree.t(:card_number), with: '4111 1111 1111 1111'
+    fill_in Spree.t(:card_expire_human_readable), with: '12 / 24'
+    fill_in Spree.t(:cvv), with: '123'
   end
 
   def expected_address_format(address_title, address)

--- a/frontend/spec/support/shared_contexts/checkout_setup.rb
+++ b/frontend/spec/support/shared_contexts/checkout_setup.rb
@@ -23,10 +23,10 @@ shared_context 'checkout setup' do
   end
 
   def fill_in_credit_card_info(invalid: false)
-    fill_in 'name_on_card', with: 'Spree Commerce'
-    fill_in 'card_number', with: invalid ? '123' : '4111 1111 1111 1111'
-    fill_in 'card_expiry', with: '12 / 24'
-    fill_in 'card_code', with: '123'
+    fill_in Spree.t(:name_on_card), with: 'Spree Commerce'
+    fill_in Spree.t(:card_number), with: invalid ? '123' : '4111 1111 1111 1111'
+    fill_in Spree.t(:card_expire_human_readable), with: '12 / 24'
+    fill_in Spree.t(:cvv), with: '123'
   end
 
   def add_mug_to_cart


### PR DESCRIPTION
- Fixed a bug: If a store has multiple payment options that allow card inputs, the formatting would only apply to the first in the DOM.
- Moved a common section of JavaScript into the core, to be called as a utility function from the frontend or backend as needed.
- Added the translations to MM/YYYY or MM/YY for card express date.
- Added floating labels to card input fields.