### PR TITLE
Fix/i18n locale issue

### DIFF
--- a/core/lib/spree/i18n.rb
+++ b/core/lib/spree/i18n.rb
@@ -18,7 +18,12 @@ module Spree
 
     def available_locales
       locales_from_i18n = I18n.available_locales
-      locales = [Rails.application.config.i18n.default_locale, I18n.locale, :en]
+      locales =
+        if defined?(SpreeI18n)
+          (SpreeI18n::Locale.all << :en).map(&:to_s)
+        else
+          [Rails.application.config.i18n.default_locale, I18n.locale, :en]
+        end
 
       (locales + locales_from_i18n).uniq.compact
     end

--- a/core/lib/spree/i18n.rb
+++ b/core/lib/spree/i18n.rb
@@ -20,7 +20,7 @@ module Spree
       locales_from_i18n = I18n.available_locales
       locales =
         if defined?(SpreeI18n)
-          (SpreeI18n::Locale.all << :en).map(&:to_s)
+          (SpreeI18n::Locale.all << :en).map(&:to_sym)
         else
           [Rails.application.config.i18n.default_locale, I18n.locale, :en]
         end

--- a/core/spec/lib/i18n_spec.rb
+++ b/core/spec/lib/i18n_spec.rb
@@ -28,14 +28,13 @@ describe 'i18n' do
 
       it 'returns all locales from the SpreeI18n' do
         locales = Spree.available_locales
-        expected_locales = ([:en, :de, :nl] + I18n.available_locales)
+        expected_locales = [:en, :de, :nl, :ar, :az, :bg, :ca, :cs, :da, :el, :es, :fa, :fi, :fr, :hu, :id, :it, :ja, :"pt-BR", :ro, :ru, :sk, :tr, :"zh-CN", :"zh-TW", :pl, :uk, :vi]
 
-        expect(locales).to eq expected_locales.compact.uniq
+        expect(locales).to eq expected_locales
       end
 
       it 'returns an array with the string "en" removed' do
         locales = Spree.available_locales
-        expected_locales = ([:en, :de, :nl] + I18n.available_locales)
 
         expect(locales).not_to include('en')
       end

--- a/core/spec/lib/i18n_spec.rb
+++ b/core/spec/lib/i18n_spec.rb
@@ -45,7 +45,7 @@ describe 'i18n' do
       it 'returns just default locales' do
         locales = Spree.available_locales
 
-        expected_locales = ([Rails.application.config.i18n.default_locale, I18n.locale, :en] + I18n.available_locales).uniq.compact
+        expected_locales = [:en, :ar, :az, :bg, :ca, :cs, :da, :de, :el, :es, :fa, :fi, :fr, :hu, :id, :it, :ja, :nl, :"pt-BR", :ro, :ru, :sk, :tr, :"zh-CN", :"zh-TW", :pl, :uk, :vi]
 
         expect(locales).to eq expected_locales
       end

--- a/core/spec/lib/i18n_spec.rb
+++ b/core/spec/lib/i18n_spec.rb
@@ -23,15 +23,21 @@ describe 'i18n' do
       before do
         class_double('SpreeI18n').
           as_stubbed_const(transfer_nested_constants: true)
-        class_double('SpreeI18n::Locale', all: [:en, :de, :nl]).as_stubbed_const(transfer_nested_constants: true)
+        class_double('SpreeI18n::Locale', all: ['en',:en, :de, :nl]).as_stubbed_const(transfer_nested_constants: true)
       end
 
       it 'returns all locales from the SpreeI18n' do
         locales = Spree.available_locales
+        expected_locales = ([:en, :de, :nl] + I18n.available_locales)
 
-        expected_locales = (['en', 'de', 'nl'] + I18n.available_locales).uniq.compact
+        expect(locales).to eq expected_locales.compact.uniq
+      end
 
-        expect(locales).to eq expected_locales
+      it 'returns an array with the string "en" removed' do
+        locales = Spree.available_locales
+        expected_locales = ([:en, :de, :nl] + I18n.available_locales)
+
+        expect(locales).not_to include('en')
       end
     end
 

--- a/core/spec/lib/i18n_spec.rb
+++ b/core/spec/lib/i18n_spec.rb
@@ -19,12 +19,30 @@ describe 'i18n' do
   end
 
   describe '#available_locales' do
-    it 'returns locales defined in Spree and all other installed gems' do
-      locales = Spree.available_locales
+    context 'when SpreeI18n is defined' do
+      before do
+        class_double('SpreeI18n').
+          as_stubbed_const(transfer_nested_constants: true)
+        class_double('SpreeI18n::Locale', all: [:en, :de, :nl]).as_stubbed_const(transfer_nested_constants: true)
+      end
 
-      expected_locales = ([Rails.application.config.i18n.default_locale, I18n.locale, :en] + I18n.available_locales).uniq.compact
+      it 'returns all locales from the SpreeI18n' do
+        locales = Spree.available_locales
 
-      expect(locales).to eq expected_locales
+        expected_locales = (['en', 'de', 'nl'] + I18n.available_locales).uniq.compact
+
+        expect(locales).to eq expected_locales
+      end
+    end
+
+    context 'when SpreeI18n is not defined' do
+      it 'returns just default locales' do
+        locales = Spree.available_locales
+
+        expected_locales = ([Rails.application.config.i18n.default_locale, I18n.locale, :en] + I18n.available_locales).uniq.compact
+
+        expect(locales).to eq expected_locales
+      end
     end
   end
 


### PR DESCRIPTION
- Revert "Fix Duplicate Locales Coming From spree_i18n (#10871)"
- use `(SpreeI18n::Locale.all << :en).map(&:to_sym)` `.to_sym` vs `.to_s` help unique catch` :en` and `"en"`