### PR TITLE
SD-1361 Add destroy endpoint for basket in spree-api.

### DIFF
--- a/api/app/controllers/spree/api/v1/orders_controller.rb
+++ b/api/app/controllers/spree/api/v1/orders_controller.rb
@@ -56,7 +56,7 @@ module Spree
 
         def empty
           authorize! :update, @order, order_token
-          Spree::Dependencies.cart_empty_service.constantize.call(order: @order)
+          cart_empty_service
           render plain: nil, status: 204
         end
 
@@ -149,6 +149,10 @@ module Spree
 
         def order_id
           super || params[:id]
+        end
+
+        def cart_empty_service
+          Spree::Dependencies.cart_empty_service.constantize.call(order: @order)
         end
       end
     end

--- a/api/app/controllers/spree/api/v1/orders_controller.rb
+++ b/api/app/controllers/spree/api/v1/orders_controller.rb
@@ -56,7 +56,7 @@ module Spree
 
         def empty
           authorize! :update, @order, order_token
-          cart_empty_service
+          cart_empty_service.call(order: @order)
           render plain: nil, status: 204
         end
 
@@ -152,7 +152,7 @@ module Spree
         end
 
         def cart_empty_service
-          Spree::Dependencies.cart_empty_service.constantize.call(order: @order)
+          Spree::Dependencies.cart_empty_service.constantize
         end
       end
     end

--- a/api/app/controllers/spree/api/v1/orders_controller.rb
+++ b/api/app/controllers/spree/api/v1/orders_controller.rb
@@ -56,7 +56,7 @@ module Spree
 
         def empty
           authorize! :update, @order, order_token
-          @order.empty!
+          Spree::Dependencies.cart_empty_service.constantize.call(order: @order)
           render plain: nil, status: 204
         end
 

--- a/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
@@ -50,9 +50,13 @@ module Spree
           def empty
             spree_authorize! :update, spree_current_order, order_token
 
-            empty_cart_service.call(order: spree_current_order)
-
-            render_serialized_payload { serialized_current_order }
+            result = empty_cart_service.call(order: spree_current_order)
+            
+            if result.success?
+              render_serialized_payload { serialized_current_order }
+            else
+              render_error_payload(result.error)
+            end
           end
 
           def set_quantity

--- a/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
@@ -50,7 +50,7 @@ module Spree
           def empty
             spree_authorize! :update, spree_current_order, order_token
 
-            result = spree_current_order.empty!
+            result = empty_cart_service.call(order: spree_current_order)
 
             if result.success?
               render_serialized_payload { serialized_current_order }
@@ -62,7 +62,7 @@ module Spree
           def destroy
             spree_authorize! :update, spree_current_order, order_token
 
-            result = spree_current_order.destroy!
+            result = destroy_cart_service.call(order: spree_current_order)
 
             if result.success?
               head 204
@@ -140,6 +140,14 @@ module Spree
 
           def add_item_service
             Spree::Api::Dependencies.storefront_cart_add_item_service.constantize
+          end
+
+          def empty_cart_service
+            Spree::Api::Dependencies.storefront_cart_empty_service.constantize
+          end
+
+          def destroy_cart_service
+            Spree::Api::Dependencies.storefront_cart_destroy_service.constantize
           end
 
           def set_item_quantity_service

--- a/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
@@ -59,7 +59,7 @@ module Spree
             end
           end
 
-          def delete
+          def destroy
             spree_authorize! :update, spree_current_order, order_token
 
             result = spree_current_order.destroy!

--- a/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
@@ -50,7 +50,7 @@ module Spree
           def empty
             spree_authorize! :update, spree_current_order, order_token
 
-            result = empty_cart_service.call(order: spree_current_order)
+            result = spree_current_order.empty!
 
             if result.success?
               render_serialized_payload { serialized_current_order }
@@ -128,10 +128,6 @@ module Spree
 
           def add_item_service
             Spree::Api::Dependencies.storefront_cart_add_item_service.constantize
-          end
-
-          def empty_cart_service
-            Spree::Api::Dependencies.storefront_cart_empty_service.constantize
           end
 
           def set_item_quantity_service

--- a/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
@@ -51,7 +51,7 @@ module Spree
             spree_authorize! :update, spree_current_order, order_token
 
             result = empty_cart_service.call(order: spree_current_order)
-            
+
             if result.success?
               render_serialized_payload { serialized_current_order }
             else

--- a/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
@@ -59,6 +59,18 @@ module Spree
             end
           end
 
+          def delete
+            spree_authorize! :update, spree_current_order, order_token
+
+            result = spree_current_order.destroy!
+
+            if result.success?
+              head 204
+            else
+              render_error_payload(result.error)
+            end
+          end
+
           def set_quantity
             return render_error_item_quantity unless params[:quantity].to_i > 0
 

--- a/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
@@ -50,9 +50,7 @@ module Spree
           def empty
             spree_authorize! :update, spree_current_order, order_token
 
-            # TODO: we should extract this logic into service and let
-            # developers overwrite it
-            spree_current_order.empty!
+            empty_cart_service.call(order: spree_current_order)
 
             render_serialized_payload { serialized_current_order }
           end
@@ -126,6 +124,10 @@ module Spree
 
           def add_item_service
             Spree::Api::Dependencies.storefront_cart_add_item_service.constantize
+          end
+
+          def empty_cart_service
+            Spree::Api::Dependencies.storefront_cart_empty_service.constantize
           end
 
           def set_item_quantity_service

