### PR TITLE
[SD-1476] - Add OpenAPI documentation to Platform API for CMS Pages and CMS Sections

### DIFF
--- a/api/app/controllers/spree/api/v2/platform/cms_sections_controller.rb
+++ b/api/app/controllers/spree/api/v2/platform/cms_sections_controller.rb
@@ -8,6 +8,11 @@ module Spree
           def reposition
             spree_authorize! :update, @moved_section if spree_current_user.present?
 
+            unless params[:new_position_idx].present?
+              render json: { error: I18n.t('spree.api.v2.cms_sections.pass_position_index') }, status: 422
+              return
+            end
+
             @moved_section = scope.find(params[:id])
             new_index = params[:new_position_idx].to_i + 1
 
@@ -18,7 +23,7 @@ module Spree
             end
 
             if @moved_section.save
-              head :no_content
+              render_serialized_payload { serialize_resource(resource) }
             end
           end
 

--- a/api/app/controllers/spree/api/v2/platform/cms_sections_controller.rb
+++ b/api/app/controllers/spree/api/v2/platform/cms_sections_controller.rb
@@ -8,7 +8,7 @@ module Spree
           def reposition
             spree_authorize! :update, @moved_section if spree_current_user.present?
 
-            @moved_section = scope.find(params[:section_id])
+            @moved_section = scope.find(params[:id])
             new_index = params[:new_position_idx].to_i + 1
 
             if @moved_section && new_index

--- a/api/app/serializers/spree/api/v2/platform/cms_section_serializer.rb
+++ b/api/app/serializers/spree/api/v2/platform/cms_section_serializer.rb
@@ -4,6 +4,13 @@ module Spree
       module Platform
         class CmsSectionSerializer < BaseSerializer
           include ::Spree::Api::V2::ResourceSerializerConcern
+
+          belongs_to :cms_page, serializer: :cms_page
+          belongs_to :linked_resource, polymorphic: {
+            Spree::Cms::Pages::StandardPage => :cms_page,
+            Spree::Cms::Pages::FeaturePage => :cms_page,
+            Spree::Cms::Pages::Homepage => :cms_page
+          }
         end
       end
     end

--- a/api/app/serializers/spree/v2/storefront/cms_section_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/cms_section_serializer.rb
@@ -21,7 +21,11 @@ module Spree
           section.fullscreen?
         end
 
-        belongs_to :linked_resource, polymorphic: true
+        belongs_to :linked_resource, polymorphic: {
+          Spree::Cms::Pages::StandardPage => :cms_page,
+          Spree::Cms::Pages::FeaturePage => :cms_page,
+          Spree::Cms::Pages::Homepage => :cms_page
+        }
       end
     end
   end

--- a/api/config/locales/en.yml
+++ b/api/config/locales/en.yml
@@ -38,3 +38,5 @@ en:
           wrong_quantity: "Quantity has to be greater than 0"
           pass_variant_id: "Pass the variant id that you want to add to this wishlist, eg.{ variant_id: 20 }"
           must_be_an_integer: "Sorry, you must pass an integer value, eg. 5"
+        cms_sections:
+          pass_position_index: "Pass 'new_position_idx' with an interger value in the request body"

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -279,7 +279,8 @@ Spree::Core::Engine.add_routes do
           end
         end
 
-        resource :cms_sections do
+        # CMS Sections API
+        resources :cms_sections do
           member do
             patch :reposition
           end

--- a/api/docs/v2/platform/index.yaml
+++ b/api/docs/v2/platform/index.yaml
@@ -63,8 +63,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-09-27T22:00:20.200Z'
-                        updated_at: '2021-09-27T22:00:20.200Z'
+                        created_at: '2021-09-27T22:41:57.860Z'
+                        updated_at: '2021-09-27T22:41:57.860Z'
                         deleted_at:
                         label:
                       relationships:
@@ -91,8 +91,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-09-27T22:00:20.202Z'
-                        updated_at: '2021-09-27T22:00:20.202Z'
+                        created_at: '2021-09-27T22:41:57.862Z'
+                        updated_at: '2021-09-27T22:41:57.862Z'
                         deleted_at:
                         label:
                       relationships:
@@ -162,8 +162,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-09-27T22:00:20.312Z'
-                        updated_at: '2021-09-27T22:00:20.312Z'
+                        created_at: '2021-09-27T22:41:57.976Z'
+                        updated_at: '2021-09-27T22:41:57.976Z'
                         deleted_at:
                         label:
                       relationships:
@@ -253,8 +253,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-09-27T22:00:20.334Z'
-                        updated_at: '2021-09-27T22:00:20.334Z'
+                        created_at: '2021-09-27T22:41:57.997Z'
+                        updated_at: '2021-09-27T22:41:57.997Z'
                         deleted_at:
                         label:
                       relationships:
@@ -327,8 +327,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-09-27T22:00:20.363Z'
-                        updated_at: '2021-09-27T22:00:20.367Z'
+                        created_at: '2021-09-27T22:41:58.028Z'
+                        updated_at: '2021-09-27T22:41:58.033Z'
                         deleted_at:
                         label:
                       relationships:
@@ -455,8 +455,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-09-27T22:00:20.611Z'
-                        updated_at: '2021-09-27T22:00:20.611Z'
+                        created_at: '2021-09-27T22:41:58.287Z'
+                        updated_at: '2021-09-27T22:41:58.287Z'
                       relationships:
                         product:
                           data:
@@ -470,8 +470,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-09-27T22:00:20.678Z'
-                        updated_at: '2021-09-27T22:00:20.678Z'
+                        created_at: '2021-09-27T22:41:58.356Z'
+                        updated_at: '2021-09-27T22:41:58.356Z'
                       relationships:
                         product:
                           data:
@@ -528,8 +528,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-09-27T22:00:20.944Z'
-                        updated_at: '2021-09-27T22:00:20.944Z'
+                        created_at: '2021-09-27T22:41:58.641Z'
+                        updated_at: '2021-09-27T22:41:58.641Z'
                       relationships:
                         product:
                           data:
@@ -592,8 +592,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-09-27T22:00:21.037Z'
-                        updated_at: '2021-09-27T22:00:21.037Z'
+                        created_at: '2021-09-27T22:41:58.746Z'
+                        updated_at: '2021-09-27T22:41:58.746Z'
                       relationships:
                         product:
                           data:
@@ -653,8 +653,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-09-27T22:00:21.225Z'
-                        updated_at: '2021-09-27T22:00:21.225Z'
+                        created_at: '2021-09-27T22:41:58.964Z'
+                        updated_at: '2021-09-27T22:41:58.964Z'
                       relationships:
                         product:
                           data:
@@ -764,8 +764,8 @@ paths:
                       type: classification
                       attributes:
                         position: 2
-                        created_at: '2021-09-27T22:00:21.684Z'
-                        updated_at: '2021-09-27T22:00:21.695Z'
+                        created_at: '2021-09-27T22:41:59.461Z'
+                        updated_at: '2021-09-27T22:41:59.472Z'
                       relationships:
                         product:
                           data:
@@ -850,35 +850,34 @@ paths:
                     - id: '1'
                       type: cms_page
                       attributes:
-                        title: Fugit voluptatibus deserunt nulla id dolore fugiat.
+                        title: Quae illum sed aut aliquam nulla enim.
                         meta_title:
                         content:
                         meta_description:
                         visible: true
-                        slug: fugit-voluptatibus-deserunt-nulla-id-dolore-fugiat
+                        slug: quae-illum-sed-aut-aliquam-nulla-enim
                         type: Spree::Cms::Pages::StandardPage
                         locale: en
                         deleted_at:
-                        created_at: '2021-09-27T22:00:21.898Z'
-                        updated_at: '2021-09-27T22:00:21.898Z'
+                        created_at: '2021-09-27T22:41:59.683Z'
+                        updated_at: '2021-09-27T22:41:59.683Z'
                       relationships:
                         cms_sections:
                           data: []
                     - id: '2'
                       type: cms_page
                       attributes:
-                        title: Dolore voluptate voluptates repellendus excepturi rerum
-                          velit dignissimos.
+                        title: Unde a reprehenderit ad similique recusandae quos laboriosam.
                         meta_title:
                         content:
                         meta_description:
                         visible: true
-                        slug: dolore-voluptate-voluptates-repellendus-excepturi-rerum-velit-dignissimos
+                        slug: unde-a-reprehenderit-ad-similique-recusandae-quos-laboriosam
                         type: Spree::Cms::Pages::StandardPage
                         locale: en
                         deleted_at:
-                        created_at: '2021-09-27T22:00:21.900Z'
-                        updated_at: '2021-09-27T22:00:21.900Z'
+                        created_at: '2021-09-27T22:41:59.686Z'
+                        updated_at: '2021-09-27T22:41:59.686Z'
                       relationships:
                         cms_sections:
                           data: []
@@ -928,17 +927,18 @@ paths:
                       id: '1'
                       type: cms_page
                       attributes:
-                        title: Blanditiis quae neque voluptates impedit beatae.
+                        title: Exercitationem fugit architecto aspernatur consectetur
+                          voluptatem perferendis.
                         meta_title:
                         content:
                         meta_description:
                         visible: true
-                        slug: blanditiis-quae-neque-voluptates-impedit-beatae
+                        slug: exercitationem-fugit-architecto-aspernatur-consectetur-voluptatem-perferendis
                         type:
                         locale: en
                         deleted_at:
-                        created_at: '2021-09-27T22:00:21.942Z'
-                        updated_at: '2021-09-27T22:00:21.942Z'
+                        created_at: '2021-09-27T22:41:59.728Z'
+                        updated_at: '2021-09-27T22:41:59.728Z'
                       relationships:
                         cms_sections:
                           data: []
@@ -994,17 +994,18 @@ paths:
                       id: '1'
                       type: cms_page
                       attributes:
-                        title: Officiis corrupti unde quibusdam velit.
+                        title: Magni earum enim deleniti architecto inventore illo
+                          perferendis.
                         meta_title:
                         content:
                         meta_description:
                         visible: true
-                        slug: officiis-corrupti-unde-quibusdam-velit
+                        slug: magni-earum-enim-deleniti-architecto-inventore-illo-perferendis
                         type: Spree::Cms::Pages::StandardPage
                         locale: en
                         deleted_at:
-                        created_at: '2021-09-27T22:00:21.964Z'
-                        updated_at: '2021-09-27T22:00:21.964Z'
+                        created_at: '2021-09-27T22:41:59.753Z'
+                        updated_at: '2021-09-27T22:41:59.753Z'
                       relationships:
                         cms_sections:
                           data: []
@@ -1062,12 +1063,12 @@ paths:
                         content:
                         meta_description:
                         visible: true
-                        slug: distinctio-quidem-pariatur-harum-voluptatem
+                        slug: ipsam-magnam-laboriosam-id-architecto
                         type: Spree::Cms::Pages::StandardPage
                         locale: en
                         deleted_at:
-                        created_at: '2021-09-27T22:00:22.007Z'
-                        updated_at: '2021-09-27T22:00:22.013Z'
+                        created_at: '2021-09-27T22:41:59.795Z'
+                        updated_at: '2021-09-27T22:41:59.801Z'
                       relationships:
                         cms_sections:
                           data: []
@@ -1181,7 +1182,7 @@ paths:
                     - id: '1'
                       type: cms_section
                       attributes:
-                        name: Unde animi aliquid velit ut cumque odit hic corporis.
+                        name: Neque excepturi minima consequuntur vero eligendi.
                         content: {}
                         settings:
                           gutters: No Gutters
@@ -1189,9 +1190,76 @@ paths:
                         destination:
                         type: Spree::Cms::Sections::HeroImage
                         position: 1
+                        linked_resource_type: Spree::Taxon
+                        created_at: '2021-09-27T22:41:59.900Z'
+                        updated_at: '2021-09-27T22:41:59.900Z'
+                      relationships:
+                        cms_page:
+                          data:
+                            id: '1'
+                            type: cms_page
+                        linked_resource:
+                          data:
+                    - id: '2'
+                      type: cms_section
+                      attributes:
+                        name: Qui voluptate nesciunt animi nemo similique numquam.
+                        content:
+                          link_type_one: Spree::Taxon
+                          link_type_two: Spree::Taxon
+                          link_type_three: Spree::Taxon
+                        settings:
+                          layout_style: Default
+                        fit: Container
+                        destination:
+                        type: Spree::Cms::Sections::ImageGallery
+                        position: 2
+                        linked_resource_type:
+                        created_at: '2021-09-27T22:41:59.902Z'
+                        updated_at: '2021-09-27T22:41:59.902Z'
+                      relationships:
+                        cms_page:
+                          data:
+                            id: '1'
+                            type: cms_page
+                        linked_resource:
+                          data:
+                    - id: '3'
+                      type: cms_section
+                      attributes:
+                        name: Quibusdam voluptas consequuntur fugiat iste doloribus
+                          quidem ab facilis.
+                        content: {}
+                        settings:
+                          gutters: No Gutters
+                        fit: Screen
+                        destination:
+                        type: Spree::Cms::Sections::FeaturedArticle
+                        position: 3
+                        linked_resource_type: Spree::Taxon
+                        created_at: '2021-09-27T22:41:59.909Z'
+                        updated_at: '2021-09-27T22:41:59.909Z'
+                      relationships:
+                        cms_page:
+                          data:
+                            id: '1'
+                            type: cms_page
+                        linked_resource:
+                          data:
+                    - id: '4'
+                      type: cms_section
+                      attributes:
+                        name: Rerum occaecati blanditiis quia hic laborum natus.
+                        content: {}
+                        settings:
+                          gutters: No Gutters
+                        fit: Screen
+                        destination:
+                        type: Spree::Cms::Sections::HeroImage
+                        position: 4
                         linked_resource_type: Spree::Product
-                        created_at: '2021-09-27T22:00:22.114Z'
-                        updated_at: '2021-09-27T22:00:22.114Z'
+                        created_at: '2021-09-27T22:41:59.915Z'
+                        updated_at: '2021-09-27T22:41:59.915Z'
                       relationships:
                         cms_page:
                           data:
@@ -1201,21 +1269,20 @@ paths:
                           data:
                             id: '1'
                             type: product
-                    - id: '2'
+                    - id: '5'
                       type: cms_section
                       attributes:
-                        name: Id ratione sit nulla voluptates ex laudantium tempora
-                          dolorem.
+                        name: Cumque expedita repellendus occaecati ex magni.
                         content: {}
                         settings:
                           gutters: No Gutters
                         fit: Screen
                         destination:
                         type: Spree::Cms::Sections::HeroImage
-                        position: 2
+                        position: 5
                         linked_resource_type: Spree::Product
-                        created_at: '2021-09-27T22:00:22.116Z'
-                        updated_at: '2021-09-27T22:00:22.116Z'
+                        created_at: '2021-09-27T22:41:59.920Z'
+                        updated_at: '2021-09-27T22:41:59.920Z'
                       relationships:
                         cms_page:
                           data:
@@ -1226,8 +1293,8 @@ paths:
                             id: '1'
                             type: product
                     meta:
-                      count: 2
-                      total_count: 2
+                      count: 5
+                      total_count: 5
                       total_pages: 1
                     links:
                       self: http://www.example.com/api/v2/platform/cms_sections?page=1&per_page=&include=&filter=
@@ -1268,19 +1335,20 @@ paths:
                 Example:
                   value:
                     data:
-                      id: '1'
+                      id: '4'
                       type: cms_section
                       attributes:
-                        name: Recusandae suscipit officiis nam dolorem incidunt facilis.
+                        name: Illo ipsam officia magni molestiae doloribus culpa at
+                          eligendi.
                         content:
                         settings:
                         fit:
                         destination:
                         type:
-                        position: 1
+                        position: 4
                         linked_resource_type:
-                        created_at: '2021-09-27T22:00:22.208Z'
-                        updated_at: '2021-09-27T22:00:22.208Z'
+                        created_at: '2021-09-27T22:42:00.021Z'
+                        updated_at: '2021-09-27T22:42:00.021Z'
                       relationships:
                         cms_page:
                           data:
@@ -1337,20 +1405,20 @@ paths:
                 Example:
                   value:
                     data:
-                      id: '1'
+                      id: '4'
                       type: cms_section
                       attributes:
-                        name: Quas repudiandae sed dicta sapiente repellat.
+                        name: Labore commodi minima eos officiis ea.
                         content: {}
                         settings:
                           gutters: No Gutters
                         fit: Screen
                         destination:
                         type: Spree::Cms::Sections::HeroImage
-                        position: 1
+                        position: 4
                         linked_resource_type: Spree::Product
-                        created_at: '2021-09-27T22:00:22.273Z'
-                        updated_at: '2021-09-27T22:00:22.273Z'
+                        created_at: '2021-09-27T22:42:00.096Z'
+                        updated_at: '2021-09-27T22:42:00.096Z'
                       relationships:
                         cms_page:
                           data:
@@ -1406,7 +1474,7 @@ paths:
                 Example:
                   value:
                     data:
-                      id: '1'
+                      id: '4'
                       type: cms_section
                       attributes:
                         name: Super Hero
