### PR TITLE
Fixed: do not call OrderMailer directly and use Order#deliver_order_c…

### DIFF
--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -113,7 +113,7 @@ module Spree
       end
 
       def resend
-        OrderMailer.confirm_email(@order.id, true).deliver_later
+        @order.deliver_order_confirmation_email
         flash[:success] = Spree.t(:order_email_resent)
 
         redirect_back fallback_location: spree.edit_admin_order_url(@order)

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -98,6 +98,15 @@ describe Spree::Admin::OrdersController, type: :controller do
       end
     end
 
+    describe '#resend' do
+      let(:order) { create(:order, state: 'canceled', store: store) }
+
+      it 'resends oder mailer' do
+        put :resend, params: { id: order.number }
+        expect(flash[:success]).to eq Spree.t(:order_email_resent)
+      end
+    end
+
     context 'pagination' do
       it 'can page through the orders' do
         get :index, params: { page: 2, per_page: 10 }


### PR DESCRIPTION
…onfirmation_email

Order#deliver_order_confirmation_email can be replaced with a custom email send out system like Klaviyo or other 3rd parties. Also this fixes 50x error when spree_emails aren't installed