### PR TITLE
Disable client authentication for password grant in the Doorkeeper

### DIFF
--- a/api/config/initializers/doorkeeper.rb
+++ b/api/config/initializers/doorkeeper.rb
@@ -3,7 +3,7 @@ Doorkeeper.configure do
   use_refresh_token
   api_only
 
-  skip_client_authentication_for_password_grant { true }
+  skip_client_authentication_for_password_grant { true } if defined?(skip_client_authentication_for_password_grant)
 
   resource_owner_authenticator { current_spree_user }
 

--- a/api/config/initializers/doorkeeper.rb
+++ b/api/config/initializers/doorkeeper.rb
@@ -3,6 +3,8 @@ Doorkeeper.configure do
   use_refresh_token
   api_only
 
+  skip_client_authentication_for_password_grant { true }
+
   resource_owner_authenticator { current_spree_user }
 
   resource_owner_from_credentials do


### PR DESCRIPTION
Doorkeeper in the version `>= 5.5` will require `client_id` and `client_secret` when using `grant_type=password` 