@@ -1416,10 +1484,10 @@ paths:
                         fit: Screen
                         destination:
                         type: Spree::Cms::Sections::HeroImage
-                        position: 1
+                        position: 4
                         linked_resource_type: Spree::Product
-                        created_at: '2021-09-27T22:00:22.378Z'
-                        updated_at: '2021-09-27T22:00:22.384Z'
+                        created_at: '2021-09-27T22:42:00.215Z'
+                        updated_at: '2021-09-27T22:42:00.222Z'
                       relationships:
                         cms_page:
                           data:
@@ -1494,6 +1562,74 @@ paths:
                 Example:
                   value:
                     error: The access token is invalid
+  "/api/v2/platform/cms_sections/{id}/reposition":
+    patch:
+      summary: Reposition a CMS Section
+      tags:
+      - CMS Sections
+      security:
+      - bearer_auth: []
+      operationId: reposition-cms-section
+      description: Reposition a Menu Item
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: record updated
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    data:
+                      id: '4'
+                      type: cms_section
+                      attributes:
+                        name: Eos iste adipisci laudantium beatae amet eius.
+                        content: {}
+                        settings:
+                          gutters: No Gutters
+                        fit: Screen
+                        destination:
+                        type: Spree::Cms::Sections::HeroImage
+                        position: 3
+                        linked_resource_type: Spree::Product
+                        created_at: '2021-09-27T22:42:00.499Z'
+                        updated_at: '2021-09-27T22:42:00.506Z'
+                      relationships:
+                        cms_page:
+                          data:
+                            id: '1'
+                            type: cms_page
+                        linked_resource:
+                          data:
+                            id: '1'
+                            type: product
+        '404':
+          description: Record not found
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    error: The resource you were looking for could not be found.
+        '401':
+          description: Authentication Failed
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    error: The access token is invalid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/cms_section_reposition_params"
   "/api/v2/platform/countries":
     get:
       summary: Returns a list of Countries
@@ -1517,13 +1653,13 @@ paths:
                       attributes:
                         iso_name: UNITED STATES
                         iso: US
-                        iso3: IS62
+                        iso3: IS65
                         name: United States of America
                         numcode: 840
                         states_required: true
-                        updated_at: '2021-09-27T22:00:22.600Z'
+                        updated_at: '2021-09-27T22:42:00.594Z'
                         zipcode_required: true
-                        created_at: '2021-09-27T22:00:22.600Z'
+                        created_at: '2021-09-27T22:42:00.594Z'
                       relationships:
                         states:
                           data: []
@@ -1532,13 +1668,13 @@ paths:
                       attributes:
                         iso_name: ISO_NAME_2
                         iso: I2
-                        iso3: IS63
+                        iso3: IS66
                         name: NAME_2
                         numcode: 840
                         states_required: false
-                        updated_at: '2021-09-27T22:00:22.603Z'
+                        updated_at: '2021-09-27T22:42:00.598Z'
                         zipcode_required: true
-                        created_at: '2021-09-27T22:00:22.603Z'
+                        created_at: '2021-09-27T22:42:00.598Z'
                       relationships:
                         states:
                           data: []
@@ -1547,13 +1683,13 @@ paths:
                       attributes:
                         iso_name: ISO_NAME_3
                         iso: I3
-                        iso3: IS64
+                        iso3: IS67
                         name: NAME_3
                         numcode: 840
                         states_required: false
-                        updated_at: '2021-09-27T22:00:22.604Z'
+                        updated_at: '2021-09-27T22:42:00.598Z'
                         zipcode_required: true
-                        created_at: '2021-09-27T22:00:22.604Z'
+                        created_at: '2021-09-27T22:42:00.598Z'
                       relationships:
                         states:
                           data: []
@@ -1604,13 +1740,13 @@ paths:
                       attributes:
                         iso_name: ISO_NAME_6
                         iso: I6
-                        iso3: IS69
+                        iso3: IS72
                         name: NAME_6
                         numcode: 840
                         states_required: false
-                        updated_at: '2021-09-27T22:00:22.632Z'
+                        updated_at: '2021-09-27T22:42:00.626Z'
                         zipcode_required: true
-                        created_at: '2021-09-27T22:00:22.632Z'
+                        created_at: '2021-09-27T22:42:00.626Z'
                       relationships:
                         states:
                           data: []
@@ -1675,7 +1811,8 @@ paths:
                     - id: '1'
                       type: menu_item
                       attributes:
-                        name: Sit voluptas non quo distinctio.
+                        name: Perspiciatis cupiditate quae quas incidunt nostrum alias
+                          vitae.
                         subtitle:
                         destination:
                         new_window: false
@@ -1685,8 +1822,8 @@ paths:
                         lft: 1
                         rgt: 16
                         depth: 0
-                        created_at: '2021-09-27T22:00:22.671Z'
-                        updated_at: '2021-09-27T22:00:22.970Z'
+                        created_at: '2021-09-27T22:42:00.664Z'
+                        updated_at: '2021-09-27T22:42:00.969Z'
                         link:
                         is_container: true
                         is_root: true
@@ -1732,8 +1869,8 @@ paths:
                         lft: 2
                         rgt: 3
                         depth: 1
-                        created_at: '2021-09-27T22:00:22.711Z'
-                        updated_at: '2021-09-27T22:00:22.714Z'
+                        created_at: '2021-09-27T22:42:00.704Z'
+                        updated_at: '2021-09-27T22:42:00.707Z'
                         link:
                         is_container: false
                         is_root: false
@@ -1769,8 +1906,8 @@ paths:
                         lft: 4
                         rgt: 5
                         depth: 1
-                        created_at: '2021-09-27T22:00:22.751Z'
-                        updated_at: '2021-09-27T22:00:22.754Z'
+                        created_at: '2021-09-27T22:42:00.745Z'
+                        updated_at: '2021-09-27T22:42:00.748Z'
                         link:
                         is_container: false
                         is_root: false
@@ -1806,8 +1943,8 @@ paths:
                         lft: 6
                         rgt: 7
                         depth: 1
-                        created_at: '2021-09-27T22:00:22.791Z'
-                        updated_at: '2021-09-27T22:00:22.794Z'
+                        created_at: '2021-09-27T22:42:00.786Z'
+                        updated_at: '2021-09-27T22:42:00.789Z'
                         link:
                         is_container: false
                         is_root: false
@@ -1843,8 +1980,8 @@ paths:
                         lft: 8
                         rgt: 9
                         depth: 1
-                        created_at: '2021-09-27T22:00:22.832Z'
-                        updated_at: '2021-09-27T22:00:22.844Z'
+                        created_at: '2021-09-27T22:42:00.835Z'
+                        updated_at: '2021-09-27T22:42:00.838Z'
                         link:
                         is_container: false
                         is_root: false
@@ -1880,8 +2017,8 @@ paths:
                         lft: 10
                         rgt: 11
                         depth: 1
-                        created_at: '2021-09-27T22:00:22.881Z'
-                        updated_at: '2021-09-27T22:00:22.884Z'
+                        created_at: '2021-09-27T22:42:00.877Z'
+                        updated_at: '2021-09-27T22:42:00.880Z'
                         link:
                         is_container: false
                         is_root: false
@@ -1917,8 +2054,8 @@ paths:
                         lft: 12
                         rgt: 13
                         depth: 1
-                        created_at: '2021-09-27T22:00:22.922Z'
-                        updated_at: '2021-09-27T22:00:22.925Z'
+                        created_at: '2021-09-27T22:42:00.919Z'
+                        updated_at: '2021-09-27T22:42:00.922Z'
                         link:
                         is_container: false
                         is_root: false
@@ -1954,8 +2091,8 @@ paths:
                         lft: 14
                         rgt: 15
                         depth: 1
-                        created_at: '2021-09-27T22:00:22.963Z'
-                        updated_at: '2021-09-27T22:00:22.966Z'
+                        created_at: '2021-09-27T22:42:00.961Z'
+                        updated_at: '2021-09-27T22:42:00.964Z'
                         link:
                         is_container: false
                         is_root: false
@@ -2034,8 +2171,8 @@ paths:
                         lft: 8
                         rgt: 9
                         depth: 1
-                        created_at: '2021-09-27T22:00:23.435Z'
-                        updated_at: '2021-09-27T22:00:23.438Z'
+                        created_at: '2021-09-27T22:42:01.441Z'
+                        updated_at: '2021-09-27T22:42:01.443Z'
                         link:
                         is_container: false
                         is_root: false
@@ -2121,8 +2258,8 @@ paths:
                         lft: 8
                         rgt: 9
                         depth: 1
-                        created_at: '2021-09-27T22:00:23.747Z'
-                        updated_at: '2021-09-27T22:00:23.750Z'
+                        created_at: '2021-09-27T22:42:01.802Z'
+                        updated_at: '2021-09-27T22:42:01.805Z'
                         link:
                         is_container: false
                         is_root: false
@@ -2204,8 +2341,8 @@ paths:
                         lft: 8
                         rgt: 9
                         depth: 1
-                        created_at: '2021-09-27T22:00:24.254Z'
-                        updated_at: '2021-09-27T22:00:24.267Z'
+                        created_at: '2021-09-27T22:42:02.322Z'
+                        updated_at: '2021-09-27T22:42:02.341Z'
                         link:
                         is_container: false
                         is_root: false
@@ -2330,8 +2467,8 @@ paths:
                         lft: 5
                         rgt: 6
                         depth: 2
-                        created_at: '2021-09-27T22:00:25.476Z'
-                        updated_at: '2021-09-27T22:00:25.491Z'
+                        created_at: '2021-09-27T22:42:03.595Z'
+                        updated_at: '2021-09-27T22:42:03.610Z'
                         link:
                         is_container: false
                         is_root: false
@@ -2423,8 +2560,8 @@ paths:
                         name: Main Menu
                         location: header
                         locale: en
-                        created_at: '2021-09-27T22:00:25.831Z'
-                        updated_at: '2021-09-27T22:00:25.919Z'
+                        created_at: '2021-09-27T22:42:03.961Z'
+                        updated_at: '2021-09-27T22:42:04.051Z'
                       relationships:
                         menu_items:
                           data:
@@ -2440,8 +2577,8 @@ paths:
                         name: Footer Menu
                         location: footer
                         locale: en
-                        created_at: '2021-09-27T22:00:25.835Z'
-                        updated_at: '2021-09-27T22:00:26.001Z'
+                        created_at: '2021-09-27T22:42:03.966Z'
+                        updated_at: '2021-09-27T22:42:04.135Z'
                       relationships:
                         menu_items:
                           data:
@@ -2500,8 +2637,8 @@ paths:
                         name: Main Menu
                         location: header
                         locale: en
-                        created_at: '2021-09-27T22:00:26.218Z'
-                        updated_at: '2021-09-27T22:00:26.221Z'
+                        created_at: '2021-09-27T22:42:04.360Z'
+                        updated_at: '2021-09-27T22:42:04.364Z'
                       relationships:
                         menu_items:
                           data:
@@ -2565,8 +2702,8 @@ paths:
                         name: Main Menu
                         location: header
                         locale: en
-                        created_at: '2021-09-27T22:00:26.243Z'
-                        updated_at: '2021-09-27T22:00:26.246Z'
+                        created_at: '2021-09-27T22:42:04.389Z'
+                        updated_at: '2021-09-27T22:42:04.392Z'
                       relationships:
                         menu_items:
                           data:
@@ -2624,8 +2761,8 @@ paths:
                         name: Main Menu
                         location: header
                         locale: en
-                        created_at: '2021-09-27T22:00:26.283Z'
-                        updated_at: '2021-09-27T22:00:26.286Z'
+                        created_at: '2021-09-27T22:42:04.503Z'
+                        updated_at: '2021-09-27T22:42:04.506Z'
                       relationships:
                         menu_items:
                           data:
@@ -2749,8 +2886,8 @@ paths:
                         name: foo-size-1
                         presentation: Size
                         position: 1
-                        created_at: '2021-09-27T22:00:26.390Z'
-                        updated_at: '2021-09-27T22:00:26.390Z'
+                        created_at: '2021-09-27T22:42:04.605Z'
+                        updated_at: '2021-09-27T22:42:04.605Z'
                         filterable: true
                       relationships:
                         option_values:
@@ -2761,8 +2898,8 @@ paths:
                         name: foo-size-2
                         presentation: Size
                         position: 2
-                        created_at: '2021-09-27T22:00:26.391Z'
-                        updated_at: '2021-09-27T22:00:26.391Z'
+                        created_at: '2021-09-27T22:42:04.606Z'
+                        updated_at: '2021-09-27T22:42:04.606Z'
                         filterable: true
                       relationships:
                         option_values:
@@ -2816,8 +2953,8 @@ paths:
                         name: foo-size-5
                         presentation: Size
                         position: 1
-                        created_at: '2021-09-27T22:00:26.423Z'
-                        updated_at: '2021-09-27T22:00:26.423Z'
+                        created_at: '2021-09-27T22:42:04.638Z'
+                        updated_at: '2021-09-27T22:42:04.638Z'
                         filterable: true
                       relationships:
                         option_values:
@@ -2877,8 +3014,8 @@ paths:
                         name: foo-size-6
                         presentation: Size
                         position: 1
-                        created_at: '2021-09-27T22:00:26.447Z'
-                        updated_at: '2021-09-27T22:00:26.447Z'
+                        created_at: '2021-09-27T22:42:04.658Z'
+                        updated_at: '2021-09-27T22:42:04.658Z'
                         filterable: true
                       relationships:
                         option_values:
@@ -2935,8 +3072,8 @@ paths:
                         name: Size-X
                         presentation: Size
                         position: 1
-                        created_at: '2021-09-27T22:00:26.477Z'
-                        updated_at: '2021-09-27T22:00:26.481Z'
+                        created_at: '2021-09-27T22:42:04.708Z'
+                        updated_at: '2021-09-27T22:42:04.714Z'
                         filterable: true
                       relationships:
                         option_values:
@@ -3054,8 +3191,8 @@ paths:
                         position: 1
                         name: Size-1
                         presentation: S
-                        created_at: '2021-09-27T22:00:26.621Z'
-                        updated_at: '2021-09-27T22:00:26.621Z'
+                        created_at: '2021-09-27T22:42:04.850Z'
+                        updated_at: '2021-09-27T22:42:04.850Z'
                       relationships:
                         option_type:
                           data:
@@ -3067,8 +3204,8 @@ paths:
                         position: 1
                         name: Size-2
                         presentation: S
-                        created_at: '2021-09-27T22:00:26.625Z'
-                        updated_at: '2021-09-27T22:00:26.625Z'
+                        created_at: '2021-09-27T22:42:04.854Z'
+                        updated_at: '2021-09-27T22:42:04.854Z'
                       relationships:
                         option_type:
                           data:
@@ -3123,8 +3260,8 @@ paths:
                         position: 1
                         name: Size-5
                         presentation: S
-                        created_at: '2021-09-27T22:00:26.661Z'
-                        updated_at: '2021-09-27T22:00:26.661Z'
+                        created_at: '2021-09-27T22:42:04.895Z'
+                        updated_at: '2021-09-27T22:42:04.895Z'
                       relationships:
                         option_type:
                           data:
@@ -3183,8 +3320,8 @@ paths:
                         position: 1
                         name: Size-6
                         presentation: S
-                        created_at: '2021-09-27T22:00:26.681Z'
-                        updated_at: '2021-09-27T22:00:26.681Z'
+                        created_at: '2021-09-27T22:42:04.922Z'
+                        updated_at: '2021-09-27T22:42:04.922Z'
                       relationships:
                         option_type:
                           data:
@@ -3242,8 +3379,8 @@ paths:
                         position: 1
                         name: M
                         presentation: S
-                        created_at: '2021-09-27T22:00:26.713Z'
-                        updated_at: '2021-09-27T22:00:26.718Z'
+                        created_at: '2021-09-27T22:42:04.968Z'
+                        updated_at: '2021-09-27T22:42:04.974Z'
                       relationships:
                         option_type:
                           data:
@@ -3365,8 +3502,8 @@ paths:
                         lft: 1
                         rgt: 6
                         description:
-                        created_at: '2021-09-27T22:00:26.805Z'
-                        updated_at: '2021-09-27T22:00:26.897Z'
+                        created_at: '2021-09-27T22:42:05.071Z'
+                        updated_at: '2021-09-27T22:42:05.161Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -3400,8 +3537,8 @@ paths:
                         lft: 2
                         rgt: 3
                         description:
-                        created_at: '2021-09-27T22:00:26.845Z'
-                        updated_at: '2021-09-27T22:00:26.847Z'
+                        created_at: '2021-09-27T22:42:05.113Z'
+                        updated_at: '2021-09-27T22:42:05.114Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -3435,8 +3572,8 @@ paths:
                         lft: 4
                         rgt: 5
                         description:
-                        created_at: '2021-09-27T22:00:26.889Z'
-                        updated_at: '2021-09-27T22:00:26.891Z'
+                        created_at: '2021-09-27T22:42:05.154Z'
+                        updated_at: '2021-09-27T22:42:05.156Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -3513,8 +3650,8 @@ paths:
                         lft: 2
                         rgt: 3
                         description:
