### PR TITLE
ADMIN UI - Use svg for missing image

### DIFF
--- a/backend/app/assets/images/noimage/backend-missing-image.svg
+++ b/backend/app/assets/images/noimage/backend-missing-image.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-image" viewBox="0 0 16 16">
+  <path d="M6.002 5.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"/>
+  <path d="M2.002 1a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V3a2 2 0 0 0-2-2h-12zm12 1a1 1 0 0 1 1 1v6.5l-3.777-1.947a.5.5 0 0 0-.577.093l-3.71 3.71-2.66-1.772a.5.5 0 0 0-.63.062L1.002 12V3a1 1 0 0 1 1-1h12z"/>
+</svg>

--- a/backend/app/assets/stylesheets/spree/backend/shared/_base.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_base.scss
@@ -28,6 +28,54 @@ figure.admin-img-holder {
   }
 }
 
+div.admin-product-image-container {
+  border: 1px solid $gray-500;
+  background-color: #fefefe;
+  border-radius: $border-radius;
+  overflow: hidden;
+  display: flex;
+  justify-content: center;
+  margin: auto;
+
+  img {
+    max-width: 100%;
+    height: auto;
+    align-self: center;
+    transform: scale(1.6);
+  }
+
+  svg {
+    color: $gray-600;
+    align-self: center;
+  }
+
+  &.mini-img {
+    border-radius: $border-radius / 2;
+    width: 24px;
+    height: 24px;
+  }
+
+  &.small-img {
+    border-radius: $border-radius;
+    width: 50px;
+    height: 50px;
+  }
+
+  &.product-img {
+    border-width: 2px;
+    border-radius: $border-radius * 2;
+    width: 100px;
+    height: 100px;
+  }
+
+  &.large-img {
+    border-width: 3px;
+    border-radius: $border-radius * 3;
+    width: 300px;
+    height: 300px;
+  }
+}
+
 .js-remove-promo-rule-option-value {
   color: $primary !important;
   &:hover {

--- a/backend/app/views/spree/admin/images/index.html.erb
+++ b/backend/app/views/spree/admin/images/index.html.erb
@@ -41,7 +41,9 @@
             <% end %>
           </td>
           <td class="image">
-            <%= link_to image_tag(main_app.url_for(image.url(:mini))), main_app.rails_blob_url(image.attachment) %>
+            <div class="admin-product-image-container small-img">
+              <%= link_to image_tag(main_app.url_for(image.url(:mini))), main_app.rails_blob_url(image.attachment) %>
+            </div>
           </td>
           <% if has_variants %>
             <td><%= options_text_for(image) %></td>

--- a/backend/app/views/spree/admin/orders/_line_items.html.erb
+++ b/backend/app/views/spree/admin/orders/_line_items.html.erb
@@ -20,7 +20,7 @@
           <% order.line_items.each do |item| %>
             <tr class="line-item" id="line-item-<%= item.id %>">
               <td class="line-item-image image text-center">
-                <%= link_to mini_image(item.variant), edit_admin_product_path(item.variant.product) %>
+                <%= link_to small_image(item.variant), edit_admin_product_path(item.variant.product) %>
               </td>
               <td class="line-item-name text-center">
                 <%= link_to item.name, edit_admin_product_path(item.variant.product) %>

--- a/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
@@ -1,7 +1,7 @@
 <% shipment.manifest.each do |item| %>
   <tr class="stock-item" data-item-quantity="<%= item.quantity %>">
     <td class="item-image image text-center">
-      <%= link_to mini_image(item.variant), edit_admin_product_path(item.variant.product) %>
+      <%= link_to small_image(item.variant), edit_admin_product_path(item.variant.product) %>
     </td>
 
     <td class="item-name">

--- a/backend/app/views/spree/admin/products/_autocomplete.js.erb
+++ b/backend/app/views/spree/admin/products/_autocomplete.js.erb
@@ -17,9 +17,13 @@
       </nav>
       <div class='image'>
         {{#if image }}
-          <img src='{{image}}' alt='{{ product.attributes.name }}' class='thumbnail rounded border border' />
+          <div class="admin-product-image-container small-img">
+            <img src='{{image}}' alt='{{ product.attributes.name }}' class='thumbnail rounded border border' />
+          </div>
         {{ else }}
-          <img src='<%= image_path("noimage/small.png") %>' alt='{{product.name }}' class='thumbnail' />
+          <div class="admin-product-image-container small-img">
+            <%= inline_svg_tag "noimage/backend-missing-image.svg", class: "noimage", size: "60%*60%" %>
+          </div>
         {{/if}}
       </div>
       <div class="p-0 pt-1 text-center product-info">

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -68,7 +68,7 @@
           <tr <%== "style='color: red;'" if product.deleted? %> id="<%= spree_dom_id product %>" data-hook="admin_products_index_rows" class="<%= cycle('odd', 'even') %>">
             <td scope="row" class="image">
               <%= link_to edit_admin_product_path(product) do %>
-                <%= mini_image product %>
+                <%= small_image product %>
               <% end %>
             </td>
             <td><%= link_to product.try(:name), edit_admin_product_path(product) %></td>

--- a/backend/app/views/spree/admin/users/items.html.erb
+++ b/backend/app/views/spree/admin/users/items.html.erb
@@ -27,7 +27,7 @@
             <tr class="stock-item" data-item-quantity="<%= item.quantity %>">
               <td class="order-completed-at"><%= order_time(order.completed_at) if order.completed_at %></td>
               <td class="item-image">
-                <%= mini_image(item.variant) %>
+                <%= small_image(item.variant) %>
               </td>
               <td class="item-name">
                 <%= item.name %>

--- a/backend/app/views/spree/admin/variants/_autocomplete.js.erb
+++ b/backend/app/views/spree/admin/variants/_autocomplete.js.erb
@@ -2,9 +2,13 @@
   <div class='variant-autocomplete-item media align-items-center'>
     <figure class='variant-image media-left mb-0 mr-3'>
       {{#if variant.image }}
-        <img src='{{variant.image}}' class="thumbnail mb-0" />
+        <div class="admin-product-image-container small-img">
+          <img src='{{variant.image}}' class="thumbnail mb-0" />
+        </div>
       {{ else }}
-        <img src='<%= image_path("noimage/mini.png") %>' class="thumbnail mb-0" />
+        <div class="admin-product-image-container small-img">
+          <%= inline_svg_tag "noimage/backend-missing-image.svg", class: "noimage", size: "60%*60%" %>
+        </div>
       {{/if}}
     </figure>
 

--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -246,11 +246,13 @@ module Spree
         options = options.first || {}
         options[:alt] ||= product.name
         image_path = default_image_for_product_or_variant(product)
-        if image_path.present?
-          create_product_image_tag image_path, product, options, style
-        else
-          image_tag "noimage/#{style}.png", options
-        end
+        img = if image_path.present?
+                create_product_image_tag image_path, product, options, style
+              else
+               inline_svg_tag "noimage/backend-missing-image.svg", class: "noimage", size: "60%*60%"
+              end
+
+        content_tag(:div, img, class: "admin-product-image-container #{style}-img")
       end
     end
 

--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -128,6 +128,7 @@ describe Spree::BaseHelper, type: :helper do
         styles[:very_strange] = '1x1'
         styles.merge!(foobar: '2x2')
       end
+      allow_any_instance_of(described_class).to receive(:inline_svg_tag).and_return('<svg></svg>')
     end
 
     it 'does not raise errors when style exists' do


### PR DESCRIPTION
ADMIN UI - Use svg for missing image and frame images to be uniform sizes.
<img width="1186" alt="Screenshot 2021-08-29 at 21 26 44" src="https://user-images.githubusercontent.com/1240766/131264461-ca476ac1-1936-4be3-b21a-2b32d668145a.png">
<img width="878" alt="Screenshot 2021-08-29 at 21 04 58" src="https://user-images.githubusercontent.com/1240766/131264469-481d5c99-52d7-496f-9276-fc2f2e245093.png">
<img width="875" alt="Screenshot 2021-08-29 at 21 04 51" src="https://user-images.githubusercontent.com/1240766/131264471-42330177-e6fc-4b85-b94a-30a436bd759d.png">
<img width="871" alt="Screenshot 2021-08-29 at 21 04 41" src="https://user-images.githubusercontent.com/1240766/131264473-25c786b2-6485-46c8-8db1-d122c7a5002b.png">

<img width="1185" alt="Screenshot 2021-08-29 at 21 05 09" src="https://user-images.githubusercontent.com/1240766/131264464-977895f1-0b91-44d1-9b21-8396001fc979.png">
<img width="1196" alt="Screenshot 2021-08-29 at 21 30 20" src="https://user-images.githubusercontent.com/1240766/131264503-00e6dfa7-6c54-4615-bcda-e81a06a766a7.png">

