### PR TITLE
Move #ensure_current_store to core based controller helper

### DIFF
--- a/api/spec/serializers/spree/api/v2/platform/store_serializer_spec.rb
+++ b/api/spec/serializers/spree/api/v2/platform/store_serializer_spec.rb
@@ -3,7 +3,8 @@ require 'spec_helper'
 describe Spree::Api::V2::Platform::StoreSerializer do
   subject { described_class.new(store) }
 
-  let(:store) { create(:store, menus: [create(:menu), create(:menu, location: 'Footer')]) }
+  let!(:store) { Spree::Store.default }
+  let!(:menus) { [create(:menu, store: store), create(:menu, location: 'Footer', store: store)] }
 
   it { expect(subject.serializable_hash).to be_kind_of(Hash) }
 

--- a/backend/app/controllers/spree/admin/payment_methods_controller.rb
+++ b/backend/app/controllers/spree/admin/payment_methods_controller.rb
@@ -10,7 +10,7 @@ module Spree
       def create
         @payment_method = params[:payment_method].delete(:type).constantize.new(payment_method_params)
         @object = @payment_method
-        ensure_current_store
+        ensure_current_store(@object)
         invoke_callbacks(:create, :before)
         if @payment_method.save
           invoke_callbacks(:create, :after)
@@ -39,7 +39,7 @@ module Spree
         end
 
         if @payment_method.update(attributes)
-          ensure_current_store
+          ensure_current_store(@payment_method)
           invoke_callbacks(:update, :after)
           flash[:success] = Spree.t(:successfully_updated, resource: Spree.t(:payment_method))
           redirect_to spree.edit_admin_payment_method_path(@payment_method)

--- a/backend/app/controllers/spree/admin/payment_methods_controller.rb
+++ b/backend/app/controllers/spree/admin/payment_methods_controller.rb
@@ -10,7 +10,7 @@ module Spree
       def create
         @payment_method = params[:payment_method].delete(:type).constantize.new(payment_method_params)
         @object = @payment_method
-        ensure_current_store(@object)
+        set_current_store
         invoke_callbacks(:create, :before)
         if @payment_method.save
           invoke_callbacks(:create, :after)
@@ -39,7 +39,7 @@ module Spree
         end
 
         if @payment_method.update(attributes)
-          ensure_current_store(@payment_method)
+          set_current_store
           invoke_callbacks(:update, :after)
           flash[:success] = Spree.t(:successfully_updated, resource: Spree.t(:payment_method))
           redirect_to spree.edit_admin_payment_method_path(@payment_method)

--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -30,7 +30,7 @@ module Spree
         end
         invoke_callbacks(:update, :before)
         if @object.update(permitted_resource_params)
-          ensure_current_store
+          ensure_current_store(@object)
           invoke_callbacks(:update, :after)
           flash[:success] = flash_message_for(@object, :successfully_updated)
           respond_with(@object) do |format|

--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -30,7 +30,7 @@ module Spree
         end
         invoke_callbacks(:update, :before)
         if @object.update(permitted_resource_params)
-          ensure_current_store(@object)
+          set_current_store
           invoke_callbacks(:update, :after)
           flash[:success] = flash_message_for(@object, :successfully_updated)
           respond_with(@object) do |format|

--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -3,7 +3,11 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
 
   helper_method :new_object_url, :edit_object_url, :object_url, :collection_url
   before_action :load_resource, except: :update_positions
-  before_action :set_currency, :ensure_current_store, only: [:new, :create]
+  before_action only: [:new, :create] do
+    set_currency
+    ensure_current_store(@object)
+  end
+
   rescue_from ActiveRecord::RecordNotFound, with: :resource_not_found
 
   respond_to :html
@@ -26,7 +30,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
   def update
     invoke_callbacks(:update, :before)
     if @object.update(permitted_resource_params)
-      ensure_current_store
+      ensure_current_store(@object)
       invoke_callbacks(:update, :after)
       respond_with(@object) do |format|
         format.html do
