### PR TITLE
cancelled & returned orders should be uneditable by user

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -326,6 +326,10 @@ module Spree
       complete? || resumed? || awaiting_return? || returned?
     end
 
+    def uneditable?
+      complete? || canceled? || returned?
+    end
+
     def credit_cards
       credit_card_ids = payments.from_credit_card.pluck(:source_id).uniq
       CreditCard.where(id: credit_card_ids)

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -763,6 +763,34 @@ describe Spree::Order, type: :model do
     end
   end
 
+  context '#uneditable?' do
+    let(:order) { Spree::Order.create }
+
+    it 'returns true when order is completed' do
+      allow(order).to receive_messages(complete?: true)
+
+      expect(order.uneditable?).to be true
+    end
+
+    it 'returns true when order is canceled' do
+      allow(order).to receive_messages(canceled?: true)
+
+      expect(order.uneditable?).to be true
+    end
+
+    it 'returns true when order is returned' do
+      allow(order).to receive_messages(returned?: true)
+
+      expect(order.uneditable?).to be true
+    end
+
+    it 'returns false when order is during checkout' do
+      allow(order).to receive_messages(confirm?: true)
+
+      expect(order.uneditable?).to be false
+    end
+  end
+
   context '#completed?' do
     it 'indicates if order is completed' do
       order.completed_at = nil

--- a/frontend/app/helpers/spree/frontend_helper.rb
+++ b/frontend/app/helpers/spree/frontend_helper.rb
@@ -305,7 +305,7 @@ module Spree
     end
 
     def checkout_edit_link(step = 'address', order = @order)
-      return if order.complete?
+      return if order.uneditable?
 
       classes = 'align-text-bottom checkout-confirm-delivery-informations-link'
 

--- a/frontend/app/views/spree/shared/_order_details.html.erb
+++ b/frontend/app/views/spree/shared/_order_details.html.erb
@@ -117,7 +117,7 @@
 
   <div class="mt-5" id="checkout-summary" data-hook="checkout_summary_box">
     <%= render partial: 'spree/checkout/summary', locals: { order: @order } %>
-    <% unless @order.complete? %>
+    <% unless @order.uneditable? %>
       <div data-hook="buttons">
         <% submit_label_key = @order.confirm? ? :place_order : :save_and_continue %>
         <%= submit_tag Spree.t(submit_label_key), class: 'btn btn-primary text-uppercase font-weight-bold w-100 checkout-content-save-continue-button' %>

--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -230,6 +230,24 @@ describe 'Checkout', type: :feature, inaccessible: true, js: true do
 
       expect(page).to have_selector('input.btn-primary.checkout-content-save-continue-button[data-disable-with]')
     end
+
+    it 'checks if link to checkout address step will be displayed' do
+      visit spree.checkout_state_path(:confirm)
+
+      expect(page).to have_link(href: spree.checkout_state_path(:address))
+    end
+
+    it 'checks if link to checkout delivery step will be displayed' do
+      visit spree.checkout_state_path(:confirm)
+
+      expect(page).to have_link(href: spree.checkout_state_path(:delivery))
+    end
+
+    it 'checks if link to checkout payment step will be displayed' do
+      visit spree.checkout_state_path(:confirm)
+
+      expect(page).to have_link(href: spree.checkout_state_path(:payment))
+    end
   end
 
   context 'when several payment methods are available', js: true do

--- a/frontend/spec/features/order_spec.rb
+++ b/frontend/spec/features/order_spec.rb
@@ -105,4 +105,34 @@ describe 'orders', type: :feature do
       end
     end
   end
+
+  it 'does not have save and continue button' do
+    visit spree.order_path(order)
+
+    expect(page).not_to have_selector('input.btn-primary.checkout-content-save-continue-button[data-disable-with]')
+  end
+
+  it 'does not have place order button' do
+    visit spree.order_path(order)
+
+    expect(page).not_to have_button(class: 'btn-primary', value: 'Place Order')
+  end
+
+  it 'does not have link to checkout address step' do
+    visit spree.order_path(order)
+
+    expect(page).not_to have_link(href: spree.checkout_state_path(:address))
+  end
+
+  it 'does not have link to checkout delivery step' do
+    visit spree.order_path(order)
+
+    expect(page).not_to have_link(href: spree.checkout_state_path(:delivery))
+  end
+
+  it 'does not have link to checkout payment step' do
+    visit spree.order_path(order)
+
+    expect(page).not_to have_link(href: spree.checkout_state_path(:payment))
+  end
 end


### PR DESCRIPTION
Cancelled & returned orders should not be editable by user in order summary.