### PR TITLE
Quick fix for clean request on AutoComplete

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/global/select2_autocomplete.es6
+++ b/backend/app/assets/javascripts/spree/backend/global/select2_autocomplete.es6
@@ -92,27 +92,52 @@ $.fn.select2Autocomplete = function(params) {
     }
   }
 
-  this.select2({
-    multiple: select2Multiple,
-    allowClear: select2allowClear,
-    placeholder: select2placeHolder,
-    minimumInputLength: minimumInput,
-    ajax: {
-      url: apiUrl,
-      headers: Spree.apiV2Authentication(),
-      data: function (params) {
-        return {
-          filter: {
-            [searchQuery]: params.term,
-            [additionalQuery]: additionalTerm
+  if (additionalQuery == null && additionalTerm == null) {
+    this.select2({
+      multiple: select2Multiple,
+      allowClear: select2allowClear,
+      placeholder: select2placeHolder,
+      minimumInputLength: minimumInput,
+      ajax: {
+        url: apiUrl,
+        headers: Spree.apiV2Authentication(),
+        data: function (params) {
+          return {
+            filter: {
+              [searchQuery]: params.term
+            }
+          }
+        },
+        processResults: function(json) {
+          return {
+            results: formatList(json.data)
           }
         }
-      },
-      processResults: function(json) {
-        return {
-          results: formatList(json.data)
+      }
+    })
+  } else {
+    this.select2({
+      multiple: select2Multiple,
+      allowClear: select2allowClear,
+      placeholder: select2placeHolder,
+      minimumInputLength: minimumInput,
+      ajax: {
+        url: apiUrl,
+        headers: Spree.apiV2Authentication(),
+        data: function (params) {
+          return {
+            filter: {
+              [searchQuery]: params.term,
+              [additionalQuery]: additionalTerm
+            }
+          }
+        },
+        processResults: function(json) {
+          return {
+            results: formatList(json.data)
+          }
         }
       }
-    }
-  })
+    })
+  }
 }


### PR DESCRIPTION
This quick fix allows for use of additional filter params, but also clean request without the null for requests where no additional filter is used.

