### PR TITLE
make remove contact email and default country kind migrations reversible

### DIFF
--- a/core/db/migrate/20201127084048_add_default_country_kind_to_spree_zones.rb
+++ b/core/db/migrate/20201127084048_add_default_country_kind_to_spree_zones.rb
@@ -1,5 +1,5 @@
 class AddDefaultCountryKindToSpreeZones < ActiveRecord::Migration[6.0]
   def change
-    change_column_default(:spree_zones, :kind, :state)
+    change_column_default(:spree_zones, :kind, from: nil, to: :state)
   end
 end

--- a/core/db/migrate/20210112193440_remove_contact_email_from_spree_stores.rb
+++ b/core/db/migrate/20210112193440_remove_contact_email_from_spree_stores.rb
@@ -1,5 +1,5 @@
 class RemoveContactEmailFromSpreeStores < ActiveRecord::Migration[6.0]
   def change
-    remove_column :spree_stores, :contact_email
+    remove_column :spree_stores, :contact_email, :string
   end
 end


### PR DESCRIPTION
I encountered this problem while updating my application to spree 4.2 and wanting to rollback all migrations added with this version.

With this changes you should be able to rollback safely all the latest migrations.