### PR TITLE
Fix flatpickr intermittent failing tests.

### DIFF
--- a/backend/spec/features/admin/orders/listing_spec.rb
+++ b/backend/spec/features/admin/orders/listing_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'Orders Listing', type: :feature do
   stub_authorization!
 
-  let(:other_store) { create(:store, name: 'Other Store', url: "another-store.lvh.me") }
+  let(:other_store) { create(:store, name: 'Other Store', url: 'another-store.lvh.me') }
 
   let(:order1) do
     create :order_with_line_items,
@@ -298,9 +298,14 @@ describe 'Orders Listing', type: :feature do
           select2 'spree', from: 'Channel'
         end
 
+        fill_in_date_picker('q_created_at_gt', { year: 2018, month: 1, day: 18 })
+        fill_in_date_picker('q_created_at_lt', { year: 2019, month: 3, day: 25 })
+
         click_on 'Filter Results'
 
         within('.table-active-filters') do
+          expect(page).to have_content('Start: 2018-01-18')
+          expect(page).to have_content('Stop: 2019-03-25')
           expect(page).to have_content('Order Number: R100')
           expect(page).to have_content('Status: cart')
           expect(page).to have_content('Payment State: paid')

--- a/backend/spec/features/admin/orders/listing_spec.rb
+++ b/backend/spec/features/admin/orders/listing_spec.rb
@@ -297,15 +297,17 @@ describe 'Orders Listing', type: :feature do
           fill_in 'q_bill_address_lastname_start', with: 'Smith'
           select2 'spree', from: 'Channel'
 
-          fill_in_date_picker('q_created_at_gt', with: '2015-5-6')
-          fill_in_date_picker('q_created_at_lt', with: '2018-1-9')
+          # Can not test these in the filter dropdown
+          # With current implementation of flatpickr test support.
+          # fill_in_date_picker('q_created_at_gt', with: '2018-01-01')
+          # fill_in_date_picker('q_created_at_lt', with: '2018-01-01')
         end
 
         click_on 'Filter Results'
 
         within('.table-active-filters') do
-          expect(page).to have_content('Start: 2015-05-06')
-          expect(page).to have_content('Stop: 2018-01-09')
+          # expect(page).to have_content('Start: 2018-01-01')
+          # expect(page).to have_content('Stop: 2018-06-30')
           expect(page).to have_content('Order Number: R100')
           expect(page).to have_content('Status: cart')
           expect(page).to have_content('Payment State: paid')

--- a/backend/spec/features/admin/orders/listing_spec.rb
+++ b/backend/spec/features/admin/orders/listing_spec.rb
@@ -297,17 +297,15 @@ describe 'Orders Listing', type: :feature do
           fill_in 'q_bill_address_lastname_start', with: 'Smith'
           select2 'spree', from: 'Channel'
 
-          # Can not test these in the filter dropdown
-          # With current implementation of flatpickr test support.
-          # fill_in_date_picker('q_created_at_gt', with: '2018-01-01')
-          # fill_in_date_picker('q_created_at_lt', with: '2018-01-01')
+          fill_in_date_picker('q_created_at_gt', with: '2015-5-6')
+          fill_in_date_picker('q_created_at_lt', with: '2018-1-9')
         end
 
         click_on 'Filter Results'
 
         within('.table-active-filters') do
-          # expect(page).to have_content('Start: 2018-01-01')
-          # expect(page).to have_content('Stop: 2018-06-30')
+          expect(page).to have_content('Start: 2015-05-06')
+          expect(page).to have_content('Stop: 2018-01-09')
           expect(page).to have_content('Order Number: R100')
           expect(page).to have_content('Status: cart')
           expect(page).to have_content('Payment State: paid')

--- a/backend/spec/features/admin/orders/listing_spec.rb
+++ b/backend/spec/features/admin/orders/listing_spec.rb
@@ -296,18 +296,11 @@ describe 'Orders Listing', type: :feature do
           fill_in 'q_bill_address_firstname_start', with: 'John'
           fill_in 'q_bill_address_lastname_start', with: 'Smith'
           select2 'spree', from: 'Channel'
-
-          # Can not test these in the filter dropdown
-          # With current implementation of flatpickr test support.
-          # fill_in_date_picker('q_created_at_gt', with: '2018-01-01')
-          # fill_in_date_picker('q_created_at_lt', with: '2018-01-01')
         end
 
         click_on 'Filter Results'
 
         within('.table-active-filters') do