-                        created_at: '2021-09-27T22:00:27.073Z'
-                        updated_at: '2021-09-27T22:00:27.076Z'
+                        created_at: '2021-09-27T22:42:05.317Z'
+                        updated_at: '2021-09-27T22:42:05.320Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -3595,8 +3732,8 @@ paths:
                         lft: 2
                         rgt: 3
                         description:
-                        created_at: '2021-09-27T22:00:27.142Z'
-                        updated_at: '2021-09-27T22:00:27.144Z'
+                        created_at: '2021-09-27T22:42:05.388Z'
+                        updated_at: '2021-09-27T22:42:05.390Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -3678,8 +3815,8 @@ paths:
                         lft: 2
                         rgt: 3
                         description:
-                        created_at: '2021-09-27T22:00:27.287Z'
-                        updated_at: '2021-09-27T22:00:27.301Z'
+                        created_at: '2021-09-27T22:42:05.559Z'
+                        updated_at: '2021-09-27T22:42:05.575Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -3814,9 +3951,9 @@ paths:
                     - id: '1'
                       type: user
                       attributes:
-                        email: adele@kesslercassin.co.uk
-                        created_at: '2021-09-27T22:00:27.600Z'
-                        updated_at: '2021-09-27T22:00:27.600Z'
+                        email: delena@buckridge.ca
+                        created_at: '2021-09-27T22:42:05.876Z'
+                        updated_at: '2021-09-27T22:42:05.876Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -3828,9 +3965,9 @@ paths:
                     - id: '2'
                       type: user
                       attributes:
-                        email: rachele.gorczany@willms.ca
-                        created_at: '2021-09-27T22:00:27.603Z'
-                        updated_at: '2021-09-27T22:00:27.603Z'
+                        email: bobby@torphygoyette.co.uk
+                        created_at: '2021-09-27T22:42:05.880Z'
+                        updated_at: '2021-09-27T22:42:05.880Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -3842,9 +3979,9 @@ paths:
                     - id: '3'
                       type: user
                       attributes:
-                        email: keri@hoegerwolf.info
-                        created_at: '2021-09-27T22:00:27.604Z'
-                        updated_at: '2021-09-27T22:00:27.604Z'
+                        email: joselyn@kohlercrist.com
+                        created_at: '2021-09-27T22:42:05.881Z'
+                        updated_at: '2021-09-27T22:42:05.881Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -3899,9 +4036,9 @@ paths:
                       id: '2'
                       type: user
                       attributes:
-                        email: elyse@cremin.co.uk
-                        created_at: '2021-09-27T22:00:27.645Z'
-                        updated_at: '2021-09-27T22:00:27.645Z'
+                        email: rebekah_rohan@ondricka.name
+                        created_at: '2021-09-27T22:42:05.931Z'
+                        updated_at: '2021-09-27T22:42:05.931Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -3960,9 +4097,9 @@ paths:
                       id: '2'
                       type: user
                       attributes:
-                        email: roni_bosco@beahan.biz
-                        created_at: '2021-09-27T22:00:27.673Z'
-                        updated_at: '2021-09-27T22:00:27.673Z'
+                        email: tonisha_oconner@okeefe.us
+                        created_at: '2021-09-27T22:42:05.959Z'
+                        updated_at: '2021-09-27T22:42:05.959Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -4021,8 +4158,8 @@ paths:
                       type: user
                       attributes:
                         email: john@example.com
-                        created_at: '2021-09-27T22:00:27.720Z'
-                        updated_at: '2021-09-27T22:00:27.725Z'
+                        created_at: '2021-09-27T22:42:06.001Z'
+                        updated_at: '2021-09-27T22:42:06.005Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -4136,8 +4273,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-09-27T22:00:27.894Z'
-                        updated_at: '2021-09-27T22:00:27.894Z'
+                        created_at: '2021-09-27T22:42:06.193Z'
+                        updated_at: '2021-09-27T22:42:06.193Z'
                         price: '19.99'
                         total: '19.99'
                         display_price: "$19.99"
@@ -4151,8 +4288,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-09-27T22:00:27.921Z'
-                        updated_at: '2021-09-27T22:00:27.921Z'
+                        created_at: '2021-09-27T22:42:06.219Z'
+                        updated_at: '2021-09-27T22:42:06.219Z'
                         price: '19.99'
                         total: '19.99'
                         display_price: "$19.99"
@@ -4166,8 +4303,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-09-27T22:00:27.947Z'
-                        updated_at: '2021-09-27T22:00:27.947Z'
+                        created_at: '2021-09-27T22:42:06.248Z'
+                        updated_at: '2021-09-27T22:42:06.248Z'
                         price: '19.99'
                         total: '19.99'
                         display_price: "$19.99"
@@ -4181,8 +4318,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-09-27T22:00:27.974Z'
-                        updated_at: '2021-09-27T22:00:27.974Z'
+                        created_at: '2021-09-27T22:42:06.283Z'
+                        updated_at: '2021-09-27T22:42:06.283Z'
                         price: '19.99'
                         total: '19.99'
                         display_price: "$19.99"
@@ -4239,8 +4376,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-09-27T22:00:28.192Z'
-                        updated_at: '2021-09-27T22:00:28.192Z'
+                        created_at: '2021-09-27T22:42:06.544Z'
+                        updated_at: '2021-09-27T22:42:06.544Z'
                         price: '19.99'
                         total: '19.99'
                         display_price: "$19.99"
@@ -4306,8 +4443,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-09-27T22:00:28.319Z'
-                        updated_at: '2021-09-27T22:00:28.319Z'
+                        created_at: '2021-09-27T22:42:06.680Z'
+                        updated_at: '2021-09-27T22:42:06.680Z'
                         price: '19.99'
                         total: '19.99'
                         display_price: "$19.99"
@@ -4367,8 +4504,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 3
-                        created_at: '2021-09-27T22:00:28.523Z'
-                        updated_at: '2021-09-27T22:00:28.527Z'
+                        created_at: '2021-09-27T22:42:06.886Z'
+                        updated_at: '2021-09-27T22:42:06.890Z'
                         price: '19.99'
                         total: '59.97'
                         display_price: "$19.99"
@@ -4491,9 +4628,9 @@ paths:
                         name: Black Friday
                         is_private: true
                         is_default: false
-                        created_at: '2021-09-27T22:00:29.015Z'
-                        updated_at: '2021-09-27T22:00:29.015Z'
-                        token: yKswZxfaUEveH7vRUEpeY1xn
+                        created_at: '2021-09-27T22:42:07.394Z'
+                        updated_at: '2021-09-27T22:42:07.394Z'
+                        token: Nr8hjLVZCvWRa8WAAytPNK9E
                         variant_included: false
                       relationships:
                         wished_items:
@@ -4508,9 +4645,9 @@ paths:
                         name: Birthday
                         is_private: true
                         is_default: false
-                        created_at: '2021-09-27T22:00:29.016Z'
-                        updated_at: '2021-09-27T22:00:29.016Z'
-                        token: m6XR8TV44mfUvTyJS67nkafK
+                        created_at: '2021-09-27T22:42:07.396Z'
+                        updated_at: '2021-09-27T22:42:07.396Z'
+                        token: YzviFd1H6FqmzmYYoKzgkek6
                         variant_included: false
                       relationships:
                         wished_items:
@@ -4568,9 +4705,9 @@ paths:
                         name: Wishlist_26
                         is_private: true
                         is_default: false
-                        created_at: '2021-09-27T22:00:29.288Z'
-                        updated_at: '2021-09-27T22:00:29.288Z'
-                        token: 4baVLBWa8DnEnG9cUG4X5LDT
+                        created_at: '2021-09-27T22:42:07.677Z'
+                        updated_at: '2021-09-27T22:42:07.677Z'
+                        token: YtspLEk3GWr7gioBmsBCw7tf
                         variant_included: false
                       relationships:
                         wished_items:
@@ -4630,9 +4767,9 @@ paths:
                         name: My Wishlist
                         is_private: true
                         is_default: false
-                        created_at: '2021-09-27T22:00:29.311Z'
-                        updated_at: '2021-09-27T22:00:29.311Z'
-                        token: XzJvyAZy979ow5t1YrGPvrKb
+                        created_at: '2021-09-27T22:42:07.700Z'
+                        updated_at: '2021-09-27T22:42:07.700Z'
+                        token: AJNdSqCxTup2bzES8DNnwzsJ
                         variant_included: false
                       relationships:
                         wished_items:
@@ -4689,9 +4826,9 @@ paths:
                         name: My Super Wishlist
                         is_private: true
                         is_default: false
-                        created_at: '2021-09-27T22:00:29.348Z'
-                        updated_at: '2021-09-27T22:00:29.352Z'
-                        token: aBdXs8jW9jVgUCQB7Td96T4D
+                        created_at: '2021-09-27T22:42:07.735Z'
+                        updated_at: '2021-09-27T22:42:07.740Z'
+                        token: DqLANX4PY9o2RCQiEnFnG8Nb
                         variant_included: false
                       relationships:
                         wished_items:
@@ -5041,6 +5178,13 @@ components:
       required:
       - name
       - cms_page_id
+    cms_section_reposition_params:
+      type: object
+      properties:
+        new_position_idx:
+          type: integer
+      required:
+      - new_position_idx
     resources_list:
       type: object
       properties:

--- a/api/docs/v2/platform/index.yaml
+++ b/api/docs/v2/platform/index.yaml
@@ -63,8 +63,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-09-27T16:52:18.256Z'
-                        updated_at: '2021-09-27T16:52:18.256Z'
+                        created_at: '2021-09-27T22:00:20.200Z'
+                        updated_at: '2021-09-27T22:00:20.200Z'
                         deleted_at:
                         label:
                       relationships:
@@ -91,8 +91,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-09-27T16:52:18.259Z'
-                        updated_at: '2021-09-27T16:52:18.259Z'
+                        created_at: '2021-09-27T22:00:20.202Z'
+                        updated_at: '2021-09-27T22:00:20.202Z'
                         deleted_at:
                         label:
                       relationships:
@@ -162,8 +162,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-09-27T16:52:18.371Z'
-                        updated_at: '2021-09-27T16:52:18.371Z'
+                        created_at: '2021-09-27T22:00:20.312Z'
+                        updated_at: '2021-09-27T22:00:20.312Z'
                         deleted_at:
                         label:
                       relationships:
@@ -253,8 +253,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-09-27T16:52:18.392Z'
-                        updated_at: '2021-09-27T16:52:18.392Z'
+                        created_at: '2021-09-27T22:00:20.334Z'
+                        updated_at: '2021-09-27T22:00:20.334Z'
                         deleted_at:
                         label:
                       relationships:
@@ -327,8 +327,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-09-27T16:52:18.421Z'
-                        updated_at: '2021-09-27T16:52:18.426Z'
+                        created_at: '2021-09-27T22:00:20.363Z'
+                        updated_at: '2021-09-27T22:00:20.367Z'
                         deleted_at:
                         label:
                       relationships:
@@ -455,8 +455,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-09-27T16:52:18.664Z'
-                        updated_at: '2021-09-27T16:52:18.664Z'
+                        created_at: '2021-09-27T22:00:20.611Z'
+                        updated_at: '2021-09-27T22:00:20.611Z'
                       relationships:
                         product:
                           data:
@@ -470,8 +470,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-09-27T16:52:18.731Z'
-                        updated_at: '2021-09-27T16:52:18.731Z'
+                        created_at: '2021-09-27T22:00:20.678Z'
+                        updated_at: '2021-09-27T22:00:20.678Z'
                       relationships:
                         product:
                           data:
@@ -528,8 +528,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-09-27T16:52:18.993Z'
-                        updated_at: '2021-09-27T16:52:18.993Z'
+                        created_at: '2021-09-27T22:00:20.944Z'
+                        updated_at: '2021-09-27T22:00:20.944Z'
                       relationships:
                         product:
                           data:
@@ -592,8 +592,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-09-27T16:52:19.085Z'
-                        updated_at: '2021-09-27T16:52:19.085Z'
+                        created_at: '2021-09-27T22:00:21.037Z'
+                        updated_at: '2021-09-27T22:00:21.037Z'
                       relationships:
                         product:
                           data:
@@ -653,8 +653,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-09-27T16:52:19.279Z'
-                        updated_at: '2021-09-27T16:52:19.279Z'
+                        created_at: '2021-09-27T22:00:21.225Z'
+                        updated_at: '2021-09-27T22:00:21.225Z'
                       relationships:
                         product:
                           data:
@@ -764,8 +764,8 @@ paths:
                       type: classification
                       attributes:
                         position: 2
-                        created_at: '2021-09-27T16:52:19.727Z'
-                        updated_at: '2021-09-27T16:52:19.738Z'
+                        created_at: '2021-09-27T22:00:21.684Z'
+                        updated_at: '2021-09-27T22:00:21.695Z'
                       relationships:
                         product:
                           data:
@@ -850,35 +850,35 @@ paths:
                     - id: '1'
                       type: cms_page
                       attributes:
-                        title: Eum incidunt deserunt blanditiis quam ipsa enim necessitatibus
-                          mollitia.
+                        title: Fugit voluptatibus deserunt nulla id dolore fugiat.
                         meta_title:
                         content:
                         meta_description:
                         visible: true
-                        slug: eum-incidunt-deserunt-blanditiis-quam-ipsa-enim-necessitatibus-mollitia
+                        slug: fugit-voluptatibus-deserunt-nulla-id-dolore-fugiat
                         type: Spree::Cms::Pages::StandardPage
                         locale: en
                         deleted_at:
-                        created_at: '2021-09-27T16:52:19.940Z'
-                        updated_at: '2021-09-27T16:52:19.940Z'
+                        created_at: '2021-09-27T22:00:21.898Z'
+                        updated_at: '2021-09-27T22:00:21.898Z'
                       relationships:
                         cms_sections:
                           data: []
                     - id: '2'
                       type: cms_page
                       attributes:
-                        title: Animi quis eligendi et corporis officia soluta nisi.
+                        title: Dolore voluptate voluptates repellendus excepturi rerum
+                          velit dignissimos.
                         meta_title:
                         content:
                         meta_description:
                         visible: true
-                        slug: animi-quis-eligendi-et-corporis-officia-soluta-nisi
+                        slug: dolore-voluptate-voluptates-repellendus-excepturi-rerum-velit-dignissimos
                         type: Spree::Cms::Pages::StandardPage
                         locale: en
                         deleted_at:
-                        created_at: '2021-09-27T16:52:19.942Z'
-                        updated_at: '2021-09-27T16:52:19.942Z'
+                        created_at: '2021-09-27T22:00:21.900Z'
+                        updated_at: '2021-09-27T22:00:21.900Z'
                       relationships:
                         cms_sections:
                           data: []
@@ -928,18 +928,17 @@ paths:
                       id: '1'
                       type: cms_page
                       attributes:
-                        title: Possimus autem ipsam recusandae architecto consequuntur
-                          dolorum tenetur voluptates.
+                        title: Blanditiis quae neque voluptates impedit beatae.
                         meta_title:
                         content:
                         meta_description:
                         visible: true
-                        slug: possimus-autem-ipsam-recusandae-architecto-consequuntur-dolorum-tenetur-voluptates
+                        slug: blanditiis-quae-neque-voluptates-impedit-beatae
                         type:
                         locale: en
                         deleted_at:
-                        created_at: '2021-09-27T16:52:19.983Z'
-                        updated_at: '2021-09-27T16:52:19.983Z'
+                        created_at: '2021-09-27T22:00:21.942Z'
+                        updated_at: '2021-09-27T22:00:21.942Z'
                       relationships:
                         cms_sections:
                           data: []
@@ -995,18 +994,17 @@ paths:
                       id: '1'
                       type: cms_page
                       attributes:
-                        title: Officiis odit deserunt ipsa similique consequuntur
-                          neque voluptates.
+                        title: Officiis corrupti unde quibusdam velit.
                         meta_title:
                         content:
                         meta_description:
                         visible: true
-                        slug: officiis-odit-deserunt-ipsa-similique-consequuntur-neque-voluptates
+                        slug: officiis-corrupti-unde-quibusdam-velit
                         type: Spree::Cms::Pages::StandardPage
                         locale: en
                         deleted_at:
-                        created_at: '2021-09-27T16:52:20.004Z'
-                        updated_at: '2021-09-27T16:52:20.004Z'
+                        created_at: '2021-09-27T22:00:21.964Z'
+                        updated_at: '2021-09-27T22:00:21.964Z'
                       relationships:
                         cms_sections:
                           data: []
@@ -1064,12 +1062,12 @@ paths:
                         content:
                         meta_description:
                         visible: true
-                        slug: suscipit-rem-blanditiis-corporis-placeat-exercitationem
+                        slug: distinctio-quidem-pariatur-harum-voluptatem
                         type: Spree::Cms::Pages::StandardPage
                         locale: en
                         deleted_at:
-                        created_at: '2021-09-27T16:52:20.036Z'
-                        updated_at: '2021-09-27T16:52:20.042Z'
+                        created_at: '2021-09-27T22:00:22.007Z'
+                        updated_at: '2021-09-27T22:00:22.013Z'
                       relationships:
                         cms_sections:
                           data: []
