### PR TITLE
Safe navigation operator for current_api_user has_spree_role? call in…

### DIFF
--- a/api/app/controllers/spree/api/v1/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/v1/checkouts_controller.rb
@@ -22,7 +22,7 @@ module Spree
           authorize! :update, @order, order_token
 
           if @order.update_from_params(params, permitted_checkout_attributes, request.headers.env)
-            if current_api_user&.has_spree_role?('admin') && user_id.present?
+            if user_id.present? && current_api_user&.has_spree_role?('admin')
               @order.associate_user!(Spree.user_class.find(user_id))
             end
 

--- a/api/app/controllers/spree/api/v1/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/v1/checkouts_controller.rb
@@ -22,7 +22,7 @@ module Spree
           authorize! :update, @order, order_token
 
           if @order.update_from_params(params, permitted_checkout_attributes, request.headers.env)
-            if current_api_user.has_spree_role?('admin') && user_id.present?
+            if current_api_user&.has_spree_role?('admin') && user_id.present?
               @order.associate_user!(Spree.user_class.find(user_id))
             end
 

--- a/api/app/controllers/spree/api/v1/orders_controller.rb
+++ b/api/app/controllers/spree/api/v1/orders_controller.rb
@@ -77,7 +77,7 @@ module Spree
 
           if Cart::Update.call(order: @order, params: order_params).success?
             user_id = params[:order][:user_id]
-            if current_api_user.has_spree_role?('admin') && user_id
+            if current_api_user&.has_spree_role?('admin') && user_id
               @order.associate_user!(Spree.user_class.find(user_id))
             end
             respond_with(@order, default_template: :show)

--- a/api/app/controllers/spree/api/v1/orders_controller.rb
+++ b/api/app/controllers/spree/api/v1/orders_controller.rb
@@ -77,7 +77,7 @@ module Spree
 
           if Cart::Update.call(order: @order, params: order_params).success?
             user_id = params[:order][:user_id]
-            if current_api_user&.has_spree_role?('admin') && user_id
+            if user_id && current_api_user&.has_spree_role?('admin')
               @order.associate_user!(Spree.user_class.find(user_id))
             end
             respond_with(@order, default_template: :show)


### PR DESCRIPTION
… checkouts_controller

The current_api_user can be nil hence we need to safely navigate it to prevent a no method error when a customer is using guest checkout.