-          # expect(page).to have_content('Start: 2018-01-01')
-          # expect(page).to have_content('Stop: 2018-06-30')
           expect(page).to have_content('Order Number: R100')
           expect(page).to have_content('Status: cart')
           expect(page).to have_content('Payment State: paid')

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -176,7 +176,7 @@ describe 'Products', type: :feature do
         fill_in 'product_sku', with: 'B100'
         fill_in 'product_price', with: '100'
 
-        fill_in_date_picker('product_available_on', with: '2012-01-24')
+        fill_in_date_picker('product_available_on', with: '2012-1-24')
         select2 'Size', from: 'Prototype'
         check 'Large'
         select2 @shipping_category.name, css: '#product_shipping_category_field'

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -176,7 +176,7 @@ describe 'Products', type: :feature do
         fill_in 'product_sku', with: 'B100'
         fill_in 'product_price', with: '100'
 
-        fill_in_date_picker('product_available_on', { year: 2012, month: 01, day: 24 })
+        fill_in_date_picker('product_available_on', { year: 2012, month: 1, day: 24 })
 
         select2 'Size', from: 'Prototype'
         check 'Large'

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -176,11 +176,14 @@ describe 'Products', type: :feature do
         fill_in 'product_sku', with: 'B100'
         fill_in 'product_price', with: '100'
 
-        fill_in_date_picker('product_available_on', with: '2012-1-24')
+        fill_in_date_picker('product_available_on', { year: 2012, month: 01, day: 24 })
+
         select2 'Size', from: 'Prototype'
         check 'Large'
         select2 @shipping_category.name, css: '#product_shipping_category_field'
+
         click_button 'Create'
+
         expect(page).to have_content('successfully created!')
         expect(page).to have_field(id: 'product_available_on', type: :hidden, with: '2012-01-24')
         expect(Spree::Product.last.variants.length).to eq(1)

--- a/backend/spec/features/admin/promotions/promotion_spec.rb
+++ b/backend/spec/features/admin/promotions/promotion_spec.rb
@@ -23,10 +23,11 @@ describe 'Create New Promotion', type: :feature, js: true do
     end
 
     it 'Allows you to set a promotion with start and end time' do
-      fill_in_date_time_picker('promotion_starts_at', with: '2012-1-18-16-45')
       fill_in 'Name', with: 'Promotion 2'
 
-      fill_in_date_time_picker('promotion_expires_at', with: '2013-3-25-22-10')
+      fill_in_date_picker('promotion_starts_at', { year: 2012, month: 01, day: 18, hour: 16, minute: 45 })
+      fill_in_date_picker('promotion_expires_at', { year: 2013, month: 03, day: 25, hour: 22, minute: 10 })
+
       fill_in 'Code', with: 'Random 2323'
 
       click_button 'Create'

--- a/backend/spec/features/admin/promotions/promotion_spec.rb
+++ b/backend/spec/features/admin/promotions/promotion_spec.rb
@@ -23,17 +23,17 @@ describe 'Create New Promotion', type: :feature, js: true do
     end
 
     it 'Allows you to set a promotion with start and end time' do
-      fill_in_date_time_picker('promotion_starts_at', with: '2012-01-24-16-45')
+      fill_in_date_time_picker('promotion_starts_at', with: '2012-1-18-16-45')
       fill_in 'Name', with: 'Promotion 2'
 
-      fill_in_date_time_picker('promotion_expires_at', with: '2012-01-25-22-10')
+      fill_in_date_time_picker('promotion_expires_at', with: '2013-3-25-22-10')
       fill_in 'Code', with: 'Random 2323'
 
       click_button 'Create'
 
       promotion = store.promotions.last
-      expect(promotion.starts_at).to eq(DateTime.new(2012, 1, 24, 16, 45))
-      expect(promotion.expires_at).to eq(DateTime.new(2012, 1, 25, 22, 10))
+      expect(promotion.starts_at).to eq(DateTime.new(2012, 1, 18, 16, 45))
+      expect(promotion.expires_at).to eq(DateTime.new(2013, 3, 25, 22, 10))
     end
 
     it 'allows assigning multiple stores' do

--- a/backend/spec/features/admin/promotions/promotion_spec.rb
+++ b/backend/spec/features/admin/promotions/promotion_spec.rb
@@ -25,8 +25,8 @@ describe 'Create New Promotion', type: :feature, js: true do
     it 'Allows you to set a promotion with start and end time' do
       fill_in 'Name', with: 'Promotion 2'
 
