### PR TITLE
Fix broken test for touch after create, add tests for level of newly …

### DIFF
--- a/backend/app/views/spree/admin/menu_items/_form.html.erb
+++ b/backend/app/views/spree/admin/menu_items/_form.html.erb
@@ -21,7 +21,7 @@
             </small>
           <% end %>
 
-         <%= f.field_container :parent_id, class: ['form-group'] do %>
+          <%= f.field_container :parent_id, class: ['form-group'] do %>
             <%= f.label :parent_id, Spree.t('admin.navigation.nested_under') %>
             <%= f.select :parent_id, nested_set_options(@menu.menu_items, @menu_item) {|i| "#{'-' * i.level} #{i.name}" }, {include_blank: false}, {class: 'select2'} %>
             <%= f.error_message_on :parent_id %>

--- a/core/app/models/spree/menu_item.rb
+++ b/core/app/models/spree/menu_item.rb
@@ -5,7 +5,7 @@ module Spree
     belongs_to :menu, touch: true
     belongs_to :linked_resource, polymorphic: true
 
-    around_create :ensure_item_belongs_to_root
+    before_create :ensure_item_belongs_to_root
     before_save :reset_link_attributes, :build_path, :paremeterize_code
 
     after_save :touch_ancestors_and_menu
@@ -75,11 +75,9 @@ module Spree
     def ensure_item_belongs_to_root
       if menu.try(:root).present? && parent_id.nil?
         self.parent = menu.root
+
+        store_new_parent
       end
-
-      yield
-
-      move_to_child_of(menu.root) unless root
     end
 
     def touch_ancestors_and_menu

--- a/core/spec/models/spree/menu_item_spec.rb
+++ b/core/spec/models/spree/menu_item_spec.rb
@@ -103,7 +103,7 @@ describe Spree::MenuItem, type: :model do
       item_taxon.update(linked_resource: taxon)
       item_taxon.update(linked_resource_id: nil)
 
-      expect(item_taxon.destination).to eql nil
+      expect(item_taxon.destination).to be nil
     end
 
     it 'returns product path' do
@@ -116,7 +116,7 @@ describe Spree::MenuItem, type: :model do
       item_product.update(linked_resource: product)
       item_product.update(linked_resource_id: nil)
 
-      expect(item_product.destination).to eql nil
+      expect(item_product.destination).to be nil
     end
 
     it 'returns root path' do
@@ -137,10 +137,18 @@ describe Spree::MenuItem, type: :model do
   end
 
   describe '.ensure_item_belongs_to_root' do
-    let(:item_x) { create(:menu_item, name: 'URL', item_type: 'Link', menu: menu, parent: menu.root, linked_resource_type: 'URL', code: 'My Fantastic Code') }
+    let(:item_x) { create(:menu_item, name: 'URL', item_type: 'Link', menu: menu, linked_resource_type: 'URL', code: 'My Fantastic Code') }
 
     it 'Sets new items parent_id to root.id' do
       expect(item_x.parent_id).to eql menu.root.id
+    end
+
+    it 'is not a root' do
+      expect(item_x.root?).to be false
+    end
+
+    it 'is level 1' do
+      expect(item_x.level).to eql 1
     end
   end
 


### PR DESCRIPTION
Fix Issue causing test to fail for touch after create on new menu items. 

Add test to:
- Verify the level of newly added items = 1.
- Verify that newly added items are not a root