--- a/api/app/models/spree/api_dependencies.rb
+++ b/api/app/models/spree/api_dependencies.rb
@@ -17,8 +17,7 @@ module Spree
       :storefront_cart_estimate_shipping_rates_service, :storefront_estimated_shipment_serializer,
       :storefront_store_serializer, :storefront_address_serializer, :storefront_order_serializer,
       :storefront_account_create_address_service, :storefront_account_update_address_service, :storefront_address_finder,
-      :storefront_account_create_service, :storefront_account_update_service, :storefront_collection_sorter, :error_handler,
-      :storefront_cart_empty_service
+      :storefront_account_create_service, :storefront_account_update_service, :storefront_collection_sorter, :error_handler
     ].freeze
 
     attr_accessor *INJECTION_POINTS
@@ -40,7 +39,6 @@ module Spree
       @storefront_cart_set_item_quantity_service = Spree::Dependencies.cart_set_item_quantity_service
       @storefront_cart_recalculate_service = Spree::Dependencies.cart_recalculate_service
       @storefront_cart_estimate_shipping_rates_service = Spree::Dependencies.cart_estimate_shipping_rates_service
-      @storefront_cart_empty_service = Spree::Dependencies.cart_empty_service
 
       # coupon code handler
       @storefront_coupon_handler = Spree::Dependencies.coupon_handler

--- a/api/app/models/spree/api_dependencies.rb
+++ b/api/app/models/spree/api_dependencies.rb
@@ -17,7 +17,8 @@ module Spree
       :storefront_cart_estimate_shipping_rates_service, :storefront_estimated_shipment_serializer,
       :storefront_store_serializer, :storefront_address_serializer, :storefront_order_serializer,
       :storefront_account_create_address_service, :storefront_account_update_address_service, :storefront_address_finder,
-      :storefront_account_create_service, :storefront_account_update_service, :storefront_collection_sorter, :error_handler
+      :storefront_account_create_service, :storefront_account_update_service, :storefront_collection_sorter, :error_handler,
+      :storefront_cart_empty_service
     ].freeze
 
     attr_accessor *INJECTION_POINTS
@@ -39,6 +40,7 @@ module Spree
       @storefront_cart_set_item_quantity_service = Spree::Dependencies.cart_set_item_quantity_service
       @storefront_cart_recalculate_service = Spree::Dependencies.cart_recalculate_service
       @storefront_cart_estimate_shipping_rates_service = Spree::Dependencies.cart_estimate_shipping_rates_service
+      @storefront_cart_empty_service = Spree::Dependencies.cart_empty_service
 
       # coupon code handler
       @storefront_coupon_handler = Spree::Dependencies.coupon_handler

--- a/api/app/models/spree/api_dependencies.rb
+++ b/api/app/models/spree/api_dependencies.rb
@@ -17,7 +17,8 @@ module Spree
       :storefront_cart_estimate_shipping_rates_service, :storefront_estimated_shipment_serializer,
       :storefront_store_serializer, :storefront_address_serializer, :storefront_order_serializer,
       :storefront_account_create_address_service, :storefront_account_update_address_service, :storefront_address_finder,
-      :storefront_account_create_service, :storefront_account_update_service, :storefront_collection_sorter, :error_handler
+      :storefront_account_create_service, :storefront_account_update_service, :storefront_collection_sorter, :error_handler,
+      :storefront_cart_empty_service, :storefront_cart_destroy_service
     ].freeze
 
     attr_accessor *INJECTION_POINTS
@@ -39,6 +40,8 @@ module Spree
       @storefront_cart_set_item_quantity_service = Spree::Dependencies.cart_set_item_quantity_service
       @storefront_cart_recalculate_service = Spree::Dependencies.cart_recalculate_service
       @storefront_cart_estimate_shipping_rates_service = Spree::Dependencies.cart_estimate_shipping_rates_service
+      @storefront_cart_empty_service = Spree::Dependencies.cart_empty_service
+      @storefront_cart_destroy_service = Spree::Dependencies.cart_destroy_service
 
       # coupon code handler
       @storefront_coupon_handler = Spree::Dependencies.coupon_handler

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -131,7 +131,7 @@ Spree::Core::Engine.add_routes do
         resource :cart, controller: :cart, only: %i[show create] do
           post   :add_item
           patch  :empty
-          # delete :destroy
+          patch  :delete
           delete 'remove_line_item/:line_item_id', to: 'cart#remove_line_item', as: :cart_remove_line_item
           patch  :set_quantity
           patch  :apply_coupon_code

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -131,6 +131,7 @@ Spree::Core::Engine.add_routes do
         resource :cart, controller: :cart, only: %i[show create] do
           post   :add_item
           patch  :empty
+          # delete :destroy
           delete 'remove_line_item/:line_item_id', to: 'cart#remove_line_item', as: :cart_remove_line_item
           patch  :set_quantity
           patch  :apply_coupon_code

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -131,7 +131,7 @@ Spree::Core::Engine.add_routes do
         resource :cart, controller: :cart, only: %i[show create] do
           post   :add_item
           patch  :empty
-          patch  :delete
+          delete :delete
           delete 'remove_line_item/:line_item_id', to: 'cart#remove_line_item', as: :cart_remove_line_item
           patch  :set_quantity
           patch  :apply_coupon_code

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -128,10 +128,9 @@ Spree::Core::Engine.add_routes do
 
     namespace :v2 do
       namespace :storefront do
-        resource :cart, controller: :cart, only: %i[show create] do
+        resource :cart, controller: :cart, only: %i[show create destroy] do
           post   :add_item
           patch  :empty
-          delete :delete
           delete 'remove_line_item/:line_item_id', to: 'cart#remove_line_item', as: :cart_remove_line_item
           patch  :set_quantity
           patch  :apply_coupon_code

