### PR TITLE
Fix bug, ensure that current_oauth_token method return not expirable token

### DIFF
--- a/core/lib/spree/core/controller_helpers/auth.rb
+++ b/core/lib/spree/core/controller_helpers/auth.rb
@@ -34,12 +34,12 @@ module Spree
         end
 
         def current_oauth_token
+          get_last_access_token = ->(user) { Doorkeeper::AccessToken.active_for(user).where(expires_in: nil).last }
+          create_access_token = ->(user) { Doorkeeper::AccessToken.create!(resource_owner_id: user.id) }
           user = try_spree_current_user
           return unless user
 
-          @current_oauth_token ||= 
-            Doorkeeper::AccessToken.active_for(user).where(expires_in: nil).last || 
-              Doorkeeper::AccessToken.create!(resource_owner_id: user.id)
+          @current_oauth_token ||= get_last_access_token.call(user) || create_access_token.call(user)
         end
 
         def store_location

--- a/core/lib/spree/core/controller_helpers/auth.rb
+++ b/core/lib/spree/core/controller_helpers/auth.rb
@@ -37,7 +37,9 @@ module Spree
           user = try_spree_current_user
           return unless user
 
-          @current_oauth_token ||= Doorkeeper::AccessToken.active_for(user).where(expires_in: nil).last || Doorkeeper::AccessToken.create!(resource_owner_id: user.id)
+          @current_oauth_token ||= 
+            Doorkeeper::AccessToken.active_for(user).where(expires_in: nil).last || 
+              Doorkeeper::AccessToken.create!(resource_owner_id: user.id)
         end
 
         def store_location

--- a/core/lib/spree/core/controller_helpers/auth.rb
+++ b/core/lib/spree/core/controller_helpers/auth.rb
@@ -37,7 +37,7 @@ module Spree
           user = try_spree_current_user
           return unless user
 
-          @current_oauth_token ||= Doorkeeper::AccessToken.active_for(user).last || Doorkeeper::AccessToken.create!(resource_owner_id: user.id)
+          @current_oauth_token ||= Doorkeeper::AccessToken.active_for(user).where(expires_in: nil).last || Doorkeeper::AccessToken.create!(resource_owner_id: user.id)
         end
 
         def store_location


### PR DESCRIPTION
On "/api_tokens" request, that gives API token to the store, if API token doesn't exist, this function will create new non expirable token. But if it already exist, this function will give last created token. The thing is that API login request, "/spree_oauth/token", will create a new expirable token, and then, when "current_oauth_token" method gives last API token to the web on "/api_tokens" request, **it can be already expired**. And API functions used in store will no longer work. For example, you will not able to add item to cart.