### PR TITLE
Added Image Carousel cms section.

### DIFF
--- a/backend/app/views/spree/admin/cms_sections/types/_image_carousel.html.erb
+++ b/backend/app/views/spree/admin/cms_sections/types/_image_carousel.html.erb
@@ -1,0 +1,97 @@
+<div class="row">
+  <% Spree::Cms::Sections::ImageCarousel::IMAGE_COUNT.each_with_index do |count, index| %>
+    <% img_field = "image_#{count}" %>
+    <% title_field = "title_#{count}" %>
+    <% link_type_field = "link_type_#{count}" %>
+    <% link_field = "link_#{count}" %>
+
+    <div class="col-12 col-md-4 mb-3">
+      <div class="card p-3">
+        <div class="text-center">
+          <h4 class="pb-2"><%= Spree.t("admin.cms.image_carousel.image_#{index}") %></h4>
+          <% if @cms_section.try(img_field).attached? %>
+            <div id="cms_section_image_<%= count %>_preview">
+              <figure class="admin-img-holder mb-0">
+                <%= image_tag main_app.url_for(@cms_section.try(img_field).variant(resize: '244x104>')) %>
+              </figure>
+              <div class="mb-4">
+                <%= link_to_with_icon 'delete.svg', Spree.t('delete'), "#!",
+                    class: 'btn btn-danger btn-sm _remove_image', data: {count: count} %>
+                <%= f.hidden_field "remove_#{count}" %>
+              </div>
+            </div>
+          <% end %>
+
+          <%= f.field_container img_field, class: ['form-group mb-0'] do %>
+            <%= f.file_field img_field %>
+            <%= f.error_message_on img_field %>
+          <% end %>
+        </div>
+
+        <small class="text-muted mb-4"><%= Spree.t('admin.cms.image_carousel.aspect_ratio') %></small>
+
+        <%= f.field_container title_field, class: ['form-group'] do %>
+          <%= f.label title_field, Spree.t('admin.cms.title') %>
+          <%= f.text_field title_field, class: 'form-control' %>
+          <%= f.error_message_on title_field %>
+        <% end %>
+
+        <div class="col-12"><hr></div>
+        <% unless rails_5? %>
+          <%= f.field_container link_type_field, class: ['form-group'] do %>
+            <%= f.label link_type_field, Spree.t('admin.navigation.link_to') %>
+            <%= f.select(link_type_field,
+                spree_humanize_dropdown_values('Spree::Cms::Sections::ImageCarousel',
+                                                { const: 'LINKED_RESOURCE_TYPE' }),
+                                                { include_blank: Spree.t('none') },
+                                                class: 'link_switcher',
+                                                data: { target_field: link_field}) %>
+            <%= f.error_message_on link_type_field %>
+          <% end %>
+        <% end %>
+
+        <%= render "spree/admin/shared/link_fields",
+          resource: @cms_section,
+          linked_type: @cms_section.try(link_type_field),
+          save_to: link_field, f: f %>
+      </div>
+    </div>
+  <% end %>
+</div>
+
+<div class="row pb-0">
+  <div class="col-12"> <hr></div>
+  <%= f.field_container :fit, class: ['form-group col-6'] do %>
+    <%= f.label :fit, Spree.t('admin.cms.fit') %>
+    <%= f.select(:fit, @cms_section.boundaries, {include_blank: false}, class: 'select2') %>
+    <%= f.error_message_on :fit %>
+  <% end %>
+
+  <%= f.field_container :interval, class: ['form-group col-6'] do %>
+    <%= f.label :interval, Spree.t('admin.cms.image_carousel.interval') %>
+    <%= f.number_field :interval, step: 100, min: 1000, class: 'form-control' %>
+    <%= f.error_message_on :interval %>
+  <% end %>
+
+  <% %w[controls indicators captions crossfade autoplay pause wrap].each do |field| %>
+    <%= f.field_container field, class: ['form-group col-6'] do %>
+      <div class="custom-control custom-checkbox">
+        <%= f.check_box field, class: 'custom-control-input' %>
+        <%= f.label field, Spree.t("admin.cms.image_carousel.#{field}"), class: 'custom-control-label' %>
+      </div>
+    <% end %>
+  <% end %>
+</div>
+
+<script>
+  $("._remove_image").each(function() {
+    const count = $(this).data('count')
+
+    $(this).click(function(evt) {
+      $(`#cms_section_image_${count}_preview`).hide()
+      $(`#cms_section_remove_${count}`).val(true)
+      $(`#cms_section_title_${count}`).val('')
+      $(`#cms_section_link_type_${count}`).val('').trigger('change');
+    })
+  })
+</script>

