### PR TITLE
Guard against nil value slug or permalink.

### DIFF
--- a/core/app/models/concerns/spree/display_link.rb
+++ b/core/app/models/concerns/spree/display_link.rb
@@ -4,6 +4,7 @@ module Spree
       case linked_resource_type
       when 'Spree::Taxon'
         return if linked_resource.nil?
+        return if linked_resource.permalink.nil?
 
         if spree_routes.method_defined?(:nested_taxons_path)
           spree_routes.nested_taxons_path(linked_resource.permalink)
@@ -12,6 +13,7 @@ module Spree
         end
       when 'Spree::Product'
         return if linked_resource.nil?
+        return if linked_resource.slug.nil?
 
         if spree_routes.method_defined?(:products_path)
           spree_routes.product_path(linked_resource)
@@ -20,6 +22,7 @@ module Spree
         end
       when 'Spree::CmsPage'
         return if linked_resource.nil?
+        return if linked_resource.slug.nil?
 
         if spree_routes.method_defined?(:page_path)
           spree_routes.page_path(linked_resource.slug)

--- a/core/app/models/concerns/spree/display_link.rb
+++ b/core/app/models/concerns/spree/display_link.rb
@@ -4,7 +4,7 @@ module Spree
       case linked_resource_type
       when 'Spree::Taxon'
         return if linked_resource.nil?
-        return if linked_resource.permalink.nil?
+        return if linked_resource.permalink.blank?
 
         if spree_routes.method_defined?(:nested_taxons_path)
           spree_routes.nested_taxons_path(linked_resource.permalink)
@@ -13,7 +13,7 @@ module Spree
         end
       when 'Spree::Product'
         return if linked_resource.nil?
-        return if linked_resource.slug.nil?
+        return if linked_resource.slug.blank?
 
         if spree_routes.method_defined?(:products_path)
           spree_routes.product_path(linked_resource)
@@ -22,7 +22,7 @@ module Spree
         end
       when 'Spree::CmsPage'
         return if linked_resource.nil?
-        return if linked_resource.slug.nil?
+        return if linked_resource.slug.blank?
 
         if spree_routes.method_defined?(:page_path)
           spree_routes.page_path(linked_resource.slug)

--- a/core/app/models/concerns/spree/display_link.rb
+++ b/core/app/models/concerns/spree/display_link.rb
@@ -3,8 +3,7 @@ module Spree
     def link
       case linked_resource_type
       when 'Spree::Taxon'
-        return if linked_resource.nil?
-        return if linked_resource.permalink.blank?
+        return if linked_resource&.permalink.blank?
 
         if spree_routes.method_defined?(:nested_taxons_path)
           spree_routes.nested_taxons_path(linked_resource.permalink)
@@ -12,8 +11,7 @@ module Spree
           "/#{Spree::Config[:storefront_taxons_path]}/#{linked_resource.permalink}"
         end
       when 'Spree::Product'
-        return if linked_resource.nil?
-        return if linked_resource.slug.blank?
+        return if linked_resource&.slug.blank?
 
         if spree_routes.method_defined?(:products_path)
           spree_routes.product_path(linked_resource)
@@ -21,8 +19,7 @@ module Spree
           "/#{Spree::Config[:storefront_products_path]}/#{linked_resource.slug}"
         end
       when 'Spree::CmsPage'
-        return if linked_resource.nil?
-        return if linked_resource.slug.blank?
+        return if linked_resource&.slug.blank?
 
         if spree_routes.method_defined?(:page_path)
           spree_routes.page_path(linked_resource.slug)

--- a/core/spec/models/spree/menu_item_spec.rb
+++ b/core/spec/models/spree/menu_item_spec.rb
@@ -107,16 +107,33 @@ describe Spree::MenuItem, type: :model do
   describe '#link' do
     let(:product) { create(:product, stores: [store]) }
     let(:taxon) { create(:taxon) }
+    let(:cms_page) { create(:cms_standard_page) }
+    let(:cms_page_with_no_slug) { create(:cms_homepage) }
+
     let(:item_url) { create(:menu_item, name: 'URL To Random Site', item_type: 'Link', menu: menu, linked_resource_type: 'URL', destination: 'https://some-other-website.com') }
     let(:item_empty_url) { create(:menu_item, name: 'URL To Random Site', item_type: 'Link', menu: menu, linked_resource_type: 'URL', destination: nil) }
     let(:item_home) { create(:menu_item, name: 'Home', item_type: 'Link', menu: menu, linked_resource_type: 'Home Page') }
     let(:item_product) { create(:menu_item, name: product.name, item_type: 'Link', menu: menu, linked_resource_type: 'Spree::Product') }
     let(:item_taxon) { create(:menu_item, name: taxon.name, item_type: 'Link', menu: menu, linked_resource_type: 'Spree::Taxon') }
+    let(:item_cms_page) { create(:menu_item, name: cms_page.title, item_type: 'Link', menu: menu, linked_resource_type: 'Spree::CmsPage') }
+    let(:item_cms_page_with_no_slug) { create(:menu_item, name: cms_page_with_no_slug.title, item_type: 'Link', menu: menu, linked_resource_type: 'Spree::CmsPage') }
 
     it 'returns correct taxon path' do
       item_taxon.update(linked_resource: taxon)
 
       expect(item_taxon.link).to eql "/t/#{taxon.permalink}"
+    end
+
+    it 'returns correct cms_standard_page path' do
+      item_cms_page.update(linked_resource: cms_page)
+
+      expect(item_cms_page.link).to eql "/pages/#{cms_page.slug}"
+    end
+
+    it 'returns nil if no slug is present' do
+      item_cms_page_with_no_slug.update(linked_resource: cms_page_with_no_slug)
+
+      expect(item_cms_page_with_no_slug.link).to be nil
     end
 
     it 'returns nil for destination when taxon is removed' do


### PR DESCRIPTION
If a user links to a standard page (about us) in the Menu, and then changes that page to a type Homepage, it is possible to have no slug value causing an error.