--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -634,6 +634,20 @@ paths:
         - $ref: '#/components/parameters/CartIncludeParam'
         - $ref: '#/components/parameters/SparseFieldsParam'
       summary: Empty the Cart
+  /api/v2/storefront/cart:
+    delete:
+      description: 'Destroys current Order.'
+      tags:
+        - Order
+      operationId: Destroy Order
+      responses:
+        '204':
+          description: Current Order has been removed.
+        '404':
+          $ref: '#/components/responses/404NotFound'
+      security:
+        - bearerAuth: [ ]
+      summary: Destroy Order
   /api/v2/storefront/cart/apply_coupon_code:
     patch:
       description: Applies a coupon code to the Cart

--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -637,20 +637,20 @@ paths:
   /api/v2/storefront/cart:
     delete:
       description: |-
-        Destroys current Order.
+        Deletes Cart.
         Endpoint can be called after PATCH /api/v2/storefront/cart/empty, or individually.
-        Shipments are canceled, payments are voided, then Line Items, Shipments & Payments are destroyed.
+        Shipments are canceled, payments are voided, then Line Items, Shipments & Payments are deleted.
       tags:
-        - Order
-      operationId: Destroy Order
+        - Cart
+      operationId: Deletes Cart
       responses:
         '204':
-          description: Current Order has been removed.
+          description: Current Cart has been removed.
         '404':
           $ref: '#/components/responses/404NotFound'
       security:
         - bearerAuth: [ ]
-      summary: Destroy Order
+      summary: Deletes Cart
   /api/v2/storefront/cart/apply_coupon_code:
     patch:
       description: Applies a coupon code to the Cart

--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -636,7 +636,10 @@ paths:
       summary: Empty the Cart
   /api/v2/storefront/cart:
     delete:
-      description: 'Destroys current Order.'
+      description: |-
+        Destroys current Order.
+        Endpoint can be called after PATCH /api/v2/storefront/cart/empty, or individually.
+        Shipments are canceled, payments are voided, then Line Items, Shipments & Payments are destroyed.
       tags:
         - Order
       operationId: Destroy Order

--- a/api/spec/requests/spree/api/v2/storefront/cart_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/cart_spec.rb
@@ -291,6 +291,42 @@ describe 'API V2 Storefront Cart Spec', type: :request do
     end
   end
 
+  describe 'cart#delete' do
+    let(:execute) { patch '/api/v2/storefront/cart/delete', headers: headers }
+
+    shared_examples 'deleting order' do
+      it 'deletes the order' do
+        expect{ execute }.to change { Spree::Order.count }.by(-1)
+      end
+    end
+
+    shared_examples '204 status returned' do
+      before { execute }
+
+      it_behaves_like 'returns 204 HTTP status'
+    end
+
+    context 'as a signed in user' do
+      context 'with existing order with line item' do
+        include_context 'creates order with line item'
+
+        it_behaves_like 'deleting order'
+        it_behaves_like '204 status returned'
+        it_behaves_like 'no current order'
+      end
+    end
+
+    context 'as a guest user' do
+      context 'with existing guest order with line item' do
+        include_context 'creates guest order with guest token'
+
+        it_behaves_like 'deleting order'
+        it_behaves_like '204 status returned'
+        it_behaves_like 'no current order'
+      end
+    end
+  end
+
   describe 'cart#set_quantity' do
     let(:line_item) { create(:line_item, order: order) }
     let(:params) { { order: order, line_item_id: line_item.id, quantity: 5 } }

--- a/api/spec/requests/spree/api/v2/storefront/cart_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/cart_spec.rb
@@ -291,11 +291,11 @@ describe 'API V2 Storefront Cart Spec', type: :request do
     end
   end
 
-  describe 'cart#delete' do
-    let(:execute) { delete '/api/v2/storefront/cart/delete', headers: headers }
+  describe 'cart#destroy' do
+    let(:execute) { delete '/api/v2/storefront/cart', headers: headers }
 
-    shared_examples 'deleting order' do
-      it 'deletes the order' do
+    shared_examples 'destroying order' do
+      it 'destroys the order' do
         expect{ execute }.to change { Spree::Order.count }.by(-1)
       end
     end
@@ -310,7 +310,7 @@ describe 'API V2 Storefront Cart Spec', type: :request do
       context 'with existing order with line item' do
         include_context 'creates order with line item'
 
-        it_behaves_like 'deleting order'
+        it_behaves_like 'destroying order'
         it_behaves_like '204 status returned'
         it_behaves_like 'no current order'
       end
@@ -320,7 +320,7 @@ describe 'API V2 Storefront Cart Spec', type: :request do
       context 'with existing guest order with line item' do
         include_context 'creates guest order with guest token'
 
-        it_behaves_like 'deleting order'
+        it_behaves_like 'destroying order'
         it_behaves_like '204 status returned'
         it_behaves_like 'no current order'
       end

--- a/api/spec/requests/spree/api/v2/storefront/cart_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/cart_spec.rb
@@ -292,7 +292,7 @@ describe 'API V2 Storefront Cart Spec', type: :request do
   end
 
   describe 'cart#delete' do
-    let(:execute) { patch '/api/v2/storefront/cart/delete', headers: headers }
+    let(:execute) { delete '/api/v2/storefront/cart/delete', headers: headers }
 
     shared_examples 'deleting order' do
       it 'deletes the order' do

--- a/core/app/models/spree/app_dependencies.rb
+++ b/core/app/models/spree/app_dependencies.rb
@@ -13,7 +13,7 @@ module Spree
       :completed_order_finder, :order_sorter, :cart_compare_line_items_service, :collection_paginator, :products_sorter,
       :products_finder, :taxon_finder, :line_item_by_variant_finder, :cart_estimate_shipping_rates_service,
       :account_create_address_service, :account_update_address_service, :account_create_service, :account_update_service,
