### PR TITLE
Add scope examples to Authorisation API Docs.

### DIFF
--- a/api/docs/oauth/index.yml
+++ b/api/docs/oauth/index.yml
@@ -130,7 +130,7 @@ components:
           grant_type: password
           username: spree@example.com
           password: spree123
-        Admin Token:
+        Application Token:
           grant_type: password
           username: spree@example.com
           password: spree123

--- a/api/docs/oauth/index.yml
+++ b/api/docs/oauth/index.yml
@@ -7,7 +7,7 @@ servers:
 info:
   version: 1.0.0
   title: Authentication
-  description: "Spree uses oAuth based Authentication via short-lived Bearer tokens. You can either create a new one or refresh existing token."
+  description: Spree uses oAuth based Authentication via short-lived Bearer tokens. You can either create a new one or refresh existing token.
   contact:
     name: Spark Solutions
     url: 'https://sparksolutions.co'
@@ -18,26 +18,34 @@ info:
 paths:
   /spree_oauth/token:
     post:
-      description: Creates or refreshes a Bearer token required to authorize API calls
+      description: Creates or refreshes a Bearer Token required to authorize API calls.
       tags:
         - Token
-      operationId: Create or Refresh Token
+      operationId: create-or-refresh-token
       responses:
         '200':
-          description: Token was successfully created or refreshed
+          description: Token was successfully created or refreshed.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Token'
               examples:
-                create token:
+                User Token:
                   value:
                     access_token: SfM3k8kq5Wkc6xz6rgMlsl-mbygJ1ptq4DR0Ah51vjA
                     token_type: Bearer
                     expires_in: 7200
                     refresh_token: SqJDIwX00fehqHxS6xmb-kzqAlrYe_0EHgekMexVT8k
                     created_at: 1581873931
-                refresh token:
+                Admin Token:
+                  value:
+                    access_token: 2480c16561d1391ea81ca5336b651e9a29f4524f6dee8c7f3f02a600159189c3
+                    token_type: Bearer
+                    expires_in: 7200
+                    refresh_token: f5d78642252eeb3f3001f67b196ac21a27afc030462a54060b0ebbdae2b8dc9c
+                    scope: admin
+                    created_at: 1539863418
+                Refresh Token:
                   value:
                     access_token: Es9lLPW2mVaDB80I-I_OdQCw3JfOT1s19YN1naFWx98
                     token_type: Bearer
@@ -53,19 +61,40 @@ paths:
                 - $ref: '#/components/schemas/CreateTokenBody'
                 - $ref: '#/components/schemas/RefreshTokenBody'
             examples:
-              create token:
+              Create User Token:
                 value:
                   grant_type: password
                   username: spree@example.com
                   password: spree123
-              refresh token:
+              Create Admin Token:
+                value:
+                  grant_type: password
+                  username: spree@example.com
+                  password: spree123
+                  scope: admin
+              Refresh Token:
                 value:
                   grant_type: refresh_token
                   refresh_token: SqJDIwX00fehqHxS6xmb-kzqAlrYe_0EHgekMexVT8k
         description: ''
+      summary: Create or Refresh a Token
 components:
   schemas:
     Token:
+      x-examples:
+        create token:
+          access_token: SfM3k8kq5Wkc6xz6rgMlsl-mbygJ1ptq4DR0Ah51vjA
+          token_type: Bearer
+          expires_in: 7200
+          refresh_token: SqJDIwX00fehqHxS6xmb-kzqAlrYe_0EHgekMexVT8k
+          created_at: 1581873931
+        refresh token:
+          access_token: Es9lLPW2mVaDB80I-I_OdQCw3JfOT1s19YN1naFWx98
+          token_type: Bearer
+          expires_in: 7200
+          refresh_token: j92BxulqIIYtiiaBsuAM1TzGsGSVxaykT4kk8OYHGNY
+          created_at: 1581876572
+      type: object
       properties:
         access_token:
           type: string
@@ -81,29 +110,31 @@ components:
         refresh_token:
           type: string
           example: f5d78642252eeb3f3001f67b196ac21a27afc030462a54060b0ebbdae2b8dc9c
+        scope:
+          type: string
+          example: admin
+          default: admin
         created_at:
           type: integer
           example: 1539863418
-      x-examples:
-        create token:
-          access_token: SfM3k8kq5Wkc6xz6rgMlsl-mbygJ1ptq4DR0Ah51vjA
-          token_type: Bearer
-          expires_in: 7200
-          refresh_token: SqJDIwX00fehqHxS6xmb-kzqAlrYe_0EHgekMexVT8k
-          created_at: 1581873931
-        refresh token:
-          access_token: Es9lLPW2mVaDB80I-I_OdQCw3JfOT1s19YN1naFWx98
-          token_type: Bearer
-          expires_in: 7200
-          refresh_token: j92BxulqIIYtiiaBsuAM1TzGsGSVxaykT4kk8OYHGNY
-          created_at: 1581876572
+      required:
+        - access_token
+        - token_type
+        - expires_in
+        - refresh_token
+        - created_at
     CreateTokenBody:
       type: object
       x-examples:
-        example-1:
+        User Token:
           grant_type: password
           username: spree@example.com
           password: spree123
+        Admin Token:
+          grant_type: password
+          username: spree@example.com
+          password: spree123
+          scope: admin
       properties:
         grant_type:
           type: string
@@ -117,6 +148,12 @@ components:
           type: string
           description: User password
           example: spree123
+        scope:
+          type: string
+          enum:
+            - admin
+          description: Pass the value `admin` to create a token for use in the Platform API v2.
+          nullable: true
       required:
         - grant_type
         - username
