### PR TITLE
Allow 4 digit CVV for Amex cards

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/payments/new.js
+++ b/backend/app/assets/javascripts/spree/backend/payments/new.js
@@ -2,22 +2,35 @@
 
 $(document).ready(function () {
   if ($('#new_payment').length) {
+    var cardCodeCleave;
+    var updateCardCodeCleave = function (length) {
+      if (cardCodeCleave) cardCodeCleave.destroy()
+
+      cardCodeCleave = new Cleave('.cardCode', {
+        numericOnly: true,
+        blocks: [length]
+      })
+    }
+
+    updateCardCodeCleave(3)
+
     /* eslint-disable no-new */
     new Cleave('.cardNumber', {
       creditCard: true,
       onCreditCardTypeChanged: function (type) {
         $('.ccType').val(type)
+
+        if (type === 'amex') {
+          updateCardCodeCleave(4)
+        } else {
+          updateCardCodeCleave(3)
+        }
       }
     })
     /* eslint-disable no-new */
     new Cleave('.cardExpiry', {
       date: true,
       datePattern: ['m', 'Y']
-    })
-    /* eslint-disable no-new */
-    new Cleave('.cardCode', {
-      numericOnly: true,
-      blocks: [3]
     })
 
     $('.payment_methods_radios').click(

--- a/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js
@@ -27,22 +27,36 @@ Spree.ready(function ($) {
       if ($(CARD_NUMBER_SELECTOR).length > 0 &&
           $(CARD_EXPIRATION_SELECTOR).length > 0 &&
           $(CARD_CODE_SELECTOR).length > 0) {
+
+        var cardCodeCleave;
+        var updateCardCodeCleave = function (length) {
+          if (cardCodeCleave) cardCodeCleave.destroy()
+
+          cardCodeCleave = new Cleave(CARD_CODE_SELECTOR, {
+            numericOnly: true,
+            blocks: [length]
+          })
+        }
+
+        updateCardCodeCleave(3)
+
         /* eslint-disable no-new */
         new Cleave(CARD_NUMBER_SELECTOR, {
           creditCard: true,
           onCreditCardTypeChanged: function (type) {
             $('.ccType').val(type)
+
+            if (type === 'amex') {
+              updateCardCodeCleave(4)
+            } else {
+              updateCardCodeCleave(3)
+            }
           }
         })
         /* eslint-disable no-new */
         new Cleave(CARD_EXPIRATION_SELECTOR, {
           date: true,
           datePattern: ['m', 'Y']
-        })
-        /* eslint-disable no-new */
-        new Cleave(CARD_CODE_SELECTOR, {
-          numericOnly: true,
-          blocks: [3]
         })
       }
 

--- a/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js
@@ -27,7 +27,6 @@ Spree.ready(function ($) {
       if ($(CARD_NUMBER_SELECTOR).length > 0 &&
           $(CARD_EXPIRATION_SELECTOR).length > 0 &&
           $(CARD_CODE_SELECTOR).length > 0) {
-
         var cardCodeCleave;
         var updateCardCodeCleave = function (length) {
           if (cardCodeCleave) cardCodeCleave.destroy()


### PR DESCRIPTION
Amex cards have a 4 digit CVV, but the code was always limiting it to 3 digits (I'm writing a new gateway implementation and this was blocking me).

Calling `#destroy` and recreating the Cleave object seems to be the only way to "update" it.

I tested this code by overriding the 2 files in my store (Spree 4.2.1) and it worked.

https://jsfiddle.net/rf85en1z/

Amex card number for testing: 372700699251018