### PR TITLE
Fix Duplicate Locales Coming From spree_i18n

### DIFF
--- a/core/lib/spree/i18n.rb
+++ b/core/lib/spree/i18n.rb
@@ -18,12 +18,7 @@ module Spree
 
     def available_locales
       locales_from_i18n = I18n.available_locales
-      locales =
-        if defined?(SpreeI18n)
-          (SpreeI18n::Locale.all << :en).map(&:to_s)
-        else
-          [Rails.application.config.i18n.default_locale, I18n.locale, :en]
-        end
+      locales = [Rails.application.config.i18n.default_locale, I18n.locale, :en]
 
       (locales + locales_from_i18n).uniq.compact
     end

--- a/core/spec/lib/i18n_spec.rb
+++ b/core/spec/lib/i18n_spec.rb
@@ -19,30 +19,12 @@ describe 'i18n' do
   end
 
   describe '#available_locales' do
-    context 'when SpreeI18n is defined' do
-      before do
-        class_double('SpreeI18n').
-          as_stubbed_const(transfer_nested_constants: true)
-        class_double('SpreeI18n::Locale', all: [:en, :de, :nl]).as_stubbed_const(transfer_nested_constants: true)
-      end
+    it 'returns locales defined in Spree and all other installed gems' do
+      locales = Spree.available_locales
 
-      it 'returns all locales from the SpreeI18n' do
-        locales = Spree.available_locales
+      expected_locales = ([Rails.application.config.i18n.default_locale, I18n.locale, :en] + I18n.available_locales).uniq.compact
 
-        expected_locales = (['en', 'de', 'nl'] + I18n.available_locales).uniq.compact
-
-        expect(locales).to eq expected_locales
-      end
-    end
-
-    context 'when SpreeI18n is not defined' do
-      it 'returns just default locales' do
-        locales = Spree.available_locales
-
-        expected_locales = ([Rails.application.config.i18n.default_locale, I18n.locale, :en] + I18n.available_locales).uniq.compact
-
-        expect(locales).to eq expected_locales
-      end
+      expect(locales).to eq expected_locales
     end
   end
 


### PR DESCRIPTION
`I18n.available_locales` finds all locales defined in the main Rails app and any installed gems.
The behaviour in spree_i18n seems to duplicate this unnecessarily. 