--- a/backend/app/views/spree/admin/shared/_link_fields.html.erb
+++ b/backend/app/views/spree/admin/shared/_link_fields.html.erb
@@ -9,6 +9,9 @@
   <div data-panel-type="<%= resource.linked_resource_type %>" data-panel-id="<%= save_to %>">
     <%= render "spree/admin/shared/linkables/#{spree_class_name_as_path(resource.linked_resource_type)}", resource: resource, f: f %>
   </div>
+<% else %>
+  <div data-panel-type="<%= linked_type %>" data-panel-id="<%= save_to %>">
+  </div>
 <% end %>
 
 <div class="d-none" data-target-message-pannel="<%= save_to %>">

--- a/core/app/models/spree/cms/sections/image_carousel.rb
+++ b/core/app/models/spree/cms/sections/image_carousel.rb
@@ -1,0 +1,94 @@
+module Spree::Cms::Sections
+  class ImageCarousel < Spree::CmsSection
+    LINKED_RESOURCE_TYPE = if Rails::VERSION::STRING < '6.0'
+                             ['Spree::Taxon'].freeze
+                           else
+                             ['Spree::Taxon', 'Spree::Product'].freeze
+                           end
+
+    store :content, accessors: [:link_type_one, :link_one, :title_one,
+                                :link_type_two, :link_two, :title_two,
+                                :link_type_three, :link_three, :title_three], coder: JSON
+
+    store :settings, accessors: [:controls, :indicators, :captions, :crossfade,
+                                 :interval, :autoplay, :pause, :wrap], coder: JSON
+
+    attr_accessor :remove_one, :remove_two, :remove_three
+
+
+    before_save :reset_link_attributes
+    after_initialize :default_values
+    after_update :remove_images
+
+    def default_values
+      self.fit ||= 'Container'
+      self.link_type_one ||= ''
+      self.link_type_two ||= ''
+      self.link_type_three ||= ''
+
+      self.interval ||= 5000
+      self.autoplay ||= '1'
+      self.controls ||= '0'
+      self.indicators ||= '0'
+      self.crossfade ||= '0'
+      self.captions ||= '0'
+      self.pause ||= '1'
+      self.wrap ||= '1'
+    end
+
+    def data_attributes
+      attributes = ["data-interval=#{interval}"]
+      attributes.push('data-ride=carousel') if active_setting?(:autoplay)
+      attributes.push('data-wrap=false') unless active_setting?(:wrap)
+      attributes.push('data-pause=false') unless active_setting?(:pause)
+      attributes.join(' ')
+    end
+
+    def attached_images
+      IMAGE_COUNT.filter_map do |count|
+        if try("image_#{count}").attached?
+          {
+            title: try("title_#{count}"),
+            link_type: try("link_type_#{count}"),
+            link: try("link_#{count}"),
+            file: try("image_#{count}")
+          }
+        end
+      end
+    end
+
+    def active_setting?(option)
+      option && ActiveRecord::Type::Boolean.new.cast(try(option))
+    end
+
+    private
+
+    def reset_link_attributes
+      return if Rails::VERSION::STRING < '6.0'
+
+      if link_type_one_changed?
+        return if link_type_one_was.nil?
+
+        self.link_one = nil
+      end
+
+      if link_type_two_changed?
+        return if link_type_two_was.nil?
+
+        self.link_two = nil
+      end
+
+      if link_type_three_changed?
+        return if link_type_three_was.nil?
+
+        self.link_three = nil
+      end
+    end
+
+    def remove_images
+      image_one.purge if remove_one.present?
+      image_two.purge if remove_two.present?
+      image_three.purge if remove_three.present?
+    end
+  end
+end

