### PR TITLE
Add Ability To Remove Icon Image From menu_item.

### DIFF
--- a/backend/app/controllers/spree/admin/menu_items_controller.rb
+++ b/backend/app/controllers/spree/admin/menu_items_controller.rb
@@ -13,6 +13,18 @@ module Spree
         spree.edit_admin_menu_menu_item_path(@menu, @menu_item)
       end
 
+      def remove_icon
+        if @menu_item.icon.destroy
+          flash[:success] = Spree.t('notice_messages.icon_removed')
+          redirect_to spree.edit_admin_menu_menu_item_path(@menu, @menu_item)
+        else
+          flash[:error] = Spree.t('errors.messages.cannot_remove_icon')
+          render :edit
+        end
+      end
+
+      private
+
       def load_data
         @menu_item_types = Spree::MenuItem::ITEM_TYPE
       end

--- a/backend/app/controllers/spree/admin/menu_items_controller.rb
+++ b/backend/app/controllers/spree/admin/menu_items_controller.rb
@@ -14,7 +14,7 @@ module Spree
       end
 
       def remove_icon
-        if @menu_item.icon.destroy
+        if @menu_item.icon&.destroy
           flash[:success] = Spree.t('notice_messages.icon_removed')
           redirect_to spree.edit_admin_menu_menu_item_path(@menu, @menu_item)
         else

--- a/backend/app/views/spree/admin/menu_items/_form.html.erb
+++ b/backend/app/views/spree/admin/menu_items/_form.html.erb
@@ -62,8 +62,9 @@
             <%= f.fields_for :icon do |icon_field| %>
               <%= f.field_container :icon_attachment do %>
                 <% unless @menu_item.icon.new_record? %>
-                  <div id="menuItemImgContainer" class="my-2">
+                  <div id="menuItemImgContainer" class="my-3 ">
                     <%= image_tag(main_app.url_for(@menu_item.icon.attachment)) %>
+                    <%= link_to Spree.t(:remove_image), remove_icon_admin_menu_menu_item_path(@menu, @menu_item), method: :delete %>
                   </div>
                 <% end %>
               <div id="<% unless @menu_item.icon.new_record? %>MenuItemImageButton<% end %>">

--- a/backend/app/views/spree/admin/menus/edit.html.erb
+++ b/backend/app/views/spree/admin/menus/edit.html.erb
@@ -45,7 +45,7 @@
                 <% end %>
               <% else %>
                 <div class="alert alert-info no-objects-found m-5">
-                  <%= raw Spree.t('admin.navigation.no_menu_items', menu: @menu.name) %>
+                  <%= raw Spree.t('admin.navigation.no_menu_items', menu: @menu.root.name) %>
                 </div>
               <% end %>
             </div>

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -189,7 +189,11 @@ Spree::Core::Engine.add_routes do
     end
 
     resources :menus do
-      resources :menu_items, except: :index
+      resources :menu_items, except: :index do
+        member do
+          delete :remove_icon
+        end
+      end
     end
   end
 

--- a/backend/spec/features/admin/menus/edit_menu_spec.rb
+++ b/backend/spec/features/admin/menus/edit_menu_spec.rb
@@ -4,8 +4,9 @@ describe 'Menu Edit', type: :feature do
   stub_authorization!
 
   let!(:store_1) { create(:store) }
-  let!(:main_menu) { create(:menu, name: 'Main Menu', store_id: store_1.id) }
-  let!(:menu_item) { create(:menu_item, menu_id: main_menu.id, parent_id: main_menu.root.id) }
+  let!(:main_menu) { create(:menu, name: 'Main Menu', store: store_1) }
+  let!(:menu_item) { create(:menu_item, menu: main_menu, parent: main_menu.root) }
+  let(:file_path) { Rails.root + '../../spec/support/ror_ringer.jpeg' }
 
   context 'when link to URL the user can' do
     before do
@@ -59,7 +60,7 @@ describe 'Menu Edit', type: :feature do
     end
   end
 
-  context 'setting the link to a taxon link', js: true do
+  context 'setting the link to a menu link', js: true do
     let!(:taxon_1) { create(:taxon) }
     let!(:taxon_2) { create(:taxon) }
     let!(:taxon_3) { create(:taxon) }
@@ -68,7 +69,7 @@ describe 'Menu Edit', type: :feature do
       visit spree.edit_admin_menu_menu_item_path(main_menu, menu_item)
     end
 
-    it 'allows you to select a taxon and save' do
+    it 'allows you to select a menu and save' do
       select2 'Taxon', from: 'Link To'
       expect(page).to have_text 'Click the Update button below to change the link.'
       click_on 'Update'
@@ -93,6 +94,26 @@ describe 'Menu Edit', type: :feature do
       click_on 'Update'
 
       expect(page).to have_text "Name can't be blank"
+    end
+  end
+
+  context 'when admin adds and removes an image icon' do
+    before do
+      visit spree.edit_admin_menu_menu_item_path(main_menu, menu_item)
+    end
+
+    it 'adds menu_item icon and removes when clicked' do
+      attach_file('menu_item_icon_attributes_attachment', file_path)
+
+      click_button 'Update'
+
+      expect(page).to have_content('successfully updated!')
+      expect(page).to have_css('#menuItemImgContainer img')
+
+      click_link 'Remove Image'
+
+      expect(page).to have_content('Image has been successfully removed')
+      expect(page).not_to have_css('#menuItemImgContainer img')
     end
   end
 end

--- a/backend/spec/features/admin/menus/edit_menu_spec.rb
+++ b/backend/spec/features/admin/menus/edit_menu_spec.rb
@@ -60,7 +60,7 @@ describe 'Menu Edit', type: :feature do
     end
   end
 
