### PR TITLE
[Documentation] Fix Storefront update generator task

### DIFF
--- a/guides/src/content/developer/upgrades/four-dot-one-to-four-dot-two.md
+++ b/guides/src/content/developer/upgrades/four-dot-one-to-four-dot-two.md
@@ -113,7 +113,7 @@ If you're using Spree default Storefront (`spree_frontend` gem) make sure to upd
 * [app/views/spree/shared/_nav_bar.html.erb](https://github.com/spree/spree/blob/4-2-stable/frontend/app/views/spree/shared/_nav_bar.html.erb)
 * [app/views/spree/shared/_line_item.html.erb](https://github.com/spree/spree/blob/4-2-stable/frontend/app/views/spree/shared/_line_item.html.erb)
 
-Or simply run `bundle exec rails g spree:storefront:copy_storefront`
+Or simply run `bundle exec rails g spree:frontend:copy_storefront`
 
 ## Read the release notes
 


### PR DESCRIPTION
This patch changes 4.1 to 4.2 upgrade guides to point to `spree:frontend:copy_storefront` (working) instead of previous `spree:storefront:copy_storefront` (not found).

See: https://guides.spreecommerce.org/developer/upgrades/four-dot-one-to-four-dot-two.html#make-sure-youve-got-up-to-date-spree-templates-storefront