### PR TITLE
Support Store's Default Country

### DIFF
--- a/api/app/serializers/spree/v2/storefront/country_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/country_serializer.rb
@@ -7,8 +7,8 @@ module Spree
         attributes :iso, :iso3, :iso_name, :name, :states_required,
                    :zipcode_required
 
-        attribute :default do |object|
-          object.default?
+        attribute :default do |object, params|
+          object.default?(params[:store])
         end
 
         has_many :states, if: proc { |_record, params| params && params[:include_states] }

--- a/api/spec/controllers/spree/api/v1/stores_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/stores_controller_spec.rb
@@ -5,7 +5,8 @@ module Spree
     render_views
 
     let!(:store) do
-      create(:store, name: 'My Spree Store', url: 'spreestore.example.com')
+      Spree::Store.default.update!(name: 'My Spree Store', url: 'spreestore.example.com')
+      Spree::Store.default
     end
 
     before do

--- a/api/spec/requests/spree/api/v2/caching_spec.rb
+++ b/api/spec/requests/spree/api/v2/caching_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'API v2 Caching spec', type: :request do
   let!(:product) { create(:product, name: 'Some name', stores: [store]) }
-  let(:store) { create(:store) }
+  let(:store) { Spree::Store.default }
 
   let(:cache_store) { Spree::V2::Storefront::ProductSerializer.cache_store_instance }
   let(:cache_entry) { cache_store.read(product, namespace: cache_namespace) }
@@ -39,8 +39,9 @@ describe 'API v2 Caching spec', type: :request do
   context 'currency and user' do
     include_context 'API v2 tokens'
 
+    before { store.update!(supported_currencies: 'USD,EUR') }
+
     let!(:user) { create(:user) }
-    let!(:store) { create(:store, supported_currencies: 'USD,EUR') }
     let(:currency) { 'EUR' }
     let(:cache_namespace) { "jsonapi-serializer-EUR-#{user.cache_key_with_version}-#{store.cache_key_with_version}" }
 

--- a/api/spec/requests/spree/api/v2/storefront/account/addresses_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/account/addresses_spec.rb
@@ -193,10 +193,10 @@ describe 'Storefront API v2 Addresses spec', type: :request do
       before { patch "/api/v2/storefront/account/addresses/#{address.id}", params: params, headers: headers_bearer }
 
       it 'returns errors' do
-        expect(json_response['error']).to eq("City can't be blank, Zip Code can't be blank")
+        expect(json_response['error']).to eq("City can't be blank, Zip Code can't be blank, Zip Code is invalid")
         expect(json_response['errors']).to eq(
           'city' => ["can't be blank"],
-          'zipcode' => ["can't be blank"]
+          'zipcode' => ["can't be blank", "is invalid"]
         )
       end
     end

--- a/api/spec/requests/spree/api/v2/storefront/cart_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/cart_spec.rb
@@ -1,8 +1,7 @@
 require 'spec_helper'
 
 describe 'API V2 Storefront Cart Spec', type: :request do
-  let(:default_currency) { 'USD' }
-  let!(:store) { create(:store, default_currency: default_currency) }
+  let!(:store) { Spree::Store.default }
   let(:currency) { store.default_currency }
   let(:user)  { create(:user) }
   let(:order) { create(:order, user: user, store: store, currency: currency) }

--- a/api/spec/requests/spree/api/v2/storefront/checkout_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/checkout_spec.rb
@@ -1,8 +1,7 @@
 require 'spec_helper'
 
 describe 'API V2 Storefront Checkout Spec', type: :request do
-  let(:default_currency) { 'USD' }
-  let(:store) { create(:store, default_currency: default_currency) }
+  let(:store) { Spree::Store.default }
   let(:currency) { store.default_currency }
   let(:user)  { create(:user) }
   let(:order) { create(:order, user: user, store: store, currency: currency) }
@@ -455,14 +454,14 @@ describe 'API V2 Storefront Checkout Spec', type: :request do
     end
 
     context 'for guest or user without store credit' do
-      let!(:order) { create(:order, total: order_total) }
+      let!(:order) { create(:order, total: order_total, store: store) }
 
       it_behaves_like 'returns 422 HTTP status'
     end
 
     context 'for user with store credits' do
       let!(:store_credit) { create(:store_credit, amount: order_total) }
-      let!(:order) { create(:order, user: store_credit.user, total: order_total) }
+      let!(:order) { create(:order, user: store_credit.user, total: order_total, store: store) }
 
       shared_examples 'valid payload' do |amount|
         it 'returns StoreCredit payment' do
@@ -527,8 +526,7 @@ describe 'API V2 Storefront Checkout Spec', type: :request do
     let(:order_total) { 500.00 }
     let(:params) { { order_token: order.token, include: 'payments', fields: { payment: 'state' } } }
     let(:execute) { post '/api/v2/storefront/checkout/remove_store_credit', params: params, headers: headers }
-    let!(:store_credit) { create(:store_credit, amount: order_total) }
-    let!(:order) { create(:order, user: store_credit.user, total: order_total) }
+    let!(:store_credit) { create(:store_credit, amount: order_total, user: user) }
 
     before do
       create(:store_credit_payment_method)

--- a/api/spec/requests/spree/api/v2/storefront/checkout_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/checkout_spec.rb
@@ -577,7 +577,7 @@ describe 'API V2 Storefront Checkout Spec', type: :request do
   describe 'checkout#shipping_rates' do
     let(:execute) { get '/api/v2/storefront/checkout/shipping_rates', headers: headers }
 
