### PR TITLE
SD-1255 Display correct currency for customer return's pre-tax total

### DIFF
--- a/core/app/models/spree/customer_return.rb
+++ b/core/app/models/spree/customer_return.rb
@@ -17,7 +17,7 @@ module Spree
     accepts_nested_attributes_for :return_items
 
     extend DisplayMoney
-    money_methods pre_tax_total: { currency: Spree::Config[:currency] }
+    money_methods :pre_tax_total
 
     self.whitelisted_ransackable_attributes = ['number']
 
@@ -29,6 +29,10 @@ module Spree
 
     def fully_reimbursed?
       completely_decided? && return_items.accepted.includes(:reimbursement).all? { |return_item| return_item.reimbursement.try(:reimbursed?) }
+    end
+
+    def currency
+      order&.currency
     end
 
     # Temporarily tie a customer_return to one order

--- a/core/spec/models/spree/customer_return_spec.rb
+++ b/core/spec/models/spree/customer_return_spec.rb
@@ -126,7 +126,7 @@ describe Spree::CustomerReturn, type: :model do
     let(:return_item) { create(:return_item) }
     let(:customer_return) { build(:customer_return, return_items: [return_item]) }
     let(:order) { create(:order, currency: test_currency) }
-    let(:test_currency) { 'TEST' }
+    let(:test_currency) { 'EUR' }
 
     before { return_item.inventory_unit.update(order: order)}
 

--- a/core/spec/models/spree/customer_return_spec.rb
+++ b/core/spec/models/spree/customer_return_spec.rb
@@ -83,6 +83,19 @@ describe Spree::CustomerReturn, type: :model do
     it { expect(Spree::CustomerReturn.whitelisted_ransackable_attributes).to eq(%w(number)) }
   end
 
+  describe '#display_pre_tax_total' do
+    subject { customer_return.display_pre_tax_total.to_s }
+
+    let(:pre_tax_amount)  { 15.0 }
+    let(:customer_return) { create(:customer_return, line_items_count: 2) }
+
+    before do
+      Spree::ReturnItem.where(customer_return_id: customer_return.id).update_all(pre_tax_amount: pre_tax_amount)
+    end
+
+    it { is_expected.to eq '$30.00' }
+  end
+
   describe '#pre_tax_total' do
     subject { customer_return.pre_tax_total }
 
@@ -105,6 +118,19 @@ describe Spree::CustomerReturn, type: :model do
       allow(customer_return).to receive_messages(pre_tax_total: 21.22)
       expect(customer_return.display_pre_tax_total).to eq(Spree::Money.new(21.22))
     end
+  end
+
+  describe '#currency' do
+    subject { customer_return.currency }
+
+    let(:return_item) { create(:return_item) }
+    let(:customer_return) { build(:customer_return, return_items: [return_item]) }
+    let(:order) { create(:order, currency: test_currency) }
+    let(:test_currency) { 'TEST' }
+
+    before { return_item.inventory_unit.update(order: order)}
+
+    it { is_expected.to eq test_currency }
   end
 
   describe '#order' do


### PR DESCRIPTION
Fixes https://github.com/spree/spree/issues/10925