@@ -212,10 +216,6 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
 
     @object.currency = current_currency if model_class.method_defined?(:currency=)
     @object.cost_currency = current_currency if model_class.method_defined?(:cost_currency=)
-  end
-
-  def ensure_current_store
-    set_current_store(@object)
   end
 
   # URL helpers

--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -3,7 +3,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
 
   helper_method :new_object_url, :edit_object_url, :object_url, :collection_url
   before_action :load_resource, except: :update_positions
-  before_action :set_currency, :ensure_current_store, only: [:new, :create]
+  before_action :set_currency, :set_current_store, only: [:new, :create]
   rescue_from ActiveRecord::RecordNotFound, with: :resource_not_found
 
   respond_to :html
@@ -214,14 +214,8 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
     @object.cost_currency = current_currency if model_class.method_defined?(:cost_currency=)
   end
 
-  def ensure_current_store
-    return if @object.nil?
-
-    if @object.has_attribute?(:store_id)
-      @object.store = current_store
-    elsif model_class.method_defined?(:stores) && @object.stores.exclude?(current_store)
-      @object.stores << current_store
-    end
+  def set_current_store
+    ensure_current_store(@object, model_class)
   end
 
   # URL helpers

--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -215,9 +215,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
   end
 
   def ensure_current_store
-    return if @object.nil?
-
-    set_current_store(@object, model_class)
+    set_current_store(@object)
   end
 
   # URL helpers

--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -215,6 +215,8 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
   end
 
   def ensure_current_store
+    return if @object.nil?
+
     set_current_store(@object, model_class)
   end
 

--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -3,10 +3,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
 
   helper_method :new_object_url, :edit_object_url, :object_url, :collection_url
   before_action :load_resource, except: :update_positions
-  before_action only: [:new, :create] do
-    set_currency
-    ensure_current_store(@object)
-  end
+  before_action :set_currency, :set_current_store, only: [:new, :create]
 
   rescue_from ActiveRecord::RecordNotFound, with: :resource_not_found
 
@@ -30,7 +27,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
   def update
     invoke_callbacks(:update, :before)
     if @object.update(permitted_resource_params)
-      ensure_current_store(@object)
+      set_current_store
       invoke_callbacks(:update, :after)
       respond_with(@object) do |format|
         format.html do
@@ -209,6 +206,12 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
 
   def location_after_save
     collection_url
+  end
+
+  def set_current_store
+    return if @object.nil?
+
+    ensure_current_store(@object)
   end
 
   def set_currency

--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -3,7 +3,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
 
   helper_method :new_object_url, :edit_object_url, :object_url, :collection_url
   before_action :load_resource, except: :update_positions
-  before_action :set_currency, :set_current_store, only: [:new, :create]
+  before_action :set_currency, :ensure_current_store, only: [:new, :create]
   rescue_from ActiveRecord::RecordNotFound, with: :resource_not_found
 
   respond_to :html
@@ -214,8 +214,8 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
     @object.cost_currency = current_currency if model_class.method_defined?(:cost_currency=)
   end
 
-  def set_current_store
-    ensure_current_store(@object, model_class)
+  def ensure_current_store
+    set_current_store(@object, model_class)
   end
 
   # URL helpers

--- a/core/app/models/concerns/spree/single_store_resource.rb
+++ b/core/app/models/concerns/spree/single_store_resource.rb
@@ -12,7 +12,6 @@ module Spree
 
     def ensure_store_association_is_not_changed
       if store_id_changed? && persisted?
-
         errors.add(:store, Spree.t('errors.messages.store_association_can_not_be_changed'))
       end
     end

--- a/core/app/models/concerns/spree/single_store_resource.rb
+++ b/core/app/models/concerns/spree/single_store_resource.rb
@@ -3,7 +3,18 @@ module Spree
     extend ActiveSupport::Concern
 
     included do
