### PR TITLE
Fixed Ruby 2.7 errors for the Spree 4.0

### DIFF
--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -24,10 +24,9 @@ module Spree
     attribute :month, ActiveRecord::Type::Integer.new
     attribute :year,  ActiveRecord::Type::Integer.new
 
-    attr_reader :number
+    attr_reader :number, :verification_value
     attr_accessor :encrypted_data,
                   :imported,
-                  :verification_value,
                   :manual_entry
 
     with_options if: :require_card_numbers?, on: :create do
@@ -101,9 +100,11 @@ module Spree
                        end
     end
 
+    def verification_value=(value)
+      @verification_value = value.to_s.gsub(/\s/, '')
+    end
+
     def set_last_digits
-      number.to_s.gsub!(/\s/, '')
-      verification_value.to_s.gsub!(/\s/, '')
       self.last_digits ||= number.to_s.length <= 4 ? number : number.to_s.slice(-4..-1)
     end
 

--- a/core/app/models/spree/preferences/preferable.rb
+++ b/core/app/models/spree/preferences/preferable.rb
@@ -100,7 +100,7 @@ module Spree::Preferences::Preferable
       if value.is_a?(FalseClass) ||
           value.nil? ||
           value == 0 ||
-          value =~ /^(f|false|0)$/i ||
+          value&.to_s =~ /^(f|false|0)$/i ||
           (value.respond_to?(:empty?) && value.empty?)
         false
       else

--- a/core/lib/generators/spree/dummy/dummy_generator.rb
+++ b/core/lib/generators/spree/dummy/dummy_generator.rb
@@ -137,7 +137,7 @@ end
     end
 
     def gemfile_path
-      core_gems = ['spree/core', 'spree/api', 'spree/backend', 'spree/frontend']
+      core_gems = ['spree/core', 'spree/api', 'spree/backend', 'spree/frontend', 'spree/sample']
 
       if core_gems.include?(lib_name)
         '../../../../../Gemfile'

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -144,6 +144,28 @@ describe Spree::CreditCard, type: :model do
     end
   end
 
+  describe "#verification_value=" do
+    it "accepts a valid 3-digit value" do
+      credit_card.verification_value = "123"
+      expect(credit_card.verification_value).to eq("123")
+    end
+
+    it "accepts a valid 4-digit value" do
+      credit_card.verification_value = "1234"
+      expect(credit_card.verification_value).to eq("1234")
+    end
+
+    it "stringifies an integer" do
+      credit_card.verification_value = 123
+      expect(credit_card.verification_value).to eq("123")
+    end
+
+    it "strips any whitespace" do
+      credit_card.verification_value = ' 1 2  3 '
+      expect(credit_card.verification_value).to eq('123')
+    end
+  end
+
   # Regression test for #3847 & #3896
   context '#expiry=' do
     it 'can set with a 2-digit month and year' do
@@ -281,7 +303,7 @@ describe Spree::CreditCard, type: :model do
       expect(am_card.month).to eq(Time.current.month)
       expect(am_card.first_name).to eq('Ludwig')
       expect(am_card.last_name).to eq('van Beethoven')
-      expect(am_card.verification_value).to eq(123)
+      expect(am_card.verification_value).to eq('123')
     end
   end
 

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -84,7 +84,7 @@ module Spree
 
           allow(subject).to receive(:shipping_methods).and_return(shipping_methods)
 
-          expect(subject.shipping_rates(package).map(&:cost)).to eq %w[3.00 4.00 5.00].map(&BigDecimal.method(:new))
+          expect(subject.shipping_rates(package).map(&:cost)).to eq [3.00, 4.00, 5.00]
         end
 
         context 'general shipping methods' do


### PR DESCRIPTION
Fixes #10088 , fixes #10088

Adds CreditCard#verification_value= method based on
https://github.com/solidusio/solidus/commit/d76cc5c580a685f0cdd24561d76d85541dff3be1