-      :address_finder, :collection_sorter, :error_handler, :current_store_finder, :cart_empty_service
+      :address_finder, :collection_sorter, :error_handler, :current_store_finder, :cart_empty_service, :cart_destroy_service
     ].freeze
 
     attr_accessor *INJECTION_POINTS
@@ -42,6 +42,7 @@ module Spree
       @cart_set_item_quantity_service = 'Spree::Cart::SetQuantity'
       @cart_estimate_shipping_rates_service = 'Spree::Cart::EstimateShippingRates'
       @cart_empty_service = 'Spree::Cart::Empty'
+      @cart_destroy_service = 'Spree::Cart::Destroy'
 
       # checkout
       @checkout_next_service = 'Spree::Checkout::Next'

--- a/core/app/models/spree/app_dependencies.rb
+++ b/core/app/models/spree/app_dependencies.rb
@@ -13,7 +13,7 @@ module Spree
       :completed_order_finder, :order_sorter, :cart_compare_line_items_service, :collection_paginator, :products_sorter,
       :products_finder, :taxon_finder, :line_item_by_variant_finder, :cart_estimate_shipping_rates_service,
       :account_create_address_service, :account_update_address_service, :account_create_service, :account_update_service,
-      :address_finder, :collection_sorter, :error_handler, :current_store_finder
+      :address_finder, :collection_sorter, :error_handler, :current_store_finder, :cart_empty_service
     ].freeze
 
     attr_accessor *INJECTION_POINTS
@@ -41,6 +41,7 @@ module Spree
       @cart_remove_line_item_service = 'Spree::Cart::RemoveLineItem'
       @cart_set_item_quantity_service = 'Spree::Cart::SetQuantity'
       @cart_estimate_shipping_rates_service = 'Spree::Cart::EstimateShippingRates'
+      @cart_empty_service = 'Spree::Cart::Empty'
 
       # checkout
       @checkout_next_service = 'Spree::Checkout::Next'

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -424,11 +424,13 @@ module Spree
     end
 
     def empty!
-      Spree::Dependencies.cart_empty_service.constantize.new.call(order: self)
-    end
+      ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+        `Order#empty!` is deprecated and will be removed in Spree 5.0.
+        Please use `Spree::Cart::Empty.call(order: order)` instead.
+      DEPRECATION
 
-    def destroy!
-      Spree::Dependencies.cart_destroy_service.constantize.new.call(order: self)
+      result = Spree::Dependencies.cart_empty_service.constantize.call(order: self)
+      result.value
     end
 
     def has_step?(step)

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -429,6 +429,7 @@ module Spree
         Please use `Spree::Cart::Empty.call(order: order)` instead.
       DEPRECATION
 
+      raise Spree.t(:cannot_empty_completed_order) if completed?
       result = Spree::Dependencies.cart_empty_service.constantize.call(order: self)
       result.value
     end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -568,6 +568,10 @@ module Spree
       !approved?
     end
 
+    def can_be_destroyed?
+      !completed? && payments.completed.empty?
+    end
+
     def consider_risk
       considered_risky! if is_risky? && !approved?
     end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -430,6 +430,7 @@ module Spree
       DEPRECATION
 
       raise Spree.t(:cannot_empty_completed_order) if completed?
+      
       result = Spree::Dependencies.cart_empty_service.constantize.call(order: self)
       result.value
     end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -427,6 +427,10 @@ module Spree
       Spree::Dependencies.cart_empty_service.constantize.new.call(order: self)
     end
 
+    def destroy!
+      Spree::Dependencies.cart_destroy_service.constantize.new.call(order: self)
+    end
+
     def has_step?(step)
       checkout_steps.include?(step)
     end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -424,21 +424,7 @@ module Spree
     end
 
     def empty!
-      if completed?
-        raise Spree.t(:cannot_empty_completed_order)
-      else
-        line_items.destroy_all
-        updater.update_item_count
-        adjustments.destroy_all
-        shipments.destroy_all
-        state_changes.destroy_all
-        order_promotions.destroy_all
-
-        update_totals
-        persist_totals
-        restart_checkout_flow
-        self
-      end
+      Spree::Dependencies.cart_empty_service.constantize.new.call(order: self)
     end
 
     def has_step?(step)

--- a/core/app/services/spree/cart/destroy.rb
+++ b/core/app/services/spree/cart/destroy.rb
@@ -12,7 +12,7 @@ module Spree
 
       def check_if_can_be_empty(order:)
         return failure(Spree.t(:no_order_given)) if order.nil?
-        return failure(order, Spree.t(:cannot_empty_completed_order)) if order.completed?
+        return failure(order, Spree.t(:cannot_be_destroyed)) if order.can_be_destroyed?
 
         success(order: order)
       end

--- a/core/app/services/spree/cart/destroy.rb
+++ b/core/app/services/spree/cart/destroy.rb
@@ -5,6 +5,8 @@ module Spree
 
       def call(order:)
         run :check_if_can_be_destroyed
+        run :cancel_shipments
+        run :void_payments
         run :destroy_order
       end
 
@@ -12,6 +14,18 @@ module Spree
 
       def check_if_can_be_destroyed(order:)
         return failure(Spree.t(:cannot_be_destroyed)) unless order&.can_be_destroyed?
+
+        success(order: order)
+      end
+
+      def cancel_shipments(order:)
+        order.shipments.each(&:cancel!)
+
+        success(order: order)
+      end
+
+      def void_payments(order:)
+        order.payments.each(&:void!)
 
         success(order: order)
       end

