### PR TITLE
Move back into BaseController some methods moved previously to Resour…

### DIFF
--- a/api/app/controllers/spree/api/v2/base_controller.rb
+++ b/api/app/controllers/spree/api/v2/base_controller.rb
@@ -15,6 +15,32 @@ module Spree
           Spree::Api::Config[:api_v2_content_type]
         end
 
+        protected
+
+        def serialize_collection(collection)
+          collection_serializer.new(
+            collection,
+            collection_options(collection).merge(params: serializer_params)
+          ).serializable_hash
+        end
+
+        def serialize_resource(resource)
+          resource_serializer.new(
+            resource,
+            params: serializer_params,
+            include: resource_includes,
+            fields: sparse_fields
+          ).serializable_hash
+        end
+
+        def paginated_collection
+          collection_paginator.new(sorted_collection, params).call
+        end
+
+        def collection_paginator
+          Spree::Api::Dependencies.storefront_collection_paginator.constantize
+        end
+
         def render_serialized_payload(status = 200)
           render json: yield, status: status, content_type: content_type
         rescue ArgumentError => exception

--- a/api/app/controllers/spree/api/v2/resource_controller.rb
+++ b/api/app/controllers/spree/api/v2/resource_controller.rb
@@ -14,30 +14,6 @@ module Spree
 
         protected
 
-        def serialize_collection(collection)
-          collection_serializer.new(
-            collection,
-            collection_options(collection).merge(params: serializer_params)
-          ).serializable_hash
-        end
-
-        def serialize_resource(resource)
-          resource_serializer.new(
-            resource,
-            params: serializer_params,
-            include: resource_includes,
-            fields: sparse_fields
-          ).serializable_hash
-        end
-
-        def paginated_collection
-          collection_paginator.new(sorted_collection, params).call
-        end
-
-        def collection_paginator
-          Spree::Api::Dependencies.storefront_collection_paginator.constantize
-        end
-
         def sorted_collection
           collection_sorter.new(collection, params, allowed_sort_attributes).call
         end


### PR DESCRIPTION
…ceController

This can be a big breaking change for existing Spree isntallations and we should perform this in a better way during 4.x->5.0 migration.