### PR TITLE
Lint money.rb

### DIFF
--- a/core/lib/spree/money.rb
+++ b/core/lib/spree/money.rb
@@ -5,7 +5,7 @@ Money.rounding_mode = BigDecimal::ROUND_HALF_UP
 
 module Spree
   class Money
-    class <<self
+    class << self
       attr_accessor :default_formatting_rules
     end
 
@@ -16,6 +16,7 @@ module Spree
     }
 
     attr_reader :money
+
     delegate    :cents, :currency, to: :money
 
     def initialize(amount, options = {})


### PR DESCRIPTION
Add space between `class <<self` now `class << self` I don't think it fixes anything other than the syntax highlighting in my text editor.

BEFORE:
<img width="953" alt="Screenshot 2021-04-09 at 22 46 40" src="https://user-images.githubusercontent.com/1240766/114244288-16ac7380-9986-11eb-8225-922d61811853.png">

AFTER:
<img width="957" alt="Screenshot 2021-04-09 at 22 46 51" src="https://user-images.githubusercontent.com/1240766/114244323-22983580-9986-11eb-8602-d0aac07e5110.png">