+      validate :ensure_store_association_is_not_changed
+
       scope :for_store, ->(store) { where(store_id: store.id) }
+    end
+
+    protected
+
+    def ensure_store_association_is_not_changed
+      if store_id_changed? && persisted?
+
+        errors.add(:store, Spree.t('errors.messages.store_association_can_not_be_changed'))
+      end
     end
   end
 end

--- a/core/app/models/concerns/spree/single_store_resource.rb
+++ b/core/app/models/concerns/spree/single_store_resource.rb
@@ -3,7 +3,9 @@ module Spree
     extend ActiveSupport::Concern
 
     included do
-      scope :for_store, ->(store) { where(store_id: store.id) }
+      if has_attribute?(:store_id)
+        scope :for_store, ->(store) { where(store_id: store.id) }
+      end
     end
   end
 end

--- a/core/app/models/concerns/spree/single_store_resource.rb
+++ b/core/app/models/concerns/spree/single_store_resource.rb
@@ -3,9 +3,7 @@ module Spree
     extend ActiveSupport::Concern
 
     included do
-      if has_attribute?(:store_id)
-        scope :for_store, ->(store) { where(store_id: store.id) }
-      end
+      scope :for_store, ->(store) { where(store_id: store.id) }
     end
   end
 end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -970,6 +970,7 @@ en:
     error: error
     errors:
       messages:
+        store_association_can_not_be_changed: The store association can not be changed
         store_is_already_set: Store is already set
         blank: can't be blank
         could_not_create_taxon: Could not create taxon

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -970,6 +970,7 @@ en:
     error: error
     errors:
       messages:
+        store_is_already_set: Store is already set
         blank: can't be blank
         could_not_create_taxon: Could not create taxon
         no_shipping_methods_available: No shipping methods available for selected location, please change your address and try again.

--- a/core/lib/spree/core/controller_helpers/store.rb
+++ b/core/lib/spree/core/controller_helpers/store.rb
@@ -23,12 +23,12 @@ module Spree
           current_store.default_locale
         end
 
-        def set_current_store(object, model_class)
-          return if object.nil? || model_class.nil?
+        def set_current_store(object)
+          return if object.nil?
 
           if object.has_attribute?(:store_id)
             object.store = current_store
-          elsif model_class.method_defined?(:stores) && object.stores.exclude?(current_store)
+          elsif object.class.method_defined?(:stores) && object.stores.exclude?(current_store)
             object.stores << current_store
           end
         end

--- a/core/lib/spree/core/controller_helpers/store.rb
+++ b/core/lib/spree/core/controller_helpers/store.rb
@@ -8,7 +8,6 @@ module Spree
           helper_method :current_store
           helper_method :current_price_options
           helper_method :available_menus
-          helper_method :ensure_current_store
         end
 
         def current_store

--- a/core/lib/spree/core/controller_helpers/store.rb
+++ b/core/lib/spree/core/controller_helpers/store.rb
@@ -27,7 +27,7 @@ module Spree
 
           if object.has_attribute?(:store_id)
             if object.store.present?
-              raise StandardError, Spree.t('errors.messages.store_is_already_set')
+              raise Spree.t('errors.messages.store_is_already_set')
             else
               object.store = current_store
             end

--- a/core/lib/spree/core/controller_helpers/store.rb
+++ b/core/lib/spree/core/controller_helpers/store.rb
@@ -8,7 +8,7 @@ module Spree
           helper_method :current_store
           helper_method :current_price_options
           helper_method :available_menus
-          helper_method :ensure_current_store
+          helper_method :set_current_store
         end
 
         def current_store
@@ -23,7 +23,7 @@ module Spree
           current_store.default_locale
         end
 
-        def ensure_current_store(resource, model_class)
+        def set_current_store(resource, model_class)
           return unless resource.instance_of? model_class
 
           if resource.has_attribute?(:store_id)

