### PR TITLE
Remove page from whitelisted parameters

### DIFF
--- a/frontend/config/initializers/canonical_rails.rb
+++ b/frontend/config/initializers/canonical_rails.rb
@@ -10,5 +10,5 @@ CanonicalRails.setup do |config|
   # Parameter spamming can cause index dilution by creating seemingly different URLs with identical or near-identical content.
   # Unless whitelisted, these parameters will be omitted
 
-  config.allowed_parameters = [:keywords, :page, :search, :taxon]
+  config.allowed_parameters = [:keywords, :search, :taxon]
 end


### PR DESCRIPTION
SEMrush seo report shows that we should remove `page` param from whitelist because it treats same URL as different sites:

SEO report example:
<img width="531" alt="Screenshot 2021-03-01 at 13 25 47" src="https://user-images.githubusercontent.com/43354669/109497077-d0fcb100-7a91-11eb-9a23-8838248c8983.png">
