### PR TITLE
Fix Issue when creating a store and a required field has no value.

### DIFF
--- a/backend/app/controllers/spree/admin/stores_controller.rb
+++ b/backend/app/controllers/spree/admin/stores_controller.rb
@@ -8,7 +8,7 @@ module Spree
       before_action :normalize_supported_locales, only: [:create, :update]
       before_action :set_default_country_id, only: :new
       before_action :load_all_countries, only: [:new, :edit, :update, :create]
-      before_action :load_all_zones, only: [:new, :edit, :create]
+      before_action :load_all_zones, only: [:new, :edit, :update, :create]
 
       def index
         if params[:ids]

--- a/backend/app/controllers/spree/admin/stores_controller.rb
+++ b/backend/app/controllers/spree/admin/stores_controller.rb
@@ -8,7 +8,7 @@ module Spree
       before_action :normalize_supported_locales, only: [:create, :update]
       before_action :set_default_country_id, only: :new
       before_action :load_all_countries, only: [:new, :edit, :update, :create]
-      before_action :load_all_zones, only: %i[new edit]
+      before_action :load_all_zones, only: [:new, :edit, :create]
 
       def index
         if params[:ids]


### PR DESCRIPTION
Populate checkout zone option select by calling  :load_all_zones on the create action.