### PR TITLE
[SD-1327] Fix issue with mixing Properties and Price filters

### DIFF
--- a/frontend/app/assets/javascripts/spree/frontend/views/spree/products/price_filters.es6
+++ b/frontend/app/assets/javascripts/spree/frontend/views/spree/products/price_filters.es6
@@ -22,12 +22,10 @@ Spree.ready(function() {
 
     updatePricesForFiltering(minPrice, maxPrice) {
       const formattedPriceRange = `${minPrice}-${maxPrice}`
+      const url = new URL(this.filterButton.href)
 
-      const dataParams = JSON.parse(this.filterButton.dataset.params)
-      const urlParams = new URLSearchParams(dataParams)
-
-      urlParams.set('price', formattedPriceRange)
-      this.filterButton.href = decodeURIComponent(`${location.pathname}?${urlParams.toString()}`)
+      url.searchParams.set('price', formattedPriceRange)
+      this.filterButton.href = `${url.pathname}${url.search}`
     }
   }
 

--- a/frontend/spec/features/products_filtering_spec.rb
+++ b/frontend/spec/features/products_filtering_spec.rb
@@ -39,14 +39,16 @@ describe 'Products filtering', :js do
     fill_in 'keywords', with: "#{text}\n"
   end
 
-  def click_on_filter(filter_name, value:)
+  def click_on_filter(filter_name, value: nil)
     filter_element = find('.plp-filters-card', text: filter_name)
     filter_header_element = filter_element.find('.plp-filters-card-header')
 
     filter_header_element.click if filter_header_element[:class].include?('collapsed')
 
-    filter_element.click_link(value)
-    wait_for_turbolinks
+    if value.present?
+      filter_element.click_link(value)
+      wait_for_turbolinks
+    end
   end
 
   def wait_for_turbolinks
@@ -108,6 +110,12 @@ describe 'Products filtering', :js do
     expect(page).to have_selected_filter_with(value: 'WILSON')
     expect(page).to have_selected_filter_with(value: 'ZETA')
     expect(page).to have_selected_filter_with(value: 'ALPHA')
+
+    click_on_filter 'Price'
+    fill_in "$ #{Spree.t(:min)}", with: '19'
+    fill_in "$ #{Spree.t(:max)}", with: '20'
+    click_on 'DONE'
+    expect(page).to have_content 'Second shirt'
 
     expect_working_filters_clearing
 


### PR DESCRIPTION
Using price range inputs for filtering Products made an invalid request with URL params. When we also wanted to filter by properties, it wrongly built params with a nested object. This resulted in having this param: `properties=[object Object]`