### PR TITLE
Introduce `Base#spree_base_uniqueness_scope` and `UniqueName` concern

### DIFF
--- a/core/app/models/concerns/spree/named_type.rb
+++ b/core/app/models/concerns/spree/named_type.rb
@@ -6,7 +6,7 @@ module Spree
       scope :active, -> { where(active: true) }
       default_scope { order(Arel.sql("LOWER(#{table_name}.name)")) }
 
-      validates :name, presence: true, uniqueness: { case_sensitive: false }
+      include UniqueName
     end
   end
 end

--- a/core/app/models/concerns/spree/number_identifier.rb
+++ b/core/app/models/concerns/spree/number_identifier.rb
@@ -5,7 +5,8 @@ module Spree
     included do
       before_validation :uppercase_number
 
-      validates :number, presence: true, length: { maximum: 32, allow_blank: true }, uniqueness: { allow_blank: true, case_sensitive: true }
+      validates :number, presence: true, length: { maximum: 32, allow_blank: true },
+                         uniqueness: { allow_blank: true, case_sensitive: true, scope: spree_base_uniqueness_scope }
     end
 
     protected

--- a/core/app/models/concerns/spree/unique_name.rb
+++ b/core/app/models/concerns/spree/unique_name.rb
@@ -1,0 +1,10 @@
+module Spree
+  module UniqueName
+    extend ActiveSupport::Concern
+
+    included do
+      validates :name, presence: true,
+                       uniqueness: { case_sensitive: false, allow_blank: true, scope: spree_base_uniqueness_scope }
+    end
+  end
+end

--- a/core/app/models/spree/base.rb
+++ b/core/app/models/spree/base.rb
@@ -36,6 +36,10 @@ class Spree::Base < ApplicationRecord
     where(nil)
   end
 
+  def self.spree_base_uniqueness_scope
+    ApplicationRecord.try(:spree_base_uniqueness_scope) || []
+  end
+
   # FIXME: https://github.com/rails/rails/issues/40943
   def self.has_many_inversing
     false

--- a/core/app/models/spree/country.rb
+++ b/core/app/models/spree/country.rb
@@ -16,7 +16,7 @@ module Spree
              foreign_key: :zoneable_id
     has_many :zones, through: :zone_members, class_name: 'Spree::Zone'
 
-    validates :name, :iso_name, :iso, :iso3, presence: true, uniqueness: { case_sensitive: false }
+    validates :name, :iso_name, :iso, :iso3, presence: true, uniqueness: { case_sensitive: false, scope: spree_base_uniqueness_scope }
 
     def self.default(store = nil)
       ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)

--- a/core/app/models/spree/option_type.rb
+++ b/core/app/models/spree/option_type.rb
@@ -1,5 +1,7 @@
 module Spree
   class OptionType < Spree::Base
+    include UniqueName
+
     acts_as_list
 
     with_options dependent: :destroy, inverse_of: :option_type do
@@ -12,10 +14,7 @@ module Spree
     has_many :option_type_prototypes, class_name: 'Spree::OptionTypePrototype'
     has_many :prototypes, through: :option_type_prototypes, class_name: 'Spree::Prototype'
 
-    with_options presence: true do
-      validates :name, uniqueness: { case_sensitive: false, allow_blank: true }
-      validates :presentation
-    end
+    validates :presentation, presence: true
 
     default_scope { order(:position) }
 

--- a/core/app/models/spree/preference.rb
+++ b/core/app/models/spree/preference.rb
@@ -1,5 +1,6 @@
 class Spree::Preference < Spree::Base
   serialize :value
 
-  validates :key, presence: true, uniqueness: { case_sensitive: false, allow_blank: true }
+  validates :key, presence: true,
+                  uniqueness: { case_sensitive: false, allow_blank: true, scope: spree_base_uniqueness_scope }
 end

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -115,7 +115,7 @@ module Spree
       validates :price, if: :requires_price?
     end
 
