### PR TITLE
fix: use select2-full for full back compatibility

### DIFF
--- a/backend/app/assets/javascripts/spree/backend.js
+++ b/backend/app/assets/javascripts/spree/backend.js
@@ -11,7 +11,7 @@
 //= require jquery.jstree/jquery.jstree
 //= require jquery_ujs
 //= require jquery-ui/widgets/autocomplete
-//= require select2
+//= require select2-full
 //= require underscore-min.js
 
 //= require spree


### PR DESCRIPTION
With Spree 4.2 some of our custom backend admin pages broke because select2 @v4 breaks backwards compatibility by default unless `select2-full` is loaded.