### PR TITLE
Add publishable preferences to payment methods

### DIFF
--- a/api/app/serializers/spree/v2/storefront/payment_method_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/payment_method_serializer.rb
@@ -4,7 +4,7 @@ module Spree
       class PaymentMethodSerializer < BaseSerializer
         set_type :payment_method
 
-        attributes :type, :name, :description
+        attributes :type, :name, :description, :publishable_preferences
       end
     end
   end

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -87,5 +87,17 @@ module Spree
 
       store_ids.include?(store.id)
     end
+
+    def publishable_preferences
+      publishable_preference_keys.each_with_object({}) do |key, hash|
+        hash[key] = preferences[key]
+      end
+    end
+
+    private
+
+    def publishable_preference_keys
+      []
+    end
   end
 end

--- a/core/spec/models/spree/gateway_spec.rb
+++ b/core/spec/models/spree/gateway_spec.rb
@@ -8,8 +8,18 @@ describe Spree::Gateway, type: :model do
   end
 
   class TestGateway < Spree::Gateway
+    preference :publishable_preference1, :string
+    preference :publishable_preference2, :string
+    preference :private_preference, :string
+
     def provider_class
       Provider
+    end
+
+    private
+
+    def publishable_preference_keys
+      [:publishable_preference1, :publishable_preference2]
     end
   end
 
@@ -54,5 +64,17 @@ describe Spree::Gateway, type: :model do
 
     rate = Spree::Gateway::FROM_DOLLAR_TO_CENT_RATE
     expect(gateway.exchange_multiplier).to eq rate
+  end
+
+  it 'returns publishable preferences' do
+    gateway = TestGateway.new
+    gateway.preferences[:publishable_preference1] = 'public1'
+    gateway.preferences[:publishable_preference2] = 'public2'
+    gateway.preferences[:private_preference] = 'secret'
+
+    expect(gateway.publishable_preferences).to eq({
+      publishable_preference1: 'public1',
+      publishable_preference2: 'public2'
+    })
   end
 end


### PR DESCRIPTION
@damianlegawiec based on our discussion here https://github.com/spree/spree/pull/11217, I've added a method allowing devs to configure which preferences should be returned in the API when serializing a PaymentMethod.

I will also send out a separate PR to spree_gateway with a relevant implementation of `publishable_preference_keys` for Stripe payment methods.

Let me know your thoughts on that.