### PR TITLE
AP for associating order with user

### DIFF
--- a/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
@@ -132,14 +132,14 @@ module Spree
 
           def associate
             guest_order_token = params[:guest_order_token]
-            guest_order = ::Spree::Orders::FindCurrent.new.execute(
+            guest_order = ::Spree::Api::Dependencies.storefront_current_order_finder.constantize.new.execute(
               store: current_store,
               user: nil,
               token: guest_order_token,
               currency: current_currency
             )
 
-            spree_authorize! :show, guest_order, guest_order_token
+            spree_authorize! :update, guest_order, guest_order_token
 
             result = associate_service.call(guest_order: guest_order, user: spree_current_user)
 

--- a/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
@@ -4,8 +4,10 @@ module Spree
       module Storefront
         class CartController < ::Spree::Api::V2::BaseController
           include Spree::Api::V2::Storefront::OrderConcern
-          before_action :ensure_order, except: :create
+          before_action :ensure_order, except: %i[create associate]
           before_action :load_variant, only: :add_item
+          before_action :require_spree_current_user, only: :associate
+
 
           def create
             spree_authorize! :create, Spree::Order
@@ -128,6 +130,26 @@ module Spree
             end
           end
 
+          def associate
+            guest_order_token = params[:guest_order_token]
+            guest_order = ::Spree::Orders::FindCurrent.new.execute(
+              store: current_store,
+              user: nil,
+              token: guest_order_token,
+              currency: current_currency
+            )
+
+            spree_authorize! :show, guest_order, guest_order_token
+
+            result = associate_service.call(guest_order: guest_order, user: spree_current_user)
+
+            if result.success?
+              render_serialized_payload { serialize_resource(guest_order) }
+            else
+              render_error_payload(result.error)
+            end
+          end
+
           private
 
           def resource_serializer
@@ -164,6 +186,10 @@ module Spree
 
           def estimate_shipping_rates_service
             Spree::Api::Dependencies.storefront_cart_estimate_shipping_rates_service.constantize
+          end
+
+          def associate_service
+            Spree::Api::Dependencies.storefront_cart_associate_service.constantize
           end
 
           def line_item

--- a/api/app/models/spree/api_dependencies.rb
+++ b/api/app/models/spree/api_dependencies.rb
@@ -14,7 +14,7 @@ module Spree
       :storefront_country_serializer, :storefront_menu_serializer, :storefront_menu_finder, :storefront_current_order_finder,
       :storefront_completed_order_finder, :storefront_order_sorter, :storefront_collection_paginator, :storefront_user_serializer,
       :storefront_products_sorter, :storefront_products_finder, :storefront_product_serializer, :storefront_taxon_serializer,
-      :storefront_taxon_finder, :storefront_find_by_variant_finder, :storefront_cart_update_service,
+      :storefront_taxon_finder, :storefront_find_by_variant_finder, :storefront_cart_update_service, :storefront_cart_associate_service,
       :storefront_cart_estimate_shipping_rates_service, :storefront_estimated_shipment_serializer,
       :storefront_store_serializer, :storefront_address_serializer, :storefront_order_serializer,
       :storefront_account_create_address_service, :storefront_account_update_address_service, :storefront_address_finder,
@@ -43,6 +43,7 @@ module Spree
       @storefront_cart_estimate_shipping_rates_service = Spree::Dependencies.cart_estimate_shipping_rates_service
       @storefront_cart_empty_service = Spree::Dependencies.cart_empty_service
       @storefront_cart_destroy_service = Spree::Dependencies.cart_destroy_service
+      @storefront_cart_associate_service = Spree::Dependencies.cart_associate_service
 
       # coupon code handler
       @storefront_coupon_handler = Spree::Dependencies.coupon_handler

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -137,6 +137,7 @@ Spree::Core::Engine.add_routes do
           delete 'remove_coupon_code/:coupon_code', to: 'cart#remove_coupon_code', as: :cart_remove_coupon_code
           delete 'remove_coupon_code', to: 'cart#remove_coupon_code', as: :cart_remove_coupon_code_without_code
           get :estimate_shipping_rates
+          patch :associate
         end
 
         resource :checkout, controller: :checkout, only: %i[update] do

--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -763,6 +763,38 @@ paths:
         - orderToken: []
         - bearerAuth: []
       summary: Get estimated Shipping Rates
+  /api/v2/storefront/cart/associate:
+    patch:
+      description: Associates a guest cart with the currently signed in user.
+      tags:
+        - Cart
+      operationId: Associate
+      parameters:
+        - name: guest_order_token
+          in: query
+          description: Token of the guest cart to be associated with user
+          schema:
+            type: string
+        - $ref: '#/components/parameters/CartIncludeParam'
+        - $ref: '#/components/parameters/SparseFieldsParam'
+      responses:
+        '200':
+          description: Cart has been successfully associated
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/Cart'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '422':
+          description: Returned for already assigned cart
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+        - bearerAuth: []
+      summary: Associate a guest cart to a user
   /api/v2/storefront/checkout:
     patch:
       description: |-

--- a/api/spec/requests/spree/api/v2/storefront/cart_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/cart_spec.rb
@@ -888,4 +888,45 @@ describe 'API V2 Storefront Cart Spec', type: :request do
       it_behaves_like 'returns a list of shipments with shipping rates'
     end
   end
+
+  describe 'cart#associate' do
+    let(:order) { create(:order, user: assigned_user, store: store, currency: currency) }
+
+    before do
+      patch '/api/v2/storefront/cart/associate', params: { guest_order_token: guest_order_token}, headers: headers
+    end
+
+    context 'as a signed in user' do
+      let(:headers) { headers_bearer }
+
+      context 'when order was not assigned' do
+        let(:assigned_user) { nil }
+        let(:guest_order_token) { order.token }
+
+        it_behaves_like 'returns valid cart JSON'
+      end
+
+      context 'when order was already assigned' do
+        let(:assigned_user) { create(:user) }
+        let(:guest_order_token) { order.token }
+
+        it_behaves_like 'returns 422 HTTP status'
+      end
+
+      context 'when order token is invalid' do
+        let(:assigned_user) { nil }
+        let(:guest_order_token) { 'invalid' }
+
+        it_behaves_like 'returns 403 HTTP status'
+      end
+    end
+
+    context 'as a guest user' do
+      let(:headers) {}
+      let(:assigned_user) { nil }
+      let(:guest_order_token) { order.token }
+
+      it_behaves_like 'returns 403 HTTP status'
+    end
+  end
 end

--- a/core/app/models/spree/app_dependencies.rb
+++ b/core/app/models/spree/app_dependencies.rb
@@ -13,7 +13,7 @@ module Spree
       :products_finder, :taxon_finder, :line_item_by_variant_finder, :cart_estimate_shipping_rates_service,
       :account_create_address_service, :account_update_address_service, :account_create_service, :account_update_service,
       :address_finder, :collection_sorter, :error_handler, :current_store_finder, :cart_empty_service, :cart_destroy_service,
-      :classification_reposition_service, :credit_cards_destroy_service
+      :classification_reposition_service, :credit_cards_destroy_service, :cart_associate_service
     ].freeze
 
     attr_accessor *INJECTION_POINTS
