### PR TITLE
Return only Store resources in Storefront API, Platform API and Storefront UI

### DIFF
--- a/api/app/controllers/spree/api/v2/platform/resource_controller.rb
+++ b/api/app/controllers/spree/api/v2/platform/resource_controller.rb
@@ -61,7 +61,7 @@ module Spree
           def scope
             return super if spree_current_user.present?
 
-            model_class.includes(scope_includes)
+            super(skip_cancancan: true)
           end
 
           # We're overwriting this method because the original one calls `dookreeper_authorize`

--- a/api/app/controllers/spree/api/v2/resource_controller.rb
+++ b/api/app/controllers/spree/api/v2/resource_controller.rb
@@ -27,15 +27,17 @@ module Spree
         end
 
         def scope
-          base_scope = if model_class.respond_to?(:store_id)
-                         model_class.where(store_id: current_store.id)
-                       elsif model_class.respond_to?(:for_store)
-                         model_class.for_store(current_store)
+          plural_model_name = model_class.model_name.plural.gsub(/spree_/, '').to_sym
+
+          base_scope = if current_store.respond_to?(plural_model_name)
+                         current_store.send(plural_model_name)
                        else
                          model_class
                        end
 
-          base_scope.accessible_by(current_ability, :show).includes(scope_includes)
+          base_scope = base_scope.accessible_by(current_ability, :show)
+          base_scope = base_scope.includes(scope_includes) if scope_includes.any?
+          base_scope
         end
 
         def scope_includes

--- a/api/app/controllers/spree/api/v2/resource_controller.rb
+++ b/api/app/controllers/spree/api/v2/resource_controller.rb
@@ -26,7 +26,7 @@ module Spree
           [:id, :name, :number, :updated_at, :created_at]
         end
 
-        def scope
+        def scope(skip_cancancan: false)
           plural_model_name = model_class.model_name.plural.gsub(/spree_/, '').to_sym
 
           base_scope = if current_store.respond_to?(plural_model_name)
@@ -35,7 +35,7 @@ module Spree
                          model_class
                        end
 
-          base_scope = base_scope.accessible_by(current_ability, :show)
+          base_scope = base_scope.accessible_by(current_ability, :show) unless skip_cancancan
           base_scope = base_scope.includes(scope_includes) if scope_includes.any?
           base_scope
         end

--- a/api/app/controllers/spree/api/v2/resource_controller.rb
+++ b/api/app/controllers/spree/api/v2/resource_controller.rb
@@ -27,7 +27,15 @@ module Spree
         end
 
         def scope
-          model_class.accessible_by(current_ability, :show).includes(scope_includes)
+          base_scope = if model_class.respond_to?(:store_id)
+                         model_class.where(store_id: current_store.id)
+                       elsif model_class.respond_to?(:for_store)
+                         model_class.for_store(current_store)
+                       else
+                         model_class
+                       end
+
+          base_scope.accessible_by(current_ability, :show).includes(scope_includes)
         end
 
         def scope_includes
@@ -36,7 +44,7 @@ module Spree
 
         def resource
           @resource ||= if defined?(resource_finder)
-                          resource_finder.new(scope: scope, params: params).execute
+                          resource_finder.new(scope: scope, params: finder_params).execute
                         else
                           scope.find(params[:id])
                         end
@@ -44,10 +52,19 @@ module Spree
 
         def collection
           @collection ||= if defined?(collection_finder)
-                            collection_finder.new(scope: scope, params: params).execute
+                            collection_finder.new(scope: scope, params: finder_params).execute
                           else
                             scope
                           end
+        end
+
+        def finder_params
+          params.merge(
+            store: current_store,
+            locale: current_locale,
+            currency: current_currency,
+            user: spree_current_user
+          )
         end
 
         def collection_sorter

--- a/api/app/controllers/spree/api/v2/storefront/account/addresses_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/account/addresses_controller.rb
@@ -33,7 +33,7 @@ module Spree
             private
 
             def collection
-              collection_finder.new(scope: scope, params: params).execute
+              collection_finder.new(scope: scope, params: finder_params).execute
             end
 
             def scope

--- a/api/app/controllers/spree/api/v2/storefront/account/orders_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/account/orders_controller.rb
@@ -9,11 +9,11 @@ module Spree
             private
 
             def collection
-              collection_finder.new(user: spree_current_user).execute
+              collection_finder.new(user: spree_current_user, store: current_store).execute
             end
 
             def resource
-              resource = resource_finder.new(user: spree_current_user, number: params[:id]).execute.take
+              resource = resource_finder.new(user: spree_current_user, number: params[:id], store: current_store).execute.take
               raise ActiveRecord::RecordNotFound if resource.nil?
 
               resource

--- a/api/app/controllers/spree/api/v2/storefront/order_status_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/order_status_controller.rb
@@ -10,7 +10,7 @@ module Spree
           private
 
           def resource
-            resource = resource_finder.new(number: params[:number], token: order_token).execute.take
+            resource = resource_finder.new(number: params[:number], token: order_token, store: current_store).execute.take
             raise ActiveRecord::RecordNotFound if resource.nil?
 
             resource

--- a/api/app/controllers/spree/api/v2/storefront/products_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/products_controller.rb
@@ -3,7 +3,7 @@ module Spree
     module V2
       module Storefront
         class ProductsController < ::Spree::Api::V2::ResourceController
-          private
+          protected
 
           def sorted_collection
             collection_sorter.new(collection, current_currency, params, allowed_sort_attributes).call
@@ -35,6 +35,10 @@ module Spree
 
           def model_class
             Spree::Product
+          end
+
+          def scope
+            current_store.products.accessible_by(current_ability, :show).includes(scope_includes)
           end
 
           def scope_includes

--- a/api/app/controllers/spree/api/v2/storefront/products_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/products_controller.rb
@@ -10,7 +10,7 @@ module Spree
           end
 
           def collection
-            @collection ||= collection_finder.new(scope: scope, params: params, current_currency: current_currency).execute
+            @collection ||= collection_finder.new(scope: scope, params: finder_params).execute
           end
 
           def resource
@@ -35,10 +35,6 @@ module Spree
 
           def model_class
             Spree::Product
-          end
-
-          def scope
-            current_store.products.accessible_by(current_ability, :show).includes(scope_includes)
           end
 
           def scope_includes

--- a/api/spec/controllers/spree/api/v1/checkouts_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/checkouts_controller_spec.rb
@@ -4,6 +4,8 @@ module Spree
   describe Api::V1::CheckoutsController, type: :controller do
     render_views
 
+    let(:store) { Spree::Store.default }
+
     shared_examples_for 'action which loads order using load_order_with_lock' do
       before do
         allow(controller).to receive(:load_order).with(true).and_return(true)
@@ -44,7 +46,7 @@ module Spree
       create(:stock_location)
 
       @shipping_method = create(:shipping_method, zones: [country_zone])
-      @payment_method = create(:credit_card_payment_method)
+      @payment_method = create(:credit_card_payment_method, stores: [store], display_on: 'both')
     end
 
     after do
@@ -53,7 +55,7 @@ module Spree
 
     context "PUT 'update'" do
       let(:order) do
-        order = create(:order_with_line_items)
+        order = create(:order_with_line_items, store: store)
         # Order should be in a pristine state
         # Without doing this, the order may transition from 'cart' straight to 'delivery'
         Spree::ShippingRate.where(shipment_id: order.shipment_ids).delete_all
@@ -305,7 +307,7 @@ module Spree
     end
 
     context "PUT 'next'" do
-      let!(:order) { create(:order_with_line_items) }
+      let!(:order) { create(:order_with_line_items, store: store) }
 
       it 'cannot transition to address without a line item' do
         order.line_items.delete_all
@@ -355,7 +357,7 @@ module Spree
     end
 
     context "PUT 'advance'" do