@@ -1138,6 +1136,364 @@ paths:
                 Example:
                   value:
                     error: The access token is invalid
+  "/api/v2/platform/cms_sections":
+    get:
+      summary: Returns a list of CMS Sections
+      tags:
+      - CMS Sections
+      security:
+      - bearer_auth: []
+      description: Returns a list of CMS Sections
+      operationId: cms-sections-list
+      parameters:
+      - name: page
+        in: query
+        example: 1
+        schema:
+          type: integer
+      - name: per_page
+        in: query
+        example: 50
+        schema:
+          type: integer
+      - name: include
+        in: query
+        description: 'Select which associated resources you would like to fetch, see:
+          <a href="https://jsonapi.org/format/#fetching-includes">https://jsonapi.org/format/#fetching-includes</a>'
+        example: product
+        schema:
+          type: string
+      - name: filter
+        in: query
+        description: ''
+        example: name_eq=Hero
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Records returned
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    data:
+                    - id: '1'
+                      type: cms_section
+                      attributes:
+                        name: Unde animi aliquid velit ut cumque odit hic corporis.
+                        content: {}
+                        settings:
+                          gutters: No Gutters
+                        fit: Screen
+                        destination:
+                        type: Spree::Cms::Sections::HeroImage
+                        position: 1
+                        linked_resource_type: Spree::Product
+                        created_at: '2021-09-27T22:00:22.114Z'
+                        updated_at: '2021-09-27T22:00:22.114Z'
+                      relationships:
+                        cms_page:
+                          data:
+                            id: '1'
+                            type: cms_page
+                        linked_resource:
+                          data:
+                            id: '1'
+                            type: product
+                    - id: '2'
+                      type: cms_section
+                      attributes:
+                        name: Id ratione sit nulla voluptates ex laudantium tempora
+                          dolorem.
+                        content: {}
+                        settings:
+                          gutters: No Gutters
+                        fit: Screen
+                        destination:
+                        type: Spree::Cms::Sections::HeroImage
+                        position: 2
+                        linked_resource_type: Spree::Product
+                        created_at: '2021-09-27T22:00:22.116Z'
+                        updated_at: '2021-09-27T22:00:22.116Z'
+                      relationships:
+                        cms_page:
+                          data:
+                            id: '1'
+                            type: cms_page
+                        linked_resource:
+                          data:
+                            id: '1'
+                            type: product
+                    meta:
+                      count: 2
+                      total_count: 2
+                      total_pages: 1
+                    links:
+                      self: http://www.example.com/api/v2/platform/cms_sections?page=1&per_page=&include=&filter=
+                      next: http://www.example.com/api/v2/platform/cms_sections?include=&page=1&per_page=
+                      prev: http://www.example.com/api/v2/platform/cms_sections?include=&page=1&per_page=
+                      last: http://www.example.com/api/v2/platform/cms_sections?include=&page=1&per_page=
+                      first: http://www.example.com/api/v2/platform/cms_sections?include=&page=1&per_page=
+        '401':
+          description: Authentication Failed
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    error: The access token is invalid
+    post:
+      summary: Creates a CMS Section
+      tags:
+      - CMS Sections
+      security:
+      - bearer_auth: []
+      description: Creates a CMS Section
+      operationId: create-cms-section
+      parameters:
+      - name: include
+        in: query
+        description: 'Select which associated resources you would like to fetch, see:
+          <a href="https://jsonapi.org/format/#fetching-includes">https://jsonapi.org/format/#fetching-includes</a>'
+        example: product
+        schema:
+          type: string
+      responses:
+        '201':
+          description: record created
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    data:
+                      id: '1'
+                      type: cms_section
+                      attributes:
+                        name: Recusandae suscipit officiis nam dolorem incidunt facilis.
+                        content:
+                        settings:
+                        fit:
+                        destination:
+                        type:
+                        position: 1
+                        linked_resource_type:
+                        created_at: '2021-09-27T22:00:22.208Z'
+                        updated_at: '2021-09-27T22:00:22.208Z'
+                      relationships:
+                        cms_page:
+                          data:
+                            id: '1'
+                            type: cms_page
+                        linked_resource:
+                          data:
+        '422':
+          description: invalid request
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    error: Name can't be blank and Cms page can't be blank
+                    errors:
+                      name:
+                      - can't be blank
+                      cms_page:
+                      - can't be blank
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/cms_section_params"
+  "/api/v2/platform/cms_sections/{id}":
+    get:
+      summary: Returns a CMS Section
+      tags:
+      - CMS Sections
+      security:
+      - bearer_auth: []
+      description: Returns a CMS Section
+      operationId: show-cms-section
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: include
+        in: query
+        description: 'Select which associated resources you would like to fetch, see:
+          <a href="https://jsonapi.org/format/#fetching-includes">https://jsonapi.org/format/#fetching-includes</a>'
+        example: product
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Record found
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    data:
+                      id: '1'
+                      type: cms_section
+                      attributes:
+                        name: Quas repudiandae sed dicta sapiente repellat.
+                        content: {}
+                        settings:
+                          gutters: No Gutters
+                        fit: Screen
+                        destination:
+                        type: Spree::Cms::Sections::HeroImage
+                        position: 1
+                        linked_resource_type: Spree::Product
+                        created_at: '2021-09-27T22:00:22.273Z'
+                        updated_at: '2021-09-27T22:00:22.273Z'
+                      relationships:
+                        cms_page:
+                          data:
+                            id: '1'
+                            type: cms_page
+                        linked_resource:
+                          data:
+                            id: '1'
+                            type: product
+        '404':
+          description: Record not found
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    error: The resource you were looking for could not be found.
+        '401':
+          description: Authentication Failed
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    error: The access token is invalid
+    put:
+      summary: Updates a CMS Section
+      tags:
+      - CMS Sections
+      security:
+      - bearer_auth: []
+      description: Updates a CMS Section
+      operationId: update-cms-section
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: include
+        in: query
+        description: 'Select which associated resources you would like to fetch, see:
+          <a href="https://jsonapi.org/format/#fetching-includes">https://jsonapi.org/format/#fetching-includes</a>'
+        example: product
+        schema:
+          type: string
+      responses:
+        '200':
+          description: record updated
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    data:
+                      id: '1'
+                      type: cms_section
+                      attributes:
+                        name: Super Hero
+                        content: {}
+                        settings:
+                          gutters: No Gutters
+                        fit: Screen
+                        destination:
+                        type: Spree::Cms::Sections::HeroImage
+                        position: 1
+                        linked_resource_type: Spree::Product
+                        created_at: '2021-09-27T22:00:22.378Z'
+                        updated_at: '2021-09-27T22:00:22.384Z'
+                      relationships:
+                        cms_page:
+                          data:
+                            id: '1'
+                            type: cms_page
+                        linked_resource:
+                          data:
+                            id: '1'
+                            type: product
+        '422':
+          description: invalid request
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    error: Name can't be blank
+                    errors:
+                      name:
+                      - can't be blank
+        '404':
+          description: Record not found
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    error: The resource you were looking for could not be found.
+        '401':
+          description: Authentication Failed
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    error: The access token is invalid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/cms_section_params"
+    delete:
+      summary: Deletes a CMS Section
+      tags:
+      - CMS Sections
+      security:
+      - bearer_auth: []
+      description: Deletes a CMS Section
+      operationId: delete-cms-section
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: Record deleted
+        '404':
+          description: Record not found
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    error: The resource you were looking for could not be found.
+        '401':
+          description: Authentication Failed
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    error: The access token is invalid
   "/api/v2/platform/countries":
     get:
       summary: Returns a list of Countries
@@ -1161,13 +1517,13 @@ paths:
                       attributes:
                         iso_name: UNITED STATES
                         iso: US
-                        iso3: IS48
+                        iso3: IS62
                         name: United States of America
                         numcode: 840
                         states_required: true
-                        updated_at: '2021-09-27T16:52:20.119Z'
+                        updated_at: '2021-09-27T22:00:22.600Z'
                         zipcode_required: true
-                        created_at: '2021-09-27T16:52:20.119Z'
+                        created_at: '2021-09-27T22:00:22.600Z'
                       relationships:
                         states:
                           data: []
@@ -1176,13 +1532,13 @@ paths:
                       attributes:
                         iso_name: ISO_NAME_2
                         iso: I2
-                        iso3: IS49
+                        iso3: IS63
                         name: NAME_2
                         numcode: 840
                         states_required: false
-                        updated_at: '2021-09-27T16:52:20.123Z'
+                        updated_at: '2021-09-27T22:00:22.603Z'
                         zipcode_required: true
-                        created_at: '2021-09-27T16:52:20.123Z'
+                        created_at: '2021-09-27T22:00:22.603Z'
                       relationships:
                         states:
                           data: []
@@ -1191,13 +1547,13 @@ paths:
                       attributes:
                         iso_name: ISO_NAME_3
                         iso: I3
-                        iso3: IS50
+                        iso3: IS64
                         name: NAME_3
                         numcode: 840
                         states_required: false
-                        updated_at: '2021-09-27T16:52:20.124Z'
+                        updated_at: '2021-09-27T22:00:22.604Z'
                         zipcode_required: true
-                        created_at: '2021-09-27T16:52:20.124Z'
+                        created_at: '2021-09-27T22:00:22.604Z'
                       relationships:
                         states:
                           data: []
@@ -1248,13 +1604,13 @@ paths:
                       attributes:
                         iso_name: ISO_NAME_6
                         iso: I6
-                        iso3: IS55
+                        iso3: IS69
                         name: NAME_6
                         numcode: 840
                         states_required: false
-                        updated_at: '2021-09-27T16:52:20.150Z'
+                        updated_at: '2021-09-27T22:00:22.632Z'
                         zipcode_required: true
-                        created_at: '2021-09-27T16:52:20.150Z'
+                        created_at: '2021-09-27T22:00:22.632Z'
                       relationships:
                         states:
                           data: []
@@ -1319,7 +1675,7 @@ paths:
                     - id: '1'
                       type: menu_item
                       attributes:
-                        name: Quos sequi error iste rerum id at officia illo.
+                        name: Sit voluptas non quo distinctio.
                         subtitle:
                         destination:
                         new_window: false
@@ -1329,8 +1685,8 @@ paths:
                         lft: 1
                         rgt: 16
                         depth: 0
-                        created_at: '2021-09-27T16:52:20.191Z'
-                        updated_at: '2021-09-27T16:52:20.485Z'
+                        created_at: '2021-09-27T22:00:22.671Z'
+                        updated_at: '2021-09-27T22:00:22.970Z'
                         link:
                         is_container: true
                         is_root: true
@@ -1376,8 +1732,8 @@ paths:
                         lft: 2
                         rgt: 3
                         depth: 1
-                        created_at: '2021-09-27T16:52:20.230Z'
-                        updated_at: '2021-09-27T16:52:20.232Z'
+                        created_at: '2021-09-27T22:00:22.711Z'
+                        updated_at: '2021-09-27T22:00:22.714Z'
                         link:
                         is_container: false
                         is_root: false
@@ -1413,8 +1769,8 @@ paths:
                         lft: 4
                         rgt: 5
                         depth: 1
-                        created_at: '2021-09-27T16:52:20.270Z'
-                        updated_at: '2021-09-27T16:52:20.272Z'
+                        created_at: '2021-09-27T22:00:22.751Z'
+                        updated_at: '2021-09-27T22:00:22.754Z'
                         link:
                         is_container: false
                         is_root: false
@@ -1450,8 +1806,8 @@ paths:
                         lft: 6
                         rgt: 7
                         depth: 1
-                        created_at: '2021-09-27T16:52:20.309Z'
-                        updated_at: '2021-09-27T16:52:20.311Z'
+                        created_at: '2021-09-27T22:00:22.791Z'
+                        updated_at: '2021-09-27T22:00:22.794Z'
                         link:
                         is_container: false
                         is_root: false
@@ -1487,8 +1843,8 @@ paths:
                         lft: 8
                         rgt: 9
                         depth: 1
-                        created_at: '2021-09-27T16:52:20.348Z'
-                        updated_at: '2021-09-27T16:52:20.358Z'
+                        created_at: '2021-09-27T22:00:22.832Z'
+                        updated_at: '2021-09-27T22:00:22.844Z'
                         link:
                         is_container: false
                         is_root: false
@@ -1524,8 +1880,8 @@ paths:
                         lft: 10
                         rgt: 11
                         depth: 1
-                        created_at: '2021-09-27T16:52:20.397Z'
-                        updated_at: '2021-09-27T16:52:20.399Z'
+                        created_at: '2021-09-27T22:00:22.881Z'
+                        updated_at: '2021-09-27T22:00:22.884Z'
                         link:
                         is_container: false
                         is_root: false
@@ -1561,8 +1917,8 @@ paths:
                         lft: 12
                         rgt: 13
                         depth: 1
-                        created_at: '2021-09-27T16:52:20.437Z'
-                        updated_at: '2021-09-27T16:52:20.440Z'
+                        created_at: '2021-09-27T22:00:22.922Z'
+                        updated_at: '2021-09-27T22:00:22.925Z'
                         link:
                         is_container: false
                         is_root: false
@@ -1598,8 +1954,8 @@ paths:
                         lft: 14
                         rgt: 15
                         depth: 1
-                        created_at: '2021-09-27T16:52:20.478Z'
-                        updated_at: '2021-09-27T16:52:20.480Z'
+                        created_at: '2021-09-27T22:00:22.963Z'
+                        updated_at: '2021-09-27T22:00:22.966Z'
                         link:
                         is_container: false
                         is_root: false
@@ -1678,8 +2034,8 @@ paths:
                         lft: 8
                         rgt: 9
                         depth: 1
-                        created_at: '2021-09-27T16:52:20.949Z'
-                        updated_at: '2021-09-27T16:52:20.951Z'
+                        created_at: '2021-09-27T22:00:23.435Z'
+                        updated_at: '2021-09-27T22:00:23.438Z'
                         link:
                         is_container: false
                         is_root: false
@@ -1765,8 +2121,8 @@ paths:
                         lft: 8
                         rgt: 9
                         depth: 1
-                        created_at: '2021-09-27T16:52:21.261Z'
-                        updated_at: '2021-09-27T16:52:21.263Z'
+                        created_at: '2021-09-27T22:00:23.747Z'
+                        updated_at: '2021-09-27T22:00:23.750Z'
                         link:
                         is_container: false
                         is_root: false
@@ -1848,8 +2204,8 @@ paths:
                         lft: 8
                         rgt: 9
                         depth: 1
-                        created_at: '2021-09-27T16:52:21.757Z'
-                        updated_at: '2021-09-27T16:52:21.770Z'
+                        created_at: '2021-09-27T22:00:24.254Z'
+                        updated_at: '2021-09-27T22:00:24.267Z'
                         link:
                         is_container: false
                         is_root: false
@@ -1974,8 +2330,8 @@ paths:
                         lft: 5
                         rgt: 6
                         depth: 2
-                        created_at: '2021-09-27T16:52:22.938Z'
-                        updated_at: '2021-09-27T16:52:22.952Z'
+                        created_at: '2021-09-27T22:00:25.476Z'
+                        updated_at: '2021-09-27T22:00:25.491Z'
                         link:
                         is_container: false
                         is_root: false
@@ -2067,8 +2423,8 @@ paths:
                         name: Main Menu
                         location: header
                         locale: en
-                        created_at: '2021-09-27T16:52:23.290Z'
-                        updated_at: '2021-09-27T16:52:23.378Z'
+                        created_at: '2021-09-27T22:00:25.831Z'
+                        updated_at: '2021-09-27T22:00:25.919Z'
                       relationships:
                         menu_items:
                           data:
@@ -2084,8 +2440,8 @@ paths:
                         name: Footer Menu
                         location: footer
                         locale: en
-                        created_at: '2021-09-27T16:52:23.295Z'
-                        updated_at: '2021-09-27T16:52:23.459Z'
+                        created_at: '2021-09-27T22:00:25.835Z'
+                        updated_at: '2021-09-27T22:00:26.001Z'
                       relationships:
                         menu_items:
                           data:
@@ -2144,8 +2500,8 @@ paths:
                         name: Main Menu
                         location: header
                         locale: en
-                        created_at: '2021-09-27T16:52:23.671Z'
-                        updated_at: '2021-09-27T16:52:23.675Z'
+                        created_at: '2021-09-27T22:00:26.218Z'
+                        updated_at: '2021-09-27T22:00:26.221Z'
                       relationships:
                         menu_items:
                           data:
@@ -2209,8 +2565,8 @@ paths:
                         name: Main Menu
                         location: header
                         locale: en
-                        created_at: '2021-09-27T16:52:23.696Z'
-                        updated_at: '2021-09-27T16:52:23.699Z'
+                        created_at: '2021-09-27T22:00:26.243Z'
+                        updated_at: '2021-09-27T22:00:26.246Z'
                       relationships:
                         menu_items:
                           data:
@@ -2268,8 +2624,8 @@ paths:
                         name: Main Menu
                         location: header
                         locale: en