-    let(:country) { Spree::Country.default }
+    let(:country) { store.default_country }
     let(:zone) { create(:zone, name: 'US') }
     let(:shipping_method) { create(:shipping_method) }
     let(:shipping_method_2) { create(:shipping_method) }

--- a/api/spec/requests/spree/api/v2/storefront/countries_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/countries_spec.rb
@@ -1,13 +1,11 @@
 require 'spec_helper'
 
 describe 'Storefront API v2 Countries spec', type: :request do
+  let(:store) { Spree::Store.default }
+  let(:default_country) { store.default_country }
   let!(:country) { create(:country) }
   let!(:states)    { create_list(:state, 2, country: country) }
-  let!(:default_country) do
-    country = create(:country, iso3: 'GBR')
-    Spree::Config[:default_country_id] = country.id
-    country
-  end
+
   shared_examples 'returns valid country resource JSON' do
     it 'returns a valid country resource JSON response' do
       expect(response.status).to eq(200)
@@ -83,7 +81,7 @@ describe 'Storefront API v2 Countries spec', type: :request do
         expect(json_response['data']).to have_attribute(:iso3).with_value(country.iso3)
         expect(json_response['data']).to have_attribute(:iso_name).with_value(country.iso_name)
         expect(json_response['data']).to have_attribute(:name).with_value(country.name)
-        expect(json_response['data']).to have_attribute(:default).with_value(country == Spree::Country.default)
+        expect(json_response['data']).to have_attribute(:default).with_value(country == store.default_country)
         expect(json_response['data']).to have_attribute(:states_required).with_value(country.states_required)
         expect(json_response['data']).to have_attribute(:zipcode_required).with_value(country.zipcode_required)
       end

--- a/api/spec/spec_helper.rb
+++ b/api/spec/spec_helper.rb
@@ -63,6 +63,11 @@ RSpec.configure do |config|
 
   config.before do
     Spree::Api::Config[:requires_authentication] = true
+
+    country = create(:country, name: 'United States of America', iso_name: 'UNITED STATES', iso: 'US', states_required: true)
+    Spree::Config[:default_country_id] = country.id
+
+    create(:store, default: true)
   end
 
   config.order = :random

--- a/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
+++ b/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
@@ -11,9 +11,8 @@ module Spree
         end
 
         def edit
-          country_id = Address.default.country_id
-          @order.build_bill_address(country_id: country_id) if @order.bill_address.nil?
-          @order.build_ship_address(country_id: country_id) if @order.ship_address.nil?
+          @order.build_bill_address(country: current_store.default_country) if @order.bill_address.nil?
+          @order.build_ship_address(country: current_store.default_country) if @order.ship_address.nil?
 
           @order.bill_address.country_id = country_id if @order.bill_address.country.nil?
           @order.ship_address.country_id = country_id if @order.ship_address.country.nil?

--- a/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
+++ b/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
@@ -13,9 +13,6 @@ module Spree
         def edit
           @order.build_bill_address(country: current_store.default_country) if @order.bill_address.nil?
           @order.build_ship_address(country: current_store.default_country) if @order.ship_address.nil?
-
-          @order.bill_address.country_id = country_id if @order.bill_address.country.nil?
-          @order.ship_address.country_id = country_id if @order.ship_address.country.nil?
         end
 
         def update

--- a/backend/app/controllers/spree/admin/stock_locations_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_locations_controller.rb
@@ -6,7 +6,7 @@ module Spree
       private
 
       def set_country
-        @stock_location.country = Spree::Country.default
+        @stock_location.country = current_store.default_country
         unless @stock_location.country
           flash[:error] = Spree.t(:stock_locations_need_a_default_country)
           redirect_to admin_stock_locations_path

--- a/backend/app/views/spree/admin/shared/sub_menu/_configuration.html.erb
+++ b/backend/app/views/spree/admin/shared/sub_menu/_configuration.html.erb
@@ -6,7 +6,7 @@
   <%= configurations_sidebar_menu_item(Spree.t(:zones), spree.admin_zones_path) if can? :manage, Spree::Zone %>
   <%= configurations_sidebar_menu_item(Spree.t(:countries), spree.admin_countries_path) if can? :manage, Spree::Country %>
 
-  <% if country = Spree::Country.find_by(id: Spree::Config[:default_country_id]) || Spree::Country.first %>
+  <% if country = current_store.default_country %>
     <%= configurations_sidebar_menu_item(Spree.t(:states), spree.admin_country_states_path(country)) if can? :manage, Spree::Country %>
   <% end %>
 

--- a/backend/app/views/spree/admin/stores/_form.html.erb
+++ b/backend/app/views/spree/admin/stores/_form.html.erb
@@ -176,7 +176,7 @@
     <% end %>
     <%= f.field_container :default_country_id, class: ['form-group'] do %>
       <%= f.label :default_country_id, Spree.t('i18n.default_country') %>
-      <%= f.select :default_country_id, options_from_collection_for_select(@countries, :id, :name, @store.default_country_id || Spree::Config[:default_country_id]), {}, { class: 'select2' } %>
+      <%= f.select :default_country_id, options_from_collection_for_select(@countries, :id, :name, @store.default_country_id), {}, { class: 'select2' } %>
       <%= f.error_message_on :default_country_id %>
       <small class="form-text text-muted">
         <%= Spree.t('store_form.default_country_help') %>

