### PR TITLE
Use RTE for product description.

### DIFF
--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -21,7 +21,7 @@
       <div data-hook="admin_product_form_description">
         <%= f.field_container :description, class: ['form-group'] do %>
           <%= f.label :description, Spree.t(:description) %>
-          <%= f.text_area :description, { rows: "#{unless @product.has_variants? then '29' else '30' end}", class: "form-control #{"spree-rte" if Spree::Config[:use_rte_for_product_description] }" } %>
+          <%= f.text_area :description, { rows: "#{unless @product.has_variants? then '29' else '30' end}", class: "form-control #{"spree-rte" if product_wysiwyg_editor_enabled? }" } %>
           <%= f.error_message_on :description %>
         <% end %>
       </div>

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -21,7 +21,7 @@
       <div data-hook="admin_product_form_description">
         <%= f.field_container :description, class: ['form-group'] do %>
           <%= f.label :description, Spree.t(:description) %>
-          <%= f.text_area :description, { rows: "#{unless @product.has_variants? then '20' else '13' end}", class: 'form-control' } %>
+          <%= f.text_area :description, { rows: "#{unless @product.has_variants? then '29' else '30' end}", class: "form-control #{"spree-rte" if Spree::Config[:use_rte_for_product_description] }" } %>
           <%= f.error_message_on :description %>
         <% end %>
       </div>

--- a/backend/spec/features/admin/products/edit/products_spec.rb
+++ b/backend/spec/features/admin/products/edit/products_spec.rb
@@ -3,26 +3,45 @@ require 'spec_helper'
 describe 'Product Details', type: :feature, js: true do
   stub_authorization!
 
-  context 'editing a product' do
+  context 'editing a product with wysiwyg disabled' do
     before do
-      create(:product, name: 'Bún thịt nướng', sku: 'A100',
-                       description: 'lorem ipsum', available_on: '2013-08-14 01:02:03')
+      Spree::Config.product_wysiwyg_editor_enabled = false
+      create(:product, name: 'Bún thịt nướng', sku: 'A100', description: 'lorem ipsum', available_on: '2013-08-14 01:02:03')
+      visit spree.admin_products_path
+      within_row(1) { click_icon :edit }
+    end
 
+    after { Spree::Config.product_wysiwyg_editor_enabled = true }
+
+    it 'lists the product description in standard input' do
+      expect(page).to have_field(id: 'product_description', with: 'lorem ipsum')
+      expect(page).not_to have_css('#product_description_ifr')
+    end
+  end
+
+  context 'editing a product with wysiwyg editer on' do
+    before do
+      Spree::Config.product_wysiwyg_editor_enabled = true
+      create(:product, name: 'Bún thịt nướng', sku: 'A100', description: 'lorem ipsum', available_on: '2013-08-14 01:02:03')
       visit spree.admin_products_path
       within_row(1) { click_icon :edit }
     end
 
     it 'lists the product details' do
-      click_link 'Details'
-
       expect(page).to have_css('.content-header h1', text: 'Products / Bún thịt nướng')
       expect(page).to have_field(id: 'product_name', with: 'Bún thịt nướng')
       expect(page).to have_field(id: 'product_slug', with: 'bun-th-t-n-ng')
-      expect(page).to have_field(id: 'product_description', with: 'lorem ipsum')
+      expect(page).not_to have_field(id: 'product_description', with: 'lorem ipsum')
+      expect(page).to have_css('#product_description_ifr')
       expect(page).to have_field(id: 'product_price', with: '19.99')
       expect(page).to have_field(id: 'product_cost_price', with: '17.00')
       expect(page).to have_field(id: 'product_available_on', type: :hidden, with: '2013-08-14')
       expect(page).to have_field(id: 'product_sku', with: 'A100')
+    end
+
+    it 'shows product description using wysiwyg editor' do
+      expect(page).not_to have_field(id: 'product_description', with: 'lorem ipsum')
+      expect(page).to have_css('#product_description_ifr')
     end
 
     it 'handles slug changes' do

--- a/core/app/helpers/spree/products_helper.rb
+++ b/core/app/helpers/spree/products_helper.rb
@@ -46,7 +46,7 @@ module Spree
 
     # converts line breaks in product description into <p> tags (for html display purposes)
     def product_description(product)
-      description = if Spree::Config[:show_raw_product_description]
+      description = if Spree::Config[:show_raw_product_description] || Spree::Config[:use_rte_for_product_description]
                       product.description
                     else
                       product.description.to_s.gsub(/(.*?)\r?\n\r?\n/m, '<p>\1</p>')

--- a/core/app/helpers/spree/products_helper.rb
+++ b/core/app/helpers/spree/products_helper.rb
@@ -44,9 +44,13 @@ module Spree
       variants_option_types_presenter(variants, product).options
     end
 
+    def product_wysiwyg_editor_enabled?
+      Spree::Config[:product_wysiwyg_editor_enabled]
+    end
+
     # converts line breaks in product description into <p> tags (for html display purposes)
     def product_description(product)
