### PR TITLE
Add Indication To Search

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/global/ransack.js
+++ b/backend/app/assets/javascripts/spree/backend/global/ransack.js
@@ -1,4 +1,12 @@
+/* eslint-disable no-var */
 document.addEventListener('DOMContentLoaded', function() {
+  var QuickSearchInput = document.getElementById('quick_search')
+  var QuickSearchPlaceHolder = QuickSearchInput.placeholder
+  var TargetSearchFieldId = document.querySelector('input.js-quick-search-target').id
+  var AssociatedLabelName = document.querySelector(`label[for="${TargetSearchFieldId}"]`).innerHTML
+
+  QuickSearchInput.placeholder = `${QuickSearchPlaceHolder} ${AssociatedLabelName}`
+
   $('.js-show-index-filters').click(function() {
     $('.filter-well').slideToggle()
     $(this).parents('.filter-wrap').toggleClass('collapsed')
@@ -8,6 +16,7 @@ document.addEventListener('DOMContentLoaded', function() {
   // Temp quick search
   // When there was a search term, copy it
   $('.js-quick-search').val($('.js-quick-search-target').val())
+
   // Catch the quick search form submit and submit the real form
   $('#quick-search').submit(function() {
     $('.js-quick-search-target').val($('.js-quick-search').val())

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -54,7 +54,7 @@
       </div>
       <div class="col-12 col-lg-4">
         <div class="form-group">
-          <%= label_tag :q_number_cont, Spree.t(:order_number, number: '') %>
+          <%= label_tag :q_number_cont, Spree.t(:order_number, number: 'Number') %>
           <%= f.text_field :number_cont, class: 'form-control js-quick-search-target js-filterable' %>
         </div>
       </div>

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -14,7 +14,7 @@
       <div data-hook="admin_products_index_search" class="row">
         <div class="col-12 col-lg-6">
           <div class="form-group">
-            <%= f.label :search_by_name, Spree.t(:name) %>
+            <%= f.label :search_by_name, Spree.t(:product_name) %>
             <%= f.text_field :search_by_name, size: 15, class: "form-control js-quick-search-target js-filterable" %>
           </div>
         </div>

--- a/backend/app/views/spree/admin/return_index/return_authorizations.html.erb
+++ b/backend/app/views/spree/admin/return_index/return_authorizations.html.erb
@@ -26,7 +26,7 @@
       <div class="row">
         <div class="col-12 col-lg-6">
           <div class="form-group">
-            <%= f.label :number_cont, Spree.t(:number) %>
+            <%= f.label :number_cont, Spree.t(:return_number) %>
             <%= f.text_field :number_cont, class: "form-control js-quick-search-target js-filterable" %>
           </div>
         </div>

--- a/backend/app/views/spree/admin/shared/_table_filter.html.erb
+++ b/backend/app/views/spree/admin/shared/_table_filter.html.erb
@@ -9,7 +9,7 @@
           </button>
         </span>
         <%= form_tag request.fullpath, id: "quick-search", class: 'flex-grow-1' do %>
-          <%= text_field_tag :quick_search, nil, class: "form-control js-quick-search", placeholder: Spree.t(:quick_search) %>
+          <%= text_field_tag :quick_search, nil, class: "form-control js-quick-search", placeholder: Spree.t(:search_by) %>
         <% end %>
       </div>
       <% unless defined?(simple) %>

--- a/backend/app/views/spree/admin/stock_transfers/index.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/index.html.erb
@@ -9,12 +9,11 @@
 <% content_for :table_filter do %>
   <div data-hook="admin_orders_index_search">
     <%= search_form_for @q, url: admin_stock_transfers_path do |f| %>
-
       <div class="row mb-0">
         <div class="col-12 col-lg-4">
           <div class="form-group">
             <%= f.label :reference_cont, Spree.t(:reference_contains) %>
-            <%= f.text_field :reference_cont, class: 'form-control' %>
+            <%= f.text_field :reference_cont, class: 'form-control js-filterable js-quick-search-target' %>
           </div>
         </div>
 

--- a/backend/spec/features/admin/orders/listing_spec.rb
+++ b/backend/spec/features/admin/orders/listing_spec.rb
@@ -260,7 +260,7 @@ describe 'Orders Listing', type: :feature do
         within('.table-active-filters') do
           # expect(page).to have_content('Start: 2018-01-01')
           # expect(page).to have_content('Stop: 2018-06-30')
-          expect(page).to have_content('Order: R100')
+          expect(page).to have_content('Order Number: R100')
           expect(page).to have_content('Status: cart')
           expect(page).to have_content('Payment State: paid')
           expect(page).to have_content('Shipment State: pending')

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1281,6 +1281,7 @@ en:
     price_sack: Price Sack
     process: Process
     product: Product
+    product_name: Product Name
     product_details: Product Details
     product_has_no_description: This product has no description
     product_not_available_in_this_currency: This product is not available in the selected currency.
@@ -1457,6 +1458,7 @@ en:
     say_yes: 'Yes'
     scope: Scope
     search: Search
+    search_by: 'Search by:'
     search_results: Search results for '%{keywords}'
     searching: Searching
     secure_connection_type: Secure Connection Type
@@ -1623,7 +1625,6 @@ en:
       customer_support_email_help: "This email is visible to your Store visitors in the Footer section"
       new_order_notifications_email_help: "If you want to receive an email notification every time someone places an Order please provide an email address for that notification to be sent to"
       seo_robots: "Please check <a href='https://developers.google.com/search/reference/robots_meta_tag' target='_blank'>this page for more help</a>"
-    store_set_default_button: Set as default
     stores: Stores
     store_credit_name: Store Credit
     store_credit:


### PR DESCRIPTION
Add a little clue to what each search filed is intended to be used for, example:
`Search by: Order Number`
`Search by: Product Name`

Issus Fixed in this PR:
- Duplicate key in `en.yml`
- Missing `js-filterable js-quick-search-target` class causing the ransack search and filters panel to be unusable on stock transfers index.

https://user-images.githubusercontent.com/1240766/113426196-0404ce00-93cb-11eb-95f9-a77b4496f72e.mov
