### PR TITLE
Return option types in the api

### DIFF
--- a/api/app/controllers/spree/api/v2/storefront/option_types_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/option_types_controller.rb
@@ -1,0 +1,31 @@
+module Spree
+  module Api
+    module V2
+      module Storefront
+        class OptionTypesController < ::Spree::Api::V2::ResourceController
+          private
+
+          def resource_serializer
+            Spree::Api::Dependencies.storefront_option_type_serializer.constantize
+          end
+
+          def collection_serializer
+            Spree::Api::Dependencies.storefront_option_type_serializer.constantize
+          end
+
+          def collection_finder
+            Spree::Api::Dependencies.storefront_option_type_finder.constantize
+          end
+
+          def model_class
+            Spree::OptionType
+          end
+
+          def scope_includes
+            [:option_values]
+          end
+        end
+      end
+    end
+  end
+end

--- a/api/app/models/spree/api_dependencies.rb
+++ b/api/app/models/spree/api_dependencies.rb
@@ -14,6 +14,7 @@ module Spree
       :storefront_country_serializer, :storefront_menu_serializer, :storefront_menu_finder, :storefront_current_order_finder,
       :storefront_completed_order_finder, :storefront_order_sorter, :storefront_collection_paginator, :storefront_user_serializer,
       :storefront_products_sorter, :storefront_products_finder, :storefront_product_serializer, :storefront_taxon_serializer,
+      :storefront_option_type_serializer, :storefront_option_type_finder,
       :storefront_taxon_finder, :storefront_find_by_variant_finder, :storefront_cart_update_service, :storefront_cart_associate_service,
       :storefront_cart_estimate_shipping_rates_service, :storefront_estimated_shipment_serializer,
       :storefront_store_serializer, :storefront_address_serializer, :storefront_order_serializer,
@@ -81,6 +82,7 @@ module Spree
       @storefront_estimated_shipment_serializer = 'Spree::V2::Storefront::EstimatedShippingRateSerializer'
       @storefront_store_serializer = 'Spree::V2::Storefront::StoreSerializer'
       @storefront_order_serializer = 'Spree::V2::Storefront::CartSerializer'
+      @storefront_option_type_serializer = 'Spree::V2::Storefront::OptionTypeSerializer'
 
       # sorters
       @storefront_collection_sorter = Spree::Dependencies.collection_sorter
@@ -102,6 +104,7 @@ module Spree
       @storefront_find_by_variant_finder = Spree::Dependencies.line_item_by_variant_finder
       @storefront_products_finder = Spree::Dependencies.products_finder
       @storefront_taxon_finder = Spree::Dependencies.taxon_finder
+      @storefront_option_type_finder = Spree::Dependencies.option_type_finder
 
       @error_handler = 'Spree::Api::ErrorHandler'
     end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -163,6 +163,7 @@ Spree::Core::Engine.add_routes do
         get '/order_status/:number', to: 'order_status#show', as: :order_status
         resources :products, only: %i[index show]
         resources :taxons,   only: %i[index show], id: /.+/
+        resources :option_types, only: %i[index show]
         get '/stores/:code', to: 'stores#show', as: :store
 
         resources :menus, only: %i[index show]

--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -3975,6 +3975,55 @@ paths:
         '404':
           $ref: '#/components/responses/404NotFound'
       summary: Get a Taxon
+  /api/v2/storefront/option_types:
+    get:
+      description: 'Returns a list of Option Types.'
+      tags:
+        - Option Types
+      operationId: Option Types List
+      parameters:
+        - in: query
+          name: 'filter[filterable]'
+          schema:
+            type: boolean
+          example: 'true'
+          description: Fetch only option types marked as filterable
+        - $ref: '#/components/parameters/PageParam'
+        - $ref: '#/components/parameters/PerPageParam'
+        - $ref: '#/components/parameters/OptionTypeIncludeParam'
+        - $ref: '#/components/parameters/SparseFieldsParam'
+      responses:
+        '200':
+          description: Returns a list of Option Types
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/OptionTypesList'
+      summary: List of Option Types
+  '/api/v2/storefront/option_types/{id}':
+    get:
+      description: |-
+        Returns Option Type details.
+        ```
+        GET /api/v2/storefront/option_types/1
+        ```
+      tags:
+        - Option Types
+      operationId: Show Option Type
+      parameters:
+        - $ref: '#/components/parameters/Id'
+        - $ref: '#/components/parameters/OptionTypeIncludeParam'
+        - $ref: '#/components/parameters/SparseFieldsParam'
+      responses:
+        '200':
+          description: Returns the reqested Option Type
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/OptionType'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+      summary: Get an Option Type
   /api/v2/storefront/countries:
     get:
       description: Returns a list of all Countries
