### PR TITLE
Fix Issue with menu changes not appearing because of Turbo Links

### DIFF
--- a/api/app/controllers/spree/api/v2/storefront/menus_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/menus_controller.rb
@@ -31,6 +31,10 @@ module Spree
           def model_class
             Spree::Menu
           end
+
+          def scope
+            super.by_store(current_store)
+          end
         end
       end
     end

--- a/api/app/controllers/spree/api/v2/storefront/menus_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/menus_controller.rb
@@ -40,4 +40,3 @@ module Spree
     end
   end
 end
-

--- a/api/app/controllers/spree/api/v2/storefront/menus_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/menus_controller.rb
@@ -33,7 +33,7 @@ module Spree
           end
 
           def scope
-            super.by_store(current_store)
+            super.by_store(current_store).by_locale(I18n.locale)
           end
         end
       end

--- a/api/app/controllers/spree/api/v2/storefront/menus_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/menus_controller.rb
@@ -13,7 +13,7 @@ module Spree
           end
 
           def resource
-            scope.find_by(unique_code: params[:unique_code])
+            @resource ||= scope.find_by(location: params[:location])
           end
 
           def resource_serializer
@@ -31,12 +31,9 @@ module Spree
           def model_class
             Spree::Menu
           end
-
-          def scope
-            super.by_store(current_store)
-          end
         end
       end
     end
   end
 end
+

--- a/backend/app/assets/javascripts/spree/backend.js
+++ b/backend/app/assets/javascripts/spree/backend.js
@@ -89,7 +89,7 @@ Spree.routes.stock_items_api = function (stockLocationId) {
 // API v2
 Spree.routes.countries_api_v2 = Spree.pathFor('api/v2/platform/countries')
 Spree.routes.menus_api_v2 = Spree.pathFor('api/v2/platform/menus')
-Spree.routes.menus_items_api_v2 = Spree.pathFor('api/v2/platform/menu_items/reposition')
+Spree.routes.menus_items_api_v2 = Spree.pathFor('api/v2/platform/menu_items')
 Spree.routes.option_types_api_v2 = Spree.pathFor('api/v2/platform/option_types')
 Spree.routes.option_values_api_v2 = Spree.pathFor('api/v2/platform/option_values')
 Spree.routes.products_api_v2 = Spree.pathFor('/api/v2/platform/products')

--- a/backend/app/assets/javascripts/spree/backend/menus/menu.es6
+++ b/backend/app/assets/javascripts/spree/backend/menus/menu.es6
@@ -27,14 +27,14 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 })
 
