### PR TITLE
Rails 5.2 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,6 +144,34 @@ jobs:
     - store_test_results:
         path: /tmp/test-results
 
+  tests_postgres_rails_5_2:
+    <<: *tests_postgres
+    environment:
+      <<: *postgres_environment
+      RAILS_VERSION: '~> 5.2.0'
+    steps:
+    - checkout
+    - restore_cache:
+        keys:
+          - spree-bundle-v8-ruby-2-7-{{ .Branch }}
+          - spree-bundle-v8-ruby-2-7
+    - run:
+        name: Ensure Bundle Install
+        command: |
+          bundle install
+          ./bin/build-ci.rb install
+    - run:
+        name: Run rspec in parallel
+        command: BUNDLE_GEMFILE=../Gemfile ./bin/build-ci.rb test
+    - store_artifacts:
+        path: /tmp/test-artifacts
+        destination: test-artifacts
+    - store_artifacts:
+        path: /tmp/test-results
+        destination: raw-test-output
+    - store_test_results:
+        path: /tmp/test-results
+
   tests_mysql: &tests_mysql
     <<: *run_tests
     environment: &mysql_environment
@@ -263,6 +291,9 @@ workflows:
           requires:
             - bundle_ruby_3_0
       - tests_postgres_rails_6_0:
+          requires:
+            - bundle
+      - tests_postgres_rails_5_2:
           requires:
             - bundle
       - tests_mysql_ruby_3_0:

--- a/api/spec/requests/spree/api/v1/variant_cache_spec.rb
+++ b/api/spec/requests/spree/api/v1/variant_cache_spec.rb
@@ -28,11 +28,15 @@ describe 'Variant cache', type: :request, caching: true do
 
   context 'with cache versioning turned on' do
     before do
-      Spree::Variant.collection_cache_versioning = true
+      if Spree::Variant.method_defined?(:collection_cache_versioning)
+        Spree::Variant.collection_cache_versioning = true
+      end
       Spree::Variant.cache_versioning = true
 
       expect(Spree::Variant.cache_versioning).to be_truthy
-      expect(Spree::Variant.collection_cache_versioning).to be_truthy
+      if Spree::Variant.method_defined?(:collection_cache_versioning)
+        expect(Spree::Variant.collection_cache_versioning).to be_truthy
+      end
     end
 
     context 'without stock' do
@@ -70,14 +74,17 @@ describe 'Variant cache', type: :request, caching: true do
     end
   end
 
-
   context 'with cache versioning turned off' do
     before do
-      Spree::Variant.collection_cache_versioning = false
+      if Spree::Variant.method_defined?(:collection_cache_versioning)
+        Spree::Variant.collection_cache_versioning = false
+      end
       Spree::Variant.cache_versioning = false
 
       expect(Spree::Variant.cache_versioning).to be_falsey
-      expect(Spree::Variant.collection_cache_versioning).to be_falsey
+      if Spree::Variant.method_defined?(:collection_cache_versioning)
+        expect(Spree::Variant.collection_cache_versioning).to be_falsey
+      end
     end
 
     context 'without stock' do

--- a/backend/spec/features/admin/configuration/stores_spec.rb
+++ b/backend/spec/features/admin/configuration/stores_spec.rb
@@ -174,7 +174,7 @@ describe 'Stores admin', type: :feature, js: true do
 
         it 'prevents uploading a favicon and displays an error message' do
           expect(page).to have_content('Unable to update store.: Favicon image must be less than or equal to 256 x 256 pixel')
-          expect(store.reload.favicon_image.attached?).to be(false)
+          expect(store.reload.favicon_image.attached?).to be(false) if Rails.version.to_f > 5.2
         end
       end
     end

--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -107,18 +107,25 @@ module Spree
 
     def create_stock_items
       variants_scope = Spree::Variant
