### PR TITLE
Depreciate NavigationHelper#configurations_sidebar_menu_item

### DIFF
--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -1,6 +1,8 @@
 module Spree
   module Admin
     module NavigationHelper
+      ICON_SIZE = 16
+
       # Makes an admin navigation tab (<li> tag) that links to a routing resource under /admin.
       # The arguments should be a list of symbolized controller names that will cause this tab to
       # be highlighted, with the first being the name of the resouce to link (uses URL helpers).
@@ -15,9 +17,6 @@ module Spree
       # Example:
       #   # Link to /admin/orders, also highlight tab for ProductsController and ShipmentsController
       #   tab :orders, :products, :shipments
-
-      ICON_SIZE = 16
-
       def tab(*args)
         options = { label: args.first.to_s }
 

--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -240,6 +240,11 @@ module Spree
       end
 
       def configurations_sidebar_menu_item(link_text, url, options = {})
+        ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+          NavigationHelper#configurations_sidebar_menu_item is deprecated and will be removed in Spree 5.0.
+          Please use NavigationHelper#tab.
+        DEPRECATION
+
         is_selected = url.ends_with?(controller.controller_name) ||
           url.ends_with?("#{controller.controller_name}/edit") ||
           url.ends_with?("#{controller.controller_name.singularize}/edit")

--- a/backend/app/views/spree/admin/shared/sub_menu/_configuration.html.erb
+++ b/backend/app/views/spree/admin/shared/sub_menu/_configuration.html.erb
@@ -1,21 +1,25 @@
-<ul data-hook="admin_configurations_sidebar_menu" class="border-top bg-white collapse nav nav-pills nav-stacked" id="sidebar-configuration">
-  <%= configurations_sidebar_menu_item(Spree.t(:general_settings), spree.edit_admin_general_settings_path) if can? :manage, Spree::Config %>
-  <%= configurations_sidebar_menu_item(Spree.t(:stores), spree.admin_stores_path) if can? :manage, Spree::Store %>
-  <%= configurations_sidebar_menu_item(Spree.t(:tax_categories), spree.admin_tax_categories_path) if can? :manage, Spree::TaxCategory %>
-  <%= configurations_sidebar_menu_item(Spree.t(:tax_rates), spree.admin_tax_rates_path) if can? :manage, Spree::TaxRate %>
-  <%= configurations_sidebar_menu_item(Spree.t(:zones), spree.admin_zones_path) if can? :manage, Spree::Zone %>
-  <%= configurations_sidebar_menu_item(Spree.t(:countries), spree.admin_countries_path) if can? :manage, Spree::Country %>
+<ul id="sidebar-configuration"
+    class="border-top bg-white collapse nav nav-pills nav-stacked"
+    data-hook="admin_configurations_sidebar_menu">
+
+  <%= tab(:general_settings, url: spree.edit_admin_general_settings_path) if can? :manage, Spree::Config %>
+  <%= tab(:stores) if can? :manage, Spree::Store %>
+  <%= tab(:tax_categories) if can? :manage, Spree::TaxCategory %>
+  <%= tab(:tax_rates) if can? :manage, Spree::TaxRate %>
+  <%= tab(:zones) if can? :manage, Spree::Zone %>
+  <%= tab(:countries) if can? :manage, Spree::Country %>
 
   <% if country = current_store.default_country %>
-    <%= configurations_sidebar_menu_item(Spree.t(:states), spree.admin_country_states_path(country)) if can? :manage, Spree::Country %>
+    <%= tab(:states, url: spree.admin_country_states_path(country)) if can? :manage, Spree::Country %>
   <% end %>
 
-  <%= configurations_sidebar_menu_item(Spree.t(:payment_methods), spree.admin_payment_methods_path) if can? :manage, Spree::PaymentMethod %>
-  <%= configurations_sidebar_menu_item(Spree.t(:shipping_methods), spree.admin_shipping_methods_path) if can? :manage, Spree::ShippingMethod %>
-  <%= configurations_sidebar_menu_item(Spree.t(:shipping_categories), spree.admin_shipping_categories_path) if can? :manage, Spree::ShippingCategory %>
-  <%= configurations_sidebar_menu_item(Spree.t(:store_credit_categories), spree.admin_store_credit_categories_path) if can? :manage, Spree::StoreCreditCategory %>
-  <%= configurations_sidebar_menu_item(Spree.t(:refund_reasons), spree.admin_refund_reasons_path) if can? :manage, Spree::RefundReason %>
-  <%= configurations_sidebar_menu_item(Spree.t(:reimbursement_types), spree.admin_reimbursement_types_path) if can? :manage, Spree::ReimbursementType %>
-  <%= configurations_sidebar_menu_item(Spree.t(:return_authorization_reasons), spree.admin_return_authorization_reasons_path) if can? :manage, Spree::ReturnAuthorizationReason %>
-  <%= configurations_sidebar_menu_item(Spree.t(:roles), spree.admin_roles_path) if can? :manage, Spree::Role %>
+  <%= tab(:payment_methods) if can? :manage, Spree::PaymentMethod %>
+  <%= tab(:shipping_methods) if can? :manage, Spree::ShippingMethod %>
+  <%= tab(:shipping_categories) if can? :manage, Spree::ShippingCategory %>
+  <%= tab(:store_credit_categories) if can? :manage, Spree::StoreCreditCategory %>
+  <%= tab(:refund_reasons) if can? :manage, Spree::RefundReason %>
+  <%= tab(:reimbursement_types) if can? :manage, Spree::ReimbursementType %>
+  <%= tab(:return_authorization_reasons) if can? :manage, Spree::ReturnAuthorizationReason %>
+  <%= tab(:roles) if can? :manage, Spree::Role %>
 </ul>
