### PR TITLE
Back to validate number with case sensitive true

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -129,7 +129,7 @@ module Spree
     before_update :homogenize_line_item_currencies, if: :currency_changed?
 
     with_options presence: true do
-      validates :number, length: { maximum: 32, allow_blank: true }, uniqueness: { allow_blank: true, case_sensitive: false }
+      validates :number, length: { maximum: 32, allow_blank: true }, uniqueness: { allow_blank: true, case_sensitive: true }
       validates :email, length: { maximum: 254, allow_blank: true }, email: { allow_blank: true }, if: :require_email
       validates :item_count, numericality: { greater_than_or_equal_to: 0, less_than: 2**31, only_integer: true, allow_blank: true }
       validates :store


### PR DESCRIPTION
Because of case insensitive validation, as the database grows, that validation gets slower and slower

`Spree::Order Exists? (53.2ms) SELECT 1 AS one FROM "spree_orders" WHERE LOWER("spree_orders"."number") = LOWER($1) AND "spree_orders"."id" != $2 LIMIT $3 [["number", "R371731416"], ["id", 66199], ["LIMIT", 1]]`

`Spree::Order Exists? (3.6ms) SELECT 1 AS one FROM "spree_orders" WHERE "spree_orders"."number" = $1 AND "spree_orders"."id" != $2 LIMIT $3 [["number", "R371731416"], ["id", 66199], ["LIMIT", 1]]`