--- a/backend/app/views/spree/admin/users/_addresses_form.html.erb
+++ b/backend/app/views/spree/admin/users/_addresses_form.html.erb
@@ -8,8 +8,7 @@
       </div>
 
       <div class="card-body">
-        <%= f.fields_for :bill_address, (@user.bill_address || Spree::Address.default(@user, "bill")) do |ba_form| %>
-          <% ba_form.object ||= Spree::Address.new(country: Spree::Country.new) %>
+        <%= f.fields_for :bill_address, @user.bill_address || @user.addresses.new(country: current_store.default_country) do |ba_form| %>
           <%= render partial: 'spree/admin/shared/address_form', locals: { f: ba_form, type: "billing" } %>
         <% end %>
       </div>
@@ -30,8 +29,7 @@
             <%= check_box_tag 'user[use_billing]', '1', checked, class: 'checkbox' %>
             <%= label_tag :use_billing, Spree.t(:use_billing_address), for: 'user_use_billing', id: 'use_billing', class: 'form-check-label' %>
           </p>
-        <%= f.fields_for :ship_address, (@user.ship_address || Spree::Address.default(@user, "ship")) do |sa_form| %>
-          <% sa_form.object ||= Spree::Address.new(country: Spree::Country.new) %>
+        <%= f.fields_for :ship_address, @user.ship_address || @user.addresses.new(country: current_store.default_country) do |sa_form| %>
           <%= render partial: 'spree/admin/shared/address_form', locals: { f: sa_form, type: "shipping" } %>
         <% end %>
       </div>

--- a/backend/spec/controllers/spree/admin/stock_locations_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/stock_locations_controller_spec.rb
@@ -5,32 +5,7 @@ module Spree
     describe StockLocationsController, type: :controller do
       stub_authorization!
 
-      # Regression for #4272
-      context 'with no countries present' do
-        it 'cannot create a new stock location' do
-          get :new
-          expect(flash[:error]).to eq(Spree.t(:stock_locations_need_a_default_country))
-          expect(response).to redirect_to(spree.admin_stock_locations_path)
-        end
-      end
-
       context 'with a default country present' do
-        before do
-          country = FactoryBot.create(:country)
-          Spree::Config[:default_country_id] = country.id
-        end
-
-        it 'can create a new stock location' do
-          get :new
-          expect(response).to be_successful
-        end
-      end
-
-      context "with a country with the ISO code of 'US' existing" do
-        before do
-          FactoryBot.create(:country, iso: 'US')
-        end
-
         it 'can create a new stock location' do
           get :new
           expect(response).to be_successful

--- a/backend/spec/features/admin/configuration/stock_locations_spec.rb
+++ b/backend/spec/features/admin/configuration/stock_locations_spec.rb
@@ -12,7 +12,7 @@ describe 'Stock Locations', type: :feature do
     within find('#contentHeader') do
       click_link 'New Stock Location'
     end
-    
+
     fill_in 'Name', with: 'London'
     check 'Active'
     click_button 'Create'

--- a/backend/spec/features/admin/configuration/stores_spec.rb
+++ b/backend/spec/features/admin/configuration/stores_spec.rb
@@ -3,9 +3,11 @@ require 'spec_helper'
 describe 'Stores admin', type: :feature, js: true do
   stub_authorization!
 
-  let!(:store) { create(:store, checkout_zone_id: zone.id) }
-  let!(:zone) { create(:zone, name: 'EU_VAT') }
+  let(:store) { Spree::Store.default }
+  let(:zone) { create(:zone, name: 'EU_VAT') }
   let!(:no_limits) { create(:zone, name: 'No Limits') }
+
+  before { store.update!(checkout_zone: zone) }
 
   describe 'visiting the stores page' do
     before do

--- a/backend/spec/features/admin/orders/customer_details_spec.rb
+++ b/backend/spec/features/admin/orders/customer_details_spec.rb
@@ -3,7 +3,8 @@ require 'spec_helper'
 describe 'Customer Details', type: :feature, js: true do
   stub_authorization!
 
-  let!(:country) { create(:country, name: 'United States of America', iso: 'US') }
+  let(:store) { Spree::Store.default }
+  let!(:country) { store.default_country }
   let!(:state) { create(:state, name: 'Alabama', country: country, abbr: 'AL') }
   let!(:order) { create(:order, state: 'complete', completed_at: '2011-02-01 12:36:15') }
   let!(:product) { create(:product_in_stock) }

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -49,7 +49,7 @@ describe 'Products', type: :feature do
         context 'using Russian Rubles' do
           before do
             Spree::Config[:currency] = 'RUB'
-            create(:store, default: true, default_currency: 'RUB')
+            Spree::Store.default.update!(default_currency: 'RUB')
             create(:product, name: 'Just a product', price: 19.99)
           end
 

--- a/backend/spec/features/admin/products/variant_spec.rb
+++ b/backend/spec/features/admin/products/variant_spec.rb
@@ -31,7 +31,7 @@ describe 'Variants', type: :feature do
       context 'using Russian Rubles' do
         before do
           Spree::Config[:currency] = 'RUB'
-          create(:store, default: true, default_currency: 'RUB')
+          Spree::Store.default.update!(default_currency: 'RUB')
           create(:variant, product: product, price: 19.99)
         end
 

--- a/backend/spec/helpers/spree/admin/stores_helper_spec.rb
+++ b/backend/spec/helpers/spree/admin/stores_helper_spec.rb
@@ -1,11 +1,10 @@
 require 'spec_helper'
 
 describe Spree::Admin::StoresHelper, type: :helper do
-
   describe '#selected_checkout_zone' do