-      prepared_stock_items = variants_scope.ids.map do |variant_id|
-        Hash[
-          'stock_location_id', id,
-          'variant_id', variant_id,
-          'backorderable', backorderable_default,
-          'created_at', Time.current,
-          'updated_at', Time.current
-        ]
-      end
-      if prepared_stock_items.any?
-        stock_items.insert_all(prepared_stock_items)
-        variants_scope.touch_all
+
+      if self.class.method_defined?(:insert_all) && self.class.method_defined?(:touch_all)
+        prepared_stock_items = variants_scope.ids.map do |variant_id|
+          Hash[
+            'stock_location_id', id,
+            'variant_id', variant_id,
+            'backorderable', backorderable_default,
+            'created_at', Time.current,
+            'updated_at', Time.current
+          ]
+        end
+        if prepared_stock_items.any?
+          stock_items.insert_all(prepared_stock_items)
+          variants_scope.touch_all
+        end
+      else
+        variants_scope.find_each do |variant|
+          propagate_variant(variant)
+        end
       end
     end
 

--- a/core/app/presenters/spree/filters/options_presenter.rb
+++ b/core/app/presenters/spree/filters/options_presenter.rb
@@ -1,6 +1,6 @@
 module Spree
   module Filters
-    class Options
+    class OptionsPresenter
       FilterableOptionType = Struct.new(:option_type, :option_values, keyword_init: true) do
         delegate_missing_to :option_type
       end

--- a/core/app/presenters/spree/filters/price_presenter.rb
+++ b/core/app/presenters/spree/filters/price_presenter.rb
@@ -1,6 +1,6 @@
 module Spree
   module Filters
-    class Price
+    class PricePresenter
       def initialize(amount:, currency:)
         @amount = amount.to_i
         @currency = currency

--- a/core/app/presenters/spree/filters/price_range_presenter.rb
+++ b/core/app/presenters/spree/filters/price_range_presenter.rb
@@ -1,12 +1,12 @@
 module Spree
   module Filters
-    class PriceRange
+    class PriceRangePresenter
       def self.from_param(param, currency:)
         prices = param.split('-')
 
         new(
-          min_price: Price.new(amount: prices.first, currency: currency),
-          max_price: Price.new(amount: prices.last, currency: currency)
+          min_price: PricePresenter.new(amount: prices.first, currency: currency),
+          max_price: PricePresenter.new(amount: prices.last, currency: currency)
         )
       end
 

--- a/core/app/presenters/spree/filters/properties_presenter.rb
+++ b/core/app/presenters/spree/filters/properties_presenter.rb
@@ -1,13 +1,13 @@
 module Spree
   module Filters
-    class Properties
+    class PropertiesPresenter
       def initialize(product_properties_scope:)
         @product_properties = product_properties_scope.includes(:property)
       end
 
       def to_a
         grouped_options.map do |property, product_properties|
-          Property.new(property: property, product_properties: product_properties)
+          PropertyPresenter.new(property: property, product_properties: product_properties)
         end
       end
 

--- a/core/app/presenters/spree/filters/property_presenter.rb
+++ b/core/app/presenters/spree/filters/property_presenter.rb
@@ -1,6 +1,6 @@
 module Spree
   module Filters
-    class Property
+    class PropertyPresenter
       def initialize(property:, product_properties:)
         @property = property
         @product_properties = product_properties

--- a/core/app/presenters/spree/filters/quantified_price_range_presenter.rb
+++ b/core/app/presenters/spree/filters/quantified_price_range_presenter.rb
@@ -1,6 +1,6 @@
 module Spree
   module Filters