--- a/core/app/services/spree/cart/destroy.rb
+++ b/core/app/services/spree/cart/destroy.rb
@@ -5,7 +5,7 @@ module Spree
 
       def call(order:)
         run :check_if_can_be_empty
-        run :empty_order
+        run :destroy_order
       end
 
       private
@@ -16,20 +16,10 @@ module Spree
         success(order: order)
       end
 
-      def empty_order(order:)
-        ActiveRecord::Base.transaction do
-          order.line_items.destroy_all
-          order.updater.update_item_count
-          order.adjustments.destroy_all
-          order.shipments.destroy_all
-          order.state_changes.destroy_all
-          order.order_promotions.destroy_all
-          order.update_totals
-          order.persist_totals
-          order.restart_checkout_flow
-          order.delete
-          success(order)
-        end
+      def destroy_order(order:)
+        order.destroy
+
+        success(order)
       end
     end
   end

--- a/core/app/services/spree/cart/destroy.rb
+++ b/core/app/services/spree/cart/destroy.rb
@@ -11,6 +11,7 @@ module Spree
       private
 
       def check_if_can_be_empty(order:)
+        return failure(Spree.t(:no_order_given)) if order.nil?
         return failure(order, Spree.t(:cannot_empty_completed_order)) if order.completed?
 
         success(order: order)

--- a/core/app/services/spree/cart/destroy.rb
+++ b/core/app/services/spree/cart/destroy.rb
@@ -1,0 +1,36 @@
+module Spree
+  module Cart
+    class Destroy
+      prepend Spree::ServiceModule::Base
+
+      def call(order:)
+        run :check_if_can_be_empty
+        run :empty_order
+      end
+
+      private
+
+      def check_if_can_be_empty(order:)
+        return failure(order, Spree.t(:cannot_empty_completed_order)) if order.completed?
+
+        success(order: order)
+      end
+
+      def empty_order(order:)
+        ActiveRecord::Base.transaction do
+          order.line_items.destroy_all
+          order.updater.update_item_count
+          order.adjustments.destroy_all
+          order.shipments.destroy_all
+          order.state_changes.destroy_all
+          order.order_promotions.destroy_all
+          order.update_totals
+          order.persist_totals
+          order.restart_checkout_flow
+          order.delete
+          success(order)
+        end
+      end
+    end
+  end
+end

--- a/core/app/services/spree/cart/destroy.rb
+++ b/core/app/services/spree/cart/destroy.rb
@@ -4,15 +4,14 @@ module Spree
       prepend Spree::ServiceModule::Base
 
       def call(order:)
-        run :check_if_can_be_empty
+        run :check_if_can_be_destroyed
         run :destroy_order
       end
 
       private
 
-      def check_if_can_be_empty(order:)
-        return failure(Spree.t(:no_order_given)) if order.nil?
-        return failure(order, Spree.t(:cannot_be_destroyed)) if order.can_be_destroyed?
+      def check_if_can_be_destroyed(order:)
+        return failure(Spree.t(:cannot_be_destroyed)) unless order&.can_be_destroyed?
 
         success(order: order)
       end

--- a/core/app/services/spree/cart/empty.rb
+++ b/core/app/services/spree/cart/empty.rb
@@ -4,7 +4,32 @@ module Spree
       prepend Spree::ServiceModule::Base
 
       def call(order:)
-        order.empty! ? success(order) : failure(order)
+        run :check_if_can_be_empty
+        run :empty_order
+      end
+
+      private
+
+      def check_if_can_be_empty(order:)
+        return failure(order, Spree.t(:cannot_empty_completed_order)) if order.completed?
+
+        success(order: order)
+      end
+
+      def empty_order(order:)
+        ActiveRecord::Base.transaction do
+          order.line_items.destroy_all
+          order.updater.update_item_count
+          order.adjustments.destroy_all
+          order.shipments.destroy_all
+          order.state_changes.destroy_all
+          order.order_promotions.destroy_all
+          order.update_totals
+          order.persist_totals
+          order.restart_checkout_flow
+
+          success(order)
+        end
       end
     end
   end

--- a/core/app/services/spree/cart/empty.rb
+++ b/core/app/services/spree/cart/empty.rb
@@ -1,0 +1,11 @@
+module Spree
+  module Cart
+    class Empty
+      prepend Spree::ServiceModule::Base
+
+      def call(order:)
+        order.empty! ? success(order) : failure(order)
+      end
+    end
+  end
+end

--- a/core/app/services/spree/cart/empty.rb
+++ b/core/app/services/spree/cart/empty.rb
@@ -11,8 +11,7 @@ module Spree
       private
 
       def check_if_can_be_empty(order:)
-        return failure(Spree.t(:no_order_given)) if order.nil?
-        return failure(order, Spree.t(:cannot_empty_completed_order)) if order.completed?
+        return failure(Spree.t(:cannot_empty)) if order.nil? || order.completed?
 
         success(order: order)
       end

--- a/core/app/services/spree/cart/empty.rb
+++ b/core/app/services/spree/cart/empty.rb
@@ -11,6 +11,7 @@ module Spree
       private
 
       def check_if_can_be_empty(order:)
+        return failure(Spree.t(:no_order_given)) if order.nil?
         return failure(order, Spree.t(:cannot_empty_completed_order)) if order.completed?
 
         success(order: order)

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -695,7 +695,8 @@ en:
     canceled: Canceled
     canceler: Canceler
     canceled_at: Canceled at
