### PR TITLE
SD-1099 - Add info note to option type filterable.

### DIFF
--- a/backend/app/views/spree/admin/option_types/_form.html.erb
+++ b/backend/app/views/spree/admin/option_types/_form.html.erb
@@ -21,6 +21,9 @@
         <%= f.check_box :filterable %>
         <%= Spree.t(:filterable) %>
       <% end %>
+      <small class="form-text text-muted">
+        <%= raw Spree.t('option_type_filterable_info') %>
+      </small>
     <% end %>
   </div>
 </div>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1186,6 +1186,7 @@ en:
     open: Open
     open_all_adjustments: Open All Adjustments
     option_type: Option Type
+    option_type_filterable_info: 'When an option type is set to Filterable, your storefront visitors are presented with the option to filter a taxon of products based on the option type. A typical example of this would be to filter clothing by size and color.<br><br><b>Please Note:</b> Filters will only be visible in the storefront taxons that contain products with this option type set.'
     option_type_placeholder: Choose an option type
     option_types: Option Types
     option_value: Option Value


### PR DESCRIPTION
Add option type filtrable info message; noting that filters only appear in taxon that contain product that have this option type set. 

<img width="1182" alt="Screenshot 2021-05-26 at 14 24 03" src="https://user-images.githubusercontent.com/1240766/119667292-0ebd6b80-be2e-11eb-9606-cf3cf3c33e44.png">