### PR TITLE
Small Fix to Menu Sample Data + Add Active Class to Spree Menu Links

### DIFF
--- a/core/app/models/spree/menu.rb
+++ b/core/app/models/spree/menu.rb
@@ -11,7 +11,7 @@ module Spree
     has_many :menu_items, dependent: :destroy
     belongs_to :store, touch: true
 
-    before_validation :paremeterize_location
+    before_validation :parameterize_location
     after_create :set_root
     after_save :update_root_name
     after_touch :touch_store
@@ -39,7 +39,7 @@ module Spree
 
     private
 
-    def paremeterize_location
+    def parameterize_location
       return unless location.present?
 
       self.location = location.parameterize(separator: '_')

--- a/core/spec/models/spree/menu_spec.rb
+++ b/core/spec/models/spree/menu_spec.rb
@@ -80,7 +80,7 @@ describe Spree::Menu, type: :model do
       expect(described_class.new(name: 'BBB', location: 'Footer', locale: 'en', store: store_2)).to be_valid
     end
 
-    it '.paremeterize_location parametizes the location' do
+    it '.parameterize_location parametizes the location' do
       expect(menu.location).to eql('footer')
     end
 

--- a/frontend/app/assets/stylesheets/spree/frontend/views/spree/shared/main_nav_bar.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/views/spree/shared/main_nav_bar.scss
@@ -28,6 +28,14 @@
       }
     }
 
+    #{$self}-button.active {
+      color: $header-font-color;
+      text-decoration: none;
+      &:after {
+        border-bottom-color: $header-font-color;
+      }
+    }
+
     .dropdown-item {
       width: auto;
       padding: 0;

--- a/frontend/app/helpers/spree/navigation_helper.rb
+++ b/frontend/app/helpers/spree/navigation_helper.rb
@@ -88,7 +88,14 @@ module Spree
         rel = opts[:rel] || 'noopener noreferrer'
       end
 
-      link_opts = { target: target, rel: rel, class: opts[:class], id: opts[:id], data: opts[:data], aria: opts[:aria] }
+      active_class = if current_page?(spree_localized_link(item))
+                       "active #{opts[:class]}"
+                     else
+                       opts[:class]
+                     end
+
+      link_opts = { target: target, rel: rel, class: active_class, id: opts[:id], data: opts[:data], aria: opts[:aria] }
+
       if block_given?
         link_to spree_localized_link(item), link_opts, &block
       else

--- a/frontend/app/helpers/spree/navigation_helper.rb
+++ b/frontend/app/helpers/spree/navigation_helper.rb
@@ -88,7 +88,7 @@ module Spree
         rel = opts[:rel] || 'noopener noreferrer'
       end
 
-      active_class = if current_page?(spree_localized_link(item))
+      active_class = if request && current_page?(spree_localized_link(item))
                        "active #{opts[:class]}"
                      else
                        opts[:class]

--- a/sample/db/samples/menu_items.rb
+++ b/sample/db/samples/menu_items.rb
@@ -219,7 +219,7 @@ MENUS.each do |menu|
       name: promo_a_name,
       subtitle: promo_a_subtitle,
       linked_resource_type: 'Spree::Taxon',
-      item_type: 'Container',
+      item_type: 'Link',
       menu_id: menu,
       parent_id: promo
     ).first_or_create!
@@ -230,7 +230,7 @@ MENUS.each do |menu|
       name: promo_b_name,
       subtitle: promo_b_subtitle,
       linked_resource_type: 'Spree::Taxon',
-      item_type: 'Container',
+      item_type: 'Link',
       menu_id: menu,
       parent_id: promo
     ).first_or_create!


### PR DESCRIPTION
- Fix Sample data. (wrong link type on promotion links in main menu).
- Add active class to `spree_nav_link_tag`.
- Fix spelling on `parameterize_location` method.