### PR TITLE
Add text foreground and background color options to WYSIWYG editor.

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/global/tinymce.es6
+++ b/backend/app/assets/javascripts/spree/backend/global/tinymce.es6
@@ -3,7 +3,7 @@ document.addEventListener('DOMContentLoaded', function() {
   tinymce.init({
     selector: '.spree-rte',
     plugins: [
-      'image table paste code link table textcolor'
+      'image table paste code link table'
     ],
     menubar: false,
     toolbar: 'undo redo | styleselect | bold italic link forecolor backcolor | alignleft aligncenter alignright alignjustify | table | bullist numlist outdent indent | code '

--- a/backend/app/assets/javascripts/spree/backend/global/tinymce.es6
+++ b/backend/app/assets/javascripts/spree/backend/global/tinymce.es6
@@ -3,9 +3,9 @@ document.addEventListener('DOMContentLoaded', function() {
   tinymce.init({
     selector: '.spree-rte',
     plugins: [
-      'image table paste code link table'
+      'image table paste code link table textcolor'
     ],
     menubar: false,
-    toolbar: 'undo redo | styleselect | bold italic link | alignleft aligncenter alignright alignjustify | table | bullist numlist outdent indent | code '
+    toolbar: 'undo redo | styleselect | bold italic link forecolor backcolor | alignleft aligncenter alignright alignjustify | table | bullist numlist outdent indent | code '
   });
 })


### PR DESCRIPTION
<img width="764" alt="Screenshot 2021-08-12 at 14 49 45" src="https://user-images.githubusercontent.com/1240766/129208543-341c4de1-72d5-4150-ad3a-e02b7b661808.png">
