### PR TITLE
Remove 'id: :serial' from create table

### DIFF
--- a/core/db/migrate/20210527094055_create_spree_products_stores.rb
+++ b/core/db/migrate/20210527094055_create_spree_products_stores.rb
@@ -1,7 +1,7 @@
 class CreateSpreeProductsStores < ActiveRecord::Migration[5.2]
   def up
     unless table_exists?(:spree_products_stores)
-      create_table :spree_products_stores, id: :serial do |t|
+      create_table :spree_products_stores do |t|
         t.references :product, index: true
         t.references :store,  index: true
         t.timestamps


### PR DESCRIPTION
`id: :serial` is very specific to certain databases, this causes issues when running local tests on SQLite .

```ruby
  create_table "spree_products", force: :cascade do |t|
    t.string "name", default: "", null: false
    t.text "description"
    t.datetime "available_on"
    t.datetime "deleted_at"
    t.string "slug"
    t.text "meta_description"
    t.string "meta_keywords"
    t.integer "tax_category_id"
    t.integer "shipping_category_id"
    t.datetime "created_at", precision: 6, null: false
    t.datetime "updated_at", precision: 6, null: false
    t.boolean "promotionable", default: true
    t.string "meta_title"
    t.datetime "discontinue_on"
    t.index ["available_on"], name: "index_spree_products_on_available_on"
    t.index ["deleted_at"], name: "index_spree_products_on_deleted_at"
    t.index ["discontinue_on"], name: "index_spree_products_on_discontinue_on"
    t.index ["name"], name: "index_spree_products_on_name"
    t.index ["shipping_category_id"], name: "index_spree_products_on_shipping_category_id"
    t.index ["slug"], name: "index_spree_products_on_slug", unique: true
    t.index ["tax_category_id"], name: "index_spree_products_on_tax_category_id"
  end

# Could not dump table "spree_products_stores" because of following StandardError
#   Unknown type 'serial' for column 'id'

  create_table "spree_products_taxons", force: :cascade do |t|
    t.integer "product_id"
    t.integer "taxon_id"
    t.integer "position"
    t.index ["position"], name: "index_spree_products_taxons_on_position"
    t.index ["product_id", "taxon_id"], name: "index_spree_products_taxons_on_product_id_and_taxon_id", unique: true
    t.index ["product_id"], name: "index_spree_products_taxons_on_product_id"
    t.index ["taxon_id"], name: "index_spree_products_taxons_on_taxon_id"
  end
```