-    no_order_given: Does not handle nil as argument.
+    cannot_be_destroyed: Order can not be destroyed.
+    cannot_empty: Cannot empty order.
     cannot_empty_completed_order: Order has already been processed so it cannot be emptied
     cannot_create_payment_without_payment_methods: You cannot create a payment for an order without any payment methods defined.
     cannot_create_customer_returns: Cannot create customer returns as this order has no shipped units.

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -695,7 +695,7 @@ en:
     canceled: Canceled
     canceler: Canceler
     canceled_at: Canceled at
-    cannot_be_destroyed: Order can not be destroyed.
+    cannot_be_destroyed: Order cannot be destroyed.
     cannot_empty: Cannot empty order.
     cannot_empty_completed_order: Order has already been processed so it cannot be emptied
     cannot_create_payment_without_payment_methods: You cannot create a payment for an order without any payment methods defined.

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -695,6 +695,7 @@ en:
     canceled: Canceled
     canceler: Canceler
     canceled_at: Canceled at
+    no_order_given: Does not handle nil as argument.
     cannot_empty_completed_order: Order has already been processed so it cannot be emptied
     cannot_create_payment_without_payment_methods: You cannot create a payment for an order without any payment methods defined.
     cannot_create_customer_returns: Cannot create customer returns as this order has no shipped units.

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -312,61 +312,6 @@ describe Spree::Order, type: :model do
     end
   end
 
-  describe 'empty!' do
-    subject(:result) { order.empty! }
-
-    let(:order) { Spree::Order.create(email: 'test@example.com') }
-    let(:promotion) { create :promotion, code: '10off' }
-
-    before do
-      promotion.orders << order
-    end
-
-    context 'completed order' do
-      before do
-        order.update_columns(state: 'complete', completed_at: Time.current)
-      end
-
-      it 'returns failure' do
-        expect(result.success?).to be false
-        expect(result.error.value).to eq Spree.t(:cannot_empty_completed_order)
-      end
-    end
-
-    context 'incomplete order' do
-      before do
-        order.empty!
-      end
-
-      it 'returns success' do
-        expect(result.success?).to be true
-        expect(result.value).to eq(order)
-      end
-
-      it 'clears out line items, adjustments and update totals' do
-        expect(order.line_items.count).to be_zero
-        expect(order.adjustments.count).to be_zero
-        expect(order.shipments.count).to be_zero
-        expect(order.order_promotions.count).to be_zero
-        expect(order.promo_total).to be_zero
-        expect(order.item_total).to be_zero
-        expect(order.ship_total).to be_zero
-      end
-    end
-  end
-
-  describe 'destroy!' do
-    subject(:result) { order.destroy! }
-
-    before { order.empty! }
-
-    it 'destroys the order' do
-      result
-
-      expect(order.destroyed?).to be true
-    end
-  end
-
   context '#display_outstanding_balance' do
     it 'returns the value as a spree money' do
       allow(order).to receive(:outstanding_balance).and_return(10.55)

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -747,6 +747,32 @@ describe Spree::Order, type: :model do
     end
   end
 
+  context '#can_be_destroyed?' do
+    shared_examples 'cannot be destroyed' do
+      it { expect(order.can_be_destroyed?).to be false }
+    end
+
+    context 'when order is completed' do
+      let(:order) { create(:completed_order_with_pending_payment) }
+
+      it_behaves_like 'cannot be destroyed'
+    end
+
+    context 'when order has finalized payments' do
+      let(:order) { create(:order_ready_to_ship) }
+
+      it_behaves_like 'cannot be destroyed'
+    end
+
+    context 'when order is not completed and does not have finalized payments' do
+      let(:order) { create(:order) }
+
+      it 'can be destroyed' do
+        expect(order.can_be_destroyed?).to be true
+      end
+    end
+  end
+
   context '#uneditable?' do
     let(:order) { Spree::Order.create }
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -312,11 +312,9 @@ describe Spree::Order, type: :model do
     end
   end
 
-  context 'empty!' do
+  shared_examples 'empty order' do
     let(:order) { Spree::Order.create(email: 'test@example.com') }
     let(:promotion) { create :promotion, code: '10off' }
-
-    subject(:result) { order.empty! }
 
     before do
       promotion.orders << order
@@ -338,6 +336,11 @@ describe Spree::Order, type: :model do
         order.empty!
       end
 
+      it 'returns success' do
+        expect(result.success?).to be true
+        expect(result.value).to eq(order)
+      end
+
       it 'clears out line items, adjustments and update totals' do
         expect(order.line_items.count).to be_zero
         expect(order.adjustments.count).to be_zero
@@ -345,9 +348,26 @@ describe Spree::Order, type: :model do
         expect(order.order_promotions.count).to be_zero
         expect(order.promo_total).to be_zero
         expect(order.item_total).to be_zero
-        expect(order.empty!.success?).to be true
-        expect(order.empty!.value).to eq(order)
+        expect(order.ship_total).to be_zero
       end
+    end
+  end
+
+  describe 'empty!' do
+    subject(:result) { order.empty! }
+
+    it_behaves_like 'empty order'
+  end
+
+  describe 'destroy!' do
+    subject(:result) { order.destroy! }
+
+    it_behaves_like 'empty order'
+
+    it 'destroys the order' do
+      result
+
+      expect(order.destroyed?).to be true
     end
   end
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -316,6 +316,8 @@ describe Spree::Order, type: :model do
     let(:order) { Spree::Order.create(email: 'test@example.com') }
     let(:promotion) { create :promotion, code: '10off' }
 
+    subject(:result) { order.empty! }
+
     before do
       promotion.orders << order
     end
@@ -325,8 +327,9 @@ describe Spree::Order, type: :model do
         order.update_columns(state: 'complete', completed_at: Time.current)
       end
 