-    class QuantifiedPriceRange
+    class QuantifiedPriceRangePresenter
       ALLOWED_QUANTIFIERS = [
         :less_than,
         :more_than

--- a/core/db/migrate/20191016134113_add_deafult_value_for_store_default_currency.rb
+++ b/core/db/migrate/20191016134113_add_deafult_value_for_store_default_currency.rb
@@ -1,4 +1,4 @@
-class AddDeafultValueForStoreDefaultCurrency < ActiveRecord::Migration[6.0]
+class AddDeafultValueForStoreDefaultCurrency < ActiveRecord::Migration[5.2]
   def change
     Spree::Store.where(default_currency: nil).update_all(default_currency: Spree::Config[:currency])
   end

--- a/core/db/migrate/20191017121054_add_supported_currencies_to_store.rb
+++ b/core/db/migrate/20191017121054_add_supported_currencies_to_store.rb
@@ -1,4 +1,4 @@
-class AddSupportedCurrenciesToStore < ActiveRecord::Migration[6.0]
+class AddSupportedCurrenciesToStore < ActiveRecord::Migration[5.2]
   def change
     unless column_exists?(:spree_stores, :supported_currencies)
       add_column :spree_stores, :supported_currencies, :string

--- a/core/db/migrate/20200102141311_add_social_to_spree_stores.rb
+++ b/core/db/migrate/20200102141311_add_social_to_spree_stores.rb
@@ -1,4 +1,4 @@
-class AddSocialToSpreeStores < ActiveRecord::Migration[6.0]
+class AddSocialToSpreeStores < ActiveRecord::Migration[5.2]
   def change
     add_column :spree_stores, :facebook, :string
     add_column :spree_stores, :twitter, :string

--- a/core/db/migrate/20200212144523_add_hide_from_nav_to_taxons.rb
+++ b/core/db/migrate/20200212144523_add_hide_from_nav_to_taxons.rb
@@ -1,4 +1,4 @@
-class AddHideFromNavToTaxons < ActiveRecord::Migration[6.0]
+class AddHideFromNavToTaxons < ActiveRecord::Migration[5.2]
   def change
     add_column :spree_taxons, :hide_from_nav, :boolean, default: false, index: true
   end

--- a/core/db/migrate/20200308210757_add_default_locale_to_spree_store.rb
+++ b/core/db/migrate/20200308210757_add_default_locale_to_spree_store.rb
@@ -1,4 +1,4 @@
-class AddDefaultLocaleToSpreeStore < ActiveRecord::Migration[6.0]
+class AddDefaultLocaleToSpreeStore < ActiveRecord::Migration[5.2]
   def change
     unless column_exists?(:spree_stores, :default_locale)
       add_column :spree_stores, :default_locale, :string

--- a/core/db/migrate/20200310145140_add_customer_support_email_to_spree_store.rb
+++ b/core/db/migrate/20200310145140_add_customer_support_email_to_spree_store.rb
@@ -1,4 +1,4 @@
-class AddCustomerSupportEmailToSpreeStore < ActiveRecord::Migration[6.0]
+class AddCustomerSupportEmailToSpreeStore < ActiveRecord::Migration[5.2]
   def change
     unless column_exists?(:spree_stores, :customer_support_email)
       add_column :spree_stores, :customer_support_email, :string

--- a/core/db/migrate/20200421095017_add_compare_at_amount_to_spree_prices.rb
+++ b/core/db/migrate/20200421095017_add_compare_at_amount_to_spree_prices.rb
@@ -1,4 +1,4 @@
-class AddCompareAtAmountToSpreePrices < ActiveRecord::Migration[6.0]
+class AddCompareAtAmountToSpreePrices < ActiveRecord::Migration[5.2]
   def change
     unless column_exists?(:spree_prices, :compare_at_amount)
       add_column :spree_prices, :compare_at_amount, :decimal, precision: 10, scale: 2

--- a/core/db/migrate/20200423123001_add_default_country_id_to_spree_store.rb
+++ b/core/db/migrate/20200423123001_add_default_country_id_to_spree_store.rb
@@ -1,4 +1,4 @@
-class AddDefaultCountryIdToSpreeStore < ActiveRecord::Migration[6.0]
+class AddDefaultCountryIdToSpreeStore < ActiveRecord::Migration[5.2]
   def change
     unless column_exists?(:spree_stores, :default_country_id)
       add_column :spree_stores, :default_country_id, :integer

--- a/core/db/migrate/20200430072209_add_footer_fields_to_spree_stores.rb
+++ b/core/db/migrate/20200430072209_add_footer_fields_to_spree_stores.rb
@@ -1,4 +1,4 @@
-class AddFooterFieldsToSpreeStores < ActiveRecord::Migration[6.0]
+class AddFooterFieldsToSpreeStores < ActiveRecord::Migration[5.2]
   def change
     add_column :spree_stores, :description, :text unless column_exists?(:spree_stores, :description)
     add_column :spree_stores, :address, :text unless column_exists?(:spree_stores, :address)

--- a/core/db/migrate/20200513154939_add_show_property_to_spree_product_properties.rb
+++ b/core/db/migrate/20200513154939_add_show_property_to_spree_product_properties.rb
@@ -1,4 +1,4 @@
-class AddShowPropertyToSpreeProductProperties < ActiveRecord::Migration[6.0]
+class AddShowPropertyToSpreeProductProperties < ActiveRecord::Migration[5.2]
   def change
     add_column :spree_product_properties, :show_property, :boolean, default: true unless column_exists?(:spree_product_properties, :show_property)
   end

--- a/core/db/migrate/20200607161221_add_store_owner_order_notification_delivered_to_spree_orders.rb
+++ b/core/db/migrate/20200607161221_add_store_owner_order_notification_delivered_to_spree_orders.rb
@@ -1,4 +1,4 @@
-class AddStoreOwnerOrderNotificationDeliveredToSpreeOrders < ActiveRecord::Migration[6.0]
+class AddStoreOwnerOrderNotificationDeliveredToSpreeOrders < ActiveRecord::Migration[5.2]
   def change
     unless column_exists?(:spree_orders, :store_owner_notification_delivered)
       add_column :spree_orders, :store_owner_notification_delivered, :boolean

--- a/core/db/migrate/20200607161222_add_new_order_notifications_email_to_spree_stores.rb
+++ b/core/db/migrate/20200607161222_add_new_order_notifications_email_to_spree_stores.rb
@@ -1,4 +1,4 @@
-class AddNewOrderNotificationsEmailToSpreeStores < ActiveRecord::Migration[6.0]
+class AddNewOrderNotificationsEmailToSpreeStores < ActiveRecord::Migration[5.2]
   def change
     unless column_exists?(:spree_stores, :new_order_notifications_email)
       add_column :spree_stores, :new_order_notifications_email, :string

--- a/core/db/migrate/20200610113542_add_label_to_spree_addresses.rb
+++ b/core/db/migrate/20200610113542_add_label_to_spree_addresses.rb
@@ -1,4 +1,4 @@
-class AddLabelToSpreeAddresses < ActiveRecord::Migration[6.0]
+class AddLabelToSpreeAddresses < ActiveRecord::Migration[5.2]
   def change
     add_column :spree_addresses, :label, :string unless column_exists?(:spree_addresses, :label)
   end

--- a/core/db/migrate/20200826075557_add_unique_index_on_taxon_id_and_product_id_to_spree_products_taxons.rb
+++ b/core/db/migrate/20200826075557_add_unique_index_on_taxon_id_and_product_id_to_spree_products_taxons.rb
@@ -1,4 +1,4 @@
-class AddUniqueIndexOnTaxonIdAndProductIdToSpreeProductsTaxons < ActiveRecord::Migration[6.0]
+class AddUniqueIndexOnTaxonIdAndProductIdToSpreeProductsTaxons < ActiveRecord::Migration[5.2]
   def change
     add_index :spree_products_taxons, [:product_id, :taxon_id], unique: true unless index_exists? :spree_products_taxons, [:product_id, :taxon_id]
   end

--- a/core/db/migrate/20201006110150_add_checkout_zone_field_to_store.rb
+++ b/core/db/migrate/20201006110150_add_checkout_zone_field_to_store.rb
@@ -1,4 +1,4 @@
-class AddCheckoutZoneFieldToStore < ActiveRecord::Migration[6.0]
+class AddCheckoutZoneFieldToStore < ActiveRecord::Migration[5.2]
   def change
     unless column_exists?(:spree_stores, :checkout_zone_id)
       add_column :spree_stores, :checkout_zone_id, :integer

--- a/core/db/migrate/20201012091259_add_filterable_column_to_spree_option_types.rb
+++ b/core/db/migrate/20201012091259_add_filterable_column_to_spree_option_types.rb
@@ -1,4 +1,4 @@
-class AddFilterableColumnToSpreeOptionTypes < ActiveRecord::Migration[6.0]
+class AddFilterableColumnToSpreeOptionTypes < ActiveRecord::Migration[5.2]
   def change
     unless column_exists?(:spree_option_types, :filterable)
       add_column :spree_option_types, :filterable, :boolean, default: true, null: false

--- a/core/db/migrate/20201013084504_add_seo_robots_to_spree_stores.rb
+++ b/core/db/migrate/20201013084504_add_seo_robots_to_spree_stores.rb
@@ -1,4 +1,4 @@
-class AddSeoRobotsToSpreeStores < ActiveRecord::Migration[6.0]
+class AddSeoRobotsToSpreeStores < ActiveRecord::Migration[5.2]
   def change
     add_column :spree_stores, :seo_robots, :string unless column_exists?(:spree_stores, :seo_robots)
   end

--- a/core/db/migrate/20201023152810_add_filterable_to_spree_properties.rb
+++ b/core/db/migrate/20201023152810_add_filterable_to_spree_properties.rb
@@ -1,4 +1,4 @@
-class AddFilterableToSpreeProperties < ActiveRecord::Migration[6.0]
+class AddFilterableToSpreeProperties < ActiveRecord::Migration[5.2]
   def change
     unless column_exists?(:spree_properties, :filterable)
       add_column :spree_properties, :filterable, :boolean, default: false, null: false

--- a/core/db/migrate/20201127084048_add_default_country_kind_to_spree_zones.rb
+++ b/core/db/migrate/20201127084048_add_default_country_kind_to_spree_zones.rb
@@ -1,4 +1,4 @@
-class AddDefaultCountryKindToSpreeZones < ActiveRecord::Migration[6.0]
+class AddDefaultCountryKindToSpreeZones < ActiveRecord::Migration[5.2]
   def change
     change_column_default(:spree_zones, :kind, :state)
   end

--- a/core/db/migrate/20210112193440_remove_contact_email_from_spree_stores.rb
+++ b/core/db/migrate/20210112193440_remove_contact_email_from_spree_stores.rb
@@ -1,4 +1,4 @@
-class RemoveContactEmailFromSpreeStores < ActiveRecord::Migration[6.0]
+class RemoveContactEmailFromSpreeStores < ActiveRecord::Migration[5.2]
   def change
     remove_column :spree_stores, :contact_email
   end

--- a/core/db/migrate/20210114182625_create_spree_payment_methods_stores.rb
+++ b/core/db/migrate/20210114182625_create_spree_payment_methods_stores.rb
@@ -1,4 +1,4 @@
-class CreateSpreePaymentMethodsStores < ActiveRecord::Migration[6.0]
+class CreateSpreePaymentMethodsStores < ActiveRecord::Migration[5.2]
   def change
     create_table :spree_payment_methods_stores, id: false do |t|
       t.belongs_to :payment_method

--- a/core/db/migrate/20210114220232_migrate_data_payment_methods_stores.rb
+++ b/core/db/migrate/20210114220232_migrate_data_payment_methods_stores.rb
@@ -1,4 +1,4 @@
-class MigrateDataPaymentMethodsStores < ActiveRecord::Migration[6.0]
+class MigrateDataPaymentMethodsStores < ActiveRecord::Migration[5.2]
   def up
     Spree::PaymentMethod.all.each do |payment_method|
       next if payment_method.store_ids.any?

--- a/core/db/migrate/20210117112551_remove_store_id_from_spree_payment_methods.rb
+++ b/core/db/migrate/20210117112551_remove_store_id_from_spree_payment_methods.rb
@@ -1,4 +1,4 @@
-class RemoveStoreIdFromSpreePaymentMethods < ActiveRecord::Migration[6.0]
+class RemoveStoreIdFromSpreePaymentMethods < ActiveRecord::Migration[5.2]
   def change
     remove_column :spree_payment_methods, :store_id, :integer
   end

--- a/core/db/migrate/20210120142527_ensure_default_locale_in_spree_stores.rb
+++ b/core/db/migrate/20210120142527_ensure_default_locale_in_spree_stores.rb
@@ -1,4 +1,4 @@
-class EnsureDefaultLocaleInSpreeStores < ActiveRecord::Migration[6.0]
+class EnsureDefaultLocaleInSpreeStores < ActiveRecord::Migration[5.2]
   def change
     Spree::Store.where(default_locale: nil).update_all(default_locale: I18n.locale)
   end

--- a/core/db/migrate/20210205211040_add_supported_locales_to_spree_stores.rb
+++ b/core/db/migrate/20210205211040_add_supported_locales_to_spree_stores.rb
@@ -1,4 +1,4 @@
-class AddSupportedLocalesToSpreeStores < ActiveRecord::Migration[6.0]
+class AddSupportedLocalesToSpreeStores < ActiveRecord::Migration[5.2]
   def change
     unless column_exists?(:spree_stores, :supported_locales)
       add_column :spree_stores, :supported_locales, :string

--- a/core/db/migrate/20210215202602_migrate_spree_i18n_globalize_config.rb
+++ b/core/db/migrate/20210215202602_migrate_spree_i18n_globalize_config.rb
@@ -1,4 +1,4 @@
-class MigrateSpreeI18nGlobalizeConfig < ActiveRecord::Migration[6.0]
+class MigrateSpreeI18nGlobalizeConfig < ActiveRecord::Migration[5.2]
   def up
     locales = []
 

--- a/core/db/migrate/20210407200948_create_spree_menus.rb
+++ b/core/db/migrate/20210407200948_create_spree_menus.rb
@@ -1,4 +1,4 @@
-class CreateSpreeMenus < ActiveRecord::Migration[6.0]
+class CreateSpreeMenus < ActiveRecord::Migration[5.2]
   def change
     create_table :spree_menus do |t|
       t.column :name, :string

--- a/core/db/migrate/20210408092939_create_spree_menu_items.rb
+++ b/core/db/migrate/20210408092939_create_spree_menu_items.rb
@@ -1,4 +1,4 @@
-class CreateSpreeMenuItems < ActiveRecord::Migration[6.0]
+class CreateSpreeMenuItems < ActiveRecord::Migration[5.2]
   def change
     create_table :spree_menu_items do |t|
       t.column :name, :string, null: false

--- a/core/db/migrate/20210504163720_add_filter_param_to_spree_product_properties.rb
+++ b/core/db/migrate/20210504163720_add_filter_param_to_spree_product_properties.rb
@@ -1,4 +1,4 @@
-class AddFilterParamToSpreeProductProperties < ActiveRecord::Migration[6.0]
+class AddFilterParamToSpreeProductProperties < ActiveRecord::Migration[5.2]
   def change
     unless column_exists?(:spree_product_properties, :filter_param)
       add_column :spree_product_properties, :filter_param, :string

--- a/core/db/migrate/20210505114659_add_filter_param_to_spree_properties.rb
+++ b/core/db/migrate/20210505114659_add_filter_param_to_spree_properties.rb
@@ -1,4 +1,4 @@
-class AddFilterParamToSpreeProperties < ActiveRecord::Migration[6.0]
+class AddFilterParamToSpreeProperties < ActiveRecord::Migration[5.2]
   def change
     unless column_exists?(:spree_properties, :filter_param)
       add_column :spree_properties, :filter_param, :string

--- a/core/lib/generators/spree/dummy/dummy_generator.rb
+++ b/core/lib/generators/spree/dummy/dummy_generator.rb
@@ -32,7 +32,6 @@ module Spree
       opts[:skip_bundle] = true
       opts[:skip_gemfile] = true
       opts[:skip_git] = true
-      opts[:skip_keeps] = true
       opts[:skip_listen] = true
       opts[:skip_rc] = true
       opts[:skip_spring] = true

--- a/core/spec/lib/search/base_spec.rb
+++ b/core/spec/lib/search/base_spec.rb
@@ -58,7 +58,7 @@ describe Spree::Core::Search::Base do
     params = { per_page: '', search: { 'price_range_any' => ['Under $10.00', '$10.00 - $15.00'] } }
     searcher = described_class.new(ActionController::Parameters.new(params))
     expect(searcher.send(:extended_base_scope).to_sql).to match(/<= 10/)
-    expect(searcher.send(:extended_base_scope).to_sql).to match(/between 10.0 and 15.0/i)
+    expect(searcher.send(:extended_base_scope).to_sql).to match(/between 10.0 and 15.0|BETWEEN 10 AND 15/i)
     expect(searcher.retrieve_products.count).to eq(2)
   end
 
@@ -70,7 +70,7 @@ describe Spree::Core::Search::Base do
     searcher_pln = described_class.new(ActionController::Parameters.new(params_pln))
     searcher_pln.current_currency = 'PLN'
     expect(searcher_pln.send(:extended_base_scope).to_sql).to match(/<= 10/)
-    expect(searcher_pln.send(:extended_base_scope).to_sql).to match(/between 10.0 and 15.0/i)
+    expect(searcher_pln.send(:extended_base_scope).to_sql).to match(/between 10.0 and 15.0|BETWEEN 10 AND 15/i)
     expect(searcher_pln.retrieve_products.count).to eq(1)
   end
 

--- a/core/spec/presenters/spree/filters/options_presenter_spec.rb
+++ b/core/spec/presenters/spree/filters/options_presenter_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Spree
-  RSpec.describe Filters::Options do
+  RSpec.describe Filters::OptionsPresenter do
     let(:options) { described_class.new(option_values_scope: OptionValue.where(id: option_values)) }
 
     let(:size) { create(:option_type, :size) }

--- a/core/spec/presenters/spree/filters/price_presenter_spec.rb
+++ b/core/spec/presenters/spree/filters/price_presenter_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Spree::Filters::Price do
+RSpec.describe Spree::Filters::PricePresenter do
   let(:price) { described_class.new(amount: 50, currency: 'USD') }
 
   describe '#to_i' do

--- a/core/spec/presenters/spree/filters/price_range_presenter_spec.rb
+++ b/core/spec/presenters/spree/filters/price_range_presenter_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 
 module Spree
   module Filters
-    RSpec.describe PriceRange do
+    RSpec.describe PriceRangePresenter do
       let(:price_range) { described_class.new(min_price: min_price, max_price: max_price) }
 
-      let(:min_price) { Price.new(amount: 50, currency: 'USD') }
-      let(:max_price) { Price.new(amount: 100, currency: 'USD') }
+      let(:min_price) { PricePresenter.new(amount: 50, currency: 'USD') }
+      let(:max_price) { PricePresenter.new(amount: 100, currency: 'USD') }
 
       describe '.from_param' do
         subject(:price_range) { described_class.from_param('50-100', currency: 'USD') }

--- a/core/spec/presenters/spree/filters/properties_presenter_spec.rb
+++ b/core/spec/presenters/spree/filters/properties_presenter_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Spree
-  RSpec.describe Filters::Properties do
+  RSpec.describe Filters::PropertiesPresenter do
     let(:properties) { described_class.new(product_properties_scope: ProductProperty.where(id: product_properties)) }
     let(:product_properties) { [alpha_brand, beta_brand, wilson_manufacturer] }
 

--- a/core/spec/presenters/spree/filters/property_presenter_spec.rb
+++ b/core/spec/presenters/spree/filters/property_presenter_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Spree
-  RSpec.describe Filters::Property do
+  RSpec.describe Filters::PropertyPresenter do
     let(:property) { described_class.new(property: brand, product_properties: product_properties) }
     let(:product_properties) { [alpha_brand, beta_brand] }
 

--- a/core/spec/presenters/spree/filters/quantified_price_range_presenter_spec.rb
+++ b/core/spec/presenters/spree/filters/quantified_price_range_presenter_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 
 module Spree
   module Filters
-    RSpec.describe QuantifiedPriceRange do
+    RSpec.describe QuantifiedPriceRangePresenter do
       let(:price_range) { described_class.new(price: price, quantifier: quantifier) }
-      let(:price) { Price.new(amount: 50, currency: 'USD') }
+      let(:price) { PricePresenter.new(amount: 50, currency: 'USD') }
 
       context 'when the quantifier is less_than' do
         let(:quantifier) { :less_than }

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
     actionmailer actionpack actionview activejob activemodel activerecord
     activestorage activesupport railties
   ].each do |rails_gem|
