### PR TITLE
Add API endpoint for changing cart currency

### DIFF
--- a/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
@@ -150,6 +150,14 @@ module Spree
             end
           end
 
+          def change_currency
+            spree_authorize! :update, spree_current_order, order_token
+
+            result = change_currency_service.call(order: spree_current_order, new_currency: params[:new_currency])
+
+            render_order(result)
+          end
+
           private
 
           def resource_serializer
@@ -190,6 +198,10 @@ module Spree
 
           def associate_service
             Spree::Api::Dependencies.storefront_cart_associate_service.constantize
+          end
+
+          def change_currency_service
+            Spree::Api::Dependencies.storefront_cart_change_currency_service.constantize
           end
 
           def line_item

--- a/api/app/models/spree/api_dependencies.rb
+++ b/api/app/models/spree/api_dependencies.rb
@@ -19,7 +19,8 @@ module Spree
       :storefront_store_serializer, :storefront_address_serializer, :storefront_order_serializer,
       :storefront_account_create_address_service, :storefront_account_update_address_service, :storefront_address_finder,
       :storefront_account_create_service, :storefront_account_update_service, :storefront_collection_sorter, :error_handler,
-      :storefront_cart_empty_service, :storefront_cart_destroy_service, :storefront_credit_cards_destroy_service, :platform_products_sorter
+      :storefront_cart_empty_service, :storefront_cart_destroy_service, :storefront_credit_cards_destroy_service, :platform_products_sorter,
+      :storefront_cart_change_currency_service
     ].freeze
 
     attr_accessor *INJECTION_POINTS
@@ -44,6 +45,7 @@ module Spree
       @storefront_cart_empty_service = Spree::Dependencies.cart_empty_service
       @storefront_cart_destroy_service = Spree::Dependencies.cart_destroy_service
       @storefront_cart_associate_service = Spree::Dependencies.cart_associate_service
+      @storefront_cart_change_currency_service = Spree::Dependencies.cart_change_currency_service
 
       # coupon code handler
       @storefront_coupon_handler = Spree::Dependencies.coupon_handler

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -138,6 +138,7 @@ Spree::Core::Engine.add_routes do
           delete 'remove_coupon_code', to: 'cart#remove_coupon_code', as: :cart_remove_coupon_code_without_code
           get :estimate_shipping_rates
           patch :associate
+          patch :change_currency
         end
 
         resource :checkout, controller: :checkout, only: %i[update] do

--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -822,6 +822,38 @@ paths:
       security:
         - bearerAuth: []
       summary: Associate a guest cart to a user
+  /api/v2/storefront/cart/change_currency:
+    patch:
+      description: Changes cart currency and recalculates its value.
+      tags:
+        - Cart
+      operationId: change-currency
+      parameters:
+        - name: new_currency
+          in: query
+          description: Currency to change the cart to
+          schema:
+            type: string
+        - $ref: '#/components/parameters/CartIncludeParam'
+        - $ref: '#/components/parameters/SparseFieldsParam'
+      responses:
+        '200':
+          description: Currency has been successfully changed
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/Cart'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '422':
+          description: Returned when currency is not supported or cart cannot be updated
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+        - bearerAuth: []
+      summary: Change cart currency
   /api/v2/storefront/checkout:
     patch:
       description: |-

--- a/api/spec/requests/spree/api/v2/storefront/cart_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/cart_spec.rb
@@ -929,4 +929,30 @@ describe 'API V2 Storefront Cart Spec', type: :request do
       it_behaves_like 'returns 403 HTTP status'
     end
   end
+
+  describe 'cart#change_currency' do
+    let(:order) { create(:order, store: store, currency: currency) }
+    let!(:line_item) { create(:line_item, order: order) }
+    let!(:price) { create(:price, currency: 'EUR', variant: order.line_items.first.variant)}
+
+    before do
+      patch '/api/v2/storefront/cart/change_currency', params: { currency: currency, new_currency: new_currency, order_token: order.token }, headers: headers
+    end
+
+    context 'when switching to supported currency' do
+      let(:new_currency) { 'EUR' }
+
+      it_behaves_like 'returns valid cart JSON'
+
+      it 'sets cart currency to new currency' do
+        expect(json_response['data']).to have_attribute(:currency).with_value('EUR')
+      end
+    end
+
+    context 'when switching to unsupported currency' do
+      let(:new_currency) { 'XOF' }
+
+      it_behaves_like 'returns 422 HTTP status'
+    end
+  end
 end

