### PR TITLE
Introduce `Spree::Oauth` models

### DIFF
--- a/api/app/models/spree/oauth_access_grant.rb
+++ b/api/app/models/spree/oauth_access_grant.rb
@@ -1,0 +1,7 @@
+module Spree
+  class OauthAccessGrant < Base
+    include ::Doorkeeper::Orm::ActiveRecord::Mixins::AccessGrant
+
+    self.table_name = 'spree_oauth_access_grants'
+  end
+end

--- a/api/app/models/spree/oauth_access_token.rb
+++ b/api/app/models/spree/oauth_access_token.rb
@@ -1,0 +1,7 @@
+module Spree
+  class OauthAccessToken < Base
+    include ::Doorkeeper::Orm::ActiveRecord::Mixins::AccessToken
+
+    self.table_name = 'spree_oauth_access_tokens'
+  end
+end

--- a/api/app/models/spree/oauth_application.rb
+++ b/api/app/models/spree/oauth_application.rb
@@ -1,0 +1,7 @@
+module Spree
+  class OauthApplication < Base
+    include ::Doorkeeper::Orm::ActiveRecord::Mixins::Application
+
+    self.table_name = 'spree_oauth_applications'
+  end
+end

--- a/api/config/initializers/doorkeeper.rb
+++ b/api/config/initializers/doorkeeper.rb
@@ -33,16 +33,8 @@ Doorkeeper.configure do
   access_token_methods :from_bearer_authorization, :from_access_token_param
 
   optional_scopes :admin, :write, :read
-end
 
-Doorkeeper::AccessGrant.class_eval do
-  self.table_name = 'spree_oauth_access_grants'
-end
-
-Doorkeeper::AccessToken.class_eval do
-  self.table_name = 'spree_oauth_access_tokens'
-end
-
-Doorkeeper::Application.class_eval do
-  self.table_name = 'spree_oauth_applications'
+  access_token_class 'Spree::OauthAccessToken'
+  access_grant_class 'Spree::OauthAccessGrant'
+  application_class 'Spree::OauthApplication'
 end

--- a/api/lib/spree/api/testing_support/v2/base.rb
+++ b/api/lib/spree/api/testing_support/v2/base.rb
@@ -1,5 +1,5 @@
 shared_context 'API v2 tokens' do
-  let(:token) { Doorkeeper::AccessToken.create!(resource_owner_id: user.id, expires_in: nil) }
+  let(:token) { Spree::OauthAccessToken.create!(resource_owner_id: user.id, expires_in: nil) }
   let(:headers_bearer) { { 'Authorization' => "Bearer #{token.token}" } }
   let(:headers_order_token) { { 'X-Spree-Order-Token' => order.token } }
 end

--- a/api/lib/spree/api/testing_support/v2/platform_contexts.rb
+++ b/api/lib/spree/api/testing_support/v2/platform_contexts.rb
@@ -6,22 +6,22 @@ end
 
 shared_context 'Platform API v2' do
   let(:store) { Spree::Store.default }
-  let(:admin_app) { Doorkeeper::Application.find_or_create_by!(name: 'Admin Panel', scopes: 'admin', redirect_uri: '') }
-  let(:read_app) { Doorkeeper::Application.find_or_create_by!(name: 'Read App', scopes: 'read', redirect_uri: '') }
+  let(:admin_app) { Spree::OauthApplication.find_or_create_by!(name: 'Admin Panel', scopes: 'admin', redirect_uri: '') }
+  let(:read_app) { Spree::OauthApplication.find_or_create_by!(name: 'Read App', scopes: 'read', redirect_uri: '') }
   let(:oauth_token) do
-    Doorkeeper::AccessToken.create!(
+    Spree::OauthAccessToken.create!(
       application_id: admin_app.id,
       scopes: admin_app.scopes
     )
   end
   let(:read_oauth_token) do
-    Doorkeeper::AccessToken.create!(
+    Spree::OauthAccessToken.create!(
       application_id: read_app.id,
       scopes: read_app.scopes
     )
   end
   let(:user_oauth_token) do
-    Doorkeeper::AccessToken.create!(
+    Spree::OauthAccessToken.create!(
       resource_owner_id: user.id,
       application_id: admin_app.id,
       scopes: admin_app.scopes

--- a/api/spree_api.gemspec
+++ b/api/spree_api.gemspec
@@ -31,6 +31,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_core', s.version
   s.add_dependency 'rabl', '~> 0.14', '>= 0.14.2'
   s.add_dependency 'jsonapi-serializer', '~> 2.1'
-  s.add_dependency 'doorkeeper', '~> 5.2', '>= 5.2.1'
+  s.add_dependency 'doorkeeper', '~> 5.3'
   s.add_dependency 'responders'
 end

--- a/backend/app/controllers/spree/admin/base_controller.rb
+++ b/backend/app/controllers/spree/admin/base_controller.rb
@@ -95,7 +95,7 @@ module Spree
 
       def admin_oauth_application
         @admin_oauth_application ||= begin
-          Doorkeeper::Application.find_or_create_by!(name: 'Admin Panel', scopes: 'admin', redirect_uri: '')
+          Spree::OauthApplication.find_or_create_by!(name: 'Admin Panel', scopes: 'admin', redirect_uri: '')
         end
       end
 
@@ -105,8 +105,8 @@ module Spree
         return unless user
 
         @admin_oauth_token ||= begin
-          Doorkeeper::AccessToken.active_for(user).where(application_id: admin_oauth_application.id).last ||
-            Doorkeeper::AccessToken.create!(
+          Spree::OauthAccessToken.active_for(user).where(application_id: admin_oauth_application.id).last ||
+            Spree::OauthAccessToken.create!(
               resource_owner_id: user.id,
               application_id: admin_oauth_application.id,
               scopes: admin_oauth_application.scopes

--- a/core/lib/spree/core/controller_helpers/auth.rb
+++ b/core/lib/spree/core/controller_helpers/auth.rb
@@ -34,8 +34,8 @@ module Spree
         end
 
         def current_oauth_token
-          get_last_access_token = ->(user) { Doorkeeper::AccessToken.active_for(user).where(expires_in: nil).last }
-          create_access_token = ->(user) { Doorkeeper::AccessToken.create!(resource_owner_id: user.id) }
+          get_last_access_token = ->(user) { Spree::OauthAccessToken.active_for(user).where(expires_in: nil).last }
+          create_access_token = ->(user) { Spree::OauthAccessToken.create!(resource_owner_id: user.id) }
           user = try_spree_current_user
           return unless user
 

--- a/core/lib/spree/testing_support/authorization_helpers.rb
+++ b/core/lib/spree/testing_support/authorization_helpers.rb
@@ -37,7 +37,7 @@ module Spree
             ability_class.register_ability(ability)
           end
 
-          let(:admin_token) { Doorkeeper::AccessToken.create!(scopes: 'admin read write').token }
+          let(:admin_token) { Spree::OauthAccessToken.create!(scopes: 'admin read write').token }
 
           before do
             allow(Spree.user_class).to receive(:find_by).and_return(Spree.user_class.new)


### PR DESCRIPTION
Doorkeeper 5.3 added an ability to use custom models https://doorkeeper.gitbook.io/guides/configuration/models and thanks to this we can avoid `class_evals` and also allow for more customization by developers.