### PR TITLE
Drop Promotion#code and path uniqueness validation

### DIFF
--- a/backend/spec/controllers/spree/admin/promotions_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/promotions_controller_spec.rb
@@ -46,48 +46,20 @@ describe Spree::Admin::PromotionsController, type: :controller do
   end
 
   describe '#clone' do
-    context 'cloning valid promotion' do
-      subject do
-        post :clone, params: { id: promotion1.id }
-      end
-
-      it 'creates a copy of promotion' do
-        expect { subject }.to change { Spree::Promotion.count }.by(1)
-      end
-
-      it 'creates a copy of promotion with changed fields' do
-        subject
-        new_promo = Spree::Promotion.last
-        expect(new_promo.name).to eq 'New name1'
-        expect(new_promo.code).to match(/code1_[a-zA-Z]{4}/)
-        expect(new_promo.path).to match(/path1_[a-zA-Z]{4}/)
-      end
+    subject do
+      post :clone, params: { id: promotion1.id }
     end
 
-    context 'cloning invalid promotion' do
-      subject do
-        post :clone, params: { id: promotion4.id }
-      end
+    it 'creates a copy of promotion' do
+      expect { subject }.to change { Spree::Promotion.count }.by(1)
+    end
 
-      let(:promotion4) { create(:promotion, stores: [store]) }
-
-      before do
-        promotion_duplicator_mock = Spree::PromotionHandler::PromotionDuplicator.new(promotion4, random_string: "ABCD")
-        allow(Spree::PromotionHandler::PromotionDuplicator).to receive(:new).
-          with(promotion4).and_return(promotion_duplicator_mock)
-
-        create(:promotion, name: 'Name4', code: 'code4', path: '_ABCD') # promotion 4
-      end
-
-      it 'doesnt create a copy of promotion' do
-        expect { subject }.not_to(change { Spree::Promotion.count })
-      end
-
-      it 'returns error' do
-        subject
-        expected_error = Spree.t('promotion_not_cloned', error: assigns(:new_promo).errors.full_messages.to_sentence)
-        expect(flash[:error]).to eq(expected_error)
-      end
+    it 'creates a copy of promotion with changed fields' do
+      subject
+      new_promo = Spree::Promotion.last
+      expect(new_promo.name).to eq 'New name1'
+      expect(new_promo.code).to match(/code1_[a-zA-Z]{4}/)
+      expect(new_promo.path).to match(/path1_[a-zA-Z]{4}/)
     end
   end
 

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -45,7 +45,7 @@ module Spree
     def self.with_coupon_code(coupon_code)
       where("lower(#{table_name}.code) = ?", coupon_code.strip.downcase).
         includes(:promotion_actions).where.not(spree_promotion_actions: { id: nil }).
-        first
+        last
     end
 
     def self.active

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -25,14 +25,11 @@ module Spree
     validates_associated :rules
 
     validates :name, presence: true
-    validates :path, :code, uniqueness: { case_sensitive: false, allow_blank: true }
     validates :usage_limit, numericality: { greater_than: 0, allow_nil: true }
     validates :description, length: { maximum: 255 }, allow_blank: true
     validate :expires_at_must_be_later_than_starts_at, if: -> { starts_at && expires_at }
 
-    before_save :normalize_blank_values
-
-    before_validation :normalize_code
+    auto_strip_attributes :code, :path, :name
 
     scope :coupons, -> { where.not(code: nil) }
     scope :advertised, -> { where(advertise: true) }
@@ -214,16 +211,6 @@ module Spree
         promotable.line_items.any? &&
           promotable.line_items.joins(:product).where(spree_products: { promotionable: true }).none?
       end
-    end
-
-    def normalize_blank_values
-      [:code, :path].each do |column|
-        self[column] = nil if self[column].blank?
-      end
-    end
-
-    def normalize_code
-      self.code = code.strip if code.present?
     end
 
     def match_all?

--- a/core/db/migrate/20210730154425_fix_promotion_code_and_path_unique_indexes.rb
+++ b/core/db/migrate/20210730154425_fix_promotion_code_and_path_unique_indexes.rb
@@ -1,0 +1,9 @@
+class FixPromotionCodeAndPathUniqueIndexes < ActiveRecord::Migration[5.2]
+  def change
+    # removing unique indexes
+    remove_index :spree_promotions, :code
+    # applying standard indexes
+    add_index :spree_promotions, :code
+    add_index :spree_promotions, :path unless index_exists?(:spree_promotions, :path)
+  end
+end

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -26,38 +26,6 @@ describe Spree::Promotion, type: :model do
       expect(@valid_promotion).not_to be_valid
     end
 
-    describe 'code should be unique' do
-      let(:code) { 'code' }
-
-      context 'code is unique' do
-        before do
-          @valid_promotion.code = code
-        end
-
-        it { expect(@valid_promotion).to be_valid }
-      end
-
-      context 'code is not unique' do
-        let!(:promotion_with_code) { create :promotion,  name: 'test1', code: code }
-
-        context 'code is identical' do
-          before do
-            @valid_promotion.code = code
-          end
-
-          it { expect(@valid_promotion).not_to be_valid }
-        end
-
-        context 'code is identical with whitespace' do
-          before do
-            @valid_promotion.code = code + ' '
-          end
-
-          it { expect(@valid_promotion).not_to be_valid }
-        end
-      end
-    end
-
     describe 'expires_at_must_be_later_than_starts_at' do
       before do
         @valid_promotion.starts_at = Date.today
@@ -97,7 +65,7 @@ describe Spree::Promotion, type: :model do
 
   describe 'scopes' do
     describe '.coupons' do
-      subject { Spree::Promotion.coupons }
+      subject { described_class.coupons }
 
       let!(:promotion_without_code) { create :promotion,  name: 'test', code: '' }
       let!(:promotion_with_code) { create :promotion,  name: 'test1', code: 'code' }
@@ -112,7 +80,7 @@ describe Spree::Promotion, type: :model do
     end
 
     describe '.applied' do
-      subject { Spree::Promotion.applied }
+      subject { described_class.applied }
 
       let!(:promotion_not_applied) { create :promotion,  name: 'test', code: '' }
       let(:order) { create(:order) }
@@ -132,7 +100,7 @@ describe Spree::Promotion, type: :model do
     end
 
     describe '.advertised' do
-      subject { Spree::Promotion.advertised }
+      subject { described_class.advertised }
 
       let!(:promotion_not_advertised) { create :promotion,  name: 'test', advertise: false }
       let!(:promotion_advertised) { create :promotion,  name: 'test1', advertise: true }
@@ -631,7 +599,7 @@ describe Spree::Promotion, type: :model do
       let!(:promotion) { create(:promotion, :with_order_adjustment, code: 'MY-COUPON-123') }
 
       it 'finds the code with lowercase' do
-        expect(Spree::Promotion.with_coupon_code('my-coupon-123')).to eql promotion
+        expect(described_class.with_coupon_code('my-coupon-123')).to eql promotion
       end
     end
 
@@ -639,7 +607,7 @@ describe Spree::Promotion, type: :model do
       let!(:promotion_without_actions) { create(:promotion, code: 'MY-COUPON-123').actions.clear }
 
       it 'then returns the one with an action' do
-        expect(Spree::Promotion.with_coupon_code('MY-COUPON-123')).to be_nil
+        expect(described_class.with_coupon_code('MY-COUPON-123')).to be_nil
       end
     end
   end


### PR DESCRIPTION
In a multi-store environment this does not make sense.

Also replaced custom code with `auto_strip_attributes` gem