-      fill_in_date_picker('promotion_starts_at', { year: 2012, month: 01, day: 18, hour: 16, minute: 45 })
-      fill_in_date_picker('promotion_expires_at', { year: 2013, month: 03, day: 25, hour: 22, minute: 10 })
+      fill_in_date_picker('promotion_starts_at', { year: 2012, month: 1, day: 18, hour: 16, minute: 45 })
+      fill_in_date_picker('promotion_expires_at', { year: 2013, month: 3, day: 25, hour: 22, minute: 10 })
 
       fill_in 'Code', with: 'Random 2323'
 

--- a/core/lib/spree/testing_support/flatpickr_capybara.rb
+++ b/core/lib/spree/testing_support/flatpickr_capybara.rb
@@ -2,55 +2,52 @@ module Spree
   module TestingSupport
     module FlatpickrCapybara
       def fill_in_date_manually(label_text, options = {})
-        string_date = if options[:hour].present? && options[:minute].present?
-                        "#{options[:year]}-#{options[:month]}-#{options[:day]}-#{options[:hour]}-#{options[:minute]}"
-                      else
-                        "#{options[:year]}-#{options[:month]}-#{options[:day]}"
-                      end
-
         with_open_flatpickr(label_text) do |field|
-          fill_in field[:id], with: string_date
+          fill_in field[:id], with: string_date(options)
         end
       end
 
       def fill_in_date_picker(label_text, options = {})
-        within_open_flatpickr(label_text) do
-
-
-          if options[:hour].blank? && options[:minute].blank?
-            within_flatpickr_months do
-              fill_in_flatpickr_year(options[:year].to_i)
-              select_flatpickr_month(options[:month].to_i)
-              click_on_flatpickr_day(options[:day].to_i)
-            end
-          else
-            within_flatpickr_months do
-              fill_in_flatpickr_year(options[:year].to_i)
-              select_flatpickr_month(options[:month].to_i)
-              click_on_flatpickr_day(options[:day].to_i)
-            end
-            within_flatpickr_time do
-              select_flatpickr_hour(options[:hour].to_i)
-              select_flatpickr_min(options[:minute].to_i)
-            end
-          end
+        if options[:hour].blank? && options[:minute].blank?
+          flatpickr_date_only(label_text, options)
+        else
+          flatpickr_date_time(label_text, options)
         end
       end
 
-      def fill_in_date_with_js(label_text, options ={})
-        string_date = if options[:hour].present? && options[:minute].present?
-                "#{options[:year]}-#{options[:month]}-#{options[:day]}-#{options[:hour]}-#{options[:minute]}"
-              else
-                "#{options[:year]}-#{options[:month]}-#{options[:day]}"
-              end
-
+      def fill_in_date_with_js(label_text, options = {})
         date_field = find("input[id='#{label_text}']")
-        script = "document.querySelector('#{date_field}').flatpickr().setDate('#{string_date}');"
+        script = "document.querySelector('#{date_field}').flatpickr().setDate('#{string_date(options)}');"
 
         page.execute_script(script)
       end
 
       private
+
+      def flatpickr_date_only(label_text, options = {})
+        within_open_flatpickr(label_text) do
+          within_flatpickr_months do
+            fill_in_flatpickr_year(options[:year].to_i)
+            select_flatpickr_month(options[:month].to_i)
+            click_on_flatpickr_day(options[:day].to_i)
+          end
+        end
+      end
+
+      def flatpickr_date_time(label_text, options = {})
+        within_open_flatpickr(label_text) do
+          within_flatpickr_months do
+            fill_in_flatpickr_year(options[:year].to_i)
+            select_flatpickr_month(options[:month].to_i)
+            click_on_flatpickr_day(options[:day].to_i)
+          end
+
+          within_flatpickr_time do
+            select_flatpickr_hour(options[:hour].to_i)
+            select_flatpickr_min(options[:minute].to_i)
+          end
+        end
+      end
 
       def with_open_flatpickr(label_text)
         field_label = find_field(id: label_text, type: :hidden)
@@ -105,6 +102,14 @@ module Spree
 
       def select_flatpickr_min(min)
         find('input.flatpickr-minute').set(min)
+      end
+
+      def string_date(options)
+        if options[:hour].present? && options[:minute].present?
+          "#{options[:year]}-#{options[:month]}-#{options[:day]}-#{options[:hour]}-#{options[:minute]}"
+        else
+          "#{options[:year]}-#{options[:month]}-#{options[:day]}"
+        end
       end
     end
   end

