### PR TITLE
Fix incorrect popup on cart page during success flash

### DIFF
--- a/frontend/app/views/spree/orders/edit.html.erb
+++ b/frontend/app/views/spree/orders/edit.html.erb
@@ -96,7 +96,7 @@
 <script>
   window.addEventListener('DOMContentLoaded', function() {
     Spree.current_order_token = "<%= @order.token %>"
-    <% if flash.any? %>
+    <% if flash[:error].present? %>
       document.getElementById('overlay').classList.add('shown');
       document.getElementById('no-product-available').classList.add('shown');
       window.scrollTo(0, 0);


### PR DESCRIPTION
Fixes #10423 

# Description
This PR fixes a bug where if we redirect to `spree.cart_path` with any flash type(for eg: `:success` or `:warning`), it incorrectly shows the `no-product-available` popup.
Currently, the only scenario where we redirect to cart with a flash is if the order has insufficient stock line items during the checkout.