--- a/core/lib/spree/core/controller_helpers/store.rb
+++ b/core/lib/spree/core/controller_helpers/store.rb
@@ -8,7 +8,7 @@ module Spree
           helper_method :current_store
           helper_method :current_price_options
           helper_method :available_menus
-          helper_method :set_current_store
+          helper_method :ensure_current_store
         end
 
         def current_store
@@ -23,7 +23,7 @@ module Spree
           current_store.default_locale
         end
 
-        def set_current_store(object)
+        def ensure_current_store(object)
           return if object.nil?
 
           if object.has_attribute?(:store_id)

--- a/core/lib/spree/core/controller_helpers/store.rb
+++ b/core/lib/spree/core/controller_helpers/store.rb
@@ -26,7 +26,7 @@ module Spree
           return if object.nil?
 
           if object.has_attribute?(:store_id)
-            if object.store.present?
+            if object.store.present? && object.store != current_store
               raise Spree.t('errors.messages.store_is_already_set')
             else
               object.store = current_store

--- a/core/lib/spree/core/controller_helpers/store.rb
+++ b/core/lib/spree/core/controller_helpers/store.rb
@@ -23,13 +23,13 @@ module Spree
           current_store.default_locale
         end
 
-        def set_current_store(resource, model_class)
-          return unless resource.instance_of? model_class
+        def set_current_store(object, model_class)
+          return if object.nil? || model_class.nil?
 
-          if resource.has_attribute?(:store_id)
-            resource.store = current_store
-          elsif model_class.method_defined?(:stores) && resource.stores.exclude?(current_store)
-            resource.stores << current_store
+          if object.has_attribute?(:store_id)
+            object.store = current_store
+          elsif model_class.method_defined?(:stores) && object.stores.exclude?(current_store)
+            object.stores << current_store
           end
         end
 

--- a/core/lib/spree/core/controller_helpers/store.rb
+++ b/core/lib/spree/core/controller_helpers/store.rb
@@ -26,7 +26,11 @@ module Spree
           return if object.nil?
 
           if object.has_attribute?(:store_id)
-            object.store = current_store
+            if object.store.present?
+              raise StandardError, Spree.t('errors.messages.store_is_already_set')
+            else
+              object.store = current_store
+            end
           elsif object.class.method_defined?(:stores) && object.stores.exclude?(current_store)
             object.stores << current_store
           end

--- a/core/lib/spree/core/controller_helpers/store.rb
+++ b/core/lib/spree/core/controller_helpers/store.rb
@@ -8,6 +8,7 @@ module Spree
           helper_method :current_store
           helper_method :current_price_options
           helper_method :available_menus
+          helper_method :ensure_current_store
         end
 
         def current_store
@@ -20,6 +21,16 @@ module Spree
 
         def store_locale
           current_store.default_locale
+        end
+
+        def ensure_current_store(resource, model_class)
+          return unless resource.instance_of? model_class
+
+          if resource.has_attribute?(:store_id)
+            resource.store = current_store
+          elsif model_class.method_defined?(:stores) && resource.stores.exclude?(current_store)
+            resource.stores << current_store
+          end
         end
 
         # Return a Hash of things that influence the prices displayed in your shop.

--- a/core/spec/lib/spree/core/controller_helpers/store_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/store_spec.rb
@@ -110,6 +110,17 @@ describe Spree::Core::ControllerHelpers::Store, type: :controller do
           expect { controller.ensure_current_store(object) }.to raise_error('Store is already set')
         end
       end
+
+      context 'when an object already has a store assigned and the same store is re-assigned' do
+        object = Spree::Menu.new
+
+        it 'no exception is raised' do
+          object.store = store
+          object.save
+
+          expect { controller.ensure_current_store(object) }.not_to raise_error
+        end
+      end
     end
 
     context 'when an object that does not have store association is passed in' do

