### PR TITLE
Fix copyright link target attribute

### DIFF
--- a/frontend/app/views/spree/shared/_copyright.html.erb
+++ b/frontend/app/views/spree/shared/_copyright.html.erb
@@ -3,7 +3,7 @@
     <div class="d-flex flex-column flex-lg-row align-items-center justify-content-center py-3 footer-spree-copyright-content">
       <div>Designed and developed by</div>
       <div class="mb-1 mb-lg-0">
-        <%= link_to 'https://sparksolutions.co/', target: :blank, 'aria-label': 'Go to Spark Solutions', rel: :follow do %>
+        <%= link_to 'https://sparksolutions.co/', target: :_blank, 'aria-label': 'Go to Spark Solutions', rel: :follow do %>
           <%= image_tag 'spark-logo@3x.png', class: 'footer-spree-copyright-logo-spark mx-2', alt: 'Spree Commerce & Ruby on Rails developers', title: 'Spree Commerce & Ruby on Rails developers' %>
         <% end %>
       </div>


### PR DESCRIPTION
Using just `:blank` doesn't work, it must be `:_blank`.