-      let!(:order) { create(:order_with_line_items) }
+      let!(:order) { create(:order_with_line_items, store: store) }
 
       it 'continues to advance advances an order while it can move forward' do
         expect_any_instance_of(Spree::Order).to receive(:next).exactly(3).times.and_return(true, true, false)

--- a/api/spec/controllers/spree/api/v1/payments_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/payments_controller_spec.rb
@@ -3,7 +3,8 @@ require 'spec_helper'
 module Spree
   describe Api::V1::PaymentsController, type: :controller do
     render_views
-    let!(:order) { create(:order) }
+    let(:store) { Spree::Store.default }
+    let!(:order) { create(:order, store: store) }
     let!(:payment) { create(:payment, order: order) }
     let!(:attributes) do
       [:id, :source_type, :source_id, :amount, :display_amount,

--- a/api/spec/controllers/spree/api/v2/resource_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v2/resource_controller_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+class ApiV2DummyController < Spree::Api::V2::ResourceController
+  private
+
+  def model_class
+    Spree::Order
+  end
+end
+
+describe Spree::Api::V2::ResourceController, type: :controller do
+  let(:dummy_controller) { ApiV2DummyController.new }
+  let(:store) { Spree::Store.default }
+
+  describe '#finder_params' do
+    let(:currency) { store.default_currency }
+    let(:locale) { store.default_locale }
+    let(:user) { nil }
+    let(:params) { {} }
+
+    shared_examples 'returns proper values' do
+      before do
+        allow(dummy_controller).to receive(:current_store).and_return(store)
+        allow(dummy_controller).to receive(:current_currency).and_return(currency)
+        allow(dummy_controller).to receive(:current_locale).and_return(locale)
+        allow(dummy_controller).to receive(:spree_current_user).and_return(user)
+        allow(dummy_controller).to receive(:params).and_return(params)
+      end
+
+      it do
+        expect(dummy_controller.send(:finder_params)).to eq(
+          params.merge(
+            store: store,
+            currency: currency,
+            user: user,
+            locale: locale
+          )
+        )
+      end
+    end
+
+    context 'default values' do
+      it_behaves_like 'returns proper values'
+    end
+
+    context 'non-default values' do
+      let(:user) { create(:user) }
+      let(:currency) { 'EUR' }
+      let(:locale) { 'de' }
+      let(:store) { create(:store, default_locale: locale, default_currency: currency) }
+      let(:params) { { filter: {}, page: 1, per_page: 10 } }
+
+      it_behaves_like 'returns proper values'
+    end
+  end
+end

--- a/api/spec/controllers/spree/api/v2/resource_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v2/resource_controller_spec.rb
@@ -4,7 +4,7 @@ class ApiV2DummyController < Spree::Api::V2::ResourceController
   private
 
   def model_class
-    Spree::Order
+    Spree::Product
   end
 end
 
@@ -52,5 +52,22 @@ describe Spree::Api::V2::ResourceController, type: :controller do
 
       it_behaves_like 'returns proper values'
     end
+  end
+
+  describe '#collection' do
+    let!(:product) { create(:product, stores: [store]) }
+    let!(:product_from_another_store) { create(:product, stores: [create(:store)]) }
+    let(:collection) { dummy_controller.send(:collection) }
+
+    before do
+      dummy_controller.params = {}
+      allow(dummy_controller).to receive(:current_store).and_return(store)
+      allow(dummy_controller).to receive(:spree_current_user).and_return(nil)
+    end
+
+    it { expect(collection.first).to be_instance_of(Spree::Product) }
+    it { expect(collection.count).to eq(store.products.count) }
+    it { expect(collection.map(&:id)).to include(product.id) }
+    it { expect(collection.map(&:id)).not_to include(product_from_another_store.id) }
   end
 end

--- a/api/spec/requests/spree/api/v2/storefront/order_status_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/order_status_spec.rb
@@ -1,7 +1,10 @@
 require 'spec_helper'
 
 describe 'Storefront API v2 OrderStatus spec', type: :request do
-  let!(:order) { create(:order, state: 'complete', completed_at: Time.current) }
+  let(:store) { Spree::Store.default }
+  let!(:order) { create(:order, state: 'complete', completed_at: Time.current, store: store) }
+  let(:store_2) { create(:store) }
+  let(:order_2) { create(:order, state: 'complete', completed_at: Time.current, store: store_2) }
 
   include_context 'API v2 tokens'
 
@@ -32,12 +35,19 @@ describe 'Storefront API v2 OrderStatus spec', type: :request do
       context 'as a guest user with valid token' do
         before { get "/api/v2/storefront/order_status/#{order.number}", headers: headers_order_token }
 
+        it_behaves_like 'returns 200 HTTP status'
         it_behaves_like 'returns valid cart JSON'
       end
     end
 
     context 'with non-existing Order number' do
       before { get '/api/v2/storefront/order_status/1' }
+
+      it_behaves_like 'returns 404 HTTP status'
+    end
+
+    context 'with Order from different Store' do
+      before { get "/api/v2/storefront/order_status/#{order_2.number}", headers: headers_order_token }
 
       it_behaves_like 'returns 404 HTTP status'
     end

--- a/core/app/finders/spree/orders/find_complete.rb
+++ b/core/app/finders/spree/orders/find_complete.rb
@@ -1,18 +1,20 @@
 module Spree
   module Orders
     class FindComplete
-      attr_reader :user, :number, :token
+      attr_reader :user, :number, :token, :store
 
-      def initialize(user: nil, number: nil, token: nil)
+      def initialize(user: nil, number: nil, token: nil, store: nil)
         @user = user
         @number = number
         @token = token
+        @store = store
       end
 
       def execute
         orders = by_user(scope)
         orders = by_number(orders)
         orders = by_token(orders)
+        orders = by_store(orders)
 
         orders
       end
@@ -35,6 +37,10 @@ module Spree
         token.present?
       end
 
+      def store?
+        store.present?
+      end
+
       def by_user(orders)
         return orders unless user?
 
@@ -51,6 +57,12 @@ module Spree
         return orders unless token?
 
         orders.where(token: token)
+      end
+
+      def by_store(orders)
+        return orders unless store?
+
+        orders.where(store: store)
       end
 
       def scope_includes

--- a/core/app/finders/spree/products/find.rb
+++ b/core/app/finders/spree/products/find.rb
@@ -1,13 +1,22 @@
 module Spree
   module Products
     class Find
-      def initialize(scope:, params:, current_currency:)
+      def initialize(scope:, params:, current_currency: nil)
         @scope = scope
+
+        ActiveSupport::Deprecation.warn('`current_currency` param is deprecated and will be removed in Spree 5') if current_currency
+
+        if current_currency.present?
+          ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+            `current_currency` param is deprecated and will be removed in Spree 5.
+            Please pass `:currency` in `params` hash instead.
+          DEPRECATION
+        end
 
         @ids              = String(params.dig(:filter, :ids)).split(',')
         @skus             = String(params.dig(:filter, :skus)).split(',')
         @price            = map_prices(String(params.dig(:filter, :price)).split(','))
-        @currency         = current_currency
+        @currency         = current_currency || params.dig(:filter, :currency) || params[:currency]
         @taxons           = taxon_ids(params.dig(:filter, :taxons))
         @concat_taxons    = taxon_ids(params.dig(:filter, :concat_taxons))
         @name             = params.dig(:filter, :name)

--- a/core/app/finders/spree/stores/find_current.rb
+++ b/core/app/finders/spree/stores/find_current.rb
@@ -1,0 +1,24 @@
+module Spree
+  module Stores
+    class FindCurrent
+      def initialize(scope: nil, url: nil)
+        @scope = scope || Spree::Store
+        @url = url
+      end
+
+      def execute
+        by_url(scope) || scope.default
+      end
+
+      protected
+
+      attr_reader :scope, :url
+
+      def by_url(scope)
+        return if url.blank?
+
+        scope.by_url(url).first
+      end
+    end
+  end
+end

--- a/core/app/helpers/spree/products_helper.rb
+++ b/core/app/helpers/spree/products_helper.rb
@@ -131,7 +131,7 @@ module Spree
 
       return [] if product_ids.empty?
 
-      Spree::Product.
+      current_store.products.
         available.not_discontinued.distinct.
         where(id: product_ids).
         includes(

--- a/core/app/mailers/spree/base_mailer.rb
+++ b/core/app/mailers/spree/base_mailer.rb
@@ -3,7 +3,7 @@ module Spree
     helper Spree::MailHelper
 
     def current_store
-      @current_store ||= Spree::Store.current
+      @current_store ||= Spree::Dependencies.current_store_finder.constantize.new.execute
     end
     helper_method :current_store
 

--- a/core/app/mailers/spree/reimbursement_mailer.rb
+++ b/core/app/mailers/spree/reimbursement_mailer.rb
@@ -3,7 +3,7 @@ module Spree
     def reimbursement_email(reimbursement, resend = false)
       @reimbursement = reimbursement.respond_to?(:id) ? reimbursement : Spree::Reimbursement.find(reimbursement)
       @order = @reimbursement.order
-      current_store = @reimbursement.store || Spree::Store.current
+      current_store = @reimbursement.store || Spree::Store.default
       subject = (resend ? "[#{Spree.t(:resend).upcase}] " : '')
       subject += "#{current_store.name} #{Spree.t('reimbursement_mailer.reimbursement_email.subject')} ##{@order.number}"
       mail(to: @order.email, from: current_store.mail_from_address, subject: subject, store_url: current_store.url)

--- a/core/app/mailers/spree/test_mailer.rb
+++ b/core/app/mailers/spree/test_mailer.rb
@@ -1,7 +1,7 @@
 module Spree
   class TestMailer < BaseMailer
     def test_email(email)
-      subject = "#{Spree::Store.current.name} #{Spree.t('test_mailer.test_email.subject')}"
+      subject = "#{Spree::Store.default.name} #{Spree.t('test_mailer.test_email.subject')}"
       mail(to: email, from: from_address, subject: subject)
     end
   end

--- a/core/app/models/concerns/spree/multiple_stores_resource.rb
+++ b/core/app/models/concerns/spree/multiple_stores_resource.rb
@@ -1,0 +1,9 @@
+module Spree
+  module MultipleStoresResource
+    extend ActiveSupport::Concern
+
+    included do
+      scope :for_store, ->(store) { joins(:stores).where(Store.table_name => { id: store.id }) }
+    end
+  end
+end

--- a/core/app/models/concerns/spree/product_scopes.rb
+++ b/core/app/models/concerns/spree/product_scopes.rb
@@ -62,10 +62,6 @@ module Spree
         where("#{price_table_name}.amount >= ?", price)
       end
 
-      add_search_scope :by_store do |store|
-        joins(:stores).where(Spree::StoreProduct.table_name => { store_id: store.id })
-      end
-
       # This scope selects products in taxon AND all its descendants
       # If you need products only within one taxon use
       #
@@ -250,10 +246,9 @@ module Spree
       end
       search_scopes << :active
 
-      def self.for_filters(currency, taxon: nil, store: nil)
+      def self.for_filters(currency, taxon: nil)
         scope = active(currency)
         scope = scope.in_taxon(taxon) if taxon.present?
-        scope = scope.by_store(store) if store.present?
         scope
       end
       search_scopes << :for_filters

--- a/core/app/models/spree/app_dependencies.rb
+++ b/core/app/models/spree/app_dependencies.rb
@@ -13,7 +13,7 @@ module Spree
       :completed_order_finder, :order_sorter, :cart_compare_line_items_service, :collection_paginator, :products_sorter,
       :products_finder, :taxon_finder, :line_item_by_variant_finder, :cart_estimate_shipping_rates_service,
       :account_create_address_service, :account_update_address_service, :account_create_service, :account_update_service,
-      :address_finder, :collection_sorter, :error_handler
+      :address_finder, :collection_sorter, :error_handler, :current_store_finder
     ].freeze
 
     attr_accessor *INJECTION_POINTS
@@ -77,6 +77,7 @@ module Spree
       @country_finder = 'Spree::Countries::Find'
       @menu_finder = 'Spree::Menus::Find'
       @current_order_finder = 'Spree::Orders::FindCurrent'
+      @current_store_finder = 'Spree::Stores::FindCurrent'
       @completed_order_finder = 'Spree::Orders::FindComplete'
       @credit_card_finder = 'Spree::CreditCards::Find'
       @products_finder = 'Spree::Products::Find'

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -389,6 +389,10 @@ module Spree
     end
 
     def available_payment_methods(store = nil)
+      if store.present?
+        ActiveSupport::Deprecation.warn('The `store` parameter is deprecated and will be removed in Spree 5. Order is already associated with Store')
+      end
+
       @available_payment_methods ||= collect_payment_methods(store)
     end
 
@@ -627,12 +631,12 @@ module Spree
 
     def validate_payments_attributes(attributes)
       # Ensure the payment methods specified are allowed for this user
-      payment_methods = Spree::PaymentMethod.where(id: available_payment_methods.map(&:id))
-      attributes.each do |payment_attributes|
-        payment_method_id = payment_attributes[:payment_method_id]
+      payment_method_ids = available_payment_methods.map(&:id)
 
-        # raise RecordNotFound unless it is an allowed payment method
-        payment_methods.find(payment_method_id) if payment_method_id
+      attributes.each do |payment_attributes|
+        payment_method_id = payment_attributes[:payment_method_id].to_i
+
+        raise ActiveRecord::RecordNotFound unless payment_method_ids.include?(payment_method_id)
       end
     end
 
@@ -725,7 +729,12 @@ module Spree
     end
 
     def collect_payment_methods(store = nil)
-      PaymentMethod.available_on_front_end.select { |pm| pm.available_for_order?(self) && pm.available_for_store?(store) }
+      if store.present?
+        ActiveSupport::Deprecation.warn('The `store` parameter is deprecated and will be removed in Spree 5. Order is already associated with Store')
+      end
+      store ||= self.store
+
+      PaymentMethod.for_store(store).available_on_front_end.select { |pm| pm.available_for_order?(self) }
     end
 
     def credit_card_nil_payment?(attributes)

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -3,6 +3,8 @@ module Spree
     acts_as_paranoid
     acts_as_list
 
+    include MultipleStoresResource
+
     DISPLAY = [:both, :front_end, :back_end].freeze
 
     scope :active,                 -> { where(active: true).order(position: :asc) }

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -21,7 +21,8 @@
 module Spree
   class Product < Spree::Base
     extend FriendlyId
-    include Spree::ProductScopes
+    include ProductScopes
+    include MultipleStoresResource
 
     friendly_id :slug_candidates, use: :history
 

--- a/core/app/models/spree/promotion/rules/first_order.rb
+++ b/core/app/models/spree/promotion/rules/first_order.rb
@@ -30,6 +30,7 @@ module Spree
         end
 
         def orders_by_email
+          # FIXME: this will need a change after we associate Promotion with Store
           Spree::Order.where(email: email).complete
         end
       end

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -47,9 +47,12 @@ module Spree
 
     alias_attribute :contact_email, :customer_support_email
 
-    def self.current(domain = nil)
-      current_store = domain ? Store.by_url(domain).first : nil
-      current_store || Store.default
+    def self.current(url = nil)
+      ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+        `Spree::Store.default` is deprecated and will be removed in Spree 5
+        Spree::Stores::FindCurrent.new(url: "http://example.com") instead
+      DEPRECATION
+      Stores::FindCurrent.new(url: url).execute
     end
 
     def self.default

--- a/core/app/services/spree/cart/create.rb
+++ b/core/app/services/spree/cart/create.rb
@@ -6,9 +6,12 @@ module Spree
       def call(user:, store:, currency:, order_params: nil)
         order_params ||= {}
 
+        # we cannot create an order without store
+        return failure(:store_is_required) if store.nil?
+
         default_params = {
           user: user,
-          currency: currency,
+          currency: currency || store.default_currency,
           token: Spree::GenerateToken.new.call(Spree::Order)
         }
 

--- a/core/app/services/spree/cart/create.rb
+++ b/core/app/services/spree/cart/create.rb
@@ -8,12 +8,11 @@ module Spree
 
         default_params = {
           user: user,
-          store: store,
           currency: currency,
           token: Spree::GenerateToken.new.call(Spree::Order)
         }
 
-        order = Spree::Order.create!(default_params.merge(order_params))
+        order = store.orders.create!(default_params.merge(order_params))
         success(order)
       end
     end

--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -19,7 +19,7 @@ module Spree
             @simple_current_order.last_ip_address = ip_address
             return @simple_current_order
           else
-            @simple_current_order = Spree::Order.new
+            @simple_current_order = current_store.orders.new
           end
         end
 
@@ -36,7 +36,7 @@ module Spree
           @current_order = find_order_by_token_or_user(options, true)
 
           if options[:create_order_if_necessary] && (@current_order.nil? || @current_order.completed?)
-            @current_order = Spree::Order.create!(current_order_params)
+            @current_order = current_store.orders.create!(current_order_params)
             @current_order.associate_user! try_spree_current_user if try_spree_current_user
             @current_order.last_ip_address = ip_address
           end
@@ -75,7 +75,7 @@ module Spree
         end
 
         def current_order_params
-          { currency: current_currency, token: cookies.signed[:token], store_id: current_store.id, user_id: try_spree_current_user.try(:id) }
+          { currency: current_currency, token: cookies.signed[:token], user_id: try_spree_current_user.try(:id) }
         end
 
         def find_order_by_token_or_user(options = {}, with_adjustments = false)
@@ -88,7 +88,7 @@ module Spree
                      end
 
           # Find any incomplete orders for the token
-          incomplete_orders = Spree::Order.incomplete.includes(includes)
+          incomplete_orders = current_store.orders.incomplete.includes(includes)
 
           token_order_params = current_order_params.except(:user_id)
           order = if with_adjustments

--- a/core/lib/spree/core/controller_helpers/search.rb
+++ b/core/lib/spree/core/controller_helpers/search.rb
@@ -6,6 +6,7 @@ module Spree
           Spree::Config.searcher_class.new(params).tap do |searcher|
             searcher.current_user = try_spree_current_user
             searcher.current_currency = current_currency&.upcase
+            searcher.current_store = current_store
           end
         end
       end

--- a/core/lib/spree/core/controller_helpers/store.rb
+++ b/core/lib/spree/core/controller_helpers/store.rb
@@ -11,7 +11,7 @@ module Spree
         end
 
         def current_store
-          @current_store ||= Spree::Store.current(request.env['SERVER_NAME'])
+          @current_store ||= current_store_finder.new(url: request.env['HTTP_SERVER_NAME']).execute
         end
 
         def available_menus
@@ -48,6 +48,10 @@ module Spree
 
         def current_tax_zone
           @current_tax_zone ||= @current_order&.tax_zone || Spree::Zone.default_tax
+        end
+
+        def current_store_finder
+          Spree::Dependencies.current_store_finder.constantize
         end
       end
     end

--- a/core/lib/spree/core/search/base.rb
+++ b/core/lib/spree/core/search/base.rb
@@ -7,7 +7,7 @@ module Spree
         def initialize(params)
           @properties = {}
           @current_currency = Spree::Config[:currency]
-          @current_store = params[:current_store]
+          @current_store = params[:current_store] || Spree::Store.default
           @taxon = params[:taxon]
 
           prepare(params)
@@ -28,8 +28,7 @@ module Spree
         protected
 
         def extended_base_scope
-          base_scope = Spree::Product.spree_base_scopes
-          base_scope = base_scope.by_store(current_store) if current_store.present?
+          base_scope = current_store.products.spree_base_scopes
           base_scope = get_products_conditions_for(base_scope, keywords)
           base_scope = Spree::Dependencies.products_finder.constantize.new(
             scope: base_scope,

--- a/core/lib/spree/core/search/base.rb
+++ b/core/lib/spree/core/search/base.rb
@@ -6,8 +6,8 @@ module Spree
 
         def initialize(params)
           @properties = {}
-          @current_currency = Spree::Config[:currency]
           @current_store = params[:current_store] || Spree::Store.default
+          @current_currency = @current_store.default_currency
           @taxon = params[:taxon]
 
           prepare(params)
@@ -37,11 +37,11 @@ module Spree
                 price: price,
                 option_value_ids: option_value_ids,
                 properties: product_properties,
-                taxons: taxon&.id
+                taxons: taxon&.id,
+                currency: current_currency
               },
               sort_by: sort_by
-            },
-            current_currency: current_currency
+            }
           ).execute
           base_scope = add_search_scopes(base_scope)
           add_eagerload_scopes(base_scope)

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     bill_address
     store
     completed_at { nil }
