### PR TITLE
Fix payment_methods association for Spree::Store.

### DIFF
--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -1,7 +1,7 @@
 module Spree
   class Store < Spree::Base
     has_many :orders, class_name: 'Spree::Order'
-    has_many :payment_methods, class_name: 'Spree::PaymentMethod'
+    has_many_and_belongs_to_many :payment_methods, class_name: 'Spree::PaymentMethod'
     belongs_to :default_country, class_name: 'Spree::Country'
     belongs_to :checkout_zone, class_name: 'Spree::Zone'
 


### PR DESCRIPTION
Spree::PaymentMethod associates with stores via habtm
Spree::Store had a has_many association with Spree::PaymentMethods. 

Replaced the has_many on Spree::Store with a habtm association.