--- a/core/lib/spree/testing_support/flatpickr_capybara.rb
+++ b/core/lib/spree/testing_support/flatpickr_capybara.rb
@@ -54,7 +54,7 @@ module Spree
 
         sleep(0.25)                 # Pause to let JavaScript populate DOM.
 
-        yield(date_field)           # Complete required action
+        yield(date_field)           # Complete required action.
 
         date_field.send_keys :tab   # Close the date picker widget
       end

--- a/core/lib/spree/testing_support/flatpickr_capybara.rb
+++ b/core/lib/spree/testing_support/flatpickr_capybara.rb
@@ -50,21 +50,23 @@ module Spree
         field_label = find_field(id: label_text, type: :hidden)
 
         date_field = field_label.sibling('.flatpickr-alt-input')
-        date_field.click # Open the widget
+        date_field.click            # Open the widget
 
-        yield(date_field)
+        sleep(0.25)                 # Pause to let JavaScript populate DOM
 
-        date_field.send_keys :tab # Close the date picker widget
+        yield(date_field)           # Complete required action
+
+        date_field.send_keys :tab   # Close the date picker widget
       end
 
       def within_open_flatpickr(label_text, &block)
         with_open_flatpickr(label_text) do
-          within find(:xpath, "/html/body/div[contains(@class, 'flatpickr-calendar') and contains(@class, 'open')]", &block)
+          within find('.flatpickr-calendar.open', &block)
         end
       end
 
       def within_flatpickr_months(&block)
-        within find('.flatpickr-months .flatpickr-month .flatpickr-current-month', &block)
+        within find('.flatpickr-months > .flatpickr-month > .flatpickr-current-month', &block)
       end
 
       def within_flatpickr_time(&block)
@@ -72,7 +74,9 @@ module Spree
       end
 
       def select_flatpickr_month(month)
-        find("select.flatpickr-monthDropdown-months > option:nth-child(#{month.to_i})").select_option
+        accurate_month = (month.to_i - 1)
+
+        find("select.flatpickr-monthDropdown-months > option[value='#{accurate_month}']").select_option
       end
 
       def fill_in_flatpickr_year(year)
@@ -81,7 +85,7 @@ module Spree
 
       def click_on_flatpickr_day(day)
         within_flatpickr_days do
-          find('.flatpickr-day:not(.prevMonthDay):not(.nextMonthDay)', text: day).click
+          find('.flatpickr-day:not(.prevMonthDay):not(.nextMonthDay)', text: day, exact_text: true).click
         end
       end
 

--- a/core/lib/spree/testing_support/flatpickr_capybara.rb
+++ b/core/lib/spree/testing_support/flatpickr_capybara.rb
@@ -28,7 +28,11 @@ module Spree
         within_open_flatpickr(label_text) do
           within_flatpickr_months do
             fill_in_flatpickr_year(options[:year].to_i)
+            sleep(0.25) # Pause to let JavaScript adjust DOM.
+
             select_flatpickr_month(options[:month].to_i)
+            sleep(0.25) # Pause to let JavaScript adjust DOM.
+
             click_on_flatpickr_day(options[:day].to_i)
           end
         end
@@ -38,7 +42,11 @@ module Spree
         within_open_flatpickr(label_text) do
           within_flatpickr_months do
             fill_in_flatpickr_year(options[:year].to_i)
+            sleep(0.25) # Pause to let JavaScript adjust DOM.
+
             select_flatpickr_month(options[:month].to_i)
+            sleep(0.25) # Pause to let JavaScript adjust DOM.
+
             click_on_flatpickr_day(options[:day].to_i)
           end
 
@@ -54,7 +62,6 @@ module Spree
 
         date_field = field_label.sibling('.flatpickr-alt-input')
         date_field.click            # Open the flatpcikr cal.
-
         sleep(0.25)                 # Pause to let JavaScript populate DOM.
 
         yield(date_field)           # Complete required action.

--- a/core/lib/spree/testing_support/flatpickr_capybara.rb
+++ b/core/lib/spree/testing_support/flatpickr_capybara.rb
@@ -56,7 +56,7 @@ module Spree
 
         yield(date_field)           # Complete required action.
 
-        date_field.send_keys :tab   # Close the date picker widget
+        date_field.send_keys :tab   # Close the date picker widget.
       end
 
       def within_open_flatpickr(label_text, &block)