-      description = if Spree::Config[:show_raw_product_description] || Spree::Config[:use_rte_for_product_description]
+      description = if Spree::Config[:show_raw_product_description] || product_wysiwyg_editor_enabled?
                       product.description
                     else
                       product.description.to_s.gsub(/(.*?)\r?\n\r?\n/m, '<p>\1</p>')

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -53,6 +53,7 @@ module Spree
     preference :mailer_logo, :string, default: 'logo/spree_50.png'
     preference :max_level_in_taxons_menu, :integer, default: 1 # maximum nesting level in taxons menu
     preference :products_per_page, :integer, default: 12
+    preference :product_wysiwyg_editor_enabled, :boolean, default: true
     preference :require_master_price, :boolean, default: true
     preference :restock_inventory, :boolean, default: true # Determines if a return item is restocked automatically once it has been received
     preference :return_eligibility_number_of_days, :integer, default: 365
@@ -64,7 +65,6 @@ module Spree
     preference :show_raw_product_description, :boolean, default: false
     preference :tax_using_ship_address, :boolean, default: true
     preference :track_inventory_levels, :boolean, default: true # Determines whether to track on_hand values for variants / products.
-    preference :use_rte_for_product_description, :boolean, default: true
 
     # Store credits configurations
     preference :non_expiring_credit_types, :array, default: []

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -64,6 +64,7 @@ module Spree
     preference :show_raw_product_description, :boolean, default: false
     preference :tax_using_ship_address, :boolean, default: true
     preference :track_inventory_levels, :boolean, default: true # Determines whether to track on_hand values for variants / products.
+    preference :use_rte_for_product_description, :boolean, default: true
 
     # Store credits configurations
     preference :non_expiring_credit_types, :array, default: []

--- a/core/spec/helpers/products_helper_spec.rb
+++ b/core/spec/helpers/products_helper_spec.rb
@@ -118,49 +118,55 @@ module Spree
     end
 
     context '#product_description' do
-      # Regression test for #1607
-      it 'renders a product description without excessive paragraph breaks' do
-        product.description = %Q{
+      context 'when configuration is set to sanitize output' do
+        before { Spree::Config.product_wysiwyg_editor_enabled = false }
+
+        after { Spree::Config.product_wysiwyg_editor_enabled = true }
+
+        # Regression test for #1607
+        it 'renders a product description without excessive paragraph breaks' do
+          product.description = %Q{
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus a ligula leo. Proin eu arcu at ipsum dapibus ullamcorper. Pellentesque egestas orci nec magna condimentum luctus. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Ut ac ante et mauris bibendum ultricies non sed massa. Fusce facilisis dui eget lacus scelerisque eget aliquam urna ultricies. Duis et rhoncus quam. Praesent tellus nisi, ultrices sed iaculis quis, euismod interdum ipsum.</p>
 <ul>
 <li>Lorem ipsum dolor sit amet</li>
 <li>Lorem ipsum dolor sit amet</li>
 </ul>
-        }
-        description = product_description(product)
-        expect(description.strip).to eq(product.description.strip)
-      end
+          }
+          description = product_description(product)
+          expect(description.strip).to eq(product.description.strip)
+        end
 
