### PR TITLE
Fix filtering Products by Options

### DIFF
--- a/api/spec/requests/spree/api/v2/storefront/products_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/products_spec.rb
@@ -99,6 +99,64 @@ describe 'API V2 Storefront Products Spec', type: :request do
       end
     end
 
+    context 'with multiple specified options' do
+      let!(:color) { create(:option_type, :color) }
+      let!(:green_color) { create(:option_value, option_type: color, name: 'green') }
+      let!(:white_color) { create(:option_value, option_type: color, name: 'white') }
+
+      let!(:size) { create(:option_type, :size) }
+      let!(:s_size) { create(:option_value, option_type: size, name: 's') }
+      let!(:m_size) { create(:option_value, option_type: size, name: 'm') }
+
+      let(:product_1) { create(:product, option_types: [color, size]) }
+      let!(:variant_1) { create(:variant, product: product_1, option_values: [white_color, m_size]) }
+
+      let(:product_2) { create(:product, option_types: [color, size]) }
+      let!(:variant_2_1) { create(:variant, product: product_2, option_values: [green_color, s_size]) }
+      let!(:variant_2_2) { create(:variant, product: product_2, option_values: [white_color, s_size]) }
+
+      context 'for filters with products' do
+        let(:options_filter) do
+          [
+            "filter[options][#{color.name}]=#{white_color.name}",
+            "filter[options][#{size.name}]=#{m_size.name}"
+          ].join('&')
+        end
+
+        before { get "/api/v2/storefront/products?#{options_filter}&include=option_types,variants.option_values" }
+
+        it_behaves_like 'returns 200 HTTP status'
+
+        it 'returns products with specified options' do
+          expect(json_response['data']).to include(have_id(product_1.id.to_s))
+          expect(json_response['data']).not_to include(have_id(product_2.id.to_s))
+
+          expect(json_response['included']).to include(have_type('option_type').and(have_attribute(:name).with_value(color.name)))
+          expect(json_response['included']).to include(have_type('option_value').and(have_attribute(:name).with_value(white_color.name)))
+
+          expect(json_response['included']).to include(have_type('option_type').and(have_attribute(:name).with_value(size.name)))
+          expect(json_response['included']).to include(have_type('option_value').and(have_attribute(:name).with_value(m_size.name)))
+        end
+      end
+
+      context 'for excluding filters' do
+        let(:options_filter) do
+          [
+            "filter[options][#{color.name}]=#{green_color.name}",
+            "filter[options][#{size.name}]=#{m_size.name}"
+          ].join('&')
+        end
+
+        before { get "/api/v2/storefront/products?#{options_filter}&include=option_types,variants.option_values" }
+
+        it_behaves_like 'returns 200 HTTP status'
+
+        it 'returns no products' do
+          expect(json_response['data']).to be_empty
+        end
+      end
+    end
+
     context 'with specified properties' do
       context 'using proper filter params' do
         before { get "/api/v2/storefront/products?filter[properties][#{property.filter_param}]=#{product_property.filter_param}&include=product_properties" }

--- a/core/app/finders/spree/products/find.rb
+++ b/core/app/finders/spree/products/find.rb
@@ -142,11 +142,8 @@ module Spree
       def by_options(products)
         return products unless options?
 
-        products.where(
-          id: options.map do |key, value|
-            products.with_option_value(key, value).ids
-          end.flatten.compact.uniq
-        )
+        products_ids = options.map { |key, value| products.with_option_value(key, value).ids }
+        products.where(id: products_ids.reduce(&:intersection))
       end
 
       def by_option_value_ids(products)

--- a/core/spec/finders/spree/products/find_spec.rb
+++ b/core/spec/finders/spree/products/find_spec.rb
@@ -92,7 +92,7 @@ module Spree
       end
     end
 
-    describe 'filter by option values' do
+    describe 'filter by options and option values' do
       subject(:products) do
         described_class.new(
           scope: Spree::Product.all,
@@ -117,28 +117,47 @@ module Spree
       let!(:variant_2) { create :variant, product: product_2, option_values: [option_value_1_2, option_value_2_2] }
       let!(:variant_3) { create :variant, product: product_3, option_values: [option_value_1_1, option_value_2_2] }
 
-      let(:option_value_ids) { [] }
-      let(:params) do
-        {
-          filter: {
-            option_value_ids: option_value_ids
+      context 'for options' do
+        let(:params) do
+          {
+            filter: {
+              options: ActionController::Parameters.new(
+                size: 's',
+                state: 'old'
+              )
+            }
           }
-        }
-      end
+        end
 
-      context 'filtering by one option' do
-        let(:option_value_ids) { [option_value_1_1.id] }
-
-        it 'returns products with proper option values' do
-          expect(products).to match_array([product_1, product_3])
+        it 'returns products matching all given options' do
+          expect(products).to contain_exactly(product_1)
         end
       end
 
-      context 'filtering by several options' do
-        let(:option_value_ids) { [option_value_1_1.id, option_value_2_2.id] }
+      context 'for option values' do
+        let(:option_value_ids) { [] }
+        let(:params) do
+          {
+            filter: {
+              option_value_ids: option_value_ids
+            }
+          }
+        end
 
-        it 'returns products that have both options' do
-          expect(products).to match_array([product_3])
+        context 'filtering by one option' do
+          let(:option_value_ids) { [option_value_1_1.id] }
+
+          it 'returns products with proper option values' do
+            expect(products).to match_array([product_1, product_3])
+          end
+        end
+
+        context 'filtering by several options' do
+          let(:option_value_ids) { [option_value_1_1.id, option_value_2_2.id] }
+
+          it 'returns products that have both options' do
+            expect(products).to match_array([product_3])
+          end
         end
       end
     end


### PR DESCRIPTION
When filtering Products by Options on the Storefront API, we had an issue that we responded with products from **either** matched Option instead of **every** one of them.

This PR fixes that issue. Filtering on the Storefront frontend is unaffected since it filters by option values which is a different method on the finder.