### PR TITLE
Add locale for model cms_pages and cms_sections

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -184,6 +184,12 @@ en:
       spree/address:
         one: Address
         other: Addresses
+      spree/cms_page:
+        one: Page
+        other: Pages
+      spree/cms_section:
+        one: Section
+        other: Sections
       spree/country:
         one: Country
         other: Countries


### PR DESCRIPTION
Now Use: `Page Created` or `Section Created` in flash notifications, vs `Cms page Created` , `Cms section Created`