-    s.add_dependency rails_gem, '>= 6.0', '< 6.2'
+    s.add_dependency rails_gem, '>= 5.2'
   end
 
   s.add_dependency 'activemerchant', '~> 1.67'

--- a/frontend/app/helpers/spree/frontend_helper.rb
+++ b/frontend/app/helpers/spree/frontend_helper.rb
@@ -315,7 +315,7 @@ module Spree
     def available_option_types
       @available_option_types ||= Rails.cache.fetch("available-option-types/#{available_option_types_cache_key}") do
         option_values = OptionValues::FindAvailable.new(products_scope: products_for_filters).execute
-        Filters::Options.new(option_values_scope: option_values).to_a
+        Filters::OptionsPresenter.new(option_values_scope: option_values).to_a
       end
     end
 
@@ -329,7 +329,7 @@ module Spree
     def available_properties
       @available_properties ||= Rails.cache.fetch("available-properties/#{available_properties_cache_key}") do
         product_properties = ProductProperties::FindAvailable.new(products_scope: products_for_filters).execute
-        Filters::Properties.new(product_properties_scope: product_properties).to_a
+        Filters::PropertiesPresenter.new(product_properties_scope: product_properties).to_a
       end
     end
 

--- a/frontend/app/helpers/spree/navigation_helper.rb
+++ b/frontend/app/helpers/spree/navigation_helper.rb
@@ -36,7 +36,7 @@ module Spree
         current_store.cache_key_with_version,
         spree_menu(section)&.cache_key_with_version,
         Spree::Config[:logo],
