### PR TITLE
Rescue load error on dummy app generation

### DIFF
--- a/core/lib/generators/spree/dummy/dummy_generator.rb
+++ b/core/lib/generators/spree/dummy/dummy_generator.rb
@@ -68,7 +68,7 @@ module Spree
             inside dummy_path do
               inject_require_for(gem)
             end
-          rescue
+          rescue StandardError, LoadError
           end
         end
       end


### PR DESCRIPTION
This change is needed for test_app task invoked from spree gems like spree_auth_devise, that do not require all of SPREE_GEMS.
By default `rescue` will rescue only StandardError exceptions and subclasses.
LoadError doesn't inherit from StandardError.