### PR TITLE
[SD-1101] Allow clearing all Filters on PLP

### DIFF
--- a/frontend/app/views/spree/products/_filters_desktop.html.erb
+++ b/frontend/app/views/spree/products/_filters_desktop.html.erb
@@ -1,5 +1,7 @@
 <% cache filters_cache_key('desktop') do %>
   <div id="plp-filters-accordion" class="d-none d-lg-block col-lg-3 pr-5 position-sticky h-100 plp-filters" data-hook="taxon_sidebar_navigation">
+    <%= clear_all_filters_link(permitted_params) if product_filters_present?(permitted_params) %>
+
     <div class="plp-filters-scroller">
       <% @available_option_types.each do |option_type| %>
         <div class="w-100 card plp-filters-card">

--- a/frontend/app/views/spree/products/_filters_mobile.html.erb
+++ b/frontend/app/views/spree/products/_filters_mobile.html.erb
@@ -88,7 +88,7 @@
   <% end %>
 
   <div class="container position-absolute text-center plp-overlay-buttons pt-3">
-    <%= link_to Spree.t('plp.clear_all'), permitted_params.select { |key, value| key == "sort_by"}, class: 'btn spree-btn btn-outline-primary w-100 mb-4', data: { params: permitted_params.select { |key, value| key == "sort_by"} } %>
+    <%= clear_all_filters_link(permitted_params) %>
     <%= link_to Spree.t('plp.done'), permitted_params, id: 'filterProductsButtonMobile', class: 'btn btn-primary spree-btn w-100 done-btn', data: { params: permitted_params } %>
   </div>
 </div>

--- a/frontend/spec/features/products_filtering_spec.rb
+++ b/frontend/spec/features/products_filtering_spec.rb
@@ -47,12 +47,21 @@ describe 'Products filtering', :js do
     have_css '.plp-overlay-card-item--selected', text: value
   end
 
+  def expect_working_filters_clearing
+    click_on 'CLEAR ALL'
+    expect(page).to have_content 'First shirt'
+    expect(page).to have_content 'Second shirt'
+    expect(page).not_to have_css('.plp-overlay-card-item--selected')
+  end
+
   def filters
     find('#plp-filters-accordion')
   end
 
   it 'correctly filters Products' do
     visit spree.nested_taxons_path(taxon)
+
+    expect(page).not_to have_content('CLEAR ALL')
 
     search_by 'shirt'
     expect(page).to have_content 'First shirt'
@@ -65,6 +74,21 @@ describe 'Products filtering', :js do
     expect(page).to have_content 'First shirt'
     expect(page).to have_selected_filter_with(value: 'M')
     expect(page).to have_selected_filter_with(value: 'S')
+
+    expect_working_filters_clearing
+
+    click_on_filter 'Brand', value: 'Alpha'
+    expect(page).not_to have_content 'First shirt'
+    expect(page).to have_content 'Second shirt'
+    expect(page).to have_selected_filter_with(value: 'ALPHA')
+
+    expect_working_filters_clearing
+
+    click_on_filter 'Price', value: '$50 - $100'
+    expect(page).to have_content 'No results'
+
+    expect_working_filters_clearing
+
     expect(current_path).to eq spree.products_path
   end
 


### PR DESCRIPTION
- added a reusable link for clearing filters (based on the mobile view link)
- displaying "Clear All" link when any of the filters are applied