-function handleMenuItemMove(evt, successCallback) {
+function handleMenuItemMove(evt) {
   const data = {
     moved_item_id: parseInt(evt.item.dataset.itemId, 10),
     new_parent_id: parseInt(evt.to.dataset.parentId, 10) || null,
     new_position_idx: parseInt(evt.newIndex, 10)
   }
 
-  fetch(Spree.routes.menus_items_api_v2, {
+  fetch(Spree.routes.menus_items_api_v2 + '/reposition', {
     method: 'PATCH',
     headers: {
       Authorization: 'Bearer ' + OAUTH_TOKEN,

--- a/backend/app/views/spree/admin/menu_items/link_inputs/_url.html.erb
+++ b/backend/app/views/spree/admin/menu_items/link_inputs/_url.html.erb
@@ -2,6 +2,9 @@
   <%= f.label :destination, Spree.t(:url) %>
   <%= f.text_field :destination, class: 'form-control' %>
   <%= f.error_message_on :destination %>
+  <small class="form-text text-muted">
+    <%= raw Spree.t('admin.navigation.url_info') %>
+  </small>
 <% end %>
 
 <%= f.field_container :new_window do %>

--- a/core/app/models/spree/menu.rb
+++ b/core/app/models/spree/menu.rb
@@ -22,6 +22,8 @@ module Spree
 
     has_one :root, -> { where(parent_id: nil) }, class_name: 'Spree::MenuItem', dependent: :destroy
 
+    scope :by_store, ->(store) { where(store: store) }
+
     self.whitelisted_ransackable_attributes = %w[name location locale store_id]
 
     MENU_LOCATIONS_PARAMETERIZED.each do |name|

--- a/core/app/models/spree/menu.rb
+++ b/core/app/models/spree/menu.rb
@@ -23,6 +23,7 @@ module Spree
     has_one :root, -> { where(parent_id: nil) }, class_name: 'Spree::MenuItem', dependent: :destroy
 
     scope :by_store, ->(store) { where(store: store) }
+    scope :by_locale, ->(locale) { where(locale: locale) }
 
     self.whitelisted_ransackable_attributes = %w[name location locale store_id]
 

--- a/core/app/models/spree/menu_item.rb
+++ b/core/app/models/spree/menu_item.rb
@@ -32,6 +32,10 @@ module Spree
       where(linked_resource_type: resorce.class.name, linked_resource_id: resorce.id).each(&:save!)
     end
 
+    def container?
+      item_type == 'Container'
+    end
+
     private
 
     def build_path

--- a/core/app/models/spree/menu_item.rb
+++ b/core/app/models/spree/menu_item.rb
@@ -36,6 +36,14 @@ module Spree
       item_type == 'Container'
     end
 
+    def code?(item_code = nil)
+      if item_code
+        code == item_code
+      else
+        code.present?
+      end
+    end
+
     private
 
     def build_path

--- a/core/app/models/spree/menu_item.rb
+++ b/core/app/models/spree/menu_item.rb
@@ -11,7 +11,7 @@ module Spree
     after_save :touch_ancestors_and_menu
     after_touch :touch_ancestors_and_menu
 
-    ITEM_TYPE = %w[Link Promotion Container]
+    ITEM_TYPE = %w[Link Container]
 
     LINKED_RESOURCE_TYPE = ['URL']
     STATIC_RESOURCE_TYPE = ['Home Page']

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -604,6 +604,8 @@ en:
         public_details: Public Details
         unique_code_store_error: 'The code: %{code} is already used for Menu: %{menus}, make sure your unique code is unique within the store it is being used for.'
         subtitle: Subtitle
+        url_info: 'The URL field can link to an external website using <b>https://example.com</b>, link to an otherwise unreachable internal path using <b>/policies/privacy</b>,
+        lanch an email client using <b>mailto:sales@example.com</b> or used to create a clickable phone number with <b>tel:123456789</b>'
         seach_for_a_product: Search for a Product
         seach_for_a_taxon: Search for a Taxon
         settings: Settings

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -605,7 +605,7 @@ en:
         unique_code_store_error: 'The code: %{code} is already used for Menu: %{menus}, make sure your unique code is unique within the store it is being used for.'
         subtitle: Subtitle
         url_info: 'The URL field can link to an external website using <b>https://example.com</b>, link to an otherwise unreachable internal path using <b>/policies/privacy</b>,
-        lanch an email client using <b>mailto:sales@example.com</b> or used to create a clickable phone number with <b>tel:123456789</b>'
+        launch an email client using <b>mailto:sales@example.com</b> or used to create a clickable phone number with <b>tel:123456789</b>'
         seach_for_a_product: Search for a Product
         seach_for_a_taxon: Search for a Taxon
         settings: Settings

--- a/core/spec/models/spree/menu_item_spec.rb
+++ b/core/spec/models/spree/menu_item_spec.rb
@@ -36,7 +36,7 @@ describe Spree::MenuItem, type: :model do
     end
   end
 
-  describe '.reset_link_attributes from URL to Taxon' do
+  describe '#reset_link_attributes from URL to Taxon' do
     let(:i_a) do
       create(:menu_item, name: 'Home', item_type: 'Link', menu: menu,
                          parent: menu.root, linked_resource_type: 'URL', destination: 'http://somewhere.com', new_window: true, linked_resource_id: 5)
@@ -68,7 +68,32 @@ describe Spree::MenuItem, type: :model do
     end
   end
 
-  describe '.reset_link_attributes from URL to Home Page' do
+  describe '#code?' do
+    let(:coded_item){ create(:menu_item, name: 'Link 1', item_type: 'Container', menu: menu, code: 'some-code') }
+    let(:not_coded_item) { create(:menu_item, name: 'Home', item_type: 'Link', menu: menu) }
+
+    it 'returns true when the menu item has a matching code' do
+      expect(coded_item.code?('some-code')).to be true
+    end
+
+    it 'returns false when the menu item has a code but the code does not match' do
+      expect(coded_item.code?('Some-code')).to be false
+    end
+
+    it 'returns false when the menu item has no code' do
+      expect(not_coded_item.code?('some-code')).to be false
+    end
+
+    it 'returns true if no args are passed, and the item has a code' do
+      expect(coded_item.code?).to be true
+    end
+
+    it 'returns false if no args are passed, and the item has no code' do
+      expect(not_coded_item.code?).to be false
+    end
+  end
+
+  describe '#reset_link_attributes from URL to Home Page' do
     let(:i_b) do
       create(:menu_item, name: 'Home', item_type: 'Link', menu: menu,
                          parent: menu.root, linked_resource_type: 'URL', destination: 'http://somewhere.com', new_window: true, linked_resource_id: 5)
@@ -83,7 +108,7 @@ describe Spree::MenuItem, type: :model do
     end
   end
 
-  describe '.reset_link_attributes from Link to Container' do
+  describe '#reset_link_attributes from Link to Container' do
     let(:i_c) do
       create(:menu_item, name: 'Home', item_type: 'Link', menu: menu,
                          parent: menu.root, linked_resource_type: 'URL', destination: 'http://somewhere.com', new_window: true, linked_resource_id: 5)
@@ -141,7 +166,7 @@ describe Spree::MenuItem, type: :model do
     end
   end
 
-  describe '.paremeterize_code' do
+  describe '#paremeterize_code' do
     let(:item) { create(:menu_item, name: 'URL', item_type: 'Link', menu: menu, parent: menu.root, linked_resource_type: 'URL', code: 'My Fantastic Code') }
 
     it 'paramatizes a code when one is given' do
@@ -149,7 +174,7 @@ describe Spree::MenuItem, type: :model do
     end
   end
 
-  describe '.ensure_item_belongs_to_root' do
+  describe '#ensure_item_belongs_to_root' do
     let(:item_x) { create(:menu_item, name: 'URL', item_type: 'Link', menu: menu, linked_resource_type: 'URL', code: 'My Fantastic Code') }
 
     it 'Sets new items parent_id to root.id' do

--- a/core/spec/models/spree/menu_item_spec.rb
+++ b/core/spec/models/spree/menu_item_spec.rb
@@ -55,6 +55,19 @@ describe Spree::MenuItem, type: :model do
     end
   end
 
+  describe '#container?' do
+    let(:container_item){ create(:menu_item, name: 'Link 1', item_type: 'Container', menu: menu) }
+    let(:link_item) { create(:menu_item, name: 'Home', item_type: 'Link', menu: menu) }
+
+    it 'returns true when the menu item is of type container' do
+      expect(container_item.container?).to be true
+    end
+
+    it 'returns false when the menu item is of type Link' do
+      expect(link_item.container?).to be false
+    end
+  end
+
   describe '.reset_link_attributes from URL to Home Page' do
     let(:i_b) do
       create(:menu_item, name: 'Home', item_type: 'Link', menu: menu,

--- a/frontend/app/assets/stylesheets/spree/frontend/views/spree/shared/footer.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/views/spree/shared/footer.scss
@@ -41,6 +41,10 @@
     @include media-breakpoint-up(xl) {
       font-size: font-px-to-rem(16px);
       font-weight: 500;
+
+      a {
+        font-size: font-px-to-rem(16px) !important;
+      }
     }
   }
   &-info {

--- a/frontend/app/helpers/spree/navigation_helper.rb
+++ b/frontend/app/helpers/spree/navigation_helper.rb
@@ -82,7 +82,7 @@ module Spree
         (defined?(should_render_currency_dropdown?) && should_render_currency_dropdown?)
     end
 
-    def spree_nav_link_tag(item, opts = {})
+    def spree_nav_link_tag(item, opts = {}, &block)
       if item.new_window
         target = opts[:target] || '_blank'
         rel = opts[:rel] || 'noopener noreferrer'
@@ -90,13 +90,11 @@ module Spree
 
       if block_given?
         link_to spree_localized_item_link(item), target: target, rel: rel, class: opts[:class],
-                                                          id: opts[:id], data: opts[:data], aria: opts[:aria] do
-                                                            yield
-                                                          end
+                                                 id: opts[:id], data: opts[:data], aria: opts[:aria], &block
 
       else
         link_to item.name, spree_localized_item_link(item), target: target, rel: rel, class: opts[:class],
-                                                          id: opts[:id], data: opts[:data], aria: opts[:aria]
+                                                            id: opts[:id], data: opts[:data], aria: opts[:aria]
       end
     end
 

--- a/frontend/app/helpers/spree/navigation_helper.rb
+++ b/frontend/app/helpers/spree/navigation_helper.rb
@@ -90,7 +90,7 @@ module Spree
 
       link_opts = { target: target, rel: rel, class: opts[:class], id: opts[:id], data: opts[:data], aria: opts[:aria] }
       if block_given?
-        link_to spree_localized_item_link(item), spree_localized_item_link(item), link_opts, &block
+        link_to spree_localized_item_link(item), link_opts, &block
       else
         link_to item.name, spree_localized_item_link(item), link_opts
       end

--- a/frontend/app/helpers/spree/navigation_helper.rb
+++ b/frontend/app/helpers/spree/navigation_helper.rb
@@ -88,13 +88,11 @@ module Spree
         rel = opts[:rel] || 'noopener noreferrer'
       end
 
+      link_opts = { target: target, rel: rel, class: opts[:class], id: opts[:id], data: opts[:data], aria: opts[:aria] }
       if block_given?
-        link_to spree_localized_item_link(item), target: target, rel: rel, class: opts[:class],
-                                                 id: opts[:id], data: opts[:data], aria: opts[:aria], &block
-
+        link_to spree_localized_item_link(item), spree_localized_item_link(item), link_opts, &block
       else
-        link_to item.name, spree_localized_item_link(item), target: target, rel: rel, class: opts[:class],
-                                                            id: opts[:id], data: opts[:data], aria: opts[:aria]
+        link_to item.name, spree_localized_item_link(item), link_opts
       end
     end
 

--- a/frontend/app/helpers/spree/navigation_helper.rb
+++ b/frontend/app/helpers/spree/navigation_helper.rb
@@ -82,6 +82,24 @@ module Spree
         (defined?(should_render_currency_dropdown?) && should_render_currency_dropdown?)
     end
 
+    def spree_nav_link_tag(item, opts = {})
+      if item.new_window
+        target = opts[:target] || '_blank'
+        rel = opts[:rel] || 'noopener noreferrer'
+      end
+
+      if block_given?
+        link_to spree_localized_item_link(item), target: target, rel: rel, class: opts[:class],
+                                                          id: opts[:id], data: opts[:data], aria: opts[:aria] do
+                                                            yield
+                                                          end
+
+      else
+        link_to item.name, spree_localized_item_link(item), target: target, rel: rel, class: opts[:class],
+                                                          id: opts[:id], data: opts[:data], aria: opts[:aria]
+      end
+    end
+
     private
 
     def spree_navigation_data_cache_key

--- a/frontend/app/views/spree/shared/_footer.html.erb
+++ b/frontend/app/views/spree/shared/_footer.html.erb
@@ -53,10 +53,20 @@
           <% spree_menu('footer').children.each do |parent| %>
             <div class="col-3">
               <div class="footer-spree-label">
-                <%= link_to parent.name, spree_localized_item_link(parent) %>
+                <% if parent.item_type == 'Container' %>
+                  <%= parent.name %>
+                <% else %>
+                  <%= link_to parent.name, spree_localized_item_link(parent) %>
+                <% end %>
               </div>
               <% parent.children.each do |child| %>
-                <div class="pt-2"><%= link_to child.name, spree_localized_item_link(child) %></div>
+                <div class="pt-2">
+                  <% if child.new_window %>
+                    <%= link_to child.name, spree_localized_item_link(child), target: '_blank', rel: 'noopener noreferrer' %>
+                  <% else %>
+                    <%= link_to child.name, spree_localized_item_link(child) %>
+                  <% end %>
+                </div>
               <% end %>
             </div>
           <% end %>

--- a/frontend/app/views/spree/shared/_footer.html.erb
+++ b/frontend/app/views/spree/shared/_footer.html.erb
@@ -56,13 +56,7 @@
                 <%= link_to parent.name, spree_localized_item_link(parent) %>
               </div>
               <% parent.children.each do |child| %>
-                <% if child.code == 'category' && child.item_type == 'Container' %>
-                  <% if child.children.present? %>
-                    <% child.children.each do |category_link| %>
-                      <div class="pt-2"><%= link_to category_link.name, spree_localized_item_link(category_link) %></div>
-                    <% end %>
-                  <% end %>
-                <% end %>
+                <div class="pt-2"><%= link_to child.name, spree_localized_item_link(child) %></div>
               <% end %>
             </div>
           <% end %>

--- a/frontend/app/views/spree/shared/_footer.html.erb
+++ b/frontend/app/views/spree/shared/_footer.html.erb
@@ -53,19 +53,15 @@
           <% spree_menu('footer').children.each do |parent| %>
             <div class="col-3">
               <div class="footer-spree-label">
-                <% if parent.item_type == 'Container' %>
+                <% if parent.container? %>
                   <%= parent.name %>
                 <% else %>
-                  <%= link_to parent.name, spree_localized_item_link(parent) %>
+                  <%= spree_nav_link_tag(parent) %>
                 <% end %>
               </div>
               <% parent.children.each do |child| %>
                 <div class="pt-2">
-                  <% if child.new_window %>
-                    <%= link_to child.name, spree_localized_item_link(child), target: '_blank', rel: 'noopener noreferrer' %>
-                  <% else %>
-                    <%= link_to child.name, spree_localized_item_link(child) %>
-                  <% end %>
+                  <%= spree_nav_link_tag(child) %>
                 </div>
               <% end %>
             </div>

--- a/frontend/app/views/spree/shared/_footer.html.erb
+++ b/frontend/app/views/spree/shared/_footer.html.erb
@@ -1,5 +1,5 @@
 <% cache spree_menu_cache_key('footer') do %>
-  <footer id="footer" class="pt-2 mx-auto border-top footer-spree" data-turbolinks-permanent>
+  <footer id="footer" class="pt-2 mx-auto border-top footer-spree">
     <div class="container">
       <div class="row d-xl-flex justify-content-xl-around pb-xl-5">
         <div class="d-flex d-xl-block flex-xl-grow-0 col-xl-4">

--- a/frontend/app/views/spree/shared/_header.html.erb
+++ b/frontend/app/views/spree/shared/_header.html.erb
@@ -1,6 +1,6 @@
 <%# leaving #spree-header div for legacy support  %>
 <% cache spree_menu_cache_key('header') do %>
-  <div id="spree-header" data-turbolinks-permanent>
+  <div id="spree-header">
     <header id="header" class="d-flex align-items-center header-spree border-bottom">
       <div class="container-fluid h-100 header-spree-fluid">
         <div class="d-flex flex-nowrap align-items-center h-100">

--- a/frontend/app/views/spree/shared/_main_nav_bar.html.erb
+++ b/frontend/app/views/spree/shared/_main_nav_bar.html.erb
@@ -10,7 +10,12 @@
             <% dropdown_toggle_class = has_dropdown ? "dropdown-toggle" : "" %>
             <% data_attr = has_dropdown ? { toggle: "dropdown" } : {} %>
             <% aria_attr = has_dropdown ? { haspopup: true, expanded: false } : {} %>
-            <%= link_to(parent.name, spree_localized_item_link(parent), class: "nav-link main-nav-bar-item main-nav-bar-category-button #{dropdown_toggle_class}", data: data_attr, aria: aria_attr) %>
+            <% if parent.item_type == "Container" %>
+              <%= content_tag :span, parent.name, class: "nav-link main-nav-bar-item main-nav-bar-category-button #{dropdown_toggle_class}", data: data_attr, aria: aria_attr %>
+            <% else %>
+               <%= link_to(parent.name, spree_localized_item_link(parent), class: "nav-link main-nav-bar-item main-nav-bar-category-button #{dropdown_toggle_class}", data: data_attr, aria: aria_attr) %>
+            <% end %>
+
              <% if has_dropdown %>
               <div class="dropdown-menu w-100 shadow main-nav-bar-category-dropdown">
                 <div class="container p-0 d-flex justify-content-xl-around mx-auto">

--- a/frontend/app/views/spree/shared/_main_nav_bar.html.erb
+++ b/frontend/app/views/spree/shared/_main_nav_bar.html.erb
@@ -13,7 +13,7 @@
             <% if parent.item_type == "Container" %>
               <%= content_tag :span, parent.name, class: "nav-link main-nav-bar-item main-nav-bar-category-button #{dropdown_toggle_class}", data: data_attr, aria: aria_attr %>
             <% else %>
-               <%= link_to(parent.name, spree_localized_item_link(parent), class: "nav-link main-nav-bar-item main-nav-bar-category-button #{dropdown_toggle_class}", data: data_attr, aria: aria_attr) %>
+               <%= spree_nav_link_tag(parent, { class: "nav-link main-nav-bar-item main-nav-bar-category-button #{dropdown_toggle_class}", data: data_attr, aria: aria_attr }) %>
             <% end %>
 
              <% if has_dropdown %>
@@ -23,7 +23,7 @@
                     <% parent.children.each do |child| %>
 
                       <!-- Categories -->
-                      <% if child.code == category && child.item_type == 'Container' %>
+                      <% if child.container? && child.code == category %>
                         <div class="category-links my-4 mx-2">
                           <div class="category-links-header text-uppercase">
                             <%= child.name %>
@@ -32,7 +32,7 @@
                             <ul class="pl-0">
                               <% child.children.each do |category_link| %>
                                 <li>
-                                  <%= link_to category_link.name, spree_localized_item_link(category_link), class: "text-uppercase main-nav-bar-category-links dropdown-item truncate" %>
+                                  <%= spree_nav_link_tag(category_link, { class: "text-uppercase main-nav-bar-category-links dropdown-item truncate" }) %>
                                 </li>
                               <% end %>
                             </ul>
@@ -41,10 +41,10 @@
                       <% end %>
 
                       <!-- Promos -->
-                      <% if child.code == promo && child.item_type == 'Container' %>
+                      <% if child.container? && child.code == promo %>
                         <% if child.children.present? %>
                           <% child.children.each do |promo_banner| %>
-                            <%= link_to spree_localized_item_link(promo_banner), class: "dropdown-item" do %>
+                            <%= spree_nav_link_tag(promo_banner, { class: "dropdown-item" }) do %>
                               <div class="category-image text-center my-4 mx-3">
                                 <% if promo_banner.icon.present? %>
                                   <%= image_tag main_app.url_for(promo_banner.icon.attachment), alt: promo_banner.icon.alt ,title: promo_banner.subtitle %>

--- a/frontend/app/views/spree/shared/_main_nav_bar.html.erb
+++ b/frontend/app/views/spree/shared/_main_nav_bar.html.erb
@@ -1,7 +1,4 @@
 <% if spree_menu.present? %>
-  <% category = 'category' %>
-  <% promo = 'promo' %>
-
   <div class="h-100" role="navigation" aria-label="<%= Spree.t('nav_bar.desktop') %>">
     <ul class="nav h-100 main-nav-bar">
       <% spree_menu.children.each do |parent| %>
@@ -23,7 +20,7 @@
                     <% parent.children.each do |child| %>
 
                       <!-- Categories -->
-                      <% if child.container? && child.code == category %>
+                      <% if child.container? && child.code?('category') %>
                         <div class="category-links my-4 mx-2">
                           <div class="category-links-header text-uppercase">
                             <%= child.name %>
@@ -41,7 +38,7 @@
                       <% end %>
 
                       <!-- Promos -->
-                      <% if child.container? && child.code == promo %>
+                      <% if child.container? && child.code?('promo') %>
                         <% if child.children.present? %>
                           <% child.children.each do |promo_banner| %>
                             <%= spree_nav_link_tag(promo_banner, { class: "dropdown-item" }) do %>

--- a/frontend/app/views/spree/shared/_main_nav_bar.html.erb
+++ b/frontend/app/views/spree/shared/_main_nav_bar.html.erb
@@ -7,7 +7,7 @@
             <% dropdown_toggle_class = has_dropdown ? "dropdown-toggle" : "" %>
             <% data_attr = has_dropdown ? { toggle: "dropdown" } : {} %>
             <% aria_attr = has_dropdown ? { haspopup: true, expanded: false } : {} %>
-            <% if parent.item_type == "Container" %>
+            <% if parent.container? %>
               <%= content_tag :span, parent.name, class: "nav-link main-nav-bar-item main-nav-bar-category-button #{dropdown_toggle_class}", data: data_attr, aria: aria_attr %>
             <% else %>
                <%= spree_nav_link_tag(parent, { class: "nav-link main-nav-bar-item main-nav-bar-category-button #{dropdown_toggle_class}", data: data_attr, aria: aria_attr }) %>

--- a/frontend/app/views/spree/shared/_mobile_navigation.html.erb
+++ b/frontend/app/views/spree/shared/_mobile_navigation.html.erb
@@ -39,7 +39,7 @@
                 </li>
 
                 <% parent.children.each do |child| %>
-                  <% if child.code == 'category' && child.item_type == 'Container' %>
+                  <% if child.container? && child.code?('category') %>
                   <li class="text-muted mt-2"><%= child.name %></li>
                     <% if child.children.present? %>
                       <% child.children.each do |category_link| %>

--- a/frontend/app/views/spree/shared/_mobile_navigation.html.erb
+++ b/frontend/app/views/spree/shared/_mobile_navigation.html.erb
@@ -20,7 +20,7 @@
     <ul class="list-unstyled position-relative h-100 mobile-navigation-list">
       <% spree_menu.children.each do |parent| %>
           <li class="d-flex justify-content-between align-items-center mobile-navigation-list-item">
-          <% if parent.item_type == "Container" %>
+          <% if parent.container? %>
             <%= content_tag :span, parent.name %>
           <% else %>
             <%= link_to parent.name, spree_localized_item_link(parent), class: 'w-75' %>

--- a/frontend/app/views/spree/shared/_mobile_navigation.html.erb
+++ b/frontend/app/views/spree/shared/_mobile_navigation.html.erb
@@ -20,7 +20,12 @@
     <ul class="list-unstyled position-relative h-100 mobile-navigation-list">
       <% spree_menu.children.each do |parent| %>
           <li class="d-flex justify-content-between align-items-center mobile-navigation-list-item">
-          <%= link_to parent.name, spree_localized_item_link(parent), class: 'w-75' %>
+          <% if parent.item_type == "Container" %>
+            <%= content_tag :span, parent.name %>
+          <% else %>
+            <%= link_to parent.name, spree_localized_item_link(parent), class: 'w-75' %>
+          <% end %>
+
           <% if parent.children.present? %>
             <a class="w-25 text-right mobile-navigation-category-link" data-category="<%= parent.name.parameterize %>" href="#" aria-label="<%= Spree.t('go_to_category') %>">
               <%= icon(name: 'arrow-right',

--- a/frontend/app/views/spree/shared/_nav_bar.html.erb
+++ b/frontend/app/views/spree/shared/_nav_bar.html.erb
@@ -1,4 +1,4 @@
-<ul id="nav-bar" class="nav align-items-center d-flex flex-nowrap justify-content-end navbar-right" data-turbolinks-permanent>
+<ul id="nav-bar" class="nav align-items-center d-flex flex-nowrap justify-content-end navbar-right">
   <li>
     <div class="navbar-right-search-menu">
       <button type="button" class="navbar-right-dropdown-toggle search-icons" aria-label="<%= Spree.t('nav_bar.show_search') %>">
@@ -28,7 +28,7 @@
       </div>
     </li>
   <% end %>
-  <li id="link-to-cart">
+  <li id="link-to-cart" data-turbo-permanent data-turbolinks-permanent>
     <%= render 'spree/shared/cart', class: 'd-inline-block cart-icon', size: 36, item_count: 0 %>
   </li>
   <%= render partial: 'spree/shared/internationalization_options' %>

--- a/frontend/app/views/spree/shared/_nav_bar.html.erb
+++ b/frontend/app/views/spree/shared/_nav_bar.html.erb
@@ -1,4 +1,4 @@
-<ul id="nav-bar" class="nav align-items-center d-flex flex-nowrap justify-content-end navbar-right">
+<ul id="nav-bar" class="nav align-items-center d-flex flex-nowrap justify-content-end navbar-right" data-turbo-permanent data-turbolinks-permanent>
   <li>
     <div class="navbar-right-search-menu">
       <button type="button" class="navbar-right-dropdown-toggle search-icons" aria-label="<%= Spree.t('nav_bar.show_search') %>">
@@ -28,7 +28,7 @@
       </div>
     </li>
   <% end %>
-  <li id="link-to-cart" data-turbo-permanent data-turbolinks-permanent>
+  <li id="link-to-cart">
     <%= render 'spree/shared/cart', class: 'd-inline-block cart-icon', size: 36, item_count: 0 %>
   </li>
   <%= render partial: 'spree/shared/internationalization_options' %>

--- a/frontend/app/views/spree/shared/_nav_bar.html.erb
+++ b/frontend/app/views/spree/shared/_nav_bar.html.erb
@@ -1,4 +1,4 @@
-<ul id="nav-bar" class="nav align-items-center d-flex flex-nowrap justify-content-end navbar-right">
+<ul id="nav-bar" class="nav align-items-center d-flex flex-nowrap justify-content-end navbar-right" data-turbolinks-permanent>
   <li>
     <div class="navbar-right-search-menu">
       <button type="button" class="navbar-right-dropdown-toggle search-icons" aria-label="<%= Spree.t('nav_bar.show_search') %>">

--- a/frontend/spec/helpers/navigation_helper_spec.rb
+++ b/frontend/spec/helpers/navigation_helper_spec.rb
@@ -30,5 +30,48 @@ module Spree
         it { expect(should_render_internationalization_dropdown?).to be_falsey }
       end
     end
+
+    describe '#spree_nav_link_tag' do
+      let(:store) { create(:store) }
+      let(:menu) { create(:menu, store: store) }
+      let(:locale_param) { 'en' }
+
+      include Spree::CurrencyHelper
+      include Spree::LocaleHelper
+
+      context 'when link is passed with no arguments' do
+        let(:menu_item) { create(:menu_item, menu: menu, destination: 'https://my-website.com') }
+
+        it 'returns the link destination with no unexpected attributes' do
+          expect(spree_nav_link_tag(menu_item)).to eq('<a href="https://my-website.com">Link To Somewhere</a>')
+        end
+      end
+
+      context 'when link is passed with setting to open in a new window' do
+        let(:menu_item) { create(:menu_item, menu: menu, destination: 'https://my-website.com', new_window: true) }
+
+        it 'returns the link destination with target="_blank" rel="noopener noreferrer"' do
+          expect(spree_nav_link_tag(menu_item)).to eq('<a target="_blank" rel="noopener noreferrer" href="https://my-website.com">Link To Somewhere</a>')
+        end
+      end
+
+      context 'when link is passed with setting to open in a new window, and passed custom attributes' do
+        let(:menu_item) { create(:menu_item, menu: menu, destination: 'https://my-website.com', new_window: true) }
+
+        it 'returns the link destination with target="_blank" rel="noopener noreferrer"' do
+          expect(spree_nav_link_tag(menu_item, { class: 'custom-class', id: 'custonId', target: '_not_so_blank', rel: 'related', data: 'custom-data', aria: 'custom-aria' })).
+            to eq('<a target="_not_so_blank" rel="related" class="custom-class" id="custonId" data="custom-data" aria="custom-aria" href="https://my-website.com">Link To Somewhere</a>')
+        end
+      end
+
+      context 'when passed a block' do
+        let(:menu_item) { create(:menu_item, menu: menu, destination: 'https://my-website.com', new_window: true) }
+
+        it 'returns the link containing the contents of the block' do
+          expect(spree_nav_link_tag(menu_item) { content_tag :span, 'Hello' }).
+            to eq('<a target="_blank" rel="noopener noreferrer" href="https://my-website.com"><span>Hello</span></a>')
+        end
+      end
+    end
   end
 end

--- a/frontend/spec/helpers/navigation_helper_spec.rb
+++ b/frontend/spec/helpers/navigation_helper_spec.rb
@@ -58,7 +58,7 @@ module Spree
       context 'when link is passed with setting to open in a new window, and passed custom attributes' do
         let(:menu_item) { create(:menu_item, menu: menu, destination: 'https://my-website.com', new_window: true) }
 
-        it 'returns the link destination with target="_blank" rel="noopener noreferrer"' do
+        it 'returns the link destination with a full set of cutstom attributes' do
           expect(spree_nav_link_tag(menu_item, { class: 'custom-class', id: 'custonId', target: '_not_so_blank', rel: 'related', data: 'custom-data', aria: 'custom-aria' })).
             to eq('<a target="_not_so_blank" rel="related" class="custom-class" id="custonId" data="custom-data" aria="custom-aria" href="https://my-website.com">Link To Somewhere</a>')
         end

--- a/sample/db/samples/menu_items.rb
+++ b/sample/db/samples/menu_items.rb
@@ -110,7 +110,6 @@ MENUS.each do |menu|
     promo_b_subtitle = 'Obtenga hasta un 30% de descuento'
   end
 
-
   ##############
   # Root Items #
   ##############
@@ -220,7 +219,7 @@ MENUS.each do |menu|
       name: promo_a_name,
       subtitle: promo_a_subtitle,
       linked_resource_type: 'Spree::Taxon',
-      item_type: 'Promotion',
+      item_type: 'Container',
       menu_id: menu,
       parent_id: promo
     ).first_or_create!
@@ -231,7 +230,7 @@ MENUS.each do |menu|
       name: promo_b_name,
       subtitle: promo_b_subtitle,
       linked_resource_type: 'Spree::Taxon',
-      item_type: 'Promotion',
+      item_type: 'Container',
       menu_id: menu,
       parent_id: promo
     ).first_or_create!
@@ -244,10 +243,10 @@ MENUS.each do |menu|
   #################################
 
   women_link_parent_id = if menu.location == 'header'
-                              menu_cat_women
-                           else
-                              menu_root_women
-                           end
+                           menu_cat_women
+                         else
+                           menu_root_women
+                         end
 
   women_skirts_t = Spree::Taxon.find_by!(permalink: 'women/skirts')
   women_skirts = Spree::MenuItem.where(
@@ -320,10 +319,10 @@ MENUS.each do |menu|
   ###############################
 
   men_link_parent_id = if menu.location == 'header'
-                              menu_cat_men
-                           else
-                              menu_root_men
-                           end
+                         menu_cat_men
+                       else
+                         menu_root_men
+                       end
 
   men_shirts_t = Spree::Taxon.find_by!(permalink: 'men/shirts')
   men_shirts = Spree::MenuItem.where(
@@ -374,10 +373,10 @@ MENUS.each do |menu|
   ######################################
 
   sw_link_parent_id = if menu.location == 'header'
-                              menu_cat_sw
-                           else
-                              menu_root_sw
-                           end
+                        menu_cat_sw
+                      else
+                        menu_root_sw
+                      end
 
   sw_tops_t = Spree::Taxon.find_by!(permalink: 'sportswear/tops')
   sw_tops = Spree::MenuItem.where(

--- a/sample/db/samples/menu_items.rb
+++ b/sample/db/samples/menu_items.rb
@@ -5,9 +5,9 @@ Spree::Menu.all.each do |menu|
 end
 
 MENUS.each do |menu|
-  ##############
-  # Root Items #
-  ##############
+  ################
+  # Translations #
+  ################
   case menu.locale
   when 'en'
     root_name_a = 'Women'
@@ -110,6 +110,10 @@ MENUS.each do |menu|
     promo_b_subtitle = 'Obtenga hasta un 30% de descuento'
   end
 
+
+  ##############
+  # Root Items #
+  ##############
   woman_taxon = Spree::Taxon.find_by!(permalink: 'women')
   menu_root_women = Spree::MenuItem.where(
     name: root_name_a,
@@ -143,37 +147,38 @@ MENUS.each do |menu|
   menu_root_sw.linked_resource_id = sw_taxon.id
   menu_root_sw.save!
 
-  ##############
-  # Categories #
-  ##############
-  menu_cat_women = Spree::MenuItem.where(
-    name: catagories,
-    item_type: 'Container',
-    code: 'category',
-    menu_id: menu,
-    parent_id: menu_root_women
-  ).first_or_create!
-
-  menu_cat_men = Spree::MenuItem.where(
-    name: catagories,
-    item_type: 'Container',
-    code: 'category',
-    menu_id: menu,
-    parent_id: menu_root_men
-  ).first_or_create!
-
-  menu_cat_sw = Spree::MenuItem.where(
-    name: catagories,
-    item_type: 'Container',
-    code: 'category',
-    menu_id: menu,
-    parent_id: menu_root_sw
-  ).first_or_create!
-
-  ##############
-  # Promotions #
-  ##############
   if menu.location == 'header'
+    ## Only For Header Menu
+    ##############
+    # Categories #
+    ##############
+    menu_cat_women = Spree::MenuItem.where(
+      name: catagories,
+      item_type: 'Container',
+      code: 'category',
+      menu_id: menu,
+      parent_id: menu_root_women
+    ).first_or_create!
+
+    menu_cat_men = Spree::MenuItem.where(
+      name: catagories,
+      item_type: 'Container',
+      code: 'category',
+      menu_id: menu,
+      parent_id: menu_root_men
+    ).first_or_create!
+
+    menu_cat_sw = Spree::MenuItem.where(
+      name: catagories,
+      item_type: 'Container',
+      code: 'category',
+      menu_id: menu,
+      parent_id: menu_root_sw
+    ).first_or_create!
+
+    ##############
+    # Promotions #
+    ##############
     menu_promo_women = Spree::MenuItem.where(
       name: 'Promos',
       item_type: 'Container',
@@ -237,13 +242,20 @@ MENUS.each do |menu|
   #################################
   # Links For: WOMEN / CATAGORIES #
   #################################
+
+  women_link_parent_id = if menu.location == 'header'
+                              menu_cat_women
+                           else
+                              menu_root_women
+                           end
+
   women_skirts_t = Spree::Taxon.find_by!(permalink: 'women/skirts')
   women_skirts = Spree::MenuItem.where(
     name: skirts,
     linked_resource_type: 'Spree::Taxon',
     item_type: 'Link',
     menu_id: menu,
-    parent_id: menu_cat_women
+    parent_id: women_link_parent_id
   ).first_or_create!
   women_skirts.linked_resource_id = women_skirts_t.id
   women_skirts.save!
@@ -254,7 +266,7 @@ MENUS.each do |menu|
     linked_resource_type: 'Spree::Taxon',
     item_type: 'Link',
     menu_id: menu,
-    parent_id: menu_cat_women
+    parent_id: women_link_parent_id
   ).first_or_create!
   women_dresses.linked_resource_id = women_dresses_t.id
   women_dresses.save!
@@ -265,7 +277,7 @@ MENUS.each do |menu|
     linked_resource_type: 'Spree::Taxon',
     item_type: 'Link',
     menu_id: menu,
-    parent_id: menu_cat_women
+    parent_id: women_link_parent_id
   ).first_or_create!
   women_s_b.linked_resource_id = women_s_b_t.id
   women_s_b.save!
@@ -276,7 +288,7 @@ MENUS.each do |menu|
     linked_resource_type: 'Spree::Taxon',
     item_type: 'Link',
     menu_id: menu,
-    parent_id: menu_cat_women
+    parent_id: women_link_parent_id
   ).first_or_create!
   women_sweaters.linked_resource_id = women_sweaters_t.id
   women_sweaters.save!
@@ -287,7 +299,7 @@ MENUS.each do |menu|
     linked_resource_type: 'Spree::Taxon',
     item_type: 'Link',
     menu_id: menu,
-    parent_id: menu_cat_women
+    parent_id: women_link_parent_id
   ).first_or_create!
   women_tops_tees.linked_resource_id = women_tops_tees_t.id
   women_tops_tees.save!
@@ -298,7 +310,7 @@ MENUS.each do |menu|
     linked_resource_type: 'Spree::Taxon',
     item_type: 'Link',
     menu_id: menu,
-    parent_id: menu_cat_women
+    parent_id: women_link_parent_id
   ).first_or_create!
   women_j_c.linked_resource_id = women_j_c_t.id
   women_j_c.save!
@@ -306,13 +318,20 @@ MENUS.each do |menu|
   ###############################
   # Links For: MEN / CATAGORIES #
   ###############################
+
+  men_link_parent_id = if menu.location == 'header'
+                              menu_cat_men
+                           else
+                              menu_root_men
+                           end
+
   men_shirts_t = Spree::Taxon.find_by!(permalink: 'men/shirts')
   men_shirts = Spree::MenuItem.where(
     name: shirts,
     linked_resource_type: 'Spree::Taxon',
     item_type: 'Link',
     menu_id: menu,
-    parent_id: menu_cat_men
+    parent_id: men_link_parent_id
   ).first_or_create!
   men_shirts.linked_resource_id = men_shirts_t.id
   men_shirts.save!
@@ -323,7 +342,7 @@ MENUS.each do |menu|
     linked_resource_type: 'Spree::Taxon',
     item_type: 'Link',
     menu_id: menu,
-    parent_id: menu_cat_men
+    parent_id: men_link_parent_id
   ).first_or_create!
   men_t_shirts.linked_resource_id = men_t_shirts_t.id
   men_t_shirts.save!
@@ -334,7 +353,7 @@ MENUS.each do |menu|
     linked_resource_type: 'Spree::Taxon',
     item_type: 'Link',
     menu_id: menu,
-    parent_id: menu_cat_men
+    parent_id: men_link_parent_id
   ).first_or_create!
   men_sweaters.linked_resource_id = men_sweaters_t.id
   men_sweaters.save!
@@ -345,7 +364,7 @@ MENUS.each do |menu|
     linked_resource_type: 'Spree::Taxon',
     item_type: 'Link',
     menu_id: menu,
-    parent_id: menu_cat_men
+    parent_id: men_link_parent_id
   ).first_or_create!
   men_j_c.linked_resource_id = men_j_c_t.id
   men_j_c.save!
@@ -353,13 +372,20 @@ MENUS.each do |menu|
   ######################################
   # Links For: SPORTSWARE / CATAGORIES #
   ######################################
+
+  sw_link_parent_id = if menu.location == 'header'
+                              menu_cat_sw
+                           else
+                              menu_root_sw
+                           end
+
   sw_tops_t = Spree::Taxon.find_by!(permalink: 'sportswear/tops')
   sw_tops = Spree::MenuItem.where(
     name: tops,
     linked_resource_type: 'Spree::Taxon',
     item_type: 'Link',
     menu_id: menu,
-    parent_id: menu_cat_sw
+    parent_id: sw_link_parent_id
   ).first_or_create!
   sw_tops.linked_resource_id = sw_tops_t.id
   sw_tops.save!
@@ -370,7 +396,7 @@ MENUS.each do |menu|
     linked_resource_type: 'Spree::Taxon',
     item_type: 'Link',
     menu_id: menu,
-    parent_id: menu_cat_sw
+    parent_id: sw_link_parent_id
   ).first_or_create!
   sw_sweatshirts.linked_resource_id = sw_sweatshirts_t.id
   sw_sweatshirts.save!
@@ -381,7 +407,7 @@ MENUS.each do |menu|
     linked_resource_type: 'Spree::Taxon',
     item_type: 'Link',
     menu_id: menu,
-    parent_id: menu_cat_sw
+    parent_id: sw_link_parent_id
   ).first_or_create!
   sw_pants.linked_resource_id = sw_pants_t.id
   sw_pants.save!


### PR DESCRIPTION
### Fix Issue With Menu Changes Appearing In DOM
Move `data-turbolinks-permanent` down to the nav that has the cart Icon, I believe preserving the the item cart count on the badge if the back button was pressed was its intended use.
https://github.com/turbolinks/turbolinks#persisting-elements-across-page-loads

### Simplify Footer Menu
Lets show how simple a menu can be when it is not based off the most complex use case scenario (a Mega Menu).

### Add Info To URL
Explain some of the possible use cases of the URL box, `mailto:` `https:` `tel:`

### Footer Menu Improvements

- Adds ability to use open in new window from footer links.
- Adds ability to create labels for footer menu root items.

### Remove Promotion Menu Item Type
Essentially having a Menu Item Type of `Promotion` did nothing other than adds confusion as to when it should be used.

When it comes down to it there are two main types of Menu Item, `Links` and `Containers`, and you can create everything from 2 clear menu item types.

If someone wants to add any more they can do, but out of the box we can provide spree Mega Menu fully featured without the need for the additional menu item type.

### Main Menu Improvements

- Allow using a contain as a top level item to create a hover to open menu label.


Video series all done on this PR: https://youtube.com/playlist?list=PL1Rc_fPmaL4vsHGZbLNJEWZdKoHQ4V_z7