### PR TITLE
Remove Line That Strips Out 'categories/' From Permalink In Sample Data.

### DIFF
--- a/sample/db/samples/taxons.rb
+++ b/sample/db/samples/taxons.rb
@@ -17,7 +17,6 @@ categories_taxon = Spree::Taxon.where(name: I18n.t('spree.taxonomy_categories_na
 
 TAXON_NAMES.each do |taxon_name|
   taxon = categories_taxon.children.where(name: taxon_name).first_or_create!
-  taxon.permalink = taxon.permalink.gsub('categories/', '')
   taxon.taxonomy = categories
   taxon.save!
 end


### PR DESCRIPTION
Not sure why, but the sample data strips out the permalink on Taxons nested under Categories. It's not a big deal but does not replicate how the data would be if created in the UI.

I'm not sure of the reason for doing this in the sample data.