### PR TITLE
[SD-1460] Fix - Image Belongs To Product and  Variant

### DIFF
--- a/backend/app/controllers/spree/admin/images_controller.rb
+++ b/backend/app/controllers/spree/admin/images_controller.rb
@@ -10,11 +10,11 @@ module Spree
       private
 
       def location_after_destroy
-        admin_product_images_url(@product)
+        spree.admin_product_images_url(@product)
       end
 
       def location_after_save
-        admin_product_images_url(@product)
+        spree.admin_product_images_url(@product)
       end
 
       def load_edit_data

--- a/backend/app/controllers/spree/admin/images_controller.rb
+++ b/backend/app/controllers/spree/admin/images_controller.rb
@@ -44,6 +44,10 @@ module Spree
       def modle_class
         Spree::Image
       end
+
+      def collection
+        @collection ||= scope.friendly.find(params[:product_id]).variant_images
+      end
     end
   end
 end

--- a/backend/app/controllers/spree/admin/images_controller.rb
+++ b/backend/app/controllers/spree/admin/images_controller.rb
@@ -38,7 +38,7 @@ module Spree
       end
 
       def collection_url
-        admin_product_images_url
+        spree.admin_product_images_url
       end
 
       def modle_class

--- a/backend/app/controllers/spree/admin/images_controller.rb
+++ b/backend/app/controllers/spree/admin/images_controller.rb
@@ -48,10 +48,6 @@ module Spree
       def collection
         @collection ||= load_product.variant_images
       end
-
-      # def find_resource
-      #   load_product.variant_images.where(variant_id: )
-      # end
     end
   end
 end

--- a/backend/app/controllers/spree/admin/images_controller.rb
+++ b/backend/app/controllers/spree/admin/images_controller.rb
@@ -46,8 +46,12 @@ module Spree
       end
 
       def collection
-        @collection ||= scope.friendly.find(params[:product_id]).variant_images
+        @collection ||= load_product.variant_images
       end
+
+      # def find_resource
+      #   load_product.variant_images.where(variant_id: )
+      # end
     end
   end
 end

--- a/backend/app/controllers/spree/admin/images_controller.rb
+++ b/backend/app/controllers/spree/admin/images_controller.rb
@@ -1,10 +1,7 @@
 module Spree
   module Admin
     class ImagesController < ResourceController
-      include Spree::Admin::ProductConcern
-
-      belongs_to 'spree/product', find_by: :slug
-
+      before_action :load_product
       before_action :load_edit_data, except: :index
 
       create.before :set_viewable
@@ -13,23 +10,39 @@ module Spree
       private
 
       def location_after_destroy
-        spree.admin_product_images_url(parent)
+        admin_product_images_url(@product)
       end
 
       def location_after_save
-        spree.admin_product_images_url(parent)
+        admin_product_images_url(@product)
       end
 
       def load_edit_data
-        @variants = parent.variants.map do |variant|
+        @variants = @product.variants.map do |variant|
           [variant.sku_and_options_text, variant.id]
         end
-        @variants.insert(0, [Spree.t(:all), parent.master.id])
+        @variants.insert(0, [Spree.t(:all), @product.master_id])
       end
 
       def set_viewable
         @image.viewable_type = 'Spree::Variant'
         @image.viewable_id = params[:image][:viewable_id]
+      end
+
+      def load_product
+        @product = scope.friendly.find(params[:product_id])
+      end
+
+      def scope
+        current_store.products
+      end
+
+      def collection_url
+        admin_product_images_url
+      end
+
+      def modle_class
+        Spree::Image
       end
     end
   end

--- a/backend/spec/controllers/spree/admin/images_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/images_controller_spec.rb
@@ -45,6 +45,24 @@ module Spree
             end
           end
 
+          context 'can destroy image belonging to a variant not master_variant' do
+            let(:variant) { create(:variant) }
+            let(:product) { variant.product }
+            let(:image) { create(:image, viewable: variant) }
+
+            before do
+              product.update(stores: [store])
+              product.save
+              product.reload
+            end
+
+            it do
+              send_request
+              expect(flash[:error]).not_to eq('Image is not found')
+              expect(flash[:success]).to eq('Image has been successfully removed!')
+            end
+          end
+
           context 'cannot destroy image of other product' do
             let(:other_product) { create(:product, stores: [store]) }
             let(:image) { create(:image, viewable: other_product) }
@@ -88,6 +106,25 @@ module Spree
             end
           end
 
+          context 'can destroy image belonging to a variant not master_variant' do
+            let(:variant) { create(:variant) }
+            let(:product) { variant.product }
+            let(:image) { create(:image, viewable: variant) }
+
+            before do
+              product.update(stores: [store])
+              product.save
+              product.reload
+            end
+
+            it do
+              send_request
+              expect(flash[:error]).not_to eq('Image is not found')
+              expect(flash[:success]).to eq('Image has been successfully removed!')
+              expect(send_request).to redirect_to(spree.admin_product_images_path(product))
+            end
+          end
+
           context 'cannot destroy image of other product' do
             let(:other_product) { create(:product, stores: [store]) }
             let(:image) { create(:image, viewable: other_product) }