--- a/core/app/models/spree/cms_section.rb
+++ b/core/app/models/spree/cms_section.rb
@@ -34,6 +34,7 @@ module Spree
     TYPES = ['Spree::Cms::Sections::HeroImage',
              'Spree::Cms::Sections::FeaturedArticle',
              'Spree::Cms::Sections::ProductCarousel',
+             'Spree::Cms::Sections::ImageCarousel',
              'Spree::Cms::Sections::ImageGallery',
              'Spree::Cms::Sections::SideBySideImages',
              'Spree::Cms::Sections::RichTextContent']

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -578,6 +578,8 @@ en:
         info_side_by_side_images_body: "<p>The Side-by-Side Images section can be configured in several ways, you have the option of using them as plane images, images with text, and either of those options can be clickable links if a link is set.</p>
         <p><b>Tip:</b> You can blow these images out to the edge of the screen and remove the gutters to create a completely different look.</p>"
         info_rich_text_content_body: "<p>The Rich Text Content section is simply a section that offers nothing more than an area of rich text editor content to be displayed on your page.</p>"
+        info_image_carousel_body: "<p>The Image Carousel section allows you to add a slideshow component for cycling through images.</p>
+        <p>Each image can link to a product or taxon.</p>"
         brand_bar:
           uses_menu: This section uses your Spree Menu named <b>%{menu}</b> to manage the images and links,
           vist_menu_to_edit: to edit this menu.
@@ -621,6 +623,19 @@ en:
           layout_style: Layout Style
           square_image: Please use an image with an aspect ratio of 18:13 (1080px x 780px).
           tall_image: Please use an image with an aspect ratio of 27:40 (1080px x 1600px).
+        image_carousel:
+          image_0: Image A
+          image_1: Image B
+          image_2: Image C
+          aspect_ratio: Please use an image with the aspect ratio of 12:5 (2400px x 1000px)
+          wrap: Wrap
+          controls: Controls
+          captions: Captions
+          autoplay: Autoplay
+          indicators: Indicators
+          crossfade: Crossfade
+          pause: Pause
+          interval: Interval
       linkable:
         seach_for_a_page: Search for a page
       tab:

--- a/core/lib/spree/testing_support/factories/cms_section_factory.rb
+++ b/core/lib/spree/testing_support/factories/cms_section_factory.rb
@@ -20,6 +20,10 @@ FactoryBot.define do
       type { 'Spree::Cms::Sections::ImageGallery' }
     end
 
+    factory :cms_image_carousel_section do
+      type { 'Spree::Cms::Sections::ImageCarousel' }
+    end
+
     factory :cms_side_by_side_images_section do
       type { 'Spree::Cms::Sections::SideBySideImages' }
     end

