### PR TITLE
Use None Native Date Picker On Mobile 

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -354,7 +354,7 @@ $(document).ready(function() {
   })
 
   // Sortable List Up-Down
-  var parentEl = document.getElementsByClassName("sortable")[0];
+  var parentEl = document.getElementsByClassName('sortable')[0];
   if (parentEl) {
     var element = parentEl.querySelector('tbody')
   }

--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -25,8 +25,8 @@ jQuery(function ($) {
   })
 
   // Responsive Menus
-  var body  = $('body')
-  var modalBackdrop  = $('#multi-backdrop')
+  var body = $('body')
+  var modalBackdrop = $('#multi-backdrop')
 
   // Fail safe on resize
   var resizeTimer;
@@ -48,9 +48,9 @@ jQuery(function ($) {
   modalBackdrop.click(closeAllMenus)
 
   // Main Menu Functionality
-  var sidebarOpen    = $('#sidebar-open')
-  var sidebarClose   = $('#sidebar-close')
-  var activeItem     = $('#main-sidebar').find('.selected')
+  var sidebarOpen = $('#sidebar-open')
+  var sidebarClose = $('#sidebar-close')
+  var activeItem = $('#main-sidebar').find('.selected')
 
   activeItem.closest('.nav-sidebar').addClass('active-option')
   activeItem.closest('.nav-pills').addClass('in show')
@@ -188,7 +188,7 @@ $(document).ready(function () {
   }
 })
 
-$.fn.visible = function (cond) { this[ cond ? 'show' : 'hide' ]() }
+$.fn.visible = function (cond) { this[cond ? 'show' : 'hide']() }
 // Triggers alerts when requested by javascript.
 // eslint-disable-next-line camelcase
 function show_flash (type, message) {
@@ -227,6 +227,7 @@ $.fn.radioControlsVisibilityOfElement = function (dependentElementSelector) {
 
 document.addEventListener('DOMContentLoaded', function() {
   flatpickr.setDefaults({
+    disableMobile: true,
     altInput: true,
     time_24hr: true,
     altInputClass: 'flatpickr-alt-input',
@@ -250,7 +251,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
 $(document).ready(function() {
   $('.observe_field').on('change', function() {
-    target = $(this).data('update')
+    var target = $(this).data('update')
     $(target).hide()
     $.ajax({
       dataType: 'html',
@@ -298,8 +299,8 @@ $(document).ready(function() {
           el.blur()
         }
       }).done(function () {
-        var $flash_element = $('.alert-success')
-        if ($flash_element.length) {
+        var $flashElement = $('.alert-success')
+        if ($flashElement.length) {
           el.parents('tr').fadeOut('hide', function () {
             $(this).remove()
           })
@@ -314,7 +315,7 @@ $(document).ready(function() {
   })
 
   $('body').on('click', 'a.spree_remove_fields', function () {
-    el = $(this)
+    var el = $(this)
     el.prev('input[type=hidden]').val('1')
     el.closest('.fields').hide()
     if (el.prop('href').substr(-1) === '#') {
@@ -340,13 +341,13 @@ $(document).ready(function() {
 
   $('body').on('click', '.select_properties_from_prototype', function() {
     $('#busy_indicator').show()
-    var clicked_link = $(this)
+    var clickedLink = $(this)
     $.ajax({
       dataType: 'script',
-      url: clicked_link.prop('href'),
+      url: clickedLink.prop('href'),
       type: 'GET'
     }).done(function () {
-      clicked_link.parent('td').parent('tr').hide()
+      clickedLink.parent('td').parent('tr').hide()
       $('#busy_indicator').hide()
     })
     return false
@@ -363,7 +364,7 @@ $(document).ready(function() {
       handle: '.move-handle',
       animation: 550,
       ghostClass: 'bg-light',
-      dragClass: "sortable-drag-v",
+      dragClass: 'sortable-drag-v',
       easing: 'cubic-bezier(1, 0, 0, 1)',
       swapThreshold: 0.9,
       forceFallback: true,
@@ -371,8 +372,8 @@ $(document).ready(function() {
         var itemEl = evt.item
         var positions = { authenticity_token: AUTH_TOKEN }
         $.each($('tr', element), function(position, obj) {
-          reg = /spree_(\w+_?)+_(\d+)/
-          parts = reg.exec($(obj).prop('id'))
+          var reg = /spree_(\w+_?)+_(\d+)/
+          var parts = reg.exec($(obj).prop('id'))
           if (parts) {
             positions['positions[' + parts[2] + ']'] = position + 1
           }

--- a/backend/app/views/spree/admin/shared/_report_order_criteria.html.erb
+++ b/backend/app/views/spree/admin/shared/_report_order_criteria.html.erb
@@ -12,7 +12,6 @@
                            placeholder: Spree.t(:starting_from),
                            value: datepicker_field_value(params[:q][:completed_at_gt]),
                            'data-input':'' %>
-
           <%= render partial: 'spree/admin/shared/cal_close' %>
         </div>
       </div>


### PR DESCRIPTION
As much as it appears nice using the native calendar for basic use on mobile devises, in the interest of consistency on complex cases such as date ranges,I think it might be best to go with the default Flat Picker calendar on all devices.

- add `disableMobile: true` to flat picker config.
- and a small valet to `admin.js` in this PR.

Should fix Mobile AP: User is unable to select certain dates in consecutive report searches #10916