-  context 'setting the link to a menu link', js: true do
+  context 'setting the link to a Taxon link', js: true do
     let!(:taxon_1) { create(:taxon) }
     let!(:taxon_2) { create(:taxon) }
     let!(:taxon_3) { create(:taxon) }
@@ -69,7 +69,7 @@ describe 'Menu Edit', type: :feature do
       visit spree.edit_admin_menu_menu_item_path(main_menu, menu_item)
     end
 
-    it 'allows you to select a menu and save' do
+    it 'allows you to select a Taxon and save' do
       select2 'Taxon', from: 'Link To'
       expect(page).to have_text 'Click the Update button below to change the link.'
       click_on 'Update'

--- a/backend/spec/features/admin/menus/index_menu_spec.rb
+++ b/backend/spec/features/admin/menus/index_menu_spec.rb
@@ -19,15 +19,15 @@ describe 'Menus Index', type: :feature do
     let!(:store_3) { create(:store) }
     let!(:store_4) { create(:store) }
 
-    let!(:main_menu) { create(:menu, name: 'Main Menu', store_id: store_1.id) }
-    let!(:main_menu_fr) { create(:menu, name: 'Main Menu FR', store_id: store_1.id, locale: 'fr') }
+    let!(:main_menu) { create(:menu, name: 'Main Menu', store: store_1) }
+    let!(:main_menu_fr) { create(:menu, name: 'Main Menu FR', store: store_1, locale: 'fr') }
 
-    let!(:main_menu_a) { create(:menu, name: 'MA', store_id: store_2.id) }
-    let!(:main_menu_b) { create(:menu, name: 'MB', store_id: store_3.id) }
+    let!(:main_menu_a) { create(:menu, name: 'MA', store: store_2) }
+    let!(:main_menu_b) { create(:menu, name: 'MB', store: store_3) }
 
-    let!(:footer_menu) { create(:menu, name: 'Footer Menu', location: 'footer', store_id: store_3.id) }
-    let!(:footer_menu_a) { create(:menu, name: 'FA', location: 'footer', store_id: store_1.id) }
-    let!(:footer_menu_b) { create(:menu, name: 'FB', location: 'footer', store_id: store_2.id) }
+    let!(:footer_menu) { create(:menu, name: 'Footer Menu', location: 'footer', store: store_3) }
+    let!(:footer_menu_a) { create(:menu, name: 'FA', location: 'footer', store: store_1) }
+    let!(:footer_menu_b) { create(:menu, name: 'FB', location: 'footer', store: store_2) }
 
     before do
       visit spree.admin_menus_path

--- a/backend/spec/features/admin/menus/new_menu_spec.rb
+++ b/backend/spec/features/admin/menus/new_menu_spec.rb
@@ -36,7 +36,7 @@ describe 'New Menu', type: :feature do
 
   context 'when a user tries to create a menu with a duplicate location within scope of stores and language', js: true do
     let!(:store_1) { create(:store) }
-    let!(:main_menu) { create(:menu, name: 'Main Menu', store_id: store_1.id) }
+    let!(:main_menu) { create(:menu, name: 'Main Menu', store: store_1) }
 
     before do
       visit spree.new_admin_menu_path
@@ -72,6 +72,11 @@ describe 'New Menu', type: :feature do
       expect(page).to have_selector('a', text: Spree.t('admin.navigation.add_new_item'))
 
       expect(page).not_to have_css('.translation_missing', visible: :all)
+
+      # Tests that root name is in sync with menu name.
+      fill_in 'Name', with: 'X14dP'
+      click_on 'Update'
+      expect(page).to have_text 'X14dP has no items. Click the Add New Item button to begin adding links to this menu.'
     end
   end
 end

--- a/core/app/models/spree/menu_item.rb
+++ b/core/app/models/spree/menu_item.rb
@@ -5,8 +5,11 @@ module Spree
     belongs_to :menu
     belongs_to :linked_resource, polymorphic: true
 
-    before_create :ensure_item_belongs_to_root
+    around_create :ensure_item_belongs_to_root
     before_save :reset_link_attributes, :build_path, :paremeterize_code
+
+    after_save :touch_ancestors_and_menu
+    after_touch :touch_ancestors_and_menu
 
     ITEM_TYPE = %w[Link Promotion Container]
 
@@ -71,8 +74,17 @@ module Spree
 
     def ensure_item_belongs_to_root
       if menu.try(:root).present? && parent_id.nil?
-        self.parent_id = menu.root.id
+        self.parent = menu.root
       end
+
+      yield
+
+      move_to_child_of(menu.root) unless root
+    end
+
+    def touch_ancestors_and_menu
+      ancestors.update_all(updated_at: Time.current)
+      menu.try!(:touch)
     end
 
     def paremeterize_code


### PR DESCRIPTION
- Add ability to remove icon image from menu_item.
- Fix small bug with adding menu_item to root.
- Use @menu.root.name in admin view and test it is in sync with Menu Name.

Bug example: https://www.youtube.com/watch?v=sf15t27AZXE

Because the API test broke on the depth check, it shows that all the menu items that were being created were being given the parent_id, but the depth was not being set, if we run `move_to_child_of(menu.root) unless root` after_create, ANS takes care of all that and the depth is set correctly on creation, and tacks the positioning from the word go.

- Added comments to the API reposition test to make this clear.

**NOTE:**
Added the following to menu_item.rb, taken from taxon.rb, I assume for cashing.

```ruby
after_save :touch_ancestors_and_menu
after_touch :touch_ancestors_and_menu

def touch_ancestors_and_menu
  ancestors.update_all(updated_at: Time.current)
  menu.try!(:touch)
end
```

Let me know if you think these are needed or not.