### PR TITLE
Allow for use of Spree in other languages, without spree_i18n ext

### DIFF
--- a/backend/lib/spree_backend.rb
+++ b/backend/lib/spree_backend.rb
@@ -1,3 +1,4 @@
 require 'spree/backend'
 require 'sprockets/rails'
 require 'bootstrap'
+require 'rails-i18n'

--- a/backend/spree_backend.gemspec
+++ b/backend/spree_backend.gemspec
@@ -34,5 +34,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'inline_svg',      '~> 1.5'
   s.add_dependency 'jquery-rails',    '~> 4.3'
   s.add_dependency 'jquery-ui-rails', '~> 6.0.1'
+  s.add_dependency 'rails-i18n'
   s.add_dependency 'select2-rails',   '~> 4.0.0'
 end

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -20,6 +20,7 @@ module Spree
 
       initializer 'spree.environment', before: :load_config_initializers do |app|
         app.config.spree = Environment.new(SpreeCalculators.new, Spree::AppConfiguration.new, Spree::AppDependencies.new)
+        app.config.i18n.fallbacks = true
         Spree::Config = app.config.spree.preferences
         Spree::Dependencies = app.config.spree.dependencies
       end


### PR DESCRIPTION
Taken the `rails-i18n` gem and `app.config.i18n.fallbacks = true` form the spree_i18n extension, and added them to Spree, this is to stop the admin ui crashing, if a user decides to pick one of the none default languages for the default store / default language.

If you set the default store - default language to anything other than English and navigate to the Orders page you get this:
<img width="1032" alt="Screenshot 2021-03-11 at 11 59 04" src="https://user-images.githubusercontent.com/1240766/110788822-08741600-8267-11eb-804e-5b1db0245cea.png">

I tried to write a test for this but for the life in me I cant replicate this in the test environment. It's like the dummy app has fallback switched on, or maybe the test environment pulls in a gem that required `rails-i18n`, although the gem lock file does not show it, I'm at a loss as to why the capybara can visit the orders page in `:fr` and the store works.


It might be wise to `require 'rails-18n'` for the frontend also? Although the fallback would stop any crashing, you would just get any dates localised?
