### PR TITLE
Fixes error on pages without price filters html elements

### DIFF
--- a/frontend/app/assets/javascripts/spree/frontend/views/spree/products/price_filters.es6
+++ b/frontend/app/assets/javascripts/spree/frontend/views/spree/products/price_filters.es6
@@ -33,12 +33,16 @@ Spree.ready(function() {
 
   // we have 2 elements for filtering prices - desktop and mobile
   const desktopElement = document.getElementById('filterPriceRangeDesktop')
-  const desktopFilterButton = desktopElement.querySelector('a')
-  const desktopPriceRangeFilter = new PriceRangeFilter(desktopElement, desktopFilterButton)
-  desktopPriceRangeFilter.handlePriceChange()
+  if (desktopElement) {
+    const desktopFilterButton = desktopElement.querySelector('a')
+    const desktopPriceRangeFilter = new PriceRangeFilter(desktopElement, desktopFilterButton)
+    desktopPriceRangeFilter.handlePriceChange()
+  }
 
   const mobileElement = document.getElementById('filterPriceRangeMobile')
-  const mobileFilterButton = document.getElementById('filterProductsButtonMobile')
-  const mobilePriceRangeFilter = new PriceRangeFilter(mobileElement, mobileFilterButton)
-  mobilePriceRangeFilter.handlePriceChange()
+  if (mobileElement) {
+    const mobileFilterButton = document.getElementById('filterProductsButtonMobile')
+    const mobilePriceRangeFilter = new PriceRangeFilter(mobileElement, mobileFilterButton)
+    mobilePriceRangeFilter.handlePriceChange()
+  }
 });


### PR DESCRIPTION
On pages other than PLP there is an error:
<img width="613" alt="Screenshot 2021-05-12 at 09 04 54" src="https://user-images.githubusercontent.com/5177038/117932825-26aad080-b301-11eb-858a-5c97164c5cb6.png">
because the script is looking for HTML elements that are present only on PLP (related to price filters).
The error could be interfering with other scripts and prevent them from working properly.