### PR TITLE
Increased API v2 per page limit to 500

### DIFF
--- a/api/app/models/spree/api_configuration.rb
+++ b/api/app/models/spree/api_configuration.rb
@@ -5,6 +5,6 @@ module Spree
     preference :api_v2_collection_cache_ttl, :integer, default: 3600 # 1 hour in seconds
     preference :api_v2_collection_cache_namespace, :string, default: 'api_v2_collection_cache'
     preference :api_v2_content_type, :string, default: 'application/vnd.api+json'
-    preference :api_v2_per_page_limit, :integer, default: 100
+    preference :api_v2_per_page_limit, :integer, default: 500
   end
 end


### PR DESCRIPTION
100 is too restrictive for most common-world scenarios and with new improvements to performance and caching we can allow by default bigger records list returned