### PR TITLE
Improve styles of footer logo

### DIFF
--- a/frontend/app/assets/stylesheets/spree/frontend/views/spree/shared/footer.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/views/spree/shared/footer.scss
@@ -3,11 +3,10 @@
   color: $footer-font-color;
   border-color: $global-border-style !important;
   .logo img {
-    height: 27px;
-    width: 62px;
+    max-width: 62px;
+    height: auto;
     @include media-breakpoint-up(xl) {
-      height: 52px;
-      width: 122px;
+      max-width: 122px;
     }
   }
   .spree-icon path {


### PR DESCRIPTION
Existing styles can potentially display a stretched logo and there are no validations or notices to the user to provide specific ratio for the logo. IMHO there also shouldn't be a restriction anyway. Proposing the css changes in this commit to allow the original logo to be displayed, while maintaining a max-width as to not overpower other elements in the default view template.