+

--- a/backend/app/views/spree/admin/shared/sub_menu/_content.html.erb
+++ b/backend/app/views/spree/admin/shared/sub_menu/_content.html.erb
@@ -1,4 +1,7 @@
-<ul id="sidebar-content" class="border-top bg-white collapse nav nav-pills nav-stacked" data-hook="admin_content">
-  <%= tab :menus, match_path: '/menus', label: Spree.t('admin.tab.navigation') %>
-  <%= tab :cms_pages, match_path: '/cms_pages', label: Spree.t('admin.tab.pages') %>
+<ul id="sidebar-content"
+    class="border-top bg-white collapse nav nav-pills nav-stacked"
+    data-hook="admin_content">
+
+  <%= tab(:menus, match_path: '/menus', label: Spree.t('admin.tab.navigation')) %>
+  <%= tab(:cms_pages, match_path: '/cms_pages', label: Spree.t('admin.tab.pages')) %>
 </ul>

--- a/backend/app/views/spree/admin/shared/sub_menu/_product.html.erb
+++ b/backend/app/views/spree/admin/shared/sub_menu/_product.html.erb
@@ -1,8 +1,11 @@
-<ul id="sidebar-product" class="border-top bg-white collapse nav nav-pills nav-stacked" data-hook="admin_product_sub_tabs">
-  <%= tab :products, match_path: '/products' %>
-  <%= tab :option_types, match_path: '/option_types' %>
-  <%= tab :properties %>
-  <%= tab :prototypes %>
-  <%= tab :taxonomies, match_path: '/taxonomies' %>
-  <%= tab :taxons, match_path: '/taxons' %>
+<ul id="sidebar-product"
+    class="border-top bg-white collapse nav nav-pills nav-stacked"
+    data-hook="admin_product_sub_tabs">
+
+  <%= tab(:products, match_path: '/products') %>
+  <%= tab(:option_types, match_path: '/option_types') %>
+  <%= tab(:properties) %>
+  <%= tab(:prototypes) %>
+  <%= tab(:taxonomies, match_path: '/taxonomies') %>
+  <%= tab(:taxons, match_path: '/taxons') %>
 </ul>

--- a/backend/app/views/spree/admin/shared/sub_menu/_promotion.html.erb
+++ b/backend/app/views/spree/admin/shared/sub_menu/_promotion.html.erb
@@ -1,4 +1,7 @@
-<ul id="sidebar-promotions" class="border-top bg-white collapse nav nav-pills nav-stacked" data-hook="admin_promotion_sub_tabs">
-  <%= tab :promotions %>
-  <%= tab :promotion_categories %>
+<ul id="sidebar-promotions"
+    class="border-top bg-white collapse nav nav-pills nav-stacked"
+    data-hook="admin_promotion_sub_tabs">
+
+  <%= tab(:promotions) %>
+  <%= tab(:promotion_categories) %>
 </ul>

--- a/backend/app/views/spree/admin/shared/sub_menu/_returns.html.erb
+++ b/backend/app/views/spree/admin/shared/sub_menu/_returns.html.erb
@@ -1,4 +1,7 @@
-<ul id="sidebar-returns" class="border-top bg-white collapse nav nav-pills nav-stacked" data-hook="admin_returns_sub_tabs">
-  <%= tab :return_authorizations, url: spree.admin_return_authorizations_path, match_path: '/return_authorizations' if can?(:admin, Spree::ReturnAuthorization) %>
-  <%= tab :customer_returns, url: spree.admin_customer_returns_path, match_path: '/customer_returns' if can?(:admin, Spree::CustomerReturn) %>
+<ul id="sidebar-returns"
+    class="border-top bg-white collapse nav nav-pills nav-stacked"
+    data-hook="admin_returns_sub_tabs">
+
+  <%= tab(:return_authorizations, url: spree.admin_return_authorizations_path, match_path: '/return_authorizations') if can?(:admin, Spree::ReturnAuthorization) %>
+  <%= tab(:customer_returns, url: spree.admin_customer_returns_path, match_path: '/customer_returns') if can?(:admin, Spree::CustomerReturn) %>
 </ul>

--- a/backend/app/views/spree/admin/shared/sub_menu/_stock.html.erb
+++ b/backend/app/views/spree/admin/shared/sub_menu/_stock.html.erb
@@ -1,4 +1,7 @@
-<ul id="sidebar-stock" class="border-top bg-white collapse nav nav-pills nav-stacked" data-hook="admin_stock_sub_tabs">
+<ul id="sidebar-stock"
+    class="border-top bg-white collapse nav nav-pills nav-stacked"
+    data-hook="admin_stock_sub_tabs">
+
   <%= tab(:stock_transfers, spree.admin_stock_transfers_path) if can? :manage, Spree::StockTransfer %>
   <%= tab(:stock_locations, spree.admin_stock_locations_path) if can? :manage, Spree::StockLocation %>
 </ul>


### PR DESCRIPTION
Depreciate NavigationHelper#configurations_sidebar_menu_item, I might be missing something, but on face value I can't see any reason to have a separate method for the configurations sub menu items vs other sub menu items that all use NavvigationHelper#tab

Additionally formatted all the submenu tabs with braces to match.

**Benefits of using one method to build the submenus:**
- Less chance of inconsistency occurring in both visual styling and function as issue was found while working on: **SD-1437 Small enhancements to Admin layout**

