### PR TITLE
 Move validation of locale uniqueness on homepage to cms_page.rb

### DIFF
--- a/core/app/models/spree/cms/pages/homepage.rb
+++ b/core/app/models/spree/cms/pages/homepage.rb
@@ -3,8 +3,6 @@ module Spree::Cms::Pages
     before_create :empty_slug
     after_save :empty_slug
 
-    validates :type, uniqueness: { scope: [:store, :locale] }
-
     def sections?
       true
     end

--- a/core/app/models/spree/cms_page.rb
+++ b/core/app/models/spree/cms_page.rb
@@ -18,6 +18,7 @@ module Spree
 
     validates :title, :store, :locale, presence: true
     validates :slug, uniqueness: { scope: :store_id, allow_nil: true, case_sensitive: true }
+    validates :locale, uniqueness: { scope: [:store, :type] }, if: :homepage?
 
     scope :visible, -> { where(visible: true) }
     scope :by_locale, ->(locale) { where(locale: locale) }

--- a/core/spec/models/spree/cms_page_spec.rb
+++ b/core/spec/models/spree/cms_page_spec.rb
@@ -16,8 +16,16 @@ describe Spree::CmsPage, type: :model do
     expect(described_class.new(title: 'Got Name', store: store_a, locale: nil)).not_to be_valid
   end
 
+  describe 'validates uniqueness of homepage by locale' do
+    let!(:homepage) { create(:cms_homepage, store: store_a, locale: 'en') }
+
+    it 'valid' do
+      expect(described_class.new(title: 'Got Name', store: store_a, locale: 'en', type: 'Spree::Cms::Pages::Homepage')).not_to be_valid
+    end
+  end
+
   describe 'Spree::Cms::Pages::Homepage' do
-    let(:homepage) { create(:cms_homepage, store: store_a) }
+    let(:homepage) { create(:cms_homepage, store: store_a, locale: 'en') }
 
     it 'has a type of Spree::Cms::Pages::Homepage' do
       expect(homepage.type).to eq('Spree::Cms::Pages::Homepage')


### PR DESCRIPTION
This validation was not being caught on creating a new home page, because the validation was nested in STI.