@@ -14356,6 +14405,49 @@ components:
                 position:
                   type: integer
                   example: 1
+      OptionTypeRelationships:
+      type: object
+      option_values:
+        children:
+          type: object
+          description: List of option values
+          properties:
+            data:
+              type: array
+              items:
+                $ref: '#/components/schemas/Relation'
+    OptionTypeAttributesAndRelationships:
+      properties:
+        id:
+          type: string
+          example: '1'
+        type:
+          type: string
+          default: option_type
+        attributes:
+          $ref: '#/components/schemas/OptionTypeAttributes'
+        relationships:
+          $ref: '#/components/schemas/OptionTypeRelationships'
+      x-examples: {}
+    OptionTypesList:
+      required:
+        - links
+        - data
+        - included
+      properties:
+        links:
+          $ref: '#/components/schemas/ListLinks'
+        meta:
+          $ref: '#/components/schemas/ListMeta'
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/OptionTypeAttributesAndRelationships'
+        included:
+          type: array
+          items:
+            oneOf:
+              - $ref: '#/components/schemas/OptionValue'
     OptionValue:
       required:
         - data
@@ -15866,6 +15958,18 @@ components:
 
         [More information](https://jsonapi.org/format/#fetching-includes)
       example: 'parent,taxonomy,children,image,products'
+    OptionTypeIncludeParam:
+      name: include
+      in: query
+      schema:
+        type: string
+      description: |-
+        Specify what related resources (relationships) you would like to receive in the response body. Eg.
+        ```
+        option_values
+        ```
+        [More information](https://jsonapi.org/format/#fetching-includes)
+      example: 'option_values'
     IsoOrIso3:
       name: iso
       in: path

--- a/api/spec/requests/spree/api/v2/storefront/option_types_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/option_types_spec.rb
@@ -1,0 +1,132 @@
+require 'spec_helper'
+
+describe 'Option Types Spec', type: :request do
+  let!(:option_types) { create_list(:option_type, 2, filterable: false) }
+  let!(:filterable_option_type) { create(:option_type, filterable: true) }
+
+  let(:all_option_types) { option_types + [filterable_option_type] }
+
+  before { Spree::Api::Config[:api_v2_per_page_limit] = 3 }
+
+  shared_examples 'returns valid option type resource JSON' do
+    it 'returns a valid option type resource JSON response' do
+      expect(response.status).to eq(200)
+
+      expect(json_response['data']).to have_type('option_type')
+      expect(json_response['data']).to have_relationships(:option_values)
+    end
+  end
+
+  describe 'option_types#index' do
+    context 'with no params' do
+      before { get '/api/v2/storefront/option_types' }
+
+      it_behaves_like 'returns 200 HTTP status'
+
+      it 'returns all option types' do
+        expect(json_response['data'].size).to eq(3)
+        expect(json_response['data'][0]).to have_type('option_type')
+        expect(json_response['data'][0]).to have_relationships(:option_values)
+        expect(json_response['data'][0]).not_to have_relationships(:products)
+      end
+    end
+
+    context 'only filterable' do
+      before { get '/api/v2/storefront/option_types?filter[filterable]=true' }
+
+      it_behaves_like 'returns 200 HTTP status'
+
+      it 'returns filterable option types' do
+        expect(json_response['data'].size).to eq(1)
+        expect(json_response['data'][0]).to have_type('option_type')
+        expect(json_response['data'][0]).to have_id(filterable_option_type.id.to_s)
+        expect(json_response['data'][0]).to have_relationships(:option_values)
+      end
+    end
+
+    context 'paginate option_types' do
+      context 'with specified pagination params' do
+        context 'when per_page is between 1 and default value' do
+          before { get '/api/v2/storefront/option_types?page=1&per_page=1' }
+
+          it_behaves_like 'returns 200 HTTP status'
+
+          it 'returns specified amount of option_types' do
+            expect(json_response['data'].count).to eq 1
+          end
+
+          it 'returns proper meta data' do
+            expect(json_response['meta']['count']).to eq 1
+            expect(json_response['meta']['total_count']).to eq Spree::OptionType.count
+          end
+
+          it 'returns proper links data' do
+            expect(json_response['links']['self']).to include('/api/v2/storefront/option_types?page=1&per_page=1')
+            expect(json_response['links']['next']).to include('/api/v2/storefront/option_types?page=2&per_page=1')
+            expect(json_response['links']['prev']).to include('/api/v2/storefront/option_types?page=1&per_page=1')
+          end
+        end
+
+        context 'when per_page is above the default value' do
+          before { get '/api/v2/storefront/option_types?page=1&per_page=10' }
+
+          it 'returns the default number of option types' do
+            expect(json_response['data'].count).to eq 3
+          end
+        end
+
+        context 'when per_page is less than 0' do
+          before { get '/api/v2/storefront/option_types?page=1&per_page=-1' }
+
+          it 'returns the default number of option types' do
+            expect(json_response['data'].count).to eq 3
+          end
+        end
+
+        context 'when per_page is equal 0' do
+          before { get '/api/v2/storefront/option_types?page=1&per_page=0' }
+
+          it 'returns the default number of option types' do
+            expect(json_response['data'].count).to eq 3
+          end
+        end
+      end
+
+      context 'without specified pagination params' do
+        before { get '/api/v2/storefront/option_types' }
+
+        it_behaves_like 'returns 200 HTTP status'
+
+        it 'returns specified amount of option types' do
+          expect(json_response['data'].count).to eq Spree::OptionType.count
+        end
+
+        it 'returns proper meta data' do
+          expect(json_response['meta']['count']).to eq json_response['data'].count
+          expect(json_response['meta']['total_count']).to eq Spree::OptionType.count
+        end
+
+        it 'returns proper links data' do
+          expect(json_response['links']['self']).to include('/api/v2/storefront/option_types')
+          expect(json_response['links']['next']).to include('/api/v2/storefront/option_types?page=1')
+          expect(json_response['links']['prev']).to include('/api/v2/storefront/option_types?page=1')
+        end
+      end
+    end
+  end
+
+  describe 'option_types#show' do
+    context 'by id' do
+      before do
+        get "/api/v2/storefront/option_types/#{option_types.first.id}"
+      end
+
+      it_behaves_like 'returns valid option type resource JSON'
+
+      it 'returns option type by id' do
+        expect(json_response['data']).to have_id(option_types.first.id.to_s)
+        expect(json_response['data']).to have_attribute(:name).with_value(option_types.first.name)
+      end
+    end
+  end
+end

--- a/core/app/finders/spree/option_types/find.rb
+++ b/core/app/finders/spree/option_types/find.rb
@@ -1,0 +1,11 @@
+module Spree
+  module OptionTypes
+    class Find < ::Spree::BaseFinder
+      def execute
+        return scope.filterable if params[:filter].present? && params[:filter]['filterable'].present?
+
+        scope
+      end
+    end
+  end
+end

--- a/core/app/models/spree/app_dependencies.rb
+++ b/core/app/models/spree/app_dependencies.rb
@@ -13,7 +13,7 @@ module Spree
       :products_finder, :taxon_finder, :line_item_by_variant_finder, :cart_estimate_shipping_rates_service,
       :account_create_address_service, :account_update_address_service, :account_create_service, :account_update_service,
       :address_finder, :collection_sorter, :error_handler, :current_store_finder, :cart_empty_service, :cart_destroy_service,
-      :classification_reposition_service, :credit_cards_destroy_service, :cart_associate_service
+      :classification_reposition_service, :credit_cards_destroy_service, :cart_associate_service, :option_type_finder
     ].freeze
 
     attr_accessor *INJECTION_POINTS
@@ -91,6 +91,7 @@ module Spree
       @credit_card_finder = 'Spree::CreditCards::Find'
       @products_finder = 'Spree::Products::Find'
       @taxon_finder = 'Spree::Taxons::Find'
+      @option_type_finder = 'Spree::OptionTypes::Find'
       @line_item_by_variant_finder = 'Spree::LineItems::FindByVariant'
     end
   end


### PR DESCRIPTION
One of the things missing in current V2 API is an option to fetch option types and their values. 
We need that to e.g. display filters in PWA storefronts - I added a simple endpoint for that.

Comments welcome