### PR TITLE
Tidy up the view for Menus new / edit form.

### DIFF
--- a/backend/app/views/spree/admin/menus/_form.html.erb
+++ b/backend/app/views/spree/admin/menus/_form.html.erb
@@ -13,15 +13,15 @@
     <% end %>
   </div>
   <div class="col-12 col-md-6">
-    <div class="form-group">
+    <%= f.field_container :menu_stores, class: ['form-group'] do %>
       <%= label_tag :menu_stores, Spree.t(:stores) %>
       <%= collection_select(:menu, :store_id, @stores, :id, :unique_name, {}, { class: 'select2' }) %>
       <%= f.error_message_on :menu_stores %>
-    </div>
-    <div class="form-group">
+    <% end %>
+    <%= f.field_container :locale, class: ['form-group'] do %>
       <%= f.label :locale %>
       <%= f.select :locale, options_from_collection_for_select(all_locales_options, :last, :first, @menu.locale || I18n.locale), {}, { class: 'select2' } %>
       <%= f.error_message_on :default_locale %>
-    </div>
+    <% end %>
   </div>
 </div>

--- a/backend/app/views/spree/admin/menus/edit.html.erb
+++ b/backend/app/views/spree/admin/menus/edit.html.erb
@@ -6,7 +6,7 @@
     <div class="col-12">
       <div class="card mb-3">
         <div class="card-header">
-          <h5>Settings</h5>
+          <h5 class="mb-0"><%= Spree.t('settings') %></h5>
         </div>
         <div class="card-body">
           <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @menu } %>

--- a/backend/app/views/spree/admin/menus/new.html.erb
+++ b/backend/app/views/spree/admin/menus/new.html.erb
@@ -2,9 +2,21 @@
   <%= link_to Spree.t('admin.navigation.all_menus'), spree.admin_menus_path %> / <%= Spree.t('admin.navigation.new_menu') %>
 <% end %>
 
-<%= render partial: 'spree/admin/shared/error_messages', locals: { target: @menu } %>
-
-<%= form_for [:admin, @menu] do |f| %>
-    <%= render partial: 'form', locals: { f: f } %>
-    <%= render partial: 'spree/admin/shared/new_resource_links' %>
-<% end %>
+<div class="row">
+    <div class="col-12">
+      <div class="card mb-3">
+        <div class="card-header">
+          <h5 class="mb-0"><%= Spree.t('settings') %></h5>
+        </div>
+        <div class="card-body">
+          <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @menu } %>
+          <%= form_for [:admin, @menu] do |f| %>
+            <%= render partial: 'form', locals: { f: f } %>
+            <div class="d-flex ">
+              <%= render partial: 'spree/admin/shared/new_resource_links' %>
+            </div>
+          <% end %>
+        </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
- Found the hard coded word `Settings` in the `new.html.erb` and `edit.html.erb` file, swapped for proper locale key.
- Remove an inconsistency between the `new.html.erb` and `edit.html.erb` Menu views.
- Add consistency to menu _form by using all ERB for form group containers.