-    validates :slug, presence: true, uniqueness: { allow_blank: true, case_sensitive: true }
+    validates :slug, presence: true, uniqueness: { allow_blank: true, case_sensitive: true, scope: spree_base_uniqueness_scope }
     validate :discontinue_on_must_be_later_than_available_on, if: -> { available_on && discontinue_on }
 
     attr_accessor :option_values_hash

--- a/core/app/models/spree/role.rb
+++ b/core/app/models/spree/role.rb
@@ -1,8 +1,8 @@
 module Spree
   class Role < Spree::Base
+    include UniqueName
+
     has_many :role_users, class_name: 'Spree::RoleUser', dependent: :destroy
     has_many :users, through: :role_users, class_name: Spree.user_class.to_s
-
-    validates :name, presence: true, uniqueness: { case_sensitive: false, allow_blank: true }
   end
 end

--- a/core/app/models/spree/shipping_category.rb
+++ b/core/app/models/spree/shipping_category.rb
@@ -1,6 +1,6 @@
 module Spree
   class ShippingCategory < Spree::Base
-    validates :name, presence: true, uniqueness: { case_sensitive: false, allow_blank: true }
+    include UniqueName
 
     with_options inverse_of: :shipping_category do
       has_many :products

--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -1,5 +1,7 @@
 module Spree
   class StockLocation < Spree::Base
+    include UniqueName
+
     has_many :shipments
     has_many :stock_items, dependent: :delete_all, inverse_of: :stock_location
     has_many :variants, through: :stock_items
@@ -7,8 +9,6 @@ module Spree
 
     belongs_to :state, class_name: 'Spree::State', optional: true
     belongs_to :country, class_name: 'Spree::Country'
-
-    validates :name, presence: true, uniqueness: { allow_blank: true, case_sensitive: false }
 
     scope :active, -> { where(active: true) }
     scope :order_default, -> { order(default: :desc, name: :asc) }

--- a/core/app/models/spree/tax_category.rb
+++ b/core/app/models/spree/tax_category.rb
@@ -1,7 +1,7 @@
 module Spree
   class TaxCategory < Spree::Base
     acts_as_paranoid
-    validates :name, presence: true, uniqueness: { case_sensitive: false, scope: :deleted_at }
+    validates :name, presence: true, uniqueness: { case_sensitive: false, scope: spree_base_uniqueness_scope.push(:deleted_at) }
 
     has_many :tax_rates, dependent: :destroy, inverse_of: :tax_category
 

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -52,7 +52,7 @@ module Spree
       validates :cost_price
       validates :price
     end
-    validates :sku, uniqueness: { conditions: -> { where(deleted_at: nil) }, case_sensitive: false },
+    validates :sku, uniqueness: { conditions: -> { where(deleted_at: nil) }, case_sensitive: false, scope: spree_base_uniqueness_scope },
                     allow_blank: true, unless: :disable_sku_validation?
 
     after_create :create_stock_items

--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -1,5 +1,7 @@
 module Spree
   class Zone < Spree::Base
+    include UniqueName
+
     with_options dependent: :destroy, inverse_of: :zone do
       has_many :zone_members, class_name: 'Spree::ZoneMember'
       has_many :tax_rates
@@ -11,8 +13,6 @@ module Spree
 
     has_many :shipping_method_zones, class_name: 'Spree::ShippingMethodZone'
     has_many :shipping_methods, through: :shipping_method_zones, class_name: 'Spree::ShippingMethod'
-
-    validates :name, presence: true, uniqueness: { case_sensitive: false, allow_blank: true }
 
     scope :with_default_tax, -> { where(default_tax: true) }
 


### PR DESCRIPTION
To unify uniqueness validations of global (not-store specfic) resources across the codebase.

Also via `spree_base_uniqueness_scope` adds an ability to change the default scope of uniqueness check, which is essential for multi tenant apps.