-    let!(:store) { create(:store) }
-    let!(:country) { create(:country) }
-    let!(:country_zone) { create(:zone, name: 'CountryZone') }
+    let!(:store) { Spree::Store.default }
+    let!(:country) { store.default_country }
+    let!(:country_zone) { create(:zone, name: 'CountryZone', kind: 'country') }
 
     context 'with set preference checkout_zone in spree config file' do
       before do

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -83,6 +83,11 @@ RSpec.configure do |config|
 
     DatabaseCleaner.start
     reset_spree_preferences
+
+    country = create(:country, name: 'United States of America', iso_name: 'UNITED STATES', iso: 'US', states_required: true)
+    Spree::Config[:default_country_id] = country.id
+
+    create(:store, default: true)
   end
 
   config.after(:each, type: :feature) do |example|

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -59,10 +59,17 @@ module Spree
     self.whitelisted_ransackable_associations = %w[country state user]
 
     def self.build_default
+      ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+        `Address#build_default` is deprecated and will be removed in Spree 5.0.
+        Please use standard rails `Address.new(country: current_store.default_country)`
+      DEPRECATION
       new(country: Spree::Country.default)
     end
 
     def self.default(user = nil, kind = 'bill')
+      ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+        `Address#default` is deprecated and will be removed in Spree 5.0.
+      DEPRECATION
       if user && user_address = user.public_send(:"#{kind}_address")
         user_address.clone
       else

--- a/core/app/models/spree/country.rb
+++ b/core/app/models/spree/country.rb
@@ -18,8 +18,9 @@ module Spree
 
     validates :name, :iso_name, :iso, :iso3, presence: true, uniqueness: { case_sensitive: false }
 
-    def self.default
-      country_id = Spree::Config[:default_country_id]
+    def self.default(store = nil)
+      store ||= Spree::Store.default
+      country_id = store.default_country_id
       default = find_by(id: country_id) if country_id.present?
       default || find_by(iso: 'US') || first
     end
@@ -28,8 +29,9 @@ module Spree
       where(['LOWER(iso) = ?', iso.downcase]).or(where(['LOWER(iso3) = ?', iso.downcase])).take
     end
 
-    def default?
-      id == Spree::Config[:default_country_id]
+    def default?(store = nil)
+      store ||= Spree::Store.default
+      self == store.default_country
     end
 
     def <=>(other)

--- a/core/app/models/spree/country.rb
+++ b/core/app/models/spree/country.rb
@@ -19,6 +19,10 @@ module Spree
     validates :name, :iso_name, :iso, :iso3, presence: true, uniqueness: { case_sensitive: false }
 
     def self.default(store = nil)
+      ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+        `Country#default` is deprecated and will be removed in Spree 5.0.
+        Please use `current_store.default_country` instead
+      DEPRECATION
       store ||= Spree::Store.default
       country_id = store.default_country_id
       default = find_by(id: country_id) if country_id.present?

--- a/core/app/models/spree/promotion/rules/country.rb
+++ b/core/app/models/spree/promotion/rules/country.rb
@@ -11,7 +11,7 @@ module Spree
 
         def eligible?(order, options = {})
           country_id = options[:country_id] || order.ship_address.try(:country_id)
-          unless country_id.eql?(preferred_country_id || Spree::Country.default)
+          unless country_id.eql?(preferred_country_id || order.store.default_country_id)
             eligibility_errors.add(:base, eligibility_error_message(:wrong_country))
           end
 

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -38,7 +38,7 @@ module Spree
                               size: { less_than_or_equal_to: 1.megabyte }
 
     before_save :ensure_default_exists_and_is_unique
-    before_save :ensure_supported_currencies, :ensure_supported_locales
+    before_save :ensure_supported_currencies, :ensure_supported_locales, :ensure_default_country
     before_destroy :validate_not_default
 
     scope :by_url, ->(url) { where('url like ?', "%#{url}%") }
@@ -149,6 +149,17 @@ module Spree
     def clear_cache
       Rails.cache.delete('default_store')
       Rails.cache.delete('stores_available_locales')
+    end
+
+    def ensure_default_country
+      return unless has_attribute?(:default_country_id)
+      return if default_country.present? && (checkout_zone.blank? || checkout_zone.country_list.blank? || checkout_zone.country_list.include?(default_country))
+
+      self.default_country = if checkout_zone.present? && checkout_zone.country_list.any?
+                               checkout_zone.country_list.first
+                             else
+                               Country.default
+                             end
     end
   end
 end

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -158,7 +158,7 @@ module Spree
       self.default_country = if checkout_zone.present? && checkout_zone.country_list.any?
                                checkout_zone.country_list.first
                              else
-                               Country.default
+                               Country.find_by(iso: 'US') || Country.first
                              end
     end
   end

--- a/core/app/services/spree/cart/estimate_shipping_rates.rb
+++ b/core/app/services/spree/cart/estimate_shipping_rates.rb
@@ -4,7 +4,7 @@ module Spree
       prepend Spree::ServiceModule::Base
 
       def call(order:, country_iso: nil)
-        country_id = country_id(country_iso)
+        country_id = country_id(order.store, country_iso)
         dummy_order = generate_dummy_order(order, country_id)
 
         packages = ::Spree::Stock::Coordinator.new(dummy_order).packages
@@ -20,11 +20,11 @@ module Spree
 
       private
 
-      def country_id(country_iso)
+      def country_id(store, country_iso)
         if country_iso.present?
           ::Spree::Country.by_iso(country_iso)&.id
         else