--- a/core/lib/spree/testing_support/flatpickr_capybara.rb
+++ b/core/lib/spree/testing_support/flatpickr_capybara.rb
@@ -52,7 +52,7 @@ module Spree
         date_field = field_label.sibling('.flatpickr-alt-input')
         date_field.click            # Open the widget.
 
-        sleep(0.25)                 # Pause to let JavaScript populate DOM
+        sleep(0.25)                 # Pause to let JavaScript populate DOM.
 
         yield(date_field)           # Complete required action
 

--- a/core/lib/spree/testing_support/flatpickr_capybara.rb
+++ b/core/lib/spree/testing_support/flatpickr_capybara.rb
@@ -1,45 +1,51 @@
 module Spree
   module TestingSupport
     module FlatpickrCapybara
-      def fill_in_date_manually(label_text, with:)
+      def fill_in_date_manually(label_text, options = {})
+        string_date = if options[:hour].present? && options[:minute].present?
+                        "#{options[:year]}-#{options[:month]}-#{options[:day]}-#{options[:hour]}-#{options[:minute]}"
+                      else
+                        "#{options[:year]}-#{options[:month]}-#{options[:day]}"
+                      end
+
         with_open_flatpickr(label_text) do |field|
-          fill_in field[:id], with: with
+          fill_in field[:id], with: string_date
         end
       end
 
-      def fill_in_date_picker(label_text, with:)
+      def fill_in_date_picker(label_text, options = {})
         within_open_flatpickr(label_text) do
-          within_flatpickr_months do
-            fill_in_flatpickr_year(with.split('-')[0])
 
-            select_flatpickr_month(with.split('-')[1])
 
-            click_on_flatpickr_day(with.split('-')[2])
+          if options[:hour].blank? && options[:minute].blank?
+            within_flatpickr_months do
+              fill_in_flatpickr_year(options[:year].to_i)
+              select_flatpickr_month(options[:month].to_i)
+              click_on_flatpickr_day(options[:day].to_i)
+            end
+          else
+            within_flatpickr_months do
+              fill_in_flatpickr_year(options[:year].to_i)
+              select_flatpickr_month(options[:month].to_i)
+              click_on_flatpickr_day(options[:day].to_i)
+            end
+            within_flatpickr_time do
+              select_flatpickr_hour(options[:hour].to_i)
+              select_flatpickr_min(options[:minute].to_i)
+            end
           end
         end
       end
 
-      def fill_in_date_time_picker(label_text, with:)
-        within_open_flatpickr(label_text) do
-          within_flatpickr_months do
-            fill_in_flatpickr_year(with.split('-')[0])
+      def fill_in_date_with_js(label_text, options ={})
+        string_date = if options[:hour].present? && options[:minute].present?
+                "#{options[:year]}-#{options[:month]}-#{options[:day]}-#{options[:hour]}-#{options[:minute]}"
+              else
+                "#{options[:year]}-#{options[:month]}-#{options[:day]}"
+              end
 
-            select_flatpickr_month(with.split('-')[1])
-
-            click_on_flatpickr_day(with.split('-')[2])
-          end
-
-          within_flatpickr_time do
-            select_flatpickr_hour(with.split('-')[3])
-
-            select_flatpickr_min(with.split('-')[4])
-          end
-        end
-      end
-
-      def fill_in_date_with_js(label_text, with:)
         date_field = find("input[id='#{label_text}']")
-        script = "document.querySelector('#{date_field}').flatpickr().setDate('#{with}');"
+        script = "document.querySelector('#{date_field}').flatpickr().setDate('#{string_date}');"
 
         page.execute_script(script)
       end

--- a/core/lib/spree/testing_support/flatpickr_capybara.rb
+++ b/core/lib/spree/testing_support/flatpickr_capybara.rb
@@ -50,7 +50,7 @@ module Spree
         field_label = find_field(id: label_text, type: :hidden)
 
         date_field = field_label.sibling('.flatpickr-alt-input')
-        date_field.click            # Open the widget.
+        date_field.click            # Open the flatpcikr cal.
 
         sleep(0.25)                 # Pause to let JavaScript populate DOM.
 

--- a/core/lib/spree/testing_support/flatpickr_capybara.rb
+++ b/core/lib/spree/testing_support/flatpickr_capybara.rb
@@ -50,7 +50,7 @@ module Spree
         field_label = find_field(id: label_text, type: :hidden)
 
         date_field = field_label.sibling('.flatpickr-alt-input')
-        date_field.click            # Open the widget
+        date_field.click            # Open the widget.
 
         sleep(0.25)                 # Pause to let JavaScript populate DOM
 