-                        created_at: '2021-09-27T16:52:23.734Z'
-                        updated_at: '2021-09-27T16:52:23.737Z'
+                        created_at: '2021-09-27T22:00:26.283Z'
+                        updated_at: '2021-09-27T22:00:26.286Z'
                       relationships:
                         menu_items:
                           data:
@@ -2393,8 +2749,8 @@ paths:
                         name: foo-size-1
                         presentation: Size
                         position: 1
-                        created_at: '2021-09-27T16:52:23.835Z'
-                        updated_at: '2021-09-27T16:52:23.835Z'
+                        created_at: '2021-09-27T22:00:26.390Z'
+                        updated_at: '2021-09-27T22:00:26.390Z'
                         filterable: true
                       relationships:
                         option_values:
@@ -2405,8 +2761,8 @@ paths:
                         name: foo-size-2
                         presentation: Size
                         position: 2
-                        created_at: '2021-09-27T16:52:23.836Z'
-                        updated_at: '2021-09-27T16:52:23.836Z'
+                        created_at: '2021-09-27T22:00:26.391Z'
+                        updated_at: '2021-09-27T22:00:26.391Z'
                         filterable: true
                       relationships:
                         option_values:
@@ -2460,8 +2816,8 @@ paths:
                         name: foo-size-5
                         presentation: Size
                         position: 1
-                        created_at: '2021-09-27T16:52:23.866Z'
-                        updated_at: '2021-09-27T16:52:23.866Z'
+                        created_at: '2021-09-27T22:00:26.423Z'
+                        updated_at: '2021-09-27T22:00:26.423Z'
                         filterable: true
                       relationships:
                         option_values:
@@ -2521,8 +2877,8 @@ paths:
                         name: foo-size-6
                         presentation: Size
                         position: 1
-                        created_at: '2021-09-27T16:52:23.883Z'
-                        updated_at: '2021-09-27T16:52:23.883Z'
+                        created_at: '2021-09-27T22:00:26.447Z'
+                        updated_at: '2021-09-27T22:00:26.447Z'
                         filterable: true
                       relationships:
                         option_values:
@@ -2579,8 +2935,8 @@ paths:
                         name: Size-X
                         presentation: Size
                         position: 1
-                        created_at: '2021-09-27T16:52:23.916Z'
-                        updated_at: '2021-09-27T16:52:23.920Z'
+                        created_at: '2021-09-27T22:00:26.477Z'
+                        updated_at: '2021-09-27T22:00:26.481Z'
                         filterable: true
                       relationships:
                         option_values:
@@ -2698,8 +3054,8 @@ paths:
                         position: 1
                         name: Size-1
                         presentation: S
-                        created_at: '2021-09-27T16:52:23.985Z'
-                        updated_at: '2021-09-27T16:52:23.985Z'
+                        created_at: '2021-09-27T22:00:26.621Z'
+                        updated_at: '2021-09-27T22:00:26.621Z'
                       relationships:
                         option_type:
                           data:
@@ -2711,8 +3067,8 @@ paths:
                         position: 1
                         name: Size-2
                         presentation: S
-                        created_at: '2021-09-27T16:52:23.988Z'
-                        updated_at: '2021-09-27T16:52:23.988Z'
+                        created_at: '2021-09-27T22:00:26.625Z'
+                        updated_at: '2021-09-27T22:00:26.625Z'
                       relationships:
                         option_type:
                           data:
@@ -2767,8 +3123,8 @@ paths:
                         position: 1
                         name: Size-5
                         presentation: S
-                        created_at: '2021-09-27T16:52:24.024Z'
-                        updated_at: '2021-09-27T16:52:24.024Z'
+                        created_at: '2021-09-27T22:00:26.661Z'
+                        updated_at: '2021-09-27T22:00:26.661Z'
                       relationships:
                         option_type:
                           data:
@@ -2827,8 +3183,8 @@ paths:
                         position: 1
                         name: Size-6
                         presentation: S
-                        created_at: '2021-09-27T16:52:24.044Z'
-                        updated_at: '2021-09-27T16:52:24.044Z'
+                        created_at: '2021-09-27T22:00:26.681Z'
+                        updated_at: '2021-09-27T22:00:26.681Z'
                       relationships:
                         option_type:
                           data:
@@ -2886,8 +3242,8 @@ paths:
                         position: 1
                         name: M
                         presentation: S
-                        created_at: '2021-09-27T16:52:24.075Z'
-                        updated_at: '2021-09-27T16:52:24.079Z'
+                        created_at: '2021-09-27T22:00:26.713Z'
+                        updated_at: '2021-09-27T22:00:26.718Z'
                       relationships:
                         option_type:
                           data:
@@ -3009,8 +3365,8 @@ paths:
                         lft: 1
                         rgt: 6
                         description:
-                        created_at: '2021-09-27T16:52:24.156Z'
-                        updated_at: '2021-09-27T16:52:24.251Z'
+                        created_at: '2021-09-27T22:00:26.805Z'
+                        updated_at: '2021-09-27T22:00:26.897Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -3044,8 +3400,8 @@ paths:
                         lft: 2
                         rgt: 3
                         description:
-                        created_at: '2021-09-27T16:52:24.196Z'
-                        updated_at: '2021-09-27T16:52:24.198Z'
+                        created_at: '2021-09-27T22:00:26.845Z'
+                        updated_at: '2021-09-27T22:00:26.847Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -3079,8 +3435,8 @@ paths:
                         lft: 4
                         rgt: 5
                         description:
-                        created_at: '2021-09-27T16:52:24.244Z'
-                        updated_at: '2021-09-27T16:52:24.246Z'
+                        created_at: '2021-09-27T22:00:26.889Z'
+                        updated_at: '2021-09-27T22:00:26.891Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -3157,8 +3513,8 @@ paths:
                         lft: 2
                         rgt: 3
                         description:
-                        created_at: '2021-09-27T16:52:24.394Z'
-                        updated_at: '2021-09-27T16:52:24.397Z'
+                        created_at: '2021-09-27T22:00:27.073Z'
+                        updated_at: '2021-09-27T22:00:27.076Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -3239,8 +3595,8 @@ paths:
                         lft: 2
                         rgt: 3
                         description:
-                        created_at: '2021-09-27T16:52:24.469Z'
-                        updated_at: '2021-09-27T16:52:24.471Z'
+                        created_at: '2021-09-27T22:00:27.142Z'
+                        updated_at: '2021-09-27T22:00:27.144Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -3322,8 +3678,8 @@ paths:
                         lft: 2
                         rgt: 3
                         description:
-                        created_at: '2021-09-27T16:52:24.606Z'
-                        updated_at: '2021-09-27T16:52:24.619Z'
+                        created_at: '2021-09-27T22:00:27.287Z'
+                        updated_at: '2021-09-27T22:00:27.301Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -3458,9 +3814,9 @@ paths:
                     - id: '1'
                       type: user
                       attributes:
-                        email: sharolyn@bradtke.name
-                        created_at: '2021-09-27T16:52:24.912Z'
-                        updated_at: '2021-09-27T16:52:24.912Z'
+                        email: adele@kesslercassin.co.uk
+                        created_at: '2021-09-27T22:00:27.600Z'
+                        updated_at: '2021-09-27T22:00:27.600Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -3472,9 +3828,9 @@ paths:
                     - id: '2'
                       type: user
                       attributes:
-                        email: francis@nikolaus.ca
-                        created_at: '2021-09-27T16:52:24.916Z'
-                        updated_at: '2021-09-27T16:52:24.916Z'
+                        email: rachele.gorczany@willms.ca
+                        created_at: '2021-09-27T22:00:27.603Z'
+                        updated_at: '2021-09-27T22:00:27.603Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -3486,9 +3842,9 @@ paths:
                     - id: '3'
                       type: user
                       attributes:
-                        email: venice@pagac.co.uk
-                        created_at: '2021-09-27T16:52:24.917Z'
-                        updated_at: '2021-09-27T16:52:24.917Z'
+                        email: keri@hoegerwolf.info
+                        created_at: '2021-09-27T22:00:27.604Z'
+                        updated_at: '2021-09-27T22:00:27.604Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -3543,9 +3899,9 @@ paths:
                       id: '2'
                       type: user
                       attributes:
-                        email: julianne@greenholt.us
-                        created_at: '2021-09-27T16:52:24.967Z'
-                        updated_at: '2021-09-27T16:52:24.967Z'
+                        email: elyse@cremin.co.uk
+                        created_at: '2021-09-27T22:00:27.645Z'
+                        updated_at: '2021-09-27T22:00:27.645Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -3604,9 +3960,9 @@ paths:
                       id: '2'
                       type: user
                       attributes:
-                        email: elwood@fadel.name
-                        created_at: '2021-09-27T16:52:24.994Z'
-                        updated_at: '2021-09-27T16:52:24.994Z'
+                        email: roni_bosco@beahan.biz
+                        created_at: '2021-09-27T22:00:27.673Z'
+                        updated_at: '2021-09-27T22:00:27.673Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -3665,8 +4021,8 @@ paths:
                       type: user
                       attributes:
                         email: john@example.com
-                        created_at: '2021-09-27T16:52:25.036Z'
-                        updated_at: '2021-09-27T16:52:25.040Z'
+                        created_at: '2021-09-27T22:00:27.720Z'
+                        updated_at: '2021-09-27T22:00:27.725Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -3780,8 +4136,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-09-27T16:52:25.282Z'
-                        updated_at: '2021-09-27T16:52:25.282Z'
+                        created_at: '2021-09-27T22:00:27.894Z'
+                        updated_at: '2021-09-27T22:00:27.894Z'
                         price: '19.99'
                         total: '19.99'
                         display_price: "$19.99"
@@ -3795,8 +4151,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-09-27T16:52:25.310Z'
-                        updated_at: '2021-09-27T16:52:25.310Z'
+                        created_at: '2021-09-27T22:00:27.921Z'
+                        updated_at: '2021-09-27T22:00:27.921Z'
                         price: '19.99'
                         total: '19.99'
                         display_price: "$19.99"
@@ -3810,8 +4166,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-09-27T16:52:25.336Z'
-                        updated_at: '2021-09-27T16:52:25.336Z'
+                        created_at: '2021-09-27T22:00:27.947Z'
+                        updated_at: '2021-09-27T22:00:27.947Z'
                         price: '19.99'
                         total: '19.99'
                         display_price: "$19.99"
@@ -3825,8 +4181,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-09-27T16:52:25.362Z'
-                        updated_at: '2021-09-27T16:52:25.362Z'
+                        created_at: '2021-09-27T22:00:27.974Z'
+                        updated_at: '2021-09-27T22:00:27.974Z'
                         price: '19.99'
                         total: '19.99'
                         display_price: "$19.99"
@@ -3883,8 +4239,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-09-27T16:52:25.588Z'
-                        updated_at: '2021-09-27T16:52:25.588Z'
+                        created_at: '2021-09-27T22:00:28.192Z'
+                        updated_at: '2021-09-27T22:00:28.192Z'
                         price: '19.99'
                         total: '19.99'
                         display_price: "$19.99"
@@ -3950,8 +4306,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-09-27T16:52:25.714Z'
-                        updated_at: '2021-09-27T16:52:25.714Z'
+                        created_at: '2021-09-27T22:00:28.319Z'
+                        updated_at: '2021-09-27T22:00:28.319Z'
                         price: '19.99'
                         total: '19.99'
                         display_price: "$19.99"
@@ -4011,8 +4367,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 3
-                        created_at: '2021-09-27T16:52:25.915Z'
-                        updated_at: '2021-09-27T16:52:25.920Z'
+                        created_at: '2021-09-27T22:00:28.523Z'
+                        updated_at: '2021-09-27T22:00:28.527Z'
                         price: '19.99'
                         total: '59.97'
                         display_price: "$19.99"
@@ -4135,9 +4491,9 @@ paths:
                         name: Black Friday
                         is_private: true
                         is_default: false
-                        created_at: '2021-09-27T16:52:26.337Z'
-                        updated_at: '2021-09-27T16:52:26.337Z'
-                        token: jj13MGanYgMvEEs3CYsmt5ba
+                        created_at: '2021-09-27T22:00:29.015Z'
+                        updated_at: '2021-09-27T22:00:29.015Z'
+                        token: yKswZxfaUEveH7vRUEpeY1xn
                         variant_included: false
                       relationships:
                         wished_items:
@@ -4152,9 +4508,9 @@ paths:
                         name: Birthday
                         is_private: true
                         is_default: false
-                        created_at: '2021-09-27T16:52:26.338Z'
-                        updated_at: '2021-09-27T16:52:26.338Z'
-                        token: ameCHAkBPam2E9xGnWRZpgUm
+                        created_at: '2021-09-27T22:00:29.016Z'
+                        updated_at: '2021-09-27T22:00:29.016Z'
+                        token: m6XR8TV44mfUvTyJS67nkafK
                         variant_included: false
                       relationships:
                         wished_items:
@@ -4212,9 +4568,9 @@ paths:
                         name: Wishlist_26
                         is_private: true
                         is_default: false
-                        created_at: '2021-09-27T16:52:26.670Z'
-                        updated_at: '2021-09-27T16:52:26.670Z'
-                        token: uA6R4QmB6cUDN4TJyUd7nw6r
+                        created_at: '2021-09-27T22:00:29.288Z'
+                        updated_at: '2021-09-27T22:00:29.288Z'
+                        token: 4baVLBWa8DnEnG9cUG4X5LDT
                         variant_included: false
                       relationships:
                         wished_items:
@@ -4274,9 +4630,9 @@ paths:
                         name: My Wishlist
                         is_private: true
                         is_default: false
-                        created_at: '2021-09-27T16:52:26.696Z'
-                        updated_at: '2021-09-27T16:52:26.696Z'
-                        token: td4SM5WV7R6deHr6kMQZnvLw
+                        created_at: '2021-09-27T22:00:29.311Z'
+                        updated_at: '2021-09-27T22:00:29.311Z'
+                        token: XzJvyAZy979ow5t1YrGPvrKb
                         variant_included: false
                       relationships:
                         wished_items:
@@ -4333,9 +4689,9 @@ paths:
                         name: My Super Wishlist
                         is_private: true
                         is_default: false
-                        created_at: '2021-09-27T16:52:26.733Z'
-                        updated_at: '2021-09-27T16:52:26.738Z'
-                        token: HpbexEzk3w3E1dhLikwDezKA
+                        created_at: '2021-09-27T22:00:29.348Z'
+                        updated_at: '2021-09-27T22:00:29.352Z'
+                        token: aBdXs8jW9jVgUCQB7Td96T4D
                         variant_included: false
                       relationships:
                         wished_items:
@@ -4414,6 +4770,8 @@ tags:
 - name: Addresses
 - name: Classifications
 - name: Countries
+- name: CMS Pages
+- name: CMS Sections
 - name: Menu Items
 - name: Menus
 - name: Option Types
@@ -4594,6 +4952,8 @@ components:
           type: string
         destination:
           type: string
+        menu_id:
+          type: string
         new_window:
           type: boolean
         item_type:
@@ -4604,6 +4964,7 @@ components:
           type: integer
       required:
       - name
+      - menu_id
     menu_item_reposition_params:
       type: object
       properties:
@@ -4612,16 +4973,22 @@ components:
         new_position_idx:
           type: integer
       required:
-      - name
+      - new_parent_id
+      - new_position_idx
     wishlist_params:
       type: object
       properties:
-        user_id:
-          type: string
         name:
           type: string
+        user_id:
+          type: string
+        is_default:
+          type: boolean
+        is_private:
+          type: boolean
       required:
       - name
+      - user_id
     wished_item_params:
       type: object
       properties:
@@ -4631,8 +4998,49 @@ components:
           type: string
         quantity:
           type: integer
+          description: Must be an integer greater than 0
+      required:
+      - wishlist_id
+      - variant_id
+      - quantity
+    cms_page_params:
+      type: object
+      properties:
+        title:
+          type: string
+        meta_title:
+          type: string
+        content:
+          type: string
+        meta_description:
+          type: string
+        visible:
+          type: string
+        slug:
+          type: string
+        locale:
+          type: string
+      required:
+      - title
+      - locale
+    cms_section_params:
+      type: object
+      properties:
+        name:
+          type: string
+        cms_page_id:
+          type: string
+        content:
+          type: object
+        settings:
+          type: object
+        fit:
+          type: string
+        destination:
+          type: string
       required:
       - name
+      - cms_page_id
     resources_list:
       type: object
       properties:

--- a/api/docs/v2/platform/index.yaml
+++ b/api/docs/v2/platform/index.yaml
@@ -63,8 +63,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-09-21T20:47:27.913Z'
-                        updated_at: '2021-09-21T20:47:27.913Z'
+                        created_at: '2021-09-27T16:52:18.256Z'
+                        updated_at: '2021-09-27T16:52:18.256Z'
                         deleted_at:
                         label:
                       relationships:
@@ -91,8 +91,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-09-21T20:47:27.915Z'
-                        updated_at: '2021-09-21T20:47:27.915Z'
+                        created_at: '2021-09-27T16:52:18.259Z'
+                        updated_at: '2021-09-27T16:52:18.259Z'
                         deleted_at:
                         label:
                       relationships:
@@ -162,8 +162,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-09-21T20:47:28.023Z'
-                        updated_at: '2021-09-21T20:47:28.023Z'
+                        created_at: '2021-09-27T16:52:18.371Z'
+                        updated_at: '2021-09-27T16:52:18.371Z'
                         deleted_at:
                         label:
                       relationships:
@@ -253,8 +253,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-09-21T20:47:28.044Z'
-                        updated_at: '2021-09-21T20:47:28.044Z'
+                        created_at: '2021-09-27T16:52:18.392Z'
+                        updated_at: '2021-09-27T16:52:18.392Z'
                         deleted_at:
                         label:
                       relationships:
@@ -327,8 +327,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-09-21T20:47:28.083Z'
-                        updated_at: '2021-09-21T20:47:28.089Z'
+                        created_at: '2021-09-27T16:52:18.421Z'
+                        updated_at: '2021-09-27T16:52:18.426Z'
                         deleted_at:
                         label:
                       relationships:
@@ -455,8 +455,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-09-21T20:47:28.323Z'
-                        updated_at: '2021-09-21T20:47:28.323Z'
+                        created_at: '2021-09-27T16:52:18.664Z'
+                        updated_at: '2021-09-27T16:52:18.664Z'
                       relationships:
                         product:
                           data:
@@ -470,8 +470,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-09-21T20:47:28.404Z'
-                        updated_at: '2021-09-21T20:47:28.404Z'
+                        created_at: '2021-09-27T16:52:18.731Z'
+                        updated_at: '2021-09-27T16:52:18.731Z'
                       relationships:
                         product:
                           data:
@@ -528,8 +528,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-09-21T20:47:28.653Z'
-                        updated_at: '2021-09-21T20:47:28.653Z'
+                        created_at: '2021-09-27T16:52:18.993Z'
+                        updated_at: '2021-09-27T16:52:18.993Z'
                       relationships:
                         product:
                           data:
@@ -592,8 +592,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-09-21T20:47:28.756Z'
-                        updated_at: '2021-09-21T20:47:28.756Z'
+                        created_at: '2021-09-27T16:52:19.085Z'
+                        updated_at: '2021-09-27T16:52:19.085Z'
                       relationships:
                         product:
                           data:
@@ -653,8 +653,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-09-21T20:47:28.939Z'
-                        updated_at: '2021-09-21T20:47:28.939Z'
+                        created_at: '2021-09-27T16:52:19.279Z'
+                        updated_at: '2021-09-27T16:52:19.279Z'
                       relationships:
                         product:
                           data:
@@ -764,8 +764,8 @@ paths:
                       type: classification
                       attributes:
                         position: 2
-                        created_at: '2021-09-21T20:47:29.407Z'
-                        updated_at: '2021-09-21T20:47:29.417Z'
+                        created_at: '2021-09-27T16:52:19.727Z'
+                        updated_at: '2021-09-27T16:52:19.738Z'
                       relationships:
                         product:
                           data:
@@ -805,6 +805,339 @@ paths:
           application/json:
             schema:
               "$ref": "#/components/schemas/classification_params"
+  "/api/v2/platform/cms_pages":
+    get:
+      summary: Returns a list of CMS Pages
+      tags:
+      - CMS Pages
+      security:
+      - bearer_auth: []
+      description: Returns a list of CMS Pages
+      operationId: cms-pages-list
+      parameters:
+      - name: page
+        in: query
+        example: 1
+        schema:
+          type: integer
+      - name: per_page
+        in: query
+        example: 50
+        schema:
+          type: integer
+      - name: include
+        in: query
+        description: 'Select which associated resources you would like to fetch, see:
+          <a href="https://jsonapi.org/format/#fetching-includes">https://jsonapi.org/format/#fetching-includes</a>'
+        example: cms_sections
+        schema:
+          type: string
+      - name: filter
+        in: query
+        description: ''
+        example: type=homepage
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Records returned
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    data:
+                    - id: '1'
+                      type: cms_page
+                      attributes:
+                        title: Eum incidunt deserunt blanditiis quam ipsa enim necessitatibus
+                          mollitia.
+                        meta_title:
+                        content:
+                        meta_description:
+                        visible: true
+                        slug: eum-incidunt-deserunt-blanditiis-quam-ipsa-enim-necessitatibus-mollitia
+                        type: Spree::Cms::Pages::StandardPage
+                        locale: en
+                        deleted_at:
+                        created_at: '2021-09-27T16:52:19.940Z'
+                        updated_at: '2021-09-27T16:52:19.940Z'
+                      relationships:
+                        cms_sections:
+                          data: []
+                    - id: '2'
+                      type: cms_page
+                      attributes:
+                        title: Animi quis eligendi et corporis officia soluta nisi.
+                        meta_title:
+                        content:
+                        meta_description:
+                        visible: true
+                        slug: animi-quis-eligendi-et-corporis-officia-soluta-nisi
+                        type: Spree::Cms::Pages::StandardPage
+                        locale: en
+                        deleted_at:
+                        created_at: '2021-09-27T16:52:19.942Z'
+                        updated_at: '2021-09-27T16:52:19.942Z'
+                      relationships:
+                        cms_sections:
+                          data: []
+                    meta:
+                      count: 2
+                      total_count: 2
+                      total_pages: 1
+                    links:
+                      self: http://www.example.com/api/v2/platform/cms_pages?page=1&per_page=&include=&filter=
+                      next: http://www.example.com/api/v2/platform/cms_pages?include=&page=1&per_page=
+                      prev: http://www.example.com/api/v2/platform/cms_pages?include=&page=1&per_page=
+                      last: http://www.example.com/api/v2/platform/cms_pages?include=&page=1&per_page=
+                      first: http://www.example.com/api/v2/platform/cms_pages?include=&page=1&per_page=
+        '401':
+          description: Authentication Failed
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    error: The access token is invalid
+    post:
+      summary: Creates a CMS Page
+      tags:
+      - CMS Pages
+      security:
+      - bearer_auth: []
+      description: Creates a CMS Page
+      operationId: create-cms-page
+      parameters:
+      - name: include
+        in: query
+        description: 'Select which associated resources you would like to fetch, see:
+          <a href="https://jsonapi.org/format/#fetching-includes">https://jsonapi.org/format/#fetching-includes</a>'
+        example: cms_sections
+        schema:
+          type: string
+      responses:
+        '201':
+          description: record created
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    data:
+                      id: '1'
+                      type: cms_page
+                      attributes:
+                        title: Possimus autem ipsam recusandae architecto consequuntur
+                          dolorum tenetur voluptates.
+                        meta_title:
+                        content:
+                        meta_description:
+                        visible: true
+                        slug: possimus-autem-ipsam-recusandae-architecto-consequuntur-dolorum-tenetur-voluptates
+                        type:
+                        locale: en
+                        deleted_at:
+                        created_at: '2021-09-27T16:52:19.983Z'
+                        updated_at: '2021-09-27T16:52:19.983Z'
+                      relationships:
+                        cms_sections:
+                          data: []
+        '422':
+          description: invalid request
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    error: Title can't be blank and Locale can't be blank
+                    errors:
+                      title:
+                      - can't be blank
+                      locale:
+                      - can't be blank
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/cms_page_params"
+  "/api/v2/platform/cms_pages/{id}":
+    get:
+      summary: Returns a CMS Page
+      tags:
+      - CMS Pages
+      security:
+      - bearer_auth: []
+      description: Returns a CMS Page
+      operationId: show-cms-page
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: include
+        in: query
+        description: 'Select which associated resources you would like to fetch, see:
+          <a href="https://jsonapi.org/format/#fetching-includes">https://jsonapi.org/format/#fetching-includes</a>'
+        example: cms_sections
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Record found
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    data:
+                      id: '1'
+                      type: cms_page
+                      attributes:
+                        title: Officiis odit deserunt ipsa similique consequuntur
+                          neque voluptates.
+                        meta_title:
+                        content:
+                        meta_description:
+                        visible: true
+                        slug: officiis-odit-deserunt-ipsa-similique-consequuntur-neque-voluptates
+                        type: Spree::Cms::Pages::StandardPage
+                        locale: en
+                        deleted_at:
+                        created_at: '2021-09-27T16:52:20.004Z'
+                        updated_at: '2021-09-27T16:52:20.004Z'
+                      relationships:
+                        cms_sections:
+                          data: []
+        '404':
+          description: Record not found
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    error: The resource you were looking for could not be found.
+        '401':
+          description: Authentication Failed
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    error: The access token is invalid
+    put:
+      summary: Updates a CMS Page
+      tags:
+      - CMS Pages
+      security:
+      - bearer_auth: []
+      description: Updates a CMS Page
+      operationId: update-cms-page
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: include
+        in: query
+        description: 'Select which associated resources you would like to fetch, see:
+          <a href="https://jsonapi.org/format/#fetching-includes">https://jsonapi.org/format/#fetching-includes</a>'
+        example: cms_sections
+        schema:
+          type: string
+      responses:
+        '200':
+          description: record updated
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    data:
+                      id: '1'
+                      type: cms_page
+                      attributes:
+                        title: My Super Page
+                        meta_title:
+                        content:
+                        meta_description:
+                        visible: true
+                        slug: suscipit-rem-blanditiis-corporis-placeat-exercitationem
+                        type: Spree::Cms::Pages::StandardPage
+                        locale: en
+                        deleted_at:
+                        created_at: '2021-09-27T16:52:20.036Z'
+                        updated_at: '2021-09-27T16:52:20.042Z'
+                      relationships:
+                        cms_sections:
+                          data: []
+        '422':
+          description: invalid request
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    error: Title can't be blank
+                    errors:
+                      title:
+                      - can't be blank
+        '404':
+          description: Record not found
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    error: The resource you were looking for could not be found.
+        '401':
+          description: Authentication Failed
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    error: The access token is invalid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/cms_page_params"
+    delete:
+      summary: Deletes a CMS Page
+      tags:
+      - CMS Pages
+      security:
+      - bearer_auth: []
+      description: Deletes a CMS Page
+      operationId: delete-cms-page
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: Record deleted
+        '404':
+          description: Record not found
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    error: The resource you were looking for could not be found.
+        '401':
+          description: Authentication Failed
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    error: The access token is invalid
   "/api/v2/platform/countries":
     get:
       summary: Returns a list of Countries
@@ -828,13 +1161,13 @@ paths:
                       attributes:
                         iso_name: UNITED STATES
                         iso: US
-                        iso3: IS34
+                        iso3: IS48
                         name: United States of America
                         numcode: 840
                         states_required: true
-                        updated_at: '2021-09-21T20:47:29.609Z'
+                        updated_at: '2021-09-27T16:52:20.119Z'
                         zipcode_required: true
-                        created_at: '2021-09-21T20:47:29.609Z'
+                        created_at: '2021-09-27T16:52:20.119Z'
                       relationships:
                         states:
                           data: []
@@ -843,13 +1176,13 @@ paths:
                       attributes:
                         iso_name: ISO_NAME_2
                         iso: I2
-                        iso3: IS35
+                        iso3: IS49
                         name: NAME_2
                         numcode: 840
                         states_required: false
-                        updated_at: '2021-09-21T20:47:29.613Z'
+                        updated_at: '2021-09-27T16:52:20.123Z'
                         zipcode_required: true
-                        created_at: '2021-09-21T20:47:29.613Z'
+                        created_at: '2021-09-27T16:52:20.123Z'
                       relationships:
                         states:
                           data: []
@@ -858,13 +1191,13 @@ paths:
                       attributes:
                         iso_name: ISO_NAME_3
                         iso: I3
-                        iso3: IS36
+                        iso3: IS50
                         name: NAME_3
                         numcode: 840
                         states_required: false
-                        updated_at: '2021-09-21T20:47:29.613Z'
+                        updated_at: '2021-09-27T16:52:20.124Z'
                         zipcode_required: true
-                        created_at: '2021-09-21T20:47:29.613Z'
+                        created_at: '2021-09-27T16:52:20.124Z'
                       relationships:
                         states:
                           data: []
@@ -915,13 +1248,13 @@ paths:
                       attributes:
                         iso_name: ISO_NAME_6
                         iso: I6
-                        iso3: IS41
+                        iso3: IS55
                         name: NAME_6
                         numcode: 840
                         states_required: false
-                        updated_at: '2021-09-21T20:47:29.642Z'
+                        updated_at: '2021-09-27T16:52:20.150Z'
                         zipcode_required: true
-                        created_at: '2021-09-21T20:47:29.642Z'
+                        created_at: '2021-09-27T16:52:20.150Z'
                       relationships:
                         states:
                           data: []
@@ -986,7 +1319,7 @@ paths:
                     - id: '1'
                       type: menu_item
                       attributes:
-                        name: Possimus deserunt similique asperiores eveniet.
+                        name: Quos sequi error iste rerum id at officia illo.
                         subtitle:
                         destination:
                         new_window: false
@@ -996,8 +1329,8 @@ paths:
                         lft: 1
                         rgt: 16
                         depth: 0
-                        created_at: '2021-09-21T20:47:29.680Z'
-                        updated_at: '2021-09-21T20:47:29.972Z'
+                        created_at: '2021-09-27T16:52:20.191Z'
+                        updated_at: '2021-09-27T16:52:20.485Z'
                         link:
                         is_container: true
                         is_root: true
@@ -1043,8 +1376,8 @@ paths:
                         lft: 2
                         rgt: 3
                         depth: 1
-                        created_at: '2021-09-21T20:47:29.721Z'
-                        updated_at: '2021-09-21T20:47:29.724Z'
+                        created_at: '2021-09-27T16:52:20.230Z'
+                        updated_at: '2021-09-27T16:52:20.232Z'
                         link:
                         is_container: false
                         is_root: false
@@ -1080,8 +1413,8 @@ paths:
                         lft: 4
                         rgt: 5
                         depth: 1
-                        created_at: '2021-09-21T20:47:29.761Z'
-                        updated_at: '2021-09-21T20:47:29.764Z'
+                        created_at: '2021-09-27T16:52:20.270Z'
+                        updated_at: '2021-09-27T16:52:20.272Z'
                         link:
                         is_container: false
                         is_root: false
@@ -1117,8 +1450,8 @@ paths:
                         lft: 6
                         rgt: 7
                         depth: 1
-                        created_at: '2021-09-21T20:47:29.800Z'
-                        updated_at: '2021-09-21T20:47:29.802Z'
+                        created_at: '2021-09-27T16:52:20.309Z'
+                        updated_at: '2021-09-27T16:52:20.311Z'
                         link:
                         is_container: false
                         is_root: false
@@ -1154,8 +1487,8 @@ paths:
                         lft: 8
                         rgt: 9
                         depth: 1
-                        created_at: '2021-09-21T20:47:29.838Z'
-                        updated_at: '2021-09-21T20:47:29.840Z'
+                        created_at: '2021-09-27T16:52:20.348Z'
+                        updated_at: '2021-09-27T16:52:20.358Z'
                         link:
                         is_container: false
                         is_root: false
@@ -1191,8 +1524,8 @@ paths:
                         lft: 10
                         rgt: 11
                         depth: 1
-                        created_at: '2021-09-21T20:47:29.877Z'
-                        updated_at: '2021-09-21T20:47:29.880Z'
+                        created_at: '2021-09-27T16:52:20.397Z'
+                        updated_at: '2021-09-27T16:52:20.399Z'
                         link:
                         is_container: false
                         is_root: false
@@ -1228,8 +1561,8 @@ paths:
                         lft: 12
                         rgt: 13
                         depth: 1
-                        created_at: '2021-09-21T20:47:29.917Z'
-                        updated_at: '2021-09-21T20:47:29.920Z'
+                        created_at: '2021-09-27T16:52:20.437Z'
+                        updated_at: '2021-09-27T16:52:20.440Z'
                         link:
                         is_container: false
                         is_root: false
@@ -1265,8 +1598,8 @@ paths:
                         lft: 14
                         rgt: 15
                         depth: 1
-                        created_at: '2021-09-21T20:47:29.957Z'
-                        updated_at: '2021-09-21T20:47:29.959Z'
+                        created_at: '2021-09-27T16:52:20.478Z'
+                        updated_at: '2021-09-27T16:52:20.480Z'
                         link:
                         is_container: false
                         is_root: false
@@ -1345,8 +1678,8 @@ paths:
                         lft: 8
                         rgt: 9
                         depth: 1
-                        created_at: '2021-09-21T20:47:30.427Z'
-                        updated_at: '2021-09-21T20:47:30.429Z'
+                        created_at: '2021-09-27T16:52:20.949Z'
+                        updated_at: '2021-09-27T16:52:20.951Z'
                         link:
                         is_container: false
                         is_root: false
@@ -1432,8 +1765,8 @@ paths:
                         lft: 8
                         rgt: 9
                         depth: 1
-                        created_at: '2021-09-21T20:47:30.745Z'
-                        updated_at: '2021-09-21T20:47:30.748Z'
+                        created_at: '2021-09-27T16:52:21.261Z'
+                        updated_at: '2021-09-27T16:52:21.263Z'
                         link:
                         is_container: false
                         is_root: false
