### PR TITLE
[SD-1297] - Fix menu-item links drop down on mobile.

### DIFF
--- a/backend/app/views/spree/admin/menu_items/_form.html.erb
+++ b/backend/app/views/spree/admin/menu_items/_form.html.erb
@@ -92,14 +92,14 @@
           </div>
           <div class="card-body">
             <div class="row">
-              <div class="col-6">
+              <div class="col-12 col-md-6">
                 <%= f.field_container :linked_resource_type, class: ['form-group'] do %>
                   <%= f.label :linked_resource_type, Spree.t('admin.navigation.link_to') %>
                   <%= f.select(:linked_resource_type, resorce_types_dropdown_values, {include_blank: false}, class: 'link_switcher') %>
                   <%= f.error_message_on :linked_resource_type %>
                 <% end %>
               </div>
-              <div class="col-6">
+              <div class="col-12 col-md-6">
                 <%= render "spree/admin/shared/link_fields", resource: @menu_item, f: f %>
               </div>
             </div>


### PR DESCRIPTION
Fix for menu item linking section to drop down to two will width items on mobile.


**BEFORE:**
<img width="391" alt="Screenshot 2021-06-01 at 14 47 18" src="https://user-images.githubusercontent.com/1240766/120334112-4887e980-c2e8-11eb-9460-89ea18e0f354.png">


**AFTER:**
<img width="387" alt="Screenshot 2021-06-01 at 14 46 53" src="https://user-images.githubusercontent.com/1240766/120334151-52a9e800-c2e8-11eb-822d-aceae2ff831a.png">