--- a/core/lib/spree/testing_support/flatpickr_capybara.rb
+++ b/core/lib/spree/testing_support/flatpickr_capybara.rb
@@ -28,10 +28,10 @@ module Spree
         within_open_flatpickr(label_text) do
           within_flatpickr_months do
             fill_in_flatpickr_year(options[:year].to_i)
-            sleep(0.25) # Pause to let JavaScript adjust the DOM.
+            sleep(0.25) # Pause to let JavaScript adjust the month selector in the flatpickr cal in relation to any related FROM...TO cal.
 
             select_flatpickr_month(options[:month].to_i)
-            sleep(0.25) # Pause to let JavaScript adjust DOM.
+            sleep(0.25) # Pause to let JavaScript adjust the day selection area in the flatpickr cal in relation to any related FROM...TO cal.
 
             click_on_flatpickr_day(options[:day].to_i)
           end
@@ -42,10 +42,10 @@ module Spree
         within_open_flatpickr(label_text) do
           within_flatpickr_months do
             fill_in_flatpickr_year(options[:year].to_i)
-            sleep(0.25) # Pause to let JavaScript adjust DOM.
+            sleep(0.25) # Pause to let JavaScript adjust the month selector in the flatpickr cal in relation to any related FROM...TO cal.
 
             select_flatpickr_month(options[:month].to_i)
-            sleep(0.25) # Pause to let JavaScript adjust DOM.
+            sleep(0.25) # Pause to let JavaScript adjust the day selection area in the flatpickr cal in relation to any related FROM...TO cal.
 
             click_on_flatpickr_day(options[:day].to_i)
           end
@@ -61,12 +61,13 @@ module Spree
         field_label = find_field(id: label_text, type: :hidden)
 
         date_field = field_label.sibling('.flatpickr-alt-input')
-        date_field.click            # Open the flatpcikr cal.
-        sleep(0.25)                 # Pause to let JavaScript populate DOM.
+        date_field.click # Open the flatpickr cal.
+        sleep(0.25) # Pause to let JavaScript populate DOM with an open flatpickr cal.
 
-        yield(date_field)           # Complete required action.
+        yield(date_field) # Complete required action within the open flatpickr cal.
 
-        date_field.send_keys :tab   # Close the date picker widget.
+        date_field.send_keys :tab # Close the date flatpickr cal.
+        sleep(0.25) # Pause to let JavaScript adjust any DOM values in relation to any related FROM...TO cal.
       end
 
       def within_open_flatpickr(label_text, &block)

--- a/core/lib/spree/testing_support/flatpickr_capybara.rb
+++ b/core/lib/spree/testing_support/flatpickr_capybara.rb
@@ -28,7 +28,7 @@ module Spree
         within_open_flatpickr(label_text) do
           within_flatpickr_months do
             fill_in_flatpickr_year(options[:year].to_i)
-            sleep(0.25) # Pause to let JavaScript adjust DOM.
+            sleep(0.25) # Pause to let JavaScript adjust the DOM.
 
             select_flatpickr_month(options[:month].to_i)
             sleep(0.25) # Pause to let JavaScript adjust DOM.


### PR DESCRIPTION
- Use exact text when selecting day to avoid ambiguous match on single digit dates.
- Add small pause between changing flatpickr values that adjust the DOM in the calendar, to ensure JavaScript to updates the DOM before next section is made.
- Select month by` value=`, not by `nth-child`  _(**1)_
- Use `find` not `xpath`.
- REFACTOR: Rather than passing in a string and chopping it up, now pass an options hash specifying the `day:  4, month: 3, year: 2018`. This gives greater clarity regardless if you use U.S. or European date standards as to what the values are actually being sent.
- REFACTOR: Reduce 2 methods into one, instead of calling `fill_in_date_time_picker( ... )`, now just pass in the `hour: 11, minute: 45` along with the `day:  4, month: 3, year: 2018` and `fill_in_date_picker` will recognise the presence of the additional time values and set the time.

_(**1)_  If the From and To dates are close together, only the available months are populated in the options, so if nth-child(9) (September) is looked up, but the months start from September, then September would be the nth-child(1) and nth-child(9) would not exist, as per the image attached.
<img width="377" alt="Screenshot 2021-08-09 at 19 27 06" src="https://user-images.githubusercontent.com/1240766/128755544-7d7fed74-91f7-4fa5-84bb-b88ad4884fcf.png">

Added back in previously broken test for filter using date pickers, since refactor this is now testable.
