### PR TITLE
Add -order-success to order show url when order is confirmed

### DIFF
--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -41,7 +41,7 @@ module Spree
         if @order.completed?
           @current_order = nil
           flash['order_completed'] = true
-          redirect_to completion_route
+          redirect_to "#{completion_route}-order-success"
         else
           redirect_to spree.checkout_state_path(@order.state)
         end

--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -10,7 +10,8 @@ module Spree
     before_action :assign_order_with_lock, only: :update
 
     def show
-      @order = Order.includes(line_items: [variant: [:option_values, :images, :product]], bill_address: :state, ship_address: :state).find_by!(number: params[:id])
+      order_id = params[:id].gsub('-order-success','')
+      @order = Order.includes(line_items: [variant: [:option_values, :images, :product]], bill_address: :state, ship_address: :state).find_by!(number: order_id)
     end
 
     def update

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -561,7 +561,7 @@ describe Spree::CheckoutController, type: :controller do
         # This inadvertently is a regression test for #2694
         it 'redirects to the order view' do
           post :update, params: { state: 'confirm' }
-          expect(response).to redirect_to spree.order_path(order)
+          expect(response).to redirect_to "#{spree.order_path(order)}-order-success"
         end
 
         it 'removes completed order from current_order' do


### PR DESCRIPTION
Order success URL must be different from My Account-Orders URL #10072

Now, when the order is confirmed and redirected to order show page. The order show url is appended with '-order-success' string to id. So that adverts know that the order is just placed.