### PR TITLE
Ensure comparison is on a symbol.

### DIFF
--- a/backend/app/helpers/spree/admin/base_helper.rb
+++ b/backend/app/helpers/spree/admin/base_helper.rb
@@ -147,7 +147,7 @@ module Spree
                 (form.select "preferred_#{key}", currency_options(object.preferences[key]), {}, { class: 'form-control select2' }),
                           class: 'form-group', id: [object.class.to_s.parameterize, 'preference', key].join('-'))
             else
-              if object.preference_type(key) == :boolean
+              if object.preference_type(key).to_sym == :boolean
                 content_tag(:div, preference_field_for(form, "preferred_#{key}", type: object.preference_type(key)) +
                   form.label("preferred_#{key}", Spree.t(key), class: 'form-check-label'),
                             class: 'form-group form-check', id: [object.class.to_s.parameterize, 'preference', key].join('-'))


### PR DESCRIPTION
Possible Fix for: Admin Panel: Misplaced checkboxes in the Payment Provider Settings window #10902

I can't confirm if this is a fix yet, as I can't recreate the problem locally or in my production env.