@@ -1515,8 +1848,8 @@ paths:
                         lft: 8
                         rgt: 9
                         depth: 1
-                        created_at: '2021-09-21T20:47:31.244Z'
-                        updated_at: '2021-09-21T20:47:31.257Z'
+                        created_at: '2021-09-27T16:52:21.757Z'
+                        updated_at: '2021-09-27T16:52:21.770Z'
                         link:
                         is_container: false
                         is_root: false
@@ -1641,8 +1974,8 @@ paths:
                         lft: 5
                         rgt: 6
                         depth: 2
-                        created_at: '2021-09-21T20:47:32.441Z'
-                        updated_at: '2021-09-21T20:47:32.456Z'
+                        created_at: '2021-09-27T16:52:22.938Z'
+                        updated_at: '2021-09-27T16:52:22.952Z'
                         link:
                         is_container: false
                         is_root: false
@@ -1734,8 +2067,8 @@ paths:
                         name: Main Menu
                         location: header
                         locale: en
-                        created_at: '2021-09-21T20:47:32.789Z'
-                        updated_at: '2021-09-21T20:47:32.878Z'
+                        created_at: '2021-09-27T16:52:23.290Z'
+                        updated_at: '2021-09-27T16:52:23.378Z'
                       relationships:
                         menu_items:
                           data:
@@ -1751,8 +2084,8 @@ paths:
                         name: Footer Menu
                         location: footer
                         locale: en
-                        created_at: '2021-09-21T20:47:32.794Z'
-                        updated_at: '2021-09-21T20:47:32.961Z'
+                        created_at: '2021-09-27T16:52:23.295Z'
+                        updated_at: '2021-09-27T16:52:23.459Z'
                       relationships:
                         menu_items:
                           data:
@@ -1811,8 +2144,8 @@ paths:
                         name: Main Menu
                         location: header
                         locale: en
-                        created_at: '2021-09-21T20:47:33.175Z'
-                        updated_at: '2021-09-21T20:47:33.179Z'
+                        created_at: '2021-09-27T16:52:23.671Z'
+                        updated_at: '2021-09-27T16:52:23.675Z'
                       relationships:
                         menu_items:
                           data:
@@ -1876,8 +2209,8 @@ paths:
                         name: Main Menu
                         location: header
                         locale: en
-                        created_at: '2021-09-21T20:47:33.200Z'
-                        updated_at: '2021-09-21T20:47:33.203Z'
+                        created_at: '2021-09-27T16:52:23.696Z'
+                        updated_at: '2021-09-27T16:52:23.699Z'
                       relationships:
                         menu_items:
                           data:
@@ -1935,8 +2268,8 @@ paths:
                         name: Main Menu
                         location: header
                         locale: en
-                        created_at: '2021-09-21T20:47:33.239Z'
-                        updated_at: '2021-09-21T20:47:33.242Z'
+                        created_at: '2021-09-27T16:52:23.734Z'
+                        updated_at: '2021-09-27T16:52:23.737Z'
                       relationships:
                         menu_items:
                           data:
@@ -2060,8 +2393,8 @@ paths:
                         name: foo-size-1
                         presentation: Size
                         position: 1
-                        created_at: '2021-09-21T20:47:33.339Z'
-                        updated_at: '2021-09-21T20:47:33.339Z'
+                        created_at: '2021-09-27T16:52:23.835Z'
+                        updated_at: '2021-09-27T16:52:23.835Z'
                         filterable: true
                       relationships:
                         option_values:
@@ -2072,8 +2405,8 @@ paths:
                         name: foo-size-2
                         presentation: Size
                         position: 2
-                        created_at: '2021-09-21T20:47:33.340Z'
-                        updated_at: '2021-09-21T20:47:33.340Z'
+                        created_at: '2021-09-27T16:52:23.836Z'
+                        updated_at: '2021-09-27T16:52:23.836Z'
                         filterable: true
                       relationships:
                         option_values:
@@ -2127,8 +2460,8 @@ paths:
                         name: foo-size-5
                         presentation: Size
                         position: 1
-                        created_at: '2021-09-21T20:47:33.369Z'
-                        updated_at: '2021-09-21T20:47:33.369Z'
+                        created_at: '2021-09-27T16:52:23.866Z'
+                        updated_at: '2021-09-27T16:52:23.866Z'
                         filterable: true
                       relationships:
                         option_values:
@@ -2188,8 +2521,8 @@ paths:
                         name: foo-size-6
                         presentation: Size
                         position: 1
-                        created_at: '2021-09-21T20:47:33.387Z'
-                        updated_at: '2021-09-21T20:47:33.387Z'
+                        created_at: '2021-09-27T16:52:23.883Z'
+                        updated_at: '2021-09-27T16:52:23.883Z'
                         filterable: true
                       relationships:
                         option_values:
@@ -2246,8 +2579,8 @@ paths:
                         name: Size-X
                         presentation: Size
                         position: 1
-                        created_at: '2021-09-21T20:47:33.421Z'
-                        updated_at: '2021-09-21T20:47:33.425Z'
+                        created_at: '2021-09-27T16:52:23.916Z'
+                        updated_at: '2021-09-27T16:52:23.920Z'
                         filterable: true
                       relationships:
                         option_values:
@@ -2365,8 +2698,8 @@ paths:
                         position: 1
                         name: Size-1
                         presentation: S
-                        created_at: '2021-09-21T20:47:33.493Z'
-                        updated_at: '2021-09-21T20:47:33.493Z'
+                        created_at: '2021-09-27T16:52:23.985Z'
+                        updated_at: '2021-09-27T16:52:23.985Z'
                       relationships:
                         option_type:
                           data:
@@ -2378,8 +2711,8 @@ paths:
                         position: 1
                         name: Size-2
                         presentation: S
-                        created_at: '2021-09-21T20:47:33.496Z'
-                        updated_at: '2021-09-21T20:47:33.496Z'
+                        created_at: '2021-09-27T16:52:23.988Z'
+                        updated_at: '2021-09-27T16:52:23.988Z'
                       relationships:
                         option_type:
                           data:
@@ -2434,8 +2767,8 @@ paths:
                         position: 1
                         name: Size-5
                         presentation: S
-                        created_at: '2021-09-21T20:47:33.595Z'
-                        updated_at: '2021-09-21T20:47:33.595Z'
+                        created_at: '2021-09-27T16:52:24.024Z'
+                        updated_at: '2021-09-27T16:52:24.024Z'
                       relationships:
                         option_type:
                           data:
@@ -2494,8 +2827,8 @@ paths:
                         position: 1
                         name: Size-6
                         presentation: S
-                        created_at: '2021-09-21T20:47:33.616Z'
-                        updated_at: '2021-09-21T20:47:33.616Z'
+                        created_at: '2021-09-27T16:52:24.044Z'
+                        updated_at: '2021-09-27T16:52:24.044Z'
                       relationships:
                         option_type:
                           data:
@@ -2553,8 +2886,8 @@ paths:
                         position: 1
                         name: M
                         presentation: S
-                        created_at: '2021-09-21T20:47:33.647Z'
-                        updated_at: '2021-09-21T20:47:33.652Z'
+                        created_at: '2021-09-27T16:52:24.075Z'
+                        updated_at: '2021-09-27T16:52:24.079Z'
                       relationships:
                         option_type:
                           data:
@@ -2676,8 +3009,8 @@ paths:
                         lft: 1
                         rgt: 6
                         description:
-                        created_at: '2021-09-21T20:47:33.731Z'
-                        updated_at: '2021-09-21T20:47:33.825Z'
+                        created_at: '2021-09-27T16:52:24.156Z'
+                        updated_at: '2021-09-27T16:52:24.251Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -2711,8 +3044,8 @@ paths:
                         lft: 2
                         rgt: 3
                         description:
-                        created_at: '2021-09-21T20:47:33.777Z'
-                        updated_at: '2021-09-21T20:47:33.779Z'
+                        created_at: '2021-09-27T16:52:24.196Z'
+                        updated_at: '2021-09-27T16:52:24.198Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -2746,8 +3079,8 @@ paths:
                         lft: 4
                         rgt: 5
                         description:
-                        created_at: '2021-09-21T20:47:33.818Z'
-                        updated_at: '2021-09-21T20:47:33.820Z'
+                        created_at: '2021-09-27T16:52:24.244Z'
+                        updated_at: '2021-09-27T16:52:24.246Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -2824,8 +3157,8 @@ paths:
                         lft: 2
                         rgt: 3
                         description:
-                        created_at: '2021-09-21T20:47:33.967Z'
-                        updated_at: '2021-09-21T20:47:33.970Z'
+                        created_at: '2021-09-27T16:52:24.394Z'
+                        updated_at: '2021-09-27T16:52:24.397Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -2906,8 +3239,8 @@ paths:
                         lft: 2
                         rgt: 3
                         description:
-                        created_at: '2021-09-21T20:47:34.035Z'
-                        updated_at: '2021-09-21T20:47:34.036Z'
+                        created_at: '2021-09-27T16:52:24.469Z'
+                        updated_at: '2021-09-27T16:52:24.471Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -2989,8 +3322,8 @@ paths:
                         lft: 2
                         rgt: 3
                         description:
-                        created_at: '2021-09-21T20:47:34.179Z'
-                        updated_at: '2021-09-21T20:47:34.193Z'
+                        created_at: '2021-09-27T16:52:24.606Z'
+                        updated_at: '2021-09-27T16:52:24.619Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -3125,9 +3458,9 @@ paths:
                     - id: '1'
                       type: user
                       attributes:
-                        email: sherryl.christiansen@schiller.com
-                        created_at: '2021-09-21T20:47:34.489Z'
-                        updated_at: '2021-09-21T20:47:34.489Z'
+                        email: sharolyn@bradtke.name
+                        created_at: '2021-09-27T16:52:24.912Z'
+                        updated_at: '2021-09-27T16:52:24.912Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -3139,9 +3472,9 @@ paths:
                     - id: '2'
                       type: user
                       attributes:
-                        email: carol@wiza.biz
-                        created_at: '2021-09-21T20:47:34.492Z'
-                        updated_at: '2021-09-21T20:47:34.492Z'
+                        email: francis@nikolaus.ca
+                        created_at: '2021-09-27T16:52:24.916Z'
+                        updated_at: '2021-09-27T16:52:24.916Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -3153,9 +3486,9 @@ paths:
                     - id: '3'
                       type: user
                       attributes:
-                        email: hilario_hirthe@gorczanymcclure.info
-                        created_at: '2021-09-21T20:47:34.493Z'
-                        updated_at: '2021-09-21T20:47:34.493Z'
+                        email: venice@pagac.co.uk
+                        created_at: '2021-09-27T16:52:24.917Z'
+                        updated_at: '2021-09-27T16:52:24.917Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -3210,9 +3543,9 @@ paths:
                       id: '2'
                       type: user
                       attributes:
-                        email: madalyn@damore.info
-                        created_at: '2021-09-21T20:47:34.534Z'
-                        updated_at: '2021-09-21T20:47:34.534Z'
+                        email: julianne@greenholt.us
+                        created_at: '2021-09-27T16:52:24.967Z'
+                        updated_at: '2021-09-27T16:52:24.967Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -3271,9 +3604,9 @@ paths:
                       id: '2'
                       type: user
                       attributes:
-                        email: shameka.botsford@braun.us
-                        created_at: '2021-09-21T20:47:34.562Z'
-                        updated_at: '2021-09-21T20:47:34.562Z'
+                        email: elwood@fadel.name
+                        created_at: '2021-09-27T16:52:24.994Z'
+                        updated_at: '2021-09-27T16:52:24.994Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -3332,8 +3665,8 @@ paths:
                       type: user
                       attributes:
                         email: john@example.com
-                        created_at: '2021-09-21T20:47:34.602Z'
-                        updated_at: '2021-09-21T20:47:34.612Z'
+                        created_at: '2021-09-27T16:52:25.036Z'
+                        updated_at: '2021-09-27T16:52:25.040Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -3447,8 +3780,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-09-21T20:47:34.780Z'
-                        updated_at: '2021-09-21T20:47:34.780Z'
+                        created_at: '2021-09-27T16:52:25.282Z'
+                        updated_at: '2021-09-27T16:52:25.282Z'
                         price: '19.99'
                         total: '19.99'
                         display_price: "$19.99"
@@ -3462,8 +3795,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-09-21T20:47:34.808Z'
-                        updated_at: '2021-09-21T20:47:34.808Z'
+                        created_at: '2021-09-27T16:52:25.310Z'
+                        updated_at: '2021-09-27T16:52:25.310Z'
                         price: '19.99'
                         total: '19.99'
                         display_price: "$19.99"
@@ -3477,8 +3810,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-09-21T20:47:34.835Z'
-                        updated_at: '2021-09-21T20:47:34.835Z'
+                        created_at: '2021-09-27T16:52:25.336Z'
+                        updated_at: '2021-09-27T16:52:25.336Z'
                         price: '19.99'
                         total: '19.99'
                         display_price: "$19.99"
@@ -3492,8 +3825,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-09-21T20:47:34.860Z'
-                        updated_at: '2021-09-21T20:47:34.860Z'
+                        created_at: '2021-09-27T16:52:25.362Z'
+                        updated_at: '2021-09-27T16:52:25.362Z'
                         price: '19.99'
                         total: '19.99'
                         display_price: "$19.99"
@@ -3550,8 +3883,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-09-21T20:47:35.079Z'
-                        updated_at: '2021-09-21T20:47:35.079Z'
+                        created_at: '2021-09-27T16:52:25.588Z'
+                        updated_at: '2021-09-27T16:52:25.588Z'
                         price: '19.99'
                         total: '19.99'
                         display_price: "$19.99"
@@ -3617,8 +3950,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-09-21T20:47:35.206Z'
-                        updated_at: '2021-09-21T20:47:35.206Z'
+                        created_at: '2021-09-27T16:52:25.714Z'
+                        updated_at: '2021-09-27T16:52:25.714Z'
                         price: '19.99'
                         total: '19.99'
                         display_price: "$19.99"
@@ -3678,8 +4011,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 3
-                        created_at: '2021-09-21T20:47:35.413Z'
-                        updated_at: '2021-09-21T20:47:35.417Z'
+                        created_at: '2021-09-27T16:52:25.915Z'
+                        updated_at: '2021-09-27T16:52:25.920Z'
                         price: '19.99'
                         total: '59.97'
                         display_price: "$19.99"
@@ -3802,9 +4135,9 @@ paths:
                         name: Black Friday
                         is_private: true
                         is_default: false
-                        created_at: '2021-09-21T20:47:35.895Z'
-                        updated_at: '2021-09-21T20:47:35.895Z'
-                        token: pJr3H1bG436ZJWwPdhCescuZ
+                        created_at: '2021-09-27T16:52:26.337Z'
+                        updated_at: '2021-09-27T16:52:26.337Z'
+                        token: jj13MGanYgMvEEs3CYsmt5ba
                         variant_included: false
                       relationships:
                         wished_items:
@@ -3819,9 +4152,9 @@ paths:
                         name: Birthday
                         is_private: true
                         is_default: false
-                        created_at: '2021-09-21T20:47:35.896Z'
-                        updated_at: '2021-09-21T20:47:35.896Z'
-                        token: g73YVuAfDcznufS7BfkT7Dgv
+                        created_at: '2021-09-27T16:52:26.338Z'
+                        updated_at: '2021-09-27T16:52:26.338Z'
+                        token: ameCHAkBPam2E9xGnWRZpgUm
                         variant_included: false
                       relationships:
                         wished_items:
@@ -3879,9 +4212,9 @@ paths:
                         name: Wishlist_26
                         is_private: true
                         is_default: false
-                        created_at: '2021-09-21T20:47:36.169Z'
-                        updated_at: '2021-09-21T20:47:36.169Z'
-                        token: RzyRAZhruHGocmvdDhEEkK3y
+                        created_at: '2021-09-27T16:52:26.670Z'
+                        updated_at: '2021-09-27T16:52:26.670Z'
+                        token: uA6R4QmB6cUDN4TJyUd7nw6r
                         variant_included: false
                       relationships:
                         wished_items:
@@ -3941,9 +4274,9 @@ paths:
                         name: My Wishlist
                         is_private: true
                         is_default: false
-                        created_at: '2021-09-21T20:47:36.191Z'
-                        updated_at: '2021-09-21T20:47:36.191Z'
-                        token: zTKLwrNBQkM1L8FKiCkqFpxX
+                        created_at: '2021-09-27T16:52:26.696Z'
+                        updated_at: '2021-09-27T16:52:26.696Z'
+                        token: td4SM5WV7R6deHr6kMQZnvLw
                         variant_included: false
                       relationships:
                         wished_items:
@@ -4000,9 +4333,9 @@ paths:
                         name: My Super Wishlist
                         is_private: true
                         is_default: false
-                        created_at: '2021-09-21T20:47:36.228Z'
-                        updated_at: '2021-09-21T20:47:36.232Z'
-                        token: xVvmNoXkzi8i7fvG5i3moE7T
+                        created_at: '2021-09-27T16:52:26.733Z'
+                        updated_at: '2021-09-27T16:52:26.738Z'
+                        token: HpbexEzk3w3E1dhLikwDezKA
                         variant_included: false
                       relationships:
                         wished_items:

