### PR TITLE
Use `load` instead of `require` when loading seeds

### DIFF
--- a/core/lib/tasks/core.rake
+++ b/core/lib/tasks/core.rake
@@ -8,7 +8,7 @@ use rake db:load_file[/absolute/path/to/sample/filename.rb]}
     file = Pathname.new(args.file)
 
     puts "loading ruby #{file}"
-    require file
+    load file
   end
 
   desc 'Loads fixtures from the the dir you specify using rake db:load_dir[loadfrom]'


### PR DESCRIPTION
Calling `require` will only load the file once per process, this works fine for calling the rake task manually because it's a different process every time, but it may cause problems when running it programatically (`Spree::Core::Engine.load_seed`) in long running services like a Delayed::Job worker (my use case). So it's best to use `load` instead, which executes the file every time it's called.

[Rails itself uses `load` to load seeds, not `require`](https://github.com/rails/rails/blob/v6.1.3.2/railties/lib/rails/engine.rb#L566).

As a patch, in my code I have replaced `Spree::Core::Engine.load_seed` with:

```ruby
spree_core_seed_files = Dir[Spree::Core::Engine.root.join('db/default/spree/**/*.rb')]
spree_core_seed_files.sort.each { |path| load path }
```