### PR TITLE
Fix no resource found translation on stores#index

### DIFF
--- a/backend/app/views/spree/admin/stores/index.html.erb
+++ b/backend/app/views/spree/admin/stores/index.html.erb
@@ -46,6 +46,6 @@
 </div>
 <% else %>
   <div class="alert alert-info no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::StoreCredit)) %>
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::Store)) %>
   </div>
 <% end %>


### PR DESCRIPTION
Rename from plural_resource_name from StoreCredit to Store