--- a/core/spec/models/spree/cms/sections/image_carousel_spec.rb
+++ b/core/spec/models/spree/cms/sections/image_carousel_spec.rb
@@ -1,0 +1,156 @@
+require 'spec_helper'
+
+describe Spree::Cms::Sections::ImageCarousel, type: :model do
+  let!(:store) { create(:store) }
+  let!(:homepage) { create(:cms_homepage, store: store) }
+
+  it 'validates presence of name' do
+    expect(described_class.new(name: nil, cms_page: homepage)).not_to be_valid
+  end
+
+  it 'validates presence of page' do
+    expect(described_class.new(name: 'Got Name')).not_to be_valid
+  end
+
+  context 'when a new Image Gallery section is created' do
+    let!(:image_carousel_section) { create(:cms_image_carousel_section, cms_page: homepage) }
+
+    it 'sets link_type_one to none' do
+      section = Spree::CmsSection.find(image_carousel_section.id)
+
+      expect(section.content[:link_type_one]).to eq('')
+    end
+
+    it 'sets link_type_two to none' do
+      section = Spree::CmsSection.find(image_carousel_section.id)
+
+      expect(section.content[:link_type_two]).to eq('')
+    end
+
+    it 'sets link_type_three to none' do
+      section = Spree::CmsSection.find(image_carousel_section.id)
+
+      expect(section.content[:link_type_three]).to eq('')
+    end
+
+    it 'sets fit to Container' do
+      section = Spree::CmsSection.find(image_carousel_section.id)
+
+      expect(section.fit).to eq('Container')
+    end
+
+    it 'sets interval to 5000' do
+      section = Spree::CmsSection.find(image_carousel_section.id)
+
+      expect(section.settings[:interval]).to eq(5000)
+    end
+
+    it 'sets autoplay setting to active' do
+      section = Spree::CmsSection.find(image_carousel_section.id)
+
+      expect(section.active_setting?(:autoplay)).to be_truthy
+    end
+
+    it 'sets controls setting to active' do
+      section = Spree::CmsSection.find(image_carousel_section.id)
+
+      expect(section.active_setting?(:controls)).to be_falsey
+    end
+
+    it 'sets indicators setting to active' do
+      section = Spree::CmsSection.find(image_carousel_section.id)
+
+      expect(section.active_setting?(:indicators)).to be_falsey
+    end
+
+    it 'sets crossfade setting to active' do
+      section = Spree::CmsSection.find(image_carousel_section.id)
+
+      expect(section.active_setting?(:crossfade)).to be_falsey
+    end
+
+    it 'sets captions setting to active' do
+      section = Spree::CmsSection.find(image_carousel_section.id)
+
+      expect(section.active_setting?(:captions)).to be_falsey
+    end
+
+    it 'sets pause setting to active' do
+      section = Spree::CmsSection.find(image_carousel_section.id)
+
+      expect(section.active_setting?(:pause)).to be_truthy
+    end
+
+    it 'sets wrap setting to active' do
+      section = Spree::CmsSection.find(image_carousel_section.id)
+
+      expect(section.active_setting?(:wrap)).to be_truthy
+    end
+
+    it '#data_attributes returns settings as data attributes' do
+      section = Spree::CmsSection.find(image_carousel_section.id)
+      section.wrap = false
+      section.pause = false
+
+      expect(section.data_attributes).to eq(
+        'data-interval=5000 data-ride=carousel data-wrap=false data-pause=false'
+      )
+    end
+  end
+
+  context 'when set remove fields' do
+    let!(:image_carousel_section) { create(:cms_image_carousel_section, cms_page: homepage) }
+
+    it 'remove images' do
+      section = Spree::CmsSection.find(image_carousel_section.id)
+      expect(section.image_one).to receive(:purge)
+      expect(section.image_two).to receive(:purge)
+      expect(section.image_three).to receive(:purge)
+
+      section.update(remove_one: true, remove_two: true, remove_three: true)
+    end
+  end
+
+  if Rails::VERSION::STRING >= '6.1'
+    context 'when changing the link types for links one two and three' do
+      let!(:image_carousel_section) { create(:cms_image_carousel_section, cms_page: homepage) }
+
+      before do
+        section = Spree::CmsSection.find(image_carousel_section.id)
+
+        section.content[:link_type_one] = 'Spree::Product'
+        section.content[:link_type_two] = 'Spree::Product'
+        section.content[:link_type_three] = 'Spree::Product'
+
+        section.content[:link_one] = 'Shirt 1'
+        section.content[:link_two] = 'Shirt 2'
+        section.content[:link_three] = 'Shirt 3'
+
+        section.save!
+        section.reload
+      end
+
+      it 'link_one, link_two and save the initail values' do
+        section = Spree::CmsSection.find(image_carousel_section.id)
+
+        expect(section.link_one).to eql 'Shirt 1'
+        expect(section.link_two).to eql 'Shirt 2'
+        expect(section.link_three).to eql 'Shirt 3'
+      end
+
+      it 'link_one, link_two and link_three are reset to nil' do
+        section = Spree::CmsSection.find(image_carousel_section.id)
+
+        section.content[:link_type_one] = 'Spree::Taxon'
+        section.content[:link_type_two] = 'Spree::Taxon'
+        section.content[:link_type_three] = 'Spree::Taxon'
+        section.save!
+        section.reload
+
+        expect(section.link_one).to be nil
+        expect(section.link_two).to be nil
+        expect(section.link_three).to be nil
+      end
+    end
+  end
+end

--- a/frontend/app/assets/stylesheets/spree/frontend/helpers/spree/frontend_helper.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/helpers/spree/frontend_helper.scss
@@ -52,7 +52,9 @@
 
 // Aspect Ratios
 [style*="--aspect-ratio"] > img,
