### PR TITLE
Fix Change from :unique_code to :location in Menus API

### DIFF
--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -165,7 +165,7 @@ Spree::Core::Engine.add_routes do
         get '/stores/:code', to: 'stores#show', as: :store
 
         resources :menus, only: %i[index]
-        get '/menus/:unique_code', to: 'menus#show', as: :menu
+        get '/menus/:location', to: 'menus#show', as: :menu
       end
 
       namespace :platform do

--- a/core/app/finders/spree/menus/find.rb
+++ b/core/app/finders/spree/menus/find.rb
@@ -2,7 +2,7 @@ module Spree
   module Menus
     class Find < ::Spree::BaseFinder
       def execute
-        return scope.where(unique_code: params[:filter]['unique_code']) if params[:filter].present?
+        return scope.where(location: params[:filter]['location']) if params[:filter].present?
 
         scope
       end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -625,7 +625,6 @@ en:
         menus: Menus
         menu_items: '%{menu_name} Items'
         public_details: Public Details
-        unique_code_store_error: 'The code: %{code} is already used for Menu: %{menus}, make sure your unique code is unique within the store it is being used for.'
         subtitle: Subtitle
         url_info: 'The URL field can link to an external website using <b>https://example.com</b>, link to an otherwise unreachable internal path using <b>/policies/privacy</b>,
         launch an email client using <b>mailto:sales@example.com</b> or used to create a clickable phone number with <b>tel:123456789</b>'
@@ -636,7 +635,6 @@ en:
         the Spree main menu use the code <b>category</b> or <b>promo</b> to create the containers that organize links and promotions appropriately. To learn more view the documentation by <a href='https://guides.spreecommerce.org/user/navigation/add_menu_items.html' target='_blank' class='alert-link'>clicking here</a>."
         type: Type
         used_in: Used In
-        unique_code: Unique Code
         you_have_no_menus: You have no Menus, click the Add New Menu button to create your first Menu.
         this_link_takes_you_to_your_stores_home_page: This link takes you to your stores home page.
     administration: Administration

--- a/sample/db/samples/menu_items.rb
+++ b/sample/db/samples/menu_items.rb
@@ -12,7 +12,7 @@ MENUS.each do |menu|
   when 'en'
     root_name_a = 'Women'
     root_name_b = 'Men'
-    root_name_c = 'Sportsware'
+    root_name_c = 'Sportswear'
 
     catagories = 'Categories'
 
@@ -37,7 +37,7 @@ MENUS.each do |menu|
   when 'fr'
     root_name_a = 'Femmes'
     root_name_b = 'Hommes'
-    root_name_c = 'Vêtements de sport'
+    root_name_c = 'Tenue de sport'
 
     catagories = 'Catégories'
 
@@ -62,7 +62,7 @@ MENUS.each do |menu|
   when 'de'
     root_name_a = 'Frauen'
     root_name_b = 'Männer'
-    root_name_c = 'Sportartikel'
+    root_name_c = 'Sportbekleidung'
 
     catagories = 'Kategorien'
 
@@ -87,7 +87,7 @@ MENUS.each do |menu|
   when 'es'
     root_name_a = 'Hombres'
     root_name_b = 'Mujeres'
-    root_name_c = 'Deportes'
+    root_name_c = 'Ropa de deporte'
 
     catagories = 'Categorías'
 


### PR DESCRIPTION
Fix for finding menus by location in API.
**Use:**
`/api/v2/storefront/menus/header`
or
`/api/v2/storefront/menus/header?include=menu_items`