### PR TITLE
Don't display Store dropdown when it shouldn't be

### DIFF
--- a/backend/app/views/spree/admin/payment_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/_form.html.erb
@@ -24,7 +24,7 @@
             <%= text_area :payment_method, :description, { cols: 60, rows: 6, class: 'form-control' } %>
           <% end %>
 
-          <% if @payment_method.persisted? %>
+          <% if @stores.count > 1 %>
             <div data-hook="store" class="form-group">
               <%= label_tag :payment_method_stores, Spree.t(:stores) %>
               <%= collection_select(:payment_method, :store_ids, @stores, :id, :unique_name, {}, { multiple: true, class: 'select2' }) %>

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -237,12 +237,14 @@
     <% end %>
   </div>
 
-  <div data-hook="admin_product_form_stores">
-    <%= f.field_container :stores, class: ['form-group'] do %>
-      <%= f.label :product_stores, Spree.t(:stores) %>
-      <%= collection_select(:product, :store_ids, @stores, :id, :unique_name, {}, { multiple: true, class: 'select2' }) %>
-    <% end %>
-  </div>
+  <% if @stores.count > 1 %>
+    <div data-hook="admin_product_form_stores">
+      <%= f.field_container :stores, class: ['form-group'] do %>
+        <%= f.label :product_stores, Spree.t(:stores) %>
+        <%= collection_select(:product, :store_ids, @stores, :id, :unique_name, {}, { multiple: true, class: 'select2' }) %>
+      <% end %>
+    </div>
+  <% end %>
 
   <div data-hook="admin_product_form_meta">
     <div data-hook="admin_product_form_meta_title">

--- a/backend/app/views/spree/admin/promotions/_form.html.erb
+++ b/backend/app/views/spree/admin/promotions/_form.html.erb
@@ -46,9 +46,11 @@
       <%= f.collection_select(:promotion_category_id, @promotion_categories, :id, :name, { include_blank: Spree.t('match_choices.none') }, { class: 'select2 w-100' }) %>
     <% end %>
 
-    <%= f.field_container :stores, class: ['form-group'] do %>
-      <%= f.label :promotion_stores, Spree.t(:stores) %>
-      <%= collection_select(:promotion, :store_ids, @stores, :id, :unique_name, {}, { multiple: true, class: 'select2' }) %>
+    <% if @stores.count > 1 %>
+      <%= f.field_container :stores, class: ['form-group'] do %>
+        <%= f.label :promotion_stores, Spree.t(:stores) %>
+        <%= collection_select(:promotion, :store_ids, @stores, :id, :unique_name, {}, { multiple: true, class: 'select2' }) %>
+      <% end %>
     <% end %>
   </div>
 

--- a/core/lib/spree/testing_support/capybara_config.rb
+++ b/core/lib/spree/testing_support/capybara_config.rb
@@ -22,7 +22,7 @@ else
     driver.browser.save_screenshot(path)
   end
 end
-Capybara.default_max_wait_time = 45
+Capybara.default_max_wait_time = ENV.fetch('CAPYBARA_MAX_WAIT_TIME', 45).to_i
 Capybara.server = :puma
 
 Capybara.always_include_port = true


### PR DESCRIPTION
1. For users who don't have access to more Store(s)
2. When there's no more Stores than 1