-    email        { user.email }
+    email        { user&.email }
     currency     { 'USD' }
 
     transient do

--- a/core/lib/spree/testing_support/factories/product_factory.rb
+++ b/core/lib/spree/testing_support/factories/product_factory.rb
@@ -19,7 +19,7 @@ FactoryBot.define do
     before(:create) do |product, evaluator|
       if evaluator.with_store && product.stores.empty?
         default_store = Spree::Store.default.persisted? ? Spree::Store.default : nil
-        store = default_store || create(:store)
+        store = default_store || create(:store, default: true)
 
         product.stores << store
       end

--- a/core/lib/spree/testing_support/order_walkthrough.rb
+++ b/core/lib/spree/testing_support/order_walkthrough.rb
@@ -1,12 +1,12 @@
 class OrderWalkthrough
-  def self.up_to(state)
-    store = if Spree::Store.exists?
-              # Ensure the default store is used
-              Spree::Store.default || FactoryBot.create(:store, default: true)
-            else
-              # Create a default store
-              FactoryBot.create(:store, default: true)
-            end
+  def self.up_to(state, store = nil)
+    store ||= if Spree::Store.exists?
+                # Ensure the default store is used
+                Spree::Store.default || FactoryBot.create(:store, default: true)
+              else
+                # Create a default store
+                FactoryBot.create(:store, default: true)
+              end
 
     # A payment method must exist for an order to proceed through the Address state
     unless Spree::PaymentMethod.exists?

