### PR TITLE
Fix spree localizedpathfor js function

### DIFF
--- a/core/app/assets/javascripts/spree.js
+++ b/core/app/assets/javascripts/spree.js
@@ -8,7 +8,7 @@ Spree.ready = function (callback) {
 }
 
 Spree.mountedAt = function () {
-  return window.SpreePaths.mounted_at
+    return window.SpreePaths.mounted_at
 }
 
 Spree.adminPath = function () {
@@ -32,10 +32,9 @@ Spree.localizedPathFor = function(path) {
     if (pathName.match(/api\/v/)) {
       params.set('locale', SPREE_LOCALE)
     } else {
-      pathName = SPREE_LOCALE + '/' + pathName
+      pathName = SPREE_LOCALE + '/' + path
     }
-
-    path = pathName + '?' + params.toString()
+    return fullUrl.origin + (this.mountedAt()) + pathName + '?' + params.toString()
   }
   return Spree.pathFor(path)
 }

--- a/core/app/assets/javascripts/spree.js
+++ b/core/app/assets/javascripts/spree.js
@@ -8,7 +8,7 @@ Spree.ready = function (callback) {
 }
 
 Spree.mountedAt = function () {
-    return window.SpreePaths.mounted_at
+  return window.SpreePaths.mounted_at
 }
 
 Spree.adminPath = function () {


### PR DESCRIPTION
The issue is when we have mounted default namespace for our shop i.e `domain.com/shop/`
<img width="701" alt="Screenshot 2021-03-19 at 18 16 26" src="https://user-images.githubusercontent.com/43354669/111818447-765fb380-88df-11eb-81b5-f7d7cf28db79.png">

When we call `Spree.localizedPathFor('account_link')` it returns https://domain/shop/en//shop/account_link?currency=USD (we have doubled `/shop` namespace in URL.)
This is because `localizedPathFor` function calls `Spree.pathFor(path)` twice which uses `Spree.mountedAt` where we get mounted namespace.

To get rid of this I used created URL object.

Current behaviour:
<img width="447" alt="Screenshot 2021-03-19 at 17 47 56" src="https://user-images.githubusercontent.com/43354669/111814885-4c0bf700-88db-11eb-955a-b32e65f0a788.png">
New behaviour:
<img width="407" alt="Screenshot 2021-03-19 at 17 51 46" src="https://user-images.githubusercontent.com/43354669/111815352-d94f4b80-88db-11eb-8ca7-d52e21158532.png">

