### PR TITLE
Allow frontend flash alert to span full width of screen.

### DIFF
--- a/frontend/app/views/spree/layouts/spree_application.html.erb
+++ b/frontend/app/views/spree/layouts/spree_application.html.erb
@@ -12,8 +12,8 @@
     <div id="overlay" class="overlay hide-on-esc"></div>
 
     <div data-hook>
+      <%= flash_messages %>
       <main class="col-12" id="content" data-hook>
-        <%= flash_messages %>
         <%= yield %>
       </main>
 


### PR DESCRIPTION
**Before**
<img width="1440" alt="Screenshot 2021-08-17 at 23 32 24" src="https://user-images.githubusercontent.com/1240766/129809311-61002d8c-2544-44f1-a3df-d5dab71cd274.png">

**After**
<img width="1440" alt="Screenshot 2021-08-17 at 23 32 00" src="https://user-images.githubusercontent.com/1240766/129809332-81c44959-3599-4872-8d3a-50a274da7d51.png">