--- a/core/lib/spree/testing_support/order_walkthrough.rb
+++ b/core/lib/spree/testing_support/order_walkthrough.rb
@@ -28,7 +28,7 @@ class OrderWalkthrough
       end
     end
 
-    order = Spree::Order.create!(email: 'spree@example.com')
+    order = store.orders.create!(email: 'spree@example.com')
     add_line_item!(order)
     order.next!
 

--- a/core/spec/finders/spree/products/find_spec.rb
+++ b/core/spec/finders/spree/products/find_spec.rb
@@ -16,7 +16,7 @@ module Spree
             ids: '',
             skus: '',
             price: '',
-            currency: false,
+            currency: 'USD',
             taxons: '',
             concat_taxons: '',
             name: false,
@@ -29,8 +29,7 @@ module Spree
         expect(
           described_class.new(
             scope: Spree::Product.all,
-            params: params,
-            current_currency: 'USD'
+            params: params
           ).execute
         ).to include(product, product_2, discontinued_product)
       end
@@ -45,8 +44,8 @@ module Spree
             ids: '',
             skus: '',
             price: '',
-            currency: false,
             taxons: '',
+            currency: 'USD',
             concat_taxons: '',
             name: false,
             options: false,
@@ -58,8 +57,7 @@ module Spree
         expect(
           described_class.new(
             scope: Spree::Product.all,
-            params: params,
-            current_currency: 'USD'
+            params: params
           ).execute
         ).to include(product, product_2, deleted_product)
       end
