### PR TITLE
SD-1245 - Fix Text Blowing Out of Containers

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -729,7 +729,7 @@ en:
     checkout_page:
       main_navigation: Main navigation
       checkout_navigation: Checkout navigation
-      back_to_cart: back to the cart
+      back_to_cart: back to cart
       delivery_method: delivery method
       header: Checkout
       product: Product

--- a/frontend/app/assets/stylesheets/spree/frontend/views/spree/checkout/edit.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/views/spree/checkout/edit.scss
@@ -388,19 +388,19 @@
       }
       &-header {
         font-size: font-px-to-rem(16px);
+        hyphens: auto;
+        overflow-wrap: break-word;
+        word-wrap: break-word;
         font-weight: 500;
-        line-height: 1.06;
         letter-spacing: 0.4px;
-        margin-bottom: 35px;
+        margin-bottom: 30px;
         @include media-breakpoint-up(sm) {
           font-size: font-px-to-rem(29px);
-          line-height: 1.1;
           letter-spacing: 0.73px;
           margin-bottom: 74px;
         }
         @include media-breakpoint-up(lg) {
           font-size: font-px-to-rem(26px);
-          line-height: 0.65;
           letter-spacing: 0.65px;
           margin-bottom: 35px;
         }

--- a/frontend/app/assets/stylesheets/spree/frontend/views/spree/checkout/edit.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/views/spree/checkout/edit.scss
@@ -32,9 +32,21 @@
         }
       }
       &-text {
-        padding-left: 15px;
+        color: black;
+        font-size: 0.8rem;
+        @include media-breakpoint-up(sm) {
+          font-size: 1rem;
+        }
+        @include media-breakpoint-up(lg) {
+          font-size: 1.25rem;
+        }
+        svg {
+          height: 15px;
+          padding-top: 2px;
+        }
         &:hover {
           text-decoration: underline;
+          color: black;
         }
       }
     }

--- a/frontend/app/views/spree/shared/_checkout_header.html.erb
+++ b/frontend/app/views/spree/shared/_checkout_header.html.erb
@@ -1,27 +1,25 @@
 <div id="spree-header">
   <header id="header" class="d-flex align-items-center header-spree border-bottom">
-    <div class="container position-relative" role="navigation" aria-label="<%= Spree.t('checkout_page.main_navigation') %>">
-      <div class="position-absolute checkout-header-link">
-        <%= link_to spree.cart_path, class: "d-none d-sm-inline text-uppercase", method: :get do %>
-          <%= icon(name: 'arrow-right',
-                   classes: 'spree-icon-arrow spree-icon-arrow-left',
-                   width: 7,
-                   height: 14) %>
-          <span class="checkout-header-link-text"><%= Spree.t('checkout_page.back_to_cart') %></span>
-        <% end %>
+    <div class="container" role="navigation" aria-label="<%= Spree.t('checkout_page.main_navigation') %>">
 
-        <%= link_to spree.cart_path, class: "d-sm-none text-uppercase", method: :get do %>
-          <%= icon(name: 'arrow-right',
-                   classes: 'spree-icon-arrow spree-icon-arrow-left',
-                   width: 7,
-                   height: 14) %>
-          <span class="checkout-header-link-text"><%= Spree.t('back') %></span>
-        <% end %>
-      </div>
-      <div class="d-flex flex-nowrap align-items-center justify-content-center">
-        <figure class="logo flex-grow-0 flex-xl-grow-0 order-xl-0 header-spree-fluid-logo m-0">
-          <%= logo(nil, {method: :get}) %>
-        </figure>
+      <div class="row">
+        <div class="col d-flex align-items-center truncate pr-0">
+          <%= link_to spree.cart_path, class: "text-uppercase truncate checkout-header-link-text", method: :get do %>
+            <%= icon(name: 'arrow-right',
+                     classes: 'spree-icon-arrow spree-icon-arrow-left',
+                     width: 14,
+                     height: 14) %>
+            <%= Spree.t('checkout_page.back_to_cart') %>
+          <% end %>
+        </div>
+
+        <div class="col-auto d-flex align-items-center justify-content-end justify-content-md-center">
+          <figure class="logo header-spree-fluid-logo m-0 p-0">
+            <%= logo(nil, {method: :get}) %>
+          </figure>
+        </div>
+        <div class="col-0 col-md"><!-- spacer --></div>
+
       </div>
     </div>
   </header>

--- a/frontend/app/views/spree/shared/_checkout_header.html.erb
+++ b/frontend/app/views/spree/shared/_checkout_header.html.erb
@@ -1,8 +1,8 @@
 <div id="spree-header">
   <header id="header" class="d-flex align-items-center header-spree border-bottom">
     <div class="container" role="navigation" aria-label="<%= Spree.t('checkout_page.main_navigation') %>">
-
       <div class="row">
+
         <div class="col d-flex align-items-center truncate pr-0">
           <%= link_to spree.cart_path, class: "text-uppercase truncate checkout-header-link-text", method: :get do %>
             <%= icon(name: 'arrow-right',
@@ -18,7 +18,10 @@
             <%= logo(nil, {method: :get}) %>
           </figure>
         </div>
-        <div class="col-0 col-md"><!-- spacer --></div>
+
+        <div class="col-0 col-md">
+          <!-- spacer -->
+        </div>
 
       </div>
     </div>


### PR DESCRIPTION
## Order summary container
BEFORE:
<img width="486" alt="SV_OrderSummary" src="https://user-images.githubusercontent.com/1240766/119800006-86de6c80-bed4-11eb-96ac-7ea3c145a588.png">

AFTER:
<img width="397" alt="Screenshot 2021-05-27 at 10 14 56" src="https://user-images.githubusercontent.com/1240766/119799939-78905080-bed4-11eb-8e36-23c3145cd66d.png">


## Checkout Header Back to Cart /  logo overlap fix.
https://www.youtube.com/watch?v=SRJ2hItcpwM