-      it 'raises an exception' do
-        expect { order.empty! }.to raise_error(RuntimeError, Spree.t(:cannot_empty_completed_order))
+      it 'returns failure' do
+        expect(result.success?).to be false
+        expect(result.error.value).to eq Spree.t(:cannot_empty_completed_order)
       end
     end
 
@@ -342,7 +345,8 @@ describe Spree::Order, type: :model do
         expect(order.order_promotions.count).to be_zero
         expect(order.promo_total).to be_zero
         expect(order.item_total).to be_zero
-        expect(order.empty!).to eq(order)
+        expect(order.empty!.success?).to be true
+        expect(order.empty!.value).to eq(order)
       end
     end
   end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -312,7 +312,9 @@ describe Spree::Order, type: :model do
     end
   end
 
-  shared_examples 'empty order' do
+  describe 'empty!' do
+    subject(:result) { order.empty! }
+
     let(:order) { Spree::Order.create(email: 'test@example.com') }
     let(:promotion) { create :promotion, code: '10off' }
 
@@ -353,16 +355,10 @@ describe Spree::Order, type: :model do
     end
   end
 
-  describe 'empty!' do
-    subject(:result) { order.empty! }
-
-    it_behaves_like 'empty order'
-  end
-
   describe 'destroy!' do
     subject(:result) { order.destroy! }
 
-    it_behaves_like 'empty order'
+    before { order.empty! }
 
     it 'destroys the order' do
       result

--- a/core/spec/services/spree/cart/destroy_spec.rb
+++ b/core/spec/services/spree/cart/destroy_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+module Spree
+  describe Cart::Destroy do
+    subject { described_class.call order: order }
+
+    let(:order) { Spree::Order.create(email: 'test@example.com') }
+
+    before { Spree::Dependencies.cart_empty_service.constantize.call(order: order) }
+
+    it 'destroys the order' do
+      subject
+
+      expect(order.destroyed?).to be true
+    end
+  end
+end

--- a/core/spec/services/spree/cart/destroy_spec.rb
+++ b/core/spec/services/spree/cart/destroy_spec.rb
@@ -4,14 +4,42 @@ module Spree
   describe Cart::Destroy do
     subject { described_class.call order: order }
 
-    let(:order) { Spree::Order.create(email: 'test@example.com') }
+    context 'when order is given' do
+      context 'when can be destroyed' do
+        let(:order) { create(:order) }
 
-    before { Spree::Dependencies.cart_empty_service.constantize.call(order: order) }
+        it 'returns success' do
+          expect(subject.success?).to be true
+        end
 
-    it 'destroys the order' do
-      subject
+        it 'destroys the order' do
+          expect(order.destroyed?).not_to be true
 
-      expect(order.destroyed?).to be true
+          subject
+
+          expect(order.destroyed?).to be true
+        end
+      end
+
+      context 'when cannot be destroyed' do
+        let(:order) { create(:completed_order_with_totals) }
+
+        it 'returns failure' do
+          expect(subject.success?).to be false
+          expect(subject.value).to eq Spree.t(:cannot_be_destroyed)
+        end
+      end
+    end
+
+    context 'when nil is given' do
+      let(:order) { nil }
+
+      before { subject }
+
+      it 'returns failure' do
+        expect(subject.success?).to be false
+        expect(subject.value).to eq Spree.t(:cannot_be_destroyed)
+      end
     end
   end
 end

--- a/core/spec/services/spree/cart/destroy_spec.rb
+++ b/core/spec/services/spree/cart/destroy_spec.rb
@@ -6,10 +6,27 @@ module Spree
 
     context 'when order is given' do
       context 'when can be destroyed' do
-        let(:order) { create(:order) }
+        let(:order) { create(:order_with_line_items) }
+        let(:shipment) { order.shipments.take }
+        let!(:payment) { create(:payment, amount: order.total, order: order) }
+        let!(:line_item_ids) { order.line_item_ids }
+        let!(:shipment_ids) { order.shipment_ids }
+        let!(:payment_ids) { order.payment_ids }
 
         it 'returns success' do
           expect(subject.success?).to be true
+        end
+
+        it 'voids pending payments' do
+          expect_any_instance_of(Spree::Payment).to receive(:void!).exactly(order.payments.count).times
+
+          subject
+        end
+
+        it 'cancel not shipped shipments' do
+          expect_any_instance_of(Spree::Shipment).to receive(:cancel!).exactly(order.shipments.count).times
+
+          subject
         end
 
         it 'destroys the order' do
@@ -18,6 +35,26 @@ module Spree
           subject
 
           expect(order.destroyed?).to be true
+        end
+
+        it 'destroys line_items, shipments and payments' do
+          subject
+
+          expect(Spree::LineItem.where(id: line_item_ids)).to be_empty
+          expect(Spree::Shipment.where(id: shipment_ids)).to be_empty
+          expect(Spree::Payment.where(id: payment_ids)).to be_empty
+        end
+
+        context 'when empty service is called first' do
+          before { Spree::Cart::Empty.call(order: order) }
+
+          it 'destroys the order' do
+            expect(order.destroyed?).not_to be true
+
+            subject
+
+            expect(order.destroyed?).to be true
+          end
         end
       end
 

--- a/core/spec/services/spree/cart/empty_spec.rb
+++ b/core/spec/services/spree/cart/empty_spec.rb
@@ -3,41 +3,54 @@ require 'spec_helper'
 module Spree
   describe Cart::Empty do
     subject { described_class.call order: order }
-    
-    let(:order) { Spree::Order.create(email: 'test@example.com') }
-    let(:promotion) { create :promotion, code: '10off' }
 