--- a/core/spec/lib/spree/core/controller_helpers/store_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/store_spec.rb
@@ -49,38 +49,49 @@ describe Spree::Core::ControllerHelpers::Store, type: :controller do
     let!(:store) { create :store, default: true }
     let!(:store_2) { create :store }
 
-    context 'sets current store on a resource that accepts multiple stores' do
+    context 'on an object that accepts multiple stores' do
       before { allow(controller).to receive(:current_store).and_return(store) }
 
-      resource = Spree::Product.new
+      object = Spree::Product.new
 
-      it 'sets only the current store' do
-        controller.set_current_store(resource, Spree::Product)
-        expect(resource.stores).to contain_exactly(store)
-        expect(resource.stores).not_to contain_exactly(store_2)
+      it 'object has only the current store set' do
+        controller.set_current_store(object, Spree::Product)
+        expect(object.stores).to contain_exactly(store)
+        expect(object.stores).not_to contain_exactly(store_2)
       end
     end
 
-    context 'sets current store on a resource that accepts one store' do
+    context 'on a object that accepts a single store' do
       before { allow(controller).to receive(:current_store).and_return(store) }
 
-      resource = Spree::Menu.new
+      object = Spree::Menu.new
 
-      it 'applies the current store' do
-        controller.set_current_store(resource, Spree::Menu)
-        expect(resource.store).to eql(store)
-        expect(resource.store).not_to eql(store_2)
+      it 'object has the current store set' do
+        controller.set_current_store(object, Spree::Menu)
+        expect(object.store).to eql(store)
+        expect(object.store).not_to eql(store_2)
       end
     end
 
-    context 'when instance is not matching the model class' do
+    context 'when object is nil' do
       before { allow(controller).to receive(:current_store).and_return(store) }
 
-      resource = Spree::Menu.new
+      object = nil
 
       it 'returns nil' do
-        controller.set_current_store(resource, Spree::Taxon)
-        expect(resource.store).to be_nil
+        expect(controller.set_current_store(object, Spree::Taxon)).to be_nil
+      end
+    end
+
+    context 'when model_class is nil' do
+      before { allow(controller).to receive(:current_store).and_return(store) }
+
+      object = Spree::Menu.new
+
+      it 'returns nil' do
+        controller.set_current_store(object, nil)
+        expect(object.store).to be_nil
+        expect(controller.set_current_store(object, nil)).to be_nil
       end
     end
   end

--- a/core/spec/lib/spree/core/controller_helpers/store_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/store_spec.rb
@@ -55,7 +55,7 @@ describe Spree::Core::ControllerHelpers::Store, type: :controller do
       object = Spree::Product.new
 
       it 'object has only the current store set' do
-        controller.set_current_store(object, Spree::Product)
+        controller.set_current_store(object)
         expect(object.stores).to contain_exactly(store)
         expect(object.stores).not_to contain_exactly(store_2)
       end
@@ -67,7 +67,7 @@ describe Spree::Core::ControllerHelpers::Store, type: :controller do
       object = Spree::Menu.new
 
       it 'object has the current store set' do
-        controller.set_current_store(object, Spree::Menu)
+        controller.set_current_store(object)
         expect(object.store).to eql(store)
         expect(object.store).not_to eql(store_2)
       end
@@ -79,19 +79,7 @@ describe Spree::Core::ControllerHelpers::Store, type: :controller do
       object = nil
 
       it 'returns nil' do
-        expect(controller.set_current_store(object, Spree::Taxon)).to be_nil
-      end
-    end
-
-    context 'when model_class is nil' do
-      before { allow(controller).to receive(:current_store).and_return(store) }
-
-      object = Spree::Menu.new
-
-      it 'returns nil' do
-        controller.set_current_store(object, nil)
-        expect(object.store).to be_nil
-        expect(controller.set_current_store(object, nil)).to be_nil
+        expect(controller.set_current_store(object)).to be_nil
       end
     end
   end

--- a/core/spec/lib/spree/core/controller_helpers/store_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/store_spec.rb
@@ -45,6 +45,46 @@ describe Spree::Core::ControllerHelpers::Store, type: :controller do
     end
   end
 
