### PR TITLE
[SD-987] Stop displaying duplicate Products on PLP when viewing by Taxon

### DIFF
--- a/core/app/finders/spree/products/find.rb
+++ b/core/app/finders/spree/products/find.rb
@@ -197,9 +197,7 @@ module Spree
         case sort_by
         when 'default'
           if taxons?
-            products.
-              select("#{Product.table_name}.*, #{Classification.table_name}.position").
-              order("#{Classification.table_name}.position" => :asc)
+            products.ascend_by_taxons_min_position(taxons)
           else
             products
           end

--- a/core/app/helpers/spree/products_helper.rb
+++ b/core/app/helpers/spree/products_helper.rb
@@ -63,7 +63,8 @@ module Spree
     end
 
     def cache_key_for_products(products = @products, additional_cache_key = nil)
-      max_updated_at = (products.maximum(:updated_at) || Date.today).to_s(:number)
+      products_max_updated_at = products.max_by(&:updated_at)&.updated_at
+      max_updated_at = (products_max_updated_at || Date.today).to_s(:number)
       products_cache_keys = "spree/products/#{products.map(&:id).join('-')}-#{params[:page]}-#{params[:sort_by]}-#{max_updated_at}-#{@taxon&.id}"
       (common_product_cache_keys + [products_cache_keys] + [additional_cache_key]).compact.join('/')
     end

--- a/core/app/helpers/spree/products_helper.rb
+++ b/core/app/helpers/spree/products_helper.rb
@@ -63,8 +63,7 @@ module Spree
     end
 
     def cache_key_for_products(products = @products, additional_cache_key = nil)
-      products_max_updated_at = products.max_by(&:updated_at)&.updated_at
-      max_updated_at = (products_max_updated_at || Date.today).to_s(:number)
+      max_updated_at = (products.except(:group, :order).maximum(:updated_at) || Date.today).to_s(:number)
       products_cache_keys = "spree/products/#{products.map(&:id).join('-')}-#{params[:page]}-#{params[:sort_by]}-#{max_updated_at}-#{@taxon&.id}"
       (common_product_cache_keys + [products_cache_keys] + [additional_cache_key]).compact.join('/')
     end

--- a/core/app/models/concerns/spree/product_scopes.rb
+++ b/core/app/models/concerns/spree/product_scopes.rb
@@ -94,6 +94,19 @@ module Spree
         taxons.first ? prepare_taxon_conditions(taxons) : where(nil)
       end
 
+      add_search_scope :ascend_by_taxons_min_position do |taxon_ids|
+        joins(:classifications).
+          where(Classification.table_name => { taxon_id: taxon_ids }).
+          select(
+            [
+              "#{Product.table_name}.*",
+              "MIN(#{Classification.table_name}.position) AS min_position"
+            ].join(', ')
+          ).
+          group(:id).
+          order(min_position: :asc)
+      end
+
       # a scope that finds all products having property specified by name, object or id
       add_search_scope :with_property do |property|
         joins(:properties).where(property_conditions(property))

--- a/core/lib/spree/testing_support/factories/classification_factory.rb
+++ b/core/lib/spree/testing_support/factories/classification_factory.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :classification, class: Spree::Classification do
+    product
+    taxon
+
+    position { 1 }
+  end
+end

--- a/core/spec/finders/spree/products/find_spec.rb
+++ b/core/spec/finders/spree/products/find_spec.rb
@@ -360,22 +360,27 @@ module Spree
         end
 
         context 'when filtering by taxons' do
-          let(:taxonomy) { create(:taxonomy) }
-          let(:child_taxon) { create(:taxon, taxonomy: taxonomy) }
-
-          before do
-            product.taxons << child_taxon
-            product_2.taxons << child_taxon
-
-            # swap products positions
-            product.classifications.find_by(taxon: child_taxon).update(position: 2)
-            product_2.classifications.find_by(taxon: child_taxon).update(position: 1)
+          let(:params) do
+            { sort_by: 'default', filter: { taxons: taxonomy.root.id } }
           end
 
-          let(:params) { { sort_by: 'default', filter: { taxons: taxonomy.root.id } } }
+          let(:taxonomy) { create(:taxonomy) }
+          let(:child_taxon_1) { create(:taxon, taxonomy: taxonomy) }
+          let(:child_taxon_2) { create(:taxon, taxonomy: taxonomy) }
+
+          before do
+            product.taxons << child_taxon_1
+            product_2.taxons << child_taxon_1
+            product_3.taxons << child_taxon_2
+
+            # swap products positions
+            product.classifications.find_by(taxon: child_taxon_1).update(position: 3)
+            product_3.classifications.find_by(taxon: child_taxon_2).update(position: 2)
+            product_2.classifications.find_by(taxon: child_taxon_1).update(position: 1)
+          end
 
           it 'returns products ordered by associated taxon position' do
