### PR TITLE
Make product modal reusable

### DIFF
--- a/frontend/app/views/spree/shared/_product_added_modal.html.erb
+++ b/frontend/app/views/spree/shared/_product_added_modal.html.erb
@@ -48,14 +48,14 @@
           <div class="row pb-4 justify-content-center">
             <div class="col-12 col-lg-8">
               <%= link_to spree.checkout_path, class: 'btn btn-primary w-100 font-weight-bold text-uppercase product-added-modal-button', method: :get do %>
-                <%= Spree.t('checkout') %>
+                <%= Spree.t(:checkout) %>
               <% end %>
             </div>
           </div>
           <div class="row justify-content-center">
             <div class="col-12 col-lg-8">
               <%= link_to spree.cart_path, class: 'btn btn-outline-primary w-100 font-weight-bold text-uppercase product-added-modal-button' do %>
-                <%= Spree.t('view_cart') %>
+                <%= Spree.t(:view_cart) %>
               <% end %>
             </div>
           </div>

--- a/frontend/app/views/spree/shared/_product_added_modal.html.erb
+++ b/frontend/app/views/spree/shared/_product_added_modal.html.erb
@@ -34,7 +34,7 @@
           </div>
           <div class="row pt-5 justify-content-center align-items-center product-added-modal-product">
             <div class="col-4 col-sm-2 product-added-modal-product-image-container">
-              <img class="product-added-modal-product-image-container-image" src="data:," alt="">
+              <img class="product-added-modal-product-image-container-image" src="data:," alt="<%= @product&.name %>">
             </div>
             <div class="col-8 col-sm-6 col-lg-4 py-1 product-added-modal-product-details">
               <div class="product-added-modal-product-details-name"></div>

--- a/frontend/app/views/spree/shared/_product_added_modal.html.erb
+++ b/frontend/app/views/spree/shared/_product_added_modal.html.erb
@@ -55,7 +55,7 @@
           <div class="row justify-content-center">
             <div class="col-12 col-lg-8">
               <%= link_to spree.cart_path, class: 'btn btn-outline-primary w-100 font-weight-bold text-uppercase product-added-modal-button' do %>
-                <%= Spree.t(:view_cart) %>
+                <%= Spree.t('pdp.view_cart') %>
               <% end %>
             </div>
           </div>

--- a/frontend/app/views/spree/shared/_product_added_modal.html.erb
+++ b/frontend/app/views/spree/shared/_product_added_modal.html.erb
@@ -48,14 +48,14 @@
           <div class="row pb-4 justify-content-center">
             <div class="col-12 col-lg-8">
               <%= link_to spree.checkout_path, class: 'btn btn-primary w-100 font-weight-bold text-uppercase product-added-modal-button', method: :get do %>
-                <%= Spree.t('pdp.checkout') %>
+                <%= Spree.t('checkout') %>
               <% end %>
             </div>
           </div>
           <div class="row justify-content-center">
             <div class="col-12 col-lg-8">
               <%= link_to spree.cart_path, class: 'btn btn-outline-primary w-100 font-weight-bold text-uppercase product-added-modal-button' do %>
-                <%= Spree.t('pdp.view_cart') %>
+                <%= Spree.t('view_cart') %>
               <% end %>
             </div>
           </div>

--- a/frontend/app/views/spree/shared/_product_added_modal.html.erb
+++ b/frontend/app/views/spree/shared/_product_added_modal.html.erb
@@ -34,7 +34,7 @@
           </div>
           <div class="row pt-5 justify-content-center align-items-center product-added-modal-product">
             <div class="col-4 col-sm-2 product-added-modal-product-image-container">
-              <img class="product-added-modal-product-image-container-image" src="data:," alt="<%= @product.name %>">
+              <img class="product-added-modal-product-image-container-image" src="data:," alt="">
             </div>
             <div class="col-8 col-sm-6 col-lg-4 py-1 product-added-modal-product-details">
               <div class="product-added-modal-product-details-name"></div>


### PR DESCRIPTION
Since `product_added_modal.js` already inserts the product's name and image alt text, it's pointless to have a `product` variable inside the modal's HTML. This makes the modal reusable should a client wishes to use the modal on other pages, ie: in a products loop.

```js
[..]

$modal.find(nameSelector).text(name) // Here
$modal.find(priceSelector).html(price)

 if (leadImage !== null) {
    $modal
      .removeClass(modalNoImageClass)
      .find(imageSelector)
      .attr('src', leadImage.url_product)
      .attr('alt', leadImage.alt || name) // Here
  } else {

[..]

```