+  describe '#ensure_current_store' do
+    let!(:store) { create :store, default: true }
+    let!(:store_2) { create :store }
+
+    context 'sets current store on a resource that accepts multiple stores' do
+      before { allow(controller).to receive(:current_store).and_return(store) }
+
+      resource = Spree::Product.new
+
+      it 'sets only the current store' do
+        controller.ensure_current_store(resource, Spree::Product)
+        expect(resource.stores).to contain_exactly(store)
+        expect(resource.stores).not_to contain_exactly(store_2)
+      end
+    end
+
+    context 'sets current store on a resource that accepts one store' do
+      before { allow(controller).to receive(:current_store).and_return(store) }
+
+      resource = Spree::Menu.new
+
+      it 'applies the current store' do
+        controller.ensure_current_store(resource, Spree::Menu)
+        expect(resource.store).to eql(store)
+        expect(resource.store).not_to eql(store_2)
+      end
+    end
+
+    context 'when instance is not matching the model class' do
+      before { allow(controller).to receive(:current_store).and_return(store) }
+
+      resource = Spree::Menu.new
+
+      it 'returns nil' do
+        controller.ensure_current_store(resource, Spree::Taxon)
+        expect(resource.store).to be_nil
+      end
+    end
+  end
+
   describe '#current_price_options' do
     subject(:current_price_options) { controller.current_price_options }
 

--- a/core/spec/lib/spree/core/controller_helpers/store_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/store_spec.rb
@@ -107,7 +107,7 @@ describe Spree::Core::ControllerHelpers::Store, type: :controller do
           object.store = store_2
           object.save
 
-          expect { controller.ensure_current_store(object) }.to raise_error("Store is already set")
+          expect { controller.ensure_current_store(object) }.to raise_error('Store is already set')
         end
       end
     end

--- a/core/spec/lib/spree/core/controller_helpers/store_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/store_spec.rb
@@ -103,13 +103,11 @@ describe Spree::Core::ControllerHelpers::Store, type: :controller do
       context 'when an object already has a store assigned' do
         object = Spree::Menu.new
 
-        it 'overrides the store with current_store' do
+        it 'raises an exception' do
           object.store = store_2
           object.save
 
-          controller.ensure_current_store(object)
-          expect(object.store).to eql(store)
-          expect(object.store).not_to eql(store_2)
+          expect { controller.ensure_current_store(object) }.to raise_error("Store is already set")
         end
       end
     end

--- a/core/spec/lib/spree/core/controller_helpers/store_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/store_spec.rb
@@ -45,7 +45,7 @@ describe Spree::Core::ControllerHelpers::Store, type: :controller do
     end
   end
 
-  describe '#set_current_store' do
+  describe '#ensure_current_store' do
     let!(:store) { create :store, default: true }
     let!(:store_2) { create :store }
 
@@ -55,7 +55,7 @@ describe Spree::Core::ControllerHelpers::Store, type: :controller do
       object = Spree::Product.new
 
       it 'object has only the current store set' do
-        controller.set_current_store(object)
+        controller.ensure_current_store(object)
         expect(object.stores).to contain_exactly(store)
         expect(object.stores).not_to contain_exactly(store_2)
       end
@@ -67,7 +67,7 @@ describe Spree::Core::ControllerHelpers::Store, type: :controller do
       object = Spree::Menu.new
 
       it 'object has the current store set' do
-        controller.set_current_store(object)
+        controller.ensure_current_store(object)
         expect(object.store).to eql(store)
         expect(object.store).not_to eql(store_2)
       end
@@ -79,7 +79,7 @@ describe Spree::Core::ControllerHelpers::Store, type: :controller do
       object = nil
 
       it 'returns nil' do
-        expect(controller.set_current_store(object)).to be_nil
+        expect(controller.ensure_current_store(object)).to be_nil
       end
     end
   end

