### PR TITLE
Add publishable key and intents to payment method serializer

### DIFF
--- a/api/app/serializers/spree/v2/storefront/payment_method_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/payment_method_serializer.rb
@@ -5,6 +5,15 @@ module Spree
         set_type :payment_method
 
         attributes :type, :name, :description
+
+        attribute :preferences do |payment_method|
+          {
+            intents: payment_method.preferences[:intents],
+            publishable_key: payment_method.preferences[:publishable_key],
+            server: payment_method.preferences[:server],
+            test_mode: payment_method.preferences[:test_mode]
+          }
+        end
       end
     end
   end


### PR DESCRIPTION
Currently, in stock Spree installation, the V2 API endpoint for integrating payment methods only returns payment method id, name and type.

I was thinking that it would make sense to add some common preferences to the response, to make it easier to integrate popular providers without having to dive deep into overriding serializers for payment methods.
The preferences that I added enable developers to easily get Stripe's publishable key and server. For payment methods without these preferences, these fields will simply return null.

@damianlegawiec would love to hear your thoughts on that. On one hand this would include provider-specific preferences in a generic serializer, on the other it would make it easier to adopt the V2 API in custom storefronts. 

As a next step, maybe it would make sense to add a flag in Spree::Gateway subclasses for flagging which preferences should be returned by the API.