@@ -72,7 +70,7 @@ module Spree
             ids: '',
             skus: '',
             price: '',
-            currency: false,
+            currency: 'USD',
             taxons: '',
             concat_taxons: '',
             name: false,
@@ -85,8 +83,7 @@ module Spree
         expect(
           described_class.new(
             scope: Spree::Product.all,
-            params: params,
-            current_currency: 'USD'
+            params: params
           ).execute
         ).to include(product, product_2)
       end
@@ -96,8 +93,7 @@ module Spree
       subject(:products) do
         described_class.new(
           scope: Spree::Product.all,
-          params: params,
-          current_currency: 'USD'
+          params: params
         ).execute
       end
 
@@ -166,8 +162,7 @@ module Spree
       subject(:products) do
         described_class.new(
             scope: Spree::Product.all,
-            params: params,
-            current_currency: 'USD'
+            params: params
         ).execute
       end
 
@@ -261,8 +256,7 @@ module Spree
       subject(:products) do
         described_class.new(
           scope: Spree::Product.all,
-          params: params,
-          current_currency: 'USD'
+          params: params
         ).execute
       end
 
@@ -293,8 +287,7 @@ module Spree
       subject(:products) do
         described_class.new(
           scope: Spree::Product.all,
-          params: params,
-          current_currency: 'USD'
+          params: params
         ).execute
       end
 
@@ -365,8 +358,7 @@ module Spree
         subject(:products) do
           described_class.new(
             scope: Spree::Product.all,
-            params: params,
-            current_currency: 'USD'
+            params: params
           ).execute
         end
 
@@ -411,8 +403,7 @@ module Spree
 
         product_ids = described_class.new(
           scope: Spree::Product.all,
-          params: params,
-          current_currency: 'USD'
+          params: params
         ).execute.map(&:id)
 
         expect(product_ids).to eq Spree::Product.available.order(available_on: :desc).map(&:id)
@@ -425,8 +416,7 @@ module Spree
 
         products = described_class.new(
           scope: Spree::Product.all,
-          params: params,
-          current_currency: 'USD'
+          params: params
         ).execute.to_a
 
         expect(products).to eq [product_2, product_3, product]
@@ -439,8 +429,7 @@ module Spree
 
         products = described_class.new(
           scope: Spree::Product.all,
-          params: params,
-          current_currency: 'USD'
+          params: params
         ).execute
 
         expect(products).to eq [product, product_3, product_2]
@@ -453,8 +442,7 @@ module Spree
 
         products = described_class.new(
           scope: Spree::Product.all,
-          params: params,
-          current_currency: 'USD'
+          params: params
         ).execute
 
         expect(products).to eq [product, product_2, product_3]
@@ -467,8 +455,7 @@ module Spree
 
         products = described_class.new(
           scope: Spree::Product.all,
-          params: params,
-          current_currency: 'USD'
+          params: params
         ).execute
 
         expect(products).to eq [product_3, product_2, product]

--- a/core/spec/finders/spree/stores/find_current_spec.rb
+++ b/core/spec/finders/spree/stores/find_current_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+module Spree
+  describe Stores::FindCurrent do
+    subject { described_class.new(scope: scope, url: url).execute }
+
+    let!(:store) { create(:store, default: true) }
+    let!(:store_2) { create(:store, url: 'another.com', default_currency: 'GBP') }
+
+    let(:scope) { nil }
+    let(:url) { nil }
+
+    context 'no arguments' do
+      it { expect(subject).to eq(store) }
+    end
+
+    context 'existing store' do
+      let(:url) { 'another.com' }
+
+      it { expect(subject).to eq(store_2) }
+    end
+
+    context 'non-existing store' do
+      let(:url) { 'something-different.com' }
+
+      it { expect(subject).to eq(store) }
+    end
+
+    context 'with scope' do
+      let(:scope) { Spree::Store.where(default_currency: 'GBP') }
+      let(:url) { 'another.com' }
+
+      it { expect(subject).to eq(store_2) }
+    end
+  end
+end

--- a/core/spec/lib/search/base_spec.rb
+++ b/core/spec/lib/search/base_spec.rb
@@ -105,13 +105,13 @@ describe Spree::Core::Search::Base do
 
     let!(:products_for_eu_store) do
       (1..3).map do |v|
-        create(:product, name: "P-EU-#{v}", stores: [eu_store])
+        create(:product, name: "P-EU-#{v}", stores: [eu_store], currency: 'EUR')
       end
     end
 
     let!(:products_for_uk_store) do
       (1..2).map do |v|
-        create(:product, name: "P-UK-#{v}", stores: [uk_store])
+        create(:product, name: "P-UK-#{v}", stores: [uk_store], currency: 'GBP')
       end
     end
 
@@ -154,23 +154,6 @@ describe Spree::Core::Search::Base do
         it 'returns only products from Spree store' do
           expect(retrieved_products).to contain_exactly(product_for_spree_store)
         end
-      end
-    end
-
-    context 'current store is not given in params' do
-      let(:params) { { current_store: nil } }
-
-      it 'returns 8 products' do
-        expect(retrieved_products.count).to eq(8)
-      end
-
-      it 'returns products from all stores' do
-        expect(retrieved_products).to contain_exactly(
-          product1, product2,
-          product_for_spree_store,
-          *products_for_eu_store,
-          *products_for_uk_store
-        )
       end
     end
   end

--- a/core/spec/lib/spree/core/controller_helpers/order_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/order_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 class FakesController < ApplicationController
   include Spree::Core::ControllerHelpers::Store
   include Spree::Core::ControllerHelpers::Order
+  include Spree::Core::ControllerHelpers::Currency
+  include Spree::Core::ControllerHelpers::Locale
 end
 
 describe Spree::Core::ControllerHelpers::Order, type: :controller do
@@ -52,8 +54,8 @@ describe Spree::Core::ControllerHelpers::Order, type: :controller do
     end
 
     context 'gets using the token' do