--- a/core/spec/lib/spree/core/controller_helpers/store_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/store_spec.rb
@@ -45,7 +45,7 @@ describe Spree::Core::ControllerHelpers::Store, type: :controller do
     end
   end
 
-  describe '#ensure_current_store' do
+  describe '#set_current_store' do
     let!(:store) { create :store, default: true }
     let!(:store_2) { create :store }
 
@@ -55,7 +55,7 @@ describe Spree::Core::ControllerHelpers::Store, type: :controller do
       resource = Spree::Product.new
 
       it 'sets only the current store' do
-        controller.ensure_current_store(resource, Spree::Product)
+        controller.set_current_store(resource, Spree::Product)
         expect(resource.stores).to contain_exactly(store)
         expect(resource.stores).not_to contain_exactly(store_2)
       end
@@ -67,7 +67,7 @@ describe Spree::Core::ControllerHelpers::Store, type: :controller do
       resource = Spree::Menu.new
 
       it 'applies the current store' do
-        controller.ensure_current_store(resource, Spree::Menu)
+        controller.set_current_store(resource, Spree::Menu)
         expect(resource.store).to eql(store)
         expect(resource.store).not_to eql(store_2)
       end
@@ -79,7 +79,7 @@ describe Spree::Core::ControllerHelpers::Store, type: :controller do
       resource = Spree::Menu.new
 
       it 'returns nil' do
-        controller.ensure_current_store(resource, Spree::Taxon)
+        controller.set_current_store(resource, Spree::Taxon)
         expect(resource.store).to be_nil
       end
     end

--- a/core/spec/models/spree/concerns/single_store_spec.rb
+++ b/core/spec/models/spree/concerns/single_store_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+module Spree
+  describe Spree::SingleStoreResource do
+    let(:store) { Spree::Store.default }
+    let(:store_2) { create :store }
+
+    describe '.ensure_store_association_is_not_changed' do
+      let(:menu) { create :menu }
+      let(:menu_b) { create :menu, location: 'footer' }
+
+      it 'allows creation of a new instance, update the store then save witout triggering validation error' do
+        object = Spree::CmsPage.new(title: 'Got Name', locale: 'de')
+        object.update(store: store)
+
+        expect(object.save!).to be true
+      end
+
+      context 'when an attempt to change the associated store' do
+        it 'raises an ActiveRecord::RecordInvalid' do
+          expect { menu.update!(store: store_2) }.to raise_error(ActiveRecord::RecordInvalid)
+        end
+      end
+
+      context 'when update is made and store is same as existing store' do
+        it 'does not raise an error' do
+          expect { menu.update!(name:'Jones', store: store) }.not_to raise_error
+        end
+      end
+
+      context 'when destroy a an item with store association' do
+        it 'validation does not raise an error' do
+          expect { menu_b.reload }.not_to raise_error
+
+          menu_b.destroy
+
+          expect { menu_b.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1094,8 +1094,10 @@ describe Spree::Order, type: :model do
   end
 
   describe '#promo_code' do
+    let(:new_order_x) { create(:order) }
+
     context 'without promo_code applied' do
-      it { expect(order.promo_code).to eq nil }
+      it { expect(new_order_x.promo_code).to eq nil }
     end
 
     context 'with_promo_code applied' do
@@ -1103,11 +1105,11 @@ describe Spree::Order, type: :model do
       let(:promotion) { create :promotion, code: promo_code }
 
       before do
-        promotion.orders << order
+        promotion.orders << new_order_x
       end
 
       it 'returns applied promo_code' do
-        expect(order.promo_code).to eq promo_code
+        expect(new_order_x.promo_code).to eq promo_code
       end
     end
   end


### PR DESCRIPTION
- Move #ensure_current_store to core based controller helper for use in both API and Backend controllers.
- Add tests for #ensure_current_store.
- Add model validation to ensure that a resource can not have its store association changed.