### PR TITLE
Center images in an a tag and increase image size to get rid of blur

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/shared/_base.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_base.scss
@@ -37,6 +37,10 @@ div.admin-product-image-container {
   justify-content: center;
   margin: auto;
 
+  a {
+    display: flex
+  }
+
   img {
     max-width: 100%;
     height: auto;

--- a/backend/app/views/spree/admin/images/index.html.erb
+++ b/backend/app/views/spree/admin/images/index.html.erb
@@ -42,7 +42,7 @@
           </td>
           <td class="image">
             <div class="admin-product-image-container small-img">
-              <%= link_to image_tag(main_app.url_for(image.url(:mini))), main_app.rails_blob_url(image.attachment) %>
+              <%= link_to image_tag(main_app.url_for(image.url(:product))), main_app.rails_blob_url(image.attachment) %>
             </div>
           </td>
           <% if has_variants %>


### PR DESCRIPTION
Before:
<img width="1199" alt="Screenshot 2021-09-14 at 10 16 05" src="https://user-images.githubusercontent.com/1240766/133231041-4ff5b434-4375-413b-b2f5-815c6c3ee567.png">


After:
<img width="1191" alt="Screenshot 2021-09-14 at 10 17 09" src="https://user-images.githubusercontent.com/1240766/133231112-605dbcea-28f8-4ef1-bd59-31c62ef428cf.png">