-          Spree::Config[:default_country_id]
+          store.default_country_id
         end
       end
 

--- a/core/db/migrate/20210608045519_ensure_store_default_country_is_set.rb
+++ b/core/db/migrate/20210608045519_ensure_store_default_country_is_set.rb
@@ -1,0 +1,5 @@
+class EnsureStoreDefaultCountryIsSet < ActiveRecord::Migration[5.2]
+  def change
+    Spree::Store.find_each(&:save)
+  end
+end

--- a/core/spec/models/spree/country_spec.rb
+++ b/core/spec/models/spree/country_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe Spree::Country, type: :model do
+  let(:store) { create(:store, default: true, default_country: america) }
   let(:america) { create :country }
   let(:canada)  { create :country, name: 'Canada', iso_name: 'CANADA', iso: 'CA', iso3: 'CAN', numcode: '124' }
 
@@ -95,15 +96,31 @@ describe Spree::Country, type: :model do
     end
   end
 
-  context '#default?' do
-    before { Spree::Config[:default_country_id] = america.id }
-
-    it 'returns true for default country' do
-      expect(america.default?).to eq(true)
+  describe '#default?' do
+    before do
+      allow_any_instance_of(Spree::Store).to receive(:default).and_return(store)
     end
 
-    it 'returns false for other countries' do
-      expect(canada.default?).to eq(false)
+    context 'no arguments' do
+      it 'returns true for store default country' do
+        expect(america.default?).to eq(true)
+      end
+
+      it 'returns false for other countries' do
+        expect(canada.default?).to eq(false)
+      end
+    end
+
+    context 'other store passed' do
+      let(:other_store) { create(:store, default_country: canada) }
+
+      it 'returns true for store default country' do
+        expect(canada.default?(other_store)).to eq(true)
+      end
+
+      it 'returns false for other countries' do
+        expect(america.default?(other_store)).to eq(false)
+      end
     end
   end
 end

--- a/core/spec/models/spree/promotion/rules/country_spec.rb
+++ b/core/spec/models/spree/promotion/rules/country_spec.rb
@@ -1,12 +1,11 @@
 require 'spec_helper'
 
 describe Spree::Promotion::Rules::Country, type: :model do
-  let(:rule) { Spree::Promotion::Rules::Country.new }
-  let(:order) { create(:order) }
+  let!(:store) { create(:store, default_country: other_country) }
+  let(:rule) { described_class.new }
+  let(:order) { create(:order, store: store) }
   let(:country) { create(:country) }
   let(:other_country) { create(:country) }
-
-  before { allow(Spree::Country).to receive(:default) { other_country } }
 
   context 'preferred country is set' do
     before { rule.preferred_country_id = country.id }

--- a/core/spec/models/spree/promotion/rules/country_spec.rb
+++ b/core/spec/models/spree/promotion/rules/country_spec.rb
@@ -6,7 +6,7 @@ describe Spree::Promotion::Rules::Country, type: :model do
   let(:country) { create(:country) }
   let(:other_country) { create(:country) }
 
-  before { allow(Spree::Country).to receive(:default) { other_country.id } }
+  before { allow(Spree::Country).to receive(:default) { other_country } }
 
   context 'preferred country is set' do
     before { rule.preferred_country_id = country.id }

--- a/frontend/app/controllers/spree/addresses_controller.rb
+++ b/frontend/app/controllers/spree/addresses_controller.rb
@@ -23,7 +23,7 @@ module Spree
     end
 
     def new
-      @address = Spree::Address.default
+      @address = try_spree_current_user.addresses.new(country: current_store.default_country)
     end
 
     def update

--- a/frontend/app/controllers/spree/addresses_controller.rb
+++ b/frontend/app/controllers/spree/addresses_controller.rb
@@ -23,7 +23,7 @@ module Spree
     end
 
     def new
-      @address = try_spree_current_user.addresses.new(country: current_store.default_country)
+      @address = Spree::Address.new(country: current_store.default_country, user: try_spree_current_user)
     end
 
     def update

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -141,8 +141,8 @@ module Spree
     def before_address
       # if the user has a default address, a callback takes care of setting
       # that; but if he doesn't, we need to build an empty one here
-      @order.bill_address ||= Address.build_default
-      @order.ship_address ||= Address.build_default if @order.checkout_steps.include?('delivery')
+      @order.bill_address ||= Address.new(country: current_store.default_country, user: try_spree_current_user)
+      @order.ship_address ||= Address.new(country: current_store.default_country, user: try_spree_current_user) if @order.checkout_steps.include?('delivery')
     end
 
     def before_delivery

--- a/frontend/app/helpers/spree/addresses_helper.rb
+++ b/frontend/app/helpers/spree/addresses_helper.rb
@@ -22,7 +22,7 @@ module Spree
     end
 
     def address_zipcode(form, country, address_id = 'b')
-      country ||= Spree::Country.default
+      country ||= address_default_country
       is_required = country.zipcode_required?
       method_name = Spree.t(:zipcode)
       required = Spree.t(:required)
@@ -38,7 +38,7 @@ module Spree
     end
 
     def address_state(form, country, address_id = 'b')