-[style*="--aspect-ratio"] > svg {
+[style*="--aspect-ratio"] > svg,
+[style*="--aspect-ratio"] > a > img,
+[style*="--aspect-ratio"] > a > svg {
   width: 100%;
   height: 100%;
   position: absolute;

--- a/frontend/app/views/spree/shared/cms/sections/_image_carousel.html.erb
+++ b/frontend/app/views/spree/shared/cms/sections/_image_carousel.html.erb
@@ -1,0 +1,72 @@
+<% id = "image_carousel_#{section.id}" %>
+
+<% crossfade_class = section.active_setting?(:crossfade) ? 'carousel-fade' : '' %>
+
+<div class="col-12 position-relative p-0">
+  <div id="<%= id %>" class="carousel slide <%= crossfade_class %>" <%= section.data_attributes %>>
+    <% if section.active_setting?(:indicators) %>
+      <ol class="carousel-indicators">
+        <% section.attached_images.each_with_index do |image, index| %>
+          <li data-target="#<%= id %>"
+              data-slide-to="<%= index %>"
+              class="<%= index.zero? ? 'active' : '' %>">
+          </li>
+        <% end %>
+      </ol>
+    <% end %>
+
+    <div class="carousel-inner">
+      <% section.attached_images.each_with_index do |image, index| %>
+        <div class="carousel-item <%= index.zero? ? 'active' : '' %>" style="--aspect-ratio:12/5;">
+          <% if image[:link_type] == 'Spree::Taxon' %>
+            <% link = spree.nested_taxons_path(image[:link]) %>
+          <% elsif image[:link_type] == 'Spree::Product' %>
+            <% link = spree.product_path(image[:link]) %>
+          <% else %>
+            <% link = nil %>
+          <% end %>
+
+          <% if link %><a href="<%= link %>"><% end %>
+
+            <!-- XS to MD -->
+            <img class="d-md-none lazyload"
+              data-src="<%= main_app.url_for(image[:file].variant(resize: '600x250>')) %>"
+              data-srcset="<%= main_app.url_for(image[:file].variant(resize: '600x250>')) %>"
+              alt="<%= image[:title] %>">
+
+            <!-- MD to XL -->
+            <img class="d-none d-md-block d-xl-none lazyload"
+              data-src="<%= main_app.url_for(image[:file].variant(resize: '1200x500>')) %>"
+              data-srcset="<%= main_app.url_for(image[:file].variant(resize: '1200x500>')) %>"
+              alt="<%= image[:title] %>">
+
+            <!-- XL UP -->
+            <img class="d-none d-xl-block lazyload"
+              data-src="<%= main_app.url_for(image[:file].variant(resize: '2400x1000>')) %>"
+              data-srcset="<%= main_app.url_for(image[:file].variant(resize: '2400x1000>')) %>"
+              alt="<%= image[:title] %>">
+
+          <% if link %></a><% end %>
+
+          <% if section.active_setting?(:captions) %>
+            <div class="carousel-caption d-none d-md-block">
+              <h4><%= image[:title] %></h5>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+
+    <% if section.active_setting?(:controls) %>
+      <a class="carousel-control-prev" href="#<%= id %>" role="button" data-slide="prev">
+        <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+        <span class="sr-only">Previous</span>
+      </a>
+
+      <a class="carousel-control-next" href="#<%= id %>" role="button" data-slide="next">
+        <span class="carousel-control-next-icon" aria-hidden="true"></span>
+        <span class="sr-only">Next</span>
+      </a>
+    <% end %>
+  </div>
+</div>

--- a/frontend/spec/features/cms_sections/image_carousel_spec.rb
+++ b/frontend/spec/features/cms_sections/image_carousel_spec.rb
@@ -1,0 +1,117 @@
+require 'spec_helper'
+
+describe 'Visiting the homepage with image carousel', type: :feature, js: true do
+  let!(:store) { Spree::Store.default }
+
+  let!(:homepage) { create(:cms_homepage, store: store, locale: 'en') }
+  let!(:carousel_section) { create(:cms_image_carousel_section, cms_page: homepage) }
+
+  let(:image_file_one) { File.open("#{Spree::Core::Engine.root}/spec/fixtures/thinking-cat.jpg") }
+  let(:image_file_three) { File.open("#{Spree::Core::Engine.root}/spec/fixtures/thinking-cat.jpg") }
+  let(:iamge_one) { Rack::Test::UploadedFile.new("#{Spree::Core::Engine.root}/spec/fixtures/thinking-cat.jpg") }
+  let(:main_app) { Rails.application.routes.url_helpers }
+
+  context 'when page is viewed and carousel has all options activated' do
+    before do
+      section = Spree::CmsSection.find(carousel_section.id)
+      section.image_one.attach(io: image_file_one, filename: 'thinking-cat1.jpg', content_type: 'image/jpeg')
+      section.image_three.attach(io: image_file_three, filename: 'thinking-cat3.jpg', content_type: 'image/jpeg')
+      section.title_one = 'Title one'
+      section.title_three = 'Title three'
+      section.link_type_three = 'Spree::Taxon'
+      section.link_three = 'categories/men/shirts'
+      section.captions = '1'
+      section.controls = '1'
+      section.indicators = '1'
+      section.autoplay = '1'
+      section.pause = '1'
+      section.wrap = '1'
+      section.save
+
+      visit spree.root_path
+    end
+
+    it 'the carousel section displays the images with links' do
+      expect(page).to have_selector(:css, 'img[alt="Title one"][data-src*="thinking-cat1.jpg"]')
+      expect(page).to have_selector(:css, 'img[alt="Title three"][data-src*="thinking-cat3.jpg"]')
+    end
+
+    it 'the carousel section displays the links' do
+      expect(page).not_to have_selector(:css, 'a img[alt="Title one"]')
+      expect(page).to have_selector(:css, 'a[href="/t/categories/men/shirts"] img[alt="Title three"]')
+    end
+
+    it 'has cations' do
+      expect(page).to have_selector(:css, '.carousel-caption', text: 'Title one')
+      expect(page).to have_selector(:css, '.carousel-caption', text: 'Title three')
+    end
+
+    it 'has controls' do
+      expect(page).to have_selector(:css, '.carousel-control-next')
+      expect(page).to have_selector(:css, '.carousel-control-prev')
+    end
+
+    it 'has indicators' do
+      expect(page).to have_selector(:css, '.carousel-indicators')
+    end
+
+    it 'has autoplay' do
+      expect(page).to have_selector(:css, '.carousel[data-ride="carousel"]')
+    end
+
+    it 'has pause' do
+      expect(page).not_to have_selector(:css, '.carousel[data-pause="false"]')
+    end
+
+    it 'has wrap' do
+      expect(page).not_to have_selector(:css, '.carousel[data-wrap="false"]')
+    end
+  end
+
+  context 'when page is viewed and carousel has all options deactivated' do
+    before do
+      section = Spree::CmsSection.find(carousel_section.id)
+      section.image_one.attach(io: image_file_one, filename: 'thinking-cat1.jpg', content_type: 'image/jpeg')
+      section.title_one = 'Title one'
+      section.captions = '0'
+      section.controls = '0'
+      section.indicators = '0'
+      section.autoplay = '0'
+      section.pause = '0'
+      section.wrap = '0'
+      section.save
+
+      visit spree.root_path
+    end
+
+    it 'the carousel section displays the images' do
+      expect(page).to have_selector(:css, 'img[alt="Title one"][data-src*="thinking-cat1.jpg"]')
+    end
+
+    it 'does not have cations' do
+      expect(page).not_to have_selector(:css, '.carousel-caption', text: 'Title one')
+      expect(page).not_to have_selector(:css, '.carousel-caption', text: 'Title three')
+    end
+
+    it 'does not have controls' do
+      expect(page).not_to have_selector(:css, '.carousel-control-next')
+      expect(page).not_to have_selector(:css, '.carousel-control-prev')
+    end
+
+    it 'does not have indicators' do
+      expect(page).not_to have_selector(:css, '.carousel-indicators')
+    end
+
+    it 'does not have autoplay' do
+      expect(page).not_to have_selector(:css, '.carousel[data-ride="carousel"]')
+    end
+
+    it 'does not have pause' do
+      expect(page).to have_selector(:css, '.carousel[data-pause="false"]')
+    end
+
+    it 'does not have wrap' do
+      expect(page).to have_selector(:css, '.carousel[data-wrap="false"]')
+    end
+  end
+end


### PR DESCRIPTION
Allows to create a slideshow component for cycling images like a carousel.

Each image can be a link to a Taxon or Product.

It uses bootstrap carousel and map this options:

- interval
- autoplay
- controls
- indicators
- crossfade
- captions
- pause
- wrap

### Screenshots

Admin panel:

![Screenshot_20210901_201549](https://user-images.githubusercontent.com/1703608/131723140-ab17d857-f304-4456-8410-e1f9467e1776.png)

Frontend result:

![Screenshot_20210901_202100](https://user-images.githubusercontent.com/1703608/131723451-a37c5418-285c-4ac4-b9d0-e18dad962650.png)