@@ -130,7 +167,7 @@ components:
         refresh_token:
           type: string
           description: Refresh token obtained from the create token response
-          example: "27af95fd57a424e5d01aaf5eab1324a8d5c0ca57daf384fae39f811a5144330143301'"
+          example: 27af95fd57a424e5d01aaf5eab1324a8d5c0ca57daf384fae39f811a5144330143301'
       required:
         - grant_type
         - refresh_token
@@ -138,3 +175,5 @@ components:
         example-1:
           grant_type: refresh_token
           refresh_token: SqJDIwX00fehqHxS6xmb-kzqAlrYe_0EHgekMexVT8k
+tags:
+  - name: Token

--- a/api/docs/oauth/index.yml
+++ b/api/docs/oauth/index.yml
@@ -152,7 +152,7 @@ components:
           type: string
           enum:
             - admin
-          description: Pass the value `admin` to create a token for use in the Platform API v2.
+          description: Pass the value `admin` to create a token for use in the Platform API.
           nullable: true
       required:
         - grant_type

--- a/api/docs/oauth/index.yml
+++ b/api/docs/oauth/index.yml
@@ -1,4 +1,4 @@
-openapi: 3.0.0
+openapi: 3.0.3
 servers:
   - url: 'https://demo.spreecommerce.org'
     description: demo
@@ -18,7 +18,10 @@ info:
 paths:
   /spree_oauth/token:
     post:
-      description: Creates or refreshes a Bearer Token required to authorize API calls.
+      description: |-
+        This endpoint creates a new Bearer Token or refreshes an existing Bearer Token.
+
+        The `token` found in the response body is required to authorize API calls.
       tags:
         - Token
       operationId: create-or-refresh-token
@@ -30,14 +33,14 @@ paths:
               schema:
                 $ref: '#/components/schemas/Token'
               examples:
-                User Token:
+                Storefront User Token:
                   value:
                     access_token: SfM3k8kq5Wkc6xz6rgMlsl-mbygJ1ptq4DR0Ah51vjA
                     token_type: Bearer
                     expires_in: 7200
                     refresh_token: SqJDIwX00fehqHxS6xmb-kzqAlrYe_0EHgekMexVT8k
                     created_at: 1581873931
-                Application Token:
+                Platform User Token:
                   value:
                     access_token: 2480c16561d1391ea81ca5336b651e9a29f4524f6dee8c7f3f02a600159189c3
                     token_type: Bearer
@@ -45,7 +48,7 @@ paths:
                     refresh_token: f5d78642252eeb3f3001f67b196ac21a27afc030462a54060b0ebbdae2b8dc9c
                     scope: admin
                     created_at: 1539863418
-                Refresh Token:
+                Refreshed Token:
                   value:
                     access_token: Es9lLPW2mVaDB80I-I_OdQCw3JfOT1s19YN1naFWx98
                     token_type: Bearer
@@ -61,18 +64,18 @@ paths:
                 - $ref: '#/components/schemas/CreateTokenBody'
                 - $ref: '#/components/schemas/RefreshTokenBody'
             examples:
-              Create User Token:
+              Create Storefront User Token:
                 value:
                   grant_type: password
                   username: spree@example.com
                   password: spree123
-              Create Application Token:
+              Create Platform User Token:
                 value:
                   grant_type: password
                   username: spree@example.com
                   password: spree123
                   scope: admin
-              Refresh Token:
+              Refresh a Token:
                 value:
                   grant_type: refresh_token
                   refresh_token: SqJDIwX00fehqHxS6xmb-kzqAlrYe_0EHgekMexVT8k
@@ -123,6 +126,7 @@ components:
         - expires_in
         - refresh_token
         - created_at
+      x-internal: true
     CreateTokenBody:
       type: object
       x-examples:
@@ -138,8 +142,10 @@ components:
       properties:
         grant_type:
           type: string
-          default: password
-          description: Use `password` to create a token and `refresh_token` to refresh it
+          description: 'Use `password` to create a new token, or `refresh_token` to refresh an existing token.'
+          enum:
+            - password
+            - refresh_token
         username:
           type: string
           description: User email address
@@ -152,12 +158,13 @@ components:
           type: string
           enum:
             - admin
-          description: Pass the value `admin` to create a token for use in the Platform API.
+          description: 'Pass the value `admin` to create a Platform User Token, allowing access to the Platform API.'
           nullable: true
       required:
         - grant_type
         - username
         - password
+      x-internal: true
     RefreshTokenBody:
       type: object
       properties:
@@ -175,5 +182,6 @@ components:
         example-1:
           grant_type: refresh_token
           refresh_token: SqJDIwX00fehqHxS6xmb-kzqAlrYe_0EHgekMexVT8k
+      x-internal: true
 tags:
   - name: Token

--- a/api/docs/oauth/index.yml
+++ b/api/docs/oauth/index.yml
@@ -66,7 +66,7 @@ paths:
                   grant_type: password
                   username: spree@example.com
                   password: spree123
-              Create Admin Token:
+              Create Application Token:
                 value:
                   grant_type: password
                   username: spree@example.com

--- a/api/docs/oauth/index.yml
+++ b/api/docs/oauth/index.yml
@@ -37,7 +37,7 @@ paths:
                     expires_in: 7200
                     refresh_token: SqJDIwX00fehqHxS6xmb-kzqAlrYe_0EHgekMexVT8k
                     created_at: 1581873931
-                Admin Token:
+                Application Token:
                   value:
                     access_token: 2480c16561d1391ea81ca5336b651e9a29f4524f6dee8c7f3f02a600159189c3
                     token_type: Bearer


### PR DESCRIPTION
Add `"scope": "admin"` example to access token docs. 

Fixed all lint validation errors.