### PR TITLE
Clarifies use of mount point and modules.

### DIFF
--- a/guides/src/content/developer/3_customization/authentication.md
+++ b/guides/src/content/developer/3_customization/authentication.md
@@ -114,9 +114,7 @@ include Spree::Core::ControllerHelpers::Currency
 include Spree::Core::ControllerHelpers::Locale
 
 helper 'spree/base'
-helper 'spree/locale' if defined?(Spree::LocaleHelper)
-helper 'spree/currency' if defined?(Spree::CurrencyHelper)
-helper 'spree/store' if defined?(Spree::StoreHelper)
+helper 'spree/locale', 'spree/currency', 'spree/store'
 ```
 
 Please note that including `Spree::Core::ControllerHelpers::Common` will replace your application layout with [Spree layout](https://github.com/spree/spree/blob/master/frontend/app/views/spree/layouts/spree_application.html.erb). For applications not wanting to use Spree layout omit the `Spree::Core::ControllerHelpers::Common` module.

--- a/guides/src/content/developer/3_customization/authentication.md
+++ b/guides/src/content/developer/3_customization/authentication.md
@@ -119,7 +119,7 @@ helper 'spree/currency' if defined?(Spree::CurrencyHelper)
 helper 'spree/store' if defined?(Spree::StoreHelper)
 ```
 
-Please note that including `Spree::Core::ControllerHelpers::Common` will direct all Spree routes to the root of the app. For applications not mounting Spree at `'/'` omit the `Spree::Core::ControllerHelpers::Common` module to preserve existing application routes. Move the `mount Spree::Core::Engine` statement to the end of the `config/routes.rb` file.
+Please note that including `Spree::Core::ControllerHelpers::Common` will replace your application layout with [Spree layout](https://github.com/spree/spree/blob/master/frontend/app/views/spree/layouts/spree_application.html.erb). For applications not wanting to use Spree layout omit the `Spree::Core::ControllerHelpers::Common` module.
 
 
 Each of the methods defined in this module return values that are the

--- a/guides/src/content/developer/3_customization/authentication.md
+++ b/guides/src/content/developer/3_customization/authentication.md
@@ -110,8 +110,17 @@ include Spree::Core::ControllerHelpers::Auth
 include Spree::Core::ControllerHelpers::Common
 include Spree::Core::ControllerHelpers::Order
 include Spree::Core::ControllerHelpers::Store
+include Spree::Core::ControllerHelpers::Currency
+include Spree::Core::ControllerHelpers::Locale
+
 helper 'spree/base'
+helper 'spree/locale' if defined?(Spree::LocaleHelper)
+helper 'spree/currency' if defined?(Spree::CurrencyHelper)
+helper 'spree/store' if defined?(Spree::StoreHelper)
 ```
+
+Please note that including `Spree::Core::ControllerHelpers::Common` will direct all Spree routes to the root of the app. For applications not mounting Spree at `'/'` omit the `Spree::Core::ControllerHelpers::Common` module to preserve existing application routes. Move the `mount Spree::Core::Engine` statement to the end of the `config/routes.rb` file.
+
 
 Each of the methods defined in this module return values that are the
 most common in Rails applications today, but you may need to customize
@@ -247,6 +256,10 @@ This will then use the URL helpers you have defined in
 allow users to logout, one to allow them to login, and one to allow them
 to signup. These links will be visible on all customer-facing pages of
 Spree.
+
+## Gemfile
+
+The `spree_auth_devise` gem is not needed when using an existing application authentication unless the goal is to have two separate authentication methods.
 
 ## Signup promotion
 


### PR DESCRIPTION
When mounting a Spree app into an existing application and using existing authentication, this documentation change clarifies and updates the way includes are handled and how mount points in the routes for the Spree engine can