@@ -43,6 +43,7 @@ module Spree
       @cart_estimate_shipping_rates_service = 'Spree::Cart::EstimateShippingRates'
       @cart_empty_service = 'Spree::Cart::Empty'
       @cart_destroy_service = 'Spree::Cart::Destroy'
+      @cart_associate_service = 'Spree::Cart::Associate'
 
       # checkout
       @checkout_next_service = 'Spree::Checkout::Next'

--- a/core/app/services/spree/cart/associate.rb
+++ b/core/app/services/spree/cart/associate.rb
@@ -1,0 +1,16 @@
+module Spree
+  module Cart
+    class Associate
+      prepend Spree::ServiceModule::Base
+
+      def call(guest_order:, user:)
+        if guest_order.user.nil?
+          guest_order.associate_user!(user)
+          success(guest_order)
+        else
+          failure(guest_order, 'Already assigned to a user')
+        end
+      end
+    end
+  end
+end

--- a/core/spec/services/spree/cart/associate_spec.rb
+++ b/core/spec/services/spree/cart/associate_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+module Spree
+  describe Cart::Associate do
+    subject { described_class.call(guest_order: order, user: user) }
+    let(:user) { create(:user) }
+
+    context 'when guest order is given' do
+      let(:order) { create(:order, user: nil) }
+
+      it 'assigns order to user' do
+        expect(subject).to be_success
+        expect(order.user).to eq(user)
+      end
+    end
+
+    context 'when already assigned order is given' do
+      let(:assigned_user) { create(:user) }
+      let(:order) { create(:order, user: assigned_user) }
+
+      it 'returns failure' do
+        expect(subject).to be_failure
+        expect(order.user).to eq(assigned_user)
+      end
+    end
+  end
+end


### PR DESCRIPTION
When integrating a PWA storefront via v2 API, we noticed that there's no way to associate a guest cart when customer signs in.

In the built-in frontend this seems to be done at this point: https://github.com/spree/spree/blob/main/core/lib/spree/core/controller_helpers/order.rb#L47
This helper is not included in API controllers though.

In this PR, I created an additional endpoint in the cart resource, that allows to pass guest_cart_token and associate it with currently authenticated user. 