### PR TITLE
Allow footer columns to stack neatly if more than 4 used.

### DIFF
--- a/frontend/app/views/spree/shared/_footer.html.erb
+++ b/frontend/app/views/spree/shared/_footer.html.erb
@@ -47,11 +47,11 @@
           </div>
         </div>
       </div>
-      <div class="row d-none d-xl-flex border-top py-5 text-uppercase footer-spree-menu-links">
+      <div class="row d-none d-xl-flex border-top pt-5 text-uppercase footer-spree-menu-links">
 
         <% if spree_menu('footer').present? %>
           <% spree_menu('footer').children.each do |parent| %>
-            <div class="col-3">
+            <div class="col-3 mb-5">
               <div class="footer-spree-label">
                 <% if parent.container? %>
                   <%= parent.name %>
@@ -69,7 +69,7 @@
         <% end %>
 
         <% if spree.respond_to?(:account_path) %>
-          <div class="col-3">
+          <div class="col-3 mb-5">
             <div class="footer-spree-label">
               <%= Spree.t('nav_bar.my_account') %>
             </div>


### PR DESCRIPTION
**Before**
<img width="1267" alt="Screenshot 2021-08-17 at 14 11 35" src="https://user-images.githubusercontent.com/1240766/129725931-35a9740d-e380-4161-b159-40327e21438f.png">
**After**
<img width="1406" alt="Screenshot 2021-08-17 at 13 30 33" src="https://user-images.githubusercontent.com/1240766/129725834-6b357e52-5b7c-4c37-9e98-a038a93d89d5.png">
