### PR TITLE
Replace Twitter::CLDR with ValidatesZipcode

### DIFF
--- a/core/spec/models/spree/address_spec.rb
+++ b/core/spec/models/spree/address_spec.rb
@@ -212,7 +212,7 @@ describe Spree::Address, type: :model do
         end
 
         it 'does not have a supported country iso' do
-          allow(address.country).to receive(:iso).and_return('BO')
+          allow(address.country).to receive(:iso).and_return('XX')
           address.valid?
           expect(address.errors['zipcode']).not_to include('is invalid')
         end

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'state_machines-activerecord', '~> 0.6'
   s.add_dependency 'state_machines-activemodel', '~> 0.7'
   s.add_dependency 'stringex'
-  s.add_dependency 'twitter_cldr', '>= 4.3'
+  s.add_dependency 'validates_zipcode'
   s.add_dependency 'mini_magick', '~> 4.9', '>= 4.9.4'
   s.add_dependency 'image_processing', '~> 1.2'
   s.add_dependency 'active_storage_validations', '~> 0.9'


### PR DESCRIPTION
The zip code is first formatted because of [this](https://github.com/dgilperez/validates_zipcode/issues/56) issue.