-      country ||= Spree::Country.find(Spree::Config[:default_country_id])
+      country ||= address_default_country
       have_states = country.states.any?
       state_elements = [
         form.collection_select(:state_id, checkout_zone_applicable_states_for(country).sort_by(&:name),
@@ -80,6 +80,10 @@ module Spree
 
     def checkout_zone_applicable_states_for(country)
       current_store.states_available_for_checkout(country)
+    end
+
+    def address_default_country
+      @address_default_country ||= current_store.default_country
     end
   end
 end

--- a/frontend/app/views/spree/checkout/_address.html.erb
+++ b/frontend/app/views/spree/checkout/_address.html.erb
@@ -54,7 +54,7 @@
               address_name: address_name,
               address_form: address_form,
               address_type: address_type,
-              address: Spree::Address.default,
+              address: Spree::Address.new(country: current_store.default_country),
               form: form
             } %>
           </div>

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -1,12 +1,15 @@
 require 'spec_helper'
 
 describe Spree::CheckoutController, type: :controller do
+  let(:store) { Spree::Store.default }
+  let(:country) { store.default_country }
+  let(:state) { country.states.first }
   let(:token) { 'some_token' }
   let(:user) { stub_model(Spree::LegacyUser) }
-  let(:order) { FactoryBot.create(:order_with_totals) }
+  let(:order) { create(:order_with_totals, store: store) }
 
   let(:address_params) do
-    address = FactoryBot.build(:address)
+    address = build(:address, country: country, state: state)
     address.attributes.except('created_at', 'updated_at')
   end
 
@@ -126,7 +129,8 @@ describe Spree::CheckoutController, type: :controller do
                  bill_address: bill_address,
                  ship_address: ship_address,
                  state: 'address',
-                 user: user)
+                 user: user,
+                 store: store)
         end
         let(:save_user_address) { true }
         let(:update_params) do
@@ -249,8 +253,8 @@ describe Spree::CheckoutController, type: :controller do
 
             context 'when default address is editable' do
               let(:use_billing) { false }
-              let(:bill_address_params) { build(:address, city: 'Chicago').attributes.merge(id: default_bill_address.id).except(:user_id, :created_at, :updated_at) }
-              let(:ship_address_params) { build(:address, city: 'Washington').attributes.merge(id: default_ship_address.id).except(:user_id, :created_at, :updated_at) }
+              let(:bill_address_params) { build(:address, city: 'Chicago', state: state).attributes.merge(id: default_bill_address.id).except(:user_id, :created_at, :updated_at) }
+              let(:ship_address_params) { build(:address, city: 'Washington', state: state).attributes.merge(id: default_ship_address.id).except(:user_id, :created_at, :updated_at) }
 
               it 'updates current addresses' do
                 expect(default_bill_address.city).to eq 'Herndon'
@@ -269,8 +273,8 @@ describe Spree::CheckoutController, type: :controller do
             context 'when default address is not editable' do
               let(:use_billing) { true }
               let!(:shipment) { create(:shipment, address: default_bill_address) }
-              let(:bill_address_params) { build(:address, city: 'Chicago').attributes.merge(id: default_bill_address.id).except(:user_id, :created_at, :updated_at) }
-              let(:ship_address_params) { build(:address, city: 'Washington').attributes.merge(id: default_ship_address.id).except(:user_id, :created_at, :updated_at) }
+              let(:bill_address_params) { build(:address, city: 'Chicago', state: state).attributes.merge(id: default_bill_address.id).except(:user_id, :created_at, :updated_at) }
+              let(:ship_address_params) { build(:address, city: 'Washington', state: state).attributes.merge(id: default_ship_address.id).except(:user_id, :created_at, :updated_at) }
               let(:created_address_id) { Spree::Address.find_by(city: 'Chicago').id }
 
               it_behaves_like 'default address not changed'
@@ -332,7 +336,7 @@ describe Spree::CheckoutController, type: :controller do
             context 'when submitted addresses already exist' do
               let!(:bill_address) { create(:address, city: 'Chicago', user: nil) }
               let!(:ship_address) { create(:address, city: 'Washington', user: nil) }
-              let(:order) { create(:order_with_totals, bill_address: nil, ship_address: nil, state: 'address', user: nil, email: 'example@email.com') }
+              let(:order) { create(:order_with_totals, store: store, bill_address: nil, ship_address: nil, state: 'address', user: nil, email: 'example@email.com') }
               let(:bill_address_params) { bill_address.attributes.except(:id, :user_id, :created_at, :updated_at) }
               let(:ship_address_params) { ship_address.attributes.except(:id, :user_id, :created_at, :updated_at) }
 
@@ -347,9 +351,9 @@ describe Spree::CheckoutController, type: :controller do
             end
 
             context 'when submitted addresses does not exist' do
-              let(:order) { create(:order_with_totals, bill_address: nil, ship_address: nil, state: 'address', user: nil, email: 'example@email.com') }
-              let(:bill_address_params) { build(:address, city: 'Chicago', user: nil).attributes.except(:user_id, :created_at, :updated_at) }
-              let(:ship_address_params) { build(:address, city: 'Washington', user: nil).attributes.except(:user_id, :created_at, :updated_at) }
+              let(:order) { create(:order_with_totals, store: store, bill_address: nil, ship_address: nil, state: 'address', user: nil, email: 'example@email.com') }
+              let(:bill_address_params) { build(:address, city: 'Chicago', user: nil, state: state).attributes.except(:user_id, :created_at, :updated_at) }
+              let(:ship_address_params) { build(:address, city: 'Washington', user: nil, state: state).attributes.except(:user_id, :created_at, :updated_at) }
 
               it 'keeps created addresses unassigned' do
                 update
@@ -364,7 +368,7 @@ describe Spree::CheckoutController, type: :controller do
             end
 
             context 'when attributes are invalid' do