--- a/api/spec/integration/api/v2/platform/cms_pages_spec.rb
+++ b/api/spec/integration/api/v2/platform/cms_pages_spec.rb
@@ -1,0 +1,27 @@
+require 'swagger_helper'
+
+describe 'CMS Pages API', swagger: true do
+  include_context 'Platform API v2'
+
+  resource_name = 'CMS Page'
+  include_example = 'cms_sections'
+  filter_example = 'type=homepage'
+
+  let(:store) { Spree::Store.default }
+
+  let(:id) { create(:cms_standard_page, store: store).id }
+  let(:records_list) { create_list(:cms_standard_page, 2, store: store) }
+  let(:valid_create_param_value) { build(:cms_standard_page).attributes }
+  let(:valid_update_param_value) do
+    {
+      title: 'My Super Page'
+    }
+  end
+  let(:invalid_param_value) do
+    {
+      title: ''
+    }
+  end
+
+  include_examples 'CRUD examples', resource_name, include_example, filter_example
+end

--- a/api/spec/integration/api/v2/platform/cms_sections_spec.rb
+++ b/api/spec/integration/api/v2/platform/cms_sections_spec.rb
@@ -10,6 +10,9 @@ describe 'CMS Section API', swagger: true do
   let!(:store) { Spree::Store.default }
   let!(:product) { create(:product) }
   let!(:cms_page) { create(:cms_feature_page, store: store) }
+  let!(:cms_hero_section) { create(:cms_hero_image_section, cms_page: cms_page) }
+  let!(:cms_image_gallery_section) { create(:cms_image_gallery_section, cms_page: cms_page) }
+  let!(:cms_featured_article_section) { create(:cms_featured_article_section, cms_page: cms_page) }
 
   let(:id) { create(:cms_hero_image_section, cms_page: cms_page, linked_resource: product).id }
   let(:records_list) { create_list(:cms_hero_image_section, 2, cms_page: cms_page, linked_resource: product) }
@@ -25,6 +28,34 @@ describe 'CMS Section API', swagger: true do
       name: ''
     }
   end
+  let(:valid_update_position_param_value) do
+    {
+      new_position_idx: 2
+    }
+  end
 
   include_examples 'CRUD examples', resource_name, include_example, filter_example
+
+  path '/api/v2/platform/cms_sections/{id}/reposition' do
+    patch 'Reposition a CMS Section' do
+      tags resource_name.pluralize
+      security [ bearer_auth: [] ]
+      operationId 'reposition-cms-section'
+      description 'Reposition a Menu Item'
+      consumes 'application/json'
+      parameter name: :id, in: :path, type: :string
+      parameter name: :cms_section, in: :body, schema: { '$ref' => '#/components/schemas/cms_section_reposition_params' }
+
+      let(:cms_section) { valid_update_position_param_value }
+      let(:invalid_param_value) do
+        {
+          new_position_idx: 'invalid'
+        }
+      end
+
+      it_behaves_like 'record updated'
+      it_behaves_like 'record not found', :cms_section
+      it_behaves_like 'authentication failed'
+    end
+  end
 end

--- a/api/spec/integration/api/v2/platform/cms_sections_spec.rb
+++ b/api/spec/integration/api/v2/platform/cms_sections_spec.rb
@@ -1,0 +1,30 @@
+require 'swagger_helper'
+
+describe 'CMS Section API', swagger: true do
+  include_context 'Platform API v2'
+
+  resource_name = 'CMS Section'
+  include_example = 'product'
+  filter_example = 'name_eq=Hero'
+
+  let!(:store) { Spree::Store.default }
+  let!(:product) { create(:product) }
+  let!(:cms_page) { create(:cms_feature_page, store: store) }
+
+  let(:id) { create(:cms_hero_image_section, cms_page: cms_page, linked_resource: product).id }
+  let(:records_list) { create_list(:cms_hero_image_section, 2, cms_page: cms_page, linked_resource: product) }
+
+  let(:valid_create_param_value) { build(:cms_hero_image_section, cms_page: cms_page, linked_resource: product).attributes }
+  let(:valid_update_param_value) do
+    {
+      name: 'Super Hero'
+    }
+  end
+  let(:invalid_param_value) do
+    {
+      name: ''
+    }
+  end
+
+  include_examples 'CRUD examples', resource_name, include_example, filter_example
+end

--- a/api/spec/requests/spree/api/v2/platform/cms_sections_spec.rb
+++ b/api/spec/requests/spree/api/v2/platform/cms_sections_spec.rb
@@ -14,10 +14,10 @@ describe 'Platform API v2 CmsSections', type: :request do
 
   describe 'cms_section#reposition' do
     context 'with no params' do
-      let(:params) { nil }
+      let(:params) { }
 
       before do
-        patch "/api/v2/platform/cms_sections/x/reposition", headers: bearer_token, params: params
+        patch "/api/v2/platform/cms_sections/#{section_a.id}/reposition", headers: bearer_token, params: params
       end
 
       it_behaves_like 'returns 422 HTTP status'

--- a/api/spec/requests/spree/api/v2/platform/cms_sections_spec.rb
+++ b/api/spec/requests/spree/api/v2/platform/cms_sections_spec.rb
@@ -20,7 +20,7 @@ describe 'Platform API v2 CmsSections', type: :request do
         patch "/api/v2/platform/cms_sections/x/reposition", headers: bearer_token, params: params
       end
 
-      it_behaves_like 'returns 404 HTTP status'
+      it_behaves_like 'returns 422 HTTP status'
     end
 
     context 'with correct params' do
@@ -30,7 +30,7 @@ describe 'Platform API v2 CmsSections', type: :request do
         patch "/api/v2/platform/cms_sections/#{section_d.id}/reposition", headers: bearer_token, params: params
       end
 
-      it_behaves_like 'returns 204 HTTP status'
+      it_behaves_like 'returns 200 HTTP status'
 
       it 'repositions section from position 4 to position 1' do
         # acts_as_list is not zero indexed so moving to
@@ -47,7 +47,7 @@ describe 'Platform API v2 CmsSections', type: :request do
         patch "/api/v2/platform/cms_sections/#{section_a.id}/reposition", headers: bearer_token, params: params
       end
 
-      it_behaves_like 'returns 204 HTTP status'
+      it_behaves_like 'returns 200 HTTP status'
 
       it 'moves item from position 1 to position 4' do
         # acts_as_list is not zero indexed so moving to

--- a/api/spec/requests/spree/api/v2/platform/cms_sections_spec.rb
+++ b/api/spec/requests/spree/api/v2/platform/cms_sections_spec.rb
@@ -17,17 +17,17 @@ describe 'Platform API v2 CmsSections', type: :request do
       let(:params) { nil }
 
       before do
-        patch '/api/v2/platform/cms_sections/reposition', headers: bearer_token, params: params
+        patch "/api/v2/platform/cms_sections/x/reposition", headers: bearer_token, params: params
       end
 
       it_behaves_like 'returns 404 HTTP status'
     end
 
     context 'with correct params' do
-      let(:params) { { section_id: section_d.id, new_position_idx: 0 } }
+      let(:params) { { new_position_idx: 0 } }
 
       before do
-        patch '/api/v2/platform/cms_sections/reposition', headers: bearer_token, params: params
+        patch "/api/v2/platform/cms_sections/#{section_d.id}/reposition", headers: bearer_token, params: params
       end
 
       it_behaves_like 'returns 204 HTTP status'
@@ -41,10 +41,10 @@ describe 'Platform API v2 CmsSections', type: :request do
     end
 
     context 'with correct params' do
-      let(:params) { { section_id: section_a.id, new_position_idx: 3 } }
+      let(:params) { { new_position_idx: 3 } }
 
       before do
-        patch '/api/v2/platform/cms_sections/reposition', headers: bearer_token, params: params
+        patch "/api/v2/platform/cms_sections/#{section_a.id}/reposition", headers: bearer_token, params: params
       end
 
       it_behaves_like 'returns 204 HTTP status'

--- a/api/spec/requests/spree/api/v2/platform/cms_sections_spec.rb
+++ b/api/spec/requests/spree/api/v2/platform/cms_sections_spec.rb
@@ -34,7 +34,7 @@ describe 'Platform API v2 CmsSections', type: :request do
 
       it 'repositions section from position 4 to position 1' do
         # acts_as_list is not zero indexed so moving to
-        # position 0 results in a seved postiton at 1.
+        # position 0 results in a saved postiton at 1.
         section_d.reload
         expect(section_d.position).to eq(1)
       end
@@ -51,7 +51,7 @@ describe 'Platform API v2 CmsSections', type: :request do
 
       it 'moves item from position 1 to position 4' do
         # acts_as_list is not zero indexed so moving to
-        # position 3 results in a seved postiton at 4.
+        # position 3 results in a saved postiton at 4.
         section_a.reload
         expect(section_a.position).to eq(4)
       end

--- a/api/spec/serializers/spree/api/v2/platform/cms_section_serializer_spec.rb
+++ b/api/spec/serializers/spree/api/v2/platform/cms_section_serializer_spec.rb
@@ -3,7 +3,9 @@ require 'spec_helper'
 describe Spree::Api::V2::Platform::CmsSectionSerializer do
   subject { described_class.new(cms_section) }
 
-  let(:cms_section) { create(:cms_section) }
+  let(:product) { create(:product) }
+  let(:cms_page) { create(:cms_feature_page) }
+  let(:cms_section) { create(:cms_hero_image_section, cms_page: cms_page, linked_resource: product) }
 
   it { expect(subject.serializable_hash).to be_kind_of(Hash) }
 
@@ -25,7 +27,21 @@ describe Spree::Api::V2::Platform::CmsSectionSerializer do
             created_at: cms_section.created_at,
             updated_at: cms_section.updated_at
           },
-        }
+          relationships: {
+            cms_page: {
+              data: {
+                id: cms_section.cms_page.id.to_s,
+                type: :cms_page
+              }
+            },
+            linked_resource: {
+              data: {
+                id: product.id.to_s,
+                type: :product
+              }
+            }
+          }
+        },
       }
     )
   end

--- a/api/spec/swagger_helper.rb
+++ b/api/spec/swagger_helper.rb
@@ -43,6 +43,8 @@ RSpec.configure do |config|
         { name: 'Addresses' },
         { name: 'Classifications' },
         { name: 'Countries' },
+        { name: 'CMS Pages' },
+        { name: 'CMS Sections' },
         { name: 'Menu Items' },
         { name: 'Menus' },
         { name: 'Option Types' },
@@ -168,12 +170,13 @@ RSpec.configure do |config|
               code: { type: :string },
               subtitle: { type: :string },
               destination: { type: :string },
+              menu_id: { type: :string },
               new_window: { type: :boolean },
               item_type: { type: :string },
               linked_resource_type: { type: :string },
               linked_resource_id: { type: :integer }
             },
-            required: %w[name]
+            required: %w[name menu_id]
           },
           menu_item_reposition_params: {
             type: :object,
@@ -181,24 +184,54 @@ RSpec.configure do |config|
               new_parent_id: { type: :integer },
               new_position_idx: { type: :integer }
             },
-            required: %w[name]
+            required: %w[new_parent_id new_position_idx]
           },
           wishlist_params: {
             type: :object,
             properties: {
+              name: { type: :string },
               user_id: { type: :string },
-              name: { type: :string }
+              is_default: { type: :boolean },
+              is_private: { type: :boolean }
             },
-            required: %w[name]
+            required: %w[name user_id]
           },
           wished_item_params: {
             type: :object,
             properties: {
               wishlist_id: { type: :string },
               variant_id: { type: :string },
-              quantity: { type: :integer }
+              quantity: {
+                type: :integer,
+                description: 'Must be an integer greater than 0'
+              }
             },
-            required: %w[name]
+            required: %w[wishlist_id variant_id quantity]
+          },
+          cms_page_params: {
+            type: :object,
+            properties: {
+              title: { type: :string },
+              meta_title: { type: :string },
+              content: { type: :string, },
+              meta_description: { type: :string },
+              visible: { type: :string },
+              slug: { type: :string },
+              locale: { type: :string }
+            },
+            required: %w[title locale]
+          },
+          cms_section_params: {
+            type: :object,
+            properties: {
+              name: { type: :string },
+              cms_page_id: { type: :string },
+              content: { type: :object, },
+              settings: { type: :object },
+              fit: { type: :string },
+              destination: { type: :string },
+            },
+            required: %w[name cms_page_id]
           },
           resources_list: {
             type: :object,

--- a/api/spec/swagger_helper.rb
+++ b/api/spec/swagger_helper.rb
@@ -233,6 +233,13 @@ RSpec.configure do |config|
             },
             required: %w[name cms_page_id]
           },
+          cms_section_reposition_params: {
+            type: :object,
+            properties: {
+              new_position_idx: { type: :integer }
+            },
+            required: %w[new_position_idx]
+          },
           resources_list: {
             type: :object,
             properties: {

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -4,6 +4,8 @@ module Spree
       :address_attributes,
       :classification_attributes,
       :checkout_attributes,
+      :cms_page_attributes,
+      :cms_section_attributes,
       :customer_return_attributes,
       :image_attributes,
       :inventory_unit_attributes,
@@ -28,21 +30,19 @@ module Spree
       :taxonomy_attributes,
       :user_attributes,
       :variant_attributes,
-      :cms_page_attributes,
-      :cms_section_attributes,
       :wishlist_attributes,
       :wished_item_attributes
     ]
 
-    mattr_reader *ATTRIBUTES
+    mattr_reader(*ATTRIBUTES)
 
     @@address_attributes = [
       :id, :firstname, :lastname, :first_name, :last_name,
       :address1, :address2, :city, :country_iso, :country_id, :state_id,
       :zipcode, :phone, :state_name, :alternative_phone, :company,
       :user_id, :deleted_at, :label,
-      country: [:iso, :name, :iso3, :iso_name],
-      state: [:name, :abbr]
+      { country: [:iso, :name, :iso3, :iso_name],
+        state: [:name, :abbr] }
     ]
 
     @@checkout_attributes = [
@@ -56,9 +56,11 @@ module Spree
 
     @@cms_page_attributes = [:title, :meta_title, :content, :meta_description, :visible, :slug, :locale]
 
-    @@cms_section_attributes = [:name, :content, :settings, :fit, :destination]
+    @@cms_section_attributes = [:name, :cms_page_id, :fit, :destination, { content: {}, settings: {} }]
 
-    @@customer_return_attributes = [:stock_location_id, return_items_attributes: [:id, :inventory_unit_id, :return_authorization_id, :returned, :pre_tax_amount, :acceptance_status, :exchange_variant_id, :resellable]]
+    @@customer_return_attributes = [:stock_location_id, {
+      return_items_attributes: [:id, :inventory_unit_id, :return_authorization_id, :returned, :pre_tax_amount, :acceptance_status, :exchange_variant_id, :resellable]
+    }]
 
     @@image_attributes = [:alt, :attachment, :position, :viewable_type, :viewable_id]
 
@@ -85,7 +87,7 @@ module Spree
       :option_values_hash, :weight, :height, :width, :depth,
       :shipping_category_id, :tax_category_id,
       :cost_currency, :cost_price, :compare_at_price,
-      option_type_ids: [], taxon_ids: []
+      { option_type_ids: [], taxon_ids: [] }
     ]
 
     @@property_attributes = [:name, :presentation]
@@ -140,7 +142,7 @@ module Spree
       :position, :track_inventory,
       :product_id, :product, :option_values_attributes, :price, :compare_at_price,
       :weight, :height, :width, :depth, :sku, :cost_currency,
-      options: [:name, :value], option_value_ids: []
+      { options: [:name, :value], option_value_ids: [] }
     ]
 
     @@wishlist_attributes = [:name, :is_default, :is_private]

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -59,7 +59,8 @@ module Spree
     @@cms_section_attributes = [:name, :cms_page_id, :fit, :destination, { content: {}, settings: {} }]
 
     @@customer_return_attributes = [:stock_location_id, {
-      return_items_attributes: [:id, :inventory_unit_id, :return_authorization_id, :returned, :pre_tax_amount, :acceptance_status, :exchange_variant_id, :resellable]
+      return_items_attributes: [:id, :inventory_unit_id, :return_authorization_id, :returned, :pre_tax_amount,
+                                :acceptance_status, :exchange_variant_id, :resellable]
     }]
 
     @@image_attributes = [:alt, :attachment, :position, :viewable_type, :viewable_id]


### PR DESCRIPTION
Standard Docs for CMS Pages

For CMS Section I had to make some changes, notable changes were:

- Changed `resource` to `resources` in the routes file and thus had to make some changes to the reposition action.
- Added a helpful error message in the `new_position_idx` param is not passed in.
- Added the missing relationships in the `cms_section_serializer` serializer and updated the serializer spec test to reflect this.
- Copied a fix we applied to the `menu_item_serializer` linked_resources relationship to the `cms_section_serializer` to fix any Single Table Inheritance issue thought the API when requesting a linked page


If this PR is merged I will need to update the Javascript in the `spree_backend` gem to fix the new reposition action.