### PR TITLE
Replace master_id with master.id

### DIFF
--- a/backend/app/controllers/spree/admin/images_controller.rb
+++ b/backend/app/controllers/spree/admin/images_controller.rb
@@ -26,7 +26,7 @@ module Spree
         @variants = @product.variants.map do |variant|
           [variant.sku_and_options_text, variant.id]
         end
-        @variants.insert(0, [Spree.t(:all), @product.master_id])
+        @variants.insert(0, [Spree.t(:all), @product.master.id])
       end
 
       def set_viewable

--- a/core/lib/spree/testing_support/factories/stock_location_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_location_factory.rb
@@ -20,8 +20,8 @@ FactoryBot.define do
         product_1 = create(:product)
         product_2 = create(:product)
 
-        stock_location.stock_items.where(variant_id: product_1.master_id).first.adjust_count_on_hand(10)
-        stock_location.stock_items.where(variant_id: product_2.master_id).first.adjust_count_on_hand(20)
+        stock_location.stock_items.where(variant_id: product_1.master.id).first.adjust_count_on_hand(10)
+        stock_location.stock_items.where(variant_id: product_2.master.id).first.adjust_count_on_hand(20)
       end
     end
   end

--- a/frontend/app/views/spree/shared/carousel/_single.html.erb
+++ b/frontend/app/views/spree/shared/carousel/_single.html.erb
@@ -43,7 +43,7 @@
     <% images.each_with_index do |image, imageIndex| %>
       <div
         class="carousel-item product-carousel-item<%= ' active' if imageIndex == 0 %>"
-        data-variant-is-master="<%= image.viewable_id == @product.master_id %>"
+        data-variant-is-master="<%= image.viewable_id == @product.master.id %>"
         data-variant-id="<%= image.viewable_id %>">
         <div class="product-carousel-item-squared <%= 'product-carousel-item-squared-only' if images.length == 1 %>">
           <% image_attrs = {

--- a/frontend/app/views/spree/shared/carousel/_thumbnails.html.erb
+++ b/frontend/app/views/spree/shared/carousel/_thumbnails.html.erb
@@ -17,7 +17,7 @@
               <div
                 class="product-thumbnails-carousel-item-single product-thumbnails-carousel-item-single--visible"
                 data-product-carousel-to-slide="<%= image_index %>"
-                data-variant-is-master="<%= image.viewable_id == @product.master_id %>"
+                data-variant-is-master="<%= image.viewable_id == @product.master.id %>"
                 data-variant-id="<%= image.viewable_id %>">
                 <%= lazy_image(
                   src: main_app.url_for(image.url(:pdp_thumbnail)),


### PR DESCRIPTION
There's no `master_id` column on Product model, so it does not make any difference performance wise.