### PR TITLE
Order Tabs (Pills)

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -248,7 +248,7 @@ document.addEventListener('DOMContentLoaded', function() {
   // FLATPICKR
   // Gives Spree its date picker calenders [>= 4.2]
   flatpickr.setDefaults({
-    disableMobile: true,
+    // disableMobile: true,
     altInput: true,
     time_24hr: true,
     altInputClass: 'flatpickr-alt-input',

--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-var */
 /**
 This is a collection of javascript functions and whatnot
 under the spree namespace that do stuff we find helpful.
@@ -25,8 +26,8 @@ jQuery(function ($) {
   })
 
   // Responsive Menus
-  var body  = $('body')
-  var modalBackdrop  = $('#multi-backdrop')
+  var body = $('body')
+  var modalBackdrop = $('#multi-backdrop')
 
   // Fail safe on resize
   var resizeTimer;
@@ -48,9 +49,9 @@ jQuery(function ($) {
   modalBackdrop.click(closeAllMenus)
 
   // Main Menu Functionality
-  var sidebarOpen    = $('#sidebar-open')
-  var sidebarClose   = $('#sidebar-close')
-  var activeItem     = $('#main-sidebar').find('.selected')
+  var sidebarOpen = $('#sidebar-open')
+  var sidebarClose = $('#sidebar-close')
+  var activeItem = $('#main-sidebar').find('.selected')
 
   activeItem.closest('.nav-sidebar').addClass('active-option')
   activeItem.closest('.nav-pills').addClass('in show')
@@ -188,7 +189,7 @@ $(document).ready(function () {
   }
 })
 
-$.fn.visible = function (cond) { this[ cond ? 'show' : 'hide' ]() }
+$.fn.visible = function (cond) { this[cond ? 'show' : 'hide']() }
 // Triggers alerts when requested by javascript.
 // eslint-disable-next-line camelcase
 function show_flash (type, message) {
@@ -226,7 +227,29 @@ $.fn.radioControlsVisibilityOfElement = function (dependentElementSelector) {
 }
 
 document.addEventListener('DOMContentLoaded', function() {
+  // ADAPTIVE NAMING + ACTIVE
+  // Adds the ability to set mobile drop-downs within the tabs area
+  // and have the active link that is nested in the drop down show as the tab name
+  // + mark the parent tab of the nested link as active.
+  var parentNode = document.querySelectorAll('.mobile-only-pills');
+
+  if (!parentNode) return
+
+  parentNode.forEach(function (elem) {
+    var activeLink = elem.querySelector('div.dropdown-menu .active')
+    var dropDownLink = elem.querySelector('[data-toggle=dropdown]')
+
+    if (!activeLink) return
+
+    var activeLinkText = activeLink.innerHTML
+    dropDownLink.innerHTML = activeLinkText
+    dropDownLink.classList.add('active')
+  })
+
+  // FLATPICKR
+  // Gives Spree its date picker calenders [>= 4.2]
   flatpickr.setDefaults({
+    disableMobile: true,
     altInput: true,
     time_24hr: true,
     altInputClass: 'flatpickr-alt-input',
@@ -250,7 +273,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
 $(document).ready(function() {
   $('.observe_field').on('change', function() {
-    target = $(this).data('update')
+    var target = $(this).data('update')
     $(target).hide()
     $.ajax({
       dataType: 'html',
@@ -298,8 +321,8 @@ $(document).ready(function() {
           el.blur()
         }
       }).done(function () {
-        var $flash_element = $('.alert-success')
-        if ($flash_element.length) {
+        var $flashElement = $('.alert-success')
+        if ($flashElement.length) {
           el.parents('tr').fadeOut('hide', function () {
             $(this).remove()
           })
@@ -314,7 +337,7 @@ $(document).ready(function() {
   })
 
   $('body').on('click', 'a.spree_remove_fields', function () {
-    el = $(this)
+    var el = $(this)
     el.prev('input[type=hidden]').val('1')
     el.closest('.fields').hide()
     if (el.prop('href').substr(-1) === '#') {
@@ -340,20 +363,21 @@ $(document).ready(function() {
 
   $('body').on('click', '.select_properties_from_prototype', function() {
     $('#busy_indicator').show()
-    var clicked_link = $(this)
+    var clickedLink = $(this)
     $.ajax({
       dataType: 'script',
-      url: clicked_link.prop('href'),
+      url: clickedLink.prop('href'),
       type: 'GET'
     }).done(function () {
-      clicked_link.parent('td').parent('tr').hide()
+      clickedLink.parent('td').parent('tr').hide()
       $('#busy_indicator').hide()
     })
     return false
   })
 
-  // Sortable List Up-Down
-  var parentEl = document.getElementsByClassName("sortable")[0];
+  // SORTABLE
+  // Gives Spree drag and drop sortable lists. [>= 4.2]
+  var parentEl = document.getElementsByClassName('sortable')[0];
   if (parentEl) {
     var element = parentEl.querySelector('tbody')
   }
@@ -363,7 +387,7 @@ $(document).ready(function() {
       handle: '.move-handle',
       animation: 550,
       ghostClass: 'bg-light',
-      dragClass: "sortable-drag-v",
+      dragClass: 'sortable-drag-v',
       easing: 'cubic-bezier(1, 0, 0, 1)',
       swapThreshold: 0.9,
       forceFallback: true,
@@ -371,8 +395,8 @@ $(document).ready(function() {
         var itemEl = evt.item
         var positions = { authenticity_token: AUTH_TOKEN }
         $.each($('tr', element), function(position, obj) {
-          reg = /spree_(\w+_?)+_(\d+)/
-          parts = reg.exec($(obj).prop('id'))
+          var reg = /spree_(\w+_?)+_(\d+)/
+          var parts = reg.exec($(obj).prop('id'))
           if (parts) {
             positions['positions[' + parts[2] + ']'] = position + 1
           }
@@ -387,7 +411,8 @@ $(document).ready(function() {
     })
   }
 
-  // Close notifications
+  // CLOSE ALERTS
+  // From legacy alerts. [< 4.2] DEPRECIATED?
   $('a.dismiss').click(function () {
     $(this).parent().fadeOut()
   })

--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-var */
 /**
 This is a collection of javascript functions and whatnot
 under the spree namespace that do stuff we find helpful.

--- a/backend/app/assets/stylesheets/spree/backend/shared/_base.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_base.scss
@@ -63,10 +63,10 @@
 // Make the tabs (Pills) not quite so tall
 ul#spreePageTabs {
   li.nav-item {
-    a.dropdown-toggle {
+    a {
       padding: 0.3rem 1rem;
 
-      &::after {
+      &.dropdown-toggle::after {
         margin-left: 0.75em;
         vertical-align: 0.175em;
       }

--- a/backend/app/assets/stylesheets/spree/backend/shared/_base.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_base.scss
@@ -59,3 +59,18 @@
 .button_to {
   display: inline-block;
 }
+
+// Make the tabs (Pills) not quite so tall
+ul#spreePageTabs {
+  li.nav-item {
+    a.dropdown-toggle {
+      padding: 0.3rem 1rem;
+
+      &::after {
+        margin-left: 0.75em;
+        vertical-align: 0.175em;
+      }
+    }
+
+  }
+}

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -17,12 +17,12 @@
         class: "nav-link #{'active' if params[:q][:state_eq].blank? && params[:q][:state_not_eq].blank?}" %>
     </li>
     <li class="nav-item">
-      <%= link_to Spree.t(:unpaid),
+      <%= link_to Spree.t('unpaid'),
         params.merge({q: {state_eq: :complete, payment_state_eq: :balance_due}}).permit!,
         class: "nav-link #{'active' if params[:q][:state_eq] == 'complete' && params[:q][:payment_state_eq] == 'balance_due'}" %>
     </li>
     <li class="nav-item d-none d-sm-flex">
-      <%= link_to Spree.t(:unfulfilled),
+      <%= link_to Spree.t('unfulfilled'),
         params.merge({q: {state_eq: :complete, payment_state_eq: :paid, shipment_state_not_eq: :shipped}}).permit!,
         class: "nav-link #{'active' if params[:q][:state_eq] == 'complete' && params[:q][:payment_state_eq] == 'paid'} " %>
     </li>
@@ -35,7 +35,7 @@
   <li class="nav-item dropdown d-sm-none mobile-only-pills">
     <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false"><%= Spree.t('more_views') %></a>
     <div class="dropdown-menu">
-      <%= link_to Spree.t(:unfulfilled),
+      <%= link_to Spree.t('unfulfilled'),
         params.merge({q: {state_eq: :complete, payment_state_eq: :paid, shipment_state_not_eq: :shipped}}).permit!,
         class: "dropdown-item #{'active' if params[:q][:state_eq] == 'complete' && params[:q][:payment_state_eq] == 'paid'} " %>
 

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -32,8 +32,8 @@
         class: "nav-link #{'active' if params[:q][:completed_at_not_null] == '' && params[:q][:state_not_eq] == 'complete'}" %>
     </li>
 
-  <li class="nav-item dropdown d-sm-none">
-    <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">More Views</a>
+  <li class="nav-item dropdown d-sm-none mobile-only-pills">
+    <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false"><%= Spree.t('more_views') %></a>
     <div class="dropdown-menu">
       <%= link_to Spree.t(:unfulfilled),
         params.merge({q: {state_eq: :complete, payment_state_eq: :paid, shipment_state_not_eq: :shipped}}).permit!,
@@ -215,7 +215,7 @@
 <% end %>
 
 <% if @orders.any? %>
-<div class="table-responsive">
+<div class="table-responsive mt-4">
   <table class="table" id="listing_orders" data-hook>
     <thead>
       <tr data-hook="admin_orders_index_headers">

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -12,19 +12,24 @@
 
 <% content_for :page_tabs do %>
   <li class="nav-item">
-    <%= link_to Spree.t(:completed),
+    <%= link_to Spree.t(:all),
       spree.admin_orders_path,
-      class: "nav-link #{'active' if params[:q][:state_not_eq].blank?}" %>
+      class: "nav-link #{'active' if params[:q][:state_eq].blank? && params[:q][:state_not_eq].blank?}" %>
   </li>
   <li class="nav-item">
-    <%= link_to Spree.t('abandoned'),
-      params.merge({q: {completed_at_not_null: nil, state_not_eq: :complete }}).permit!,
-      class: "nav-link #{'active' if params[:q][:state_not_eq] == 'complete'}" %>
+    <%= link_to Spree.t(:unpaid),
+      params.merge({q: {state_eq: :complete, payment_state_eq: :balance_due}}).permit!,
+      class: "nav-link #{'active' if params[:q][:state_eq] == 'complete' && params[:q][:payment_state_eq] == 'balance_due'}" %>
   </li>
   <li class="nav-item">
-    <%= link_to Spree.t(:canceled),
-      params.merge({q: {state_eq: :canceled}}).permit!,
-      class: "nav-link #{'active' if params[:q][:state_eq] == 'canceled'}" %>
+    <%= link_to Spree.t(:unfulfilled),
+      params.merge({q: {state_eq: :complete, payment_state_eq: :paid, shipment_state_not_eq: :shipped}}).permit!,
+      class: "nav-link #{'active' if params[:q][:state_eq] == 'complete' && params[:q][:payment_state_eq] == 'paid'} " %>
+  </li>
+  <li class="nav-item">
+    <%= link_to Spree.t('incomplete'),
+      params.merge({q: {completed_at_not_null: '', state_not_eq: :complete }}).permit!,
+      class: "nav-link #{'active' if params[:q][:completed_at_not_null] == '' && params[:q][:state_not_eq] == 'complete'}" %>
   </li>
 <% end %>
 

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -11,25 +11,38 @@
 <% end if can? :create, Spree::Order %>
 
 <% content_for :page_tabs do %>
-  <li class="nav-item">
-    <%= link_to Spree.t(:all),
-      spree.admin_orders_path,
-      class: "nav-link #{'active' if params[:q][:state_eq].blank? && params[:q][:state_not_eq].blank?}" %>
-  </li>
-  <li class="nav-item">
-    <%= link_to Spree.t(:unpaid),
-      params.merge({q: {state_eq: :complete, payment_state_eq: :balance_due}}).permit!,
-      class: "nav-link #{'active' if params[:q][:state_eq] == 'complete' && params[:q][:payment_state_eq] == 'balance_due'}" %>
-  </li>
-  <li class="nav-item">
-    <%= link_to Spree.t(:unfulfilled),
-      params.merge({q: {state_eq: :complete, payment_state_eq: :paid, shipment_state_not_eq: :shipped}}).permit!,
-      class: "nav-link #{'active' if params[:q][:state_eq] == 'complete' && params[:q][:payment_state_eq] == 'paid'} " %>
-  </li>
-  <li class="nav-item">
-    <%= link_to Spree.t('incomplete'),
-      params.merge({q: {completed_at_not_null: '', state_not_eq: :complete }}).permit!,
-      class: "nav-link #{'active' if params[:q][:completed_at_not_null] == '' && params[:q][:state_not_eq] == 'complete'}" %>
+    <li class="nav-item">
+      <%= link_to Spree.t(:all),
+        spree.admin_orders_path,
+        class: "nav-link #{'active' if params[:q][:state_eq].blank? && params[:q][:state_not_eq].blank?}" %>
+    </li>
+    <li class="nav-item">
+      <%= link_to Spree.t(:unpaid),
+        params.merge({q: {state_eq: :complete, payment_state_eq: :balance_due}}).permit!,
+        class: "nav-link #{'active' if params[:q][:state_eq] == 'complete' && params[:q][:payment_state_eq] == 'balance_due'}" %>
+    </li>
+    <li class="nav-item d-none d-sm-flex">
+      <%= link_to Spree.t(:unfulfilled),
+        params.merge({q: {state_eq: :complete, payment_state_eq: :paid, shipment_state_not_eq: :shipped}}).permit!,
+        class: "nav-link #{'active' if params[:q][:state_eq] == 'complete' && params[:q][:payment_state_eq] == 'paid'} " %>
+    </li>
+    <li class="nav-item d-none d-sm-flex">
+      <%= link_to Spree.t('incomplete'),
+        params.merge({q: {completed_at_not_null: '', state_not_eq: :complete }}).permit!,
+        class: "nav-link #{'active' if params[:q][:completed_at_not_null] == '' && params[:q][:state_not_eq] == 'complete'}" %>
+    </li>
+
+  <li class="nav-item dropdown d-sm-none">
+    <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">More Views</a>
+    <div class="dropdown-menu">
+      <%= link_to Spree.t(:unfulfilled),
+        params.merge({q: {state_eq: :complete, payment_state_eq: :paid, shipment_state_not_eq: :shipped}}).permit!,
+        class: "dropdown-item #{'active' if params[:q][:state_eq] == 'complete' && params[:q][:payment_state_eq] == 'paid'} " %>
+
+      <%= link_to Spree.t('incomplete'),
+        params.merge({q: {completed_at_not_null: '', state_not_eq: :complete }}).permit!,
+        class: "dropdown-item #{'active' if params[:q][:completed_at_not_null] == '' && params[:q][:state_not_eq] == 'complete'}" %>
+    </div>
   </li>
 <% end %>
 

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -10,6 +10,24 @@
       id: 'admin_new_order' %>
 <% end if can? :create, Spree::Order %>
 
+<% content_for :page_tabs do %>
+  <li class="nav-item">
+    <%= link_to Spree.t(:completed),
+      spree.admin_orders_path,
+      class: "nav-link #{'active' if params[:q][:state_not_eq].blank?}" %>
+  </li>
+  <li class="nav-item">
+    <%= link_to Spree.t('abandoned'),
+      params.merge({q: {completed_at_not_null: nil, state_not_eq: :complete }}).permit!,
+      class: "nav-link #{'active' if params[:q][:state_not_eq] == 'complete'}" %>
+  </li>
+  <li class="nav-item">
+    <%= link_to Spree.t(:canceled),
+      params.merge({q: {state_eq: :canceled}}).permit!,
+      class: "nav-link #{'active' if params[:q][:state_eq] == 'canceled'}" %>
+  </li>
+<% end %>
+
 <% content_for :table_filter do %>
   <div data-hook="admin_orders_index_search">
 

--- a/backend/app/views/spree/admin/shared/_content_header.html.erb
+++ b/backend/app/views/spree/admin/shared/_content_header.html.erb
@@ -1,6 +1,6 @@
 <div id="contentHeader" class="row">
   <% if content_for?(:page_title) || content_for?(:page_actions) %>
-    <div class="content-header col <%= "with-page-tabs" if content_for?(:page_tabs) %> page-header">
+    <div class="content-header col page-header">
       <div class="row align-items-center border-bottom">
 
         <% if content_for?(:page_title) %>
@@ -33,9 +33,9 @@
       </div>
 
       <% if content_for?(:page_tabs) %>
-        <div class="row">
+        <div class="row pb-0 mb-0">
           <div class="col-12">
-            <ul class="nav nav-pills mt-4">
+            <ul id="spreePageTabs" class="nav nav-pills mt-2">
               <%= yield :page_tabs %>
             </ul>
           </div>

--- a/backend/app/views/spree/admin/shared/_content_header.html.erb
+++ b/backend/app/views/spree/admin/shared/_content_header.html.erb
@@ -1,7 +1,7 @@
-<div id="contentHeader" class="row mb-3">
+<div id="contentHeader" class="row">
   <% if content_for?(:page_title) || content_for?(:page_actions) %>
     <div class="content-header col <%= "with-page-tabs" if content_for?(:page_tabs) %> page-header">
-      <div class="row align-items-center  <%= if content_for?(:page_tabs) then "pb-0" else "border-bottom" end %>">
+      <div class="row align-items-center border-bottom">
 
         <% if content_for?(:page_title) %>
           <h1 class="contextual-title px-0 mb-0 col">
@@ -34,9 +34,11 @@
 
       <% if content_for?(:page_tabs) %>
         <div class="row">
-          <ul class="nav nav-tabs w-100 mt-4 px-0">
-            <%= yield :page_tabs %>
-          </ul>
+          <div class="col-12">
+            <ul class="nav nav-pills mt-4">
+              <%= yield :page_tabs %>
+            </ul>
+          </div>
         </div>
       <% end %>
 

--- a/backend/app/views/spree/admin/shared/_table_filter.html.erb
+++ b/backend/app/views/spree/admin/shared/_table_filter.html.erb
@@ -1,11 +1,11 @@
 <% if content_for?(:table_filter) %>
-  <div class="filter-wrap row mb-4">
+  <div class="filter-wrap row">
     <div class="col-12">
-      <div class="input-group index-filter-button">
+      <div class="input-group index-filter-button flex-nowrap">
         <span class="input-group-btn">
           <button class="btn js-show-index-filters m-0" type="button">
-              <%= svg_icon name: "chevron-right.svg", width: '12', height: '12' %>
-            <%= Spree.t(:filter) %>
+            <%= svg_icon name: "chevron-right.svg", width: '12', height: '12' %>
+            <span class="d-none d-sm-inline"><%= Spree.t(:filter) %></span>
           </button>
         </span>
         <%= form_tag request.fullpath, id: "quick-search", class: 'flex-grow-1' do %>

--- a/backend/spec/features/admin/returns/return_authorizations_spec.rb
+++ b/backend/spec/features/admin/returns/return_authorizations_spec.rb
@@ -116,7 +116,7 @@ describe 'Return Authorizations', type: :feature do
 
       it 'only shows authorized return authorizations' do
         visit spree.admin_return_authorizations_path
-        within('.nav-pills') do
+        within('#spreePageTabs') do
           click_link 'Authorized'
         end
 
@@ -126,7 +126,7 @@ describe 'Return Authorizations', type: :feature do
 
       it 'preselects authorized status in filter' do
         visit spree.admin_return_authorizations_path
-        within('.nav-pills') do
+        within('#spreePageTabs') do
           click_link 'Authorized'
         end
 
@@ -143,7 +143,7 @@ describe 'Return Authorizations', type: :feature do
 
       it 'only shows canceled return authorizations' do
         visit spree.admin_return_authorizations_path
-        within('.nav-pills') do
+        within('#spreePageTabs') do
           click_link 'Canceled'
         end
 
@@ -153,7 +153,7 @@ describe 'Return Authorizations', type: :feature do
 
       it 'preselects canceled status in filter' do
         visit spree.admin_return_authorizations_path
-        within('.nav-pills') do
+        within('#spreePageTabs') do
           click_link 'Canceled'
         end
 

--- a/backend/spec/features/admin/returns/return_authorizations_spec.rb
+++ b/backend/spec/features/admin/returns/return_authorizations_spec.rb
@@ -116,7 +116,7 @@ describe 'Return Authorizations', type: :feature do
 
       it 'only shows authorized return authorizations' do
         visit spree.admin_return_authorizations_path
-        within('.nav-tabs') do
+        within('.nav-pills') do
           click_link 'Authorized'
         end
 
@@ -126,7 +126,7 @@ describe 'Return Authorizations', type: :feature do
 
       it 'preselects authorized status in filter' do
         visit spree.admin_return_authorizations_path
-        within('.nav-tabs') do
+        within('.nav-pills') do
           click_link 'Authorized'
         end
 
@@ -143,7 +143,7 @@ describe 'Return Authorizations', type: :feature do
 
       it 'only shows canceled return authorizations' do
         visit spree.admin_return_authorizations_path
-        within('.nav-tabs') do
+        within('.nav-pills') do
           click_link 'Canceled'
         end
 
@@ -153,7 +153,7 @@ describe 'Return Authorizations', type: :feature do
 
       it 'preselects canceled status in filter' do
         visit spree.admin_return_authorizations_path
-        within('.nav-tabs') do
+        within('.nav-pills') do
           click_link 'Canceled'
         end
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1657,7 +1657,6 @@ en:
       user_has_no_store_credits: "User does not have any available store credit"
       select_one_store_credit: "Select store credit to go towards remaining balance"
     store_default: Default store
-    store_set_default_button: Set as default
     store_not_set_as_default: Couldn't set store %{store} as a default store
     store_set_as_default: Store %{store} is now a default store
     street_address: Street Address
@@ -1737,6 +1736,8 @@ en:
     unable_to_connect_to_gateway: Unable to connect to gateway.
     unable_to_create_reimbursements: Unable to create reimbursements because there are items pending manual intervention.
     under_price: Under %{price}
+    unpaid: Unpaid
+    unfulfilled: Unfulfilled
     unlock: Unlock
     unrecognized_card_type: Unrecognized card type
     unshippable_items: Unshippable Items

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1017,6 +1017,7 @@ en:
     missing_return_authorization: ! 'Missing Return Authorization for %{item_name}.'
     month: Month
     more: More
+    more_views: More views
     move_stock_between_locations: Move Stock Between Locations
     my_account: My Account
     my_orders: My Orders


### PR DESCRIPTION
As a user of Spree I often look for a short cut to view certain orders states, namely incomplete orders, or ready to ship orders, but this can be a little fiddly on mobile devices, having to fold out the filter panel, then set the desired filters, and lastly, scroll down further to find the Filter button.

With this in mind I thought about adding some common use cases as tabs on the Orders Page as a short cut, especially for mobile use, but in the process of adding this feature I noticed that the tabs feature is not responsive on small screens as the tabs will stack under each other if there are too many tabs. 


With this in mind I set them to BS4 "pills" and implemented an idea for mobile drop-down.

- Add tabs (pills) For Order Page.
- Make pills responsive with optional drop-down on small screens.
- Stop search / filter elements stacking on small screens.


https://user-images.githubusercontent.com/1240766/112505555-ce396700-8d84-11eb-81b2-54cc170c0dbf.mov



