### PR TITLE
Revert "SD-1354 Add pagination to the view of product's variants"

### DIFF
--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -10,7 +10,7 @@
       <tr>
         <th colspan="2"><%= Spree.t(:options) %></th>
         <th><%= Spree.t(:price) %></th>
-        <th><%= sort_link @search, :sku, Spree.t(:sku) %></th>
+        <th><%= Spree.t(:sku) %></th>
         <th class="actions"></th>
       </tr>
     </thead>
@@ -65,7 +65,6 @@
   <% content_for :page_actions do %>
     <%= product_preview_link(@product) %>
     <%= button_link_to(Spree.t(:new_variant), spree.new_admin_product_variant_url(@product), { icon: 'add.svg', :'data-update' => 'new_variant', class: 'btn-success', id: 'new_var_link' }) if can? :create, Spree::Variant %>
-    <%= button_link_to (@deleted == '1' ? Spree.t(:show_active) : Spree.t(:show_deleted)), spree.admin_product_variants_url(@product, { q: { deleted_at_null: @deleted == '1' ? "0" : "1" } }), { class: 'btn-outline-secondary', icon: 'filter.svg' } %>
+    <%= button_link_to (@deleted.blank? ? Spree.t(:show_deleted) : Spree.t(:show_active)), spree.admin_product_variants_url(@product, deleted: @deleted.blank? ? "on" : "off"), { class: 'btn-outline-secondary', icon: 'filter.svg' } %>
   <% end %>
 <% end %>
-<%= render partial: 'spree/admin/shared/index_table_options', locals: { collection: @collection } %>

--- a/backend/spec/controllers/spree/admin/variants_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/variants_controller_spec.rb
@@ -22,7 +22,7 @@ module Spree
           before { variant_2.destroy }
 
           it 'assigns only deleted variants for a requested product' do
-            get :index, params: { product_id: product.slug, q: { deleted_at_null: '1' } }
+            get :index, params: { product_id: product.slug, deleted: 'on' }
             expect(assigns(:collection)).not_to include variant_1
             expect(assigns(:collection)).to include variant_2
           end

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -63,7 +63,6 @@ module Spree
     preference :show_raw_product_description, :boolean, default: false
     preference :tax_using_ship_address, :boolean, default: true
     preference :track_inventory_levels, :boolean, default: true # Determines whether to track on_hand values for variants / products.
-    preference :variants_per_page, :integer, default: Kaminari.config.default_per_page
 
     # Store credits configurations
     preference :non_expiring_credit_types, :array, default: []


### PR DESCRIPTION
Reverts spree/spree#11129

This requires more work:

1. preference needs to be moved to https://github.com/spree/spree/blob/master/backend/app/models/spree/backend_configuration.rb
2. There are no feature tests