@@ -102,6 +139,7 @@ module Spree
 
           context 'cannot destroy image of product from different store' do
             let(:product) { create(:product, stores: [create(:store)]) }
+
             before { send_request }
 
             it do

--- a/backend/spec/controllers/spree/admin/images_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/images_controller_spec.rb
@@ -59,8 +59,12 @@ module Spree
 
           context 'cannot destroy image of product from different store' do
             let(:product) { create(:product, stores: [create(:store)]) }
+            before { send_request }
 
-            it { expect { send_request }.to raise_error(ActiveRecord::RecordNotFound) }
+            it do
+              expect(send_request).to redirect_to(spree.admin_product_images_path(product))
+              expect(flash[:error]).to eq('Image is not found')
+            end
           end
         end
 
@@ -98,8 +102,12 @@ module Spree
 
           context 'cannot destroy image of product from different store' do
             let(:product) { create(:product, stores: [create(:store)]) }
+            before { send_request }
 
-            it { expect { send_request }.to raise_error(ActiveRecord::RecordNotFound) }
+            it do
+              expect(send_request).to redirect_to(spree.admin_product_images_path(product))
+              expect(flash[:error]).to eq('Image is not found')
+            end
           end
         end
       end

--- a/backend/spec/controllers/spree/admin/images_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/images_controller_spec.rb
@@ -7,17 +7,19 @@ module Spree
 
       let(:store) { Spree::Store.default }
       let(:product) { create(:product, stores: [store]) }
+      let(:product_in_other_store) { create(:product, stores: [create(:store)]) }
 
       describe '#index' do
         let!(:image_1) { create(:image, viewable: product.master) }
         let!(:image_2) { create(:image, viewable: product.master) }
         let!(:image_3) { create(:image, viewable: create(:variant)) }
+        let!(:image_4) { create(:image, viewable: product_in_other_store.master) }
 
         it 'assigns the images for a requested product' do
           get :index, params: { product_id: product.slug }
           expect(assigns(:collection)).to include image_1
           expect(assigns(:collection)).to include image_2
-          expect(assigns(:collection)).not_to include image_3
+          expect(assigns(:collection)).not_to include image_4
         end
       end
 

--- a/backend/spec/controllers/spree/admin/images_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/images_controller_spec.rb
@@ -63,6 +63,23 @@ module Spree
             end
           end
 
+          context 'can not destroy image belonging to a variant not master_variant but also belongs to other store' do
+            let(:variant) { create(:variant) }
+            let(:product) { variant.product }
+            let(:image) { create(:image, viewable: variant) }
+
+            before do
+              product.update(stores: [create(:store)])
+              product.save
+              product.reload
+            end
+
+            it do
+              send_request
+              expect(flash[:error]).to eq('Image is not found')
+            end
+          end
+
           context 'cannot destroy image of other product' do
             let(:other_product) { create(:product, stores: [store]) }
             let(:image) { create(:image, viewable: other_product) }
@@ -122,6 +139,23 @@ module Spree
               expect(flash[:error]).not_to eq('Image is not found')
               expect(flash[:success]).to eq('Image has been successfully removed!')
               expect(send_request).to redirect_to(spree.admin_product_images_path(product))
+            end
+          end
+
+          context 'can not destroy image belonging to a variant not master_variant but also belongs to other store' do
+            let(:variant) { create(:variant) }
+            let(:product) { variant.product }
+            let(:image) { create(:image, viewable: variant) }
+
+            before do
+              product.update(stores: [create(:store)])
+              product.save
+              product.reload
+            end
+
+            it do
+              send_request
+              expect(flash[:error]).to eq('Image is not found')
             end
           end
 


### PR DESCRIPTION
**Reason this is difficult to fix:**

Images are associated with a variant in `spree_assets` `viewable_type` -> `Spree::Variant`, but the images_controller was using `belong_to spree/product` I think only the master variant is looked up in this relationship, looking at the logs it was looking for a variant where `is_master: true`, not sure if this is easy to fix other than doing what I have done in this PR?

------------------------------
IDEA FOR PRODUCT IMAGES:
While doing this, I considered the use of Product images as viewable type being `Spree::Product` so all images belong to the Product, and then having the ability to tag the images by option value, so you could have images that are tagged with:

Color: Red 
Color: Blue 
Color: Green

That way they don't belong to a variant, but can tagged with the option type values specific to any variants.

**Benefits:**
- Images are easier to manage from a controller side, as they all belong to the one product, product belongs to stores.
- Makes more efficient use of a single image that might appears under multiple variants (Red , S,M,L)

**Drawbacks:**
- Implementing it to not brake existing usage of images.