-      it 'renders a product description with automatic paragraph breaks' do
-        product.description = %Q{
+        it 'renders a product description with automatic paragraph breaks' do
+          product.description = %Q{
 THIS IS THE BEST PRODUCT EVER!
 
 "IT CHANGED MY LIFE" - Sue, MD}
 
-        description = product_description(product)
-        expect(description.strip).to eq(%Q{<p>\nTHIS IS THE BEST PRODUCT EVER!</p>"IT CHANGED MY LIFE" - Sue, MD})
-      end
+          description = product_description(product)
+          expect(description.strip).to eq(%Q{<p>\nTHIS IS THE BEST PRODUCT EVER!</p>"IT CHANGED MY LIFE" - Sue, MD})
+        end
 
-      it 'renders a product description without any formatting based on configuration' do
-        initial_description = %Q{
-            <p>hello world</p>
+        it 'renders a product description without any formatting based on configuration' do
+          initial_description = %Q{
+              <p>hello world</p>
 
-            <p>tihs is completely awesome and it works</p>
+              <p>tihs is completely awesome and it works</p>
 
-            <p>why so many spaces in the code. and why some more formatting afterwards?</p>
-        }
+              <p>why so many spaces in the code. and why some more formatting afterwards?</p>
+          }
 
-        product.description = initial_description
+          product.description = initial_description
 
-        Spree::Config[:show_raw_product_description] = true
-        description = product_description(product)
-        expect(description).to eq(initial_description)
-      end
+          Spree::Config[:show_raw_product_description] = true
+          description = product_description(product)
+          expect(description).to eq(initial_description)
+        end
 
-      context 'renders a product description default description incase description is blank' do
-        before { product.description = '' }
+        context 'renders a product description default description incase description is blank' do
+          before { product.description = '' }
 
-        it { expect(product_description(product)).to eq(Spree.t(:product_has_no_description)) }
+          it { expect(product_description(product)).to eq(Spree.t(:product_has_no_description)) }
+        end
       end
     end
 

--- a/frontend/app/assets/stylesheets/spree/frontend/views/spree/home/index.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/views/spree/home/index.scss
@@ -21,7 +21,7 @@
 .homepage {
   &-hero-image {
     display: flex;
-    justify-content: start;
+    justify-content: flex-start;
     flex-direction: column;
     text-align: center;
     width: 100%;

--- a/frontend/app/views/spree/products/_description.html.erb
+++ b/frontend/app/views/spree/products/_description.html.erb
@@ -1,6 +1,6 @@
 <h3 class="pt-4 font-weight-bold text-uppercase product-details-subtitle"><%= Spree.t(:description) %></h3>
 
-<% if Spree::Config[:show_raw_product_description] || Spree::Config[:use_rte_for_product_description] %>
+<% if Spree::Config[:show_raw_product_description] || product_wysiwyg_editor_enabled? %>
   <div id="product-description-long" class="m-0 text-break product-description" data-hook="description">
     <%= raw product_description(@product) %>
   </div>

--- a/frontend/app/views/spree/products/_description.html.erb
+++ b/frontend/app/views/spree/products/_description.html.erb
@@ -1,25 +1,22 @@
 <h3 class="pt-4 font-weight-bold text-uppercase product-details-subtitle"><%= Spree.t(:description) %></h3>
-<div id="product-description-short" class="m-0 text-break product-description" data-hook="description">
-  <% if Spree::Config[:show_raw_product_description] %>
-    <%= raw product_description(@product).truncate(450) %>
-  <% else %>
-    <%= sanitize product_description(@product).truncate(450) %>
-  <% end %>
-</div>
 
-<div id="product-description-long" class="m-0 text-break product-description d-none" data-hook="description">
-  <% if Spree::Config[:show_raw_product_description] %>
+<% if Spree::Config[:show_raw_product_description] || Spree::Config[:use_rte_for_product_description] %>
+  <div id="product-description-long" class="m-0 text-break product-description" data-hook="description">
     <%= raw product_description(@product) %>
-  <% else %>
+  </div>
+<% else %>
+  <div id="product-description-short" class="m-0 text-break product-description" data-hook="short-description">
+      <%= sanitize product_description(@product).truncate(450) %>
+  </div>
+  <div id="product-description-long" class="m-0 text-break product-description d-none" data-hook="description">
     <%= sanitize product_description(@product) %>
+  </div>
+  <% if product_description(@product).length > 450 %>
+    <span id="product-description-arrow" class="d-flex justify-content-center align-items-center mt-3 mx-auto product-description-arrow" aria-hidden="true">
+      <%= icon(name: 'arrow-right',
+               classes: 'spree-icon-arrow spree-icon-arrow-down',
+               width: 20,
+               height: 20) %>
+    </span>
   <% end %>
-</div>
-
-<% if product_description(@product).length > 450 %>
-  <span id="product-description-arrow" class="d-flex justify-content-center align-items-center mt-3 mx-auto product-description-arrow" aria-hidden="true">
-    <%= icon(name: 'arrow-right',
-             classes: 'spree-icon-arrow spree-icon-arrow-down',
-             width: 20,
-             height: 20) %>
-  </span>
 <% end %>

--- a/frontend/spec/features/products_spec.rb
+++ b/frontend/spec/features/products_spec.rb
@@ -407,7 +407,11 @@ describe 'Visiting Products', type: :feature, inaccessible: true do
     end
   end
 
-  context 'when rendering the product description' do
+  context 'when rendering the product description with product_wysiwyg_editor_enabled = false' do
+    before { Spree::Config.product_wysiwyg_editor_enabled = false }
+
+    after { Spree::Config.product_wysiwyg_editor_enabled = true }
+
     context 'when <script> tag exists' do
       it 'prevents the script from running', js: true do
         description = '<script>window.alert("Message")</script>'
@@ -452,6 +456,29 @@ describe 'Visiting Products', type: :feature, inaccessible: true do
         within('[data-hook=product_description]') do
           node = first('[data-hook=description]')
           expect(node).to have_selector 'p'
+        end
+      end
+    end
+  end
+
+  context 'when rendering the product description with product_wysiwyg_editor_enabled' do
+    before { Spree::Config.product_wysiwyg_editor_enabled = true }
+
+    context 'when <table> tag exists' do
+      it 'returns <table> tag in html' do
+        description = '<table style="border-collapse: collapse; width: 100%; height: 66px;" border="1">
+                        <tbody>
+                          <tr style="height: 22px;">
+                            <td style="width: 17.341967680608363%; height: 22px;">This is the table</td>
+                          </tr>
+                        </tbody>
+                      </table>'
+        product = FactoryBot.create(:base_product, description: description, name: 'Sample', price: '19.99')
+        visit spree.product_path(product)
+
+        within('[data-hook=product_description]') do
+          node = first('[data-hook=description]')
+          expect(node).to have_selector 'table'
         end
       end
     end


### PR DESCRIPTION
- Tests to write

Note: Moved raw frontend product description code outside of shot/ long description behaviour, truncating HTML results in broken HTML.

Fixes https://github.com/spree/spree/issues/11039