-              let(:order) { create(:order_with_totals, bill_address: nil, ship_address: nil, state: 'address', user: nil, email: 'example@email.com') }
+              let(:order) { create(:order_with_totals, store: store, bill_address: nil, ship_address: nil, state: 'address', user: nil, email: 'example@email.com') }
               let(:bill_address_params) { build(:address, firstname: nil, city: 'Chicago', user: nil).attributes.except(:user_id, :created_at, :updated_at) }
               let(:ship_address_params) { build(:address, firstname: nil, city: 'Washington', user: nil).attributes.except(:user_id, :created_at, :updated_at) }
               let(:bill_address_error) { { "bill_address.firstname": ["can't be blank"] } }
@@ -467,7 +471,7 @@ describe Spree::CheckoutController, type: :controller do
 
             context 'when default address is not editable' do
               let!(:shipment) { create(:shipment, address: default_bill_address) }
-              let(:bill_address_params) { build(:address, city: 'Chicago').attributes.merge(id: default_bill_address.id).except(:user_id, :created_at, :updated_at) }
+              let(:bill_address_params) { build(:address, city: 'Chicago', state: state).attributes.merge(id: default_bill_address.id).except(:user_id, :created_at, :updated_at) }
               let(:created_address_id) { Spree::Address.find_by(city: 'Chicago').id }
 
               it_behaves_like 'default address not changed'
@@ -505,7 +509,7 @@ describe Spree::CheckoutController, type: :controller do
 
             context 'when submitted bill address already exists' do
               let!(:bill_address) { create(:address, city: 'Chicago', user: nil) }
-              let(:order) { create(:order_with_totals, bill_address: nil, ship_address: nil, state: 'address', user: nil, email: 'exaple@email.com') }
+              let(:order) { create(:order_with_totals, store: store, bill_address: nil, ship_address: nil, state: 'address', user: nil, email: 'exaple@email.com') }
               let(:bill_address_params) { bill_address.attributes.except(:id, :user_id, :created_at, :updated_at) }
 
               it 'keeps address unassigned' do
@@ -518,8 +522,8 @@ describe Spree::CheckoutController, type: :controller do
             end
 
             context 'when submitted bill address does not exits' do
-              let(:order) { create(:order_with_totals, bill_address: nil, ship_address: nil, state: 'address', user: nil, email: 'example@email.com') }
-              let(:bill_address_params) { build(:address, city: 'Chicago', user: nil).attributes.except(:user_id, :created_at, :updated_at) }
+              let(:order) { create(:order_with_totals, store: store, bill_address: nil, ship_address: nil, state: 'address', user: nil, email: 'example@email.com') }
+              let(:bill_address_params) { build(:address, city: 'Chicago', state: state, user: nil).attributes.except(:user_id, :created_at, :updated_at) }
 
               it 'keeps created address unassigned' do
                 update
@@ -531,7 +535,7 @@ describe Spree::CheckoutController, type: :controller do
             end
 
             context 'when attributes are invalid' do
-              let(:order) { create(:order_with_totals, bill_address: nil, ship_address: nil, state: 'address', user: nil, email: 'example@email.com') }
+              let(:order) { create(:order_with_totals, store: store, bill_address: nil, ship_address: nil, state: 'address', user: nil, email: 'example@email.com') }
               let(:bill_address_params) { build(:address, firstname: nil, city: 'Chicago', user: nil).attributes.except(:user_id, :created_at, :updated_at) }
               let(:bill_address_error) { { "bill_address.firstname": ["can't be blank"] } }
 
@@ -721,7 +725,7 @@ describe Spree::CheckoutController, type: :controller do
 
     context 'fails to transition from payment to complete' do
       let(:order) do
-        FactoryBot.create(:order_with_line_items).tap do |order|
+        create(:order_with_line_items, store: store).tap do |order|
           order.next! until order.state == 'payment'
           # So that the confirmation step is skipped and we get straight to the action.
           payment_method = FactoryBot.create(:simple_credit_card_payment_method)
@@ -747,7 +751,7 @@ describe Spree::CheckoutController, type: :controller do
     let(:product) { mock_model(Spree::Product, name: 'Amazing Object') }
     let(:variant) { mock_model(Spree::Variant) }
     let(:line_item) { mock_model Spree::LineItem, insufficient_stock?: true, amount: 0 }
-    let(:order) { create(:order_with_line_items) }
+    let(:order) { create(:order_with_line_items, store: store) }
 
     before do
       allow(order).to receive_messages(insufficient_stock_lines: [line_item], state: 'payment')
@@ -913,8 +917,8 @@ describe Spree::CheckoutController, type: :controller do
   context 'Address Book' do
     let!(:user) { create(:user) }
     let!(:variant) { create(:product, sku: 'Demo-SKU').master }
-    let!(:address) { create(:address, user: user) }
-    let!(:order) { create(:order, bill_address_id: nil, ship_address_id: nil, user: user, state: 'address') }
+    let!(:address) { create(:address, user: user, country: country, state: state) }
+    let!(:order) { create(:order, store: store, bill_address_id: nil, ship_address_id: nil, user: user, state: 'address') }
     let(:address_params) { address.value_attributes.merge(firstname: 'Something Else') }
 
     before do

--- a/frontend/spec/features/address_spec.rb
+++ b/frontend/spec/features/address_spec.rb
@@ -110,7 +110,7 @@ describe 'Address', type: :feature, inaccessible: true do
     let!(:canada) { create(:country, name: 'Canada', states_required: true, iso: 'CA', zipcode_required: true) }
     let!(:uk) { create(:country, name: 'United Kingdom', states_required: false, iso: 'UK', zipcode_required: true) }
 