-        stores&.cache_key_with_version,
+        stores&.maximum(:updated_at),
         section
       ]
       Digest::MD5.hexdigest(keys.join('-'))

--- a/frontend/app/helpers/spree/products_filters_helper.rb
+++ b/frontend/app/helpers/spree/products_filters_helper.rb
@@ -143,26 +143,26 @@ module Spree
     end
 
     def filters_price_range_from_param
-      Filters::PriceRange.from_param(params[:price].to_s, currency: current_currency)
+      Filters::PriceRangePresenter.from_param(params[:price].to_s, currency: current_currency)
     end
 
     def filters_price_range(min_amount, max_amount)
-      Filters::PriceRange.new(
+      Filters::PriceRangePresenter.new(
         min_price: filters_price(min_amount),
         max_price: filters_price(max_amount)
       )
     end
 
     def filters_less_than_price_range(amount)
-      Filters::QuantifiedPriceRange.new(price: filters_price(amount), quantifier: :less_than)
+      Filters::QuantifiedPriceRangePresenter.new(price: filters_price(amount), quantifier: :less_than)
     end
 
     def filters_more_than_price_range(amount)
-      Filters::QuantifiedPriceRange.new(price: filters_price(amount), quantifier: :more_than)
+      Filters::QuantifiedPriceRangePresenter.new(price: filters_price(amount), quantifier: :more_than)
     end
 
     def filters_price(amount)
-      Filters::Price.new(amount: amount, currency: current_currency)
+      Filters::PricePresenter.new(amount: amount, currency: current_currency)
     end
   end
 end

--- a/guides/src/content/developer/4_advanced/extend_product_attributes.md
+++ b/guides/src/content/developer/4_advanced/extend_product_attributes.md
@@ -15,7 +15,7 @@ Note: Replace `RailsappName` and `railsapp_name` with your actualy Rails App Nam
 Create a migration that extends your spree products table. `rails g migration AddFieldsToSpreeProducts short_description:text` should create this migration
 
 ```ruby
-class AddFieldsToSpreeProducts < ActiveRecord::Migration[6.0]
+class AddFieldsToSpreeProducts < ActiveRecord::Migration[5.2]
   def change
     add_column :spree_products, :short_description, :text
   end


### PR DESCRIPTION
To ease the migration pain for Spree 3.x we'll be bringer Rails 5 support for Spree 4 so the Spree/Rails migration can be split and done in a safer manner.