--- a/core/app/models/spree/app_dependencies.rb
+++ b/core/app/models/spree/app_dependencies.rb
@@ -13,7 +13,7 @@ module Spree
       :products_finder, :taxon_finder, :line_item_by_variant_finder, :cart_estimate_shipping_rates_service,
       :account_create_address_service, :account_update_address_service, :account_create_service, :account_update_service,
       :address_finder, :collection_sorter, :error_handler, :current_store_finder, :cart_empty_service, :cart_destroy_service,
-      :classification_reposition_service, :credit_cards_destroy_service, :cart_associate_service
+      :classification_reposition_service, :credit_cards_destroy_service, :cart_associate_service, :cart_change_currency_service
     ].freeze
 
     attr_accessor *INJECTION_POINTS
@@ -44,6 +44,7 @@ module Spree
       @cart_empty_service = 'Spree::Cart::Empty'
       @cart_destroy_service = 'Spree::Cart::Destroy'
       @cart_associate_service = 'Spree::Cart::Associate'
+      @cart_change_currency_service = 'Spree::Cart::ChangeCurrency'
 
       # checkout
       @checkout_next_service = 'Spree::Checkout::Next'

--- a/core/app/services/spree/cart/change_currency.rb
+++ b/core/app/services/spree/cart/change_currency.rb
@@ -1,0 +1,27 @@
+module Spree
+  module Cart
+    class ChangeCurrency
+      prepend Spree::ServiceModule::Base
+
+      def call(order:, new_currency:)
+        return failure('Currency not supported') unless supported_currency?(order, new_currency)
+
+        result = order.update!(currency: new_currency) rescue false
+
+        if result
+          success(order)
+        else
+          failure('Failed to update order')
+        end
+      end
+
+      private
+
+      def supported_currency?(order, currency)
+        store = order.store
+        supported_currencies = store.supported_currencies_list
+        supported_currencies.map(&:iso_code).include?(currency.upcase)
+      end
+    end
+  end
+end

--- a/core/spec/services/spree/cart/change_currency_spec.rb
+++ b/core/spec/services/spree/cart/change_currency_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+module Spree
+  describe Cart::ChangeCurrency do
+    subject { described_class.call(order: order, new_currency: new_currency) }
+
+    let(:order) { create(:order_with_line_items, store: store, currency: 'USD') }
+    let(:store) { create(:store, supported_currencies: 'USD,EUR,GBP') }
+
+    context 'when switching to a supported currency' do
+      let(:new_currency) { 'EUR' }
+
+      context 'when product has a price in given currency' do
+        let!(:price) { create(:price, currency: 'EUR', variant: order.line_items.first.variant)}
+
+        it 'changes order and line items currency' do
+          expect(subject).to be_success
+          order.reload
+          expect(order.currency).to eq('EUR')
+          expect(order.line_items.first.currency).to eq('EUR')
+        end
+      end
+
+      context 'when product does not have a price in given currency' do
+        it 'returns failure' do
+          expect(subject).to be_failure
+          order.reload
+          expect(order.currency).to eq('USD')
+          expect(order.line_items.first.currency).to eq('USD')
+        end
+      end
+    end
+
+    context 'when switching to an unsupported currency' do
+      let(:new_currency) { 'XOF' }
+
+      it 'returns failure' do
+        expect(subject).to be_failure
+        order.reload
+        expect(order.currency).to eq('USD')
+        expect(order.line_items.first.currency).to eq('USD')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently, we're missing a way of changing cart's currency. I added an endpoint at /api/v2/storefront/cart/change_currency that allows to update cart's currency and recalculate its value (similarly to how the built-in frontend does it)