-      let!(:order)       { create :order, user: user }
-      let!(:guest_order) { create :order, user: nil, email: nil, token: 'token' }
+      let!(:order)       { create :order, user: user, store: store }
+      let!(:guest_order) { create :order, user: nil, email: nil, token: 'token', store: store }
 
       before do
         expect(controller).to receive(:current_order_params).and_return(

--- a/core/spec/lib/spree/core/controller_helpers/store_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/store_spec.rb
@@ -14,9 +14,34 @@ describe Spree::Core::ControllerHelpers::Store, type: :controller do
 
   describe '#current_store' do
     let!(:store) { create :store, default: true }
+    let!(:store_2) { create :store, url: 'another.com' }
 
-    it 'returns current store' do
-      expect(controller.current_store).to eq store
+    context 'default store' do
+      it 'returns current store' do
+        expect(controller.current_store).to eq store
+      end
+    end
+
+    context 'by domain' do
+      before do
+        controller.request.env['HTTP_SERVER_NAME'] = 'another.com'
+      end
+
+      it 'returns current store' do
+        expect(controller.current_store).to eq store_2
+      end
+    end
+
+    context 'by subdomain' do
+      let!(:store_3) { create :store, url: 'some.another.com' }
+
+      before do
+        controller.request.env['HTTP_SERVER_NAME'] = 'some.another.com'
+      end
+
+      it 'returns current store' do
+        expect(controller.current_store).to eq store_3
+      end
     end
   end
 

--- a/core/spec/mailers/order_mailer_spec.rb
+++ b/core/spec/mailers/order_mailer_spec.rb
@@ -41,7 +41,7 @@ describe Spree::OrderMailer, type: :mailer do
   context ':from not set explicitly' do
     it 'falls back to spree config' do
       message = Spree::OrderMailer.confirm_email(order)
-      expect(message.from).to eq([Spree::Store.current.mail_from_address])
+      expect(message.from).to eq([Spree::Store.default.mail_from_address])
     end
   end
 

--- a/core/spec/mailers/reimbursement_mailer_spec.rb
+++ b/core/spec/mailers/reimbursement_mailer_spec.rb
@@ -10,7 +10,7 @@ describe Spree::ReimbursementMailer, type: :mailer do
   context ':from not set explicitly' do
     it 'falls back to spree config' do
       message = Spree::ReimbursementMailer.reimbursement_email(reimbursement)
-      expect(message.from).to eq [Spree::Store.current.mail_from_address]
+      expect(message.from).to eq [Spree::Store.default.mail_from_address]
     end
   end
 

--- a/core/spec/mailers/shipment_mailer_spec.rb
+++ b/core/spec/mailers/shipment_mailer_spec.rb
@@ -23,7 +23,7 @@ describe Spree::ShipmentMailer, type: :mailer do
   context ':from not set explicitly' do
     it 'falls back to spree config' do
       message = Spree::ShipmentMailer.shipped_email(shipment)
-      expect(message.from).to eq([Spree::Store.current.mail_from_address])
+      expect(message.from).to eq([Spree::Store.default.mail_from_address])
     end
   end
 

--- a/core/spec/mailers/test_mailer_spec.rb
+++ b/core/spec/mailers/test_mailer_spec.rb
@@ -12,7 +12,7 @@ describe Spree::TestMailer, type: :mailer do
   context ':from not set explicitly' do
     it 'falls back to spree config' do
       message = Spree::TestMailer.test_email('test@example.com')
-      expect(message.from).to eq([Spree::Store.current.mail_from_address])
+      expect(message.from).to eq([Spree::Store.default.mail_from_address])
     end
   end
 
@@ -26,7 +26,7 @@ describe Spree::TestMailer, type: :mailer do
     it 'falls back to spree store url' do
       ActionMailer::Base.default_url_options = {}
       Spree::TestMailer.test_email('test@example.com').deliver_now
-      expect(ActionMailer::Base.default_url_options[:host]).to eq(Spree::Store.current.url)
+      expect(ActionMailer::Base.default_url_options[:host]).to eq(Spree::Store.default.url)
     end
 
     it 'uses developer set host' do

--- a/core/spec/models/spree/order/payment_spec.rb
+++ b/core/spec/models/spree/order/payment_spec.rb
@@ -120,8 +120,9 @@ module Spree
       end
 
       it 'keeps source attributes after updating' do
-        persisted_order = Spree::Order.create
-        credit_card_payment_method = create(:credit_card_payment_method)
+        store = create(:store)
+        persisted_order = create(:order, store: store)
+        credit_card_payment_method = create(:credit_card_payment_method, stores: [store])
         attributes = {
           payments_attributes: [
             {

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -8,10 +8,10 @@ end
 
 describe Spree::Order, type: :model do
   let(:user) { stub_model(Spree::LegacyUser, email: 'spree@example.com') }
-  let(:order) { stub_model(Spree::Order, user: user) }
+  let(:store) { create(:store, default: true) }
+  let(:order) { stub_model(Spree::Order, user: user, store: store) }
 
   before do
-    create(:store)
     allow(Spree::LegacyUser).to receive_messages(current: mock_model(Spree::LegacyUser, id: 123))
   end
 
@@ -47,7 +47,7 @@ describe Spree::Order, type: :model do
   end
 
   context '#cancel' do
-    let(:order) { create(:completed_order_with_totals) }
+    let(:order) { create(:completed_order_with_totals, store: store) }
     let!(:payment) do
       create(
         :payment,
@@ -125,7 +125,7 @@ describe Spree::Order, type: :model do
   end
 
   context '#finalize!' do
-    let(:order) { Spree::Order.create(email: 'test@example.com') }
+    let(:order) { Spree::Order.create(email: 'test@example.com', store: store) }
 
     before do
       order.update_column :state, 'complete'
@@ -511,28 +511,35 @@ describe Spree::Order, type: :model do
 
   # Regression test for #4199
   context '#available_payment_methods' do
-    let(:ok_method) { double :payment_method, available_for_order?: true, available_for_store?: true }
-    let(:no_method) { double :payment_method, available_for_order?: false, available_for_store?: true }
+    let(:ok_method) { double :payment_method, available_for_order?: true, available_for_store?: true, stores: [store] }
+    let(:no_method) { double :payment_method, available_for_order?: false, available_for_store?: true, stores: [store] }
     let(:methods) { [ok_method, no_method] }
+    let(:store_2) { create(:store) }
 
     it 'includes frontend payment methods' do
       payment_method = Spree::PaymentMethod.create!(name: 'Fake',
                                                     active: true,
-                                                    display_on: 'front_end')
+                                                    display_on: 'front_end',
+                                                    stores: [store]
+                                                   )
       expect(order.available_payment_methods).to include(payment_method)
     end
 
     it "includes 'both' payment methods" do
       payment_method = Spree::PaymentMethod.create!(name: 'Fake',
                                                     active: true,
-                                                    display_on: 'both')
+                                                    display_on: 'both',
+                                                    stores: [store]
+                                                   )
       expect(order.available_payment_methods).to include(payment_method)
     end
 
     it 'does not include a payment method twice if display_on is blank' do
       payment_method = Spree::PaymentMethod.create!(name: 'Fake',
                                                     active: true,
-                                                    display_on: 'both')
+                                                    display_on: 'both',
+                                                    stores: [store]
+                                                   )
       expect(order.available_payment_methods.count).to eq(1)
       expect(order.available_payment_methods).to include(payment_method)
     end
@@ -541,6 +548,18 @@ describe Spree::Order, type: :model do
       allow(Spree::PaymentMethod).to receive(:available_on_front_end).and_return(methods)
 
       expect(order.available_payment_methods).to match_array [ok_method]
+    end
+
+    it 'does not include a payment method from different stores' do
+      payment_method = Spree::PaymentMethod.create!(name: 'Fake',
+                                                    active: true,
+                                                    display_on: 'both',
+                                                    stores: [store_2]
+                                                   )
+      expect(order.available_payment_methods).not_to include(payment_method)
+
+      order = stub_model(Spree::Order, user: user, store: store_2)
+      expect(order.available_payment_methods).to include(payment_method)
     end
   end
 
@@ -1107,7 +1126,7 @@ describe Spree::Order, type: :model do
   end
 
   describe '#validate_payments_attributes' do
-    let(:payment_method) { create(:credit_card_payment_method) }
+    let(:payment_method) { create(:credit_card_payment_method, stores: [store]) }
     let(:attributes) do
       [{ amount: 50, payment_method_id: payment_method.id }]
     end
@@ -1119,7 +1138,7 @@ describe Spree::Order, type: :model do
     end
 
     context 'not existing payment method' do
-      let(:payment_method) { create(:credit_card_payment_method, display_on: 'backend') }
+      let(:payment_method) { create(:credit_card_payment_method, display_on: 'backend', stores: [store]) }
 
       it 'raises RecordNotFound' do
         expect { order.validate_payments_attributes(attributes) }.to raise_error(ActiveRecord::RecordNotFound)
@@ -1150,8 +1169,8 @@ describe Spree::Order, type: :model do
   end
 
   describe 'credit_card_nil_payment' do
-    let!(:order) { create(:order_with_line_items, line_items_count: 2) }
-    let!(:credit_card_payment_method) { create(:simple_credit_card_payment_method) }
+    let!(:order) { create(:order_with_line_items, line_items_count: 2, store: store) }
+    let!(:credit_card_payment_method) { create(:simple_credit_card_payment_method, stores: [store]) }
     let!(:store_credits) { create(:store_credit_payment, order: order) }
 
     def attributes(amount = 0)

--- a/core/spec/models/spree/payment_method_spec.rb
+++ b/core/spec/models/spree/payment_method_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Spree::PaymentMethod, type: :model do
+  let(:store) { create(:store) }
+
   context 'visibility scopes' do
     before do
       [nil, '', 'both', 'front_end', 'back_end'].each do |display_on|
@@ -8,7 +10,8 @@ describe Spree::PaymentMethod, type: :model do
           name: 'Display Both',
           display_on: display_on,
           active: true,
-          description: 'foofah'
+          description: 'foofah',
+          stores: [store]
         )
       end
     end
@@ -38,6 +41,21 @@ describe Spree::PaymentMethod, type: :model do
         methods = Spree::PaymentMethod.available_on_back_end
         expect(methods.size).to eq(2)
         expect(methods.pluck(:display_on)).to eq(['both', 'back_end'])
+      end
+    end
+
+    describe '#for_store' do
+      it 'returns all methods available to front-end/back-end for a store' do
+        store_2 = create(:store)
+        method_from_other_store = Spree::Gateway::Test.create(
+          name: 'Display Both',
+          active: true,
+          description: 'foofah',
+          stores: [store_2]
+        )
+        methods = Spree::PaymentMethod.for_store(store)
+        expect(methods).not_to include(method_from_other_store)
+        expect(methods.size).to eq(5)
       end
     end
   end

--- a/core/spec/models/spree/product/scopes_spec.rb
+++ b/core/spec/models/spree/product/scopes_spec.rb
@@ -43,11 +43,8 @@ describe 'Product scopes', type: :model do
     let(:taxon_1) { create(:taxon) }
     let(:taxon_2) { create(:taxon) }
 
-    let(:store_1) { create(:store) }
-    let(:store_2) { create(:store) }
-
-    let!(:product_1) { create(:product, currency: 'GBP', taxons: [taxon_1], stores: [store_1]) }
-    let!(:product_2) { create(:product, currency: 'GBP', taxons: [taxon_2], stores: [store_2]) }
+    let!(:product_1) { create(:product, currency: 'GBP', taxons: [taxon_1]) }
+    let!(:product_2) { create(:product, currency: 'GBP', taxons: [taxon_2]) }
 
     before do
       create(:product, currency: 'USD', taxons: [create(:taxon)])
@@ -55,18 +52,6 @@ describe 'Product scopes', type: :model do
 
     context 'when giving a taxon' do
       it { expect(subject.call('GBP', taxon: taxon_1)).to contain_exactly(product_1) }
-    end
-
-    context 'when giving a store' do
-      it { expect(subject.call('GBP', store: store_2)).to contain_exactly(product_2) }
-    end
-
-    context 'when giving both taxon and store' do
-      it { expect(subject.call('GBP', taxon: taxon_1, store: store_1)).to contain_exactly(product_1) }
-    end
-
-    context 'when giving no taxon and store' do
-      it { expect(subject.call('GBP')).to contain_exactly(product_1, product_2) }
     end
 
     context 'when giving a currency with no products' do
@@ -321,8 +306,8 @@ describe 'Product scopes', type: :model do
     end
   end
 
-  context '#by_store' do
-    subject(:products_by_store) { Spree::Product.by_store(store) }
+  describe '#for_store' do
+    subject(:products_by_store) { Spree::Product.for_store(store) }
 
     let(:store) { create(:store) }
 

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -723,37 +723,37 @@ describe Spree::Product, type: :model do
       end
     end
   end
-end
 
-describe '#default_variant_cache_key' do
-  let(:product) { create(:product) }
-  let(:key) { product.send(:default_variant_cache_key) }
+  describe '#default_variant_cache_key' do
+    let(:product) { create(:product) }
+    let(:key) { product.send(:default_variant_cache_key) }
 
-  context 'with inventory tracking' do
-    before { Spree::Config[:track_inventory_levels] = true }
+    context 'with inventory tracking' do
+      before { Spree::Config[:track_inventory_levels] = true }
 
-    it 'returns proper key' do
-      expect(key).to eq("spree/default-variant/#{product.cache_key_with_version}/true")
+      it 'returns proper key' do
+        expect(key).to eq("spree/default-variant/#{product.cache_key_with_version}/true")
+      end
     end
-  end
 
-  context 'without invenrtory tracking' do
-    before { Spree::Config[:track_inventory_levels] = false }
+    context 'without invenrtory tracking' do
+      before { Spree::Config[:track_inventory_levels] = false }
 
-    it 'returns proper key' do
-      expect(key).to eq("spree/default-variant/#{product.cache_key_with_version}/false")
+      it 'returns proper key' do
+        expect(key).to eq("spree/default-variant/#{product.cache_key_with_version}/false")
+      end
     end
-  end
 
-  describe '#requires_shipping_category?' do
-    let(:product) { build(:product, shipping_category: nil) }
+    describe '#requires_shipping_category?' do
+      let(:product) { build(:product, shipping_category: nil) }
 
-    it { expect(product.save).to eq(false) }
-  end
+      it { expect(product.save).to eq(false) }
+    end
 
-  describe '#downcase_slug' do
-    let(:product) { build(:product, slug: 'My-slug') }
+    describe '#downcase_slug' do
+      let(:product) { build(:product, slug: 'My-slug') }
 
-    it { expect { product.valid? }.to change(product, :slug).to('my-slug') }
+      it { expect { product.valid? }.to change(product, :slug).to('my-slug') }
+    end
   end
 end

--- a/core/spec/services/spree/cart/create_spec.rb
+++ b/core/spec/services/spree/cart/create_spec.rb
@@ -5,7 +5,7 @@ module Spree
     subject { described_class }
 
     let(:user) { create :user }
-    let(:store) { create :store }
+    let(:store) { create :store, default_currency: 'EUR' }
     let(:currency) { 'USD' }
     let(:expected) { Order.first }
 
@@ -24,7 +24,7 @@ module Spree
     context 'create an order with store in params' do
       let(:store_2) { create :store }
       let(:order_params) { { store: store_2, currency: 'XVII' } }
-      let(:execute) { subject.call user: user, store: store, currency: currency, order_params: order_params }
+      let(:execute) { subject.call user: user, store: store_2, currency: currency, order_params: order_params }
       let(:value) { execute.value }
 
       it do
@@ -38,18 +38,30 @@ module Spree
       end
     end
 
-    context 'create an order when no store and currency pass in params' do
-      let!(:default_store) { create :store, default: true }
-      let(:execute) { subject.call user: user, store: nil, currency: nil }
+    context 'create an order with store currency' do
+      let(:order_params) { { store: store, currency: nil } }
+      let(:execute) { subject.call user: user, store: store, currency: currency, order_params: order_params }
       let(:value) { execute.value }
 
       it do
         expect { execute }.to change(Order, :count)
         expect(execute).to be_success
         expect(value).to eq expected
-        expect(expected.currency).to eq Spree::Config[:currency]
-        expect(expected.store).to eq Spree::Store.default
+        expect(expected.user).to eq user
+        expect(expected.store).to eq store
+        expect(expected.currency).to eq 'EUR'
         expect(expected.number).to be_present
+      end
+    end
+
+    context 'returns failure when no store is passed' do
+      let!(:default_store) { create :store, default: true }
+      let(:execute) { subject.call user: user, store: nil, currency: nil }
+      let(:value) { execute.value }
+
+      it do
+        expect { execute }.not_to change(Order, :count)
+        expect(execute).to be_failure
       end
     end
   end

--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -10,7 +10,7 @@ module Spree
     before_action :assign_order_with_lock, only: :update
 
     def show
-      @order = Order.includes(line_items: [variant: [:option_values, :images, :product]], bill_address: :state, ship_address: :state).find_by!(number: params[:id])
+      @order = current_store.orders.includes(line_items: [variant: [:option_values, :images, :product]], bill_address: :state, ship_address: :state).find_by!(number: params[:id])
     end
 
     def update
@@ -33,7 +33,7 @@ module Spree
 
     # Shows the current incomplete order from the session
     def edit
-      @order = current_order || Order.incomplete.
+      @order = current_order || current_store.orders.incomplete.
                includes(line_items: [variant: [:images, :product, option_values: :option_type]]).
                find_or_initialize_by(token: cookies.signed[:token])
       associate_user
@@ -56,7 +56,7 @@ module Spree
     end
 
     def check_authorization
-      order = Spree::Order.find_by(number: params[:id]) if params[:id].present?
+      order = current_store.orders.find_by(number: params[:id]) if params[:id].present?
       order ||= current_order
 
       if order && action_name.to_sym == :show

--- a/frontend/app/controllers/spree/products_controller.rb
+++ b/frontend/app/controllers/spree/products_controller.rb
@@ -54,7 +54,7 @@ module Spree
     end
 
     def load_product
-      @product = Product.for_user(try_spree_current_user).friendly.find(params[:id])
+      @product = current_store.products.for_user(try_spree_current_user).friendly.find(params[:id])
     end
 
     def load_taxon

--- a/frontend/app/helpers/spree/frontend_helper.rb
+++ b/frontend/app/helpers/spree/frontend_helper.rb
@@ -344,7 +344,7 @@ module Spree
     end
 
     def checkout_available_payment_methods
-      @checkout_available_payment_methods ||= @order.available_payment_methods(current_store)
+      @checkout_available_payment_methods ||= @order.available_payment_methods
     end
 
     def color_option_type_name

--- a/frontend/app/helpers/spree/frontend_helper.rb
+++ b/frontend/app/helpers/spree/frontend_helper.rb
@@ -388,11 +388,13 @@ module Spree
     end
 
     def products_for_filters_cache_key
-      [
-        products_for_filters.maximum(:updated_at).to_f,
-        base_cache_key,
-        @taxon&.permalink
-      ].flatten.compact
+      @products_for_filters_cache_key ||= begin
+        [
+          products_for_filters.maximum(:updated_at).to_f,
+          base_cache_key,
+          @taxon&.permalink
+        ].flatten.compact
+      end
     end
   end
 end

--- a/frontend/app/helpers/spree/frontend_helper.rb
+++ b/frontend/app/helpers/spree/frontend_helper.rb
@@ -384,7 +384,7 @@ module Spree
     end
 
     def products_for_filters
-      Product.for_filters(current_currency, taxon: @taxon, store: current_store)
+      @products_for_filters ||= current_store.products.for_filters(current_currency, taxon: @taxon)
     end
 
     def products_for_filters_cache_key

--- a/frontend/spec/controllers/spree/products_controller_spec.rb
+++ b/frontend/spec/controllers/spree/products_controller_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe Spree::ProductsController, type: :controller do
   let!(:product) { create(:product, available_on: 1.year.from_now) }
+  let(:product_from_other_store) { create(:product, stores: [create(:store)]) }
   let(:taxon) { create(:taxon) }
 
   # Regression test for #1390
@@ -13,6 +14,10 @@ describe Spree::ProductsController, type: :controller do
 
   it 'cannot view non-active products' do
     expect { get :show, params: { id: product.to_param } }.to raise_error(ActiveRecord::RecordNotFound)
+  end
+
+  it 'cannot view products from other store' do
+    expect { get :show, params: { id: product_from_other_store.to_param } }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
   it 'provides the current user to the searcher class' do

--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -596,7 +596,7 @@ describe 'Checkout', type: :feature, inaccessible: true, js: true do
 
   context 'when order is completed' do
     let!(:user) { create(:user) }
-    let!(:order) { create(:order) }
+    let!(:order) { create(:order, store: store) }
 
     before do
       add_mug_to_cart

--- a/guides/src/content/release_notes/4_3_0.md
+++ b/guides/src/content/release_notes/4_3_0.md
@@ -38,17 +38,34 @@ Please review each of the noteworthy changes to ensure your customizations or ex
 ### Storefront
 
 * Upgraded **Sprockets** to **v4** and added support for **ES6**, **Source Maps** and **Manifest.js**  [Spark Solutions](https://github.com/spree/spree/pull/10852)
+* **Multi-Store** Only Store Orders are returned [Spark Solutions](https://github.com/spree/spree/pull/11126/commits/a694445a99a41f36825666fe04f73f020951fa2e)
+* **Multi-Store** Only Store Products are returned [Spark Solutions](https://github.com/spree/spree/pull/11126/commits/e72ced9330e371211027d7a3371792d8fd5ed6e1)
 
 ### API
 
 * Added caching to API v2 serialized increasing API responsivenes 3-5 times [Spark Solutions](https://github.com/spree/spree/pull/10875)
 
     This also includes new confirmation option `Spree::Api::Config[:api_v2_cache_ttl]` for the cache expiration period. Defualt value is `3600` (1 hour). Cache auto-expires when record is updated, more on this topic: https://github.com/jsonapi-serializer/jsonapi-serializer#caching
-* 
+    
+* **Multi-Store** Storefront Products API returns Products from the current Store [Spark Solutions](https://github.com/spree/spree/pull/11126)
+* **Multi-Store** Storefront Account Orders API returns Orders from the current Store [Spark Solutions](https://github.com/spree/spree/pull/11126)
+* **Multi-Store** Storefront Order Status API returns Order from the current Store [Spark Solutions](https://github.com/spree/spree/pull/11126)
 
 ### Admin Panel
 
 ### Core
+
+* **Multi-Store** `Order#available_payment_methods` by default will return only Payment Methods available in Order's Store [Spark Solutions](https://github.com/spree/spree/pull/11126/commits/8f52301c8178e04bb1aa6a03cde5ebb9f0063cbb)
+
+    Passing `store` argument to that method will result in deprecation warning
+* **Multi-Store** Deprecated `Store.current` in favour of ` Stores::FindCurrent` [Spark Solutions](https://github.com/spree/spree/pull/11126/commits/f3414d67b92a2b1d2eb920abab95ff48ab8afd72)
+
+  Also this finder class can be repleced by custom one by setting 
+  
+  ```ruby
+  Spree::Dependencies.current_store_finder = YourCustomStoreFinder
+  ``` 
+  in `config/initializers/spree.rb` (please check [documentation](https://guides.spreecommerce.org/developer/customization/dependencies.html))
 
 ## Full Changelog
 


### PR DESCRIPTION
Storefront API, Platform API and Storefront will now return Store:
- [x] Products
- [x] Payment Methods
- [x] Orders

Resources from other stores will not be returned :)

TODO: 
- [x] add more tests for fetching store resources vs not accessing other stores resources
- [x] add more tests for `Product#for_store`
- [x] add more tests for `PaymentMethod#for_store`
- [x] add tests for  `Api::V2::Resourcecontroller#finder_params`
- [x] add more tests for Platform API as well
- [x] add tests for API v2 store switching

There will be required more work for Emails, but this will need to wait after https://github.com/spree/spree/pull/11110 is merged

Admin panel is handled in https://github.com/spree/spree/pull/11099