-    before { Spree::Config[:default_country_id] = uk.id }
+    before { store.update(default_country: uk) }
 
     context 'but has no states in the database' do
       before do
@@ -204,7 +204,7 @@ describe 'Address', type: :feature, inaccessible: true do
     let!(:ug) { create(:country, name: 'Uganda', states_required: false, iso: 'UG', zipcode_required: false) }
 
     before do
-      Spree::Config[:default_country_id] = canada.id
+      store.update(default_country: canada)
 
       add_to_cart(mug) do
         click_link 'Checkout'
@@ -231,7 +231,7 @@ describe 'Address', type: :feature, inaccessible: true do
     let!(:ug) { create(:country, name: 'Uganda', states_required: false, iso: 'UG', zipcode_required: false) }
 
     before do
-      Spree::Config[:default_country_id] = ug.id
+      store.update!(default_country: ug)
 
       add_to_cart(mug) do
         click_link 'Checkout'

--- a/frontend/spec/features/automatic_promotion_adjustments_spec.rb
+++ b/frontend/spec/features/automatic_promotion_adjustments_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe 'Automatic promotions', type: :feature, js: true do
-  let!(:country) { create(:country, name: 'United States of America', states_required: true) }
+  let(:store) { Spree::Store.default }
+  let(:country) { store.default_country }
   let!(:product) { create(:product, name: 'RoR Mug', price: 20) }
 
   before do

--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'Checkout', type: :feature, inaccessible: true, js: true do
   include_context 'checkout setup'
 
-  let(:country) { create(:country, name: 'United States of America', iso_name: 'UNITED STATES') }
+  let(:country) { store.default_country }
   let(:state) { create(:state, name: 'Alabama', abbr: 'AL', country: country) }
   let(:store) { Spree::Store.default }
 

--- a/frontend/spec/features/coupon_code_spec.rb
+++ b/frontend/spec/features/coupon_code_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe 'Coupon code promotions', type: :feature, js: true do
-  let!(:country) { create(:country, name: 'United States of America', states_required: true) }
+  let(:store) { Spree::Store.default }
+  let(:country) { store.default_country }
   let!(:state) { create(:state, name: 'Alabama', country: country) }
   let!(:mug) { create(:product, name: 'RoR Mug', price: 20) }
 

--- a/frontend/spec/features/delivery_spec.rb
+++ b/frontend/spec/features/delivery_spec.rb
@@ -3,7 +3,8 @@ require 'spec_helper'
 describe 'Delivery', type: :feature, inaccessible: true, js: true do
   include_context 'checkout setup'
 
-  let(:country) { create(:country, name: 'United States of America', iso_name: 'UNITED STATES', iso: 'US') }
+  let(:store) { Spree::Store.default }
+  let(:country) { store.default_country }
   let(:state) { create(:state, name: 'Alabama', abbr: 'AL', country: country) }
   let(:user) { create(:user) }
   let(:promotion) { create(:promotion, name: 'Free Shipping', starts_at: 1.day.ago, expires_at: 1.day.from_now) }

--- a/frontend/spec/features/free_shipping_promotions_spec.rb
+++ b/frontend/spec/features/free_shipping_promotions_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe 'Free shipping promotions', type: :feature, js: true do
-  let!(:country) { create(:country, name: 'United States of America', states_required: true) }
+  let(:store) { Spree::Store.default }
+  let(:country) { store.default_country }
   let!(:state) { create(:state, name: 'Alabama', country: country) }
 
   before do

--- a/frontend/spec/helpers/store_helper_spec.rb
+++ b/frontend/spec/helpers/store_helper_spec.rb
@@ -22,10 +22,8 @@ module Spree
     end
 
     describe '#store_country_iso' do
-      let(:store_with_default_country) { build(:store, default_country: germany) }
-
       it { expect(store_country_iso(eu_store)).to eq('gr') }
-      it { expect(store_country_iso(Spree::Store.default)).to be_nil }
+      it { expect(store_country_iso(Spree::Store.default)).to eq('us') }
       it { expect { store_country_iso(nil) }.not_to raise_error }
     end
 

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -90,6 +90,9 @@ RSpec.configure do |config|
     DatabaseCleaner.start
     reset_spree_preferences
 
+    country = create(:country, name: 'United States of America', iso_name: 'UNITED STATES', iso: 'US', states_required: true)
+    Spree::Config[:default_country_id] = country.id
+
     create(:store, default: true)
     create(:taxon, permalink: 'trending')
     create(:taxon, permalink: 'bestsellers')

--- a/sample/db/samples/stores.rb
+++ b/sample/db/samples/stores.rb
@@ -1,6 +1,6 @@
 default_store = Spree::Store.default
 default_store.checkout_zone = Spree::Zone.find_by(name: 'North America')
-default_store.default_country = Spree::Country.default
+default_store.default_country = Spree::Country.find_by(iso: 'US')
 default_store.supported_currencies = 'CAD,USD'
 default_store.supported_locales = 'en,fr'
 default_store.url = Rails.env.development? ? 'localhost:3000' : 'demo.spreecommerce.org'


### PR DESCRIPTION
- [X] drop usage of `Spree::Config[:default_country_id]`
- [X] rely on `current_store.default_country` for Address forms and others
- [X] automatically switch to country inside the checkout zone if the previous selection is outside of the zone 