-            expect(products).to match_array [product_2, product]
+            expect(products).to eq [product_2, product_3, product]
           end
         end
       end

--- a/core/spec/helpers/products_helper_spec.rb
+++ b/core/spec/helpers/products_helper_spec.rb
@@ -206,6 +206,8 @@ THIS IS THE BEST PRODUCT EVER!
       before do
         allow(helper).to receive(:params).and_return(page: 10)
         allow(helper).to receive(:current_price_options) { price_options }
+
+        allow(products).to receive(:except).with(:group, :order).and_return(products)
       end
 
       context 'when there is a maximum updated date' do

--- a/core/spec/models/spree/product/scopes_spec.rb
+++ b/core/spec/models/spree/product/scopes_spec.rb
@@ -258,4 +258,55 @@ describe 'Product scopes', type: :model do
       expect(result.count).to eq(2)
     end
   end
+
+  context '#ascend_by_taxons_min_position' do
+    subject(:ordered_products) { Spree::Product.ascend_by_taxons_min_position(taxons) }
+
+    let(:taxons) { [parent_taxon, child_taxon_1, child_taxon_2, child_taxon_1_1, child_taxon_2_1] }
+
+    let(:parent_taxon) { create(:taxon) }
+
+    let(:child_taxon_1) { create(:taxon, parent: parent_taxon) }
+    let(:child_taxon_1_1) { create(:taxon, parent: child_taxon_1) }
+
+    let(:child_taxon_2) { create(:taxon, parent: parent_taxon) }
+    let(:child_taxon_2_1) { create(:taxon, parent: child_taxon_2) }
+
+    let!(:product_1) { create(:product) }
+    let!(:classification_1_1) { create(:classification, position: 5, product: product_1, taxon: parent_taxon) }
+    let!(:classification_1_2) { create(:classification, position: 4, product: product_1, taxon: child_taxon_1_1) }
+
+    let!(:product_2) { create(:product) }
+    let!(:classification_2_1) { create(:classification, position: 1, product: product_2, taxon: parent_taxon) }
+    let!(:classification_2_2) { create(:classification, position: 2, product: product_2, taxon: child_taxon_2_1) }
+
+    let!(:product_3) { create(:product) }
+    let!(:classification_3_1) { create(:classification, position: 3, product: product_3, taxon: child_taxon_1) }
+    let!(:classification_3_2) { create(:classification, position: 4, product: product_3, taxon: child_taxon_2_1) }
+
+    let!(:product_4) { create(:product) }
+    let!(:classification_4_1) { create(:classification, position: 2, product: product_4, taxon: child_taxon_2) }
+
+    let!(:product_5) { create(:product) }
+    let!(:classification_5_1) { create(:classification, position: 1, product: product_5, taxon: child_taxon_1_1) }
+
+    let!(:product_6) { create(:product) }
+    let!(:classification_6_1) { create(:classification, position: 6, product: product_6, taxon: child_taxon_2) }
+    let!(:classification_6_2) { create(:classification, position: 3, product: product_6, taxon: child_taxon_1) }
+
+    before do
+      create_list(:product, 3, taxons: [create(:taxon)])
+    end
+
+    it 'orders products by ascending taxons minimum position' do
+      expect(ordered_products).to eq(
+        [
+          product_5, product_2, # position: 1
+          product_4,            # position: 2
+          product_6, product_3, # position: 3
+          product_1             # position: 4
+        ]
+      )
+    end
+  end
 end

--- a/core/spec/models/spree/product/scopes_spec.rb
+++ b/core/spec/models/spree/product/scopes_spec.rb
@@ -301,7 +301,7 @@ describe 'Product scopes', type: :model do
     it 'orders products by ascending taxons minimum position' do
       expect(ordered_products).to eq(
         [
-          product_5, product_2, # position: 1
+          product_2, product_5, # position: 1
           product_4,            # position: 2
           product_6, product_3, # position: 3
           product_1             # position: 4


### PR DESCRIPTION
TODO:

- [x] add detailed description
- [x] add specs for the new scope
- [x] update specs for the Products finder

There's an issue with displaying Products on PLP when picking a Taxon. If some products are also in descendant Taxons, it'll be displayed twice _unless_ the position is the same as for other Classifications. 

It happens so because we select the `Classification#position` column when ordering Products: https://github.com/spree/spree/blob/master/core/app/finders/spree/products/find.rb#L201

We call `distinct` on the Products scope, but it also takes position into consideration. So these two records are unique:
1. Id: 1, position: 0
2. Id: 2, position: 1

In the end, we see 2 same records on the PLP page.