### PR TITLE
Fix validation errors for Swagger Open API

### DIFF
--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -452,7 +452,7 @@ paths:
                         currency: USD
                         state: cart
                         token: zdmOIe5GUtZhZdh0zeFv9w1581837294588
-                        email: null
+                        email: example@example.com
                         display_item_total: $0.00
                         display_ship_total: $0.00
                         display_adjustment_total: $0.00
@@ -479,6 +479,45 @@ paths:
                           data: null
                         shipping_address:
                           data: null
+                    included:
+                      - id: "2"
+                        type: "promotion"
+                        attributes:
+                          name: "10% Discount"
+                          description: "Super discount for you"
+                          amount: "-22.0"
+                          display_amount: "$22.00"
+                      - id: "4"
+                        type: "user"
+                        attributes:
+                          email: "example@example.com"
+                      - id: "1"
+                        type: "address"
+                        attributes:
+                          firstname: "Bob"
+                          lastname: "Billerson"
+                          address1: "1600 Clear View Pkwy"
+                          address2: "Mountain View"
+                          city: "LA"
+                          zipcode: '94043'
+                          phone: "(+1) 123 456 789"
+                          state_name: "California"
+                          state_code: "CA"
+                          country_name: "United States of America"
+                          country_iso3: "USA"
+                          company: null
+                      - id: "2832"
+                        type: "shipment"
+                        attributes:
+                          number: "H121354"
+                          free: false
+                          final_price: '10.0'
+                          display_final_price: '$10.00'
+                          tracking_url: 'https://tools.usps.com/go/TrackConfirmAction?tRef=fullpage&tLc=2&text28777=&tLabels=4123412434%2C'
+                          state: "shipped"
+                          shipped_at: '2019-01-02 13:42:12'
+
+
       parameters:
         - $ref: '#/components/parameters/CartIncludeParam'
         - $ref: '#/components/parameters/SparseFieldsParam'
@@ -4038,7 +4077,7 @@ components:
         included:
           type: array
           items:
-            oneOf:
+            anyOf:
               - $ref: '#/components/schemas/Promotion'
               - $ref: '#/components/schemas/User'
               - $ref: '#/components/schemas/Address'
@@ -4068,7 +4107,7 @@ components:
           type: array
           items:
             type: object
-            oneOf:
+            anyOf:
               - $ref: '#/components/schemas/Variant'
               - $ref: '#/components/schemas/LineItem'
               - $ref: '#/components/schemas/Promotion'
@@ -4218,6 +4257,7 @@ components:
           minimum: 0
         special_instructions:
           type: string
+          nullable: true
           example: Please wrap it as a gift
           description: Message added by the Customer
         currency:
@@ -4283,7 +4323,7 @@ components:
           type: array
           items:
             type: object
-            oneOf:
+            anyOf:
               - $ref: '#/components/schemas/PaymentMethod'
     CreditCard:
       required:
@@ -4296,7 +4336,7 @@ components:
           type: array
           items:
             type: object
-            oneOf:
+            anyOf:
               - $ref: '#/components/schemas/PaymentMethod'
     CreditCardAttributes:
       type: object
@@ -4504,7 +4544,7 @@ components:
             name:
               type: string
               example: 10% Discount
-            descriptiom:
+            description:
               type: string
               example: Super discount for you
             amount:
@@ -4523,7 +4563,7 @@ components:
         included:
           type: array
           items:
-            oneOf:
+            anyOf:
               - $ref: '#/components/schemas/OptionType'
               - $ref: '#/components/schemas/OptionValue'
               - $ref: '#/components/schemas/ProductProperty'
@@ -4548,7 +4588,7 @@ components:
         included:
           type: array
           items:
-            oneOf:
+            anyOf:
               - $ref: '#/components/schemas/OptionType'
               - $ref: '#/components/schemas/OptionValue'
               - $ref: '#/components/schemas/ProductProperty'
@@ -4672,7 +4712,7 @@ components:
         included:
           type: array
           items:
-            oneOf:
+            anyOf:
               - $ref: '#/components/schemas/ProductAttributesAndRelationships'
               - $ref: '#/components/schemas/TaxonAttributesAndRelationships'
               - $ref: '#/components/schemas/TaxonomyAttributesAndRelationships'
@@ -4799,7 +4839,7 @@ components:
         included:
           type: array
           items:
-            oneOf:
+            anyOf:
               - $ref: '#/components/schemas/TaxonAttributesAndRelationships'
               - $ref: '#/components/schemas/TaxonImage'
               - $ref: '#/components/schemas/TaxonomyAttributesAndRelationships'
@@ -4969,7 +5009,7 @@ components:
         included:
           type: array
           items:
-            oneOf:
+            anyOf:
               - $ref: '#/components/schemas/Image'
               - $ref: '#/components/schemas/OptionValue'
               - $ref: '#/components/schemas/OptionType'
@@ -5069,7 +5109,7 @@ components:
         included:
           type: array
           items:
-            oneOf:
+            anyOf:
               - $ref: '#/components/schemas/State'
       description: 'Countries within Spree are used as a container for states. Countries can be zone members, and also link to an address. The difference between one country and another on an address record can determine which tax rates and shipping methods are used for the order.[Read more about Countries in Spree](https://guides.spreecommerce.org/developer/core/addresses.html#countries)'
     CountriesList:
@@ -5254,7 +5294,7 @@ components:
         included:
           type: array
           items:
-            oneOf:
+            anyOf:
               - $ref: '#/components/schemas/ShippingRate'
               - $ref: '#/components/schemas/StockLocation'
     EstimateShippingRatesList:
@@ -5333,7 +5373,7 @@ components:
         included:
           type: array
           items:
-            oneOf:
+            anyOf:
               - $ref: '#/components/schemas/Address'
       required:
         - data

--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -5,7 +5,7 @@ servers:
   - url: 'http://localhost:3000'
     description: localhost
 info:
-  version: 2.0.0
+  version: 2.0.1
   title: Storefront API v2
   description: |-
     Storefront API v2 is a modern REST API based on the [JSON API spec](https://jsonapi.org/) which provides you with necessary endpoints to build amazing user intefaces either in JavaScript frameworks or native mobile libraries.
@@ -5618,3 +5618,12 @@ components:
                 type: string
                 example: You are not authorized to access this page.
                 default: You are not authorized to access this page.
+
+tags:
+  - name: Account
+  - name: Cart
+  - name: Checkout
+  - name: Countries
+  - name: Order Status
+  - name: Products
+  - name: Taxons

--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -4108,7 +4108,7 @@ components:
           items:
             type: object
             anyOf:
-              - $ref: '#/components/schemas/Variant'
+              - $ref: '#/components/schemas/VariantAttributesAndRelationships'
               - $ref: '#/components/schemas/LineItem'
               - $ref: '#/components/schemas/Promotion'
               - $ref: '#/components/schemas/User'

--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -231,14 +231,14 @@ paths:
           $ref: '#/components/responses/403Forbidden'
       security:
         - bearerAuth: []
-  '/api/v2/storefront/account/addresses/{address_id}':
+  '/api/v2/storefront/account/addresses/{id}':
     delete:
       description: 'Removes selected Address for the signed in User. It uses soft-delete for addresses with shipments and orders.'
       tags:
         - Account
       operationId: remove-address
       parameters:
-        - $ref: '#/components/parameters/AddressId'
+        - $ref: '#/components/parameters/Id'
       responses:
         '204':
           description: Requested Address has been removed from the User Account
@@ -254,7 +254,7 @@ paths:
         - Account
       operationId: update-address
       parameters:
-        - $ref: '#/components/parameters/AddressId'
+        - $ref: '#/components/parameters/Id'
       requestBody:
         required: true
         content:
@@ -302,14 +302,14 @@ paths:
           description: Filter based on payment method ID
         - $ref: '#/components/parameters/CreditCardIncludeParam'
         - $ref: '#/components/parameters/SparseFieldsParam'
-  '/api/v2/storefront/account/credit_cards/{card_id}':
+  '/api/v2/storefront/account/credit_cards/{id}':
     delete:
       description: 'Removes selected credit card for the signed in User. It uses soft-delete.'
       tags:
         - Account
       operationId: remove-credit-card
       parameters:
-        - $ref: '#/components/parameters/CardId'
+        - $ref: '#/components/parameters/Id'
         - $ref: '#/components/parameters/CreditCardIncludeParam'
         - $ref: '#/components/parameters/SparseFieldsParam'
       responses:
@@ -644,7 +644,7 @@ paths:
                 line_item_id: '1'
                 quantity: 5
       summary: Set Quantity of a Line Item
-  '/api/v2/storefront/cart/remove_line_item/{line_item_id}':
+  '/api/v2/storefront/cart/remove_line_item/{id}':
     delete:
       description: |-
         Removes Line Item from Cart. After removing Item system will re-calculate taxes, promotions, shipments etc.
@@ -654,7 +654,7 @@ paths:
         - Cart
       operationId: remove-line-item
       parameters:
-        - $ref: '#/components/parameters/LineItemId'
+        - $ref: '#/components/parameters/Id'
         - $ref: '#/components/parameters/CartIncludeParam'
         - $ref: '#/components/parameters/SparseFieldsParam'
       responses:
@@ -4568,7 +4568,7 @@ components:
               - $ref: '#/components/schemas/OptionValue'
               - $ref: '#/components/schemas/ProductProperty'
               - $ref: '#/components/schemas/Property'
-              - $ref: '#/components/schemas/Variant'
+              - $ref: '#/components/schemas/VariantAttributesAndRelationships'
               - $ref: '#/components/schemas/Image'
               - $ref: '#/components/schemas/TaxonAttributesAndRelationships'
     ProductsList:
@@ -4593,7 +4593,7 @@ components:
               - $ref: '#/components/schemas/OptionValue'
               - $ref: '#/components/schemas/ProductProperty'
               - $ref: '#/components/schemas/Property'
-              - $ref: '#/components/schemas/Variant'
+              - $ref: '#/components/schemas/VariantAttributesAndRelationships'
               - $ref: '#/components/schemas/Image'
               - $ref: '#/components/schemas/TaxonAttributesAndRelationships'
     ProductAttributes:
@@ -5466,19 +5466,11 @@ components:
         - state_name
         - country_iso
   parameters:
-    AddressId:
-      name: address_id
+    Id:
+      name: id
       in: path
       required: true
-      description: Address ID
-      schema:
-        type: string
-      example: '1'
-    CardId:
-      name: card_id
-      in: path
-      required: true
-      description: Card ID
+      description: id
       schema:
         type: string
       example: '1'
@@ -5513,14 +5505,6 @@ components:
       schema:
         type: string
       example: "categories/women"
-    LineItemId:
-      name: line_item_id
-      in: path
-      required: true
-      description: Line Item ID
-      schema:
-        type: string
-      example: '1'
     PageParam:
       name: page
       in: query

--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -5,7 +5,7 @@ servers:
   - url: 'http://localhost:3000'
     description: localhost
 info:
-  version: 2.0.1
+  version: 2.0.0
   title: Storefront API v2
   description: |-
     Storefront API v2 is a modern REST API based on the [JSON API spec](https://jsonapi.org/) which provides you with necessary endpoints to build amazing user intefaces either in JavaScript frameworks or native mobile libraries.

--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -94,18 +94,6 @@ paths:
                           state_code: NY
         '403':
           $ref: '#/components/responses/403Forbidden'
-          description: ''
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  '':
-                    type: string
-              examples:
-                example-1:
-                  value:
-                    error: You are not authorized to access this page.
       security:
         - bearerAuth: []
     post:
@@ -243,7 +231,7 @@ paths:
           $ref: '#/components/responses/403Forbidden'
       security:
         - bearerAuth: []
-  '/api/v2/storefront/account/addresses/{id}':
+  '/api/v2/storefront/account/addresses/{address_id}':
     delete:
       description: 'Removes selected Address for the signed in User. It uses soft-delete for addresses with shipments and orders.'
       tags:
@@ -314,13 +302,14 @@ paths:
           description: Filter based on payment method ID
         - $ref: '#/components/parameters/CreditCardIncludeParam'
         - $ref: '#/components/parameters/SparseFieldsParam'
-  '/api/v2/storefront/account/credit_cards/{id}':
+  '/api/v2/storefront/account/credit_cards/{card_id}':
     delete:
       description: 'Removes selected credit card for the signed in User. It uses soft-delete.'
       tags:
         - Account
       operationId: Remove Credit Card
       parameters:
+        - $ref: '#/components/parameters/CardId'
         - $ref: '#/components/parameters/CreditCardIncludeParam'
         - $ref: '#/components/parameters/SparseFieldsParam'
       responses:
@@ -375,7 +364,7 @@ paths:
         - $ref: '#/components/parameters/PerPageParam'
       security:
         - bearerAuth: []
-  '/api/v2/storefront/account/orders/{number}':
+  '/api/v2/storefront/account/orders/{order_number}':
     get:
       description: Return the User's completed Order
       summary: Get an Order
@@ -397,7 +386,7 @@ paths:
         - $ref: '#/components/parameters/SparseFieldsParam'
       security:
         - bearerAuth: []
-  '/api/v2/storefront/order_status/{number}':
+  '/api/v2/storefront/order_status/{order_number}':
     get:
       description: |-
         Returns placed Order information. This endpoint is useful for fetching Order information for non-signed in Users. This way customers without an account can check their Order status (shipment/paymnet/processing/etc).
@@ -712,7 +701,7 @@ paths:
       parameters:
         - name: coupon_code
           in: path
-          required: false
+          required: true
           description: Selected Coupon code for removal
           schema:
             type: string
@@ -1181,7 +1170,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProductsList'
       summary: List of Products
-  '/api/v2/storefront/products/{id}':
+  '/api/v2/storefront/products/{product_slug}':
     get:
       description: |-
         Returns Product details. You can use product permalink:
@@ -1201,7 +1190,7 @@ paths:
         - Products
       operationId: Show Product
       parameters:
-        - $ref: '#/components/parameters/IdOrPermalink'
+        - $ref: '#/components/parameters/ProductSlug'
         - $ref: '#/components/parameters/ProductIncludeParam'
         - $ref: '#/components/parameters/SparseFieldsParam'
       responses:
@@ -3575,7 +3564,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/TaxonsList'
       summary: List of Taxons
-  '/api/v2/storefront/taxons/{id}':
+  '/api/v2/storefront/taxons/{taxon_permalink}':
     get:
       description: |-
         Returns Taxon details.
@@ -3595,7 +3584,7 @@ paths:
         - Taxons
       operationId: Show Taxon
       parameters:
-        - $ref: '#/components/parameters/IdOrPermalink'
+        - $ref: '#/components/parameters/TaxonPermalink'
         - $ref: '#/components/parameters/TaxonIncludeParam'
         - $ref: '#/components/parameters/SparseFieldsParam'
       responses:
@@ -4044,7 +4033,6 @@ components:
     Cart:
       properties:
         data:
-          type: object
           $ref: '#/components/schemas/CartAttributesWithRelationships'
         included:
           type: array
@@ -4080,7 +4068,7 @@ components:
           items:
             type: object
             oneOf:
-              - $ref: '#/components/schemas/VariantAttributesAndRelationships'
+              - $ref: '#/components/schemas/Variant'
               - $ref: '#/components/schemas/LineItem'
               - $ref: '#/components/schemas/Promotion'
               - $ref: '#/components/schemas/User'
@@ -4302,7 +4290,6 @@ components:
         - included
       properties:
         data:
-          type: object
           $ref: '#/components/schemas/CreditCardAttributesWithRelationships'
         included:
           type: array
@@ -4349,7 +4336,6 @@ components:
           type: string
           example: credit_card
         attributes:
-          type: object
           $ref: '#/components/schemas/CreditCardAttributes'
         relationships:
           type: object
@@ -4541,7 +4527,7 @@ components:
               - $ref: '#/components/schemas/OptionValue'
               - $ref: '#/components/schemas/ProductProperty'
               - $ref: '#/components/schemas/Property'
-              - $ref: '#/components/schemas/VariantAttributesAndRelationships'
+              - $ref: '#/components/schemas/Variant'
               - $ref: '#/components/schemas/Image'
               - $ref: '#/components/schemas/TaxonAttributesAndRelationships'
     ProductsList:
@@ -4566,7 +4552,7 @@ components:
               - $ref: '#/components/schemas/OptionValue'
               - $ref: '#/components/schemas/ProductProperty'
               - $ref: '#/components/schemas/Property'
-              - $ref: '#/components/schemas/VariantAttributesAndRelationships'
+              - $ref: '#/components/schemas/Variant'
               - $ref: '#/components/schemas/Image'
               - $ref: '#/components/schemas/TaxonAttributesAndRelationships'
     ProductAttributes:
@@ -5443,6 +5429,14 @@ components:
       schema:
         type: string
       example: '1'
+    CardId:
+      name: card_id
+      in: path
+      required: true
+      description: Card ID
+      schema:
+        type: string
+      example: '1'
     CreditCardIncludeParam:
       name: include
       in: query
@@ -5458,14 +5452,22 @@ components:
         ```
 
         [More information](https://jsonapi.org/format/#fetching-includes)
-    IdOrPermalink:
-      name: id
+    ProductSlug:
+      name: product_slug
       in: path
       required: true
-      description: ID or a permalink
+      description: Product Slug
       schema:
         type: string
       example: knitted-high-neck-sweater
+    TaxonPermalink:
+      name: taxon_permalink
+      in: path
+      required: true
+      description: Taxon Permalink
+      schema:
+        type: string
+      example: "categories/women"
     LineItemId:
       name: line_item_id
       in: path
@@ -5489,7 +5491,7 @@ components:
         type: integer
       example: null
     OrderParam:
-      name: number
+      name: order_number
       in: path
       required: true
       description: Number of Order

--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -29,7 +29,7 @@ paths:
       summary: Get an Account
       tags:
         - Account
-      operationId: Account Information
+      operationId: account-information
       parameters:
         - $ref: '#/components/parameters/AccountIncludeParam'
         - $ref: '#/components/parameters/SparseFieldsParam'
@@ -104,7 +104,7 @@ paths:
       summary: Create an Account
       tags:
         - Account
-      operationId: Account Creation
+      operationId: account-creation
       requestBody:
         required: true
         content:
@@ -146,7 +146,7 @@ paths:
       summary: Update an Account
       tags:
         - Account
-      operationId: Account Updates
+      operationId: account-updates
       requestBody:
         required: true
         content:
@@ -193,7 +193,7 @@ paths:
       summary: List of Addresses
       tags:
         - Account
-      operationId: Addresses list
+      operationId: addresses-list
       responses:
         '200':
           description: Listing user addresses.
@@ -210,7 +210,7 @@ paths:
       summary: Create an Address
       tags:
         - Account
-      operationId: Create Address
+      operationId: create-address
       requestBody:
         required: true
         content:
@@ -236,7 +236,7 @@ paths:
       description: 'Removes selected Address for the signed in User. It uses soft-delete for addresses with shipments and orders.'
       tags:
         - Account
-      operationId: Remove Address
+      operationId: remove-address
       parameters:
         - $ref: '#/components/parameters/AddressId'
       responses:
@@ -252,7 +252,7 @@ paths:
       summary: Update Address
       tags:
         - Account
-      operationId: Update Address
+      operationId: update-address
       parameters:
         - $ref: '#/components/parameters/AddressId'
       requestBody:
@@ -281,7 +281,7 @@ paths:
       summary: List of Credit Cards
       tags:
         - Account
-      operationId: Credit Cards list
+      operationId: credit-cards-list
       responses:
         '200':
           description: Listing user credit cards.
@@ -298,7 +298,7 @@ paths:
           name: 'filter[payment_method_id]'
           schema:
             type: string
-          example: 2
+          example: "2"
           description: Filter based on payment method ID
         - $ref: '#/components/parameters/CreditCardIncludeParam'
         - $ref: '#/components/parameters/SparseFieldsParam'
@@ -307,7 +307,7 @@ paths:
       description: 'Removes selected credit card for the signed in User. It uses soft-delete.'
       tags:
         - Account
-      operationId: Remove Credit Card
+      operationId: remove-credit-card
       parameters:
         - $ref: '#/components/parameters/CardId'
         - $ref: '#/components/parameters/CreditCardIncludeParam'
@@ -326,7 +326,7 @@ paths:
       summary: Get Default Credit Card
       tags:
         - Account
-      operationId: Default Credit Card
+      operationId: default-credit-card
       responses:
         '200':
           description: Listing user default credit card.
@@ -347,7 +347,7 @@ paths:
       summary: List of Orders
       tags:
         - Account
-      operationId: Completed Orders
+      operationId: completed-orders
       responses:
         '200':
           description: Listing user completed orders.
@@ -370,7 +370,7 @@ paths:
       summary: Get an Order
       tags:
         - Account
-      operationId: Completed User Order
+      operationId: completed-user-order
       responses:
         '200':
           description: Listing user completed order.
@@ -395,7 +395,7 @@ paths:
       summary: Get an Order Status
       tags:
         - Order Status
-      operationId: Order Status
+      operationId: order-status
       responses:
         '200':
           description: Requested Order information
@@ -421,7 +421,7 @@ paths:
         It is required to create a Cart before adding items to the Cart. After completing the Checkout you will need to create a new Cart.
       tags:
         - Cart
-      operationId: Create Cart
+      operationId: create-cart
       responses:
         '201':
           description: Cart was successfully created
@@ -490,7 +490,7 @@ paths:
         Shipments are canceled, payments are voided, then Line Items, Shipments & Payments are deleted.
       tags:
         - Cart
-      operationId: Deletes Cart
+      operationId: deletes-cart
       responses:
         '204':
           description: Current Cart has been removed.
@@ -503,7 +503,7 @@ paths:
       description: Returns contents of the currently used Cart
       tags:
         - Cart
-      operationId: Get Cart
+      operationId: get-cart
       responses:
         '200':
           description: Correct cart was returned
@@ -531,7 +531,7 @@ paths:
         ```
       tags:
         - Cart
-      operationId: Add Item
+      operationId: add-item
       responses:
         '200':
           description: Item was added to the Cart successfully
@@ -570,7 +570,7 @@ paths:
       description: Sets the quantity of a given line item. It has to be a positive integer greater than 0.
       tags:
         - Cart
-      operationId: Set Quantity
+      operationId: set-quantity
       responses:
         '200':
           description: New quantity has been successfully set for a requested Line Item
@@ -613,7 +613,7 @@ paths:
         Updated Cart will be returned.
       tags:
         - Cart
-      operationId: Remove Line Item
+      operationId: remove-line-item
       parameters:
         - $ref: '#/components/parameters/LineItemId'
         - $ref: '#/components/parameters/CartIncludeParam'
@@ -639,7 +639,7 @@ paths:
         Returns updated Cart.
       tags:
         - Cart
-      operationId: Empty Cart
+      operationId: empty-cart
       responses:
         '200':
           description: Cart has been successfully emptied
@@ -661,7 +661,7 @@ paths:
       description: Applies a coupon code to the Cart
       tags:
         - Cart
-      operationId: Apply Coupon Code
+      operationId: apply-coupon-code
       responses:
         '200':
           description: Coupon code was applied successfully
@@ -697,7 +697,7 @@ paths:
       description: 'Removes a coupon code from the Cart. If no `coupon_code` aprameter is passed , it will remove all applied coupon codes.'
       tags:
         - Cart
-      operationId: Remove Coupon Code
+      operationId: remove-coupon-code
       parameters:
         - name: coupon_code
           in: path
@@ -730,7 +730,7 @@ paths:
       description: Returns a list of Estimated Shipping Rates for Cart. Those are only estimates and can vary from the final shipping rates.
       tags:
         - Cart
-      operationId: Estimate Shipping Rates
+      operationId: estimate-shipping-rates
       parameters:
         - name: country_iso
           in: query
@@ -861,7 +861,7 @@ paths:
         This will complete the Checkout and mark the Order as completed. You cannot execute any operations on this Order anymore via Storefront API. Further operations on the Order are possible via [Spree API v1](https://guides.spreecommerce.org/api/).
       tags:
         - Checkout
-      operationId: Update Checkout
+      operationId: update-checkout
       responses:
         '200':
           description: Checkout was updated
@@ -918,7 +918,7 @@ paths:
       description: Goes to the next Checkout step
       tags:
         - Checkout
-      operationId: Checkout Next
+      operationId: checkout-next
       responses:
         '200':
           description: Checkout transitioned to the next step
@@ -946,7 +946,7 @@ paths:
       description: 'Advances Checkout to the furthest Checkout step validation allows, until the Complete step'
       tags:
         - Checkout
-      operationId: Advance Checkout
+      operationId: advance-checkout
       responses:
         '200':
           description: Checkout was advanced to the furthest step
@@ -974,7 +974,7 @@ paths:
       description: Completes the Checkout
       tags:
         - Checkout
-      operationId: Complete Checkout
+      operationId: complete-checkout
       responses:
         '200':
           description: Checkout was completed
@@ -1001,7 +1001,7 @@ paths:
       description: 'Adds Store Credit payment if the currently signed in User has any available. [Read more about Store Credits](https://guides.spreecommerce.org/user/users/editing_users.html#store-credits)'
       tags:
         - Checkout
-      operationId: Add Store Credit
+      operationId: add-store-credit
       responses:
         '200':
           description: Store Credit payment created
@@ -1026,7 +1026,7 @@ paths:
           description: Amount of Store Credit to use. As much as possible Store Credit will be applied if no amount is passed.
           schema:
             type: string
-          example: 100
+          example: "100"
         - $ref: '#/components/parameters/CartIncludeParam'
         - $ref: '#/components/parameters/SparseFieldsParam'
       summary: Add Store Credit
@@ -1035,7 +1035,7 @@ paths:
       description: Remove Store Credit payments if any applied
       tags:
         - Checkout
-      operationId: Remove Store Credit
+      operationId: remove-store-credit
       responses:
         '200':
           description: Store Credit payment removed
@@ -1063,7 +1063,7 @@ paths:
       description: Returns a list of available Payment Methods for this Checkout
       tags:
         - Checkout
-      operationId: Payment Methods
+      operationId: payment-methods
       responses:
         '200':
           description: Returns a list of available Payment Methods
@@ -1082,7 +1082,7 @@ paths:
       description: Returns a list of available Shipping Rates for Checkout. Shipping Rates are grouped against Shipments. Each checkout can have multiple Shipments eg. some products are available in stock and will be send out instantly and some needs to be backordered.
       tags:
         - Checkout
-      operationId: Shipping Rates
+      operationId: shipping-rates
       responses:
         '200':
           description: Returns a list of available Shipping Rates for Checkout
@@ -1101,7 +1101,7 @@ paths:
       description: Returns a list of Products for the current Store.
       tags:
         - Products
-      operationId: Products List
+      operationId: products-list
       parameters:
         - $ref: '#/components/parameters/FilterByIds'
         - $ref: '#/components/parameters/FilterBySKUs'
@@ -1188,7 +1188,7 @@ paths:
         **Note** API will attempt a permalink lookup before an ID lookup.
       tags:
         - Products
-      operationId: Show Product
+      operationId: show-product
       parameters:
         - $ref: '#/components/parameters/ProductSlug'
         - $ref: '#/components/parameters/ProductIncludeParam'
@@ -3530,7 +3530,7 @@ paths:
       description: 'Returns a list of Taxons. [Read more about Taxons](https://guides.spreecommerce.org/developer/core/products.html#taxons-and-taxonomies)'
       tags:
         - Taxons
-      operationId: Taxons List
+      operationId: taxons-list
       parameters:
         - $ref: '#/components/parameters/FilterByIds'
         - $ref: '#/components/parameters/FilterByName'
@@ -3582,7 +3582,7 @@ paths:
         **Note** API will attempt a permalink lookup before an ID lookup.
       tags:
         - Taxons
-      operationId: Show Taxon
+      operationId: show-taxon
       parameters:
         - $ref: '#/components/parameters/TaxonPermalink'
         - $ref: '#/components/parameters/TaxonIncludeParam'
@@ -3852,7 +3852,7 @@ paths:
       description: Returns a list of all Countries
       tags:
         - Countries
-      operationId: Countries List
+      operationId: countries-list
       responses:
         '200':
           description: Returns a list of all Countries
@@ -3879,7 +3879,7 @@ paths:
         **Note** API will attempt a iso lookup before an iso3 lookup.
       tags:
         - Countries
-      operationId: Show Country
+      operationId: show-country
       parameters:
         - $ref: '#/components/parameters/IsoOrIso3'
         - $ref: '#/components/parameters/CountryIncludeParam'
@@ -3899,7 +3899,7 @@ paths:
       description: Returns the default Country for the application. By default this will be the US.
       tags:
         - Countries
-      operationId: Default Country
+      operationId: default-country
       parameters:
         - $ref: '#/components/parameters/CountryIncludeParam'
         - $ref: '#/components/parameters/SparseFieldsParam'
@@ -4021,6 +4021,7 @@ components:
               description: Country ISO3 code
             company:
               type: string
+              nullable: true
               example: Google Inc.
     AddressList:
       required:
@@ -4391,7 +4392,7 @@ components:
       properties:
         id:
           type: string
-          example: 1
+          example: "1"
         type:
           type: string
           default: user
@@ -4693,12 +4694,15 @@ components:
           example: Clothes - T-shirts
         meta_title:
           type: string
+          nullable: true
           example: T-shirts
         meta_description:
           type: string
+          nullable: true
           example: 'A list of cool t-shirts '
         meta_keywords:
           type: string
+          nullable: true
           example: 't-shirts, cool'
         left:
           type: integer
@@ -4711,6 +4715,7 @@ components:
           example: 0
         depth:
           type: integer
+          nullable: true
           example: 1
         is_root:
           type: boolean
@@ -5235,7 +5240,7 @@ components:
         shipped_at:
           type: string
           format: date-time
-          example: '2019-01-02 13:42:12 UTC'
+          example: '2019-01-02 13:42:12'
           description: Date when Shipment was being sent from the warehouse
     ShippingRatesList:
       required:
@@ -5489,7 +5494,7 @@ components:
       description: Number of requested records per page when paginating collection
       schema:
         type: integer
-      example: null
+      example: 25
     OrderParam:
       name: order_number
       in: path
@@ -5596,7 +5601,7 @@ components:
         [More information](https://jsonapi.org/format/#fetching-sparse-fieldsets)
       example: '[cart]=total,currency,number'
       schema:
-        type: object
+        type: string
   responses:
     404NotFound:
       description: Resource not found


### PR DESCRIPTION
- Fix errors for` $ref '#...'` nested under an object unnecessarily.
- Set compliant operation ID's 
- Add global Tags.
- Use string example where type is declared string.
- Set cart example to match the Schema.
- use anyOf: where appropriate.
- convert `IdOrPermalink` into 2 separate references, one dedicated `productSlug` and another for `taxonPermalink` so examples are more relevant to each.