-    before do
-      promotion.orders << order
+    context 'when order is given' do
+      let(:order) { Spree::Order.create(email: 'test@example.com') }
+      let(:promotion) { create :promotion, code: '10off' }
+
+      before do
+        promotion.orders << order
+      end
+
+      context 'completed order' do
+        before do
+          order.update_columns(state: 'complete', completed_at: Time.current)
+        end
+
+        it 'returns failure' do
+          expect(subject.success?).to be false
+          expect(subject.value).to eq Spree.t(:cannot_empty)
+        end
+      end
+
+      context 'incomplete order' do
+        before { subject }
+
+        it 'returns success' do
+          expect(subject.success?).to be true
+          expect(subject.value).to eq(order)
+        end
+
+        it 'clears out line items, adjustments and update totals' do
+          expect(order.line_items.count).to be_zero
+          expect(order.adjustments.count).to be_zero
+          expect(order.shipments.count).to be_zero
+          expect(order.order_promotions.count).to be_zero
+          expect(order.promo_total).to be_zero
+          expect(order.item_total).to be_zero
+          expect(order.ship_total).to be_zero
+        end
+      end
     end
 
-    context 'completed order' do
-      before do
-        order.update_columns(state: 'complete', completed_at: Time.current)
-      end
+    context 'when nil is given' do
+      let(:order) { nil }
+
+      before { subject }
 
       it 'returns failure' do
         expect(subject.success?).to be false
-        expect(subject.error.value).to eq Spree.t(:cannot_empty_completed_order)
-      end
-    end
-
-    context 'incomplete order' do
-      before { subject }
-
-      it 'returns success' do
-        expect(subject.success?).to be true
-        expect(subject.value).to eq(order)
-      end
-
-      it 'clears out line items, adjustments and update totals' do
-        expect(order.line_items.count).to be_zero
-        expect(order.adjustments.count).to be_zero
-        expect(order.shipments.count).to be_zero
-        expect(order.order_promotions.count).to be_zero
-        expect(order.promo_total).to be_zero
-        expect(order.item_total).to be_zero
-        expect(order.ship_total).to be_zero
+        expect(subject.value).to eq Spree.t(:cannot_empty)
       end
     end
   end

--- a/core/spec/services/spree/cart/empty_spec.rb
+++ b/core/spec/services/spree/cart/empty_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+module Spree
+  describe Cart::Empty do
+    subject { described_class.call order: order }
+    
+    let(:order) { Spree::Order.create(email: 'test@example.com') }
+    let(:promotion) { create :promotion, code: '10off' }
+
+    before do
+      promotion.orders << order
+    end
+
+    context 'completed order' do
+      before do
+        order.update_columns(state: 'complete', completed_at: Time.current)
+      end
+
+      it 'returns failure' do
+        expect(subject.success?).to be false
+        expect(subject.error.value).to eq Spree.t(:cannot_empty_completed_order)
+      end
+    end
+
+    context 'incomplete order' do
+      before { subject }
+
+      it 'returns success' do
+        expect(subject.success?).to be true
+        expect(subject.value).to eq(order)
+      end
+
+      it 'clears out line items, adjustments and update totals' do
+        expect(order.line_items.count).to be_zero
+        expect(order.adjustments.count).to be_zero
+        expect(order.shipments.count).to be_zero
+        expect(order.order_promotions.count).to be_zero
+        expect(order.promo_total).to be_zero
+        expect(order.item_total).to be_zero
+        expect(order.ship_total).to be_zero
+      end
+    end
+  end
+end

--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -40,7 +40,7 @@ module Spree
     end
 
     def empty
-      current_order.try(:empty!)
+      Spree::Dependencies.cart_empty_service.constantize.call(order: current_order)
 
       redirect_to spree.cart_path
     end

--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -40,7 +40,7 @@ module Spree
     end
 
     def empty
-      Spree::Dependencies.cart_empty_service.constantize.call(order: current_order)
+      cart_empty_service
 
       redirect_to spree.cart_path
     end
@@ -86,6 +86,10 @@ module Spree
 
     def cart_add_item_service
       Spree::Dependencies.cart_add_item_service.constantize
+    end
+
+    def cart_empty_service
+      Spree::Dependencies.cart_empty_service.constantize.call(order: current_order)
     end
   end
 end

--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -40,7 +40,7 @@ module Spree
     end
 
     def empty
-      cart_empty_service
+      cart_empty_service.call(order: current_order)
 
       redirect_to spree.cart_path
     end
@@ -89,7 +89,7 @@ module Spree
     end
 
     def cart_empty_service
-      Spree::Dependencies.cart_empty_service.constantize.call(order: current_order)
+      Spree::Dependencies.cart_empty_service.constantize
     end
   end
 end

--- a/frontend/spec/controllers/spree/orders_controller_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_spec.rb
@@ -38,12 +38,19 @@ describe Spree::OrdersController, type: :controller do
     context '#empty' do
       before do
         allow(controller).to receive :check_authorization
+        allow(controller).to receive(:current_order).and_return(order)
+        put :empty
       end
 
       it 'destroys line items in the current order' do
-        allow(controller).to receive(:current_order).and_return(order)
-        expect(order).to receive(:empty!)
-        put :empty
+        expect(order.reload.line_items).to be_empty
+      end
+
+      it 'destroys adjustments' do
+        expect(order.reload.adjustments).to be_empty
+      end
+
+      it 'redirects to spree cart path' do
         expect(response).to redirect_to(spree.cart_path)
       end
     end


### PR DESCRIPTION
So far we could only empty the basket.
I'm also adding create service for spree-api cart#empty.