### PR TITLE
SD-1340 Add missing timestamps to join tables

### DIFF
--- a/core/db/migrate/20210702112334_add_missing_timestamp_columns.rb
+++ b/core/db/migrate/20210702112334_add_missing_timestamp_columns.rb
@@ -1,37 +1,46 @@
 class AddMissingTimestampColumns < ActiveRecord::Migration[5.2]
   def change
     # Add missing created_at columns
-    add_column :spree_promotion_actions, :created_at, :datetime
-    add_column :spree_roles, :created_at, :datetime
-    add_column :spree_promotion_rule_taxons, :created_at, :datetime
-    add_column :spree_products_taxons, :created_at, :datetime
-    add_column :spree_reimbursement_credits, :created_at, :datetime
-    add_column :spree_promotion_rule_users, :created_at, :datetime
-    add_column :spree_promotion_action_line_items, :created_at, :datetime
-    add_column :spree_states, :created_at, :datetime
-    add_column :spree_option_type_prototypes, :created_at, :datetime
-    add_column :spree_order_promotions, :created_at, :datetime
-    add_column :spree_product_promotion_rules, :created_at, :datetime
-    add_column :spree_role_users, :created_at, :datetime
-    add_column :spree_shipping_method_zones, :created_at, :datetime
-    add_column :spree_option_value_variants, :created_at, :datetime
-    add_column :spree_property_prototypes, :created_at, :datetime
-    add_column :spree_countries, :created_at, :datetime
-    add_column :spree_prototype_taxons, :created_at, :datetime
+    %i[
+      spree_countries
+      spree_option_type_prototypes
+      spree_option_value_variants
+      spree_order_promotions
+      spree_product_promotion_rules
+      spree_products_taxons
+      spree_promotion_action_line_items
+      spree_promotion_actions
+      spree_promotion_rule_taxons
+      spree_promotion_rule_users
+      spree_property_prototypes
+      spree_prototype_taxons
+      spree_reimbursement_credits
+      spree_role_users
+      spree_roles
+      spree_shipping_method_zones
+      spree_states
+    ].each do |table|
+      add_column table, :created_at, :datetime unless column_exists?(table, :created_at)
+    end
     # Add missing updated_at columns
-    add_column :spree_promotion_actions, :updated_at, :datetime
-    add_column :spree_roles, :updated_at, :datetime
-    add_column :spree_promotion_rule_taxons, :updated_at, :datetime
-    add_column :spree_products_taxons, :updated_at, :datetime
-    add_column :spree_reimbursement_credits, :updated_at, :datetime
-    add_column :spree_promotion_rule_users, :updated_at, :datetime
-    add_column :spree_promotion_action_line_items, :updated_at, :datetime
-    add_column :spree_option_type_prototypes, :updated_at, :datetime
-    add_column :spree_order_promotions, :updated_at, :datetime
-    add_column :spree_product_promotion_rules, :updated_at, :datetime
-    add_column :spree_role_users, :updated_at, :datetime
-    add_column :spree_shipping_method_zones, :updated_at, :datetime
-    add_column :spree_option_value_variants, :updated_at, :datetime
-    add_column :spree_property_prototypes, :updated_at, :datetime
-    add_column :spree_prototype_taxons, :updated_at, :datetime  end
+    %i[
+      spree_option_type_prototypes
+      spree_option_value_variants
+      spree_order_promotions
+      spree_product_promotion_rules
+      spree_products_taxons
+      spree_promotion_action_line_items
+      spree_promotion_actions
+      spree_promotion_rule_taxons
+      spree_promotion_rule_users
+      spree_property_prototypes
+      spree_prototype_taxons
+      spree_reimbursement_credits
+      spree_role_users
+      spree_roles
+      spree_shipping_method_zones
+    ].each do |table|
+      add_column table, :updated_at, :datetime unless column_exists?(table, :updated_at)
+    end
+  end
 end

--- a/core/db/migrate/20210702112334_add_missing_timestamp_columns.rb
+++ b/core/db/migrate/20210702112334_add_missing_timestamp_columns.rb
@@ -1,0 +1,37 @@
+class AddMissingTimestampColumns < ActiveRecord::Migration[5.2]
+  def change
+    # Add missing created_at columns
+    add_column :spree_promotion_actions, :created_at, :datetime
+    add_column :spree_roles, :created_at, :datetime
+    add_column :spree_promotion_rule_taxons, :created_at, :datetime
+    add_column :spree_products_taxons, :created_at, :datetime
+    add_column :spree_reimbursement_credits, :created_at, :datetime
+    add_column :spree_promotion_rule_users, :created_at, :datetime
+    add_column :spree_promotion_action_line_items, :created_at, :datetime
+    add_column :spree_states, :created_at, :datetime
+    add_column :spree_option_type_prototypes, :created_at, :datetime
+    add_column :spree_order_promotions, :created_at, :datetime
+    add_column :spree_product_promotion_rules, :created_at, :datetime
+    add_column :spree_role_users, :created_at, :datetime
+    add_column :spree_shipping_method_zones, :created_at, :datetime
+    add_column :spree_option_value_variants, :created_at, :datetime
+    add_column :spree_property_prototypes, :created_at, :datetime
+    add_column :spree_countries, :created_at, :datetime
+    add_column :spree_prototype_taxons, :created_at, :datetime
+    # Add missing updated_at columns
+    add_column :spree_promotion_actions, :updated_at, :datetime
+    add_column :spree_roles, :updated_at, :datetime
+    add_column :spree_promotion_rule_taxons, :updated_at, :datetime
+    add_column :spree_products_taxons, :updated_at, :datetime
+    add_column :spree_reimbursement_credits, :updated_at, :datetime
+    add_column :spree_promotion_rule_users, :updated_at, :datetime
+    add_column :spree_promotion_action_line_items, :updated_at, :datetime
+    add_column :spree_option_type_prototypes, :updated_at, :datetime
+    add_column :spree_order_promotions, :updated_at, :datetime
+    add_column :spree_product_promotion_rules, :updated_at, :datetime
+    add_column :spree_role_users, :updated_at, :datetime
+    add_column :spree_shipping_method_zones, :updated_at, :datetime
+    add_column :spree_option_value_variants, :updated_at, :datetime
+    add_column :spree_property_prototypes, :updated_at, :datetime
+    add_column :spree_prototype_taxons, :updated_at, :datetime  end
+end


### PR DESCRIPTION
Created with the following code:
```
created=ApplicationRecord.descendants.select do |x|
  !x.new.attributes.keys.include?('created_at')
rescue NotImplementedError
end.map(&:name)

updated=ApplicationRecord.descendants.select do |x|
  !x.new.attributes.keys.include?('updated_at')
  rescue NotImplementedError
end.map(&:name)

created.map! do |class_name|
  class_name.constantize.table_name
end

updated.map! do |class_name|
  class_name.constantize.table_name
end

created.uniq.each do |table_name|
  puts "add_column :#{table_name}, :created_at, :datetime"
end

updated.uniq.each do |table_name|
  puts "add_column :#{table_name}, :updated_at, :datetime"
end
```