### PR TITLE
Use Pretty Name in section Links + Bug Fix

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/global/select2_autocomplete.es6
+++ b/backend/app/assets/javascripts/spree/backend/global/select2_autocomplete.es6
@@ -104,7 +104,7 @@ $.fn.select2Autocomplete = function(params) {
   }
 
   //
-  // Make AJAX request
+  // Set-up Select2 and make AJAX request.
   this.select2({
     multiple: select2Multiple,
     allowClear: select2allowClear,

--- a/backend/app/assets/javascripts/spree/backend/global/select2_autocomplete.es6
+++ b/backend/app/assets/javascripts/spree/backend/global/select2_autocomplete.es6
@@ -1,29 +1,24 @@
 // SELECT2 AUTOCOMPLETE JS
-// This JavaScript file allows Spree developers to set up Select2 autocomplete search
-// using the API v2 by simply adding data attributes to a select element with the class: 'select2autocomplete'
-// as shown here: <select class="select2autocomplete"></select>.
+//  The JavaScript in this file allows Spree developers to set up Select2 autocomplete search
+//  using the API v2 by simply adding data attributes to a select element.
 
 // REQUIRED ATTRIBUTES
-// You must provide a URL for the API V2, use the format shown below.
-// See the backend.js file for other API V2 URL's.
-//
-//  Example:
+//  You must provide a URL for the API V2, use the format shown below. See backend.js for other API V2 URL's.
+//  REQUIRED:
 //  data-autocomplete-url-value="products_api_v2"
 
-// OPTIONAL ATTRIBUTES
-// These optional attributes have sensible defaults, you many not need to use them in many cases,
-// but they do provide a powerful toolkit to refine your autocomplete search as required.
+//  OPTIONAL:
+//  data-autocomplete-placeholder-value="Seach Pages"     <- Sets the placeholder | DEFAULT is: 'Search'.
+//  data-autocomplete-clear-value=boolean                 <- Allow select2 to be cleared | DEFAULT is: false (no clear button).
+//  data-autocomplete-multiple-value=boolean              <- Multiple or Single select | DEFAULT is: false (single).
+//  data-autocomplete-return-attr-value="pretty_name"     <- Return Attribute. | DEFAULT is: 'name'.
+//  data-autocomplete-min-input-value="4"                 <- Minimum input for search | DEFAULT is: 3.
+//  data-autocomplete-search-query-value="title_i_cont"   <- Custom search query | DEFAULT is: 'name_i_cont'.
+//  data-autocomplete-custom-return-id-value="permalink"  <- Return a custom attribute | DEFAULT: returns id.
+//  data-autocomplete-debug-mode-value=boolean            <- Turn on console loggin of data returned by the request.
 //
-//  Examples:
-//  data-autocomplete-placeholder-value="Seach Pages"    <- Sets the placeholder | DEFAULT is: 'Search'
-//  data-autocomplete-clear-value="boolean"              <- Allow select2 to be cleared | DEFAULT is: false (no clear button)
-//  data-autocomplete-multiple-value="boolean"           <- Multiple or Single select | DEFAULT is: false (single)
-//  data-autocomplete-return-attr-value="pretty_name"    <- Return Attribute. | DEFAULT is: 'name'
-//  data-autocomplete-min-input-value="4"                <- Minimum input for search | DEFAULT is: 3
-//  data-autocomplete-search-query-value="title_i_cont"  <- Custom search query | DEFAULT is: 'name_i_cont'
-//  data-autocomplete-custom-return-id-value="permalink" <- Return a custom attribute rather than the ID | DEFAULT: returns id
-
-//  You can add your own custom URL params to the request as needed
+//  Add your own custom URL params to the request as needed
+//  EXAMPLE:
 //  data-autocomplete-additional-url-params-value="filter[type_not_eq]=Spree::Cms::Pages::Homepage"
 
 document.addEventListener('DOMContentLoaded', function() {
@@ -38,10 +33,7 @@ function loadAutoCompleteParams() {
 
 function buildParamsFromDataAttrs(element) {
   $(element).select2Autocomplete({
-    // Required Attributes
     apiUrl: Spree.routes[element.dataset.autocompleteUrlValue],
-
-    // Optional Attributes
     placeholder: element.dataset.autocompletePlaceholderValue,
     allow_clear: element.dataset.autocompleteClearValue,
     multiple: element.dataset.autocompleteMultipleValue,
@@ -49,21 +41,17 @@ function buildParamsFromDataAttrs(element) {
     minimum_input: element.dataset.autocompleteMinInputValue,
     search_query: element.dataset.autocompleteSearchQueryValue,
     custom_return_id: element.dataset.autocompleteCustomReturnIdValue,
-    additional_url_params: element.dataset.autocompleteAdditionalUrlParamsValue
+    additional_url_params: element.dataset.autocompleteAdditionalUrlParamsValue,
+    debug_mode: element.dataset.autocompleteDebugModeValue
   })
 }
 
-// Can also be called directly as javastript.
 $.fn.select2Autocomplete = function(params) {
-  // Required params
   let apiUrl = null
   let returnedFields
 
   const resourcePlural = params.apiUrl.match(/([^/]*)\/*$/)[1]
   const resourceSingular = resourcePlural.slice(0, -1)
-
-  //
-  // Optional Params
   const select2placeHolder = params.placeholder || Spree.translations.search
   const select2Multiple = params.multiple || false
   const select2allowClear = params.allow_clear || false
@@ -72,25 +60,31 @@ $.fn.select2Autocomplete = function(params) {
   const searchQuery = params.search_query || 'name_i_cont'
   const customReturnId = params.custom_return_id || null
   const additionalUrlParams = params.additional_url_params || null
+  const DebugMode = params.debug_mode || null
 
   //
-  // Set up a clean URL with based on additional Url Params presence.
-  if (additionalUrlParams == null) {
-    apiUrl = params.apiUrl
-  } else {
-    apiUrl = `${params.apiUrl}?${additionalUrlParams}`
-  }
-
-  //
-  // Set up a clean URL with based on custom return id presence.
+  // Set up a clean URL for sparseFields
   if (customReturnId == null) {
     returnedFields = returnAttribute
   } else {
     returnedFields = `${returnAttribute},${customReturnId}`
   }
+  const sparseFields = `fields[${resourceSingular}]=${returnedFields}`
 
   //
-  // Formats returned values.
+  // Set up a clean URL for Additional URL Params
+  if (additionalUrlParams != null) {
+    // URL + Additional URL Params + Sparse Fields
+    apiUrl = `${params.apiUrl}?${additionalUrlParams}&${sparseFields}`
+  } else {
+    // URL + Sparse Fields (the default response for a noraml Select2)
+    apiUrl = `${params.apiUrl}?${sparseFields}`
+  }
+
+  if (DebugMode != null) console.log('Request URL:' + apiUrl)
+
+  //
+  // Format the returned values.
   function formatList(values) {
     if (customReturnId) {
       return values.map(function(obj) {
@@ -109,6 +103,8 @@ $.fn.select2Autocomplete = function(params) {
     }
   }
 
+  //
+  // Make AJAX request
   this.select2({
     multiple: select2Multiple,
     allowClear: select2allowClear,
@@ -119,15 +115,14 @@ $.fn.select2Autocomplete = function(params) {
       headers: Spree.apiV2Authentication(),
       data: function(params) {
         return {
-          fields: {
-            [resourceSingular]: returnedFields
-          },
           filter: {
             [searchQuery]: params.term
           }
         }
       },
       processResults: function(json) {
+        if (DebugMode != null) console.log(json)
+
         return {
           results: formatList(json.data)
         }

--- a/backend/app/assets/javascripts/spree/backend/global/select2_populate.es6
+++ b/backend/app/assets/javascripts/spree/backend/global/select2_populate.es6
@@ -1,11 +1,9 @@
 /**
   populateSelectOptionsFromApi(params)
+  Allows you to easily fetch data from API (Platfrom v2) and populate an empty <select> with <option> tags, including a selected <option> tag.
 
-  Allows you to easily fetch data from API (Platfrom v2)
-  and populate an empty <select> with <option> tags,
-  including a selected <option> tag.
-
-  ## EXAMPLE USE CASE called from ERB view file:
+  ## EXAMPLE A
+  # Populating a list of all taxons including a selected item
 
   populateSelectOptionsFromApi({
     targetElement: '#mySelectElement',
@@ -16,6 +14,24 @@
       selectedOption: <%= @menu_item.linked_resource_id %>
     <% end %>
   })
+
+  ## EXAMPLE B
+  # Populating a single selected item using filter and returning an attribute other than the ID
+
+  <% if resource.link_one.present? %>
+    <script>
+      populateSelectOptionsFromApi({
+        targetElement: "#<%= save_to %>Select2",
+        apiUrl: Spree.routes.taxons_api_v2 + "?filter[permalink_matches]=<%= resource.send(save_to) %>",
+        returnValueFromAttributes: 'permalink',
+        returnOptionText: 'pretty_name',
+
+        <% if resource.send(save_to) %>
+          selectedOption: "<%= resource.send(save_to) %>"
+        <% end %>
+      })
+    </script>
+  <% end %>
 **/
 
 // eslint-disable-next-line no-unused-vars
@@ -32,30 +48,34 @@ const handleErrors = function(response) {
 const createRequest = function(params, succeed, fail) {
   const targetElement = params.targetElement
   const apiUrl = params.apiUrl
-  const returnAttribute = params.returnAttribute
+  const returnOptionText = params.returnOptionText
+  const returnValueFromAttributes = params.returnValueFromAttributes || null
   const selectedOption = params.selectedOption
   const selectEl = document.querySelector(targetElement)
 
   fetch(apiUrl, { headers: Spree.apiV2Authentication() })
     .then((response) => handleErrors(response))
-    .then((json) => succeed(json.data, returnAttribute, selectEl, selectedOption))
+    .then((json) => succeed(json.data, returnValueFromAttributes, returnOptionText, selectEl, selectedOption))
     .catch((error) => fail(error, selectEl))
 }
 
-const updateSelectSuccess = function(parsedData, returnAttribute, selectEl, selectedOption) {
+const updateSelectSuccess = function(parsedData, returnValueFromAttributes, returnOptionText, selectEl, selectedOption) {
   parsedData.forEach((object) => {
     const optionEl = document.createElement('option')
-    optionEl.value = object.id
-    optionEl.innerHTML = object.attributes[returnAttribute]
 
-    if (parseInt(selectedOption, 10) === parseInt(object.id, 10)) optionEl.selected = true
+    if (returnValueFromAttributes == null) {
+      optionEl.value = object.id
+      if (parseInt(selectedOption, 10) === parseInt(object.id, 10)) optionEl.selected = true
+    } else {
+      optionEl.value = object.attributes[returnValueFromAttributes]
+      if (selectedOption === object.attributes[returnValueFromAttributes]) optionEl.selected = true
+    }
 
+    optionEl.innerHTML = object.attributes[returnOptionText]
     selectEl.appendChild(optionEl)
   })
 }
 
 const updateSelectError = function(error, selectEl) {
-  selectEl.disabled = true
-
   console.log(error)
 }

--- a/backend/app/assets/javascripts/spree/backend/global/select2_populate.es6
+++ b/backend/app/assets/javascripts/spree/backend/global/select2_populate.es6
@@ -60,6 +60,8 @@ const createRequest = function(params, succeed, fail) {
 }
 
 const updateSelectSuccess = function(parsedData, returnValueFromAttributes, returnOptionText, selectEl, selectedOption) {
+  const selectedOpt = selectEl.querySelector('option[selected]')
+
   parsedData.forEach((object) => {
     const optionEl = document.createElement('option')
 
@@ -68,7 +70,11 @@ const updateSelectSuccess = function(parsedData, returnValueFromAttributes, retu
       if (parseInt(selectedOption, 10) === parseInt(object.id, 10)) optionEl.selected = true
     } else {
       optionEl.value = object.attributes[returnValueFromAttributes]
-      if (selectedOption === object.attributes[returnValueFromAttributes]) optionEl.selected = true
+      if (selectedOpt.value === object.attributes[returnValueFromAttributes]) {
+        selectedOpt.remove()
+
+        optionEl.setAttribute('selected', 'selected')
+      }
     }
 
     optionEl.innerHTML = object.attributes[returnOptionText]

--- a/backend/app/views/spree/admin/cms_sections/types/_hero_image.html.erb
+++ b/backend/app/views/spree/admin/cms_sections/types/_hero_image.html.erb
@@ -37,10 +37,9 @@
           <%= image_tag main_app.url_for(@cms_section.image_one) %>
         </figure>
       <% end %>
-      <%= f.field_container :image_one, class: ['form-group mb-0'] do %>
-        <%= f.file_field :image_one %>
-        <%= f.error_message_on :image_one %>
-      <% end %>
+
+      <%= f.file_field :image_one %>
+      <%= f.error_message_on :image_one %>
     <% end %>
     <small class="form-text text-muted"><%= Spree.t('admin.cms.hero.aspect_ratio') %></small>
   </div>

--- a/backend/app/views/spree/admin/cms_sections/types/_image_gallery.html.erb
+++ b/backend/app/views/spree/admin/cms_sections/types/_image_gallery.html.erb
@@ -22,7 +22,7 @@
 
 <div class="row">
   <div class="col-12 col-md-4 mb-3">
-    <div class="card p-3">
+    <div id="image_a_details" class="card p-3">
       <div class="text-center">
         <h4 class="pb-2"><%= Spree.t('admin.cms.image_gallery.image_a') %></h4>
         <%= f.field_container :image_one, class: ['form-group'] do %>
@@ -35,10 +35,9 @@
               <%= image_tag main_app.url_for(@cms_section.image_one) %>
             </figure>
           <% end %>
-          <%= f.field_container :image_one, class: ['form-group mb-0'] do %>
-            <%= f.file_field :image_one %>
-            <%= f.error_message_on :image_one %>
-          <% end %>
+
+          <%= f.file_field :image_one %>
+          <%= f.error_message_on :image_one %>
         <% end %>
       </div>
       <small class="text-muted mb-4"><%= Spree.t('admin.cms.image_gallery.square_image') %></small>
@@ -67,7 +66,7 @@
   </div>
 
   <div class="col-12 col-md-4 mb-3">
-    <div class="card p-3">
+    <div id="image_b_details" class="card p-3">
       <div class="text-center">
         <h4 class="pb-2"><%= Spree.t('admin.cms.image_gallery.image_b') %></h4>
         <%= f.field_container :image_two, class: ['form-group'] do %>
@@ -80,10 +79,9 @@
               <%= image_tag main_app.url_for(@cms_section.image_two) %>
             </figure>
           <% end %>
-          <%= f.field_container :image_two, class: ['form-group mb-0'] do %>
-            <%= f.file_field :image_two %>
-            <%= f.error_message_on :image_two %>
-          <% end %>
+
+          <%= f.file_field :image_two %>
+          <%= f.error_message_on :image_two %>
         <% end %>
       </div>
       <small class="text-muted mb-4"><%= Spree.t('admin.cms.image_gallery.tall_image') %></small>
@@ -112,7 +110,7 @@
   </div>
 
   <div class="col-12 col-md-4 mb-3">
-    <div class="card p-3">
+    <div id="image_c_details" class="card p-3">
       <div class="text-center">
         <h4 class="pb-2"><%= Spree.t('admin.cms.image_gallery.image_c') %></h4>
         <%= f.field_container :image_three, class: ['form-group'] do %>
@@ -125,10 +123,9 @@
               <%= image_tag main_app.url_for(@cms_section.image_three) %>
             </figure>
           <% end %>
-          <%= f.field_container :image_three, class: ['form-group mb-0'] do %>
-            <%= f.file_field :image_three %>
-            <%= f.error_message_on :image_three %>
-          <% end %>
+
+          <%= f.file_field :image_three %>
+          <%= f.error_message_on :image_three %>
         <% end %>
       </div>
       <small class="text-muted mb-4"><%= Spree.t('admin.cms.image_gallery.square_image') %></small>

--- a/backend/app/views/spree/admin/cms_sections/types/_side_by_side_images.html.erb
+++ b/backend/app/views/spree/admin/cms_sections/types/_side_by_side_images.html.erb
@@ -1,6 +1,6 @@
 <div class="row pb-0">
   <div class="col-12 col-md-6 mb-3">
-    <div class="card p-3">
+    <div id="left_image_details" class="card p-3">
       <div class="text-center">
         <h4 class="pb-2"><%= Spree.t('admin.cms.side_by_side.left_image') %></h4>
         <%= f.field_container :image_one, class: ['form-group'] do %>
@@ -51,7 +51,7 @@
   </div>
 
   <div class="col-12 col-md-6 mb-3">
-    <div class="card p-3">
+    <div id="right_image_details" class="card p-3">
       <div class="text-center">
         <h4 class="pb-2"><%= Spree.t('admin.cms.side_by_side.right_image') %></h4>
         <%= f.field_container :image_two, class: ['form-group'] do %>

--- a/backend/app/views/spree/admin/shared/cms/_spree_product.html.erb
+++ b/backend/app/views/spree/admin/shared/cms/_spree_product.html.erb
@@ -1,14 +1,28 @@
 <%= f.field_container save_to, class: ['form-group'] do %>
   <%= f.label save_to, Spree.t('admin.cms.link_to_product') %>
-  <%= f.select save_to,
-       options_from_collection_for_select([resource],
-                                       save_to, save_to, resource.send(save_to) || nil),
-       { include_blank: true },
-       class: 'select2autocomplete',
-       data: { autocomplete_placeholder_value: Spree.t('admin.navigation.seach_for_a_product'),
-               autocomplete_clear_value: true,
-               autocomplete_url_value: 'products_api_v2',
-               autocomplete_return_attr_value: 'name',
-               autocomplete_custom_return_id_value: 'slug' } %>
+  <%= f.select save_to, options_from_collection_for_select([resource], save_to, save_to, resource.send(save_to) || nil), { include_blank: true },
+                          class: 'select2autocomplete',
+                          id: "#{save_to}Select2",
+                          data: { autocomplete_placeholder_value: Spree.t('admin.navigation.seach_for_a_product'),
+                                 autocomplete_clear_value: true,
+                                 autocomplete_url_value: 'products_api_v2',
+                                 autocomplete_return_attr_value: 'name',
+                                 autocomplete_custom_return_id_value: 'slug' } %>
+
   <%= f.error_message_on :save_to %>
+<% end %>
+
+<% if resource.link_one.present? %>
+  <script>
+    populateSelectOptionsFromApi({
+      targetElement: "#<%= save_to %>Select2",
+      apiUrl: Spree.routes.products_api_v2 + "?filter[slug_matches]=<%= resource.send(save_to) %>",
+      returnValueFromAttributes: 'slug',
+      returnOptionText: 'name',
+
+      <% if resource.send(save_to) %>
+        selectedOption: "<%= resource.send(save_to) %>"
+      <% end %>
+    })
+  </script>
 <% end %>

--- a/backend/app/views/spree/admin/shared/cms/_spree_product.html.erb
+++ b/backend/app/views/spree/admin/shared/cms/_spree_product.html.erb
@@ -1,13 +1,12 @@
 <%= f.field_container save_to, class: ['form-group'] do %>
   <%= f.label save_to, Spree.t('admin.cms.link_to_product') %>
   <%= f.select save_to, options_from_collection_for_select([resource], save_to, save_to, resource.send(save_to) || nil), { include_blank: true },
-                          class: 'select2autocomplete',
-                          id: "#{save_to}Select2",
+                          id: "cms_section_#{save_to}",
                           data: { autocomplete_placeholder_value: Spree.t('admin.navigation.seach_for_a_product'),
-                                 autocomplete_clear_value: true,
-                                 autocomplete_url_value: 'products_api_v2',
-                                 autocomplete_return_attr_value: 'name',
-                                 autocomplete_custom_return_id_value: 'slug' } %>
+                                  autocomplete_clear_value: true,
+                                  autocomplete_url_value: 'products_api_v2',
+                                  autocomplete_return_attr_value: 'name',
+                                  autocomplete_custom_return_id_value: 'slug' } %>
 
   <%= f.error_message_on :save_to %>
 <% end %>
@@ -15,7 +14,7 @@
 <% if resource.link_one.present? %>
   <script>
     populateSelectOptionsFromApi({
-      targetElement: "#<%= save_to %>Select2",
+      targetElement: "#cms_section_<%= save_to %>",
       apiUrl: Spree.routes.products_api_v2 + "?filter[slug_matches]=<%= resource.send(save_to) %>",
       returnValueFromAttributes: 'slug',
       returnOptionText: 'name',

--- a/backend/app/views/spree/admin/shared/cms/_spree_taxon.html.erb
+++ b/backend/app/views/spree/admin/shared/cms/_spree_taxon.html.erb
@@ -1,14 +1,28 @@
 <%= f.field_container save_to, class: ['form-group'] do %>
   <%= f.label save_to, Spree.t('admin.cms.link_to_taxon') %>
-  <%= f.select save_to,
-       options_from_collection_for_select([resource],
-                                       save_to, save_to, resource.send(save_to) || nil),
-       { include_blank: true },
-       class: 'select2autocomplete',
-       data: { autocomplete_placeholder_value: Spree.t('admin.navigation.seach_for_a_taxon'),
-               autocomplete_clear_value: true,
-               autocomplete_url_value: 'taxons_api_v2',
-               autocomplete_return_attr_value: 'permalink',
-               autocomplete_custom_return_id_value: 'permalink' } %>
+  <%= f.select save_to, options_from_collection_for_select([resource], save_to, save_to, resource.send(save_to) || nil), { include_blank: true },
+                          class: 'select2autocomplete',
+                          id: "#{save_to}Select2",
+                          data: { autocomplete_placeholder_value: Spree.t('admin.navigation.seach_for_a_taxon'),
+                                 autocomplete_clear_value: true,
+                                 autocomplete_url_value: 'taxons_api_v2',
+                                 autocomplete_return_attr_value: 'pretty_name',
+                                 autocomplete_custom_return_id_value: 'permalink' } %>
+
   <%= f.error_message_on :save_to %>
+<% end %>
+
+<% if resource.link_one.present? %>
+  <script>
+    populateSelectOptionsFromApi({
+      targetElement: "#<%= save_to %>Select2",
+      apiUrl: Spree.routes.taxons_api_v2 + "?filter[permalink_matches]=<%= resource.send(save_to) %>",
+      returnValueFromAttributes: 'permalink',
+      returnOptionText: 'pretty_name',
+
+      <% if resource.send(save_to) %>
+        selectedOption: "<%= resource.send(save_to) %>"
+      <% end %>
+    })
+  </script>
 <% end %>

--- a/backend/app/views/spree/admin/shared/cms/_spree_taxon.html.erb
+++ b/backend/app/views/spree/admin/shared/cms/_spree_taxon.html.erb
@@ -1,13 +1,12 @@
 <%= f.field_container save_to, class: ['form-group'] do %>
   <%= f.label save_to, Spree.t('admin.cms.link_to_taxon') %>
   <%= f.select save_to, options_from_collection_for_select([resource], save_to, save_to, resource.send(save_to) || nil), { include_blank: true },
-                          class: 'select2autocomplete',
-                          id: "#{save_to}Select2",
+                          id: "cms_section_#{save_to}",
                           data: { autocomplete_placeholder_value: Spree.t('admin.navigation.seach_for_a_taxon'),
-                                 autocomplete_clear_value: true,
-                                 autocomplete_url_value: 'taxons_api_v2',
-                                 autocomplete_return_attr_value: 'pretty_name',
-                                 autocomplete_custom_return_id_value: 'permalink' } %>
+                                  autocomplete_clear_value: true,
+                                  autocomplete_url_value: 'taxons_api_v2',
+                                  autocomplete_return_attr_value: 'pretty_name',
+                                  autocomplete_custom_return_id_value: 'permalink' } %>
 
   <%= f.error_message_on :save_to %>
 <% end %>
@@ -15,7 +14,7 @@
 <% if resource.link_one.present? %>
   <script>
     populateSelectOptionsFromApi({
-      targetElement: "#<%= save_to %>Select2",
+      targetElement: "#cms_section_<%= save_to %>",
       apiUrl: Spree.routes.taxons_api_v2 + "?filter[permalink_matches]=<%= resource.send(save_to) %>",
       returnValueFromAttributes: 'permalink',
       returnOptionText: 'pretty_name',

--- a/backend/app/views/spree/admin/shared/linkables/_spree_cms_page.erb
+++ b/backend/app/views/spree/admin/shared/linkables/_spree_cms_page.erb
@@ -16,12 +16,7 @@
                  autocomplete_url_value: 'pages_api_v2',
                  autocomplete_return_attr_value: 'title',
                  autocomplete_search_query_value: 'title_i_cont',
-
-                 # Hard coded additional filter to filter out homepages from
-                 # the results. Homepages don't have a slug, and we already have
-                 # a dedicated Home Page link_to type.
-                 autocomplete_additional_query_value: 'type_not_eq',
-                 autocomplete_additional_term_value: 'Spree::Cms::Pages::Homepage' } %>
+                 autocomplete_additional_url_params_value: 'filter[type_not_eq]=Spree::Cms::Pages::Homepage' } %>
 
    <%= f.error_message_on :linked_resource_id %>
    <small class="form-text text-muted"><%= resource.link %></small>

--- a/backend/spec/features/admin/cms_sections/featured_article_spec.rb
+++ b/backend/spec/features/admin/cms_sections/featured_article_spec.rb
@@ -1,0 +1,109 @@
+require 'spec_helper'
+
+describe 'Featured Article section', type: :feature do
+  stub_authorization!
+
+  section_type = 'Featured Article'
+
+  let!(:store) { Spree::Store.default }
+  let!(:feature_page) { create(:cms_feature_page, store: store, title: 'Test Page') }
+  let!(:taxon) { create(:taxon) }
+  let!(:product) { create(:product) }
+  let!(:cms_standard_page) { create(:cms_standard_page, store: store) }
+  let!(:homepage) { create(:cms_homepage, store: store, title: 'Super Home Page') }
+  let!(:section) { create(:cms_featured_article_section, cms_page: feature_page, name: "Test #{section_type}") }
+
+  before do
+    visit spree.edit_admin_cms_page_cms_section_path(feature_page, section)
+  end
+
+  context 'editing new page', js: true  do
+    it 'loads with correct defaults setings' do
+      expect(page).to have_field('Name *', with: "Test #{section_type}")
+      expect(page).to have_select('Section Type', selected: section_type)
+      expect(page).to have_content("Options For: #{ section_type}")
+      expect(page).to have_select('Gutters', selected: 'No Gutters')
+    end
+
+    it 'saves WYSIWYG content to database' do
+      rte_content = 'Ipsum blanditiis labore voluptates vero asperiores ullam excepturi'
+
+      page.execute_script("$(tinymce.editors[0].setContent('#{rte_content}'))")
+
+      click_on 'Update'
+
+      expect(page).to have_field(id: 'cms_section_rte_content', with: "<p>#{rte_content}</p>", visible: :hidden, disabled: false)
+      assert_admin_flash_alert_success('Section "Test Featured Article" has been successfully updated!')
+    end
+
+    it 'saves taxon path and loads it back into the view' do
+      select2 taxon.name, from: 'Taxon', search: true
+
+      click_on 'Update'
+
+      expect(page).to have_content(taxon.permalink)
+      assert_admin_flash_alert_success('Section "Test Featured Article" has been successfully updated!')
+    end
+
+    it 'saves product path and loads it back into the view' do
+      select2 'Product', from: 'Link To'
+
+      click_on 'Update'
+
+      select2 product.name, from: 'Product', search: true
+
+      click_on 'Update'
+
+      expect(page).to have_content(product.slug)
+      assert_admin_flash_alert_success('Section "Test Featured Article" has been successfully updated!')
+    end
+
+
+    it 'saves page path and loads it back into the view' do
+      select2 'Page', from: 'Link To'
+
+      click_on 'Update'
+
+      select2 cms_standard_page.title, from: 'Page', search: true
+
+      click_on 'Update'
+
+      expect(page).to have_content(cms_standard_page.slug)
+      assert_admin_flash_alert_success('Section "Test Featured Article" has been successfully updated!')
+    end
+
+    it 'does not display homepages in Link To Page results' do
+      select2 'Page', from: 'Link To'
+
+      click_on 'Update'
+
+      select2_open label: 'Page'
+      select2_search homepage.title, label: 'Page'
+
+      wait_for_ajax do
+        expect(page).to have_text('No results found')
+      end
+    end
+
+    it 'allows admin to enter and save details' do
+      fill_in 'Title', with: 'Trendy Styles'
+      fill_in 'Subtitle', with: 'Shop Today'
+      fill_in 'Button Text', with: 'Learn More'
+      select2('Gutters', from: 'Gutters', exact_text: true)
+
+      click_on 'Update'
+
+      expect(page).to have_field('Title', with: 'Trendy Styles')
+      expect(page).to have_field('Subtitle', with: 'Shop Today')
+      expect(page).to have_field('Button Text', with: 'Learn More')
+      expect(page).to have_select('Gutters', selected: 'Gutters')
+    end
+
+
+    it 'allows changing of the section name' do
+      fill_in 'Name *', with: 'My New Section Name'
+      click_on 'Update'
+      expect(page).to have_field('Name *', with: 'My New Section Name')
+    end
+  end
+end

--- a/backend/spec/features/admin/cms_sections/featured_article_spec.rb
+++ b/backend/spec/features/admin/cms_sections/featured_article_spec.rb
@@ -21,7 +21,7 @@ describe 'Featured Article section', type: :feature do
     it 'loads with correct defaults setings' do
       expect(page).to have_field('Name *', with: "Test #{section_type}")
       expect(page).to have_select('Section Type', selected: section_type)
-      expect(page).to have_content("Options For: #{ section_type}")
+      expect(page).to have_content("Options For: #{section_type}")
       expect(page).to have_select('Gutters', selected: 'No Gutters')
     end
 
@@ -57,7 +57,6 @@ describe 'Featured Article section', type: :feature do
       expect(page).to have_content(product.slug)
       assert_admin_flash_alert_success('Section "Test Featured Article" has been successfully updated!')
     end
-
 
     it 'saves page path and loads it back into the view' do
       select2 'Page', from: 'Link To'
@@ -98,7 +97,6 @@ describe 'Featured Article section', type: :feature do
       expect(page).to have_field('Button Text', with: 'Learn More')
       expect(page).to have_select('Gutters', selected: 'Gutters')
     end
-
 
     it 'allows changing of the section name' do
       fill_in 'Name *', with: 'My New Section Name'

--- a/backend/spec/features/admin/cms_sections/hero_image_spec.rb
+++ b/backend/spec/features/admin/cms_sections/hero_image_spec.rb
@@ -1,0 +1,107 @@
+require 'spec_helper'
+
+describe 'Hero Image section', type: :feature do
+  stub_authorization!
+
+  section_type = 'Hero Image'
+
+  let!(:store) { Spree::Store.default }
+  let!(:feature_page) { create(:cms_feature_page, store: store, title: 'Test Page') }
+  let!(:taxon) { create(:taxon) }
+  let!(:product) { create(:product) }
+  let!(:cms_standard_page) { create(:cms_standard_page, store: store) }
+  let!(:homepage) { create(:cms_homepage, store: store, title: 'Super Home Page') }
+  let!(:section) { create(:cms_hero_image_section, cms_page: feature_page, name: "Test #{section_type}") }
+  let(:file_path) { Rails.root + '../../spec/support/ror_ringer.jpeg' }
+
+  before do
+    visit spree.edit_admin_cms_page_cms_section_path(feature_page, section)
+  end
+
+  context 'editing new page', js: true  do
+    it 'loads with correct defaults setings' do
+      expect(page).to have_field('Name *', with: "Test #{section_type}")
+      expect(page).to have_select('Section Type', selected: section_type)
+      expect(page).to have_content("Options For: #{section_type}")
+      expect(page).to have_select('Gutters', selected: 'No Gutters')
+      expect(page).to have_select('Fit To', selected: 'Screen')
+    end
+
+    it 'saves taxon path and loads it back into the view' do
+      select2 taxon.name, from: 'Taxon', search: true
+
+      click_on 'Update'
+
+      expect(page).to have_content(taxon.permalink)
+      assert_admin_flash_alert_success('Section "Test Hero Image" has been successfully updated!')
+    end
+
+    it 'admin should be able to add image' do
+      attach_file('cms_section_image_one', file_path)
+
+      click_button 'Update'
+
+      expect(page).to have_content('successfully updated!')
+      expect(page).to have_css('.admin-img-holder img')
+    end
+
+    it 'saves product path and loads it back into the view' do
+      select2 'Product', from: 'Link To'
+
+      click_on 'Update'
+
+      select2 product.name, from: 'Product', search: true
+
+      click_on 'Update'
+
+      expect(page).to have_content(product.slug)
+      assert_admin_flash_alert_success('Section "Test Hero Image" has been successfully updated!')
+    end
+
+    it 'saves page path and loads it back into the view' do
+      select2 'Page', from: 'Link To'
+
+      click_on 'Update'
+
+      select2 cms_standard_page.title, from: 'Page', search: true
+
+      click_on 'Update'
+
+      expect(page).to have_content(cms_standard_page.slug)
+      assert_admin_flash_alert_success('Section "Test Hero Image" has been successfully updated!')
+    end
+
+    it 'does not display homepages in Link To Page results' do
+      select2 'Page', from: 'Link To'
+
+      click_on 'Update'
+
+      select2_open label: 'Page'
+      select2_search homepage.title, label: 'Page'
+
+      wait_for_ajax do
+        expect(page).to have_text('No results found')
+      end
+    end
+
+    it 'allows admin to enter and save details' do
+      fill_in 'Title', with: 'Trendy Styles'
+      fill_in 'Button Text', with: 'Learn More'
+      select2('Gutters', from: 'Gutters', exact_text: true)
+      select2('Container', from: 'Fit To', exact_text: true)
+
+      click_on 'Update'
+
+      expect(page).to have_field('Title', with: 'Trendy Styles')
+      expect(page).to have_field('Button Text', with: 'Learn More')
+      expect(page).to have_select('Fit To', selected: 'Container')
+      expect(page).to have_select('Gutters', selected: 'Gutters')
+    end
+
+    it 'allows changing of the section name' do
+      fill_in 'Name *', with: 'My New Section Name'
+      click_on 'Update'
+      expect(page).to have_field('Name *', with: 'My New Section Name')
+    end
+  end
+end

--- a/backend/spec/features/admin/cms_sections/image_gallery_spec.rb
+++ b/backend/spec/features/admin/cms_sections/image_gallery_spec.rb
@@ -1,0 +1,212 @@
+require 'spec_helper'
+
+describe 'Image Gallery section', type: :feature do
+  stub_authorization!
+
+  let!(:store) { Spree::Store.default }
+  let!(:feature_page) { create(:cms_feature_page, store: store, title: 'Test Page') }
+  let!(:section) { create(:cms_image_gallery_section, cms_page: feature_page, name: 'Test Section') }
+  let!(:taxonomy) { create(:taxon, name: 'Shirts', permalink: 'all-ts') }
+  let!(:product) { create(:product, name: 'Zomg Shirt', slug: 'black-zomg-shirt') }
+  let(:file_path) { Rails.root + '../../spec/support/ror_ringer.jpeg' }
+
+
+  before do
+    visit spree.edit_admin_cms_page_cms_section_path(feature_page, section)
+  end
+
+  context 'editing new page', js: true  do
+    it 'loads with correct defaults setings' do
+      expect(page).to have_field('Name *', with: 'Test Section')
+      expect(page).to have_select('Section Type', selected: 'Image Gallery')
+      expect(page).to have_content('Options For: Image Gallery')
+
+      within 'div#image_a_details' do
+        expect(page).to have_content('Image A')
+        expect(page).to have_content('Title')
+        expect(page).to have_select('Link To', selected: 'Taxon')
+      end
+
+      within 'div#image_b_details' do
+        expect(page).to have_content('Image B')
+        expect(page).to have_content('Title')
+        expect(page).to have_select('Link To', selected: 'Taxon')
+      end
+
+      within 'div#image_c_details' do
+        expect(page).to have_content('Image C')
+        expect(page).to have_content('Title')
+        expect(page).to have_select('Link To', selected: 'Taxon')
+      end
+
+      expect(page).to have_select('Layout Style', selected: 'Default')
+      expect(page).to have_select('Fit To', selected: 'Container')
+      expect(page).to have_select('Display labels', selected: 'Show')
+    end
+
+    it 'allows the selection of layout style and saves to database' do
+      select2('Reversed', from: 'Layout Style')
+      click_on 'Update'
+      expect(page).to have_select('Layout Style', selected: 'Reversed')
+    end
+
+    it 'allows the selection of Fit To and saves to database' do
+      select2('Screen', from: 'Fit To')
+      click_on 'Update'
+      expect(page).to have_select('Fit To', selected: 'Screen')
+    end
+
+    it 'allows the selection of Display Labels and saves to database' do
+      select2('Hide', from: 'Display labels')
+      click_on 'Update'
+      expect(page).to have_select('Display labels', selected: 'Hide')
+    end
+
+    it 'allows changing of the section name' do
+      fill_in 'Name *', with: 'My New Section Name'
+      click_on 'Update'
+      expect(page).to have_field('Name *', with: 'My New Section Name')
+    end
+
+    context 'Editing Image A' do
+      it 'allows admin to enter and save details' do
+        within 'div#image_a_details' do
+          fill_in 'Title', with: 'Trendy Styles'
+        end
+
+        select2('Shirts', css: '#cms_section_link_one_field', search: true)
+
+        click_on 'Update'
+
+        within 'div#image_a_details' do
+          expect(page).to have_field('Title', with: 'Trendy Styles')
+
+          wait_for_ajax do
+            expect(page).to have_select('Link To Taxon', selected: 'Shirts', value: 'all-ts', visible: :all)
+          end
+        end
+      end
+
+      if Rails::VERSION::STRING >= '6.0'
+        it 'allows admin to change the link type and save a product' do
+          select2('Product', css: '#cms_section_link_type_one_field')
+
+          click_on 'Update'
+
+          select2('Zomg Shirt', css: '#cms_section_link_one_field', search: true)
+
+          click_on 'Update'
+
+          within 'div#image_a_details' do
+            wait_for_ajax do
+              expect(page).to have_select('Link To Product', selected: 'Zomg Shirt', value: 'black-zomg-shirt', visible: :all)
+            end
+          end
+        end
+      end
+
+      it 'admin should be able to add image' do
+        attach_file('cms_section_image_one', file_path)
+
+        click_button 'Update'
+
+        expect(page).to have_content('successfully updated!')
+        expect(page).to have_css('.admin-img-holder img')
+      end
+    end
+
+    context 'Editing Image B' do
+      it 'allows admin to enter and save details' do
+        within 'div#image_b_details' do
+          fill_in 'Title', with: 'Trendy Styles'
+        end
+
+        select2('Shirts', css: '#cms_section_link_two_field', search: true)
+
+        click_on 'Update'
+
+        within 'div#image_b_details' do
+          expect(page).to have_field('Title', with: 'Trendy Styles')
+
+          wait_for_ajax do
+            expect(page).to have_select('Link To Taxon', selected: 'Shirts', value: 'all-ts', visible: :all)
+          end
+        end
+      end
+
+      if Rails::VERSION::STRING >= '6.0'
+        it 'allows admin to change the link type and save a product' do
+          select2('Product', css: '#cms_section_link_type_two_field')
+
+          click_on 'Update'
+
+          select2('Zomg Shirt', css: '#cms_section_link_two_field', search: true)
+
+          click_on 'Update'
+
+          within 'div#image_b_details' do
+            wait_for_ajax do
+              expect(page).to have_select('Link To Product', selected: 'Zomg Shirt', value: 'black-zomg-shirt', visible: :all)
+            end
+          end
+        end
+      end
+
+      it 'admin should be able to add image' do
+        attach_file('cms_section_image_two', file_path)
+
+        click_button 'Update'
+
+        expect(page).to have_content('successfully updated!')
+        expect(page).to have_css('.admin-img-holder img')
+      end
+    end
+
+    context 'Editing Image C' do
+      it 'allows admin to enter and save details' do
+        within 'div#image_c_details' do
+          fill_in 'Title', with: 'Trendy Styles'
+        end
+
+        select2('Shirts', css: '#cms_section_link_three_field', search: true)
+
+        click_on 'Update'
+
+        within 'div#image_c_details' do
+          expect(page).to have_field('Title', with: 'Trendy Styles')
+
+          wait_for_ajax do
+            expect(page).to have_select('Link To Taxon', selected: 'Shirts', value: 'all-ts', visible: :all)
+          end
+        end
+      end
+
+      if Rails::VERSION::STRING >= '6.0'
+        it 'allows admin to change the link type and save a product' do
+          select2('Product', css: '#cms_section_link_type_three_field')
+
+          click_on 'Update'
+
+          select2('Zomg Shirt', css: '#cms_section_link_three_field', search: true)
+
+          click_on 'Update'
+
+          within 'div#image_c_details' do
+            wait_for_ajax do
+              expect(page).to have_select('Link To Product', selected: 'Zomg Shirt', value: 'black-zomg-shirt', visible: :all)
+            end
+          end
+        end
+      end
+
+      it 'admin should be able to add image' do
+        attach_file('cms_section_image_three', file_path)
+
+        click_button 'Update'
+
+        expect(page).to have_content('successfully updated!')
+        expect(page).to have_css('.admin-img-holder img')
+      end
+    end
+  end
+end

--- a/backend/spec/features/admin/cms_sections/image_gallery_spec.rb
+++ b/backend/spec/features/admin/cms_sections/image_gallery_spec.rb
@@ -12,7 +12,6 @@ describe 'Image Gallery section', type: :feature do
   let!(:product) { create(:product, name: 'Zomg Shirt', slug: 'black-zomg-shirt') }
   let(:file_path) { Rails.root + '../../spec/support/ror_ringer.jpeg' }
 
-
   before do
     visit spree.edit_admin_cms_page_cms_section_path(feature_page, section)
   end
@@ -21,7 +20,7 @@ describe 'Image Gallery section', type: :feature do
     it 'loads with correct defaults setings' do
       expect(page).to have_field('Name *', with: "Test #{section_type}")
       expect(page).to have_select('Section Type', selected: section_type)
-      expect(page).to have_content("Options For: #{ section_type}")
+      expect(page).to have_content("Options For: #{section_type}")
 
       within 'div#image_a_details' do
         expect(page).to have_content('Image A')

--- a/backend/spec/features/admin/cms_sections/image_gallery_spec.rb
+++ b/backend/spec/features/admin/cms_sections/image_gallery_spec.rb
@@ -24,19 +24,28 @@ describe 'Image Gallery section', type: :feature do
       within 'div#image_a_details' do
         expect(page).to have_content('Image A')
         expect(page).to have_content('Title')
-        expect(page).to have_select('Link To', selected: 'Taxon')
+
+        if Rails::VERSION::STRING >= '6.0'
+          expect(page).to have_select('Link To', selected: 'Taxon')
+        end
       end
 
       within 'div#image_b_details' do
         expect(page).to have_content('Image B')
         expect(page).to have_content('Title')
-        expect(page).to have_select('Link To', selected: 'Taxon')
+
+        if Rails::VERSION::STRING >= '6.0'
+          expect(page).to have_select('Link To', selected: 'Taxon')
+        end
       end
 
       within 'div#image_c_details' do
         expect(page).to have_content('Image C')
         expect(page).to have_content('Title')
-        expect(page).to have_select('Link To', selected: 'Taxon')
+
+        if Rails::VERSION::STRING >= '6.0'
+          expect(page).to have_select('Link To', selected: 'Taxon')
+        end
       end
 
       expect(page).to have_select('Layout Style', selected: 'Default')

--- a/backend/spec/features/admin/cms_sections/product_carousel_spec.rb
+++ b/backend/spec/features/admin/cms_sections/product_carousel_spec.rb
@@ -1,13 +1,14 @@
 require 'spec_helper'
 
-describe 'Rich Text Content section', type: :feature do
+describe 'Product Carousel section', type: :feature do
   stub_authorization!
 
-  section_type = 'Rich Text Content'
+  section_type = 'Product Carousel'
 
   let!(:store) { Spree::Store.default }
   let!(:feature_page) { create(:cms_feature_page, store: store, title: 'Test Page') }
-  let!(:section) { create(:cms_rich_text_content_section, cms_page: feature_page, name: "Test #{section_type}") }
+  let!(:taxon) { create(:taxon) }
+  let!(:section) { create(:cms_product_carousel_section, cms_page: feature_page, name: "Test #{section_type}") }
 
   before do
     visit spree.edit_admin_cms_page_cms_section_path(feature_page, section)
@@ -20,17 +21,14 @@ describe 'Rich Text Content section', type: :feature do
       expect(page).to have_content("Options For: #{ section_type}")
     end
 
-    it 'saves WYSIWYG content to database' do
-      rte_content = 'Ipsum blanditiis labore voluptates vero asperiores ullam excepturi'
-
-      page.execute_script("$(tinymce.editors[0].setContent('#{rte_content}'))")
+    it 'saves taxon path and loads it back into the view database' do
+      select2 taxon.name, from: 'Taxon', search: true
 
       click_on 'Update'
 
-      expect(page).to have_field(id: 'cms_section_rte_content', with: "<p>#{rte_content}</p>", visible: :hidden, disabled: false)
-      assert_admin_flash_alert_success('Section "Test Rich Text Content" has been successfully updated!')
+      expect(page).to have_content(taxon.permalink)
+      assert_admin_flash_alert_success('Section "Test Product Carousel" has been successfully updated!')
     end
-
 
     it 'allows changing of the section name' do
       fill_in 'Name *', with: 'My New Section Name'

--- a/backend/spec/features/admin/cms_sections/product_carousel_spec.rb
+++ b/backend/spec/features/admin/cms_sections/product_carousel_spec.rb
@@ -21,7 +21,7 @@ describe 'Product Carousel section', type: :feature do
       expect(page).to have_content("Options For: #{ section_type}")
     end
 
-    it 'saves taxon path and loads it back into the view database' do
+    it 'saves taxon path and loads it back into the view' do
       select2 taxon.name, from: 'Taxon', search: true
 
       click_on 'Update'

--- a/backend/spec/features/admin/cms_sections/product_carousel_spec.rb
+++ b/backend/spec/features/admin/cms_sections/product_carousel_spec.rb
@@ -18,7 +18,7 @@ describe 'Product Carousel section', type: :feature do
     it 'loads with correct defaults setings' do
       expect(page).to have_field('Name *', with: "Test #{section_type}")
       expect(page).to have_select('Section Type', selected: section_type)
-      expect(page).to have_content("Options For: #{ section_type}")
+      expect(page).to have_content("Options For: #{section_type}")
     end
 
     it 'saves taxon path and loads it back into the view' do

--- a/backend/spec/features/admin/cms_sections/rich_text_content_spec.rb
+++ b/backend/spec/features/admin/cms_sections/rich_text_content_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+require 'ffaker'
+
+describe 'Rich Text Content section', type: :feature do
+  stub_authorization!
+
+  section_type = 'Rich Text Content'
+
+  let!(:store) { Spree::Store.default }
+  let!(:feature_page) { create(:cms_feature_page, store: store, title: 'Test Page') }
+  let!(:section) { create(:cms_rich_text_content_section, cms_page: feature_page, name: "Test #{section_type}") }
+
+  before do
+    visit spree.edit_admin_cms_page_cms_section_path(feature_page, section)
+  end
+
+  context 'editing new page', js: true  do
+    it 'loads with correct defaults setings' do
+      expect(page).to have_field('Name *', with: "Test #{section_type}")
+      expect(page).to have_select('Section Type', selected: section_type)
+      expect(page).to have_content("Options For: #{ section_type}")
+    end
+
+    it 'saves WYSIWYG content to database' do
+      rte_content = 'Ipsum blanditiis labore voluptates vero asperiores ullam excepturi'
+
+      page.execute_script("$(tinymce.editors[0].setContent('#{rte_content}'))")
+
+      click_on 'Update'
+
+      expect(page).to have_field(id: 'cms_section_rte_content', with: "<p>#{rte_content}</p>", visible: :hidden, disabled: false)
+      assert_admin_flash_alert_success('Section "Test Rich Text Content" has been successfully updated!')
+    end
+
+
+    it 'allows changing of the section name' do
+      fill_in 'Name *', with: 'My New Section Name'
+      click_on 'Update'
+      expect(page).to have_field('Name *', with: 'My New Section Name')
+    end
+  end
+end

--- a/backend/spec/features/admin/cms_sections/rich_text_content_spec.rb
+++ b/backend/spec/features/admin/cms_sections/rich_text_content_spec.rb
@@ -17,7 +17,7 @@ describe 'Rich Text Content section', type: :feature do
     it 'loads with correct defaults setings' do
       expect(page).to have_field('Name *', with: "Test #{section_type}")
       expect(page).to have_select('Section Type', selected: section_type)
-      expect(page).to have_content("Options For: #{ section_type}")
+      expect(page).to have_content("Options For: #{section_type}")
     end
 
     it 'saves WYSIWYG content to database' do

--- a/backend/spec/features/admin/cms_sections/side_by_side_images_spec.rb
+++ b/backend/spec/features/admin/cms_sections/side_by_side_images_spec.rb
@@ -12,7 +12,6 @@ describe 'Image Side By Side Images section', type: :feature do
   let!(:product) { create(:product, name: 'Zomg Shirt', slug: 'black-zomg-shirt') }
   let(:file_path) { Rails.root + '../../spec/support/ror_ringer.jpeg' }
 
-
   before do
     visit spree.edit_admin_cms_page_cms_section_path(feature_page, section)
   end
@@ -21,7 +20,7 @@ describe 'Image Side By Side Images section', type: :feature do
     it 'loads with correct defaults setings' do
       expect(page).to have_field('Name *', with: "Test #{section_type}")
       expect(page).to have_select('Section Type', selected: section_type)
-      expect(page).to have_content("Options For: #{ section_type}")
+      expect(page).to have_content("Options For: #{section_type}")
 
       within 'div#left_image_details' do
         expect(page).to have_content('Left Image')
@@ -46,7 +45,6 @@ describe 'Image Side By Side Images section', type: :feature do
       expect(page).to have_select('Fit To', selected: 'Container')
       expect(page).to have_select('Set Gutters', selected: 'Gutters')
     end
-
 
     it 'allows the selection of Fit To and saves to database' do
       select2('Screen', from: 'Fit To')

--- a/backend/spec/features/admin/cms_sections/side_by_side_images_spec.rb
+++ b/backend/spec/features/admin/cms_sections/side_by_side_images_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
-describe 'Image Gallery section', type: :feature do
+describe 'Image Side By Side Images section', type: :feature do
   stub_authorization!
 
-  section_type = 'Image Gallery'
+  section_type = 'Side By Side Images'
 
   let!(:store) { Spree::Store.default }
   let!(:feature_page) { create(:cms_feature_page, store: store, title: 'Test Page') }
-  let!(:section) { create(:cms_image_gallery_section, cms_page: feature_page, name: "Test #{section_type}") }
+  let!(:section) { create(:cms_side_by_side_images_section, cms_page: feature_page, name: "Test #{section_type}") }
   let!(:taxonomy) { create(:taxon, name: 'Shirts', permalink: 'all-ts') }
   let!(:product) { create(:product, name: 'Zomg Shirt', slug: 'black-zomg-shirt') }
   let(:file_path) { Rails.root + '../../spec/support/ror_ringer.jpeg' }
@@ -23,43 +23,30 @@ describe 'Image Gallery section', type: :feature do
       expect(page).to have_select('Section Type', selected: section_type)
       expect(page).to have_content("Options For: #{ section_type}")
 
-      within 'div#image_a_details' do
-        expect(page).to have_content('Image A')
-        expect(page).to have_content('Title')
+      within 'div#left_image_details' do
+        expect(page).to have_content('Left Image')
+        expect(page).to have_field('Title')
+        expect(page).to have_field('Subtitle')
 
         if Rails::VERSION::STRING >= '6.0'
           expect(page).to have_select('Link To', selected: 'Taxon')
         end
       end
 
-      within 'div#image_b_details' do
-        expect(page).to have_content('Image B')
-        expect(page).to have_content('Title')
+      within 'div#right_image_details' do
+        expect(page).to have_content('Right Image')
+        expect(page).to have_field('Title')
+        expect(page).to have_field('Subtitle')
 
         if Rails::VERSION::STRING >= '6.0'
           expect(page).to have_select('Link To', selected: 'Taxon')
         end
       end
 
-      within 'div#image_c_details' do
-        expect(page).to have_content('Image C')
-        expect(page).to have_content('Title')
-
-        if Rails::VERSION::STRING >= '6.0'
-          expect(page).to have_select('Link To', selected: 'Taxon')
-        end
-      end
-
-      expect(page).to have_select('Layout Style', selected: 'Default')
       expect(page).to have_select('Fit To', selected: 'Container')
-      expect(page).to have_select('Display labels', selected: 'Show')
+      expect(page).to have_select('Set Gutters', selected: 'Gutters')
     end
 
-    it 'allows the selection of layout style and saves to database' do
-      select2('Reversed', from: 'Layout Style')
-      click_on 'Update'
-      expect(page).to have_select('Layout Style', selected: 'Reversed')
-    end
 
     it 'allows the selection of Fit To and saves to database' do
       select2('Screen', from: 'Fit To')
@@ -67,10 +54,10 @@ describe 'Image Gallery section', type: :feature do
       expect(page).to have_select('Fit To', selected: 'Screen')
     end
 
-    it 'allows the selection of Display Labels and saves to database' do
-      select2('Hide', from: 'Display labels')
+    it 'allows the selection of Gutters and saves to database' do
+      select2('No Gutters', from: 'Set Gutters')
       click_on 'Update'
-      expect(page).to have_select('Display labels', selected: 'Hide')
+      expect(page).to have_select('Set Gutters', selected: 'No Gutters')
     end
 
     it 'allows changing of the section name' do
@@ -79,18 +66,20 @@ describe 'Image Gallery section', type: :feature do
       expect(page).to have_field('Name *', with: 'My New Section Name')
     end
 
-    context 'Editing Image A' do
+    context 'Editing Left Image' do
       it 'allows admin to enter and save details' do
-        within 'div#image_a_details' do
+        within 'div#left_image_details' do
           fill_in 'Title', with: 'Trendy Styles'
+          fill_in 'Subtitle', with: 'Shop Today'
         end
 
         select2('Shirts', css: '#cms_section_link_one_field', search: true)
 
         click_on 'Update'
 
-        within 'div#image_a_details' do
+        within 'div#left_image_details' do
           expect(page).to have_field('Title', with: 'Trendy Styles')
+          expect(page).to have_field('Subtitle', with: 'Shop Today')
 
           wait_for_ajax do
             expect(page).to have_select('Link To Taxon', selected: 'Shirts', value: 'all-ts', visible: :all)
@@ -108,7 +97,7 @@ describe 'Image Gallery section', type: :feature do
 
           click_on 'Update'
 
-          within 'div#image_a_details' do
+          within 'div#left_image_details' do
             wait_for_ajax do
               expect(page).to have_select('Link To Product', selected: 'Zomg Shirt', value: 'black-zomg-shirt', visible: :all)
             end
@@ -126,18 +115,20 @@ describe 'Image Gallery section', type: :feature do
       end
     end
 
-    context 'Editing Image B' do
+    context 'Editing Right Image' do
       it 'allows admin to enter and save details' do
-        within 'div#image_b_details' do
+        within 'div#right_image_details' do
           fill_in 'Title', with: 'Trendy Styles'
+          fill_in 'Subtitle', with: 'Shop Today'
         end
 
-        select2('Shirts', css: '#cms_section_link_two_field', search: true)
+        select2('Shirts', css: '#cms_section_link_one_field', search: true)
 
         click_on 'Update'
 
-        within 'div#image_b_details' do
+        within 'div#right_image_details' do
           expect(page).to have_field('Title', with: 'Trendy Styles')
+          expect(page).to have_field('Subtitle', with: 'Shop Today')
 
           wait_for_ajax do
             expect(page).to have_select('Link To Taxon', selected: 'Shirts', value: 'all-ts', visible: :all)
@@ -147,15 +138,15 @@ describe 'Image Gallery section', type: :feature do
 
       if Rails::VERSION::STRING >= '6.0'
         it 'allows admin to change the link type and save a product' do
-          select2('Product', css: '#cms_section_link_type_two_field')
+          select2('Product', css: '#cms_section_link_type_one_field')
 
           click_on 'Update'
 
-          select2('Zomg Shirt', css: '#cms_section_link_two_field', search: true)
+          select2('Zomg Shirt', css: '#cms_section_link_one_field', search: true)
 
           click_on 'Update'
 
-          within 'div#image_b_details' do
+          within 'div#right_image_details' do
             wait_for_ajax do
               expect(page).to have_select('Link To Product', selected: 'Zomg Shirt', value: 'black-zomg-shirt', visible: :all)
             end
@@ -164,54 +155,7 @@ describe 'Image Gallery section', type: :feature do
       end
 
       it 'admin should be able to add image' do
-        attach_file('cms_section_image_two', file_path)
-
-        click_button 'Update'
-
-        expect(page).to have_content('successfully updated!')
-        expect(page).to have_css('.admin-img-holder img')
-      end
-    end
-
-    context 'Editing Image C' do
-      it 'allows admin to enter and save details' do
-        within 'div#image_c_details' do
-          fill_in 'Title', with: 'Trendy Styles'
-        end
-
-        select2('Shirts', css: '#cms_section_link_three_field', search: true)
-
-        click_on 'Update'
-
-        within 'div#image_c_details' do
-          expect(page).to have_field('Title', with: 'Trendy Styles')
-
-          wait_for_ajax do
-            expect(page).to have_select('Link To Taxon', selected: 'Shirts', value: 'all-ts', visible: :all)
-          end
-        end
-      end
-
-      if Rails::VERSION::STRING >= '6.0'
-        it 'allows admin to change the link type and save a product' do
-          select2('Product', css: '#cms_section_link_type_three_field')
-
-          click_on 'Update'
-
-          select2('Zomg Shirt', css: '#cms_section_link_three_field', search: true)
-
-          click_on 'Update'
-
-          within 'div#image_c_details' do
-            wait_for_ajax do
-              expect(page).to have_select('Link To Product', selected: 'Zomg Shirt', value: 'black-zomg-shirt', visible: :all)
-            end
-          end
-        end
-      end
-
-      it 'admin should be able to add image' do
-        attach_file('cms_section_image_three', file_path)
+        attach_file('cms_section_image_one', file_path)
 
         click_button 'Update'
 

--- a/core/app/models/spree/cms/sections/featured_article.rb
+++ b/core/app/models/spree/cms/sections/featured_article.rb
@@ -1,6 +1,5 @@
 module Spree::Cms::Sections
   class FeaturedArticle < Spree::CmsSection
-    before_save :reset_link_attributes
     after_initialize :default_values
 
     store :content, accessors: [:title, :subtitle, :button_text, :rte_content], coder: JSON
@@ -13,12 +12,6 @@ module Spree::Cms::Sections
     end
 
     private
-
-    def reset_link_attributes
-      if linked_resource_type_changed?
-        self.linked_resource_id = nil
-      end
-    end
 
     def default_values
       self.gutters ||= 'No Gutters'

--- a/core/app/models/spree/cms/sections/hero_image.rb
+++ b/core/app/models/spree/cms/sections/hero_image.rb
@@ -1,6 +1,5 @@
 module Spree::Cms::Sections
   class HeroImage < Spree::CmsSection
-    before_save :reset_link_attributes
     after_initialize :default_values
 
     store :content, accessors: [:title, :button_text], coder: JSON
@@ -29,14 +28,6 @@ module Spree::Cms::Sections
     end
 
     private
-
-    def reset_link_attributes
-      if linked_resource_type_changed?
-        return if linked_resource_id_was.nil?
-
-        self.linked_resource_id = nil
-      end
-    end
 
     def default_values
       self.gutters ||= 'No Gutters'

--- a/core/app/models/spree/cms/sections/image_gallery.rb
+++ b/core/app/models/spree/cms/sections/image_gallery.rb
@@ -1,7 +1,7 @@
 module Spree::Cms::Sections
   class ImageGallery < Spree::CmsSection
     after_initialize :default_values
-    before_save :reset_link_attributes
+    validate :reset_multiple_link_attributes
 
     LINKED_RESOURCE_TYPE = if Rails::VERSION::STRING < '6.0'
                              ['Spree::Taxon'].freeze
@@ -70,7 +70,7 @@ module Spree::Cms::Sections
 
     private
 
-    def reset_link_attributes
+    def reset_multiple_link_attributes
       return if Rails::VERSION::STRING < '6.0'
 
       if link_type_one_changed?

--- a/core/app/models/spree/cms/sections/side_by_side_images.rb
+++ b/core/app/models/spree/cms/sections/side_by_side_images.rb
@@ -1,7 +1,7 @@
 module Spree::Cms::Sections
   class SideBySideImages < Spree::CmsSection
     after_initialize :default_values
-    before_save :reset_link_attributes
+    validate :reset_multiple_link_attributes
 
     LINKED_RESOURCE_TYPE = if Rails::VERSION::STRING < '6.0'
                              ['Spree::Taxon'].freeze
@@ -48,7 +48,7 @@ module Spree::Cms::Sections
 
     private
 
-    def reset_link_attributes
+    def reset_multiple_link_attributes
       return if Rails::VERSION::STRING < '6.0'
 
       if link_type_one_changed?

--- a/core/app/models/spree/cms_section.rb
+++ b/core/app/models/spree/cms_section.rb
@@ -5,6 +5,8 @@ module Spree
     acts_as_list scope: :cms_page
     belongs_to :cms_page, touch: true
 
+    validate :reset_link_attributes
+
     IMAGE_COUNT = ['one', 'two', 'three']
     IMAGE_TYPES = ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'].freeze
     IMAGE_SIZE = ['sm', 'md', 'lg', 'xl']
@@ -24,6 +26,7 @@ module Spree
     belongs_to :linked_resource, polymorphic: true
 
     default_scope { order(position: :asc) }
+
 
     validates :name, :cms_page, presence: true
 
@@ -52,6 +55,16 @@ module Spree
 
     def fullscreen?
       fit == 'Screen'
+    end
+
+    private
+
+    def reset_link_attributes
+      if linked_resource_type_changed?
+        return if linked_resource_id_was.nil?
+
+        self.linked_resource_id = nil
+      end
     end
   end
 end

--- a/core/app/models/spree/cms_section.rb
+++ b/core/app/models/spree/cms_section.rb
@@ -27,7 +27,6 @@ module Spree
 
     default_scope { order(position: :asc) }
 
-
     validates :name, :cms_page, presence: true
 
     validates :image_one, :image_two, :image_three, content_type: IMAGE_TYPES

--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -44,6 +44,7 @@ module Spree
     scope :for_store, ->(store) { joins(:taxonomy).where(spree_taxonomies: { store_id: store.id }) }
 
     self.whitelisted_ransackable_associations = %w[taxonomy]
+    self.whitelisted_ransackable_attributes = %w[name permalink]
 
     scope :for_stores, ->(stores) { joins(:taxonomy).where(spree_taxonomies: { store_id: stores.ids }) }
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1350,6 +1350,7 @@ en:
     backordered_confirm_info: Selected item is backordered so expect delays. Are you sure you want to order it?
     overview: Overview
     package_from: package from
+    page: Page
     page_not_found: Sorry! Page you are looking can’t be found.
     pagination:
       next_page: next page &raquo;

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -564,6 +564,7 @@ en:
         draft_mode: Draft Mode
         full_width: Full width
         link_to_taxon: Link to Taxon
+        link_to_product: Link to Product
         title: Title
         fit: Fit To
         info_hero_image_body: "<p>The Hero Image section adds a large image with a button and tagline text to your page.</p>

--- a/core/spec/models/spree/cms/sections/image_gallery_spec.rb
+++ b/core/spec/models/spree/cms/sections/image_gallery_spec.rb
@@ -58,7 +58,7 @@ describe Spree::Cms::Sections::ImageGallery, type: :model do
     end
   end
 
-  if Rails::VERSION::STRING >= '6.1'
+  if Rails::VERSION::STRING >= '6.0'
     context 'when changing the link types for links one two and three' do
       let!(:image_gallery_section) { create(:cms_image_gallery_section, cms_page: homepage) }
 

--- a/core/spec/models/spree/cms/sections/side_by_side_images_spec.rb
+++ b/core/spec/models/spree/cms/sections/side_by_side_images_spec.rb
@@ -46,7 +46,7 @@ describe Spree::Cms::Sections::SideBySideImages, type: :model do
     end
   end
 
-  if Rails::VERSION::STRING >= '6.1'
+  if Rails::VERSION::STRING >= '6.0'
     context 'when changing the link types for links one and two' do
       let!(:side_by_side_images_section) { create(:cms_side_by_side_images_section, cms_page: homepage) }
 


### PR DESCRIPTION
- Display Taxon pretty_name for selected Taxon in sections with several links (Had to whitelist filter by permalink in Taxon Model).
- Display Product name for selected Product in sections with several links
- Add Feature Tests For All `cms_sections`
- Fix Two Bugs

**Bug Fixes:**
- In `select2_autocomplete.es6` we use sparse fields for the return values, if you request a custom return value, such as when selecting a Product or Taxon on a section with multiple links, the slug or permalink was missing from the return value.

- Linking to Taxon on new Featured Article section would not save because initial value was being changed.

**Improvement to JavaScript code**
In `select2_autocomplete.es6` We applied a quick fix for allowing additional filters when making a request, for those edge cases when you need to filter out certain results, example is filtering home pages form the pages list this is now implemented better.

In `select2_populate.es6` was written but not used, it is now revamped and used to populate the select2's with pretty_name in certain sections that contian multiple links and the path is stored.